### PR TITLE
chore(ci): add pbs throughput benchmarks

### DIFF
--- a/ci/benchmark_parser.py
+++ b/ci/benchmark_parser.py
@@ -95,6 +95,7 @@ def recursive_parse(directory, walk_subdirs=False, name_suffix="", compute_throu
 
             for stat_name, value in parse_estimate_file(subdir).items():
                 test_name_parts = list(filter(None, [test_name, stat_name, name_suffix]))
+
                 result_values.append(
                     _create_point(
                         value,

--- a/tfhe/benches/boolean/bench.rs
+++ b/tfhe/benches/boolean/bench.rs
@@ -17,7 +17,7 @@ criterion_group!(
 criterion_main!(gates_benches);
 
 /// Helper function to write boolean benchmarks parameters to disk in JSON format.
-pub fn write_to_json_boolean<T: Into<CryptoParametersRecord>>(
+pub fn write_to_json_boolean<T: Into<CryptoParametersRecord<u32>>>(
     bench_id: &str,
     params: T,
     params_alias: impl Into<String>,

--- a/tfhe/benches/core_crypto/pbs_bench.rs
+++ b/tfhe/benches/core_crypto/pbs_bench.rs
@@ -1,8 +1,10 @@
 #[path = "../utilities.rs"]
 mod utilities;
 use crate::utilities::{write_to_json, CryptoParametersRecord, OperatorType};
+use rayon::prelude::*;
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use serde::Serialize;
 use tfhe::boolean::parameters::{BooleanParameters, DEFAULT_PARAMETERS, TFHE_LIB_PARAMETERS};
 use tfhe::core_crypto::prelude::*;
 use tfhe::shortint::keycache::NamedParam;
@@ -47,9 +49,16 @@ criterion_group!(
                 multi_bit_deterministic_pbs::<u32>,
 );
 
-criterion_main!(pbs_group, multi_bit_pbs_group);
+criterion_group!(
+    name = pbs_throughput_groug;
+    config = Criterion::default().sample_size(100);
+    targets = pbs_throughput::<u64>, pbs_throughput::<u32>
+);
 
-fn benchmark_parameters<Scalar: Numeric>() -> Vec<(String, CryptoParametersRecord)> {
+criterion_main!(pbs_group, multi_bit_pbs_group, pbs_throughput_groug);
+
+fn benchmark_parameters<Scalar: UnsignedInteger>() -> Vec<(String, CryptoParametersRecord<Scalar>)>
+{
     if Scalar::BITS == 64 {
         SHORTINT_BENCH_PARAMS
             .iter()
@@ -65,8 +74,31 @@ fn benchmark_parameters<Scalar: Numeric>() -> Vec<(String, CryptoParametersRecor
     }
 }
 
-fn multi_bit_benchmark_parameters<Scalar: Numeric>(
-) -> Vec<(String, (CryptoParametersRecord, LweBskGroupingFactor))> {
+fn throughput_benchmark_parameters<Scalar: UnsignedInteger>(
+) -> Vec<(String, CryptoParametersRecord<Scalar>)> {
+    if Scalar::BITS == 64 {
+        vec![
+            PARAM_MESSAGE_1_CARRY_1,
+            PARAM_MESSAGE_2_CARRY_2,
+            PARAM_MESSAGE_3_CARRY_3,
+        ]
+        .iter()
+        .map(|params| (params.name(), params.to_owned().into()))
+        .collect()
+    } else if Scalar::BITS == 32 {
+        BOOLEAN_BENCH_PARAMS
+            .iter()
+            .map(|(name, params)| (name.to_string(), params.to_owned().into()))
+            .collect()
+    } else {
+        vec![]
+    }
+}
+
+fn multi_bit_benchmark_parameters<Scalar: UnsignedInteger + Default>() -> Vec<(
+    String,
+    (CryptoParametersRecord<Scalar>, LweBskGroupingFactor),
+)> {
     if Scalar::BITS == 64 {
         vec![
             (
@@ -228,7 +260,7 @@ fn multi_bit_benchmark_parameters<Scalar: Numeric>(
     }
 }
 
-fn mem_optimized_pbs<Scalar: UnsignedTorus + CastInto<usize>>(c: &mut Criterion) {
+fn mem_optimized_pbs<Scalar: UnsignedTorus + CastInto<usize> + Serialize>(c: &mut Criterion) {
     let bench_name = "PBS_mem-optimized";
     let mut bench_group = c.benchmark_group(bench_name);
 
@@ -331,7 +363,9 @@ fn mem_optimized_pbs<Scalar: UnsignedTorus + CastInto<usize>>(c: &mut Criterion)
     }
 }
 
-fn multi_bit_pbs<Scalar: UnsignedTorus + CastInto<usize> + CastFrom<usize> + Sync>(
+fn multi_bit_pbs<
+    Scalar: UnsignedTorus + CastInto<usize> + CastFrom<usize> + Default + Sync + Serialize,
+>(
     c: &mut Criterion,
 ) {
     let bench_name = "multi_bits_PBS";
@@ -418,7 +452,9 @@ fn multi_bit_pbs<Scalar: UnsignedTorus + CastInto<usize> + CastFrom<usize> + Syn
     }
 }
 
-fn multi_bit_deterministic_pbs<Scalar: UnsignedTorus + CastInto<usize> + CastFrom<usize> + Sync>(
+fn multi_bit_deterministic_pbs<
+    Scalar: UnsignedTorus + CastInto<usize> + CastFrom<usize> + Default + Serialize + Sync,
+>(
     c: &mut Criterion,
 ) {
     let bench_name = "multi_bits_deterministic_PBS";
@@ -502,5 +538,128 @@ fn multi_bit_deterministic_pbs<Scalar: UnsignedTorus + CastInto<usize> + CastFro
             bit_size,
             vec![bit_size],
         );
+    }
+}
+
+fn pbs_throughput<Scalar: UnsignedTorus + CastInto<usize> + Sync + Send + Serialize>(
+    c: &mut Criterion,
+) {
+    let bench_name = "PBS_throughput";
+    let mut bench_group = c.benchmark_group(bench_name);
+
+    // Create the PRNG
+    let mut seeder = new_seeder();
+    let seeder = seeder.as_mut();
+    let mut encryption_generator =
+        EncryptionRandomGenerator::<ActivatedRandomGenerator>::new(seeder.seed(), seeder);
+    let mut secret_generator =
+        SecretRandomGenerator::<ActivatedRandomGenerator>::new(seeder.seed());
+
+    for (name, params) in throughput_benchmark_parameters::<Scalar>().iter() {
+        let input_lwe_secret_key = allocate_and_generate_new_binary_lwe_secret_key(
+            params.lwe_dimension.unwrap(),
+            &mut secret_generator,
+        );
+
+        let glwe_secret_key = GlweSecretKey::new_empty_key(
+            Scalar::ZERO,
+            params.glwe_dimension.unwrap(),
+            params.polynomial_size.unwrap(),
+        );
+        let big_lwe_sk = glwe_secret_key.into_lwe_secret_key();
+        let big_lwe_dimension = big_lwe_sk.lwe_dimension();
+
+        const NUM_CTS: usize = 512;
+        let lwe_vec: Vec<_> = (0..NUM_CTS)
+            .map(|_| {
+                allocate_and_encrypt_new_lwe_ciphertext(
+                    &input_lwe_secret_key,
+                    Plaintext(Scalar::ZERO),
+                    params.lwe_modular_std_dev.unwrap(),
+                    tfhe::core_crypto::prelude::CiphertextModulus::new_native(),
+                    &mut encryption_generator,
+                )
+            })
+            .collect();
+
+        let mut output_lwe_list = LweCiphertextList::new(
+            Scalar::ZERO,
+            big_lwe_dimension.to_lwe_size(),
+            LweCiphertextCount(NUM_CTS),
+            params.ciphertext_modulus.unwrap(),
+        );
+
+        let lwe_vec = lwe_vec;
+
+        let fft = Fft::new(params.polynomial_size.unwrap());
+        let fft = fft.as_view();
+
+        let mut vec_buffers: Vec<_> = (0..NUM_CTS)
+            .map(|_| {
+                let mut buffers = ComputationBuffers::new();
+                buffers.resize(
+                    programmable_bootstrap_lwe_ciphertext_mem_optimized_requirement::<Scalar>(
+                        params.glwe_dimension.unwrap().to_glwe_size(),
+                        params.polynomial_size.unwrap(),
+                        fft,
+                    )
+                    .unwrap()
+                    .unaligned_bytes_required(),
+                );
+                buffers
+            })
+            .collect();
+
+        let glwe = GlweCiphertext::new(
+            Scalar::ONE << 60,
+            params.glwe_dimension.unwrap().to_glwe_size(),
+            params.polynomial_size.unwrap(),
+            params.ciphertext_modulus.unwrap(),
+        );
+
+        let fbsk = FourierLweBootstrapKey::new(
+            params.lwe_dimension.unwrap(),
+            params.glwe_dimension.unwrap().to_glwe_size(),
+            params.polynomial_size.unwrap(),
+            params.pbs_base_log.unwrap(),
+            params.pbs_level.unwrap(),
+        );
+
+        for chunk_size in [1, 16, 32, 64, 128, 256, 512] {
+            let id = format!("{bench_name}_{name}_{chunk_size}chunk");
+            {
+                bench_group.bench_function(&id, |b| {
+                    b.iter(|| {
+                        lwe_vec
+                            .par_iter()
+                            .zip(output_lwe_list.par_iter_mut())
+                            .zip(vec_buffers.par_iter_mut())
+                            .take(chunk_size)
+                            .for_each(|((input_lwe, mut out_lwe), buffer)| {
+                                programmable_bootstrap_lwe_ciphertext_mem_optimized(
+                                    input_lwe,
+                                    &mut out_lwe,
+                                    &glwe,
+                                    &fbsk,
+                                    fft,
+                                    buffer.stack(),
+                                );
+                            });
+                        black_box(&mut output_lwe_list);
+                    })
+                });
+            }
+
+            let bit_size = (params.message_modulus.unwrap_or(2) as u32).ilog2();
+            write_to_json(
+                &id,
+                *params,
+                name,
+                "pbs",
+                &OperatorType::Atomic,
+                bit_size,
+                vec![bit_size],
+            );
+        }
     }
 }

--- a/tfhe/benches/integer/bench.rs
+++ b/tfhe/benches/integer/bench.rs
@@ -113,7 +113,7 @@ fn bench_server_key_binary_function_dirty_inputs<F>(
             )
         });
 
-        write_to_json(
+        write_to_json::<u64, _>(
             &bench_id,
             param,
             param.name(),
@@ -173,7 +173,7 @@ fn bench_server_key_binary_function_clean_inputs<F>(
             )
         });
 
-        write_to_json(
+        write_to_json::<u64, _>(
             &bench_id,
             param,
             param.name(),
@@ -244,7 +244,7 @@ fn bench_server_key_unary_function_dirty_inputs<F>(
             )
         });
 
-        write_to_json(
+        write_to_json::<u64, _>(
             &bench_id,
             param,
             param.name(),
@@ -300,7 +300,7 @@ fn bench_server_key_unary_function_clean_inputs<F>(
             )
         });
 
-        write_to_json(
+        write_to_json::<u64, _>(
             &bench_id,
             param,
             param.name(),
@@ -369,7 +369,7 @@ fn bench_server_key_binary_scalar_function_dirty_inputs<F>(
             )
         });
 
-        write_to_json(
+        write_to_json::<u64, _>(
             &bench_id,
             param,
             param.name(),
@@ -425,7 +425,7 @@ fn bench_server_key_binary_scalar_function_clean_inputs<F>(
             )
         });
 
-        write_to_json(
+        write_to_json::<u64, _>(
             &bench_id,
             param,
             param.name(),

--- a/tfhe/benches/shortint/bench.rs
+++ b/tfhe/benches/shortint/bench.rs
@@ -68,7 +68,7 @@ fn bench_server_key_unary_function<F>(
             })
         });
 
-        write_to_json(
+        write_to_json::<u64, _>(
             &bench_id,
             *param,
             param.name(),
@@ -114,7 +114,7 @@ fn bench_server_key_binary_function<F>(
             })
         });
 
-        write_to_json(
+        write_to_json::<u64, _>(
             &bench_id,
             *param,
             param.name(),
@@ -159,7 +159,7 @@ fn bench_server_key_binary_scalar_function<F>(
             })
         });
 
-        write_to_json(
+        write_to_json::<u64, _>(
             &bench_id,
             *param,
             param.name(),
@@ -208,7 +208,7 @@ fn bench_server_key_binary_scalar_division_function<F>(
             })
         });
 
-        write_to_json(
+        write_to_json::<u64, _>(
             &bench_id,
             *param,
             param.name(),
@@ -244,7 +244,7 @@ fn carry_extract(c: &mut Criterion) {
             })
         });
 
-        write_to_json(
+        write_to_json::<u64, _>(
             &bench_id,
             param,
             param.name(),
@@ -283,7 +283,7 @@ fn programmable_bootstrapping(c: &mut Criterion) {
             })
         });
 
-        write_to_json(
+        write_to_json::<u64, _>(
             &bench_id,
             param,
             param.name(),

--- a/tfhe/benches/utilities.rs
+++ b/tfhe/benches/utilities.rs
@@ -8,7 +8,7 @@ use tfhe::core_crypto::prelude::*;
 use tfhe::shortint::ClassicPBSParameters;
 
 #[derive(Clone, Copy, Default, Serialize)]
-pub struct CryptoParametersRecord {
+pub struct CryptoParametersRecord<Scalar: UnsignedInteger> {
     pub lwe_dimension: Option<LweDimension>,
     pub glwe_dimension: Option<GlweDimension>,
     pub polynomial_size: Option<PolynomialSize>,
@@ -25,10 +25,11 @@ pub struct CryptoParametersRecord {
     pub cbs_base_log: Option<DecompositionBaseLog>,
     pub message_modulus: Option<usize>,
     pub carry_modulus: Option<usize>,
+    pub ciphertext_modulus: Option<CiphertextModulus<Scalar>>,
 }
 
 #[cfg(feature = "boolean")]
-impl From<BooleanParameters> for CryptoParametersRecord {
+impl<Scalar: UnsignedInteger> From<BooleanParameters> for CryptoParametersRecord<Scalar> {
     fn from(params: BooleanParameters) -> Self {
         CryptoParametersRecord {
             lwe_dimension: Some(params.lwe_dimension),
@@ -47,12 +48,16 @@ impl From<BooleanParameters> for CryptoParametersRecord {
             cbs_base_log: None,
             message_modulus: None,
             carry_modulus: None,
+            ciphertext_modulus: None,
         }
     }
 }
 
 #[cfg(feature = "shortint")]
-impl From<ClassicPBSParameters> for CryptoParametersRecord {
+impl<Scalar> From<ClassicPBSParameters> for CryptoParametersRecord<Scalar>
+where
+    Scalar: UnsignedInteger + CastInto<u128>,
+{
     fn from(params: ClassicPBSParameters) -> Self {
         CryptoParametersRecord {
             lwe_dimension: Some(params.lwe_dimension),
@@ -71,6 +76,12 @@ impl From<ClassicPBSParameters> for CryptoParametersRecord {
             cbs_base_log: None,
             message_modulus: Some(params.message_modulus.0),
             carry_modulus: Some(params.carry_modulus.0),
+            ciphertext_modulus: Some(
+                params
+                    .ciphertext_modulus
+                    .try_to()
+                    .expect("failed to convert ciphertext modulus"),
+            ),
         }
     }
 }
@@ -113,10 +124,10 @@ pub enum OperatorType {
 }
 
 #[derive(Serialize)]
-struct BenchmarkParametersRecord {
+struct BenchmarkParametersRecord<Scalar: UnsignedInteger> {
     display_name: String,
     crypto_parameters_alias: String,
-    crypto_parameters: CryptoParametersRecord,
+    crypto_parameters: CryptoParametersRecord<Scalar>,
     message_modulus: Option<usize>,
     carry_modulus: Option<usize>,
     ciphertext_modulus: usize,
@@ -134,7 +145,10 @@ struct BenchmarkParametersRecord {
 }
 
 /// Writes benchmarks parameters to disk in JSON format.
-pub fn write_to_json<T: Into<CryptoParametersRecord>>(
+pub fn write_to_json<
+    Scalar: UnsignedInteger + Serialize,
+    T: Into<CryptoParametersRecord<Scalar>>,
+>(
     bench_id: &str,
     params: T,
     params_alias: impl Into<String>,

--- a/tfhe/examples/utilities/boolean_key_sizes.rs
+++ b/tfhe/examples/utilities/boolean_key_sizes.rs
@@ -42,7 +42,7 @@ fn client_server_key_sizes(results_file: &Path) {
         let test_name = format!("boolean_key_sizes_{params_name}_ksk");
 
         write_result(&mut file, &test_name, ksk_size);
-        write_to_json(
+        write_to_json::<u32, _>(
             &test_name,
             *params,
             *params_name,
@@ -62,7 +62,7 @@ fn client_server_key_sizes(results_file: &Path) {
         let test_name = format!("boolean_key_sizes_{params_name}_bsk");
 
         write_result(&mut file, &test_name, bsk_size);
-        write_to_json(
+        write_to_json::<u32, _>(
             &test_name,
             *params,
             *params_name,

--- a/tfhe/examples/utilities/hlapi_compact_pk_ct_sizes.rs
+++ b/tfhe/examples/utilities/hlapi_compact_pk_ct_sizes.rs
@@ -53,7 +53,7 @@ pub fn cpk_and_cctl_sizes(results_file: &Path) {
 
         println!("PK size: {cpk_size} bytes");
         write_result(&mut file, &test_name, cpk_size);
-        write_to_json(
+        write_to_json::<u64, _>(
             &test_name,
             params,
             params.name(),
@@ -73,7 +73,7 @@ pub fn cpk_and_cctl_sizes(results_file: &Path) {
         println!("Compact CT list for {NB_CTXT} CTs: {} bytes", cctl_size);
 
         write_result(&mut file, &test_name, cctl_size);
-        write_to_json(
+        write_to_json::<u64, _>(
             &test_name,
             params,
             params.name(),
@@ -109,7 +109,7 @@ pub fn cpk_and_cctl_sizes(results_file: &Path) {
 
         println!("PK size: {cpk_size} bytes");
         write_result(&mut file, &test_name, cpk_size);
-        write_to_json(
+        write_to_json::<u64, _>(
             &test_name,
             params,
             params.name(),
@@ -129,7 +129,7 @@ pub fn cpk_and_cctl_sizes(results_file: &Path) {
         println!("Compact CT list for {NB_CTXT} CTs: {} bytes", cctl_size);
 
         write_result(&mut file, &test_name, cctl_size);
-        write_to_json(
+        write_to_json::<u64, _>(
             &test_name,
             params,
             params.name(),
@@ -177,7 +177,7 @@ pub fn cpk_and_cctl_sizes(results_file: &Path) {
         println!("Compact CT list for {NB_CTXT} CTs: {} bytes", cctl_size);
 
         write_result(&mut file, &test_name, cctl_size);
-        write_to_json(
+        write_to_json::<u64, _>(
             &test_name,
             params,
             params.name(),
@@ -224,7 +224,7 @@ pub fn cpk_and_cctl_sizes(results_file: &Path) {
         println!("Compact CT list for {NB_CTXT} CTs: {} bytes", cctl_size);
 
         write_result(&mut file, &test_name, cctl_size);
-        write_to_json(
+        write_to_json::<u64, _>(
             &test_name,
             params,
             params.name(),

--- a/tfhe/examples/utilities/shortint_key_sizes.rs
+++ b/tfhe/examples/utilities/shortint_key_sizes.rs
@@ -50,7 +50,7 @@ fn client_server_key_sizes(results_file: &Path) {
         let test_name = format!("shortint_key_sizes_{}_ksk", params.name());
 
         write_result(&mut file, &test_name, ksk_size);
-        write_to_json(
+        write_to_json::<u64, _>(
             &test_name,
             *params,
             params.name(),
@@ -70,7 +70,7 @@ fn client_server_key_sizes(results_file: &Path) {
         let test_name = format!("shortint_key_sizes_{}_bsk", params.name());
 
         write_result(&mut file, &test_name, bsk_size);
-        write_to_json(
+        write_to_json::<u64, _>(
             &test_name,
             *params,
             params.name(),

--- a/tfhe/examples/utilities/wasm_benchmarks_parser.rs
+++ b/tfhe/examples/utilities/wasm_benchmarks_parser.rs
@@ -59,7 +59,7 @@ pub fn parse_wasm_benchmarks(results_file: &Path, raw_results_dir: &Path) {
             let value_in_ns = (val * 1_000_000_f32) as usize;
 
             write_result(&mut file, full_name, value_in_ns);
-            write_to_json(
+            write_to_json::<u64, _>(
                 full_name,
                 params,
                 params.name(),


### PR DESCRIPTION

<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: zama-ai/tfhe-rs-internal#164

### PR content/description

This implies to add a conversion method to CiphertextModulus in order to create the CryptoParametersRecord struct used as utils.

### Check-list:

* [x] Tests for the changes have been added (for bug fixes / features)
* [ ] ~~Docs have been added / updated (for bug fixes / features)~~
* [x] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] ~~Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]~~

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
