### PR TITLE
chore(ci): disable codecov patch status

### DIFF
--- a/.github/workflows/trigger_aws_tests_on_pr.yml
+++ b/.github/workflows/trigger_aws_tests_on_pr.yml
@@ -29,7 +29,6 @@ jobs:
           allow-repeats: true
           message: |
             @slab-ci cpu_fast_test
-            @slab-ci code_coverage
 
       - name: Add approved label
         uses: actions-ecosystem/action-add-labels@bd52874380e3909a1ac983768df6976535ece7f8

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,4 @@
+coverage:
+  status:
+    # Disable patch checks in GitHub until all tfhe-rs layers have coverage implemented.
+    patch: false


### PR DESCRIPTION
This is done to avoid noisy reports in GitHub since coverage in all the library layers haven't been implemented yet.