### PR TITLE
refactor(shortint): add max_noise_level field to CompressedServerKey

### DIFF
--- a/tfhe/src/integer/gpu/server_key/mod.rs
+++ b/tfhe/src/integer/gpu/server_key/mod.rs
@@ -8,7 +8,7 @@ use crate::core_crypto::prelude::{
     LweMultiBitBootstrapKeyOwned,
 };
 use crate::integer::ClientKey;
-use crate::shortint::ciphertext::MaxDegree;
+use crate::shortint::ciphertext::{MaxDegree, MaxNoiseLevel};
 use crate::shortint::engine::ShortintEngine;
 use crate::shortint::{CarryModulus, CiphertextModulus, MessageModulus, PBSOrder};
 
@@ -33,6 +33,7 @@ pub struct CudaServerKey {
     pub carry_modulus: CarryModulus,
     // Maximum number of operations that can be done before emptying the operation buffer
     pub max_degree: MaxDegree,
+    pub max_noise_level: MaxNoiseLevel,
     // Modulus use for computations on the ciphertext
     pub ciphertext_modulus: CiphertextModulus,
     pub pbs_order: PBSOrder,
@@ -147,6 +148,7 @@ impl CudaServerKey {
             message_modulus: cks.parameters().message_modulus(),
             carry_modulus: cks.parameters().carry_modulus(),
             max_degree,
+            max_noise_level: cks.parameters().max_noise_level(),
             ciphertext_modulus: cks.parameters().ciphertext_modulus(),
             pbs_order: cks.parameters().encryption_key_choice().into(),
         }
@@ -195,6 +197,7 @@ impl CudaServerKey {
             message_modulus,
             carry_modulus,
             max_degree,
+            max_noise_level,
             ciphertext_modulus,
             pbs_order,
         } = cpu_key.key.clone();
@@ -239,6 +242,7 @@ impl CudaServerKey {
             message_modulus,
             carry_modulus,
             max_degree,
+            max_noise_level,
             ciphertext_modulus,
             pbs_order,
         }

--- a/tfhe/src/safe_deserialization.rs
+++ b/tfhe/src/safe_deserialization.rs
@@ -13,7 +13,7 @@ use serde::Serialize;
 // release.
 // When this happens, it also gives a clear version mismatch error rather than a generic
 // deserialization error or worse, a garbage object.
-const SERIALIZATION_VERSION: &str = "0.2";
+const SERIALIZATION_VERSION: &str = "0.3";
 
 // `VERSION_LENGTH_LIMIT` is the maximum `SERIALIZATION_VERSION` size which `safe_deserialization`
 // is going to try to read (it returns an error if it's too big).

--- a/tfhe/src/shortint/engine/server_side.rs
+++ b/tfhe/src/shortint/engine/server_side.rs
@@ -263,6 +263,7 @@ impl ShortintEngine {
             message_modulus: cks.parameters.message_modulus(),
             carry_modulus: cks.parameters.carry_modulus(),
             max_degree,
+            max_noise_level: cks.parameters.max_noise_level(),
             ciphertext_modulus: cks.parameters.ciphertext_modulus(),
             pbs_order: cks.parameters.encryption_key_choice().into(),
         }

--- a/tfhe/src/shortint/server_key/compressed.rs
+++ b/tfhe/src/shortint/server_key/compressed.rs
@@ -115,6 +115,7 @@ pub struct CompressedServerKey {
     pub carry_modulus: CarryModulus,
     // Maximum number of operations that can be done before emptying the operation buffer
     pub max_degree: MaxDegree,
+    pub max_noise_level: MaxNoiseLevel,
     pub ciphertext_modulus: CiphertextModulus,
     pub pbs_order: PBSOrder,
 }
@@ -146,6 +147,7 @@ impl CompressedServerKey {
             message_modulus,
             carry_modulus,
             max_degree,
+            max_noise_level,
             ciphertext_modulus,
             pbs_order,
         } = self;
@@ -258,7 +260,7 @@ impl CompressedServerKey {
         let message_modulus = *message_modulus;
         let carry_modulus = *carry_modulus;
         let max_degree = *max_degree;
-        let max_noise_level = MaxNoiseLevel::from_msg_carry_modulus(message_modulus, carry_modulus);
+        let max_noise_level = *max_noise_level;
         let ciphertext_modulus = *ciphertext_modulus;
         let pbs_order = *pbs_order;
 
@@ -283,6 +285,7 @@ impl CompressedServerKey {
         MessageModulus,
         CarryModulus,
         MaxDegree,
+        MaxNoiseLevel,
         CiphertextModulus,
         PBSOrder,
     ) {
@@ -292,6 +295,7 @@ impl CompressedServerKey {
             message_modulus,
             carry_modulus,
             max_degree,
+            max_noise_level,
             ciphertext_modulus,
             pbs_order,
         } = self;
@@ -302,6 +306,7 @@ impl CompressedServerKey {
             message_modulus,
             carry_modulus,
             max_degree,
+            max_noise_level,
             ciphertext_modulus,
             pbs_order,
         )
@@ -312,12 +317,14 @@ impl CompressedServerKey {
     /// # Panics
     ///
     /// Panics if the constituents are not compatible with each others.
+    #[allow(clippy::too_many_arguments)]
     pub fn from_raw_parts(
         key_switching_key: SeededLweKeyswitchKeyOwned<u64>,
         bootstrapping_key: ShortintCompressedBootstrappingKey,
         message_modulus: MessageModulus,
         carry_modulus: CarryModulus,
         max_degree: MaxDegree,
+        max_noise_level: MaxNoiseLevel,
         ciphertext_modulus: CiphertextModulus,
         pbs_order: PBSOrder,
     ) -> Self {
@@ -370,6 +377,7 @@ impl CompressedServerKey {
             message_modulus,
             carry_modulus,
             max_degree,
+            max_noise_level,
             ciphertext_modulus,
             pbs_order,
         }


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: https://github.com/zama-ai/tfhe-rs-internal/issues/399

Also has the serialization version update, we will need to make a 0.6.1 and yank the 0.6.0 otherwise we have a problem for serialization

This is for main, backport later