### PR TITLE
Fhebool boolean block

### DIFF
--- a/apps/trivium/src/trans_ciphering/mod.rs
+++ b/apps/trivium/src/trans_ciphering/mod.rs
@@ -4,6 +4,7 @@
 use crate::{KreyviumStreamByte, KreyviumStreamShortint, TriviumStreamByte, TriviumStreamShortint};
 use tfhe::shortint::Ciphertext;
 
+use tfhe::prelude::*;
 use tfhe::{set_server_key, unset_server_key, FheUint64, FheUint8, ServerKey};
 
 use rayon::prelude::*;

--- a/tfhe/docs/getting_started/operations.md
+++ b/tfhe/docs/getting_started/operations.md
@@ -204,17 +204,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let lower_or_equal = a.le(&b);
     let equal = a.eq(&b);
 
-    let dec_gt: i8 = greater.decrypt(&keys);
-    let dec_ge: i8 = greater_or_equal.decrypt(&keys);
-    let dec_lt: i8 = lower.decrypt(&keys);
-    let dec_le: i8 = lower_or_equal.decrypt(&keys);
-    let dec_eq: i8 = equal.decrypt(&keys);
+    let dec_gt = greater.decrypt(&keys);
+    let dec_ge = greater_or_equal.decrypt(&keys);
+    let dec_lt = lower.decrypt(&keys);
+    let dec_le = lower_or_equal.decrypt(&keys);
+    let dec_eq = equal.decrypt(&keys);
 
-    assert_eq!(dec_gt, (clear_a > clear_b ) as i8);
-    assert_eq!(dec_ge, (clear_a >= clear_b) as i8);
-    assert_eq!(dec_lt, (clear_a < clear_b ) as i8);
-    assert_eq!(dec_le, (clear_a <= clear_b) as i8);
-    assert_eq!(dec_eq, (clear_a == clear_b) as i8);
+    assert_eq!(dec_gt, clear_a > clear_b);
+    assert_eq!(dec_ge, clear_a >= clear_b);
+    assert_eq!(dec_lt, clear_a < clear_b);
+    assert_eq!(dec_le, clear_a <= clear_b);
+    assert_eq!(dec_eq, clear_a == clear_b);
 
     Ok(())
 }
@@ -292,11 +292,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 	
 	// Clear equivalent computations: 32 > -45
 	let encrypted_comp = &encrypted_a.gt(&encrypted_b);
-	let clear_res: i32 = encrypted_comp.decrypt(&client_key);
-	assert_eq!(clear_res, (clear_a > clear_b) as i32);
+	let clear_res = encrypted_comp.decrypt(&client_key);
+	assert_eq!(clear_res, clear_a > clear_b);
 	
-	// `encrypted_comp` contains the result of the comparison, i.e.,
-	// a boolean value. This acts as a condition on which the
+	// `encrypted_comp` is a FheBool, thus it encrypts a boolean value.
+    // This acts as a condition on which the
 	// `if_then_else` function can be applied on.
 	// Clear equivalent computations:
 	// if 32 > -45 {result = 32} else {result = -45}

