### PR TITLE
feat(integer): improve scalar_mul

### DIFF
--- a/tfhe/src/integer/server_key/radix_parallel/scalar_comparison.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/scalar_comparison.rs
@@ -270,7 +270,7 @@ impl ServerKey {
         //
         // If all blocks were 0, the sum will be zero
         // If at least one bock was not zero, the sum won't be zero
-        let num_additions_to_fill_carry = (total_modulus - message_max) / message_max;
+        let num_elements_to_fill_carry = (total_modulus - 1) / message_max;
         let is_equal_to_zero = self.key.generate_lookup_table(|x| {
             if matches!(comparison_type, ZeroComparisonType::Equality) {
                 u64::from((x % total_modulus as u64) == 0)
@@ -279,7 +279,7 @@ impl ServerKey {
             }
         });
 
-        lhs.par_chunks(num_additions_to_fill_carry)
+        lhs.par_chunks(num_elements_to_fill_carry)
             .map(|chunk| {
                 let mut sum = chunk[0].clone();
                 for other_block in &chunk[1..] {


### PR DESCRIPTION
### PR content/description


This changes the algorithm for scalar_mul.
The new algorithm allows to remove a lot of work.

For small precisions (16, 32, 64) the gains are in range 5%-10% for higher precisions the gains are 25%-50%.

This also changes the mul to use the functions that sums many clean ciphertexts in parallel. For mul, there is only a 5%-10% improvements for 128bits and 256bits mul.

