### PR TITLE
feat(hlapi): Make it possible to get num_bits for FheUint type

### DIFF
--- a/tfhe/Cargo.toml
+++ b/tfhe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tfhe"
-version = "0.8.0-alpha.0"
+version = "0.8.0-alpha.1"
 edition = "2021"
 readme = "../README.md"
 keywords = ["fully", "homomorphic", "encryption", "fhe", "cryptography"]

--- a/tfhe/src/high_level_api/booleans/base.rs
+++ b/tfhe/src/high_level_api/booleans/base.rs
@@ -96,6 +96,10 @@ impl FheBool {
         self.ciphertext.current_device()
     }
 
+    pub fn num_bits() -> usize {
+        1
+    }
+
     /// Moves (in-place) the ciphertext to the desired device.
     ///
     /// Does nothing if the ciphertext is already in the desired device

--- a/tfhe/src/high_level_api/integers/signed/base.rs
+++ b/tfhe/src/high_level_api/integers/signed/base.rs
@@ -106,6 +106,10 @@ where
         }
     }
 
+    pub fn num_bits() -> usize {
+        Id::num_bits()
+    }
+
     /// Moves (in-place) the ciphertext to the desired device.
     ///
     /// Does nothing if the ciphertext is already in the desired device

--- a/tfhe/src/high_level_api/integers/unsigned/base.rs
+++ b/tfhe/src/high_level_api/integers/unsigned/base.rs
@@ -151,6 +151,10 @@ where
         }
     }
 
+    pub fn num_bits() -> usize {
+        Id::num_bits()
+    }
+
     pub(in crate::high_level_api) fn move_to_device_of_server_key_if_set(&mut self) {
         self.ciphertext.move_to_device_of_server_key_if_set();
     }


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description
Makes it possible to grab the number of plaintext bits of a FheUint or FheInt or FheBool.
Useful to know the number of bits of the plaintext whilst using the type aliases.
### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
