### PR TITLE
fix(bench): use correct name for parameters in wasm benches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -435,7 +435,7 @@ check_rust_bindings_did_not_change:
 	cargo build -p tfhe-cuda-backend && "$(MAKE)" fmt_gpu && \
 	git diff --quiet HEAD -- backends/tfhe-cuda-backend/src/bindings.rs || \
 	( echo "Generated bindings have changed! Please run 'git add backends/tfhe-cuda-backend/src/bindings.rs' \
-	and commit the changes." && exit 1 ) 
+	and commit the changes." && exit 1 )
 
 
 .PHONY: tfhe_lints # Run custom tfhe-rs lints
@@ -1315,7 +1315,7 @@ fpcc: no_tfhe_typo no_dbg_log check_fmt check_typos lint_doc check_md_docs_are_t
 check_compile_tests
 
 .PHONY: conformance # Automatically fix problems that can be fixed
-conformance: fix_newline fmt
+conformance: fmt fmt_js
 
 #=============================== FFT Section ==================================
 .PHONY: doc_fft # Build rust doc for tfhe-fft
@@ -1387,7 +1387,7 @@ test_fft_nightly: install_rs_check_toolchain
 .PHONY: test_fft_no_std
 test_fft_no_std: install_rs_build_toolchain
 	RUSTFLAGS="$(RUSTFLAGS)" cargo $(CARGO_RS_BUILD_TOOLCHAIN) test --release -p tfhe-fft \
-		--no-default-features 
+		--no-default-features
 	RUSTFLAGS="$(RUSTFLAGS)" cargo $(CARGO_RS_BUILD_TOOLCHAIN) test --release -p tfhe-fft \
 		--no-default-features \
 		--features=fft128
@@ -1481,7 +1481,7 @@ test_ntt_nightly: install_rs_check_toolchain
 .PHONY: test_ntt_no_std
 test_ntt_no_std: install_rs_build_toolchain
 	RUSTFLAGS="$(RUSTFLAGS)" cargo $(CARGO_RS_BUILD_TOOLCHAIN) test --release -p tfhe-ntt \
-		--no-default-features 
+		--no-default-features
 
 .PHONY: test_ntt_no_std_nightly
 test_ntt_no_std_nightly: install_rs_check_toolchain

