### PR TITLE
Ns/rename pp crs

### DIFF
--- a/tfhe/Cargo.toml
+++ b/tfhe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tfhe"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 readme = "../README.md"
 keywords = ["fully", "homomorphic", "encryption", "fhe", "cryptography"]

--- a/tfhe/c_api_tests/test_high_level_zk.c
+++ b/tfhe/c_api_tests/test_high_level_zk.c
@@ -31,10 +31,6 @@ int main(void) {
   status = compact_pke_crs_from_config(config, max_num_bits, &crs);
   assert(status == 0);
 
-  CompactPkePublicParams *public_params;
-  status = compact_pke_crs_public_params(crs, &public_params);
-  assert(status == 0);
-
 #define METADATA_LEN 5
   uint8_t metadata[METADATA_LEN] = {'c', '-', 'a', 'p', 'i'};
 
@@ -71,7 +67,7 @@ int main(void) {
     assert(status == 0);
 
     status = compact_ciphertext_list_builder_build_with_proof_packed(
-        builder, public_params, metadata, METADATA_LEN, ZkComputeLoadProof, &compact_list);
+        builder, crs, metadata, METADATA_LEN, ZkComputeLoadProof, &compact_list);
     assert(status == 0);
 
     // Don't forget to destroy the builder
@@ -85,7 +81,7 @@ int main(void) {
   FheUint2 *d = NULL;
   {
     CompactCiphertextListExpander *expander = NULL;
-    status = proven_compact_ciphertext_list_verify_and_expand(compact_list, public_params, pk,
+    status = proven_compact_ciphertext_list_verify_and_expand(compact_list, crs, pk,
                                                               metadata, METADATA_LEN, &expander);
     assert(status == 0);
 
@@ -132,7 +128,6 @@ int main(void) {
   client_key_destroy(client_key);
   server_key_destroy(server_key);
   compact_public_key_destroy(pk);
-  compact_pke_public_params_destroy(public_params);
   compact_pke_crs_destroy(crs);
 
   return EXIT_SUCCESS;

--- a/tfhe/js_on_wasm_tests/test-hlapi-signed.js
+++ b/tfhe/js_on_wasm_tests/test-hlapi-signed.js
@@ -23,7 +23,6 @@ const {
     FheInt256,
     CompactCiphertextList,
     ProvenCompactCiphertextList,
-    CompactPkePublicParams,
     CompactPkeCrs,
     ZkComputeLoad,
     Shortint,
@@ -509,12 +508,11 @@ test('hlapi_compact_ciphertext_list_with_proof', (t) => {
     let publicKey = TfheCompactPublicKey.new(clientKey);
 
     let crs = CompactPkeCrs.from_parameters(block_params, 2 + 32 + 1 + 256);
-    let public_params = crs.public_params();
 
     const compress = false; // We don't compress as it's too slow on wasm
-    let serialized_pke_params = public_params.serialize(compress);
+    let serialized_pke_crs = crs.serialize(compress);
     let validate = false; // Also too slow on wasm
-    public_params = CompactPkePublicParams.deserialize(serialized_pke_params, compress, validate);
+    crs = CompactPkeCrs.deserialize(serialized_pke_crs, compress, validate);
 
     let clear_u2 = 3;
     let clear_i32 = -3284;
@@ -526,7 +524,7 @@ test('hlapi_compact_ciphertext_list_with_proof', (t) => {
     builder.push_i32(clear_i32);
     builder.push_boolean(clear_bool);
     builder.push_u256(clear_u256);
-    let list = builder.build_with_proof_packed(public_params, ZkComputeLoad.Proof);
+    let list = builder.build_with_proof_packed(crs, ZkComputeLoad.Proof);
 
     let serialized = list.safe_serialize(BigInt(10000000));
     let deserialized = ProvenCompactCiphertextList.safe_deserialize(serialized, BigInt(10000000));

--- a/tfhe/src/c_api/high_level_api/compact_list.rs
+++ b/tfhe/src/c_api/high_level_api/compact_list.rs
@@ -13,7 +13,7 @@ use crate::c_api::high_level_api::utils::{
     impl_destroy_on_type, impl_serialize_deserialize_on_type, CApiIntegerType,
 };
 #[cfg(feature = "zk-pok")]
-use crate::c_api::high_level_api::zk::{CompactPkePublicParams, ZkComputeLoad};
+use crate::c_api::high_level_api::zk::{CompactPkeCrs, ZkComputeLoad};
 use crate::c_api::utils::{catch_panic, get_mut_checked, get_ref_checked};
 use crate::prelude::CiphertextList;
 use std::ffi::c_int;
@@ -78,7 +78,7 @@ pub unsafe extern "C" fn compact_ciphertext_list_builder_build_packed(
 #[no_mangle]
 pub unsafe extern "C" fn compact_ciphertext_list_builder_build_with_proof_packed(
     builder: *const CompactCiphertextListBuilder,
-    public_params: *const CompactPkePublicParams,
+    crs: *const CompactPkeCrs,
     metadata: *const u8,
     metadata_len: usize,
     compute_load: ZkComputeLoad,
@@ -86,7 +86,7 @@ pub unsafe extern "C" fn compact_ciphertext_list_builder_build_with_proof_packed
 ) -> c_int {
     catch_panic(|| {
         let builder = get_ref_checked(builder).unwrap();
-        let public_params = get_ref_checked(public_params).unwrap();
+        let crs = get_ref_checked(crs).unwrap();
 
         let metadata = if metadata.is_null() {
             &[]
@@ -97,7 +97,7 @@ pub unsafe extern "C" fn compact_ciphertext_list_builder_build_with_proof_packed
 
         let inner = builder
             .0
-            .build_with_proof_packed(&public_params.0, metadata, compute_load.into())
+            .build_with_proof_packed(&crs.0, metadata, compute_load.into())
             .unwrap();
 
         *list = Box::into_raw(Box::new(ProvenCompactCiphertextList(inner)));
@@ -182,7 +182,7 @@ pub unsafe extern "C" fn compact_ciphertext_list_expand(
 #[no_mangle]
 pub unsafe extern "C" fn proven_compact_ciphertext_list_verify_and_expand(
     compact_list: *const ProvenCompactCiphertextList,
-    public_params: *const CompactPkePublicParams,
+    crs: *const CompactPkeCrs,
     public_key: *const CompactPublicKey,
     metadata: *const u8,
     metadata_len: usize,
@@ -190,7 +190,7 @@ pub unsafe extern "C" fn proven_compact_ciphertext_list_verify_and_expand(
 ) -> c_int {
     catch_panic(|| {
         let list = get_ref_checked(compact_list).unwrap();
-        let public_params = get_ref_checked(public_params).unwrap();
+        let crs = get_ref_checked(crs).unwrap();
         let public_key = get_ref_checked(public_key).unwrap();
 
         let metadata = if metadata.is_null() {
@@ -202,7 +202,7 @@ pub unsafe extern "C" fn proven_compact_ciphertext_list_verify_and_expand(
 
         let inner = list
             .0
-            .verify_and_expand(&public_params.0, &public_key.0, metadata)
+            .verify_and_expand(&crs.0, &public_key.0, metadata)
             .unwrap();
 
         *expander = Box::into_raw(Box::new(CompactCiphertextListExpander(inner)));

--- a/tfhe/src/core_crypto/algorithms/lwe_encryption.rs
+++ b/tfhe/src/core_crypto/algorithms/lwe_encryption.rs
@@ -1847,7 +1847,7 @@ fn verify_zero_knowledge_preconditions<Scalar, KeyCont, MaskDistribution, BodyDi
     delta: Scalar,
     mask_noise_distribution: MaskDistribution,
     body_noise_distribution: BodyDistribution,
-    public_params: &CompactPkePublicParams,
+    crs: &CompactPkeCrs,
 ) -> crate::Result<()>
 where
     Scalar: UnsignedInteger + CastFrom<u64>,
@@ -1858,6 +1858,7 @@ where
     BodyDistribution: BoundedDistribution<Scalar::Signed>,
     KeyCont: Container<Element = Scalar>,
 {
+    let public_params = crs.public_params();
     let exclusive_max = public_params.exclusive_max_noise();
     if Scalar::BITS < 64 && (1u64 << Scalar::BITS) >= exclusive_max {
         return Err(
@@ -2200,21 +2201,16 @@ pub fn encrypt_lwe_ciphertext_with_compact_public_key<
 ///     &mut secret_generator,
 ///     &mut encryption_generator,
 ///     &mut random_generator,
-///     crs.public_params(),
+///     &crs,
 ///     &metadata,
 ///     ZkComputeLoad::Proof,
 /// )
 /// .unwrap();
 ///
 /// // verify the ciphertext list with the proof
-/// assert!(verify_lwe_ciphertext(
-///     &lwe,
-///     &lwe_compact_public_key,
-///     &proof,
-///     crs.public_params(),
-///     &metadata
-/// )
-/// .is_valid());
+/// assert!(
+///     verify_lwe_ciphertext(&lwe, &lwe_compact_public_key, &proof, &crs, &metadata).is_valid()
+/// );
 ///
 /// let decrypted_plaintext = decrypt_lwe_ciphertext(&lwe_secret_key, &lwe);
 ///
@@ -2254,7 +2250,7 @@ pub fn encrypt_and_prove_lwe_ciphertext_with_compact_public_key<
     secret_generator: &mut SecretRandomGenerator<SecretGen>,
     encryption_generator: &mut EncryptionRandomGenerator<EncryptionGen>,
     random_generator: &mut RandomGenerator<G>,
-    public_params: &CompactPkePublicParams,
+    crs: &CompactPkeCrs,
     metadata: &[u8],
     load: ZkComputeLoad,
 ) -> crate::Result<CompactPkeProof>
@@ -2280,7 +2276,7 @@ where
         delta,
         mask_noise_distribution,
         body_noise_distribution,
-        public_params,
+        crs,
     )?;
 
     let CompactPublicKeyRandomVectors {
@@ -2336,12 +2332,12 @@ where
             .copied()
             .map(CastFrom::cast_from)
             .collect::<Vec<_>>(),
-        public_params,
+        crs.public_params(),
         random_generator,
     );
 
     Ok(prove(
-        (public_params, &public_commit),
+        (crs.public_params(), &public_commit),
         &private_commit,
         metadata,
         load,
@@ -2698,7 +2694,7 @@ pub fn encrypt_lwe_compact_ciphertext_list_with_compact_public_key<
 ///     &mut secret_generator,
 ///     &mut encryption_generator,
 ///     &mut random_generator,
-///     crs.public_params(),
+///     &crs,
 ///     &metadata,
 ///     ZkComputeLoad::Proof,
 /// )
@@ -2709,7 +2705,7 @@ pub fn encrypt_lwe_compact_ciphertext_list_with_compact_public_key<
 ///     &output_compact_ct_list,
 ///     &lwe_compact_public_key,
 ///     &proof,
-///     crs.public_params(),
+///     &crs,
 ///     &metadata,
 /// )
 /// .is_valid());
@@ -2760,7 +2756,7 @@ pub fn encrypt_and_prove_lwe_compact_ciphertext_list_with_compact_public_key<
     secret_generator: &mut SecretRandomGenerator<SecretGen>,
     encryption_generator: &mut EncryptionRandomGenerator<EncryptionGen>,
     random_generator: &mut RandomGenerator<G>,
-    public_params: &CompactPkePublicParams,
+    crs: &CompactPkeCrs,
     metadata: &[u8],
     load: ZkComputeLoad,
 ) -> crate::Result<CompactPkeProof>
@@ -2787,7 +2783,7 @@ where
         delta,
         mask_noise_distribution,
         body_noise_distribution,
-        public_params,
+        crs,
     )?;
 
     let encoded = PlaintextList::from_container(
@@ -2861,12 +2857,12 @@ where
             .copied()
             .map(CastFrom::cast_from)
             .collect::<Vec<_>>(),
-        public_params,
+        crs.public_params(),
         random_generator,
     );
 
     Ok(prove(
-        (public_params, &public_commit),
+        (crs.public_params(), &public_commit),
         &private_commit,
         metadata,
         load,
@@ -3232,7 +3228,7 @@ pub fn par_encrypt_lwe_compact_ciphertext_list_with_compact_public_key<
 ///     &mut secret_generator,
 ///     &mut encryption_generator,
 ///     &mut random_generator,
-///     crs.public_params(),
+///     &crs,
 ///     &metadata,
 ///     ZkComputeLoad::Proof,
 /// )
@@ -3243,7 +3239,7 @@ pub fn par_encrypt_lwe_compact_ciphertext_list_with_compact_public_key<
 ///     &output_compact_ct_list,
 ///     &lwe_compact_public_key,
 ///     &proof,
-///     crs.public_params(),
+///     &crs,
 ///     &metadata,
 /// )
 /// .is_valid());
@@ -3294,7 +3290,7 @@ pub fn par_encrypt_and_prove_lwe_compact_ciphertext_list_with_compact_public_key
     secret_generator: &mut SecretRandomGenerator<SecretGen>,
     encryption_generator: &mut EncryptionRandomGenerator<EncryptionGen>,
     random_generator: &mut RandomGenerator<G>,
-    public_params: &CompactPkePublicParams,
+    crs: &CompactPkeCrs,
     metadata: &[u8],
     load: ZkComputeLoad,
 ) -> crate::Result<CompactPkeProof>
@@ -3321,7 +3317,7 @@ where
         delta,
         mask_noise_distribution,
         body_noise_distribution,
-        public_params,
+        crs,
     )?;
 
     let encoded = PlaintextList::from_container(
@@ -3395,12 +3391,12 @@ where
             .copied()
             .map(CastFrom::cast_from)
             .collect::<Vec<_>>(),
-        public_params,
+        crs.public_params(),
         random_generator,
     );
 
     Ok(prove(
-        (public_params, &public_commit),
+        (crs.public_params(), &public_commit),
         &private_commit,
         metadata,
         load,

--- a/tfhe/src/core_crypto/algorithms/lwe_zero_knowledge_verification.rs
+++ b/tfhe/src/core_crypto/algorithms/lwe_zero_knowledge_verification.rs
@@ -1,6 +1,6 @@
 use crate::core_crypto::entities::{LweCompactCiphertextList, LweCompactPublicKey};
 use crate::core_crypto::prelude::{CastFrom, Container, LweCiphertext, UnsignedInteger};
-use crate::zk::{CompactPkeProof, CompactPkePublicParams, ZkVerificationOutCome};
+use crate::zk::{CompactPkeCrs, CompactPkeProof, ZkVerificationOutCome};
 use tfhe_zk_pok::proofs::pke::{verify, PublicCommit};
 
 /// Verifies with the given proof that a [`LweCompactCiphertextList`]
@@ -9,7 +9,7 @@ pub fn verify_lwe_compact_ciphertext_list<Scalar, ListCont, KeyCont>(
     lwe_compact_list: &LweCompactCiphertextList<ListCont>,
     compact_public_key: &LweCompactPublicKey<KeyCont>,
     proof: &CompactPkeProof,
-    public_params: &CompactPkePublicParams,
+    crs: &CompactPkeCrs,
     metadata: &[u8],
 ) -> ZkVerificationOutCome
 where
@@ -51,7 +51,7 @@ where
             .map(|x| i64::cast_from(x))
             .collect(),
     );
-    match verify(proof, (public_params, &public_commit), metadata) {
+    match verify(proof, (crs.public_params(), &public_commit), metadata) {
         Ok(_) => ZkVerificationOutCome::Valid,
         Err(_) => ZkVerificationOutCome::Invalid,
     }
@@ -61,7 +61,7 @@ pub fn verify_lwe_ciphertext<Scalar, Cont, KeyCont>(
     lwe_ciphertext: &LweCiphertext<Cont>,
     compact_public_key: &LweCompactPublicKey<KeyCont>,
     proof: &CompactPkeProof,
-    public_params: &CompactPkePublicParams,
+    crs: &CompactPkeCrs,
     metadata: &[u8],
 ) -> ZkVerificationOutCome
 where
@@ -97,7 +97,7 @@ where
             .collect(),
         vec![i64::cast_from(*lwe_ciphertext.get_body().data); 1],
     );
-    match verify(proof, (public_params, &public_commit), metadata) {
+    match verify(proof, (crs.public_params(), &public_commit), metadata) {
         Ok(_) => ZkVerificationOutCome::Valid,
         Err(_) => ZkVerificationOutCome::Invalid,
     }

--- a/tfhe/src/core_crypto/algorithms/test/lwe_encryption.rs
+++ b/tfhe/src/core_crypto/algorithms/test/lwe_encryption.rs
@@ -1064,7 +1064,7 @@ fn lwe_compact_public_encrypt_prove_verify_decrypt_custom_mod<Scalar>(
                 &mut rsc.secret_random_generator,
                 &mut rsc.encryption_random_generator,
                 &mut random_generator,
-                crs.public_params(),
+                &crs,
                 &metadata,
                 ZkComputeLoad::Proof,
             )
@@ -1082,18 +1082,13 @@ fn lwe_compact_public_encrypt_prove_verify_decrypt_custom_mod<Scalar>(
             assert_eq!(msg, decoded);
 
             // Verify the proof
-            assert!(
-                verify_lwe_ciphertext(&ct, &pk, &proof, crs.public_params(), &metadata).is_valid()
-            );
+            assert!(verify_lwe_ciphertext(&ct, &pk, &proof, &crs, &metadata).is_valid());
 
             // verify proof with invalid ciphertext
             let index = random_generator.gen::<usize>() % ct.as_ref().len();
             let value_to_add = random_generator.gen::<Scalar>();
             ct.as_mut()[index] = ct.as_mut()[index].wrapping_add(value_to_add);
-            assert!(
-                verify_lwe_ciphertext(&ct, &pk, &proof, crs.public_params(), &metadata)
-                    .is_invalid()
-            );
+            assert!(verify_lwe_ciphertext(&ct, &pk, &proof, &crs, &metadata).is_invalid());
         }
 
         // In coverage, we break after one while loop iteration, changing message values does not
@@ -1193,7 +1188,7 @@ fn test_par_compact_lwe_list_public_key_encryption_and_proof() {
                 &mut secret_random_generator,
                 &mut encryption_random_generator,
                 &mut random_generator,
-                crs.public_params(),
+                &crs,
                 &metadata,
                 ZkComputeLoad::Proof,
             )
@@ -1203,7 +1198,7 @@ fn test_par_compact_lwe_list_public_key_encryption_and_proof() {
                 &output_compact_ct_list,
                 &compact_lwe_pk,
                 &proof,
-                crs.public_params(),
+                &crs,
                 &metadata
             )
             .is_valid());
@@ -1234,7 +1229,7 @@ fn test_par_compact_lwe_list_public_key_encryption_and_proof() {
                 &output_compact_ct_list,
                 &compact_lwe_pk,
                 &proof,
-                crs.public_params(),
+                &crs,
                 &metadata
             )
             .is_invalid());
@@ -1285,7 +1280,7 @@ fn test_par_compact_lwe_list_public_key_encryption_and_proof() {
                 &mut secret_random_generator,
                 &mut encryption_random_generator,
                 &mut random_generator,
-                crs.public_params(),
+                &crs,
                 &metadata,
                 ZkComputeLoad::Proof,
             )
@@ -1295,7 +1290,7 @@ fn test_par_compact_lwe_list_public_key_encryption_and_proof() {
                 &output_compact_ct_list,
                 &compact_lwe_pk,
                 &proof,
-                crs.public_params(),
+                &crs,
                 &metadata
             )
             .is_valid());
@@ -1326,7 +1321,7 @@ fn test_par_compact_lwe_list_public_key_encryption_and_proof() {
                 &output_compact_ct_list,
                 &compact_lwe_pk,
                 &proof,
-                crs.public_params(),
+                &crs,
                 &metadata
             )
             .is_invalid());

--- a/tfhe/src/high_level_api/tests/tags_on_entities.rs
+++ b/tfhe/src/high_level_api/tests/tags_on_entities.rs
@@ -58,18 +58,14 @@ fn test_tag_propagation_zk_pok() {
         .push(i64::MIN)
         .push(false)
         .push(true)
-        .build_with_proof_packed(
-            crs.public_params(),
-            &metadata,
-            crate::zk::ZkComputeLoad::Proof,
-        )
+        .build_with_proof_packed(&crs, &metadata, crate::zk::ZkComputeLoad::Proof)
         .unwrap();
 
     let list_packed: ProvenCompactCiphertextList = serialize_then_deserialize(list_packed);
     assert_eq!(list_packed.tag(), cks.tag());
 
     let expander = list_packed
-        .verify_and_expand(crs.public_params(), &cpk, &metadata)
+        .verify_and_expand(&crs, &cpk, &metadata)
         .unwrap();
 
     {

--- a/tfhe/src/js_on_wasm_api/js_high_level_api/integers.rs
+++ b/tfhe/src/js_on_wasm_api/js_high_level_api/integers.rs
@@ -4,7 +4,7 @@ use crate::integer::bigint::{StaticUnsignedBigInt, U1024, U2048, U512};
 use crate::integer::{I256, U256};
 use crate::js_on_wasm_api::js_high_level_api::keys::TfheCompactPublicKey;
 #[cfg(feature = "zk-pok")]
-use crate::js_on_wasm_api::js_high_level_api::zk::{CompactPkePublicParams, ZkComputeLoad};
+use crate::js_on_wasm_api::js_high_level_api::zk::{CompactPkeCrs, ZkComputeLoad};
 use crate::js_on_wasm_api::js_high_level_api::{catch_panic, catch_panic_result, into_js_error};
 use js_sys::BigInt;
 use wasm_bindgen::prelude::*;
@@ -794,14 +794,14 @@ impl ProvenCompactCiphertextList {
     #[wasm_bindgen]
     pub fn verify_and_expand(
         &self,
-        public_params: &CompactPkePublicParams,
+        crs: &CompactPkeCrs,
         public_key: &TfheCompactPublicKey,
         metadata: &[u8],
     ) -> Result<CompactCiphertextListExpander, JsError> {
         catch_panic_result(|| {
             let inner = self
                 .0
-                .verify_and_expand(&public_params.0, &public_key.0, metadata)
+                .verify_and_expand(&crs.0, &public_key.0, metadata)
                 .map_err(into_js_error)?;
             Ok(CompactCiphertextListExpander(inner))
         })
@@ -1040,13 +1040,13 @@ impl CompactCiphertextListBuilder {
     #[cfg(feature = "zk-pok")]
     pub fn build_with_proof_packed(
         &self,
-        public_params: &CompactPkePublicParams,
+        crs: &CompactPkeCrs,
         metadata: &[u8],
         compute_load: ZkComputeLoad,
     ) -> Result<ProvenCompactCiphertextList, JsError> {
         catch_panic_result(|| {
             self.0
-                .build_with_proof_packed(&public_params.0, metadata, compute_load.into())
+                .build_with_proof_packed(&crs.0, metadata, compute_load.into())
                 .map_err(into_js_error)
                 .map(ProvenCompactCiphertextList)
         })

--- a/tfhe/src/js_on_wasm_api/js_high_level_api/zk.rs
+++ b/tfhe/src/js_on_wasm_api/js_high_level_api/zk.rs
@@ -25,13 +25,10 @@ impl From<ZkComputeLoad> for crate::zk::ZkComputeLoad {
 #[wasm_bindgen]
 pub struct CompactPkeCrs(pub(crate) crate::core_crypto::entities::CompactPkeCrs);
 
-#[wasm_bindgen]
-pub struct CompactPkePublicParams(pub(crate) crate::zk::CompactPkePublicParams);
-
 // "wasm bindgen is fragile and prefers the actual type vs. Self"
 #[allow(clippy::use_self)]
 #[wasm_bindgen]
-impl CompactPkePublicParams {
+impl CompactPkeCrs {
     #[wasm_bindgen]
     pub fn serialize(&self, compress: bool) -> Result<Vec<u8>, JsError> {
         catch_panic_result(|| {
@@ -45,12 +42,12 @@ impl CompactPkePublicParams {
     }
 
     #[wasm_bindgen]
-    pub fn deserialize(buffer: &[u8]) -> Result<CompactPkePublicParams, JsError> {
+    pub fn deserialize(buffer: &[u8]) -> Result<CompactPkeCrs, JsError> {
         // If buffer is compressed it is automatically detected and uncompressed.
         // TODO: handle validation
         catch_panic_result(|| {
             bincode::deserialize(buffer)
-                .map(CompactPkePublicParams)
+                .map(CompactPkeCrs)
                 .map_err(into_js_error)
         })
     }
@@ -71,7 +68,7 @@ impl CompactPkePublicParams {
     pub fn safe_deserialize(
         buffer: &[u8],
         serialized_size_limit: u64,
-    ) -> Result<CompactPkePublicParams, JsError> {
+    ) -> Result<CompactPkeCrs, JsError> {
         catch_panic_result(|| {
             crate::safe_serialization::DeserializationConfig::new(serialized_size_limit)
                 .disable_conformance()
@@ -80,12 +77,7 @@ impl CompactPkePublicParams {
                 .map_err(into_js_error)
         })
     }
-}
 
-// "wasm bindgen is fragile and prefers the actual type vs. Self"
-#[allow(clippy::use_self)]
-#[wasm_bindgen]
-impl CompactPkeCrs {
     #[wasm_bindgen]
     pub fn from_parameters(
         parameters: &ShortintParameters,
@@ -111,7 +103,28 @@ impl CompactPkeCrs {
     }
 
     #[wasm_bindgen]
-    pub fn public_params(&self) -> CompactPkePublicParams {
-        CompactPkePublicParams(self.0.public_params().clone())
+    pub fn deserialize_from_public_params(buffer: &[u8]) -> Result<CompactPkeCrs, JsError> {
+        // If buffer is compressed it is automatically detected and uncompressed.
+        catch_panic_result(|| {
+            bincode::deserialize(buffer)
+                .map(crate::zk::CompactPkePublicParams::into)
+                .map(CompactPkeCrs)
+                .map_err(into_js_error)
+        })
+    }
+
+    #[wasm_bindgen]
+    pub fn safe_deserialize_from_public_params(
+        buffer: &[u8],
+        serialized_size_limit: u64,
+    ) -> Result<CompactPkeCrs, JsError> {
+        catch_panic_result(|| {
+            crate::safe_serialization::DeserializationConfig::new(serialized_size_limit)
+                .disable_conformance()
+                .deserialize_from(buffer)
+                .map(crate::zk::CompactPkePublicParams::into)
+                .map(CompactPkeCrs)
+                .map_err(into_js_error)
+        })
     }
 }

--- a/tfhe/tests/backward_compatibility/high_level_api.rs
+++ b/tfhe/tests/backward_compatibility/high_level_api.rs
@@ -4,6 +4,8 @@ use std::path::Path;
 use tfhe::prelude::{CiphertextList, FheDecrypt, FheEncrypt};
 use tfhe::shortint::PBSParameters;
 #[cfg(feature = "zk-pok")]
+use tfhe::zk::CompactPkeCrs;
+#[cfg(feature = "zk-pok")]
 use tfhe::zk::CompactPkePublicParams;
 use tfhe::{
     set_server_key, ClientKey, CompactCiphertextList, CompressedCiphertextList,
@@ -148,8 +150,13 @@ pub fn test_zk_params(
     test: &ZkPkePublicParamsTest,
     format: DataFormat,
 ) -> Result<TestSuccess, TestFailure> {
+    // Since CompactPkeCrs is a repr(transparent) of a CompactPkePublicParams, both can be loaded
+    // from the same data, so we check this.
     #[cfg(feature = "zk-pok")]
     let _loaded_params: CompactPkePublicParams = load_and_unversionize(dir, test, format)?;
+
+    #[cfg(feature = "zk-pok")]
+    let _loaded_crs: CompactPkeCrs = load_and_unversionize(dir, test, format)?;
 
     #[cfg(not(feature = "zk-pok"))]
     let _ = dir;
@@ -180,10 +187,11 @@ pub fn test_hl_heterogeneous_ciphertext_list(
         #[cfg(feature = "zk-pok")]
         {
             let crs_file = dir.join(&*zk_info.params_filename);
-            let crs = CompactPkePublicParams::unversionize(
+            let public_params = CompactPkePublicParams::unversionize(
                 load_versioned_auxiliary(crs_file).map_err(|e| test.failure(e, format))?,
             )
             .map_err(|e| test.failure(e, format))?;
+            let crs = CompactPkeCrs::from(public_params);
 
             let pubkey_file = dir.join(&*zk_info.public_key_filename);
             let pubkey = CompactPublicKey::unversionize(

--- a/tfhe/tests/zk_wasm_x86_test.rs
+++ b/tfhe/tests/zk_wasm_x86_test.rs
@@ -14,7 +14,7 @@ use tfhe::safe_serialization::{safe_deserialize, safe_serialize};
 use tfhe::shortint::parameters::compact_public_key_only::p_fail_2_minus_64::ks_pbs::PARAM_PKE_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64;
 use tfhe::shortint::parameters::key_switching::p_fail_2_minus_64::ks_pbs::PARAM_KEYSWITCH_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64;
 use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64;
-use tfhe::zk::{CompactPkeCrs, CompactPkePublicParams};
+use tfhe::zk::CompactPkeCrs;
 use tfhe::{ClientKey, CompactPublicKey, ConfigBuilder, ProvenCompactCiphertextList};
 
 const SIZE_LIMIT: u64 = 1024 * 1024 * 1024;
@@ -59,7 +59,7 @@ fn gen_proven_ct_in_wasm(path: &Path) {
 
 fn verify_proof(
     public_key: &CompactPublicKey,
-    crs: &CompactPkePublicParams,
+    crs: &CompactPkeCrs,
     proven_ct: &ProvenCompactCiphertextList,
 ) {
     println!("Verifying proof");
@@ -86,12 +86,12 @@ fn test_proof_compat_with_wasm() {
     safe_serialize(&pub_key, &mut f_pubkey, SIZE_LIMIT).unwrap();
 
     let mut f_crs = File::create(test_path.join("crs.bin")).unwrap();
-    safe_serialize(crs.public_params(), &mut f_crs, SIZE_LIMIT).unwrap();
+    safe_serialize(&crs, &mut f_crs, SIZE_LIMIT).unwrap();
 
     gen_proven_ct_in_wasm(&test_path);
 
     let mut f_ct = File::open(test_path.join("proof.bin")).unwrap();
     let proven_ct: ProvenCompactCiphertextList = safe_deserialize(&mut f_ct, SIZE_LIMIT).unwrap();
 
-    verify_proof(&pub_key, crs.public_params(), &proven_ct);
+    verify_proof(&pub_key, &crs, &proven_ct);
 }

--- a/tfhe/tests/zk_wasm_x86_test/index.js
+++ b/tfhe/tests/zk_wasm_x86_test/index.js
@@ -1,7 +1,7 @@
 const {
     TfheCompactPublicKey,
     CompactCiphertextList,
-    CompactPkePublicParams,
+    CompactPkeCrs,
     ZkComputeLoad,
 } = require('node-tfhe');
 
@@ -14,7 +14,7 @@ const tfhe_proof = async () => {
     const publicKeyBuf = fs.readFileSync(`${__dirname}/public_key.bin`);
     const publicParamsBuf = fs.readFileSync(`${__dirname}/crs.bin`);
     const publicKey = TfheCompactPublicKey.safe_deserialize(publicKeyBuf, SIZE_LIMIT);
-    const publicParams = CompactPkePublicParams.safe_deserialize(publicParamsBuf, SIZE_LIMIT);
+    const publicParams = CompactPkeCrs.safe_deserialize(publicParamsBuf, SIZE_LIMIT);
 
     const builder = CompactCiphertextList.builder(publicKey);
     builder.push_u4(1);


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: https://github.com/zama-ai/tfhe-rs-internal/issues/800#issue-2603108396

### PR content/description
Use the CompactPkeCrs instead of the CompactPkePublicParams. It simplifies a bit the workflow for users, they generate a crs and are directly able to use it and serialize it without having to extract the params.

Having a release 0.11 in Cargo.toml was necessary to be able to update the data repo.

### Check-list:

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [x] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
