### PR TITLE
feat(integer): implement more U256 operators

### DIFF
--- a/tfhe/src/integer/u256.rs
+++ b/tfhe/src/integer/u256.rs
@@ -1,10 +1,57 @@
-use crate::core_crypto::prelude::{CastFrom, Numeric};
+use crate::core_crypto::prelude::{CastFrom, Numeric, UnsignedInteger};
 
 #[inline(always)]
-pub const fn adc(l: u64, r: u64, c: bool) -> (u64, bool) {
+pub fn add_with_carry<T: UnsignedInteger>(l: T, r: T, c: bool) -> (T, bool) {
     let (lr, o0) = l.overflowing_add(r);
-    let (lrc, o1) = lr.overflowing_add(c as u64);
+    let (lrc, o1) = lr.overflowing_add(T::cast_from(c));
     (lrc, o0 | o1)
+}
+
+pub fn add_assign_words<T: UnsignedInteger>(lhs: &mut [T], rhs: &[T]) {
+    let iter = lhs
+        .iter_mut()
+        .zip(rhs.iter().copied().chain(std::iter::repeat(T::ZERO)));
+
+    let mut carry = false;
+    for (lhs_block, rhs_block) in iter {
+        let (result, out_carry) = add_with_carry(*lhs_block, rhs_block, carry);
+        *lhs_block = result;
+        carry = out_carry;
+    }
+}
+
+/// lhs and rhs are slice of words.
+///
+/// They must be in lsb -> msb order
+pub(crate) fn schoolbook_mul_assign(lhs: &mut [u64], rhs: &[u64]) {
+    assert!(lhs.len() >= rhs.len());
+    let mut terms = Vec::with_capacity(rhs.len());
+
+    for (i, rhs_block) in rhs.iter().copied().enumerate() {
+        let mut blocks = Vec::with_capacity(lhs.len() + i);
+        blocks.resize(i, 0u64); // pad with 0
+
+        let mut carry = 0;
+        for lhs_block in lhs.iter().copied() {
+            let mut res = lhs_block as u128 * rhs_block as u128;
+            res += carry;
+            let carry_out = res >> u64::BITS;
+            blocks.push((res & u64::MAX as u128) as u64);
+            carry = carry_out;
+        }
+        blocks.push(carry as u64);
+
+        terms.push(blocks)
+    }
+
+    let mut result = terms.pop().unwrap();
+    for term in terms {
+        add_assign_words(&mut result, &term);
+    }
+
+    for (lhs_block, result_block) in lhs.iter_mut().zip(result) {
+        *lhs_block = result_block;
+    }
 }
 
 // Little endian order
@@ -113,6 +160,35 @@ impl U256 {
         let high = self.0[2] as u128 | ((self.0[3] as u128) << 64);
         (low, high)
     }
+
+    pub fn is_power_of_two(self) -> bool {
+        if self == Self::ZERO {
+            return false;
+        }
+        (self & (self - Self::ONE)) == Self::ZERO
+    }
+
+    pub fn leading_zeros(self) -> u32 {
+        // iter from msb to lsb
+        for (i, word) in self.0.iter().copied().rev().enumerate() {
+            let leading_zeros = dbg!(word.leading_zeros());
+            if leading_zeros != u64::BITS {
+                return (i as u32 * u64::BITS) + leading_zeros;
+            }
+        }
+
+        // Everyting is zero
+        self.0.len() as u32 * u64::BITS
+    }
+
+    pub fn ilog2(self) -> u32 {
+        // Rust has the same assert
+        assert!(
+            self > Self::ZERO,
+            "argument of integer logarithm must be positive"
+        );
+        (self.0.len() as u32 * u64::BITS) - self.leading_zeros() - 1
+    }
 }
 
 #[cfg(test)]
@@ -138,16 +214,24 @@ impl std::cmp::Ord for U256 {
     }
 }
 
