### PR TITLE
chore(core): change the test LUT to apply the identity function

### DIFF
--- a/tfhe/src/core_crypto/algorithms/test/lwe_multi_bit_programmable_bootstrapping.rs
+++ b/tfhe/src/core_crypto/algorithms/test/lwe_multi_bit_programmable_bootstrapping.rs
@@ -93,11 +93,7 @@ where
 
     let mut rsc = TestResources::new();
 
-    let f = |x: Scalar| {
-        x.wrapping_mul(Scalar::TWO)
-            .wrapping_sub(Scalar::ONE)
-            .wrapping_rem(msg_modulus)
-    };
+    let f = |x: Scalar| x;
 
     let delta: Scalar = encoding_with_padding / msg_modulus;
     let mut msg = msg_modulus;
@@ -201,11 +197,7 @@ fn lwe_encrypt_multi_bit_deterministic_pbs_decrypt_custom_mod<Scalar>(
 
     let mut rsc = TestResources::new();
 
-    let f = |x: Scalar| {
-        x.wrapping_mul(Scalar::TWO)
-            .wrapping_sub(Scalar::ONE)
-            .wrapping_rem(msg_modulus)
-    };
+    let f = |x: Scalar| x;
 
     let delta: Scalar = encoding_with_padding / msg_modulus;
     let mut msg = msg_modulus;
@@ -332,11 +324,7 @@ where
 
     let mut rsc = TestResources::new();
 
-    let f = |x: Scalar| {
-        x.wrapping_mul(Scalar::TWO)
-            .wrapping_sub(Scalar::ONE)
-            .wrapping_rem(msg_modulus)
-    };
+    let f = |x: Scalar| x;
 
     let delta: Scalar = encoding_with_padding / msg_modulus;
     let mut msg = msg_modulus;
@@ -440,11 +428,7 @@ fn std_lwe_encrypt_multi_bit_deterministic_pbs_decrypt_custom_mod<Scalar>(
 
     let mut rsc = TestResources::new();
 
-    let f = |x: Scalar| {
-        x.wrapping_mul(Scalar::TWO)
-            .wrapping_sub(Scalar::ONE)
-            .wrapping_rem(msg_modulus)
-    };
+    let f = |x: Scalar| x;
 
     let delta: Scalar = encoding_with_padding / msg_modulus;
     let mut msg = msg_modulus;

--- a/tfhe/src/core_crypto/algorithms/test/lwe_programmable_bootstrapping.rs
+++ b/tfhe/src/core_crypto/algorithms/test/lwe_programmable_bootstrapping.rs
@@ -88,11 +88,7 @@ where
 
     let mut rsc = TestResources::new();
 
-    let f = |x: Scalar| {
-        x.wrapping_mul(Scalar::TWO)
-            .wrapping_sub(Scalar::ONE)
-            .wrapping_rem(msg_modulus)
-    };
+    let f = |x: Scalar| x;
 
     let delta: Scalar = encoding_with_padding / msg_modulus;
     let mut msg = msg_modulus;
@@ -232,11 +228,7 @@ where
 
     let mut rsc = TestResources::new();
 
-    let f = |x: Scalar| {
-        x.wrapping_mul(Scalar::TWO)
-            .wrapping_sub(Scalar::ONE)
-            .wrapping_rem(msg_modulus)
-    };
+    let f = |x: Scalar| x;
 
     let delta: Scalar = encoding_with_padding / msg_modulus;
     let mut msg = msg_modulus;


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: https://github.com/zama-ai/tfhe-rs-internal/issues/330

### PR content/description

- the identity function more easily detects errors in the PBS as each mega case contains a different value compared to its neighbours

### Check-list:

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [x] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
