### PR TITLE
feat(gpu): add compatibility with cuda from package managers

### DIFF
--- a/backends/tfhe-cuda-backend/Cargo.toml
+++ b/backends/tfhe-cuda-backend/Cargo.toml
@@ -13,6 +13,7 @@ keywords = ["fully", "homomorphic", "encryption", "fhe", "cryptography"]
 
 [build-dependencies]
 cmake = { version = "0.1" }
+pkg-config = { version = "0.3" }
 
 [dependencies]
 thiserror = "1.0"

--- a/backends/tfhe-cuda-backend/build.rs
+++ b/backends/tfhe-cuda-backend/build.rs
@@ -21,7 +21,15 @@ fn main() {
         let dest = cmake::build("cuda");
         println!("cargo:rustc-link-search=native={}", dest.display());
         println!("cargo:rustc-link-lib=static=tfhe_cuda_backend");
-        println!("cargo:rustc-link-search=native=/usr/local/cuda/lib64");
+
+        // Try to find the cuda libs with pkg-config, default to the path used by the nvidia runfile
+        if pkg_config::Config::new()
+            .atleast_version("10")
+            .probe("cuda")
+            .is_err()
+        {
+            println!("cargo:rustc-link-search=native=/usr/local/cuda/lib64");
+        }
         println!("cargo:rustc-link-lib=gomp");
         println!("cargo:rustc-link-lib=cudart");
         println!("cargo:rustc-link-search=native=/usr/lib/x86_64-linux-gnu/");


### PR DESCRIPTION
### PR content/description
The `build.rs` of the cuda backend uses the default install path from the nvidia runfile to look for libraries. Linux distributions may install the cuda libs in another location. The pkg-config utility should be able to automatically the path of libraries if cuda was installed using a package manager. We can add "best effort" support to other installation methods using this tool.

This has been tested by running the pcc_gpu checks using the cuda provided by the package manager of Archlinux.