### PR TITLE
chore(ci): ignore tfhe_lib_parameters check in lattice esitmator

### DIFF
--- a/ci/lattice_estimator.sage
+++ b/ci/lattice_estimator.sage
@@ -27,6 +27,10 @@ def check_security(filename):
     to_update = []
 
     for param in all_params:
+        if param.tag.startswith("TFHE_LIB_PARAMETERS"):
+            # This third-party parameters set is known to be less secure, just skip the analysis.
+            continue
+
         print(f"\t{param.tag}...\t", end= "")
 
         try:


### PR DESCRIPTION
This third-party parameters set is known to be insecure, so there is no need to make the CI fail because of this set.