### PR TITLE
chore(hl): a bad merge led to two server key generation

### DIFF
--- a/tfhe/src/high_level_api/keys/inner.rs
+++ b/tfhe/src/high_level_api/keys/inner.rs
@@ -306,8 +306,6 @@ impl IntegerCompressedServerKey {
                     build_helper.into()
                 });
 
-        let key = crate::integer::CompressedServerKey::new_radix_compressed_server_key(cks);
-
         let (compression_key, decompression_key) =
             client_key
                 .compression_key


### PR DESCRIPTION
probably what led to some wasm bench to be slower

cc @nsarlin-zama when you are back