### PR TITLE
chore(ci): .gitignore was ignoring all files/directories names keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,9 @@ target/
 .vscode/
 
 # Path we use for internal-keycache during tests
-keys/
+/keys/
 # In case of symlinked keys
-keys
+/keys
 
 **/Cargo.lock
 **/*.bin
@@ -18,4 +18,4 @@ keys
 dieharder_run.log
 
 # Coverage reports
-./coverage/
+/coverage/


### PR DESCRIPTION
- this was hiding some source files in vscode search and could likely have been very annoying when commiting stuff
