### PR TITLE
chore(ci): fix missing backslash in rtx benchmark workflow

### DIFF
--- a/.github/workflows/integer_gpu_4090_full_benchmark.yml
+++ b/.github/workflows/integer_gpu_4090_full_benchmark.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           python3 ./ci/benchmark_parser.py target/criterion ${{ env.RESULTS_FILENAME }} \
           --database tfhe_rs \
-          --hardware "rtx4090"
+          --hardware "rtx4090" \
           --backend gpu \
           --project-version "${{ env.COMMIT_HASH }}" \
           --branch ${{ github.ref_name }} \


### PR DESCRIPTION
This missing backslash causes the Python command to fail since some input arguments are missing.
