### PR TITLE
chore(bench): use clean inputs for default ops bench

### DIFF
--- a/tfhe/benches/integer/bench.rs
+++ b/tfhe/benches/integer/bench.rs
@@ -53,8 +53,9 @@ impl Iterator for ParamsAndNumBlocksIter {
     }
 }
 
-/// Base function to bench a server key function that is a binary operation
-fn bench_server_key_binary_function<F>(
+/// Base function to bench a server key function that is a binary operation, input ciphertexts will
+/// contain non zero carries
+fn bench_server_key_binary_function_dirty_inputs<F>(
     c: &mut Criterion,
     bench_name: &str,
     display_name: &str,
@@ -124,8 +125,67 @@ fn bench_server_key_binary_function<F>(
     bench_group.finish()
 }
 
-/// Base function to bench a server key function that is a unary operation
-fn bench_server_key_unary_function<F>(
+/// Base function to bench a server key function that is a binary operation, input ciphertext will
+/// contain only zero carries
+fn bench_server_key_binary_function_clean_inputs<F>(
+    c: &mut Criterion,
+    bench_name: &str,
+    display_name: &str,
+    binary_op: F,
+) where
+    F: Fn(&ServerKey, &mut RadixCiphertextBig, &mut RadixCiphertextBig),
+{
+    let mut bench_group = c.benchmark_group(bench_name);
+    bench_group
+        .sample_size(15)
+        .measurement_time(std::time::Duration::from_secs(60));
+    let mut rng = rand::thread_rng();
+
+    for (param, num_block, bit_size) in ParamsAndNumBlocksIter::default() {
+        let param_name = param.name();
+
+        let bench_id = format!("{bench_name}::{param_name}::{bit_size}_bits");
+        bench_group.bench_function(&bench_id, |b| {
+            let (cks, sks) = KEY_CACHE.get_from_params(param);
+
+            let encrypt_two_values = || {
+                let clearlow = rng.gen::<u128>();
+                let clearhigh = rng.gen::<u128>();
+                let clear_0 = tfhe::integer::U256::from((clearlow, clearhigh));
+                let ct_0 = cks.encrypt_radix(clear_0, num_block);
+
+                let clearlow = rng.gen::<u128>();
+                let clearhigh = rng.gen::<u128>();
+                let clear_1 = tfhe::integer::U256::from((clearlow, clearhigh));
+                let ct_1 = cks.encrypt_radix(clear_1, num_block);
+
+                (ct_0, ct_1)
+            };
+
+            b.iter_batched(
+                encrypt_two_values,
+                |(mut ct_0, mut ct_1)| {
+                    binary_op(&sks, &mut ct_0, &mut ct_1);
+                },
+                criterion::BatchSize::SmallInput,
+            )
+        });
+
+        write_to_json(
+            &bench_id,
+            param,
+            param.name(),
+            display_name,
+            &OperatorType::Atomic,
+        );
+    }
+
+    bench_group.finish()
+}
+
+/// Base function to bench a server key function that is a unary operation, input ciphertexts will
+/// contain non zero carries
+fn bench_server_key_unary_function_dirty_inputs<F>(
     c: &mut Criterion,
     bench_name: &str,
     display_name: &str,
@@ -189,7 +249,122 @@ fn bench_server_key_unary_function<F>(
     bench_group.finish()
 }
 
-fn bench_server_key_binary_scalar_function<F>(
+/// Base function to bench a server key function that is a unary operation, input ciphertext will
+/// contain only zero carries
+fn bench_server_key_unary_function_clean_inputs<F>(
+    c: &mut Criterion,
+    bench_name: &str,
+    display_name: &str,
+    unary_fn: F,
+) where
+    F: Fn(&ServerKey, &mut RadixCiphertextBig),
+{
+    let mut bench_group = c.benchmark_group(bench_name);
+
+    let mut rng = rand::thread_rng();
+
+    for (param, num_block, bit_size) in ParamsAndNumBlocksIter::default() {
+        let param_name = param.name();
+
+        let bench_id = format!("{bench_name}::{param_name}::{bit_size}_bits");
+        bench_group.bench_function(&bench_id, |b| {
+            let (cks, sks) = KEY_CACHE.get_from_params(param);
+
+            let encrypt_one_value = || {
+                let clearlow = rng.gen::<u128>();
+                let clearhigh = rng.gen::<u128>();
+
+                let clear_0 = tfhe::integer::U256::from((clearlow, clearhigh));
+
+                cks.encrypt_radix(clear_0, num_block)
+            };
+
+            b.iter_batched(
+                encrypt_one_value,
+                |mut ct_0| {
+                    unary_fn(&sks, &mut ct_0);
+                },
+                criterion::BatchSize::SmallInput,
+            )
+        });
+
+        write_to_json(
+            &bench_id,
+            param,
+            param.name(),
+            display_name,
+            &OperatorType::Atomic,
+        );
+    }
+
+    bench_group.finish()
+}
+
+fn bench_server_key_binary_scalar_function_dirty_inputs<F>(
+    c: &mut Criterion,
+    bench_name: &str,
+    display_name: &str,
+    binary_op: F,
+) where
+    F: Fn(&ServerKey, &mut RadixCiphertextBig, u64),
+{
+    let mut bench_group = c.benchmark_group(bench_name);
+    let mut rng = rand::thread_rng();
+
+    for (param, num_block, bit_size) in ParamsAndNumBlocksIter::default() {
+        let param_name = param.name();
+
+        let bench_id = format!("{bench_name}::{param_name}::{bit_size}_bits");
+        bench_group.bench_function(&bench_id, |b| {
+            let (cks, sks) = KEY_CACHE.get_from_params(param);
+
+            let encrypt_one_value = || {
+                let clearlow = rng.gen::<u128>();
+                let clearhigh = rng.gen::<u128>();
+
+                let clear_0 = tfhe::integer::U256::from((clearlow, clearhigh));
+                let mut ct_0 = cks.encrypt_radix(clear_0, num_block);
+
+                // Raise the degree, so as to ensure worst case path in operations
+                let mut carry_mod = param.carry_modulus.0;
+                while carry_mod > 0 {
+                    // Raise the degree, so as to ensure worst case path in operations
+                    let clearlow = rng.gen::<u128>();
+                    let clearhigh = rng.gen::<u128>();
+                    let clear_2 = tfhe::integer::U256::from((clearlow, clearhigh));
+                    let ct_2 = cks.encrypt_radix(clear_2, num_block);
+                    sks.unchecked_add_assign(&mut ct_0, &ct_2);
+
+                    carry_mod -= 1;
+                }
+
+                let clear_1 = rng.gen::<u64>();
+
+                (ct_0, clear_1)
+            };
+
+            b.iter_batched(
+                encrypt_one_value,
+                |(mut ct_0, clear_1)| {
+                    binary_op(&sks, &mut ct_0, clear_1);
+                },
+                criterion::BatchSize::SmallInput,
+            )
+        });
+
+        write_to_json(
+            &bench_id,
+            param,
+            param.name(),
+            display_name,
+            &OperatorType::Atomic,
+        );
+    }
+
+    bench_group.finish()
+}
+
+fn bench_server_key_binary_scalar_function_clean_inputs<F>(
     c: &mut Criterion,
     bench_name: &str,
     display_name: &str,
@@ -243,7 +418,7 @@ fn bench_server_key_binary_scalar_function<F>(
 macro_rules! define_server_key_bench_unary_fn (
     (method_name: $server_key_method:ident, display_name:$name:ident) => {
         fn $server_key_method(c: &mut Criterion) {
-            bench_server_key_unary_function(
+            bench_server_key_unary_function_dirty_inputs(
                 c,
                 concat!("ServerKey::", stringify!($server_key_method)),
                 stringify!($name),
@@ -252,12 +427,26 @@ macro_rules! define_server_key_bench_unary_fn (
             })
         }
     }
-  );
+);
+
+macro_rules! define_server_key_bench_unary_default_fn (
+    (method_name: $server_key_method:ident, display_name:$name:ident) => {
+        fn $server_key_method(c: &mut Criterion) {
+            bench_server_key_unary_function_clean_inputs(
+                c,
+                concat!("ServerKey::", stringify!($server_key_method)),
+                stringify!($name),
+                |server_key, lhs| {
+                  server_key.$server_key_method(lhs);
+            })
+        }
+    }
+);
 
 macro_rules! define_server_key_bench_fn (
   (method_name: $server_key_method:ident, display_name:$name:ident) => {
       fn $server_key_method(c: &mut Criterion) {
-          bench_server_key_binary_function(
+        bench_server_key_binary_function_dirty_inputs(
               c,
               concat!("ServerKey::", stringify!($server_key_method)),
               stringify!($name),
@@ -268,10 +457,24 @@ macro_rules! define_server_key_bench_fn (
   }
 );
 
+macro_rules! define_server_key_bench_default_fn (
+    (method_name: $server_key_method:ident, display_name:$name:ident) => {
+        fn $server_key_method(c: &mut Criterion) {
+          bench_server_key_binary_function_clean_inputs(
+                c,
+                concat!("ServerKey::", stringify!($server_key_method)),
+                stringify!($name),
+                |server_key, lhs, rhs| {
+                  server_key.$server_key_method(lhs, rhs);
+            })
+        }
+    }
+  );
+
 macro_rules! define_server_key_bench_scalar_fn (
   (method_name: $server_key_method:ident, display_name:$name:ident) => {
       fn $server_key_method(c: &mut Criterion) {
-          bench_server_key_binary_scalar_function(
+          bench_server_key_binary_scalar_function_dirty_inputs(
               c,
               concat!("ServerKey::", stringify!($server_key_method)),
               stringify!($name),
@@ -281,6 +484,20 @@ macro_rules! define_server_key_bench_scalar_fn (
       }
   }
 );
+
+macro_rules! define_server_key_bench_scalar_default_fn (
+    (method_name: $server_key_method:ident, display_name:$name:ident) => {
+        fn $server_key_method(c: &mut Criterion) {
+            bench_server_key_binary_scalar_function_clean_inputs(
+                c,
+                concat!("ServerKey::", stringify!($server_key_method)),
+                stringify!($name),
+                |server_key, lhs, rhs| {
+                  server_key.$server_key_method(lhs, rhs);
+            })
+        }
+    }
+  );
 
 define_server_key_bench_fn!(method_name: smart_add, display_name: add);
 define_server_key_bench_fn!(method_name: smart_sub, display_name: sub);
@@ -296,12 +513,12 @@ define_server_key_bench_fn!(method_name: smart_bitand_parallelized, display_name
 define_server_key_bench_fn!(method_name: smart_bitxor_parallelized, display_name: bitxor);
 define_server_key_bench_fn!(method_name: smart_bitor_parallelized, display_name: bitor);
 
-define_server_key_bench_fn!(method_name: add_parallelized, display_name: add);
-define_server_key_bench_fn!(method_name: sub_parallelized, display_name: sub);
-define_server_key_bench_fn!(method_name: mul_parallelized, display_name: mul);
-define_server_key_bench_fn!(method_name: bitand_parallelized, display_name: bitand);
-define_server_key_bench_fn!(method_name: bitxor_parallelized, display_name: bitxor);
-define_server_key_bench_fn!(method_name: bitor_parallelized, display_name: bitor);
+define_server_key_bench_default_fn!(method_name: add_parallelized, display_name: add);
+define_server_key_bench_default_fn!(method_name: sub_parallelized, display_name: sub);
+define_server_key_bench_default_fn!(method_name: mul_parallelized, display_name: mul);
+define_server_key_bench_default_fn!(method_name: bitand_parallelized, display_name: bitand);
+define_server_key_bench_default_fn!(method_name: bitxor_parallelized, display_name: bitxor);
+define_server_key_bench_default_fn!(method_name: bitor_parallelized, display_name: bitor);
 
 define_server_key_bench_fn!(method_name: unchecked_add, display_name: add);
 define_server_key_bench_fn!(method_name: unchecked_sub, display_name: sub);
@@ -341,9 +558,9 @@ define_server_key_bench_scalar_fn!(
     display_name: mul
 );
 
-define_server_key_bench_scalar_fn!(method_name: scalar_add_parallelized, display_name: add);
-define_server_key_bench_scalar_fn!(method_name: scalar_sub_parallelized, display_name: sub);
-define_server_key_bench_scalar_fn!(method_name: scalar_mul_parallelized, display_name: mul);
+define_server_key_bench_scalar_default_fn!(method_name: scalar_add_parallelized, display_name: add);
+define_server_key_bench_scalar_default_fn!(method_name: scalar_sub_parallelized, display_name: sub);
+define_server_key_bench_scalar_default_fn!(method_name: scalar_mul_parallelized, display_name: mul);
 
 define_server_key_bench_scalar_fn!(method_name: unchecked_scalar_add, display_name: add);
 define_server_key_bench_scalar_fn!(method_name: unchecked_scalar_sub, display_name: sub);
@@ -351,7 +568,7 @@ define_server_key_bench_scalar_fn!(method_name: unchecked_small_scalar_mul, disp
 
 define_server_key_bench_unary_fn!(method_name: smart_neg, display_name: negation);
 define_server_key_bench_unary_fn!(method_name: smart_neg_parallelized, display_name: negation);
-define_server_key_bench_unary_fn!(method_name: neg_parallelized, display_name: negation);
+define_server_key_bench_unary_default_fn!(method_name: neg_parallelized, display_name: negation);
 
 define_server_key_bench_unary_fn!(method_name: full_propagate, display_name: carry_propagation);
 define_server_key_bench_unary_fn!(
@@ -412,13 +629,13 @@ define_server_key_bench_fn!(
     display_name: greater_or_equal
 );
 
-define_server_key_bench_fn!(method_name: max_parallelized, display_name: max);
-define_server_key_bench_fn!(method_name: min_parallelized, display_name: min);
-define_server_key_bench_fn!(method_name: eq_parallelized, display_name: equal);
-define_server_key_bench_fn!(method_name: lt_parallelized, display_name: less_than);
-define_server_key_bench_fn!(method_name: le_parallelized, display_name: less_or_equal);
-define_server_key_bench_fn!(method_name: gt_parallelized, display_name: greater_than);
-define_server_key_bench_fn!(method_name: ge_parallelized, display_name: greater_or_equal);
+define_server_key_bench_default_fn!(method_name: max_parallelized, display_name: max);
+define_server_key_bench_default_fn!(method_name: min_parallelized, display_name: min);
+define_server_key_bench_default_fn!(method_name: eq_parallelized, display_name: equal);
+define_server_key_bench_default_fn!(method_name: lt_parallelized, display_name: less_than);
+define_server_key_bench_default_fn!(method_name: le_parallelized, display_name: less_or_equal);
+define_server_key_bench_default_fn!(method_name: gt_parallelized, display_name: greater_than);
+define_server_key_bench_default_fn!(method_name: ge_parallelized, display_name: greater_or_equal);
 
 criterion_group!(
     smart_arithmetic_operation,
@@ -546,6 +763,9 @@ criterion_group!(
     le_parallelized,
     gt_parallelized,
     ge_parallelized,
+    scalar_add_parallelized,
+    scalar_sub_parallelized,
+    scalar_mul_parallelized,
 );
 
 criterion_main!(


### PR DESCRIPTION
- by design default ops are made to work best on clean CTs