### PR TITLE
chore(gpu): do not unwrap in blocks_of, to have the same behavior as the CPU

### DIFF
--- a/tfhe/src/integer/gpu/ciphertext/compressed_ciphertext_list.rs
+++ b/tfhe/src/integer/gpu/ciphertext/compressed_ciphertext_list.rs
@@ -85,8 +85,8 @@ impl CudaCompressedCiphertextList {
         decomp_key: &CudaDecompressionKey,
         streams: &CudaStreams,
     ) -> Option<(CudaRadixCiphertext, DataKind)> {
-        let preceding_infos = self.info.get(..index).unwrap();
-        let current_info = self.info.get(index).copied().unwrap();
+        let preceding_infos = self.info.get(..index)?;
+        let current_info = self.info.get(index).copied()?;
 
         let start_block_index: usize = preceding_infos
             .iter()


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: https://github.com/zama-ai/tfhe-rs-internal/issues/766

### PR content/description

I realized we unwrap in `blocks_of` for the Cuda compression, which causes the user doc example for compression to fail on GPU.

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
