### PR TITLE
chore(ci): change benchmark aws ec2 machine type

### DIFF
--- a/ci/ec2_products_cost.json
+++ b/ci/ec2_products_cost.json
@@ -1,3 +1,4 @@
 {
-  "m6i.metal": 7.168
+  "m6i.metal": 7.168,
+  "hpc7a.96xlarge": 7.7252
 }

--- a/ci/slab.toml
+++ b/ci/slab.toml
@@ -9,9 +9,9 @@ image_id = "ami-051942e4055555752"
 instance_type = "m6i.4xlarge"
 
 [profile.bench]
-region = "eu-west-3"
-image_id = "ami-051942e4055555752"
-instance_type = "m6i.metal"
+region = "eu-west-1"
+image_id = "ami-0e88d98b86aff13de"
+instance_type = "hpc7a.96xlarge"
 
 [command.cpu_test]
 workflow = "aws_tfhe_tests.yml"


### PR DESCRIPTION
This instance type hpc7a.96xlarge yields better performances for nearly the same hourly cost.