### PR TITLE
chore(ci): the detect handles option from jest is freezing the runner

### DIFF
--- a/tfhe/web_wasm_parallel_tests/package.json
+++ b/tfhe/web_wasm_parallel_tests/package.json
@@ -4,12 +4,12 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "jest ./test --runInBand --detectOpenHandles --testNamePattern=Test",
-    "bench": "jest ./test --runInBand --detectOpenHandles --testNamePattern=Bench",
+    "test": "jest ./test --runInBand --testNamePattern=Test",
+    "bench": "jest ./test --runInBand --testNamePattern=Bench",
     "build": "cp -r ../../tfhe/pkg ./ && webpack build ./index.js --mode production -o dist --output-filename index.js && cp index.html dist/ && cp favicon.ico dist/",
     "server": "serve --config ../serve.json dist/",
-    "test-separate-processes": "jest --listTests | xargs -L 1 jest --runInBand --detectOpenHandles --testNamePattern=Test",
-    "bench-separate-processes": "jest --listTests | xargs -L 1 jest --runInBand --detectOpenHandles --testNamePattern=Bench",
+    "test-separate-processes": "jest --listTests | xargs -L 1 jest --runInBand --testNamePattern=Test",
+    "bench-separate-processes": "jest --listTests | xargs -L 1 jest --runInBand --testNamePattern=Bench",
     "test2": "mocha",
     "format": "prettier . --write",
     "check-format": "prettier . --check"


### PR DESCRIPTION
https://github.com/jestjs/jest/issues/10777

the open handle thing is it seems a known issue freezing the test runner, removing it from our tests/benchmarks as it's not helping at the moment