### PR TITLE
chore(docs): Remove mention to NVLink

### DIFF
--- a/tfhe/docs/guides/run_on_gpu.md
+++ b/tfhe/docs/guides/run_on_gpu.md
@@ -164,13 +164,7 @@ All operations follow the same syntax than the one described in [here](../gettin
 
 ## Multi-GPU support
 
-TFHE-rs supports platforms with multiple GPUs with some restrictions at the moment:
-the platform should have NVLink support, and only GPUs that have peer access to GPU 0 via NVLink
-will be used for the computation. 
-Depending on the platform, this can restrict the number of GPUs used to perform the computation.
-
-There is **nothing to change in the code to execute on multiple GPUs**, when 
-they are available and have peer access to GPU 0 via NVLink. To keep the API as user-friendly as possible, the configuration is automatically set, i.e., the user has no fine-grained control over the number of GPUs to be used.
+TFHE-rs supports platforms with multiple GPUs. There is **nothing to change in the code to execute on such platforms**. To keep the API as user-friendly as possible, the configuration is automatically set, i.e., the user has no fine-grained control over the number of GPUs to be used.
 
 ## Benchmark 
 Please refer to the [GPU benchmarks](../getting_started/benchmarks/gpu_benchmarks.md) for detailed performance benchmark results.


### PR DESCRIPTION
NVLink is not a constraint anymore to the CUDA backend. Thus, we should update the multi-gpu section to not mention it anymore.

<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
