### PR TITLE
versionize: rework of the from/into/convert feature to allow conversion with generics

### DIFF
--- a/tfhe-zk-pok/src/curve_api/bls12_381.rs
+++ b/tfhe-zk-pok/src/curve_api/bls12_381.rs
@@ -36,18 +36,13 @@ fn bigint_to_le_bytes(x: [u64; 6]) -> [u8; 6 * 8] {
 mod g1 {
     use tfhe_versionable::Versionize;
 
-    use crate::backward_compatibility::SerializableG1AffineVersions;
     use crate::serialization::{InvalidSerializedAffineError, SerializableG1Affine};
 
     use super::*;
 
     #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash, Versionize)]
     #[serde(try_from = "SerializableG1Affine", into = "SerializableG1Affine")]
-    #[versionize(
-        SerializableG1AffineVersions,
-        try_from = "SerializableG1Affine",
-        into = "SerializableG1Affine"
-    )]
+    #[versionize(try_from = "SerializableG1Affine", into = "SerializableG1Affine")]
     #[repr(transparent)]
     pub struct G1Affine {
         pub(crate) inner: ark_bls12_381::g1::G1Affine,
@@ -99,11 +94,7 @@ mod g1 {
 
     #[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Hash, Versionize)]
     #[serde(try_from = "SerializableG1Affine", into = "SerializableG1Affine")]
-    #[versionize(
-        SerializableG1AffineVersions,
-        try_from = "SerializableG1Affine",
-        into = "SerializableG1Affine"
-    )]
+    #[versionize(try_from = "SerializableG1Affine", into = "SerializableG1Affine")]
     #[repr(transparent)]
     pub struct G1 {
         pub(crate) inner: ark_bls12_381::G1Projective,
@@ -264,18 +255,13 @@ mod g1 {
 mod g2 {
     use tfhe_versionable::Versionize;
 
-    use crate::backward_compatibility::SerializableG2AffineVersions;
     use crate::serialization::{InvalidSerializedAffineError, SerializableG2Affine};
 
     use super::*;
 
     #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash, Versionize)]
     #[serde(try_from = "SerializableG2Affine", into = "SerializableG2Affine")]
-    #[versionize(
-        SerializableG2AffineVersions,
-        try_from = "SerializableG2Affine",
-        into = "SerializableG2Affine"
-    )]
+    #[versionize(try_from = "SerializableG2Affine", into = "SerializableG2Affine")]
     #[repr(transparent)]
     pub struct G2Affine {
         pub(crate) inner: ark_bls12_381::g2::G2Affine,
@@ -328,11 +314,7 @@ mod g2 {
 
     #[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Hash, Versionize)]
     #[serde(try_from = "SerializableG2Affine", into = "SerializableG2Affine")]
-    #[versionize(
-        SerializableG2AffineVersions,
-        try_from = "SerializableG2Affine",
-        into = "SerializableG2Affine"
-    )]
+    #[versionize(try_from = "SerializableG2Affine", into = "SerializableG2Affine")]
     #[repr(transparent)]
     pub struct G2 {
         pub(crate) inner: ark_bls12_381::G2Projective,
@@ -539,7 +521,6 @@ mod g2 {
 }
 
 mod gt {
-    use crate::backward_compatibility::SerializableFp12Versions;
     use crate::serialization::InvalidArraySizeError;
 
     use super::*;
@@ -548,11 +529,7 @@ mod gt {
 
     #[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Versionize, Hash)]
     #[serde(try_from = "SerializableFp12", into = "SerializableFp12")]
-    #[versionize(
-        SerializableFp12Versions,
-        try_from = "SerializableFp12",
-        into = "SerializableFp12"
-    )]
+    #[versionize(try_from = "SerializableFp12", into = "SerializableFp12")]
     #[repr(transparent)]
     pub struct Gt {
         inner: ark_ec::pairing::PairingOutput<ark_bls12_381::Bls12_381>,
@@ -697,7 +674,6 @@ mod gt {
 }
 
 mod zp {
-    use crate::backward_compatibility::SerializableFpVersions;
     use crate::serialization::InvalidArraySizeError;
 
     use super::*;
@@ -741,11 +717,7 @@ mod zp {
 
     #[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Versionize, Hash, Zeroize)]
     #[serde(try_from = "SerializableFp", into = "SerializableFp")]
-    #[versionize(
-        SerializableFpVersions,
-        try_from = "SerializableFp",
-        into = "SerializableFp"
-    )]
+    #[versionize(try_from = "SerializableFp", into = "SerializableFp")]
     #[repr(transparent)]
     pub struct Zp {
         pub(crate) inner: ark_bls12_381::Fr,

--- a/tfhe-zk-pok/src/curve_api/bls12_446.rs
+++ b/tfhe-zk-pok/src/curve_api/bls12_446.rs
@@ -36,18 +36,13 @@ fn bigint_to_le_bytes(x: [u64; 7]) -> [u8; 7 * 8] {
 mod g1 {
     use tfhe_versionable::Versionize;
 
-    use crate::backward_compatibility::SerializableG1AffineVersions;
     use crate::serialization::{InvalidSerializedAffineError, SerializableG1Affine};
 
     use super::*;
 
     #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash, Versionize)]
     #[serde(try_from = "SerializableG1Affine", into = "SerializableG1Affine")]
-    #[versionize(
-        SerializableG1AffineVersions,
-        try_from = "SerializableG1Affine",
-        into = "SerializableG1Affine"
-    )]
+    #[versionize(try_from = "SerializableG1Affine", into = "SerializableG1Affine")]
     #[repr(transparent)]
     pub struct G1Affine {
         pub(crate) inner: crate::curve_446::g1::G1Affine,
@@ -101,11 +96,7 @@ mod g1 {
 
     #[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Hash, Versionize)]
     #[serde(try_from = "SerializableG1Affine", into = "SerializableG1Affine")]
-    #[versionize(
-        SerializableG1AffineVersions,
-        try_from = "SerializableG1Affine",
-        into = "SerializableG1Affine"
-    )]
+    #[versionize(try_from = "SerializableG1Affine", into = "SerializableG1Affine")]
     #[repr(transparent)]
     pub struct G1 {
         pub(crate) inner: crate::curve_446::g1::G1Projective,
@@ -267,7 +258,6 @@ mod g1 {
 mod g2 {
     use tfhe_versionable::Versionize;
 
-    use crate::backward_compatibility::SerializableG2AffineVersions;
     use crate::serialization::SerializableG2Affine;
 
     use super::*;
@@ -275,11 +265,7 @@ mod g2 {
 
     #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash, Versionize)]
     #[serde(try_from = "SerializableG2Affine", into = "SerializableG2Affine")]
-    #[versionize(
-        SerializableG2AffineVersions,
-        try_from = "SerializableG2Affine",
-        into = "SerializableG2Affine"
-    )]
+    #[versionize(try_from = "SerializableG2Affine", into = "SerializableG2Affine")]
     #[repr(transparent)]
     pub struct G2Affine {
         pub(crate) inner: crate::curve_446::g2::G2Affine,
@@ -423,11 +409,7 @@ mod g2 {
 
     #[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Hash, Versionize)]
     #[serde(try_from = "SerializableG2Affine", into = "SerializableG2Affine")]
-    #[versionize(
-        SerializableG2AffineVersions,
-        try_from = "SerializableG2Affine",
-        into = "SerializableG2Affine"
-    )]
+    #[versionize(try_from = "SerializableG2Affine", into = "SerializableG2Affine")]
     #[repr(transparent)]
     pub struct G2 {
         pub(crate) inner: crate::curve_446::g2::G2Projective,
@@ -633,7 +615,6 @@ mod g2 {
 }
 
 mod gt {
-    use crate::backward_compatibility::SerializableFp12Versions;
     use crate::curve_446::{Fq, Fq12, Fq2};
     use crate::serialization::InvalidSerializedAffineError;
 
@@ -812,11 +793,7 @@ mod gt {
 
     #[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Versionize, Hash)]
     #[serde(try_from = "SerializableFp12", into = "SerializableFp12")]
-    #[versionize(
-        SerializableFp12Versions,
-        try_from = "SerializableFp12",
-        into = "SerializableFp12"
-    )]
+    #[versionize(try_from = "SerializableFp12", into = "SerializableFp12")]
     #[repr(transparent)]
     pub struct Gt {
         pub(crate) inner: ark_ec::pairing::PairingOutput<crate::curve_446::Bls12_446>,
@@ -959,8 +936,6 @@ mod gt {
 }
 
 mod zp {
-    use crate::backward_compatibility::SerializableFpVersions;
-
     use super::*;
     use crate::serialization::InvalidArraySizeError;
     use ark_ff::Fp;
@@ -1003,11 +978,7 @@ mod zp {
 
     #[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Versionize, Hash, Zeroize)]
     #[serde(try_from = "SerializableFp", into = "SerializableFp")]
-    #[versionize(
-        SerializableFpVersions,
-        try_from = "SerializableFp",
-        into = "SerializableFp"
-    )]
+    #[versionize(try_from = "SerializableFp", into = "SerializableFp")]
     #[repr(transparent)]
     pub struct Zp {
         pub inner: crate::curve_446::Fr,

--- a/utils/tfhe-versionable-derive/src/associated.rs
+++ b/utils/tfhe-versionable-derive/src/associated.rs
@@ -6,8 +6,9 @@ use syn::{
 };
 
 use crate::{
-    add_lifetime_bound, add_trait_where_clause, add_where_lifetime_bound, extend_where_clause,
-    parse_const_str, DESERIALIZE_TRAIT_NAME, LIFETIME_NAME, SERIALIZE_TRAIT_NAME,
+    add_lifetime_param, add_trait_where_clause, add_where_lifetime_bound_to_generics,
+    extend_where_clause, parse_const_str, DESERIALIZE_TRAIT_NAME, LIFETIME_NAME,
+    SERIALIZE_TRAIT_NAME,
 };
 
 /// Generates an impl block for the From trait. This will be:
@@ -116,7 +117,7 @@ pub(crate) trait AssociatedType: Sized {
         let mut generics = self.orig_type_generics().clone();
         if let AssociatedTypeKind::Ref(opt_lifetime) = &self.kind() {
             if let Some(lifetime) = opt_lifetime {
-                add_lifetime_bound(&mut generics, lifetime);
+                add_lifetime_param(&mut generics, lifetime);
             }
             add_trait_where_clause(&mut generics, self.inner_types()?, Self::REF_BOUNDS)?;
         } else {
@@ -214,8 +215,8 @@ impl<T: AssociatedType> AssociatingTrait<T> {
         let mut ref_type_generics = self.ref_type.orig_type_generics().clone();
         // If the original type has some generics, we need to add a lifetime bound on them
         if let Some(lifetime) = self.ref_type.lifetime() {
-            add_lifetime_bound(&mut ref_type_generics, lifetime);
-            add_where_lifetime_bound(&mut ref_type_generics, lifetime);
+            add_lifetime_param(&mut ref_type_generics, lifetime);
+            add_where_lifetime_bound_to_generics(&mut ref_type_generics, lifetime);
         }
 
         let (impl_generics, orig_generics, where_clause) = generics.split_for_impl();

--- a/utils/tfhe-versionable-derive/src/versionize_attribute.rs
+++ b/utils/tfhe-versionable-derive/src/versionize_attribute.rs
@@ -106,7 +106,14 @@ impl VersionizeAttribute {
                             attribute_builder.into =
                                 Some(parse_path_ignore_quotes(&name_value.value)?);
                         }
-                        // parse versionize(bound = "Type: Bound")
+                        // parse versionize(dispatch = "Type")
+                    } else if name_value.path.is_ident("dispatch") {
+                        if attribute_builder.dispatch_enum.is_some() {
+                            return Err(Self::default_error(meta.span()));
+                        } else {
+                            attribute_builder.dispatch_enum =
+                                Some(parse_path_ignore_quotes(&name_value.value)?);
+                        }
                     } else {
                         return Err(Self::default_error(meta.span()));
                     }

--- a/utils/tfhe-versionable-derive/src/versionize_attribute.rs
+++ b/utils/tfhe-versionable-derive/src/versionize_attribute.rs
@@ -2,47 +2,146 @@ use proc_macro2::Span;
 use quote::{quote, ToTokens};
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
-use syn::{Attribute, Expr, Ident, Lit, Meta, Path, Token, TraitBound, Type};
+use syn::{
+    parse_quote, Attribute, Expr, GenericArgument, GenericParam, Generics, Ident, Lifetime, Lit,
+    Meta, Path, PathArguments, Token, TraitBound, Type, TypeParam, WhereClause,
+};
 
-use crate::{parse_const_str, UNVERSIONIZE_ERROR_NAME, VERSIONIZE_OWNED_TRAIT_NAME};
+use crate::{
+    add_lifetime_where_clause, add_trait_where_clause, add_where_lifetime_bound_to_generics,
+    parse_const_str, DISPATCH_TRAIT_NAME, ERROR_TRAIT_NAME, FROM_TRAIT_NAME, INTO_TRAIT_NAME,
+    SEND_TRAIT_NAME, STATIC_LIFETIME_NAME, SYNC_TRAIT_NAME, TRY_INTO_TRAIT_NAME,
+    UNVERSIONIZE_ERROR_NAME, UNVERSIONIZE_TRAIT_NAME, VERSIONIZE_OWNED_TRAIT_NAME,
+};
 
 /// Name of the attribute used to give arguments to the `Versionize` macro
 const VERSIONIZE_ATTR_NAME: &str = "versionize";
 
-pub(crate) struct VersionizeAttribute {
+pub(crate) struct ClassicVersionizeAttribute {
     dispatch_enum: Path,
-    from: Option<Path>,
-    try_from: Option<Path>,
-    into: Option<Path>,
+}
+
+pub(crate) enum ConversionType {
+    Direct,
+    Try,
+}
+
+pub(crate) struct ConvertVersionizeAttribute {
+    conversion_target: Path,
+    conversion_type: ConversionType,
+}
+
+pub(crate) enum VersionizeAttribute {
+    Classic(ClassicVersionizeAttribute),
+    Convert(ConvertVersionizeAttribute),
 }
 
 #[derive(Default)]
 struct VersionizeAttributeBuilder {
     dispatch_enum: Option<Path>,
+    convert: Option<Path>,
+    try_convert: Option<Path>,
     from: Option<Path>,
     try_from: Option<Path>,
     into: Option<Path>,
 }
 
 impl VersionizeAttributeBuilder {
-    fn build(self) -> Option<VersionizeAttribute> {
-        // These attributes are mutually exclusive
-        if self.from.is_some() && self.try_from.is_some() {
-            return None;
+    fn build(self, base_span: &Span) -> syn::Result<VersionizeAttribute> {
+        let convert_is_try = self.try_convert.is_some() || self.try_from.is_some();
+        // User should not use `from` and `try_from` at the same time
+        let from_target = match (self.from, self.try_from) {
+            (None, None) => None,
+            (Some(_), Some(try_from)) => {
+                return Err(syn::Error::new(
+                    try_from.span(),
+                    "'try_from' and 'from' attributes are mutually exclusive",
+                ))
+            }
+            (None, Some(try_from)) => Some(try_from),
+            (Some(from), None) => Some(from),
+        };
+
+        // Same with `convert`/`try_convert`
+        let convert_target = match (self.convert, self.try_convert) {
+            (None, None) => None,
+            (Some(_), Some(try_convert)) => {
+                return Err(syn::Error::new(
+                    try_convert.span(),
+                    "'try_convert' and 'convert' attributes are mutually exclusive",
+                ))
+            }
+            (None, Some(try_convert)) => Some(try_convert),
+            (Some(convert), None) => Some(convert),
+        };
+
+        // from/into are here for similarity with serde, but we don't actually support having
+        // different target inside. So we check this to warn the user
+        let from_target =
+            match (from_target, self.into) {
+                (None, None) => None,
+                (None, Some(into)) => return Err(syn::Error::new(
+                    into.span(),
+                    "unidirectional conversions are not handled, please add a 'from'/'try_from' \
+attribute or use the 'convert'/'try_convert' attribute instead",
+                )),
+                (Some(from), None) => return Err(syn::Error::new(
+                    from.span(),
+                    "unidirectional conversions are not handled, please add a 'into' attribute or \
+use the 'convert'/'try_convert' attribute instead",
+                )),
+                (Some(from), Some(into)) => {
+                    if format!("{}", from.to_token_stream())
+                        != format!("{}", into.to_token_stream())
+                    {
+                        return Err(syn::Error::new(
+                        from.span(),
+                        "unidirectional conversions are not handled, 'from' and 'into' parameters \
+should have the same value",
+                    ));
+                    } else {
+                        Some(from)
+                    }
+                }
+            };
+
+        // Finally, checks that the user doesn't use both from/into and convert
+        let conversion_target = match (from_target, convert_target) {
+            (None, None) => None,
+            (Some(_), Some(convert)) => {
+                return Err(syn::Error::new(
+                    convert.span(),
+                    "'convert' and 'from'/'into' attributes are mutually exclusive",
+                ))
+            }
+            (None, Some(convert)) => Some(convert),
+            (Some(from), None) => Some(from),
+        };
+
+        if let Some(conversion_target) = conversion_target {
+            Ok(VersionizeAttribute::Convert(ConvertVersionizeAttribute {
+                conversion_target,
+                conversion_type: if convert_is_try {
+                    ConversionType::Try
+                } else {
+                    ConversionType::Direct
+                },
+            }))
+        } else {
+            Ok(VersionizeAttribute::Classic(ClassicVersionizeAttribute {
+                dispatch_enum: self.dispatch_enum.ok_or(syn::Error::new(
+                    *base_span,
+                    "Missing dispatch enum argument",
+                ))?,
+            }))
         }
-        Some(VersionizeAttribute {
-            dispatch_enum: self.dispatch_enum?,
-            from: self.from,
-            try_from: self.try_from,
-            into: self.into,
-        })
     }
 }
 
 impl VersionizeAttribute {
     /// Find and parse an attribute with the form `#[versionize(DispatchType)]`, where
     /// `DispatchType` is the name of the type holding the dispatch enum.
-    /// Returns an error if no `versionize` attribute has been found, if multiple attributes are
+    /// Return an error if no `versionize` attribute has been found, if multiple attributes are
     /// present on the same struct or if the attribute is malformed.
     pub(crate) fn parse_from_attributes_list(
         attributes: &[Attribute],
@@ -82,8 +181,24 @@ impl VersionizeAttribute {
                     }
                 }
                 Meta::NameValue(name_value) => {
+                    // parse versionize(convert = "TypeConvert")
+                    if name_value.path.is_ident("convert") {
+                        if attribute_builder.convert.is_some() {
+                            return Err(Self::default_error(meta.span()));
+                        } else {
+                            attribute_builder.convert =
+                                Some(parse_path_ignore_quotes(&name_value.value)?);
+                        }
+                        // parse versionize(try_convert = "TypeTryConvert")
+                    } else if name_value.path.is_ident("try_convert") {
+                        if attribute_builder.try_convert.is_some() {
+                            return Err(Self::default_error(meta.span()));
+                        } else {
+                            attribute_builder.try_convert =
+                                Some(parse_path_ignore_quotes(&name_value.value)?);
+                        }
                     // parse versionize(from = "TypeFrom")
-                    if name_value.path.is_ident("from") {
+                    } else if name_value.path.is_ident("from") {
                         if attribute_builder.from.is_some() {
                             return Err(Self::default_error(meta.span()));
                         } else {
@@ -122,60 +237,289 @@ impl VersionizeAttribute {
             }
         }
 
-        attribute_builder
-            .build()
-            .ok_or_else(|| Self::default_error(attribute.span()))
-    }
-
-    pub(crate) fn dispatch_enum(&self) -> &Path {
-        &self.dispatch_enum
+        attribute_builder.build(&attribute.span())
     }
 
     pub(crate) fn needs_conversion(&self) -> bool {
-        self.try_from.is_some() || self.from.is_some()
+        match self {
+            VersionizeAttribute::Classic(_) => false,
+            VersionizeAttribute::Convert(_) => true,
+        }
     }
 
-    pub(crate) fn dispatch_target(&self) -> Path {
-        self.from
-            .as_ref()
-            .or(self.try_from.as_ref())
-            .map(|target| target.to_owned())
-            .unwrap_or_else(|| {
-                syn::parse_str("Self").expect("Parsing of const value should never fail")
-            })
+    /// Return the associated type used in the `Versionize` trait: `MyType::Versioned<'vers>`
+    ///
+    /// If the type is directly versioned, this will be a type generated by the `VersionDispatch`.
+    ///
+    /// If we have a conversion before the versioning, we re-use the versioned_owned type of the
+    /// conversion target. The versioned_owned is needed because the conversion will create a new
+    /// value, so we can't just use a reference.
+    pub(crate) fn versioned_type(
+        &self,
+        lifetime: &Lifetime,
+        input_generics: &Generics,
+    ) -> proc_macro2::TokenStream {
+        match self {
+            VersionizeAttribute::Classic(attr) => {
+                let (_, ty_generics, _) = input_generics.split_for_impl();
+
+                let dispatch_trait: Path = parse_const_str(DISPATCH_TRAIT_NAME);
+                let dispatch_enum_path = &attr.dispatch_enum;
+                quote! {
+                    <#dispatch_enum_path #ty_generics as
+                    #dispatch_trait<Self>>::Ref<#lifetime>
+                }
+            }
+            VersionizeAttribute::Convert(_) => {
+                // If we want to apply a conversion before the call to versionize we need to use the
+                // "owned" alternative of the dispatch enum to be able to store the
+                // conversion result.
+                self.versioned_owned_type(input_generics)
+            }
+        }
     }
 
+    /// Return the where clause for `MyType::Versioned<'vers>`. if `MyType` has generics, this means
+    /// adding a 'vers lifetime bound on them.
+    pub(crate) fn versioned_type_where_clause(
+        &self,
+        lifetime: &Lifetime,
+        input_generics: &Generics,
+    ) -> Option<WhereClause> {
+        let mut generics = input_generics.clone();
+
+        add_where_lifetime_bound_to_generics(&mut generics, lifetime);
+        let (_, _, where_clause) = generics.split_for_impl();
+        where_clause.cloned()
+    }
+
+    /// Return the associated type used in the `VersionizeOwned` trait: `MyType::VersionedOwned`
+    ///
+    /// If the type is directly versioned, this will be a type generated by the `VersionDispatch`.
+    ///
+    /// If we have a conversion before the versioning, we re-use the versioned_owned type of the
+    /// conversion target.
+    pub(crate) fn versioned_owned_type(
+        &self,
+        input_generics: &Generics,
+    ) -> proc_macro2::TokenStream {
+        let (_, ty_generics, _) = input_generics.split_for_impl();
+        match self {
+            VersionizeAttribute::Classic(attr) => {
+                let dispatch_trait: Path = parse_const_str(DISPATCH_TRAIT_NAME);
+                let dispatch_enum_path = &attr.dispatch_enum;
+                quote! {
+                    <#dispatch_enum_path #ty_generics as
+                    #dispatch_trait<Self>>::Owned
+                }
+            }
+            VersionizeAttribute::Convert(convert_attr) => {
+                let convert_type_path = &convert_attr.conversion_target;
+                let versionize_owned_trait: Path = parse_const_str(VERSIONIZE_OWNED_TRAIT_NAME);
+
+                quote! {
+                    <#convert_type_path as #versionize_owned_trait>::VersionedOwned
+                }
+            }
+        }
+    }
+
+    /// Return the where clause for `MyType::VersionedOwned`.
+    ///
+    /// This is simply the where clause of the input type.
+    pub(crate) fn versioned_owned_type_where_clause(
+        &self,
+        input_generics: &Generics,
+    ) -> Option<WhereClause> {
+        match self {
+            VersionizeAttribute::Classic(_) => input_generics.split_for_impl().2.cloned(),
+            VersionizeAttribute::Convert(convert_attr) => {
+                extract_generics(&convert_attr.conversion_target)
+                    .split_for_impl()
+                    .2
+                    .cloned()
+            }
+        }
+    }
+
+    /// Return the where clause needed to implement the Versionize trait.
+    ///
+    /// This is the same as the one for the VersionizeOwned, with an additional "Clone" bound in the
+    /// case where we need to perform a conversion before the versioning.
+    pub(crate) fn versionize_trait_where_clause(
+        &self,
+        input_generics: &Generics,
+    ) -> syn::Result<Option<WhereClause>> {
+        // The base bounds for the owned traits are also used for the ref traits
+        let mut generics = input_generics.clone();
+        if self.needs_conversion() {
+            // The versionize method takes a ref. We need to own the input type in the conversion
+            // case to apply `From<Input> for Target`. This adds a `Clone` bound to have
+            // a better error message if the input type is not Clone.
+            add_trait_where_clause(&mut generics, [&parse_quote! { Self }], &["Clone"])?;
+        }
+
+        self.versionize_owned_trait_where_clause(&generics)
+    }
+
+    /// Return the where clause needed to implement the VersionizeOwned trait.
+    ///
+    /// If the type is directly versioned, the bound states that the argument points to a valid
+    /// DispatchEnum for this type. This is done by adding a bound on this argument to
+    /// `VersionsDisaptch<Self>`.
+    ///
+    /// If there is a conversion, the target of the conversion should implement `VersionizeOwned`
+    /// and `From<Self>`.
+    pub(crate) fn versionize_owned_trait_where_clause(
+        &self,
+        input_generics: &Generics,
+    ) -> syn::Result<Option<WhereClause>> {
+        let mut generics = input_generics.clone();
+        match self {
+            VersionizeAttribute::Classic(attr) => {
+                let dispatch_generics = generics.clone();
+                let dispatch_ty_generics = dispatch_generics.split_for_impl().1;
+                let dispatch_enum_path = &attr.dispatch_enum;
+
+                add_trait_where_clause(
+                    &mut generics,
+                    [&parse_quote!(#dispatch_enum_path #dispatch_ty_generics)],
+                    &[format!("{}<Self>", DISPATCH_TRAIT_NAME,)],
+                )?;
+            }
+            VersionizeAttribute::Convert(convert_attr) => {
+                let convert_type_path = &convert_attr.conversion_target;
+                add_trait_where_clause(
+                    &mut generics,
+                    [&parse_quote!(#convert_type_path)],
+                    &[
+                        VERSIONIZE_OWNED_TRAIT_NAME,
+                        &format!("{}<Self>", FROM_TRAIT_NAME),
+                    ],
+                )?;
+            }
+        }
+
+        Ok(generics.split_for_impl().2.cloned())
+    }
+
+    /// Return the where clause for the `Unversionize` trait.
+    ///
+    /// If the versioning is direct, this is the same bound as the one used for `VersionizeOwned`.
+    ///
+    /// If there is a conversion, the target of the conversion need to implement `Unversionize` and
+    /// `Into` or `TryInto<T, E>`, with `E: Error + Send + Sync + 'static`
+    pub(crate) fn unversionize_trait_where_clause(
+        &self,
+        input_generics: &Generics,
+    ) -> syn::Result<Option<WhereClause>> {
+        match self {
+            VersionizeAttribute::Classic(_) => {
+                self.versionize_owned_trait_where_clause(input_generics)
+            }
+            VersionizeAttribute::Convert(convert_attr) => {
+                let mut generics = input_generics.clone();
+                let convert_type_path = &convert_attr.conversion_target;
+                let into_trait = match convert_attr.conversion_type {
+                    ConversionType::Direct => format!("{}<Self>", INTO_TRAIT_NAME),
+                    ConversionType::Try => {
+                        // Doing a TryFrom requires that the error
+                        // impl Error + Send + Sync + 'static
+                        let try_into_trait: Path = parse_const_str(TRY_INTO_TRAIT_NAME);
+                        add_trait_where_clause(
+                            &mut generics,
+                            [&parse_quote!(<#convert_type_path as #try_into_trait<Self>>::Error)],
+                            &[ERROR_TRAIT_NAME, SYNC_TRAIT_NAME, SEND_TRAIT_NAME],
+                        )?;
+                        add_lifetime_where_clause(
+                            &mut generics,
+                            [&parse_quote!(<#convert_type_path as #try_into_trait<Self>>::Error)],
+                            &[STATIC_LIFETIME_NAME],
+                        )?;
+
+                        format!("{}<Self>", TRY_INTO_TRAIT_NAME)
+                    }
+                };
+                add_trait_where_clause(
+                    &mut generics,
+                    [&parse_quote!(#convert_type_path)],
+                    &[
+                        UNVERSIONIZE_TRAIT_NAME,
+                        &format!("{}<Self>", FROM_TRAIT_NAME),
+                        &into_trait,
+                    ],
+                )?;
+
+                Ok(generics.split_for_impl().2.cloned())
+            }
+        }
+    }
+
+    /// Return the body of the versionize method.
     pub(crate) fn versionize_method_body(&self) -> proc_macro2::TokenStream {
         let versionize_owned_trait: TraitBound = parse_const_str(VERSIONIZE_OWNED_TRAIT_NAME);
-        self.into
-            .as_ref()
-            .map(|target| {
-                quote! {
-                    #versionize_owned_trait::versionize_owned(#target::from(self.to_owned()))
-                }
-            })
-            .unwrap_or_else(|| {
+
+        match self {
+            VersionizeAttribute::Classic(_) => {
                 quote! {
                     self.into()
                 }
-            })
+            }
+            VersionizeAttribute::Convert(convert_attr) => {
+                let convert_type_path = with_turbofish(&convert_attr.conversion_target);
+                quote! {
+                    #versionize_owned_trait::versionize_owned(#convert_type_path::from(self.to_owned()))
+                }
+            }
+        }
     }
 
+    /// Return the body of the versionize_owned method.
+    pub(crate) fn versionize_owned_method_body(&self) -> proc_macro2::TokenStream {
+        let versionize_owned_trait: TraitBound = parse_const_str(VERSIONIZE_OWNED_TRAIT_NAME);
+
+        match self {
+            VersionizeAttribute::Classic(_) => {
+                quote! {
+                    self.into()
+                }
+            }
+            VersionizeAttribute::Convert(convert_attr) => {
+                let convert_type_path = with_turbofish(&convert_attr.conversion_target);
+                quote! {
+                    #versionize_owned_trait::versionize_owned(#convert_type_path::from(self))
+                }
+            }
+        }
+    }
+
+    /// Return the body of the unversionize method.
     pub(crate) fn unversionize_method_body(&self, arg_name: &Ident) -> proc_macro2::TokenStream {
         let error: Type = parse_const_str(UNVERSIONIZE_ERROR_NAME);
-        if let Some(target) = &self.from {
-            quote! { #target::unversionize(#arg_name).map(|value| value.into()) }
-        } else if let Some(target) = &self.try_from {
-            let target_name = format!("{}", target.to_token_stream());
-            quote! { #target::unversionize(#arg_name).and_then(|value| TryInto::<Self>::try_into(value)
-                .map_err(|e| #error::conversion(#target_name, e)))
+        match self {
+            VersionizeAttribute::Classic(_) => {
+                quote! { #arg_name.try_into() }
             }
-        } else {
-            quote! { #arg_name.try_into() }
+            VersionizeAttribute::Convert(convert_attr) => {
+                let target = with_turbofish(&convert_attr.conversion_target);
+                match convert_attr.conversion_type {
+                    ConversionType::Direct => {
+                        quote! { #target::unversionize(#arg_name).map(|value| value.into()) }
+                    }
+                    ConversionType::Try => {
+                        let target_name = format!("{}", target.to_token_stream());
+                        quote! { #target::unversionize(#arg_name).and_then(|value| TryInto::<Self>::try_into(value)
+                            .map_err(|e| #error::conversion(#target_name, e)))
+                        }
+                    }
+                }
+            }
         }
     }
 }
 
+/// Allow the user to give type arguments as `#[versionize(MyType)]` as well as
+/// `#[versionize("MyType")]`
 fn parse_path_ignore_quotes(value: &Expr) -> syn::Result<Path> {
     match &value {
         Expr::Path(expr_path) => Ok(expr_path.path.clone()),
@@ -191,4 +535,38 @@ fn parse_path_ignore_quotes(value: &Expr) -> syn::Result<Path> {
             "Malformed `versionize` attribute",
         )),
     }
+}
+
+/// Return the same type but with generics that use the turbofish syntax. Converts
+/// `MyStruct<T>` into `MyStruct::<T>`
+fn with_turbofish(path: &Path) -> Path {
+    let mut with_turbo = path.clone();
+
+    for segment in with_turbo.segments.iter_mut() {
+        if let PathArguments::AngleBracketed(generics) = &mut segment.arguments {
+            generics.colon2_token = Some(Token![::](generics.span()));
+        }
+    }
+
+    with_turbo
+}
+
+/// Extract the generics inside a type
+fn extract_generics(path: &Path) -> Generics {
+    let mut generics = Generics::default();
+
+    if let Some(last_segment) = path.segments.last() {
+        if let PathArguments::AngleBracketed(args) = &last_segment.arguments {
+            for arg in &args.args {
+                if let GenericArgument::Type(Type::Path(type_path)) = arg {
+                    if let Some(ident) = type_path.path.get_ident() {
+                        let param = TypeParam::from(ident.clone());
+                        generics.params.push(GenericParam::Type(param));
+                    }
+                }
+            }
+        }
+    }
+
+    generics
 }

--- a/utils/tfhe-versionable/examples/manual_impl.rs
+++ b/utils/tfhe-versionable/examples/manual_impl.rs
@@ -2,11 +2,10 @@
 
 use std::convert::Infallible;
 
-use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use tfhe_versionable::{Unversionize, UnversionizeError, Upgrade, Versionize, VersionizeOwned};
 
-struct MyStruct<T: Default> {
+struct MyStruct<T> {
     attr: T,
     builtin: u32,
 }
@@ -28,18 +27,18 @@ impl<T: Default> Upgrade<MyStruct<T>> for MyStructV0 {
 }
 
 #[derive(Serialize)]
-struct MyStructVersion<'vers, T: 'vers + Default + Versionize> {
+struct MyStructVersion<'vers, T: 'vers + Versionize> {
     attr: T::Versioned<'vers>,
     builtin: u32,
 }
 
 #[derive(Serialize, Deserialize)]
-struct MyStructVersionOwned<T: Default + VersionizeOwned> {
+struct MyStructVersionOwned<T: VersionizeOwned> {
     attr: T::VersionedOwned,
     builtin: u32,
 }
 
-impl<T: Default + Versionize + Serialize + DeserializeOwned> Versionize for MyStruct<T> {
+impl<T: Versionize + Serialize> Versionize for MyStruct<T> {
     type Versioned<'vers>
         = MyStructVersionsDispatch<'vers, T>
     where
@@ -54,7 +53,7 @@ impl<T: Default + Versionize + Serialize + DeserializeOwned> Versionize for MySt
     }
 }
 
-impl<T: Default + VersionizeOwned + Serialize + DeserializeOwned> VersionizeOwned for MyStruct<T> {
+impl<T: VersionizeOwned + Serialize + for<'de> Deserialize<'de>> VersionizeOwned for MyStruct<T> {
     type VersionedOwned = MyStructVersionsDispatchOwned<T>;
 
     fn versionize_owned(self) -> Self::VersionedOwned {
@@ -66,7 +65,7 @@ impl<T: Default + VersionizeOwned + Serialize + DeserializeOwned> VersionizeOwne
     }
 }
 
-impl<T: Default + VersionizeOwned + Unversionize + Serialize + DeserializeOwned> Unversionize
+impl<T: Unversionize + Serialize + for<'de> Deserialize<'de> + Default> Unversionize
     for MyStruct<T>
 {
     fn unversionize(versioned: Self::VersionedOwned) -> Result<Self, UnversionizeError> {
@@ -82,28 +81,80 @@ impl<T: Default + VersionizeOwned + Unversionize + Serialize + DeserializeOwned>
     }
 }
 
+// Since MyStructV0 is only composed of built-in types, it does not need recursive versioning and
+// can be used as its own "version type".
 #[derive(Serialize)]
 #[allow(dead_code)]
-enum MyStructVersionsDispatch<'vers, T: 'vers + Default + Versionize> {
+enum MyStructVersionsDispatch<'vers, T: 'vers + Versionize> {
     V0(MyStructV0),
     V1(MyStructVersion<'vers, T>),
 }
 
 #[derive(Serialize, Deserialize)]
-enum MyStructVersionsDispatchOwned<T: Default + VersionizeOwned> {
+enum MyStructVersionsDispatchOwned<T: VersionizeOwned> {
     V0(MyStructV0),
     V1(MyStructVersionOwned<T>),
 }
 
+mod v0 {
+    use serde::{Deserialize, Serialize};
+    use tfhe_versionable::{Unversionize, UnversionizeError, Versionize, VersionizeOwned};
+
+    #[derive(Serialize, Deserialize)]
+    pub(super) struct MyStruct {
+        pub(super) builtin: u32,
+    }
+
+    impl Versionize for MyStruct {
+        type Versioned<'vers> = MyStructVersionsDispatch;
+
+        fn versionize(&self) -> Self::Versioned<'_> {
+            let ver = MyStruct {
+                builtin: self.builtin,
+            };
+            MyStructVersionsDispatch::V0(ver)
+        }
+    }
+
+    impl VersionizeOwned for MyStruct {
+        type VersionedOwned = MyStructVersionsDispatchOwned;
+
+        fn versionize_owned(self) -> Self::VersionedOwned {
+            MyStructVersionsDispatchOwned::V0(self)
+        }
+    }
+
+    impl Unversionize for MyStruct {
+        fn unversionize(versioned: Self::VersionedOwned) -> Result<Self, UnversionizeError> {
+            match versioned {
+                MyStructVersionsDispatchOwned::V0(v0) => Ok(v0),
+            }
+        }
+    }
+
+    #[derive(Serialize)]
+    #[allow(dead_code)]
+    pub(super) enum MyStructVersionsDispatch {
+        V0(MyStruct),
+    }
+
+    #[derive(Serialize, Deserialize)]
+    pub(super) enum MyStructVersionsDispatchOwned {
+        V0(MyStruct),
+    }
+}
+
 fn main() {
-    let ms = MyStruct {
-        attr: 37u64,
-        builtin: 1234,
-    };
+    let value = 1234;
+    let ms = v0::MyStruct { builtin: value };
 
     let serialized = bincode::serialize(&ms.versionize()).unwrap();
 
-    let _unserialized = MyStruct::<u64>::unversionize(bincode::deserialize(&serialized).unwrap());
+    let unserialized =
+        MyStruct::<u64>::unversionize(bincode::deserialize(&serialized).unwrap()).unwrap();
+
+    assert_eq!(unserialized.builtin, value);
+    assert_eq!(unserialized.attr, u64::default());
 }
 
 #[test]

--- a/utils/tfhe-versionable/examples/recursive.rs
+++ b/utils/tfhe-versionable/examples/recursive.rs
@@ -7,7 +7,7 @@ use tfhe_versionable::{Unversionize, Upgrade, Version, Versionize, VersionsDispa
 // The inner struct is independently versioned
 #[derive(Versionize)]
 #[versionize(MyStructInnerVersions)]
-struct MyStructInner<T: Default> {
+struct MyStructInner<T> {
     attr: T,
     builtin: u32,
 }
@@ -30,7 +30,7 @@ impl<T: Default> Upgrade<MyStructInner<T>> for MyStructInnerV0 {
 
 #[derive(VersionsDispatch)]
 #[allow(unused)]
-enum MyStructInnerVersions<T: Default> {
+enum MyStructInnerVersions<T> {
     V0(MyStructInnerV0),
     V1(MyStructInner<T>),
 }
@@ -38,13 +38,13 @@ enum MyStructInnerVersions<T: Default> {
 // An upgrade of the inner struct does not require an upgrade of the outer struct
 #[derive(Versionize)]
 #[versionize(MyStructVersions)]
-struct MyStruct<T: Default> {
+struct MyStruct<T> {
     inner: MyStructInner<T>,
 }
 
 #[derive(VersionsDispatch)]
 #[allow(unused)]
-enum MyStructVersions<T: Default> {
+enum MyStructVersions<T> {
     V0(MyStruct<T>),
 }
 

--- a/utils/tfhe-versionable/examples/simple.rs
+++ b/utils/tfhe-versionable/examples/simple.rs
@@ -8,7 +8,7 @@ use tfhe_versionable::{Unversionize, Upgrade, Version, Versionize, VersionsDispa
 #[derive(Versionize)]
 #[versionize(MyStructVersions)] // Link to the enum type that will holds all the versions of this
                                 // type
-struct MyStruct<T: Default> {
+struct MyStruct<T> {
     attr: T,
     builtin: u32,
 }
@@ -38,7 +38,7 @@ impl<T: Default> Upgrade<MyStruct<T>> for MyStructV0 {
 // This enum is not directly used but serves as a template to generate a new enum that will be
 // serialized. This allows recursive versioning.
 #[allow(unused)]
-enum MyStructVersions<T: Default> {
+enum MyStructVersions<T> {
     V0(MyStructV0),
     V1(MyStruct<T>),
 }

--- a/utils/tfhe-versionable/examples/simple.rs
+++ b/utils/tfhe-versionable/examples/simple.rs
@@ -6,8 +6,9 @@ use tfhe_versionable::{Unversionize, Upgrade, Version, Versionize, VersionsDispa
 
 // The structure that should be versioned, as defined in your code
 #[derive(Versionize)]
-#[versionize(MyStructVersions)] // Link to the enum type that will holds all the versions of this
-                                // type
+// We have to link to the enum type that will holds all the versions of this
+// type. This can also be written `#[versionize(dispatch = MyStructVersions)]`.
+#[versionize(MyStructVersions)]
 struct MyStruct<T> {
     attr: T,
     builtin: u32,

--- a/utils/tfhe-versionable/examples/upgrades.rs
+++ b/utils/tfhe-versionable/examples/upgrades.rs
@@ -34,7 +34,7 @@ mod v1 {
 
     #[derive(Serialize, Deserialize, Versionize)]
     #[versionize(MyStructVersions)]
-    pub struct MyStruct<T: Default>(pub u32, pub T);
+    pub struct MyStruct<T>(pub u32, pub T);
 
     mod backward_compat {
         use std::convert::Infallible;
@@ -56,7 +56,7 @@ mod v1 {
 
         #[derive(VersionsDispatch)]
         #[allow(unused)]
-        pub enum MyStructVersions<T: Default> {
+        pub enum MyStructVersions<T> {
             V0(MyStructV0),
             V1(MyStruct<T>),
         }
@@ -71,7 +71,7 @@ mod v2 {
 
     #[derive(Serialize, Deserialize, Versionize)]
     #[versionize(MyEnumVersions)]
-    pub enum MyEnum<T: Default> {
+    pub enum MyEnum<T> {
         Variant0,
         Variant1 { count: u64 },
         Variant2(T),
@@ -79,7 +79,7 @@ mod v2 {
 
     #[derive(Serialize, Deserialize, Versionize)]
     #[versionize(MyStructVersions)]
-    pub struct MyStruct<T: Default> {
+    pub struct MyStruct<T> {
         pub count: u32,
         pub attr: T,
     }
@@ -118,7 +118,7 @@ mod v2 {
 
         #[derive(VersionsDispatch)]
         #[allow(unused)]
-        pub enum MyStructVersions<T: Default> {
+        pub enum MyStructVersions<T> {
             V0(MyStructV0),
             V1(MyStructV1<T>),
             V2(MyStruct<T>),
@@ -126,7 +126,7 @@ mod v2 {
 
         #[derive(VersionsDispatch)]
         #[allow(unused)]
-        pub enum MyEnumVersions<T: Default> {
+        pub enum MyEnumVersions<T> {
             V0(MyEnum<T>),
         }
     }

--- a/utils/tfhe-versionable/tests/convert_with_bounds.rs
+++ b/utils/tfhe-versionable/tests/convert_with_bounds.rs
@@ -1,0 +1,51 @@
+//! Checks compatibility between the "convert" feature and bounds on the From/Into trait
+
+use tfhe_versionable::{Unversionize, Versionize, VersionsDispatch};
+
+#[derive(Clone, Versionize)]
+#[versionize(try_convert = "SerializableMyStruct")]
+struct MyStruct<T> {
+    generics: T,
+}
+
+#[derive(Versionize)]
+#[versionize(SerializableMyStructVersions)]
+struct SerializableMyStruct {
+    concrete: u64,
+}
+
+#[derive(VersionsDispatch)]
+#[allow(unused)]
+enum SerializableMyStructVersions {
+    V0(SerializableMyStruct),
+}
+
+impl<T: Into<u64>> From<MyStruct<T>> for SerializableMyStruct {
+    fn from(value: MyStruct<T>) -> Self {
+        Self {
+            concrete: value.generics.into(),
+        }
+    }
+}
+
+impl<T: TryFrom<u64>> TryFrom<SerializableMyStruct> for MyStruct<T> {
+    fn try_from(value: SerializableMyStruct) -> Result<Self, Self::Error> {
+        Ok(Self {
+            generics: value.concrete.try_into()?,
+        })
+    }
+
+    type Error = T::Error;
+}
+
+#[test]
+fn test() {
+    let stru = MyStruct { generics: 90u32 };
+
+    let serialized = bincode::serialize(&stru.versionize()).unwrap();
+
+    let stru_decoded: MyStruct<u32> =
+        MyStruct::unversionize(bincode::deserialize(&serialized).unwrap()).unwrap();
+
+    assert_eq!(stru.generics, stru_decoded.generics)
+}

--- a/utils/tfhe-versionable/tests/convert_with_generics.rs
+++ b/utils/tfhe-versionable/tests/convert_with_generics.rs
@@ -1,10 +1,8 @@
-//! Show how to call a conversion method (from/into) before versioning/unversioning
+//! Checks compatibility between the "convert" feature and generics
 
 use tfhe_versionable::{Unversionize, Versionize, VersionsDispatch};
 
 #[derive(Clone, Versionize)]
-// To mimic serde parameters, this can also be expressed as
-// "#[versionize(from = SerializableMyStruct, into = SerializableMyStruct)]"
 #[versionize(convert = "SerializableMyStruct<T>")]
 struct MyStruct<T> {
     val: u64,
@@ -44,7 +42,8 @@ impl<T> From<SerializableMyStruct<T>> for MyStruct<T> {
     }
 }
 
-fn main() {
+#[test]
+fn test() {
     let stru = MyStruct {
         val: 37,
         generics: 90,
@@ -56,9 +55,4 @@ fn main() {
         MyStruct::unversionize(bincode::deserialize(&serialized).unwrap()).unwrap();
 
     assert_eq!(stru.val, stru_decoded.val)
-}
-
-#[test]
-fn test() {
-    main()
 }

--- a/utils/tfhe-versionable/tests/testcases/struct.rs
+++ b/utils/tfhe-versionable/tests/testcases/struct.rs
@@ -37,6 +37,18 @@ pub struct MyStruct2<T, U> {
     field1: U,
 }
 
+#[derive(Versionize)]
+#[versionize(dispatch = MyStruct3Versions)]
+pub struct MyStruct3<T> {
+    field0: u64,
+    field1: T,
+}
+
+#[derive(VersionsDispatch)]
+pub enum MyStruct3Versions<T> {
+    V0(MyStruct3<T>),
+}
+
 fn main() {
     assert_impl_all!(MyEmptyStruct: Version);
     assert_impl_all!(MyEmptyStruct2: Version);
@@ -47,7 +59,9 @@ fn main() {
 
     assert_impl_all!(MyAnonStruct3<u64>: Version);
 
-    assert_impl_all!(MyStruct<u32>: Version);
+    assert_impl_all!(MyStruct<u32>: Versionize);
 
     assert_impl_all!(MyStruct2<usize, String>: Version);
+
+    assert_impl_all!(MyStruct3<u32>: Versionize);
 }


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: https://github.com/zama-ai/tfhe-rs-internal/issues/748

### PR content/description
The `Versionize` proc macro accepts some arguments that will affect the implementation of the traits. From example, the `#[versionize(SerializableMyTypeVersions, from = SerializableMyType, into = SerializableMyType)]` will apply a conversion method before the versioning, like serde does: https://serde.rs/container-attrs.html#from. However before this PR, this parameter did not work if the conversion type had generics, or if the conversion method needed specific bounds.

On a side note, the syntax was a bit updated. The `from`/`try_from`/`into` keywords were used to mimic serde, for user convenience. However in Versionize we actually don't support having a different value for from and into. This is now checked during the argument parsing. New shortcut arguments have also been added: `convert`/`try_convert`. They work the same way except that you only need one argument: `#[versionize(SerializableMyTypeVersions, convert = SerializableMyType)]`.

On the same topic, before this pr the attribute required the to state the name of the dispatch enum in that case: `#[versionize(SerializableMyTypeVersions, from = SerializableMyType, into = SerializableMyType)]`. This is now automatically detected when we use a conversion, which means that the attribute can be simplified as `#[versionize(convert = SerializableMyType)]`

### Check-list:

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [x] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
