### PR TITLE
feat(c_api): add #[repr(C)] for boolean parameters

### DIFF
--- a/tfhe/c_api_tests/test_boolean_keygen.c
+++ b/tfhe/c_api_tests/test_boolean_keygen.c
@@ -75,7 +75,7 @@ void test_predefined_keygen_w_serde(void) {
   BooleanClientKey *cks = NULL;
   BooleanServerKey *sks = NULL;
 
-  int gen_keys_ok = boolean_gen_keys_with_predefined_parameters_set(
+  int gen_keys_ok = boolean_gen_keys_with_parameters(
       BOOLEAN_PARAMETERS_SET_DEFAULT_PARAMETERS, &cks, &sks);
 
   assert(gen_keys_ok == 0);
@@ -83,7 +83,7 @@ void test_predefined_keygen_w_serde(void) {
   destroy_boolean_client_key(cks);
   destroy_boolean_server_key(sks);
 
-  gen_keys_ok = boolean_gen_keys_with_predefined_parameters_set(
+  gen_keys_ok = boolean_gen_keys_with_parameters(
       BOOLEAN_PARAMETERS_SET_TFHE_LIB_PARAMETERS, &cks, &sks);
 
   assert(gen_keys_ok == 0);
@@ -95,16 +95,22 @@ void test_predefined_keygen_w_serde(void) {
 void test_custom_keygen(void) {
   BooleanClientKey *cks = NULL;
   BooleanServerKey *sks = NULL;
-  BooleanParameters *params = NULL;
-
-  int params_ok = boolean_create_parameters(10, 1, 1024, 10e-100, 10e-100, 3, 1, 4, 2, &params);
-  assert(params_ok == 0);
+  BooleanParameters params = {
+      .lwe_dimension = 10,
+      .glwe_dimension = 1,
+      .polynomial_size = 1024,
+      .lwe_modular_std_dev = 10e-100,
+      .glwe_modular_std_dev = 10e-100,
+      .pbs_base_log = 3,
+      .pbs_level = 1,
+      .ks_base_log = 4,
+      .ks_level = 2,
+  };
 
   int gen_keys_ok = boolean_gen_keys_with_parameters(params, &cks, &sks);
 
   assert(gen_keys_ok == 0);
 
-  destroy_boolean_parameters(params);
   destroy_boolean_client_key(cks);
   destroy_boolean_server_key(sks);
 }
@@ -112,13 +118,9 @@ void test_custom_keygen(void) {
 void test_public_keygen(void) {
   BooleanClientKey *cks = NULL;
   BooleanPublicKey *pks = NULL;
-  BooleanParameters *params = NULL;
   BooleanCiphertext *ct = NULL;
 
-  int get_params_ok = boolean_get_parameters(BOOLEAN_PARAMETERS_SET_DEFAULT_PARAMETERS, &params);
-  assert(get_params_ok == 0);
-
-  int gen_keys_ok = boolean_gen_client_key(params, &cks);
+  int gen_keys_ok = boolean_gen_client_key(BOOLEAN_PARAMETERS_SET_DEFAULT_PARAMETERS, &cks);
   assert(gen_keys_ok == 0);
 
   int gen_pks = boolean_gen_public_key(cks, &pks);
@@ -135,7 +137,6 @@ void test_public_keygen(void) {
 
   assert(result == true);
 
-  destroy_boolean_parameters(params);
   destroy_boolean_client_key(cks);
   destroy_boolean_public_key(pks);
   destroy_boolean_ciphertext(ct);

--- a/tfhe/c_api_tests/test_boolean_server_key.c
+++ b/tfhe/c_api_tests/test_boolean_server_key.c
@@ -334,12 +334,8 @@ void test_server_key(void) {
   BooleanCompressedServerKey *deser_csks = NULL;
   Buffer sks_ser_buffer = {.pointer = NULL, .length = 0};
   BooleanServerKey *deser_sks = NULL;
-  BooleanParameters *params = NULL;
 
-  int get_params_ok = boolean_get_parameters(BOOLEAN_PARAMETERS_SET_DEFAULT_PARAMETERS, &params);
-  assert(get_params_ok == 0);
-
-  int gen_cks_ok = boolean_gen_client_key(params, &cks);
+  int gen_cks_ok = boolean_gen_client_key(BOOLEAN_PARAMETERS_SET_DEFAULT_PARAMETERS, &cks);
   assert(gen_cks_ok == 0);
 
   int gen_csks_ok = boolean_gen_compressed_server_key(cks, &csks);
@@ -417,7 +413,6 @@ void test_server_key(void) {
   destroy_boolean_client_key(deser_cks);
   destroy_boolean_compressed_server_key(deser_csks);
   destroy_boolean_server_key(deser_sks);
-  destroy_boolean_parameters(params);
   destroy_buffer(&cks_ser_buffer);
   destroy_buffer(&csks_ser_buffer);
   destroy_buffer(&sks_ser_buffer);

--- a/tfhe/c_api_tests/test_micro_bench_and.c
+++ b/tfhe/c_api_tests/test_micro_bench_and.c
@@ -13,8 +13,8 @@ void micro_bench_and() {
   // int gen_keys_ok = boolean_gen_keys_with_default_parameters(&cks, &sks);
   // assert(gen_keys_ok == 0);
 
-  int gen_keys_ok = boolean_gen_keys_with_predefined_parameters_set(
-      BOOLEAN_PARAMETERS_SET_TFHE_LIB_PARAMETERS, &cks, &sks);
+  int gen_keys_ok =
+      boolean_gen_keys_with_parameters(BOOLEAN_PARAMETERS_SET_TFHE_LIB_PARAMETERS, &cks, &sks);
   assert(gen_keys_ok == 0);
 
   int num_loops = 10000;

--- a/tfhe/src/c_api/boolean/client_key.rs
+++ b/tfhe/src/c_api/boolean/client_key.rs
@@ -10,7 +10,7 @@ pub struct BooleanClientKey(pub(in crate::c_api) boolean::client_key::ClientKey)
 
 #[no_mangle]
 pub unsafe extern "C" fn boolean_gen_client_key(
-    boolean_parameters: *const super::parameters::BooleanParameters,
+    boolean_parameters: super::parameters::BooleanParameters,
     result_client_key: *mut *mut BooleanClientKey,
 ) -> c_int {
     catch_panic(|| {
@@ -20,9 +20,8 @@ pub unsafe extern "C" fn boolean_gen_client_key(
         // checked, then any access to the result pointer will segfault (mimics malloc on failure)
         *result_client_key = std::ptr::null_mut();
 
-        let boolean_parameters = get_ref_checked(boolean_parameters).unwrap();
-
-        let client_key = boolean::client_key::ClientKey::new(&boolean_parameters.0);
+        let params = crate::boolean::parameters::BooleanParameters::from(boolean_parameters);
+        let client_key = boolean::client_key::ClientKey::new(&params);
 
         let heap_allocated_client_key = Box::new(BooleanClientKey(client_key));
 

--- a/tfhe/src/c_api/boolean/destroy.rs
+++ b/tfhe/src/c_api/boolean/destroy.rs
@@ -1,7 +1,6 @@
 use crate::c_api::utils::*;
 use std::os::raw::c_int;
 
-use super::parameters::BooleanParameters;
 use super::{
     BooleanCiphertext, BooleanClientKey, BooleanCompressedCiphertext, BooleanCompressedServerKey,
     BooleanPublicKey, BooleanServerKey,
@@ -42,17 +41,6 @@ pub unsafe extern "C" fn destroy_boolean_public_key(public_key: *mut BooleanPubl
         check_ptr_is_non_null_and_aligned(public_key).unwrap();
 
         drop(Box::from_raw(public_key));
-    })
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn destroy_boolean_parameters(
-    boolean_parameters: *mut BooleanParameters,
-) -> c_int {
-    catch_panic(|| {
-        check_ptr_is_non_null_and_aligned(boolean_parameters).unwrap();
-
-        drop(Box::from_raw(boolean_parameters));
     })
 }
 

--- a/tfhe/src/c_api/boolean/mod.rs
+++ b/tfhe/src/c_api/boolean/mod.rs
@@ -40,7 +40,7 @@ pub unsafe extern "C" fn boolean_gen_keys_with_default_parameters(
 
 #[no_mangle]
 pub unsafe extern "C" fn boolean_gen_keys_with_parameters(
-    boolean_parameters: *const parameters::BooleanParameters,
+    boolean_parameters: parameters::BooleanParameters,
     result_client_key: *mut *mut BooleanClientKey,
     result_server_key: *mut *mut BooleanServerKey,
 ) -> c_int {
@@ -53,41 +53,8 @@ pub unsafe extern "C" fn boolean_gen_keys_with_parameters(
         *result_client_key = std::ptr::null_mut();
         *result_server_key = std::ptr::null_mut();
 
-        let boolean_parameters = get_ref_checked(boolean_parameters).unwrap();
-
-        let client_key = boolean::client_key::ClientKey::new(&boolean_parameters.0);
-        let server_key = boolean::server_key::ServerKey::new(&client_key);
-
-        let heap_allocated_client_key = Box::new(BooleanClientKey(client_key));
-        let heap_allocated_server_key = Box::new(BooleanServerKey(server_key));
-
-        *result_client_key = Box::into_raw(heap_allocated_client_key);
-        *result_server_key = Box::into_raw(heap_allocated_server_key);
-    })
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn boolean_gen_keys_with_predefined_parameters_set(
-    boolean_parameters_set: c_int,
-    result_client_key: *mut *mut BooleanClientKey,
-    result_server_key: *mut *mut BooleanServerKey,
-) -> c_int {
-    catch_panic(|| {
-        check_ptr_is_non_null_and_aligned(result_client_key).unwrap();
-        check_ptr_is_non_null_and_aligned(result_server_key).unwrap();
-
-        // First fill the result with a null ptr so that if we fail and the return code is not
-        // checked, then any access to the result pointer will segfault (mimics malloc on failure)
-        *result_client_key = std::ptr::null_mut();
-        *result_server_key = std::ptr::null_mut();
-
-        let boolean_parameters_set_as_enum =
-            parameters::BooleanParametersSet::try_from(boolean_parameters_set).unwrap();
-
-        let boolean_parameters =
-            parameters::BooleanParameters::from(boolean_parameters_set_as_enum);
-
-        let client_key = boolean::client_key::ClientKey::new(&boolean_parameters.0);
+        let params = crate::boolean::parameters::BooleanParameters::from(boolean_parameters);
+        let client_key = boolean::client_key::ClientKey::new(&params);
         let server_key = boolean::server_key::ServerKey::new(&client_key);
 
         let heap_allocated_client_key = Box::new(BooleanClientKey(client_key));

--- a/tfhe/src/c_api/boolean/parameters.rs
+++ b/tfhe/src/c_api/boolean/parameters.rs
@@ -1,104 +1,64 @@
-use crate::c_api::utils::*;
 use crate::core_crypto::commons::dispersion::StandardDev;
 use crate::core_crypto::commons::parameters::{
     DecompositionBaseLog, DecompositionLevelCount, GlweDimension, LweDimension, PolynomialSize,
 };
-use std::os::raw::c_int;
 
-use crate::boolean;
-
-pub struct BooleanParameters(pub(in crate::c_api) boolean::parameters::BooleanParameters);
-
-#[no_mangle]
-pub unsafe extern "C" fn boolean_get_parameters(
-    boolean_parameters_set: c_int,
-    result: *mut *mut BooleanParameters,
-) -> c_int {
-    catch_panic(|| {
-        check_ptr_is_non_null_and_aligned(result).unwrap();
-
-        let boolean_parameters_set_as_enum =
-            BooleanParametersSet::try_from(boolean_parameters_set).unwrap();
-
-        let boolean_parameters = Box::new(BooleanParameters::from(boolean_parameters_set_as_enum));
-
-        *result = Box::into_raw(boolean_parameters);
-    })
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct BooleanParameters {
+    pub lwe_dimension: usize,
+    pub glwe_dimension: usize,
+    pub polynomial_size: usize,
+    pub lwe_modular_std_dev: f64,
+    pub glwe_modular_std_dev: f64,
+    pub pbs_base_log: usize,
+    pub pbs_level: usize,
+    pub ks_base_log: usize,
+    pub ks_level: usize,
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn boolean_create_parameters(
-    lwe_dimension: usize,
-    glwe_dimension: usize,
-    polynomial_size: usize,
-    lwe_modular_std_dev: f64,
-    glwe_modular_std_dev: f64,
-    pbs_base_log: usize,
-    pbs_level: usize,
-    ks_base_log: usize,
-    ks_level: usize,
-    result_parameters: *mut *mut BooleanParameters,
-) -> c_int {
-    catch_panic(|| {
-        check_ptr_is_non_null_and_aligned(result_parameters).unwrap();
-
-        // First fill the result with a null ptr so that if we fail and the return code is not
-        // checked, then any access to the result pointer will segfault (mimics malloc on failure)
-        *result_parameters = std::ptr::null_mut();
-
-        let heap_allocated_parameters =
-            Box::new(BooleanParameters(boolean::parameters::BooleanParameters {
-                lwe_dimension: LweDimension(lwe_dimension),
-                glwe_dimension: GlweDimension(glwe_dimension),
-                polynomial_size: PolynomialSize(polynomial_size),
-                lwe_modular_std_dev: StandardDev(lwe_modular_std_dev),
-                glwe_modular_std_dev: StandardDev(glwe_modular_std_dev),
-                pbs_base_log: DecompositionBaseLog(pbs_base_log),
-                pbs_level: DecompositionLevelCount(pbs_level),
-                ks_base_log: DecompositionBaseLog(ks_base_log),
-                ks_level: DecompositionLevelCount(ks_level),
-            }));
-
-        *result_parameters = Box::into_raw(heap_allocated_parameters);
-    })
-}
-
-pub(in crate::c_api) enum BooleanParametersSet {
-    DefaultParameters,
-    TfheLibParameters,
-}
-
-pub const BOOLEAN_PARAMETERS_SET_DEFAULT_PARAMETERS: c_int = 0;
-pub const BOOLEAN_PARAMETERS_SET_TFHE_LIB_PARAMETERS: c_int = 1;
-
-impl TryFrom<c_int> for BooleanParametersSet {
-    type Error = String;
-
-    fn try_from(value: c_int) -> Result<Self, Self::Error> {
-        match value {
-            BOOLEAN_PARAMETERS_SET_DEFAULT_PARAMETERS => {
-                Ok(BooleanParametersSet::DefaultParameters)
-            }
-            BOOLEAN_PARAMETERS_SET_TFHE_LIB_PARAMETERS => {
-                Ok(BooleanParametersSet::TfheLibParameters)
-            }
-            _ => Err(format!(
-                "Invalid value '{value}' for BooleansParametersSet, use \
-                BOOLEAN_PARAMETERS_SET constants"
-            )),
+impl From<BooleanParameters> for crate::boolean::parameters::BooleanParameters {
+    fn from(c_params: BooleanParameters) -> Self {
+        Self {
+            lwe_dimension: LweDimension(c_params.lwe_dimension),
+            glwe_dimension: GlweDimension(c_params.glwe_dimension),
+            polynomial_size: PolynomialSize(c_params.polynomial_size),
+            lwe_modular_std_dev: StandardDev(c_params.lwe_modular_std_dev),
+            glwe_modular_std_dev: StandardDev(c_params.glwe_modular_std_dev),
+            pbs_base_log: DecompositionBaseLog(c_params.pbs_base_log),
+            pbs_level: DecompositionLevelCount(c_params.pbs_level),
+            ks_base_log: DecompositionBaseLog(c_params.ks_base_log),
+            ks_level: DecompositionLevelCount(c_params.ks_level),
         }
     }
 }
 
-impl From<BooleanParametersSet> for BooleanParameters {
-    fn from(boolean_parameters_set: BooleanParametersSet) -> Self {
-        match boolean_parameters_set {
-            BooleanParametersSet::DefaultParameters => {
-                BooleanParameters(boolean::parameters::DEFAULT_PARAMETERS)
-            }
-            BooleanParametersSet::TfheLibParameters => {
-                BooleanParameters(boolean::parameters::TFHE_LIB_PARAMETERS)
-            }
+impl From<crate::boolean::parameters::BooleanParameters> for BooleanParameters {
+    fn from(rust_params: crate::boolean::parameters::BooleanParameters) -> Self {
+        Self::convert(rust_params)
+    }
+}
+
+impl BooleanParameters {
+    const fn convert(rust_params: crate::boolean::parameters::BooleanParameters) -> Self {
+        Self {
+            lwe_dimension: rust_params.lwe_dimension.0,
+            glwe_dimension: rust_params.glwe_dimension.0,
+            polynomial_size: rust_params.polynomial_size.0,
+            lwe_modular_std_dev: rust_params.lwe_modular_std_dev.0,
+            glwe_modular_std_dev: rust_params.glwe_modular_std_dev.0,
+            pbs_base_log: rust_params.pbs_base_log.0,
+            pbs_level: rust_params.pbs_level.0,
+            ks_base_log: rust_params.ks_base_log.0,
+            ks_level: rust_params.ks_level.0,
         }
     }
 }
+
+#[no_mangle]
+pub static BOOLEAN_PARAMETERS_SET_DEFAULT_PARAMETERS: BooleanParameters =
+    BooleanParameters::convert(crate::boolean::parameters::DEFAULT_PARAMETERS);
+
+#[no_mangle]
+pub static BOOLEAN_PARAMETERS_SET_TFHE_LIB_PARAMETERS: BooleanParameters =
+    BooleanParameters::convert(crate::boolean::parameters::TFHE_LIB_PARAMETERS);


### PR DESCRIPTION
The same thing was done in 3508019cd2b46dc105d5374988dc337e2ce2ff66 for shortint.

This does it for booleans

#Fixes https://github.com/zama-ai/tfhe-rs-internal/issues/60