### PR TITLE
feat(wasm): add missing push_u{512,1024,2048}

### DIFF
--- a/tfhe/Cargo.toml
+++ b/tfhe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tfhe"
-version = "0.8.0-alpha.2"
+version = "0.8.0-alpha.3"
 edition = "2021"
 readme = "../README.md"
 keywords = ["fully", "homomorphic", "encryption", "fhe", "cryptography"]

--- a/tfhe/js_on_wasm_tests/test-hlapi-signed.js
+++ b/tfhe/js_on_wasm_tests/test-hlapi-signed.js
@@ -354,7 +354,6 @@ test('hlapi_public_key_encrypt_decrypt_int256_small', (t) => {
 });
 
 
-
 //////////////////////////////////////////////////////////////////////////////
 /// 32 bits compact
 //////////////////////////////////////////////////////////////////////////////
@@ -423,12 +422,14 @@ test('hlapi_compact_ciphertext_list', (t) => {
     let clear_i32 = -3284;
     let clear_bool = true;
     let clear_u256 = generateRandomBigInt(256);
+    let clear_u2048 = generateRandomBigInt(2048);
 
     let builder = CompactCiphertextList.builder(publicKey);
     builder.push_u2(clear_u2);
     builder.push_i32(clear_i32);
     builder.push_boolean(clear_bool);
     builder.push_u256(clear_u256);
+    builder.push_u2048(clear_u2048);
     let list = builder.build();
 
     let serialized = list.safe_serialize(BigInt(10000000));
@@ -455,6 +456,12 @@ test('hlapi_compact_ciphertext_list', (t) => {
         expander.get_uint256(3).decrypt(clientKey),
         clear_u256,
     );
+
+    assert.deepStrictEqual(
+        expander.get_uint2048(4).decrypt(clientKey),
+        clear_u2048,
+    );
+
 });
 
 test('hlapi_compact_ciphertext_list_with_proof', (t) => {

--- a/tfhe/src/js_on_wasm_api/js_high_level_api/integers.rs
+++ b/tfhe/src/js_on_wasm_api/js_high_level_api/integers.rs
@@ -899,6 +899,33 @@ impl CompactCiphertextListBuilder {
     }
 
     #[wasm_bindgen]
+    pub fn push_u512(&mut self, value: JsValue) -> Result<(), JsError> {
+        catch_panic_result(|| {
+            let value = U512::try_from(value)?;
+            self.0.push(value);
+            Ok(())
+        })
+    }
+
+    #[wasm_bindgen]
+    pub fn push_u1024(&mut self, value: JsValue) -> Result<(), JsError> {
+        catch_panic_result(|| {
+            let value = U1024::try_from(value)?;
+            self.0.push(value);
+            Ok(())
+        })
+    }
+
+    #[wasm_bindgen]
+    pub fn push_u2048(&mut self, value: JsValue) -> Result<(), JsError> {
+        catch_panic_result(|| {
+            let value = U2048::try_from(value)?;
+            self.0.push(value);
+            Ok(())
+        })
+    }
+
+    #[wasm_bindgen]
     pub fn push_i128(&mut self, value: JsValue) -> Result<(), JsError> {
         catch_panic_result(|| {
             let value = i128::try_from(value).map_err(into_js_error)?;
@@ -1018,7 +1045,7 @@ macro_rules! define_expander_get_method {
     };
 }
 define_expander_get_method!(
-    unsigned: { 2, 4, 6, 8, 10, 12, 14, 16, 32, 64, 128, 160, 256 }
+    unsigned: { 2, 4, 6, 8, 10, 12, 14, 16, 32, 64, 128, 160, 256, 512, 1024, 2048 }
 );
 define_expander_get_method!(
     signed: { 2, 4, 6, 8, 10, 12, 14, 16, 32, 64, 128, 160, 256 }


### PR DESCRIPTION
This adds the missing push functions for some big
uint type that the fhEVM needs





### Check-list:

* [x] Tests for the changes have been added (for bug fixes / features)
