### PR TITLE
refactor(core): remove a copy in the external product

### DIFF
--- a/tfhe/src/core_crypto/fft_impl/fft64/crypto/ggsw.rs
+++ b/tfhe/src/core_crypto/fft_impl/fft64/crypto/ggsw.rs
@@ -1,6 +1,6 @@
 use super::super::math::decomposition::TensorSignedDecompositionLendingIter;
 use super::super::math::fft::{FftView, FourierPolynomialList};
-use super::super::math::polynomial::{FourierPolynomialMutView, FourierPolynomialView};
+use super::super::math::polynomial::FourierPolynomialMutView;
 use crate::core_crypto::commons::math::decomposition::{DecompositionLevel, SignedDecomposer};
 use crate::core_crypto::commons::math::torus::UnsignedTorus;
 use crate::core_crypto::commons::parameters::{
@@ -588,10 +588,12 @@ pub fn add_external_product_assign<Scalar, InputGlweCont>(
             out.as_mut_polynomial_list().iter_mut(),
             output_fft_buffer
                 .into_chunks(fourier_poly_size)
-                .map(|slice| FourierPolynomialView { data: slice }),
+                .map(|slice| FourierPolynomialMutView { data: slice }),
         )
         .for_each(|(out, fourier)| {
-            fft.add_backward_as_torus(out, fourier, substack0.rb_mut());
+            // The fourier buffer is not re-used afterwards so we can use the in-place version of
+            // the add_backward_as_torus function
+            fft.add_backward_in_place_as_torus(out, fourier, substack0.rb_mut());
         });
     }
 }


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
### PR content/description

- add an fft backward primitive that can use the input fourier buffer as output as well
- gains 0.6 ms on 2_2 m6i.metal

### Check-list:

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [x] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
