### PR TITLE
feat(core): add experimental lwe shrinking keyswitch from keytricks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -633,7 +633,7 @@ doc: install_rs_check_toolchain
 	DOCS_RS=1 \
 	RUSTDOCFLAGS="--html-in-header katex-header.html" \
 	cargo "$(CARGO_RS_CHECK_TOOLCHAIN)" doc \
-		--features=$(TARGET_ARCH_FEATURE),boolean,shortint,integer,gpu,internal-keycache --no-deps -p $(TFHE_SPEC)
+		--features=$(TARGET_ARCH_FEATURE),boolean,shortint,integer,gpu,internal-keycache,experimental --no-deps -p $(TFHE_SPEC)
 
 .PHONY: docs # Build rust doc alias for doc
 docs: doc
@@ -644,7 +644,7 @@ lint_doc: install_rs_check_toolchain
 	DOCS_RS=1 \
 	RUSTDOCFLAGS="--html-in-header katex-header.html -Dwarnings" \
 	cargo "$(CARGO_RS_CHECK_TOOLCHAIN)" doc \
-		--features=$(TARGET_ARCH_FEATURE),boolean,shortint,integer,gpu,internal-keycache -p $(TFHE_SPEC) --no-deps
+		--features=$(TARGET_ARCH_FEATURE),boolean,shortint,integer,gpu,internal-keycache,experimental -p $(TFHE_SPEC) --no-deps
 
 .PHONY: lint_docs # Build rust doc with linting enabled alias for lint_doc
 lint_docs: lint_doc

