### PR TITLE
chore(ci): bench multiple scalar bit sizes and add operators

### DIFF
--- a/.github/workflows/integer_full_benchmark.yml
+++ b/.github/workflows/integer_full_benchmark.yml
@@ -38,16 +38,27 @@ jobs:
           echo "Type: ${{ inputs.instance_type }}"
           echo "Request ID: ${{ inputs.request_id }}"
 
-      - name: Checkout tfhe-rs repo with tags
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
-        with:
-          fetch-depth: 0
-
       - name: Get benchmark details
         run: |
           echo "BENCH_DATE=$(date --iso-8601=seconds)" >> "${GITHUB_ENV}"
           echo "COMMIT_DATE=$(git --no-pager show -s --format=%cd --date=iso8601-strict ${{ github.sha }})" >> "${GITHUB_ENV}"
           echo "COMMIT_HASH=$(git describe --tags --dirty)" >> "${GITHUB_ENV}"
+
+  integer-benchmarks:
+    name: Execute integer benchmarks for all operations flavor
+    runs-on: ${{ github.event.inputs.runner_name }}
+    if: ${{ !cancelled() }}
+    needs: prepare-benchmarks
+    strategy:
+      max-parallel: 1
+      matrix:
+        command: [ integer, integer_multi_bit ]
+        op_flavor: [ default, default_scalar, smart, smart_scalar, smart_parallelized, smart_scalar_parallelized, unchecked, unchecked_scalar, misc ]
+    steps:
+      - name: Checkout tfhe-rs repo with tags
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
+        with:
+            fetch-depth: 0
 
       - name: Set up home
         # "Install rust" step require root user to have a HOME directory which is not set.
@@ -67,17 +78,6 @@ jobs:
           path: slab
           token: ${{ secrets.CONCRETE_ACTIONS_TOKEN }}
 
-  integer-benchmarks:
-    name: Execute integer benchmarks for all operations flavor
-    runs-on: ${{ github.event.inputs.runner_name }}
-    if: ${{ !cancelled() }}
-    needs: prepare-benchmarks
-    strategy:
-      max-parallel: 1
-      matrix:
-        command: [ integer, integer_multi_bit]
-        op_flavor: [ default, default_scalar, smart, smart_scalar, smart_parallelized, smart_scalar_parallelized, unchecked, unchecked_scalar, misc ]
-    steps:
       - name: Run benchmarks with AVX512
         run: |
           make AVX512_SUPPORT=ON BENCH_OP_FLAVOR=${{ matrix.op_flavor }} bench_${{ matrix.command }}

--- a/.github/workflows/integer_full_benchmark.yml
+++ b/.github/workflows/integer_full_benchmark.yml
@@ -1,5 +1,5 @@
 # Run all integer benchmarks on an AWS instance and return parsed results to Slab CI bot.
-name: Integer benchmarks
+name: Integer full benchmarks
 
 on:
   workflow_dispatch:
@@ -26,10 +26,15 @@ env:
   ACTION_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 jobs:
-  prepare-benchmarks:
-    name: Prepare benchmarks environment
+  integer-benchmarks:
+    name: Execute integer benchmarks for all operations flavor
     runs-on: ${{ github.event.inputs.runner_name }}
     if: ${{ !cancelled() }}
+    strategy:
+      max-parallel: 1
+      matrix:
+        command: [ integer, integer_multi_bit]
+        op_flavor: [ default, default_scalar, smart, smart_scalar, smart_parallelized, smart_scalar_parallelized, unchecked, unchecked_scalar, misc ]
     steps:
       - name: Instance configuration used
         run: |
@@ -38,27 +43,16 @@ jobs:
           echo "Type: ${{ inputs.instance_type }}"
           echo "Request ID: ${{ inputs.request_id }}"
 
+      - name: Checkout tfhe-rs repo with tags
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
+        with:
+          fetch-depth: 0
+
       - name: Get benchmark details
         run: |
           echo "BENCH_DATE=$(date --iso-8601=seconds)" >> "${GITHUB_ENV}"
           echo "COMMIT_DATE=$(git --no-pager show -s --format=%cd --date=iso8601-strict ${{ github.sha }})" >> "${GITHUB_ENV}"
           echo "COMMIT_HASH=$(git describe --tags --dirty)" >> "${GITHUB_ENV}"
