### PR TITLE
fix(integer): add assert on scalar bits in scalar_div

### DIFF
--- a/tfhe/src/integer/server_key/radix_parallel/scalar_div_mod.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/scalar_div_mod.rs
@@ -220,6 +220,15 @@ impl ServerKey {
         // Rust has a check on all division, so we shall also have one
         assert_ne!(divisor, T::ZERO, "Cannot divide by zero");
 
+        assert!(
+            T::BITS >= numerator_bits as usize,
+            "The scalar divisor type must have a number of bits that is \
+            >= to the number of bits encrypted in the ciphertext: \n\
+            encrypted bits: {numerator_bits}, scalar bits: {}
+            ",
+            T::BITS
+        );
+
         if divisor.is_power_of_two() {
             // Even in FHE, shifting is faster than multiplying / dividing
             return self

--- a/tfhe/src/integer/server_key/radix_parallel/tests_unsigned.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_unsigned.rs
@@ -2135,7 +2135,7 @@ where
     // hard-coded tests
     // 10, 7, 14 are from the paper and should trigger different branches
     // 16 is a power of two and should trigger the corresponding branch
-    let hard_coded_divisors: [u32; 4] = [10, 7, 14, 16];
+    let hard_coded_divisors: [u64; 4] = [10, 7, 14, 16];
     for divisor in hard_coded_divisors {
         let clear = rng.gen::<u64>() % modulus;
         let ct = cks.encrypt(clear);
@@ -2144,13 +2144,13 @@ where
 
         let q_res: u64 = cks.decrypt(&q);
         let r_res: u64 = cks.decrypt(&r);
-        assert_eq!(q_res, clear / divisor as u64);
-        assert_eq!(r_res, clear % divisor as u64);
+        assert_eq!(q_res, clear / divisor);
+        assert_eq!(r_res, clear % divisor);
     }
 
     for _ in 0..NB_TEST {
         let clear = rng.gen::<u64>() % modulus;
-        let scalar = rng.gen_range(1u32..=u32::MAX);
+        let scalar = rng.gen_range(1u32..=u32::MAX) as u64;
 
         let ct = cks.encrypt(clear);
 
@@ -2164,8 +2164,8 @@ where
 
             let q_res: u64 = cks.decrypt(&q);
             let r_res: u64 = cks.decrypt(&r);
-            assert_eq!(q_res, clear / scalar as u64);
-            assert_eq!(r_res, clear % scalar as u64);
+            assert_eq!(q_res, clear / scalar);
+            assert_eq!(r_res, clear % scalar);
         }
 
         {


### PR DESCRIPTION
### PR content/description

To work the scalar div requires that the scalar type (u32, u64, etc) has at least as many bits of precision that what the ciphertext encrypts (e.g. if the ciphertext encrypt 32bits, the scalar type must have at least 32 bits)

We were missing the assert which lead to misuse, so we add it.



