### PR TITLE
bench(multi-bit-pbs): hard set the number of threads to 10 for the multi-bit PBS

### DIFF
--- a/tfhe/benches/core_crypto/pbs_bench.rs
+++ b/tfhe/benches/core_crypto/pbs_bench.rs
@@ -400,7 +400,7 @@ fn multi_bit_pbs<Scalar: UnsignedTorus + CastInto<usize> + CastFrom<usize> + Syn
                     &mut out_pbs_ct,
                     &accumulator.as_view(),
                     &multi_bit_bsk,
-                    ThreadCount(num_cpus::get()),
+                    ThreadCount(10),
                 );
                 black_box(&mut out_pbs_ct);
             })


### PR DESCRIPTION
It's the optimal value measured on an m6i.metal instance where we run the benchmarks.
See: https://zama.grafana.net/d/a60a669c-5199-4e26-bcd6-8a69d7bc97e5/misc-panels-to-help-team?orgId=1&from=1683712319833&to=1683885119833&var-branch=ci%2Fbench_multi_bits&var-messagemodulus=All&var-hardware=m6i.metal