### PR TITLE
feat(tfhe): add LWE encryption with non power of 2 moduli

### DIFF
--- a/tfhe/src/core_crypto/algorithms/seeded_lwe_ciphertext_decompression.rs
+++ b/tfhe/src/core_crypto/algorithms/seeded_lwe_ciphertext_decompression.rs
@@ -1,6 +1,7 @@
 //! Module with primitives pertaining to [`SeededLweCiphertext`] decompression.
 
 use crate::core_crypto::algorithms::slice_algorithms::slice_wrapping_scalar_mul_assign;
+use crate::core_crypto::commons::ciphertext_modulus::CiphertextModulusKind;
 use crate::core_crypto::commons::generators::MaskRandomGenerator;
 use crate::core_crypto::commons::traits::*;
 use crate::core_crypto::entities::*;
@@ -26,16 +27,20 @@ pub fn decompress_seeded_lwe_ciphertext_with_existing_generator<Scalar, OutputCo
     );
 
     let ciphertext_modulus = output_lwe.ciphertext_modulus();
-    assert!(ciphertext_modulus.is_compatible_with_native_modulus());
     let (mut output_mask, output_body) = output_lwe.get_mut_mask_and_body();
 
     // generate a uniformly random mask
     generator.fill_slice_with_random_mask_custom_mod(output_mask.as_mut(), ciphertext_modulus);
-    if !ciphertext_modulus.is_native_modulus() {
-        slice_wrapping_scalar_mul_assign(
-            output_mask.as_mut(),
-            ciphertext_modulus.get_power_of_two_scaling_to_native_torus(),
-        );
+    match ciphertext_modulus.kind() {
+        // Manage the specific encoding for non native power of 2
+        CiphertextModulusKind::NonNativePowerOfTwo => {
+            slice_wrapping_scalar_mul_assign(
+                output_mask.as_mut(),
+                ciphertext_modulus.get_power_of_two_scaling_to_native_torus(),
+            );
+        }
+        // Nothing to do
+        CiphertextModulusKind::Native | CiphertextModulusKind::Other => (),
     }
     *output_body.data = *input_seeded_lwe.get_body().data;
 }

--- a/tfhe/src/core_crypto/algorithms/test/lwe_encryption.rs
+++ b/tfhe/src/core_crypto/algorithms/test/lwe_encryption.rs
@@ -7,7 +7,7 @@ const NB_TESTS: usize = 10;
 #[cfg(feature = "__coverage")]
 const NB_TESTS: usize = 1;
 
-fn test_parallel_and_seeded_lwe_list_encryption_equivalence<Scalar: UnsignedTorus + Sync + Send>(
+fn parallel_and_seeded_lwe_list_encryption_equivalence<Scalar: UnsignedTorus + Sync + Send>(
     params: ClassicTestParams<Scalar>,
 ) {
     // DISCLAIMER: these toy example parameters are not guaranteed to be secure or yield correct
@@ -131,25 +131,13 @@ fn test_parallel_and_seeded_lwe_list_encryption_equivalence<Scalar: UnsignedToru
     }
 }
 
