### PR TITLE
chore(ci): setup centralized workflow launcher

### DIFF
--- a/.github/workflows/aws_tfhe_fast_tests.yml
+++ b/.github/workflows/aws_tfhe_fast_tests.yml
@@ -11,13 +11,34 @@ env:
   SLACK_ICON: https://pbs.twimg.com/profile_images/1274014582265298945/OjBKP9kn_400x400.png
   SLACK_USERNAME: ${{ secrets.BOT_USERNAME }}
   SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-  IS_PULL_REQUEST: ${{ github.event_name == 'pull_request_target' }}
-  REF: ${{ github.event.pull_request.head.sha || github.sha }}
+  IS_PULL_REQUEST: ${{ github.event_name == 'workflow_call' }}
+  REF: ${{ inputs.ref || github.sha }}
 
 on:
   # Allows you to run this workflow manually from the Actions tab as an alternative.
   workflow_dispatch:
-  pull_request_target:
+  workflow_call:
+    inputs:
+      ref:
+        required: true
+        type: string
+    secrets:
+      REPO_CHECKOUT_TOKEN:
+        required: true
+      SLAB_ACTION_TOKEN:
+        required: true
+      SLAB_BASE_URL:
+        required: true
+      SLAB_URL:
+        required: true
+      JOB_SECRET:
+        required: true
+      SLACK_CHANNEL:
+        required: true
+      BOT_USERNAME:
+        required: true
+      SLACK_WEBHOOK:
+        required: true
 
 jobs:
   should-run:
@@ -126,7 +147,10 @@ jobs:
 
   check-user-permission:
     needs: should-run
-    uses: ./.github/workflows/check_triggering_actor.yml
+    uses: ./.github/workflows/check_actor_permissions.yml
+    with:
+      # Check on triggering actor to ensure only Zama organization member can run this workflow
+      actor: ${{ github.triggering_actor }}
     secrets:
       TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/check_actor_permissions.yml
+++ b/.github/workflows/check_actor_permissions.yml
@@ -1,8 +1,12 @@
-# Check if triggering actor is a collaborator and has write access
-name: Check Triggering Actor
+# Check if an actor is a collaborator and has write access
+name: Check Actor Permissions
 
 on:
   workflow_call:
+    inputs:
+      actor:
+        required: true
+        type: string
     secrets:
       TOKEN:
         required: true
@@ -16,7 +20,7 @@ jobs:
         uses: actions-cool/check-user-permission@956b2e73cdfe3bcb819bb7225e490cb3b18fd76e # v2.2.1
         with:
           require: write
-          username: ${{ github.triggering_actor }}
+          username: ${{ inputs.actor }}
         env:
           GITHUB_TOKEN: ${{ secrets.TOKEN }}
 

--- a/.github/workflows/launch_pr_workflows.yml
+++ b/.github/workflows/launch_pr_workflows.yml
@@ -1,0 +1,74 @@
+# Centralized launcher for pull-request related workflows
+name: Launch PR Workflows
+
+on:
+  pull_request_target:
+
+jobs:
+  file-changes-check:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    outputs:
+      forbidden-files: ${{ steps.changed-files.outputs.ci_any_changed }}
+    steps:
+      - name: Checkout tfhe-rs
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          fetch-depth: 0
+          persist-credentials: 'false'
+          token: ${{ secrets.REPO_CHECKOUT_TOKEN }}
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Check for file changes
+        id: changed-files
+        uses: tj-actions/changed-files@d6e91a2266cdb9d62096cebf1e8546899c6aa18f
+        with:
+          since_last_remote_commit: true
+          files_yaml: |
+            ci:
+              - .github/**
+              - ci/**
+              - scripts/**
+              - Makefile
+
+  check-pr-author-permission:
+    uses: ./.github/workflows/check_actor_permissions.yml
+    with:
+      actor: ${{ github.event.pull_request.user.login }}
+    secrets:
+      TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  can-launch-workflows:
+    runs-on: ubuntu-latest
+    needs: [file-changes-check, check-pr-author-permission]
+    if: ${{ always() }}
+    steps:
+      - name: Forbidden files are unchanged
+        if: needs.file-changes-check.outputs.forbidden-files == 'false'
+        run: |
+          echo "Workflows can be launched forbidden files are unchanged"
+
+      # Only Zama organization members are allowed to make changes on forbidden files.
+      - name: Forbidden files have changed
+        if: needs.file-changes-check.outputs.forbidden-files == 'true'
+        run: |
+          if [ "${{ needs.check-pr-author-permission.result }}" == "failure" ]; then
+            echo "Actor '${{ github.event.pull_request.user.login }}' is not authorized to perform changes on forbidden files"
+            exit 1
+          fi
+
+  #
+  # CPU tests
+  #
+
+  aws-fast-tests:
+    needs: can-launch-workflows
+    uses: ./.github/workflows/aws_tfhe_fast_tests.yml
+    with:
+      ref: ${{ github.event.pull_request.head.sha }}
+    secrets: inherit
+
+  #
+  # GPU tests
+  #


### PR DESCRIPTION
To ease external contributions, this implements a workflow responsible for triggering workflows that are currently related to pull_request event.
To ensure security, changes on some files are allowed only to Zama members. Since workflows are included in this file, this protects against secret leaks.

For now only AWS fast CPU tests is targeted as a proof of concept.
