### PR TITLE
feat(all): add `safe_serialize_versioned`

### DIFF
--- a/tfhe/c_api_tests/test_high_level_integers.c
+++ b/tfhe/c_api_tests/test_high_level_integers.c
@@ -430,6 +430,67 @@ int uint8_safe_serialization(const ClientKey *client_key, const ServerKey *serve
   return ok;
 }
 
+int uint8_safe_serialization_versioned(const ClientKey *client_key, const ServerKey *server_key) {
+  int ok;
+  CompactFheUint8 *lhs = NULL;
+  CompactFheUint8 *deserialized_lhs = NULL;
+  CompactFheUint8 *result = NULL;
+  DynamicBuffer value_buffer = {.pointer = NULL, .length = 0, .destructor = NULL};
+  DynamicBuffer cks_buffer = {.pointer = NULL, .length = 0, .destructor = NULL};
+  DynamicBufferView deser_view = {.pointer = NULL, .length = 0};
+  ClientKey *deserialized_client_key = NULL;
+
+  const uint64_t max_serialization_size = UINT64_C(1) << UINT64_C(20);
+
+  uint8_t lhs_clear = 123;
+
+  ok = client_key_serialize(client_key, &cks_buffer);
+  assert(ok == 0);
+
+  deser_view.pointer = cks_buffer.pointer;
+  deser_view.length = cks_buffer.length;
+  ok = client_key_deserialize(deser_view, &deserialized_client_key);
+  assert(ok == 0);
+
+  struct CompactPublicKey *public_key;
+
+  ok = compact_public_key_new(deserialized_client_key, &public_key);
+  assert(ok == 0);
+
+  ok = compact_fhe_uint8_try_encrypt_with_compact_public_key_u8(lhs_clear, public_key, &lhs);
+  assert(ok == 0);
+
+  ok = compact_fhe_uint8_safe_serialize_versioned(lhs, &value_buffer, max_serialization_size);
+  assert(ok == 0);
+
+  deser_view.pointer = value_buffer.pointer;
+  deser_view.length = value_buffer.length;
+  ok = compact_fhe_uint8_safe_deserialize_conformant_versioned(deser_view, max_serialization_size, server_key,
+                                                     &deserialized_lhs);
+  assert(ok == 0);
+
+  FheUint8 *expanded = NULL;
+
+  ok = compact_fhe_uint8_expand(deserialized_lhs, &expanded);
+  assert(ok == 0);
+
+  uint8_t clear;
+  ok = fhe_uint8_decrypt(expanded, deserialized_client_key, &clear);
+  assert(ok == 0);
+
+  assert(clear == lhs_clear);
+
+  if (value_buffer.pointer != NULL) {
+    destroy_dynamic_buffer(&value_buffer);
+  }
+  compact_fhe_uint8_destroy(lhs);
+  compact_fhe_uint8_destroy(deserialized_lhs);
+  compact_fhe_uint8_destroy(result);
+  fhe_uint8_destroy(expanded);
+
+  return ok;
+}
+
 int uint8_serialization(const ClientKey *client_key) {
   int ok;
   FheUint8 *lhs = NULL;
@@ -626,6 +687,8 @@ int main(void) {
     ok = uint8_serialization(client_key);
     assert(ok == 0);
     ok = uint8_safe_serialization(client_key, server_key);
+    assert(ok == 0);
+		ok = uint8_safe_serialization_versioned(client_key, server_key);
     assert(ok == 0);
     ok = uint8_compressed(client_key);
     assert(ok == 0);

--- a/tfhe/src/c_api/high_level_api/booleans.rs
+++ b/tfhe/src/c_api/high_level_api/booleans.rs
@@ -9,7 +9,9 @@ impl_destroy_on_type!(FheBool);
 impl_clone_on_type!(FheBool);
 impl_serialize_deserialize_on_type!(FheBool);
 impl_safe_serialize_on_type!(FheBool);
+impl_safe_serialize_versioned_on_type!(FheBool);
 impl_safe_deserialize_conformant_integer!(FheBool, FheBoolConformanceParams);
+impl_safe_deserialize_conformant_versioned_integer!(FheBool, FheBoolConformanceParams);
 
 impl_binary_fn_on_type!(FheBool => bitand, bitor, bitxor);
 impl_binary_assign_fn_on_type!(FheBool => bitand_assign,  bitor_assign, bitxor_assign);
@@ -48,7 +50,9 @@ impl_destroy_on_type!(CompressedFheBool);
 impl_clone_on_type!(CompressedFheBool);
 impl_serialize_deserialize_on_type!(CompressedFheBool);
 impl_safe_serialize_on_type!(CompressedFheBool);
+impl_safe_serialize_versioned_on_type!(CompressedFheBool);
 impl_safe_deserialize_conformant_integer!(CompressedFheBool, FheBoolConformanceParams);
+impl_safe_deserialize_conformant_versioned_integer!(CompressedFheBool, FheBoolConformanceParams);
 impl_try_encrypt_with_client_key_on_type!(CompressedFheBool{crate::high_level_api::CompressedFheBool}, bool);
 
 #[no_mangle]
@@ -83,7 +87,9 @@ impl_destroy_on_type!(CompactFheBool);
 impl_clone_on_type!(CompactFheBool);
 impl_serialize_deserialize_on_type!(CompactFheBool);
 impl_safe_serialize_on_type!(CompactFheBool);
+impl_safe_serialize_versioned_on_type!(CompactFheBool);
 impl_safe_deserialize_conformant_integer!(CompactFheBool, FheBoolConformanceParams);
+impl_safe_deserialize_conformant_versioned_integer!(CompactFheBool, FheBoolConformanceParams);
 impl_try_encrypt_with_compact_public_key_on_type!(CompactFheBool{crate::high_level_api::CompactFheBool}, bool);
 
 #[no_mangle]
@@ -105,7 +111,9 @@ impl_destroy_on_type!(CompactFheBoolList);
 impl_clone_on_type!(CompactFheBoolList);
 impl_serialize_deserialize_on_type!(CompactFheBoolList);
 impl_safe_serialize_on_type!(CompactFheBoolList);
+impl_safe_serialize_versioned_on_type!(CompactFheBoolList);
 impl_safe_deserialize_conformant_integer_list!(CompactFheBoolList);
+impl_safe_deserialize_conformant_versioned_integer_list!(CompactFheBoolList);
 impl_try_encrypt_list_with_compact_public_key_on_type!(CompactFheBoolList{crate::high_level_api::CompactFheBoolList}, bool);
 
 #[no_mangle]

--- a/tfhe/src/c_api/high_level_api/integers.rs
+++ b/tfhe/src/c_api/high_level_api/integers.rs
@@ -307,8 +307,14 @@ macro_rules! create_integer_wrapper_type {
 
         impl_safe_serialize_on_type!($name);
 
+        impl_safe_serialize_versioned_on_type!($name);
+
         ::paste::paste! {
             impl_safe_deserialize_conformant_integer!($name, [<$name ConformanceParams>]);
+        }
+
+        ::paste::paste! {
+            impl_safe_deserialize_conformant_versioned_integer!($name, [<$name ConformanceParams>]);
         }
 
         define_all_cast_into_for_integer_type!($name);
@@ -327,8 +333,11 @@ macro_rules! create_integer_wrapper_type {
 
             impl_safe_serialize_on_type!([<Compressed $name>]);
 
+            impl_safe_serialize_versioned_on_type!([<Compressed $name>]);
+
             impl_safe_deserialize_conformant_integer!([<Compressed $name>],  [<$name ConformanceParams>]);
 
+            impl_safe_deserialize_conformant_versioned_integer!([<Compressed $name>],  [<$name ConformanceParams>]);
 
             #[no_mangle]
             pub unsafe extern "C" fn [<compressed_ $name:snake _decompress>](
@@ -372,7 +381,11 @@ macro_rules! create_integer_wrapper_type {
 
             impl_safe_serialize_on_type!([<Compact $name>]);
 
+            impl_safe_serialize_versioned_on_type!([<Compact $name>]);
+
             impl_safe_deserialize_conformant_integer!([<Compact $name>],  [<$name ConformanceParams>]);
+
+            impl_safe_deserialize_conformant_versioned_integer!([<Compact $name>],  [<$name ConformanceParams>]);
 
             #[no_mangle]
             pub unsafe extern "C" fn [<compact_ $name:snake _expand>](
@@ -401,7 +414,11 @@ macro_rules! create_integer_wrapper_type {
 
             impl_safe_serialize_on_type!([<Compact $name List>]);
 
+            impl_safe_serialize_versioned_on_type!([<Compact $name List>]);
+
             impl_safe_deserialize_conformant_integer_list!([<Compact $name List>]);
+
+            impl_safe_deserialize_conformant_versioned_integer_list!([<Compact $name List>]);
 
             #[no_mangle]
             pub unsafe extern "C" fn [<compact_ $name:snake _list_len>](

--- a/tfhe/src/c_api/high_level_api/utils.rs
+++ b/tfhe/src/c_api/high_level_api/utils.rs
@@ -337,10 +337,36 @@ macro_rules! impl_safe_serialize_on_type {
                 })
             }
         }
+    }
+}
+
+macro_rules! impl_safe_serialize_versioned_on_type {
+    ($wrapper_type:ty) => {
+        ::paste::paste! {
+            #[no_mangle]
+            pub unsafe extern "C" fn [<$wrapper_type:snake _safe_serialize_versioned>](
+                sself: *const $wrapper_type,
+                result: *mut crate::c_api::buffer::DynamicBuffer,
+                serialized_size_limit: u64,
+            ) -> ::std::os::raw::c_int {
+                crate::c_api::utils::catch_panic(|| {
+                    crate::c_api::utils::check_ptr_is_non_null_and_aligned(result).unwrap();
+
+                    let mut buffer = vec![];
+
+                    let sself = crate::c_api::utils::get_ref_checked(sself).unwrap();
+
+                    crate::high_level_api::safe_serialize_versioned(&sself.0, &mut buffer, serialized_size_limit)
+                        .unwrap();
+
+                    *result = buffer.into();
+                })
+            }
+        }
     };
 }
 
-pub(crate) use impl_safe_serialize_on_type;
+pub(crate) use {impl_safe_serialize_on_type, impl_safe_serialize_versioned_on_type};
 
 macro_rules! impl_safe_deserialize_conformant_integer {
     ($wrapper_type:ty, $conformance_param_type:ty) => {
@@ -394,7 +420,61 @@ macro_rules! impl_safe_deserialize_conformant_integer {
     };
 }
 
-pub(crate) use impl_safe_deserialize_conformant_integer;
+macro_rules! impl_safe_deserialize_conformant_versioned_integer {
+    ($wrapper_type:ty, $conformance_param_type:ty) => {
+        ::paste::paste! {
+            #[no_mangle]
+            /// Deserializes safely, and checks that the resulting ciphertext
+            /// is in compliance with the shape of ciphertext that the `server_key` expects.
+            ///
+            /// This function can only deserialize, types which have been serialized and versioned
+            /// by a `safe_serialize_versioned` function.
+            ///
+            /// - `serialized_size_limit`: size limit (in number of byte) of the serialized object
+            ///    (to avoid out of memory attacks)
+            /// - `server_key`: ServerKey used in the conformance check
+            /// - `result`: pointer where resulting deserialized object needs to be stored.
+            ///    * cannot be NULL
+            ///    * (*result) will point the deserialized object on success, else NULL
+            pub unsafe extern "C" fn [<$wrapper_type:snake _safe_deserialize_conformant_versioned>](
+                buffer_view: crate::c_api::buffer::DynamicBufferView,
+                serialized_size_limit: u64,
+                server_key: *const crate::c_api::high_level_api::keys::ServerKey,
+                result: *mut *mut $wrapper_type,
+            ) -> ::std::os::raw::c_int {
+                ::paste::paste! {
+                     crate::c_api::utils::catch_panic(|| {
+                        crate::c_api::utils::check_ptr_is_non_null_and_aligned(result).unwrap();
+
+                        let sk = crate::c_api::utils::get_ref_checked(server_key).unwrap();
+
+                        let buffer_view: &[u8] = buffer_view.as_slice();
+
+                        // First fill the result with a null ptr so that if we fail and the return code is not
+                        // checked, then any access to the result pointer will segfault (mimics malloc on failure)
+                        *result = std::ptr::null_mut();
+
+                        let params = $crate::high_level_api::$conformance_param_type::from(&sk.0);
+                        let inner = $crate::safe_deserialization::safe_deserialize_conformant_versioned(
+                                buffer_view,
+                                serialized_size_limit,
+                                &params,
+                            )
+                            .unwrap();
+
+                        let heap_allocated_object = Box::new($wrapper_type(inner));
+
+                        *result = Box::into_raw(heap_allocated_object);
+                    })
+                }
+            }
+        }
+    };
+}
+
+pub(crate) use {
+    impl_safe_deserialize_conformant_integer, impl_safe_deserialize_conformant_versioned_integer,
+};
 
 macro_rules! impl_safe_deserialize_conformant_integer_list {
     ($wrapper_type:ty) => {
@@ -453,7 +533,67 @@ macro_rules! impl_safe_deserialize_conformant_integer_list {
     };
 }
 
-pub(crate) use impl_safe_deserialize_conformant_integer_list;
+macro_rules! impl_safe_deserialize_conformant_versioned_integer_list {
+    ($wrapper_type:ty) => {
+        ::paste::paste! {
+            /// Deserializes a list safely, and checks that the resulting ciphertext
+            /// is in compliance with the shape of ciphertext that the `server_key` expects.
+            ///
+            /// This function can only deserialize, types which have been serialized and versioned
+            /// by a `safe_serialize_versioned` function.
+            ///
+            /// - `serialized_size_limit`: size limit (in number of byte) of the serialized object
+            ///    (to avoid out of memory attacks)
+            /// - `server_key`: ServerKey used in the conformance check
+            /// - `exact_len`: exact lenght/size/number of element the list must have
+            ///    (not less nor more, otherwise, it's considered an error)
+            /// - `result`: pointer where resulting deserialized object needs to be stored.
+            ///    * cannot be NULL
+            ///    * (*result) will point the deserialized object on success, else NULL
+            #[no_mangle]
+            pub unsafe extern "C" fn [<$wrapper_type:snake _safe_deserialize_conformant_versioned>](
+                buffer_view: crate::c_api::buffer::DynamicBufferView,
+                serialized_size_limit: u64,
+                server_key: *const crate::c_api::high_level_api::keys::ServerKey,
+                exact_len: usize,
+                result: *mut *mut $wrapper_type,
+            ) -> ::std::os::raw::c_int {
+                ::paste::paste! {
+                  crate::c_api::utils::catch_panic(|| {
+                    crate::c_api::utils::check_ptr_is_non_null_and_aligned(result).unwrap();
+
+                    let sk = crate::c_api::utils::get_ref_checked(server_key).unwrap();
+
+                    let buffer_view: &[u8] = buffer_view.as_slice();
+
+                    // First fill the result with a null ptr so that if we fail and the return code is not
+                    // checked, then any access to the result pointer will segfault (mimics malloc on failure)
+                    *result = std::ptr::null_mut();
+
+                    let params = $crate::high_level_api::[<$wrapper_type ConformanceParams>]::from(
+                        (&sk.0, $crate::conformance::ListSizeConstraint::exact_size(exact_len))
+                    );
+                    let inner = $crate::safe_deserialization::safe_deserialize_conformant_versioned(
+                            buffer_view,
+                            serialized_size_limit,
+                            &params
+                        )
+                        .unwrap();
+
+                    let heap_allocated_object = Box::new($wrapper_type(inner));
+
+                    *result = Box::into_raw(heap_allocated_object);
+                })
+              }
+            }
+        }
+    };
+}
+
+pub(crate) use {
+    impl_safe_deserialize_conformant_integer_list,
+    impl_safe_deserialize_conformant_versioned_integer_list,
+};
 
 macro_rules! impl_binary_fn_on_type {
     // More general binary fn case,

--- a/tfhe/src/high_level_api/mod.rs
+++ b/tfhe/src/high_level_api/mod.rs
@@ -69,7 +69,7 @@ expand_pub_use_fhe_type!(
     };
 );
 
-pub use safe_serialize::safe_serialize;
+pub use safe_serialize::{safe_serialize, safe_serialize_versioned};
 
 mod config;
 mod global_state;
@@ -99,6 +99,7 @@ pub enum Device {
 pub mod safe_serialize {
     use crate::named::Named;
     use serde::Serialize;
+    use tfhe_versionable::Versionize;
 
     pub fn safe_serialize<T>(
         a: &T,
@@ -109,6 +110,18 @@ pub mod safe_serialize {
         T: Named + Serialize,
     {
         crate::safe_deserialization::safe_serialize(a, writer, serialized_size_limit)
+            .map_err(|err| err.to_string())
+    }
+
+    pub fn safe_serialize_versioned<T>(
+        a: &T,
+        writer: impl std::io::Write,
+        serialized_size_limit: u64,
+    ) -> Result<(), String>
+    where
+        T: Named + Versionize,
+    {
+        crate::safe_deserialization::safe_serialize_versioned(a, writer, serialized_size_limit)
             .map_err(|err| err.to_string())
     }
 }

--- a/tfhe/src/safe_deserialization.rs
+++ b/tfhe/src/safe_deserialization.rs
@@ -1,8 +1,11 @@
+use std::borrow::Cow;
+
 use crate::conformance::ParameterSetConformant;
 use crate::named::Named;
 use bincode::Options;
 use serde::de::DeserializeOwned;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
+use tfhe_versionable::{Unversionize, Versionize};
 
 // The `SERIALIZATION_VERSION` is serialized along objects serialized with `safe_serialize`.
 // This `SERIALIZATION_VERSION` should be changed on each release where any object serialization
@@ -15,12 +18,77 @@ use serde::Serialize;
 // deserialization error or worse, a garbage object.
 const SERIALIZATION_VERSION: &str = "0.3";
 
+/// Tells if this serialized object is versioned or not
+#[derive(Serialize, Deserialize, PartialEq, Eq)]
+enum SerializationMode {
+    /// Serialize with type versioning for backward compatibility
+    Versioned,
+    /// Directly serialize the type as it is provided
+    Direct,
+}
+
+/// Header with global metadata about the serialized object.
+#[derive(Serialize, Deserialize)]
+struct SerializationHeader {
+    mode: SerializationMode,
+    version: Cow<'static, str>,
+    name: Cow<'static, str>,
+}
+
+impl SerializationHeader {
+    /// Creates a new header for a versioned message
+    fn new_versioned<T: Named>() -> Self {
+        Self {
+            mode: SerializationMode::Versioned,
+            version: Cow::Borrowed(VERSIONING_VERSION),
+            name: Cow::Borrowed(T::NAME),
+        }
+    }
+
+    /// Checks the validity of a versioned message
+    fn check_versioned<T: Named>(&self) -> Result<(), String> {
+        if self.mode != SerializationMode::Versioned {
+            return Err(
+                "On deserialization, expected versioned type but got unversioned one".to_string(),
+            );
+        }
+
+        // Since there is only one "VERSIONING_VERSION", a message with a different value than the
+        // expected one is clearly invalid, so we return an error. In the future, we want to
+        // be able to upgrade it to the new versioning scheme.
+        if self.version != VERSIONING_VERSION {
+            return Err(format!(
+                "On deserialization, expected versioning scheme version {VERSIONING_VERSION}, \
+                got version {}",
+                self.version
+            ));
+        }
+
+        if self.name != T::NAME {
+            return Err(format!(
+                "On deserialization, expected type {}, got type {}",
+                T::NAME,
+                self.name
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+// This is the version of the versioning scheme used to add backward compatibibility on tfhe-rs
+// types. Similar to SERIALIZATION_VERSION, this number should be increased when the versioning
+// scheme is upgraded.
+const VERSIONING_VERSION: &str = "0.1";
+
 // `VERSION_LENGTH_LIMIT` is the maximum `SERIALIZATION_VERSION` size which `safe_deserialization`
 // is going to try to read (it returns an error if it's too big).
 // It helps prevent an attacker passing a very long `SERIALIZATION_VERSION` to exhaust memory.
 const VERSION_LENGTH_LIMIT: u64 = 100;
 
 const TYPE_NAME_LENGTH_LIMIT: u64 = 1000;
+
+const HEADER_LENGTH_LIMIT: u64 = 1000;
 
 /// Serializes an object into a [writer](std::io::Write).
 /// The result contains a version of the serialization and the name of the
@@ -47,6 +115,29 @@ pub fn safe_serialize<T: Serialize + Named>(
     options
         .with_limit(serialized_size_limit)
         .serialize_into(&mut writer, object)?;
+
+    Ok(())
+}
+
+/// Serializes an object into a [writer](std::io::Write) like [`safe_serialize`] does,
+/// but adds versioning information before.
+pub fn safe_serialize_versioned<T: Versionize + Named>(
+    object: &T,
+    mut writer: impl std::io::Write,
+    serialized_size_limit: u64,
+) -> bincode::Result<()> {
+    let options = bincode::DefaultOptions::new()
+        .with_fixint_encoding()
+        .with_limit(0);
+
+    let header = SerializationHeader::new_versioned::<T>();
+    options
+        .with_limit(HEADER_LENGTH_LIMIT)
+        .serialize_into(&mut writer, &header)?;
+
+    options
+        .with_limit(serialized_size_limit)
+        .serialize_into(&mut writer, &object.versionize())?;
 
     Ok(())
 }
@@ -113,16 +204,65 @@ pub fn safe_deserialize_conformant<T: DeserializeOwned + Named + ParameterSetCon
     Ok(deser)
 }
 
+/// Deserializes an object serialized by `safe_serialize_versioned` from a [reader](std::io::Read).
+/// Checks that the serialization version and the name of the
+/// deserialized type are correct.
+/// `serialized_size_limit` is the size limit (in number of byte) of the serialized object
+/// (excluding version and name serialization).
+pub fn safe_deserialize_versioned<T: Unversionize + Named>(
+    mut reader: impl std::io::Read,
+    serialized_size_limit: u64,
+) -> Result<T, String> {
+    let options = bincode::DefaultOptions::new()
+        .with_fixint_encoding()
+        .with_limit(0);
+
+    let deserialized_header: SerializationHeader = options
+        .with_limit(HEADER_LENGTH_LIMIT)
+        .deserialize_from(&mut reader)
+        .map_err(|err| err.to_string())?;
+
+    deserialized_header.check_versioned::<T>()?;
+
+    options
+        .with_limit(serialized_size_limit)
+        .deserialize_from(&mut reader)
+        .map_err(|err| err.to_string())
+        .and_then(|val| T::unversionize(val).map_err(|err| err.to_string()))
+}
+
+/// Deserializes an object with [safe_deserialize] and checks than it is conformant with the given
+/// parameter set
+pub fn safe_deserialize_conformant_versioned<T: Unversionize + Named + ParameterSetConformant>(
+    reader: impl std::io::Read,
+    serialized_size_limit: u64,
+    parameter_set: &T::ParameterSet,
+) -> Result<T, String> {
+    let deser: T = safe_deserialize_versioned(reader, serialized_size_limit)?;
+
+    if !deser.is_conformant(parameter_set) {
+        return Err(format!(
+            "Deserialized object of type {} not conformant with given parameter set",
+            T::NAME
+        ));
+    }
+
+    Ok(deser)
+}
+
 #[cfg(all(test, feature = "shortint"))]
 mod test_shortint {
-    use crate::safe_deserialization::{safe_deserialize_conformant, safe_serialize};
+    use crate::safe_deserialization::{
+        safe_deserialize_conformant, safe_deserialize_conformant_versioned, safe_serialize,
+        safe_serialize_versioned,
+    };
     use crate::shortint::parameters::{
         PARAM_MESSAGE_2_CARRY_2_KS_PBS, PARAM_MESSAGE_3_CARRY_3_KS_PBS,
     };
     use crate::shortint::{gen_keys, Ciphertext};
 
     #[test]
-    fn safe_desererialization_ct() {
+    fn safe_deserialization_ct() {
         let (ck, _sk) = gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
 
         let msg = 2_u64;
@@ -150,6 +290,36 @@ mod test_shortint {
         let dec = ck.decrypt(&ct2);
         assert_eq!(msg, dec);
     }
+
+    #[test]
+    fn safe_deserialization_ct_versioned() {
+        let (ck, _sk) = gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+
+        let msg = 2_u64;
+
+        let ct = ck.encrypt(msg);
+
+        let mut buffer = vec![];
+
+        safe_serialize_versioned(&ct, &mut buffer, 1 << 40).unwrap();
+
+        assert!(safe_deserialize_conformant_versioned::<Ciphertext>(
+            buffer.as_slice(),
+            1 << 20,
+            &PARAM_MESSAGE_3_CARRY_3_KS_PBS.to_shortint_conformance_param(),
+        )
+        .is_err());
+
+        let ct2 = safe_deserialize_conformant_versioned(
+            buffer.as_slice(),
+            1 << 20,
+            &PARAM_MESSAGE_2_CARRY_2_KS_PBS.to_shortint_conformance_param(),
+        )
+        .unwrap();
+
+        let dec = ck.decrypt(&ct2);
+        assert_eq!(msg, dec);
+    }
 }
 
 #[cfg(all(test, feature = "integer"))]
@@ -157,7 +327,10 @@ mod test_integer {
     use crate::conformance::ListSizeConstraint;
     use crate::high_level_api::{generate_keys, ConfigBuilder};
     use crate::prelude::{FheDecrypt, FheTryEncrypt};
-    use crate::safe_deserialization::{safe_deserialize_conformant, safe_serialize};
+    use crate::safe_deserialization::{
+        safe_deserialize_conformant, safe_deserialize_conformant_versioned, safe_serialize,
+        safe_serialize_versioned,
+    };
     use crate::shortint::parameters::{
         PARAM_MESSAGE_1_CARRY_1_KS_PBS, PARAM_MESSAGE_2_CARRY_2_KS_PBS,
         PARAM_MESSAGE_3_CARRY_3_KS_PBS,
@@ -166,8 +339,9 @@ mod test_integer {
         CompactFheUint8, CompactFheUint8List, CompactFheUint8ListConformanceParams,
         CompactPublicKey, FheUint8ConformanceParams,
     };
+
     #[test]
-    fn safe_desererialization_ct() {
+    fn safe_deserialization_ct() {
         let (client_key, server_key) = generate_keys(ConfigBuilder::default().build());
 
         let public_key = CompactPublicKey::new(&client_key);
@@ -198,7 +372,41 @@ mod test_integer {
     }
 
     #[test]
-    fn safe_desererialization_ct_list() {
+    fn safe_deserialization_ct_versioned() {
+        let (client_key, server_key) = generate_keys(ConfigBuilder::default().build());
+
+        let public_key = CompactPublicKey::new(&client_key);
+
+        let msg = 27u8;
+
+        let ct = CompactFheUint8::try_encrypt(msg, &public_key).unwrap();
+
+        let mut buffer = vec![];
+
+        safe_serialize_versioned(&ct, &mut buffer, 1 << 40).unwrap();
+
+        let params = FheUint8ConformanceParams::from(PARAM_MESSAGE_1_CARRY_1_KS_PBS);
+        assert!(safe_deserialize_conformant_versioned::<CompactFheUint8>(
+            buffer.as_slice(),
+            1 << 20,
+            &params
+        )
+        .is_err());
+
+        let params = FheUint8ConformanceParams::from(&server_key);
+        let ct2 = safe_deserialize_conformant_versioned::<CompactFheUint8>(
+            buffer.as_slice(),
+            1 << 20,
+            &params,
+        )
+        .unwrap();
+
+        let dec: u8 = ct2.expand().decrypt(&client_key);
+        assert_eq!(msg, dec);
+    }
+
+    #[test]
+    fn safe_deserialization_ct_list() {
         let (client_key, server_key) = generate_keys(ConfigBuilder::default().build());
 
         let public_key = CompactPublicKey::new(&client_key);


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description

Adds a few methods for versioned serializations:
- `safe_serialize_versioned`
- `safe_deserialize_versioned`
- `safe_deserialize_conformant_versioned`

To avoid conflict with the `SERIALIZATION_VERSION`, a different number `VERSIONING_VERSION` is used to record the version of the versioning scheme that has been used. A specific header type has been created that will be embed inside the serialized packet and records if the message is versioned or not. To be compatible with other message serialized with previous 0.6, this header is not used for messages that are not versioned.

However this might be useless in the future since the SERIALIZATION_VERSION should not evolve anymore when versioning will be used by default.

### Check-list:

* [x] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
