### PR TITLE
cb/feat/support_large_custom_modulus_multiplication

### DIFF
--- a/tfhe/src/core_crypto/commons/numeric/unsigned.rs
+++ b/tfhe/src/core_crypto/commons/numeric/unsigned.rs
@@ -157,10 +157,52 @@ macro_rules! implement {
                 let self_u128: u128 = self.cast_into();
                 let other_u128: u128 = other.cast_into();
                 let custom_modulus_u128: u128 = custom_modulus.cast_into();
-                self_u128
-                    .wrapping_mul(other_u128)
-                    .wrapping_rem(custom_modulus_u128)
-                    .cast_into()
+                let (prod, wrong) = self_u128.overflowing_mul(other_u128);
+                // if we are not able to multiply directly without wrapping around
+                if wrong {
+                    // we try to do the multiplication as
+                    // (a + b*2^64)*(c + d*2^64) = ac + (bc + ad)*2^64 + bd*2^18
+                    // with the assumption that b and d are very small
+                    // writing bc + ad = e + f*2^64 where again f should be small if b and d are
+                    // we have that the product is
+                    // ac + e*2^64 + (bd + f)*2^128
+                    // where bd + f is small
+                    // let 2^128 = r modulo the custom modulus
+                    // so that the product is ac + e*2^64 + (bd + f)*r
+                    // this can be computed without wrap around modulo 2^128 if
+                    // (bd + f)*r < 2^128 otherwise there is an error
+                    // there should be no error if the modulus is not close to 2^128 or is equal to
+                    // 2^128 -r with r not too close to 2^128
+                    let self_top = self_u128 >> 64;
+                    let other_top = other_u128 >> 64;
+                    let self_bottom = self_u128 - (self_top << 64);
+                    let other_bottom = other_u128 - (other_top << 64);
+                    let bottom = self_bottom.wrapping_mul(other_bottom);
+                    let middle1 = self_bottom.wrapping_mul(other_top);
+                    let middle2 = other_bottom.wrapping_mul(self_top);
+                    let (middle, wrong) = middle1.overflowing_add(middle2);
+                    assert!(!wrong, "multiplication of custom u128s failed: {:?}, {:?}",
+                    self_u128, other_u128);
+                    let middle_top = middle >> 64;
+                    let middle_bottom = middle - (middle_top << 64);
+                    let middle = (middle_bottom << 64).wrapping_rem(custom_modulus_u128);
+                    let rem = 0u128.wrapping_sub(1u128).wrapping_rem(custom_modulus_u128)
+                    .wrapping_add(1u128);
+                    let top = self_top.wrapping_mul(other_top);
+                    let (top, wrong) = top.overflowing_add(middle_top);
+                    assert!(!wrong, "multiplication of custom u128s failed: {:?}, \
+                    {:?}", self_u128, other_u128);
+                    let (top, wrong) = top.overflowing_mul(rem);
+                    assert!(!wrong, "multiplication of custom u128s failed: {:?}, \
+                    {:?}", self_u128, other_u128);
+                    let top = top.wrapping_rem(custom_modulus_u128);
+                    let out = top.wrapping_add(middle).wrapping_rem(custom_modulus_u128);
+                    out.wrapping_add(bottom).wrapping_rem(custom_modulus_u128).cast_into()
+                } else {
+                    prod
+                        .wrapping_rem(custom_modulus_u128)
+                        .cast_into()
+                }
             }
             #[inline]
             fn wrapping_rem(self, other: Self) -> Self {

--- a/tfhe/src/core_crypto/commons/numeric/unsigned.rs
+++ b/tfhe/src/core_crypto/commons/numeric/unsigned.rs
@@ -161,7 +161,7 @@ macro_rules! implement {
                 // if we are not able to multiply directly without wrapping around
                 if wrong {
                     // we try to do the multiplication as
-                    // (a + b*2^64)*(c + d*2^64) = ac + (bc + ad)*2^64 + bd*2^18
+                    // (a + b*2^64)*(c + d*2^64) = ac + (bc + ad)*2^64 + bd*2^128
                     // with the assumption that b and d are very small
                     // writing bc + ad = e + f*2^64 where again f should be small if b and d are
                     // we have that the product is
@@ -181,27 +181,38 @@ macro_rules! implement {
                     let middle1 = self_bottom.wrapping_mul(other_top);
                     let middle2 = other_bottom.wrapping_mul(self_top);
                     let (middle, wrong) = middle1.overflowing_add(middle2);
-                    assert!(!wrong, "multiplication of custom u128s failed: {:?}, {:?}",
-                    self_u128, other_u128);
+                    assert!(
+                        !wrong,
+                        "multiplication of custom u128s failed: {:?}, {:?}",
+                        self_u128, other_u128
+                    );
                     let middle_top = middle >> 64;
                     let middle_bottom = middle - (middle_top << 64);
                     let middle = (middle_bottom << 64).wrapping_rem(custom_modulus_u128);
-                    let rem = 0u128.wrapping_sub(1u128).wrapping_rem(custom_modulus_u128)
-                    .wrapping_add(1u128);
+                    let rem = 0u128
+                        .wrapping_sub(1u128)
+                        .wrapping_rem(custom_modulus_u128)
+                        .wrapping_add(1u128);
                     let top = self_top.wrapping_mul(other_top);
                     let (top, wrong) = top.overflowing_add(middle_top);
-                    assert!(!wrong, "multiplication of custom u128s failed: {:?}, \
-                    {:?}", self_u128, other_u128);
+                    assert!(
+                        !wrong,
+                        "multiplication of custom u128s failed: {:?}, {:?}",
+                        self_u128, other_u128
+                    );
                     let (top, wrong) = top.overflowing_mul(rem);
-                    assert!(!wrong, "multiplication of custom u128s failed: {:?}, \
-                    {:?}", self_u128, other_u128);
+                    assert!(
+                        !wrong,
+                        "multiplication of custom u128s failed: {:?}, {:?}",
+                        self_u128, other_u128
+                    );
                     let top = top.wrapping_rem(custom_modulus_u128);
                     let out = top.wrapping_add(middle).wrapping_rem(custom_modulus_u128);
-                    out.wrapping_add(bottom).wrapping_rem(custom_modulus_u128).cast_into()
-                } else {
-                    prod
+                    out.wrapping_add(bottom)
                         .wrapping_rem(custom_modulus_u128)
                         .cast_into()
+                } else {
+                    prod.wrapping_rem(custom_modulus_u128).cast_into()
                 }
             }
             #[inline]


### PR DESCRIPTION
Fixes an issue where if we have two polynomials p_1 mod q and p_2 mod q with q a custom 64-bit modulus and we want to compute p_1 * p_2 mod q^2 then the result could be incorrect.

This is due to the polynomial multiplication base case (when using a custom modulus) using a modified schoolbook algorithm which first adds two polynomials together (giving coefficients > 2^64 in general) first before multiplying two such polynomials. This can result in trying to multiply two integers > 2^64 modulo a 2^128 bit custom modulus which fails to be correct due to a wrap around modulo 2^128.

The fix now checks for a wrap around and if it occurs tries to compute the correct result using a simple divide and conquer approach and also fails instead of outputting an incorrect result.