### PR TITLE
chore(ci): verify commit on release

### DIFF
--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -30,8 +30,15 @@ env:
   NPM_TAG: ""
 
 jobs:
+  verify_tag:
+    uses: ./.github/workflows/verify_tagged_commit.yml
+    secrets:
+      RELEASE_TEAM: ${{ secrets.RELEASE_TEAM }}
+      READ_ORG_TOKEN: ${{ secrets.READ_ORG_TOKEN }}
+
   package:
     runs-on: ubuntu-latest
+    needs: verify_tag
     outputs:
       hash: ${{ steps.hash.outputs.hash }}
     steps:

--- a/.github/workflows/make_release_concrete_csprng.yml
+++ b/.github/workflows/make_release_concrete_csprng.yml
@@ -12,8 +12,15 @@ env:
   ACTION_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 jobs:
+  verify_tag:
+    uses: ./.github/workflows/verify_tagged_commit.yml
+    secrets:
+      RELEASE_TEAM: ${{ secrets.RELEASE_TEAM }}
+      READ_ORG_TOKEN: ${{ secrets.READ_ORG_TOKEN }}
+
   publish_release:
     name: Publish concrete-csprng Release
+    needs: verify_tag
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/make_release_cuda.yml
+++ b/.github/workflows/make_release_cuda.yml
@@ -21,8 +21,15 @@ env:
   SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
 jobs:
+  verify_tag:
+    uses: ./.github/workflows/verify_tagged_commit.yml
+    secrets:
+      RELEASE_TEAM: ${{ secrets.RELEASE_TEAM }}
+      READ_ORG_TOKEN: ${{ secrets.READ_ORG_TOKEN }}
+
   setup-instance:
     name: Setup instance (publish-cuda-release)
+    needs: verify_tag
     runs-on: ubuntu-latest
     outputs:
       runner-name: ${{ steps.start-instance.outputs.label }}

--- a/.github/workflows/make_release_tfhe_versionable.yml
+++ b/.github/workflows/make_release_tfhe_versionable.yml
@@ -12,8 +12,15 @@ env:
   ACTION_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 jobs:
+  verify_tag:
+    uses: ./.github/workflows/verify_tagged_commit.yml
+    secrets:
+      RELEASE_TEAM: ${{ secrets.RELEASE_TEAM }}
+      READ_ORG_TOKEN: ${{ secrets.READ_ORG_TOKEN }}
+
   publish_release:
     name: Publish tfhe-versionable Release
+    needs: verify_tag
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/make_release_zk_pok.yml
+++ b/.github/workflows/make_release_zk_pok.yml
@@ -13,8 +13,15 @@ env:
   ACTION_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 jobs:
+  verify_tag:
+    uses: ./.github/workflows/verify_tagged_commit.yml
+    secrets:
+      RELEASE_TEAM: ${{ secrets.RELEASE_TEAM }}
+      READ_ORG_TOKEN: ${{ secrets.READ_ORG_TOKEN }}
+
   publish_release:
     name: Publish tfhe-zk-pok Release
+    needs: verify_tag
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/verify_tagged_commit.yml
+++ b/.github/workflows/verify_tagged_commit.yml
@@ -1,0 +1,32 @@
+# Verify a tagged commit
+name: Verify tagged commit
+
+on:
+  workflow_call:
+    secrets:
+      RELEASE_TEAM:
+        required: true
+      READ_ORG_TOKEN:
+        required: true
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      # Check triggering actor membership
+      - name: Actor verification
+        id: actor_check
+        uses: morfien101/actions-authorized-user@4a3cfbf0bcb3cafe4a71710a278920c5d94bb38b
+        with:
+          username: ${{ github.triggering_actor }}
+          org: ${{ github.repository_owner }}
+          team: ${{ secrets.RELEASE_TEAM }}
+          github_token: ${{ secrets.READ_ORG_TOKEN }}
+
+      - name: Actor authorized
+        run: |
+          if [ "${{ steps.actor_check.outputs.authorized }}" == "false" ]; then
+            echo "Actor '${{ github.triggering_actor }}' is not authorized to perform release"
+            exit 1
+          fi


### PR DESCRIPTION
Enforce commit being associated to a tag.
The tag must be committed by a member of the release team. In addition, the tag needs to be verified. Finally, triggering actor must also be a member of the release team.
