### PR TITLE
refactor(tfhe): create associated CompactPrivateKey and prepare casting

### DIFF
--- a/tfhe/c_api_tests/test_high_level_compact_list.c
+++ b/tfhe/c_api_tests/test_high_level_compact_list.c
@@ -125,5 +125,6 @@ int main(void) {
   fhe_uint2_destroy(d);
   client_key_destroy(client_key);
   compact_public_key_destroy(public_key);
+  compact_ciphertext_list_destroy(compact_list);
   return EXIT_SUCCESS;
 }

--- a/tfhe/c_api_tests/test_high_level_custom_integers.c
+++ b/tfhe/c_api_tests/test_high_level_custom_integers.c
@@ -82,6 +82,7 @@ int uint256_compact_public_key(const ClientKey *client_key,
                                const CompressedCompactPublicKey *compressed_public_key) {
   int ok;
   CompactPublicKey *public_key = NULL;
+  CompactCiphertextList *compact_list = NULL;
   FheUint256 *lhs = NULL;
   FheUint256 *rhs = NULL;
   FheUint256 *result = NULL;
@@ -93,10 +94,31 @@ int uint256_compact_public_key(const ClientKey *client_key,
   assert(ok == 0);
 
   {
-    ok = fhe_uint256_try_encrypt_with_compact_public_key_u256(clears[0], public_key, &lhs);
+    CompactCiphertextListBuilder *builder = NULL;
+    CompactCiphertextListExpander *expander = NULL;
+    ok = compact_ciphertext_list_builder_new(public_key, &builder);
     assert(ok == 0);
 
-    ok = fhe_uint256_try_encrypt_with_compact_public_key_u256(clears[1], public_key, &rhs);
+    ok = compact_ciphertext_list_builder_push_u256(builder, clears[0]);
+    assert(ok == 0);
+
+    ok = compact_ciphertext_list_builder_push_u256(builder, clears[1]);
+    assert(ok == 0);
+
+    ok = compact_ciphertext_list_builder_build(builder, &compact_list);
+    assert(ok == 0);
+
+    ok = compact_ciphertext_list_expand(compact_list, &expander);
+    assert(ok == 0);
+
+    size_t len = 0;
+    ok = compact_ciphertext_list_expander_len(expander, &len);
+    assert(ok == 0 && len == 2);
+
+    ok = compact_ciphertext_list_expander_get_fhe_uint256(expander, 0, &lhs);
+    assert(ok == 0);
+
+    ok = compact_ciphertext_list_expander_get_fhe_uint256(expander, 1, &rhs);
     assert(ok == 0);
 
     ok = fhe_uint256_sub(lhs, rhs, &result);
@@ -110,12 +132,15 @@ int uint256_compact_public_key(const ClientKey *client_key,
     assert(result_clear.w2 == 4);
     assert(result_clear.w3 == 4);
 
+    compact_ciphertext_list_expander_destroy(expander);
+    compact_ciphertext_list_builder_destroy(builder);
     fhe_uint256_destroy(lhs);
     fhe_uint256_destroy(rhs);
     fhe_uint256_destroy(result);
   }
 
   compact_public_key_destroy(public_key);
+  compact_ciphertext_list_destroy(compact_list);
   return ok;
 }
 
@@ -123,6 +148,7 @@ int int32_compact_public_key(const ClientKey *client_key,
                              const CompressedCompactPublicKey *compressed_public_key) {
   int ok;
   CompactPublicKey *public_key = NULL;
+  CompactCiphertextList *compact_list = NULL;
   FheInt32 *lhs = NULL;
   FheInt32 *rhs = NULL;
   FheInt32 *result = NULL;
@@ -134,10 +160,31 @@ int int32_compact_public_key(const ClientKey *client_key,
   assert(ok == 0);
 
   {
-    ok = fhe_int32_try_encrypt_with_compact_public_key_i32(clears[0], public_key, &lhs);
+    CompactCiphertextListBuilder *builder = NULL;
+    CompactCiphertextListExpander *expander = NULL;
+    ok = compact_ciphertext_list_builder_new(public_key, &builder);
     assert(ok == 0);
 
-    ok = fhe_int32_try_encrypt_with_compact_public_key_i32(clears[1], public_key, &rhs);
+    ok = compact_ciphertext_list_builder_push_i32(builder, clears[0]);
+    assert(ok == 0);
+
+    ok = compact_ciphertext_list_builder_push_i32(builder, clears[1]);
+    assert(ok == 0);
+
+    ok = compact_ciphertext_list_builder_build(builder, &compact_list);
+    assert(ok == 0);
+
+    ok = compact_ciphertext_list_expand(compact_list, &expander);
+    assert(ok == 0);
+
+    size_t len = 0;
+    ok = compact_ciphertext_list_expander_len(expander, &len);
+    assert(ok == 0 && len == 2);
+
+    ok = compact_ciphertext_list_expander_get_fhe_int32(expander, 0, &lhs);
+    assert(ok == 0);
+
+    ok = compact_ciphertext_list_expander_get_fhe_int32(expander, 1, &rhs);
     assert(ok == 0);
 
     ok = fhe_int32_add(lhs, rhs, &result);
@@ -148,12 +195,15 @@ int int32_compact_public_key(const ClientKey *client_key,
 
     assert(result_clear == clears[0] + clears[1]);
 
+    compact_ciphertext_list_expander_destroy(expander);
+    compact_ciphertext_list_builder_destroy(builder);
     fhe_int32_destroy(lhs);
     fhe_int32_destroy(rhs);
     fhe_int32_destroy(result);
   }
 
   compact_public_key_destroy(public_key);
+  compact_ciphertext_list_destroy(compact_list);
   return ok;
 }
 

--- a/tfhe/docs/fundamentals/compress.md
+++ b/tfhe/docs/fundamentals/compress.md
@@ -120,7 +120,10 @@ This example shows how to use compressed compact public keys:
 
 ```rust
 use tfhe::prelude::*;
-use tfhe::{generate_keys, set_server_key, CompressedCompactPublicKey, ConfigBuilder, FheUint8};
+use tfhe::{
+    generate_keys, set_server_key, CompactCiphertextList, CompressedCompactPublicKey,
+    ConfigBuilder, FheUint8,
+};
 
 fn main() {
     let config = ConfigBuilder::default()
@@ -145,7 +148,12 @@ fn main() {
         bincode::serialize(&public_key).unwrap().len()
     );
 
-    let a = FheUint8::try_encrypt(255u8, &public_key).unwrap();
+    let compact_list = CompactCiphertextList::builder(&public_key)
+        .push(255u8)
+        .build();
+    let expanded = compact_list.expand().unwrap();
+    let a: FheUint8 = expanded.get(0).unwrap().unwrap();
+
     let clear: u8 = a.decrypt(&client_key);
     assert_eq!(clear, 255u8);
 }

--- a/tfhe/docs/guides/public_key.md
+++ b/tfhe/docs/guides/public_key.md
@@ -33,11 +33,14 @@ fn main() {
 
 This example shows how to use compact public keys. The main difference is in the `ConfigBuilder` where the parameter set has been changed.
 
-For more information on using compact public keys to encrypt data and generate a zero-knowledge proof of correct encryption at the same time, see[ the guide on ZK proofs](zk-pok.md).
+For more information on using compact public keys to encrypt data and generate a zero-knowledge proof of correct encryption at the same time, see [the guide on ZK proofs](zk-pok.md).
 
 ```rust
 use tfhe::prelude::*;
-use tfhe::{ConfigBuilder, generate_keys, set_server_key, FheUint8, CompactPublicKey};
+use tfhe::{
+    generate_keys, set_server_key, CompactCiphertextList, CompactPublicKey, ConfigBuilder, FheUint8,
+};
+
 
 fn main() {
      let config = ConfigBuilder::default()
@@ -49,8 +52,12 @@ fn main() {
     let (client_key, _) = generate_keys(config);
 
     let public_key = CompactPublicKey::new(&client_key);
+    let compact_list = CompactCiphertextList::builder(&public_key)
+        .push(255u8)
+        .build();
+    let expanded = compact_list.expand().unwrap();
+    let a: FheUint8 = expanded.get(0).unwrap().unwrap();
 
-    let a = FheUint8::try_encrypt(255u8, &public_key).unwrap();
     let clear: u8 = a.decrypt(&client_key);
     assert_eq!(clear, 255u8);
 }

--- a/tfhe/js_on_wasm_tests/test-hlapi-signed.js
+++ b/tfhe/js_on_wasm_tests/test-hlapi-signed.js
@@ -361,7 +361,12 @@ function hlapi_compact_public_key_encrypt_decrypt_int32_single(config) {
     let clientKey = TfheClientKey.generate(config);
     let publicKey = TfheCompactPublicKey.new(clientKey);
 
-    let encrypted = FheInt32.encrypt_with_compact_public_key(I32_MIN, publicKey);
+    let builder = CompactCiphertextList.builder(publicKey);
+    builder.push_i32(I32_MIN);
+    let list = builder.build();
+    let expander = list.expand();
+    let encrypted = expander.get_int32(0);
+
     let decrypted = encrypted.decrypt(clientKey);
     assert.deepStrictEqual(decrypted, I32_MIN);
 

--- a/tfhe/src/c_api/high_level_api/booleans.rs
+++ b/tfhe/src/c_api/high_level_api/booleans.rs
@@ -39,7 +39,6 @@ impl_try_decrypt_trivial_on_type!(FheBool, bool);
 impl_try_encrypt_trivial_on_type!(FheBool{crate::high_level_api::FheBool}, bool);
 impl_try_encrypt_with_client_key_on_type!(FheBool{crate::high_level_api::FheBool}, bool);
 impl_try_encrypt_with_public_key_on_type!(FheBool{crate::high_level_api::FheBool}, bool);
-impl_try_encrypt_with_compact_public_key_on_type!(FheBool{crate::high_level_api::FheBool}, bool);
 
 pub struct CompressedFheBool(crate::high_level_api::CompressedFheBool);
 

--- a/tfhe/src/c_api/high_level_api/integers.rs
+++ b/tfhe/src/c_api/high_level_api/integers.rs
@@ -293,8 +293,6 @@ macro_rules! create_integer_wrapper_type {
 
         impl_try_encrypt_with_public_key_on_type!($name{crate::high_level_api::$name}, $clear_scalar_type);
 
-        impl_try_encrypt_with_compact_public_key_on_type!($name{crate::high_level_api::$name}, $clear_scalar_type);
-
         impl_decrypt_on_type!($name, $clear_scalar_type);
 
         impl_try_decrypt_trivial_on_type!($name, $clear_scalar_type);

--- a/tfhe/src/c_api/high_level_api/utils.rs
+++ b/tfhe/src/c_api/high_level_api/utils.rs
@@ -113,31 +113,6 @@ macro_rules! impl_try_encrypt_with_public_key_on_type {
 
 pub(crate) use impl_try_encrypt_with_public_key_on_type;
 
-macro_rules! impl_try_encrypt_with_compact_public_key_on_type {
-    ($wrapper_type:ty{$wrapped_type:ty}, $input_type:ty) => {
-        ::paste::paste! {
-            #[no_mangle]
-            pub unsafe extern "C" fn  [<$wrapper_type:snake _try_encrypt_with_compact_public_key_ $input_type:snake>](
-                value: $input_type,
-                public_key: *const $crate::c_api::high_level_api::keys::CompactPublicKey,
-                result: *mut *mut $wrapper_type,
-            ) -> ::std::os::raw::c_int {
-                $crate::c_api::utils::catch_panic(|| {
-                    let value = <$input_type as $crate::c_api::high_level_api::utils::CApiIntegerType>::to_rust(value);
-
-                    let public_key = $crate::c_api::utils::get_ref_checked(public_key).unwrap();
-
-                    let inner = <$wrapped_type>::try_encrypt(value, &public_key.0).unwrap();
-
-                    *result = Box::into_raw(Box::new($wrapper_type(inner)));
-                })
-            }
-        }
-    };
-}
-
-pub(crate) use impl_try_encrypt_with_compact_public_key_on_type;
-
 macro_rules! impl_try_encrypt_trivial_on_type {
     ($wrapper_type:ty{$wrapped_type:ty}, $input_type:ty) => {
         ::paste::paste! {

--- a/tfhe/src/high_level_api/booleans/encrypt.rs
+++ b/tfhe/src/high_level_api/booleans/encrypt.rs
@@ -8,10 +8,8 @@ use crate::high_level_api::keys::InternalServerKey;
 use crate::integer::gpu::ciphertext::boolean_value::CudaBooleanBlock;
 #[cfg(feature = "gpu")]
 use crate::integer::gpu::ciphertext::{CudaIntegerRadixCiphertext, CudaUnsignedRadixCiphertext};
-use crate::integer::BooleanBlock;
 use crate::prelude::{FheDecrypt, FheTrivialEncrypt, FheTryEncrypt, FheTryTrivialEncrypt};
-use crate::shortint::ciphertext::Degree;
-use crate::{ClientKey, CompactPublicKey, CompressedPublicKey, PublicKey};
+use crate::{ClientKey, CompressedPublicKey, PublicKey};
 
 impl FheTryEncrypt<bool, ClientKey> for FheBool {
     type Error = crate::Error;
@@ -21,18 +19,6 @@ impl FheTryEncrypt<bool, ClientKey> for FheBool {
         let mut ciphertext = Self::new(integer_client_key.encrypt_bool(value));
         ciphertext.ciphertext.move_to_device_of_server_key_if_set();
         Ok(ciphertext)
-    }
-}
-
-impl FheTryEncrypt<bool, CompactPublicKey> for FheBool {
-    type Error = crate::Error;
-
-    fn try_encrypt(value: bool, key: &CompactPublicKey) -> Result<Self, Self::Error> {
-        let mut ciphertext = key.key.key.encrypt_radix(value as u8, 1);
-        ciphertext.blocks[0].degree = Degree::new(1);
-        Ok(Self::new(BooleanBlock::new_unchecked(
-            ciphertext.blocks.into_iter().next().unwrap(),
-        )))
     }
 }
 

--- a/tfhe/src/high_level_api/integers/signed/encrypt.rs
+++ b/tfhe/src/high_level_api/integers/signed/encrypt.rs
@@ -4,7 +4,7 @@ use crate::high_level_api::integers::FheIntId;
 use crate::integer::block_decomposition::DecomposableInto;
 use crate::integer::client_key::RecomposableSignedInteger;
 use crate::prelude::{FheDecrypt, FheTrivialEncrypt, FheTryEncrypt, FheTryTrivialEncrypt};
-use crate::{ClientKey, CompactPublicKey, CompressedPublicKey, FheInt, PublicKey};
+use crate::{ClientKey, CompressedPublicKey, FheInt, PublicKey};
 
 impl<Id, ClearType> FheDecrypt<ClearType> for FheInt<Id>
 where
@@ -78,22 +78,6 @@ where
 
     fn try_encrypt(value: T, key: &CompressedPublicKey) -> Result<Self, Self::Error> {
         let ciphertext = key
-            .key
-            .encrypt_signed_radix(value, Id::num_blocks(key.message_modulus()));
-        Ok(Self::new(ciphertext))
-    }
-}
-
-impl<Id, T> FheTryEncrypt<T, CompactPublicKey> for FheInt<Id>
-where
-    Id: FheIntId,
-    T: DecomposableInto<u64> + SignedNumeric,
-{
-    type Error = crate::Error;
-
-    fn try_encrypt(value: T, key: &CompactPublicKey) -> Result<Self, Self::Error> {
-        let ciphertext = key
-            .key
             .key
             .encrypt_signed_radix(value, Id::num_blocks(key.message_modulus()));
         Ok(Self::new(ciphertext))

--- a/tfhe/src/high_level_api/integers/signed/tests.rs
+++ b/tfhe/src/high_level_api/integers/signed/tests.rs
@@ -3,8 +3,8 @@ use crate::prelude::*;
 use crate::safe_deserialization::safe_deserialize_conformant;
 use crate::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
 use crate::{
-    generate_keys, set_server_key, ClientKey, CompactPublicKey, CompressedFheInt16,
-    CompressedFheInt32, Config, ConfigBuilder, FheInt16, FheInt256, FheInt32,
+    generate_keys, set_server_key, ClientKey, CompactCiphertextList, CompactPublicKey,
+    CompressedFheInt16, CompressedFheInt32, Config, ConfigBuilder, FheInt16, FheInt256, FheInt32,
     FheInt32ConformanceParams, FheInt64, FheInt8, FheUint64, FheUint8,
 };
 use rand::prelude::*;
@@ -552,8 +552,12 @@ fn test_compact_public_key_big() {
     let (client_key, _) = generate_keys(config);
 
     let public_key = CompactPublicKey::new(&client_key);
+    let compact_list = CompactCiphertextList::builder(&public_key)
+        .push(-1i8)
+        .build();
+    let expanded = compact_list.expand().unwrap();
+    let a: FheInt8 = expanded.get(0).unwrap().unwrap();
 
-    let a = FheInt8::try_encrypt(-1i8, &public_key).unwrap();
     let clear: i8 = a.decrypt(&client_key);
     assert_eq!(clear, -1i8);
 }
@@ -570,8 +574,12 @@ fn test_compact_public_key_small() {
     let (client_key, _) = generate_keys(config);
 
     let public_key = CompactPublicKey::new(&client_key);
+    let compact_list = CompactCiphertextList::builder(&public_key)
+        .push(-123i8)
+        .build();
+    let expanded = compact_list.expand().unwrap();
+    let a: FheInt8 = expanded.get(0).unwrap().unwrap();
 
-    let a = FheInt8::try_encrypt(-123i8, &public_key).unwrap();
     let clear: i8 = a.decrypt(&client_key);
     assert_eq!(clear, -123i8);
 }

--- a/tfhe/src/high_level_api/integers/unsigned/encrypt.rs
+++ b/tfhe/src/high_level_api/integers/unsigned/encrypt.rs
@@ -8,7 +8,7 @@ use crate::integer::block_decomposition::{DecomposableInto, RecomposableFrom};
 #[cfg(feature = "gpu")]
 use crate::integer::gpu::ciphertext::CudaUnsignedRadixCiphertext;
 use crate::prelude::{FheDecrypt, FheTrivialEncrypt, FheTryEncrypt, FheTryTrivialEncrypt};
-use crate::{ClientKey, CompactPublicKey, CompressedPublicKey, FheUint, PublicKey};
+use crate::{ClientKey, CompressedPublicKey, FheUint, PublicKey};
 
 impl<Id, ClearType> FheDecrypt<ClearType> for FheUint<Id>
 where
@@ -90,25 +90,6 @@ where
 
     fn try_encrypt(value: T, key: &CompressedPublicKey) -> Result<Self, Self::Error> {
         let cpu_ciphertext = key
-            .key
-            .encrypt_radix(value, Id::num_blocks(key.message_modulus()));
-        let mut ciphertext = Self::new(cpu_ciphertext);
-
-        ciphertext.move_to_device_of_server_key_if_set();
-        Ok(ciphertext)
-    }
-}
-
-impl<Id, T> FheTryEncrypt<T, CompactPublicKey> for FheUint<Id>
-where
-    Id: FheUintId,
-    T: DecomposableInto<u64> + UnsignedNumeric,
-{
-    type Error = crate::Error;
-
-    fn try_encrypt(value: T, key: &CompactPublicKey) -> Result<Self, Self::Error> {
-        let cpu_ciphertext = key
-            .key
             .key
             .encrypt_radix(value, Id::num_blocks(key.message_modulus()));
         let mut ciphertext = Self::new(cpu_ciphertext);

--- a/tfhe/src/high_level_api/integers/unsigned/tests/cpu.rs
+++ b/tfhe/src/high_level_api/integers/unsigned/tests/cpu.rs
@@ -198,8 +198,12 @@ fn test_compact_public_key_big() {
     let (client_key, _) = generate_keys(config);
 
     let public_key = CompactPublicKey::new(&client_key);
+    let compact_list = CompactCiphertextList::builder(&public_key)
+        .push(255u8)
+        .build();
+    let expanded = compact_list.expand().unwrap();
+    let a: FheUint8 = expanded.get(0).unwrap().unwrap();
 
-    let a = FheUint8::try_encrypt(255u8, &public_key).unwrap();
     let clear: u8 = a.decrypt(&client_key);
     assert_eq!(clear, 255u8);
 }
@@ -212,8 +216,12 @@ fn test_compact_public_key_small() {
     let (client_key, _) = generate_keys(config);
 
     let public_key = CompactPublicKey::new(&client_key);
+    let compact_list = CompactCiphertextList::builder(&public_key)
+        .push(255u8)
+        .build();
+    let expanded = compact_list.expand().unwrap();
+    let a: FheUint8 = expanded.get(0).unwrap().unwrap();
 
-    let a = FheUint8::try_encrypt(255u8, &public_key).unwrap();
     let clear: u8 = a.decrypt(&client_key);
     assert_eq!(clear, 255u8);
 }

--- a/tfhe/src/high_level_api/keys/inner.rs
+++ b/tfhe/src/high_level_api/keys/inner.rs
@@ -3,6 +3,7 @@ use crate::core_crypto::prelude::ActivatedRandomGenerator;
 use crate::integer::public_key::CompactPublicKey;
 use crate::integer::CompressedCompactPublicKey;
 use crate::shortint::{EncryptionKeyChoice, MessageModulus};
+use crate::Error;
 use concrete_csprng::seeders::Seed;
 use serde::{Deserialize, Serialize};
 
@@ -207,12 +208,12 @@ impl IntegerCompactPublicKey {
         Self::try_new(client_key).expect("Incompatible parameters")
     }
 
-    pub(in crate::high_level_api) fn try_new(client_key: &IntegerClientKey) -> Option<Self> {
+    pub(in crate::high_level_api) fn try_new(client_key: &IntegerClientKey) -> Result<Self, Error> {
         let cks = &client_key.key;
 
         let key = CompactPublicKey::try_new(cks)?;
 
-        Some(Self { key })
+        Ok(Self { key })
     }
 
     pub fn into_raw_parts(self) -> CompactPublicKey {

--- a/tfhe/src/high_level_api/keys/public.rs
+++ b/tfhe/src/high_level_api/keys/public.rs
@@ -15,8 +15,8 @@
 //! - [CompressedCompactPublicKey]
 use super::ClientKey;
 use crate::high_level_api::keys::{IntegerCompactPublicKey, IntegerCompressedCompactPublicKey};
-use crate::integer::encryption::KnowsMessageModulus;
 use crate::shortint::MessageModulus;
+use crate::Error;
 
 /// Classical public key.
 ///
@@ -102,7 +102,7 @@ impl CompactPublicKey {
         }
     }
 
-    pub fn try_new(client_key: &ClientKey) -> Option<Self> {
+    pub fn try_new(client_key: &ClientKey) -> Result<Self, Error> {
         IntegerCompactPublicKey::try_new(&client_key.key).map(|key| Self { key })
     }
 
@@ -114,10 +114,6 @@ impl CompactPublicKey {
         Self {
             key: IntegerCompactPublicKey::from_raw_parts(key),
         }
-    }
-
-    pub(crate) fn message_modulus(&self) -> MessageModulus {
-        self.key.key.key.message_modulus()
     }
 }
 

--- a/tfhe/src/integer/ciphertext/compact_list.rs
+++ b/tfhe/src/integer/ciphertext/compact_list.rs
@@ -179,7 +179,7 @@ impl CompactCiphertextListBuilder {
     }
 
     pub fn build_packed(&self) -> crate::Result<CompactCiphertextList> {
-        if self.pk.key.parameters.carry_modulus().0 < self.pk.key.parameters.message_modulus().0 {
+        if self.pk.key.parameters.carry_modulus.0 < self.pk.key.parameters.message_modulus.0 {
             return Err(crate::Error::new("In order to build a packed compact ciphertext list, parameters must have CarryModulus >= MessageModulus".to_string()));
         }
 
@@ -210,7 +210,7 @@ impl CompactCiphertextListBuilder {
             self.messages.as_slice(),
             public_params,
             load,
-            self.pk.key.parameters.message_modulus().0 as u64,
+            self.pk.key.parameters.message_modulus.0 as u64,
         )?;
         Ok(ProvenCompactCiphertextList {
             ct_list,
@@ -224,11 +224,15 @@ impl CompactCiphertextListBuilder {
         public_params: &CompactPkePublicParams,
         load: ZkComputeLoad,
     ) -> crate::Result<ProvenCompactCiphertextList> {
-        if self.pk.key.parameters.carry_modulus().0 < self.pk.key.parameters.message_modulus().0 {
-            return Err(crate::Error::new("In order to build a packed compact ciphertext list, parameters must have CarryModulus >= MessageModulus".to_string()));
+        if self.pk.key.parameters.carry_modulus.0 < self.pk.key.parameters.message_modulus.0 {
+            return Err(crate::Error::new(
+                "In order to build a packed ProvenCompactCiphertextList, \
+                parameters must have CarryModulus >= MessageModulus"
+                    .to_string(),
+            ));
         }
 
-        let msg_mod = self.pk.key.message_modulus().0 as u64;
+        let msg_mod = self.pk.key.parameters.message_modulus.0 as u64;
         let packed_messages = self
             .messages
             .chunks(2)

--- a/tfhe/src/integer/encryption.rs
+++ b/tfhe/src/integer/encryption.rs
@@ -25,7 +25,7 @@ impl KnowsMessageModulus for crate::shortint::CompressedPublicKey {
 
 impl KnowsMessageModulus for crate::shortint::CompactPublicKey {
     fn message_modulus(&self) -> MessageModulus {
-        self.parameters.message_modulus()
+        self.parameters.message_modulus
     }
 }
 

--- a/tfhe/src/integer/public_key/compact.rs
+++ b/tfhe/src/integer/public_key/compact.rs
@@ -1,12 +1,11 @@
-use crate::core_crypto::prelude::{SignedNumeric, UnsignedNumeric};
 use crate::integer::block_decomposition::DecomposableInto;
-use crate::integer::ciphertext::{CompactCiphertextList, RadixCiphertext};
-use crate::integer::encryption::encrypt_words_radix_impl;
-use crate::integer::{ClientKey, SignedRadixCiphertext};
+use crate::integer::ciphertext::CompactCiphertextList;
+use crate::integer::ClientKey;
 use crate::shortint::{
     CompactPublicKey as ShortintCompactPublicKey,
     CompressedCompactPublicKey as ShortintCompressedCompactPublicKey,
 };
+use crate::Error;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -20,9 +19,9 @@ impl CompactPublicKey {
         Self { key }
     }
 
-    pub fn try_new(client_key: &ClientKey) -> Option<Self> {
+    pub fn try_new(client_key: &ClientKey) -> Result<Self, Error> {
         let key = ShortintCompactPublicKey::try_new(&client_key.key)?;
-        Some(Self { key })
+        Ok(Self { key })
     }
 
     /// Deconstruct a [`CompactPublicKey`] into its constituents.
@@ -33,30 +32,6 @@ impl CompactPublicKey {
     /// Construct a [`CompactPublicKey`] from its constituents.
     pub fn from_raw_parts(key: ShortintCompactPublicKey) -> Self {
         Self { key }
-    }
-
-    pub fn encrypt_radix<T>(&self, message: T, num_blocks: usize) -> RadixCiphertext
-    where
-        T: DecomposableInto<u64> + UnsignedNumeric,
-    {
-        encrypt_words_radix_impl(
-            &self.key,
-            message,
-            num_blocks,
-            ShortintCompactPublicKey::encrypt,
-        )
-    }
-
-    pub fn encrypt_signed_radix<T>(&self, message: T, num_blocks: usize) -> SignedRadixCiphertext
-    where
-        T: DecomposableInto<u64> + SignedNumeric,
-    {
-        encrypt_words_radix_impl(
-            &self.key,
-            message,
-            num_blocks,
-            ShortintCompactPublicKey::encrypt,
-        )
     }
 
     pub fn encrypt_radix_compact<T: DecomposableInto<u64> + std::ops::Shl<usize, Output = T>>(

--- a/tfhe/src/js_on_wasm_api/js_high_level_api/integers.rs
+++ b/tfhe/src/js_on_wasm_api/js_high_level_api/integers.rs
@@ -145,20 +145,6 @@ macro_rules! create_wrapper_type_non_native_type (
             }
 
             #[wasm_bindgen]
-            pub fn encrypt_with_compact_public_key(
-                value: JsValue,
-                compact_public_key: &crate::js_on_wasm_api::js_high_level_api::keys::TfheCompactPublicKey,
-            ) -> Result<$type_name, JsError> {
-                catch_panic_result(|| {
-                    let value = <$rust_type>::try_from(value)
-                        .map_err(|_| JsError::new(&format!("Failed to convert the value to a {}", stringify!($rust_type))))?;
-                    crate::high_level_api::$type_name::try_encrypt(value, &compact_public_key.0)
-                        .map($type_name)
-                        .map_err(into_js_error)
-                })
-            }
-
-            #[wasm_bindgen]
             pub fn decrypt(
                 &self,
                 client_key: &crate::js_on_wasm_api::js_high_level_api::keys::TfheClientKey,
@@ -382,19 +368,6 @@ macro_rules! create_wrapper_type_that_has_native_type (
                         .map_err(into_js_error)
                 })
             }
-
-            #[wasm_bindgen]
-            pub fn encrypt_with_compact_public_key(
-                value: $native_type,
-                compact_public_key: &crate::js_on_wasm_api::js_high_level_api::keys::TfheCompactPublicKey,
-            ) -> Result<$type_name, JsError> {
-                catch_panic_result(|| {
-                    crate::high_level_api::$type_name::try_encrypt(value, &compact_public_key.0)
-                        .map($type_name)
-                        .map_err(into_js_error)
-                })
-            }
-
 
             #[wasm_bindgen]
             pub fn decrypt(

--- a/tfhe/src/shortint/parameters/compact_public_key_only.rs
+++ b/tfhe/src/shortint/parameters/compact_public_key_only.rs
@@ -1,0 +1,105 @@
+use super::{CiphertextModulus, PBSOrder};
+use crate::core_crypto::commons::parameters::{DynamicDistribution, LweDimension};
+use crate::shortint::parameters::{CarryModulus, MessageModulus, ShortintParameterSet};
+use crate::Error;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CompactCiphertextListExpansionKind {
+    RequiresCasting,
+    NoCasting(PBSOrder),
+}
+
+impl From<PBSOrder> for CompactCiphertextListExpansionKind {
+    fn from(value: PBSOrder) -> Self {
+        Self::NoCasting(value)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct CompactPublicKeyEncryptionParameters {
+    pub encryption_lwe_dimension: LweDimension,
+    pub encryption_noise_distribution: DynamicDistribution<u64>,
+    pub message_modulus: MessageModulus,
+    pub carry_modulus: CarryModulus,
+    pub ciphertext_modulus: CiphertextModulus,
+    pub expansion_kind: CompactCiphertextListExpansionKind,
+}
+
+impl CompactPublicKeyEncryptionParameters {
+    pub fn try_new(
+        encryption_lwe_dimension: LweDimension,
+        encryption_noise_distribution: DynamicDistribution<u64>,
+        message_modulus: MessageModulus,
+        carry_modulus: CarryModulus,
+        ciphertext_modulus: CiphertextModulus,
+        output_ciphertext_kind: CompactCiphertextListExpansionKind,
+    ) -> Result<Self, Error> {
+        let parameters = Self {
+            encryption_lwe_dimension,
+            encryption_noise_distribution,
+            message_modulus,
+            carry_modulus,
+            ciphertext_modulus,
+            expansion_kind: output_ciphertext_kind,
+        };
+
+        if !parameters.is_valid() {
+            return Err(Error::new(format!(
+                "Invalid CompactPublicKeyEncryptionParameters, \
+                encryption_lwe_dimension ({:?}) is not a power of 2, which is required.",
+                parameters.encryption_lwe_dimension
+            )));
+        }
+
+        Ok(parameters)
+    }
+
+    pub const fn is_valid(&self) -> bool {
+        self.encryption_lwe_dimension.0.is_power_of_two()
+    }
+
+    /// This should be used while defining static parameters to verify they comply with the
+    /// requirements of compact public key encryption.
+    pub const fn validate(self) -> Self {
+        if self.is_valid() {
+            return self;
+        }
+
+        panic!(
+            "Invalid CompactPublicKeyEncryptionParameters, \
+            encryption_lwe_dimension is not a power of 2, which is required.",
+        );
+    }
+}
+
+impl TryFrom<ShortintParameterSet> for CompactPublicKeyEncryptionParameters {
+    type Error = Error;
+
+    #[track_caller]
+    fn try_from(parameters: ShortintParameterSet) -> Result<Self, Self::Error> {
+        if parameters.wopbs_only() {
+            return Err(Error::new(String::from(
+                "Cannot convert Wopbs only parameters to CompactPublicKeyEncryption parameters.",
+            )));
+        }
+
+        let encryption_lwe_dimension = parameters.encryption_lwe_dimension();
+        let encryption_noise_distribution = parameters.encryption_noise_distribution();
+        let message_modulus = parameters.message_modulus();
+        let carry_modulus = parameters.carry_modulus();
+        let ciphertext_modulus = parameters.ciphertext_modulus();
+        let output_ciphertext_kind = CompactCiphertextListExpansionKind::NoCasting(
+            parameters.encryption_key_choice().into(),
+        );
+
+        Self::try_new(
+            encryption_lwe_dimension,
+            encryption_noise_distribution,
+            message_modulus,
+            carry_modulus,
+            ciphertext_modulus,
+            output_ciphertext_kind,
+        )
+    }
+}

--- a/tfhe/src/shortint/parameters/mod.rs
+++ b/tfhe/src/shortint/parameters/mod.rs
@@ -17,6 +17,7 @@ use crate::core_crypto::prelude::{
 use serde::{Deserialize, Serialize};
 
 pub mod classic;
+pub mod compact_public_key_only;
 #[cfg(tarpaulin)]
 pub mod coverage_parameters;
 pub mod key_switching;
@@ -30,6 +31,7 @@ pub use super::PBSOrder;
 pub use crate::core_crypto::commons::parameters::EncryptionKeyChoice;
 pub use crate::shortint::parameters::classic::compact_pk::*;
 use crate::shortint::parameters::classic::p_fail_2_minus_40::{ks_pbs, pbs_ks};
+pub use compact_public_key_only::CompactCiphertextListExpansionKind;
 #[cfg(tarpaulin)]
 pub use coverage_parameters::*;
 pub use key_switching::ShortintKeySwitchingParameters;
@@ -200,7 +202,7 @@ pub struct CiphertextListConformanceParams {
     pub carry_modulus: CarryModulus,
     pub degree: Degree,
     pub noise_level: NoiseLevel,
-    pub pbs_order: PBSOrder,
+    pub expansion_kind: CompactCiphertextListExpansionKind,
 }
 
 impl CiphertextConformanceParams {
@@ -217,7 +219,7 @@ impl CiphertextConformanceParams {
             message_modulus: self.message_modulus,
             carry_modulus: self.carry_modulus,
             degree: self.degree,
-            pbs_order: self.pbs_order,
+            expansion_kind: self.pbs_order.into(),
             noise_level: self.noise_level,
         }
     }

--- a/tfhe/src/shortint/server_key/tests/shortint_compact_pk.rs
+++ b/tfhe/src/shortint/server_key/tests/shortint_compact_pk.rs
@@ -109,9 +109,11 @@ fn shortint_compact_public_key_base_smart_add(params: ClassicPBSParameters) {
 
         let clear_1 = rng.gen::<u64>() % modulus;
 
-        let mut ctxt_0 = pk.encrypt(clear_0);
+        let ctxt_0 = pk.encrypt_slice(&[clear_0]);
+        let ctxt_1 = pk.encrypt_slice(&[clear_1]);
 
-        let ctxt_1 = pk.encrypt(clear_1);
+        let mut ctxt_0 = ctxt_0.expand().into_iter().next().unwrap();
+        let ctxt_1 = ctxt_1.expand().into_iter().next().unwrap();
 
         let d = cks.decrypt(&ctxt_0);
         assert_eq!(d, clear_0);


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description

- for casting from the CompacthPublicKey parameter we need to add the notion of a kind on the CompactCiphertextList, where one kind will need to be cast thanks to an auxiliary keyswitching key and the other kind can just be expanded as before
- to avoid weird situations/corner cases we remove the ability to encrypt a "normal" ciphertext from a CompactPublicKey (which consisted in expanding right after encryption)

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
