### PR TITLE
Scalar add sub neg

### DIFF
--- a/tfhe/src/core_crypto/commons/numeric/unsigned.rs
+++ b/tfhe/src/core_crypto/commons/numeric/unsigned.rs
@@ -67,6 +67,8 @@ pub trait UnsignedInteger:
     #[must_use]
     fn wrapping_shr(self, rhs: u32) -> Self;
     #[must_use]
+    fn overflowing_add(self, rhs: Self) -> (Self, bool);
+    #[must_use]
     fn is_power_of_two(self) -> bool;
     /// Return the casting of the current value to the signed type of the same size.
     fn into_signed(self) -> Self::Signed;
@@ -139,6 +141,10 @@ macro_rules! implement {
             #[inline]
             fn wrapping_pow(self, exp: u32) -> Self {
                 self.wrapping_pow(exp)
+            }
+            #[inline]
+            fn overflowing_add(self, rhs: Self) -> (Self, bool) {
+                self.overflowing_add(rhs)
             }
             #[inline]
             fn is_power_of_two(self) -> bool {

--- a/tfhe/src/high_level_api/integers/server_key.rs
+++ b/tfhe/src/high_level_api/integers/server_key.rs
@@ -325,12 +325,13 @@ macro_rules! impl_default_scalar_op_for_tfhe_integer_server_key_dyn {
             type Output = RadixCiphertextDyn;
 
             fn $default_trait_fn(&self, lhs: &RadixCiphertextDyn, rhs: u64) -> Self::Output {
+                let value: u64 = rhs.try_into().unwrap();
                 match lhs {
                     RadixCiphertextDyn::Big(lhs) => {
-                        RadixCiphertextDyn::Big(self.$method(lhs, rhs.try_into().unwrap()))
+                        RadixCiphertextDyn::Big(self.$method(lhs, value))
                     }
                     RadixCiphertextDyn::Small(lhs) => {
-                        RadixCiphertextDyn::Small(self.$method(lhs, rhs.try_into().unwrap()))
+                        RadixCiphertextDyn::Small(self.$method(lhs, value))
                     }
                 }
             }
@@ -342,13 +343,10 @@ macro_rules! impl_default_scalar_assign_op_for_tfhe_integer_server_key_dyn {
     ($default_trait:ident($default_trait_fn:ident) => $method_assign:ident) => {
         impl $default_trait<RadixCiphertextDyn, u64> for crate::integer::ServerKey {
             fn $default_trait_fn(&self, lhs: &mut RadixCiphertextDyn, rhs: u64) {
+                let value: u64 = rhs.try_into().unwrap();
                 match lhs {
-                    RadixCiphertextDyn::Big(lhs) => {
-                        self.$method_assign(lhs, rhs.try_into().unwrap())
-                    }
-                    RadixCiphertextDyn::Small(lhs) => {
-                        self.$method_assign(lhs, rhs.try_into().unwrap())
-                    }
+                    RadixCiphertextDyn::Big(lhs) => self.$method_assign(lhs, value),
+                    RadixCiphertextDyn::Small(lhs) => self.$method_assign(lhs, value),
                 }
             }
         }

--- a/tfhe/src/integer/u256.rs
+++ b/tfhe/src/integer/u256.rs
@@ -269,6 +269,23 @@ impl std::ops::AddAssign<Self> for U256 {
     }
 }
 
+impl std::ops::BitOr<Self> for U256 {
+    type Output = Self;
+
+    fn bitor(mut self, rhs: Self) -> Self::Output {
+        self |= rhs;
+        self
+    }
+}
+
+impl std::ops::BitOrAssign<Self> for U256 {
+    fn bitor_assign(&mut self, rhs: Self) {
+        for (self_word, rhs_word) in self.0.iter_mut().zip(rhs.0) {
+            *self_word |= rhs_word;
+        }
+    }
+}
+
 impl std::cmp::PartialOrd for U256 {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
@@ -439,6 +456,12 @@ impl CastFrom<U256> for u64 {
     }
 }
 
+impl CastFrom<U256> for u8 {
+    fn cast_from(input: U256) -> Self {
+        input.0[0] as u8
+    }
+}
+
 impl CastFrom<u32> for U256 {
     fn cast_from(input: u32) -> Self {
         Self::from(input)
@@ -448,6 +471,12 @@ impl CastFrom<u32> for U256 {
 impl CastFrom<u64> for U256 {
     fn cast_from(input: u64) -> Self {
         Self::from(input)
+    }
+}
+
+impl CastFrom<u8> for U256 {
+    fn cast_from(input: u8) -> Self {
+        Self::from(input as u64)
     }
 }
 


### PR DESCRIPTION
- scalar_add now uses the same parallel carry propagation algorithm
  as the add function.

- scalar_sub now uses the same parallel carry propagation algorithm
  as the sub function.

- the 'default' negation function uses the now improved scalar_add
  to be faster

- unchecked_scalar_add, smart_scalar_add, checked_scalar_add, scalar_add
  have been updated to work on generic scalar type so it should work
  on u32, u64, u128, U256, etc

- unchecked_scalar_sub, smart_scalar_sub, checked_scalar_sub, scalar_sub
  have been updated to work on generic scalar type so it should work
  on u32, u64, u128.
  As U256 does not yet implement the UnsignedInteger trait, its not
  usable yet as a scalar type for the sub operation.

- The HLAPI is still locked to u64 scalars, it will be updated
  when most / all scalar ops are ready

# Requires
- #306