### PR TITLE
chore(ci): lock version of lattice-estimator in workflow

### DIFF
--- a/.github/workflows/parameters_check.yml
+++ b/.github/workflows/parameters_check.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           repository: malb/lattice-estimator
           path: lattice_estimator
+          ref: '53508253629d3b5d31a2ad110e85dc69391ccb95'
 
       - name: Install Sage
         run: |


### PR DESCRIPTION
Latest version of lattice-estimator produce overflow errors. We force the checkout to the last working version to avoid a red CI.
