### PR TITLE
doc(tfhe): add doc page about data migration which will redirect to 0.4 doc

### DIFF
--- a/tfhe/docs/SUMMARY.md
+++ b/tfhe/docs/SUMMARY.md
@@ -16,6 +16,7 @@
 ## How To
 * [Configure Rust](how_to/rust_configuration.md)
 * [Serialize/Deserialize](how_to/serialization.md)
+* [Migrate Data to Newer Versions of TFHE-rs](how_to/migrate_data.md)
 * [Compress Ciphertexts/Keys](how_to/compress.md)
 * [Use Public Key Encryption](how_to/public_key.md)
 * [Use Trivial Ciphertext](how_to/trivial_ciphertext.md)

--- a/tfhe/docs/how_to/migrate_data.md
+++ b/tfhe/docs/how_to/migrate_data.md
@@ -1,0 +1,3 @@
+# Migrating Data to TFHE-rs 0.5.0 (This Release)
+
+Forward compatibility code to migrate data from TFHE-rs 0.4 to TFHE-rs 0.5 has been added in a minor release of TFHE-rs 0.4, the documentation about the process can be found [here](https://docs.zama.ai/tfhe-rs/0.4-1/how-to/migrate_data).


### PR DESCRIPTION
Preparing the terrain for redirecting to 0.4 documentation about data migration as 0.5 does not have code to handle that itself