### PR TITLE
feat(cuda): modify double to torus cast and normalization for bsk

### DIFF
--- a/backends/tfhe-cuda-backend/cuda/src/crypto/torus.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/crypto/torus.cuh
@@ -1,9 +1,15 @@
 #ifndef CNCRT_TORUS_CUH
 #define CNCRT_TORUS_CUH
 
+#include "polynomial/parameters.cuh"
 #include "types/int128.cuh"
 #include "utils/kernel_dimensions.cuh"
 #include <limits>
+
+template <typename T>
+__host__ __device__ __forceinline__ constexpr double get_two_pow_torus_bits() {
+  return (sizeof(T) == 4) ? 4294967296.0 : 18446744073709551616.0;
+}
 
 template <typename T>
 __device__ inline void typecast_double_to_torus(double x, T &r) {
@@ -25,6 +31,16 @@ __device__ inline void typecast_double_to_torus<uint64_t>(double x,
   uint128 nnnn = make_uint128_from_float(x);
   uint64_t lll = nnnn.lo_;
   r = lll;
+}
+
+template <typename T>
+__device__ inline void typecast_double_round_to_torus(double x, T &r) {
+  constexpr double mx = get_two_pow_torus_bits<T>();
+  // floor must be used here because round has an issue with rounding .5,
+  // as it rounds away from zero.
+  double frac = x - floor(x);
+  frac *= mx;
+  typecast_double_to_torus(round(frac), r);
 }
 
 template <typename T>

--- a/backends/tfhe-cuda-backend/cuda/src/pbs/bootstrapping_key.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/pbs/bootstrapping_key.cuh
@@ -95,6 +95,7 @@ void cuda_convert_lwe_programmable_bootstrap_key(cudaStream_t stream,
 
   double2 *d_bsk = (double2 *)cuda_malloc_async(buffer_size, stream, gpu_index);
 
+  constexpr double two_pow_torus_bits = get_two_pow_torus_bits<T>();
   // compress real bsk to complex and divide it on DOUBLE_MAX
   for (int i = 0; i < total_polynomials; i++) {
     int complex_current_poly_idx = i * polynomial_size / 2;
@@ -103,10 +104,8 @@ void cuda_convert_lwe_programmable_bootstrap_key(cudaStream_t stream,
       h_bsk[complex_current_poly_idx + j].x = src[torus_current_poly_idx + j];
       h_bsk[complex_current_poly_idx + j].y =
           src[torus_current_poly_idx + j + polynomial_size / 2];
-      h_bsk[complex_current_poly_idx + j].x /=
-          (double)std::numeric_limits<T>::max();
-      h_bsk[complex_current_poly_idx + j].y /=
-          (double)std::numeric_limits<T>::max();
+      h_bsk[complex_current_poly_idx + j].x /= two_pow_torus_bits;
+      h_bsk[complex_current_poly_idx + j].y /= two_pow_torus_bits;
     }
   }
 

--- a/backends/tfhe-cuda-backend/cuda/src/types/complex/operations.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/types/complex/operations.cuh
@@ -49,16 +49,9 @@ __device__ inline double2 operator-(const double2 a, const double2 b) {
 }
 
 __device__ inline double2 operator*(const double2 a, const double2 b) {
-  double xx = a.x * b.x;
-  double xy = a.x * b.y;
-  double yx = a.y * b.x;
-  double yy = a.y * b.y;
-
   double2 res;
-  // asm volatile("fma.rn.f64 %0, %1, %2, %3;": "=d"(res.x) : "d"(a.x),
-  // "d"(b.x), "d"(yy));
-  res.x = xx - yy;
-  res.y = xy + yx;
+  res.x = (a.y * -b.y) + (a.x * b.x);
+  res.y = (a.x * b.y) + (a.y * b.x);
   return res;
 }
 


### PR DESCRIPTION
### PR content/description

Normalization for bsk is changed to divide on 2^bits_in_torus instead of TORUS_MAX. cast from double to torus is modified to avoid casting into in128

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
