### PR TITLE
[DO NOT MERGE] refactor(core): simplify closest_representable and pbs_modulus_switch

### DIFF
--- a/tfhe/src/core_crypto/fft_impl/common.rs
+++ b/tfhe/src/core_crypto/fft_impl/common.rs
@@ -25,7 +25,7 @@ pub fn pbs_modulus_switch<Scalar: UnsignedTorus + CastInto<usize>>(
     // Start doing the right shift
     output >>= Scalar::BITS - poly_size.log2().0 - 2 + lut_count_log.0;
     // Do the rounding
-    output += output & Scalar::ONE;
+    output += Scalar::ONE;
     // Finish the right shift
     output >>= 1;
     // Apply the lsb padding


### PR DESCRIPTION
- both code were selecting the bit below the last representable bit, extracted it and then added it to the bit above, the same effect can be achieved by adding a 1 at the bit below the last representable bit