### PR TITLE
chore(tfhe): bump criterion version to remove outdated dep from dep tree

### DIFF
--- a/tfhe/Cargo.toml
+++ b/tfhe/Cargo.toml
@@ -21,7 +21,7 @@ rand_distr = "0.4.3"
 kolmogorov_smirnov = "1.1.0"
 paste = "1.0.7"
 lazy_static = { version = "1.4.0" }
-criterion = "0.3.5"
+criterion = "0.4.0"
 doc-comment = "0.3.3"
 # Used in user documentation
 bincode = "1.3.3"


### PR DESCRIPTION
closes https://github.com/zama-ai/tfhe-rs/issues/3