### PR TITLE
fix: clean noise of skipped block in full_propagate_parallelized

### DIFF
--- a/tfhe/src/integer/server_key/radix_parallel/mod.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/mod.rs
@@ -39,6 +39,8 @@ mod vector_find;
 
 use super::ServerKey;
 use crate::integer::ciphertext::IntegerRadixCiphertext;
+use crate::integer::RadixCiphertext;
+use crate::shortint::ciphertext::{Ciphertext, NoiseLevel};
 pub(crate) use add::OutputFlag;
 use rayon::prelude::*;
 pub use scalar_div_mod::{MiniUnsignedInteger, Reciprocable};
@@ -71,11 +73,7 @@ impl ServerKey {
     /// let res: u64 = cks.decrypt_one_block(&ct_res.blocks()[1]);
     /// assert_eq!(3, res);
     /// ```
-    pub fn propagate_parallelized<T>(
-        &self,
-        ctxt: &mut T,
-        index: usize,
-    ) -> crate::shortint::Ciphertext
+    pub fn propagate_parallelized<T>(&self, ctxt: &mut T, index: usize) -> Ciphertext
     where
         T: IntegerRadixCiphertext,
     {
@@ -97,14 +95,18 @@ impl ServerKey {
     /// Propagates carries starting from start_index.
     ///
     /// Does nothing if start_index >= ctxt.len() or ctxt is empty
-    pub fn partial_propagate_parallelized<T>(&self, ctxt: &mut T, mut start_index: usize)
+    pub fn partial_propagate_parallelized<T>(&self, ctxt: &mut T, start_index: usize)
     where
         T: IntegerRadixCiphertext,
     {
-        if start_index >= ctxt.blocks().len() || ctxt.blocks().is_empty() {
+        if start_index >= ctxt.blocks().len() {
             return;
         }
 
+        self.partial_propagate_blocks_parallelized(&mut ctxt.blocks_mut()[start_index..]);
+    }
+
+    fn partial_propagate_blocks_parallelized(&self, blocks: &mut [Ciphertext]) {
         // Extract message blocks and carry blocks from the
         // input block slice.
         // Carries Vec has one less block than message Vec
@@ -130,8 +132,8 @@ impl ServerKey {
             )
         };
 
-        if self.is_eligible_for_parallel_single_carry_propagation(ctxt.blocks().len()) {
-            let highest_degree = ctxt.blocks()[start_index..]
+        if self.is_eligible_for_parallel_single_carry_propagation(blocks.len()) {
+            let highest_degree = blocks
                 .iter()
                 .max_by(|block_a, block_b| block_a.degree.get().cmp(&block_b.degree.get()))
                 .map(|block| block.degree.get())
@@ -140,45 +142,51 @@ impl ServerKey {
             if highest_degree >= (self.key.message_modulus.0 - 1) * 2 {
                 // At least one of the blocks has more than one carry,
                 // we need to extract message and carries, then add + propagate
-                let (mut message_blocks, carry_blocks) =
-                    extract_message_and_carry_blocks(&ctxt.blocks()[start_index..]);
+                let (mut message_blocks, carry_blocks) = extract_message_and_carry_blocks(blocks);
 
-                ctxt.blocks_mut()[start_index] = message_blocks.remove(0);
-                let mut lhs = T::from(message_blocks);
-                let rhs = T::from(carry_blocks);
+                blocks[0] = message_blocks.remove(0);
+                let mut lhs = RadixCiphertext::from(message_blocks);
+                let rhs = RadixCiphertext::from(carry_blocks);
                 self.add_assign_with_carry_parallelized(&mut lhs, &rhs, None);
-                ctxt.blocks_mut()[start_index + 1..].clone_from_slice(lhs.blocks());
+                blocks[1..].clone_from_slice(&lhs.blocks);
             } else {
-                self.propagate_single_carry_parallelized(&mut ctxt.blocks_mut()[start_index..]);
+                self.propagate_single_carry_parallelized(&mut blocks[..]);
             }
         } else {
-            let maybe_highest_degree = ctxt
+            let maybe_highest_degree =
                 // We do not care about degree of 'first' block as it won't receive any carries
-                .blocks()[start_index + 1..]
+                blocks[1..]
                 .iter()
                 .max_by(|block_a, block_b| block_a.degree.get().cmp(&block_b.degree.get()))
                 .map(|block| block.degree.get());
 
+            let mut start_index = 0;
             if maybe_highest_degree.is_some_and(|degree| degree > self.key.max_degree.get()) {
                 // At least one of the blocks than can receive a carry, won't be able too
                 // so we need to do a first 'partial' round
-                let (mut message_blocks, carry_blocks) =
-                    extract_message_and_carry_blocks(&ctxt.blocks()[start_index..]);
-                ctxt.blocks_mut()[start_index..].swap_with_slice(&mut message_blocks);
-                for (block, carry) in ctxt.blocks_mut()[start_index + 1..]
-                    .iter_mut()
-                    .zip(carry_blocks.iter())
-                {
+                let (mut message_blocks, carry_blocks) = extract_message_and_carry_blocks(blocks);
+                blocks[0..].swap_with_slice(&mut message_blocks);
+                for (block, carry) in blocks[1..].iter_mut().zip(carry_blocks.iter()) {
                     self.key.unchecked_add_assign(block, carry);
                 }
                 // We can start propagation one index later as we already did the first block
                 start_index += 1;
             }
 
-            let len = ctxt.blocks().len();
+            let len = blocks.len();
             // If start_index >= len, the range is considered empty
             for i in start_index..len {
-                let _ = self.propagate_parallelized(ctxt, i);
+                let (carry, message) = rayon::join(
+                    || self.key.carry_extract(&blocks[i]),
+                    || self.key.message_extract(&blocks[i]),
+                );
+
+                blocks[i] = message;
+
+                //add the carry to the next block
+                if i < blocks.len() - 1 {
+                    self.key.unchecked_add_assign(&mut blocks[i + 1], &carry);
+                }
             }
         }
     }
@@ -212,14 +220,30 @@ impl ServerKey {
     where
         T: IntegerRadixCiphertext,
     {
-        let Some(start_index) = ctxt
+        let num_blocks = ctxt.blocks().len();
+        let start_index = ctxt
             .blocks()
             .iter()
             .position(|block| !block.carry_is_empty())
-        else {
-            // No block has any carries, do nothing
-            return;
-        };
-        self.partial_propagate_parallelized(ctxt, start_index);
+            .unwrap_or(num_blocks);
+
+        let (to_be_cleaned, to_be_propagated) = ctxt.blocks_mut().split_at_mut(start_index);
+
+        rayon::scope(|s| {
+            if !to_be_propagated.is_empty() {
+                s.spawn(|_| {
+                    self.partial_propagate_blocks_parallelized(to_be_propagated);
+                })
+            }
+
+            if !to_be_cleaned.is_empty() {
+                s.spawn(|_| {
+                    to_be_cleaned
+                        .par_iter_mut()
+                        .filter(|block| block.noise_level > NoiseLevel::NOMINAL)
+                        .for_each(|block| self.key.message_extract_assign(block));
+                });
+            }
+        })
     }
 }

--- a/tfhe/src/shortint/server_key/mod.rs
+++ b/tfhe/src/shortint/server_key/mod.rs
@@ -1385,10 +1385,19 @@ impl ServerKey {
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct CiphertextNoiseDegree {
     pub noise_level: NoiseLevel,
     pub degree: Degree,
+}
+
+impl CiphertextNoiseDegree {
+    pub fn new(noise_level: NoiseLevel, degree: Degree) -> Self {
+        Self {
+            noise_level,
+            degree,
+        }
+    }
 }
 
 impl Ciphertext {


### PR DESCRIPTION
In full_propagate_parallelized we find the first block which has a degree >= msg_mod, meaning it has a carry and start propagating from there.

However, while the preceding blocks may have no carry, their noise level may not be nominal, and so to leave the radix in a consistent state and clean state, full_propagate now also clean the noise for blocks that are not propagated


