### PR TITLE
chore(ci): update gpu ec2 ami with rustup snap package removed

### DIFF
--- a/ci/slab.toml
+++ b/ci/slab.toml
@@ -26,7 +26,7 @@ instance_type = "hpc7a.96xlarge"
 
 [backend.aws.gpu-test]
 region = "us-east-1"
-image_id = "ami-0c0bf195ca4c175b6"
+image_id = "ami-06b3d61f41bf8350a"
 instance_type = "p3.2xlarge"
 # One spawn attempt every 30 seconds for 1 hour
 spawn_retry_attempts = 120
@@ -49,7 +49,7 @@ flavor_name = "n3-A100x8-NVLink"
 
 [backend.aws.multi-gpu-test]
 region = "us-east-1"
-image_id = "ami-0c0bf195ca4c175b6"
+image_id = "ami-06b3d61f41bf8350a"
 instance_type = "p3.8xlarge"
 # One spawn attempt every 30 seconds for 1 hour
 spawn_retry_attempts = 120


### PR DESCRIPTION
Rustup was installed using snap and could clash in the workflow notably on cargo-clippy calls.

