### PR TITLE
chore(ci): change full suite benchmarks worflow description

### DIFF
--- a/.github/workflows/start_full_benchmarks.yml
+++ b/.github/workflows/start_full_benchmarks.yml
@@ -1,5 +1,5 @@
-# Start all benchmark jobs on Slab CI bot.
-name: Start all benchmarks
+# Start all benchmark jobs, including full shortint and integer, on Slab CI bot.
+name: Start full suite benchmarks
 
 on:
   schedule:


### PR DESCRIPTION
This is done to avoid having the same name than the other full benchmarks workflow.