### PR TITLE
feat(hlapi): add CompressedServerKey

### DIFF
--- a/tfhe/src/high_level_api/booleans/mod.rs
+++ b/tfhe/src/high_level_api/booleans/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) use keys::{
-    BooleanClientKey, BooleanCompressedPublicKey, BooleanConfig, BooleanPublicKey, BooleanServerKey,
+    BooleanClientKey, BooleanCompressedPublicKey, BooleanCompressedServerKey, BooleanConfig,
+    BooleanPublicKey, BooleanServerKey,
 };
 pub use parameters::FheBoolParameters;
 pub use types::{CompressedFheBool, FheBool, GenericBool};

--- a/tfhe/src/high_level_api/booleans/server_key.rs
+++ b/tfhe/src/high_level_api/booleans/server_key.rs
@@ -1,7 +1,7 @@
 use super::client_key::GenericBoolClientKey;
 use super::parameters::BooleanParameterSet;
 use super::types::GenericBool;
-use crate::boolean::server_key::{BinaryBooleanGates, ServerKey};
+use crate::boolean::server_key::{BinaryBooleanGates, CompressedServerKey, ServerKey};
 
 #[cfg_attr(all(doc, not(doctest)), cfg(feature = "boolean"))]
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
@@ -87,5 +87,34 @@ where
             &else_result.ciphertext,
         );
         GenericBool::<P>::new(ciphertext, condition.id)
+    }
+}
+
+#[cfg_attr(all(doc, not(doctest)), cfg(feature = "boolean"))]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
+pub struct GenericBoolCompressedServerKey<P>
+where
+    P: BooleanParameterSet,
+{
+    pub(in crate::high_level_api::booleans) key: CompressedServerKey,
+    _marker: std::marker::PhantomData<P>,
+}
+
+impl<P> GenericBoolCompressedServerKey<P>
+where
+    P: BooleanParameterSet,
+{
+    pub(in crate::high_level_api::booleans) fn new(client_key: &GenericBoolClientKey<P>) -> Self {
+        Self {
+            key: CompressedServerKey::new(&client_key.key),
+            _marker: Default::default(),
+        }
+    }
+
+    pub(in crate::high_level_api::booleans) fn decompress(self) -> GenericBoolServerKey<P> {
+        GenericBoolServerKey {
+            key: self.key.into(),
+            _marker: std::marker::PhantomData,
+        }
     }
 }

--- a/tfhe/src/high_level_api/booleans/types/static_.rs
+++ b/tfhe/src/high_level_api/booleans/types/static_.rs
@@ -3,9 +3,11 @@ use serde::{Deserialize, Serialize};
 
 use crate::high_level_api::booleans::client_key::GenericBoolClientKey;
 use crate::high_level_api::booleans::parameters::BooleanParameterSet;
-pub use crate::high_level_api::booleans::parameters::FheBoolParameters;
+pub(crate) use crate::high_level_api::booleans::parameters::FheBoolParameters;
 use crate::high_level_api::booleans::public_key::GenericBoolPublicKey;
-use crate::high_level_api::booleans::server_key::GenericBoolServerKey;
+use crate::high_level_api::booleans::server_key::{
+    GenericBoolCompressedServerKey, GenericBoolServerKey,
+};
 use crate::high_level_api::booleans::types::CompressedBool;
 use crate::high_level_api::errors::Type;
 
@@ -57,6 +59,8 @@ pub(in crate::high_level_api::booleans) type FheBoolServerKey =
     GenericBoolServerKey<StaticBoolParameters>;
 pub(in crate::high_level_api::booleans) type FheBoolPublicKey =
     GenericBoolPublicKey<StaticBoolParameters>;
+pub(in crate::high_level_api::booleans) type FheBoolCompressedServerKey =
+    GenericBoolCompressedServerKey<StaticBoolParameters>;
 
 #[derive(Clone, Debug, ::serde::Deserialize, ::serde::Serialize)]
 pub(in crate::high_level_api::booleans) struct FheBoolCompressedPublicKey;

--- a/tfhe/src/high_level_api/details.rs
+++ b/tfhe/src/high_level_api/details.rs
@@ -16,7 +16,8 @@ macro_rules! define_key_structs {
                     [<$base_ty_name ClientKey>],
                     [<$base_ty_name PublicKey>],
                     [<$base_ty_name CompressedPublicKey>],
-                    [<$base_ty_name ServerKey>]
+                    [<$base_ty_name ServerKey>],
+                    [<$base_ty_name CompressedServerKey>],
                 };
             )*
 
@@ -145,6 +146,45 @@ macro_rules! define_key_structs {
                     }
                 }
             }
