### PR TITLE
chore(doc): update installation to match README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,15 +51,14 @@ tfhe = { version = "*", features = ["boolean", "shortint", "integer", "x86_64-un
 ```toml
 tfhe = { version = "*", features = ["boolean", "shortint", "integer", "aarch64-unix"] }
 ```
-Note: users with ARM devices must compile `TFHE-rs` using a stable toolchain with version >= 1.72.
 
-
-+ For x86_64-based machines with the [`rdseed instruction`](https://en.wikipedia.org/wiki/RDRAND) 
-running Windows:
++ For x86_64-based machines with the [`rdseed instruction`](https://en.wikipedia.org/wiki/RDRAND) running Windows:
 
 ```toml
 tfhe = { version = "*", features = ["boolean", "shortint", "integer", "x86_64"] }
 ```
+
+Note: You need to use a Rust version >= 1.72 to compile TFHE-rs.
 
 Note: aarch64-based machines are not yet supported for Windows as it's currently missing an entropy source to be able to seed the [CSPRNGs](https://en.wikipedia.org/wiki/Cryptographically_secure_pseudorandom_number_generator) used in TFHE-rs.
 

--- a/tfhe/docs/getting_started/installation.md
+++ b/tfhe/docs/getting_started/installation.md
@@ -6,15 +6,22 @@
 
 To use `TFHE-rs` in your project, you first need to add it as a dependency in your `Cargo.toml`.
 
-If you are using an `x86` machine:
+If you are using an `x86_64` machine running a Unix-like OS:
 ```toml
 tfhe = { version = "0.5.0", features = [ "boolean", "shortint", "integer", "x86_64-unix" ] }
 ```
 
-If you are using an `ARM` machine:
+If you are using an `ARM` machine running a Unix-like OS:
 ```toml
 tfhe = { version = "0.5.0", features = [ "boolean", "shortint", "integer", "aarch64-unix" ] }
 ```
+
+If you are using an `x86_64` machines with the [`rdseed instruction`](https://en.wikipedia.org/wiki/RDRAND) running Windows:
+
+```toml
+tfhe = { version = "*", features = ["boolean", "shortint", "integer", "x86_64"] }
+```
+
 
 {% hint style="info" %}
 You need to use a Rust version >= 1.72 to compile TFHE-rs.


### PR DESCRIPTION
- added more clearly the information for x86 windows machines

as discussed the installation sections should better match

closes: https://github.com/zama-ai/tfhe-rs-internal/issues/443