### PR TITLE
chore(ci): use only pull_request event in workflow

### DIFF
--- a/.github/workflows/approve_label.yml
+++ b/.github/workflows/approve_label.yml
@@ -3,7 +3,6 @@ name: PR label manager
 
 on:
   pull_request:
-  pull_request_target:
   pull_request_review:
     types: [submitted]
 
@@ -18,8 +17,7 @@ jobs:
 
       # Remove label if a push is performed after an approval
       - name: Remove approved label
-        if: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_target')
-          && contains(fromJSON(env.LABELS), 'approved') }}
+        if: ${{ github.event_name == 'pull_request' && contains(fromJSON(env.LABELS), 'approved') }}
         uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0
         with:
           # We use a PAT to have the same user (zama-bot) for label deletion as for creation.
@@ -36,12 +34,3 @@ jobs:
           # We need to use a PAT to be able to trigger `labeled` event for the other workflow.
           github_token: ${{ secrets.FHE_ACTIONS_TOKEN }}
           labels: approved
-
-      # Add label only if the pull request is from a forked repository
-      - name: Add external contribution label
-        uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf
-        if: ${{ github.event_name == 'pull_request_target' 
-          && !contains(fromJSON(env.LABELS), 'external-contribution') }}
-        with:
-          github_token: ${{ secrets.FHE_ACTIONS_TOKEN }}
-          labels: external-contribution

--- a/.github/workflows/aws_tfhe_fast_tests.yml
+++ b/.github/workflows/aws_tfhe_fast_tests.yml
@@ -16,7 +16,6 @@ on:
   # Allows you to run this workflow manually from the Actions tab as an alternative.
   workflow_dispatch:
   pull_request:
-  pull_request_target:
 
 jobs:
   setup-instance:

--- a/.github/workflows/aws_tfhe_gpu_4090_tests.yml
+++ b/.github/workflows/aws_tfhe_gpu_4090_tests.yml
@@ -16,8 +16,6 @@ on:
   # Allows you to run this workflow manually from the Actions tab as an alternative.
   workflow_dispatch:
   pull_request:
-    types: [labeled]
-  pull_request_target:
     types: [ labeled ]
 
 jobs:

--- a/.github/workflows/aws_tfhe_gpu_tests.yml
+++ b/.github/workflows/aws_tfhe_gpu_tests.yml
@@ -16,7 +16,6 @@ on:
   # Allows you to run this workflow manually from the Actions tab as an alternative.
   workflow_dispatch:
   pull_request:
-  pull_request_target:
 
 jobs:
   setup-instance:

--- a/.github/workflows/aws_tfhe_integer_tests.yml
+++ b/.github/workflows/aws_tfhe_integer_tests.yml
@@ -16,8 +16,6 @@ on:
   workflow_dispatch:
   pull_request:
     types: [ labeled ]
-  pull_request_target:
-    types: [ labeled ]
 
 jobs:
   setup-instance:

--- a/.github/workflows/aws_tfhe_signed_integer_tests.yml
+++ b/.github/workflows/aws_tfhe_signed_integer_tests.yml
@@ -16,8 +16,6 @@ on:
   workflow_dispatch:
   pull_request:
     types: [ labeled ]
-  pull_request_target:
-    types: [ labeled ]
 
 jobs:
   setup-instance:

--- a/.github/workflows/aws_tfhe_tests.yml
+++ b/.github/workflows/aws_tfhe_tests.yml
@@ -17,8 +17,6 @@ on:
   workflow_dispatch:
   pull_request:
     types: [ labeled ]
-  pull_request_target:
-    types: [ labeled ]
   schedule:
     # Nightly tests @ 1AM after each work day
     - cron: "0 1 * * MON-FRI"
@@ -120,9 +118,8 @@ jobs:
 
   setup-instance:
     name: Setup instance (cpu-tests)
-    if: (github.event_name != 'pull_request' && github.event_name != 'pull_request_target') ||
-      ((github.event_name == 'pull_request' || github.event_name != 'pull_request_target') && 
-      needs.should-run.outputs.any_file_changed == 'true')
+    if: github.event_name != 'pull_request' ||
+      (github.event_name == 'pull_request' && needs.should-run.outputs.any_file_changed == 'true')
     needs: should-run
     runs-on: ubuntu-latest
     outputs:
@@ -141,9 +138,8 @@ jobs:
 
   cpu-tests:
     name: CPU tests
-    if: (github.event_name != 'pull_request' && github.event_name != 'pull_request_target') ||
-      ((github.event_name == 'pull_request' || github.event_name != 'pull_request_target') &&
-      needs.setup-instance.result != 'skipped')
+    if: github.event_name != 'pull_request' ||
+      (github.event_name == 'pull_request' && needs.setup-instance.result != 'skipped')
     needs: [ should-run, setup-instance ]
     concurrency:
       group: ${{ github.workflow }}_${{github.event_name}}_${{ github.ref }}

--- a/.github/workflows/aws_tfhe_wasm_tests.yml
+++ b/.github/workflows/aws_tfhe_wasm_tests.yml
@@ -16,8 +16,6 @@ on:
   workflow_dispatch:
   pull_request:
     types: [ labeled ]
-  pull_request_target:
-    types: [ labeled ]
 
 jobs:
   setup-instance:

--- a/.github/workflows/csprng_randomness_tests.yml
+++ b/.github/workflows/csprng_randomness_tests.yml
@@ -16,8 +16,6 @@ on:
   workflow_dispatch:
   pull_request:
     types: [ labeled ]
-  pull_request_target:
-    types: [labeled]
 
 jobs:
   setup-instance:

--- a/.github/workflows/m1_tests.yml
+++ b/.github/workflows/m1_tests.yml
@@ -3,8 +3,6 @@ name: Tests on M1 CPU
 on:
   workflow_dispatch:
   pull_request:
-    types: [labeled]
-  pull_request_target:
     types: [ labeled ]
   # Have a nightly build for M1 tests
   schedule:
@@ -140,7 +138,7 @@ jobs:
     if: ${{ always() }}
     steps:
       - uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0
-        if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
+        if: ${{ github.event_name == 'pull_request' }}
         with:
           labels: m1_test
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Using pull_request_target event to handle PR from forks was clashing with pull_request event. It would launch double amount of actions and moreover leads to cancellation in jobs due to the concurrency directive.
