### PR TITLE
chore(tfhe): remove anyhow, just use Box<dyn std::error::Error>

### DIFF
--- a/tfhe/Cargo.toml
+++ b/tfhe/Cargo.toml
@@ -33,7 +33,6 @@ num_cpus = "1.15"
 libm = "0.2.6"
 test-case = "*"
 combine = "*"
-anyhow = "*"
 env_logger = "*"
 log = "*"
 

--- a/tfhe/examples/regex_engine/ciphertext.rs
+++ b/tfhe/examples/regex_engine/ciphertext.rs
@@ -1,12 +1,14 @@
-use anyhow::{anyhow, Result};
 use tfhe::integer::{gen_keys_radix, RadixCiphertextBig, RadixClientKey, ServerKey};
 use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2;
 
 pub type StringCiphertext = Vec<RadixCiphertextBig>;
 
-pub fn encrypt_str(client_key: &RadixClientKey, s: &str) -> Result<StringCiphertext> {
+pub fn encrypt_str(
+    client_key: &RadixClientKey,
+    s: &str,
+) -> Result<StringCiphertext, Box<dyn std::error::Error>> {
     if !s.is_ascii() {
-        return Err(anyhow!("content contains non-ascii characters"));
+        return Err("content contains non-ascii characters".into());
     }
     Ok(s.as_bytes()
         .iter()

--- a/tfhe/examples/regex_engine/engine.rs
+++ b/tfhe/examples/regex_engine/engine.rs
@@ -1,6 +1,5 @@
 use crate::execution::{Executed, Execution, LazyExecution};
 use crate::parser::{parse, RegExpr};
-use anyhow::Result;
 use std::rc::Rc;
 use tfhe::integer::{RadixCiphertextBig, ServerKey};
 
@@ -8,7 +7,7 @@ pub fn has_match(
     sk: &ServerKey,
     content: &[RadixCiphertextBig],
     pattern: &str,
-) -> Result<RadixCiphertextBig> {
+) -> Result<RadixCiphertextBig, Box<dyn std::error::Error>> {
     let re = parse(pattern)?;
 
     let branches: Vec<LazyExecution> = (0..content.len())

--- a/tfhe/examples/regex_engine/parser.rs
+++ b/tfhe/examples/regex_engine/parser.rs
@@ -1,4 +1,3 @@
-use anyhow::{anyhow, Result};
 use combine::parser::byte;
 use combine::parser::byte::byte;
 use combine::*;
@@ -147,7 +146,7 @@ impl fmt::Debug for RegExpr {
     }
 }
 
-pub(crate) fn parse(pattern: &str) -> Result<RegExpr> {
+pub(crate) fn parse(pattern: &str) -> Result<RegExpr, Box<dyn std::error::Error>> {
     let (parsed, unparsed) = (
         between(
             byte(b'/'),
@@ -179,10 +178,11 @@ pub(crate) fn parse(pattern: &str) -> Result<RegExpr> {
         })
         .parse(pattern.as_bytes())?;
     if !unparsed.is_empty() {
-        return Err(anyhow!(
+        return Err(format!(
             "failed to parse regular expression, unexpected token at start of: {}",
             std::str::from_utf8(unparsed).unwrap()
-        ));
+        )
+        .into());
     }
 
     Ok(parsed)


### PR DESCRIPTION
For whatever reason some backtrace feature gets enabled, remove anyhow we don't need it