### PR TITLE
refactor(integer): improve decomposition/recomposition into blocks

### DIFF
--- a/tfhe/src/high_level_api/integers/client_key.rs
+++ b/tfhe/src/high_level_api/integers/client_key.rs
@@ -1,31 +1,9 @@
 use super::server_key::RadixCiphertextDyn;
 use crate::high_level_api::internal_traits::DecryptionKey;
 
-impl DecryptionKey<RadixCiphertextDyn, u16> for crate::integer::ClientKey {
-    fn decrypt(&self, ciphertext: &RadixCiphertextDyn) -> u16 {
-        let clear: u64 = match ciphertext {
-            RadixCiphertextDyn::Big(ct) => self.decrypt_radix(ct),
-            RadixCiphertextDyn::Small(ct) => self.decrypt_radix(ct),
-        };
-
-        clear as u16
-    }
-}
-
-impl DecryptionKey<RadixCiphertextDyn, u32> for crate::integer::ClientKey {
-    fn decrypt(&self, ciphertext: &RadixCiphertextDyn) -> u32 {
-        let clear: u64 = match ciphertext {
-            RadixCiphertextDyn::Big(ct) => self.decrypt_radix(ct),
-            RadixCiphertextDyn::Small(ct) => self.decrypt_radix(ct),
-        };
-
-        clear as u32
-    }
-}
-
 impl<ClearType> DecryptionKey<RadixCiphertextDyn, ClearType> for crate::integer::ClientKey
 where
