### PR TITLE
feat(c_api): safer destroys

### DIFF
--- a/tfhe/c_api_tests/test_boolean_keygen.c
+++ b/tfhe/c_api_tests/test_boolean_keygen.c
@@ -61,13 +61,13 @@ void test_default_keygen_w_serde(void) {
 
   assert(c_result == true);
 
-  destroy_boolean_client_key(cks);
-  destroy_boolean_server_key(sks);
-  destroy_boolean_ciphertext(ct);
-  destroy_boolean_ciphertext(deser_ct);
-  destroy_boolean_compressed_ciphertext(cct);
-  destroy_boolean_compressed_ciphertext(deser_cct);
-  destroy_boolean_ciphertext(decompressed_ct);
+  boolean_destroy_client_key(cks);
+  boolean_destroy_server_key(sks);
+  boolean_destroy_ciphertext(ct);
+  boolean_destroy_ciphertext(deser_ct);
+  boolean_destroy_compressed_ciphertext(cct);
+  boolean_destroy_compressed_ciphertext(deser_cct);
+  boolean_destroy_ciphertext(decompressed_ct);
   destroy_buffer(&ct_ser_buffer);
 }
 
@@ -80,16 +80,16 @@ void test_predefined_keygen_w_serde(void) {
 
   assert(gen_keys_ok == 0);
 
-  destroy_boolean_client_key(cks);
-  destroy_boolean_server_key(sks);
+  boolean_destroy_client_key(cks);
+  boolean_destroy_server_key(sks);
 
   gen_keys_ok = boolean_gen_keys_with_parameters(
       BOOLEAN_PARAMETERS_SET_TFHE_LIB_PARAMETERS, &cks, &sks);
 
   assert(gen_keys_ok == 0);
 
-  destroy_boolean_client_key(cks);
-  destroy_boolean_server_key(sks);
+  boolean_destroy_client_key(cks);
+  boolean_destroy_server_key(sks);
 }
 
 void test_custom_keygen(void) {
@@ -111,8 +111,8 @@ void test_custom_keygen(void) {
 
   assert(gen_keys_ok == 0);
 
-  destroy_boolean_client_key(cks);
-  destroy_boolean_server_key(sks);
+  boolean_destroy_client_key(cks);
+  boolean_destroy_server_key(sks);
 }
 
 void test_public_keygen(void) {
@@ -137,9 +137,9 @@ void test_public_keygen(void) {
 
   assert(result == true);
 
-  destroy_boolean_client_key(cks);
-  destroy_boolean_public_key(pks);
-  destroy_boolean_ciphertext(ct);
+  boolean_destroy_client_key(cks);
+  boolean_destroy_public_key(pks);
+  boolean_destroy_ciphertext(ct);
 }
 
 int main(void) {

--- a/tfhe/c_api_tests/test_boolean_server_key.c
+++ b/tfhe/c_api_tests/test_boolean_server_key.c
@@ -51,9 +51,9 @@ void test_binary_boolean_function(BooleanClientKey *cks, BooleanServerKey *sks,
 
           assert(decrypted_result == expected);
 
-          destroy_boolean_ciphertext(ct_left);
-          destroy_boolean_ciphertext(ct_right);
-          destroy_boolean_ciphertext(ct_result);
+          boolean_destroy_ciphertext(ct_left);
+          boolean_destroy_ciphertext(ct_right);
+          boolean_destroy_ciphertext(ct_result);
         }
       }
     }
@@ -103,8 +103,8 @@ void test_binary_boolean_function_assign(
 
           assert(decrypted_result == expected);
 
-          destroy_boolean_ciphertext(ct_left_and_result);
-          destroy_boolean_ciphertext(ct_right);
+          boolean_destroy_ciphertext(ct_left_and_result);
+          boolean_destroy_ciphertext(ct_right);
         }
       }
     }
@@ -139,8 +139,8 @@ void test_binary_boolean_function_scalar(BooleanClientKey *cks, BooleanServerKey
 
       assert(decrypted_result == expected);
 
-      destroy_boolean_ciphertext(ct_left);
-      destroy_boolean_ciphertext(ct_result);
+      boolean_destroy_ciphertext(ct_left);
+      boolean_destroy_ciphertext(ct_result);
     }
   }
 }
