### PR TITLE
chore(ci): skip aws fast tests if ci files changed

### DIFF
--- a/.github/workflows/aws_tfhe_fast_tests.yml
+++ b/.github/workflows/aws_tfhe_fast_tests.yml
@@ -60,6 +60,7 @@ jobs:
       user_docs_test: ${{ env.IS_PULL_REQUEST == 'false' ||
         steps.changed-files.outputs.user_docs_any_changed ||
         steps.changed-files.outputs.dependencies_any_changed }}
+      ci_file_changed: ${{ env.IS_PULL_REQUEST == 'false' || steps.changed-files.outputs.ci_any_changed }}
       any_file_changed: ${{ env.IS_PULL_REQUEST == 'false' || steps.aggregated-changes.outputs.any_changed }}
     steps:
       - name: Checkout tfhe-rs
@@ -118,9 +119,13 @@ jobs:
               - '!tfhe/src/c_api/**'
               - 'tfhe/docs/**.md'
               - README.md
+            ci:
+              - .github/**
+              - ci/**
 
       - name: Aggregate file changes
         id: aggregated-changes
+        # CI files are not included in this aggregator.
         if: ( steps.changed-files.outputs.dependencies_any_changed == 'true' ||
           steps.changed-files.outputs.csprng_any_changed == 'true' ||
           steps.changed-files.outputs.zk_pok_any_changed == 'true' ||
@@ -136,16 +141,19 @@ jobs:
           echo "any_changed=true" >> "$GITHUB_OUTPUT"
 
   # Fail if the triggering actor is not part of Zama organization.
+  # If pull_request_target is emitted and CI files have changed, skip this job. This would skip following jobs.
   check-user-permission:
     needs: should-run
+    if: github.event_name != 'pull_request_target' ||
+      (github.event_name == 'pull_request_target' && needs.should-run.outputs.ci_file_changed == 'false')
     uses: ./.github/workflows/check_triggering_actor.yml
     secrets:
       TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   setup-instance:
     name: Setup instance (fast-tests)
-    if: github.event_name != 'pull_request_target' ||
-      needs.should-run.outputs.any_file_changed == 'true'
+    if: github.event_name == 'workflow_dispatch' ||
+      (github.event_name != 'workflow_dispatch' && needs.should-run.outputs.any_file_changed == 'true')
     needs: [ should-run, check-user-permission ]
     runs-on: ubuntu-latest
     outputs:
@@ -164,8 +172,6 @@ jobs:
 
   fast-tests:
     name: Fast CPU tests
-    if: github.event_name != 'pull_request_target' ||
-      (github.event_name == 'pull_request_target' && needs.setup-instance.result != 'skipped')
     needs: [ should-run, setup-instance ]
     concurrency:
       group: ${{ github.workflow }}_${{ github.head_ref || github.ref }}

--- a/.github/workflows/aws_tfhe_fast_tests.yml
+++ b/.github/workflows/aws_tfhe_fast_tests.yml
@@ -11,6 +11,8 @@ env:
   SLACK_ICON: https://pbs.twimg.com/profile_images/1274014582265298945/OjBKP9kn_400x400.png
   SLACK_USERNAME: ${{ secrets.BOT_USERNAME }}
   SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+  MSG_MINIMAL: event,action url,commit
+  BRANCH: ${{ github.head_ref || github.ref }}
   IS_PULL_REQUEST: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
   REF: ${{ github.event.pull_request.head.sha || github.sha }}
 
@@ -287,7 +289,7 @@ jobs:
         uses: rtCamp/action-slack-notify@c33737706dea87cd7784c687dadc9adf1be59990
         env:
           SLACK_COLOR: ${{ job.status }}
-          SLACK_MESSAGE: "Fast AWS tests finished with status: ${{ job.status }}. (${{ env.ACTION_RUN_URL }})"
+          SLACK_MESSAGE: "Fast AWS tests finished with status: ${{ job.status }} on '${{ env.BRANCH }}'. (${{ env.ACTION_RUN_URL }})"
 
   teardown-instance:
     name: Teardown instance (fast-tests)
@@ -311,4 +313,4 @@ jobs:
         uses: rtCamp/action-slack-notify@c33737706dea87cd7784c687dadc9adf1be59990
         env:
           SLACK_COLOR: ${{ job.status }}
-          SLACK_MESSAGE: "Instance teardown (fast-tests) finished with status: ${{ job.status }}. (${{ env.ACTION_RUN_URL }})"
+          SLACK_MESSAGE: "Instance teardown (fast-tests) finished with status: ${{ job.status }} on '${{ env.BRANCH }}'. (${{ env.ACTION_RUN_URL }})"


### PR DESCRIPTION
This would skip 'check-user-permission' job if the event 'pull_request_target' is emitted and CI files have changed. It avoids overlapping of 'pull_request' and 'pull_request_target' events. CI changes would only be tested on 'pull_request' for Zama own pull requests.
