### PR TITLE
chore(ci): use multi-bit params in shortint for pbs benchmarks

### DIFF
--- a/tfhe/benches/core_crypto/pbs_bench.rs
+++ b/tfhe/benches/core_crypto/pbs_bench.rs
@@ -109,165 +109,28 @@ fn throughput_benchmark_parameters<Scalar: UnsignedInteger>(
     }
 }
 
-fn multi_bit_benchmark_parameters<Scalar: UnsignedInteger + Default>() -> Vec<(
-    String,
-    (CryptoParametersRecord<Scalar>, LweBskGroupingFactor),
-)> {
+fn multi_bit_benchmark_parameters<Scalar: UnsignedInteger + Default>(
+) -> Vec<(String, CryptoParametersRecord<Scalar>, LweBskGroupingFactor)> {
     if Scalar::BITS == 64 {
         vec![
-            (
-                "2_bits_multi_bit_group_2".to_string(),
-                (
-                    CryptoParametersRecord {
-                        lwe_dimension: Some(LweDimension(764)),
-                        lwe_modular_std_dev: Some(StandardDev(0.000006025673585415336)),
-                        pbs_base_log: Some(DecompositionBaseLog(18)),
-                        pbs_level: Some(DecompositionLevelCount(1)),
-                        glwe_dimension: Some(GlweDimension(3)),
-                        glwe_modular_std_dev: Some(StandardDev(0.0000000000039666089171633006)),
-                        polynomial_size: Some(PolynomialSize(1 << 9)),
-                        message_modulus: Some(1),
-                        carry_modulus: Some(1),
-                        ..Default::default()
-                    },
-                    LweBskGroupingFactor(2),
-                ),
-            ),
-            (
-                "2_bits_multi_bit_group_3".to_string(),
-                (
-                    CryptoParametersRecord {
-                        lwe_dimension: Some(LweDimension(765)),
-                        lwe_modular_std_dev: Some(StandardDev(0.000005915594083804978)),
-                        pbs_base_log: Some(DecompositionBaseLog(18)),
-                        pbs_level: Some(DecompositionLevelCount(1)),
-                        glwe_dimension: Some(GlweDimension(3)),
-                        glwe_modular_std_dev: Some(StandardDev(0.0000000000039666089171633006)),
-                        polynomial_size: Some(PolynomialSize(1 << 9)),
-                        message_modulus: Some(1),
-                        carry_modulus: Some(1),
-                        ..Default::default()
-                    },
-                    LweBskGroupingFactor(3),
-                ),
-            ),
-            (
-                "4_bits_multi_bit_group_2".to_string(),
-                (
-                    CryptoParametersRecord {
-                        lwe_dimension: Some(LweDimension(818)),
-                        lwe_modular_std_dev: Some(StandardDev(0.000002226459789930014)),
-                        pbs_base_log: Some(DecompositionBaseLog(22)),
-                        pbs_level: Some(DecompositionLevelCount(1)),
-                        glwe_dimension: Some(GlweDimension(1)),
-                        glwe_modular_std_dev: Some(StandardDev(0.0000000000000003152931493498455)),
-                        polynomial_size: Some(PolynomialSize(1 << 11)),
-                        message_modulus: Some(2),
-                        carry_modulus: Some(2),
-                        ..Default::default()
-                    },
-                    LweBskGroupingFactor(2),
-                ),
-            ),
-            (
-                "4_bits_multi_bit_group_3".to_string(),
-                (
-                    CryptoParametersRecord {
-                        lwe_dimension: Some(LweDimension(888)),
-                        lwe_modular_std_dev: Some(StandardDev(0.0000006125031601933181)),
-                        pbs_base_log: Some(DecompositionBaseLog(21)),
-                        pbs_level: Some(DecompositionLevelCount(1)),
-                        glwe_dimension: Some(GlweDimension(1)),
-                        glwe_modular_std_dev: Some(StandardDev(0.0000000000000003152931493498455)),
-                        polynomial_size: Some(PolynomialSize(1 << 11)),
-                        message_modulus: Some(2),
-                        carry_modulus: Some(2),
-                        ..Default::default()
-                    },
-                    LweBskGroupingFactor(3),
-                ),
-            ),
-            (
-                "6_bits_multi_bit_group_2".to_string(),
-                (
-                    CryptoParametersRecord {
-                        lwe_dimension: Some(LweDimension(922)),
-                        lwe_modular_std_dev: Some(StandardDev(0.0000003272369292345697)),
-                        pbs_base_log: Some(DecompositionBaseLog(14)),
-                        pbs_level: Some(DecompositionLevelCount(2)),
-                        glwe_dimension: Some(GlweDimension(1)),
-                        glwe_modular_std_dev: Some(StandardDev(
-                            0.0000000000000000002168404344971009,
-                        )),
-                        polynomial_size: Some(PolynomialSize(1 << 13)),
-                        message_modulus: Some(3),
-                        carry_modulus: Some(3),
-                        ..Default::default()
-                    },
-                    LweBskGroupingFactor(2),
-                ),
-            ),
-            (
-                "6_bits_multi_bit_group_3".to_string(),
-                (
-                    CryptoParametersRecord {
-                        lwe_dimension: Some(LweDimension(972)),
-                        lwe_modular_std_dev: Some(StandardDev(0.00000013016688349592805)),
-                        pbs_base_log: Some(DecompositionBaseLog(14)),
-                        pbs_level: Some(DecompositionLevelCount(2)),
-                        glwe_dimension: Some(GlweDimension(1)),
-                        glwe_modular_std_dev: Some(StandardDev(
-                            0.0000000000000000002168404344971009,
-                        )),
-                        polynomial_size: Some(PolynomialSize(1 << 13)),
-                        message_modulus: Some(3),
-                        carry_modulus: Some(3),
-                        ..Default::default()
-                    },
-                    LweBskGroupingFactor(3),
-                ),
-            ),
-            (
-                "8_bits_multi_bit_group_2".to_string(),
-                (
-                    CryptoParametersRecord {
-                        lwe_dimension: Some(LweDimension(1052)),
-                        lwe_modular_std_dev: Some(StandardDev(0.000000029779789543501806)),
-                        pbs_base_log: Some(DecompositionBaseLog(14)),
-                        pbs_level: Some(DecompositionLevelCount(2)),
-                        glwe_dimension: Some(GlweDimension(1)),
-                        glwe_modular_std_dev: Some(StandardDev(
-                            0.0000000000000000002168404344971009,
-                        )),
-                        polynomial_size: Some(PolynomialSize(1 << 15)),
-                        message_modulus: Some(4),
-                        carry_modulus: Some(4),
-                        ..Default::default()
-                    },
-                    LweBskGroupingFactor(2),
-                ),
-            ),
-            (
-                "8_bits_multi_bit_group_3".to_string(),
-                (
-                    CryptoParametersRecord {
-                        lwe_dimension: Some(LweDimension(1098)),
-                        lwe_modular_std_dev: Some(StandardDev(0.000000012752307213087621)),
-                        pbs_base_log: Some(DecompositionBaseLog(14)),
-                        pbs_level: Some(DecompositionLevelCount(2)),
-                        glwe_dimension: Some(GlweDimension(1)),
-                        glwe_modular_std_dev: Some(StandardDev(
-                            0.0000000000000000002168404344971009,
-                        )),
-                        polynomial_size: Some(PolynomialSize(1 << 15)),
-                        message_modulus: Some(4),
-                        carry_modulus: Some(4),
-                        ..Default::default()
-                    },
-                    LweBskGroupingFactor(3),
-                ),
-            ),
+            PARAM_MULTI_BIT_MESSAGE_1_CARRY_1_GROUP_2_KS_PBS,
+            PARAM_MULTI_BIT_MESSAGE_2_CARRY_2_GROUP_2_KS_PBS,
+            PARAM_MULTI_BIT_MESSAGE_3_CARRY_3_GROUP_2_KS_PBS,
+            PARAM_MULTI_BIT_MESSAGE_1_CARRY_1_GROUP_3_KS_PBS,
+            PARAM_MULTI_BIT_MESSAGE_2_CARRY_2_GROUP_3_KS_PBS,
+            PARAM_MULTI_BIT_MESSAGE_3_CARRY_3_GROUP_3_KS_PBS,
         ]
+        .iter()
+        .map(|params| {
+            (
+                params.name(),
+                <MultiBitPBSParameters as Into<PBSParameters>>::into(*params)
+                    .to_owned()
+                    .into(),
+                params.grouping_factor,
+            )
+        })
+        .collect()
     } else {
         // For now there are no parameters available to test multi bit PBS on 32 bits.
         vec![]
@@ -393,7 +256,7 @@ fn multi_bit_pbs<
     let mut secret_generator =
         SecretRandomGenerator::<ActivatedRandomGenerator>::new(seeder.seed());
 
-    for (name, (params, grouping_factor)) in multi_bit_benchmark_parameters::<Scalar>().iter() {
+    for (name, params, grouping_factor) in multi_bit_benchmark_parameters::<Scalar>().iter() {
         // Create the LweSecretKey
         let input_lwe_secret_key = allocate_and_generate_new_binary_lwe_secret_key(
             params.lwe_dimension.unwrap(),
@@ -482,7 +345,7 @@ fn multi_bit_deterministic_pbs<
     let mut secret_generator =
         SecretRandomGenerator::<ActivatedRandomGenerator>::new(seeder.seed());
 
-    for (name, (params, grouping_factor)) in multi_bit_benchmark_parameters::<Scalar>().iter() {
+    for (name, params, grouping_factor) in multi_bit_benchmark_parameters::<Scalar>().iter() {
         // Create the LweSecretKey
         let input_lwe_secret_key = allocate_and_generate_new_binary_lwe_secret_key(
             params.lwe_dimension.unwrap(),


### PR DESCRIPTION
Use up-to-date crypto parameters for PBS benchmarks with multi-bit instead of hardcoded ones.