### PR TITLE
fix(shortint): programmable_bootstrapping_native_crt could alter its input

### DIFF
--- a/tfhe/benches/shortint/bench.rs
+++ b/tfhe/benches/shortint/bench.rs
@@ -402,14 +402,14 @@ fn _bench_wopbs_param_message_8_norm2_5(c: &mut Criterion) {
     let mut rng = rand::thread_rng();
 
     let clear = rng.gen::<usize>() % param.message_modulus.0;
-    let mut ct = cks.encrypt_without_padding(clear as u64);
+    let ct = cks.encrypt_without_padding(clear as u64);
     let vec_lut = wopbs_key.generate_lut_native_crt(&ct, |x| x);
 
     let id = format!("Shortint WOPBS: {param:?}");
 
     bench_group.bench_function(&id, |b| {
         b.iter(|| {
-            let _ = wopbs_key.programmable_bootstrapping_native_crt(&mut ct, &vec_lut);
+            let _ = wopbs_key.programmable_bootstrapping_native_crt(&ct, &vec_lut);
         })
     });
 

--- a/tfhe/src/shortint/wopbs/test.rs
+++ b/tfhe/src/shortint/wopbs/test.rs
@@ -163,10 +163,10 @@ fn generate_lut_modulus_not_power_of_two(params: WopbsParameters) {
         let message_modulus = MessageModulus(params.message_modulus.0 - 1);
 
         let m = rng.gen::<usize>() % message_modulus.0;
-        let mut ct = cks.encrypt_native_crt(m as u64, message_modulus.0 as u8);
+        let ct = cks.encrypt_native_crt(m as u64, message_modulus.0 as u8);
         let lut = wopbs_key.generate_lut_native_crt(&ct, |x| (x * x) % message_modulus.0 as u64);
 
-        let ct_res = wopbs_key.programmable_bootstrapping_native_crt(&mut ct, &lut);
+        let ct_res = wopbs_key.programmable_bootstrapping_native_crt(&ct, &lut);
         let res = cks.decrypt_message_native_crt(&ct_res, message_modulus.0 as u8);
         assert_eq!(res as usize, (m * m) % message_modulus.0);
     }


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: https://github.com/zama-ai/tfhe-rs-internal/issues/354

### PR content/description

- the alteration is a trick to be able to perform the wopbs in the native crt mode but it modifies the input ciphertext and leaves it modified meaning that the input no longer represents the same data/encryption
- applying the functon several times likely would lead to incorrect results starting from the second call with increasing error/divergence from the original encrypted data
- clone locally instead, should be negligible given wopbs runtime

BREAKING CHANGE:
programmable_bootstrapping_native_crt signature has changed

### Check-list:

~* [ ] Tests for the changes have been added (for bug fixes / features)~
~* [ ] Docs have been added / updated (for bug fixes / features)~
* [x] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [x] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
