### PR TITLE
feat(integer): be smarter about parallel carry propagation usage

### DIFF
--- a/tfhe/src/integer/server_key/radix_parallel/mod.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/mod.rs
@@ -78,10 +78,7 @@ impl ServerKey {
     where
         T: IntegerRadixCiphertext,
     {
-        // The fully parallelized way introduces more work
-        // and so is slower for low number of blocks
-        const MIN_NUM_BLOCKS: usize = 6;
-        if self.is_eligible_for_parallel_carryless_add() && ctxt.blocks().len() >= MIN_NUM_BLOCKS {
+        if self.is_eligible_for_parallel_single_carry_propagation(ctxt) {
             let num_blocks = ctxt.blocks().len();
 
             let (mut message_blocks, carry_blocks) = rayon::join(

--- a/tfhe/src/integer/server_key/radix_parallel/neg.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/neg.rs
@@ -81,7 +81,7 @@ impl ServerKey {
             ctxt
         };
 
-        if self.is_eligible_for_parallel_carryless_add() {
+        if self.is_eligible_for_parallel_single_carry_propagation(ct) {
             let mut ct = self.unchecked_neg(ct);
             self.propagate_single_carry_parallelized_low_latency(&mut ct);
             ct

--- a/tfhe/src/integer/server_key/radix_parallel/scalar_add.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/scalar_add.rs
@@ -166,7 +166,7 @@ impl ServerKey {
             self.full_propagate_parallelized(ct);
         };
 
-        if self.is_eligible_for_parallel_carryless_add() {
+        if self.is_eligible_for_parallel_single_carry_propagation(ct) {
             self.unchecked_scalar_add_assign(ct, scalar);
             self.propagate_single_carry_parallelized_low_latency(ct);
         } else {

--- a/tfhe/src/integer/server_key/radix_parallel/scalar_sub.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/scalar_sub.rs
@@ -104,7 +104,7 @@ impl ServerKey {
 
         self.unchecked_scalar_sub_assign(ct, scalar);
 
-        if self.is_eligible_for_parallel_carryless_add() {
+        if self.is_eligible_for_parallel_single_carry_propagation(ct) {
             self.propagate_single_carry_parallelized_low_latency(ct);
         } else {
             self.full_propagate_parallelized(ct);

--- a/tfhe/src/integer/server_key/radix_parallel/sub.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/sub.rs
@@ -210,7 +210,7 @@ impl ServerKey {
             }
         };
 
-        if self.is_eligible_for_parallel_carryless_add() {
+        if self.is_eligible_for_parallel_single_carry_propagation(lhs) {
             let neg = self.unchecked_neg(rhs);
             self.unchecked_add_assign_parallelized_low_latency(lhs, &neg);
         } else {


### PR DESCRIPTION
The parallel carry propagation algorithm is a lot faster than the non parallel one, however to actually be faster it requires the CPU to have enough threads.

This adds checks so that we use the parallel algorithm only if this condition is met.

This should improve performance on smaller CPUs
typically found in standard laptops/desktops.


