### PR TITLE
refactor(shortint): refactor the shortint keyswitching code

### DIFF
--- a/tfhe/src/integer/key_switching_key/test.rs
+++ b/tfhe/src/integer/key_switching_key/test.rs
@@ -8,9 +8,13 @@ use crate::integer::{
     IntegerKeyKind, RadixCiphertext, RadixClientKey, ServerKey,
 };
 use crate::shortint::parameters::compact_public_key_only::PARAM_PKE_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64;
-use crate::shortint::parameters::key_switching::PARAM_KEYSWITCH_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64;
+use crate::shortint::parameters::key_switching::{
+    PARAM_KEYSWITCH_PKE_TO_BIG_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64,
+    PARAM_KEYSWITCH_PKE_TO_SMALL_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64,
+};
 use crate::shortint::parameters::{
-    ShortintKeySwitchingParameters, PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64,
+    ClassicPBSParameters, CompactPublicKeyEncryptionParameters, ShortintKeySwitchingParameters,
+    PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64,
 };
 use crate::shortint::prelude::{PARAM_MESSAGE_1_CARRY_1_KS_PBS, PARAM_MESSAGE_2_CARRY_2_KS_PBS};
 
@@ -160,12 +164,11 @@ fn gen_multi_keys_test_integer_to_integer_ci_run_filter() {
     assert_eq!(clear, 228);
 }
 
