### PR TITLE
chore(ci): split sync repo url into several secrets

### DIFF
--- a/.github/workflows/sync_on_push.yml
+++ b/.github/workflows/sync_on_push.yml
@@ -26,12 +26,12 @@ jobs:
         with:
           source_repo: "zama-ai/tfhe-rs"
           source_branch: "main"
-          destination_repo: ${{ secrets.SYNC_DEST_REPO }}
+          destination_repo: "https://${{ secrets.BOT_USERNAME }}:${{ secrets.CONCRETE_ACTIONS_TOKEN }}@github.com/${{ secrets.SYNC_DEST_REPO }}"
           destination_branch: "main"
       - name: git-sync tags
         uses: wei/git-sync@55c6b63b4f21607da0e9877ca9b4d11a29fc6d83
         with:
           source_repo: "zama-ai/tfhe-rs"
           source_branch: "refs/tags/*"
-          destination_repo: ${{ secrets.SYNC_DEST_REPO }}
+          destination_repo: "https://${{ secrets.BOT_USERNAME }}:${{ secrets.CONCRETE_ACTIONS_TOKEN }}@github.com/${{ secrets.SYNC_DEST_REPO }}"
           destination_branch: "refs/tags/*"


### PR DESCRIPTION
Enforcing usage of fine-grained token means that a token always have an expiration date. Thus it must be update fromp time to time. The seldom SYNC_DEST_REPO secrets would have contained such fine grained token. By spliting this seldom secret and using CONCRETE_ACTIONS_TOKEN there is no need to update SYNC_DEST_REPO each time the token is updated.