### PR TITLE
fix(integer): handle trivial ct in if_then_else

### DIFF
--- a/tfhe/src/integer/server_key/radix_parallel/cmux.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/cmux.rs
@@ -224,7 +224,12 @@ impl ServerKey {
         assert!(condition_block.degree.0 < condition_block.message_modulus.0);
 
         if condition_block.degree.0 == 0 {
-            return self.create_trivial_zero_assign_radix(ct);
+            // The block 'encrypts'  0, and only 0
+            if predicate(0u64) {
+                self.create_trivial_zero_assign_radix(ct);
+            }
+            // else, condition is false, don't do anything
+            return;
         }
 
         let lut =

--- a/tfhe/src/integer/server_key/radix_parallel/tests_cases_unsigned.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_cases_unsigned.rs
@@ -2345,6 +2345,51 @@ where
             }
         );
     }
+
+    // Some test with trivial ciphertext as input
+    let one = sks.create_trivial_radix(1, NB_CTXT);
+    let two = sks.create_trivial_radix(2, NB_CTXT);
+    {
+        // Condition is false
+        let condition: RadixCiphertext = sks.create_trivial_zero_radix(NB_CTXT);
+        assert!(condition.blocks.iter().all(|b| b.degree.0 == 0));
+
+        let result = executor.execute((&condition, &one, &two));
+        assert!(result.block_carries_are_empty());
+        assert_eq!(cks.decrypt::<u64>(&result), 2);
+
+        let result = executor.execute((&condition, &one, &one));
+        assert!(result.block_carries_are_empty());
+        assert_eq!(cks.decrypt::<u64>(&result), 1);
+
+        let result = executor.execute((&condition, &two, &one));
+        assert!(result.block_carries_are_empty());
+        assert_eq!(cks.decrypt::<u64>(&result), 1);
+
+        let result = executor.execute((&condition, &two, &two));
+        assert!(result.block_carries_are_empty());
+        assert_eq!(cks.decrypt::<u64>(&result), 2);
+    }
+    {
+        // Condition is true
+        let condition: RadixCiphertext = sks.create_trivial_radix(1, NB_CTXT);
+
+        let result = executor.execute((&condition, &one, &two));
+        assert!(result.block_carries_are_empty());
+        assert_eq!(cks.decrypt::<u64>(&result), 1);
+
+        let result = executor.execute((&condition, &one, &one));
+        assert!(result.block_carries_are_empty());
+        assert_eq!(cks.decrypt::<u64>(&result), 1);
+
+        let result = executor.execute((&condition, &two, &one));
+        assert!(result.block_carries_are_empty());
+        assert_eq!(cks.decrypt::<u64>(&result), 2);
+
+        let result = executor.execute((&condition, &two, &two));
+        assert!(result.block_carries_are_empty());
+        assert_eq!(cks.decrypt::<u64>(&result), 2);
+    }
 }
 
 //=============================================================================


### PR DESCRIPTION
if_then_else uses two calls to zero_out_if.

In zero_out_if, if the condition block given has a degree of 0
then it would return 0, without calling the predicate function.

This is not correct, as its the predicate function that
gives whether the output should be 0 or the original ciphertext.

Which meant that if if_then_else received a condition with a
degree of 0, it would always return 0.
### Check-list:

* [x] Tests for the changes have been added (for bug fixes / features)
