### PR TITLE
refactor(core): implement missing traits for u128/i128 to make them usable

### DIFF
--- a/tfhe/src/core_crypto/commons/math/random/uniform_binary.rs
+++ b/tfhe/src/core_crypto/commons/math/random/uniform_binary.rs
@@ -26,3 +26,4 @@ implement_uniform_binary!(u8);
 implement_uniform_binary!(u16);
 implement_uniform_binary!(u32);
 implement_uniform_binary!(u64);
+implement_uniform_binary!(u128);

--- a/tfhe/src/core_crypto/commons/math/random/uniform_ternary.rs
+++ b/tfhe/src/core_crypto/commons/math/random/uniform_ternary.rs
@@ -29,3 +29,4 @@ implement_uniform_ternary!(u8);
 implement_uniform_ternary!(u16);
 implement_uniform_ternary!(u32);
 implement_uniform_ternary!(u64);
+implement_uniform_ternary!(u128);

--- a/tfhe/src/core_crypto/commons/math/torus/mod.rs
+++ b/tfhe/src/core_crypto/commons/math/torus/mod.rs
@@ -12,7 +12,6 @@
 //! traits which allow to go back and forth between an unsigned integer representation and a
 //! floating point representation.
 
-use crate::core_crypto::commons::dispersion::LogStandardDev;
 use crate::core_crypto::commons::math::random::{
     Gaussian, RandomGenerable, Uniform, UniformBinary, UniformTernary,
 };
@@ -89,14 +88,10 @@ pub trait UnsignedTorus:
     + Display
     + Debug
 {
-    /// The log standard deviation used to sample gaussian keys in this precision.
-    const GAUSSIAN_KEY_LOG_STD: LogStandardDev;
 }
 
-impl UnsignedTorus for u32 {
-    const GAUSSIAN_KEY_LOG_STD: LogStandardDev = LogStandardDev(-30.32192809488736);
-}
+impl UnsignedTorus for u32 {}
 
-impl UnsignedTorus for u64 {
-    const GAUSSIAN_KEY_LOG_STD: LogStandardDev = LogStandardDev(-62.32192809488736);
-}
+impl UnsignedTorus for u64 {}
+
+impl UnsignedTorus for u128 {}


### PR DESCRIPTION
- enables the use of u128 in ciphertexts
- add encryption test based on shortint 2_2 params