### PR TITLE
refactor(shortint): rename generate_accumulator into generate_lookup_…

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ fn main() {
     // f: x -> sum of the bits of x
     let f = |x:u64| x.count_ones() as u64;
 
-    // Generate the accumulator for the function
-    let acc = server_key.generate_accumulator(f);
+    // Generate the lookup table for the function
+    let acc = server_key.generate_lookup_table(f);
 
     // Compute the function over the ciphertext using the PBS
     let ct_res = server_key.apply_lookup_table(&ct_add, &acc);

--- a/tfhe/benches/shortint/bench.rs
+++ b/tfhe/benches/shortint/bench.rs
@@ -269,7 +269,7 @@ fn programmable_bootstrapping(c: &mut Criterion) {
 
         let modulus = cks.parameters.message_modulus().0 as u64;
 
-        let acc = sks.generate_accumulator(|x| x);
+        let acc = sks.generate_lookup_table(|x| x);
 
         let clear_0 = rng.gen::<u64>() % modulus;
 

--- a/tfhe/c_api_tests/test_shortint_pbs.c
+++ b/tfhe/c_api_tests/test_shortint_pbs.c
@@ -5,31 +5,31 @@
 #include <stdlib.h>
 #include <tgmath.h>
 
-uint64_t double_accumulator_2_bits_message(uint64_t in) { return (in * 2) % 4; }
+uint64_t double_lookup_table_2_bits_message(uint64_t in) { return (in * 2) % 4; }
 
-uint64_t get_max_value_of_accumulator_generator(uint64_t (*accumulator_func)(uint64_t),
+uint64_t get_max_value_of_lookup_table_generator(uint64_t (*lookup_table_func)(uint64_t),
                                                 size_t message_bits) {
   uint64_t max_value = 0;
   for (size_t idx = 0; idx < (1 << message_bits); ++idx) {
-    uint64_t acc_value = accumulator_func((uint64_t)idx);
+    uint64_t acc_value = lookup_table_func((uint64_t)idx);
     max_value = acc_value > max_value ? acc_value : max_value;
   }
 
   return max_value;
 }
 
-uint64_t product_accumulator_2_bits_encrypted_mul(uint64_t left, uint64_t right) {
+uint64_t product_lookup_table_2_bits_encrypted_mul(uint64_t left, uint64_t right) {
   return (left * right) % 4;
 }
 
-uint64_t get_max_value_of_bivariate_accumulator_generator(uint64_t (*accumulator_func)(uint64_t,
+uint64_t get_max_value_of_bivariate_lookup_table_generator(uint64_t (*lookup_table_func)(uint64_t,
                                                                                        uint64_t),
                                                           size_t message_bits_left,
                                                           size_t message_bits_right) {
   uint64_t max_value = 0;
   for (size_t idx_left = 0; idx_left < (1 << message_bits_left); ++idx_left) {
     for (size_t idx_right = 0; idx_right < (1 << message_bits_right); ++idx_right) {
-      uint64_t acc_value = accumulator_func((uint64_t)idx_left, (uint64_t)idx_right);
+      uint64_t acc_value = lookup_table_func((uint64_t)idx_left, (uint64_t)idx_right);
       max_value = acc_value > max_value ? acc_value : max_value;
     }
   }
@@ -38,7 +38,7 @@ uint64_t get_max_value_of_bivariate_accumulator_generator(uint64_t (*accumulator
 }
 
 void test_shortint_pbs_2_bits_message(void) {
-  ShortintPBSLookupTable *accumulator = NULL;
+  ShortintPBSLookupTable *lookup_table = NULL;
   ShortintClientKey *cks = NULL;
   ShortintServerKey *sks = NULL;
   ShortintPBSParameters params = SHORTINT_PARAM_MESSAGE_2_CARRY_2;
@@ -46,8 +46,8 @@ void test_shortint_pbs_2_bits_message(void) {
   int gen_keys_ok = shortint_gen_keys_with_parameters(params, &cks, &sks);
   assert(gen_keys_ok == 0);
 
-  int gen_acc_ok = shortint_server_key_generate_pbs_accumulator(
-      sks, double_accumulator_2_bits_message, &accumulator);
+  int gen_acc_ok = shortint_server_key_generate_pbs_lookup_table(
+      sks, double_lookup_table_2_bits_message, &lookup_table);
   assert(gen_acc_ok == 0);
 
   for (int in_idx = 0; in_idx < 4; ++in_idx) {
@@ -65,11 +65,11 @@ void test_shortint_pbs_2_bits_message(void) {
 
     assert(degree == 3);
 
-    int pbs_ok = shortint_server_key_programmable_bootstrap(sks, accumulator, ct, &ct_out);
+    int pbs_ok = shortint_server_key_programmable_bootstrap(sks, lookup_table, ct, &ct_out);
     assert(pbs_ok == 0);
 
     size_t degree_to_set =
-        (size_t)get_max_value_of_accumulator_generator(double_accumulator_2_bits_message, 2);
+        (size_t)get_max_value_of_lookup_table_generator(double_lookup_table_2_bits_message, 2);
 
     int set_degree_ok = shortint_ciphertext_set_degree(ct_out, degree_to_set);
     assert(set_degree_ok == 0);
@@ -84,13 +84,13 @@ void test_shortint_pbs_2_bits_message(void) {
     int decrypt_non_assign_ok = shortint_client_key_decrypt(cks, ct_out, &result_non_assign);
     assert(decrypt_non_assign_ok == 0);
 
-    assert(result_non_assign == double_accumulator_2_bits_message(in_val));
+    assert(result_non_assign == double_lookup_table_2_bits_message(in_val));
 
-    int pbs_assign_ok = shortint_server_key_programmable_bootstrap_assign(sks, accumulator, ct_out);
+    int pbs_assign_ok = shortint_server_key_programmable_bootstrap_assign(sks, lookup_table, ct_out);
     assert(pbs_assign_ok == 0);
 
     degree_to_set =
-        (size_t)get_max_value_of_accumulator_generator(double_accumulator_2_bits_message, 2);
+        (size_t)get_max_value_of_lookup_table_generator(double_lookup_table_2_bits_message, 2);
 
     set_degree_ok = shortint_ciphertext_set_degree(ct_out, degree_to_set);
     assert(set_degree_ok == 0);
@@ -99,19 +99,19 @@ void test_shortint_pbs_2_bits_message(void) {
     int decrypt_assign_ok = shortint_client_key_decrypt(cks, ct_out, &result_assign);
     assert(decrypt_assign_ok == 0);
 
-    assert(result_assign == double_accumulator_2_bits_message(result_non_assign));
+    assert(result_assign == double_lookup_table_2_bits_message(result_non_assign));
 
     shortint_destroy_ciphertext(ct);
     shortint_destroy_ciphertext(ct_out);
   }
 
-  shortint_destroy_pbs_accumulator(accumulator);
+  shortint_destroy_pbs_lookup_table(lookup_table);
   shortint_destroy_client_key(cks);
   shortint_destroy_server_key(sks);
 }
 
 void test_shortint_bivariate_pbs_2_bits_message(void) {
-  ShortintBivariatePBSLookupTable *accumulator = NULL;
+  ShortintBivariatePBSLookupTable *lookup_table = NULL;
   ShortintClientKey *cks = NULL;
   ShortintServerKey *sks = NULL;
   ShortintPBSParameters params = SHORTINT_PARAM_MESSAGE_2_CARRY_2;
@@ -119,8 +119,8 @@ void test_shortint_bivariate_pbs_2_bits_message(void) {
   int gen_keys_ok = shortint_gen_keys_with_parameters(params, &cks, &sks);
   assert(gen_keys_ok == 0);
 
-  int gen_acc_ok = shortint_server_key_generate_bivariate_pbs_accumulator(
-      sks, product_accumulator_2_bits_encrypted_mul, &accumulator);
+  int gen_acc_ok = shortint_server_key_generate_bivariate_pbs_lookup_table(
+      sks, product_lookup_table_2_bits_encrypted_mul, &lookup_table);
   assert(gen_acc_ok == 0);
 
   for (int left_idx = 0; left_idx < 4; ++left_idx) {
@@ -138,12 +138,12 @@ void test_shortint_bivariate_pbs_2_bits_message(void) {
       int encrypt_right_ok = shortint_client_key_encrypt(cks, right_val, &ct_right);
       assert(encrypt_right_ok == 0);
 
-      int pbs_ok = shortint_server_key_bivariate_programmable_bootstrap(sks, accumulator, ct_left,
+      int pbs_ok = shortint_server_key_bivariate_programmable_bootstrap(sks, lookup_table, ct_left,
                                                                         ct_right, &ct_out);
       assert(pbs_ok == 0);
 
-      size_t degree_to_set = (size_t)get_max_value_of_bivariate_accumulator_generator(
-          product_accumulator_2_bits_encrypted_mul, 2, 2);
+      size_t degree_to_set = (size_t)get_max_value_of_bivariate_lookup_table_generator(
+          product_lookup_table_2_bits_encrypted_mul, 2, 2);
 
       int set_degree_ok = shortint_ciphertext_set_degree(ct_right, degree_to_set);
       assert(set_degree_ok == 0);
@@ -152,14 +152,14 @@ void test_shortint_bivariate_pbs_2_bits_message(void) {
       int decrypt_non_assign_ok = shortint_client_key_decrypt(cks, ct_out, &result_non_assign);
       assert(decrypt_non_assign_ok == 0);
 
-      assert(result_non_assign == product_accumulator_2_bits_encrypted_mul(left_val, right_val));
+      assert(result_non_assign == product_lookup_table_2_bits_encrypted_mul(left_val, right_val));
 
       int pbs_assign_ok = shortint_server_key_bivariate_programmable_bootstrap_assign(
-          sks, accumulator, ct_out, ct_right);
+          sks, lookup_table, ct_out, ct_right);
       assert(pbs_assign_ok == 0);
 
       degree_to_set =
-          (size_t)get_max_value_of_accumulator_generator(double_accumulator_2_bits_message, 2);
+          (size_t)get_max_value_of_lookup_table_generator(double_lookup_table_2_bits_message, 2);
 
       set_degree_ok = shortint_ciphertext_set_degree(ct_out, degree_to_set);
       assert(set_degree_ok == 0);
@@ -169,7 +169,7 @@ void test_shortint_bivariate_pbs_2_bits_message(void) {
       assert(decrypt_assign_ok == 0);
 
       assert(result_assign ==
-             product_accumulator_2_bits_encrypted_mul(result_non_assign, right_val));
+             product_lookup_table_2_bits_encrypted_mul(result_non_assign, right_val));
 
       shortint_destroy_ciphertext(ct_left);
       shortint_destroy_ciphertext(ct_right);
@@ -177,7 +177,7 @@ void test_shortint_bivariate_pbs_2_bits_message(void) {
     }
   }
 
-  shortint_destroy_bivariate_pbs_accumulator(accumulator);
+  shortint_destroy_bivariate_pbs_lookup_table(lookup_table);
   shortint_destroy_client_key(cks);
   shortint_destroy_server_key(sks);
 }

--- a/tfhe/docs/shortint/operations.md
+++ b/tfhe/docs/shortint/operations.md
@@ -336,8 +336,7 @@ fn main() {
     // We use the private client key to encrypt two messages:
     let ct_1 = client_key.encrypt(msg1);
 
-    //define the accumulator as the
-    let acc = server_key.generate_accumulator(|n| n.count_ones().into());
+    let acc = server_key.generate_lookup_table(|n| n.count_ones().into());
 
     // add the two ciphertexts
     let ct_res = server_key.apply_lookup_table(&ct_1, &acc);
@@ -371,8 +370,8 @@ fn main() {
     let ct_1 = client_key.encrypt(msg1);
     let mut ct_2 = client_key.encrypt(msg2);
 
-    // Compute the accumulator for the bivariate functions
-    let acc = server_key.generate_accumulator_bivariate(|x,y| (x.count_ones()
+    // Compute the lookup table for the bivariate functions
+    let acc = server_key.generate_lookup_table_bivariate(|x,y| (x.count_ones()
         + y.count_ones()) as u64 % modulus );
 
     let ct_res = server_key.smart_apply_lookup_table_bivariate(&ct_1, &mut ct_2, &acc);

--- a/tfhe/src/c_api/shortint/destroy.rs
+++ b/tfhe/src/c_api/shortint/destroy.rs
@@ -100,29 +100,29 @@ pub unsafe extern "C" fn shortint_destroy_compressed_ciphertext(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn shortint_destroy_pbs_accumulator(
-    pbs_accumulator: *mut ShortintPBSLookupTable,
+pub unsafe extern "C" fn shortint_destroy_pbs_lookup_table(
+    pbs_lookup_table: *mut ShortintPBSLookupTable,
 ) -> c_int {
-    if pbs_accumulator.is_null() {
+    if pbs_lookup_table.is_null() {
         return 0;
     }
     catch_panic(|| {
-        check_ptr_is_non_null_and_aligned(pbs_accumulator).unwrap();
+        check_ptr_is_non_null_and_aligned(pbs_lookup_table).unwrap();
 
-        drop(Box::from_raw(pbs_accumulator));
+        drop(Box::from_raw(pbs_lookup_table));
     })
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn shortint_destroy_bivariate_pbs_accumulator(
-    pbs_accumulator: *mut ShortintBivariatePBSLookupTable,
+pub unsafe extern "C" fn shortint_destroy_bivariate_pbs_lookup_table(
+    pbs_lookup_table: *mut ShortintBivariatePBSLookupTable,
 ) -> c_int {
-    if pbs_accumulator.is_null() {
+    if pbs_lookup_table.is_null() {
         return 0;
     }
     catch_panic(|| {
-        check_ptr_is_non_null_and_aligned(pbs_accumulator).unwrap();
+        check_ptr_is_non_null_and_aligned(pbs_lookup_table).unwrap();
 
-        drop(Box::from_raw(pbs_accumulator));
+        drop(Box::from_raw(pbs_lookup_table));
     })
 }

--- a/tfhe/src/c_api/shortint/server_key/pbs.rs
+++ b/tfhe/src/c_api/shortint/server_key/pbs.rs
@@ -15,9 +15,9 @@ pub struct ShortintBivariatePBSLookupTable(
 );
 
 #[no_mangle]
-pub unsafe extern "C" fn shortint_server_key_generate_pbs_accumulator(
+pub unsafe extern "C" fn shortint_server_key_generate_pbs_lookup_table(
     server_key: *const ShortintServerKey,
-    accumulator_callback: LookupTableCallback,
+    lookup_table_callback: LookupTableCallback,
     result: *mut *mut ShortintPBSLookupTable,
 ) -> c_int {
     catch_panic(|| {
@@ -27,26 +27,26 @@ pub unsafe extern "C" fn shortint_server_key_generate_pbs_accumulator(
         // checked, then any access to the result pointer will segfault (mimics malloc on failure)
         *result = std::ptr::null_mut();
 
-        let accumulator_callback = accumulator_callback.unwrap();
+        let lookup_table_callback = lookup_table_callback.unwrap();
 
         let server_key = get_ref_checked(server_key).unwrap();
 
         // Closure is required as extern "C" fn does not implement the Fn trait
         #[allow(clippy::redundant_closure)]
-        let heap_allocated_accumulator = Box::new(ShortintPBSLookupTable(
+        let heap_allocated_lookup_table = Box::new(ShortintPBSLookupTable(
             server_key
                 .0
-                .generate_accumulator(|x: u64| accumulator_callback(x)),
+                .generate_lookup_table(|x: u64| lookup_table_callback(x)),
         ));
 
-        *result = Box::into_raw(heap_allocated_accumulator);
+        *result = Box::into_raw(heap_allocated_lookup_table);
     })
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn shortint_server_key_programmable_bootstrap(
     server_key: *const ShortintServerKey,
-    accumulator: *const ShortintPBSLookupTable,
+    lookup_table: *const ShortintPBSLookupTable,
     ct_in: *const ShortintCiphertext,
     result: *mut *mut ShortintCiphertext,
 ) -> c_int {
@@ -58,10 +58,10 @@ pub unsafe extern "C" fn shortint_server_key_programmable_bootstrap(
         *result = std::ptr::null_mut();
 
         let server_key = get_ref_checked(server_key).unwrap();
-        let accumulator = get_ref_checked(accumulator).unwrap();
+        let lookup_table = get_ref_checked(lookup_table).unwrap();
         let ct_in = get_ref_checked(ct_in).unwrap();
 
-        let res = server_key.0.apply_lookup_table(&ct_in.0, &accumulator.0);
+        let res = server_key.0.apply_lookup_table(&ct_in.0, &lookup_table.0);
 
         let heap_allocated_result = Box::new(ShortintCiphertext(res));
 
@@ -72,24 +72,24 @@ pub unsafe extern "C" fn shortint_server_key_programmable_bootstrap(
 #[no_mangle]
 pub unsafe extern "C" fn shortint_server_key_programmable_bootstrap_assign(
     server_key: *const ShortintServerKey,
-    accumulator: *const ShortintPBSLookupTable,
+    lookup_table: *const ShortintPBSLookupTable,
     ct_in_and_result: *mut ShortintCiphertext,
 ) -> c_int {
     catch_panic(|| {
         let server_key = get_ref_checked(server_key).unwrap();
-        let accumulator = get_ref_checked(accumulator).unwrap();
+        let lookup_table = get_ref_checked(lookup_table).unwrap();
         let ct_in_and_result = get_mut_checked(ct_in_and_result).unwrap();
 
         server_key
             .0
-            .apply_lookup_table_assign(&mut ct_in_and_result.0, &accumulator.0);
+            .apply_lookup_table_assign(&mut ct_in_and_result.0, &lookup_table.0);
     })
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn shortint_server_key_generate_bivariate_pbs_accumulator(
+pub unsafe extern "C" fn shortint_server_key_generate_bivariate_pbs_lookup_table(
     server_key: *const ShortintServerKey,
-    accumulator_callback: BivariateLookupTableCallback,
+    lookup_table_callback: BivariateLookupTableCallback,
     result: *mut *mut ShortintBivariatePBSLookupTable,
 ) -> c_int {
     catch_panic(|| {
@@ -99,26 +99,26 @@ pub unsafe extern "C" fn shortint_server_key_generate_bivariate_pbs_accumulator(
         // checked, then any access to the result pointer will segfault (mimics malloc on failure)
         *result = std::ptr::null_mut();
 
-        let accumulator_callback = accumulator_callback.unwrap();
+        let lookup_table_callback = lookup_table_callback.unwrap();
 
         let server_key = get_ref_checked(server_key).unwrap();
 
         // Closure is required as extern "C" fn does not implement the Fn trait
         #[allow(clippy::redundant_closure)]
-        let heap_allocated_accumulator = Box::new(ShortintBivariatePBSLookupTable(
+        let heap_allocated_lookup_table = Box::new(ShortintBivariatePBSLookupTable(
             server_key
                 .0
-                .generate_accumulator_bivariate(|x: u64, y: u64| accumulator_callback(x, y)),
+                .generate_lookup_table_bivariate(|x: u64, y: u64| lookup_table_callback(x, y)),
         ));
 
-        *result = Box::into_raw(heap_allocated_accumulator);
+        *result = Box::into_raw(heap_allocated_lookup_table);
     })
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn shortint_server_key_bivariate_programmable_bootstrap(
     server_key: *const ShortintServerKey,
-    accumulator: *const ShortintBivariatePBSLookupTable,
+    lookup_table: *const ShortintBivariatePBSLookupTable,
     ct_left: *const ShortintCiphertext,
     ct_right: *mut ShortintCiphertext,
     result: *mut *mut ShortintCiphertext,
@@ -131,7 +131,7 @@ pub unsafe extern "C" fn shortint_server_key_bivariate_programmable_bootstrap(
         *result = std::ptr::null_mut();
 
         let server_key = get_ref_checked(server_key).unwrap();
-        let accumulator = get_ref_checked(accumulator).unwrap();
+        let lookup_table = get_ref_checked(lookup_table).unwrap();
         let ct_left = get_ref_checked(ct_left).unwrap();
         let ct_right = get_mut_checked(ct_right).unwrap();
 
@@ -141,7 +141,7 @@ pub unsafe extern "C" fn shortint_server_key_bivariate_programmable_bootstrap(
                     &server_key.0,
                     &ct_left.0,
                     &mut ct_right.0,
-                    &accumulator.0,
+                    &lookup_table.0,
                 )
                 .unwrap()
         });
@@ -155,13 +155,13 @@ pub unsafe extern "C" fn shortint_server_key_bivariate_programmable_bootstrap(
 #[no_mangle]
 pub unsafe extern "C" fn shortint_server_key_bivariate_programmable_bootstrap_assign(
     server_key: *const ShortintServerKey,
-    accumulator: *const ShortintBivariatePBSLookupTable,
+    lookup_table: *const ShortintBivariatePBSLookupTable,
     ct_left_and_result: *mut ShortintCiphertext,
     ct_right: *mut ShortintCiphertext,
 ) -> c_int {
     catch_panic(|| {
         let server_key = get_ref_checked(server_key).unwrap();
-        let accumulator = get_ref_checked(accumulator).unwrap();
+        let lookup_table = get_ref_checked(lookup_table).unwrap();
         let ct_left_and_result = get_mut_checked(ct_left_and_result).unwrap();
         let ct_right = get_mut_checked(ct_right).unwrap();
 
@@ -171,7 +171,7 @@ pub unsafe extern "C" fn shortint_server_key_bivariate_programmable_bootstrap_as
                     &server_key.0,
                     &mut ct_left_and_result.0,
                     &mut ct_right.0,
-                    &accumulator.0,
+                    &lookup_table.0,
                 )
                 .unwrap()
         });

--- a/tfhe/src/high_level_api/shortints/server_key.rs
+++ b/tfhe/src/high_level_api/shortints/server_key.rs
@@ -395,10 +395,10 @@ where
     where
         F: Fn(u64) -> u64,
     {
-        let accumulator = self.key.generate_accumulator(func);
+        let lookup_table = self.key.generate_lookup_table(func);
         let new_ciphertext = self
             .key
-            .apply_lookup_table(&ciphertext.ciphertext.borrow(), &accumulator);
+            .apply_lookup_table(&ciphertext.ciphertext.borrow(), &lookup_table);
         GenericShortInt {
             ciphertext: RefCell::new(new_ciphertext),
             id: ciphertext.id,
@@ -409,9 +409,9 @@ where
     where
         F: Fn(u64) -> u64,
     {
-        let accumulator = self.key.generate_accumulator(func);
+        let lookup_table = self.key.generate_lookup_table(func);
         self.key
-            .apply_lookup_table_assign(&mut ciphertext.ciphertext.borrow_mut(), &accumulator)
+            .apply_lookup_table_assign(&mut ciphertext.ciphertext.borrow_mut(), &lookup_table)
     }
 
     pub(super) fn bivariate_pbs<F>(

--- a/tfhe/src/integer/server_key/comparator.rs
+++ b/tfhe/src/integer/server_key/comparator.rs
@@ -57,7 +57,7 @@ impl<'a> Comparator<'a> {
         );
 
         let message_modulus = server_key.key.message_modulus.0 as u64;
-        let sign_lut = server_key.key.generate_accumulator(|x| u64::from(x != 0));
+        let sign_lut = server_key.key.generate_lookup_table(|x| u64::from(x != 0));
         // Comparison encoding
         // -------------------
         // x > y -> 2 = 10
@@ -79,7 +79,7 @@ impl<'a> Comparator<'a> {
         //   10     00    10
         //   10     01    10
         //   10     10    10
-        let sign_reduction_lsb_msb_lut = server_key.key.generate_accumulator(|x| {
+        let sign_reduction_lsb_msb_lut = server_key.key.generate_lookup_table(|x| {
             [
                 Self::IS_INFERIOR,
                 Self::IS_INFERIOR,
@@ -100,7 +100,7 @@ impl<'a> Comparator<'a> {
             .unwrap_or(0)
         });
 
-        let sign_to_offset_lut = server_key.key.generate_accumulator(|sign| {
+        let sign_to_offset_lut = server_key.key.generate_lookup_table(|sign| {
             if sign == Self::IS_INFERIOR {
                 message_modulus
             } else {
@@ -110,9 +110,9 @@ impl<'a> Comparator<'a> {
 
         let lhs_lut = server_key
             .key
-            .generate_accumulator(|x| if x < message_modulus { x } else { 0 });
+            .generate_lookup_table(|x| if x < message_modulus { x } else { 0 });
 
-        let rhs_lut = server_key.key.generate_accumulator(|x| {
+        let rhs_lut = server_key.key.generate_lookup_table(|x| {
             if x >= message_modulus {
                 x - message_modulus
             } else {
@@ -466,7 +466,7 @@ where {
                 );
                 let are_all_msb_equal_to_zero =
                     self.server_key.are_all_comparisons_block_true(msb_cmp_zero);
-                let lut = self.server_key.key.generate_accumulator(|x| {
+                let lut = self.server_key.key.generate_lookup_table(|x| {
                     if x == 1 {
                         Self::IS_EQUAL
                     } else {
@@ -718,7 +718,7 @@ where {
         let acc = self
             .server_key
             .key
-            .generate_accumulator(|x| u64::from(sign_result_handler_fn(x)));
+            .generate_lookup_table(|x| u64::from(sign_result_handler_fn(x)));
         let result_block = self.server_key.key.apply_lookup_table(&comparison, &acc);
 
         let mut blocks = Vec::with_capacity(num_blocks);

--- a/tfhe/src/integer/server_key/crt/mod.rs
+++ b/tfhe/src/integer/server_key/crt/mod.rs
@@ -80,12 +80,12 @@ impl ServerKey {
     {
         let basis = &ct1.moduli;
 
-        let accumulators = basis
+        let lookup_tables = basis
             .iter()
             .copied()
-            .map(|b| self.key.generate_accumulator(|x| f(x) % b));
+            .map(|b| self.key.generate_lookup_table(|x| f(x) % b));
 
-        for (block, acc) in ct1.blocks.iter_mut().zip(accumulators) {
+        for (block, acc) in ct1.blocks.iter_mut().zip(lookup_tables) {
             self.key.apply_lookup_table_assign(block, &acc);
         }
     }

--- a/tfhe/src/integer/server_key/crt_parallel/mod.rs
+++ b/tfhe/src/integer/server_key/crt_parallel/mod.rs
@@ -79,15 +79,15 @@ impl ServerKey {
     {
         let basis = &ct1.moduli;
 
-        let accumulators = basis
+        let lookup_tables = basis
             .iter()
             .copied()
-            .map(|b| self.key.generate_accumulator(|x| f(x) % b))
+            .map(|b| self.key.generate_lookup_table(|x| f(x) % b))
             .collect::<Vec<_>>();
 
         ct1.blocks
             .par_iter_mut()
-            .zip(&accumulators)
+            .zip(&lookup_tables)
             .for_each(|(block, acc)| {
                 self.key.apply_lookup_table_assign(block, acc);
             });

--- a/tfhe/src/integer/server_key/radix/comparison.rs
+++ b/tfhe/src/integer/server_key/radix/comparison.rs
@@ -39,7 +39,7 @@ impl ServerKey {
         // we generate our own lut to do less allocations
         let lut = self
             .key
-            .generate_accumulator_bivariate(|x, y| u64::from(x == y));
+            .generate_lookup_table_bivariate(|x, y| u64::from(x == y));
         let mut block_comparisons = lhs.blocks.clone();
         block_comparisons
             .iter_mut()
@@ -56,7 +56,7 @@ impl ServerKey {
 
         let is_max_value = self
             .key
-            .generate_accumulator(|x| u64::from((x & max_value as u64) == max_value as u64));
+            .generate_lookup_table(|x| u64::from((x & max_value as u64) == max_value as u64));
 
         while block_comparisons.len() > 1 {
             block_comparisons = block_comparisons
@@ -70,7 +70,7 @@ impl ServerKey {
                     if blocks.len() == max_value {
                         self.key.apply_lookup_table(&sum, &is_max_value)
                     } else {
-                        let is_equal_to_num_blocks = self.key.generate_accumulator(|x| {
+                        let is_equal_to_num_blocks = self.key.generate_lookup_table(|x| {
                             u64::from((x & max_value as u64) == blocks.len() as u64)
                         });
                         self.key.apply_lookup_table(&sum, &is_equal_to_num_blocks)
@@ -92,7 +92,7 @@ impl ServerKey {
         // we generate our own lut to do less allocations
         let lut = self
             .key
-            .generate_accumulator_bivariate(|x, y| u64::from(x != y));
+            .generate_lookup_table_bivariate(|x, y| u64::from(x != y));
         let mut block_comparisons = lhs.blocks.clone();
         block_comparisons
             .iter_mut()
@@ -106,7 +106,7 @@ impl ServerKey {
         let carry_modulus = self.key.carry_modulus.0;
         let total_modulus = message_modulus * carry_modulus;
         let max_value = total_modulus - 1;
-        let is_non_zero = self.key.generate_accumulator(|x| u64::from(x != 0));
+        let is_non_zero = self.key.generate_lookup_table(|x| u64::from(x != 0));
 
         while block_comparisons.len() > 1 {
             block_comparisons = block_comparisons

--- a/tfhe/src/integer/server_key/radix/shift.rs
+++ b/tfhe/src/integer/server_key/radix/shift.rs
@@ -143,7 +143,7 @@ impl ServerKey {
         let message_modulus = self.key.message_modulus.0 as u64;
         let lut = self
             .key
-            .generate_accumulator_bivariate(|current_block, mut previous_block| {
+            .generate_lookup_table_bivariate(|current_block, mut previous_block| {
                 // left shift not to lose
                 // bits when shifting right afterwards
                 previous_block <<= num_bits_in_block;
@@ -285,7 +285,7 @@ impl ServerKey {
 
         let lut = self
             .key
-            .generate_accumulator_bivariate(|current_block, previous_block| {
+            .generate_lookup_table_bivariate(|current_block, previous_block| {
                 let current_block = current_block << shift_within_block;
                 let previous_block = previous_block << shift_within_block;
 

--- a/tfhe/src/integer/server_key/radix_parallel/add.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/add.rs
@@ -325,7 +325,7 @@ impl ServerKey {
 
         let lut_carry_propagation_sum = self
             .key
-            .generate_accumulator_bivariate(prefix_sum_carry_propagation);
+            .generate_lookup_table_bivariate(prefix_sum_carry_propagation);
 
         let mut space = 1;
         let mut step_output = generates_or_propagates.clone();
@@ -411,7 +411,7 @@ impl ServerKey {
 
         let lut_carry_propagation_sum = self
             .key
-            .generate_accumulator_bivariate(prefix_sum_carry_propagation);
+            .generate_lookup_table_bivariate(prefix_sum_carry_propagation);
 
         use std::cell::UnsafeCell;
 
@@ -509,7 +509,7 @@ impl ServerKey {
 
         // This used for the first pair of blocks
         // as this pair can either generate or not, but never propagate
-        let lut_does_block_generate_carry = self.key.generate_accumulator(|x| {
+        let lut_does_block_generate_carry = self.key.generate_lookup_table(|x| {
             if x >= modulus {
                 OutputCarry::Generated as u64
             } else {
@@ -517,7 +517,7 @@ impl ServerKey {
             }
         });
 
-        let lut_does_block_generate_or_propagate = self.key.generate_accumulator(|x| {
+        let lut_does_block_generate_or_propagate = self.key.generate_lookup_table(|x| {
             if x >= modulus {
                 OutputCarry::Generated as u64
             } else if x == (modulus - 1) {

--- a/tfhe/src/integer/server_key/radix_parallel/bitwise_op.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/bitwise_op.rs
@@ -498,7 +498,7 @@ impl ServerKey {
         }
 
         let modulus = self.key.message_modulus.0 as u64;
-        let lut = self.key.generate_accumulator(|x| (!x) % modulus);
+        let lut = self.key.generate_lookup_table(|x| (!x) % modulus);
         ct.blocks
             .par_iter_mut()
             .for_each(|block| self.key.apply_lookup_table_assign(block, &lut))

--- a/tfhe/src/integer/server_key/radix_parallel/comparison.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/comparison.rs
@@ -17,7 +17,7 @@ impl ServerKey {
         // one for all the threads as opposed to one per thread
         let lut = self
             .key
-            .generate_accumulator_bivariate(|x, y| u64::from(x == y));
+            .generate_lookup_table_bivariate(|x, y| u64::from(x == y));
         let mut block_comparisons = lhs.blocks.clone();
         block_comparisons
             .par_iter_mut()
@@ -47,7 +47,7 @@ impl ServerKey {
         // one for all the threads as opposed to one per thread
         let lut = self
             .key
-            .generate_accumulator_bivariate(|x, y| u64::from(x != y));
+            .generate_lookup_table_bivariate(|x, y| u64::from(x != y));
         let mut block_comparisons = lhs.blocks.clone();
         block_comparisons
             .par_iter_mut()
@@ -63,7 +63,7 @@ impl ServerKey {
         let max_value = total_modulus - 1;
 
         let mut block_comparisons_2 = Vec::with_capacity(block_comparisons.len() / 2);
-        let is_non_zero = self.key.generate_accumulator(|x| u64::from(x != 0));
+        let is_non_zero = self.key.generate_lookup_table(|x| u64::from(x != 0));
 
         while block_comparisons.len() > 1 {
             block_comparisons

--- a/tfhe/src/integer/server_key/radix_parallel/scalar_comparison.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/scalar_comparison.rs
@@ -76,7 +76,7 @@ impl ServerKey {
 
         let is_max_value = self
             .key
-            .generate_accumulator(|x| u64::from(x == max_value as u64));
+            .generate_lookup_table(|x| u64::from(x == max_value as u64));
 
         while block_comparisons.len() > 1 {
             // Since all blocks encrypt either 0 or 1, we can sum max_value of them
@@ -94,7 +94,7 @@ impl ServerKey {
                     } else {
                         let is_equal_to_num_blocks = self
                             .key
-                            .generate_accumulator(|x| u64::from(x == blocks.len() as u64));
+                            .generate_lookup_table(|x| u64::from(x == blocks.len() as u64));
                         self.key.apply_lookup_table(&sum, &is_equal_to_num_blocks)
                     }
                 })
@@ -127,7 +127,7 @@ impl ServerKey {
         let total_modulus = message_modulus * carry_modulus;
         let max_value = total_modulus - 1;
 
-        let is_not_zero = self.key.generate_accumulator(|x| u64::from(x != 0));
+        let is_not_zero = self.key.generate_lookup_table(|x| u64::from(x != 0));
 
         while block_comparisons.len() > 1 {
             block_comparisons = block_comparisons
@@ -190,7 +190,7 @@ impl ServerKey {
         // If all blocks were 0, the sum will be zero
         // If at least one bock was not zero, the sum won't be zero
         let num_additions_to_fill_carry = (total_modulus - message_max) / message_max;
-        let is_equal_to_zero = self.key.generate_accumulator(|x| {
+        let is_equal_to_zero = self.key.generate_lookup_table(|x| {
             if matches!(comparison_type, ZeroComparisonType::Equality) {
                 u64::from((x % total_modulus as u64) == 0)
             } else {
@@ -246,7 +246,7 @@ impl ServerKey {
             }
             let lut = self
                 .key
-                .generate_accumulator(|x| u64::from(comparison_fn(x as u8, scalar_block)));
+                .generate_lookup_table(|x| u64::from(comparison_fn(x as u8, scalar_block)));
             scalar_comp_luts[scalar_block as usize] = Some(lut);
         }
         scalar_comp_luts

--- a/tfhe/src/integer/server_key/radix_parallel/scalar_rotate.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/scalar_rotate.rs
@@ -285,22 +285,22 @@ impl ServerKey {
 
         let message_modulus = self.key.message_modulus.0 as u64;
         if shift_within_block != 0 {
-            let lut = self
-                .key
-                .generate_accumulator_bivariate(|receiver_block, mut giver_block| {
-                    // left shift so as not to lose
-                    // bits when shifting right afterwards
-                    giver_block <<= num_bits_in_message;
-                    giver_block >>= shift_within_block;
+            let lut =
+                self.key
+                    .generate_lookup_table_bivariate(|receiver_block, mut giver_block| {
+                        // left shift so as not to lose
+                        // bits when shifting right afterwards
+                        giver_block <<= num_bits_in_message;
+                        giver_block >>= shift_within_block;
 
-                    // The way of getting carry / message is reversed compared
-                    // to the usual way but its normal:
-                    // The message is in the upper bits, the carry in lower bits
-                    let message_of_current_block = receiver_block >> shift_within_block;
-                    let carry_of_previous_block = giver_block % message_modulus;
+                        // The way of getting carry / message is reversed compared
+                        // to the usual way but its normal:
+                        // The message is in the upper bits, the carry in lower bits
+                        let message_of_current_block = receiver_block >> shift_within_block;
+                        let carry_of_previous_block = giver_block % message_modulus;
 
-                    message_of_current_block + carry_of_previous_block
-                });
+                        message_of_current_block + carry_of_previous_block
+                    });
             let new_blocks = (0..num_blocks)
                 .into_par_iter()
                 .map(|index| {
@@ -609,7 +609,7 @@ impl ServerKey {
         if shift_within_block != 0 {
             let lut = self
                 .key
-                .generate_accumulator_bivariate(|receiver_block, giver_block| {
+                .generate_lookup_table_bivariate(|receiver_block, giver_block| {
                     let receiver_block = receiver_block << shift_within_block;
                     let giver_block = giver_block << shift_within_block;
 

--- a/tfhe/src/integer/server_key/radix_parallel/scalar_shift.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/scalar_shift.rs
@@ -137,7 +137,7 @@ impl ServerKey {
         let create_blocks_using_bivariate_pbs = || {
             let lut = self
                 .key
-                .generate_accumulator_bivariate(|current_block, mut next_block| {
+                .generate_lookup_table_bivariate(|current_block, mut next_block| {
                     // left shift so as not to lose
                     // bits when shifting right afterwards
                     next_block <<= num_bits_in_block;
@@ -402,7 +402,7 @@ impl ServerKey {
         let create_blocks_using_bivariate_pbs = || {
             let lut = self
                 .key
-                .generate_accumulator_bivariate(|previous_block, current_block| {
+                .generate_lookup_table_bivariate(|previous_block, current_block| {
                     let current_block = current_block << shift_within_block;
                     let previous_block = previous_block << shift_within_block;
 

--- a/tfhe/src/integer/server_key/radix_parallel/shift.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/shift.rs
@@ -350,7 +350,7 @@ impl ServerKey {
             .into_par_iter()
             .map(|i| {
                 self.key
-                    .generate_accumulator(|x| ((x % message_modulus) >> i) & 1)
+                    .generate_lookup_table(|x| ((x % message_modulus) >> i) & 1)
             })
             .collect::<Vec<_>>();
 
@@ -393,7 +393,7 @@ impl ServerKey {
             },
         );
 
-        let mux_lut = self.key.generate_accumulator(|x| {
+        let mux_lut = self.key.generate_lookup_table(|x| {
             // x is expected to be x = 0bcba
             // where
             // - c is the control bit

--- a/tfhe/src/shortint/engine/server_side/comp_op.rs
+++ b/tfhe/src/shortint/engine/server_side/comp_op.rs
@@ -277,7 +277,7 @@ impl ShortintEngine {
     ) -> EngineResult<()> {
         let modulus = ct_left.message_modulus.0 as u64;
         let acc =
-            self.generate_accumulator(server_key, |x| (x % modulus == scalar as u64) as u64)?;
+            self.generate_lookup_table(server_key, |x| (x % modulus == scalar as u64) as u64)?;
         self.apply_lookup_table_assign(server_key, ct_left, &acc)?;
         ct_left.degree.0 = 1;
         Ok(())
@@ -353,7 +353,7 @@ impl ShortintEngine {
     ) -> EngineResult<()> {
         let modulus = ct_left.message_modulus.0 as u64;
         let acc =
-            self.generate_accumulator(server_key, |x| (x % modulus != scalar as u64) as u64)?;
+            self.generate_lookup_table(server_key, |x| (x % modulus != scalar as u64) as u64)?;
         self.apply_lookup_table_assign(server_key, ct_left, &acc)?;
         ct_left.degree.0 = 1;
         Ok(())
@@ -376,7 +376,7 @@ impl ShortintEngine {
         ct_left: &mut Ciphertext,
         scalar: u8,
     ) -> EngineResult<()> {
-        let acc = self.generate_accumulator(server_key, |x| (x >= scalar as u64) as u64)?;
+        let acc = self.generate_lookup_table(server_key, |x| (x >= scalar as u64) as u64)?;
         self.apply_lookup_table_assign(server_key, ct_left, &acc)?;
         ct_left.degree.0 = 1;
         Ok(())
@@ -399,7 +399,7 @@ impl ShortintEngine {
         ct_left: &mut Ciphertext,
         scalar: u8,
     ) -> EngineResult<()> {
-        let acc = self.generate_accumulator(server_key, |x| (x <= scalar as u64) as u64)?;
+        let acc = self.generate_lookup_table(server_key, |x| (x <= scalar as u64) as u64)?;
         self.apply_lookup_table_assign(server_key, ct_left, &acc)?;
         ct_left.degree.0 = 1;
         Ok(())
@@ -422,7 +422,7 @@ impl ShortintEngine {
         ct_left: &mut Ciphertext,
         scalar: u8,
     ) -> EngineResult<()> {
-        let acc = self.generate_accumulator(server_key, |x| (x > scalar as u64) as u64)?;
+        let acc = self.generate_lookup_table(server_key, |x| (x > scalar as u64) as u64)?;
         self.apply_lookup_table_assign(server_key, ct_left, &acc)?;
         ct_left.degree.0 = 1;
         Ok(())
@@ -445,7 +445,7 @@ impl ShortintEngine {
         ct_left: &mut Ciphertext,
         scalar: u8,
     ) -> EngineResult<()> {
-        let acc = self.generate_accumulator(server_key, |x| (x < scalar as u64) as u64)?;
+        let acc = self.generate_lookup_table(server_key, |x| (x < scalar as u64) as u64)?;
         self.apply_lookup_table_assign(server_key, ct_left, &acc)?;
         ct_left.degree.0 = 1;
         Ok(())

--- a/tfhe/src/shortint/engine/server_side/div_mod.rs
+++ b/tfhe/src/shortint/engine/server_side/div_mod.rs
@@ -94,9 +94,8 @@ impl ShortintEngine {
         scalar: u8,
     ) -> EngineResult<()> {
         assert_ne!(scalar, 0);
-        //generate the accumulator for the multiplication
-        let acc = self.generate_accumulator(server_key, |x| x / (scalar as u64))?;
-        self.apply_lookup_table_assign(server_key, ct, &acc)?;
+        let lookup_table = self.generate_lookup_table(server_key, |x| x / (scalar as u64))?;
+        self.apply_lookup_table_assign(server_key, ct, &lookup_table)?;
         ct.degree = Degree(ct.degree.0 / scalar as usize);
         Ok(())
     }
@@ -122,7 +121,7 @@ impl ShortintEngine {
         modulus: u8,
     ) -> EngineResult<()> {
         assert_ne!(modulus, 0);
-        let acc = self.generate_accumulator(server_key, |x| x % modulus as u64)?;
+        let acc = self.generate_lookup_table(server_key, |x| x % modulus as u64)?;
         self.apply_lookup_table_assign(server_key, ct, &acc)?;
         ct.degree = Degree(modulus as usize - 1);
         Ok(())

--- a/tfhe/src/shortint/engine/server_side/mul.rs
+++ b/tfhe/src/shortint/engine/server_side/mul.rs
@@ -31,12 +31,11 @@ impl ShortintEngine {
         //Modulus of the msg in the msg bits
         let res_modulus = ct_left.message_modulus.0 as u64;
 
-        //generate the accumulator for the multiplication
-        let acc = self.generate_accumulator(server_key, |x| {
+        let lookup_table = self.generate_lookup_table(server_key, |x| {
             ((x / modulus) * (x % modulus)) % res_modulus
         })?;
 
-        self.apply_lookup_table_assign(server_key, ct_left, &acc)?;
+        self.apply_lookup_table_assign(server_key, ct_left, &lookup_table)?;
         ct_left.degree = Degree(ct_left.message_modulus.0 - 1);
         Ok(())
     }
@@ -71,12 +70,11 @@ impl ShortintEngine {
         // Modulus of the msg in the msg bits
         let res_modulus = server_key.message_modulus.0 as u64;
 
-        // Generate the accumulator for the multiplication
-        let acc = self.generate_accumulator(server_key, |x| {
+        let lookup_table = self.generate_lookup_table(server_key, |x| {
             ((x / modulus) * (x % modulus)) / res_modulus
         })?;
 
-        self.apply_lookup_table_assign(server_key, ct_left, &acc)?;
+        self.apply_lookup_table_assign(server_key, ct_left, &lookup_table)?;
 
         ct_left.degree = Degree(deg);
         Ok(())
@@ -99,8 +97,8 @@ impl ShortintEngine {
         let modulus = ct1.message_modulus.0 as u64;
 
         let acc_add =
-            self.generate_accumulator(server_key, |x| ((x.wrapping_mul(x)) / 4) % modulus)?;
-        let acc_sub = self.generate_accumulator(server_key, |x| {
+            self.generate_lookup_table(server_key, |x| ((x.wrapping_mul(x)) / 4) % modulus)?;
+        let acc_sub = self.generate_lookup_table(server_key, |x| {
             (((x.wrapping_sub(z)).wrapping_mul(x.wrapping_sub(z))) / 4) % modulus
         })?;
 

--- a/tfhe/src/shortint/engine/server_side/scalar_add.rs
+++ b/tfhe/src/shortint/engine/server_side/scalar_add.rs
@@ -69,7 +69,7 @@ impl ShortintEngine {
             self.unchecked_scalar_add_assign(ct, scalar)?;
         } else {
             // If the scalar is too large, PBS is used to compute the scalar mul
-            let acc = self.generate_accumulator(server_key, |x| (scalar as u64 + x) % modulus)?;
+            let acc = self.generate_lookup_table(server_key, |x| (scalar as u64 + x) % modulus)?;
             self.apply_lookup_table_assign(server_key, ct, &acc)?;
             ct.degree = Degree(server_key.message_modulus.0 - 1);
         }

--- a/tfhe/src/shortint/engine/server_side/scalar_mul.rs
+++ b/tfhe/src/shortint/engine/server_side/scalar_mul.rs
@@ -55,7 +55,7 @@ impl ShortintEngine {
         }
         // If the ciphertext cannot be multiplied without exceeding the degree max
         else {
-            let acc = self.generate_accumulator(server_key, |x| (scalar as u64 * x) % modulus)?;
+            let acc = self.generate_lookup_table(server_key, |x| (scalar as u64 * x) % modulus)?;
             self.apply_lookup_table_assign(server_key, ctxt, &acc)?;
             ctxt.degree = Degree(server_key.message_modulus.0 - 1);
         }

--- a/tfhe/src/shortint/engine/server_side/scalar_sub.rs
+++ b/tfhe/src/shortint/engine/server_side/scalar_sub.rs
@@ -56,7 +56,7 @@ impl ShortintEngine {
         } else {
             let scalar = u64::from(scalar);
             // If the scalar is too large, PBS is used to compute the scalar mul
-            let acc = self.generate_accumulator(server_key, |x| (x - scalar) % modulus)?;
+            let acc = self.generate_lookup_table(server_key, |x| (x - scalar) % modulus)?;
             self.apply_lookup_table_assign(server_key, ct, &acc)?;
             ct.degree = Degree(server_key.message_modulus.0 - 1);
         }

--- a/tfhe/src/shortint/engine/server_side/shift.rs
+++ b/tfhe/src/shortint/engine/server_side/shift.rs
@@ -20,7 +20,7 @@ impl ShortintEngine {
         ct: &mut Ciphertext,
         shift: u8,
     ) -> EngineResult<()> {
-        let acc = self.generate_accumulator(server_key, |x| x >> shift)?;
+        let acc = self.generate_lookup_table(server_key, |x| x >> shift)?;
         self.apply_lookup_table_assign(server_key, ct, &acc)?;
 
         ct.degree = Degree(ct.degree.0 >> shift);
@@ -68,7 +68,7 @@ impl ShortintEngine {
             self.unchecked_scalar_left_shift_assign(ct, shift)?;
         } else {
             let modulus = server_key.message_modulus.0 as u64;
-            let acc = self.generate_accumulator(server_key, |x| (x << shift) % modulus)?;
+            let acc = self.generate_lookup_table(server_key, |x| (x << shift) % modulus)?;
             self.apply_lookup_table_assign(server_key, ct, &acc)?;
             ct.degree = ct.degree.after_left_shift(shift, modulus as usize);
         }

--- a/tfhe/src/shortint/engine/wopbs/mod.rs
+++ b/tfhe/src/shortint/engine/wopbs/mod.rs
@@ -421,7 +421,7 @@ impl ShortintEngine {
         ct_in: &Ciphertext,
     ) -> EngineResult<Ciphertext> {
         // First PBS to remove the noise
-        let acc = self.generate_accumulator(sks, |x| x)?;
+        let acc = self.generate_lookup_table(sks, |x| x)?;
         let ct_clean = self.apply_lookup_table(sks, ct_in, &acc)?;
 
         let mut buffer_lwe_after_ks = LweCiphertextOwned::new(
@@ -461,9 +461,9 @@ impl ShortintEngine {
         // 1. KS to go back to the original encryption key
         // 2. PBS to remove the noise added by the previous KS
         //
-        let acc = self.generate_accumulator(&wopbs_key.pbs_server_key, |x| x)?;
+        let acc = self.generate_lookup_table(&wopbs_key.pbs_server_key, |x| x)?;
         let (mut ciphertext_buffers, buffers) =
-            self.get_carry_clearing_accumulator_and_buffers(&wopbs_key.pbs_server_key);
+            self.get_carry_clearing_lookup_table_and_buffers(&wopbs_key.pbs_server_key);
         // Compute a key switch
         keyswitch_lwe_ciphertext(
             &wopbs_key.pbs_server_key.key_switching_key,

--- a/tfhe/src/shortint/key_switching_key/mod.rs
+++ b/tfhe/src/shortint/key_switching_key/mod.rs
@@ -103,14 +103,14 @@ impl KeySwitchingKey {
             i if i > 0 => {
                 keyswitch_lwe_ciphertext(&self.key_switching_key, &ct.ct, &mut ct_dest.ct);
 
-                let acc = self.dest_server_key.generate_accumulator(|n| n >> i);
+                let acc = self.dest_server_key.generate_lookup_table(|n| n >> i);
                 self.dest_server_key
                     .apply_lookup_table_assign(ct_dest, &acc);
             }
 
             // Cast to smaller bit length: left shift, then keyswitch
             i if i < 0 => {
-                let acc = self.src_server_key.generate_accumulator(|n| n << -i);
+                let acc = self.src_server_key.generate_lookup_table(|n| n << -i);
                 let shifted_cipher = self.src_server_key.apply_lookup_table(ct, &acc);
 
                 keyswitch_lwe_ciphertext(

--- a/tfhe/src/shortint/server_key/mod.rs
+++ b/tfhe/src/shortint/server_key/mod.rs
@@ -215,7 +215,7 @@ pub type LookupTableView<'a> = LookupTable<&'a [u64]>;
 
 #[must_use]
 pub struct BivariateLookupTable<C: Container<Element = u64>> {
-    // A bivariate accumulator is an univariate accumulator
+    // A bivariate lookup table is an univariate loolookup table
     // where the message space is shared to encode
     // 2 values
     pub acc: LookupTable<C>,
@@ -261,7 +261,7 @@ impl ServerKey {
         })
     }
 
-    /// Constructs the accumulator given a function as input.
+    /// Constructs the lookup table given a function as input.
     ///
     /// # Example
     ///
@@ -276,26 +276,26 @@ impl ServerKey {
     ///
     /// let ct = cks.encrypt(msg);
     ///
-    /// // Generate the accumulator for the function f: x -> x^2 mod 2^2
+    /// // Generate the lookup table for the function f: x -> x^2 mod 2^2
     /// let f = |x| x ^ 2 % 4;
     ///
-    /// let acc = sks.generate_accumulator(f);
+    /// let acc = sks.generate_lookup_table(f);
     /// let ct_res = sks.apply_lookup_table(&ct, &acc);
     ///
     /// let dec = cks.decrypt(&ct_res);
     /// // 3^2 mod 4 = 1
     /// assert_eq!(dec, f(msg));
     /// ```
-    pub fn generate_accumulator<F>(&self, f: F) -> LookupTableOwned
+    pub fn generate_lookup_table<F>(&self, f: F) -> LookupTableOwned
     where
         F: Fn(u64) -> u64,
     {
         ShortintEngine::with_thread_local_mut(|engine| {
-            engine.generate_accumulator(self, f).unwrap()
+            engine.generate_lookup_table(self, f).unwrap()
         })
     }
 
-    pub fn generate_accumulator_bivariate_with_factor<F>(
+    pub fn generate_lookup_table_bivariate_with_factor<F>(
         &self,
         f: F,
         left_message_scaling: MessageModulus,
@@ -305,12 +305,12 @@ impl ServerKey {
     {
         ShortintEngine::with_thread_local_mut(|engine| {
             engine
-                .generate_accumulator_bivariate_with_factor(self, f, left_message_scaling)
+                .generate_lookup_table_bivariate_with_factor(self, f, left_message_scaling)
                 .unwrap()
         })
     }
 
-    /// Constructs the accumulator for a given bivariate function as input.
+    /// Constructs the lookup table for a given bivariate function as input.
     ///
     /// # Example
     ///
@@ -329,19 +329,19 @@ impl ServerKey {
     ///
     /// let f = |x, y| (x + y) % 4;
     ///
-    /// let acc = sks.generate_accumulator_bivariate(f);
+    /// let acc = sks.generate_lookup_table_bivariate(f);
     /// assert!(acc.is_bivariate_pbs_possible(&ct1, &ct2));
     /// let ct_res = sks.smart_apply_lookup_table_bivariate(&ct1, &mut ct2, &acc);
     ///
     /// let dec = cks.decrypt(&ct_res);
     /// assert_eq!(dec, f(msg_1, msg_2));
     /// ```
-    pub fn generate_accumulator_bivariate<F>(&self, f: F) -> BivariateLookupTableOwned
+    pub fn generate_lookup_table_bivariate<F>(&self, f: F) -> BivariateLookupTableOwned
     where
         F: Fn(u64, u64) -> u64,
     {
         ShortintEngine::with_thread_local_mut(|engine| {
-            engine.generate_accumulator_bivariate(self, f).unwrap()
+            engine.generate_lookup_table_bivariate(self, f).unwrap()
         })
     }
 
@@ -449,8 +449,8 @@ impl ServerKey {
     /// let ct2 = cks.encrypt(msg);
     /// let modulus = cks.parameters.message_modulus().0 as u64;
     ///
-    /// // Generate the accumulator for the function f: x -> x^3 mod 2^2
-    /// let acc = sks.generate_accumulator_bivariate(|x, y| x * y * x % modulus);
+    /// // Generate the lookup table for the function f: x -> x^3 mod 2^2
+    /// let acc = sks.generate_lookup_table_bivariate(|x, y| x * y * x % modulus);
     /// let ct_res = sks.unchecked_apply_lookup_table_bivariate(&ct1, &ct2, &acc);
     ///
     /// let dec = cks.decrypt(&ct_res);
@@ -499,8 +499,8 @@ impl ServerKey {
     /// let mut ct2 = cks.encrypt(msg);
     /// let modulus = cks.parameters.message_modulus().0 as u64;
     ///
-    /// // Generate the accumulator for the function f: x -> x^3 mod 2^2
-    /// let acc = sks.generate_accumulator_bivariate(|x, y| x * y * x % modulus);
+    /// // Generate the lookup table for the function f: x -> x^3 mod 2^2
+    /// let acc = sks.generate_lookup_table_bivariate(|x, y| x * y * x % modulus);
     /// let ct_res = sks.smart_apply_lookup_table_bivariate(&ct1, &mut ct2, &acc);
     ///
     /// let dec = cks.decrypt(&ct_res);
@@ -548,8 +548,8 @@ impl ServerKey {
     /// let ct = cks.encrypt(msg);
     /// let modulus = cks.parameters.message_modulus().0 as u64;
     ///
-    /// // Generate the accumulator for the function f: x -> x^3 mod 2^2
-    /// let acc = sks.generate_accumulator(|x| x * x * x % modulus);
+    /// // Generate the lookup table for the function f: x -> x^3 mod 2^2
+    /// let acc = sks.generate_lookup_table(|x| x * x * x % modulus);
     /// let ct_res = sks.apply_lookup_table(&ct, &acc);
     ///
     /// let dec = cks.decrypt(&ct_res);

--- a/tfhe/src/shortint/server_key/scalar_add.rs
+++ b/tfhe/src/shortint/server_key/scalar_add.rs
@@ -119,7 +119,7 @@ impl ServerKey {
     /// ```
     pub fn scalar_add_assign(&self, ct: &mut Ciphertext, scalar: u8) {
         let modulus = self.message_modulus.0 as u64;
-        let acc = self.generate_accumulator(|x| (scalar as u64 + x) % modulus);
+        let acc = self.generate_lookup_table(|x| (scalar as u64 + x) % modulus);
         self.apply_lookup_table_assign(ct, &acc);
     }
 

--- a/tfhe/src/shortint/server_key/scalar_mul.rs
+++ b/tfhe/src/shortint/server_key/scalar_mul.rs
@@ -109,7 +109,7 @@ impl ServerKey {
     /// ```
     pub fn scalar_mul_assign(&self, ct: &mut Ciphertext, scalar: u8) {
         let modulus = self.message_modulus.0 as u64;
-        let acc = self.generate_accumulator(|x| (scalar as u64 * x) % modulus);
+        let acc = self.generate_lookup_table(|x| (scalar as u64 * x) % modulus);
         self.apply_lookup_table_assign(ct, &acc);
     }
 

--- a/tfhe/src/shortint/server_key/scalar_sub.rs
+++ b/tfhe/src/shortint/server_key/scalar_sub.rs
@@ -113,7 +113,7 @@ impl ServerKey {
     /// ```
     pub fn scalar_sub_assign(&self, ct: &mut Ciphertext, scalar: u8) {
         let modulus = self.message_modulus.0 as u64;
-        let acc = self.generate_accumulator(|x| (x.wrapping_sub(scalar as u64)) % modulus);
+        let acc = self.generate_lookup_table(|x| (x.wrapping_sub(scalar as u64)) % modulus);
         self.apply_lookup_table_assign(ct, &acc);
     }
 

--- a/tfhe/src/shortint/server_key/shift.rs
+++ b/tfhe/src/shortint/server_key/shift.rs
@@ -140,7 +140,7 @@ impl ServerKey {
     /// ```
     pub fn scalar_right_shift_assign(&self, ct: &mut Ciphertext, shift: u8) {
         let modulus = self.message_modulus.0 as u64;
-        let acc = self.generate_accumulator(|x| (x >> shift) % modulus);
+        let acc = self.generate_lookup_table(|x| (x >> shift) % modulus);
         self.apply_lookup_table_assign(ct, &acc);
     }
 
@@ -402,7 +402,7 @@ impl ServerKey {
     /// ```
     pub fn scalar_left_shift_assign(&self, ct: &mut Ciphertext, shift: u8) {
         let modulus = self.message_modulus.0 as u64;
-        let acc = self.generate_accumulator(|x| (x << shift) % modulus);
+        let acc = self.generate_lookup_table(|x| (x << shift) % modulus);
         self.apply_lookup_table_assign(ct, &acc);
     }
 

--- a/tfhe/src/shortint/server_key/tests.rs
+++ b/tfhe/src/shortint/server_key/tests.rs
@@ -116,7 +116,7 @@ create_parametrized_test!(shortint_keyswitch_bootstrap);
 create_parametrized_test!(shortint_keyswitch_programmable_bootstrap);
 create_parametrized_test!(shortint_carry_extract);
 create_parametrized_test!(shortint_message_extract);
-create_parametrized_test!(shortint_generate_accumulator);
+create_parametrized_test!(shortint_generate_lookup_table);
 create_parametrized_test!(shortint_unchecked_add);
 create_parametrized_test!(shortint_smart_add);
 create_parametrized_test!(shortint_default_add);
@@ -339,8 +339,8 @@ where
         // encryption of an integer
         let ctxt_0 = cks.encrypt(clear_0);
 
-        //define the accumulator as identity
-        let acc = sks.generate_accumulator(|n| n % modulus);
+        //define the lookup_table as identity
+        let acc = sks.generate_lookup_table(|n| n % modulus);
         // add the two ciphertexts
         let ct_res = sks.apply_lookup_table(&ctxt_0, &acc);
 
@@ -370,8 +370,8 @@ where
         // encryption of an integer
         let ctxt_0 = cks.encrypt(clear_0);
         let ctxt_1 = cks.encrypt(clear_1);
-        //define the accumulator as identity
-        let acc = sks.generate_accumulator_bivariate(|x, y| x * 2 * y);
+        //define the lookup_table as identity
+        let acc = sks.generate_lookup_table_bivariate(|x, y| x * 2 * y);
         // add the two ciphertexts
         let ct_res = sks.unchecked_apply_lookup_table_bivariate(&ctxt_0, &ctxt_1, &acc);
 
@@ -452,14 +452,14 @@ where
 }
 
 /// test multiplication with the LWE server key
-fn shortint_generate_accumulator<P>(param: P)
+fn shortint_generate_lookup_table<P>(param: P)
 where
     P: Into<PBSParameters>,
 {
     let keys = KEY_CACHE.get_from_param(param);
     let (cks, sks) = (keys.client_key(), keys.server_key());
     let double = |x| 2 * x;
-    let acc = sks.generate_accumulator(double);
+    let acc = sks.generate_lookup_table(double);
 
     //RNG
     let mut rng = rand::thread_rng();


### PR DESCRIPTION
…table

This renames the generate_accumulator* family of
functions into `generate_lookup_table`.

The reasoning is that we have `generate_accumulator` which returns a `LookupTable` type, and you use
that with the `apply_lookup_table` function which is not coherent.

Accumulator was the name we had originaly and consistently for these, however lookup_table is probably easier to understand / guess what it is about.
Also, it is the term used in concrete, the other
Zama product.