### PR TITLE
fix(integer): stop decomposing before overflow

### DIFF
--- a/tfhe/src/integer/server_key/radix/scalar_add.rs
+++ b/tfhe/src/integer/server_key/radix/scalar_add.rs
@@ -58,7 +58,8 @@ impl ServerKey {
             self.key.unchecked_scalar_add_assign(ct_i, decomp as u8);
 
             //modulus to the power i
-            power *= self.key.message_modulus.0 as u64;
+            let Some(new_power) = power.checked_mul(self.key.message_modulus.0 as u64) else {break};
+            power = new_power;
         }
     }
 
@@ -101,7 +102,8 @@ impl ServerKey {
             }
 
             //modulus to the power i
-            power *= self.key.message_modulus.0 as u64;
+            let Some(new_power) = power.checked_mul(self.key.message_modulus.0 as u64) else {break};
+            power = new_power;
         }
         true
     }

--- a/tfhe/src/integer/server_key/radix/scalar_mul.rs
+++ b/tfhe/src/integer/server_key/radix/scalar_mul.rs
@@ -338,7 +338,8 @@ impl ServerKey {
 
             if u_i == 0 {
                 //update the power b^{i+1}
-                b_i *= self.key.message_modulus.0 as u64;
+                let Some(new_power) = b_i.checked_mul(self.key.message_modulus.0 as u64) else {break};
+                b_i = new_power;
                 continue;
             } else if u_i == 1 {
                 // tmp = ctxt * 1 * b^i
@@ -357,7 +358,8 @@ impl ServerKey {
             result = self.smart_add(&mut result, &mut tmp);
 
             //update the power b^{i+1}
-            b_i *= self.key.message_modulus.0 as u64;
+            let Some(new_power) = b_i.checked_mul(self.key.message_modulus.0 as u64) else {break};
+            b_i = new_power;
         }
 
         result


### PR DESCRIPTION
This only happens on binary scalar operations over 64bits of precision.