### PR TITLE
docs(bench): add scalar benchmarks for integer

### DIFF
--- a/tfhe/docs/getting_started/benchmarks.md
+++ b/tfhe/docs/getting_started/benchmarks.md
@@ -3,26 +3,42 @@
 Due to their nature, homomorphic operations are naturally slower than their cleartext equivalents. Some timings are exposed for basic operations. For completeness, benchmarks for other libraries are also given.
 
 {% hint style="info" %}
-All benchmarks were launched on an AWS m6i.metal with the following specifications: Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz and 512GB of RAM.
+All benchmarks were launched on an AWS hpc7a.96xlarge instance with the following specifications: AMD EPYC 9R14 CPU @ 2.60GHz and 740GB of RAM.
 {% endhint %}
 
 ## Integer
 
 This measures the execution time for some operation sets of tfhe-rs::integer (the unsigned version). Note that the timings for `FheInt` (i.e., the signed integers) are similar.
 
+The table below reports the timing when the inputs of the benchmarked operation are encrypted.
+
 | Operation \ Size                                       | `FheUint8` | `FheUint16` | `FheUint32` | `FheUint64` | `FheUint128` | `FheUint256` |
 |--------------------------------------------------------|------------|-------------|-------------|-------------|--------------|--------------|
-| Negation (`-`)                                         | 70.9 ms    | 99.3 ms     | 129 ms      | 180 ms      | 239 ms       | 333 ms       |
-| Add / Sub (`+`,`-`)                                    | 70.5 ms    | 100 ms      | 132 ms      | 186 ms      | 249 ms       | 334 ms       |
-| Mul (`x`)                                              | 144 ms     | 216 ms      | 333 ms      | 832 ms      | 2.50 s       | 8.85 s       |
-| Equal / Not Equal (`eq`, `ne`)                         | 36.1 ms    | 36.5 ms     | 57.4 ms     | 64.2 ms     | 67.3 ms      | 78.1 ms      |
-| Comparisons  (`ge`, `gt`, `le`, `lt`)                  | 52.6 ms    | 73.1 ms     | 98.8 ms     | 124 ms      | 165 ms       | 201 ms       |
-| Max / Min   (`max`,`min`)                              | 76.2 ms    | 102 ms      | 135 ms      | 171 ms      | 212 ms       | 301 ms       |
-| Bitwise operations (`&`, `\|`, `^`)                    | 19.4 ms    | 20.3 ms     | 21.0 ms     | 27.2 ms     | 31.6 ms      | 40.2 ms      |
-| Div / Rem  (`/`, `%`)                                  | 729 ms     | 1.93 s      | 4.81 s      | 12.2 s      | 30.7 s       | 89.6 s       |
-| Left / Right Shifts (`<<`, `>>`)                       | 99.4 ms    | 129 ms      | 180 ms      | 243 ms      | 372 ms       | 762 ms       |
-| Left / Right Rotations (`left_rotate`, `right_rotate`) | 103 ms     | 128 ms      | 182 ms      | 241 ms      | 374 ms       | 763 ms       |
+| Negation (`-`)                                         | 55.4 ms    | 79.7 ms     | 105 ms      | 133 ms      | 163 ms       | 199 ms       |
+| Add / Sub (`+`,`-`)                                    | 58.9 ms    | 86.0 ms     | 106 ms      | 124 ms      | 151 ms       | 193 ms       |
+| Mul (`x`)                                              | 122 ms     | 164 ms      | 227 ms      | 410 ms      | 1,04 s       | 3,41 s       |
+| Equal / Not Equal (`eq`, `ne`)                         | 32.0 ms    | 32.0 ms     | 50.4 ms     | 50.9 ms     | 53.1 ms      | 54.6 ms      |
+| Comparisons  (`ge`, `gt`, `le`, `lt`)                  | 43.7 ms    | 65.2 ms     | 84.3 ms     | 107 ms      | 132 ms       | 159 ms       |
+| Max / Min   (`max`,`min`)                              | 68.4 ms    | 86.8 ms     | 106 ms      | 132 ms      | 160 ms       | 200 ms       |
+| Bitwise operations (`&`, `\|`, `^`)                    | 17.1 ms    | 17.3 ms     | 17.8 ms     | 18.8 ms     | 20.2 ms      | 22.2 ms      |
+| Div / Rem  (`/`, `%`)                                  | 631 ms     | 1.59 s      | 3.77 s      | 8,64 s      | 20,3 s       | 53,4 s       |
+| Left / Right Shifts (`<<`, `>>`)                       | 82.8 ms    | 99.2 ms     | 121 ms      | 149 ms      | 194 ms       | 401 ms       |
+| Left / Right Rotations (`left_rotate`, `right_rotate`) | 82.1 ms    | 99.4 ms     | 120 ms      | 149 ms      | 194 ms       | 402 ms       |
 
