### PR TITLE
refactor!: gate wops behind "experimental" feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -285,11 +285,17 @@ clippy_shortint: install_rs_check_toolchain
 	RUSTFLAGS="$(RUSTFLAGS)" cargo "$(CARGO_RS_CHECK_TOOLCHAIN)" clippy \
 		--features=$(TARGET_ARCH_FEATURE),shortint \
 		-p $(TFHE_SPEC) -- --no-deps -D warnings
+	RUSTFLAGS="$(RUSTFLAGS)" cargo "$(CARGO_RS_CHECK_TOOLCHAIN)" clippy \
+		--features=$(TARGET_ARCH_FEATURE),shortint,experimental \
+		-p $(TFHE_SPEC) -- --no-deps -D warnings
 
 .PHONY: clippy_integer # Run clippy lints enabling the integer features
 clippy_integer: install_rs_check_toolchain
 	RUSTFLAGS="$(RUSTFLAGS)" cargo "$(CARGO_RS_CHECK_TOOLCHAIN)" clippy \
 		--features=$(TARGET_ARCH_FEATURE),integer \
+		-p $(TFHE_SPEC) -- --no-deps -D warnings
+	RUSTFLAGS="$(RUSTFLAGS)" cargo "$(CARGO_RS_CHECK_TOOLCHAIN)" clippy \
+		--features=$(TARGET_ARCH_FEATURE),integer,experimental \
 		-p $(TFHE_SPEC) -- --no-deps -D warnings
 
 .PHONY: clippy # Run clippy lints enabling the boolean, shortint, integer
@@ -338,6 +344,9 @@ clippy_trivium: install_rs_check_toolchain
 clippy_all_targets: install_rs_check_toolchain
 	RUSTFLAGS="$(RUSTFLAGS)" cargo "$(CARGO_RS_CHECK_TOOLCHAIN)" clippy --all-targets \
 		--features=$(TARGET_ARCH_FEATURE),boolean,shortint,integer,internal-keycache,zk-pok \
+		-p $(TFHE_SPEC) -- --no-deps -D warnings
+	RUSTFLAGS="$(RUSTFLAGS)" cargo "$(CARGO_RS_CHECK_TOOLCHAIN)" clippy --all-targets \
+		--features=$(TARGET_ARCH_FEATURE),boolean,shortint,integer,internal-keycache,zk-pok,experimental \
 		-p $(TFHE_SPEC) -- --no-deps -D warnings
 
 .PHONY: clippy_concrete_csprng # Run clippy lints on concrete-csprng

--- a/scripts/integer-tests.sh
+++ b/scripts/integer-tests.sh
@@ -155,7 +155,7 @@ cargo "${RUST_TOOLCHAIN}" nextest run \
     --cargo-profile "${cargo_profile}" \
     --package "${tfhe_package}" \
     --profile ci \
-    --features="${ARCH_FEATURE}",integer,internal-keycache,zk-pok,"${avx512_feature}","${gpu_feature}" \
+    --features="${ARCH_FEATURE}",integer,internal-keycache,zk-pok,experimental,"${avx512_feature}","${gpu_feature}" \
     --test-threads "${test_threads}" \
     -E "$filter_expression"
 
@@ -163,7 +163,7 @@ if [[ -z ${multi_bit_argument} ]]; then
     cargo "${RUST_TOOLCHAIN}" test \
         --profile "${cargo_profile}" \
         --package "${tfhe_package}" \
-        --features="${ARCH_FEATURE}",integer,internal-keycache,"${avx512_feature}","${gpu_feature}" \
+        --features="${ARCH_FEATURE}",integer,internal-keycache,experimental,"${avx512_feature}","${gpu_feature}" \
         --doc \
         -- --test-threads="${doctest_threads}" integer::"${gpu_feature}"
 fi

--- a/scripts/shortint-tests.sh
+++ b/scripts/shortint-tests.sh
@@ -101,7 +101,7 @@ if [[ "${BIG_TESTS_INSTANCE}" != TRUE ]]; then
         --cargo-profile "${cargo_profile}" \
         --package "${tfhe_package}" \
         --profile ci \
-        --features="${ARCH_FEATURE}",shortint,internal-keycache,zk-pok \
+        --features="${ARCH_FEATURE}",shortint,internal-keycache,zk-pok,experimental \
         --test-threads "${n_threads_small}" \
         -E "${filter_expression_small_params}"
 
@@ -118,7 +118,7 @@ and not test(~smart_add_and_mul)"""
         --cargo-profile "${cargo_profile}" \
         --package "${tfhe_package}" \
         --profile ci \
-        --features="${ARCH_FEATURE}",shortint,internal-keycache \
+        --features="${ARCH_FEATURE}",shortint,internal-keycache,experimental \
         --test-threads "${n_threads_big}" \
         -E "${filter_expression_big_params}"
 
@@ -126,7 +126,7 @@ and not test(~smart_add_and_mul)"""
             cargo "${RUST_TOOLCHAIN}" test \
                 --profile "${cargo_profile}" \
                 --package "${tfhe_package}" \
-                --features="${ARCH_FEATURE}",shortint,internal-keycache \
+                --features="${ARCH_FEATURE}",shortint,internal-keycache,experimental \
                 --doc \
                 -- shortint::
         fi
@@ -140,7 +140,7 @@ else
         --cargo-profile "${cargo_profile}" \
         --package "${tfhe_package}" \
         --profile ci \
-        --features="${ARCH_FEATURE}",shortint,internal-keycache \
+        --features="${ARCH_FEATURE}",shortint,internal-keycache,experimental \
         --test-threads "${n_threads_big}" \
         -E "${filter_expression}"
 
@@ -148,7 +148,7 @@ else
         cargo "${RUST_TOOLCHAIN}" test \
             --profile "${cargo_profile}" \
             --package "${tfhe_package}" \
-            --features="${ARCH_FEATURE}",shortint,internal-keycache \
+            --features="${ARCH_FEATURE}",shortint,internal-keycache,experimental \
             --doc \
             -- --test-threads="${n_threads_big}" shortint::
     fi

--- a/tfhe/examples/utilities/generates_test_keys.rs
+++ b/tfhe/examples/utilities/generates_test_keys.rs
@@ -2,7 +2,9 @@ use clap::{Arg, ArgAction, Command};
 use tfhe::boolean;
 use tfhe::boolean::parameters::{BooleanParameters, DEFAULT_PARAMETERS, DEFAULT_PARAMETERS_KS_PBS};
 use tfhe::keycache::NamedParam;
-use tfhe::shortint::keycache::{KEY_CACHE, KEY_CACHE_KSK, KEY_CACHE_WOPBS};
+#[cfg(feature = "experimental")]
+use tfhe::shortint::keycache::KEY_CACHE_WOPBS;
+use tfhe::shortint::keycache::{KEY_CACHE, KEY_CACHE_KSK};
 #[cfg(tarpaulin)]
 use tfhe::shortint::parameters::coverage_parameters::{
     COVERAGE_PARAM_MESSAGE_2_CARRY_2_COMPACT_PK_KS_PBS,
@@ -14,14 +16,16 @@ use tfhe::shortint::parameters::key_switching::p_fail_2_minus_64::ks_pbs::PARAM_
 use tfhe::shortint::parameters::key_switching::ShortintKeySwitchingParameters;
 
 use tfhe::shortint::parameters::{
-    ClassicPBSParameters, WopbsParameters, ALL_MULTI_BIT_PARAMETER_VEC,
-    PARAM_MESSAGE_1_CARRY_1_KS_PBS, PARAM_MESSAGE_1_CARRY_2_KS_PBS, PARAM_MESSAGE_1_CARRY_3_KS_PBS,
-    PARAM_MESSAGE_1_CARRY_4_KS_PBS, PARAM_MESSAGE_1_CARRY_5_KS_PBS, PARAM_MESSAGE_1_CARRY_6_KS_PBS,
-    PARAM_MESSAGE_2_CARRY_1_KS_PBS, PARAM_MESSAGE_2_CARRY_2_KS_PBS, PARAM_MESSAGE_2_CARRY_3_KS_PBS,
-    PARAM_MESSAGE_3_CARRY_1_KS_PBS, PARAM_MESSAGE_3_CARRY_2_KS_PBS, PARAM_MESSAGE_3_CARRY_3_KS_PBS,
-    PARAM_MESSAGE_4_CARRY_4_KS_PBS, WOPBS_PARAM_MESSAGE_1_CARRY_1_KS_PBS,
-    WOPBS_PARAM_MESSAGE_2_CARRY_2_KS_PBS, WOPBS_PARAM_MESSAGE_3_CARRY_3_KS_PBS,
-    WOPBS_PARAM_MESSAGE_4_CARRY_4_KS_PBS,
+    ClassicPBSParameters, ALL_MULTI_BIT_PARAMETER_VEC, PARAM_MESSAGE_1_CARRY_1_KS_PBS,
+    PARAM_MESSAGE_1_CARRY_2_KS_PBS, PARAM_MESSAGE_1_CARRY_3_KS_PBS, PARAM_MESSAGE_1_CARRY_4_KS_PBS,
+    PARAM_MESSAGE_1_CARRY_5_KS_PBS, PARAM_MESSAGE_1_CARRY_6_KS_PBS, PARAM_MESSAGE_2_CARRY_1_KS_PBS,
+    PARAM_MESSAGE_2_CARRY_2_KS_PBS, PARAM_MESSAGE_2_CARRY_3_KS_PBS, PARAM_MESSAGE_3_CARRY_1_KS_PBS,
+    PARAM_MESSAGE_3_CARRY_2_KS_PBS, PARAM_MESSAGE_3_CARRY_3_KS_PBS, PARAM_MESSAGE_4_CARRY_4_KS_PBS,
+};
+#[cfg(feature = "experimental")]
+use tfhe::shortint::parameters::{
+    WopbsParameters, WOPBS_PARAM_MESSAGE_1_CARRY_1_KS_PBS, WOPBS_PARAM_MESSAGE_2_CARRY_2_KS_PBS,
+    WOPBS_PARAM_MESSAGE_3_CARRY_3_KS_PBS, WOPBS_PARAM_MESSAGE_4_CARRY_4_KS_PBS,
 };
 use tfhe::shortint::MultiBitPBSParameters;
 
@@ -89,11 +93,14 @@ fn client_server_keys() {
 
         generate_ksk_keys(&KSK_PARAMS);
 
-        const WOPBS_PARAMS: [(ClassicPBSParameters, WopbsParameters); 1] = [(
-            PARAM_MESSAGE_2_CARRY_2_KS_PBS,
-            WOPBS_PARAM_MESSAGE_2_CARRY_2_KS_PBS,
-        )];
-        generate_wopbs_keys(&WOPBS_PARAMS);
+        #[cfg(feature = "experimental")]
+        {
+            const WOPBS_PARAMS: [(ClassicPBSParameters, WopbsParameters); 1] = [(
+                PARAM_MESSAGE_2_CARRY_2_KS_PBS,
+                WOPBS_PARAM_MESSAGE_2_CARRY_2_KS_PBS,
+            )];
+            generate_wopbs_keys(&WOPBS_PARAMS);
+        }
 
         const BOOLEAN_PARAMS: [BooleanParameters; 2] =
             [DEFAULT_PARAMETERS, DEFAULT_PARAMETERS_KS_PBS];
@@ -116,26 +123,29 @@ fn client_server_keys() {
         ];
         generate_pbs_keys(&PBS_KEYS);
 
-        const WOPBS_PARAMS: [(ClassicPBSParameters, WopbsParameters); 4] = [
-            (
-                PARAM_MESSAGE_1_CARRY_1_KS_PBS,
-                WOPBS_PARAM_MESSAGE_1_CARRY_1_KS_PBS,
-            ),
-            (
-                PARAM_MESSAGE_2_CARRY_2_KS_PBS,
-                WOPBS_PARAM_MESSAGE_2_CARRY_2_KS_PBS,
-            ),
-            (
-                PARAM_MESSAGE_3_CARRY_3_KS_PBS,
-                WOPBS_PARAM_MESSAGE_3_CARRY_3_KS_PBS,
-            ),
-            (
-                PARAM_MESSAGE_4_CARRY_4_KS_PBS,
-                WOPBS_PARAM_MESSAGE_4_CARRY_4_KS_PBS,
-            ),
-        ];
+        #[cfg(feature = "experimental")]
+        {
+            const WOPBS_PARAMS: [(ClassicPBSParameters, WopbsParameters); 4] = [
+                (
+                    PARAM_MESSAGE_1_CARRY_1_KS_PBS,
+                    WOPBS_PARAM_MESSAGE_1_CARRY_1_KS_PBS,
+                ),
+                (
+                    PARAM_MESSAGE_2_CARRY_2_KS_PBS,
+                    WOPBS_PARAM_MESSAGE_2_CARRY_2_KS_PBS,
+                ),
+                (
+                    PARAM_MESSAGE_3_CARRY_3_KS_PBS,
+                    WOPBS_PARAM_MESSAGE_3_CARRY_3_KS_PBS,
+                ),
+                (
+                    PARAM_MESSAGE_4_CARRY_4_KS_PBS,
+                    WOPBS_PARAM_MESSAGE_4_CARRY_4_KS_PBS,
+                ),
+            ];
 
-        generate_wopbs_keys(&WOPBS_PARAMS);
+            generate_wopbs_keys(&WOPBS_PARAMS);
+        }
     }
 }
 
@@ -219,6 +229,7 @@ fn generate_ksk_keys(
     }
 }
 
