### PR TITLE
fix: zk-pok bench workflow using an invalid argument

### DIFF
--- a/.github/workflows/benchmark_tfhe_zk_pok.yml
+++ b/.github/workflows/benchmark_tfhe_zk_pok.yml
@@ -118,8 +118,7 @@ jobs:
           --commit-date "${{ env.COMMIT_DATE }}" \
           --bench-date "${{ env.BENCH_DATE }}" \
           --walk-subdirs \
-          --name-suffix avx512 \
-          --throughput
+          --name-suffix avx512
 
       - name: Upload parsed results artifact
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882


### PR DESCRIPTION


### PR content/description
Fix failed workflow: https://github.com/zama-ai/tfhe-rs/actions/runs/11983559817/job/33413286395#step:8:42
