### PR TITLE
test(tfhe): add tests for types backward compatibility

### DIFF
--- a/.github/workflows/aws_tfhe_fast_tests.yml
+++ b/.github/workflows/aws_tfhe_fast_tests.yml
@@ -55,6 +55,10 @@ jobs:
         with:
           toolchain: stable
 
+      - name: Install git-lfs
+        run: |
+          sudo apt update && sudo apt -y install git-lfs
+
       - name: Run concrete-csprng tests
         run: |
           make test_concrete_csprng
@@ -106,6 +110,17 @@ jobs:
       - name: Run safe deserialization tests
         run: |
           make test_safe_deserialization
+
+      - name: Clone test data
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+        with:
+          repository: zama-ai/tfhe-backward-compat-data
+          path: tfhe/tfhe-backward-compat-data
+          lfs: 'true'
+
+      - name: Run backward compatibility tests
+        run: |
+          make test_backward_compatibility_ci
 
       - name: Slack Notification
         if: ${{ always() }}

--- a/.github/workflows/aws_tfhe_wasm_tests.yml
+++ b/.github/workflows/aws_tfhe_wasm_tests.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Run parallel wasm tests
         run: |
-          make ci_test_web_js_api_parallel
+          make test_web_js_api_parallel_ci
 
       - name: Slack Notification
         if: ${{ always() }}

--- a/.github/workflows/wasm_client_benchmark.yml
+++ b/.github/workflows/wasm_client_benchmark.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Run benchmarks
         run: |
           make install_node
-          make ci_bench_web_js_api_parallel
+          make bench_web_js_api_parallel_ci
 
       - name: Parse results
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dieharder_run.log
 
 # Cuda local build
 backends/tfhe-cuda-backend/cuda/cmake-build-debug/
+
+# Dir used for backward compatibility test data
+tfhe/tfhe-backward-compat-data/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ members = [
     "utils/tfhe-versionable",
     "utils/tfhe-versionable-derive"
 ]
+exclude = [
+    "tfhe/backward_compatibility_tests"
+]
 
 [profile.bench]
 lto = "fat"

--- a/Makefile
+++ b/Makefile
@@ -756,8 +756,8 @@ test_nodejs_wasm_api: build_node_js_api
 test_web_js_api_parallel: build_web_js_api_parallel
 	$(MAKE) -C tfhe/web_wasm_parallel_tests test
 
-.PHONY: ci_test_web_js_api_parallel # Run tests for the web wasm api
-ci_test_web_js_api_parallel: build_web_js_api_parallel
+.PHONY: test_web_js_api_parallel_ci # Run tests for the web wasm api
+test_web_js_api_parallel_ci: build_web_js_api_parallel
 	source ~/.nvm/nvm.sh && \
 	nvm install $(NODE_VERSION) && \
 	nvm use $(NODE_VERSION) && \
@@ -884,8 +884,8 @@ bench_ks_gpu: install_rs_check_toolchain
 bench_web_js_api_parallel: build_web_js_api_parallel
 	$(MAKE) -C tfhe/web_wasm_parallel_tests bench
 
-.PHONY: ci_bench_web_js_api_parallel # Run benchmarks for the web wasm api
-ci_bench_web_js_api_parallel: build_web_js_api_parallel
+.PHONY: bench_web_js_api_parallel_ci # Run benchmarks for the web wasm api
+bench_web_js_api_parallel_ci: build_web_js_api_parallel
 	source ~/.nvm/nvm.sh && \
 	nvm use node && \
 	$(MAKE) -C tfhe/web_wasm_parallel_tests bench-ci

