### PR TITLE
feat(capi): allow cbindgen to generate docs

### DIFF
--- a/tfhe/cbindgen.toml
+++ b/tfhe/cbindgen.toml
@@ -31,7 +31,7 @@ after_includes = ""
 braces = "SameLine"
 line_length = 100
 tab_width = 2
-documentation = false
+documentation = true
 documentation_style = "auto"
 line_endings = "LF"          # also "CR", "CRLF", "Native"
 


### PR DESCRIPTION
with `documentation=true` cbindgen now properly
generates/copies any rust documentation that
are on `#[no_mangle] pub extern "C" fn` into
their corresponding declaration in the header file.

This will allows to finally start adding some documentation on the CAPI (tfhe.h)

### Check-list:

* [x] Tests for the changes have been added (for bug fixes / features)
