### PR TITLE
feat(integer): add decrypt_trivial

### DIFF
--- a/tfhe/src/integer/ciphertext/mod.rs
+++ b/tfhe/src/integer/ciphertext/mod.rs
@@ -5,6 +5,10 @@ use super::parameters::{
     RadixCiphertextConformanceParams, RadixCompactCiphertextListConformanceParams,
 };
 use crate::conformance::ParameterSetConformant;
+use crate::core_crypto::prelude::UnsignedNumeric;
+use crate::integer::block_decomposition::{BlockRecomposer, RecomposableFrom};
+use crate::integer::client_key::{sign_extend_partial_number, RecomposableSignedInteger};
+use crate::shortint::ciphertext::NotTrivialCiphertextError;
 use crate::shortint::{Ciphertext, CompressedCiphertext};
 use serde::{Deserialize, Serialize};
 
@@ -128,6 +132,69 @@ impl RadixCiphertext {
     pub fn block_carries_are_empty(&self) -> bool {
         self.blocks.iter().all(Ciphertext::carry_is_empty)
     }
+
+    pub fn is_trivial(&self) -> bool {
+        self.blocks.iter().all(Ciphertext::is_trivial)
+    }
+
+    /// Decrypts a trivial ciphertext
+    ///
+    /// Trivial ciphertexts are ciphertexts which are not encrypted
+    /// meaning they can be decrypted by any key, or even without a key.
+    ///
+    /// For debugging it can be useful to use trivial ciphertext to speed up
+    /// execution, and use [Self::decrypt_trivial] to decrypt temporary values
+    /// and debug.
+    ///
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use tfhe::integer::{gen_keys_radix, RadixCiphertext};
+    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    ///
+    /// // 8 bits
+    /// let (cks, sks) = gen_keys_radix(PARAM_MESSAGE_2_CARRY_2_KS_PBS, 4);
+    ///
+    /// let msg = 124u8;
+    /// let msg2 = 17u8;
+    ///
+    /// // Trivial encryption
+    /// let trivial_ct: RadixCiphertext = sks.create_trivial_radix(msg, 4);
+    /// let non_trivial_ct = cks.encrypt(msg2);
+    ///
+    /// let res = trivial_ct.decrypt_trivial();
+    /// assert_eq!(Ok(msg), res);
+    ///
+    /// let res = non_trivial_ct.decrypt_trivial::<u8>();
+    /// matches!(res, Err(_));
+    ///
+    /// // Doing operations that mixes trivial and non trivial
+    /// // will always return a non trivial
+    /// let ct_res = sks.add_parallelized(&trivial_ct, &non_trivial_ct);
+    /// let res = ct_res.decrypt_trivial::<u8>();
+    /// matches!(res, Err(_));
+    ///
+    /// // Doing operations using only trivial ciphertexts
+    /// // will return a trivial
+    /// let ct_res = sks.add_parallelized(&trivial_ct, &trivial_ct);
+    /// let res = ct_res.decrypt_trivial::<u8>();
+    /// assert_eq!(Ok(msg + msg), res);
+    /// ```
+    pub fn decrypt_trivial<Clear>(&self) -> Result<Clear, NotTrivialCiphertextError>
+    where
+        Clear: UnsignedNumeric + RecomposableFrom<u64>,
+    {
+        let bits_in_block = self.blocks[0].message_modulus.0.ilog2();
+        let mut recomposer = BlockRecomposer::<Clear>::new(bits_in_block);
+
+        for encrypted_block in &self.blocks {
+            let decrypted_block = encrypted_block.decrypt_trivial_message_and_carry()?;
+            recomposer.add_unmasked(decrypted_block);
+        }
+
+        Ok(recomposer.value())
+    }
 }
 
 /// Structure containing a ciphertext in radix decomposition
