### PR TITLE
chore(ci): fix CUDA_PATH bin not being exported in GITHUB_PATH

### DIFF
--- a/.github/workflows/core_crypto_gpu_benchmark.yml
+++ b/.github/workflows/core_crypto_gpu_benchmark.yml
@@ -80,10 +80,10 @@ jobs:
         run: |
           {
             echo "CUDA_PATH=$CUDA_PATH";
-            echo "$CUDA_PATH/bin";
             echo "LD_LIBRARY_PATH=$CUDA_PATH/lib:$LD_LIBRARY_PATH";
             echo "CUDACXX=/usr/local/cuda-${{ matrix.cuda }}/bin/nvcc";
           } >> "${GITHUB_ENV}"
+          echo "$CUDA_PATH/bin" >> "${GITHUB_PATH}"
 
       # Specify the correct host compilers
       - name: Export gcc and g++ variables

--- a/.github/workflows/integer_gpu_benchmark.yml
+++ b/.github/workflows/integer_gpu_benchmark.yml
@@ -74,10 +74,10 @@ jobs:
         run: |
           {
             echo "CUDA_PATH=$CUDA_PATH";
-            echo "$CUDA_PATH/bin";
             echo "LD_LIBRARY_PATH=$CUDA_PATH/lib:$LD_LIBRARY_PATH";
             echo "CUDACXX=/usr/local/cuda-${{ matrix.cuda }}/bin/nvcc";
           } >> "${GITHUB_ENV}"
+          echo "$CUDA_PATH/bin" >> "${GITHUB_PATH}"
 
       # Specify the correct host compilers
       - name: Export gcc and g++ variables

--- a/.github/workflows/integer_gpu_full_benchmark.yml
+++ b/.github/workflows/integer_gpu_full_benchmark.yml
@@ -90,10 +90,10 @@ jobs:
         run: |
           {
             echo "CUDA_PATH=$CUDA_PATH";
-            echo "$CUDA_PATH/bin";
             echo "LD_LIBRARY_PATH=$CUDA_PATH/lib:$LD_LIBRARY_PATH";
             echo "CUDACXX=/usr/local/cuda-${{ matrix.cuda }}/bin/nvcc";
           } >> "${GITHUB_ENV}"
+          echo "$CUDA_PATH/bin" >> "${GITHUB_PATH}"
 
       # Specify the correct host compilers
       - name: Export gcc and g++ variables

--- a/.github/workflows/integer_multi_bit_gpu_benchmark.yml
+++ b/.github/workflows/integer_multi_bit_gpu_benchmark.yml
@@ -75,10 +75,10 @@ jobs:
         run: |
           {
             echo "CUDA_PATH=$CUDA_PATH";
-            echo "$CUDA_PATH/bin";
             echo "LD_LIBRARY_PATH=$CUDA_PATH/lib:$LD_LIBRARY_PATH";
             echo "CUDACXX=/usr/local/cuda-${{ matrix.cuda }}/bin/nvcc";
           } >> "${GITHUB_ENV}"
+          echo "$CUDA_PATH/bin" >> "${GITHUB_PATH}"
 
       # Specify the correct host compilers
       - name: Export gcc and g++ variables


### PR DESCRIPTION
A small mistake was made while fixing lints in the workflows, restore the cuda path bin to be sent to GITHUB_PATH