### PR TITLE
chore(ci): fix decomposition basis and add bit size to params

### DIFF
--- a/tfhe/benches/boolean/bench.rs
+++ b/tfhe/benches/boolean/bench.rs
@@ -1,6 +1,6 @@
 #[path = "../utilities.rs"]
 mod utilities;
-use crate::utilities::{write_to_json, OperatorType};
+use crate::utilities::{write_to_json, CryptoParametersRecord, OperatorType};
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use tfhe::boolean::client_key::ClientKey;
@@ -16,6 +16,24 @@ criterion_group!(
 
 criterion_main!(gates_benches);
 
+/// Helper function to write boolean benchmarks parameters to disk in JSON format.
+pub fn write_to_json_boolean<T: Into<CryptoParametersRecord>>(
+    bench_id: &str,
+    params: T,
+    params_alias: impl Into<String>,
+    display_name: impl Into<String>,
+) {
+    write_to_json(
+        bench_id,
+        params,
+        params_alias,
+        display_name,
+        &OperatorType::Atomic,
+        1,
+        vec![1],
+    );
+}
+
 // Put all `bench_function` in one place
 // so the keygen is only run once per parameters saving time.
 fn benchs(c: &mut Criterion, params: BooleanParameters, parameter_name: &str) {
@@ -28,35 +46,33 @@ fn benchs(c: &mut Criterion, params: BooleanParameters, parameter_name: &str) {
     let ct2 = cks.encrypt(false);
     let ct3 = cks.encrypt(true);
 
-    let operator = OperatorType::Atomic;
-
     let id = format!("AND::{parameter_name}");
     bench_group.bench_function(&id, |b| b.iter(|| black_box(sks.and(&ct1, &ct2))));
-    write_to_json(&id, params, parameter_name, "and", &operator);
+    write_to_json_boolean(&id, params, parameter_name, "and");
 
     let id = format!("NAND::{parameter_name}");
     bench_group.bench_function(&id, |b| b.iter(|| black_box(sks.nand(&ct1, &ct2))));
-    write_to_json(&id, params, parameter_name, "nand", &operator);
+    write_to_json_boolean(&id, params, parameter_name, "nand");
 
     let id = format!("OR::{parameter_name}");
     bench_group.bench_function(&id, |b| b.iter(|| black_box(sks.or(&ct1, &ct2))));
-    write_to_json(&id, params, parameter_name, "or", &operator);
+    write_to_json_boolean(&id, params, parameter_name, "or");
 
     let id = format!("XOR::{parameter_name}");
     bench_group.bench_function(&id, |b| b.iter(|| black_box(sks.xor(&ct1, &ct2))));
-    write_to_json(&id, params, parameter_name, "xor", &operator);
+    write_to_json_boolean(&id, params, parameter_name, "xor");
 
     let id = format!("XNOR::{parameter_name}");
     bench_group.bench_function(&id, |b| b.iter(|| black_box(sks.xnor(&ct1, &ct2))));
-    write_to_json(&id, params, parameter_name, "xnor", &operator);
+    write_to_json_boolean(&id, params, parameter_name, "xnor");
 
     let id = format!("NOT::{parameter_name}");
     bench_group.bench_function(&id, |b| b.iter(|| black_box(sks.not(&ct1))));
-    write_to_json(&id, params, parameter_name, "not", &operator);
+    write_to_json_boolean(&id, params, parameter_name, "not");
 
     let id = format!("MUX::{parameter_name}");
     bench_group.bench_function(&id, |b| b.iter(|| black_box(sks.mux(&ct1, &ct2, &ct3))));
-    write_to_json(&id, params, parameter_name, "mux", &operator);
+    write_to_json_boolean(&id, params, parameter_name, "mux");
 }
 
 fn bench_default_parameters(c: &mut Criterion) {

--- a/tfhe/benches/core_crypto/pbs_bench.rs
+++ b/tfhe/benches/core_crypto/pbs_bench.rs
@@ -315,7 +315,16 @@ fn mem_optimized_pbs<Scalar: UnsignedTorus + CastInto<usize>>(c: &mut Criterion)
             });
         }
 
-        write_to_json(&id, *params, name, "pbs", &OperatorType::Atomic);
+        let bit_size = (params.message_modulus.unwrap_or(2) as u32).ilog2();
+        write_to_json(
+            &id,
+            *params,
+            name,
+            "pbs",
+            &OperatorType::Atomic,
+            bit_size,
+            vec![bit_size],
+        );
     }
 }
 