@@ -178,6 +245,71 @@ impl ParameterSetConformant for CompressedSignedRadixCiphertext {
 impl SignedRadixCiphertext {
     pub fn block_carries_are_empty(&self) -> bool {
         self.blocks.iter().all(Ciphertext::carry_is_empty)
+    }
+
+    pub fn is_trivial(&self) -> bool {
+        self.blocks.iter().all(Ciphertext::is_trivial)
+    }
+
+    /// Decrypts a trivial ciphertext
+    ///
+    /// Trivial ciphertexts are ciphertexts which are not encrypted
+    /// meaning they can be decrypted by any key, or even without a key.
+    ///
+    /// For debugging it can be useful to use trivial ciphertext to speed up
+    /// execution, and use [Self::decrypt_trivial] to decrypt temporary values
+    /// and debug.
+    ///
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use tfhe::integer::{gen_keys_radix, RadixCiphertext, SignedRadixCiphertext};
+    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    ///
+    /// // 8 bits
+    /// let (cks, sks) = gen_keys_radix(PARAM_MESSAGE_2_CARRY_2_KS_PBS, 4);
+    ///
+    /// let msg = -35i8;
+    /// let msg2 = 17i8;
+    ///
+    /// // Trivial encryption
+    /// let trivial_ct: SignedRadixCiphertext = sks.create_trivial_radix(msg, 4);
+    /// let non_trivial_ct = cks.encrypt_signed(msg2);
+    ///
+    /// let res = trivial_ct.decrypt_trivial();
+    /// assert_eq!(Ok(msg), res);
+    ///
+    /// let res = non_trivial_ct.decrypt_trivial::<i8>();
+    /// matches!(res, Err(_));
+    ///
+    /// // Doing operations that mixes trivial and non trivial
+    /// // will always return a non trivial
+    /// let ct_res = sks.add_parallelized(&trivial_ct, &non_trivial_ct);
+    /// let res = ct_res.decrypt_trivial::<i8>();
+    /// matches!(res, Err(_));
+    ///
+    /// // Doing operations using only trivial ciphertexts
+    /// // will return a trivial
+    /// let ct_res = sks.add_parallelized(&trivial_ct, &trivial_ct);
+    /// let res = ct_res.decrypt_trivial::<i8>();
+    /// assert_eq!(Ok(msg + msg), res);
+    /// ```
+    pub fn decrypt_trivial<Clear>(&self) -> Result<Clear, NotTrivialCiphertextError>
+    where
+        Clear: RecomposableSignedInteger,
+    {
+        let bits_in_block = self.blocks[0].message_modulus.0.ilog2();
+        let mut recomposer = BlockRecomposer::<Clear>::new(bits_in_block);
+
+        for encrypted_block in &self.blocks {
+            let decrypted_block = encrypted_block.decrypt_trivial_message_and_carry()?;
+            recomposer.add_unmasked(decrypted_block);
+        }
+
+        let num_bits_in_ctxt = bits_in_block * self.blocks.len() as u32;
+        let unpadded_value = recomposer.value();
+        Ok(sign_extend_partial_number(unpadded_value, num_bits_in_ctxt))
     }
 }
 impl From<CompressedSignedRadixCiphertext> for SignedRadixCiphertext {

--- a/tfhe/src/integer/client_key/mod.rs
+++ b/tfhe/src/integer/client_key/mod.rs
@@ -50,6 +50,35 @@ impl RecomposableSignedInteger for i128 {}
 
 impl<const N: usize> RecomposableSignedInteger for StaticSignedBigInt<N> {}
 
+/// This function takes a signed integer of type `T` for which `num_bits_set`
+/// have been set.
+///
+/// It will set the most significant bits to the value of the bit
+/// at pos `num_bits_set - 1`.
+///
+/// This is used to correctly decrypt a signed radix ciphertext into a clear type
+/// that has more bits than the original ciphertext.
+///
+/// This is like doing i8 as i16, i16 as i64, i6 as i8, etc
+pub(in crate::integer) fn sign_extend_partial_number<T>(unpadded_value: T, num_bits_set: u32) -> T
+where
+    T: RecomposableSignedInteger,
+{
+    if num_bits_set >= T::BITS as u32 {
+        return unpadded_value;
+    }
+
+    let sign_bit_pos = num_bits_set - 1;
+    let sign_bit_mask = T::cast_from(1u32 << sign_bit_pos);
+    let sign_bit = (unpadded_value & sign_bit_mask) >> sign_bit_pos;
+
+    // Creates a padding mask
+    // where bits above num_bits_set
+    // are 1s if sign bit is `1` else `0`
+    let padding = (T::MAX * sign_bit) << num_bits_set;
+    padding | unpadded_value
+}
+
 /// A structure containing the client key, which must be kept secret.
 ///
 /// This key can be used to encrypt both in Radix and CRT
@@ -391,19 +420,7 @@ impl ClientKey {
 
         let num_bits_in_message = message_modulus.ilog2();
         let num_bits_in_ctxt = num_bits_in_message * ctxt.blocks.len() as u32;
-        if num_bits_in_ctxt >= T::BITS as u32 {
-            return unpadded_value;
-        }
-
-        let sign_bit_pos = num_bits_in_ctxt - 1;
-        let sign_bit_mask = T::cast_from(1u32 << sign_bit_pos);
-        let sign_bit = (unpadded_value & sign_bit_mask) >> sign_bit_pos;
-
-        // Creates a padding mask
-        // where bits above num_bits_in_ctxt
-        // are 1s if sign bit is one else 0
-        let padding = (T::MAX * sign_bit) << num_bits_in_ctxt;
-        padding | unpadded_value
+        sign_extend_partial_number(unpadded_value, num_bits_in_ctxt)
     }
 
     /// Encrypts one block.


### PR DESCRIPTION
### PR content/description

This adds a decrypt_trivial method to all ciphertext types of shortint and integer.

This functions tries to "decrypt" the ciphertext if it is a trivial one, otherwise it return an error.

This is meant to be a debugging 'tool':

To debug a function / circuit, users can call the function on trivial ciphertexts intead of real ciphertext, that way, computations are faster _and_ they will now be able to see intermediate values via these decrypt_trivial, to do some print-debugging or use a debugger.

### Check-list:

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
