### PR TITLE
Add KeySwitchingKey in the high-level API

### DIFF
--- a/tfhe/src/high_level_api/booleans/key_switching_key.rs
+++ b/tfhe/src/high_level_api/booleans/key_switching_key.rs
@@ -1,0 +1,48 @@
+use super::client_key::FheBoolClientKey;
+use super::server_key::FheBoolServerKey;
+use crate::boolean::prelude::{BooleanKeySwitchingParameters, KeySwitchingKey};
+
+#[derive(Clone, Debug, ::serde::Deserialize, ::serde::Serialize)]
+pub(crate) struct FheBoolKeySwitchingParameters {
+    pub(crate) params: BooleanKeySwitchingParameters,
+}
+
+impl From<BooleanKeySwitchingParameters> for FheBoolKeySwitchingParameters {
+    fn from(params: BooleanKeySwitchingParameters) -> Self {
+        Self { params }
+    }
+}
+
+#[cfg_attr(all(doc, not(doctest)), cfg(feature = "boolean"))]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct FheBoolKeySwitchingKey {
+    pub(in crate::high_level_api::booleans) key: KeySwitchingKey,
+}
+
+impl FheBoolKeySwitchingKey {
+    pub(crate) fn new(
+        key_pair_1: (&FheBoolClientKey, &FheBoolServerKey),
+        key_pair_2: (&FheBoolClientKey, &FheBoolServerKey),
+        parameters: FheBoolKeySwitchingParameters,
+    ) -> Self {
+        Self {
+            key: KeySwitchingKey::new(&key_pair_1.0.key, &key_pair_2.0.key, parameters.params),
+        }
+    }
+
+    pub(crate) fn for_same_parameters(
+        key_pair_1: (&FheBoolClientKey, &FheBoolServerKey),
+        key_pair_2: (&FheBoolClientKey, &FheBoolServerKey),
+    ) -> Option<Self> {
+        if key_pair_1.0.key.parameters != key_pair_2.0.key.parameters {
+            return None;
+        }
+        let ksk_params = BooleanKeySwitchingParameters::new(
+            key_pair_2.0.key.parameters.ks_base_log,
+            key_pair_2.0.key.parameters.ks_level,
+        );
+        Some(Self {
+            key: KeySwitchingKey::new(&key_pair_1.0.key, &key_pair_2.0.key, ksk_params),
+        })
+    }
+}

--- a/tfhe/src/high_level_api/booleans/mod.rs
+++ b/tfhe/src/high_level_api/booleans/mod.rs
@@ -1,11 +1,12 @@
 pub(crate) use keys::{
     BooleanClientKey, BooleanCompressedPublicKey, BooleanCompressedServerKey, BooleanConfig,
-    BooleanPublicKey, BooleanServerKey,
+    BooleanKeySwitchingKey, BooleanKeySwitchingParameters, BooleanPublicKey, BooleanServerKey,
 };
 pub use parameters::FheBoolParameters;
 pub use types::{CompressedFheBool, FheBool};
 
 mod client_key;
+mod key_switching_key;
 mod keys;
 mod public_key;
 mod server_key;

--- a/tfhe/src/high_level_api/booleans/types/static_.rs
+++ b/tfhe/src/high_level_api/booleans/types/static_.rs
@@ -1,5 +1,8 @@
 // This contains re-export to keep working a macro that expect these to be here
 pub(in crate::high_level_api) use crate::high_level_api::booleans::client_key::FheBoolClientKey;
+pub(in crate::high_level_api) use crate::high_level_api::booleans::key_switching_key::{
+    FheBoolKeySwitchingKey, FheBoolKeySwitchingParameters,
+};
 pub(in crate::high_level_api) use crate::high_level_api::booleans::parameters::FheBoolParameters;
 pub(in crate::high_level_api) use crate::high_level_api::booleans::public_key::{
     FheBoolCompressedPublicKey, FheBoolPublicKey,

--- a/tfhe/src/high_level_api/errors.rs
+++ b/tfhe/src/high_level_api/errors.rs
@@ -92,6 +92,24 @@ impl Display for UninitializedClientKey {
 
 impl std::error::Error for UninitializedClientKey {}
 
+/// The key switching key of a given type was not initialized
+#[derive(Debug)]
+pub struct UninitializedKeySwitchingKey(pub(crate) Type);
+
+impl Display for UninitializedKeySwitchingKey {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "The key switching key for the type '{:?}' was not properly initialized\n\
+             Did you forget to enable the type in the config ?
+            ",
+            self.0
+        )
+    }
+}
+
+impl std::error::Error for UninitializedKeySwitchingKey {}
+
 /// The public key of a given type was not initialized
 #[derive(Debug)]
 pub struct UninitializedPublicKey(pub(crate) Type);
