### PR TITLE
Ns/zk test bad ct

### DIFF
--- a/tfhe-zk-pok/src/proofs/mod.rs
+++ b/tfhe-zk-pok/src/proofs/mod.rs
@@ -133,7 +133,7 @@ impl<G: Curve> GroupElements<G> {
 }
 
 /// Allows to compute proof with bad inputs for tests
-#[derive(PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 enum ProofSanityCheckMode {
     Panic,
     #[cfg(test)]

--- a/tfhe-zk-pok/src/proofs/pke.rs
+++ b/tfhe-zk-pok/src/proofs/pke.rs
@@ -1274,6 +1274,16 @@ mod tests {
         msbs_zero_padding_bit_count: 1,
     };
 
+    /// Compact key params used with pkve1 to encrypt a single message
+    pub(super) const PKEV1_TEST_PARAMS_SINGLE: PkeTestParameters = PkeTestParameters {
+        d: 1024,
+        k: 1,
+        B: 4398046511104, // 2**42
+        q: 0,
+        t: 32, // 2b msg, 2b carry, 1b padding
+        msbs_zero_padding_bit_count: 1,
+    };
+
     /// Test that the proof is rejected if we use a different value between encryption and proof
     #[test]
     fn test_pke() {
@@ -1673,6 +1683,128 @@ mod tests {
         }
     }
 
