### PR TITLE
Ns/clippy versionable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -318,9 +318,17 @@ clippy_zk_pok: install_rs_check_toolchain
 	RUSTFLAGS="$(RUSTFLAGS)" cargo "$(CARGO_RS_CHECK_TOOLCHAIN)" clippy --all-targets \
 		-p tfhe-zk-pok -- --no-deps -D warnings
 
+.PHONY: clippy_versionable # Run clippy lints on tfhe-versionable
+clippy_versionable: install_rs_check_toolchain
+	RUSTFLAGS="$(RUSTFLAGS)" cargo "$(CARGO_RS_CHECK_TOOLCHAIN)" clippy --all-targets \
+		-p tfhe-versionable-derive -- --no-deps -D warnings
+	RUSTFLAGS="$(RUSTFLAGS)" cargo "$(CARGO_RS_CHECK_TOOLCHAIN)" clippy --all-targets \
+		-p tfhe-versionable -- --no-deps -D warnings
+
 .PHONY: clippy_all # Run all clippy targets
 clippy_all: clippy_rustdoc clippy clippy_boolean clippy_shortint clippy_integer clippy_all_targets \
-clippy_c_api clippy_js_wasm_api clippy_tasks clippy_core clippy_concrete_csprng clippy_zk_pok clippy_trivium
+clippy_c_api clippy_js_wasm_api clippy_tasks clippy_core clippy_concrete_csprng clippy_zk_pok clippy_trivium \
+clippy_versionable
 
 .PHONY: clippy_fast # Run main clippy targets
 clippy_fast: clippy_rustdoc clippy clippy_all_targets clippy_c_api clippy_js_wasm_api clippy_tasks \

--- a/utils/tfhe-versionable/Cargo.toml
+++ b/utils/tfhe-versionable/Cargo.toml
@@ -29,3 +29,43 @@ serde = { version = "1.0", features = ["derive"] }
 tfhe-versionable-derive = { version = "0.3.0", path = "../tfhe-versionable-derive" }
 num-complex = { version = "0.4", features = ["serde"] }
 aligned-vec = { version = "0.5", features = ["serde"] }
+
+[[example]]
+name = "manual_impl"
+test = true
+
+[[example]]
+name = "simple"
+test = true
+
+[[example]]
+name = "recursive"
+test = true
+
+[[example]]
+name = "upgrades"
+test = true
+
+[[example]]
+name = "failed_upgrade"
+test = true
+
+[[example]]
+name = "not_versioned"
+test = true
+
+[[example]]
+name = "convert"
+test = true
+
+[[example]]
+name = "vec"
+test = true
+
+[[example]]
+name = "bounds"
+test = true
+
+[[example]]
+name = "associated_bounds"
+test = true

--- a/utils/tfhe-versionable/examples/associated_bounds.rs
+++ b/utils/tfhe-versionable/examples/associated_bounds.rs
@@ -28,7 +28,6 @@ struct MyStruct<T: WithAssociated> {
     other_val: T::OtherAssoc,
 }
 
