### PR TITLE
shortint/small optim

### DIFF
--- a/tfhe/docs/fine_grained_api/shortint/operations.md
+++ b/tfhe/docs/fine_grained_api/shortint/operations.md
@@ -367,14 +367,14 @@ fn main() {
     let modulus = client_key.parameters.message_modulus().0 as u64;
 
     // We use the private client key to encrypt two messages:
-    let ct_1 = client_key.encrypt(msg1);
+    let mut ct_1 = client_key.encrypt(msg1);
     let mut ct_2 = client_key.encrypt(msg2);
 
     // Compute the lookup table for the bivariate functions
     let acc = server_key.generate_lookup_table_bivariate(|x,y| (x.count_ones()
         + y.count_ones()) as u64 % modulus );
 
-    let ct_res = server_key.smart_apply_lookup_table_bivariate(&ct_1, &mut ct_2, &acc);
+    let ct_res = server_key.smart_apply_lookup_table_bivariate(&mut ct_1, &mut ct_2, &acc);
 
     // We use the client key to decrypt the output of the circuit:
     let output = client_key.decrypt(&ct_res);

--- a/tfhe/src/c_api/shortint/server_key/pbs.rs
+++ b/tfhe/src/c_api/shortint/server_key/pbs.rs
@@ -119,7 +119,7 @@ pub unsafe extern "C" fn shortint_server_key_generate_bivariate_pbs_lookup_table
 pub unsafe extern "C" fn shortint_server_key_bivariate_programmable_bootstrap(
     server_key: *const ShortintServerKey,
     lookup_table: *const ShortintBivariatePBSLookupTable,
-    ct_left: *const ShortintCiphertext,
+    ct_left: *mut ShortintCiphertext,
     ct_right: *mut ShortintCiphertext,
     result: *mut *mut ShortintCiphertext,
 ) -> c_int {
@@ -132,14 +132,14 @@ pub unsafe extern "C" fn shortint_server_key_bivariate_programmable_bootstrap(
 
         let server_key = get_ref_checked(server_key).unwrap();
         let lookup_table = get_ref_checked(lookup_table).unwrap();
-        let ct_left = get_ref_checked(ct_left).unwrap();
+        let ct_left = get_mut_checked(ct_left).unwrap();
         let ct_right = get_mut_checked(ct_right).unwrap();
 
         let res = crate::shortint::engine::ShortintEngine::with_thread_local_mut(|engine| {
             engine
                 .smart_apply_lookup_table_bivariate(
                     &server_key.0,
-                    &ct_left.0,
+                    &mut ct_left.0,
                     &mut ct_right.0,
                     &lookup_table.0,
                 )

--- a/tfhe/src/integer/client_key/crt.rs
+++ b/tfhe/src/integer/client_key/crt.rs
@@ -12,10 +12,10 @@ use serde::{Deserialize, Serialize};
 ///
 /// ```rust
 /// use tfhe::integer::CrtClientKey;
-/// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+/// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
 ///
 /// let basis = vec![2, 3, 5];
-/// let cks = CrtClientKey::new(PARAM_MESSAGE_2_CARRY_2_KS_PBS, basis);
+/// let cks = CrtClientKey::new(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
 ///
 /// let msg = 13_u64;
 ///

--- a/tfhe/src/integer/server_key/crt/add_crt.rs
+++ b/tfhe/src/integer/server_key/crt/add_crt.rs
@@ -7,10 +7,10 @@ impl ServerKey {
     ///
     ///```rust
     /// use tfhe::integer::gen_keys;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 14;

--- a/tfhe/src/integer/server_key/crt/add_crt.rs
+++ b/tfhe/src/integer/server_key/crt/add_crt.rs
@@ -15,6 +15,7 @@ impl ServerKey {
     /// let clear_1 = 14;
     /// let clear_2 = 14;
     /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
     /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
     /// let mut ctxt_2 = cks.encrypt_crt(clear_2, basis);
@@ -23,7 +24,7 @@ impl ServerKey {
     ///
     /// // Decrypt
     /// let res = cks.decrypt_crt(&ctxt_1);
-    /// assert_eq!((clear_1 + clear_2) % 30, res);
+    /// assert_eq!((clear_1 + clear_2) % modulus, res);
     /// ```
     pub fn smart_crt_add(
         &self,

--- a/tfhe/src/integer/server_key/crt/mod.rs
+++ b/tfhe/src/integer/server_key/crt/mod.rs
@@ -19,10 +19,10 @@ impl ServerKey {
     ///
     ///```rust
     /// use tfhe::integer::gen_keys;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 14;
@@ -58,12 +58,12 @@ impl ServerKey {
     ///
     /// ```rust
     /// use tfhe::integer::gen_keys_crt;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
     /// let basis = vec![2, 3, 5];
     /// let modulus: u64 = basis.iter().product();
-    /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_2_CARRY_2_KS_PBS, basis);
+    /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
     ///
     /// let clear_1 = 28;
     ///

--- a/tfhe/src/integer/server_key/crt/mod.rs
+++ b/tfhe/src/integer/server_key/crt/mod.rs
@@ -27,6 +27,7 @@ impl ServerKey {
     /// let clear_1 = 14;
     /// let clear_2 = 14;
     /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
     /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
     /// let ctxt_2 = cks.encrypt_crt(clear_2, basis);
@@ -38,7 +39,7 @@ impl ServerKey {
     ///
     /// // Decrypt
     /// let res = cks.decrypt_crt(&ctxt_1);
-    /// assert_eq!((clear_1 + clear_2) % 30, res);
+    /// assert_eq!((clear_1 + clear_2) % modulus, res);
     /// ```
     pub fn full_extract_message_assign(&self, ctxt: &mut CrtCiphertext) {
         for ct_i in ctxt.blocks.iter_mut() {
@@ -61,6 +62,7 @@ impl ServerKey {
     ///
     /// // Generate the client key and the server key:
     /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
     /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_2_CARRY_2_KS_PBS, basis);
     ///
     /// let clear_1 = 28;
@@ -72,7 +74,7 @@ impl ServerKey {
     ///
     /// // Decrypt
     /// let res = cks.decrypt(&ctxt_1);
-    /// assert_eq!((clear_1 * clear_1 * clear_1) % 30, res);
+    /// assert_eq!((clear_1 * clear_1 * clear_1) % modulus, res);
     /// ```
     pub fn pbs_crt_compliant_function_assign<F>(&self, ct1: &mut CrtCiphertext, f: F)
     where

--- a/tfhe/src/integer/server_key/crt/mul_crt.rs
+++ b/tfhe/src/integer/server_key/crt/mul_crt.rs
@@ -16,6 +16,7 @@ impl ServerKey {
     /// let clear_1 = 29;
     /// let clear_2 = 23;
     /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
     /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
     /// let ctxt_2 = cks.encrypt_crt(clear_2, basis);
@@ -24,7 +25,7 @@ impl ServerKey {
     /// sks.unchecked_crt_mul_assign(&mut ctxt_1, &ctxt_2);
     /// // Decrypt
     /// let res = cks.decrypt_crt(&ctxt_1);
-    /// assert_eq!((clear_1 * clear_2) % 30, res);
+    /// assert_eq!((clear_1 * clear_2) % modulus, res);
     /// ```
     pub fn unchecked_crt_mul_assign(&self, ct_left: &mut CrtCiphertext, ct_right: &CrtCiphertext) {
         for (ct_left, ct_right) in ct_left.blocks.iter_mut().zip(ct_right.blocks.iter()) {
@@ -59,6 +60,7 @@ impl ServerKey {
     /// let clear_1 = 29;
     /// let clear_2 = 29;
     /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
     /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
     /// let mut ctxt_2 = cks.encrypt_crt(clear_2, basis);
@@ -68,7 +70,7 @@ impl ServerKey {
     ///
     /// // Decrypt
     /// let res = cks.decrypt_crt(&ctxt_1);
-    /// assert_eq!((clear_1 * clear_2) % 30, res);
+    /// assert_eq!((clear_1 * clear_2) % modulus, res);
     /// ```
     pub fn smart_crt_mul_assign(&self, ct_left: &mut CrtCiphertext, ct_right: &mut CrtCiphertext) {
         for (block_left, block_right) in ct_left.blocks.iter_mut().zip(ct_right.blocks.iter_mut()) {

--- a/tfhe/src/integer/server_key/crt/neg_crt.rs
+++ b/tfhe/src/integer/server_key/crt/neg_crt.rs
@@ -11,10 +11,10 @@ impl ServerKey {
     ///
     ///```rust
     /// use tfhe::integer::gen_keys;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
     ///
     /// let clear = 14_u64;
     /// let basis = vec![2, 3, 5];
@@ -53,10 +53,10 @@ impl ServerKey {
     ///
     ///```rust
     /// use tfhe::integer::gen_keys;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
     ///
     /// let clear = 14_u64;
     /// let basis = vec![2, 3, 5];

--- a/tfhe/src/integer/server_key/crt/scalar_add_crt.rs
+++ b/tfhe/src/integer/server_key/crt/scalar_add_crt.rs
@@ -14,10 +14,10 @@ impl ServerKey {
     ///
     ///```rust
     /// use tfhe::integer::gen_keys;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 14;
@@ -59,10 +59,10 @@ impl ServerKey {
     ///
     ///```rust
     /// use tfhe::integer::gen_keys;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 14;
@@ -96,10 +96,10 @@ impl ServerKey {
     /// ```rust
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use tfhe::integer::gen_keys;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 14;
@@ -153,10 +153,10 @@ impl ServerKey {
     ///
     ///```rust
     /// use tfhe::integer::gen_keys;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 14;
@@ -189,10 +189,10 @@ impl ServerKey {
     ///
     ///```rust
     /// use tfhe::integer::gen_keys;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 14;

--- a/tfhe/src/integer/server_key/crt/scalar_add_crt.rs
+++ b/tfhe/src/integer/server_key/crt/scalar_add_crt.rs
@@ -22,6 +22,7 @@ impl ServerKey {
     /// let clear_1 = 14;
     /// let clear_2 = 14;
     /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
     /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
     ///
@@ -29,7 +30,7 @@ impl ServerKey {
     ///
     /// // Decrypt
     /// let res = cks.decrypt_crt(&ctxt_1);
-    /// assert_eq!((clear_1 + clear_2) % 30, res);
+    /// assert_eq!((clear_1 + clear_2) % modulus, res);
     /// ```
     pub fn unchecked_crt_scalar_add(&self, ct: &CrtCiphertext, scalar: u64) -> CrtCiphertext {
         let mut result = ct.clone();
@@ -103,6 +104,7 @@ impl ServerKey {
     /// let clear_1 = 14;
     /// let clear_2 = 14;
     /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
     /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
     ///
@@ -110,7 +112,7 @@ impl ServerKey {
     ///
     /// // Decrypt
     /// let res = cks.decrypt_crt(&ctxt_1);
-    /// assert_eq!((clear_1 + clear_2) % 30, res);
+    /// assert_eq!((clear_1 + clear_2) % modulus, res);
     /// # Ok(())
     /// # }
     /// ```
@@ -159,6 +161,7 @@ impl ServerKey {
     /// let clear_1 = 14;
     /// let clear_2 = 14;
     /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
     /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
     ///
@@ -166,7 +169,7 @@ impl ServerKey {
     ///
     /// // Decrypt
     /// let res = cks.decrypt_crt(&ctxt);
-    /// assert_eq!((clear_1 + clear_2) % 30, res);
+    /// assert_eq!((clear_1 + clear_2) % modulus, res);
     /// ```
     pub fn smart_crt_scalar_add(&self, ct: &mut CrtCiphertext, scalar: u64) -> CrtCiphertext {
         if !self.is_crt_scalar_add_possible(ct, scalar) {
@@ -194,6 +197,7 @@ impl ServerKey {
     /// let clear_1 = 14;
     /// let clear_2 = 14;
     /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
     /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
     ///
@@ -201,7 +205,7 @@ impl ServerKey {
     ///
     /// // Decrypt
     /// let res = cks.decrypt_crt(&ctxt_1);
-    /// assert_eq!((clear_1 + clear_2) % 30, res);
+    /// assert_eq!((clear_1 + clear_2) % modulus, res);
     /// ```
     pub fn smart_crt_scalar_add_assign(&self, ct: &mut CrtCiphertext, scalar: u64) {
         if !self.is_crt_scalar_add_possible(ct, scalar) {

--- a/tfhe/src/integer/server_key/crt/scalar_mul_crt.rs
+++ b/tfhe/src/integer/server_key/crt/scalar_mul_crt.rs
@@ -14,10 +14,10 @@ impl ServerKey {
     ///
     ///```rust
     /// use tfhe::integer::gen_keys;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 2;
@@ -52,10 +52,10 @@ impl ServerKey {
     ///
     ///```rust
     /// use tfhe::integer::gen_keys;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 2;
@@ -89,10 +89,10 @@ impl ServerKey {
     /// ```rust
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use tfhe::integer::gen_keys;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 2;
@@ -148,7 +148,7 @@ impl ServerKey {
     /// Computes homomorphically a multiplication between a scalar and a ciphertext.
     ///
     /// `small` means the scalar value shall fit in a __shortint block__.
-    /// For example, if the parameters are PARAM_MESSAGE_2_CARRY_2_KS_PBS,
+    /// For example, if the parameters are PARAM_MESSAGE_3_CARRY_3_KS_PBS,
     /// the scalar should fit in 2 bits.
     ///
     /// The result is returned as a new ciphertext.
@@ -157,10 +157,10 @@ impl ServerKey {
     ///
     ///```rust
     /// use tfhe::integer::gen_keys;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 14;
@@ -185,7 +185,7 @@ impl ServerKey {
     /// Computes homomorphically a multiplication between a scalar and a ciphertext.
     ///
     /// `small` means the scalar shall value fit in a __shortint block__.
-    /// For example, if the parameters are PARAM_MESSAGE_2_CARRY_2_KS_PBS,
+    /// For example, if the parameters are PARAM_MESSAGE_3_CARRY_3_KS_PBS,
     /// the scalar should fit in 2 bits.
     ///
     /// The result is assigned to the input ciphertext
@@ -194,10 +194,10 @@ impl ServerKey {
     ///
     ///```rust
     /// use tfhe::integer::gen_keys;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 14;

--- a/tfhe/src/integer/server_key/crt/scalar_mul_crt.rs
+++ b/tfhe/src/integer/server_key/crt/scalar_mul_crt.rs
@@ -22,6 +22,7 @@ impl ServerKey {
     /// let clear_1 = 14;
     /// let clear_2 = 2;
     /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
     /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
     ///
@@ -29,7 +30,7 @@ impl ServerKey {
     ///
     /// // Decrypt
     /// let res = cks.decrypt_crt(&ctxt_1);
-    /// assert_eq!((clear_1 * clear_2) % 30, res);
+    /// assert_eq!((clear_1 * clear_2) % modulus, res);
     /// ```
     pub fn unchecked_crt_scalar_mul(&self, ctxt: &CrtCiphertext, scalar: u64) -> CrtCiphertext {
         let mut ct_result = ctxt.clone();
@@ -96,6 +97,7 @@ impl ServerKey {
     /// let clear_1 = 14;
     /// let clear_2 = 2;
     /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
     /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
     ///
@@ -103,7 +105,7 @@ impl ServerKey {
     ///
     /// // Decrypt
     /// let res = cks.decrypt_crt(&ctxt_1);
-    /// assert_eq!((clear_1 * clear_2) % 30, res);
+    /// assert_eq!((clear_1 * clear_2) % modulus, res);
     /// # Ok(())
     /// # }
     /// ```
@@ -163,6 +165,7 @@ impl ServerKey {
     /// let clear_1 = 14;
     /// let clear_2 = 14;
     /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
     /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
     ///
@@ -170,7 +173,7 @@ impl ServerKey {
     ///
     /// // Decrypt
     /// let res = cks.decrypt_crt(&ctxt);
-    /// assert_eq!((clear_1 * clear_2) % 30, res);
+    /// assert_eq!((clear_1 * clear_2) % modulus, res);
     /// ```
     pub fn smart_crt_scalar_mul(&self, ctxt: &mut CrtCiphertext, scalar: u64) -> CrtCiphertext {
         if !self.is_crt_scalar_mul_possible(ctxt, scalar) {
@@ -199,6 +202,7 @@ impl ServerKey {
     /// let clear_1 = 14;
     /// let clear_2 = 14;
     /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
     /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
     ///
@@ -206,7 +210,7 @@ impl ServerKey {
     ///
     /// // Decrypt
     /// let res = cks.decrypt_crt(&ctxt_1);
-    /// assert_eq!((clear_1 * clear_2) % 30, res);
+    /// assert_eq!((clear_1 * clear_2) % modulus, res);
     /// ```
     pub fn smart_crt_scalar_mul_assign(&self, ctxt: &mut CrtCiphertext, scalar: u64) {
         if !self.is_crt_small_scalar_mul_possible(ctxt, scalar) {

--- a/tfhe/src/integer/server_key/crt/scalar_sub_crt.rs
+++ b/tfhe/src/integer/server_key/crt/scalar_sub_crt.rs
@@ -14,10 +14,10 @@ impl ServerKey {
     ///
     ///```rust
     /// use tfhe::integer::gen_keys;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 7;
@@ -53,10 +53,10 @@ impl ServerKey {
     ///
     ///```rust
     /// use tfhe::integer::gen_keys;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 7;
@@ -91,10 +91,10 @@ impl ServerKey {
     /// ```rust
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use tfhe::integer::gen_keys;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 8;
@@ -133,10 +133,10 @@ impl ServerKey {
     /// ```rust
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use tfhe::integer::gen_keys;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 7;
@@ -172,10 +172,10 @@ impl ServerKey {
     ///
     ///```rust
     /// use tfhe::integer::gen_keys;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 7;

--- a/tfhe/src/integer/server_key/crt/scalar_sub_crt.rs
+++ b/tfhe/src/integer/server_key/crt/scalar_sub_crt.rs
@@ -22,6 +22,7 @@ impl ServerKey {
     /// let clear_1 = 14;
     /// let clear_2 = 7;
     /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
     /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
     ///
@@ -29,7 +30,7 @@ impl ServerKey {
     ///
     /// // Decrypt
     /// let res = cks.decrypt_crt(&ctxt_1);
-    /// assert_eq!((clear_1 - clear_2) % 30, res);
+    /// assert_eq!((clear_1 - clear_2) % modulus, res);
     /// ```
     pub fn unchecked_crt_scalar_sub(&self, ct: &CrtCiphertext, scalar: u64) -> CrtCiphertext {
         let mut result = ct.clone();
@@ -98,6 +99,7 @@ impl ServerKey {
     /// let clear_1 = 14;
     /// let clear_2 = 8;
     /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
     ///
     /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
     ///
@@ -105,7 +107,7 @@ impl ServerKey {
     ///
     /// // Decrypt:
     /// let dec = cks.decrypt_crt(&ct_res);
-    /// assert_eq!((clear_1 - clear_2) % 30, dec);
+    /// assert_eq!((clear_1 - clear_2) % modulus, dec);
     /// # Ok(())
     /// # }
     /// ```
@@ -139,6 +141,7 @@ impl ServerKey {
     /// let clear_1 = 14;
     /// let clear_2 = 7;
     /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
     ///
     /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
     ///
@@ -146,7 +149,7 @@ impl ServerKey {
     ///
     /// // Decrypt:
     /// let dec = cks.decrypt_crt(&ctxt_1);
-    /// assert_eq!((clear_1 - clear_2) % 30, dec);
+    /// assert_eq!((clear_1 - clear_2) % modulus, dec);
     /// # Ok(())
     /// # }
     /// ```
@@ -177,6 +180,7 @@ impl ServerKey {
     /// let clear_1 = 14;
     /// let clear_2 = 7;
     /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
     /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
     ///
@@ -184,7 +188,7 @@ impl ServerKey {
     ///
     /// // Decrypt
     /// let res = cks.decrypt_crt(&ctxt_1);
-    /// assert_eq!((clear_1 - clear_2) % 30, res);
+    /// assert_eq!((clear_1 - clear_2) % modulus, res);
     /// ```
     pub fn smart_crt_scalar_sub(&self, ct: &mut CrtCiphertext, scalar: u64) -> CrtCiphertext {
         if !self.is_crt_scalar_sub_possible(ct, scalar) {

--- a/tfhe/src/integer/server_key/crt/sub_crt.rs
+++ b/tfhe/src/integer/server_key/crt/sub_crt.rs
@@ -19,6 +19,7 @@ impl ServerKey {
     /// let clear_1 = 14;
     /// let clear_2 = 5;
     /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
     /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
     /// let mut ctxt_2 = cks.encrypt_crt(clear_2, basis.clone());
@@ -27,7 +28,7 @@ impl ServerKey {
     ///
     /// // Decrypt
     /// let res = cks.decrypt_crt(&ctxt);
-    /// assert_eq!((clear_1 - clear_2) % 30, res);
+    /// assert_eq!((clear_1 - clear_2) % modulus, res);
     /// ```
     pub fn unchecked_crt_sub(
         &self,
@@ -57,6 +58,7 @@ impl ServerKey {
     /// let clear_1 = 14;
     /// let clear_2 = 5;
     /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
     /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
     /// let mut ctxt_2 = cks.encrypt_crt(clear_2, basis.clone());
@@ -65,7 +67,7 @@ impl ServerKey {
     ///
     /// // Decrypt
     /// let res = cks.decrypt_crt(&ctxt);
-    /// assert_eq!((clear_1 - clear_2) % 30, res);
+    /// assert_eq!((clear_1 - clear_2) % modulus, res);
     /// ```
     pub fn unchecked_crt_sub_assign(
         &self,
@@ -90,6 +92,7 @@ impl ServerKey {
     /// let clear_1 = 14;
     /// let clear_2 = 5;
     /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
     /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
     /// let mut ctxt_2 = cks.encrypt_crt(clear_2, basis.clone());
@@ -98,7 +101,7 @@ impl ServerKey {
     ///
     /// // Decrypt
     /// let res = cks.decrypt_crt(&ctxt);
-    /// assert_eq!((clear_1 - clear_2) % 30, res);
+    /// assert_eq!((clear_1 - clear_2) % modulus, res);
     /// ```
     pub fn smart_crt_sub(
         &self,
@@ -131,6 +134,7 @@ impl ServerKey {
     /// let clear_1 = 14;
     /// let clear_2 = 5;
     /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
     /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
     /// let mut ctxt_2 = cks.encrypt_crt(clear_2, basis.clone());
@@ -139,7 +143,7 @@ impl ServerKey {
     ///
     /// // Decrypt
     /// let res = cks.decrypt_crt(&ctxt_1);
-    /// assert_eq!((clear_1 - clear_2) % 30, res);
+    /// assert_eq!((clear_1 - clear_2) % modulus, res);
     /// ```
     pub fn smart_crt_sub_assign(
         &self,

--- a/tfhe/src/integer/server_key/crt/sub_crt.rs
+++ b/tfhe/src/integer/server_key/crt/sub_crt.rs
@@ -11,10 +11,10 @@ impl ServerKey {
     ///
     ///```rust
     /// use tfhe::integer::gen_keys;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 5;
@@ -50,10 +50,10 @@ impl ServerKey {
     ///
     ///```rust
     /// use tfhe::integer::gen_keys;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 5;
@@ -84,10 +84,10 @@ impl ServerKey {
     ///
     ///```rust
     /// use tfhe::integer::gen_keys;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 5;
@@ -126,10 +126,10 @@ impl ServerKey {
     ///
     ///```rust
     /// use tfhe::integer::gen_keys;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 5;

--- a/tfhe/src/integer/server_key/crt_parallel/add_crt.rs
+++ b/tfhe/src/integer/server_key/crt_parallel/add_crt.rs
@@ -14,6 +14,7 @@ impl ServerKey {
     ///
     /// // Generate the client key and the server key:
     /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
     /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_2_CARRY_2_KS_PBS, basis);
     ///
     /// let clear_1 = 14;
@@ -28,7 +29,7 @@ impl ServerKey {
     ///
     /// // Decrypt
     /// let res = cks.decrypt(&ctxt_1);
-    /// assert_eq!((clear_1 + clear_2) % 30, res);
+    /// assert_eq!((clear_1 + clear_2) % modulus, res);
     /// ```
     pub fn unchecked_crt_add_assign_parallelized(
         &self,
@@ -69,6 +70,7 @@ impl ServerKey {
     ///
     /// // Generate the client key and the server key:
     /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
     /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_2_CARRY_2_KS_PBS, basis);
     ///
     /// let clear_1 = 29;
@@ -83,7 +85,7 @@ impl ServerKey {
     ///
     /// // Decrypt
     /// let res = cks.decrypt(&ctxt_1);
-    /// assert_eq!((clear_1 + clear_2) % 30, res);
+    /// assert_eq!((clear_1 + clear_2) % modulus, res);
     /// ```
     pub fn smart_crt_add_assign_parallelized(
         &self,

--- a/tfhe/src/integer/server_key/crt_parallel/add_crt.rs
+++ b/tfhe/src/integer/server_key/crt_parallel/add_crt.rs
@@ -10,12 +10,12 @@ impl ServerKey {
     ///
     ///```rust
     /// use tfhe::integer::gen_keys_crt;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
     /// let basis = vec![2, 3, 5];
     /// let modulus: u64 = basis.iter().product();
-    /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_2_CARRY_2_KS_PBS, basis);
+    /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 14;
@@ -65,13 +65,13 @@ impl ServerKey {
     ///
     /// ```rust
     /// use tfhe::integer::gen_keys_crt;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     /// let size = 4;
     ///
     /// // Generate the client key and the server key:
     /// let basis = vec![2, 3, 5];
     /// let modulus: u64 = basis.iter().product();
-    /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_2_CARRY_2_KS_PBS, basis);
+    /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
     ///
     /// let clear_1 = 29;
     /// let clear_2 = 29;

--- a/tfhe/src/integer/server_key/crt_parallel/mod.rs
+++ b/tfhe/src/integer/server_key/crt_parallel/mod.rs
@@ -17,10 +17,10 @@ impl ServerKey {
     ///
     ///```rust
     /// use tfhe::integer::gen_keys;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 14;
@@ -57,12 +57,12 @@ impl ServerKey {
     ///
     /// ```rust
     /// use tfhe::integer::gen_keys_crt;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
     /// let basis = vec![2, 3, 5];
     /// let modulus: u64 = basis.iter().product();
-    /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_2_CARRY_2_KS_PBS, basis);
+    /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
     ///
     /// let clear_1 = 28;
     ///

--- a/tfhe/src/integer/server_key/crt_parallel/mod.rs
+++ b/tfhe/src/integer/server_key/crt_parallel/mod.rs
@@ -25,6 +25,7 @@ impl ServerKey {
     /// let clear_1 = 14;
     /// let clear_2 = 14;
     /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
     /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
     /// let ctxt_2 = cks.encrypt_crt(clear_2, basis);
@@ -36,7 +37,7 @@ impl ServerKey {
     ///
     /// // Decrypt
     /// let res = cks.decrypt_crt(&ctxt_1);
-    /// assert_eq!((clear_1 + clear_2) % 30, res);
+    /// assert_eq!((clear_1 + clear_2) % modulus, res);
     /// ```
     pub fn full_extract_message_assign_parallelized(&self, ctxt: &mut CrtCiphertext) {
         ctxt.blocks.par_iter_mut().for_each(|ct_i| {
@@ -60,6 +61,7 @@ impl ServerKey {
     ///
     /// // Generate the client key and the server key:
     /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
     /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_2_CARRY_2_KS_PBS, basis);
     ///
     /// let clear_1 = 28;
@@ -71,7 +73,7 @@ impl ServerKey {
     ///
     /// // Decrypt
     /// let res = cks.decrypt(&ctxt_1);
-    /// assert_eq!((clear_1 * clear_1 * clear_1) % 30, res);
+    /// assert_eq!((clear_1 * clear_1 * clear_1) % modulus, res);
     /// ```
     pub fn pbs_crt_compliant_function_assign_parallelized<F>(&self, ct1: &mut CrtCiphertext, f: F)
     where

--- a/tfhe/src/integer/server_key/crt_parallel/mul_crt.rs
+++ b/tfhe/src/integer/server_key/crt_parallel/mul_crt.rs
@@ -15,6 +15,7 @@ impl ServerKey {
     ///
     /// // Generate the client key and the server key:
     /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
     /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
     ///
     /// let clear_1 = 29;
@@ -28,7 +29,7 @@ impl ServerKey {
     /// sks.unchecked_crt_mul_assign_parallelized(&mut ctxt_1, &ctxt_2);
     /// // Decrypt
     /// let res = cks.decrypt(&ctxt_1);
-    /// assert_eq!((clear_1 * clear_2) % 30, res);
+    /// assert_eq!((clear_1 * clear_2) % modulus, res);
     /// ```
     pub fn unchecked_crt_mul_assign_parallelized(
         &self,
@@ -67,6 +68,7 @@ impl ServerKey {
     /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
     /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
     ///
     /// let clear_1 = 29;
@@ -81,7 +83,7 @@ impl ServerKey {
     ///
     /// // Decrypt
     /// let res = cks.decrypt(&ctxt_1);
-    /// assert_eq!((clear_1 * clear_2) % 30, res);
+    /// assert_eq!((clear_1 * clear_2) % modulus, res);
     /// ```
     pub fn smart_crt_mul_assign_parallelized(
         &self,

--- a/tfhe/src/integer/server_key/crt_parallel/neg_crt.rs
+++ b/tfhe/src/integer/server_key/crt_parallel/neg_crt.rs
@@ -12,10 +12,10 @@ impl ServerKey {
     ///
     ///```rust
     /// use tfhe::integer::gen_keys;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
     ///
     /// let clear = 14_u64;
     /// let basis = vec![2, 3, 5];
@@ -52,10 +52,10 @@ impl ServerKey {
     ///
     ///```rust
     /// use tfhe::integer::gen_keys;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
     ///
     /// let clear = 14_u64;
     /// let basis = vec![2, 3, 5];

--- a/tfhe/src/integer/server_key/crt_parallel/scalar_add_crt.rs
+++ b/tfhe/src/integer/server_key/crt_parallel/scalar_add_crt.rs
@@ -23,6 +23,7 @@ impl ServerKey {
     /// let clear_1 = 14;
     /// let clear_2 = 14;
     /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
     /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
     ///
@@ -30,7 +31,7 @@ impl ServerKey {
     ///
     /// // Decrypt
     /// let res = cks.decrypt_crt(&ctxt_1);
-    /// assert_eq!((clear_1 + clear_2) % 30, res);
+    /// assert_eq!((clear_1 + clear_2) % modulus, res);
     /// ```
     pub fn unchecked_crt_scalar_add_parallelized(
         &self,
@@ -81,6 +82,7 @@ impl ServerKey {
     /// let clear_1 = 14;
     /// let clear_2 = 14;
     /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
     /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
     ///
@@ -88,7 +90,7 @@ impl ServerKey {
     ///
     /// // Decrypt
     /// let res = cks.decrypt_crt(&ctxt_1);
-    /// assert_eq!((clear_1 + clear_2) % 30, res);
+    /// assert_eq!((clear_1 + clear_2) % modulus, res);
     /// # Ok(())
     /// # }
     /// ```
@@ -137,6 +139,7 @@ impl ServerKey {
     /// let clear_1 = 14;
     /// let clear_2 = 14;
     /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
     /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
     ///
@@ -144,7 +147,7 @@ impl ServerKey {
     ///
     /// // Decrypt
     /// let res = cks.decrypt_crt(&ctxt);
-    /// assert_eq!((clear_1 + clear_2) % 30, res);
+    /// assert_eq!((clear_1 + clear_2) % modulus, res);
     /// ```
     pub fn smart_crt_scalar_add_parallelized(
         &self,
@@ -176,6 +179,7 @@ impl ServerKey {
     /// let clear_1 = 14;
     /// let clear_2 = 14;
     /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
     /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
     ///
@@ -183,7 +187,7 @@ impl ServerKey {
     ///
     /// // Decrypt
     /// let res = cks.decrypt_crt(&ctxt_1);
-    /// assert_eq!((clear_1 + clear_2) % 30, res);
+    /// assert_eq!((clear_1 + clear_2) % modulus, res);
     /// ```
     pub fn smart_crt_scalar_add_assign_parallelized(&self, ct: &mut CrtCiphertext, scalar: u64) {
         if !self.is_crt_scalar_add_possible(ct, scalar) {

--- a/tfhe/src/integer/server_key/crt_parallel/scalar_add_crt.rs
+++ b/tfhe/src/integer/server_key/crt_parallel/scalar_add_crt.rs
@@ -15,10 +15,10 @@ impl ServerKey {
     ///
     ///```rust
     /// use tfhe::integer::gen_keys;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 14;
@@ -74,10 +74,10 @@ impl ServerKey {
     /// ```rust
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use tfhe::integer::gen_keys;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 14;
@@ -131,10 +131,10 @@ impl ServerKey {
     ///
     ///```rust
     /// use tfhe::integer::gen_keys;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 14;
@@ -171,10 +171,10 @@ impl ServerKey {
     ///
     ///```rust
     /// use tfhe::integer::gen_keys;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 14;

--- a/tfhe/src/integer/server_key/crt_parallel/scalar_mul_crt.rs
+++ b/tfhe/src/integer/server_key/crt_parallel/scalar_mul_crt.rs
@@ -23,6 +23,7 @@ impl ServerKey {
     /// let clear_1 = 14;
     /// let clear_2 = 2;
     /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
     /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
     ///
@@ -30,7 +31,7 @@ impl ServerKey {
     ///
     /// // Decrypt
     /// let res = cks.decrypt_crt(&ctxt_1);
-    /// assert_eq!((clear_1 * clear_2) % 30, res);
+    /// assert_eq!((clear_1 * clear_2) % modulus, res);
     /// ```
     pub fn unchecked_crt_scalar_mul_parallelized(
         &self,
@@ -74,6 +75,7 @@ impl ServerKey {
     /// let clear_1 = 14;
     /// let clear_2 = 2;
     /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
     /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
     ///
@@ -81,7 +83,7 @@ impl ServerKey {
     ///
     /// // Decrypt
     /// let res = cks.decrypt_crt(&ctxt_1);
-    /// assert_eq!((clear_1 * clear_2) % 30, res);
+    /// assert_eq!((clear_1 * clear_2) % modulus, res);
     /// # Ok(())
     /// # }
     /// ```
@@ -141,6 +143,7 @@ impl ServerKey {
     /// let clear_1 = 14;
     /// let clear_2 = 14;
     /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
     /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
     ///
@@ -148,7 +151,7 @@ impl ServerKey {
     ///
     /// // Decrypt
     /// let res = cks.decrypt_crt(&ctxt);
-    /// assert_eq!((clear_1 * clear_2) % 30, res);
+    /// assert_eq!((clear_1 * clear_2) % modulus, res);
     /// ```
     pub fn smart_crt_scalar_mul_parallelized(
         &self,
@@ -181,6 +184,7 @@ impl ServerKey {
     /// let clear_1 = 14;
     /// let clear_2 = 14;
     /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
     /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
     ///
@@ -188,7 +192,7 @@ impl ServerKey {
     ///
     /// // Decrypt
     /// let res = cks.decrypt_crt(&ctxt_1);
-    /// assert_eq!((clear_1 * clear_2) % 30, res);
+    /// assert_eq!((clear_1 * clear_2) % modulus, res);
     /// ```
     pub fn smart_crt_scalar_mul_assign_parallelized(&self, ctxt: &mut CrtCiphertext, scalar: u64) {
         if !self.is_crt_small_scalar_mul_possible(ctxt, scalar) {

--- a/tfhe/src/integer/server_key/crt_parallel/scalar_mul_crt.rs
+++ b/tfhe/src/integer/server_key/crt_parallel/scalar_mul_crt.rs
@@ -15,10 +15,10 @@ impl ServerKey {
     ///
     ///```rust
     /// use tfhe::integer::gen_keys;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 2;
@@ -67,10 +67,10 @@ impl ServerKey {
     /// ```rust
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use tfhe::integer::gen_keys;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 2;
@@ -126,7 +126,7 @@ impl ServerKey {
     /// Computes homomorphically a multiplication between a scalar and a ciphertext.
     ///
     /// `small` means the scalar value shall fit in a __shortint block__.
-    /// For example, if the parameters are PARAM_MESSAGE_2_CARRY_2_KS_PBS,
+    /// For example, if the parameters are PARAM_MESSAGE_3_CARRY_3_KS_PBS,
     /// the scalar should fit in 2 bits.
     ///
     /// The result is returned as a new ciphertext.
@@ -135,10 +135,10 @@ impl ServerKey {
     ///
     ///```rust
     /// use tfhe::integer::gen_keys;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 14;
@@ -167,7 +167,7 @@ impl ServerKey {
     /// Computes homomorphically a multiplication between a scalar and a ciphertext.
     ///
     /// `small` means the scalar shall value fit in a __shortint block__.
-    /// For example, if the parameters are PARAM_MESSAGE_2_CARRY_2_KS_PBS,
+    /// For example, if the parameters are PARAM_MESSAGE_3_CARRY_3_KS_PBS,
     /// the scalar should fit in 2 bits.
     ///
     /// The result is assigned to the input ciphertext
@@ -176,10 +176,10 @@ impl ServerKey {
     ///
     ///```rust
     /// use tfhe::integer::gen_keys;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 14;

--- a/tfhe/src/integer/server_key/crt_parallel/scalar_sub_crt.rs
+++ b/tfhe/src/integer/server_key/crt_parallel/scalar_sub_crt.rs
@@ -15,10 +15,10 @@ impl ServerKey {
     ///
     ///```rust
     /// use tfhe::integer::gen_keys;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 7;
@@ -69,10 +69,10 @@ impl ServerKey {
     /// ```rust
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use tfhe::integer::gen_keys;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 8;
@@ -111,10 +111,10 @@ impl ServerKey {
     /// ```rust
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use tfhe::integer::gen_keys;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 7;
@@ -150,10 +150,10 @@ impl ServerKey {
     ///
     ///```rust
     /// use tfhe::integer::gen_keys;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 7;

--- a/tfhe/src/integer/server_key/crt_parallel/scalar_sub_crt.rs
+++ b/tfhe/src/integer/server_key/crt_parallel/scalar_sub_crt.rs
@@ -23,6 +23,7 @@ impl ServerKey {
     /// let clear_1 = 14;
     /// let clear_2 = 7;
     /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
     /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
     ///
@@ -30,7 +31,7 @@ impl ServerKey {
     ///
     /// // Decrypt
     /// let res = cks.decrypt_crt(&ctxt_1);
-    /// assert_eq!((clear_1 - clear_2) % 30, res);
+    /// assert_eq!((clear_1 - clear_2) % modulus, res);
     /// ```
     pub fn unchecked_crt_scalar_sub_parallelized(
         &self,
@@ -76,6 +77,7 @@ impl ServerKey {
     /// let clear_1 = 14;
     /// let clear_2 = 8;
     /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
     ///
     /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
     ///
@@ -83,7 +85,7 @@ impl ServerKey {
     ///
     /// // Decrypt:
     /// let dec = cks.decrypt_crt(&ct_res);
-    /// assert_eq!((clear_1 - clear_2) % 30, dec);
+    /// assert_eq!((clear_1 - clear_2) % modulus, dec);
     /// # Ok(())
     /// # }
     /// ```
@@ -117,6 +119,7 @@ impl ServerKey {
     /// let clear_1 = 14;
     /// let clear_2 = 7;
     /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
     ///
     /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
     ///
@@ -124,7 +127,7 @@ impl ServerKey {
     ///
     /// // Decrypt:
     /// let dec = cks.decrypt_crt(&ctxt_1);
-    /// assert_eq!((clear_1 - clear_2) % 30, dec);
+    /// assert_eq!((clear_1 - clear_2) % modulus, dec);
     /// # Ok(())
     /// # }
     /// ```
@@ -155,6 +158,7 @@ impl ServerKey {
     /// let clear_1 = 14;
     /// let clear_2 = 7;
     /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
     /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
     ///
@@ -162,7 +166,7 @@ impl ServerKey {
     ///
     /// // Decrypt
     /// let res = cks.decrypt_crt(&ctxt_1);
-    /// assert_eq!((clear_1 - clear_2) % 30, res);
+    /// assert_eq!((clear_1 - clear_2) % modulus, res);
     /// ```
     pub fn smart_crt_scalar_sub_parallelized(
         &self,

--- a/tfhe/src/integer/server_key/crt_parallel/sub_crt.rs
+++ b/tfhe/src/integer/server_key/crt_parallel/sub_crt.rs
@@ -11,10 +11,10 @@ impl ServerKey {
     ///
     ///```rust
     /// use tfhe::integer::gen_keys;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 5;
@@ -50,10 +50,10 @@ impl ServerKey {
     ///
     ///```rust
     /// use tfhe::integer::gen_keys;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 5;
@@ -84,10 +84,10 @@ impl ServerKey {
     ///
     ///```rust
     /// use tfhe::integer::gen_keys;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 5;
@@ -125,10 +125,10 @@ impl ServerKey {
     ///
     ///```rust
     /// use tfhe::integer::gen_keys;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 5;

--- a/tfhe/src/integer/server_key/crt_parallel/sub_crt.rs
+++ b/tfhe/src/integer/server_key/crt_parallel/sub_crt.rs
@@ -19,6 +19,7 @@ impl ServerKey {
     /// let clear_1 = 14;
     /// let clear_2 = 5;
     /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
     /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
     /// let mut ctxt_2 = cks.encrypt_crt(clear_2, basis.clone());
@@ -27,7 +28,7 @@ impl ServerKey {
     ///
     /// // Decrypt
     /// let res = cks.decrypt_crt(&ctxt);
-    /// assert_eq!((clear_1 - clear_2) % 30, res);
+    /// assert_eq!((clear_1 - clear_2) % modulus, res);
     /// ```
     pub fn unchecked_crt_sub_parallelized(
         &self,
@@ -57,6 +58,7 @@ impl ServerKey {
     /// let clear_1 = 14;
     /// let clear_2 = 5;
     /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
     /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
     /// let mut ctxt_2 = cks.encrypt_crt(clear_2, basis.clone());
@@ -65,7 +67,7 @@ impl ServerKey {
     ///
     /// // Decrypt
     /// let res = cks.decrypt_crt(&ctxt);
-    /// assert_eq!((clear_1 - clear_2) % 30, res);
+    /// assert_eq!((clear_1 - clear_2) % modulus, res);
     /// ```
     pub fn unchecked_crt_sub_assign_parallelized(
         &self,
@@ -90,6 +92,7 @@ impl ServerKey {
     /// let clear_1 = 14;
     /// let clear_2 = 5;
     /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
     /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
     /// let mut ctxt_2 = cks.encrypt_crt(clear_2, basis.clone());
@@ -98,7 +101,7 @@ impl ServerKey {
     ///
     /// // Decrypt
     /// let res = cks.decrypt_crt(&ctxt);
-    /// assert_eq!((clear_1 - clear_2) % 30, res);
+    /// assert_eq!((clear_1 - clear_2) % modulus, res);
     /// ```
     pub fn smart_crt_sub_parallelized(
         &self,
@@ -130,6 +133,7 @@ impl ServerKey {
     /// let clear_1 = 14;
     /// let clear_2 = 5;
     /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
     /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
     /// let mut ctxt_2 = cks.encrypt_crt(clear_2, basis.clone());
@@ -138,7 +142,7 @@ impl ServerKey {
     ///
     /// // Decrypt
     /// let res = cks.decrypt_crt(&ctxt_1);
-    /// assert_eq!((clear_1 - clear_2) % 30, res);
+    /// assert_eq!((clear_1 - clear_2) % modulus, res);
     /// ```
     pub fn smart_crt_sub_assign_parallelized(
         &self,

--- a/tfhe/src/integer/server_key/radix/add.rs
+++ b/tfhe/src/integer/server_key/radix/add.rs
@@ -163,10 +163,7 @@ impl ServerKey {
         T: IntegerRadixCiphertext,
     {
         if self.is_add_possible(ct_left, ct_right) {
-            let mut result = ct_left.clone();
-            self.unchecked_add_assign(&mut result, ct_right);
-
-            Ok(result)
+            Ok(self.unchecked_add(ct_left, ct_right))
         } else {
             Err(CarryFull)
         }

--- a/tfhe/src/integer/server_key/radix/scalar_mul.rs
+++ b/tfhe/src/integer/server_key/radix/scalar_mul.rs
@@ -263,7 +263,7 @@ impl ServerKey {
     /// let (cks, sks) = gen_keys_radix(PARAM_MESSAGE_2_CARRY_2_KS_PBS, size);
     ///
     /// let msg = 13;
-    /// let scalar = 5;
+    /// let scalar = 2;
     ///
     /// let mut ct = cks.encrypt(msg);
     ///

--- a/tfhe/src/shortint/engine/server_side/add.rs
+++ b/tfhe/src/shortint/engine/server_side/add.rs
@@ -44,9 +44,7 @@ impl ShortintEngine {
 
         assert!(server_key.is_add_possible(ct_left, ct_right));
 
-        let mut result = ct_left.clone();
-        self.unchecked_add_assign(&mut result, ct_right)?;
-        Ok(result)
+        self.unchecked_add(ct_left, ct_right)
     }
 
     pub(crate) fn smart_add_assign(

--- a/tfhe/src/shortint/engine/server_side/add.rs
+++ b/tfhe/src/shortint/engine/server_side/add.rs
@@ -24,16 +24,28 @@ impl ShortintEngine {
         Ok(())
     }
 
-    // by convention smart operations take mut refs to their inputs, even if they do not modify them
-    #[allow(clippy::needless_pass_by_ref_mut)]
     pub(crate) fn smart_add(
         &mut self,
         server_key: &ServerKey,
         ct_left: &mut Ciphertext,
         ct_right: &mut Ciphertext,
     ) -> EngineResult<Ciphertext> {
+        //If the ciphertext cannot be added together without exceeding the capacity of a ciphertext
+        if !server_key.is_add_possible(ct_left, ct_right) {
+            if ct_left.message_modulus.0 - 1 + ct_right.degree.0 <= server_key.max_degree.0 {
+                self.message_extract_assign(server_key, ct_left)?;
+            } else if ct_right.message_modulus.0 - 1 + ct_left.degree.0 <= server_key.max_degree.0 {
+                self.message_extract_assign(server_key, ct_right)?;
+            } else {
+                self.message_extract_assign(server_key, ct_left)?;
+                self.message_extract_assign(server_key, ct_right)?;
+            }
+        }
+
+        assert!(server_key.is_add_possible(ct_left, ct_right));
+
         let mut result = ct_left.clone();
-        self.smart_add_assign(server_key, &mut result, ct_right)?;
+        self.unchecked_add_assign(&mut result, ct_right)?;
         Ok(result)
     }
 

--- a/tfhe/src/shortint/engine/server_side/bitwise_op.rs
+++ b/tfhe/src/shortint/engine/server_side/bitwise_op.rs
@@ -29,17 +29,20 @@ impl ShortintEngine {
         Ok(())
     }
 
-    // by convention smart operations take mut refs to their inputs, even if they do not modify them
-    #[allow(clippy::needless_pass_by_ref_mut)]
     pub(crate) fn smart_bitand(
         &mut self,
         server_key: &ServerKey,
         ct_left: &mut Ciphertext,
         ct_right: &mut Ciphertext,
     ) -> EngineResult<Ciphertext> {
-        let mut result = ct_left.clone();
-        self.smart_bitand_assign(server_key, &mut result, ct_right)?;
-        Ok(result)
+        if !server_key.is_functional_bivariate_pbs_possible(ct_left, ct_right) {
+            self.message_extract_assign(server_key, ct_left)?;
+            self.message_extract_assign(server_key, ct_right)?;
+        }
+
+        assert!(server_key.is_functional_bivariate_pbs_possible(ct_left, ct_right));
+
+        self.unchecked_bitand(server_key, ct_left, ct_right)
     }
 
     pub(crate) fn smart_bitand_assign(
@@ -83,17 +86,19 @@ impl ShortintEngine {
         Ok(())
     }
 
-    // by convention smart operations take mut refs to their inputs, even if they do not modify them
-    #[allow(clippy::needless_pass_by_ref_mut)]
     pub(crate) fn smart_bitxor(
         &mut self,
         server_key: &ServerKey,
         ct_left: &mut Ciphertext,
         ct_right: &mut Ciphertext,
     ) -> EngineResult<Ciphertext> {
-        let mut result = ct_left.clone();
-        self.smart_bitxor_assign(server_key, &mut result, ct_right)?;
-        Ok(result)
+        if !server_key.is_functional_bivariate_pbs_possible(ct_left, ct_right) {
+            self.message_extract_assign(server_key, ct_left)?;
+            self.message_extract_assign(server_key, ct_right)?;
+        }
+        assert!(server_key.is_functional_bivariate_pbs_possible(ct_left, ct_right));
+
+        self.unchecked_bitxor(server_key, ct_left, ct_right)
     }
 
     pub(crate) fn smart_bitxor_assign(
@@ -137,17 +142,20 @@ impl ShortintEngine {
         Ok(())
     }
 
-    // by convention smart operations take mut refs to their inputs, even if they do not modify them
-    #[allow(clippy::needless_pass_by_ref_mut)]
     pub(crate) fn smart_bitor(
         &mut self,
         server_key: &ServerKey,
         ct_left: &mut Ciphertext,
         ct_right: &mut Ciphertext,
     ) -> EngineResult<Ciphertext> {
-        let mut result = ct_left.clone();
-        self.smart_bitor_assign(server_key, &mut result, ct_right)?;
-        Ok(result)
+        if !server_key.is_functional_bivariate_pbs_possible(ct_left, ct_right) {
+            self.message_extract_assign(server_key, ct_left)?;
+            self.message_extract_assign(server_key, ct_right)?;
+        }
+
+        assert!(server_key.is_functional_bivariate_pbs_possible(ct_left, ct_right));
+
+        self.unchecked_bitor(server_key, ct_left, ct_right)
     }
 
     pub(crate) fn smart_bitor_assign(

--- a/tfhe/src/shortint/engine/server_side/comp_op.rs
+++ b/tfhe/src/shortint/engine/server_side/comp_op.rs
@@ -38,9 +38,7 @@ impl ShortintEngine {
             self.message_extract_assign(server_key, ct_left)?;
             self.message_extract_assign(server_key, ct_right)?;
         }
-        let mut result = ct_left.clone();
-        self.unchecked_greater_assign(server_key, &mut result, ct_right)?;
-        Ok(result)
+        self.unchecked_greater(server_key, ct_left, ct_right)
     }
 
     pub(crate) fn unchecked_greater_or_equal(
@@ -79,9 +77,7 @@ impl ShortintEngine {
             self.message_extract_assign(server_key, ct_left)?;
             self.message_extract_assign(server_key, ct_right)?;
         }
-        let mut result = ct_left.clone();
-        self.unchecked_greater_or_equal_assign(server_key, &mut result, ct_right)?;
-        Ok(result)
+        self.unchecked_greater_or_equal(server_key, ct_left, ct_right)
     }
 
     pub(crate) fn unchecked_less(
@@ -120,9 +116,7 @@ impl ShortintEngine {
             self.message_extract_assign(server_key, ct_left)?;
             self.message_extract_assign(server_key, ct_right)?;
         }
-        let mut result = ct_left.clone();
-        self.unchecked_less_assign(server_key, &mut result, ct_right)?;
-        Ok(result)
+        self.unchecked_less(server_key, ct_left, ct_right)
     }
 
     pub(crate) fn unchecked_less_or_equal(
@@ -161,9 +155,7 @@ impl ShortintEngine {
             self.message_extract_assign(server_key, ct_left)?;
             self.message_extract_assign(server_key, ct_right)?;
         }
-        let mut result = ct_left.clone();
-        self.unchecked_less_or_equal_assign(server_key, &mut result, ct_right)?;
-        Ok(result)
+        self.unchecked_less_or_equal(server_key, ct_left, ct_right)
     }
 
     pub(crate) fn unchecked_equal(
@@ -202,9 +194,7 @@ impl ShortintEngine {
             self.message_extract_assign(server_key, ct_left)?;
             self.message_extract_assign(server_key, ct_right)?;
         }
-        let mut result = ct_left.clone();
-        self.unchecked_equal_assign(server_key, &mut result, ct_right)?;
-        Ok(result)
+        self.unchecked_equal(server_key, ct_left, ct_right)
     }
 
     // by convention smart operations take mut refs to their inputs, even if they do not modify them
@@ -270,9 +260,7 @@ impl ShortintEngine {
             self.message_extract_assign(server_key, ct_left)?;
             self.message_extract_assign(server_key, ct_right)?;
         }
-        let mut result = ct_left.clone();
-        self.unchecked_not_equal_assign(server_key, &mut result, ct_right)?;
-        Ok(result)
+        self.unchecked_not_equal(server_key, ct_left, ct_right)
     }
 
     // by convention smart operations take mut refs to their inputs, even if they do not modify them

--- a/tfhe/src/shortint/engine/server_side/div_mod.rs
+++ b/tfhe/src/shortint/engine/server_side/div_mod.rs
@@ -39,17 +39,27 @@ impl ShortintEngine {
         Ok(())
     }
 
-    // by convention smart operations take mut refs to their inputs, even if they do not modify them
-    #[allow(clippy::needless_pass_by_ref_mut)]
     pub(crate) fn smart_div(
         &mut self,
         server_key: &ServerKey,
         ct_left: &mut Ciphertext,
         ct_right: &mut Ciphertext,
     ) -> EngineResult<Ciphertext> {
-        let mut result = ct_left.clone();
-        self.smart_div_assign(server_key, &mut result, ct_right)?;
-        Ok(result)
+        if !server_key.is_functional_bivariate_pbs_possible(ct_left, ct_right) {
+            if ct_left.message_modulus.0 + ct_right.degree.0 <= server_key.max_degree.0 {
+                self.message_extract_assign(server_key, ct_left)?;
+            } else if ct_right.message_modulus.0 + (ct_left.degree.0 + 1) <= server_key.max_degree.0
+            {
+                self.message_extract_assign(server_key, ct_right)?;
+            } else {
+                self.message_extract_assign(server_key, ct_left)?;
+                self.message_extract_assign(server_key, ct_right)?;
+            }
+        }
+
+        assert!(server_key.is_functional_bivariate_pbs_possible(ct_left, ct_right));
+
+        self.unchecked_div(server_key, ct_left, ct_right)
     }
 
     pub(crate) fn smart_div_assign(

--- a/tfhe/src/shortint/engine/server_side/mul.rs
+++ b/tfhe/src/shortint/engine/server_side/mul.rs
@@ -137,7 +137,7 @@ impl ShortintEngine {
     ) -> EngineResult<()> {
         //Choice of the multiplication algorithm depending on the parameters
         if ct_left.message_modulus.0 > ct_left.carry_modulus.0 {
-            //If the ciphertext cannot be added together without exceeding the capacity of a
+            //If the ciphertexts cannot be multiplied together without exceeding the capacity of a
             // ciphertext
             if !server_key.is_mul_small_carry_possible(ct_left, ct_right) {
                 self.message_extract_assign(server_key, ct_left)?;
@@ -145,7 +145,7 @@ impl ShortintEngine {
             }
             self.unchecked_mul_lsb_small_carry_modulus_assign(server_key, ct_left, ct_right)?;
         } else {
-            //If the ciphertext cannot be added together without exceeding the capacity of a
+            //If the ciphertexts cannot be multiplied together without exceeding the capacity of a
             // ciphertext
             if !server_key.is_mul_possible(ct_left, ct_right) {
                 if (server_key.message_modulus.0 - 1) * ct_right.degree.0
@@ -166,17 +166,45 @@ impl ShortintEngine {
         Ok(())
     }
 
-    // by convention smart operations take mut refs to their inputs, even if they do not modify them
-    #[allow(clippy::needless_pass_by_ref_mut)]
     pub(crate) fn smart_mul_lsb(
         &mut self,
         server_key: &ServerKey,
         ct_left: &mut Ciphertext,
         ct_right: &mut Ciphertext,
     ) -> EngineResult<Ciphertext> {
-        let mut result = ct_left.clone();
-        self.smart_mul_lsb_assign(server_key, &mut result, ct_right)?;
-        Ok(result)
+        if ct_left.message_modulus.0 > ct_left.carry_modulus.0 {
+            //If the ciphertexts cannot be multiplied together without exceeding the capacity of a
+            // ciphertext
+            if !server_key.is_mul_small_carry_possible(ct_left, ct_right) {
+                self.message_extract_assign(server_key, ct_left)?;
+                self.message_extract_assign(server_key, ct_right)?;
+            }
+
+            assert!(server_key.is_mul_small_carry_possible(ct_left, ct_right));
+
+            self.unchecked_mul_lsb_small_carry_modulus(server_key, ct_left, ct_right)
+        } else {
+            //If the ciphertexts cannot be multiplied together without exceeding the capacity of a
+            // ciphertext
+            if !server_key.is_mul_possible(ct_left, ct_right) {
+                if (server_key.message_modulus.0 - 1) * ct_right.degree.0
+                    < (ct_right.carry_modulus.0 * ct_right.message_modulus.0 - 1)
+                {
+                    self.message_extract_assign(server_key, ct_left)?;
+                } else if (server_key.message_modulus.0 - 1) + ct_left.degree.0
+                    < (ct_right.carry_modulus.0 * ct_right.message_modulus.0 - 1)
+                {
+                    self.message_extract_assign(server_key, ct_right)?;
+                } else {
+                    self.message_extract_assign(server_key, ct_left)?;
+                    self.message_extract_assign(server_key, ct_right)?;
+                }
+            }
+
+            assert!(server_key.is_mul_possible(ct_left, ct_right));
+
+            self.unchecked_mul_lsb(server_key, ct_left, ct_right)
+        }
     }
 
     pub(crate) fn smart_mul_msb_assign(

--- a/tfhe/src/shortint/server_key/mod.rs
+++ b/tfhe/src/shortint/server_key/mod.rs
@@ -392,14 +392,14 @@ impl ServerKey {
     /// let msg_1 = 3;
     /// let msg_2 = 2;
     ///
-    /// let ct1 = cks.encrypt(msg_1);
+    /// let mut ct1 = cks.encrypt(msg_1);
     /// let mut ct2 = cks.encrypt(msg_2);
     ///
     /// let f = |x, y| (x + y) % 4;
     ///
     /// let acc = sks.generate_lookup_table_bivariate(f);
     /// assert!(acc.is_bivariate_pbs_possible(&ct1, &ct2));
-    /// let ct_res = sks.smart_apply_lookup_table_bivariate(&ct1, &mut ct2, &acc);
+    /// let ct_res = sks.smart_apply_lookup_table_bivariate(&mut ct1, &mut ct2, &acc);
     ///
     /// let dec = cks.decrypt(&ct_res);
     /// assert_eq!(dec, f(msg_1, msg_2));
@@ -475,13 +475,13 @@ impl ServerKey {
     /// let (cks, sks) = gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
     ///
     /// let msg: u64 = 3;
-    /// let ct1 = cks.encrypt(msg);
+    /// let mut ct1 = cks.encrypt(msg);
     /// let mut ct2 = cks.encrypt(msg);
     /// let modulus = cks.parameters.message_modulus().0 as u64;
     ///
     /// // Generate the lookup table for the function f: x -> x^3 mod 2^2
     /// let acc = sks.generate_lookup_table_bivariate(|x, y| x * y * x % modulus);
-    /// let ct_res = sks.smart_apply_lookup_table_bivariate(&ct1, &mut ct2, &acc);
+    /// let ct_res = sks.smart_apply_lookup_table_bivariate(&mut ct1, &mut ct2, &acc);
     ///
     /// let dec = cks.decrypt(&ct_res);
     /// // 3^3 mod 4 = 3
@@ -489,7 +489,7 @@ impl ServerKey {
     /// ```
     pub fn smart_apply_lookup_table_bivariate(
         &self,
-        ct_left: &Ciphertext,
+        ct_left: &mut Ciphertext,
         ct_right: &mut Ciphertext,
         acc: &BivariateLookupTableOwned,
     ) -> Ciphertext {


### PR DESCRIPTION
- cleanup inputs of smart ops instead of cleanup clones
- do not bootstrap when not necessary
- add asserts on smart ops