### PR TITLE
About "the simple example" part on github page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ use tfhe::{generate_keys, set_server_key, ConfigBuilder, FheUint32, FheUint8};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Basic configuration to use homomorphic integers
-    let config = ConfigBuilder::default().build();
+    let config = ConfigBuilder::all_disabled()
+        .enable_default_integers()
+        .build();
 
     // Key generation
     let (client_key, server_keys) = generate_keys(config);


### PR DESCRIPTION
I found the simple example code on the github page couldn't run. After I check out the README in my local crate, I found there's a slight difference(ConfigBuilder method). I replace it and that work for me. Please check it out. Thanks.
