### PR TITLE
chore(ci): reduce ci duration by not running 4_4 parameters set

### DIFF
--- a/.github/workflows/aws_tfhe_integer_tests.yml
+++ b/.github/workflows/aws_tfhe_integer_tests.yml
@@ -13,12 +13,19 @@ env:
   # We clear the cache to reduce memory pressure because of the numerous processes of cargo
   # nextest
   TFHE_RS_CLEAR_IN_MEMORY_KEY_CACHE: "1"
+  NO_BIG_PARAMS: FALSE
 
 on:
   # Allows you to run this workflow manually from the Actions tab as an alternative.
   workflow_dispatch:
   pull_request:
     types: [ labeled ]
+  push:
+    branches:
+      - main
+  schedule:
+    # Nightly tests @ 3AM after each work day
+    - cron: "0 3 * * MON-FRI"
 
 jobs:
   setup-instance:
@@ -61,6 +68,11 @@ jobs:
         with:
           toolchain: stable
 
+      - name: Should skip big parameters set
+        if: github.event_name == 'pull_request'
+        run: |
+          echo "NO_BIG_PARAMS=TRUE" >> "${GITHUB_ENV}"
+
       - name: Gen Keys if required
         run: |
           make GEN_KEY_CACHE_MULTI_BIT_ONLY=TRUE gen_key_cache
@@ -75,7 +87,7 @@ jobs:
 
       - name: Run unsigned integer tests
         run: |
-          AVX512_SUPPORT=ON BIG_TESTS_INSTANCE=TRUE make test_unsigned_integer_ci
+          AVX512_SUPPORT=ON NO_BIG_PARAMS=${{ env.NO_BIG_PARAMS }} BIG_TESTS_INSTANCE=TRUE make test_unsigned_integer_ci
 
       - name: Slack Notification
         if: ${{ always() }}

--- a/.github/workflows/aws_tfhe_signed_integer_tests.yml
+++ b/.github/workflows/aws_tfhe_signed_integer_tests.yml
@@ -13,12 +13,19 @@ env:
   # We clear the cache to reduce memory pressure because of the numerous processes of cargo
   # nextest
   TFHE_RS_CLEAR_IN_MEMORY_KEY_CACHE: "1"
+  NO_BIG_PARAMS: FALSE
 
 on:
   # Allows you to run this workflow manually from the Actions tab as an alternative.
   workflow_dispatch:
   pull_request:
     types: [ labeled ]
+  push:
+    branches:
+      - main
+  schedule:
+    # Nightly tests @ 3AM after each work day
+    - cron: "0 3 * * MON-FRI"
 
 jobs:
   setup-instance:
@@ -61,6 +68,11 @@ jobs:
         with:
           toolchain: stable
 
+      - name: Should skip big parameters set
+        if: github.event_name == 'pull_request'
+        run: |
+          echo "NO_BIG_PARAMS=TRUE" >> "${GITHUB_ENV}"
+
       - name: Gen Keys if required
         run: |
           make GEN_KEY_CACHE_MULTI_BIT_ONLY=TRUE gen_key_cache
@@ -79,7 +91,7 @@ jobs:
 
       - name: Run signed integer tests
         run: |
-          AVX512_SUPPORT=ON BIG_TESTS_INSTANCE=TRUE make test_signed_integer_ci
+          AVX512_SUPPORT=ON NO_BIG_PARAMS=${{ env.NO_BIG_PARAMS }} BIG_TESTS_INSTANCE=TRUE make test_signed_integer_ci
 
       - name: Slack Notification
         if: ${{ always() }}

--- a/scripts/integer-tests.sh
+++ b/scripts/integer-tests.sh
@@ -21,6 +21,7 @@ RUST_TOOLCHAIN="+stable"
 multi_bit_argument=
 sign_argument=
 fast_tests_argument=
+no_big_params_argument=
 cargo_profile="release"
 backend="cpu"
 gpu_feature=""
@@ -89,6 +90,10 @@ if [[ "${FAST_TESTS}" == TRUE ]]; then
     fast_tests_argument=--fast-tests
 fi
 
+if [[ "${NO_BIG_PARAMS}" == TRUE ]]; then
+    no_big_params_argument=--no-big-params
+fi
+
 if [[ "${backend}" == "gpu" ]]; then
     gpu_feature="gpu"
 fi
@@ -117,7 +122,7 @@ else
     doctest_threads="${num_cpu_threads}"
 fi
 
-filter_expression=$(/usr/bin/python3 scripts/test_filtering.py --layer integer --backend "${backend}" ${fast_tests_argument} ${multi_bit_argument} ${sign_argument})
+filter_expression=$(/usr/bin/python3 scripts/test_filtering.py --layer integer --backend "${backend}" ${fast_tests_argument} ${multi_bit_argument} ${sign_argument} ${no_big_params_argument})
 
 if [[ "${FAST_TESTS}" == "TRUE" ]]; then
     echo "Running 'fast' test set'"

--- a/scripts/test_filtering.py
+++ b/scripts/test_filtering.py
@@ -49,6 +49,12 @@ parser.add_argument(
     action="store_true",
     help="Include only unsigned integer tests",
 )
+parser.add_argument(
+    "--no-big-params",
+    dest="no_big_params",
+    action="store_true",
+    help="Do not run tests with big parameters set (e.g. 4bits message with 4 bits carry)",
+)
 
 # block PBS are too slow for high params
 # mul_crt_4_4 is extremely flaky (~80% failure)
@@ -77,6 +83,9 @@ EXCLUDED_INTEGER_FAST_TESTS = [
     "/.*default_add_sequence_multi_thread_param_message_3_carry_3_ks_pbs$/",
 ]
 
+EXCLUDED_BIG_PARAMETERS = [
+    "/.*_param_message_4_carry_4_ks_pbs$/",
+]
 
 def filter_integer_tests(input_args):
     multi_bit_filter = "_multi_bit" if input_args.multi_bit else ""
@@ -95,6 +104,10 @@ def filter_integer_tests(input_args):
         filter_expression.append("test(~_signed)")
     if input_args.unsigned_only:
         filter_expression.append("not test(~_signed)")
+
+    if input_args.no_big_params:
+        for pattern in EXCLUDED_BIG_PARAMETERS:
+            filter_expression.append(f"not test({pattern})")
 
     if input_args.fast_tests:
         # Test only fast default operations with only two set of parameters


### PR DESCRIPTION
This only apply for CI triggered in pull-request.
A nightly run is added that run 4bits message/4bits carry parameters set.