### PR TITLE
chore(core_crypto): fix overflows in tests

### DIFF
--- a/tfhe/src/core_crypto/algorithms/lwe_encryption.rs
+++ b/tfhe/src/core_crypto/algorithms/lwe_encryption.rs
@@ -1368,7 +1368,7 @@ mod test {
             );
             // Create the plaintext
             let msg: Scalar = test_tools::random_uint_between(Scalar::ZERO..Scalar::TWO.shl(2));
-            let encoded_msg = msg << 60;
+            let encoded_msg = msg << (Scalar::BITS - 5);
             let plaintext_list =
                 PlaintextList::new(encoded_msg, PlaintextCount(lwe_ciphertext_count.0));
             // Create a new LweCiphertextList

--- a/tfhe/src/core_crypto/fft_impl/math/fft/tests.rs
+++ b/tfhe/src/core_crypto/fft_impl/math/fft/tests.rs
@@ -235,7 +235,7 @@ fn f64_to_i64_bit_twiddles() {
         let value = if sign == 0 {
             explicit_mantissa_shift as i64
         } else {
-            -(explicit_mantissa_shift as i64)
+            (explicit_mantissa_shift as i64).wrapping_neg()
         };
 
         let value = if biased_exp == 0 { 0 } else { value };


### PR DESCRIPTION
These overflows appeared in debug builds,
and are easly fixed by using explicit wrapping operation or correct values.

Fixes #136 (even tho running test in debug mode is not recommended)