### PR TITLE
Compute throughput on boolean and shortint benchmarks

### DIFF
--- a/.github/workflows/boolean_benchmark.yml
+++ b/.github/workflows/boolean_benchmark.yml
@@ -76,7 +76,8 @@ jobs:
           --project-version "${COMMIT_HASH}" \
           --branch ${{ github.ref_name }} \
           --commit-date "${COMMIT_DATE}" \
-          --bench-date "${{ env.BENCH_DATE }}"
+          --bench-date "${{ env.BENCH_DATE }}" \
+          --throughput
 
       - name: Remove previous raw results
         run: |
@@ -90,6 +91,7 @@ jobs:
         run: |
           python3 ./ci/benchmark_parser.py target/criterion ${{ env.RESULTS_FILENAME }} \
           --name-suffix avx512 \
+          --throughput \
           --append-results
 
       - name: Measure key sizes

--- a/.github/workflows/shortint_benchmark.yml
+++ b/.github/workflows/shortint_benchmark.yml
@@ -77,7 +77,8 @@ jobs:
           --branch ${{ github.ref_name }} \
           --commit-date "${COMMIT_DATE}" \
           --bench-date "${{ env.BENCH_DATE }}" \
-          --walk-subdirs
+          --walk-subdirs \
+          --throughput
 
       - name: Remove previous raw results
         run: |
@@ -92,6 +93,7 @@ jobs:
           python3 ./ci/benchmark_parser.py target/criterion ${{ env.RESULTS_FILENAME }} \
           --walk-subdirs \
           --name-suffix avx512 \
+          --throughput \
           --append-results
 
       - name: Measure key sizes

--- a/.github/workflows/start_benchmarks.yml
+++ b/.github/workflows/start_benchmarks.yml
@@ -11,7 +11,7 @@ jobs:
   start-benchmarks:
     strategy:
       matrix:
-        command: [boolean_bench, shortint_bench, pbs-bench]
+        command: [boolean_bench, shortint_bench, pbs_bench]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Slab repo

--- a/ci/benchmark_parser.py
+++ b/ci/benchmark_parser.py
@@ -203,7 +203,8 @@ def check_mandatory_args(input_args):
     missing_args = []
     for arg_name in vars(input_args):
         if arg_name in ["results_dir", "output_file", "name_suffix",
-                        "append_results", "walk_subdirs", "key_sizes"]:
+                        "append_results", "walk_subdirs", "key_sizes",
+                        "throughput"]:
             continue
         if not getattr(input_args, arg_name):
             missing_args.append(arg_name)
@@ -223,9 +224,11 @@ if __name__ == "__main__":
         print("Parsing benchmark results... ")
         hardware_cost = None
         if args.throughput:
+            print("Throughput computation enabled")
             ec2_costs = json.loads(
                 pathlib.Path("ci/ec2_products_cost.json").read_text(encoding="utf-8"))
             hardware_cost = abs(ec2_costs[args.hardware])
+            print(f"Hardware hourly cost: {hardware_cost} $/h")
 
         results = recursive_parse(raw_results, args.walk_subdirs, args.name_suffix, args.throughput,
                                   hardware_cost)

--- a/ci/slab.toml
+++ b/ci/slab.toml
@@ -22,3 +22,8 @@ check_run_name = "Shortint CPU AWS Benchmarks"
 workflow = "boolean_benchmark.yml"
 profile = "bench"
 check_run_name = "Boolean CPU AWS Benchmarks"
+
+[command.pbs_bench]
+workflow = "pbs_benchmark.yml"
+profile = "bench"
+check_run_name = "PBS CPU AWS Benchmarks"


### PR DESCRIPTION
This commit series makes `--throughput` CLI argument for benchmark result parser optional.
In addition an AWS Slab profile for PBS benchmarks had been added. It couldn't run without it... :sweat_smile: 