### PR TITLE
feat(integer): speed-up division by using overflowing_sub

### DIFF
--- a/tfhe/src/integer/server_key/comparator.rs
+++ b/tfhe/src/integer/server_key/comparator.rs
@@ -845,17 +845,26 @@ where {
         T: IntegerRadixCiphertext,
     {
         let sign = self.unchecked_compare_parallelized(lhs, rhs);
+        let do_clean_message = true;
         match selector {
             MinMaxSelector::Max => self
                 .server_key
-                .unchecked_programmable_if_then_else_parallelized(&sign, lhs, rhs, |sign| {
-                    sign == Self::IS_SUPERIOR
-                }),
+                .unchecked_programmable_if_then_else_parallelized(
+                    &sign,
+                    lhs,
+                    rhs,
+                    |sign| sign == Self::IS_SUPERIOR,
+                    do_clean_message,
+                ),
             MinMaxSelector::Min => self
                 .server_key
-                .unchecked_programmable_if_then_else_parallelized(&sign, lhs, rhs, |sign| {
-                    sign == Self::IS_INFERIOR
-                }),
+                .unchecked_programmable_if_then_else_parallelized(
+                    &sign,
+                    lhs,
+                    rhs,
+                    |sign| sign == Self::IS_INFERIOR,
+                    do_clean_message,
+                ),
         }
     }
 
@@ -873,17 +882,26 @@ where {
         let rhs = self
             .server_key
             .create_trivial_radix(rhs, lhs.blocks().len());
+        let do_clean_message = true;
         match selector {
             MinMaxSelector::Max => self
                 .server_key
-                .unchecked_programmable_if_then_else_parallelized(&sign, lhs, &rhs, |sign| {
-                    sign == Self::IS_SUPERIOR
-                }),
+                .unchecked_programmable_if_then_else_parallelized(
+                    &sign,
+                    lhs,
+                    &rhs,
+                    |sign| sign == Self::IS_SUPERIOR,
+                    do_clean_message,
+                ),
             MinMaxSelector::Min => self
                 .server_key
-                .unchecked_programmable_if_then_else_parallelized(&sign, lhs, &rhs, |sign| {
-                    sign == Self::IS_INFERIOR
-                }),
+                .unchecked_programmable_if_then_else_parallelized(
+                    &sign,
+                    lhs,
+                    &rhs,
+                    |sign| sign == Self::IS_INFERIOR,
+                    do_clean_message,
+                ),
         }
     }
 

--- a/tfhe/src/integer/server_key/radix_parallel/sub.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/sub.rs
@@ -389,7 +389,7 @@ impl ServerKey {
             output_borrow.degree.0 = 1;
             (ct, output_borrow)
         } else {
-            self.unsigned_overflowing_sub(lhs, rhs)
+            self.unchecked_unsigned_overflowing_sub(lhs, rhs)
         }
     }
 


### PR DESCRIPTION
using overflowing sub allows to remove the comparison used in the algorithm, giving significant performance boost.

```
before
                8        16       32      40       64       128        256
hpc7a:    `981 ms` `2.53 s` `6.41 s` `9.04 s` `16.1 s` `39.3 s` `1.55 min`
m6i:        `1.10 s` `2.97 s` `7.17 s` `10.5 s` `19.7 s` `50.2 s` `2.11 min`

afer:
                8        16       32      40       64       128        256
hpc7a:   `604 ms` `1.6 s`  `3.8 s`  `5.14 s` `9.4 s`  `22.4 s`  `54.613 s`
m6i:      `659 ms` `1.77 s` `4.4 s`  `5.9 s`  `11.5 s` `29.8 s`  `79.95 s`
```