--- a/tfhe/src/core_crypto/experimental/algorithms/lwe_shrinking_keyswitch.rs
+++ b/tfhe/src/core_crypto/experimental/algorithms/lwe_shrinking_keyswitch.rs
@@ -1,0 +1,186 @@
+//! Module containing primitives pertaining to [`LWE ciphertext shrinking
+//! keyswitch`](`crate::core_crypto::entities::LweKeyswitchKey#lwe-keyswitch`).
+
+use crate::core_crypto::algorithms::slice_algorithms::*;
+use crate::core_crypto::commons::math::decomposition::SignedDecomposer;
+use crate::core_crypto::commons::traits::*;
+use crate::core_crypto::entities::LweCiphertext;
+use crate::core_crypto::experimental::entities::LweShrinkingKeyswitchKey;
+
+/// Keyswitch an LWE ciphertext under an LWE secret key S1 to an LWE ciphertext under an LWE secret
+/// key S2 where S1 is bigger than S2 and S2 takes all its coefficients from the start of S1.
+///
+/// ```rust
+/// use tfhe::core_crypto::experimental::prelude::*;
+/// use tfhe::core_crypto::prelude::*;
+///
+/// // DISCLAIMER: these toy example parameters are not guaranteed to be secure or yield correct
+/// // computations
+/// // Define parameters for LweShrinkingKeyswitchKey creation
+/// let large_lwe_dimension = LweDimension(10);
+/// let lwe_noise_distribution =
+///     Gaussian::from_standard_dev(StandardDev(8.881784197001252e-16), 0.0);
+/// let small_lwe_dimension = LweDimension(5);
+/// let lwe_secret_key_shared_coef_count = LweSecretKeySharedCoefCount(small_lwe_dimension.0);
+/// let decomp_base_log = DecompositionBaseLog(30);
+/// let decomp_level_count = DecompositionLevelCount(1);
+/// let ciphertext_modulus = CiphertextModulus::new_native();
+///
+/// // Create the PRNG
+/// let mut seeder = new_seeder();
+/// let seeder = seeder.as_mut();
+/// let mut encryption_generator =
+///     EncryptionRandomGenerator::<ActivatedRandomGenerator>::new(seeder.seed(), seeder);
+/// let mut secret_generator =
+///     SecretRandomGenerator::<ActivatedRandomGenerator>::new(seeder.seed());
+///
+/// // Create the large LweSecretKey
+/// let large_lwe_secret_key =
+///     allocate_and_generate_new_binary_lwe_secret_key(large_lwe_dimension, &mut secret_generator);
+///
+/// // Generate a small LweSecretKey that shares part of its coefficients with the large secret key
+/// let small_lwe_secret_key = allocate_and_generate_fully_shared_binary_lwe_secret_key(
+///     &large_lwe_secret_key,
+///     small_lwe_dimension,
+/// );
+///
+/// let ksk = allocate_and_generate_new_lwe_shrinking_keyswitch_key(
+///     &large_lwe_secret_key,
+///     lwe_secret_key_shared_coef_count,
+///     decomp_base_log,
+///     decomp_level_count,
+///     lwe_noise_distribution,
+///     ciphertext_modulus,
+///     &mut encryption_generator,
+/// );
+///
+/// // Create the plaintext
+/// let msg = 3u64;
+/// let plaintext = Plaintext(msg << 60);
+///
+/// // Create a new LweCiphertext
+/// let input_lwe = allocate_and_encrypt_new_lwe_ciphertext(
+///     &large_lwe_secret_key,
+///     plaintext,
+///     lwe_noise_distribution,
+///     ciphertext_modulus,
+///     &mut encryption_generator,
+/// );
+///
+/// let mut output_lwe = LweCiphertext::new(
+///     0,
+///     small_lwe_secret_key.lwe_dimension().to_lwe_size(),
+///     ciphertext_modulus,
+/// );
+///
+/// shrinking_keyswitch_lwe_ciphertext(&ksk, &input_lwe, &mut output_lwe);
+///
+/// let decrypted_plaintext = decrypt_lwe_ciphertext(&small_lwe_secret_key, &output_lwe);
+///
+/// // Round and remove encoding
+/// // First create a decomposer working on the high 4 bits corresponding to our encoding.
+/// let decomposer = SignedDecomposer::new(DecompositionBaseLog(4), DecompositionLevelCount(1));
+///
+/// let rounded = decomposer.closest_representable(decrypted_plaintext.0);
+///
+/// // Remove the encoding
+/// let cleartext = rounded >> 60;
+///
+/// // Check we recovered the original message
+/// assert_eq!(cleartext, msg);
+/// ```
+pub fn shrinking_keyswitch_lwe_ciphertext<Scalar, KSKCont, InputCont, OutputCont>(
+    lwe_shrinking_keyswitch_key: &LweShrinkingKeyswitchKey<KSKCont>,
+    input_lwe_ciphertext: &LweCiphertext<InputCont>,
+    output_lwe_ciphertext: &mut LweCiphertext<OutputCont>,
+) where
+    Scalar: UnsignedInteger,
+    KSKCont: Container<Element = Scalar>,
+    InputCont: Container<Element = Scalar>,
+    OutputCont: ContainerMut<Element = Scalar>,
+{
+    assert!(
+        lwe_shrinking_keyswitch_key.input_key_lwe_dimension()
+            == input_lwe_ciphertext.lwe_size().to_lwe_dimension(),
+        "Mismatched input LweDimension. \
+        LweShrinkingKeyswitchKey input LweDimension: {:?}, input LweCiphertext LweDimension {:?}.",
+        lwe_shrinking_keyswitch_key.input_key_lwe_dimension(),
+        input_lwe_ciphertext.lwe_size().to_lwe_dimension(),
+    );
+    assert!(
+        lwe_shrinking_keyswitch_key.output_key_lwe_dimension()
+            == output_lwe_ciphertext.lwe_size().to_lwe_dimension(),
+        "Mismatched output LweDimension. \
+        LweShrinkingKeyswitchKey output LweDimension: {:?}, output LweCiphertext LweDimension {:?}.",
+        lwe_shrinking_keyswitch_key.output_key_lwe_dimension(),
+        output_lwe_ciphertext.lwe_size().to_lwe_dimension(),
+    );
+
+    let output_ciphertext_modulus = output_lwe_ciphertext.ciphertext_modulus();
+
+    assert_eq!(
+        lwe_shrinking_keyswitch_key.ciphertext_modulus(),
+        output_ciphertext_modulus,
+        "Mismatched CiphertextModulus. \
+        LweShrinkingKeyswitchKey CiphertextModulus: {:?}, output LweCiphertext CiphertextModulus {:?}.",
+        lwe_shrinking_keyswitch_key.ciphertext_modulus(),
+        output_ciphertext_modulus
+    );
+    assert!(
+        output_ciphertext_modulus.is_compatible_with_native_modulus(),
+        "This operation currently only supports power of 2 moduli"
+    );
+
+    let input_ciphertext_modulus = input_lwe_ciphertext.ciphertext_modulus();
+
+    assert_eq!(
+        lwe_shrinking_keyswitch_key.ciphertext_modulus(),
+        input_ciphertext_modulus,
+        "Mismatched CiphertextModulus. \
+        LweShrinkingKeyswitchKey CiphertextModulus: {:?}, output LweCiphertext CiphertextModulus {:?}.",
+        lwe_shrinking_keyswitch_key.ciphertext_modulus(),
+        input_ciphertext_modulus
+    );
+
+    // Clear the output ciphertext, as it will get updated gradually
+    output_lwe_ciphertext.as_mut().fill(Scalar::ZERO);
+
+    // Copy the input body to the output ciphertext
+    *output_lwe_ciphertext.get_mut_body().data = *input_lwe_ciphertext.get_body().data;
+
+    let shared_randomness = lwe_shrinking_keyswitch_key.shared_randomness();
+
+    let input_lwe_ciphertext_mask = input_lwe_ciphertext.get_mask();
+    let (input_shared_mask_slice, input_unshared_mask_slice) = input_lwe_ciphertext_mask
+        .as_ref()
+        .split_at(shared_randomness.0);
+
+    // Copy the shared elements of the mask
+    output_lwe_ciphertext
+        .get_mut_mask()
+        .as_mut()
+        .copy_from_slice(input_shared_mask_slice);
+
+    // We instantiate a decomposer
+    let decomposer = SignedDecomposer::new(
+        lwe_shrinking_keyswitch_key.decomposition_base_log(),
+        lwe_shrinking_keyswitch_key.decomposition_level_count(),
+    );
+
+    for (keyswitch_key_block, &input_mask_element) in lwe_shrinking_keyswitch_key
+        .as_lwe_keyswitch_key()
+        .iter()
+        .zip(input_unshared_mask_slice.iter())
+    {
+        let decomposition_iter = decomposer.decompose(input_mask_element);
+        // Loop over the levels
+        for (level_key_ciphertext, decomposed) in keyswitch_key_block.iter().zip(decomposition_iter)
+        {
+            slice_wrapping_sub_scalar_mul_assign(
+                output_lwe_ciphertext.as_mut(),
+                level_key_ciphertext.as_ref(),
+                decomposed.value(),
+            );
+        }
+    }
+}

