### PR TITLE
refactor(integer): improve decomposition/recomposition into blocks

### DIFF
--- a/tfhe/docs/integer/operations.md
+++ b/tfhe/docs/integer/operations.md
@@ -183,9 +183,9 @@ fn main() {
     let num_block = 4;
     let (client_key, server_key) = gen_keys_radix(PARAM_MESSAGE_2_CARRY_2, num_block);
 
-    let msg1 = 12;
-    let msg2 = 11;
-    let msg3 = 9;
+    let msg1 = 12u64;
+    let msg2 = 11u64;
+    let msg3 = 9u64;
     let scalar = 3;
 
     // message_modulus^vec_length
@@ -222,9 +222,9 @@ fn main() {
     let num_block = 4;
     let (client_key, server_key) = gen_keys_radix(PARAM_MESSAGE_2_CARRY_2, num_block);
 
-    let msg1 = 12;
-    let msg2 = 11;
-    let msg3 = 9;
+    let msg1 = 12u64;
+    let msg2 = 11u64;
+    let msg3 = 9u64;
     let scalar = 3;
 
     // message_modulus^vec_length

--- a/tfhe/src/high_level_api/integers/client_key.rs
+++ b/tfhe/src/high_level_api/integers/client_key.rs
@@ -1,31 +1,9 @@
 use super::server_key::RadixCiphertextDyn;
 use crate::high_level_api::internal_traits::DecryptionKey;
 
-impl DecryptionKey<RadixCiphertextDyn, u16> for crate::integer::ClientKey {
-    fn decrypt(&self, ciphertext: &RadixCiphertextDyn) -> u16 {
-        let clear: u64 = match ciphertext {
-            RadixCiphertextDyn::Big(ct) => self.decrypt_radix(ct),
-            RadixCiphertextDyn::Small(ct) => self.decrypt_radix(ct),
-        };
-
-        clear as u16
-    }
-}
-
-impl DecryptionKey<RadixCiphertextDyn, u32> for crate::integer::ClientKey {
-    fn decrypt(&self, ciphertext: &RadixCiphertextDyn) -> u32 {
-        let clear: u64 = match ciphertext {
-            RadixCiphertextDyn::Big(ct) => self.decrypt_radix(ct),
-            RadixCiphertextDyn::Small(ct) => self.decrypt_radix(ct),
-        };
-
-        clear as u32
-    }
-}
-
 impl<ClearType> DecryptionKey<RadixCiphertextDyn, ClearType> for crate::integer::ClientKey
 where
-    ClearType: crate::integer::encryption::AsLittleEndianWords + Default,
+    ClearType: Default + bytemuck::Pod,
 {
     fn decrypt(&self, ciphertext: &RadixCiphertextDyn) -> ClearType {
         match ciphertext {

--- a/tfhe/src/high_level_api/integers/types/base.rs
+++ b/tfhe/src/high_level_api/integers/types/base.rs
@@ -116,47 +116,8 @@ where
     }
 }
 
-impl<P> FheDecrypt<u8> for GenericInteger<P>
-where
-    P: IntegerParameter,
-    P::Id: RefKeyFromKeyChain<Key = crate::integer::ClientKey>,
-    crate::integer::ClientKey: DecryptionKey<RadixCiphertextDyn, u16>,
-{
-    fn decrypt(&self, key: &ClientKey) -> u8 {
-        let key = self.id.unwrapped_ref_key(key);
-        let value: u64 = key.decrypt(&self.ciphertext);
-        value as u8
-    }
-}
-
-impl<P> FheDecrypt<u16> for GenericInteger<P>
-where
-    P: IntegerParameter,
-    P::Id: RefKeyFromKeyChain<Key = crate::integer::ClientKey>,
-    crate::integer::ClientKey: DecryptionKey<RadixCiphertextDyn, u16>,
-{
-    fn decrypt(&self, key: &ClientKey) -> u16 {
-        let key = self.id.unwrapped_ref_key(key);
-        let value: u64 = key.decrypt(&self.ciphertext);
-        value as u16
-    }
-}
-
-impl<P> FheDecrypt<u32> for GenericInteger<P>
-where
-    P: IntegerParameter,
-    P::Id: RefKeyFromKeyChain<Key = crate::integer::ClientKey>,
-    crate::integer::ClientKey: DecryptionKey<RadixCiphertextDyn, u32>,
-{
-    fn decrypt(&self, key: &ClientKey) -> u32 {
-        let key = self.id.unwrapped_ref_key(key);
-        key.decrypt(&self.ciphertext)
-    }
-}
-
 impl<P, ClearType> FheDecrypt<ClearType> for GenericInteger<P>
 where
-    ClearType: crate::integer::encryption::AsLittleEndianWords,
     P: IntegerParameter,
     P::Id: RefKeyFromKeyChain<Key = crate::integer::ClientKey>,
     crate::integer::ClientKey: DecryptionKey<RadixCiphertextDyn, ClearType>,

--- a/tfhe/src/integer/block_decomposition.rs
+++ b/tfhe/src/integer/block_decomposition.rs
@@ -1,0 +1,543 @@
+/// BitBlockDecomposer
+///
+/// This struct allows to decompose the bytes of values of any type
+/// into sub blocks with the desired number of bits.
+///
+/// This will return None when all bytes of the input value
+/// have been decomposed.
+pub struct BitBlockDecomposer<T> {
+    byte_iterator: T,
+
+    // Buffer where we will copy bytes that are
+    // fetched from the source
+    block_buffer: u64,
+    // Used to track when we need to re-fetched
+    // bytes from the byte_iterator into the buffer
+    num_valid_bits: u32,
+
+    bits_per_block: u8,
+    bit_mask: u64,
+}
+
+impl<'a> BitBlockDecomposer<LittleEndianByteIter<'a>> {
+    pub fn new_little_endian<T: bytemuck::NoUninit>(value: &'a T, bits_per_block: u8) -> Self {
+        let a = LittleEndianByteIter::new(value);
+        Self::with_iter(a, bits_per_block)
+    }
+}
+
+impl<T> BitBlockDecomposer<T>
+where
+    T: Iterator<Item = u8>,
+{
+    pub fn with_iter(byte_iterator: T, bits_per_block: u8) -> Self {
+        assert!(bits_per_block < 64);
+        let bit_mask = (1 << bits_per_block as u64) - 1;
+        Self {
+            byte_iterator,
+            block_buffer: 0,
+            num_valid_bits: 0,
+            bits_per_block,
+            bit_mask,
+        }
+    }
+
+    // Fetch bytes from the source
+    fn fetch_bytes(&mut self) -> (u64, u32) {
+        let num_bytes_to_fetch = (self.bits_per_block as u32 / u8::BITS) + 1;
+
+        let mut output = 0;
+        let mut byte_count = 0u32;
+        while byte_count < num_bytes_to_fetch {
+            let Some(byte) = self.byte_iterator.next() else {
+                break;
+            };
+            output <<= u8::BITS;
+            output += byte as u64;
+            byte_count += 1;
+        }
+
+        (output, byte_count)
+    }
+}
+
+impl<T> Iterator for BitBlockDecomposer<T>
+where
+    T: Iterator<Item = u8>,
+{
+    type Item = u64;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.num_valid_bits < self.bits_per_block as u32 {
+            let (fetched, byte_count) = self.fetch_bytes();
+            if byte_count == 0 && self.num_valid_bits == 0 {
+                return None;
+            } else if byte_count == 0 && self.num_valid_bits != 0 {
+                // No more bytes to fetch from the source,
+                // however, we still have some data that can be returned
+                // before considering ourselves completely done
+                let diff = self.bits_per_block as u32 - self.num_valid_bits;
+                let ret = self.block_buffer & (self.bit_mask >> diff);
+                self.block_buffer >>= self.num_valid_bits as u64;
+                self.num_valid_bits = 0;
+                return Some(ret);
+            } else {
+                self.block_buffer += fetched << self.num_valid_bits;
+                self.num_valid_bits += byte_count * u8::BITS;
+            }
+        }
+
+        let ret = self.block_buffer & self.bit_mask;
+        self.block_buffer >>= self.bits_per_block as u64;
+        self.num_valid_bits -= self.bits_per_block as u32;
+
+        Some(ret)
+    }
+}
+
+/// BitBlockRecomposer
+///
+/// This struct allows to recompose the bytes of values of any type
+/// from sub blocks (generally acquired by using BitBlockDecomposer).
+///
+/// This will return None when all bytes of the output value
+/// have been recomposed.
+pub struct BitBlockRecomposer<T> {
+    dest: T,
+
+    // Buffer where we recompose bytes
+    // from input blocks before writing into
+    // the dest
+    block_buffer: u64,
+    // Used to track when we can write bytes
+    // from the block_buffer into the dest
+    num_valid_bits: u32,
+
+    bits_per_blocks: u8,
+    bit_mask: u64,
+}
+
+impl<'a> BitBlockRecomposer<LittleEndianByteIterMut<'a>> {
+    pub fn new_little_endian<T: bytemuck::Pod>(value: &'a mut T, bits_per_blocks: u8) -> Self {
+        let a = LittleEndianByteIterMut::new(value);
+        Self::with_iter(a, bits_per_blocks)
+    }
+}
+
+impl<'a, T> BitBlockRecomposer<T>
+where
+    T: Iterator<Item = &'a mut u8>,
+{
+    pub fn with_iter(dest: T, bits_per_blocks: u8) -> Self {
+        assert!(bits_per_blocks < 64);
+        let bit_mask = (1 << bits_per_blocks as u64) - 1;
+        Self {
+            dest,
+            block_buffer: 0,
+            num_valid_bits: 0,
+            bits_per_blocks,
+            bit_mask,
+        }
+    }
+
+    fn send_byte(&mut self, byte: u8) -> Option<()> {
+        let output_ref = self.dest.next()?;
+        *output_ref = byte;
+        Some(())
+    }
+
+    /// Takes into acocunt the block value without masking it,
+    /// meaning it will also take into account bits that are
+    /// above the expected number of bits per block.
+    ///
+    /// Useful to handle carry propagation while recomposing
+    pub fn write_block_unmasked(&mut self, mut block_value: u64) -> Option<()> {
+        block_value <<= self.num_valid_bits;
+        self.block_buffer += block_value;
+        self.num_valid_bits += self.bits_per_blocks as u32;
+
+        if self.num_valid_bits >= u8::BITS {
+            let byte = (self.block_buffer & u64::from(u8::MAX)) as u8;
+            self.send_byte(byte)?;
+            self.block_buffer >>= u8::BITS;
+            self.num_valid_bits -= u8::BITS;
+        }
+        Some(())
+    }
+
+    /// Takes into account only the bits that are
+    /// in the range of bits per block, others are ingnored
+    ///
+    /// Useful when you need to make sure any potention
+    /// carry in block_value are discarded
+    pub fn write_block(&mut self, block_value: u64) -> Option<()> {
+        self.write_block_unmasked(block_value & self.bit_mask)
+    }
+
+    // flushes the last valid bits into the destination
+    pub fn flush(&mut self) -> Option<()> {
+        debug_assert!(self.num_valid_bits < u8::BITS);
+        let mask = (1 << self.num_valid_bits) - 1;
+        let byte = (self.block_buffer & mask) as u8;
+        self.send_byte(byte)
+    }
+}
+
+/// Iterator over the bytes of any T in Little Endian Order
+///
+/// This iterator allows to iterate over the bytes of
+/// any type, in the Little Endian order
+#[derive(Debug)]
+pub struct LittleEndianByteIter<'a> {
+    current_ptr: *const u8,
+    end_ptr: *const u8,
+    _marker: std::marker::PhantomData<&'a ()>,
+}
+
+impl<'a> LittleEndianByteIter<'a> {
+    pub fn new<T: bytemuck::NoUninit>(value: &'a T) -> Self {
+        let bytes = bytemuck::bytes_of(value);
+        let std::ops::Range { start, end } = bytes.as_ptr_range();
+        #[cfg(target_endian = "little")]
+        {
+            // the end ptr we got from the range is one past the end
+            // which is what we want
+            Self {
+                current_ptr: start,
+                end_ptr: end,
+                _marker: Default::default(),
+            }
+        }
+        #[cfg(target_endian = "big")]
+        {
+            // In Big endian, we swap the end and start,
+            // and go back one  byte (as end it one past the end
+            // and we want it to point to actual last byte
+            // and start which becomes our end, has to be one before the beginning
+            let current_ptr = end.wrapping_sub(1);
+            let end_ptr = start.wrapping_sub(1);
+
+            Self {
+                current_ptr,
+                end_ptr,
+                _marker: Default::default(),
+            }
+        }
+    }
+
+    fn advance(&mut self) {
+        #[cfg(target_endian = "little")]
+        {
+            self.current_ptr = self.current_ptr.wrapping_add(1);
+        }
+        #[cfg(target_endian = "big")]
+        {
+            self.current_ptr = self.current_ptr.wrapping_sub(1);
+        }
+    }
+
+    fn is_current_ptr_valid(&self) -> bool {
+        #[cfg(target_endian = "little")]
+        {
+            self.current_ptr < self.end_ptr
+        }
+        #[cfg(target_endian = "big")]
+        {
+            self.current_ptr > self.end_ptr
+        }
+    }
+}
+
+impl<'a> Iterator for LittleEndianByteIter<'a> {
+    type Item = u8;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.is_current_ptr_valid() {
+            unsafe {
+                // SAFETY
+                // The constructor guarantees current_ptr is initialized
+                // within the allocated object bounds
+                //
+                // And end_ptr is guaranteed to be one byte past the
+                // end / beginning.
+                //
+                // So the check done above guarantees that current_ptr is
+                // still within the bounds of the allocated object
+                // and so is safe to deref
+                let value = *self.current_ptr;
+                self.advance();
+                Some(value)
+            }
+        } else {
+            None
+        }
+    }
+}
+
+impl<'a> std::iter::FusedIterator for LittleEndianByteIter<'a> {}
+
+/// Iterator over the mutable bytes of any T in Little Endian Order
+///
+/// This iterator allows to iterate over mutable ref to the bytes of
+/// any type, in the Little Endian order
+#[derive(Debug)]
+pub struct LittleEndianByteIterMut<'a> {
+    current_ptr: *mut u8,
+    end_ptr: *mut u8,
+    _marker: std::marker::PhantomData<&'a mut ()>,
+}
+
+impl<'a> LittleEndianByteIterMut<'a> {
+    pub fn new<T: bytemuck::Pod>(value: &'a mut T) -> Self {
+        // SAFETY
+        //
+        // The bytemuck::Pod trait bounds gives us the needed
+        // safety guarantees. e.g, T is guaranteed to have
+        // all bits pattern valid
+        unsafe { Self::new_unchecked(value) }
+    }
+
+    /// SAFETY
+    ///
+    /// Prefer the safe `Self::new`, which won't compile
+    /// if your type T is not valid to use here.
+    ///
+    /// You must make sure the value of bytes you are going
+    /// to modify do not violate any condition of the underlying type.
+    ///
+    /// In other words, with this it is possible set the bytes
+    /// to value / bit patterns that are not valid for the type T.
+    ///
+    ///
+    /// For example, with this is it is possible to set an already
+    /// constructed std::ptr::NonNull (so guarantees ptr is not null)
+    /// to null, violating its invariant.
+    ///
+    /// ```ignore
+    /// # fn main() {
+    /// let mut a = 32i32;
+    /// {
+    ///     let ptr = &mut a as *mut i32;
+    ///     assert!(!ptr.is_null());
+    ///     let mut non_null_ptr = std::ptr::NonNull::new(ptr).unwrap();
+    ///
+    ///     let iter = unsafe { LittleEndianByteIterMut::new_unchecked(&mut non_null_ptr) };
+    ///
+    ///     for byte in iter {
+    ///         *byte = 0;
+    ///     }
+    ///
+    ///     // We effectily made the non null ptr null
+    ///     let ptr = non_null_ptr.as_ptr();
+    ///     assert!(ptr.is_null());
+    ///     assert!(std::ptr::NonNull::new(ptr).is_none());
+    /// }
+    /// # }
+    /// ```
+    pub unsafe fn new_unchecked<T>(value: &'a mut T) -> Self {
+        let ptr = value as *mut T as *mut u8;
+        let num_bytes = std::mem::size_of::<T>();
+        #[cfg(target_endian = "little")]
+        {
+            let current_ptr = ptr;
+            let end_ptr = ptr.wrapping_add(num_bytes);
+
+            Self {
+                current_ptr,
+                end_ptr,
+                _marker: Default::default(),
+            }
+        }
+        #[cfg(target_endian = "big")]
+        {
+            let current_ptr = ptr.wrapping_add(num_bytes - 1);
+            let end_ptr = ptr.wrapping_sub(1);
+
+            Self {
+                current_ptr,
+                end_ptr,
+                _marker: Default::default(),
+            }
+        }
+    }
+
+    fn advance(&mut self) {
+        #[cfg(target_endian = "little")]
+        {
+            self.current_ptr = self.current_ptr.wrapping_add(1);
+        }
+        #[cfg(target_endian = "big")]
+        {
+            self.current_ptr = self.current_ptr.wrapping_sub(1);
+        }
+    }
+
+    fn is_current_ptr_valid(&self) -> bool {
+        #[cfg(target_endian = "little")]
+        {
+            self.current_ptr < self.end_ptr
+        }
+        #[cfg(target_endian = "big")]
+        {
+            self.current_ptr > self.end_ptr
+        }
+    }
+}
+
+impl<'a> Iterator for LittleEndianByteIterMut<'a> {
+    type Item = &'a mut u8;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.is_current_ptr_valid() {
+            unsafe {
+                // SAFETY
+                // The constructor guarantees current_ptr is initialized
+                // within the allocated object bounds
+                //
+                // And end_ptr is guaranteed to be one byte past the
+                // end / beginning.
+                //
+                // So the check done above guarantees that current_ptr is
+                // still within the bounds of the allocated object
+                // and so is safe to deref
+                let value = &mut *self.current_ptr;
+                self.advance();
+                Some(value)
+            }
+        } else {
+            None
+        }
+    }
+}
+
+impl<'a> std::iter::FusedIterator for LittleEndianByteIterMut<'a> {}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    #[test]
+    fn test_little_endian_byte_iter() {
+        let value = u16::MAX as u32;
+
+        let expected = value.to_le_bytes();
+        let got = LittleEndianByteIter::new(&value).collect::<Vec<_>>();
+        assert_eq!(got.as_slice(), expected.as_slice());
+    }
+
+    #[test]
+    fn test_little_endian_byte_iter_mut() {
+        let mut value = 0u32;
+        let num_bytes = std::mem::size_of::<u32>();
+
+        LittleEndianByteIterMut::new(&mut value)
+            .skip(num_bytes / 2)
+            .for_each(|byte| *byte = u8::MAX);
+
+        let expected = (u16::MAX as u32) << 16;
+
+        assert_eq!(value, expected);
+    }
+
+    #[test]
+    fn test_bit_block_decomposer() {
+        let value = u16::MAX as u32;
+        let bits_per_block = 2;
+        let blocks =
+            BitBlockDecomposer::new_little_endian(&value, bits_per_block as u8).collect::<Vec<_>>();
+        let expected_blocks = vec![3, 3, 3, 3, 3, 3, 3, 3, 0, 0, 0, 0, 0, 0, 0, 0];
+        assert_eq!(expected_blocks, blocks);
+    }
+
+    #[test]
+    fn test_bit_block_decomposer_recomposer_carry_handling_in_between() {
+        let value = u16::MAX as u32;
+        let bits_per_block = 2;
+        let mut blocks =
+            BitBlockDecomposer::new_little_endian(&value, bits_per_block).collect::<Vec<_>>();
+        let expected_blocks = vec![3, 3, 3, 3, 3, 3, 3, 3, 0, 0, 0, 0, 0, 0, 0, 0];
+        assert_eq!(expected_blocks, blocks);
+
+        // Now this block, which is not the last will have a 'carry'
+        blocks[0] += 2;
+
+        let mut output = 0u32;
+        let mut recomposer = BitBlockRecomposer::new_little_endian(&mut output, bits_per_block);
+        for block in blocks {
+            recomposer.write_block_unmasked(block);
+        }
+
+        assert_eq!(output, value + 2);
+    }
+
+    #[test]
+    fn test_bit_block_decomposer_zero_sized_type() {
+        let value = std::marker::PhantomData::<u8>::default();
+        assert_eq!(std::mem::size_of_val(&value), 0);
+
+        let mut iter = LittleEndianByteIter::new(&value);
+        assert!(iter.next().is_none()); // It must not be possible to even to 1 iter
+
+        let bits_per_block = 2;
+        let blocks =
+            BitBlockDecomposer::new_little_endian(&value, bits_per_block).collect::<Vec<_>>();
+        let expected_blocks: Vec<u64> = vec![];
+        assert_eq!(expected_blocks, blocks);
+    }
+
+    #[test]
+    fn test_bit_block_decomposer_round_trip_unsigned() {
+        for i in 0..u32::BITS {
+            let value = (u16::MAX as u32).rotate_left(i);
+            let bits_per_block = 2;
+            let blocks = BitBlockDecomposer::new_little_endian(&value, bits_per_block as u8)
+                .collect::<Vec<_>>();
+
+            let mut value_2 = 0u32;
+            let mut recomposer =
+                BitBlockRecomposer::new_little_endian(&mut value_2, bits_per_block as u8);
+            for block in blocks {
+                recomposer.write_block(block).unwrap();
+            }
+            assert_eq!(value_2, value);
+        }
+    }
+
+    #[test]
+    fn test_bit_block_decomposer_round_trip_signed() {
+        for i in 0..i32::BITS {
+            let value = (i16::MAX as i32).rotate_left(i);
+            let bits_per_block = 2;
+            let blocks = BitBlockDecomposer::new_little_endian(&value, bits_per_block as u8)
+                .collect::<Vec<_>>();
+
+            let mut value_2 = 0i32;
+            let mut recomposer =
+                BitBlockRecomposer::new_little_endian(&mut value_2, bits_per_block as u8);
+            for block in blocks {
+                recomposer.write_block(block).unwrap();
+            }
+            assert_eq!(value_2, value);
+        }
+    }
+
+    /// Test that when the bits per block is not a multiple of the number of bytes
+    /// we can decompose and recompose
+    #[test]
+    fn test_bit_block_decomposer_round_trip_non_multiple_bits_per_block() {
+        for i in 0..u32::BITS {
+            let value = (u16::MAX as u32).rotate_left(i);
+            let bits_per_block = 3;
+            let blocks = BitBlockDecomposer::new_little_endian(&value, bits_per_block as u8)
+                .collect::<Vec<_>>();
+
+            let mut value_2 = 0u32;
+            let mut recomposer =
+                BitBlockRecomposer::new_little_endian(&mut value_2, bits_per_block as u8);
+            for block in blocks {
+                recomposer.write_block(block).unwrap();
+            }
+            assert_eq!(value_2, value);
+        }
+    }
+}

