### PR TITLE
refactor(gpu): fix sample extraction when nth > 0 and keep input unchanged

### DIFF
--- a/backends/tfhe-cuda-backend/cuda/include/ciphertext.h
+++ b/backends/tfhe-cuda-backend/cuda/include/ciphertext.h
@@ -1,6 +1,7 @@
 #ifndef CUDA_CIPHERTEXT_H
 #define CUDA_CIPHERTEXT_H
 
+#include "device.h"
 #include <cstdint>
 
 extern "C" {
@@ -14,5 +15,11 @@ void cuda_convert_lwe_ciphertext_vector_to_cpu_64(void *stream,
                                                   void *dest, void *src,
                                                   uint32_t number_of_cts,
                                                   uint32_t lwe_dimension);
+
+void cuda_glwe_sample_extract_64(void *stream, uint32_t gpu_index,
+                                 void *lwe_array_out, void *glwe_array_in,
+                                 uint32_t *nth_array, uint32_t num_glwes,
+                                 uint32_t glwe_dimension,
+                                 uint32_t polynomial_size);
 };
 #endif

--- a/backends/tfhe-cuda-backend/cuda/src/crypto/ciphertext.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/crypto/ciphertext.cu
@@ -1,4 +1,5 @@
 #include "ciphertext.cuh"
