### PR TITLE
chore(core_crypto): disable seeded entities for non power of 2 moduli

### DIFF
--- a/tfhe/src/core_crypto/algorithms/test/lwe_encryption.rs
+++ b/tfhe/src/core_crypto/algorithms/test/lwe_encryption.rs
@@ -134,7 +134,6 @@ fn parallel_and_seeded_lwe_list_encryption_equivalence<Scalar: UnsignedTorus + S
 create_parametrized_test!(parallel_and_seeded_lwe_list_encryption_equivalence {
     TEST_PARAMS_4_BITS_NATIVE_U64,
     TEST_PARAMS_3_BITS_63_U64,
-    TEST_PARAMS_3_BITS_SOLINAS_U64,
     DUMMY_NATIVE_U32,
     DUMMY_31_U32,
 });
@@ -635,7 +634,7 @@ fn lwe_seeded_public_encrypt_decrypt_custom_mod<Scalar: UnsignedTorus>(
     }
 }
 
-create_parametrized_test_with_non_native_parameters!(lwe_seeded_public_encrypt_decrypt_custom_mod);
+create_parametrized_test!(lwe_seeded_public_encrypt_decrypt_custom_mod);
 
 fn lwe_seeded_list_par_encrypt_decrypt_custom_mod<Scalar: UnsignedTorus + Sync + Send>(
     params: ClassicTestParams<Scalar>,
@@ -718,9 +717,7 @@ fn lwe_seeded_list_par_encrypt_decrypt_custom_mod<Scalar: UnsignedTorus + Sync +
     }
 }
 
