### PR TITLE
fix(integer): remove remove if_then_else assert

### DIFF
--- a/tfhe/src/integer/server_key/radix_parallel/cmux.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/cmux.rs
@@ -12,11 +12,6 @@ impl ServerKey {
     where
         T: IntegerRadixCiphertext,
     {
-        assert!(
-            condition.holds_boolean_value(),
-            "The condition ciphertext does not encrypt a boolean (0 or 1) value"
-        );
-
         let condition_block = &condition.blocks()[0];
         self.unchecked_programmable_if_then_else_parallelized(
             condition_block,


### PR DESCRIPTION
unchecked_if_then_else had an assert that required that the condition value looked like it encrypts a boolean usind the degree

However, the only cases where a value looks like it encrypts a boolean value is when they are the result of a comparison (lt, le, eq, etc).

But there are other cases were the value holds a boolean value but due to how degree works, it's not possible to know thus limiting the use of if_then_else.

So we remove that assert, and rely on the developpe knowing its condition is 0 or 1.


Fixes: https://github.com/zama-ai/tfhe-rs/issues/615
Fixes: https://github.com/zama-ai/tfhe-rs-internal/issues/246
