### PR TITLE
chore(ci): temporarily disable the multi bit noise check on Apple M1

### DIFF
--- a/tfhe/src/core_crypto/algorithms/test/noise_distribution/mod.rs
+++ b/tfhe/src/core_crypto/algorithms/test/noise_distribution/mod.rs
@@ -2,6 +2,9 @@ use super::*;
 
 mod lwe_encryption_noise;
 mod lwe_keyswitch_noise;
+// We are having crashes on aarch64 at the moment, problem is the code paths are not the same
+// between archs, so we disable those on the Apple M1
+#[cfg(not(target_arch = "aarch64"))]
 mod lwe_multi_bit_programmable_bootstrapping_noise;
 mod lwe_programmable_bootstrapping_noise;
 


### PR DESCRIPTION
follow up is here: https://github.com/zama-ai/tfhe-rs-internal/issues/872

It is most likely down to stuff like float precision as we have hand optimized assembly for x86 and not for aarch, meaning some rounding mode might be different (and some fmadd less precise on aarch64)