### PR TITLE
chore(ci): rename benchmark parsing option to object-sizes

### DIFF
--- a/.github/workflows/benchmark_boolean.yml
+++ b/.github/workflows/benchmark_boolean.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Parse key sizes results
         run: |
           python3 ./ci/benchmark_parser.py tfhe/boolean_key_sizes.csv ${{ env.RESULTS_FILENAME }} \
-          --key-sizes \
+          --object-sizes \
           --append-results
 
       - name: Upload parsed results artifact

--- a/.github/workflows/benchmark_erc20.yml
+++ b/.github/workflows/benchmark_erc20.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Parse PBS counts
         run: |
           python3 ./ci/benchmark_parser.py tfhe/erc20_pbs_count.csv ${{ env.RESULTS_FILENAME }} \
-          --key-sizes \
+          --object-sizes \
           --append-results
 
       - name: Upload parsed results artifact

--- a/.github/workflows/benchmark_gpu_erc20.yml
+++ b/.github/workflows/benchmark_gpu_erc20.yml
@@ -135,7 +135,7 @@ jobs:
       - name: Parse PBS counts
         run: |
           python3 ./ci/benchmark_parser.py tfhe/erc20_pbs_count.csv ${{ env.RESULTS_FILENAME }} \
-          --key-sizes \
+          --object-sizes \
           --append-results
 
       - name: Upload parsed results artifact

--- a/.github/workflows/benchmark_shortint.yml
+++ b/.github/workflows/benchmark_shortint.yml
@@ -138,7 +138,7 @@ jobs:
         if: matrix.op_flavor == 'default'
         run: |
           python3 ./ci/benchmark_parser.py tfhe/shortint_key_sizes.csv ${{ env.RESULTS_FILENAME }} \
-          --key-sizes \
+          --object-sizes \
           --append-results
 
       - name: Upload parsed results artifact

--- a/.github/workflows/benchmark_zk_pke.yml
+++ b/.github/workflows/benchmark_zk_pke.yml
@@ -135,7 +135,7 @@ jobs:
       - name: Parse CRS sizes results
         run: |
           python3 ./ci/benchmark_parser.py tfhe/pke_zk_crs_sizes.csv ${{ env.RESULTS_FILENAME }} \
-          --key-sizes \
+          --object-sizes \
           --append-results
 
       - name: Upload parsed results artifact

--- a/ci/benchmark_parser.py
+++ b/ci/benchmark_parser.py
@@ -70,8 +70,8 @@ parser.add_argument(
     help="Check for results in subdirectories",
 )
 parser.add_argument(
-    "--key-sizes",
-    dest="key_sizes",
+    "--object-sizes",
+    dest="object_sizes",
     action="store_true",
     help="Parse only the results regarding keys size measurements",
 )
@@ -296,7 +296,7 @@ def _parse_key_results(result_file, bench_type):
     return result_values, parsing_failures
 
 
-def parse_key_sizes(result_file):
+def parse_object_sizes(result_file):
     """
     Parse file containing key sizes results. The file must be formatted as CSV.
 
@@ -414,7 +414,7 @@ def check_mandatory_args(input_args):
             "name_suffix",
             "append_results",
             "walk_subdirs",
-            "key_sizes",
+            "object_sizes",
             "key_gen",
             "throughput",
         ]:
@@ -434,10 +434,10 @@ if __name__ == "__main__":
 
     # failures = []
     raw_results = pathlib.Path(args.results)
-    if args.key_sizes or args.key_gen:
-        if args.key_sizes:
+    if args.object_sizes or args.key_gen:
+        if args.object_sizes:
             print("Parsing key sizes results... ")
-            results, failures = parse_key_sizes(raw_results)
+            results, failures = parse_object_sizes(raw_results)
 
         if args.key_gen:
             print("Parsing key generation time results... ")


### PR DESCRIPTION
Since not only key sizes are measured now, it makes more sense to rename it to --object-sizes.

