### PR TITLE
chore(ci): record benchmarks parameters to be stored in database

### DIFF
--- a/.github/workflows/boolean_benchmark.yml
+++ b/.github/workflows/boolean_benchmark.yml
@@ -19,10 +19,6 @@ on:
       request_id:
         description: 'Slab request ID'
         type: string
-      matrix_item:
-        description: 'Build matrix item'
-        type: string
-
 
 env:
   CARGO_TERM_COLOR: always
@@ -40,7 +36,6 @@ jobs:
           echo "AMI: ${{ inputs.instance_image_id }}"
           echo "Type: ${{ inputs.instance_type }}"
           echo "Request ID: ${{ inputs.request_id }}"
-          echo "Matrix item: ${{ inputs.matrix_item }}"
 
       - name: Get benchmark date
         run: |
@@ -71,12 +66,13 @@ jobs:
           COMMIT_DATE="$(git --no-pager show -s --format=%cd --date=iso8601-strict ${{ github.sha }})"
           COMMIT_HASH="$(git describe --tags --dirty)"
           python3 ./ci/benchmark_parser.py target/criterion ${{ env.RESULTS_FILENAME }} \
-          --database tfhe_rs_benchmarks \
+          --database tfhe_rs \
           --hardware ${{ inputs.instance_type }} \
           --project-version "${COMMIT_HASH}" \
           --branch ${{ github.ref_name }} \
           --commit-date "${COMMIT_DATE}" \
           --bench-date "${{ env.BENCH_DATE }}" \
+          --walk-subdirs \
           --throughput
 
       - name: Remove previous raw results
@@ -92,6 +88,7 @@ jobs:
           python3 ./ci/benchmark_parser.py target/criterion ${{ env.RESULTS_FILENAME }} \
           --hardware ${{ inputs.instance_type }} \
           --name-suffix avx512 \
+          --walk-subdirs \
           --throughput \
           --append-results
 
@@ -120,14 +117,16 @@ jobs:
 
       - name: Send data to Slab
         shell: bash
+        env:
+          COMPRESSED_RESULTS : ${{ env.RESULTS_FILENAME }}.gz
         run: |
-          echo "Computing HMac on downloaded artifact"
+          echo "Computing HMac on results file"
           SIGNATURE="$(slab/scripts/hmac_calculator.sh ${{ env.RESULTS_FILENAME }} '${{ secrets.JOB_SECRET }}')"
           echo "Sending results to Slab..."
           curl -v -k \
           -H "Content-Type: application/json" \
           -H "X-Slab-Repository: ${{ github.repository }}" \
-          -H "X-Slab-Command: store_data" \
+          -H "X-Slab-Command: store_data_v2" \
           -H "X-Hub-Signature-256: sha256=${SIGNATURE}" \
           -d @${{ env.RESULTS_FILENAME }} \
           ${{ secrets.SLAB_URL }}

--- a/.github/workflows/integer_benchmark.yml
+++ b/.github/workflows/integer_benchmark.yml
@@ -1,5 +1,5 @@
-# Run shortint benchmarks on an AWS instance and return parsed results to Slab CI bot.
-name: Shortint benchmarks
+# Run integer benchmarks on an AWS instance and return parsed results to Slab CI bot.
+name: Integer benchmarks
 
 on:
   workflow_dispatch:
@@ -20,14 +20,13 @@ on:
         description: 'Slab request ID'
         type: string
 
-
 env:
   CARGO_TERM_COLOR: always
   RESULTS_FILENAME: parsed_benchmark_results_${{ github.sha }}.json
 
 jobs:
-  run-shortint-benchmarks:
-    name: Execute shortint benchmarks in EC2
+  run-integer-benchmarks:
+    name: Execute integer benchmarks in EC2
     runs-on: ${{ github.event.inputs.runner_name }}
     if: ${{ !cancelled() }}
     steps:
@@ -60,7 +59,7 @@ jobs:
 
       - name: Run benchmarks
         run: |
-          make bench_shortint
+          make bench_integer
 
       - name: Parse results
         run: |
@@ -82,7 +81,7 @@ jobs:
 
       - name: Run benchmarks with AVX512
         run: |
-          make AVX512_SUPPORT=ON bench_shortint
+          make AVX512_SUPPORT=ON bench_integer
 
       - name: Parse AVX512 results
         run: |
@@ -93,20 +92,10 @@ jobs:
           --throughput \
           --append-results
 
-      - name: Measure key sizes
-        run: |
-          make measure_shortint_key_sizes
-
-      - name: Parse key sizes results
-        run: |
-          python3 ./ci/benchmark_parser.py tfhe/shortint_key_sizes.csv ${{ env.RESULTS_FILENAME }} \
-          --key-sizes \
-          --append-results
-
       - name: Upload parsed results artifact
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
         with:
-          name: ${{ github.sha }}_shortint
+          name: ${{ github.sha }}_integer
           path: ${{ env.RESULTS_FILENAME }}
 
       - name: Checkout Slab repo

