### PR TITLE
Ns/chore/zk use stable isqrt

### DIFF
--- a/tfhe-zk-pok/Cargo.toml
+++ b/tfhe-zk-pok/Cargo.toml
@@ -8,6 +8,7 @@ documentation = "https://docs.zama.ai/tfhe-rs"
 repository = "https://github.com/zama-ai/tfhe-rs"
 license = "BSD-3-Clause-Clear"
 description = "tfhe-zk-pok: An implementation of zero-knowledge proofs of encryption for TFHE."
+rust-version = "1.84"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tfhe-zk-pok/src/backward_compatibility/mod.rs
+++ b/tfhe-zk-pok/src/backward_compatibility/mod.rs
@@ -11,7 +11,7 @@ use std::fmt::Display;
 use tfhe_versionable::{Upgrade, Version, VersionsDispatch};
 
 use crate::curve_api::Curve;
-use crate::four_squares::{isqrt, sqr};
+use crate::four_squares::sqr;
 use crate::proofs::pke_v2::Bound;
 use crate::proofs::GroupElements;
 use crate::serialization::{
@@ -102,7 +102,7 @@ impl Upgrade<SerializablePKEv2PublicParams> for SerializablePKEv2PublicParamsV0 
     type Error = Infallible;
 
     fn upgrade(self) -> Result<SerializablePKEv2PublicParams, Self::Error> {
-        let slack_factor = isqrt((self.d + self.k) as u128) as u64;
+        let slack_factor = (self.d + self.k).isqrt() as u64;
         let B_inf = self.B / slack_factor;
         Ok(SerializablePKEv2PublicParams {
             g_lists: self.g_lists,

--- a/tfhe-zk-pok/src/backward_compatibility/mod.rs
+++ b/tfhe-zk-pok/src/backward_compatibility/mod.rs
@@ -110,7 +110,7 @@ impl Upgrade<SerializablePKEv2PublicParams> for SerializablePKEv2PublicParamsV0 
             n: self.n,
             d: self.d,
             k: self.k,
-            B_bound_squared: sqr(self.B_bound as u128),
+            B_bound_squared: sqr(self.B_bound),
             B_inf,
             q: self.q,
             t: self.t,

--- a/tfhe-zk-pok/src/four_squares.rs
+++ b/tfhe-zk-pok/src/four_squares.rs
@@ -1,7 +1,9 @@
 use ark_ff::biginteger::arithmetic::widening_mul;
 use rand::prelude::*;
 
-pub fn sqr(x: u128) -> u128 {
+/// Avoid overflows for squares of u64
+pub fn sqr(x: u64) -> u128 {
+    let x = x as u128;
     x * x
 }
 
@@ -231,7 +233,7 @@ pub fn four_squares(v: u128) -> [u64; 4] {
             let x = 2 + rng.gen::<u64>() % (b - 2);
             let y = 2 + rng.gen::<u64>() % (b - 2);
 
-            let (sum, o) = u128::overflowing_add(sqr(x as u128), sqr(y as u128));
+            let (sum, o) = u128::overflowing_add(sqr(x), sqr(y));
             if o || sum > v {
                 continue 'main_loop;
             }
@@ -288,9 +290,9 @@ pub fn four_squares(v: u128) -> [u64; 4] {
             let i = mont.natural_from_mont(sqrt);
             let i = if i <= p / 2 { p - i } else { i };
             let z = half_gcd(p, i) as u64;
-            let w = isqrt(p - sqr(z as u128)) as u64;
+            let w = isqrt(p - sqr(z)) as u64;
 
-            if p != sqr(z as u128) + sqr(w as u128) {
+            if p != sqr(z) + sqr(w) {
                 continue 'main_loop;
             }
 

--- a/tfhe-zk-pok/src/four_squares.rs
+++ b/tfhe-zk-pok/src/four_squares.rs
@@ -11,37 +11,8 @@ pub fn checked_sqr(x: u128) -> Option<u128> {
     x.checked_mul(x)
 }
 
-// copied from the standard library
-// since isqrt is unstable at the moment
-pub fn isqrt(this: u128) -> u128 {
-    if this < 2 {
-        return this;
-    }
-
-    // The algorithm is based on the one presented in
-    // <https://en.wikipedia.org/wiki/Methods_of_computing_square_roots#Binary_numeral_system_(base_2)>
-    // which cites as source the following C code:
-    // <https://web.archive.org/web/20120306040058/http://medialab.freaknet.org/martin/src/sqrt/sqrt.c>.
-
-    let mut op = this;
-    let mut res = 0;
-    let mut one = 1 << (this.ilog2() & !1);
-
-    while one != 0 {
-        if op >= res + one {
-            op -= res + one;
-            res = (res >> 1) + one;
-        } else {
-            res >>= 1;
-        }
-        one >>= 2;
-    }
-
-    res
-}
-
 fn half_gcd(p: u128, s: u128) -> u128 {
-    let sq_p = isqrt(p as _);
+    let sq_p = p.isqrt();
     let mut a = p;
     let mut b = s;
     while b > sq_p {
@@ -227,7 +198,7 @@ pub fn four_squares(v: u128) -> [u64; 4] {
 
     let f = v % 4;
     if f == 2 {
-        let b = isqrt(v as _) as u64;
+        let b = v.isqrt() as u64;
 
         'main_loop: loop {
             let x = 2 + rng.gen::<u64>() % (b - 2);
@@ -290,7 +261,7 @@ pub fn four_squares(v: u128) -> [u64; 4] {
             let i = mont.natural_from_mont(sqrt);
             let i = if i <= p / 2 { p - i } else { i };
             let z = half_gcd(p, i) as u64;
-            let w = isqrt(p - sqr(z)) as u64;
+            let w = (p - sqr(z)).isqrt() as u64;
 
             if p != sqr(z) + sqr(w) {
                 continue 'main_loop;

--- a/tfhe-zk-pok/src/proofs/pke_v2.rs
+++ b/tfhe-zk-pok/src/proofs/pke_v2.rs
@@ -2787,7 +2787,7 @@ mod tests {
             };
 
             let B_with_slack_squared = inf_norm_bound_to_euclidean_squared(B, d + k);
-            let B_with_slack = isqrt(B_with_slack_squared) as u64;
+            let B_with_slack = B_with_slack_squared.isqrt() as u64;
 
             let bound = match slack_mode {
                 // The slack is maximal, any term above B+slack should be refused
@@ -2808,7 +2808,7 @@ mod tests {
 
                     let bound_squared =
                         B_with_slack_squared - (e_sqr_norm - sqr(orig_value as u64));
-                    isqrt(bound_squared) as i64
+                    bound_squared.isqrt() as i64
                 }
                 // There is no slack effect, any term above B should be refused
                 BoundTestSlackMode::Min => B as i64,
@@ -2850,7 +2850,7 @@ mod tests {
         let crs_max_k = crs_gen::<Curve>(d, d, B, q, t, msbs_zero_padding_bit_count, rng);
 
         let B_with_slack_squared = inf_norm_bound_to_euclidean_squared(B, d + k);
-        let B_with_slack_upper = isqrt(B_with_slack_squared) as u64 + 1;
+        let B_with_slack_upper = B_with_slack_squared.isqrt() as u64 + 1;
 
         // Generate test noise vectors with random coeffs and one completely out of bounds
 

--- a/tfhe/Cargo.toml
+++ b/tfhe/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [
     "/js_on_wasm_tests/",
     "/web_wasm_parallel_tests/",
 ]
-rust-version = "1.83"
+rust-version = "1.84"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description
isqrt has been stabilized with 1.84, we don't need the custom implementation anymore.
I also changed the `sqr` function signature to `sqr(u64) -> u128`, so that it explicitly cannot overflow.