+impl std::cmp::PartialOrd for U256 {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
 impl std::ops::Add<Self> for U256 {
     type Output = Self;
 
-    fn add(self, rhs: Self) -> Self::Output {
-        let (x0, carry) = adc(self.0[0], rhs.0[0], false);
-        let (x1, carry) = adc(self.0[1], rhs.0[1], carry);
-        let (x2, carry) = adc(self.0[2], rhs.0[2], carry);
-        let (x3, _) = adc(self.0[3], rhs.0[3], carry);
+    fn add(mut self, rhs: Self) -> Self::Output {
+        self += rhs;
+        self
+    }
+}
 
-        Self([x0, x1, x2, x3])
+impl std::ops::AddAssign<Self> for U256 {
+    fn add_assign(&mut self, rhs: Self) {
+        add_assign_words(self.0.as_mut_slice(), rhs.0.as_slice())
     }
 }
 
@@ -160,6 +244,40 @@ impl std::ops::Sub<Self> for U256 {
     }
 }
 
+impl std::ops::SubAssign<Self> for U256 {
+    fn sub_assign(&mut self, rhs: Self) {
+        *self = *self - rhs;
+    }
+}
+
+impl std::ops::Shr<u32> for U256 {
+    type Output = Self;
+
+    fn shr(mut self, rhs: u32) -> Self::Output {
+        self >>= rhs;
+        self
+    }
+}
+
+impl std::ops::MulAssign<Self> for U256 {
+    fn mul_assign(&mut self, rhs: Self) {
+        if rhs.is_power_of_two() {
+            use std::ops::ShlAssign;
+            self.shl_assign(rhs.ilog2());
+            return;
+        }
+        schoolbook_mul_assign(self.0.as_mut_slice(), rhs.0.as_slice());
+    }
+}
+
+impl std::ops::Mul<Self> for U256 {
+    type Output = Self;
+
+    fn mul(mut self, rhs: Self) -> Self::Output {
+        self *= rhs;
+        self
+    }
+}
 impl std::ops::ShrAssign<u32> for U256 {
     // move bits from MSB to LSB
     fn shr_assign(&mut self, shift: u32) {
@@ -189,11 +307,11 @@ impl std::ops::ShrAssign<u32> for U256 {
     }
 }
 
-impl std::ops::Shr<u32> for U256 {
+impl std::ops::Shl<u32> for U256 {
     type Output = Self;
 
-    fn shr(mut self, rhs: u32) -> Self::Output {
-        self >>= rhs;
+    fn shl(mut self, rhs: u32) -> Self::Output {
+        self <<= rhs;
         self
     }
 }
@@ -226,15 +344,6 @@ impl std::ops::ShlAssign<u32> for U256 {
     }
 }
 
-impl std::ops::Shl<u32> for U256 {
-    type Output = Self;
-
-    fn shl(mut self, rhs: u32) -> Self::Output {
-        self <<= rhs;
-        self
-    }
-}
-
 impl std::ops::Not for U256 {
     type Output = Self;
 
@@ -243,14 +352,6 @@ impl std::ops::Not for U256 {
             *self_word = !*self_word;
         }
         self
-    }
-}
-
-impl std::ops::BitAndAssign<Self> for U256 {
-    fn bitand_assign(&mut self, rhs: Self) {
-        for (self_word, rhs_word) in self.0.iter_mut().zip(rhs.0) {
-            *self_word &= rhs_word;
-        }
     }
 }
 
@@ -263,9 +364,19 @@ impl std::ops::BitAnd<Self> for U256 {
     }
 }
 
-impl std::ops::AddAssign<Self> for U256 {
-    fn add_assign(&mut self, rhs: Self) {
-        *self = *self + rhs;
+impl std::ops::BitAndAssign<Self> for U256 {
+    fn bitand_assign(&mut self, rhs: Self) {
+        for (self_word, rhs_word) in self.0.iter_mut().zip(rhs.0) {
+            *self_word &= rhs_word;
+        }
+    }
+}
+
+impl std::ops::BitOrAssign<Self> for U256 {
+    fn bitor_assign(&mut self, rhs: Self) {
+        for (self_word, rhs_word) in self.0.iter_mut().zip(rhs.0) {
+            *self_word |= rhs_word;
+        }
     }
 }
 
@@ -278,26 +389,28 @@ impl std::ops::BitOr<Self> for U256 {
     }
 }
 
-impl std::ops::BitOrAssign<Self> for U256 {
-    fn bitor_assign(&mut self, rhs: Self) {
-        for (self_word, rhs_word) in self.0.iter_mut().zip(rhs.0) {
-            *self_word |= rhs_word;
-        }
-    }
-}
-
-impl std::cmp::PartialOrd for U256 {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
 impl From<(u64, u64, u64, u64)> for U256 {
     fn from(value: (u64, u64, u64, u64)) -> Self {
         Self([value.0, value.1, value.2, value.3])
     }
 }
 
+impl std::ops::BitXorAssign<Self> for U256 {
+    fn bitxor_assign(&mut self, rhs: Self) {
+        for (self_word, rhs_word) in self.0.iter_mut().zip(rhs.0) {
+            *self_word ^= rhs_word;
+        }
+    }
+}
+
+impl std::ops::BitXor<Self> for U256 {
+    type Output = Self;
+
+    fn bitxor(mut self, rhs: Self) -> Self::Output {
+        self ^= rhs;
+        self
+    }
+}
 impl From<(u128, u128)> for U256 {
     fn from(v: (u128, u128)) -> Self {
         Self([
@@ -344,9 +457,220 @@ impl From<u128> for U256 {
     }
 }
 
+impl CastFrom<U256> for u64 {
+    fn cast_from(input: U256) -> Self {
+        input.0[0]
+    }
+}
+
+impl CastFrom<U256> for u8 {
+    fn cast_from(input: U256) -> Self {
+        input.0[0] as u8
+    }
+}
+
+impl CastFrom<u32> for U256 {
+    fn cast_from(input: u32) -> Self {
+        Self::from(input)
+    }
+}
+
+impl CastFrom<u64> for U256 {
+    fn cast_from(input: u64) -> Self {
+        Self::from(input)
+    }
+}
+
+impl CastFrom<u8> for U256 {
+    fn cast_from(input: u8) -> Self {
+        Self::from(input as u64)
+    }
+}
+
+impl From<bool> for U256 {
+    fn from(input: bool) -> Self {
+        Self::from(if input { 1u64 } else { 0u64 })
+    }
+}
+
+// SAFETY
+//
+// U256 is allowed to be all zeros
+unsafe impl bytemuck::Zeroable for U256 {}
+
+// SAFETY
+//
+// u64 impl bytemuck::Pod,
+// [T; N] impl bytemuck::Pod if T: bytemuck::Pod
+//
+// https://docs.rs/bytemuck/latest/bytemuck/trait.Pod.html#foreign-impls
+//
+// Thus U256 can safely be considered Pod
+unsafe impl bytemuck::Pod for U256 {}
+
+impl Numeric for U256 {
+    const BITS: usize = Self::BITS as usize;
+
+    const ZERO: Self = Self::ZERO;
+
+    const ONE: Self = Self::ONE;
+
+    const TWO: Self = Self::TWO;
+
+    const MAX: Self = Self::MAX;
+}
+
 #[cfg(test)]
 mod tests {
+    use std::panic::catch_unwind;
+
+    use rand::Rng;
+
     use super::*;
+
+    fn u64_with_odd_bits_set() -> u64 {
+        let mut v = 0u64;
+
+        for i in (1..=63).step_by(2) {
+            v |= 1u64 << i;
+        }
+
+        v
+    }
+
+    fn u64_with_even_bits_set() -> u64 {
+        let mut v = 0u64;
+
+        // bit index are from 0 to 63
+        for i in (0..=62).step_by(2) {
+            v |= 1u64 << i;
+        }
+
+        v
+    }
+
+    #[test]
+    fn test_u64_even_odd_bits() {
+        let all_even_bits_set = u64_with_even_bits_set();
+        let all_odd_bits_set = u64_with_odd_bits_set();
+
+        assert_ne!(all_odd_bits_set, all_even_bits_set);
+
+        assert_eq!(all_even_bits_set.rotate_right(1), all_odd_bits_set);
+        assert_eq!(all_even_bits_set, all_odd_bits_set.rotate_left(1));
+    }
+
+    #[test]
+    fn test_bitand() {
+        let all_even_bits_set = U256([u64_with_even_bits_set(); 4]);
+        let all_odd_bits_set = U256([u64_with_odd_bits_set(); 4]);
+
+        assert_ne!(all_odd_bits_set, all_even_bits_set);
+        assert_eq!(all_odd_bits_set & all_odd_bits_set, all_odd_bits_set);
+        assert_eq!(all_even_bits_set & all_even_bits_set, all_even_bits_set);
+        assert_eq!(all_even_bits_set & all_odd_bits_set, U256::ZERO);
+    }
+
+    #[test]
+    fn test_bitor() {
+        let all_even_bits_set = U256([u64_with_even_bits_set(); 4]);
+        let all_odd_bits_set = U256([u64_with_odd_bits_set(); 4]);
+
+        assert_ne!(all_odd_bits_set, all_even_bits_set);
+        assert_eq!(all_odd_bits_set | all_odd_bits_set, all_odd_bits_set);
+        assert_eq!(all_even_bits_set | all_even_bits_set, all_even_bits_set);
+        assert_eq!(all_even_bits_set | all_odd_bits_set, U256::MAX);
+    }
+
+    #[test]
+    fn test_bitxor() {
+        let all_even_bits_set = U256([u64_with_even_bits_set(); 4]);
+        let all_odd_bits_set = U256([u64_with_odd_bits_set(); 4]);
+
+        assert_ne!(all_odd_bits_set, all_even_bits_set);
+        assert_eq!(all_odd_bits_set ^ all_odd_bits_set, U256::ZERO);
+        assert_eq!(all_even_bits_set ^ all_even_bits_set, U256::ZERO);
+        assert_eq!(all_even_bits_set ^ all_odd_bits_set, U256::MAX);
+    }
+
+    #[test]
+    fn test_is_power_of_two() {
+        assert!(!U256::ZERO.is_power_of_two());
+        assert!(!U256::MAX.is_power_of_two());
+        assert!(!U256::from(8329842348123u64).is_power_of_two());
+
+        for i in 0..U256::BITS {
+            assert!((U256::ONE << i).is_power_of_two())
+        }
+    }
+
+    #[test]
+    fn test_ilog2() {
+        assert!(catch_unwind(|| { U256::ZERO.ilog2() }).is_err());
+
+        assert_eq!(U256::MAX.ilog2(), 255);
+        assert_eq!(
+            U256::from(8329842348123u64).ilog2(),
+            8329842348123u64.ilog2()
+        );
+
+        assert_eq!(
+            U256::from(8320912948329842348123u128).ilog2(),
+            8320912948329842348123u128.ilog2()
+        );
+
+        assert_eq!(
+            U256::from(2323912928329942718123u128).ilog2(),
+            2323912928329942718123u128.ilog2()
+        );
+
+        for i in 0..U256::BITS {
+            assert_eq!((U256::ONE << i).ilog2(), i)
+        }
+    }
+
+    #[test]
+    fn test_mul() {
+        let u64_max = U256::from(u64::MAX);
+        let expected = u64::MAX as u128 * u64::MAX as u128;
+        assert_eq!(u64_max * u64_max, U256::from(expected));
+
+        let mut rng = rand::thread_rng();
+        for _ in 0..5 {
+            let a = rng.gen::<u64>();
+            let b = rng.gen::<u64>();
+
+            let res = U256::from(a) * U256::from(b);
+            let expected = a as u128 * b as u128;
+            assert_eq!(res, U256::from(expected));
+        }
+
+        let u128_max = U256::from(u128::MAX);
+        let res = u128_max * u128_max;
+        let expected = U256::from((1u128, 340282366920938463463374607431768211454u128));
+        assert_eq!(res, expected);
+
+        let u128_max = U256::from(u128::MAX);
+        let res = u128_max * U256::from(3284723894u64);
+        let expected = U256::from((340282366920938463463374607428483487562u128, 3284723893u128));
+        assert_eq!(res, expected);
+
+        let u128_max = U256::from(u128::MAX);
+        let res = u128_max * U256::from(u64::MAX);
+        let expected = U256::from((
+            340282366920938463444927863358058659841u128,
+            18446744073709551614u128,
+        ));
+        assert_eq!(res, expected);
+
+        let u128_max = U256::from(u128::MAX);
+        let res = u128_max * U256::ZERO;
+        assert_eq!(res, U256::ZERO);
+
+        let u128_max = U256::from(u128::MAX);
+        let res = u128_max * U256::ONE;
+        assert_eq!(res, u128_max);
+    }
 
     #[test]
     fn test_add_wrap_around() {
@@ -448,67 +772,4 @@ mod tests {
 
         assert_eq!(be_bytes_2, be_bytes);
     }
-}
-
-impl CastFrom<U256> for u64 {
-    fn cast_from(input: U256) -> Self {
-        input.0[0]
-    }
-}
-
-impl CastFrom<U256> for u8 {
-    fn cast_from(input: U256) -> Self {
-        input.0[0] as u8
-    }
-}
-
-impl CastFrom<u32> for U256 {
-    fn cast_from(input: u32) -> Self {
-        Self::from(input)
-    }
-}
-
-impl CastFrom<u64> for U256 {
-    fn cast_from(input: u64) -> Self {
-        Self::from(input)
-    }
-}
-
-impl CastFrom<u8> for U256 {
-    fn cast_from(input: u8) -> Self {
-        Self::from(input as u64)
-    }
-}
-
-impl From<bool> for U256 {
-    fn from(input: bool) -> Self {
-        Self::from(if input { 1u64 } else { 0u64 })
-    }
-}
-
-// SAFETY
-//
-// U256 is allowed to be all zeros
-unsafe impl bytemuck::Zeroable for U256 {}
-
-// SAFETY
-//
-// u64 impl bytemuck::Pod,
-// [T; N] impl bytemuck::Pod if T: bytemuck::Pod
-//
-// https://docs.rs/bytemuck/latest/bytemuck/trait.Pod.html#foreign-impls
-//
-// Thus U256 can safely be considered Pod
-unsafe impl bytemuck::Pod for U256 {}
-
-impl Numeric for U256 {
-    const BITS: usize = Self::BITS as usize;
-
-    const ZERO: Self = Self::ZERO;
-
-    const ONE: Self = Self::ONE;
-
-    const TWO: Self = Self::TWO;
-
-    const MAX: Self = Self::MAX;
 }


### PR DESCRIPTION
### PR content/description

This implements the following operators for U256
- BitXor
- Mul
- is_power_of_two
- ilog2
- SubAssign

This makes us progress on https://github.com/zama-ai/tfhe-rs-internal/issues/120

### Check-list:

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [x] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
