### PR TITLE
chore(ci): speed-up boolean coverage

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -76,15 +76,16 @@ jobs:
               - concrete-csprng/src/**
 
       - name: Generate Keys
+        if: steps.changed-files.outputs.tfhe_any_changed == 'true'
         run: |
           make GEN_KEY_CACHE_COVERAGE_ONLY=TRUE gen_key_cache
 
-      - name: Run boolean coverage
+      - name: Run coverage for boolean
         if: steps.changed-files.outputs.tfhe_any_changed == 'true'
         run: |
           make test_boolean_cov
 
-      - name: Run shortint coverage
+      - name: Run coverage for shortint
         if: steps.changed-files.outputs.tfhe_any_changed == 'true'
         run: |
           make test_shortint_cov

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,6 @@ PARSE_INTEGER_BENCH_CSV_FILE?=tfhe_rs_integer_benches.csv
 FAST_TESTS?=FALSE
 FAST_BENCH?=FALSE
 BENCH_OP_FLAVOR?=DEFAULT
-COVERAGE_EXCLUDED_FILES = tfhe/benches/*,apps/trivium/src/*,tfhe/examples/*,tasks/src/*
 # This is done to avoid forgetting it, we still precise the RUSTFLAGS in the commands to be able to
 # copy paste the command in the terminal and change them if required without forgetting the flags
 export RUSTFLAGS?=-C target-cpu=native
@@ -42,6 +41,22 @@ endif
 # Variables used only for regex_engine example
 REGEX_STRING?=''
 REGEX_PATTERN?=''
+
+# Exclude these files from coverage reports
+define COVERAGE_EXCLUDED_FILES
+--exclude-files apps/trivium/src/trivium/* \
+--exclude-files apps/trivium/src/kreyvium/* \
+--exclude-files apps/trivium/src/static_deque/* \
+--exclude-files apps/trivium/src/trans_ciphering/* \
+--exclude-files tasks/src/* \
+--exclude-files tfhe/benches/boolean/* \
+--exclude-files tfhe/benches/core_crypto/* \
+--exclude-files tfhe/benches/shortint/* \
+--exclude-files tfhe/benches/integer/* \
+--exclude-files tfhe/benches/* \
+--exclude-files tfhe/examples/regex_engine/* \
+--exclude-files tfhe/examples/utilities/*
+endef
 
 .PHONY: rs_check_toolchain # Echo the rust toolchain used for checks
 rs_check_toolchain:
@@ -302,7 +317,7 @@ test_boolean: install_rs_build_toolchain
 test_boolean_cov: install_rs_check_toolchain install_tarpaulin
 	RUSTFLAGS="$(RUSTFLAGS)" cargo $(CARGO_RS_CHECK_TOOLCHAIN) tarpaulin --profile $(CARGO_PROFILE) \
 		--out xml --output-dir coverage/boolean --line --engine llvm --timeout 500 \
-		--exclude-files $(COVERAGE_EXCLUDED_FILES) \
+		$(COVERAGE_EXCLUDED_FILES) \
 		--features=$(TARGET_ARCH_FEATURE),boolean,internal-keycache,__coverage \
 		-p tfhe -- boolean::
 
@@ -343,7 +358,7 @@ test_shortint: install_rs_build_toolchain
 test_shortint_cov: install_rs_check_toolchain install_tarpaulin
 	RUSTFLAGS="$(RUSTFLAGS)" cargo $(CARGO_RS_CHECK_TOOLCHAIN) tarpaulin --profile $(CARGO_PROFILE) \
 		--out xml --output-dir coverage/shortint --line --engine llvm --timeout 500 \
-		--exclude-files $(COVERAGE_EXCLUDED_FILES) \
+		$(COVERAGE_EXCLUDED_FILES) \
 		--features=$(TARGET_ARCH_FEATURE),shortint,internal-keycache,__coverage \
 		-p tfhe -- shortint::
 

--- a/Makefile
+++ b/Makefile
@@ -301,7 +301,7 @@ test_boolean: install_rs_build_toolchain
 .PHONY: test_boolean_cov # Run the tests of the boolean module with code coverage
 test_boolean_cov: install_rs_check_toolchain install_tarpaulin
 	RUSTFLAGS="$(RUSTFLAGS)" cargo $(CARGO_RS_CHECK_TOOLCHAIN) tarpaulin --profile $(CARGO_PROFILE) \
-		--out Xml --output-dir coverage/boolean --line --engine Llvm --timeout 500 \
+		--out xml --output-dir coverage/boolean --line --engine llvm --timeout 500 \
 		--exclude-files $(COVERAGE_EXCLUDED_FILES) \
 		--features=$(TARGET_ARCH_FEATURE),boolean,internal-keycache,__coverage \
 		-p tfhe -- boolean::
@@ -342,7 +342,7 @@ test_shortint: install_rs_build_toolchain
 .PHONY: test_shortint_cov # Run the tests of the shortint module with code coverage
 test_shortint_cov: install_rs_check_toolchain install_tarpaulin
 	RUSTFLAGS="$(RUSTFLAGS)" cargo $(CARGO_RS_CHECK_TOOLCHAIN) tarpaulin --profile $(CARGO_PROFILE) \
-		--out Xml --output-dir coverage/shortint --line --engine Llvm --timeout 500 \
+		--out xml --output-dir coverage/shortint --line --engine llvm --timeout 500 \
 		--exclude-files $(COVERAGE_EXCLUDED_FILES) \
 		--features=$(TARGET_ARCH_FEATURE),shortint,internal-keycache,__coverage \
 		-p tfhe -- shortint::

--- a/tfhe/examples/utilities/generates_test_keys.rs
+++ b/tfhe/examples/utilities/generates_test_keys.rs
@@ -1,10 +1,6 @@
 use clap::{Arg, ArgAction, Command};
 use tfhe::boolean;
-use tfhe::boolean::parameters::{
-    BooleanParameters, DEFAULT_PARAMETERS, DEFAULT_PARAMETERS_KS_PBS,
-    PARAMETERS_ERROR_PROB_2_POW_MINUS_165, PARAMETERS_ERROR_PROB_2_POW_MINUS_165_KS_PBS,
-    TFHE_LIB_PARAMETERS,
-};
+use tfhe::boolean::parameters::{BooleanParameters, DEFAULT_PARAMETERS, DEFAULT_PARAMETERS_KS_PBS};
 use tfhe::keycache::NamedParam;
 use tfhe::shortint::keycache::{KEY_CACHE, KEY_CACHE_KSK, KEY_CACHE_WOPBS};
 use tfhe::shortint::parameters::key_switching::{
@@ -97,13 +93,8 @@ fn client_server_keys() {
         )];
         generate_wopbs_keys(&WOPBS_PARAMS);
 
-        const BOOLEAN_PARAMS: [BooleanParameters; 5] = [
-            DEFAULT_PARAMETERS,
-            DEFAULT_PARAMETERS_KS_PBS,
-            TFHE_LIB_PARAMETERS,
-            PARAMETERS_ERROR_PROB_2_POW_MINUS_165,
-            PARAMETERS_ERROR_PROB_2_POW_MINUS_165_KS_PBS,
-        ];
+        const BOOLEAN_PARAMS: [BooleanParameters; 2] =
+            [DEFAULT_PARAMETERS, DEFAULT_PARAMETERS_KS_PBS];
         generate_boolean_keys(&BOOLEAN_PARAMS);
     } else {
         generate_pbs_keys(&ALL_PARAMETER_VEC);

--- a/tfhe/src/boolean/key_switching_key/test.rs
+++ b/tfhe/src/boolean/key_switching_key/test.rs
@@ -1,15 +1,18 @@
+use crate::boolean::keycache::KEY_CACHE;
 use crate::boolean::prelude::*;
 
 #[test]
 fn test_cast_boolean() {
-    let (client_key_1, _server_key_1): (ClientKey, ServerKey) = gen_keys();
-    let (client_key_2, _server_key_2): (ClientKey, ServerKey) = gen_keys();
+    let keys_1 = KEY_CACHE.get_from_param(DEFAULT_PARAMETERS);
+    let client_key_1 = keys_1.client_key();
+    let keys_2 = KEY_CACHE.get_from_param(DEFAULT_PARAMETERS);
+    let client_key_2 = keys_2.client_key();
 
     let ksk_params = BooleanKeySwitchingParameters::new(
         client_key_2.parameters.ks_base_log,
         client_key_2.parameters.ks_level,
     );
-    let ksk = KeySwitchingKey::new(&client_key_1, &client_key_2, ksk_params);
+    let ksk = KeySwitchingKey::new(client_key_1, client_key_2, ksk_params);
 
     let mut ct_true = client_key_1.encrypt(true);
     ct_true = ksk.cast(&ct_true);
@@ -24,14 +27,16 @@ fn test_cast_boolean() {
 
 #[test]
 fn test_cast_into_boolean() {
-    let (client_key_1, server_key_1): (ClientKey, ServerKey) = gen_keys();
-    let (client_key_2, _server_key_2): (ClientKey, ServerKey) = gen_keys();
+    let keys_1 = KEY_CACHE.get_from_param(DEFAULT_PARAMETERS);
+    let (client_key_1, server_key_1) = (keys_1.client_key(), keys_1.server_key());
+    let keys_2 = KEY_CACHE.get_from_param(DEFAULT_PARAMETERS);
+    let client_key_2 = keys_2.client_key();
 
     let ksk_params = BooleanKeySwitchingParameters::new(
         client_key_2.parameters.ks_base_log,
         client_key_2.parameters.ks_level,
     );
-    let ksk = KeySwitchingKey::new(&client_key_1, &client_key_2, ksk_params);
+    let ksk = KeySwitchingKey::new(client_key_1, client_key_2, ksk_params);
 
     let ct_true = client_key_1.encrypt(true);
     let mut ct_cast = server_key_1.trivial_encrypt(false);

--- a/tfhe/src/boolean/public_key/compressed.rs
+++ b/tfhe/src/boolean/public_key/compressed.rs
@@ -88,27 +88,32 @@ impl CompressedPublicKey {
 
 #[cfg(test)]
 mod tests {
+    use crate::boolean::keycache::KEY_CACHE;
     use crate::boolean::prelude::{
-        BinaryBooleanGates, BooleanParameters, ClientKey, CompressedPublicKey, ServerKey,
-        DEFAULT_PARAMETERS, PARAMETERS_ERROR_PROB_2_POW_MINUS_165,
+        BinaryBooleanGates, BooleanParameters, CompressedPublicKey, DEFAULT_PARAMETERS,
+        PARAMETERS_ERROR_PROB_2_POW_MINUS_165,
     };
     use crate::boolean::random_boolean;
+    #[cfg(not(feature = "__coverage"))]
     const NB_TEST: usize = 32;
+    #[cfg(feature = "__coverage")]
+    const NB_TEST: usize = 1;
 
     #[test]
     fn test_compressed_public_key_default_parameters() {
         test_compressed_public_key(DEFAULT_PARAMETERS);
     }
 
+    #[cfg(not(feature = "__coverage"))]
     #[test]
     fn test_compressed_public_key_tfhe_lib_parameters() {
         test_compressed_public_key(PARAMETERS_ERROR_PROB_2_POW_MINUS_165);
     }
 
     fn test_compressed_public_key(parameters: BooleanParameters) {
-        let cks = ClientKey::new(&parameters);
-        let sks = ServerKey::new(&cks);
-        let cpks = CompressedPublicKey::new(&cks);
+        let keys = KEY_CACHE.get_from_param(parameters);
+        let (cks, sks) = (keys.client_key(), keys.server_key());
+        let cpks = CompressedPublicKey::new(cks);
 
         for _ in 0..NB_TEST {
             let b1 = random_boolean();

--- a/tfhe/src/boolean/public_key/standard.rs
+++ b/tfhe/src/boolean/public_key/standard.rs
@@ -80,29 +80,34 @@ impl From<CompressedPublicKey> for PublicKey {
 
 #[cfg(test)]
 mod tests {
+    use crate::boolean::keycache::KEY_CACHE;
     use crate::boolean::prelude::{
-        BinaryBooleanGates, BooleanParameters, ClientKey, CompressedPublicKey, ServerKey,
-        DEFAULT_PARAMETERS, PARAMETERS_ERROR_PROB_2_POW_MINUS_165,
+        BinaryBooleanGates, BooleanParameters, CompressedPublicKey, DEFAULT_PARAMETERS,
+        PARAMETERS_ERROR_PROB_2_POW_MINUS_165,
     };
     use crate::boolean::random_boolean;
 
     use super::PublicKey;
+    #[cfg(not(feature = "__coverage"))]
     const NB_TEST: usize = 32;
+    #[cfg(feature = "__coverage")]
+    const NB_TEST: usize = 1;
 
     #[test]
     fn test_public_key_default_parameters() {
         test_public_key(DEFAULT_PARAMETERS);
     }
 
+    #[cfg(not(feature = "__coverage"))]
     #[test]
     fn test_public_key_tfhe_lib_parameters() {
         test_public_key(PARAMETERS_ERROR_PROB_2_POW_MINUS_165);
     }
 
     fn test_public_key(parameters: BooleanParameters) {
-        let cks = ClientKey::new(&parameters);
-        let sks = ServerKey::new(&cks);
-        let pks = PublicKey::new(&cks);
+        let keys = KEY_CACHE.get_from_param(parameters);
+        let (cks, sks) = (keys.client_key(), keys.server_key());
+        let pks = PublicKey::new(cks);
 
         for _ in 0..NB_TEST {
             let b1 = random_boolean();
@@ -129,15 +134,16 @@ mod tests {
         test_public_key(DEFAULT_PARAMETERS);
     }
 
+    #[cfg(not(feature = "__coverage"))]
     #[test]
     fn test_decompressing_public_key_tfhe_lib_parameters() {
         test_decompressing_public_key(PARAMETERS_ERROR_PROB_2_POW_MINUS_165);
     }
 
     fn test_decompressing_public_key(parameters: BooleanParameters) {
-        let cks = ClientKey::new(&parameters);
-        let sks = ServerKey::new(&cks);
-        let cpks = CompressedPublicKey::new(&cks);
+        let keys = KEY_CACHE.get_from_param(parameters);
+        let (cks, sks) = (keys.client_key(), keys.server_key());
+        let cpks = CompressedPublicKey::new(cks);
         let pks = PublicKey::from(cpks);
 
         for _ in 0..NB_TEST {

--- a/tfhe/src/boolean/server_key/tests.rs
+++ b/tfhe/src/boolean/server_key/tests.rs
@@ -69,6 +69,7 @@ mod default_parameters_tests {
     }
 }
 
+#[cfg(not(feature = "__coverage"))]
 mod low_prob_parameters_tests {
     use super::*;
     use crate::boolean::parameters::PARAMETERS_ERROR_PROB_2_POW_MINUS_165;
@@ -161,6 +162,7 @@ mod default_parameters_ks_pbs_tests {
     }
 }
 
+#[cfg(not(feature = "__coverage"))]
 mod low_prob_parameters_ks_pbs_tests {
     use super::*;
     use crate::boolean::parameters::PARAMETERS_ERROR_PROB_2_POW_MINUS_165_KS_PBS;
@@ -207,6 +209,7 @@ mod low_prob_parameters_ks_pbs_tests {
     }
 }
 
+#[cfg(not(feature = "__coverage"))]
 mod tfhe_lib_parameters_tests {
     use super::*;
     use crate::boolean::parameters::TFHE_LIB_PARAMETERS;


### PR DESCRIPTION
This is done by reducing the number of parameters set run in tests.
