### PR TITLE
chore: update tfhe to 0.8.0-alpha.8 / cuda-backend to 0.4.0-alpha.1

### DIFF
--- a/backends/tfhe-cuda-backend/Cargo.toml
+++ b/backends/tfhe-cuda-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tfhe-cuda-backend"
-version = "0.4.0-alpha.0"
+version = "0.4.0-alpha.1"
 edition = "2021"
 authors = ["Zama team"]
 license = "BSD-3-Clause-Clear"

--- a/tfhe/Cargo.toml
+++ b/tfhe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tfhe"
-version = "0.8.0-alpha.7"
+version = "0.8.0-alpha.8"
 edition = "2021"
 readme = "../README.md"
 keywords = ["fully", "homomorphic", "encryption", "fhe", "cryptography"]
@@ -65,7 +65,7 @@ bincode = "1.3.3"
 concrete-fft = { version = "0.5.1", features = ["serde", "fft128"] }
 concrete-ntt = { version = "0.2.0" }
 pulp = "0.18.22"
-tfhe-cuda-backend = { version = "0.4.0-alpha.0", path = "../backends/tfhe-cuda-backend", optional = true }
+tfhe-cuda-backend = { version = "0.4.0-alpha.1", path = "../backends/tfhe-cuda-backend", optional = true }
 aligned-vec = { version = "0.5", features = ["serde"] }
 dyn-stack = { version = "0.10" }
 paste = "1.0.7"


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description
Update the dependency to cuda backend in the alpha



[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