+#include "polynomial/parameters.cuh"
 
 void cuda_convert_lwe_ciphertext_vector_to_gpu_64(void *stream,
                                                   uint32_t gpu_index,
@@ -18,4 +19,59 @@ void cuda_convert_lwe_ciphertext_vector_to_cpu_64(void *stream,
   cuda_convert_lwe_ciphertext_vector_to_cpu<uint64_t>(
       static_cast<cudaStream_t>(stream), gpu_index, (uint64_t *)dest,
       (uint64_t *)src, number_of_cts, lwe_dimension);
+}
+
+void cuda_glwe_sample_extract_64(void *stream, uint32_t gpu_index,
+                                 void *lwe_array_out, void *glwe_array_in,
+                                 uint32_t *nth_array, uint32_t num_glwes,
+                                 uint32_t glwe_dimension,
+                                 uint32_t polynomial_size) {
+
+  switch (polynomial_size) {
+  case 256:
+    host_sample_extract<uint64_t, AmortizedDegree<256>>(
+        static_cast<cudaStream_t>(stream), gpu_index, (uint64_t *)lwe_array_out,
+        (uint64_t *)glwe_array_in, (uint32_t *)nth_array, num_glwes,
+        glwe_dimension);
+    break;
+  case 512:
+    host_sample_extract<uint64_t, AmortizedDegree<512>>(
+        static_cast<cudaStream_t>(stream), gpu_index, (uint64_t *)lwe_array_out,
+        (uint64_t *)glwe_array_in, (uint32_t *)nth_array, num_glwes,
+        glwe_dimension);
+    break;
+  case 1024:
+    host_sample_extract<uint64_t, AmortizedDegree<1024>>(
+        static_cast<cudaStream_t>(stream), gpu_index, (uint64_t *)lwe_array_out,
+        (uint64_t *)glwe_array_in, (uint32_t *)nth_array, num_glwes,
+        glwe_dimension);
+    break;
+  case 2048:
+    host_sample_extract<uint64_t, AmortizedDegree<2048>>(
+        static_cast<cudaStream_t>(stream), gpu_index, (uint64_t *)lwe_array_out,
+        (uint64_t *)glwe_array_in, (uint32_t *)nth_array, num_glwes,
+        glwe_dimension);
+    break;
+  case 4096:
+    host_sample_extract<uint64_t, AmortizedDegree<4096>>(
+        static_cast<cudaStream_t>(stream), gpu_index, (uint64_t *)lwe_array_out,
+        (uint64_t *)glwe_array_in, (uint32_t *)nth_array, num_glwes,
+        glwe_dimension);
+    break;
+  case 8192:
+    host_sample_extract<uint64_t, AmortizedDegree<8192>>(
+        static_cast<cudaStream_t>(stream), gpu_index, (uint64_t *)lwe_array_out,
+        (uint64_t *)glwe_array_in, (uint32_t *)nth_array, num_glwes,
+        glwe_dimension);
+    break;
+  case 16384:
+    host_sample_extract<uint64_t, AmortizedDegree<16384>>(
+        static_cast<cudaStream_t>(stream), gpu_index, (uint64_t *)lwe_array_out,
+        (uint64_t *)glwe_array_in, (uint32_t *)nth_array, num_glwes,
+        glwe_dimension);
+    break;
+  default:
+    PANIC("Cuda error: unsupported polynomial size. Supported "
+          "N's are powers of two in the interval [256..16384].")
+  }
 }

--- a/backends/tfhe-cuda-backend/src/cuda_bind.rs
+++ b/backends/tfhe-cuda-backend/src/cuda_bind.rs
@@ -598,6 +598,16 @@ extern "C" {
         gpu_count: u32,
         mem_ptr: *mut *mut i8,
     );
+    pub fn cuda_glwe_sample_extract_64(
+        stream: *mut c_void,
+        gpu_index: u32,
+        lwe_array_out: *mut c_void,
+        glwe_array_in: *const c_void,
+        nth_array: *const u32,
+        num_glwes: u32,
+        glwe_dimension: u32,
+        polynomial_size: u32,
+    );
 
     pub fn scratch_cuda_integer_radix_comparison_kb_64(
         streams: *const *mut c_void,

--- a/tfhe/src/core_crypto/gpu/algorithms/glwe_sample_extraction.rs
+++ b/tfhe/src/core_crypto/gpu/algorithms/glwe_sample_extraction.rs
@@ -1,0 +1,60 @@
+use crate::core_crypto::gpu::glwe_ciphertext_list::CudaGlweCiphertextList;
+use crate::core_crypto::gpu::lwe_ciphertext_list::CudaLweCiphertextList;
+use crate::core_crypto::gpu::vec::CudaVec;
+use crate::core_crypto::gpu::{extract_lwe_samples_from_glwe_ciphertext_list_async, CudaStreams};
+use crate::core_crypto::prelude::{MonomialDegree, UnsignedTorus};
+use itertools::Itertools;
+
+/// For each [`GLWE Ciphertext`] (`CudaGlweCiphertextList`) given as input, extract the nth
+/// coefficient from its body as an [`LWE ciphertext`](`CudaLweCiphertextList`). This variant is
+/// GPU-accelerated.
+pub fn cuda_extract_lwe_samples_from_glwe_ciphertext_list<Scalar>(
+    input_glwe_list: &CudaGlweCiphertextList<Scalar>,
+    output_lwe_list: &mut CudaLweCiphertextList<Scalar>,
+    vec_nth: &[MonomialDegree],
+    streams: &CudaStreams,
+) where
+    // CastInto required for PBS modulus switch which returns a usize
+    Scalar: UnsignedTorus,
+{
+    let in_lwe_dim = input_glwe_list
+        .glwe_dimension()
+        .to_equivalent_lwe_dimension(input_glwe_list.polynomial_size());
+
+    let out_lwe_dim = output_lwe_list.lwe_dimension();
+
+    assert_eq!(
+        in_lwe_dim, out_lwe_dim,
+        "Mismatch between equivalent LweDimension of input ciphertext and output ciphertext. \
+        Got {in_lwe_dim:?} for input and {out_lwe_dim:?} for output.",
+    );
+
+    assert_eq!(
+        vec_nth.len(),
+        input_glwe_list.glwe_ciphertext_count().0 * input_glwe_list.polynomial_size().0,
+        "Mismatch between number of nths and number of GLWEs provided.",
+    );
+
+    assert_eq!(
+        input_glwe_list.ciphertext_modulus(),
+        output_lwe_list.ciphertext_modulus(),
+        "Mismatched moduli between input_glwe ({:?}) and output_lwe ({:?})",
+        input_glwe_list.ciphertext_modulus(),
+        output_lwe_list.ciphertext_modulus()
+    );
+
+    let nth_array: Vec<u32> = vec_nth.iter().map(|x| x.0 as u32).collect_vec();
+    let gpu_indexes = &streams.gpu_indexes;
+    unsafe {
+        let d_nth_array = CudaVec::from_cpu_async(&nth_array, streams, gpu_indexes[0]);
+        extract_lwe_samples_from_glwe_ciphertext_list_async(
+            streams,
+            &mut output_lwe_list.0.d_vec,
+            &input_glwe_list.0.d_vec,
+            &d_nth_array,
+            vec_nth.len() as u32,
+            input_glwe_list.glwe_dimension(),
+            input_glwe_list.polynomial_size(),
+        );
+    }
+}

--- a/tfhe/src/core_crypto/gpu/algorithms/mod.rs
+++ b/tfhe/src/core_crypto/gpu/algorithms/mod.rs
@@ -2,6 +2,7 @@ pub mod lwe_linear_algebra;
 pub mod lwe_multi_bit_programmable_bootstrapping;
 pub mod lwe_programmable_bootstrapping;
 
+pub mod glwe_sample_extraction;
 mod lwe_keyswitch;
 #[cfg(test)]
 mod test;

--- a/tfhe/src/core_crypto/gpu/algorithms/test/glwe_sample_extraction.rs
+++ b/tfhe/src/core_crypto/gpu/algorithms/test/glwe_sample_extraction.rs
@@ -1,0 +1,125 @@
+use super::*;
+use crate::core_crypto::gpu::glwe_ciphertext_list::CudaGlweCiphertextList;
+use crate::core_crypto::gpu::glwe_sample_extraction::cuda_extract_lwe_samples_from_glwe_ciphertext_list;
+use crate::core_crypto::gpu::lwe_ciphertext_list::CudaLweCiphertextList;
+use crate::core_crypto::gpu::CudaStreams;
+use itertools::Itertools;
+
+#[cfg(not(tarpaulin))]
+const NB_TESTS: usize = 10;
+#[cfg(tarpaulin)]
+const NB_TESTS: usize = 1;
+
+fn glwe_encrypt_sample_extract_decrypt_custom_mod<Scalar: UnsignedTorus + Send + Sync>(
+    params: ClassicTestParams<Scalar>,
+) {
+    let glwe_dimension = params.glwe_dimension;
+    let polynomial_size = params.polynomial_size;
+    let glwe_noise_distribution = params.glwe_noise_distribution;
+    let ciphertext_modulus = params.ciphertext_modulus;
+    let message_modulus_log = params.message_modulus_log;
+    let encoding_with_padding = get_encoding_with_padding(ciphertext_modulus);
+
+    let mut rsc = TestResources::new();
+
+    let msg_modulus = Scalar::ONE.shl(message_modulus_log.0);
+    let delta: Scalar = encoding_with_padding / msg_modulus;
+
+    let gpu_index = 0;
+    let streams = CudaStreams::new_single_gpu(gpu_index);
+
+    let mut msgs = vec![];
+
+    // Build msg
+    // TODO: Can't we collect from (0..msg_modulus) if msg_modulus is Scalar?
+    let mut msg = msg_modulus;
+    msg = msg.wrapping_sub(Scalar::ONE);
+    while msg != Scalar::ZERO {
+        msgs.push(msg);
+        msg = msg.wrapping_sub(Scalar::ONE);
+    }
+
+    // Run tests
+    for _ in 0..NB_TESTS {
+        let glwe_sk = allocate_and_generate_new_binary_glwe_secret_key(
+            glwe_dimension,
+            polynomial_size,
+            &mut rsc.secret_random_generator,
+        );
+
+        let equivalent_lwe_sk = glwe_sk.clone().into_lwe_secret_key();
+
+        let mut glwe_list = GlweCiphertextList::new(
+            Scalar::ZERO,
+            glwe_dimension.to_glwe_size(),
+            polynomial_size,
+            GlweCiphertextCount(msgs.len()),
+            ciphertext_modulus,
+        );
+
+        let cleartext_list = msgs
+            .iter()
+            .flat_map(|&x| vec![x * delta; glwe_list.polynomial_size().0])
+            .collect_vec();
+
+        let plaintext_list = PlaintextList::from_container(cleartext_list);
+        encrypt_glwe_ciphertext_list(
+            &glwe_sk,
+            &mut glwe_list,
+            &plaintext_list,
+            glwe_noise_distribution,
+            &mut rsc.encryption_random_generator,
+        );
+
+        let input_cuda_glwe_list =
+            CudaGlweCiphertextList::from_glwe_ciphertext_list(&glwe_list, &streams);
+
+        let mut output_cuda_lwe_ciphertext_list = CudaLweCiphertextList::new(
+            equivalent_lwe_sk.lwe_dimension(),
+            LweCiphertextCount(msgs.len() * glwe_list.polynomial_size().0),
+            ciphertext_modulus,
+            &streams,
+        );
+
+        let nths = (0..(msgs.len() * glwe_list.polynomial_size().0))
+            .map(|x| MonomialDegree(x % glwe_list.polynomial_size().0))
+            .collect_vec();
+
+        cuda_extract_lwe_samples_from_glwe_ciphertext_list(
+            &input_cuda_glwe_list,
+            &mut output_cuda_lwe_ciphertext_list,
+            nths.as_slice(),
+            &streams,
+        );
+
+        let gpu_output_lwe_ciphertext_list =
+            output_cuda_lwe_ciphertext_list.to_lwe_ciphertext_list(&streams);
+
+        let mut output_plaintext_list = PlaintextList::new(
+            Scalar::ZERO,
+            PlaintextCount(gpu_output_lwe_ciphertext_list.lwe_ciphertext_count().0),
+        );
+
+        decrypt_lwe_ciphertext_list(
+            &equivalent_lwe_sk,
+            &gpu_output_lwe_ciphertext_list,
+            &mut output_plaintext_list,
+        );
+
+        let mut decoded = vec![Scalar::ZERO; plaintext_list.plaintext_count().0];
+
+        decoded
+            .iter_mut()
+            .zip(output_plaintext_list.iter())
+            .for_each(|(dst, src)| *dst = round_decode(*src.0, delta) % msg_modulus);
+
+        let mut count = msg_modulus;
+        count = count.wrapping_sub(Scalar::ONE);
+        for result in decoded.chunks_exact(glwe_list.polynomial_size().0) {
+            assert!(result.iter().all(|&x| x == count));
+            count = count.wrapping_sub(Scalar::ONE);
+        }
+    }
+}
+
+create_gpu_parametrized_test!(glwe_encrypt_sample_extract_decrypt_custom_mod);

--- a/tfhe/src/core_crypto/gpu/algorithms/test/mod.rs
+++ b/tfhe/src/core_crypto/gpu/algorithms/test/mod.rs
@@ -1,5 +1,6 @@
 use crate::core_crypto::algorithms::test::*;
 
+mod glwe_sample_extraction;
 mod lwe_keyswitch;
 mod lwe_linear_algebra;
 mod lwe_multi_bit_programmable_bootstrapping;

--- a/tfhe/src/core_crypto/gpu/mod.rs
+++ b/tfhe/src/core_crypto/gpu/mod.rs
@@ -328,6 +328,32 @@ pub unsafe fn convert_lwe_multi_bit_programmable_bootstrap_key_async<T: Unsigned
     }
 }
 
