### PR TITLE
fix(c-api): add missing function on FheBool

### DIFF
--- a/tfhe/src/c_api/high_level_api/booleans.rs
+++ b/tfhe/src/c_api/high_level_api/booleans.rs
@@ -1,15 +1,42 @@
 use crate::high_level_api::prelude::*;
 
 use crate::c_api::utils::check_ptr_is_non_null_and_aligned;
-use std::ops::{BitAnd, BitOr, BitXor, Not};
+use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Not};
 
 pub struct FheBool(pub(in crate::c_api) crate::high_level_api::FheBool);
 
 impl_destroy_on_type!(FheBool);
 impl_clone_on_type!(FheBool);
+impl_serialize_deserialize_on_type!(FheBool);
+impl_safe_serialize_on_type!(FheBool);
+impl_safe_deserialize_conformant_integer!(
+    FheBool,
+    crate::high_level_api::safe_deserialize_conformant
+);
 
 impl_binary_fn_on_type!(FheBool => bitand, bitor, bitxor);
+impl_binary_assign_fn_on_type!(FheBool => bitand_assign,  bitor_assign, bitxor_assign);
 impl_unary_fn_on_type!(FheBool => not);
+impl_comparison_fn_on_type!(
+    lhs_type: FheBool,
+    rhs_type: FheBool,
+    comparison_fn_names: eq, ne,
+);
+impl_scalar_binary_fn_on_type!(FheBool, bool =>
+    bitand,
+    bitor,
+    bitxor,
+);
+impl_scalar_binary_assign_fn_on_type!(FheBool, bool =>
+    bitand_assign,
+    bitor_assign,
+    bitxor_assign,
+);
+impl_scalar_comparison_fn_on_type!(
+    lhs_type: FheBool,
+    clear_type: bool,
+    comparison_fn_names: eq, ne
+);
 
 impl_decrypt_on_type!(FheBool, bool);
 impl_try_decrypt_trivial_on_type!(FheBool, bool);
@@ -23,6 +50,12 @@ pub struct CompressedFheBool(crate::high_level_api::CompressedFheBool);
 impl_destroy_on_type!(CompressedFheBool);
 impl_clone_on_type!(CompressedFheBool);
 impl_serialize_deserialize_on_type!(CompressedFheBool);
