### PR TITLE
fix(gpu): ensure `single carry propagation` returns carry

### DIFF
--- a/backends/tfhe-cuda-backend/cuda/include/integer.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer.h
@@ -242,9 +242,12 @@ void scratch_cuda_propagate_single_carry_kb_64_inplace(
     uint32_t num_blocks, uint32_t message_modulus, uint32_t carry_modulus,
     PBS_TYPE pbs_type, bool allocate_gpu_memory);
 
-void cuda_propagate_single_carry_kb_64_inplace(
-    void **streams, uint32_t *gpu_indexes, uint32_t gpu_count, void *lwe_array,
-    int8_t *mem_ptr, void *bsk, void *ksk, uint32_t num_blocks);
+void cuda_propagate_single_carry_kb_64_inplace(void **streams,
+                                               uint32_t *gpu_indexes,
+                                               uint32_t gpu_count,
+                                               void *lwe_array, void *carry_out,
+                                               int8_t *mem_ptr, void *bsk,
+                                               void *ksk, uint32_t num_blocks);
 
 void cleanup_cuda_propagate_single_carry(void *stream, uint32_t gpu_index,
                                          int8_t **mem_ptr_void);

--- a/backends/tfhe-cuda-backend/cuda/src/integer/integer.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/integer.cu
@@ -134,12 +134,15 @@ void scratch_cuda_propagate_single_carry_kb_64_inplace(
       allocate_gpu_memory);
 }
 
