### PR TITLE
Mz/fix oom

### DIFF
--- a/scripts/c_api_tests.sh
+++ b/scripts/c_api_tests.sh
@@ -49,13 +49,29 @@ REPO_ROOT="${CURR_DIR}/.."
 TFHE_BUILD_DIR="${REPO_ROOT}/tfhe/build/"
 CPU_COUNT="$("${CURR_DIR}"/cpu_count.sh)"
 
+
+
+LINKING_CPU_COUNT=4
+
+# On linux
+if [[ $(uname) != "Darwin" ]]; then
+    mem_in_gb="$(free -g | awk '/Mem:/ {print $2}')"
+
+    # If there is more than 100GB on the system,
+    # use all available cores for linking
+    # Otherwise, only use 4, to avoid OOM when linking
+    if [ 100 -lt "$mem_in_gb" ]; then
+        LINKING_CPU_COUNT="$(CPU_COUNT)"
+    fi
+fi
+
 mkdir -p "${TFHE_BUILD_DIR}"
 
 cd "${TFHE_BUILD_DIR}"
 
 cmake .. -DCMAKE_BUILD_TYPE=RELEASE -DCARGO_PROFILE="${CARGO_PROFILE}" -DWITH_FEATURE_GPU="${WITH_FEATURE_GPU}"
 
-make -j "${CPU_COUNT}"
+make -j "${LINKING_CPU_COUNT}"
 
 if [[ "${BUILD_ONLY}" == "1" ]]; then
     exit 0

--- a/scripts/c_api_tests.sh
+++ b/scripts/c_api_tests.sh
@@ -61,15 +61,10 @@ if [[ "${BUILD_ONLY}" == "1" ]]; then
     exit 0
 fi
 
-nproc_bin=nproc
 
-# macOS detects CPUs differently
-if [[ $(uname) == "Darwin" ]]; then
-    nproc_bin="sysctl -n hw.logicalcpu"
-fi
 
 if [ "${WITH_FEATURE_GPU}" == "ON" ]; then
-    ctest --output-on-failure --test-dir "." --parallel "$(${nproc_bin})" --tests-regex ".*cuda.*"
+    ctest --output-on-failure --test-dir "." --parallel "${CPU_COUNT}" --tests-regex ".*cuda.*"
 else
-    ctest --output-on-failure --test-dir "." --parallel "$(${nproc_bin})" --exclude-regex ".*cuda.*"
+    ctest --output-on-failure --test-dir "." --parallel "${CPU_COUNT}" --exclude-regex ".*cuda.*"
 fi

--- a/scripts/shortint-tests.sh
+++ b/scripts/shortint-tests.sh
@@ -67,14 +67,7 @@ fi
 CURR_DIR="$(dirname "$0")"
 ARCH_FEATURE="$("${CURR_DIR}/get_arch_feature.sh")"
 
-nproc_bin=nproc
-
-# macOS detects CPUs differently
-if [[ $(uname) == "Darwin" ]]; then
-    nproc_bin="sysctl -n hw.logicalcpu"
-fi
-
-n_threads_small="$(${nproc_bin})"
+n_threads_small="$("${CURR_DIR}"/cpu_count.sh)"
 n_threads_big="${n_threads_small}"
 
 # TODO: automate thread selection by measuring host machine ram and loading the key sizes from the


### PR DESCRIPTION
Use fewer CPU cores when linking C API tests (expect if there if more than 100GB of total RAM for the CI machines)