### PR TITLE
chore(ci): parse subdirectories for shortint benchmark results

### DIFF
--- a/.github/workflows/shortint_benchmark.yml
+++ b/.github/workflows/shortint_benchmark.yml
@@ -76,7 +76,8 @@ jobs:
           --project-version ${COMMIT_HASH} \
           --branch ${{ github.ref_name }} \
           --commit-date ${COMMIT_DATE} \
-          --bench-date "${{ env.BENCH_DATE }}"
+          --bench-date "${{ env.BENCH_DATE }}" \
+          --walk-subdirs
 
       - name: Remove previous raw results
         run: |
@@ -89,6 +90,7 @@ jobs:
       - name: Parse AVX512 results
         run: |
           python3 ./ci/benchmark_parser.py target/criterion ${{ env.RESULTS_FILENAME }} \
+          --walk-subdirs \
           --name-suffix avx512 \
           --append-results
 


### PR DESCRIPTION
This fixes behavior for shortint benchmarks.