### PR TITLE
chore(ci): improve code coverage execution

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -6,17 +6,64 @@ env:
   RUSTFLAGS: "-C target-cpu=native"
 
 on:
-  push:
-    branches:
-      - "main"
-  pull_request:
+  # Allows you to run this workflow manually from the Actions tab as an alternative.
+  workflow_dispatch:
+    # All the inputs are provided by Slab
+    inputs:
+      instance_id:
+        description: "AWS instance ID"
+        type: string
+      instance_image_id:
+        description: "AWS instance AMI ID"
+        type: string
+      instance_type:
+        description: "AWS instance product type"
+        type: string
+      runner_name:
+        description: "Action runner name"
+        type: string
+      request_id:
+        description: 'Slab request ID'
+        type: string
+      fork_repo:
+        description: 'Name of forked repo as user/repo'
+        type: string
+      fork_git_sha:
+        description: 'Git SHA to checkout from fork'
+        type: string
 
 jobs:
   code-coverage:
-    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}_${{ github.ref }}_${{ inputs.instance_image_id }}_${{ inputs.instance_type }}
+      cancel-in-progress: true
+    runs-on: ${{ inputs.runner_name }}
     steps:
+      # Step used for log purpose.
+      - name: Instance configuration used
+        run: |
+          echo "ID: ${{ inputs.instance_id }}"
+          echo "AMI: ${{ inputs.instance_image_id }}"
+          echo "Type: ${{ inputs.instance_type }}"
+          echo "Request ID: ${{ inputs.request_id }}"
+          echo "Fork repo: ${{ inputs.fork_repo }}"
+          echo "Fork git sha: ${{ inputs.fork_git_sha }}"
+
       - name: Checkout tfhe-rs
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
+        with:
+          repository: ${{ inputs.fork_repo }}
+          ref: ${{ inputs.fork_git_sha }}
+
+      - name: Set up home
+        run: |
+          echo "HOME=/home/ubuntu" >> "${GITHUB_ENV}"
+
+      - name: Install latest stable
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af
+        with:
+          toolchain: stable
+          default: true
 
       - name: Check for file changes
         id: changed-files
@@ -37,9 +84,9 @@ jobs:
         run: |
           make test_shortint_cov
 
-      - name: Upload coverage to Codecov
+      - name: Upload tfhe coverage to Codecov
         uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
-        if: steps.changed-files.outputs.any_changed == 'true'
+        if: steps.changed-files.outputs.tfhe_any_changed == 'true'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -18,16 +18,28 @@ jobs:
       - name: Checkout tfhe-rs
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
 
-      - name: Gen Keys if required
+      - name: Check for file changes
+        id: changed-files
+        uses: tj-actions/changed-files@246636f5fa148b5ad8e65ca4c57b18af3123e5f6
+        with:
+          files_yaml: |
+            tfhe:
+              - tfhe/src/**
+            concrete_csprng:
+              - concrete-csprng/src/**
+
+      - name: Generate Keys
         run: |
           make GEN_KEY_CACHE_COVERAGE_ONLY=TRUE gen_key_cache
 
       - name: Run shortint coverage
+        if: steps.changed-files.outputs.tfhe_any_changed == 'true'
         run: |
           make test_shortint_cov
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
+        if: steps.changed-files.outputs.any_changed == 'true'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/.github/workflows/trigger_aws_tests_on_pr.yml
+++ b/.github/workflows/trigger_aws_tests_on_pr.yml
@@ -29,6 +29,7 @@ jobs:
           allow-repeats: true
           message: |
             @slab-ci cpu_fast_test
+            @slab-ci code_coverage
 
       - name: Add approved label
         uses: actions-ecosystem/action-add-labels@bd52874380e3909a1ac983768df6976535ece7f8

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ PARSE_INTEGER_BENCH_CSV_FILE?=tfhe_rs_integer_benches.csv
 FAST_TESTS?=FALSE
 FAST_BENCH?=FALSE
 BENCH_OP_FLAVOR?=DEFAULT
+COVERAGE_EXCLUDED_FILES = tfhe/benches/*,apps/trivium/src/*,tfhe/examples/*,tasks/src/*
 # This is done to avoid forgetting it, we still precise the RUSTFLAGS in the commands to be able to
 # copy paste the command in the terminal and change them if required without forgetting the flags
 export RUSTFLAGS?=-C target-cpu=native
@@ -321,7 +322,9 @@ test_shortint: install_rs_build_toolchain
 test_shortint_cov: install_rs_check_toolchain install_tarpaulin
 	RUSTFLAGS="$(RUSTFLAGS)" cargo $(CARGO_RS_CHECK_TOOLCHAIN) tarpaulin --profile $(CARGO_PROFILE) \
 		--out Xml --output-dir coverage/shortint --line --engine Llvm --timeout 500 \
-		--features=$(TARGET_ARCH_FEATURE),shortint,internal-keycache,__coverage -p tfhe -- shortint::
+		--exclude-files $(COVERAGE_EXCLUDED_FILES) \
+		--features=$(TARGET_ARCH_FEATURE),shortint,internal-keycache,__coverage \
+		-p tfhe -- shortint::
 
 .PHONY: test_integer_ci # Run the tests for integer ci
 test_integer_ci: install_rs_build_toolchain install_cargo_nextest

--- a/ci/slab.toml
+++ b/ci/slab.toml
@@ -82,3 +82,8 @@ check_run_name = "WASM Client AWS Benchmarks"
 workflow = "csprng_randomness_testing.yml"
 profile = "cpu-small"
 check_run_name = "CSPRNG randomness testing"
+
+[command.code_coverage]
+workflow = "code_coverage.yml"
+profile = "cpu-small"
+check_run_name = "Code coverage"

--- a/ci/slab.toml
+++ b/ci/slab.toml
@@ -1,16 +1,16 @@
 [profile.cpu-big]
 region = "eu-west-3"
-image_id = "ami-0ab73f5bd11708a85"
+image_id = "ami-051942e4055555752"
 instance_type = "m6i.32xlarge"
 
 [profile.cpu-small]
 region = "eu-west-3"
-image_id = "ami-0ab73f5bd11708a85"
+image_id = "ami-051942e4055555752"
 instance_type = "m6i.4xlarge"
 
 [profile.bench]
 region = "eu-west-3"
-image_id = "ami-0ab73f5bd11708a85"
+image_id = "ami-051942e4055555752"
 instance_type = "m6i.metal"
 
 [command.cpu_test]


### PR DESCRIPTION
This PR does the following:
- exclude files from coverage reports
- trigger code coverage only if sources changed
- run coverage on AWS EC2

Resolves: zama-ai/tfhe-rs-internal#234