### PR TITLE
fix(tools): fix arch detection script for aarch64

### DIFF
--- a/scripts/get_arch_feature.sh
+++ b/scripts/get_arch_feature.sh
@@ -4,7 +4,7 @@ set -e
 
 ARCH_FEATURE=x86_64
 
-IS_AARCH64="$( (uname -a | grep -c arm64) || true)"
+IS_AARCH64="$( (uname -a | grep -c "arm64\|aarch64") || true)"
 
 if [[ "${IS_AARCH64}" != "0" ]]; then
     ARCH_FEATURE=aarch64


### PR DESCRIPTION
On Linux with Apple M1, the output of `uname -a` is:

```
Linux ... aarch64 aarch64 aarch64 GNU/Linux
```

Therefore, recognize that output as aarch64.