### PR TITLE
Ns/bench zk cs ghl

### DIFF
--- a/tfhe-zk-pok/benches/utils.rs
+++ b/tfhe-zk-pok/benches/utils.rs
@@ -9,8 +9,9 @@ use serde::Serialize;
 use tfhe_zk_pok::proofs::pke::{commit, crs_gen, PrivateCommit, PublicCommit, PublicParams};
 
 use tfhe_zk_pok::proofs::pke_v2::{
-    commit as commitv2, crs_gen as crs_genv2, PrivateCommit as PrivateCommitv2,
-    PublicCommit as PublicCommitv2, PublicParams as PublicParamsv2,
+    commit as commitv2, crs_gen_cs as crs_genv2_cs, crs_gen_ghl as crs_genv2_ghl, Bound,
+    PrivateCommit as PrivateCommitv2, PublicCommit as PublicCommitv2,
+    PublicParams as PublicParamsv2,
 };
 
 // One of our usecases uses 320 bits of additional metadata
@@ -414,6 +415,7 @@ pub fn init_params_v1(
 #[allow(unused)]
 pub fn init_params_v2(
     test_params: PkeTestParameters,
+    bound: Bound,
 ) -> (
     PublicParamsv2<Curve>,
     PublicCommitv2<Curve>,
@@ -435,7 +437,10 @@ pub fn init_params_v2(
 
     let ct = testcase.encrypt(test_params);
 
-    let public_param = crs_genv2::<Curve>(d, k, B, q, t, msbs_zero_padding_bit_count, rng);
+    let public_param = match bound {
+        Bound::GHL => crs_genv2_ghl::<Curve>(d, k, B, q, t, msbs_zero_padding_bit_count, rng),
+        Bound::CS => crs_genv2_cs::<Curve>(d, k, B, q, t, msbs_zero_padding_bit_count, rng),
+    };
 
     let (public_commit, private_commit) = commitv2(
         testcase.a.clone(),

--- a/tfhe-zk-pok/src/four_squares.rs
+++ b/tfhe-zk-pok/src/four_squares.rs
@@ -1,8 +1,12 @@
 use ark_ff::biginteger::arithmetic::widening_mul;
 use rand::prelude::*;
 
-pub fn sqr<T: Copy + core::ops::Mul>(x: T) -> T::Output {
+pub fn sqr(x: u128) -> u128 {
     x * x
+}
+
+pub fn checked_sqr(x: u128) -> Option<u128> {
+    x.checked_mul(x)
 }
 
 // copied from the standard library

--- a/tfhe-zk-pok/src/proofs/pke_v2.rs
+++ b/tfhe-zk-pok/src/proofs/pke_v2.rs
@@ -525,7 +525,7 @@ Please select a smaller B, d and/or k"
     // safely used for this
     assert!(
         m_bound <= 64,
-        "Invalid paramters for zk_pok, w e only support 64 bits integer. \
+        "Invalid parameters for zk_pok, w e only support 64 bits integer. \
 The computed m parameter is {m_bound} > 64. Please select a smaller B, d and/or k"
     );
 


### PR DESCRIPTION
### PR content/description
Adds a bench to compare ghl and cs bounds for zk v2. Also add some limit tests for zk with extreme but supported values
