### PR TITLE
chore(integer): restore assert after using 3_3 params for CRT doctests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,9 @@ target/
 .vscode/
 
 # Path we use for internal-keycache during tests
-./keys/
+keys/
 # In case of symlinked keys
-./keys
+keys
 
 **/Cargo.lock
 **/*.bin

--- a/tfhe/benches/integer/bench.rs
+++ b/tfhe/benches/integer/bench.rs
@@ -12,7 +12,7 @@ use rand::prelude::*;
 use rand::Rng;
 use std::vec::IntoIter;
 use tfhe::integer::keycache::KEY_CACHE;
-use tfhe::integer::{RadixCiphertext, ServerKey};
+use tfhe::integer::{IntegerKeyKind, RadixCiphertext, ServerKey};
 use tfhe::keycache::NamedParam;
 
 use tfhe::integer::U256;
@@ -118,7 +118,7 @@ fn bench_server_key_binary_function_dirty_inputs<F>(
 
         let bench_id = format!("{bench_name}::{param_name}::{bit_size}_bits");
         bench_group.bench_function(&bench_id, |b| {
-            let (cks, sks) = KEY_CACHE.get_from_params(param);
+            let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
             let encrypt_two_values = || {
                 let clear_0 = gen_random_u256(&mut rng);
@@ -186,7 +186,7 @@ fn bench_server_key_binary_function_clean_inputs<F>(
 
         let bench_id = format!("{bench_name}::{param_name}::{bit_size}_bits");
         bench_group.bench_function(&bench_id, |b| {
-            let (cks, sks) = KEY_CACHE.get_from_params(param);
+            let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
             let encrypt_two_values = || {
                 let clear_0 = gen_random_u256(&mut rng);
@@ -243,7 +243,7 @@ fn bench_server_key_unary_function_dirty_inputs<F>(
 
         let bench_id = format!("{bench_name}::{param_name}::{bit_size}_bits");
         bench_group.bench_function(&bench_id, |b| {
-            let (cks, sks) = KEY_CACHE.get_from_params(param);
+            let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
             let encrypt_one_value = || {
                 let clear_0 = gen_random_u256(&mut rng);
@@ -308,7 +308,7 @@ fn bench_server_key_unary_function_clean_inputs<F>(
 
         let bench_id = format!("{bench_name}::{param_name}::{bit_size}_bits");
         bench_group.bench_function(&bench_id, |b| {
-            let (cks, sks) = KEY_CACHE.get_from_params(param);
+            let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
             let encrypt_one_value = || {
                 let clear_0 = gen_random_u256(&mut rng);
@@ -362,7 +362,7 @@ fn bench_server_key_binary_scalar_function_dirty_inputs<F, G>(
 
         let bench_id = format!("{bench_name}::{param_name}::{bit_size}_bits");
         bench_group.bench_function(&bench_id, |b| {
-            let (cks, sks) = KEY_CACHE.get_from_params(param);
+            let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
             let encrypt_one_value = || {
                 let clear_0 = gen_random_u256(&mut rng);
@@ -435,7 +435,7 @@ fn bench_server_key_binary_scalar_function_clean_inputs<F, G>(
 
         let bench_id = format!("{bench_name}::{param_name}::{bit_size}_bits_scalar_{bit_size}");
         bench_group.bench_function(&bench_id, |b| {
-            let (cks, sks) = KEY_CACHE.get_from_params(param);
+            let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
             let encrypt_one_value = || {
                 let clear_0 = gen_random_u256(&mut rng);
@@ -515,7 +515,7 @@ fn if_then_else_parallelized(c: &mut Criterion) {
 
         let bench_id = format!("{bench_name}::{param_name}::{bit_size}_bits");
         bench_group.bench_function(&bench_id, |b| {
-            let (cks, sks) = KEY_CACHE.get_from_params(param);
+            let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
             let encrypt_tree_values = || {
                 let clear_0 = gen_random_u256(&mut rng);

--- a/tfhe/benches/integer/signed_bench.rs
+++ b/tfhe/benches/integer/signed_bench.rs
@@ -10,7 +10,7 @@ use rand::prelude::*;
 use rand::Rng;
 use std::vec::IntoIter;
 use tfhe::integer::keycache::KEY_CACHE;
-use tfhe::integer::{RadixCiphertext, ServerKey, SignedRadixCiphertext, I256};
+use tfhe::integer::{IntegerKeyKind, RadixCiphertext, ServerKey, SignedRadixCiphertext, I256};
 use tfhe::keycache::NamedParam;
 
 use tfhe::shortint::parameters::{
@@ -114,7 +114,7 @@ fn bench_server_key_signed_binary_function_clean_inputs<F>(
 
         let bench_id = format!("{bench_name}::{param_name}::{bit_size}_bits");
         bench_group.bench_function(&bench_id, |b| {
-            let (cks, sks) = KEY_CACHE.get_from_params(param);
+            let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
             let encrypt_two_values = || {
                 let ct_0 = cks.encrypt_signed_radix(gen_random_i256(&mut rng), num_block);
@@ -167,7 +167,7 @@ fn bench_server_key_signed_shift_function_clean_inputs<F>(
 
         let bench_id = format!("{bench_name}::{param_name}::{bit_size}_bits");
         bench_group.bench_function(&bench_id, |b| {
-            let (cks, sks) = KEY_CACHE.get_from_params(param);
+            let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
             let encrypt_two_values = || {
                 let clear_1 = rng.gen_range(0u128..bit_size as u128);
@@ -223,7 +223,7 @@ fn bench_server_key_unary_function_clean_inputs<F>(
 
         let bench_id = format!("{bench_name}::{param_name}::{bit_size}_bits");
         bench_group.bench_function(&bench_id, |b| {
-            let (cks, sks) = KEY_CACHE.get_from_params(param);
+            let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
             let encrypt_one_value =
                 || cks.encrypt_signed_radix(gen_random_i256(&mut rng), num_block);
@@ -266,7 +266,7 @@ fn signed_if_then_else_parallelized(c: &mut Criterion) {
 
         let bench_id = format!("{bench_name}::{param_name}::{bit_size}_bits");
         bench_group.bench_function(&bench_id, |b| {
-            let (cks, sks) = KEY_CACHE.get_from_params(param);
+            let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
             let encrypt_tree_values = || {
                 let ct_0 = cks.encrypt_signed_radix(gen_random_i256(&mut rng), num_block);
@@ -691,7 +691,7 @@ fn bench_server_key_binary_scalar_function_clean_inputs<F, G>(
 
         let bench_id = format!("{bench_name}::{param_name}::{bit_size}_bits_scalar_{bit_size}");
         bench_group.bench_function(&bench_id, |b| {
-            let (cks, sks) = KEY_CACHE.get_from_params(param);
+            let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
             let encrypt_one_value = || {
                 let ct_0 = cks.encrypt_signed_radix(gen_random_i256(&mut rng), num_block);

--- a/tfhe/examples/dark_market/main.rs
+++ b/tfhe/examples/dark_market/main.rs
@@ -2,7 +2,7 @@ use std::time::Instant;
 
 use tfhe::integer::ciphertext::RadixCiphertext;
 use tfhe::integer::keycache::IntegerKeyCache;
-use tfhe::integer::ServerKey;
+use tfhe::integer::{IntegerKeyKind, ServerKey};
 use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
 
 mod fhe;
@@ -73,7 +73,8 @@ fn test_volume_match_fhe(
 ) {
     println!("Generating keys...");
     let time = Instant::now();
-    let (client_key, server_key) = IntegerKeyCache.get_from_params(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+    let (client_key, server_key) =
+        IntegerKeyCache.get_from_params(PARAM_MESSAGE_2_CARRY_2_KS_PBS, IntegerKeyKind::Radix);
     println!("Keys generated in {:?}", time.elapsed());
 
     println!("Running test cases for the FHE implementation");

--- a/tfhe/src/high_level_api/integers/keys.rs
+++ b/tfhe/src/high_level_api/integers/keys.rs
@@ -98,7 +98,7 @@ impl IntegerServerKey {
             4,
             "This API only supports integers with 2 bits per block (MessageModulus(4))",
         );
-        let base_integer_key = crate::integer::ServerKey::new(cks);
+        let base_integer_key = crate::integer::ServerKey::new_radix_server_key(cks);
         let wopbs_key = client_key
             .wopbs_block_parameters
             .as_ref()
@@ -133,7 +133,7 @@ impl IntegerCompressedServerKey {
                    to create a CompressedServerKey.
                    "
         );
-        let key = crate::integer::CompressedServerKey::new(integer_key);
+        let key = crate::integer::CompressedServerKey::new_radix_compressed_server_key(integer_key);
         Self { key }
     }
 

--- a/tfhe/src/high_level_api/integers/types/static_.rs
+++ b/tfhe/src/high_level_api/integers/types/static_.rs
@@ -178,12 +178,15 @@ where
         #[cfg(feature = "internal-keycache")]
         {
             KEY_CACHE
-                .get_from_params(client_key.as_ref().parameters())
+                .get_from_params(
+                    client_key.as_ref().parameters(),
+                    crate::integer::IntegerKeyKind::Radix,
+                )
                 .1
         }
         #[cfg(not(feature = "internal-keycache"))]
         {
-            Self::new(client_key)
+            Self::new_radix_server_key(client_key)
         }
     }
 

--- a/tfhe/src/integer/client_key/crt.rs
+++ b/tfhe/src/integer/client_key/crt.rs
@@ -53,8 +53,16 @@ impl CrtClientKey {
         self.key.encrypt_crt(message, self.moduli.clone())
     }
 
+    pub fn encrypt_native_crt(&self, message: u64) -> CrtCiphertext {
+        self.key.encrypt_native_crt(message, self.moduli.clone())
+    }
+
     pub fn decrypt(&self, ciphertext: &CrtCiphertext) -> u64 {
         self.key.decrypt_crt(ciphertext)
+    }
+
+    pub fn decrypt_native_crt(&self, ciphertext: &CrtCiphertext) -> u64 {
+        self.key.decrypt_native_crt(ciphertext)
     }
 
     /// Returns the parameters used by the client key.

--- a/tfhe/src/integer/client_key/mod.rs
+++ b/tfhe/src/integer/client_key/mod.rs
@@ -80,6 +80,12 @@ impl AsRef<Self> for ClientKey {
     }
 }
 
+impl AsRef<ShortintClientKey> for ClientKey {
+    fn as_ref(&self) -> &ShortintClientKey {
+        &self.key
+    }
+}
+
 impl ClientKey {
     /// Creates a Client Key.
     ///
@@ -431,19 +437,19 @@ impl ClientKey {
     /// # Example
     ///
     /// ```
-    /// use tfhe::integer::{gen_keys, BooleanBlock};
+    /// use tfhe::integer::{gen_keys_radix, BooleanBlock};
     /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
     ///
     /// // We have 4 * 2 = 8 bits of message
     /// let size = 4;
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+    /// let (cks, sks) = gen_keys_radix(PARAM_MESSAGE_2_CARRY_2_KS_PBS, size);
     ///
     /// let a = cks.encrypt_bool(false);
     /// let dec = cks.decrypt_bool(&a);
     /// assert_eq!(dec, false);
     ///
     /// let a = a.into_radix(size, &sks);
-    /// let dec: u64 = cks.decrypt_radix(&a);
+    /// let dec: u64 = cks.decrypt(&a);
     /// assert_eq!(dec, 0);
     /// ```
     pub fn encrypt_bool(&self, msg: bool) -> BooleanBlock {

--- a/tfhe/src/integer/client_key/radix.rs
+++ b/tfhe/src/integer/client_key/radix.rs
@@ -61,6 +61,14 @@ impl RadixClientKey {
         self.key.encrypt_radix(message, self.num_blocks)
     }
 
+    pub fn encrypt_without_padding<T: DecomposableInto<u64> + UnsignedNumeric>(
+        &self,
+        message: T,
+    ) -> RadixCiphertext {
+        self.key
+            .encrypt_radix_without_padding(message, self.num_blocks)
+    }
+
     pub fn encrypt_signed<T: DecomposableInto<u64> + SignedNumeric>(
         &self,
         message: T,
@@ -77,6 +85,13 @@ impl RadixClientKey {
         T: RecomposableFrom<u64> + UnsignedNumeric,
     {
         self.key.decrypt_radix(ciphertext)
+    }
+
+    pub fn decrypt_without_padding<T>(&self, ctxt: &RadixCiphertext) -> T
+    where
+        T: RecomposableFrom<u64> + UnsignedNumeric,
+    {
+        self.key.decrypt_radix_without_padding(ctxt)
     }
 
     pub fn decrypt_signed<T>(&self, ciphertext: &SignedRadixCiphertext) -> T

--- a/tfhe/src/integer/key_switching_key/test.rs
+++ b/tfhe/src/integer/key_switching_key/test.rs
@@ -2,6 +2,7 @@ use crate::shortint::parameters::ShortintKeySwitchingParameters;
 use crate::shortint::prelude::{PARAM_MESSAGE_1_CARRY_1_KS_PBS, PARAM_MESSAGE_2_CARRY_2_KS_PBS};
 
 use crate::integer::key_switching_key::KeySwitchingKey;
+use crate::integer::IntegerKeyKind;
 
 #[test]
 fn gen_multi_keys_test_rdxinteger_to_rdxinteger() {
@@ -97,10 +98,12 @@ fn gen_multi_keys_test_crtinteger_to_crtinteger_fail() {
 #[test]
 fn gen_multi_keys_test_integer_to_integer() {
     // We generate a set of client/server keys, using the default parameters:
-    let (client_key_1, server_key_1) = crate::integer::gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+    let (client_key_1, server_key_1) =
+        crate::integer::gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS, IntegerKeyKind::Radix);
 
     // We generate a set of client/server keys, using the default parameters:
-    let (client_key_2, server_key_2) = crate::integer::gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+    let (client_key_2, server_key_2) =
+        crate::integer::gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS, IntegerKeyKind::Radix);
 
     // Get casting key
     let ksk_params = ShortintKeySwitchingParameters::new(

--- a/tfhe/src/integer/keycache.rs
+++ b/tfhe/src/integer/keycache.rs
@@ -2,13 +2,13 @@ use crate::shortint::{PBSParameters, WopbsParameters};
 use lazy_static::lazy_static;
 
 use crate::integer::wopbs::WopbsKey;
-use crate::integer::{ClientKey, ServerKey};
+use crate::integer::{ClientKey, IntegerKeyKind, ServerKey};
 
 #[derive(Default)]
 pub struct IntegerKeyCache;
 
 impl IntegerKeyCache {
-    pub fn get_from_params<P>(&self, params: P) -> (ClientKey, ServerKey)
+    pub fn get_from_params<P>(&self, params: P, key_kind: IntegerKeyKind) -> (ClientKey, ServerKey)
     where
         P: Into<PBSParameters>,
     {
@@ -16,7 +16,14 @@ impl IntegerKeyCache {
         let (client_key, server_key) = (keys.client_key(), keys.server_key());
 
         let client_key = ClientKey::from(client_key.clone());
-        let server_key = ServerKey::from_shortint(&client_key, server_key.clone());
+        let server_key = match key_kind {
+            IntegerKeyKind::Radix => {
+                ServerKey::new_radix_server_key_from_shortint(&client_key, server_key.clone())
+            }
+            IntegerKeyKind::CRT => {
+                ServerKey::new_crt_server_key_from_shortint(&client_key, server_key.clone())
+            }
+        };
 
         (client_key, server_key)
     }

--- a/tfhe/src/integer/public_key/standard.rs
+++ b/tfhe/src/integer/public_key/standard.rs
@@ -93,6 +93,7 @@ impl From<CompressedPublicKey> for PublicKey {
 #[cfg(test)]
 mod tests {
     use crate::integer::keycache::KEY_CACHE;
+    use crate::integer::IntegerKeyKind;
     use crate::shortint::parameters::*;
     use crate::shortint::ClassicPBSParameters;
 
@@ -101,7 +102,7 @@ mod tests {
     });
 
     fn integer_public_key_decompression_small(param: ClassicPBSParameters) {
-        let (cks, sks) = KEY_CACHE.get_from_params(param);
+        let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
         let compressed_pk = crate::integer::CompressedPublicKey::new(&cks);
         let pk = crate::integer::PublicKey::from(compressed_pk);

--- a/tfhe/src/integer/public_key/tests.rs
+++ b/tfhe/src/integer/public_key/tests.rs
@@ -1,6 +1,6 @@
 use rand::Rng;
 
-use crate::integer::{gen_keys, CompressedPublicKey, PublicKey};
+use crate::integer::{gen_keys, CompressedPublicKey, IntegerKeyKind, PublicKey};
 use crate::shortint::parameters::*;
 use crate::shortint::ClassicPBSParameters;
 
@@ -30,7 +30,7 @@ create_parametrized_test!(small_radix_encrypt_decrypt_compact_128_bits_list {
 /// Test that the public key can encrypt a 128 bit number
 /// in radix decomposition, and that the client key can decrypt it
 fn big_radix_encrypt_decrypt_128_bits(param: ClassicPBSParameters) {
-    let (cks, _) = KEY_CACHE.get_from_params(param);
+    let (cks, _) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let public_key = PublicKey::new(&cks);
 
     // RNG
@@ -50,7 +50,7 @@ fn big_radix_encrypt_decrypt_128_bits(param: ClassicPBSParameters) {
 }
 
 fn radix_encrypt_decrypt_compressed_128_bits(param: ClassicPBSParameters) {
-    let (cks, _) = KEY_CACHE.get_from_params(param);
+    let (cks, _) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let public_key = CompressedPublicKey::new(&cks);
 
     // RNG
@@ -78,7 +78,7 @@ fn small_radix_encrypt_decrypt_compact_128_bits_list(params: ClassicPBSParameter
 }
 
 fn radix_encrypt_decrypt_compact_128_bits_list(params: ClassicPBSParameters) {
-    let (cks, _) = gen_keys(params);
+    let (cks, _) = gen_keys(params, IntegerKeyKind::Radix);
     let pk = crate::integer::public_key::CompactPublicKey::new(&cks);
 
     let mut rng = rand::thread_rng();

--- a/tfhe/src/integer/server_key/crt/add_crt.rs
+++ b/tfhe/src/integer/server_key/crt/add_crt.rs
@@ -6,24 +6,24 @@ impl ServerKey {
     /// # Example
     ///
     ///```rust
-    /// use tfhe::integer::gen_keys;
+    /// use tfhe::integer::gen_keys_crt;
     /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
+    /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
+    /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 14;
-    /// let basis = vec![2, 3, 5];
-    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
-    /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
-    /// let mut ctxt_2 = cks.encrypt_crt(clear_2, basis);
+    /// let mut ctxt_1 = cks.encrypt(clear_1);
+    /// let mut ctxt_2 = cks.encrypt(clear_2);
     ///
     /// sks.smart_crt_add_assign(&mut ctxt_1, &mut ctxt_2);
     ///
     /// // Decrypt
-    /// let res = cks.decrypt_crt(&ctxt_1);
+    /// let res = cks.decrypt(&ctxt_1);
     /// assert_eq!((clear_1 + clear_2) % modulus, res);
     /// ```
     pub fn smart_crt_add(

--- a/tfhe/src/integer/server_key/crt/mod.rs
+++ b/tfhe/src/integer/server_key/crt/mod.rs
@@ -18,19 +18,19 @@ impl ServerKey {
     /// # Example
     ///
     ///```rust
-    /// use tfhe::integer::gen_keys;
+    /// use tfhe::integer::gen_keys_crt;
     /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
+    /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
+    /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 14;
-    /// let basis = vec![2, 3, 5];
-    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
-    /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
-    /// let ctxt_2 = cks.encrypt_crt(clear_2, basis);
+    /// let mut ctxt_1 = cks.encrypt(clear_1);
+    /// let ctxt_2 = cks.encrypt(clear_2);
     ///
     /// // Compute homomorphically a multiplication
     /// sks.unchecked_crt_add_assign(&mut ctxt_1, &ctxt_2);
@@ -38,7 +38,7 @@ impl ServerKey {
     /// sks.full_extract_message_assign(&mut ctxt_1);
     ///
     /// // Decrypt
-    /// let res = cks.decrypt_crt(&ctxt_1);
+    /// let res = cks.decrypt(&ctxt_1);
     /// assert_eq!((clear_1 + clear_2) % modulus, res);
     /// ```
     pub fn full_extract_message_assign(&self, ctxt: &mut CrtCiphertext) {

--- a/tfhe/src/integer/server_key/crt/mul_crt.rs
+++ b/tfhe/src/integer/server_key/crt/mul_crt.rs
@@ -7,24 +7,24 @@ impl ServerKey {
     /// # Example
     ///
     /// ```rust
-    /// use tfhe::integer::gen_keys;
+    /// use tfhe::integer::gen_keys_crt;
     /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
+    /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
+    /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
     ///
     /// let clear_1 = 29;
     /// let clear_2 = 23;
-    /// let basis = vec![2, 3, 5];
-    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
-    /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
-    /// let ctxt_2 = cks.encrypt_crt(clear_2, basis);
+    /// let mut ctxt_1 = cks.encrypt(clear_1);
+    /// let ctxt_2 = cks.encrypt(clear_2);
     ///
     /// // Compute homomorphically a multiplication
     /// sks.unchecked_crt_mul_assign(&mut ctxt_1, &ctxt_2);
     /// // Decrypt
-    /// let res = cks.decrypt_crt(&ctxt_1);
+    /// let res = cks.decrypt(&ctxt_1);
     /// assert_eq!((clear_1 * clear_2) % modulus, res);
     /// ```
     pub fn unchecked_crt_mul_assign(&self, ct_left: &mut CrtCiphertext, ct_right: &CrtCiphertext) {
@@ -57,24 +57,24 @@ impl ServerKey {
     /// # Example
     ///
     /// ```rust
-    /// use tfhe::integer::gen_keys;
+    /// use tfhe::integer::gen_keys_crt;
     /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
+    /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
+    /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
     ///
     /// let clear_1 = 29;
     /// let clear_2 = 29;
-    /// let basis = vec![2, 3, 5];
-    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
-    /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
-    /// let mut ctxt_2 = cks.encrypt_crt(clear_2, basis);
+    /// let mut ctxt_1 = cks.encrypt(clear_1);
+    /// let mut ctxt_2 = cks.encrypt(clear_2);
     ///
     /// // Compute homomorphically a multiplication
     /// sks.smart_crt_mul_assign(&mut ctxt_1, &mut ctxt_2);
     ///
     /// // Decrypt
-    /// let res = cks.decrypt_crt(&ctxt_1);
+    /// let res = cks.decrypt(&ctxt_1);
     /// assert_eq!((clear_1 * clear_2) % modulus, res);
     /// ```
     pub fn smart_crt_mul_assign(&self, ct_left: &mut CrtCiphertext, ct_right: &mut CrtCiphertext) {

--- a/tfhe/src/integer/server_key/crt/neg_crt.rs
+++ b/tfhe/src/integer/server_key/crt/neg_crt.rs
@@ -10,21 +10,21 @@ impl ServerKey {
     /// # Example
     ///
     ///```rust
-    /// use tfhe::integer::gen_keys;
+    /// use tfhe::integer::gen_keys_crt;
     /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
+    /// let basis = vec![2, 3, 5];
+    /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
     ///
     /// let clear = 14_u64;
-    /// let basis = vec![2, 3, 5];
     ///
-    /// let mut ctxt = cks.encrypt_crt(clear, basis.clone());
+    /// let mut ctxt = cks.encrypt(clear);
     ///
     /// sks.unchecked_crt_neg_assign(&mut ctxt);
     ///
     /// // Decrypt
-    /// let res = cks.decrypt_crt(&ctxt);
+    /// let res = cks.decrypt(&ctxt);
     /// assert_eq!(16, res);
     /// ```
     pub fn unchecked_crt_neg(&self, ctxt: &CrtCiphertext) -> CrtCiphertext {
@@ -52,21 +52,21 @@ impl ServerKey {
     /// # Example
     ///
     ///```rust
-    /// use tfhe::integer::gen_keys;
+    /// use tfhe::integer::gen_keys_crt;
     /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
+    /// let basis = vec![2, 3, 5];
+    /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
     ///
     /// let clear = 14_u64;
-    /// let basis = vec![2, 3, 5];
     ///
-    /// let mut ctxt = cks.encrypt_crt(clear, basis.clone());
+    /// let mut ctxt = cks.encrypt(clear);
     ///
     /// sks.smart_crt_neg_assign(&mut ctxt);
     ///
     /// // Decrypt
-    /// let res = cks.decrypt_crt(&ctxt);
+    /// let res = cks.decrypt(&ctxt);
     /// assert_eq!(16, res);
     /// ```
     pub fn smart_crt_neg_assign(&self, ctxt: &mut CrtCiphertext) {

--- a/tfhe/src/integer/server_key/crt/scalar_add_crt.rs
+++ b/tfhe/src/integer/server_key/crt/scalar_add_crt.rs
@@ -13,23 +13,23 @@ impl ServerKey {
     /// # Example
     ///
     ///```rust
-    /// use tfhe::integer::gen_keys;
+    /// use tfhe::integer::gen_keys_crt;
     /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
+    /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
+    /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 14;
-    /// let basis = vec![2, 3, 5];
-    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
-    /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
+    /// let mut ctxt_1 = cks.encrypt(clear_1);
     ///
     /// sks.unchecked_crt_scalar_add_assign(&mut ctxt_1, clear_2);
     ///
     /// // Decrypt
-    /// let res = cks.decrypt_crt(&ctxt_1);
+    /// let res = cks.decrypt(&ctxt_1);
     /// assert_eq!((clear_1 + clear_2) % modulus, res);
     /// ```
     pub fn unchecked_crt_scalar_add(&self, ct: &CrtCiphertext, scalar: u64) -> CrtCiphertext {
@@ -58,17 +58,17 @@ impl ServerKey {
     /// # Example
     ///
     ///```rust
-    /// use tfhe::integer::gen_keys;
+    /// use tfhe::integer::gen_keys_crt;
     /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
+    /// let basis = vec![2, 3, 5];
+    /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 14;
-    /// let basis = vec![2, 3, 5];
     /// // Encrypt two messages
-    /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
+    /// let mut ctxt_1 = cks.encrypt(clear_1);
     ///
     /// let tmp = sks.is_crt_scalar_add_possible(&mut ctxt_1, clear_2);
     ///
@@ -95,23 +95,23 @@ impl ServerKey {
     ///
     /// ```rust
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// use tfhe::integer::gen_keys;
+    /// use tfhe::integer::gen_keys_crt;
     /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
+    /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
+    /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 14;
-    /// let basis = vec![2, 3, 5];
-    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
-    /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
+    /// let mut ctxt_1 = cks.encrypt(clear_1);
     ///
     /// sks.checked_crt_scalar_add_assign(&mut ctxt_1, clear_2);
     ///
     /// // Decrypt
-    /// let res = cks.decrypt_crt(&ctxt_1);
+    /// let res = cks.decrypt(&ctxt_1);
     /// assert_eq!((clear_1 + clear_2) % modulus, res);
     /// # Ok(())
     /// # }
@@ -152,23 +152,23 @@ impl ServerKey {
     /// # Example
     ///
     ///```rust
-    /// use tfhe::integer::gen_keys;
+    /// use tfhe::integer::gen_keys_crt;
     /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
+    /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
+    /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 14;
-    /// let basis = vec![2, 3, 5];
-    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
-    /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
+    /// let mut ctxt_1 = cks.encrypt(clear_1);
     ///
     /// let ctxt = sks.smart_crt_scalar_add(&mut ctxt_1, clear_2);
     ///
     /// // Decrypt
-    /// let res = cks.decrypt_crt(&ctxt);
+    /// let res = cks.decrypt(&ctxt);
     /// assert_eq!((clear_1 + clear_2) % modulus, res);
     /// ```
     pub fn smart_crt_scalar_add(&self, ct: &mut CrtCiphertext, scalar: u64) -> CrtCiphertext {
@@ -190,23 +190,23 @@ impl ServerKey {
     /// # Example
     ///
     ///```rust
-    /// use tfhe::integer::gen_keys;
+    /// use tfhe::integer::gen_keys_crt;
     /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
+    /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
+    /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 14;
-    /// let basis = vec![2, 3, 5];
-    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
-    /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
+    /// let mut ctxt_1 = cks.encrypt(clear_1);
     ///
     /// sks.smart_crt_scalar_add_assign(&mut ctxt_1, clear_2);
     ///
     /// // Decrypt
-    /// let res = cks.decrypt_crt(&ctxt_1);
+    /// let res = cks.decrypt(&ctxt_1);
     /// assert_eq!((clear_1 + clear_2) % modulus, res);
     /// ```
     pub fn smart_crt_scalar_add_assign(&self, ct: &mut CrtCiphertext, scalar: u64) {

--- a/tfhe/src/integer/server_key/crt/scalar_mul_crt.rs
+++ b/tfhe/src/integer/server_key/crt/scalar_mul_crt.rs
@@ -13,23 +13,23 @@ impl ServerKey {
     /// # Example
     ///
     ///```rust
-    /// use tfhe::integer::gen_keys;
+    /// use tfhe::integer::gen_keys_crt;
     /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
+    /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
+    /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 2;
-    /// let basis = vec![2, 3, 5];
-    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
-    /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
+    /// let mut ctxt_1 = cks.encrypt(clear_1);
     ///
     /// sks.unchecked_crt_scalar_mul_assign(&mut ctxt_1, clear_2);
     ///
     /// // Decrypt
-    /// let res = cks.decrypt_crt(&ctxt_1);
+    /// let res = cks.decrypt(&ctxt_1);
     /// assert_eq!((clear_1 * clear_2) % modulus, res);
     /// ```
     pub fn unchecked_crt_scalar_mul(&self, ctxt: &CrtCiphertext, scalar: u64) -> CrtCiphertext {
@@ -56,17 +56,17 @@ impl ServerKey {
     /// # Example
     ///
     ///```rust
-    /// use tfhe::integer::gen_keys;
+    /// use tfhe::integer::gen_keys_crt;
     /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
+    /// let basis = vec![2, 3, 5];
+    /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 2;
-    /// let basis = vec![2, 3, 5];
     /// // Encrypt two messages
-    /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
+    /// let mut ctxt_1 = cks.encrypt(clear_1);
     ///
     /// let tmp = sks.is_crt_scalar_mul_possible(&mut ctxt_1, clear_2);
     ///
@@ -93,23 +93,23 @@ impl ServerKey {
     ///
     /// ```rust
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// use tfhe::integer::gen_keys;
+    /// use tfhe::integer::gen_keys_crt;
     /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
+    /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
+    /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 2;
-    /// let basis = vec![2, 3, 5];
-    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
-    /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
+    /// let mut ctxt_1 = cks.encrypt(clear_1);
     ///
     /// sks.checked_crt_scalar_mul_assign(&mut ctxt_1, clear_2);
     ///
     /// // Decrypt
-    /// let res = cks.decrypt_crt(&ctxt_1);
+    /// let res = cks.decrypt(&ctxt_1);
     /// assert_eq!((clear_1 * clear_2) % modulus, res);
     /// # Ok(())
     /// # }
@@ -161,23 +161,23 @@ impl ServerKey {
     /// # Example
     ///
     ///```rust
-    /// use tfhe::integer::gen_keys;
+    /// use tfhe::integer::gen_keys_crt;
     /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
+    /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
+    /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 14;
-    /// let basis = vec![2, 3, 5];
-    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
-    /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
+    /// let mut ctxt_1 = cks.encrypt(clear_1);
     ///
     /// let ctxt = sks.smart_crt_scalar_mul(&mut ctxt_1, clear_2);
     ///
     /// // Decrypt
-    /// let res = cks.decrypt_crt(&ctxt);
+    /// let res = cks.decrypt(&ctxt);
     /// assert_eq!((clear_1 * clear_2) % modulus, res);
     /// ```
     pub fn smart_crt_scalar_mul(&self, ctxt: &mut CrtCiphertext, scalar: u64) -> CrtCiphertext {
@@ -201,23 +201,23 @@ impl ServerKey {
     /// # Example
     ///
     ///```rust
-    /// use tfhe::integer::gen_keys;
+    /// use tfhe::integer::gen_keys_crt;
     /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
+    /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
+    /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 14;
-    /// let basis = vec![2, 3, 5];
-    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
-    /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
+    /// let mut ctxt_1 = cks.encrypt(clear_1);
     ///
     /// sks.smart_crt_scalar_mul_assign(&mut ctxt_1, clear_2);
     ///
     /// // Decrypt
-    /// let res = cks.decrypt_crt(&ctxt_1);
+    /// let res = cks.decrypt(&ctxt_1);
     /// assert_eq!((clear_1 * clear_2) % modulus, res);
     /// ```
     pub fn smart_crt_scalar_mul_assign(&self, ctxt: &mut CrtCiphertext, scalar: u64) {

--- a/tfhe/src/integer/server_key/crt/scalar_sub_crt.rs
+++ b/tfhe/src/integer/server_key/crt/scalar_sub_crt.rs
@@ -13,23 +13,23 @@ impl ServerKey {
     /// # Example
     ///
     ///```rust
-    /// use tfhe::integer::gen_keys;
+    /// use tfhe::integer::gen_keys_crt;
     /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
+    /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
+    /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 7;
-    /// let basis = vec![2, 3, 5];
-    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
-    /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
+    /// let mut ctxt_1 = cks.encrypt(clear_1);
     ///
     /// sks.unchecked_crt_scalar_sub_assign(&mut ctxt_1, clear_2);
     ///
     /// // Decrypt
-    /// let res = cks.decrypt_crt(&ctxt_1);
+    /// let res = cks.decrypt(&ctxt_1);
     /// assert_eq!((clear_1 - clear_2) % modulus, res);
     /// ```
     pub fn unchecked_crt_scalar_sub(&self, ct: &CrtCiphertext, scalar: u64) -> CrtCiphertext {
@@ -51,22 +51,22 @@ impl ServerKey {
     /// # Example
     ///
     ///```rust
-    /// use tfhe::integer::gen_keys;
+    /// use tfhe::integer::gen_keys_crt;
+    /// let basis = vec![2, 3, 5];
     /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
+    /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 7;
-    /// let basis = vec![2, 3, 5];
     /// // Encrypt two messages
-    /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
+    /// let mut ctxt_1 = cks.encrypt(clear_1);
     ///
     /// let bit = sks.is_crt_scalar_sub_possible(&mut ctxt_1, clear_2);
     ///
     /// // Decrypt
-    /// let res = cks.decrypt_crt(&ctxt_1);
+    /// let res = cks.decrypt(&ctxt_1);
     /// assert_eq!(true, bit);
     /// ```
     pub fn is_crt_scalar_sub_possible(&self, ct: &CrtCiphertext, scalar: u64) -> bool {
@@ -89,23 +89,23 @@ impl ServerKey {
     ///
     /// ```rust
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// use tfhe::integer::gen_keys;
+    /// use tfhe::integer::gen_keys_crt;
     /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
+    /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
+    /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 8;
-    /// let basis = vec![2, 3, 5];
-    /// let modulus: u64 = basis.iter().product();
     ///
-    /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
+    /// let mut ctxt_1 = cks.encrypt(clear_1);
     ///
     /// let ct_res = sks.checked_crt_scalar_sub(&mut ctxt_1, clear_2)?;
     ///
     /// // Decrypt:
-    /// let dec = cks.decrypt_crt(&ct_res);
+    /// let dec = cks.decrypt(&ct_res);
     /// assert_eq!((clear_1 - clear_2) % modulus, dec);
     /// # Ok(())
     /// # }
@@ -131,23 +131,23 @@ impl ServerKey {
     ///
     /// ```rust
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// use tfhe::integer::gen_keys;
+    /// use tfhe::integer::gen_keys_crt;
     /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
+    /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
+    /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 7;
-    /// let basis = vec![2, 3, 5];
-    /// let modulus: u64 = basis.iter().product();
     ///
-    /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
+    /// let mut ctxt_1 = cks.encrypt(clear_1);
     ///
     /// sks.checked_crt_scalar_sub_assign(&mut ctxt_1, clear_2)?;
     ///
     /// // Decrypt:
-    /// let dec = cks.decrypt_crt(&ctxt_1);
+    /// let dec = cks.decrypt(&ctxt_1);
     /// assert_eq!((clear_1 - clear_2) % modulus, dec);
     /// # Ok(())
     /// # }
@@ -170,23 +170,23 @@ impl ServerKey {
     /// # Example
     ///
     ///```rust
-    /// use tfhe::integer::gen_keys;
+    /// use tfhe::integer::gen_keys_crt;
     /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
+    /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
+    /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 7;
-    /// let basis = vec![2, 3, 5];
-    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
-    /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
+    /// let mut ctxt_1 = cks.encrypt(clear_1);
     ///
     /// sks.smart_crt_scalar_sub_assign(&mut ctxt_1, clear_2);
     ///
     /// // Decrypt
-    /// let res = cks.decrypt_crt(&ctxt_1);
+    /// let res = cks.decrypt(&ctxt_1);
     /// assert_eq!((clear_1 - clear_2) % modulus, res);
     /// ```
     pub fn smart_crt_scalar_sub(&self, ct: &mut CrtCiphertext, scalar: u64) -> CrtCiphertext {

--- a/tfhe/src/integer/server_key/crt/sub_crt.rs
+++ b/tfhe/src/integer/server_key/crt/sub_crt.rs
@@ -10,24 +10,24 @@ impl ServerKey {
     /// # Example
     ///
     ///```rust
-    /// use tfhe::integer::gen_keys;
+    /// use tfhe::integer::gen_keys_crt;
     /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
+    /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
+    /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 5;
-    /// let basis = vec![2, 3, 5];
-    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
-    /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
-    /// let mut ctxt_2 = cks.encrypt_crt(clear_2, basis.clone());
+    /// let mut ctxt_1 = cks.encrypt(clear_1);
+    /// let mut ctxt_2 = cks.encrypt(clear_2);
     ///
     /// let ctxt = sks.unchecked_crt_sub(&mut ctxt_1, &mut ctxt_2);
     ///
     /// // Decrypt
-    /// let res = cks.decrypt_crt(&ctxt);
+    /// let res = cks.decrypt(&ctxt);
     /// assert_eq!((clear_1 - clear_2) % modulus, res);
     /// ```
     pub fn unchecked_crt_sub(
@@ -49,24 +49,24 @@ impl ServerKey {
     /// # Example
     ///
     ///```rust
-    /// use tfhe::integer::gen_keys;
+    /// use tfhe::integer::gen_keys_crt;
     /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
+    /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
+    /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 5;
-    /// let basis = vec![2, 3, 5];
-    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
-    /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
-    /// let mut ctxt_2 = cks.encrypt_crt(clear_2, basis.clone());
+    /// let mut ctxt_1 = cks.encrypt(clear_1);
+    /// let mut ctxt_2 = cks.encrypt(clear_2);
     ///
     /// let ctxt = sks.unchecked_crt_sub(&mut ctxt_1, &mut ctxt_2);
     ///
     /// // Decrypt
-    /// let res = cks.decrypt_crt(&ctxt);
+    /// let res = cks.decrypt(&ctxt);
     /// assert_eq!((clear_1 - clear_2) % modulus, res);
     /// ```
     pub fn unchecked_crt_sub_assign(
@@ -83,24 +83,24 @@ impl ServerKey {
     /// # Example
     ///
     ///```rust
-    /// use tfhe::integer::gen_keys;
+    /// use tfhe::integer::gen_keys_crt;
     /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
+    /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
+    /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 5;
-    /// let basis = vec![2, 3, 5];
-    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
-    /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
-    /// let mut ctxt_2 = cks.encrypt_crt(clear_2, basis.clone());
+    /// let mut ctxt_1 = cks.encrypt(clear_1);
+    /// let mut ctxt_2 = cks.encrypt(clear_2);
     ///
     /// let ctxt = sks.smart_crt_sub(&mut ctxt_1, &mut ctxt_2);
     ///
     /// // Decrypt
-    /// let res = cks.decrypt_crt(&ctxt);
+    /// let res = cks.decrypt(&ctxt);
     /// assert_eq!((clear_1 - clear_2) % modulus, res);
     /// ```
     pub fn smart_crt_sub(
@@ -127,24 +127,24 @@ impl ServerKey {
     /// # Example
     ///
     ///```rust
-    /// use tfhe::integer::gen_keys;
+    /// use tfhe::integer::gen_keys_crt;
     /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
+    /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
+    /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 5;
-    /// let basis = vec![2, 3, 5];
-    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
-    /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
-    /// let mut ctxt_2 = cks.encrypt_crt(clear_2, basis.clone());
+    /// let mut ctxt_1 = cks.encrypt(clear_1);
+    /// let mut ctxt_2 = cks.encrypt(clear_2);
     ///
     /// sks.smart_crt_sub_assign(&mut ctxt_1, &mut ctxt_2);
     ///
     /// // Decrypt
-    /// let res = cks.decrypt_crt(&ctxt_1);
+    /// let res = cks.decrypt(&ctxt_1);
     /// assert_eq!((clear_1 - clear_2) % modulus, res);
     /// ```
     pub fn smart_crt_sub_assign(
@@ -158,9 +158,7 @@ impl ServerKey {
             self.full_extract_message_assign(ctxt_right);
         }
 
-        // assert broken because of issue
-        // https://github.com/zama-ai/tfhe-rs-internal/issues/256
-        // assert!(self.is_crt_sub_possible(ctxt_left, ctxt_right));
+        assert!(self.is_crt_sub_possible(ctxt_left, ctxt_right));
 
         self.unchecked_crt_sub_assign(ctxt_left, ctxt_right);
     }

--- a/tfhe/src/integer/server_key/crt/tests.rs
+++ b/tfhe/src/integer/server_key/crt/tests.rs
@@ -1,4 +1,5 @@
 use crate::integer::keycache::KEY_CACHE;
+use crate::integer::IntegerKeyKind;
 use crate::shortint::parameters::*;
 use crate::shortint::ClassicPBSParameters;
 use rand::Rng;
@@ -33,14 +34,14 @@ fn make_basis(message_modulus: usize) -> Vec<u64> {
 
 #[test]
 fn integer_unchecked_crt_add_32_bits() {
-    let params = PARAM_MESSAGE_5_CARRY_1_KS_PBS;
+    let param = PARAM_MESSAGE_5_CARRY_1_KS_PBS;
 
     // Define CRT basis, and global modulus
     let basis = [3u64, 11, 13, 19, 23, 29, 31, 32];
 
     // Use u128 to avoid overflows as the modulus is slightly larger than 32 bits
     let modulus = basis.iter().copied().map(u128::from).product::<u128>();
-    let (cks, sks) = KEY_CACHE.get_from_params(params);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::CRT);
     let mut rng = rand::thread_rng();
 
     for _ in 0..NB_TEST {
@@ -66,14 +67,14 @@ fn integer_unchecked_crt_add_32_bits() {
 
 #[test]
 fn integer_unchecked_crt_mul_32_bits() {
-    let params = PARAM_MESSAGE_5_CARRY_1_KS_PBS;
+    let param = PARAM_MESSAGE_5_CARRY_1_KS_PBS;
 
     // Define CRT basis, and global modulus
     let basis = [3u64, 11, 13, 19, 23, 29, 31, 32];
 
     // Use u128 to avoid overflows as the modulus is slightly larger than 32 bits
     let modulus = basis.iter().copied().map(u128::from).product::<u128>();
-    let (cks, sks) = KEY_CACHE.get_from_params(params);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::CRT);
     let mut rng = rand::thread_rng();
 
     for _ in 0..NB_TEST {
@@ -99,14 +100,14 @@ fn integer_unchecked_crt_mul_32_bits() {
 
 #[test]
 fn integer_unchecked_crt_neg_32_bits() {
-    let params = PARAM_MESSAGE_5_CARRY_1_KS_PBS;
+    let param = PARAM_MESSAGE_5_CARRY_1_KS_PBS;
 
     // Define CRT basis, and global modulus
     let basis = [3u64, 11, 13, 19, 23, 29, 31, 32];
 
     // Use u128 to avoid overflows as the modulus is slightly larger than 32 bits
     let modulus = basis.iter().copied().map(u128::from).product::<u128>();
-    let (cks, sks) = KEY_CACHE.get_from_params(params);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::CRT);
     let mut rng = rand::thread_rng();
 
     for _ in 0..NB_TEST {
@@ -127,14 +128,14 @@ fn integer_unchecked_crt_neg_32_bits() {
 
 #[test]
 fn integer_unchecked_crt_sub_32_bits() {
-    let params = PARAM_MESSAGE_5_CARRY_1_KS_PBS;
+    let param = PARAM_MESSAGE_5_CARRY_1_KS_PBS;
 
     // Define CRT basis, and global modulus
     let basis = [3u64, 11, 13, 19, 23, 29, 31, 32];
 
     // Use u128 to avoid overflows as the modulus is slightly larger than 32 bits
     let modulus = basis.iter().copied().map(u128::from).product::<u128>();
-    let (cks, sks) = KEY_CACHE.get_from_params(params);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::CRT);
     let mut rng = rand::thread_rng();
 
     for _ in 0..NB_TEST {
@@ -160,14 +161,14 @@ fn integer_unchecked_crt_sub_32_bits() {
 
 #[test]
 fn integer_unchecked_crt_scalar_add_32_bits() {
-    let params = PARAM_MESSAGE_5_CARRY_1_KS_PBS;
+    let param = PARAM_MESSAGE_5_CARRY_1_KS_PBS;
 
     // Define CRT basis, and global modulus
     let basis = [3u64, 11, 13, 19, 23, 29, 31, 32];
 
     // Use u128 to avoid overflows as the modulus is slightly larger than 32 bits
     let modulus = basis.iter().copied().map(u128::from).product::<u128>();
-    let (cks, sks) = KEY_CACHE.get_from_params(params);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::CRT);
     let mut rng = rand::thread_rng();
 
     for _ in 0..NB_TEST {
@@ -192,14 +193,14 @@ fn integer_unchecked_crt_scalar_add_32_bits() {
 
 #[test]
 fn integer_unchecked_crt_scalar_mul_32_bits() {
-    let params = PARAM_MESSAGE_5_CARRY_1_KS_PBS;
+    let param = PARAM_MESSAGE_5_CARRY_1_KS_PBS;
 
     // Define CRT basis, and global modulus
     let basis = [3u64, 11, 13, 19, 23, 29, 31, 32];
 
     // Use u128 to avoid overflows as the modulus is slightly larger than 32 bits
     let modulus = basis.iter().copied().map(u128::from).product::<u128>();
-    let (cks, sks) = KEY_CACHE.get_from_params(params);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::CRT);
     let mut rng = rand::thread_rng();
 
     for _ in 0..NB_TEST {
@@ -224,14 +225,14 @@ fn integer_unchecked_crt_scalar_mul_32_bits() {
 
 #[test]
 fn integer_unchecked_crt_scalar_sub_32_bits() {
-    let params = PARAM_MESSAGE_5_CARRY_1_KS_PBS;
+    let param = PARAM_MESSAGE_5_CARRY_1_KS_PBS;
 
     // Define CRT basis, and global modulus
     let basis = [3u64, 11, 13, 19, 23, 29, 31, 32];
 
     // Use u128 to avoid overflows as the modulus is slightly larger than 32 bits
     let modulus = basis.iter().copied().map(u128::from).product::<u128>();
-    let (cks, sks) = KEY_CACHE.get_from_params(params);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::CRT);
     let mut rng = rand::thread_rng();
 
     for _ in 0..NB_TEST {
@@ -256,7 +257,7 @@ fn integer_unchecked_crt_scalar_sub_32_bits() {
 
 fn integer_unchecked_crt_mul(param: ClassicPBSParameters) {
     // generate the server-client key set
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::CRT);
 
     //RNG
     let mut rng = rand::thread_rng();
@@ -289,7 +290,7 @@ fn integer_smart_crt_add(param: ClassicPBSParameters) {
     let basis = make_basis(param.message_modulus.0);
     let modulus = basis.iter().product::<u64>();
 
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::CRT);
 
     //RNG
     let mut rng = rand::thread_rng();
@@ -316,7 +317,7 @@ fn integer_smart_crt_add(param: ClassicPBSParameters) {
 
 fn integer_smart_crt_mul(param: ClassicPBSParameters) {
     // generate the server-client key set
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::CRT);
 
     // Define CRT basis, and global modulus
     let basis = make_basis(param.message_modulus.0);
@@ -351,7 +352,7 @@ fn integer_smart_crt_neg(param: ClassicPBSParameters) {
     let basis = make_basis(param.message_modulus.0);
     let modulus = basis.iter().product::<u64>();
 
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::CRT);
 
     //RNG
     let mut rng = rand::thread_rng();
@@ -381,7 +382,7 @@ fn integer_smart_crt_scalar_add(param: ClassicPBSParameters) {
     let basis = make_basis(param.message_modulus.0);
     let modulus = basis.iter().product::<u64>();
 
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::CRT);
 
     //RNG
     let mut rng = rand::thread_rng();
@@ -409,7 +410,7 @@ fn integer_smart_crt_scalar_mul(param: ClassicPBSParameters) {
     let basis = make_basis(param.message_modulus.0);
     let modulus = basis.iter().product::<u64>();
 
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::CRT);
 
     //RNG
     let mut rng = rand::thread_rng();
@@ -437,7 +438,7 @@ fn integer_smart_crt_scalar_sub(param: ClassicPBSParameters) {
     let basis = make_basis(param.message_modulus.0);
     let modulus = basis.iter().product::<u64>();
 
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::CRT);
 
     //RNG
     let mut rng = rand::thread_rng();
@@ -468,7 +469,7 @@ fn integer_smart_crt_sub(param: ClassicPBSParameters) {
     let basis = make_basis(param.message_modulus.0);
     let modulus = basis.iter().product::<u64>();
 
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::CRT);
 
     //RNG
     let mut rng = rand::thread_rng();

--- a/tfhe/src/integer/server_key/crt_parallel/mod.rs
+++ b/tfhe/src/integer/server_key/crt_parallel/mod.rs
@@ -18,19 +18,19 @@ impl ServerKey {
     /// # Example
     ///
     ///```rust
-    /// use tfhe::integer::gen_keys;
+    /// use tfhe::integer::gen_keys_crt;
     /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
+    /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
+    /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 14;
-    /// let basis = vec![2, 3, 5];
-    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
-    /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
-    /// let ctxt_2 = cks.encrypt_crt(clear_2, basis);
+    /// let mut ctxt_1 = cks.encrypt(clear_1);
+    /// let ctxt_2 = cks.encrypt(clear_2);
     ///
     /// // Compute homomorphically a multiplication
     /// sks.unchecked_crt_add_assign(&mut ctxt_1, &ctxt_2);
@@ -38,7 +38,7 @@ impl ServerKey {
     /// sks.full_extract_message_assign_parallelized(&mut ctxt_1);
     ///
     /// // Decrypt
-    /// let res = cks.decrypt_crt(&ctxt_1);
+    /// let res = cks.decrypt(&ctxt_1);
     /// assert_eq!((clear_1 + clear_2) % modulus, res);
     /// ```
     pub fn full_extract_message_assign_parallelized(&self, ctxt: &mut CrtCiphertext) {

--- a/tfhe/src/integer/server_key/crt_parallel/neg_crt.rs
+++ b/tfhe/src/integer/server_key/crt_parallel/neg_crt.rs
@@ -11,21 +11,21 @@ impl ServerKey {
     /// # Example
     ///
     ///```rust
-    /// use tfhe::integer::gen_keys;
+    /// use tfhe::integer::gen_keys_crt;
     /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
+    /// let basis = vec![2, 3, 5];
+    /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
     ///
     /// let clear = 14_u64;
-    /// let basis = vec![2, 3, 5];
     ///
-    /// let mut ctxt = cks.encrypt_crt(clear, basis.clone());
+    /// let mut ctxt = cks.encrypt(clear);
     ///
     /// sks.unchecked_crt_neg_assign_parallelized(&mut ctxt);
     ///
     /// // Decrypt
-    /// let res = cks.decrypt_crt(&ctxt);
+    /// let res = cks.decrypt(&ctxt);
     /// assert_eq!(16, res);
     /// ```
     pub fn unchecked_crt_neg_parallelized(&self, ctxt: &CrtCiphertext) -> CrtCiphertext {
@@ -51,21 +51,21 @@ impl ServerKey {
     /// # Example
     ///
     ///```rust
-    /// use tfhe::integer::gen_keys;
+    /// use tfhe::integer::gen_keys_crt;
     /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
+    /// let basis = vec![2, 3, 5];
+    /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
     ///
     /// let clear = 14_u64;
-    /// let basis = vec![2, 3, 5];
     ///
-    /// let mut ctxt = cks.encrypt_crt(clear, basis.clone());
+    /// let mut ctxt = cks.encrypt(clear);
     ///
     /// sks.smart_crt_neg_assign_parallelized(&mut ctxt);
     ///
     /// // Decrypt
-    /// let res = cks.decrypt_crt(&ctxt);
+    /// let res = cks.decrypt(&ctxt);
     /// assert_eq!(16, res);
     /// ```
     pub fn smart_crt_neg_assign_parallelized(&self, ctxt: &mut CrtCiphertext) {

--- a/tfhe/src/integer/server_key/crt_parallel/scalar_add_crt.rs
+++ b/tfhe/src/integer/server_key/crt_parallel/scalar_add_crt.rs
@@ -14,23 +14,23 @@ impl ServerKey {
     /// # Example
     ///
     ///```rust
-    /// use tfhe::integer::gen_keys;
+    /// use tfhe::integer::gen_keys_crt;
     /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
+    /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
+    /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 14;
-    /// let basis = vec![2, 3, 5];
-    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
-    /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
+    /// let mut ctxt_1 = cks.encrypt(clear_1);
     ///
     /// sks.unchecked_crt_scalar_add_assign_parallelized(&mut ctxt_1, clear_2);
     ///
     /// // Decrypt
-    /// let res = cks.decrypt_crt(&ctxt_1);
+    /// let res = cks.decrypt(&ctxt_1);
     /// assert_eq!((clear_1 + clear_2) % modulus, res);
     /// ```
     pub fn unchecked_crt_scalar_add_parallelized(
@@ -73,23 +73,23 @@ impl ServerKey {
     ///
     /// ```rust
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// use tfhe::integer::gen_keys;
+    /// use tfhe::integer::gen_keys_crt;
     /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
+    /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
+    /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 14;
-    /// let basis = vec![2, 3, 5];
-    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
-    /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
+    /// let mut ctxt_1 = cks.encrypt(clear_1);
     ///
     /// sks.checked_crt_scalar_add_assign_parallelized(&mut ctxt_1, clear_2);
     ///
     /// // Decrypt
-    /// let res = cks.decrypt_crt(&ctxt_1);
+    /// let res = cks.decrypt(&ctxt_1);
     /// assert_eq!((clear_1 + clear_2) % modulus, res);
     /// # Ok(())
     /// # }
@@ -130,23 +130,23 @@ impl ServerKey {
     /// # Example
     ///
     ///```rust
-    /// use tfhe::integer::gen_keys;
+    /// use tfhe::integer::gen_keys_crt;
     /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
+    /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
+    /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 14;
-    /// let basis = vec![2, 3, 5];
-    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
-    /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
+    /// let mut ctxt_1 = cks.encrypt(clear_1);
     ///
     /// let ctxt = sks.smart_crt_scalar_add_parallelized(&mut ctxt_1, clear_2);
     ///
     /// // Decrypt
-    /// let res = cks.decrypt_crt(&ctxt);
+    /// let res = cks.decrypt(&ctxt);
     /// assert_eq!((clear_1 + clear_2) % modulus, res);
     /// ```
     pub fn smart_crt_scalar_add_parallelized(
@@ -172,23 +172,23 @@ impl ServerKey {
     /// # Example
     ///
     ///```rust
-    /// use tfhe::integer::gen_keys;
+    /// use tfhe::integer::gen_keys_crt;
     /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
+    /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
+    /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 14;
-    /// let basis = vec![2, 3, 5];
-    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
-    /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
+    /// let mut ctxt_1 = cks.encrypt(clear_1);
     ///
     /// sks.smart_crt_scalar_add_assign_parallelized(&mut ctxt_1, clear_2);
     ///
     /// // Decrypt
-    /// let res = cks.decrypt_crt(&ctxt_1);
+    /// let res = cks.decrypt(&ctxt_1);
     /// assert_eq!((clear_1 + clear_2) % modulus, res);
     /// ```
     pub fn smart_crt_scalar_add_assign_parallelized(&self, ct: &mut CrtCiphertext, scalar: u64) {

--- a/tfhe/src/integer/server_key/crt_parallel/scalar_mul_crt.rs
+++ b/tfhe/src/integer/server_key/crt_parallel/scalar_mul_crt.rs
@@ -14,23 +14,23 @@ impl ServerKey {
     /// # Example
     ///
     ///```rust
-    /// use tfhe::integer::gen_keys;
+    /// use tfhe::integer::gen_keys_crt;
     /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
+    /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
+    /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 2;
-    /// let basis = vec![2, 3, 5];
-    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
-    /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
+    /// let mut ctxt_1 = cks.encrypt(clear_1);
     ///
     /// sks.unchecked_crt_scalar_mul_assign_parallelized(&mut ctxt_1, clear_2);
     ///
     /// // Decrypt
-    /// let res = cks.decrypt_crt(&ctxt_1);
+    /// let res = cks.decrypt(&ctxt_1);
     /// assert_eq!((clear_1 * clear_2) % modulus, res);
     /// ```
     pub fn unchecked_crt_scalar_mul_parallelized(
@@ -70,27 +70,24 @@ impl ServerKey {
     /// # Example
     ///
     /// ```rust
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// use tfhe::integer::gen_keys;
+    /// use tfhe::integer::gen_keys_crt;
     /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
+    /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
+    /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 2;
-    /// let basis = vec![2, 3, 5];
-    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
-    /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
+    /// let mut ctxt_1 = cks.encrypt(clear_1);
     ///
     /// sks.checked_crt_scalar_mul_assign_parallelized(&mut ctxt_1, clear_2);
     ///
     /// // Decrypt
-    /// let res = cks.decrypt_crt(&ctxt_1);
+    /// let res = cks.decrypt(&ctxt_1);
     /// assert_eq!((clear_1 * clear_2) % modulus, res);
-    /// # Ok(())
-    /// # }
     /// ```
     pub fn checked_crt_scalar_mul_parallelized(
         &self,
@@ -139,23 +136,23 @@ impl ServerKey {
     /// # Example
     ///
     ///```rust
-    /// use tfhe::integer::gen_keys;
+    /// use tfhe::integer::gen_keys_crt;
     /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
+    /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
+    /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 14;
-    /// let basis = vec![2, 3, 5];
-    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
-    /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
+    /// let mut ctxt_1 = cks.encrypt(clear_1);
     ///
     /// let ctxt = sks.smart_crt_scalar_mul_parallelized(&mut ctxt_1, clear_2);
     ///
     /// // Decrypt
-    /// let res = cks.decrypt_crt(&ctxt);
+    /// let res = cks.decrypt(&ctxt);
     /// assert_eq!((clear_1 * clear_2) % modulus, res);
     /// ```
     pub fn smart_crt_scalar_mul_parallelized(
@@ -181,23 +178,23 @@ impl ServerKey {
     /// # Example
     ///
     ///```rust
-    /// use tfhe::integer::gen_keys;
+    /// use tfhe::integer::gen_keys_crt;
     /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
+    /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
+    /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 14;
-    /// let basis = vec![2, 3, 5];
-    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
-    /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
+    /// let mut ctxt_1 = cks.encrypt(clear_1);
     ///
     /// sks.smart_crt_scalar_mul_assign_parallelized(&mut ctxt_1, clear_2);
     ///
     /// // Decrypt
-    /// let res = cks.decrypt_crt(&ctxt_1);
+    /// let res = cks.decrypt(&ctxt_1);
     /// assert_eq!((clear_1 * clear_2) % modulus, res);
     /// ```
     pub fn smart_crt_scalar_mul_assign_parallelized(&self, ctxt: &mut CrtCiphertext, scalar: u64) {

--- a/tfhe/src/integer/server_key/crt_parallel/scalar_sub_crt.rs
+++ b/tfhe/src/integer/server_key/crt_parallel/scalar_sub_crt.rs
@@ -14,23 +14,23 @@ impl ServerKey {
     /// # Example
     ///
     ///```rust
-    /// use tfhe::integer::gen_keys;
+    /// use tfhe::integer::gen_keys_crt;
     /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
+    /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
+    /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 7;
-    /// let basis = vec![2, 3, 5];
-    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
-    /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
+    /// let mut ctxt_1 = cks.encrypt(clear_1);
     ///
     /// sks.unchecked_crt_scalar_sub_assign_parallelized(&mut ctxt_1, clear_2);
     ///
     /// // Decrypt
-    /// let res = cks.decrypt_crt(&ctxt_1);
+    /// let res = cks.decrypt(&ctxt_1);
     /// assert_eq!((clear_1 - clear_2) % modulus, res);
     /// ```
     pub fn unchecked_crt_scalar_sub_parallelized(
@@ -67,23 +67,23 @@ impl ServerKey {
     ///
     /// ```rust
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// use tfhe::integer::gen_keys;
+    /// use tfhe::integer::gen_keys_crt;
     /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
+    /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
+    /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 8;
-    /// let basis = vec![2, 3, 5];
-    /// let modulus: u64 = basis.iter().product();
     ///
-    /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
+    /// let mut ctxt_1 = cks.encrypt(clear_1);
     ///
     /// let ct_res = sks.checked_crt_scalar_sub_parallelized(&mut ctxt_1, clear_2)?;
     ///
     /// // Decrypt:
-    /// let dec = cks.decrypt_crt(&ct_res);
+    /// let dec = cks.decrypt(&ct_res);
     /// assert_eq!((clear_1 - clear_2) % modulus, dec);
     /// # Ok(())
     /// # }
@@ -109,23 +109,23 @@ impl ServerKey {
     ///
     /// ```rust
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// use tfhe::integer::gen_keys;
+    /// use tfhe::integer::gen_keys_crt;
     /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
+    /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
+    /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 7;
-    /// let basis = vec![2, 3, 5];
-    /// let modulus: u64 = basis.iter().product();
     ///
-    /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
+    /// let mut ctxt_1 = cks.encrypt(clear_1);
     ///
     /// sks.checked_crt_scalar_sub_assign_parallelized(&mut ctxt_1, clear_2)?;
     ///
     /// // Decrypt:
-    /// let dec = cks.decrypt_crt(&ctxt_1);
+    /// let dec = cks.decrypt(&ctxt_1);
     /// assert_eq!((clear_1 - clear_2) % modulus, dec);
     /// # Ok(())
     /// # }
@@ -148,23 +148,23 @@ impl ServerKey {
     /// # Example
     ///
     ///```rust
-    /// use tfhe::integer::gen_keys;
+    /// use tfhe::integer::gen_keys_crt;
     /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
+    /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
+    /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 7;
-    /// let basis = vec![2, 3, 5];
-    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
-    /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
+    /// let mut ctxt_1 = cks.encrypt(clear_1);
     ///
     /// sks.smart_crt_scalar_sub_assign_parallelized(&mut ctxt_1, clear_2);
     ///
     /// // Decrypt
-    /// let res = cks.decrypt_crt(&ctxt_1);
+    /// let res = cks.decrypt(&ctxt_1);
     /// assert_eq!((clear_1 - clear_2) % modulus, res);
     /// ```
     pub fn smart_crt_scalar_sub_parallelized(

--- a/tfhe/src/integer/server_key/crt_parallel/sub_crt.rs
+++ b/tfhe/src/integer/server_key/crt_parallel/sub_crt.rs
@@ -10,24 +10,24 @@ impl ServerKey {
     /// # Example
     ///
     ///```rust
-    /// use tfhe::integer::gen_keys;
+    /// use tfhe::integer::gen_keys_crt;
     /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
+    /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
+    /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 5;
-    /// let basis = vec![2, 3, 5];
-    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
-    /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
-    /// let mut ctxt_2 = cks.encrypt_crt(clear_2, basis.clone());
+    /// let mut ctxt_1 = cks.encrypt(clear_1);
+    /// let mut ctxt_2 = cks.encrypt(clear_2);
     ///
     /// let ctxt = sks.unchecked_crt_sub_parallelized(&mut ctxt_1, &mut ctxt_2);
     ///
     /// // Decrypt
-    /// let res = cks.decrypt_crt(&ctxt);
+    /// let res = cks.decrypt(&ctxt);
     /// assert_eq!((clear_1 - clear_2) % modulus, res);
     /// ```
     pub fn unchecked_crt_sub_parallelized(
@@ -49,24 +49,24 @@ impl ServerKey {
     /// # Example
     ///
     ///```rust
-    /// use tfhe::integer::gen_keys;
+    /// use tfhe::integer::gen_keys_crt;
     /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
+    /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
+    /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 5;
-    /// let basis = vec![2, 3, 5];
-    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
-    /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
-    /// let mut ctxt_2 = cks.encrypt_crt(clear_2, basis.clone());
+    /// let mut ctxt_1 = cks.encrypt(clear_1);
+    /// let mut ctxt_2 = cks.encrypt(clear_2);
     ///
     /// let ctxt = sks.unchecked_crt_sub_parallelized(&mut ctxt_1, &mut ctxt_2);
     ///
     /// // Decrypt
-    /// let res = cks.decrypt_crt(&ctxt);
+    /// let res = cks.decrypt(&ctxt);
     /// assert_eq!((clear_1 - clear_2) % modulus, res);
     /// ```
     pub fn unchecked_crt_sub_assign_parallelized(
@@ -83,24 +83,24 @@ impl ServerKey {
     /// # Example
     ///
     ///```rust
-    /// use tfhe::integer::gen_keys;
+    /// use tfhe::integer::gen_keys_crt;
     /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
+    /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
+    /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 5;
-    /// let basis = vec![2, 3, 5];
-    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
-    /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
-    /// let mut ctxt_2 = cks.encrypt_crt(clear_2, basis.clone());
+    /// let mut ctxt_1 = cks.encrypt(clear_1);
+    /// let mut ctxt_2 = cks.encrypt(clear_2);
     ///
     /// let ctxt = sks.smart_crt_sub_parallelized(&mut ctxt_1, &mut ctxt_2);
     ///
     /// // Decrypt
-    /// let res = cks.decrypt_crt(&ctxt);
+    /// let res = cks.decrypt(&ctxt);
     /// assert_eq!((clear_1 - clear_2) % modulus, res);
     /// ```
     pub fn smart_crt_sub_parallelized(
@@ -126,24 +126,24 @@ impl ServerKey {
     /// # Example
     ///
     ///```rust
-    /// use tfhe::integer::gen_keys;
+    /// use tfhe::integer::gen_keys_crt;
     /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
+    /// let basis = vec![2, 3, 5];
+    /// let modulus: u64 = basis.iter().product();
+    /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
     ///
     /// let clear_1 = 14;
     /// let clear_2 = 5;
-    /// let basis = vec![2, 3, 5];
-    /// let modulus: u64 = basis.iter().product();
     /// // Encrypt two messages
-    /// let mut ctxt_1 = cks.encrypt_crt(clear_1, basis.clone());
-    /// let mut ctxt_2 = cks.encrypt_crt(clear_2, basis.clone());
+    /// let mut ctxt_1 = cks.encrypt(clear_1);
+    /// let mut ctxt_2 = cks.encrypt(clear_2);
     ///
     /// sks.smart_crt_sub_assign_parallelized(&mut ctxt_1, &mut ctxt_2);
     ///
     /// // Decrypt
-    /// let res = cks.decrypt_crt(&ctxt_1);
+    /// let res = cks.decrypt(&ctxt_1);
     /// assert_eq!((clear_1 - clear_2) % modulus, res);
     /// ```
     pub fn smart_crt_sub_assign_parallelized(

--- a/tfhe/src/integer/server_key/crt_parallel/tests.rs
+++ b/tfhe/src/integer/server_key/crt_parallel/tests.rs
@@ -1,4 +1,5 @@
 use crate::integer::keycache::KEY_CACHE;
+use crate::integer::IntegerKeyKind;
 use crate::shortint::parameters::*;
 use rand::Rng;
 
@@ -7,14 +8,14 @@ const NB_TEST: usize = 30;
 
 #[test]
 fn integer_unchecked_crt_add_parallelized_32_bits() {
-    let params = PARAM_MESSAGE_5_CARRY_1_KS_PBS;
+    let param = PARAM_MESSAGE_5_CARRY_1_KS_PBS;
 
     // Define CRT basis, and global modulus
     let basis = [3u64, 11, 13, 19, 23, 29, 31, 32];
 
     // Use u128 to avoid overflows as the modulus is slightly larger than 32 bits
     let modulus = basis.iter().copied().map(u128::from).product::<u128>();
-    let (cks, sks) = KEY_CACHE.get_from_params(params);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::CRT);
     let mut rng = rand::thread_rng();
 
     for _ in 0..NB_TEST {
@@ -40,14 +41,14 @@ fn integer_unchecked_crt_add_parallelized_32_bits() {
 
 #[test]
 fn integer_unchecked_crt_mul_parallelized_32_bits() {
-    let params = PARAM_MESSAGE_5_CARRY_1_KS_PBS;
+    let param = PARAM_MESSAGE_5_CARRY_1_KS_PBS;
 
     // Define CRT basis, and global modulus
     let basis = [3u64, 11, 13, 19, 23, 29, 31, 32];
 
     // Use u128 to avoid overflows as the modulus is slightly larger than 32 bits
     let modulus = basis.iter().copied().map(u128::from).product::<u128>();
-    let (cks, sks) = KEY_CACHE.get_from_params(params);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::CRT);
     let mut rng = rand::thread_rng();
 
     for _ in 0..NB_TEST {
@@ -74,14 +75,14 @@ fn integer_unchecked_crt_mul_parallelized_32_bits() {
 
 #[test]
 fn integer_unchecked_crt_neg_parallelized_32_bits() {
-    let params = PARAM_MESSAGE_5_CARRY_1_KS_PBS;
+    let param = PARAM_MESSAGE_5_CARRY_1_KS_PBS;
 
     // Define CRT basis, and global modulus
     let basis = [3u64, 11, 13, 19, 23, 29, 31, 32];
 
     // Use u128 to avoid overflows as the modulus is slightly larger than 32 bits
     let modulus = basis.iter().copied().map(u128::from).product::<u128>();
-    let (cks, sks) = KEY_CACHE.get_from_params(params);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::CRT);
     let mut rng = rand::thread_rng();
 
     for _ in 0..NB_TEST {
@@ -102,14 +103,14 @@ fn integer_unchecked_crt_neg_parallelized_32_bits() {
 
 #[test]
 fn integer_unchecked_crt_sub_parallelized_32_bits() {
-    let params = PARAM_MESSAGE_5_CARRY_1_KS_PBS;
+    let param = PARAM_MESSAGE_5_CARRY_1_KS_PBS;
 
     // Define CRT basis, and global modulus
     let basis = [3u64, 11, 13, 19, 23, 29, 31, 32];
 
     // Use u128 to avoid overflows as the modulus is slightly larger than 32 bits
     let modulus = basis.iter().copied().map(u128::from).product::<u128>();
-    let (cks, sks) = KEY_CACHE.get_from_params(params);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::CRT);
     let mut rng = rand::thread_rng();
 
     for _ in 0..NB_TEST {
@@ -135,14 +136,14 @@ fn integer_unchecked_crt_sub_parallelized_32_bits() {
 
 #[test]
 fn integer_unchecked_crt_scalar_add_parallelized_32_bits() {
-    let params = PARAM_MESSAGE_5_CARRY_1_KS_PBS;
+    let param = PARAM_MESSAGE_5_CARRY_1_KS_PBS;
 
     // Define CRT basis, and global modulus
     let basis = [3u64, 11, 13, 19, 23, 29, 31, 32];
 
     // Use u128 to avoid overflows as the modulus is slightly larger than 32 bits
     let modulus = basis.iter().copied().map(u128::from).product::<u128>();
-    let (cks, sks) = KEY_CACHE.get_from_params(params);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::CRT);
     let mut rng = rand::thread_rng();
 
     for _ in 0..NB_TEST {
@@ -167,14 +168,14 @@ fn integer_unchecked_crt_scalar_add_parallelized_32_bits() {
 
 #[test]
 fn integer_unchecked_crt_scalar_mul_parallelized_32_bits() {
-    let params = PARAM_MESSAGE_5_CARRY_1_KS_PBS;
+    let param = PARAM_MESSAGE_5_CARRY_1_KS_PBS;
 
     // Define CRT basis, and global modulus
     let basis = [3u64, 11, 13, 19, 23, 29, 31, 32];
 
     // Use u128 to avoid overflows as the modulus is slightly larger than 32 bits
     let modulus = basis.iter().copied().map(u128::from).product::<u128>();
-    let (cks, sks) = KEY_CACHE.get_from_params(params);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::CRT);
     let mut rng = rand::thread_rng();
 
     for _ in 0..NB_TEST {
@@ -199,14 +200,14 @@ fn integer_unchecked_crt_scalar_mul_parallelized_32_bits() {
 
 #[test]
 fn integer_unchecked_crt_scalar_sub_parallelized_32_bits() {
-    let params = PARAM_MESSAGE_5_CARRY_1_KS_PBS;
+    let param = PARAM_MESSAGE_5_CARRY_1_KS_PBS;
 
     // Define CRT basis, and global modulus
     let basis = [3u64, 11, 13, 19, 23, 29, 31, 32];
 
     // Use u128 to avoid overflows as the modulus is slightly larger than 32 bits
     let modulus = basis.iter().copied().map(u128::from).product::<u128>();
-    let (cks, sks) = KEY_CACHE.get_from_params(params);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::CRT);
     let mut rng = rand::thread_rng();
 
     for _ in 0..NB_TEST {

--- a/tfhe/src/integer/server_key/radix/tests.rs
+++ b/tfhe/src/integer/server_key/radix/tests.rs
@@ -1,5 +1,5 @@
 use crate::integer::keycache::KEY_CACHE;
-use crate::integer::{ServerKey, U256};
+use crate::integer::{IntegerKeyKind, ServerKey, U256};
 use crate::shortint::parameters::*;
 use crate::shortint::ClassicPBSParameters;
 use rand::Rng;
@@ -69,7 +69,7 @@ create_parametrized_test!(integer_full_propagate {
 });
 
 fn integer_encrypt_decrypt(param: ClassicPBSParameters) {
-    let (cks, _) = KEY_CACHE.get_from_params(param);
+    let (cks, _) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     let mut rng = rand::thread_rng();
 
@@ -87,7 +87,7 @@ fn integer_encrypt_decrypt(param: ClassicPBSParameters) {
 }
 
 fn integer_encrypt_decrypt_128_bits(param: ClassicPBSParameters) {
-    let (cks, _) = KEY_CACHE.get_from_params(param);
+    let (cks, _) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     let mut rng = rand::thread_rng();
     let num_block = (128f64 / (param.message_modulus.0 as f64).log(2.0)).ceil() as usize;
@@ -103,7 +103,7 @@ fn integer_encrypt_decrypt_128_bits(param: ClassicPBSParameters) {
 }
 
 fn integer_encrypt_decrypt_128_bits_specific_values(param: ClassicPBSParameters) {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     let num_block = (128f64 / (param.message_modulus.0 as f64).log(2.0)).ceil() as usize;
     {
@@ -155,7 +155,7 @@ fn integer_encrypt_decrypt_128_bits_specific_values(param: ClassicPBSParameters)
 }
 
 fn integer_encrypt_decrypt_256_bits_specific_values(param: ClassicPBSParameters) {
-    let (cks, _) = KEY_CACHE.get_from_params(param);
+    let (cks, _) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     let num_block = (256f64 / (param.message_modulus.0 as f64).log(2.0)).ceil() as usize;
     {
@@ -179,7 +179,7 @@ fn integer_encrypt_decrypt_256_bits_specific_values(param: ClassicPBSParameters)
 }
 
 fn integer_encrypt_decrypt_256_bits(param: ClassicPBSParameters) {
-    let (cks, _) = KEY_CACHE.get_from_params(param);
+    let (cks, _) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     // RNG
     let mut rng = rand::thread_rng();
@@ -203,7 +203,7 @@ fn integer_encrypt_decrypt_256_bits(param: ClassicPBSParameters) {
 }
 
 fn integer_smart_add_128_bits(param: ClassicPBSParameters) {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     let mut rng = rand::thread_rng();
     let num_block = (128f64 / (param.message_modulus.0 as f64).log(2.0)).ceil() as usize;
@@ -241,7 +241,7 @@ fn integer_smart_add_128_bits(param: ClassicPBSParameters) {
 }
 
 fn integer_unchecked_add(param: ClassicPBSParameters) {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     let mut rng = rand::thread_rng();
 
@@ -262,7 +262,7 @@ fn integer_unchecked_add(param: ClassicPBSParameters) {
 }
 
 fn integer_smart_add(param: ClassicPBSParameters) {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     let mut rng = rand::thread_rng();
 
@@ -294,7 +294,7 @@ fn integer_smart_add(param: ClassicPBSParameters) {
 }
 
 fn integer_unchecked_bitand(param: ClassicPBSParameters) {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     //RNG
     let mut rng = rand::thread_rng();
@@ -325,7 +325,7 @@ fn integer_unchecked_bitand(param: ClassicPBSParameters) {
 }
 
 fn integer_unchecked_bitor(param: ClassicPBSParameters) {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     //RNG
     let mut rng = rand::thread_rng();
@@ -356,7 +356,7 @@ fn integer_unchecked_bitor(param: ClassicPBSParameters) {
 }
 
 fn integer_unchecked_bitxor(param: ClassicPBSParameters) {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     //RNG
     let mut rng = rand::thread_rng();
@@ -387,7 +387,7 @@ fn integer_unchecked_bitxor(param: ClassicPBSParameters) {
 }
 
 fn integer_smart_bitand(param: ClassicPBSParameters) {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     //RNG
     let mut rng = rand::thread_rng();
@@ -432,7 +432,7 @@ fn integer_smart_bitand(param: ClassicPBSParameters) {
 }
 
 fn integer_smart_bitor(param: ClassicPBSParameters) {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     //RNG
     let mut rng = rand::thread_rng();
@@ -477,7 +477,7 @@ fn integer_smart_bitor(param: ClassicPBSParameters) {
 }
 
 fn integer_smart_bitxor(param: ClassicPBSParameters) {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     //RNG
     let mut rng = rand::thread_rng();
@@ -522,7 +522,7 @@ fn integer_smart_bitxor(param: ClassicPBSParameters) {
 }
 
 fn integer_unchecked_small_scalar_mul(param: ClassicPBSParameters) {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     //RNG
     let mut rng = rand::thread_rng();
@@ -552,7 +552,7 @@ fn integer_unchecked_small_scalar_mul(param: ClassicPBSParameters) {
 }
 
 fn integer_smart_small_scalar_mul(param: ClassicPBSParameters) {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     //RNG
     let mut rng = rand::thread_rng();
@@ -589,7 +589,7 @@ fn integer_smart_small_scalar_mul(param: ClassicPBSParameters) {
 }
 
 fn integer_blockshift(param: ClassicPBSParameters) {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     //RNG
     let mut rng = rand::thread_rng();
@@ -620,7 +620,7 @@ fn integer_blockshift(param: ClassicPBSParameters) {
 }
 
 fn integer_blockshift_right(param: ClassicPBSParameters) {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     //RNG
     let mut rng = rand::thread_rng();
@@ -651,7 +651,7 @@ fn integer_blockshift_right(param: ClassicPBSParameters) {
 }
 
 fn integer_smart_scalar_mul(param: ClassicPBSParameters) {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     //RNG
     let mut rng = rand::thread_rng();
@@ -679,7 +679,7 @@ fn integer_smart_scalar_mul(param: ClassicPBSParameters) {
 }
 
 fn integer_unchecked_scalar_left_shift(param: ClassicPBSParameters) {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     let mut rng = rand::thread_rng();
 
@@ -713,7 +713,7 @@ fn integer_unchecked_scalar_left_shift(param: ClassicPBSParameters) {
 }
 
 fn integer_unchecked_scalar_right_shift(param: ClassicPBSParameters) {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     //RNG
     let mut rng = rand::thread_rng();
@@ -756,7 +756,7 @@ where
 }
 
 fn integer_smart_neg(param: ClassicPBSParameters) {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     let mut rng = rand::thread_rng();
 
@@ -792,7 +792,7 @@ where
 }
 
 fn integer_smart_sub(param: ClassicPBSParameters) {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     //RNG
     let mut rng = rand::thread_rng();
@@ -826,7 +826,7 @@ fn integer_smart_sub(param: ClassicPBSParameters) {
 }
 
 fn integer_unchecked_block_mul(param: ClassicPBSParameters) {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     //RNG
     let mut rng = rand::thread_rng();
@@ -859,7 +859,7 @@ fn integer_unchecked_block_mul(param: ClassicPBSParameters) {
 }
 
 fn integer_smart_block_mul(param: ClassicPBSParameters) {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     //RNG
     let mut rng = rand::thread_rng();
@@ -896,7 +896,7 @@ fn integer_smart_block_mul(param: ClassicPBSParameters) {
 }
 
 fn integer_unchecked_mul(param: ClassicPBSParameters) {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     //RNG
     let mut rng = rand::thread_rng();
@@ -925,7 +925,7 @@ fn integer_unchecked_mul(param: ClassicPBSParameters) {
 }
 
 fn integer_smart_mul(param: ClassicPBSParameters) {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     //RNG
     let mut rng = rand::thread_rng();
@@ -971,7 +971,7 @@ where
 
 fn integer_smart_scalar_add(param: ClassicPBSParameters) {
     // generate the server-client key set
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     // message_modulus^vec_length
     let modulus = param.message_modulus.0.pow(NB_CTXT as u32) as u64;
@@ -1020,7 +1020,7 @@ where
 
 fn integer_smart_scalar_sub(param: ClassicPBSParameters) {
     // generate the server-client key set
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     // message_modulus^vec_length
     let modulus = param.message_modulus.0.pow(NB_CTXT as u32) as u64;
@@ -1069,7 +1069,7 @@ fn integer_unchecked_scalar_decomposition_overflow(param: ClassicPBSParameters) 
 
     let num_block = (128_f64 / (param.message_modulus.0 as f64).log(2.0)).ceil() as usize;
 
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     // Check addition
     // --------------
@@ -1109,7 +1109,7 @@ fn integer_smart_scalar_mul_decomposition_overflow() {
 
     let num_block = (128_f64 / (param.message_modulus.0 as f64).log(2.0)).ceil() as usize;
 
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     let scalar = rng.gen::<u64>();
     let clear_0 = rng.gen::<u128>();

--- a/tfhe/src/integer/server_key/radix_parallel/tests_cases_comparisons.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_cases_comparisons.rs
@@ -1,5 +1,5 @@
 use crate::integer::ciphertext::{RadixCiphertext, SignedRadixCiphertext};
-use crate::integer::{gen_keys, ServerKey, I256, U256};
+use crate::integer::{gen_keys, IntegerKeyKind, ServerKey, I256, U256};
 use crate::shortint::ClassicPBSParameters;
 use rand;
 use rand::prelude::*;
@@ -22,7 +22,7 @@ fn test_unchecked_function<UncheckedFn, ClearF>(
 
     let num_block = (256f64 / (param.message_modulus.0 as f64).log(2.0)).ceil() as usize;
 
-    let (cks, sks) = gen_keys(param);
+    let (cks, sks) = gen_keys(param, IntegerKeyKind::Radix);
 
     for _ in 0..num_test {
         let clear_a = rng.gen::<U256>();
@@ -66,7 +66,7 @@ fn test_smart_function<SmartFn, ClearF>(
     ) -> RadixCiphertext,
     ClearF: Fn(U256, U256) -> U256,
 {
-    let (cks, sks) = gen_keys(param);
+    let (cks, sks) = gen_keys(param, IntegerKeyKind::Radix);
     let num_block = (256f64 / (param.message_modulus.0 as f64).log(2.0)).ceil() as usize;
 
     let mut rng = rand::thread_rng();
@@ -137,7 +137,7 @@ fn test_default_function<SmartFn, ClearF>(
     SmartFn: for<'a> Fn(&'a ServerKey, &'a RadixCiphertext, &'a RadixCiphertext) -> RadixCiphertext,
     ClearF: Fn(U256, U256) -> U256,
 {
-    let (cks, sks) = gen_keys(param);
+    let (cks, sks) = gen_keys(param, IntegerKeyKind::Radix);
     let num_block = (256f64 / (param.message_modulus.0 as f64).log(2.0)).ceil() as usize;
 
     let mut rng = rand::thread_rng();
@@ -568,7 +568,7 @@ fn test_signed_unchecked_function<UncheckedFn, ClearF>(
 
     let num_block = (128f64 / (param.message_modulus.0.ilog2() as f64)).ceil() as usize;
 
-    let (cks, sks) = gen_keys(param);
+    let (cks, sks) = gen_keys(param, IntegerKeyKind::Radix);
 
     // Some hard coded tests
     let pairs = [
@@ -631,7 +631,7 @@ fn test_signed_smart_function<SmartFn, ClearF>(
     ) -> SignedRadixCiphertext,
     ClearF: Fn(i128, i128) -> i128,
 {
-    let (cks, sks) = gen_keys(param);
+    let (cks, sks) = gen_keys(param, IntegerKeyKind::Radix);
     let num_block = (128f64 / (param.message_modulus.0.ilog2() as f64).ceil()) as usize;
 
     let mut rng = rand::thread_rng();
@@ -706,7 +706,7 @@ fn test_signed_default_function<SmartFn, ClearF>(
     ) -> SignedRadixCiphertext,
     ClearF: Fn(i128, i128) -> i128,
 {
-    let (cks, sks) = gen_keys(param);
+    let (cks, sks) = gen_keys(param, IntegerKeyKind::Radix);
     let num_block = (128f64 / (param.message_modulus.0.ilog2() as f64).ceil()) as usize;
 
     let mut rng = rand::thread_rng();
@@ -1021,7 +1021,7 @@ fn test_unchecked_scalar_function<UncheckedFn, ClearF>(
 
     let num_block = (256f64 / (param.message_modulus.0 as f64).log(2.0)).ceil() as usize;
 
-    let (cks, sks) = gen_keys(param);
+    let (cks, sks) = gen_keys(param, IntegerKeyKind::Radix);
 
     for _ in 0..num_test {
         let clear_a = rng.gen::<U256>();
@@ -1056,7 +1056,7 @@ fn test_smart_scalar_function<SmartFn, ClearF>(
     SmartFn: for<'a, 'b> Fn(&'a ServerKey, &'a mut RadixCiphertext, U256) -> RadixCiphertext,
     ClearF: Fn(U256, U256) -> U256,
 {
-    let (cks, sks) = gen_keys(param);
+    let (cks, sks) = gen_keys(param, IntegerKeyKind::Radix);
     let num_block = (256f64 / (param.message_modulus.0 as f64).log(2.0)).ceil() as usize;
 
     let mut rng = rand::thread_rng();
@@ -1107,7 +1107,7 @@ fn test_default_scalar_function<SmartFn, ClearF>(
     SmartFn: for<'a, 'b> Fn(&'a ServerKey, &'a RadixCiphertext, U256) -> RadixCiphertext,
     ClearF: Fn(U256, U256) -> U256,
 {
-    let (cks, sks) = gen_keys(param);
+    let (cks, sks) = gen_keys(param, IntegerKeyKind::Radix);
     let num_block = (256f64 / (param.message_modulus.0 as f64).log(2.0)).ceil() as usize;
 
     let mut rng = rand::thread_rng();
@@ -1382,7 +1382,7 @@ fn test_unchecked_scalar_comparisons_edge(param: ClassicPBSParameters) {
 
     let num_block = (128f64 / (param.message_modulus.0 as f64).log(2.0)).ceil() as usize;
 
-    let (cks, sks) = gen_keys(param);
+    let (cks, sks) = gen_keys(param, IntegerKeyKind::Radix);
 
     for _ in 0..4 {
         let clear_a = rng.gen::<u128>();
@@ -1490,7 +1490,7 @@ create_parametrized_test!(test_unchecked_scalar_comparisons_edge {
 });
 
 fn integer_is_scalar_out_of_bounds(param: ClassicPBSParameters) {
-    let (cks, sks) = gen_keys(param);
+    let (cks, sks) = gen_keys(param, IntegerKeyKind::Radix);
     let num_block = (128f64 / (param.message_modulus.0 as f64).log(2.0)).ceil() as usize;
 
     let mut rng = rand::thread_rng();
@@ -1575,7 +1575,7 @@ fn test_signed_unchecked_scalar_function<UncheckedFn, ClearF>(
 
     let num_block = (128f64 / (param.message_modulus.0 as f64).log(2.0)).ceil() as usize;
 
-    let (cks, sks) = gen_keys(param);
+    let (cks, sks) = gen_keys(param, IntegerKeyKind::Radix);
 
     for _ in 0..num_test {
         let clear_a = rng.gen::<i128>();
@@ -1611,7 +1611,7 @@ fn test_signed_smart_scalar_function<SmartFn, ClearF>(
         for<'a, 'b> Fn(&'a ServerKey, &'a mut SignedRadixCiphertext, i128) -> SignedRadixCiphertext,
     ClearF: Fn(i128, i128) -> i128,
 {
-    let (cks, sks) = gen_keys(param);
+    let (cks, sks) = gen_keys(param, IntegerKeyKind::Radix);
     let num_block = (128f64 / (param.message_modulus.0 as f64).log(2.0)).ceil() as usize;
 
     let mut rng = rand::thread_rng();
@@ -1663,7 +1663,7 @@ fn test_signed_default_scalar_function<SmartFn, ClearF>(
         for<'a, 'b> Fn(&'a ServerKey, &'a SignedRadixCiphertext, i128) -> SignedRadixCiphertext,
     ClearF: Fn(i128, i128) -> i128,
 {
-    let (cks, sks) = gen_keys(param);
+    let (cks, sks) = gen_keys(param, IntegerKeyKind::Radix);
     let num_block = (128f64 / (param.message_modulus.0 as f64).log(2.0)).ceil() as usize;
 
     let mut rng = rand::thread_rng();
@@ -1899,7 +1899,7 @@ create_parametrized_test!(integer_signed_scalar_min_parallelized_128_bits {
 });
 
 fn integer_signed_is_scalar_out_of_bounds(param: ClassicPBSParameters) {
-    let (cks, sks) = gen_keys(param);
+    let (cks, sks) = gen_keys(param, IntegerKeyKind::Radix);
     let num_block = (128f64 / (param.message_modulus.0 as f64).log(2.0)).ceil() as usize;
 
     let mut rng = rand::thread_rng();

--- a/tfhe/src/integer/server_key/radix_parallel/tests_cases_unsigned.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_cases_unsigned.rs
@@ -1,7 +1,9 @@
 use crate::integer::block_decomposition::BlockDecomposer;
 use crate::integer::ciphertext::boolean_value::BooleanBlock;
 use crate::integer::keycache::KEY_CACHE;
-use crate::integer::{IntegerRadixCiphertext, RadixCiphertext, RadixClientKey, ServerKey};
+use crate::integer::{
+    IntegerKeyKind, IntegerRadixCiphertext, RadixCiphertext, RadixClientKey, ServerKey,
+};
 use crate::shortint::parameters::*;
 use crate::shortint::Ciphertext;
 use rand::prelude::ThreadRng;
@@ -102,7 +104,7 @@ where
     P: Into<PBSParameters>,
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, &'a RadixCiphertext), RadixCiphertext>,
 {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let sks = Arc::new(sks);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
@@ -137,7 +139,7 @@ where
     P: Into<PBSParameters>,
     T: for<'a> FunctionExecutor<(&'a mut RadixCiphertext, &'a RadixCiphertext), ()>,
 {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let sks = Arc::new(sks);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
@@ -172,7 +174,7 @@ where
     P: Into<PBSParameters>,
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, &'a RadixCiphertext), RadixCiphertext>,
 {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let sks = Arc::new(sks);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
@@ -207,7 +209,7 @@ where
     P: Into<PBSParameters>,
     T: for<'a> FunctionExecutor<&'a RadixCiphertext, RadixCiphertext>,
 {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let sks = Arc::new(sks);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
@@ -236,7 +238,7 @@ where
     P: Into<PBSParameters>,
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, &'a RadixCiphertext), RadixCiphertext>,
 {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let sks = Arc::new(sks);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
@@ -270,7 +272,7 @@ where
         RadixCiphertext,
     >,
 {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let sks = Arc::new(sks);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
@@ -307,7 +309,7 @@ where
     P: Into<PBSParameters>,
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, &'a RadixCiphertext), RadixCiphertext>,
 {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let sks = Arc::new(sks);
     let nb_ct =
         (128f64 / (cks.parameters().message_modulus().0 as f64).log2().ceil()).ceil() as usize;
@@ -347,7 +349,7 @@ where
     P: Into<PBSParameters>,
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, &'a RadixCiphertext), RadixCiphertext>,
 {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let sks = Arc::new(sks);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
@@ -402,7 +404,7 @@ where
     P: Into<PBSParameters>,
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, &'a RadixCiphertext), RadixCiphertext>,
 {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let sks = Arc::new(sks);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
@@ -458,7 +460,7 @@ where
     P: Into<PBSParameters>,
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, &'a RadixCiphertext), RadixCiphertext>,
 {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let sks = Arc::new(sks);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
@@ -511,7 +513,7 @@ where
     P: Into<PBSParameters>,
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, &'a RadixCiphertext), RadixCiphertext>,
 {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let sks = Arc::new(sks);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
@@ -568,7 +570,7 @@ where
     P: Into<PBSParameters>,
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, u64), RadixCiphertext>,
 {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let sks = Arc::new(sks);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
@@ -602,7 +604,7 @@ where
     P: Into<PBSParameters>,
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, u64), RadixCiphertext>,
 {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let sks = Arc::new(sks);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
@@ -635,7 +637,7 @@ where
     P: Into<PBSParameters>,
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, u64), RadixCiphertext>,
 {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let sks = Arc::new(sks);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
@@ -667,7 +669,7 @@ where
     P: Into<PBSParameters>,
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, u64), RadixCiphertext>,
 {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let sks = Arc::new(sks);
     let nb_ct =
         (128f64 / (cks.parameters().message_modulus().0 as f64).log2().ceil()).ceil() as usize;
@@ -722,7 +724,7 @@ where
     P: Into<PBSParameters>,
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, u64), RadixCiphertext>,
 {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let sks = Arc::new(sks);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
@@ -791,7 +793,7 @@ where
     P: Into<PBSParameters>,
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, u64), RadixCiphertext>,
 {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let sks = Arc::new(sks);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
@@ -863,7 +865,7 @@ where
     P: Into<PBSParameters>,
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, u64), RadixCiphertext>,
 {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let sks = Arc::new(sks);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
@@ -927,7 +929,7 @@ where
     P: Into<PBSParameters>,
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, u64), RadixCiphertext>,
 {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let sks = Arc::new(sks);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
@@ -998,7 +1000,7 @@ where
         RadixCiphertext,
     >,
 {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let sks = Arc::new(sks);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
@@ -1042,7 +1044,7 @@ where
         RadixCiphertext,
     >,
 {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let sks = Arc::new(sks);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
@@ -1084,7 +1086,7 @@ where
     >,
 {
     let param: PBSParameters = param.into();
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let sks = Arc::new(sks);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
@@ -1131,7 +1133,7 @@ where
         RadixCiphertext,
     >,
 {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let sks = Arc::new(sks);
     let cks = RadixClientKey::from((cks, NB_CTXT));
     let mut rng = rand::thread_rng();
@@ -1177,7 +1179,7 @@ where
     P: Into<PBSParameters>,
     T: for<'a> FunctionExecutor<&'a mut RadixCiphertext, RadixCiphertext>,
 {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let sks = Arc::new(sks);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
@@ -1216,7 +1218,7 @@ where
         RadixCiphertext,
     >,
 {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let sks = Arc::new(sks);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
@@ -1262,7 +1264,7 @@ where
         RadixCiphertext,
     >,
 {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let sks = Arc::new(sks);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
@@ -1309,7 +1311,7 @@ where
         RadixCiphertext,
     >,
 {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let sks = Arc::new(sks);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
@@ -1356,7 +1358,7 @@ where
         (RadixCiphertext, RadixCiphertext),
     >,
 {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let sks = Arc::new(sks);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
@@ -1398,7 +1400,7 @@ where
         RadixCiphertext,
     >,
 {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let sks = Arc::new(sks);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
@@ -1437,7 +1439,7 @@ where
         RadixCiphertext,
     >,
 {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let sks = Arc::new(sks);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
@@ -1480,7 +1482,7 @@ where
         RadixCiphertext,
     >,
 {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let sks = Arc::new(sks);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
@@ -1552,7 +1554,7 @@ where
     P: Into<PBSParameters>,
     T: for<'a> FunctionExecutor<(&'a mut RadixCiphertext, u64), RadixCiphertext>,
 {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let sks = Arc::new(sks);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
@@ -1592,7 +1594,7 @@ where
     T: for<'a> FunctionExecutor<(&'a mut RadixCiphertext, u64), RadixCiphertext>,
 {
     // generate the server-client key set
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let sks = Arc::new(sks);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
@@ -1631,7 +1633,7 @@ where
     P: Into<PBSParameters>,
     T: for<'a> FunctionExecutor<(&'a mut RadixCiphertext, u64), RadixCiphertext>,
 {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let sks = Arc::new(sks);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
@@ -1660,7 +1662,7 @@ where
     P: Into<PBSParameters>,
     T: for<'a> FunctionExecutor<(&'a mut RadixCiphertext, u64), RadixCiphertext>,
 {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let sks = Arc::new(sks);
     let nb_ct =
         (128f64 / (cks.parameters().message_modulus().0 as f64).log2().ceil()).ceil() as usize;
@@ -1686,7 +1688,7 @@ where
     P: Into<PBSParameters>,
     T: for<'a> FunctionExecutor<(&'a mut RadixCiphertext, u64), RadixCiphertext>,
 {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let sks = Arc::new(sks);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
@@ -1729,7 +1731,7 @@ where
     P: Into<PBSParameters>,
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, &'a RadixCiphertext), RadixCiphertext>,
 {
-    let (cks, mut sks) = KEY_CACHE.get_from_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
     sks.set_deterministic_pbs_execution(true);
@@ -1779,7 +1781,7 @@ where
         (RadixCiphertext, Ciphertext),
     >,
 {
-    let (cks, mut sks) = KEY_CACHE.get_from_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
     sks.set_deterministic_pbs_execution(true);
@@ -1902,7 +1904,7 @@ where
     P: Into<PBSParameters>,
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, &'a RadixCiphertext), RadixCiphertext>,
 {
-    let (cks, mut sks) = KEY_CACHE.get_from_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
     sks.set_deterministic_pbs_execution(true);
@@ -1944,7 +1946,7 @@ where
     P: Into<PBSParameters>,
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, &'a RadixCiphertext), RadixCiphertext>,
 {
-    let (cks, mut sks) = KEY_CACHE.get_from_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
     sks.set_deterministic_pbs_execution(true);
@@ -2008,7 +2010,7 @@ where
     P: Into<PBSParameters>,
     T: for<'a> FunctionExecutor<&'a RadixCiphertext, RadixCiphertext>,
 {
-    let (cks, mut sks) = KEY_CACHE.get_from_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
     sks.set_deterministic_pbs_execution(true);
@@ -2042,7 +2044,7 @@ where
     P: Into<PBSParameters>,
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, &'a RadixCiphertext), RadixCiphertext>,
 {
-    let (cks, mut sks) = KEY_CACHE.get_from_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
     sks.set_deterministic_pbs_execution(true);
@@ -2091,7 +2093,7 @@ where
     P: Into<PBSParameters>,
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, &'a RadixCiphertext), RadixCiphertext>,
 {
-    let (cks, mut sks) = KEY_CACHE.get_from_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
     sks.set_deterministic_pbs_execution(true);
@@ -2140,7 +2142,7 @@ where
     P: Into<PBSParameters>,
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, &'a RadixCiphertext), RadixCiphertext>,
 {
-    let (cks, mut sks) = KEY_CACHE.get_from_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
     sks.set_deterministic_pbs_execution(true);
@@ -2189,7 +2191,7 @@ where
     P: Into<PBSParameters>,
     T: for<'a> FunctionExecutor<&'a RadixCiphertext, RadixCiphertext>,
 {
-    let (cks, mut sks) = KEY_CACHE.get_from_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
     sks.set_deterministic_pbs_execution(true);
@@ -2227,7 +2229,7 @@ where
         (RadixCiphertext, RadixCiphertext),
     >,
 {
-    let (cks, mut sks) = KEY_CACHE.get_from_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
     sks.set_deterministic_pbs_execution(true);
@@ -2273,7 +2275,7 @@ where
     P: Into<PBSParameters>,
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, &'a RadixCiphertext), RadixCiphertext>,
 {
-    let (cks, mut sks) = KEY_CACHE.get_from_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
     sks.set_deterministic_pbs_execution(true);
@@ -2316,7 +2318,7 @@ where
     P: Into<PBSParameters>,
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, &'a RadixCiphertext), RadixCiphertext>,
 {
-    let (cks, mut sks) = KEY_CACHE.get_from_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
     sks.set_deterministic_pbs_execution(true);
@@ -2362,7 +2364,7 @@ where
         RadixCiphertext,
     >,
 {
-    let (cks, mut sks) = KEY_CACHE.get_from_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
     sks.set_deterministic_pbs_execution(true);
@@ -2483,7 +2485,7 @@ where
     P: Into<PBSParameters>,
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, u64), RadixCiphertext>,
 {
-    let (cks, mut sks) = KEY_CACHE.get_from_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
     sks.set_deterministic_pbs_execution(true);
@@ -2529,7 +2531,7 @@ where
     P: Into<PBSParameters>,
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, u64), RadixCiphertext>,
 {
-    let (cks, mut sks) = KEY_CACHE.get_from_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
     sks.set_deterministic_pbs_execution(true);
@@ -2574,7 +2576,7 @@ where
     P: Into<PBSParameters>,
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, u64), RadixCiphertext>,
 {
-    let (cks, mut sks) = KEY_CACHE.get_from_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
     sks.set_deterministic_pbs_execution(true);
@@ -2619,7 +2621,7 @@ where
     P: Into<PBSParameters>,
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, u64), RadixCiphertext>,
 {
-    let (cks, mut sks) = KEY_CACHE.get_from_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
     sks.set_deterministic_pbs_execution(true);
@@ -2656,7 +2658,7 @@ where
         RadixCiphertext,
     >,
 {
-    let (cks, mut sks) = KEY_CACHE.get_from_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
     sks.set_deterministic_pbs_execution(true);
@@ -2706,7 +2708,7 @@ where
     P: Into<PBSParameters>,
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, u64), RadixCiphertext>,
 {
-    let (cks, mut sks) = KEY_CACHE.get_from_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let nb_ct =
         (128f64 / (cks.parameters().message_modulus().0 as f64).log2().ceil()).ceil() as usize;
     let cks = RadixClientKey::from((cks, nb_ct));
@@ -2734,7 +2736,7 @@ where
     P: Into<PBSParameters>,
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, u64), RadixCiphertext>,
 {
-    let (cks, mut sks) = KEY_CACHE.get_from_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
     sks.set_deterministic_pbs_execution(true);
@@ -2787,7 +2789,7 @@ where
     P: Into<PBSParameters>,
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, u64), RadixCiphertext>,
 {
-    let (cks, mut sks) = KEY_CACHE.get_from_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
     sks.set_deterministic_pbs_execution(true);
@@ -2838,7 +2840,7 @@ where
     P: Into<PBSParameters>,
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, u64), RadixCiphertext>,
 {
-    let (cks, mut sks) = KEY_CACHE.get_from_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
     sks.set_deterministic_pbs_execution(true);
@@ -2889,7 +2891,7 @@ where
     P: Into<PBSParameters>,
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, u64), RadixCiphertext>,
 {
-    let (cks, mut sks) = KEY_CACHE.get_from_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
     sks.set_deterministic_pbs_execution(true);
@@ -2947,7 +2949,7 @@ where
     P: Into<PBSParameters>,
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, u64), RadixCiphertext>,
 {
-    let (cks, mut sks) = KEY_CACHE.get_from_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
     sks.set_deterministic_pbs_execution(true);
@@ -3009,7 +3011,7 @@ where
     P: Into<PBSParameters>,
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, u64), RadixCiphertext>,
 {
-    let (cks, mut sks) = KEY_CACHE.get_from_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
     sks.set_deterministic_pbs_execution(true);
@@ -3081,7 +3083,7 @@ where
     P: Into<PBSParameters>,
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, u64), RadixCiphertext>,
 {
-    let (cks, mut sks) = KEY_CACHE.get_from_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
     sks.set_deterministic_pbs_execution(true);
@@ -3154,7 +3156,7 @@ where
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, u64), (RadixCiphertext, RadixCiphertext)>
         + std::panic::UnwindSafe,
 {
-    let (cks, mut sks) = KEY_CACHE.get_from_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     let num_block =
         (32f64 / (cks.parameters().message_modulus().0 as f64).log(2.0)).ceil() as usize;
@@ -3241,7 +3243,7 @@ where
     P: Into<PBSParameters>,
     T: for<'a> FunctionExecutor<&'a mut RadixCiphertext, ()>,
 {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let sks = Arc::new(sks);
 
     let cks = RadixClientKey::from((cks, NB_CTXT));

--- a/tfhe/src/integer/server_key/radix_parallel/tests_signed.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_signed.rs
@@ -1,5 +1,5 @@
 use crate::integer::keycache::KEY_CACHE;
-use crate::integer::{RadixClientKey, ServerKey, SignedRadixCiphertext};
+use crate::integer::{IntegerKeyKind, RadixClientKey, ServerKey, SignedRadixCiphertext};
 use crate::shortint::parameters::*;
 use itertools::{iproduct, izip};
 use paste::paste;
@@ -318,7 +318,7 @@ create_parametrized_test!(integer_signed_encrypt_decrypt);
 create_parametrized_test!(integer_signed_encrypt_decrypt_128_bits);
 
 fn integer_signed_encrypt_decrypt_128_bits(param: impl Into<PBSParameters>) {
-    let (cks, _) = KEY_CACHE.get_from_params(param);
+    let (cks, _) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     let mut rng = rand::thread_rng();
     let num_block =
@@ -335,7 +335,7 @@ fn integer_signed_encrypt_decrypt_128_bits(param: impl Into<PBSParameters>) {
 }
 
 fn integer_signed_encrypt_decrypt(param: impl Into<PBSParameters>) {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     let mut rng = rand::thread_rng();
 
@@ -460,7 +460,7 @@ create_parametrized_test!(integer_signed_unchecked_div_rem_floor {
 create_parametrized_test!(integer_signed_unchecked_absolute_value);
 
 fn integer_signed_unchecked_add(param: impl Into<PBSParameters>) {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     let mut rng = rand::thread_rng();
 
@@ -498,7 +498,7 @@ fn integer_signed_unchecked_add(param: impl Into<PBSParameters>) {
 // but test the non parallel version here anyway
 // as it is used in other parallel ops (e.g: sub)
 fn integer_signed_unchecked_neg(param: impl Into<PBSParameters>) {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     let mut rng = rand::thread_rng();
 
@@ -531,7 +531,7 @@ fn integer_signed_unchecked_neg(param: impl Into<PBSParameters>) {
 }
 
 fn integer_signed_unchecked_sub(param: impl Into<PBSParameters>) {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     let mut rng = rand::thread_rng();
 
@@ -574,7 +574,7 @@ where
         &'a SignedRadixCiphertext,
     ) -> (SignedRadixCiphertext, crate::shortint::Ciphertext),
 {
-    let (cks, mut sks) = KEY_CACHE.get_from_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
     sks.set_deterministic_pbs_execution(true);
@@ -667,7 +667,7 @@ where
 }
 
 fn integer_signed_unchecked_mul(param: impl Into<PBSParameters>) {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     let mut rng = rand::thread_rng();
 
@@ -685,7 +685,7 @@ fn integer_signed_unchecked_mul(param: impl Into<PBSParameters>) {
 }
 
 fn integer_signed_unchecked_bitand(param: impl Into<PBSParameters>) {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     let mut rng = rand::thread_rng();
 
@@ -703,7 +703,7 @@ fn integer_signed_unchecked_bitand(param: impl Into<PBSParameters>) {
 }
 
 fn integer_signed_unchecked_bitor(param: impl Into<PBSParameters>) {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     let mut rng = rand::thread_rng();
 
@@ -721,7 +721,7 @@ fn integer_signed_unchecked_bitor(param: impl Into<PBSParameters>) {
 }
 
 fn integer_signed_unchecked_bitxor(param: impl Into<PBSParameters>) {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     let mut rng = rand::thread_rng();
 
@@ -739,7 +739,7 @@ fn integer_signed_unchecked_bitxor(param: impl Into<PBSParameters>) {
 }
 
 fn integer_signed_unchecked_absolute_value(param: impl Into<PBSParameters>) {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     let mut rng = rand::thread_rng();
 
@@ -781,7 +781,7 @@ fn integer_signed_unchecked_left_shift<P>(param: P)
 where
     P: Into<PBSParameters>,
 {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
     let mut rng = rand::thread_rng();
@@ -832,7 +832,7 @@ fn integer_signed_unchecked_right_shift<P>(param: P)
 where
     P: Into<PBSParameters>,
 {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
     let mut rng = rand::thread_rng();
@@ -884,7 +884,7 @@ fn integer_signed_unchecked_rotate_left<P>(param: P)
 where
     P: Into<PBSParameters>,
 {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
     let mut rng = rand::thread_rng();
@@ -935,7 +935,7 @@ fn integer_signed_unchecked_rotate_right<P>(param: P)
 where
     P: Into<PBSParameters>,
 {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
     let mut rng = rand::thread_rng();
@@ -982,7 +982,7 @@ where
 }
 
 fn integer_signed_unchecked_div_rem(param: impl Into<PBSParameters>) {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     let mut rng = rand::thread_rng();
 
@@ -1035,7 +1035,7 @@ fn integer_signed_unchecked_div_rem(param: impl Into<PBSParameters>) {
 }
 
 fn integer_signed_unchecked_div_rem_floor(param: impl Into<PBSParameters>) {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     let mut rng = rand::thread_rng();
 
@@ -1125,7 +1125,7 @@ create_parametrized_test!(integer_signed_smart_neg);
 create_parametrized_test!(integer_signed_smart_absolute_value);
 
 fn integer_signed_smart_add(param: impl Into<PBSParameters>) {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     let mut rng = rand::thread_rng();
 
@@ -1162,7 +1162,7 @@ fn integer_signed_smart_neg<P>(param: P)
 where
     P: Into<PBSParameters>,
 {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
     let mut rng = rand::thread_rng();
@@ -1191,7 +1191,7 @@ where
 }
 
 fn integer_signed_smart_absolute_value(param: impl Into<PBSParameters>) {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     let mut rng = rand::thread_rng();
 
@@ -1283,7 +1283,7 @@ fn integer_signed_default_add<P>(param: P)
 where
     P: Into<PBSParameters>,
 {
-    let (cks, mut sks) = KEY_CACHE.get_from_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
     sks.set_deterministic_pbs_execution(true);
@@ -1328,7 +1328,7 @@ fn integer_signed_default_neg<P>(param: P)
 where
     P: Into<PBSParameters>,
 {
-    let (cks, mut sks) = KEY_CACHE.get_from_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
     sks.set_deterministic_pbs_execution(true);
@@ -1376,7 +1376,7 @@ fn integer_signed_default_sub<P>(param: P)
 where
     P: Into<PBSParameters>,
 {
-    let (cks, mut sks) = KEY_CACHE.get_from_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
     sks.set_deterministic_pbs_execution(true);
@@ -1420,7 +1420,7 @@ fn integer_signed_default_overflowing_sub<P>(param: P)
 where
     P: Into<PBSParameters>,
 {
-    let (cks, mut sks) = KEY_CACHE.get_from_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
     sks.set_deterministic_pbs_execution(true);
@@ -1537,7 +1537,7 @@ fn integer_signed_default_mul<P>(param: P)
 where
     P: Into<PBSParameters>,
 {
-    let (cks, mut sks) = KEY_CACHE.get_from_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
     sks.set_deterministic_pbs_execution(true);
@@ -1578,7 +1578,7 @@ where
 }
 
 fn integer_signed_default_bitnot(param: impl Into<PBSParameters>) {
-    let (cks, mut sks) = KEY_CACHE.get_from_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     sks.set_deterministic_pbs_execution(true);
 
     let mut rng = rand::thread_rng();
@@ -1601,7 +1601,7 @@ fn integer_signed_default_bitnot(param: impl Into<PBSParameters>) {
 }
 
 fn integer_signed_default_bitand(param: impl Into<PBSParameters>) {
-    let (cks, mut sks) = KEY_CACHE.get_from_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     sks.set_deterministic_pbs_execution(true);
 
     let mut rng = rand::thread_rng();
@@ -1645,7 +1645,7 @@ fn integer_signed_default_bitand(param: impl Into<PBSParameters>) {
 }
 
 fn integer_signed_default_bitor(param: impl Into<PBSParameters>) {
-    let (cks, mut sks) = KEY_CACHE.get_from_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     sks.set_deterministic_pbs_execution(true);
 
     let mut rng = rand::thread_rng();
@@ -1689,7 +1689,7 @@ fn integer_signed_default_bitor(param: impl Into<PBSParameters>) {
 }
 
 fn integer_signed_default_bitxor(param: impl Into<PBSParameters>) {
-    let (cks, mut sks) = KEY_CACHE.get_from_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     sks.set_deterministic_pbs_execution(true);
 
     let mut rng = rand::thread_rng();
@@ -1733,7 +1733,7 @@ fn integer_signed_default_bitxor(param: impl Into<PBSParameters>) {
 }
 
 fn integer_signed_default_absolute_value(param: impl Into<PBSParameters>) {
-    let (cks, mut sks) = KEY_CACHE.get_from_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     sks.set_deterministic_pbs_execution(true);
 
     let mut rng = rand::thread_rng();
@@ -1770,7 +1770,7 @@ fn integer_signed_default_left_shift<P>(param: P)
 where
     P: Into<PBSParameters>,
 {
-    let (cks, mut sks) = KEY_CACHE.get_from_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
     sks.set_deterministic_pbs_execution(true);
@@ -1853,7 +1853,7 @@ fn integer_signed_default_right_shift<P>(param: P)
 where
     P: Into<PBSParameters>,
 {
-    let (cks, mut sks) = KEY_CACHE.get_from_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
     sks.set_deterministic_pbs_execution(true);
@@ -1936,7 +1936,7 @@ fn integer_signed_default_rotate_left<P>(param: P)
 where
     P: Into<PBSParameters>,
 {
-    let (cks, mut sks) = KEY_CACHE.get_from_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
     sks.set_deterministic_pbs_execution(true);
@@ -2022,7 +2022,7 @@ fn integer_signed_default_rotate_right<P>(param: P)
 where
     P: Into<PBSParameters>,
 {
-    let (cks, mut sks) = KEY_CACHE.get_from_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
     sks.set_deterministic_pbs_execution(true);
@@ -2120,7 +2120,7 @@ create_parametrized_test!(integer_signed_unchecked_scalar_div_rem);
 create_parametrized_test!(integer_signed_unchecked_scalar_div_rem_floor);
 
 fn integer_signed_unchecked_scalar_add(param: impl Into<PBSParameters>) {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     let mut rng = rand::thread_rng();
 
@@ -2156,7 +2156,7 @@ fn integer_signed_unchecked_scalar_add(param: impl Into<PBSParameters>) {
 }
 
 fn integer_signed_unchecked_scalar_sub(param: impl Into<PBSParameters>) {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     let mut rng = rand::thread_rng();
 
@@ -2192,7 +2192,7 @@ fn integer_signed_unchecked_scalar_sub(param: impl Into<PBSParameters>) {
 }
 
 fn integer_signed_unchecked_scalar_mul(param: impl Into<PBSParameters>) {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     let mut rng = rand::thread_rng();
 
@@ -2212,7 +2212,7 @@ fn integer_signed_unchecked_scalar_mul(param: impl Into<PBSParameters>) {
 }
 
 fn integer_signed_unchecked_scalar_bitand(param: impl Into<PBSParameters>) {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     let mut rng = rand::thread_rng();
 
@@ -2232,7 +2232,7 @@ fn integer_signed_unchecked_scalar_bitand(param: impl Into<PBSParameters>) {
 }
 
 fn integer_signed_unchecked_scalar_bitor(param: impl Into<PBSParameters>) {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     let mut rng = rand::thread_rng();
 
@@ -2252,7 +2252,7 @@ fn integer_signed_unchecked_scalar_bitor(param: impl Into<PBSParameters>) {
 }
 
 fn integer_signed_unchecked_scalar_bitxor(param: impl Into<PBSParameters>) {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     let mut rng = rand::thread_rng();
 
@@ -2272,7 +2272,7 @@ fn integer_signed_unchecked_scalar_bitxor(param: impl Into<PBSParameters>) {
 }
 
 fn integer_signed_unchecked_scalar_rotate_left(param: impl Into<PBSParameters>) {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     let mut rng = rand::thread_rng();
 
@@ -2308,7 +2308,7 @@ fn integer_signed_unchecked_scalar_rotate_left(param: impl Into<PBSParameters>) 
 }
 
 fn integer_signed_unchecked_scalar_rotate_right(param: impl Into<PBSParameters>) {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     let mut rng = rand::thread_rng();
 
@@ -2344,7 +2344,7 @@ fn integer_signed_unchecked_scalar_rotate_right(param: impl Into<PBSParameters>)
 }
 
 fn integer_signed_unchecked_scalar_left_shift(param: impl Into<PBSParameters>) {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     let mut rng = rand::thread_rng();
 
@@ -2380,7 +2380,7 @@ fn integer_signed_unchecked_scalar_left_shift(param: impl Into<PBSParameters>) {
 }
 
 fn integer_signed_unchecked_scalar_right_shift(param: impl Into<PBSParameters>) {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     let mut rng = rand::thread_rng();
 
@@ -2416,7 +2416,7 @@ fn integer_signed_unchecked_scalar_right_shift(param: impl Into<PBSParameters>) 
 }
 
 fn integer_signed_unchecked_scalar_div_rem(param: impl Into<PBSParameters>) {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     let mut rng = rand::thread_rng();
 
@@ -2561,7 +2561,7 @@ fn integer_signed_unchecked_scalar_div_rem(param: impl Into<PBSParameters>) {
 }
 
 fn integer_signed_unchecked_scalar_div_rem_floor(param: impl Into<PBSParameters>) {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
 
     let mut rng = rand::thread_rng();
 
@@ -2685,7 +2685,7 @@ fn integer_signed_default_scalar_add<P>(param: P)
 where
     P: Into<PBSParameters>,
 {
-    let (cks, mut sks) = KEY_CACHE.get_from_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
     sks.set_deterministic_pbs_execution(true);
@@ -2723,7 +2723,7 @@ where
 }
 
 fn integer_signed_default_scalar_bitand(param: impl Into<PBSParameters>) {
-    let (cks, mut sks) = KEY_CACHE.get_from_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     sks.set_deterministic_pbs_execution(true);
 
     let mut rng = rand::thread_rng();
@@ -2759,7 +2759,7 @@ fn integer_signed_default_scalar_bitand(param: impl Into<PBSParameters>) {
 }
 
 fn integer_signed_default_scalar_bitor(param: impl Into<PBSParameters>) {
-    let (cks, mut sks) = KEY_CACHE.get_from_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     sks.set_deterministic_pbs_execution(true);
 
     let mut rng = rand::thread_rng();
@@ -2795,7 +2795,7 @@ fn integer_signed_default_scalar_bitor(param: impl Into<PBSParameters>) {
 }
 
 fn integer_signed_default_scalar_bitxor(param: impl Into<PBSParameters>) {
-    let (cks, mut sks) = KEY_CACHE.get_from_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     sks.set_deterministic_pbs_execution(true);
 
     let mut rng = rand::thread_rng();
@@ -2831,7 +2831,7 @@ fn integer_signed_default_scalar_bitxor(param: impl Into<PBSParameters>) {
 }
 
 fn integer_signed_default_scalar_div_rem(param: impl Into<PBSParameters>) {
-    let (cks, mut sks) = KEY_CACHE.get_from_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     sks.set_deterministic_pbs_execution(true);
 
     let mut rng = rand::thread_rng();
@@ -2886,7 +2886,7 @@ fn integer_signed_default_scalar_left_shift<P>(param: P)
 where
     P: Into<PBSParameters>,
 {
-    let (cks, mut sks) = KEY_CACHE.get_from_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
     sks.set_deterministic_pbs_execution(true);
@@ -2948,7 +2948,7 @@ fn integer_signed_default_scalar_right_shift<P>(param: P)
 where
     P: Into<PBSParameters>,
 {
-    let (cks, mut sks) = KEY_CACHE.get_from_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
     sks.set_deterministic_pbs_execution(true);
@@ -3010,7 +3010,7 @@ fn integer_signed_default_scalar_rotate_left<P>(param: P)
 where
     P: Into<PBSParameters>,
 {
-    let (cks, mut sks) = KEY_CACHE.get_from_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
     sks.set_deterministic_pbs_execution(true);
@@ -3074,7 +3074,7 @@ fn integer_signed_default_scalar_rotate_right<P>(param: P)
 where
     P: Into<PBSParameters>,
 {
-    let (cks, mut sks) = KEY_CACHE.get_from_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
     sks.set_deterministic_pbs_execution(true);

--- a/tfhe/src/integer/server_key/radix_parallel/tests_unsigned.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_unsigned.rs
@@ -1,5 +1,5 @@
 use crate::integer::keycache::KEY_CACHE;
-use crate::integer::{RadixCiphertext, RadixClientKey, ServerKey};
+use crate::integer::{IntegerKeyKind, RadixCiphertext, RadixClientKey, ServerKey};
 use crate::shortint::parameters::*;
 use paste::paste;
 use rand::Rng;
@@ -573,7 +573,7 @@ fn integer_smart_add_sequence_multi_thread<P>(param: P)
 where
     P: Into<PBSParameters>,
 {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
     //RNG
@@ -612,7 +612,7 @@ fn integer_smart_add_sequence_single_thread<P>(param: P)
 where
     P: Into<PBSParameters>,
 {
-    let (cks, sks) = KEY_CACHE.get_from_params(param);
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
     //RNG
@@ -834,7 +834,7 @@ fn integer_default_add_sequence_multi_thread<P>(param: P)
 where
     P: Into<PBSParameters>,
 {
-    let (cks, mut sks) = KEY_CACHE.get_from_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
     sks.set_deterministic_pbs_execution(true);
@@ -878,7 +878,7 @@ fn integer_default_add_sequence_single_thread<P>(param: P)
 where
     P: Into<PBSParameters>,
 {
-    let (cks, mut sks) = KEY_CACHE.get_from_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
     sks.set_deterministic_pbs_execution(true);
@@ -1039,7 +1039,8 @@ where
 #[test]
 fn test_non_regression_clone_from() {
     // Issue: https://github.com/zama-ai/tfhe-rs/issues/410
-    let (client_key, server_key) = KEY_CACHE.get_from_params(PARAM_MESSAGE_2_CARRY_2);
+    let (client_key, server_key) =
+        KEY_CACHE.get_from_params(PARAM_MESSAGE_2_CARRY_2, IntegerKeyKind::Radix);
     const NUM_BLOCK: usize = 4;
     let a: u8 = 248;
     let b: u8 = 249;

--- a/tfhe/src/integer/wopbs/test.rs
+++ b/tfhe/src/integer/wopbs/test.rs
@@ -1,8 +1,8 @@
 #![allow(unused)]
 
-use crate::integer::gen_keys;
 use crate::integer::parameters::*;
 use crate::integer::wopbs::{encode_radix, WopbsKey};
+use crate::integer::{gen_keys, IntegerKeyKind};
 use crate::shortint::parameters::parameters_wopbs::*;
 use crate::shortint::parameters::parameters_wopbs_message_carry::*;
 use crate::shortint::parameters::{ClassicPBSParameters, *};
@@ -58,7 +58,7 @@ pub fn wopbs_native_crt() {
 
     let params = crate::shortint::parameters::parameters_wopbs::PARAM_4_BITS_5_BLOCKS;
 
-    let (cks, sks) = gen_keys(params);
+    let (cks, sks) = gen_keys(params, IntegerKeyKind::Radix);
     let wopbs_key = WopbsKey::new_wopbs_key_only_for_wopbs(&cks, &sks);
 
     let mut msg_space = 1;
@@ -108,7 +108,7 @@ pub fn wopbs_native_crt_bivariate() {
 
     let params = (pbs_params, wopbs_params);
 
-    let (cks, sks) = gen_keys(params.0);
+    let (cks, sks) = gen_keys(params.0, IntegerKeyKind::Radix);
     let wopbs_key = KEY_CACHE_WOPBS.get_from_params(params);
 
     let mut msg_space = 1;
@@ -143,7 +143,7 @@ pub fn wopbs_crt(params: (ClassicPBSParameters, WopbsParameters)) {
 
     let nb_block = basis.len();
 
-    let (cks, sks) = gen_keys(params.0);
+    let (cks, sks) = gen_keys(params.0, IntegerKeyKind::Radix);
     let wopbs_key = KEY_CACHE_WOPBS.get_from_params(params);
 
     let mut msg_space = 1;
@@ -186,7 +186,7 @@ pub fn wopbs_radix(params: (ClassicPBSParameters, WopbsParameters)) {
 
     let nb_block = 2;
 
-    let (cks, sks) = gen_keys(params.0);
+    let (cks, sks) = gen_keys(params.0, IntegerKeyKind::Radix);
     let wopbs_key = KEY_CACHE_WOPBS.get_from_params(params);
 
     let mut msg_space: u64 = params.0.message_modulus.0 as u64;
@@ -223,7 +223,7 @@ pub fn wopbs_bivariate_radix(params: (ClassicPBSParameters, WopbsParameters)) {
 
     let nb_block = 2;
 
-    let (cks, sks) = gen_keys(params.0);
+    let (cks, sks) = gen_keys(params.0, IntegerKeyKind::Radix);
     let wopbs_key = KEY_CACHE_WOPBS.get_from_params(params);
 
     let mut msg_space: u64 = params.0.message_modulus.0 as u64;
@@ -266,7 +266,7 @@ pub fn wopbs_bivariate_crt(params: (ClassicPBSParameters, WopbsParameters)) {
     let basis = make_basis(params.1.message_modulus.0);
     let modulus = basis.iter().product::<u64>();
 
-    let (cks, sks) = gen_keys(params.0);
+    let (cks, sks) = gen_keys(params.0, IntegerKeyKind::Radix);
     let wopbs_key = KEY_CACHE_WOPBS.get_from_params(params);
 
     let mut msg_space: u64 = 1;

--- a/tfhe/src/shortint/mod.rs
+++ b/tfhe/src/shortint/mod.rs
@@ -27,7 +27,8 @@
 //! homomorphically.
 //!
 //! ```rust
-//! use tfhe::shortint::{gen_keys, Parameters};
+//! use tfhe::shortint::gen_keys;
+//! use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
 //!
 //! // We generate a set of client/server keys, using the default parameters:
 //! let (mut client_key, mut server_key) = gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS);


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: https://github.com/zama-ai/tfhe-rs-internal/issues/256

### PR content/description

- fix max degree for CRT keys which don't need to propagate carries

also prevent users to have access to gen_keys which was wrong for the CRT max degree, the old Integer ClientKey is still accessible through as_ref calls, but some convenience functions have been added on the key itself

Some API breaks because of the change

### Check-list:

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [x] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
