### PR TITLE
Fix cuda_drop binding, mark async functions unsafe

### DIFF
--- a/backends/tfhe-cuda-backend/src/cuda_bind.rs
+++ b/backends/tfhe-cuda-backend/src/cuda_bind.rs
@@ -61,7 +61,7 @@ extern "C" {
     pub fn cuda_drop_async(ptr: *mut c_void, v_stream: *const c_void) -> i32;
 
     /// Free memory for pointer `ptr` on GPU `gpu_index` synchronously
-    pub fn cuda_drop(ptr: *mut c_void) -> i32;
+    pub fn cuda_drop(ptr: *mut c_void, gpu_index: u32) -> i32;
 
     /// Get the maximum amount of shared memory on GPU `gpu_index`
     pub fn cuda_get_max_shared_memory(gpu_index: u32) -> i32;

--- a/tfhe/src/core_crypto/gpu/algorithms/lwe_multi_bit_programmable_bootstrapping.rs
+++ b/tfhe/src/core_crypto/gpu/algorithms/lwe_multi_bit_programmable_bootstrapping.rs
@@ -120,4 +120,5 @@ pub fn cuda_multi_bit_programmable_bootstrap_lwe_ciphertext<Scalar>(
             stream,
         );
     }
+    stream.synchronize();
 }

--- a/tfhe/src/core_crypto/gpu/algorithms/lwe_programmable_bootstrapping.rs
+++ b/tfhe/src/core_crypto/gpu/algorithms/lwe_programmable_bootstrapping.rs
@@ -78,4 +78,5 @@ pub fn cuda_programmable_bootstrap_lwe_ciphertext<Scalar>(
             stream,
         );
     }
+    stream.synchronize();
 }

