### PR TITLE
feat(integer): improve scalar shifts performances

### DIFF
--- a/tfhe/benches/integer/bench.rs
+++ b/tfhe/benches/integer/bench.rs
@@ -585,6 +585,14 @@ define_server_key_bench_scalar_fn!(
 define_server_key_bench_scalar_default_fn!(method_name: scalar_add_parallelized, display_name: add);
 define_server_key_bench_scalar_default_fn!(method_name: scalar_sub_parallelized, display_name: sub);
 define_server_key_bench_scalar_default_fn!(method_name: scalar_mul_parallelized, display_name: mul);
+define_server_key_bench_scalar_default_fn!(
+    method_name: scalar_left_shift_parallelized,
+    display_name: left_shift
+);
+define_server_key_bench_scalar_default_fn!(
+    method_name: scalar_right_shift_parallelized,
+    display_name: right_shift
+);
 
 define_server_key_bench_scalar_fn!(method_name: unchecked_scalar_add, display_name: add);
 define_server_key_bench_scalar_fn!(method_name: unchecked_scalar_sub, display_name: sub);
@@ -731,6 +739,8 @@ criterion_group!(
     scalar_add_parallelized,
     scalar_sub_parallelized,
     scalar_mul_parallelized,
+    scalar_left_shift_parallelized,
+    scalar_right_shift_parallelized,
 );
 
 criterion_group!(
@@ -790,6 +800,8 @@ criterion_group!(
     scalar_add_parallelized,
     scalar_sub_parallelized,
     scalar_mul_parallelized,
+    scalar_left_shift_parallelized,
+    scalar_right_shift_parallelized,
 );
 
 criterion_main!(

--- a/tfhe/src/integer/server_key/radix/mod.rs
+++ b/tfhe/src/integer/server_key/radix/mod.rs
@@ -157,8 +157,21 @@ impl ServerKey {
     /// assert_eq!(msg + msg, res);
     /// ```
     pub fn full_propagate<PBSOrder: PBSOrderMarker>(&self, ctxt: &mut RadixCiphertext<PBSOrder>) {
+        self.partial_propagate(ctxt, 0);
+    }
+
+    /// Propagates carries from
+    /// start_index to then end.
+    ///
+    /// Last carry is not propagated as
+    /// it has nothing to propagate to.
+    fn partial_propagate<PBSOrder: PBSOrderMarker>(
+        &self,
+        ctxt: &mut RadixCiphertext<PBSOrder>,
+        start_index: usize,
+    ) {
         let len = ctxt.blocks.len();
-        for i in 0..len {
+        for i in start_index..len {
             self.propagate(ctxt, i);
         }
     }

--- a/tfhe/src/integer/server_key/radix_parallel/mod.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/mod.rs
@@ -61,6 +61,17 @@ impl ServerKey {
         }
     }
 
+    pub fn partial_propagate_parallelized<PBSOrder: PBSOrderMarker>(
+        &self,
+        ctxt: &mut RadixCiphertext<PBSOrder>,
+        start_index: usize,
+    ) {
+        let len = ctxt.blocks.len();
+        for i in start_index..len {
+            self.propagate_parallelized(ctxt, i);
+        }
+    }
+
     /// Propagate all the carries.
     ///
     /// # Example
@@ -90,9 +101,6 @@ impl ServerKey {
         &self,
         ctxt: &mut RadixCiphertext<PBSOrder>,
     ) {
-        let len = ctxt.blocks.len();
-        for i in 0..len {
-            self.propagate_parallelized(ctxt, i);
-        }
+        self.partial_propagate_parallelized(ctxt, 0)
     }
 }

--- a/tfhe/src/integer/server_key/radix_parallel/shift.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/shift.rs
@@ -1,11 +1,23 @@
+use crate::core_crypto::commons::utils::izip;
 use crate::integer::ciphertext::RadixCiphertext;
 use crate::integer::ServerKey;
 use crate::shortint::PBSOrderMarker;
+
+use rayon::prelude::*;
 
 impl ServerKey {
     /// Computes homomorphically a right shift.
     ///
     /// The result is returned as a new ciphertext.
+    ///
+    /// # Requirements
+    ///
+    /// - The blocks parameter's carry space have at least one more bit than message space
+    /// - The input ciphertext carry buffer is emtpy / clean
+    ///
+    /// # Output
+    ///
+    /// - The output's carries will be clean
     ///
     /// # Example
     ///
@@ -32,7 +44,7 @@ impl ServerKey {
     pub fn unchecked_scalar_right_shift_parallelized<PBSOrder: PBSOrderMarker>(
         &self,
         ct: &RadixCiphertext<PBSOrder>,
-        shift: usize,
+        shift: u64,
     ) -> RadixCiphertext<PBSOrder> {
         let mut result = ct.clone();
         self.unchecked_scalar_right_shift_assign_parallelized(&mut result, shift);
@@ -42,6 +54,16 @@ impl ServerKey {
     /// Computes homomorphically a right shift.
     ///
     /// The result is returned as a new ciphertext.
+    ///
+    ///
+    /// # Requirements
+    ///
+    /// - The blocks parameter's carry space have at at least (message_bits - 1)
+    /// - The input ciphertext carry buffer is emtpy / clean
+    ///
+    /// # Output
+    ///
+    /// - The carry of the output blocks will be emtpy / clean
     ///
     /// # Example
     ///
@@ -68,35 +90,101 @@ impl ServerKey {
     pub fn unchecked_scalar_right_shift_assign_parallelized<PBSOrder: PBSOrderMarker>(
         &self,
         ct: &mut RadixCiphertext<PBSOrder>,
-        shift: usize,
+        shift: u64,
     ) {
-        let tmp = self.key.message_modulus.0 as f64;
+        // The general idea, is that we know by how much we want to shift
+        // since `shift` is a clear value.
+        //
+        // So we can use that to implement shifting in two step
+        // 1) shift blocks (implemented by using rotate + replace with
+        //    trivial ciphertext block which 'wrapped around`
+        // 2) shift within each block in propagate block to the next one
+        //
+        debug_assert!(ct.block_carries_are_empty());
+        debug_assert!(self.key.carry_modulus.0 >= self.key.message_modulus.0 / 2);
 
-        //number of bits of message
-        let nb_bits = tmp.log2() as usize;
-
-        // 2^u = 2^{p*q+r} = 2^{p*(q+1)}*2^{r-p}
-        let quotient = shift / nb_bits;
-
-        //p-r
-        let modified_remainder = nb_bits - (shift % nb_bits);
-
-        //if r == 0
-        if modified_remainder == nb_bits {
-            self.full_propagate_parallelized(ct);
-            self.blockshift_right_assign(ct, quotient);
-        } else {
-            // B/2^u = (B*2^{p-r}) / (2^{p*(q+1)})
-            self.unchecked_scalar_left_shift_assign_parallelized(ct, modified_remainder);
-
-            // We partially propagate in order to not lose information
-            self.partial_propagate_parallelized(ct);
-            self.blockshift_right_assign(ct, 1_usize);
-
-            // We propagate the last block in order to not lose information
-            self.propagate_parallelized(ct, ct.blocks.len() - 2);
-            self.blockshift_right_assign(ct, quotient);
+        if shift == 0 {
+            return;
         }
+
+        let num_bits_in_block = self.key.message_modulus.0.ilog2() as u64;
+        let rotations = ((shift / num_bits_in_block) as usize).min(ct.blocks.len());
+        let shift_within_block = shift % num_bits_in_block;
+        let num_blocks = ct.blocks.len();
+        let total_num_bits = num_bits_in_block * ct.blocks.len() as u64;
+
+        if shift > total_num_bits {
+            for block in ct.blocks.iter_mut() {
+                self.key.create_trivial_assign(block, 0)
+            }
+            return;
+        }
+
+        // rotate left as the blocks are from LSB to MSB
+        ct.blocks.rotate_left(rotations);
+        for block in &mut ct.blocks[num_blocks - rotations..] {
+            self.key.create_trivial_assign(block, 0)
+        }
+
+        if shift_within_block == 0 || rotations == ct.blocks.len() {
+            return;
+        }
+
+        let message_modulus = self.key.message_modulus.0 as u64;
+
+        // Since we require that carries are empty,
+        // we can use the bivariate bps to shift and propagate in parallel at the same time
+        // instead of first shifting then propagating
+        //
+        // The first block is done separately as it does not
+        // need to recuperate the shifted bits from its next block,
+        // and also that way is does not need a special case for when rotations == 0
+        let create_blocks_using_bivariate_pbs = || {
+            let lut = self
+                .key
+                .generate_accumulator_bivariate(|current_block, mut next_block| {
+                    // left shift so as not to lose
+                    // bits when shifting right afterwards
+                    next_block <<= num_bits_in_block;
+                    next_block >>= shift_within_block;
+
+                    // The way of gettint caryy / message is reversed compared
+                    // to the usual way but its normal:
+                    // The message is in the upper bits, the carry in lower bits
+                    let message_of_current_block = current_block >> shift_within_block;
+                    let carry_of_previous_block = next_block % message_modulus;
+
+                    message_of_current_block + carry_of_previous_block
+                });
+            let partial_blocks = ct.blocks[..num_blocks - rotations]
+                .par_windows(2)
+                .map(|blocks| {
+                    // We are right-shifting,
+                    // so we get the bits from the next block in the vec
+                    let (current_block, next_block) = (&blocks[0], &blocks[1]);
+                    self.key
+                        .unchecked_apply_lookup_table_bivariate(current_block, next_block, &lut)
+                })
+                .collect::<Vec<_>>();
+            partial_blocks
+        };
+
+        let shift_last_block = || {
+            let block = &ct.blocks[num_blocks - rotations - 1];
+            self.key.scalar_right_shift(block, shift_within_block as u8)
+        };
+        let (partial_blocks, last_shifted_block) =
+            rayon::join(create_blocks_using_bivariate_pbs, shift_last_block);
+        ct.blocks[num_blocks - rotations - 1] = last_shifted_block;
+
+        // We started with num_blocks, discarded 'rotations' blocks
+        // and did the last one separately
+        let blocks_to_replace = &mut ct.blocks[..num_blocks - rotations - 1];
+        assert_eq!(partial_blocks.len(), blocks_to_replace.len());
+        for (block, shifted_block) in izip!(blocks_to_replace, partial_blocks) {
+            *block = shifted_block
+        }
+        debug_assert!(ct.block_carries_are_empty());
     }
 
     /// Computes homomorphically a right shift.
@@ -137,7 +225,7 @@ impl ServerKey {
     pub fn scalar_right_shift_parallelized<PBSOrder: PBSOrderMarker>(
         &self,
         ct: &RadixCiphertext<PBSOrder>,
-        shift: usize,
+        shift: u64,
     ) -> RadixCiphertext<PBSOrder> {
         let mut result = ct.clone();
         self.scalar_right_shift_assign_parallelized(&mut result, shift);
@@ -182,30 +270,27 @@ impl ServerKey {
     pub fn scalar_right_shift_assign_parallelized<PBSOrder: PBSOrderMarker>(
         &self,
         ct: &mut RadixCiphertext<PBSOrder>,
-        shift: usize,
+        shift: u64,
     ) {
         if !ct.block_carries_are_empty() {
             self.full_propagate_parallelized(ct);
         }
-        self.unchecked_scalar_right_shift_assign_parallelized(ct, shift);
-        self.full_propagate_parallelized(ct);
-    }
 
-    /// Propagates all carries except the last one.
-    /// For development purpose only.
-    fn partial_propagate_parallelized<PBSOrder: PBSOrderMarker>(
-        &self,
-        ctxt: &mut RadixCiphertext<PBSOrder>,
-    ) {
-        let len = ctxt.blocks.len() - 1;
-        for i in 0..len {
-            self.propagate_parallelized(ctxt, i);
-        }
+        self.unchecked_scalar_right_shift_assign_parallelized(ct, shift);
     }
 
     /// Computes homomorphically a left shift by a scalar.
     ///
     /// The result is returned as a new ciphertext.
+    ///
+    /// # Requirements
+    ///
+    /// - The blocks parameter's carry space have at least one more bit than message space
+    /// - The input ciphertext carry buffer is emtpy / clean
+    ///
+    /// # Output
+    ///
+    /// - The output ciphertext carry buffers will be clean / empty
     ///
     /// # Example
     ///
@@ -232,7 +317,7 @@ impl ServerKey {
     pub fn unchecked_scalar_left_shift_parallelized<PBSOrder: PBSOrderMarker>(
         &self,
         ct_left: &RadixCiphertext<PBSOrder>,
-        shift: usize,
+        shift: u64,
     ) -> RadixCiphertext<PBSOrder> {
         let mut result = ct_left.clone();
         self.unchecked_scalar_left_shift_assign_parallelized(&mut result, shift);
@@ -242,6 +327,15 @@ impl ServerKey {
     /// Computes homomorphically a left shift by a scalar.
     ///
     /// The result is assigned in the input ciphertext
+    ///
+    /// # Requirements
+    ///
+    /// - The blocks parameter's carry space have at at least (message_bits - 1)
+    /// - The input ciphertext carry buffer is emtpy / clean
+    ///
+    /// # Output
+    ///
+    /// - The ct carry buffers will be clean / empty afterwards
     ///
     /// # Example
     ///
@@ -268,10 +362,99 @@ impl ServerKey {
     pub fn unchecked_scalar_left_shift_assign_parallelized<PBSOrder: PBSOrderMarker>(
         &self,
         ct: &mut RadixCiphertext<PBSOrder>,
-        shift: usize,
+        shift: u64,
     ) {
-        let tmp = 1_u64 << shift;
-        self.smart_scalar_mul_assign_parallelized(ct, tmp);
+        // The general idea, is that we know by how much we want to shift
+        // since `shift` is a clear value.
+        //
+        // So we can use that to implement shifting in two step
+        // 1) shift blocks (implemented by using rotate + replace with
+        //    trivial ciphertext block which 'wrapped around`
+        // 2) shift within each block in propagate block to the next one
+
+        debug_assert!(ct.block_carries_are_empty());
+        debug_assert!(self.key.carry_modulus.0 >= self.key.message_modulus.0 / 2);
+
+        if shift == 0 {
+            return;
+        }
+
+        let num_bits_in_block = self.key.message_modulus.0.ilog2() as u64;
+        let rotations = ((shift / num_bits_in_block) as usize).min(ct.blocks.len());
+        let shift_within_block = shift % num_bits_in_block;
+        let total_num_bits = num_bits_in_block * ct.blocks.len() as u64;
+
+        if shift > total_num_bits {
+            for block in ct.blocks.iter_mut() {
+                self.key.create_trivial_assign(block, 0)
+            }
+            return;
+        }
+
+        // rotate right as the blocks are from LSB to MSB
+        ct.blocks.rotate_right(rotations);
+        // Every block below 'rotations' should be discarded
+        for block in &mut ct.blocks[..rotations] {
+            self.key.create_trivial_assign(block, 0)
+        }
+
+        if shift_within_block == 0 || rotations == ct.blocks.len() {
+            return;
+        }
+
+        // Since we require that carries are empty,
+        // we can use the bivariate bps to shift and propagate in parallel at the same time
+        // instead of first shifting then propagating
+        //
+        // The first block is done separately as it does not
+        // need to recuperate the shifted bits from its previous block,
+        // and also that way is does not need a special case for when rotations == 0
+        let create_blocks_using_bivariate_pbs = || {
+            let lut = self
+                .key
+                .generate_accumulator_bivariate(|previous_block, current_block| {
+                    let current_block = current_block << shift_within_block;
+                    let previous_block = previous_block << shift_within_block;
+
+                    let message_of_current_block =
+                        current_block % self.key.message_modulus.0 as u64;
+                    let carry_of_previous_block =
+                        previous_block / self.key.message_modulus.0 as u64;
+                    message_of_current_block + carry_of_previous_block
+                });
+            let partial_blocks = ct.blocks[rotations..]
+                .par_windows(2)
+                .map(|blocks| {
+                    let (previous_block, current_block) = (&blocks[0], &blocks[1]);
+                    self.key.unchecked_apply_lookup_table_bivariate(
+                        previous_block,
+                        current_block,
+                        &lut,
+                    )
+                })
+                .collect::<Vec<_>>();
+            partial_blocks
+        };
+
+        let shift_last_block = || {
+            let mut block = ct.blocks[rotations].clone();
+            self.key
+                .scalar_left_shift_assign(&mut block, shift_within_block as u8);
+            block
+        };
+
+        let (partial_blocks, block) =
+            rayon::join(create_blocks_using_bivariate_pbs, shift_last_block);
+
+        // We started with num_blocks, discarded 'rotations' blocks
+        // and did the last one separately
+        ct.blocks[rotations] = block;
+        let blocks_to_replace = &mut ct.blocks[rotations + 1..];
+        assert_eq!(partial_blocks.len(), blocks_to_replace.len());
+        for (block, shifted_block) in izip!(blocks_to_replace, partial_blocks) {
+            *block = shifted_block
+        }
+        debug_assert!(ct.block_carries_are_empty());
     }
 
     /// Computes homomorphically a left shift by a scalar.
@@ -312,7 +495,7 @@ impl ServerKey {
     pub fn scalar_left_shift_parallelized<PBSOrder: PBSOrderMarker>(
         &self,
         ct_left: &RadixCiphertext<PBSOrder>,
-        shift: usize,
+        shift: u64,
     ) -> RadixCiphertext<PBSOrder> {
         let mut result = ct_left.clone();
         self.scalar_left_shift_assign_parallelized(&mut result, shift);
@@ -357,12 +540,12 @@ impl ServerKey {
     pub fn scalar_left_shift_assign_parallelized<PBSOrder: PBSOrderMarker>(
         &self,
         ct: &mut RadixCiphertext<PBSOrder>,
-        shift: usize,
+        shift: u64,
     ) {
         if !ct.block_carries_are_empty() {
             self.full_propagate_parallelized(ct);
         }
+
         self.unchecked_scalar_left_shift_assign_parallelized(ct, shift);
-        self.full_propagate_parallelized(ct);
     }
 }


### PR DESCRIPTION
This reworks the left/right scalar shift method.

This new implementation takes more advantage of the
radix representation property and use a combo
of shifting/moving blocks via a rotate_left/right
optionnaly followed by in-block shifting and propagation
to other blocks.

This new implementation requires the carries to be empty
(not sure what the preconditions were for the previous implementation)
and the output will also have clean carries.
Requiring empty carries allows to do the shift in a way
that scales well with the number of blocks as we can use truly parallel
operations.

This means that the time required to shift is dependent
in the shift value, which should not be a security problem
as its a clear value. (The previous implementation also
had timing that depended on the shift value)

There are two scenarios possible:
- The shift only require to move blocks -> its fast
- The shift requires moving + in-block shifting -> slower,
  but still faster than the previous implementation.

Worst case is when shift is less than the number of bits
in a block.

This also changes the type of the `shift` parameter from
`usize` to `u64` to be consistent with other scalar operations.

The follwing pseudo bench code on 64 bits
gives the following time ranges:

With changes:
```
unchecked_left: BenchStat {
    min: 16.743µs
    max: 526.518563ms
    mean: 150.77871ms
}
unchecked_left_parallelized: BenchStat {
    min: 17.291µs
    max: 94.408455ms
    mean: 30.092279ms
}
unchecked_right: BenchStat {
    min: 16.723µs
    max: 548.417332ms
    mean: 160.345234ms
}
unchecked_right_parallelized: BenchStat {
    min: 16.978µs
    max: 97.955322ms
    mean: 33.500562ms
}
Measured in 37.890296743s
```

Previous code:
```
unchecked_left: BenchStat {
    min: 1.055401595s
    max: 1.156574075s
    mean: 1.085648592s
}
unchecked_left_parallelized: BenchStat {
    min: 559.636545ms
    max: 630.83338ms
    mean: 584.747893ms
}
unchecked_right: BenchStat {
    min: 1.055041354s
    max: 2.314891255s
    mean: 1.644513996s
}
unchecked_right_parallelized: BenchStat {
    min: 562.017144ms
    max: 1.275945891s
    mean: 894.812286ms
}
Measured in 421.412913883s
```

```rust
use rand::Rng;
use std::time::Instant;
use tfhe::integer::{gen_keys, RadixClientKey};
use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2;

const NB_CTXT: usize = 32;
const NB_TEST: usize = 100;

struct BenchStat {
    min: Option<std::time::Duration>,
    max: Option<std::time::Duration>,
    sum: std::time::Duration,
    count: u32,
}

impl BenchStat {
    fn update(&mut self, elapsed: std::time::Duration) {
        if self.min.is_none() {
            self.min = Some(elapsed);
        } else {
            self.min = self.min.map(|l| l.min(elapsed));
        }
        if self.max.is_none() {
            self.max = Some(elapsed);
        } else {
            self.max = self.max.map(|l| l.max(elapsed));
        }
        self.sum += elapsed;
        self.count += 1;
    }

    fn print(&self) {
        println!("BenchStat {{");
        println!("    min: {:?}", self.min.unwrap());
        println!("    max: {:?}", self.max.unwrap());
        println!("    mean: {:?}", self.sum / self.count);
        println!("}}");
    }
}

type ShiftType = u64;

fn main() {
    let mut unchecked_left_timing = BenchStat::default();
    let mut unchecked_left_parallelized_timing = BenchStat::default();
    let mut unchecked_right_timing = BenchStat::default();
    let mut unchecked_right_parallelized_timing = BenchStat::default();

    let total = Instant::now();

    let param = PARAM_MESSAGE_2_CARRY_2;
    let (cks, sks) = gen_keys(&param);
    let cks = RadixClientKey::from((cks, NB_CTXT));

    let mut rng = rand::thread_rng();

    //Nb of bits to shift
    let tmp_f64 = param.message_modulus.0 as f64;
    let nb_bits = tmp_f64.log2().floor() as usize * NB_CTXT;
    let modulus = (param.message_modulus.0 as u128).pow(NB_CTXT as u32);
    assert_eq!(nb_bits, 64);

    for i in 0..NB_TEST {
        println!("{} / {NB_TEST}", i + 1);
        let clear = rng.gen::<u128>() % modulus;
        let scalar = rng.gen::<u128>() % nb_bits as u128;

        println!("clear: {clear}, scalar: {scalar}");

        let ct = cks.encrypt(clear);

        {
            let before = Instant::now();
            let ct_res = sks.unchecked_scalar_left_shift(&ct, scalar as ShiftType);
            unchecked_left_timing.update(before.elapsed());
            //assert!(ct_res.block_carries_are_empty());
            let dec_res: u128 = cks.decrypt(&ct_res);
            assert_eq!((clear << scalar) % modulus, dec_res);

            let before = Instant::now();
            let ct_res = sks.unchecked_scalar_left_shift_parallelized(&ct, scalar as ShiftType);
            unchecked_left_parallelized_timing.update(before.elapsed());
            //assert!(ct_res.block_carries_are_empty());
            let dec_res: u128 = cks.decrypt(&ct_res);
            assert_eq!((clear << scalar) % modulus, dec_res);
        }

        {
            let before = Instant::now();
            let ct_res = sks.unchecked_scalar_right_shift(&ct, scalar as ShiftType);
            unchecked_right_timing.update(before.elapsed());
            // assert!(ct_res.block_carries_are_empty());
            let dec_res: u128 = cks.decrypt(&ct_res);
            assert_eq!((clear >> scalar) % modulus, dec_res);

            let before = Instant::now();
            let ct_res = sks.unchecked_scalar_right_shift_parallelized(&ct, scalar as ShiftType);
            unchecked_right_parallelized_timing.update(before.elapsed());
            //assert!(ct_res.block_carries_are_empty());
            let dec_res: u128 = cks.decrypt(&ct_res);
            assert_eq!((clear >> scalar) % modulus, dec_res);
        }
    }

    print!("unchecked_left: ");
    unchecked_left_timing.print();
    print!("unchecked_left_parallelized: ");
    unchecked_left_parallelized_timing.print();

    print!("unchecked_right: ");
    unchecked_right_timing.print();
    print!("unchecked_right_parallelized: ");
    unchecked_right_parallelized_timing.print();

    println!("Measured in {:?}", total.elapsed());
}
```

BREAKING CHANGE: parameter type changed from usize to u64