### PR TITLE
fix(core_crypto): correct PFPKSK serial generation

### DIFF
--- a/tfhe/src/core_crypto/algorithms/lwe_private_functional_packing_keyswitch_key_generation.rs
+++ b/tfhe/src/core_crypto/algorithms/lwe_private_functional_packing_keyswitch_key_generation.rs
@@ -97,6 +97,9 @@ pub fn generate_lwe_private_functional_packing_keyswitch_key<
     for ((&input_key_bit, mut keyswitch_key_block), mut loop_generator) in
         input_key_bit_iter.zip(lwe_pfpksk.iter_mut()).zip(gen_iter)
     {
+        // Reset the buffer before using it in assign operations
+        messages.as_mut().fill(Scalar::ZERO);
+
         // We fill the buffer with the powers of the key bits
         for (level, mut message) in (1..=decomp_level_count.0)
             .map(DecompositionLevel)
@@ -236,4 +239,85 @@ pub fn par_generate_lwe_private_functional_packing_keyswitch_key<
                 )
             },
         );
+}
+
+#[cfg(test)]
+mod test {
+    use crate::core_crypto::commons::generators::DeterministicSeeder;
+    use crate::core_crypto::commons::math::random::Seed;
+    use crate::core_crypto::prelude::*;
+
+    #[test]
+    fn test_pfpksk_list_gen_equivalence() {
+        const NB_TESTS: usize = 10;
+
+        for _ in 0..NB_TESTS {
+            // DISCLAIMER: these toy example parameters are not guaranteed to be secure or yield
+            // correct computations
+            let glwe_dimension =
+                GlweDimension(crate::core_crypto::commons::test_tools::random_usize_between(5..10));
+            let polynomial_size = PolynomialSize(
+                crate::core_crypto::commons::test_tools::random_usize_between(5..10),
+            );
+            let pfpksk_level_count = DecompositionLevelCount(
+                crate::core_crypto::commons::test_tools::random_usize_between(2..5),
+            );
+            let pfpksk_base_log = DecompositionBaseLog(
+                crate::core_crypto::commons::test_tools::random_usize_between(2..5),
+            );
+
+            let common_encryption_seed =
+                Seed(crate::core_crypto::commons::test_tools::random_uint_between(0..u128::MAX));
+
+            let var_small = Variance::from_variance(2f64.powf(-80.0));
+
+            // Create the PRNG
+            let mut seeder = new_seeder();
+            let mut secret_generator =
+                SecretRandomGenerator::<ActivatedRandomGenerator>::new(seeder.seed());
+
+            let glwe_sk: GlweSecretKeyOwned<u64> = allocate_and_generate_new_binary_glwe_secret_key(
+                glwe_dimension,
+                polynomial_size,
+                &mut secret_generator,
+            );
+            let lwe_big_sk = glwe_sk.clone().into_lwe_secret_key();
+
+            let mut seeder =
+                DeterministicSeeder::<ActivatedRandomGenerator>::new(common_encryption_seed);
+            let mut encryption_generator =
+                EncryptionRandomGenerator::<ActivatedRandomGenerator>::new(
+                    seeder.seed(),
+                    &mut seeder,
+                );
+
+            let par_cbs_pfpksk = par_allocate_and_generate_new_circuit_bootstrap_lwe_pfpksk_list(
+                &lwe_big_sk,
+                &glwe_sk,
+                pfpksk_base_log,
+                pfpksk_level_count,
+                var_small,
+                &mut encryption_generator,
+            );
+
+            let mut seeder =
+                DeterministicSeeder::<ActivatedRandomGenerator>::new(common_encryption_seed);
+            let mut encryption_generator =
+                EncryptionRandomGenerator::<ActivatedRandomGenerator>::new(
+                    seeder.seed(),
+                    &mut seeder,
+                );
+
+            let ser_cbs_pfpksk = allocate_and_generate_new_circuit_bootstrap_lwe_pfpksk_list(
+                &lwe_big_sk,
+                &glwe_sk,
+                pfpksk_base_log,
+                pfpksk_level_count,
+                var_small,
+                &mut encryption_generator,
+            );
+
+            assert_eq!(par_cbs_pfpksk, ser_cbs_pfpksk)
+        }
+    }
 }


### PR DESCRIPTION
- add equivalence keygen test between serial and parallel as we now near exclusively use the parallel version ourselves

closes https://github.com/zama-ai/tfhe-rs/issues/108