### PR TITLE
Am/feat/prime q lwe glwe ggsw

### DIFF
--- a/tfhe/src/core_crypto/algorithms/ggsw_encryption.rs
+++ b/tfhe/src/core_crypto/algorithms/ggsw_encryption.rs
@@ -3,9 +3,12 @@
 
 use crate::core_crypto::algorithms::slice_algorithms::*;
 use crate::core_crypto::algorithms::*;
+use crate::core_crypto::commons::ciphertext_modulus::CiphertextModulusKind;
 use crate::core_crypto::commons::dispersion::DispersionParameter;
 use crate::core_crypto::commons::generators::EncryptionRandomGenerator;
-use crate::core_crypto::commons::math::decomposition::{DecompositionLevel, SignedDecomposer};
+use crate::core_crypto::commons::math::decomposition::{
+    DecompositionLevel, DecompositionTermNonNative, SignedDecomposer, SignedDecomposerNonNative,
+};
 use crate::core_crypto::commons::math::random::ActivatedRandomGenerator;
 use crate::core_crypto::commons::parameters::PlaintextCount;
 use crate::core_crypto::commons::traits::*;
@@ -111,19 +114,33 @@ pub fn encrypt_constant_ggsw_ciphertext<Scalar, KeyCont, OutputCont, Gen>(
     let decomp_base_log = output.decomposition_base_log();
     let ciphertext_modulus = output.ciphertext_modulus();
 
-    assert!(ciphertext_modulus.is_compatible_with_native_modulus());
-
     for (level_index, (mut level_matrix, mut generator)) in
         output.iter_mut().zip(gen_iter).enumerate()
     {
         let decomp_level = DecompositionLevel(level_index + 1);
-        // We scale the factor down from the native torus to whatever our torus is, the
-        // encryption process will scale it back up
-        let factor = encoded
-            .0
-            .wrapping_neg()
-            .wrapping_mul(Scalar::ONE << (Scalar::BITS - (decomp_base_log.0 * decomp_level.0)))
-            .wrapping_div(ciphertext_modulus.get_power_of_two_scaling_to_native_torus());
+        let factor = match ciphertext_modulus.kind() {
+            CiphertextModulusKind::NonNative => DecompositionTermNonNative::new(
+                decomp_level,
+                decomp_base_log,
+                encoded
+                    .0
+                    .wrapping_neg_custom_mod(ciphertext_modulus.get_custom_modulus().cast_into()),
+                ciphertext_modulus,
+            )
+            .to_recomposition_summand(),
+            CiphertextModulusKind::Native | CiphertextModulusKind::NonNativePowerOfTwo =>
+            // We scale the factor down from the native torus to whatever our torus is, the
+            // encryption process will scale it back up
+            {
+                encoded
+                    .0
+                    .wrapping_neg()
+                    .wrapping_mul(
+                        Scalar::ONE << (Scalar::BITS - (decomp_base_log.0 * decomp_level.0)),
+                    )
+                    .wrapping_div(ciphertext_modulus.get_power_of_two_scaling_to_native_torus())
+            }
+        };
 
         // We iterate over the rows of the level matrix, the last row needs special treatment
         let gen_iter = generator
@@ -251,18 +268,32 @@ pub fn par_encrypt_constant_ggsw_ciphertext<Scalar, KeyCont, OutputCont, Gen>(
     let decomp_base_log = output.decomposition_base_log();
     let ciphertext_modulus = output.ciphertext_modulus();
 
-    assert!(ciphertext_modulus.is_compatible_with_native_modulus());
-
     output.par_iter_mut().zip(gen_iter).enumerate().for_each(
         |(level_index, (mut level_matrix, mut generator))| {
             let decomp_level = DecompositionLevel(level_index + 1);
-            // We scale the factor down from the native torus to whatever our torus is, the
-            // encryption process will scale it back up
-            let factor = encoded
-                .0
-                .wrapping_neg()
-                .wrapping_mul(Scalar::ONE << (Scalar::BITS - (decomp_base_log.0 * decomp_level.0)))
-                .wrapping_div(ciphertext_modulus.get_power_of_two_scaling_to_native_torus());
+            let factor = match ciphertext_modulus.kind() {
+                CiphertextModulusKind::NonNative => DecompositionTermNonNative::new(
+                    decomp_level,
+                    decomp_base_log,
+                    encoded.0.wrapping_neg_custom_mod(
+                        ciphertext_modulus.get_custom_modulus().cast_into(),
+                    ),
+                    ciphertext_modulus,
+                )
+                .to_recomposition_summand(),
+                CiphertextModulusKind::Native | CiphertextModulusKind::NonNativePowerOfTwo =>
+                // We scale the factor down from the native torus to whatever our torus is, the
+                // encryption process will scale it back up
+                {
+                    encoded
+                        .0
+                        .wrapping_neg()
+                        .wrapping_mul(
+                            Scalar::ONE << (Scalar::BITS - (decomp_base_log.0 * decomp_level.0)),
+                        )
+                        .wrapping_div(ciphertext_modulus.get_power_of_two_scaling_to_native_torus())
+                }
+            };
 
             // We iterate over the rows of the level matrix, the last row needs special
             // treatment
@@ -319,15 +350,35 @@ fn encrypt_constant_ggsw_level_matrix_row<Scalar, KeyCont, OutputCont, Gen>(
         let mut body = row_as_glwe.get_mut_body();
         body.as_mut().copy_from_slice(sk_poly.as_ref());
 
-        slice_wrapping_scalar_mul_assign(body.as_mut(), factor);
+        let ciphertext_modulus = body.ciphertext_modulus();
+
+        match ciphertext_modulus.kind() {
+            CiphertextModulusKind::NonNative => slice_wrapping_scalar_mul_assign_custom_mod(
+                body.as_mut(),
+                factor,
+                ciphertext_modulus.get_custom_modulus().cast_into(),
+            ),
+            CiphertextModulusKind::Native | CiphertextModulusKind::NonNativePowerOfTwo => {
+                slice_wrapping_scalar_mul_assign(body.as_mut(), factor)
+            }
+        }
 
         encrypt_glwe_ciphertext_assign(glwe_secret_key, row_as_glwe, noise_parameters, generator);
     } else {
         // The last row needs a slightly different treatment
         let mut body = row_as_glwe.get_mut_body();
+        let ciphertext_modulus = body.ciphertext_modulus();
 
         body.as_mut().fill(Scalar::ZERO);
-        body.as_mut()[0] = factor.wrapping_neg();
+        let encoded = match ciphertext_modulus.kind() {
+            CiphertextModulusKind::NonNative => {
+                factor.wrapping_neg_custom_mod(ciphertext_modulus.get_custom_modulus().cast_into())
+            }
+            CiphertextModulusKind::Native | CiphertextModulusKind::NonNativePowerOfTwo => {
+                factor.wrapping_neg()
+            }
+        };
+        body.as_mut()[0] = encoded;
 
         encrypt_glwe_ciphertext_assign(glwe_secret_key, row_as_glwe, noise_parameters, generator);
     }
@@ -371,19 +422,33 @@ pub fn encrypt_constant_seeded_ggsw_ciphertext_with_existing_generator<
     let decomp_base_log = output.decomposition_base_log();
     let ciphertext_modulus = output.ciphertext_modulus();
 
-    assert!(ciphertext_modulus.is_compatible_with_native_modulus());
-
     for (level_index, (mut level_matrix, mut loop_generator)) in
         output.iter_mut().zip(gen_iter).enumerate()
     {
         let decomp_level = DecompositionLevel(level_index + 1);
-        // We scale the factor down from the native torus to whatever our torus is, the
-        // encryption process will scale it back up
-        let factor = encoded
-            .0
-            .wrapping_neg()
-            .wrapping_mul(Scalar::ONE << (Scalar::BITS - (decomp_base_log.0 * decomp_level.0)))
-            .wrapping_div(ciphertext_modulus.get_power_of_two_scaling_to_native_torus());
+        let factor = match ciphertext_modulus.kind() {
+            CiphertextModulusKind::NonNative => DecompositionTermNonNative::new(
+                decomp_level,
+                decomp_base_log,
+                encoded
+                    .0
+                    .wrapping_neg_custom_mod(ciphertext_modulus.get_custom_modulus().cast_into()),
+                ciphertext_modulus,
+            )
+            .to_recomposition_summand(),
+            CiphertextModulusKind::Native | CiphertextModulusKind::NonNativePowerOfTwo =>
+            // We scale the factor down from the native torus to whatever our torus is, the
+            // encryption process will scale it back up
+            {
+                encoded
+                    .0
+                    .wrapping_neg()
+                    .wrapping_mul(
+                        Scalar::ONE << (Scalar::BITS - (decomp_base_log.0 * decomp_level.0)),
+                    )
+                    .wrapping_div(ciphertext_modulus.get_power_of_two_scaling_to_native_torus())
+            }
+        };
 
         // We iterate over the rows of the level matrix, the last row needs special treatment
         let gen_iter = loop_generator
@@ -548,18 +613,32 @@ pub fn par_encrypt_constant_seeded_ggsw_ciphertext_with_existing_generator<
     let decomp_base_log = output.decomposition_base_log();
     let ciphertext_modulus = output.ciphertext_modulus();
 
-    assert!(ciphertext_modulus.is_compatible_with_native_modulus());
-
     output.par_iter_mut().zip(gen_iter).enumerate().for_each(
         |(level_index, (mut level_matrix, mut generator))| {
             let decomp_level = DecompositionLevel(level_index + 1);
-            // We scale the factor down from the native torus to whatever our torus is, the
-            // encryption process will scale it back up
-            let factor = encoded
-                .0
-                .wrapping_neg()
-                .wrapping_mul(Scalar::ONE << (Scalar::BITS - (decomp_base_log.0 * decomp_level.0)))
-                .wrapping_div(ciphertext_modulus.get_power_of_two_scaling_to_native_torus());
+            let factor = match ciphertext_modulus.kind() {
+                CiphertextModulusKind::NonNative => DecompositionTermNonNative::new(
+                    decomp_level,
+                    decomp_base_log,
+                    encoded.0.wrapping_neg_custom_mod(
+                        ciphertext_modulus.get_custom_modulus().cast_into(),
+                    ),
+                    ciphertext_modulus,
+                )
+                .to_recomposition_summand(),
+                CiphertextModulusKind::Native | CiphertextModulusKind::NonNativePowerOfTwo =>
+                // We scale the factor down from the native torus to whatever our torus is, the
+                // encryption process will scale it back up
+                {
+                    encoded
+                        .0
+                        .wrapping_neg()
+                        .wrapping_mul(
+                            Scalar::ONE << (Scalar::BITS - (decomp_base_log.0 * decomp_level.0)),
+                        )
+                        .wrapping_div(ciphertext_modulus.get_power_of_two_scaling_to_native_torus())
+                }
+            };
 
             // We iterate over the rows of the level matrix, the last row needs special treatment
             let gen_iter = generator
@@ -716,7 +795,18 @@ fn encrypt_constant_seeded_ggsw_level_matrix_row<Scalar, KeyCont, OutputCont, Ge
         let mut body = row_as_glwe.get_mut_body();
         body.as_mut().copy_from_slice(sk_poly.as_ref());
 
-        slice_wrapping_scalar_mul_assign(body.as_mut(), factor);
+        let ciphertext_modulus = body.ciphertext_modulus();
+
+        match ciphertext_modulus.kind() {
+            CiphertextModulusKind::NonNative => slice_wrapping_scalar_mul_assign_custom_mod(
+                body.as_mut(),
+                factor,
+                ciphertext_modulus.get_custom_modulus().cast_into(),
+            ),
+            CiphertextModulusKind::Native | CiphertextModulusKind::NonNativePowerOfTwo => {
+                slice_wrapping_scalar_mul_assign(body.as_mut(), factor)
+            }
+        }
 
         encrypt_seeded_glwe_ciphertext_assign_with_existing_generator(
             glwe_secret_key,
@@ -727,9 +817,18 @@ fn encrypt_constant_seeded_ggsw_level_matrix_row<Scalar, KeyCont, OutputCont, Ge
     } else {
         // The last row needs a slightly different treatment
         let mut body = row_as_glwe.get_mut_body();
+        let ciphertext_modulus = body.ciphertext_modulus();
 
         body.as_mut().fill(Scalar::ZERO);
-        body.as_mut()[0] = factor.wrapping_neg();
+        let encoded = match ciphertext_modulus.kind() {
+            CiphertextModulusKind::NonNative => {
+                factor.wrapping_neg_custom_mod(ciphertext_modulus.get_custom_modulus().cast_into())
+            }
+            CiphertextModulusKind::Native | CiphertextModulusKind::NonNativePowerOfTwo => {
+                factor.wrapping_neg()
+            }
+        };
+        body.as_mut()[0] = encoded;
 
         encrypt_seeded_glwe_ciphertext_assign_with_existing_generator(
             glwe_secret_key,
@@ -836,20 +935,40 @@ where
 
     let decomp_base_log = ggsw_ciphertext.decomposition_base_log();
 
-    let decomposer = SignedDecomposer::new(decomp_base_log, decomp_level);
-
     let plaintext_ref = decrypted_plaintext_list.get(0);
 
     let ciphertext_modulus = ggsw_ciphertext.ciphertext_modulus();
-    assert!(ciphertext_modulus.is_compatible_with_native_modulus());
 
-    // Glwe decryption maps to a smaller torus potentially, map back to the native torus
-    let rounded = decomposer.closest_representable(
-        (*plaintext_ref.0)
-            .wrapping_mul(ciphertext_modulus.get_power_of_two_scaling_to_native_torus()),
-    );
-    let decoded =
-        rounded.wrapping_div(Scalar::ONE << (Scalar::BITS - (decomp_base_log.0 * decomp_level.0)));
+    match ciphertext_modulus.kind() {
+        CiphertextModulusKind::NonNative => {
+            let decomposer =
+                SignedDecomposerNonNative::new(decomp_base_log, decomp_level, ciphertext_modulus);
 
-    Plaintext(decoded)
+            let rounded = decomposer.closest_representable(*plaintext_ref.0);
+            let delta = DecompositionTermNonNative::new(
+                DecompositionLevel(decomp_level.0),
+                decomp_base_log,
+                Scalar::ONE,
+                ciphertext_modulus,
+            )
+            .to_recomposition_summand();
+
+            let decoded = rounded.wrapping_div(delta);
+
+            Plaintext(decoded)
+        }
+        CiphertextModulusKind::Native | CiphertextModulusKind::NonNativePowerOfTwo => {
+            let decomposer = SignedDecomposer::new(decomp_base_log, decomp_level);
+
+            // Glwe decryption maps to a smaller torus potentially, map back to the native torus
+            let rounded = decomposer.closest_representable(
+                (*plaintext_ref.0)
+                    .wrapping_mul(ciphertext_modulus.get_power_of_two_scaling_to_native_torus()),
+            );
+            let decoded = rounded
+                .wrapping_div(Scalar::ONE << (Scalar::BITS - (decomp_base_log.0 * decomp_level.0)));
+
+            Plaintext(decoded)
+        }
+    }
 }

--- a/tfhe/src/core_crypto/algorithms/glwe_sample_extraction.rs
+++ b/tfhe/src/core_crypto/algorithms/glwe_sample_extraction.rs
@@ -125,17 +125,37 @@ pub fn extract_lwe_sample_from_glwe_ciphertext<Scalar, InputCont, OutputCont>(
     // We compute the number of elements which must be
     // turned into their opposite
     let opposite_count = input_glwe.polynomial_size().0 - nth.0 - 1;
+    let ciphertext_modulus = input_glwe.ciphertext_modulus();
 
-    // We loop through the polynomials
-    for lwe_mask_poly in lwe_mask
-        .as_mut()
-        .chunks_exact_mut(input_glwe.polynomial_size().0)
-    {
-        // We reverse the polynomial
-        lwe_mask_poly.reverse();
-        // We compute the opposite of the proper coefficients
-        slice_wrapping_opposite_assign(&mut lwe_mask_poly[0..opposite_count]);
-        // We rotate the polynomial properly
-        lwe_mask_poly.rotate_left(opposite_count);
+    if ciphertext_modulus.is_compatible_with_native_modulus() {
+        // We loop through the polynomials
+        for lwe_mask_poly in lwe_mask
+            .as_mut()
+            .chunks_exact_mut(input_glwe.polynomial_size().0)
+        {
+            // We reverse the polynomial
+            lwe_mask_poly.reverse();
+            // We compute the opposite of the proper coefficients
+            slice_wrapping_opposite_assign(&mut lwe_mask_poly[0..opposite_count]);
+            // We rotate the polynomial properly
+            lwe_mask_poly.rotate_left(opposite_count);
+        }
+    } else {
+        let modulus: Scalar = ciphertext_modulus.get_custom_modulus().cast_into();
+        // We loop through the polynomials
+        for lwe_mask_poly in lwe_mask
+            .as_mut()
+            .chunks_exact_mut(input_glwe.polynomial_size().0)
+        {
+            // We reverse the polynomial
+            lwe_mask_poly.reverse();
+            // We compute the opposite of the proper coefficients
+            slice_wrapping_opposite_assign_custom_mod(
+                &mut lwe_mask_poly[0..opposite_count],
+                modulus,
+            );
+            // We rotate the polynomial properly
+            lwe_mask_poly.rotate_left(opposite_count);
+        }
     }
 }

--- a/tfhe/src/core_crypto/algorithms/lwe_keyswitch_key_generation.rs
+++ b/tfhe/src/core_crypto/algorithms/lwe_keyswitch_key_generation.rs
@@ -5,7 +5,9 @@
 use crate::core_crypto::algorithms::*;
 use crate::core_crypto::commons::dispersion::DispersionParameter;
 use crate::core_crypto::commons::generators::EncryptionRandomGenerator;
-use crate::core_crypto::commons::math::decomposition::{DecompositionLevel, DecompositionTerm};
+use crate::core_crypto::commons::math::decomposition::{
+    DecompositionLevel, DecompositionTerm, DecompositionTermNonNative,
+};
 use crate::core_crypto::commons::math::random::ActivatedRandomGenerator;
 use crate::core_crypto::commons::parameters::*;
 use crate::core_crypto::commons::traits::*;
@@ -75,58 +77,215 @@ pub fn generate_lwe_keyswitch_key<Scalar, InputKeyCont, OutputKeyCont, KSKeyCont
     KSKeyCont: ContainerMut<Element = Scalar>,
     Gen: ByteRandomGenerator,
 {
-    assert!(
-        lwe_keyswitch_key.input_key_lwe_dimension() == input_lwe_sk.lwe_dimension(),
-        "The destination LweKeyswitchKey input LweDimension is not equal \
-    to the input LweSecretKey LweDimension. Destination: {:?}, input: {:?}",
-        lwe_keyswitch_key.input_key_lwe_dimension(),
-        input_lwe_sk.lwe_dimension()
-    );
-    assert!(
-        lwe_keyswitch_key.output_key_lwe_dimension() == output_lwe_sk.lwe_dimension(),
-        "The destination LweKeyswitchKey output LweDimension is not equal \
-    to the output LweSecretKey LweDimension. Destination: {:?}, output: {:?}",
-        lwe_keyswitch_key.output_key_lwe_dimension(),
-        input_lwe_sk.lwe_dimension()
-    );
-
-    let decomp_base_log = lwe_keyswitch_key.decomposition_base_log();
-    let decomp_level_count = lwe_keyswitch_key.decomposition_level_count();
     let ciphertext_modulus = lwe_keyswitch_key.ciphertext_modulus();
-    assert!(ciphertext_modulus.is_compatible_with_native_modulus());
 
-    // The plaintexts used to encrypt a key element will be stored in this buffer
-    let mut decomposition_plaintexts_buffer =
-        PlaintextListOwned::new(Scalar::ZERO, PlaintextCount(decomp_level_count.0));
-
-    // Iterate over the input key elements and the destination lwe_keyswitch_key memory
-    for (input_key_element, mut keyswitch_key_block) in input_lwe_sk
-        .as_ref()
-        .iter()
-        .zip(lwe_keyswitch_key.iter_mut())
-    {
-        // We fill the buffer with the powers of the key elmements
-        for (level, message) in (1..=decomp_level_count.0)
-            .rev()
-            .map(DecompositionLevel)
-            .zip(decomposition_plaintexts_buffer.iter_mut())
-        {
-            // Here  we take the decomposition term from the native torus, bring it to the torus we
-            // are working with by dividing by the scaling factor and the encryption will take care
-            // of mapping that back to the native torus
-            *message.0 = DecompositionTerm::new(level, decomp_base_log, *input_key_element)
-                .to_recomposition_summand()
-                .wrapping_div(ciphertext_modulus.get_power_of_two_scaling_to_native_torus());
-        }
-
-        encrypt_lwe_ciphertext_list(
+    if ciphertext_modulus.is_compatible_with_native_modulus() {
+        generate_lwe_keyswitch_key_native_mod_compatible(
+            input_lwe_sk,
             output_lwe_sk,
-            &mut keyswitch_key_block,
-            &decomposition_plaintexts_buffer,
+            lwe_keyswitch_key,
             noise_parameters,
             generator,
-        );
+        )
+    } else {
+        generate_lwe_keyswitch_key_non_native_mod(
+            input_lwe_sk,
+            output_lwe_sk,
+            lwe_keyswitch_key,
+            noise_parameters,
+            generator,
+        )
     }
+}
+
+pub fn generate_lwe_keyswitch_key_native_mod_compatible<
+    Scalar,
+    InputKeyCont,
+    OutputKeyCont,
+    KSKeyCont,
+    Gen,
+>(
+    input_lwe_sk: &LweSecretKey<InputKeyCont>,
+    output_lwe_sk: &LweSecretKey<OutputKeyCont>,
+    lwe_keyswitch_key: &mut LweKeyswitchKey<KSKeyCont>,
+    noise_parameters: impl DispersionParameter,
+    generator: &mut EncryptionRandomGenerator<Gen>,
+) where
+    Scalar: UnsignedTorus,
+    InputKeyCont: Container<Element = Scalar>,
+    OutputKeyCont: Container<Element = Scalar>,
+    KSKeyCont: ContainerMut<Element = Scalar>,
+    Gen: ByteRandomGenerator,
+{
+    fn implementation<Scalar, Gen>(
+        input_lwe_sk: LweSecretKeyView<'_, Scalar>,
+        output_lwe_sk: LweSecretKeyView<'_, Scalar>,
+        mut lwe_keyswitch_key: LweKeyswitchKeyMutView<'_, Scalar>,
+        noise_parameters: impl DispersionParameter,
+        generator: &mut EncryptionRandomGenerator<Gen>,
+    ) where
+        Scalar: UnsignedTorus,
+        Gen: ByteRandomGenerator,
+    {
+        assert!(
+            lwe_keyswitch_key.input_key_lwe_dimension() == input_lwe_sk.lwe_dimension(),
+            "The destination LweKeyswitchKey input LweDimension is not equal \
+to the input LweSecretKey LweDimension. Destination: {:?}, input: {:?}",
+            lwe_keyswitch_key.input_key_lwe_dimension(),
+            input_lwe_sk.lwe_dimension()
+        );
+        assert!(
+            lwe_keyswitch_key.output_key_lwe_dimension() == output_lwe_sk.lwe_dimension(),
+            "The destination LweKeyswitchKey output LweDimension is not equal \
+to the output LweSecretKey LweDimension. Destination: {:?}, output: {:?}",
+            lwe_keyswitch_key.output_key_lwe_dimension(),
+            input_lwe_sk.lwe_dimension()
+        );
+        assert!(lwe_keyswitch_key
+            .ciphertext_modulus()
+            .is_compatible_with_native_modulus());
+
+        let decomp_base_log = lwe_keyswitch_key.decomposition_base_log();
+        let decomp_level_count = lwe_keyswitch_key.decomposition_level_count();
+        let ciphertext_modulus = lwe_keyswitch_key.ciphertext_modulus();
+
+        // The plaintexts used to encrypt a key element will be stored in this buffer
+        let mut decomposition_plaintexts_buffer =
+            PlaintextListOwned::new(Scalar::ZERO, PlaintextCount(decomp_level_count.0));
+
+        // Iterate over the input key elements and the destination lwe_keyswitch_key memory
+        for (input_key_element, mut keyswitch_key_block) in input_lwe_sk
+            .as_ref()
+            .iter()
+            .zip(lwe_keyswitch_key.iter_mut())
+        {
+            // We fill the buffer with the powers of the key elmements
+            for (level, message) in (1..=decomp_level_count.0)
+                .rev()
+                .map(DecompositionLevel)
+                .zip(decomposition_plaintexts_buffer.iter_mut())
+            {
+                // Here  we take the decomposition term from the native torus, bring it to the torus
+                // we are working with by dividing by the scaling factor and the
+                // encryption will take care of mapping that back to the native
+                // torus
+                *message.0 = DecompositionTerm::new(level, decomp_base_log, *input_key_element)
+                    .to_recomposition_summand()
+                    .wrapping_div(ciphertext_modulus.get_power_of_two_scaling_to_native_torus());
+            }
+
+            encrypt_lwe_ciphertext_list(
+                &output_lwe_sk,
+                &mut keyswitch_key_block,
+                &decomposition_plaintexts_buffer,
+                noise_parameters,
+                generator,
+            );
+        }
+    }
+
+    implementation(
+        input_lwe_sk.as_view(),
+        output_lwe_sk.as_view(),
+        lwe_keyswitch_key.as_mut_view(),
+        noise_parameters,
+        generator,
+    )
+}
+
+pub fn generate_lwe_keyswitch_key_non_native_mod<
+    Scalar,
+    InputKeyCont,
+    OutputKeyCont,
+    KSKeyCont,
+    Gen,
+>(
+    input_lwe_sk: &LweSecretKey<InputKeyCont>,
+    output_lwe_sk: &LweSecretKey<OutputKeyCont>,
+    lwe_keyswitch_key: &mut LweKeyswitchKey<KSKeyCont>,
+    noise_parameters: impl DispersionParameter,
+    generator: &mut EncryptionRandomGenerator<Gen>,
+) where
+    Scalar: UnsignedTorus,
+    InputKeyCont: Container<Element = Scalar>,
+    OutputKeyCont: Container<Element = Scalar>,
+    KSKeyCont: ContainerMut<Element = Scalar>,
+    Gen: ByteRandomGenerator,
+{
+    fn implementation<Scalar, Gen>(
+        input_lwe_sk: LweSecretKeyView<'_, Scalar>,
+        output_lwe_sk: LweSecretKeyView<'_, Scalar>,
+        mut lwe_keyswitch_key: LweKeyswitchKeyMutView<'_, Scalar>,
+        noise_parameters: impl DispersionParameter,
+        generator: &mut EncryptionRandomGenerator<Gen>,
+    ) where
+        Scalar: UnsignedTorus,
+        Gen: ByteRandomGenerator,
+    {
+        assert!(
+            lwe_keyswitch_key.input_key_lwe_dimension() == input_lwe_sk.lwe_dimension(),
+            "The destination LweKeyswitchKey input LweDimension is not equal \
+to the input LweSecretKey LweDimension. Destination: {:?}, input: {:?}",
+            lwe_keyswitch_key.input_key_lwe_dimension(),
+            input_lwe_sk.lwe_dimension()
+        );
+        assert!(
+            lwe_keyswitch_key.output_key_lwe_dimension() == output_lwe_sk.lwe_dimension(),
+            "The destination LweKeyswitchKey output LweDimension is not equal \
+to the output LweSecretKey LweDimension. Destination: {:?}, output: {:?}",
+            lwe_keyswitch_key.output_key_lwe_dimension(),
+            input_lwe_sk.lwe_dimension()
+        );
+        assert!(!lwe_keyswitch_key
+            .ciphertext_modulus()
+            .is_compatible_with_native_modulus());
+
+        let decomp_base_log = lwe_keyswitch_key.decomposition_base_log();
+        let decomp_level_count = lwe_keyswitch_key.decomposition_level_count();
+        let ciphertext_modulus = lwe_keyswitch_key.ciphertext_modulus();
+
+        // The plaintexts used to encrypt a key element will be stored in this buffer
+        let mut decomposition_plaintexts_buffer =
+            PlaintextListOwned::new(Scalar::ZERO, PlaintextCount(decomp_level_count.0));
+
+        // Iterate over the input key elements and the destination lwe_keyswitch_key memory
+        for (input_key_element, mut keyswitch_key_block) in input_lwe_sk
+            .as_ref()
+            .iter()
+            .zip(lwe_keyswitch_key.iter_mut())
+        {
+            // We fill the buffer with the powers of the key elmements
+            for (level, message) in (1..=decomp_level_count.0)
+                .rev()
+                .map(DecompositionLevel)
+                .zip(decomposition_plaintexts_buffer.iter_mut())
+            {
+                *message.0 = DecompositionTermNonNative::new(
+                    level,
+                    decomp_base_log,
+                    *input_key_element,
+                    ciphertext_modulus,
+                )
+                .to_recomposition_summand();
+            }
+
+            encrypt_lwe_ciphertext_list(
+                &output_lwe_sk,
+                &mut keyswitch_key_block,
+                &decomposition_plaintexts_buffer,
+                noise_parameters,
+                generator,
+            );
+        }
+    }
+
+    implementation(
+        input_lwe_sk.as_view(),
+        output_lwe_sk.as_view(),
+        lwe_keyswitch_key.as_mut_view(),
+        noise_parameters,
+        generator,
+    )
 }
 
 /// Allocate a new [`LWE keyswitch key`](`LweKeyswitchKey`) and fill it with an actual keyswitching
@@ -238,6 +397,46 @@ pub fn generate_seeded_lwe_keyswitch_key<
     // Maybe Sized allows to pass Box<dyn Seeder>.
     NoiseSeeder: Seeder + ?Sized,
 {
+    let ciphertext_modulus = lwe_keyswitch_key.ciphertext_modulus();
+    if ciphertext_modulus.is_compatible_with_native_modulus() {
+        generate_seeded_lwe_keyswitch_key_native_mod_compatible(
+            input_lwe_sk,
+            output_lwe_sk,
+            lwe_keyswitch_key,
+            noise_parameters,
+            noise_seeder,
+        )
+    } else {
+        generate_seeded_lwe_keyswitch_key_non_native_mod(
+            input_lwe_sk,
+            output_lwe_sk,
+            lwe_keyswitch_key,
+            noise_parameters,
+            noise_seeder,
+        )
+    }
+}
+
+pub fn generate_seeded_lwe_keyswitch_key_native_mod_compatible<
+    Scalar,
+    InputKeyCont,
+    OutputKeyCont,
+    KSKeyCont,
+    NoiseSeeder,
+>(
+    input_lwe_sk: &LweSecretKey<InputKeyCont>,
+    output_lwe_sk: &LweSecretKey<OutputKeyCont>,
+    lwe_keyswitch_key: &mut SeededLweKeyswitchKey<KSKeyCont>,
+    noise_parameters: impl DispersionParameter,
+    noise_seeder: &mut NoiseSeeder,
+) where
+    Scalar: UnsignedTorus,
+    InputKeyCont: Container<Element = Scalar>,
+    OutputKeyCont: Container<Element = Scalar>,
+    KSKeyCont: ContainerMut<Element = Scalar>,
+    // Maybe Sized allows to pass Box<dyn Seeder>.
+    NoiseSeeder: Seeder + ?Sized,
+{
     assert!(
         lwe_keyswitch_key.input_key_lwe_dimension() == input_lwe_sk.lwe_dimension(),
         "The destination SeededLweKeyswitchKey input LweDimension is not equal \
@@ -285,6 +484,86 @@ pub fn generate_seeded_lwe_keyswitch_key<
             *message.0 = DecompositionTerm::new(level, decomp_base_log, *input_key_element)
                 .to_recomposition_summand()
                 .wrapping_div(ciphertext_modulus.get_power_of_two_scaling_to_native_torus());
+        }
+
+        encrypt_seeded_lwe_ciphertext_list_with_existing_generator(
+            output_lwe_sk,
+            &mut keyswitch_key_block,
+            &decomposition_plaintexts_buffer,
+            noise_parameters,
+            &mut generator,
+        );
+    }
+}
+
+pub fn generate_seeded_lwe_keyswitch_key_non_native_mod<
+    Scalar,
+    InputKeyCont,
+    OutputKeyCont,
+    KSKeyCont,
+    NoiseSeeder,
+>(
+    input_lwe_sk: &LweSecretKey<InputKeyCont>,
+    output_lwe_sk: &LweSecretKey<OutputKeyCont>,
+    lwe_keyswitch_key: &mut SeededLweKeyswitchKey<KSKeyCont>,
+    noise_parameters: impl DispersionParameter,
+    noise_seeder: &mut NoiseSeeder,
+) where
+    Scalar: UnsignedTorus,
+    InputKeyCont: Container<Element = Scalar>,
+    OutputKeyCont: Container<Element = Scalar>,
+    KSKeyCont: ContainerMut<Element = Scalar>,
+    // Maybe Sized allows to pass Box<dyn Seeder>.
+    NoiseSeeder: Seeder + ?Sized,
+{
+    assert!(
+        lwe_keyswitch_key.input_key_lwe_dimension() == input_lwe_sk.lwe_dimension(),
+        "The destination SeededLweKeyswitchKey input LweDimension is not equal \
+    to the input LweSecretKey LweDimension. Destination: {:?}, input: {:?}",
+        lwe_keyswitch_key.input_key_lwe_dimension(),
+        input_lwe_sk.lwe_dimension()
+    );
+    assert!(
+        lwe_keyswitch_key.output_key_lwe_dimension() == output_lwe_sk.lwe_dimension(),
+        "The destination SeededLweKeyswitchKey output LweDimension is not equal \
+    to the output LweSecretKey LweDimension. Destination: {:?}, output: {:?}",
+        lwe_keyswitch_key.output_key_lwe_dimension(),
+        input_lwe_sk.lwe_dimension()
+    );
+
+    let decomp_base_log = lwe_keyswitch_key.decomposition_base_log();
+    let decomp_level_count = lwe_keyswitch_key.decomposition_level_count();
+    let ciphertext_modulus = lwe_keyswitch_key.ciphertext_modulus();
+    assert!(!ciphertext_modulus.is_compatible_with_native_modulus());
+
+    // The plaintexts used to encrypt a key element will be stored in this buffer
+    let mut decomposition_plaintexts_buffer =
+        PlaintextListOwned::new(Scalar::ZERO, PlaintextCount(decomp_level_count.0));
+
+    let mut generator = EncryptionRandomGenerator::<ActivatedRandomGenerator>::new(
+        lwe_keyswitch_key.compression_seed().seed,
+        noise_seeder,
+    );
+
+    // Iterate over the input key elements and the destination lwe_keyswitch_key memory
+    for (input_key_element, mut keyswitch_key_block) in input_lwe_sk
+        .as_ref()
+        .iter()
+        .zip(lwe_keyswitch_key.iter_mut())
+    {
+        // We fill the buffer with the powers of the key elmements
+        for (level, message) in (1..=decomp_level_count.0)
+            .rev()
+            .map(DecompositionLevel)
+            .zip(decomposition_plaintexts_buffer.iter_mut())
+        {
+            *message.0 = DecompositionTermNonNative::new(
+                level,
+                decomp_base_log,
+                *input_key_element,
+                ciphertext_modulus,
+            )
+            .to_recomposition_summand();
         }
 
         encrypt_seeded_lwe_ciphertext_list_with_existing_generator(

--- a/tfhe/src/core_crypto/algorithms/lwe_linear_algebra.rs
+++ b/tfhe/src/core_crypto/algorithms/lwe_linear_algebra.rs
@@ -2,6 +2,7 @@
 //! like addition, multiplication, etc.
 
 use crate::core_crypto::algorithms::slice_algorithms::*;
+use crate::core_crypto::commons::ciphertext_modulus::CiphertextModulusKind;
 use crate::core_crypto::commons::numeric::UnsignedInteger;
 use crate::core_crypto::commons::traits::*;
 use crate::core_crypto::entities::*;
@@ -72,6 +73,22 @@ pub fn lwe_ciphertext_add_assign<Scalar, LhsCont, RhsCont>(
     LhsCont: ContainerMut<Element = Scalar>,
     RhsCont: Container<Element = Scalar>,
 {
+    let ciphertext_modulus = rhs.ciphertext_modulus();
+    if ciphertext_modulus.is_compatible_with_native_modulus() {
+        lwe_ciphertext_add_assign_native_mod_compatible(lhs, rhs)
+    } else {
+        lwe_ciphertext_add_assign_non_native_mod(lhs, rhs)
+    }
+}
+
+pub fn lwe_ciphertext_add_assign_native_mod_compatible<Scalar, LhsCont, RhsCont>(
+    lhs: &mut LweCiphertext<LhsCont>,
+    rhs: &LweCiphertext<RhsCont>,
+) where
+    Scalar: UnsignedInteger,
+    LhsCont: ContainerMut<Element = Scalar>,
+    RhsCont: Container<Element = Scalar>,
+{
     assert_eq!(
         lhs.ciphertext_modulus(),
         rhs.ciphertext_modulus(),
@@ -79,8 +96,35 @@ pub fn lwe_ciphertext_add_assign<Scalar, LhsCont, RhsCont>(
         lhs.ciphertext_modulus(),
         rhs.ciphertext_modulus()
     );
+    let ciphertext_modulus = rhs.ciphertext_modulus();
+    assert!(ciphertext_modulus.is_compatible_with_native_modulus());
 
     slice_wrapping_add_assign(lhs.as_mut(), rhs.as_ref());
+}
+
+pub fn lwe_ciphertext_add_assign_non_native_mod<Scalar, LhsCont, RhsCont>(
+    lhs: &mut LweCiphertext<LhsCont>,
+    rhs: &LweCiphertext<RhsCont>,
+) where
+    Scalar: UnsignedInteger,
+    LhsCont: ContainerMut<Element = Scalar>,
+    RhsCont: Container<Element = Scalar>,
+{
+    assert_eq!(
+        lhs.ciphertext_modulus(),
+        rhs.ciphertext_modulus(),
+        "Mismatched moduli between lhs ({:?}) and rhs ({:?}) LweCiphertext",
+        lhs.ciphertext_modulus(),
+        rhs.ciphertext_modulus()
+    );
+    let ciphertext_modulus = rhs.ciphertext_modulus();
+    assert!(!ciphertext_modulus.is_compatible_with_native_modulus());
+
+    slice_wrapping_add_assign_custom_mod(
+        lhs.as_mut(),
+        rhs.as_ref(),
+        ciphertext_modulus.get_custom_modulus().cast_into(),
+    );
 }
 
 /// Add the right-hand side [`LWE ciphertext`](`LweCiphertext`) to the left-hand side [`LWE
@@ -236,17 +280,48 @@ pub fn lwe_ciphertext_plaintext_add_assign<Scalar, InCont>(
     Scalar: UnsignedInteger,
     InCont: ContainerMut<Element = Scalar>,
 {
+    let ciphertext_modulus = lhs.ciphertext_modulus();
+    if ciphertext_modulus.is_compatible_with_native_modulus() {
+        lwe_ciphertext_plaintext_add_assign_native_mod_compatible(lhs, rhs)
+    } else {
+        lwe_ciphertext_plaintext_add_assign_non_native_mod(lhs, rhs)
+    }
+}
+
+pub fn lwe_ciphertext_plaintext_add_assign_native_mod_compatible<Scalar, InCont>(
+    lhs: &mut LweCiphertext<InCont>,
+    rhs: Plaintext<Scalar>,
+) where
+    Scalar: UnsignedInteger,
+    InCont: ContainerMut<Element = Scalar>,
+{
     let body = lhs.get_mut_body();
     let ciphertext_modulus = body.ciphertext_modulus();
     assert!(ciphertext_modulus.is_compatible_with_native_modulus());
-    if ciphertext_modulus.is_native_modulus() {
-        *body.data = (*body.data).wrapping_add(rhs.0);
-    } else {
-        *body.data = (*body.data).wrapping_add(
-            rhs.0
-                .wrapping_mul(ciphertext_modulus.get_power_of_two_scaling_to_native_torus()),
-        );
+    match ciphertext_modulus.kind() {
+        CiphertextModulusKind::Native => *body.data = (*body.data).wrapping_add(rhs.0),
+        CiphertextModulusKind::NonNativePowerOfTwo => {
+            *body.data = (*body.data).wrapping_add(
+                rhs.0
+                    .wrapping_mul(ciphertext_modulus.get_power_of_two_scaling_to_native_torus()),
+            )
+        }
+        CiphertextModulusKind::NonNative => unreachable!(),
     }
+}
+
+pub fn lwe_ciphertext_plaintext_add_assign_non_native_mod<Scalar, InCont>(
+    lhs: &mut LweCiphertext<InCont>,
+    rhs: Plaintext<Scalar>,
+) where
+    Scalar: UnsignedInteger,
+    InCont: ContainerMut<Element = Scalar>,
+{
+    let body = lhs.get_mut_body();
+    let ciphertext_modulus = body.ciphertext_modulus();
+    assert!(!ciphertext_modulus.is_compatible_with_native_modulus());
+    *body.data = (*body.data)
+        .wrapping_add_custom_mod(rhs.0, ciphertext_modulus.get_custom_modulus().cast_into());
 }
 
 /// Add the right-hand side encoded [`Plaintext`] to the left-hand side [`LWE
@@ -312,6 +387,21 @@ pub fn lwe_ciphertext_plaintext_sub_assign<Scalar, InCont>(
     Scalar: UnsignedInteger,
     InCont: ContainerMut<Element = Scalar>,
 {
+    let ciphertext_modulus = lhs.ciphertext_modulus();
+    if ciphertext_modulus.is_compatible_with_native_modulus() {
+        lwe_ciphertext_plaintext_sub_assign_native_mod_compatible(lhs, rhs)
+    } else {
+        lwe_ciphertext_plaintext_sub_assign_non_native_mod(lhs, rhs)
+    }
+}
+
+pub fn lwe_ciphertext_plaintext_sub_assign_native_mod_compatible<Scalar, InCont>(
+    lhs: &mut LweCiphertext<InCont>,
+    rhs: Plaintext<Scalar>,
+) where
+    Scalar: UnsignedInteger,
+    InCont: ContainerMut<Element = Scalar>,
+{
     let body = lhs.get_mut_body();
     let ciphertext_modulus = body.ciphertext_modulus();
     assert!(ciphertext_modulus.is_compatible_with_native_modulus());
@@ -323,6 +413,20 @@ pub fn lwe_ciphertext_plaintext_sub_assign<Scalar, InCont>(
                 .wrapping_mul(ciphertext_modulus.get_power_of_two_scaling_to_native_torus()),
         );
     }
+}
+
+pub fn lwe_ciphertext_plaintext_sub_assign_non_native_mod<Scalar, InCont>(
+    lhs: &mut LweCiphertext<InCont>,
+    rhs: Plaintext<Scalar>,
+) where
+    Scalar: UnsignedInteger,
+    InCont: ContainerMut<Element = Scalar>,
+{
+    let body = lhs.get_mut_body();
+    let ciphertext_modulus = body.ciphertext_modulus();
+    assert!(!ciphertext_modulus.is_compatible_with_native_modulus());
+    *body.data = (*body.data)
+        .wrapping_sub_custom_mod(rhs.0, ciphertext_modulus.get_custom_modulus().cast_into());
 }
 
 /// Compute the opposite of the input [`LWE ciphertext`](`LweCiphertext`) and update it in place.

--- a/tfhe/src/core_crypto/algorithms/misc.rs
+++ b/tfhe/src/core_crypto/algorithms/misc.rs
@@ -1,86 +1,67 @@
-//! Miscellaneous algorithms.
-
-use crate::core_crypto::prelude::*;
+use crate::core_crypto::commons::numeric::UnsignedInteger;
 
 #[inline]
-pub fn divide_round_to_u128<Scalar>(numerator: Scalar, denominator: Scalar) -> u128
-where
-    Scalar: UnsignedInteger,
-{
-    let numerator_128: u128 = numerator.cast_into();
-    let half_denominator: u128 = (denominator / Scalar::TWO).cast_into();
-    let denominator_128: u128 = denominator.cast_into();
-    // That's the rounding
-    (numerator_128 + half_denominator) / denominator_128
+pub fn divide_round<Scalar: UnsignedInteger>(numerator: Scalar, denominator: Scalar) -> Scalar {
+    // // Does the following without overflowing (which can happen with the addition of denom / 2)
+    // (numerator + denominator / Scalar::TWO) / denominator
+
+    // div and rem should be computed in a single instruction on most CPUs for native types < u128
+    let (div, rem) = (numerator / denominator, numerator % denominator);
+    div + Scalar::from(rem >= (denominator >> 1))
 }
 
-#[inline]
-pub fn divide_round_to_u128_custom_mod<Scalar>(
-    numerator: Scalar,
-    denominator: Scalar,
-    modulus: u128,
-) -> u128
-where
-    Scalar: UnsignedInteger,
-{
-    let numerator_128: u128 = numerator.cast_into();
-    let half_denominator: u128 = (denominator / Scalar::TWO).cast_into();
-    let denominator_128: u128 = denominator.cast_into();
-    // That's the rounding
-    ((numerator_128 + half_denominator) % modulus) / denominator_128
-}
-
-pub fn odd_modular_inverse_pow_2<Scalar>(odd_value_to_invert: Scalar, log2_modulo: usize) -> Scalar
-where
-    Scalar: UnsignedInteger,
-{
-    let t = log2_modulo.ilog2() + if log2_modulo.is_power_of_two() { 0 } else { 1 };
-    let mut y = Scalar::ONE;
-    let e = odd_value_to_invert;
-
-    for i in 1..=t {
-        // 1 << (1 << i) == 2 ^ {2 ^ i}
-        let curr_mod = Scalar::ONE.shl(1 << i);
-        // y = y * (2 - y * e) mod 2 ^ {2 ^ i}
-        // Here using wrapping ops is ok as the modulus used is a power of 2, as long as 2 ^ {2 ^ i}
-        // is smaller than Scalar::BITS, we are good to go, the discarded values would not have been
-        // Used anyways, and 2 ^ {2 ^ i} is compatible with a native modulus
-        y = (y.wrapping_mul(Scalar::TWO.wrapping_sub(y.wrapping_mul(e)))).wrapping_rem(curr_mod);
+pub fn modular_distance_custom_mod<Scalar: UnsignedInteger>(
+    x: Scalar,
+    y: Scalar,
+    modulus: Scalar,
+) -> Scalar {
+    if y >= x {
+        let diff = y - x;
+        let x_u128: u128 = x.cast_into();
+        let y_u128: u128 = y.cast_into();
+        let modulus_u128: u128 = modulus.cast_into();
+        let wrap_diff = Scalar::cast_from(modulus_u128 + x_u128 - y_u128);
+        diff.min(wrap_diff)
+    } else {
+        modular_distance_custom_mod(y, x, modulus)
     }
-
-    y.wrapping_rem(Scalar::ONE.shl(log2_modulo))
 }
 
-#[test]
-fn test_divide_round() {
-    use rand::Rng;
+#[cfg(test)]
+mod test {
+    use super::divide_round;
 
-    let mut rng = rand::thread_rng();
+    #[test]
+    fn test_divide_round() {
+        use rand::Rng;
 
-    const NB_TESTS: usize = 1_000_000_000;
-    const SCALING: f64 = u64::MAX as f64;
-    for _ in 0..NB_TESTS {
-        let num: f64 = rng.gen();
-        let mut denom = 0.0f64;
-        while denom == 0.0f64 {
-            denom = rng.gen();
+        let mut rng = rand::thread_rng();
+
+        const NB_TESTS: usize = 1_000_000_000;
+        const SCALING: f64 = u64::MAX as f64;
+        for _ in 0..NB_TESTS {
+            let num: f64 = rng.gen();
+            let mut denom = 0.0f64;
+            while denom == 0.0f64 {
+                denom = rng.gen();
+            }
+
+            let num = (num * SCALING).round();
+            let denom = (denom * SCALING).round();
+
+            let rounded = (num / denom).round();
+            let expected_rounded_u64: u64 = rounded as u64;
+
+            let num_u64: u64 = num as u64;
+            let denom_u64: u64 = denom as u64;
+
+            // sanity check
+            assert_eq!(num, num_u64 as f64);
+            assert_eq!(denom, denom_u64 as f64);
+
+            let rounded_u64 = divide_round(num_u64, denom_u64);
+
+            assert_eq!(expected_rounded_u64, rounded_u64);
         }
-
-        let num = (num * SCALING).round();
-        let denom = (denom * SCALING).round();
-
-        let rounded = (num / denom).round();
-        let expected_rounded_u64: u64 = rounded as u64;
-
-        let num_u64: u64 = num as u64;
-        let denom_u64: u64 = denom as u64;
-
-        // sanity check
-        assert_eq!(num, num_u64 as f64);
-        assert_eq!(denom, denom_u64 as f64);
-
-        let rounded_u128 = divide_round_to_u128(num_u64, denom_u64);
-
-        assert_eq!(expected_rounded_u64, rounded_u128 as u64);
     }
 }

--- a/tfhe/src/core_crypto/algorithms/mod.rs
+++ b/tfhe/src/core_crypto/algorithms/mod.rs
@@ -66,6 +66,7 @@ pub use lwe_programmable_bootstrapping::*;
 pub use lwe_public_key_generation::*;
 pub use lwe_secret_key_generation::*;
 pub use lwe_wopbs::*;
+pub use misc::*;
 pub use seeded_ggsw_ciphertext_decompression::*;
 pub use seeded_ggsw_ciphertext_list_decompression::*;
 pub use seeded_glwe_ciphertext_decompression::*;

--- a/tfhe/src/core_crypto/algorithms/polynomial_algorithms.rs
+++ b/tfhe/src/core_crypto/algorithms/polynomial_algorithms.rs
@@ -35,6 +35,19 @@ pub fn polynomial_wrapping_add_assign<Scalar, OutputCont, InputCont>(
     slice_wrapping_add_assign(lhs.as_mut(), rhs.as_ref())
 }
 
+pub fn polynomial_wrapping_add_assign_custom_mod<Scalar, OutputCont, InputCont>(
+    lhs: &mut Polynomial<OutputCont>,
+    rhs: &Polynomial<InputCont>,
+    custom_modulus: Scalar,
+) where
+    Scalar: UnsignedInteger,
+    OutputCont: ContainerMut<Element = Scalar>,
+    InputCont: Container<Element = Scalar>,
+{
+    assert_eq!(lhs.polynomial_size(), rhs.polynomial_size());
+    slice_wrapping_add_assign_custom_mod(lhs.as_mut(), rhs.as_ref(), custom_modulus)
+}
+
 /// Subtract a polynomial to the output polynomial.
 ///
 /// # Note
@@ -62,6 +75,19 @@ pub fn polynomial_wrapping_sub_assign<Scalar, OutputCont, InputCont>(
 {
     assert_eq!(lhs.polynomial_size(), rhs.polynomial_size());
     slice_wrapping_sub_assign(lhs.as_mut(), rhs.as_ref())
+}
+
+pub fn polynomial_wrapping_sub_assign_custom_mod<Scalar, OutputCont, InputCont>(
+    lhs: &mut Polynomial<OutputCont>,
+    rhs: &Polynomial<InputCont>,
+    custom_modulus: Scalar,
+) where
+    Scalar: UnsignedInteger,
+    OutputCont: ContainerMut<Element = Scalar>,
+    InputCont: Container<Element = Scalar>,
+{
+    assert_eq!(lhs.polynomial_size(), rhs.polynomial_size());
+    slice_wrapping_sub_assign_custom_mod(lhs.as_mut(), rhs.as_ref(), custom_modulus)
 }
 
 /// Add the sum of the element-wise product between two lists of polynomials to the output
@@ -102,6 +128,27 @@ pub fn polynomial_wrapping_add_multisum_assign<Scalar, OutputCont, InputCont1, I
 {
     for (poly_1, poly_2) in poly_list_1.iter().zip(poly_list_2.iter()) {
         polynomial_wrapping_add_mul_assign(output, &poly_1, &poly_2);
+    }
+}
+
+pub fn polynomial_wrapping_add_multisum_assign_custom_mod<
+    Scalar,
+    OutputCont,
+    InputCont1,
+    InputCont2,
+>(
+    output: &mut Polynomial<OutputCont>,
+    poly_list_1: &PolynomialList<InputCont1>,
+    poly_list_2: &PolynomialList<InputCont2>,
+    custom_modulus: Scalar,
+) where
+    Scalar: UnsignedInteger,
+    OutputCont: ContainerMut<Element = Scalar>,
+    InputCont1: Container<Element = Scalar>,
+    InputCont2: Container<Element = Scalar>,
+{
+    for (poly_1, poly_2) in poly_list_1.iter().zip(poly_list_2.iter()) {
+        polynomial_wrapping_add_mul_assign_custom_mod(output, &poly_1, &poly_2, custom_modulus);
     }
 }
 
@@ -170,6 +217,63 @@ pub fn polynomial_wrapping_add_mul_assign<Scalar, OutputCont, InputCont1, InputC
 
                     *output_coefficient =
                         (*output_coefficient).wrapping_sub(lhs_coeff.wrapping_mul(rhs_coeff));
+                }
+            }
+        }
+    }
+}
+
+pub fn polynomial_wrapping_add_mul_assign_custom_mod<Scalar, OutputCont, InputCont1, InputCont2>(
+    output: &mut Polynomial<OutputCont>,
+    lhs: &Polynomial<InputCont1>,
+    rhs: &Polynomial<InputCont2>,
+    custom_modulus: Scalar,
+) where
+    Scalar: UnsignedInteger,
+    OutputCont: ContainerMut<Element = Scalar>,
+    InputCont1: Container<Element = Scalar>,
+    InputCont2: Container<Element = Scalar>,
+{
+    assert!(
+        output.polynomial_size() == lhs.polynomial_size(),
+        "Output polynomial size {:?} is not the same as input lhs polynomial {:?}.",
+        output.polynomial_size(),
+        lhs.polynomial_size(),
+    );
+    assert!(
+        output.polynomial_size() == rhs.polynomial_size(),
+        "Output polynomial size {:?} is not the same as input rhs polynomial {:?}.",
+        output.polynomial_size(),
+        rhs.polynomial_size(),
+    );
+
+    let polynomial_size = output.polynomial_size();
+
+    if polynomial_size.0.is_power_of_two() && polynomial_size.0 > KARATUSBA_STOP {
+        let mut tmp = Polynomial::new(Scalar::ZERO, polynomial_size);
+
+        polynomial_karatsuba_wrapping_mul_custom_mod(&mut tmp, lhs, rhs, custom_modulus);
+        polynomial_wrapping_add_assign_custom_mod(output, &tmp, custom_modulus);
+    } else {
+        let degree = output.degree();
+        for (lhs_degree, &lhs_coeff) in lhs.iter().enumerate() {
+            for (rhs_degree, &rhs_coeff) in rhs.iter().enumerate() {
+                let target_degree = lhs_degree + rhs_degree;
+                if target_degree <= degree {
+                    let output_coefficient = &mut output.as_mut()[target_degree];
+
+                    *output_coefficient = (*output_coefficient).wrapping_add_custom_mod(
+                        lhs_coeff.wrapping_mul_custom_mod(rhs_coeff, custom_modulus),
+                        custom_modulus,
+                    );
+                } else {
+                    let target_degree = target_degree % polynomial_size.0;
+                    let output_coefficient = &mut output.as_mut()[target_degree];
+
+                    *output_coefficient = (*output_coefficient).wrapping_sub_custom_mod(
+                        lhs_coeff.wrapping_mul_custom_mod(rhs_coeff, custom_modulus),
+                        custom_modulus,
+                    );
                 }
             }
         }
@@ -419,6 +523,27 @@ pub fn polynomial_wrapping_sub_multisum_assign<Scalar, OutputCont, InputCont1, I
     }
 }
 
+pub fn polynomial_wrapping_sub_multisum_assign_custom_mod<
+    Scalar,
+    OutputCont,
+    InputCont1,
+    InputCont2,
+>(
+    output: &mut Polynomial<OutputCont>,
+    poly_list_1: &PolynomialList<InputCont1>,
+    poly_list_2: &PolynomialList<InputCont2>,
+    custom_modulus: Scalar,
+) where
+    Scalar: UnsignedInteger,
+    OutputCont: ContainerMut<Element = Scalar>,
+    InputCont1: Container<Element = Scalar>,
+    InputCont2: Container<Element = Scalar>,
+{
+    for (poly_1, poly_2) in poly_list_1.iter().zip(poly_list_2.iter()) {
+        polynomial_wrapping_sub_mul_assign_custom_mod(output, &poly_1, &poly_2, custom_modulus);
+    }
+}
+
 /// Subtract the result of the product between two polynomials, reduced modulo $(X^{N}+1)$, to the
 /// output polynomial.
 ///
@@ -484,6 +609,63 @@ pub fn polynomial_wrapping_sub_mul_assign<Scalar, OutputCont, InputCont1, InputC
 
                     *output_coefficient =
                         (*output_coefficient).wrapping_add(lhs_coeff.wrapping_mul(rhs_coeff));
+                }
+            }
+        }
+    }
+}
+
+pub fn polynomial_wrapping_sub_mul_assign_custom_mod<Scalar, OutputCont, InputCont1, InputCont2>(
+    output: &mut Polynomial<OutputCont>,
+    lhs: &Polynomial<InputCont1>,
+    rhs: &Polynomial<InputCont2>,
+    custom_modulus: Scalar,
+) where
+    Scalar: UnsignedInteger,
+    OutputCont: ContainerMut<Element = Scalar>,
+    InputCont1: Container<Element = Scalar>,
+    InputCont2: Container<Element = Scalar>,
+{
+    assert!(
+        output.polynomial_size() == lhs.polynomial_size(),
+        "Output polynomial size {:?} is not the same as input lhs polynomial {:?}.",
+        output.polynomial_size(),
+        lhs.polynomial_size(),
+    );
+    assert!(
+        output.polynomial_size() == rhs.polynomial_size(),
+        "Output polynomial size {:?} is not the same as input rhs polynomial {:?}.",
+        output.polynomial_size(),
+        rhs.polynomial_size(),
+    );
+
+    let polynomial_size = output.polynomial_size();
+
+    if polynomial_size.0.is_power_of_two() && polynomial_size.0 > KARATUSBA_STOP {
+        let mut tmp = Polynomial::new(Scalar::ZERO, polynomial_size);
+
+        polynomial_karatsuba_wrapping_mul_custom_mod(&mut tmp, lhs, rhs, custom_modulus);
+        polynomial_wrapping_sub_assign_custom_mod(output, &tmp, custom_modulus);
+    } else {
+        let degree = output.degree();
+        for (lhs_degree, &lhs_coeff) in lhs.iter().enumerate() {
+            for (rhs_degree, &rhs_coeff) in rhs.iter().enumerate() {
+                let target_degree = lhs_degree + rhs_degree;
+                if target_degree <= degree {
+                    let output_coefficient = &mut output.as_mut()[target_degree];
+
+                    *output_coefficient = (*output_coefficient).wrapping_sub_custom_mod(
+                        lhs_coeff.wrapping_mul_custom_mod(rhs_coeff, custom_modulus),
+                        custom_modulus,
+                    );
+                } else {
+                    let target_degree = target_degree % polynomial_size.0;
+                    let output_coefficient = &mut output.as_mut()[target_degree];
+
+                    *output_coefficient = (*output_coefficient).wrapping_add_custom_mod(
+                        lhs_coeff.wrapping_mul_custom_mod(rhs_coeff, custom_modulus),
+                        custom_modulus,
+                    );
                 }
             }
         }
@@ -645,6 +827,172 @@ where
         slice_wrapping_sub_assign(&mut res[(poly_size / 4)..(3 * poly_size / 4)], &a1);
         slice_wrapping_add_assign(&mut res[0..(poly_size / 2)], &a0);
         slice_wrapping_add_assign(&mut res[(poly_size / 2)..poly_size], &a1);
+    }
+}
+
+pub fn polynomial_karatsuba_wrapping_mul_custom_mod<Scalar, OutputCont, LhsCont, RhsCont>(
+    output: &mut Polynomial<OutputCont>,
+    p: &Polynomial<LhsCont>,
+    q: &Polynomial<RhsCont>,
+    custom_modulus: Scalar,
+) where
+    Scalar: UnsignedInteger,
+    OutputCont: ContainerMut<Element = Scalar>,
+    LhsCont: Container<Element = Scalar>,
+    RhsCont: Container<Element = Scalar>,
+{
+    // check same dimensions
+    assert!(
+        output.polynomial_size() == p.polynomial_size(),
+        "Output polynomial size {:?} is not the same as input lhs polynomial {:?}.",
+        output.polynomial_size(),
+        p.polynomial_size(),
+    );
+    assert!(
+        output.polynomial_size() == q.polynomial_size(),
+        "Output polynomial size {:?} is not the same as input rhs polynomial {:?}.",
+        output.polynomial_size(),
+        q.polynomial_size(),
+    );
+
+    let poly_size = output.polynomial_size().0;
+
+    // check dimensions are a power of 2
+    assert!(poly_size.is_power_of_two());
+
+    // allocate slices for the rec
+    let mut a0 = vec![Scalar::ZERO; poly_size];
+    let mut a1 = vec![Scalar::ZERO; poly_size];
+    let mut a2 = vec![Scalar::ZERO; poly_size];
+    let mut input_a2_p = vec![Scalar::ZERO; poly_size / 2];
+    let mut input_a2_q = vec![Scalar::ZERO; poly_size / 2];
+
+    // prepare for splitting
+    let bottom = 0..(poly_size / 2);
+    let top = (poly_size / 2)..poly_size;
+
+    // induction
+    induction_karatsuba_custom_mod(
+        &mut a0,
+        &p[bottom.clone()],
+        &q[bottom.clone()],
+        custom_modulus,
+    );
+    induction_karatsuba_custom_mod(&mut a1, &p[top.clone()], &q[top.clone()], custom_modulus);
+    slice_wrapping_add_custom_mod(
+        &mut input_a2_p,
+        &p[bottom.clone()],
+        &p[top.clone()],
+        custom_modulus,
+    );
+    slice_wrapping_add_custom_mod(
+        &mut input_a2_q,
+        &q[bottom.clone()],
+        &q[top.clone()],
+        custom_modulus,
+    );
+    induction_karatsuba_custom_mod(&mut a2, &input_a2_p, &input_a2_q, custom_modulus);
+
+    // rebuild the result
+    let output: &mut [Scalar] = output.as_mut();
+    slice_wrapping_sub_custom_mod(output, &a0, &a1, custom_modulus);
+    slice_wrapping_sub_assign_custom_mod(
+        &mut output[bottom.clone()],
+        &a2[top.clone()],
+        custom_modulus,
+    );
+    slice_wrapping_add_assign_custom_mod(
+        &mut output[bottom.clone()],
+        &a0[top.clone()],
+        custom_modulus,
+    );
+    slice_wrapping_add_assign_custom_mod(
+        &mut output[bottom.clone()],
+        &a1[top.clone()],
+        custom_modulus,
+    );
+    slice_wrapping_add_assign_custom_mod(
+        &mut output[top.clone()],
+        &a2[bottom.clone()],
+        custom_modulus,
+    );
+    slice_wrapping_sub_assign_custom_mod(
+        &mut output[top.clone()],
+        &a0[bottom.clone()],
+        custom_modulus,
+    );
+    slice_wrapping_sub_assign_custom_mod(&mut output[top], &a1[bottom], custom_modulus);
+}
+
+fn induction_karatsuba_custom_mod<Scalar>(
+    res: &mut [Scalar],
+    p: &[Scalar],
+    q: &[Scalar],
+    custom_modulus: Scalar,
+) where
+    Scalar: UnsignedInteger,
+{
+    // stop the induction when polynomials have KARATUSBA_STOP elements
+    if p.len() <= KARATUSBA_STOP {
+        // schoolbook algorithm
+        for (lhs_degree, &lhs_elt) in p.iter().enumerate() {
+            let res = &mut res[lhs_degree..];
+            for (&rhs_elt, res) in q.iter().zip(res) {
+                *res = (*res).wrapping_add_custom_mod(
+                    lhs_elt.wrapping_mul_custom_mod(rhs_elt, custom_modulus),
+                    custom_modulus,
+                )
+            }
+        }
+    } else {
+        let poly_size = res.len();
+
+        // allocate slices for the rec
+        let mut a0 = vec![Scalar::ZERO; poly_size / 2];
+        let mut a1 = vec![Scalar::ZERO; poly_size / 2];
+        let mut a2 = vec![Scalar::ZERO; poly_size / 2];
+        let mut input_a2_p = vec![Scalar::ZERO; poly_size / 4];
+        let mut input_a2_q = vec![Scalar::ZERO; poly_size / 4];
+
+        // prepare for splitting
+        let bottom = 0..(poly_size / 4);
+        let top = (poly_size / 4)..(poly_size / 2);
+
+        // rec
+        induction_karatsuba_custom_mod(
+            &mut a0,
+            &p[bottom.clone()],
+            &q[bottom.clone()],
+            custom_modulus,
+        );
+        induction_karatsuba_custom_mod(&mut a1, &p[top.clone()], &q[top.clone()], custom_modulus);
+        slice_wrapping_add_custom_mod(
+            &mut input_a2_p,
+            &p[bottom.clone()],
+            &p[top.clone()],
+            custom_modulus,
+        );
+        slice_wrapping_add_custom_mod(&mut input_a2_q, &q[bottom], &q[top], custom_modulus);
+        induction_karatsuba_custom_mod(&mut a2, &input_a2_p, &input_a2_q, custom_modulus);
+
+        // rebuild the result
+        slice_wrapping_sub_custom_mod(
+            &mut res[(poly_size / 4)..(3 * poly_size / 4)],
+            &a2,
+            &a0,
+            custom_modulus,
+        );
+        slice_wrapping_sub_assign_custom_mod(
+            &mut res[(poly_size / 4)..(3 * poly_size / 4)],
+            &a1,
+            custom_modulus,
+        );
+        slice_wrapping_add_assign_custom_mod(&mut res[0..(poly_size / 2)], &a0, custom_modulus);
+        slice_wrapping_add_assign_custom_mod(
+            &mut res[(poly_size / 2)..poly_size],
+            &a1,
+            custom_modulus,
+        );
     }
 }
 

--- a/tfhe/src/core_crypto/algorithms/seeded_glwe_ciphertext_decompression.rs
+++ b/tfhe/src/core_crypto/algorithms/seeded_glwe_ciphertext_decompression.rs
@@ -1,6 +1,7 @@
 //! Module with primitives pertaining to [`SeededGlweCiphertext`] decompression.
 
 use crate::core_crypto::algorithms::slice_algorithms::slice_wrapping_scalar_mul_assign;
+use crate::core_crypto::commons::ciphertext_modulus::CiphertextModulusKind;
 use crate::core_crypto::commons::math::random::RandomGenerator;
 use crate::core_crypto::commons::traits::*;
 use crate::core_crypto::entities::*;
@@ -34,11 +35,11 @@ pub fn decompress_seeded_glwe_ciphertext_with_existing_generator<
     let (mut output_mask, mut output_body) = output_glwe.get_mut_mask_and_body();
 
     let ciphertext_modulus = output_mask.ciphertext_modulus();
-    assert!(ciphertext_modulus.is_compatible_with_native_modulus());
 
     // generate a uniformly random mask
     generator.fill_slice_with_random_uniform_custom_mod(output_mask.as_mut(), ciphertext_modulus);
-    if !ciphertext_modulus.is_native_modulus() {
+    // Manage the non native power of 2 encoding
+    if ciphertext_modulus.kind() == CiphertextModulusKind::NonNativePowerOfTwo {
         slice_wrapping_scalar_mul_assign(
             output_mask.as_mut(),
             ciphertext_modulus.get_power_of_two_scaling_to_native_torus(),

--- a/tfhe/src/core_crypto/algorithms/seeded_glwe_ciphertext_list_decompression.rs
+++ b/tfhe/src/core_crypto/algorithms/seeded_glwe_ciphertext_list_decompression.rs
@@ -1,6 +1,7 @@
 //! Module with primitives pertaining to [`SeededGlweCiphertextList`] decompression.
 
 use crate::core_crypto::algorithms::slice_algorithms::slice_wrapping_scalar_mul_assign;
+use crate::core_crypto::commons::ciphertext_modulus::CiphertextModulusKind;
 use crate::core_crypto::commons::math::random::RandomGenerator;
 use crate::core_crypto::commons::traits::*;
 use crate::core_crypto::entities::*;
@@ -32,7 +33,6 @@ pub fn decompress_seeded_glwe_ciphertext_list_with_existing_generator<
     );
 
     let ciphertext_modulus = output_list.ciphertext_modulus();
-    assert!(ciphertext_modulus.is_compatible_with_native_modulus());
 
     for (mut glwe_out, body_in) in output_list.iter_mut().zip(input_seeded_list.iter()) {
         let (mut output_mask, mut output_body) = glwe_out.get_mut_mask_and_body();
@@ -40,7 +40,8 @@ pub fn decompress_seeded_glwe_ciphertext_list_with_existing_generator<
         // generate a uniformly random mask
         generator
             .fill_slice_with_random_uniform_custom_mod(output_mask.as_mut(), ciphertext_modulus);
-        if !ciphertext_modulus.is_native_modulus() {
+        // Manage the non native power of 2 encoding
+        if ciphertext_modulus.kind() == CiphertextModulusKind::NonNativePowerOfTwo {
             slice_wrapping_scalar_mul_assign(
                 output_mask.as_mut(),
                 ciphertext_modulus.get_power_of_two_scaling_to_native_torus(),

--- a/tfhe/src/core_crypto/algorithms/seeded_lwe_ciphertext_decompression.rs
+++ b/tfhe/src/core_crypto/algorithms/seeded_lwe_ciphertext_decompression.rs
@@ -1,6 +1,7 @@
 //! Module with primitives pertaining to [`SeededLweCiphertext`] decompression.
 
 use crate::core_crypto::algorithms::slice_algorithms::slice_wrapping_scalar_mul_assign;
+use crate::core_crypto::commons::ciphertext_modulus::CiphertextModulusKind;
 use crate::core_crypto::commons::math::random::RandomGenerator;
 use crate::core_crypto::commons::traits::*;
 use crate::core_crypto::entities::*;
@@ -26,12 +27,12 @@ pub fn decompress_seeded_lwe_ciphertext_with_existing_generator<Scalar, OutputCo
     );
 
     let ciphertext_modulus = output_lwe.ciphertext_modulus();
-    assert!(ciphertext_modulus.is_compatible_with_native_modulus());
     let (mut output_mask, output_body) = output_lwe.get_mut_mask_and_body();
 
     // generate a uniformly random mask
     generator.fill_slice_with_random_uniform_custom_mod(output_mask.as_mut(), ciphertext_modulus);
-    if !ciphertext_modulus.is_native_modulus() {
+    // Manage the specific encoding for non native power of 2
+    if ciphertext_modulus.kind() == CiphertextModulusKind::NonNativePowerOfTwo {
         slice_wrapping_scalar_mul_assign(
             output_mask.as_mut(),
             ciphertext_modulus.get_power_of_two_scaling_to_native_torus(),

--- a/tfhe/src/core_crypto/algorithms/seeded_lwe_ciphertext_list_decompression.rs
+++ b/tfhe/src/core_crypto/algorithms/seeded_lwe_ciphertext_list_decompression.rs
@@ -1,6 +1,7 @@
 //! Module with primitives pertaining to [`SeededLweCiphertextList`] decompression.
 
 use crate::core_crypto::algorithms::slice_algorithms::slice_wrapping_scalar_mul_assign;
+use crate::core_crypto::commons::ciphertext_modulus::CiphertextModulusKind;
 use crate::core_crypto::commons::math::random::RandomGenerator;
 use crate::core_crypto::commons::traits::*;
 use crate::core_crypto::entities::*;
@@ -34,7 +35,6 @@ pub fn decompress_seeded_lwe_ciphertext_list_with_existing_generator<
     );
 
     let ciphertext_modulus = output_list.ciphertext_modulus();
-    assert!(ciphertext_modulus.is_compatible_with_native_modulus());
 
     for (mut lwe_out, body_in) in output_list.iter_mut().zip(input_seeded_list.iter()) {
         let (mut output_mask, output_body) = lwe_out.get_mut_mask_and_body();
@@ -42,7 +42,8 @@ pub fn decompress_seeded_lwe_ciphertext_list_with_existing_generator<
         // generate a uniformly random mask
         generator
             .fill_slice_with_random_uniform_custom_mod(output_mask.as_mut(), ciphertext_modulus);
-        if !ciphertext_modulus.is_native_modulus() {
+        // Manage the non native power of 2 encoding
+        if ciphertext_modulus.kind() == CiphertextModulusKind::NonNativePowerOfTwo {
             slice_wrapping_scalar_mul_assign(
                 output_mask.as_mut(),
                 ciphertext_modulus.get_power_of_two_scaling_to_native_torus(),

--- a/tfhe/src/core_crypto/algorithms/slice_algorithms.rs
+++ b/tfhe/src/core_crypto/algorithms/slice_algorithms.rs
@@ -419,6 +419,17 @@ where
         .for_each(|elt| *elt = (*elt).wrapping_neg());
 }
 
+pub fn slice_wrapping_opposite_assign_custom_mod<Scalar>(
+    slice: &mut [Scalar],
+    custom_modulus: Scalar,
+) where
+    Scalar: UnsignedInteger,
+{
+    slice
+        .iter_mut()
+        .for_each(|elt| *elt = (*elt).wrapping_neg_custom_mod(custom_modulus));
+}
+
 /// Multiply a slice containing unsigned integers by a scalar, element-wise and in place.
 ///
 /// # Note

--- a/tfhe/src/core_crypto/algorithms/slice_algorithms.rs
+++ b/tfhe/src/core_crypto/algorithms/slice_algorithms.rs
@@ -103,6 +103,33 @@ where
         .for_each(|(out, (&lhs, &rhs))| *out = lhs.wrapping_add(rhs));
 }
 
+pub fn slice_wrapping_add_custom_mod<Scalar>(
+    output: &mut [Scalar],
+    lhs: &[Scalar],
+    rhs: &[Scalar],
+    custom_modulus: Scalar,
+) where
+    Scalar: UnsignedInteger,
+{
+    assert!(
+        lhs.len() == rhs.len(),
+        "lhs (len: {}) and rhs (len: {}) must have the same length",
+        lhs.len(),
+        rhs.len()
+    );
+    assert!(
+        output.len() == lhs.len(),
+        "output (len: {}) and rhs (len: {}) must have the same length",
+        output.len(),
+        lhs.len()
+    );
+
+    output
+        .iter_mut()
+        .zip(lhs.iter().zip(rhs.iter()))
+        .for_each(|(out, (&lhs, &rhs))| *out = lhs.wrapping_add_custom_mod(rhs, custom_modulus));
+}
+
 /// Add a slice containing unsigned integers to another one element-wise and in place.
 ///
 /// # Note
@@ -231,6 +258,33 @@ where
         .for_each(|(out, (&lhs, &rhs))| *out = lhs.wrapping_sub(rhs));
 }
 
+pub fn slice_wrapping_sub_custom_mod<Scalar>(
+    output: &mut [Scalar],
+    lhs: &[Scalar],
+    rhs: &[Scalar],
+    custom_modulus: Scalar,
+) where
+    Scalar: UnsignedInteger,
+{
+    assert!(
+        lhs.len() == rhs.len(),
+        "lhs (len: {}) and rhs (len: {}) must have the same length",
+        lhs.len(),
+        rhs.len()
+    );
+    assert!(
+        output.len() == lhs.len(),
+        "output (len: {}) and rhs (len: {}) must have the same length",
+        output.len(),
+        lhs.len()
+    );
+
+    output
+        .iter_mut()
+        .zip(lhs.iter().zip(rhs.iter()))
+        .for_each(|(out, (&lhs, &rhs))| *out = lhs.wrapping_sub_custom_mod(rhs, custom_modulus));
+}
+
 /// Subtract a slice containing unsigned integers to another one, element-wise and in place.
 ///
 /// # Note
@@ -261,6 +315,25 @@ where
     lhs.iter_mut()
         .zip(rhs.iter())
         .for_each(|(lhs, &rhs)| *lhs = (*lhs).wrapping_sub(rhs));
+}
+
+pub fn slice_wrapping_sub_assign_custom_mod<Scalar>(
+    lhs: &mut [Scalar],
+    rhs: &[Scalar],
+    custom_modulus: Scalar,
+) where
+    Scalar: UnsignedInteger,
+{
+    assert!(
+        lhs.len() == rhs.len(),
+        "lhs (len: {}) and rhs (len: {}) must have the same length",
+        lhs.len(),
+        rhs.len()
+    );
+
+    lhs.iter_mut()
+        .zip(rhs.iter())
+        .for_each(|(lhs, &rhs)| *lhs = (*lhs).wrapping_sub_custom_mod(rhs, custom_modulus));
 }
 
 /// Subtract a slice containing unsigned integers to another one mutiplied by a scalar,
@@ -368,6 +441,17 @@ where
 {
     lhs.iter_mut()
         .for_each(|lhs| *lhs = (*lhs).wrapping_mul(rhs));
+}
+
+pub fn slice_wrapping_scalar_mul_assign_custom_mod<Scalar>(
+    lhs: &mut [Scalar],
+    rhs: Scalar,
+    custom_modulus: Scalar,
+) where
+    Scalar: UnsignedInteger,
+{
+    lhs.iter_mut()
+        .for_each(|lhs| *lhs = (*lhs).wrapping_mul_custom_mod(rhs, custom_modulus));
 }
 
 pub fn slice_wrapping_scalar_div_assign<Scalar>(lhs: &mut [Scalar], rhs: Scalar)

--- a/tfhe/src/core_crypto/algorithms/slice_algorithms.rs
+++ b/tfhe/src/core_crypto/algorithms/slice_algorithms.rs
@@ -38,6 +38,31 @@ where
         })
 }
 
+/// This primitive is meant to manage the dot product avoiding overflow on multiplication by casting
+/// to u128, for example for u64, avoiding overflow on each multiplication (as u64::MAX * u64::MAX <
+/// u128::MAX)
+pub fn slice_wrapping_dot_product_custom_mod<Scalar>(
+    lhs: &[Scalar],
+    rhs: &[Scalar],
+    modulus: Scalar,
+) -> Scalar
+where
+    Scalar: UnsignedInteger,
+{
+    assert!(
+        lhs.len() == rhs.len(),
+        "lhs (len: {}) and rhs (len: {}) must have the same length",
+        lhs.len(),
+        rhs.len()
+    );
+
+    lhs.iter()
+        .zip(rhs.iter())
+        .fold(Scalar::ZERO, |acc, (&left, &right)| {
+            acc.wrapping_add_custom_mod(left.wrapping_mul_custom_mod(right, modulus), modulus)
+        })
+}
+
 /// Add a slice containing unsigned integers to another one element-wise.
 ///
 /// # Note
@@ -108,6 +133,25 @@ where
     lhs.iter_mut()
         .zip(rhs.iter())
         .for_each(|(lhs, &rhs)| *lhs = (*lhs).wrapping_add(rhs));
+}
+
+pub fn slice_wrapping_add_assign_custom_mod<Scalar>(
+    lhs: &mut [Scalar],
+    rhs: &[Scalar],
+    custom_modulus: Scalar,
+) where
+    Scalar: UnsignedInteger,
+{
+    assert!(
+        lhs.len() == rhs.len(),
+        "lhs (len: {}) and rhs (len: {}) must have the same length",
+        lhs.len(),
+        rhs.len()
+    );
+
+    lhs.iter_mut()
+        .zip(rhs.iter())
+        .for_each(|(lhs, &rhs)| *lhs = (*lhs).wrapping_add_custom_mod(rhs, custom_modulus));
 }
 
 /// Add a slice containing unsigned integers to another one mutiplied by a scalar.
@@ -254,6 +298,28 @@ pub fn slice_wrapping_sub_scalar_mul_assign<Scalar>(
     lhs.iter_mut()
         .zip(rhs.iter())
         .for_each(|(lhs, &rhs)| *lhs = (*lhs).wrapping_sub(rhs.wrapping_mul(scalar)));
+}
+
+/// This primitive is meant to manage the sub_scalar_mul operation for values that were cast to a
+/// bigger type, for example u64 to u128, avoiding overflow on each multiplication (as u64::MAX *
+/// u64::MAX < u128::MAX )
+pub fn slice_wrapping_sub_scalar_mul_assign_custom_modulus<Scalar>(
+    lhs: &mut [Scalar],
+    rhs: &[Scalar],
+    scalar: Scalar,
+    modulus: Scalar,
+) where
+    Scalar: UnsignedInteger,
+{
+    assert!(
+        lhs.len() == rhs.len(),
+        "lhs (len: {}) and rhs (len: {}) must have the same length",
+        lhs.len(),
+        rhs.len()
+    );
+    lhs.iter_mut().zip(rhs.iter()).for_each(|(lhs, &rhs)| {
+        *lhs = (*lhs).wrapping_sub_custom_mod(rhs.wrapping_mul_custom_mod(scalar, modulus), modulus)
+    });
 }
 
 /// Compute the opposite of a slice containing unsigned integers, element-wise and in place.

--- a/tfhe/src/core_crypto/algorithms/test/ggsw_encryption.rs
+++ b/tfhe/src/core_crypto/algorithms/test/ggsw_encryption.rs
@@ -170,6 +170,13 @@ fn test_parallel_and_seeded_ggsw_encryption_equivalence_u64_custom_mod() {
     );
 }
 
+#[test]
+fn test_parallel_and_seeded_ggsw_encryption_equivalence_u64_solinas_mod() {
+    test_parallel_and_seeded_ggsw_encryption_equivalence::<u64>(
+        CiphertextModulus::try_new((1 << 64) - (1 << 32) + 1).unwrap(),
+    );
+}
+
 fn ggsw_encrypt_decrypt_custom_mod<Scalar: UnsignedTorus>(params: TestParams<Scalar>) {
     let glwe_dimension = params.glwe_dimension;
     let polynomial_size = params.polynomial_size;
@@ -223,7 +230,7 @@ fn ggsw_encrypt_decrypt_custom_mod<Scalar: UnsignedTorus>(params: TestParams<Sca
 
             let decoded = decrypt_constant_ggsw_ciphertext(&glwe_sk, &ggsw);
 
-            assert!(decoded.0 == msg);
+            assert_eq!(decoded.0, msg);
         }
     }
 }
@@ -285,7 +292,7 @@ fn ggsw_par_encrypt_decrypt_custom_mod<Scalar: UnsignedTorus + Send + Sync>(
 
             let decoded = decrypt_constant_ggsw_ciphertext(&glwe_sk, &ggsw);
 
-            assert!(decoded.0 == msg);
+            assert_eq!(decoded.0, msg);
         }
     }
 }
@@ -348,7 +355,7 @@ fn ggsw_seeded_encrypt_decrypt_custom_mod<Scalar: UnsignedTorus>(params: TestPar
 
             let decoded = decrypt_constant_ggsw_ciphertext(&glwe_sk, &ggsw);
 
-            assert!(decoded.0 == msg);
+            assert_eq!(decoded.0, msg);
         }
     }
 }
@@ -413,7 +420,7 @@ fn ggsw_seeded_par_encrypt_decrypt_custom_mod<Scalar: UnsignedTorus + Sync + Sen
 
             let decoded = decrypt_constant_ggsw_ciphertext(&glwe_sk, &ggsw);
 
-            assert!(decoded.0 == msg);
+            assert_eq!(decoded.0, msg);
         }
     }
 }

--- a/tfhe/src/core_crypto/algorithms/test/lwe_bootstrap_key_generation.rs
+++ b/tfhe/src/core_crypto/algorithms/test/lwe_bootstrap_key_generation.rs
@@ -156,3 +156,10 @@ fn test_parallel_and_seeded_bsk_gen_equivalence_u64_custom_mod() {
         CiphertextModulus::try_new_power_of_2(63).unwrap(),
     );
 }
+
+#[test]
+fn test_parallel_and_seeded_bsk_gen_equivalence_u64_solinas_mod() {
+    test_parallel_and_seeded_bsk_gen_equivalence::<u64>(
+        CiphertextModulus::try_new((1 << 64) - (1 << 32) + 1).unwrap(),
+    );
+}

--- a/tfhe/src/core_crypto/algorithms/test/lwe_encryption.rs
+++ b/tfhe/src/core_crypto/algorithms/test/lwe_encryption.rs
@@ -134,6 +134,11 @@ fn test_parallel_and_seeded_lwe_list_encryption_equivalence_non_native_power_of_
 }
 
 #[test]
+fn test_parallel_and_seeded_lwe_list_encryption_equivalence_solinas_mod_u64() {
+    test_parallel_and_seeded_lwe_list_encryption_equivalence(TEST_PARAMS_3_BITS_SOLINAS_U64);
+}
+
+#[test]
 fn test_parallel_and_seeded_lwe_list_encryption_equivalence_native_mod_u32() {
     test_parallel_and_seeded_lwe_list_encryption_equivalence(DUMMY_NATIVE_U32);
 }

--- a/tfhe/src/core_crypto/algorithms/test/lwe_keyswitch.rs
+++ b/tfhe/src/core_crypto/algorithms/test/lwe_keyswitch.rs
@@ -3,6 +3,7 @@ use super::*;
 fn lwe_encrypt_ks_decrypt_custom_mod<Scalar: UnsignedTorus>(params: TestParams<Scalar>) {
     let lwe_dimension = params.lwe_dimension;
     let lwe_modular_std_dev = params.lwe_modular_std_dev;
+    let glwe_moduluar_std_dev = params.glwe_modular_std_dev;
     let ciphertext_modulus = params.ciphertext_modulus;
     let message_modulus_log = params.message_modulus_log;
     let encoding_with_padding = get_encoding_with_padding(ciphertext_modulus);
@@ -21,6 +22,7 @@ fn lwe_encrypt_ks_decrypt_custom_mod<Scalar: UnsignedTorus>(params: TestParams<S
     while msg != Scalar::ZERO {
         msg = msg.wrapping_sub(Scalar::ONE);
         for _ in 0..NB_TESTS {
+            println!("{msg}");
             let lwe_sk = allocate_and_generate_new_binary_lwe_secret_key(
                 lwe_dimension,
                 &mut rsc.secret_random_generator,
@@ -54,7 +56,7 @@ fn lwe_encrypt_ks_decrypt_custom_mod<Scalar: UnsignedTorus>(params: TestParams<S
             let ct = allocate_and_encrypt_new_lwe_ciphertext(
                 &big_lwe_sk,
                 plaintext,
-                lwe_modular_std_dev,
+                glwe_moduluar_std_dev,
                 ciphertext_modulus,
                 &mut rsc.encryption_random_generator,
             );

--- a/tfhe/src/core_crypto/algorithms/test/lwe_keyswitch_key_generation.rs
+++ b/tfhe/src/core_crypto/algorithms/test/lwe_keyswitch_key_generation.rs
@@ -112,3 +112,10 @@ fn test_seeded_lwe_ksk_gen_equivalence_u32_custom_mod() {
 fn test_seeded_lwe_ksk_gen_equivalence_u64_custom_mod() {
     test_seeded_lwe_ksk_gen_equivalence::<u64>(CiphertextModulus::try_new_power_of_2(63).unwrap())
 }
+
+#[test]
+fn test_seeded_lwe_ksk_gen_equivalence_u64_solinas_mod() {
+    test_seeded_lwe_ksk_gen_equivalence::<u64>(
+        CiphertextModulus::try_new((1 << 64) - (1 << 32) + 1).unwrap(),
+    )
+}

--- a/tfhe/src/core_crypto/algorithms/test/lwe_programmable_bootstrapping.rs
+++ b/tfhe/src/core_crypto/algorithms/test/lwe_programmable_bootstrapping.rs
@@ -126,7 +126,10 @@ fn lwe_encrypt_pbs_decrypt_custom_mod<
     }
 }
 
-create_parametrized_test!(lwe_encrypt_pbs_decrypt_custom_mod);
+create_parametrized_test!(lwe_encrypt_pbs_decrypt_custom_mod {
+    TEST_PARAMS_4_BITS_NATIVE_U64,
+    TEST_PARAMS_3_BITS_63_U64
+});
 
 // DISCLAIMER: all parameters here are not guaranteed to be secure or yield correct computations
 pub const TEST_PARAMS_4_BITS_NATIVE_U128: TestParams<u128> = TestParams {

--- a/tfhe/src/core_crypto/algorithms/test/mod.rs
+++ b/tfhe/src/core_crypto/algorithms/test/mod.rs
@@ -131,6 +131,25 @@ pub const DUMMY_31_U32: TestParams<u32> = TestParams {
     ciphertext_modulus: unsafe { CiphertextModulus::new_unchecked(1 << 31) },
 };
 
+pub const TEST_PARAMS_3_BITS_SOLINAS_U64: TestParams<u64> = TestParams {
+    lwe_dimension: LweDimension(742),
+    glwe_dimension: GlweDimension(1),
+    polynomial_size: PolynomialSize(2048),
+    lwe_modular_std_dev: StandardDev(0.000007069849454709433),
+    glwe_modular_std_dev: StandardDev(0.00000000000000029403601535432533),
+    pbs_base_log: DecompositionBaseLog(23),
+    pbs_level: DecompositionLevelCount(1),
+    ks_level: DecompositionLevelCount(5),
+    ks_base_log: DecompositionBaseLog(3),
+    pfks_level: DecompositionLevelCount(1),
+    pfks_base_log: DecompositionBaseLog(23),
+    pfks_modular_std_dev: StandardDev(0.00000000000000029403601535432533),
+    cbs_level: DecompositionLevelCount(0),
+    cbs_base_log: DecompositionBaseLog(0),
+    message_modulus_log: CiphertextModulusLog(3),
+    ciphertext_modulus: unsafe { CiphertextModulus::new_unchecked((1 << 64) - (1 << 32) + 1) },
+};
+
 // Our representation of non native power of 2 moduli puts the information in the MSBs and leaves
 // the LSBs empty, this is what this function is checking
 pub fn check_content_respects_mod<Scalar: UnsignedInteger, Input: AsRef<[Scalar]>>(
@@ -138,26 +157,42 @@ pub fn check_content_respects_mod<Scalar: UnsignedInteger, Input: AsRef<[Scalar]
     modulus: CiphertextModulus<Scalar>,
 ) -> bool {
     if !modulus.is_native_modulus() {
-        // If our modulus is 2^60, the scaling is 2^4 = 00...00010000, minus 1 = 00...00001111
-        // we want the bits under the mask to be 0
-        let power_2_diff_mask = modulus.get_power_of_two_scaling_to_native_torus() - Scalar::ONE;
-        return input
-            .as_ref()
-            .iter()
-            .all(|&x| (x & power_2_diff_mask) == Scalar::ZERO);
+        // Power of two has a specific encoding in MSBs of the native torus to re-use native torus
+        // implementations for free
+        if modulus.is_power_of_two() {
+            // If our modulus is 2^60, the scaling is 2^4 = 00...00010000, minus 1 = 00...00001111
+            // we want the bits under the mask to be 0
+            let power_2_diff_mask =
+                modulus.get_power_of_two_scaling_to_native_torus() - Scalar::ONE;
+            return input
+                .as_ref()
+                .iter()
+                .all(|&x| (x & power_2_diff_mask) == Scalar::ZERO);
+        } else {
+            // Custom moduli non power of two use the "true" modulus representation
+            return input
+                .as_ref()
+                .iter()
+                .all(|&x| x < Scalar::cast_from(modulus.get_custom_modulus()));
+        }
     }
 
     true
 }
 
-// See above
+// See above comments for modulus check logic
 pub fn check_scalar_respects_mod<Scalar: UnsignedInteger>(
     input: Scalar,
     modulus: CiphertextModulus<Scalar>,
 ) -> bool {
     if !modulus.is_native_modulus() {
-        let power_2_diff_mask = modulus.get_power_of_two_scaling_to_native_torus() - Scalar::ONE;
-        return (input & power_2_diff_mask) == Scalar::ZERO;
+        if modulus.is_power_of_two() {
+            let power_2_diff_mask =
+                modulus.get_power_of_two_scaling_to_native_torus() - Scalar::ONE;
+            return (input & power_2_diff_mask) == Scalar::ZERO;
+        } else {
+            return input < Scalar::cast_from(modulus.get_custom_modulus());
+        }
     }
 
     true
@@ -246,6 +281,7 @@ macro_rules! create_parametrized_test{
         create_parametrized_test!($name
         {
             TEST_PARAMS_4_BITS_NATIVE_U64,
+            TEST_PARAMS_3_BITS_SOLINAS_U64,
             TEST_PARAMS_3_BITS_63_U64
         });
     };

--- a/tfhe/src/core_crypto/algorithms/test/mod.rs
+++ b/tfhe/src/core_crypto/algorithms/test/mod.rs
@@ -242,9 +242,16 @@ where
 
     let half_box_size = box_size / 2;
 
-    // Negate the first half_box_size coefficients to manage negacyclicity and rotate
-    for a_i in accumulator_scalar[0..half_box_size].iter_mut() {
-        *a_i = (*a_i).wrapping_neg();
+    if ciphertext_modulus.is_compatible_with_native_modulus() {
+        // Negate the first half_box_size coefficients to manage negacyclicity and rotate
+        for a_i in accumulator_scalar[0..half_box_size].iter_mut() {
+            *a_i = (*a_i).wrapping_neg();
+        }
+    } else {
+        let modulus: Scalar = ciphertext_modulus.get_custom_modulus().cast_into();
+        for a_i in accumulator_scalar[0..half_box_size].iter_mut() {
+            *a_i = (*a_i).wrapping_neg_custom_mod(modulus);
+        }
     }
 
     // Rotate the accumulator

--- a/tfhe/src/core_crypto/algorithms/test/mod.rs
+++ b/tfhe/src/core_crypto/algorithms/test/mod.rs
@@ -209,13 +209,7 @@ pub fn get_encoding_with_padding<Scalar: UnsignedInteger>(
 }
 
 pub fn round_decode<Scalar: UnsignedInteger>(decrypted: Scalar, delta: Scalar) -> Scalar {
-    // Get half interval on the discretized torus
-    let rounding_margin = delta.wrapping_div(Scalar::TWO);
-
-    // Add the half interval mapping
-    // [delta * (m - 1/2); delta * (m + 1/2)[ to [delta * m; delta * (m + 1)[
-    // Dividing by delta gives m which is what we want
-    (decrypted.wrapping_add(rounding_margin)).wrapping_div(delta)
+    divide_round(decrypted, delta)
 }
 
 // Here we will define a helper function to generate an accumulator for a PBS

--- a/tfhe/src/core_crypto/algorithms/test/noise_distribution/lwe_encryption_noise.rs
+++ b/tfhe/src/core_crypto/algorithms/test/noise_distribution/lwe_encryption_noise.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::core_crypto::commons::test_tools::{torus_modular_distance, variance};
+use crate::core_crypto::commons::test_tools::{torus_modular_diff, variance};
 
 // This is 1 / 16 which is exactly representable in an f64 (even an f32)
 // 1 / 32 is too strict and fails the tests
@@ -57,21 +57,27 @@ fn lwe_encrypt_decrypt_noise_distribution_custom_mod<Scalar: UnsignedTorus + Cas
 
             assert_eq!(msg, decoded);
 
-            let torus_distance =
-                torus_modular_distance(plaintext.0, decrypted.0, ciphertext_modulus);
-            noise_samples.push(torus_distance);
+            let torus_diff = torus_modular_diff(plaintext.0, decrypted.0, ciphertext_modulus);
+            noise_samples.push(torus_diff);
         }
     }
 
     let measured_variance = variance(&noise_samples);
+    let var_abs_diff = (expected_variance.0 - measured_variance.0).abs();
+    let tolerance_threshold = RELATIVE_TOLERANCE * expected_variance.0;
     assert!(
-        (expected_variance.0 - measured_variance.0).abs()
-            < RELATIVE_TOLERANCE * expected_variance.0
+        var_abs_diff < tolerance_threshold,
+        "Absolute difference for variance: {var_abs_diff}, \
+        tolerance threshold: {tolerance_threshold}, \
+        got variance: {measured_variance:?}, \
+        expected variance: {expected_variance:?}"
     );
 }
 
 create_parametrized_test!(lwe_encrypt_decrypt_noise_distribution_custom_mod {
-    TEST_PARAMS_4_BITS_NATIVE_U64
+    TEST_PARAMS_4_BITS_NATIVE_U64,
+    TEST_PARAMS_3_BITS_SOLINAS_U64,
+    TEST_PARAMS_3_BITS_63_U64
 });
 
 fn lwe_compact_public_key_encryption_expected_variance(
@@ -158,16 +164,20 @@ fn lwe_compact_public_encrypt_noise_distribution_custom_mod<
 
             assert_eq!(msg, decoded);
 
-            let torus_distance =
-                torus_modular_distance(plaintext.0, decrypted.0, ciphertext_modulus);
-            noise_samples.push(torus_distance);
+            let torus_diff = torus_modular_diff(plaintext.0, decrypted.0, ciphertext_modulus);
+            noise_samples.push(torus_diff);
         }
     }
 
     let measured_variance = variance(&noise_samples);
+    let var_abs_diff = (expected_variance.0 - measured_variance.0).abs();
+    let tolerance_threshold = RELATIVE_TOLERANCE * expected_variance.0;
     assert!(
-        (expected_variance.0 - measured_variance.0).abs()
-            < RELATIVE_TOLERANCE * expected_variance.0
+        var_abs_diff < tolerance_threshold,
+        "Absolute difference for variance: {var_abs_diff}, \
+        tolerance threshold: {tolerance_threshold}, \
+        got variance: {measured_variance:?}, \
+        expected variance: {expected_variance:?}"
     );
 }
 

--- a/tfhe/src/core_crypto/commons/ciphertext_modulus.rs
+++ b/tfhe/src/core_crypto/commons/ciphertext_modulus.rs
@@ -31,6 +31,13 @@ pub struct CiphertextModulus<Scalar: UnsignedInteger> {
     _scalar: PhantomData<Scalar>,
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum CiphertextModulusKind {
+    Native,
+    NonNativePowerOfTwo,
+    NonNative,
+}
+
 #[derive(serde::Serialize, serde::Deserialize)]
 struct SerialiazableLweCiphertextModulus {
     pub modulus: u128,
@@ -149,7 +156,11 @@ impl<Scalar: UnsignedInteger> CiphertextModulus<Scalar> {
                     }
                 }
             };
-            Ok(res.canonicalize())
+            let canonicalized_result = res.canonicalize();
+            if Scalar::BITS > 64 && !canonicalized_result.is_compatible_with_native_modulus() {
+                return Err("Non power of 2 moduli are not supported for types wider than u64");
+            }
+            Ok(canonicalized_result)
         }
     }
 
@@ -183,6 +194,7 @@ impl<Scalar: UnsignedInteger> CiphertextModulus<Scalar> {
         res.canonicalize()
     }
 
+    #[track_caller]
     pub fn get_power_of_two_scaling_to_native_torus(&self) -> Scalar {
         match self.inner {
             CiphertextModulusInner::Native => Scalar::ONE,
@@ -217,6 +229,13 @@ impl<Scalar: UnsignedInteger> CiphertextModulus<Scalar> {
 
     pub const fn is_compatible_with_native_modulus(&self) -> bool {
         self.is_native_modulus() || self.is_power_of_two()
+    }
+
+    pub const fn is_non_native_power_of_two(&self) -> bool {
+        match self.inner {
+            CiphertextModulusInner::Native => false,
+            CiphertextModulusInner::Custom(modulus) => modulus.is_power_of_two(),
+        }
     }
 
     pub const fn is_power_of_two(&self) -> bool {
@@ -258,6 +277,19 @@ impl<Scalar: UnsignedInteger> CiphertextModulus<Scalar> {
             _scalar: Default::default(),
         }
         .canonicalize())
+    }
+
+    pub const fn kind(&self) -> CiphertextModulusKind {
+        match self.inner {
+            CiphertextModulusInner::Native => CiphertextModulusKind::Native,
+            CiphertextModulusInner::Custom(modulus) => {
+                if modulus.is_power_of_two() {
+                    CiphertextModulusKind::NonNativePowerOfTwo
+                } else {
+                    CiphertextModulusKind::NonNative
+                }
+            }
+        }
     }
 }
 

--- a/tfhe/src/core_crypto/commons/generators/encryption.rs
+++ b/tfhe/src/core_crypto/commons/generators/encryption.rs
@@ -588,6 +588,7 @@ fn noise_bytes_per_lwe_compact_ciphertext_bin(lwe_dimension: LweDimension) -> us
 mod test {
     use crate::core_crypto::algorithms::*;
     use crate::core_crypto::commons::dispersion::{StandardDev, Variance};
+    use crate::core_crypto::commons::numeric::CastInto;
     use crate::core_crypto::commons::parameters::{
         CiphertextModulus, DecompositionBaseLog, DecompositionLevelCount, GlweSize, LweDimension,
         PolynomialSize,
@@ -947,7 +948,13 @@ mod test {
                     .iter()
                     .copied()
                     .map(|x| {
-                        let torus = x.into_torus();
+                        let torus = if ciphertext_modulus.is_native_modulus() {
+                            x.into_torus()
+                        } else {
+                            x.into_torus_custom_mod(
+                                ciphertext_modulus.get_custom_modulus().cast_into(),
+                            )
+                        };
                         // The upper half of the torus corresponds to the negative domain when
                         // mapping unsigned integer back to float (MSB or
                         // sign bit is set)
@@ -1029,7 +1036,13 @@ mod test {
                     .iter()
                     .copied()
                     .map(|x| {
-                        let torus = x.into_torus();
+                        let torus = if ciphertext_modulus.is_native_modulus() {
+                            x.into_torus()
+                        } else {
+                            x.into_torus_custom_mod(
+                                ciphertext_modulus.get_custom_modulus().cast_into(),
+                            )
+                        };
                         // The upper half of the torus corresponds to the negative domain when
                         // mapping unsigned integer back to float (MSB or
                         // sign bit is set)

--- a/tfhe/src/core_crypto/commons/generators/encryption.rs
+++ b/tfhe/src/core_crypto/commons/generators/encryption.rs
@@ -639,7 +639,7 @@ mod test {
     fn noise_gen_native<Scalar: UnsignedTorus>() {
         let mut gen = new_encryption_random_generator();
 
-        let bits = (Scalar::BITS / 2) as i32;
+        let bits = (Scalar::BITS / 4) as i32;
 
         for _ in 0..1000 {
             let mut retries = 100;
@@ -676,7 +676,7 @@ mod test {
     fn noise_gen_custom_mod<Scalar: UnsignedTorus>(ciphertext_modulus: CiphertextModulus<Scalar>) {
         let mut gen = new_encryption_random_generator();
 
-        let bits = (Scalar::BITS / 2) as i32;
+        let bits = (Scalar::BITS / 4) as i32;
 
         for _ in 0..1000 {
             let mut retries = 100;
@@ -729,7 +729,7 @@ mod test {
     fn noise_gen_slice_native<Scalar: UnsignedTorus>() {
         let mut gen = new_encryption_random_generator();
 
-        let bits = (Scalar::BITS / 2) as i32;
+        let bits = (Scalar::BITS / 4) as i32;
 
         let mut vec = vec![Scalar::ZERO; 1000];
         let mut retries = 100;
@@ -878,7 +878,7 @@ mod test {
     ) {
         let mut gen = new_encryption_random_generator();
 
-        let bits = (Scalar::BITS / 2) as i32;
+        let bits = (Scalar::BITS / 4) as i32;
 
         let mut vec = vec![Scalar::ZERO; 1000];
         let mut retries = 100;

--- a/tfhe/src/core_crypto/commons/generators/encryption.rs
+++ b/tfhe/src/core_crypto/commons/generators/encryption.rs
@@ -995,6 +995,13 @@ mod test {
     }
 
     #[test]
+    fn test_normal_random_encryption_custom_mod_solinas_u64() {
+        test_normal_random_encryption_custom_mod::<u64>(
+            CiphertextModulus::try_new((1 << 64) - (1 << 32) + 1).unwrap(),
+        );
+    }
+
+    #[test]
     fn test_normal_random_encryption_custom_mod_u128() {
         test_normal_random_encryption_custom_mod::<u128>(
             CiphertextModulus::try_new_power_of_2(127).unwrap(),
@@ -1083,6 +1090,13 @@ mod test {
     }
 
     #[test]
+    fn test_normal_random_encryption_add_assign_custom_mod_solinas_u64() {
+        test_normal_random_encryption_add_assign_custom_mod::<u64>(
+            CiphertextModulus::try_new((1 << 64) - (1 << 32) + 1).unwrap(),
+        );
+    }
+
+    #[test]
     fn test_normal_random_encryption_add_assign_custom_mod_u128() {
         test_normal_random_encryption_add_assign_custom_mod::<u128>(
             CiphertextModulus::try_new_power_of_2(127).unwrap(),
@@ -1163,6 +1177,13 @@ mod test {
     #[test]
     fn mask_gen_slice_custom_mod_u64() {
         mask_gen_slice_custom_mod::<u64>(CiphertextModulus::try_new_power_of_2(63).unwrap());
+    }
+
+    #[test]
+    fn mask_gen_slice_custom_mod_solinas_u64() {
+        mask_gen_slice_custom_mod::<u64>(
+            CiphertextModulus::try_new((1 << 64) - (1 << 32) + 1).unwrap(),
+        );
     }
 
     #[test]

--- a/tfhe/src/core_crypto/commons/math/decomposition/decomposer.rs
+++ b/tfhe/src/core_crypto/commons/math/decomposition/decomposer.rs
@@ -191,6 +191,7 @@ where
     pub(crate) base_log: usize,
     pub(crate) level_count: usize,
     pub(crate) ciphertext_modulus: CiphertextModulus<Scalar>,
+    pub(crate) shift: Scalar,
 }
 
 impl<Scalar> SignedDecomposerNonNative<Scalar>
@@ -223,10 +224,15 @@ where
             Scalar::BITS > base_log.0 * level_count.0,
             "Decomposed bits exceeds the size of the integer to be decomposed"
         );
+        let modulus = ciphertext_modulus.get_custom_modulus();
+        let base = 1u128 << base_log.0;
+        let mod_over_base = divide_round(modulus, base);
+        let shift = Scalar::cast_from(divide_round(modulus, mod_over_base));
         SignedDecomposerNonNative {
             base_log: base_log.0,
             level_count: level_count.0,
             ciphertext_modulus,
+            shift,
         }
     }
 
@@ -343,22 +349,19 @@ where
 
     #[inline]
     pub fn init_decomposition_state(&self, input: Scalar) -> (Scalar, Scalar) {
-        // TODO: Some of these can be precomputed to chose one state init over the other
         let ciphertext_modulus = self.ciphertext_modulus.get_custom_modulus();
-        let base = 1u128 << self.base_log;
+        let base = Scalar::ONE << self.base_log;
         let base_to_the_level = 1u128 << (self.base_log * self.level_count);
-        let mod_over_base = divide_round(ciphertext_modulus, base);
-        let shift = divide_round(ciphertext_modulus, mod_over_base);
         let input_u128: u128 = input.cast_into();
 
-        if shift == base {
+        if self.shift == base {
             let mul_u128 = input_u128 * base_to_the_level;
             let rounded_u128 = divide_round(mul_u128, ciphertext_modulus);
-            (Scalar::cast_from(rounded_u128), Scalar::cast_from(shift))
+            (Scalar::cast_from(rounded_u128), self.shift)
         } else {
             let mod_over_bl = divide_round(ciphertext_modulus, base_to_the_level);
             let rounded_u128 = divide_round(input_u128, mod_over_bl);
-            (Scalar::cast_from(rounded_u128), Scalar::cast_from(shift))
+            (Scalar::cast_from(rounded_u128), self.shift)
         }
     }
 

--- a/tfhe/src/core_crypto/commons/math/decomposition/decomposer.rs
+++ b/tfhe/src/core_crypto/commons/math/decomposition/decomposer.rs
@@ -1,10 +1,10 @@
+use crate::core_crypto::algorithms::divide_round;
 use crate::core_crypto::commons::ciphertext_modulus::CiphertextModulus;
 use crate::core_crypto::commons::math::decomposition::{
     SignedDecompositionIter, SignedDecompositionIterNonNative,
 };
 use crate::core_crypto::commons::numeric::{Numeric, UnsignedInteger};
 use crate::core_crypto::commons::parameters::{DecompositionBaseLog, DecompositionLevelCount};
-use crate::core_crypto::prelude::misc::divide_round_to_u128_custom_mod;
 use std::marker::PhantomData;
 
 /// A structure which allows to decompose unsigned integers into a set of smaller terms.
@@ -319,24 +319,47 @@ where
     ///     CiphertextModulus::try_new((1 << 64) - (1 << 32) + 1).unwrap(),
     /// );
     /// let closest = decomposer.closest_representable(16982820785129133100u64);
-    /// assert_eq!(closest, 16983074190859960320u64);
+    /// assert_eq!(closest, 16983074190859960321u64);
     /// ```
     #[inline]
     pub fn closest_representable(&self, input: Scalar) -> Scalar {
+        let (interval_count, shift) = self.init_decomposition_state(input);
         let ciphertext_modulus = self.ciphertext_modulus.get_custom_modulus();
-        // Floored approach
-        // B^l
-        let base_to_level_count = 1 << (self.base_log * self.level_count);
-        // sr = floor(q/(B^l))
-        let smallest_representable = ciphertext_modulus / base_to_level_count;
+        let base = Scalar::ONE << self.base_log;
+        if base == shift {
+            let interval_count: u128 = interval_count.cast_into();
+            let base_to_the_level = 1u128 << (self.base_log * self.level_count);
+            Scalar::cast_from(
+                divide_round(interval_count * ciphertext_modulus, base_to_the_level)
+                    % ciphertext_modulus,
+            )
+        } else {
+            let interval_count: u128 = interval_count.cast_into();
+            let base_to_the_level = 1u128 << (self.base_log * self.level_count);
+            let mod_over_bl = divide_round(ciphertext_modulus, base_to_the_level);
+            Scalar::cast_from(interval_count * mod_over_bl)
+        }
+    }
 
-        let input_128: u128 = input.cast_into();
-        // rounded = round(input/sr)
-        let rounded =
-            divide_round_to_u128_custom_mod(input_128, smallest_representable, ciphertext_modulus);
-        // rounded * sr
-        let closest_representable = rounded * smallest_representable;
-        Scalar::cast_from(closest_representable)
+    #[inline]
+    pub fn init_decomposition_state(&self, input: Scalar) -> (Scalar, Scalar) {
+        // TODO: Some of these can be precomputed to chose one state init over the other
+        let ciphertext_modulus = self.ciphertext_modulus.get_custom_modulus();
+        let base = 1u128 << self.base_log;
+        let base_to_the_level = 1u128 << (self.base_log * self.level_count);
+        let mod_over_base = divide_round(ciphertext_modulus, base);
+        let shift = divide_round(ciphertext_modulus, mod_over_base);
+        let input_u128: u128 = input.cast_into();
+
+        if shift == base {
+            let mul_u128 = input_u128 * base_to_the_level;
+            let rounded_u128 = divide_round(mul_u128, ciphertext_modulus);
+            (Scalar::cast_from(rounded_u128), Scalar::cast_from(shift))
+        } else {
+            let mod_over_bl = divide_round(ciphertext_modulus, base_to_the_level);
+            let rounded_u128 = divide_round(input_u128, mod_over_bl);
+            (Scalar::cast_from(rounded_u128), Scalar::cast_from(shift))
+        }
     }
 
     /// Generate an iterator over the terms of the decomposition of the input.
@@ -383,10 +406,50 @@ where
         // Note that there would be no sense of making the decomposition on an input which was
         // not rounded to the closest representable first. We then perform it before decomposing.
         SignedDecompositionIterNonNative::new(
-            self.closest_representable(input),
+            self.init_decomposition_state(input),
             DecompositionBaseLog(self.base_log),
             DecompositionLevelCount(self.level_count),
             self.ciphertext_modulus,
         )
+    }
+
+    /// Recomposes a decomposed value by summing all the terms.
+    ///
+    /// If the input iterator yields $\tilde{\theta}\_i$, this returns
+    /// $\sum\_{i=1}^l\tilde{\theta}\_i\frac{q}{B^i}$.
+    ///
+    /// # Warning
+    /// Note: all recompositions may not be exact if $B^i$ for all $i <= l$ does not divide $q$.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use tfhe::core_crypto::commons::math::decomposition::SignedDecomposerNonNative;
+    /// use tfhe::core_crypto::commons::parameters::{
+    ///     CiphertextModulus, DecompositionBaseLog, DecompositionLevelCount,
+    /// };
+    /// let decomposer = SignedDecomposerNonNative::new(
+    ///     DecompositionBaseLog(4),
+    ///     DecompositionLevelCount(3),
+    ///     CiphertextModulus::try_new((1 << 64) - (1 << 32) + 1).unwrap(),
+    /// );
+    /// let val = 1u64 << 60;
+    /// let dec = decomposer.decompose(val);
+    /// let rec = decomposer.recompose(dec);
+    /// assert_eq!(decomposer.closest_representable(val), rec.unwrap());
+    /// ```
+    pub fn recompose(&self, decomp: SignedDecompositionIterNonNative<Scalar>) -> Option<Scalar> {
+        if decomp.is_fresh() {
+            let ciphertext_modulus_as_scalar =
+                Scalar::cast_from(self.ciphertext_modulus.get_custom_modulus());
+            Some(decomp.fold(Scalar::ZERO, |acc, term| {
+                acc.wrapping_add_custom_mod(
+                    term.to_recomposition_summand(),
+                    ciphertext_modulus_as_scalar,
+                )
+            }))
+        } else {
+            None
+        }
     }
 }

--- a/tfhe/src/core_crypto/commons/math/decomposition/iter.rs
+++ b/tfhe/src/core_crypto/commons/math/decomposition/iter.rs
@@ -152,6 +152,7 @@ where
     ciphertext_modulus: CiphertextModulus<T>,
     // A flag which store whether the iterator is a fresh one (for the recompose method)
     fresh: bool,
+    shift: T,
 }
 
 impl<T> SignedDecompositionIterNonNative<T>
@@ -159,17 +160,17 @@ where
     T: UnsignedInteger,
 {
     pub(crate) fn new(
-        input: T,
+        (state, shift): (T, T),
         base_log: DecompositionBaseLog,
         level: DecompositionLevelCount,
         ciphertext_modulus: CiphertextModulus<T>,
     ) -> SignedDecompositionIterNonNative<T> {
-        let base_to_the_level = 1 << (base_log.0 * level.0);
-        let smallest_representable = ciphertext_modulus.get_custom_modulus() / base_to_the_level;
-
-        let input_128: u128 = input.cast_into();
-        let state = T::cast_from(input_128 / smallest_representable);
-
+        // To guarantee correctness of the custom fast modulus from native to q to work
+        // we need abs(decomp_val) <= ciphertext_modulus / 2
+        // the iter returns decomp_val such that abs(decomp_val) <= base / 2
+        // so if base <= ciphertex_modulus
+        // then abs(decomp_val) <= ciphertext_modulus / 2
+        assert!((1 << base_log.0) <= ciphertext_modulus.get_custom_modulus());
         SignedDecompositionIterNonNative {
             base_log: base_log.0,
             level_count: level.0,
@@ -178,6 +179,7 @@ where
             mod_b_mask: (T::ONE << base_log.0) - T::ONE,
             ciphertext_modulus,
             fresh: true,
+            shift,
         }
     }
 
@@ -253,6 +255,7 @@ where
             &mut self.state,
             self.mod_b_mask,
             T::cast_from(self.ciphertext_modulus.get_custom_modulus()),
+            self.shift,
         );
         self.current_level -= 1;
         // We return the output for this level
@@ -265,18 +268,60 @@ where
     }
 }
 
-fn decompose_one_level_non_native<S: UnsignedInteger>(
+fn decompose_one_level_w_shift<S: UnsignedInteger>(
     base_log: usize,
     state: &mut S,
     mod_b_mask: S,
-    ciphertext_modulus: S,
+    shift: S,
 ) -> S {
     let res = *state & mod_b_mask;
     *state >>= base_log;
     let mut carry = (res.wrapping_sub(S::ONE) | *state) & res;
     carry >>= base_log - 1;
     *state += carry;
-    res.wrapping_add(ciphertext_modulus)
-        .wrapping_sub(carry << base_log)
-        .wrapping_rem(ciphertext_modulus)
+    res.wrapping_sub(carry * shift)
+}
+
+fn decompose_one_level_non_native<S: UnsignedInteger>(
+    base_log: usize,
+    state: &mut S,
+    mod_b_mask: S,
+    ciphertext_modulus: S,
+    shift: S,
+) -> S {
+    let res = decompose_one_level_w_shift(base_log, state, mod_b_mask, shift);
+
+    /// Takes as input a native unsigned integer interpreting it in a signed way, i.e. using the
+    /// most significant bit as a sign bit and returns the `rem_euclid` using modulus
+    /// Only works if abs(input) <= modulus / 2 which should always be verified in our case
+    #[inline(always)]
+    fn rem_euclid_native_to_custom_mod<Scalar: UnsignedInteger>(
+        input: Scalar,
+        modulus: Scalar,
+    ) -> Scalar {
+        // Here is a branching version of the code below which performed better in synthetic
+        // benchmarks keyswitch Solinas q test in 61 seconds on dev laptop
+
+        // // This branching version proved faster than a branchless alternative in synthetic
+        // benchmarks let sign_bit = (input >> (Scalar::BITS - 1)) & Scalar::ONE;
+        // if sign_bit == Scalar::ZERO {
+        //     input
+        // } else {
+        //     // As the sign bit is set and the integers are/should be 2's complement the addition
+        // is     // actually computing the subtraction which we want in that case
+        //     modulus.wrapping_add(input)
+        // }
+
+        // This branchless version, though a bit heavier in terms of computation proved faster in
+        // actual TFHE-rs test workloads
+        // keyswitch Solinas q test in 46 seconds on dev laptop
+        let sign_bit = (input >> (Scalar::BITS - 1)) & Scalar::ONE;
+        let pos_res = (Scalar::ONE - sign_bit) * input;
+        // As the sign bit is set and the integers are/should be 2's complement the addition is
+        // actually computing the subtraction which we want in that case
+        let neg_res = sign_bit * ((modulus).wrapping_add(input));
+        // One of the result is 0 so we can OR rather than add both
+        pos_res | neg_res
+    }
+    rem_euclid_native_to_custom_mod(res, ciphertext_modulus)
 }

--- a/tfhe/src/core_crypto/commons/math/decomposition/tests.rs
+++ b/tfhe/src/core_crypto/commons/math/decomposition/tests.rs
@@ -1,4 +1,4 @@
-use crate::core_crypto::algorithms::{divide_round, modular_distance_custom_mod};
+use crate::core_crypto::algorithms::{divide_round, torus_abs_diff_custom_mod};
 use crate::core_crypto::commons::ciphertext_modulus::CiphertextModulus;
 use crate::core_crypto::commons::math::decomposition::{
     SignedDecomposer, SignedDecomposerNonNative,
@@ -243,7 +243,7 @@ fn test_round_to_closest_representable_non_native<T: UnsignedTorus>(
                 assert!(abs_term <= half_basis);
             }
             let closest = decomposer.closest_representable(val_plus_epsilon);
-            let distance = modular_distance_custom_mod(val, closest, ciphertext_modulus_as_t);
+            let distance = torus_abs_diff_custom_mod(val, closest, ciphertext_modulus_as_t);
             let distance_f64: f64 = distance.cast_into();
             // -1 as we don't divide exactly for prime Q
             let max_correct_bits: usize = base_log * level_count - 1;
@@ -271,7 +271,7 @@ fn test_round_to_closest_representable_non_native<T: UnsignedTorus>(
                 assert!(abs_term <= half_basis);
             }
             let closest = decomposer.closest_representable(val_minus_epsilon);
-            let distance = modular_distance_custom_mod(val, closest, ciphertext_modulus_as_t);
+            let distance = torus_abs_diff_custom_mod(val, closest, ciphertext_modulus_as_t);
             let distance_f64: f64 = distance.cast_into();
             // -1 as we don't divide exactly for prime Q
             let max_correct_bits: usize = base_log * level_count - 1;
@@ -369,7 +369,7 @@ fn test_decompose_recompose_non_native<T: UnsignedInteger + Debug + RandomGenera
             assert!(abs_term <= half_basis);
         }
         let closest = decomposer.closest_representable(input);
-        let distance = modular_distance_custom_mod(input, closest, ciphertext_modulus_as_t);
+        let distance = torus_abs_diff_custom_mod(input, closest, ciphertext_modulus_as_t);
         let distance_f64: f64 = distance.cast_into();
         let base_log = decomposer.base_log().0;
         let level_count = decomposer.level_count().0;

--- a/tfhe/src/core_crypto/commons/math/random/generator.rs
+++ b/tfhe/src/core_crypto/commons/math/random/generator.rs
@@ -211,7 +211,8 @@ impl<G: ByteRandomGenerator> RandomGenerator<G> {
     ) where
         Scalar: UnsignedInteger + RandomGenerable<Uniform>,
     {
-        assert!(custom_modulus.is_compatible_with_native_modulus());
+        // TODO
+        // Implement the proper generation function for custom mod for the uniform distribution
         self.fill_slice_with_random_uniform(output);
 
         if !custom_modulus.is_native_modulus() {

--- a/tfhe/src/core_crypto/commons/math/random/tests.rs
+++ b/tfhe/src/core_crypto/commons/math/random/tests.rs
@@ -1,5 +1,5 @@
 use crate::core_crypto::commons::ciphertext_modulus::CiphertextModulus;
-use crate::core_crypto::commons::math::torus::UnsignedTorus;
+use crate::core_crypto::commons::math::torus::{CastInto, UnsignedTorus};
 use crate::core_crypto::commons::test_tools::*;
 
 fn test_normal_random_three_sigma<T: UnsignedTorus>() {
@@ -159,7 +159,11 @@ fn test_normal_random_custom_mod<Scalar: UnsignedTorus>(
                 .iter()
                 .copied()
                 .map(|x| {
-                    let torus = x.into_torus();
+                    let torus = if ciphertext_modulus.is_native_modulus() {
+                        x.into_torus()
+                    } else {
+                        x.into_torus_custom_mod(ciphertext_modulus.get_custom_modulus().cast_into())
+                    };
                     // The upper half of the torus corresponds to the negative domain when mapping
                     // unsigned integer back to float (MSB or sign bit is set)
                     if torus > 0.5 {
@@ -212,6 +216,13 @@ fn test_normal_random_native_custom_mod_u64() {
 #[test]
 fn test_normal_random_native_custom_mod_u128() {
     test_normal_random_custom_mod::<u128>(CiphertextModulus::new_native());
+}
+
+#[test]
+fn test_normal_random_solinas_custom_mod_u64() {
+    test_normal_random_custom_mod::<u64>(
+        CiphertextModulus::try_new((1 << 64) - (1 << 32) + 1).unwrap(),
+    );
 }
 
 fn test_normal_random_add_assign_native<Scalar: UnsignedTorus>() {
@@ -293,7 +304,11 @@ fn test_normal_random_add_assign_custom_mod<Scalar: UnsignedTorus>(
                 .iter()
                 .copied()
                 .map(|x| {
-                    let torus = x.into_torus();
+                    let torus = if ciphertext_modulus.is_native_modulus() {
+                        x.into_torus()
+                    } else {
+                        x.into_torus_custom_mod(ciphertext_modulus.get_custom_modulus().cast_into())
+                    };
                     // The upper half of the torus corresponds to the negative domain when mapping
                     // unsigned integer back to float (MSB or sign bit is set)
                     if torus > 0.5 {
@@ -352,4 +367,11 @@ fn test_normal_random_add_assign_native_custom_mod_u64() {
 #[test]
 fn test_normal_random_add_assign_native_custom_mod_u128() {
     test_normal_random_add_assign_custom_mod::<u128>(CiphertextModulus::new_native());
+}
+
+#[test]
+fn test_normal_random_add_assign_solinas_custom_mod_u64() {
+    test_normal_random_add_assign_custom_mod::<u64>(
+        CiphertextModulus::try_new((1 << 64) - (1 << 32) + 1).unwrap(),
+    );
 }

--- a/tfhe/src/core_crypto/commons/math/torus/mod.rs
+++ b/tfhe/src/core_crypto/commons/math/torus/mod.rs
@@ -86,7 +86,7 @@ macro_rules! implement {
                 }
                 // Scale to the modulus
                 fract *= custom_modulus;
-                fract = F::round(fract);
+                fract = F::round(fract) % custom_modulus;
                 return fract.cast_into();
             }
         }

--- a/tfhe/src/core_crypto/commons/numeric/signed.rs
+++ b/tfhe/src/core_crypto/commons/numeric/signed.rs
@@ -31,6 +31,7 @@ pub trait SignedInteger:
     + ShrAssign<usize>
     + CastFrom<f64>
     + CastInto<f64>
+    + From<bool>
 {
     /// The unsigned type of the same precicion
     type Unsigned: UnsignedInteger<Signed = Self> + CastFrom<Self>;

--- a/tfhe/src/core_crypto/commons/numeric/unsigned.rs
+++ b/tfhe/src/core_crypto/commons/numeric/unsigned.rs
@@ -205,7 +205,7 @@ macro_rules! implement {
             }
             #[inline]
             fn wrapping_neg_custom_mod(self, custom_modulus: Self) -> Self {
-                custom_modulus.wrapping_sub_custom_mod(self, custom_modulus)
+                Self::ZERO.wrapping_sub_custom_mod(self, custom_modulus)
                 // Custom modulus applied by wrapping_sub
             }
             #[inline]

--- a/tfhe/src/core_crypto/commons/numeric/unsigned.rs
+++ b/tfhe/src/core_crypto/commons/numeric/unsigned.rs
@@ -70,6 +70,9 @@ pub trait UnsignedInteger:
     /// Compute a negation, modulo the max of the type.
     #[must_use]
     fn wrapping_neg(self) -> Self;
+    /// Compute a negation, modulo the max of the type.
+    #[must_use]
+    fn wrapping_neg_custom_mod(self, custom_modulus: Self) -> Self;
     /// Compute an exponentiation, modulo the max of the type.
     #[must_use]
     fn wrapping_pow(self, exp: u32) -> Self;
@@ -199,6 +202,11 @@ macro_rules! implement {
             #[inline]
             fn wrapping_neg(self) -> Self {
                 self.wrapping_neg()
+            }
+            #[inline]
+            fn wrapping_neg_custom_mod(self, custom_modulus: Self) -> Self {
+                custom_modulus.wrapping_sub_custom_mod(self, custom_modulus)
+                // Custom modulus applied by wrapping_sub
             }
             #[inline]
             fn wrapping_shl(self, rhs: u32) -> Self {

--- a/tfhe/src/core_crypto/commons/numeric/unsigned.rs
+++ b/tfhe/src/core_crypto/commons/numeric/unsigned.rs
@@ -36,21 +36,34 @@ pub trait UnsignedInteger:
     + CastFrom<u128>
     + CastInto<u128>
     + std::fmt::Binary
+    + From<bool>
 {
     /// The signed type of the same precision.
     type Signed: SignedInteger<Unsigned = Self> + CastFrom<Self>;
+    /// Return the leading zeros of the value.
+    #[must_use]
+    fn leading_zeros(self) -> u32;
     /// Compute an addition, modulo the max of the type.
     #[must_use]
     fn wrapping_add(self, other: Self) -> Self;
     /// Compute a subtraction, modulo the max of the type.
     #[must_use]
     fn wrapping_sub(self, other: Self) -> Self;
+    /// Compute an addition, modulo a custom modulus.
+    #[must_use]
+    fn wrapping_add_custom_mod(self, other: Self, custom_modulus: Self) -> Self;
+    /// Compute a subtraction, modulo a custom modulus.
+    #[must_use]
+    fn wrapping_sub_custom_mod(self, other: Self, custom_modulus: Self) -> Self;
     /// Compute a division, modulo the max of the type.
     #[must_use]
     fn wrapping_div(self, other: Self) -> Self;
     /// Compute a multiplication, modulo the max of the type.
     #[must_use]
     fn wrapping_mul(self, other: Self) -> Self;
+    /// Compute a multiplication, modulo a custom modulus.
+    #[must_use]
+    fn wrapping_mul_custom_mod(self, other: Self, custom_modulus: Self) -> Self;
     /// Compute the remainder, modulo the max of the type.
     #[must_use]
     fn wrapping_rem(self, other: Self) -> Self;
@@ -117,12 +130,45 @@ macro_rules! implement {
                 strn
             }
             #[inline]
+            fn leading_zeros(self) -> u32 {
+                self.leading_zeros()
+            }
+            #[inline]
             fn wrapping_add(self, other: Self) -> Self {
                 self.wrapping_add(other)
             }
             #[inline]
             fn wrapping_sub(self, other: Self) -> Self {
                 self.wrapping_sub(other)
+            }
+            #[inline]
+            fn wrapping_add_custom_mod(self, other: Self, custom_modulus: Self) -> Self {
+                if Self::BITS < 128 {
+                    let self_u128: u128 = self.cast_into();
+                    let other_u128: u128 = other.cast_into();
+                    let custom_modulus_u128: u128 = custom_modulus.cast_into();
+                    self_u128
+                        .wrapping_add(other_u128)
+                        .wrapping_rem(custom_modulus_u128)
+                        .cast_into()
+                } else {
+                    todo!("wrapping_add_custom_mod is not yet implemented for types wider than u64")
+                }
+            }
+            #[inline]
+            fn wrapping_sub_custom_mod(self, other: Self, custom_modulus: Self) -> Self {
+                if Self::BITS < 128 {
+                    let self_u128: u128 = self.cast_into();
+                    let other_u128: u128 = other.cast_into();
+                    let custom_modulus_u128: u128 = custom_modulus.cast_into();
+                    self_u128
+                        .wrapping_add(custom_modulus_u128)
+                        .wrapping_sub(other_u128)
+                        .wrapping_rem(custom_modulus_u128)
+                        .cast_into()
+                } else {
+                    todo!("wrapping_sub_custom_mod is not yet implemented for types wider than u64")
+                }
             }
             #[inline]
             fn wrapping_div(self, other: Self) -> Self {
@@ -132,7 +178,21 @@ macro_rules! implement {
             fn wrapping_mul(self, other: Self) -> Self {
                 self.wrapping_mul(other)
             }
-            #[must_use]
+            #[inline]
+            fn wrapping_mul_custom_mod(self, other: Self, custom_modulus: Self) -> Self {
+                if Self::BITS < 128 {
+                    let self_u128: u128 = self.cast_into();
+                    let other_u128: u128 = other.cast_into();
+                    let custom_modulus_u128: u128 = custom_modulus.cast_into();
+                    self_u128
+                        .wrapping_mul(other_u128)
+                        .wrapping_rem(custom_modulus_u128)
+                        .cast_into()
+                } else {
+                    todo!("wrapping_mul_custom_mod is not yet implemented for types wider than u64")
+                }
+            }
+            #[inline]
             fn wrapping_rem(self, other: Self) -> Self {
                 self.wrapping_rem(other)
             }
@@ -224,5 +284,78 @@ mod test {
                        0011 1010 0110 1101 1100 1001 0011 0010"
                 .to_string()
         );
+    }
+
+    #[test]
+    fn test_wrapping_add_custom_mod() {
+        let a = u64::MAX;
+        let b = u64::MAX;
+        let custom_modulus_u128 = (1u128 << 64) - (1 << 32) + 1;
+        let custom_modulus = custom_modulus_u128 as u64;
+
+        let a_u128: u128 = a.into();
+        let b_u128: u128 = b.into();
+
+        let expected_res = ((a_u128 + b_u128) % custom_modulus_u128) as u64;
+
+        let res = a.wrapping_add_custom_mod(b, custom_modulus);
+        assert_eq!(expected_res, res);
+
+        const NB_REPS: usize = 100_000_000;
+
+        use rand::Rng;
+        let mut thread_rng = rand::thread_rng();
+        for _ in 0..NB_REPS {
+            let a: u64 = thread_rng.gen();
+            let b: u64 = thread_rng.gen();
+
+            let a_u128: u128 = a.into();
+            let b_u128: u128 = b.into();
+
+            let expected_res = ((a_u128 + b_u128) % custom_modulus_u128) as u64;
+
+            let res = a.wrapping_add_custom_mod(b, custom_modulus);
+            assert_eq!(expected_res, res, "a: {a}, b: {b}");
+        }
+    }
+
+    #[test]
+    fn test_wrapping_sub_custom_mod() {
+        let custom_modulus_u128 = (1u128 << 64) - (1 << 32) + 1;
+        let custom_modulus = custom_modulus_u128 as u64;
+
+        let a = 0u64;
+        let b = u64::MAX % custom_modulus;
+
+        let a_u128: u128 = a.into();
+        let b_u128: u128 = b.into();
+
+        let expected_res = ((a_u128
+            .wrapping_add(custom_modulus_u128)
+            .wrapping_sub(b_u128))
+            % custom_modulus_u128) as u64;
+
+        let res = a.wrapping_sub_custom_mod(b, custom_modulus);
+        assert_eq!(expected_res, res);
+
+        const NB_REPS: usize = 100_000_000;
+
+        use rand::Rng;
+        let mut thread_rng = rand::thread_rng();
+        for _ in 0..NB_REPS {
+            let a: u64 = thread_rng.gen();
+            let b: u64 = thread_rng.gen();
+
+            let a_u128: u128 = a.into();
+            let b_u128: u128 = b.into();
+
+            let expected_res = ((a_u128
+                .wrapping_add(custom_modulus_u128)
+                .wrapping_sub(b_u128))
+                % custom_modulus_u128) as u64;
+
+            let res = a.wrapping_sub_custom_mod(b, custom_modulus);
+            assert_eq!(expected_res, res, "a: {a}, b: {b}");
+        }
     }
 }

--- a/tfhe/src/core_crypto/entities/lwe_keyswitch_key.rs
+++ b/tfhe/src/core_crypto/entities/lwe_keyswitch_key.rs
@@ -248,7 +248,7 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> LweKeyswitchKey<C>
 
     /// Return a view of the [`LweKeyswitchKey`]. This is useful if an algorithm takes a view by
     /// value.
-    pub fn as_view(&self) -> LweKeyswitchKey<&'_ [Scalar]> {
+    pub fn as_view(&self) -> LweKeyswitchKeyView<'_, Scalar> {
         LweKeyswitchKey::from_container(
             self.as_ref(),
             self.decomp_base_log,
@@ -280,7 +280,7 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> LweKeyswitchKey<C>
 
 impl<Scalar: UnsignedInteger, C: ContainerMut<Element = Scalar>> LweKeyswitchKey<C> {
     /// Mutable variant of [`LweKeyswitchKey::as_view`].
-    pub fn as_mut_view(&mut self) -> LweKeyswitchKey<&'_ mut [Scalar]> {
+    pub fn as_mut_view(&mut self) -> LweKeyswitchKeyMutView<'_, Scalar> {
         let decomp_base_log = self.decomp_base_log;
         let decomp_level_count = self.decomp_level_count;
         let output_lwe_size = self.output_lwe_size;
@@ -303,6 +303,8 @@ impl<Scalar: UnsignedInteger, C: ContainerMut<Element = Scalar>> LweKeyswitchKey
 
 /// An [`LweKeyswitchKey`] owning the memory for its own storage.
 pub type LweKeyswitchKeyOwned<Scalar> = LweKeyswitchKey<Vec<Scalar>>;
+pub type LweKeyswitchKeyView<'a, Scalar> = LweKeyswitchKey<&'a [Scalar]>;
+pub type LweKeyswitchKeyMutView<'a, Scalar> = LweKeyswitchKey<&'a mut [Scalar]>;
 
 impl<Scalar: UnsignedInteger> LweKeyswitchKeyOwned<Scalar> {
     /// Allocate memory and create a new owned [`LweKeyswitchKey`].

--- a/tfhe/src/core_crypto/entities/lwe_secret_key.rs
+++ b/tfhe/src/core_crypto/entities/lwe_secret_key.rs
@@ -88,10 +88,26 @@ impl<Scalar, C: Container<Element = Scalar>> LweSecretKey<C> {
     pub fn into_container(self) -> C {
         self.data
     }
+
+    pub fn as_view(&self) -> LweSecretKeyView<'_, Scalar> {
+        LweSecretKey {
+            data: self.as_ref(),
+        }
+    }
+}
+
+impl<Scalar, C: ContainerMut<Element = Scalar>> LweSecretKey<C> {
+    pub fn as_mut_view(&mut self) -> LweSecretKeyMutView<'_, Scalar> {
+        LweSecretKey {
+            data: self.as_mut(),
+        }
+    }
 }
 
 /// An [`LweSecretKey`] owning the memory for its own storage.
 pub type LweSecretKeyOwned<Scalar> = LweSecretKey<Vec<Scalar>>;
+pub type LweSecretKeyView<'a, Scalar> = LweSecretKey<&'a [Scalar]>;
+pub type LweSecretKeyMutView<'a, Scalar> = LweSecretKey<&'a mut [Scalar]>;
 
 impl<Scalar> LweSecretKeyOwned<Scalar>
 where

--- a/tfhe/src/core_crypto/prelude.rs
+++ b/tfhe/src/core_crypto/prelude.rs
@@ -3,9 +3,7 @@
 //! The TFHE-rs preludes include convenient imports.
 //! Having `tfhe::core_crypto::prelude::*;` should be enough to start using the lib.
 
-pub use super::algorithms::{
-    add_external_product_assign, polynomial_algorithms, slice_algorithms, *,
-};
+pub use super::algorithms::{polynomial_algorithms, slice_algorithms, *};
 pub use super::commons::computation_buffers::ComputationBuffers;
 pub use super::commons::dispersion::*;
 pub use super::commons::generators::{EncryptionRandomGenerator, SecretRandomGenerator};


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: https://github.com/zama-ai/tfhe-rs-internal/issues/132
refs: https://github.com/zama-ai/tfhe-rs-internal/issues/19

### PR content/description

Not sure we can close issue 19, it's a first integration with all ciphertext moduli kind covered for LWE + linalg + KS, GLWE and GGSW only have the encryption done

I think https://github.com/zama-ai/tfhe-rs-internal/issues/82 might be handled kind of ok, but the way we use floating points means we may be losing up to 11 bits of a u64 modulus when scaling the gaussian sampler to send it to the unsigned integer domain

Random uniform generation is skewed for non power of 2 moduli as we discussed for now @jborfila issue https://github.com/zama-ai/tfhe-rs-internal/issues/104

Dispersion should scale with Q and not the native modulus

This PR is probably missing some polish, I think it was required to get something out in review so that it starts to be a thing rather than some obscure piece of code being worked on in the shadows, so I expect quite a few comments for this revision (sorry in advance, but I think in that case it's better)

# Initially
Uses the following construction for non power of 2 decomposition:

```
we consider the integer q which is a non power-of-two such that q<2^64
we define left_pad = 64 - ceil(log2(q)) which is the number of most significant bits always set to zero when considering a number between 0 and q-1

Rounding & decomposition:

inputs:
x: an integer mod q
left_pad (as defined above)
base
level
algorithm:
x' <- x << left_pad
output traditional_decomposer(x', base, level) (with modular subtractions)

Key switching key generation:

for the level i, traditionally encrypts s_j<< (64 - log_base * (i+1))
replace with s_j<< (64 - left_pad - log_base * (i+1))
```

# Now uses a different approach for now

Custom moduli add/sub/mul/neg are added in this PR for UnsignedInteger and have "dumb" basic implems for now.
A new CiphertextModulusKind is also added to easily see if we are dealing with a Native modulus, non native power of 2 or just non native (any) modulus

### Check-list:

* [x] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [x] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [x] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
