### PR TITLE
fix(integer): fix unsigned_overflowing_sub on trivials

### DIFF
--- a/tfhe/src/integer/server_key/radix/sub.rs
+++ b/tfhe/src/integer/server_key/radix/sub.rs
@@ -416,7 +416,17 @@ impl ServerKey {
         let mut borrow = self.key.create_trivial(0);
         let mut new_blocks = Vec::with_capacity(lhs.blocks.len());
         for (lhs_b, rhs_b) in lhs.blocks.iter().zip(rhs.blocks.iter()) {
-            let mut result_block = self.key.unchecked_sub(lhs_b, rhs_b);
+            let (mut result_block, correction) =
+                self.key.unchecked_sub_with_correcting_term(lhs_b, rhs_b);
+            if correction == 0 {
+                // When rhs_block is a trivial zero, the correcting term added is 0
+                // However we rely on that correcting term to be added regardless
+                assert_eq!(rhs_b.degree.0, 0);
+                self.key.unchecked_scalar_add_assign(
+                    &mut result_block,
+                    self.key.message_modulus.0 as u8,
+                );
+            }
             // Here unchecked_sub_assign does not give correct result, we don't want
             // the correcting term to be used
             // -> This is ok as the value returned by unchecked_sub is in range 1..(message_mod * 2)


### PR DESCRIPTION
unsigned_overflowing_sub does an independant subtraction on each blocks with a correcting term being added to avoid trashing the padding bit (lhs - rhs + correction).

The correction depended on rhs's degree.
e.g. if rhs's degree was in range 1..(msg_mod-1) -> correction =
     msg_mod

However if rhs's degree was zero (so rhs is a trivial 0), the correction was also 0, however the borrow propagation rely on that correction to always be added.

Fixes https://github.com/zama-ai/tfhe-rs-internal/issues/296

### Check-list:

* [x] Tests for the changes have been added (for bug fixes / features)
