### PR TITLE
Fix incorrect comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Clear equivalent computations: 1344 * 5 = 6720
     let encrypted_res_mul = &encrypted_a * &encrypted_b;
 
-    // Clear equivalent computations: 1344 >> 5 = 42
+    // Clear equivalent computations: 6720 >> 5 = 210
     encrypted_a = &encrypted_res_mul >> &encrypted_b;
 
     // Clear equivalent computations: let casted_a = a as u8;


### PR DESCRIPTION
The example defines encrypted_res_mul as 6720 in the lines above, but the comment says it is 1344, which is actually encrypted_a. This of course also means the result is wrong. Fix the comment to reflect the correct values.
