### PR TITLE
chore(core): reverse the order in which we encrypt KS levels

### DIFF
--- a/tfhe/src/core_crypto/algorithms/lwe_keyswitch.rs
+++ b/tfhe/src/core_crypto/algorithms/lwe_keyswitch.rs
@@ -127,9 +127,8 @@ pub fn keyswitch_lwe_ciphertext<Scalar, KSKCont, InputCont, OutputCont>(
         .zip(input_lwe_ciphertext.get_mask().as_ref())
     {
         let decomposition_iter = decomposer.decompose(input_mask_element);
-        // loop over the number of levels in reverse (from highest to lowest)
-        for (level_key_ciphertext, decomposed) in
-            keyswitch_key_block.iter().rev().zip(decomposition_iter)
+        // Loop over the levels
+        for (level_key_ciphertext, decomposed) in keyswitch_key_block.iter().zip(decomposition_iter)
         {
             slice_wrapping_sub_scalar_mul_assign(
                 output_lwe_ciphertext.as_mut(),

--- a/tfhe/src/core_crypto/algorithms/lwe_keyswitch_key_generation.rs
+++ b/tfhe/src/core_crypto/algorithms/lwe_keyswitch_key_generation.rs
@@ -103,6 +103,7 @@ pub fn generate_lwe_keyswitch_key<Scalar, InputKeyCont, OutputKeyCont, KSKeyCont
     {
         // We fill the buffer with the powers of the key elmements
         for (level, message) in (1..=decomp_level_count.0)
+            .rev()
             .map(DecompositionLevel)
             .zip(decomposition_plaintexts_buffer.iter_mut())
         {
@@ -260,6 +261,7 @@ pub fn generate_seeded_lwe_keyswitch_key<
     {
         // We fill the buffer with the powers of the key elmements
         for (level, message) in (1..=decomp_level_count.0)
+            .rev()
             .map(DecompositionLevel)
             .zip(decomposition_plaintexts_buffer.iter_mut())
         {


### PR DESCRIPTION
- allows to avoid reversing the iterator, potentially improving cache access during a keyswitch

BREAKING CHANGE: the keyswitch key level order has been reversed

TODO: fix the mismatch between DecompositionTerm and DecompositionIter for the meaning of a decomposition level see
https://github.com/zama-ai/tfhe-rs-internal/issues/72

The same could be done for the PBS but the change is not wopbs friendly (kind of expected) and is a much more impacting change than this one