### PR TITLE
chore(integer): simplify an API to create a ServerKey from a shortint one

### DIFF
--- a/tfhe/src/integer/keycache.rs
+++ b/tfhe/src/integer/keycache.rs
@@ -18,11 +18,9 @@ impl IntegerKeyCache {
         let client_key = ClientKey::from(client_key.clone());
         let server_key = match key_kind {
             IntegerKeyKind::Radix => {
-                ServerKey::new_radix_server_key_from_shortint(&client_key, server_key.clone())
+                ServerKey::new_radix_server_key_from_shortint(server_key.clone())
             }
-            IntegerKeyKind::CRT => {
-                ServerKey::new_crt_server_key_from_shortint(&client_key, server_key.clone())
-            }
+            IntegerKeyKind::CRT => ServerKey::new_crt_server_key_from_shortint(server_key.clone()),
         };
 
         (client_key, server_key)


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
### PR content/description

- the API required passing the client_key to get access to the message and carry modulus, as the shortint ServerKey already has that information drop the requirement to pass the ClientKey

BREAKING CHANGE:
new_radix_server_key_from_shortint, new_crt_server_key_from_shortint APIs have changed and no longer require a ClienKey, the max degree methods now only take a MessageModulus and CarryModulus instead of the full parameter set

### Check-list:

~~* [ ] Tests for the changes have been added (for bug fixes / features)~~
* [x] Docs have been added / updated (for bug fixes / features)
~~* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description~~
* [x] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
