### PR TITLE
chore(gpu): reduce memory consumption in host_integer_sum_ciphertexts_vec_kb

### DIFF
--- a/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_multibit.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_multibit.cu
@@ -392,7 +392,7 @@ __host__ uint32_t get_lwe_chunk_size(uint32_t ct_count) {
   return (ct_count > 10000) ? 30 : 45;
 #elif CUDA_ARCH >= 700
   // Tesla V100
-  return (ct_count > 10000) ? 12 : 18;
+  return (ct_count > 10000) ? 4 : 18;
 #else
   // Generic case
   return (ct_count > 10000) ? 2 : 1;


### PR DESCRIPTION
`host_integer_scalar_mul_radix` relies on `host_integer_sum_ciphertexts_vec_kb`, which initializes `luts_message_carry`, a pair of LUTs initialized to handle `total_count` PBSs in parallel. 

The current implementation assumes the worse case always with `total_count = num_blocks_in_radix * max_num_radix_in_vec`. This may imply in several GBs being allocated only for scalar_mul, which becomes a big problem on more limited GPUs as RTX4090.

This PR moves the allocation of those LUTs to the host function so we only allocate the amount of bits we really need for the given inputs. 

<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
