### PR TITLE
chore(ci): fix wasm benchmarks and boolean keys measurement

### DIFF
--- a/.github/workflows/wasm_client_benchmark.yml
+++ b/.github/workflows/wasm_client_benchmark.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Run benchmarks
         run: |
           make install_node
-          make bench_web_js_api_parallel
+          make ci_bench_web_js_api_parallel
 
       - name: Parse results
         run: |

--- a/tfhe/examples/utilities/boolean_key_sizes.rs
+++ b/tfhe/examples/utilities/boolean_key_sizes.rs
@@ -81,6 +81,11 @@ fn client_server_key_sizes(results_file: &Path) {
 }
 
 fn main() {
+    let work_dir = std::env::current_dir().unwrap();
+    let mut new_work_dir = work_dir;
+    new_work_dir.push("tfhe");
+    std::env::set_current_dir(new_work_dir).unwrap();
+
     let results_file = Path::new("tfhe/boolean_key_sizes.csv");
     client_server_key_sizes(results_file)
 }

--- a/tfhe/examples/utilities/wasm_benchmarks_parser.rs
+++ b/tfhe/examples/utilities/wasm_benchmarks_parser.rs
@@ -75,7 +75,12 @@ pub fn parse_wasm_benchmarks(results_file: &Path, raw_results_dir: &Path) {
 fn main() {
     let args = Args::parse();
 
-    let results_file = Path::new("tfhe/wasm_pk_gen.csv");
+    let work_dir = std::env::current_dir().unwrap();
+    let mut new_work_dir = work_dir;
+    new_work_dir.push("tfhe");
+    std::env::set_current_dir(new_work_dir).unwrap();
+
+    let results_file = Path::new("wasm_pk_gen.csv");
     let raw_results_dir = Path::new(&args.raw_results_dir);
 
     parse_wasm_benchmarks(results_file, raw_results_dir);


### PR DESCRIPTION
Now use the CI version of the make recipe to run WASM client benchmarks. In addition, boolean keys and wasm parsing is fixed so that benchmarks_parameters directory is created and populated under tfhe directory.