--- a/tfhe/src/core_crypto/experimental/algorithms/lwe_shrinking_keyswitch_key_generation.rs
+++ b/tfhe/src/core_crypto/experimental/algorithms/lwe_shrinking_keyswitch_key_generation.rs
@@ -1,0 +1,92 @@
+//! Module containing primitives pertaining to [`LWE shrinking keyswitch keys
+//! generation`](`crate::core_crypto::entities::LweKeyswitchKey#key-switching-key`).
+
+use crate::core_crypto::algorithms::generate_lwe_keyswitch_key;
+use crate::core_crypto::commons::generators::EncryptionRandomGenerator;
+use crate::core_crypto::commons::math::random::{Distribution, Uniform};
+use crate::core_crypto::commons::parameters::*;
+use crate::core_crypto::commons::traits::*;
+use crate::core_crypto::entities::LweSecretKey;
+use crate::core_crypto::experimental::commons::parameters::LweSecretKeySharedCoefCount;
+use crate::core_crypto::experimental::entities::{
+    LweShrinkingKeyswitchKey, LweShrinkingKeyswitchKeyOwned,
+};
+
+pub fn generate_lwe_shrinking_keyswitch_key<
+    Scalar,
+    NoiseDistribution,
+    InputKeyCont,
+    KSKeyCont,
+    Gen,
+>(
+    input_lwe_sk: &LweSecretKey<InputKeyCont>,
+    lwe_keyswitch_key: &mut LweShrinkingKeyswitchKey<KSKeyCont>,
+    noise_distribution: NoiseDistribution,
+    generator: &mut EncryptionRandomGenerator<Gen>,
+) where
+    Scalar: Encryptable<Uniform, NoiseDistribution>,
+    NoiseDistribution: Distribution,
+    InputKeyCont: Container<Element = Scalar>,
+    KSKeyCont: ContainerMut<Element = Scalar>,
+    Gen: ByteRandomGenerator,
+{
+    let shared_randomness = lwe_keyswitch_key.shared_randomness();
+
+    let output_lwe_sk = LweSecretKey::from_container(&input_lwe_sk.as_ref()[..shared_randomness.0]);
+    let shrunk_input_lwe_secret_key =
+        LweSecretKey::from_container(&input_lwe_sk.as_ref()[shared_randomness.0..]);
+
+    generate_lwe_keyswitch_key(
+        &shrunk_input_lwe_secret_key,
+        &output_lwe_sk,
+        &mut lwe_keyswitch_key.as_mut_lwe_keyswitch_key(),
+        noise_distribution,
+        generator,
+    )
+}
+
+/// Allocate a new [`shrinking LWE keyswitch key`](`LweShrinkingKeyswitchKey`) and fill it with an
+/// actual keyswitching key constructed from an input key [`LWE secret
+/// key`](`LweSecretKey`) from which the shared output key is derived.
+///
+/// See [`crate::core_crypto::experimental::algorithms::shrinking_keyswitch_lwe_ciphertext`] for
+/// usage.
+#[allow(clippy::too_many_arguments)]
+pub fn allocate_and_generate_new_lwe_shrinking_keyswitch_key<
+    Scalar,
+    NoiseDistribution,
+    InputKeyCont,
+    Gen,
+>(
+    input_lwe_sk: &LweSecretKey<InputKeyCont>,
+    lwe_secret_key_shared_coef_count: LweSecretKeySharedCoefCount,
+    decomp_base_log: DecompositionBaseLog,
+    decomp_level_count: DecompositionLevelCount,
+    noise_distribution: NoiseDistribution,
+    ciphertext_modulus: CiphertextModulus<Scalar>,
+    generator: &mut EncryptionRandomGenerator<Gen>,
+) -> LweShrinkingKeyswitchKeyOwned<Scalar>
+where
+    Scalar: Encryptable<Uniform, NoiseDistribution>,
+    NoiseDistribution: Distribution,
+    InputKeyCont: Container<Element = Scalar>,
+    Gen: ByteRandomGenerator,
+{
+    let mut new_lwe_keyswitch_key = LweShrinkingKeyswitchKeyOwned::new(
+        Scalar::ZERO,
+        decomp_base_log,
+        decomp_level_count,
+        input_lwe_sk.lwe_dimension(),
+        LweDimension(lwe_secret_key_shared_coef_count.0),
+        ciphertext_modulus,
+    );
+
+    generate_lwe_shrinking_keyswitch_key(
+        input_lwe_sk,
+        &mut new_lwe_keyswitch_key,
+        noise_distribution,
+        generator,
+    );
+
+    new_lwe_keyswitch_key
+}

