### PR TITLE
chore(ci): create dummy release workflow

### DIFF
--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -1,0 +1,18 @@
+# Create and publish new release of tfhe-rs using semantic-release.
+name: Make release
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+        with:
+          fetch-depth: 0


### PR DESCRIPTION
This is done to be able to test the effective worklfow implementation in a development branch.