### PR TITLE
chore(ci): add aws ec2 fallback profile for cpu tests

### DIFF
--- a/ci/slab.toml
+++ b/ci/slab.toml
@@ -3,6 +3,11 @@ region = "eu-west-3"
 image_id = "ami-051942e4055555752"
 instance_type = "m6i.32xlarge"
 
+[profile.cpu-big_fallback]
+region = "us-east-1"
+image_id = "ami-04e3bb9aebb6786df"
+instance_type = "m6i.32xlarge"
+
 [profile.cpu-small]
 region = "eu-west-3"
 image_id = "ami-051942e4055555752"


### PR DESCRIPTION
This is done to mitigate resource shortages in our base AWS region (eu-west-3) due to the high number of instances that are launched in parallel in our Pull Requests.
