### PR TITLE
Am/chore/noise max unknown

### DIFF
--- a/tfhe/src/shortint/key_switching_key/test.rs
+++ b/tfhe/src/shortint/key_switching_key/test.rs
@@ -3,7 +3,7 @@ use crate::shortint::parameters::ShortintKeySwitchingParameters;
 use crate::shortint::prelude::*;
 
 #[test]
-fn gen_multi_keys_test_fresh() {
+fn gen_multi_keys_test_fresh_ci_run_filter() {
     let keys = KEY_CACHE_KSK.get_from_param((
         PARAM_MESSAGE_1_CARRY_1_KS_PBS,
         PARAM_MESSAGE_2_CARRY_2_KS_PBS,
@@ -53,7 +53,7 @@ fn gen_multi_keys_test_fresh() {
 }
 
 #[test]
-fn gen_multi_keys_test_fresh_2() {
+fn gen_multi_keys_test_fresh_2_ci_run_filter() {
     let keys2 = KEY_CACHE.get_from_param(PARAM_MESSAGE_3_CARRY_3_KS_PBS);
     let (ck2, sk2) = (keys2.client_key(), keys2.server_key());
 
@@ -110,7 +110,7 @@ fn gen_multi_keys_test_fresh_2() {
 }
 
 #[test]
-fn gen_multi_keys_test_add_with_overflow() {
+fn gen_multi_keys_test_add_with_overflow_ci_run_filter() {
     let keys = KEY_CACHE_KSK.get_from_param((
         PARAM_MESSAGE_1_CARRY_1_KS_PBS,
         PARAM_MESSAGE_3_CARRY_3_KS_PBS,
@@ -136,7 +136,7 @@ fn gen_multi_keys_test_add_with_overflow() {
 }
 
 #[test]
-fn gen_multi_keys_test_no_shift() {
+fn gen_multi_keys_test_no_shift_ci_run_filter() {
     let keys2 = KEY_CACHE.get_from_param(PARAM_MESSAGE_1_CARRY_1_KS_PBS);
     let ck2 = keys2.client_key();
 
@@ -156,7 +156,7 @@ fn gen_multi_keys_test_no_shift() {
 }
 
 #[test]
-fn gen_multi_keys_test_truncate() {
+fn gen_multi_keys_test_truncate_ci_run_filter() {
     let keys2 = KEY_CACHE.get_from_param(PARAM_MESSAGE_1_CARRY_1_KS_PBS);
     let (ck2, sk2) = (keys2.client_key(), keys2.server_key());
 

--- a/tfhe/src/shortint/server_key/tests/noise_level.rs
+++ b/tfhe/src/shortint/server_key/tests/noise_level.rs
@@ -254,7 +254,7 @@ fn test_ct_scalar_op_assign_noise_level_propagation(sk: &ServerKey, ct: &Ciphert
 }
 
 #[test]
-fn test_noise_level_propagation() {
+fn test_noise_level_propagation_ci_run_filter() {
     let params = PARAM_MESSAGE_2_CARRY_2_KS_PBS;
 
     let keys = KEY_CACHE.get_from_param(params);


### PR DESCRIPTION
add _ci_run_filter on scattered tests in shortint that were ignored
saturate when adding two NoiseLevel and when multiplying by a usize, this is required for a "NoiseLevel::MAX/UNKNOWN" that will be safe to use when updating serialization format from 0.4 to 0.5