### PR TITLE
style(docs): fixing a few typos in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ running Windows:
 tfhe = { version = "*", features = ["boolean", "shortint", "integer", "x86_64"] }
 ```
 
-Note: aarch64-based machines are not yet supported for Windows as it's currently missing an entropy source to be able to seed the [CSPRNGs](https://en.wikipedia.org/wiki/Cryptographically_secure_pseudorandom_number_generator) used in TFHE-rs
+Note: aarch64-based machines are not yet supported for Windows as it's currently missing an entropy source to be able to seed the [CSPRNGs](https://en.wikipedia.org/wiki/Cryptographically_secure_pseudorandom_number_generator) used in TFHE-rs.
 
 
 ## A simple example
@@ -118,7 +118,7 @@ To run this code, use the following command:
 <p align="center"> <code> cargo run --release </code> </p>
 
 Note that when running code that uses `tfhe-rs`, it is highly recommended
-to run in release mode with cargo's `--release` flag to have the best performances possible,
+to run in release mode with cargo's `--release` flag to have the best performances possible.
 
 
 ## Contributing


### PR DESCRIPTION
I have seen a few typos in the README while having a look. Sorry, I don't know all your conformance tools, so I might miss a few conventions.