--- a/tfhe/src/core_crypto/experimental/algorithms/mod.rs
+++ b/tfhe/src/core_crypto/experimental/algorithms/mod.rs
@@ -1,0 +1,7 @@
+pub mod lwe_shrinking_keyswitch;
+pub mod lwe_shrinking_keyswitch_key_generation;
+pub mod shared_lwe_secret_key_generation;
+
+pub use lwe_shrinking_keyswitch::*;
+pub use lwe_shrinking_keyswitch_key_generation::*;
+pub use shared_lwe_secret_key_generation::*;

--- a/tfhe/src/core_crypto/experimental/algorithms/shared_lwe_secret_key_generation.rs
+++ b/tfhe/src/core_crypto/experimental/algorithms/shared_lwe_secret_key_generation.rs
@@ -1,0 +1,48 @@
+//! Module containing primitives pertaining to shared [`LweSecretKey`] generation.
+
+use crate::core_crypto::commons::numeric::Numeric;
+use crate::core_crypto::commons::parameters::LweDimension;
+use crate::core_crypto::commons::traits::{Container, ContainerMut};
+use crate::core_crypto::entities::{LweSecretKey, LweSecretKeyOwned};
+
+/// Fill an [`LWE secret key`](`LweSecretKey`) with coefficients from an already existing secret
+/// key.
+pub fn generate_fully_shared_binary_lwe_secret_key<Scalar, KeyCont, InputKeyCont>(
+    lwe_secret_key_with_shared_coefficients: &mut LweSecretKey<KeyCont>,
+    source_key_to_share_coefficients: &LweSecretKey<InputKeyCont>,
+) where
+    Scalar: Copy,
+    KeyCont: ContainerMut<Element = Scalar>,
+    InputKeyCont: Container<Element = Scalar>,
+{
+    let output_len = lwe_secret_key_with_shared_coefficients.as_ref().len();
+    let input_len = source_key_to_share_coefficients.as_ref().len();
+
+    assert!(
+        output_len <= input_len,
+        "Output lwe_secret_key_with_shared_coefficients (len {output_len})\
+        has to be smaller than  source_key_to_share_coefficients (len {input_len})."
+    );
+
+    lwe_secret_key_with_shared_coefficients
+        .as_mut()
+        .copy_from_slice(&source_key_to_share_coefficients.as_ref()[..output_len]);
+}
+
+pub fn allocate_and_generate_fully_shared_binary_lwe_secret_key<Scalar, InputKeyCont>(
+    source_key_to_share_coefficients: &LweSecretKey<InputKeyCont>,
+    output_key_lwe_dimension: LweDimension,
+) -> LweSecretKeyOwned<Scalar>
+where
+    Scalar: Numeric,
+    InputKeyCont: Container<Element = Scalar>,
+{
+    let mut lwe_secret_key = LweSecretKey::new_empty_key(Scalar::ZERO, output_key_lwe_dimension);
+
+    generate_fully_shared_binary_lwe_secret_key(
+        &mut lwe_secret_key,
+        source_key_to_share_coefficients,
+    );
+
+    lwe_secret_key
+}

--- a/tfhe/src/core_crypto/experimental/commons/mod.rs
+++ b/tfhe/src/core_crypto/experimental/commons/mod.rs
@@ -1,0 +1,1 @@
+pub mod parameters;

