### PR TITLE
chore: feature gating js_high_level_api

### DIFF
--- a/tfhe/src/js_on_wasm_api/js_high_level_api/mod.rs
+++ b/tfhe/src/js_on_wasm_api/js_high_level_api/mod.rs
@@ -1,6 +1,7 @@
 use wasm_bindgen::prelude::*;
 
 pub(crate) mod config;
+
 pub(crate) mod integers;
 // using Self does not work well with #[wasm_bindgen] macro
 #[allow(clippy::use_self)]
@@ -8,9 +9,7 @@ pub(crate) mod keys;
 #[cfg(feature = "zk-pok")]
 mod zk;
 
-pub(crate) fn into_js_error<E: std::fmt::Debug>(e: E) -> wasm_bindgen::JsError {
-    wasm_bindgen::JsError::new(format!("{e:?}").as_str())
-}
+use super::into_js_error;
 
 pub(crate) fn catch_panic_result<F, R>(closure: F) -> Result<R, JsError>
 where

--- a/tfhe/src/js_on_wasm_api/mod.rs
+++ b/tfhe/src/js_on_wasm_api/mod.rs
@@ -10,4 +10,9 @@ mod boolean;
 #[cfg(feature = "parallel-wasm-api")]
 pub use wasm_bindgen_rayon::init_thread_pool;
 
+#[cfg(feature = "integer")]
 mod js_high_level_api;
+
+pub(crate) fn into_js_error<E: std::fmt::Debug>(e: E) -> wasm_bindgen::JsError {
+    wasm_bindgen::JsError::new(format!("{e:?}").as_str())
+}

--- a/tfhe/src/js_on_wasm_api/shortint.rs
+++ b/tfhe/src/js_on_wasm_api/shortint.rs
@@ -2,7 +2,7 @@
 use crate::core_crypto::commons::generators::DeterministicSeeder;
 use crate::core_crypto::commons::math::random::Seed;
 use crate::core_crypto::prelude::DefaultRandomGenerator;
-use crate::js_on_wasm_api::js_high_level_api::into_js_error;
+use crate::js_on_wasm_api::into_js_error;
 use crate::shortint::parameters::classic::compact_pk::*;
 use crate::shortint::parameters::compact_public_key_only::p_fail_2_minus_64::ks_pbs::{
     V0_11_PARAM_PKE_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64,


### PR DESCRIPTION
Fixes `cargo clippy --features=shortint_wasm_api`