### PR TITLE
fix: bench key size parsing

### DIFF
--- a/ci/benchmark_parser.py
+++ b/ci/benchmark_parser.py
@@ -284,7 +284,7 @@ def _parse_key_results(result_file, bench_type):
         reader = csv.reader(csv_file)
         for test_name, value in reader:
             try:
-                params, display_name, operator = get_parameters(test_name, crate)
+                params, display_name, operator = get_parameters(test_name, "tfhe")
             except Exception as err:
                 parsing_failures.append((test_name, f"failed to get parameters: {err}"))
                 continue


### PR DESCRIPTION
For keygen and keysize benches, the `crate` argument was not set when calling `get_parameters` from `_parse_key_results`.
Since these benches only make sense from the main `tfhe` crate, the value of the argument is forced to be `tfhe`.