### PR TITLE
chore(backward): use the Deprecated type from tfhe-versionable

### DIFF
--- a/tfhe/src/core_crypto/backward_compatibility/entities/seeded_lwe_keyswitch_key.rs
+++ b/tfhe/src/core_crypto/backward_compatibility/entities/seeded_lwe_keyswitch_key.rs
@@ -1,22 +1,14 @@
-use tfhe_versionable::{Upgrade, Version, VersionsDispatch};
+use tfhe_versionable::deprecation::{Deprecable, Deprecated};
+use tfhe_versionable::VersionsDispatch;
 
 use crate::core_crypto::prelude::{Container, SeededLweKeyswitchKey, UnsignedInteger};
 
-#[derive(Version)]
-pub struct UnsupportedSeededLweKeyswitchKeyV0;
-
-impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> Upgrade<SeededLweKeyswitchKey<C>>
-    for UnsupportedSeededLweKeyswitchKeyV0
+impl<C: Container> Deprecable for SeededLweKeyswitchKey<C>
+where
+    C::Element: UnsignedInteger,
 {
-    type Error = crate::Error;
-
-    fn upgrade(self) -> Result<SeededLweKeyswitchKey<C>, Self::Error> {
-        Err(crate::Error::new(
-            "Unable to load SeededLweKeyswitchKey, \
-            this format is unsupported by this TFHE-rs version."
-                .to_string(),
-        ))
-    }
+    const TYPE_NAME: &'static str = "SeededLweKeyswitchKey";
+    const MIN_SUPPORTED_APP_VERSION: &'static str = "TFHE-rs v0.9";
 }
 
 #[derive(VersionsDispatch)]
@@ -24,6 +16,6 @@ pub enum SeededLweKeyswitchKeyVersions<C: Container>
 where
     C::Element: UnsignedInteger,
 {
-    V0(UnsupportedSeededLweKeyswitchKeyV0),
+    V0(Deprecated<SeededLweKeyswitchKey<C>>),
     V1(SeededLweKeyswitchKey<C>),
 }

--- a/tfhe/src/core_crypto/backward_compatibility/entities/seeded_lwe_packing_keyswitch_key.rs
+++ b/tfhe/src/core_crypto/backward_compatibility/entities/seeded_lwe_packing_keyswitch_key.rs
@@ -1,22 +1,14 @@
-use tfhe_versionable::{Upgrade, Version, VersionsDispatch};
+use tfhe_versionable::deprecation::{Deprecable, Deprecated};
+use tfhe_versionable::VersionsDispatch;
 
 use crate::core_crypto::prelude::{Container, SeededLwePackingKeyswitchKey, UnsignedInteger};
 
-#[derive(Version)]
-pub struct UnsupportedSeededLwePackingKeyswitchKeyV0;
-
-impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>>
-    Upgrade<SeededLwePackingKeyswitchKey<C>> for UnsupportedSeededLwePackingKeyswitchKeyV0
+impl<C: Container> Deprecable for SeededLwePackingKeyswitchKey<C>
+where
+    C::Element: UnsignedInteger,
 {
-    type Error = crate::Error;
-
-    fn upgrade(self) -> Result<SeededLwePackingKeyswitchKey<C>, Self::Error> {
-        Err(crate::Error::new(
-            "Unable to load SeededLwePackingKeyswitchKey, \
-            this format is unsupported by this TFHE-rs version."
-                .to_string(),
-        ))
-    }
+    const TYPE_NAME: &'static str = "SeededLwePackingKeyswitchKey";
+    const MIN_SUPPORTED_APP_VERSION: &'static str = "TFHE-rs v0.9";
 }
 
 #[derive(VersionsDispatch)]
@@ -24,6 +16,6 @@ pub enum SeededLwePackingKeyswitchKeyVersions<C: Container>
 where
     C::Element: UnsignedInteger,
 {
-    V0(UnsupportedSeededLwePackingKeyswitchKeyV0),
+    V0(Deprecated<SeededLwePackingKeyswitchKey<C>>),
     V1(SeededLwePackingKeyswitchKey<C>),
 }

--- a/tfhe/src/high_level_api/backward_compatibility/keys.rs
+++ b/tfhe/src/high_level_api/backward_compatibility/keys.rs
@@ -2,6 +2,7 @@ use crate::high_level_api::keys::*;
 use crate::Tag;
 use std::convert::Infallible;
 use std::sync::Arc;
+use tfhe_versionable::deprecation::{Deprecable, Deprecated};
 use tfhe_versionable::{Upgrade, Version, VersionsDispatch};
 
 #[derive(VersionsDispatch)]
