### PR TITLE
fix(safe_ser): aliases in named for renamed types deserialization

### DIFF
--- a/tfhe/src/named.rs
+++ b/tfhe/src/named.rs
@@ -1,3 +1,7 @@
 pub trait Named {
+    /// Default name for the type
     const NAME: &'static str;
+    /// Aliases that should also be accepted for backward compatibility when checking the name of
+    /// values of this type
+    const BACKWARD_COMPATIBILITY_ALIASES: &'static [&'static str] = &[];
 }

--- a/tfhe/src/zk/mod.rs
+++ b/tfhe/src/zk/mod.rs
@@ -196,6 +196,8 @@ pub enum CompactPkeCrs {
 
 impl Named for CompactPkeCrs {
     const NAME: &'static str = "zk::CompactPkeCrs";
+
+    const BACKWARD_COMPATIBILITY_ALIASES: &'static [&'static str] = &["zk::CompactPkePublicParams"];
 }
 
 impl From<ZkCompactPkeV1PublicParams> for CompactPkeCrs {


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description
Adds the possibility to have aliases in the Named trait.

Context:
In previous versions of TFHE-rs only the `CompactPkePublicParams` were serializable. Since 0.11, the `CompactPkeCrs` is the main exposed type and is serializable. For versioning, there is an upgrade path that allows to load and upgrade an old `CompactPkePublicParams` into a new `CompactPkeCrs`. However this could not work in practice for `CompactPkePublicParams` serialized with `safe_serialize` because of the `Named` impl was different and the data was rejected in the header check.

This PR allows to have aliases to a name, that will be accepted when loading this name. This is optional so it does not break previous code. That way, "zk::CompactPkePublicParams" is seen as an alias for "zk::CompactPkeCrs".

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
