### PR TITLE
chore(ci): reduce pbs benchmark execution duration

### DIFF
--- a/tfhe/benches/core_crypto/pbs_bench.rs
+++ b/tfhe/benches/core_crypto/pbs_bench.rs
@@ -30,7 +30,7 @@ const BOOLEAN_BENCH_PARAMS: [(&str, BooleanParameters); 2] = [
 
 criterion_group!(
     name = pbs_group;
-    config = Criterion::default().sample_size(5000);
+    config = Criterion::default().sample_size(2000);
     targets = mem_optimized_pbs::<u64>, mem_optimized_pbs::<u32>
 );
 


### PR DESCRIPTION
When using a criterion sample size of 5000, the benchmark duration for PBS using shortint can be very long (3620s for MESSAGE_4_CARRY_4). Switching to a sample size of 2000 would cut down all of the benchmarks duration by a factor of at least 2.