### PR TITLE
fix(ci): fix backward data test branch for 0.7

### DIFF
--- a/.github/workflows/aws_tfhe_fast_tests.yml
+++ b/.github/workflows/aws_tfhe_fast_tests.yml
@@ -119,6 +119,7 @@ jobs:
           repository: zama-ai/tfhe-backward-compat-data
           path: tfhe/tfhe-backward-compat-data
           lfs: 'true'
+          ref: 'v0.1'
 
       - name: Run backward compatibility tests
         run: |


### PR DESCRIPTION
Specific fix for backward compat test on 0.7. The data branch was not yet chosen dynamically so it defaulted to main.
I forced it to use the branch that is compatible with the 0.7 branch (v0.1)