### PR TITLE
fix(tfhe-lints): linter was not run, missing compile time env var

### DIFF
--- a/tfhe/src/high_level_api/compressed_ciphertext_list.rs
+++ b/tfhe/src/high_level_api/compressed_ciphertext_list.rs
@@ -213,12 +213,6 @@ pub(crate) enum InnerCompressedCiphertextList {
     Cuda(crate::integer::gpu::ciphertext::compressed_ciphertext_list::CudaCompressedCiphertextList),
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
-#[cfg_attr(tfhe_lints, allow(tfhe_lints::serialize_without_versionize))]
-pub(crate) struct InnerCompressedCiphertextListVersionOwned(
-    <crate::integer::ciphertext::CompressedCiphertextList as VersionizeOwned>::VersionedOwned,
-);
-
 impl Versionize for InnerCompressedCiphertextList {
     type Versioned<'vers> =
         <crate::integer::ciphertext::CompressedCiphertextList as VersionizeOwned>::VersionedOwned;

--- a/tfhe/src/shortint/wopbs/mod.rs
+++ b/tfhe/src/shortint/wopbs/mod.rs
@@ -17,6 +17,7 @@ mod test;
 
 // Struct for WoPBS based on the private functional packing keyswitch.
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(tfhe_lints, allow(tfhe_lints::serialize_without_versionize))]
 pub struct WopbsKey {
     //Key for the private functional keyswitch
     pub wopbs_server_key: ServerKey,

--- a/utils/cargo-tfhe-lints-inner/src/main.rs
+++ b/utils/cargo-tfhe-lints-inner/src/main.rs
@@ -27,6 +27,11 @@ fn main() {
         (tool_args.as_slice(), &[] as &[String])
     };
 
+    // The linter calls rustc without cargo, so these variables won't be set. Since we use them in
+    // our code, we need to set them to any value to avoid a compilation error.
+    std::env::set_var("CARGO_PKG_VERSION_MAJOR", "X");
+    std::env::set_var("CARGO_PKG_VERSION_MINOR", "Y");
+
     rustc_tools::cargo_integration(&cargo_args, |args| {
         let mut args = args.to_vec();
         args.extend(rustc_args.iter().skip(1).cloned());


### PR DESCRIPTION
### PR content/description
Fix the custom linter that was not running anymore due to an error in the child compiler process that was not propagated. Failure in the child process will now make the ci fail.

This is linked to https://github.com/zama-ai/tfhe-rs/pull/1810 but we also need the PR in rustc-tools to be merged to fix the issue with the toolchain update