-
-  integer-benchmarks:
-    name: Execute integer benchmarks for all operations flavor
-    runs-on: ${{ github.event.inputs.runner_name }}
-    if: ${{ !cancelled() }}
-    needs: prepare-benchmarks
-    strategy:
-      max-parallel: 1
-      matrix:
-        command: [ integer, integer_multi_bit ]
-        op_flavor: [ default, default_scalar, smart, smart_scalar, smart_parallelized, smart_scalar_parallelized, unchecked, unchecked_scalar, misc ]
-    steps:
-      - name: Checkout tfhe-rs repo with tags
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
-        with:
-            fetch-depth: 0
 
       - name: Set up home
         # "Install rust" step require root user to have a HOME directory which is not set.

--- a/.github/workflows/shortint_full_benchmark.yml
+++ b/.github/workflows/shortint_full_benchmark.yml
@@ -1,5 +1,5 @@
 # Run all shortint benchmarks on an AWS instance and return parsed results to Slab CI bot.
-name: Integer benchmarks
+name: Shortint full benchmarks
 
 on:
   workflow_dispatch:
@@ -26,10 +26,14 @@ env:
   ACTION_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 jobs:
-  prepare-benchmarks:
-    name: Prepare benchmarks environment
+  shortint-benchmarks:
+    name: Execute shortint benchmarks for all operations flavor
     runs-on: ${{ github.event.inputs.runner_name }}
     if: ${{ !cancelled() }}
+    strategy:
+      max-parallel: 1
+      matrix:
+        op_flavor: [ default, smart, unchecked ]
     steps:
       - name: Instance configuration used
         run: |
@@ -38,26 +42,16 @@ jobs:
           echo "Type: ${{ inputs.instance_type }}"
           echo "Request ID: ${{ inputs.request_id }}"
 
+      - name: Checkout tfhe-rs repo with tags
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
+        with:
+          fetch-depth: 0
+
       - name: Get benchmark details
         run: |
           echo "BENCH_DATE=$(date --iso-8601=seconds)" >> "${GITHUB_ENV}"
           echo "COMMIT_DATE=$(git --no-pager show -s --format=%cd --date=iso8601-strict ${{ github.sha }})" >> "${GITHUB_ENV}"
           echo "COMMIT_HASH=$(git describe --tags --dirty)" >> "${GITHUB_ENV}"
-
-  shortint-benchmarks:
-    name: Execute shortint benchmarks for all operations flavor
-    runs-on: ${{ github.event.inputs.runner_name }}
-    if: ${{ !cancelled() }}
-    needs: prepare-benchmarks
-    strategy:
-      max-parallel: 1
-      matrix:
-        op_flavor: [ default, smart, unchecked ]
-    steps:
-      - name: Checkout tfhe-rs repo with tags
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
-        with:
-          fetch-depth: 0
 
       - name: Set up home
         # "Install rust" step require root user to have a HOME directory which is not set.
@@ -133,7 +127,7 @@ jobs:
     name: Slack Notification
     runs-on: ${{ github.event.inputs.runner_name }}
     if: ${{ failure() }}
-    needs: integer-benchmarks
+    needs: shortint-benchmarks
     steps:
       - name: Notify
         continue-on-error: true

--- a/.github/workflows/shortint_full_benchmark.yml
+++ b/.github/workflows/shortint_full_benchmark.yml
@@ -38,16 +38,26 @@ jobs:
           echo "Type: ${{ inputs.instance_type }}"
           echo "Request ID: ${{ inputs.request_id }}"
 
-      - name: Checkout tfhe-rs repo with tags
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
-        with:
-          fetch-depth: 0
-
       - name: Get benchmark details
         run: |
           echo "BENCH_DATE=$(date --iso-8601=seconds)" >> "${GITHUB_ENV}"
           echo "COMMIT_DATE=$(git --no-pager show -s --format=%cd --date=iso8601-strict ${{ github.sha }})" >> "${GITHUB_ENV}"
           echo "COMMIT_HASH=$(git describe --tags --dirty)" >> "${GITHUB_ENV}"
+
+  shortint-benchmarks:
+    name: Execute shortint benchmarks for all operations flavor
+    runs-on: ${{ github.event.inputs.runner_name }}
+    if: ${{ !cancelled() }}
+    needs: prepare-benchmarks
+    strategy:
+      max-parallel: 1
+      matrix:
+        op_flavor: [ default, smart, unchecked ]
+    steps:
+      - name: Checkout tfhe-rs repo with tags
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
+        with:
+          fetch-depth: 0
 
       - name: Set up home
         # "Install rust" step require root user to have a HOME directory which is not set.
