### PR TITLE
Am/chore/container metadata

### DIFF
--- a/tasks/src/check_tfhe_docs_are_tested.rs
+++ b/tasks/src/check_tfhe_docs_are_tested.rs
@@ -2,6 +2,9 @@ use no_comment::{languages, IntoWithoutComments};
 use std::collections::HashSet;
 use std::io::{Error, ErrorKind};
 
+// TODO use .gitignore or git to resolve ignored files
+const DIR_TO_IGNORE: [&str; 2] = [".git", "target"];
+
 const FILES_TO_IGNORE: [&str; 4] = [
     // This contains fragments of code that are unrelated to TFHE-rs
     "tfhe/docs/tutorials/sha256_bool.md",
@@ -103,6 +106,11 @@ pub fn check_tfhe_docs_are_tested() -> Result<(), Error> {
             }
         })
         .collect();
+
+    for dir_to_remove in DIR_TO_IGNORE {
+        let path_to_remove = curr_dir.join(dir_to_remove);
+        doc_files.retain(|v| !v.starts_with(&path_to_remove));
+    }
 
     for value_to_remove in FILES_TO_IGNORE {
         let path_to_remove = curr_dir.join(value_to_remove).canonicalize()?.to_path_buf();

--- a/tfhe/src/core_crypto/entities/ggsw_ciphertext.rs
+++ b/tfhe/src/core_crypto/entities/ggsw_ciphertext.rs
@@ -602,24 +602,24 @@ impl<Scalar: UnsignedInteger> GgswCiphertextOwned<Scalar> {
 
 /// Metadata used in the [`CreateFrom`] implementation to create [`GgswCiphertext`] entities.
 #[derive(Clone, Copy)]
-pub struct GgswCiphertextCreationMetadata<Scalar: UnsignedInteger>(
-    pub GlweSize,
-    pub PolynomialSize,
-    pub DecompositionBaseLog,
-    pub CiphertextModulus<Scalar>,
-);
+pub struct GgswCiphertextCreationMetadata<Scalar: UnsignedInteger> {
+    pub glwe_size: GlweSize,
+    pub polynomial_size: PolynomialSize,
+    pub decomp_base_log: DecompositionBaseLog,
+    pub ciphertext_modulus: CiphertextModulus<Scalar>,
+}
 
 impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> CreateFrom<C> for GgswCiphertext<C> {
     type Metadata = GgswCiphertextCreationMetadata<Scalar>;
 
     #[inline]
     fn create_from(from: C, meta: Self::Metadata) -> Self {
-        let GgswCiphertextCreationMetadata(
+        let GgswCiphertextCreationMetadata {
             glwe_size,
             polynomial_size,
             decomp_base_log,
             ciphertext_modulus,
-        ) = meta;
+        } = meta;
         Self::from_container(
             from,
             glwe_size,
@@ -756,18 +756,22 @@ impl<Scalar: UnsignedInteger, C: ContainerMut<Element = Scalar>> GgswLevelMatrix
 
 /// Metadata used in the [`CreateFrom`] implementation to create [`GgswLevelMatrix`] entities.
 #[derive(Clone, Copy)]
-pub struct GgswLevelMatrixCreationMetadata<Scalar: UnsignedInteger>(
-    pub GlweSize,
-    pub PolynomialSize,
-    pub CiphertextModulus<Scalar>,
-);
+pub struct GgswLevelMatrixCreationMetadata<Scalar: UnsignedInteger> {
+    pub glwe_size: GlweSize,
+    pub polynomial_size: PolynomialSize,
+    pub ciphertext_modulus: CiphertextModulus<Scalar>,
+}
 
 impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> CreateFrom<C> for GgswLevelMatrix<C> {
     type Metadata = GgswLevelMatrixCreationMetadata<C::Element>;
 
     #[inline]
     fn create_from(from: C, meta: Self::Metadata) -> Self {
-        let GgswLevelMatrixCreationMetadata(glwe_size, polynomial_size, ciphertext_modulus) = meta;
+        let GgswLevelMatrixCreationMetadata {
+            glwe_size,
+            polynomial_size,
+            ciphertext_modulus,
+        } = meta;
         Self::from_container(from, glwe_size, polynomial_size, ciphertext_modulus)
     }
 }
@@ -790,11 +794,11 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> ContiguousEntityCo
         Self: 'this;
 
     fn get_entity_view_creation_metadata(&self) -> Self::EntityViewMetadata {
-        GgswLevelMatrixCreationMetadata(
-            self.glwe_size,
-            self.polynomial_size,
-            self.ciphertext_modulus,
-        )
+        GgswLevelMatrixCreationMetadata {
+            glwe_size: self.glwe_size,
+            polynomial_size: self.polynomial_size,
+            ciphertext_modulus: self.ciphertext_modulus,
+        }
     }
 
     fn get_entity_view_pod_size(&self) -> usize {

--- a/tfhe/src/core_crypto/entities/ggsw_ciphertext_list.rs
+++ b/tfhe/src/core_crypto/entities/ggsw_ciphertext_list.rs
@@ -319,13 +319,13 @@ impl<Scalar: UnsignedInteger> GgswCiphertextListOwned<Scalar> {
 
 /// Metadata used in the [`CreateFrom`] implementation to create [`GgswCiphertextList`] entities.
 #[derive(Clone, Copy)]
-pub struct GgswCiphertextListCreationMetadata<Scalar: UnsignedInteger>(
-    pub GlweSize,
-    pub PolynomialSize,
-    pub DecompositionBaseLog,
-    pub DecompositionLevelCount,
-    pub CiphertextModulus<Scalar>,
-);
+pub struct GgswCiphertextListCreationMetadata<Scalar: UnsignedInteger> {
+    pub glwe_size: GlweSize,
+    pub polynomial_size: PolynomialSize,
+    pub decomp_base_log: DecompositionBaseLog,
+    pub decomp_level_count: DecompositionLevelCount,
+    pub ciphertext_modulus: CiphertextModulus<Scalar>,
+}
 
 impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> CreateFrom<C>
     for GgswCiphertextList<C>
@@ -334,13 +334,13 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> CreateFrom<C>
 
     #[inline]
     fn create_from(from: C, meta: Self::Metadata) -> Self {
-        let GgswCiphertextListCreationMetadata(
+        let GgswCiphertextListCreationMetadata {
             glwe_size,
             polynomial_size,
             decomp_base_log,
             decomp_level_count,
             ciphertext_modulus,
-        ) = meta;
+        } = meta;
         Self::from_container(
             from,
             glwe_size,
@@ -357,7 +357,7 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> ContiguousEntityCo
 {
     type Element = C::Element;
 
-    type EntityViewMetadata = GgswCiphertextCreationMetadata<Scalar>;
+    type EntityViewMetadata = GgswCiphertextCreationMetadata<Self::Element>;
 
     type EntityView<'this> = GgswCiphertextView<'this, Self::Element>
     where
@@ -370,12 +370,12 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> ContiguousEntityCo
         Self: 'this;
 
     fn get_entity_view_creation_metadata(&self) -> Self::EntityViewMetadata {
-        GgswCiphertextCreationMetadata(
-            self.glwe_size,
-            self.polynomial_size,
-            self.decomp_base_log,
-            self.ciphertext_modulus,
-        )
+        GgswCiphertextCreationMetadata {
+            glwe_size: self.glwe_size,
+            polynomial_size: self.polynomial_size,
+            decomp_base_log: self.decomp_base_log,
+            ciphertext_modulus: self.ciphertext_modulus,
+        }
     }
 
     fn get_entity_view_pod_size(&self) -> usize {
@@ -387,13 +387,13 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> ContiguousEntityCo
     }
 
     fn get_self_view_creation_metadata(&self) -> Self::SelfViewMetadata {
-        GgswCiphertextListCreationMetadata(
-            self.glwe_size,
-            self.polynomial_size,
-            self.decomp_base_log,
-            self.decomp_level_count,
-            self.ciphertext_modulus,
-        )
+        GgswCiphertextListCreationMetadata {
+            glwe_size: self.glwe_size,
+            polynomial_size: self.polynomial_size,
+            decomp_base_log: self.decomp_base_log,
+            decomp_level_count: self.decomp_level_count,
+            ciphertext_modulus: self.ciphertext_modulus,
+        }
     }
 }
 

--- a/tfhe/src/core_crypto/entities/glwe_ciphertext.rs
+++ b/tfhe/src/core_crypto/entities/glwe_ciphertext.rs
@@ -83,7 +83,10 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> CreateFrom<C> for 
 
     #[inline]
     fn create_from(from: C, meta: Self::Metadata) -> Self {
-        let GlweCiphertextCreationMetadata(_, ciphertext_modulus) = meta;
+        let GlweCiphertextCreationMetadata {
+            polynomial_size: _,
+            ciphertext_modulus,
+        } = meta;
         Self::from_container(from, ciphertext_modulus)
     }
 }
@@ -602,17 +605,20 @@ impl<Scalar: UnsignedInteger> GlweCiphertextOwned<Scalar> {
 
 /// Metadata used in the [`CreateFrom`] implementation to create [`GlweCiphertext`] entities.
 #[derive(Clone, Copy)]
-pub struct GlweCiphertextCreationMetadata<Scalar: UnsignedInteger>(
-    pub PolynomialSize,
-    pub CiphertextModulus<Scalar>,
-);
+pub struct GlweCiphertextCreationMetadata<Scalar: UnsignedInteger> {
+    pub polynomial_size: PolynomialSize,
+    pub ciphertext_modulus: CiphertextModulus<Scalar>,
+}
 
 impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> CreateFrom<C> for GlweCiphertext<C> {
     type Metadata = GlweCiphertextCreationMetadata<Scalar>;
 
     #[inline]
     fn create_from(from: C, meta: Self::Metadata) -> Self {
-        let GlweCiphertextCreationMetadata(polynomial_size, ciphertext_modulus) = meta;
+        let GlweCiphertextCreationMetadata {
+            polynomial_size,
+            ciphertext_modulus,
+        } = meta;
         Self::from_container(from, polynomial_size, ciphertext_modulus)
     }
 }

--- a/tfhe/src/core_crypto/entities/glwe_ciphertext_list.rs
+++ b/tfhe/src/core_crypto/entities/glwe_ciphertext_list.rs
@@ -233,11 +233,11 @@ impl<Scalar: UnsignedInteger> GlweCiphertextListOwned<Scalar> {
 
 /// Metadata used in the [`CreateFrom`] implementation to create [`GlweCiphertextList`] entities.
 #[derive(Clone, Copy)]
-pub struct GlweCiphertextListCreationMetadata<Scalar: UnsignedInteger>(
-    pub GlweSize,
-    pub PolynomialSize,
-    pub CiphertextModulus<Scalar>,
-);
+pub struct GlweCiphertextListCreationMetadata<Scalar: UnsignedInteger> {
+    pub glwe_size: GlweSize,
+    pub polynomial_size: PolynomialSize,
+    pub ciphertext_modulus: CiphertextModulus<Scalar>,
+}
 
 impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> CreateFrom<C>
     for GlweCiphertextList<C>
@@ -246,8 +246,11 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> CreateFrom<C>
 
     #[inline]
     fn create_from(from: C, meta: Self::Metadata) -> Self {
-        let GlweCiphertextListCreationMetadata(glwe_size, polynomial_size, ciphertext_modulus) =
-            meta;
+        let GlweCiphertextListCreationMetadata {
+            glwe_size,
+            polynomial_size,
+            ciphertext_modulus,
+        } = meta;
         Self::from_container(from, glwe_size, polynomial_size, ciphertext_modulus)
     }
 }
@@ -270,7 +273,10 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> ContiguousEntityCo
         Self: 'this;
 
     fn get_entity_view_creation_metadata(&self) -> Self::EntityViewMetadata {
-        GlweCiphertextCreationMetadata(self.polynomial_size(), self.ciphertext_modulus())
+        GlweCiphertextCreationMetadata {
+            polynomial_size: self.polynomial_size(),
+            ciphertext_modulus: self.ciphertext_modulus(),
+        }
     }
 
     fn get_entity_view_pod_size(&self) -> usize {
@@ -278,11 +284,11 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> ContiguousEntityCo
     }
 
     fn get_self_view_creation_metadata(&self) -> Self::SelfViewMetadata {
-        GlweCiphertextListCreationMetadata(
-            self.glwe_size(),
-            self.polynomial_size(),
-            self.ciphertext_modulus(),
-        )
+        GlweCiphertextListCreationMetadata {
+            glwe_size: self.glwe_size(),
+            polynomial_size: self.polynomial_size(),
+            ciphertext_modulus: self.ciphertext_modulus(),
+        }
     }
 }
 

--- a/tfhe/src/core_crypto/entities/lwe_ciphertext.rs
+++ b/tfhe/src/core_crypto/entities/lwe_ciphertext.rs
@@ -71,7 +71,7 @@ impl<'data, T: UnsignedInteger> CreateFrom<&'data [T]> for LweBodyRef<'data, T> 
 
     #[inline]
     fn create_from(from: &[T], meta: Self::Metadata) -> LweBodyRef<T> {
-        let LweBodyCreationMetadata(ciphertext_modulus) = meta;
+        let LweBodyCreationMetadata { ciphertext_modulus } = meta;
         LweBodyRef {
             data: &from[0],
             ciphertext_modulus,
@@ -84,7 +84,7 @@ impl<'data, T: UnsignedInteger> CreateFrom<&'data mut [T]> for LweBodyRefMut<'da
 
     #[inline]
     fn create_from(from: &mut [T], meta: Self::Metadata) -> LweBodyRefMut<T> {
-        let LweBodyCreationMetadata(ciphertext_modulus) = meta;
+        let LweBodyCreationMetadata { ciphertext_modulus } = meta;
         LweBodyRefMut {
             data: &mut from[0],
             ciphertext_modulus,
@@ -121,7 +121,7 @@ impl<'data, T: UnsignedInteger> CreateFrom<&'data [T]> for LweBodyListView<'data
 
     #[inline]
     fn create_from(from: &[T], meta: Self::Metadata) -> LweBodyListView<'_, T> {
-        let LweBodyListCreationMetadata(ciphertext_modulus) = meta;
+        let LweBodyListCreationMetadata { ciphertext_modulus } = meta;
         LweBodyList {
             data: from,
             ciphertext_modulus,
@@ -134,7 +134,7 @@ impl<'data, T: UnsignedInteger> CreateFrom<&'data mut [T]> for LweBodyListMutVie
 
     #[inline]
     fn create_from(from: &mut [T], meta: Self::Metadata) -> LweBodyListMutView<'_, T> {
-        let LweBodyListCreationMetadata(ciphertext_modulus) = meta;
+        let LweBodyListCreationMetadata { ciphertext_modulus } = meta;
         LweBodyList {
             data: from,
             ciphertext_modulus,
@@ -161,11 +161,15 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> LweBodyList<C> {
 
 /// Metadata used in the [`CreateFrom`] implementation to create [`LweBody`] entities.
 #[derive(Clone, Copy)]
-pub struct LweBodyCreationMetadata<Scalar: UnsignedInteger>(pub CiphertextModulus<Scalar>);
+pub struct LweBodyCreationMetadata<Scalar: UnsignedInteger> {
+    pub ciphertext_modulus: CiphertextModulus<Scalar>,
+}
 
 /// Metadata used in the [`CreateFrom`] implementation to create [`LweBodyList`] entities.
 #[derive(Clone, Copy)]
-pub struct LweBodyListCreationMetadata<Scalar: UnsignedInteger>(pub CiphertextModulus<Scalar>);
+pub struct LweBodyListCreationMetadata<Scalar: UnsignedInteger> {
+    pub ciphertext_modulus: CiphertextModulus<Scalar>,
+}
 
 impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> ContiguousEntityContainer
     for LweBodyList<C>
@@ -185,7 +189,9 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> ContiguousEntityCo
         Self: 'this;
 
     fn get_entity_view_creation_metadata(&self) -> Self::EntityViewMetadata {
-        LweBodyCreationMetadata(self.ciphertext_modulus())
+        LweBodyCreationMetadata {
+            ciphertext_modulus: self.ciphertext_modulus(),
+        }
     }
 
     fn get_entity_view_pod_size(&self) -> usize {
@@ -193,7 +199,9 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> ContiguousEntityCo
     }
 
     fn get_self_view_creation_metadata(&self) -> Self::SelfViewMetadata {
-        LweBodyListCreationMetadata(self.ciphertext_modulus())
+        LweBodyListCreationMetadata {
+            ciphertext_modulus: self.ciphertext_modulus(),
+        }
     }
 }
 
@@ -279,7 +287,7 @@ impl<'data, T: UnsignedInteger> CreateFrom<&'data [T]> for LweMask<&'data [T]> {
 
     #[inline]
     fn create_from(from: &[T], meta: Self::Metadata) -> LweMask<&[T]> {
-        let LweMaskCreationMetadata(ciphertext_modulus) = meta;
+        let LweMaskCreationMetadata { ciphertext_modulus } = meta;
         LweMask {
             data: from,
             ciphertext_modulus,
@@ -292,7 +300,7 @@ impl<'data, T: UnsignedInteger> CreateFrom<&'data mut [T]> for LweMask<&'data mu
 
     #[inline]
     fn create_from(from: &mut [T], meta: Self::Metadata) -> LweMask<&mut [T]> {
-        let LweMaskCreationMetadata(ciphertext_modulus) = meta;
+        let LweMaskCreationMetadata { ciphertext_modulus } = meta;
         LweMask {
             data: from,
             ciphertext_modulus,
@@ -334,7 +342,10 @@ impl<'data, T: UnsignedInteger> CreateFrom<&'data [T]> for LweMaskListView<'data
 
     #[inline]
     fn create_from(from: &[T], meta: Self::Metadata) -> LweMaskListView<'_, T> {
-        let LweMaskListCreationMetadata(lwe_dimension, ciphertext_modulus) = meta;
+        let LweMaskListCreationMetadata {
+            lwe_dimension,
+            ciphertext_modulus,
+        } = meta;
         LweMaskList {
             data: from,
             lwe_dimension,
@@ -348,7 +359,10 @@ impl<'data, T: UnsignedInteger> CreateFrom<&'data mut [T]> for LweMaskListMutVie
 
     #[inline]
     fn create_from(from: &mut [T], meta: Self::Metadata) -> LweMaskListMutView<'_, T> {
-        let LweMaskListCreationMetadata(lwe_dimension, ciphertext_modulus) = meta;
+        let LweMaskListCreationMetadata {
+            lwe_dimension,
+            ciphertext_modulus,
+        } = meta;
         LweMaskList {
             data: from,
             lwe_dimension,
@@ -397,14 +411,16 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> LweMaskList<C> {
 
 /// Metadata used in the [`CreateFrom`] implementation to create [`LweMask`] entities.
 #[derive(Clone, Copy)]
-pub struct LweMaskCreationMetadata<Scalar: UnsignedInteger>(pub CiphertextModulus<Scalar>);
+pub struct LweMaskCreationMetadata<Scalar: UnsignedInteger> {
+    pub ciphertext_modulus: CiphertextModulus<Scalar>,
+}
 
 /// Metadata used in the [`CreateFrom`] implementation to create [`LweMaskList`] entities.
 #[derive(Clone, Copy)]
-pub struct LweMaskListCreationMetadata<Scalar: UnsignedInteger>(
-    pub LweDimension,
-    pub CiphertextModulus<Scalar>,
-);
+pub struct LweMaskListCreationMetadata<Scalar: UnsignedInteger> {
+    pub lwe_dimension: LweDimension,
+    pub ciphertext_modulus: CiphertextModulus<Scalar>,
+}
 
 impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> ContiguousEntityContainer
     for LweMaskList<C>
@@ -413,7 +429,7 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> ContiguousEntityCo
 
     type EntityViewMetadata = LweMaskCreationMetadata<Self::Element>;
 
-    type EntityView<'this> = LweMask<&'this [ Self::Element]>
+    type EntityView<'this> = LweMask<&'this [Self::Element]>
     where
         Self: 'this;
 
@@ -424,7 +440,9 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> ContiguousEntityCo
         Self: 'this;
 
     fn get_entity_view_creation_metadata(&self) -> Self::EntityViewMetadata {
-        LweMaskCreationMetadata(self.ciphertext_modulus())
+        LweMaskCreationMetadata {
+            ciphertext_modulus: self.ciphertext_modulus(),
+        }
     }
 
     fn get_entity_view_pod_size(&self) -> usize {
@@ -432,14 +450,17 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> ContiguousEntityCo
     }
 
     fn get_self_view_creation_metadata(&self) -> Self::SelfViewMetadata {
-        LweMaskListCreationMetadata(self.lwe_dimension(), self.ciphertext_modulus())
+        LweMaskListCreationMetadata {
+            lwe_dimension: self.lwe_dimension(),
+            ciphertext_modulus: self.ciphertext_modulus(),
+        }
     }
 }
 
 impl<Scalar: UnsignedInteger, C: ContainerMut<Element = Scalar>> ContiguousEntityContainerMut
     for LweMaskList<C>
 {
-    type EntityMutView<'this> = LweMask<&'this mut [ Self::Element]>
+    type EntityMutView<'this> = LweMask<&'this mut [Self::Element]>
     where
         Self: 'this;
 
@@ -768,14 +789,16 @@ impl<Scalar: UnsignedInteger> LweCiphertextOwned<Scalar> {
 
 /// Metadata used in the [`CreateFrom`] implementation to create [`LweCiphertext`] entities.
 #[derive(Clone, Copy)]
-pub struct LweCiphertextCreationMetadata<Scalar: UnsignedInteger>(pub CiphertextModulus<Scalar>);
+pub struct LweCiphertextCreationMetadata<Scalar: UnsignedInteger> {
+    pub ciphertext_modulus: CiphertextModulus<Scalar>,
+}
 
 impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> CreateFrom<C> for LweCiphertext<C> {
     type Metadata = LweCiphertextCreationMetadata<C::Element>;
 
     #[inline]
     fn create_from(from: C, meta: Self::Metadata) -> Self {
-        let LweCiphertextCreationMetadata(modulus) = meta;
-        Self::from_container(from, modulus)
+        let LweCiphertextCreationMetadata { ciphertext_modulus } = meta;
+        Self::from_container(from, ciphertext_modulus)
     }
 }

--- a/tfhe/src/core_crypto/entities/lwe_ciphertext_list.rs
+++ b/tfhe/src/core_crypto/entities/lwe_ciphertext_list.rs
@@ -288,10 +288,10 @@ impl<Scalar: UnsignedInteger> LweCiphertextListOwned<Scalar> {
 
 /// Metadata used in the [`CreateFrom`] implementation to create [`LweCiphertextList`] entities.
 #[derive(Clone, Copy)]
-pub struct LweCiphertextListCreationMetadata<Scalar: UnsignedInteger>(
-    pub LweSize,
-    pub CiphertextModulus<Scalar>,
-);
+pub struct LweCiphertextListCreationMetadata<Scalar: UnsignedInteger> {
+    pub lwe_size: LweSize,
+    pub ciphertext_modulus: CiphertextModulus<Scalar>,
+}
 
 impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> CreateFrom<C>
     for LweCiphertextList<C>
@@ -300,8 +300,11 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> CreateFrom<C>
 
     #[inline]
     fn create_from(from: C, meta: Self::Metadata) -> Self {
-        let LweCiphertextListCreationMetadata(lwe_size, modulus) = meta;
-        Self::from_container(from, lwe_size, modulus)
+        let LweCiphertextListCreationMetadata {
+            lwe_size,
+            ciphertext_modulus,
+        } = meta;
+        Self::from_container(from, lwe_size, ciphertext_modulus)
     }
 }
 
@@ -323,7 +326,9 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> ContiguousEntityCo
         Self: 'this;
 
     fn get_entity_view_creation_metadata(&self) -> Self::EntityViewMetadata {
-        LweCiphertextCreationMetadata(self.ciphertext_modulus())
+        LweCiphertextCreationMetadata {
+            ciphertext_modulus: self.ciphertext_modulus(),
+        }
     }
 
     fn get_entity_view_pod_size(&self) -> usize {
@@ -331,7 +336,10 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> ContiguousEntityCo
     }
 
     fn get_self_view_creation_metadata(&self) -> Self::SelfViewMetadata {
-        LweCiphertextListCreationMetadata(self.lwe_size(), self.ciphertext_modulus())
+        LweCiphertextListCreationMetadata {
+            lwe_size: self.lwe_size(),
+            ciphertext_modulus: self.ciphertext_modulus(),
+        }
     }
 }
 

--- a/tfhe/src/core_crypto/entities/lwe_keyswitch_key.rs
+++ b/tfhe/src/core_crypto/entities/lwe_keyswitch_key.rs
@@ -348,24 +348,24 @@ impl<Scalar: UnsignedInteger> LweKeyswitchKeyOwned<Scalar> {
 }
 
 #[derive(Clone, Copy)]
-pub struct LweKeyswitchKeyCreationMetadata<Scalar: UnsignedInteger>(
-    pub DecompositionBaseLog,
-    pub DecompositionLevelCount,
-    pub LweSize,
-    pub CiphertextModulus<Scalar>,
-);
+pub struct LweKeyswitchKeyCreationMetadata<Scalar: UnsignedInteger> {
+    pub decomp_base_log: DecompositionBaseLog,
+    pub decomp_level_count: DecompositionLevelCount,
+    pub output_lwe_size: LweSize,
+    pub ciphertext_modulus: CiphertextModulus<Scalar>,
+}
 
 impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> CreateFrom<C> for LweKeyswitchKey<C> {
     type Metadata = LweKeyswitchKeyCreationMetadata<Scalar>;
 
     #[inline]
     fn create_from(from: C, meta: Self::Metadata) -> Self {
-        let LweKeyswitchKeyCreationMetadata(
+        let LweKeyswitchKeyCreationMetadata {
             decomp_base_log,
             decomp_level_count,
             output_lwe_size,
             ciphertext_modulus,
-        ) = meta;
+        } = meta;
         Self::from_container(
             from,
             decomp_base_log,
@@ -394,7 +394,10 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> ContiguousEntityCo
         Self: 'this;
 
     fn get_entity_view_creation_metadata(&self) -> Self::EntityViewMetadata {
-        LweCiphertextListCreationMetadata(self.output_lwe_size(), self.ciphertext_modulus())
+        LweCiphertextListCreationMetadata {
+            lwe_size: self.output_lwe_size(),
+            ciphertext_modulus: self.ciphertext_modulus(),
+        }
     }
 
     fn get_entity_view_pod_size(&self) -> usize {
@@ -402,12 +405,12 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> ContiguousEntityCo
     }
 
     fn get_self_view_creation_metadata(&self) -> Self::SelfViewMetadata {
-        LweKeyswitchKeyCreationMetadata(
-            self.decomposition_base_log(),
-            self.decomposition_level_count(),
-            self.output_lwe_size(),
-            self.ciphertext_modulus(),
-        )
+        LweKeyswitchKeyCreationMetadata {
+            decomp_base_log: self.decomposition_base_log(),
+            decomp_level_count: self.decomposition_level_count(),
+            output_lwe_size: self.output_lwe_size(),
+            ciphertext_modulus: self.ciphertext_modulus(),
+        }
     }
 }
 

--- a/tfhe/src/core_crypto/entities/lwe_packing_keyswitch_key.rs
+++ b/tfhe/src/core_crypto/entities/lwe_packing_keyswitch_key.rs
@@ -362,11 +362,11 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> ContiguousEntityCo
         Self: 'this;
 
     fn get_entity_view_creation_metadata(&self) -> Self::EntityViewMetadata {
-        GlweCiphertextListCreationMetadata(
-            self.output_glwe_size(),
-            self.output_polynomial_size(),
-            self.ciphertext_modulus(),
-        )
+        GlweCiphertextListCreationMetadata {
+            glwe_size: self.output_glwe_size(),
+            polynomial_size: self.output_polynomial_size(),
+            ciphertext_modulus: self.ciphertext_modulus(),
+        }
     }
 
     fn get_entity_view_pod_size(&self) -> usize {

--- a/tfhe/src/core_crypto/entities/lwe_private_functional_packing_keyswitch_key.rs
+++ b/tfhe/src/core_crypto/entities/lwe_private_functional_packing_keyswitch_key.rs
@@ -448,11 +448,11 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> ContiguousEntityCo
         Self: 'this;
 
     fn get_entity_view_creation_metadata(&self) -> Self::EntityViewMetadata {
-        GlweCiphertextListCreationMetadata(
-            self.output_glwe_size,
-            self.output_polynomial_size,
-            self.ciphertext_modulus,
-        )
+        GlweCiphertextListCreationMetadata {
+            glwe_size: self.output_glwe_size,
+            polynomial_size: self.output_polynomial_size,
+            ciphertext_modulus: self.ciphertext_modulus,
+        }
     }
 
     fn get_entity_view_pod_size(&self) -> usize {
@@ -460,13 +460,13 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> ContiguousEntityCo
     }
 
     fn get_self_view_creation_metadata(&self) -> Self::SelfViewMetadata {
-        LwePrivateFunctionalPackingKeyswitchKeyCreationMetadata(
-            self.decomposition_base_log(),
-            self.decomposition_level_count(),
-            self.output_glwe_size(),
-            self.output_polynomial_size(),
-            self.ciphertext_modulus(),
-        )
+        LwePrivateFunctionalPackingKeyswitchKeyCreationMetadata {
+            decomp_base_log: self.decomposition_base_log(),
+            decomp_level_count: self.decomposition_level_count(),
+            output_glwe_size: self.output_glwe_size(),
+            output_polynomial_size: self.output_polynomial_size(),
+            ciphertext_modulus: self.ciphertext_modulus(),
+        }
     }
 }
 
@@ -485,13 +485,13 @@ impl<Scalar: UnsignedInteger, C: ContainerMut<Element = Scalar>> ContiguousEntit
 /// Metadata used in the [`CreateFrom`] implementation to create
 /// [`LwePrivateFunctionalPackingKeyswitchKey`] entities.
 #[derive(Clone, Copy)]
-pub struct LwePrivateFunctionalPackingKeyswitchKeyCreationMetadata<Scalar: UnsignedInteger>(
-    pub DecompositionBaseLog,
-    pub DecompositionLevelCount,
-    pub GlweSize,
-    pub PolynomialSize,
-    pub CiphertextModulus<Scalar>,
-);
+pub struct LwePrivateFunctionalPackingKeyswitchKeyCreationMetadata<Scalar: UnsignedInteger> {
+    pub decomp_base_log: DecompositionBaseLog,
+    pub decomp_level_count: DecompositionLevelCount,
+    pub output_glwe_size: GlweSize,
+    pub output_polynomial_size: PolynomialSize,
+    pub ciphertext_modulus: CiphertextModulus<Scalar>,
+}
 
 impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> CreateFrom<C>
     for LwePrivateFunctionalPackingKeyswitchKey<C>
@@ -500,13 +500,13 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> CreateFrom<C>
 
     #[inline]
     fn create_from(from: C, meta: Self::Metadata) -> Self {
-        let LwePrivateFunctionalPackingKeyswitchKeyCreationMetadata(
+        let LwePrivateFunctionalPackingKeyswitchKeyCreationMetadata {
             decomp_base_log,
             decomp_level_count,
             output_glwe_size,
             output_polynomial_size,
             ciphertext_modulus,
-        ) = meta;
+        } = meta;
         Self::from_container(
             from,
             decomp_base_log,

--- a/tfhe/src/core_crypto/entities/lwe_private_functional_packing_keyswitch_key_list.rs
+++ b/tfhe/src/core_crypto/entities/lwe_private_functional_packing_keyswitch_key_list.rs
@@ -399,14 +399,14 @@ impl<Scalar: UnsignedInteger> LwePrivateFunctionalPackingKeyswitchKeyListOwned<S
 /// Metadata used in the [`CreateFrom`] implementation to create
 /// [`LwePrivateFunctionalPackingKeyswitchKeyList`] entities.
 #[derive(Clone, Copy)]
-pub struct LwePrivateFunctionalPackingKeyswitchKeyListCreationMetadata<Scalar: UnsignedInteger>(
-    pub DecompositionBaseLog,
-    pub DecompositionLevelCount,
-    pub LweSize,
-    pub GlweSize,
-    pub PolynomialSize,
-    pub CiphertextModulus<Scalar>,
-);
+pub struct LwePrivateFunctionalPackingKeyswitchKeyListCreationMetadata<Scalar: UnsignedInteger> {
+    pub decomp_base_log: DecompositionBaseLog,
+    pub decomp_level_count: DecompositionLevelCount,
+    pub input_lwe_size: LweSize,
+    pub output_glwe_size: GlweSize,
+    pub output_polynomial_size: PolynomialSize,
+    pub ciphertext_modulus: CiphertextModulus<Scalar>,
+}
 
 impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> CreateFrom<C>
     for LwePrivateFunctionalPackingKeyswitchKeyList<C>
@@ -415,14 +415,14 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> CreateFrom<C>
 
     #[inline]
     fn create_from(from: C, meta: Self::Metadata) -> Self {
-        let LwePrivateFunctionalPackingKeyswitchKeyListCreationMetadata(
+        let LwePrivateFunctionalPackingKeyswitchKeyListCreationMetadata {
             decomp_base_log,
             decomp_level_count,
             input_lwe_size,
             output_glwe_size,
             output_polynomial_size,
             ciphertext_modulus,
-        ) = meta;
+        } = meta;
         Self::from_container(
             from,
             decomp_base_log,
@@ -455,13 +455,13 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> ContiguousEntityCo
         Self: 'this;
 
     fn get_entity_view_creation_metadata(&self) -> Self::EntityViewMetadata {
-        LwePrivateFunctionalPackingKeyswitchKeyCreationMetadata(
-            self.decomposition_base_log(),
-            self.decomposition_level_count(),
-            self.output_glwe_size(),
-            self.output_polynomial_size(),
-            self.ciphertext_modulus(),
-        )
+        LwePrivateFunctionalPackingKeyswitchKeyCreationMetadata {
+            decomp_base_log: self.decomposition_base_log(),
+            decomp_level_count: self.decomposition_level_count(),
+            output_glwe_size: self.output_glwe_size(),
+            output_polynomial_size: self.output_polynomial_size(),
+            ciphertext_modulus: self.ciphertext_modulus(),
+        }
     }
 
     fn get_entity_view_pod_size(&self) -> usize {
@@ -469,14 +469,14 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> ContiguousEntityCo
     }
 
     fn get_self_view_creation_metadata(&self) -> Self::SelfViewMetadata {
-        LwePrivateFunctionalPackingKeyswitchKeyListCreationMetadata(
-            self.decomposition_base_log(),
-            self.decomposition_level_count(),
-            self.input_lwe_size(),
-            self.output_glwe_size(),
-            self.output_polynomial_size(),
-            self.ciphertext_modulus(),
-        )
+        LwePrivateFunctionalPackingKeyswitchKeyListCreationMetadata {
+            decomp_base_log: self.decomposition_base_log(),
+            decomp_level_count: self.decomposition_level_count(),
+            input_lwe_size: self.input_lwe_size(),
+            output_glwe_size: self.output_glwe_size(),
+            output_polynomial_size: self.output_polynomial_size(),
+            ciphertext_modulus: self.ciphertext_modulus(),
+        }
     }
 }
 

--- a/tfhe/src/core_crypto/entities/polynomial.rs
+++ b/tfhe/src/core_crypto/entities/polynomial.rs
@@ -150,7 +150,7 @@ where
 
 /// Metadata used in the [`CreateFrom`] implementation to create [`Polynomial`] entities.
 #[derive(Clone, Copy)]
-pub struct PolynomialCreationMetadata();
+pub struct PolynomialCreationMetadata {}
 
 impl<C: Container> CreateFrom<C> for Polynomial<C> {
     type Metadata = PolynomialCreationMetadata;

--- a/tfhe/src/core_crypto/entities/polynomial_list.rs
+++ b/tfhe/src/core_crypto/entities/polynomial_list.rs
@@ -137,14 +137,16 @@ impl<Scalar: Copy> PolynomialListOwned<Scalar> {
 
 /// Metadata used in the [`CreateFrom`] implementation to create [`PolynomialList`] entities.
 #[derive(Clone, Copy)]
-pub struct PolynomialListCreationMetadata(pub PolynomialSize);
+pub struct PolynomialListCreationMetadata {
+    pub polynomial_size: PolynomialSize,
+}
 
 impl<C: Container> CreateFrom<C> for PolynomialList<C> {
     type Metadata = PolynomialListCreationMetadata;
 
     #[inline]
     fn create_from(from: C, meta: Self::Metadata) -> Self {
-        let PolynomialListCreationMetadata(polynomial_size) = meta;
+        let PolynomialListCreationMetadata { polynomial_size } = meta;
         Self::from_container(from, polynomial_size)
     }
 }
@@ -165,7 +167,7 @@ impl<C: Container> ContiguousEntityContainer for PolynomialList<C> {
         Self: 'this;
 
     fn get_entity_view_creation_metadata(&self) -> Self::EntityViewMetadata {
-        PolynomialCreationMetadata()
+        PolynomialCreationMetadata {}
     }
 
     fn get_entity_view_pod_size(&self) -> usize {
@@ -173,7 +175,9 @@ impl<C: Container> ContiguousEntityContainer for PolynomialList<C> {
     }
 
     fn get_self_view_creation_metadata(&self) -> Self::SelfViewMetadata {
-        PolynomialListCreationMetadata(self.polynomial_size())
+        PolynomialListCreationMetadata {
+            polynomial_size: self.polynomial_size(),
+        }
     }
 }
 

--- a/tfhe/src/core_crypto/entities/seeded_ggsw_ciphertext.rs
+++ b/tfhe/src/core_crypto/entities/seeded_ggsw_ciphertext.rs
@@ -446,13 +446,13 @@ impl<Scalar: UnsignedInteger> SeededGgswCiphertextOwned<Scalar> {
 
 /// Metadata used in the [`CreateFrom`] implementation to create [`SeededGgswCiphertext`] entities.
 #[derive(Clone, Copy)]
-pub struct SeededGgswCiphertextCreationMetadata<Scalar: UnsignedInteger>(
-    pub GlweSize,
-    pub PolynomialSize,
-    pub DecompositionBaseLog,
-    pub CompressionSeed,
-    pub CiphertextModulus<Scalar>,
-);
+pub struct SeededGgswCiphertextCreationMetadata<Scalar: UnsignedInteger> {
+    pub glwe_size: GlweSize,
+    pub polynomial_size: PolynomialSize,
+    pub decomp_base_log: DecompositionBaseLog,
+    pub compression_seed: CompressionSeed,
+    pub ciphertext_modulus: CiphertextModulus<Scalar>,
+}
 
 impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> CreateFrom<C>
     for SeededGgswCiphertext<C>
@@ -461,13 +461,13 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> CreateFrom<C>
 
     #[inline]
     fn create_from(from: C, meta: Self::Metadata) -> Self {
-        let SeededGgswCiphertextCreationMetadata(
+        let SeededGgswCiphertextCreationMetadata {
             glwe_size,
             polynomial_size,
             decomp_base_log,
             compression_seed,
             ciphertext_modulus,
-        ) = meta;
+        } = meta;
         Self::from_container(
             from,
             glwe_size,
@@ -649,12 +649,12 @@ impl<Scalar: UnsignedInteger, C: ContainerMut<Element = Scalar>> SeededGgswLevel
 
 /// Metadata used in the [`CreateFrom`] implementation to create [`SeededGgswLevelMatrix`] entities.
 #[derive(Clone, Copy)]
-pub struct SeededGgswLevelMatrixCreationMetadata<Scalar: UnsignedInteger>(
-    pub GlweSize,
-    pub PolynomialSize,
-    pub CompressionSeed,
-    pub CiphertextModulus<Scalar>,
-);
+pub struct SeededGgswLevelMatrixCreationMetadata<Scalar: UnsignedInteger> {
+    pub glwe_size: GlweSize,
+    pub polynomial_size: PolynomialSize,
+    pub compression_seed: CompressionSeed,
+    pub ciphertext_modulus: CiphertextModulus<Scalar>,
+}
 
 impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> CreateFrom<C>
     for SeededGgswLevelMatrix<C>
@@ -663,12 +663,12 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> CreateFrom<C>
 
     #[inline]
     fn create_from(from: C, meta: Self::Metadata) -> Self {
-        let SeededGgswLevelMatrixCreationMetadata(
+        let SeededGgswLevelMatrixCreationMetadata {
             glwe_size,
             polynomial_size,
             compression_seed,
             ciphertext_modulus,
-        ) = meta;
+        } = meta;
         Self::from_container(
             from,
             glwe_size,
@@ -697,12 +697,12 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> ContiguousEntityCo
         Self: 'this;
 
     fn get_entity_view_creation_metadata(&self) -> Self::EntityViewMetadata {
-        SeededGgswLevelMatrixCreationMetadata(
-            self.glwe_size,
-            self.polynomial_size,
-            self.compression_seed,
-            self.ciphertext_modulus,
-        )
+        SeededGgswLevelMatrixCreationMetadata {
+            glwe_size: self.glwe_size,
+            polynomial_size: self.polynomial_size,
+            compression_seed: self.compression_seed,
+            ciphertext_modulus: self.ciphertext_modulus,
+        }
     }
 
     fn get_entity_view_pod_size(&self) -> usize {

--- a/tfhe/src/core_crypto/entities/seeded_ggsw_ciphertext_list.rs
+++ b/tfhe/src/core_crypto/entities/seeded_ggsw_ciphertext_list.rs
@@ -370,14 +370,14 @@ impl<Scalar: UnsignedInteger> SeededGgswCiphertextListOwned<Scalar> {
 /// Metadata used in the [`CreateFrom`] implementation to create [`SeededGgswCiphertextList`]
 /// entities.
 #[derive(Clone, Copy)]
-pub struct SeededGgswCiphertextListCreationMetadata<Scalar: UnsignedInteger>(
-    pub GlweSize,
-    pub PolynomialSize,
-    pub DecompositionBaseLog,
-    pub DecompositionLevelCount,
-    pub CompressionSeed,
-    pub CiphertextModulus<Scalar>,
-);
+pub struct SeededGgswCiphertextListCreationMetadata<Scalar: UnsignedInteger> {
+    pub glwe_size: GlweSize,
+    pub polynomial_size: PolynomialSize,
+    pub decomp_base_log: DecompositionBaseLog,
+    pub decomp_level_count: DecompositionLevelCount,
+    pub compression_seed: CompressionSeed,
+    pub ciphertext_modulus: CiphertextModulus<Scalar>,
+}
 
 impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> CreateFrom<C>
     for SeededGgswCiphertextList<C>
@@ -386,14 +386,14 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> CreateFrom<C>
 
     #[inline]
     fn create_from(from: C, meta: Self::Metadata) -> Self {
-        let SeededGgswCiphertextListCreationMetadata(
+        let SeededGgswCiphertextListCreationMetadata {
             glwe_size,
             polynomial_size,
             decomp_base_log,
             decomp_level_count,
             compression_seed,
             ciphertext_modulus,
-        ) = meta;
+        } = meta;
         Self::from_container(
             from,
             glwe_size,
@@ -424,13 +424,13 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> ContiguousEntityCo
         Self: 'this;
 
     fn get_entity_view_creation_metadata(&self) -> Self::EntityViewMetadata {
-        SeededGgswCiphertextCreationMetadata(
-            self.glwe_size,
-            self.polynomial_size,
-            self.decomp_base_log,
-            self.compression_seed,
-            self.ciphertext_modulus,
-        )
+        SeededGgswCiphertextCreationMetadata {
+            glwe_size: self.glwe_size,
+            polynomial_size: self.polynomial_size,
+            decomp_base_log: self.decomp_base_log,
+            compression_seed: self.compression_seed,
+            ciphertext_modulus: self.ciphertext_modulus,
+        }
     }
 
     fn get_entity_view_pod_size(&self) -> usize {
@@ -444,14 +444,14 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> ContiguousEntityCo
     /// Unimplemented for [`SeededGgswCiphertextList`]. At the moment it does not make sense to
     /// return "sub" seeded lists.
     fn get_self_view_creation_metadata(&self) -> Self::SelfViewMetadata {
-        SeededGgswCiphertextListCreationMetadata(
-            self.glwe_size,
-            self.polynomial_size,
-            self.decomp_base_log,
-            self.decomp_level_count,
-            self.compression_seed,
-            self.ciphertext_modulus,
-        )
+        SeededGgswCiphertextListCreationMetadata {
+            glwe_size: self.glwe_size,
+            polynomial_size: self.polynomial_size,
+            decomp_base_log: self.decomp_base_log,
+            decomp_level_count: self.decomp_level_count,
+            compression_seed: self.compression_seed,
+            ciphertext_modulus: self.ciphertext_modulus,
+        }
     }
 }
 

--- a/tfhe/src/core_crypto/entities/seeded_glwe_ciphertext.rs
+++ b/tfhe/src/core_crypto/entities/seeded_glwe_ciphertext.rs
@@ -275,11 +275,11 @@ impl<Scalar: UnsignedInteger> SeededGlweCiphertextOwned<Scalar> {
 
 /// Metadata used in the [`CreateFrom`] implementation to create [`SeededGlweCiphertext`] entities.
 #[derive(Clone, Copy)]
-pub struct SeededGlweCiphertextCreationMetadata<Scalar: UnsignedInteger>(
-    pub GlweSize,
-    pub CompressionSeed,
-    pub CiphertextModulus<Scalar>,
-);
+pub struct SeededGlweCiphertextCreationMetadata<Scalar: UnsignedInteger> {
+    pub glwe_size: GlweSize,
+    pub compression_seed: CompressionSeed,
+    pub ciphertext_modulus: CiphertextModulus<Scalar>,
+}
 
 impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> CreateFrom<C>
     for SeededGlweCiphertext<C>
@@ -288,8 +288,11 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> CreateFrom<C>
 
     #[inline]
     fn create_from(from: C, meta: Self::Metadata) -> Self {
-        let SeededGlweCiphertextCreationMetadata(glwe_size, compression_seed, ciphertext_modulus) =
-            meta;
+        let SeededGlweCiphertextCreationMetadata {
+            glwe_size,
+            compression_seed,
+            ciphertext_modulus,
+        } = meta;
         Self::from_container(from, glwe_size, compression_seed, ciphertext_modulus)
     }
 }

--- a/tfhe/src/core_crypto/entities/seeded_glwe_ciphertext_list.rs
+++ b/tfhe/src/core_crypto/entities/seeded_glwe_ciphertext_list.rs
@@ -265,12 +265,12 @@ impl<Scalar: UnsignedInteger> SeededGlweCiphertextListOwned<Scalar> {
 /// Metadata used in the [`CreateFrom`] implementation to create [`SeededGlweCiphertextList`]
 /// entities.
 #[derive(Clone, Copy)]
-pub struct SeededGlweCiphertextListCreationMetadata<Scalar: UnsignedInteger>(
-    pub GlweSize,
-    pub PolynomialSize,
-    pub CompressionSeed,
-    pub CiphertextModulus<Scalar>,
-);
+pub struct SeededGlweCiphertextListCreationMetadata<Scalar: UnsignedInteger> {
+    pub glwe_size: GlweSize,
+    pub polynomial_size: PolynomialSize,
+    pub compression_seed: CompressionSeed,
+    pub ciphertext_modulus: CiphertextModulus<Scalar>,
+}
 
 impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> CreateFrom<C>
     for SeededGlweCiphertextList<C>
@@ -279,13 +279,19 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> CreateFrom<C>
 
     #[inline]
     fn create_from(from: C, meta: Self::Metadata) -> Self {
-        let SeededGlweCiphertextListCreationMetadata(
+        let SeededGlweCiphertextListCreationMetadata {
             glwe_size,
             polynomial_size,
             compression_seed,
-            modulus,
-        ) = meta;
-        Self::from_container(from, glwe_size, polynomial_size, compression_seed, modulus)
+            ciphertext_modulus,
+        } = meta;
+        Self::from_container(
+            from,
+            glwe_size,
+            polynomial_size,
+            compression_seed,
+            ciphertext_modulus,
+        )
     }
 }
 
@@ -307,11 +313,11 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> ContiguousEntityCo
         Self: 'this;
 
     fn get_entity_view_creation_metadata(&self) -> Self::EntityViewMetadata {
-        SeededGlweCiphertextCreationMetadata(
-            self.glwe_size(),
-            self.compression_seed(),
-            self.ciphertext_modulus(),
-        )
+        SeededGlweCiphertextCreationMetadata {
+            glwe_size: self.glwe_size(),
+            compression_seed: self.compression_seed(),
+            ciphertext_modulus: self.ciphertext_modulus(),
+        }
     }
 
     fn get_entity_view_pod_size(&self) -> usize {

--- a/tfhe/src/core_crypto/entities/seeded_lwe_ciphertext_list.rs
+++ b/tfhe/src/core_crypto/entities/seeded_lwe_ciphertext_list.rs
@@ -303,11 +303,11 @@ impl<Scalar: UnsignedInteger> SeededLweCiphertextListOwned<Scalar> {
 /// Metadata used in the [`CreateFrom`] implementation to create [`SeededLweCiphertextList`]
 /// entities.
 #[derive(Clone, Copy)]
-pub struct SeededLweCiphertextListCreationMetadata<Scalar: UnsignedInteger>(
-    pub LweSize,
-    pub CompressionSeed,
-    pub CiphertextModulus<Scalar>,
-);
+pub struct SeededLweCiphertextListCreationMetadata<Scalar: UnsignedInteger> {
+    pub lwe_size: LweSize,
+    pub compression_seed: CompressionSeed,
+    pub ciphertext_modulus: CiphertextModulus<Scalar>,
+}
 
 impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> CreateFrom<C>
     for SeededLweCiphertextList<C>
@@ -316,8 +316,12 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> CreateFrom<C>
 
     #[inline]
     fn create_from(from: C, meta: Self::Metadata) -> Self {
-        let SeededLweCiphertextListCreationMetadata(lwe_size, compression_seed, modulus) = meta;
-        Self::from_container(from, lwe_size, compression_seed, modulus)
+        let SeededLweCiphertextListCreationMetadata {
+            lwe_size,
+            compression_seed,
+            ciphertext_modulus,
+        } = meta;
+        Self::from_container(from, lwe_size, compression_seed, ciphertext_modulus)
     }
 }
 
@@ -339,7 +343,9 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> ContiguousEntityCo
         Self: 'this;
 
     fn get_entity_view_creation_metadata(&self) -> Self::EntityViewMetadata {
-        LweBodyCreationMetadata(self.ciphertext_modulus())
+        LweBodyCreationMetadata {
+            ciphertext_modulus: self.ciphertext_modulus(),
+        }
     }
 
     fn get_entity_view_pod_size(&self) -> usize {

--- a/tfhe/src/core_crypto/entities/seeded_lwe_keyswitch_key.rs
+++ b/tfhe/src/core_crypto/entities/seeded_lwe_keyswitch_key.rs
@@ -386,11 +386,11 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> ContiguousEntityCo
     fn get_entity_view_creation_metadata(
         &self,
     ) -> SeededLweCiphertextListCreationMetadata<Self::Element> {
-        SeededLweCiphertextListCreationMetadata(
-            self.output_lwe_size(),
-            self.compression_seed(),
-            self.ciphertext_modulus(),
-        )
+        SeededLweCiphertextListCreationMetadata {
+            lwe_size: self.output_lwe_size(),
+            compression_seed: self.compression_seed(),
+            ciphertext_modulus: self.ciphertext_modulus(),
+        }
     }
 
     fn get_entity_view_pod_size(&self) -> usize {

--- a/tfhe/src/core_crypto/entities/seeded_lwe_packing_keyswitch_key.rs
+++ b/tfhe/src/core_crypto/entities/seeded_lwe_packing_keyswitch_key.rs
@@ -421,12 +421,12 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> ContiguousEntityCo
     fn get_entity_view_creation_metadata(
         &self,
     ) -> SeededGlweCiphertextListCreationMetadata<Self::Element> {
-        SeededGlweCiphertextListCreationMetadata(
-            self.output_glwe_size(),
-            self.output_polynomial_size(),
-            self.compression_seed(),
-            self.ciphertext_modulus(),
-        )
+        SeededGlweCiphertextListCreationMetadata {
+            glwe_size: self.output_glwe_size(),
+            polynomial_size: self.output_polynomial_size(),
+            compression_seed: self.compression_seed(),
+            ciphertext_modulus: self.ciphertext_modulus(),
+        }
     }
 
     fn get_entity_view_pod_size(&self) -> usize {

--- a/tfhe/src/core_crypto/experimental/entities/pseudo_ggsw_ciphertext.rs
+++ b/tfhe/src/core_crypto/experimental/entities/pseudo_ggsw_ciphertext.rs
@@ -17,8 +17,8 @@ where
     C::Element: UnsignedInteger,
 {
     data: C,
-    glwe_size_in: GlweSize,
-    glwe_size_out: GlweSize,
+    input_glwe_size: GlweSize,
+    output_glwe_size: GlweSize,
     polynomial_size: PolynomialSize,
     decomp_base_log: DecompositionBaseLog,
     ciphertext_modulus: CiphertextModulus<C::Element>,
@@ -39,23 +39,23 @@ impl<T: UnsignedInteger, C: ContainerMut<Element = T>> AsMut<[T]> for PseudoGgsw
 /// Return the number of elements in a [`PseudoGgswCiphertext`] given a [`GlweSize`],
 /// [`PolynomialSize`] and [`DecompositionLevelCount`].
 pub fn pseudo_ggsw_ciphertext_size(
-    glwe_size_in: GlweSize,
-    glwe_size_out: GlweSize,
+    input_glwe_size: GlweSize,
+    output_glwe_size: GlweSize,
     polynomial_size: PolynomialSize,
     decomp_level_count: DecompositionLevelCount,
 ) -> usize {
     decomp_level_count.0
-        * pseudo_ggsw_level_matrix_size(glwe_size_in, glwe_size_out, polynomial_size)
+        * pseudo_ggsw_level_matrix_size(input_glwe_size, output_glwe_size, polynomial_size)
 }
 
 /// Return the number of elements in a [`GgswLevelMatrix`] given a [`GlweSize`] and
 /// [`PolynomialSize`].
 pub fn pseudo_ggsw_level_matrix_size(
-    glwe_size_in: GlweSize,
-    glwe_size_out: GlweSize,
+    input_glwe_size: GlweSize,
+    output_glwe_size: GlweSize,
     polynomial_size: PolynomialSize,
 ) -> usize {
-    glwe_size_in.to_glwe_dimension().0 * glwe_size_out.0 * polynomial_size.0
+    input_glwe_size.to_glwe_dimension().0 * output_glwe_size.0 * polynomial_size.0
 }
 
 /// Return the number of mask samples used during encryption of a [`PseudoGgswCiphertext`] given an
@@ -204,8 +204,8 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> PseudoGgswCipherte
     /// // DISCLAIMER: these toy example parameters are not guaranteed to be secure or yield correct
     /// // computations
     /// // Define parameters for PseudoGgswCiphertext creation
-    /// let glwe_size_in = GlweSize(2);
-    /// let glwe_size_out = GlweSize(3);
+    /// let input_glwe_size = GlweSize(2);
+    /// let output_glwe_size = GlweSize(3);
     /// let polynomial_size = PolynomialSize(1024);
     /// let decomp_base_log = DecompositionBaseLog(8);
     /// let decomp_level_count = DecompositionLevelCount(3);
@@ -214,23 +214,23 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> PseudoGgswCipherte
     /// // Create a new PseudoGgswCiphertext
     /// let ggsw = PseudoGgswCiphertext::new(
     ///     0u64,
-    ///     glwe_size_in,
-    ///     glwe_size_out,
+    ///     input_glwe_size,
+    ///     output_glwe_size,
     ///     polynomial_size,
     ///     decomp_base_log,
     ///     decomp_level_count,
     ///     ciphertext_modulus,
     /// );
     ///
-    /// assert_eq!(ggsw.glwe_size_in(), glwe_size_in);
-    /// assert_eq!(ggsw.glwe_size_out(), glwe_size_out);
+    /// assert_eq!(ggsw.input_glwe_size(), input_glwe_size);
+    /// assert_eq!(ggsw.output_glwe_size(), output_glwe_size);
     /// assert_eq!(ggsw.polynomial_size(), polynomial_size);
     /// assert_eq!(ggsw.decomposition_base_log(), decomp_base_log);
     /// assert_eq!(ggsw.decomposition_level_count(), decomp_level_count);
     /// assert_eq!(ggsw.ciphertext_modulus(), ciphertext_modulus);
     /// assert_eq!(
     ///     ggsw.pseudo_ggsw_level_matrix_size(),
-    ///     pseudo_ggsw_level_matrix_size(glwe_size_in, glwe_size_out, polynomial_size)
+    ///     pseudo_ggsw_level_matrix_size(input_glwe_size, output_glwe_size, polynomial_size)
     /// );
     ///
     /// // Demonstrate how to recover the allocated container
@@ -239,28 +239,28 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> PseudoGgswCipherte
     /// // Recreate a ciphertext using from_container
     /// let ggsw = PseudoGgswCiphertext::from_container(
     ///     underlying_container,
-    ///     glwe_size_in,
-    ///     glwe_size_out,
+    ///     input_glwe_size,
+    ///     output_glwe_size,
     ///     polynomial_size,
     ///     decomp_base_log,
     ///     ciphertext_modulus,
     /// );
     ///
-    /// assert_eq!(ggsw.glwe_size_in(), glwe_size_in);
-    /// assert_eq!(ggsw.glwe_size_out(), glwe_size_out);
+    /// assert_eq!(ggsw.input_glwe_size(), input_glwe_size);
+    /// assert_eq!(ggsw.output_glwe_size(), output_glwe_size);
     /// assert_eq!(ggsw.polynomial_size(), polynomial_size);
     /// assert_eq!(ggsw.decomposition_base_log(), decomp_base_log);
     /// assert_eq!(ggsw.decomposition_level_count(), decomp_level_count);
     /// assert_eq!(ggsw.ciphertext_modulus(), ciphertext_modulus);
     /// assert_eq!(
     ///     ggsw.pseudo_ggsw_level_matrix_size(),
-    ///     pseudo_ggsw_level_matrix_size(glwe_size_in, glwe_size_out, polynomial_size)
+    ///     pseudo_ggsw_level_matrix_size(input_glwe_size, output_glwe_size, polynomial_size)
     /// );
     /// ```
     pub fn from_container(
         container: C,
-        glwe_size_in: GlweSize,
-        glwe_size_out: GlweSize,
+        input_glwe_size: GlweSize,
+        output_glwe_size: GlweSize,
         polynomial_size: PolynomialSize,
         decomp_base_log: DecompositionBaseLog,
         ciphertext_modulus: CiphertextModulus<C::Element>,
@@ -271,22 +271,22 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> PseudoGgswCipherte
         );
         assert!(
             container.container_len()
-                % (glwe_size_in.to_glwe_dimension().0 * glwe_size_out.0 * polynomial_size.0)
+                % (input_glwe_size.to_glwe_dimension().0 * output_glwe_size.0 * polynomial_size.0)
                 == 0,
             "The provided container length is not valid. \
-        It needs to be dividable by glwe_dimension_in * glwe_size_out * polynomial_size: {}. \
-        Got container length: {} and glwe_dimension_in: {:?}, glwe_size_out: \
-        {glwe_size_out:?}\
+        It needs to be dividable by glwe_dimension_in * output_glwe_size * polynomial_size: {}. \
+        Got container length: {} and glwe_dimension_in: {:?}, output_glwe_size: \
+        {output_glwe_size:?}\
         polynomial_size: {polynomial_size:?}.",
-            glwe_size_in.0 * glwe_size_out.0 * polynomial_size.0,
+            input_glwe_size.0 * output_glwe_size.0 * polynomial_size.0,
             container.container_len(),
-            glwe_size_in.to_glwe_dimension()
+            input_glwe_size.to_glwe_dimension()
         );
 
         Self {
             data: container,
-            glwe_size_in,
-            glwe_size_out,
+            input_glwe_size,
+            output_glwe_size,
             polynomial_size,
             decomp_base_log,
             ciphertext_modulus,
@@ -303,15 +303,15 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> PseudoGgswCipherte
     /// Return the [`GlweSize`] of the [`PseudoGgswCiphertext`].
     ///
     /// See [`PseudoGgswCiphertext::from_container`] for usage.
-    pub fn glwe_size_in(&self) -> GlweSize {
-        self.glwe_size_in
+    pub fn input_glwe_size(&self) -> GlweSize {
+        self.input_glwe_size
     }
 
     /// Return the [`GlweSize`] of the [`PseudoGgswCiphertext`].
     ///
     /// See [`PseudoGgswCiphertext::from_container`] for usage.
-    pub fn glwe_size_out(&self) -> GlweSize {
-        self.glwe_size_out
+    pub fn output_glwe_size(&self) -> GlweSize {
+        self.output_glwe_size
     }
 
     /// Return the [`DecompositionBaseLog`] of the [`PseudoGgswCiphertext`].
@@ -341,7 +341,11 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> PseudoGgswCipherte
     /// See [`PseudoGgswCiphertext::from_container`] for usage.
     pub fn pseudo_ggsw_level_matrix_size(&self) -> usize {
         // GlweSize GlweCiphertext(glwe_size, polynomial_size) per level
-        pseudo_ggsw_level_matrix_size(self.glwe_size_in, self.glwe_size_out, self.polynomial_size)
+        pseudo_ggsw_level_matrix_size(
+            self.input_glwe_size,
+            self.output_glwe_size,
+            self.polynomial_size,
+        )
     }
 
     /// Interpret the [`PseudoGgswCiphertext`] as a [`PolynomialList`].
@@ -353,7 +357,7 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> PseudoGgswCipherte
     pub fn as_glwe_list(&self) -> GlweCiphertextListView<'_, Scalar> {
         GlweCiphertextListView::from_container(
             self.as_ref(),
-            self.glwe_size_out,
+            self.output_glwe_size,
             self.polynomial_size,
             self.ciphertext_modulus,
         )
@@ -364,8 +368,8 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> PseudoGgswCipherte
     pub fn as_view(&self) -> PseudoGgswCiphertextView<'_, Scalar> {
         PseudoGgswCiphertextView::from_container(
             self.as_ref(),
-            self.glwe_size_in(),
-            self.glwe_size_out(),
+            self.input_glwe_size(),
+            self.output_glwe_size(),
             self.polynomial_size(),
             self.decomposition_base_log(),
             self.ciphertext_modulus(),
@@ -391,8 +395,8 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> PseudoGgswCipherte
             + RandomGenerable<NoiseDistribution, CustomModulus = Scalar>,
     {
         pseudo_ggsw_ciphertext_encryption_fork_config(
-            self.glwe_size_in(),
-            self.glwe_size_out(),
+            self.input_glwe_size(),
+            self.output_glwe_size(),
             self.polynomial_size(),
             self.decomposition_level_count(),
             mask_distribution,
@@ -412,11 +416,11 @@ impl<Scalar: UnsignedInteger, C: ContainerMut<Element = Scalar>> PseudoGgswCiphe
     /// Mutable variant of [`PseudoGgswCiphertext::as_glwe_list`].
     pub fn as_mut_glwe_list(&mut self) -> GlweCiphertextListMutView<'_, Scalar> {
         let polynomial_size = self.polynomial_size;
-        let glwe_size_out = self.glwe_size_out;
+        let output_glwe_size = self.output_glwe_size;
         let ciphertext_modulus = self.ciphertext_modulus;
         GlweCiphertextListMutView::from_container(
             self.as_mut(),
-            glwe_size_out,
+            output_glwe_size,
             polynomial_size,
             ciphertext_modulus,
         )
@@ -424,15 +428,15 @@ impl<Scalar: UnsignedInteger, C: ContainerMut<Element = Scalar>> PseudoGgswCiphe
 
     /// Mutable variant of [`PseudoGgswCiphertext::as_view`].
     pub fn as_mut_view(&mut self) -> PseudoGgswCiphertextMutView<'_, Scalar> {
-        let glwe_size_in = self.glwe_size_in();
-        let glwe_size_out = self.glwe_size_out();
+        let input_glwe_size = self.input_glwe_size();
+        let output_glwe_size = self.output_glwe_size();
         let polynomial_size = self.polynomial_size();
         let decomp_base_log = self.decomposition_base_log();
         let ciphertext_modulus = self.ciphertext_modulus;
         PseudoGgswCiphertextMutView::from_container(
             self.as_mut(),
-            glwe_size_in,
-            glwe_size_out,
+            input_glwe_size,
+            output_glwe_size,
             polynomial_size,
             decomp_base_log,
             ciphertext_modulus,
@@ -461,8 +465,8 @@ impl<Scalar: UnsignedInteger> PseudoGgswCiphertextOwned<Scalar> {
     /// See [`PseudoGgswCiphertext::from_container`] for usage.
     pub fn new(
         fill_with: Scalar,
-        glwe_size_in: GlweSize,
-        glwe_size_out: GlweSize,
+        input_glwe_size: GlweSize,
+        output_glwe_size: GlweSize,
         polynomial_size: PolynomialSize,
         decomp_base_log: DecompositionBaseLog,
         decomp_level_count: DecompositionLevelCount,
@@ -472,14 +476,14 @@ impl<Scalar: UnsignedInteger> PseudoGgswCiphertextOwned<Scalar> {
             vec![
                 fill_with;
                 pseudo_ggsw_ciphertext_size(
-                    glwe_size_in,
-                    glwe_size_out,
+                    input_glwe_size,
+                    output_glwe_size,
                     polynomial_size,
                     decomp_level_count
                 )
             ],
-            glwe_size_in,
-            glwe_size_out,
+            input_glwe_size,
+            output_glwe_size,
             polynomial_size,
             decomp_base_log,
             ciphertext_modulus,
@@ -489,13 +493,13 @@ impl<Scalar: UnsignedInteger> PseudoGgswCiphertextOwned<Scalar> {
 
 /// Metadata used in the [`CreateFrom`] implementation to create [`PseudoGgswCiphertext`] entities.
 #[derive(Clone, Copy)]
-pub struct PseudoGgswCiphertextCreationMetadata<Scalar: UnsignedInteger>(
-    pub GlweSize,
-    pub GlweSize,
-    pub PolynomialSize,
-    pub DecompositionBaseLog,
-    pub CiphertextModulus<Scalar>,
-);
+pub struct PseudoGgswCiphertextCreationMetadata<Scalar: UnsignedInteger> {
+    pub input_glwe_size: GlweSize,
+    pub output_glwe_size: GlweSize,
+    pub polynomial_size: PolynomialSize,
+    pub decomp_base_log: DecompositionBaseLog,
+    pub ciphertext_modulus: CiphertextModulus<Scalar>,
+}
 
 impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> CreateFrom<C>
     for PseudoGgswCiphertext<C>
@@ -504,17 +508,17 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> CreateFrom<C>
 
     #[inline]
     fn create_from(from: C, meta: Self::Metadata) -> Self {
-        let PseudoGgswCiphertextCreationMetadata(
-            glwe_size_in,
-            glwe_size_out,
+        let PseudoGgswCiphertextCreationMetadata {
+            input_glwe_size,
+            output_glwe_size,
             polynomial_size,
             decomp_base_log,
             ciphertext_modulus,
-        ) = meta;
+        } = meta;
         Self::from_container(
             from,
-            glwe_size_in,
-            glwe_size_out,
+            input_glwe_size,
+            output_glwe_size,
             polynomial_size,
             decomp_base_log,
             ciphertext_modulus,
@@ -528,8 +532,8 @@ where
     C::Element: UnsignedInteger,
 {
     data: C,
-    glwe_size_in: GlweSize,
-    glwe_size_out: GlweSize,
+    input_glwe_size: GlweSize,
+    output_glwe_size: GlweSize,
     polynomial_size: PolynomialSize,
     ciphertext_modulus: CiphertextModulus<C::Element>,
 }
@@ -548,48 +552,55 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> PseudoGgswLevelMat
     /// // DISCLAIMER: these toy example parameters are not guaranteed to be secure or yield correct
     /// // computations
     /// // Define parameters for GgswLevelMatrix creation
-    /// let glwe_size_in = GlweSize(3);
-    /// let glwe_size_out = GlweSize(2);
+    /// let input_glwe_size = GlweSize(3);
+    /// let output_glwe_size = GlweSize(2);
     /// let polynomial_size = PolynomialSize(1024);
     /// let ciphertext_modulus = CiphertextModulus::new_native();
     ///
     /// let container =
-    ///     vec![0u64; pseudo_ggsw_level_matrix_size(glwe_size_in, glwe_size_out, polynomial_size)];
+    ///     vec![
+    ///         0u64;
+    ///         pseudo_ggsw_level_matrix_size(input_glwe_size, output_glwe_size, polynomial_size)
+    ///     ];
     ///
     /// // Create a new GgswLevelMatrix
     /// let ggsw_level_matrix = PseudoGgswLevelMatrix::from_container(
     ///     container,
-    ///     glwe_size_in,
-    ///     glwe_size_out,
+    ///     input_glwe_size,
+    ///     output_glwe_size,
     ///     polynomial_size,
     ///     ciphertext_modulus,
     /// );
     ///
-    /// assert_eq!(ggsw_level_matrix.glwe_size_in(), glwe_size_in);
-    /// assert_eq!(ggsw_level_matrix.glwe_size_out(), glwe_size_out);
+    /// assert_eq!(ggsw_level_matrix.input_glwe_size(), input_glwe_size);
+    /// assert_eq!(ggsw_level_matrix.output_glwe_size(), output_glwe_size);
     /// assert_eq!(ggsw_level_matrix.polynomial_size(), polynomial_size);
     /// assert_eq!(ggsw_level_matrix.ciphertext_modulus(), ciphertext_modulus);
     /// ```
     pub fn from_container(
         container: C,
-        glwe_size_in: GlweSize,
-        glwe_size_out: GlweSize,
+        input_glwe_size: GlweSize,
+        output_glwe_size: GlweSize,
         polynomial_size: PolynomialSize,
         ciphertext_modulus: CiphertextModulus<C::Element>,
     ) -> Self {
         assert!(
             container.container_len()
-                == pseudo_ggsw_level_matrix_size(glwe_size_in, glwe_size_out, polynomial_size),
+                == pseudo_ggsw_level_matrix_size(
+                    input_glwe_size,
+                    output_glwe_size,
+                    polynomial_size
+                ),
             "The provided container length is not valid. \
             Expected length of {} (glwe_size * glwe_size * polynomial_size), got {}",
-            pseudo_ggsw_level_matrix_size(glwe_size_in, glwe_size_out, polynomial_size),
+            pseudo_ggsw_level_matrix_size(input_glwe_size, output_glwe_size, polynomial_size),
             container.container_len(),
         );
 
         Self {
             data: container,
-            glwe_size_in,
-            glwe_size_out,
+            input_glwe_size,
+            output_glwe_size,
             polynomial_size,
             ciphertext_modulus,
         }
@@ -598,12 +609,12 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> PseudoGgswLevelMat
     /// Return the [`GlweSize`] of the [`GgswLevelMatrix`].
     ///
     /// See [`GgswLevelMatrix::from_container`] for usage.
-    pub fn glwe_size_in(&self) -> GlweSize {
-        self.glwe_size_in
+    pub fn input_glwe_size(&self) -> GlweSize {
+        self.input_glwe_size
     }
 
-    pub fn glwe_size_out(&self) -> GlweSize {
-        self.glwe_size_out
+    pub fn output_glwe_size(&self) -> GlweSize {
+        self.output_glwe_size
     }
 
     /// Return the [`PolynomialSize`] of the [`GgswLevelMatrix`].
@@ -624,7 +635,7 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> PseudoGgswLevelMat
     pub fn as_glwe_list(&self) -> GlweCiphertextListView<'_, C::Element> {
         GlweCiphertextListView::from_container(
             self.data.as_ref(),
-            self.glwe_size_out,
+            self.output_glwe_size,
             self.polynomial_size,
             self.ciphertext_modulus,
         )
@@ -642,8 +653,8 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> PseudoGgswLevelMat
             + RandomGenerable<NoiseDistribution, CustomModulus = Scalar>,
     {
         pseudo_ggsw_level_matrix_encryption_fork_config(
-            self.glwe_size_in(),
-            self.glwe_size_out(),
+            self.input_glwe_size(),
+            self.output_glwe_size(),
             self.polynomial_size(),
             mask_distribution,
             noise_distribution,
@@ -657,7 +668,7 @@ impl<Scalar: UnsignedInteger, C: ContainerMut<Element = Scalar>> PseudoGgswLevel
     pub fn as_mut_glwe_list(&mut self) -> GlweCiphertextListMutView<'_, C::Element> {
         GlweCiphertextListMutView::from_container(
             self.data.as_mut(),
-            self.glwe_size_out,
+            self.output_glwe_size,
             self.polynomial_size,
             self.ciphertext_modulus,
         )
@@ -666,12 +677,12 @@ impl<Scalar: UnsignedInteger, C: ContainerMut<Element = Scalar>> PseudoGgswLevel
 
 /// Metadata used in the [`CreateFrom`] implementation to create [`GgswLevelMatrix`] entities.
 #[derive(Clone, Copy)]
-pub struct PseudoGgswLevelMatrixCreationMetadata<Scalar: UnsignedInteger>(
-    pub GlweSize,
-    pub GlweSize,
-    pub PolynomialSize,
-    pub CiphertextModulus<Scalar>,
-);
+pub struct PseudoGgswLevelMatrixCreationMetadata<Scalar: UnsignedInteger> {
+    pub input_glwe_size: GlweSize,
+    pub output_glwe_size: GlweSize,
+    pub polynomial_size: PolynomialSize,
+    pub ciphertext_modulus: CiphertextModulus<Scalar>,
+}
 
 impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> CreateFrom<C>
     for PseudoGgswLevelMatrix<C>
@@ -680,16 +691,16 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> CreateFrom<C>
 
     #[inline]
     fn create_from(from: C, meta: Self::Metadata) -> Self {
-        let PseudoGgswLevelMatrixCreationMetadata(
-            glwe_size_in,
-            glwe_size_out,
+        let PseudoGgswLevelMatrixCreationMetadata {
+            input_glwe_size,
+            output_glwe_size,
             polynomial_size,
             ciphertext_modulus,
-        ) = meta;
+        } = meta;
         Self::from_container(
             from,
-            glwe_size_in,
-            glwe_size_out,
+            input_glwe_size,
+            output_glwe_size,
             polynomial_size,
             ciphertext_modulus,
         )
@@ -714,12 +725,12 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> ContiguousEntityCo
         Self: 'this;
 
     fn get_entity_view_creation_metadata(&self) -> Self::EntityViewMetadata {
-        PseudoGgswLevelMatrixCreationMetadata(
-            self.glwe_size_in,
-            self.glwe_size_out,
-            self.polynomial_size,
-            self.ciphertext_modulus,
-        )
+        PseudoGgswLevelMatrixCreationMetadata {
+            input_glwe_size: self.input_glwe_size,
+            output_glwe_size: self.output_glwe_size,
+            polynomial_size: self.polynomial_size,
+            ciphertext_modulus: self.ciphertext_modulus,
+        }
     }
 
     fn get_entity_view_pod_size(&self) -> usize {


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: https://github.com/zama-ai/tfhe-rs-internal/issues/194

### PR content/description

Metadata for container implementations were tuple structs but it could be unclear what value should be provided, changed all tuple metadata to structs with named fields.
