### PR TITLE
chore(ci): fix firefox wasm benchmarks with new aws ami

### DIFF
--- a/.github/workflows/aws_tfhe_fast_tests.yml
+++ b/.github/workflows/aws_tfhe_fast_tests.yml
@@ -156,10 +156,6 @@ jobs:
           persist-credentials: 'false'
           token: ${{ secrets.FHE_ACTIONS_TOKEN }}
 
-      - name: Set up home
-        run: |
-          echo "HOME=/home/ubuntu" >> "${GITHUB_ENV}"
-
       - name: Install latest stable
         uses: dtolnay/rust-toolchain@7b1c307e0dcbda6122208f10795a713336a9b35a
         with:
@@ -198,7 +194,8 @@ jobs:
       - name: Run js on wasm API tests
         if: needs.should-run.outputs.wasm_test == 'true'
         run: |
-          make test_nodejs_wasm_api_in_docker
+          make install_node
+          make test_nodejs_wasm_api_ci
 
       - name: Gen Keys if required
         if: needs.should-run.outputs.shortint_test == 'true' ||

--- a/.github/workflows/aws_tfhe_wasm_tests.yml
+++ b/.github/workflows/aws_tfhe_wasm_tests.yml
@@ -50,10 +50,6 @@ jobs:
           persist-credentials: 'false'
           token: ${{ secrets.FHE_ACTIONS_TOKEN }}
 
-      - name: Set up home
-        run: |
-          echo "HOME=/home/ubuntu" >> "${GITHUB_ENV}"
-
       - name: Install latest stable
         uses: dtolnay/rust-toolchain@7b1c307e0dcbda6122208f10795a713336a9b35a
         with:
@@ -71,7 +67,7 @@ jobs:
 
       - name: Run js on wasm API tests
         run: |
-          make test_nodejs_wasm_api_in_docker
+          make test_nodejs_wasm_api_ci
 
       - name: Run parallel wasm tests
         run: |

--- a/.github/workflows/benchmark_wasm_client.yml
+++ b/.github/workflows/benchmark_wasm_client.yml
@@ -97,11 +97,6 @@ jobs:
             echo "COMMIT_HASH=$(git describe --tags --dirty)";
           } >> "${GITHUB_ENV}"
 
-      - name: Set up home
-        # "Install rust" step require root user to have a HOME directory which is not set.
-        run: |
-          echo "HOME=/home/ubuntu" >> "${GITHUB_ENV}"
-
       - name: Install rust
         uses: dtolnay/rust-toolchain@7b1c307e0dcbda6122208f10795a713336a9b35a
         with:

--- a/ci/slab.toml
+++ b/ci/slab.toml
@@ -1,6 +1,6 @@
 [backend.aws.cpu-big]
 region = "eu-west-3"
-image_id = "ami-09b5f2f71828035d4"
+image_id = "ami-0cd5012d17ae64070"
 instance_type = "m6i.32xlarge"
 
 [backend.aws.cpu-big_fallback]
@@ -10,8 +10,9 @@ instance_type = "m6i.32xlarge"
 
 [backend.aws.cpu-small]
 region = "eu-west-3"
-image_id = "ami-09b5f2f71828035d4"
+image_id = "ami-0cd5012d17ae64070"
 instance_type = "m6i.4xlarge"
+user = "ubuntu"
 
 [backend.aws.bench]
 region = "eu-west-1"


### PR DESCRIPTION
Some libs were missing to be able to run Firefox out of the box. Besides, action runner is now installed as ubuntu user since Firefox is not able to run as root.