### PR TITLE
refactor(hlpai): remove ServerKeyOp trait and macros

### DIFF
--- a/tfhe/src/high_level_api/integers/client_key.rs
+++ b/tfhe/src/high_level_api/integers/client_key.rs
@@ -1,4 +1,4 @@
-use super::server_key::RadixCiphertextDyn;
+use super::types::base::RadixCiphertextDyn;
 use crate::high_level_api::internal_traits::DecryptionKey;
 
 impl<ClearType> DecryptionKey<RadixCiphertextDyn, ClearType> for crate::integer::ClientKey

--- a/tfhe/src/high_level_api/integers/keys.rs
+++ b/tfhe/src/high_level_api/integers/keys.rs
@@ -6,7 +6,7 @@ use crate::core_crypto::prelude::ActivatedRandomGenerator;
 use crate::integer::U256;
 use crate::shortint::EncryptionKeyChoice;
 
-use super::server_key::RadixCiphertextDyn;
+use super::types::base::RadixCiphertextDyn;
 use super::types::compact::CompactCiphertextListDyn;
 
 #[derive(Copy, Clone, Debug, serde::Serialize, serde::Deserialize)]

--- a/tfhe/src/high_level_api/integers/server_key.rs
+++ b/tfhe/src/high_level_api/integers/server_key.rs
@@ -1,5 +1,7 @@
 use crate::integer::wopbs::WopbsKey;
 
+use super::types::base::RadixCiphertextDyn;
+
 pub(crate) fn wopbs_radix<O>(
     wopbs_key: &WopbsKey,
     server_key: &crate::integer::ServerKey,
@@ -72,18 +74,13 @@ pub trait WopbsEvaluationKey<ServerKey, Ciphertext> {
     ) -> Ciphertext;
 }
 