+    /// Test verification with modified ciphertexts
+    #[test]
+    fn test_bad_ct() {
+        let PkeTestParameters {
+            d,
+            k,
+            B,
+            q,
+            t,
+            msbs_zero_padding_bit_count,
+        } = PKEV1_TEST_PARAMS;
+
+        let effective_cleartext_t = t >> msbs_zero_padding_bit_count;
+
+        let rng = &mut StdRng::seed_from_u64(0);
+
+        let testcase = PkeTestcase::gen(rng, PKEV1_TEST_PARAMS_SINGLE);
+        let ct = testcase.encrypt(PKEV1_TEST_PARAMS_SINGLE);
+
+        let ct_zero = testcase.sk_encrypt_zero(PKEV1_TEST_PARAMS_SINGLE, rng);
+
+        let c1_plus_zero = ct
+            .c1
+            .iter()
+            .zip(ct_zero.iter())
+            .map(|(a1, az)| a1.wrapping_add(*az))
+            .collect();
+        let c2_plus_zero = vec![ct.c2[0].wrapping_add(*ct_zero.last().unwrap())];
+
+        let ct_plus_zero = PkeTestCiphertext {
+            c1: c1_plus_zero,
+            c2: c2_plus_zero,
+        };
+
+        let m_plus_zero = testcase.decrypt(&ct_plus_zero, PKEV1_TEST_PARAMS_SINGLE);
+        assert_eq!(testcase.m, m_plus_zero);
+
+        let delta = {
+            let q = decode_q(q) as i128;
+            // delta takes the encoding with the padding bit
+            (q / t as i128) as u64
+        };
+
+        let trivial = rng.gen::<u64>() % effective_cleartext_t;
+        let trivial_pt = trivial * delta;
+        let c2_plus_trivial = vec![ct.c2[0].wrapping_add(trivial_pt as i64)];
+
+        let ct_plus_trivial = PkeTestCiphertext {
+            c1: ct.c1.clone(),
+            c2: c2_plus_trivial,
+        };
+
+        let m_plus_trivial = testcase.decrypt(&ct_plus_trivial, PKEV1_TEST_PARAMS_SINGLE);
+        assert_eq!(testcase.m[0] + trivial as i64, m_plus_trivial[0]);
+
+        let crs = crs_gen::<Curve>(d, k, B, q, t, msbs_zero_padding_bit_count, rng);
+
+        // Test proving with one ct and verifying another
+        let (public_commit_proof, private_commit) = commit(
+            testcase.a.clone(),
+            testcase.b.clone(),
+            ct.c1.clone(),
+            ct.c2.clone(),
+            testcase.r.clone(),
+            testcase.e1.clone(),
+            testcase.m.clone(),
+            testcase.e2.clone(),
+            &crs,
+            rng,
+        );
+
+        let (public_commit_verify_zero, _) = commit(
+            testcase.a.clone(),
+            testcase.b.clone(),
+            ct_plus_zero.c1.clone(),
+            ct_plus_zero.c2.clone(),
+            testcase.r.clone(),
+            testcase.e1.clone(),
+            testcase.m.clone(),
+            testcase.e2.clone(),
+            &crs,
+            rng,
+        );
+
+        let (public_commit_verify_trivial, _) = commit(
+            testcase.a.clone(),
+            testcase.b.clone(),
+            ct_plus_trivial.c1.clone(),
+            ct_plus_trivial.c2.clone(),
+            testcase.r.clone(),
+            testcase.e1.clone(),
+            testcase.m.clone(),
+            testcase.e2.clone(),
+            &crs,
+            rng,
+        );
+
+        for load in [ComputeLoad::Proof, ComputeLoad::Verify] {
+            let proof = prove(
+                (&crs, &public_commit_proof),
+                &private_commit,
+                &testcase.metadata,
+                load,
+                rng,
+            );
+
+            assert!(verify(
+                &proof,
+                (&crs, &public_commit_verify_zero),
+                &testcase.metadata
+            )
+            .is_err());
+
+            assert!(verify(
+                &proof,
+                (&crs, &public_commit_verify_trivial),
+                &testcase.metadata
+            )
+            .is_err());
+        }
+    }
+
     /// Test compression of proofs
     #[test]
     fn test_proof_compression() {
@@ -1689,8 +1821,6 @@ mod tests {
 
         let testcase = PkeTestcase::gen(rng, PKEV1_TEST_PARAMS);
         let ct = testcase.encrypt(PKEV1_TEST_PARAMS);
-
-        type Curve = curve_api::Bls12_446;
 
         let crs_k = k + 1 + (rng.gen::<usize>() % (d - k));
 
@@ -1742,8 +1872,6 @@ mod tests {
 
         let testcase = PkeTestcase::gen(rng, PKEV1_TEST_PARAMS);
         let ct = testcase.encrypt(PKEV1_TEST_PARAMS);
-
-        type Curve = curve_api::Bls12_446;
 
         let crs_k = k + 1 + (rng.gen::<usize>() % (d - k));
 

--- a/tfhe-zk-pok/src/proofs/pke.rs
+++ b/tfhe-zk-pok/src/proofs/pke.rs
@@ -1262,6 +1262,8 @@ mod tests {
     use rand::rngs::StdRng;
     use rand::{Rng, SeedableRng};
 
+    type Curve = curve_api::Bls12_446;
+
     /// Compact key params used with pkev1
     pub(super) const PKEV1_TEST_PARAMS: PkeTestParameters = PkeTestParameters {
         d: 1024,
@@ -1309,8 +1311,6 @@ mod tests {
 
         let mut fake_metadata = [255u8; METADATA_LEN];
         fake_metadata.fill_with(|| rng.gen::<u8>());
-
-        type Curve = curve_api::Bls12_446;
 
         // To check management of bigger k_max from CRS during test
         let crs_k = k + 1 + (rng.gen::<usize>() % (d - k));
@@ -1397,9 +1397,9 @@ mod tests {
         }
     }
 
-    fn prove_and_verify<G: Curve>(
+    fn prove_and_verify(
         testcase: &PkeTestcase,
-        crs: &PublicParams<G>,
+        crs: &PublicParams<Curve>,
         load: ComputeLoad,
         rng: &mut StdRng,
     ) -> VerificationResult {
@@ -1434,10 +1434,10 @@ mod tests {
         }
     }
 
-    fn assert_prove_and_verify<G: Curve>(
+    fn assert_prove_and_verify(
         testcase: &PkeTestcase,
         testcase_name: &str,
-        crs: &PublicParams<G>,
+        crs: &PublicParams<Curve>,
         rng: &mut StdRng,
         expected_result: VerificationResult,
     ) {
@@ -1465,8 +1465,6 @@ mod tests {
         let rng = &mut StdRng::seed_from_u64(0);
 
         let testcase = PkeTestcase::gen(rng, PKEV1_TEST_PARAMS);
-
-        type Curve = curve_api::Bls12_446;
 
         // A CRS where the number of slots = the number of messages to encrypt
         let crs = crs_gen::<Curve>(d, k, B, q, t, msbs_zero_padding_bit_count, rng);
@@ -1630,7 +1628,6 @@ mod tests {
         };
 
         let ct = testcase.encrypt(PKEV1_TEST_PARAMS);
-        type Curve = curve_api::Bls12_446;
 
         // To check management of bigger k_max from CRS during test
         let crs_k = k + 1 + (rng.gen::<usize>() % (d - k));


### PR DESCRIPTION


### PR content/description
Adds a zk test for a proof/verify, where the ct used in verify is the one of the proof with an encryption of zero that has been added.

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