-#[test]
 fn main() {
     let ms = MyStruct::<Marker> {
         val: 27,
@@ -36,4 +35,9 @@ fn main() {
     };
 
     ms.versionize();
+}
+
+#[test]
+fn test() {
+    main()
 }

--- a/utils/tfhe-versionable/examples/bounds.rs
+++ b/utils/tfhe-versionable/examples/bounds.rs
@@ -57,7 +57,6 @@ enum MyStructVersions<T> {
     V1(MyStruct<T>),
 }
 
-#[test]
 fn main() {
     let val = 64;
     let stru_v0 = v0::MyStruct {
@@ -72,4 +71,9 @@ fn main() {
             .unwrap();
 
     assert_eq!(unvers.val, val);
+}
+
+#[test]
+fn test() {
+    main()
 }

--- a/utils/tfhe-versionable/examples/convert.rs
+++ b/utils/tfhe-versionable/examples/convert.rs
@@ -39,7 +39,6 @@ impl From<SerializableMyStruct> for MyStruct {
     }
 }
 
-#[test]
 fn main() {
     let stru = MyStruct { val: 37 };
 
@@ -48,4 +47,9 @@ fn main() {
     let stru_decoded = MyStruct::unversionize(bincode::deserialize(&serialized).unwrap()).unwrap();
 
     assert_eq!(stru.val, stru_decoded.val)
+}
+
+#[test]
+fn test() {
+    main()
 }

--- a/utils/tfhe-versionable/examples/failed_upgrade.rs
+++ b/utils/tfhe-versionable/examples/failed_upgrade.rs
@@ -77,7 +77,6 @@ mod v1 {
     }
 }
 
-#[test]
 fn main() {
     let v0 = v0::MyStruct(Some(37));
     let serialized = bincode::serialize(&v0.versionize()).unwrap();
@@ -90,4 +89,9 @@ fn main() {
     let serialized_empty = bincode::serialize(&v0_empty.versionize()).unwrap();
 
     assert!(v1::MyStruct::unversionize(bincode::deserialize(&serialized_empty).unwrap()).is_err());
+}
+
+#[test]
+fn test() {
+    main()
 }

--- a/utils/tfhe-versionable/examples/manual_impl.rs
+++ b/utils/tfhe-versionable/examples/manual_impl.rs
@@ -94,7 +94,6 @@ enum MyStructVersionsDispatchOwned<T: Default + VersionizeOwned> {
     V1(MyStructVersionOwned<T>),
 }
 
-#[test]
 fn main() {
     let ms = MyStruct {
         attr: 37u64,
@@ -104,4 +103,9 @@ fn main() {
     let serialized = bincode::serialize(&ms.versionize()).unwrap();
 
     let _unserialized = MyStruct::<u64>::unversionize(bincode::deserialize(&serialized).unwrap());
+}
+
+#[test]
+fn test() {
+    main()
 }

--- a/utils/tfhe-versionable/examples/not_versioned.rs
+++ b/utils/tfhe-versionable/examples/not_versioned.rs
@@ -22,11 +22,15 @@ enum MyStructVersions {
     V0(MyStruct),
 }
 
-#[test]
 fn main() {
     let ms = MyStruct {
         inner: MyStructNotVersioned { val: 1234 },
     };
 
     let _versioned = ms.versionize();
+}
+
+#[test]
+fn test() {
+    main()
 }

--- a/utils/tfhe-versionable/examples/recursive.rs
+++ b/utils/tfhe-versionable/examples/recursive.rs
@@ -76,7 +76,6 @@ mod v0 {
     }
 }
 
-#[test]
 fn main() {
     let builtin = 654;
     let inner = v0::MyStructInner { builtin: 654 };
@@ -89,4 +88,9 @@ fn main() {
         MyStruct::<u64>::unversionize(bincode::deserialize(&serialized).unwrap()).unwrap();
 
     assert_eq!(unserialized.inner.builtin, builtin);
+}
+
+#[test]
+fn test() {
+    main()
 }

--- a/utils/tfhe-versionable/examples/simple.rs
+++ b/utils/tfhe-versionable/examples/simple.rs
@@ -61,7 +61,6 @@ mod v0 {
     }
 }
 
-#[test]
 fn main() {
     // In the past we saved a value
     let value = 1234;
@@ -74,4 +73,9 @@ fn main() {
         MyStruct::<u64>::unversionize(bincode::deserialize(&serialized).unwrap()).unwrap();
 
     assert_eq!(unserialized.builtin, value);
+}
+
+#[test]
+fn test() {
+    main()
 }

--- a/utils/tfhe-versionable/examples/upgrades.rs
+++ b/utils/tfhe-versionable/examples/upgrades.rs
@@ -132,7 +132,6 @@ mod v2 {
     }
 }
 
-#[test]
 fn main() {
     let v0 = v0::MyStruct(37);
 
@@ -147,4 +146,9 @@ fn main() {
 
     assert_eq!(v0.0, v2.count);
     assert_eq!(v2.attr, u64::default());
+}
+
+#[test]
+fn test() {
+    main()
 }

--- a/utils/tfhe-versionable/examples/vec.rs
+++ b/utils/tfhe-versionable/examples/vec.rs
@@ -77,7 +77,6 @@ mod v0 {
     }
 }
 
-#[test]
 fn main() {
     let values: [u64; 6] = [12, 23, 34, 45, 56, 67];
     let vec = values
@@ -94,4 +93,9 @@ fn main() {
     let unser_values: Vec<u64> = unserialized.vec.iter().map(|inner| inner.val).collect();
 
     assert_eq!(unser_values, values);
+}
+
+#[test]
+fn test() {
+    main()
 }


### PR DESCRIPTION
The idea is to run examples as tests, as it is not done by default by `cargo test` (even with `cargo test --examples`). Adding the `#[test]` to the main worked with `cargo test --examples` but not in the other cases.