### PR TITLE
chore(zk): bump version to 0.2.1 for perf patch release

### DIFF
--- a/tfhe-zk-pok/Cargo.toml
+++ b/tfhe-zk-pok/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tfhe-zk-pok"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 keywords = ["zero", "knowledge", "proof", "vector-commitments"]
 homepage = "https://zama.ai/"


### PR DESCRIPTION
Sarah pushed some code improvements for the ZKs for performance, we can release a 0.2.1 to benefit from it in the 0.7.0 release