### PR TITLE
Boolean value wrapper

### DIFF
--- a/tfhe/benches/integer/bench.rs
+++ b/tfhe/benches/integer/bench.rs
@@ -524,7 +524,7 @@ fn if_then_else_parallelized(c: &mut Criterion) {
                 let clear_1 = gen_random_u256(&mut rng);
                 let ct_1 = cks.encrypt_radix(clear_1, num_block);
 
-                let cond = sks.create_trivial_radix(rng.gen_bool(0.5) as u64, num_block);
+                let cond = sks.create_trivial_boolean_block(rng.gen_bool(0.5));
 
                 (cond, ct_0, ct_1)
             };

--- a/tfhe/benches/integer/signed_bench.rs
+++ b/tfhe/benches/integer/signed_bench.rs
@@ -272,7 +272,7 @@ fn signed_if_then_else_parallelized(c: &mut Criterion) {
                 let ct_0 = cks.encrypt_signed_radix(gen_random_i256(&mut rng), num_block);
                 let ct_1 = cks.encrypt_signed_radix(gen_random_i256(&mut rng), num_block);
 
-                let cond = sks.create_trivial_radix(rng.gen_bool(0.5) as u64, num_block);
+                let cond = sks.create_trivial_boolean_block(rng.gen_bool(0.5));
 
                 (cond, ct_0, ct_1)
             };

--- a/tfhe/examples/dark_market/improved_parallel_fhe.rs
+++ b/tfhe/examples/dark_market/improved_parallel_fhe.rs
@@ -3,7 +3,7 @@ use std::time::Instant;
 use rayon::prelude::*;
 
 use tfhe::integer::ciphertext::RadixCiphertext;
-use tfhe::integer::ServerKey;
+use tfhe::integer::{IntegerCiphertext, ServerKey};
 
 use crate::NUMBER_OF_BLOCKS;
 
@@ -70,10 +70,12 @@ fn fill_orders(
                 );
 
                 // total_orders > prefix_sum
-                let mut cond = server_key.smart_gt_parallelized(
-                    &mut total_orders.clone(),
-                    &mut previous_prefix_sum.clone(),
-                );
+                let mut cond = server_key
+                    .smart_gt_parallelized(
+                        &mut total_orders.clone(),
+                        &mut previous_prefix_sum.clone(),
+                    )
+                    .into_radix(diff.blocks().len(), server_key);
 
                 // (total_orders - previous_prefix_sum) * (total_orders > previous_prefix_sum)
                 // = (total_orders - previous_prefix_sum).max(0)

--- a/tfhe/examples/regex_engine/execution.rs
+++ b/tfhe/examples/regex_engine/execution.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::rc::Rc;
-use tfhe::integer::{RadixCiphertext, ServerKey};
+use tfhe::integer::{IntegerCiphertext, RadixCiphertext, ServerKey};
 
 use crate::parser::u8_to_char;
 
@@ -72,7 +72,12 @@ impl Execution {
 
                 let mut ct_a = a.0.clone();
                 let mut ct_b = b.0.clone();
-                (exec.sk.smart_eq(&mut ct_a, &mut ct_b), ctx.clone())
+                (
+                    exec.sk
+                        .smart_eq(&mut ct_a, &mut ct_b)
+                        .into_radix(ct_a.blocks().len(), &exec.sk),
+                    ctx.clone(),
+                )
             }),
         )
     }
@@ -89,7 +94,12 @@ impl Execution {
 
                 let mut ct_a = a.0.clone();
                 let mut ct_b = b.0.clone();
-                (exec.sk.smart_gt(&mut ct_a, &mut ct_b), ctx.clone())
+                (
+                    exec.sk
+                        .smart_gt(&mut ct_a, &mut ct_b)
+                        .into_radix(ct_a.blocks().len(), &exec.sk),
+                    ctx.clone(),
+                )
             }),
         )
     }
@@ -106,7 +116,12 @@ impl Execution {
 
                 let mut ct_a = a.0.clone();
                 let mut ct_b = b.0.clone();
-                (exec.sk.smart_le(&mut ct_a, &mut ct_b), ctx.clone())
+                (
+                    exec.sk
+                        .smart_le(&mut ct_a, &mut ct_b)
+                        .into_radix(ct_a.blocks().len(), &exec.sk),
+                    ctx.clone(),
+                )
             }),
         )
     }

