### PR TITLE
refactor(hlapi): separate hlapi compressed list from integer

### DIFF
--- a/tfhe/src/high_level_api/backward_compatibility/compressed_ciphertext_list.rs
+++ b/tfhe/src/high_level_api/backward_compatibility/compressed_ciphertext_list.rs
@@ -1,7 +1,127 @@
 use std::convert::Infallible;
-use tfhe_versionable::{Upgrade, Version, VersionsDispatch};
+use tfhe_versionable::{
+    Unversionize, UnversionizeError, Upgrade, Version, Versionize, VersionizeOwned,
+    VersionsDispatch,
+};
 
-use crate::{CompressedCiphertextList, Tag};
+use crate::core_crypto::commons::math::random::{Deserialize, Serialize};
+use crate::high_level_api::compressed_ciphertext_list::InnerCompressedCiphertextList;
+#[cfg(feature = "gpu")]
+use crate::high_level_api::global_state::with_thread_local_cuda_streams;
+#[cfg(feature = "gpu")]
+use crate::integer::gpu::ciphertext::compressed_ciphertext_list::CudaCompressedCiphertextList;
+use crate::{CompressedCiphertextList, SerializedKind, Tag};
+
+#[derive(Clone, Serialize, Deserialize)]
+pub(crate) enum InnerCompressedCiphertextListV0 {
+    Cpu(crate::integer::ciphertext::CompressedCiphertextList),
+    #[cfg(feature = "gpu")]
+    Cuda(CudaCompressedCiphertextList),
+}
+
+#[derive(serde::Serialize)]
+pub struct InnerCompressedCiphertextListV0Version<'vers>(
+    <InnerCompressedCiphertextListV0 as Versionize>::Versioned<'vers>,
+);
+
+impl<'vers> From<&'vers InnerCompressedCiphertextListV0>
+    for InnerCompressedCiphertextListV0Version<'vers>
+{
+    fn from(value: &'vers InnerCompressedCiphertextListV0) -> Self {
+        Self(value.versionize())
+    }
+}
+
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+pub struct InnerCompressedCiphertextListV0Owned(
+    <InnerCompressedCiphertextListV0 as VersionizeOwned>::VersionedOwned,
+);
+
+impl From<InnerCompressedCiphertextListV0> for InnerCompressedCiphertextListV0Owned {
+    fn from(value: InnerCompressedCiphertextListV0) -> Self {
+        Self(value.versionize_owned())
+    }
+}
+
+impl TryFrom<InnerCompressedCiphertextListV0Owned> for InnerCompressedCiphertextListV0 {
+    type Error = UnversionizeError;
+
+    fn try_from(value: InnerCompressedCiphertextListV0Owned) -> Result<Self, Self::Error> {
+        Self::unversionize(value.0)
+    }
+}
+
+impl Version for InnerCompressedCiphertextListV0 {
+    type Ref<'vers>
+        = InnerCompressedCiphertextListV0Version<'vers>
+    where
+        Self: 'vers;
+
+    type Owned = InnerCompressedCiphertextListV0Owned;
+}
+
+impl Versionize for InnerCompressedCiphertextListV0 {
+    type Versioned<'vers> =
+        <crate::integer::ciphertext::CompressedCiphertextList as VersionizeOwned>::VersionedOwned;
+
+    fn versionize(&self) -> Self::Versioned<'_> {
+        match self {
+            Self::Cpu(inner) => inner.clone().versionize_owned(),
+            #[cfg(feature = "gpu")]
+            Self::Cuda(inner) => {
+                let cpu_data = with_thread_local_cuda_streams(|streams| {
+                    inner.to_compressed_ciphertext_list(streams)
+                });
+                cpu_data.versionize_owned()
+            }
+        }
+    }
+}
+
+impl VersionizeOwned for InnerCompressedCiphertextListV0 {
+    type VersionedOwned =
+        <crate::integer::ciphertext::CompressedCiphertextList as VersionizeOwned>::VersionedOwned;
+
+    fn versionize_owned(self) -> Self::VersionedOwned {
+        match self {
+            Self::Cpu(inner) => inner.versionize_owned(),
+            #[cfg(feature = "gpu")]
+            Self::Cuda(inner) => {
+                let cpu_data = with_thread_local_cuda_streams(|streams| {
+                    inner.to_compressed_ciphertext_list(streams)
+                });
+                cpu_data.versionize_owned()
+            }
+        }
+    }
+}
+
+impl Unversionize for InnerCompressedCiphertextListV0 {
+    fn unversionize(versioned: Self::VersionedOwned) -> Result<Self, UnversionizeError> {
+        Ok(Self::Cpu(
+            crate::integer::ciphertext::CompressedCiphertextList::unversionize(versioned)?,
+        ))
+    }
+}
+
+impl Upgrade<InnerCompressedCiphertextList> for InnerCompressedCiphertextListV0 {
+    type Error = Infallible;
+
+    fn upgrade(self) -> Result<InnerCompressedCiphertextList, Self::Error> {
+        Ok(match self {
+            Self::Cpu(cpu) => InnerCompressedCiphertextList::Cpu(cpu.packed_list),
+            #[cfg(feature = "gpu")]
+            Self::Cuda(cuda) => InnerCompressedCiphertextList::Cuda(cuda.packed_list),
+        })
+    }
+}
+
+#[derive(VersionsDispatch)]
+#[allow(unused)]
+pub(crate) enum InnerCompressedCiphertextListVersions {
+    V0(InnerCompressedCiphertextListV0),
+    V1(InnerCompressedCiphertextList),
+}
 
 #[derive(Version)]
 pub struct CompressedCiphertextListV0(crate::integer::ciphertext::CompressedCiphertextList);
