### PR TITLE
Fix: degree for min max

### DIFF
--- a/tfhe/src/integer/server_key/comparator.rs
+++ b/tfhe/src/integer/server_key/comparator.rs
@@ -1,6 +1,7 @@
 use super::ServerKey;
 use crate::integer::ciphertext::boolean_value::BooleanBlock;
 use crate::integer::ciphertext::IntegerRadixCiphertext;
+use crate::shortint::ciphertext::Degree;
 use crate::shortint::server_key::LookupTableOwned;
 use crate::shortint::Ciphertext;
 
@@ -407,8 +408,9 @@ impl<'a> Comparator<'a> {
 
             let maybe_lhs = self.server_key.key.apply_lookup_table(&lhs_block, lhs_lut);
             let maybe_rhs = self.server_key.key.apply_lookup_table(&rhs_block, rhs_lut);
-
-            let r = self.server_key.key.unchecked_add(&maybe_lhs, &maybe_rhs);
+            let mut r = self.server_key.key.unchecked_add(&maybe_lhs, &maybe_rhs);
+            // Either maybe_lhs or maybe_rhs is zero, which means that the degree is tighter.
+            r.degree = Degree::new(self.server_key.message_modulus().0 - 1);
             result.push(r);
         }
 

--- a/tfhe/src/integer/server_key/radix/tests.rs
+++ b/tfhe/src/integer/server_key/radix/tests.rs
@@ -1,6 +1,7 @@
 use crate::integer::keycache::KEY_CACHE;
 use crate::integer::server_key::radix_parallel::tests_cases_unsigned::*;
 use crate::integer::server_key::radix_parallel::tests_unsigned::test_add::smart_add_test;
+use crate::integer::server_key::radix_parallel::tests_unsigned::test_comparison::test_unchecked_minmax;
 use crate::integer::server_key::radix_parallel::tests_unsigned::test_neg::smart_neg_test;
 use crate::integer::server_key::radix_parallel::tests_unsigned::test_slice::{
     default_scalar_bitslice_assign_test, default_scalar_bitslice_test,
@@ -117,6 +118,16 @@ create_parametrized_test_classical_params!(integer_default_scalar_slice);
 create_parametrized_test_classical_params!(integer_default_scalar_slice_assign);
 create_parametrized_test_classical_params!(integer_smart_scalar_slice);
 create_parametrized_test_classical_params!(integer_smart_scalar_slice_assign);
+create_parametrized_test!(integer_unchecked_min {
+    coverage => {
+        COVERAGE_PARAM_MESSAGE_2_CARRY_2_KS_PBS
+    },
+    no_coverage => {
+        PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64,
+        PARAM_MESSAGE_3_CARRY_3_KS_PBS_GAUSSIAN_2M64,
+        PARAM_MESSAGE_4_CARRY_4_KS_PBS_GAUSSIAN_2M64
+    }
+});
 
 fn integer_encrypt_decrypt(param: ClassicPBSParameters) {
     let (cks, _) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
@@ -799,4 +810,9 @@ fn integer_smart_scalar_slice(param: ClassicPBSParameters) {
 fn integer_smart_scalar_slice_assign(param: ClassicPBSParameters) {
     let executor = CpuFunctionExecutor::new(&ServerKey::smart_scalar_bitslice_assign);
     smart_scalar_bitslice_assign_test(param, executor);
+}
+
+fn integer_unchecked_min(param: ClassicPBSParameters) {
+    let executor = CpuFunctionExecutor::new(&ServerKey::unchecked_min);
+    test_unchecked_minmax(param, 2, executor, std::cmp::min::<u64>);
 }

--- a/tfhe/src/shortint/ciphertext/common.rs
+++ b/tfhe/src/shortint/ciphertext/common.rs
@@ -143,7 +143,7 @@ impl MaxDegree {
     }
 }
 
-/// This tracks the number of operations that has been done.
+/// The maximum value a given ciphertext can have. This helps with optimizations.
 #[derive(
     Debug, PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Serialize, Deserialize, Versionize,
 )]


### PR DESCRIPTION
### PR content/description

Contains a test to recreate an issue we have been having at Belfort. The min - max functions seem to fail at the assertion that [the carries are empty](https://github.com/zama-ai/tfhe-rs/blob/46cf46563770f8e8072ff97692bf18d7d8673158/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_comparison.rs#L611). IIUC, this is due to the fact that `unchecked_add` will add together the degrees, but we know that either the LHS or the RHS will be set to 0 after performing the LUT [here](https://github.com/zama-ai/tfhe-rs/blob/46cf46563770f8e8072ff97692bf18d7d8673158/tfhe/src/integer/server_key/comparator.rs#L405-L406).

 It can be solved in the following ways:

1. Set the degree to `Degree::new(msg_modulus - 1)`.
2. Add a remainder operation in the LUTs (`% message_modulus`).
3. Calculate the maximum degree before applying the additions and the LUTs.

- Which one is your preferred solution?

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
