### PR TITLE
fix: expand_with_key was not providing the safest set of modes

### DIFF
--- a/tfhe/src/shortint/ciphertext/compact_list.rs
+++ b/tfhe/src/shortint/ciphertext/compact_list.rs
@@ -59,6 +59,13 @@ impl ParameterSetConformant for CompactCiphertextList {
 }
 
 impl CompactCiphertextList {
+    /// Expand a [`CompactCiphertextList`] to a `Vec` of [`Ciphertext`].
+    ///
+    /// The function takes a [`ShortintCompactCiphertextListCastingMode`] to indicate whether a
+    /// keyswitch should be applied during expansion.
+    ///
+    /// This is useful when using separate parameters for the public key used to encrypt the
+    /// [`CompactCiphertextList`] allowing to keyswitch to the computation params during expansion.
     pub fn expand(
         &self,
         casting_mode: ShortintCompactCiphertextListCastingMode<'_>,


### PR DESCRIPTION
- it meant that lists needing unpacking could crash during expand

added non reg test