### PR TITLE
chore(gpu): pin host memory before copying to GPU

### DIFF
--- a/backends/tfhe-cuda-backend/cuda/src/device.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/device.cu
@@ -107,9 +107,14 @@ void cuda_memcpy_async_to_gpu(void *dest, void *src, uint64_t size,
     PANIC("Cuda error: invalid device pointer in async copy to GPU.")
   }
 
+  void *pinned_src;
+  cudaMallocHost(&pinned_src, size);
+  memcpy(pinned_src, src, size);
   check_cuda_error(cudaSetDevice(gpu_index));
   check_cuda_error(
-      cudaMemcpyAsync(dest, src, size, cudaMemcpyHostToDevice, stream));
+      cudaMemcpyAsync(dest, pinned_src, size, cudaMemcpyHostToDevice, stream));
+  cuda_synchronize_stream(stream, gpu_index);
+  cudaFreeHost(pinned_src);
 }
 
 /// Copy memory within a GPU asynchronously


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description

With this PR the keyswitch key will be copied asynchronously to all GPUs.

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
