### PR TITLE
chore(core): freshen up native decomposition tests

### DIFF
--- a/tfhe/src/core_crypto/commons/math/decomposition/tests.rs
+++ b/tfhe/src/core_crypto/commons/math/decomposition/tests.rs
@@ -1,3 +1,4 @@
+use crate::core_crypto::algorithms::misc::divide_ceil;
 use crate::core_crypto::commons::ciphertext_modulus::CiphertextModulus;
 use crate::core_crypto::commons::math::decomposition::{
     SignedDecomposer, SignedDecomposerNonNative,
@@ -10,44 +11,57 @@ use crate::core_crypto::commons::test_tools::{any_uint, any_usize, random_usize_
 use crate::core_crypto::commons::traits::CastInto;
 use std::fmt::Debug;
 
-// Return a random decomposition valid for the size of the T type.
-fn random_decomp<T: UnsignedInteger>() -> SignedDecomposer<T> {
-    let mut base_log;
-    let mut level_count;
-    loop {
-        base_log = random_usize_between(2..T::BITS);
-        level_count = random_usize_between(2..T::BITS);
-        if base_log * level_count < T::BITS {
+fn valid_decomposers<T: UnsignedInteger>() -> Vec<SignedDecomposer<T>> {
+    let mut valid_decomposers = vec![];
+    for base_log in (1..T::BITS).map(DecompositionBaseLog) {
+        for level_count in (1..T::BITS).map(DecompositionLevelCount) {
+            if base_log.0 * level_count.0 < T::BITS {
+                valid_decomposers.push(SignedDecomposer::new(base_log, level_count));
+                continue;
+            }
+
+            // If the current base_log * level_count exceeds T::BITS then as level_count increases
+            // all the decomposers after it won't be valid, so break
             break;
         }
     }
-    SignedDecomposer::new(
-        DecompositionBaseLog(base_log),
-        DecompositionLevelCount(level_count),
-    )
+
+    valid_decomposers
 }
 
 fn test_decompose_recompose<T: UnsignedInteger + Debug + RandomGenerable<Uniform>>()
 where
     <T as UnsignedInteger>::Signed: Debug + SignedInteger,
 {
-    // Checks that the decomposing and recomposing a value brings the closest representable
-    for _ in 0..100_000 {
-        let decomposer = random_decomp::<T>();
-        let input = any_uint::<T>();
-        for term in decomposer.decompose(input) {
-            assert!(1 <= term.level().0);
-            assert!(term.level().0 <= decomposer.level_count);
-            let signed_term = term.value().into_signed();
-            let half_basis = (T::Signed::ONE << decomposer.base_log) / T::TWO.into_signed();
-            assert!(-half_basis <= signed_term);
-            assert!(signed_term <= half_basis);
+    let valid_decomposers = valid_decomposers::<T>();
+    let runs_per_decomposer = divide_ceil(100_000, valid_decomposers.len());
+
+    for decomposer in valid_decomposers {
+        for _ in 0..runs_per_decomposer {
+            let input = any_uint::<T>();
+
+            // Decompose/recompose test
+            for (term_idx, term) in decomposer.decompose(input).enumerate() {
+                assert_eq!(term.level().0, decomposer.level_count - term_idx);
+                let signed_term = term.value().into_signed();
+                // Shift by base_log - 1 directly to avoid overflows
+                let half_basis = T::Signed::ONE << (decomposer.base_log - 1);
+                assert!(
+                    -half_basis <= signed_term,
+                    "-half_basis={:?}, signed_term = {signed_term:?}",
+                    -half_basis,
+                );
+                assert!(
+                    signed_term <= half_basis,
+                    "signed_term={signed_term:?}, half_basis = {half_basis:?}",
+                );
+            }
+            let closest = decomposer.closest_representable(input);
+            assert_eq!(
+                closest,
+                decomposer.recompose(decomposer.decompose(input)).unwrap()
+            );
         }
-        let closest = decomposer.closest_representable(input);
-        assert_eq!(
-            closest,
-            decomposer.recompose(decomposer.decompose(closest)).unwrap()
-        );
     }
 }
 
@@ -62,32 +76,28 @@ fn test_decompose_recompose_u64() {
 }
 
 fn test_round_to_closest_representable<T: UnsignedTorus>() {
-    for _ in 0..1000 {
-        let log_b = any_usize();
-        let level_max = any_usize();
-        let val = any_uint::<T>();
-        let delta = any_uint::<T>();
-        let bits = T::BITS;
-        let log_b = (log_b % ((bits / 4) - 1)) + 1;
-        let level_max = (level_max % 4) + 1;
-        let bit: usize = log_b * level_max;
+    let valid_decomposers = valid_decomposers::<T>();
+    let runs_per_decomposer = divide_ceil(100_000, valid_decomposers.len());
 
-        let val = val << (bits - bit);
-        let delta = delta >> (bit + 1);
+    // Checks that the decomposing and recomposing a value brings the closest representable
+    for decomposer in valid_decomposers {
+        for _ in 0..runs_per_decomposer {
+            let input = any_uint::<T>();
 
-        let decomposer = SignedDecomposer::new(
-            DecompositionBaseLog(log_b),
-            DecompositionLevelCount(level_max),
-        );
+            let rounded = decomposer.closest_representable(input);
 
-        assert_eq!(
-            val,
-            decomposer.closest_representable(val.wrapping_add(delta))
-        );
-        assert_eq!(
-            val,
-            decomposer.closest_representable(val.wrapping_sub(delta))
-        );
+            let epsilon =
+                (T::ONE << (T::BITS - (decomposer.base_log * decomposer.level_count) - 1)) / T::TWO;
+            // Adding/removing an epsilon should not change the closest representable
+            assert_eq!(
+                rounded,
+                decomposer.closest_representable(rounded.wrapping_add(epsilon))
+            );
+            assert_eq!(
+                rounded,
+                decomposer.closest_representable(rounded.wrapping_sub(epsilon))
+            );
+        }
     }
 }
 
@@ -102,13 +112,18 @@ fn test_round_to_closest_representable_u64() {
 }
 
 fn test_round_to_closest_twice<T: UnsignedTorus + Debug>() {
-    for _ in 0..1000 {
-        let decomp = random_decomp();
-        let input: T = any_uint();
+    let valid_decomposers = valid_decomposers::<T>();
+    let runs_per_decomposer = divide_ceil(100_000, valid_decomposers.len());
 
-        let rounded_once = decomp.closest_representable(input);
-        let rounded_twice = decomp.closest_representable(rounded_once);
-        assert_eq!(rounded_once, rounded_twice);
+    for decomposer in valid_decomposers {
+        for _ in 0..runs_per_decomposer {
+            let input = any_uint::<T>();
+
+            // Round twice test, should not change the returned value
+            let rounded_once = decomposer.closest_representable(input);
+            let rounded_twice = decomposer.closest_representable(rounded_once);
+            assert_eq!(rounded_once, rounded_twice);
+        }
     }
 }
 
@@ -129,8 +144,8 @@ fn random_decomp_non_native<T: UnsignedInteger>(
     let mut base_log;
     let mut level_count;
     loop {
-        base_log = random_usize_between(2..T::BITS);
-        level_count = random_usize_between(2..T::BITS);
+        base_log = random_usize_between(1..T::BITS);
+        level_count = random_usize_between(1..T::BITS);
         if base_log * level_count < T::BITS {
             break;
         }


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
### PR content/description

- the classic native decomposer results are exact and there aren't that many cases to test so tests are changed to be exhaustive
- non native currently still has some work in progress parts so won't be made exhaustive right away, additionally the next PR for the prime Q effort will make some changes to it, so this is why the current code has not been touched for the non native decomposer

This is a preparatory commit to re-organize the native decomposer tests, the non native have not been touched in this PR as the next commit for the prime Q effort will modify them, so no value in updating it for now, plus the prime Q stuff still has some rough edges and so tests are not transposable 1:1