--- a/.github/workflows/pbs_benchmark.yml
+++ b/.github/workflows/pbs_benchmark.yml
@@ -67,13 +67,14 @@ jobs:
           COMMIT_DATE="$(git --no-pager show -s --format=%cd --date=iso8601-strict ${{ github.sha }})"
           COMMIT_HASH="$(git describe --tags --dirty)"
           python3 ./ci/benchmark_parser.py target/criterion ${{ env.RESULTS_FILENAME }} \
-          --database tfhe_rs_benchmarks \
+          --database tfhe_rs \
           --hardware ${{ inputs.instance_type }} \
           --project-version "${COMMIT_HASH}" \
           --branch ${{ github.ref_name }} \
           --commit-date "${COMMIT_DATE}" \
           --bench-date "${{ env.BENCH_DATE }}" \
           --name-suffix avx512 \
+          --walk-subdirs \
           --throughput
 
       - name: Upload parsed results artifact
@@ -98,7 +99,7 @@ jobs:
           curl -v -k \
           -H "Content-Type: application/json" \
           -H "X-Slab-Repository: ${{ github.repository }}" \
-          -H "X-Slab-Command: store_data" \
+          -H "X-Slab-Command: store_data_v2" \
           -H "X-Hub-Signature-256: sha256=${SIGNATURE}" \
           -d @${{ env.RESULTS_FILENAME }} \
           ${{ secrets.SLAB_URL }}

--- a/.github/workflows/start_benchmarks.yml
+++ b/.github/workflows/start_benchmarks.yml
@@ -11,7 +11,7 @@ jobs:
   start-benchmarks:
     strategy:
       matrix:
-        command: [boolean_bench, shortint_bench, pbs_bench]
+        command: [boolean_bench, shortint_bench, integer_bench, pbs_bench]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Slab repo

--- a/.github/workflows/start_benchmarks.yml
+++ b/.github/workflows/start_benchmarks.yml
@@ -23,11 +23,11 @@ jobs:
 
       - name: Start AWS job in Slab
         shell: bash
-        # TODO: step result must be correlated to HTTP return code.
         run: |
           echo -n '{"command": "${{ matrix.command }}", "git_ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}' > command.json
           SIGNATURE="$(slab/scripts/hmac_calculator.sh command.json '${{ secrets.JOB_SECRET }}')"
           curl -v -k \
+          --fail-with-body \
           -H "Content-Type: application/json" \
           -H "X-Slab-Repository: ${{ github.repository }}" \
           -H "X-Slab-Command: start_aws" \

--- a/Makefile
+++ b/Makefile
@@ -280,6 +280,12 @@ test_nodejs_wasm_api: build_node_js_api
 no_tfhe_typo:
 	@./scripts/no_tfhe_typo.sh
 
+.PHONY: bench_integer # Run benchmarks for integer
+bench_integer: install_rs_check_toolchain
+	RUSTFLAGS="$(RUSTFLAGS)" cargo $(CARGO_RS_CHECK_TOOLCHAIN) bench \
+	--bench integer-bench \
+	--features=$(TARGET_ARCH_FEATURE),integer,internal-keycache,$(AVX512_FEATURE) -p tfhe
+
 .PHONY: bench_shortint # Run benchmarks for shortint
 bench_shortint: install_rs_check_toolchain
 	RUSTFLAGS="$(RUSTFLAGS)" cargo $(CARGO_RS_CHECK_TOOLCHAIN) bench \

--- a/ci/slab.toml
+++ b/ci/slab.toml
@@ -18,6 +18,11 @@ workflow = "aws_tfhe_integer_tests.yml"
 profile = "cpu-big"
 check_run_name = "CPU Integer AWS Tests"
 
+[command.integer_bench]
+workflow = "integer_benchmark.yml"
+profile = "bench"
+check_run_name = "Integer CPU AWS Benchmarks"
+
 [command.shortint_bench]
 workflow = "shortint_benchmark.yml"
 profile = "bench"

--- a/tfhe/Cargo.toml
+++ b/tfhe/Cargo.toml
@@ -23,6 +23,7 @@ paste = "1.0.7"
 lazy_static = { version = "1.4.0" }
 criterion = "0.4.0"
 doc-comment = "0.3.3"
+serde_json = "1.0.94"
 # Used in user documentation
 bincode = "1.3.3"
 fs2 = { version = "0.4.3" }
@@ -166,6 +167,12 @@ name = "keygen"
 path = "benches/keygen/bench.rs"
 harness = false
 required-features = ["shortint", "internal-keycache"]
+
+[[bench]]
+name = "utilities"
+path = "benches/utilities.rs"
+harness = false
+required-features = ["boolean", "shortint", "integer", "internal-keycache"]
 
 [[example]]
 name = "generates_test_keys"