+
+            /////////////////////////
+            // Compressed Server Key
+            /////////////////////////
+            #[derive(Clone, ::serde::Deserialize, ::serde::Serialize)]
+            pub(crate) struct [<$base_struct_name CompressedServerKey>] {
+                $(
+                    pub(super) [<$name _key>]: Option<[<$base_ty_name CompressedServerKey>]>,
+                )*
+            }
+
+            impl [<$base_struct_name CompressedServerKey>] {
+                pub(crate) fn new(client_key: &[<$base_struct_name ClientKey>]) -> Self {
+                    Self {
+                        $(
+                            [<$name _key>]: client_key.[<$name _key>].as_ref().map(<[<$base_ty_name CompressedServerKey>]>::new),
+                        )*
+                    }
+                }
+
+                pub(crate) fn decompress(self) -> [<$base_struct_name ServerKey>] {
+                    [<$base_struct_name ServerKey>] {
+                        $(
+                            [<$name _key>]: self.[<$name _key>].map(|compressed_key| compressed_key.decompress()),
+                        )*
+                    }
+                }
+            }
+
+            impl Default for [<$base_struct_name CompressedServerKey>] {
+                fn default() -> Self {
+                    Self {
+                        $(
+                            [<$name _key>]: None,
+                        )*
+                    }
+                }
+            }
+
         }
     }
 }

--- a/tfhe/src/high_level_api/integers/mod.rs
+++ b/tfhe/src/high_level_api/integers/mod.rs
@@ -5,7 +5,9 @@ pub use types::{
     FheUint32, FheUint64, FheUint8, GenericInteger,
 };
 
-pub(in crate::high_level_api) use keys::{IntegerClientKey, IntegerConfig, IntegerServerKey};
+pub(in crate::high_level_api) use keys::{
+    IntegerClientKey, IntegerCompressedServerKey, IntegerConfig, IntegerServerKey,
+};
 pub(in crate::high_level_api) use public_key::compressed::CompressedPublicKeyDyn;
 pub(in crate::high_level_api) use public_key::PublicKeyDyn;
 

--- a/tfhe/src/high_level_api/keys/client.rs
+++ b/tfhe/src/high_level_api/keys/client.rs
@@ -11,7 +11,7 @@ use crate::high_level_api::integers::IntegerClientKey;
 #[cfg(feature = "shortint")]
 use crate::high_level_api::shortints::ShortIntClientKey;
 
-use super::ServerKey;
+use super::{CompressedServerKey, ServerKey};
 
 /// Key of the client
 ///
@@ -44,12 +44,17 @@ impl ClientKey {
         }
     }
 
-    /// Generates a new ServerKeyChain
+    /// Generates a new ServerKey
     ///
-    /// The `ServerKeyChain` generated is meant to be used to initialize the global state
+    /// The `ServerKey` generated is meant to be used to initialize the global state
     /// using [crate::high_level_api::set_server_key].
     pub fn generate_server_key(&self) -> ServerKey {
         ServerKey::new(self)
+    }
+
+    /// Generates a new CompressedServerKey
+    pub fn generate_compressed_server_key(&self) -> CompressedServerKey {
+        CompressedServerKey::new(self)
     }
 }
 

--- a/tfhe/src/high_level_api/keys/mod.rs
+++ b/tfhe/src/high_level_api/keys/mod.rs
@@ -9,7 +9,7 @@ pub use client::{ClientKey, RefKeyFromKeyChain};
 pub use public::{
     CompressedPublicKey, PublicKey, RefKeyFromCompressedPublicKeyChain, RefKeyFromPublicKeyChain,
 };
-pub use server::ServerKey;
+pub use server::{CompressedServerKey, ServerKey};
 
 /// Generates keys using the provided config.
 ///

--- a/tfhe/src/high_level_api/mod.rs
+++ b/tfhe/src/high_level_api/mod.rs
@@ -2,7 +2,9 @@
 pub use config::{Config, ConfigBuilder};
 pub use errors::{Error, OutOfRangeError};
 pub use global_state::{set_server_key, unset_server_key, with_server_key_as_context};
-pub use keys::{generate_keys, ClientKey, CompressedPublicKey, PublicKey, ServerKey};
+pub use keys::{
+    generate_keys, ClientKey, CompressedPublicKey, CompressedServerKey, PublicKey, ServerKey,
+};
 
 #[cfg(test)]
 mod tests;

--- a/tfhe/src/high_level_api/shortints/mod.rs
+++ b/tfhe/src/high_level_api/shortints/mod.rs
@@ -1,6 +1,6 @@
 pub(crate) use keys::{
-    ShortIntClientKey, ShortIntCompressedPublicKey, ShortIntConfig, ShortIntPublicKey,
-    ShortIntServerKey,
+    ShortIntClientKey, ShortIntCompressedPublicKey, ShortIntCompressedServerKey, ShortIntConfig,
+    ShortIntPublicKey, ShortIntServerKey,
 };
 pub use types::{
     CompressedFheUint2, CompressedFheUint3, CompressedFheUint4, CompressedGenericShortint,

--- a/tfhe/src/high_level_api/shortints/server_key.rs
+++ b/tfhe/src/high_level_api/shortints/server_key.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "internal-keycache")]
 use crate::shortint::keycache::KEY_CACHE;
