### PR TITLE
refactor(core): make GGSW encryption consistent

### DIFF
--- a/tfhe/src/c_api/core_crypto/mod.rs
+++ b/tfhe/src/c_api/core_crypto/mod.rs
@@ -196,7 +196,7 @@ pub unsafe extern "C" fn core_crypto_lwe_encrypt(
 #[no_mangle]
 pub unsafe extern "C" fn core_crypto_ggsw_encrypt(
     output_ct_ptr: *mut u64,
-    pt: u64,
+    cleartext: u64,
     glwe_sk_ptr: *const u64,
     glwe_sk_dim: usize,
     poly_size: usize,
@@ -225,7 +225,7 @@ pub unsafe extern "C" fn core_crypto_ggsw_encrypt(
             &mut deterministic_seeder,
         );
 
-        let plaintext = Plaintext(pt);
+        let cleartext = Cleartext(cleartext);
         let output_ct = std::slice::from_raw_parts_mut(
             output_ct_ptr,
             ggsw_ciphertext_size(
@@ -248,7 +248,7 @@ pub unsafe extern "C" fn core_crypto_ggsw_encrypt(
         encrypt_constant_ggsw_ciphertext(
             &glwe_sk,
             &mut ct,
-            plaintext,
+            cleartext,
             glwe_noise_distribution,
             &mut encryption_generator,
         );

--- a/tfhe/src/core_crypto/algorithms/ggsw_encryption.rs
+++ b/tfhe/src/core_crypto/algorithms/ggsw_encryption.rs
@@ -21,19 +21,19 @@ pub fn ggsw_encryption_multiplicative_factor<Scalar: UnsignedInteger>(
     ciphertext_modulus: CiphertextModulus<Scalar>,
     decomp_level: DecompositionLevel,
     decomp_base_log: DecompositionBaseLog,
-    encoded: Plaintext<Scalar>,
+    cleartext: Cleartext<Scalar>,
 ) -> Scalar {
     match ciphertext_modulus.kind() {
         CiphertextModulusKind::Other => DecompositionTermNonNative::new(
             decomp_level,
             decomp_base_log,
-            encoded.0.wrapping_neg(),
+            cleartext.0.wrapping_neg(),
             ciphertext_modulus,
         )
         .to_approximate_recomposition_summand(),
         CiphertextModulusKind::Native | CiphertextModulusKind::NonNativePowerOfTwo => {
             let native_decomp_term =
-                DecompositionTerm::new(decomp_level, decomp_base_log, encoded.0.wrapping_neg())
+                DecompositionTerm::new(decomp_level, decomp_base_log, cleartext.0.wrapping_neg())
                     .to_recomposition_summand();
             // We scale the factor down from the native torus to whatever our power of 2 torus is,
             // the encryption process will scale it back up
@@ -77,8 +77,8 @@ pub fn ggsw_encryption_multiplicative_factor<Scalar: UnsignedInteger>(
 ///     &mut secret_generator,
 /// );
 ///
-/// // Create the plaintext
-/// let plaintext = Plaintext(3u64);
+/// // Create the cleartext
+/// let cleartext = Cleartext(3u64);
 ///
 /// // Create a new GgswCiphertext
 /// let mut ggsw = GgswCiphertext::new(
@@ -93,18 +93,18 @@ pub fn ggsw_encryption_multiplicative_factor<Scalar: UnsignedInteger>(
 /// encrypt_constant_ggsw_ciphertext(
 ///     &glwe_secret_key,
 ///     &mut ggsw,
-///     plaintext,
+///     cleartext,
 ///     glwe_noise_distribution,
 ///     &mut encryption_generator,
 /// );
 ///
 /// let decrypted = decrypt_constant_ggsw_ciphertext(&glwe_secret_key, &ggsw);
-/// assert_eq!(decrypted, plaintext);
+/// assert_eq!(decrypted, cleartext);
 /// ```
 pub fn encrypt_constant_ggsw_ciphertext<Scalar, NoiseDistribution, KeyCont, OutputCont, Gen>(
     glwe_secret_key: &GlweSecretKey<KeyCont>,
     output: &mut GgswCiphertext<OutputCont>,
-    encoded: Plaintext<Scalar>,
+    cleartext: Cleartext<Scalar>,
     noise_distribution: NoiseDistribution,
     generator: &mut EncryptionRandomGenerator<Gen>,
 ) where
@@ -146,7 +146,7 @@ pub fn encrypt_constant_ggsw_ciphertext<Scalar, NoiseDistribution, KeyCont, Outp
             ciphertext_modulus,
             decomp_level,
             decomp_base_log,
-            encoded,
+            cleartext,
         );
 
         // We iterate over the rows of the level matrix, the last row needs special treatment
@@ -210,8 +210,8 @@ pub fn encrypt_constant_ggsw_ciphertext<Scalar, NoiseDistribution, KeyCont, Outp
 ///     &mut secret_generator,
 /// );
 ///
-/// // Create the plaintext
-/// let plaintext = Plaintext(3u64);
+/// // Create the cleartext
+/// let cleartext = Cleartext(3u64);
 ///
 /// // Create a new GgswCiphertext
 /// let mut ggsw = GgswCiphertext::new(
@@ -226,18 +226,18 @@ pub fn encrypt_constant_ggsw_ciphertext<Scalar, NoiseDistribution, KeyCont, Outp
 /// par_encrypt_constant_ggsw_ciphertext(
 ///     &glwe_secret_key,
 ///     &mut ggsw,
-///     plaintext,
+///     cleartext,
 ///     glwe_noise_distribution,
 ///     &mut encryption_generator,
 /// );
 ///
 /// let decrypted = decrypt_constant_ggsw_ciphertext(&glwe_secret_key, &ggsw);
-/// assert_eq!(decrypted, plaintext);
+/// assert_eq!(decrypted, cleartext);
 /// ```
 pub fn par_encrypt_constant_ggsw_ciphertext<Scalar, NoiseDistribution, KeyCont, OutputCont, Gen>(
     glwe_secret_key: &GlweSecretKey<KeyCont>,
     output: &mut GgswCiphertext<OutputCont>,
-    encoded: Plaintext<Scalar>,
+    cleartext: Cleartext<Scalar>,
     noise_distribution: NoiseDistribution,
     generator: &mut EncryptionRandomGenerator<Gen>,
 ) where
@@ -278,11 +278,10 @@ pub fn par_encrypt_constant_ggsw_ciphertext<Scalar, NoiseDistribution, KeyCont, 
                 ciphertext_modulus,
                 decomp_level,
                 decomp_base_log,
-                encoded,
+                cleartext,
             );
 
-            // We iterate over the rows of the level matrix, the last row needs special
-            // treatment
+            // We iterate over the rows of the level matrix, the last row needs special treatment
             let gen_iter = generator
                 .par_try_fork_from_config(
                     level_matrix.encryption_fork_config(Uniform, noise_distribution),
@@ -386,7 +385,7 @@ pub fn encrypt_constant_seeded_ggsw_ciphertext_with_existing_generator<
 >(
     glwe_secret_key: &GlweSecretKey<KeyCont>,
     output: &mut SeededGgswCiphertext<OutputCont>,
-    encoded: Plaintext<Scalar>,
+    cleartext: Cleartext<Scalar>,
     noise_distribution: NoiseDistribution,
     generator: &mut EncryptionRandomGenerator<Gen>,
 ) where
@@ -412,7 +411,7 @@ pub fn encrypt_constant_seeded_ggsw_ciphertext_with_existing_generator<
             ciphertext_modulus,
             decomp_level,
             decomp_base_log,
-            encoded,
+            cleartext,
         );
 
         // We iterate over the rows of the level matrix, the last row needs special treatment
@@ -440,7 +439,7 @@ pub fn encrypt_constant_seeded_ggsw_ciphertext_with_existing_generator<
     }
 }
 
-/// Encrypt a plaintext in a [`seeded GGSW ciphertext`](`SeededGgswCiphertext`) in the constant
+/// Encrypt a cleartext in a [`seeded GGSW ciphertext`](`SeededGgswCiphertext`) in the constant
 /// coefficient.
 ///
 /// See the [`formal definition`](`GgswCiphertext#ggsw-encryption`) for the definition of the
@@ -475,9 +474,8 @@ pub fn encrypt_constant_seeded_ggsw_ciphertext_with_existing_generator<
 ///     &mut secret_generator,
 /// );
 ///
-/// // Create the plaintext
-/// let encoded_msg = 3u64 << 60;
-/// let plaintext = Plaintext(encoded_msg);
+/// // Create the cleartext
+/// let cleartext = Cleartext(3u64);
 ///
 /// // Create a new GgswCiphertext
 /// let mut ggsw = SeededGgswCiphertext::new(
@@ -493,10 +491,15 @@ pub fn encrypt_constant_seeded_ggsw_ciphertext_with_existing_generator<
 /// encrypt_constant_seeded_ggsw_ciphertext(
 ///     &glwe_secret_key,
 ///     &mut ggsw,
-///     plaintext,
+///     cleartext,
 ///     glwe_noise_distribution,
 ///     seeder,
 /// );
+///
+/// let ggsw = ggsw.decompress_into_ggsw_ciphertext();
+///
+/// let decrypted = decrypt_constant_ggsw_ciphertext(&glwe_secret_key, &ggsw);
+/// assert_eq!(decrypted, cleartext);
 /// ```
 pub fn encrypt_constant_seeded_ggsw_ciphertext<
     Scalar,
@@ -507,7 +510,7 @@ pub fn encrypt_constant_seeded_ggsw_ciphertext<
 >(
     glwe_secret_key: &GlweSecretKey<KeyCont>,
     output: &mut SeededGgswCiphertext<OutputCont>,
-    encoded: Plaintext<Scalar>,
+    cleartext: Cleartext<Scalar>,
     noise_distribution: NoiseDistribution,
     noise_seeder: &mut NoiseSeeder,
 ) where
@@ -542,7 +545,7 @@ pub fn encrypt_constant_seeded_ggsw_ciphertext<
     encrypt_constant_seeded_ggsw_ciphertext_with_existing_generator(
         glwe_secret_key,
         output,
-        encoded,
+        cleartext,
         noise_distribution,
         &mut generator,
     );
@@ -564,7 +567,7 @@ pub fn par_encrypt_constant_seeded_ggsw_ciphertext_with_existing_generator<
 >(
     glwe_secret_key: &GlweSecretKey<KeyCont>,
     output: &mut SeededGgswCiphertext<OutputCont>,
-    encoded: Plaintext<Scalar>,
+    cleartext: Cleartext<Scalar>,
     noise_distribution: NoiseDistribution,
     generator: &mut EncryptionRandomGenerator<Gen>,
 ) where
@@ -589,7 +592,7 @@ pub fn par_encrypt_constant_seeded_ggsw_ciphertext_with_existing_generator<
                 ciphertext_modulus,
                 decomp_level,
                 decomp_base_log,
-                encoded,
+                cleartext,
             );
 
             // We iterate over the rows of the level matrix, the last row needs special treatment
@@ -656,9 +659,8 @@ pub fn par_encrypt_constant_seeded_ggsw_ciphertext_with_existing_generator<
 ///     &mut secret_generator,
 /// );
 ///
-/// // Create the plaintext
-/// let encoded_msg = 3u64 << 60;
-/// let plaintext = Plaintext(encoded_msg);
+/// // Create the cleartext
+/// let cleartext = Cleartext(3u64);
 ///
 /// // Create a new GgswCiphertext
 /// let mut ggsw = SeededGgswCiphertext::new(
@@ -674,7 +676,7 @@ pub fn par_encrypt_constant_seeded_ggsw_ciphertext_with_existing_generator<
 /// par_encrypt_constant_seeded_ggsw_ciphertext(
 ///     &glwe_secret_key,
 ///     &mut ggsw,
-///     plaintext,
+///     cleartext,
 ///     glwe_noise_distribution,
 ///     seeder,
 /// );
@@ -688,7 +690,7 @@ pub fn par_encrypt_constant_seeded_ggsw_ciphertext<
 >(
     glwe_secret_key: &GlweSecretKey<KeyCont>,
     output: &mut SeededGgswCiphertext<OutputCont>,
-    encoded: Plaintext<Scalar>,
+    cleartext: Cleartext<Scalar>,
     noise_distribution: NoiseDistribution,
     noise_seeder: &mut NoiseSeeder,
 ) where
@@ -723,7 +725,7 @@ pub fn par_encrypt_constant_seeded_ggsw_ciphertext<
     par_encrypt_constant_seeded_ggsw_ciphertext_with_existing_generator(
         glwe_secret_key,
         output,
-        encoded,
+        cleartext,
         noise_distribution,
         &mut generator,
     );
@@ -800,7 +802,7 @@ fn encrypt_constant_seeded_ggsw_level_matrix_row<
     );
 }
 
-/// Decrypt a [`GGSW ciphertext`](`GgswCiphertext`) only yielding the plaintext from the constant
+/// Decrypt a [`GGSW ciphertext`](`GgswCiphertext`) only yielding the cleartext from the constant
 /// term of the polynomial.
 ///
 /// # Example
@@ -834,8 +836,8 @@ fn encrypt_constant_seeded_ggsw_level_matrix_row<
 ///     &mut secret_generator,
 /// );
 ///
-/// // Create the plaintext
-/// let plaintext = Plaintext(3u64);
+/// // Create the cleartext
+/// let cleartext = Cleartext(3u64);
 ///
 /// // Create a new GgswCiphertext
 /// let mut ggsw = GgswCiphertext::new(
@@ -850,18 +852,18 @@ fn encrypt_constant_seeded_ggsw_level_matrix_row<
 /// par_encrypt_constant_ggsw_ciphertext(
 ///     &glwe_secret_key,
 ///     &mut ggsw,
-///     plaintext,
+///     cleartext,
 ///     glwe_noise_distribution,
 ///     &mut encryption_generator,
 /// );
 ///
 /// let decrypted = decrypt_constant_ggsw_ciphertext(&glwe_secret_key, &ggsw);
-/// assert_eq!(decrypted, plaintext);
+/// assert_eq!(decrypted, cleartext);
 /// ```
 pub fn decrypt_constant_ggsw_ciphertext<Scalar, KeyCont, InputCont>(
     glwe_secret_key: &GlweSecretKey<KeyCont>,
     ggsw_ciphertext: &GgswCiphertext<InputCont>,
-) -> Plaintext<Scalar>
+) -> Cleartext<Scalar>
 where
     Scalar: UnsignedTorus,
     KeyCont: Container<Element = Scalar>,
@@ -897,7 +899,7 @@ where
 
     let decomp_base_log = ggsw_ciphertext.decomposition_base_log();
 
-    let plaintext_ref = decrypted_plaintext_list.get(0);
+    let cleartext_ref = decrypted_plaintext_list.get(0);
 
     let ciphertext_modulus = ggsw_ciphertext.ciphertext_modulus();
 
@@ -911,23 +913,23 @@ where
             )
             .to_approximate_recomposition_summand();
 
-            let decoded = divide_round(*plaintext_ref.0, delta)
+            let decoded = divide_round(*cleartext_ref.0, delta)
                 .wrapping_rem(Scalar::ONE << (decomp_level.0 * decomp_base_log.0));
 
-            Plaintext(decoded)
+            Cleartext(decoded)
         }
         CiphertextModulusKind::Native | CiphertextModulusKind::NonNativePowerOfTwo => {
             let decomposer = SignedDecomposer::new(decomp_base_log, decomp_level);
 
             // Glwe decryption maps to a smaller torus potentially, map back to the native torus
             let rounded = decomposer.closest_representable(
-                (*plaintext_ref.0)
+                (*cleartext_ref.0)
                     .wrapping_mul(ciphertext_modulus.get_power_of_two_scaling_to_native_torus()),
             );
             let decoded = rounded
                 .wrapping_div(Scalar::ONE << (Scalar::BITS - (decomp_base_log.0 * decomp_level.0)));
 
-            Plaintext(decoded)
+            Cleartext(decoded)
         }
     }
 }