-    ClearType: crate::integer::encryption::AsLittleEndianWords + Default,
+    ClearType: crate::integer::block_decomposition::RecomposableFrom<u64>,
 {
     fn decrypt(&self, ciphertext: &RadixCiphertextDyn) -> ClearType {
         match ciphertext {

--- a/tfhe/src/integer/block_decomposition.rs
+++ b/tfhe/src/integer/block_decomposition.rs
@@ -1,0 +1,349 @@
+use core::ops::{AddAssign, BitAnd, ShlAssign, ShrAssign};
+use std::ops::{Shl, Sub};
+
+use crate::core_crypto::prelude::{CastFrom, CastInto, Numeric};
+use crate::integer::U256;
+
+// These work for signed number as rust uses 2-Complements
+// And Arithmetic shift for signed number (logical for unsigned)
+// https://doc.rust-lang.org/reference/expressions/operator-expr.html#arithmetic-and-logical-binary-operators
+
+pub trait Decomposable:
+    Numeric + BitAnd<Self, Output = Self> + ShrAssign<u32> + Eq + CastFrom<u32>
+{
+}
+pub trait Recomposable:
+    Numeric
+    + ShlAssign<u32>
+    + AddAssign<Self>
+    + CastFrom<u32>
+    + BitAnd<Self, Output = Self>
+    + Shl<u32, Output = Self>
+    + Sub<Self, Output = Self>
+{
+}
+
+// Convenience traits have simpler bounds
+pub trait RecomposableFrom<T>: Recomposable + CastFrom<T> {}
+pub trait DecomposableInto<T>: Decomposable + CastInto<T> {}
+
+pub struct BlockDecomposer<T> {
+    data: T,
+    bit_mask: T,
+    num_bits_in_mask: u32,
+    num_bits_valid: u32,
+    limit: Option<T>,
+}
+
+macro_rules! impl_recomposable_decomposable {
+    (
+        $($type:ty),* $(,)?
+    ) => {
+        $(
+            impl Decomposable for $type { }
+            impl Recomposable for $type { }
+            impl RecomposableFrom<u64> for $type { }
+            impl DecomposableInto<u64> for $type { }
+        )*
+
+    };
+}
+
+impl_recomposable_decomposable!(u8, u16, u32, u64, u128, U256, i8, i16, i32, i64, i128);
+
+impl<T> BlockDecomposer<T>
+where
+    T: Decomposable,
+{
+    pub fn with_early_stop_at_zero(value: T, bits_per_block: u32) -> Self {
+        Self::new_(value, bits_per_block, Some(T::ZERO))
+    }
+
+    pub fn new(value: T, bits_per_block: u32) -> Self {
+        Self::new_(value, bits_per_block, None)
+    }
+
+    fn new_(value: T, bits_per_block: u32, limit: Option<T>) -> Self {
+        assert!(bits_per_block <= T::BITS as u32);
+        let num_bits_valid = T::BITS as u32;
+
+        let num_bits_in_mask = bits_per_block;
+        let bit_mask = 1_u32.checked_shl(bits_per_block).unwrap() - 1;
+        let bit_mask = T::cast_from(bit_mask);
+
+        Self {
+            data: value,
+            bit_mask,
+            num_bits_in_mask,
+            num_bits_valid,
+            limit,
+        }
+    }
+}
+
+impl<T> Iterator for BlockDecomposer<T>
+where
+    T: Decomposable,
+{
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.num_bits_valid == 0 {
+            return None;
+        }
+
+        if self.limit.map(|limit| limit == self.data).unwrap_or(false) {
+            return None;
+        }
+
+        let masked = self.data & self.bit_mask;
+        self.data >>= self.num_bits_in_mask;
+        self.num_bits_valid = self.num_bits_valid.saturating_sub(self.num_bits_in_mask);
+
+        Some(masked)
+    }
+}
+
+impl<T> BlockDecomposer<T>
+where
+    T: Decomposable,
+{
+    pub fn iter_as<V>(self) -> impl Iterator<Item = V>
+    where
+        T: CastInto<V>,
+    {
+        self.map(|masked| masked.cast_into())
+    }
+
+    pub fn next_as<V>(&mut self) -> Option<V>
+    where
+        V: CastFrom<T>,
+    {
+        self.next().map(|masked| V::cast_from(masked))
+    }
+
+    pub fn checked_next_as<V>(&mut self) -> Option<V>
+    where
+        V: TryFrom<T>,
+    {
+        self.next().and_then(|masked| V::try_from(masked).ok())
+    }
+}
+
+pub struct BlockRecomposer<T> {
+    data: T,
+    bit_mask: T,
+    num_bits_in_block: u32,
+    bit_pos: u32,
+}
+
+impl<T> BlockRecomposer<T>
+where
+    T: Recomposable,
+{
+    pub fn value(&self) -> T {
+        if self.bit_pos >= T::BITS as u32 {
+            self.data
+        } else {
+            let valid_mask = (T::ONE << self.bit_pos) - T::ONE;
+            self.data & valid_mask
+        }
+    }
+
+    pub fn unmasked_value(&self) -> T {
+        self.data
+    }
+}
+
+impl<T> BlockRecomposer<T>
+where
+    T: Recomposable,
+{
+    pub fn new(bits_per_block: u32) -> Self {
+        let num_bits_in_block = bits_per_block;
+        let bit_pos = 0;
+        let bit_mask = 1_u32.checked_shl(bits_per_block).unwrap() - 1;
+        let bit_mask = T::cast_from(bit_mask);
+
+        Self {
+            data: T::ZERO,
+            bit_mask,
+            num_bits_in_block,
+            bit_pos,
+        }
+    }
+}
+
+impl<T> BlockRecomposer<T>
+where
+    T: Recomposable,
+{
+    pub fn add_unmasked<V>(&mut self, block: V) -> bool
+    where
+        T: CastFrom<V>,
+    {
+        let casted_block = T::cast_from(block);
+        self.add(casted_block)
+    }
+
+    pub fn add_masked<V>(&mut self, block: V) -> bool
+    where
+        T: CastFrom<V>,
+    {
+        if self.bit_pos >= T::BITS as u32 {
+            return false;
+        }
+        let casted_block = T::cast_from(block);
+        self.add(casted_block & self.bit_mask)
+    }
+
+    fn add(&mut self, mut block: T) -> bool {
+        if self.bit_pos >= T::BITS as u32 {
+            return false;
+        }
+
+        block <<= self.bit_pos;
+        self.data += block;
+        self.bit_pos += self.num_bits_in_block;
+
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_bit_block_decomposer() {
+        let value = u16::MAX as u32;
+        let bits_per_block = 2;
+        let blocks = BlockDecomposer::new(value, bits_per_block)
+            .iter_as::<u64>()
+            .collect::<Vec<_>>();
+        let expected_blocks = vec![3, 3, 3, 3, 3, 3, 3, 3, 0, 0, 0, 0, 0, 0, 0, 0];
+        assert_eq!(expected_blocks, blocks);
+    }
+
+    #[test]
+    fn test_bit_block_decomposer_recomposer_carry_handling_in_between() {
+        let value = u16::MAX as u32;
+        let bits_per_block = 2;
+        let mut blocks = BlockDecomposer::new(value, bits_per_block)
+            .iter_as::<u64>()
+            .collect::<Vec<_>>();
+        let expected_blocks = vec![3, 3, 3, 3, 3, 3, 3, 3, 0, 0, 0, 0, 0, 0, 0, 0];
+        assert_eq!(expected_blocks, blocks);
+
+        // Now this block, which is not the last will have a 'carry'
+        blocks[0] += 2;
+
+        let mut recomposer = BlockRecomposer::new(bits_per_block);
+        for block in blocks {
+            recomposer.add_unmasked(block);
+        }
+        let recomposed: u32 = recomposer.value();
+        assert_eq!(recomposed, value.wrapping_add(2));
+    }
+
+    #[test]
+    fn test_bit_block_decomposer_recomposer_carry_overflow() {
+        let value = u16::MAX;
+        let bits_per_block = 2;
+        let mut blocks = BlockDecomposer::new(value, bits_per_block)
+            .iter_as::<u64>()
+            .collect::<Vec<_>>();
+        let expected_blocks = vec![3, 3, 3, 3, 3, 3, 3, 3];
+        assert_eq!(expected_blocks, blocks);
+
+        // Now this block, which is not the last will have a 'carry'
+        blocks[0] += 2;
+
+        let mut recomposer = BlockRecomposer::new(bits_per_block);
+        for block in blocks {
+            recomposer.add_unmasked(block);
+        }
+        let recomposed: u16 = recomposer.value();
+        assert_eq!(recomposed, value.wrapping_add(2));
+    }
+
+    #[test]
+    fn test_bit_block_decomposer_recomposer_carry_bigger_recomposed_type() {
+        // Test that when we use a bigger type to decompose / recompose our value
+        // (by taking a smaller number of blocks), the recomposed value is
+        // ok
+        let value = u8::MAX as u16;
+        let bits_per_block = 2;
+        let mut blocks = BlockDecomposer::new(value, bits_per_block)
+            .iter_as::<u64>()
+            .take(4)
+            .collect::<Vec<_>>();
+        let expected_blocks = vec![3, 3, 3, 3];
+        assert_eq!(expected_blocks, blocks);
+
+        // Now this block, which is not the last will have a 'carry'
+        blocks[0] += 2;
+
+        let mut recomposer = BlockRecomposer::new(bits_per_block);
+        for block in blocks {
+            recomposer.add_unmasked(block);
+        }
+        let recomposed: u16 = recomposer.value();
+        assert_eq!(recomposed, u8::MAX.wrapping_add(2) as u16);
+    }
+
+    #[test]
+    fn test_bit_block_decomposer_round_trip_unsigned() {
+        for i in 0..u32::BITS {
+            let value = (u16::MAX as u32).rotate_left(i);
+            let bits_per_block = 2;
+            let blocks = BlockDecomposer::new(value, bits_per_block)
+                .iter_as::<u64>()
+                .collect::<Vec<_>>();
+
+            let mut recomposer = BlockRecomposer::new(bits_per_block);
+            for block in blocks {
+                recomposer.add_unmasked(block);
+            }
+            let recomposed: u32 = recomposer.value();
+            assert_eq!(recomposed, value);
+        }
+    }
+
+    #[test]
+    fn test_bit_block_decomposer_round_trip_signed() {
+        for i in 0..i32::BITS {
+            let value = (i16::MAX as i32).rotate_left(i);
+            let bits_per_block = 2;
+            let blocks = BlockDecomposer::new(value, bits_per_block).collect::<Vec<_>>();
+
+            let mut recomposer = BlockRecomposer::new(bits_per_block);
+            for block in blocks {
+                recomposer.add_unmasked(block);
+            }
+            let recomposed: i32 = recomposer.value();
+            assert_eq!(recomposed, value);
+        }
+    }
+
+    /// Test that when the bits per block is not a multiple of the number of bytes
+    /// we can decompose and recompose
+    #[test]
+    fn test_bit_block_decomposer_round_trip_non_multiple_bits_per_block() {
+        for i in 0..u32::BITS {
+            let value = (u16::MAX as u32).rotate_left(i);
+            let bits_per_block = 3;
+            let blocks = BlockDecomposer::new(value, bits_per_block)
+                .iter_as::<u64>()
+                .collect::<Vec<_>>();
+
+            let mut recomposer = BlockRecomposer::new(bits_per_block);
+            for block in blocks {
+                recomposer.add_unmasked(block);
+            }
+            let recomposed: u32 = recomposer.value();
+            assert_eq!(recomposed, value);
+        }
+    }
+}

--- a/tfhe/src/integer/client_key/radix.rs
+++ b/tfhe/src/integer/client_key/radix.rs
@@ -1,8 +1,8 @@
 //! Definition of the client key for radix decomposition
 
 use super::ClientKey;
+use crate::integer::block_decomposition::{DecomposableInto, RecomposableFrom};
 use crate::integer::ciphertext::RadixCiphertext;
-use crate::integer::encryption::AsLittleEndianWords;
 use crate::integer::{RadixCiphertextBig, RadixCiphertextSmall};
 use crate::shortint::{
     CiphertextBase, CiphertextBig as ShortintCiphertext, PBSOrderMarker,
@@ -54,17 +54,17 @@ impl RadixClientKey {
         }
     }
 
-    pub fn encrypt<T: AsLittleEndianWords>(&self, message: T) -> RadixCiphertextBig {
+    pub fn encrypt<T: DecomposableInto<u64>>(&self, message: T) -> RadixCiphertextBig {
         self.key.encrypt_radix(message, self.num_blocks)
     }
 
-    pub fn encrypt_small<T: AsLittleEndianWords>(&self, message: T) -> RadixCiphertextSmall {
+    pub fn encrypt_small<T: DecomposableInto<u64>>(&self, message: T) -> RadixCiphertextSmall {
         self.key.encrypt_radix_small(message, self.num_blocks)
     }
 
     pub fn decrypt<T, PBSOrder>(&self, ciphertext: &RadixCiphertext<PBSOrder>) -> T
     where
-        T: AsLittleEndianWords + Default,
+        T: RecomposableFrom<u64>,
         PBSOrder: PBSOrderMarker,
     {
         self.key.decrypt_radix(ciphertext)

--- a/tfhe/src/integer/mod.rs
+++ b/tfhe/src/integer/mod.rs
@@ -50,6 +50,7 @@ extern crate core;
 #[cfg(test)]
 #[macro_use]
 mod tests;
+pub mod block_decomposition;
 pub(crate) mod encryption;
 
 pub mod ciphertext;

--- a/tfhe/src/integer/public_key/compressed.rs
+++ b/tfhe/src/integer/public_key/compressed.rs
@@ -1,6 +1,7 @@
+use crate::integer::block_decomposition::DecomposableInto;
 use crate::integer::ciphertext::{CrtCiphertext, RadixCiphertext};
 use crate::integer::client_key::ClientKey;
-use crate::integer::encryption::{encrypt_crt, encrypt_words_radix_impl, AsLittleEndianWords};
+use crate::integer::encryption::{encrypt_crt, encrypt_words_radix_impl};
 use crate::shortint::ciphertext::{BootstrapKeyswitch, KeyswitchBootstrap};
 use crate::shortint::parameters::MessageModulus;
 use crate::shortint::PBSOrderMarker;
@@ -71,7 +72,7 @@ impl<OpOrder: PBSOrderMarker> CompressedPublicKeyBase<OpOrder> {
         self.key.parameters.pbs_parameters().unwrap()
     }
 
-    pub fn encrypt_radix<T: AsLittleEndianWords>(
+    pub fn encrypt_radix<T: DecomposableInto<u64>>(
         &self,
         message: T,
         num_blocks: usize,
@@ -102,7 +103,7 @@ impl<OpOrder: PBSOrderMarker> CompressedPublicKeyBase<OpOrder> {
         encrypt_block: F,
     ) -> RadixCiphertextType
     where
-        T: AsLittleEndianWords,
+        T: DecomposableInto<u64>,
         F: Fn(&crate::shortint::CompressedPublicKeyBase<OpOrder>, u64) -> Block,
         RadixCiphertextType: From<Vec<Block>>,
     {

--- a/tfhe/src/integer/public_key/tests.rs
+++ b/tfhe/src/integer/public_key/tests.rs
@@ -33,8 +33,7 @@ fn big_radix_encrypt_decrypt_128_bits(param: PBSParameters) {
     let ct = public_key.encrypt_radix(clear, num_block);
 
     // decryption
-    let mut dec = 0u128;
-    cks.decrypt_radix_into(&ct, &mut dec);
+    let dec: u128 = cks.decrypt_radix(&ct);
 
     // assert
     assert_eq!(clear, dec);
@@ -54,8 +53,7 @@ fn radix_encrypt_decrypt_compressed_128_bits(param: PBSParameters) {
     let ct = public_key.encrypt_radix(clear, num_block);
 
     // decryption
-    let mut dec = 0u128;
-    cks.decrypt_radix_into(&ct, &mut dec);
+    let dec: u128 = cks.decrypt_radix(&ct);
 
     // assert
     assert_eq!(clear, dec);

--- a/tfhe/src/integer/server_key/comparator.rs
+++ b/tfhe/src/integer/server_key/comparator.rs
@@ -1200,9 +1200,7 @@ mod tests {
 
             {
                 let result = unchecked_comparator_method(&comparator, &a, &b);
-                let mut decrypted = U256::default();
-                cks.decrypt_radix_into(&result, &mut decrypted);
-
+                let decrypted: U256 = cks.decrypt_radix(&result);
                 let expected_result = clear_fn(clear_a, clear_b);
                 assert_eq!(decrypted, expected_result);
             }
@@ -1210,9 +1208,7 @@ mod tests {
             {
                 // Force case where lhs == rhs
                 let result = unchecked_comparator_method(&comparator, &a, &a);
-                let mut decrypted = U256::default();
-                cks.decrypt_radix_into(&result, &mut decrypted);
-
+                let decrypted: U256 = cks.decrypt_radix(&result);
                 let expected_result = clear_fn(clear_a, clear_a);
                 assert_eq!(decrypted, expected_result);
             }
@@ -1266,12 +1262,11 @@ mod tests {
 
             // Sanity decryption checks
             {
-                let mut a = U256::default();
-                cks.decrypt_radix_into(&ct_0, &mut a);
+                let a: U256 = cks.decrypt_radix(&ct_0);
                 assert_eq!(a, clear_0);
 
-                cks.decrypt_radix_into(&ct_1, &mut a);
-                assert_eq!(a, clear_1);
+                let b: U256 = cks.decrypt_radix(&ct_1);
+                assert_eq!(b, clear_1);
             }
 
             assert!(super::has_non_zero_carries(&ct_0));
@@ -1282,15 +1277,14 @@ mod tests {
 
             // Sanity decryption checks
             {
-                let mut a = U256::default();
-                cks.decrypt_radix_into(&ct_0, &mut a);
+                let a: U256 = cks.decrypt_radix(&ct_0);
                 assert_eq!(a, clear_0);
-                cks.decrypt_radix_into(&ct_1, &mut a);
-                assert_eq!(a, clear_1);
+
+                let b: U256 = cks.decrypt_radix(&ct_1);
+                assert_eq!(b, clear_1);
             }
 
-            let mut decrypted_result = U256::default();
-            cks.decrypt_radix_into(&encrypted_result, &mut decrypted_result);
+            let decrypted_result: U256 = cks.decrypt_radix(&encrypted_result);
 
             let expected_result = clear_fn(clear_0, clear_1);
             assert_eq!(decrypted_result, expected_result);
@@ -1344,12 +1338,11 @@ mod tests {
 
             // Sanity decryption checks
             {
-                let mut a = U256::default();
-                cks.decrypt_radix_into(&ct_0, &mut a);
+                let a: U256 = cks.decrypt_radix(&ct_0);
                 assert_eq!(a, clear_0);
 
-                cks.decrypt_radix_into(&ct_1, &mut a);
-                assert_eq!(a, clear_1);
+                let b: U256 = cks.decrypt_radix(&ct_1);
+                assert_eq!(b, clear_1);
             }
 
             assert!(super::has_non_zero_carries(&ct_0));
@@ -1359,15 +1352,14 @@ mod tests {
 
             // Sanity decryption checks
             {
-                let mut a = U256::default();
-                cks.decrypt_radix_into(&ct_0, &mut a);
+                let a: U256 = cks.decrypt_radix(&ct_0);
                 assert_eq!(a, clear_0);
-                cks.decrypt_radix_into(&ct_1, &mut a);
-                assert_eq!(a, clear_1);
+
+                let b: U256 = cks.decrypt_radix(&ct_1);
+                assert_eq!(b, clear_1);
             }
 
-            let mut decrypted_result = U256::default();
-            cks.decrypt_radix_into(&encrypted_result, &mut decrypted_result);
+            let decrypted_result: U256 = cks.decrypt_radix(&encrypted_result);
 
             let expected_result = clear_fn(clear_0, clear_1);
             assert_eq!(decrypted_result, expected_result);

--- a/tfhe/src/integer/server_key/radix/mod.rs
+++ b/tfhe/src/integer/server_key/radix/mod.rs
@@ -11,8 +11,9 @@ mod sub;
 
 use super::ServerKey;
 
+use crate::integer::block_decomposition::DecomposableInto;
 use crate::integer::ciphertext::RadixCiphertext;
-use crate::integer::encryption::{encrypt_words_radix_impl, AsLittleEndianWords};
+use crate::integer::encryption::encrypt_words_radix_impl;
 use crate::shortint::PBSOrderMarker;
 
 #[cfg(test)]
@@ -78,7 +79,7 @@ impl ServerKey {
     ) -> RadixCiphertext<PBSOrder>
     where
         PBSOrder: PBSOrderMarker,
-        T: AsLittleEndianWords,
+        T: DecomposableInto<u64>,
     {
         encrypt_words_radix_impl(
             &self.key,

--- a/tfhe/src/integer/server_key/radix/tests.rs
+++ b/tfhe/src/integer/server_key/radix/tests.rs
@@ -1,4 +1,5 @@
 use crate::integer::keycache::KEY_CACHE;
+use crate::integer::U256;
 use crate::shortint::parameters::*;
 use crate::shortint::PBSParameters;
 use rand::Rng;
@@ -92,8 +93,7 @@ fn integer_encrypt_decrypt_128_bits(param: PBSParameters) {
         let ct = cks.encrypt_radix(clear, num_block);
 
         // decryption
-        let mut dec = 0u128;
-        cks.decrypt_radix_into(&ct, &mut dec);
+        let dec: u128 = cks.decrypt_radix(&ct);
 
         // assert
         assert_eq!(clear, dec);
@@ -108,8 +108,7 @@ fn integer_encrypt_decrypt_128_bits_specific_values(param: PBSParameters) {
         let a = u64::MAX as u128;
         let ct = cks.encrypt_radix(a, num_block);
 
-        let mut dec = 0u128;
-        cks.decrypt_radix_into(&ct, &mut dec);
+        let dec: u128 = cks.decrypt_radix(&ct);
 
         assert_eq!(a, dec);
     }
@@ -117,8 +116,7 @@ fn integer_encrypt_decrypt_128_bits_specific_values(param: PBSParameters) {
         let a = (u64::MAX as u128) << 64;
         let ct = cks.encrypt_radix(a, num_block);
 
-        let mut dec = 0u128;
-        cks.decrypt_radix_into(&ct, &mut dec);
+        let dec: u128 = cks.decrypt_radix(&ct);
 
         assert_eq!(a, dec);
     }
@@ -132,8 +130,7 @@ fn integer_encrypt_decrypt_128_bits_specific_values(param: PBSParameters) {
         let ct = sks.smart_add(&mut ct, &mut ct2);
 
         // decryption
-        let mut dec = 0u128;
-        cks.decrypt_radix_into(&ct, &mut dec);
+        let dec: u128 = cks.decrypt_radix(&ct);
 
         // assert
         assert_eq!(clear_0.wrapping_add(clear_1), dec);
@@ -148,8 +145,7 @@ fn integer_encrypt_decrypt_128_bits_specific_values(param: PBSParameters) {
         let ct = sks.smart_add(&mut ct, &mut ct2);
 
         // decryption
-        let mut dec = 0u128;
-        cks.decrypt_radix_into(&ct, &mut dec);
+        let dec: u128 = cks.decrypt_radix(&ct);
 
         // assert
         assert_eq!(clear_0.wrapping_add(clear_1), dec);
@@ -166,9 +162,7 @@ fn integer_encrypt_decrypt_256_bits_specific_values(param: PBSParameters) {
         let clear = crate::integer::U256::from((a, b));
         let ct = cks.encrypt_radix(clear, num_block);
 
-        let mut dec = crate::integer::U256::from((0, 0));
-        cks.decrypt_radix_into(&ct, &mut dec);
-
+        let dec: U256 = cks.decrypt_radix(&ct);
         assert_eq!(clear, dec);
     }
     {
@@ -177,9 +171,7 @@ fn integer_encrypt_decrypt_256_bits_specific_values(param: PBSParameters) {
         let clear = crate::integer::U256::from((a, b));
         let ct = cks.encrypt_radix(clear, num_block);
 
-        let mut dec = crate::integer::U256::from((0, 0));
-        cks.decrypt_radix_into(&ct, &mut dec);
-
+        let dec: U256 = cks.decrypt_radix(&ct);
         assert_eq!(clear, dec);
     }
 }
@@ -201,8 +193,7 @@ fn integer_encrypt_decrypt_256_bits(param: PBSParameters) {
         let ct = cks.encrypt_radix(clear, num_block);
 
         // decryption
-        let mut dec = crate::integer::U256::default();
-        cks.decrypt_radix_into(&ct, &mut dec);
+        let dec: U256 = cks.decrypt_radix(&ct);
 
         // assert
         assert_eq!(clear, dec);
@@ -240,8 +231,7 @@ fn integer_smart_add_128_bits(param: PBSParameters) {
             clear_result += clear_0;
 
             // decryption of ct_res
-            let mut dec_res = 0u128;
-            cks.decrypt_radix_into(&ct_res, &mut dec_res);
+            let dec_res: u128 = cks.decrypt_radix(&ct_res);
             // println!("clear = {}, dec_res = {}", clear, dec_res);
             assert_eq!(clear_result, dec_res);
         }


### PR DESCRIPTION
This new implementation should hopefully be a little bit easier to understand.

But more importantly it is more general/generic,
the previous implementation required the input type to be able to be described as u64 words, the new one works for any type (as long as needed trait are implemented)

Also the new implementation is separated from the encryption code, meaning it will be usable by scalar operation, which will allow us to deduplicate code and start making scalar ops support scalar values that are on more than 64-bits.