### PR TITLE
feat(core): add std multi-bit bootstrapping

### DIFF
--- a/tfhe/src/core_crypto/algorithms/lwe_multi_bit_programmable_bootstrapping.rs
+++ b/tfhe/src/core_crypto/algorithms/lwe_multi_bit_programmable_bootstrapping.rs
@@ -1,5 +1,6 @@
 use crate::core_crypto::algorithms::extract_lwe_sample_from_glwe_ciphertext;
 use crate::core_crypto::algorithms::polynomial_algorithms::*;
+use crate::core_crypto::algorithms::slice_algorithms::*;
 use crate::core_crypto::commons::computation_buffers::ComputationBuffers;
 use crate::core_crypto::commons::math::decomposition::SignedDecomposer;
 use crate::core_crypto::commons::parameters::*;
@@ -9,10 +10,88 @@ use crate::core_crypto::fft_impl::common::pbs_modulus_switch;
 use crate::core_crypto::fft_impl::fft64::crypto::ggsw::{
     add_external_product_assign, add_external_product_assign_scratch, update_with_fmadd,
 };
-use crate::core_crypto::fft_impl::fft64::math::fft::Fft;
+use crate::core_crypto::fft_impl::fft64::math::fft::{Fft, FftView};
 use concrete_fft::c64;
 use std::sync::{mpsc, Condvar, Mutex};
 use std::thread;
+
+pub fn prepare_multi_bit_ggsw_mem_optimized<
+    Scalar,
+    GgswBufferCont,
+    GgswGroupCont,
+    PolyCont,
+    FourierPolyCont,
+>(
+    fourier_ggsw_buffer: &mut FourierGgswCiphertext<GgswBufferCont>,
+    ggsw_group: &[FourierGgswCiphertext<GgswGroupCont>],
+    lwe_mask_elements: &[Scalar],
+    a_monomial: &mut Polynomial<PolyCont>,
+    fourier_a_monomial: &mut FourierPolynomial<FourierPolyCont>,
+    fft: FftView<'_>,
+    buffers: &mut ComputationBuffers,
+) where
+    Scalar: UnsignedTorus + CastInto<usize> + CastFrom<usize>,
+    GgswBufferCont: ContainerMut<Element = c64>,
+    GgswGroupCont: Container<Element = c64>,
+    PolyCont: ContainerMut<Element = Scalar>,
+    FourierPolyCont: ContainerMut<Element = c64>,
+{
+    let mut ggsw_group_iter = ggsw_group.iter();
+
+    // Keygen guarantees the first term is a constant term of the polynomial, no
+    // polynomial multiplication required
+    let ggsw_a_none = ggsw_group_iter.next().unwrap();
+
+    fourier_ggsw_buffer
+        .as_mut_view()
+        .data()
+        .copy_from_slice(ggsw_a_none.as_view().data());
+
+    let multi_bit_fourier_ggsw = fourier_ggsw_buffer.as_mut_view().data();
+
+    let polynomial_size = a_monomial.polynomial_size();
+
+    for (ggsw_idx, fourier_ggsw) in ggsw_group_iter.enumerate() {
+        // We already processed the first ggsw, advance the index by 1
+        let ggsw_idx = ggsw_idx + 1;
+
+        // Select the proper mask elements to build the monomial degree depending on
+        // the order the GGSW were generated in, using the bits from mask_idx and
+        // ggsw_idx as selector bits
+        let mut monomial_degree = Scalar::ZERO;
+        for (mask_idx, &mask_element) in lwe_mask_elements.iter().enumerate() {
+            let mask_position = lwe_mask_elements.len() - (mask_idx + 1);
+            let selection_bit: Scalar = Scalar::cast_from((ggsw_idx >> mask_position) & 1);
+            monomial_degree =
+                monomial_degree.wrapping_add(selection_bit.wrapping_mul(mask_element));
+        }
+
+        let switched_degree = pbs_modulus_switch(
+            monomial_degree,
+            polynomial_size,
+            ModulusSwitchOffset(0),
+            LutCountLog(0),
+        );
+
+        a_monomial.as_mut()[0] = Scalar::ONE;
+        a_monomial.as_mut()[1..].fill(Scalar::ZERO);
+        polynomial_wrapping_monic_monomial_mul_assign(a_monomial, MonomialDegree(switched_degree));
+
+        fft.forward_as_integer(
+            fourier_a_monomial.as_mut_view(),
+            a_monomial.as_view(),
+            buffers.stack(),
+        );
+
+        update_with_fmadd(
+            multi_bit_fourier_ggsw,
+            fourier_ggsw.as_view().data(),
+            fourier_a_monomial.as_view().data,
+            false,
+            polynomial_size.to_fourier_polynomial_size().0,
+        );
+    }
+}
 
 /// Perform a blind rotation given an input [`LWE ciphertext`](`LweCiphertext`), modifying a look-up
 /// table passed as a [`GLWE ciphertext`](`GlweCiphertext`) and an [`LWE bootstrap
