### PR TITLE
chore(ci): add workflow to trigger all benchmarks automatically

### DIFF
--- a/.github/workflows/boolean_benchmark.yml
+++ b/.github/workflows/boolean_benchmark.yml
@@ -71,7 +71,7 @@ jobs:
           COMMIT_DATE="$(git --no-pager show -s --format=%cd --date=iso8601-strict ${{ github.sha }})"
           COMMIT_HASH="$(git describe --tags --dirty)"
           python3 ./ci/benchmark_parser.py target/criterion ${{ env.RESULTS_FILENAME }} \
-          --schema tfhe_rs_benchmarks \
+          --database tfhe_rs_benchmarks \
           --hardware ${{ inputs.instance_type }} \
           --project-version ${COMMIT_HASH} \
           --branch ${{ github.ref_name }} \

--- a/.github/workflows/boolean_benchmark.yml
+++ b/.github/workflows/boolean_benchmark.yml
@@ -46,12 +46,10 @@ jobs:
         run: |
           echo "BENCH_DATE=$(date --iso-8601=seconds)" >> "${GITHUB_ENV}"
 
-      - name: Fetch submodules
+      - name: Checkout tfhe-rs repo with tags
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          submodules: recursive
-          token: ${{ secrets.GH_TOKEN }}
 
       - name: Set up home
         # "Install rust" step require root user to have a HOME directory which is not set.
@@ -105,7 +103,7 @@ jobs:
         with:
           repository: zama-ai/slab
           path: slab
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.CONCRETE_ACTIONS_TOKEN }}
 
       - name: Send data to Slab
         shell: bash

--- a/.github/workflows/shortint_benchmark.yml
+++ b/.github/workflows/shortint_benchmark.yml
@@ -71,7 +71,7 @@ jobs:
           COMMIT_DATE="$(git --no-pager show -s --format=%cd --date=iso8601-strict ${{ github.sha }})"
           COMMIT_HASH="$(git describe --tags --dirty)"
           python3 ./ci/benchmark_parser.py target/criterion ${{ env.RESULTS_FILENAME }} \
-          --schema tfhe_rs_benchmarks \
+          --database tfhe_rs_benchmarks \
           --hardware ${{ inputs.instance_type }} \
           --project-version ${COMMIT_HASH} \
           --branch ${{ github.ref_name }} \

--- a/.github/workflows/shortint_benchmark.yml
+++ b/.github/workflows/shortint_benchmark.yml
@@ -46,12 +46,10 @@ jobs:
         run: |
           echo "BENCH_DATE=$(date --iso-8601=seconds)" >> "${GITHUB_ENV}"
 
-      - name: Fetch submodules
+      - name: Checkout tfhe-rs repo with tags
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          submodules: recursive
-          token: ${{ secrets.GH_TOKEN }}
 
       - name: Set up home
         # "Install rust" step require root user to have a HOME directory which is not set.
@@ -105,7 +103,7 @@ jobs:
         with:
           repository: zama-ai/slab
           path: slab
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.CONCRETE_ACTIONS_TOKEN }}
 
       - name: Send data to Slab
         shell: bash

--- a/.github/workflows/start_benchmarks.yml
+++ b/.github/workflows/start_benchmarks.yml
@@ -1,0 +1,36 @@
+# Start all benchmark jobs on Slab CI bot.
+name: Start all benchmarks
+
+on:
+  push:
+    branches:
+      - 'main'
+  workflow_dispatch:
+
+jobs:
+  start-benchmarks:
+    strategy:
+      matrix:
+        command: [boolean_bench, shortint_bench]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Slab repo
+        uses: actions/checkout@v3
+        with:
+          repository: zama-ai/slab
+          path: slab
+          token: ${{ secrets.CONCRETE_ACTIONS_TOKEN }}
+
+      - name: Start AWS job in Slab
+        shell: bash
+        # TODO: step result must be correlated to HTTP return code.
+        run: |
+          echo -n '{"command": "${{ matrix.command }}", "git_ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}' > command.json
+          SIGNATURE="$(slab/scripts/hmac_calculator.sh command.json '${{ secrets.JOB_SECRET }}')"
+          curl -v -k \
+          -H "Content-Type: application/json" \
+          -H "X-Slab-Repository: ${{ github.repository }}" \
+          -H "X-Slab-Command: start_aws" \
+          -H "X-Hub-Signature-256: sha256=${SIGNATURE}" \
+          -d @command.json \
+          ${{ secrets.SLAB_URL }}

--- a/ci/benchmark_parser.py
+++ b/ci/benchmark_parser.py
@@ -14,8 +14,8 @@ parser = argparse.ArgumentParser()
 parser.add_argument('results_dir',
                     help='Location of criterion benchmark results directory')
 parser.add_argument('output_file', help='File storing parsed results')
-parser.add_argument('-s', '--schema', dest='schema',
-                    help='Name of the database schema used to store results')
+parser.add_argument('-d', '--database', dest='database',
+                    help='Name of the database used to store results')
 parser.add_argument('-w', '--hardware', dest='hardware',
                     help='Hardware reference used to perform benchmark')
 parser.add_argument('-V', '--project-version', dest='project_version',
@@ -106,7 +106,7 @@ def dump_results(parsed_results, filename, input_args):
     else:
         filename.parent.mkdir(parents=True, exist_ok=True)
         series = {
-            "schema": input_args.schema,
+            "database": input_args.database,
             "hardware": input_args.hardware,
             "project_version": input_args.project_version,
             "branch": input_args.branch,

--- a/ci/slab.toml
+++ b/ci/slab.toml
@@ -10,6 +10,11 @@ instance_type = "p3.2xlarge"
 subnet_id = "subnet-8123c9e7"
 security_group = "sg-0466d33ced960ba35"
 
+[profile.bench]
+region = "eu-west-3"
+image_id = "ami-04deffe45b5b236fd"
+instance_type = "m6i.metal"
+
 [command.cpu_test]
 workflow = "aws_tfhe_tests.yml"
 profile = "cpu-big"
@@ -22,10 +27,10 @@ check_run_name = "AWS tests GPU (Slab)"
 
 [command.shortint_bench]
 workflow = "shortint_benchmark.yml"
-profile = "cpu-big"
+profile = "bench"
 check_run_name = "Shortint CPU AWS Benchmarks"
 
 [command.boolean_bench]
 workflow = "boolean_benchmark.yml"
-profile = "cpu-big"
+profile = "bench"
 check_run_name = "Boolean CPU AWS Benchmarks"


### PR DESCRIPTION
This workflow enables benchmarks automation. It will be called on each push in `main`, and with a workflow-dispatch capability if one wants to run all benchmarks in one go outside a PR.