### PR TITLE
chore(gpu): add back async entry points

### DIFF
--- a/tfhe/src/integer/gpu/mod.rs
+++ b/tfhe/src/integer/gpu/mod.rs
@@ -525,7 +525,7 @@ pub unsafe fn decompress_integer_radix_async<T: UnsignedInteger, B: Numeric>(
 ///
 /// - [CudaStreams::synchronize] __must__ be called after this function as soon as synchronization
 ///   is required
-pub unsafe fn unchecked_add_integer_radix_assign(
+pub unsafe fn unchecked_add_integer_radix_assign_async(
     streams: &CudaStreams,
     radix_lwe_left: &mut CudaRadixCiphertext,
     radix_lwe_right: &CudaRadixCiphertext,
@@ -589,7 +589,6 @@ pub unsafe fn unchecked_add_integer_radix_assign(
         &radix_lwe_right_data,
     );
     update_noise_degree(radix_lwe_left, &radix_lwe_left_data);
-    streams.synchronize();
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -2163,7 +2162,7 @@ pub unsafe fn unchecked_rotate_left_integer_radix_kb_assign_async<
 ///
 /// - [CudaStreams::synchronize] __must__ be called after this function as soon as synchronization
 ///   is required
-pub unsafe fn unchecked_cmux_integer_radix_kb<T: UnsignedInteger, B: Numeric>(
+pub unsafe fn unchecked_cmux_integer_radix_kb_async<T: UnsignedInteger, B: Numeric>(
     streams: &CudaStreams,
     radix_lwe_out: &mut CudaRadixCiphertext,
     radix_lwe_condition: &CudaBooleanBlock,
@@ -2347,7 +2346,6 @@ pub unsafe fn unchecked_cmux_integer_radix_kb<T: UnsignedInteger, B: Numeric>(
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
     );
-    streams.synchronize()
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -3302,7 +3300,7 @@ pub(crate) unsafe fn unchecked_unsigned_overflowing_sub_integer_radix_kb_assign_
 ///
 /// - [CudaStreams::synchronize] __must__ be called after this function as soon as synchronization
 ///   is required
-pub unsafe fn unchecked_signed_abs_radix_kb_assign<T: UnsignedInteger, B: Numeric>(
+pub unsafe fn unchecked_signed_abs_radix_kb_assign_async<T: UnsignedInteger, B: Numeric>(
     streams: &CudaStreams,
     ct: &mut CudaRadixCiphertext,
     bootstrapping_key: &CudaVec<B>,
@@ -3382,7 +3380,6 @@ pub unsafe fn unchecked_signed_abs_radix_kb_assign<T: UnsignedInteger, B: Numeri
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
     );
-    streams.synchronize()
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/tfhe/src/integer/gpu/server_key/radix/bitwise_op.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/bitwise_op.rs
@@ -465,18 +465,18 @@ impl CudaServerKey {
                 (true, true) => (ct_left, ct_right),
                 (true, false) => {
                     tmp_rhs = ct_right.duplicate_async(streams);
-                    self.full_propagate_assign(&mut tmp_rhs, streams);
+                    self.full_propagate_assign_async(&mut tmp_rhs, streams);
                     (ct_left, &tmp_rhs)
                 }
                 (false, true) => {
-                    self.full_propagate_assign(ct_left, streams);
+                    self.full_propagate_assign_async(ct_left, streams);
                     (ct_left, ct_right)
                 }
                 (false, false) => {
                     tmp_rhs = ct_right.duplicate_async(streams);
 
-                    self.full_propagate_assign(ct_left, streams);
-                    self.full_propagate_assign(&mut tmp_rhs, streams);
+                    self.full_propagate_assign_async(ct_left, streams);
+                    self.full_propagate_assign_async(&mut tmp_rhs, streams);
                     (ct_left, &tmp_rhs)
                 }
             }
@@ -570,18 +570,18 @@ impl CudaServerKey {
             (true, true) => (ct_left, ct_right),
             (true, false) => {
                 tmp_rhs = ct_right.duplicate_async(streams);
-                self.full_propagate_assign(&mut tmp_rhs, streams);
+                self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (ct_left, &tmp_rhs)
             }
             (false, true) => {
-                self.full_propagate_assign(ct_left, streams);
+                self.full_propagate_assign_async(ct_left, streams);
                 (ct_left, ct_right)
             }
             (false, false) => {
                 tmp_rhs = ct_right.duplicate_async(streams);
 
-                self.full_propagate_assign(ct_left, streams);
-                self.full_propagate_assign(&mut tmp_rhs, streams);
+                self.full_propagate_assign_async(ct_left, streams);
+                self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (ct_left, &tmp_rhs)
             }
         };
@@ -675,18 +675,18 @@ impl CudaServerKey {
             (true, true) => (ct_left, ct_right),
             (true, false) => {
                 tmp_rhs = ct_right.duplicate_async(streams);
-                self.full_propagate_assign(&mut tmp_rhs, streams);
+                self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (ct_left, &tmp_rhs)
             }
             (false, true) => {
-                self.full_propagate_assign(ct_left, streams);
+                self.full_propagate_assign_async(ct_left, streams);
                 (ct_left, ct_right)
             }
             (false, false) => {
                 tmp_rhs = ct_right.duplicate_async(streams);
 
-                self.full_propagate_assign(ct_left, streams);
-                self.full_propagate_assign(&mut tmp_rhs, streams);
+                self.full_propagate_assign_async(ct_left, streams);
+                self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (ct_left, &tmp_rhs)
             }
         };
@@ -764,7 +764,7 @@ impl CudaServerKey {
         streams: &CudaStreams,
     ) {
         if !ct.block_carries_are_empty() {
-            self.full_propagate_assign(ct, streams);
+            self.full_propagate_assign_async(ct, streams);
         }
 
         self.unchecked_bitnot_assign_async(ct, streams);

--- a/tfhe/src/integer/gpu/server_key/radix/comparison.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/comparison.rs
@@ -285,20 +285,20 @@ impl CudaServerKey {
             (true, true) => (ct_left, ct_right),
             (true, false) => {
                 tmp_rhs = ct_right.duplicate_async(streams);
-                self.full_propagate_assign(&mut tmp_rhs, streams);
+                self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (ct_left, &tmp_rhs)
             }
             (false, true) => {
                 tmp_lhs = ct_left.duplicate_async(streams);
-                self.full_propagate_assign(&mut tmp_lhs, streams);
+                self.full_propagate_assign_async(&mut tmp_lhs, streams);
                 (&tmp_lhs, ct_right)
             }
             (false, false) => {
                 tmp_lhs = ct_left.duplicate_async(streams);
                 tmp_rhs = ct_right.duplicate_async(streams);
 
-                self.full_propagate_assign(&mut tmp_lhs, streams);
-                self.full_propagate_assign(&mut tmp_rhs, streams);
+                self.full_propagate_assign_async(&mut tmp_lhs, streams);
+                self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (&tmp_lhs, &tmp_rhs)
             }
         };
@@ -379,20 +379,20 @@ impl CudaServerKey {
             (true, true) => (ct_left, ct_right),
             (true, false) => {
                 tmp_rhs = ct_right.duplicate_async(streams);
-                self.full_propagate_assign(&mut tmp_rhs, streams);
+                self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (ct_left, &tmp_rhs)
             }
             (false, true) => {
                 tmp_lhs = ct_left.duplicate_async(streams);
-                self.full_propagate_assign(&mut tmp_lhs, streams);
+                self.full_propagate_assign_async(&mut tmp_lhs, streams);
                 (&tmp_lhs, ct_right)
             }
             (false, false) => {
                 tmp_lhs = ct_left.duplicate_async(streams);
                 tmp_rhs = ct_right.duplicate_async(streams);
 
-                self.full_propagate_assign(&mut tmp_lhs, streams);
-                self.full_propagate_assign(&mut tmp_rhs, streams);
+                self.full_propagate_assign_async(&mut tmp_lhs, streams);
+                self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (&tmp_lhs, &tmp_rhs)
             }
         };
@@ -558,20 +558,20 @@ impl CudaServerKey {
             (true, true) => (ct_left, ct_right),
             (true, false) => {
                 tmp_rhs = ct_right.duplicate_async(streams);
-                self.full_propagate_assign(&mut tmp_rhs, streams);
+                self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (ct_left, &tmp_rhs)
             }
             (false, true) => {
                 tmp_lhs = ct_left.duplicate_async(streams);
-                self.full_propagate_assign(&mut tmp_lhs, streams);
+                self.full_propagate_assign_async(&mut tmp_lhs, streams);
                 (&tmp_lhs, ct_right)
             }
             (false, false) => {
                 tmp_lhs = ct_left.duplicate_async(streams);
                 tmp_rhs = ct_right.duplicate_async(streams);
 
-                self.full_propagate_assign(&mut tmp_lhs, streams);
-                self.full_propagate_assign(&mut tmp_rhs, streams);
+                self.full_propagate_assign_async(&mut tmp_lhs, streams);
+                self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (&tmp_lhs, &tmp_rhs)
             }
         };
@@ -666,20 +666,20 @@ impl CudaServerKey {
             (true, true) => (ct_left, ct_right),
             (true, false) => {
                 tmp_rhs = ct_right.duplicate_async(streams);
-                self.full_propagate_assign(&mut tmp_rhs, streams);
+                self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (ct_left, &tmp_rhs)
             }
             (false, true) => {
                 tmp_lhs = ct_left.duplicate_async(streams);
-                self.full_propagate_assign(&mut tmp_lhs, streams);
+                self.full_propagate_assign_async(&mut tmp_lhs, streams);
                 (&tmp_lhs, ct_right)
             }
             (false, false) => {
                 tmp_lhs = ct_left.duplicate_async(streams);
                 tmp_rhs = ct_right.duplicate_async(streams);
 
-                self.full_propagate_assign(&mut tmp_lhs, streams);
-                self.full_propagate_assign(&mut tmp_rhs, streams);
+                self.full_propagate_assign_async(&mut tmp_lhs, streams);
+                self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (&tmp_lhs, &tmp_rhs)
             }
         };
@@ -790,20 +790,20 @@ impl CudaServerKey {
             (true, true) => (ct_left, ct_right),
             (true, false) => {
                 tmp_rhs = ct_right.duplicate_async(streams);
-                self.full_propagate_assign(&mut tmp_rhs, streams);
+                self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (ct_left, &tmp_rhs)
             }
             (false, true) => {
                 tmp_lhs = ct_left.duplicate_async(streams);
-                self.full_propagate_assign(&mut tmp_lhs, streams);
+                self.full_propagate_assign_async(&mut tmp_lhs, streams);
                 (&tmp_lhs, ct_right)
             }
             (false, false) => {
                 tmp_lhs = ct_left.duplicate_async(streams);
                 tmp_rhs = ct_right.duplicate_async(streams);
 
-                self.full_propagate_assign(&mut tmp_lhs, streams);
-                self.full_propagate_assign(&mut tmp_rhs, streams);
+                self.full_propagate_assign_async(&mut tmp_lhs, streams);
+                self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (&tmp_lhs, &tmp_rhs)
             }
         };
@@ -914,20 +914,20 @@ impl CudaServerKey {
             (true, true) => (ct_left, ct_right),
             (true, false) => {
                 tmp_rhs = ct_right.duplicate_async(streams);
-                self.full_propagate_assign(&mut tmp_rhs, streams);
+                self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (ct_left, &tmp_rhs)
             }
             (false, true) => {
                 tmp_lhs = ct_left.duplicate_async(streams);
-                self.full_propagate_assign(&mut tmp_lhs, streams);
+                self.full_propagate_assign_async(&mut tmp_lhs, streams);
                 (&tmp_lhs, ct_right)
             }
             (false, false) => {
                 tmp_lhs = ct_left.duplicate_async(streams);
                 tmp_rhs = ct_right.duplicate_async(streams);
 
-                self.full_propagate_assign(&mut tmp_lhs, streams);
-                self.full_propagate_assign(&mut tmp_rhs, streams);
+                self.full_propagate_assign_async(&mut tmp_lhs, streams);
+                self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (&tmp_lhs, &tmp_rhs)
             }
         };
@@ -1161,20 +1161,20 @@ impl CudaServerKey {
             (true, true) => (ct_left, ct_right),
             (true, false) => {
                 tmp_rhs = ct_right.duplicate_async(streams);
-                self.full_propagate_assign(&mut tmp_rhs, streams);
+                self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (ct_left, &tmp_rhs)
             }
             (false, true) => {
                 tmp_lhs = ct_left.duplicate_async(streams);
-                self.full_propagate_assign(&mut tmp_lhs, streams);
+                self.full_propagate_assign_async(&mut tmp_lhs, streams);
                 (&tmp_lhs, ct_right)
             }
             (false, false) => {
                 tmp_lhs = ct_left.duplicate_async(streams);
                 tmp_rhs = ct_right.duplicate_async(streams);
 
-                self.full_propagate_assign(&mut tmp_lhs, streams);
-                self.full_propagate_assign(&mut tmp_rhs, streams);
+                self.full_propagate_assign_async(&mut tmp_lhs, streams);
+                self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (&tmp_lhs, &tmp_rhs)
             }
         };
@@ -1208,20 +1208,20 @@ impl CudaServerKey {
             (true, true) => (ct_left, ct_right),
             (true, false) => {
                 tmp_rhs = ct_right.duplicate_async(streams);
-                self.full_propagate_assign(&mut tmp_rhs, streams);
+                self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (ct_left, &tmp_rhs)
             }
             (false, true) => {
                 tmp_lhs = ct_left.duplicate_async(streams);
-                self.full_propagate_assign(&mut tmp_lhs, streams);
+                self.full_propagate_assign_async(&mut tmp_lhs, streams);
                 (&tmp_lhs, ct_right)
             }
             (false, false) => {
                 tmp_lhs = ct_left.duplicate_async(streams);
                 tmp_rhs = ct_right.duplicate_async(streams);
 
-                self.full_propagate_assign(&mut tmp_lhs, streams);
-                self.full_propagate_assign(&mut tmp_rhs, streams);
+                self.full_propagate_assign_async(&mut tmp_lhs, streams);
+                self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (&tmp_lhs, &tmp_rhs)
             }
         };

--- a/tfhe/src/integer/gpu/server_key/radix/div_mod.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/div_mod.rs
@@ -136,19 +136,19 @@ impl CudaServerKey {
             (true, true) => (numerator, divisor),
             (true, false) => {
                 tmp_divisor = divisor.duplicate(streams);
-                self.full_propagate_assign(&mut tmp_divisor, streams);
+                unsafe { self.full_propagate_assign_async(&mut tmp_divisor, streams) };
                 (numerator, &tmp_divisor)
             }
             (false, true) => {
                 tmp_numerator = numerator.duplicate(streams);
-                self.full_propagate_assign(&mut tmp_numerator, streams);
+                unsafe { self.full_propagate_assign_async(&mut tmp_numerator, streams) };
                 (&tmp_numerator, divisor)
             }
             (false, false) => {
                 tmp_divisor = divisor.duplicate(streams);
                 tmp_numerator = numerator.duplicate(streams);
-                self.full_propagate_assign(&mut tmp_numerator, streams);
-                self.full_propagate_assign(&mut tmp_divisor, streams);
+                unsafe { self.full_propagate_assign_async(&mut tmp_numerator, streams) };
+                unsafe { self.full_propagate_assign_async(&mut tmp_divisor, streams) };
                 (&tmp_numerator, &tmp_divisor)
             }
         };
@@ -176,19 +176,19 @@ impl CudaServerKey {
             (true, true) => (numerator, divisor),
             (true, false) => {
                 tmp_divisor = divisor.duplicate(streams);
-                self.full_propagate_assign(&mut tmp_divisor, streams);
+                unsafe { self.full_propagate_assign_async(&mut tmp_divisor, streams) };
                 (numerator, &tmp_divisor)
             }
             (false, true) => {
                 tmp_numerator = numerator.duplicate(streams);
-                self.full_propagate_assign(&mut tmp_numerator, streams);
+                unsafe { self.full_propagate_assign_async(&mut tmp_numerator, streams) };
                 (&tmp_numerator, divisor)
             }
             (false, false) => {
                 tmp_divisor = divisor.duplicate(streams);
                 tmp_numerator = numerator.duplicate(streams);
-                self.full_propagate_assign(&mut tmp_numerator, streams);
-                self.full_propagate_assign(&mut tmp_divisor, streams);
+                unsafe { self.full_propagate_assign_async(&mut tmp_numerator, streams) };
+                unsafe { self.full_propagate_assign_async(&mut tmp_divisor, streams) };
                 (&tmp_numerator, &tmp_divisor)
             }
         };

--- a/tfhe/src/integer/gpu/server_key/radix/ilog2.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/ilog2.rs
@@ -847,7 +847,7 @@ impl CudaServerKey {
             ct
         } else {
             tmp = ct.duplicate_async(streams);
-            self.full_propagate_assign(&mut tmp, streams);
+            self.full_propagate_assign_async(&mut tmp, streams);
             &tmp
         };
         self.unchecked_trailing_zeros_async(ct, streams)
@@ -920,7 +920,7 @@ impl CudaServerKey {
             ct
         } else {
             tmp = ct.duplicate_async(streams);
-            self.full_propagate_assign(&mut tmp, streams);
+            self.full_propagate_assign_async(&mut tmp, streams);
             &tmp
         };
         self.unchecked_trailing_ones_async(ct, streams)
@@ -993,7 +993,7 @@ impl CudaServerKey {
             ct
         } else {
             tmp = ct.duplicate_async(streams);
-            self.full_propagate_assign(&mut tmp, streams);
+            self.full_propagate_assign_async(&mut tmp, streams);
             &tmp
         };
         self.unchecked_leading_zeros_async(ct, streams)
@@ -1066,7 +1066,7 @@ impl CudaServerKey {
             ct
         } else {
             tmp = ct.duplicate_async(streams);
-            self.full_propagate_assign(&mut tmp, streams);
+            self.full_propagate_assign_async(&mut tmp, streams);
             &tmp
         };
         self.unchecked_leading_ones_async(ct, streams)
@@ -1132,7 +1132,7 @@ impl CudaServerKey {
             ct
         } else {
             tmp = ct.duplicate_async(streams);
-            self.full_propagate_assign(&mut tmp, streams);
+            self.full_propagate_assign_async(&mut tmp, streams);
             &tmp
         };
 
@@ -1207,7 +1207,7 @@ impl CudaServerKey {
             ct
         } else {
             tmp = ct.duplicate_async(streams);
-            self.full_propagate_assign(&mut tmp, streams);
+            self.full_propagate_assign_async(&mut tmp, streams);
             &tmp
         };
 

--- a/tfhe/src/integer/gpu/server_key/radix/mod.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/mod.rs
@@ -386,7 +386,7 @@ impl CudaServerKey {
         carry_out
     }
 
-    pub(crate) fn full_propagate_assign<T: CudaIntegerRadixCiphertext>(
+    pub(crate) unsafe fn full_propagate_assign_async<T: CudaIntegerRadixCiphertext>(
         &self,
         ct: &mut T,
         streams: &CudaStreams,
@@ -445,7 +445,6 @@ impl CudaServerKey {
                 NoiseLevel::NOMINAL
             };
         });
-        streams.synchronize();
     }
 
     /// Prepend trivial zero LSB blocks to an existing [`CudaUnsignedRadixCiphertext`] or
@@ -1353,7 +1352,7 @@ impl CudaServerKey {
         T: CudaIntegerRadixCiphertext,
     {
         if !source.block_carries_are_empty() {
-            self.full_propagate_assign(&mut source, streams);
+            self.full_propagate_assign_async(&mut source, streams);
         }
         let current_num_blocks = source.as_ref().info.blocks.len();
         if T::IS_SIGNED {
@@ -1459,7 +1458,7 @@ impl CudaServerKey {
         T: CudaIntegerRadixCiphertext,
     {
         if !source.block_carries_are_empty() {
-            self.full_propagate_assign(&mut source, streams);
+            self.full_propagate_assign_async(&mut source, streams);
         }
 
         let current_num_blocks = source.as_ref().info.blocks.len();

--- a/tfhe/src/integer/gpu/server_key/radix/mul.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/mul.rs
@@ -214,18 +214,18 @@ impl CudaServerKey {
             (true, true) => (ct_left, ct_right),
             (true, false) => {
                 tmp_rhs = ct_right.duplicate_async(streams);
-                self.full_propagate_assign(&mut tmp_rhs, streams);
+                self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (ct_left, &tmp_rhs)
             }
             (false, true) => {
-                self.full_propagate_assign(ct_left, streams);
+                self.full_propagate_assign_async(ct_left, streams);
                 (ct_left, ct_right)
             }
             (false, false) => {
                 tmp_rhs = ct_right.duplicate_async(streams);
 
-                self.full_propagate_assign(ct_left, streams);
-                self.full_propagate_assign(&mut tmp_rhs, streams);
+                self.full_propagate_assign_async(ct_left, streams);
+                self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (ct_left, &tmp_rhs)
             }
         };

--- a/tfhe/src/integer/gpu/server_key/radix/neg.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/neg.rs
@@ -142,7 +142,7 @@ impl CudaServerKey {
             ctxt
         } else {
             tmp_ctxt = ctxt.duplicate_async(streams);
-            self.full_propagate_assign(&mut tmp_ctxt, streams);
+            self.full_propagate_assign_async(&mut tmp_ctxt, streams);
             &mut tmp_ctxt
         };
 

--- a/tfhe/src/integer/gpu/server_key/radix/rotate.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/rotate.rs
@@ -271,20 +271,20 @@ impl CudaServerKey {
             (true, true) => (ct, rotate),
             (true, false) => {
                 tmp_rhs = rotate.duplicate_async(streams);
-                self.full_propagate_assign(&mut tmp_rhs, streams);
+                self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (ct, &tmp_rhs)
             }
             (false, true) => {
                 tmp_lhs = ct.duplicate_async(streams);
-                self.full_propagate_assign(&mut tmp_lhs, streams);
+                self.full_propagate_assign_async(&mut tmp_lhs, streams);
                 (&tmp_lhs, rotate)
             }
             (false, false) => {
                 tmp_lhs = ct.duplicate_async(streams);
                 tmp_rhs = rotate.duplicate_async(streams);
 
-                self.full_propagate_assign(&mut tmp_lhs, streams);
-                self.full_propagate_assign(&mut tmp_rhs, streams);
+                self.full_propagate_assign_async(&mut tmp_lhs, streams);
+                self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (&tmp_lhs, &tmp_rhs)
             }
         };
@@ -316,20 +316,20 @@ impl CudaServerKey {
             (true, true) => (ct, rotate),
             (true, false) => {
                 tmp_rhs = rotate.duplicate_async(streams);
-                self.full_propagate_assign(&mut tmp_rhs, streams);
+                self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (ct, &tmp_rhs)
             }
             (false, true) => {
                 tmp_lhs = ct.duplicate_async(streams);
-                self.full_propagate_assign(&mut tmp_lhs, streams);
+                self.full_propagate_assign_async(&mut tmp_lhs, streams);
                 (&mut tmp_lhs, rotate)
             }
             (false, false) => {
                 tmp_lhs = ct.duplicate_async(streams);
                 tmp_rhs = rotate.duplicate_async(streams);
 
-                self.full_propagate_assign(&mut tmp_lhs, streams);
-                self.full_propagate_assign(&mut tmp_rhs, streams);
+                self.full_propagate_assign_async(&mut tmp_lhs, streams);
+                self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (&mut tmp_lhs, &tmp_rhs)
             }
         };
@@ -425,20 +425,20 @@ impl CudaServerKey {
             (true, true) => (ct, rotate),
             (true, false) => {
                 tmp_rhs = rotate.duplicate_async(streams);
-                self.full_propagate_assign(&mut tmp_rhs, streams);
+                self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (ct, &tmp_rhs)
             }
             (false, true) => {
                 tmp_lhs = ct.duplicate_async(streams);
-                self.full_propagate_assign(&mut tmp_lhs, streams);
+                self.full_propagate_assign_async(&mut tmp_lhs, streams);
                 (&tmp_lhs, rotate)
             }
             (false, false) => {
                 tmp_lhs = ct.duplicate_async(streams);
                 tmp_rhs = rotate.duplicate_async(streams);
 
-                self.full_propagate_assign(&mut tmp_lhs, streams);
-                self.full_propagate_assign(&mut tmp_rhs, streams);
+                self.full_propagate_assign_async(&mut tmp_lhs, streams);
+                self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (&tmp_lhs, &tmp_rhs)
             }
         };
@@ -470,20 +470,20 @@ impl CudaServerKey {
             (true, true) => (ct, rotate),
             (true, false) => {
                 tmp_rhs = rotate.duplicate_async(streams);
-                self.full_propagate_assign(&mut tmp_rhs, streams);
+                self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (ct, &tmp_rhs)
             }
             (false, true) => {
                 tmp_lhs = ct.duplicate_async(streams);
-                self.full_propagate_assign(&mut tmp_lhs, streams);
+                self.full_propagate_assign_async(&mut tmp_lhs, streams);
                 (&mut tmp_lhs, rotate)
             }
             (false, false) => {
                 tmp_lhs = ct.duplicate_async(streams);
                 tmp_rhs = rotate.duplicate_async(streams);
 
-                self.full_propagate_assign(&mut tmp_lhs, streams);
-                self.full_propagate_assign(&mut tmp_rhs, streams);
+                self.full_propagate_assign_async(&mut tmp_lhs, streams);
+                self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (&mut tmp_lhs, &tmp_rhs)
             }
         };

--- a/tfhe/src/integer/gpu/server_key/radix/scalar_add.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/scalar_add.rs
@@ -185,7 +185,7 @@ impl CudaServerKey {
         T: CudaIntegerRadixCiphertext,
     {
         if !ct.block_carries_are_empty() {
-            self.full_propagate_assign(ct, streams);
+            self.full_propagate_assign_async(ct, streams);
         };
 
         self.unchecked_scalar_add_assign_async(ct, scalar, streams);
@@ -228,7 +228,7 @@ impl CudaServerKey {
         Scalar: DecomposableInto<u8> + CastInto<u64>,
     {
         if !ct_left.block_carries_are_empty() {
-            self.full_propagate_assign(ct_left, stream);
+            unsafe { self.full_propagate_assign_async(ct_left, stream) };
         }
         self.unchecked_unsigned_overflowing_scalar_add_assign(ct_left, scalar, stream)
     }
@@ -330,7 +330,7 @@ impl CudaServerKey {
         let mut tmp_lhs;
         tmp_lhs = ct_left.duplicate(streams);
         if !tmp_lhs.block_carries_are_empty() {
-            self.full_propagate_assign(&mut tmp_lhs, streams);
+            unsafe { self.full_propagate_assign_async(&mut tmp_lhs, streams) };
         }
 
         let trivial: CudaSignedRadixCiphertext = self.create_trivial_radix(

--- a/tfhe/src/integer/gpu/server_key/radix/scalar_bitwise_op.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/scalar_bitwise_op.rs
@@ -193,7 +193,7 @@ impl CudaServerKey {
         T: CudaIntegerRadixCiphertext,
     {
         if !ct.block_carries_are_empty() {
-            self.full_propagate_assign(ct, streams);
+            self.full_propagate_assign_async(ct, streams);
         }
         self.unchecked_scalar_bitop_assign_async(ct, rhs, BitOpType::ScalarAnd, streams);
         ct.as_mut().info = ct.as_ref().info.after_scalar_bitand(rhs);
@@ -234,7 +234,7 @@ impl CudaServerKey {
         T: CudaIntegerRadixCiphertext,
     {
         if !ct.block_carries_are_empty() {
-            self.full_propagate_assign(ct, streams);
+            self.full_propagate_assign_async(ct, streams);
         }
         self.unchecked_scalar_bitop_assign_async(ct, rhs, BitOpType::ScalarOr, streams);
         ct.as_mut().info = ct.as_ref().info.after_scalar_bitor(rhs);
@@ -275,7 +275,7 @@ impl CudaServerKey {
         T: CudaIntegerRadixCiphertext,
     {
         if !ct.block_carries_are_empty() {
-            self.full_propagate_assign(ct, streams);
+            self.full_propagate_assign_async(ct, streams);
         }
         self.unchecked_scalar_bitop_assign_async(ct, rhs, BitOpType::ScalarXor, streams);
         ct.as_mut().info = ct.as_ref().info.after_scalar_bitxor(rhs);

--- a/tfhe/src/integer/gpu/server_key/radix/scalar_comparison.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/scalar_comparison.rs
@@ -606,7 +606,7 @@ impl CudaServerKey {
             ct
         } else {
             tmp_lhs = ct.duplicate_async(streams);
-            self.full_propagate_assign(&mut tmp_lhs, streams);
+            self.full_propagate_assign_async(&mut tmp_lhs, streams);
             &tmp_lhs
         };
 
@@ -688,7 +688,7 @@ impl CudaServerKey {
             ct
         } else {
             tmp_lhs = ct.duplicate_async(streams);
-            self.full_propagate_assign(&mut tmp_lhs, streams);
+            self.full_propagate_assign_async(&mut tmp_lhs, streams);
             &tmp_lhs
         };
 
@@ -929,7 +929,7 @@ impl CudaServerKey {
             ct
         } else {
             tmp_lhs = ct.duplicate_async(streams);
-            self.full_propagate_assign(&mut tmp_lhs, streams);
+            self.full_propagate_assign_async(&mut tmp_lhs, streams);
             &tmp_lhs
         };
 
@@ -970,7 +970,7 @@ impl CudaServerKey {
             ct
         } else {
             tmp_lhs = ct.duplicate_async(streams);
-            self.full_propagate_assign(&mut tmp_lhs, streams);
+            self.full_propagate_assign_async(&mut tmp_lhs, streams);
             &tmp_lhs
         };
 
@@ -1011,7 +1011,7 @@ impl CudaServerKey {
             ct
         } else {
             tmp_lhs = ct.duplicate_async(streams);
-            self.full_propagate_assign(&mut tmp_lhs, streams);
+            self.full_propagate_assign_async(&mut tmp_lhs, streams);
             &tmp_lhs
         };
 
@@ -1051,7 +1051,7 @@ impl CudaServerKey {
             ct
         } else {
             tmp_lhs = ct.duplicate_async(streams);
-            self.full_propagate_assign(&mut tmp_lhs, streams);
+            self.full_propagate_assign_async(&mut tmp_lhs, streams);
             &tmp_lhs
         };
 
@@ -1156,7 +1156,7 @@ impl CudaServerKey {
             ct
         } else {
             tmp_lhs = ct.duplicate_async(streams);
-            self.full_propagate_assign(&mut tmp_lhs, streams);
+            self.full_propagate_assign_async(&mut tmp_lhs, streams);
             &tmp_lhs
         };
 
@@ -1192,7 +1192,7 @@ impl CudaServerKey {
             ct
         } else {
             tmp_lhs = ct.duplicate_async(streams);
-            self.full_propagate_assign(&mut tmp_lhs, streams);
+            self.full_propagate_assign_async(&mut tmp_lhs, streams);
             &tmp_lhs
         };
 

--- a/tfhe/src/integer/gpu/server_key/radix/scalar_div_mod.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/scalar_div_mod.rs
@@ -296,7 +296,7 @@ impl CudaServerKey {
             numerator
         } else {
             tmp_numerator = numerator.duplicate_async(streams);
-            self.full_propagate_assign(&mut tmp_numerator, streams);
+            self.full_propagate_assign_async(&mut tmp_numerator, streams);
             &tmp_numerator
         };
 
@@ -425,7 +425,7 @@ impl CudaServerKey {
             numerator
         } else {
             tmp_numerator = numerator.duplicate_async(streams);
-            self.full_propagate_assign(&mut tmp_numerator, streams);
+            self.full_propagate_assign_async(&mut tmp_numerator, streams);
             &tmp_numerator
         };
 
@@ -536,7 +536,7 @@ impl CudaServerKey {
             numerator
         } else {
             tmp_numerator = numerator.duplicate_async(streams);
-            self.full_propagate_assign(&mut tmp_numerator, streams);
+            self.full_propagate_assign_async(&mut tmp_numerator, streams);
             &tmp_numerator
         };
 
@@ -776,7 +776,7 @@ impl CudaServerKey {
             numerator
         } else {
             tmp_numerator = numerator.duplicate_async(streams);
-            self.full_propagate_assign(&mut tmp_numerator, streams);
+            self.full_propagate_assign_async(&mut tmp_numerator, streams);
             &tmp_numerator
         };
 
@@ -894,7 +894,7 @@ impl CudaServerKey {
             numerator
         } else {
             tmp_numerator = numerator.duplicate_async(streams);
-            self.full_propagate_assign(&mut tmp_numerator, streams);
+            self.full_propagate_assign_async(&mut tmp_numerator, streams);
             &tmp_numerator
         };
 
@@ -1006,7 +1006,7 @@ impl CudaServerKey {
             numerator
         } else {
             tmp_numerator = numerator.duplicate_async(streams);
-            self.full_propagate_assign(&mut tmp_numerator, streams);
+            self.full_propagate_assign_async(&mut tmp_numerator, streams);
             &tmp_numerator
         };
 

--- a/tfhe/src/integer/gpu/server_key/radix/scalar_mul.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/scalar_mul.rs
@@ -242,7 +242,7 @@ impl CudaServerKey {
         T: CudaIntegerRadixCiphertext,
     {
         if !ct.block_carries_are_empty() {
-            self.full_propagate_assign(ct, streams);
+            self.full_propagate_assign_async(ct, streams);
         };
 
         self.unchecked_scalar_mul_assign_async(ct, scalar, streams);

--- a/tfhe/src/integer/gpu/server_key/radix/scalar_rotate.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/scalar_rotate.rs
@@ -231,7 +231,7 @@ impl CudaServerKey {
         u32: CastFrom<Scalar>,
     {
         if !ct.block_carries_are_empty() {
-            self.full_propagate_assign(ct, stream);
+            unsafe { self.full_propagate_assign_async(ct, stream) };
         }
 
         unsafe { self.unchecked_scalar_rotate_left_assign_async(ct, n, stream) };
@@ -245,7 +245,7 @@ impl CudaServerKey {
         u32: CastFrom<Scalar>,
     {
         if !ct.block_carries_are_empty() {
-            self.full_propagate_assign(ct, stream);
+            unsafe { self.full_propagate_assign_async(ct, stream) };
         }
 
         unsafe { self.unchecked_scalar_rotate_right_assign_async(ct, n, stream) };

--- a/tfhe/src/integer/gpu/server_key/radix/scalar_shift.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/scalar_shift.rs
@@ -371,7 +371,7 @@ impl CudaServerKey {
         T: CudaIntegerRadixCiphertext,
     {
         if !ct.block_carries_are_empty() {
-            self.full_propagate_assign(ct, streams);
+            self.full_propagate_assign_async(ct, streams);
         }
 
         self.unchecked_scalar_right_shift_assign_async(ct, shift, streams);
@@ -459,7 +459,7 @@ impl CudaServerKey {
         T: CudaIntegerRadixCiphertext,
     {
         if !ct.block_carries_are_empty() {
-            self.full_propagate_assign(ct, streams);
+            self.full_propagate_assign_async(ct, streams);
         }
 
         self.unchecked_scalar_left_shift_assign_async(ct, shift, streams);
@@ -543,7 +543,7 @@ impl CudaServerKey {
         T: CudaIntegerRadixCiphertext,
     {
         if !ct.block_carries_are_empty() {
-            self.full_propagate_assign(ct, streams);
+            unsafe { self.full_propagate_assign_async(ct, streams) };
         }
 
         unsafe {
@@ -563,7 +563,7 @@ impl CudaServerKey {
         T: CudaIntegerRadixCiphertext,
     {
         if !ct.block_carries_are_empty() {
-            self.full_propagate_assign(ct, streams);
+            unsafe { self.full_propagate_assign_async(ct, streams) };
         }
 
         unsafe {

--- a/tfhe/src/integer/gpu/server_key/radix/scalar_sub.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/scalar_sub.rs
@@ -155,7 +155,7 @@ impl CudaServerKey {
         T: CudaIntegerRadixCiphertext,
     {
         if !ct.block_carries_are_empty() {
-            self.full_propagate_assign(ct, streams);
+            self.full_propagate_assign_async(ct, streams);
         };
 
         self.unchecked_scalar_sub_assign_async(ct, scalar, streams);
@@ -221,7 +221,7 @@ impl CudaServerKey {
         unsafe {
             tmp_lhs = ct_left.duplicate_async(streams);
             if !tmp_lhs.block_carries_are_empty() {
-                self.full_propagate_assign(&mut tmp_lhs, streams);
+                self.full_propagate_assign_async(&mut tmp_lhs, streams);
             }
         }
 

--- a/tfhe/src/integer/gpu/server_key/radix/shift.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/shift.rs
@@ -267,20 +267,20 @@ impl CudaServerKey {
             (true, true) => (ct, shift),
             (true, false) => {
                 tmp_rhs = shift.duplicate_async(streams);
-                self.full_propagate_assign(&mut tmp_rhs, streams);
+                self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (ct, &tmp_rhs)
             }
             (false, true) => {
                 tmp_lhs = ct.duplicate_async(streams);
-                self.full_propagate_assign(&mut tmp_lhs, streams);
+                self.full_propagate_assign_async(&mut tmp_lhs, streams);
                 (&tmp_lhs, shift)
             }
             (false, false) => {
                 tmp_lhs = ct.duplicate_async(streams);
                 tmp_rhs = shift.duplicate_async(streams);
 
-                self.full_propagate_assign(&mut tmp_lhs, streams);
-                self.full_propagate_assign(&mut tmp_rhs, streams);
+                self.full_propagate_assign_async(&mut tmp_lhs, streams);
+                self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (&tmp_lhs, &tmp_rhs)
             }
         };
@@ -312,20 +312,20 @@ impl CudaServerKey {
             (true, true) => (ct, shift),
             (true, false) => {
                 tmp_rhs = shift.duplicate_async(streams);
-                self.full_propagate_assign(&mut tmp_rhs, streams);
+                self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (ct, &tmp_rhs)
             }
             (false, true) => {
                 tmp_lhs = ct.duplicate_async(streams);
-                self.full_propagate_assign(&mut tmp_lhs, streams);
+                self.full_propagate_assign_async(&mut tmp_lhs, streams);
                 (&mut tmp_lhs, shift)
             }
             (false, false) => {
                 tmp_lhs = ct.duplicate_async(streams);
                 tmp_rhs = shift.duplicate_async(streams);
 
-                self.full_propagate_assign(&mut tmp_lhs, streams);
-                self.full_propagate_assign(&mut tmp_rhs, streams);
+                self.full_propagate_assign_async(&mut tmp_lhs, streams);
+                self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (&mut tmp_lhs, &tmp_rhs)
             }
         };
@@ -420,20 +420,20 @@ impl CudaServerKey {
             (true, true) => (ct, shift),
             (true, false) => {
                 tmp_rhs = shift.duplicate_async(streams);
-                self.full_propagate_assign(&mut tmp_rhs, streams);
+                self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (ct, &tmp_rhs)
             }
             (false, true) => {
                 tmp_lhs = ct.duplicate_async(streams);
-                self.full_propagate_assign(&mut tmp_lhs, streams);
+                self.full_propagate_assign_async(&mut tmp_lhs, streams);
                 (&tmp_lhs, shift)
             }
             (false, false) => {
                 tmp_lhs = ct.duplicate_async(streams);
                 tmp_rhs = shift.duplicate_async(streams);
 
-                self.full_propagate_assign(&mut tmp_lhs, streams);
-                self.full_propagate_assign(&mut tmp_rhs, streams);
+                self.full_propagate_assign_async(&mut tmp_lhs, streams);
+                self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (&tmp_lhs, &tmp_rhs)
             }
         };
@@ -465,20 +465,20 @@ impl CudaServerKey {
             (true, true) => (ct, shift),
             (true, false) => {
                 tmp_rhs = shift.duplicate_async(streams);
-                self.full_propagate_assign(&mut tmp_rhs, streams);
+                self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (ct, &tmp_rhs)
             }
             (false, true) => {
                 tmp_lhs = ct.duplicate_async(streams);
-                self.full_propagate_assign(&mut tmp_lhs, streams);
+                self.full_propagate_assign_async(&mut tmp_lhs, streams);
                 (&mut tmp_lhs, shift)
             }
             (false, false) => {
                 tmp_lhs = ct.duplicate_async(streams);
                 tmp_rhs = shift.duplicate_async(streams);
 
-                self.full_propagate_assign(&mut tmp_lhs, streams);
-                self.full_propagate_assign(&mut tmp_rhs, streams);
+                self.full_propagate_assign_async(&mut tmp_lhs, streams);
+                self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (&mut tmp_lhs, &tmp_rhs)
             }
         };

--- a/tfhe/src/integer/gpu/server_key/radix/sub.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/sub.rs
@@ -94,7 +94,7 @@ impl CudaServerKey {
         streams: &CudaStreams,
     ) {
         let neg = self.unchecked_neg_async(ct_right, streams);
-        self.unchecked_add_assign(ct_left, &neg, streams);
+        self.unchecked_add_assign_async(ct_left, &neg, streams);
     }
 
     /// Computes homomorphically a subtraction between two ciphertexts encrypting integer values.
@@ -257,18 +257,18 @@ impl CudaServerKey {
             (true, true) => (ct_left, ct_right),
             (true, false) => {
                 tmp_rhs = ct_right.duplicate_async(streams);
-                self.full_propagate_assign(&mut tmp_rhs, streams);
+                self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (ct_left, &tmp_rhs)
             }
             (false, true) => {
-                self.full_propagate_assign(ct_left, streams);
+                self.full_propagate_assign_async(ct_left, streams);
                 (ct_left, ct_right)
             }
             (false, false) => {
                 tmp_rhs = ct_right.duplicate_async(streams);
 
-                self.full_propagate_assign(ct_left, streams);
-                self.full_propagate_assign(&mut tmp_rhs, streams);
+                self.full_propagate_assign_async(ct_left, streams);
+                self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (ct_left, &tmp_rhs)
             }
         };
@@ -299,14 +299,14 @@ impl CudaServerKey {
             (true, false) => {
                 unsafe {
                     tmp_rhs = ct_right.duplicate_async(stream);
-                    self.full_propagate_assign(&mut tmp_rhs, stream);
+                    self.full_propagate_assign_async(&mut tmp_rhs, stream);
                 }
                 (ct_left, &tmp_rhs)
             }
             (false, true) => {
                 unsafe {
                     tmp_lhs = ct_left.duplicate_async(stream);
-                    self.full_propagate_assign(&mut tmp_lhs, stream);
+                    self.full_propagate_assign_async(&mut tmp_lhs, stream);
                 }
                 (&tmp_lhs, ct_right)
             }
@@ -315,8 +315,8 @@ impl CudaServerKey {
                     tmp_lhs = ct_left.duplicate_async(stream);
                     tmp_rhs = ct_right.duplicate_async(stream);
 
-                    self.full_propagate_assign(&mut tmp_lhs, stream);
-                    self.full_propagate_assign(&mut tmp_rhs, stream);
+                    self.full_propagate_assign_async(&mut tmp_lhs, stream);
+                    self.full_propagate_assign_async(&mut tmp_rhs, stream);
                 }
 
                 (&tmp_lhs, &tmp_rhs)
@@ -521,14 +521,14 @@ impl CudaServerKey {
             (true, false) => {
                 unsafe {
                     tmp_rhs = ct_right.duplicate_async(stream);
-                    self.full_propagate_assign(&mut tmp_rhs, stream);
+                    self.full_propagate_assign_async(&mut tmp_rhs, stream);
                 }
                 (ct_left, &tmp_rhs)
             }
             (false, true) => {
                 unsafe {
                     tmp_lhs = ct_left.duplicate_async(stream);
-                    self.full_propagate_assign(&mut tmp_lhs, stream);
+                    self.full_propagate_assign_async(&mut tmp_lhs, stream);
                 }
                 (&tmp_lhs, ct_right)
             }
@@ -537,8 +537,8 @@ impl CudaServerKey {
                     tmp_lhs = ct_left.duplicate_async(stream);
                     tmp_rhs = ct_right.duplicate_async(stream);
 
-                    self.full_propagate_assign(&mut tmp_lhs, stream);
-                    self.full_propagate_assign(&mut tmp_rhs, stream);
+                    self.full_propagate_assign_async(&mut tmp_lhs, stream);
+                    self.full_propagate_assign_async(&mut tmp_rhs, stream);
                 }
 
                 (&tmp_lhs, &tmp_rhs)

--- a/tfhe/src/integer/gpu/server_key/radix/vector_comparisons.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/vector_comparisons.rs
@@ -260,7 +260,7 @@ impl CudaServerKey {
             for ct in lhs.iter() {
                 let mut temp_ct = ct.duplicate(streams);
                 if !temp_ct.block_carries_are_empty() {
-                    self.full_propagate_assign(&mut temp_ct, streams);
+                    unsafe { self.full_propagate_assign_async(&mut temp_ct, streams) };
                 }
                 tmp_lhs.push(temp_ct);
             }
@@ -275,7 +275,7 @@ impl CudaServerKey {
             for ct in rhs.iter() {
                 let mut temp_ct = ct.duplicate(streams);
                 if !temp_ct.block_carries_are_empty() {
-                    self.full_propagate_assign(&mut temp_ct, streams);
+                    unsafe { self.full_propagate_assign_async(&mut temp_ct, streams) };
                 }
                 tmp_rhs.push(temp_ct);
             }
@@ -411,7 +411,7 @@ impl CudaServerKey {
             for ct in lhs.iter() {
                 let mut temp_ct = ct.duplicate(streams);
                 if !temp_ct.block_carries_are_empty() {
-                    self.full_propagate_assign(&mut temp_ct, streams);
+                    unsafe { self.full_propagate_assign_async(&mut temp_ct, streams) };
                 }
                 tmp_lhs.push(temp_ct);
             }
@@ -426,7 +426,7 @@ impl CudaServerKey {
             for ct in rhs.iter() {
                 let mut temp_ct = ct.duplicate(streams);
                 if !temp_ct.block_carries_are_empty() {
-                    self.full_propagate_assign(&mut temp_ct, streams);
+                    unsafe { self.full_propagate_assign_async(&mut temp_ct, streams) };
                 }
                 tmp_rhs.push(temp_ct);
             }

--- a/tfhe/src/integer/gpu/server_key/radix/vector_find.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/vector_find.rs
@@ -250,7 +250,7 @@ impl CudaServerKey {
             self.unchecked_match_value(ct, matches, streams)
         } else {
             let mut clone = ct.duplicate(streams);
-            self.full_propagate_assign(&mut clone, streams);
+            unsafe { self.full_propagate_assign_async(&mut clone, streams) };
             self.unchecked_match_value(&clone, matches, streams)
         }
     }
@@ -364,7 +364,7 @@ impl CudaServerKey {
             self.unchecked_match_value_or(ct, matches, or_value, streams)
         } else {
             let mut clone = ct.duplicate(streams);
-            self.full_propagate_assign(&mut clone, streams);
+            unsafe { self.full_propagate_assign_async(&mut clone, streams) };
             self.unchecked_match_value_or(&clone, matches, or_value, streams)
         }
     }
@@ -444,7 +444,7 @@ impl CudaServerKey {
             for ct in cts.iter() {
                 let mut temp_ct = ct.duplicate(streams);
                 if !temp_ct.block_carries_are_empty() {
-                    self.full_propagate_assign(&mut temp_ct, streams);
+                    unsafe { self.full_propagate_assign_async(&mut temp_ct, streams) };
                 }
                 tmp_cts.push(temp_ct);
             }
@@ -458,7 +458,7 @@ impl CudaServerKey {
             value
         } else {
             tmp_value = value.duplicate(streams);
-            self.full_propagate_assign(&mut tmp_value, streams);
+            unsafe { self.full_propagate_assign_async(&mut tmp_value, streams) };
             &tmp_value
         };
 
@@ -544,7 +544,7 @@ impl CudaServerKey {
             for ct in cts.iter() {
                 let mut temp_ct = ct.duplicate(streams);
                 if !temp_ct.block_carries_are_empty() {
-                    self.full_propagate_assign(&mut temp_ct, streams);
+                    unsafe { self.full_propagate_assign_async(&mut temp_ct, streams) };
                 }
                 tmp_cts.push(temp_ct);
             }
@@ -632,7 +632,7 @@ impl CudaServerKey {
             ct
         } else {
             tmp_ct = ct.duplicate(streams);
-            self.full_propagate_assign(&mut tmp_ct, streams);
+            unsafe { self.full_propagate_assign_async(&mut tmp_ct, streams) };
             &tmp_ct
         };
         self.unchecked_is_in_clears(ct, clears, streams)
@@ -732,7 +732,7 @@ impl CudaServerKey {
             ct
         } else {
             tmp_ct = ct.duplicate(streams);
-            self.full_propagate_assign(&mut tmp_ct, streams);
+            unsafe { self.full_propagate_assign_async(&mut tmp_ct, streams) };
             streams.synchronize();
             &tmp_ct
         };
@@ -859,7 +859,7 @@ impl CudaServerKey {
             ct
         } else {
             tmp_ct = ct.duplicate(streams);
-            self.full_propagate_assign(&mut tmp_ct, streams);
+            unsafe { self.full_propagate_assign_async(&mut tmp_ct, streams) };
             streams.synchronize();
             &tmp_ct
         };
@@ -964,7 +964,7 @@ impl CudaServerKey {
             for ct in cts.iter() {
                 let mut temp_ct = ct.duplicate(streams);
                 if !temp_ct.block_carries_are_empty() {
-                    self.full_propagate_assign(&mut temp_ct, streams);
+                    unsafe { self.full_propagate_assign_async(&mut temp_ct, streams) };
                 }
                 tmp_cts.push(temp_ct);
             }
@@ -978,7 +978,7 @@ impl CudaServerKey {
             value
         } else {
             tmp_value = value.duplicate(streams);
-            self.full_propagate_assign(&mut tmp_value, streams);
+            unsafe { self.full_propagate_assign_async(&mut tmp_value, streams) };
             &tmp_value
         };
         self.unchecked_index_of(cts, value, streams)
@@ -1082,7 +1082,7 @@ impl CudaServerKey {
             for ct in cts.iter() {
                 let mut temp_ct = ct.duplicate(streams);
                 if !temp_ct.block_carries_are_empty() {
-                    self.full_propagate_assign(&mut temp_ct, streams);
+                    unsafe { self.full_propagate_assign_async(&mut temp_ct, streams) };
                 }
                 tmp_cts.push(temp_ct);
             }
@@ -1211,7 +1211,7 @@ impl CudaServerKey {
             for ct in cts.iter() {
                 let mut temp_ct = ct.duplicate(streams);
                 if !temp_ct.block_carries_are_empty() {
-                    self.full_propagate_assign(&mut temp_ct, streams);
+                    unsafe { self.full_propagate_assign_async(&mut temp_ct, streams) };
                 }
                 tmp_cts.push(temp_ct);
             }
@@ -1343,7 +1343,7 @@ impl CudaServerKey {
             for ct in cts.iter() {
                 let mut temp_ct = ct.duplicate(streams);
                 if !temp_ct.block_carries_are_empty() {
-                    self.full_propagate_assign(&mut temp_ct, streams);
+                    unsafe { self.full_propagate_assign_async(&mut temp_ct, streams) };
                 }
                 tmp_cts.push(temp_ct);
             }
@@ -1357,7 +1357,7 @@ impl CudaServerKey {
             value
         } else {
             tmp_value = value.duplicate(streams);
-            self.full_propagate_assign(&mut tmp_value, streams);
+            unsafe { self.full_propagate_assign_async(&mut tmp_value, streams) };
             &tmp_value
         };
         self.unchecked_first_index_of(cts, value, streams)
@@ -1606,11 +1606,13 @@ impl CudaServerKey {
         for chunk_idx in 0..(num_chunks - 1) {
             for ct_idx in 0..chunk_size {
                 let one_hot_idx = chunk_idx * chunk_size + ct_idx;
-                self.unchecked_add_assign(
-                    &mut aggregated_vector,
-                    &one_hot_vector[one_hot_idx],
-                    streams,
-                );
+                unsafe {
+                    self.unchecked_add_assign_async(
+                        &mut aggregated_vector,
+                        &one_hot_vector[one_hot_idx],
+                        streams,
+                    )
+                };
             }
             let mut temp = aggregated_vector.duplicate(streams);
             let mut aggregated_mut_slice = aggregated_vector
@@ -1684,11 +1686,13 @@ impl CudaServerKey {
         let last_chunk_size = one_hot_vector.len() - (num_chunks - 1) * chunk_size;
         for ct_idx in 0..last_chunk_size {
             let one_hot_idx = (num_chunks - 1) * chunk_size + ct_idx;
-            self.unchecked_add_assign(
-                &mut aggregated_vector,
-                &one_hot_vector[one_hot_idx],
-                streams,
-            );
+            unsafe {
+                self.unchecked_add_assign_async(
+                    &mut aggregated_vector,
+                    &one_hot_vector[one_hot_idx],
+                    streams,
+                )
+            };
         }
 
         let message_extract_lut =


### PR DESCRIPTION
We need to have async entry points for asynchronous execution between the CPU & GPU at the HL API level later. We can't remove it.

<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
