### PR TITLE
fix issue #115

### DIFF
--- a/tfhe/src/c_api/shortint/server_key/pbs.rs
+++ b/tfhe/src/c_api/shortint/server_key/pbs.rs
@@ -9,7 +9,7 @@ pub type BivariateAccumulatorCallback = Option<extern "C" fn(u64, u64) -> u64>;
 
 pub struct ShortintPBSAccumulator(pub(in crate::c_api) crate::shortint::server_key::Accumulator);
 pub struct ShortintBivariatePBSAccumulator(
-    pub(in crate::c_api) crate::shortint::server_key::Accumulator,
+    pub(in crate::c_api) crate::shortint::server_key::BivariateAccumulator,
 );
 
 #[no_mangle]

--- a/tfhe/src/shortint/engine/server_side/bitwise_op.rs
+++ b/tfhe/src/shortint/engine/server_side/bitwise_op.rs
@@ -19,10 +19,12 @@ impl ShortintEngine {
         ct_left: &mut Ciphertext,
         ct_right: &Ciphertext,
     ) -> EngineResult<()> {
-        let modulus = (ct_right.degree.0 + 1) as u64;
-        self.unchecked_functional_bivariate_pbs_assign(server_key, ct_left, ct_right, |x| {
-            (x / modulus) & (x % modulus)
-        })?;
+        self.unchecked_functional_bivariate_pbs_assign(
+            server_key,
+            ct_left,
+            ct_right,
+            |lhs, rhs| lhs & rhs,
+        )?;
         ct_left.degree = ct_left.degree.after_bitand(ct_right.degree);
         Ok(())
     }
@@ -69,10 +71,12 @@ impl ShortintEngine {
         ct_left: &mut Ciphertext,
         ct_right: &Ciphertext,
     ) -> EngineResult<()> {
-        let modulus = (ct_right.degree.0 + 1) as u64;
-        self.unchecked_functional_bivariate_pbs_assign(server_key, ct_left, ct_right, |x| {
-            (x / modulus) ^ (x % modulus)
-        })?;
+        self.unchecked_functional_bivariate_pbs_assign(
+            server_key,
+            ct_left,
+            ct_right,
+            |lhs, rhs| lhs ^ rhs,
+        )?;
         ct_left.degree = ct_left.degree.after_bitxor(ct_right.degree);
         Ok(())
     }
@@ -119,10 +123,12 @@ impl ShortintEngine {
         ct_left: &mut Ciphertext,
         ct_right: &Ciphertext,
     ) -> EngineResult<()> {
-        let modulus = (ct_right.degree.0 + 1) as u64;
-        self.unchecked_functional_bivariate_pbs_assign(server_key, ct_left, ct_right, |x| {
-            (x / modulus) | (x % modulus)
-        })?;
+        self.unchecked_functional_bivariate_pbs_assign(
+            server_key,
+            ct_left,
+            ct_right,
+            |lhs, rhs| lhs | rhs,
+        )?;
         ct_left.degree = ct_left.degree.after_bitor(ct_right.degree);
         Ok(())
     }

--- a/tfhe/src/shortint/engine/server_side/comp_op.rs
+++ b/tfhe/src/shortint/engine/server_side/comp_op.rs
@@ -19,13 +19,12 @@ impl ShortintEngine {
         ct_left: &mut Ciphertext,
         ct_right: &Ciphertext,
     ) -> EngineResult<()> {
-        let modulus_right = (ct_right.degree.0 + 1) as u64;
-        let modulus_left = ct_left.message_modulus.0 as u64;
-        self.unchecked_functional_bivariate_pbs_assign(server_key, ct_left, ct_right, |x| {
-            (((x / modulus_right) % modulus_left) > (x % modulus_left)) as u64
-        })?;
-
-        ct_left.degree.0 = 1;
+        self.unchecked_functional_bivariate_pbs_assign(
+            server_key,
+            ct_left,
+            ct_right,
+            |lhs, rhs| u64::from(lhs > rhs),
+        )?;
         Ok(())
     }
 