--- a/tfhe/docs/tutorials/ascii_fhe_string.md
+++ b/tfhe/docs/tutorials/ascii_fhe_string.md
@@ -69,7 +69,7 @@ use tfhe::FheUint8;
 pub const UP_LOW_DISTANCE: u8 = 32;
 
 fn to_lower(c: &FheUint8) -> FheUint8 {
-    c + (c.gt(64) & c.lt(91)) * UP_LOW_DISTANCE
+    c + FheUint8::cast_from(c.gt(64) & c.lt(91)) * UP_LOW_DISTANCE
 }
 ```
 
@@ -86,11 +86,11 @@ struct FheAsciiString {
 }
 
 fn to_upper(c: &FheUint8) -> FheUint8 {
-    c - (c.gt(96) & c.lt(123)) * UP_LOW_DISTANCE
+    c - FheUint8::cast_from(c.gt(96) & c.lt(123)) * UP_LOW_DISTANCE
 }
 
 fn to_lower(c: &FheUint8) -> FheUint8 {
-    c + (c.gt(64) & c.lt(91)) * UP_LOW_DISTANCE
+    c + FheUint8::cast_from(c.gt(64) & c.lt(91)) * UP_LOW_DISTANCE
 }
 
 impl FheAsciiString {

--- a/tfhe/src/c_api/high_level_api/booleans.rs
+++ b/tfhe/src/c_api/high_level_api/booleans.rs
@@ -2,7 +2,7 @@ use crate::high_level_api::prelude::*;
 
 use std::ops::{BitAnd, BitOr, BitXor, Not};
 
-pub struct FheBool(crate::high_level_api::FheBool);
+pub struct FheBool(pub(in crate::c_api) crate::high_level_api::FheBool);
 
 impl_destroy_on_type!(FheBool);
 impl_clone_on_type!(FheBool);

--- a/tfhe/src/high_level_api/integers/mod.rs
+++ b/tfhe/src/high_level_api/integers/mod.rs
@@ -10,6 +10,9 @@ pub(in crate::high_level_api) use keys::{
     IntegerCompressedServerKey, IntegerConfig, IntegerServerKey,
 };
 
+pub(in crate::high_level_api) use parameters::IntegerId;
+pub(in crate::high_level_api) use types::GenericInteger;
+
 mod client_key;
 mod keys;
 mod parameters;

--- a/tfhe/src/high_level_api/integers/tests_signed.rs
+++ b/tfhe/src/high_level_api/integers/tests_signed.rs
@@ -52,86 +52,86 @@ fn test_int32_compare() {
     // Test comparing encrypted with encrypted
     {
         let result = &a.eq(&b);
-        let decrypted_result: i32 = result.decrypt(&client_key);
-        let clear_result = i32::from(clear_a == clear_b);
+        let decrypted_result = result.decrypt(&client_key);
+        let clear_result = clear_a == clear_b;
         assert_eq!(decrypted_result, clear_result);
 
         let result = &a.eq(&a);
-        let decrypted_result: i32 = result.decrypt(&client_key);
-        let clear_result = i32::from(clear_a == clear_a);
+        let decrypted_result = result.decrypt(&client_key);
+        let clear_result = clear_a == clear_a;
         assert_eq!(decrypted_result, clear_result);
 
         let result = &a.ne(&b);
-        let decrypted_result: i32 = result.decrypt(&client_key);
-        let clear_result = i32::from(clear_a != clear_b);
+        let decrypted_result = result.decrypt(&client_key);
+        let clear_result = clear_a != clear_b;
         assert_eq!(decrypted_result, clear_result);
 
         let result = &a.ne(&a);
-        let decrypted_result: i32 = result.decrypt(&client_key);
-        let clear_result = i32::from(clear_a != clear_a);
+        let decrypted_result = result.decrypt(&client_key);
+        let clear_result = clear_a != clear_a;
         assert_eq!(decrypted_result, clear_result);
 
         let result = &a.le(&b);
-        let decrypted_result: i32 = result.decrypt(&client_key);
-        let clear_result = i32::from(clear_a <= clear_b);
+        let decrypted_result = result.decrypt(&client_key);
+        let clear_result = clear_a <= clear_b;
         assert_eq!(decrypted_result, clear_result);
 
         let result = &a.lt(&b);
-        let decrypted_result: i32 = result.decrypt(&client_key);
-        let clear_result = i32::from(clear_a < clear_b);
+        let decrypted_result = result.decrypt(&client_key);
+        let clear_result = clear_a < clear_b;
         assert_eq!(decrypted_result, clear_result);
 
         let result = &a.ge(&b);
-        let decrypted_result: i32 = result.decrypt(&client_key);
-        let clear_result = i32::from(clear_a >= clear_b);
+        let decrypted_result = result.decrypt(&client_key);
+        let clear_result = clear_a >= clear_b;
         assert_eq!(decrypted_result, clear_result);
 
         let result = &a.gt(&b);
-        let decrypted_result: i32 = result.decrypt(&client_key);
-        let clear_result = i32::from(clear_a > clear_b);
+        let decrypted_result = result.decrypt(&client_key);
+        let clear_result = clear_a > clear_b;
         assert_eq!(decrypted_result, clear_result);
     }
 
     // Test comparing encrypted with clear
     {
         let result = &a.eq(clear_b);
-        let decrypted_result: i32 = result.decrypt(&client_key);
-        let clear_result = i32::from(clear_a == clear_b);
+        let decrypted_result = result.decrypt(&client_key);
+        let clear_result = clear_a == clear_b;
         assert_eq!(decrypted_result, clear_result);
 
         let result = &a.eq(clear_a);
-        let decrypted_result: i32 = result.decrypt(&client_key);
-        let clear_result = i32::from(clear_a == clear_a);
+        let decrypted_result = result.decrypt(&client_key);
+        let clear_result = clear_a == clear_a;
         assert_eq!(decrypted_result, clear_result);
 
         let result = &a.ne(clear_b);
-        let decrypted_result: i32 = result.decrypt(&client_key);
-        let clear_result = i32::from(clear_a != clear_b);
+        let decrypted_result = result.decrypt(&client_key);
+        let clear_result = clear_a != clear_b;
         assert_eq!(decrypted_result, clear_result);
 
         let result = &a.ne(clear_a);
-        let decrypted_result: i32 = result.decrypt(&client_key);
-        let clear_result = i32::from(clear_a != clear_a);
+        let decrypted_result = result.decrypt(&client_key);
+        let clear_result = clear_a != clear_a;
         assert_eq!(decrypted_result, clear_result);
 
         let result = &a.le(clear_b);
-        let decrypted_result: i32 = result.decrypt(&client_key);
-        let clear_result = i32::from(clear_a <= clear_b);
+        let decrypted_result = result.decrypt(&client_key);
+        let clear_result = clear_a <= clear_b;
         assert_eq!(decrypted_result, clear_result);
 
         let result = &a.lt(clear_b);
-        let decrypted_result: i32 = result.decrypt(&client_key);
-        let clear_result = i32::from(clear_a < clear_b);
+        let decrypted_result = result.decrypt(&client_key);
+        let clear_result = clear_a < clear_b;
         assert_eq!(decrypted_result, clear_result);
 
         let result = &a.ge(clear_b);
-        let decrypted_result: i32 = result.decrypt(&client_key);
-        let clear_result = i32::from(clear_a >= clear_b);
+        let decrypted_result = result.decrypt(&client_key);
+        let clear_result = clear_a >= clear_b;
         assert_eq!(decrypted_result, clear_result);
 
         let result = &a.gt(clear_b);
-        let decrypted_result: i32 = result.decrypt(&client_key);
-        let clear_result = i32::from(clear_a > clear_b);
+        let decrypted_result = result.decrypt(&client_key);
+        let clear_result = clear_a > clear_b;
         assert_eq!(decrypted_result, clear_result);
     }
 }

--- a/tfhe/src/high_level_api/integers/tests_unsigned.rs
+++ b/tfhe/src/high_level_api/integers/tests_unsigned.rs
@@ -5,8 +5,8 @@ use crate::high_level_api::{generate_keys, set_server_key, ConfigBuilder, FheUin
 use crate::integer::U256;
 use crate::{
     CompactFheUint32, CompactFheUint32List, CompactPublicKey, CompressedFheUint16,
-    CompressedFheUint256, CompressedPublicKey, Config, FheInt32, FheInt8, FheUint128, FheUint16,
-    FheUint256, FheUint32, FheUint64,
+    CompressedFheUint256, CompressedPublicKey, Config, FheInt16, FheInt32, FheInt8, FheUint128,
+    FheUint16, FheUint256, FheUint32, FheUint64,
 };
 
 #[test]
@@ -766,6 +766,16 @@ fn test_integer_casting() {
         let a: FheUint32 = a.cast_into();
         let da: u32 = a.decrypt(&client_key);
         assert_eq!(da, (clear as i8) as u32);
+    }
+
+    {
+        let clear = rng.gen_range(i16::MIN..0);
+        let a = FheInt16::encrypt(clear, &client_key);
+
+        // Upcasting
+        let a: FheUint32 = a.cast_into();
+        let da: u32 = a.decrypt(&client_key);
+        assert_eq!(da, clear as u32);
     }
 
     // Upcasting to bigger signed integer then downcasting back to unsigned

--- a/tfhe/src/high_level_api/integers/tests_unsigned.rs
+++ b/tfhe/src/high_level_api/integers/tests_unsigned.rs
@@ -49,86 +49,86 @@ fn test_uint8_compare() {
     // Test comparing encrypted with encrypted
     {
         let result = &a.eq(&b);
-        let decrypted_result: u8 = result.decrypt(&client_key);
-        let clear_result = u8::from(clear_a == clear_b);
+        let decrypted_result = result.decrypt(&client_key);
+        let clear_result = clear_a == clear_b;
         assert_eq!(decrypted_result, clear_result);
 
         let result = &a.eq(&a);
-        let decrypted_result: u8 = result.decrypt(&client_key);
-        let clear_result = u8::from(clear_a == clear_a);
+        let decrypted_result = result.decrypt(&client_key);
+        let clear_result = clear_a == clear_a;
         assert_eq!(decrypted_result, clear_result);
 
         let result = &a.ne(&b);
-        let decrypted_result: u8 = result.decrypt(&client_key);
-        let clear_result = u8::from(clear_a != clear_b);
+        let decrypted_result = result.decrypt(&client_key);
+        let clear_result = clear_a != clear_b;
         assert_eq!(decrypted_result, clear_result);
 
         let result = &a.ne(&a);
-        let decrypted_result: u8 = result.decrypt(&client_key);
-        let clear_result = u8::from(clear_a != clear_a);
+        let decrypted_result = result.decrypt(&client_key);
+        let clear_result = clear_a != clear_a;
         assert_eq!(decrypted_result, clear_result);
 
         let result = &a.le(&b);
-        let decrypted_result: u8 = result.decrypt(&client_key);
-        let clear_result = u8::from(clear_a <= clear_b);
+        let decrypted_result = result.decrypt(&client_key);
+        let clear_result = clear_a <= clear_b;
         assert_eq!(decrypted_result, clear_result);
 
         let result = &a.lt(&b);
-        let decrypted_result: u8 = result.decrypt(&client_key);
-        let clear_result = u8::from(clear_a < clear_b);
+        let decrypted_result = result.decrypt(&client_key);
+        let clear_result = clear_a < clear_b;
         assert_eq!(decrypted_result, clear_result);
 
         let result = &a.ge(&b);
-        let decrypted_result: u8 = result.decrypt(&client_key);
-        let clear_result = u8::from(clear_a >= clear_b);
+        let decrypted_result = result.decrypt(&client_key);
+        let clear_result = clear_a >= clear_b;
         assert_eq!(decrypted_result, clear_result);
 
         let result = &a.gt(&b);
-        let decrypted_result: u8 = result.decrypt(&client_key);
-        let clear_result = u8::from(clear_a > clear_b);
+        let decrypted_result = result.decrypt(&client_key);
+        let clear_result = clear_a > clear_b;
         assert_eq!(decrypted_result, clear_result);
     }
 
     // Test comparing encrypted with clear
     {
         let result = &a.eq(clear_b);
-        let decrypted_result: u8 = result.decrypt(&client_key);
-        let clear_result = u8::from(clear_a == clear_b);
+        let decrypted_result = result.decrypt(&client_key);
+        let clear_result = clear_a == clear_b;
         assert_eq!(decrypted_result, clear_result);
 
         let result = &a.eq(clear_a);
-        let decrypted_result: u8 = result.decrypt(&client_key);
-        let clear_result = u8::from(clear_a == clear_a);
+        let decrypted_result = result.decrypt(&client_key);
+        let clear_result = clear_a == clear_a;
         assert_eq!(decrypted_result, clear_result);
 
         let result = &a.ne(clear_b);
-        let decrypted_result: u8 = result.decrypt(&client_key);
-        let clear_result = u8::from(clear_a != clear_b);
+        let decrypted_result = result.decrypt(&client_key);
+        let clear_result = clear_a != clear_b;
         assert_eq!(decrypted_result, clear_result);
 
         let result = &a.ne(clear_a);
-        let decrypted_result: u8 = result.decrypt(&client_key);
-        let clear_result = u8::from(clear_a != clear_a);
+        let decrypted_result = result.decrypt(&client_key);
+        let clear_result = clear_a != clear_a;
         assert_eq!(decrypted_result, clear_result);
 
         let result = &a.le(clear_b);
-        let decrypted_result: u8 = result.decrypt(&client_key);
-        let clear_result = u8::from(clear_a <= clear_b);
+        let decrypted_result = result.decrypt(&client_key);
+        let clear_result = clear_a <= clear_b;
         assert_eq!(decrypted_result, clear_result);
 
         let result = &a.lt(clear_b);
-        let decrypted_result: u8 = result.decrypt(&client_key);
-        let clear_result = u8::from(clear_a < clear_b);
+        let decrypted_result = result.decrypt(&client_key);
+        let clear_result = clear_a < clear_b;
         assert_eq!(decrypted_result, clear_result);
 
         let result = &a.ge(clear_b);
-        let decrypted_result: u8 = result.decrypt(&client_key);
-        let clear_result = u8::from(clear_a >= clear_b);
+        let decrypted_result = result.decrypt(&client_key);
+        let clear_result = clear_a >= clear_b;
         assert_eq!(decrypted_result, clear_result);
 
         let result = &a.gt(clear_b);
-        let decrypted_result: u8 = result.decrypt(&client_key);
-        let clear_result = u8::from(clear_a > clear_b);
+        let decrypted_result = result.decrypt(&client_key);
+        let clear_result = clear_a > clear_b;
         assert_eq!(decrypted_result, clear_result);
     }
 }

--- a/tfhe/src/high_level_api/prelude.rs
+++ b/tfhe/src/high_level_api/prelude.rs
@@ -11,3 +11,5 @@ pub use crate::high_level_api::traits::{
     FheTryEncrypt, FheTryTrivialEncrypt, RotateLeft, RotateLeftAssign, RotateRight,
     RotateRightAssign,
 };
+
+pub use crate::core_crypto::prelude::{CastFrom, CastInto};

--- a/tfhe/src/high_level_api/traits.rs
+++ b/tfhe/src/high_level_api/traits.rs
@@ -1,4 +1,5 @@
 use crate::high_level_api::ClientKey;
+use crate::FheBool;
 
 /// Trait used to have a generic way of creating a value of a FHE type
 /// from a native value.
@@ -87,11 +88,9 @@ pub trait FheDecrypt<T> {
 /// for equality, one cannot use the standard operator `==` but rather, use
 /// the function directly.
 pub trait FheEq<Rhs = Self> {
-    type Output;
+    fn eq(&self, other: Rhs) -> FheBool;
 
-    fn eq(&self, other: Rhs) -> Self::Output;
-
-    fn ne(&self, other: Rhs) -> Self::Output;
+    fn ne(&self, other: Rhs) -> FheBool;
 }
 
 /// Trait for fully homomorphic comparisons.
@@ -103,12 +102,10 @@ pub trait FheEq<Rhs = Self> {
 /// one cannot use the standard operators (`>`, `<`, etc) and must use
 /// the functions directly.
 pub trait FheOrd<Rhs = Self> {
-    type Output;
-
-    fn lt(&self, other: Rhs) -> Self::Output;
-    fn le(&self, other: Rhs) -> Self::Output;
-    fn gt(&self, other: Rhs) -> Self::Output;
-    fn ge(&self, other: Rhs) -> Self::Output;
+    fn lt(&self, other: Rhs) -> FheBool;
+    fn le(&self, other: Rhs) -> FheBool;
+    fn gt(&self, other: Rhs) -> FheBool;
+    fn ge(&self, other: Rhs) -> FheBool;
 }
 
 pub trait FheMin<Rhs = Self> {

--- a/tfhe/src/integer/public_key/compressed.rs
+++ b/tfhe/src/integer/public_key/compressed.rs
@@ -2,7 +2,7 @@ use crate::integer::block_decomposition::DecomposableInto;
 use crate::integer::ciphertext::{CrtCiphertext, RadixCiphertext};
 use crate::integer::client_key::ClientKey;
 use crate::integer::encryption::{encrypt_crt, encrypt_words_radix_impl};
-use crate::integer::SignedRadixCiphertext;
+use crate::integer::{BooleanBlock, SignedRadixCiphertext};
 use crate::shortint::parameters::MessageModulus;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -46,9 +46,7 @@ impl CompressedPublicKey {
     {
         encrypt_crt(&self.key, message, base_vec, encrypt_block)
     }
-}
 
-impl CompressedPublicKey {
     pub fn parameters(&self) -> crate::shortint::PBSParameters {
         self.key.parameters.pbs_parameters().unwrap()
     }
@@ -75,6 +73,10 @@ impl CompressedPublicKey {
             num_blocks,
             crate::shortint::CompressedPublicKey::encrypt,
         )
+    }
+
+    pub fn encrypt_bool(&self, message: bool) -> BooleanBlock {
+        BooleanBlock::new_unchecked(self.key.encrypt(u64::from(message)))
     }
 
     pub fn encrypt_radix_without_padding(

--- a/tfhe/src/integer/public_key/standard.rs
+++ b/tfhe/src/integer/public_key/standard.rs
@@ -4,7 +4,7 @@ use crate::integer::ciphertext::{CrtCiphertext, RadixCiphertext};
 use crate::integer::client_key::ClientKey;
 use crate::integer::encryption::{encrypt_crt, encrypt_words_radix_impl};
 use crate::integer::public_key::compressed::CompressedPublicKey;
-use crate::integer::SignedRadixCiphertext;
+use crate::integer::{BooleanBlock, SignedRadixCiphertext};
 use crate::shortint::parameters::MessageModulus;
 use crate::shortint::PublicKey as ShortintPublicKey;
 
@@ -66,6 +66,10 @@ impl PublicKey {
         T: DecomposableInto<u64> + SignedNumeric,
     {
         encrypt_words_radix_impl(&self.key, message, num_blocks, ShortintPublicKey::encrypt)
+    }
+
+    pub fn encrypt_bool(&self, message: bool) -> BooleanBlock {
+        BooleanBlock::new_unchecked(self.key.encrypt(u64::from(message)))
     }
 
     pub fn encrypt_radix_without_padding(


### PR DESCRIPTION
- This makes FheBool use integer::BooleanBlock internally.
- It makes comparisons (eq, ne, le, etc) return a FheBool instead of
  FheUint/FheInt.
- It also moves the if_then_else and cmux methods to FheBool.
- Adds casting from FheBool to FheUint/FheInt (but not from
  FheUint/FheInt to FheBool as we expect users to do `a.ne(0)`
  as its matches Rust)

BREAKING CHANGE:
    - Comparisons now return FheBool
    - if_then_else/cmux are now methods of FheBool.