### PR TITLE
chore: force wasm-bindgen-rayon to 1.2.2

### DIFF
--- a/tfhe/Cargo.toml
+++ b/tfhe/Cargo.toml
@@ -79,7 +79,7 @@ tfhe-versionable = { version = "0.3.2", path = "../utils/tfhe-versionable" }
 wasm-bindgen = { workspace = true, features = [
     "serde-serialize",
 ], optional = true }
-wasm-bindgen-rayon = { version = "1.0", optional = true }
+wasm-bindgen-rayon = { version = "=1.2.2", optional = true }
 js-sys = { version = "0.3", optional = true }
 console_error_panic_hook = { version = "0.1.7", optional = true }
 serde-wasm-bindgen = { version = "0.6.0", optional = true }


### PR DESCRIPTION
the new 1.3.0 version changes the way some files are bundled, I don't want to discover during the release that nothing works properly anymore.