+The table below reports the timing when the left input of the benchmarked operation is encrypted and the other is a clear scalar of the same size.
+
+| Operation \ Size                                       | `FheUint8` | `FheUint16` | `FheUint32` | `FheUint64` | `FheUint128` | `FheUint256` |
+|--------------------------------------------------------|------------|-------------|-------------|-------------|--------------|--------------|
+| Add / Sub (`+`,`-`)                                    | 68.3 ms    | 82.4 ms     | 102 ms      | 122 ms      | 151 ms       | 191 ms       |
+| Mul (`x`)                                              | 93.7 ms    | 139 ms      | 178 ms      | 242 ms      | 516 ms       | 1.02 s       |
+| Equal / Not Equal (`eq`, `ne`)                         | 30.2 ms    | 30.8 ms     | 32.7 ms     | 50.4 ms     | 51.2 ms      | 54.8 ms      |
+| Comparisons  (`ge`, `gt`, `le`, `lt`)                  | 47.3 ms    | 69.9 ms     | 96.3 ms     | 102 ms      | 138 ms       | 141 ms       |
+| Max / Min   (`max`,`min`)                              | 75.4 ms    | 99.7 ms     | 120 ms      | 126 ms      | 150 ms       | 186 ms       |
+| Bitwise operations (`&`, `\|`, `^`)                    | 17.1 ms    | 17.4 ms     | 18.2 ms     | 19.2 ms     | 19.7 ms      | 22.6 ms      |
+| Div (`/`)                                              | 160 ms     | 212 ms      | 272 ms      | 402 ms      | 796 ms       | 2.27 s       |
+| Rem (`%`)                                              | 315 ms     | 428 ms      | 556 ms      | 767 ms      | 1.27 s       | 2.86 s       |
+| Left / Right Shifts (`<<`, `>>`)                       | 16.8 ms    | 16.8 ms     | 17.3 ms     | 18.0 ms     | 18.9 ms      | 22.6 ms      |
+| Left / Right Rotations (`left_rotate`, `right_rotate`) | 16.8 ms    | 16.9 ms     | 17.3 ms     | 18.3 ms     | 19.0 ms      | 22.8 ms      |
 
 All timings are related to parallelized Radix-based integer operations, where each block is encrypted using the default parameters (i.e., PARAM\_MESSAGE\_2\_CARRY\_2\_KS\_PBS, more information about parameters can be found [here](../fine_grained_api/shortint/parameters.md)).
 To ensure predictable timings, the operation flavor is the `default` one: the carry is propagated if needed. The operation costs may be reduced by using `unchecked`, `checked`, or `smart`.
@@ -36,10 +52,10 @@ This uses the Concrete FFT + AVX-512 configuration.
 
 | Parameter set                      | PARAM\_MESSAGE\_1\_CARRY\_1 | PARAM\_MESSAGE\_2\_CARRY\_2 | PARAM\_MESSAGE\_3\_CARRY\_3 | PARAM\_MESSAGE\_4\_CARRY\_4 |
 |------------------------------------|-----------------------------|-----------------------------|-----------------------------|-----------------------------|