@@ -23,12 +143,43 @@ pub struct CompressedCiphertextListV1 {
     tag: Tag,
 }
 
-impl Upgrade<CompressedCiphertextList> for CompressedCiphertextListV1 {
+impl Upgrade<CompressedCiphertextListV2> for CompressedCiphertextListV1 {
+    type Error = Infallible;
+
+    fn upgrade(self) -> Result<CompressedCiphertextListV2, Self::Error> {
+        Ok(CompressedCiphertextListV2 {
+            inner: InnerCompressedCiphertextListV0::Cpu(self.inner),
+            tag: self.tag,
+        })
+    }
+}
+
+#[derive(Version)]
+pub struct CompressedCiphertextListV2 {
+    inner: InnerCompressedCiphertextListV0,
+    tag: Tag,
+}
+
+impl Upgrade<CompressedCiphertextList> for CompressedCiphertextListV2 {
     type Error = Infallible;
 
     fn upgrade(self) -> Result<CompressedCiphertextList, Self::Error> {
+        let (block_kinds, msg_modulus) = match &self.inner {
+            InnerCompressedCiphertextListV0::Cpu(inner) => {
+                (&inner.info, inner.packed_list.message_modulus)
+            }
+            #[cfg(feature = "gpu")]
+            InnerCompressedCiphertextListV0::Cuda(inner) => {
+                (&inner.info, inner.packed_list.message_modulus)
+            }
+        };
+        let info = block_kinds
+            .iter()
+            .map(|kind| SerializedKind::from_data_kind(*kind, msg_modulus))
+            .collect();
         Ok(CompressedCiphertextList {
-            inner: crate::high_level_api::compressed_ciphertext_list::InnerCompressedCiphertextList::Cpu(self.inner),
+            inner: self.inner.upgrade()?,
+            info,
             tag: self.tag,
         })
     }
@@ -38,5 +189,6 @@ impl Upgrade<CompressedCiphertextList> for CompressedCiphertextListV1 {
 pub enum CompressedCiphertextListVersions {
     V0(CompressedCiphertextListV0),
     V1(CompressedCiphertextListV1),
-    V2(CompressedCiphertextList),
+    V2(CompressedCiphertextListV2),
+    V3(CompressedCiphertextList),
 }

--- a/tfhe/src/shortint/list_compression/compression.rs
+++ b/tfhe/src/shortint/list_compression/compression.rs
@@ -13,7 +13,9 @@ use crate::shortint::server_key::{
 };
 use crate::shortint::{Ciphertext, CiphertextModulus, MaxNoiseLevel};
 use rayon::iter::ParallelIterator;
+use rayon::prelude::*;
 use rayon::slice::ParallelSlice;
+use std::ops::Range;
 
 impl CompressionKey {
     pub fn compress_ciphertexts_into_list(
@@ -126,6 +128,17 @@ impl CompressionKey {
 }
 
 impl DecompressionKey {
+    pub fn unpack_range(
+        &self,
+        packed: &CompressedCiphertextList,
+        range: Range<usize>,
+    ) -> crate::Result<Vec<Ciphertext>> {
+        range
+            .into_par_iter()
+            .map(|i| self.unpack(packed, i))
+            .collect()
+    }
+
     pub fn unpack(
         &self,
         packed: &CompressedCiphertextList,


### PR DESCRIPTION
This makes the HLAPI's compressed list use lower level struct (from shortint) rather than integer, this will allow the list to store non integer data.

<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
