### PR TITLE
chore(ci): add product cost for rtx4090 to compute throughput

### DIFF
--- a/ci/ec2_products_cost.json
+++ b/ci/ec2_products_cost.json
@@ -3,5 +3,6 @@
   "hpc7a.96xlarge": 7.7252,
   "p3.2xlarge": 3.06,
   "p4d.24xlarge": 32.7726,
-  "p5.48xlarge": 98.32
+  "p5.48xlarge": 98.32,
+  "rtx4090": 0.04
 }


### PR DESCRIPTION
RTX4090 we're using here is owned by Zama. So we don't pay an hourly rate to AWS per se. But in ordrer to compute throughput on benchmarks results, the parser needs a numeric value corresponding to the hardware used. Ops-per-dollar metric is not really used today conversely ops-per-seconds is.