### PR TITLE
chore(all): remove the dependency to lazy_static

### DIFF
--- a/tasks/Cargo.toml
+++ b/tasks/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 
 [dependencies]
 clap = "=4.4.4"
-lazy_static = "1.4"
 log = "0.4"
 simplelog = "0.12"
 walkdir = "2.5.0"

--- a/tasks/src/main.rs
+++ b/tasks/src/main.rs
@@ -1,5 +1,4 @@
 use clap::{Arg, Command};
-use lazy_static::lazy_static;
 use log::LevelFilter;
 use simplelog::{ColorChoice, CombinedLogger, Config, TermLogger, TerminalMode};
 use std::sync::atomic::AtomicBool;
@@ -12,9 +11,8 @@ mod utils;
 // -------------------------------------------------------------------------------------------------
 // CONSTANTS
 // -------------------------------------------------------------------------------------------------
-lazy_static! {
-    static ref DRY_RUN: AtomicBool = AtomicBool::new(false);
-}
+
+static DRY_RUN: AtomicBool = AtomicBool::new(false);
 
 // -------------------------------------------------------------------------------------------------
 // MAIN

--- a/tfhe/Cargo.toml
+++ b/tfhe/Cargo.toml
@@ -24,7 +24,6 @@ rust-version = "1.83"
 [dev-dependencies]
 rand = { workspace = true }
 rand_distr = "0.4.3"
-lazy_static = { version = "1.4.0" }
 criterion = "0.5.1"
 doc-comment = "0.3.3"
 serde_json = "1.0.94"
@@ -57,7 +56,6 @@ tfhe-csprng = { version = "0.4.1", path = "../tfhe-csprng", features = [
     "generator_fallback",
     "parallel",
 ] }
-lazy_static = { version = "1.4.0", optional = true }
 serde = { workspace = true, features = ["default", "derive"] }
 rayon = { workspace = true }
 bincode = "1.3.3"
@@ -95,7 +93,7 @@ boolean = []
 shortint = ["dep:sha3"]
 integer = ["shortint"]
 strings = ["integer"]
-internal-keycache = ["dep:lazy_static", "dep:fs2"]
+internal-keycache = ["dep:fs2"]
 gpu = ["dep:tfhe-cuda-backend"]
 zk-pok = ["dep:tfhe-zk-pok"]
 

--- a/tfhe/examples/regex_engine/engine.rs
+++ b/tfhe/examples/regex_engine/engine.rs
@@ -213,16 +213,15 @@ fn build_branches(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::LazyLock;
+
     use crate::engine::has_match;
     use test_case::test_case;
 
     use crate::ciphertext::{encrypt_str, gen_keys, StringCiphertext};
-    use lazy_static::lazy_static;
     use tfhe::integer::{RadixClientKey, ServerKey};
 
-    lazy_static! {
-        pub static ref KEYS: (RadixClientKey, ServerKey) = gen_keys();
-    }
+    pub static KEYS: LazyLock<(RadixClientKey, ServerKey)> = LazyLock::new(|| gen_keys());
 
     #[test_case("ab", "/ab/", 1)]
     #[test_case("b", "/ab/", 0)]

--- a/tfhe/src/boolean/keycache.rs
+++ b/tfhe/src/boolean/keycache.rs
@@ -1,8 +1,9 @@
+use std::sync::LazyLock;
+
 use crate::boolean::parameters::*;
 use crate::boolean::{ClientKey, ServerKey};
 use crate::keycache::utils::named_params_impl;
 use crate::keycache::*;
-use lazy_static::*;
 
 named_params_impl!( BooleanParameters =>
     DEFAULT_PARAMETERS,
@@ -59,6 +60,4 @@ impl Keycache {
     }
 }
 
-lazy_static! {
-    pub static ref KEY_CACHE: Keycache = Keycache::default();
-}
+pub static KEY_CACHE: LazyLock<Keycache> = LazyLock::new(Keycache::default);

--- a/tfhe/src/core_crypto/keycache.rs
+++ b/tfhe/src/core_crypto/keycache.rs
@@ -4,11 +4,11 @@ use crate::core_crypto::algorithms::test::{
     PackingKeySwitchTestParams,
 };
 use crate::keycache::*;
-use lazy_static::*;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 #[cfg(feature = "internal-keycache")]
 use std::fmt::Debug;
+use std::sync::LazyLock;
 
 pub struct KeyCacheCoreImpl<P, K>
 where
@@ -177,9 +177,7 @@ impl KeyCacheAccess for PackingKeySwitchTestParams<u64> {
     }
 }
 