-use crate::shortint::ServerKey;
+use crate::shortint::{CompressedServerKey, ServerKey};
 
 use super::client_key::GenericShortIntClientKey;
 use super::parameters::ShortIntegerParameter;
@@ -434,6 +434,37 @@ where
         GenericShortInt {
             ciphertext: RefCell::new(ciphertext),
             id: lhs_ct.id,
+        }
+    }
+}
+
+#[cfg_attr(all(doc, not(doctest)), cfg(feature = "boolean"))]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
+pub struct GenericShortIntCompressedServerKey<P>
+where
+    P: ShortIntegerParameter,
+{
+    pub(in crate::high_level_api::shortints) key: CompressedServerKey,
+    _marker: std::marker::PhantomData<P>,
+}
+
+impl<P> GenericShortIntCompressedServerKey<P>
+where
+    P: ShortIntegerParameter,
+{
+    pub(in crate::high_level_api::shortints) fn new(
+        client_key: &GenericShortIntClientKey<P>,
+    ) -> Self {
+        Self {
+            key: CompressedServerKey::new(&client_key.key),
+            _marker: Default::default(),
+        }
+    }
+
+    pub(in crate::high_level_api::shortints) fn decompress(self) -> GenericShortIntServerKey<P> {
+        GenericShortIntServerKey {
+            key: self.key.into(),
+            _marker: std::marker::PhantomData,
         }
     }
 }

--- a/tfhe/src/high_level_api/shortints/types/mod.rs
+++ b/tfhe/src/high_level_api/shortints/types/mod.rs
@@ -9,7 +9,7 @@ pub use static_::{
 use super::client_key::GenericShortIntClientKey;
 use super::public_key::compressed::GenericShortIntCompressedPublicKey;
 use super::public_key::GenericShortIntPublicKey;
-use super::server_key::GenericShortIntServerKey;
+use super::server_key::{GenericShortIntCompressedServerKey, GenericShortIntServerKey};
 
 mod base;
 mod compressed;

--- a/tfhe/src/high_level_api/shortints/types/static_.rs
+++ b/tfhe/src/high_level_api/shortints/types/static_.rs
@@ -10,8 +10,8 @@ use crate::shortint::parameters::{
 use crate::high_level_api::shortints::{CompressedGenericShortint, GenericShortInt};
 
 use super::{
-    GenericShortIntClientKey, GenericShortIntCompressedPublicKey, GenericShortIntPublicKey,
-    GenericShortIntServerKey,
+    GenericShortIntClientKey, GenericShortIntCompressedPublicKey,
+    GenericShortIntCompressedServerKey, GenericShortIntPublicKey, GenericShortIntServerKey,
 };
 
 use crate::high_level_api::shortints::parameters::{
@@ -160,6 +160,7 @@ macro_rules! static_shortint_type {
             pub(in crate::high_level_api) type [<$name PublicKey>] = GenericShortIntPublicKey<[<$name Parameters>]>;
             pub(in crate::high_level_api) type [<$name CompressedPublicKey>] = GenericShortIntCompressedPublicKey<[<$name Parameters>]>;
             pub(in crate::high_level_api) type [<$name ServerKey>] = GenericShortIntServerKey<[<$name Parameters>]>;
+            pub(in crate::high_level_api) type [<$name CompressedServerKey>] = GenericShortIntCompressedServerKey<[<$name Parameters>]>;
 
             $(#[$outer])*
             #[doc=concat!("An unsigned integer type with ", stringify!($num_bits), " bits.")]

--- a/tfhe/src/integer/mod.rs
+++ b/tfhe/src/integer/mod.rs
@@ -70,7 +70,7 @@ pub use client_key::{ClientKey, CrtClientKey, RadixClientKey};
 pub use public_key::{
     CompressedPublicKeyBig, CompressedPublicKeySmall, PublicKeyBig, PublicKeySmall,
 };
-pub use server_key::{CheckError, ServerKey};
+pub use server_key::{CheckError, CompressedServerKey, ServerKey};
 pub use u256::U256;
 
 /// Generate a couple of client and server keys with given parameters

--- a/tfhe/src/integer/server_key/mod.rs
+++ b/tfhe/src/integer/server_key/mod.rs
@@ -92,6 +92,7 @@ impl ServerKey {
     }
 }
 
+#[derive(Clone, Serialize, Deserialize)]
 pub struct CompressedServerKey {
     pub(crate) key: crate::shortint::CompressedServerKey,
 }


### PR DESCRIPTION
Now that WopPBS key are optional in the hlapi
we can have a CompressedServerKey.
If a user tries to create a CompressedServerKey
but has enabled function evaluation on integers
(WopPBS) then it will panic as WopPBS are not yet compressible. And 'stuffing' the non-compressed wopbs-key in the compressed server key, would defeat the purpose of compressed server key, as WopPBS key makes of for
the vast majority of the space used.

Also having CompressedServerKey is required to
be able to have wasm API of the hlapi
as wasm cannot generate normal server key.