### PR TITLE
Fix Config builder `default()` method 

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ use tfhe::{generate_keys, set_server_key, ConfigBuilder, FheUint32, FheUint8};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Basic configuration to use homomorphic integers
-    let config = ConfigBuilder::default().build();
+    let config = ConfigBuilder::all_enabled();
 
     // Key generation
     let (client_key, server_keys) = generate_keys(config);


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description
It seems like `ConfigBuilder::default()` method is not available in the latest version of tfhe-rs. Instead `all_enabled()` could be used

### Check-list:

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [x] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
