### PR TITLE
Fix: comparison less or equal then

### DIFF
--- a/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_scalar_comparison.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_scalar_comparison.rs
@@ -736,6 +736,13 @@ mod no_coverage {
         // but with param 3_3 we actually encrypt more that 128bits
         PARAM_MESSAGE_4_CARRY_4_KS_PBS_GAUSSIAN_2M64
     });
+
+    create_parametrized_test!(integer_comparisons_for_empty_blocks {
+        PARAM_MESSAGE_1_CARRY_1_KS_PBS_GAUSSIAN_2M64,
+        PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64,
+        PARAM_MESSAGE_3_CARRY_3_KS_PBS_GAUSSIAN_2M64,
+        PARAM_MESSAGE_4_CARRY_4_KS_PBS_GAUSSIAN_2M64,
+    });
 }
 
 // Smaller integers are used in coverage to speed-up execution.


### PR DESCRIPTION
### PR content/description

There was an equality sign missing in the scalar comparisons.

### Check-list:

* [x] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
