### PR TITLE
chore(core_crypto): remove Serde on some decomposition structs

### DIFF
--- a/tfhe/src/core_crypto/commons/math/decomposition/mod.rs
+++ b/tfhe/src/core_crypto/commons/math/decomposition/mod.rs
@@ -19,8 +19,6 @@
 //! located in the least significant bits, which are already erroneous.
 use std::fmt::Debug;
 
-use serde::{Deserialize, Serialize};
-
 pub use decomposer::*;
 pub use iter::*;
 pub use term::*;
@@ -35,5 +33,5 @@ mod tests;
 ///
 /// When decomposing an integer over the $l$ levels, this type represent the level (in $[0,l)$)
 /// currently manipulated.
-#[derive(Debug, PartialEq, Eq, Copy, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub struct DecompositionLevel(pub usize);

--- a/tfhe/src/core_crypto/commons/math/decomposition/term.rs
+++ b/tfhe/src/core_crypto/commons/math/decomposition/term.rs
@@ -2,14 +2,13 @@ use crate::core_crypto::commons::ciphertext_modulus::CiphertextModulus;
 use crate::core_crypto::commons::math::decomposition::DecompositionLevel;
 use crate::core_crypto::commons::numeric::{Numeric, UnsignedInteger};
 use crate::core_crypto::commons::parameters::DecompositionBaseLog;
-use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 
 /// A member of the decomposition.
 ///
 /// If we decompose a value $\theta$ as a sum $\sum\_{i=1}^l\tilde{\theta}\_i\frac{q}{B^i}$, this
 /// represents a $\tilde{\theta}\_i$.
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct DecompositionTerm<T>
 where
     T: UnsignedInteger,
@@ -93,7 +92,7 @@ where
 ///
 /// If we decompose a value $\theta$ as a sum $\sum\_{i=1}^l\tilde{\theta}\_i\frac{q}{B^i}$, this
 /// represents a $\tilde{\theta}\_i$.
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct DecompositionTermNonNative<T>
 where
     T: UnsignedInteger,


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
### PR content/description

- those structures are not expected to be serialized by a user

clean up a bit given what was found during the semver trick exploration