-#[test]
-fn test_parallel_and_seeded_lwe_list_encryption_equivalence_native_mod_u64() {
-    test_parallel_and_seeded_lwe_list_encryption_equivalence(TEST_PARAMS_4_BITS_NATIVE_U64);
-}
-
-#[test]
-fn test_parallel_and_seeded_lwe_list_encryption_equivalence_non_native_power_of_2_mod_u64() {
-    test_parallel_and_seeded_lwe_list_encryption_equivalence(TEST_PARAMS_3_BITS_63_U64);
-}
-
-#[test]
-fn test_parallel_and_seeded_lwe_list_encryption_equivalence_native_mod_u32() {
-    test_parallel_and_seeded_lwe_list_encryption_equivalence(DUMMY_NATIVE_U32);
-}
-
-#[test]
-fn test_parallel_and_seeded_lwe_list_encryption_equivalence_non_native_power_of_2_mod_u32() {
-    test_parallel_and_seeded_lwe_list_encryption_equivalence(DUMMY_31_U32);
-}
+create_parametrized_test!(parallel_and_seeded_lwe_list_encryption_equivalence {
+    TEST_PARAMS_4_BITS_NATIVE_U64,
+    TEST_PARAMS_3_BITS_63_U64,
+    TEST_PARAMS_3_BITS_SOLINAS_U64,
+    DUMMY_NATIVE_U32,
+    DUMMY_31_U32,
+});
 
 fn lwe_encrypt_decrypt_custom_mod<Scalar: UnsignedTorus>(params: ClassicTestParams<Scalar>) {
     let lwe_dimension = params.lwe_dimension;
@@ -207,7 +195,7 @@ fn lwe_encrypt_decrypt_custom_mod<Scalar: UnsignedTorus>(params: ClassicTestPara
     }
 }
 
-create_parametrized_test!(lwe_encrypt_decrypt_custom_mod);
+create_parametrized_test_with_non_native_parameters!(lwe_encrypt_decrypt_custom_mod);
 
 fn lwe_allocate_encrypt_decrypt_custom_mod<Scalar: UnsignedTorus>(
     params: ClassicTestParams<Scalar>,
@@ -261,7 +249,7 @@ fn lwe_allocate_encrypt_decrypt_custom_mod<Scalar: UnsignedTorus>(
     }
 }
 
-create_parametrized_test!(lwe_allocate_encrypt_decrypt_custom_mod);
+create_parametrized_test_with_non_native_parameters!(lwe_allocate_encrypt_decrypt_custom_mod);
 
 fn lwe_trivial_encrypt_decrypt_custom_mod<Scalar: UnsignedTorus>(
     params: ClassicTestParams<Scalar>,
@@ -313,7 +301,7 @@ fn lwe_trivial_encrypt_decrypt_custom_mod<Scalar: UnsignedTorus>(
         break;
     }
 }
-create_parametrized_test!(lwe_trivial_encrypt_decrypt_custom_mod);
+create_parametrized_test_with_non_native_parameters!(lwe_trivial_encrypt_decrypt_custom_mod);
 
 fn lwe_allocate_trivial_encrypt_decrypt_custom_mod<Scalar: UnsignedTorus>(
     params: ClassicTestParams<Scalar>,
@@ -364,7 +352,9 @@ fn lwe_allocate_trivial_encrypt_decrypt_custom_mod<Scalar: UnsignedTorus>(
     }
 }
 
-create_parametrized_test!(lwe_allocate_trivial_encrypt_decrypt_custom_mod);
+create_parametrized_test_with_non_native_parameters!(
+    lwe_allocate_trivial_encrypt_decrypt_custom_mod
+);
 
 fn lwe_list_encrypt_decrypt_custom_mod<Scalar: UnsignedTorus>(params: ClassicTestParams<Scalar>) {
     let lwe_dimension = params.lwe_dimension;
@@ -433,7 +423,7 @@ fn lwe_list_encrypt_decrypt_custom_mod<Scalar: UnsignedTorus>(params: ClassicTes
     }
 }
 
-create_parametrized_test!(lwe_list_encrypt_decrypt_custom_mod);
+create_parametrized_test_with_non_native_parameters!(lwe_list_encrypt_decrypt_custom_mod);
 
 fn lwe_list_par_encrypt_decrypt_custom_mod<Scalar: UnsignedTorus + Sync + Send>(
     params: ClassicTestParams<Scalar>,
@@ -504,7 +494,7 @@ fn lwe_list_par_encrypt_decrypt_custom_mod<Scalar: UnsignedTorus + Sync + Send>(
     }
 }
 
