### PR TITLE
chore(gpu): change target for multi-gpu tests

### DIFF
--- a/ci/slab.toml
+++ b/ci/slab.toml
@@ -66,7 +66,7 @@ flavor_name = "n3-A100x8-NVLink"
 [backend.hyperstack.multi-gpu-test]
 environment_name = "canada"
 image_name = "Ubuntu Server 22.04 LTS R535 CUDA 12.2"
-flavor_name = "n3-RTX-A6000x4"
+flavor_name = "n3-L40x4"
 
 [backend.hyperstack.l40]
 environment_name = "canada"


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description
I'm changing the target for multi-gpu tests as L40s seem to be still quite available, while rtx a6000 are not anymore...
### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
