### PR TITLE
chore(ci): fix doctest by using parameters with enough precision

### DIFF
--- a/tfhe/src/shortint/wopbs/mod.rs
+++ b/tfhe/src/shortint/wopbs/mod.rs
@@ -319,11 +319,11 @@ impl WopbsKey {
     /// ```rust
     /// use rand::Rng;
     /// use tfhe::shortint::gen_keys;
-    /// use tfhe::shortint::parameters::parameters_wopbs::WOPBS_PARAM_MESSAGE_3_NORM2_2_KS_PBS;
+    /// use tfhe::shortint::parameters::parameters_wopbs_message_carry::WOPBS_PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     /// use tfhe::shortint::wopbs::WopbsKey;
     ///
     /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(WOPBS_PARAM_MESSAGE_3_NORM2_2_KS_PBS);
+    /// let (cks, sks) = gen_keys(WOPBS_PARAM_MESSAGE_3_CARRY_3_KS_PBS);
     /// let wopbs_key = WopbsKey::new_wopbs_key_only_for_wopbs(&cks, &sks);
     /// let message_modulus = 5;
     /// let m = 2;
@@ -454,10 +454,10 @@ impl WopbsKey {
     ///
     /// ```rust
     /// use tfhe::shortint::gen_keys;
-    /// use tfhe::shortint::parameters::parameters_wopbs::WOPBS_PARAM_MESSAGE_3_NORM2_2_KS_PBS;
+    /// use tfhe::shortint::parameters::parameters_wopbs_message_carry::WOPBS_PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     /// use tfhe::shortint::wopbs::*;
     ///
-    /// let (cks, sks) = gen_keys(WOPBS_PARAM_MESSAGE_3_NORM2_2_KS_PBS);
+    /// let (cks, sks) = gen_keys(WOPBS_PARAM_MESSAGE_3_CARRY_3_KS_PBS);
     /// let wopbs_key = WopbsKey::new_wopbs_key_only_for_wopbs(&cks, &sks);
     /// let msg = 2;
     /// let modulus = 5;


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: https://github.com/zama-ai/tfhe-rs-internal/issues/5
closes: https://github.com/zama-ai/tfhe-rs-internal/issues/348

### PR content/description

The doctests were using parameters with too little precision, update to avoid flaky doctests