### PR TITLE
chore(gpu): limit base log to 32 because of int32 cast in decomposition

### DIFF
--- a/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_classic.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_classic.cu
@@ -530,8 +530,7 @@ void cuda_programmable_bootstrap_lwe_ciphertext_vector_32(
     uint32_t num_samples, uint32_t lut_count, uint32_t lut_stride) {
 
   if (base_log > 32)
-    PANIC("Cuda error (classical PBS): base log should be > number of bits "
-          "in the ciphertext representation (32)");
+    PANIC("Cuda error (classical PBS): base log should be <= 32")
 
   pbs_buffer<uint32_t, CLASSICAL> *buffer =
       (pbs_buffer<uint32_t, CLASSICAL> *)mem_ptr;
@@ -650,9 +649,8 @@ void cuda_programmable_bootstrap_lwe_ciphertext_vector_64(
     int8_t *mem_ptr, uint32_t lwe_dimension, uint32_t glwe_dimension,
     uint32_t polynomial_size, uint32_t base_log, uint32_t level_count,
     uint32_t num_samples, uint32_t lut_count, uint32_t lut_stride) {
-  if (base_log > 64)
-    PANIC("Cuda error (classical PBS): base log should be > number of bits "
-          "in the ciphertext representation (64)");
+  if (base_log > 32)
+    PANIC("Cuda error (classical PBS): base log should be <= 32")
 
   pbs_buffer<uint64_t, CLASSICAL> *buffer =
       (pbs_buffer<uint64_t, CLASSICAL> *)mem_ptr;

--- a/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_multibit.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_multibit.cu
@@ -68,9 +68,8 @@ void cuda_cg_multi_bit_programmable_bootstrap_lwe_ciphertext_vector(
     uint32_t base_log, uint32_t level_count, uint32_t num_samples,
     uint32_t lut_count, uint32_t lut_stride) {
 
-  if (base_log > 64)
-    PANIC("Cuda error (multi-bit PBS): base log should be > number of bits in "
-          "the ciphertext representation (64)");
+  if (base_log > 32)
+    PANIC("Cuda error (multi-bit PBS): base log should be <= 32")
 
   switch (polynomial_size) {
   case 256:
@@ -146,9 +145,8 @@ void cuda_multi_bit_programmable_bootstrap_lwe_ciphertext_vector(
     uint32_t base_log, uint32_t level_count, uint32_t num_samples,
     uint32_t lut_count, uint32_t lut_stride) {
 
-  if (base_log > 64)
-    PANIC("Cuda error (multi-bit PBS): base log should be > number of bits in "
-          "the ciphertext representation (64)");
+  if (base_log > 32)
+    PANIC("Cuda error (multi-bit PBS): base log should be <= 32")
 
   switch (polynomial_size) {
   case 256:
@@ -591,9 +589,8 @@ void cuda_tbc_multi_bit_programmable_bootstrap_lwe_ciphertext_vector(
     uint32_t base_log, uint32_t level_count, uint32_t num_samples,
     uint32_t lut_count, uint32_t lut_stride) {
 
-  if (base_log > 64)
-    PANIC("Cuda error (multi-bit PBS): base log should be > number of bits in "
-          "the ciphertext representation (64)");
+  if (base_log > 32)
+    PANIC("Cuda error (multi-bit PBS): base log should be <= 32")
 
   switch (polynomial_size) {
   case 256:


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: https://github.com/zama-ai/tfhe-rs-internal/issues/742

### PR content/description

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