@@ -67,16 +77,6 @@ jobs:
           path: slab
           token: ${{ secrets.CONCRETE_ACTIONS_TOKEN }}
 
-  shortint-benchmarks:
-    name: Execute shortint benchmarks for all operations flavor
-    runs-on: ${{ github.event.inputs.runner_name }}
-    if: ${{ !cancelled() }}
-    needs: prepare-benchmarks
-    strategy:
-      max-parallel: 1
-      matrix:
-        op_flavor: [ default, smart, unchecked ]
-    steps:
       - name: Run benchmarks with AVX512
         run: |
           make AVX512_SUPPORT=ON BENCH_OP_FLAVOR=${{ matrix.op_flavor }} bench_shortint

--- a/ci/parse_integer_benches_to_csv.py
+++ b/ci/parse_integer_benches_to_csv.py
@@ -21,8 +21,15 @@ def main(args):
 
             split = bench_function_id.split("::")
             (_, function_name, parameter_set, bits) = split
-            (bits, _) = bits.split("_")
-            bits = int(bits)
+
+            if "_scalar_" in bits:
+                (bits, scalar) = bits.split("_bits_scalar_")
+                bits = int(bits)
+                scalar = int(scalar)
+            else:
+                (bits, _) = bits.split("_")
+                bits = int(bits)
+                scalar = None
 
             estimate_mean_ms = estimate_data["mean"]["point_estimate"] / 1000000
             estimate_lower_bound_ms = (
@@ -37,6 +44,7 @@ def main(args):
                     function_name,
                     parameter_set,
                     bits,
+                    scalar,
                     estimate_mean_ms,
                     estimate_lower_bound_ms,
                     estimate_upper_bound_ms,
@@ -51,7 +59,7 @@ def main(args):
 
     with open(output_file, "w", encoding="utf-8") as output:
         output.write(
-            "function_name,parameter_set,bits,mean_ms,"
+            "function_name,parameter_set,bits,scalar,mean_ms,"
             "confidence_interval_lower_bound_ms,confidence_interval_upper_bound_ms\n"
         )
         # Sort by func_name, bit width and then parameters
@@ -62,12 +70,13 @@ def main(args):
                 function_name,
                 parameter_set,
                 bits,
+                scalar,
                 estimate_mean_ms,
                 estimate_lower_bound_ms,
                 estimate_upper_bound_ms,
             ) = dat
             output.write(
-                f"{function_name},{parameter_set},{bits},{estimate_mean_ms},"
+                f"{function_name},{parameter_set},{bits},{scalar},{estimate_mean_ms},"
                 f"{estimate_lower_bound_ms},{estimate_upper_bound_ms}\n"
             )
 