--- a/tfhe/src/core_crypto/algorithms/lwe_bootstrap_key_generation.rs
+++ b/tfhe/src/core_crypto/algorithms/lwe_bootstrap_key_generation.rs
@@ -131,7 +131,7 @@ pub fn generate_lwe_bootstrap_key<
         encrypt_constant_ggsw_ciphertext(
             output_glwe_secret_key,
             &mut ggsw,
-            Plaintext(input_key_element),
+            Cleartext(input_key_element),
             noise_distribution,
             &mut generator,
         );
@@ -304,7 +304,7 @@ pub fn par_generate_lwe_bootstrap_key<
             par_encrypt_constant_ggsw_ciphertext(
                 output_glwe_secret_key,
                 &mut ggsw,
-                Plaintext(input_key_element),
+                Cleartext(input_key_element),
                 noise_distribution,
                 &mut generator,
             );
@@ -426,7 +426,7 @@ pub fn generate_seeded_lwe_bootstrap_key<
         encrypt_constant_seeded_ggsw_ciphertext_with_existing_generator(
             output_glwe_secret_key,
             &mut ggsw,
-            Plaintext(input_key_element),
+            Cleartext(input_key_element),
             noise_distribution,
             &mut generator,
         );
@@ -549,7 +549,7 @@ pub fn par_generate_seeded_lwe_bootstrap_key<
             par_encrypt_constant_seeded_ggsw_ciphertext_with_existing_generator(
                 output_glwe_secret_key,
                 &mut ggsw,
-                Plaintext(input_key_element),
+                Cleartext(input_key_element),
                 noise_distribution,
                 &mut generator,
             );

