### PR TITLE
chore(ci): force the removal of the 4090 label for PRs even for failures

### DIFF
--- a/.github/workflows/aws_tfhe_gpu_4090_tests.yml
+++ b/.github/workflows/aws_tfhe_gpu_4090_tests.yml
@@ -61,7 +61,7 @@ jobs:
           make test_high_level_api_gpu
 
       - uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ always() && github.event_name == 'pull_request' }}
         with:
           labels: 4090_test
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gpu_4090_full_benchmark.yml
+++ b/.github/workflows/gpu_4090_full_benchmark.yml
@@ -192,7 +192,7 @@ jobs:
 
   remove_github_label:
     name: Remove 4090 bench label
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ always() && github.event_name == 'pull_request' }}
     needs: [cuda-integer-benchmarks, cuda-core-crypto-benchmarks]
     runs-on: ["self-hosted", "4090-desktop"]
     steps:


### PR DESCRIPTION
- always() forces the evaluation of the PR removal even if there was a failure before, which is irrelevant for removing a label