@@ -171,7 +171,7 @@ void test_binary_boolean_function_scalar_assign(BooleanClientKey *cks, BooleanSe
 
       assert(decrypted_result == expected);
 
-      destroy_boolean_ciphertext(ct_left_and_result);
+      boolean_destroy_ciphertext(ct_left_and_result);
     }
   }
 }
@@ -205,8 +205,8 @@ void test_not(BooleanClientKey *cks, BooleanServerKey *sks) {
 
       assert(decrypted_result == expected);
 
-      destroy_boolean_ciphertext(ct_in);
-      destroy_boolean_ciphertext(ct_result);
+      boolean_destroy_ciphertext(ct_in);
+      boolean_destroy_ciphertext(ct_result);
     }
   }
 }
@@ -239,7 +239,7 @@ void test_not_assign(BooleanClientKey *cks, BooleanServerKey *sks) {
 
       assert(decrypted_result == expected);
 
-      destroy_boolean_ciphertext(ct_in_and_result);
+      boolean_destroy_ciphertext(ct_in_and_result);
     }
   }
 }
@@ -300,10 +300,10 @@ void test_mux(BooleanClientKey *cks, BooleanServerKey *sks) {
 
               assert(decrypted_result == expected);
 
-              destroy_boolean_ciphertext(ct_cond);
-              destroy_boolean_ciphertext(ct_then);
-              destroy_boolean_ciphertext(ct_else);
-              destroy_boolean_ciphertext(ct_result);
+              boolean_destroy_ciphertext(ct_cond);
+              boolean_destroy_ciphertext(ct_then);
+              boolean_destroy_ciphertext(ct_else);
+              boolean_destroy_ciphertext(ct_result);
             }
           }
         }