--- a/tfhe/Cargo.toml
+++ b/tfhe/Cargo.toml
@@ -27,6 +27,7 @@ doc-comment = "0.3.3"
 bincode = "1.3.3"
 fs2 = { version = "0.4.3" }
 itertools = "0.10.5"
+num_cpus = "1.15"
 
 [build-dependencies]
 cbindgen = { version = "0.24.3", optional = true }

--- a/tfhe/benches/boolean/bench.rs
+++ b/tfhe/benches/boolean/bench.rs
@@ -1,3 +1,7 @@
+#[path = "../utilities.rs"]
+mod utilities;
+use crate::utilities::{write_to_json, OperatorType};
+
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use tfhe::boolean::client_key::ClientKey;
 use tfhe::boolean::parameters::{BooleanParameters, DEFAULT_PARAMETERS, TFHE_LIB_PARAMETERS};
@@ -14,7 +18,9 @@ criterion_main!(gates_benches);
 
 // Put all `bench_function` in one place
 // so the keygen is only run once per parameters saving time.
-fn bench_gates(c: &mut Criterion, params: BooleanParameters, parameter_name: &str) {
+fn benchs(c: &mut Criterion, params: BooleanParameters, parameter_name: &str) {
+    let mut bench_group = c.benchmark_group("gates_benches");
+
     let cks = ClientKey::new(&params);
     let sks = ServerKey::new(&cks);
 
@@ -22,32 +28,41 @@ fn bench_gates(c: &mut Criterion, params: BooleanParameters, parameter_name: &st
     let ct2 = cks.encrypt(false);
     let ct3 = cks.encrypt(true);
 
-    let id = format!("AND gate {parameter_name}");
-    c.bench_function(&id, |b| b.iter(|| black_box(sks.and(&ct1, &ct2))));
+    let operator = OperatorType::Atomic;
 
-    let id = format!("NAND gate {parameter_name}");
-    c.bench_function(&id, |b| b.iter(|| black_box(sks.nand(&ct1, &ct2))));
+    let id = format!("AND::{parameter_name}");
+    bench_group.bench_function(&id, |b| b.iter(|| black_box(sks.and(&ct1, &ct2))));
+    write_to_json(&id, params, parameter_name, "and", &operator);
 
-    let id = format!("OR gate {parameter_name}");
-    c.bench_function(&id, |b| b.iter(|| black_box(sks.or(&ct1, &ct2))));
+    let id = format!("NAND::{parameter_name}");
+    bench_group.bench_function(&id, |b| b.iter(|| black_box(sks.nand(&ct1, &ct2))));
+    write_to_json(&id, params, parameter_name, "nand", &operator);
 
-    let id = format!("XOR gate {parameter_name}");
-    c.bench_function(&id, |b| b.iter(|| black_box(sks.xor(&ct1, &ct2))));
+    let id = format!("OR::{parameter_name}");
+    bench_group.bench_function(&id, |b| b.iter(|| black_box(sks.or(&ct1, &ct2))));
+    write_to_json(&id, params, parameter_name, "or", &operator);
 
-    let id = format!("XNOR gate {parameter_name}");
-    c.bench_function(&id, |b| b.iter(|| black_box(sks.xnor(&ct1, &ct2))));
+    let id = format!("XOR::{parameter_name}");
+    bench_group.bench_function(&id, |b| b.iter(|| black_box(sks.xor(&ct1, &ct2))));
+    write_to_json(&id, params, parameter_name, "xor", &operator);
 
-    let id = format!("NOT gate {parameter_name}");
-    c.bench_function(&id, |b| b.iter(|| black_box(sks.not(&ct1))));
+    let id = format!("XNOR::{parameter_name}");
+    bench_group.bench_function(&id, |b| b.iter(|| black_box(sks.xnor(&ct1, &ct2))));
+    write_to_json(&id, params, parameter_name, "xnor", &operator);
 
-    let id = format!("MUX gate {parameter_name}");
-    c.bench_function(&id, |b| b.iter(|| black_box(sks.mux(&ct1, &ct2, &ct3))));
+    let id = format!("NOT::{parameter_name}");
+    bench_group.bench_function(&id, |b| b.iter(|| black_box(sks.not(&ct1))));
+    write_to_json(&id, params, parameter_name, "not", &operator);
+
+    let id = format!("MUX::{parameter_name}");
+    bench_group.bench_function(&id, |b| b.iter(|| black_box(sks.mux(&ct1, &ct2, &ct3))));
+    write_to_json(&id, params, parameter_name, "mux", &operator);
 }
 
 fn bench_default_parameters(c: &mut Criterion) {
-    bench_gates(c, DEFAULT_PARAMETERS, "DEFAULT_PARAMETERS");
+    benchs(c, DEFAULT_PARAMETERS, "DEFAULT_PARAMETERS");
 }
 
 fn bench_tfhe_lib_parameters(c: &mut Criterion) {
-    bench_gates(c, TFHE_LIB_PARAMETERS, "TFHE_LIB_PARAMETERS");
+    benchs(c, TFHE_LIB_PARAMETERS, "TFHE_LIB_PARAMETERS");
 }

--- a/tfhe/benches/core_crypto/pbs_bench.rs
+++ b/tfhe/benches/core_crypto/pbs_bench.rs
@@ -28,14 +28,52 @@ const BOOLEAN_BENCH_PARAMS: [(&str, BooleanParameters); 2] = [
     ("boolean_tfhe_lib_params", TFHE_LIB_PARAMETERS),
 ];
 
+const MULTI_BIT_PARAMS: [(&str, (BenchmarkPbsParameters, LweBskGroupingFactor)); 2] = [
+    (
+        "4_bits_multi_bit_group_2",
+        (
+            BenchmarkPbsParameters {
+                input_lwe_dimension: LweDimension(724),
+                lwe_modular_std_dev: StandardDev(1.58705e-10),
+                decomp_base_log: DecompositionBaseLog(1),
+                decomp_level_count: DecompositionLevelCount(18),
+                glwe_dimension: GlweDimension(3),
+                polynomial_size: PolynomialSize(512),
+            },
+            LweBskGroupingFactor(2),
+        ),
+    ),
+    (
+        "4_bits_multi_bit_group_3",
+        (
+            BenchmarkPbsParameters {
+                input_lwe_dimension: LweDimension(732),
+                lwe_modular_std_dev: StandardDev(1.18161e-10),
+                decomp_base_log: DecompositionBaseLog(1),
+                decomp_level_count: DecompositionLevelCount(18),
+                glwe_dimension: GlweDimension(3),
+                polynomial_size: PolynomialSize(512),
+            },
+            LweBskGroupingFactor(3),
+        ),
+    ),
+];
+
 criterion_group!(
     name = pbs_group;
     config = Criterion::default().sample_size(2000);
     targets = mem_optimized_pbs::<u64>, mem_optimized_pbs::<u32>
 );
 
-criterion_main!(pbs_group);
+criterion_group!(
+    name = multi_bit_pbs_group;
+    config = Criterion::default().sample_size(2000);
+    targets = multi_bit_pbs::<u64>, multi_bit_pbs::<u32>
+);
 
+criterion_main!(pbs_group, multi_bit_pbs_group);
+
+#[derive(Clone, Copy)]
 struct BenchmarkPbsParameters {
     input_lwe_dimension: LweDimension,
     lwe_modular_std_dev: StandardDev,
@@ -86,6 +124,23 @@ fn benchmark_parameters<Scalar: Numeric>() -> Vec<(String, BenchmarkPbsParameter
         BOOLEAN_BENCH_PARAMS
             .iter()
             .map(|(name, params)| (name.to_string(), params.to_owned().into()))
+            .collect()
+    } else {
+        vec![]
+    }
+}
+
+fn multi_bit_benchmark_parameters<Scalar: Numeric>(
+) -> Vec<(String, (BenchmarkPbsParameters, LweBskGroupingFactor))> {
+    if Scalar::BITS == 64 {
+        MULTI_BIT_PARAMS
+            .iter()
+            .map(|(name, (params, grouping_factor))| {
+                (
+                    name.to_string(),
+                    (params.to_owned(), grouping_factor.to_owned()),
+                )
+            })
             .collect()
     } else {
         vec![]
@@ -175,5 +230,80 @@ fn mem_optimized_pbs<Scalar: UnsignedTorus + CastInto<usize>>(c: &mut Criterion)
                 })
             });
         }
