### PR TITLE
chore(shortint): add some flaky/failing doctests as actual tests

### DIFF
--- a/scripts/shortint-tests.sh
+++ b/scripts/shortint-tests.sh
@@ -94,6 +94,7 @@ or test(/^shortint::.*_param${multi_bit}_message_2_carry_3${multi_bit:+"_group_[
 or test(/^shortint::.*_param${multi_bit}_message_3_carry_1${multi_bit:+"_group_[0-9]"}(_compact_pk)?_ks_pbs/) \
 or test(/^shortint::.*_param${multi_bit}_message_3_carry_2${multi_bit:+"_group_[0-9]"}(_compact_pk)?_ks_pbs/) \
 or test(/^shortint::.*_param${multi_bit}_message_3_carry_3${multi_bit:+"_group_[0-9]"}(_compact_pk)?_ks_pbs/) \
+or test(/^shortint::.*_ci_run_filter/) \
 )\
 and not test(~smart_add_and_mul)""" # This test is too slow
     else
@@ -159,6 +160,7 @@ or test(/^shortint::.*_param${multi_bit}_message_3_carry_1${multi_bit:+"_group_[
 or test(/^shortint::.*_param${multi_bit}_message_3_carry_2${multi_bit:+"_group_[0-9]"}(_compact_pk)?_ks_pbs/) \
 or test(/^shortint::.*_param${multi_bit}_message_3_carry_3${multi_bit:+"_group_[0-9]"}(_compact_pk)?_ks_pbs/) \
 or test(/^shortint::.*_param${multi_bit}_message_4_carry_4${multi_bit:+"_group_[0-9]"}(_compact_pk)?_ks_pbs/) \
+or test(/^shortint::.*_ci_run_filter/) \
 )\
 and not test(~smart_add_and_mul)""" # This test is too slow
     else

--- a/tfhe/src/shortint/wopbs/test.rs
+++ b/tfhe/src/shortint/wopbs/test.rs
@@ -171,3 +171,42 @@ fn generate_lut_modulus_not_power_of_two(params: WopbsParameters) {
         assert_eq!(res as usize, (m * m) % message_modulus.0);
     }
 }
+
+// This test comes from the module file and is flaky/failing as a doctest, checking if it works as a
+// standalone test
+#[test]
+fn test_generate_lut_native_crt_doctest_ci_run_filter() {
+    use crate::shortint::gen_keys;
+    use crate::shortint::parameters::parameters_wopbs::WOPBS_PARAM_MESSAGE_3_NORM2_2_KS_PBS;
+    use crate::shortint::wopbs::WopbsKey;
+
+    // Generate the client key and the server key:
+    let (cks, sks) = gen_keys(WOPBS_PARAM_MESSAGE_3_NORM2_2_KS_PBS);
+    let wopbs_key = WopbsKey::new_wopbs_key_only_for_wopbs(&cks, &sks);
+    let message_modulus = 5;
+    let m = 2;
+    let mut ct = cks.encrypt_native_crt(m, message_modulus);
+    let lut = wopbs_key.generate_lut_native_crt(&ct, |x| x * x % message_modulus as u64);
+    let ct_res = wopbs_key.programmable_bootstrapping_native_crt(&mut ct, &lut);
+    let res = cks.decrypt_message_native_crt(&ct_res, message_modulus);
+    assert_eq!(res, (m * m) % message_modulus as u64);
+}
+
+// This test comes from the module file and is flaky/failing as a doctest, checking if it works as a
+// standalone test
+#[test]
+fn test_programmable_bootstrapping_native_crt_doctest_ci_run_filter() {
+    use crate::shortint::gen_keys;
+    use crate::shortint::parameters::parameters_wopbs::WOPBS_PARAM_MESSAGE_3_NORM2_2_KS_PBS;
+    use crate::shortint::wopbs::*;
+
+    let (cks, sks) = gen_keys(WOPBS_PARAM_MESSAGE_3_NORM2_2_KS_PBS);
+    let wopbs_key = WopbsKey::new_wopbs_key_only_for_wopbs(&cks, &sks);
+    let msg = 2;
+    let modulus = 5;
+    let mut ct = cks.encrypt_native_crt(msg, modulus);
+    let lut = wopbs_key.generate_lut_native_crt(&ct, |x| x);
+    let ct_res = wopbs_key.programmable_bootstrapping_native_crt(&mut ct, &lut);
+    let res = cks.decrypt_message_native_crt(&ct_res, modulus);
+    assert_eq!(res, msg);
+}


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: https://github.com/zama-ai/tfhe-rs-internal/issues/323

### PR content/description

- check that those are actually failing or that they are a doctest bug
- add _ci_run_filter so that we can easily make sure tests run in CI even if they don't have the "parameter format"

### Check-list:

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [x] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