--- a/tfhe/src/core_crypto/algorithms/lwe_multi_bit_bootstrap_key_generation.rs
+++ b/tfhe/src/core_crypto/algorithms/lwe_multi_bit_bootstrap_key_generation.rs
@@ -162,7 +162,7 @@ pub fn generate_lwe_multi_bit_bootstrap_key<
             encrypt_constant_ggsw_ciphertext(
                 output_glwe_secret_key,
                 &mut ggsw,
-                Plaintext(key_bits_plaintext),
+                Cleartext(key_bits_plaintext),
                 noise_distribution,
                 &mut inner_loop_generator,
             );
@@ -386,7 +386,7 @@ pub fn par_generate_lwe_multi_bit_bootstrap_key<
                             par_encrypt_constant_ggsw_ciphertext(
                                 output_glwe_secret_key,
                                 &mut ggsw,
-                                Plaintext(key_bits_plaintext),
+                                Cleartext(key_bits_plaintext),
                                 noise_distribution,
                                 &mut inner_loop_generator,
                             );
@@ -585,7 +585,7 @@ pub fn generate_seeded_lwe_multi_bit_bootstrap_key<
             encrypt_constant_seeded_ggsw_ciphertext_with_existing_generator(
                 output_glwe_secret_key,
                 &mut ggsw,
-                Plaintext(key_bits_plaintext),
+                Cleartext(key_bits_plaintext),
                 noise_distribution,
                 &mut inner_loop_generator,
             );
