### PR TITLE
Am/refactor/better compressed pk

### DIFF
--- a/tfhe/src/core_crypto/commons/generators/secret.rs
+++ b/tfhe/src/core_crypto/commons/generators/secret.rs
@@ -25,4 +25,11 @@ impl<G: ByteRandomGenerator> SecretRandomGenerator<G> {
     {
         self.0.fill_slice_with_random_uniform_binary(slice);
     }
+
+    pub(crate) fn generate_random_uniform_binary<Scalar>(&mut self) -> Scalar
+    where
+        Scalar: RandomGenerable<UniformBinary>,
+    {
+        self.0.random_uniform_binary()
+    }
 }

--- a/tfhe/src/integer/block_decomposition.rs
+++ b/tfhe/src/integer/block_decomposition.rs
@@ -183,7 +183,9 @@ impl<T> BlockDecomposer<T>
 where
     T: Decomposable,
 {
-    pub fn iter_as<V>(self) -> impl Iterator<Item = V>
+    // We concretize the iterator type to allow usage of callbacks working on iterator for generic
+    // integer encryption
+    pub fn iter_as<V>(self) -> std::iter::Map<Self, fn(T) -> V>
     where
         V: Numeric,
         T: CastInto<V>,

--- a/tfhe/src/integer/client_key/mod.rs
+++ b/tfhe/src/integer/client_key/mod.rs
@@ -643,9 +643,11 @@ impl ClientKey {
     /// assert_eq!(msg, dec);
     /// ```
     pub fn encrypt_native_crt(&self, message: u64, base_vec: Vec<u64>) -> CrtCiphertext {
-        self.encrypt_crt_impl(message, base_vec, |cks, msg, moduli| {
-            cks.encrypt_native_crt(msg, moduli.0 as u8)
-        })
+        self.encrypt_crt_impl(
+            message,
+            base_vec,
+            crate::shortint::ClientKey::encrypt_native_crt,
+        )
     }
 
     pub fn encrypt_native_crt_compressed(
@@ -653,9 +655,11 @@ impl ClientKey {
         message: u64,
         base_vec: Vec<u64>,
     ) -> CompressedCrtCiphertext {
-        self.encrypt_crt_impl(message, base_vec, |cks, msg, moduli| {
-            cks.encrypt_native_crt_compressed(msg, moduli.0 as u8)
-        })
+        self.encrypt_crt_impl(
+            message,
+            base_vec,
+            crate::shortint::ClientKey::encrypt_native_crt_compressed,
+        )
     }
 
     /// Decrypts a ciphertext encrypting an integer message with some moduli basis without
@@ -684,7 +688,10 @@ impl ClientKey {
         //Decrypting each block individually
         for (c_i, b_i) in ct.blocks.iter().zip(ct.moduli.iter()) {
             //decrypt the component i of the integer and multiply it by the radix product
-            val.push(self.key.decrypt_message_native_crt(c_i, *b_i as u8));
+            val.push(
+                self.key
+                    .decrypt_message_native_crt(c_i, MessageModulus(*b_i as usize)),
+            );
         }
 
         //Computing the inverse CRT to recompose the message

--- a/tfhe/src/integer/public_key/compressed.rs
+++ b/tfhe/src/integer/public_key/compressed.rs
@@ -44,9 +44,11 @@ impl CompressedPublicKey {
     }
 
     pub fn encrypt_native_crt(&self, message: u64, base_vec: Vec<u64>) -> CrtCiphertext {
-        self.encrypt_crt_impl(message, base_vec, |cks, msg, moduli| {
-            cks.encrypt_native_crt(msg, moduli.0 as u8)
-        })
+        self.encrypt_crt_impl(
+            message,
+            base_vec,
+            crate::shortint::CompressedPublicKey::encrypt_native_crt,
+        )
     }
 
     fn encrypt_crt_impl<Block, CrtCiphertextType, F>(

--- a/tfhe/src/integer/public_key/standard.rs
+++ b/tfhe/src/integer/public_key/standard.rs
@@ -47,9 +47,11 @@ impl PublicKey {
     }
 
     pub fn encrypt_native_crt(&self, message: u64, base_vec: Vec<u64>) -> CrtCiphertext {
-        self.encrypt_crt_impl(message, base_vec, |cks, msg, moduli| {
-            cks.encrypt_native_crt(msg, moduli.0 as u8)
-        })
+        self.encrypt_crt_impl(
+            message,
+            base_vec,
+            crate::shortint::PublicKey::encrypt_native_crt,
+        )
     }
 
     fn encrypt_crt_impl<Block, CrtCiphertextType, F>(

--- a/tfhe/src/shortint/client_key/mod.rs
+++ b/tfhe/src/shortint/client_key/mod.rs
@@ -607,23 +607,23 @@ impl ClientKey {
     /// # Example
     ///
     /// ```rust
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    /// use tfhe::shortint::parameters::{MessageModulus, PARAM_MESSAGE_2_CARRY_2_KS_PBS};
     /// use tfhe::shortint::ClientKey;
     ///
     /// // Generate the client key
     /// let cks = ClientKey::new(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
     ///
     /// let msg = 2;
-    /// let modulus = 3;
+    /// let modulus = MessageModulus(3);
     ///
     /// // Encryption of one message:
     /// let ct = cks.encrypt_native_crt(msg, modulus);
     ///
     /// // Decryption:
     /// let dec = cks.decrypt_message_native_crt(&ct, modulus);
-    /// assert_eq!(msg, dec % modulus as u64);
+    /// assert_eq!(msg, dec % modulus.0 as u64);
     /// ```
-    pub fn encrypt_native_crt(&self, message: u64, message_modulus: u8) -> Ciphertext {
+    pub fn encrypt_native_crt(&self, message: u64, message_modulus: MessageModulus) -> Ciphertext {
         ShortintEngine::with_thread_local_mut(|engine| {
             engine.encrypt_native_crt(self, message, message_modulus)
         })
@@ -637,14 +637,14 @@ impl ClientKey {
     /// # Example
     ///
     /// ```rust
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    /// use tfhe::shortint::parameters::{MessageModulus, PARAM_MESSAGE_2_CARRY_2_KS_PBS};
     /// use tfhe::shortint::ClientKey;
     ///
     /// // Generate the client key
     /// let cks = ClientKey::new(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
     ///
     /// let msg = 2;
-    /// let modulus = 3;
+    /// let modulus = MessageModulus(3);
     ///
     /// // Encryption of one message:
     /// let ct = cks.encrypt_native_crt_compressed(msg, modulus);
@@ -653,12 +653,12 @@ impl ClientKey {
     ///
     /// // Decryption:
     /// let dec = cks.decrypt_message_native_crt(&ct, modulus);
-    /// assert_eq!(msg, dec % modulus as u64);
+    /// assert_eq!(msg, dec % modulus.0 as u64);
     /// ```
     pub fn encrypt_native_crt_compressed(
         &self,
         message: u64,
-        message_modulus: u8,
+        message_modulus: MessageModulus,
     ) -> CompressedCiphertext {
         ShortintEngine::with_thread_local_mut(|engine| {
             engine.encrypt_native_crt_compressed(self, message, message_modulus)
@@ -672,7 +672,7 @@ impl ClientKey {
     ///
     /// ```rust
     /// use tfhe::shortint::parameters::{
-    ///     PARAM_MESSAGE_2_CARRY_2_KS_PBS, PARAM_MESSAGE_2_CARRY_2_PBS_KS,
+    ///     MessageModulus, PARAM_MESSAGE_2_CARRY_2_KS_PBS, PARAM_MESSAGE_2_CARRY_2_PBS_KS,
     /// };
     /// use tfhe::shortint::ClientKey;
     ///
@@ -680,14 +680,14 @@ impl ClientKey {
     /// let cks = ClientKey::new(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
     ///
     /// let msg = 1;
-    /// let modulus = 3;
+    /// let modulus = MessageModulus(3);
     ///
     /// // Encryption of one message:
     /// let ct = cks.encrypt_native_crt(msg, modulus);
     ///
     /// // Decryption:
     /// let dec = cks.decrypt_message_native_crt(&ct, modulus);
-    /// assert_eq!(msg, dec % modulus as u64);
+    /// assert_eq!(msg, dec % modulus.0 as u64);
     ///
     /// // Generate the client key
     /// let cks = ClientKey::new(PARAM_MESSAGE_2_CARRY_2_PBS_KS);
@@ -697,10 +697,14 @@ impl ClientKey {
     ///
     /// // Decryption:
     /// let dec = cks.decrypt_message_native_crt(&ct, modulus);
-    /// assert_eq!(msg, dec % modulus as u64);
+    /// assert_eq!(msg, dec % modulus.0 as u64);
     /// ```
-    pub fn decrypt_message_native_crt(&self, ct: &Ciphertext, basis: u8) -> u64 {
-        let basis = basis as u64;
+    pub fn decrypt_message_native_crt(
+        &self,
+        ct: &Ciphertext,
+        message_modulus: MessageModulus,
+    ) -> u64 {
+        let basis = message_modulus.0 as u64;
 
         let decrypted_u64: u64 = self.decrypt_no_decode(ct);
 

--- a/tfhe/src/shortint/engine/client_side.rs
+++ b/tfhe/src/shortint/engine/client_side.rs
@@ -320,11 +320,11 @@ impl ShortintEngine {
         &mut self,
         client_key: &ClientKey,
         message: u64,
-        message_modulus: u8,
+        message_modulus: MessageModulus,
     ) -> Ciphertext {
-        let carry_modulus = 1;
-        let m = (message % message_modulus as u64) as u128;
-        let shifted_message = (m * (1 << 64) / message_modulus as u128) as u64;
+        let carry_modulus = CarryModulus(1);
+        let m = (message % message_modulus.0 as u64) as u128;
+        let shifted_message = (m * (1 << 64) / message_modulus.0 as u128) as u64;
 
         let encoded = Plaintext(shifted_message);
 
@@ -343,10 +343,10 @@ impl ShortintEngine {
 
         Ciphertext::new(
             ct,
-            Degree::new(message_modulus as usize - 1),
+            Degree::new(message_modulus.0 - 1),
             NoiseLevel::NOMINAL,
-            MessageModulus(message_modulus as usize),
-            CarryModulus(carry_modulus),
+            message_modulus,
+            carry_modulus,
             params_op_order,
         )
     }
@@ -355,11 +355,11 @@ impl ShortintEngine {
         &mut self,
         client_key: &ClientKey,
         message: u64,
-        message_modulus: u8,
+        message_modulus: MessageModulus,
     ) -> CompressedCiphertext {
-        let carry_modulus = 1;
-        let m = (message % message_modulus as u64) as u128;
-        let shifted_message = (m * (1 << 64) / message_modulus as u128) as u64;
+        let carry_modulus = CarryModulus(1);
+        let m = (message % message_modulus.0 as u64) as u128;
+        let shifted_message = (m * (1 << 64) / message_modulus.0 as u128) as u64;
 
         let encoded = Plaintext(shifted_message);
 
@@ -378,9 +378,9 @@ impl ShortintEngine {
 
         CompressedCiphertext {
             ct,
-            degree: Degree::new(message_modulus as usize - 1),
-            message_modulus: MessageModulus(message_modulus as usize),
-            carry_modulus: CarryModulus(carry_modulus),
+            degree: Degree::new(message_modulus.0 - 1),
+            message_modulus,
+            carry_modulus,
             pbs_order: params_op_order,
             noise_level: NoiseLevel::NOMINAL,
         }

--- a/tfhe/src/shortint/engine/public_side.rs
+++ b/tfhe/src/shortint/engine/public_side.rs
@@ -292,11 +292,11 @@ impl ShortintEngine {
         &mut self,
         public_key: &PublicKey,
         message: u64,
-        message_modulus: u8,
+        message_modulus: MessageModulus,
     ) -> Ciphertext {
-        let carry_modulus = 1;
-        let m = (message % message_modulus as u64) as u128;
-        let shifted_message = m * (1 << 64) / message_modulus as u128;
+        let carry_modulus = CarryModulus(1);
+        let m = (message % message_modulus.0 as u64) as u128;
+        let shifted_message = m * (1 << 64) / message_modulus.0 as u128;
         // encode the message
 
         let plain = Plaintext(shifted_message as u64);
@@ -317,10 +317,10 @@ impl ShortintEngine {
 
         Ciphertext::new(
             encrypted_ct,
-            Degree::new(message_modulus as usize - 1),
+            Degree::new(message_modulus.0 - 1),
             NoiseLevel::NOMINAL,
-            MessageModulus(message_modulus as usize),
-            CarryModulus(carry_modulus),
+            message_modulus,
+            carry_modulus,
             public_key.pbs_order,
         )
     }
@@ -329,11 +329,11 @@ impl ShortintEngine {
         &mut self,
         public_key: &CompressedPublicKey,
         message: u64,
-        message_modulus: u8,
+        message_modulus: MessageModulus,
     ) -> Ciphertext {
-        let carry_modulus = 1;
-        let m = (message % message_modulus as u64) as u128;
-        let shifted_message = m * (1 << 64) / message_modulus as u128;
+        let carry_modulus = CarryModulus(1);
+        let m = (message % message_modulus.0 as u64) as u128;
+        let shifted_message = m * (1 << 64) / message_modulus.0 as u128;
         // encode the message
 
         let plain = Plaintext(shifted_message as u64);
@@ -354,10 +354,10 @@ impl ShortintEngine {
 
         Ciphertext::new(
             encrypted_ct,
-            Degree::new(message_modulus as usize - 1),
+            Degree::new(message_modulus.0 - 1),
             NoiseLevel::NOMINAL,
-            MessageModulus(message_modulus as usize),
-            CarryModulus(carry_modulus),
+            message_modulus,
+            carry_modulus,
             public_key.pbs_order,
         )
     }

--- a/tfhe/src/shortint/public_key/compressed.rs
+++ b/tfhe/src/shortint/public_key/compressed.rs
@@ -129,6 +129,13 @@ impl CompressedPublicKey {
         })
     }
 
+    /// [`Self::encrypt`] variant that can encrypt many messages efficiently at the same time.
+    pub fn encrypt_many(&self, messages: impl Iterator<Item = u64>) -> Vec<Ciphertext> {
+        ShortintEngine::with_thread_local_mut(|engine| {
+            engine.encrypt_many_ciphertexts_with_compressed_public_key(self, messages)
+        })
+    }
+
     /// Encrypts a small integer message using the client key with a specific message modulus
     ///
     /// # Example
@@ -161,6 +168,22 @@ impl CompressedPublicKey {
                 self,
                 message,
                 message_modulus,
+            )
+        })
+    }
+
+    /// [`Self::encrypt_with_message_modulus`] variant that can encrypt a message under several
+    /// moduli efficiently at the same time.
+    pub fn encrypt_with_many_message_moduli(
+        &self,
+        message: u64,
+        message_moduli: impl Iterator<Item = MessageModulus>,
+    ) -> Vec<Ciphertext> {
+        ShortintEngine::with_thread_local_mut(|engine| {
+            engine.encrypt_with_many_message_moduli_and_compressed_public_key(
+                self,
+                message,
+                message_moduli,
             )
         })
     }
@@ -222,6 +245,18 @@ impl CompressedPublicKey {
         })
     }
 
+    /// [`Self::encrypt_without_padding`] variant that can encrypt many messages efficiently at the
+    /// same time.
+    pub fn encrypt_many_without_padding(
+        &self,
+        messages: impl Iterator<Item = u64>,
+    ) -> Vec<Ciphertext> {
+        ShortintEngine::with_thread_local_mut(|engine| {
+            engine
+                .encrypt_many_ciphertexts_without_padding_with_compressed_public_key(self, messages)
+        })
+    }
+
     /// Encrypts a small integer message using the client key without padding bit with some modulus.
     /// The input message is reduced to the encrypted message space modulus
     ///
@@ -249,6 +284,22 @@ impl CompressedPublicKey {
     pub fn encrypt_native_crt(&self, message: u64, message_modulus: MessageModulus) -> Ciphertext {
         ShortintEngine::with_thread_local_mut(|engine| {
             engine.encrypt_native_crt_with_compressed_public_key(self, message, message_modulus)
+        })
+    }
+
+    /// [`Self::encrypt_native_crt`] variant that can encrypt a message under several moduli
+    /// efficiently at the same time.
+    pub fn encrypt_native_crt_with_many_message_moduli(
+        &self,
+        message: u64,
+        message_modulus: impl Iterator<Item = MessageModulus>,
+    ) -> Vec<Ciphertext> {
+        ShortintEngine::with_thread_local_mut(|engine| {
+            engine.encrypt_native_crt_with_many_message_moduli_and_compressed_public_key(
+                self,
+                message,
+                message_modulus,
+            )
         })
     }
 }

--- a/tfhe/src/shortint/public_key/compressed.rs
+++ b/tfhe/src/shortint/public_key/compressed.rs
@@ -228,7 +228,7 @@ impl CompressedPublicKey {
     /// # Example
     ///
     /// ```rust
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    /// use tfhe::shortint::parameters::{MessageModulus, PARAM_MESSAGE_2_CARRY_2_KS_PBS};
     /// use tfhe::shortint::{ClientKey, CompressedPublicKey};
     ///
     /// // Generate the client key:
@@ -237,9 +237,16 @@ impl CompressedPublicKey {
     /// let pk = CompressedPublicKey::new(&cks);
     ///
     /// let msg = 2;
-    /// let modulus = 3;
+    /// let modulus = MessageModulus(3);
+    ///
+    /// // Encryption of one message:
+    /// let ct = pk.encrypt_native_crt(msg, modulus);
+    ///
+    /// // Decryption:
+    /// let dec = cks.decrypt_message_native_crt(&ct, modulus);
+    /// assert_eq!(msg, dec % modulus.0 as u64);
     /// ```
-    pub fn encrypt_native_crt(&self, message: u64, message_modulus: u8) -> Ciphertext {
+    pub fn encrypt_native_crt(&self, message: u64, message_modulus: MessageModulus) -> Ciphertext {
         ShortintEngine::with_thread_local_mut(|engine| {
             engine.encrypt_native_crt_with_compressed_public_key(self, message, message_modulus)
         })

--- a/tfhe/src/shortint/public_key/standard.rs
+++ b/tfhe/src/shortint/public_key/standard.rs
@@ -225,7 +225,7 @@ impl PublicKey {
     /// # Example
     ///
     /// ```rust
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    /// use tfhe::shortint::parameters::{MessageModulus, PARAM_MESSAGE_2_CARRY_2_KS_PBS};
     /// use tfhe::shortint::{ClientKey, PublicKey};
     ///
     /// // Generate the client key:
@@ -234,16 +234,16 @@ impl PublicKey {
     /// let pk = PublicKey::new(&cks);
     ///
     /// let msg = 2;
-    /// let modulus = 3;
+    /// let modulus = MessageModulus(3);
     ///
     /// // Encryption of one message:
     /// let ct = pk.encrypt_native_crt(msg, modulus);
     ///
     /// // Decryption:
     /// let dec = cks.decrypt_message_native_crt(&ct, modulus);
-    /// assert_eq!(msg, dec % modulus as u64);
+    /// assert_eq!(msg, dec % modulus.0 as u64);
     /// ```
-    pub fn encrypt_native_crt(&self, message: u64, message_modulus: u8) -> Ciphertext {
+    pub fn encrypt_native_crt(&self, message: u64, message_modulus: MessageModulus) -> Ciphertext {
         ShortintEngine::with_thread_local_mut(|engine| {
             engine.encrypt_native_crt_with_public_key(self, message, message_modulus)
         })

--- a/tfhe/src/shortint/wopbs/mod.rs
+++ b/tfhe/src/shortint/wopbs/mod.rs
@@ -405,17 +405,18 @@ impl WopbsKey {
     /// use tfhe::shortint::gen_keys;
     /// use tfhe::shortint::parameters::parameters_wopbs_message_carry::WOPBS_PARAM_MESSAGE_3_CARRY_3_KS_PBS;
     /// use tfhe::shortint::wopbs::WopbsKey;
+    /// use tfhe::shortint::parameters::MessageModulus;
     ///
     /// // Generate the client key and the server key:
     /// let (cks, sks) = gen_keys(WOPBS_PARAM_MESSAGE_3_CARRY_3_KS_PBS);
     /// let wopbs_key = WopbsKey::new_wopbs_key_only_for_wopbs(&cks, &sks);
-    /// let message_modulus = 5;
+    /// let message_modulus = MessageModulus(5);
     /// let m = 2;
     /// let ct = cks.encrypt_native_crt(m, message_modulus);
-    /// let lut = wopbs_key.generate_lut_native_crt(&ct, |x| x * x % message_modulus as u64);
+    /// let lut = wopbs_key.generate_lut_native_crt(&ct, |x| x * x % message_modulus.0 as u64);
     /// let ct_res = wopbs_key.programmable_bootstrapping_native_crt(&ct, &lut);
     /// let res = cks.decrypt_message_native_crt(&ct_res, message_modulus);
-    /// assert_eq!(res, (m * m) % message_modulus as u64);
+    /// assert_eq!(res, (m * m) % message_modulus.0 as u64);
     /// ```
     pub fn generate_lut_native_crt<F>(&self, ct: &Ciphertext, f: F) -> ShortintWopbsLUT
     where
@@ -567,12 +568,13 @@ impl WopbsKey {
     /// ```rust
     /// use tfhe::shortint::gen_keys;
     /// use tfhe::shortint::parameters::parameters_wopbs_message_carry::WOPBS_PARAM_MESSAGE_3_CARRY_3_KS_PBS;
+    /// use tfhe::shortint::parameters::MessageModulus;
     /// use tfhe::shortint::wopbs::*;
     ///
     /// let (cks, sks) = gen_keys(WOPBS_PARAM_MESSAGE_3_CARRY_3_KS_PBS);
     /// let wopbs_key = WopbsKey::new_wopbs_key_only_for_wopbs(&cks, &sks);
     /// let msg = 2;
-    /// let modulus = 5;
+    /// let modulus = MessageModulus(5);
     /// let ct = cks.encrypt_native_crt(msg, modulus);
     /// let lut = wopbs_key.generate_lut_native_crt(&ct, |x| x);
     /// let ct_res = wopbs_key.programmable_bootstrapping_native_crt(&ct, &lut);

--- a/tfhe/src/shortint/wopbs/test.rs
+++ b/tfhe/src/shortint/wopbs/test.rs
@@ -196,11 +196,11 @@ fn generate_lut_modulus_not_power_of_two(params: WopbsParameters) {
         let message_modulus = MessageModulus(params.message_modulus.0 - 1);
 
         let m = rng.gen::<usize>() % message_modulus.0;
-        let ct = cks.encrypt_native_crt(m as u64, message_modulus.0 as u8);
+        let ct = cks.encrypt_native_crt(m as u64, message_modulus);
         let lut = wopbs_key.generate_lut_native_crt(&ct, |x| (x * x) % message_modulus.0 as u64);
 
         let ct_res = wopbs_key.programmable_bootstrapping_native_crt(&ct, &lut);
-        let res = cks.decrypt_message_native_crt(&ct_res, message_modulus.0 as u8);
+        let res = cks.decrypt_message_native_crt(&ct_res, message_modulus);
         assert_eq!(res as usize, (m * m) % message_modulus.0);
     }
 }


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: https://github.com/zama-ai/tfhe-rs-internal/issues/186

### PR content/description

avoids slow tests by decompressing the compressed public key as we go for integers instead of decompressing it for every block
