### PR TITLE
feat(hlapi): allow scalar ops on values up to U256 

### DIFF
--- a/tfhe/src/c_api/high_level_api/integers.rs
+++ b/tfhe/src/c_api/high_level_api/integers.rs
@@ -104,6 +104,8 @@ macro_rules! impl_operations_for_integer_type {
             ) -> c_int {
                 $crate::c_api::utils::catch_panic(|| {
                     let lhs = $crate::c_api::utils::get_ref_checked(lhs).unwrap();
+                    let rhs = <$clear_scalar_type as $crate::c_api::high_level_api::utils::ToRustScalarType
+                        >::to_rust_scalar_type(rhs);
 
                     let (q, r) = (&lhs.0).div_rem(rhs);
 
@@ -230,8 +232,8 @@ create_integer_wrapper_type!(name: FheUint14, clear_scalar_type: u16);
 create_integer_wrapper_type!(name: FheUint16, clear_scalar_type: u16);
 create_integer_wrapper_type!(name: FheUint32, clear_scalar_type: u32);
 create_integer_wrapper_type!(name: FheUint64, clear_scalar_type: u64);
-create_integer_wrapper_type!(name: FheUint128, clear_scalar_type: u64);
-create_integer_wrapper_type!(name: FheUint256, clear_scalar_type: u64);
+create_integer_wrapper_type!(name: FheUint128, clear_scalar_type: U128);
+create_integer_wrapper_type!(name: FheUint256, clear_scalar_type: U256);
 
 impl_decrypt_on_type!(FheUint8, u8);
 impl_try_encrypt_trivial_on_type!(FheUint8{crate::high_level_api::FheUint8}, u8);


### PR DESCRIPTION
### PR content/description

This enables to use u128 and U256 as operands to
operations in the high level api.

BREAKING CHANGE: a breaking change in the C API for scalar operations
for FheUint128 and FheUint256 as they previously required
a u64 and now a U218 / U256 respectively.


### Check-list:

* [x] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