--- a/scripts/clone_backward_compat_data.sh
+++ b/scripts/clone_backward_compat_data.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [ $# -lt 2 ]; then
+		echo "$0 git_url dest_path"
+		exit 1
+fi
+
+if ! git lfs env 2>/dev/null >/dev/null; then
+		echo "git lfs is not installed, please install it and try again"
+		exit 1
+fi
+
+if [ -d $2 ]; then
+		cd $2 && git pull
+else
+		git clone $1 $2
+fi

--- a/tfhe/Cargo.toml
+++ b/tfhe/Cargo.toml
@@ -44,6 +44,9 @@ env_logger = "0.10.0"
 log = "0.4.19"
 hex = "0.4.3"
 # End regex-engine deps
+# Used for backward compatibility test metadata
+ron = "0.8"
+tfhe-backward-compat-data = { git = "https://github.com/zama-ai/tfhe-backward-compat-data.git", default-features = false, features = ["load"] }
 
 [build-dependencies]
 cbindgen = { version = "0.26.0", optional = true }

--- a/tfhe/src/lib.rs
+++ b/tfhe/src/lib.rs
@@ -138,3 +138,5 @@ pub mod zk;
 
 pub use error::{Error, ErrorKind};
 pub type Result<T> = std::result::Result<T, Error>;
+
+pub use tfhe_versionable::{Unversionize, Versionize};

--- a/tfhe/tests/backward_compatibility/mod.rs
+++ b/tfhe/tests/backward_compatibility/mod.rs
@@ -1,0 +1,2 @@
+#[cfg(feature = "shortint")]
+pub mod shortint;

--- a/tfhe/tests/backward_compatibility/shortint.rs
+++ b/tfhe/tests/backward_compatibility/shortint.rs
@@ -1,0 +1,119 @@
+use std::path::Path;
+
+use tfhe::shortint::parameters::{
+    DecompositionBaseLog, DecompositionLevelCount, DynamicDistribution, GlweDimension,
+    LweDimension, PolynomialSize, StandardDev,
+};
+use tfhe_backward_compat_data::load::{load_tests_metadata, load_versioned_auxiliary, DataFormat};
+use tfhe_backward_compat_data::{
+    ShortintCiphertextTest, ShortintClientKeyTest, TestFailure, TestParameterSet, TestSuccess,
+    TestType,
+};
+
+use tfhe::shortint::{
+    CarryModulus, Ciphertext, CiphertextModulus, ClassicPBSParameters, ClientKey,
+    EncryptionKeyChoice, MaxNoiseLevel, MessageModulus, PBSParameters, ShortintParameterSet,
+};
+use tfhe_versionable::Unversionize;
+
+use crate::run_test;
+
+/// Converts test parameters metadata that are independant of any tfhe-rs version and use only
+/// built-in types into parameters suitable for the currently tested version.
+fn load_params(test_params: &TestParameterSet) -> ShortintParameterSet {
+    ShortintParameterSet::new_pbs_param_set(PBSParameters::PBS(ClassicPBSParameters {
+        lwe_dimension: LweDimension(test_params.lwe_dimension),
+        glwe_dimension: GlweDimension(test_params.glwe_dimension),
+        polynomial_size: PolynomialSize(test_params.polynomial_size),
+        lwe_noise_distribution: DynamicDistribution::new_gaussian_from_std_dev(StandardDev(
+            test_params.lwe_noise_gaussian_stddev,
+        )),
+        glwe_noise_distribution: DynamicDistribution::new_gaussian_from_std_dev(StandardDev(
+            test_params.glwe_noise_gaussian_stddev,
+        )),
+        pbs_base_log: DecompositionBaseLog(test_params.pbs_base_log),
+        pbs_level: DecompositionLevelCount(test_params.pbs_level),
+        ks_base_log: DecompositionBaseLog(test_params.ks_base_log),
+        ks_level: DecompositionLevelCount(test_params.ks_level),
+        message_modulus: MessageModulus(test_params.message_modulus),
+        carry_modulus: CarryModulus(test_params.carry_modulus),
+        max_noise_level: MaxNoiseLevel::new(test_params.max_noise_level),
+        log2_p_fail: test_params.log2_p_fail,
+        ciphertext_modulus: CiphertextModulus::try_new(test_params.ciphertext_modulus).unwrap(),
+        encryption_key_choice: {
+            match &*test_params.encryption_key_choice {
+                "big" => EncryptionKeyChoice::Big,
+                "small" => EncryptionKeyChoice::Small,
+                _ => panic!("Invalid encryption key choice"),
+            }
+        },
+    }))
+}
+
+pub fn test_shortint_ciphertext(
+    test: &ShortintCiphertextTest,
+    format: DataFormat,
+    dir: &Path,
+) -> Result<TestSuccess, TestFailure> {
+    let key_file = dir.join(&*test.key_filename);
+    let key =
+        ClientKey::unversionize(load_versioned_auxiliary(key_file).map_err(|e| test.failure(e))?)
+            .map_err(|e| test.failure(e))?;
+
+    let ct = Ciphertext::unversionize(
+        format
+            .load_versioned_test(dir, &test.test_filename)
+            .map_err(|e| test.failure(e))?,
+    )
+    .map_err(|e| test.failure(e))?;
+
+    let clear = key.decrypt(&ct);
+    if clear != test.clear_value {
+        Err(test.failure(format!(
+            "Invalid {} decrypted cleartext:\n Expected :\n{:?}\nGot:\n{:?}",
+            format, clear, test.clear_value
+        )))
+    } else {
+        Ok(test.success())
+    }
+}
+
+pub fn test_shortint_clientkey(
+    test: &ShortintClientKeyTest,
+    format: DataFormat,
+    dir: &Path,
+) -> Result<TestSuccess, TestFailure> {
+    let test_params = load_params(&test.parameters);
+
+    let versioned_key = format
+        .load_versioned_test(dir, &test.test_filename)
+        .map_err(|e| test.failure(e))?;
+
+    let key = ClientKey::unversionize(versioned_key).map_err(|e| test.failure(e))?;
+
+    if test_params != key.parameters {
+        Err(test.failure(format!(
+            "Invalid {} parameters:\n Expected :\n{:?}\nGot:\n{:?}",
+            format, test_params, key.parameters
+        )))
+    } else {
+        Ok(test.success())
+    }
+}
+
+pub fn test_shortint<P: AsRef<Path>>(base_dir: P) -> Vec<Result<TestSuccess, TestFailure>> {
+    let meta = load_tests_metadata(base_dir.as_ref().join("shortint.ron")).unwrap();
+
+    let mut results = Vec::new();
+
+    for testcase in meta {
+        if testcase.is_valid_for_version(env!("CARGO_PKG_VERSION")) {
+            let test_result = run_test(&base_dir, &testcase, DataFormat::Cbor);
+            results.push(test_result);
+            let test_result = run_test(&base_dir, &testcase, DataFormat::Bincode);
+            results.push(test_result)
+        }
+    }
+
+    results
+}

--- a/tfhe/tests/backward_compatibility_tests.rs
+++ b/tfhe/tests/backward_compatibility_tests.rs
@@ -1,0 +1,81 @@
+//! Tests breaking change in serialized data by trying to load historical data stored in https://github.com/zama-ai/tfhe-backward-compat-data.
+//! For each tfhe-rs module, there is a folder with some serialized messages and a [ron](https://github.com/ron-rs/ron)
+//! file. The ron file stores some metadata that are parsed in this test. These metadata tell us
+//! what to test for each message.
+
+mod backward_compatibility;
+
+use std::env;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+
+#[cfg(feature = "shortint")]
+use backward_compatibility::shortint::{test_shortint_ciphertext, test_shortint_clientkey};
+use tfhe_backward_compat_data::load::DataFormat;
+use tfhe_backward_compat_data::{
+    data_dir, dir_for_version, TestFailure, TestMetadata, TestSuccess, Testcase,
+};
+
+#[cfg(feature = "shortint")]
+use backward_compatibility::shortint;
+
+fn test_data_dir() -> PathBuf {
+    // Try to load the test data from the user provided environment variable or default to a
+    // hardcoded path
+    let root_dir = if let Ok(dir_str) = env::var("TFHE_BACKWARD_COMPAT_DATA_DIR") {
+        PathBuf::from_str(&dir_str).unwrap()
+    } else {
+        PathBuf::from_str(env!("CARGO_MANIFEST_DIR"))
+            .unwrap()
+            .join("tfhe-backward-compat-data")
+    };
+
+    if !root_dir.exists() {
+        panic!("Missing backward compatibility test data. Clone them using `make clone_backward_compat_data`")
+    }
+
+    data_dir(root_dir)
+}
+
+/// Run a specific testcase. The testcase should be valid for the current version.
+fn run_test<P: AsRef<Path>>(
+    base_dir: P,
+    testcase: &Testcase,
+    format: DataFormat,
+) -> Result<TestSuccess, TestFailure> {
+    let version = &testcase.tfhe_version_min;
+    let module = &testcase.tfhe_module;
+
+    let mut test_dir = dir_for_version(base_dir, version);
+    test_dir.push(module);
+
+    #[allow(unreachable_patterns)]
+    let test_result = match &testcase.metadata {
+        #[cfg(feature = "shortint")]
+        TestMetadata::ShortintCiphertext(test) => test_shortint_ciphertext(test, format, &test_dir),
+        #[cfg(feature = "shortint")]
+        TestMetadata::ShortintClientKey(test) => test_shortint_clientkey(test, format, &test_dir),
+        _ => {
+            panic!("missing feature, could not run test")
+        }
+    };
+
+    match &test_result {
+        Ok(r) => println!("{}", r),
+        Err(r) => println!("{}", r),
+    }
+
+    test_result
+}
+
+#[test]
+#[cfg(feature = "shortint")]
+fn test_backward_compatibility_shortint() {
+    let base_dir = test_data_dir();
+
+    let results = shortint::test_shortint(base_dir);
+
+    if results.iter().any(|r| r.is_err()) {
+        panic!("Backward compatibility test failed")
+    }
+}


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description
Add tests for types backward compatibility:
- the repo https://github.com/zama-ai/tfhe-backward-compat-data holds data for historical tfhe-rs versions with associated metadata (eg: for a ciphertext, the metadata is the value of the cleartext)
- for the current version, the test tries to load/deserialize/unversionize the historical data and check their validity using the provided metadata

### Check-list:

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [x] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
