### PR TITLE
chore(c_api): mark some functions manipulating pointers as unsafe

### DIFF
--- a/tfhe/src/c_api/utils.rs
+++ b/tfhe/src/c_api/utils.rs
@@ -25,22 +25,49 @@ pub fn check_ptr_is_non_null_and_aligned<T>(ptr: *const T) -> Result<(), String>
     Ok(())
 }
 
-pub fn get_mut_checked<'a, T>(ptr: *mut T) -> Result<&'a mut T, String> {
+/// Get a mutable reference from a pointer checking the pointer is well aligned for the given type.
+///
+/// # Safety
+///
+/// Caller of this function needs to make sure the pointer type corresponds to the data type being
+/// pointed to.
+///
+/// Caller of this function needs to make sure the aliasing rules for mutable reference are
+/// respected.
+///
+/// The basics are: at any time only a single mutable reference may exist to a given memory location
+/// XOR any number of immutable reference may exist to a given memory location.
+///
+/// Failure to abide by the above rules will result in undefined behavior (UB).
+pub(super) unsafe fn get_mut_checked<'a, T>(ptr: *mut T) -> Result<&'a mut T, String> {
     match check_ptr_is_non_null_and_aligned(ptr) {
-        Ok(()) => unsafe {
-            ptr.as_mut()
-                .ok_or_else(|| "Error while converting to mut reference".into())
-        },
+        Ok(()) => ptr
+            .as_mut()
+            .ok_or_else(|| "Error while converting to mut reference".into()),
         Err(e) => Err(e),
     }
 }
 
-pub fn get_ref_checked<'a, T>(ptr: *const T) -> Result<&'a T, String> {
+/// Get an immutable reference from a pointer checking the pointer is well aligned for the given
+/// type.
+///
+/// # Safety
+///
+/// Caller of this function needs to make sure the pointer type corresponds to the data type being
+/// pointed to.
+///
+/// Caller of this function needs to make sure the aliasing rules for immutable reference are
+/// respected.
+///
+/// The basics are: at any time only a single mutable reference may exist to a given memory location
+/// XOR any number of immutable reference may exist to a given memory location.
+///
+/// Failure to abide by the above rules will result in undefined behavior (UB).
+pub(super) unsafe fn get_ref_checked<'a, T>(ptr: *const T) -> Result<&'a T, String> {
     match check_ptr_is_non_null_and_aligned(ptr) {
-        Ok(()) => unsafe {
-            ptr.as_ref()
-                .ok_or_else(|| "Error while converting to reference".into())
-        },
+        Ok(()) => ptr
+            .as_ref()
+            .ok_or_else(|| "Error while converting to reference".into()),
         Err(e) => Err(e),
     }
 }


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: https://github.com/zama-ai/tfhe-rs/issues/526

### PR content/description

chore(c_api): mark some functions manipulating pointers as unsafe

- restrict visibility to the c_api

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [x] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