--- a/tfhe/src/core_crypto/gpu/algorithms/test/lwe_keyswitch.rs
+++ b/tfhe/src/core_crypto/gpu/algorithms/test/lwe_keyswitch.rs
@@ -90,10 +90,10 @@ fn lwe_encrypt_ks_decrypt_custom_mod<Scalar: UnsignedTorus + CastFrom<usize>>(
                 .iter()
                 .map(|&x| <usize as CastInto<Scalar>>::cast_into(x))
                 .collect_vec();
-            let mut d_input_indexes = stream.malloc_async::<Scalar>(num_blocks as u32);
-            let mut d_output_indexes = stream.malloc_async::<Scalar>(num_blocks as u32);
-            stream.copy_to_gpu_async(&mut d_input_indexes, &lwe_indexes);
-            stream.copy_to_gpu_async(&mut d_output_indexes, &lwe_indexes);
+            let mut d_input_indexes = unsafe { stream.malloc_async::<Scalar>(num_blocks as u32) };
+            let mut d_output_indexes = unsafe { stream.malloc_async::<Scalar>(num_blocks as u32) };
+            unsafe { stream.copy_to_gpu_async(&mut d_input_indexes, &lwe_indexes) };
+            unsafe { stream.copy_to_gpu_async(&mut d_output_indexes, &lwe_indexes) };
 
             cuda_keyswitch_lwe_ciphertext(
                 &d_ksk_big_to_small,

--- a/tfhe/src/core_crypto/gpu/algorithms/test/lwe_multi_bit_programmable_bootstrapping.rs
+++ b/tfhe/src/core_crypto/gpu/algorithms/test/lwe_multi_bit_programmable_bootstrapping.rs
@@ -145,8 +145,8 @@ fn lwe_encrypt_multi_bit_pbs_decrypt_custom_mod<
             }
 
             let mut d_test_vector_indexes =
-                stream.malloc_async::<Scalar>(number_of_messages as u32);
-            stream.copy_to_gpu_async(&mut d_test_vector_indexes, &test_vector_indexes);
+                unsafe { stream.malloc_async::<Scalar>(number_of_messages as u32) };
+            unsafe { stream.copy_to_gpu_async(&mut d_test_vector_indexes, &test_vector_indexes) };
 
             let num_blocks = d_lwe_ciphertext_in.0.lwe_ciphertext_count.0;
             let lwe_indexes_usize: Vec<usize> = (0..num_blocks).collect_vec();
@@ -154,10 +154,12 @@ fn lwe_encrypt_multi_bit_pbs_decrypt_custom_mod<
                 .iter()
                 .map(|&x| <usize as CastInto<Scalar>>::cast_into(x))
                 .collect_vec();
-            let mut d_output_indexes = stream.malloc_async::<Scalar>(num_blocks as u32);
-            let mut d_input_indexes = stream.malloc_async::<Scalar>(num_blocks as u32);
-            stream.copy_to_gpu_async(&mut d_output_indexes, &lwe_indexes);
-            stream.copy_to_gpu_async(&mut d_input_indexes, &lwe_indexes);
+            let mut d_output_indexes = unsafe { stream.malloc_async::<Scalar>(num_blocks as u32) };
+            let mut d_input_indexes = unsafe { stream.malloc_async::<Scalar>(num_blocks as u32) };
+            unsafe {
+                stream.copy_to_gpu_async(&mut d_output_indexes, &lwe_indexes);
+                stream.copy_to_gpu_async(&mut d_input_indexes, &lwe_indexes);
+            }
 
             cuda_multi_bit_programmable_bootstrap_lwe_ciphertext(
                 &d_lwe_ciphertext_in,

--- a/tfhe/src/core_crypto/gpu/algorithms/test/lwe_programmable_bootstrapping.rs
+++ b/tfhe/src/core_crypto/gpu/algorithms/test/lwe_programmable_bootstrapping.rs
@@ -127,8 +127,8 @@ fn lwe_encrypt_pbs_decrypt<
             }
 
             let mut d_test_vector_indexes =
-                stream.malloc_async::<Scalar>(number_of_messages as u32);
-            stream.copy_to_gpu_async(&mut d_test_vector_indexes, &test_vector_indexes);
+                unsafe { stream.malloc_async::<Scalar>(number_of_messages as u32) };
+            unsafe { stream.copy_to_gpu_async(&mut d_test_vector_indexes, &test_vector_indexes) };
 
             let num_blocks = d_lwe_ciphertext_in.0.lwe_ciphertext_count.0;
             let lwe_indexes_usize: Vec<usize> = (0..num_blocks).collect_vec();
@@ -136,10 +136,12 @@ fn lwe_encrypt_pbs_decrypt<
                 .iter()
                 .map(|&x| <usize as CastInto<Scalar>>::cast_into(x))
                 .collect_vec();
-            let mut d_output_indexes = stream.malloc_async::<Scalar>(num_blocks as u32);
-            let mut d_input_indexes = stream.malloc_async::<Scalar>(num_blocks as u32);
-            stream.copy_to_gpu_async(&mut d_output_indexes, &lwe_indexes);
-            stream.copy_to_gpu_async(&mut d_input_indexes, &lwe_indexes);
+            let mut d_output_indexes = unsafe { stream.malloc_async::<Scalar>(num_blocks as u32) };
+            let mut d_input_indexes = unsafe { stream.malloc_async::<Scalar>(num_blocks as u32) };
+            unsafe {
+                stream.copy_to_gpu_async(&mut d_output_indexes, &lwe_indexes);
+                stream.copy_to_gpu_async(&mut d_input_indexes, &lwe_indexes);
+            }
 
             cuda_programmable_bootstrap_lwe_ciphertext(
                 &d_lwe_ciphertext_in,

--- a/tfhe/src/core_crypto/gpu/entities/lwe_bootstrap_key.rs
+++ b/tfhe/src/core_crypto/gpu/entities/lwe_bootstrap_key.rs
@@ -39,21 +39,25 @@ impl CudaLweBootstrapKey {
         let glwe_dimension = bsk.glwe_size().to_glwe_dimension();
 
         // Allocate memory
-        let mut d_vec = stream.malloc_async::<f64>(lwe_bootstrap_key_size(
-            input_lwe_dimension,
-            glwe_dimension.to_glwe_size(),
-            polynomial_size,
-            decomp_level_count,
-        ) as u32);
+        let mut d_vec = unsafe {
+            stream.malloc_async::<f64>(lwe_bootstrap_key_size(
+                input_lwe_dimension,
+                glwe_dimension.to_glwe_size(),
+                polynomial_size,
+                decomp_level_count,
+            ) as u32)
+        };
         // Copy to the GPU
-        stream.convert_lwe_bootstrap_key_async(
-            &mut d_vec,
-            bsk.as_ref(),
-            input_lwe_dimension,
-            glwe_dimension,
-            decomp_level_count,
-            polynomial_size,
-        );
+        unsafe {
+            stream.convert_lwe_bootstrap_key_async(
+                &mut d_vec,
+                bsk.as_ref(),
+                input_lwe_dimension,
+                glwe_dimension,
+                decomp_level_count,
+                polynomial_size,
+            );
+        }
         stream.synchronize();
         Self {
             d_vec,

--- a/tfhe/src/core_crypto/gpu/entities/lwe_keyswitch_key.rs
+++ b/tfhe/src/core_crypto/gpu/entities/lwe_keyswitch_key.rs
@@ -28,15 +28,19 @@ impl<T: UnsignedInteger> CudaLweKeyswitchKey<T> {
         let ciphertext_modulus = h_ksk.ciphertext_modulus();
 
         // Allocate memory
-        let mut d_vec = stream.malloc_async::<T>(
-            (input_lwe_size.to_lwe_dimension().0
-                * lwe_keyswitch_key_input_key_element_encrypted_size(
-                    decomp_level_count,
-                    output_lwe_size,
-                )) as u32,
-        );
+        let mut d_vec = unsafe {
+            stream.malloc_async::<T>(
+                (input_lwe_size.to_lwe_dimension().0
+                    * lwe_keyswitch_key_input_key_element_encrypted_size(
+                        decomp_level_count,
+                        output_lwe_size,
+                    )) as u32,
+            )
+        };
 
-        stream.convert_lwe_keyswitch_key_async(&mut d_vec, h_ksk.as_ref());
+        unsafe {
+            stream.convert_lwe_keyswitch_key_async(&mut d_vec, h_ksk.as_ref());
+        }
 
         stream.synchronize();
 

--- a/tfhe/src/core_crypto/gpu/entities/lwe_multi_bit_bootstrap_key.rs
+++ b/tfhe/src/core_crypto/gpu/entities/lwe_multi_bit_bootstrap_key.rs
@@ -41,26 +41,30 @@ impl CudaLweMultiBitBootstrapKey {
         let grouping_factor = bsk.grouping_factor();
 
         // Allocate memory
-        let mut d_vec = stream.malloc_async::<u64>(
-            lwe_multi_bit_bootstrap_key_size(
-                input_lwe_dimension,
-                glwe_dimension.to_glwe_size(),
-                polynomial_size,
-                decomp_level_count,
-                grouping_factor,
+        let mut d_vec = unsafe {
+            stream.malloc_async::<u64>(
+                lwe_multi_bit_bootstrap_key_size(
+                    input_lwe_dimension,
+                    glwe_dimension.to_glwe_size(),
+                    polynomial_size,
+                    decomp_level_count,
+                    grouping_factor,
+                )
+                .unwrap() as u32,
             )
-            .unwrap() as u32,
-        );
+        };
         // Copy to the GPU
-        stream.convert_lwe_multi_bit_bootstrap_key_async(
-            &mut d_vec,
-            bsk.as_ref(),
-            input_lwe_dimension,
-            glwe_dimension,
-            decomp_level_count,
-            polynomial_size,
-            grouping_factor,
-        );
+        unsafe {
+            stream.convert_lwe_multi_bit_bootstrap_key_async(
+                &mut d_vec,
+                bsk.as_ref(),
+                input_lwe_dimension,
+                glwe_dimension,
+                decomp_level_count,
+                polynomial_size,
+                grouping_factor,
+            );
+        }
         stream.synchronize();
         Self {
             d_vec,

--- a/tfhe/src/integer/gpu/mod.rs
+++ b/tfhe/src/integer/gpu/mod.rs
@@ -144,7 +144,11 @@ where
 
 impl CudaStream {
     #[allow(clippy::too_many_arguments)]
-    pub fn scalar_addition_integer_radix_assign_async<T: UnsignedInteger>(
+    /// # Safety
+    ///
+    /// - [CudaStream::synchronize] __must__ be called after this function
+    /// as soon as synchronization is required
+    pub unsafe fn scalar_addition_integer_radix_assign_async<T: UnsignedInteger>(
         &self,
         lwe_array: &mut CudaVec<T>,
         scalar_input: &CudaVec<T>,
@@ -153,59 +157,65 @@ impl CudaStream {
         message_modulus: u32,
         carry_modulus: u32,
     ) {
-        unsafe {
-            cuda_scalar_addition_integer_radix_ciphertext_64_inplace(
-                self.as_c_ptr(),
-                lwe_array.as_mut_c_ptr(),
-                scalar_input.as_c_ptr(),
-                lwe_dimension.0 as u32,
-                num_samples,
-                message_modulus,
-                carry_modulus,
-            );
-        }
+        cuda_scalar_addition_integer_radix_ciphertext_64_inplace(
+            self.as_c_ptr(),
+            lwe_array.as_mut_c_ptr(),
+            scalar_input.as_c_ptr(),
+            lwe_dimension.0 as u32,
+            num_samples,
+            message_modulus,
+            carry_modulus,
+        );
     }
 
-    pub fn small_scalar_mult_integer_radix_assign_async<T: UnsignedInteger>(
+    /// # Safety
+    ///
+    /// - [CudaStream::synchronize] __must__ be called after this function
+    /// as soon as synchronization is required
+    pub unsafe fn small_scalar_mult_integer_radix_assign_async<T: UnsignedInteger>(
         &self,
         lwe_array: &mut CudaVec<T>,
         scalar: u64,
         lwe_dimension: LweDimension,
         num_blocks: u32,
     ) {
-        unsafe {
-            cuda_small_scalar_multiplication_integer_radix_ciphertext_64_inplace(
-                self.as_c_ptr(),
-                lwe_array.as_mut_c_ptr(),
-                scalar,
-                lwe_dimension.0 as u32,
-                num_blocks,
-            );
-        }
+        cuda_small_scalar_multiplication_integer_radix_ciphertext_64_inplace(
+            self.as_c_ptr(),
+            lwe_array.as_mut_c_ptr(),
+            scalar,
+            lwe_dimension.0 as u32,
+            num_blocks,
+        );
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn unchecked_add_integer_radix_assign_async<T: UnsignedInteger>(
+    /// # Safety
+    ///
+    /// - [CudaStream::synchronize] __must__ be called after this function
+    /// as soon as synchronization is required
+    pub unsafe fn unchecked_add_integer_radix_assign_async<T: UnsignedInteger>(
         &self,
         radix_lwe_left: &mut CudaVec<T>,
         radix_lwe_right: &CudaVec<T>,
         lwe_dimension: LweDimension,
         num_blocks: u32,
     ) {
-        unsafe {
-            cuda_add_lwe_ciphertext_vector_64(
-                self.as_c_ptr(),
-                radix_lwe_left.as_mut_c_ptr(),
-                radix_lwe_left.as_c_ptr(),
-                radix_lwe_right.as_c_ptr(),
-                lwe_dimension.0 as u32,
-                num_blocks,
-            );
-        }
+        cuda_add_lwe_ciphertext_vector_64(
+            self.as_c_ptr(),
+            radix_lwe_left.as_mut_c_ptr(),
+            radix_lwe_left.as_c_ptr(),
+            radix_lwe_right.as_c_ptr(),
+            lwe_dimension.0 as u32,
+            num_blocks,
+        );
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn unchecked_mul_integer_radix_classic_kb_async<T: UnsignedInteger>(
+    /// # Safety
+    ///
+    /// - [CudaStream::synchronize] __must__ be called after this function
+    /// as soon as synchronization is required
+    pub unsafe fn unchecked_mul_integer_radix_classic_kb_async<T: UnsignedInteger>(
         &self,
         radix_lwe_out: &mut CudaVec<T>,
         radix_lwe_left: &CudaVec<T>,
@@ -224,53 +234,55 @@ impl CudaStream {
         num_blocks: u32,
     ) {
         let mut mem_ptr: *mut i8 = std::ptr::null_mut();
-        unsafe {
-            scratch_cuda_integer_mult_radix_ciphertext_kb_64(
-                self.as_c_ptr(),
-                std::ptr::addr_of_mut!(mem_ptr),
-                message_modulus.0 as u32,
-                carry_modulus.0 as u32,
-                glwe_dimension.0 as u32,
-                lwe_dimension.0 as u32,
-                polynomial_size.0 as u32,
-                pbs_base_log.0 as u32,
-                pbs_level.0 as u32,
-                ks_base_log.0 as u32,
-                ks_level.0 as u32,
-                0,
-                num_blocks,
-                PBSType::ClassicalLowLat as u32,
-                self.device().get_max_shared_memory() as u32,
-                true,
-            );
-            cuda_integer_mult_radix_ciphertext_kb_64(
-                self.as_c_ptr(),
-                radix_lwe_out.as_mut_c_ptr(),
-                radix_lwe_left.as_c_ptr(),
-                radix_lwe_right.as_c_ptr(),
-                bootstrapping_key.as_c_ptr(),
-                keyswitch_key.as_c_ptr(),
-                mem_ptr,
-                message_modulus.0 as u32,
-                carry_modulus.0 as u32,
-                glwe_dimension.0 as u32,
-                lwe_dimension.0 as u32,
-                polynomial_size.0 as u32,
-                pbs_base_log.0 as u32,
-                pbs_level.0 as u32,
-                ks_base_log.0 as u32,
-                ks_level.0 as u32,
-                0,
-                num_blocks,
-                PBSType::ClassicalLowLat as u32,
-                self.device().get_max_shared_memory() as u32,
-            );
-            cleanup_cuda_integer_mult(self.as_c_ptr(), std::ptr::addr_of_mut!(mem_ptr));
-        }
+        scratch_cuda_integer_mult_radix_ciphertext_kb_64(
+            self.as_c_ptr(),
+            std::ptr::addr_of_mut!(mem_ptr),
+            message_modulus.0 as u32,
+            carry_modulus.0 as u32,
+            glwe_dimension.0 as u32,
+            lwe_dimension.0 as u32,
+            polynomial_size.0 as u32,
+            pbs_base_log.0 as u32,
+            pbs_level.0 as u32,
+            ks_base_log.0 as u32,
+            ks_level.0 as u32,
+            0,
+            num_blocks,
+            PBSType::ClassicalLowLat as u32,
+            self.device().get_max_shared_memory() as u32,
+            true,
+        );
+        cuda_integer_mult_radix_ciphertext_kb_64(
+            self.as_c_ptr(),
+            radix_lwe_out.as_mut_c_ptr(),
+            radix_lwe_left.as_c_ptr(),
+            radix_lwe_right.as_c_ptr(),
+            bootstrapping_key.as_c_ptr(),
+            keyswitch_key.as_c_ptr(),
+            mem_ptr,
+            message_modulus.0 as u32,
+            carry_modulus.0 as u32,
+            glwe_dimension.0 as u32,
+            lwe_dimension.0 as u32,
+            polynomial_size.0 as u32,
+            pbs_base_log.0 as u32,
+            pbs_level.0 as u32,
+            ks_base_log.0 as u32,
+            ks_level.0 as u32,
+            0,
+            num_blocks,
+            PBSType::ClassicalLowLat as u32,
+            self.device().get_max_shared_memory() as u32,
+        );
+        cleanup_cuda_integer_mult(self.as_c_ptr(), std::ptr::addr_of_mut!(mem_ptr));
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn unchecked_mul_integer_radix_multibit_kb_async<T: UnsignedInteger>(
+    /// # Safety
+    ///
+    /// - [CudaStream::synchronize] __must__ be called after this function
+    /// as soon as synchronization is required
+    pub unsafe fn unchecked_mul_integer_radix_multibit_kb_async<T: UnsignedInteger>(
         &self,
         radix_lwe_out: &mut CudaVec<T>,
         radix_lwe_left: &CudaVec<T>,
@@ -290,53 +302,55 @@ impl CudaStream {
         num_blocks: u32,
     ) {
         let mut mem_ptr: *mut i8 = std::ptr::null_mut();
-        unsafe {
-            scratch_cuda_integer_mult_radix_ciphertext_kb_64(
-                self.as_c_ptr(),
-                std::ptr::addr_of_mut!(mem_ptr),
-                message_modulus.0 as u32,
-                carry_modulus.0 as u32,
-                glwe_dimension.0 as u32,
-                lwe_dimension.0 as u32,
-                polynomial_size.0 as u32,
-                pbs_base_log.0 as u32,
-                pbs_level.0 as u32,
-                ks_base_log.0 as u32,
-                ks_level.0 as u32,
-                grouping_factor.0 as u32,
-                num_blocks,
-                PBSType::MultiBit as u32,
-                self.device().get_max_shared_memory() as u32,
-                true,
-            );
-            cuda_integer_mult_radix_ciphertext_kb_64(
-                self.as_c_ptr(),
-                radix_lwe_out.as_mut_c_ptr(),
-                radix_lwe_left.as_c_ptr(),
-                radix_lwe_right.as_c_ptr(),
-                bootstrapping_key.as_c_ptr(),
-                keyswitch_key.as_c_ptr(),
-                mem_ptr,
-                message_modulus.0 as u32,
-                carry_modulus.0 as u32,
-                glwe_dimension.0 as u32,
-                lwe_dimension.0 as u32,
-                polynomial_size.0 as u32,
-                pbs_base_log.0 as u32,
-                pbs_level.0 as u32,
-                ks_base_log.0 as u32,
-                ks_level.0 as u32,
-                grouping_factor.0 as u32,
-                num_blocks,
-                PBSType::MultiBit as u32,
-                self.device().get_max_shared_memory() as u32,
-            );
-            cleanup_cuda_integer_mult(self.as_c_ptr(), std::ptr::addr_of_mut!(mem_ptr));
-        }
+        scratch_cuda_integer_mult_radix_ciphertext_kb_64(
+            self.as_c_ptr(),
+            std::ptr::addr_of_mut!(mem_ptr),
+            message_modulus.0 as u32,
+            carry_modulus.0 as u32,
+            glwe_dimension.0 as u32,
+            lwe_dimension.0 as u32,
+            polynomial_size.0 as u32,
+            pbs_base_log.0 as u32,
+            pbs_level.0 as u32,
+            ks_base_log.0 as u32,
+            ks_level.0 as u32,
+            grouping_factor.0 as u32,
+            num_blocks,
+            PBSType::MultiBit as u32,
+            self.device().get_max_shared_memory() as u32,
+            true,
+        );
+        cuda_integer_mult_radix_ciphertext_kb_64(
+            self.as_c_ptr(),
+            radix_lwe_out.as_mut_c_ptr(),
+            radix_lwe_left.as_c_ptr(),
+            radix_lwe_right.as_c_ptr(),
+            bootstrapping_key.as_c_ptr(),
+            keyswitch_key.as_c_ptr(),
+            mem_ptr,
+            message_modulus.0 as u32,
+            carry_modulus.0 as u32,
+            glwe_dimension.0 as u32,
+            lwe_dimension.0 as u32,
+            polynomial_size.0 as u32,
+            pbs_base_log.0 as u32,
+            pbs_level.0 as u32,
+            ks_base_log.0 as u32,
+            ks_level.0 as u32,
+            grouping_factor.0 as u32,
+            num_blocks,
+            PBSType::MultiBit as u32,
+            self.device().get_max_shared_memory() as u32,
+        );
+        cleanup_cuda_integer_mult(self.as_c_ptr(), std::ptr::addr_of_mut!(mem_ptr));
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn unchecked_mul_integer_radix_classic_kb_assign_async<T: UnsignedInteger>(
+    /// # Safety
+    ///
+    /// - [CudaStream::synchronize] __must__ be called after this function
+    /// as soon as synchronization is required
+    pub unsafe fn unchecked_mul_integer_radix_classic_kb_assign_async<T: UnsignedInteger>(
         &self,
         radix_lwe_left: &mut CudaVec<T>,
         radix_lwe_right: &CudaVec<T>,
@@ -354,53 +368,55 @@ impl CudaStream {
         num_blocks: u32,
     ) {
         let mut mem_ptr: *mut i8 = std::ptr::null_mut();
-        unsafe {
-            scratch_cuda_integer_mult_radix_ciphertext_kb_64(
-                self.as_c_ptr(),
-                std::ptr::addr_of_mut!(mem_ptr),
-                message_modulus.0 as u32,
-                carry_modulus.0 as u32,
-                glwe_dimension.0 as u32,
-                lwe_dimension.0 as u32,
-                polynomial_size.0 as u32,
-                pbs_base_log.0 as u32,
-                pbs_level.0 as u32,
-                ks_base_log.0 as u32,
-                ks_level.0 as u32,
-                0,
-                num_blocks,
-                PBSType::ClassicalLowLat as u32,
-                self.device().get_max_shared_memory() as u32,
-                true,
-            );
-            cuda_integer_mult_radix_ciphertext_kb_64(
-                self.as_c_ptr(),
-                radix_lwe_left.as_mut_c_ptr(),
-                radix_lwe_left.as_c_ptr(),
-                radix_lwe_right.as_c_ptr(),
-                bootstrapping_key.as_c_ptr(),
-                keyswitch_key.as_c_ptr(),
-                mem_ptr,
-                message_modulus.0 as u32,
-                carry_modulus.0 as u32,
-                glwe_dimension.0 as u32,
-                lwe_dimension.0 as u32,
-                polynomial_size.0 as u32,
-                pbs_base_log.0 as u32,
-                pbs_level.0 as u32,
-                ks_base_log.0 as u32,
-                ks_level.0 as u32,
-                0,
-                num_blocks,
-                PBSType::ClassicalLowLat as u32,
-                self.device().get_max_shared_memory() as u32,
-            );
-            cleanup_cuda_integer_mult(self.as_c_ptr(), std::ptr::addr_of_mut!(mem_ptr));
-        }
+        scratch_cuda_integer_mult_radix_ciphertext_kb_64(
+            self.as_c_ptr(),
+            std::ptr::addr_of_mut!(mem_ptr),
+            message_modulus.0 as u32,
+            carry_modulus.0 as u32,
+            glwe_dimension.0 as u32,
+            lwe_dimension.0 as u32,
+            polynomial_size.0 as u32,
+            pbs_base_log.0 as u32,
+            pbs_level.0 as u32,
+            ks_base_log.0 as u32,
+            ks_level.0 as u32,
+            0,
+            num_blocks,
+            PBSType::ClassicalLowLat as u32,
+            self.device().get_max_shared_memory() as u32,
+            true,
+        );
+        cuda_integer_mult_radix_ciphertext_kb_64(
+            self.as_c_ptr(),
+            radix_lwe_left.as_mut_c_ptr(),
+            radix_lwe_left.as_c_ptr(),
+            radix_lwe_right.as_c_ptr(),
+            bootstrapping_key.as_c_ptr(),
+            keyswitch_key.as_c_ptr(),
+            mem_ptr,
+            message_modulus.0 as u32,
+            carry_modulus.0 as u32,
+            glwe_dimension.0 as u32,
+            lwe_dimension.0 as u32,
+            polynomial_size.0 as u32,
+            pbs_base_log.0 as u32,
+            pbs_level.0 as u32,
+            ks_base_log.0 as u32,
+            ks_level.0 as u32,
+            0,
+            num_blocks,
+            PBSType::ClassicalLowLat as u32,
+            self.device().get_max_shared_memory() as u32,
+        );
+        cleanup_cuda_integer_mult(self.as_c_ptr(), std::ptr::addr_of_mut!(mem_ptr));
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn unchecked_mul_integer_radix_multibit_kb_assign_async<T: UnsignedInteger>(
+    /// # Safety
+    ///
+    /// - [CudaStream::synchronize] __must__ be called after this function
+    /// as soon as synchronization is required
+    pub unsafe fn unchecked_mul_integer_radix_multibit_kb_assign_async<T: UnsignedInteger>(
         &self,
         radix_lwe_left: &mut CudaVec<T>,
         radix_lwe_right: &CudaVec<T>,
@@ -419,53 +435,55 @@ impl CudaStream {
         num_blocks: u32,
     ) {
         let mut mem_ptr: *mut i8 = std::ptr::null_mut();
-        unsafe {
-            scratch_cuda_integer_mult_radix_ciphertext_kb_64(
-                self.as_c_ptr(),
-                std::ptr::addr_of_mut!(mem_ptr),
-                message_modulus.0 as u32,
-                carry_modulus.0 as u32,
-                glwe_dimension.0 as u32,
-                lwe_dimension.0 as u32,
-                polynomial_size.0 as u32,
-                pbs_base_log.0 as u32,
-                pbs_level.0 as u32,
-                ks_base_log.0 as u32,
-                ks_level.0 as u32,
-                grouping_factor.0 as u32,
-                num_blocks,
-                PBSType::MultiBit as u32,
-                self.device().get_max_shared_memory() as u32,
-                true,
-            );
-            cuda_integer_mult_radix_ciphertext_kb_64(
-                self.as_c_ptr(),
-                radix_lwe_left.as_mut_c_ptr(),
-                radix_lwe_left.as_c_ptr(),
-                radix_lwe_right.as_c_ptr(),
-                bootstrapping_key.as_c_ptr(),
-                keyswitch_key.as_c_ptr(),
-                mem_ptr,
-                message_modulus.0 as u32,
-                carry_modulus.0 as u32,
-                glwe_dimension.0 as u32,
-                lwe_dimension.0 as u32,
-                polynomial_size.0 as u32,
-                pbs_base_log.0 as u32,
-                pbs_level.0 as u32,
-                ks_base_log.0 as u32,
-                ks_level.0 as u32,
-                grouping_factor.0 as u32,
-                num_blocks,
-                PBSType::MultiBit as u32,
-                self.device().get_max_shared_memory() as u32,
-            );
-            cleanup_cuda_integer_mult(self.as_c_ptr(), std::ptr::addr_of_mut!(mem_ptr));
-        }
+        scratch_cuda_integer_mult_radix_ciphertext_kb_64(
+            self.as_c_ptr(),
+            std::ptr::addr_of_mut!(mem_ptr),
+            message_modulus.0 as u32,
+            carry_modulus.0 as u32,
+            glwe_dimension.0 as u32,
+            lwe_dimension.0 as u32,
+            polynomial_size.0 as u32,
+            pbs_base_log.0 as u32,
+            pbs_level.0 as u32,
+            ks_base_log.0 as u32,
+            ks_level.0 as u32,
+            grouping_factor.0 as u32,
+            num_blocks,
+            PBSType::MultiBit as u32,
+            self.device().get_max_shared_memory() as u32,
+            true,
+        );
+        cuda_integer_mult_radix_ciphertext_kb_64(
+            self.as_c_ptr(),
+            radix_lwe_left.as_mut_c_ptr(),
+            radix_lwe_left.as_c_ptr(),
+            radix_lwe_right.as_c_ptr(),
+            bootstrapping_key.as_c_ptr(),
+            keyswitch_key.as_c_ptr(),
+            mem_ptr,
+            message_modulus.0 as u32,
+            carry_modulus.0 as u32,
+            glwe_dimension.0 as u32,
+            lwe_dimension.0 as u32,
+            polynomial_size.0 as u32,
+            pbs_base_log.0 as u32,
+            pbs_level.0 as u32,
+            ks_base_log.0 as u32,
+            ks_level.0 as u32,
+            grouping_factor.0 as u32,
+            num_blocks,
+            PBSType::MultiBit as u32,
+            self.device().get_max_shared_memory() as u32,
+        );
+        cleanup_cuda_integer_mult(self.as_c_ptr(), std::ptr::addr_of_mut!(mem_ptr));
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn unchecked_bitop_integer_radix_classic_kb_async<T: UnsignedInteger>(
+    /// # Safety
+    ///
+    /// - [CudaStream::synchronize] __must__ be called after this function
+    /// as soon as synchronization is required
+    pub unsafe fn unchecked_bitop_integer_radix_classic_kb_async<T: UnsignedInteger>(
         &self,
         radix_lwe_out: &mut CudaVec<T>,
         radix_lwe_left: &CudaVec<T>,
@@ -486,42 +504,44 @@ impl CudaStream {
         num_blocks: u32,
     ) {
         let mut mem_ptr: *mut i8 = std::ptr::null_mut();
-        unsafe {
-            scratch_cuda_integer_radix_bitop_kb_64(
-                self.as_c_ptr(),
-                std::ptr::addr_of_mut!(mem_ptr),
-                glwe_dimension.0 as u32,
-                polynomial_size.0 as u32,
-                big_lwe_dimension.0 as u32,
-                small_lwe_dimension.0 as u32,
-                ks_level.0 as u32,
-                ks_base_log.0 as u32,
-                pbs_level.0 as u32,
-                pbs_base_log.0 as u32,
-                0,
-                num_blocks,
-                message_modulus.0 as u32,
-                carry_modulus.0 as u32,
-                PBSType::ClassicalLowLat as u32,
-                op as u32,
-                true,
-            );
-            cuda_bitop_integer_radix_ciphertext_kb_64(
-                self.as_c_ptr(),
-                radix_lwe_out.as_mut_c_ptr(),
-                radix_lwe_left.as_c_ptr(),
-                radix_lwe_right.as_c_ptr(),
-                mem_ptr,
-                bootstrapping_key.as_c_ptr(),
-                keyswitch_key.as_c_ptr(),
-                num_blocks,
-            );
-            cleanup_cuda_integer_bitop(self.as_c_ptr(), std::ptr::addr_of_mut!(mem_ptr));
-        }
+        scratch_cuda_integer_radix_bitop_kb_64(
+            self.as_c_ptr(),
+            std::ptr::addr_of_mut!(mem_ptr),
+            glwe_dimension.0 as u32,
+            polynomial_size.0 as u32,
+            big_lwe_dimension.0 as u32,
+            small_lwe_dimension.0 as u32,
+            ks_level.0 as u32,
+            ks_base_log.0 as u32,
+            pbs_level.0 as u32,
+            pbs_base_log.0 as u32,
+            0,
+            num_blocks,
+            message_modulus.0 as u32,
+            carry_modulus.0 as u32,
+            PBSType::ClassicalLowLat as u32,
+            op as u32,
+            true,
+        );
+        cuda_bitop_integer_radix_ciphertext_kb_64(
+            self.as_c_ptr(),
+            radix_lwe_out.as_mut_c_ptr(),
+            radix_lwe_left.as_c_ptr(),
+            radix_lwe_right.as_c_ptr(),
+            mem_ptr,
+            bootstrapping_key.as_c_ptr(),
+            keyswitch_key.as_c_ptr(),
+            num_blocks,
+        );
+        cleanup_cuda_integer_bitop(self.as_c_ptr(), std::ptr::addr_of_mut!(mem_ptr));
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn unchecked_bitop_integer_radix_classic_kb_assign_async<T: UnsignedInteger>(
+    /// # Safety
+    ///
+    /// - [CudaStream::synchronize] __must__ be called after this function
+    /// as soon as synchronization is required
+    pub unsafe fn unchecked_bitop_integer_radix_classic_kb_assign_async<T: UnsignedInteger>(
         &self,
         radix_lwe_left: &mut CudaVec<T>,
         radix_lwe_right: &CudaVec<T>,
@@ -541,42 +561,44 @@ impl CudaStream {
         num_blocks: u32,
     ) {
         let mut mem_ptr: *mut i8 = std::ptr::null_mut();
-        unsafe {
-            scratch_cuda_integer_radix_bitop_kb_64(
-                self.as_c_ptr(),
-                std::ptr::addr_of_mut!(mem_ptr),
-                glwe_dimension.0 as u32,
-                polynomial_size.0 as u32,
-                big_lwe_dimension.0 as u32,
-                small_lwe_dimension.0 as u32,
-                ks_level.0 as u32,
-                ks_base_log.0 as u32,
-                pbs_level.0 as u32,
-                pbs_base_log.0 as u32,
-                0,
-                num_blocks,
-                message_modulus.0 as u32,
-                carry_modulus.0 as u32,
-                PBSType::ClassicalLowLat as u32,
-                op as u32,
-                true,
-            );
-            cuda_bitop_integer_radix_ciphertext_kb_64(
-                self.as_c_ptr(),
-                radix_lwe_left.as_mut_c_ptr(),
-                radix_lwe_left.as_c_ptr(),
-                radix_lwe_right.as_c_ptr(),
-                mem_ptr,
-                bootstrapping_key.as_c_ptr(),
-                keyswitch_key.as_c_ptr(),
-                num_blocks,
-            );
-            cleanup_cuda_integer_bitop(self.as_c_ptr(), std::ptr::addr_of_mut!(mem_ptr));
-        }
+        scratch_cuda_integer_radix_bitop_kb_64(
+            self.as_c_ptr(),
+            std::ptr::addr_of_mut!(mem_ptr),
+            glwe_dimension.0 as u32,
+            polynomial_size.0 as u32,
+            big_lwe_dimension.0 as u32,
+            small_lwe_dimension.0 as u32,
+            ks_level.0 as u32,
+            ks_base_log.0 as u32,
+            pbs_level.0 as u32,
+            pbs_base_log.0 as u32,
+            0,
+            num_blocks,
+            message_modulus.0 as u32,
+            carry_modulus.0 as u32,
+            PBSType::ClassicalLowLat as u32,
+            op as u32,
+            true,
+        );
+        cuda_bitop_integer_radix_ciphertext_kb_64(
+            self.as_c_ptr(),
+            radix_lwe_left.as_mut_c_ptr(),
+            radix_lwe_left.as_c_ptr(),
+            radix_lwe_right.as_c_ptr(),
+            mem_ptr,
+            bootstrapping_key.as_c_ptr(),
+            keyswitch_key.as_c_ptr(),
+            num_blocks,
+        );
+        cleanup_cuda_integer_bitop(self.as_c_ptr(), std::ptr::addr_of_mut!(mem_ptr));
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn unchecked_bitnot_integer_radix_classic_kb_assign_async<T: UnsignedInteger>(
+    /// # Safety
+    ///
+    /// - [CudaStream::synchronize] __must__ be called after this function
+    /// as soon as synchronization is required
+    pub unsafe fn unchecked_bitnot_integer_radix_classic_kb_assign_async<T: UnsignedInteger>(
         &self,
         radix_lwe_left: &mut CudaVec<T>,
         bootstrapping_key: &CudaVec<f64>,
@@ -594,41 +616,43 @@ impl CudaStream {
         num_blocks: u32,
     ) {
         let mut mem_ptr: *mut i8 = std::ptr::null_mut();
-        unsafe {
-            scratch_cuda_integer_radix_bitop_kb_64(
-                self.as_c_ptr(),
-                std::ptr::addr_of_mut!(mem_ptr),
-                glwe_dimension.0 as u32,
-                polynomial_size.0 as u32,
-                big_lwe_dimension.0 as u32,
-                small_lwe_dimension.0 as u32,
-                ks_level.0 as u32,
-                ks_base_log.0 as u32,
-                pbs_level.0 as u32,
-                pbs_base_log.0 as u32,
-                0,
-                num_blocks,
-                message_modulus.0 as u32,
-                carry_modulus.0 as u32,
-                PBSType::ClassicalLowLat as u32,
-                BitOpType::Not as u32,
-                true,
-            );
-            cuda_bitnot_integer_radix_ciphertext_kb_64(
-                self.as_c_ptr(),
-                radix_lwe_left.as_mut_c_ptr(),
-                radix_lwe_left.as_c_ptr(),
-                mem_ptr,
-                bootstrapping_key.as_c_ptr(),
-                keyswitch_key.as_c_ptr(),
-                num_blocks,
-            );
-            cleanup_cuda_integer_bitop(self.as_c_ptr(), std::ptr::addr_of_mut!(mem_ptr));
-        }
+        scratch_cuda_integer_radix_bitop_kb_64(
+            self.as_c_ptr(),
+            std::ptr::addr_of_mut!(mem_ptr),
+            glwe_dimension.0 as u32,
+            polynomial_size.0 as u32,
+            big_lwe_dimension.0 as u32,
+            small_lwe_dimension.0 as u32,
+            ks_level.0 as u32,
+            ks_base_log.0 as u32,
+            pbs_level.0 as u32,
+            pbs_base_log.0 as u32,
+            0,
+            num_blocks,
+            message_modulus.0 as u32,
+            carry_modulus.0 as u32,
+            PBSType::ClassicalLowLat as u32,
+            BitOpType::Not as u32,
+            true,
+        );
+        cuda_bitnot_integer_radix_ciphertext_kb_64(
+            self.as_c_ptr(),
+            radix_lwe_left.as_mut_c_ptr(),
+            radix_lwe_left.as_c_ptr(),
+            mem_ptr,
+            bootstrapping_key.as_c_ptr(),
+            keyswitch_key.as_c_ptr(),
+            num_blocks,
+        );
+        cleanup_cuda_integer_bitop(self.as_c_ptr(), std::ptr::addr_of_mut!(mem_ptr));
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn unchecked_bitnot_integer_radix_multibit_kb_assign_async<T: UnsignedInteger>(
+    /// # Safety
+    ///
+    /// - [CudaStream::synchronize] __must__ be called after this function
+    /// as soon as synchronization is required
+    pub unsafe fn unchecked_bitnot_integer_radix_multibit_kb_assign_async<T: UnsignedInteger>(
         &self,
         radix_lwe_left: &mut CudaVec<T>,
         bootstrapping_key: &CudaVec<u64>,
@@ -647,41 +671,45 @@ impl CudaStream {
         num_blocks: u32,
     ) {
         let mut mem_ptr: *mut i8 = std::ptr::null_mut();
-        unsafe {
-            scratch_cuda_integer_radix_bitop_kb_64(
-                self.as_c_ptr(),
-                std::ptr::addr_of_mut!(mem_ptr),
-                glwe_dimension.0 as u32,
-                polynomial_size.0 as u32,
-                big_lwe_dimension.0 as u32,
-                small_lwe_dimension.0 as u32,
-                ks_level.0 as u32,
-                ks_base_log.0 as u32,
-                pbs_level.0 as u32,
-                pbs_base_log.0 as u32,
-                pbs_grouping_factor.0 as u32,
-                num_blocks,
-                message_modulus.0 as u32,
-                carry_modulus.0 as u32,
-                PBSType::MultiBit as u32,
-                BitOpType::Not as u32,
-                true,
-            );
-            cuda_bitnot_integer_radix_ciphertext_kb_64(
-                self.as_c_ptr(),
-                radix_lwe_left.as_mut_c_ptr(),
-                radix_lwe_left.as_c_ptr(),
-                mem_ptr,
-                bootstrapping_key.as_c_ptr(),
-                keyswitch_key.as_c_ptr(),
-                num_blocks,
-            );
-            cleanup_cuda_integer_bitop(self.as_c_ptr(), std::ptr::addr_of_mut!(mem_ptr));
-        }
+        scratch_cuda_integer_radix_bitop_kb_64(
+            self.as_c_ptr(),
+            std::ptr::addr_of_mut!(mem_ptr),
+            glwe_dimension.0 as u32,
+            polynomial_size.0 as u32,
+            big_lwe_dimension.0 as u32,
+            small_lwe_dimension.0 as u32,
+            ks_level.0 as u32,
+            ks_base_log.0 as u32,
+            pbs_level.0 as u32,
+            pbs_base_log.0 as u32,
+            pbs_grouping_factor.0 as u32,
+            num_blocks,
+            message_modulus.0 as u32,
+            carry_modulus.0 as u32,
+            PBSType::MultiBit as u32,
+            BitOpType::Not as u32,
+            true,
+        );
+        cuda_bitnot_integer_radix_ciphertext_kb_64(
+            self.as_c_ptr(),
+            radix_lwe_left.as_mut_c_ptr(),
+            radix_lwe_left.as_c_ptr(),
+            mem_ptr,
+            bootstrapping_key.as_c_ptr(),
+            keyswitch_key.as_c_ptr(),
+            num_blocks,
+        );
+        cleanup_cuda_integer_bitop(self.as_c_ptr(), std::ptr::addr_of_mut!(mem_ptr));
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn unchecked_scalar_bitop_integer_radix_multibit_kb_assign_async<T: UnsignedInteger>(
+    /// # Safety
+    ///
+    /// - [CudaStream::synchronize] __must__ be called after this function
+    /// as soon as synchronization is required
+    pub unsafe fn unchecked_scalar_bitop_integer_radix_multibit_kb_assign_async<
+        T: UnsignedInteger,
+    >(
         &self,
         radix_lwe: &mut CudaVec<T>,
         clear_blocks: &CudaVec<T>,
@@ -702,44 +730,48 @@ impl CudaStream {
         num_blocks: u32,
     ) {
         let mut mem_ptr: *mut i8 = std::ptr::null_mut();
-        unsafe {
-            scratch_cuda_integer_radix_bitop_kb_64(
-                self.as_c_ptr(),
-                std::ptr::addr_of_mut!(mem_ptr),
-                glwe_dimension.0 as u32,
-                polynomial_size.0 as u32,
-                big_lwe_dimension.0 as u32,
-                small_lwe_dimension.0 as u32,
-                ks_level.0 as u32,
-                ks_base_log.0 as u32,
-                pbs_level.0 as u32,
-                pbs_base_log.0 as u32,
-                grouping_factor.0 as u32,
-                num_blocks,
-                message_modulus.0 as u32,
-                carry_modulus.0 as u32,
-                PBSType::MultiBit as u32,
-                op as u32,
-                true,
-            );
-            cuda_scalar_bitop_integer_radix_ciphertext_kb_64(
-                self.as_c_ptr(),
-                radix_lwe.as_mut_c_ptr(),
-                radix_lwe.as_mut_c_ptr(),
-                clear_blocks.as_c_ptr(),
-                clear_blocks.len() as u32,
-                mem_ptr,
-                bootstrapping_key.as_c_ptr(),
-                keyswitch_key.as_c_ptr(),
-                num_blocks,
-                op as u32,
-            );
-            cleanup_cuda_integer_bitop(self.as_c_ptr(), std::ptr::addr_of_mut!(mem_ptr));
-        }
+        scratch_cuda_integer_radix_bitop_kb_64(
+            self.as_c_ptr(),
+            std::ptr::addr_of_mut!(mem_ptr),
+            glwe_dimension.0 as u32,
+            polynomial_size.0 as u32,
+            big_lwe_dimension.0 as u32,
+            small_lwe_dimension.0 as u32,
+            ks_level.0 as u32,
+            ks_base_log.0 as u32,
+            pbs_level.0 as u32,
+            pbs_base_log.0 as u32,
+            grouping_factor.0 as u32,
+            num_blocks,
+            message_modulus.0 as u32,
+            carry_modulus.0 as u32,
+            PBSType::MultiBit as u32,
+            op as u32,
+            true,
+        );
+        cuda_scalar_bitop_integer_radix_ciphertext_kb_64(
+            self.as_c_ptr(),
+            radix_lwe.as_mut_c_ptr(),
+            radix_lwe.as_mut_c_ptr(),
+            clear_blocks.as_c_ptr(),
+            clear_blocks.len() as u32,
+            mem_ptr,
+            bootstrapping_key.as_c_ptr(),
+            keyswitch_key.as_c_ptr(),
+            num_blocks,
+            op as u32,
+        );
+        cleanup_cuda_integer_bitop(self.as_c_ptr(), std::ptr::addr_of_mut!(mem_ptr));
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn unchecked_scalar_bitop_integer_radix_classic_kb_assign_async<T: UnsignedInteger>(
+    /// # Safety
+    ///
+    /// - [CudaStream::synchronize] __must__ be called after this function
+    /// as soon as synchronization is required
+    pub unsafe fn unchecked_scalar_bitop_integer_radix_classic_kb_assign_async<
+        T: UnsignedInteger,
+    >(
         &self,
         radix_lwe: &mut CudaVec<T>,
         clear_blocks: &CudaVec<T>,
@@ -759,44 +791,46 @@ impl CudaStream {
         num_blocks: u32,
     ) {
         let mut mem_ptr: *mut i8 = std::ptr::null_mut();
-        unsafe {
-            scratch_cuda_integer_radix_bitop_kb_64(
-                self.as_c_ptr(),
-                std::ptr::addr_of_mut!(mem_ptr),
-                glwe_dimension.0 as u32,
-                polynomial_size.0 as u32,
-                big_lwe_dimension.0 as u32,
-                small_lwe_dimension.0 as u32,
-                ks_level.0 as u32,
-                ks_base_log.0 as u32,
-                pbs_level.0 as u32,
-                pbs_base_log.0 as u32,
-                0u32,
-                num_blocks,
-                message_modulus.0 as u32,
-                carry_modulus.0 as u32,
-                PBSType::ClassicalLowLat as u32,
-                op as u32,
-                true,
-            );
-            cuda_scalar_bitop_integer_radix_ciphertext_kb_64(
-                self.as_c_ptr(),
-                radix_lwe.as_mut_c_ptr(),
-                radix_lwe.as_mut_c_ptr(),
-                clear_blocks.as_c_ptr(),
-                clear_blocks.len() as u32,
-                mem_ptr,
-                bootstrapping_key.as_c_ptr(),
-                keyswitch_key.as_c_ptr(),
-                num_blocks,
-                op as u32,
-            );
-            cleanup_cuda_integer_bitop(self.as_c_ptr(), std::ptr::addr_of_mut!(mem_ptr));
-        }
+        scratch_cuda_integer_radix_bitop_kb_64(
+            self.as_c_ptr(),
+            std::ptr::addr_of_mut!(mem_ptr),
+            glwe_dimension.0 as u32,
+            polynomial_size.0 as u32,
+            big_lwe_dimension.0 as u32,
+            small_lwe_dimension.0 as u32,
+            ks_level.0 as u32,
+            ks_base_log.0 as u32,
+            pbs_level.0 as u32,
+            pbs_base_log.0 as u32,
+            0u32,
+            num_blocks,
+            message_modulus.0 as u32,
+            carry_modulus.0 as u32,
+            PBSType::ClassicalLowLat as u32,
+            op as u32,
+            true,
+        );
+        cuda_scalar_bitop_integer_radix_ciphertext_kb_64(
+            self.as_c_ptr(),
+            radix_lwe.as_mut_c_ptr(),
+            radix_lwe.as_mut_c_ptr(),
+            clear_blocks.as_c_ptr(),
+            clear_blocks.len() as u32,
+            mem_ptr,
+            bootstrapping_key.as_c_ptr(),
+            keyswitch_key.as_c_ptr(),
+            num_blocks,
+            op as u32,
+        );
+        cleanup_cuda_integer_bitop(self.as_c_ptr(), std::ptr::addr_of_mut!(mem_ptr));
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn unchecked_bitop_integer_radix_multibit_kb_assign_async<T: UnsignedInteger>(
+    /// # Safety
+    ///
+    /// - [CudaStream::synchronize] __must__ be called after this function
+    /// as soon as synchronization is required
+    pub unsafe fn unchecked_bitop_integer_radix_multibit_kb_assign_async<T: UnsignedInteger>(
         &self,
         radix_lwe_left: &mut CudaVec<T>,
         radix_lwe_right: &CudaVec<T>,
@@ -817,42 +851,44 @@ impl CudaStream {
         num_blocks: u32,
     ) {
         let mut mem_ptr: *mut i8 = std::ptr::null_mut();
-        unsafe {
-            scratch_cuda_integer_radix_bitop_kb_64(
-                self.as_c_ptr(),
-                std::ptr::addr_of_mut!(mem_ptr),
-                glwe_dimension.0 as u32,
-                polynomial_size.0 as u32,
-                big_lwe_dimension.0 as u32,
-                small_lwe_dimension.0 as u32,
-                ks_level.0 as u32,
-                ks_base_log.0 as u32,
-                pbs_level.0 as u32,
-                pbs_base_log.0 as u32,
-                pbs_grouping_factor.0 as u32,
-                num_blocks,
-                message_modulus.0 as u32,
-                carry_modulus.0 as u32,
-                PBSType::MultiBit as u32,
-                op as u32,
-                true,
-            );
-            cuda_bitop_integer_radix_ciphertext_kb_64(
-                self.as_c_ptr(),
-                radix_lwe_left.as_mut_c_ptr(),
-                radix_lwe_left.as_c_ptr(),
-                radix_lwe_right.as_c_ptr(),
-                mem_ptr,
-                bootstrapping_key.as_c_ptr(),
-                keyswitch_key.as_c_ptr(),
-                num_blocks,
-            );
-            cleanup_cuda_integer_bitop(self.as_c_ptr(), std::ptr::addr_of_mut!(mem_ptr));
-        }
+        scratch_cuda_integer_radix_bitop_kb_64(
+            self.as_c_ptr(),
+            std::ptr::addr_of_mut!(mem_ptr),
+            glwe_dimension.0 as u32,
+            polynomial_size.0 as u32,
+            big_lwe_dimension.0 as u32,
+            small_lwe_dimension.0 as u32,
+            ks_level.0 as u32,
+            ks_base_log.0 as u32,
+            pbs_level.0 as u32,
+            pbs_base_log.0 as u32,
+            pbs_grouping_factor.0 as u32,
+            num_blocks,
+            message_modulus.0 as u32,
+            carry_modulus.0 as u32,
+            PBSType::MultiBit as u32,
+            op as u32,
+            true,
+        );
+        cuda_bitop_integer_radix_ciphertext_kb_64(
+            self.as_c_ptr(),
+            radix_lwe_left.as_mut_c_ptr(),
+            radix_lwe_left.as_c_ptr(),
+            radix_lwe_right.as_c_ptr(),
+            mem_ptr,
+            bootstrapping_key.as_c_ptr(),
+            keyswitch_key.as_c_ptr(),
+            num_blocks,
+        );
+        cleanup_cuda_integer_bitop(self.as_c_ptr(), std::ptr::addr_of_mut!(mem_ptr));
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn unchecked_comparison_integer_radix_classic_kb_async<T: UnsignedInteger>(
+    /// # Safety
+    ///
+    /// - [CudaStream::synchronize] __must__ be called after this function
+    /// as soon as synchronization is required
+    pub unsafe fn unchecked_comparison_integer_radix_classic_kb_async<T: UnsignedInteger>(
         &self,
         radix_lwe_out: &mut CudaVec<T>,
         radix_lwe_left: &CudaVec<T>,
@@ -873,44 +909,46 @@ impl CudaStream {
         op: ComparisonType,
     ) {
         let mut mem_ptr: *mut i8 = std::ptr::null_mut();
-        unsafe {
-            scratch_cuda_integer_radix_comparison_kb_64(
-                self.as_c_ptr(),
-                std::ptr::addr_of_mut!(mem_ptr),
-                glwe_dimension.0 as u32,
-                polynomial_size.0 as u32,
-                big_lwe_dimension.0 as u32,
-                small_lwe_dimension.0 as u32,
-                ks_level.0 as u32,
-                ks_base_log.0 as u32,
-                pbs_level.0 as u32,
-                pbs_base_log.0 as u32,
-                0,
-                num_blocks,
-                message_modulus.0 as u32,
-                carry_modulus.0 as u32,
-                PBSType::ClassicalLowLat as u32,
-                op as u32,
-                true,
-            );
+        scratch_cuda_integer_radix_comparison_kb_64(
+            self.as_c_ptr(),
+            std::ptr::addr_of_mut!(mem_ptr),
+            glwe_dimension.0 as u32,
+            polynomial_size.0 as u32,
+            big_lwe_dimension.0 as u32,
+            small_lwe_dimension.0 as u32,
+            ks_level.0 as u32,
+            ks_base_log.0 as u32,
+            pbs_level.0 as u32,
+            pbs_base_log.0 as u32,
+            0,
+            num_blocks,
+            message_modulus.0 as u32,
+            carry_modulus.0 as u32,
+            PBSType::ClassicalLowLat as u32,
+            op as u32,
+            true,
+        );
 
-            cuda_comparison_integer_radix_ciphertext_kb_64(
-                self.as_c_ptr(),
-                radix_lwe_out.as_mut_c_ptr(),
-                radix_lwe_left.as_c_ptr(),
-                radix_lwe_right.as_c_ptr(),
-                mem_ptr,
-                bootstrapping_key.as_c_ptr(),
-                keyswitch_key.as_c_ptr(),
-                num_blocks,
-            );
+        cuda_comparison_integer_radix_ciphertext_kb_64(
+            self.as_c_ptr(),
+            radix_lwe_out.as_mut_c_ptr(),
+            radix_lwe_left.as_c_ptr(),
+            radix_lwe_right.as_c_ptr(),
+            mem_ptr,
+            bootstrapping_key.as_c_ptr(),
+            keyswitch_key.as_c_ptr(),
+            num_blocks,
+        );
 
-            cleanup_cuda_integer_comparison(self.as_c_ptr(), std::ptr::addr_of_mut!(mem_ptr));
-        }
+        cleanup_cuda_integer_comparison(self.as_c_ptr(), std::ptr::addr_of_mut!(mem_ptr));
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn unchecked_comparison_integer_radix_classic_kb_assign_async<T: UnsignedInteger>(
+    /// # Safety
+    ///
+    /// - [CudaStream::synchronize] __must__ be called after this function
+    /// as soon as synchronization is required
+    pub unsafe fn unchecked_comparison_integer_radix_classic_kb_assign_async<T: UnsignedInteger>(
         &self,
         radix_lwe_left: &mut CudaVec<T>,
         radix_lwe_right: &CudaVec<T>,
@@ -930,42 +968,44 @@ impl CudaStream {
         op: ComparisonType,
     ) {
         let mut mem_ptr: *mut i8 = std::ptr::null_mut();
-        unsafe {
-            scratch_cuda_integer_radix_comparison_kb_64(
-                self.as_c_ptr(),
-                std::ptr::addr_of_mut!(mem_ptr),
-                glwe_dimension.0 as u32,
-                polynomial_size.0 as u32,
-                big_lwe_dimension.0 as u32,
-                small_lwe_dimension.0 as u32,
-                ks_level.0 as u32,
-                ks_base_log.0 as u32,
-                pbs_level.0 as u32,
-                pbs_base_log.0 as u32,
-                0,
-                num_blocks,
-                message_modulus.0 as u32,
-                carry_modulus.0 as u32,
-                PBSType::ClassicalLowLat as u32,
-                op as u32,
-                true,
-            );
-            cuda_comparison_integer_radix_ciphertext_kb_64(
-                self.as_c_ptr(),
-                radix_lwe_left.as_mut_c_ptr(),
-                radix_lwe_left.as_c_ptr(),
-                radix_lwe_right.as_c_ptr(),
-                mem_ptr,
-                bootstrapping_key.as_c_ptr(),
-                keyswitch_key.as_c_ptr(),
-                num_blocks,
-            );
-            cleanup_cuda_integer_comparison(self.as_c_ptr(), std::ptr::addr_of_mut!(mem_ptr));
-        }
+        scratch_cuda_integer_radix_comparison_kb_64(
+            self.as_c_ptr(),
+            std::ptr::addr_of_mut!(mem_ptr),
+            glwe_dimension.0 as u32,
+            polynomial_size.0 as u32,
+            big_lwe_dimension.0 as u32,
+            small_lwe_dimension.0 as u32,
+            ks_level.0 as u32,
+            ks_base_log.0 as u32,
+            pbs_level.0 as u32,
+            pbs_base_log.0 as u32,
+            0,
+            num_blocks,
+            message_modulus.0 as u32,
+            carry_modulus.0 as u32,
+            PBSType::ClassicalLowLat as u32,
+            op as u32,
+            true,
+        );
+        cuda_comparison_integer_radix_ciphertext_kb_64(
+            self.as_c_ptr(),
+            radix_lwe_left.as_mut_c_ptr(),
+            radix_lwe_left.as_c_ptr(),
+            radix_lwe_right.as_c_ptr(),
+            mem_ptr,
+            bootstrapping_key.as_c_ptr(),
+            keyswitch_key.as_c_ptr(),
+            num_blocks,
+        );
+        cleanup_cuda_integer_comparison(self.as_c_ptr(), std::ptr::addr_of_mut!(mem_ptr));
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn unchecked_comparison_integer_radix_multibit_kb_async<T: UnsignedInteger>(
+    /// # Safety
+    ///
+    /// - [CudaStream::synchronize] __must__ be called after this function
+    /// as soon as synchronization is required
+    pub unsafe fn unchecked_comparison_integer_radix_multibit_kb_async<T: UnsignedInteger>(
         &self,
         radix_lwe_out: &mut CudaVec<T>,
         radix_lwe_left: &CudaVec<T>,
@@ -987,42 +1027,44 @@ impl CudaStream {
         op: ComparisonType,
     ) {
         let mut mem_ptr: *mut i8 = std::ptr::null_mut();
-        unsafe {
-            scratch_cuda_integer_radix_comparison_kb_64(
-                self.as_c_ptr(),
-                std::ptr::addr_of_mut!(mem_ptr),
-                glwe_dimension.0 as u32,
-                polynomial_size.0 as u32,
-                big_lwe_dimension.0 as u32,
-                small_lwe_dimension.0 as u32,
-                ks_level.0 as u32,
-                ks_base_log.0 as u32,
-                pbs_level.0 as u32,
-                pbs_base_log.0 as u32,
-                pbs_grouping_factor.0 as u32,
-                num_blocks,
-                message_modulus.0 as u32,
-                carry_modulus.0 as u32,
-                PBSType::MultiBit as u32,
-                op as u32,
-                true,
-            );
-            cuda_comparison_integer_radix_ciphertext_kb_64(
-                self.as_c_ptr(),
-                radix_lwe_out.as_mut_c_ptr(),
-                radix_lwe_left.as_c_ptr(),
-                radix_lwe_right.as_c_ptr(),
-                mem_ptr,
-                bootstrapping_key.as_c_ptr(),
-                keyswitch_key.as_c_ptr(),
-                num_blocks,
-            );
-            cleanup_cuda_integer_comparison(self.as_c_ptr(), std::ptr::addr_of_mut!(mem_ptr));
-        }
+        scratch_cuda_integer_radix_comparison_kb_64(
+            self.as_c_ptr(),
+            std::ptr::addr_of_mut!(mem_ptr),
+            glwe_dimension.0 as u32,
+            polynomial_size.0 as u32,
+            big_lwe_dimension.0 as u32,
+            small_lwe_dimension.0 as u32,
+            ks_level.0 as u32,
+            ks_base_log.0 as u32,
+            pbs_level.0 as u32,
+            pbs_base_log.0 as u32,
+            pbs_grouping_factor.0 as u32,
+            num_blocks,
+            message_modulus.0 as u32,
+            carry_modulus.0 as u32,
+            PBSType::MultiBit as u32,
+            op as u32,
+            true,
+        );
+        cuda_comparison_integer_radix_ciphertext_kb_64(
+            self.as_c_ptr(),
+            radix_lwe_out.as_mut_c_ptr(),
+            radix_lwe_left.as_c_ptr(),
+            radix_lwe_right.as_c_ptr(),
+            mem_ptr,
+            bootstrapping_key.as_c_ptr(),
+            keyswitch_key.as_c_ptr(),
+            num_blocks,
+        );
+        cleanup_cuda_integer_comparison(self.as_c_ptr(), std::ptr::addr_of_mut!(mem_ptr));
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn unchecked_scalar_comparison_integer_radix_classic_kb_async<T: UnsignedInteger>(
+    /// # Safety
+    ///
+    /// - [CudaStream::synchronize] __must__ be called after this function
+    /// as soon as synchronization is required
+    pub unsafe fn unchecked_scalar_comparison_integer_radix_classic_kb_async<T: UnsignedInteger>(
         &self,
         radix_lwe_out: &mut CudaVec<T>,
         radix_lwe_in: &CudaVec<T>,
@@ -1044,45 +1086,49 @@ impl CudaStream {
         op: ComparisonType,
     ) {
         let mut mem_ptr: *mut i8 = std::ptr::null_mut();
-        unsafe {
-            scratch_cuda_integer_radix_comparison_kb_64(
-                self.as_c_ptr(),
-                std::ptr::addr_of_mut!(mem_ptr),
-                glwe_dimension.0 as u32,
-                polynomial_size.0 as u32,
-                big_lwe_dimension.0 as u32,
-                small_lwe_dimension.0 as u32,
-                ks_level.0 as u32,
-                ks_base_log.0 as u32,
-                pbs_level.0 as u32,
-                pbs_base_log.0 as u32,
-                0,
-                num_blocks,
-                message_modulus.0 as u32,
-                carry_modulus.0 as u32,
-                PBSType::ClassicalLowLat as u32,
-                op as u32,
-                true,
-            );
+        scratch_cuda_integer_radix_comparison_kb_64(
+            self.as_c_ptr(),
+            std::ptr::addr_of_mut!(mem_ptr),
+            glwe_dimension.0 as u32,
+            polynomial_size.0 as u32,
+            big_lwe_dimension.0 as u32,
+            small_lwe_dimension.0 as u32,
+            ks_level.0 as u32,
+            ks_base_log.0 as u32,
+            pbs_level.0 as u32,
+            pbs_base_log.0 as u32,
+            0,
+            num_blocks,
+            message_modulus.0 as u32,
+            carry_modulus.0 as u32,
+            PBSType::ClassicalLowLat as u32,
+            op as u32,
+            true,
+        );
 
-            cuda_scalar_comparison_integer_radix_ciphertext_kb_64(
-                self.as_c_ptr(),
-                radix_lwe_out.as_mut_c_ptr(),
-                radix_lwe_in.as_c_ptr(),
-                scalar_blocks.as_c_ptr(),
-                mem_ptr,
-                bootstrapping_key.as_c_ptr(),
-                keyswitch_key.as_c_ptr(),
-                num_blocks,
-                num_scalar_blocks,
-            );
+        cuda_scalar_comparison_integer_radix_ciphertext_kb_64(
+            self.as_c_ptr(),
+            radix_lwe_out.as_mut_c_ptr(),
+            radix_lwe_in.as_c_ptr(),
+            scalar_blocks.as_c_ptr(),
+            mem_ptr,
+            bootstrapping_key.as_c_ptr(),
+            keyswitch_key.as_c_ptr(),
+            num_blocks,
+            num_scalar_blocks,
+        );
 
-            cleanup_cuda_integer_comparison(self.as_c_ptr(), std::ptr::addr_of_mut!(mem_ptr));
-        }
+        cleanup_cuda_integer_comparison(self.as_c_ptr(), std::ptr::addr_of_mut!(mem_ptr));
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn unchecked_scalar_comparison_integer_radix_multibit_kb_async<T: UnsignedInteger>(
+    /// # Safety
+    ///
+    /// - [CudaStream::synchronize] __must__ be called after this function
+    /// as soon as synchronization is required
+    pub unsafe fn unchecked_scalar_comparison_integer_radix_multibit_kb_async<
+        T: UnsignedInteger,
+    >(
         &self,
         radix_lwe_out: &mut CudaVec<T>,
         radix_lwe_in: &CudaVec<T>,
@@ -1105,43 +1151,45 @@ impl CudaStream {
         op: ComparisonType,
     ) {
         let mut mem_ptr: *mut i8 = std::ptr::null_mut();
-        unsafe {
-            scratch_cuda_integer_radix_comparison_kb_64(
-                self.as_c_ptr(),
-                std::ptr::addr_of_mut!(mem_ptr),
-                glwe_dimension.0 as u32,
-                polynomial_size.0 as u32,
-                big_lwe_dimension.0 as u32,
-                small_lwe_dimension.0 as u32,
-                ks_level.0 as u32,
-                ks_base_log.0 as u32,
-                pbs_level.0 as u32,
-                pbs_base_log.0 as u32,
-                pbs_grouping_factor.0 as u32,
-                num_blocks,
-                message_modulus.0 as u32,
-                carry_modulus.0 as u32,
-                PBSType::MultiBit as u32,
-                op as u32,
-                true,
-            );
-            cuda_scalar_comparison_integer_radix_ciphertext_kb_64(
-                self.as_c_ptr(),
-                radix_lwe_out.as_mut_c_ptr(),
-                radix_lwe_in.as_c_ptr(),
-                scalar_blocks.as_c_ptr(),
-                mem_ptr,
-                bootstrapping_key.as_c_ptr(),
-                keyswitch_key.as_c_ptr(),
-                num_blocks,
-                num_scalar_blocks,
-            );
-            cleanup_cuda_integer_comparison(self.as_c_ptr(), std::ptr::addr_of_mut!(mem_ptr));
-        }
+        scratch_cuda_integer_radix_comparison_kb_64(
+            self.as_c_ptr(),
+            std::ptr::addr_of_mut!(mem_ptr),
+            glwe_dimension.0 as u32,
+            polynomial_size.0 as u32,
+            big_lwe_dimension.0 as u32,
+            small_lwe_dimension.0 as u32,
+            ks_level.0 as u32,
+            ks_base_log.0 as u32,
+            pbs_level.0 as u32,
+            pbs_base_log.0 as u32,
+            pbs_grouping_factor.0 as u32,
+            num_blocks,
+            message_modulus.0 as u32,
+            carry_modulus.0 as u32,
+            PBSType::MultiBit as u32,
+            op as u32,
+            true,
+        );
+        cuda_scalar_comparison_integer_radix_ciphertext_kb_64(
+            self.as_c_ptr(),
+            radix_lwe_out.as_mut_c_ptr(),
+            radix_lwe_in.as_c_ptr(),
+            scalar_blocks.as_c_ptr(),
+            mem_ptr,
+            bootstrapping_key.as_c_ptr(),
+            keyswitch_key.as_c_ptr(),
+            num_blocks,
+            num_scalar_blocks,
+        );
+        cleanup_cuda_integer_comparison(self.as_c_ptr(), std::ptr::addr_of_mut!(mem_ptr));
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn full_propagate_classic_assign_async<T: UnsignedInteger>(
+    /// # Safety
+    ///
+    /// - [CudaStream::synchronize] __must__ be called after this function
+    /// as soon as synchronization is required
+    pub unsafe fn full_propagate_classic_assign_async<T: UnsignedInteger>(
         &self,
         radix_lwe_input: &mut CudaVec<T>,
         bootstrapping_key: &CudaVec<f64>,
@@ -1158,43 +1206,45 @@ impl CudaStream {
         carry_modulus: CarryModulus,
     ) {
         let mut mem_ptr: *mut i8 = std::ptr::null_mut();
-        unsafe {
-            scratch_cuda_full_propagation_64(
-                self.as_c_ptr(),
-                std::ptr::addr_of_mut!(mem_ptr),
-                lwe_dimension.0 as u32,
-                glwe_dimension.0 as u32,
-                polynomial_size.0 as u32,
-                pbs_level.0 as u32,
-                0,
-                num_blocks,
-                message_modulus.0 as u32,
-                carry_modulus.0 as u32,
-                PBSType::ClassicalLowLat as u32,
-                true,
-            );
-            cuda_full_propagation_64_inplace(
-                self.as_c_ptr(),
-                radix_lwe_input.as_mut_c_ptr(),
-                mem_ptr,
-                keyswitch_key.as_c_ptr(),
-                bootstrapping_key.as_c_ptr(),
-                lwe_dimension.0 as u32,
-                glwe_dimension.0 as u32,
-                polynomial_size.0 as u32,
-                ks_base_log.0 as u32,
-                ks_level.0 as u32,
-                pbs_base_log.0 as u32,
-                pbs_level.0 as u32,
-                0,
-                num_blocks,
-            );
-            cleanup_cuda_full_propagation(self.as_c_ptr(), std::ptr::addr_of_mut!(mem_ptr));
-        }
+        scratch_cuda_full_propagation_64(
+            self.as_c_ptr(),
+            std::ptr::addr_of_mut!(mem_ptr),
+            lwe_dimension.0 as u32,
+            glwe_dimension.0 as u32,
+            polynomial_size.0 as u32,
+            pbs_level.0 as u32,
+            0,
+            num_blocks,
+            message_modulus.0 as u32,
+            carry_modulus.0 as u32,
+            PBSType::ClassicalLowLat as u32,
+            true,
+        );
+        cuda_full_propagation_64_inplace(
+            self.as_c_ptr(),
+            radix_lwe_input.as_mut_c_ptr(),
+            mem_ptr,
+            keyswitch_key.as_c_ptr(),
+            bootstrapping_key.as_c_ptr(),
+            lwe_dimension.0 as u32,
+            glwe_dimension.0 as u32,
+            polynomial_size.0 as u32,
+            ks_base_log.0 as u32,
+            ks_level.0 as u32,
+            pbs_base_log.0 as u32,
+            pbs_level.0 as u32,
+            0,
+            num_blocks,
+        );
+        cleanup_cuda_full_propagation(self.as_c_ptr(), std::ptr::addr_of_mut!(mem_ptr));
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn full_propagate_multibit_assign_async<T: UnsignedInteger>(
+    /// # Safety
+    ///
+    /// - [CudaStream::synchronize] __must__ be called after this function
+    /// as soon as synchronization is required
+    pub unsafe fn full_propagate_multibit_assign_async<T: UnsignedInteger>(
         &self,
         radix_lwe_input: &mut CudaVec<T>,
         bootstrapping_key: &CudaVec<u64>,
@@ -1212,43 +1262,45 @@ impl CudaStream {
         carry_modulus: CarryModulus,
     ) {
         let mut mem_ptr: *mut i8 = std::ptr::null_mut();
-        unsafe {
-            scratch_cuda_full_propagation_64(
-                self.as_c_ptr(),
-                std::ptr::addr_of_mut!(mem_ptr),
-                lwe_dimension.0 as u32,
-                glwe_dimension.0 as u32,
-                polynomial_size.0 as u32,
-                pbs_level.0 as u32,
-                pbs_grouping_factor.0 as u32,
-                num_blocks,
-                message_modulus.0 as u32,
-                carry_modulus.0 as u32,
-                PBSType::MultiBit as u32,
-                true,
-            );
-            cuda_full_propagation_64_inplace(
-                self.as_c_ptr(),
-                radix_lwe_input.as_mut_c_ptr(),
-                mem_ptr,
-                keyswitch_key.as_c_ptr(),
-                bootstrapping_key.as_c_ptr(),
-                lwe_dimension.0 as u32,
-                glwe_dimension.0 as u32,
-                polynomial_size.0 as u32,
-                ks_base_log.0 as u32,
-                ks_level.0 as u32,
-                pbs_base_log.0 as u32,
-                pbs_level.0 as u32,
-                pbs_grouping_factor.0 as u32,
-                num_blocks,
-            );
-            cleanup_cuda_full_propagation(self.as_c_ptr(), std::ptr::addr_of_mut!(mem_ptr));
-        }
+        scratch_cuda_full_propagation_64(
+            self.as_c_ptr(),
+            std::ptr::addr_of_mut!(mem_ptr),
+            lwe_dimension.0 as u32,
+            glwe_dimension.0 as u32,
+            polynomial_size.0 as u32,
+            pbs_level.0 as u32,
+            pbs_grouping_factor.0 as u32,
+            num_blocks,
+            message_modulus.0 as u32,
+            carry_modulus.0 as u32,
+            PBSType::MultiBit as u32,
+            true,
+        );
+        cuda_full_propagation_64_inplace(
+            self.as_c_ptr(),
+            radix_lwe_input.as_mut_c_ptr(),
+            mem_ptr,
+            keyswitch_key.as_c_ptr(),
+            bootstrapping_key.as_c_ptr(),
+            lwe_dimension.0 as u32,
+            glwe_dimension.0 as u32,
+            polynomial_size.0 as u32,
+            ks_base_log.0 as u32,
+            ks_level.0 as u32,
+            pbs_base_log.0 as u32,
+            pbs_level.0 as u32,
+            pbs_grouping_factor.0 as u32,
+            num_blocks,
+        );
+        cleanup_cuda_full_propagation(self.as_c_ptr(), std::ptr::addr_of_mut!(mem_ptr));
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn propagate_single_carry_classic_assign_async<T: UnsignedInteger>(
+    /// # Safety
+    ///
+    /// - [CudaStream::synchronize] __must__ be called after this function
+    /// as soon as synchronization is required
+    pub unsafe fn propagate_single_carry_classic_assign_async<T: UnsignedInteger>(
         &self,
         radix_lwe_input: &mut CudaVec<T>,
         bootstrapping_key: &CudaVec<f64>,
@@ -1265,43 +1317,45 @@ impl CudaStream {
         carry_modulus: CarryModulus,
     ) {
         let mut mem_ptr: *mut i8 = std::ptr::null_mut();
-        unsafe {
-            let big_lwe_dimension: u32 = glwe_dimension.0 as u32 * polynomial_size.0 as u32;
-            scratch_cuda_propagate_single_carry_low_latency_kb_64_inplace(
-                self.as_c_ptr(),
-                std::ptr::addr_of_mut!(mem_ptr),
-                glwe_dimension.0 as u32,
-                polynomial_size.0 as u32,
-                big_lwe_dimension,
-                lwe_dimension.0 as u32,
-                ks_level.0 as u32,
-                ks_base_log.0 as u32,
-                pbs_level.0 as u32,
-                pbs_base_log.0 as u32,
-                0,
-                num_blocks,
-                message_modulus.0 as u32,
-                carry_modulus.0 as u32,
-                PBSType::ClassicalLowLat as u32,
-                true,
-            );
-            cuda_propagate_single_carry_low_latency_kb_64_inplace(
-                self.as_c_ptr(),
-                radix_lwe_input.as_mut_c_ptr(),
-                mem_ptr,
-                bootstrapping_key.as_c_ptr(),
-                keyswitch_key.as_c_ptr(),
-                num_blocks,
-            );
-            cleanup_cuda_propagate_single_carry_low_latency(
-                self.as_c_ptr(),
-                std::ptr::addr_of_mut!(mem_ptr),
-            );
-        }
+        let big_lwe_dimension: u32 = glwe_dimension.0 as u32 * polynomial_size.0 as u32;
+        scratch_cuda_propagate_single_carry_low_latency_kb_64_inplace(
+            self.as_c_ptr(),
+            std::ptr::addr_of_mut!(mem_ptr),
+            glwe_dimension.0 as u32,
+            polynomial_size.0 as u32,
+            big_lwe_dimension,
+            lwe_dimension.0 as u32,
+            ks_level.0 as u32,
+            ks_base_log.0 as u32,
+            pbs_level.0 as u32,
+            pbs_base_log.0 as u32,
+            0,
+            num_blocks,
+            message_modulus.0 as u32,
+            carry_modulus.0 as u32,
+            PBSType::ClassicalLowLat as u32,
+            true,
+        );
+        cuda_propagate_single_carry_low_latency_kb_64_inplace(
+            self.as_c_ptr(),
+            radix_lwe_input.as_mut_c_ptr(),
+            mem_ptr,
+            bootstrapping_key.as_c_ptr(),
+            keyswitch_key.as_c_ptr(),
+            num_blocks,
+        );
+        cleanup_cuda_propagate_single_carry_low_latency(
+            self.as_c_ptr(),
+            std::ptr::addr_of_mut!(mem_ptr),
+        );
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn propagate_single_carry_multibit_assign_async<T: UnsignedInteger>(
+    /// # Safety
+    ///
+    /// - [CudaStream::synchronize] __must__ be called after this function
+    /// as soon as synchronization is required
+    pub unsafe fn propagate_single_carry_multibit_assign_async<T: UnsignedInteger>(
         &self,
         radix_lwe_input: &mut CudaVec<T>,
         bootstrapping_key: &CudaVec<u64>,
@@ -1319,43 +1373,47 @@ impl CudaStream {
         carry_modulus: CarryModulus,
     ) {
         let mut mem_ptr: *mut i8 = std::ptr::null_mut();
-        unsafe {
-            let big_lwe_dimension: u32 = glwe_dimension.0 as u32 * polynomial_size.0 as u32;
-            scratch_cuda_propagate_single_carry_low_latency_kb_64_inplace(
-                self.as_c_ptr(),
-                std::ptr::addr_of_mut!(mem_ptr),
-                glwe_dimension.0 as u32,
-                polynomial_size.0 as u32,
-                big_lwe_dimension,
-                lwe_dimension.0 as u32,
-                ks_level.0 as u32,
-                ks_base_log.0 as u32,
-                pbs_level.0 as u32,
-                pbs_base_log.0 as u32,
-                pbs_grouping_factor.0 as u32,
-                num_blocks,
-                message_modulus.0 as u32,
-                carry_modulus.0 as u32,
-                PBSType::MultiBit as u32,
-                true,
-            );
-            cuda_propagate_single_carry_low_latency_kb_64_inplace(
-                self.as_c_ptr(),
-                radix_lwe_input.as_mut_c_ptr(),
-                mem_ptr,
-                bootstrapping_key.as_c_ptr(),
-                keyswitch_key.as_c_ptr(),
-                num_blocks,
-            );
-            cleanup_cuda_propagate_single_carry_low_latency(
-                self.as_c_ptr(),
-                std::ptr::addr_of_mut!(mem_ptr),
-            );
-        }
+        let big_lwe_dimension: u32 = glwe_dimension.0 as u32 * polynomial_size.0 as u32;
+        scratch_cuda_propagate_single_carry_low_latency_kb_64_inplace(
+            self.as_c_ptr(),
+            std::ptr::addr_of_mut!(mem_ptr),
+            glwe_dimension.0 as u32,
+            polynomial_size.0 as u32,
+            big_lwe_dimension,
+            lwe_dimension.0 as u32,
+            ks_level.0 as u32,
+            ks_base_log.0 as u32,
+            pbs_level.0 as u32,
+            pbs_base_log.0 as u32,
+            pbs_grouping_factor.0 as u32,
+            num_blocks,
+            message_modulus.0 as u32,
+            carry_modulus.0 as u32,
+            PBSType::MultiBit as u32,
+            true,
+        );
+        cuda_propagate_single_carry_low_latency_kb_64_inplace(
+            self.as_c_ptr(),
+            radix_lwe_input.as_mut_c_ptr(),
+            mem_ptr,
+            bootstrapping_key.as_c_ptr(),
+            keyswitch_key.as_c_ptr(),
+            num_blocks,
+        );
+        cleanup_cuda_propagate_single_carry_low_latency(
+            self.as_c_ptr(),
+            std::ptr::addr_of_mut!(mem_ptr),
+        );
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn unchecked_scalar_shift_left_integer_radix_classic_kb_assign_async<T: UnsignedInteger>(
+    /// # Safety
+    ///
+    /// - [CudaStream::synchronize] __must__ be called after this function
+    /// as soon as synchronization is required
+    pub unsafe fn unchecked_scalar_shift_left_integer_radix_classic_kb_assign_async<
+        T: UnsignedInteger,
+    >(
         &self,
         radix_lwe_left: &mut CudaVec<T>,
         shift: u32,
@@ -1374,44 +1432,43 @@ impl CudaStream {
         num_blocks: u32,
     ) {
         let mut mem_ptr: *mut i8 = std::ptr::null_mut();
-        unsafe {
-            scratch_cuda_integer_radix_scalar_shift_kb_64(
-                self.as_c_ptr(),
-                std::ptr::addr_of_mut!(mem_ptr),
-                glwe_dimension.0 as u32,
-                polynomial_size.0 as u32,
-                big_lwe_dimension.0 as u32,
-                small_lwe_dimension.0 as u32,
-                ks_level.0 as u32,
-                ks_base_log.0 as u32,
-                pbs_level.0 as u32,
-                pbs_base_log.0 as u32,
-                0,
-                num_blocks,
-                message_modulus.0 as u32,
-                carry_modulus.0 as u32,
-                PBSType::ClassicalLowLat as u32,
-                ShiftType::Left as u32,
-                true,
-            );
-            cuda_integer_radix_scalar_shift_kb_64_inplace(
-                self.as_c_ptr(),
-                radix_lwe_left.as_mut_c_ptr(),
-                shift,
-                mem_ptr,
-                bootstrapping_key.as_c_ptr(),
-                keyswitch_key.as_c_ptr(),
-                num_blocks,
-            );
-            cleanup_cuda_integer_radix_scalar_shift(
-                self.as_c_ptr(),
-                std::ptr::addr_of_mut!(mem_ptr),
-            );
-        }
+        scratch_cuda_integer_radix_scalar_shift_kb_64(
+            self.as_c_ptr(),
+            std::ptr::addr_of_mut!(mem_ptr),
+            glwe_dimension.0 as u32,
+            polynomial_size.0 as u32,
+            big_lwe_dimension.0 as u32,
+            small_lwe_dimension.0 as u32,
+            ks_level.0 as u32,
+            ks_base_log.0 as u32,
+            pbs_level.0 as u32,
+            pbs_base_log.0 as u32,
+            0,
+            num_blocks,
+            message_modulus.0 as u32,
+            carry_modulus.0 as u32,
+            PBSType::ClassicalLowLat as u32,
+            ShiftType::Left as u32,
+            true,
+        );
+        cuda_integer_radix_scalar_shift_kb_64_inplace(
+            self.as_c_ptr(),
+            radix_lwe_left.as_mut_c_ptr(),
+            shift,
+            mem_ptr,
+            bootstrapping_key.as_c_ptr(),
+            keyswitch_key.as_c_ptr(),
+            num_blocks,
+        );
+        cleanup_cuda_integer_radix_scalar_shift(self.as_c_ptr(), std::ptr::addr_of_mut!(mem_ptr));
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn unchecked_scalar_shift_left_integer_radix_multibit_kb_assign_async<
+    /// # Safety
+    ///
+    /// - [CudaStream::synchronize] __must__ be called after this function
+    /// as soon as synchronization is required
+    pub unsafe fn unchecked_scalar_shift_left_integer_radix_multibit_kb_assign_async<
         T: UnsignedInteger,
     >(
         &self,
@@ -1433,44 +1490,43 @@ impl CudaStream {
         num_blocks: u32,
     ) {
         let mut mem_ptr: *mut i8 = std::ptr::null_mut();
-        unsafe {
-            scratch_cuda_integer_radix_scalar_shift_kb_64(
-                self.as_c_ptr(),
-                std::ptr::addr_of_mut!(mem_ptr),
-                glwe_dimension.0 as u32,
-                polynomial_size.0 as u32,
-                big_lwe_dimension.0 as u32,
-                small_lwe_dimension.0 as u32,
-                ks_level.0 as u32,
-                ks_base_log.0 as u32,
-                pbs_level.0 as u32,
-                pbs_base_log.0 as u32,
-                pbs_grouping_factor.0 as u32,
-                num_blocks,
-                message_modulus.0 as u32,
-                carry_modulus.0 as u32,
-                PBSType::MultiBit as u32,
-                ShiftType::Left as u32,
-                true,
-            );
-            cuda_integer_radix_scalar_shift_kb_64_inplace(
-                self.as_c_ptr(),
-                radix_lwe_left.as_mut_c_ptr(),
-                shift,
-                mem_ptr,
-                bootstrapping_key.as_c_ptr(),
-                keyswitch_key.as_c_ptr(),
-                num_blocks,
-            );
-            cleanup_cuda_integer_radix_scalar_shift(
-                self.as_c_ptr(),
-                std::ptr::addr_of_mut!(mem_ptr),
-            );
-        }
+        scratch_cuda_integer_radix_scalar_shift_kb_64(
+            self.as_c_ptr(),
+            std::ptr::addr_of_mut!(mem_ptr),
+            glwe_dimension.0 as u32,
+            polynomial_size.0 as u32,
+            big_lwe_dimension.0 as u32,
+            small_lwe_dimension.0 as u32,
+            ks_level.0 as u32,
+            ks_base_log.0 as u32,
+            pbs_level.0 as u32,
+            pbs_base_log.0 as u32,
+            pbs_grouping_factor.0 as u32,
+            num_blocks,
+            message_modulus.0 as u32,
+            carry_modulus.0 as u32,
+            PBSType::MultiBit as u32,
+            ShiftType::Left as u32,
+            true,
+        );
+        cuda_integer_radix_scalar_shift_kb_64_inplace(
+            self.as_c_ptr(),
+            radix_lwe_left.as_mut_c_ptr(),
+            shift,
+            mem_ptr,
+            bootstrapping_key.as_c_ptr(),
+            keyswitch_key.as_c_ptr(),
+            num_blocks,
+        );
+        cleanup_cuda_integer_radix_scalar_shift(self.as_c_ptr(), std::ptr::addr_of_mut!(mem_ptr));
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn unchecked_scalar_shift_right_integer_radix_classic_kb_assign_async<
+    /// # Safety
+    ///
+    /// - [CudaStream::synchronize] __must__ be called after this function
+    /// as soon as synchronization is required
+    pub unsafe fn unchecked_scalar_shift_right_integer_radix_classic_kb_assign_async<
         T: UnsignedInteger,
     >(
         &self,
@@ -1491,44 +1547,43 @@ impl CudaStream {
         num_blocks: u32,
     ) {
         let mut mem_ptr: *mut i8 = std::ptr::null_mut();
-        unsafe {
-            scratch_cuda_integer_radix_scalar_shift_kb_64(
-                self.as_c_ptr(),
-                std::ptr::addr_of_mut!(mem_ptr),
-                glwe_dimension.0 as u32,
-                polynomial_size.0 as u32,
-                big_lwe_dimension.0 as u32,
-                small_lwe_dimension.0 as u32,
-                ks_level.0 as u32,
-                ks_base_log.0 as u32,
-                pbs_level.0 as u32,
-                pbs_base_log.0 as u32,
-                0,
-                num_blocks,
-                message_modulus.0 as u32,
-                carry_modulus.0 as u32,
-                PBSType::ClassicalLowLat as u32,
-                ShiftType::Right as u32,
-                true,
-            );
-            cuda_integer_radix_scalar_shift_kb_64_inplace(
-                self.as_c_ptr(),
-                radix_lwe_left.as_mut_c_ptr(),
-                shift,
-                mem_ptr,
-                bootstrapping_key.as_c_ptr(),
-                keyswitch_key.as_c_ptr(),
-                num_blocks,
-            );
-            cleanup_cuda_integer_radix_scalar_shift(
-                self.as_c_ptr(),
-                std::ptr::addr_of_mut!(mem_ptr),
-            );
-        }
+        scratch_cuda_integer_radix_scalar_shift_kb_64(
+            self.as_c_ptr(),
+            std::ptr::addr_of_mut!(mem_ptr),
+            glwe_dimension.0 as u32,
+            polynomial_size.0 as u32,
+            big_lwe_dimension.0 as u32,
+            small_lwe_dimension.0 as u32,
+            ks_level.0 as u32,
+            ks_base_log.0 as u32,
+            pbs_level.0 as u32,
+            pbs_base_log.0 as u32,
+            0,
+            num_blocks,
+            message_modulus.0 as u32,
+            carry_modulus.0 as u32,
+            PBSType::ClassicalLowLat as u32,
+            ShiftType::Right as u32,
+            true,
+        );
+        cuda_integer_radix_scalar_shift_kb_64_inplace(
+            self.as_c_ptr(),
+            radix_lwe_left.as_mut_c_ptr(),
+            shift,
+            mem_ptr,
+            bootstrapping_key.as_c_ptr(),
+            keyswitch_key.as_c_ptr(),
+            num_blocks,
+        );
+        cleanup_cuda_integer_radix_scalar_shift(self.as_c_ptr(), std::ptr::addr_of_mut!(mem_ptr));
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn unchecked_scalar_shift_right_integer_radix_multibit_kb_assign_async<
+    /// # Safety
+    ///
+    /// - [CudaStream::synchronize] __must__ be called after this function
+    /// as soon as synchronization is required
+    pub unsafe fn unchecked_scalar_shift_right_integer_radix_multibit_kb_assign_async<
         T: UnsignedInteger,
     >(
         &self,
@@ -1550,44 +1605,43 @@ impl CudaStream {
         num_blocks: u32,
     ) {
         let mut mem_ptr: *mut i8 = std::ptr::null_mut();
-        unsafe {
-            scratch_cuda_integer_radix_scalar_shift_kb_64(
-                self.as_c_ptr(),
-                std::ptr::addr_of_mut!(mem_ptr),
-                glwe_dimension.0 as u32,
-                polynomial_size.0 as u32,
-                big_lwe_dimension.0 as u32,
-                small_lwe_dimension.0 as u32,
-                ks_level.0 as u32,
-                ks_base_log.0 as u32,
-                pbs_level.0 as u32,
-                pbs_base_log.0 as u32,
-                pbs_grouping_factor.0 as u32,
-                num_blocks,
-                message_modulus.0 as u32,
-                carry_modulus.0 as u32,
-                PBSType::MultiBit as u32,
-                ShiftType::Right as u32,
-                true,
-            );
-            cuda_integer_radix_scalar_shift_kb_64_inplace(
-                self.as_c_ptr(),
-                radix_lwe_left.as_mut_c_ptr(),
-                shift,
-                mem_ptr,
-                bootstrapping_key.as_c_ptr(),
-                keyswitch_key.as_c_ptr(),
-                num_blocks,
-            );
-            cleanup_cuda_integer_radix_scalar_shift(
-                self.as_c_ptr(),
-                std::ptr::addr_of_mut!(mem_ptr),
-            );
-        }
+        scratch_cuda_integer_radix_scalar_shift_kb_64(
+            self.as_c_ptr(),
+            std::ptr::addr_of_mut!(mem_ptr),
+            glwe_dimension.0 as u32,
+            polynomial_size.0 as u32,
+            big_lwe_dimension.0 as u32,
+            small_lwe_dimension.0 as u32,
+            ks_level.0 as u32,
+            ks_base_log.0 as u32,
+            pbs_level.0 as u32,
+            pbs_base_log.0 as u32,
+            pbs_grouping_factor.0 as u32,
+            num_blocks,
+            message_modulus.0 as u32,
+            carry_modulus.0 as u32,
+            PBSType::MultiBit as u32,
+            ShiftType::Right as u32,
+            true,
+        );
+        cuda_integer_radix_scalar_shift_kb_64_inplace(
+            self.as_c_ptr(),
+            radix_lwe_left.as_mut_c_ptr(),
+            shift,
+            mem_ptr,
+            bootstrapping_key.as_c_ptr(),
+            keyswitch_key.as_c_ptr(),
+            num_blocks,
+        );
+        cleanup_cuda_integer_radix_scalar_shift(self.as_c_ptr(), std::ptr::addr_of_mut!(mem_ptr));
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn unchecked_cmux_integer_radix_classic_kb_async<T: UnsignedInteger>(
+    /// # Safety
+    ///
+    /// - [CudaStream::synchronize] __must__ be called after this function
+    /// as soon as synchronization is required
+    pub unsafe fn unchecked_cmux_integer_radix_classic_kb_async<T: UnsignedInteger>(
         &self,
         radix_lwe_out: &mut CudaVec<T>,
         radix_lwe_condition: &CudaVec<T>,
@@ -1608,42 +1662,44 @@ impl CudaStream {
         num_blocks: u32,
     ) {
         let mut mem_ptr: *mut i8 = std::ptr::null_mut();
-        unsafe {
-            scratch_cuda_integer_radix_cmux_kb_64(
-                self.as_c_ptr(),
-                std::ptr::addr_of_mut!(mem_ptr),
-                glwe_dimension.0 as u32,
-                polynomial_size.0 as u32,
-                big_lwe_dimension.0 as u32,
-                small_lwe_dimension.0 as u32,
-                ks_level.0 as u32,
-                ks_base_log.0 as u32,
-                pbs_level.0 as u32,
-                pbs_base_log.0 as u32,
-                0,
-                num_blocks,
-                message_modulus.0 as u32,
-                carry_modulus.0 as u32,
-                PBSType::ClassicalLowLat as u32,
-                true,
-            );
-            cuda_cmux_integer_radix_ciphertext_kb_64(
-                self.as_c_ptr(),
-                radix_lwe_out.as_mut_c_ptr(),
-                radix_lwe_condition.as_c_ptr(),
-                radix_lwe_true.as_c_ptr(),
-                radix_lwe_false.as_c_ptr(),
-                mem_ptr,
-                bootstrapping_key.as_c_ptr(),
-                keyswitch_key.as_c_ptr(),
-                num_blocks,
-            );
-            cleanup_cuda_integer_radix_cmux(self.as_c_ptr(), std::ptr::addr_of_mut!(mem_ptr));
-        }
+        scratch_cuda_integer_radix_cmux_kb_64(
+            self.as_c_ptr(),
+            std::ptr::addr_of_mut!(mem_ptr),
+            glwe_dimension.0 as u32,
+            polynomial_size.0 as u32,
+            big_lwe_dimension.0 as u32,
+            small_lwe_dimension.0 as u32,
+            ks_level.0 as u32,
+            ks_base_log.0 as u32,
+            pbs_level.0 as u32,
+            pbs_base_log.0 as u32,
+            0,
+            num_blocks,
+            message_modulus.0 as u32,
+            carry_modulus.0 as u32,
+            PBSType::ClassicalLowLat as u32,
+            true,
+        );
+        cuda_cmux_integer_radix_ciphertext_kb_64(
+            self.as_c_ptr(),
+            radix_lwe_out.as_mut_c_ptr(),
+            radix_lwe_condition.as_c_ptr(),
+            radix_lwe_true.as_c_ptr(),
+            radix_lwe_false.as_c_ptr(),
+            mem_ptr,
+            bootstrapping_key.as_c_ptr(),
+            keyswitch_key.as_c_ptr(),
+            num_blocks,
+        );
+        cleanup_cuda_integer_radix_cmux(self.as_c_ptr(), std::ptr::addr_of_mut!(mem_ptr));
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn unchecked_cmux_integer_radix_multibit_kb_async<T: UnsignedInteger>(
+    /// # Safety
+    ///
+    /// - [CudaStream::synchronize] __must__ be called after this function
+    /// as soon as synchronization is required
+    pub unsafe fn unchecked_cmux_integer_radix_multibit_kb_async<T: UnsignedInteger>(
         &self,
         radix_lwe_out: &mut CudaVec<T>,
         radix_lwe_condition: &CudaVec<T>,
@@ -1665,42 +1721,44 @@ impl CudaStream {
         num_blocks: u32,
     ) {
         let mut mem_ptr: *mut i8 = std::ptr::null_mut();
-        unsafe {
-            scratch_cuda_integer_radix_cmux_kb_64(
-                self.as_c_ptr(),
-                std::ptr::addr_of_mut!(mem_ptr),
-                glwe_dimension.0 as u32,
-                polynomial_size.0 as u32,
-                big_lwe_dimension.0 as u32,
-                small_lwe_dimension.0 as u32,
-                ks_level.0 as u32,
-                ks_base_log.0 as u32,
-                pbs_level.0 as u32,
-                pbs_base_log.0 as u32,
-                pbs_grouping_factor.0 as u32,
-                num_blocks,
-                message_modulus.0 as u32,
-                carry_modulus.0 as u32,
-                PBSType::MultiBit as u32,
-                true,
-            );
-            cuda_cmux_integer_radix_ciphertext_kb_64(
-                self.as_c_ptr(),
-                radix_lwe_out.as_mut_c_ptr(),
-                radix_lwe_condition.as_c_ptr(),
-                radix_lwe_true.as_c_ptr(),
-                radix_lwe_false.as_c_ptr(),
-                mem_ptr,
-                bootstrapping_key.as_c_ptr(),
-                keyswitch_key.as_c_ptr(),
-                num_blocks,
-            );
-            cleanup_cuda_integer_radix_cmux(self.as_c_ptr(), std::ptr::addr_of_mut!(mem_ptr));
-        }
+        scratch_cuda_integer_radix_cmux_kb_64(
+            self.as_c_ptr(),
+            std::ptr::addr_of_mut!(mem_ptr),
+            glwe_dimension.0 as u32,
+            polynomial_size.0 as u32,
+            big_lwe_dimension.0 as u32,
+            small_lwe_dimension.0 as u32,
+            ks_level.0 as u32,
+            ks_base_log.0 as u32,
+            pbs_level.0 as u32,
+            pbs_base_log.0 as u32,
+            pbs_grouping_factor.0 as u32,
+            num_blocks,
+            message_modulus.0 as u32,
+            carry_modulus.0 as u32,
+            PBSType::MultiBit as u32,
+            true,
+        );
+        cuda_cmux_integer_radix_ciphertext_kb_64(
+            self.as_c_ptr(),
+            radix_lwe_out.as_mut_c_ptr(),
+            radix_lwe_condition.as_c_ptr(),
+            radix_lwe_true.as_c_ptr(),
+            radix_lwe_false.as_c_ptr(),
+            mem_ptr,
+            bootstrapping_key.as_c_ptr(),
+            keyswitch_key.as_c_ptr(),
+            num_blocks,
+        );
+        cleanup_cuda_integer_radix_cmux(self.as_c_ptr(), std::ptr::addr_of_mut!(mem_ptr));
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn unchecked_scalar_rotate_left_integer_radix_classic_kb_assign_async<
+    /// # Safety
+    ///
+    /// - [CudaStream::synchronize] __must__ be called after this function
+    /// as soon as synchronization is required
+    pub unsafe fn unchecked_scalar_rotate_left_integer_radix_classic_kb_assign_async<
         T: UnsignedInteger,
     >(
         &self,
@@ -1721,44 +1779,43 @@ impl CudaStream {
         num_blocks: u32,
     ) {
         let mut mem_ptr: *mut i8 = std::ptr::null_mut();
-        unsafe {
-            scratch_cuda_integer_radix_scalar_rotate_kb_64(
-                self.as_c_ptr(),
-                std::ptr::addr_of_mut!(mem_ptr),
-                glwe_dimension.0 as u32,
-                polynomial_size.0 as u32,
-                big_lwe_dimension.0 as u32,
-                small_lwe_dimension.0 as u32,
-                ks_level.0 as u32,
-                ks_base_log.0 as u32,
-                pbs_level.0 as u32,
-                pbs_base_log.0 as u32,
-                0,
-                num_blocks,
-                message_modulus.0 as u32,
-                carry_modulus.0 as u32,
-                PBSType::ClassicalLowLat as u32,
-                ShiftType::Left as u32,
-                true,
-            );
-            cuda_integer_radix_scalar_rotate_kb_64_inplace(
-                self.as_c_ptr(),
-                radix_lwe_left.as_mut_c_ptr(),
-                n,
-                mem_ptr,
-                bootstrapping_key.as_c_ptr(),
-                keyswitch_key.as_c_ptr(),
-                num_blocks,
-            );
-            cleanup_cuda_integer_radix_scalar_rotate(
-                self.as_c_ptr(),
-                std::ptr::addr_of_mut!(mem_ptr),
-            );
-        }
+        scratch_cuda_integer_radix_scalar_rotate_kb_64(
+            self.as_c_ptr(),
+            std::ptr::addr_of_mut!(mem_ptr),
+            glwe_dimension.0 as u32,
+            polynomial_size.0 as u32,
+            big_lwe_dimension.0 as u32,
+            small_lwe_dimension.0 as u32,
+            ks_level.0 as u32,
+            ks_base_log.0 as u32,
+            pbs_level.0 as u32,
+            pbs_base_log.0 as u32,
+            0,
+            num_blocks,
+            message_modulus.0 as u32,
+            carry_modulus.0 as u32,
+            PBSType::ClassicalLowLat as u32,
+            ShiftType::Left as u32,
+            true,
+        );
+        cuda_integer_radix_scalar_rotate_kb_64_inplace(
+            self.as_c_ptr(),
+            radix_lwe_left.as_mut_c_ptr(),
+            n,
+            mem_ptr,
+            bootstrapping_key.as_c_ptr(),
+            keyswitch_key.as_c_ptr(),
+            num_blocks,
+        );
+        cleanup_cuda_integer_radix_scalar_rotate(self.as_c_ptr(), std::ptr::addr_of_mut!(mem_ptr));
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn unchecked_scalar_rotate_left_integer_radix_multibit_kb_assign_async<
+    /// # Safety
+    ///
+    /// - [CudaStream::synchronize] __must__ be called after this function
+    /// as soon as synchronization is required
+    pub unsafe fn unchecked_scalar_rotate_left_integer_radix_multibit_kb_assign_async<
         T: UnsignedInteger,
     >(
         &self,
@@ -1780,44 +1837,43 @@ impl CudaStream {
         num_blocks: u32,
     ) {
         let mut mem_ptr: *mut i8 = std::ptr::null_mut();
-        unsafe {
-            scratch_cuda_integer_radix_scalar_rotate_kb_64(
-                self.as_c_ptr(),
-                std::ptr::addr_of_mut!(mem_ptr),
-                glwe_dimension.0 as u32,
-                polynomial_size.0 as u32,
-                big_lwe_dimension.0 as u32,
-                small_lwe_dimension.0 as u32,
-                ks_level.0 as u32,
-                ks_base_log.0 as u32,
-                pbs_level.0 as u32,
-                pbs_base_log.0 as u32,
-                pbs_grouping_factor.0 as u32,
-                num_blocks,
-                message_modulus.0 as u32,
-                carry_modulus.0 as u32,
-                PBSType::MultiBit as u32,
-                ShiftType::Left as u32,
-                true,
-            );
-            cuda_integer_radix_scalar_rotate_kb_64_inplace(
-                self.as_c_ptr(),
-                radix_lwe_left.as_mut_c_ptr(),
-                n,
-                mem_ptr,
-                bootstrapping_key.as_c_ptr(),
-                keyswitch_key.as_c_ptr(),
-                num_blocks,
-            );
-            cleanup_cuda_integer_radix_scalar_rotate(
-                self.as_c_ptr(),
-                std::ptr::addr_of_mut!(mem_ptr),
-            );
-        }
+        scratch_cuda_integer_radix_scalar_rotate_kb_64(
+            self.as_c_ptr(),
+            std::ptr::addr_of_mut!(mem_ptr),
+            glwe_dimension.0 as u32,
+            polynomial_size.0 as u32,
+            big_lwe_dimension.0 as u32,
+            small_lwe_dimension.0 as u32,
+            ks_level.0 as u32,
+            ks_base_log.0 as u32,
+            pbs_level.0 as u32,
+            pbs_base_log.0 as u32,
+            pbs_grouping_factor.0 as u32,
+            num_blocks,
+            message_modulus.0 as u32,
+            carry_modulus.0 as u32,
+            PBSType::MultiBit as u32,
+            ShiftType::Left as u32,
+            true,
+        );
+        cuda_integer_radix_scalar_rotate_kb_64_inplace(
+            self.as_c_ptr(),
+            radix_lwe_left.as_mut_c_ptr(),
+            n,
+            mem_ptr,
+            bootstrapping_key.as_c_ptr(),
+            keyswitch_key.as_c_ptr(),
+            num_blocks,
+        );
+        cleanup_cuda_integer_radix_scalar_rotate(self.as_c_ptr(), std::ptr::addr_of_mut!(mem_ptr));
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn unchecked_scalar_rotate_right_integer_radix_classic_kb_assign_async<
+    /// # Safety
+    ///
+    /// - [CudaStream::synchronize] __must__ be called after this function
+    /// as soon as synchronization is required
+    pub unsafe fn unchecked_scalar_rotate_right_integer_radix_classic_kb_assign_async<
         T: UnsignedInteger,
     >(
         &self,
@@ -1838,44 +1894,43 @@ impl CudaStream {
         num_blocks: u32,
     ) {
         let mut mem_ptr: *mut i8 = std::ptr::null_mut();
-        unsafe {
-            scratch_cuda_integer_radix_scalar_rotate_kb_64(
-                self.as_c_ptr(),
-                std::ptr::addr_of_mut!(mem_ptr),
-                glwe_dimension.0 as u32,
-                polynomial_size.0 as u32,
-                big_lwe_dimension.0 as u32,
-                small_lwe_dimension.0 as u32,
-                ks_level.0 as u32,
-                ks_base_log.0 as u32,
-                pbs_level.0 as u32,
-                pbs_base_log.0 as u32,
-                0,
-                num_blocks,
-                message_modulus.0 as u32,
-                carry_modulus.0 as u32,
-                PBSType::ClassicalLowLat as u32,
-                ShiftType::Right as u32,
-                true,
-            );
-            cuda_integer_radix_scalar_rotate_kb_64_inplace(
-                self.as_c_ptr(),
-                radix_lwe_left.as_mut_c_ptr(),
-                n,
-                mem_ptr,
-                bootstrapping_key.as_c_ptr(),
-                keyswitch_key.as_c_ptr(),
-                num_blocks,
-            );
-            cleanup_cuda_integer_radix_scalar_rotate(
-                self.as_c_ptr(),
-                std::ptr::addr_of_mut!(mem_ptr),
-            );
-        }
+        scratch_cuda_integer_radix_scalar_rotate_kb_64(
+            self.as_c_ptr(),
+            std::ptr::addr_of_mut!(mem_ptr),
+            glwe_dimension.0 as u32,
+            polynomial_size.0 as u32,
+            big_lwe_dimension.0 as u32,
+            small_lwe_dimension.0 as u32,
+            ks_level.0 as u32,
+            ks_base_log.0 as u32,
+            pbs_level.0 as u32,
+            pbs_base_log.0 as u32,
+            0,
+            num_blocks,
+            message_modulus.0 as u32,
+            carry_modulus.0 as u32,
+            PBSType::ClassicalLowLat as u32,
+            ShiftType::Right as u32,
+            true,
+        );
+        cuda_integer_radix_scalar_rotate_kb_64_inplace(
+            self.as_c_ptr(),
+            radix_lwe_left.as_mut_c_ptr(),
+            n,
+            mem_ptr,
+            bootstrapping_key.as_c_ptr(),
+            keyswitch_key.as_c_ptr(),
+            num_blocks,
+        );
+        cleanup_cuda_integer_radix_scalar_rotate(self.as_c_ptr(), std::ptr::addr_of_mut!(mem_ptr));
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn unchecked_scalar_rotate_right_integer_radix_multibit_kb_assign_async<
+    /// # Safety
+    ///
+    /// - [CudaStream::synchronize] __must__ be called after this function
+    /// as soon as synchronization is required
+    pub unsafe fn unchecked_scalar_rotate_right_integer_radix_multibit_kb_assign_async<
         T: UnsignedInteger,
     >(
         &self,
@@ -1897,39 +1952,34 @@ impl CudaStream {
         num_blocks: u32,
     ) {
         let mut mem_ptr: *mut i8 = std::ptr::null_mut();
-        unsafe {
-            scratch_cuda_integer_radix_scalar_rotate_kb_64(
-                self.as_c_ptr(),
-                std::ptr::addr_of_mut!(mem_ptr),
-                glwe_dimension.0 as u32,
-                polynomial_size.0 as u32,
-                big_lwe_dimension.0 as u32,
-                small_lwe_dimension.0 as u32,
-                ks_level.0 as u32,
-                ks_base_log.0 as u32,
-                pbs_level.0 as u32,
-                pbs_base_log.0 as u32,
-                pbs_grouping_factor.0 as u32,
-                num_blocks,
-                message_modulus.0 as u32,
-                carry_modulus.0 as u32,
-                PBSType::MultiBit as u32,
-                ShiftType::Right as u32,
-                true,
-            );
-            cuda_integer_radix_scalar_rotate_kb_64_inplace(
-                self.as_c_ptr(),
-                radix_lwe_left.as_mut_c_ptr(),
-                n,
-                mem_ptr,
-                bootstrapping_key.as_c_ptr(),
-                keyswitch_key.as_c_ptr(),
-                num_blocks,
-            );
-            cleanup_cuda_integer_radix_scalar_rotate(
-                self.as_c_ptr(),
-                std::ptr::addr_of_mut!(mem_ptr),
-            );
-        }
+        scratch_cuda_integer_radix_scalar_rotate_kb_64(
+            self.as_c_ptr(),
+            std::ptr::addr_of_mut!(mem_ptr),
+            glwe_dimension.0 as u32,
+            polynomial_size.0 as u32,
+            big_lwe_dimension.0 as u32,
+            small_lwe_dimension.0 as u32,
+            ks_level.0 as u32,
+            ks_base_log.0 as u32,
+            pbs_level.0 as u32,
+            pbs_base_log.0 as u32,
+            pbs_grouping_factor.0 as u32,
+            num_blocks,
+            message_modulus.0 as u32,
+            carry_modulus.0 as u32,
+            PBSType::MultiBit as u32,
+            ShiftType::Right as u32,
+            true,
+        );
+        cuda_integer_radix_scalar_rotate_kb_64_inplace(
+            self.as_c_ptr(),
+            radix_lwe_left.as_mut_c_ptr(),
+            n,
+            mem_ptr,
+            bootstrapping_key.as_c_ptr(),
+            keyswitch_key.as_c_ptr(),
+            num_blocks,
+        );
+        cleanup_cuda_integer_radix_scalar_rotate(self.as_c_ptr(), std::ptr::addr_of_mut!(mem_ptr));
     }
 }

--- a/tfhe/src/integer/gpu/server_key/radix/scalar_rotate.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/scalar_rotate.rs
@@ -253,7 +253,6 @@ impl CudaServerKey {
     {
         let mut result = unsafe { ct.duplicate_async(stream) };
         self.scalar_rotate_left_assign(&mut result, shift, stream);
-        stream.synchronize();
         result
     }
 
@@ -269,7 +268,6 @@ impl CudaServerKey {
     {
         let mut result = unsafe { ct.duplicate_async(stream) };
         self.scalar_rotate_right_assign(&mut result, shift, stream);
-        stream.synchronize();
         result
     }
 }


### PR DESCRIPTION
closes: https://github.com/zama-ai/tfhe-rs-internal/issues/433

### PR content/description

This PR fixes the `cuda_drop` binding between C++ and Rust.
It also makes all async functions unsafe in the GPU modules, adds some missing synchronize calls and removes two redundant ones.

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