@@ -147,6 +165,7 @@ pub enum Error {
     UninitializedClientKey(Type),
     UninitializedPublicKey(Type),
     UninitializedServerKey(Type),
+    UninitializedKeySwitchingKey(Type),
 }
 
 impl From<OutOfRangeError> for Error {
@@ -173,6 +192,12 @@ impl From<UninitializedServerKey> for Error {
     }
 }
 
+impl From<UninitializedKeySwitchingKey> for Error {
+    fn from(value: UninitializedKeySwitchingKey) -> Self {
+        Self::UninitializedKeySwitchingKey(value.0)
+    }
+}
+
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -187,6 +212,9 @@ impl Display for Error {
             }
             Error::UninitializedServerKey(ty) => {
                 write!(f, "{}", UninitializedServerKey(*ty))
+            }
+            Error::UninitializedKeySwitchingKey(ty) => {
+                write!(f, "{}", UninitializedKeySwitchingKey(*ty))
             }
         }
     }

--- a/tfhe/src/high_level_api/integers/mod.rs
+++ b/tfhe/src/high_level_api/integers/mod.rs
@@ -7,7 +7,8 @@ expand_pub_use_fhe_type!(
 
 pub(in crate::high_level_api) use keys::{
     IntegerClientKey, IntegerCompactPublicKey, IntegerCompressedCompactPublicKey,
-    IntegerCompressedServerKey, IntegerConfig, IntegerServerKey,
+    IntegerCompressedServerKey, IntegerConfig, IntegerKeySwitchingKey,
+    IntegerKeySwitchingParameters, IntegerServerKey,
 };
 
 mod client_key;

--- a/tfhe/src/high_level_api/keys/key_switching.rs
+++ b/tfhe/src/high_level_api/keys/key_switching.rs
@@ -1,0 +1,189 @@
+use crate::{ClientKey, ServerKey};
+
+use crate::errors::UninitializedKeySwitchingKey;
+use crate::high_level_api::errors::UnwrapResultExt;
+
+#[cfg(feature = "boolean")]
+use crate::high_level_api::booleans::{BooleanKeySwitchingKey, BooleanKeySwitchingParameters};
+#[cfg(feature = "integer")]
+use crate::high_level_api::integers::{IntegerKeySwitchingKey, IntegerKeySwitchingParameters};
+#[cfg(feature = "shortint")]
+use crate::high_level_api::shortints::{ShortIntKeySwitchingKey, ShortIntKeySwitchingParameters};
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+pub struct KeySwitchingParameters {
+    #[cfg(feature = "boolean")]
+    pub(crate) boolean_params: BooleanKeySwitchingParameters,
+    #[cfg(feature = "shortint")]
+    pub(crate) shortint_params: ShortIntKeySwitchingParameters,
+    #[cfg(feature = "integer")]
+    pub(crate) integer_params: IntegerKeySwitchingParameters,
+}
+
+impl KeySwitchingParameters {
+    #[cfg(feature = "boolean")]
+    pub fn with_boolean_parameters(
+        &mut self,
+        params: crate::boolean::parameters::BooleanKeySwitchingParameters,
+    ) -> &mut Self {
+        self.boolean_params.bool_params = Some(params.into());
+        self
+    }
+
+    #[cfg(feature = "shortint")]
+    pub fn with_uint2_parameters(
+        &mut self,
+        params: crate::shortint::parameters::ShortintKeySwitchingParameters,
+    ) -> &mut Self {
+        self.shortint_params.uint2_params = Some(params.into());
+        self
+    }
+
+    #[cfg(feature = "shortint")]
+    pub fn with_uint3_parameters(
+        &mut self,
+        params: crate::shortint::parameters::ShortintKeySwitchingParameters,
+    ) -> &mut Self {
+        self.shortint_params.uint3_params = Some(params.into());
+        self
+    }
+
+    #[cfg(feature = "shortint")]
+    pub fn with_uint4_parameters(
+        &mut self,
+        params: crate::shortint::parameters::ShortintKeySwitchingParameters,
+    ) -> &mut Self {
+        self.shortint_params.uint4_params = Some(params.into());
+        self
+    }
+
+    #[cfg(feature = "integer")]
+    pub fn with_integer_parameters(
+        &mut self,
+        params: crate::shortint::parameters::ShortintKeySwitchingParameters,
+    ) -> &mut Self {
+        self.integer_params = IntegerKeySwitchingParameters::from(params);
+        self
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct KeySwitchingKey {
+    #[cfg(feature = "boolean")]
+    pub(crate) boolean_key: BooleanKeySwitchingKey,
+    #[cfg(feature = "shortint")]
+    pub(crate) shortint_key: ShortIntKeySwitchingKey,
+    #[cfg(feature = "integer")]
+    pub(crate) integer_key: IntegerKeySwitchingKey,
+}
+
+impl KeySwitchingKey {
+    /// Creates a key switching key that is able to key switch
+    /// ciphertext between two client keys, using the provided parameters.
+    pub fn new(
+        key_pair_1: (&ClientKey, &ServerKey),
+        key_pair_2: (&ClientKey, &ServerKey),
+        parameters: KeySwitchingParameters,
+    ) -> Self {
+        Self {
+            #[cfg(feature = "boolean")]
+            boolean_key: BooleanKeySwitchingKey::new(
+                (&key_pair_1.0.boolean_key, &key_pair_1.1.boolean_key),
+                (&key_pair_2.0.boolean_key, &key_pair_2.1.boolean_key),
+                parameters.boolean_params,
+            ),
+            #[cfg(feature = "shortint")]
+            shortint_key: ShortIntKeySwitchingKey::new(
+                (&key_pair_1.0.shortint_key, &key_pair_1.1.shortint_key),
+                (&key_pair_2.0.shortint_key, &key_pair_2.1.shortint_key),
+                parameters.shortint_params,
+            ),
+            #[cfg(feature = "integer")]
+            integer_key: IntegerKeySwitchingKey::new(
+                (&key_pair_1.0.integer_key, &key_pair_1.1.integer_key),
+                (&key_pair_2.0.integer_key, &key_pair_2.1.integer_key),
+                parameters.integer_params,
+            ),
+        }
+    }
+
+    /// Creates a key switching key that is able to key switch
+    /// ciphertext between two client keys that were created using the same parameters
+    pub fn for_same_parameters(
+        key_pair_1: (&ClientKey, &ServerKey),
+        key_pair_2: (&ClientKey, &ServerKey),
+    ) -> Option<Self> {
+        Some(Self {
+            #[cfg(feature = "boolean")]
+            boolean_key: BooleanKeySwitchingKey::for_same_parameters(
+                (&key_pair_1.0.boolean_key, &key_pair_1.1.boolean_key),
+                (&key_pair_2.0.boolean_key, &key_pair_2.1.boolean_key),
+            )?,
+            #[cfg(feature = "shortint")]
+            shortint_key: ShortIntKeySwitchingKey::for_same_parameters(
+                (&key_pair_1.0.shortint_key, &key_pair_1.1.shortint_key),
+                (&key_pair_2.0.shortint_key, &key_pair_2.1.shortint_key),
+            )?,
+            #[cfg(feature = "integer")]
+            integer_key: IntegerKeySwitchingKey::for_same_parameters(
+                (&key_pair_1.0.integer_key, &key_pair_1.1.integer_key),
+                (&key_pair_2.0.integer_key, &key_pair_2.1.integer_key),
+            )?,
+        })
+    }
+}
+
+/// Trait to be implemented on the key switching key types that have a corresponding member
+/// in the `KeySwitchingKeyChain`.
+///
+/// This is to allow the writing of generic functions.
+pub trait RefKeyFromKeySwitchingKeyChain: Sized {
+    type Key;
+
+    /// The method to implement, shall return a ref to the key or an error if
+    /// the key member in the key was not initialized
+    fn ref_key(self, keys: &KeySwitchingKey) -> Result<&Self::Key, UninitializedKeySwitchingKey>;
+
+    /// Returns a ref to the key member of the key
+    ///
+    /// # Panic
+    ///
+    /// This will panic if the key was not initialized
+    #[track_caller]
+    fn unwrapped_ref_key(self, keys: &KeySwitchingKey) -> &Self::Key {
+        self.ref_key(keys).unwrap_display()
+    }
+}
+
+/// Helper macro to help reduce boiler plate
+/// needed to implement `RefCastingKeyFromKeyChain` since for
+/// our keys, the implementation is the same, only a few things change.
+///
+/// It expects:
+/// - The implementor type
+/// - The  `name` of the key type for which the trait will be implemented.
+/// - The identifier (or identifier chain) that points to the member in the `ClientKey` that holds
+///   the key for which the trait is implemented.
+/// - Type Variant used to identify the type at runtime (see `error.rs`)
+#[cfg(any(feature = "integer", feature = "shortint", feature = "boolean"))]
+macro_rules! impl_ref_key_from_key_switching_keychain {
+    (
+        for $implementor:ty {
+            key_type: $key_type:ty,
+            keychain_member: $($member:ident).*,
+            type_variant: $enum_variant:expr,
+        }
+    ) => {
+        impl crate::high_level_api::keys::RefKeyFromKeySwitchingKeyChain for $implementor {
+            type Key = $key_type;
+
+            fn ref_key(self, keys: &crate::high_level_api::keys::KeySwitchingKey) -> Result<&Self::Key, crate::high_level_api::errors::UninitializedKeySwitchingKey> {
+                keys$(.$member)*
+                    .as_ref()
+                    .ok_or(crate::high_level_api::errors::UninitializedKeySwitchingKey($enum_variant))
+            }
+        }
+    }
+}

--- a/tfhe/src/high_level_api/keys/mod.rs
+++ b/tfhe/src/high_level_api/keys/mod.rs
@@ -2,10 +2,13 @@
 mod client;
 #[macro_use]
 mod public;
+#[macro_use]
+mod key_switching;
 mod server;
 
 use crate::high_level_api::config::Config;
 pub use client::{ClientKey, RefKeyFromKeyChain};
+pub use key_switching::{KeySwitchingKey, KeySwitchingParameters, RefKeyFromKeySwitchingKeyChain};
 pub use public::{
     CompactPublicKey, CompressedCompactPublicKey, CompressedPublicKey, PublicKey,
     RefKeyFromCompressedPublicKeyChain, RefKeyFromPublicKeyChain,

--- a/tfhe/src/high_level_api/mod.rs
+++ b/tfhe/src/high_level_api/mod.rs
@@ -26,7 +26,7 @@ pub use errors::{Error, OutOfRangeError};
 pub use global_state::{set_server_key, unset_server_key, with_server_key_as_context};
 pub use keys::{
     generate_keys, ClientKey, CompactPublicKey, CompressedCompactPublicKey, CompressedPublicKey,
-    CompressedServerKey, PublicKey, ServerKey,
+    CompressedServerKey, KeySwitchingKey, KeySwitchingParameters, PublicKey, ServerKey,
 };
 
 #[cfg(test)]

--- a/tfhe/src/high_level_api/prelude.rs
+++ b/tfhe/src/high_level_api/prelude.rs
@@ -7,7 +7,7 @@
 //! ```
 pub use crate::high_level_api::traits::{
     DivRem, DynamicFheEncryptor, DynamicFheTrivialEncryptor, DynamicFheTryEncryptor, FheBootstrap,
-    FheDecrypt, FheEncrypt, FheEq, FheMax, FheMin, FheNumberConstant, FheOrd, FheTrivialEncrypt,
-    FheTryEncrypt, FheTryTrivialEncrypt, RotateLeft, RotateLeftAssign, RotateRight,
-    RotateRightAssign,
+    FheDecrypt, FheEncrypt, FheEq, FheKeySwitch, FheMax, FheMin, FheNumberConstant, FheOrd,
+    FheTrivialEncrypt, FheTryEncrypt, FheTryTrivialEncrypt, RotateLeft, RotateLeftAssign,
+    RotateRight, RotateRightAssign,
 };

--- a/tfhe/src/high_level_api/shortints/key_switching_key.rs
+++ b/tfhe/src/high_level_api/shortints/key_switching_key.rs
@@ -1,0 +1,72 @@
+use super::client_key::GenericShortIntClientKey;
+use super::parameters::ShortIntegerParameter;
+use super::server_key::GenericShortIntServerKey;
+use crate::shortint::parameters::ShortintKeySwitchingParameters;
+use crate::shortint::KeySwitchingKey;
+
+use serde::{Deserialize, Serialize};
+use std::marker::PhantomData;
+
+#[derive(Clone, Debug, ::serde::Deserialize, ::serde::Serialize)]
+pub(crate) struct GenericShortIntKeySwitchingParameters<P: ShortIntegerParameter> {
+    pub(crate) params: ShortintKeySwitchingParameters,
+    _marker: PhantomData<P>,
+}
+
+impl<P: ShortIntegerParameter> From<ShortintKeySwitchingParameters>
+    for GenericShortIntKeySwitchingParameters<P>
+{
+    fn from(params: ShortintKeySwitchingParameters) -> Self {
+        Self {
+            params,
+            _marker: Default::default(),
+        }
+    }
+}
+
+/// The key switching key of a short integer type
+///
+/// A wrapper around `tfhe-shortint` `KeySwitchingKey`
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct GenericShortIntKeySwitchingKey<P: ShortIntegerParameter> {
+    pub(super) key: KeySwitchingKey,
+    _marker: PhantomData<P>,
+}
+
+impl<P: ShortIntegerParameter> GenericShortIntKeySwitchingKey<P> {
+    pub(crate) fn new(
+        key_pair_1: (&GenericShortIntClientKey<P>, &GenericShortIntServerKey<P>),
+        key_pair_2: (&GenericShortIntClientKey<P>, &GenericShortIntServerKey<P>),
+        parameters: GenericShortIntKeySwitchingParameters<P>,
+    ) -> Self {
+        Self {
+            key: KeySwitchingKey::new(
+                (&key_pair_1.0.key, &key_pair_1.1.key),
+                (&key_pair_2.0.key, &key_pair_2.1.key),
+                parameters.params,
+            ),
+            _marker: Default::default(),
+        }
+    }
+
+    pub(crate) fn for_same_parameters(
+        key_pair_1: (&GenericShortIntClientKey<P>, &GenericShortIntServerKey<P>),
+        key_pair_2: (&GenericShortIntClientKey<P>, &GenericShortIntServerKey<P>),
+    ) -> Option<Self> {
+        if key_pair_1.0.key.parameters != key_pair_2.0.key.parameters {
+            return None;
+        }
+        let ksk_params = ShortintKeySwitchingParameters::new(
+            key_pair_2.0.key.parameters.ks_base_log(),
+            key_pair_2.0.key.parameters.ks_level(),
+        );
+        Some(Self {
+            key: KeySwitchingKey::new(
+                (&key_pair_1.0.key, &key_pair_1.1.key),
+                (&key_pair_2.0.key, &key_pair_2.1.key),
+                ksk_params,
+            ),
+            _marker: Default::default(),
+        })
+    }
+}

--- a/tfhe/src/high_level_api/shortints/mod.rs
+++ b/tfhe/src/high_level_api/shortints/mod.rs
@@ -1,6 +1,6 @@
 pub(crate) use keys::{
     ShortIntClientKey, ShortIntCompressedPublicKey, ShortIntCompressedServerKey, ShortIntConfig,
-    ShortIntPublicKey, ShortIntServerKey,
+    ShortIntKeySwitchingKey, ShortIntKeySwitchingParameters, ShortIntPublicKey, ShortIntServerKey,
 };
 pub use types::{
     CompressedFheUint2, CompressedFheUint3, CompressedFheUint4, CompressedGenericShortint,
@@ -9,6 +9,7 @@ pub use types::{
 };
 
 mod client_key;
+mod key_switching_key;
 mod keys;
 mod parameters;
 mod public_key;

--- a/tfhe/src/high_level_api/shortints/types/mod.rs
+++ b/tfhe/src/high_level_api/shortints/types/mod.rs
@@ -7,6 +7,9 @@ pub use static_::{
 };
 
 use super::client_key::GenericShortIntClientKey;
+use super::key_switching_key::{
+    GenericShortIntKeySwitchingKey, GenericShortIntKeySwitchingParameters,
+};
 use super::public_key::compressed::GenericShortIntCompressedPublicKey;
 use super::public_key::GenericShortIntPublicKey;
 use super::server_key::{GenericShortIntCompressedServerKey, GenericShortIntServerKey};

--- a/tfhe/src/high_level_api/shortints/types/static_.rs
+++ b/tfhe/src/high_level_api/shortints/types/static_.rs
@@ -11,7 +11,8 @@ use crate::high_level_api::shortints::{CompressedGenericShortint, GenericShortIn
 
 use super::{
     GenericShortIntClientKey, GenericShortIntCompressedPublicKey,
-    GenericShortIntCompressedServerKey, GenericShortIntPublicKey, GenericShortIntServerKey,
+    GenericShortIntCompressedServerKey, GenericShortIntKeySwitchingKey,
+    GenericShortIntKeySwitchingParameters, GenericShortIntPublicKey, GenericShortIntServerKey,
 };
 
 use crate::high_level_api::shortints::parameters::{
@@ -157,6 +158,9 @@ macro_rules! static_shortint_type {
             pub type [<$name Parameters>] = ShortIntegerParameterSet<$num_bits>;
 
             pub(in crate::high_level_api) type [<$name ClientKey>] = GenericShortIntClientKey<[<$name Parameters>]>;
+
+            pub(in crate::high_level_api) type [<$name KeySwitchingParameters>] = GenericShortIntKeySwitchingParameters<[<$name Parameters>]>;
+            pub(in crate::high_level_api) type [<$name KeySwitchingKey>] = GenericShortIntKeySwitchingKey<[<$name Parameters>]>;
             pub(in crate::high_level_api) type [<$name PublicKey>] = GenericShortIntPublicKey<[<$name Parameters>]>;
             pub(in crate::high_level_api) type [<$name CompressedPublicKey>] = GenericShortIntCompressedPublicKey<[<$name Parameters>]>;
             pub(in crate::high_level_api) type [<$name ServerKey>] = GenericShortIntServerKey<[<$name Parameters>]>;
@@ -173,6 +177,14 @@ macro_rules! static_shortint_type {
             impl_ref_key_from_keychain!(
                 for <[<$name Parameters>] as ShortIntegerParameter>::Id {
                     key_type: [<$name ClientKey>],
+                    keychain_member: $($member).*,
+                    type_variant: crate::high_level_api::errors::Type::$name,
+                }
+            );
+
+            impl_ref_key_from_key_switching_keychain!(
+                for <[<$name Parameters>] as ShortIntegerParameter>::Id {
+                    key_type: [<$name KeySwitchingKey>],
                     keychain_member: $($member).*,
                     type_variant: crate::high_level_api::errors::Type::$name,
                 }

--- a/tfhe/src/high_level_api/traits.rs
+++ b/tfhe/src/high_level_api/traits.rs
@@ -1,4 +1,4 @@
-use crate::high_level_api::ClientKey;
+use crate::high_level_api::{ClientKey, KeySwitchingKey};
 
 /// Trait used to have a generic way of creating a value of a FHE type
 /// from a native value.
@@ -136,6 +136,16 @@ where
 
     /// Compute a function over the encrypted message.
     fn apply<F: Fn(u64) -> u64>(&mut self, func: F);
+}
+
+/// Trait used to have a generic way of keyswitching values
+/// that were encrypted using different client keys.
+///
+///
+/// The `Key` is required as it contains the key needed to do the
+/// actual key switch.
+pub trait FheKeySwitch {
+    fn keyswitch(&self, key: &KeySwitchingKey) -> Self;
 }
 
 #[doc(hidden)]

--- a/tfhe/src/integer/mod.rs
+++ b/tfhe/src/integer/mod.rs
@@ -68,6 +68,7 @@ pub use bigint::u256::U256;
 pub use bigint::u512::U512;
 pub use ciphertext::{CrtCiphertext, IntegerCiphertext, RadixCiphertext};
 pub use client_key::{ClientKey, CrtClientKey, RadixClientKey};
+pub use key_switching_key::KeySwitchingKey;
 pub use public_key::{CompressedCompactPublicKey, CompressedPublicKey, PublicKey};
 pub use server_key::{CheckError, CompressedServerKey, ServerKey};
 


### PR DESCRIPTION
This is the follow-up PR from #344
This is allowing HL users to swich keys for boolean, shortint, or integer ciphertexts.

What's missing before merging: the actual key switching parameters. In the HL API we only allow switching from one set of parameters to the same, but we would still need to provide key switching parameters, which are not available right now. In the current state of the PR I use a workaround that kinda works but don't have the guarantee of "below 2 to the -40th proba of error", but this should be fixed before merging.