-impl
-    WopbsEvaluationKey<
-        crate::integer::ServerKey,
-        crate::high_level_api::integers::server_key::RadixCiphertextDyn,
-    > for WopbsKey
-{
+impl WopbsEvaluationKey<crate::integer::ServerKey, RadixCiphertextDyn> for WopbsKey {
     fn apply_wopbs(
         &self,
         sks: &crate::integer::ServerKey,
-        ct: &crate::high_level_api::integers::server_key::RadixCiphertextDyn,
+        ct: &RadixCiphertextDyn,
         f: impl Fn(u64) -> u64,
-    ) -> crate::high_level_api::integers::server_key::RadixCiphertextDyn {
+    ) -> RadixCiphertextDyn {
         match ct {
             RadixCiphertextDyn::Big(ct) => {
                 let mut tmp_ct: crate::integer::ciphertext::RadixCiphertextBig;
@@ -119,10 +116,10 @@ impl
     fn apply_bivariate_wopbs(
         &self,
         sks: &crate::integer::ServerKey,
-        lhs: &crate::high_level_api::integers::server_key::RadixCiphertextDyn,
-        rhs: &crate::high_level_api::integers::server_key::RadixCiphertextDyn,
+        lhs: &RadixCiphertextDyn,
+        rhs: &RadixCiphertextDyn,
         f: impl Fn(u64, u64) -> u64,
-    ) -> crate::high_level_api::integers::server_key::RadixCiphertextDyn {
+    ) -> RadixCiphertextDyn {
         match (lhs, rhs) {
             (RadixCiphertextDyn::Big(lhs), RadixCiphertextDyn::Big(rhs)) => {
                 let mut tmp_lhs: crate::integer::ciphertext::RadixCiphertextBig;
@@ -215,173 +212,3 @@ impl WopbsEvaluationKey<crate::integer::ServerKey, crate::integer::CrtCiphertext
         bivariate_wopbs_crt(self, sks, lhs, rhs, f)
     }
 }
-
-#[derive(Clone, serde::Deserialize, serde::Serialize)]
-pub enum RadixCiphertextDyn {
-    Big(crate::integer::RadixCiphertextBig),
-    Small(crate::integer::RadixCiphertextSmall),
-}
-
-pub(super) trait ServerKeyDefaultNeg<Ciphertext> {
-    type Output;
-    fn neg(&self, lhs: Ciphertext) -> Self::Output;
-}
-
-macro_rules! define_default_server_key_op {
-    ($op_name:ident) => {
-        paste::paste! {
-            pub trait [< ServerKeyDefault $op_name >]<Lhs, Rhs> {
-                type Output;
-
-                fn [< $op_name:lower >](
-                    &self,
-                    lhs: Lhs,
-                    rhs: Rhs,
-                ) -> Self::Output;
-            }
-
-            pub trait [< ServerKeyDefault $op_name Assign >]<Lhs, Rhs> {
-                fn [< $op_name:lower _assign >](
-                    &self,
-                    lhs: &mut Lhs,
-                    rhs: Rhs,
-                );
-            }
-        }
-    };
-    ($($op:ident),*) => {
-        $(
-            define_default_server_key_op!($op);
-        )*
-    };
-}
-
-define_default_server_key_op!(
-    Add, Sub, Mul, BitAnd, BitOr, BitXor, Shl, Shr, Eq, Ge, Gt, Le, Lt, Max, Min
-);
-
-impl ServerKeyDefaultNeg<&RadixCiphertextDyn> for crate::integer::ServerKey {
-    type Output = RadixCiphertextDyn;
-
-    fn neg(&self, lhs: &RadixCiphertextDyn) -> Self::Output {
-        match lhs {
-            RadixCiphertextDyn::Big(lhs) => RadixCiphertextDyn::Big(self.neg_parallelized(lhs)),
-            RadixCiphertextDyn::Small(lhs) => RadixCiphertextDyn::Small(self.neg_parallelized(lhs)),
-        }
-    }
-}
-
-macro_rules! impl_default_op_for_tfhe_integer_server_key_dyn {
-    ($default_trait:ident($default_trait_fn:ident) => $method:ident) => {
-        impl $default_trait<&RadixCiphertextDyn, &RadixCiphertextDyn>
-            for crate::integer::ServerKey
-        {
-            type Output = RadixCiphertextDyn;
-
-            fn $default_trait_fn(
-                &self,
-                lhs_enum: &RadixCiphertextDyn,
-                rhs_enum: &RadixCiphertextDyn,
-            ) -> Self::Output {
-                match (lhs_enum, rhs_enum) {
-                    (RadixCiphertextDyn::Big(lhs), RadixCiphertextDyn::Big(rhs)) => {
-                        RadixCiphertextDyn::Big(self.$method(lhs, rhs))
-                    }
-                    (RadixCiphertextDyn::Small(lhs), RadixCiphertextDyn::Small(rhs)) => {
-                        RadixCiphertextDyn::Small(self.$method(lhs, rhs))
-                    }
-                    (_, _) => unreachable!("internal error: mismatched big and small integer"),
-                }
-            }
-        }
-    };
-}
-
-macro_rules! impl_default_assign_op_for_tfhe_integer_server_key_dyn {
-    ($default_trait:ident($default_trait_fn:ident) => $method_assign:ident) => {
-        impl $default_trait<RadixCiphertextDyn, &RadixCiphertextDyn> for crate::integer::ServerKey {
-            fn $default_trait_fn(
-                &self,
-                lhs_enum: &mut RadixCiphertextDyn,
-                rhs_enum: &RadixCiphertextDyn,
-            ) {
-                match (lhs_enum, rhs_enum) {
-                    (RadixCiphertextDyn::Big(lhs), RadixCiphertextDyn::Big(rhs)) => {
-                        self.$method_assign(lhs, rhs)
-                    }
-                    (RadixCiphertextDyn::Small(lhs), RadixCiphertextDyn::Small(rhs)) => {
-                        self.$method_assign(lhs, rhs)
-                    }
-                    (_, _) => unreachable!("internal error: mismatched big and small integer"),
-                }
-            }
-        }
-    };
-}
-
-macro_rules! impl_default_scalar_op_for_tfhe_integer_server_key_dyn {
-    ($default_trait:ident($default_trait_fn:ident) => $method:ident) => {
-        impl $default_trait<&RadixCiphertextDyn, u64> for crate::integer::ServerKey {
-            type Output = RadixCiphertextDyn;
-
-            fn $default_trait_fn(&self, lhs: &RadixCiphertextDyn, rhs: u64) -> Self::Output {
-                let value: u64 = rhs.try_into().unwrap();
-                match lhs {
-                    RadixCiphertextDyn::Big(lhs) => {
-                        RadixCiphertextDyn::Big(self.$method(lhs, value))
-                    }
-                    RadixCiphertextDyn::Small(lhs) => {
-                        RadixCiphertextDyn::Small(self.$method(lhs, value))
-                    }
-                }
-            }
-        }
-    };
-}
-
-macro_rules! impl_default_scalar_assign_op_for_tfhe_integer_server_key_dyn {
-    ($default_trait:ident($default_trait_fn:ident) => $method_assign:ident) => {
-        impl $default_trait<RadixCiphertextDyn, u64> for crate::integer::ServerKey {
-            fn $default_trait_fn(&self, lhs: &mut RadixCiphertextDyn, rhs: u64) {
-                let value: u64 = rhs.try_into().unwrap();
-                match lhs {
-                    RadixCiphertextDyn::Big(lhs) => self.$method_assign(lhs, value),
-                    RadixCiphertextDyn::Small(lhs) => self.$method_assign(lhs, value),
-                }
-            }
-        }
-    };
-}
-
-impl_default_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultAdd(add) => add_parallelized);
-impl_default_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultSub(sub) => sub_parallelized);
-impl_default_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultMul(mul) => mul_parallelized);
-impl_default_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultBitAnd(bitand) => bitand_parallelized);
-impl_default_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultBitOr(bitor) => bitor_parallelized);
-impl_default_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultBitXor(bitxor) => bitxor_parallelized);
-impl_default_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultEq(eq) => eq_parallelized);
-impl_default_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultGe(ge) => ge_parallelized);
-impl_default_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultGt(gt) => gt_parallelized);
-impl_default_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultLe(le) => le_parallelized);
-impl_default_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultLt(lt) => lt_parallelized);
-impl_default_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultMax(max) => max_parallelized);
-impl_default_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultMin(min) => min_parallelized);
-
-impl_default_assign_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultAddAssign(add_assign) => add_assign_parallelized);
-impl_default_assign_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultSubAssign(sub_assign) => sub_assign_parallelized);
-impl_default_assign_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultMulAssign(mul_assign) => mul_assign_parallelized);
-impl_default_assign_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultBitAndAssign(bitand_assign) => bitand_assign_parallelized);
-impl_default_assign_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultBitOrAssign(bitor_assign) => bitor_assign_parallelized);
-impl_default_assign_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultBitXorAssign(bitxor_assign) => bitxor_assign_parallelized);
-
-impl_default_scalar_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultAdd(add) => scalar_add_parallelized);
-impl_default_scalar_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultSub(sub) => scalar_sub_parallelized);
-impl_default_scalar_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultMul(mul) => scalar_mul_parallelized);
-impl_default_scalar_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultShl(shl) => scalar_left_shift_parallelized);
-impl_default_scalar_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultShr(shr) => scalar_right_shift_parallelized);
-
-impl_default_scalar_assign_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultAddAssign(add_assign) => scalar_add_assign_parallelized);
-impl_default_scalar_assign_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultSubAssign(sub_assign) => scalar_sub_assign_parallelized);
-impl_default_scalar_assign_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultMulAssign(mul_assign) => scalar_mul_assign_parallelized);
-impl_default_scalar_assign_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultShlAssign(shl_assign) => scalar_left_shift_assign_parallelized);
-impl_default_scalar_assign_op_for_tfhe_integer_server_key_dyn!(ServerKeyDefaultShrAssign(shr_assign) => scalar_right_shift_assign_parallelized);

