### PR TITLE
chore(gpu): change the number of threads in smart copy, pack blocks and blocks rotate

### DIFF
--- a/backends/tfhe-cuda-backend/cuda/src/integer/integer.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/integer.cuh
@@ -72,7 +72,7 @@ host_radix_blocks_rotate_right(cudaStream_t *streams, uint32_t *gpu_indexes,
           "pointers should be different");
   }
   cudaSetDevice(gpu_indexes[0]);
-  radix_blocks_rotate_right<<<blocks_count, 256, 0, streams[0]>>>(
+  radix_blocks_rotate_right<<<blocks_count, 1024, 0, streams[0]>>>(
       dst, src, value, blocks_count, lwe_size);
 }
 
@@ -89,7 +89,7 @@ host_radix_blocks_rotate_left(cudaStream_t *streams, uint32_t *gpu_indexes,
           "pointers should be different");
   }
   cudaSetDevice(gpu_indexes[0]);
-  radix_blocks_rotate_left<<<blocks_count, 256, 0, streams[0]>>>(
+  radix_blocks_rotate_left<<<blocks_count, 1024, 0, streams[0]>>>(
       dst, src, value, blocks_count, lwe_size);
 }
 
@@ -740,7 +740,7 @@ __host__ void pack_blocks(cudaStream_t stream, uint32_t gpu_index,
 
   int num_blocks = 0, num_threads = 0;
   int num_entries = (lwe_dimension + 1);
-  getNumBlocksAndThreads(num_entries, 512, num_blocks, num_threads);
+  getNumBlocksAndThreads(num_entries, 1024, num_blocks, num_threads);
   device_pack_blocks<<<num_blocks, num_threads, 0, stream>>>(
       lwe_array_out, lwe_array_in, lwe_dimension, num_radix_blocks, factor);
 }

--- a/backends/tfhe-cuda-backend/cuda/src/integer/multiplication.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/multiplication.cuh
@@ -316,7 +316,7 @@ __host__ void host_integer_sum_ciphertexts_vec_kb(
     cuda_memcpy_async_to_gpu(d_smart_copy_out, h_smart_copy_out, copy_size,
                              streams[0], gpu_indexes[0]);
 
-    smart_copy<<<sm_copy_count, 256, 0, streams[0]>>>(
+    smart_copy<<<sm_copy_count, 1024, 0, streams[0]>>>(
         new_blocks, new_blocks, d_smart_copy_out, d_smart_copy_in,
         big_lwe_size);
     check_cuda_error(cudaGetLastError());

--- a/backends/tfhe-cuda-backend/cuda/src/integer/scalar_rotate.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/scalar_rotate.cuh
@@ -60,6 +60,7 @@ __host__ void host_integer_radix_scalar_rotate_kb_inplace(
   // block_count blocks will be used in the grid
   // one block is responsible to process single lwe ciphertext
   if (mem->shift_type == LEFT_SHIFT) {
+    // rotate right as the blocks are from LSB to MSB
     host_radix_blocks_rotate_right(streams, gpu_indexes, gpu_count,
                                    rotated_buffer, lwe_array, rotations,
                                    num_blocks, big_lwe_size);
@@ -84,7 +85,7 @@ __host__ void host_integer_radix_scalar_rotate_kb_inplace(
         lut_bivariate->params.message_modulus);
 
   } else {
-    // left shift
+    // rotate left as the blocks are from LSB to MSB
     host_radix_blocks_rotate_left(streams, gpu_indexes, gpu_count,
                                   rotated_buffer, lwe_array, rotations,
                                   num_blocks, big_lwe_size);

--- a/backends/tfhe-cuda-backend/cuda/src/integer/scalar_shifts.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/scalar_shifts.cuh
@@ -59,10 +59,11 @@ __host__ void host_integer_radix_logical_scalar_shift_kb_inplace(
 
   // rotate right all the blocks in radix ciphertext
   // copy result in new buffer
-  // 256 threads are used in every block
+  // 1024 threads are used in every block
   // block_count blocks will be used in the grid
   // one block is responsible to process single lwe ciphertext
   if (mem->shift_type == LEFT_SHIFT) {
+    // rotate right as the blocks are from LSB to MSB
     host_radix_blocks_rotate_right(streams, gpu_indexes, gpu_count,
                                    rotated_buffer, lwe_array, rotations,
                                    num_blocks, big_lwe_size);

--- a/backends/tfhe-cuda-backend/cuda/src/integer/shift_and_rotate.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/shift_and_rotate.cuh
@@ -90,6 +90,7 @@ __host__ void host_integer_radix_shift_and_rotate_kb_inplace(
     auto rotations = 1 << d;
     switch (mem->shift_type) {
     case LEFT_SHIFT:
+      // rotate right as the blocks are from LSB to MSB
       host_radix_blocks_rotate_right(streams, gpu_indexes, gpu_count,
                                      rotated_input, input_bits_b, rotations,
                                      total_nb_bits, big_lwe_size);
@@ -104,6 +105,7 @@ __host__ void host_integer_radix_shift_and_rotate_kb_inplace(
                           streams[0], gpu_indexes[0]);
       break;
     case RIGHT_SHIFT:
+      // rotate left as the blocks are from LSB to MSB
       host_radix_blocks_rotate_left(streams, gpu_indexes, gpu_count,
                                     rotated_input, input_bits_b, rotations,
                                     total_nb_bits, big_lwe_size);
@@ -119,11 +121,13 @@ __host__ void host_integer_radix_shift_and_rotate_kb_inplace(
             rotations * big_lwe_size_bytes, streams[0], gpu_indexes[0]);
       break;
     case LEFT_ROTATE:
+      // rotate right as the blocks are from LSB to MSB
       host_radix_blocks_rotate_right(streams, gpu_indexes, gpu_count,
                                      rotated_input, input_bits_b, rotations,
                                      total_nb_bits, big_lwe_size);
       break;
     case RIGHT_ROTATE:
+      // rotate left as the blocks are from LSB to MSB
       host_radix_blocks_rotate_left(streams, gpu_indexes, gpu_count,
                                     rotated_input, input_bits_b, rotations,
                                     total_nb_bits, big_lwe_size);


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description

This PR fixes naming in gpu rotations and increases the number of threads in some kernels (to use the maximum possible number of threads always).

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
