### PR TITLE
refactor(integer): remove usage of Mutex for determinism

### DIFF
--- a/tfhe/src/integer/ciphertext/mod.rs
+++ b/tfhe/src/integer/ciphertext/mod.rs
@@ -7,7 +7,7 @@ use crate::shortint::{
 use serde::{Deserialize, Serialize};
 
 /// Structure containing a ciphertext in radix decomposition.
-#[derive(Serialize, Clone, Deserialize)]
+#[derive(Serialize, Clone, Deserialize, PartialEq, Eq, Debug)]
 pub struct BaseRadixCiphertext<Block> {
     /// The blocks are stored from LSB to MSB
     pub(crate) blocks: Vec<Block>,

--- a/tfhe/src/integer/server_key/radix_parallel/scalar_mul.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/scalar_mul.rs
@@ -4,8 +4,6 @@ use crate::integer::server_key::CheckError::CarryFull;
 use crate::integer::ServerKey;
 use crate::shortint::PBSOrderMarker;
 use rayon::prelude::*;
-use std::collections::HashMap;
-use std::sync::Mutex;
 
 impl ServerKey {
     /// Computes homomorphically a multiplication between a scalar and a ciphertext.
@@ -363,53 +361,68 @@ impl ServerKey {
             return zero;
         }
 
+        let num_tasks = self.key.message_modulus.0;
         let b = self.key.message_modulus.0 as u64;
-        let n = ct.blocks.len();
+        let num_blocks = ct.blocks.len();
 
         //Propagate the carries before doing the multiplications
         self.full_propagate_parallelized(ct);
         let ct = &*ct;
 
-        // key is the small scalar we multiply by
-        // value is the vector of blockshifts
-        let mut task_map = HashMap::<u64, Vec<usize>>::new();
+        // index is the small scalar we multiply by, value is the vector of blockshifts
+        let mut task_vec: Vec<Vec<usize>> =
+            vec![Vec::with_capacity((u64::BITS / b.ilog2()) as usize); num_tasks];
 
         // Divide scalar progressively towards zero
         let mut scalar_i = scalar;
-        for i in 0..n {
+        for i in 0..num_blocks {
             let u_i = scalar_i % b;
-            task_map.entry(u_i).or_insert_with(Vec::new).push(i);
+            task_vec[u_i as usize].push(i);
             scalar_i /= b;
             if scalar_i == 0 {
                 break;
             }
         }
 
-        let terms = Mutex::new(Vec::<RadixCiphertext<PBSOrder>>::new());
-        task_map.par_iter().for_each(|(&u_i, blockshifts)| {
-            if u_i == 0 {
-                return;
-            }
+        let task_vec: Vec<_> = task_vec
+            .into_iter()
+            .enumerate()
+            .skip(1) // skip u_i == 0, multiplying by 0 yielding 0
+            .filter(|(u_i, blockshifts)| !blockshifts.is_empty())
+            .collect();
 
-            let blockshifts = &**blockshifts;
-            let min_blockshift = *blockshifts.iter().min().unwrap();
+        let mut terms: Vec<_> = task_vec
+            .iter()
+            .map(|(_, blockshifts)| {
+                vec![self.create_trivial_zero_radix(num_blocks); blockshifts.len()]
+            })
+            .collect();
+        terms
+            .par_iter_mut()
+            .zip(task_vec.par_iter())
+            .for_each(|(term_vec, (u_i, blockshifts))| {
+                let min_blockshift = blockshifts.iter().min().unwrap();
 
-            let mut tmp = ct.clone();
-            if u_i != 1 {
-                tmp.blocks[0..n - min_blockshift]
+                let u_i = *u_i;
+                let mut tmp = ct.clone();
+                if u_i != 1 {
+                    tmp.blocks[0..num_blocks - *min_blockshift]
+                        .par_iter_mut()
+                        .for_each(|ct_i| self.key.unchecked_scalar_mul_assign(ct_i, u_i as u8));
+                }
+
+                term_vec
                     .par_iter_mut()
-                    .for_each(|ct_i| self.key.unchecked_scalar_mul_assign(ct_i, u_i as u8));
-            }
-
-            let tmp = &tmp;
-            blockshifts.par_iter().for_each(|&shift| {
-                let term = self.blockshift(tmp, shift);
-                terms.lock().unwrap().push(term);
+                    .zip(blockshifts.par_iter())
+                    .for_each(|(term, &shift)| {
+                        *term = self.blockshift(&tmp, shift);
+                    });
             });
-        });
-        let mut terms = terms.into_inner().unwrap();
-        self.smart_binary_op_seq_parallelized(&mut terms, ServerKey::smart_add_parallelized)
-            .unwrap_or(zero)
+        self.smart_binary_op_seq_parallelized(
+            terms.iter_mut().flatten(),
+            ServerKey::smart_add_parallelized,
+        )
+        .unwrap_or(zero)
     }
 
     pub fn smart_scalar_mul_assign_parallelized<PBSOrder: PBSOrderMarker>(
@@ -475,51 +488,67 @@ impl ServerKey {
             return;
         }
 
+        let num_tasks = self.key.message_modulus.0;
         let b = self.key.message_modulus.0 as u64;
-        let n = ct.blocks.len();
+        let num_blocks = ct.blocks.len();
 
         //Propagate the carries before doing the multiplications
         self.full_propagate_parallelized(ct);
 
-        // key is the small scalar we multiply by
-        // value is the vector of blockshifts
-        let mut task_map = HashMap::<u64, Vec<usize>>::new();
+        // index is the small scalar we multiply by, value is the vector of blockshifts
+        let mut task_vec: Vec<Vec<usize>> =
+            vec![Vec::with_capacity((u64::BITS / b.ilog2()) as usize); num_tasks];
 
+        // Divide scalar progressively towards zero
         let mut scalar_i = scalar;
-        for i in 0..n {
+        for i in 0..num_blocks {
             let u_i = scalar_i % b;
-            task_map.entry(u_i).or_insert_with(Vec::new).push(i);
+            task_vec[u_i as usize].push(i);
             scalar_i /= b;
             if scalar_i == 0 {
                 break;
             }
         }
 
-        let terms = Mutex::new(Vec::<RadixCiphertext<PBSOrder>>::new());
-        task_map.par_iter().for_each(|(&u_i, blockshifts)| {
-            if u_i == 0 {
-                return;
-            }
+        let task_vec: Vec<_> = task_vec
+            .into_iter()
+            .enumerate()
+            .skip(1) // skip u_i == 0, multiplying by 0 yielding 0
+            .filter(|(u_i, blockshifts)| !blockshifts.is_empty())
+            .collect();
 
-            let blockshifts = &**blockshifts;
-            let min_blockshift = *blockshifts.iter().min().unwrap();
+        let mut terms: Vec<_> = task_vec
+            .iter()
+            .map(|(_, blockshifts)| {
+                vec![self.create_trivial_zero_radix(num_blocks); blockshifts.len()]
+            })
+            .collect();
+        terms
+            .par_iter_mut()
+            .zip(task_vec.par_iter())
+            .for_each(|(term_vec, (u_i, blockshifts))| {
+                let min_blockshift = blockshifts.iter().min().unwrap();
 
-            let mut tmp = ct.clone();
-            if u_i != 1 {
-                tmp.blocks[0..n - min_blockshift]
+                let u_i = *u_i;
+                let mut tmp = ct.clone();
+                if u_i != 1 {
+                    tmp.blocks[0..num_blocks - *min_blockshift]
+                        .par_iter_mut()
+                        .for_each(|ct_i| self.key.unchecked_scalar_mul_assign(ct_i, u_i as u8));
+                }
+
+                term_vec
                     .par_iter_mut()
-                    .for_each(|ct_i| self.key.unchecked_scalar_mul_assign(ct_i, u_i as u8));
-            }
-
-            let tmp = &tmp;
-            blockshifts.par_iter().for_each(|&shift| {
-                let term = self.blockshift(tmp, shift);
-                terms.lock().unwrap().push(term);
+                    .zip(blockshifts.par_iter())
+                    .for_each(|(term, &shift)| {
+                        *term = self.blockshift(&tmp, shift);
+                    });
             });
-        });
-        let terms = terms.into_inner().unwrap();
         *ct = self
-            .default_binary_op_seq_parallelized(&terms, ServerKey::add_parallelized)
+            .smart_binary_op_seq_parallelized(
+                terms.iter_mut().flatten(),
+                ServerKey::smart_add_parallelized,
+            )
             .unwrap_or(zero);
         self.full_propagate_parallelized(ct);
     }

--- a/tfhe/src/integer/server_key/radix_parallel/tests.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests.rs
@@ -103,7 +103,6 @@ fn integer_smart_add(param: Parameters) {
         // encryption of an integer
         let mut ctxt_1 = cks.encrypt(clear_1);
 
-        // add the two ciphertexts
         let mut ct_res = sks.smart_add_parallelized(&mut ctxt_0, &mut ctxt_1);
 
         clear = (clear_0 + clear_1) % modulus;
@@ -147,7 +146,6 @@ fn integer_smart_add_sequence_multi_thread(param: Parameters) {
                 .map(|clear| cks.encrypt(clear))
                 .collect::<Vec<_>>();
 
-            // add the ciphertexts
             let ct_res = sks
                 .smart_binary_op_seq_parallelized(&mut ctxts, ServerKey::smart_add_parallelized)
                 .unwrap();
@@ -182,7 +180,6 @@ fn integer_smart_add_sequence_single_thread(param: Parameters) {
                 .map(|clear| cks.encrypt(clear))
                 .collect::<Vec<_>>();
 
-            // add the ciphertexts
             let threadpool = rayon::ThreadPoolBuilder::new()
                 .num_threads(1)
                 .build()
@@ -223,9 +220,10 @@ fn integer_default_add(param: Parameters) {
         // encryption of an integer
         let ctxt_1 = cks.encrypt(clear_1);
 
-        // add the two ciphertexts
         let mut ct_res = sks.add_parallelized(&ctxt_0, &ctxt_1);
+        let tmp_ct = sks.add_parallelized(&ctxt_0, &ctxt_1);
         assert!(ct_res.block_carries_are_empty());
+        assert_eq!(ct_res, tmp_ct);
 
         clear = (clear_0 + clear_1) % modulus;
 
@@ -269,11 +267,14 @@ fn integer_default_add_sequence_multi_thread(param: Parameters) {
                 .map(|clear| cks.encrypt(clear))
                 .collect::<Vec<_>>();
 
-            // add the ciphertexts
             let ct_res = sks
                 .default_binary_op_seq_parallelized(&ctxts, ServerKey::add_parallelized)
                 .unwrap();
+            let tmp_ct = sks
+                .default_binary_op_seq_parallelized(&ctxts, ServerKey::add_parallelized)
+                .unwrap();
             assert!(ct_res.block_carries_are_empty());
+            assert_eq!(ct_res, tmp_ct);
             let ct_res: u64 = cks.decrypt(&ct_res);
             let clear = clears.iter().sum::<u64>() % modulus;
 
@@ -305,7 +306,6 @@ fn integer_default_add_sequence_single_thread(param: Parameters) {
                 .map(|clear| cks.encrypt(clear))
                 .collect::<Vec<_>>();
 
-            // add the ciphertexts
             let threadpool = rayon::ThreadPoolBuilder::new()
                 .num_threads(1)
                 .build()
@@ -347,7 +347,6 @@ fn integer_smart_bitand(param: Parameters) {
         // encryption of an integer
         let mut ctxt_1 = cks.encrypt(clear_1);
 
-        // add the two ciphertexts
         let mut ct_res = sks.smart_bitand_parallelized(&mut ctxt_0, &mut ctxt_1);
 
         clear = clear_0 & clear_1;
@@ -393,7 +392,6 @@ fn integer_smart_bitor(param: Parameters) {
         // encryption of an integer
         let mut ctxt_1 = cks.encrypt(clear_1);
 
-        // add the two ciphertexts
         let mut ct_res = sks.smart_bitor_parallelized(&mut ctxt_0, &mut ctxt_1);
 
         clear = (clear_0 | clear_1) % modulus;
@@ -439,7 +437,6 @@ fn integer_smart_bitxor(param: Parameters) {
         // encryption of an integer
         let mut ctxt_1 = cks.encrypt(clear_1);
 
-        // add the two ciphertexts
         let mut ct_res = sks.smart_bitxor_parallelized(&mut ctxt_0, &mut ctxt_1);
 
         clear = (clear_0 ^ clear_1) % modulus;
@@ -485,7 +482,6 @@ fn integer_default_bitand(param: Parameters) {
         // encryption of an integer
         let ctxt_1 = cks.encrypt(clear_1);
 
-        // add the two ciphertexts
         let mut ct_res = sks.bitand_parallelized(&ctxt_0, &ctxt_1);
         assert!(ct_res.block_carries_are_empty());
 
@@ -497,8 +493,10 @@ fn integer_default_bitand(param: Parameters) {
             // encryption of an integer
             let ctxt_2 = cks.encrypt(clear_2);
 
+            let tmp = sks.bitand_parallelized(&ct_res, &ctxt_2);
             ct_res = sks.bitand_parallelized(&ct_res, &ctxt_2);
             assert!(ct_res.block_carries_are_empty());
+            assert_eq!(ct_res, tmp);
             clear &= clear_2;
 
             // decryption of ct_res
@@ -533,7 +531,6 @@ fn integer_default_bitor(param: Parameters) {
         // encryption of an integer
         let ctxt_1 = cks.encrypt(clear_1);
 
-        // add the two ciphertexts
         let mut ct_res = sks.bitor_parallelized(&ctxt_0, &ctxt_1);
         assert!(ct_res.block_carries_are_empty());
 
@@ -545,8 +542,10 @@ fn integer_default_bitor(param: Parameters) {
             // encryption of an integer
             let ctxt_2 = cks.encrypt(clear_2);
 
+            let tmp = sks.bitor_parallelized(&ct_res, &ctxt_2);
             ct_res = sks.bitor_parallelized(&ct_res, &ctxt_2);
             assert!(ct_res.block_carries_are_empty());
+            assert_eq!(ct_res, tmp);
             clear = (clear | clear_2) % modulus;
 
             // decryption of ct_res
@@ -581,7 +580,6 @@ fn integer_default_bitxor(param: Parameters) {
         // encryption of an integer
         let ctxt_1 = cks.encrypt(clear_1);
 
-        // add the two ciphertexts
         let mut ct_res = sks.bitxor_parallelized(&ctxt_0, &ctxt_1);
         assert!(ct_res.block_carries_are_empty());
 
@@ -593,8 +591,10 @@ fn integer_default_bitxor(param: Parameters) {
             // encryption of an integer
             let ctxt_2 = cks.encrypt(clear_2);
 
+            let tmp = sks.bitxor_parallelized(&ct_res, &ctxt_2);
             ct_res = sks.bitxor_parallelized(&ct_res, &ctxt_2);
             assert!(ct_res.block_carries_are_empty());
+            assert_eq!(ct_res, tmp);
             clear = (clear ^ clear_2) % modulus;
 
             // decryption of ct_res
@@ -626,7 +626,6 @@ fn integer_unchecked_small_scalar_mul(param: Parameters) {
         // encryption of an integer
         let ct = cks.encrypt(clear);
 
-        // add the two ciphertexts
         let ct_res = sks.unchecked_small_scalar_mul_parallelized(&ct, scalar);
 
         // decryption of ct_res
@@ -702,8 +701,10 @@ fn integer_default_small_scalar_mul(param: Parameters) {
         clear_res = clear * scalar;
         for _ in 0..NB_TEST_SMALLER {
             // scalar multiplication
+            let tmp = sks.small_scalar_mul_parallelized(&ct_res, scalar);
             ct_res = sks.small_scalar_mul_parallelized(&ct_res, scalar);
             assert!(ct_res.block_carries_are_empty());
+            assert_eq!(tmp, ct_res);
             clear_res *= scalar;
         }
 
@@ -764,7 +765,9 @@ fn integer_default_scalar_mul(param: Parameters) {
 
         // scalar mul
         let ct_res = sks.scalar_mul_parallelized(&ct, scalar);
+        let tmp = sks.scalar_mul_parallelized(&ct, scalar);
         assert!(ct_res.block_carries_are_empty());
+        assert_eq!(ct_res, tmp);
 
         // decryption of ct_res
         let dec_res: u64 = cks.decrypt(&ct_res);
@@ -846,7 +849,6 @@ fn integer_unchecked_scalar_left_shift(param: Parameters) {
         // encryption of an integer
         let ct = cks.encrypt(clear);
 
-        // add the two ciphertexts
         let ct_res = sks.unchecked_scalar_left_shift_parallelized(&ct, scalar);
 
         // decryption of ct_res
@@ -879,9 +881,10 @@ fn integer_default_scalar_left_shift(param: Parameters) {
         // encryption of an integer
         let ct = cks.encrypt(clear);
 
-        // add the two ciphertexts
         let ct_res = sks.scalar_left_shift_parallelized(&ct, scalar);
+        let tmp = sks.scalar_left_shift_parallelized(&ct, scalar);
         assert!(ct_res.block_carries_are_empty());
+        assert_eq!(ct_res, tmp);
 
         // decryption of ct_res
         let dec_res: u64 = cks.decrypt(&ct_res);
@@ -913,7 +916,6 @@ fn integer_unchecked_scalar_right_shift(param: Parameters) {
         // encryption of an integer
         let ct = cks.encrypt(clear);
 
-        // add the two ciphertexts
         let ct_res = sks.unchecked_scalar_right_shift_parallelized(&ct, scalar);
 
         // decryption of ct_res
@@ -946,9 +948,10 @@ fn integer_default_scalar_right_shift(param: Parameters) {
         // encryption of an integer
         let ct = cks.encrypt(clear);
 
-        // add the two ciphertexts
         let ct_res = sks.scalar_right_shift_parallelized(&ct, scalar);
+        let tmp = sks.scalar_right_shift_parallelized(&ct, scalar);
         assert!(ct_res.block_carries_are_empty());
+        assert_eq!(ct_res, tmp);
 
         // decryption of ct_res
         let dec_res: u64 = cks.decrypt(&ct_res);
@@ -1006,11 +1009,13 @@ fn integer_default_neg(param: Parameters) {
         let ctxt = cks.encrypt(clear);
 
         // Negates the ctxt
-        let ct_tmp = sks.neg_parallelized(&ctxt);
-        assert!(ct_tmp.block_carries_are_empty());
+        let ct_res = sks.neg_parallelized(&ctxt);
+        let tmp = sks.neg_parallelized(&ctxt);
+        assert!(ct_res.block_carries_are_empty());
+        assert_eq!(ct_res, tmp);
 
         // Decrypt the result
-        let dec: u64 = cks.decrypt(&ct_tmp);
+        let dec: u64 = cks.decrypt(&ct_res);
 
         // Check the correctness
         let clear_result = clear.wrapping_neg() % modulus;
@@ -1078,8 +1083,10 @@ fn integer_default_sub(param: Parameters) {
 
         //subtract multiple times to raise the degree
         for _ in 0..NB_TEST_SMALLER {
+            let tmp = sks.sub_parallelized(&res, &ctxt_2);
             res = sks.sub_parallelized(&res, &ctxt_2);
             assert!(res.block_carries_are_empty());
+            assert_eq!(res, tmp);
             clear = (clear.wrapping_sub(clear2)) % modulus;
             // println!("clear = {}, clear2 = {}", clear, cks.decrypt(&res));
         }
@@ -1113,7 +1120,6 @@ fn integer_unchecked_block_mul(param: Parameters) {
         // encryption of an integer
         let ct_one = cks.encrypt_one_block(clear_1);
 
-        // add the two ciphertexts
         let ct_res = sks.unchecked_block_mul_parallelized(&ct_zero, &ct_one, 0);
 
         // decryption of ct_res
@@ -1189,8 +1195,10 @@ fn integer_default_block_mul(param: Parameters) {
         res = sks.block_mul_parallelized(&res, &ctxt_2, 0);
         assert!(res.block_carries_are_empty());
         for _ in 0..5 {
+            let tmp = sks.block_mul_parallelized(&res, &ctxt_2, 0);
             res = sks.block_mul_parallelized(&res, &ctxt_2, 0);
             assert!(res.block_carries_are_empty());
+            assert_eq!(res, tmp);
             clear = (clear * clear2) % modulus;
         }
         let dec: u64 = cks.decrypt(&res);
@@ -1267,8 +1275,10 @@ fn integer_default_mul(param: Parameters) {
         res = sks.mul_parallelized(&res, &ctxt_2);
         assert!(res.block_carries_are_empty());
         for _ in 0..5 {
+            let tmp = sks.mul_parallelized(&res, &ctxt_2);
             res = sks.mul_parallelized(&res, &ctxt_2);
             assert!(res.block_carries_are_empty());
+            assert_eq!(res, tmp);
             clear = (clear * clear2) % modulus;
         }
         let dec: u64 = cks.decrypt(&res);
@@ -1301,7 +1311,6 @@ fn integer_smart_scalar_add(param: Parameters) {
         // encryption of an integer
         let mut ctxt_0 = cks.encrypt(clear_0);
 
-        // add the two ciphertexts
         let mut ct_res = sks.smart_scalar_add_parallelized(&mut ctxt_0, clear_1);
 
         clear = (clear_0 + clear_1) % modulus;
@@ -1343,7 +1352,6 @@ fn integer_default_scalar_add(param: Parameters) {
         // encryption of an integer
         let ctxt_0 = cks.encrypt(clear_0);
 
-        // add the two ciphertexts
         let mut ct_res = sks.scalar_add_parallelized(&ctxt_0, clear_1);
         assert!(ct_res.block_carries_are_empty());
 
@@ -1352,8 +1360,10 @@ fn integer_default_scalar_add(param: Parameters) {
         // println!("clear_0 = {}, clear_1 = {}", clear_0, clear_1);
         //add multiple times to raise the degree
         for _ in 0..NB_TEST_SMALLER {
+            let tmp = sks.scalar_add_parallelized(&ct_res, clear_1);
             ct_res = sks.scalar_add_parallelized(&ct_res, clear_1);
             assert!(ct_res.block_carries_are_empty());
+            assert_eq!(ct_res, tmp);
             clear = (clear + clear_1) % modulus;
 
             // decryption of ct_res
@@ -1387,7 +1397,6 @@ fn integer_smart_scalar_sub(param: Parameters) {
         // encryption of an integer
         let mut ctxt_0 = cks.encrypt(clear_0);
 
-        // add the two ciphertexts
         let mut ct_res = sks.smart_scalar_sub_parallelized(&mut ctxt_0, clear_1);
 
         clear = (clear_0 - clear_1) % modulus;
@@ -1429,7 +1438,6 @@ fn integer_default_scalar_sub(param: Parameters) {
         // encryption of an integer
         let ctxt_0 = cks.encrypt(clear_0);
 
-        // add the two ciphertexts
         let mut ct_res = sks.scalar_sub_parallelized(&ctxt_0, clear_1);
         assert!(ct_res.block_carries_are_empty());
 
@@ -1438,8 +1446,10 @@ fn integer_default_scalar_sub(param: Parameters) {
         // println!("clear_0 = {}, clear_1 = {}", clear_0, clear_1);
         //add multiple times to raise the degree
         for _ in 0..NB_TEST_SMALLER {
+            let tmp = sks.scalar_sub_parallelized(&ct_res, clear_1);
             ct_res = sks.scalar_sub_parallelized(&ct_res, clear_1);
             assert!(ct_res.block_carries_are_empty());
+            assert_eq!(ct_res, tmp);
             clear = (clear.wrapping_sub(clear_1)) % modulus;
 
             // decryption of ct_res

--- a/tfhe/src/shortint/ciphertext/mod.rs
+++ b/tfhe/src/shortint/ciphertext/mod.rs
@@ -35,7 +35,7 @@ pub trait PBSOrderMarker: seal::Sealed + Debug + Clone + Copy + Send + Sync {
     fn pbs_order() -> PBSOrder;
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub struct KeyswitchBootstrap;
 
 impl PBSOrderMarker for KeyswitchBootstrap {
@@ -118,7 +118,7 @@ impl Degree {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[must_use]
 pub struct CiphertextBase<OpOrder: PBSOrderMarker> {
     pub ct: LweCiphertextOwned<u64>,


### PR DESCRIPTION
remove cmuxes and prefer processing preallocated chunks for determinism

add determinism tests in default integer tests