+/// # Safety
+///
+/// [CudaStreams::synchronize] __must__ be called as soon as synchronization is
+/// required
+#[allow(clippy::too_many_arguments)]
+pub unsafe fn extract_lwe_samples_from_glwe_ciphertext_list_async<T: UnsignedInteger>(
+    streams: &CudaStreams,
+    lwe_array_out: &mut CudaVec<T>,
+    glwe_array_in: &CudaVec<T>,
+    nth_array: &CudaVec<u32>,
+    num_nths: u32,
+    glwe_dimension: GlweDimension,
+    polynomial_size: PolynomialSize,
+) {
+    cuda_glwe_sample_extract_64(
+        streams.ptr[0],
+        streams.gpu_indexes[0],
+        lwe_array_out.as_mut_c_ptr(0),
+        glwe_array_in.as_c_ptr(0),
+        nth_array.as_c_ptr(0).cast::<u32>(),
+        num_nths,
+        glwe_dimension.0 as u32,
+        polynomial_size.0 as u32,
+    );
+}
+
 /// Discarding addition of a vector of LWE ciphertexts
 ///
 /// # Safety


### PR DESCRIPTION
This PR:

- introduces a rust test for GPU's sample extraction,
- fixes it when `nth > 0`,
- refactors it so the input (the glwe) is not modified by the method.

We might also observe another performance improvement.

<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: https://github.com/zama-ai/tfhe-rs-internal/issues/671

### PR content/description

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