@@ -347,10 +426,7 @@ pub fn multi_bit_blind_rotate_assign<Scalar, InputCont, OutputCont, KeyCont>(
 
             buffers.resize(fft.forward_scratch().unwrap().unaligned_bytes_required());
 
-            let mut unit_polynomial =
-                Polynomial::new(Scalar::ZERO, multi_bit_bsk.polynomial_size());
-            unit_polynomial.as_mut()[0] = Scalar::ONE;
-            let mut a_monomial = unit_polynomial.clone();
+            let mut a_monomial = Polynomial::new(Scalar::ZERO, multi_bit_bsk.polynomial_size());
             let mut fourier_a_monomial = FourierPolynomial::new(multi_bit_bsk.polynomial_size());
 
             let work_queue = &work_queue;
@@ -376,64 +452,15 @@ pub fn multi_bit_blind_rotate_assign<Scalar, InputCont, OutputCont, KeyCont>(
 
                 let mut fourier_ggsw_buffer = fourier_ggsw_buffer.lock().unwrap();
 
-                let mut ggsw_group_iter = ggsw_group.iter();
-
-                // Keygen guarantees the first term is a constant term of the polynomial, no
-                // polynomial multiplication required
-                let ggsw_a_none = ggsw_group_iter.next().unwrap();
-
-                fourier_ggsw_buffer
-                    .as_mut_view()
-                    .data()
-                    .copy_from_slice(ggsw_a_none.as_view().data());
-
-                let multi_bit_fourier_ggsw = fourier_ggsw_buffer.as_mut_view().data();
-
-                for (ggsw_idx, fourier_ggsw) in ggsw_group_iter.enumerate() {
-                    // We already processed the first ggsw, advance the index by 1
-                    let ggsw_idx = ggsw_idx + 1;
-
-                    // Select the proper mask elements to build the monomial degree depending on
-                    // the order the GGSW were generated in, using the bits from mask_idx and
-                    // ggsw_idx as selector bits
-                    let mut monomial_degree = Scalar::ZERO;
-                    for (mask_idx, &mask_element) in lwe_mask_elements.iter().enumerate() {
-                        let mask_position = lwe_mask_elements.len() - (mask_idx + 1);
-                        let selection_bit: Scalar =
-                            Scalar::cast_from((ggsw_idx >> mask_position) & 1);
-                        monomial_degree =
-                            monomial_degree.wrapping_add(selection_bit.wrapping_mul(mask_element));
-                    }
-
-                    let switched_degree = pbs_modulus_switch(
-                        monomial_degree,
-                        lut_poly_size,
-                        ModulusSwitchOffset(0),
-                        LutCountLog(0),
-                    );
-
-                    a_monomial
-                        .as_mut()
-                        .copy_from_slice(unit_polynomial.as_ref());
-                    polynomial_wrapping_monic_monomial_mul_assign(
-                        &mut a_monomial,
-                        MonomialDegree(switched_degree),
-                    );
-
-                    fft.forward_as_integer(
-                        fourier_a_monomial.as_mut_view(),
-                        a_monomial.as_view(),
-                        buffers.stack(),
-                    );
-
-                    update_with_fmadd(
-                        multi_bit_fourier_ggsw,
-                        fourier_ggsw.as_view().data(),
-                        fourier_a_monomial.as_view().data,
-                        false,
-                        lut_poly_size.to_fourier_polynomial_size().0,
-                    );
-                }
+                prepare_multi_bit_ggsw_mem_optimized(
+                    &mut fourier_ggsw_buffer,
+                    ggsw_group,
+                    lwe_mask_elements,
+                    &mut a_monomial,
+                    &mut fourier_a_monomial,
+                    fft,
+                    &mut buffers,
+                );
 
                 // Drop the lock before we wake other threads
                 drop(fourier_ggsw_buffer);
@@ -826,6 +853,433 @@ pub fn multi_bit_programmable_bootstrap_lwe_ciphertext<
         .copy_from_slice(accumulator.as_ref());
 
     multi_bit_blind_rotate_assign(input, &mut local_accumulator, multi_bit_bsk, thread_count);
+
+    extract_lwe_sample_from_glwe_ciphertext(&local_accumulator, output, MonomialDegree(0));
+}
+
+pub fn std_prepare_multi_bit_ggsw<Scalar, GgswBufferCont, TmpGgswBufferCont, GgswGroupCont>(
+    multi_bit_ggsw: &mut GgswCiphertext<GgswBufferCont>,
+    tmp_ggsw_buffer: &mut GgswCiphertext<TmpGgswBufferCont>,
+    ggsw_group: &GgswCiphertextList<GgswGroupCont>,
+    lwe_mask_elements: &[Scalar],
+) where
+    Scalar: UnsignedTorus + CastInto<usize> + CastFrom<usize>,
+    GgswBufferCont: ContainerMut<Element = Scalar>,
+    TmpGgswBufferCont: ContainerMut<Element = Scalar>,
+    GgswGroupCont: Container<Element = Scalar>,
+{
+    let mut ggsw_group_iter = ggsw_group.iter();
+
+    // Keygen guarantees the first term is a constant term of the polynomial, no
+    // polynomial multiplication required
+    let ggsw_a_none = ggsw_group_iter.next().unwrap();
+
+    multi_bit_ggsw
+        .as_mut()
+        .copy_from_slice(ggsw_a_none.as_ref());
+
+    let polynomial_size = multi_bit_ggsw.polynomial_size();
+
+    for (ggsw_idx, std_ggsw) in ggsw_group_iter.enumerate() {
+        // We already processed the first ggsw, advance the index by 1
+        let ggsw_idx = ggsw_idx + 1;
+
+        // Select the proper mask elements to build the monomial degree depending on
+        // the order the GGSW were generated in, using the bits from mask_idx and
+        // ggsw_idx as selector bits
+        let mut monomial_degree = Scalar::ZERO;
+        for (mask_idx, &mask_element) in lwe_mask_elements.iter().enumerate() {
+            let mask_position = lwe_mask_elements.len() - (mask_idx + 1);
+            let selection_bit: Scalar = Scalar::cast_from((ggsw_idx >> mask_position) & 1);
+            monomial_degree =
+                monomial_degree.wrapping_add(selection_bit.wrapping_mul(mask_element));
+        }
+
+        let switched_degree = pbs_modulus_switch(
+            monomial_degree,
+            polynomial_size,
+            ModulusSwitchOffset(0),
+            LutCountLog(0),
+        );
+
+        tmp_ggsw_buffer
+            .as_mut_polynomial_list()
+            .iter_mut()
+            .zip(std_ggsw.as_polynomial_list().iter())
+            .for_each(|(mut tmp_polynomial, input_polynomial)| {
+                polynomial_wrapping_monic_monomial_mul(
+                    &mut tmp_polynomial,
+                    &input_polynomial,
+                    MonomialDegree(switched_degree),
+                );
+            });
+
+        slice_wrapping_add_assign(multi_bit_ggsw.as_mut(), tmp_ggsw_buffer.as_ref());
+    }
+}
+
+pub fn std_multi_bit_blind_rotate_assign<Scalar, InputCont, OutputCont, KeyCont>(
+    input: &LweCiphertext<InputCont>,
+    accumulator: &mut GlweCiphertext<OutputCont>,
+    multi_bit_bsk: &LweMultiBitBootstrapKey<KeyCont>,
+    thread_count: ThreadCount,
+) where
+    // CastInto required for PBS modulus switch which returns a usize
+    Scalar: UnsignedTorus + CastInto<usize> + CastFrom<usize> + Sync + Send,
+    InputCont: Container<Element = Scalar> + Sync,
+    OutputCont: ContainerMut<Element = Scalar>,
+    KeyCont: Container<Element = Scalar> + Sync,
+{
+    assert_eq!(
+        input.lwe_size().to_lwe_dimension(),
+        multi_bit_bsk.input_lwe_dimension(),
+        "Mimatched input LweDimension. LweCiphertext input LweDimension {:?}. \
+        FourierLweMultiBitBootstrapKey input LweDimension {:?}.",
+        input.lwe_size().to_lwe_dimension(),
+        multi_bit_bsk.input_lwe_dimension(),
+    );
+
+    assert_eq!(
+        accumulator.glwe_size(),
+        multi_bit_bsk.glwe_size(),
+        "Mimatched GlweSize. Accumulator GlweSize {:?}. \
+        FourierLweMultiBitBootstrapKey GlweSize {:?}.",
+        accumulator.glwe_size(),
+        multi_bit_bsk.glwe_size(),
+    );
+
+    assert_eq!(
+        accumulator.polynomial_size(),
+        multi_bit_bsk.polynomial_size(),
+        "Mimatched PolynomialSize. Accumulator PolynomialSize {:?}. \
+        FourierLweMultiBitBootstrapKey PolynomialSize {:?}.",
+        accumulator.polynomial_size(),
+        multi_bit_bsk.polynomial_size(),
+    );
+
+    assert_eq!(
+        accumulator.ciphertext_modulus(),
+        multi_bit_bsk.ciphertext_modulus(),
+        "Mimatched CiphertextModulus. Accumulator CiphertextModulus {:?}. \
+        LweMultiBitBootstrapKey CiphertextModulus {:?}.",
+        accumulator.ciphertext_modulus(),
+        multi_bit_bsk.ciphertext_modulus(),
+    );
+
+    assert_eq!(
+        input.ciphertext_modulus(),
+        multi_bit_bsk.ciphertext_modulus(),
+        "Mimatched CiphertextModulus. LweCiphertext CiphertextModulus {:?}. \
+        LweMultiBitBootstrapKey CiphertextModulus {:?}.",
+        input.ciphertext_modulus(),
+        multi_bit_bsk.ciphertext_modulus(),
+    );
+
+    let (lwe_mask, lwe_body) = input.get_mask_and_body();
+
+    // No way to chunk the result of ggsw_iter at the moment
+    // let ggsw_vec: Vec<_> = multi_bit_bsk.ggsw_iter().collect();
+    let mut work_queue = Vec::with_capacity(multi_bit_bsk.multi_bit_input_lwe_dimension().0);
+
+    let grouping_factor = multi_bit_bsk.grouping_factor();
+    let ggsw_per_multi_bit_element = grouping_factor.ggsw_per_multi_bit_element();
+
+    for (lwe_mask_elements, ggsw_group) in lwe_mask
+        .as_ref()
+        .chunks_exact(grouping_factor.0)
+        .zip(multi_bit_bsk.chunks_exact(ggsw_per_multi_bit_element.0))
+    {
+        work_queue.push((lwe_mask_elements, ggsw_group));
+    }
+
+    assert!(work_queue.len() == lwe_mask.lwe_dimension().0 / grouping_factor.0);
+
+    let work_queue = Mutex::new(work_queue);
+
+    // Each producer thread works in a dedicated slot of the buffer
+    let thread_buffers: usize = thread_count.0;
+
+    let lut_poly_size = accumulator.polynomial_size();
+    let monomial_degree = pbs_modulus_switch(
+        *lwe_body.data,
+        lut_poly_size,
+        ModulusSwitchOffset(0),
+        LutCountLog(0),
+    );
+
+    // Modulus switching
+    accumulator
+        .as_mut_polynomial_list()
+        .iter_mut()
+        .for_each(|mut poly| {
+            polynomial_wrapping_monic_monomial_div_assign(
+                &mut poly,
+                MonomialDegree(monomial_degree),
+            )
+        });
+
+    let fourier_multi_bit_ggsw_buffers = (0..thread_buffers)
+        .map(|_| {
+            (
+                Mutex::new(false),
+                Condvar::new(),
+                Mutex::new(FourierGgswCiphertext::new(
+                    multi_bit_bsk.glwe_size(),
+                    multi_bit_bsk.polynomial_size(),
+                    multi_bit_bsk.decomposition_base_log(),
+                    multi_bit_bsk.decomposition_level_count(),
+                )),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    let (tx, rx) = mpsc::channel::<usize>();
+
+    let fft = Fft::new(multi_bit_bsk.polynomial_size());
+    let fft = fft.as_view();
+    thread::scope(|s| {
+        let produce_multi_bit_fourier_ggsw = |thread_id: usize, tx: mpsc::Sender<usize>| {
+            let mut buffers = ComputationBuffers::new();
+
+            buffers.resize(fft.forward_scratch().unwrap().unaligned_bytes_required());
+
+            let mut std_ggsw_buffer = GgswCiphertext::new(
+                Scalar::ZERO,
+                multi_bit_bsk.glwe_size(),
+                multi_bit_bsk.polynomial_size(),
+                multi_bit_bsk.decomposition_base_log(),
+                multi_bit_bsk.decomposition_level_count(),
+                multi_bit_bsk.ciphertext_modulus(),
+            );
+
+            let mut tmp_ggsw_buffer = GgswCiphertext::new(
+                Scalar::ZERO,
+                multi_bit_bsk.glwe_size(),
+                multi_bit_bsk.polynomial_size(),
+                multi_bit_bsk.decomposition_base_log(),
+                multi_bit_bsk.decomposition_level_count(),
+                multi_bit_bsk.ciphertext_modulus(),
+            );
+
+            let work_queue = &work_queue;
+
+            let dest_idx = thread_id;
+            let (ready_for_consumer_lock, condvar, fourier_ggsw_buffer) =
+                &fourier_multi_bit_ggsw_buffers[dest_idx];
+
+            loop {
+                let maybe_work = {
+                    let mut queue_lock = work_queue.lock().unwrap();
+                    queue_lock.pop()
+                };
+
+                let Some((lwe_mask_elements, ggsw_group)) = maybe_work else {break};
+                let mut ready_for_consumer = ready_for_consumer_lock.lock().unwrap();
+
+                // Wait while the buffer is not ready for processing and wait on the condvar
+                // to get notified when we can start processing again
+                while *ready_for_consumer {
+                    ready_for_consumer = condvar.wait(ready_for_consumer).unwrap();
+                }
+
+                let mut fourier_ggsw_buffer = fourier_ggsw_buffer.lock().unwrap();
+
+                std_prepare_multi_bit_ggsw(
+                    &mut std_ggsw_buffer,
+                    &mut tmp_ggsw_buffer,
+                    &ggsw_group,
+                    lwe_mask_elements,
+                );
+
+                fourier_ggsw_buffer.as_mut_view().fill_with_forward_fourier(
+                    std_ggsw_buffer.as_view(),
+                    fft,
+                    buffers.stack(),
+                );
+
+                // Drop the lock before we wake other threads
+                drop(fourier_ggsw_buffer);
+
+                *ready_for_consumer = true;
+                tx.send(dest_idx).unwrap();
+
+                // Wake threads waiting on the condvar
+                condvar.notify_all();
+            }
+        };
+
+        let threads: Vec<_> = (0..thread_count.0)
+            .map(|id| {
+                let tx = tx.clone();
+                s.spawn(move || produce_multi_bit_fourier_ggsw(id, tx))
+            })
+            .collect();
+
+        // We initialize ct0 for the successive external products
+        let ct0 = accumulator;
+        let mut ct1 = GlweCiphertext::new(
+            Scalar::ZERO,
+            ct0.glwe_size(),
+            ct0.polynomial_size(),
+            ct0.ciphertext_modulus(),
+        );
+        let ct1 = &mut ct1;
+
+        let mut buffers = ComputationBuffers::new();
+
+        buffers.resize(
+            add_external_product_assign_scratch::<Scalar>(
+                multi_bit_bsk.glwe_size(),
+                multi_bit_bsk.polynomial_size(),
+                fft,
+            )
+            .unwrap()
+            .unaligned_bytes_required(),
+        );
+
+        let mut src_idx = 1usize;
+
+        for _ in 0..multi_bit_bsk.multi_bit_input_lwe_dimension().0 {
+            src_idx ^= 1;
+            let idx = rx.recv().unwrap();
+            let (ready_lock, condvar, multi_bit_fourier_ggsw) =
+                &fourier_multi_bit_ggsw_buffers[idx];
+
+            let (src_ct, mut dst_ct) = if src_idx == 0 {
+                (ct0.as_view(), ct1.as_mut_view())
+            } else {
+                (ct1.as_view(), ct0.as_mut_view())
+            };
+
+            dst_ct.as_mut().fill(Scalar::ZERO);
+
+            let mut ready = ready_lock.lock().unwrap();
+            assert!(*ready);
+
+            let multi_bit_fourier_ggsw = multi_bit_fourier_ggsw.lock().unwrap();
+            add_external_product_assign(
+                dst_ct,
+                multi_bit_fourier_ggsw.as_view(),
+                src_ct,
+                fft,
+                buffers.stack(),
+            );
+            drop(multi_bit_fourier_ggsw);
+
+            *ready = false;
+            // Wake a single producer thread sleeping on the condvar (only one will get to work
+            // anyways)
+            condvar.notify_one();
+        }
+
+        if src_idx == 0 {
+            ct0.as_mut().copy_from_slice(ct1.as_ref());
+        }
+
+        let ciphertext_modulus = ct0.ciphertext_modulus();
+        if !ciphertext_modulus.is_native_modulus() {
+            // When we convert back from the fourier domain, integer values will contain up to 53
+            // MSBs with information. In our representation of power of 2 moduli < native modulus we
+            // fill the MSBs and leave the LSBs empty, this usage of the signed decomposer allows to
+            // round while keeping the data in the MSBs
+            let signed_decomposer = SignedDecomposer::new(
+                DecompositionBaseLog(ciphertext_modulus.get_custom_modulus().ilog2() as usize),
+                DecompositionLevelCount(1),
+            );
+            ct0.as_mut()
+                .iter_mut()
+                .for_each(|x| *x = signed_decomposer.closest_representable(*x));
+        }
+
+        threads.into_iter().for_each(|t| t.join().unwrap());
+    });
+}
+
+pub fn std_multi_bit_programmable_bootstrap_lwe_ciphertext<
+    Scalar,
+    InputCont,
+    OutputCont,
+    AccCont,
+    KeyCont,
+>(
+    input: &LweCiphertext<InputCont>,
+    output: &mut LweCiphertext<OutputCont>,
+    accumulator: &GlweCiphertext<AccCont>,
+    multi_bit_bsk: &LweMultiBitBootstrapKey<KeyCont>,
+    thread_count: ThreadCount,
+) where
+    // CastInto required for PBS modulus switch which returns a usize
+    Scalar: UnsignedTorus + CastInto<usize> + CastFrom<usize> + Sync + Send,
+    InputCont: Container<Element = Scalar> + Sync,
+    OutputCont: ContainerMut<Element = Scalar>,
+    AccCont: Container<Element = Scalar>,
+    KeyCont: Container<Element = Scalar> + Sync,
+{
+    assert_eq!(
+        input.lwe_size().to_lwe_dimension(),
+        multi_bit_bsk.input_lwe_dimension(),
+        "Mimatched input LweDimension. LweCiphertext input LweDimension {:?}. \
+        FourierLweMultiBitBootstrapKey input LweDimension {:?}.",
+        input.lwe_size().to_lwe_dimension(),
+        multi_bit_bsk.input_lwe_dimension(),
+    );
+
+    assert_eq!(
+        output.lwe_size().to_lwe_dimension(),
+        multi_bit_bsk.output_lwe_dimension(),
+        "Mimatched output LweDimension. LweCiphertext output LweDimension {:?}. \
+        FourierLweMultiBitBootstrapKey output LweDimension {:?}.",
+        output.lwe_size().to_lwe_dimension(),
+        multi_bit_bsk.output_lwe_dimension(),
+    );
+
+    assert_eq!(
+        accumulator.glwe_size(),
+        multi_bit_bsk.glwe_size(),
+        "Mimatched GlweSize. Accumulator GlweSize {:?}. \
+        FourierLweMultiBitBootstrapKey GlweSize {:?}.",
+        accumulator.glwe_size(),
+        multi_bit_bsk.glwe_size(),
+    );
+
+    assert_eq!(
+        accumulator.polynomial_size(),
+        multi_bit_bsk.polynomial_size(),
+        "Mimatched PolynomialSize. Accumulator PolynomialSize {:?}. \
+        FourierLweMultiBitBootstrapKey PolynomialSize {:?}.",
+        accumulator.polynomial_size(),
+        multi_bit_bsk.polynomial_size(),
+    );
+
+    assert_eq!(
+        input.ciphertext_modulus(),
+        multi_bit_bsk.ciphertext_modulus(),
+        "Mimatched CiphertextModulus. LweCiphertext CiphertextModulus {:?}. \
+        LweMultiBitBootstrapKey CiphertextModulus {:?}.",
+        input.ciphertext_modulus(),
+        multi_bit_bsk.ciphertext_modulus(),
+    );
+
+    assert_eq!(
+        accumulator.ciphertext_modulus(),
+        multi_bit_bsk.ciphertext_modulus(),
+        "Mimatched CiphertextModulus. Accumulator CiphertextModulus {:?}. \
+        LweMultiBitBootstrapKey CiphertextModulus {:?}.",
+        accumulator.ciphertext_modulus(),
+        multi_bit_bsk.ciphertext_modulus(),
+    );
+
+    let mut local_accumulator = GlweCiphertext::new(
+        Scalar::ZERO,
+        accumulator.glwe_size(),
+        accumulator.polynomial_size(),
+        accumulator.ciphertext_modulus(),
+    );
+    local_accumulator
+        .as_mut()
+        .copy_from_slice(accumulator.as_ref());
+
+    std_multi_bit_blind_rotate_assign(input, &mut local_accumulator, multi_bit_bsk, thread_count);
 
     extract_lwe_sample_from_glwe_ciphertext(&local_accumulator, output, MonomialDegree(0));
 }

--- a/tfhe/src/core_crypto/algorithms/polynomial_algorithms.rs
+++ b/tfhe/src/core_crypto/algorithms/polynomial_algorithms.rs
@@ -259,6 +259,124 @@ pub fn polynomial_wrapping_monic_monomial_mul_assign<Scalar, OutputCont>(
         .for_each(|a| *a = a.wrapping_neg());
 }
 
+/// Divides (mod $(X^{N}+1)$), the input polynomial with a monic monomial of a given degree i.e.
+/// $X^{degree}$.
+///
+/// # Note
+///
+/// Computations wrap around (similar to computing modulo $2^{n\_{bits}}$) when exceeding the
+/// unsigned integer capacity.
+///
+/// # Examples
+///
+/// ```
+/// use tfhe::core_crypto::algorithms::polynomial_algorithms::*;
+/// use tfhe::core_crypto::commons::parameters::*;
+/// use tfhe::core_crypto::entities::*;
+/// let input = Polynomial::from_container(vec![1u8, 2, 3]);
+/// let mut output = Polynomial::from_container(vec![0, 0, 0]);
+/// polynomial_wrapping_monic_monomial_div(&mut output, &input, MonomialDegree(2));
+/// assert_eq!(output.as_ref(), &[3, 255, 254]);
+/// ```
+pub fn polynomial_wrapping_monic_monomial_div<Scalar, OutputCont, InputCont>(
+    output: &mut Polynomial<OutputCont>,
+    input: &Polynomial<InputCont>,
+    monomial_degree: MonomialDegree,
+) where
+    Scalar: UnsignedInteger,
+    OutputCont: ContainerMut<Element = Scalar>,
+    InputCont: Container<Element = Scalar>,
+{
+    assert!(
+        output.polynomial_size() == input.polynomial_size(),
+        "Output polynomial size {:?} is not the same as input polynomial size {:?}.",
+        output.polynomial_size(),
+        input.polynomial_size(),
+    );
+
+    let polynomial_len = output.container_len();
+    let remaining_degree = monomial_degree.0 % output.as_ref().container_len();
+
+    let src_slice = &input[remaining_degree..];
+    let src_slice_len = src_slice.len();
+    let dst_slice = &mut output[..src_slice_len];
+    dst_slice.copy_from_slice(src_slice);
+
+    for (dst, &src) in output[polynomial_len - remaining_degree..]
+        .iter_mut()
+        .zip(input[..remaining_degree].iter())
+    {
+        *dst = src.wrapping_neg();
+    }
+
+    let full_cycles_count = monomial_degree.0 / polynomial_len;
+    if full_cycles_count % 2 != 0 {
+        output
+            .as_mut()
+            .iter_mut()
+            .for_each(|a| *a = a.wrapping_neg());
+    }
+}
+
+/// Multiply (mod $(X^{N}+1)$), the input polynomial with a monic monomial of a given degree i.e.
+/// $X^{degree}$.
+///
+/// # Note
+///
+/// Computations wrap around (similar to computing modulo $2^{n\_{bits}}$) when exceeding the
+/// unsigned integer capacity.
+///
+/// # Examples
+///
+/// ```
+/// use tfhe::core_crypto::algorithms::polynomial_algorithms::*;
+/// use tfhe::core_crypto::commons::parameters::*;
+/// use tfhe::core_crypto::entities::*;
+/// let input = Polynomial::from_container(vec![1u8, 2, 3]);
+/// let mut output = Polynomial::from_container(vec![0, 0, 0]);
+/// polynomial_wrapping_monic_monomial_mul(&mut output, &input, MonomialDegree(2));
+/// assert_eq!(output.as_ref(), &[254, 253, 1]);
+/// ```
+pub fn polynomial_wrapping_monic_monomial_mul<Scalar, OutputCont, InputCont>(
+    output: &mut Polynomial<OutputCont>,
+    input: &Polynomial<InputCont>,
+    monomial_degree: MonomialDegree,
+) where
+    Scalar: UnsignedInteger,
+    OutputCont: ContainerMut<Element = Scalar>,
+    InputCont: Container<Element = Scalar>,
+{
+    assert!(
+        output.polynomial_size() == input.polynomial_size(),
+        "Output polynomial size {:?} is not the same as input polynomial size {:?}.",
+        output.polynomial_size(),
+        input.polynomial_size(),
+    );
+
+    let polynomial_len = output.container_len();
+    let remaining_degree = monomial_degree.0 % output.as_ref().container_len();
+
+    for (dst, &src) in output[..remaining_degree]
+        .iter_mut()
+        .zip(input[polynomial_len - remaining_degree..].iter())
+    {
+        *dst = src.wrapping_neg();
+    }
+
+    let dst_slice = &mut output[remaining_degree..];
+    let dst_slice_len = dst_slice.len();
+    let src_slice = &input[..dst_slice_len];
+    dst_slice.copy_from_slice(src_slice);
+
+    let full_cycles_count = monomial_degree.0 / polynomial_len;
+    if full_cycles_count % 2 != 0 {
+        output
+            .as_mut()
+            .iter_mut()
+            .for_each(|a| *a = a.wrapping_neg());
+    }
+}
+
 /// Subtract the sum of the element-wise product between two lists of polynomials, to the output
 /// polynomial.
 ///

--- a/tfhe/src/core_crypto/algorithms/test/lwe_multi_bit_programmable_bootstrapping.rs
+++ b/tfhe/src/core_crypto/algorithms/test/lwe_multi_bit_programmable_bootstrapping.rs
@@ -146,6 +146,125 @@ fn lwe_encrypt_multi_bit_pbs_decrypt_custom_mod<
     }
 }
 
+fn lwe_encrypt_std_multi_bit_pbs_decrypt_custom_mod<
+    Scalar: UnsignedTorus + Sync + Send + CastFrom<usize> + CastInto<usize>,
+>(
+    params: MultiBitParams<Scalar>,
+) {
+    let input_lwe_dimension = params.input_lwe_dimension;
+    let lwe_modular_std_dev = params.lwe_modular_std_dev;
+    let glwe_modular_std_dev = params.glwe_modular_std_dev;
+    let ciphertext_modulus = params.ciphertext_modulus;
+    let message_modulus_log = params.message_modulus_log;
+    let msg_modulus = Scalar::ONE.shl(message_modulus_log.0);
+    let encoding_with_padding = get_encoding_with_padding(ciphertext_modulus);
+    let glwe_dimension = params.glwe_dimension;
+    let polynomial_size = params.polynomial_size;
+    let decomp_base_log = params.decomp_base_log;
+    let decomp_level_count = params.decomp_level_count;
+    let grouping_factor = params.grouping_factor;
+    let thread_count = params.thread_count;
+
+    let mut rsc = TestResources::new();
+
+    let f = |x: Scalar| {
+        x.wrapping_mul(Scalar::TWO)
+            .wrapping_sub(Scalar::ONE)
+            .wrapping_rem(msg_modulus)
+    };
+
+    let delta: Scalar = encoding_with_padding / msg_modulus;
+    let mut msg = msg_modulus;
+    const NB_TESTS: usize = 10;
+
+    let accumulator = generate_accumulator(
+        polynomial_size,
+        glwe_dimension.to_glwe_size(),
+        msg_modulus.cast_into(),
+        ciphertext_modulus,
+        delta,
+        f,
+    );
+
+    assert!(check_content_respects_mod(&accumulator, ciphertext_modulus));
+
+    // Keygen is a bit slow on this one so we keep it out of the testing loop
+    // Create the LweSecretKey
+    let input_lwe_secret_key = allocate_and_generate_new_binary_lwe_secret_key(
+        input_lwe_dimension,
+        &mut rsc.secret_random_generator,
+    );
+    let output_glwe_secret_key = allocate_and_generate_new_binary_glwe_secret_key(
+        glwe_dimension,
+        polynomial_size,
+        &mut rsc.secret_random_generator,
+    );
+    let output_lwe_secret_key = output_glwe_secret_key.clone().into_lwe_secret_key();
+
+    let mut bsk = LweMultiBitBootstrapKey::new(
+        Scalar::ZERO,
+        glwe_dimension.to_glwe_size(),
+        polynomial_size,
+        decomp_base_log,
+        decomp_level_count,
+        input_lwe_dimension,
+        grouping_factor,
+        ciphertext_modulus,
+    );
+
+    par_generate_lwe_multi_bit_bootstrap_key(
+        &input_lwe_secret_key,
+        &output_glwe_secret_key,
+        &mut bsk,
+        glwe_modular_std_dev,
+        &mut rsc.encryption_random_generator,
+    );
+
+    assert!(check_content_respects_mod(&*bsk, ciphertext_modulus));
+
+    while msg != Scalar::ZERO {
+        msg = msg.wrapping_sub(Scalar::ONE);
+        for _ in 0..NB_TESTS {
+            let plaintext = Plaintext(msg * delta);
+
+            let lwe_ciphertext_in = allocate_and_encrypt_new_lwe_ciphertext(
+                &input_lwe_secret_key,
+                plaintext,
+                lwe_modular_std_dev,
+                ciphertext_modulus,
+                &mut rsc.encryption_random_generator,
+            );
+
+            assert!(check_content_respects_mod(
+                &lwe_ciphertext_in,
+                ciphertext_modulus
+            ));
+
+            let mut out_pbs_ct = LweCiphertext::new(
+                Scalar::ZERO,
+                output_lwe_secret_key.lwe_dimension().to_lwe_size(),
+                ciphertext_modulus,
+            );
+
+            std_multi_bit_programmable_bootstrap_lwe_ciphertext(
+                &lwe_ciphertext_in,
+                &mut out_pbs_ct,
+                &accumulator,
+                &bsk,
+                thread_count,
+            );
+
+            assert!(check_content_respects_mod(&out_pbs_ct, ciphertext_modulus));
+
+            let decrypted = decrypt_lwe_ciphertext(&output_lwe_secret_key, &out_pbs_ct);
+
+            let decoded = round_decode(decrypted.0, delta) % msg_modulus;
+
+            assert_eq!(decoded, f(msg));
+        }
+    }
+}
+
 #[test]
 pub fn test_lwe_encrypt_multi_bit_pbs_decrypt_factor_2_thread_5_native_mod() {
     lwe_encrypt_multi_bit_pbs_decrypt_custom_mod::<u64>(
@@ -217,6 +336,90 @@ pub fn test_lwe_encrypt_multi_bit_pbs_decrypt_factor_3_thread_12_custom_mod() {
         MultiBitParams {
             input_lwe_dimension: LweDimension(789),
             lwe_modular_std_dev: StandardDev(0.0000038003596741624174),
+            decomp_base_log: DecompositionBaseLog(22),
+            decomp_level_count: DecompositionLevelCount(1),
+            glwe_dimension: GlweDimension(2),
+            polynomial_size: PolynomialSize(1024),
+            glwe_modular_std_dev: StandardDev(0.0000000000000003152931493498455),
+            message_modulus_log: CiphertextModulusLog(3),
+            ciphertext_modulus: CiphertextModulus::try_new_power_of_2(63).unwrap(),
+            grouping_factor: LweBskGroupingFactor(3),
+            thread_count: ThreadCount(12),
+        },
+    );
+}
+
+#[test]
+pub fn test_lwe_encrypt_std_multi_bit_pbs_decrypt_factor_2_thread_5_native_mod() {
+    lwe_encrypt_std_multi_bit_pbs_decrypt_custom_mod::<u64>(
+        // DISCLAIMER: these toy example parameters are not guaranteed to be secure or yield
+        // correct computations
+        MultiBitParams {
+            input_lwe_dimension: LweDimension(786),
+            lwe_modular_std_dev: StandardDev(0.0000040164874030685975),
+            decomp_base_log: DecompositionBaseLog(23),
+            decomp_level_count: DecompositionLevelCount(1),
+            glwe_dimension: GlweDimension(2),
+            polynomial_size: PolynomialSize(1024),
+            glwe_modular_std_dev: StandardDev(0.0000000000000003152931493498455),
+            message_modulus_log: CiphertextModulusLog(4),
+            ciphertext_modulus: CiphertextModulus::new_native(),
+            grouping_factor: LweBskGroupingFactor(2),
+            thread_count: ThreadCount(5),
+        },
+    );
+}
+
+#[test]
+pub fn test_lwe_encrypt_std_multi_bit_pbs_decrypt_factor_3_thread_12_native_mod() {
+    lwe_encrypt_std_multi_bit_pbs_decrypt_custom_mod::<u64>(
+        // DISCLAIMER: these toy example parameters are not guaranteed to be secure or yield
+        // correct computations
+        MultiBitParams {
+            input_lwe_dimension: LweDimension(786),
+            lwe_modular_std_dev: StandardDev(0.0000040164874030685975),
+            decomp_base_log: DecompositionBaseLog(22),
+            decomp_level_count: DecompositionLevelCount(1),
+            glwe_dimension: GlweDimension(2),
+            polynomial_size: PolynomialSize(1024),
+            glwe_modular_std_dev: StandardDev(0.0000000000000003152931493498455),
+            message_modulus_log: CiphertextModulusLog(4),
+            ciphertext_modulus: CiphertextModulus::new_native(),
+            grouping_factor: LweBskGroupingFactor(3),
+            thread_count: ThreadCount(12),
+        },
+    );
+}
+
+#[test]
+pub fn test_lwe_encrypt_std_multi_bit_pbs_decrypt_factor_2_thread_5_custom_mod() {
+    lwe_encrypt_std_multi_bit_pbs_decrypt_custom_mod::<u64>(
+        // DISCLAIMER: these toy example parameters are not guaranteed to be secure or yield
+        // correct computations
+        MultiBitParams {
+            input_lwe_dimension: LweDimension(786),
+            lwe_modular_std_dev: StandardDev(0.0000040164874030685975),
+            decomp_base_log: DecompositionBaseLog(23),
+            decomp_level_count: DecompositionLevelCount(1),
+            glwe_dimension: GlweDimension(2),
+            polynomial_size: PolynomialSize(1024),
+            glwe_modular_std_dev: StandardDev(0.0000000000000003152931493498455),
+            message_modulus_log: CiphertextModulusLog(3),
+            ciphertext_modulus: CiphertextModulus::try_new_power_of_2(63).unwrap(),
+            grouping_factor: LweBskGroupingFactor(2),
+            thread_count: ThreadCount(5),
+        },
+    );
+}
+
+#[test]
+pub fn test_lwe_encrypt_std_multi_bit_pbs_decrypt_factor_3_thread_12_custom_mod() {
+    lwe_encrypt_std_multi_bit_pbs_decrypt_custom_mod::<u64>(
+        // DISCLAIMER: these toy example parameters are not guaranteed to be secure or yield
+        // correct computations
+        MultiBitParams {
+            input_lwe_dimension: LweDimension(786),
+            lwe_modular_std_dev: StandardDev(0.0000040164874030685975),
             decomp_base_log: DecompositionBaseLog(22),
             decomp_level_count: DecompositionLevelCount(1),
             glwe_dimension: GlweDimension(2),


### PR DESCRIPTION
An alternative way of generating the key bits for the multi-bit bootstrapping, computations are made in the standard domain meaning the resulting ciphertext contains less noise, but is more costly to compute, it is interesting to have that trade-off to better manage noise even if it means using more thread to keep the consumer thread saturated