### PR TITLE
Scalar sub mul 256

### DIFF
--- a/tfhe/src/integer/server_key/radix/mod.rs
+++ b/tfhe/src/integer/server_key/radix/mod.rs
@@ -5,7 +5,7 @@ mod mul;
 mod neg;
 mod scalar_add;
 mod scalar_mul;
-mod scalar_sub;
+pub(super) mod scalar_sub;
 mod shift;
 mod sub;
 

--- a/tfhe/src/integer/server_key/radix/mod.rs
+++ b/tfhe/src/integer/server_key/radix/mod.rs
@@ -4,7 +4,7 @@ mod comparison;
 mod mul;
 mod neg;
 mod scalar_add;
-mod scalar_mul;
+pub(super) mod scalar_mul;
 pub(super) mod scalar_sub;
 mod shift;
 mod sub;

--- a/tfhe/src/integer/server_key/radix/scalar_mul.rs
+++ b/tfhe/src/integer/server_key/radix/scalar_mul.rs
@@ -1,10 +1,39 @@
-use crate::core_crypto::prelude::UnsignedInteger;
+use crate::core_crypto::prelude::{Numeric, UnsignedInteger};
 use crate::integer::block_decomposition::{BlockDecomposer, DecomposableInto};
 use crate::integer::ciphertext::RadixCiphertext;
 use crate::integer::server_key::CheckError;
 use crate::integer::server_key::CheckError::CarryFull;
-use crate::integer::ServerKey;
+use crate::integer::{ServerKey, U256};
 use std::collections::BTreeMap;
