### PR TITLE
feat(tfhe): use concrete-fft 0.4.1 for faster pbs 128 by default

### DIFF
--- a/tfhe/Cargo.toml
+++ b/tfhe/Cargo.toml
@@ -60,7 +60,7 @@ lazy_static = { version = "1.4.0", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 rayon = { version = "1.5.0" }
 bincode = "1.3.3"
-concrete-fft = { version = "0.4.0", features = ["serde", "fft128"] }
+concrete-fft = { version = "0.4.1", features = ["serde", "fft128"] }
 pulp = "0.18.8"
 tfhe-cuda-backend = { version = "0.2.0", path = "../backends/tfhe-cuda-backend", optional = true }
 aligned-vec = { version = "0.5", features = ["serde"] }


### PR DESCRIPTION
In practice it should already use the 0.4.1 version but this way it will be officially faster