-create_parametrized_test!(lwe_list_par_encrypt_decrypt_custom_mod);
+create_parametrized_test_with_non_native_parameters!(lwe_list_par_encrypt_decrypt_custom_mod);
 
 fn lwe_public_encrypt_decrypt_custom_mod<Scalar: UnsignedTorus>(params: ClassicTestParams<Scalar>) {
     let lwe_dimension = params.lwe_dimension;
@@ -570,7 +560,7 @@ fn lwe_public_encrypt_decrypt_custom_mod<Scalar: UnsignedTorus>(params: ClassicT
     }
 }
 
-create_parametrized_test!(lwe_public_encrypt_decrypt_custom_mod);
+create_parametrized_test_with_non_native_parameters!(lwe_public_encrypt_decrypt_custom_mod);
 
 fn lwe_seeded_public_encrypt_decrypt_custom_mod<Scalar: UnsignedTorus>(
     params: ClassicTestParams<Scalar>,
@@ -645,7 +635,7 @@ fn lwe_seeded_public_encrypt_decrypt_custom_mod<Scalar: UnsignedTorus>(
     }
 }
 
-create_parametrized_test!(lwe_seeded_public_encrypt_decrypt_custom_mod);
+create_parametrized_test_with_non_native_parameters!(lwe_seeded_public_encrypt_decrypt_custom_mod);
 
 fn lwe_seeded_list_par_encrypt_decrypt_custom_mod<Scalar: UnsignedTorus + Sync + Send>(
     params: ClassicTestParams<Scalar>,
@@ -728,7 +718,9 @@ fn lwe_seeded_list_par_encrypt_decrypt_custom_mod<Scalar: UnsignedTorus + Sync +
     }
 }
 
-create_parametrized_test!(lwe_seeded_list_par_encrypt_decrypt_custom_mod);
+create_parametrized_test_with_non_native_parameters!(
+    lwe_seeded_list_par_encrypt_decrypt_custom_mod
+);
 
 fn lwe_seeded_encrypt_decrypt_custom_mod<Scalar: UnsignedTorus>(params: ClassicTestParams<Scalar>) {
     let lwe_dimension = params.lwe_dimension;
@@ -794,7 +786,7 @@ fn lwe_seeded_encrypt_decrypt_custom_mod<Scalar: UnsignedTorus>(params: ClassicT
     }
 }
 
-create_parametrized_test!(lwe_seeded_encrypt_decrypt_custom_mod);
+create_parametrized_test_with_non_native_parameters!(lwe_seeded_encrypt_decrypt_custom_mod);
 
 fn lwe_seeded_allocate_encrypt_decrypt_custom_mod<Scalar: UnsignedTorus>(
     params: ClassicTestParams<Scalar>,
@@ -855,7 +847,9 @@ fn lwe_seeded_allocate_encrypt_decrypt_custom_mod<Scalar: UnsignedTorus>(
     }
 }
 