--- a/tfhe/src/core_crypto/experimental/commons/parameters.rs
+++ b/tfhe/src/core_crypto/experimental/commons/parameters.rs
@@ -1,0 +1,37 @@
+use serde::{Deserialize, Serialize};
+
+/// The number of elements in an LWE secret key shared with another key.
+#[derive(Debug, PartialEq, Eq, Copy, Clone, Serialize, Deserialize)]
+pub struct LweSecretKeySharedCoefCount(pub usize);
+
+/// The number of elements in an LWE secret key that are not shared with another key.
+#[derive(Debug, PartialEq, Eq, Copy, Clone, Serialize, Deserialize)]
+pub struct LweSecretKeyUnsharedCoefCount(pub usize);
+
+impl crate::core_crypto::commons::parameters::LweDimension {
+    #[track_caller]
+    pub fn shared_coef_count_from(
+        &self,
+        unshared_coef_count: LweSecretKeyUnsharedCoefCount,
+    ) -> LweSecretKeySharedCoefCount {
+        assert!(
+            unshared_coef_count.0 <= self.0,
+            "unshared_coef_count {unshared_coef_count:?} must be smaller than self {:?}",
+            *self
+        );
+        LweSecretKeySharedCoefCount(self.0 - unshared_coef_count.0)
+    }
+
+    #[track_caller]
+    pub fn unshared_coef_count_from(
+        &self,
+        shared_coef_count: LweSecretKeySharedCoefCount,
+    ) -> LweSecretKeyUnsharedCoefCount {
+        assert!(
+            shared_coef_count.0 <= self.0,
+            "shared_coef_count {shared_coef_count:?} must be smaller than self {:?}",
+            *self
+        );
+        LweSecretKeyUnsharedCoefCount(self.0 - shared_coef_count.0)
+    }
+}

