### PR TITLE
fix(hlapi): rework CompressedCiphertextListBuilder

### DIFF
--- a/tfhe/src/high_level_api/booleans/inner.rs
+++ b/tfhe/src/high_level_api/booleans/inner.rs
@@ -168,18 +168,6 @@ impl InnerBoolean {
         }
     }
 
-    /// Returns the inner cpu ciphertext if self is on the CPU, otherwise, returns a copy
-    /// that is on the CPU
-    pub(crate) fn into_cpu(self) -> BooleanBlock {
-        match self {
-            Self::Cpu(ct) => ct,
-            #[cfg(feature = "gpu")]
-            Self::Cuda(ct) => {
-                with_thread_local_cuda_streams(|streams| ct.to_boolean_block(streams))
-            }
-        }
-    }
-
     #[cfg(feature = "gpu")]
     pub(crate) fn into_gpu(
         self,

--- a/tfhe/src/integer/gpu/ciphertext/compressed_ciphertext_list.rs
+++ b/tfhe/src/integer/gpu/ciphertext/compressed_ciphertext_list.rs
@@ -62,7 +62,7 @@ impl CudaExpandable for CudaBooleanBlock {
 }
 pub struct CudaCompressedCiphertextList {
     pub(crate) packed_list: CudaPackedGlweCiphertext,
-    info: Vec<DataKind>,
+    pub(crate) info: Vec<DataKind>,
 }
 
 impl CudaCompressedCiphertextList {


### PR DESCRIPTION
The hlapi builder target device was selected depending on features (gpu enabled ? gpu : cpu), but if at `build` time the thread_local key did not match the expected device, an error would be returned.

This is a bit too limiting for users that might want to do some processing on GPU and compression on CPU.

So the Builder is changed to delay, the selection of device used to compress when `build` is called.
This new design is more flexible for end users, at the cost of a bit more memory copies

* There should be no API breaking change
* There is no serialization breaking change as only the builder
  (which is not serializable) has been changed
