### PR TITLE
chore(deps): bump JS-DevTools/npm-publish from 1.4.3 to 2.0.0

### DIFF
--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -31,7 +31,7 @@ jobs:
           make build_web_js_api
 
       - name: Publish web package
-        uses: JS-DevTools/npm-publish@0f451a94170d1699fd50710966d48fb26194d939
+        uses: JS-DevTools/npm-publish@0be441d808570461daedc3fb178405dbcac54de0
         with:
           token: ${{ secrets.NPM_TOKEN }}
           package: tfhe/pkg/package.json
@@ -45,7 +45,7 @@ jobs:
           sed -i 's/"tfhe"/"node-tfhe"/g' tfhe/pkg/package.json
 
       - name: Publish Node package
-        uses: JS-DevTools/npm-publish@0f451a94170d1699fd50710966d48fb26194d939
+        uses: JS-DevTools/npm-publish@0be441d808570461daedc3fb178405dbcac54de0
         with:
           token: ${{ secrets.NPM_TOKEN }}
           package: tfhe/pkg/package.json


### PR DESCRIPTION
Cherry pick for 0.2.x