### PR TITLE
chore(tfhe): upgrade csprng version to avoid indirect deprecated aes dep

### DIFF
--- a/tfhe/Cargo.toml
+++ b/tfhe/Cargo.toml
@@ -31,8 +31,8 @@ fs2 = { version = "0.4.3" }
 cbindgen = { version = "0.24.3", optional = true }
 
 [dependencies]
-concrete-csprng = { version = "0.2.1", features = [
-    "generator_soft",
+concrete-csprng = { version = "0.3.0", features = [
+    "generator_fallback",
     "parallel",
 ] }
 lazy_static = { version = "1.4.0", optional = true }


### PR DESCRIPTION
closes https://github.com/zama-ai/tfhe-rs/issues/1