### PR TITLE
fix(core): ignore value in the body when doing LWE encryption

### DIFF
--- a/tfhe/src/core_crypto/algorithms/lwe_encryption.rs
+++ b/tfhe/src/core_crypto/algorithms/lwe_encryption.rs
@@ -94,10 +94,8 @@ pub fn fill_lwe_mask_and_body_for_encryption_native_mod_compatible<
     // generate an error from the normal distribution described by std_dev
     let noise = generator.random_noise_custom_mod(noise_parameters, ciphertext_modulus);
     // compute the multisum between the secret key and the mask
-    let mask_key_dot_product = (*output_body.data).wrapping_add(slice_wrapping_dot_product(
-        output_mask.as_ref(),
-        lwe_secret_key.as_ref(),
-    ));
+    let mask_key_dot_product =
+        slice_wrapping_dot_product(output_mask.as_ref(), lwe_secret_key.as_ref());
 
     // Store sum(ai * si) + delta * m + e in the body
     *output_body.data = mask_key_dot_product


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
### PR content/description

- update tests to have non zero values in structures to avoid depending on the initialization of the structs

### Check-list:

* [x] Tests for the changes have been added (for bug fixes / features)
~~* [ ] Docs have been added / updated (for bug fixes / features)~~
~~* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description~~
~~* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]~~

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
