### PR TITLE
hlapi casting

### DIFF
--- a/tfhe/c_api_tests/test_high_level_256_bits.c
+++ b/tfhe/c_api_tests/test_high_level_256_bits.c
@@ -9,6 +9,7 @@ int uint256_client_key(const ClientKey *client_key) {
   FheUint256 *lhs = NULL;
   FheUint256 *rhs = NULL;
   FheUint256 *result = NULL;
+  FheUint64 *cast_result = NULL;
   U256 *lhs_clear = NULL;
   U256 *rhs_clear = NULL;
   U256 *result_clear = NULL;
@@ -39,12 +40,21 @@ int uint256_client_key(const ClientKey *client_key) {
   assert(w2 == 10);
   assert(w3 == 12);
 
+  // try some casting
+  ok = fhe_uint256_cast_into_fhe_uint64(result, &cast_result);
+  assert(ok == 0);
+  uint64_t u64_clear;
+  ok = fhe_uint64_decrypt(cast_result, client_key, &u64_clear);
+  assert(ok == 0);
+  assert(u64_clear == 6);
+
   u256_destroy(lhs_clear);
   u256_destroy(rhs_clear);
   u256_destroy(result_clear);
   fhe_uint256_destroy(lhs);
   fhe_uint256_destroy(rhs);
   fhe_uint256_destroy(result);
+  fhe_uint64_destroy(cast_result);
   return ok;
 }
 

--- a/tfhe/src/c_api/high_level_api/integers.rs
+++ b/tfhe/src/c_api/high_level_api/integers.rs
@@ -286,3 +286,34 @@ pub unsafe extern "C" fn fhe_uint256_decrypt(
         *result = Box::into_raw(Box::new(U256(inner)));
     })
 }
+
+macro_rules! define_casting_operation(
+    ($from:ty => $($to:ty),*) => {
+        $(
+            ::paste::paste!{
+                #[no_mangle]
+                pub unsafe extern "C" fn [<$from:snake _cast_into_ $to:snake>](
+                    sself: *const $from,
+                    result: *mut *mut $to,
+                    ) -> ::std::os::raw::c_int {
+                    $crate::c_api::utils::catch_panic(|| {
+                        let from = $crate::c_api::utils::get_ref_checked(sself).unwrap();
+
+                        let inner_to  = from.0.clone().cast_into();
+                        *result = Box::into_raw(Box::new($to(inner_to)));
+                    })
+                }
+            }
+        )*
+    }
+);
+
+define_casting_operation!(FheUint8 => FheUint8, FheUint10, FheUint14, FheUint16, FheUint32, FheUint64, FheUint128, FheUint256);
+define_casting_operation!(FheUint10 => FheUint8, FheUint10, FheUint14, FheUint16, FheUint32, FheUint64, FheUint128, FheUint256);
+define_casting_operation!(FheUint12 => FheUint8, FheUint10, FheUint14, FheUint16, FheUint32, FheUint64, FheUint128, FheUint256);
+define_casting_operation!(FheUint14 => FheUint8, FheUint10, FheUint14, FheUint16, FheUint32, FheUint64, FheUint128, FheUint256);
+define_casting_operation!(FheUint16 => FheUint8, FheUint10, FheUint14, FheUint16, FheUint32, FheUint64, FheUint128, FheUint256);
+define_casting_operation!(FheUint32 => FheUint8, FheUint10, FheUint14, FheUint16, FheUint32, FheUint64, FheUint128, FheUint256);
+define_casting_operation!(FheUint64 => FheUint8, FheUint10, FheUint14, FheUint16, FheUint32, FheUint64, FheUint128, FheUint256);
+define_casting_operation!(FheUint128 => FheUint8, FheUint10, FheUint14, FheUint16, FheUint32, FheUint64, FheUint128, FheUint256);
+define_casting_operation!(FheUint256 => FheUint8, FheUint10, FheUint14, FheUint16, FheUint32, FheUint64, FheUint128, FheUint256);


### PR DESCRIPTION
requires:
 - [x] #273 

This adds the casting of integer types.

Downcasting truncates blocks.
Upcasting appends 0s

Casting is done via the introduced `cast_from` associated
function and the `cast_into` method. They are the equivalent of
the `From` and `Into` traits.

It was not possible to implement casting by implementing the
standard `From` and `Into` traits as initially planned because:

```rust
impl<P1, P2> From<GenericInteger<P1>> for GenericInteger<P2>
where P1: IntegerParameter,
      P2: Integer Parameter, {
    fn from(_: GenericInteger<P1>) -> Self {
        todo!()
    }
}
```

As it conflicts the blanket impl found in the stdlib
`impl<T> From<T> for T;` as P1, P2 may be the same and we have no way
of telling the compiler to consider this impl only when P1 != P2.
So we had to create our own stuff