-create_parametrized_test_with_non_native_parameters!(
-    lwe_seeded_list_par_encrypt_decrypt_custom_mod
-);
+create_parametrized_test!(lwe_seeded_list_par_encrypt_decrypt_custom_mod);
 
 fn lwe_seeded_encrypt_decrypt_custom_mod<Scalar: UnsignedTorus>(params: ClassicTestParams<Scalar>) {
     let lwe_dimension = params.lwe_dimension;

--- a/tfhe/src/core_crypto/entities/seeded_ggsw_ciphertext.rs
+++ b/tfhe/src/core_crypto/entities/seeded_ggsw_ciphertext.rs
@@ -147,6 +147,11 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> SeededGgswCipherte
         ciphertext_modulus: CiphertextModulus<C::Element>,
     ) -> Self {
         assert!(
+            ciphertext_modulus.is_compatible_with_native_modulus(),
+            "Seeded entities are not yet compatible with non power of 2 moduli."
+        );
+
+        assert!(
             container.container_len() > 0,
             "Got an empty container to create a SeededGgswCiphertext"
         );
@@ -474,6 +479,11 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> SeededGgswLevelMat
         compression_seed: CompressionSeed,
         ciphertext_modulus: CiphertextModulus<C::Element>,
     ) -> Self {
+        assert!(
+            ciphertext_modulus.is_compatible_with_native_modulus(),
+            "Seeded entities are not yet compatible with non power of 2 moduli."
+        );
+
         assert!(
             container.container_len() == seeded_ggsw_level_matrix_size(glwe_size, polynomial_size),
             "The provided container length is not valid. \

--- a/tfhe/src/core_crypto/entities/seeded_ggsw_ciphertext_list.rs
+++ b/tfhe/src/core_crypto/entities/seeded_ggsw_ciphertext_list.rs
@@ -127,6 +127,11 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> SeededGgswCipherte
         ciphertext_modulus: CiphertextModulus<C::Element>,
     ) -> Self {
         assert!(
+            ciphertext_modulus.is_compatible_with_native_modulus(),
+            "Seeded entities are not yet compatible with non power of 2 moduli."
+        );
+
+        assert!(
             container.container_len() % (decomp_level_count.0 * glwe_size.0 * polynomial_size.0)
                 == 0,
             "The provided container length is not valid. \

--- a/tfhe/src/core_crypto/entities/seeded_glwe_ciphertext.rs
+++ b/tfhe/src/core_crypto/entities/seeded_glwe_ciphertext.rs
@@ -123,6 +123,11 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> SeededGlweCipherte
         ciphertext_modulus: CiphertextModulus<C::Element>,
     ) -> Self {
         assert!(
+            ciphertext_modulus.is_compatible_with_native_modulus(),
+            "Seeded entities are not yet compatible with non power of 2 moduli."
+        );
+
+        assert!(
             container.container_len() > 0,
             "Got an empty container to create a SeededGlweCiphertext"
         );

--- a/tfhe/src/core_crypto/entities/seeded_glwe_ciphertext_list.rs
+++ b/tfhe/src/core_crypto/entities/seeded_glwe_ciphertext_list.rs
@@ -113,6 +113,11 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> SeededGlweCipherte
         compression_seed: CompressionSeed,
         ciphertext_modulus: CiphertextModulus<C::Element>,
     ) -> Self {
+        assert!(
+            ciphertext_modulus.is_compatible_with_native_modulus(),
+            "Seeded entities are not yet compatible with non power of 2 moduli."
+        );
+
         Self {
             data: container,
             glwe_size,

--- a/tfhe/src/core_crypto/entities/seeded_lwe_bootstrap_key.rs
+++ b/tfhe/src/core_crypto/entities/seeded_lwe_bootstrap_key.rs
@@ -153,6 +153,11 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> SeededLweBootstrap
         compression_seed: CompressionSeed,
         ciphertext_modulus: CiphertextModulus<C::Element>,
     ) -> Self {
+        assert!(
+            ciphertext_modulus.is_compatible_with_native_modulus(),
+            "Seeded entities are not yet compatible with non power of 2 moduli."
+        );
+
         Self {
             ggsw_list: SeededGgswCiphertextList::from_container(
                 container,

--- a/tfhe/src/core_crypto/entities/seeded_lwe_ciphertext_list.rs
+++ b/tfhe/src/core_crypto/entities/seeded_lwe_ciphertext_list.rs
@@ -100,6 +100,11 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> SeededLweCiphertex
         compression_seed: CompressionSeed,
         ciphertext_modulus: CiphertextModulus<C::Element>,
     ) -> Self {
+        assert!(
+            ciphertext_modulus.is_compatible_with_native_modulus(),
+            "Seeded entities are not yet compatible with non power of 2 moduli."
+        );
+
         Self {
             data: container,
             lwe_size,

--- a/tfhe/src/core_crypto/entities/seeded_lwe_compact_public_key.rs
+++ b/tfhe/src/core_crypto/entities/seeded_lwe_compact_public_key.rs
@@ -102,6 +102,11 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> SeededLweCompactPu
         ciphertext_modulus: CiphertextModulus<Scalar>,
     ) -> Self {
         assert!(
+            ciphertext_modulus.is_compatible_with_native_modulus(),
+            "Seeded entities are not yet compatible with non power of 2 moduli."
+        );
+
+        assert!(
             container.container_len().is_power_of_two(),
             "SeededLweCompactPublicKey container len must be a power of 2, got len = {}",
             container.container_len()

--- a/tfhe/src/core_crypto/entities/seeded_lwe_keyswitch_key.rs
+++ b/tfhe/src/core_crypto/entities/seeded_lwe_keyswitch_key.rs
@@ -136,6 +136,11 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> SeededLweKeyswitch
         ciphertext_modulus: CiphertextModulus<C::Element>,
     ) -> Self {
         assert!(
+            ciphertext_modulus.is_compatible_with_native_modulus(),
+            "Seeded entities are not yet compatible with non power of 2 moduli."
+        );
+
+        assert!(
             container.container_len() > 0,
             "Got an empty container to create an SeededLweKeyswitchKey"
         );

--- a/tfhe/src/core_crypto/entities/seeded_lwe_multi_bit_bootstrap_key.rs
+++ b/tfhe/src/core_crypto/entities/seeded_lwe_multi_bit_bootstrap_key.rs
@@ -175,6 +175,11 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> SeededLweMultiBitB
         grouping_factor: LweBskGroupingFactor,
         ciphertext_modulus: CiphertextModulus<C::Element>,
     ) -> Self {
+        assert!(
+            ciphertext_modulus.is_compatible_with_native_modulus(),
+            "Seeded entities are not yet compatible with non power of 2 moduli."
+        );
+
         let bsk = Self {
             ggsw_list: SeededGgswCiphertextList::from_container(
                 container,

--- a/tfhe/src/core_crypto/entities/seeded_lwe_packing_keyswitch_key.rs
+++ b/tfhe/src/core_crypto/entities/seeded_lwe_packing_keyswitch_key.rs
@@ -160,6 +160,11 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> SeededLwePackingKe
         ciphertext_modulus: CiphertextModulus<C::Element>,
     ) -> Self {
         assert!(
+            ciphertext_modulus.is_compatible_with_native_modulus(),
+            "Seeded entities are not yet compatible with non power of 2 moduli."
+        );
+
+        assert!(
             container.container_len() > 0,
             "Got an empty container to create an SeededLwePackingKeyswitchKey"
         );

--- a/tfhe/src/core_crypto/entities/seeded_lwe_public_key.rs
+++ b/tfhe/src/core_crypto/entities/seeded_lwe_public_key.rs
@@ -136,6 +136,11 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> SeededLwePublicKey
         ciphertext_modulus: CiphertextModulus<C::Element>,
     ) -> Self {
         assert!(
+            ciphertext_modulus.is_compatible_with_native_modulus(),
+            "Seeded entities are not yet compatible with non power of 2 moduli."
+        );
+
+        assert!(
             container.container_len() > 0,
             "Got an empty container to create a SeededLwePublicKey"
         );


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
### PR content/description

- as random uniform generation has rejection sampling for non native moduli the seeded decompression currently does not work as it allocates just enough bytes for a native integer and not for the various retries which may be needed
- follow-up issue: https://github.com/zama-ai/tfhe-rs-internal/issues/358
