### PR TITLE
refactor(hlapi): remove RefCell used to wrap integers

### DIFF
--- a/tfhe/src/c_api/high_level_api/integers.rs
+++ b/tfhe/src/c_api/high_level_api/integers.rs
@@ -16,12 +16,12 @@ macro_rules! impl_operations_for_integer_type {
         name: $name:ident,
         clear_scalar_type: $clear_scalar_type:ty
     ) => {
-        impl_binary_fn_on_type_mut!($name => add, sub, mul, bitand, bitor, bitxor, eq, ge, gt, le, lt, min, max);
-        impl_binary_assign_fn_on_type_mut!($name => add_assign, sub_assign, mul_assign, bitand_assign, bitor_assign, bitxor_assign);
-        impl_scalar_binary_fn_on_type_mut!($name, $clear_scalar_type => add, sub, mul, shl, shr);
-        impl_scalar_binary_assign_fn_on_type_mut!($name, $clear_scalar_type => add_assign, sub_assign, mul_assign, shl_assign, shr_assign);
+        impl_binary_fn_on_type!($name => add, sub, mul, bitand, bitor, bitxor, eq, ge, gt, le, lt, min, max);
+        impl_binary_assign_fn_on_type!($name => add_assign, sub_assign, mul_assign, bitand_assign, bitor_assign, bitxor_assign);
+        impl_scalar_binary_fn_on_type!($name, $clear_scalar_type => add, sub, mul, shl, shr);
+        impl_scalar_binary_assign_fn_on_type!($name, $clear_scalar_type => add_assign, sub_assign, mul_assign, shl_assign, shr_assign);
 
-        impl_unary_fn_on_type_mut!($name => neg);
+        impl_unary_fn_on_type!($name => neg);
     };
 }
 

--- a/tfhe/src/high_level_api/integers/server_key.rs
+++ b/tfhe/src/high_level_api/integers/server_key.rs
@@ -216,26 +216,32 @@ impl WopbsEvaluationKey<crate::integer::ServerKey, crate::integer::CrtCiphertext
     }
 }
 
