### PR TITLE
fix(shortint): Ciphertext::copy_from

### DIFF
--- a/tfhe/src/integer/server_key/radix_parallel/add.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/add.rs
@@ -346,7 +346,7 @@ impl ServerKey {
                     )
                 });
             for i in space..num_blocks {
-                generates_or_propagates[i].copy_from(&step_output[i]);
+                generates_or_propagates[i].clone_from(&step_output[i]);
             }
 
             space *= 2;

--- a/tfhe/src/integer/server_key/radix_parallel/div_mod.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/div_mod.rs
@@ -156,7 +156,7 @@ impl ServerKey {
                         .iter_mut()
                         .zip(interesting_remainder.blocks.iter())
                         .for_each(|(remainder_block, new_value)| {
-                            remainder_block.copy_from(new_value);
+                            remainder_block.clone_from(new_value);
                         });
                 },
                 || {

--- a/tfhe/src/integer/server_key/radix_parallel/shift.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/shift.rs
@@ -417,8 +417,8 @@ impl ServerKey {
 
         for (d, shift_bit) in shift_bits.iter().enumerate() {
             for i in 0..total_nb_bits as usize {
-                input_bits_b[i].copy_from(&input_bits_a[i]);
-                mux_inputs[i].copy_from(shift_bit);
+                input_bits_b[i].clone_from(&input_bits_a[i]);
+                mux_inputs[i].clone_from(shift_bit);
             }
 
             match operation {
@@ -476,7 +476,7 @@ impl ServerKey {
                     //
                     // control_bit|b|a
                     self.key.apply_lookup_table_assign(mux_gate_input, &mux_lut);
-                    (*a_ptr).copy_from(mux_gate_input);
+                    (*a_ptr).clone_from(mux_gate_input);
                 }
             });
         }


### PR DESCRIPTION
### PR content/description

Ciphertext::copy_from did not copy the degree
resulting in potential bad results for some operations.

This fixes it, and rewrites to use destructuring
in order to prevent such thing from happenning again
(with destructuring, if a member is not destructured,
a compile error is emited)

Also we move the implementation of copy_from into
clone_from.

Fixes https://github.com/zama-ai/tfhe-rs/issues/410

### Check-list:

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [x] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
