### PR TITLE
Tm/boolean ifthenelse

### DIFF
--- a/tfhe/benches/integer/bench.rs
+++ b/tfhe/benches/integer/bench.rs
@@ -10,6 +10,7 @@ use rand::prelude::*;
 use std::env;
 use std::vec::IntoIter;
 use tfhe::integer::keycache::KEY_CACHE;
+use tfhe::integer::prelude::*;
 use tfhe::integer::{IntegerKeyKind, RadixCiphertext, RadixClientKey, ServerKey, U256};
 use tfhe::keycache::NamedParam;
 use tfhe::shortint::parameters::*;

--- a/tfhe/benches/integer/signed_bench.rs
+++ b/tfhe/benches/integer/signed_bench.rs
@@ -8,6 +8,7 @@ use rand::prelude::*;
 use std::env;
 use std::vec::IntoIter;
 use tfhe::integer::keycache::KEY_CACHE;
+use tfhe::integer::prelude::*;
 use tfhe::integer::{IntegerKeyKind, RadixCiphertext, ServerKey, SignedRadixCiphertext, I256};
 use tfhe::keycache::NamedParam;
 #[cfg(feature = "gpu")]

--- a/tfhe/examples/fhe_strings/server_key/mod.rs
+++ b/tfhe/examples/fhe_strings/server_key/mod.rs
@@ -9,7 +9,8 @@ use crate::N;
 use rayon::prelude::*;
 use std::cmp::Ordering;
 use tfhe::integer::bigint::static_unsigned::StaticUnsignedBigInt;
-use tfhe::integer::{BooleanBlock, IntegerCiphertext, RadixCiphertext, ServerKey as FheServerKey};
+use tfhe::integer::prelude::*;
+use tfhe::integer::{BooleanBlock, RadixCiphertext, ServerKey as FheServerKey};
 
 /// Represents a server key to operate homomorphically on [`FheString`].
 #[derive(serde::Serialize, serde::Deserialize, Clone)]

--- a/tfhe/examples/fhe_strings/server_key/pattern/find.rs
+++ b/tfhe/examples/fhe_strings/server_key/pattern/find.rs
@@ -3,6 +3,7 @@ use crate::server_key::pattern::IsMatch;
 use crate::server_key::{CharIter, FheStringIsEmpty, FheStringLen, ServerKey};
 use rayon::prelude::*;
 use rayon::vec::IntoIter;
