### PR TITLE
chore(tfhe): dump non deterministic key and use deterministic when required

### DIFF
--- a/tfhe/examples/utilities/generates_test_keys.rs
+++ b/tfhe/examples/utilities/generates_test_keys.rs
@@ -36,7 +36,7 @@ fn client_server_keys() {
 
             let start = std::time::Instant::now();
 
-            let _ = KEY_CACHE.get_from_param(params.with_deterministic_execution());
+            let _ = KEY_CACHE.get_from_param(params.with_non_deterministic_execution());
 
             let stop = start.elapsed().as_secs();
 

--- a/tfhe/src/shortint/parameters/mod.rs
+++ b/tfhe/src/shortint/parameters/mod.rs
@@ -145,7 +145,7 @@ pub struct MultiBitPBSParameters {
 impl MultiBitPBSParameters {
     pub const fn with_deterministic_execution(self) -> Self {
         Self {
-            deterministic_execution: false,
+            deterministic_execution: true,
             ..self
         }
     }


### PR DESCRIPTION
Easier to dump the non deterministic key as a default case and chose deterministic execution when required