@@ -407,12 +407,12 @@ void test_server_key(void) {
   test_binary_boolean_function_scalar_assign(deser_cks, deser_sks, c_xnor,
                                              boolean_server_key_xnor_scalar_assign);
 
-  destroy_boolean_client_key(cks);
-  destroy_boolean_compressed_server_key(csks);
-  destroy_boolean_server_key(sks);
-  destroy_boolean_client_key(deser_cks);
-  destroy_boolean_compressed_server_key(deser_csks);
-  destroy_boolean_server_key(deser_sks);
+  boolean_destroy_client_key(cks);
+  boolean_destroy_compressed_server_key(csks);
+  boolean_destroy_server_key(sks);
+  boolean_destroy_client_key(deser_cks);
+  boolean_destroy_compressed_server_key(deser_csks);
+  boolean_destroy_server_key(deser_sks);
   destroy_buffer(&cks_ser_buffer);
   destroy_buffer(&csks_ser_buffer);
   destroy_buffer(&sks_ser_buffer);

--- a/tfhe/c_api_tests/test_high_level_custom_integers.c
+++ b/tfhe/c_api_tests/test_high_level_custom_integers.c
@@ -111,6 +111,9 @@ int uint256_public_key(const ClientKey *client_key,
     // transfer ownership
     lhs = expand_output[0];
     rhs = expand_output[1];
+    // We can destroy the compact list 
+    // The expanded ciphertext are independant from it
+    compact_fhe_uint256_list_destroy(list);
 
     ok = fhe_uint256_sub(lhs, rhs, &result);
     assert(ok == 0);

--- a/tfhe/c_api_tests/test_micro_bench_and.c
+++ b/tfhe/c_api_tests/test_micro_bench_and.c
@@ -32,7 +32,7 @@ void micro_bench_and() {
   for (int idx_loops = 0; idx_loops < num_loops; ++idx_loops) {
     BooleanCiphertext *ct_result = NULL;
     boolean_server_key_and(sks, ct_left, ct_right, &ct_result);
-    destroy_boolean_ciphertext(ct_result);
+    boolean_destroy_ciphertext(ct_result);
   }
 
   clock_t stop = clock();
@@ -41,10 +41,10 @@ void micro_bench_and() {
 
   printf("%g ms, mean %g ms\n", elapsed_ms, mean_ms);
 
-  destroy_boolean_client_key(cks);
-  destroy_boolean_server_key(sks);
-  destroy_boolean_ciphertext(ct_left);
-  destroy_boolean_ciphertext(ct_right);
+  boolean_destroy_client_key(cks);
+  boolean_destroy_server_key(sks);
+  boolean_destroy_ciphertext(ct_left);
+  boolean_destroy_ciphertext(ct_right);
 }
 
 int main(void) {

--- a/tfhe/c_api_tests/test_shortint_keygen.c
+++ b/tfhe/c_api_tests/test_shortint_keygen.c
@@ -62,13 +62,13 @@ void test_predefined_keygen_w_serde(void) {
 
   assert(c_result == 3);
 
-  destroy_shortint_client_key(cks);
-  destroy_shortint_server_key(sks);
-  destroy_shortint_ciphertext(ct);
-  destroy_shortint_ciphertext(deser_ct);
-  destroy_shortint_compressed_ciphertext(cct);
-  destroy_shortint_compressed_ciphertext(deser_cct);
-  destroy_shortint_ciphertext(decompressed_ct);
+  shortint_destroy_client_key(cks);
+  shortint_destroy_server_key(sks);
+  shortint_destroy_ciphertext(ct);
+  shortint_destroy_ciphertext(deser_ct);
+  shortint_destroy_compressed_ciphertext(cct);
+  shortint_destroy_compressed_ciphertext(deser_cct);
+  shortint_destroy_ciphertext(decompressed_ct);
   destroy_buffer(&ct_ser_buffer);
 }
 
@@ -90,9 +90,9 @@ void test_server_key_trivial_encrypt(void) {
 
   assert(result == 3);
 
-  destroy_shortint_client_key(cks);
-  destroy_shortint_server_key(sks);
-  destroy_shortint_ciphertext(ct);
+  shortint_destroy_client_key(cks);
+  shortint_destroy_server_key(sks);
+  shortint_destroy_ciphertext(ct);
 }
 
 void test_custom_keygen(void) {
@@ -118,8 +118,8 @@ void test_custom_keygen(void) {
 
   assert(gen_keys_ok == 0);
 
-  destroy_shortint_client_key(cks);
-  destroy_shortint_server_key(sks);
+  shortint_destroy_client_key(cks);
+  shortint_destroy_server_key(sks);
 }
 
 void test_public_keygen(ShortintPublicKeyKind pk_kind) {
@@ -154,11 +154,11 @@ void test_public_keygen(ShortintPublicKeyKind pk_kind) {
 
   assert(result == 2);
 
-  destroy_shortint_client_key(cks);
-  destroy_shortint_public_key(pks);
-  destroy_shortint_public_key(pks_deser);
+  shortint_destroy_client_key(cks);
+  shortint_destroy_public_key(pks);
+  shortint_destroy_public_key(pks_deser);
   destroy_buffer(&pks_ser_buff);
-  destroy_shortint_ciphertext(ct);
+  shortint_destroy_ciphertext(ct);
 }
 
 void test_compressed_public_keygen(ShortintPublicKeyKind pk_kind) {
@@ -197,10 +197,10 @@ void test_compressed_public_keygen(ShortintPublicKeyKind pk_kind) {
 
   assert(result == 2);
 
-  destroy_shortint_client_key(cks);
-  destroy_shortint_compressed_public_key(cpks);
-  destroy_shortint_public_key(pks);
-  destroy_shortint_ciphertext(ct);
+  shortint_destroy_client_key(cks);
+  shortint_destroy_compressed_public_key(cpks);
+  shortint_destroy_public_key(pks);
+  shortint_destroy_ciphertext(ct);
 }
 
 int main(void) {

--- a/tfhe/c_api_tests/test_shortint_pbs.c
+++ b/tfhe/c_api_tests/test_shortint_pbs.c
@@ -101,13 +101,13 @@ void test_shortint_pbs_2_bits_message(void) {
 
     assert(result_assign == double_accumulator_2_bits_message(result_non_assign));
 
-    destroy_shortint_ciphertext(ct);
-    destroy_shortint_ciphertext(ct_out);
+    shortint_destroy_ciphertext(ct);
+    shortint_destroy_ciphertext(ct_out);
   }
 
-  destroy_shortint_pbs_accumulator(accumulator);
-  destroy_shortint_client_key(cks);
-  destroy_shortint_server_key(sks);
+  shortint_destroy_pbs_accumulator(accumulator);
+  shortint_destroy_client_key(cks);
+  shortint_destroy_server_key(sks);
 }
 
 void test_shortint_bivariate_pbs_2_bits_message(void) {
@@ -171,15 +171,15 @@ void test_shortint_bivariate_pbs_2_bits_message(void) {
       assert(result_assign ==
              product_accumulator_2_bits_encrypted_mul(result_non_assign, right_val));
 
-      destroy_shortint_ciphertext(ct_left);
-      destroy_shortint_ciphertext(ct_right);
-      destroy_shortint_ciphertext(ct_out);
+      shortint_destroy_ciphertext(ct_left);
+      shortint_destroy_ciphertext(ct_right);
+      shortint_destroy_ciphertext(ct_out);
     }
   }
 
-  destroy_shortint_bivariate_pbs_accumulator(accumulator);
-  destroy_shortint_client_key(cks);
-  destroy_shortint_server_key(sks);
+  shortint_destroy_bivariate_pbs_accumulator(accumulator);
+  shortint_destroy_client_key(cks);
+  shortint_destroy_server_key(sks);
 }
 
 int main(void) {

--- a/tfhe/c_api_tests/test_shortint_server_key.c
+++ b/tfhe/c_api_tests/test_shortint_server_key.c
@@ -61,8 +61,8 @@ void test_shortint_unary_op(const ShortintClientKey *cks, const ShortintServerKe
 
       assert(decrypted_result == expected);
 
-      destroy_shortint_ciphertext(ct_in);
-      destroy_shortint_ciphertext(ct_result);
+      shortint_destroy_ciphertext(ct_in);
+      shortint_destroy_ciphertext(ct_result);
     }
   }
 }
@@ -109,7 +109,7 @@ void test_shortint_unary_op_assign(const ShortintClientKey *cks, const ShortintS
 
       assert(decrypted_result == expected);
 
-      destroy_shortint_ciphertext(ct_in_and_result);
+      shortint_destroy_ciphertext(ct_in_and_result);
     }
   }
 }
@@ -165,9 +165,9 @@ void test_shortint_binary_op(const ShortintClientKey *cks, const ShortintServerK
 
         assert(decrypted_result == expected);
 
-        destroy_shortint_ciphertext(ct_left);
-        destroy_shortint_ciphertext(ct_right);
-        destroy_shortint_ciphertext(ct_result);
+        shortint_destroy_ciphertext(ct_left);
+        shortint_destroy_ciphertext(ct_right);
+        shortint_destroy_ciphertext(ct_result);
       }
     }
   }
@@ -227,8 +227,8 @@ void test_shortint_binary_op_assign(const ShortintClientKey *cks, const Shortint
 
         assert(decrypted_result == expected);
 
-        destroy_shortint_ciphertext(ct_left_and_result);
-        destroy_shortint_ciphertext(ct_right);
+        shortint_destroy_ciphertext(ct_left_and_result);
+        shortint_destroy_ciphertext(ct_right);
       }
     }
   }