--- a/tfhe/src/core_crypto/experimental/entities/lwe_shrinking_keyswitch_key.rs
+++ b/tfhe/src/core_crypto/experimental/entities/lwe_shrinking_keyswitch_key.rs
@@ -1,0 +1,310 @@
+//! Module containing the definition of the [`LweShrinkingKeyswitchKey`].
+
+use crate::core_crypto::commons::parameters::*;
+use crate::core_crypto::commons::traits::*;
+use crate::core_crypto::entities::*;
+use crate::core_crypto::experimental::commons::parameters::{
+    LweSecretKeySharedCoefCount, LweSecretKeyUnsharedCoefCount,
+};
+
+/// An [`LWE shrinking keyswitch key`](`LweShrinkingKeyswitchKey`) is an [`LWE keyswitch
+/// key`](`LweKeyswitchKey`) where the output key is equal to the beginning of the input key.
+///
+/// See [`the formal definition of an LWE keyswitch key`](`LweKeyswitchKey#formal-definition`).
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct LweShrinkingKeyswitchKey<C: Container>
+where
+    C::Element: UnsignedInteger,
+{
+    lwe_ksk: LweKeyswitchKey<C>,
+}
+
+impl<T: UnsignedInteger, C: Container<Element = T>> AsRef<[T]> for LweShrinkingKeyswitchKey<C> {
+    fn as_ref(&self) -> &[T] {
+        self.lwe_ksk.as_ref()
+    }
+}
+
+impl<T: UnsignedInteger, C: ContainerMut<Element = T>> AsMut<[T]> for LweShrinkingKeyswitchKey<C> {
+    fn as_mut(&mut self) -> &mut [T] {
+        self.lwe_ksk.as_mut()
+    }
+}
+
+impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> LweShrinkingKeyswitchKey<C> {
+    /// Create an [`LweShrinkingKeyswitchKey`] from an existing container.
+    ///
+    /// # Note
+    ///
+    /// This function only wraps a container in the appropriate type. If you want to generate an LWE
+    /// shrinking keyswitch key you need to use
+    /// [`crate::core_crypto::experimental::algorithms::generate_lwe_shrinking_keyswitch_key`]
+    /// using this key as output.
+    ///
+    /// This docstring exhibits [`LweShrinkingKeyswitchKey`] primitives usage.
+    ///
+    /// ```rust
+    /// use tfhe::core_crypto::experimental::prelude::*;
+    /// use tfhe::core_crypto::prelude::*;
+    ///
+    /// // DISCLAIMER: these toy example parameters are not guaranteed to be secure or yield correct
+    /// // computations
+    /// // Define parameters for LweShrinkingKeyswitchKey creation
+    /// let input_lwe_dimension = LweDimension(1024);
+    /// let output_lwe_dimension = LweDimension(600);
+    /// let expected_lwe_secret_key_shared_coef_count =
+    ///     LweSecretKeySharedCoefCount(output_lwe_dimension.0);
+    /// let decomp_base_log = DecompositionBaseLog(4);
+    /// let decomp_level_count = DecompositionLevelCount(5);
+    /// let ciphertext_modulus = CiphertextModulus::new_native();
+    ///
+    /// // Create a new LweShrinkingKeyswitchKey
+    /// let lwe_ksk = LweShrinkingKeyswitchKey::new(
+    ///     0u64,
+    ///     decomp_base_log,
+    ///     decomp_level_count,
+    ///     input_lwe_dimension,
+    ///     output_lwe_dimension,
+    ///     ciphertext_modulus,
+    /// );
+    ///
+    /// assert_eq!(lwe_ksk.decomposition_base_log(), decomp_base_log);
+    /// assert_eq!(lwe_ksk.decomposition_level_count(), decomp_level_count);
+    /// assert_eq!(lwe_ksk.input_key_lwe_dimension(), input_lwe_dimension);
+    /// assert_eq!(lwe_ksk.output_key_lwe_dimension(), output_lwe_dimension);
+    /// assert_eq!(
+    ///     lwe_ksk.output_lwe_size(),
+    ///     output_lwe_dimension.to_lwe_size()
+    /// );
+    /// assert_eq!(
+    ///     lwe_ksk.shared_randomness(),
+    ///     expected_lwe_secret_key_shared_coef_count
+    /// );
+    /// assert_eq!(
+    ///     lwe_ksk.unshared_randomness(),
+    ///     LweSecretKeyUnsharedCoefCount(
+    ///         input_lwe_dimension.0 - expected_lwe_secret_key_shared_coef_count.0
+    ///     )
+    /// );
+    /// assert_eq!(lwe_ksk.ciphertext_modulus(), ciphertext_modulus);
+    ///
+    /// // Demonstrate how to recover the allocated container
+    /// let underlying_container: Vec<u64> = lwe_ksk.into_container();
+    ///
+    /// // Recreate a secret key using from_container
+    /// let lwe_ksk = LweShrinkingKeyswitchKey::from_container(
+    ///     underlying_container,
+    ///     decomp_base_log,
+    ///     decomp_level_count,
+    ///     output_lwe_dimension.to_lwe_size(),
+    ///     ciphertext_modulus,
+    /// );
+    ///
+    /// assert_eq!(lwe_ksk.decomposition_base_log(), decomp_base_log);
+    /// assert_eq!(lwe_ksk.decomposition_level_count(), decomp_level_count);
+    /// assert_eq!(lwe_ksk.input_key_lwe_dimension(), input_lwe_dimension);
+    /// assert_eq!(lwe_ksk.output_key_lwe_dimension(), output_lwe_dimension);
+    /// assert_eq!(
+    ///     lwe_ksk.output_lwe_size(),
+    ///     output_lwe_dimension.to_lwe_size()
+    /// );
+    /// assert_eq!(
+    ///     lwe_ksk.shared_randomness(),
+    ///     expected_lwe_secret_key_shared_coef_count
+    /// );
+    /// assert_eq!(
+    ///     lwe_ksk.unshared_randomness(),
+    ///     LweSecretKeyUnsharedCoefCount(
+    ///         input_lwe_dimension.0 - expected_lwe_secret_key_shared_coef_count.0
+    ///     )
+    /// );
+    /// assert_eq!(lwe_ksk.ciphertext_modulus(), ciphertext_modulus);
+    /// ```
+    pub fn from_container(
+        container: C,
+        decomp_base_log: DecompositionBaseLog,
+        decomp_level_count: DecompositionLevelCount,
+        output_lwe_size: LweSize,
+        ciphertext_modulus: CiphertextModulus<C::Element>,
+    ) -> Self {
+        let lwe_ksk = LweKeyswitchKey::from_container(
+            container,
+            decomp_base_log,
+            decomp_level_count,
+            output_lwe_size,
+            ciphertext_modulus,
+        );
+
+        let output_key_lwe_dimension = lwe_ksk.output_key_lwe_dimension();
+        let unshared_randomness_coef_count =
+            LweSecretKeyUnsharedCoefCount(lwe_ksk.input_key_lwe_dimension().0);
+        let input_key_lwe_dimension =
+            LweDimension(output_key_lwe_dimension.0 + unshared_randomness_coef_count.0);
+
+        assert!(
+            output_key_lwe_dimension.0 <= input_key_lwe_dimension.0,
+            "The output LweDimension ({output_key_lwe_dimension:?}) \
+                must be smaller than the input LweDimension ({input_key_lwe_dimension:?}) \
+                for an LweShrinkingKeyswitchKey."
+        );
+
+        Self { lwe_ksk }
+    }
+
+    pub fn as_lwe_keyswitch_key(&self) -> LweKeyswitchKey<&'_ [Scalar]> {
+        self.lwe_ksk.as_view()
+    }
+
+    /// Return the [`DecompositionBaseLog`] of the [`LweShrinkingKeyswitchKey`].
+    ///
+    /// See [`LweShrinkingKeyswitchKey::from_container`] for usage.
+    pub fn decomposition_base_log(&self) -> DecompositionBaseLog {
+        self.lwe_ksk.decomposition_base_log()
+    }
+
+    /// Return the [`DecompositionLevelCount`] of the [`LweShrinkingKeyswitchKey`].
+    ///
+    /// See [`LweShrinkingKeyswitchKey::from_container`] for usage.
+    pub fn decomposition_level_count(&self) -> DecompositionLevelCount {
+        self.lwe_ksk.decomposition_level_count()
+    }
+
+    /// Return the input [`LweDimension`] of the [`LweShrinkingKeyswitchKey`].
+    ///
+    /// See [`LweShrinkingKeyswitchKey::from_container`] for usage.
+    pub fn input_key_lwe_dimension(&self) -> LweDimension {
+        LweDimension(self.shared_randomness().0 + self.unshared_randomness().0)
+    }
+
+    /// Return the output [`LweDimension`] of the [`LweShrinkingKeyswitchKey`].
+    ///
+    /// See [`LweShrinkingKeyswitchKey::from_container`] for usage.
+    pub fn output_key_lwe_dimension(&self) -> LweDimension {
+        self.output_lwe_size().to_lwe_dimension()
+    }
+
+    /// Return the output [`LweSize`] of the [`LweShrinkingKeyswitchKey`].
+    ///
+    /// See [`LweShrinkingKeyswitchKey::from_container`] for usage.
+    pub fn output_lwe_size(&self) -> LweSize {
+        self.lwe_ksk.output_lwe_size()
+    }
+
+    /// Return the unshared [`LweSecretKeyUnsharedCoefCount`] of randomness of the input and
+    /// output [`LweSecretKey`] used to build this [`LweShrinkingKeyswitchKey`].
+    ///
+    /// See [`LweShrinkingKeyswitchKey::from_container`] for usage.
+    pub fn unshared_randomness(&self) -> LweSecretKeyUnsharedCoefCount {
+        LweSecretKeyUnsharedCoefCount(self.lwe_ksk.input_key_lwe_dimension().0)
+    }
+
+    /// Return the shared [`LweSecretKeySharedCoefCount`] of randomness of the input and
+    /// output [`LweSecretKey`] used to build this [`LweShrinkingKeyswitchKey`].
+    ///
+    /// See [`LweShrinkingKeyswitchKey::from_container`] for usage.
+    pub fn shared_randomness(&self) -> LweSecretKeySharedCoefCount {
+        LweSecretKeySharedCoefCount(self.lwe_ksk.output_key_lwe_dimension().0)
+    }
+
+    /// Return the number of elements in an encryption of an input [`LweSecretKey`] element of the
+    /// current [`LweShrinkingKeyswitchKey`].
+    pub fn input_key_element_encrypted_size(&self) -> usize {
+        self.lwe_ksk.input_key_element_encrypted_size()
+    }
+
+    /// Consume the entity and return its underlying container.
+    ///
+    /// See [`LweShrinkingKeyswitchKey::from_container`] for usage.
+    pub fn into_container(self) -> C {
+        self.lwe_ksk.into_container()
+    }
+
+    pub fn ciphertext_modulus(&self) -> CiphertextModulus<Scalar> {
+        self.lwe_ksk.ciphertext_modulus()
+    }
+
+    /// Return a view of the [`LweShrinkingKeyswitchKey`]. This is useful if an algorithm takes a
+    /// view by value.
+    pub fn as_view(&self) -> LweShrinkingKeyswitchKey<&'_ [Scalar]> {
+        LweShrinkingKeyswitchKey::from_container(
+            self.as_ref(),
+            self.decomposition_base_log(),
+            self.decomposition_level_count(),
+            self.output_lwe_size(),
+            self.ciphertext_modulus(),
+        )
+    }
+}
+
+impl<Scalar: UnsignedInteger, C: ContainerMut<Element = Scalar>> LweShrinkingKeyswitchKey<C> {
+    pub fn as_mut_lwe_keyswitch_key(&mut self) -> LweKeyswitchKey<&'_ mut [Scalar]> {
+        self.lwe_ksk.as_mut_view()
+    }
+
+    /// Mutable variant of [`LweShrinkingKeyswitchKey::as_view`].
+    pub fn as_mut_view(&mut self) -> LweShrinkingKeyswitchKey<&'_ mut [Scalar]> {
+        let decomposition_base_log = self.decomposition_base_log();
+        let decomposition_level_count = self.decomposition_level_count();
+        let output_lwe_size = self.output_lwe_size();
+        let ciphertext_modulus = self.ciphertext_modulus();
+        LweShrinkingKeyswitchKey::from_container(
+            self.as_mut(),
+            decomposition_base_log,
+            decomposition_level_count,
+            output_lwe_size,
+            ciphertext_modulus,
+        )
+    }
+}
+
+/// An [`LweShrinkingKeyswitchKey`] owning the memory for its own storage.
+pub type LweShrinkingKeyswitchKeyOwned<Scalar> = LweShrinkingKeyswitchKey<Vec<Scalar>>;
+/// A [`LweShrinkingKeyswitchKey`] immutably borrowing memory for its own storage.
+pub type LweShrinkingKeyswitchKeyView<'data, Scalar> = LweShrinkingKeyswitchKey<&'data [Scalar]>;
+/// A [`LweShrinkingKeyswitchKey`] mutably borrowing memory for its own storage.
+pub type LweShrinkingKeyswitchKeyMutView<'data, Scalar> =
+    LweShrinkingKeyswitchKey<&'data mut [Scalar]>;
+
+impl<Scalar: UnsignedInteger> LweShrinkingKeyswitchKeyOwned<Scalar> {
+    /// Allocate memory and create a new owned [`LweShrinkingKeyswitchKey`].
+    ///
+    /// # Note
+    ///
+    /// This function allocates a vector of the appropriate size and wraps it in the appropriate
+    /// type. If you want to generate an LWE shrinking keysiwtch key you need to use
+    /// [`crate::core_crypto::experimental::algorithms::generate_lwe_shrinking_keyswitch_key`] using
+    /// this key as output.
+    ///
+    /// See [`LweShrinkingKeyswitchKey::from_container`] for usage.
+    pub fn new(
+        fill_with: Scalar,
+        decomp_base_log: DecompositionBaseLog,
+        decomp_level_count: DecompositionLevelCount,
+        input_key_lwe_dimension: LweDimension,
+        output_key_lwe_dimension: LweDimension,
+        ciphertext_modulus: CiphertextModulus<Scalar>,
+    ) -> Self {
+        assert!(
+            output_key_lwe_dimension.0 <= input_key_lwe_dimension.0,
+            "The output LweDimension ({output_key_lwe_dimension:?}) \
+            must be smaller than the input LweDimension ({input_key_lwe_dimension:?}) \
+            for an LweShrinkingKeyswitchKey."
+        );
+
+        let shared_randomness_coef_count = LweSecretKeySharedCoefCount(output_key_lwe_dimension.0);
+
+        let unshared_randomness_coef_count =
+            input_key_lwe_dimension.unshared_coef_count_from(shared_randomness_coef_count);
+
+        Self {
+            lwe_ksk: LweKeyswitchKey::new(
+                fill_with,
+                decomp_base_log,
+                decomp_level_count,
+                LweDimension(unshared_randomness_coef_count.0),
+                output_key_lwe_dimension,
+                ciphertext_modulus,
+            ),
+        }
+    }
+}