@@ -72,13 +71,12 @@ impl ShortintEngine {
         ct_left: &mut Ciphertext,
         ct_right: &Ciphertext,
     ) -> EngineResult<()> {
-        let modulus_right = (ct_right.degree.0 + 1) as u64;
-        let modulus_left = ct_left.message_modulus.0 as u64;
-        self.unchecked_functional_bivariate_pbs_assign(server_key, ct_left, ct_right, |x| {
-            (((x / modulus_right) % modulus_left) >= (x % modulus_left)) as u64
-        })?;
-
-        ct_left.degree.0 = 1;
+        self.unchecked_functional_bivariate_pbs_assign(
+            server_key,
+            ct_left,
+            ct_right,
+            |lhs, rhs| u64::from(lhs >= rhs),
+        )?;
         Ok(())
     }
 
@@ -124,13 +122,12 @@ impl ShortintEngine {
         ct_left: &mut Ciphertext,
         ct_right: &Ciphertext,
     ) -> EngineResult<()> {
-        let modulus_right = (ct_right.degree.0 + 1) as u64;
-        let modulus_left = ct_left.message_modulus.0 as u64;
-        self.unchecked_functional_bivariate_pbs_assign(server_key, ct_left, ct_right, |x| {
-            (((x / modulus_right) % modulus_left) < (x % modulus_left)) as u64
-        })?;
-
-        ct_left.degree.0 = 1;
+        self.unchecked_functional_bivariate_pbs_assign(
+            server_key,
+            ct_left,
+            ct_right,
+            |lhs, rhs| u64::from(lhs < rhs),
+        )?;
         Ok(())
     }
 
@@ -176,13 +173,12 @@ impl ShortintEngine {
         ct_left: &mut Ciphertext,
         ct_right: &Ciphertext,
     ) -> EngineResult<()> {
-        let modulus_right = (ct_right.degree.0 + 1) as u64;
-        let modulus_left = ct_left.message_modulus.0 as u64;
-        self.unchecked_functional_bivariate_pbs_assign(server_key, ct_left, ct_right, |x| {
-            (((x / modulus_right) % modulus_left) <= (x % modulus_right)) as u64
-        })?;
-
-        ct_left.degree.0 = 1;
+        self.unchecked_functional_bivariate_pbs_assign(
+            server_key,
+            ct_left,
+            ct_right,
+            |lhs, rhs| u64::from(lhs <= rhs),
+        )?;
         Ok(())
     }
 
@@ -228,12 +224,12 @@ impl ShortintEngine {
         ct_left: &mut Ciphertext,
         ct_right: &Ciphertext,
     ) -> EngineResult<()> {
-        let modulus_right = (ct_right.degree.0 + 1) as u64;
-        let modulus_left = ct_left.message_modulus.0 as u64;
-        self.unchecked_functional_bivariate_pbs_assign(server_key, ct_left, ct_right, |x| {
-            (((x / modulus_right) % modulus_left) == (x % modulus_left)) as u64
-        })?;
-        ct_left.degree.0 = 1;
+        self.unchecked_functional_bivariate_pbs_assign(
+            server_key,
+            ct_left,
+            ct_right,
+            |lhs, rhs| u64::from(lhs == rhs),
+        )?;
         Ok(())
     }
 
@@ -304,12 +300,12 @@ impl ShortintEngine {
         ct_left: &mut Ciphertext,
         ct_right: &Ciphertext,
     ) -> EngineResult<()> {
-        let modulus_right = (ct_right.degree.0 + 1) as u64;
-        let modulus_left = ct_left.message_modulus.0 as u64;
-        self.unchecked_functional_bivariate_pbs_assign(server_key, ct_left, ct_right, |x| {
-            (((x / modulus_right) % modulus_left) != (x % modulus_left)) as u64
-        })?;
-        ct_left.degree.0 = 1;
+        self.unchecked_functional_bivariate_pbs_assign(
+            server_key,
+            ct_left,
+            ct_right,
+            |lhs, rhs| u64::from(lhs != rhs),
+        )?;
         Ok(())
     }
 

