### PR TITLE
chore(ci): build cuda crates on aws instead on github runner

### DIFF
--- a/.github/workflows/make_release_cuda.yml
+++ b/.github/workflows/make_release_cuda.yml
@@ -41,12 +41,53 @@ jobs:
 
   publish-cuda-release:
     name: Publish CUDA Release
-    runs-on: ubuntu-latest
+    needs: setup-ec2
+    runs-on: ${{ needs.setup-ec2.outputs.runner-name }}
+    strategy:
+      fail-fast: false
+      # explicit include-based build matrix, of known valid options
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            cuda: "12.2"
+            gcc: 9
+    env:
+      CUDA_PATH: /usr/local/cuda-${{ matrix.cuda }}
     steps:
       - name: Checkout
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
         with:
           fetch-depth: 0
+
+      - name: Set up home
+        run: |
+          echo "HOME=/home/ubuntu" >> "${GITHUB_ENV}"
+
+      - name: Install latest stable
+        uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
+        with:
+          toolchain: stable
+
+      - name: Export CUDA variables
+        if: ${{ !cancelled() }}
+        run: |
+          echo "$CUDA_PATH/bin" >> "${GITHUB_PATH}"
+          {
+            echo "CUDA_PATH=$CUDA_PATH";
+            echo "LD_LIBRARY_PATH=$CUDA_PATH/lib:$LD_LIBRARY_PATH";
+            echo "CUDACXX=/usr/local/cuda-${{ matrix.cuda }}/bin/nvcc";
+          } >> "${GITHUB_ENV}"
+
+      # Specify the correct host compilers
+      - name: Export gcc and g++ variables
+        if: ${{ !cancelled() }}
+        run: |
+          {
+            echo "CC=/usr/bin/gcc-${{ matrix.gcc }}";
+            echo "CXX=/usr/bin/g++-${{ matrix.gcc }}";
+            echo "CUDAHOSTCXX=/usr/bin/g++-${{ matrix.gcc }}";
+            echo "HOME=/home/ubuntu";
+          } >> "${GITHUB_ENV}"
 
       - name: Publish crate.io package
         if: ${{ inputs.push_to_crates }}

--- a/backends/tfhe-cuda-backend/cuda/CMakeLists.txt
+++ b/backends/tfhe-cuda-backend/cuda/CMakeLists.txt
@@ -65,9 +65,7 @@ else()
   set(CUDA_ARCH "700")
 endif()
 
-message(STATUS "CUDA_ARCH: ${CUDA_ARCH}")
-
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cuda_config.h.in ${CMAKE_CURRENT_SOURCE_DIR}/include/cuda_config.h)
+add_compile_definitions(CUDA_ARCH=${CUDA_ARCH})
 
 # in production, should use -arch=sm_70 --ptxas-options=-v to see register spills -lineinfo for better debugging
 set(CMAKE_CUDA_FLAGS

--- a/backends/tfhe-cuda-backend/cuda/cuda_config.h.in
+++ b/backends/tfhe-cuda-backend/cuda/cuda_config.h.in
@@ -1,3 +1,0 @@
-#pragma once
-
-#define CUDA_ARCH @CUDA_ARCH@

--- a/backends/tfhe-cuda-backend/cuda/include/device.h
+++ b/backends/tfhe-cuda-backend/cuda/include/device.h
@@ -1,7 +1,6 @@
 #ifndef DEVICE_H
 #define DEVICE_H
 
-#include "cuda_config.h"
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>


### PR DESCRIPTION
The build currently fails, it will be fixed on cuda backend code side.