--- a/tfhe/src/integer/client_key/radix.rs
+++ b/tfhe/src/integer/client_key/radix.rs
@@ -2,7 +2,6 @@
 
 use super::ClientKey;
 use crate::integer::ciphertext::RadixCiphertext;
-use crate::integer::encryption::AsLittleEndianWords;
 use crate::integer::{RadixCiphertextBig, RadixCiphertextSmall};
 use crate::shortint::{
     CiphertextBase, CiphertextBig as ShortintCiphertext, PBSOrderMarker,
@@ -54,17 +53,17 @@ impl RadixClientKey {
         }
     }
 
-    pub fn encrypt<T: AsLittleEndianWords>(&self, message: T) -> RadixCiphertextBig {
+    pub fn encrypt<T: bytemuck::Pod>(&self, message: T) -> RadixCiphertextBig {
         self.key.encrypt_radix(message, self.num_blocks)
     }
 
-    pub fn encrypt_small<T: AsLittleEndianWords>(&self, message: T) -> RadixCiphertextSmall {
+    pub fn encrypt_small<T: bytemuck::Pod>(&self, message: T) -> RadixCiphertextSmall {
         self.key.encrypt_radix_small(message, self.num_blocks)
     }
 
     pub fn decrypt<T, PBSOrder>(&self, ciphertext: &RadixCiphertext<PBSOrder>) -> T
     where
-        T: AsLittleEndianWords + Default,
+        T: Default + bytemuck::Pod,
         PBSOrder: PBSOrderMarker,
     {
         self.key.decrypt_radix(ciphertext)

--- a/tfhe/src/integer/encryption.rs
+++ b/tfhe/src/integer/encryption.rs
@@ -1,113 +1,5 @@
-use super::U256;
+use crate::integer::block_decomposition::BitBlockDecomposer;
 use crate::shortint::parameters::MessageModulus;
-
-pub trait AsLittleEndianWords {
-    type Iter<'a>: Iterator<Item = &'a u64>
-    where
-        Self: 'a;
-
-    type IterMut<'a>: Iterator<Item = &'a mut u64>
-    where
-        Self: 'a;
-
-    fn as_little_endian_iter(&self) -> Self::Iter<'_>;
-
-    fn as_little_endian_iter_mut(&mut self) -> Self::IterMut<'_>;
-}
-
-impl AsLittleEndianWords for u64 {
-    type Iter<'a> = std::slice::Iter<'a, u64>;
-
-    type IterMut<'a> = std::slice::IterMut<'a, u64>;
-
-    fn as_little_endian_iter(&self) -> Self::Iter<'_> {
-        let u64_slc = std::slice::from_ref(self);
-
-        u64_slc.iter()
-    }
-
-    fn as_little_endian_iter_mut(&mut self) -> Self::IterMut<'_> {
-        let u64_slc = std::slice::from_mut(self);
-
-        u64_slc.iter_mut()
-    }
-}
-
-#[cfg(target_endian = "little")]
-impl AsLittleEndianWords for u128 {
-    type Iter<'a> = std::slice::Iter<'a, u64>;
-
-    type IterMut<'a> = std::slice::IterMut<'a, u64>;
-
-    fn as_little_endian_iter(&self) -> Self::Iter<'_> {
-        let slc = std::slice::from_ref(self);
-
-        let u64_slc = unsafe { std::slice::from_raw_parts(slc.as_ptr() as *const u64, 2) };
-
-        u64_slc.iter()
-    }
-
-    fn as_little_endian_iter_mut(&mut self) -> Self::IterMut<'_> {
-        let slc = std::slice::from_mut(self);
-
-        let u64_slc = unsafe { std::slice::from_raw_parts_mut(slc.as_ptr() as *mut u64, 2) };
-
-        u64_slc.iter_mut()
-    }
-}
-
-#[cfg(target_endian = "big")]
-impl AsLittleEndianWords for u128 {
-    type Iter<'a> = core::iter::Rev<std::slice::Iter<'a, u64>>;
-
-    type IterMut<'a> = core::iter::Rev<std::slice::IterMut<'a, u64>>;
-
-    fn as_little_endian_iter(&self) -> Self::Iter<'_> {
-        let slc = std::slice::from_ref(self);
-
-        let u64_slc = unsafe { std::slice::from_raw_parts(slc.as_ptr() as *const u64, 2) };
-
-        u64_slc.iter().rev()
-    }
-
-    fn as_little_endian_iter_mut(&mut self) -> Self::IterMut<'_> {
-        let slc = std::slice::from_mut(self);
-
-        let u64_slc = unsafe { std::slice::from_raw_parts_mut(slc.as_ptr() as *mut u64, 2) };
-
-        u64_slc.iter_mut().rev()
-    }
-}
-
-#[cfg(target_endian = "little")]
-impl AsLittleEndianWords for U256 {
-    type Iter<'a> = std::slice::Iter<'a, u64>;
-
-    type IterMut<'a> = std::slice::IterMut<'a, u64>;
-
-    fn as_little_endian_iter(&self) -> Self::Iter<'_> {
-        self.0.as_slice().iter()
-    }
-
-    fn as_little_endian_iter_mut(&mut self) -> Self::IterMut<'_> {
-        self.0.as_mut_slice().iter_mut()
-    }
-}
-
-#[cfg(target_endian = "big")]
-impl AsLittleEndianWords for U256 {
-    type Iter<'a> = core::iter::Rev<std::slice::Iter<'a, u64>>;
-
-    type IterMut<'a> = core::iter::Rev<std::slice::IterMut<'a, u64>>;
-
-    fn as_little_endian_iter(&self) -> Self::Iter<'_> {
-        self.0.as_slice().iter().rev()
-    }
-
-    fn as_little_endian_iter_mut(&mut self) -> Self::IterMut<'_> {
-        self.0.as_mut_slice().iter_mut().rev()
-    }
-}
 
 pub(crate) trait KnowsMessageModulus {
     fn message_modulus(&self) -> MessageModulus;
@@ -143,85 +35,30 @@ impl KnowsMessageModulus for crate::shortint::ServerKey {
 
 /// Encrypts an arbitrary sized number under radix decomposition
 ///
-/// This function encrypts a number represented as a slice of 64bits words
-/// into an integer ciphertext in radix decomposition
-///
 /// - Each block in encrypted under the same `encrypting_key`.
-/// - `message_words` is expected to be in the current machine byte order.
 /// - `num_block` is the number of radix block the final ciphertext will have.
-pub(crate) fn encrypt_words_radix_impl<BlockKey, Block, RadixCiphertextType, T, F>(
+pub(crate) fn encrypt_radix_impl<BlockKey, Block, RadixCiphertextType, T, F>(
     encrypting_key: &BlockKey,
-    message_words: T,
+    message: T,
     num_blocks: usize,
     encrypt_block: F,
 ) -> RadixCiphertextType
 where
-    T: AsLittleEndianWords,
+    T: bytemuck::Pod,
     BlockKey: KnowsMessageModulus,
     F: Fn(&BlockKey, u64) -> Block,
     RadixCiphertextType: From<Vec<Block>>,
 {
-    // General idea:
-    // Use as a bit buffer, and "cursors" to track the start of next block of bits to encrypt
-    // and until which bit the bits are valid / not garbage.
-    // e.g:
-    // source: [b0, b1, ..., b64, b65..., b128]
-    //              ^             ^
-    //              |             |-> valid_until_power (starting from this bit,
-    //              |                 bit values are not valid and should not be encrypted)
-    //              |-> current_power (start of next block of bits to encrypt (inclusive))
-
-    let mask = (encrypting_key.message_modulus().0 - 1) as u128;
-    let block_modulus = encrypting_key.message_modulus().0 as u128;
+    let message_modulus = encrypting_key.message_modulus().0 as u64;
+    assert!(message_modulus.is_power_of_two());
+    let bits_in_message = message_modulus.ilog2();
+    let mut decomposer = BitBlockDecomposer::new_little_endian(&message, bits_in_message as u8);
 
     let mut blocks = Vec::with_capacity(num_blocks);
-
-    let mut message_block_iter = message_words.as_little_endian_iter().copied();
-
-    let mut bit_buffer = 0u128; // stores the bits of the word to be encrypted in one of the iteration
-    let mut valid_until_power = 1; // 2^0 = 1, start with nothing valid
-    let mut current_power = 1; // where the next bits to encrypt starts
     for _ in 0..num_blocks {
-        if (current_power * block_modulus) >= valid_until_power {
-            // We are going to encrypt bits that are not valid.
-            // e.g:
-            // source: [b0, ..., b63, b64, b65, b66, b67,..., b128]
-            //                   ^         ^          ^
-            //                   |         |          |-> (current_power * block_modulus)
-            //                   |         |              = end of bits to encrypt (not inclusive)
-            //                   |         |-> valid_until_power
-            //                   |             (starting from this bit, bit values are not valid)
-            //                   |-> current_power = start of next block of bits to encrypt
-
-            // 1: shift (remove) bits we know we have already encrypted
-            // source: [b0, b1, b2, b3, b4,..., b128]
-            //          ^       ^       ^
-            //          |       |       |->  (current_power * block_modulus)
-            //          |       |-> valid_until_power
-            //          |-> current_power
-            bit_buffer /= current_power;
-            valid_until_power /= current_power;
-            current_power = 1;
-
-            // 2: Append next word (or zero) to the source
-            // source: [b0, b1, b2, b3, b4,..., b67, b128]
-            //          ^               ^        ^
-            //          |               |        |-> valid_until_power
-            //          |               |-> (current_power * block_modulus)
-            //          |-> current_power
-            bit_buffer += message_block_iter
-                .next()
-                .map(u128::from)
-                .unwrap_or_default()
-                * valid_until_power;
-            valid_until_power <<= 64;
-        }
-
-        let block_value = (bit_buffer & (mask * current_power)) / current_power;
-        let ct = encrypt_block(encrypting_key, block_value as u64);
-        blocks.push(ct);
-
-        current_power *= block_modulus;
+        let clear_block_value = decomposer.next().unwrap_or(0);
+        let encrypted_block = encrypt_block(encrypting_key, clear_block_value);
+        blocks.push(encrypted_block);
     }
 
     RadixCiphertextType::from(blocks)

--- a/tfhe/src/integer/mod.rs
+++ b/tfhe/src/integer/mod.rs
@@ -50,6 +50,7 @@ extern crate core;
 #[cfg(test)]
 #[macro_use]
 mod tests;
+pub(crate) mod block_decomposition;
 pub(crate) mod encryption;
 
 pub mod ciphertext;

--- a/tfhe/src/integer/public_key/compressed.rs
+++ b/tfhe/src/integer/public_key/compressed.rs
@@ -1,6 +1,6 @@
 use crate::integer::ciphertext::{CrtCiphertext, RadixCiphertext};
 use crate::integer::client_key::ClientKey;
-use crate::integer::encryption::{encrypt_crt, encrypt_words_radix_impl, AsLittleEndianWords};
+use crate::integer::encryption::{encrypt_crt, encrypt_radix_impl};
 use crate::shortint::ciphertext::{BootstrapKeyswitch, KeyswitchBootstrap};
 use crate::shortint::parameters::MessageModulus;
 use crate::shortint::PBSOrderMarker;
@@ -71,7 +71,7 @@ impl<OpOrder: PBSOrderMarker> CompressedPublicKeyBase<OpOrder> {
         self.key.parameters.pbs_parameters().unwrap()
     }
 
-    pub fn encrypt_radix<T: AsLittleEndianWords>(
+    pub fn encrypt_radix<T: bytemuck::Pod>(
         &self,
         message: T,
         num_blocks: usize,
@@ -102,10 +102,10 @@ impl<OpOrder: PBSOrderMarker> CompressedPublicKeyBase<OpOrder> {
         encrypt_block: F,
     ) -> RadixCiphertextType
     where
-        T: AsLittleEndianWords,
+        T: bytemuck::Pod,
         F: Fn(&crate::shortint::CompressedPublicKeyBase<OpOrder>, u64) -> Block,
         RadixCiphertextType: From<Vec<Block>>,
     {
-        encrypt_words_radix_impl(&self.key, message_words, num_blocks, encrypt_block)
+        encrypt_radix_impl(&self.key, message_words, num_blocks, encrypt_block)
     }
 }

--- a/tfhe/src/integer/public_key/standard.rs
+++ b/tfhe/src/integer/public_key/standard.rs
@@ -1,6 +1,6 @@
 use crate::integer::ciphertext::{CrtCiphertext, RadixCiphertext};
 use crate::integer::client_key::ClientKey;
-use crate::integer::encryption::{encrypt_crt, encrypt_words_radix_impl, AsLittleEndianWords};
+use crate::integer::encryption::{encrypt_crt, encrypt_radix_impl};
 use crate::shortint::ciphertext::{BootstrapKeyswitch, KeyswitchBootstrap};
 use crate::shortint::parameters::MessageModulus;
 use crate::shortint::{PBSOrderMarker, PublicKeyBase};
@@ -67,7 +67,7 @@ impl<PBSOrder: PBSOrderMarker> PublicKey<PBSOrder> {
         self.key.parameters.pbs_parameters().unwrap()
     }
 
-    pub fn encrypt_radix<T: AsLittleEndianWords>(
+    pub fn encrypt_radix<T: bytemuck::Pod>(
         &self,
         message: T,
         num_blocks: usize,
@@ -90,10 +90,10 @@ impl<PBSOrder: PBSOrderMarker> PublicKey<PBSOrder> {
         encrypt_block: F,
     ) -> RadixCiphertextType
     where
-        T: AsLittleEndianWords,
+        T: bytemuck::Pod,
         F: Fn(&PublicKeyBase<PBSOrder>, u64) -> Block,
         RadixCiphertextType: From<Vec<Block>>,
     {
-        encrypt_words_radix_impl(&self.key, message_words, num_blocks, encrypt_block)
+        encrypt_radix_impl(&self.key, message_words, num_blocks, encrypt_block)
     }
 }

--- a/tfhe/src/integer/server_key/radix/mod.rs
+++ b/tfhe/src/integer/server_key/radix/mod.rs
@@ -12,7 +12,7 @@ mod sub;
 use super::ServerKey;
 
 use crate::integer::ciphertext::RadixCiphertext;
-use crate::integer::encryption::{encrypt_words_radix_impl, AsLittleEndianWords};
+use crate::integer::encryption::encrypt_radix_impl;
 use crate::shortint::PBSOrderMarker;
 
 #[cfg(test)]
@@ -77,10 +77,10 @@ impl ServerKey {
         num_blocks: usize,
     ) -> RadixCiphertext<PBSOrder>
     where
+        T: bytemuck::Pod,
         PBSOrder: PBSOrderMarker,
-        T: AsLittleEndianWords,
     {
-        encrypt_words_radix_impl(
+        encrypt_radix_impl(
             &self.key,
             value,
             num_blocks,

--- a/tfhe/src/integer/u256.rs
+++ b/tfhe/src/integer/u256.rs
@@ -7,7 +7,23 @@ pub const fn adc(l: u64, r: u64, c: bool) -> (u64, bool) {
 
 // Little endian order
 #[derive(Default, Copy, Clone, Debug, PartialEq, Eq)]
+#[repr(transparent)]
 pub struct U256(pub(crate) [u64; 4]);
+
+// SAFETY
+//
+// U256 is allowed to be all zeros
+unsafe impl bytemuck::Zeroable for U256 {}
+
+// SAFETY
+//
+// u64 impl bytemuck::Pod,
+// [T; N] impl bytemuck::Pod if T: bytemuck::Pod
+//
+// https://docs.rs/bytemuck/latest/bytemuck/trait.Pod.html#foreign-impls
+//
+// Thus U256 can safely be considered Pod
+unsafe impl bytemuck::Pod for U256 {}
 
 impl U256 {
     pub const BITS: u32 = 256;


### PR DESCRIPTION
This refactors the code that decompose / recompose an integer into smaller blocks.

This new implementation should hopefully be a little bit easier to understand.

But more importantly it is more general/generic,
the previous implementation required the input type to be able to be described as u64 words, the new one works for any type as it directly iterates over the bytes which also makes the big-endian support easier. And allows to natively support types smaller than u64.

Also the new implementation is separted from the encryption code meaning it will be usable by scalar operation, which will allow us to deduplicate code and start making scalar ops support scalar values that are on more than 64-bits.