--- a/tfhe/src/js_on_wasm_api/shortint.rs
+++ b/tfhe/src/js_on_wasm_api/shortint.rs
@@ -284,12 +284,24 @@ macro_rules! expose_predefined_parameters {
         $(,)?
     ) => {
         #[wasm_bindgen]
+        #[derive(Clone, Copy)]
         #[allow(non_camel_case_types)]
         pub enum ShortintParametersName {
             $(
                 $param_name,
             )*
         }
+
+        // wasm bindgen does not support methods on enums
+        #[wasm_bindgen]
+        pub fn shortint_params_name(param: ShortintParametersName) -> String {
+            match param {
+                $(
+                    ShortintParametersName::$param_name => stringify!($param_name).to_string(),
+                )*
+            }
+        }
+
 
         #[wasm_bindgen]
         impl ShortintParameters {

--- a/tfhe/web_wasm_parallel_tests/worker.js
+++ b/tfhe/web_wasm_parallel_tests/worker.js
@@ -3,6 +3,7 @@ import init, {
   initThreadPool,
   init_panic_hook,
   set_server_key,
+  shortint_params_name,
   ShortintParametersName,
   ShortintParameters,
   TfheClientKey,
@@ -159,28 +160,28 @@ async function compactPublicKeyBench32BitOnConfig(config) {
 }
 
 async function compactPublicKeyBench32BitBig() {
-  const block_params = new ShortintParameters(
-    ShortintParametersName.V0_11_PARAM_MESSAGE_2_CARRY_2_COMPACT_PK_KS_PBS_GAUSSIAN_2M64,
-  );
+  const params =
+    ShortintParametersName.V0_11_PARAM_MESSAGE_2_CARRY_2_COMPACT_PK_KS_PBS_GAUSSIAN_2M64;
+  const block_params = new ShortintParameters(params);
   let config = TfheConfigBuilder.default()
     .use_custom_parameters(block_params)
     .build();
   return append_param_name(
     await compactPublicKeyBench32BitOnConfig(config),
-    "PARAM_MESSAGE_2_CARRY_2_COMPACT_PK_KS_PBS_GAUSSIAN_2M64",
+    shortint_params_name(params),
   );
 }
 
 async function compactPublicKeyBench32BitSmall() {
-  const block_params = new ShortintParameters(
-    ShortintParametersName.V0_11_PARAM_MESSAGE_2_CARRY_2_COMPACT_PK_PBS_KS_GAUSSIAN_2M64,
-  );
+  const params =
+    ShortintParametersName.V0_11_PARAM_MESSAGE_2_CARRY_2_COMPACT_PK_PBS_KS_GAUSSIAN_2M64;
+  const block_params = new ShortintParameters(params);
   let config = TfheConfigBuilder.default()
     .use_custom_parameters(block_params)
     .build();
   return append_param_name(
     await compactPublicKeyBench32BitOnConfig(config),
-    "PARAM_MESSAGE_2_CARRY_2_COMPACT_PK_PBS_KS_GAUSSIAN_2M64",
+    shortint_params_name(params),
   );
 }
 
@@ -556,28 +557,28 @@ async function compactPublicKeyBench256BitOnConfig(config) {
 }
 
 async function compactPublicKeyBench256BitBig() {
-  const block_params = new ShortintParameters(
-    ShortintParametersName.V0_11_PARAM_MESSAGE_2_CARRY_2_COMPACT_PK_KS_PBS_GAUSSIAN_2M64,
-  );
+  const params =
+    ShortintParametersName.V0_11_PARAM_MESSAGE_2_CARRY_2_COMPACT_PK_KS_PBS_GAUSSIAN_2M64;
+  const block_params = new ShortintParameters(params);
   let config = TfheConfigBuilder.default()
     .use_custom_parameters(block_params)
     .build();
   return append_param_name(
     await compactPublicKeyBench256BitOnConfig(config),
-    "PARAM_MESSAGE_2_CARRY_2_COMPACT_PK_KS_PBS_GAUSSIAN_2M64",
+    shortint_params_name(params),
   );
 }
 
 async function compactPublicKeyBench256BitSmall() {
-  const block_params = new ShortintParameters(
-    ShortintParametersName.V0_11_PARAM_MESSAGE_2_CARRY_2_COMPACT_PK_PBS_KS_GAUSSIAN_2M64,
-  );
+  const params =
+    ShortintParametersName.V0_11_PARAM_MESSAGE_2_CARRY_2_COMPACT_PK_PBS_KS_GAUSSIAN_2M64;
+  const block_params = new ShortintParameters(params);
   let config = TfheConfigBuilder.default()
     .use_custom_parameters(block_params)
     .build();
   return append_param_name(
     await compactPublicKeyBench256BitOnConfig(config),
-    "PARAM_MESSAGE_2_CARRY_2_COMPACT_PK_PBS_KS_GAUSSIAN_2M64",
+    shortint_params_name(params),
   );
 }
 
@@ -616,35 +617,37 @@ async function compressedServerKeyBenchConfig(config) {
 }
 
 async function compressedServerKeyBenchMessage1Carry1() {
-  const block_params = new ShortintParameters(
-    ShortintParametersName.V0_11_PARAM_MESSAGE_1_CARRY_1_KS_PBS_GAUSSIAN_2M64,
-  );
+  const params =
+    ShortintParametersName.V0_11_PARAM_MESSAGE_1_CARRY_1_KS_PBS_GAUSSIAN_2M64;
+  const block_params = new ShortintParameters(params);
   let config = TfheConfigBuilder.default()
     .use_custom_parameters(block_params)
     .build();
   return append_param_name(
     await compressedServerKeyBenchConfig(config),
-    "PARAM_MESSAGE_1_CARRY_1_KS_PBS_GAUSSIAN_2M64",
+    shortint_params_name(params),
   );
 }
 
 async function compressedServerKeyBenchMessage2Carry2() {
-  const block_params = new ShortintParameters(
-    ShortintParametersName.V0_11_PARAM_MESSAGE_2_CARRY_2_KS_PBS_GAUSSIAN_2M64,
-  );
+  const params =
+    ShortintParametersName.V0_11_PARAM_MESSAGE_2_CARRY_2_KS_PBS_GAUSSIAN_2M64;
+  const block_params = new ShortintParameters(params);
   let config = TfheConfigBuilder.default()
     .use_custom_parameters(block_params)
     .build();
   return append_param_name(
     await compressedServerKeyBenchConfig(config),
-    "PARAM_MESSAGE_2_CARRY_2_KS_PBS_GAUSSIAN_2M64",
+    shortint_params_name(params),
   );
 }
 
 async function compactPublicKeyZeroKnowledgeBench() {
   let params_to_bench = [
     {
-      name: "PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64",
+      name: shortint_params_name(
+        ShortintParametersName.PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64,
+      ),
       block_params: new ShortintParameters(
         ShortintParametersName.PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64,
       ),


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description
Fix parsing of wasm bench names, by exporting a method to get the parameter name as a string.


