### PR TITLE
chore(ci): gather common benchmarks groups

### DIFF
--- a/.github/workflows/integer_full_benchmark.yml
+++ b/.github/workflows/integer_full_benchmark.yml
@@ -39,15 +39,12 @@ jobs:
       - name: Weekly benchmarks
         if: ${{ github.event.inputs.user_inputs == 'weekly_benchmarks' }}
         run: |
-          echo "OP_FLAVOR=[\"default\", \"default_comp\", \"default_scalar\", \"default_scalar_comp\"]" >> ${GITHUB_ENV}
+          echo "OP_FLAVOR=[\"default\"]" >> ${GITHUB_ENV}
 
       - name: Quarterly benchmarks
         if: ${{ github.event.inputs.user_inputs == 'quarterly_benchmarks' }}
         run: |
-          echo "OP_FLAVOR=[\"default\", \"default_comp\", \"default_scalar\", \"default_scalar_comp\", \
-          \"smart\", \"smart_comp\", \"smart_scalar\", \"smart_parallelized\", \"smart_parallelized_comp\", \"smart_scalar_parallelized\", \"smart_scalar_parallelized_comp\", \
-          \"unchecked\", \"unchecked_comp\", \"unchecked_scalar\", \"unchecked_scalar_comp\", \
-          \"misc\"]" >> ${GITHUB_ENV}
+          echo "OP_FLAVOR=[\"default\", \"smart\", \"unchecked\", \"misc\"]" >> ${GITHUB_ENV}
 
       -  name: Set operation flavor output
          id: set_op_flavor
@@ -60,6 +57,7 @@ jobs:
     runs-on: ${{ github.event.inputs.runner_name }}
     if: ${{ !cancelled() }}
     continue-on-error: true
+    timeout-minutes: 1440  # 24 hours
     strategy:
       max-parallel: 1
       matrix:

--- a/.github/workflows/signed_integer_full_benchmark.yml
+++ b/.github/workflows/signed_integer_full_benchmark.yml
@@ -35,12 +35,12 @@ jobs:
     runs-on: ${{ github.event.inputs.runner_name }}
     if: ${{ !cancelled() }}
     continue-on-error: true
+    timeout-minutes: 1440  # 24 hours
     strategy:
       max-parallel: 1
       matrix:
         command: [ integer, integer_multi_bit ]
-        op_flavor: [ default, default_comp, default_scalar, default_scalar_comp,
-                     unchecked, unchecked_comp, unchecked_scalar, unchecked_scalar_comp ]
+        op_flavor: [ default, unchecked ]
     steps:
       - name: Instance configuration used
         run: |

--- a/tfhe/benches/integer/bench.rs
+++ b/tfhe/benches/integer/bench.rs
@@ -1373,29 +1373,37 @@ fn main() {
     match env::var("__TFHE_RS_BENCH_OP_FLAVOR") {
         Ok(val) => {
             match val.to_lowercase().as_str() {
-                "default" => default_parallelized_ops(),
-                "default_comp" => default_parallelized_ops_comp(),
-                "default_scalar" => default_scalar_parallelized_ops(),
-                "default_scalar_comp" => default_scalar_parallelized_ops_comp(),
-                "smart" => smart_ops(),
-                "smart_comp" => smart_ops_comp(),
-                "smart_scalar" => smart_scalar_ops(),
-                "smart_parallelized" => smart_parallelized_ops(),
-                "smart_parallelized_comp" => smart_parallelized_ops_comp(),
-                "smart_scalar_parallelized" => smart_scalar_parallelized_ops(),
-                "smart_scalar_parallelized_comp" => smart_scalar_parallelized_ops_comp(),
-                "unchecked" => unchecked_ops(),
-                "unchecked_parallelized" => unchecked_parallelized_ops(),
-                "unchecked_comp" => unchecked_ops_comp(),
-                "unchecked_scalar" => unchecked_scalar_ops(),
-                "unchecked_scalar_comp" => unchecked_scalar_ops_comp(),
+                "default" => {
+                    default_parallelized_ops();
+                    default_parallelized_ops_comp();
+                    default_scalar_parallelized_ops();
+                    default_scalar_parallelized_ops_comp()
+                }
+                "smart" => {
+                    smart_ops();
+                    smart_ops_comp();
+                    smart_scalar_ops();
+                    smart_parallelized_ops();
+                    smart_parallelized_ops_comp();
+                    smart_scalar_parallelized_ops();
+                    smart_scalar_parallelized_ops_comp()
+                }
+                "unchecked" => {
+                    unchecked_ops();
+                    unchecked_parallelized_ops();
+                    unchecked_ops_comp();
+                    unchecked_scalar_ops();
+                    unchecked_scalar_ops_comp()
+                }
                 "misc" => misc(),
                 _ => panic!("unknown benchmark operations flavor"),
             };
         }
         Err(_) => {
             default_parallelized_ops();
-            default_scalar_parallelized_ops()
+            default_parallelized_ops_comp();
+            default_scalar_parallelized_ops();
+            default_scalar_parallelized_ops_comp()
         }
     };
 

--- a/tfhe/benches/integer/signed_bench.rs
+++ b/tfhe/benches/integer/signed_bench.rs
@@ -1124,14 +1124,18 @@ fn main() {
     match env::var("__TFHE_RS_BENCH_OP_FLAVOR") {
         Ok(val) => {
             match val.to_lowercase().as_str() {
-                "default" => default_parallelized_ops(),
-                "default_comp" => default_parallelized_ops_comp(),
-                "default_scalar" => default_scalar_parallelized_ops(),
-                "default_scalar_comp" => default_scalar_parallelized_ops_comp(),
-                "unchecked" => unchecked_ops(),
-                "unchecked_comp" => unchecked_ops_comp(),
-                "unchecked_scalar" => unchecked_scalar_ops(),
-                "unchecked_scalar_comp" => unchecked_scalar_ops_comp(),
+                "default" => {
+                    default_parallelized_ops();
+                    default_parallelized_ops_comp();
+                    default_scalar_parallelized_ops();
+                    default_scalar_parallelized_ops_comp()
+                }
+                "unchecked" => {
+                    unchecked_ops();
+                    unchecked_ops_comp();
+                    unchecked_scalar_ops();
+                    unchecked_scalar_ops_comp()
+                }
                 _ => panic!("unknown benchmark operations flavor"),
             };
         }


### PR DESCRIPTION
Instead of having multiple BENCH_OP_FLAVOR to run for full benchmarks, criterion groups are now gathered by operation kind (default, smart, unchecked).