+impl_safe_serialize_on_type!(CompressedFheBool);
+impl_safe_deserialize_conformant_integer!(
+    CompressedFheBool,
+    crate::high_level_api::safe_deserialize_conformant
+);
+impl_try_encrypt_with_client_key_on_type!(CompressedFheBool{crate::high_level_api::CompressedFheBool}, bool);
 
 #[no_mangle]
 pub unsafe extern "C" fn compressed_fhe_bool_decompress(
@@ -42,6 +75,11 @@ pub struct CompactFheBool(crate::high_level_api::CompactFheBool);
 impl_destroy_on_type!(CompactFheBool);
 impl_clone_on_type!(CompactFheBool);
 impl_serialize_deserialize_on_type!(CompactFheBool);
+impl_safe_serialize_on_type!(CompactFheBool);
+impl_safe_deserialize_conformant_integer!(
+    CompactFheBool,
+    crate::high_level_api::safe_deserialize_conformant
+);
 impl_try_encrypt_with_compact_public_key_on_type!(CompactFheBool{crate::high_level_api::CompactFheBool}, bool);
 
 #[no_mangle]
@@ -62,6 +100,8 @@ pub struct CompactFheBoolList(crate::high_level_api::CompactFheBoolList);
 impl_destroy_on_type!(CompactFheBoolList);
 impl_clone_on_type!(CompactFheBoolList);
 impl_serialize_deserialize_on_type!(CompactFheBoolList);
+impl_safe_serialize_on_type!(CompactFheBoolList);
+impl_try_encrypt_list_with_compact_public_key_on_type!(CompactFheBoolList{crate::high_level_api::CompactFheBoolList}, bool);
 
 #[no_mangle]
 pub unsafe extern "C" fn compact_fhe_bool_list_len(

--- a/tfhe/src/c_api/high_level_api/utils.rs
+++ b/tfhe/src/c_api/high_level_api/utils.rs
@@ -582,7 +582,7 @@ macro_rules! impl_scalar_binary_fn_on_type {
                     lhs: *const $wrapper_type,
                     rhs: $scalar_type,
                     result: *mut *mut $wrapper_type,
-                ) -> c_int {
+                ) -> ::std::os::raw::c_int {
                     $crate::c_api::utils::catch_panic(|| {
                         let lhs = $crate::c_api::utils::get_ref_checked(lhs).unwrap();
                         let rhs = <$scalar_type as $crate::c_api::high_level_api::utils::CApiIntegerType>::to_rust(rhs);
@@ -606,7 +606,7 @@ macro_rules! impl_scalar_binary_assign_fn_on_type {
                 pub unsafe extern "C" fn [<$wrapper_type:snake _scalar_ $binary_assign_fn_name>](
                     lhs: *mut $wrapper_type,
                     rhs: $scalar_type,
-                ) -> c_int {
+                ) -> ::std::os::raw::c_int {
                     $crate::c_api::utils::catch_panic(|| {
                         let lhs = $crate::c_api::utils::get_mut_checked(lhs).unwrap();
                         let rhs = <$scalar_type as $crate::c_api::high_level_api::utils::CApiIntegerType

--- a/tfhe/src/high_level_api/booleans/base.rs
+++ b/tfhe/src/high_level_api/booleans/base.rs
@@ -1,6 +1,7 @@
 use std::borrow::Borrow;
 use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign};
 
+use crate::conformance::ParameterSetConformant;
 use crate::high_level_api::booleans::compressed::CompressedFheBool;
 use crate::high_level_api::global_state;
 #[cfg(feature = "gpu")]
@@ -8,6 +9,7 @@ use crate::high_level_api::global_state::with_thread_local_cuda_stream;
 use crate::high_level_api::integers::{FheInt, FheIntId, FheUint, FheUintId};
 use crate::high_level_api::keys::InternalServerKey;
 use crate::high_level_api::traits::{FheEq, IfThenElse};
+use crate::integer::parameters::RadixCiphertextConformanceParams;
 use crate::integer::BooleanBlock;
 use crate::named::Named;
 use crate::shortint::ciphertext::NotTrivialCiphertextError;
@@ -46,6 +48,17 @@ pub struct FheBool {
 
 impl Named for FheBool {
     const NAME: &'static str = "high_level_api::FheBool";
+}
+
+impl ParameterSetConformant for FheBool {
+    type ParameterSet = RadixCiphertextConformanceParams;
+
+    fn is_conformant(&self, params: &RadixCiphertextConformanceParams) -> bool {
+        self.ciphertext
+            .on_cpu()
+            .0
+            .is_conformant(&params.shortint_params)
+    }
 }
 
 impl From<CompressedFheBool> for FheBool {

--- a/tfhe/src/high_level_api/booleans/compressed.rs
+++ b/tfhe/src/high_level_api/booleans/compressed.rs
@@ -1,9 +1,9 @@
 use crate::conformance::ParameterSetConformant;
+use crate::integer::parameters::RadixCiphertextConformanceParams;
 use crate::integer::BooleanBlock;
 use crate::named::Named;
 use crate::prelude::FheTryEncrypt;
 use crate::shortint::ciphertext::Degree;
-use crate::shortint::parameters::CiphertextConformanceParams;
 use crate::shortint::CompressedCiphertext;
 use crate::{ClientKey, FheBool};
 use serde::{Deserialize, Serialize};
@@ -61,9 +61,10 @@ impl FheTryEncrypt<bool, ClientKey> for CompressedFheBool {
 }
 
 impl ParameterSetConformant for CompressedFheBool {
-    type ParameterSet = CiphertextConformanceParams;
-    fn is_conformant(&self, params: &CiphertextConformanceParams) -> bool {
-        self.ciphertext.is_conformant(params)
+    type ParameterSet = RadixCiphertextConformanceParams;
+
+    fn is_conformant(&self, params: &RadixCiphertextConformanceParams) -> bool {
+        self.ciphertext.is_conformant(&params.shortint_params)
     }
 }
 


### PR DESCRIPTION
- safe ser/de
- classical ser/de
- comparisons
- scalar binary fn/comparisons
- compact & compressed fhe bool encryption
