### PR TITLE
fix(integer): remove double carry prop in sub

### DIFF
--- a/tfhe/src/integer/server_key/radix_parallel/sub.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/sub.rs
@@ -1,4 +1,5 @@
 use crate::integer::ciphertext::IntegerRadixCiphertext;
+use crate::integer::server_key::radix_parallel::OutputFlag;
 use crate::integer::{BooleanBlock, RadixCiphertext, ServerKey, SignedRadixCiphertext};
 use crate::shortint::ciphertext::Degree;
 use crate::shortint::Ciphertext;
@@ -226,7 +227,12 @@ impl ServerKey {
         };
 
         let neg = self.unchecked_neg(rhs);
-        self.add_assign_with_carry_parallelized(lhs, &neg, None);
+        self.advanced_add_assign_with_carry_parallelized(
+            lhs.blocks_mut(),
+            neg.blocks(),
+            None,
+            OutputFlag::None,
+        );
     }
 
     /// Computes the subtraction and returns an indicator of overflow


### PR DESCRIPTION
The subtraction is done via addition of the negation, the negation is done via unchecked_neg, this will make the first block have a carry.
Then we called add_assign_with_carry_parallelized which did a carry propagation on the rhs which here is the negated value, meaning the subtraction would do 2 carry propagation.

To fix that we directly call the lower function.