@@ -183,34 +184,9 @@ pub(crate) enum IntegerConfigVersions {
     V0(IntegerConfig),
 }
 
-#[derive(Version)]
-pub struct UnsupportedIntegerClientKeyV0;
-
-#[derive(Version)]
-pub struct UnsupportedIntegerClientKeyV1;
-
-impl Upgrade<UnsupportedIntegerClientKeyV1> for UnsupportedIntegerClientKeyV0 {
-    type Error = crate::Error;
-
-    fn upgrade(self) -> Result<UnsupportedIntegerClientKeyV1, Self::Error> {
-        Err(crate::Error::new(
-            "Unable to load IntegerClientKey, \
-            this format is unsupported by this TFHE-rs version."
-                .to_string(),
-        ))
-    }
-}
-
-impl Upgrade<IntegerClientKeyV2> for UnsupportedIntegerClientKeyV1 {
-    type Error = crate::Error;
-
-    fn upgrade(self) -> Result<IntegerClientKeyV2, Self::Error> {
-        Err(crate::Error::new(
-            "Unable to load IntegerClientKey, \
-            this format is unsupported by this TFHE-rs version."
-                .to_string(),
-        ))
-    }
+impl Deprecable for IntegerClientKey {
+    const TYPE_NAME: &'static str = "IntegerClientKey";
+    const MIN_SUPPORTED_APP_VERSION: &'static str = "TFHE-rs v0.8";
 }
 
 #[derive(Version)]
@@ -237,40 +213,15 @@ impl Upgrade<IntegerClientKey> for IntegerClientKeyV2 {
 #[derive(VersionsDispatch)]
 #[allow(unused)]
 pub(crate) enum IntegerClientKeyVersions {
-    V0(UnsupportedIntegerClientKeyV0),
-    V1(UnsupportedIntegerClientKeyV1),
+    V0(Deprecated<IntegerClientKey>),
+    V1(Deprecated<IntegerClientKey>),
     V2(IntegerClientKeyV2),
     V3(IntegerClientKey),
 }
 
-#[derive(Version)]
-pub struct UnsupportedIntegerServerKeyV0;
-
-#[derive(Version)]
-pub struct UnsupportedIntegerServerKeyV1;
-
-impl Upgrade<UnsupportedIntegerServerKeyV1> for UnsupportedIntegerServerKeyV0 {
-    type Error = crate::Error;
-
-    fn upgrade(self) -> Result<UnsupportedIntegerServerKeyV1, Self::Error> {
-        Err(crate::Error::new(
-            "Unable to load IntegerServerKey, \
-            this format is unsupported by this TFHE-rs version."
-                .to_string(),
-        ))
-    }
-}
-
-impl Upgrade<IntegerServerKeyV2> for UnsupportedIntegerServerKeyV1 {
-    type Error = crate::Error;
-
-    fn upgrade(self) -> Result<IntegerServerKeyV2, Self::Error> {
-        Err(crate::Error::new(
-            "Unable to load IntegerServerKey, \
-            this format is unsupported by this TFHE-rs version."
-                .to_string(),
-        ))
-    }
+impl Deprecable for IntegerServerKey {
+    const TYPE_NAME: &'static str = "IntegerServerKey";
+    const MIN_SUPPORTED_APP_VERSION: &'static str = "TFHE-rs v0.8";
 }
 
 #[derive(Version)]
@@ -301,30 +252,20 @@ impl Upgrade<IntegerServerKey> for IntegerServerKeyV2 {
 
 #[derive(VersionsDispatch)]
 pub enum IntegerServerKeyVersions {
-    V0(UnsupportedIntegerServerKeyV0),
-    V1(UnsupportedIntegerServerKeyV1),
+    V0(Deprecated<IntegerServerKey>),
+    V1(Deprecated<IntegerServerKey>),
     V2(IntegerServerKeyV2),
     V3(IntegerServerKey),
 }
 
-#[derive(Version)]
-pub struct UnsupportedIntegerCompressedServerKeyV0;
-
-impl Upgrade<IntegerCompressedServerKey> for UnsupportedIntegerCompressedServerKeyV0 {
-    type Error = crate::Error;
-
-    fn upgrade(self) -> Result<IntegerCompressedServerKey, Self::Error> {
-        Err(crate::Error::new(
-            "Unable to load IntegerCompressedServerKey, \
-            this format is unsupported by this TFHE-rs version."
-                .to_string(),
-        ))
-    }
+impl Deprecable for IntegerCompressedServerKey {
+    const TYPE_NAME: &'static str = "IntegerCompressedServerKey";
+    const MIN_SUPPORTED_APP_VERSION: &'static str = "TFHE-rs v0.9";
 }
 
 #[derive(VersionsDispatch)]
 pub enum IntegerCompressedServerKeyVersions {
-    V0(UnsupportedIntegerCompressedServerKeyV0),
+    V0(Deprecated<IntegerCompressedServerKey>),
     V1(IntegerCompressedServerKey),
 }
 

--- a/tfhe/src/integer/backward_compatibility/key_switching_key.rs
+++ b/tfhe/src/integer/backward_compatibility/key_switching_key.rs
@@ -1,4 +1,5 @@
-use tfhe_versionable::{Upgrade, Version, VersionsDispatch};
+use tfhe_versionable::deprecation::{Deprecable, Deprecated};
+use tfhe_versionable::VersionsDispatch;
 
 use crate::integer::key_switching_key::{
     CompressedKeySwitchingKey, CompressedKeySwitchingKeyMaterial, KeySwitchingKey,
@@ -15,44 +16,24 @@ pub enum KeySwitchingKeyVersions {
     V0(KeySwitchingKey),
 }
 
-#[derive(Version)]
-pub struct UnsupportedCompressedKeySwitchingKeyMaterialV0;
-
-impl Upgrade<CompressedKeySwitchingKeyMaterial> for UnsupportedCompressedKeySwitchingKeyMaterialV0 {
-    type Error = crate::Error;
-
-    fn upgrade(self) -> Result<CompressedKeySwitchingKeyMaterial, Self::Error> {
-        Err(crate::Error::new(
-            "Unable to load CompressedKeySwitchingKeyMaterial, \
-            this format is unsupported by this TFHE-rs version."
-                .to_string(),
-        ))
-    }
+impl Deprecable for CompressedKeySwitchingKeyMaterial {
+    const TYPE_NAME: &'static str = "CompressedKeySwitchingKeyMaterial";
+    const MIN_SUPPORTED_APP_VERSION: &'static str = "TFHE-rs v0.9";
 }
 
 #[derive(VersionsDispatch)]
 pub enum CompressedKeySwitchingKeyMaterialVersions {
-    V0(UnsupportedCompressedKeySwitchingKeyMaterialV0),
+    V0(Deprecated<CompressedKeySwitchingKeyMaterial>),
     V1(CompressedKeySwitchingKeyMaterial),
 }
 
-#[derive(Version)]
-pub struct UnsupportedCompressedKeySwitchingKeyV0;
-
-impl Upgrade<CompressedKeySwitchingKey> for UnsupportedCompressedKeySwitchingKeyV0 {
-    type Error = crate::Error;
-
-    fn upgrade(self) -> Result<CompressedKeySwitchingKey, Self::Error> {
-        Err(crate::Error::new(
-            "Unable to load CompressedKeySwitchingKey, \
-            this format is unsupported by this TFHE-rs version."
-                .to_string(),
-        ))
-    }
+impl Deprecable for CompressedKeySwitchingKey {
+    const TYPE_NAME: &'static str = "CompressedKeySwitchingKey";
+    const MIN_SUPPORTED_APP_VERSION: &'static str = "TFHE-rs v0.9";
 }
 
 #[derive(VersionsDispatch)]
 pub enum CompressedKeySwitchingKeyVersions {
-    V0(UnsupportedCompressedKeySwitchingKeyV0),
+    V0(Deprecated<CompressedKeySwitchingKey>),
     V1(CompressedKeySwitchingKey),
 }

--- a/tfhe/src/integer/backward_compatibility/list_compression.rs
+++ b/tfhe/src/integer/backward_compatibility/list_compression.rs
@@ -2,7 +2,8 @@ use crate::integer::compression_keys::{
     CompressedCompressionKey, CompressedDecompressionKey, CompressionKey, CompressionPrivateKeys,
     DecompressionKey,
 };
-use tfhe_versionable::{Upgrade, Version, VersionsDispatch};
+use tfhe_versionable::deprecation::{Deprecable, Deprecated};
+use tfhe_versionable::VersionsDispatch;
 
 #[derive(VersionsDispatch)]
 pub enum CompressionKeyVersions {
@@ -14,24 +15,14 @@ pub enum DecompressionKeyVersions {
     V0(DecompressionKey),
 }
 
-#[derive(Version)]
-pub struct UnsupportedCompressedCompressionKeyV0;
-
-impl Upgrade<CompressedCompressionKey> for UnsupportedCompressedCompressionKeyV0 {
-    type Error = crate::Error;
-
-    fn upgrade(self) -> Result<CompressedCompressionKey, Self::Error> {
-        Err(crate::Error::new(
-            "Unable to load CompressedCompressionKey, \
-            this format is unsupported by this TFHE-rs version."
-                .to_string(),
-        ))
-    }
+impl Deprecable for CompressedCompressionKey {
+    const TYPE_NAME: &'static str = "CompressedCompressionKey";
+    const MIN_SUPPORTED_APP_VERSION: &'static str = "TFHE-rs v0.9";
 }
 
 #[derive(VersionsDispatch)]
 pub enum CompressedCompressionKeyVersions {
-    V0(UnsupportedCompressedCompressionKeyV0),
+    V0(Deprecated<CompressedCompressionKey>),
     V1(CompressedCompressionKey),
 }
 

--- a/tfhe/src/integer/backward_compatibility/server_key/mod.rs
+++ b/tfhe/src/integer/backward_compatibility/server_key/mod.rs
@@ -1,4 +1,5 @@
-use tfhe_versionable::{Upgrade, Version, VersionsDispatch};
+use tfhe_versionable::deprecation::{Deprecable, Deprecated};
+use tfhe_versionable::VersionsDispatch;
 
 use crate::integer::{CompressedServerKey, ServerKey};
 
@@ -7,23 +8,13 @@ pub enum ServerKeyVersions {
     V0(ServerKey),
 }
 
-#[derive(Version)]
-pub struct UnsupportedCompressedServerKeyV0;
-
-impl Upgrade<CompressedServerKey> for UnsupportedCompressedServerKeyV0 {
-    type Error = crate::Error;
-
-    fn upgrade(self) -> Result<CompressedServerKey, Self::Error> {
-        Err(crate::Error::new(
-            "Unable to load CompressedServerKey, \
-            this format is unsupported by this TFHE-rs version."
-                .to_string(),
-        ))
-    }
+impl Deprecable for CompressedServerKey {
+    const TYPE_NAME: &'static str = "CompressedServerKey";
+    const MIN_SUPPORTED_APP_VERSION: &'static str = "TFHE-rs v0.9";
 }
 
 #[derive(VersionsDispatch)]
 pub enum CompressedServerKeyVersions {
-    V0(UnsupportedCompressedServerKeyV0),
+    V0(Deprecated<CompressedServerKey>),
     V1(CompressedServerKey),
 }

--- a/tfhe/src/shortint/backward_compatibility/key_switching_key.rs
+++ b/tfhe/src/shortint/backward_compatibility/key_switching_key.rs
@@ -1,4 +1,5 @@
-use tfhe_versionable::{Upgrade, Version, VersionsDispatch};
+use tfhe_versionable::deprecation::{Deprecable, Deprecated};
+use tfhe_versionable::VersionsDispatch;
 
 use crate::shortint::key_switching_key::{
     CompressedKeySwitchingKeyMaterial, KeySwitchingKeyMaterial,
@@ -15,44 +16,24 @@ pub enum KeySwitchingKeyVersions {
     V0(KeySwitchingKey),
 }
 
-#[derive(Version)]
-pub struct UnsupportedCompressedKeySwitchingKeyMaterialV0;
-
-impl Upgrade<CompressedKeySwitchingKeyMaterial> for UnsupportedCompressedKeySwitchingKeyMaterialV0 {
-    type Error = crate::Error;
-
-    fn upgrade(self) -> Result<CompressedKeySwitchingKeyMaterial, Self::Error> {
-        Err(crate::Error::new(
-            "Unable to load CompressedKeySwitchingKeyMaterial, \
-            this format is unsupported by this TFHE-rs version."
-                .to_string(),
-        ))
-    }
+impl Deprecable for CompressedKeySwitchingKeyMaterial {
+    const TYPE_NAME: &'static str = "CompressedKeySwitchingKeyMaterial";
+    const MIN_SUPPORTED_APP_VERSION: &'static str = "TFHE-rs v0.9";
 }
 
 #[derive(VersionsDispatch)]
 pub enum CompressedKeySwitchingKeyMaterialVersions {
-    V0(UnsupportedCompressedKeySwitchingKeyMaterialV0),
+    V0(Deprecated<CompressedKeySwitchingKeyMaterial>),
     V1(CompressedKeySwitchingKeyMaterial),
 }
 
-#[derive(Version)]
-pub struct UnsupportedCompressedKeySwitchingKeyV0;
-
-impl Upgrade<CompressedKeySwitchingKey> for UnsupportedCompressedKeySwitchingKeyV0 {
-    type Error = crate::Error;
-
-    fn upgrade(self) -> Result<CompressedKeySwitchingKey, Self::Error> {
-        Err(crate::Error::new(
-            "Unable to load CompressedKeySwitchingKey, \
-            this format is unsupported by this TFHE-rs version."
-                .to_string(),
-        ))
-    }
+impl Deprecable for CompressedKeySwitchingKey {
+    const TYPE_NAME: &'static str = "CompressedKeySwitchingKey";
+    const MIN_SUPPORTED_APP_VERSION: &'static str = "TFHE-rs v0.9";
 }
 
 #[derive(VersionsDispatch)]
 pub enum CompressedKeySwitchingKeyVersions {
-    V0(UnsupportedCompressedKeySwitchingKeyV0),
+    V0(Deprecated<CompressedKeySwitchingKey>),
     V1(CompressedKeySwitchingKey),
 }

--- a/tfhe/src/shortint/backward_compatibility/list_compression.rs
+++ b/tfhe/src/shortint/backward_compatibility/list_compression.rs
@@ -1,4 +1,5 @@
-use tfhe_versionable::{Upgrade, Version, VersionsDispatch};
+use tfhe_versionable::deprecation::{Deprecable, Deprecated};
+use tfhe_versionable::VersionsDispatch;
 
 use crate::shortint::list_compression::{
     CompressedCompressionKey, CompressedDecompressionKey, CompressionKey, CompressionPrivateKeys,
@@ -15,24 +16,14 @@ pub enum DecompressionKeyVersions {
     V0(DecompressionKey),
 }
 
-#[derive(Version)]
-pub struct UnsupportedCompressedCompressionKeyV0;
-
-impl Upgrade<CompressedCompressionKey> for UnsupportedCompressedCompressionKeyV0 {
-    type Error = crate::Error;
-
-    fn upgrade(self) -> Result<CompressedCompressionKey, Self::Error> {
-        Err(crate::Error::new(
-            "Unable to load CompressedCompressionKey, \
-            this format is unsupported by this TFHE-rs version."
-                .to_string(),
-        ))
-    }
+impl Deprecable for CompressedCompressionKey {
+    const TYPE_NAME: &'static str = "CompressedCompressionKey";
+    const MIN_SUPPORTED_APP_VERSION: &'static str = "TFHE-rs v0.9";
 }
 
 #[derive(VersionsDispatch)]
 pub enum CompressedCompressionKeyVersions {
-    V0(UnsupportedCompressedCompressionKeyV0),
+    V0(Deprecated<CompressedCompressionKey>),
     V1(CompressedCompressionKey),
 }
 

--- a/tfhe/src/shortint/backward_compatibility/server_key/mod.rs
+++ b/tfhe/src/shortint/backward_compatibility/server_key/mod.rs
@@ -1,4 +1,5 @@
-use tfhe_versionable::{Upgrade, Version, VersionsDispatch};
+use tfhe_versionable::deprecation::{Deprecable, Deprecated};
+use tfhe_versionable::VersionsDispatch;
 
 use crate::core_crypto::prelude::Container;
 use crate::shortint::server_key::*;
@@ -18,23 +19,13 @@ pub enum ShortintCompressedBootstrappingKeyVersions {
     V0(ShortintCompressedBootstrappingKey),
 }
 
-#[derive(Version)]
-pub struct UnsupportedCompressedServerKeyV0;
-
-impl Upgrade<CompressedServerKey> for UnsupportedCompressedServerKeyV0 {
-    type Error = crate::Error;
-
-    fn upgrade(self) -> Result<CompressedServerKey, Self::Error> {
-        Err(crate::Error::new(
-            "Unable to load CompressedServerKey, \
-            this format is unsupported by this TFHE-rs version."
-                .to_string(),
-        ))
-    }
+impl Deprecable for CompressedServerKey {
+    const TYPE_NAME: &'static str = "CompressedServerKey";
+    const MIN_SUPPORTED_APP_VERSION: &'static str = "TFHE-rs v0.9";
 }
 
 #[derive(VersionsDispatch)]
 pub enum CompressedServerKeyVersions {
-    V0(UnsupportedCompressedServerKeyV0),
+    V0(Deprecated<CompressedServerKey>),
     V1(CompressedServerKey),
 }


### PR DESCRIPTION


### PR content/description
Use the `Deprecated` type from `tfhe-versionable` for all the deprecated versions. This removes a bit of code in the backward_compat folders and will improve the error messages because most errors should happen at deserialization, before the call to the "upgrade" method.

Sadly the `Deprecable` trait for the types that have deprecated versions is a bit hard to implement with a declarative macro, because the macro needs to handle types with generics (especially with "nested" generics like `<Scalar: UnsignedInteger, C: Container<Element = Scalar>>`). I think it would require a proc-macro, but I don't know if its worth the price for a few impl (And I think it would be the same thing with impl of `Named`)

