### PR TITLE
chore(ci): re-enable release profile for doctest

### DIFF
--- a/scripts/integer-tests.sh
+++ b/scripts/integer-tests.sh
@@ -22,8 +22,6 @@ not_multi_bit="_multi_bit"
 signed=""
 not_signed=""
 cargo_profile="release"
-# TODO: revert to release once the bug is properly fixed/identified
-cargo_profile_doctests="release_lto_off"
 avx512_feature=""
 
 while [ -n "$1" ]
@@ -163,7 +161,7 @@ cargo "${RUST_TOOLCHAIN}" nextest run \
 
 if [[ "${multi_bit}" == "" ]]; then
     cargo "${RUST_TOOLCHAIN}" test \
-        --profile "${cargo_profile_doctests}" \
+        --profile "${cargo_profile}" \
         --package tfhe \
         --features="${ARCH_FEATURE}",integer,internal-keycache,"${avx512_feature}" \
         --doc \


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: https://github.com/zama-ai/tfhe-rs-internal/issues/333

### PR content/description

- following merge of 17.0.4 in rust stable the bug uncovered by lto on aarch64 has been fixed https://github.com/rust-lang/rust/issues/116941 so we remove the hard coded override
