### PR TITLE
fix(shortint): use correct value to shift msg in bivariate bps

### DIFF
--- a/tfhe/src/shortint/engine/server_side/bitwise_op.rs
+++ b/tfhe/src/shortint/engine/server_side/bitwise_op.rs
@@ -19,7 +19,7 @@ impl ShortintEngine {
         ct_left: &mut Ciphertext,
         ct_right: &Ciphertext,
     ) -> EngineResult<()> {
-        let modulus = (ct_right.degree.0 + 1) as u64;
+        let modulus = ct_right.message_modulus.0 as u64;
         self.unchecked_functional_bivariate_pbs_assign(server_key, ct_left, ct_right, |x| {
             (x / modulus) & (x % modulus)
         })?;
@@ -69,7 +69,7 @@ impl ShortintEngine {
         ct_left: &mut Ciphertext,
         ct_right: &Ciphertext,
     ) -> EngineResult<()> {
-        let modulus = (ct_right.degree.0 + 1) as u64;
+        let modulus = ct_right.message_modulus.0 as u64;
         self.unchecked_functional_bivariate_pbs_assign(server_key, ct_left, ct_right, |x| {
             (x / modulus) ^ (x % modulus)
         })?;
@@ -119,7 +119,7 @@ impl ShortintEngine {
         ct_left: &mut Ciphertext,
         ct_right: &Ciphertext,
     ) -> EngineResult<()> {
-        let modulus = (ct_right.degree.0 + 1) as u64;
+        let modulus = ct_right.message_modulus.0 as u64;
         self.unchecked_functional_bivariate_pbs_assign(server_key, ct_left, ct_right, |x| {
             (x / modulus) | (x % modulus)
         })?;

--- a/tfhe/src/shortint/engine/server_side/comp_op.rs
+++ b/tfhe/src/shortint/engine/server_side/comp_op.rs
@@ -19,11 +19,11 @@ impl ShortintEngine {
         ct_left: &mut Ciphertext,
         ct_right: &Ciphertext,
     ) -> EngineResult<()> {
-        let modulus = (ct_right.degree.0 + 1) as u64;
+        let modulus_carry = ct_right.carry_modulus.0 as u64;
         let modulus_msg = ct_left.message_modulus.0 as u64;
-        let large_mod = modulus * modulus_msg;
+        let large_mod = modulus_carry * modulus_msg;
         self.unchecked_functional_bivariate_pbs_assign(server_key, ct_left, ct_right, |x| {
-            (((x % large_mod / modulus) % modulus_msg) > (x % modulus_msg)) as u64
+            (((x % large_mod / modulus_msg) % modulus_msg) > (x % modulus_msg)) as u64
         })?;
 
         ct_left.degree.0 = 1;
@@ -73,11 +73,11 @@ impl ShortintEngine {
         ct_left: &mut Ciphertext,
         ct_right: &Ciphertext,
     ) -> EngineResult<()> {
-        let modulus = (ct_right.degree.0 + 1) as u64;
+        let modulus_carry = ct_right.carry_modulus.0 as u64;
         let modulus_msg = ct_left.message_modulus.0 as u64;
-        let large_mod = modulus * modulus_msg;
+        let large_mod = modulus_carry * modulus_msg;
         self.unchecked_functional_bivariate_pbs_assign(server_key, ct_left, ct_right, |x| {
-            (((x % large_mod / modulus) % modulus_msg) >= (x % modulus_msg)) as u64
+            (((x % large_mod / modulus_msg) % modulus_msg) >= (x % modulus_msg)) as u64
         })?;
 
         ct_left.degree.0 = 1;
@@ -126,11 +126,11 @@ impl ShortintEngine {
         ct_left: &mut Ciphertext,
         ct_right: &Ciphertext,
     ) -> EngineResult<()> {
-        let modulus = (ct_right.degree.0 + 1) as u64;
+        let modulus_carry = ct_right.carry_modulus.0 as u64;
         let modulus_msg = ct_left.message_modulus.0 as u64;
-        let large_mod = modulus * modulus_msg;
+        let large_mod = modulus_carry * modulus_msg;
         self.unchecked_functional_bivariate_pbs_assign(server_key, ct_left, ct_right, |x| {
-            (((x % large_mod / modulus) % modulus_msg) < (x % modulus_msg)) as u64
+            (((x % large_mod / modulus_msg) % modulus_msg) < (x % modulus_msg)) as u64
         })?;
 
         ct_left.degree.0 = 1;
@@ -179,11 +179,11 @@ impl ShortintEngine {
         ct_left: &mut Ciphertext,
         ct_right: &Ciphertext,
     ) -> EngineResult<()> {
-        let modulus = (ct_right.degree.0 + 1) as u64;
+        let modulus_carry = ct_right.carry_modulus.0 as u64;
         let modulus_msg = ct_left.message_modulus.0 as u64;
-        let large_mod = modulus * modulus_msg;
+        let large_mod = modulus_carry * modulus_msg;
         self.unchecked_functional_bivariate_pbs_assign(server_key, ct_left, ct_right, |x| {
-            (((x % large_mod / modulus) % modulus_msg) <= (x % modulus_msg)) as u64
+            (((x % large_mod / modulus_msg) % modulus_msg) <= (x % modulus_msg)) as u64
         })?;
 
         ct_left.degree.0 = 1;
@@ -232,11 +232,11 @@ impl ShortintEngine {
         ct_left: &mut Ciphertext,
         ct_right: &Ciphertext,
     ) -> EngineResult<()> {
-        let modulus = (ct_right.degree.0 + 1) as u64;
+        let modulus_carry = ct_right.carry_modulus.0 as u64;
         let modulus_msg = ct_left.message_modulus.0 as u64;
-        let large_mod = modulus * modulus_msg;
+        let large_mod = modulus_carry * modulus_msg;
         self.unchecked_functional_bivariate_pbs_assign(server_key, ct_left, ct_right, |x| {
-            ((((x % large_mod) / modulus) % modulus_msg) == (x % modulus_msg)) as u64
+            ((((x % large_mod) / modulus_msg) % modulus_msg) == (x % modulus_msg)) as u64
         })?;
         ct_left.degree.0 = 1;
         Ok(())
@@ -309,11 +309,11 @@ impl ShortintEngine {
         ct_left: &mut Ciphertext,
         ct_right: &Ciphertext,
     ) -> EngineResult<()> {
-        let modulus = (ct_right.degree.0 + 1) as u64;
+        let modulus_carry = ct_right.carry_modulus.0 as u64;
         let modulus_msg = ct_left.message_modulus.0 as u64;
-        let large_mod = modulus * modulus_msg;
+        let large_mod = modulus_carry * modulus_msg;
         self.unchecked_functional_bivariate_pbs_assign(server_key, ct_left, ct_right, |x| {
-            ((((x % large_mod) / modulus) % modulus_msg) != (x % modulus_msg)) as u64
+            ((((x % large_mod) / modulus_msg) % modulus_msg) != (x % modulus_msg)) as u64
         })?;
         ct_left.degree.0 = 1;
         Ok(())

--- a/tfhe/src/shortint/engine/server_side/div_mod.rs
+++ b/tfhe/src/shortint/engine/server_side/div_mod.rs
@@ -29,7 +29,7 @@ impl ShortintEngine {
         ct_left: &mut Ciphertext,
         ct_right: &Ciphertext,
     ) -> EngineResult<()> {
-        let modulus = (ct_right.degree.0 + 1) as u64;
+        let modulus = ct_right.message_modulus.0 as u64;
 
         //In this case the degree of the result is equal to the degree of ct_left
         self.unchecked_functional_bivariate_pbs_assign(server_key, ct_left, ct_right, |x| {

--- a/tfhe/src/shortint/engine/server_side/mul.rs
+++ b/tfhe/src/shortint/engine/server_side/mul.rs
@@ -20,7 +20,7 @@ impl ShortintEngine {
         ct_left: &mut Ciphertext,
         ct_right: &Ciphertext,
     ) -> EngineResult<()> {
-        let modulus = (ct_right.degree.0 + 1) as u64;
+        let modulus = ct_right.message_modulus.0 as u64;
 
         //message 1 is shifted to the carry bits
         self.unchecked_scalar_mul_assign(ct_left, modulus as u8)?;
@@ -59,7 +59,7 @@ impl ShortintEngine {
         ct_left: &mut Ciphertext,
         ct_right: &Ciphertext,
     ) -> EngineResult<()> {
-        let modulus = (ct_right.degree.0 + 1) as u64;
+        let modulus = ct_right.message_modulus.0 as u64;
         let deg = (ct_left.degree.0 * ct_right.degree.0) / ct_right.message_modulus.0;
 
         // Message 1 is shifted to the carry bits

--- a/tfhe/src/shortint/server_key/mod.rs
+++ b/tfhe/src/shortint/server_key/mod.rs
@@ -358,9 +358,10 @@ impl ServerKey {
 
     /// Verify if a bivariate functional pbs can be applied on ct_left and ct_right.
     pub fn is_functional_bivariate_pbs_possible(&self, ct1: &Ciphertext, ct2: &Ciphertext) -> bool {
-        //product of the degree
-        let final_degree = ct1.degree.0 * (ct2.degree.0 + 1) + ct2.degree.0;
-        final_degree < ct1.carry_modulus.0 * ct1.message_modulus.0
+        let ct1_fit_in_carry = ct1.degree.0 < ct1.carry_modulus.0;
+        let ct2_fit_in_message = ct2.degree.0 < ct1.message_modulus.0;
+
+        ct1_fit_in_carry && ct2_fit_in_message
     }
 
     /// Replace the input encrypted message by the value of its carry buffer.


### PR DESCRIPTION
fixes zama-ai/tfhe-rs-internal#32