-| unchecked\_add                     | 348 ns                      | 413 ns                      | 2.95 µs                     | 12.1 µs                     |
-| add                                | 7.59 ms                     | 17.0 ms                     | 121 ms                      | 835 ms                      |
-| mul\_lsb                           | 8.13 ms                     | 16.8 ms                     | 121 ms                      | 827 ms                      |
-| keyswitch\_programmable\_bootstrap | 7.28 ms                     | 16.6  ms                    | 121 ms                      | 811 ms                      |
+| unchecked\_add                     | 341 ns                      | 555 ns                      | 2.47 µs                     | 9.77 µs                     |
+| add                                | 5.96 ms                     | 12.6 ms                     | 102 ms                      | 508 ms                      |
+| mul\_lsb                           | 5.99 ms                     | 12.3 ms                     | 101 ms                      | 500 ms                      |
+| keyswitch\_programmable\_bootstrap | 6.40 ms                     | 12.9 ms                     | 104 ms                      | 489 ms                      |
 
 
 ## Boolean
@@ -50,20 +66,20 @@ This measures the execution time of a single binary Boolean gate.
 
 | Parameter set                                        | Concrete FFT + AVX-512 |
 |------------------------------------------------------|------------------------|
-| DEFAULT\_PARAMETERS\_KS\_PBS                         | 9.19 ms                |
-| PARAMETERS\_ERROR\_PROB\_2\_POW\_MINUS\_165\_KS\_PBS | 14.1 ms                |
-| TFHE\_LIB\_PARAMETERS                                | 10.0 ms                |
+| DEFAULT\_PARAMETERS\_KS\_PBS                         | 8.49 ms                |
+| PARAMETERS\_ERROR\_PROB\_2\_POW\_MINUS\_165\_KS\_PBS | 13.7 ms                |
+| TFHE\_LIB\_PARAMETERS                                | 9.90 ms                |
 
 
 ### tfhe-lib.
 
-Using the same m6i.metal machine as the one for tfhe-rs, the timings are:
+Using the same hpc7a.96xlarge machine as the one for tfhe-rs, the timings are:
 
 | Parameter set                                    | spqlios-fma |
 |--------------------------------------------------|-------------|
-| default\_128bit\_gate\_bootstrapping\_parameters | 15.4 ms     |
+| default\_128bit\_gate\_bootstrapping\_parameters | 13.5 ms     |
 
-### OpenFHE (v1.1.1).
+### OpenFHE (v1.1.2).
 
 Following the official instructions from OpenFHE, `clang14` and the following command are used to setup the project:
 `cmake -DNATIVE_SIZE=32 -DWITH_NATIVEOPT=ON -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DWITH_OPENMP=OFF ..`
@@ -80,12 +96,12 @@ hexl -> y
 scripts/build-openfhe-development-hexl.sh
 ```
 
-Using the same m6i.metal machine as the one for tfhe-rs, the timings are:
+Using the same hpc7a.96xlarge machine as the one for tfhe-rs, the timings are:
 
 | Parameter set                    | GINX    | GINX w/ Intel HEXL |
 |----------------------------------|---------|--------------------|
-| FHEW\_BINGATE/STD128\_OR         | 40.2 ms | 31.0 ms            |
-| FHEW\_BINGATE/STD128\_LMKCDEY_OR | 38.6 ms | 28.4 ms            |
+| FHEW\_BINGATE/STD128\_OR         | 25.5 ms | 21,6 ms            |
+| FHEW\_BINGATE/STD128\_LMKCDEY_OR | 25.4 ms | 19.9 ms            |
 
 
 ## How to reproduce TFHE-rs benchmarks


### PR DESCRIPTION
"forward port to main"

I targeted 0.5 to have the doc up to date faster, picking the commit on main for content consistency