### PR TITLE
refactor(gpu): start releasing memory before cleanup in scalar mul

### DIFF
--- a/backends/tfhe-cuda-backend/cuda/include/integer.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer.h
@@ -3010,9 +3010,7 @@ template <typename Torus> struct int_scalar_mul_buffer {
 
   void release(cudaStream_t *streams, uint32_t *gpu_indexes,
                uint32_t gpu_count) {
-    logical_scalar_shift_buffer->release(streams, gpu_indexes, gpu_count);
     sum_ciphertexts_vec_mem->release(streams, gpu_indexes, gpu_count);
-    cuda_drop_async(preshifted_buffer, streams[0], gpu_indexes[0]);
     cuda_drop_async(all_shifted_buffer, streams[0], gpu_indexes[0]);
   }
 };

--- a/backends/tfhe-cuda-backend/cuda/src/integer/scalar_mul.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/scalar_mul.cuh
@@ -108,6 +108,10 @@ __host__ void host_integer_scalar_mul_radix(
     }
   }
 
+  cuda_drop_async(preshifted_buffer, streams[0], gpu_indexes[0]);
+  mem->logical_scalar_shift_buffer->release(streams, gpu_indexes, gpu_count);
+  delete (mem->logical_scalar_shift_buffer);
+
   if (j == 0) {
     // lwe array = 0
     cuda_memset_async(lwe_array, 0, num_radix_blocks * lwe_size_bytes,


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description

In this PR I break the pattern to cleanup data in the cleanup function for scalar mul, because this function requires a lot of memory and we end up with out of memory errors in the 4090 benchmarks. I don't see how to reuse memory for sum_ciphertexts_vec in scalar_mul, contrarily to mul, so that's why I chose to release some memory early for this one.

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
