### PR TITLE
impl Versionize for HashSet/HashMap and Box<[T]>/ABox<[T]>

### DIFF
--- a/utils/tfhe-versionable/src/lib.rs
+++ b/utils/tfhe-versionable/src/lib.rs
@@ -11,6 +11,7 @@ pub mod upgrade;
 
 use aligned_vec::{ABox, AVec};
 use num_complex::Complex;
+use std::collections::{HashMap, HashSet};
 use std::convert::Infallible;
 use std::error::Error;
 use std::fmt::Display;
@@ -568,3 +569,63 @@ impl<T: Unversionize, U: Unversionize, V: Unversionize> Unversionize for (T, U, 
 }
 
 impl<T: NotVersioned, U: NotVersioned, V: NotVersioned> NotVersioned for (T, U, V) {}
+
+// converts to `Vec<T::Versioned>` for the versioned type, so we don't have to derive
+// Eq/Hash on it.
+impl<T: Versionize> Versionize for HashSet<T> {
+    type Versioned<'vers> = Vec<T::Versioned<'vers>>
+    where
+        T: 'vers;
+
+    fn versionize(&self) -> Self::Versioned<'_> {
+        self.iter().map(|val| val.versionize()).collect()
+    }
+}
+
+impl<T: VersionizeOwned> VersionizeOwned for HashSet<T> {
+    type VersionedOwned = Vec<T::VersionedOwned>;
+
+    fn versionize_owned(self) -> Self::VersionedOwned {
+        self.into_iter().map(|val| val.versionize_owned()).collect()
+    }
+}
+
+impl<T: Unversionize + std::hash::Hash + Eq> Unversionize for HashSet<T> {
+    fn unversionize(versioned: Self::VersionedOwned) -> Result<Self, UnversionizeError> {
+        versioned
+            .into_iter()
+            .map(|val| T::unversionize(val))
+            .collect()
+    }
+}
+
+// converts to `Vec<(K::Versioned, V::Versioned)>` for the versioned type, so we don't have to
+// derive Eq/Hash on it.
+impl<K: Versionize, V: Versionize> Versionize for HashMap<K, V> {
+    type Versioned<'vers> = Vec<(K::Versioned<'vers>, V::Versioned<'vers>)> where K: 'vers, V: 'vers;
+
+    fn versionize(&self) -> Self::Versioned<'_> {
+        self.iter()
+            .map(|(key, val)| (key.versionize(), val.versionize()))
+            .collect()
+    }
+}
+
+impl<K: VersionizeOwned, V: VersionizeOwned> VersionizeOwned for HashMap<K, V> {
+    type VersionedOwned = Vec<(K::VersionedOwned, V::VersionedOwned)>;
+
+    fn versionize_owned(self) -> Self::VersionedOwned {
+        self.into_iter()
+            .map(|(key, val)| (key.versionize_owned(), val.versionize_owned()))
+            .collect()
+    }
+}
+
+impl<K: Unversionize + std::hash::Hash + Eq, V: Unversionize> Unversionize for HashMap<K, V> {
+    fn unversionize(versioned: Self::VersionedOwned) -> Result<Self, UnversionizeError> {
+        versioned
+            .into_iter()
+            .map(|(key, val)| Ok((K::unversionize(key)?, V::unversionize(val)?)))
+            .collect()
+    }
+}


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description
The implem converts to `Vec<T::Versioned>` for HashSet and `Vec<(K::Versioned, V::Versioned)>` for HashMap to remove the bound on Eq/Hash for the versioned type. That shouldn't matter since the versioned type is not supposed to be modified before serialization.

This PR also implements Versionize for `Box<[T]>` and `ABox<[T]>` (boxed slices)