### PR TITLE
chore(ci): check labels to launch only on approval

### DIFF
--- a/.github/workflows/aws_tfhe_integer_gpu_tests.yml
+++ b/.github/workflows/aws_tfhe_integer_gpu_tests.yml
@@ -25,6 +25,9 @@ jobs:
   setup-instance:
     name: Setup instance (cuda-unsigned-integer-tests)
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' ||
+      github.event.action != 'labeled' ||
+      (github.event.action == 'labeled' && github.event.label.name == 'approved')
     outputs:
       runner-name: ${{ steps.start-instance.outputs.label }}
     steps:

--- a/.github/workflows/aws_tfhe_signed_integer_gpu_tests.yml
+++ b/.github/workflows/aws_tfhe_signed_integer_gpu_tests.yml
@@ -25,6 +25,9 @@ jobs:
   setup-instance:
     name: Setup instance (cuda-signed-integer-tests)
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' ||
+      github.event.action != 'labeled' ||
+      (github.event.action == 'labeled' && github.event.label.name == 'approved')
     outputs:
       runner-name: ${{ steps.start-instance.outputs.label }}
     steps:

--- a/.github/workflows/aws_tfhe_tests.yml
+++ b/.github/workflows/aws_tfhe_tests.yml
@@ -121,7 +121,7 @@ jobs:
   setup-instance:
     name: Setup instance (cpu-tests)
     if: github.event_name != 'pull_request' ||
-      (github.event_name == 'pull_request' && needs.should-run.outputs.any_file_changed == 'true')
+      (github.event.action == 'labeled' && github.event.label.name == 'approved' && needs.should-run.outputs.any_file_changed == 'true')
     needs: should-run
     runs-on: ubuntu-latest
     outputs:


### PR DESCRIPTION
Any other label added other than "approved" would trigger these workflow which is not desired.
