### PR TITLE
chore(gpu): remove decompressed ct comparison btw cpu and gpu

### DIFF
--- a/tfhe/src/integer/gpu/ciphertext/compressed_ciphertext_list.rs
+++ b/tfhe/src/integer/gpu/ciphertext/compressed_ciphertext_list.rs
@@ -173,43 +173,7 @@ impl CudaCompressedCiphertextList {
     ///     .push(d_ct3, &streams)
     ///     .build(&cuda_compression_key, &streams);
     ///
-    /// let reference_compressed = CompressedCiphertextListBuilder::new()
-    ///     .push(ct1)
-    ///     .push(ct2)
-    ///     .push(ct3)
-    ///     .build(&compression_key);
-    ///
     /// let converted_compressed = cuda_compressed.to_compressed_ciphertext_list(&streams);
-    ///
-    /// let decompressed1: RadixCiphertext = converted_compressed
-    ///     .get(0, &decompression_key)
-    ///     .unwrap()
-    ///     .unwrap();
-    /// let reference_decompressed1 = reference_compressed
-    ///     .get(0, &decompression_key)
-    ///     .unwrap()
-    ///     .unwrap();
-    /// assert_eq!(decompressed1, reference_decompressed1);
-    ///
-    /// let decompressed2: SignedRadixCiphertext = converted_compressed
-    ///     .get(1, &decompression_key)
-    ///     .unwrap()
-    ///     .unwrap();
-    /// let reference_decompressed2 = reference_compressed
-    ///     .get(1, &decompression_key)
-    ///     .unwrap()
-    ///     .unwrap();
-    /// assert_eq!(decompressed2, reference_decompressed2);
-    ///
-    /// let decompressed3: BooleanBlock = converted_compressed
-    ///     .get(2, &decompression_key)
-    ///     .unwrap()
-    ///     .unwrap();
-    /// let reference_decompressed3 = reference_compressed
-    ///     .get(2, &decompression_key)
-    ///     .unwrap()
-    ///     .unwrap();
-    /// assert_eq!(decompressed3, reference_decompressed3);
     /// ```
     pub fn to_compressed_ciphertext_list(&self, streams: &CudaStreams) -> CompressedCiphertextList {
         let glwe_list = self


### PR DESCRIPTION
The results are not expected to match bitwise

<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