-#[test]
-fn test_cpk_encrypt_cast_compute_ci_run_filter() {
-    let param_pke_only = PARAM_PKE_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64;
-    let param_fhe = PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64;
-    let param_ksk = PARAM_KEYSWITCH_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64;
-
+fn test_case_cpk_encrypt_cast_compute(
+    param_pke_only: CompactPublicKeyEncryptionParameters,
+    param_fhe: ClassicPBSParameters,
+    param_ksk: ShortintKeySwitchingParameters,
+) {
     let num_block = 4usize;
 
     assert_eq!(param_pke_only.message_modulus, param_fhe.message_modulus);
@@ -224,4 +227,22 @@ fn test_cpk_encrypt_cast_compute_ci_run_filter() {
     // High level decryption and test
     let clear = cks_fhe.decrypt_radix::<u64>(&ct1_extracted_and_cast) % modulus;
     assert_eq!(clear, (input_msg * multiplier) % modulus);
+}
+
+#[test]
+fn test_cpk_encrypt_cast_to_small_compute_big_ci_run_filter() {
+    test_case_cpk_encrypt_cast_compute(
+        PARAM_PKE_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64,
+        PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64,
+        PARAM_KEYSWITCH_PKE_TO_SMALL_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64,
+    )
+}
+
+#[test]
+fn test_cpk_encrypt_cast_to_big_compute_big_ci_run_filter() {
+    test_case_cpk_encrypt_cast_compute(
+        PARAM_PKE_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64,
+        PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64,
+        PARAM_KEYSWITCH_PKE_TO_BIG_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64,
+    )
 }

--- a/tfhe/src/shortint/key_switching_key/test.rs
+++ b/tfhe/src/shortint/key_switching_key/test.rs
@@ -181,6 +181,7 @@ fn gen_multi_keys_test_truncate_ci_run_filter() {
     // Message 0 Carry 0
     let cipher = ck1.unchecked_encrypt(0);
     let output_of_cast = ksk.cast(&cipher);
+    assert_eq!(output_of_cast.degree.get(), 3);
     let clear = ck2.decrypt(&output_of_cast);
     assert_eq!(clear, 0);
     let ct_carry = sk2.carry_extract(&output_of_cast);
@@ -190,6 +191,7 @@ fn gen_multi_keys_test_truncate_ci_run_filter() {
     // Message 1 Carry 0
     let cipher = ck1.unchecked_encrypt(1);
     let output_of_cast = ksk.cast(&cipher);
+    assert_eq!(output_of_cast.degree.get(), 3);
     let clear = ck2.decrypt(&output_of_cast);
     assert_eq!(clear, 1);
     let ct_carry = sk2.carry_extract(&output_of_cast);
@@ -199,6 +201,7 @@ fn gen_multi_keys_test_truncate_ci_run_filter() {
     // Message 0 Carry 1
     let cipher = ck1.unchecked_encrypt(2);
     let output_of_cast = ksk.cast(&cipher);
+    assert_eq!(output_of_cast.degree.get(), 3);
     let clear = ck2.decrypt(&output_of_cast);
     assert_eq!(clear, 0);
     let ct_carry = sk2.carry_extract(&output_of_cast);
@@ -208,6 +211,7 @@ fn gen_multi_keys_test_truncate_ci_run_filter() {
     // Message 1 Carry 1
     let cipher = ck1.unchecked_encrypt(3);
     let output_of_cast = ksk.cast(&cipher);
+    assert_eq!(output_of_cast.degree.get(), 3);
     let clear = ck2.decrypt(&output_of_cast);
     assert_eq!(clear, 1);
     let ct_carry = sk2.carry_extract(&output_of_cast);
@@ -222,6 +226,7 @@ fn gen_multi_keys_test_truncate_ci_run_filter() {
     assert_eq!((clear, carry), (0, 3));
 
     let output_of_cast = ksk.cast(&cipher);
+    assert_eq!(output_of_cast.degree.get(), 3);
     let clear = ck2.decrypt(&output_of_cast);
     assert_eq!(clear, 0);
     let ct_carry = sk2.carry_extract(&output_of_cast);

--- a/tfhe/src/shortint/parameters/key_switching.rs
+++ b/tfhe/src/shortint/parameters/key_switching.rs
@@ -43,9 +43,31 @@ pub const PARAM_KEYSWITCH_1_1_KS_PBS_TO_2_2_KS_PBS: ShortintKeySwitchingParamete
         destination_key: EncryptionKeyChoice::Big,
     };
 
+// The level and base log correspond to the level and base log of the 2_2 TUniform parameters, so
+// these parameters allow to keyswitch from one set of keys of the 2_2 TUniform parameters to
+// another set of keys. The ciphertext will be under the small key and a PBS with the destination
+// keys will be applied to finish the keyswitch.
 pub const PARAM_KEYSWITCH_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64: ShortintKeySwitchingParameters =
     ShortintKeySwitchingParameters {
         ks_level: DecompositionLevelCount(5),
         ks_base_log: DecompositionBaseLog(3),
         destination_key: EncryptionKeyChoice::Small,
     };
+
+// Parameters to keyswitch from input PKE 2_2 TUniform parameters to 2_2 KS_PBS compute parameters
+// arriving under the small key, requires a PBS to get to the big key
+pub const PARAM_KEYSWITCH_PKE_TO_SMALL_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64:
+    ShortintKeySwitchingParameters = ShortintKeySwitchingParameters {
+    ks_level: DecompositionLevelCount(5),
+    ks_base_log: DecompositionBaseLog(3),
+    destination_key: EncryptionKeyChoice::Small,
+};
+
+// Parameters to keyswitch from input PKE 2_2 TUniform parameters to 2_2 KS_PBS compute parameters
+// arriving under the big key, requires a PBS to get to the big key
+pub const PARAM_KEYSWITCH_PKE_TO_BIG_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64:
+    ShortintKeySwitchingParameters = ShortintKeySwitchingParameters {
+    ks_level: DecompositionLevelCount(1),
+    ks_base_log: DecompositionBaseLog(27),
+    destination_key: EncryptionKeyChoice::Big,
+};


### PR DESCRIPTION
closes: https://github.com/zama-ai/tfhe-rs-internal/issues/670

### PR content/description

- this manages better all the cases we encouter, we force a refresh PBS in all cases for now which is less optimal in certain cases but allows to be safe in cases where keyswitches might be chained


cc @titouantanguy to check the cases which were failing previously