### PR TITLE
chore(wasm): remove serialization in web test

### DIFF
--- a/tfhe/web_wasm_parallel_tests/worker.js
+++ b/tfhe/web_wasm_parallel_tests/worker.js
@@ -67,10 +67,6 @@ async function publicKeyTest() {
     let publicKey = TfhePublicKey.new(clientKey);
     console.timeEnd('PublicKey Gen')
 
-    let data = publicKey.serialize()
-    console.log("PublicKey size:", data.length)
-    data = null;
-
     console.time('FheUint8 encrypt with PublicKey')
     let encrypted = FheUint8.encrypt_with_public_key(255, publicKey);
     console.timeEnd('FheUint8 encrypt with PublicKey')


### PR DESCRIPTION
In the web wasm test we serialize the public key
to print its size (38_931_6265 bytes) this
means we hold the public key twice in ram.

I suspect this causes frequent out of
memory errors which then result in the
test timing out.

So we remove that hoping it has a positive impact