+    }
+}
+
+fn multi_bit_pbs<Scalar: UnsignedTorus + CastInto<usize> + CastFrom<usize> + Sync>(
+    c: &mut Criterion,
+) {
+    // DISCLAIMER: these toy example parameters are not guaranteed to be secure or yield correct
+    // computations
+    // Define parameters for LweBootstrapKey creation
+
+    // Create the PRNG
+    let mut seeder = new_seeder();
+    let seeder = seeder.as_mut();
+    let mut encryption_generator =
+        EncryptionRandomGenerator::<ActivatedRandomGenerator>::new(seeder.seed(), seeder);
+    let mut secret_generator =
+        SecretRandomGenerator::<ActivatedRandomGenerator>::new(seeder.seed());
+
+    for (name, (params, grouping_factor)) in multi_bit_benchmark_parameters::<Scalar>().iter() {
+        // Create the LweSecretKey
+        let input_lwe_secret_key = allocate_and_generate_new_binary_lwe_secret_key(
+            params.input_lwe_dimension,
+            &mut secret_generator,
+        );
+        let output_glwe_secret_key: GlweSecretKeyOwned<Scalar> =
+            allocate_and_generate_new_binary_glwe_secret_key(
+                params.glwe_dimension,
+                params.polynomial_size,
+                &mut secret_generator,
+            );
+        let output_lwe_secret_key = output_glwe_secret_key.into_lwe_secret_key();
+
+        let multi_bit_bsk = FourierLweMultiBitBootstrapKey::new(
+            params.input_lwe_dimension,
+            params.glwe_dimension.to_glwe_size(),
+            params.polynomial_size,
+            params.decomp_base_log,
+            params.decomp_level_count,
+            *grouping_factor,
+        );
+
+        // Allocate a new LweCiphertext and encrypt our plaintext
+        let lwe_ciphertext_in = allocate_and_encrypt_new_lwe_ciphertext(
+            &input_lwe_secret_key,
+            Plaintext(Scalar::ZERO),
+            params.lwe_modular_std_dev,
+            &mut encryption_generator,
+        );
+
+        let accumulator = GlweCiphertext::new(
+            Scalar::ZERO,
+            params.glwe_dimension.to_glwe_size(),
+            params.polynomial_size,
+        );
+
+        // Allocate the LweCiphertext to store the result of the PBS
+        let mut out_pbs_ct = LweCiphertext::new(
+            Scalar::ZERO,
+            output_lwe_secret_key.lwe_dimension().to_lwe_size(),
+        );
+
+        let id = format!("multi-bit-PBS_{name}");
+        c.bench_function(&id, |b| {
+            b.iter(|| {
+                multi_bit_programmable_bootstrap_lwe_ciphertext(
+                    &lwe_ciphertext_in,
+                    &mut out_pbs_ct,
+                    &accumulator.as_view(),
+                    &multi_bit_bsk,
+                    // Leave one thread to the OS and one for the ext product loop
+                    ThreadCount(2.max(num_cpus::get_physical() - 2)),
+                );
+                black_box(&mut out_pbs_ct);
+            })
+        });
     }
 }