@@ -294,8 +294,8 @@ void test_shortint_binary_scalar_op(
 
         assert(decrypted_result == expected);
 
-        destroy_shortint_ciphertext(ct_left);
-        destroy_shortint_ciphertext(ct_result);
+        shortint_destroy_ciphertext(ct_left);
+        shortint_destroy_ciphertext(ct_result);
       }
     }
   }
@@ -362,7 +362,7 @@ void test_shortint_binary_scalar_op_assign(
 
         assert(decrypted_result == expected);
 
-        destroy_shortint_ciphertext(ct_left_and_result);
+        shortint_destroy_ciphertext(ct_left_and_result);
       }
     }
   }
@@ -728,14 +728,14 @@ void test_server_key(void) {
       deser_cks, deser_sks, cks_small, sks_small, message_bits, carry_bits, scalar_mod,
       shortint_server_key_unchecked_scalar_mod_assign, forbidden_scalar_mod_values, 1);
 
-  destroy_shortint_client_key(cks);
-  destroy_shortint_client_key(cks_small);
-  destroy_shortint_compressed_server_key(csks);
-  destroy_shortint_server_key(sks);
-  destroy_shortint_server_key(sks_small);
-  destroy_shortint_client_key(deser_cks);
-  destroy_shortint_compressed_server_key(deser_csks);
-  destroy_shortint_server_key(deser_sks);
+  shortint_destroy_client_key(cks);
+  shortint_destroy_client_key(cks_small);
+  shortint_destroy_compressed_server_key(csks);
+  shortint_destroy_server_key(sks);
+  shortint_destroy_server_key(sks_small);
+  shortint_destroy_client_key(deser_cks);
+  shortint_destroy_compressed_server_key(deser_csks);
+  shortint_destroy_server_key(deser_sks);
   destroy_buffer(&cks_ser_buffer);
   destroy_buffer(&csks_ser_buffer);
   destroy_buffer(&sks_ser_buffer);

