### PR TITLE
fix(integer): is_scalar_out_of_bounds handles bigger ct

### DIFF
--- a/tfhe/src/integer/server_key/radix_parallel/scalar_comparison.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/scalar_comparison.rs
@@ -1,4 +1,3 @@
-// use itertools::Itertools;
 use super::ServerKey;
 
 use crate::integer::block_decomposition::{BlockDecomposer, DecomposableInto};
@@ -55,6 +54,11 @@ impl ServerKey {
             } else if scalar < Scalar::ZERO {
                 // If scalar is negative, and that any bits above the ct's n-1 bits is not set
                 // it means scalar is smaller.
+
+                if ct.blocks().len() > scalar_blocks.len() {
+                    // Ciphertext has more blocks, the scalar may be in range
+                    return None;
+                }
 
                 // (returns false for empty iter)
                 let at_least_one_block_is_not_full_of_1s = scalar_blocks[ct.blocks().len()..]


### PR DESCRIPTION
Fix a bug where in is_scalar_out_of_bounds, if the scalar was negative and the ciphertext a signed one with more blocks than the decomposed scalar, we would do an out of bound access (i.e a panic).

This fixes that, this will fix doing signed_overflowing_mul on 256 bits where the bug first appeared

### Check-list:

* [x] Tests for the changes have been added (for bug fixes / features)