--- a/tfhe/src/high_level_api/integers/types/base.rs
+++ b/tfhe/src/high_level_api/integers/types/base.rs
@@ -17,6 +17,7 @@ use crate::high_level_api::traits::{
 };
 use crate::high_level_api::{ClientKey, PublicKey};
 use crate::integer::block_decomposition::DecomposableInto;
+use crate::integer::ciphertext::boolean_value::BooleanBlock;
 use crate::integer::ciphertext::{IntegerRadixCiphertext, RadixCiphertext};
 use crate::integer::parameters::RadixCiphertextConformanceParams;
 use crate::integer::{IntegerCiphertext, SignedRadixCiphertext, I256, U256};
@@ -203,7 +204,8 @@ where
         let ct_condition = self;
         let new_ct = ct_condition.id.with_unwrapped_global(|integer_key| {
             integer_key.pbs_key().if_then_else_parallelized(
-                &ct_condition.ciphertext,
+                &BooleanBlock::try_new(&ct_condition.ciphertext)
+                    .expect("if_then_else requires a boolean value"),
                 &ct_then.ciphertext,
                 &ct_else.ciphertext,
             )
@@ -482,18 +484,20 @@ where
 
     fn eq(&self, rhs: Self) -> Self::Output {
         let inner_result = self.id.with_unwrapped_global(|integer_key| {
-            integer_key
-                .pbs_key()
+            let pbs_key = integer_key.pbs_key();
+            pbs_key
                 .eq_parallelized(&self.ciphertext, &rhs.ciphertext)
+                .into_radix(P::num_blocks(), pbs_key)
         });
         Self::new(inner_result, self.id)
     }
 
     fn ne(&self, rhs: Self) -> Self::Output {
         let inner_result = self.id.with_unwrapped_global(|integer_key| {
-            integer_key
-                .pbs_key()
+            let pbs_key = integer_key.pbs_key();
+            pbs_key
                 .ne_parallelized(&self.ciphertext, &rhs.ciphertext)
+                .into_radix(P::num_blocks(), pbs_key)
         });
         Self::new(inner_result, self.id)
     }
@@ -509,18 +513,20 @@ where
 
     fn eq(&self, rhs: &Self) -> Self::Output {
         let inner_result = self.id.with_unwrapped_global(|integer_key| {
-            integer_key
-                .pbs_key()
+            let pbs_key = integer_key.pbs_key();
+            pbs_key
                 .eq_parallelized(&self.ciphertext, &rhs.ciphertext)
+                .into_radix(P::num_blocks(), pbs_key)
         });
         Self::new(inner_result, self.id)
     }
 
     fn ne(&self, rhs: &Self) -> Self::Output {
         let inner_result = self.id.with_unwrapped_global(|integer_key| {
-            integer_key
-                .pbs_key()
+            let pbs_key = integer_key.pbs_key();
+            pbs_key
                 .ne_parallelized(&self.ciphertext, &rhs.ciphertext)
+                .into_radix(P::num_blocks(), pbs_key)
         });
         Self::new(inner_result, self.id)
     }
@@ -537,18 +543,20 @@ where
 
     fn eq(&self, rhs: Clear) -> Self::Output {
         let inner_result = self.id.with_unwrapped_global(|integer_key| {
-            integer_key
-                .pbs_key()
+            let pbs_key = integer_key.pbs_key();
+            pbs_key
                 .scalar_eq_parallelized(&self.ciphertext, rhs)
+                .into_radix(P::num_blocks(), pbs_key)
         });
         Self::new(inner_result, self.id)
     }
 
     fn ne(&self, rhs: Clear) -> Self::Output {
         let inner_result = self.id.with_unwrapped_global(|integer_key| {
-            integer_key
-                .pbs_key()
+            let pbs_key = integer_key.pbs_key();
+            pbs_key
                 .scalar_ne_parallelized(&self.ciphertext, rhs)
+                .into_radix(P::num_blocks(), pbs_key)
         });
         Self::new(inner_result, self.id)
     }
@@ -564,36 +572,40 @@ where
 
     fn lt(&self, rhs: Self) -> Self::Output {
         let inner_result = self.id.with_unwrapped_global(|integer_key| {
-            integer_key
-                .pbs_key()
+            let pbs_key = integer_key.pbs_key();
+            pbs_key
                 .lt_parallelized(&self.ciphertext, &rhs.ciphertext)
+                .into_radix(P::num_blocks(), pbs_key)
         });
         Self::new(inner_result, self.id)
     }
 
     fn le(&self, rhs: Self) -> Self::Output {
         let inner_result = self.id.with_unwrapped_global(|integer_key| {
-            integer_key
-                .pbs_key()
+            let pbs_key = integer_key.pbs_key();
+            pbs_key
                 .le_parallelized(&self.ciphertext, &rhs.ciphertext)
+                .into_radix(P::num_blocks(), pbs_key)
         });
         Self::new(inner_result, self.id)
     }
 
     fn gt(&self, rhs: Self) -> Self::Output {
         let inner_result = self.id.with_unwrapped_global(|integer_key| {
-            integer_key
-                .pbs_key()
+            let pbs_key = integer_key.pbs_key();
+            pbs_key
                 .gt_parallelized(&self.ciphertext, &rhs.ciphertext)
+                .into_radix(P::num_blocks(), pbs_key)
         });
         Self::new(inner_result, self.id)
     }
 
     fn ge(&self, rhs: Self) -> Self::Output {
         let inner_result = self.id.with_unwrapped_global(|integer_key| {
-            integer_key
-                .pbs_key()
+            let pbs_key = integer_key.pbs_key();
+            pbs_key
                 .ge_parallelized(&self.ciphertext, &rhs.ciphertext)
+                .into_radix(P::num_blocks(), pbs_key)
         });
         Self::new(inner_result, self.id)
     }
@@ -609,36 +621,40 @@ where
 
     fn lt(&self, rhs: &Self) -> Self::Output {
         let inner_result = self.id.with_unwrapped_global(|integer_key| {
-            integer_key
-                .pbs_key()
+            let pbs_key = integer_key.pbs_key();
+            pbs_key
                 .lt_parallelized(&self.ciphertext, &rhs.ciphertext)
+                .into_radix(P::num_blocks(), pbs_key)
         });
         Self::new(inner_result, self.id)
     }
 
     fn le(&self, rhs: &Self) -> Self::Output {
         let inner_result = self.id.with_unwrapped_global(|integer_key| {
-            integer_key
-                .pbs_key()
+            let pbs_key = integer_key.pbs_key();
+            pbs_key
                 .le_parallelized(&self.ciphertext, &rhs.ciphertext)
+                .into_radix(P::num_blocks(), pbs_key)
         });
         Self::new(inner_result, self.id)
     }
 
     fn gt(&self, rhs: &Self) -> Self::Output {
         let inner_result = self.id.with_unwrapped_global(|integer_key| {
-            integer_key
-                .pbs_key()
+            let pbs_key = integer_key.pbs_key();
+            pbs_key
                 .gt_parallelized(&self.ciphertext, &rhs.ciphertext)
+                .into_radix(P::num_blocks(), pbs_key)
         });
         Self::new(inner_result, self.id)
     }
 
     fn ge(&self, rhs: &Self) -> Self::Output {
         let inner_result = self.id.with_unwrapped_global(|integer_key| {
-            integer_key
-                .pbs_key()
+            let pbs_key = integer_key.pbs_key();
+            pbs_key
                 .ge_parallelized(&self.ciphertext, &rhs.ciphertext)
+                .into_radix(P::num_blocks(), pbs_key)
         });
         Self::new(inner_result, self.id)
     }
@@ -655,36 +671,40 @@ where
 
     fn lt(&self, rhs: Clear) -> Self::Output {
         let inner_result = self.id.with_unwrapped_global(|integer_key| {
-            integer_key
-                .pbs_key()
+            let pbs_key = integer_key.pbs_key();
+            pbs_key
                 .scalar_lt_parallelized(&self.ciphertext, rhs)
+                .into_radix(P::num_blocks(), pbs_key)
         });
         Self::new(inner_result, self.id)
     }
 
     fn le(&self, rhs: Clear) -> Self::Output {
         let inner_result = self.id.with_unwrapped_global(|integer_key| {
-            integer_key
-                .pbs_key()
+            let pbs_key = integer_key.pbs_key();
+            pbs_key
                 .scalar_le_parallelized(&self.ciphertext, rhs)
+                .into_radix(P::num_blocks(), pbs_key)
         });
         Self::new(inner_result, self.id)
     }
 
     fn gt(&self, rhs: Clear) -> Self::Output {
         let inner_result = self.id.with_unwrapped_global(|integer_key| {
-            integer_key
-                .pbs_key()
+            let pbs_key = integer_key.pbs_key();
+            pbs_key
                 .scalar_gt_parallelized(&self.ciphertext, rhs)
+                .into_radix(P::num_blocks(), pbs_key)
         });
         Self::new(inner_result, self.id)
     }
 
     fn ge(&self, rhs: Clear) -> Self::Output {
         let inner_result = self.id.with_unwrapped_global(|integer_key| {
-            integer_key
-                .pbs_key()
+            let pbs_key = integer_key.pbs_key();
+            pbs_key
                 .scalar_ge_parallelized(&self.ciphertext, rhs)
+                .into_radix(P::num_blocks(), pbs_key)
         });
         Self::new(inner_result, self.id)
     }

--- a/tfhe/src/integer/ciphertext/boolean_value.rs
+++ b/tfhe/src/integer/ciphertext/boolean_value.rs
@@ -1,0 +1,133 @@
+use super::{IntegerCiphertext, IntegerRadixCiphertext};
+use crate::integer::{RadixCiphertext, ServerKey};
+use crate::shortint::Ciphertext;
+use serde::{Deserialize, Serialize};
+
+/// Wrapper type used to signal that the inner value encrypts 0 or 1
+///
+/// Since values ares encrypted, it is not possible to know whether a
+/// ciphertext encrypts a boolean value (0 or 1). However some algorithms
+/// require that the ciphertext does indeed encrypt a boolean value.
+///
+/// This wrapper serves as making it explicit that it is known that the value
+/// encrypted is 0 or 1. And that if a function taking a BooleanBlock as input
+/// returns incorrect value, it may be due to the value not really being 0 or 1.
+///
+/// Also some function such as comparisons are known to return an encrypted value
+/// that is either 0 or 1, and thus return a Ciphertext wrapped in a [BooleanBlock].
+///
+/// # Examples
+/// ## Converting a [BooleanBlock] to a [RadixCiphertext]
+///
+/// ```
+/// use tfhe::integer::{gen_keys_radix, BooleanBlock};
+/// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+///
+/// // We have 4 * 2 = 8 bits of message
+/// let size = 4;
+/// let (cks, sks) = gen_keys_radix(PARAM_MESSAGE_2_CARRY_2_KS_PBS, size);
+///
+/// let a = 128u8;
+/// let b = 55u8;
+///
+/// let ct_a = cks.encrypt(a);
+/// let ct_b = cks.encrypt(b);
+///
+/// let ct_res = sks.ge_parallelized(&ct_a, &ct_b);
+/// // Convert the boolean value to a RadixCiphertext of size blocks
+/// // so we can use it in operations
+/// let ct_res = ct_res.into_radix(size, &sks);
+/// // Decrypt:
+/// let dec: u8 = cks.decrypt(&ct_res);
+/// assert_eq!(u8::from(a >= b), dec);
+/// ```
+#[derive(Clone, Deserialize, Serialize)]
+pub struct BooleanBlock(pub(crate) Ciphertext);
+
+impl BooleanBlock {
+    /// Creates a new BooleanBlock without checks.
+    ///
+    /// You have to be sure the ciphertext encrypts 0 or 1 otherwise
+    /// functions expecting a BooleanBlock could result in wrong computation
+    pub fn new_unchecked(block: Ciphertext) -> Self {
+        Self(block)
+    }
+
+    /// Creates a new BooleanBlock, but does some checks to see
+    /// if it seems plausible that it encrypts a boolean.
+    ///
+    /// Sometimes these checks may prove to be too strict,
+    /// and you might need to use [BooleanBlock::new_unchecked] if you know it actually does encrypt
+    /// a boolean, or [BooleanBlock::convert] if there is some uncertainty.
+    pub fn try_new<T>(ct: &T) -> Option<Self>
+    where
+        T: IntegerRadixCiphertext,
+    {
+        if ct.holds_boolean_value() {
+            Some(Self(ct.blocks()[0].clone()))
+        } else {
+            None
+        }
+    }
+
+    /// Creates a new BooleanBlock by doing a PBS to ensure the result in either O or 1
+    ///
+    /// It is equivalent to doing `let b: bool = value != 0`
+    ///
+    /// # Examples
+    /// ## Converting a [BooleanBlock] to a [RadixCiphertext]
+    ///
+    /// ```
+    /// use tfhe::integer::{gen_keys_radix, BooleanBlock};
+    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    ///
+    /// // We have 4 * 2 = 8 bits of message
+    /// let size = 4;
+    /// let (cks, sks) = gen_keys_radix(PARAM_MESSAGE_2_CARRY_2_KS_PBS, size);
+    ///
+    /// let a = 128u8;
+    /// let ct_a = cks.encrypt(a);
+    ///
+    /// let ct_b = BooleanBlock::convert(&ct_a, &sks);
+    ///
+    /// // Decrypt:
+    /// let dec = cks.decrypt_bool(&ct_b);
+    /// assert_eq!(a != 0, dec);
+    /// ```
+    pub fn convert<T>(ct: &T, sks: &ServerKey) -> Self
+    where
+        T: IntegerRadixCiphertext,
+    {
+        if !ct.holds_boolean_value() {
+            sks.scalar_ne_parallelized(ct, 0)
+        } else {
+            let block = ct.blocks()[0].clone();
+            Self(block)
+        }
+    }
+
+    /// Consumes the BooleanBlock to return its inner ciphertext
+    pub fn into_inner(self) -> Ciphertext {
+        self.0
+    }
+
+    /// Consumes and converts the BooleanBlock to a [RadixCiphertext] / [SignedRadixCiphertext]
+    /// with the given number of blocks.
+    ///
+    /// [SignedRadixCiphertext]: crate::integer::SignedRadixCiphertext
+    pub fn into_radix<T>(self, num_blocks: usize, sks: &ServerKey) -> T
+    where
+        T: IntegerRadixCiphertext,
+    {
+        let mut radix_ct = RadixCiphertext::from_blocks(vec![self.0]);
+        let missing_blocks = num_blocks.saturating_sub(1);
+        sks.extend_radix_with_trivial_zero_blocks_msb_assign(&mut radix_ct, missing_blocks);
+        T::from_blocks(radix_ct.blocks)
+    }
+}
+
+impl AsRef<Ciphertext> for BooleanBlock {
+    fn as_ref(&self) -> &Ciphertext {
+        &self.0
+    }
+}

--- a/tfhe/src/integer/ciphertext/mod.rs
+++ b/tfhe/src/integer/ciphertext/mod.rs
@@ -1,4 +1,6 @@
 //! This module implements the ciphertext structures.
+pub mod boolean_value;
+
 use super::parameters::{
     RadixCiphertextConformanceParams, RadixCompactCiphertextListConformanceParams,
 };
@@ -191,15 +193,17 @@ impl From<CompressedSignedRadixCiphertext> for SignedRadixCiphertext {
 }
 
 pub trait IntegerCiphertext: Clone {
-    fn from_blocks(blocks: Vec<Ciphertext>) -> Self;
     fn blocks(&self) -> &[Ciphertext];
-    fn blocks_mut(&mut self) -> &mut [Ciphertext];
     fn moduli(&self) -> Vec<u64> {
         self.blocks()
             .iter()
             .map(|x| x.message_modulus.0 as u64)
             .collect()
     }
+
+    fn from_blocks(blocks: Vec<Ciphertext>) -> Self;
+
+    fn blocks_mut(&mut self) -> &mut [Ciphertext];
 }
 
 pub trait IntegerRadixCiphertext: IntegerCiphertext + Sync + Send + From<Vec<Ciphertext>> {
@@ -222,13 +226,14 @@ pub trait IntegerRadixCiphertext: IntegerCiphertext + Sync + Send + From<Vec<Cip
 }
 
 impl IntegerCiphertext for RadixCiphertext {
+    fn blocks(&self) -> &[Ciphertext] {
+        &self.blocks
+    }
+
     fn from_blocks(blocks: Vec<Ciphertext>) -> Self {
         Self::from(blocks)
     }
 
-    fn blocks(&self) -> &[Ciphertext] {
-        &self.blocks
-    }
     fn blocks_mut(&mut self) -> &mut [Ciphertext] {
         &mut self.blocks
     }
@@ -243,12 +248,14 @@ impl IntegerRadixCiphertext for RadixCiphertext {
 }
 
 impl IntegerCiphertext for SignedRadixCiphertext {
-    fn from_blocks(blocks: Vec<Ciphertext>) -> Self {
-        Self::from(blocks)
-    }
     fn blocks(&self) -> &[Ciphertext] {
         &self.blocks
     }
+
+    fn from_blocks(blocks: Vec<Ciphertext>) -> Self {
+        Self::from(blocks)
+    }
+
     fn blocks_mut(&mut self) -> &mut [Ciphertext] {
         &mut self.blocks
     }
@@ -263,13 +270,15 @@ impl IntegerRadixCiphertext for SignedRadixCiphertext {
 }
 
 impl IntegerCiphertext for CrtCiphertext {
+    fn blocks(&self) -> &[Ciphertext] {
+        &self.blocks
+    }
+
     fn from_blocks(blocks: Vec<Ciphertext>) -> Self {
         let moduli = blocks.iter().map(|x| x.message_modulus.0 as u64).collect();
         Self { blocks, moduli }
     }
-    fn blocks(&self) -> &[Ciphertext] {
-        &self.blocks
-    }
+
     fn blocks_mut(&mut self) -> &mut [Ciphertext] {
         &mut self.blocks
     }

--- a/tfhe/src/integer/client_key/radix.rs
+++ b/tfhe/src/integer/client_key/radix.rs
@@ -4,6 +4,7 @@ use super::{ClientKey, RecomposableSignedInteger};
 use crate::core_crypto::prelude::{SignedNumeric, UnsignedNumeric};
 use crate::integer::block_decomposition::{DecomposableInto, RecomposableFrom};
 use crate::integer::ciphertext::{RadixCiphertext, SignedRadixCiphertext};
+use crate::integer::BooleanBlock;
 use crate::shortint::{Ciphertext as ShortintCiphertext, PBSParameters as ShortintParameters};
 use serde::{Deserialize, Serialize};
 
@@ -67,6 +68,10 @@ impl RadixClientKey {
         self.key.encrypt_signed_radix(message, self.num_blocks)
     }
 
+    pub fn encrypt_bool(&self, msg: bool) -> BooleanBlock {
+        self.key.encrypt_bool(msg)
+    }
+
     pub fn decrypt<T>(&self, ciphertext: &RadixCiphertext) -> T
     where
         T: RecomposableFrom<u64> + UnsignedNumeric,
@@ -79,6 +84,10 @@ impl RadixClientKey {
         T: RecomposableSignedInteger,
     {
         self.key.decrypt_signed_radix(ciphertext)
+    }
+
+    pub fn decrypt_bool(&self, ciphertext: &BooleanBlock) -> bool {
+        self.key.decrypt_bool(ciphertext)
     }
 
     /// Returns the parameters used by the client key.

--- a/tfhe/src/integer/mod.rs
+++ b/tfhe/src/integer/mod.rs
@@ -67,6 +67,7 @@ pub use bigint::i256::I256;
 pub use bigint::i512::I512;
 pub use bigint::u256::U256;
 pub use bigint::u512::U512;
+pub use ciphertext::boolean_value::BooleanBlock;
 pub use ciphertext::{
     CrtCiphertext, IntegerCiphertext, IntegerRadixCiphertext, RadixCiphertext,
     SignedRadixCiphertext,

--- a/tfhe/src/integer/server_key/mod.rs
+++ b/tfhe/src/integer/server_key/mod.rs
@@ -170,7 +170,7 @@ mod test {
             for _ in 0..5 {
                 res_ct = evaluation_key.smart_add_parallelized(&mut res_ct, &mut ct);
             }
-            let res = client_key.decrypt::<u128>(&res_ct);
+            let res: u128 = client_key.decrypt(&res_ct);
             assert_eq!(modulus - 6, res);
         }
     }

--- a/tfhe/src/integer/server_key/radix/mod.rs
+++ b/tfhe/src/integer/server_key/radix/mod.rs
@@ -14,7 +14,7 @@ use super::ServerKey;
 use crate::integer::block_decomposition::DecomposableInto;
 use crate::integer::ciphertext::{IntegerRadixCiphertext, RadixCiphertext};
 use crate::integer::encryption::encrypt_words_radix_impl;
-use crate::integer::SignedRadixCiphertext;
+use crate::integer::{BooleanBlock, SignedRadixCiphertext};
 
 #[cfg(test)]
 mod tests;
@@ -58,6 +58,10 @@ impl ServerKey {
         }
 
         T::from_blocks(vec_res)
+    }
+
+    pub fn create_trivial_boolean_block(&self, value: bool) -> BooleanBlock {
+        BooleanBlock::new_unchecked(self.key.create_trivial(u64::from(value)))
     }
 
     /// Create a trivial radix ciphertext

--- a/tfhe/src/integer/server_key/radix_parallel/comparison.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/comparison.rs
@@ -3,10 +3,11 @@ use super::ServerKey;
 use crate::integer::ciphertext::IntegerRadixCiphertext;
 use crate::integer::server_key::comparator::Comparator;
 
+use crate::integer::ciphertext::boolean_value::BooleanBlock;
 use rayon::prelude::*;
 
 impl ServerKey {
-    pub fn unchecked_eq_parallelized<T>(&self, lhs: &T, rhs: &T) -> T
+    pub fn unchecked_eq_parallelized<T>(&self, lhs: &T, rhs: &T) -> BooleanBlock
     where
         T: IntegerRadixCiphertext,
     {
@@ -28,14 +29,10 @@ impl ServerKey {
 
         let is_equal_result = self.are_all_comparisons_block_true(block_comparisons);
 
-        let mut blocks = Vec::with_capacity(lhs.blocks().len());
-        blocks.push(is_equal_result);
-        blocks.resize_with(lhs.blocks().len(), || self.key.create_trivial(0));
-
-        T::from_blocks(blocks)
+        BooleanBlock::new_unchecked(is_equal_result)
     }
 
-    pub fn unchecked_ne_parallelized<T>(&self, lhs: &T, rhs: &T) -> T
+    pub fn unchecked_ne_parallelized<T>(&self, lhs: &T, rhs: &T) -> BooleanBlock
     where
         T: IntegerRadixCiphertext,
     {
@@ -77,33 +74,36 @@ impl ServerKey {
             std::mem::swap(&mut block_comparisons_2, &mut block_comparisons);
         }
 
-        block_comparisons.resize_with(lhs.blocks().len(), || self.key.create_trivial(0));
-
-        T::from_blocks(block_comparisons)
+        BooleanBlock::new_unchecked(
+            block_comparisons
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| self.key.create_trivial(0)),
+        )
     }
 
-    pub fn unchecked_gt_parallelized<T>(&self, lhs: &T, rhs: &T) -> T
+    pub fn unchecked_gt_parallelized<T>(&self, lhs: &T, rhs: &T) -> BooleanBlock
     where
         T: IntegerRadixCiphertext,
     {
         Comparator::new(self).unchecked_gt_parallelized(lhs, rhs)
     }
 
-    pub fn unchecked_ge_parallelized<T>(&self, lhs: &T, rhs: &T) -> T
+    pub fn unchecked_ge_parallelized<T>(&self, lhs: &T, rhs: &T) -> BooleanBlock
     where
         T: IntegerRadixCiphertext,
     {
         Comparator::new(self).unchecked_ge_parallelized(lhs, rhs)
     }
 
-    pub fn unchecked_lt_parallelized<T>(&self, lhs: &T, rhs: &T) -> T
+    pub fn unchecked_lt_parallelized<T>(&self, lhs: &T, rhs: &T) -> BooleanBlock
     where
         T: IntegerRadixCiphertext,
     {
         Comparator::new(self).unchecked_lt_parallelized(lhs, rhs)
     }
 
-    pub fn unchecked_le_parallelized<T>(&self, lhs: &T, rhs: &T) -> T
+    pub fn unchecked_le_parallelized<T>(&self, lhs: &T, rhs: &T) -> BooleanBlock
     where
         T: IntegerRadixCiphertext,
     {
@@ -124,7 +124,7 @@ impl ServerKey {
         Comparator::new(self).unchecked_min_parallelized(lhs, rhs)
     }
 
-    pub fn smart_eq_parallelized<T>(&self, lhs: &mut T, rhs: &mut T) -> T
+    pub fn smart_eq_parallelized<T>(&self, lhs: &mut T, rhs: &mut T) -> BooleanBlock
     where
         T: IntegerRadixCiphertext,
     {
@@ -143,7 +143,7 @@ impl ServerKey {
         self.unchecked_eq_parallelized(lhs, rhs)
     }
 
-    pub fn smart_ne_parallelized<T>(&self, lhs: &mut T, rhs: &mut T) -> T
+    pub fn smart_ne_parallelized<T>(&self, lhs: &mut T, rhs: &mut T) -> BooleanBlock
     where
         T: IntegerRadixCiphertext,
     {
@@ -162,28 +162,28 @@ impl ServerKey {
         self.unchecked_ne_parallelized(lhs, rhs)
     }
 
-    pub fn smart_gt_parallelized<T>(&self, lhs: &mut T, rhs: &mut T) -> T
+    pub fn smart_gt_parallelized<T>(&self, lhs: &mut T, rhs: &mut T) -> BooleanBlock
     where
         T: IntegerRadixCiphertext,
     {
         Comparator::new(self).smart_gt_parallelized(lhs, rhs)
     }
 
-    pub fn smart_ge_parallelized<T>(&self, lhs: &mut T, rhs: &mut T) -> T
+    pub fn smart_ge_parallelized<T>(&self, lhs: &mut T, rhs: &mut T) -> BooleanBlock
     where
         T: IntegerRadixCiphertext,
     {
         Comparator::new(self).smart_ge_parallelized(lhs, rhs)
     }
 
-    pub fn smart_lt_parallelized<T>(&self, lhs: &mut T, rhs: &mut T) -> T
+    pub fn smart_lt_parallelized<T>(&self, lhs: &mut T, rhs: &mut T) -> BooleanBlock
     where
         T: IntegerRadixCiphertext,
     {
         Comparator::new(self).smart_lt_parallelized(lhs, rhs)
     }
 
-    pub fn smart_le_parallelized<T>(&self, lhs: &mut T, rhs: &mut T) -> T
+    pub fn smart_le_parallelized<T>(&self, lhs: &mut T, rhs: &mut T) -> BooleanBlock
     where
         T: IntegerRadixCiphertext,
     {
@@ -204,7 +204,7 @@ impl ServerKey {
         Comparator::new(self).smart_min_parallelized(lhs, rhs)
     }
 
-    pub fn eq_parallelized<T>(&self, lhs: &T, rhs: &T) -> T
+    pub fn eq_parallelized<T>(&self, lhs: &T, rhs: &T) -> BooleanBlock
     where
         T: IntegerRadixCiphertext,
     {
@@ -236,7 +236,7 @@ impl ServerKey {
         self.unchecked_eq_parallelized(lhs, rhs)
     }
 
-    pub fn ne_parallelized<T>(&self, lhs: &T, rhs: &T) -> T
+    pub fn ne_parallelized<T>(&self, lhs: &T, rhs: &T) -> BooleanBlock
     where
         T: IntegerRadixCiphertext,
     {
@@ -268,28 +268,28 @@ impl ServerKey {
         self.unchecked_ne_parallelized(lhs, rhs)
     }
 
-    pub fn gt_parallelized<T>(&self, lhs: &T, rhs: &T) -> T
+    pub fn gt_parallelized<T>(&self, lhs: &T, rhs: &T) -> BooleanBlock
     where
         T: IntegerRadixCiphertext,
     {
         Comparator::new(self).gt_parallelized(lhs, rhs)
     }
 
-    pub fn ge_parallelized<T>(&self, lhs: &T, rhs: &T) -> T
+    pub fn ge_parallelized<T>(&self, lhs: &T, rhs: &T) -> BooleanBlock
     where
         T: IntegerRadixCiphertext,
     {
         Comparator::new(self).ge_parallelized(lhs, rhs)
     }
 
-    pub fn lt_parallelized<T>(&self, lhs: &T, rhs: &T) -> T
+    pub fn lt_parallelized<T>(&self, lhs: &T, rhs: &T) -> BooleanBlock
     where
         T: IntegerRadixCiphertext,
     {
         Comparator::new(self).lt_parallelized(lhs, rhs)
     }
 
-    pub fn le_parallelized<T>(&self, lhs: &T, rhs: &T) -> T
+    pub fn le_parallelized<T>(&self, lhs: &T, rhs: &T) -> BooleanBlock
     where
         T: IntegerRadixCiphertext,
     {

--- a/tfhe/src/integer/server_key/radix_parallel/div_mod.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/div_mod.rs
@@ -38,7 +38,7 @@ impl ServerKey {
         let (quotient, remainder) = self.unchecked_div_rem_parallelized(numerator, divisor);
 
         let (remainder_is_not_zero, remainder_and_divisor_signs_disagrees) = rayon::join(
-            || self.unchecked_scalar_ne_parallelized(&remainder, 0).blocks[0].clone(),
+            || self.unchecked_scalar_ne_parallelized(&remainder, 0),
             || {
                 let sign_bit_pos = self.key.message_modulus.0.ilog2() - 1;
                 let compare_sign_bits = |x, y| {
@@ -56,7 +56,7 @@ impl ServerKey {
         );
 
         let condition = self.key.unchecked_add(
-            &remainder_is_not_zero,
+            &remainder_is_not_zero.0,
             &remainder_and_divisor_signs_disagrees,
         );
 


### PR DESCRIPTION
### PR content/description

The BooleanValue wrapper type is meant to convey the fact that
the ciphertext encrypts a 0 or 1.

Since its meant to be a simple wrapper, the goal for is to be flexible
and not add more burden than usefulness.

Hopefully this implementation somehow achieves that

Breaking Changes:
 - This changes the return type of comparisons from a T to
   a BooleanBlock. Requiring existing code to explicitely convert
   using `.into_radix`.
 - This makes the cmux/if_then_else functions take a BooleanValue
   as the input type  Requiring existing code to wrap their condition
   ciphertext in a new BooleanValue

### Check-list:

* [x] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
