### PR TITLE
feat(core): use ntt-based polynomial multiplication for large polynomials

### DIFF
--- a/tfhe/Cargo.toml
+++ b/tfhe/Cargo.toml
@@ -57,6 +57,7 @@ serde = { version = "1.0", features = ["derive"] }
 rayon = { version = "1.5.0" }
 bincode = { version = "1.3.3", optional = true }
 concrete-fft = { version = "0.2.1", features = ["serde", "fft128"] }
+concrete-ntt = { version = "0.1.0" }
 pulp = "0.11"
 aligned-vec = { version = "0.5", features = ["serde"] }
 dyn-stack = { version = "0.9" }

--- a/tfhe/benches/keygen/bench.rs
+++ b/tfhe/benches/keygen/bench.rs
@@ -3,6 +3,7 @@ use criterion::*;
 use tfhe::core_crypto::commons::generators::DeterministicSeeder;
 use tfhe::core_crypto::prelude::{
     allocate_and_generate_new_binary_glwe_secret_key,
+    allocate_and_generate_new_binary_lwe_secret_key,
     par_allocate_and_generate_new_lwe_bootstrap_key, ActivatedRandomGenerator, CiphertextModulus,
     EncryptionRandomGenerator, SecretRandomGenerator,
 };
@@ -10,7 +11,7 @@ use tfhe::core_crypto::seeders::new_seeder;
 use tfhe::shortint::prelude::*;
 
 fn criterion_bench(c: &mut Criterion) {
-    let parameters = PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    let parameters = PARAM_MESSAGE_4_CARRY_4_KS_PBS;
     let mut seeder = new_seeder();
     let mut deterministic_seeder =
         DeterministicSeeder::<ActivatedRandomGenerator>::new(seeder.seed());
@@ -25,11 +26,14 @@ fn criterion_bench(c: &mut Criterion) {
         parameters.polynomial_size,
         &mut secret_generator,
     );
-    let lwe_secret_key_after_ks = glwe_secret_key.clone().into_lwe_secret_key();
+    let small_lwe_secret_key = allocate_and_generate_new_binary_lwe_secret_key(
+        parameters.lwe_dimension,
+        &mut secret_generator,
+    );
     c.bench_function("keygen", |b| {
         b.iter(|| {
             let _ = par_allocate_and_generate_new_lwe_bootstrap_key(
-                &lwe_secret_key_after_ks,
+                &small_lwe_secret_key,
                 &glwe_secret_key,
                 parameters.pbs_base_log,
                 parameters.pbs_level,


### PR DESCRIPTION
### PR content/description
use concrete-ntt for negacyclic polynomial multiplication. this speeds up keygen by 2x for MESSAGE_2_CARRY_2 and 6x for MESSAGE_4_CARRY_4 

### Check-list:

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [x] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