--- a/tfhe/src/core_crypto/experimental/entities/mod.rs
+++ b/tfhe/src/core_crypto/experimental/entities/mod.rs
@@ -1,0 +1,3 @@
+pub mod lwe_shrinking_keyswitch_key;
+
+pub use lwe_shrinking_keyswitch_key::*;

--- a/tfhe/src/core_crypto/experimental/mod.rs
+++ b/tfhe/src/core_crypto/experimental/mod.rs
@@ -1,0 +1,4 @@
+pub mod algorithms;
+pub mod commons;
+pub mod entities;
+pub mod prelude;

--- a/tfhe/src/core_crypto/experimental/prelude.rs
+++ b/tfhe/src/core_crypto/experimental/prelude.rs
@@ -1,0 +1,8 @@
+//! Module with the definition of the experimental prelude.
+//!
+//! The TFHE-rs preludes include convenient imports.
+//! Having `tfhe::core_crypto::prelude::*;` should be enough to start using the lib.
+
+pub use super::algorithms::*;
+pub use super::commons::parameters::*;
+pub use super::entities::*;

--- a/tfhe/src/core_crypto/mod.rs
+++ b/tfhe/src/core_crypto/mod.rs
@@ -22,3 +22,7 @@ pub mod fft_impl;
 pub mod gpu;
 #[cfg(test)]
 pub mod keycache;
+
+// Experimental section
+#[cfg(feature = "experimental")]
+pub mod experimental;

--- a/tfhe/src/keycache/mod.rs
+++ b/tfhe/src/keycache/mod.rs
@@ -22,6 +22,8 @@ pub mod utils {
         fn name(&self) -> String;
     }
 
+    // Useful when defining custom parameters that may need an access to the keycache logic
+    #[macro_export]
     macro_rules! named_params_impl(
         (expose $($const_param:ident),* $(,)? ) => {
             $(
@@ -59,7 +61,7 @@ pub mod utils {
         }
     );
 
-    pub(crate) use named_params_impl;
+    pub use named_params_impl;
 
     pub struct FileStorage {
         prefix: String,


### PR DESCRIPTION
We want to get the core keytricks code in the main branch as an experimental feature so that the code does not rot, this is the first PR to do that.

We do not have very low error prob parameters in general so the recommendation from JB was to have doctests only (or tests with single iterations) for this first integration to still test things but avoid large amount of repetitions which could lead to flaky tests.

The code has to be clean but it's fine if some features are missing, like seeded entities (which would be required to be usable in production).