--- a/tfhe/benches/integer/bench.rs
+++ b/tfhe/benches/integer/bench.rs
@@ -108,7 +108,7 @@ fn bench_server_key_binary_function_dirty_inputs<F>(
     for (param, num_block, bit_size) in ParamsAndNumBlocksIter::default() {
         let param_name = param.name();
 
-        let bench_id = format!("{param_name}::{bit_size}_bits");
+        let bench_id = format!("{bench_name}::{param_name}::{bit_size}_bits");
         bench_group.bench_function(&bench_id, |b| {
             let (cks, sks) = KEY_CACHE.get_from_params(param);
 
@@ -182,7 +182,7 @@ fn bench_server_key_binary_function_clean_inputs<F>(
     for (param, num_block, bit_size) in ParamsAndNumBlocksIter::default() {
         let param_name = param.name();
 
-        let bench_id = format!("{param_name}::{bit_size}_bits");
+        let bench_id = format!("{bench_name}::{param_name}::{bit_size}_bits");
         bench_group.bench_function(&bench_id, |b| {
             let (cks, sks) = KEY_CACHE.get_from_params(param);
 
@@ -243,7 +243,7 @@ fn bench_server_key_unary_function_dirty_inputs<F>(
     for (param, num_block, bit_size) in ParamsAndNumBlocksIter::default() {
         let param_name = param.name();
 
-        let bench_id = format!("{param_name}::{bit_size}_bits");
+        let bench_id = format!("{bench_name}::{param_name}::{bit_size}_bits");
         bench_group.bench_function(&bench_id, |b| {
             let (cks, sks) = KEY_CACHE.get_from_params(param);
 
@@ -314,7 +314,7 @@ fn bench_server_key_unary_function_clean_inputs<F>(
     for (param, num_block, bit_size) in ParamsAndNumBlocksIter::default() {
         let param_name = param.name();
 
-        let bench_id = format!("{param_name}::{bit_size}_bits");
+        let bench_id = format!("{bench_name}::{param_name}::{bit_size}_bits");
         bench_group.bench_function(&bench_id, |b| {
             let (cks, sks) = KEY_CACHE.get_from_params(param);
 
@@ -367,7 +367,7 @@ fn bench_server_key_binary_scalar_function_dirty_inputs<F>(
     for (param, num_block, bit_size) in ParamsAndNumBlocksIter::default() {
         let param_name = param.name();
 
-        let bench_id = format!("{param_name}::{bit_size}_bits");
+        let bench_id = format!("{bench_name}::{param_name}::{bit_size}_bits");
         bench_group.bench_function(&bench_id, |b| {
             let (cks, sks) = KEY_CACHE.get_from_params(param);
 
@@ -441,7 +441,7 @@ fn bench_server_key_binary_scalar_function_clean_inputs<F, G>(
         }
         let param_name = param.name();
 
-        let bench_id = format!("{param_name}::{bit_size}_bits_scalar_{bit_size}");
+        let bench_id = format!("{bench_name}::{param_name}::{bit_size}_bits_scalar_{bit_size}");
         bench_group.bench_function(&bench_id, |b| {
             let (cks, sks) = KEY_CACHE.get_from_params(param);
 
@@ -516,7 +516,7 @@ macro_rules! define_server_key_bench_unary_fn (
         fn $server_key_method(c: &mut Criterion) {
             bench_server_key_unary_function_dirty_inputs(
                 c,
-                concat!("ServerKey::", stringify!($server_key_method)),
+                concat!("integer::", stringify!($server_key_method)),
                 stringify!($name),
                 |server_key, lhs| {
                   server_key.$server_key_method(lhs);
@@ -530,7 +530,7 @@ macro_rules! define_server_key_bench_unary_default_fn (
         fn $server_key_method(c: &mut Criterion) {
             bench_server_key_unary_function_clean_inputs(
                 c,
-                concat!("ServerKey::", stringify!($server_key_method)),
+                concat!("integer::", stringify!($server_key_method)),
                 stringify!($name),
                 |server_key, lhs| {
                   server_key.$server_key_method(lhs);
@@ -544,7 +544,7 @@ macro_rules! define_server_key_bench_fn (
       fn $server_key_method(c: &mut Criterion) {
         bench_server_key_binary_function_dirty_inputs(
               c,
-              concat!("ServerKey::", stringify!($server_key_method)),
+              concat!("integer::", stringify!($server_key_method)),
               stringify!($name),
               |server_key, lhs, rhs| {
                 server_key.$server_key_method(lhs, rhs);
@@ -558,7 +558,7 @@ macro_rules! define_server_key_bench_default_fn (
         fn $server_key_method(c: &mut Criterion) {
           bench_server_key_binary_function_clean_inputs(
                 c,
-                concat!("ServerKey::", stringify!($server_key_method)),
+                concat!("integer::", stringify!($server_key_method)),
                 stringify!($name),
                 |server_key, lhs, rhs| {
                   server_key.$server_key_method(lhs, rhs);
@@ -572,7 +572,7 @@ macro_rules! define_server_key_bench_scalar_fn (
       fn $server_key_method(c: &mut Criterion) {
           bench_server_key_binary_scalar_function_dirty_inputs(
               c,
-              concat!("ServerKey::", stringify!($server_key_method)),
+              concat!("integer::", stringify!($server_key_method)),
               stringify!($name),
               |server_key, lhs, rhs| {
                 server_key.$server_key_method(lhs, rhs);
@@ -586,7 +586,7 @@ macro_rules! define_server_key_bench_scalar_default_fn (
         fn $server_key_method(c: &mut Criterion) {
             bench_server_key_binary_scalar_function_clean_inputs(
                 c,
-                concat!("ServerKey::", stringify!($server_key_method)),
+                concat!("integer::", stringify!($server_key_method)),
                 stringify!($name),
                 |server_key, lhs, rhs| {
                   server_key.$server_key_method(lhs, rhs);

--- a/tfhe/benches/integer/bench.rs
+++ b/tfhe/benches/integer/bench.rs
@@ -8,6 +8,7 @@ use std::env;
 
 use criterion::{criterion_group, Criterion};
 use itertools::iproduct;
+use rand::prelude::*;
 use rand::Rng;
 use std::vec::IntoIter;
 use tfhe::integer::keycache::KEY_CACHE;
@@ -107,7 +108,7 @@ fn bench_server_key_binary_function_dirty_inputs<F>(
     for (param, num_block, bit_size) in ParamsAndNumBlocksIter::default() {
         let param_name = param.name();
 
-        let bench_id = format!("{bench_name}::{param_name}::{bit_size}_bits");
+        let bench_id = format!("{param_name}::{bit_size}_bits");
         bench_group.bench_function(&bench_id, |b| {
             let (cks, sks) = KEY_CACHE.get_from_params(param);
 
@@ -181,7 +182,7 @@ fn bench_server_key_binary_function_clean_inputs<F>(
     for (param, num_block, bit_size) in ParamsAndNumBlocksIter::default() {
         let param_name = param.name();
 
-        let bench_id = format!("{bench_name}::{param_name}::{bit_size}_bits");
+        let bench_id = format!("{param_name}::{bit_size}_bits");
         bench_group.bench_function(&bench_id, |b| {
             let (cks, sks) = KEY_CACHE.get_from_params(param);
 
@@ -242,7 +243,7 @@ fn bench_server_key_unary_function_dirty_inputs<F>(
     for (param, num_block, bit_size) in ParamsAndNumBlocksIter::default() {
         let param_name = param.name();
 
-        let bench_id = format!("{bench_name}::{param_name}::{bit_size}_bits");
+        let bench_id = format!("{param_name}::{bit_size}_bits");
         bench_group.bench_function(&bench_id, |b| {
             let (cks, sks) = KEY_CACHE.get_from_params(param);
 
@@ -313,7 +314,7 @@ fn bench_server_key_unary_function_clean_inputs<F>(
     for (param, num_block, bit_size) in ParamsAndNumBlocksIter::default() {
         let param_name = param.name();
 
-        let bench_id = format!("{bench_name}::{param_name}::{bit_size}_bits");
+        let bench_id = format!("{param_name}::{bit_size}_bits");
         bench_group.bench_function(&bench_id, |b| {
             let (cks, sks) = KEY_CACHE.get_from_params(param);
 
@@ -366,7 +367,7 @@ fn bench_server_key_binary_scalar_function_dirty_inputs<F>(
     for (param, num_block, bit_size) in ParamsAndNumBlocksIter::default() {
         let param_name = param.name();
 
-        let bench_id = format!("{bench_name}::{param_name}::{bit_size}_bits");
+        let bench_id = format!("{param_name}::{bit_size}_bits");
         bench_group.bench_function(&bench_id, |b| {
             let (cks, sks) = KEY_CACHE.get_from_params(param);
 
@@ -418,13 +419,15 @@ fn bench_server_key_binary_scalar_function_dirty_inputs<F>(
     bench_group.finish()
 }
 
-fn bench_server_key_binary_scalar_function_clean_inputs<F>(
+fn bench_server_key_binary_scalar_function_clean_inputs<F, G>(
     c: &mut Criterion,
     bench_name: &str,
     display_name: &str,
     binary_op: F,
+    rng_func: G,
 ) where
     F: Fn(&ServerKey, &mut RadixCiphertext, u64),
+    G: Fn(&mut ThreadRng, usize) -> u64,
 {
     let mut bench_group = c.benchmark_group(bench_name);
     bench_group
@@ -433,45 +436,84 @@ fn bench_server_key_binary_scalar_function_clean_inputs<F>(
     let mut rng = rand::thread_rng();
 
     for (param, num_block, bit_size) in ParamsAndNumBlocksIter::default() {
+        if bit_size > 64 {
+            break;
+        }
         let param_name = param.name();
 
-        let bench_id = format!("{bench_name}::{param_name}::{bit_size}_bits");
-        bench_group.bench_function(&bench_id, |b| {
-            let (cks, sks) = KEY_CACHE.get_from_params(param);
+        for clear_size in [2, 4, 8, 16, 32, 40, 64] {
+            if clear_size > bit_size {
+                break;
+            }
 
-            let encrypt_one_value = || {
-                let clearlow = rng.gen::<u128>();
-                let clearhigh = rng.gen::<u128>();
+            let bench_id =
+                format!("{param_name}::{bit_size}_bits_scalar_{clear_size}");
+            bench_group.bench_function(&bench_id, |b| {
+                let (cks, sks) = KEY_CACHE.get_from_params(param);
 
-                let clear_0 = tfhe::integer::U256::from((clearlow, clearhigh));
-                let ct_0 = cks.encrypt_radix(clear_0, num_block);
+                let encrypt_one_value = || {
+                    let clearlow = rng.gen::<u128>();
+                    let clearhigh = rng.gen::<u128>();
 
-                let clear_1 = rng.gen::<u64>();
+                    let clear_0 = tfhe::integer::U256::from((clearlow, clearhigh));
+                    let ct_0 = cks.encrypt_radix(clear_0, num_block);
 
-                (ct_0, clear_1)
-            };
+                    let clear_1 = rng_func(&mut rng, clear_size) % (1 << clear_size);
 
-            b.iter_batched(
-                encrypt_one_value,
-                |(mut ct_0, clear_1)| {
-                    binary_op(&sks, &mut ct_0, clear_1);
-                },
-                criterion::BatchSize::SmallInput,
-            )
-        });
+                    (ct_0, clear_1)
+                };
 
-        write_to_json::<u64, _>(
-            &bench_id,
-            param,
-            param.name(),
-            display_name,
-            &OperatorType::Atomic,
-            bit_size as u32,
-            vec![param.message_modulus().0.ilog2(); num_block],
-        );
+                b.iter_batched(
+                    encrypt_one_value,
+                    |(mut ct_0, clear_1)| {
+                        binary_op(&sks, &mut ct_0, clear_1);
+                    },
+                    criterion::BatchSize::SmallInput,
+                )
+            });
+
+            write_to_json::<u64, _>(
+                &bench_id,
+                param,
+                param.name(),
+                display_name,
+                &OperatorType::Atomic,
+                bit_size as u32,
+                vec![param.message_modulus().0.ilog2(); num_block],
+            );
+        }
     }
 
     bench_group.finish()
+}
+
+// Functions used to apply different way of selecting a scalar based on the context.
+fn default_scalar(rng: &mut ThreadRng, _clear_bit_size: usize) -> u64 {
+    rng.gen::<u64>()
+}
+
+fn shift_scalar(_rng: &mut ThreadRng, _clear_bit_size: usize) -> u64 {
+    // Shifting by one is the worst case scenario.
+    1
+}
+
+fn mul_scalar(rng: &mut ThreadRng, _clear_bit_size: usize) -> u64 {
+    loop {
+        let scalar = rng.gen_range(3u64..=u64::MAX);
+        // If scalar is power of two, it is just a shit, which is an happy path.
+        if !scalar.is_power_of_two() {
+            return scalar;
+        }
+    }
+}
+
+fn div_scalar(rng: &mut ThreadRng, clear_bit_size: usize) -> u64 {
+    loop {
+        let scalar = rng.gen_range(1..=u64::MAX);
+        if (scalar % (1 << clear_bit_size)) != 0 {
+            return scalar;
+        }
+    }
 }
 
 macro_rules! define_server_key_bench_unary_fn (
@@ -545,7 +587,7 @@ macro_rules! define_server_key_bench_scalar_fn (
 );
 
 macro_rules! define_server_key_bench_scalar_default_fn (
-    (method_name: $server_key_method:ident, display_name:$name:ident) => {
+    (method_name: $server_key_method:ident, display_name:$name:ident, rng_func:$($rng_fn:tt)*) => {
         fn $server_key_method(c: &mut Criterion) {
             bench_server_key_binary_scalar_function_clean_inputs(
                 c,
@@ -553,7 +595,7 @@ macro_rules! define_server_key_bench_scalar_default_fn (
                 stringify!($name),
                 |server_key, lhs, rhs| {
                   server_key.$server_key_method(lhs, rhs);
-            })
+            }, $($rng_fn)*)
         }
     }
   );
@@ -618,48 +660,90 @@ define_server_key_bench_scalar_fn!(
     display_name: mul
 );
 
-define_server_key_bench_scalar_default_fn!(method_name: scalar_add_parallelized, display_name: add);
-define_server_key_bench_scalar_default_fn!(method_name: scalar_sub_parallelized, display_name: sub);
-define_server_key_bench_scalar_default_fn!(method_name: scalar_mul_parallelized, display_name: mul);
+define_server_key_bench_scalar_default_fn!(
+    method_name: scalar_add_parallelized,
+    display_name: add,
+    rng_func: default_scalar
+);
+define_server_key_bench_scalar_default_fn!(
+    method_name: scalar_sub_parallelized,
+    display_name: sub,
+    rng_func: default_scalar
+);
+define_server_key_bench_scalar_default_fn!(
+    method_name: scalar_mul_parallelized,
+    display_name: mul,
+    rng_func: mul_scalar
+);
+define_server_key_bench_scalar_default_fn!(
+    method_name: scalar_div_parallelized,
+    display_name: div,
+    rng_func: div_scalar
+);
+define_server_key_bench_scalar_default_fn!(
+    method_name: scalar_rem_parallelized,
+    display_name: modulo,
+    rng_func: div_scalar
+);
 define_server_key_bench_scalar_default_fn!(
     method_name: scalar_left_shift_parallelized,
-    display_name: left_shift
+    display_name: left_shift,
+    rng_func: shift_scalar
 );
 define_server_key_bench_scalar_default_fn!(
     method_name: scalar_right_shift_parallelized,
-    display_name: right_shift
+    display_name: right_shift,
+    rng_func: shift_scalar
+);
+define_server_key_bench_scalar_default_fn!(
+    method_name: scalar_rotate_left_parallelized,
+    display_name: rotate_left,
+    rng_func: shift_scalar
+);
+define_server_key_bench_scalar_default_fn!(
+    method_name: scalar_rotate_right_parallelized,
+    display_name: rotate_right,
+    rng_func: shift_scalar
 );
 define_server_key_bench_scalar_default_fn!(
     method_name: scalar_eq_parallelized,
-    display_name: scalar_equal
+    display_name: scalar_equal,
+    rng_func: default_scalar
 );
 define_server_key_bench_scalar_default_fn!(
     method_name: scalar_ne_parallelized,
-    display_name: scalar_not_equal
+    display_name: scalar_not_equal,
+    rng_func: default_scalar
 );
 define_server_key_bench_scalar_default_fn!(
     method_name: scalar_le_parallelized,
-    display_name: scalar_less_or_equal
+    display_name: scalar_less_or_equal,
+    rng_func: default_scalar
 );
 define_server_key_bench_scalar_default_fn!(
     method_name: scalar_lt_parallelized,
-    display_name: scalar_less_than
+    display_name: scalar_less_than,
+    rng_func: default_scalar
 );
 define_server_key_bench_scalar_default_fn!(
     method_name: scalar_ge_parallelized,
-    display_name: scalar_greater_or_equal
+    display_name: scalar_greater_or_equal,
+    rng_func: default_scalar
 );
 define_server_key_bench_scalar_default_fn!(
     method_name: scalar_gt_parallelized,
-    display_name: scalar_greater_than
+    display_name: scalar_greater_than,
+    rng_func: default_scalar
 );
 define_server_key_bench_scalar_default_fn!(
     method_name: scalar_max_parallelized,
-    display_name: scalar_max
+    display_name: scalar_max,
+    rng_func: default_scalar
 );
 define_server_key_bench_scalar_default_fn!(
     method_name: scalar_min_parallelized,
-    display_name: scalar_min
+    display_name: scalar_min,
+    rng_func: default_scalar
 );
 
 define_server_key_bench_scalar_fn!(method_name: unchecked_scalar_add, display_name: add);
@@ -832,6 +916,8 @@ criterion_group!(
     scalar_add_parallelized,
     scalar_sub_parallelized,
     scalar_mul_parallelized,
+    scalar_div_parallelized,
+    scalar_rem_parallelized,
     scalar_left_shift_parallelized,
     scalar_right_shift_parallelized,
     scalar_eq_parallelized,
@@ -842,6 +928,8 @@ criterion_group!(
     scalar_ge_parallelized,
     scalar_min_parallelized,
     scalar_max_parallelized,
+    scalar_rotate_left_parallelized,
+    scalar_rotate_right_parallelized,
 );
 
 criterion_group!(

--- a/tfhe/benches/integer/bench.rs
+++ b/tfhe/benches/integer/bench.rs
@@ -446,8 +446,7 @@ fn bench_server_key_binary_scalar_function_clean_inputs<F, G>(
                 break;
             }
 
-            let bench_id =
-                format!("{param_name}::{bit_size}_bits_scalar_{clear_size}");
+            let bench_id = format!("{param_name}::{bit_size}_bits_scalar_{clear_size}");
             bench_group.bench_function(&bench_id, |b| {
                 let (cks, sks) = KEY_CACHE.get_from_params(param);
 
@@ -458,7 +457,9 @@ fn bench_server_key_binary_scalar_function_clean_inputs<F, G>(
                     let clear_0 = tfhe::integer::U256::from((clearlow, clearhigh));
                     let ct_0 = cks.encrypt_radix(clear_0, num_block);
 
-                    let clear_1 = rng_func(&mut rng, clear_size) % (1 << clear_size);
+                    // Avoid overflow issues for u64 where we would take values mod 1
+                    let clear_1 =
+                        (rng_func(&mut rng, clear_size) as u128 % (1u128 << clear_size)) as u64;
 
                     (ct_0, clear_1)
                 };
@@ -510,7 +511,8 @@ fn mul_scalar(rng: &mut ThreadRng, _clear_bit_size: usize) -> u64 {
 fn div_scalar(rng: &mut ThreadRng, clear_bit_size: usize) -> u64 {
     loop {
         let scalar = rng.gen_range(1..=u64::MAX);
-        if (scalar % (1 << clear_bit_size)) != 0 {
+        // Avoid overflow issues for u64 where we would take values mod 1
+        if (scalar as u128 % (1u128 << clear_bit_size)) != 0 {
             return scalar;
         }
     }

--- a/tfhe/benches/shortint/bench.rs
+++ b/tfhe/benches/shortint/bench.rs
@@ -244,7 +244,7 @@ fn carry_extract(c: &mut Criterion) {
 
         let ct_0 = cks.encrypt(clear_0);
 
-        let bench_id = format!("ServerKey::carry_extract::{}", param.name());
+        let bench_id = format!("shortint::carry_extract::{}", param.name());
         bench_group.bench_function(&bench_id, |b| {
             b.iter(|| {
                 let _ = sks.carry_extract(&ct_0);
@@ -283,7 +283,7 @@ fn programmable_bootstrapping(c: &mut Criterion) {
 
         let ctxt = cks.encrypt(clear_0);
 
-        let bench_id = format!("ServerKey::programmable_bootstrap::{}", param.name());
+        let bench_id = format!("shortint::programmable_bootstrap::{}", param.name());
 
         bench_group.bench_function(&bench_id, |b| {
             b.iter(|| {
@@ -338,7 +338,7 @@ macro_rules! define_server_key_unary_bench_fn (
       fn $server_key_method(c: &mut Criterion) {
           bench_server_key_unary_function(
               c,
-              concat!("ServerKey::", stringify!($server_key_method)),
+              concat!("shortint::", stringify!($server_key_method)),
               stringify!($name),
               |server_key, lhs| {
                 let _ = server_key.$server_key_method(lhs);},
@@ -352,7 +352,7 @@ macro_rules! define_server_key_bench_fn (
       fn $server_key_method(c: &mut Criterion) {
           bench_server_key_binary_function(
               c,
-              concat!("ServerKey::", stringify!($server_key_method)),
+              concat!("shortint::", stringify!($server_key_method)),
               stringify!($name),
               |server_key, lhs, rhs| {
                 let _ = server_key.$server_key_method(lhs, rhs);},
@@ -366,7 +366,7 @@ macro_rules! define_server_key_scalar_bench_fn (
       fn $server_key_method(c: &mut Criterion) {
           bench_server_key_binary_scalar_function(
               c,
-              concat!("ServerKey::", stringify!($server_key_method)),
+              concat!("shortint::", stringify!($server_key_method)),
               stringify!($name),
               |server_key, lhs, rhs| {
                 let _ = server_key.$server_key_method(lhs, rhs);},
@@ -380,7 +380,7 @@ macro_rules! define_server_key_scalar_div_bench_fn (
       fn $server_key_method(c: &mut Criterion) {
           bench_server_key_binary_scalar_division_function(
               c,
-              concat!("ServerKey::", stringify!($server_key_method)),
+              concat!("shortint::", stringify!($server_key_method)),
               stringify!($name),
               |server_key, lhs, rhs| {
                 let _ = server_key.$server_key_method(lhs, rhs);},


### PR DESCRIPTION
Scalar operations benchmark is done against scalar bit sizes.
Scalar division and modulo are added to the benchmark set.