+use tfhe::integer::prelude::*;
 use tfhe::integer::{BooleanBlock, RadixCiphertext};
 
 impl ServerKey {

--- a/tfhe/examples/fhe_strings/server_key/pattern/replace.rs
+++ b/tfhe/examples/fhe_strings/server_key/pattern/replace.rs
@@ -1,6 +1,7 @@
 use crate::ciphertext::{FheString, GenericPattern, UIntArg};
 use crate::server_key::pattern::IsMatch;
 use crate::server_key::{FheStringIsEmpty, FheStringLen, ServerKey};
+use tfhe::integer::prelude::*;
 use tfhe::integer::{BooleanBlock, RadixCiphertext};
 
 impl ServerKey {

--- a/tfhe/examples/fhe_strings/server_key/pattern/strip.rs
+++ b/tfhe/examples/fhe_strings/server_key/pattern/strip.rs
@@ -3,6 +3,7 @@ use crate::server_key::pattern::IsMatch;
 use crate::server_key::{CharIter, FheStringLen, ServerKey};
 use rayon::prelude::*;
 use std::ops::Range;
+use tfhe::integer::prelude::*;
 use tfhe::integer::BooleanBlock;
 
 impl ServerKey {

--- a/tfhe/examples/fhe_strings/server_key/trim.rs
+++ b/tfhe/examples/fhe_strings/server_key/trim.rs
@@ -1,6 +1,7 @@
 use crate::ciphertext::{FheAsciiChar, FheString};
 use crate::server_key::{FheStringIsEmpty, FheStringIterator, FheStringLen, ServerKey};
 use rayon::prelude::*;
+use tfhe::integer::prelude::*;
 use tfhe::integer::BooleanBlock;
 
 pub struct SplitAsciiWhitespace {

--- a/tfhe/src/integer/mod.rs
+++ b/tfhe/src/integer/mod.rs
@@ -59,6 +59,7 @@ pub mod key_switching_key;
 pub mod keycache;
 pub mod oprf;
 pub mod parameters;
+pub mod prelude;
 pub mod public_key;
 pub mod server_key;
 pub mod wopbs;

--- a/tfhe/src/integer/prelude.rs
+++ b/tfhe/src/integer/prelude.rs
@@ -1,0 +1,1 @@
+pub use crate::integer::ciphertext::{IntegerCiphertext, IntegerRadixCiphertext};

--- a/tfhe/src/integer/prelude.rs
+++ b/tfhe/src/integer/prelude.rs
@@ -1,1 +1,2 @@
 pub use crate::integer::ciphertext::{IntegerCiphertext, IntegerRadixCiphertext};
+pub use crate::integer::server_key::radix_parallel::cmux::ServerKeyDefaultCMux;

--- a/tfhe/src/integer/server_key/radix_parallel/mod.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/mod.rs
@@ -2,7 +2,7 @@ mod abs;
 mod add;
 mod bit_extractor;
 mod bitwise_op;
-mod cmux;
+pub(crate) mod cmux;
 mod comparison;
 mod div_mod;
 mod modulus_switch_compression;

--- a/tfhe/src/integer/server_key/radix_parallel/tests_signed/test_cmux.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_signed/test_cmux.rs
@@ -1,4 +1,5 @@
 use crate::integer::keycache::KEY_CACHE;
+use crate::integer::prelude::*;
 use crate::integer::server_key::radix_parallel::tests_cases_unsigned::{FunctionExecutor, NB_CTXT};
 use crate::integer::server_key::radix_parallel::tests_unsigned::{
     nb_tests_for_params, CpuFunctionExecutor,
@@ -36,7 +37,12 @@ fn integer_signed_default_if_then_else<P>(param: P)
 where
     P: Into<PBSParameters>,
 {
-    let executor = CpuFunctionExecutor::new(&ServerKey::if_then_else_parallelized);
+    let func =
+        |sks: &ServerKey,
+         cond: &BooleanBlock,
+         lhs: &SignedRadixCiphertext,
+         rhs: &SignedRadixCiphertext| { sks.if_then_else_parallelized(cond, lhs, rhs) };
+    let executor = CpuFunctionExecutor::new(&func);
     signed_default_if_then_else_test(param, executor);
 }
 pub(crate) fn signed_default_if_then_else_test<P, T>(param: P, mut executor: T)

--- a/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_cmux.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_cmux.rs
@@ -1,4 +1,5 @@
 use crate::integer::keycache::KEY_CACHE;
+use crate::integer::prelude::*;
 use crate::integer::server_key::radix_parallel::tests_cases_unsigned::{FunctionExecutor, NB_CTXT};
 use crate::integer::server_key::radix_parallel::tests_unsigned::{
     nb_tests_for_params, CpuFunctionExecutor,
@@ -26,7 +27,11 @@ fn integer_default_if_then_else<P>(param: P)
 where
     P: Into<PBSParameters>,
 {
-    let executor = CpuFunctionExecutor::new(&ServerKey::if_then_else_parallelized);
+    let func =
+        |sks: &ServerKey, cond: &BooleanBlock, lhs: &RadixCiphertext, rhs: &RadixCiphertext| {
+            sks.if_then_else_parallelized(cond, lhs, rhs)
+        };
+    let executor = CpuFunctionExecutor::new(&func);
     default_if_then_else_test(param, executor);
 }
 pub(crate) fn smart_if_then_else_test<P, T>(param: P, mut executor: T)

--- a/tfhe/src/safe_deserialization.rs
+++ b/tfhe/src/safe_deserialization.rs
@@ -156,7 +156,7 @@ mod test_shortint {
 mod test_integer {
     use crate::conformance::ListSizeConstraint;
     use crate::high_level_api::{generate_keys, ConfigBuilder};
-    use crate::prelude::{FheDecrypt, FheTryEncrypt};
+    use crate::prelude::*;
     use crate::safe_deserialization::{safe_deserialize_conformant, safe_serialize};
     use crate::shortint::parameters::{
         PARAM_MESSAGE_1_CARRY_1_KS_PBS, PARAM_MESSAGE_2_CARRY_2_KS_PBS,
@@ -167,7 +167,7 @@ mod test_integer {
         CompactPublicKey, FheUint8ConformanceParams,
     };
     #[test]
-    fn safe_desererialization_ct() {
+    fn safe_deserialization_ct() {
         let (client_key, server_key) = generate_keys(ConfigBuilder::default().build());
 
         let public_key = CompactPublicKey::new(&client_key);
@@ -198,7 +198,7 @@ mod test_integer {
     }
 
     #[test]
-    fn safe_desererialization_ct_list() {
+    fn safe_deserialization_ct_list() {
         let (client_key, server_key) = generate_keys(ConfigBuilder::default().build());
 
         let public_key = CompactPublicKey::new(&client_key);


### PR DESCRIPTION
This adds if_then_else/cmux on BoleanBlock for integer API
and FheBool for HLAPI.

To have the same name for both default version of the API
in integer a trait was introduced.

Ideally we would have wanted to do the boolean cmux in one PBS by
packing data like this `(cond * 4) + (if * 2) + else` but this
would not respect the max norm2.

BREAKING CHANGE: integer::ServerKey::if_then_else_parallelized requires the
trait ServerKeyDefaultCMux to be in scope.

Fixes #825

This PR also has the commit that creates the prelude