### PR TITLE
Ns/fix/versionable bad bounds

### DIFF
--- a/.github/workflows/aws_tfhe_fast_tests.yml
+++ b/.github/workflows/aws_tfhe_fast_tests.yml
@@ -26,6 +26,7 @@ jobs:
     outputs:
       csprng_test: ${{ env.IS_PULL_REQUEST == 'false' || steps.changed-files.outputs.csprng_any_changed }}
       zk_pok_test: ${{ env.IS_PULL_REQUEST == 'false' || steps.changed-files.outputs.zk_pok_any_changed }}
+      versionable_test: ${{ env.IS_PULL_REQUEST == 'false' || steps.changed-files.outputs.versionable_any_changed }}
       core_crypto_test: ${{ env.IS_PULL_REQUEST == 'false' ||
         steps.changed-files.outputs.core_crypto_any_changed ||
         steps.changed-files.outputs.dependencies_any_changed }}
@@ -64,10 +65,15 @@ jobs:
               - tfhe/Cargo.toml
               - concrete-csprng/**
               - tfhe-zk-pok/**
+              - utils/tfhe-versionable/**
+              - utils/tfhe-versionable-derive/**
             csprng:
               - concrete-csprng/**
             zk_pok:
               - tfhe-zk-pok/**
+            versionable:
+              - utils/tfhe-versionable/**
+              - utils/tfhe-versionable-derive/**
             core_crypto:
               - tfhe/src/core_crypto/**
             boolean:
@@ -103,6 +109,7 @@ jobs:
         if: ( steps.changed-files.outputs.dependencies_any_changed == 'true' ||
           steps.changed-files.outputs.csprng_any_changed == 'true' ||
           steps.changed-files.outputs.zk_pok_any_changed == 'true' ||
+          steps.changed-files.outputs.versionable_any_changed == 'true' ||
           steps.changed-files.outputs.core_crypto_any_changed == 'true' ||
           steps.changed-files.outputs.boolean_any_changed == 'true' ||
           steps.changed-files.outputs.shortint_any_changed == 'true' ||
@@ -166,6 +173,11 @@ jobs:
         if: needs.should-run.outputs.zk_pok_test == 'true'
         run: |
           make test_zk_pok
+
+      - name: Run tfhe-versionable tests
+        if: needs.should-run.outputs.versionable_test == 'true'
+        run: |
+          make test_versionable
 
       - name: Run core tests
         if: needs.should-run.outputs.core_crypto_test == 'true'

--- a/Makefile
+++ b/Makefile
@@ -744,7 +744,7 @@ test_zk_pok: install_rs_build_toolchain
 .PHONY: test_versionable # Run tests for tfhe-versionable subcrate
 test_versionable: install_rs_build_toolchain
 	RUSTFLAGS="$(RUSTFLAGS)" cargo $(CARGO_RS_BUILD_TOOLCHAIN) test --profile $(CARGO_PROFILE) \
-		-p tfhe-versionable
+		--all-targets -p tfhe-versionable
 
 # The backward compat data repo holds historical binary data but also rust code to generate and load them.
 # Here we use the "patch" functionality of Cargo to make sure the repo used for the data is the same as the one used for the code.

--- a/tfhe/Cargo.toml
+++ b/tfhe/Cargo.toml
@@ -76,7 +76,7 @@ sha3 = { version = "0.10", optional = true }
 itertools = "0.11.0"
 rand_core = { version = "0.6.4", features = ["std"] }
 tfhe-zk-pok = { version = "0.3.0-alpha.1", path = "../tfhe-zk-pok", optional = true }
-tfhe-versionable = { version = "0.2.1", path = "../utils/tfhe-versionable" }
+tfhe-versionable = { version = "0.3.0", path = "../utils/tfhe-versionable" }
 
 # wasm deps
 wasm-bindgen = { version = "0.2.86", features = [

--- a/utils/tfhe-versionable-derive/Cargo.toml
+++ b/utils/tfhe-versionable-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tfhe-versionable-derive"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 keywords = ["versioning", "serialization", "encoding", "proc-macro", "derive"]
 homepage = "https://zama.ai/"

--- a/utils/tfhe-versionable-derive/src/dispatch_type.rs
+++ b/utils/tfhe-versionable-derive/src/dispatch_type.rs
@@ -10,10 +10,10 @@ use syn::{
 
 use crate::associated::{
     generate_from_trait_impl, generate_try_from_trait_impl, AssociatedType, AssociatedTypeKind,
+    ConversionDirection,
 };
 use crate::{
-    add_lifetime_bound, add_trait_bound, add_trait_where_clause, parse_const_str, LIFETIME_NAME,
-    UNVERSIONIZE_ERROR_NAME, VERSIONIZE_TRAIT_NAME, VERSION_TRAIT_NAME,
+    parse_const_str, LIFETIME_NAME, UNVERSIONIZE_ERROR_NAME, UPGRADE_TRAIT_NAME, VERSION_TRAIT_NAME,
 };
 
 /// This is the enum that holds all the versions of a specific type. Each variant of the enum is
@@ -47,6 +47,10 @@ fn derive_input_to_enum(input: &DeriveInput) -> syn::Result<ItemEnum> {
 }
 
 impl AssociatedType for DispatchType {
+    const REF_BOUNDS: &'static [&'static str] = &[VERSION_TRAIT_NAME];
+
+    const OWNED_BOUNDS: &'static [&'static str] = &[VERSION_TRAIT_NAME];
+
     fn new_ref(orig_type: &DeriveInput) -> syn::Result<Self> {
         for lt in orig_type.generics.lifetimes() {
             // check for collision with other lifetimes in `orig_type`
@@ -93,7 +97,7 @@ impl AssociatedType for DispatchType {
 
         Ok(ItemEnum {
             ident: self.ident(),
-            generics: self.generics()?,
+            generics: self.type_generics()?,
             attrs: vec![parse_quote! { #[automatically_derived] }],
             variants: variants?,
             ..self.orig_type.clone()
@@ -101,13 +105,41 @@ impl AssociatedType for DispatchType {
         .into())
     }
 
-    fn generate_conversion(&self) -> syn::Result<Vec<ItemImpl>> {
-        let generics = self.generics()?;
-        let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+    fn kind(&self) -> &AssociatedTypeKind {
+        &self.kind
+    }
 
+    fn orig_type_generics(&self) -> &Generics {
+        &self.orig_type.generics
+    }
+
+    fn conversion_generics(&self, direction: ConversionDirection) -> syn::Result<Generics> {
+        let mut generics = self.type_generics()?;
+        let preds = &mut generics.make_where_clause().predicates;
+
+        let upgrade_trait: Path = parse_const_str(UPGRADE_TRAIT_NAME);
+
+        if let ConversionDirection::AssociatedToOrig = direction {
+            if let AssociatedTypeKind::Owned = &self.kind {
+                // Add a bound for each version to be upgradable into the next one
+                for src_idx in 0..(self.versions_count() - 1) {
+                    let src_ty = self.version_type_at(src_idx)?;
+                    let next_ty = self.version_type_at(src_idx + 1)?;
+                    preds.push(parse_quote! { #src_ty: #upgrade_trait<#next_ty> })
+                }
+            }
+        }
+
+        Ok(generics)
+    }
+
+    fn generate_conversion(&self) -> syn::Result<Vec<ItemImpl>> {
         match &self.kind {
             AssociatedTypeKind::Ref(lifetime) => {
                 // Wraps the highest version into the dispatch enum
+                let generics = self.conversion_generics(ConversionDirection::OrigToAssociated)?;
+                let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
                 let src_type = self.latest_version_type()?;
                 let src = parse_quote! { &#lifetime #src_type };
                 let dest_ident = self.ident();
@@ -126,6 +158,9 @@ impl AssociatedType for DispatchType {
             }
             AssociatedTypeKind::Owned => {
                 // Upgrade to the highest version the convert to the main type
+                let generics = self.conversion_generics(ConversionDirection::AssociatedToOrig)?;
+                let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
                 let src_ident = self.ident();
                 let src = parse_quote! { #src_ident #ty_generics };
                 let dest_type = self.latest_version_type()?;
@@ -144,6 +179,9 @@ impl AssociatedType for DispatchType {
                 )?;
 
                 // Wraps the highest version into the dispatch enum
+                let generics = self.conversion_generics(ConversionDirection::OrigToAssociated)?;
+                let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
                 let src_type = self.latest_version_type()?;
                 let src = parse_quote! { #src_type };
                 let dest_ident = self.ident();
@@ -182,12 +220,12 @@ impl AssociatedType for DispatchType {
         }
     }
 
-    fn as_trait_param(&self) -> Option<syn::Result<&Type>> {
-        Some(self.latest_version_type())
-    }
-
     fn inner_types(&self) -> syn::Result<Vec<&Type>> {
         self.version_types()
+    }
+
+    fn as_trait_param(&self) -> Option<syn::Result<&Type>> {
+        Some(self.latest_version_type())
     }
 }
 
@@ -198,19 +236,6 @@ impl DispatchType {
             self.orig_type.span(),
             "VersionsDispatch should be used on a enum with single anonymous field variants",
         )
-    }
-
-    fn generics(&self) -> syn::Result<Generics> {
-        let mut generics = self.orig_type.generics.clone();
-        if let AssociatedTypeKind::Ref(Some(lifetime)) = &self.kind {
-            add_lifetime_bound(&mut generics, lifetime);
-        }
-
-        add_trait_where_clause(&mut generics, self.inner_types()?, &[VERSION_TRAIT_NAME])?;
-
-        add_trait_bound(&mut generics, VERSIONIZE_TRAIT_NAME)?;
-
-        Ok(generics)
     }
 
     /// Returns the number of versions in this dispatch enum

--- a/utils/tfhe-versionable/Cargo.toml
+++ b/utils/tfhe-versionable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tfhe-versionable"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 keywords = ["versioning", "serialization", "encoding"]
 homepage = "https://zama.ai/"
@@ -26,6 +26,6 @@ toml = "0.8"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-tfhe-versionable-derive = { version = "0.2.1", path = "../tfhe-versionable-derive" }
+tfhe-versionable-derive = { version = "0.3.0", path = "../tfhe-versionable-derive" }
 num-complex = { version = "0.4", features = ["serde"] }
 aligned-vec = { version = "0.5", features = ["serde"] }

--- a/utils/tfhe-versionable/README.md
+++ b/utils/tfhe-versionable/README.md
@@ -1,9 +1,15 @@
 # TFHE-versionable
-This crate provides type level versioning for serialized data. It offers a way to add backward
-compatibility on any data type. The versioning scheme works recursively and is independant of the
-chosen serialization backend.
+This crate provides type level versioning for serialized data. It offers a way
+to add backward compatibility on any data type. The versioning scheme works
+recursively and is independant of the chosen serialized file format. It uses the
+`serde` framework.
 
-To use it, simply define an enum that have a variant for each version of your target type.
+The crate will convert any type into an equivalent packed with versions
+information. This "versioned" type is then serializable using any format
+compatible with `serde`.
+
+To use it, simply define an enum that have a variant for each version of your
+target type.
 
 For example, if you have defined an internal type:
 ```rust
@@ -19,7 +25,9 @@ enum MyStructVersions {
 }
 ```
 
-If at a subsequent point in time you want to add a field to this struct, the idea is to copy the previously defined version of the struct and create a new one with the added field. This mostly becomes:
+If at a subsequent point in time you want to add a field to this struct, the
+idea is to copy the previously defined version of the struct and create a new
+one with the added field. This mostly becomes:
 ```rust
 struct MyStruct {
 	val: u32,
@@ -36,16 +44,22 @@ enum MyStructVersions {
 }
 ```
 
-You also have to implement the `Upgrade` trait, that tells how to go from a version to another.
+You also have to implement the `Upgrade` trait, that tells how to go from a
+version to another.
 
-To make this work recursively, this crate defines 3 derive macro that should be used on these types:
-- `Versionize` should be used on the current version of your type, the one that is used in your code
+To make this work recursively, this crate defines 3 derive macro that should be
+used on these types:
+- `Versionize` should be used on the current version of your type, the one that
+  is used in your code
 - `Version` is used on every previous version of this type
 - `VersionsDispatch` is used on the enum holding all the versions
 
-This will implement the `Versionize`/`Unversionize` traits with their `versionize` and `unversionize` methods that should be used before/after the calls to `serialize`/`deserialize`.
+This will implement the `Versionize`/`Unversionize` traits with their
+`versionize` and `unversionize` methods that should be used before/after the
+calls to `serialize`/`deserialize`.
 
-The enum variants should keep their order and names between versions. The only supported operation is to add a new variant.
+The enum variants should keep their order and names between versions. The only
+allowed operation on this enum is to add a new variant.
 
 # Complete example
 ```rust

--- a/utils/tfhe-versionable/examples/associated_bounds.rs
+++ b/utils/tfhe-versionable/examples/associated_bounds.rs
@@ -1,0 +1,39 @@
+/// In this example, we use a generic that is not versionable itself. Only its associated types
+/// should be versioned.
+use tfhe_versionable::{Versionize, VersionsDispatch};
+
+trait WithAssociated {
+    type Assoc;
+    type OtherAssoc;
+}
+
+struct Marker;
+
+impl WithAssociated for Marker {
+    type Assoc = u64;
+
+    type OtherAssoc = u32;
+}
+
+#[derive(VersionsDispatch)]
+#[allow(unused)]
+enum MyStructVersions<T: WithAssociated> {
+    V0(MyStruct<T>),
+}
+
+#[derive(Versionize)]
+#[versionize(MyStructVersions)]
+struct MyStruct<T: WithAssociated> {
+    val: T::Assoc,
+    other_val: T::OtherAssoc,
+}
+
+#[test]
+fn main() {
+    let ms = MyStruct::<Marker> {
+        val: 27,
+        other_val: 54,
+    };
+
+    ms.versionize();
+}

--- a/utils/tfhe-versionable/examples/bounds.rs
+++ b/utils/tfhe-versionable/examples/bounds.rs
@@ -1,52 +1,75 @@
-//! This example shows how to use the `bound` attribute to add a specific bound that is needed to be
-//! able to derive `Versionize`
+//! Example of a simple struct with an Upgrade impl that requires a specific bound.
+//! In that case, the previous versions of the type used a string as a representation, but it has
+//! been changed to a Generic. For the upgrade to work, we need to be able to create this generic
+//! from a String.
 
-use serde::de::DeserializeOwned;
-use serde::Serialize;
-use tfhe_versionable::{
-    Unversionize, UnversionizeError, Versionize, VersionizeOwned, VersionsDispatch,
-};
+use std::error::Error;
+use std::io::Cursor;
+use std::str::FromStr;
 
-// Example of a simple struct with a manual Versionize impl that requires a specific bound
+use tfhe_versionable::{Unversionize, Upgrade, Version, Versionize, VersionsDispatch};
+
+/// The previous version of our application
+mod v0 {
+    use tfhe_versionable::{Versionize, VersionsDispatch};
+
+    #[derive(Versionize)]
+    #[versionize(MyStructVersions)]
+    pub(super) struct MyStruct {
+        pub(super) val: String,
+    }
+
+    #[derive(VersionsDispatch)]
+    #[allow(unused)]
+    pub(super) enum MyStructVersions {
+        V0(MyStruct),
+    }
+}
+
+#[derive(Version)]
+struct MyStructV0 {
+    val: String,
+}
+
+#[derive(Versionize)]
+#[versionize(MyStructVersions)]
 struct MyStruct<T> {
     val: T,
 }
 
-impl<T: Serialize + DeserializeOwned> Versionize for MyStruct<T> {
-    type Versioned<'vers> = &'vers T where T: 'vers;
+impl<T: FromStr> Upgrade<MyStruct<T>> for MyStructV0
+where
+    <T as FromStr>::Err: Error + Send + Sync + 'static,
+{
+    type Error = <T as FromStr>::Err;
 
-    fn versionize(&self) -> Self::Versioned<'_> {
-        &self.val
+    fn upgrade(self) -> Result<MyStruct<T>, Self::Error> {
+        let val = T::from_str(&self.val)?;
+
+        Ok(MyStruct { val })
     }
-}
-
-impl<T: Serialize + DeserializeOwned + ToOwned<Owned = T>> VersionizeOwned for MyStruct<T> {
-    type VersionedOwned = T;
-
-    fn versionize_owned(self) -> Self::VersionedOwned {
-        self.val.to_owned()
-    }
-}
-
-impl<T: Serialize + DeserializeOwned + ToOwned<Owned = T>> Unversionize for MyStruct<T> {
-    fn unversionize(versioned: Self::VersionedOwned) -> Result<Self, UnversionizeError> {
-        Ok(MyStruct { val: versioned })
-    }
-}
-
-// The additional bound can be specified on the parent struct using this attribute. This is similar
-// to what serde does. You can also use #[versionize(OuterVersions, bound(unversionize = "T:
-// ToOwned<Owned = T>"))] if the bound is only needed for the Unversionize impl.
-#[derive(Versionize)]
-#[versionize(OuterVersions, bound = "T: ToOwned<Owned = T>")]
-struct Outer<T> {
-    inner: MyStruct<T>,
 }
 
 #[derive(VersionsDispatch)]
 #[allow(unused)]
-enum OuterVersions<T: ToOwned<Owned = T>> {
-    V0(Outer<T>),
+enum MyStructVersions<T> {
+    V0(MyStructV0),
+    V1(MyStruct<T>),
 }
 
-fn main() {}
+#[test]
+fn main() {
+    let val = 64;
+    let stru_v0 = v0::MyStruct {
+        val: format!("{val}"),
+    };
+
+    let mut ser = Vec::new();
+    ciborium::ser::into_writer(&stru_v0.versionize(), &mut ser).unwrap();
+
+    let unvers =
+        MyStruct::<u64>::unversionize(ciborium::de::from_reader(&mut Cursor::new(&ser)).unwrap())
+            .unwrap();
+
+    assert_eq!(unvers.val, val);
+}

--- a/utils/tfhe-versionable/examples/convert.rs
+++ b/utils/tfhe-versionable/examples/convert.rs
@@ -39,6 +39,7 @@ impl From<SerializableMyStruct> for MyStruct {
     }
 }
 
+#[test]
 fn main() {
     let stru = MyStruct { val: 37 };
 

--- a/utils/tfhe-versionable/examples/failed_upgrade.rs
+++ b/utils/tfhe-versionable/examples/failed_upgrade.rs
@@ -77,6 +77,7 @@ mod v1 {
     }
 }
 
+#[test]
 fn main() {
     let v0 = v0::MyStruct(Some(37));
     let serialized = bincode::serialize(&v0.versionize()).unwrap();

--- a/utils/tfhe-versionable/examples/manual_impl.rs
+++ b/utils/tfhe-versionable/examples/manual_impl.rs
@@ -94,6 +94,7 @@ enum MyStructVersionsDispatchOwned<T: Default + VersionizeOwned> {
     V1(MyStructVersionOwned<T>),
 }
 
+#[test]
 fn main() {
     let ms = MyStruct {
         attr: 37u64,

--- a/utils/tfhe-versionable/examples/not_versioned.rs
+++ b/utils/tfhe-versionable/examples/not_versioned.rs
@@ -1,5 +1,6 @@
 //! This example shows how to create a type that should not be versioned, even if it is
-//! included in other versioned types
+//! included in other versioned types. Of course it means that if this type is modified in the
+//! future, the parent struct should be updated.
 
 use serde::{Deserialize, Serialize};
 use tfhe_versionable::{NotVersioned, Versionize, VersionsDispatch};
@@ -21,4 +22,11 @@ enum MyStructVersions {
     V0(MyStruct),
 }
 
-fn main() {}
+#[test]
+fn main() {
+    let ms = MyStruct {
+        inner: MyStructNotVersioned { val: 1234 },
+    };
+
+    let _versioned = ms.versionize();
+}

--- a/utils/tfhe-versionable/examples/simple.rs
+++ b/utils/tfhe-versionable/examples/simple.rs
@@ -43,14 +43,35 @@ enum MyStructVersions<T: Default> {
     V1(MyStruct<T>),
 }
 
+mod v0 {
+    // This module simulates an older version of our app where we initiated the versioning process.
+    // In real life code this would likely be only present in your git history.
+    use tfhe_versionable::{Versionize, VersionsDispatch};
+
+    #[derive(Versionize)]
+    #[versionize(MyStructVersions)]
+    pub(super) struct MyStruct {
+        pub(super) builtin: u32,
+    }
+
+    #[derive(VersionsDispatch)]
+    #[allow(unused)]
+    pub(super) enum MyStructVersions {
+        V0(MyStruct),
+    }
+}
+
+#[test]
 fn main() {
-    let ms = MyStruct {
-        attr: 37u64,
-        builtin: 1234,
-    };
+    // In the past we saved a value
+    let value = 1234;
+    let ms = v0::MyStruct { builtin: value };
 
     let serialized = bincode::serialize(&ms.versionize()).unwrap();
 
     // This can be called in future versions of your application, when more variants have been added
-    let _unserialized = MyStruct::<u64>::unversionize(bincode::deserialize(&serialized).unwrap());
+    let unserialized =
+        MyStruct::<u64>::unversionize(bincode::deserialize(&serialized).unwrap()).unwrap();
+
+    assert_eq!(unserialized.builtin, value);
 }

--- a/utils/tfhe-versionable/examples/upgrades.rs
+++ b/utils/tfhe-versionable/examples/upgrades.rs
@@ -132,6 +132,7 @@ mod v2 {
     }
 }
 
+#[test]
 fn main() {
     let v0 = v0::MyStruct(37);
 

--- a/utils/tfhe-versionable/examples/vec.rs
+++ b/utils/tfhe-versionable/examples/vec.rs
@@ -1,6 +1,16 @@
-/// The `VersionizeVec` and `UnversionizeVec` traits are also automatically derived
-/// So that Vec can be versioned as well
-use tfhe_versionable::{Versionize, VersionsDispatch};
+//! The `VersionizeVec` and `UnversionizeVec` traits are also automatically derived
+//! So that Vec can be versioned as well. Because of the recursivity, each element of the vec
+//! has its own version tag. For built-in rust types and anything that derives `NotVersioned`,
+//! the versioning of the whole vec is skipped.
+
+use std::convert::Infallible;
+
+use tfhe_versionable::{Unversionize, Upgrade, Version, Versionize, VersionsDispatch};
+
+#[derive(Version)]
+struct MyStructInnerV0 {
+    val: u64,
+}
 
 #[derive(Versionize)]
 #[versionize(MyStructInnerVersions)]
@@ -9,10 +19,22 @@ struct MyStructInner<T> {
     gen: T,
 }
 
+impl<T: Default> Upgrade<MyStructInner<T>> for MyStructInnerV0 {
+    type Error = Infallible;
+
+    fn upgrade(self) -> Result<MyStructInner<T>, Self::Error> {
+        Ok(MyStructInner {
+            val: self.val,
+            gen: T::default(),
+        })
+    }
+}
+
 #[derive(VersionsDispatch)]
 #[allow(unused)]
 enum MyStructInnerVersions<T> {
-    V0(MyStructInner<T>),
+    V0(MyStructInnerV0),
+    V1(MyStructInner<T>),
 }
 
 #[derive(Versionize)]
@@ -27,4 +49,49 @@ enum MyVecVersions<T> {
     V0(MyVec<T>),
 }
 
-fn main() {}
+mod v0 {
+    use tfhe_versionable::{Versionize, VersionsDispatch};
+
+    #[derive(Versionize)]
+    #[versionize(MyStructInnerVersions)]
+    pub(super) struct MyStructInner {
+        pub(super) val: u64,
+    }
+
+    #[derive(VersionsDispatch)]
+    #[allow(unused)]
+    pub(super) enum MyStructInnerVersions {
+        V0(MyStructInner),
+    }
+
+    #[derive(Versionize)]
+    #[versionize(MyVecVersions)]
+    pub(super) struct MyVec {
+        pub(super) vec: Vec<MyStructInner>,
+    }
+
+    #[derive(VersionsDispatch)]
+    #[allow(unused)]
+    pub(super) enum MyVecVersions {
+        V0(MyVec),
+    }
+}
+
+#[test]
+fn main() {
+    let values: [u64; 6] = [12, 23, 34, 45, 56, 67];
+    let vec = values
+        .iter()
+        .map(|val| v0::MyStructInner { val: *val })
+        .collect();
+    let mv = v0::MyVec { vec };
+
+    let serialized = bincode::serialize(&mv.versionize()).unwrap();
+
+    let unserialized =
+        MyVec::<u64>::unversionize(bincode::deserialize(&serialized).unwrap()).unwrap();
+
+    let unser_values: Vec<u64> = unserialized.vec.iter().map(|inner| inner.val).collect();
+
+    assert_eq!(unser_values, values);
+}

--- a/utils/tfhe-versionable/src/upgrade.rs
+++ b/utils/tfhe-versionable/src/upgrade.rs
@@ -3,6 +3,6 @@
 /// This trait should be implemented for each version of the original type that is not the current
 /// one. The upgrade method is called in chains until we get to the last version of the type.
 pub trait Upgrade<T> {
-    type Error: std::error::Error;
+    type Error: std::error::Error + Send + Sync + 'static;
     fn upgrade(self) -> Result<T, Self::Error>;
 }

--- a/utils/tfhe-versionable/tests/bounds_private_in_public.rs
+++ b/utils/tfhe-versionable/tests/bounds_private_in_public.rs
@@ -1,0 +1,44 @@
+//! This test checks that the bounds added by the proc macro does not prevent the code to
+//! compile by leaking a private type
+use tfhe_versionable::Versionize;
+
+mod mymod {
+    use tfhe_versionable::{Versionize, VersionsDispatch};
+
+    #[derive(Versionize)]
+    #[versionize(PublicVersions)]
+    pub struct Public<T> {
+        private: Private<T>,
+    }
+
+    impl Public<u64> {
+        pub fn new(val: u64) -> Self {
+            Self {
+                private: Private(val),
+            }
+        }
+    }
+
+    #[derive(VersionsDispatch)]
+    #[allow(unused)]
+    pub enum PublicVersions<T> {
+        V0(Public<T>),
+    }
+
+    #[derive(Versionize)]
+    #[versionize(PrivateVersions)]
+    struct Private<T>(T);
+
+    #[derive(VersionsDispatch)]
+    #[allow(dead_code)]
+    enum PrivateVersions<T> {
+        V0(Private<T>),
+    }
+}
+
+#[test]
+fn bounds_private_in_public() {
+    let public = mymod::Public::new(42);
+
+    let _vers = public.versionize();
+}


### PR DESCRIPTION
needed by: #1482 

### PR content/description
Fix the bounds added in the derived traits for the Versionize macro. These bounds were too restrictive and there were cases where they were not satisfiable, so the `versionize` method on a type was actually not callable. This was the case for example when a type was defined with a generic that is not itself used, but only through associated types. For example:

```rust
trait WithAssoc {
  type Assoc;
}

struct MyStruct<T: WithAssoc> {
  inner: T::Assoc
}
```

Using the `#[derive(Versionize)]` on this type before the PR would require `T: Versionize` which is actually not necessary and sometimes not possible. This was caused by the proc macro trying to apply bounds directly on the generics of the type.

The main idea behind this PR is to add bounds closer to what is actually used, and not necessarily to the generics. For example, If I have 3 traits:
```rust
trait TraitA {}

trait TraitB {
  fn method_b(&self);
}

trait TraitC {
  fn method_c(&self);
}
```

and these 2 types:
```rust
struct Type1<T> {
  value: T
}

impl<T: TraitA> TraitB for Type1<T> {
  fn method_b(&self) {}
}

struct Type2<T> {
  inner: Type1<T>
}

impl<T: ??> TraitC for Type2<T> where ?? {
  fn method_c(&self) {
    self.inner.method_b();
  }
}
```
I have 2 ways of expressing the bound:
- `impl<T: TraitA> TraitC for Type2<T>`
- `impl<T> TraitC for Type2<T> where Type1<T>: TraitB`

This PR works by using the second method instead of the first one. The advantage is that theses bounds are easier to generate by looking only at `Type2`, without knowing the internals of `Type1`.

As a side effect, the `#[versionize(..., bound = "...")]` attribute for the proc macro is not necessary anymore to express the bounds present in tfhe-rs, so it have been removed. This is a **breaking change**. There might still be specific corner cases that will require it, but as I don't have any example to test it I preferred to removed it.


This PR also adds the versioning of vector of small tuples of arbitrary versioned types.

### Check-list:

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [x] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
