### PR TITLE
chore(ci): create release with semantic-release

### DIFF
--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -1,18 +1,52 @@
-# Create and publish new release of tfhe-rs using semantic-release.
-name: Make release
+# Publish new release of tfhe-rs on various platform.
+name: Publish release
 
 on:
   workflow_dispatch:
-
-permissions:
-  contents: write
+    inputs:
+      dry_run:
+        description: "Dry-run"
+        type: boolean
+        default: true
 
 jobs:
-  release:
-    name: Release
+  publish_release:
+    name: Publish Release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
           fetch-depth: 0
+
+      - name: Publish crate.io package
+        env:
+          CRATES_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          DRY_RUN: ${{ inputs.dry_run && '--dry-run' || '' }}
+        run: |
+          cargo publish -p tfhe --token ${{ env.CRATES_TOKEN }} ${{ env.DRY_RUN }}
+
+      - name: Build web package
+        run: |
+          make build_web_js_api
+
+      - name: Publish web package
+        uses: JS-DevTools/npm-publish@0f451a94170d1699fd50710966d48fb26194d939
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+          package: tfhe/pkg/package.json
+          dry-run: ${{ inputs.dry_run }}
+
+      - name: Build Node package
+        run: |
+          rm -rf tfhe/pkg
+
+          make build_node_js_api
+          sed -i 's/"tfhe"/"node-tfhe"/g' tfhe/pkg/package.json
+
+      - name: Publish Node package
+        uses: JS-DevTools/npm-publish@0f451a94170d1699fd50710966d48fb26194d939
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+          package: tfhe/pkg/package.json
+          dry-run: ${{ inputs.dry_run }}

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,12 @@ install_cargo_nextest: install_rs_build_toolchain
 	cargo $(CARGO_RS_BUILD_TOOLCHAIN) install cargo-nextest --locked || \
 	( echo "Unable to install cargo nextest, unknown error." && exit 1 )
 
+.PHONY: install_wasm_pack # Install wasm-pack to build JS packages
+install_wasm_pack: install_rs_build_toolchain
+	@wasm-pack --version > /dev/null 2>&1 || \
+	cargo $(CARGO_RS_BUILD_TOOLCHAIN) install wasm-pack || \
+	( echo "Unable to install cargo wasm-pack, unknown error." && exit 1 )
+
 .PHONY: fmt # Format rust code
 fmt: install_rs_check_toolchain
 	cargo "$(CARGO_RS_CHECK_TOOLCHAIN)" fmt
@@ -174,14 +180,14 @@ build_c_api: install_rs_check_toolchain
 		-p tfhe
 
 .PHONY: build_web_js_api # Build the js API targeting the web browser
-build_web_js_api: install_rs_build_toolchain
+build_web_js_api: install_rs_build_toolchain install_wasm_pack
 	cd tfhe && \
 	RUSTFLAGS="$(WASM_RUSTFLAGS)" rustup run "$(RS_BUILD_TOOLCHAIN)" \
 		wasm-pack build --release --target=web \
 		-- --features=boolean-client-js-wasm-api,shortint-client-js-wasm-api
 
 .PHONY: build_node_js_api # Build the js API targeting nodejs
-build_node_js_api: install_rs_build_toolchain
+build_node_js_api: install_rs_build_toolchain install_wasm_pack
 	cd tfhe && \
 	RUSTFLAGS="$(WASM_RUSTFLAGS)" rustup run "$(RS_BUILD_TOOLCHAIN)" \
 		wasm-pack build --release --target=nodejs \


### PR DESCRIPTION
This will perform automatic release on GitHub. It will append a CHANGELOG file that will be versioned. It will create a new version tag and create a release entry on GitHub along with all the changes in the same format as CHANGELOG.