### PR TITLE
chore(ci): verify triggering actor on pull request from fork

### DIFF
--- a/.github/workflows/aws_tfhe_fast_tests.yml
+++ b/.github/workflows/aws_tfhe_fast_tests.yml
@@ -20,8 +20,17 @@ on:
   pull_request_target:
 
 jobs:
+  check-user-permission:
+    if: github.event_name == 'pull_request_target'
+    uses: ./.github/workflows/check_triggering_actor.yml
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   should-run:
     runs-on: ubuntu-latest
+    needs: check-user-permission
+    if: github.event_name != 'pull_request_target' ||
+      needs.check-user-permission.result == 'success'
     permissions:
       pull-requests: write
     outputs:

--- a/.github/workflows/check_triggering_actor.yml
+++ b/.github/workflows/check_triggering_actor.yml
@@ -1,0 +1,29 @@
+# Check if triggering actor is a collaborator and has write access
+name: Check Triggering Actor
+
+on:
+  workflow_call:
+    secrets:
+      GITHUB_TOKEN:
+        required: true
+
+jobs:
+  check-actor-permission:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get User Permission
+        id: check-access
+        uses: actions-cool/check-user-permission@956b2e73cdfe3bcb819bb7225e490cb3b18fd76e # v2.2.1
+        with:
+          require: write
+          username: ${{ github.triggering_actor }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check User Permission
+        if: steps.check-access.outputs.require-result == 'false'
+        run: |
+          echo "${{ github.triggering_actor }} does not have permissions on this repo."
+          echo "Current permission level is ${{ steps.check-access.outputs.user-permission }}"
+          echo "Job originally triggered by ${{ github.actor }}"
+          exit 1


### PR DESCRIPTION
If a contributor that open a Pull Request from a fork is not part of the repository collaborators, then the workflow using check_triggering_actor subworkflowwill exit with a failure. It could be re-run later by a collaborator who has a write access.

This allows reviewers to read the code proposition before running the CI, ensuring no secrets are leaked outside the repository.