### PR TITLE
fix(integer): remove incorrect bounds

### DIFF
--- a/tfhe/src/integer/server_key/radix_parallel/scalar_div_mod.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/scalar_div_mod.rs
@@ -289,7 +289,6 @@ impl ServerKey {
         divisor: T,
     ) -> (RadixCiphertext, RadixCiphertext)
     where
-        u64: From<T>,
         T: Reciprocable + ScalarMultiplier + DecomposableInto<u8>,
     {
         let quotient = self.unchecked_scalar_div_parallelized(numerator, divisor);
@@ -311,7 +310,6 @@ impl ServerKey {
         divisor: T,
     ) -> RadixCiphertext
     where
-        u64: From<T>,
         T: Reciprocable + ScalarMultiplier + DecomposableInto<u8>,
     {
         if MiniUnsignedInteger::is_power_of_two(divisor) {
@@ -328,7 +326,6 @@ impl ServerKey {
         numerator: &mut RadixCiphertext,
         divisor: T,
     ) where
-        u64: From<T>,
         T: Reciprocable + DecomposableInto<u8>,
     {
         if !numerator.block_carries_are_empty() {
@@ -343,7 +340,6 @@ impl ServerKey {
         numerator: &mut RadixCiphertext,
         divisor: T,
     ) where
-        u64: From<T>,
         T: Reciprocable + ScalarMultiplier + DecomposableInto<u8>,
     {
         if !numerator.block_carries_are_empty() {
@@ -359,7 +355,6 @@ impl ServerKey {
         divisor: T,
     ) -> RadixCiphertext
     where
-        u64: From<T>,
         T: Reciprocable + DecomposableInto<u8>,
     {
         if !numerator.block_carries_are_empty() {
@@ -375,7 +370,6 @@ impl ServerKey {
         divisor: T,
     ) -> RadixCiphertext
     where
-        u64: From<T>,
         T: Reciprocable + ScalarMultiplier + DecomposableInto<u8>,
     {
         if !numerator.block_carries_are_empty() {
@@ -391,7 +385,6 @@ impl ServerKey {
         divisor: T,
     ) -> (RadixCiphertext, RadixCiphertext)
     where
-        u64: From<T>,
         T: Reciprocable + ScalarMultiplier + DecomposableInto<u8>,
     {
         if !numerator.block_carries_are_empty() {
@@ -403,7 +396,6 @@ impl ServerKey {
 
     pub fn scalar_div_assign_parallelized<T>(&self, numerator: &mut RadixCiphertext, divisor: T)
     where
-        u64: From<T>,
         T: Reciprocable + DecomposableInto<u8>,
     {
         if !numerator.block_carries_are_empty() {
@@ -415,7 +407,6 @@ impl ServerKey {
 
     pub fn scalar_rem_assign_parallelized<T>(&self, numerator: &mut RadixCiphertext, divisor: T)
     where
-        u64: From<T>,
         T: Reciprocable + ScalarMultiplier + DecomposableInto<u8>,
     {
         if !numerator.block_carries_are_empty() {
@@ -463,7 +454,6 @@ impl ServerKey {
         divisor: T,
     ) -> RadixCiphertext
     where
-        u64: From<T>,
         T: Reciprocable + DecomposableInto<u8>,
     {
         let mut result = numerator.clone();
@@ -509,7 +499,6 @@ impl ServerKey {
         divisor: T,
     ) -> RadixCiphertext
     where
-        u64: From<T>,
         T: Reciprocable + ScalarMultiplier + DecomposableInto<u8>,
     {
         let mut result = numerator.clone();
@@ -552,7 +541,6 @@ impl ServerKey {
         divisor: T,
     ) -> (RadixCiphertext, RadixCiphertext)
     where
-        u64: From<T>,
         T: Reciprocable + ScalarMultiplier + DecomposableInto<u8>,
     {
         if !numerator.block_carries_are_empty() {


### PR DESCRIPTION
### PR content/description

In 35c6aea84b7ee89e0ded748fe4f822d9e3a10a13 the bounds for the scalar_div family of functions were changed.

However, the a few bounds `u64: From<T>` were
not removed meaning the functions which still
had these were still stuck with u64 as the max scalar value.


