### PR TITLE
backport 0.11: fix(safe_ser): aliases in named for renamed types deserialization

### DIFF
--- a/tfhe/src/named.rs
+++ b/tfhe/src/named.rs
@@ -1,3 +1,7 @@
 pub trait Named {
+    /// Default name for the type
     const NAME: &'static str;
+    /// Aliases that should also be accepted for backward compatibility when checking the name of
+    /// values of this type
+    const BACKWARD_COMPATIBILITY_ALIASES: &'static [&'static str] = &[];
 }

--- a/tfhe/src/zk/mod.rs
+++ b/tfhe/src/zk/mod.rs
@@ -196,6 +196,8 @@ pub enum CompactPkeCrs {
 
 impl Named for CompactPkeCrs {
     const NAME: &'static str = "zk::CompactPkeCrs";
+
+    const BACKWARD_COMPATIBILITY_ALIASES: &'static [&'static str] = &["zk::CompactPkePublicParams"];
 }
 
 impl From<ZkCompactPkeV1PublicParams> for CompactPkeCrs {


### PR DESCRIPTION
backport of https://github.com/zama-ai/tfhe-rs/pull/1982 for 0.11
