### PR TITLE
feat(zk): open up the API to output the CRS witness dimension

### DIFF
--- a/tfhe-zk-pok/src/proofs/pke.rs
+++ b/tfhe-zk-pok/src/proofs/pke.rs
@@ -91,18 +91,7 @@ pub struct PrivateCommit<G: Curve> {
     __marker: PhantomData<G>,
 }
 
-pub fn compute_crs_len(
-    d: usize,
-    k: usize,
-    b: u64,
-    _q: u64, // we keep q here to make sure the API is consistent with [crs_gen]
-    t: u64,
-) -> usize {
-    let (n, _, _) = compute_crs_params(d, k, b, _q, t);
-    n
-}
-
-fn compute_crs_params(
+pub fn compute_crs_params(
     d: usize,
     k: usize,
     b: u64,


### PR DESCRIPTION
The motivation of this PR is that sometimes the CRS is generated by a ceremony, instead of centrally.  So it is useful to have some function that computes the CRS witness dimension without generating the CRS centrally.

<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description

### Check-list:

* [x] Tests for the changes have been added (for bug fixes / features): existing tests will run on the new code since it's simply slicing up functions
* [x] Docs have been added / updated (for bug fixes / features)
* [x] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [x] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