@@ -397,6 +406,15 @@ fn multi_bit_pbs<Scalar: UnsignedTorus + CastInto<usize> + CastFrom<usize> + Syn
             })
         });
 
-        write_to_json(&id, *params, name, "pbs", &OperatorType::Atomic);
+        let bit_size = params.message_modulus.unwrap().ilog2();
+        write_to_json(
+            &id,
+            *params,
+            name,
+            "pbs",
+            &OperatorType::Atomic,
+            bit_size,
+            vec![bit_size],
+        );
     }
 }

--- a/tfhe/benches/integer/bench.rs
+++ b/tfhe/benches/integer/bench.rs
@@ -119,6 +119,8 @@ fn bench_server_key_binary_function_dirty_inputs<F>(
             param.name(),
             display_name,
             &OperatorType::Atomic,
+            bit_size as u32,
+            vec![param.message_modulus.0.ilog2(); num_block],
         );
     }
 
@@ -177,6 +179,8 @@ fn bench_server_key_binary_function_clean_inputs<F>(
             param.name(),
             display_name,
             &OperatorType::Atomic,
+            bit_size as u32,
+            vec![param.message_modulus.0.ilog2(); num_block],
         );
     }
 
@@ -246,6 +250,8 @@ fn bench_server_key_unary_function_dirty_inputs<F>(
             param.name(),
             display_name,
             &OperatorType::Atomic,
+            bit_size as u32,
+            vec![param.message_modulus.0.ilog2(); num_block],
         );
     }
 
@@ -300,6 +306,8 @@ fn bench_server_key_unary_function_clean_inputs<F>(
             param.name(),
             display_name,
             &OperatorType::Atomic,
+            bit_size as u32,
+            vec![param.message_modulus.0.ilog2(); num_block],
         );
     }
 
@@ -367,6 +375,8 @@ fn bench_server_key_binary_scalar_function_dirty_inputs<F>(
             param.name(),
             display_name,
             &OperatorType::Atomic,
+            bit_size as u32,
+            vec![param.message_modulus.0.ilog2(); num_block],
         );
     }
 
@@ -421,6 +431,8 @@ fn bench_server_key_binary_scalar_function_clean_inputs<F>(
             param.name(),
             display_name,
             &OperatorType::Atomic,
+            bit_size as u32,
+            vec![param.message_modulus.0.ilog2(); num_block],
         );
     }
 

--- a/tfhe/benches/shortint/bench.rs
+++ b/tfhe/benches/shortint/bench.rs
@@ -74,6 +74,8 @@ fn bench_server_key_unary_function<F>(
             param.name(),
             display_name,
             &OperatorType::Atomic,
+            param.message_modulus.0.ilog2(),
+            vec![param.message_modulus.0.ilog2()],
         );
     }
 
@@ -118,6 +120,8 @@ fn bench_server_key_binary_function<F>(
             param.name(),
             display_name,
             &OperatorType::Atomic,
+            param.message_modulus.0.ilog2(),
+            vec![param.message_modulus.0.ilog2()],
         );
     }
 
@@ -161,6 +165,8 @@ fn bench_server_key_binary_scalar_function<F>(
             param.name(),
             display_name,
             &OperatorType::Atomic,
+            param.message_modulus.0.ilog2(),
+            vec![param.message_modulus.0.ilog2()],
         );
     }
 
@@ -208,6 +214,8 @@ fn bench_server_key_binary_scalar_division_function<F>(
             param.name(),
             display_name,
             &OperatorType::Atomic,
+            param.message_modulus.0.ilog2(),
+            vec![param.message_modulus.0.ilog2()],
         );
     }
 
@@ -242,6 +250,8 @@ fn carry_extract(c: &mut Criterion) {
             param.name(),
             "carry_extract",
             &OperatorType::Atomic,
+            param.message_modulus.0.ilog2(),
+            vec![param.message_modulus.0.ilog2()],
         );
     }
 
@@ -273,7 +283,15 @@ fn programmable_bootstrapping(c: &mut Criterion) {
             })
         });
 
-        write_to_json(&bench_id, param, param.name(), "pbs", &OperatorType::Atomic);
+        write_to_json(
+            &bench_id,
+            param,
+            param.name(),
+            "pbs",
+            &OperatorType::Atomic,
+            param.message_modulus.0.ilog2(),
+            vec![param.message_modulus.0.ilog2()],
+        );
     }
 
     bench_group.finish();