--- a/tfhe/benches/integer/bench.rs
+++ b/tfhe/benches/integer/bench.rs
@@ -296,6 +296,13 @@ define_server_key_bench_fn!(method_name: smart_bitand_parallelized, display_name
 define_server_key_bench_fn!(method_name: smart_bitxor_parallelized, display_name: bitxor);
 define_server_key_bench_fn!(method_name: smart_bitor_parallelized, display_name: bitor);
 
+define_server_key_bench_fn!(method_name: add_parallelized, display_name: add);
+define_server_key_bench_fn!(method_name: sub_parallelized, display_name: sub);
+define_server_key_bench_fn!(method_name: mul_parallelized, display_name: mul);
+define_server_key_bench_fn!(method_name: bitand_parallelized, display_name: bitand);
+define_server_key_bench_fn!(method_name: bitxor_parallelized, display_name: bitxor);
+define_server_key_bench_fn!(method_name: bitor_parallelized, display_name: bitor);
+
 define_server_key_bench_fn!(method_name: unchecked_add, display_name: add);
 define_server_key_bench_fn!(method_name: unchecked_sub, display_name: sub);
 define_server_key_bench_fn!(method_name: unchecked_mul, display_name: mul);
@@ -334,11 +341,18 @@ define_server_key_bench_scalar_fn!(
     display_name: mul
 );
 
+define_server_key_bench_scalar_fn!(method_name: scalar_add_parallelized, display_name: add);
+define_server_key_bench_scalar_fn!(method_name: scalar_sub_parallelized, display_name: sub);
+define_server_key_bench_scalar_fn!(method_name: scalar_mul_parallelized, display_name: mul);
+
 define_server_key_bench_scalar_fn!(method_name: unchecked_scalar_add, display_name: add);
 define_server_key_bench_scalar_fn!(method_name: unchecked_scalar_sub, display_name: sub);
 define_server_key_bench_scalar_fn!(method_name: unchecked_small_scalar_mul, display_name: mul);
 
 define_server_key_bench_unary_fn!(method_name: smart_neg, display_name: negation);
+define_server_key_bench_unary_fn!(method_name: smart_neg_parallelized, display_name: negation);
+define_server_key_bench_unary_fn!(method_name: neg_parallelized, display_name: negation);
+
 define_server_key_bench_unary_fn!(method_name: full_propagate, display_name: carry_propagation);
 define_server_key_bench_unary_fn!(
     method_name: full_propagate_parallelized,
@@ -398,6 +412,14 @@ define_server_key_bench_fn!(
     display_name: greater_or_equal
 );
 
+define_server_key_bench_fn!(method_name: max_parallelized, display_name: max);
+define_server_key_bench_fn!(method_name: min_parallelized, display_name: min);
+define_server_key_bench_fn!(method_name: eq_parallelized, display_name: equal);
+define_server_key_bench_fn!(method_name: lt_parallelized, display_name: less_than);
+define_server_key_bench_fn!(method_name: le_parallelized, display_name: less_or_equal);
+define_server_key_bench_fn!(method_name: gt_parallelized, display_name: greater_than);
+define_server_key_bench_fn!(method_name: ge_parallelized, display_name: greater_or_equal);
+
 criterion_group!(
     smart_arithmetic_operation,
     smart_neg,
@@ -433,6 +455,23 @@ criterion_group!(
 );
 
 criterion_group!(
+    arithmetic_parallelized_operation,
+    add_parallelized,
+    sub_parallelized,
+    mul_parallelized,
+    bitand_parallelized,
+    bitor_parallelized,
+    bitxor_parallelized,
+    max_parallelized,
+    min_parallelized,
+    eq_parallelized,
+    lt_parallelized,
+    le_parallelized,
+    gt_parallelized,
+    ge_parallelized,
+);
+
+criterion_group!(
     smart_scalar_arithmetic_operation,
     smart_scalar_add,
     smart_scalar_sub,
@@ -444,6 +483,13 @@ criterion_group!(
     smart_scalar_add_parallelized,
     smart_scalar_sub_parallelized,
     smart_scalar_mul_parallelized,
+);
+
+criterion_group!(
+    scalar_arithmetic_parallel_operation,
+    scalar_add_parallelized,
+    scalar_sub_parallelized,
+    scalar_mul_parallelized,
 );
 
 criterion_group!(
@@ -486,20 +532,20 @@ criterion_group!(misc, full_propagate, full_propagate_parallelized);
 // This gather all the operations that a high-level user could use.
 criterion_group!(
     fast_integer_benchmarks,
-    smart_bitand_parallelized,
-    smart_bitor_parallelized,
-    smart_bitxor_parallelized,
-    smart_add_parallelized,
-    smart_sub_parallelized,
-    smart_mul_parallelized,
-    smart_neg,
-    smart_min_parallelized,
-    smart_max_parallelized,
-    smart_eq_parallelized,
-    smart_lt_parallelized,
-    smart_le_parallelized,
-    smart_gt_parallelized,
-    smart_ge_parallelized,
+    bitand_parallelized,
+    bitor_parallelized,
+    bitxor_parallelized,
+    add_parallelized,
+    sub_parallelized,
+    mul_parallelized,
+    neg_parallelized,
+    min_parallelized,
+    max_parallelized,
+    eq_parallelized,
+    lt_parallelized,
+    le_parallelized,
+    gt_parallelized,
+    ge_parallelized,
 );
 
 criterion_main!(

--- a/tfhe/benches/integer/bench.rs
+++ b/tfhe/benches/integer/bench.rs
@@ -23,15 +23,16 @@ use tfhe::shortint::parameters::{
 /// in radix decomposition
 struct ParamsAndNumBlocksIter {
     params_and_bit_sizes:
-        itertools::Product<IntoIter<tfhe::shortint::Parameters, 3>, IntoIter<usize, 7>>,
+        itertools::Product<IntoIter<tfhe::shortint::Parameters, 1>, IntoIter<usize, 7>>,
 }
 
 impl Default for ParamsAndNumBlocksIter {
     fn default() -> Self {
-        const PARAMS: [tfhe::shortint::Parameters; 3] = [
+        // FIXME One set of parameter is tested since we want to benchmark only quickest operations.
+        const PARAMS: [tfhe::shortint::Parameters; 1] = [
             PARAM_MESSAGE_2_CARRY_2,
-            PARAM_MESSAGE_3_CARRY_3,
-            PARAM_MESSAGE_4_CARRY_4,
+            // PARAM_MESSAGE_3_CARRY_3,
+            // PARAM_MESSAGE_4_CARRY_4,
         ];
         const BIT_SIZES: [usize; 7] = [8, 16, 32, 40, 64, 128, 256];
         let params_and_bit_sizes = iproduct!(PARAMS, BIT_SIZES);
@@ -481,12 +482,33 @@ criterion_group!(
 
 criterion_group!(misc, full_propagate, full_propagate_parallelized);
 
+// User-oriented benchmark group.
+// This gather all the operations that a high-level user could use.
+criterion_group!(
+    fast_integer_benchmarks,
+    smart_bitand_parallelized,
+    smart_bitor_parallelized,
+    smart_bitxor_parallelized,
+    smart_add_parallelized,
+    smart_sub_parallelized,
+    smart_mul_parallelized,
+    smart_neg,
+    smart_min_parallelized,
+    smart_max_parallelized,
+    smart_eq_parallelized,
+    smart_lt_parallelized,
+    smart_le_parallelized,
+    smart_gt_parallelized,
+    smart_ge_parallelized,
+);
+
 criterion_main!(
-    smart_arithmetic_operation,
-    smart_arithmetic_parallelized_operation,
-    smart_scalar_arithmetic_operation,
-    smart_scalar_arithmetic_parallel_operation,
-    unchecked_arithmetic_operation,
-    unchecked_scalar_arithmetic_operation,
-    misc,
+    fast_integer_benchmarks,
+    // smart_arithmetic_operation,
+    // smart_arithmetic_parallelized_operation,
+    // smart_scalar_arithmetic_operation,
+    // smart_scalar_arithmetic_parallel_operation,
+    // unchecked_arithmetic_operation,
+    // unchecked_scalar_arithmetic_operation,
+    // misc,
 );

--- a/tfhe/benches/utilities.rs
+++ b/tfhe/benches/utilities.rs
@@ -1,0 +1,184 @@
+use serde::Serialize;
+use std::fs;
+use std::path::PathBuf;
+#[cfg(feature = "boolean")]
+use tfhe::boolean::parameters::BooleanParameters;
+use tfhe::core_crypto::prelude::*;
+#[cfg(feature = "shortint")]
+use tfhe::shortint::Parameters;
+
+#[derive(Clone, Copy, Default, Serialize)]
+pub struct CryptoParametersRecord {
+    pub lwe_dimension: Option<LweDimension>,
+    pub glwe_dimension: Option<GlweDimension>,
+    pub polynomial_size: Option<PolynomialSize>,
+    pub lwe_modular_std_dev: Option<StandardDev>,
+    pub glwe_modular_std_dev: Option<StandardDev>,
+    pub pbs_base_log: Option<DecompositionBaseLog>,
+    pub pbs_level: Option<DecompositionLevelCount>,
+    pub ks_base_log: Option<DecompositionBaseLog>,
+    pub ks_level: Option<DecompositionLevelCount>,
+    pub pfks_level: Option<DecompositionLevelCount>,
+    pub pfks_base_log: Option<DecompositionBaseLog>,
+    pub pfks_modular_std_dev: Option<StandardDev>,
+    pub cbs_level: Option<DecompositionLevelCount>,
+    pub cbs_base_log: Option<DecompositionBaseLog>,
+    pub message_modulus: Option<usize>,
+    pub carry_modulus: Option<usize>,
+}
+
+#[cfg(feature = "boolean")]
+impl From<BooleanParameters> for CryptoParametersRecord {
+    fn from(params: BooleanParameters) -> Self {
+        CryptoParametersRecord {
+            lwe_dimension: Some(params.lwe_dimension),
+            glwe_dimension: Some(params.glwe_dimension),
+            polynomial_size: Some(params.polynomial_size),
+            lwe_modular_std_dev: Some(params.lwe_modular_std_dev),
+            glwe_modular_std_dev: Some(params.glwe_modular_std_dev),
+            pbs_base_log: Some(params.pbs_base_log),
+            pbs_level: Some(params.pbs_level),
+            ks_base_log: Some(params.ks_base_log),
+            ks_level: Some(params.ks_level),
+            pfks_level: None,
+            pfks_base_log: None,
+            pfks_modular_std_dev: None,
+            cbs_level: None,
+            cbs_base_log: None,
+            message_modulus: None,
+            carry_modulus: None,
+        }
+    }
+}
+
+#[cfg(feature = "shortint")]
+impl From<Parameters> for CryptoParametersRecord {
+    fn from(params: Parameters) -> Self {
+        CryptoParametersRecord {
+            lwe_dimension: Some(params.lwe_dimension),
+            glwe_dimension: Some(params.glwe_dimension),
+            polynomial_size: Some(params.polynomial_size),
+            lwe_modular_std_dev: Some(params.lwe_modular_std_dev),
+            glwe_modular_std_dev: Some(params.glwe_modular_std_dev),
+            pbs_base_log: Some(params.pbs_base_log),
+            pbs_level: Some(params.pbs_level),
+            ks_base_log: Some(params.ks_base_log),
+            ks_level: Some(params.ks_level),
+            pfks_level: Some(params.pfks_level),
+            pfks_base_log: Some(params.pfks_base_log),
+            pfks_modular_std_dev: Some(params.pfks_modular_std_dev),
+            cbs_level: Some(params.cbs_level),
+            cbs_base_log: Some(params.cbs_base_log),
+            message_modulus: Some(params.message_modulus.0),
+            carry_modulus: Some(params.carry_modulus.0),
+        }
+    }
+}
+
+#[derive(Serialize)]
+enum PolynomialMultiplication {
+    Fft,
+    // Ntt,
+}
+
+#[derive(Serialize)]
+enum IntegerRepresentation {
+    Radix,
+    // Crt,
+    // Hybrid,
+}
+
+#[derive(Serialize)]
+enum ExecutionType {
+    Sequential,
+    Parallel,
+}
+
+#[derive(Serialize)]
+enum KeySetType {
+    Single,
+    // Multi,
+}
+
+#[derive(Serialize)]
+enum OperandType {
+    CipherText,
+    PlainText,
+}
+
+#[derive(Clone, Serialize)]
+pub enum OperatorType {
+    Atomic,
+    // AtomicPattern,
+}
+
+#[derive(Serialize)]
+struct BenchmarkParametersRecord {
+    display_name: String,
+    crypto_parameters_alias: String,
+    crypto_parameters: CryptoParametersRecord,
+    message_modulus: Option<usize>,
+    carry_modulus: Option<usize>,
+    ciphertext_modulus: usize,
+    polynomial_multiplication: PolynomialMultiplication,
+    precision: u32,
+    error_probability: f64,
+    integer_representation: IntegerRepresentation,
+    decomposition_basis: u32,
+    pbs_algorithm: Option<String>,
+    execution_type: ExecutionType,
+    key_set_type: KeySetType,
+    operand_type: OperandType,
+    operator_type: OperatorType,
+}
+
+/// Writes benchmarks parameters to disk in JSON format.
+pub fn write_to_json<T: Into<CryptoParametersRecord>>(
+    bench_id: &str,
+    params: T,
+    params_alias: impl Into<String>,
+    display_name: impl Into<String>,
+    operator_type: &OperatorType,
+) {
+    let params = params.into();
+
+    let execution_type = match bench_id.contains("parallelized") {
+        true => ExecutionType::Parallel,
+        false => ExecutionType::Sequential,
+    };
+    let operand_type = match bench_id.contains("scalar") {
+        true => OperandType::PlainText,
+        false => OperandType::CipherText,
+    };
+
+    let record = BenchmarkParametersRecord {
+        display_name: display_name.into(),
+        crypto_parameters_alias: params_alias.into(),
+        crypto_parameters: params.to_owned(),
+        message_modulus: params.message_modulus,
+        carry_modulus: params.carry_modulus,
+        ciphertext_modulus: 64,
+        polynomial_multiplication: PolynomialMultiplication::Fft,
+        precision: (params.message_modulus.unwrap_or(2) as u32).ilog2(),
+        error_probability: 2f64.powf(-41.0),
+        integer_representation: IntegerRepresentation::Radix,
+        decomposition_basis: (params.message_modulus.unwrap_or(2) as u32).ilog2(),
+        pbs_algorithm: None, // To be added in future version
+        execution_type,
+        key_set_type: KeySetType::Single,
+        operand_type,
+        operator_type: operator_type.to_owned(),
+    };
+
+    let mut params_directory = ["benchmarks_parameters", bench_id]
+        .iter()
+        .collect::<PathBuf>();
+    fs::create_dir_all(&params_directory).unwrap();
+    params_directory.push("parameters.json");
+
+    fs::write(params_directory, serde_json::to_string(&record).unwrap()).unwrap();
+}
+
+// Empty main to please clippy.
+#[allow(dead_code)]
+pub fn main() {}

--- a/tfhe/examples/shortint_key_sizes.rs
+++ b/tfhe/examples/shortint_key_sizes.rs
@@ -1,3 +1,7 @@
+#[path = "../benches/utilities.rs"]
+mod utilities;
+use crate::utilities::{write_to_json, OperatorType};
+
 use std::fs::{File, OpenOptions};
 use std::io::Write;
 use std::path::Path;
@@ -26,13 +30,15 @@ fn client_server_key_sizes(results_file: &Path) {
         .open(results_file)
         .expect("cannot open results file");
 
+    let operator = OperatorType::Atomic;
+
     println!("Generating shortint (ClientKey, ServerKey)");
     for (i, params) in shortint_params_vec.iter().enumerate() {
         println!(
             "Generating [{} / {}] : {}",
             i + 1,
             shortint_params_vec.len(),
-            params.name()
+            params.name().to_lowercase()
         );
 
         let keys = KEY_CACHE.get_from_param(*params);
@@ -41,11 +47,11 @@ fn client_server_key_sizes(results_file: &Path) {
         // let cks = keys.client_key();
         let sks = keys.server_key();
         let ksk_size = sks.key_switching_key_size_bytes();
-        write_result(
-            &mut file,
-            &format!("shortint_{}_ksk", params.name().to_lowercase()),
-            ksk_size,
-        );
+        let test_name = format!("shortint_key_sizes_{}_ksk", params.name());
+
+        write_result(&mut file, &test_name, ksk_size);
+        write_to_json(&test_name, *params, params.name(), "KSK", &operator);
+
         println!(
             "Element in KSK: {}, size in bytes: {}",
             sks.key_switching_key_size_elements(),
@@ -53,11 +59,11 @@ fn client_server_key_sizes(results_file: &Path) {
         );
 
         let bsk_size = sks.bootstrapping_key_size_bytes();
-        write_result(
-            &mut file,
-            &format!("shortint_{}_bsk", params.name().to_lowercase()),
-            bsk_size,
-        );
+        let test_name = format!("shortint_key_sizes_{}_bsk", params.name());
+
+        write_result(&mut file, &test_name, bsk_size);
+        write_to_json(&test_name, *params, params.name(), "BSK", &operator);
+
         println!(
             "Element in BSK: {}, size in bytes: {}",
             sks.bootstrapping_key_size_elements(),


### PR DESCRIPTION
This is done to comply with the new Zama benchmark standard. Exhaustive parameters list is stored so once it's parsed and send to database, one can easily filter results on such parameters in visualization tool.