-create_parametrized_test!(lwe_seeded_allocate_encrypt_decrypt_custom_mod);
+create_parametrized_test_with_non_native_parameters!(
+    lwe_seeded_allocate_encrypt_decrypt_custom_mod
+);
 
 #[test]
 fn test_u128_encryption() {
@@ -907,8 +901,10 @@ fn test_u128_encryption() {
             // Round and remove encoding
             // First create a decomposer working on the high 4 bits corresponding to our
             // encoding.
-            let decomposer =
-                SignedDecomposer::new(DecompositionBaseLog(4), DecompositionLevelCount(1));
+            let decomposer = SignedDecomposer::new(
+                DecompositionBaseLog(MSG_BITS as usize),
+                DecompositionLevelCount(1),
+            );
 
             let rounded = decomposer.closest_representable(decrypted_plaintext.0);
 

--- a/tfhe/src/core_crypto/algorithms/test/lwe_linear_algebra.rs
+++ b/tfhe/src/core_crypto/algorithms/test/lwe_linear_algebra.rs
@@ -72,7 +72,7 @@ fn lwe_encrypt_add_assign_decrypt_custom_mod<Scalar: UnsignedTorus>(
     }
 }
 
-create_parametrized_test!(lwe_encrypt_add_assign_decrypt_custom_mod);
+create_parametrized_test_with_non_native_parameters!(lwe_encrypt_add_assign_decrypt_custom_mod);
 
 fn lwe_encrypt_add_decrypt_custom_mod<Scalar: UnsignedTorus>(params: ClassicTestParams<Scalar>) {
     let lwe_dimension = params.lwe_dimension;
@@ -139,7 +139,7 @@ fn lwe_encrypt_add_decrypt_custom_mod<Scalar: UnsignedTorus>(params: ClassicTest
     }
 }
 
-create_parametrized_test!(lwe_encrypt_add_decrypt_custom_mod);
+create_parametrized_test_with_non_native_parameters!(lwe_encrypt_add_decrypt_custom_mod);
 
 fn lwe_encrypt_plaintext_add_assign_decrypt_custom_mod<Scalar: UnsignedTorus>(
     params: ClassicTestParams<Scalar>,
@@ -206,7 +206,9 @@ fn lwe_encrypt_plaintext_add_assign_decrypt_custom_mod<Scalar: UnsignedTorus>(
     }
 }
 
-create_parametrized_test!(lwe_encrypt_plaintext_add_assign_decrypt_custom_mod);
+create_parametrized_test_with_non_native_parameters!(
+    lwe_encrypt_plaintext_add_assign_decrypt_custom_mod
+);
 
 fn lwe_encrypt_plaintext_sub_assign_decrypt_custom_mod<Scalar: UnsignedTorus>(
     params: ClassicTestParams<Scalar>,
@@ -273,7 +275,9 @@ fn lwe_encrypt_plaintext_sub_assign_decrypt_custom_mod<Scalar: UnsignedTorus>(
     }
 }
 
-create_parametrized_test!(lwe_encrypt_plaintext_sub_assign_decrypt_custom_mod);
+create_parametrized_test_with_non_native_parameters!(
+    lwe_encrypt_plaintext_sub_assign_decrypt_custom_mod
+);
 
 fn lwe_encrypt_opposite_assign_decrypt_custom_mod<Scalar: UnsignedTorus>(
     params: ClassicTestParams<Scalar>,
@@ -340,7 +344,9 @@ fn lwe_encrypt_opposite_assign_decrypt_custom_mod<Scalar: UnsignedTorus>(
     }
 }
 
-create_parametrized_test!(lwe_encrypt_opposite_assign_decrypt_custom_mod);
+create_parametrized_test_with_non_native_parameters!(
+    lwe_encrypt_opposite_assign_decrypt_custom_mod
+);
 
 fn lwe_encrypt_ciphertext_cleartext_mul_assign_decrypt_custom_mod<Scalar: UnsignedTorus>(
     params: ClassicTestParams<Scalar>,
@@ -408,7 +414,9 @@ fn lwe_encrypt_ciphertext_cleartext_mul_assign_decrypt_custom_mod<Scalar: Unsign
     }
 }
 
-create_parametrized_test!(lwe_encrypt_ciphertext_cleartext_mul_assign_decrypt_custom_mod);
+create_parametrized_test_with_non_native_parameters!(
+    lwe_encrypt_ciphertext_cleartext_mul_assign_decrypt_custom_mod
+);
 
 fn lwe_encrypt_cleartext_mul_decrypt_custom_mod<Scalar: UnsignedTorus>(
     params: ClassicTestParams<Scalar>,
@@ -478,7 +486,7 @@ fn lwe_encrypt_cleartext_mul_decrypt_custom_mod<Scalar: UnsignedTorus>(
     }
 }
 