--- a/tfhe/src/c_api/boolean/destroy.rs
+++ b/tfhe/src/c_api/boolean/destroy.rs
@@ -7,7 +7,11 @@ use super::{
 };
 
 #[no_mangle]
-pub unsafe extern "C" fn destroy_boolean_client_key(client_key: *mut BooleanClientKey) -> c_int {
+pub unsafe extern "C" fn boolean_destroy_client_key(client_key: *mut BooleanClientKey) -> c_int {
+    if client_key.is_null() {
+        return 0;
+    }
+
     catch_panic(|| {
         check_ptr_is_non_null_and_aligned(client_key).unwrap();
 
@@ -16,7 +20,10 @@ pub unsafe extern "C" fn destroy_boolean_client_key(client_key: *mut BooleanClie
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn destroy_boolean_server_key(server_key: *mut BooleanServerKey) -> c_int {
+pub unsafe extern "C" fn boolean_destroy_server_key(server_key: *mut BooleanServerKey) -> c_int {
+    if server_key.is_null() {
+        return 0;
+    }
     catch_panic(|| {
         check_ptr_is_non_null_and_aligned(server_key).unwrap();
 
@@ -25,9 +32,12 @@ pub unsafe extern "C" fn destroy_boolean_server_key(server_key: *mut BooleanServ
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn destroy_boolean_compressed_server_key(
+pub unsafe extern "C" fn boolean_destroy_compressed_server_key(
     server_key: *mut BooleanCompressedServerKey,
 ) -> c_int {
+    if server_key.is_null() {
+        return 0;
+    }
     catch_panic(|| {
         check_ptr_is_non_null_and_aligned(server_key).unwrap();
 
@@ -36,7 +46,10 @@ pub unsafe extern "C" fn destroy_boolean_compressed_server_key(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn destroy_boolean_public_key(public_key: *mut BooleanPublicKey) -> c_int {
+pub unsafe extern "C" fn boolean_destroy_public_key(public_key: *mut BooleanPublicKey) -> c_int {
+    if public_key.is_null() {
+        return 0;
+    }
     catch_panic(|| {
         check_ptr_is_non_null_and_aligned(public_key).unwrap();
 
@@ -45,9 +58,12 @@ pub unsafe extern "C" fn destroy_boolean_public_key(public_key: *mut BooleanPubl
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn destroy_boolean_ciphertext(
+pub unsafe extern "C" fn boolean_destroy_ciphertext(
     boolean_ciphertext: *mut BooleanCiphertext,
 ) -> c_int {
+    if boolean_ciphertext.is_null() {
+        return 0;
+    }
     catch_panic(|| {
         check_ptr_is_non_null_and_aligned(boolean_ciphertext).unwrap();
 
@@ -56,9 +72,12 @@ pub unsafe extern "C" fn destroy_boolean_ciphertext(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn destroy_boolean_compressed_ciphertext(
+pub unsafe extern "C" fn boolean_destroy_compressed_ciphertext(
     boolean_ciphertext: *mut BooleanCompressedCiphertext,
 ) -> c_int {
+    if boolean_ciphertext.is_null() {
+        return 0;
+    }
     catch_panic(|| {
         check_ptr_is_non_null_and_aligned(boolean_ciphertext).unwrap();
 

--- a/tfhe/src/c_api/shortint/destroy.rs
+++ b/tfhe/src/c_api/shortint/destroy.rs
@@ -8,7 +8,10 @@ use super::{
 };
 
 #[no_mangle]
-pub unsafe extern "C" fn destroy_shortint_client_key(client_key: *mut ShortintClientKey) -> c_int {
+pub unsafe extern "C" fn shortint_destroy_client_key(client_key: *mut ShortintClientKey) -> c_int {
+    if client_key.is_null() {
+        return 0;
+    }
     catch_panic(|| {
         check_ptr_is_non_null_and_aligned(client_key).unwrap();
 
@@ -17,7 +20,10 @@ pub unsafe extern "C" fn destroy_shortint_client_key(client_key: *mut ShortintCl
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn destroy_shortint_server_key(server_key: *mut ShortintServerKey) -> c_int {
+pub unsafe extern "C" fn shortint_destroy_server_key(server_key: *mut ShortintServerKey) -> c_int {
+    if server_key.is_null() {
+        return 0;
+    }
     catch_panic(|| {
         check_ptr_is_non_null_and_aligned(server_key).unwrap();
 
@@ -26,9 +32,12 @@ pub unsafe extern "C" fn destroy_shortint_server_key(server_key: *mut ShortintSe
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn destroy_shortint_compressed_server_key(
+pub unsafe extern "C" fn shortint_destroy_compressed_server_key(
     server_key: *mut ShortintCompressedServerKey,
 ) -> c_int {
+    if server_key.is_null() {
+        return 0;
+    }
     catch_panic(|| {
         check_ptr_is_non_null_and_aligned(server_key).unwrap();
 
@@ -37,7 +46,10 @@ pub unsafe extern "C" fn destroy_shortint_compressed_server_key(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn destroy_shortint_public_key(public_key: *mut ShortintPublicKey) -> c_int {
+pub unsafe extern "C" fn shortint_destroy_public_key(public_key: *mut ShortintPublicKey) -> c_int {
+    if public_key.is_null() {
+        return 0;
+    }
     catch_panic(|| {
         check_ptr_is_non_null_and_aligned(public_key).unwrap();
 
@@ -46,9 +58,12 @@ pub unsafe extern "C" fn destroy_shortint_public_key(public_key: *mut ShortintPu
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn destroy_shortint_compressed_public_key(
+pub unsafe extern "C" fn shortint_destroy_compressed_public_key(
     compressed_public_key: *mut ShortintCompressedPublicKey,
 ) -> c_int {
+    if compressed_public_key.is_null() {
+        return 0;
+    }
     catch_panic(|| {
         check_ptr_is_non_null_and_aligned(compressed_public_key).unwrap();
 
@@ -57,9 +72,12 @@ pub unsafe extern "C" fn destroy_shortint_compressed_public_key(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn destroy_shortint_ciphertext(
+pub unsafe extern "C" fn shortint_destroy_ciphertext(
     shortint_ciphertext: *mut ShortintCiphertext,
 ) -> c_int {
+    if shortint_ciphertext.is_null() {
+        return 0;
+    }
     catch_panic(|| {
         check_ptr_is_non_null_and_aligned(shortint_ciphertext).unwrap();
 
@@ -68,9 +86,12 @@ pub unsafe extern "C" fn destroy_shortint_ciphertext(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn destroy_shortint_compressed_ciphertext(
+pub unsafe extern "C" fn shortint_destroy_compressed_ciphertext(
     shortint_ciphertext: *mut ShortintCompressedCiphertext,
 ) -> c_int {
+    if shortint_ciphertext.is_null() {
+        return 0;
+    }
     catch_panic(|| {
         check_ptr_is_non_null_and_aligned(shortint_ciphertext).unwrap();
 
@@ -79,9 +100,12 @@ pub unsafe extern "C" fn destroy_shortint_compressed_ciphertext(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn destroy_shortint_pbs_accumulator(
+pub unsafe extern "C" fn shortint_destroy_pbs_accumulator(
     pbs_accumulator: *mut ShortintPBSLookupTable,
 ) -> c_int {
+    if pbs_accumulator.is_null() {
+        return 0;
+    }
     catch_panic(|| {
         check_ptr_is_non_null_and_aligned(pbs_accumulator).unwrap();
 
@@ -90,9 +114,12 @@ pub unsafe extern "C" fn destroy_shortint_pbs_accumulator(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn destroy_shortint_bivariate_pbs_accumulator(
+pub unsafe extern "C" fn shortint_destroy_bivariate_pbs_accumulator(
     pbs_accumulator: *mut ShortintBivariatePBSLookupTable,
 ) -> c_int {
+    if pbs_accumulator.is_null() {
+        return 0;
+    }
     catch_panic(|| {
         check_ptr_is_non_null_and_aligned(pbs_accumulator).unwrap();
 


### PR DESCRIPTION
This adds a null check in the different destroy function of the C API. The performance impact of this should be negligible / inexistant but should make usage more ergonomic and safer.

Also this renames the detroy functions from being named `destroy_shortint_*` | `destroy_boolean_*` to
`shortint_destroy_*` | `boolean_destroy_*` as it is more coherent with the rest of the API where functions starts with `shortint` or `boolean`.

Fixes https://github.com/zama-ai/tfhe-rs-internal/issues/76