### PR TITLE
doc(integer): fix typo in shl doc

### DIFF
--- a/tfhe/src/integer/server_key/radix/shift.rs
+++ b/tfhe/src/integer/server_key/radix/shift.rs
@@ -211,7 +211,7 @@ impl ServerKey {
     ///
     /// let ct1 = cks.encrypt(msg);
     ///
-    /// // Compute homomorphically a right shift:
+    /// // Compute homomorphically a left shift:
     /// let ct_res = sks.unchecked_scalar_left_shift(&ct1, shift);
     ///
     /// // Decrypt:


### PR DESCRIPTION
### PR content/description

Small copy/paste error in the doc for the integer shl operation