--- a/tfhe/src/high_level_api/integers/tests.rs
+++ b/tfhe/src/high_level_api/integers/tests.rs
@@ -330,7 +330,7 @@ fn test_trivial_fhe_uint8() {
     let a = FheUint8::try_encrypt_trivial(234u8).unwrap();
     assert!(matches!(
         &a.ciphertext,
-        crate::high_level_api::integers::server_key::RadixCiphertextDyn::Big(_)
+        crate::high_level_api::integers::types::base::RadixCiphertextDyn::Big(_)
     ));
 
     let clear: u8 = a.decrypt(&client_key);
@@ -350,7 +350,7 @@ fn test_trivial_fhe_uint256_small() {
     let a = FheUint256::try_encrypt_trivial(clear_a).unwrap();
     assert!(matches!(
         &a.ciphertext,
-        crate::high_level_api::integers::server_key::RadixCiphertextDyn::Small(_)
+        crate::high_level_api::integers::types::base::RadixCiphertextDyn::Small(_)
     ));
     let clear: U256 = a.decrypt(&client_key);
     assert_eq!(clear, clear_a);

--- a/tfhe/src/high_level_api/integers/types/compact.rs
+++ b/tfhe/src/high_level_api/integers/types/compact.rs
@@ -1,7 +1,6 @@
 use crate::errors::{UninitializedPublicKey, UnwrapResultExt};
 use crate::high_level_api::integers::parameters::IntegerParameter;
-use crate::high_level_api::integers::server_key::RadixCiphertextDyn;
-use crate::high_level_api::integers::types::base::GenericInteger;
+use crate::high_level_api::integers::types::base::{GenericInteger, RadixCiphertextDyn};
 use crate::high_level_api::internal_traits::TypeIdentifier;
 use crate::high_level_api::traits::FheTryEncrypt;
 use crate::integer::ciphertext::{CompactCiphertextListBig, CompactCiphertextListSmall};

--- a/tfhe/src/high_level_api/integers/types/compressed.rs
+++ b/tfhe/src/high_level_api/integers/types/compressed.rs
@@ -1,7 +1,6 @@
 use crate::errors::{UninitializedClientKey, UnwrapResultExt};
 use crate::high_level_api::integers::parameters::IntegerParameter;
-use crate::high_level_api::integers::server_key::RadixCiphertextDyn;
-use crate::high_level_api::integers::types::base::GenericInteger;
+use crate::high_level_api::integers::types::base::{GenericInteger, RadixCiphertextDyn};
 use crate::high_level_api::internal_traits::TypeIdentifier;
 use crate::high_level_api::traits::FheTryEncrypt;
 use crate::high_level_api::ClientKey;


### PR DESCRIPTION
Since 8b3d31ae8af18d0a513a1769f0b1a4f5e2ac5d7c
integers use the same serve key, so
the `GenericIntegerServerKey<P>` type was removed.

Since `GenericIntegrServerKey<P>` does not exist,
there is much less need for the collection
of server key traits (ServerKeyAdd, SeverKeySub).

This commit removes them, as well as the macro layer that was used to implement it