### PR TITLE
fix(zk): correct byte indices for uncompressed serializtion

### DIFF
--- a/tfhe-zk-pok/src/curve_446/mod.rs
+++ b/tfhe-zk-pok/src/curve_446/mod.rs
@@ -576,8 +576,8 @@ pub mod g1 {
                 writer.write_all(&bytes)?;
             } else {
                 let mut bytes = [0u8; 2 * G1_SERIALIZED_SIZE];
-                bytes[1..1 + G1_SERIALIZED_SIZE].copy_from_slice(&x_bytes[..]);
-                bytes[2 + G1_SERIALIZED_SIZE..].copy_from_slice(&serialize_fq(p.y)[..]);
+                bytes[1..G1_SERIALIZED_SIZE].copy_from_slice(&x_bytes[..]);
+                bytes[1 + G1_SERIALIZED_SIZE..].copy_from_slice(&serialize_fq(p.y)[..]);
 
                 encoding.encode_flags(&mut bytes);
                 writer.write_all(&bytes)?;


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description
This fixes (de)serialization of uncompressed BLS12-446 curve points by using the correct byte indices.

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
