### PR TITLE
fix(integer): is_neg/sub/add possible

### DIFF
--- a/tfhe/docs/fine_grained_api/integer/operations.md
+++ b/tfhe/docs/fine_grained_api/integer/operations.md
@@ -162,12 +162,15 @@ fn main() {
     assert!(result.is_ok());
 
     let result = server_key.checked_sub_assign(&mut ct_1, &ct_2);
+    assert!(result.is_ok());
+    
+    let result = server_key.checked_add_assign(&mut ct_1, &ct_3);
     assert!(result.is_err());
 
     // We use the client key to decrypt the output of the circuit:
     // Only the scalar multiplication could be done
     let output: u64 = client_key.decrypt(&ct_1);
-    assert_eq!(output, (msg1 * scalar) % modulus as u64);
+    assert_eq!(output, ((msg1 * scalar) - msg2) % modulus as u64);
 }
 ```
 

--- a/tfhe/src/integer/server_key/radix/sub.rs
+++ b/tfhe/src/integer/server_key/radix/sub.rs
@@ -1,3 +1,4 @@
+use crate::core_crypto::algorithms::misc::divide_ceil;
 use crate::integer::ciphertext::IntegerRadixCiphertext;
 use crate::integer::server_key::CheckError;
 use crate::integer::server_key::CheckError::CarryFull;
@@ -110,10 +111,35 @@ impl ServerKey {
     where
         T: IntegerRadixCiphertext,
     {
-        for (ct_left_i, ct_right_i) in ctxt_left.blocks().iter().zip(ctxt_right.blocks().iter()) {
-            if !self.key.is_sub_possible(ct_left_i, ct_right_i) {
+        let mut preceding_block_carry = 0;
+        let mut preceding_scaled_z = 0;
+        for (left_block, right_block) in ctxt_left.blocks().iter().zip(ctxt_right.blocks().iter()) {
+            // Assumes message_modulus and carry_modulus matches between pairs of block
+            let msg_mod = left_block.message_modulus.0;
+            let carry_mod = left_block.carry_modulus.0;
+            let total_modulus = msg_mod * carry_mod;
+
+            // z = ceil( degree / 2^p ) x 2^p
+            let mut z = divide_ceil(right_block.degree.0, msg_mod);
+            z = z.wrapping_mul(msg_mod);
+            // In the actual operation, preceding_scaled_z is added to the ciphertext
+            // before doing lwe_ciphertext_opposite:
+            // i.e the code does -(ciphertext + preceding_scaled_z) + z
+            // here we do -ciphertext -preceding_scaled_z + z
+            // which is easier to express degree
+            let right_block_degree_after_negation = z - preceding_scaled_z;
+
+            let degree_after_add = left_block.degree.0 + right_block_degree_after_negation;
+
+            // We want to be able to add the left block, the negated right block
+            // and we also want to be able to add the carry from preceding block addition
+            // to make sure carry propagation would be correct.
+            if (degree_after_add + preceding_block_carry) >= total_modulus {
                 return false;
             }
+
+            preceding_block_carry = degree_after_add / msg_mod;
+            preceding_scaled_z = z / msg_mod;
         }
         true
     }


### PR DESCRIPTION
The way we did the is_neg/add/sub possible at the integer level was incorrect in two ways.

1) We simply called the is_neg/add/sub_possible from
   the shortint impl on each block as if the were independant.
   However that is not the case, and to the check did not reflect
   actual computation.

2) We checked that we did not go beyond max degree on each block,
   However, a more correct approach would be to check that adding
   the potential carry from preceding block would not exceeding the
   current block max capacity.

Fixes asserts for is_sub_possible being triggered in  https://github.com/zama-ai/tfhe-rs/pull/536
