### PR TITLE
CiphertextBase can convert from generic type to explicit type

### DIFF
--- a/tfhe/src/shortint/engine/server_side/mod.rs
+++ b/tfhe/src/shortint/engine/server_side/mod.rs
@@ -375,12 +375,10 @@ impl ShortintEngine {
     ) -> EngineResult<()> {
         match OpOrder::pbs_order() {
             PBSOrder::KeyswitchBootstrap => {
-                let ct = unsafe { std::mem::transmute(ct) };
-                self.keyswitch_bootstrap_assign(server_key, ct)?;
+                self.keyswitch_bootstrap_assign(server_key, ct.to_concrete_type_mut())?;
             }
             PBSOrder::BootstrapKeyswitch => {
-                let ct = unsafe { std::mem::transmute(ct) };
-                self.bootstrap_keyswitch_assign(server_key, ct)?;
+                self.bootstrap_keyswitch_assign(server_key, ct.to_concrete_type_mut())?;
             }
         }
         Ok(())
@@ -726,14 +724,20 @@ impl ShortintEngine {
         // layout is the same as the type information is just encoded in a phantom data marker
         match OpOrder::pbs_order() {
             PBSOrder::KeyswitchBootstrap => {
-                let ct = unsafe { std::mem::transmute(ct) };
                 // This updates the ciphertext degree
-                self.keyswitch_programmable_bootstrap_assign(server_key, ct, acc)?;
+                self.keyswitch_programmable_bootstrap_assign(
+                    server_key,
+                    ct.to_concrete_type_mut(),
+                    acc,
+                )?;
             }
             PBSOrder::BootstrapKeyswitch => {
-                let ct = unsafe { std::mem::transmute(ct) };
                 // This updates the ciphertext degree
-                self.programmable_bootstrap_keyswitch_assign(server_key, ct, acc)?;
+                self.programmable_bootstrap_keyswitch_assign(
+                    server_key,
+                    ct.to_concrete_type_mut(),
+                    acc,
+                )?;
             }
         };
 
@@ -762,14 +766,12 @@ impl ShortintEngine {
         // layout is the same as the type information is just encoded in a phantom data marker
         match OpOrder::pbs_order() {
             PBSOrder::KeyswitchBootstrap => {
-                let ct = unsafe { std::mem::transmute(ct) };
                 // This updates the ciphertext degree
-                self.keyswitch_bootstrap_assign(server_key, ct)?;
+                self.keyswitch_bootstrap_assign(server_key, ct.to_concrete_type_mut())?;
             }
             PBSOrder::BootstrapKeyswitch => {
-                let ct = unsafe { std::mem::transmute(ct) };
                 // This updates the ciphertext degree
-                self.bootstrap_keyswitch_assign(server_key, ct)?;
+                self.bootstrap_keyswitch_assign(server_key, ct.to_concrete_type_mut())?;
             }
         };
 


### PR DESCRIPTION
This PR provides CiphertextBase with functions to convert from a generic type OpOrder to a specific struct.

This allows removing all calls to std::mem::transmute in shortint/engine/server_side/mod.rs, isolating unsafe blocks in the conversion functions. This makes the code safer and more likely to panic! in case of an error.

This means when you have a function `my_fun` that takes a `CiphertextBase<KeyswitchBootstrap>` and you only have a `CiphertextBase<OpOrder: PBSO0rderMarker>` that you know to be the right type, you can just do `my_fun(ct.to_concrete_type())`.