### PR TITLE
chore(shortint): proper ThreadCount serialization for bootstrapping key

### DIFF
--- a/tfhe/src/core_crypto/algorithms/lwe_multi_bit_programmable_bootstrapping.rs
+++ b/tfhe/src/core_crypto/algorithms/lwe_multi_bit_programmable_bootstrapping.rs
@@ -270,6 +270,11 @@ pub fn multi_bit_blind_rotate_assign<Scalar, InputCont, OutputCont, KeyCont>(
         accumulator.ciphertext_modulus(),
     );
 
+    assert!(
+        thread_count.0 != 0,
+        "Got thread_count == 0, this is not supported"
+    );
+
     assert!(accumulator
         .ciphertext_modulus()
         .is_compatible_with_native_modulus());
@@ -803,6 +808,11 @@ pub fn multi_bit_programmable_bootstrap_lwe_ciphertext<
         "Mismatched CiphertextModulus between input ({:?}) and accumulator ({:?})",
         input.ciphertext_modulus(),
         accumulator.ciphertext_modulus(),
+    );
+
+    assert!(
+        thread_count.0 != 0,
+        "Got thread_count == 0, this is not supported"
     );
 
     let mut local_accumulator = GlweCiphertext::new(


### PR DESCRIPTION
- skip thread_count on serialization, deserialize using the function to properly populate thread_count

closes https://github.com/zama-ai/tfhe-rs-internal/issues/126