### PR TITLE
chore(ci): put wasm tests in their own workflow

### DIFF
--- a/.github/workflows/aws_tfhe_wasm_tests.yml
+++ b/.github/workflows/aws_tfhe_wasm_tests.yml
@@ -1,4 +1,4 @@
-name: AWS Tests on CPU
+name: AWS WASM Tests on CPU
 
 env:
   CARGO_TERM_COLOR: always
@@ -33,7 +33,7 @@ on:
         type: string
 
 jobs:
-  shortint-tests:
+  wasm-tests:
     concurrency:
       group: ${{ github.workflow }}_${{ github.ref }}_${{ inputs.instance_image_id }}_${{ inputs.instance_type }}
       cancel-in-progress: true
@@ -65,33 +65,14 @@ jobs:
           toolchain: stable
           default: true
 
-      - name: Run core tests
+      - name: Run js on wasm API tests
         run: |
-          AVX512_SUPPORT=ON make test_core_crypto
+          make test_nodejs_wasm_api_in_docker
 
-      - name: Run boolean tests
+      - name: Run parallel wasm tests
         run: |
-          make test_boolean
-
-      - name: Run C API tests
-        run: |
-          make test_c_api
-
-      - name: Run user docs tests
-        run: |
-          make test_user_doc
-
-      - name: Gen Keys if required
-        run: |
-          make gen_key_cache
-
-      - name: Run shortint tests
-        run: |
-          BIG_TESTS_INSTANCE=TRUE make test_shortint_ci
-
-      - name: Run high-level API tests
-        run: |
-          BIG_TESTS_INSTANCE=TRUE make test_high_level_api
+          make install_node
+          make ci_test_web_js_api_parallel
 
       - name: Slack Notification
         if: ${{ always() }}
@@ -101,6 +82,6 @@ jobs:
           SLACK_COLOR: ${{ job.status }}
           SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
           SLACK_ICON: https://pbs.twimg.com/profile_images/1274014582265298945/OjBKP9kn_400x400.png
-          SLACK_MESSAGE: "Shortint tests finished with status: ${{ job.status }}. (${{ env.ACTION_RUN_URL }})"
+          SLACK_MESSAGE: "WASM tests finished with status: ${{ job.status }}. (${{ env.ACTION_RUN_URL }})"
           SLACK_USERNAME: ${{ secrets.BOT_USERNAME }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/trigger_aws_tests_on_pr.yml
+++ b/.github/workflows/trigger_aws_tests_on_pr.yml
@@ -17,3 +17,4 @@ jobs:
             @slab-ci cpu_test
             @slab-ci cpu_integer_test
             @slab-ci cpu_multi_bit_test
+            @slab-ci cpu_wasm_test

--- a/Makefile
+++ b/Makefile
@@ -338,9 +338,17 @@ test_web_js_api_parallel: build_web_js_api_parallel
 
 .PHONY: ci_test_web_js_api_parallel # Run tests for the web wasm api
 ci_test_web_js_api_parallel: build_web_js_api_parallel
-	source ~/.nvm/nvm.sh && \
-	nvm use node && \
-	$(MAKE) -C tfhe/web_wasm_parallel_tests test-ci; \
+	# Auto-retry since WASM tests can be flaky
+	@for i in 1 2 3 ; do \
+		source ~/.nvm/nvm.sh && \
+		nvm use node && \
+		$(MAKE) -C tfhe/web_wasm_parallel_tests test-ci | tee web_js_tests_output; \
+		if grep -q -i "timeout" web_js_tests_output; then \
+			echo "Timeout occurred starting attempt #${i}"; \
+		else \
+			break; \
+		fi; \
+	done
 
 .PHONY: no_tfhe_typo # Check we did not invert the h and f in tfhe
 no_tfhe_typo:

--- a/ci/slab.toml
+++ b/ci/slab.toml
@@ -3,6 +3,11 @@ region = "eu-west-3"
 image_id = "ami-04deffe45b5b236fd"
 instance_type = "m6i.32xlarge"
 
+[profile.cpu-small]
+region = "eu-west-3"
+image_id = "ami-04deffe45b5b236fd"
+instance_type = "m6i.4xlarge"
+
 [profile.bench]
 region = "eu-west-3"
 image_id = "ami-04deffe45b5b236fd"
@@ -22,6 +27,11 @@ check_run_name = "CPU Integer AWS Tests"
 workflow = "aws_tfhe_multi_bit_tests.yml"
 profile = "cpu-big"
 check_run_name = "CPU AWS Multi Bit Tests"
+
+[command.cpu_wasm_test]
+workflow = "aws_tfhe_wasm_tests.yml"
+profile = "cpu-small"
+check_run_name = "CPU AWS WASM Tests"
 
 [command.integer_bench]
 workflow = "integer_benchmark.yml"


### PR DESCRIPTION
This is mostly done to avoid failure on AWS tests (core, boolean, shortint, ...) workflow due to flaky tests in WASM.