### PR TITLE
fix(csprng): enable target_feature attributes for functions using simd intrinsics

### DIFF
--- a/concrete-csprng/src/seeders/implem/rdseed.rs
+++ b/concrete-csprng/src/seeders/implem/rdseed.rs
@@ -8,7 +8,7 @@ pub struct RdseedSeeder;
 
 impl Seeder for RdseedSeeder {
     fn seed(&mut self) -> Seed {
-        Seed(rdseed_random_m128())
+        Seed(unsafe { rdseed_random_m128() })
     }
 
     fn is_available() -> bool {
@@ -17,7 +17,8 @@ impl Seeder for RdseedSeeder {
 }
 
 // Generates a random 128 bits value from rdseed
-fn rdseed_random_m128() -> u128 {
+#[target_feature(enable = "rdseed")]
+unsafe fn rdseed_random_m128() -> u128 {
     let mut rand1: u64 = 0;
     let mut rand2: u64 = 0;
     let mut output_bytes = [0u8; 16];


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description
adding `#[target_feature(enable = "...")]` attributes to functions using simd intrinsics can improve performance by allowing the intrinsics to get inlined. if we don't do this, then we pay the overhead of a function call + accessing arguments/return value on the stack for every intrinsic we use, which is a big cost

### Check-list:

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [x] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