--- a/tfhe/src/shortint/engine/server_side/div_mod.rs
+++ b/tfhe/src/shortint/engine/server_side/div_mod.rs
@@ -3,11 +3,11 @@ use crate::shortint::engine::{EngineResult, ShortintEngine};
 use crate::shortint::{Ciphertext, ServerKey};
 
 // Specific division function returning 0 in case of a division by 0
-pub(crate) fn division(x: u64, modulus: u64) -> u64 {
-    if x % modulus == 0 {
+pub(crate) fn safe_division(x: u64, y: u64) -> u64 {
+    if y == 0 {
         0
     } else {
-        (x / modulus) / (x % modulus)
+        x / y
     }
 }
 
@@ -29,12 +29,12 @@ impl ShortintEngine {
         ct_left: &mut Ciphertext,
         ct_right: &Ciphertext,
     ) -> EngineResult<()> {
-        let modulus = (ct_right.degree.0 + 1) as u64;
-
-        //In this case the degree of the result is equal to the degree of ct_left
-        self.unchecked_functional_bivariate_pbs_assign(server_key, ct_left, ct_right, |x| {
-            division(x, modulus)
-        })?;
+        self.unchecked_functional_bivariate_pbs_assign(
+            server_key,
+            ct_left,
+            ct_right,
+            safe_division,
+        )?;
         Ok(())
     }
 

--- a/tfhe/src/shortint/engine/server_side/mod.rs
+++ b/tfhe/src/shortint/engine/server_side/mod.rs
@@ -5,7 +5,8 @@ use crate::core_crypto::fft_impl::crypto::bootstrap::FourierLweBootstrapKey;
 use crate::core_crypto::fft_impl::math::fft::Fft;
 use crate::shortint::ciphertext::Degree;
 use crate::shortint::engine::EngineResult;
-use crate::shortint::server_key::{Accumulator, MaxDegree};
+use crate::shortint::parameters::MessageModulus;
+use crate::shortint::server_key::{Accumulator, BivariateAccumulator, MaxDegree};
 use crate::shortint::{Ciphertext, ClientKey, CompressedServerKey, ServerKey};
 use std::cmp::min;
 
@@ -275,7 +276,7 @@ impl ShortintEngine {
         server_key: &ServerKey,
         ct_left: &Ciphertext,
         ct_right: &Ciphertext,
-        acc: &Accumulator,
+        acc: &BivariateAccumulator,
     ) -> EngineResult<Ciphertext> {
         let mut ct_res = ct_left.clone();
         self.keyswitch_programmable_bootstrap_bivariate_assign(
@@ -292,31 +293,46 @@ impl ShortintEngine {
         server_key: &ServerKey,
         ct_left: &mut Ciphertext,
         ct_right: &Ciphertext,
-        acc: &Accumulator,
+        acc: &BivariateAccumulator,
     ) -> EngineResult<()> {
         let modulus = (ct_right.degree.0 + 1) as u64;
+        assert!(modulus <= acc.ct_right_modulus.0 as u64);
 
-        // Message 1 is shifted to the carry bits
-        self.unchecked_scalar_mul_assign(ct_left, modulus as u8)?;
+        // Message 1 is shifted
+        self.unchecked_scalar_mul_assign(ct_left, acc.ct_right_modulus.0 as u8)?;
 
-        // Message 2 is placed in the message bits
         self.unchecked_add_assign(ct_left, ct_right)?;
 
         // Compute the PBS
-        self.keyswitch_programmable_bootstrap_assign(server_key, ct_left, acc)?;
+        self.keyswitch_programmable_bootstrap_assign(server_key, ct_left, &acc.acc)?;
 
         Ok(())
+    }
+
+    pub(crate) fn generate_accumulator_bivariate_with_factor<F>(
+        &mut self,
+        server_key: &ServerKey,
+        f: F,
+        left_message_scaling: MessageModulus,
+    ) -> EngineResult<BivariateAccumulator>
+    where
+        F: Fn(u64, u64) -> u64,
+    {
+        Self::generate_accumulator_bivariate_with_engine(server_key, f, left_message_scaling)
     }
 
     pub(crate) fn generate_accumulator_bivariate<F>(
         &mut self,
         server_key: &ServerKey,
         f: F,
-    ) -> EngineResult<Accumulator>
+    ) -> EngineResult<BivariateAccumulator>
     where
         F: Fn(u64, u64) -> u64,
     {
-        Self::generate_accumulator_bivariate_with_engine(server_key, f)
+        // We use the message_modulus as the multiplying factor as its the most general one.
+        // It makes it compatible with any pair of ciphertext which have empty carries,
+        // and carries can be emptied with `message_extract`
+        self.generate_accumulator_bivariate_with_factor(server_key, f, server_key.message_modulus)
     }
 
     pub(crate) fn unchecked_functional_bivariate_pbs<F>(
@@ -327,7 +343,7 @@ impl ShortintEngine {
         f: F,
     ) -> EngineResult<Ciphertext>
     where
-        F: Fn(u64) -> u64,
+        F: Fn(u64, u64) -> u64,
     {
         let mut ct_res = ct_left.clone();
         self.unchecked_functional_bivariate_pbs_assign(server_key, &mut ct_res, ct_right, f)?;
@@ -342,22 +358,63 @@ impl ShortintEngine {
         f: F,
     ) -> EngineResult<()>
     where
-        F: Fn(u64) -> u64,
+        F: Fn(u64, u64) -> u64,
     {
-        let modulus = (ct_right.degree.0 + 1) as u64;
-
-        // Message 1 is shifted to the carry bits
-        self.unchecked_scalar_mul_assign(ct_left, modulus as u8)?;
-
-        // Message 2 is placed in the message bits
-        self.unchecked_add_assign(ct_left, ct_right)?;
-
         // Generate the accumulator for the function
-        let acc = self.generate_accumulator(server_key, f)?;
+        let factor = MessageModulus(ct_right.degree.0 + 1);
+        let acc = self.generate_accumulator_bivariate_with_factor(server_key, f, factor)?;
 
         // Compute the PBS
-        self.keyswitch_programmable_bootstrap_assign(server_key, ct_left, &acc)?;
+        self.keyswitch_programmable_bootstrap_bivariate_assign(
+            server_key, ct_left, ct_right, &acc,
+        )?;
         Ok(())
+    }
+
+    pub(crate) fn smart_functional_bivariate_pbs_assign<F>(
+        &mut self,
+        server_key: &ServerKey,
+        ct_left: &mut Ciphertext,
+        ct_right: &mut Ciphertext,
+        f: F,
+    ) -> EngineResult<()>
+    where
+        F: Fn(u64, u64) -> u64,
+    {
+        // First try to clear carries of ct_right
+        if !server_key.is_functional_bivariate_pbs_possible(ct_left, ct_right) {
+            self.message_extract_assign(server_key, ct_right)?;
+        }
+
+        // It was not enough, clean the ct_left carries also
+        if !server_key.is_functional_bivariate_pbs_possible(ct_left, ct_right) {
+            self.message_extract_assign(server_key, ct_left)?;
+        }
+
+        self.unchecked_functional_bivariate_pbs_assign(server_key, ct_left, ct_right, f)
+    }
+
+    pub(crate) fn smart_functional_bivariate_pbs<F>(
+        &mut self,
+        server_key: &ServerKey,
+        ct_left: &mut Ciphertext,
+        ct_right: &mut Ciphertext,
+        f: F,
+    ) -> EngineResult<Ciphertext>
+    where
+        F: Fn(u64, u64) -> u64,
+    {
+        // First try to clear carries of ct_right
+        if !server_key.is_functional_bivariate_pbs_possible(ct_left, ct_right) {
+            self.message_extract_assign(server_key, ct_right)?;
+        }
+
+        // It was not enough, clean the ct_left carries also
+        if !server_key.is_functional_bivariate_pbs_possible(ct_left, ct_right) {
+            self.message_extract_assign(server_key, ct_left)?;
+        }
+
+        self.unchecked_functional_bivariate_pbs(server_key, ct_left, ct_right, f)
     }
 
     // Those are currently not used in shortint, we therefore disable the warning when not compiling
@@ -368,7 +425,7 @@ impl ShortintEngine {
         server_key: &ServerKey,
         ct_left: &Ciphertext,
         ct_right: &mut Ciphertext,
-        acc: &Accumulator,
+        acc: &BivariateAccumulator,
     ) -> EngineResult<Ciphertext> {
         let mut ct_res = ct_left.clone();
         self.smart_bivariate_pbs_assign(server_key, &mut ct_res, ct_right, acc)?;
@@ -381,35 +438,17 @@ impl ShortintEngine {
         server_key: &ServerKey,
         ct_left: &mut Ciphertext,
         ct_right: &mut Ciphertext,
-        acc: &Accumulator,
+        acc: &BivariateAccumulator,
     ) -> EngineResult<()> {
         if !server_key.is_functional_bivariate_pbs_possible(ct_left, ct_right) {
+            // After the message_extract, we'll have ct_left, ct_right in [0, message_modulus[
+            // so the factor has to be message_modulus
+            assert_eq!(ct_right.message_modulus.0, acc.ct_right_modulus.0);
             self.message_extract_assign(server_key, ct_left)?;
             self.message_extract_assign(server_key, ct_right)?;
         }
 
-        self.unchecked_bivariate_pbs_assign(server_key, ct_left, ct_right, acc)
-    }
-
-    #[cfg_attr(not(feature = "__c_api"), allow(dead_code))]
-    pub(crate) fn unchecked_bivariate_pbs_assign(
-        &mut self,
-        server_key: &ServerKey,
-        ct_left: &mut Ciphertext,
-        ct_right: &Ciphertext,
-        acc: &Accumulator,
-    ) -> EngineResult<()> {
-        let modulus = (ct_right.degree.0 + 1) as u64;
-
-        // Message 1 is shifted to the carry bits
-        self.unchecked_scalar_mul_assign(ct_left, modulus as u8)?;
-
-        // Message 2 is placed in the message bits
-        self.unchecked_add_assign(ct_left, ct_right)?;
-
-        // Compute the PBS
-        self.keyswitch_programmable_bootstrap_assign(server_key, ct_left, acc)?;
-        Ok(())
+        self.keyswitch_programmable_bootstrap_bivariate_assign(server_key, ct_left, ct_right, acc)
     }
 
     pub(crate) fn carry_extract_assign(

--- a/tfhe/src/shortint/server_key/tests.rs
+++ b/tfhe/src/shortint/server_key/tests.rs
@@ -315,7 +315,7 @@ fn shortint_keyswitch_bivariate_programmable_bootstrap(param: Parameters) {
         let ctxt_0 = cks.encrypt(clear_0);
         let ctxt_1 = cks.encrypt(clear_1);
         //define the accumulator as identity
-        let acc = sks.generate_accumulator_bivariate(|x, y| x * 2 * y % modulus);
+        let acc = sks.generate_accumulator_bivariate(|x, y| x * 2 * y);
         // add the two ciphertexts
         let ct_res = sks.keyswitch_programmable_bootstrap_bivariate(&ctxt_0, &ctxt_1, &acc);
 


### PR DESCRIPTION
A bivariate PBS is a univariate PBS where we encode
the lhs, and rhs values into a singular value:
`univariate_value = (lhs * shift) + rhs`

Some places shifted the lhs by the parameter's message modulus
while others shifted by rhs.degree + 1, this could leed to incoherences
and wrong result in some cases.

The commits adds a `BivariateAccumulator` that stores the shift
value that was used to create the LUT, to avoid said incoherences.

Also, bivariate function family that expected
a univariate closure `Fn(u64) -> u64` will now expect a
bivariate closure `Fn(u64, u64) -> u64` so that they are less
error prone as the user does not need to figure out the
shift to be used.