### PR TITLE
Feat/c api shortint trivial

### DIFF
--- a/tfhe/c_api_tests/test_shortint_keygen.c
+++ b/tfhe/c_api_tests/test_shortint_keygen.c
@@ -76,6 +76,33 @@ void test_predefined_keygen_w_serde(void) {
   destroy_buffer(&ct_ser_buffer);
 }
 
+void test_server_key_trivial_encrypt(void) {
+  ShortintClientKey *cks = NULL;
+  ShortintServerKey *sks = NULL;
+  ShortintParameters *params = NULL;
+  ShortintCiphertext *ct = NULL;
+
+  int get_params_ok = shortint_get_parameters(2, 2, &params);
+  assert(get_params_ok == 0);
+
+  int gen_keys_ok = shortint_gen_keys_with_parameters(params, &cks, &sks);
+  assert(gen_keys_ok == 0);
+
+  int encrypt_ok = shortint_server_key_create_trivial(sks, 3, &ct);
+  assert(encrypt_ok == 0);
+
+  uint64_t result = -1;
+  int decrypt_ok = shortint_client_key_decrypt(cks, ct, &result);
+  assert(decrypt_ok == 0);
+
+  assert(result == 3);
+
+  destroy_shortint_client_key(cks);
+  destroy_shortint_server_key(sks);
+  destroy_shortint_parameters(params);
+  destroy_shortint_ciphertext(ct);
+}
+
 void test_custom_keygen(void) {
   ShortintClientKey *cks = NULL;
   ShortintServerKey *sks = NULL;
@@ -188,5 +215,6 @@ int main(void) {
   test_custom_keygen();
   test_public_keygen();
   test_compressed_public_keygen();
+  test_server_key_trivial_encrypt();
   return EXIT_SUCCESS;
 }

--- a/tfhe/src/c_api/shortint/server_key/mod.rs
+++ b/tfhe/src/c_api/shortint/server_key/mod.rs
@@ -47,6 +47,25 @@ pub unsafe extern "C" fn shortint_gen_server_key(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn shortint_server_key_create_trivial(
+    server_key: *const ShortintServerKey,
+    value_to_trivially_encrypt: u64,
+    result: *mut *mut ShortintCiphertext,
+) -> c_int {
+    catch_panic(|| {
+        check_ptr_is_non_null_and_aligned(result).unwrap();
+
+        let server_key = get_ref_checked(server_key).unwrap();
+
+        let heap_allocated_ciphertext = Box::new(ShortintCiphertext(
+            server_key.0.create_trivial(value_to_trivially_encrypt),
+        ));
+
+        *result = Box::into_raw(heap_allocated_ciphertext);
+    })
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn shortint_serialize_server_key(
     server_key: *const ShortintServerKey,
     result: *mut Buffer,

--- a/tfhe/src/shortint/engine/server_side/mod.rs
+++ b/tfhe/src/shortint/engine/server_side/mod.rs
@@ -467,7 +467,7 @@ impl ShortintEngine {
     pub(crate) fn create_trivial(
         &mut self,
         server_key: &ServerKey,
-        value: u8,
+        value: u64,
     ) -> EngineResult<Ciphertext> {
         let lwe_size = server_key
             .bootstrapping_key
@@ -499,7 +499,7 @@ impl ShortintEngine {
         &mut self,
         server_key: &ServerKey,
         ct: &mut Ciphertext,
-        value: u8,
+        value: u64,
     ) -> EngineResult<()> {
         let modular_value = value as usize % server_key.message_modulus.0;
 

--- a/tfhe/src/shortint/server_key/mod.rs
+++ b/tfhe/src/shortint/server_key/mod.rs
@@ -534,11 +534,11 @@ impl ServerKey {
     /// let ct_res = cks.decrypt(&ct1);
     /// assert_eq!(1, ct_res);
     /// ```
-    pub fn create_trivial(&self, value: u8) -> Ciphertext {
+    pub fn create_trivial(&self, value: u64) -> Ciphertext {
         ShortintEngine::with_thread_local_mut(|engine| engine.create_trivial(self, value).unwrap())
     }
 
-    pub fn create_trivial_assign(&self, ct: &mut Ciphertext, value: u8) {
+    pub fn create_trivial_assign(&self, ct: &mut Ciphertext, value: u64) {
         ShortintEngine::with_thread_local_mut(|engine| {
             engine.create_trivial_assign(self, ct, value).unwrap()
         })


### PR DESCRIPTION
To allow BC usage where they need to create trivial encryptions