### PR TITLE
fix(core): fix decomposition over 1 level to be balanced

### DIFF
--- a/tfhe/src/core_crypto/commons/math/decomposition/iter.rs
+++ b/tfhe/src/core_crypto/commons/math/decomposition/iter.rs
@@ -43,7 +43,7 @@ where
         Self {
             base_log: base_log.0,
             level_count: level.0,
-            state: input >> (T::BITS - base_log.0 * level.0),
+            state: input,
             current_level: level.0,
             mod_b_mask: (T::ONE << base_log.0) - T::ONE,
             fresh: true,
@@ -118,6 +118,23 @@ where
     }
 }
 
+/// With
+///
+/// B = 2^base_log
+/// res < B
+///
+/// returns 1 if the following condition is true otherwise 0
+///
+/// (res > B / 2) || ((res == B / 2) && ((state % B) >= B / 2));
+#[inline(always)]
+fn decomposition_bit_trick<Scalar: UnsignedInteger>(
+    res: Scalar,
+    state: Scalar,
+    base_log: usize,
+) -> Scalar {
+    ((res.wrapping_sub(Scalar::ONE) | state) & res) >> (base_log - 1)
+}
+
 #[inline]
 pub(crate) fn decompose_one_level<S: UnsignedInteger>(
     base_log: usize,
@@ -126,8 +143,7 @@ pub(crate) fn decompose_one_level<S: UnsignedInteger>(
 ) -> S {
     let res = *state & mod_b_mask;
     *state >>= base_log;
-    let mut carry = (res.wrapping_sub(S::ONE) | *state) & res;
-    carry >>= base_log - 1;
+    let carry = decomposition_bit_trick(res, *state, base_log);
     *state += carry;
     res.wrapping_sub(carry << base_log)
 }
@@ -298,7 +314,7 @@ pub struct TensorSignedDecompositionLendingIterNonNative<'buffers> {
 
 impl<'buffers> TensorSignedDecompositionLendingIterNonNative<'buffers> {
     #[inline]
-    pub fn new(
+    pub(crate) fn new(
         decomposer: &SignedDecomposerNonNative<u64>,
         input: &[u64],
         modulus: u64,
@@ -398,5 +414,47 @@ impl<'buffers> TensorSignedDecompositionLendingIterNonNative<'buffers> {
         let (glwe_decomp_term, substack2) =
             substack1.rb_mut().collect_aligned(align, glwe_decomp_term);
         (glwe_level, glwe_decomp_term, substack2)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_decomp_bit_trick() {
+        for rep_bit_count in 1..13 {
+            println!("{rep_bit_count}");
+            let b = 1u64 << rep_bit_count;
+            let b_over_2 = b / 2;
+
+            for val in 0..b {
+                // Have a chance to sample all values in 0..b at least once, here we expect on
+                // average about 10 occurrence for each value in the range
+                for _ in 0..10 * b {
+                    let state: u64 = rand::random();
+                    let test_val =
+                        (val > b_over_2) || ((val == b_over_2) && ((state % b) >= b_over_2));
+                    let bit_trick = decomposition_bit_trick(val, state, rep_bit_count);
+                    let bit_trick_as_bool = if bit_trick == 1 {
+                        true
+                    } else if bit_trick == 0 {
+                        false
+                    } else {
+                        panic!("Bit trick result was not a bit.");
+                    };
+
+                    assert_eq!(
+                        test_val, bit_trick_as_bool,
+                        "\nval    ={val}\n\
+                           val_b  ={val:064b}\n\
+                           state  ={state}\n\
+                           state_b={state:064b}\n\
+                           expected: {test_val}\n\
+                           got     : {bit_trick_as_bool}"
+                    );
+                }
+            }
+        }
     }
 }

--- a/tfhe/src/core_crypto/commons/math/decomposition/tests.rs
+++ b/tfhe/src/core_crypto/commons/math/decomposition/tests.rs
@@ -200,3 +200,33 @@ fn test_decompose_recompose_non_native_solinas_u64() {
 fn test_decompose_recompose_non_native_edge_mod_round_up_u64() {
     test_decompose_recompose_non_native::<u64>(CiphertextModulus::try_new((1 << 48) + 1).unwrap());
 }
+
+#[test]
+fn test_single_level_decompose_balanced() {
+    let decomposer = SignedDecomposer::new(DecompositionBaseLog(12), DecompositionLevelCount(1));
+
+    assert_eq!(
+        decomposer.level_count().0,
+        1,
+        "This test is only valid if the decomposition level count is 1"
+    );
+    use rand::prelude::*;
+    let mut rng = rand::thread_rng();
+    let mut mean = 0f64;
+    // Still runs fast, about 1 billion runs which is exactly representable in float
+    let runs = 1usize << 30;
+    for _ in 0..runs {
+        let val: u64 = rng.gen();
+        let decomp = decomposer.decompose(val).next().unwrap();
+        let value: i64 = decomp.value() as i64;
+        mean += value as f64;
+    }
+    mean /= runs as f64;
+
+    // To print with --nocapture to check in the terminal
+    println!("mean={mean}");
+
+    // This bound is not very tight or good, but as an unbalanced decomposition has a mean of about
+    // 0.5 this will do
+    assert!(mean.abs() < 0.2);
+}

--- a/tfhe/src/core_crypto/experimental/algorithms/glwe_fast_keyswitch.rs
+++ b/tfhe/src/core_crypto/experimental/algorithms/glwe_fast_keyswitch.rs
@@ -207,7 +207,7 @@ pub fn glwe_fast_keyswitch<Scalar, OutputGlweCont, InputGlweCont, GgswCont>(
             let (mut decomposition, mut substack1) = TensorSignedDecompositionLendingIter::new(
                 glwe.as_ref()
                     .iter()
-                    .map(|s| decomposer.closest_representable(*s)),
+                    .map(|s| decomposer.init_decomposer_state(*s)),
                 DecompositionBaseLog(decomposer.base_log),
                 DecompositionLevelCount(decomposer.level_count),
                 substack0.rb_mut(),

--- a/tfhe/src/core_crypto/fft_impl/fft128/crypto/ggsw.rs
+++ b/tfhe/src/core_crypto/fft_impl/fft128/crypto/ggsw.rs
@@ -418,7 +418,7 @@ pub fn add_external_product_assign<Scalar, ContOut, ContGgsw, ContGlwe>(
             let (mut decomposition, mut substack1) = TensorSignedDecompositionLendingIter::new(
                 glwe.as_ref()
                     .iter()
-                    .map(|s| decomposer.closest_representable(*s)),
+                    .map(|s| decomposer.init_decomposer_state(*s)),
                 DecompositionBaseLog(decomposer.base_log),
                 DecompositionLevelCount(decomposer.level_count),
                 substack0.rb_mut(),

--- a/tfhe/src/core_crypto/fft_impl/fft128_u128/crypto/ggsw.rs
+++ b/tfhe/src/core_crypto/fft_impl/fft128_u128/crypto/ggsw.rs
@@ -87,8 +87,6 @@ pub fn add_external_product_assign_split<ContOutLo, ContOutHi, ContGgsw, ContGlw
             let (decomposition_states_hi, mut substack1) =
                 stack.make_aligned_raw::<u64>(poly_size * glwe_size, align);
 
-            let shift = 128 - decomposer.base_log * decomposer.level_count;
-
             for (out_lo, out_hi, in_lo, in_hi) in izip!(
                 &mut *decomposition_states_lo,
                 &mut *decomposition_states_hi,
@@ -96,7 +94,7 @@ pub fn add_external_product_assign_split<ContOutLo, ContOutHi, ContGgsw, ContGlw
                 glwe_hi.as_ref(),
             ) {
                 let input = (*in_lo as u128) | ((*in_hi as u128) << 64);
-                let value = decomposer.closest_representable(input) >> shift;
+                let value = decomposer.init_decomposer_state(input);
                 *out_lo = value as u64;
                 *out_hi = (value >> 64) as u64;
             }

--- a/tfhe/src/core_crypto/fft_impl/fft128_u128/crypto/tests.rs
+++ b/tfhe/src/core_crypto/fft_impl/fft128_u128/crypto/tests.rs
@@ -169,13 +169,6 @@ fn test_split_pbs() {
         ciphertext_modulus,
     );
 
-    for x in lwe_in.as_mut() {
-        *x = rand::random();
-    }
-    for x in accumulator.as_mut() {
-        *x = rand::random();
-    }
-
     let mut mem = GlobalPodBuffer::new(
         fft128::crypto::bootstrap::bootstrap_scratch::<u128>(
             glwe_dimension.to_glwe_size(),
@@ -186,62 +179,71 @@ fn test_split_pbs() {
     );
     let mut stack = PodStack::new(&mut mem);
 
-    let mut lwe_out_non_split = LweCiphertext::new(
-        0u128,
-        glwe_dimension
-            .to_equivalent_lwe_dimension(polynomial_size)
-            .to_lwe_size(),
-        ciphertext_modulus,
-    );
+    for _ in 0..20 {
+        for x in lwe_in.as_mut() {
+            *x = rand::random();
+        }
+        for x in accumulator.as_mut() {
+            *x = rand::random();
+        }
 
-    // Needed as the basic bootstrap function dispatches to the more efficient split version for
-    // u128
-    fn bootstrap_non_split<Scalar: UnsignedTorus + CastInto<usize>>(
-        this: Fourier128LweBootstrapKey<&[f64]>,
-        mut lwe_out: LweCiphertext<&mut [Scalar]>,
-        lwe_in: LweCiphertext<&[Scalar]>,
-        accumulator: GlweCiphertext<&[Scalar]>,
-        fft: Fft128View<'_>,
-        stack: PodStack<'_>,
-    ) {
-        let (local_accumulator_data, stack) =
-            stack.collect_aligned(CACHELINE_ALIGN, accumulator.as_ref().iter().copied());
-        let mut local_accumulator = GlweCiphertextMutView::from_container(
-            &mut *local_accumulator_data,
-            accumulator.polynomial_size(),
-            accumulator.ciphertext_modulus(),
+        let mut lwe_out_non_split = LweCiphertext::new(
+            0u128,
+            glwe_dimension
+                .to_equivalent_lwe_dimension(polynomial_size)
+                .to_lwe_size(),
+            ciphertext_modulus,
         );
-        this.blind_rotate_assign(&mut local_accumulator.as_mut_view(), &lwe_in, fft, stack);
-        extract_lwe_sample_from_glwe_ciphertext(
-            &local_accumulator,
-            &mut lwe_out,
-            MonomialDegree(0),
+
+        // Needed as the basic bootstrap function dispatches to the more efficient split version for
+        // u128
+        fn bootstrap_non_split<Scalar: UnsignedTorus + CastInto<usize>>(
+            this: Fourier128LweBootstrapKey<&[f64]>,
+            mut lwe_out: LweCiphertext<&mut [Scalar]>,
+            lwe_in: LweCiphertext<&[Scalar]>,
+            accumulator: GlweCiphertext<&[Scalar]>,
+            fft: Fft128View<'_>,
+            stack: PodStack<'_>,
+        ) {
+            let (local_accumulator_data, stack) =
+                stack.collect_aligned(CACHELINE_ALIGN, accumulator.as_ref().iter().copied());
+            let mut local_accumulator = GlweCiphertextMutView::from_container(
+                &mut *local_accumulator_data,
+                accumulator.polynomial_size(),
+                accumulator.ciphertext_modulus(),
+            );
+            this.blind_rotate_assign(&mut local_accumulator.as_mut_view(), &lwe_in, fft, stack);
+            extract_lwe_sample_from_glwe_ciphertext(
+                &local_accumulator,
+                &mut lwe_out,
+                MonomialDegree(0),
+            );
+        }
+
+        bootstrap_non_split(
+            fourier_bsk.as_view(),
+            lwe_out_non_split.as_mut_view(),
+            lwe_in.as_view(),
+            accumulator.as_view(),
+            fft,
+            stack.rb_mut(),
         );
+
+        let mut lwe_out_split = LweCiphertext::new(
+            0u128,
+            glwe_dimension
+                .to_equivalent_lwe_dimension(polynomial_size)
+                .to_lwe_size(),
+            ciphertext_modulus,
+        );
+        fourier_bsk.bootstrap_u128(
+            &mut lwe_out_split,
+            &lwe_in,
+            &accumulator,
+            fft,
+            stack.rb_mut(),
+        );
+
+        assert_eq!(lwe_out_split, lwe_out_non_split);
     }
-
-    bootstrap_non_split(
-        fourier_bsk.as_view(),
-        lwe_out_non_split.as_mut_view(),
-        lwe_in.as_view(),
-        accumulator.as_view(),
-        fft,
-        stack.rb_mut(),
-    );
-
-    let mut lwe_out_split = LweCiphertext::new(
-        0u128,
-        glwe_dimension
-            .to_equivalent_lwe_dimension(polynomial_size)
-            .to_lwe_size(),
-        ciphertext_modulus,
-    );
-    fourier_bsk.bootstrap_u128(
-        &mut lwe_out_split,
-        &lwe_in,
-        &accumulator,
-        fft,
-        stack.rb_mut(),
-    );
-
-    assert_eq!(lwe_out_split, lwe_out_non_split);
 }

--- a/tfhe/src/core_crypto/fft_impl/fft64/crypto/ggsw.rs
+++ b/tfhe/src/core_crypto/fft_impl/fft64/crypto/ggsw.rs
@@ -517,7 +517,7 @@ pub fn add_external_product_assign<Scalar>(
         let (mut decomposition, mut substack1) = TensorSignedDecompositionLendingIter::new(
             glwe.as_ref()
                 .iter()
-                .map(|s| decomposer.closest_representable(*s)),
+                .map(|s| decomposer.init_decomposer_state(*s)),
             DecompositionBaseLog(decomposer.base_log),
             DecompositionLevelCount(decomposer.level_count),
             substack0.rb_mut(),

--- a/tfhe/src/core_crypto/fft_impl/fft64/math/decomposition.rs
+++ b/tfhe/src/core_crypto/fft_impl/fft64/math/decomposition.rs
@@ -31,9 +31,7 @@ impl<'buffers, Scalar: UnsignedInteger> TensorSignedDecompositionLendingIter<'bu
         level: DecompositionLevelCount,
         stack: PodStack<'buffers>,
     ) -> (Self, PodStack<'buffers>) {
-        let shift = Scalar::BITS - base_log.0 * level.0;
-        let (states, stack) =
-            stack.collect_aligned(aligned_vec::CACHELINE_ALIGN, input.map(|i| i >> shift));
+        let (states, stack) = stack.collect_aligned(aligned_vec::CACHELINE_ALIGN, input);
         (
             TensorSignedDecompositionLendingIter {
                 base_log: base_log.0,


### PR DESCRIPTION
It was brought to our attention that a decomposition over 1 level was not properly balanced and could have a mean value of 0.5 which can be an issue when being fed in an FFT (generating harmonics in the process) this fixes that.

A tests has been added to check on a selected 1 level decomposition that the average of the values returning during decomposition is ~0

cc @agnesLeroy and maybe @guillermo-oyarzun so that you can check how to update this on your end, I can explain the formula in more detail, but normally the comment in the code explains how it works