@@ -740,7 +740,7 @@ pub fn par_generate_seeded_lwe_multi_bit_bootstrap_key<
                             par_encrypt_constant_seeded_ggsw_ciphertext_with_existing_generator(
                                 output_glwe_secret_key,
                                 &mut ggsw,
-                                Plaintext(key_bits_plaintext),
+                                Cleartext(key_bits_plaintext),
                                 noise_distribution,
                                 &mut inner_loop_generator,
                             );

--- a/tfhe/src/core_crypto/algorithms/lwe_programmable_bootstrapping/fft64.rs
+++ b/tfhe/src/core_crypto/algorithms/lwe_programmable_bootstrapping/fft64.rs
@@ -590,7 +590,7 @@ pub fn cmux_assign<Scalar, Cont0, Cont1, GgswCont>(
 /// );
 ///
 /// // Create the plaintext
-/// let msg_ggsw_0 = Plaintext(0u64);
+/// let msg_ggsw_0 = Cleartext(0u64);
 ///
 /// // Create a new GgswCiphertext
 /// let mut ggsw_0 = GgswCiphertext::new(
@@ -611,7 +611,7 @@ pub fn cmux_assign<Scalar, Cont0, Cont1, GgswCont>(
 /// );
 ///
 /// // Create the plaintext
-/// let msg_ggsw_1 = Plaintext(1u64);
+/// let msg_ggsw_1 = Cleartext(1u64);
 ///
 /// // Create a new GgswCiphertext
 /// let mut ggsw_1 = GgswCiphertext::new(

--- a/tfhe/src/core_crypto/algorithms/test/ggsw_encryption.rs
+++ b/tfhe/src/core_crypto/algorithms/test/ggsw_encryption.rs
@@ -39,9 +39,9 @@ fn test_parallel_and_seeded_ggsw_encryption_equivalence<Scalar>(
             &mut secret_generator,
         );
 
-        // Create the plaintext
+        // Create the cleartext
         let encoded_msg: Scalar = test_tools::random_uint_between(Scalar::ZERO..Scalar::TWO.shl(2));
-        let plaintext = Plaintext(encoded_msg);
+        let cleartext = Cleartext(encoded_msg);
 
         let compression_seed: CompressionSeed = seeder.seed().into();
 
@@ -65,7 +65,7 @@ fn test_parallel_and_seeded_ggsw_encryption_equivalence<Scalar>(
         encrypt_constant_ggsw_ciphertext(
             &glwe_secret_key,
             &mut ser_ggsw,
-            plaintext,
+            cleartext,
             glwe_noise_distribution,
             &mut encryption_generator,
         );
@@ -90,7 +90,7 @@ fn test_parallel_and_seeded_ggsw_encryption_equivalence<Scalar>(
         par_encrypt_constant_ggsw_ciphertext(
             &glwe_secret_key,
             &mut par_ggsw,
-            plaintext,
+            cleartext,
             glwe_noise_distribution,
             &mut encryption_generator,
         );
@@ -114,7 +114,7 @@ fn test_parallel_and_seeded_ggsw_encryption_equivalence<Scalar>(
         encrypt_constant_seeded_ggsw_ciphertext(
             &glwe_secret_key,
             &mut ser_seeded_ggsw,
-            plaintext,
+            cleartext,
             glwe_noise_distribution,
             &mut deterministic_seeder,
         );
@@ -135,7 +135,7 @@ fn test_parallel_and_seeded_ggsw_encryption_equivalence<Scalar>(
         par_encrypt_constant_seeded_ggsw_ciphertext(
             &glwe_secret_key,
             &mut par_seeded_ggsw,
-            plaintext,
+            cleartext,
             glwe_noise_distribution,
             &mut deterministic_seeder,
         );
@@ -212,13 +212,13 @@ fn ggsw_encrypt_decrypt_custom_mod<Scalar: UnsignedTorus>(params: ClassicTestPar
                 ciphertext_modulus,
             );
 
-            // GGSW constants are seen as plaintext, the encoding is done by the encryption itself
-            let plaintext = Plaintext(msg);
+            // GGSW constants are seen as cleartext, the encoding is done by the encryption itself
+            let cleartext = Cleartext(msg);
 
             encrypt_constant_ggsw_ciphertext(
                 &glwe_sk,
                 &mut ggsw,
-                plaintext,
+                cleartext,
                 glwe_noise_distribution,
                 &mut rsc.encryption_random_generator,
             );
@@ -280,13 +280,13 @@ fn ggsw_par_encrypt_decrypt_custom_mod<Scalar: UnsignedTorus + Send + Sync>(
                 ciphertext_modulus,
             );
 
-            // GGSW constants are seen as plaintext, the encoding is done by the encryption itself
-            let plaintext = Plaintext(msg);
+            // GGSW constants are seen as cleartext, the encoding is done by the encryption itself
+            let cleartext = Cleartext(msg);
 
             par_encrypt_constant_ggsw_ciphertext(
                 &glwe_sk,
                 &mut ggsw,
-                plaintext,
+                cleartext,
                 glwe_noise_distribution,
                 &mut rsc.encryption_random_generator,
             );
@@ -349,13 +349,13 @@ fn ggsw_seeded_encrypt_decrypt_custom_mod<Scalar: UnsignedTorus>(
                 ciphertext_modulus,
             );
 
-            // GGSW constants are seen as plaintext, the encoding is done by the encryption itself
-            let plaintext = Plaintext(msg);
+            // GGSW constants are seen as cleartext, the encoding is done by the encryption itself
+            let cleartext = Cleartext(msg);
 
             encrypt_constant_seeded_ggsw_ciphertext(
                 &glwe_sk,
                 &mut seeded_ggsw,
-                plaintext,
+                cleartext,
                 glwe_noise_distribution,
                 rsc.seeder.as_mut(),
             );
@@ -420,13 +420,13 @@ fn ggsw_seeded_par_encrypt_decrypt_custom_mod<Scalar: UnsignedTorus + Sync + Sen
                 ciphertext_modulus,
             );
 
-            // GGSW constants are seen as plaintext, the encoding is done by the encryption itself
-            let plaintext = Plaintext(msg);
+            // GGSW constants are seen as cleartext, the encoding is done by the encryption itself
+            let cleartext = Cleartext(msg);
 
             par_encrypt_constant_seeded_ggsw_ciphertext(
                 &glwe_sk,
                 &mut seeded_ggsw,
-                plaintext,
+                cleartext,
                 glwe_noise_distribution,
                 rsc.seeder.as_mut(),
             );

--- a/tfhe/src/core_crypto/fft_impl/fft64/crypto/wop_pbs/tests.rs
+++ b/tfhe/src/core_crypto/fft_impl/fft64/crypto/wop_pbs/tests.rs
@@ -495,9 +495,9 @@ pub fn test_cmux_tree() {
         let witness = value % (1 << (64 - delta_log));
 
         // Bit decomposition of the value from MSB to LSB
-        let mut vec_message = vec![Plaintext(0); nb_ggsw];
+        let mut vec_message = vec![Cleartext(0); nb_ggsw];
         for i in (0..nb_ggsw).rev() {
-            vec_message[i] = Plaintext(value & 1);
+            vec_message[i] = Cleartext(value & 1);
             value >>= 1;
         }
 


### PR DESCRIPTION
- functions take un-encoded values, reflect that by taking Cleartext instead of Plaintext