-pub(super) trait SmartNeg<Ciphertext> {
-    type Output;
-    fn smart_neg(&self, lhs: Ciphertext) -> Self::Output;
+#[derive(Clone, serde::Deserialize, serde::Serialize)]
+pub enum RadixCiphertextDyn {
+    Big(crate::integer::RadixCiphertextBig),
+    Small(crate::integer::RadixCiphertextSmall),
 }
 
-macro_rules! define_smart_server_key_op {
+pub(super) trait ServerKeyDefaultNeg<Ciphertext> {
+    type Output;
+    fn neg(&self, lhs: Ciphertext) -> Self::Output;
+}
+
+macro_rules! define_default_server_key_op {
     ($op_name:ident) => {
         paste::paste! {
-            pub trait [< Smart $op_name >]<Lhs, Rhs> {
+            pub trait [< ServerKeyDefault $op_name >]<Lhs, Rhs> {
                 type Output;
 
-                fn [< smart_ $op_name:lower >](
+                fn [< $op_name:lower >](
                     &self,
                     lhs: Lhs,
                     rhs: Rhs,
                 ) -> Self::Output;
             }
 
-            pub trait [< Smart $op_name Assign >]<Lhs, Rhs> {
-                fn [< smart_ $op_name:lower _assign >](
+            pub trait [< ServerKeyDefault $op_name Assign >]<Lhs, Rhs> {
+                fn [< $op_name:lower _assign >](
                     &self,
                     lhs: &mut Lhs,
                     rhs: Rhs,
@@ -245,46 +251,37 @@ macro_rules! define_smart_server_key_op {
     };
     ($($op:ident),*) => {
         $(
-            define_smart_server_key_op!($op);
+            define_default_server_key_op!($op);
         )*
     };
 }
 
-define_smart_server_key_op!(
+define_default_server_key_op!(
     Add, Sub, Mul, BitAnd, BitOr, BitXor, Shl, Shr, Eq, Ge, Gt, Le, Lt, Max, Min
 );
 
-#[derive(Clone, serde::Deserialize, serde::Serialize)]
-pub enum RadixCiphertextDyn {
-    Big(crate::integer::RadixCiphertextBig),
-    Small(crate::integer::RadixCiphertextSmall),
-}
-
-impl SmartNeg<&mut RadixCiphertextDyn> for crate::integer::ServerKey {
+impl ServerKeyDefaultNeg<&RadixCiphertextDyn> for crate::integer::ServerKey {
     type Output = RadixCiphertextDyn;
-    fn smart_neg(&self, lhs: &mut RadixCiphertextDyn) -> Self::Output {
+
+    fn neg(&self, lhs: &RadixCiphertextDyn) -> Self::Output {
         match lhs {
-            RadixCiphertextDyn::Big(lhs) => {
-                RadixCiphertextDyn::Big(self.smart_neg_parallelized(lhs))
-            }
-            RadixCiphertextDyn::Small(lhs) => {
-                RadixCiphertextDyn::Small(self.smart_neg_parallelized(lhs))
-            }
+            RadixCiphertextDyn::Big(lhs) => RadixCiphertextDyn::Big(self.neg_parallelized(lhs)),
+            RadixCiphertextDyn::Small(lhs) => RadixCiphertextDyn::Small(self.neg_parallelized(lhs)),
         }
     }
 }
 
-macro_rules! impl_smart_op_for_tfhe_integer_server_key_dyn {
-    ($smart_trait:ident($smart_trait_fn:ident) => $method:ident) => {
-        impl $smart_trait<&mut RadixCiphertextDyn, &mut RadixCiphertextDyn>
+macro_rules! impl_default_op_for_tfhe_integer_server_key_dyn {
+    ($default_trait:ident($default_trait_fn:ident) => $method:ident) => {
+        impl $default_trait<&RadixCiphertextDyn, &RadixCiphertextDyn>
             for crate::integer::ServerKey
         {
             type Output = RadixCiphertextDyn;
 
-            fn $smart_trait_fn(
+            fn $default_trait_fn(
                 &self,
-                lhs_enum: &mut RadixCiphertextDyn,
-                rhs_enum: &mut RadixCiphertextDyn,
+                lhs_enum: &RadixCiphertextDyn,
+                rhs_enum: &RadixCiphertextDyn,
             ) -> Self::Output {
                 match (lhs_enum, rhs_enum) {
                     (RadixCiphertextDyn::Big(lhs), RadixCiphertextDyn::Big(rhs)) => {
@@ -300,15 +297,13 @@ macro_rules! impl_smart_op_for_tfhe_integer_server_key_dyn {
     };
 }
 
-macro_rules! impl_smart_assign_op_for_tfhe_integer_server_key_dyn {
-    ($smart_trait:ident($smart_trait_fn:ident) => $method_assign:ident) => {
-        impl $smart_trait<RadixCiphertextDyn, &mut RadixCiphertextDyn>
-            for crate::integer::ServerKey
-        {
-            fn $smart_trait_fn(
+macro_rules! impl_default_assign_op_for_tfhe_integer_server_key_dyn {
+    ($default_trait:ident($default_trait_fn:ident) => $method_assign:ident) => {
+        impl $default_trait<RadixCiphertextDyn, &RadixCiphertextDyn> for crate::integer::ServerKey {
+            fn $default_trait_fn(
                 &self,
                 lhs_enum: &mut RadixCiphertextDyn,
-                rhs_enum: &mut RadixCiphertextDyn,
+                rhs_enum: &RadixCiphertextDyn,
             ) {
                 match (lhs_enum, rhs_enum) {
                     (RadixCiphertextDyn::Big(lhs), RadixCiphertextDyn::Big(rhs)) => {
@@ -324,12 +319,12 @@ macro_rules! impl_smart_assign_op_for_tfhe_integer_server_key_dyn {
     };
 }
 
-macro_rules! impl_smart_scalar_op_for_tfhe_integer_server_key_dyn {
-    ($smart_trait:ident($smart_trait_fn:ident) => $method:ident) => {
-        impl $smart_trait<&mut RadixCiphertextDyn, u64> for crate::integer::ServerKey {
+macro_rules! impl_default_scalar_op_for_tfhe_integer_server_key_dyn {
+    ($default_trait:ident($default_trait_fn:ident) => $method:ident) => {
+        impl $default_trait<&RadixCiphertextDyn, u64> for crate::integer::ServerKey {
             type Output = RadixCiphertextDyn;
 
-            fn $smart_trait_fn(&self, lhs: &mut RadixCiphertextDyn, rhs: u64) -> Self::Output {
+            fn $default_trait_fn(&self, lhs: &RadixCiphertextDyn, rhs: u64) -> Self::Output {
                 match lhs {
                     RadixCiphertextDyn::Big(lhs) => {
                         RadixCiphertextDyn::Big(self.$method(lhs, rhs.try_into().unwrap()))
@@ -343,10 +338,10 @@ macro_rules! impl_smart_scalar_op_for_tfhe_integer_server_key_dyn {
     };
 }
 
-macro_rules! impl_smart_scalar_assign_op_for_tfhe_integer_server_key_dyn {
-    ($smart_trait:ident($smart_trait_fn:ident) => $method_assign:ident) => {
-        impl $smart_trait<RadixCiphertextDyn, u64> for crate::integer::ServerKey {
-            fn $smart_trait_fn(&self, lhs: &mut RadixCiphertextDyn, rhs: u64) {
+macro_rules! impl_default_scalar_assign_op_for_tfhe_integer_server_key_dyn {
+    ($default_trait:ident($default_trait_fn:ident) => $method_assign:ident) => {
+        impl $default_trait<RadixCiphertextDyn, u64> for crate::integer::ServerKey {
+            fn $default_trait_fn(&self, lhs: &mut RadixCiphertextDyn, rhs: u64) {
                 match lhs {
                     RadixCiphertextDyn::Big(lhs) => {
                         self.$method_assign(lhs, rhs.try_into().unwrap())
@@ -360,35 +355,35 @@ macro_rules! impl_smart_scalar_assign_op_for_tfhe_integer_server_key_dyn {
     };
 }
 
-impl_smart_op_for_tfhe_integer_server_key_dyn!(SmartAdd(smart_add) => add_parallelized);
-impl_smart_op_for_tfhe_integer_server_key_dyn!(SmartSub(smart_sub) => sub_parallelized);
-impl_smart_op_for_tfhe_integer_server_key_dyn!(SmartMul(smart_mul) => mul_parallelized);
-impl_smart_op_for_tfhe_integer_server_key_dyn!(SmartBitAnd(smart_bitand) => bitand_parallelized);
-impl_smart_op_for_tfhe_integer_server_key_dyn!(SmartBitOr(smart_bitor) => bitor_parallelized);
-impl_smart_op_for_tfhe_integer_server_key_dyn!(SmartBitXor(smart_bitxor) => bitxor_parallelized);
-impl_smart_op_for_tfhe_integer_server_key_dyn!(SmartEq(smart_eq) => eq_parallelized);
-impl_smart_op_for_tfhe_integer_server_key_dyn!(SmartGe(smart_ge) => ge_parallelized);
-impl_smart_op_for_tfhe_integer_server_key_dyn!(SmartGt(smart_gt) => gt_parallelized);
-impl_smart_op_for_tfhe_integer_server_key_dyn!(SmartLe(smart_le) => le_parallelized);
-impl_smart_op_for_tfhe_integer_server_key_dyn!(SmartLt(smart_lt) => lt_parallelized);
-impl_smart_op_for_tfhe_integer_server_key_dyn!(SmartMax(smart_max) => max_parallelized);
-impl_smart_op_for_tfhe_integer_server_key_dyn!(SmartMin(smart_min) => min_parallelized);
+impl_default_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultAdd(add) => add_parallelized);
+impl_default_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultSub(sub) => sub_parallelized);
+impl_default_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultMul(mul) => mul_parallelized);
+impl_default_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultBitAnd(bitand) => bitand_parallelized);
+impl_default_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultBitOr(bitor) => bitor_parallelized);
+impl_default_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultBitXor(bitxor) => bitxor_parallelized);
+impl_default_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultEq(eq) => eq_parallelized);
+impl_default_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultGe(ge) => ge_parallelized);
+impl_default_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultGt(gt) => gt_parallelized);
+impl_default_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultLe(le) => le_parallelized);
+impl_default_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultLt(lt) => lt_parallelized);
+impl_default_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultMax(max) => max_parallelized);
+impl_default_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultMin(min) => min_parallelized);
 
-impl_smart_assign_op_for_tfhe_integer_server_key_dyn!(SmartAddAssign(smart_add_assign) => add_assign_parallelized);
-impl_smart_assign_op_for_tfhe_integer_server_key_dyn!(SmartSubAssign(smart_sub_assign) => sub_assign_parallelized);
-impl_smart_assign_op_for_tfhe_integer_server_key_dyn!(SmartMulAssign(smart_mul_assign) => mul_assign_parallelized);
-impl_smart_assign_op_for_tfhe_integer_server_key_dyn!(SmartBitAndAssign(smart_bitand_assign) => bitand_assign_parallelized);
-impl_smart_assign_op_for_tfhe_integer_server_key_dyn!(SmartBitOrAssign(smart_bitor_assign) => bitor_assign_parallelized);
-impl_smart_assign_op_for_tfhe_integer_server_key_dyn!(SmartBitXorAssign(smart_bitxor_assign) => bitxor_assign_parallelized);
+impl_default_assign_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultAddAssign(add_assign) => add_assign_parallelized);
+impl_default_assign_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultSubAssign(sub_assign) => sub_assign_parallelized);
+impl_default_assign_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultMulAssign(mul_assign) => mul_assign_parallelized);
+impl_default_assign_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultBitAndAssign(bitand_assign) => bitand_assign_parallelized);
+impl_default_assign_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultBitOrAssign(bitor_assign) => bitor_assign_parallelized);
+impl_default_assign_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultBitXorAssign(bitxor_assign) => bitxor_assign_parallelized);
 
-impl_smart_scalar_op_for_tfhe_integer_server_key_dyn!(SmartAdd(smart_add) => scalar_add_parallelized);
-impl_smart_scalar_op_for_tfhe_integer_server_key_dyn!(SmartSub(smart_sub) => scalar_sub_parallelized);
-impl_smart_scalar_op_for_tfhe_integer_server_key_dyn!(SmartMul(smart_mul) => scalar_mul_parallelized);
-impl_smart_scalar_op_for_tfhe_integer_server_key_dyn!(SmartShl(smart_shl) => scalar_left_shift_parallelized);
-impl_smart_scalar_op_for_tfhe_integer_server_key_dyn!(SmartShr(smart_shr) => scalar_right_shift_parallelized);
+impl_default_scalar_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultAdd(add) => scalar_add_parallelized);
+impl_default_scalar_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultSub(sub) => scalar_sub_parallelized);
+impl_default_scalar_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultMul(mul) => scalar_mul_parallelized);
+impl_default_scalar_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultShl(shl) => scalar_left_shift_parallelized);
+impl_default_scalar_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultShr(shr) => scalar_right_shift_parallelized);
 
-impl_smart_scalar_assign_op_for_tfhe_integer_server_key_dyn!(SmartAddAssign(smart_add_assign) => scalar_add_assign_parallelized);
-impl_smart_scalar_assign_op_for_tfhe_integer_server_key_dyn!(SmartSubAssign(smart_sub_assign) => scalar_sub_assign_parallelized);
-impl_smart_scalar_assign_op_for_tfhe_integer_server_key_dyn!(SmartMulAssign(smart_mul_assign) => scalar_mul_assign_parallelized);
-impl_smart_scalar_assign_op_for_tfhe_integer_server_key_dyn!(SmartShlAssign(smart_shl_assign) => scalar_left_shift_assign_parallelized);
-impl_smart_scalar_assign_op_for_tfhe_integer_server_key_dyn!(SmartShrAssign(smart_shr_assign) => scalar_right_shift_assign_parallelized);
+impl_default_scalar_assign_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultAddAssign(add_assign) => scalar_add_assign_parallelized);
+impl_default_scalar_assign_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultSubAssign(sub_assign) => scalar_sub_assign_parallelized);
+impl_default_scalar_assign_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultMulAssign(mul_assign) => scalar_mul_assign_parallelized);
+impl_default_scalar_assign_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultShlAssign(shl_assign) => scalar_left_shift_assign_parallelized);
+impl_default_scalar_assign_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultShrAssign(shr_assign) => scalar_right_shift_assign_parallelized);

--- a/tfhe/src/high_level_api/integers/tests.rs
+++ b/tfhe/src/high_level_api/integers/tests.rs
@@ -219,7 +219,7 @@ fn test_trivial_fhe_uint8() {
 
     let a = FheUint8::try_encrypt_trivial(234u8).unwrap();
     assert!(matches!(
-        &*a.ciphertext.borrow(),
+        &a.ciphertext,
         crate::high_level_api::integers::server_key::RadixCiphertextDyn::Big(_)
     ));
 
@@ -239,7 +239,7 @@ fn test_trivial_fhe_uint256_small() {
     let clear_a = U256::from(u128::MAX);
     let a = FheUint256::try_encrypt_trivial(clear_a).unwrap();
     assert!(matches!(
-        &*a.ciphertext.borrow(),
+        &a.ciphertext,
         crate::high_level_api::integers::server_key::RadixCiphertextDyn::Small(_)
     ));
     let clear: U256 = a.decrypt(&client_key);


### PR DESCRIPTION
Our integer types are based on tfhe::integer.

Originally, operators (+, -, *, <<, etc) were mapped to "smart" operations until commit "ee96a0ff185fedb9c4467a5b0c8195798c30b19f" where we swapped to "default" ops.

The motivation of swapping from smart to default was that default ops timing was always the same, so its easier to predict and reason about when comparing with available benchmarks.
However, they may give worse performance depending on the computations being done (addition/subtraction heavy or not).

In the High level API, we overloaded operators on const ref e.g. `&a + &b` but as we initially mapped to smart operations we needed interior mutability. RefCell was chosen, mainly because using Mutexes would have allowed users to write "fake" parallel code, that is, the code compiles but is not truly parallel due to the mutexes. RefCell makes writting parallel code harder but If you manage to do it, its truly parallel.

After moving to default ops for the hlapi, we kept the inner RefCells to allow time to decide to retract the change.

The final choice is to keep default ops as the default, so that means we can remove the RefCells.

Entry points to smart operation will be added later to enable 'power users' to explicitely try them and see if they bring improvement(s) for them.
Letting advanced user explicitely handle mutability of smart operations and let them choose their synchronisation is likely a better choice than making it for them as its an important choice.