+
+pub trait ScalarMultiplier: Numeric {
+    fn is_power_of_two(self) -> bool;
+
+    fn ilog2(self) -> u32;
+}
+
+impl<T> ScalarMultiplier for T
+where
+    T: UnsignedInteger,
+{
+    fn is_power_of_two(self) -> bool {
+        self.is_power_of_two()
+    }
+
+    fn ilog2(self) -> u32 {
+        self.ilog2()
+    }
+}
+
+impl ScalarMultiplier for U256 {
+    fn is_power_of_two(self) -> bool {
+        self.is_power_of_two()
+    }
+
+    fn ilog2(self) -> u32 {
+        self.ilog2()
+    }
+}
 
 impl ServerKey {
     /// Computes homomorphically a multiplication between a scalar and a ciphertext.
@@ -321,7 +350,7 @@ impl ServerKey {
     /// ```
     pub fn smart_scalar_mul<T>(&self, ctxt: &mut RadixCiphertext, scalar: T) -> RadixCiphertext
     where
-        T: UnsignedInteger + DecomposableInto<u8>,
+        T: ScalarMultiplier + DecomposableInto<u8>,
     {
         if scalar == T::ZERO {
             return self.create_trivial_zero_radix(ctxt.blocks.len());
@@ -372,7 +401,7 @@ impl ServerKey {
 
     pub fn smart_scalar_mul_assign<T>(&self, ctxt: &mut RadixCiphertext, scalar: T)
     where
-        T: UnsignedInteger + DecomposableInto<u8>,
+        T: ScalarMultiplier + DecomposableInto<u8>,
     {
         *ctxt = self.smart_scalar_mul(ctxt, scalar);
     }

--- a/tfhe/src/integer/server_key/radix_parallel/scalar_mul.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/scalar_mul.rs
@@ -1,6 +1,6 @@
-use crate::core_crypto::prelude::UnsignedInteger;
 use crate::integer::block_decomposition::{BlockDecomposer, DecomposableInto};
 use crate::integer::ciphertext::RadixCiphertext;
+use crate::integer::server_key::radix::scalar_mul::ScalarMultiplier;
 use crate::integer::server_key::CheckError;
 use crate::integer::server_key::CheckError::CarryFull;
 use crate::integer::ServerKey;
@@ -327,7 +327,7 @@ impl ServerKey {
         scalar: T,
     ) -> RadixCiphertext
     where
-        T: UnsignedInteger + DecomposableInto<u8>,
+        T: ScalarMultiplier + DecomposableInto<u8>,
     {
         let mut ct_res = ct.clone();
         self.unchecked_scalar_mul_assign_parallelized(&mut ct_res, scalar);
@@ -336,7 +336,7 @@ impl ServerKey {
 
     pub fn unchecked_scalar_mul_assign_parallelized<T>(&self, lhs: &mut RadixCiphertext, scalar: T)
     where
-        T: UnsignedInteger + DecomposableInto<u8>,
+        T: ScalarMultiplier + DecomposableInto<u8>,
     {
         if scalar == T::ZERO || lhs.blocks.is_empty() {
             for block in &mut lhs.blocks {
@@ -467,7 +467,7 @@ impl ServerKey {
         scalar: T,
     ) -> RadixCiphertext
     where
-        T: UnsignedInteger + DecomposableInto<u8>,
+        T: ScalarMultiplier + DecomposableInto<u8>,
     {
         if !lhs.block_carries_are_empty() {
             self.full_propagate_parallelized(lhs);
@@ -478,7 +478,7 @@ impl ServerKey {
 
     pub fn smart_scalar_mul_assign_parallelized<T>(&self, lhs: &mut RadixCiphertext, scalar: T)
     where
-        T: UnsignedInteger + DecomposableInto<u8>,
+        T: ScalarMultiplier + DecomposableInto<u8>,
     {
         if !lhs.block_carries_are_empty() {
             self.full_propagate_parallelized(lhs);
@@ -523,7 +523,7 @@ impl ServerKey {
     /// ```
     pub fn scalar_mul_parallelized<T>(&self, ct: &RadixCiphertext, scalar: T) -> RadixCiphertext
     where
-        T: UnsignedInteger + DecomposableInto<u8>,
+        T: ScalarMultiplier + DecomposableInto<u8>,
     {
         let mut ct_res = ct.clone();
         self.scalar_mul_assign_parallelized(&mut ct_res, scalar);
@@ -532,7 +532,7 @@ impl ServerKey {
 
     pub fn scalar_mul_assign_parallelized<T>(&self, lhs: &mut RadixCiphertext, scalar: T)
     where
-        T: UnsignedInteger + DecomposableInto<u8>,
+        T: ScalarMultiplier + DecomposableInto<u8>,
     {
         if !lhs.block_carries_are_empty() {
             self.full_propagate_parallelized(lhs);

--- a/tfhe/src/integer/server_key/radix_parallel/scalar_sub.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/scalar_sub.rs
@@ -1,6 +1,6 @@
-use crate::core_crypto::prelude::UnsignedInteger;
 use crate::integer::block_decomposition::DecomposableInto;
 use crate::integer::ciphertext::RadixCiphertext;
+use crate::integer::server_key::radix::scalar_sub::TwosComplementNegation;
 use crate::integer::ServerKey;
 
 impl ServerKey {
@@ -34,7 +34,7 @@ impl ServerKey {
         scalar: T,
     ) -> RadixCiphertext
     where
-        T: UnsignedInteger + DecomposableInto<u8>,
+        T: TwosComplementNegation + DecomposableInto<u8>,
     {
         if !self.is_scalar_sub_possible(ct, scalar) {
             self.full_propagate_parallelized(ct);
@@ -44,7 +44,7 @@ impl ServerKey {
 
     pub fn smart_scalar_sub_assign_parallelized<T>(&self, ct: &mut RadixCiphertext, scalar: T)
     where
-        T: UnsignedInteger + DecomposableInto<u8>,
+        T: TwosComplementNegation + DecomposableInto<u8>,
     {
         if !self.is_scalar_sub_possible(ct, scalar) {
             self.full_propagate_parallelized(ct);
@@ -87,7 +87,7 @@ impl ServerKey {
     /// ```
     pub fn scalar_sub_parallelized<T>(&self, ct: &RadixCiphertext, scalar: T) -> RadixCiphertext
     where
-        T: UnsignedInteger + DecomposableInto<u8>,
+        T: TwosComplementNegation + DecomposableInto<u8>,
     {
         let mut ct_res = ct.clone();
         self.scalar_sub_assign_parallelized(&mut ct_res, scalar);
@@ -96,7 +96,7 @@ impl ServerKey {
 
     pub fn scalar_sub_assign_parallelized<T>(&self, ct: &mut RadixCiphertext, scalar: T)
     where
-        T: UnsignedInteger + DecomposableInto<u8>,
+        T: TwosComplementNegation + DecomposableInto<u8>,
     {
         if !ct.block_carries_are_empty() {
             self.full_propagate_parallelized(ct);


### PR DESCRIPTION
The scalar (T) in scalar_sub could be at most a u128
because the bounds were `T: UnsignedInteger` and our
U256 does not implement this trait yet.

To make scalar_sub accept a U256 we create
a smaller trait.