--- a/tfhe/benches/utilities.rs
+++ b/tfhe/benches/utilities.rs
@@ -120,11 +120,12 @@ struct BenchmarkParametersRecord {
     message_modulus: Option<usize>,
     carry_modulus: Option<usize>,
     ciphertext_modulus: usize,
+    bit_size: u32,
     polynomial_multiplication: PolynomialMultiplication,
     precision: u32,
     error_probability: f64,
     integer_representation: IntegerRepresentation,
-    decomposition_basis: u32,
+    decomposition_basis: Vec<u32>,
     pbs_algorithm: Option<String>,
     execution_type: ExecutionType,
     key_set_type: KeySetType,
@@ -139,6 +140,8 @@ pub fn write_to_json<T: Into<CryptoParametersRecord>>(
     params_alias: impl Into<String>,
     display_name: impl Into<String>,
     operator_type: &OperatorType,
+    bit_size: u32,
+    decomposition_basis: Vec<u32>,
 ) {
     let params = params.into();
 
@@ -158,11 +161,12 @@ pub fn write_to_json<T: Into<CryptoParametersRecord>>(
         message_modulus: params.message_modulus,
         carry_modulus: params.carry_modulus,
         ciphertext_modulus: 64,
+        bit_size,
         polynomial_multiplication: PolynomialMultiplication::Fft,
         precision: (params.message_modulus.unwrap_or(2) as u32).ilog2(),
         error_probability: 2f64.powf(-41.0),
         integer_representation: IntegerRepresentation::Radix,
-        decomposition_basis: (params.message_modulus.unwrap_or(2) as u32).ilog2(),
+        decomposition_basis,
         pbs_algorithm: None, // To be added in future version
         execution_type,
         key_set_type: KeySetType::Single,

--- a/tfhe/examples/boolean_key_sizes.rs
+++ b/tfhe/examples/boolean_key_sizes.rs
@@ -42,7 +42,15 @@ fn client_server_key_sizes(results_file: &Path) {
         let test_name = format!("boolean_key_sizes_{params_name}_ksk");
 
         write_result(&mut file, &test_name, ksk_size);
-        write_to_json(&test_name, *params, *params_name, "KSK", &operator);
+        write_to_json(
+            &test_name,
+            *params,
+            *params_name,
+            "KSK",
+            &operator,
+            0,
+            vec![],
+        );
 
         println!(
             "Element in KSK: {}, size in bytes: {}",
@@ -54,7 +62,15 @@ fn client_server_key_sizes(results_file: &Path) {
         let test_name = format!("boolean_key_sizes_{params_name}_bsk");
 
         write_result(&mut file, &test_name, bsk_size);
-        write_to_json(&test_name, *params, *params_name, "BSK", &operator);
+        write_to_json(
+            &test_name,
+            *params,
+            *params_name,
+            "BSK",
+            &operator,
+            0,
+            vec![],
+        );
 
         println!(
             "Element in BSK: {}, size in bytes: {}",

--- a/tfhe/examples/shortint_key_sizes.rs
+++ b/tfhe/examples/shortint_key_sizes.rs
@@ -50,7 +50,15 @@ fn client_server_key_sizes(results_file: &Path) {
         let test_name = format!("shortint_key_sizes_{}_ksk", params.name());
 
         write_result(&mut file, &test_name, ksk_size);
-        write_to_json(&test_name, *params, params.name(), "KSK", &operator);
+        write_to_json(
+            &test_name,
+            *params,
+            params.name(),
+            "KSK",
+            &operator,
+            0,
+            vec![],
+        );
 
         println!(
             "Element in KSK: {}, size in bytes: {}",
@@ -62,7 +70,15 @@ fn client_server_key_sizes(results_file: &Path) {
         let test_name = format!("shortint_key_sizes_{}_bsk", params.name());
 
         write_result(&mut file, &test_name, bsk_size);
-        write_to_json(&test_name, *params, params.name(), "BSK", &operator);
+        write_to_json(
+            &test_name,
+            *params,
+            params.name(),
+            "BSK",
+            &operator,
+            0,
+            vec![],
+        );
 
         println!(
             "Element in BSK: {}, size in bytes: {}",


### PR DESCRIPTION
Decomposition basis wasn't correctly set to handle CRT. Now it uses a Vec that would be displayed as a string in the database. In addition the bit size has been added to ease comparison between various of them in Grafana.