### PR TITLE
fix(hlapi): pub use HlCompressible,HlExpandable

### DIFF
--- a/tfhe/src/high_level_api/mod.rs
+++ b/tfhe/src/high_level_api/mod.rs
@@ -92,7 +92,9 @@ pub use compact_list::ProvenCompactCiphertextList;
 pub use compact_list::{
     CompactCiphertextList, CompactCiphertextListBuilder, CompactCiphertextListExpander,
 };
-pub use compressed_ciphertext_list::{CompressedCiphertextList, CompressedCiphertextListBuilder};
+pub use compressed_ciphertext_list::{
+    CompressedCiphertextList, CompressedCiphertextListBuilder, HlCompressible, HlExpandable,
+};
 
 pub use tag::Tag;
 pub use traits::FheId;


### PR DESCRIPTION
Pub re-export the `HlCompressible` and `HlExpandable`
traits, as users may need them to write generic code
that manipulates CompressedCiphertextList/Builder