-void cuda_propagate_single_carry_kb_64_inplace(
-    void **streams, uint32_t *gpu_indexes, uint32_t gpu_count, void *lwe_array,
-    int8_t *mem_ptr, void *bsk, void *ksk, uint32_t num_blocks) {
+void cuda_propagate_single_carry_kb_64_inplace(void **streams,
+                                               uint32_t *gpu_indexes,
+                                               uint32_t gpu_count,
+                                               void *lwe_array, void *carry_out,
+                                               int8_t *mem_ptr, void *bsk,
+                                               void *ksk, uint32_t num_blocks) {
   host_propagate_single_carry<uint64_t>(
       (cudaStream_t *)(streams), gpu_indexes, gpu_count,
-      static_cast<uint64_t *>(lwe_array),
+      static_cast<uint64_t *>(lwe_array), static_cast<uint64_t *>(carry_out),
       (int_sc_prop_memory<uint64_t> *)mem_ptr, bsk,
       static_cast<uint64_t *>(ksk), num_blocks);
 }

--- a/backends/tfhe-cuda-backend/cuda/src/integer/integer.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/integer.cuh
@@ -410,6 +410,7 @@ void scratch_cuda_propagate_single_carry_kb_inplace(
 template <typename Torus>
 void host_propagate_single_carry(cudaStream_t *streams, uint32_t *gpu_indexes,
                                  uint32_t gpu_count, Torus *lwe_array,
+                                 Torus *carry_out,
                                  int_sc_prop_memory<Torus> *mem, void *bsk,
                                  Torus *ksk, uint32_t num_blocks) {
   auto params = mem->params;
@@ -459,6 +460,10 @@ void host_propagate_single_carry(cudaStream_t *streams, uint32_t *gpu_indexes,
   host_radix_blocks_rotate_right(streams, gpu_indexes, gpu_count, step_output,
                                  generates_or_propagates, 1, num_blocks,
                                  big_lwe_size);
+  if (carry_out != nullptr) {
+    cuda_memcpy_async_gpu_to_gpu(carry_out, step_output, big_lwe_size_bytes,
+                                 streams[0], gpu_indexes[0]);
+  }
   cuda_memset_async(step_output, 0, big_lwe_size_bytes, streams[0],
                     gpu_indexes[0]);
 

--- a/backends/tfhe-cuda-backend/cuda/src/integer/multiplication.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/multiplication.cuh
@@ -360,8 +360,8 @@ __host__ void host_integer_sum_ciphertexts_vec_kb(
                 num_blocks);
 
   host_propagate_single_carry<Torus>(streams, gpu_indexes, gpu_count,
-                                     radix_lwe_out, mem_ptr->scp_mem, bsk, ksk,
-                                     num_blocks);
+                                     radix_lwe_out, nullptr, mem_ptr->scp_mem,
+                                     bsk, ksk, num_blocks);
 }
 
 template <typename Torus, typename STorus, class params>

--- a/backends/tfhe-cuda-backend/src/cuda_bind.rs
+++ b/backends/tfhe-cuda-backend/src/cuda_bind.rs
@@ -1002,6 +1002,7 @@ extern "C" {
         gpu_indexes: *const u32,
         gpu_count: u32,
         radix_lwe: *mut c_void,
+        carry_out: *mut c_void,
         mem_ptr: *mut i8,
         bsk: *const c_void,
         ksk: *const c_void,

--- a/tfhe/src/integer/gpu/mod.rs
+++ b/tfhe/src/integer/gpu/mod.rs
@@ -925,6 +925,7 @@ pub unsafe fn full_propagate_assign_async<T: UnsignedInteger, B: Numeric>(
 pub unsafe fn propagate_single_carry_assign_async<T: UnsignedInteger, B: Numeric>(
     streams: &CudaStreams,
     radix_lwe_input: &mut CudaVec<T>,
+    carry_out: &mut CudaVec<T>,
     bootstrapping_key: &CudaVec<B>,
     keyswitch_key: &CudaVec<T>,
     lwe_dimension: LweDimension,
@@ -981,6 +982,7 @@ pub unsafe fn propagate_single_carry_assign_async<T: UnsignedInteger, B: Numeric
         streams.gpu_indexes.as_ptr(),
         streams.len() as u32,
         radix_lwe_input.as_mut_c_ptr(),
+        carry_out.as_mut_c_ptr(),
         mem_ptr,
         bootstrapping_key.as_c_ptr(),
         keyswitch_key.as_c_ptr(),

--- a/tfhe/src/integer/gpu/server_key/radix/add.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/add.rs
@@ -104,7 +104,7 @@ impl CudaServerKey {
             }
         };
         self.unchecked_add_assign_async(lhs, rhs, streams);
-        self.propagate_single_carry_assign_async(lhs, streams);
+        let _carry = self.propagate_single_carry_assign_async(lhs, streams);
     }
 
     pub fn add_assign<T: CudaIntegerRadixCiphertext>(

--- a/tfhe/src/integer/gpu/server_key/radix/neg.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/neg.rs
@@ -167,7 +167,7 @@ impl CudaServerKey {
         };
 
         self.unchecked_neg_assign_async(ct, stream);
-        self.propagate_single_carry_assign_async(ct, stream);
+        let _carry = self.propagate_single_carry_assign_async(ct, stream);
     }
 
     pub fn neg_assign<T: CudaIntegerRadixCiphertext>(&self, ctxt: &mut T, stream: &CudaStreams) {

--- a/tfhe/src/integer/gpu/server_key/radix/scalar_add.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/scalar_add.rs
@@ -178,7 +178,7 @@ impl CudaServerKey {
         };
 
         self.unchecked_scalar_add_assign_async(ct, scalar, streams);
-        self.propagate_single_carry_assign_async(ct, streams);
+        let _carry = self.propagate_single_carry_assign_async(ct, streams);
     }
 
     pub fn scalar_add_assign<Scalar, T>(&self, ct: &mut T, scalar: Scalar, streams: &CudaStreams)

--- a/tfhe/src/integer/gpu/server_key/radix/scalar_sub.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/scalar_sub.rs
@@ -150,7 +150,7 @@ impl CudaServerKey {
         };
 
         self.unchecked_scalar_sub_assign_async(ct, scalar, stream);
-        self.propagate_single_carry_assign_async(ct, stream);
+        let _carry = self.propagate_single_carry_assign_async(ct, stream);
     }
 
     pub fn scalar_sub_assign<Scalar, T>(&self, ct: &mut T, scalar: Scalar, stream: &CudaStreams)

--- a/tfhe/src/integer/gpu/server_key/radix/sub.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/sub.rs
@@ -270,7 +270,7 @@ impl CudaServerKey {
         };
 
         self.unchecked_sub_assign_async(lhs, rhs, streams);
-        self.propagate_single_carry_assign_async(lhs, streams);
+        let _carry = self.propagate_single_carry_assign_async(lhs, streams);
     }
 
     pub fn unsigned_overflowing_sub(


### PR DESCRIPTION
cuda backend `propagate_single_carry` now returns `carry_out` instead of only processing input carries.