+#[cfg(feature = "experimental")]
 fn generate_wopbs_keys(params: &[(ClassicPBSParameters, WopbsParameters)]) {
     println!("Generating woPBS keys");
 

--- a/tfhe/src/integer/keycache.rs
+++ b/tfhe/src/integer/keycache.rs
@@ -1,6 +1,9 @@
+#[cfg(feature = "experimental")]
 use crate::integer::wopbs::WopbsKey;
 use crate::integer::{ClientKey, IntegerKeyKind, ServerKey};
-use crate::shortint::{PBSParameters, WopbsParameters};
+use crate::shortint::PBSParameters;
+#[cfg(feature = "experimental")]
+use crate::shortint::WopbsParameters;
 use lazy_static::lazy_static;
 
 #[derive(Default)]
@@ -39,8 +42,10 @@ impl IntegerKeyCache {
 }
 
 #[derive(Default)]
+#[cfg(feature = "experimental")]
 pub struct WopbsKeyCache;
 
+#[cfg(feature = "experimental")]
 impl WopbsKeyCache {
     pub fn get_from_params<P>(&self, (pbs_params, wopbs_params): (P, WopbsParameters)) -> WopbsKey
     where
@@ -65,5 +70,8 @@ impl WopbsKeyCache {
 
 lazy_static! {
     pub static ref KEY_CACHE: IntegerKeyCache = IntegerKeyCache;
+}
+#[cfg(feature = "experimental")]
+lazy_static! {
     pub static ref KEY_CACHE_WOPBS: WopbsKeyCache = WopbsKeyCache;
 }

--- a/tfhe/src/integer/mod.rs
+++ b/tfhe/src/integer/mod.rs
@@ -63,7 +63,10 @@ pub mod parameters;
 pub mod prelude;
 pub mod public_key;
 pub mod server_key;
+#[cfg(feature = "experimental")]
 pub mod wopbs;
+#[cfg(not(feature = "experimental"))]
+pub(crate) mod wopbs;
 
 #[cfg(feature = "gpu")]
 pub mod gpu;

--- a/tfhe/src/integer/wopbs/mod.rs
+++ b/tfhe/src/integer/wopbs/mod.rs
@@ -3,19 +3,11 @@
 //! This module implements the generation of another server public key, which allows to compute
 //! an alternative version of the programmable bootstrapping. This does not require the use of a
 //! bit of padding.
-#[cfg(test)]
+#[cfg(all(test, feature = "experimental"))]
 mod test;
 
 use super::backward_compatibility::wopbs::WopbsKeyVersions;
-use super::ciphertext::RadixCiphertext;
-pub use crate::core_crypto::commons::parameters::{CiphertextCount, PlaintextCount};
-use crate::core_crypto::prelude::*;
-use crate::integer::client_key::utils::i_crt;
-use crate::integer::{ClientKey, CrtCiphertext, IntegerCiphertext, ServerKey};
-use crate::shortint::ciphertext::{Degree, NoiseLevel};
-use crate::shortint::wopbs::WopbsLUTBase;
-use crate::shortint::WopbsParameters;
-use rayon::prelude::*;
+
 use serde::{Deserialize, Serialize};
 use tfhe_versionable::Versionize;
 
@@ -25,1077 +17,316 @@ pub struct WopbsKey {
     wopbs_key: crate::shortint::wopbs::WopbsKey,
 }
 
-#[must_use]
-pub struct IntegerWopbsLUT {
-    inner: WopbsLUTBase,
-}
+#[cfg(feature = "experimental")]
+pub use experimental::*;
 
-impl IntegerWopbsLUT {
-    pub fn new(small_lut_size: PlaintextCount, output_ciphertext_count: CiphertextCount) -> Self {
-        Self {
-            inner: WopbsLUTBase::new(small_lut_size, output_ciphertext_count),
-        }
-    }
-}
+#[cfg(feature = "experimental")]
+mod experimental {
+    pub use crate::core_crypto::commons::parameters::{CiphertextCount, PlaintextCount};
+    use crate::core_crypto::prelude::*;
+    use crate::integer::client_key::utils::i_crt;
+    use crate::integer::{ClientKey, CrtCiphertext, IntegerCiphertext, RadixCiphertext, ServerKey};
+    use crate::shortint::ciphertext::{Degree, NoiseLevel};
+    use crate::shortint::WopbsParameters;
 
-impl TryFrom<Vec<Vec<u64>>> for IntegerWopbsLUT {
-    type Error = &'static str;
+    use crate::shortint::wopbs::WopbsLUTBase;
 
-    fn try_from(value: Vec<Vec<u64>>) -> Result<Self, Self::Error> {
-        let small_lut_size = value[0].len();
-        if !value.iter().all(|x| x.len() == small_lut_size) {
-            return Err("All small luts must have the same size");
-        }
+    use super::WopbsKey;
 
-        let small_lut_count = value.len();
+    use rayon::prelude::*;
 
-        Ok(Self {
-            inner: WopbsLUTBase::from_vec(
-                value.into_iter().flatten().collect(),
-                CiphertextCount(small_lut_count),
-            ),
-        })
-    }
-}
-
-impl AsRef<WopbsLUTBase> for IntegerWopbsLUT {
-    fn as_ref(&self) -> &WopbsLUTBase {
-        &self.inner
-    }
-}
-
-impl AsMut<WopbsLUTBase> for IntegerWopbsLUT {
-    fn as_mut(&mut self) -> &mut WopbsLUTBase {
-        &mut self.inner
-    }
-}
-
-impl std::ops::Index<usize> for IntegerWopbsLUT {
-    type Output = [u64];
-
-    fn index(&self, index: usize) -> &Self::Output {
-        self.as_ref().get_small_lut(index)
-    }
-}
-
-impl std::ops::IndexMut<usize> for IntegerWopbsLUT {
-    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-        self.as_mut().get_small_lut_mut(index)
-    }
-}
-
-/// ```rust
-/// use tfhe::integer::wopbs::{decode_radix, encode_radix};
-///
-/// let val = 11;
-/// let basis = 2;
-/// let nb_block = 5;
-/// let radix = encode_radix(val, basis, nb_block);
-///
-/// assert_eq!(val, decode_radix(&radix, basis));
-/// ```
-pub fn encode_radix(val: u64, basis: u64, nb_block: u64) -> Vec<u64> {
-    let mut output = vec![];
-    //Bits of message put to 1éfé
-    let mask = basis - 1;
-
-    let mut power = 1_u64;
-    //Put each decomposition into a new ciphertext
-    for _ in 0..nb_block {
-        let mut decomp = val & (mask * power);
-        decomp /= power;
-
-        // fill the vector with the message moduli
-        output.push(decomp);
-
-        //modulus to the power i
-        power *= basis;
-    }
-    output
-}
-
-pub fn encode_crt(val: u64, basis: &[u64]) -> Vec<u64> {
-    let mut output = vec![];
-    //Put each decomposition into a new ciphertext
-    for i in basis {
-        output.push(val % i);
-    }
-    output
-}
-
-//Concatenate two ciphertexts in one
-//Used to compute bivariate wopbs
-fn ciphertext_concatenation<T>(ct1: &T, ct2: &T) -> T
-where
-    T: IntegerCiphertext,
-{
-    let mut new_blocks = ct1.blocks().to_vec();
-    new_blocks.extend_from_slice(ct2.blocks());
-    T::from_blocks(new_blocks)
-}
-
-pub fn encode_mix_radix(mut val: u64, basis: &[u64], modulus: u64) -> Vec<u64> {
-    let mut output = vec![];
-    for basis in basis.iter() {
-        output.push(val % modulus);
-        val -= val % modulus;
-        let tmp = (val % (1 << basis)) >> (f64::log2(modulus as f64) as u64);
-        val >>= basis;
-        val += tmp;
-    }
-    output
-}
-
-// Example: val = 5 = 0b101 , basis = [1,2] -> output = [1, 1]
-/// ```rust
-/// use tfhe::integer::wopbs::split_value_according_to_bit_basis;
-/// // Generate the client key and the server key:
-/// let val = 5;
-/// let basis = vec![1, 2];
-/// assert_eq!(vec![1, 2], split_value_according_to_bit_basis(val, &basis));
-/// ```
-pub fn split_value_according_to_bit_basis(value: u64, basis: &[u64]) -> Vec<u64> {
-    let mut output = vec![];
-    let mut tmp = value;
-    let mask = 1;
-
-    for i in basis {
-        let mut tmp_output = 0;
-        for j in 0..*i {
-            let val = tmp & mask;
-            tmp_output += val << j;
-            tmp >>= 1;
-        }
-        output.push(tmp_output);
-    }
-    output
-}
-
-/// ```rust
-/// use tfhe::integer::wopbs::{decode_radix, encode_radix};
-///
-/// let val = 11;
-/// let basis = 2;
-/// let nb_block = 5;
-/// let radix = encode_radix(val, basis, nb_block);
-///
-/// assert_eq!(val, decode_radix(&radix, basis));
-/// ```
-pub fn decode_radix(val: &[u64], basis: u64) -> u64 {
-    let mut result = 0_u64;
-    let mut shift = 1_u64;
-    for v_i in val.iter() {
-        //decrypt the component i of the integer and multiply it by the radix product
-        let tmp = v_i.wrapping_mul(shift);
-
-        // update the result
-        result = result.wrapping_add(tmp);
-
-        // update the shift for the next iteration
-        shift = shift.wrapping_mul(basis);
-    }
-    result
-}
-
-impl From<crate::shortint::wopbs::WopbsKey> for WopbsKey {
-    fn from(wopbs_key: crate::shortint::wopbs::WopbsKey) -> Self {
-        Self { wopbs_key }
-    }
-}
-
-impl WopbsKey {
-    /// Generates the server key required to compute a WoPBS from the client and the server keys.
-    /// # Example
-    /// ```rust
-    /// use tfhe::integer::gen_keys_radix;
-    /// use tfhe::integer::wopbs::*;
-    /// use tfhe::shortint::parameters::parameters_wopbs_message_carry::WOPBS_PARAM_MESSAGE_1_CARRY_1_KS_PBS;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_1_CARRY_1_KS_PBS;
-    ///
-    /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys_radix(PARAM_MESSAGE_1_CARRY_1_KS_PBS, 1);
-    /// let wopbs_key = WopbsKey::new_wopbs_key(&cks, &sks, &WOPBS_PARAM_MESSAGE_1_CARRY_1_KS_PBS);
-    /// ```
-    pub fn new_wopbs_key<IntegerClientKey: AsRef<ClientKey>>(
-        cks: &IntegerClientKey,
-        sks: &ServerKey,
-        parameters: &WopbsParameters,
-    ) -> Self {
-        Self {
-            wopbs_key: crate::shortint::wopbs::WopbsKey::new_wopbs_key(
-                &cks.as_ref().key,
-                &sks.key,
-                parameters,
-            ),
-        }
+    #[must_use]
+    pub struct IntegerWopbsLUT {
+        inner: WopbsLUTBase,
     }
 
-    /// Deconstruct a [`WopbsKey`] into its constituents.
-    pub fn into_raw_parts(self) -> crate::shortint::wopbs::WopbsKey {
-        self.wopbs_key
-    }
-
-    /// Construct a [`WopbsKey`] from its constituents.
-    pub fn from_raw_parts(wopbs_key: crate::shortint::wopbs::WopbsKey) -> Self {
-        Self { wopbs_key }
-    }
-
-    pub fn new_wopbs_key_only_for_wopbs<IntegerClientKey: AsRef<ClientKey>>(
-        cks: &IntegerClientKey,
-        sks: &ServerKey,
-    ) -> Self {
-        Self {
-            wopbs_key: crate::shortint::wopbs::WopbsKey::new_wopbs_key_only_for_wopbs(
-                &cks.as_ref().key,
-                &sks.key,
-            ),
-        }
-    }
-
-    /// Computes the WoP-PBS given the luts.
-    ///
-    /// This works for both RadixCiphertext and CrtCiphertext.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use tfhe::integer::gen_keys_radix;
-    /// use tfhe::integer::wopbs::*;
-    /// use tfhe::shortint::parameters::parameters_wopbs_message_carry::WOPBS_PARAM_MESSAGE_2_CARRY_2_KS_PBS;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
-    ///
-    /// let nb_block = 3;
-    /// //Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys_radix(PARAM_MESSAGE_2_CARRY_2_KS_PBS, nb_block);
-    /// let wopbs_key = WopbsKey::new_wopbs_key(&cks, &sks, &WOPBS_PARAM_MESSAGE_2_CARRY_2_KS_PBS);
-    /// let mut moduli = 1_u64;
-    /// for _ in 0..nb_block {
-    ///     moduli *= cks.parameters().message_modulus().0 as u64;
-    /// }
-    /// let clear = 42 % moduli;
-    /// let ct = cks.encrypt(clear);
-    /// let ct = wopbs_key.keyswitch_to_wopbs_params(&sks, &ct);
-    /// let lut = wopbs_key.generate_lut_radix(&ct, |x| x);
-    /// let ct_res = wopbs_key.wopbs(&ct, &lut);
-    /// let ct_res = wopbs_key.keyswitch_to_pbs_params(&ct_res);
-    /// let res: u64 = cks.decrypt(&ct_res);
-    ///
-    /// assert_eq!(res, clear);
-    /// ```
-    pub fn wopbs<T>(&self, ct_in: &T, lut: &IntegerWopbsLUT) -> T
-    where
-        T: IntegerCiphertext,
-    {
-        let total_bits_extracted = ct_in.blocks().iter().fold(0usize, |acc, block| {
-            acc + f64::log2((block.degree.get() + 1) as f64).ceil() as usize
-        });
-
-        let extract_bits_output_lwe_size = self
-            .wopbs_key
-            .wopbs_server_key
-            .key_switching_key
-            .output_key_lwe_dimension()
-            .to_lwe_size();
-
-        let mut extracted_bits_blocks = LweCiphertextList::new(
-            0u64,
-            extract_bits_output_lwe_size,
-            LweCiphertextCount(total_bits_extracted),
-            self.wopbs_key.param.ciphertext_modulus,
-        );
-
-        let mut bits_extracted_so_far = 0;
-
-        // Extraction of each bit for each block
-        for block in ct_in.blocks().iter().rev() {
-            let message_modulus = self.wopbs_key.param.message_modulus.0 as u64;
-            let carry_modulus = self.wopbs_key.param.carry_modulus.0 as u64;
-            let delta = (1u64 << 63) / (carry_modulus * message_modulus);
-            // casting to usize is fine, ilog2 of u64 is guaranteed to be < 64
-            let delta_log = DeltaLog(delta.ilog2() as usize);
-            let nb_bit_to_extract = f64::log2((block.degree.get() + 1) as f64).ceil() as usize;
-
-            let extract_from_bit = bits_extracted_so_far;
-            let extract_to_bit = extract_from_bit + nb_bit_to_extract;
-            bits_extracted_so_far += nb_bit_to_extract;
-
-            let mut lwe_sub_list =
-                extracted_bits_blocks.get_sub_mut(extract_from_bit..extract_to_bit);
-
-            self.wopbs_key.extract_bits_assign(
-                delta_log,
-                block,
-                ExtractedBitsCount(nb_bit_to_extract),
-                &mut lwe_sub_list,
-            );
-        }
-
-        let vec_ct_out = self
-            .wopbs_key
-            .circuit_bootstrapping_vertical_packing(lut.as_ref(), &extracted_bits_blocks);
-
-        let mut ct_vec_out = vec![];
-        for (block, block_out) in ct_in.blocks().iter().zip(vec_ct_out) {
-            ct_vec_out.push(crate::shortint::Ciphertext::new(
-                block_out,
-                Degree::new(block.message_modulus.0 - 1),
-                NoiseLevel::NOMINAL,
-                block.message_modulus,
-                block.carry_modulus,
-                block.pbs_order,
-            ));
-        }
-        T::from_blocks(ct_vec_out)
-    }
-
-    /// # Example
-    /// ```rust
-    /// use tfhe::integer::gen_keys_radix;
-    /// use tfhe::integer::wopbs::WopbsKey;
-    /// use tfhe::shortint::parameters::parameters_wopbs_only::WOPBS_ONLY_4_BLOCKS_PARAM_MESSAGE_2_CARRY_2_KS_PBS;
-    ///
-    /// let nb_block = 3;
-    /// //Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys_radix(WOPBS_ONLY_4_BLOCKS_PARAM_MESSAGE_2_CARRY_2_KS_PBS, nb_block);
-    /// let wopbs_key = WopbsKey::new_wopbs_key_only_for_wopbs(&cks, &sks);
-    /// let mut moduli = 1_u64;
-    /// for _ in 0..nb_block {
-    ///     moduli *= cks.parameters().message_modulus().0 as u64;
-    /// }
-    /// let clear = 15 % moduli;
-    /// let ct = cks.encrypt_without_padding(clear);
-    /// let lut = wopbs_key.generate_lut_radix_without_padding(&ct, |x| 2 * x);
-    /// let ct_res = wopbs_key.wopbs_without_padding(&ct, &lut);
-    /// let res: u64 = cks.decrypt_without_padding(&ct_res);
-    ///
-    /// assert_eq!(res, (clear * 2) % moduli)
-    /// ```
-    pub fn wopbs_without_padding<T>(&self, ct_in: &T, lut: &IntegerWopbsLUT) -> T
-    where
-        T: IntegerCiphertext,
-    {
-        let total_bits_extracted = ct_in.blocks().iter().fold(0usize, |acc, block| {
-            acc + f64::log2((block.message_modulus.0 * block.carry_modulus.0) as f64) as usize
-        });
-
-        let extract_bits_output_lwe_size = self
-            .wopbs_key
-            .wopbs_server_key
-            .key_switching_key
-            .output_key_lwe_dimension()
-            .to_lwe_size();
-
-        let mut extracted_bits_blocks = LweCiphertextList::new(
-            0u64,
-            extract_bits_output_lwe_size,
-            LweCiphertextCount(total_bits_extracted),
-            self.wopbs_key.param.ciphertext_modulus,
-        );
-
-        let mut bits_extracted_so_far = 0;
-        // Extraction of each bit for each block
-        for block in ct_in.blocks().iter().rev() {
-            let block_modulus = block.message_modulus.0 as u64 * block.carry_modulus.0 as u64;
-            let delta = (1_u64 << 63) / (block_modulus / 2);
-            // casting to usize is fine, ilog2 of u64 is guaranteed to be < 64
-            let delta_log = DeltaLog(delta.ilog2() as usize);
-            let nb_bit_to_extract =
-                f64::log2((block.message_modulus.0 * block.carry_modulus.0) as f64) as usize;
-
-            let extract_from_bit = bits_extracted_so_far;
-            let extract_to_bit = extract_from_bit + nb_bit_to_extract;
-            bits_extracted_so_far += nb_bit_to_extract;
-
-            let mut lwe_sub_list =
-                extracted_bits_blocks.get_sub_mut(extract_from_bit..extract_to_bit);
-
-            self.wopbs_key.extract_bits_assign(
-                delta_log,
-                block,
-                ExtractedBitsCount(nb_bit_to_extract),
-                &mut lwe_sub_list,
-            );
-        }
-
-        let vec_ct_out = self
-            .wopbs_key
-            .circuit_bootstrapping_vertical_packing(lut.as_ref(), &extracted_bits_blocks);
-
-        let mut ct_vec_out = vec![];
-        for (block, block_out) in ct_in.blocks().iter().zip(vec_ct_out) {
-            ct_vec_out.push(crate::shortint::Ciphertext::new(
-                block_out,
-                Degree::new(block.message_modulus.0 - 1),
-                NoiseLevel::NOMINAL,
-                block.message_modulus,
-                block.carry_modulus,
-                block.pbs_order,
-            ));
-        }
-        T::from_blocks(ct_vec_out)
-    }
-
-    /// WOPBS for native CRT
-    /// # Example
-    /// ```rust
-    /// use tfhe::integer::gen_keys_crt;
-    /// use tfhe::integer::wopbs::WopbsKey;
-    /// use tfhe::shortint::parameters::parameters_wopbs_message_carry::WOPBS_PARAM_MESSAGE_4_CARRY_4_KS_PBS;
-    ///
-    /// let basis: Vec<u64> = vec![9, 11];
-    /// let msg_space: u64 = basis.iter().copied().product();
-    ///
-    /// let param = WOPBS_PARAM_MESSAGE_4_CARRY_4_KS_PBS;
-    /// //Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys_crt(param, basis);
-    /// let wopbs_key = WopbsKey::new_wopbs_key_only_for_wopbs(&cks, &sks);
-    ///
-    /// let clear = 42 % msg_space; // Encrypt the integers
-    /// let ct = cks.encrypt_native_crt(clear);
-    /// let lut = wopbs_key.generate_lut_native_crt(&ct, |x| x);
-    /// let ct_res = wopbs_key.wopbs_native_crt(&ct, &lut);
-    /// let res = cks.decrypt_native_crt(&ct_res);
-    /// assert_eq!(res, clear);
-    /// ```
-    pub fn wopbs_native_crt(&self, ct1: &CrtCiphertext, lut: &IntegerWopbsLUT) -> CrtCiphertext {
-        self.circuit_bootstrap_vertical_packing_native_crt(&[ct1.clone()], lut)
-    }
-
-    /// # Example
-    /// ```rust
-    /// use tfhe::integer::gen_keys_radix;
-    /// use tfhe::integer::wopbs::*;
-    /// use tfhe::shortint::parameters::parameters_wopbs_message_carry::WOPBS_PARAM_MESSAGE_2_CARRY_2_KS_PBS;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
-    ///
-    /// let nb_block = 3;
-    /// //Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys_radix(PARAM_MESSAGE_2_CARRY_2_KS_PBS, nb_block);
-    ///
-    /// // Generate wopbs_v0 key
-    /// let wopbs_key = WopbsKey::new_wopbs_key(&cks, &sks, &WOPBS_PARAM_MESSAGE_2_CARRY_2_KS_PBS);
-    /// let mut moduli = 1_u64;
-    /// for _ in 0..nb_block {
-    ///     moduli *= cks.parameters().message_modulus().0 as u64;
-    /// }
-    /// let clear1 = 42 % moduli;
-    /// let clear2 = 24 % moduli;
-    /// let ct1 = cks.encrypt(clear1);
-    /// let ct2 = cks.encrypt(clear2);
-    ///
-    /// let ct1 = wopbs_key.keyswitch_to_wopbs_params(&sks, &ct1);
-    /// let ct2 = wopbs_key.keyswitch_to_wopbs_params(&sks, &ct2);
-    /// let lut = wopbs_key.generate_lut_bivariate_radix(&ct1, &ct2, |x, y| 2 * x * y);
-    /// let ct_res = wopbs_key.bivariate_wopbs_with_degree(&ct1, &ct2, &lut);
-    /// let ct_res = wopbs_key.keyswitch_to_pbs_params(&ct_res);
-    /// let res: u64 = cks.decrypt(&ct_res);
-    ///
-    /// assert_eq!(res, (2 * clear1 * clear2) % moduli);
-    /// ```
-    pub fn bivariate_wopbs_with_degree<T>(&self, ct1: &T, ct2: &T, lut: &IntegerWopbsLUT) -> T
-    where
-        T: IntegerCiphertext,
-    {
-        let ct = ciphertext_concatenation(ct1, ct2);
-        self.wopbs(&ct, lut)
-    }
-
-    /// # Example
-    ///
-    /// ```rust
-    /// use tfhe::integer::gen_keys_radix;
-    /// use tfhe::integer::wopbs::*;
-    /// use tfhe::shortint::parameters::parameters_wopbs_message_carry::WOPBS_PARAM_MESSAGE_2_CARRY_2_KS_PBS;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
-    ///
-    /// let nb_block = 3;
-    /// //Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys_radix(PARAM_MESSAGE_2_CARRY_2_KS_PBS, nb_block);
-    ///
-    /// //Generate wopbs_v0 key    ///
-    /// let wopbs_key = WopbsKey::new_wopbs_key(&cks, &sks, &WOPBS_PARAM_MESSAGE_2_CARRY_2_KS_PBS);
-    /// let mut moduli = 1_u64;
-    /// for _ in 0..nb_block {
-    ///     moduli *= cks.parameters().message_modulus().0 as u64;
-    /// }
-    /// let clear = 42 % moduli;
-    /// let ct = cks.encrypt(clear);
-    /// let ct = wopbs_key.keyswitch_to_wopbs_params(&sks, &ct);
-    /// let lut = wopbs_key.generate_lut_radix(&ct, |x| 2 * x);
-    /// let ct_res = wopbs_key.wopbs(&ct, &lut);
-    /// let ct_res = wopbs_key.keyswitch_to_pbs_params(&ct_res);
-    /// let res: u64 = cks.decrypt(&ct_res);
-    ///
-    /// assert_eq!(res, (2 * clear) % moduli);
-    /// ```
-    pub fn generate_lut_radix<F, T>(&self, ct: &T, f: F) -> IntegerWopbsLUT
-    where
-        F: Fn(u64) -> u64,
-        T: IntegerCiphertext,
-    {
-        let mut total_bit = 0;
-        let block_nb = ct.blocks().len();
-        let mut modulus = 1;
-
-        //This contains the basis of each block depending on the degree
-        let mut vec_deg_basis = vec![];
-
-        for (i, deg) in ct.moduli().iter().zip(ct.blocks().iter()) {
-            modulus *= i;
-            let b = f64::log2((deg.degree.get() + 1) as f64).ceil() as u64;
-            vec_deg_basis.push(b);
-            total_bit += b;
-        }
-
-        let lut_size = if 1 << total_bit < self.wopbs_key.param.polynomial_size.0 as u64 {
-            self.wopbs_key.param.polynomial_size.0
-        } else {
-            1 << total_bit
-        };
-        let mut lut =
-            IntegerWopbsLUT::new(PlaintextCount(lut_size), CiphertextCount(ct.blocks().len()));
-
-        let basis = ct.moduli()[0];
-        let delta: u64 = (1 << 63)
-            / (self.wopbs_key.param.message_modulus.0 * self.wopbs_key.param.carry_modulus.0)
-                as u64;
-
-        for lut_index_val in 0..(1 << total_bit) {
-            let encoded_with_deg_val = encode_mix_radix(lut_index_val, &vec_deg_basis, basis);
-            let decoded_val = decode_radix(&encoded_with_deg_val, basis);
-            let f_val = f(decoded_val % modulus) % modulus;
-            let encoded_f_val = encode_radix(f_val, basis, block_nb as u64);
-            for (lut_number, radix_encoded_val) in encoded_f_val.iter().enumerate().take(block_nb) {
-                lut[lut_number][lut_index_val as usize] = radix_encoded_val * delta;
+    impl IntegerWopbsLUT {
+        pub fn new(
+            small_lut_size: PlaintextCount,
+            output_ciphertext_count: CiphertextCount,
+        ) -> Self {
+            Self {
+                inner: WopbsLUTBase::new(small_lut_size, output_ciphertext_count),
             }
         }
-        lut
     }
 
-    /// # Example
-    /// ```rust
-    /// use tfhe::integer::gen_keys_radix;
-    /// use tfhe::integer::wopbs::WopbsKey;
-    /// use tfhe::shortint::parameters::parameters_wopbs_message_carry::WOPBS_PARAM_MESSAGE_2_CARRY_2_KS_PBS;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
-    ///
-    /// let nb_block = 3;
-    /// //Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys_radix(PARAM_MESSAGE_2_CARRY_2_KS_PBS, nb_block);
-    /// //Generate wopbs_v0 key
-    /// let wopbs_key = WopbsKey::new_wopbs_key(&cks, &sks, &WOPBS_PARAM_MESSAGE_2_CARRY_2_KS_PBS);
-    /// let mut moduli = 1_u64;
-    /// for _ in 0..nb_block {
-    ///     moduli *= cks.parameters().message_modulus().0 as u64;
-    /// }
-    /// let clear = 15 % moduli;
-    /// let ct = cks.encrypt_without_padding(clear);
-    /// let ct = wopbs_key.keyswitch_to_wopbs_params(&sks, &ct);
-    /// let lut = wopbs_key.generate_lut_radix_without_padding(&ct, |x| 2 * x);
-    /// let ct_res = wopbs_key.wopbs_without_padding(&ct, &lut);
-    /// let ct_res = wopbs_key.keyswitch_to_pbs_params(&ct_res);
-    /// let res: u64 = cks.decrypt_without_padding(&ct_res);
-    ///
-    /// assert_eq!(res, (clear * 2) % moduli)
-    /// ```
-    pub fn generate_lut_radix_without_padding<F, T>(&self, ct: &T, f: F) -> IntegerWopbsLUT
-    where
-        F: Fn(u64) -> u64,
-        T: IntegerCiphertext,
-    {
-        let log_message_modulus = f64::log2((self.wopbs_key.param.message_modulus.0) as f64) as u64;
-        let log_carry_modulus = f64::log2((self.wopbs_key.param.carry_modulus.0) as f64) as u64;
-        let log_basis = log_message_modulus + log_carry_modulus;
-        let delta = 64 - log_basis;
-        let nb_block = ct.blocks().len();
-        let poly_size = self.wopbs_key.param.polynomial_size.0;
-        let mut lut_size = 1 << (nb_block * log_basis as usize);
-        if lut_size < poly_size {
-            lut_size = poly_size;
-        }
-        let mut lut = IntegerWopbsLUT::new(PlaintextCount(lut_size), CiphertextCount(nb_block));
+    impl TryFrom<Vec<Vec<u64>>> for IntegerWopbsLUT {
+        type Error = &'static str;
 
-        for index in 0..lut_size {
-            // find the value represented by the index
-            let mut value = 0;
-            let mut tmp_index = index;
-            for i in 0..nb_block as u64 {
-                let tmp = tmp_index % (1 << (log_basis * (i + 1)));
-                tmp_index -= tmp;
-                value += tmp >> (log_carry_modulus * i);
+        fn try_from(value: Vec<Vec<u64>>) -> Result<Self, Self::Error> {
+            let small_lut_size = value[0].len();
+            if !value.iter().all(|x| x.len() == small_lut_size) {
+                return Err("All small luts must have the same size");
             }
 
-            // fill the LUTs
-            for block_index in 0..nb_block {
-                lut[block_index][index] = ((f(value as u64)
-                    >> (log_carry_modulus * block_index as u64))
-                    % (1 << log_message_modulus))
-                    << delta;
-            }
-        }
-        lut
-    }
+            let small_lut_count = value.len();
 
-    /// generate lut for native CRT
-    /// # Example
-    ///
-    /// ```rust
-    /// use tfhe::integer::gen_keys_crt;
-    /// use tfhe::integer::wopbs::WopbsKey;
-    /// use tfhe::shortint::parameters::parameters_wopbs_message_carry::WOPBS_PARAM_MESSAGE_4_CARRY_4_KS_PBS;
-    ///
-    /// let basis: Vec<u64> = vec![9, 11];
-    /// let msg_space: u64 = basis.iter().copied().product();
-    ///
-    /// let param = WOPBS_PARAM_MESSAGE_4_CARRY_4_KS_PBS;
-    /// //Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys_crt(param, basis);
-    /// let wopbs_key = WopbsKey::new_wopbs_key_only_for_wopbs(&cks, &sks);
-    ///
-    /// let clear = 42 % msg_space; // Encrypt the integers
-    /// let ct = cks.encrypt_native_crt(clear);
-    /// let lut = wopbs_key.generate_lut_native_crt(&ct, |x| x);
-    /// let ct_res = wopbs_key.wopbs_native_crt(&ct, &lut);
-    /// let res = cks.decrypt_native_crt(&ct_res);
-    /// assert_eq!(res, clear);
-    /// ```
-    pub fn generate_lut_native_crt<F>(&self, ct: &CrtCiphertext, f: F) -> IntegerWopbsLUT
-    where
-        F: Fn(u64) -> u64,
-    {
-        let mut bit = vec![];
-        let mut total_bit = 0;
-        let mut modulus = 1;
-        let basis: Vec<_> = ct.moduli();
-
-        for i in basis.iter() {
-            modulus *= i;
-            let b = f64::log2(*i as f64).ceil() as u64;
-            total_bit += b;
-            bit.push(b);
-        }
-        let lut_size = if 1 << total_bit < self.wopbs_key.param.polynomial_size.0 as u64 {
-            self.wopbs_key.param.polynomial_size.0
-        } else {
-            1 << total_bit
-        };
-        let mut lut = IntegerWopbsLUT::new(PlaintextCount(lut_size), CiphertextCount(basis.len()));
-
-        for value in 0..modulus {
-            let mut index_lut = 0;
-            let mut tmp = 1;
-            for (base, bit) in basis.iter().zip(bit.iter()) {
-                index_lut += (((value % base) << bit) / base) * tmp;
-                tmp <<= bit;
-            }
-            for (j, b) in basis.iter().enumerate() {
-                lut[j][index_lut as usize] =
-                    (((f(value) % b) as u128 * (1 << 64)) / *b as u128) as u64;
-            }
-        }
-        lut
-    }
-
-    /// generate LUt for crt
-    /// # Example
-    /// ```rust
-    /// use tfhe::integer::gen_keys_crt;
-    /// use tfhe::integer::wopbs::*;
-    /// use tfhe::shortint::parameters::parameters_wopbs_message_carry::WOPBS_PARAM_MESSAGE_3_CARRY_3_KS_PBS;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
-    ///
-    /// let basis: Vec<u64> = vec![5, 7];
-    /// let msg_space: u64 = basis.iter().copied().product();
-    ///
-    /// //Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
-    /// let wopbs_key = WopbsKey::new_wopbs_key(&cks, &sks, &WOPBS_PARAM_MESSAGE_3_CARRY_3_KS_PBS);
-    ///
-    /// let clear = 42 % msg_space;
-    /// let ct = cks.encrypt(clear);
-    /// let ct = wopbs_key.keyswitch_to_wopbs_params(&sks, &ct);
-    /// let lut = wopbs_key.generate_lut_crt(&ct, |x| x);
-    /// let ct_res = wopbs_key.wopbs(&ct, &lut);
-    /// let ct_res = wopbs_key.keyswitch_to_pbs_params(&ct_res);
-    /// let res = cks.decrypt(&ct_res);
-    /// assert_eq!(res, clear);
-    /// ```
-    pub fn generate_lut_crt<F>(&self, ct: &CrtCiphertext, f: F) -> IntegerWopbsLUT
-    where
-        F: Fn(u64) -> u64,
-    {
-        let mut total_bit = 0;
-        let mut modulus = 1;
-        let basis = ct.moduli();
-
-        for (i, deg) in basis.iter().zip(ct.blocks.iter()) {
-            modulus *= i;
-            let b = f64::log2((deg.degree.get() + 1) as f64).ceil() as u64;
-            total_bit += b;
-        }
-        let lut_size = if 1 << total_bit < self.wopbs_key.param.polynomial_size.0 as u64 {
-            self.wopbs_key.param.polynomial_size.0
-        } else {
-            1 << total_bit
-        };
-        let mut lut = IntegerWopbsLUT::new(PlaintextCount(lut_size), CiphertextCount(basis.len()));
-
-        let delta: u64 = (1 << 63)
-            / (self.wopbs_key.param.message_modulus.0 * self.wopbs_key.param.carry_modulus.0)
-                as u64;
-
-        for i in 0..(1 << total_bit) {
-            let mut decomp_terms = Vec::new();
-            let mut index_copy = i;
-            for (b, block) in basis.iter().zip(ct.blocks.iter()) {
-                let block_bit_count = f64::log2((block.degree.get() + 1) as f64).ceil() as u64;
-                let bits_corresponding_to_block = index_copy % (1 << block_bit_count);
-                let decomp_term = bits_corresponding_to_block % b;
-                index_copy >>= block_bit_count;
-                decomp_terms.push(decomp_term);
-            }
-            let value_corresponding_to_index = i_crt(&basis, &decomp_terms);
-            let f_eval = f(value_corresponding_to_index);
-            for (j, block) in ct.blocks.iter().enumerate() {
-                lut[j][i as usize] = (f_eval % block.message_modulus.0 as u64) * delta;
-            }
-        }
-        lut
-    }
-
-    /// # Example
-    ///
-    /// ```rust
-    /// use tfhe::integer::gen_keys_radix;
-    /// use tfhe::integer::wopbs::*;
-    /// use tfhe::shortint::parameters::parameters_wopbs_message_carry::WOPBS_PARAM_MESSAGE_2_CARRY_2_KS_PBS;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
-    ///
-    /// let nb_block = 3;
-    /// //Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys_radix(PARAM_MESSAGE_2_CARRY_2_KS_PBS, nb_block);
-    ///
-    /// //Generate wopbs_v0 key    ///
-    /// let wopbs_key = WopbsKey::new_wopbs_key(&cks, &sks, &WOPBS_PARAM_MESSAGE_2_CARRY_2_KS_PBS);
-    /// let mut moduli = 1_u64;
-    /// for _ in 0..nb_block {
-    ///     moduli *= cks.parameters().message_modulus().0 as u64;
-    /// }
-    /// let clear1 = 42 % moduli;
-    /// let clear2 = 24 % moduli;
-    /// let ct1 = cks.encrypt(clear1);
-    /// let ct2 = cks.encrypt(clear2);
-    ///
-    /// let ct1 = wopbs_key.keyswitch_to_wopbs_params(&sks, &ct1);
-    /// let ct2 = wopbs_key.keyswitch_to_wopbs_params(&sks, &ct2);
-    /// let lut = wopbs_key.generate_lut_bivariate_radix(&ct1, &ct2, |x, y| 2 * x * y);
-    /// let ct_res = wopbs_key.bivariate_wopbs_with_degree(&ct1, &ct2, &lut);
-    /// let ct_res = wopbs_key.keyswitch_to_pbs_params(&ct_res);
-    /// let res: u64 = cks.decrypt(&ct_res);
-    ///
-    /// assert_eq!(res, (2 * clear1 * clear2) % moduli);
-    /// ```
-    pub fn generate_lut_bivariate_radix<F>(
-        &self,
-        ct1: &RadixCiphertext,
-        ct2: &RadixCiphertext,
-        f: F,
-    ) -> IntegerWopbsLUT
-    where
-        RadixCiphertext: IntegerCiphertext,
-        F: Fn(u64, u64) -> u64,
-    {
-        let mut nb_bit_to_extract = [0; 2];
-        let block_nb = ct1.blocks.len();
-        //ct2 & ct1 should have the same basis
-        let basis = ct1.moduli();
-
-        //This contains the basis of each block depending on the degree
-        let mut vec_deg_basis = vec![vec![]; 2];
-
-        let mut modulus = 1;
-        for (ct_num, ct) in [ct1, ct2].iter().enumerate() {
-            modulus = 1;
-            for deg in ct.blocks.iter() {
-                modulus *= self.wopbs_key.param.message_modulus.0 as u64;
-                let b = f64::log2((deg.degree.get() + 1) as f64).ceil() as u64;
-                vec_deg_basis[ct_num].push(b);
-                nb_bit_to_extract[ct_num] += b;
-            }
-        }
-
-        let total_bit: u64 = nb_bit_to_extract.iter().sum();
-
-        let lut_size = if 1 << total_bit < self.wopbs_key.param.polynomial_size.0 as u64 {
-            self.wopbs_key.param.polynomial_size.0
-        } else {
-            1 << total_bit
-        };
-        let mut lut = IntegerWopbsLUT::new(PlaintextCount(lut_size), CiphertextCount(basis.len()));
-        let basis = ct1.moduli()[0];
-
-        let delta: u64 = (1 << 63)
-            / (self.wopbs_key.param.message_modulus.0 * self.wopbs_key.param.carry_modulus.0)
-                as u64;
-
-        for lut_index_val in 0..(1 << total_bit) {
-            let split = [
-                lut_index_val % (1 << nb_bit_to_extract[0]),
-                lut_index_val >> nb_bit_to_extract[0],
-            ];
-            let mut decoded_val = [0; 2];
-            for i in 0..2 {
-                let encoded_with_deg_val = encode_mix_radix(split[i], &vec_deg_basis[i], basis);
-                decoded_val[i] = decode_radix(&encoded_with_deg_val, basis);
-            }
-            let f_val = f(decoded_val[0] % modulus, decoded_val[1] % modulus) % modulus;
-            let encoded_f_val = encode_radix(f_val, basis, block_nb as u64);
-            for (lut_number, radix_encoded_val) in encoded_f_val.iter().enumerate().take(block_nb) {
-                lut[lut_number][lut_index_val as usize] = radix_encoded_val * delta;
-            }
-        }
-        lut
-    }
-
-    /// generate bivariate LUT for 'fake' CRT
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use tfhe::integer::gen_keys_crt;
-    /// use tfhe::integer::wopbs::*;
-    /// use tfhe::shortint::parameters::parameters_wopbs_message_carry::WOPBS_PARAM_MESSAGE_3_CARRY_3_KS_PBS;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
-    ///
-    /// let basis: Vec<u64> = vec![5, 7];
-    /// let msg_space: u64 = basis.iter().copied().product();
-    /// //Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
-    /// let wopbs_key = WopbsKey::new_wopbs_key(&cks, &sks, &WOPBS_PARAM_MESSAGE_3_CARRY_3_KS_PBS);
-    ///
-    /// let clear1 = 42 % msg_space; // Encrypt the integers
-    /// let clear2 = 24 % msg_space; // Encrypt the integers
-    /// let ct1 = cks.encrypt(clear1);
-    /// let ct2 = cks.encrypt(clear2);
-    ///
-    /// let ct1 = wopbs_key.keyswitch_to_wopbs_params(&sks, &ct1);
-    /// let ct2 = wopbs_key.keyswitch_to_wopbs_params(&sks, &ct2);
-    ///
-    /// let lut = wopbs_key.generate_lut_bivariate_crt(&ct1, &ct2, |x, y| x * y * 2);
-    /// let ct_res = wopbs_key.bivariate_wopbs_with_degree(&ct1, &ct2, &lut);
-    /// let ct_res = wopbs_key.keyswitch_to_pbs_params(&ct_res);
-    /// let res = cks.decrypt(&ct_res);
-    /// assert_eq!(res, (clear1 * clear2 * 2) % msg_space);
-    /// ```
-    pub fn generate_lut_bivariate_crt<F>(
-        &self,
-        ct1: &CrtCiphertext,
-        ct2: &CrtCiphertext,
-        f: F,
-    ) -> IntegerWopbsLUT
-    where
-        F: Fn(u64, u64) -> u64,
-    {
-        let mut nb_bit_to_extract = [0; 2];
-        let mut modulus = 1;
-
-        //ct2 & ct1 should have the same basis
-        let basis = ct1.moduli();
-
-        for (ct_num, ct) in [ct1, ct2].iter().enumerate() {
-            for (i, deg) in basis.iter().zip(ct.blocks.iter()) {
-                modulus *= i;
-                let b = f64::log2((deg.degree.get() + 1) as f64).ceil() as u64;
-                nb_bit_to_extract[ct_num] += b;
-            }
-        }
-
-        let total_bit: u64 = nb_bit_to_extract.iter().sum();
-
-        let lut_size = if 1 << total_bit < self.wopbs_key.param.polynomial_size.0 as u64 {
-            self.wopbs_key.param.polynomial_size.0
-        } else {
-            1 << total_bit
-        };
-        let mut lut = IntegerWopbsLUT::new(PlaintextCount(lut_size), CiphertextCount(basis.len()));
-
-        let delta: u64 = (1 << 63)
-            / (self.wopbs_key.param.message_modulus.0 * self.wopbs_key.param.carry_modulus.0)
-                as u64;
-
-        for index in 0..(1 << total_bit) {
-            let mut split = encode_radix(index, 1 << nb_bit_to_extract[0], 2);
-            let mut crt_value = vec![vec![0; ct1.blocks.len()]; 2];
-            for (j, base) in basis.iter().enumerate().take(ct1.blocks.len()) {
-                let deg_1 = f64::log2((ct1.blocks[j].degree.get() + 1) as f64).ceil() as u64;
-                let deg_2 = f64::log2((ct2.blocks[j].degree.get() + 1) as f64).ceil() as u64;
-                crt_value[0][j] = (split[0] % (1 << deg_1)) % base;
-                crt_value[1][j] = (split[1] % (1 << deg_2)) % base;
-                split[0] >>= deg_1;
-                split[1] >>= deg_2;
-            }
-            let value_1 = i_crt(&ct1.moduli(), &crt_value[0]);
-            let value_2 = i_crt(&ct2.moduli(), &crt_value[1]);
-            for (j, current_mod) in basis.iter().enumerate() {
-                let value = f(value_1, value_2) % current_mod;
-                lut[j][index as usize] = (value % current_mod) * delta;
-            }
-        }
-
-        lut
-    }
-
-    /// generate bivariate LUT for 'true' CRT
-    /// # Example
-    ///
-    /// ```rust
-    /// use tfhe::integer::gen_keys_crt;
-    /// use tfhe::integer::wopbs::WopbsKey;
-    /// use tfhe::shortint::parameters::parameters_wopbs_message_carry::WOPBS_PARAM_MESSAGE_4_CARRY_4_KS_PBS;
-    ///
-    /// let basis: Vec<u64> = vec![9, 11];
-    /// let msg_space: u64 = basis.iter().copied().product();
-    ///
-    /// let param = WOPBS_PARAM_MESSAGE_4_CARRY_4_KS_PBS;
-    /// //Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys_crt(param, basis);
-    /// let wopbs_key = WopbsKey::new_wopbs_key_only_for_wopbs(&cks, &sks);
-    ///
-    /// let clear1 = 42 % msg_space;
-    /// let clear2 = 24 % msg_space;
-    /// let ct1 = cks.encrypt_native_crt(clear1);
-    /// let ct2 = cks.encrypt_native_crt(clear2);
-    /// let lut = wopbs_key.generate_lut_bivariate_native_crt(&ct1, |x, y| x * y * 2);
-    /// let ct_res = wopbs_key.bivariate_wopbs_native_crt(&ct1, &ct2, &lut);
-    /// let res = cks.decrypt_native_crt(&ct_res);
-    /// assert_eq!(res, (clear1 * clear2 * 2) % msg_space);
-    /// ```
-    pub fn generate_lut_bivariate_native_crt<F>(
-        &self,
-        ct_1: &CrtCiphertext,
-        f: F,
-    ) -> IntegerWopbsLUT
-    where
-        F: Fn(u64, u64) -> u64,
-    {
-        let mut bit = vec![];
-        let mut total_bit = 0;
-        let mut modulus = 1;
-        let basis = ct_1.moduli();
-        for i in basis.iter() {
-            modulus *= i;
-            let b = f64::log2(*i as f64).ceil() as u64;
-            total_bit += b;
-            bit.push(b);
-        }
-        let lut_size = if 1 << (2 * total_bit) < self.wopbs_key.param.polynomial_size.0 as u64 {
-            self.wopbs_key.param.polynomial_size.0
-        } else {
-            1 << (2 * total_bit)
-        };
-        let mut lut = IntegerWopbsLUT::new(PlaintextCount(lut_size), CiphertextCount(basis.len()));
-
-        for value in 0..1 << (2 * total_bit) {
-            let value_1 = value % (1 << total_bit);
-            let value_2 = value >> total_bit;
-            let mut index_lut_1 = 0;
-            let mut index_lut_2 = 0;
-            let mut tmp = 1;
-            for (base, bit) in basis.iter().zip(bit.iter()) {
-                index_lut_1 += (((value_1 % base) << bit) / base) * tmp;
-                index_lut_2 += (((value_2 % base) << bit) / base) * tmp;
-                tmp <<= bit;
-            }
-            let index = (index_lut_2 << total_bit) + (index_lut_1);
-            for (j, b) in basis.iter().enumerate() {
-                lut[j][index as usize] =
-                    (((f(value_1, value_2) % b) as u128 * (1 << 64)) / *b as u128) as u64;
-            }
-        }
-        lut
-    }
-
-    /// bivariate WOPBS for native CRT
-    /// # Example
-    ///
-    /// ```rust
-    /// use tfhe::integer::gen_keys_crt;
-    /// use tfhe::integer::wopbs::WopbsKey;
-    /// use tfhe::shortint::parameters::parameters_wopbs_message_carry::WOPBS_PARAM_MESSAGE_4_CARRY_4_KS_PBS;
-    ///
-    /// let basis: Vec<u64> = vec![9, 11];
-    /// let msg_space: u64 = basis.iter().copied().product();
-    ///
-    /// let param = WOPBS_PARAM_MESSAGE_4_CARRY_4_KS_PBS;
-    /// //Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys_crt(param, basis);
-    /// let wopbs_key = WopbsKey::new_wopbs_key_only_for_wopbs(&cks, &sks);
-    ///
-    /// let clear1 = 42 % msg_space;
-    /// let clear2 = 24 % msg_space;
-    /// let ct1 = cks.encrypt_native_crt(clear1);
-    /// let ct2 = cks.encrypt_native_crt(clear2);
-    /// let lut = wopbs_key.generate_lut_bivariate_native_crt(&ct1, |x, y| x * y * 2);
-    /// let ct_res = wopbs_key.bivariate_wopbs_native_crt(&ct1, &ct2, &lut);
-    /// let res = cks.decrypt_native_crt(&ct_res);
-    /// assert_eq!(res, (clear1 * clear2 * 2) % msg_space);
-    /// ```
-    pub fn bivariate_wopbs_native_crt(
-        &self,
-        ct1: &CrtCiphertext,
-        ct2: &CrtCiphertext,
-        lut: &IntegerWopbsLUT,
-    ) -> CrtCiphertext {
-        self.circuit_bootstrap_vertical_packing_native_crt(&[ct1.clone(), ct2.clone()], lut)
-    }
-
-    fn circuit_bootstrap_vertical_packing_native_crt<T>(
-        &self,
-        vec_ct_in: &[T],
-        lut: &IntegerWopbsLUT,
-    ) -> T
-    where
-        T: IntegerCiphertext,
-    {
-        let total_bits_extracted = vec_ct_in.iter().fold(0usize, |acc, ct_in| {
-            acc + ct_in.blocks().iter().fold(0usize, |inner_acc, block| {
-                inner_acc
-                    + f64::log2((block.message_modulus.0 * block.carry_modulus.0) as f64).ceil()
-                        as usize
+            Ok(Self {
+                inner: WopbsLUTBase::from_vec(
+                    value.into_iter().flatten().collect(),
+                    CiphertextCount(small_lut_count),
+                ),
             })
-        });
+        }
+    }
 
-        let extract_bits_output_lwe_size = self
-            .wopbs_key
-            .wopbs_server_key
-            .key_switching_key
-            .output_key_lwe_dimension()
-            .to_lwe_size();
+    impl AsRef<WopbsLUTBase> for IntegerWopbsLUT {
+        fn as_ref(&self) -> &WopbsLUTBase {
+            &self.inner
+        }
+    }
 
-        let mut extracted_bits_blocks = LweCiphertextList::new(
-            0u64,
-            extract_bits_output_lwe_size,
-            LweCiphertextCount(total_bits_extracted),
-            self.wopbs_key.param.ciphertext_modulus,
-        );
+    impl AsMut<WopbsLUTBase> for IntegerWopbsLUT {
+        fn as_mut(&mut self) -> &mut WopbsLUTBase {
+            &mut self.inner
+        }
+    }
 
-        let mut bits_extracted_so_far = 0;
-        for ct_in in vec_ct_in.iter().rev() {
-            let mut ct_in = ct_in.clone();
+    impl std::ops::Index<usize> for IntegerWopbsLUT {
+        type Output = [u64];
+
+        fn index(&self, index: usize) -> &Self::Output {
+            self.as_ref().get_small_lut(index)
+        }
+    }
+
+    impl std::ops::IndexMut<usize> for IntegerWopbsLUT {
+        fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+            self.as_mut().get_small_lut_mut(index)
+        }
+    }
+
+    /// ```rust
+    /// use tfhe::integer::wopbs::{decode_radix, encode_radix};
+    ///
+    /// let val = 11;
+    /// let basis = 2;
+    /// let nb_block = 5;
+    /// let radix = encode_radix(val, basis, nb_block);
+    ///
+    /// assert_eq!(val, decode_radix(&radix, basis));
+    /// ```
+    pub fn encode_radix(val: u64, basis: u64, nb_block: u64) -> Vec<u64> {
+        let mut output = vec![];
+        //Bits of message put to 1éfé
+        let mask = basis - 1;
+
+        let mut power = 1_u64;
+        //Put each decomposition into a new ciphertext
+        for _ in 0..nb_block {
+            let mut decomp = val & (mask * power);
+            decomp /= power;
+
+            // fill the vector with the message moduli
+            output.push(decomp);
+
+            //modulus to the power i
+            power *= basis;
+        }
+        output
+    }
+
+    pub fn encode_crt(val: u64, basis: &[u64]) -> Vec<u64> {
+        let mut output = vec![];
+        //Put each decomposition into a new ciphertext
+        for i in basis {
+            output.push(val % i);
+        }
+        output
+    }
+
+    //Concatenate two ciphertexts in one
+    //Used to compute bivariate wopbs
+    fn ciphertext_concatenation<T>(ct1: &T, ct2: &T) -> T
+    where
+        T: IntegerCiphertext,
+    {
+        let mut new_blocks = ct1.blocks().to_vec();
+        new_blocks.extend_from_slice(ct2.blocks());
+        T::from_blocks(new_blocks)
+    }
+
+    pub fn encode_mix_radix(mut val: u64, basis: &[u64], modulus: u64) -> Vec<u64> {
+        let mut output = vec![];
+        for basis in basis.iter() {
+            output.push(val % modulus);
+            val -= val % modulus;
+            let tmp = (val % (1 << basis)) >> (f64::log2(modulus as f64) as u64);
+            val >>= basis;
+            val += tmp;
+        }
+        output
+    }
+
+    // Example: val = 5 = 0b101 , basis = [1,2] -> output = [1, 1]
+    /// ```rust
+    /// use tfhe::integer::wopbs::split_value_according_to_bit_basis;
+    /// // Generate the client key and the server key:
+    /// let val = 5;
+    /// let basis = vec![1, 2];
+    /// assert_eq!(vec![1, 2], split_value_according_to_bit_basis(val, &basis));
+    /// ```
+    pub fn split_value_according_to_bit_basis(value: u64, basis: &[u64]) -> Vec<u64> {
+        let mut output = vec![];
+        let mut tmp = value;
+        let mask = 1;
+
+        for i in basis {
+            let mut tmp_output = 0;
+            for j in 0..*i {
+                let val = tmp & mask;
+                tmp_output += val << j;
+                tmp >>= 1;
+            }
+            output.push(tmp_output);
+        }
+        output
+    }
+
+    /// ```rust
+    /// use tfhe::integer::wopbs::{decode_radix, encode_radix};
+    ///
+    /// let val = 11;
+    /// let basis = 2;
+    /// let nb_block = 5;
+    /// let radix = encode_radix(val, basis, nb_block);
+    ///
+    /// assert_eq!(val, decode_radix(&radix, basis));
+    /// ```
+    pub fn decode_radix(val: &[u64], basis: u64) -> u64 {
+        let mut result = 0_u64;
+        let mut shift = 1_u64;
+        for v_i in val.iter() {
+            //decrypt the component i of the integer and multiply it by the radix product
+            let tmp = v_i.wrapping_mul(shift);
+
+            // update the result
+            result = result.wrapping_add(tmp);
+
+            // update the shift for the next iteration
+            shift = shift.wrapping_mul(basis);
+        }
+        result
+    }
+
+    impl From<crate::shortint::wopbs::WopbsKey> for WopbsKey {
+        fn from(wopbs_key: crate::shortint::wopbs::WopbsKey) -> Self {
+            Self { wopbs_key }
+        }
+    }
+
+    impl WopbsKey {
+        /// Generates the server key required to compute a WoPBS from the client and the server
+        /// keys. # Example
+        /// ```rust
+        /// use tfhe::integer::gen_keys_radix;
+        /// use tfhe::integer::wopbs::*;
+        /// use tfhe::shortint::parameters::parameters_wopbs_message_carry::WOPBS_PARAM_MESSAGE_1_CARRY_1_KS_PBS;
+        /// use tfhe::shortint::parameters::PARAM_MESSAGE_1_CARRY_1_KS_PBS;
+        ///
+        /// // Generate the client key and the server key:
+        /// let (cks, sks) = gen_keys_radix(PARAM_MESSAGE_1_CARRY_1_KS_PBS, 1);
+        /// let wopbs_key = WopbsKey::new_wopbs_key(&cks, &sks, &WOPBS_PARAM_MESSAGE_1_CARRY_1_KS_PBS);
+        /// ```
+        pub fn new_wopbs_key<IntegerClientKey: AsRef<ClientKey>>(
+            cks: &IntegerClientKey,
+            sks: &ServerKey,
+            parameters: &WopbsParameters,
+        ) -> Self {
+            Self {
+                wopbs_key: crate::shortint::wopbs::WopbsKey::new_wopbs_key(
+                    &cks.as_ref().key,
+                    &sks.key,
+                    parameters,
+                ),
+            }
+        }
+
+        /// Deconstruct a [`WopbsKey`] into its constituents.
+        pub fn into_raw_parts(self) -> crate::shortint::wopbs::WopbsKey {
+            self.wopbs_key
+        }
+
+        /// Construct a [`WopbsKey`] from its constituents.
+        pub fn from_raw_parts(wopbs_key: crate::shortint::wopbs::WopbsKey) -> Self {
+            Self { wopbs_key }
+        }
+
+        pub fn new_wopbs_key_only_for_wopbs<IntegerClientKey: AsRef<ClientKey>>(
+            cks: &IntegerClientKey,
+            sks: &ServerKey,
+        ) -> Self {
+            Self {
+                wopbs_key: crate::shortint::wopbs::WopbsKey::new_wopbs_key_only_for_wopbs(
+                    &cks.as_ref().key,
+                    &sks.key,
+                ),
+            }
+        }
+
+        /// Computes the WoP-PBS given the luts.
+        ///
+        /// This works for both RadixCiphertext and CrtCiphertext.
+        ///
+        /// # Example
+        ///
+        /// ```rust
+        /// use tfhe::integer::gen_keys_radix;
+        /// use tfhe::integer::wopbs::*;
+        /// use tfhe::shortint::parameters::parameters_wopbs_message_carry::WOPBS_PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+        /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+        ///
+        /// let nb_block = 3;
+        /// //Generate the client key and the server key:
+        /// let (cks, sks) = gen_keys_radix(PARAM_MESSAGE_2_CARRY_2_KS_PBS, nb_block);
+        /// let wopbs_key = WopbsKey::new_wopbs_key(&cks, &sks, &WOPBS_PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+        /// let mut moduli = 1_u64;
+        /// for _ in 0..nb_block {
+        ///     moduli *= cks.parameters().message_modulus().0 as u64;
+        /// }
+        /// let clear = 42 % moduli;
+        /// let ct = cks.encrypt(clear);
+        /// let ct = wopbs_key.keyswitch_to_wopbs_params(&sks, &ct);
+        /// let lut = wopbs_key.generate_lut_radix(&ct, |x| x);
+        /// let ct_res = wopbs_key.wopbs(&ct, &lut);
+        /// let ct_res = wopbs_key.keyswitch_to_pbs_params(&ct_res);
+        /// let res: u64 = cks.decrypt(&ct_res);
+        ///
+        /// assert_eq!(res, clear);
+        /// ```
+        pub fn wopbs<T>(&self, ct_in: &T, lut: &IntegerWopbsLUT) -> T
+        where
+            T: IntegerCiphertext,
+        {
+            let total_bits_extracted = ct_in.blocks().iter().fold(0usize, |acc, block| {
+                acc + f64::log2((block.degree.get() + 1) as f64).ceil() as usize
+            });
+
+            let extract_bits_output_lwe_size = self
+                .wopbs_key
+                .wopbs_server_key
+                .key_switching_key
+                .output_key_lwe_dimension()
+                .to_lwe_size();
+
+            let mut extracted_bits_blocks = LweCiphertextList::new(
+                0u64,
+                extract_bits_output_lwe_size,
+                LweCiphertextCount(total_bits_extracted),
+                self.wopbs_key.param.ciphertext_modulus,
+            );
+
+            let mut bits_extracted_so_far = 0;
+
             // Extraction of each bit for each block
-            for block in ct_in.blocks_mut().iter_mut().rev() {
-                let nb_bit_to_extract =
-                    f64::log2((block.message_modulus.0 * block.carry_modulus.0) as f64).ceil()
-                        as usize;
-                let delta_log = DeltaLog(64 - nb_bit_to_extract);
-
-                // trick ( ct - delta/2 + delta/2^4  )
-                lwe_ciphertext_plaintext_sub_assign(
-                    &mut block.ct,
-                    Plaintext(
-                        (1 << (64 - nb_bit_to_extract - 1)) - (1 << (64 - nb_bit_to_extract - 5)),
-                    ),
-                );
+            for block in ct_in.blocks().iter().rev() {
+                let message_modulus = self.wopbs_key.param.message_modulus.0 as u64;
+                let carry_modulus = self.wopbs_key.param.carry_modulus.0 as u64;
+                let delta = (1u64 << 63) / (carry_modulus * message_modulus);
+                // casting to usize is fine, ilog2 of u64 is guaranteed to be < 64
+                let delta_log = DeltaLog(delta.ilog2() as usize);
+                let nb_bit_to_extract = f64::log2((block.degree.get() + 1) as f64).ceil() as usize;
 
                 let extract_from_bit = bits_extracted_so_far;
                 let extract_to_bit = extract_from_bit + nb_bit_to_extract;
@@ -1111,51 +342,849 @@ impl WopbsKey {
                     &mut lwe_sub_list,
                 );
             }
+
+            let vec_ct_out = self
+                .wopbs_key
+                .circuit_bootstrapping_vertical_packing(lut.as_ref(), &extracted_bits_blocks);
+
+            let mut ct_vec_out = vec![];
+            for (block, block_out) in ct_in.blocks().iter().zip(vec_ct_out) {
+                ct_vec_out.push(crate::shortint::Ciphertext::new(
+                    block_out,
+                    Degree::new(block.message_modulus.0 - 1),
+                    NoiseLevel::NOMINAL,
+                    block.message_modulus,
+                    block.carry_modulus,
+                    block.pbs_order,
+                ));
+            }
+            T::from_blocks(ct_vec_out)
         }
 
-        let vec_ct_out = self
-            .wopbs_key
-            .circuit_bootstrapping_vertical_packing(lut.as_ref(), &extracted_bits_blocks);
+        /// # Example
+        /// ```rust
+        /// use tfhe::integer::gen_keys_radix;
+        /// use tfhe::integer::wopbs::WopbsKey;
+        /// use tfhe::shortint::parameters::parameters_wopbs_only::WOPBS_ONLY_4_BLOCKS_PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+        ///
+        /// let nb_block = 3;
+        /// //Generate the client key and the server key:
+        /// let (cks, sks) = gen_keys_radix(WOPBS_ONLY_4_BLOCKS_PARAM_MESSAGE_2_CARRY_2_KS_PBS, nb_block);
+        /// let wopbs_key = WopbsKey::new_wopbs_key_only_for_wopbs(&cks, &sks);
+        /// let mut moduli = 1_u64;
+        /// for _ in 0..nb_block {
+        ///     moduli *= cks.parameters().message_modulus().0 as u64;
+        /// }
+        /// let clear = 15 % moduli;
+        /// let ct = cks.encrypt_without_padding(clear);
+        /// let lut = wopbs_key.generate_lut_radix_without_padding(&ct, |x| 2 * x);
+        /// let ct_res = wopbs_key.wopbs_without_padding(&ct, &lut);
+        /// let res: u64 = cks.decrypt_without_padding(&ct_res);
+        ///
+        /// assert_eq!(res, (clear * 2) % moduli)
+        /// ```
+        pub fn wopbs_without_padding<T>(&self, ct_in: &T, lut: &IntegerWopbsLUT) -> T
+        where
+            T: IntegerCiphertext,
+        {
+            let total_bits_extracted = ct_in.blocks().iter().fold(0usize, |acc, block| {
+                acc + f64::log2((block.message_modulus.0 * block.carry_modulus.0) as f64) as usize
+            });
 
-        let mut ct_vec_out = Vec::with_capacity(vec_ct_in.len());
-        for (block, block_out) in vec_ct_in[0].blocks().iter().zip(vec_ct_out) {
-            ct_vec_out.push(crate::shortint::Ciphertext::new(
-                block_out,
-                Degree::new(block.message_modulus.0 - 1),
-                NoiseLevel::NOMINAL,
-                block.message_modulus,
-                block.carry_modulus,
-                block.pbs_order,
-            ));
+            let extract_bits_output_lwe_size = self
+                .wopbs_key
+                .wopbs_server_key
+                .key_switching_key
+                .output_key_lwe_dimension()
+                .to_lwe_size();
+
+            let mut extracted_bits_blocks = LweCiphertextList::new(
+                0u64,
+                extract_bits_output_lwe_size,
+                LweCiphertextCount(total_bits_extracted),
+                self.wopbs_key.param.ciphertext_modulus,
+            );
+
+            let mut bits_extracted_so_far = 0;
+            // Extraction of each bit for each block
+            for block in ct_in.blocks().iter().rev() {
+                let block_modulus = block.message_modulus.0 as u64 * block.carry_modulus.0 as u64;
+                let delta = (1_u64 << 63) / (block_modulus / 2);
+                // casting to usize is fine, ilog2 of u64 is guaranteed to be < 64
+                let delta_log = DeltaLog(delta.ilog2() as usize);
+                let nb_bit_to_extract =
+                    f64::log2((block.message_modulus.0 * block.carry_modulus.0) as f64) as usize;
+
+                let extract_from_bit = bits_extracted_so_far;
+                let extract_to_bit = extract_from_bit + nb_bit_to_extract;
+                bits_extracted_so_far += nb_bit_to_extract;
+
+                let mut lwe_sub_list =
+                    extracted_bits_blocks.get_sub_mut(extract_from_bit..extract_to_bit);
+
+                self.wopbs_key.extract_bits_assign(
+                    delta_log,
+                    block,
+                    ExtractedBitsCount(nb_bit_to_extract),
+                    &mut lwe_sub_list,
+                );
+            }
+
+            let vec_ct_out = self
+                .wopbs_key
+                .circuit_bootstrapping_vertical_packing(lut.as_ref(), &extracted_bits_blocks);
+
+            let mut ct_vec_out = vec![];
+            for (block, block_out) in ct_in.blocks().iter().zip(vec_ct_out) {
+                ct_vec_out.push(crate::shortint::Ciphertext::new(
+                    block_out,
+                    Degree::new(block.message_modulus.0 - 1),
+                    NoiseLevel::NOMINAL,
+                    block.message_modulus,
+                    block.carry_modulus,
+                    block.pbs_order,
+                ));
+            }
+            T::from_blocks(ct_vec_out)
         }
-        T::from_blocks(ct_vec_out)
-    }
 
-    pub fn keyswitch_to_wopbs_params<'a, T>(&self, sks: &ServerKey, ct_in: &'a T) -> T
-    where
-        T: IntegerCiphertext,
-        &'a [crate::shortint::Ciphertext]:
-            IntoParallelIterator<Item = &'a crate::shortint::Ciphertext>,
-    {
-        let blocks: Vec<_> = ct_in
-            .blocks()
-            .par_iter()
-            .map(|block| self.wopbs_key.keyswitch_to_wopbs_params(&sks.key, block))
-            .collect();
-        T::from_blocks(blocks)
-    }
+        /// WOPBS for native CRT
+        /// # Example
+        /// ```rust
+        /// use tfhe::integer::gen_keys_crt;
+        /// use tfhe::integer::wopbs::WopbsKey;
+        /// use tfhe::shortint::parameters::parameters_wopbs_message_carry::WOPBS_PARAM_MESSAGE_4_CARRY_4_KS_PBS;
+        ///
+        /// let basis: Vec<u64> = vec![9, 11];
+        /// let msg_space: u64 = basis.iter().copied().product();
+        ///
+        /// let param = WOPBS_PARAM_MESSAGE_4_CARRY_4_KS_PBS;
+        /// //Generate the client key and the server key:
+        /// let (cks, sks) = gen_keys_crt(param, basis);
+        /// let wopbs_key = WopbsKey::new_wopbs_key_only_for_wopbs(&cks, &sks);
+        ///
+        /// let clear = 42 % msg_space; // Encrypt the integers
+        /// let ct = cks.encrypt_native_crt(clear);
+        /// let lut = wopbs_key.generate_lut_native_crt(&ct, |x| x);
+        /// let ct_res = wopbs_key.wopbs_native_crt(&ct, &lut);
+        /// let res = cks.decrypt_native_crt(&ct_res);
+        /// assert_eq!(res, clear);
+        /// ```
+        pub fn wopbs_native_crt(
+            &self,
+            ct1: &CrtCiphertext,
+            lut: &IntegerWopbsLUT,
+        ) -> CrtCiphertext {
+            self.circuit_bootstrap_vertical_packing_native_crt(&[ct1.clone()], lut)
+        }
 
-    pub fn keyswitch_to_pbs_params<'a, T>(&self, ct_in: &'a T) -> T
-    where
-        T: IntegerCiphertext,
-        &'a [crate::shortint::Ciphertext]:
-            IntoParallelIterator<Item = &'a crate::shortint::Ciphertext>,
-    {
-        let blocks: Vec<_> = ct_in
-            .blocks()
-            .par_iter()
-            .map(|block| self.wopbs_key.keyswitch_to_pbs_params(block))
-            .collect();
-        T::from_blocks(blocks)
+        /// # Example
+        /// ```rust
+        /// use tfhe::integer::gen_keys_radix;
+        /// use tfhe::integer::wopbs::*;
+        /// use tfhe::shortint::parameters::parameters_wopbs_message_carry::WOPBS_PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+        /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+        ///
+        /// let nb_block = 3;
+        /// //Generate the client key and the server key:
+        /// let (cks, sks) = gen_keys_radix(PARAM_MESSAGE_2_CARRY_2_KS_PBS, nb_block);
+        ///
+        /// // Generate wopbs_v0 key
+        /// let wopbs_key = WopbsKey::new_wopbs_key(&cks, &sks, &WOPBS_PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+        /// let mut moduli = 1_u64;
+        /// for _ in 0..nb_block {
+        ///     moduli *= cks.parameters().message_modulus().0 as u64;
+        /// }
+        /// let clear1 = 42 % moduli;
+        /// let clear2 = 24 % moduli;
+        /// let ct1 = cks.encrypt(clear1);
+        /// let ct2 = cks.encrypt(clear2);
+        ///
+        /// let ct1 = wopbs_key.keyswitch_to_wopbs_params(&sks, &ct1);
+        /// let ct2 = wopbs_key.keyswitch_to_wopbs_params(&sks, &ct2);
+        /// let lut = wopbs_key.generate_lut_bivariate_radix(&ct1, &ct2, |x, y| 2 * x * y);
+        /// let ct_res = wopbs_key.bivariate_wopbs_with_degree(&ct1, &ct2, &lut);
+        /// let ct_res = wopbs_key.keyswitch_to_pbs_params(&ct_res);
+        /// let res: u64 = cks.decrypt(&ct_res);
+        ///
+        /// assert_eq!(res, (2 * clear1 * clear2) % moduli);
+        /// ```
+        pub fn bivariate_wopbs_with_degree<T>(&self, ct1: &T, ct2: &T, lut: &IntegerWopbsLUT) -> T
+        where
+            T: IntegerCiphertext,
+        {
+            let ct = ciphertext_concatenation(ct1, ct2);
+            self.wopbs(&ct, lut)
+        }
+
+        /// # Example
+        ///
+        /// ```rust
+        /// use tfhe::integer::gen_keys_radix;
+        /// use tfhe::integer::wopbs::*;
+        /// use tfhe::shortint::parameters::parameters_wopbs_message_carry::WOPBS_PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+        /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+        ///
+        /// let nb_block = 3;
+        /// //Generate the client key and the server key:
+        /// let (cks, sks) = gen_keys_radix(PARAM_MESSAGE_2_CARRY_2_KS_PBS, nb_block);
+        ///
+        /// //Generate wopbs_v0 key    ///
+        /// let wopbs_key = WopbsKey::new_wopbs_key(&cks, &sks, &WOPBS_PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+        /// let mut moduli = 1_u64;
+        /// for _ in 0..nb_block {
+        ///     moduli *= cks.parameters().message_modulus().0 as u64;
+        /// }
+        /// let clear = 42 % moduli;
+        /// let ct = cks.encrypt(clear);
+        /// let ct = wopbs_key.keyswitch_to_wopbs_params(&sks, &ct);
+        /// let lut = wopbs_key.generate_lut_radix(&ct, |x| 2 * x);
+        /// let ct_res = wopbs_key.wopbs(&ct, &lut);
+        /// let ct_res = wopbs_key.keyswitch_to_pbs_params(&ct_res);
+        /// let res: u64 = cks.decrypt(&ct_res);
+        ///
+        /// assert_eq!(res, (2 * clear) % moduli);
+        /// ```
+        pub fn generate_lut_radix<F, T>(&self, ct: &T, f: F) -> IntegerWopbsLUT
+        where
+            F: Fn(u64) -> u64,
+            T: IntegerCiphertext,
+        {
+            let mut total_bit = 0;
+            let block_nb = ct.blocks().len();
+            let mut modulus = 1;
+
+            //This contains the basis of each block depending on the degree
+            let mut vec_deg_basis = vec![];
+
+            for (i, deg) in ct.moduli().iter().zip(ct.blocks().iter()) {
+                modulus *= i;
+                let b = f64::log2((deg.degree.get() + 1) as f64).ceil() as u64;
+                vec_deg_basis.push(b);
+                total_bit += b;
+            }
+
+            let lut_size = if 1 << total_bit < self.wopbs_key.param.polynomial_size.0 as u64 {
+                self.wopbs_key.param.polynomial_size.0
+            } else {
+                1 << total_bit
+            };
+            let mut lut =
+                IntegerWopbsLUT::new(PlaintextCount(lut_size), CiphertextCount(ct.blocks().len()));
+
+            let basis = ct.moduli()[0];
+            let delta: u64 = (1 << 63)
+                / (self.wopbs_key.param.message_modulus.0 * self.wopbs_key.param.carry_modulus.0)
+                    as u64;
+
+            for lut_index_val in 0..(1 << total_bit) {
+                let encoded_with_deg_val = encode_mix_radix(lut_index_val, &vec_deg_basis, basis);
+                let decoded_val = decode_radix(&encoded_with_deg_val, basis);
+                let f_val = f(decoded_val % modulus) % modulus;
+                let encoded_f_val = encode_radix(f_val, basis, block_nb as u64);
+                for (lut_number, radix_encoded_val) in
+                    encoded_f_val.iter().enumerate().take(block_nb)
+                {
+                    lut[lut_number][lut_index_val as usize] = radix_encoded_val * delta;
+                }
+            }
+            lut
+        }
+
+        /// # Example
+        /// ```rust
+        /// use tfhe::integer::gen_keys_radix;
+        /// use tfhe::integer::wopbs::WopbsKey;
+        /// use tfhe::shortint::parameters::parameters_wopbs_message_carry::WOPBS_PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+        /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+        ///
+        /// let nb_block = 3;
+        /// //Generate the client key and the server key:
+        /// let (cks, sks) = gen_keys_radix(PARAM_MESSAGE_2_CARRY_2_KS_PBS, nb_block);
+        /// //Generate wopbs_v0 key
+        /// let wopbs_key = WopbsKey::new_wopbs_key(&cks, &sks, &WOPBS_PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+        /// let mut moduli = 1_u64;
+        /// for _ in 0..nb_block {
+        ///     moduli *= cks.parameters().message_modulus().0 as u64;
+        /// }
+        /// let clear = 15 % moduli;
+        /// let ct = cks.encrypt_without_padding(clear);
+        /// let ct = wopbs_key.keyswitch_to_wopbs_params(&sks, &ct);
+        /// let lut = wopbs_key.generate_lut_radix_without_padding(&ct, |x| 2 * x);
+        /// let ct_res = wopbs_key.wopbs_without_padding(&ct, &lut);
+        /// let ct_res = wopbs_key.keyswitch_to_pbs_params(&ct_res);
+        /// let res: u64 = cks.decrypt_without_padding(&ct_res);
+        ///
+        /// assert_eq!(res, (clear * 2) % moduli)
+        /// ```
+        pub fn generate_lut_radix_without_padding<F, T>(&self, ct: &T, f: F) -> IntegerWopbsLUT
+        where
+            F: Fn(u64) -> u64,
+            T: IntegerCiphertext,
+        {
+            let log_message_modulus =
+                f64::log2((self.wopbs_key.param.message_modulus.0) as f64) as u64;
+            let log_carry_modulus = f64::log2((self.wopbs_key.param.carry_modulus.0) as f64) as u64;
+            let log_basis = log_message_modulus + log_carry_modulus;
+            let delta = 64 - log_basis;
+            let nb_block = ct.blocks().len();
+            let poly_size = self.wopbs_key.param.polynomial_size.0;
+            let mut lut_size = 1 << (nb_block * log_basis as usize);
+            if lut_size < poly_size {
+                lut_size = poly_size;
+            }
+            let mut lut = IntegerWopbsLUT::new(PlaintextCount(lut_size), CiphertextCount(nb_block));
+
+            for index in 0..lut_size {
+                // find the value represented by the index
+                let mut value = 0;
+                let mut tmp_index = index;
+                for i in 0..nb_block as u64 {
+                    let tmp = tmp_index % (1 << (log_basis * (i + 1)));
+                    tmp_index -= tmp;
+                    value += tmp >> (log_carry_modulus * i);
+                }
+
+                // fill the LUTs
+                for block_index in 0..nb_block {
+                    lut[block_index][index] = ((f(value as u64)
+                        >> (log_carry_modulus * block_index as u64))
+                        % (1 << log_message_modulus))
+                        << delta;
+                }
+            }
+            lut
+        }
+
+        /// generate lut for native CRT
+        /// # Example
+        ///
+        /// ```rust
+        /// use tfhe::integer::gen_keys_crt;
+        /// use tfhe::integer::wopbs::WopbsKey;
+        /// use tfhe::shortint::parameters::parameters_wopbs_message_carry::WOPBS_PARAM_MESSAGE_4_CARRY_4_KS_PBS;
+        ///
+        /// let basis: Vec<u64> = vec![9, 11];
+        /// let msg_space: u64 = basis.iter().copied().product();
+        ///
+        /// let param = WOPBS_PARAM_MESSAGE_4_CARRY_4_KS_PBS;
+        /// //Generate the client key and the server key:
+        /// let (cks, sks) = gen_keys_crt(param, basis);
+        /// let wopbs_key = WopbsKey::new_wopbs_key_only_for_wopbs(&cks, &sks);
+        ///
+        /// let clear = 42 % msg_space; // Encrypt the integers
+        /// let ct = cks.encrypt_native_crt(clear);
+        /// let lut = wopbs_key.generate_lut_native_crt(&ct, |x| x);
+        /// let ct_res = wopbs_key.wopbs_native_crt(&ct, &lut);
+        /// let res = cks.decrypt_native_crt(&ct_res);
+        /// assert_eq!(res, clear);
+        /// ```
+        pub fn generate_lut_native_crt<F>(&self, ct: &CrtCiphertext, f: F) -> IntegerWopbsLUT
+        where
+            F: Fn(u64) -> u64,
+        {
+            let mut bit = vec![];
+            let mut total_bit = 0;
+            let mut modulus = 1;
+            let basis: Vec<_> = ct.moduli();
+
+            for i in basis.iter() {
+                modulus *= i;
+                let b = f64::log2(*i as f64).ceil() as u64;
+                total_bit += b;
+                bit.push(b);
+            }
+            let lut_size = if 1 << total_bit < self.wopbs_key.param.polynomial_size.0 as u64 {
+                self.wopbs_key.param.polynomial_size.0
+            } else {
+                1 << total_bit
+            };
+            let mut lut =
+                IntegerWopbsLUT::new(PlaintextCount(lut_size), CiphertextCount(basis.len()));
+
+            for value in 0..modulus {
+                let mut index_lut = 0;
+                let mut tmp = 1;
+                for (base, bit) in basis.iter().zip(bit.iter()) {
+                    index_lut += (((value % base) << bit) / base) * tmp;
+                    tmp <<= bit;
+                }
+                for (j, b) in basis.iter().enumerate() {
+                    lut[j][index_lut as usize] =
+                        (((f(value) % b) as u128 * (1 << 64)) / *b as u128) as u64;
+                }
+            }
+            lut
+        }
+
+        /// generate LUt for crt
+        /// # Example
+        /// ```rust
+        /// use tfhe::integer::gen_keys_crt;
+        /// use tfhe::integer::wopbs::*;
+        /// use tfhe::shortint::parameters::parameters_wopbs_message_carry::WOPBS_PARAM_MESSAGE_3_CARRY_3_KS_PBS;
+        /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
+        ///
+        /// let basis: Vec<u64> = vec![5, 7];
+        /// let msg_space: u64 = basis.iter().copied().product();
+        ///
+        /// //Generate the client key and the server key:
+        /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
+        /// let wopbs_key = WopbsKey::new_wopbs_key(&cks, &sks, &WOPBS_PARAM_MESSAGE_3_CARRY_3_KS_PBS);
+        ///
+        /// let clear = 42 % msg_space;
+        /// let ct = cks.encrypt(clear);
+        /// let ct = wopbs_key.keyswitch_to_wopbs_params(&sks, &ct);
+        /// let lut = wopbs_key.generate_lut_crt(&ct, |x| x);
+        /// let ct_res = wopbs_key.wopbs(&ct, &lut);
+        /// let ct_res = wopbs_key.keyswitch_to_pbs_params(&ct_res);
+        /// let res = cks.decrypt(&ct_res);
+        /// assert_eq!(res, clear);
+        /// ```
+        pub fn generate_lut_crt<F>(&self, ct: &CrtCiphertext, f: F) -> IntegerWopbsLUT
+        where
+            F: Fn(u64) -> u64,
+        {
+            let mut total_bit = 0;
+            let mut modulus = 1;
+            let basis = ct.moduli();
+
+            for (i, deg) in basis.iter().zip(ct.blocks.iter()) {
+                modulus *= i;
+                let b = f64::log2((deg.degree.get() + 1) as f64).ceil() as u64;
+                total_bit += b;
+            }
+            let lut_size = if 1 << total_bit < self.wopbs_key.param.polynomial_size.0 as u64 {
+                self.wopbs_key.param.polynomial_size.0
+            } else {
+                1 << total_bit
+            };
+            let mut lut =
+                IntegerWopbsLUT::new(PlaintextCount(lut_size), CiphertextCount(basis.len()));
+
+            let delta: u64 = (1 << 63)
+                / (self.wopbs_key.param.message_modulus.0 * self.wopbs_key.param.carry_modulus.0)
+                    as u64;
+
+            for i in 0..(1 << total_bit) {
+                let mut decomp_terms = Vec::new();
+                let mut index_copy = i;
+                for (b, block) in basis.iter().zip(ct.blocks.iter()) {
+                    let block_bit_count = f64::log2((block.degree.get() + 1) as f64).ceil() as u64;
+                    let bits_corresponding_to_block = index_copy % (1 << block_bit_count);
+                    let decomp_term = bits_corresponding_to_block % b;
+                    index_copy >>= block_bit_count;
+                    decomp_terms.push(decomp_term);
+                }
+                let value_corresponding_to_index = i_crt(&basis, &decomp_terms);
+                let f_eval = f(value_corresponding_to_index);
+                for (j, block) in ct.blocks.iter().enumerate() {
+                    lut[j][i as usize] = (f_eval % block.message_modulus.0 as u64) * delta;
+                }
+            }
+            lut
+        }
+
+        /// # Example
+        ///
+        /// ```rust
+        /// use tfhe::integer::gen_keys_radix;
+        /// use tfhe::integer::wopbs::*;
+        /// use tfhe::shortint::parameters::parameters_wopbs_message_carry::WOPBS_PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+        /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+        ///
+        /// let nb_block = 3;
+        /// //Generate the client key and the server key:
+        /// let (cks, sks) = gen_keys_radix(PARAM_MESSAGE_2_CARRY_2_KS_PBS, nb_block);
+        ///
+        /// //Generate wopbs_v0 key    ///
+        /// let wopbs_key = WopbsKey::new_wopbs_key(&cks, &sks, &WOPBS_PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+        /// let mut moduli = 1_u64;
+        /// for _ in 0..nb_block {
+        ///     moduli *= cks.parameters().message_modulus().0 as u64;
+        /// }
+        /// let clear1 = 42 % moduli;
+        /// let clear2 = 24 % moduli;
+        /// let ct1 = cks.encrypt(clear1);
+        /// let ct2 = cks.encrypt(clear2);
+        ///
+        /// let ct1 = wopbs_key.keyswitch_to_wopbs_params(&sks, &ct1);
+        /// let ct2 = wopbs_key.keyswitch_to_wopbs_params(&sks, &ct2);
+        /// let lut = wopbs_key.generate_lut_bivariate_radix(&ct1, &ct2, |x, y| 2 * x * y);
+        /// let ct_res = wopbs_key.bivariate_wopbs_with_degree(&ct1, &ct2, &lut);
+        /// let ct_res = wopbs_key.keyswitch_to_pbs_params(&ct_res);
+        /// let res: u64 = cks.decrypt(&ct_res);
+        ///
+        /// assert_eq!(res, (2 * clear1 * clear2) % moduli);
+        /// ```
+        pub fn generate_lut_bivariate_radix<F>(
+            &self,
+            ct1: &RadixCiphertext,
+            ct2: &RadixCiphertext,
+            f: F,
+        ) -> IntegerWopbsLUT
+        where
+            RadixCiphertext: IntegerCiphertext,
+            F: Fn(u64, u64) -> u64,
+        {
+            let mut nb_bit_to_extract = [0; 2];
+            let block_nb = ct1.blocks.len();
+            //ct2 & ct1 should have the same basis
+            let basis = ct1.moduli();
+
+            //This contains the basis of each block depending on the degree
+            let mut vec_deg_basis = vec![vec![]; 2];
+
+            let mut modulus = 1;
+            for (ct_num, ct) in [ct1, ct2].iter().enumerate() {
+                modulus = 1;
+                for deg in ct.blocks.iter() {
+                    modulus *= self.wopbs_key.param.message_modulus.0 as u64;
+                    let b = f64::log2((deg.degree.get() + 1) as f64).ceil() as u64;
+                    vec_deg_basis[ct_num].push(b);
+                    nb_bit_to_extract[ct_num] += b;
+                }
+            }
+
+            let total_bit: u64 = nb_bit_to_extract.iter().sum();
+
+            let lut_size = if 1 << total_bit < self.wopbs_key.param.polynomial_size.0 as u64 {
+                self.wopbs_key.param.polynomial_size.0
+            } else {
+                1 << total_bit
+            };
+            let mut lut =
+                IntegerWopbsLUT::new(PlaintextCount(lut_size), CiphertextCount(basis.len()));
+            let basis = ct1.moduli()[0];
+
+            let delta: u64 = (1 << 63)
+                / (self.wopbs_key.param.message_modulus.0 * self.wopbs_key.param.carry_modulus.0)
+                    as u64;
+
+            for lut_index_val in 0..(1 << total_bit) {
+                let split = [
+                    lut_index_val % (1 << nb_bit_to_extract[0]),
+                    lut_index_val >> nb_bit_to_extract[0],
+                ];
+                let mut decoded_val = [0; 2];
+                for i in 0..2 {
+                    let encoded_with_deg_val = encode_mix_radix(split[i], &vec_deg_basis[i], basis);
+                    decoded_val[i] = decode_radix(&encoded_with_deg_val, basis);
+                }
+                let f_val = f(decoded_val[0] % modulus, decoded_val[1] % modulus) % modulus;
+                let encoded_f_val = encode_radix(f_val, basis, block_nb as u64);
+                for (lut_number, radix_encoded_val) in
+                    encoded_f_val.iter().enumerate().take(block_nb)
+                {
+                    lut[lut_number][lut_index_val as usize] = radix_encoded_val * delta;
+                }
+            }
+            lut
+        }
+
+        /// generate bivariate LUT for 'fake' CRT
+        ///
+        /// # Example
+        ///
+        /// ```rust
+        /// use tfhe::integer::gen_keys_crt;
+        /// use tfhe::integer::wopbs::*;
+        /// use tfhe::shortint::parameters::parameters_wopbs_message_carry::WOPBS_PARAM_MESSAGE_3_CARRY_3_KS_PBS;
+        /// use tfhe::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS;
+        ///
+        /// let basis: Vec<u64> = vec![5, 7];
+        /// let msg_space: u64 = basis.iter().copied().product();
+        /// //Generate the client key and the server key:
+        /// let (cks, sks) = gen_keys_crt(PARAM_MESSAGE_3_CARRY_3_KS_PBS, basis);
+        /// let wopbs_key = WopbsKey::new_wopbs_key(&cks, &sks, &WOPBS_PARAM_MESSAGE_3_CARRY_3_KS_PBS);
+        ///
+        /// let clear1 = 42 % msg_space; // Encrypt the integers
+        /// let clear2 = 24 % msg_space; // Encrypt the integers
+        /// let ct1 = cks.encrypt(clear1);
+        /// let ct2 = cks.encrypt(clear2);
+        ///
+        /// let ct1 = wopbs_key.keyswitch_to_wopbs_params(&sks, &ct1);
+        /// let ct2 = wopbs_key.keyswitch_to_wopbs_params(&sks, &ct2);
+        ///
+        /// let lut = wopbs_key.generate_lut_bivariate_crt(&ct1, &ct2, |x, y| x * y * 2);
+        /// let ct_res = wopbs_key.bivariate_wopbs_with_degree(&ct1, &ct2, &lut);
+        /// let ct_res = wopbs_key.keyswitch_to_pbs_params(&ct_res);
+        /// let res = cks.decrypt(&ct_res);
+        /// assert_eq!(res, (clear1 * clear2 * 2) % msg_space);
+        /// ```
+        pub fn generate_lut_bivariate_crt<F>(
+            &self,
+            ct1: &CrtCiphertext,
+            ct2: &CrtCiphertext,
+            f: F,
+        ) -> IntegerWopbsLUT
+        where
+            F: Fn(u64, u64) -> u64,
+        {
+            let mut nb_bit_to_extract = [0; 2];
+            let mut modulus = 1;
+
+            //ct2 & ct1 should have the same basis
+            let basis = ct1.moduli();
+
+            for (ct_num, ct) in [ct1, ct2].iter().enumerate() {
+                for (i, deg) in basis.iter().zip(ct.blocks.iter()) {
+                    modulus *= i;
+                    let b = f64::log2((deg.degree.get() + 1) as f64).ceil() as u64;
+                    nb_bit_to_extract[ct_num] += b;
+                }
+            }
+
+            let total_bit: u64 = nb_bit_to_extract.iter().sum();
+
+            let lut_size = if 1 << total_bit < self.wopbs_key.param.polynomial_size.0 as u64 {
+                self.wopbs_key.param.polynomial_size.0
+            } else {
+                1 << total_bit
+            };
+            let mut lut =
+                IntegerWopbsLUT::new(PlaintextCount(lut_size), CiphertextCount(basis.len()));
+
+            let delta: u64 = (1 << 63)
+                / (self.wopbs_key.param.message_modulus.0 * self.wopbs_key.param.carry_modulus.0)
+                    as u64;
+
+            for index in 0..(1 << total_bit) {
+                let mut split = encode_radix(index, 1 << nb_bit_to_extract[0], 2);
+                let mut crt_value = vec![vec![0; ct1.blocks.len()]; 2];
+                for (j, base) in basis.iter().enumerate().take(ct1.blocks.len()) {
+                    let deg_1 = f64::log2((ct1.blocks[j].degree.get() + 1) as f64).ceil() as u64;
+                    let deg_2 = f64::log2((ct2.blocks[j].degree.get() + 1) as f64).ceil() as u64;
+                    crt_value[0][j] = (split[0] % (1 << deg_1)) % base;
+                    crt_value[1][j] = (split[1] % (1 << deg_2)) % base;
+                    split[0] >>= deg_1;
+                    split[1] >>= deg_2;
+                }
+                let value_1 = i_crt(&ct1.moduli(), &crt_value[0]);
+                let value_2 = i_crt(&ct2.moduli(), &crt_value[1]);
+                for (j, current_mod) in basis.iter().enumerate() {
+                    let value = f(value_1, value_2) % current_mod;
+                    lut[j][index as usize] = (value % current_mod) * delta;
+                }
+            }
+
+            lut
+        }
+
+        /// generate bivariate LUT for 'true' CRT
+        /// # Example
+        ///
+        /// ```rust
+        /// use tfhe::integer::gen_keys_crt;
+        /// use tfhe::integer::wopbs::WopbsKey;
+        /// use tfhe::shortint::parameters::parameters_wopbs_message_carry::WOPBS_PARAM_MESSAGE_4_CARRY_4_KS_PBS;
+        ///
+        /// let basis: Vec<u64> = vec![9, 11];
+        /// let msg_space: u64 = basis.iter().copied().product();
+        ///
+        /// let param = WOPBS_PARAM_MESSAGE_4_CARRY_4_KS_PBS;
+        /// //Generate the client key and the server key:
+        /// let (cks, sks) = gen_keys_crt(param, basis);
+        /// let wopbs_key = WopbsKey::new_wopbs_key_only_for_wopbs(&cks, &sks);
+        ///
+        /// let clear1 = 42 % msg_space;
+        /// let clear2 = 24 % msg_space;
+        /// let ct1 = cks.encrypt_native_crt(clear1);
+        /// let ct2 = cks.encrypt_native_crt(clear2);
+        /// let lut = wopbs_key.generate_lut_bivariate_native_crt(&ct1, |x, y| x * y * 2);
+        /// let ct_res = wopbs_key.bivariate_wopbs_native_crt(&ct1, &ct2, &lut);
+        /// let res = cks.decrypt_native_crt(&ct_res);
+        /// assert_eq!(res, (clear1 * clear2 * 2) % msg_space);
+        /// ```
+        pub fn generate_lut_bivariate_native_crt<F>(
+            &self,
+            ct_1: &CrtCiphertext,
+            f: F,
+        ) -> IntegerWopbsLUT
+        where
+            F: Fn(u64, u64) -> u64,
+        {
+            let mut bit = vec![];
+            let mut total_bit = 0;
+            let mut modulus = 1;
+            let basis = ct_1.moduli();
+            for i in basis.iter() {
+                modulus *= i;
+                let b = f64::log2(*i as f64).ceil() as u64;
+                total_bit += b;
+                bit.push(b);
+            }
+            let lut_size = if 1 << (2 * total_bit) < self.wopbs_key.param.polynomial_size.0 as u64 {
+                self.wopbs_key.param.polynomial_size.0
+            } else {
+                1 << (2 * total_bit)
+            };
+            let mut lut =
+                IntegerWopbsLUT::new(PlaintextCount(lut_size), CiphertextCount(basis.len()));
+
+            for value in 0..1 << (2 * total_bit) {
+                let value_1 = value % (1 << total_bit);
+                let value_2 = value >> total_bit;
+                let mut index_lut_1 = 0;
+                let mut index_lut_2 = 0;
+                let mut tmp = 1;
+                for (base, bit) in basis.iter().zip(bit.iter()) {
+                    index_lut_1 += (((value_1 % base) << bit) / base) * tmp;
+                    index_lut_2 += (((value_2 % base) << bit) / base) * tmp;
+                    tmp <<= bit;
+                }
+                let index = (index_lut_2 << total_bit) + (index_lut_1);
+                for (j, b) in basis.iter().enumerate() {
+                    lut[j][index as usize] =
+                        (((f(value_1, value_2) % b) as u128 * (1 << 64)) / *b as u128) as u64;
+                }
+            }
+            lut
+        }
+
+        /// bivariate WOPBS for native CRT
+        /// # Example
+        ///
+        /// ```rust
+        /// use tfhe::integer::gen_keys_crt;
+        /// use tfhe::integer::wopbs::WopbsKey;
+        /// use tfhe::shortint::parameters::parameters_wopbs_message_carry::WOPBS_PARAM_MESSAGE_4_CARRY_4_KS_PBS;
+        ///
+        /// let basis: Vec<u64> = vec![9, 11];
+        /// let msg_space: u64 = basis.iter().copied().product();
+        ///
+        /// let param = WOPBS_PARAM_MESSAGE_4_CARRY_4_KS_PBS;
+        /// //Generate the client key and the server key:
+        /// let (cks, sks) = gen_keys_crt(param, basis);
+        /// let wopbs_key = WopbsKey::new_wopbs_key_only_for_wopbs(&cks, &sks);
+        ///
+        /// let clear1 = 42 % msg_space;
+        /// let clear2 = 24 % msg_space;
+        /// let ct1 = cks.encrypt_native_crt(clear1);
+        /// let ct2 = cks.encrypt_native_crt(clear2);
+        /// let lut = wopbs_key.generate_lut_bivariate_native_crt(&ct1, |x, y| x * y * 2);
+        /// let ct_res = wopbs_key.bivariate_wopbs_native_crt(&ct1, &ct2, &lut);
+        /// let res = cks.decrypt_native_crt(&ct_res);
+        /// assert_eq!(res, (clear1 * clear2 * 2) % msg_space);
+        /// ```
+        pub fn bivariate_wopbs_native_crt(
+            &self,
+            ct1: &CrtCiphertext,
+            ct2: &CrtCiphertext,
+            lut: &IntegerWopbsLUT,
+        ) -> CrtCiphertext {
+            self.circuit_bootstrap_vertical_packing_native_crt(&[ct1.clone(), ct2.clone()], lut)
+        }
+
+        fn circuit_bootstrap_vertical_packing_native_crt<T>(
+            &self,
+            vec_ct_in: &[T],
+            lut: &IntegerWopbsLUT,
+        ) -> T
+        where
+            T: IntegerCiphertext,
+        {
+            let total_bits_extracted = vec_ct_in.iter().fold(0usize, |acc, ct_in| {
+                acc + ct_in.blocks().iter().fold(0usize, |inner_acc, block| {
+                    inner_acc
+                        + f64::log2((block.message_modulus.0 * block.carry_modulus.0) as f64).ceil()
+                            as usize
+                })
+            });
+
+            let extract_bits_output_lwe_size = self
+                .wopbs_key
+                .wopbs_server_key
+                .key_switching_key
+                .output_key_lwe_dimension()
+                .to_lwe_size();
+
+            let mut extracted_bits_blocks = LweCiphertextList::new(
+                0u64,
+                extract_bits_output_lwe_size,
+                LweCiphertextCount(total_bits_extracted),
+                self.wopbs_key.param.ciphertext_modulus,
+            );
+
+            let mut bits_extracted_so_far = 0;
+            for ct_in in vec_ct_in.iter().rev() {
+                let mut ct_in = ct_in.clone();
+                // Extraction of each bit for each block
+                for block in ct_in.blocks_mut().iter_mut().rev() {
+                    let nb_bit_to_extract =
+                        f64::log2((block.message_modulus.0 * block.carry_modulus.0) as f64).ceil()
+                            as usize;
+                    let delta_log = DeltaLog(64 - nb_bit_to_extract);
+
+                    // trick ( ct - delta/2 + delta/2^4  )
+                    lwe_ciphertext_plaintext_sub_assign(
+                        &mut block.ct,
+                        Plaintext(
+                            (1 << (64 - nb_bit_to_extract - 1))
+                                - (1 << (64 - nb_bit_to_extract - 5)),
+                        ),
+                    );
+
+                    let extract_from_bit = bits_extracted_so_far;
+                    let extract_to_bit = extract_from_bit + nb_bit_to_extract;
+                    bits_extracted_so_far += nb_bit_to_extract;
+
+                    let mut lwe_sub_list =
+                        extracted_bits_blocks.get_sub_mut(extract_from_bit..extract_to_bit);
+
+                    self.wopbs_key.extract_bits_assign(
+                        delta_log,
+                        block,
+                        ExtractedBitsCount(nb_bit_to_extract),
+                        &mut lwe_sub_list,
+                    );
+                }
+            }
+
+            let vec_ct_out = self
+                .wopbs_key
+                .circuit_bootstrapping_vertical_packing(lut.as_ref(), &extracted_bits_blocks);
+
+            let mut ct_vec_out = Vec::with_capacity(vec_ct_in.len());
+            for (block, block_out) in vec_ct_in[0].blocks().iter().zip(vec_ct_out) {
+                ct_vec_out.push(crate::shortint::Ciphertext::new(
+                    block_out,
+                    Degree::new(block.message_modulus.0 - 1),
+                    NoiseLevel::NOMINAL,
+                    block.message_modulus,
+                    block.carry_modulus,
+                    block.pbs_order,
+                ));
+            }
+            T::from_blocks(ct_vec_out)
+        }
+
+        pub fn keyswitch_to_wopbs_params<'a, T>(&self, sks: &ServerKey, ct_in: &'a T) -> T
+        where
+            T: IntegerCiphertext,
+            &'a [crate::shortint::Ciphertext]:
+                IntoParallelIterator<Item = &'a crate::shortint::Ciphertext>,
+        {
+            let blocks: Vec<_> = ct_in
+                .blocks()
+                .par_iter()
+                .map(|block| self.wopbs_key.keyswitch_to_wopbs_params(&sks.key, block))
+                .collect();
+            T::from_blocks(blocks)
+        }
+
+        pub fn keyswitch_to_pbs_params<'a, T>(&self, ct_in: &'a T) -> T
+        where
+            T: IntegerCiphertext,
+            &'a [crate::shortint::Ciphertext]:
+                IntoParallelIterator<Item = &'a crate::shortint::Ciphertext>,
+        {
+            let blocks: Vec<_> = ct_in
+                .blocks()
+                .par_iter()
+                .map(|block| self.wopbs_key.keyswitch_to_pbs_params(block))
+                .collect();
+            T::from_blocks(blocks)
+        }
     }
 }

--- a/tfhe/src/shortint/engine/mod.rs
+++ b/tfhe/src/shortint/engine/mod.rs
@@ -24,6 +24,7 @@ use std::fmt::Debug;
 mod client_side;
 mod public_side;
 mod server_side;
+#[cfg(feature = "experimental")]
 mod wopbs;
 
 thread_local! {
@@ -262,8 +263,6 @@ impl std::fmt::Display for EngineError {
         write!(f, "{}", &self.error)
     }
 }
-
-pub(crate) type EngineResult<T> = Result<T, EngineError>;
 
 /// ShortintEngine
 ///

--- a/tfhe/src/shortint/engine/wopbs/mod.rs
+++ b/tfhe/src/shortint/engine/wopbs/mod.rs
@@ -2,7 +2,7 @@
 use crate::core_crypto::algorithms::*;
 use crate::core_crypto::entities::*;
 use crate::shortint::ciphertext::{MaxDegree, MaxNoiseLevel};
-use crate::shortint::engine::{EngineResult, ShortintEngine};
+use crate::shortint::engine::ShortintEngine;
 use crate::shortint::server_key::ShortintBootstrappingKey;
 use crate::shortint::wopbs::{WopbsKey, WopbsKeyCreationError};
 use crate::shortint::{ClientKey, ServerKey, WopbsParameters};
@@ -13,12 +13,15 @@ impl ShortintEngine {
         &mut self,
         cks: &ClientKey,
         sks: &ServerKey,
-    ) -> EngineResult<WopbsKey> {
+    ) -> crate::Result<WopbsKey> {
         if matches!(
             sks.bootstrapping_key,
             ShortintBootstrappingKey::MultiBit { .. }
         ) {
-            return Err(WopbsKeyCreationError::UnsupportedMultiBit.into());
+            return Err(crate::Error::new(format!(
+                "{}",
+                WopbsKeyCreationError::UnsupportedMultiBit
+            )));
         }
 
         let wop_params = cks.parameters.wopbs_parameters().unwrap();

--- a/tfhe/src/shortint/keycache.rs
+++ b/tfhe/src/shortint/keycache.rs
@@ -412,55 +412,60 @@ impl Keycache {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct WopbsParamPair(pub PBSParameters, pub WopbsParameters);
+#[cfg(feature = "experimental")]
+mod wopbs {
+    use super::*;
 
-impl<P> From<(P, WopbsParameters)> for WopbsParamPair
-where
-    P: Into<PBSParameters>,
-{
-    fn from(tuple: (P, WopbsParameters)) -> Self {
-        Self(tuple.0.into(), tuple.1)
-    }
-}
+    #[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
+    pub struct WopbsParamPair(pub PBSParameters, pub WopbsParameters);
 
-impl NamedParam for WopbsParamPair {
-    fn name(&self) -> String {
-        self.1.name()
-    }
-}
-
-/// The KeyCache struct for shortint.
-///
-/// You should not create an instance yourself,
-/// but rather use the global variable defined: [static@KEY_CACHE_WOPBS]
-pub struct KeycacheWopbsV0 {
-    inner: ImplKeyCache<WopbsParamPair, WopbsKey, FileStorage>,
-}
-
-impl Default for KeycacheWopbsV0 {
-    fn default() -> Self {
-        Self {
-            inner: ImplKeyCache::new(FileStorage::new("../keys/shortint/wopbs_v0".to_string())),
-        }
-    }
-}
-
-impl KeycacheWopbsV0 {
-    pub fn get_from_param<T: Into<WopbsParamPair>>(&self, params: T) -> SharedWopbsKey {
-        let params = params.into();
-        let key = KEY_CACHE.get_from_param(params.0);
-        let wk = self.inner.get_with_closure(params, &mut |_| {
-            WopbsKey::new_wopbs_key(&key.inner.0, &key.inner.1, &params.1)
-        });
-        SharedWopbsKey {
-            inner: key.inner,
-            wopbs: wk,
+    impl<P> From<(P, WopbsParameters)> for WopbsParamPair
+    where
+        P: Into<PBSParameters>,
+    {
+        fn from(tuple: (P, WopbsParameters)) -> Self {
+            Self(tuple.0.into(), tuple.1)
         }
     }
 
-    pub fn clear_in_memory_cache(&self) {
-        self.inner.clear_in_memory_cache();
+    impl NamedParam for WopbsParamPair {
+        fn name(&self) -> String {
+            self.1.name()
+        }
+    }
+
+    /// The KeyCache struct for shortint.
+    ///
+    /// You should not create an instance yourself,
+    /// but rather use the global variable defined: [static@KEY_CACHE_WOPBS]
+    pub struct KeycacheWopbsV0 {
+        inner: ImplKeyCache<WopbsParamPair, WopbsKey, FileStorage>,
+    }
+
+    impl Default for KeycacheWopbsV0 {
+        fn default() -> Self {
+            Self {
+                inner: ImplKeyCache::new(FileStorage::new("../keys/shortint/wopbs_v0".to_string())),
+            }
+        }
+    }
+
+    impl KeycacheWopbsV0 {
+        pub fn get_from_param<T: Into<WopbsParamPair>>(&self, params: T) -> SharedWopbsKey {
+            let params = params.into();
+            let key = KEY_CACHE.get_from_param(params.0);
+            let wk = self.inner.get_with_closure(params, &mut |_| {
+                WopbsKey::new_wopbs_key(&key.inner.0, &key.inner.1, &params.1)
+            });
+            SharedWopbsKey {
+                inner: key.inner,
+                wopbs: wk,
+            }
+        }
+
+        pub fn clear_in_memory_cache(&self) {
+            self.inner.clear_in_memory_cache();
+        }
     }
 }
 
@@ -531,6 +536,10 @@ impl KeycacheKeySwitchingKey {
 
 lazy_static! {
     pub static ref KEY_CACHE: Keycache = Keycache::default();
-    pub static ref KEY_CACHE_WOPBS: KeycacheWopbsV0 = KeycacheWopbsV0::default();
     pub static ref KEY_CACHE_KSK: KeycacheKeySwitchingKey = KeycacheKeySwitchingKey::default();
+}
+
+#[cfg(feature = "experimental")]
+lazy_static! {
+    pub static ref KEY_CACHE_WOPBS: wopbs::KeycacheWopbsV0 = wopbs::KeycacheWopbsV0::default();
 }

--- a/tfhe/src/shortint/mod.rs
+++ b/tfhe/src/shortint/mod.rs
@@ -60,7 +60,10 @@ pub mod parameters;
 pub mod prelude;
 pub mod public_key;
 pub mod server_key;
+#[cfg(feature = "experimental")]
 pub mod wopbs;
+#[cfg(not(feature = "experimental"))]
+pub(crate) mod wopbs;
 
 pub use ciphertext::{Ciphertext, CompressedCiphertext, PBSOrder};
 pub use client_key::ClientKey;

--- a/tfhe/src/shortint/wopbs/mod.rs
+++ b/tfhe/src/shortint/wopbs/mod.rs
@@ -7,39 +7,15 @@
 //! In the case where a padding bit is defined, keys are generated so that there a compatible for
 //! both uses.
 
-use crate::core_crypto::algorithms::*;
-use crate::core_crypto::commons::parameters::*;
-pub use crate::core_crypto::commons::parameters::{CiphertextCount, PlaintextCount};
-use crate::core_crypto::commons::traits::*;
 use crate::core_crypto::entities::*;
-use crate::core_crypto::fft_impl::fft64::math::fft::Fft;
-use crate::shortint::ciphertext::*;
-use crate::shortint::engine::ShortintEngine;
-use crate::shortint::server_key::ShortintBootstrappingKey;
-use crate::shortint::{ClientKey, ServerKey, WopbsParameters};
+
+use crate::shortint::{ServerKey, WopbsParameters};
 use serde::{Deserialize, Serialize};
 use tfhe_versionable::Versionize;
 
 use super::backward_compatibility::wopbs::WopbsKeyVersions;
 
-#[derive(Debug)]
-pub enum WopbsKeyCreationError {
-    UnsupportedMultiBit,
-}
-
-impl std::error::Error for WopbsKeyCreationError {}
-
-impl std::fmt::Display for WopbsKeyCreationError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::UnsupportedMultiBit => {
-                write!(f, "WopbsKey does not yet support using multi bit PBS")
-            }
-        }
-    }
-}
-
-#[cfg(test)]
+#[cfg(all(test, feature = "experimental"))]
 mod test;
 
 // Struct for WoPBS based on the private functional packing keyswitch.
@@ -54,867 +30,917 @@ pub struct WopbsKey {
     pub param: WopbsParameters,
 }
 
-#[must_use]
-pub struct WopbsLUTBase {
-    // Flattened Wopbs LUT
-    plaintext_list: Vec<u64>,
-    // How many output ciphertexts will be produced after applying the Wopbs to an input vector of
-    // ciphertexts encrypting bits
-    output_ciphertext_count: CiphertextCount,
-}
+#[cfg(feature = "experimental")]
+pub use experimental::*;
 
-impl WopbsLUTBase {
-    pub fn from_vec(value: Vec<u64>, output_ciphertext_count: CiphertextCount) -> Self {
-        Self {
-            plaintext_list: value,
-            output_ciphertext_count,
-        }
+#[cfg(feature = "experimental")]
+mod experimental {
+    use crate::core_crypto::algorithms::*;
+    use crate::core_crypto::commons::parameters::*;
+    use crate::core_crypto::commons::traits::*;
+    use crate::core_crypto::entities::*;
+    use crate::core_crypto::fft_impl::fft64::math::fft::Fft;
+    use crate::shortint::ciphertext::*;
+    use crate::shortint::engine::ShortintEngine;
+    use crate::shortint::server_key::ShortintBootstrappingKey;
+
+    use super::WopbsKey;
+    use crate::shortint::{ClientKey, ServerKey, WopbsParameters};
+
+    #[derive(Debug)]
+    pub enum WopbsKeyCreationError {
+        UnsupportedMultiBit,
     }
 
-    pub fn new(small_lut_size: PlaintextCount, output_ciphertext_count: CiphertextCount) -> Self {
-        Self {
-            plaintext_list: vec![0; small_lut_size.0 * output_ciphertext_count.0],
-            output_ciphertext_count,
-        }
-    }
-
-    pub fn lut(&self) -> PlaintextListView<'_, u64> {
-        PlaintextList::from_container(&self.plaintext_list)
-    }
-
-    pub fn lut_mut(&mut self) -> PlaintextListMutView<'_, u64> {
-        PlaintextList::from_container(&mut self.plaintext_list)
-    }
-
-    pub fn output_ciphertext_count(&self) -> CiphertextCount {
-        self.output_ciphertext_count
-    }
-
-    pub fn small_lut_size(&self) -> PlaintextCount {
-        PlaintextCount(self.lut().plaintext_count().0 / self.output_ciphertext_count().0)
-    }
-
-    pub fn get_small_lut(&self, index: usize) -> &[u64] {
-        assert!(
-            index < self.output_ciphertext_count().0,
-            "index {index} out of bounds, max {}",
-            self.output_ciphertext_count().0
-        );
-
-        let small_lut_size = self.small_lut_size().0;
-
-        &self.plaintext_list[index * small_lut_size..(index + 1) * small_lut_size]
-    }
-
-    pub fn get_small_lut_mut(&mut self, index: usize) -> &mut [u64] {
-        assert!(
-            index < self.output_ciphertext_count().0,
-            "index {index} out of bounds, max {}",
-            self.output_ciphertext_count().0
-        );
-
-        let small_lut_size = self.small_lut_size().0;
-
-        &mut self.plaintext_list[index * small_lut_size..(index + 1) * small_lut_size]
-    }
-}
-
-impl AsRef<[u64]> for WopbsLUTBase {
-    fn as_ref(&self) -> &[u64] {
-        self.plaintext_list.as_ref()
-    }
-}
-
-impl AsMut<[u64]> for WopbsLUTBase {
-    fn as_mut(&mut self) -> &mut [u64] {
-        self.plaintext_list.as_mut()
-    }
-}
-
-#[must_use]
-pub struct ShortintWopbsLUT {
-    inner: WopbsLUTBase,
-}
-
-impl ShortintWopbsLUT {
-    pub fn new(lut_size: PlaintextCount) -> Self {
-        Self {
-            inner: WopbsLUTBase::new(lut_size, CiphertextCount(1)),
-        }
-    }
-
-    pub fn iter(&self) -> std::slice::Iter<'_, u64> {
-        self.inner.as_ref().iter()
-    }
-
-    pub fn iter_mut(&mut self) -> std::slice::IterMut<'_, u64> {
-        self.inner.as_mut().iter_mut()
-    }
-}
-
-impl<'a> IntoIterator for &'a ShortintWopbsLUT {
-    type IntoIter = std::slice::Iter<'a, u64>;
-    type Item = &'a u64;
-    fn into_iter(self) -> Self::IntoIter {
-        self.iter()
-    }
-}
-
-impl<'a> IntoIterator for &'a mut ShortintWopbsLUT {
-    type IntoIter = std::slice::IterMut<'a, u64>;
-    type Item = &'a mut u64;
-    fn into_iter(self) -> Self::IntoIter {
-        self.iter_mut()
-    }
-}
-
-impl AsRef<WopbsLUTBase> for ShortintWopbsLUT {
-    fn as_ref(&self) -> &WopbsLUTBase {
-        &self.inner
-    }
-}
-
-impl AsMut<WopbsLUTBase> for ShortintWopbsLUT {
-    fn as_mut(&mut self) -> &mut WopbsLUTBase {
-        &mut self.inner
-    }
-}
-
-impl std::ops::Index<usize> for ShortintWopbsLUT {
-    type Output = u64;
-
-    fn index(&self, index: usize) -> &Self::Output {
-        &self.inner.as_ref()[index]
-    }
-}
-
-impl std::ops::IndexMut<usize> for ShortintWopbsLUT {
-    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-        &mut self.inner.as_mut()[index]
-    }
-}
-
-impl TryFrom<Vec<Vec<u64>>> for ShortintWopbsLUT {
-    type Error = &'static str;
-
-    fn try_from(mut value: Vec<Vec<u64>>) -> Result<Self, Self::Error> {
-        if value.len() != 1 {
-            return Err("ShortintWopbsLUT can only contain one small lut");
-        }
-
-        let value = value.remove(0);
-
-        Ok(Self {
-            inner: WopbsLUTBase::from_vec(value, CiphertextCount(1)),
-        })
-    }
-}
-
-impl From<Vec<u64>> for ShortintWopbsLUT {
-    fn from(value: Vec<u64>) -> Self {
-        Self {
-            inner: WopbsLUTBase::from_vec(value, CiphertextCount(1)),
-        }
-    }
-}
-
-impl WopbsKey {
-    /// Generate the server key required to compute a WoPBS from the client and the server keys.
-    ///
-    /// #Warning
-    /// Only when the classical PBS is not used in the circuit
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use tfhe::shortint::gen_keys;
-    /// use tfhe::shortint::parameters::parameters_wopbs_only::WOPBS_ONLY_8_BLOCKS_PARAM_MESSAGE_1_CARRY_1_KS_PBS;
-    /// use tfhe::shortint::wopbs::*;
-    ///
-    /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(WOPBS_ONLY_8_BLOCKS_PARAM_MESSAGE_1_CARRY_1_KS_PBS);
-    /// let wopbs_key = WopbsKey::new_wopbs_key_only_for_wopbs(&cks, &sks);
-    /// ```
-    pub fn new_wopbs_key_only_for_wopbs(cks: &ClientKey, sks: &ServerKey) -> Self {
-        ShortintEngine::with_thread_local_mut(|engine| {
-            engine.new_wopbs_key_only_for_wopbs(cks, sks).unwrap()
-        })
-    }
-
-    /// Generate the server key required to compute a WoPBS from the client and the server keys.
-    /// # Example
-    ///
-    /// ```rust
-    /// use tfhe::shortint::gen_keys;
-    /// use tfhe::shortint::parameters::parameters_wopbs_message_carry::WOPBS_PARAM_MESSAGE_1_CARRY_1_KS_PBS;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_1_CARRY_1_KS_PBS;
-    /// use tfhe::shortint::wopbs::*;
-    ///
-    /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_1_CARRY_1_KS_PBS);
-    /// let wopbs_key = WopbsKey::new_wopbs_key(&cks, &sks, &WOPBS_PARAM_MESSAGE_1_CARRY_1_KS_PBS);
-    /// ```
-    pub fn new_wopbs_key(cks: &ClientKey, sks: &ServerKey, parameters: &WopbsParameters) -> Self {
-        ShortintEngine::with_thread_local_mut(|engine| engine.new_wopbs_key(cks, sks, parameters))
-    }
-
-    /// Deconstruct a [`WopbsKey`] into its constituents.
-    pub fn into_raw_parts(
-        self,
-    ) -> (
-        ServerKey,
-        ServerKey,
-        LwePrivateFunctionalPackingKeyswitchKeyListOwned<u64>,
-        LweKeyswitchKeyOwned<u64>,
-        WopbsParameters,
-    ) {
-        let Self {
-            wopbs_server_key,
-            pbs_server_key,
-            cbs_pfpksk,
-            ksk_pbs_to_wopbs,
-            param,
-        } = self;
-
-        (
-            wopbs_server_key,
-            pbs_server_key,
-            cbs_pfpksk,
-            ksk_pbs_to_wopbs,
-            param,
-        )
-    }
-
-    /// Construct a [`WopbsKey`] from its constituents.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the constituents are not compatible with each others.
-    pub fn from_raw_parts(
-        wopbs_server_key: ServerKey,
-        pbs_server_key: ServerKey,
-        cbs_pfpksk: LwePrivateFunctionalPackingKeyswitchKeyListOwned<u64>,
-        ksk_pbs_to_wopbs: LweKeyswitchKeyOwned<u64>,
-        param: WopbsParameters,
-    ) -> Self {
-        assert_eq!(
-            ksk_pbs_to_wopbs.input_key_lwe_dimension(),
-            pbs_server_key.ciphertext_lwe_dimension()
-        );
-
-        assert_eq!(
-            ksk_pbs_to_wopbs.output_key_lwe_dimension(),
-            wopbs_server_key.ciphertext_lwe_dimension()
-        );
-
-        // TODO add asserts/conformance checks for the wopbs key
-
-        Self {
-            wopbs_server_key,
-            pbs_server_key,
-            cbs_pfpksk,
-            ksk_pbs_to_wopbs,
-            param,
-        }
-    }
-
-    /// Generate the Look-Up Table homomorphically using the WoPBS approach.
-    ///
-    /// # Warning: this assumes one bit of padding.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use tfhe::shortint::gen_keys;
-    /// use tfhe::shortint::parameters::parameters_wopbs_message_carry::WOPBS_PARAM_MESSAGE_2_CARRY_2_KS_PBS;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
-    /// use tfhe::shortint::wopbs::*;
-    ///
-    /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
-    /// let wopbs_key = WopbsKey::new_wopbs_key(&cks, &sks, &WOPBS_PARAM_MESSAGE_2_CARRY_2_KS_PBS);
-    /// let message_modulus = WOPBS_PARAM_MESSAGE_2_CARRY_2_KS_PBS.message_modulus.0 as u64;
-    /// let m = 2;
-    /// let ct = cks.encrypt(m);
-    /// let lut = wopbs_key.generate_lut(&ct, |x| x * x % message_modulus);
-    /// let ct_res = wopbs_key.programmable_bootstrapping(&sks, &ct, &lut);
-    /// let res = cks.decrypt(&ct_res);
-    /// assert_eq!(res, (m * m) % message_modulus);
-    /// ```
-    pub fn generate_lut<F>(&self, ct: &Ciphertext, f: F) -> ShortintWopbsLUT
-    where
-        F: Fn(u64) -> u64,
-    {
-        // The function is applied only on the message modulus bits
-        let basis = ct.message_modulus.0 * ct.carry_modulus.0;
-        let delta = 64 - f64::log2((basis) as f64).ceil() as u64 - 1;
-        let poly_size = self.wopbs_server_key.bootstrapping_key.polynomial_size().0;
-        let mut lut = ShortintWopbsLUT::new(PlaintextCount(poly_size));
-        for (i, value) in lut.iter_mut().enumerate().take(basis) {
-            *value = f((i % ct.message_modulus.0) as u64) << delta;
-        }
-        lut
-    }
-
-    /// Generate the Look-Up Table homomorphically using the WoPBS approach.
-    ///
-    /// # Warning: this assumes no bit of padding.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use tfhe::shortint::gen_keys;
-    /// use tfhe::shortint::parameters::parameters_wopbs_only::WOPBS_ONLY_4_BLOCKS_PARAM_MESSAGE_2_CARRY_2_KS_PBS;
-    /// use tfhe::shortint::wopbs::WopbsKey;
-    ///
-    /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(WOPBS_ONLY_4_BLOCKS_PARAM_MESSAGE_2_CARRY_2_KS_PBS);
-    /// let wopbs_key = WopbsKey::new_wopbs_key_only_for_wopbs(&cks, &sks);
-    /// let message_modulus = WOPBS_ONLY_4_BLOCKS_PARAM_MESSAGE_2_CARRY_2_KS_PBS.message_modulus.0 as u64;
-    /// let m = 2;
-    /// let ct = cks.encrypt_without_padding(m);
-    /// let lut = wopbs_key.generate_lut(&ct, |x| x * x % message_modulus);
-    /// let ct_res = wopbs_key.programmable_bootstrapping_without_padding(&ct, &lut);
-    /// let res = cks.decrypt_without_padding(&ct_res);
-    /// assert_eq!(res, (m * m) % message_modulus);
-    /// ```
-    pub fn generate_lut_without_padding<F>(&self, ct: &Ciphertext, f: F) -> Vec<u64>
-    where
-        F: Fn(u64) -> u64,
-    {
-        // The function is applied only on the message modulus bits
-        let basis = ct.message_modulus.0 * ct.carry_modulus.0;
-        let delta = 64 - f64::log2((basis) as f64).ceil() as u64;
-        let poly_size = self.wopbs_server_key.bootstrapping_key.polynomial_size().0;
-        let mut vec_lut = vec![0; poly_size];
-        for (i, value) in vec_lut.iter_mut().enumerate().take(basis) {
-            *value = f((i % ct.message_modulus.0) as u64) << delta;
-        }
-        vec_lut
-    }
-
-    /// Generate the Look-Up Table homomorphically using the WoPBS approach.
-    ///
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use tfhe::shortint::gen_keys;
-    /// use tfhe::shortint::parameters::parameters_wopbs_message_carry::WOPBS_PARAM_MESSAGE_3_CARRY_3_KS_PBS;
-    /// use tfhe::shortint::wopbs::WopbsKey;
-    /// use tfhe::shortint::parameters::MessageModulus;
-    ///
-    /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(WOPBS_PARAM_MESSAGE_3_CARRY_3_KS_PBS);
-    /// let wopbs_key = WopbsKey::new_wopbs_key_only_for_wopbs(&cks, &sks);
-    /// let message_modulus = MessageModulus(5);
-    /// let m = 2;
-    /// let ct = cks.encrypt_native_crt(m, message_modulus);
-    /// let lut = wopbs_key.generate_lut_native_crt(&ct, |x| x * x % message_modulus.0 as u64);
-    /// let ct_res = wopbs_key.programmable_bootstrapping_native_crt(&ct, &lut);
-    /// let res = cks.decrypt_message_native_crt(&ct_res, message_modulus);
-    /// assert_eq!(res, (m * m) % message_modulus.0 as u64);
-    /// ```
-    pub fn generate_lut_native_crt<F>(&self, ct: &Ciphertext, f: F) -> ShortintWopbsLUT
-    where
-        F: Fn(u64) -> u64,
-    {
-        // The function is applied only on the message modulus bits
-        let basis = ct.message_modulus.0 * ct.carry_modulus.0;
-        let nb_bit = f64::log2((basis) as f64).ceil() as u64;
-        let poly_size = self.wopbs_server_key.bootstrapping_key.polynomial_size().0;
-        let mut lut = ShortintWopbsLUT::new(PlaintextCount(poly_size));
-        for i in 0..basis {
-            let index_lut = (((i as u64 % basis as u64) << nb_bit) / basis as u64) as usize;
-            lut[index_lut] =
-                (((f(i as u64) % basis as u64) as u128 * (1 << 64)) / basis as u128) as u64;
-        }
-        lut
-    }
-
-    /// Apply the Look-Up Table homomorphically using the WoPBS approach.
-    ///
-    /// #Warning: this assumes one bit of padding.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use rand::Rng;
-    /// use tfhe::shortint::gen_keys;
-    /// use tfhe::shortint::parameters::parameters_wopbs_message_carry::WOPBS_PARAM_MESSAGE_2_CARRY_2_KS_PBS;
-    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
-    /// use tfhe::shortint::wopbs::*;
-    ///
-    /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
-    /// let wopbs_key = WopbsKey::new_wopbs_key(&cks, &sks, &WOPBS_PARAM_MESSAGE_2_CARRY_2_KS_PBS);
-    /// let mut rng = rand::thread_rng();
-    /// let message_modulus = WOPBS_PARAM_MESSAGE_2_CARRY_2_KS_PBS.message_modulus.0;
-    /// let ct = cks.encrypt(rng.gen::<u64>() % message_modulus as u64);
-    /// let lut = vec![1_u64 << 59; wopbs_key.param.polynomial_size.0].into();
-    /// let ct_res = wopbs_key.programmable_bootstrapping(&sks, &ct, &lut);
-    /// let res = cks.decrypt_message_and_carry(&ct_res);
-    /// assert_eq!(res, 1);
-    /// ```
-    pub fn programmable_bootstrapping(
-        &self,
-        sks: &ServerKey,
-        ct_in: &Ciphertext,
-        lut: &ShortintWopbsLUT,
-    ) -> Ciphertext {
-        let ct_wopbs = self.keyswitch_to_wopbs_params(sks, ct_in);
-        let result_ct = self.wopbs(&ct_wopbs, lut);
-
-        self.keyswitch_to_pbs_params(&result_ct)
-    }
-
-    /// Apply the Look-Up Table homomorphically using the WoPBS approach.
-    ///
-    /// #Warning: this assumes one bit of padding.
-    /// #Warning: to use in a WoPBS context ONLY (i.e., non compliant with classical PBS)
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use rand::Rng;
-    /// use tfhe::shortint::gen_keys;
-    /// use tfhe::shortint::parameters::parameters_wopbs_only::WOPBS_ONLY_4_BLOCKS_PARAM_MESSAGE_2_CARRY_2_KS_PBS;
-    /// use tfhe::shortint::wopbs::*;
-    ///
-    /// // Generate the client key and the server key:
-    /// let (cks, sks) = gen_keys(WOPBS_ONLY_4_BLOCKS_PARAM_MESSAGE_2_CARRY_2_KS_PBS);
-    /// let wopbs_key = WopbsKey::new_wopbs_key_only_for_wopbs(&cks, &sks);
-    /// let mut rng = rand::thread_rng();
-    /// let message_modulus = WOPBS_ONLY_4_BLOCKS_PARAM_MESSAGE_2_CARRY_2_KS_PBS.message_modulus.0;
-    /// let ct = cks.encrypt(rng.gen::<u64>() % message_modulus as u64);
-    /// let lut = vec![1_u64 << 59; wopbs_key.param.polynomial_size.0].into();
-    /// let ct_res = wopbs_key.wopbs(&ct, &lut);
-    /// let res = cks.decrypt_message_and_carry(&ct_res);
-    /// assert_eq!(res, 1);
-    /// ```
-    pub fn wopbs(&self, ct_in: &Ciphertext, lut: &ShortintWopbsLUT) -> Ciphertext {
-        let tmp_sks = &self.wopbs_server_key;
-        let message_modulus = tmp_sks.message_modulus.0 as u64;
-        let carry_modulus = tmp_sks.carry_modulus.0 as u64;
-        let delta = (1u64 << 63) / (carry_modulus * message_modulus);
-        // casting to usize is fine, ilog2 of u64 is guaranteed to be < 64
-        let delta_log = DeltaLog(delta.ilog2() as usize);
-        let nb_bit_to_extract = f64::log2((message_modulus * carry_modulus) as f64) as usize;
-
-        let ct_out = self.extract_bits_circuit_bootstrapping(
-            ct_in,
-            lut.as_ref(),
-            delta_log,
-            ExtractedBitsCount(nb_bit_to_extract),
-        );
-
-        ct_out
-    }
-
-    /// Apply the Look-Up Table homomorphically using the WoPBS approach.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use rand::Rng;
-    /// use tfhe::shortint::gen_keys;
-    /// use tfhe::shortint::parameters::parameters_wopbs::WOPBS_ONLY_8_BLOCKS_PARAM_MESSAGE_1_CARRY_1_KS_PBS;
-    /// use tfhe::shortint::parameters::CarryModulus;
-    /// use tfhe::shortint::wopbs::*;
-    ///
-    /// let mut msg_1_carry_0_params = WOPBS_ONLY_8_BLOCKS_PARAM_MESSAGE_1_CARRY_1_KS_PBS;
-    /// msg_1_carry_0_params.carry_modulus = CarryModulus(1);
-    /// let (cks, sks) = gen_keys(msg_1_carry_0_params);
-    /// let wopbs_key = WopbsKey::new_wopbs_key_only_for_wopbs(&cks, &sks);
-    /// let mut rng = rand::thread_rng();
-    /// let ct = cks.encrypt_without_padding(rng.gen::<u64>() % 2);
-    /// let lut = vec![1_u64 << 63; wopbs_key.param.polynomial_size.0].into();
-    /// let ct_res = wopbs_key.programmable_bootstrapping_without_padding(&ct, &lut);
-    /// let res = cks.decrypt_message_and_carry_without_padding(&ct_res);
-    /// assert_eq!(res, 1);
-    /// ```
-    pub fn programmable_bootstrapping_without_padding(
-        &self,
-        ct_in: &Ciphertext,
-        lut: &ShortintWopbsLUT,
-    ) -> Ciphertext {
-        let sks = &self.wopbs_server_key;
-        let message_modulus = sks.message_modulus.0 as u64;
-        let carry_modulus = sks.carry_modulus.0 as u64;
-        let delta = (1u64 << 63) / (carry_modulus * message_modulus) * 2;
-        // casting to usize is fine, ilog2 of u64 is guaranteed to be < 64
-        let delta_log = DeltaLog(delta.ilog2() as usize);
-
-        let nb_bit_to_extract =
-            f64::log2((sks.message_modulus.0 * sks.carry_modulus.0) as f64) as usize;
-
-        let ciphertext = self.extract_bits_circuit_bootstrapping(
-            ct_in,
-            lut.as_ref(),
-            delta_log,
-            ExtractedBitsCount(nb_bit_to_extract),
-        );
-
-        ciphertext
-    }
-
-    /// Apply the Look-Up Table homomorphically using the WoPBS approach.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use tfhe::shortint::gen_keys;
-    /// use tfhe::shortint::parameters::parameters_wopbs_message_carry::WOPBS_PARAM_MESSAGE_3_CARRY_3_KS_PBS;
-    /// use tfhe::shortint::parameters::MessageModulus;
-    /// use tfhe::shortint::wopbs::*;
-    ///
-    /// let (cks, sks) = gen_keys(WOPBS_PARAM_MESSAGE_3_CARRY_3_KS_PBS);
-    /// let wopbs_key = WopbsKey::new_wopbs_key_only_for_wopbs(&cks, &sks);
-    /// let msg = 2;
-    /// let modulus = MessageModulus(5);
-    /// let ct = cks.encrypt_native_crt(msg, modulus);
-    /// let lut = wopbs_key.generate_lut_native_crt(&ct, |x| x);
-    /// let ct_res = wopbs_key.programmable_bootstrapping_native_crt(&ct, &lut);
-    /// let res = cks.decrypt_message_native_crt(&ct_res, modulus);
-    /// assert_eq!(res, msg);
-    /// ```
-    pub fn programmable_bootstrapping_native_crt(
-        &self,
-        ct_in: &Ciphertext,
-        lut: &ShortintWopbsLUT,
-    ) -> Ciphertext {
-        let nb_bit_to_extract =
-            f64::log2((ct_in.message_modulus.0 * ct_in.carry_modulus.0) as f64).ceil() as usize;
-        let delta_log = DeltaLog(64 - nb_bit_to_extract);
-
-        // We need to add a corrective term, so clone the input
-        let mut ct_in = ct_in.clone();
-
-        // trick ( ct - delta/2 + delta/2^4  )
-        lwe_ciphertext_plaintext_sub_assign(
-            &mut ct_in.ct,
-            Plaintext((1 << (64 - nb_bit_to_extract - 1)) - (1 << (64 - nb_bit_to_extract - 5))),
-        );
-
-        let ciphertext = self.extract_bits_circuit_bootstrapping(
-            &ct_in,
-            lut.as_ref(),
-            delta_log,
-            ExtractedBitsCount(nb_bit_to_extract),
-        );
-
-        ciphertext
-    }
-
-    /// Extract the given number of bits from a ciphertext.
-    ///
-    /// # Warning Experimental
-    pub fn extract_bits(
-        &self,
-        delta_log: DeltaLog,
-        ciphertext: &Ciphertext,
-        num_bits_to_extract: ExtractedBitsCount,
-    ) -> LweCiphertextListOwned<u64> {
-        let server_key = &self.wopbs_server_key;
-
-        let lwe_size = server_key
-            .key_switching_key
-            .output_key_lwe_dimension()
-            .to_lwe_size();
-
-        let mut output = LweCiphertextListOwned::new(
-            0u64,
-            lwe_size,
-            LweCiphertextCount(num_bits_to_extract.0),
-            self.param.ciphertext_modulus,
-        );
-
-        self.extract_bits_assign(delta_log, ciphertext, num_bits_to_extract, &mut output);
-
-        output
-    }
-
-    /// Extract the given number of bits from a ciphertext.
-    ///
-    /// # Warning Experimental
-    pub fn extract_bits_assign<OutputCont>(
-        &self,
-        delta_log: DeltaLog,
-        ciphertext: &Ciphertext,
-        num_bits_to_extract: ExtractedBitsCount,
-        output: &mut LweCiphertextList<OutputCont>,
-    ) where
-        OutputCont: ContainerMut<Element = u64>,
-    {
-        let server_key = &self.wopbs_server_key;
-
-        let bsk = &server_key.bootstrapping_key;
-        let ksk = &server_key.key_switching_key;
-
-        let fft = Fft::new(bsk.polynomial_size());
-        let fft = fft.as_view();
-
-        ShortintEngine::with_thread_local_mut(|engine| {
-            engine.computation_buffers.resize(
-                extract_bits_from_lwe_ciphertext_mem_optimized_requirement::<u64>(
-                    ciphertext.ct.lwe_size().to_lwe_dimension(),
-                    ksk.output_key_lwe_dimension(),
-                    bsk.glwe_size(),
-                    bsk.polynomial_size(),
-                    fft,
-                )
-                .unwrap()
-                .unaligned_bytes_required(),
-            );
-
-            let stack = engine.computation_buffers.stack();
-
-            match bsk {
-                ShortintBootstrappingKey::Classic(bsk) => {
-                    extract_bits_from_lwe_ciphertext_mem_optimized(
-                        &ciphertext.ct,
-                        output,
-                        bsk,
-                        ksk,
-                        delta_log,
-                        num_bits_to_extract,
-                        fft,
-                        stack,
-                    );
-                }
-                ShortintBootstrappingKey::MultiBit { .. } => {
-                    todo!("extract_bits_assign currently does not support multi-bit PBS")
+    impl std::error::Error for WopbsKeyCreationError {}
+
+    impl std::fmt::Display for WopbsKeyCreationError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::UnsupportedMultiBit => {
+                    write!(f, "WopbsKey does not yet support using multi bit PBS")
                 }
             }
-        });
+        }
     }
 
-    /// Temporary wrapper.
-    ///
-    /// # Warning Experimental
-    pub fn circuit_bootstrapping_vertical_packing<InputCont>(
-        &self,
-        vec_lut: &WopbsLUTBase,
-        extracted_bits_blocks: &LweCiphertextList<InputCont>,
-    ) -> Vec<LweCiphertextOwned<u64>>
-    where
-        InputCont: Container<Element = u64>,
-    {
-        let output_list = self.circuit_bootstrap_with_bits(
-            extracted_bits_blocks,
-            &vec_lut.lut(),
-            LweCiphertextCount(vec_lut.output_ciphertext_count().0),
-        );
-
-        assert_eq!(
-            output_list.lwe_ciphertext_count().0,
-            vec_lut.output_ciphertext_count().0
-        );
-
-        let output_container = output_list.into_container();
-        let ciphertext_modulus = self.param.ciphertext_modulus;
-        let lwes: Vec<_> = output_container
-            .chunks_exact(output_container.len() / vec_lut.output_ciphertext_count().0)
-            .map(|s| LweCiphertextOwned::from_container(s.to_vec(), ciphertext_modulus))
-            .collect();
-
-        assert_eq!(lwes.len(), vec_lut.output_ciphertext_count().0);
-        lwes
+    #[must_use]
+    pub struct WopbsLUTBase {
+        // Flattened Wopbs LUT
+        plaintext_list: Vec<u64>,
+        // How many output ciphertexts will be produced after applying the Wopbs to an input vector
+        // of ciphertexts encrypting bits
+        output_ciphertext_count: CiphertextCount,
     }
 
-    pub fn keyswitch_to_pbs_params(&self, ct_in: &Ciphertext) -> Ciphertext {
-        // move to wopbs parameters to pbs parameters
-        //Keyswitch-PBS:
-        // 1. KS to go back to the original encryption key
-        // 2. PBS to remove the noise added by the previous KS
-        //
-        let acc = self.pbs_server_key.generate_lookup_table(|x| x);
+    impl WopbsLUTBase {
+        pub fn from_vec(value: Vec<u64>, output_ciphertext_count: CiphertextCount) -> Self {
+            Self {
+                plaintext_list: value,
+                output_ciphertext_count,
+            }
+        }
 
-        ShortintEngine::with_thread_local_mut(|engine| {
-            let (mut ciphertext_buffers, buffers) = engine.get_buffers(&self.pbs_server_key);
+        pub fn new(
+            small_lut_size: PlaintextCount,
+            output_ciphertext_count: CiphertextCount,
+        ) -> Self {
+            Self {
+                plaintext_list: vec![0; small_lut_size.0 * output_ciphertext_count.0],
+                output_ciphertext_count,
+            }
+        }
+
+        pub fn lut(&self) -> PlaintextListView<'_, u64> {
+            PlaintextList::from_container(&self.plaintext_list)
+        }
+
+        pub fn lut_mut(&mut self) -> PlaintextListMutView<'_, u64> {
+            PlaintextList::from_container(&mut self.plaintext_list)
+        }
+
+        pub fn output_ciphertext_count(&self) -> CiphertextCount {
+            self.output_ciphertext_count
+        }
+
+        pub fn small_lut_size(&self) -> PlaintextCount {
+            PlaintextCount(self.lut().plaintext_count().0 / self.output_ciphertext_count().0)
+        }
+
+        pub fn get_small_lut(&self, index: usize) -> &[u64] {
+            assert!(
+                index < self.output_ciphertext_count().0,
+                "index {index} out of bounds, max {}",
+                self.output_ciphertext_count().0
+            );
+
+            let small_lut_size = self.small_lut_size().0;
+
+            &self.plaintext_list[index * small_lut_size..(index + 1) * small_lut_size]
+        }
+
+        pub fn get_small_lut_mut(&mut self, index: usize) -> &mut [u64] {
+            assert!(
+                index < self.output_ciphertext_count().0,
+                "index {index} out of bounds, max {}",
+                self.output_ciphertext_count().0
+            );
+
+            let small_lut_size = self.small_lut_size().0;
+
+            &mut self.plaintext_list[index * small_lut_size..(index + 1) * small_lut_size]
+        }
+    }
+
+    impl AsRef<[u64]> for WopbsLUTBase {
+        fn as_ref(&self) -> &[u64] {
+            self.plaintext_list.as_ref()
+        }
+    }
+
+    impl AsMut<[u64]> for WopbsLUTBase {
+        fn as_mut(&mut self) -> &mut [u64] {
+            self.plaintext_list.as_mut()
+        }
+    }
+
+    #[must_use]
+    pub struct ShortintWopbsLUT {
+        inner: WopbsLUTBase,
+    }
+
+    impl ShortintWopbsLUT {
+        pub fn new(lut_size: PlaintextCount) -> Self {
+            Self {
+                inner: WopbsLUTBase::new(lut_size, CiphertextCount(1)),
+            }
+        }
+
+        pub fn iter(&self) -> std::slice::Iter<'_, u64> {
+            self.inner.as_ref().iter()
+        }
+
+        pub fn iter_mut(&mut self) -> std::slice::IterMut<'_, u64> {
+            self.inner.as_mut().iter_mut()
+        }
+    }
+
+    impl<'a> IntoIterator for &'a ShortintWopbsLUT {
+        type IntoIter = std::slice::Iter<'a, u64>;
+        type Item = &'a u64;
+        fn into_iter(self) -> Self::IntoIter {
+            self.iter()
+        }
+    }
+
+    impl<'a> IntoIterator for &'a mut ShortintWopbsLUT {
+        type IntoIter = std::slice::IterMut<'a, u64>;
+        type Item = &'a mut u64;
+        fn into_iter(self) -> Self::IntoIter {
+            self.iter_mut()
+        }
+    }
+
+    impl AsRef<WopbsLUTBase> for ShortintWopbsLUT {
+        fn as_ref(&self) -> &WopbsLUTBase {
+            &self.inner
+        }
+    }
+
+    impl AsMut<WopbsLUTBase> for ShortintWopbsLUT {
+        fn as_mut(&mut self) -> &mut WopbsLUTBase {
+            &mut self.inner
+        }
+    }
+
+    impl std::ops::Index<usize> for ShortintWopbsLUT {
+        type Output = u64;
+
+        fn index(&self, index: usize) -> &Self::Output {
+            &self.inner.as_ref()[index]
+        }
+    }
+
+    impl std::ops::IndexMut<usize> for ShortintWopbsLUT {
+        fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+            &mut self.inner.as_mut()[index]
+        }
+    }
+
+    impl TryFrom<Vec<Vec<u64>>> for ShortintWopbsLUT {
+        type Error = &'static str;
+
+        fn try_from(mut value: Vec<Vec<u64>>) -> Result<Self, Self::Error> {
+            if value.len() != 1 {
+                return Err("ShortintWopbsLUT can only contain one small lut");
+            }
+
+            let value = value.remove(0);
+
+            Ok(Self {
+                inner: WopbsLUTBase::from_vec(value, CiphertextCount(1)),
+            })
+        }
+    }
+
+    impl From<Vec<u64>> for ShortintWopbsLUT {
+        fn from(value: Vec<u64>) -> Self {
+            Self {
+                inner: WopbsLUTBase::from_vec(value, CiphertextCount(1)),
+            }
+        }
+    }
+
+    impl WopbsKey {
+        /// Generate the server key required to compute a WoPBS from the client and the server keys.
+        ///
+        /// #Warning
+        /// Only when the classical PBS is not used in the circuit
+        ///
+        /// # Example
+        ///
+        /// ```rust
+        /// use tfhe::shortint::gen_keys;
+        /// use tfhe::shortint::parameters::parameters_wopbs_only::WOPBS_ONLY_8_BLOCKS_PARAM_MESSAGE_1_CARRY_1_KS_PBS;
+        /// use tfhe::shortint::wopbs::*;
+        ///
+        /// // Generate the client key and the server key:
+        /// let (cks, sks) = gen_keys(WOPBS_ONLY_8_BLOCKS_PARAM_MESSAGE_1_CARRY_1_KS_PBS);
+        /// let wopbs_key = WopbsKey::new_wopbs_key_only_for_wopbs(&cks, &sks);
+        /// ```
+        pub fn new_wopbs_key_only_for_wopbs(cks: &ClientKey, sks: &ServerKey) -> Self {
+            ShortintEngine::with_thread_local_mut(|engine| {
+                engine.new_wopbs_key_only_for_wopbs(cks, sks).unwrap()
+            })
+        }
+
+        /// Generate the server key required to compute a WoPBS from the client and the server keys.
+        /// # Example
+        ///
+        /// ```rust
+        /// use tfhe::shortint::gen_keys;
+        /// use tfhe::shortint::parameters::parameters_wopbs_message_carry::WOPBS_PARAM_MESSAGE_1_CARRY_1_KS_PBS;
+        /// use tfhe::shortint::parameters::PARAM_MESSAGE_1_CARRY_1_KS_PBS;
+        /// use tfhe::shortint::wopbs::*;
+        ///
+        /// // Generate the client key and the server key:
+        /// let (cks, sks) = gen_keys(PARAM_MESSAGE_1_CARRY_1_KS_PBS);
+        /// let wopbs_key = WopbsKey::new_wopbs_key(&cks, &sks, &WOPBS_PARAM_MESSAGE_1_CARRY_1_KS_PBS);
+        /// ```
+        pub fn new_wopbs_key(
+            cks: &ClientKey,
+            sks: &ServerKey,
+            parameters: &WopbsParameters,
+        ) -> Self {
+            ShortintEngine::with_thread_local_mut(|engine| {
+                engine.new_wopbs_key(cks, sks, parameters)
+            })
+        }
+
+        /// Deconstruct a [`WopbsKey`] into its constituents.
+        pub fn into_raw_parts(
+            self,
+        ) -> (
+            ServerKey,
+            ServerKey,
+            LwePrivateFunctionalPackingKeyswitchKeyListOwned<u64>,
+            LweKeyswitchKeyOwned<u64>,
+            WopbsParameters,
+        ) {
+            let Self {
+                wopbs_server_key,
+                pbs_server_key,
+                cbs_pfpksk,
+                ksk_pbs_to_wopbs,
+                param,
+            } = self;
+
+            (
+                wopbs_server_key,
+                pbs_server_key,
+                cbs_pfpksk,
+                ksk_pbs_to_wopbs,
+                param,
+            )
+        }
+
+        /// Construct a [`WopbsKey`] from its constituents.
+        ///
+        /// # Panics
+        ///
+        /// Panics if the constituents are not compatible with each others.
+        pub fn from_raw_parts(
+            wopbs_server_key: ServerKey,
+            pbs_server_key: ServerKey,
+            cbs_pfpksk: LwePrivateFunctionalPackingKeyswitchKeyListOwned<u64>,
+            ksk_pbs_to_wopbs: LweKeyswitchKeyOwned<u64>,
+            param: WopbsParameters,
+        ) -> Self {
+            assert_eq!(
+                ksk_pbs_to_wopbs.input_key_lwe_dimension(),
+                pbs_server_key.ciphertext_lwe_dimension()
+            );
+
+            assert_eq!(
+                ksk_pbs_to_wopbs.output_key_lwe_dimension(),
+                wopbs_server_key.ciphertext_lwe_dimension()
+            );
+
+            // TODO add asserts/conformance checks for the wopbs key
+
+            Self {
+                wopbs_server_key,
+                pbs_server_key,
+                cbs_pfpksk,
+                ksk_pbs_to_wopbs,
+                param,
+            }
+        }
+
+        /// Generate the Look-Up Table homomorphically using the WoPBS approach.
+        ///
+        /// # Warning: this assumes one bit of padding.
+        ///
+        /// # Example
+        ///
+        /// ```rust
+        /// use tfhe::shortint::gen_keys;
+        /// use tfhe::shortint::parameters::parameters_wopbs_message_carry::WOPBS_PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+        /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+        /// use tfhe::shortint::wopbs::*;
+        ///
+        /// // Generate the client key and the server key:
+        /// let (cks, sks) = gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+        /// let wopbs_key = WopbsKey::new_wopbs_key(&cks, &sks, &WOPBS_PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+        /// let message_modulus = WOPBS_PARAM_MESSAGE_2_CARRY_2_KS_PBS.message_modulus.0 as u64;
+        /// let m = 2;
+        /// let ct = cks.encrypt(m);
+        /// let lut = wopbs_key.generate_lut(&ct, |x| x * x % message_modulus);
+        /// let ct_res = wopbs_key.programmable_bootstrapping(&sks, &ct, &lut);
+        /// let res = cks.decrypt(&ct_res);
+        /// assert_eq!(res, (m * m) % message_modulus);
+        /// ```
+        pub fn generate_lut<F>(&self, ct: &Ciphertext, f: F) -> ShortintWopbsLUT
+        where
+            F: Fn(u64) -> u64,
+        {
+            // The function is applied only on the message modulus bits
+            let basis = ct.message_modulus.0 * ct.carry_modulus.0;
+            let delta = 64 - f64::log2((basis) as f64).ceil() as u64 - 1;
+            let poly_size = self.wopbs_server_key.bootstrapping_key.polynomial_size().0;
+            let mut lut = ShortintWopbsLUT::new(PlaintextCount(poly_size));
+            for (i, value) in lut.iter_mut().enumerate().take(basis) {
+                *value = f((i % ct.message_modulus.0) as u64) << delta;
+            }
+            lut
+        }
+
+        /// Generate the Look-Up Table homomorphically using the WoPBS approach.
+        ///
+        /// # Warning: this assumes no bit of padding.
+        ///
+        /// # Example
+        ///
+        /// ```rust
+        /// use tfhe::shortint::gen_keys;
+        /// use tfhe::shortint::parameters::parameters_wopbs_only::WOPBS_ONLY_4_BLOCKS_PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+        /// use tfhe::shortint::wopbs::WopbsKey;
+        ///
+        /// // Generate the client key and the server key:
+        /// let (cks, sks) = gen_keys(WOPBS_ONLY_4_BLOCKS_PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+        /// let wopbs_key = WopbsKey::new_wopbs_key_only_for_wopbs(&cks, &sks);
+        /// let message_modulus = WOPBS_ONLY_4_BLOCKS_PARAM_MESSAGE_2_CARRY_2_KS_PBS.message_modulus.0 as u64;
+        /// let m = 2;
+        /// let ct = cks.encrypt_without_padding(m);
+        /// let lut = wopbs_key.generate_lut(&ct, |x| x * x % message_modulus);
+        /// let ct_res = wopbs_key.programmable_bootstrapping_without_padding(&ct, &lut);
+        /// let res = cks.decrypt_without_padding(&ct_res);
+        /// assert_eq!(res, (m * m) % message_modulus);
+        /// ```
+        pub fn generate_lut_without_padding<F>(&self, ct: &Ciphertext, f: F) -> Vec<u64>
+        where
+            F: Fn(u64) -> u64,
+        {
+            // The function is applied only on the message modulus bits
+            let basis = ct.message_modulus.0 * ct.carry_modulus.0;
+            let delta = 64 - f64::log2((basis) as f64).ceil() as u64;
+            let poly_size = self.wopbs_server_key.bootstrapping_key.polynomial_size().0;
+            let mut vec_lut = vec![0; poly_size];
+            for (i, value) in vec_lut.iter_mut().enumerate().take(basis) {
+                *value = f((i % ct.message_modulus.0) as u64) << delta;
+            }
+            vec_lut
+        }
+
+        /// Generate the Look-Up Table homomorphically using the WoPBS approach.
+        ///
+        ///
+        /// # Example
+        ///
+        /// ```rust
+        /// use tfhe::shortint::gen_keys;
+        /// use tfhe::shortint::parameters::parameters_wopbs_message_carry::WOPBS_PARAM_MESSAGE_3_CARRY_3_KS_PBS;
+        /// use tfhe::shortint::wopbs::WopbsKey;
+        /// use tfhe::shortint::parameters::MessageModulus;
+        ///
+        /// // Generate the client key and the server key:
+        /// let (cks, sks) = gen_keys(WOPBS_PARAM_MESSAGE_3_CARRY_3_KS_PBS);
+        /// let wopbs_key = WopbsKey::new_wopbs_key_only_for_wopbs(&cks, &sks);
+        /// let message_modulus = MessageModulus(5);
+        /// let m = 2;
+        /// let ct = cks.encrypt_native_crt(m, message_modulus);
+        /// let lut = wopbs_key.generate_lut_native_crt(&ct, |x| x * x % message_modulus.0 as u64);
+        /// let ct_res = wopbs_key.programmable_bootstrapping_native_crt(&ct, &lut);
+        /// let res = cks.decrypt_message_native_crt(&ct_res, message_modulus);
+        /// assert_eq!(res, (m * m) % message_modulus.0 as u64);
+        /// ```
+        pub fn generate_lut_native_crt<F>(&self, ct: &Ciphertext, f: F) -> ShortintWopbsLUT
+        where
+            F: Fn(u64) -> u64,
+        {
+            // The function is applied only on the message modulus bits
+            let basis = ct.message_modulus.0 * ct.carry_modulus.0;
+            let nb_bit = f64::log2((basis) as f64).ceil() as u64;
+            let poly_size = self.wopbs_server_key.bootstrapping_key.polynomial_size().0;
+            let mut lut = ShortintWopbsLUT::new(PlaintextCount(poly_size));
+            for i in 0..basis {
+                let index_lut = (((i as u64 % basis as u64) << nb_bit) / basis as u64) as usize;
+                lut[index_lut] =
+                    (((f(i as u64) % basis as u64) as u128 * (1 << 64)) / basis as u128) as u64;
+            }
+            lut
+        }
+
+        /// Apply the Look-Up Table homomorphically using the WoPBS approach.
+        ///
+        /// #Warning: this assumes one bit of padding.
+        ///
+        /// # Example
+        ///
+        /// ```rust
+        /// use rand::Rng;
+        /// use tfhe::shortint::gen_keys;
+        /// use tfhe::shortint::parameters::parameters_wopbs_message_carry::WOPBS_PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+        /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+        /// use tfhe::shortint::wopbs::*;
+        ///
+        /// // Generate the client key and the server key:
+        /// let (cks, sks) = gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+        /// let wopbs_key = WopbsKey::new_wopbs_key(&cks, &sks, &WOPBS_PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+        /// let mut rng = rand::thread_rng();
+        /// let message_modulus = WOPBS_PARAM_MESSAGE_2_CARRY_2_KS_PBS.message_modulus.0;
+        /// let ct = cks.encrypt(rng.gen::<u64>() % message_modulus as u64);
+        /// let lut = vec![1_u64 << 59; wopbs_key.param.polynomial_size.0].into();
+        /// let ct_res = wopbs_key.programmable_bootstrapping(&sks, &ct, &lut);
+        /// let res = cks.decrypt_message_and_carry(&ct_res);
+        /// assert_eq!(res, 1);
+        /// ```
+        pub fn programmable_bootstrapping(
+            &self,
+            sks: &ServerKey,
+            ct_in: &Ciphertext,
+            lut: &ShortintWopbsLUT,
+        ) -> Ciphertext {
+            let ct_wopbs = self.keyswitch_to_wopbs_params(sks, ct_in);
+            let result_ct = self.wopbs(&ct_wopbs, lut);
+
+            self.keyswitch_to_pbs_params(&result_ct)
+        }
+
+        /// Apply the Look-Up Table homomorphically using the WoPBS approach.
+        ///
+        /// #Warning: this assumes one bit of padding.
+        /// #Warning: to use in a WoPBS context ONLY (i.e., non compliant with classical PBS)
+        ///
+        /// # Example
+        ///
+        /// ```rust
+        /// use rand::Rng;
+        /// use tfhe::shortint::gen_keys;
+        /// use tfhe::shortint::parameters::parameters_wopbs_only::WOPBS_ONLY_4_BLOCKS_PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+        /// use tfhe::shortint::wopbs::*;
+        ///
+        /// // Generate the client key and the server key:
+        /// let (cks, sks) = gen_keys(WOPBS_ONLY_4_BLOCKS_PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+        /// let wopbs_key = WopbsKey::new_wopbs_key_only_for_wopbs(&cks, &sks);
+        /// let mut rng = rand::thread_rng();
+        /// let message_modulus = WOPBS_ONLY_4_BLOCKS_PARAM_MESSAGE_2_CARRY_2_KS_PBS.message_modulus.0;
+        /// let ct = cks.encrypt(rng.gen::<u64>() % message_modulus as u64);
+        /// let lut = vec![1_u64 << 59; wopbs_key.param.polynomial_size.0].into();
+        /// let ct_res = wopbs_key.wopbs(&ct, &lut);
+        /// let res = cks.decrypt_message_and_carry(&ct_res);
+        /// assert_eq!(res, 1);
+        /// ```
+        pub fn wopbs(&self, ct_in: &Ciphertext, lut: &ShortintWopbsLUT) -> Ciphertext {
+            let tmp_sks = &self.wopbs_server_key;
+            let message_modulus = tmp_sks.message_modulus.0 as u64;
+            let carry_modulus = tmp_sks.carry_modulus.0 as u64;
+            let delta = (1u64 << 63) / (carry_modulus * message_modulus);
+            // casting to usize is fine, ilog2 of u64 is guaranteed to be < 64
+            let delta_log = DeltaLog(delta.ilog2() as usize);
+            let nb_bit_to_extract = f64::log2((message_modulus * carry_modulus) as f64) as usize;
+
+            let ct_out = self.extract_bits_circuit_bootstrapping(
+                ct_in,
+                lut.as_ref(),
+                delta_log,
+                ExtractedBitsCount(nb_bit_to_extract),
+            );
+
+            ct_out
+        }
+
+        /// Apply the Look-Up Table homomorphically using the WoPBS approach.
+        ///
+        /// # Example
+        ///
+        /// ```rust
+        /// use rand::Rng;
+        /// use tfhe::shortint::gen_keys;
+        /// use tfhe::shortint::parameters::parameters_wopbs::WOPBS_ONLY_8_BLOCKS_PARAM_MESSAGE_1_CARRY_1_KS_PBS;
+        /// use tfhe::shortint::parameters::CarryModulus;
+        /// use tfhe::shortint::wopbs::*;
+        ///
+        /// let mut msg_1_carry_0_params = WOPBS_ONLY_8_BLOCKS_PARAM_MESSAGE_1_CARRY_1_KS_PBS;
+        /// msg_1_carry_0_params.carry_modulus = CarryModulus(1);
+        /// let (cks, sks) = gen_keys(msg_1_carry_0_params);
+        /// let wopbs_key = WopbsKey::new_wopbs_key_only_for_wopbs(&cks, &sks);
+        /// let mut rng = rand::thread_rng();
+        /// let ct = cks.encrypt_without_padding(rng.gen::<u64>() % 2);
+        /// let lut = vec![1_u64 << 63; wopbs_key.param.polynomial_size.0].into();
+        /// let ct_res = wopbs_key.programmable_bootstrapping_without_padding(&ct, &lut);
+        /// let res = cks.decrypt_message_and_carry_without_padding(&ct_res);
+        /// assert_eq!(res, 1);
+        /// ```
+        pub fn programmable_bootstrapping_without_padding(
+            &self,
+            ct_in: &Ciphertext,
+            lut: &ShortintWopbsLUT,
+        ) -> Ciphertext {
+            let sks = &self.wopbs_server_key;
+            let message_modulus = sks.message_modulus.0 as u64;
+            let carry_modulus = sks.carry_modulus.0 as u64;
+            let delta = (1u64 << 63) / (carry_modulus * message_modulus) * 2;
+            // casting to usize is fine, ilog2 of u64 is guaranteed to be < 64
+            let delta_log = DeltaLog(delta.ilog2() as usize);
+
+            let nb_bit_to_extract =
+                f64::log2((sks.message_modulus.0 * sks.carry_modulus.0) as f64) as usize;
+
+            let ciphertext = self.extract_bits_circuit_bootstrapping(
+                ct_in,
+                lut.as_ref(),
+                delta_log,
+                ExtractedBitsCount(nb_bit_to_extract),
+            );
+
+            ciphertext
+        }
+
+        /// Apply the Look-Up Table homomorphically using the WoPBS approach.
+        ///
+        /// # Example
+        ///
+        /// ```rust
+        /// use tfhe::shortint::gen_keys;
+        /// use tfhe::shortint::parameters::parameters_wopbs_message_carry::WOPBS_PARAM_MESSAGE_3_CARRY_3_KS_PBS;
+        /// use tfhe::shortint::parameters::MessageModulus;
+        /// use tfhe::shortint::wopbs::*;
+        ///
+        /// let (cks, sks) = gen_keys(WOPBS_PARAM_MESSAGE_3_CARRY_3_KS_PBS);
+        /// let wopbs_key = WopbsKey::new_wopbs_key_only_for_wopbs(&cks, &sks);
+        /// let msg = 2;
+        /// let modulus = MessageModulus(5);
+        /// let ct = cks.encrypt_native_crt(msg, modulus);
+        /// let lut = wopbs_key.generate_lut_native_crt(&ct, |x| x);
+        /// let ct_res = wopbs_key.programmable_bootstrapping_native_crt(&ct, &lut);
+        /// let res = cks.decrypt_message_native_crt(&ct_res, modulus);
+        /// assert_eq!(res, msg);
+        /// ```
+        pub fn programmable_bootstrapping_native_crt(
+            &self,
+            ct_in: &Ciphertext,
+            lut: &ShortintWopbsLUT,
+        ) -> Ciphertext {
+            let nb_bit_to_extract =
+                f64::log2((ct_in.message_modulus.0 * ct_in.carry_modulus.0) as f64).ceil() as usize;
+            let delta_log = DeltaLog(64 - nb_bit_to_extract);
+
+            // We need to add a corrective term, so clone the input
+            let mut ct_in = ct_in.clone();
+
+            // trick ( ct - delta/2 + delta/2^4  )
+            lwe_ciphertext_plaintext_sub_assign(
+                &mut ct_in.ct,
+                Plaintext(
+                    (1 << (64 - nb_bit_to_extract - 1)) - (1 << (64 - nb_bit_to_extract - 5)),
+                ),
+            );
+
+            let ciphertext = self.extract_bits_circuit_bootstrapping(
+                &ct_in,
+                lut.as_ref(),
+                delta_log,
+                ExtractedBitsCount(nb_bit_to_extract),
+            );
+
+            ciphertext
+        }
+
+        /// Extract the given number of bits from a ciphertext.
+        ///
+        /// # Warning Experimental
+        pub fn extract_bits(
+            &self,
+            delta_log: DeltaLog,
+            ciphertext: &Ciphertext,
+            num_bits_to_extract: ExtractedBitsCount,
+        ) -> LweCiphertextListOwned<u64> {
+            let server_key = &self.wopbs_server_key;
+
+            let lwe_size = server_key
+                .key_switching_key
+                .output_key_lwe_dimension()
+                .to_lwe_size();
+
+            let mut output = LweCiphertextListOwned::new(
+                0u64,
+                lwe_size,
+                LweCiphertextCount(num_bits_to_extract.0),
+                self.param.ciphertext_modulus,
+            );
+
+            self.extract_bits_assign(delta_log, ciphertext, num_bits_to_extract, &mut output);
+
+            output
+        }
+
+        /// Extract the given number of bits from a ciphertext.
+        ///
+        /// # Warning Experimental
+        pub fn extract_bits_assign<OutputCont>(
+            &self,
+            delta_log: DeltaLog,
+            ciphertext: &Ciphertext,
+            num_bits_to_extract: ExtractedBitsCount,
+            output: &mut LweCiphertextList<OutputCont>,
+        ) where
+            OutputCont: ContainerMut<Element = u64>,
+        {
+            let server_key = &self.wopbs_server_key;
+
+            let bsk = &server_key.bootstrapping_key;
+            let ksk = &server_key.key_switching_key;
+
+            let fft = Fft::new(bsk.polynomial_size());
+            let fft = fft.as_view();
+
+            ShortintEngine::with_thread_local_mut(|engine| {
+                engine.computation_buffers.resize(
+                    extract_bits_from_lwe_ciphertext_mem_optimized_requirement::<u64>(
+                        ciphertext.ct.lwe_size().to_lwe_dimension(),
+                        ksk.output_key_lwe_dimension(),
+                        bsk.glwe_size(),
+                        bsk.polynomial_size(),
+                        fft,
+                    )
+                    .unwrap()
+                    .unaligned_bytes_required(),
+                );
+
+                let stack = engine.computation_buffers.stack();
+
+                match bsk {
+                    ShortintBootstrappingKey::Classic(bsk) => {
+                        extract_bits_from_lwe_ciphertext_mem_optimized(
+                            &ciphertext.ct,
+                            output,
+                            bsk,
+                            ksk,
+                            delta_log,
+                            num_bits_to_extract,
+                            fft,
+                            stack,
+                        );
+                    }
+                    ShortintBootstrappingKey::MultiBit { .. } => {
+                        todo!("extract_bits_assign currently does not support multi-bit PBS")
+                    }
+                }
+            });
+        }
+
+        /// Temporary wrapper.
+        ///
+        /// # Warning Experimental
+        pub fn circuit_bootstrapping_vertical_packing<InputCont>(
+            &self,
+            vec_lut: &WopbsLUTBase,
+            extracted_bits_blocks: &LweCiphertextList<InputCont>,
+        ) -> Vec<LweCiphertextOwned<u64>>
+        where
+            InputCont: Container<Element = u64>,
+        {
+            let output_list = self.circuit_bootstrap_with_bits(
+                extracted_bits_blocks,
+                &vec_lut.lut(),
+                LweCiphertextCount(vec_lut.output_ciphertext_count().0),
+            );
+
+            assert_eq!(
+                output_list.lwe_ciphertext_count().0,
+                vec_lut.output_ciphertext_count().0
+            );
+
+            let output_container = output_list.into_container();
+            let ciphertext_modulus = self.param.ciphertext_modulus;
+            let lwes: Vec<_> = output_container
+                .chunks_exact(output_container.len() / vec_lut.output_ciphertext_count().0)
+                .map(|s| LweCiphertextOwned::from_container(s.to_vec(), ciphertext_modulus))
+                .collect();
+
+            assert_eq!(lwes.len(), vec_lut.output_ciphertext_count().0);
+            lwes
+        }
+
+        pub fn keyswitch_to_pbs_params(&self, ct_in: &Ciphertext) -> Ciphertext {
+            // move to wopbs parameters to pbs parameters
+            //Keyswitch-PBS:
+            // 1. KS to go back to the original encryption key
+            // 2. PBS to remove the noise added by the previous KS
+            //
+            let acc = self.pbs_server_key.generate_lookup_table(|x| x);
+
+            ShortintEngine::with_thread_local_mut(|engine| {
+                let (mut ciphertext_buffers, buffers) = engine.get_buffers(&self.pbs_server_key);
+                // Compute a key switch
+                keyswitch_lwe_ciphertext(
+                    &self.pbs_server_key.key_switching_key,
+                    &ct_in.ct,
+                    &mut ciphertext_buffers.buffer_lwe_after_ks,
+                );
+
+                let ct_out = match &self.pbs_server_key.bootstrapping_key {
+                    ShortintBootstrappingKey::Classic(fourier_bsk) => {
+                        let out_lwe_size = fourier_bsk.output_lwe_dimension().to_lwe_size();
+                        let mut ct_out =
+                            LweCiphertextOwned::new(0, out_lwe_size, self.param.ciphertext_modulus);
+
+                        let fft = Fft::new(fourier_bsk.polynomial_size());
+                        let fft = fft.as_view();
+                        buffers.resize(
+                            programmable_bootstrap_lwe_ciphertext_mem_optimized_requirement::<u64>(
+                                fourier_bsk.glwe_size(),
+                                fourier_bsk.polynomial_size(),
+                                fft,
+                            )
+                            .unwrap()
+                            .unaligned_bytes_required(),
+                        );
+                        let stack = buffers.stack();
+
+                        // Compute a bootstrap
+                        programmable_bootstrap_lwe_ciphertext_mem_optimized(
+                            &ciphertext_buffers.buffer_lwe_after_ks,
+                            &mut ct_out,
+                            &acc.acc,
+                            fourier_bsk,
+                            fft,
+                            stack,
+                        );
+
+                        ct_out
+                    }
+                    ShortintBootstrappingKey::MultiBit { .. } => {
+                        return Err(WopbsKeyCreationError::UnsupportedMultiBit);
+                    }
+                };
+                Ok(Ciphertext::new(
+                    ct_out,
+                    ct_in.degree,
+                    NoiseLevel::NOMINAL,
+                    ct_in.message_modulus,
+                    ct_in.carry_modulus,
+                    ct_in.pbs_order,
+                ))
+            })
+            .unwrap()
+        }
+
+        pub fn keyswitch_to_wopbs_params(&self, sks: &ServerKey, ct_in: &Ciphertext) -> Ciphertext {
+            // First PBS to remove the noise
+            let acc = sks.generate_lookup_table(|x| x);
+            let ct_clean = sks.apply_lookup_table(ct_in, &acc);
+
+            let mut buffer_lwe_after_ks = LweCiphertextOwned::new(
+                0,
+                self.ksk_pbs_to_wopbs
+                    .output_key_lwe_dimension()
+                    .to_lwe_size(),
+                self.param.ciphertext_modulus,
+            );
+
             // Compute a key switch
             keyswitch_lwe_ciphertext(
-                &self.pbs_server_key.key_switching_key,
-                &ct_in.ct,
-                &mut ciphertext_buffers.buffer_lwe_after_ks,
+                &self.ksk_pbs_to_wopbs,
+                &ct_clean.ct,
+                &mut buffer_lwe_after_ks,
             );
 
-            let ct_out = match &self.pbs_server_key.bootstrapping_key {
-                ShortintBootstrappingKey::Classic(fourier_bsk) => {
-                    let out_lwe_size = fourier_bsk.output_lwe_dimension().to_lwe_size();
-                    let mut ct_out =
-                        LweCiphertextOwned::new(0, out_lwe_size, self.param.ciphertext_modulus);
-
-                    let fft = Fft::new(fourier_bsk.polynomial_size());
-                    let fft = fft.as_view();
-                    buffers.resize(
-                        programmable_bootstrap_lwe_ciphertext_mem_optimized_requirement::<u64>(
-                            fourier_bsk.glwe_size(),
-                            fourier_bsk.polynomial_size(),
-                            fft,
-                        )
-                        .unwrap()
-                        .unaligned_bytes_required(),
-                    );
-                    let stack = buffers.stack();
-
-                    // Compute a bootstrap
-                    programmable_bootstrap_lwe_ciphertext_mem_optimized(
-                        &ciphertext_buffers.buffer_lwe_after_ks,
-                        &mut ct_out,
-                        &acc.acc,
-                        fourier_bsk,
-                        fft,
-                        stack,
-                    );
-
-                    ct_out
-                }
-                ShortintBootstrappingKey::MultiBit { .. } => {
-                    return Err(WopbsKeyCreationError::UnsupportedMultiBit);
-                }
-            };
-            Ok(Ciphertext::new(
-                ct_out,
+            // The identity lut wrongly sets the max degree in the ciphertext, when in reality the
+            // degree of the ciphertext has no changed, we manage this case manually here
+            Ciphertext::new(
+                buffer_lwe_after_ks,
                 ct_in.degree,
                 NoiseLevel::NOMINAL,
-                ct_in.message_modulus,
-                ct_in.carry_modulus,
+                ct_clean.message_modulus,
+                ct_clean.carry_modulus,
                 ct_in.pbs_order,
-            ))
-        })
-        .unwrap()
-    }
+            )
+        }
 
-    pub fn keyswitch_to_wopbs_params(&self, sks: &ServerKey, ct_in: &Ciphertext) -> Ciphertext {
-        // First PBS to remove the noise
-        let acc = sks.generate_lookup_table(|x| x);
-        let ct_clean = sks.apply_lookup_table(ct_in, &acc);
+        pub(crate) fn circuit_bootstrap_with_bits<InputCont, LutCont>(
+            &self,
+            extracted_bits: &LweCiphertextList<InputCont>,
+            lut: &PlaintextList<LutCont>,
+            count: LweCiphertextCount,
+        ) -> LweCiphertextListOwned<u64>
+        where
+            InputCont: Container<Element = u64>,
+            LutCont: Container<Element = u64>,
+        {
+            let sks = &self.wopbs_server_key;
+            let fourier_bsk = &sks.bootstrapping_key;
 
-        let mut buffer_lwe_after_ks = LweCiphertextOwned::new(
-            0,
-            self.ksk_pbs_to_wopbs
-                .output_key_lwe_dimension()
-                .to_lwe_size(),
-            self.param.ciphertext_modulus,
-        );
+            let output_lwe_size = fourier_bsk.output_lwe_dimension().to_lwe_size();
 
-        // Compute a key switch
-        keyswitch_lwe_ciphertext(
-            &self.ksk_pbs_to_wopbs,
-            &ct_clean.ct,
-            &mut buffer_lwe_after_ks,
-        );
-
-        // The identity lut wrongly sets the max degree in the ciphertext, when in reality the
-        // degree of the ciphertext has no changed, we manage this case manually here
-        Ciphertext::new(
-            buffer_lwe_after_ks,
-            ct_in.degree,
-            NoiseLevel::NOMINAL,
-            ct_clean.message_modulus,
-            ct_clean.carry_modulus,
-            ct_in.pbs_order,
-        )
-    }
-
-    pub(crate) fn circuit_bootstrap_with_bits<InputCont, LutCont>(
-        &self,
-        extracted_bits: &LweCiphertextList<InputCont>,
-        lut: &PlaintextList<LutCont>,
-        count: LweCiphertextCount,
-    ) -> LweCiphertextListOwned<u64>
-    where
-        InputCont: Container<Element = u64>,
-        LutCont: Container<Element = u64>,
-    {
-        let sks = &self.wopbs_server_key;
-        let fourier_bsk = &sks.bootstrapping_key;
-
-        let output_lwe_size = fourier_bsk.output_lwe_dimension().to_lwe_size();
-
-        let mut output_cbs_vp_ct = LweCiphertextListOwned::new(
-            0u64,
-            output_lwe_size,
-            count,
-            self.param.ciphertext_modulus,
-        );
-        let lut = PolynomialListView::from_container(lut.as_ref(), fourier_bsk.polynomial_size());
-
-        let fft = Fft::new(fourier_bsk.polynomial_size());
-        let fft = fft.as_view();
-
-        ShortintEngine::with_thread_local_mut(|engine| {
-            engine.computation_buffers.resize(
-                circuit_bootstrap_boolean_vertical_packing_lwe_ciphertext_list_mem_optimized_requirement::<u64>(
-                    extracted_bits.lwe_ciphertext_count(),
-                    output_cbs_vp_ct.lwe_ciphertext_count(),
-                    extracted_bits.lwe_size(),
-                    lut.polynomial_count(),
-                    fourier_bsk.output_lwe_dimension().to_lwe_size(),
-                    fourier_bsk.glwe_size(),
-                    self.cbs_pfpksk.output_polynomial_size(),
-                    self.param.cbs_level,
-                    fft,
-                )
-                .unwrap()
-                .unaligned_bytes_required(),
+            let mut output_cbs_vp_ct = LweCiphertextListOwned::new(
+                0u64,
+                output_lwe_size,
+                count,
+                self.param.ciphertext_modulus,
             );
+            let lut =
+                PolynomialListView::from_container(lut.as_ref(), fourier_bsk.polynomial_size());
 
-            let stack = engine.computation_buffers.stack();
+            let fft = Fft::new(fourier_bsk.polynomial_size());
+            let fft = fft.as_view();
 
-            match &sks.bootstrapping_key {
-                ShortintBootstrappingKey::Classic(bsk) => {
-                    circuit_bootstrap_boolean_vertical_packing_lwe_ciphertext_list_mem_optimized(
-                        extracted_bits,
-                        &mut output_cbs_vp_ct,
-                        &lut,
-                        bsk,
-                        &self.cbs_pfpksk,
-                        self.param.cbs_base_log,
+            ShortintEngine::with_thread_local_mut(|engine| {
+                engine.computation_buffers.resize(
+                    circuit_bootstrap_boolean_vertical_packing_lwe_ciphertext_list_mem_optimized_requirement::<u64>(
+                        extracted_bits.lwe_ciphertext_count(),
+                        output_cbs_vp_ct.lwe_ciphertext_count(),
+                        extracted_bits.lwe_size(),
+                        lut.polynomial_count(),
+                        fourier_bsk.output_lwe_dimension().to_lwe_size(),
+                        fourier_bsk.glwe_size(),
+                        self.cbs_pfpksk.output_polynomial_size(),
                         self.param.cbs_level,
                         fft,
-                        stack,
-                    );
-                }
-                ShortintBootstrappingKey::MultiBit { .. } => {
-                    return Err(WopbsKeyCreationError::UnsupportedMultiBit);
-                }
-            };
-            Ok(())
-        }).unwrap();
+                    )
+                        .unwrap()
+                        .unaligned_bytes_required(),
+                );
 
-        output_cbs_vp_ct
-    }
+                let stack = engine.computation_buffers.stack();
 
-    pub(crate) fn extract_bits_circuit_bootstrapping(
-        &self,
-        ct_in: &Ciphertext,
-        lut: &WopbsLUTBase,
-        delta_log: DeltaLog,
-        nb_bit_to_extract: ExtractedBitsCount,
-    ) -> Ciphertext {
-        let extracted_bits = self.extract_bits(delta_log, ct_in, nb_bit_to_extract);
+                match &sks.bootstrapping_key {
+                    ShortintBootstrappingKey::Classic(bsk) => {
+                        circuit_bootstrap_boolean_vertical_packing_lwe_ciphertext_list_mem_optimized(
+                            extracted_bits,
+                            &mut output_cbs_vp_ct,
+                            &lut,
+                            bsk,
+                            &self.cbs_pfpksk,
+                            self.param.cbs_base_log,
+                            self.param.cbs_level,
+                            fft,
+                            stack,
+                        );
+                    }
+                    ShortintBootstrappingKey::MultiBit { .. } => {
+                        return Err(WopbsKeyCreationError::UnsupportedMultiBit);
+                    }
+                };
+                Ok(())
+            }).unwrap();
 
-        let ciphertext_list =
-            self.circuit_bootstrap_with_bits(&extracted_bits, &lut.lut(), LweCiphertextCount(1));
+            output_cbs_vp_ct
+        }
 
-        // Here the output list contains a single ciphertext, we can consume the container to
-        // convert it to a single ciphertext
-        let ciphertext = LweCiphertextOwned::from_container(
-            ciphertext_list.into_container(),
-            self.param.ciphertext_modulus,
-        );
+        pub(crate) fn extract_bits_circuit_bootstrapping(
+            &self,
+            ct_in: &Ciphertext,
+            lut: &WopbsLUTBase,
+            delta_log: DeltaLog,
+            nb_bit_to_extract: ExtractedBitsCount,
+        ) -> Ciphertext {
+            let extracted_bits = self.extract_bits(delta_log, ct_in, nb_bit_to_extract);
 
-        let sks = &self.wopbs_server_key;
+            let ciphertext_list = self.circuit_bootstrap_with_bits(
+                &extracted_bits,
+                &lut.lut(),
+                LweCiphertextCount(1),
+            );
 
-        Ciphertext::new(
-            ciphertext,
-            Degree::new(sks.message_modulus.0 - 1),
-            NoiseLevel::NOMINAL,
-            sks.message_modulus,
-            sks.carry_modulus,
-            ct_in.pbs_order,
-        )
+            // Here the output list contains a single ciphertext, we can consume the container to
+            // convert it to a single ciphertext
+            let ciphertext = LweCiphertextOwned::from_container(
+                ciphertext_list.into_container(),
+                self.param.ciphertext_modulus,
+            );
+
+            let sks = &self.wopbs_server_key;
+
+            Ciphertext::new(
+                ciphertext,
+                Degree::new(sks.message_modulus.0 - 1),
+                NoiseLevel::NOMINAL,
+                sks.message_modulus,
+                sks.carry_modulus,
+                ct_in.pbs_order,
+            )
+        }
     }
 }


### PR DESCRIPTION
This puts the WOPBS features of shortint and integer modules behind the "experimental" feature.

Due to the versioning feature, the structs definitions are not gated behind the "experimental" feature, however they are only pub(crate) in that case.

<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
