### PR TITLE
chore(ci): use complete bot names on permission checks

### DIFF
--- a/.github/workflows/check_actor_permissions.yml
+++ b/.github/workflows/check_actor_permissions.yml
@@ -30,7 +30,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.TOKEN }}
 
       - name: Check User Permission
-        if: (inputs.username != 'dependabot' || inputs.username != 'cla-bot') &&
+        if: (inputs.username != 'dependabot[bot]' || inputs.username != 'cla-bot[bot]') &&
           steps.check-access.outputs.require-result == 'false'
         run: |
           echo "${{ inputs.username }} does not have permissions on this repo."


### PR DESCRIPTION
White-listed bots have '[bot]' as username suffix.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/2005)
<!-- Reviewable:end -->
