### PR TITLE
feat(integer): improve shift/rotate by encrypted amount

### DIFF
--- a/tfhe/src/integer/server_key/radix_parallel/bit_extractor.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/bit_extractor.rs
@@ -1,18 +1,45 @@
 use crate::integer::ServerKey;
-use crate::shortint::server_key::LookupTableOwned;
+use crate::shortint::server_key::ManyLookupTableOwned;
 use crate::shortint::Ciphertext;
-use itertools::iproduct;
 use rayon::prelude::*;
+use std::collections::VecDeque;
 
+/// Extracts bits from a slice of shortint ciphertext
+///
+/// * Relies on many-lut to do less PBSes
+/// * Position of the extracted bit is customizable
+/// * Has a buffer system that allows to pre-generate extracted bits such that the next call to
+///   `next()` is free, giving better control as to where computations happen
 pub(crate) struct BitExtractor<'a> {
-    bit_extract_luts: Vec<LookupTableOwned>,
+    input_blocks: std::slice::Iter<'a, Ciphertext>,
+    bit_extract_luts: Option<ManyLookupTableOwned>,
     bits_per_block: usize,
     server_key: &'a ServerKey,
+    buffer: VecDeque<Ciphertext>,
+}
+
+impl<'a> Iterator for BitExtractor<'a> {
+    type Item = Ciphertext;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let maybe_bit_block = self.buffer.pop_front();
+        if maybe_bit_block.is_some() {
+            return maybe_bit_block;
+        }
+
+        self.prepare_next_batch();
+
+        self.buffer.pop_front()
+    }
 }
 
 impl<'a> BitExtractor<'a> {
-    pub(crate) fn new(server_key: &'a ServerKey, bits_per_block: usize) -> Self {
-        Self::with_final_offset(server_key, bits_per_block, 0)
+    pub(crate) fn new(
+        input: &'a [Ciphertext],
+        server_key: &'a ServerKey,
+        bits_per_block: usize,
+    ) -> Self {
+        Self::with_final_offset(input, server_key, bits_per_block, 0)
     }
 
     /// Creates a bit extractor that will extract bits from an input ciphertext
@@ -23,46 +50,130 @@ impl<'a> BitExtractor<'a> {
     /// It may be used to align the bit with a certain position to avoid
     /// shifting it later (and increasing noise)
     pub(crate) fn with_final_offset(
+        input: &'a [Ciphertext],
         server_key: &'a ServerKey,
         bits_per_block: usize,
         final_offset: usize,
     ) -> Self {
-        let bit_extract_luts = (0..bits_per_block)
-            .into_par_iter()
-            .map(|i| {
-                server_key.key.generate_lookup_table(|x| {
-                    let bit_value = (x >> i) & 1;
-                    bit_value << final_offset
+        assert_eq!(
+            server_key.message_modulus().0,
+            server_key.carry_modulus().0,
+            "BitExtractor requires parameters with carry modulus == message modulus"
+        );
+        let bit_extract_luts = if bits_per_block == 1 && final_offset == 0 {
+            None
+        } else {
+            let bit_extract_fns = (0..bits_per_block)
+                .into_par_iter()
+                .map(|i| {
+                    move |x: u64| {
+                        let bit_value = (x >> i) & 1u64;
+                        bit_value << final_offset
+                    }
                 })
-            })
-            .collect::<Vec<_>>();
+                .collect::<Vec<_>>();
+
+            let tmp = bit_extract_fns
+                .iter()
+                .map(|func| func as &dyn Fn(u64) -> u64)
+                .collect::<Vec<_>>();
+
+            Some(server_key.key.generate_many_lookup_table(tmp.as_slice()))
+        };
 
         Self {
+            input_blocks: input.iter(),
             bit_extract_luts,
             bits_per_block,
             server_key,
+            buffer: VecDeque::with_capacity(2 * bits_per_block),
         }
     }
 
-    pub(crate) fn extract_all_bits(&self, blocks: &[Ciphertext]) -> Vec<Ciphertext> {
-        let num_blocks = blocks.len();
-        self.extract_n_bits(blocks, num_blocks * self.bits_per_block)
+    pub(crate) fn set_source_blocks(&mut self, blocks: &'a [Ciphertext]) {
+        self.input_blocks = blocks.iter();
+        self.buffer.clear();
     }
 
-    pub(crate) fn extract_n_bits(&self, blocks: &[Ciphertext], n: usize) -> Vec<Ciphertext> {
-        let num_blocks = blocks.len();
-        let mut bits = Vec::with_capacity(n);
-        let jobs = iproduct!(0..num_blocks, 0..self.bits_per_block)
-            .take(n)
-            .collect::<Vec<_>>();
-        jobs.into_par_iter()
-            .map(|(block_index, bit_index)| {
-                let block = &blocks[block_index];
-                let lut = &self.bit_extract_luts[bit_index];
-                self.server_key.key.apply_lookup_table(block, lut)
-            })
-            .collect_into_vec(&mut bits);
+    pub(crate) fn prepare_next_batch(&mut self) {
+        if self.buffer.is_empty() {
+            let Some(next_block_to_extract_from) = self.input_blocks.next() else {
+                return;
+            };
 
+            match &self.bit_extract_luts {
+                None => self.buffer.push_back(next_block_to_extract_from.clone()),
+                Some(bit_extract_luts) => {
+                    let new_bits = self
+                        .server_key
+                        .key
+                        .apply_many_lookup_table(next_block_to_extract_from, bit_extract_luts);
+
+                    self.buffer.extend(new_bits);
+                }
+            }
+        }
+    }
+
+    pub(crate) fn prepare_all_bits(&mut self) {
+        let num_blocks = self.input_blocks.len();
+        self.prepare_n_bits(num_blocks * self.bits_per_block)
+    }
+
+    /// Extract the remaining `n` bits in parallel from the current source blocks
+    /// and place them into the internal buffer
+    ///
+    /// # Panics
+    ///
+    /// Panics if the current slice of blocks has less than n bits available
+    pub(crate) fn prepare_n_bits(&mut self, n: usize) {
+        if self.buffer.len() >= n {
+            return;
+        }
+
+        let num_bits_to_extract = n - self.buffer.len();
+        let num_blocks_to_process = num_bits_to_extract.div_ceil(self.bits_per_block);
+        let blocks = self.input_blocks.as_slice();
+
+        if let Some(bit_extract_luts) = &self.bit_extract_luts {
+            let mut new_bits = blocks[..num_blocks_to_process]
+                .par_iter()
+                .flat_map(|block| {
+                    self.server_key
+                        .key
+                        .apply_many_lookup_table(block, bit_extract_luts)
+                })
+                .collect::<Vec<_>>();
+            self.buffer.extend(new_bits.drain(..));
+        } else {
+            let iterator = blocks[..num_blocks_to_process].iter().cloned();
+            self.buffer.extend(iterator);
+        };
+
+        // We have to advance our internal iterator
+        self.input_blocks = blocks[num_blocks_to_process..].iter();
+    }
+
+    /// Extract all the remaining bits in parallel from the current source blocks
+    pub(crate) fn extract_all_bits(&mut self) -> Vec<Ciphertext> {
+        let num_blocks = self.input_blocks.len();
+        self.extract_n_bits(num_blocks * self.bits_per_block)
+    }
+
+    /// Extract the remaining `n` bits in parallel from the current source blocks
+    ///
+    /// # Panics
+    ///
+    /// Panics if the current slice of blocks has less than n bits available
+    pub(crate) fn extract_n_bits(&mut self, n: usize) -> Vec<Ciphertext> {
+        self.prepare_n_bits(n);
+
+        let mut bits = Vec::with_capacity(n);
+        bits.extend(self.buffer.drain(0..n));
         bits
+    }
+
+    pub(crate) fn current_buffer_len(&self) -> usize {
+        self.buffer.len()
     }
 }

--- a/tfhe/src/integer/server_key/radix_parallel/block_shift.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/block_shift.rs
@@ -1,0 +1,410 @@
+use crate::integer::server_key::radix_parallel::bit_extractor::BitExtractor;
+use crate::integer::{IntegerRadixCiphertext, RadixCiphertext};
+use crate::shortint::ciphertext::Ciphertext;
+use crate::shortint::parameters::NoiseLevel;
+use crate::shortint::server_key::{LookupTableOwned, ManyLookupTableOwned};
+use std::ops::Range;
+
+use super::super::ServerKey;
+use super::shift::BarrelShifterOperation;
+use rayon::prelude::*;
+
+// This may become its own thing to abstract the use of many many_luts
+// or a vec of lut when it's not possible
+enum ManyLutStrategy {
+    ManyLut(ManyLookupTableOwned),
+    Classical(Vec<LookupTableOwned>),
+}
+
+impl ManyLutStrategy {
+    pub fn execute(&self, server_key: &ServerKey, input: &Ciphertext) -> Vec<Ciphertext> {
+        match self {
+            Self::ManyLut(many_lut) => server_key.key.apply_many_lookup_table(input, many_lut),
+            Self::Classical(luts) => {
+                let mut output = vec![input.clone(); luts.len()];
+
+                output
+                    .par_iter_mut()
+                    .zip(luts.par_iter())
+                    .for_each(|(block, lut)| {
+                        server_key.key.apply_lookup_table_assign(block, lut);
+                    });
+
+                output
+            }
+        }
+    }
+}
+
+impl ServerKey {
+    /// Implementation of the barrel shift to shift/rotate blocks
+    ///
+    /// ct: The ciphertext for which blocks will be shifted/rotated
+    /// shift_bits_extractor: Must be configured such that shift bits blocks returned
+    ///     are in the first carry bit
+    /// d_range: Range of bits to process
+    ///     Note that starting from something else than 0
+    ///     does not mean that the first 'd_range.start' bits from the
+    ///     shift_bits_extractor will be skipped, but rather, the first bit returned
+    ///     by the shift_bits_extractor is actually the `d_range.start`
+    ///     e.g: d_range = 2.. => the first bit of the shift_bits_extractor is
+    ///     actually the bit at index 2
+    /// operation: The operation to perform
+    pub(super) fn block_barrel_shifter_impl<T>(
+        &self,
+        ct: &T,
+        shift_bits_extractor: &mut BitExtractor<'_>,
+        d_range: Range<usize>,
+        operation: BarrelShifterOperation,
+    ) -> T
+    where
+        T: IntegerRadixCiphertext,
+    {
+        if d_range.is_empty() {
+            return ct.clone();
+        }
+
+        assert!(
+            self.key
+                .max_noise_level
+                .validate(NoiseLevel::NOMINAL * 3usize)
+                .is_ok(),
+            "Parameters must support 2 additions before a PBS"
+        );
+        assert!(
+            ct.blocks().iter().all(|block| self
+                .key
+                .max_noise_level
+                .validate(block.noise_level + NoiseLevel::NOMINAL)
+                .is_ok()),
+            "Blocks of ciphertext to be shifted has a noise level too high"
+        );
+        let message_bits_per_block = self.key.message_modulus.0.ilog2() as u64;
+        let carry_bits_per_block = self.key.carry_modulus.0.ilog2() as u64;
+        let num_blocks = ct.blocks().len();
+
+        let message_after_shift_mut = |input| {
+            let control_bit = (input >> message_bits_per_block) % 2;
+            let x = input % self.message_modulus().0 as u64;
+
+            if control_bit == 1 {
+                0
+            } else {
+                x
+            }
+        };
+        let carry_for_next_block = |input| {
+            let control_bit = (input >> message_bits_per_block) % 2;
+            let x = input % self.message_modulus().0 as u64;
+
+            if control_bit == 1 {
+                x
+            } else {
+                0
+            }
+        };
+
+        let luts = if carry_bits_per_block >= 2 {
+            // We can use many lut
+            let many_luts = self
+                .key
+                .generate_many_lookup_table(&[&message_after_shift_mut, &carry_for_next_block]);
+            ManyLutStrategy::ManyLut(many_luts)
+        } else {
+            let luts = vec![
+                self.key.generate_lookup_table(message_after_shift_mut),
+                self.key.generate_lookup_table(carry_for_next_block),
+            ];
+            ManyLutStrategy::Classical(luts)
+        };
+
+        // For signed data, we do an arithmetic right shift, so the padding block
+        // depends on the sign bit
+        let padding_block_lut = if T::IS_SIGNED && operation == BarrelShifterOperation::RightShift {
+            let lut = self.key.generate_lookup_table(|shift_bit_and_last_block| {
+                let last_block = shift_bit_and_last_block % self.message_modulus().0 as u64;
+                let shift_bit = shift_bit_and_last_block >> self.message_modulus().0.ilog2();
+                let sign_bit_pos = self.message_modulus().0.ilog2() - 1;
+                if shift_bit == 1 {
+                    let sign_bit = (last_block >> sign_bit_pos) & 1;
+                    (self.message_modulus().0 - 1) as u64 * sign_bit
+                } else {
+                    0
+                }
+            });
+            Some(lut)
+        } else {
+            None
+        };
+
+        const MSG_INDEX: usize = 0;
+        const CARRY_INDEX: usize = 1;
+        let mut padding_block = self.key.create_trivial(0);
+        let mut current_blocks = ct.blocks().to_vec();
+        let mut d = d_range.start;
+        while let Some(shift_bit) = shift_bits_extractor.next() {
+            assert!(current_blocks.iter().all(|block| {
+                self.key
+                    .max_noise_level
+                    .validate(block.noise_level + shift_bit.noise_level())
+                    .is_ok()
+            }));
+
+            let mut messages_and_carries = Vec::with_capacity(current_blocks.len());
+            rayon::scope(|s| {
+                s.spawn(|_| {
+                    current_blocks
+                        .par_iter_mut()
+                        .map(|block| {
+                            self.key.unchecked_add_assign(block, &shift_bit);
+                            luts.execute(self, block)
+                        })
+                        .collect_into_vec(&mut messages_and_carries);
+                });
+
+                if d < d_range.end - 1 {
+                    s.spawn(|_| {
+                        // Prepare the next batch of shift bits while we are doing a round
+                        shift_bits_extractor.prepare_next_batch();
+                    });
+                }
+
+                if T::IS_SIGNED && operation == BarrelShifterOperation::RightShift {
+                    s.spawn(|_| {
+                        let mut tmp = self
+                            .key
+                            .unchecked_add(&shift_bit, ct.blocks().last().unwrap());
+                        self.key.apply_lookup_table_assign(
+                            &mut tmp,
+                            padding_block_lut.as_ref().unwrap(),
+                        );
+
+                        padding_block = tmp;
+                    });
+                }
+            });
+
+            // copy messages
+            for i in 0..num_blocks {
+                current_blocks[i].clone_from(&messages_and_carries[i][MSG_INDEX]);
+            }
+
+            // align carries
+            match operation {
+                BarrelShifterOperation::LeftShift => {
+                    messages_and_carries.rotate_right(1 << d);
+                    for block_that_wrapped in &mut messages_and_carries[..1 << d] {
+                        block_that_wrapped[CARRY_INDEX].clone_from(&padding_block);
+                    }
+                }
+                BarrelShifterOperation::RightShift => {
+                    messages_and_carries.rotate_left(1 << d);
+                    let blocks_that_wrapped = &mut messages_and_carries[num_blocks - (1 << d)..];
+                    for block_that_wrapped in blocks_that_wrapped {
+                        block_that_wrapped[CARRY_INDEX].clone_from(&padding_block);
+                    }
+                }
+                BarrelShifterOperation::LeftRotate => {
+                    messages_and_carries.rotate_right(1 << d);
+                }
+                BarrelShifterOperation::RightRotate => {
+                    messages_and_carries.rotate_left(1 << d);
+                }
+            }
+
+            for i in 0..num_blocks {
+                self.key.unchecked_add_assign(
+                    &mut current_blocks[i],
+                    &messages_and_carries[i][CARRY_INDEX],
+                );
+            }
+
+            d += 1;
+            if d >= d_range.end {
+                break;
+            }
+        }
+
+        // Reset noise due to last add
+        current_blocks
+            .par_iter_mut()
+            .for_each(|block| self.key.message_extract_assign(block));
+
+        T::from_blocks(current_blocks)
+    }
+
+    /// Shifts/Rotates blocks of the `ct` by the specified `amount`
+    fn block_barrel_shifter<T>(
+        &self,
+        ct: &T,
+        amount: &RadixCiphertext,
+        operation: BarrelShifterOperation,
+    ) -> T
+    where
+        T: IntegerRadixCiphertext,
+    {
+        let message_bits_per_block = self.key.message_modulus.0.ilog2() as u64;
+        let carry_bits_per_block = self.key.carry_modulus.0.ilog2() as u64;
+        let num_blocks = ct.blocks().len();
+
+        // 1 bit for the shift control
+        // 1 another for many lut setting
+        assert!(carry_bits_per_block >= 2);
+
+        let mut max_num_bits_that_tell_shift = num_blocks.ilog2() as u64;
+        // This effectively means, that if the block parameters
+        // give a total_nb_bits that is not a power of two,
+        // then the behaviour of shifting won't be the same
+        // if shift >= total_nb_bits compared to when total_nb_bits
+        // is a power of two, as will 'capture' more bits in `shift_bits`
+        if !num_blocks.is_power_of_two() {
+            max_num_bits_that_tell_shift += 1;
+        }
+
+        // Extracts bits and put them in the bit index 2 (=> bit number 3)
+        // so that it is already aligned to the correct position of the cmux input
+        // and we reduce noise growth
+        let mut shift_bit_extractor = BitExtractor::with_final_offset(
+            &amount.blocks,
+            self,
+            message_bits_per_block as usize,
+            2,
+        );
+        shift_bit_extractor.prepare_all_bits();
+
+        self.block_barrel_shifter_impl(
+            ct,
+            &mut shift_bit_extractor,
+            0..max_num_bits_that_tell_shift as usize,
+            operation,
+        )
+    }
+
+    pub fn unchecked_block_rotate_right<T>(&self, ct: &T, amount: &RadixCiphertext) -> T
+    where
+        T: IntegerRadixCiphertext,
+    {
+        self.block_barrel_shifter(ct, amount, BarrelShifterOperation::RightRotate)
+    }
+
+    pub fn unchecked_block_rotate_left<T>(&self, ct: &T, amount: &RadixCiphertext) -> T
+    where
+        T: IntegerRadixCiphertext,
+    {
+        self.block_barrel_shifter(ct, amount, BarrelShifterOperation::LeftRotate)
+    }
+
+    pub fn unchecked_block_shift_right<T>(&self, ct: &T, amount: &RadixCiphertext) -> T
+    where
+        T: IntegerRadixCiphertext,
+    {
+        self.block_barrel_shifter(ct, amount, BarrelShifterOperation::RightShift)
+    }
+
+    pub fn unchecked_block_shift_left<T>(&self, ct: &T, amount: &RadixCiphertext) -> T
+    where
+        T: IntegerRadixCiphertext,
+    {
+        self.block_barrel_shifter(ct, amount, BarrelShifterOperation::LeftShift)
+    }
+
+    pub fn smart_block_rotate_right<T>(&self, ct: &mut T, amount: &RadixCiphertext) -> T
+    where
+        T: IntegerRadixCiphertext,
+    {
+        if !ct.block_carries_are_empty() {
+            self.full_propagate_parallelized(ct);
+        };
+        self.block_barrel_shifter(ct, amount, BarrelShifterOperation::RightRotate)
+    }
+
+    pub fn smart_block_rotate_left<T>(&self, ct: &mut T, amount: &RadixCiphertext) -> T
+    where
+        T: IntegerRadixCiphertext,
+    {
+        if !ct.block_carries_are_empty() {
+            self.full_propagate_parallelized(ct);
+        };
+        self.block_barrel_shifter(ct, amount, BarrelShifterOperation::LeftRotate)
+    }
+
+    pub fn smart_block_shift_right<T>(&self, ct: &mut T, amount: &RadixCiphertext) -> T
+    where
+        T: IntegerRadixCiphertext,
+    {
+        if !ct.block_carries_are_empty() {
+            self.full_propagate_parallelized(ct);
+        };
+        self.block_barrel_shifter(ct, amount, BarrelShifterOperation::RightShift)
+    }
+
+    pub fn smart_block_shift_left<T>(&self, ct: &mut T, amount: &RadixCiphertext) -> T
+    where
+        T: IntegerRadixCiphertext,
+    {
+        if !ct.block_carries_are_empty() {
+            self.full_propagate_parallelized(ct);
+        };
+        self.block_barrel_shifter(ct, amount, BarrelShifterOperation::LeftShift)
+    }
+
+    pub fn block_rotate_right<T>(&self, ct: &T, amount: &RadixCiphertext) -> T
+    where
+        T: IntegerRadixCiphertext,
+    {
+        let mut tmp_ct;
+        let lhs = if ct.block_carries_are_empty() {
+            ct
+        } else {
+            tmp_ct = ct.clone();
+            self.full_propagate_parallelized(&mut tmp_ct);
+            &tmp_ct
+        };
+        self.block_barrel_shifter(lhs, amount, BarrelShifterOperation::RightRotate)
+    }
+
+    pub fn block_rotate_left<T>(&self, ct: &T, amount: &RadixCiphertext) -> T
+    where
+        T: IntegerRadixCiphertext,
+    {
+        let mut tmp_ct;
+        let lhs = if ct.block_carries_are_empty() {
+            ct
+        } else {
+            tmp_ct = ct.clone();
+            self.full_propagate_parallelized(&mut tmp_ct);
+            &tmp_ct
+        };
+        self.block_barrel_shifter(lhs, amount, BarrelShifterOperation::LeftRotate)
+    }
+
+    pub fn block_shift_right<T>(&self, ct: &T, amount: &RadixCiphertext) -> T
+    where
+        T: IntegerRadixCiphertext,
+    {
+        let mut tmp_ct;
+        let lhs = if ct.block_carries_are_empty() {
+            ct
+        } else {
+            tmp_ct = ct.clone();
+            self.full_propagate_parallelized(&mut tmp_ct);
+            &tmp_ct
+        };
+        self.block_barrel_shifter(lhs, amount, BarrelShifterOperation::RightShift)
+    }
+
+    pub fn block_shift_left<T>(&self, ct: &T, amount: &RadixCiphertext) -> T
+    where
+        T: IntegerRadixCiphertext,
+    {
+        let mut tmp_ct;
+        let lhs = if ct.block_carries_are_empty() {
+            ct
+        } else {
+            tmp_ct = ct.clone();
+            self.full_propagate_parallelized(&mut tmp_ct);
+            &tmp_ct
+        };
+        self.block_barrel_shifter(lhs, amount, BarrelShifterOperation::LeftShift)
+    }
+}

--- a/tfhe/src/integer/server_key/radix_parallel/mod.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/mod.rs
@@ -2,6 +2,7 @@ mod abs;
 mod add;
 mod bit_extractor;
 mod bitwise_op;
+mod block_shift;
 pub(crate) mod cmux;
 mod comparison;
 mod div_mod;

--- a/tfhe/src/integer/server_key/radix_parallel/rotate.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/rotate.rs
@@ -20,7 +20,7 @@ impl ServerKey {
     where
         T: IntegerRadixCiphertext,
     {
-        self.barrel_shifter(ct, n, BarrelShifterOperation::RightRotate);
+        self.unchecked_shift_rotate_bits_assign(ct, n, BarrelShifterOperation::RightRotate);
     }
 
     pub fn smart_rotate_right_assign_parallelized<T>(&self, ct: &mut T, n: &mut RadixCiphertext)
@@ -149,7 +149,7 @@ impl ServerKey {
     where
         T: IntegerRadixCiphertext,
     {
-        self.barrel_shifter(ct, n, BarrelShifterOperation::LeftRotate);
+        self.unchecked_shift_rotate_bits_assign(ct, n, BarrelShifterOperation::LeftRotate);
     }
 
     pub fn smart_rotate_left_assign_parallelized<T>(&self, ct: &mut T, n: &mut RadixCiphertext)

--- a/tfhe/src/integer/server_key/radix_parallel/shift.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/shift.rs
@@ -3,7 +3,7 @@ use crate::integer::server_key::radix_parallel::bit_extractor::BitExtractor;
 use crate::integer::ServerKey;
 use rayon::prelude::*;
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub(super) enum BarrelShifterOperation {
     LeftRotate,
     LeftShift,
@@ -29,7 +29,7 @@ impl ServerKey {
     where
         T: IntegerRadixCiphertext,
     {
-        self.barrel_shifter(ct, shift, BarrelShifterOperation::RightShift);
+        self.unchecked_shift_rotate_bits_assign(ct, shift, BarrelShifterOperation::RightShift);
     }
 
     pub fn smart_right_shift_assign_parallelized<T>(&self, ct: &mut T, shift: &mut RadixCiphertext)
@@ -177,7 +177,7 @@ impl ServerKey {
     where
         T: IntegerRadixCiphertext,
     {
-        self.barrel_shifter(ct, shift, BarrelShifterOperation::LeftShift);
+        self.unchecked_shift_rotate_bits_assign(ct, shift, BarrelShifterOperation::LeftShift);
     }
 
     pub fn smart_left_shift_assign_parallelized<T>(&self, ct: &mut T, shift: &mut RadixCiphertext)
@@ -296,6 +296,374 @@ impl ServerKey {
         ct_res
     }
 
+    /// Does a rotation/shift of bits of the `ct` by the specified `amount`
+    ///
+    /// Input must not have carries
+    pub(super) fn unchecked_shift_rotate_bits_assign<T>(
+        &self,
+        ct: &mut T,
+        amount: &RadixCiphertext,
+        operation: BarrelShifterOperation,
+    ) where
+        T: IntegerRadixCiphertext,
+    {
+        let message_bits_per_block = self.key.message_modulus.0.ilog2() as u64;
+        let carry_bits_per_block = self.key.carry_modulus.0.ilog2() as u64;
+        assert!(carry_bits_per_block >= message_bits_per_block);
+
+        let num_bits = ct.blocks().len() * message_bits_per_block as usize;
+        let mut max_num_bits_that_tell_shift = num_bits.ilog2() as u64;
+        // This effectively means, that if the block parameters
+        // give a total_nb_bits that is not a power of two,
+        // then the behaviour of shifting won't be the same
+        // if shift >= total_nb_bits compared to when total_nb_bits
+        // is a power of two, as will 'capture' more bits in `shift_bits`
+        if !num_bits.is_power_of_two() {
+            max_num_bits_that_tell_shift += 1;
+        }
+
+        if message_bits_per_block == 1 {
+            let mut shift_bit_extractor = BitExtractor::with_final_offset(
+                &amount.blocks,
+                self,
+                message_bits_per_block as usize,
+                message_bits_per_block as usize,
+            );
+
+            // If blocks encrypt one bit, then shifting bits is just shifting blocks
+            let result = self.block_barrel_shifter_impl(
+                ct,
+                &mut shift_bit_extractor,
+                0..max_num_bits_that_tell_shift as usize,
+                operation,
+            );
+
+            *ct = result;
+        } else if message_bits_per_block.is_power_of_two() {
+            let result = self.barrel_shift_bits_pow2_block_modulus(
+                ct,
+                amount,
+                operation,
+                max_num_bits_that_tell_shift as usize,
+            );
+            *ct = result;
+        } else {
+            self.bit_barrel_shifter(ct, amount, operation);
+        }
+    }
+
+    /// Does a rotation/shift of bits of the `ct` by the specified `amount`
+    ///
+    /// Uses a barrel shifter implementation
+    ///
+    /// # Note
+    ///
+    /// This only works for parameters where blocks encrypts a number of bits
+    /// of message that is a power of 2 (e.g. 1 bit, 2 bit, 4 bits, but not 3 bits)
+    pub(super) fn barrel_shift_bits_pow2_block_modulus<T>(
+        &self,
+        ct: &T,
+        amount: &RadixCiphertext,
+        operation: BarrelShifterOperation,
+        max_num_bits_that_tell_shift: usize,
+    ) -> T
+    where
+        T: IntegerRadixCiphertext,
+    {
+        let message_bits_per_block = self.key.message_modulus.0.ilog2() as u64;
+        let carry_bits_per_block = self.key.carry_modulus.0.ilog2() as u64;
+        assert!(carry_bits_per_block >= message_bits_per_block);
+
+        // Extracts bits and put them in the bit index 2 (=> bit number 3)
+        // so that it is already aligned to the correct position of the cmux input,
+        // and we reduce noise growth
+        let mut shift_bit_extractor = BitExtractor::with_final_offset(
+            &amount.blocks,
+            self,
+            message_bits_per_block as usize,
+            message_bits_per_block as usize,
+        );
+
+        assert!(message_bits_per_block.is_power_of_two());
+
+        let message_for_block =
+            self.key
+                .generate_lookup_table_bivariate(|input, first_shift_block| {
+                    let shift_within_block = first_shift_block % message_bits_per_block;
+                    let shift_to_next_block = (first_shift_block / message_bits_per_block) % 2;
+
+                    let b = match operation {
+                        BarrelShifterOperation::LeftShift | BarrelShifterOperation::LeftRotate => {
+                            (input << shift_within_block) % self.message_modulus().0 as u64
+                        }
+                        BarrelShifterOperation::RightShift
+                        | BarrelShifterOperation::RightRotate => {
+                            (input >> shift_within_block) % self.message_modulus().0 as u64
+                        }
+                    };
+
+                    if shift_to_next_block == 1 {
+                        0
+                    } else {
+                        b
+                    }
+                });
+        let message_for_next_block =
+            self.key
+                .generate_lookup_table_bivariate(|previous, first_shift_block| {
+                    let shift_within_block = first_shift_block % message_bits_per_block;
+                    let shift_to_next_block = (first_shift_block / message_bits_per_block) % 2;
+
+                    if shift_to_next_block == 1 {
+                        // We get the message part of the previous block
+                        match operation {
+                            BarrelShifterOperation::LeftShift
+                            | BarrelShifterOperation::LeftRotate => {
+                                (previous << shift_within_block) % self.message_modulus().0 as u64
+                            }
+                            BarrelShifterOperation::RightShift
+                            | BarrelShifterOperation::RightRotate => {
+                                (previous >> shift_within_block) % self.message_modulus().0 as u64
+                            }
+                        }
+                    } else {
+                        // We get the carry part of the previous block
+                        match operation {
+                            BarrelShifterOperation::LeftShift
+                            | BarrelShifterOperation::LeftRotate => {
+                                previous >> (message_bits_per_block - shift_within_block)
+                            }
+                            BarrelShifterOperation::RightShift
+                            | BarrelShifterOperation::RightRotate => {
+                                (previous << (message_bits_per_block - shift_within_block))
+                                    % self.message_modulus().0 as u64
+                            }
+                        }
+                    }
+                });
+
+        let message_for_next_next_block =
+            self.key
+                .generate_lookup_table_bivariate(|previous_previous, first_shift_block| {
+                    let shift_within_block = first_shift_block % message_bits_per_block;
+                    let shift_to_next_block = (first_shift_block / message_bits_per_block) % 2;
+
+                    if shift_to_next_block == 1 {
+                        // We get the carry part of the previous block
+                        match operation {
+                            BarrelShifterOperation::LeftShift
+                            | BarrelShifterOperation::LeftRotate => {
+                                previous_previous >> (message_bits_per_block - shift_within_block)
+                            }
+                            BarrelShifterOperation::RightShift
+                            | BarrelShifterOperation::RightRotate => {
+                                (previous_previous << (message_bits_per_block - shift_within_block))
+                                    % self.message_modulus().0 as u64
+                            }
+                        }
+                    } else {
+                        // Nothing reaches that block
+                        0
+                    }
+                });
+
+        // When doing right shift of a signed ciphertext, we do an arithmetic shift
+        // Thus, we need some special luts to be used on the last block
+        // (which has the sign big)
+        let message_for_block_right_shift_signed =
+            if T::IS_SIGNED && operation == BarrelShifterOperation::RightShift {
+                let lut = self
+                    .key
+                    .generate_lookup_table_bivariate(|input, first_shift_block| {
+                        let shift_within_block = first_shift_block % message_bits_per_block;
+                        let shift_to_next_block = (first_shift_block / message_bits_per_block) % 2;
+
+                        let sign_bit_pos = message_bits_per_block - 1;
+                        let sign_bit = (input >> sign_bit_pos) & 1;
+                        let padding_block = (self.message_modulus().0 - 1) as u64 * sign_bit;
+
+                        if shift_to_next_block == 1 {
+                            padding_block
+                        } else {
+                            // Pad with sign bits to 'simulate' an arithmetic shift
+                            let input = (padding_block << message_bits_per_block) | input;
+                            (input >> shift_within_block) % self.message_modulus().0 as u64
+                        }
+                    });
+                Some(lut)
+            } else {
+                None
+            };
+
+        let message_for_next_block_right_shift_signed = if T::IS_SIGNED
+            && operation == BarrelShifterOperation::RightShift
+        {
+            let lut = self
+                .key
+                .generate_lookup_table_bivariate(|previous, first_shift_block| {
+                    let shift_within_block = first_shift_block % message_bits_per_block;
+                    let shift_to_next_block = (first_shift_block / message_bits_per_block) % 2;
+
+                    let sign_bit_pos = message_bits_per_block - 1;
+                    let sign_bit = (previous >> sign_bit_pos) & 1;
+                    let padding_block = (self.message_modulus().0 - 1) as u64 * sign_bit;
+
+                    if shift_to_next_block == 1 {
+                        // Pad with sign bits to 'simulate' an arithmetic shift
+                        let previous = (padding_block << message_bits_per_block) | previous;
+                        // We get the message part of the previous block
+                        (previous >> shift_within_block) % self.message_modulus().0 as u64
+                    } else {
+                        // We get the carry part of the previous block
+                        (previous << (message_bits_per_block - shift_within_block))
+                            % self.message_modulus().0 as u64
+                    }
+                });
+            Some(lut)
+        } else {
+            None
+        };
+
+        let mut messages = ct.blocks().to_vec();
+        let mut messages_for_next_blocks = ct.blocks().to_vec();
+        let mut messages_for_next_next_blocks = ct.blocks().to_vec();
+        let first_block = &amount.blocks[0];
+        let num_blocks = ct.blocks().len();
+        rayon::scope(|s| {
+            s.spawn(|_| {
+                messages.par_iter_mut().enumerate().for_each(|(i, block)| {
+                    let lut = if T::IS_SIGNED
+                        && operation == BarrelShifterOperation::RightShift
+                        && i == num_blocks - 1
+                    {
+                        message_for_block_right_shift_signed.as_ref().unwrap()
+                    } else {
+                        &message_for_block
+                    };
+                    self.key
+                        .unchecked_apply_lookup_table_bivariate_assign(block, first_block, lut);
+                });
+            });
+
+            s.spawn(|_| {
+                let range = match operation {
+                    BarrelShifterOperation::RightShift => {
+                        messages_for_next_blocks[0] = self.key.create_trivial(0);
+                        1..num_blocks
+                    }
+                    BarrelShifterOperation::LeftShift => {
+                        messages_for_next_blocks[num_blocks - 1] = self.key.create_trivial(0);
+                        0..num_blocks - 1
+                    }
+                    BarrelShifterOperation::LeftRotate | BarrelShifterOperation::RightRotate => {
+                        0..num_blocks
+                    }
+                };
+
+                let range_len = range.len();
+                messages_for_next_blocks[range]
+                    .par_iter_mut()
+                    .enumerate()
+                    .for_each(|(i, block)| {
+                        let lut = if T::IS_SIGNED
+                            && operation == BarrelShifterOperation::RightShift
+                            && i == range_len - 1
+                        {
+                            message_for_next_block_right_shift_signed.as_ref().unwrap()
+                        } else {
+                            &message_for_next_block
+                        };
+                        self.key.unchecked_apply_lookup_table_bivariate_assign(
+                            block,
+                            first_block,
+                            lut,
+                        );
+                    });
+            });
+
+            s.spawn(|_| {
+                let range = match operation {
+                    BarrelShifterOperation::RightShift => {
+                        messages_for_next_next_blocks[0] = self.key.create_trivial(0);
+                        messages_for_next_next_blocks[1] = self.key.create_trivial(0);
+                        2..num_blocks
+                    }
+                    BarrelShifterOperation::LeftShift => {
+                        messages_for_next_next_blocks[num_blocks - 1] = self.key.create_trivial(0);
+                        messages_for_next_next_blocks[num_blocks - 2] = self.key.create_trivial(0);
+                        0..num_blocks - 2
+                    }
+                    BarrelShifterOperation::LeftRotate | BarrelShifterOperation::RightRotate => {
+                        0..num_blocks
+                    }
+                };
+                messages_for_next_next_blocks[range]
+                    .par_iter_mut()
+                    .for_each(|block| {
+                        self.key.unchecked_apply_lookup_table_bivariate_assign(
+                            block,
+                            first_block,
+                            &message_for_next_next_block,
+                        );
+                    });
+            });
+
+            s.spawn(|_| {
+                let num_bit_that_tells_shift_within_blocks = message_bits_per_block.ilog2();
+                let num_bits_already_done = num_bit_that_tells_shift_within_blocks + 1;
+                if u64::from(num_bits_already_done) == message_bits_per_block {
+                    shift_bit_extractor.set_source_blocks(&amount.blocks[1..]);
+                    shift_bit_extractor.prepare_next_batch();
+                } else {
+                    shift_bit_extractor.prepare_next_batch();
+                    assert!(
+                        shift_bit_extractor.current_buffer_len() > num_bits_already_done as usize
+                    );
+                    // Now remove bits that where used for the 'shift within blocks'
+                    for _ in 0..num_bits_already_done {
+                        let _ = shift_bit_extractor.next().unwrap();
+                    }
+                }
+            });
+        });
+
+        // 0 should never be possible
+        assert!(shift_bit_extractor.current_buffer_len() >= 1);
+
+        match operation {
+            BarrelShifterOperation::LeftShift | BarrelShifterOperation::LeftRotate => {
+                messages_for_next_blocks.rotate_right(1);
+                messages_for_next_next_blocks.rotate_right(2);
+            }
+            BarrelShifterOperation::RightShift | BarrelShifterOperation::RightRotate => {
+                messages_for_next_blocks.rotate_left(1);
+                messages_for_next_next_blocks.rotate_left(2);
+            }
+        }
+
+        for (m0, (m1, m2)) in messages.iter_mut().zip(
+            messages_for_next_blocks
+                .iter()
+                .zip(messages_for_next_next_blocks.iter()),
+        ) {
+            self.key.unchecked_add_assign(m0, m1);
+            self.key.unchecked_add_assign(m0, m2);
+        }
+
+        let radix = T::from_blocks(messages);
+
+        let num_bit_that_tells_shift_within_blocks = message_bits_per_block.ilog2();
+        let num_bits_already_done = num_bit_that_tells_shift_within_blocks + 1;
+        self.block_barrel_shifter_impl(
+            &radix,
+            &mut shift_bit_extractor,
+            // We already did the first block rotation so we start at 1
+            // And do + 1 as the range is exclusive
+            1..max_num_bits_that_tell_shift - num_bits_already_done as usize + 1,
+            operation,
+        )
+    }
+
     /// This implements a "barrel shifter".
     ///
     /// This construct is what is used in hardware to
@@ -317,7 +685,7 @@ impl ServerKey {
     /// thus, any bit that are higher than log2(16) will be removed
     ///
     /// `ct` will be assigned the result, and it will be in a fresh state
-    pub(super) fn barrel_shifter<T>(
+    pub(super) fn bit_barrel_shifter<T>(
         &self,
         ct: &mut T,
         shift: &RadixCiphertext,
@@ -337,8 +705,9 @@ impl ServerKey {
 
         let (bits, shift_bits) = rayon::join(
             || {
-                let bit_extractor = BitExtractor::new(self, message_bits_per_block as usize);
-                bit_extractor.extract_all_bits(ct.blocks())
+                let mut bit_extractor =
+                    BitExtractor::new(ct.blocks(), self, message_bits_per_block as usize);
+                bit_extractor.extract_all_bits()
             },
             || {
                 let mut max_num_bits_that_tell_shift = total_nb_bits.ilog2() as u64;
@@ -354,9 +723,13 @@ impl ServerKey {
                 // Extracts bits and put them in the bit index 2 (=> bit number 3)
                 // so that it is already aligned to the correct position of the cmux input
                 // and we reduce noise growth
-                let bit_extractor =
-                    BitExtractor::with_final_offset(self, message_bits_per_block as usize, 2);
-                bit_extractor.extract_n_bits(&shift.blocks, max_num_bits_that_tell_shift as usize)
+                let mut bit_extractor = BitExtractor::with_final_offset(
+                    &shift.blocks,
+                    self,
+                    message_bits_per_block as usize,
+                    2,
+                );
+                bit_extractor.extract_n_bits(max_num_bits_that_tell_shift as usize)
             },
         );
 
@@ -453,7 +826,10 @@ impl ServerKey {
 
         // rename for clarity
         let mut output_bits = input_bits_a;
-        assert!(output_bits.len() == message_bits_per_block as usize * num_blocks);
+        assert_eq!(
+            output_bits.len(),
+            message_bits_per_block as usize * num_blocks
+        );
         // We have to reconstruct blocks from the individual bits
         output_bits
             .as_mut_slice()

--- a/tfhe/src/integer/server_key/radix_parallel/tests_signed/test_rotate.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_signed/test_rotate.rs
@@ -17,85 +17,13 @@ use crate::shortint::parameters::*;
 use rand::Rng;
 use std::sync::Arc;
 
-create_parametrized_test!(
-    integer_signed_unchecked_rotate_right {
-        coverage => {
-            COVERAGE_PARAM_MESSAGE_2_CARRY_2_KS_PBS,
-            COVERAGE_PARAM_MULTI_BIT_MESSAGE_2_CARRY_2_GROUP_2_KS_PBS,
-        },
-        no_coverage => {
-            // Requires 4 bits, so 1_1 parameters are not supported
-            // until they get their own version of the algorithm
-            PARAM_MESSAGE_2_CARRY_2_KS_PBS,
-            PARAM_MESSAGE_3_CARRY_3_KS_PBS,
-            PARAM_MESSAGE_4_CARRY_4_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_2_CARRY_2_GROUP_2_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_3_CARRY_3_GROUP_2_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_2_CARRY_2_GROUP_3_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_3_CARRY_3_GROUP_3_KS_PBS,
-        }
-    }
-);
+create_parametrized_test!(integer_signed_unchecked_rotate_right);
 
-create_parametrized_test!(
-    integer_signed_unchecked_rotate_left {
-        coverage => {
-            COVERAGE_PARAM_MESSAGE_2_CARRY_2_KS_PBS,
-            COVERAGE_PARAM_MULTI_BIT_MESSAGE_2_CARRY_2_GROUP_2_KS_PBS,
-        },
-        no_coverage => {
-            // Requires 4 bits, so 1_1 parameters are not supported
-            // until they get their own version of the algorithm
-            PARAM_MESSAGE_2_CARRY_2_KS_PBS,
-            PARAM_MESSAGE_3_CARRY_3_KS_PBS,
-            PARAM_MESSAGE_4_CARRY_4_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_2_CARRY_2_GROUP_2_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_3_CARRY_3_GROUP_2_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_2_CARRY_2_GROUP_3_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_3_CARRY_3_GROUP_3_KS_PBS,
-        }
-    }
-);
+create_parametrized_test!(integer_signed_unchecked_rotate_left);
 
-create_parametrized_test!(
-    integer_signed_rotate_right {
-        coverage => {
-            COVERAGE_PARAM_MESSAGE_2_CARRY_2_KS_PBS,
-            COVERAGE_PARAM_MULTI_BIT_MESSAGE_2_CARRY_2_GROUP_2_KS_PBS,
-        },
-        no_coverage => {
-            // Requires 4 bits, so 1_1 parameters are not supported
-            // until they get their own version of the algorithm
-            PARAM_MESSAGE_2_CARRY_2_KS_PBS,
-            PARAM_MESSAGE_3_CARRY_3_KS_PBS,
-            PARAM_MESSAGE_4_CARRY_4_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_2_CARRY_2_GROUP_2_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_3_CARRY_3_GROUP_2_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_2_CARRY_2_GROUP_3_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_3_CARRY_3_GROUP_3_KS_PBS,
-        }
-    }
-);
+create_parametrized_test!(integer_signed_rotate_right);
 
-create_parametrized_test!(
-    integer_signed_rotate_left {
-        coverage => {
-            COVERAGE_PARAM_MESSAGE_2_CARRY_2_KS_PBS,
-            COVERAGE_PARAM_MULTI_BIT_MESSAGE_2_CARRY_2_GROUP_2_KS_PBS,
-        },
-        no_coverage => {
-            // Requires 4 bits, so 1_1 parameters are not supported
-            // until they get their own version of the algorithm
-            PARAM_MESSAGE_2_CARRY_2_KS_PBS,
-            PARAM_MESSAGE_3_CARRY_3_KS_PBS,
-            PARAM_MESSAGE_4_CARRY_4_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_2_CARRY_2_GROUP_2_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_3_CARRY_3_GROUP_2_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_2_CARRY_2_GROUP_3_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_3_CARRY_3_GROUP_3_KS_PBS,
-        }
-    }
-);
+create_parametrized_test!(integer_signed_rotate_left);
 
 pub(crate) fn signed_default_rotate_left_test<P, T>(param: P, mut executor: T)
 where

--- a/tfhe/src/integer/server_key/radix_parallel/tests_signed/test_shift.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_signed/test_shift.rs
@@ -17,83 +17,11 @@ use crate::shortint::parameters::*;
 use rand::Rng;
 use std::sync::Arc;
 
-create_parametrized_test!(
-    integer_signed_unchecked_left_shift {
-        coverage => {
-            COVERAGE_PARAM_MESSAGE_2_CARRY_2_KS_PBS,
-            COVERAGE_PARAM_MULTI_BIT_MESSAGE_2_CARRY_2_GROUP_2_KS_PBS,
-        },
-        no_coverage => {
-            // Requires 3 bits, so 1_1 parameters are not supported
-            // until they get their own version of the algorithm
-            PARAM_MESSAGE_2_CARRY_2_KS_PBS,
-            PARAM_MESSAGE_3_CARRY_3_KS_PBS,
-            PARAM_MESSAGE_4_CARRY_4_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_2_CARRY_2_GROUP_2_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_3_CARRY_3_GROUP_2_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_2_CARRY_2_GROUP_3_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_3_CARRY_3_GROUP_3_KS_PBS,
-        }
-    }
-);
+create_parametrized_test!(integer_signed_unchecked_left_shift);
 
-create_parametrized_test!(
-    integer_signed_unchecked_right_shift{
-        coverage => {
-            COVERAGE_PARAM_MESSAGE_2_CARRY_2_KS_PBS,
-            COVERAGE_PARAM_MULTI_BIT_MESSAGE_2_CARRY_2_GROUP_2_KS_PBS,
-        },
-        no_coverage => {
-            // Requires 3 bits, so 1_1 parameters are not supported
-            // until they get their own version of the algorithm
-            PARAM_MESSAGE_2_CARRY_2_KS_PBS,
-            PARAM_MESSAGE_3_CARRY_3_KS_PBS,
-            PARAM_MESSAGE_4_CARRY_4_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_2_CARRY_2_GROUP_2_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_3_CARRY_3_GROUP_2_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_2_CARRY_2_GROUP_3_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_3_CARRY_3_GROUP_3_KS_PBS,
-        }
-    }
-);
-create_parametrized_test!(
-    integer_signed_left_shift{
-        coverage => {
-            COVERAGE_PARAM_MESSAGE_2_CARRY_2_KS_PBS,
-            COVERAGE_PARAM_MULTI_BIT_MESSAGE_2_CARRY_2_GROUP_2_KS_PBS,
-        },
-        no_coverage => {
-            // Requires 3 bits, so 1_1 parameters are not supported
-            // until they get their own version of the algorithm
-            PARAM_MESSAGE_2_CARRY_2_KS_PBS,
-            PARAM_MESSAGE_3_CARRY_3_KS_PBS,
-            PARAM_MESSAGE_4_CARRY_4_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_2_CARRY_2_GROUP_2_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_3_CARRY_3_GROUP_2_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_2_CARRY_2_GROUP_3_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_3_CARRY_3_GROUP_3_KS_PBS,
-        }
-    }
-);
-create_parametrized_test!(
-    integer_signed_right_shift{
-        coverage => {
-            COVERAGE_PARAM_MESSAGE_2_CARRY_2_KS_PBS,
-            COVERAGE_PARAM_MULTI_BIT_MESSAGE_2_CARRY_2_GROUP_2_KS_PBS,
-        },
-        no_coverage => {
-            // Requires 3 bits, so 1_1 parameters are not supported
-            // until they get their own version of the algorithm
-            PARAM_MESSAGE_2_CARRY_2_KS_PBS,
-            PARAM_MESSAGE_3_CARRY_3_KS_PBS,
-            PARAM_MESSAGE_4_CARRY_4_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_2_CARRY_2_GROUP_2_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_3_CARRY_3_GROUP_2_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_2_CARRY_2_GROUP_3_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_3_CARRY_3_GROUP_3_KS_PBS,
-        }
-    }
-);
+create_parametrized_test!(integer_signed_unchecked_right_shift);
+create_parametrized_test!(integer_signed_left_shift);
+create_parametrized_test!(integer_signed_right_shift);
 
 pub(crate) fn signed_default_left_shift_test<P, T>(param: P, mut executor: T)
 where

--- a/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_rotate.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_rotate.rs
@@ -9,85 +9,13 @@ use crate::integer::ServerKey;
 use crate::shortint::parameters::coverage_parameters::*;
 use crate::shortint::parameters::*;
 
-create_parametrized_test!(
-    integer_unchecked_rotate_right {
-        coverage => {
-            COVERAGE_PARAM_MESSAGE_2_CARRY_2_KS_PBS,
-            COVERAGE_PARAM_MULTI_BIT_MESSAGE_2_CARRY_2_GROUP_2_KS_PBS,
-        },
-        no_coverage => {
-            // Requires 4 bits, so 1_1 parameters are not supported
-            // until they get their own version of the algorithm
-            PARAM_MESSAGE_2_CARRY_2_KS_PBS,
-            PARAM_MESSAGE_3_CARRY_3_KS_PBS,
-            PARAM_MESSAGE_4_CARRY_4_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_2_CARRY_2_GROUP_2_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_3_CARRY_3_GROUP_2_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_2_CARRY_2_GROUP_3_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_3_CARRY_3_GROUP_3_KS_PBS,
-        }
-    }
-);
+create_parametrized_test!(integer_unchecked_rotate_right);
 
-create_parametrized_test!(
-    integer_unchecked_rotate_left {
-        coverage => {
-            COVERAGE_PARAM_MESSAGE_2_CARRY_2_KS_PBS,
-            COVERAGE_PARAM_MULTI_BIT_MESSAGE_2_CARRY_2_GROUP_2_KS_PBS,
-        },
-        no_coverage => {
-            // Requires 4 bits, so 1_1 parameters are not supported
-            // until they get their own version of the algorithm
-            PARAM_MESSAGE_2_CARRY_2_KS_PBS,
-            PARAM_MESSAGE_3_CARRY_3_KS_PBS,
-            PARAM_MESSAGE_4_CARRY_4_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_2_CARRY_2_GROUP_2_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_3_CARRY_3_GROUP_2_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_2_CARRY_2_GROUP_3_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_3_CARRY_3_GROUP_3_KS_PBS,
-        }
-    }
-);
+create_parametrized_test!(integer_unchecked_rotate_left);
 
-create_parametrized_test!(
-    integer_rotate_right {
-        coverage => {
-            COVERAGE_PARAM_MESSAGE_2_CARRY_2_KS_PBS,
-            COVERAGE_PARAM_MULTI_BIT_MESSAGE_2_CARRY_2_GROUP_2_KS_PBS,
-        },
-        no_coverage => {
-            // Requires 4 bits, so 1_1 parameters are not supported
-            // until they get their own version of the algorithm
-            PARAM_MESSAGE_2_CARRY_2_KS_PBS,
-            PARAM_MESSAGE_3_CARRY_3_KS_PBS,
-            PARAM_MESSAGE_4_CARRY_4_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_2_CARRY_2_GROUP_2_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_3_CARRY_3_GROUP_2_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_2_CARRY_2_GROUP_3_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_3_CARRY_3_GROUP_3_KS_PBS,
-        }
-    }
-);
+create_parametrized_test!(integer_rotate_right);
 
-create_parametrized_test!(
-    integer_rotate_left {
-        coverage => {
-            COVERAGE_PARAM_MESSAGE_2_CARRY_2_KS_PBS,
-            COVERAGE_PARAM_MULTI_BIT_MESSAGE_2_CARRY_2_GROUP_2_KS_PBS,
-        },
-        no_coverage => {
-            // Requires 4 bits, so 1_1 parameters are not supported
-            // until they get their own version of the algorithm
-            PARAM_MESSAGE_2_CARRY_2_KS_PBS,
-            PARAM_MESSAGE_3_CARRY_3_KS_PBS,
-            PARAM_MESSAGE_4_CARRY_4_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_2_CARRY_2_GROUP_2_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_3_CARRY_3_GROUP_2_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_2_CARRY_2_GROUP_3_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_3_CARRY_3_GROUP_3_KS_PBS,
-        }
-    }
-);
+create_parametrized_test!(integer_rotate_left);
 
 fn integer_unchecked_rotate_right<P>(param: P)
 where

--- a/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_shift.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_shift.rs
@@ -9,83 +9,11 @@ use crate::integer::ServerKey;
 use crate::shortint::parameters::coverage_parameters::*;
 use crate::shortint::parameters::*;
 
-create_parametrized_test!(
-    integer_unchecked_left_shift {
-        coverage => {
-            COVERAGE_PARAM_MESSAGE_2_CARRY_2_KS_PBS,
-            COVERAGE_PARAM_MULTI_BIT_MESSAGE_2_CARRY_2_GROUP_2_KS_PBS,
-        },
-        no_coverage => {
-            // Requires 3 bits, so 1_1 parameters are not supported
-            // until they get their own version of the algorithm
-            PARAM_MESSAGE_2_CARRY_2_KS_PBS,
-            PARAM_MESSAGE_3_CARRY_3_KS_PBS,
-            PARAM_MESSAGE_4_CARRY_4_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_2_CARRY_2_GROUP_2_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_3_CARRY_3_GROUP_2_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_2_CARRY_2_GROUP_3_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_3_CARRY_3_GROUP_3_KS_PBS,
-        }
-    }
-);
+create_parametrized_test!(integer_unchecked_left_shift);
 
-create_parametrized_test!(
-    integer_unchecked_right_shift{
-        coverage => {
-            COVERAGE_PARAM_MESSAGE_2_CARRY_2_KS_PBS,
-            COVERAGE_PARAM_MULTI_BIT_MESSAGE_2_CARRY_2_GROUP_2_KS_PBS,
-        },
-        no_coverage => {
-            // Requires 3 bits, so 1_1 parameters are not supported
-            // until they get their own version of the algorithm
-            PARAM_MESSAGE_2_CARRY_2_KS_PBS,
-            PARAM_MESSAGE_3_CARRY_3_KS_PBS,
-            PARAM_MESSAGE_4_CARRY_4_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_2_CARRY_2_GROUP_2_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_3_CARRY_3_GROUP_2_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_2_CARRY_2_GROUP_3_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_3_CARRY_3_GROUP_3_KS_PBS,
-        }
-    }
-);
-create_parametrized_test!(
-    integer_left_shift{
-        coverage => {
-            COVERAGE_PARAM_MESSAGE_2_CARRY_2_KS_PBS,
-            COVERAGE_PARAM_MULTI_BIT_MESSAGE_2_CARRY_2_GROUP_2_KS_PBS,
-        },
-        no_coverage => {
-            // Requires 3 bits, so 1_1 parameters are not supported
-            // until they get their own version of the algorithm
-            PARAM_MESSAGE_2_CARRY_2_KS_PBS,
-            PARAM_MESSAGE_3_CARRY_3_KS_PBS,
-            PARAM_MESSAGE_4_CARRY_4_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_2_CARRY_2_GROUP_2_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_3_CARRY_3_GROUP_2_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_2_CARRY_2_GROUP_3_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_3_CARRY_3_GROUP_3_KS_PBS,
-        }
-    }
-);
-create_parametrized_test!(
-    integer_right_shift{
-        coverage => {
-            COVERAGE_PARAM_MESSAGE_2_CARRY_2_KS_PBS,
-            COVERAGE_PARAM_MULTI_BIT_MESSAGE_2_CARRY_2_GROUP_2_KS_PBS,
-        },
-        no_coverage => {
-            // Requires 3 bits, so 1_1 parameters are not supported
-            // until they get their own version of the algorithm
-            PARAM_MESSAGE_2_CARRY_2_KS_PBS,
-            PARAM_MESSAGE_3_CARRY_3_KS_PBS,
-            PARAM_MESSAGE_4_CARRY_4_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_2_CARRY_2_GROUP_2_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_3_CARRY_3_GROUP_2_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_2_CARRY_2_GROUP_3_KS_PBS,
-            PARAM_MULTI_BIT_MESSAGE_3_CARRY_3_GROUP_3_KS_PBS,
-        }
-    }
-);
+create_parametrized_test!(integer_unchecked_right_shift);
+create_parametrized_test!(integer_left_shift);
+create_parametrized_test!(integer_right_shift);
 
 fn integer_unchecked_right_shift<P>(param: P)
 where


### PR DESCRIPTION
This commit does a few things:
* Changes the BitExtractor to use many_lut to reduce number of PBS done
* Add blocks rotation/shift operation
* Implement a new algorithm for bit shift/rotation by encrypted amounts
* Add support bit shift/rotation for 1_1 parameters (as result of adding block shift/rotation)

The gist of the new bit shift/rotation is to use the same idea as the scalar version where we first shift blocks between adjacent blocks, then use a rotation of blocks.

Doing this requires to do a division and modulo operation:
```rust
let (shift_within_blocks, block_rotations) =
  (amount / bits_per_block, amount % bits_per_block)
```
When `amount` is clear this operation is simple, when `amount` is encrypted then is harder (`bits_per_block` is always clear). However, when bits_per_block is a power of 2 (e.g 1, 2, 4) `/` and `%` can be made by shifting and bit-masking, which are simple operations.

This means the new algorithm is only compatible with 1_1, 2_2, 4_4 but not 3_3.
The new algorithm improves the latency as well as the throughput as it requires less PBS in total

<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