-lazy_static! {
-    pub static ref KEY_CACHE: KeyCache = KeyCache::default();
-}
+pub static KEY_CACHE: LazyLock<KeyCache> = LazyLock::new(KeyCache::default);
 
 #[cfg(feature = "internal-keycache")]
 #[test]

--- a/tfhe/src/integer/keycache.rs
+++ b/tfhe/src/integer/keycache.rs
@@ -4,7 +4,6 @@ use crate::integer::{ClientKey, IntegerKeyKind, ServerKey};
 use crate::shortint::PBSParameters;
 #[cfg(feature = "experimental")]
 use crate::shortint::WopbsParameters;
-use lazy_static::lazy_static;
 
 #[derive(Default)]
 pub struct IntegerKeyCache;
@@ -68,10 +67,6 @@ impl WopbsKeyCache {
     }
 }
 
-lazy_static! {
-    pub static ref KEY_CACHE: IntegerKeyCache = IntegerKeyCache;
-}
+pub static KEY_CACHE: IntegerKeyCache = IntegerKeyCache;
 #[cfg(feature = "experimental")]
-lazy_static! {
-    pub static ref KEY_CACHE_WOPBS: WopbsKeyCache = WopbsKeyCache;
-}
+pub static KEY_CACHE_WOPBS: WopbsKeyCache = WopbsKeyCache;

--- a/tfhe/src/shortint/keycache.rs
+++ b/tfhe/src/shortint/keycache.rs
@@ -1,3 +1,5 @@
+use std::sync::LazyLock;
+
 use crate::keycache::utils::named_params_impl;
 use crate::keycache::*;
 use crate::shortint::parameters::classic::compact_pk::*;
@@ -12,7 +14,6 @@ use crate::shortint::parameters::parameters_wopbs::*;
 use crate::shortint::parameters::*;
 use crate::shortint::wopbs::WopbsKey;
 use crate::shortint::{ClientKey, KeySwitchingKey, ServerKey};
-use lazy_static::*;
 use serde::{Deserialize, Serialize};
 
 named_params_impl!( ShortintParameterSet =>
@@ -559,12 +560,10 @@ impl KeycacheKeySwitchingKey {
     }
 }
 
-lazy_static! {
-    pub static ref KEY_CACHE: Keycache = Keycache::default();
-    pub static ref KEY_CACHE_KSK: KeycacheKeySwitchingKey = KeycacheKeySwitchingKey::default();
-}
+pub static KEY_CACHE: LazyLock<Keycache> = LazyLock::new(Keycache::default);
+pub static KEY_CACHE_KSK: LazyLock<KeycacheKeySwitchingKey> =
+    LazyLock::new(KeycacheKeySwitchingKey::default);
 
 #[cfg(feature = "experimental")]
-lazy_static! {
-    pub static ref KEY_CACHE_WOPBS: wopbs::KeycacheWopbsV0 = wopbs::KeycacheWopbsV0::default();
-}
+pub static KEY_CACHE_WOPBS: LazyLock<wopbs::KeycacheWopbsV0> =
+    LazyLock::new(wopbs::KeycacheWopbsV0::default);


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: https://github.com/zama-ai/tfhe-rs-internal/issues/247

### PR content/description
Use LazyLock instead of lazy_static. (Or nothing when the value is already const)

