### PR TITLE
chore(gpu): add a compilation conditional to assert we won't be checking for cudaDevAttrClusterLaunch on archs < 9.0

### DIFF
--- a/backends/tfhe-cuda-backend/cuda/src/device.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/device.cu
@@ -86,12 +86,16 @@ bool cuda_check_support_cooperative_groups() {
 ///  false if Thread Block Cluster is not supported.
 ///  true otherwise
 bool cuda_check_support_thread_block_clusters() {
+#if CUDA_ARCH >= 900
   // To-do: Is this really the best way to check support?
   int tbc_supported = 0;
   check_cuda_error(
       cudaDeviceGetAttribute(&tbc_supported, cudaDevAttrClusterLaunch, 0));
 
   return tbc_supported > 0;
+#else
+  return false;
+#endif
 }
 
 /// Copy memory to the GPU asynchronously


### PR DESCRIPTION

<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
