### PR TITLE
chore(ci): fix concurrency group format on pull request event

### DIFF
--- a/.github/workflows/aws_tfhe_fast_tests.yml
+++ b/.github/workflows/aws_tfhe_fast_tests.yml
@@ -159,7 +159,7 @@ jobs:
       (github.event_name == 'pull_request' && needs.setup-instance.result != 'skipped')
     needs: [ should-run, setup-instance ]
     concurrency:
-      group: ${{ github.workflow }}_${{ github.ref }}
+      group: ${{ github.workflow }}_${{ github.head_ref || github.ref }}
       cancel-in-progress: true
     runs-on: ${{ needs.setup-instance.outputs.runner-name }}
     steps:


### PR DESCRIPTION
Since the addition of pull_request_target event, `github.ref` context object return name of the base branch. So when a workflow was triggered on the base branch during an execution in a pull request, the latter would be cancelled.

Using `github.head_ref`, when available, fixes this behavior. On any other event than `pull_request` or `pull_request_target`, `github.ref` will still be used and work as before.
