### PR TITLE
refactor(core): change layout of compact public key encryption for LWE list

### DIFF
--- a/tfhe/src/core_crypto/algorithms/lwe_compact_ciphertext_list_expansion.rs
+++ b/tfhe/src/core_crypto/algorithms/lwe_compact_ciphertext_list_expansion.rs
@@ -49,7 +49,7 @@ pub fn expand_lwe_compact_ciphertext_list<Scalar, InputCont, OutputCont>(
             // ring for our choice of i == n
             polynomial_wrapping_monic_monomial_mul_assign(
                 &mut out_mask_as_polynomial,
-                MonomialDegree(lwe_dimension.0 - (ct_idx + 1)),
+                MonomialDegree(ct_idx),
             );
 
             *out_body.data = *input_body.data;
@@ -101,7 +101,7 @@ pub fn par_expand_lwe_compact_ciphertext_list<Scalar, InputCont, OutputCont>(
                     // X^N + 1 ring for our choice of i == n
                     polynomial_wrapping_monic_monomial_mul_assign(
                         &mut out_mask_as_polynomial,
-                        MonomialDegree(lwe_dimension.0 - (ct_idx + 1)),
+                        MonomialDegree(ct_idx),
                     );
 
                     *out_body.data = *input_body.data;

--- a/tfhe/src/core_crypto/algorithms/lwe_encryption.rs
+++ b/tfhe/src/core_crypto/algorithms/lwe_encryption.rs
@@ -1943,11 +1943,17 @@ pub fn encrypt_lwe_compact_ciphertext_list_with_compact_public_key<
                 );
 
                 // Fill the body chunk afterwards manually as it most likely will be smaller than
-                // the full convolution result. b convolved r + Delta * m + e2
+                // the full convolution result. rev(b convolved r) + Delta * m + e2
                 // taking noise from Chi_2 for the body part of the encryption
+                // The reverse is to make the first element product match the single ciphertext case
                 output_body_chunk
                     .iter_mut()
-                    .zip(pk_body_convolved.iter().zip(input_plaintext_chunk.iter()))
+                    .zip(
+                        pk_body_convolved
+                            .iter()
+                            .rev()
+                            .zip(input_plaintext_chunk.iter()),
+                    )
                     .for_each(|(dst, (&src, plaintext))| {
                         *dst.data = src
                             .wrapping_add(
@@ -2158,11 +2164,17 @@ pub fn par_encrypt_lwe_compact_ciphertext_list_with_compact_public_key<
                 );
 
                 // Fill the body chunk afterwards manually as it most likely will be smaller than
-                // the full convolution result. b convolved r + Delta * m + e2
+                // the full convolution result. rev(b convolved r) + Delta * m + e2
                 // taking noise from Chi_2 for the body part of the encryption
+                // The reverse is to make the first element product match the single ciphertext case
                 output_body_chunk
                     .iter_mut()
-                    .zip(pk_body_convolved.iter().zip(input_plaintext_chunk.iter()))
+                    .zip(
+                        pk_body_convolved
+                            .iter()
+                            .rev()
+                            .zip(input_plaintext_chunk.iter()),
+                    )
                     .for_each(|(dst, (&src, plaintext))| {
                         *dst.data = src
                             .wrapping_add(


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
### PR content/description

- this makes sure the product computed for the first ciphertext matches the product computed for a single ciphertext in the non list case

BREAKING CHANGE:
all previous compact public key list encryptions are not compatible with the new layout

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [x] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