-create_parametrized_test!(lwe_encrypt_cleartext_mul_decrypt_custom_mod);
+create_parametrized_test_with_non_native_parameters!(lwe_encrypt_cleartext_mul_decrypt_custom_mod);
 
 fn lwe_encrypt_sub_assign_decrypt_custom_mod<Scalar: UnsignedTorus>(
     params: ClassicTestParams<Scalar>,
@@ -567,7 +575,7 @@ fn lwe_encrypt_sub_assign_decrypt_custom_mod<Scalar: UnsignedTorus>(
     }
 }
 
-create_parametrized_test!(lwe_encrypt_sub_assign_decrypt_custom_mod);
+create_parametrized_test_with_non_native_parameters!(lwe_encrypt_sub_assign_decrypt_custom_mod);
 
 fn lwe_encrypt_sub_decrypt_custom_mod<Scalar: UnsignedTorus>(params: ClassicTestParams<Scalar>) {
     let lwe_dimension = params.lwe_dimension;
@@ -656,4 +664,4 @@ fn lwe_encrypt_sub_decrypt_custom_mod<Scalar: UnsignedTorus>(params: ClassicTest
     }
 }
 
-create_parametrized_test!(lwe_encrypt_sub_decrypt_custom_mod);
+create_parametrized_test_with_non_native_parameters!(lwe_encrypt_sub_decrypt_custom_mod);

--- a/tfhe/src/core_crypto/algorithms/test/noise_distribution/lwe_encryption_noise.rs
+++ b/tfhe/src/core_crypto/algorithms/test/noise_distribution/lwe_encryption_noise.rs
@@ -64,13 +64,12 @@ fn lwe_encrypt_decrypt_noise_distribution_custom_mod<Scalar: UnsignedTorus + Cas
 
             assert_eq!(msg, decoded);
 
-            let torus_distance = torus_modular_diff(plaintext.0, decrypted.0, ciphertext_modulus);
-            noise_samples.push(torus_distance);
+            let torus_diff = torus_modular_diff(plaintext.0, decrypted.0, ciphertext_modulus);
+            noise_samples.push(torus_diff);
         }
     }
 
     let measured_variance = variance(&noise_samples);
-
     let var_abs_diff = (expected_variance.0 - measured_variance.0).abs();
     let tolerance_threshold = RELATIVE_TOLERANCE * expected_variance.0;
     assert!(
@@ -84,6 +83,7 @@ fn lwe_encrypt_decrypt_noise_distribution_custom_mod<Scalar: UnsignedTorus + Cas
 
 create_parametrized_test!(lwe_encrypt_decrypt_noise_distribution_custom_mod {
     TEST_PARAMS_4_BITS_NATIVE_U64,
+    TEST_PARAMS_3_BITS_SOLINAS_U64,
     TEST_PARAMS_3_BITS_63_U64
 });
 
@@ -173,8 +173,8 @@ fn lwe_compact_public_encrypt_noise_distribution_custom_mod<
 
             assert_eq!(msg, decoded);
 
-            let torus_distance = torus_modular_diff(plaintext.0, decrypted.0, ciphertext_modulus);
-            noise_samples.push(torus_distance);
+            let torus_diff = torus_modular_diff(plaintext.0, decrypted.0, ciphertext_modulus);
+            noise_samples.push(torus_diff);
         }
     }
 

--- a/tfhe/src/core_crypto/commons/numeric/unsigned.rs
+++ b/tfhe/src/core_crypto/commons/numeric/unsigned.rs
@@ -207,8 +207,8 @@ macro_rules! implement {
             }
             #[inline]
             fn wrapping_neg_custom_mod(self, custom_modulus: Self) -> Self {
-                Self::ZERO.wrapping_sub_custom_mod(self, custom_modulus)
                 // Custom modulus applied by wrapping_sub
+                Self::ZERO.wrapping_sub_custom_mod(self, custom_modulus)
             }
             #[inline]
             fn wrapping_shl(self, rhs: u32) -> Self {


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
### PR content/description

Add support for non power of 2 q for LWE encryption and linalg, LWE encryption tests and LWE linear algebra tests have been updated to make use of the Solinas set of parameter

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
