### PR TITLE
fix(integer): fix worst case noise growth in encrypted shifts

### DIFF
--- a/tfhe/src/integer/server_key/radix_parallel/bit_extractor.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/bit_extractor.rs
@@ -12,9 +12,29 @@ pub(crate) struct BitExtractor<'a> {
 
 impl<'a> BitExtractor<'a> {
     pub(crate) fn new(server_key: &'a ServerKey, bits_per_block: usize) -> Self {
+        Self::with_final_offset(server_key, bits_per_block, 0)
+    }
+
+    /// Creates a bit extractor that will extract bits from an input ciphertext
+    /// into single blocks.
+    ///
+    /// The final offset gives the position where the extracted bit shall be placed
+    /// in the resulting block.
+    /// It may be used to align the bit with a certain position to avoid
+    /// shifting it later (and increasing noise)
+    pub(crate) fn with_final_offset(
+        server_key: &'a ServerKey,
+        bits_per_block: usize,
+        final_offset: usize,
+    ) -> Self {
         let bit_extract_luts = (0..bits_per_block)
             .into_par_iter()
-            .map(|i| server_key.key.generate_lookup_table(|x| (x >> i) & 1))
+            .map(|i| {
+                server_key.key.generate_lookup_table(|x| {
+                    let bit_value = (x >> i) & 1;
+                    bit_value << final_offset
+                })
+            })
             .collect::<Vec<_>>();
 
         Self {


### PR DESCRIPTION
In encrypted shifts we pack 3 bits from 3 different blocks into the same blocks by doing `b0 * 4 + 2 * b1 + b2`, and then do a PBS to simulate a hardware mux gate.

If the inputs of shift (ie, in lhs << rhs, lhs != rhs, ie we don't do lhs << lhs) this is fine regarding the norm2 noise.

However if we do things like `a << a` or `a >> a`, which is probably a very rare thing but not impossible, the norm2 noise would go above the limit that guarantees our error probability.

To fix that, we extract the bits that tells shift amount, so that they are already properly aligned to their mux input position. The packing becomes `b0 + 2 * b1 + b2` and so,
the noise growth is ok even in the worst case of doind `a << a`.