### PR TITLE
fix(integer): fix scalar mul bug when representing integers > 64 bits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ target/
 
 **/Cargo.lock
 **/*.bin
+
+# Some of our bench outputs
+/tfhe/benchmarks_parameters

--- a/tfhe/benches/integer/bench.rs
+++ b/tfhe/benches/integer/bench.rs
@@ -194,6 +194,9 @@ fn bench_server_key_unary_function_dirty_inputs<F>(
     F: Fn(&ServerKey, &mut RadixCiphertextBig),
 {
     let mut bench_group = c.benchmark_group(bench_name);
+    bench_group
+        .sample_size(15)
+        .measurement_time(std::time::Duration::from_secs(60));
 
     let mut rng = rand::thread_rng();
 
@@ -260,6 +263,9 @@ fn bench_server_key_unary_function_clean_inputs<F>(
     F: Fn(&ServerKey, &mut RadixCiphertextBig),
 {
     let mut bench_group = c.benchmark_group(bench_name);
+    bench_group
+        .sample_size(15)
+        .measurement_time(std::time::Duration::from_secs(60));
 
     let mut rng = rand::thread_rng();
 
@@ -309,6 +315,9 @@ fn bench_server_key_binary_scalar_function_dirty_inputs<F>(
     F: Fn(&ServerKey, &mut RadixCiphertextBig, u64),
 {
     let mut bench_group = c.benchmark_group(bench_name);
+    bench_group
+        .sample_size(15)
+        .measurement_time(std::time::Duration::from_secs(60));
     let mut rng = rand::thread_rng();
 
     for (param, num_block, bit_size) in ParamsAndNumBlocksIter::default() {
@@ -373,6 +382,9 @@ fn bench_server_key_binary_scalar_function_clean_inputs<F>(
     F: Fn(&ServerKey, &mut RadixCiphertextBig, u64),
 {
     let mut bench_group = c.benchmark_group(bench_name);
+    bench_group
+        .sample_size(15)
+        .measurement_time(std::time::Duration::from_secs(60));
     let mut rng = rand::thread_rng();
 
     for (param, num_block, bit_size) in ParamsAndNumBlocksIter::default() {

--- a/tfhe/src/integer/server_key/radix_parallel/scalar_mul.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/scalar_mul.rs
@@ -374,11 +374,15 @@ impl ServerKey {
         // value is the vector of blockshifts
         let mut task_map = HashMap::<u64, Vec<usize>>::new();
 
-        let mut b_i = 1_u64;
+        // Divide scalar progressively towards zero
+        let mut scalar_i = scalar;
         for i in 0..n {
-            let u_i = (scalar / b_i) % b;
+            let u_i = scalar_i % b;
             task_map.entry(u_i).or_insert_with(Vec::new).push(i);
-            b_i *= b;
+            scalar_i /= b;
+            if scalar_i == 0 {
+                break;
+            }
         }
 
         let terms = Mutex::new(Vec::<RadixCiphertext<PBSOrder>>::new());
@@ -481,11 +485,14 @@ impl ServerKey {
         // value is the vector of blockshifts
         let mut task_map = HashMap::<u64, Vec<usize>>::new();
 
-        let mut b_i = 1_u64;
+        let mut scalar_i = scalar;
         for i in 0..n {
-            let u_i = (scalar / b_i) % b;
+            let u_i = scalar_i % b;
             task_map.entry(u_i).or_insert_with(Vec::new).push(i);
-            b_i *= b;
+            scalar_i /= b;
+            if scalar_i == 0 {
+                break;
+            }
         }
 
         let terms = Mutex::new(Vec::<RadixCiphertext<PBSOrder>>::new());


### PR DESCRIPTION
- a product was overflowing, we now compute a progressive division with the same effect and stop once we reach zero to limit the number of generated tasks