### PR TITLE
chore(zk): add bench zk v1 vs v2

### DIFF
--- a/tfhe/src/js_on_wasm_api/shortint.rs
+++ b/tfhe/src/js_on_wasm_api/shortint.rs
@@ -4,8 +4,14 @@ use crate::core_crypto::commons::math::random::Seed;
 use crate::core_crypto::prelude::DefaultRandomGenerator;
 use crate::js_on_wasm_api::js_high_level_api::into_js_error;
 use crate::shortint::parameters::classic::compact_pk::*;
-use crate::shortint::parameters::compact_public_key_only::p_fail_2_minus_64::ks_pbs::V0_11_PARAM_PKE_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64;
-use crate::shortint::parameters::key_switching::p_fail_2_minus_64::ks_pbs::V0_11_PARAM_KEYSWITCH_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64;
+use crate::shortint::parameters::compact_public_key_only::p_fail_2_minus_64::ks_pbs::{
+    V0_11_PARAM_PKE_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64,
+    V0_11_PARAM_PKE_TO_SMALL_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64_ZKV1,
+};
+use crate::shortint::parameters::key_switching::p_fail_2_minus_64::ks_pbs::{
+    V0_11_PARAM_KEYSWITCH_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64,
+    V0_11_PARAM_KEYSWITCH_PKE_TO_SMALL_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64_ZKV1,
+};
 use crate::shortint::parameters::*;
 use std::panic::set_hook;
 use wasm_bindgen::prelude::*;
@@ -216,6 +222,7 @@ pub struct ShortintNoiseDistribution(
 #[allow(non_camel_case_types)]
 pub enum ShortintCompactPublicKeyEncryptionParametersName {
     SHORTINT_PARAM_PKE_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64,
+    SHORTINT_PARAM_PKE_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64_ZKV1,
 }
 
 #[wasm_bindgen]
@@ -227,6 +234,10 @@ impl ShortintCompactPublicKeyEncryptionParameters {
             ShortintCompactPublicKeyEncryptionParametersName::SHORTINT_PARAM_PKE_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64 => Self {
                 compact_pke_params: V0_11_PARAM_PKE_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64,
                 casting_parameters: V0_11_PARAM_KEYSWITCH_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64,
+            },
+            ShortintCompactPublicKeyEncryptionParametersName::SHORTINT_PARAM_PKE_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64_ZKV1 => Self {
+                compact_pke_params: V0_11_PARAM_PKE_TO_SMALL_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64_ZKV1,
+                casting_parameters: V0_11_PARAM_KEYSWITCH_PKE_TO_SMALL_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64_ZKV1,
             }
         }
     }

--- a/tfhe/web_wasm_parallel_tests/worker.js
+++ b/tfhe/web_wasm_parallel_tests/worker.js
@@ -645,6 +645,7 @@ async function compressedServerKeyBenchMessage2Carry2() {
 async function compactPublicKeyZeroKnowledgeBench() {
   let params_to_bench = [
     {
+      zk_scheme: "ZKV2",
       name: shortint_params_name(
         ShortintParametersName.PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64,
       ),
@@ -653,6 +654,18 @@ async function compactPublicKeyZeroKnowledgeBench() {
       ),
       casting_params: new ShortintCompactPublicKeyEncryptionParameters(
         ShortintCompactPublicKeyEncryptionParametersName.SHORTINT_PARAM_PKE_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64,
+      ),
+    },
+    {
+      zk_scheme: "ZKV1",
+      name: shortint_params_name(
+        ShortintParametersName.PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64,
+      ),
+      block_params: new ShortintParameters(
+        ShortintParametersName.PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64,
+      ),
+      casting_params: new ShortintCompactPublicKeyEncryptionParameters(
+        ShortintCompactPublicKeyEncryptionParametersName.SHORTINT_PARAM_PKE_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64_ZKV1,
       ),
     },
   ];
@@ -718,6 +731,8 @@ async function compactPublicKeyZeroKnowledgeBench() {
         const mean = timing / bench_loops;
         const common_bench_str =
           "compact_fhe_uint_proven_encryption_" +
+          params.zk_scheme +
+          "_" +
           encrypt_count * 64 +
           "_bits_packed_" +
           load_to_str[loadChoice];


### PR DESCRIPTION


### PR content/description
Adds benchmark of zkv1 vs zkv2 inside the tfhe crate


