### PR TITLE
refactor!: Add invariant to GpuIndex

### DIFF
--- a/tfhe/benches/core_crypto/ks_bench.rs
+++ b/tfhe/benches/core_crypto/ks_bench.rs
@@ -330,7 +330,7 @@ mod cuda {
             SecretRandomGenerator::<DefaultRandomGenerator>::new(seeder.seed());
 
         let gpu_index = 0;
-        let streams = CudaStreams::new_single_gpu(GpuIndex(gpu_index));
+        let streams = CudaStreams::new_single_gpu(GpuIndex::new(gpu_index));
 
         for (name, params) in parameters.iter() {
             let lwe_dimension = params.lwe_dimension.unwrap();
@@ -433,7 +433,7 @@ mod cuda {
             SecretRandomGenerator::<DefaultRandomGenerator>::new(seeder.seed());
 
         let gpu_index = 0;
-        let streams = CudaStreams::new_single_gpu(GpuIndex(gpu_index));
+        let streams = CudaStreams::new_single_gpu(GpuIndex::new(gpu_index));
 
         for (name, params) in parameters.iter() {
             let lwe_dimension = params.lwe_dimension.unwrap();

--- a/tfhe/benches/core_crypto/pbs_bench.rs
+++ b/tfhe/benches/core_crypto/pbs_bench.rs
@@ -901,7 +901,7 @@ mod cuda {
             SecretRandomGenerator::<DefaultRandomGenerator>::new(seeder.seed());
 
         let gpu_index = 0;
-        let stream = CudaStreams::new_single_gpu(GpuIndex(gpu_index));
+        let stream = CudaStreams::new_single_gpu(GpuIndex::new(gpu_index));
 
         for (name, params) in parameters.iter() {
             // Create the LweSecretKey
@@ -1022,7 +1022,7 @@ mod cuda {
             SecretRandomGenerator::<DefaultRandomGenerator>::new(seeder.seed());
 
         let gpu_index = 0;
-        let stream = CudaStreams::new_single_gpu(GpuIndex(gpu_index));
+        let stream = CudaStreams::new_single_gpu(GpuIndex::new(gpu_index));
 
         for (name, params, grouping_factor) in parameters.iter() {
             // Create the LweSecretKey
@@ -1144,7 +1144,7 @@ mod cuda {
             SecretRandomGenerator::<DefaultRandomGenerator>::new(seeder.seed());
 
         let gpu_index = 0;
-        let stream = CudaStreams::new_single_gpu(GpuIndex(gpu_index));
+        let stream = CudaStreams::new_single_gpu(GpuIndex::new(gpu_index));
 
         for (name, params) in parameters.iter() {
             let input_lwe_secret_key = allocate_and_generate_new_binary_lwe_secret_key(
@@ -1284,7 +1284,7 @@ mod cuda {
             SecretRandomGenerator::<DefaultRandomGenerator>::new(seeder.seed());
 
         let gpu_index = 0;
-        let stream = CudaStreams::new_single_gpu(GpuIndex(gpu_index));
+        let stream = CudaStreams::new_single_gpu(GpuIndex::new(gpu_index));
 
         for (name, params, grouping_factor) in parameters.iter() {
             let input_lwe_secret_key = allocate_and_generate_new_binary_lwe_secret_key(

--- a/tfhe/src/core_crypto/gpu/algorithms/glwe_sample_extraction.rs
+++ b/tfhe/src/core_crypto/gpu/algorithms/glwe_sample_extraction.rs
@@ -46,7 +46,7 @@ pub unsafe fn cuda_extract_lwe_samples_from_glwe_ciphertext_list_async<Scalar>(
     let nth_array: Vec<u32> = vec_nth.iter().map(|x| x.0 as u32).collect_vec();
     let gpu_indexes = &streams.gpu_indexes;
     unsafe {
-        let d_nth_array = CudaVec::from_cpu_async(&nth_array, streams, gpu_indexes[0].0);
+        let d_nth_array = CudaVec::from_cpu_async(&nth_array, streams, gpu_indexes[0].get());
         extract_lwe_samples_from_glwe_ciphertext_list_async(
             streams,
             &mut output_lwe_list.0.d_vec,

--- a/tfhe/src/core_crypto/gpu/algorithms/test/glwe_sample_extraction.rs
+++ b/tfhe/src/core_crypto/gpu/algorithms/test/glwe_sample_extraction.rs
@@ -27,7 +27,7 @@ fn glwe_encrypt_sample_extract_decrypt_custom_mod<Scalar: UnsignedTorus + Send +
     let delta: Scalar = encoding_with_padding / msg_modulus;
 
     let gpu_index = 0;
-    let streams = CudaStreams::new_single_gpu(GpuIndex(gpu_index));
+    let streams = CudaStreams::new_single_gpu(GpuIndex::new(gpu_index));
 
     let mut msgs = vec![];
 

--- a/tfhe/src/core_crypto/gpu/algorithms/test/lwe_keyswitch.rs
+++ b/tfhe/src/core_crypto/gpu/algorithms/test/lwe_keyswitch.rs
@@ -18,7 +18,7 @@ fn lwe_encrypt_ks_decrypt_custom_mod<Scalar: UnsignedTorus + CastFrom<usize>>(
     let ks_decomp_base_log = params.ks_base_log;
     let ks_decomp_level_count = params.ks_level;
 
-    let stream = CudaStreams::new_single_gpu(GpuIndex(0));
+    let stream = CudaStreams::new_single_gpu(GpuIndex::new(0));
 
     let mut rsc = TestResources::new();
 

--- a/tfhe/src/core_crypto/gpu/algorithms/test/lwe_multi_bit_programmable_bootstrapping.rs
+++ b/tfhe/src/core_crypto/gpu/algorithms/test/lwe_multi_bit_programmable_bootstrapping.rs
@@ -28,7 +28,7 @@ fn lwe_encrypt_multi_bit_pbs_decrypt_custom_mod<
     let grouping_factor = params.grouping_factor;
 
     let gpu_index = 0;
-    let stream = CudaStreams::new_single_gpu(GpuIndex(gpu_index));
+    let stream = CudaStreams::new_single_gpu(GpuIndex::new(gpu_index));
 
     let mut rsc = TestResources::new();
 

--- a/tfhe/src/core_crypto/gpu/algorithms/test/lwe_packing_keyswitch.rs
+++ b/tfhe/src/core_crypto/gpu/algorithms/test/lwe_packing_keyswitch.rs
@@ -68,7 +68,7 @@ where
     let delta: Scalar = encoding_with_padding / msg_modulus;
 
     let gpu_index = 0;
-    let stream = CudaStreams::new_single_gpu(GpuIndex(gpu_index));
+    let stream = CudaStreams::new_single_gpu(GpuIndex::new(gpu_index));
 
     while msg != Scalar::ZERO {
         msg = msg.wrapping_sub(Scalar::ONE);
@@ -152,7 +152,7 @@ where
     let delta: Scalar = encoding_with_padding / msg_modulus;
 
     let gpu_index = 0;
-    let stream = CudaStreams::new_single_gpu(GpuIndex(gpu_index));
+    let stream = CudaStreams::new_single_gpu(GpuIndex::new(gpu_index));
 
     while msg != Scalar::ZERO {
         msg = msg.wrapping_sub(Scalar::ONE);

--- a/tfhe/src/core_crypto/gpu/algorithms/test/lwe_programmable_bootstrapping.rs
+++ b/tfhe/src/core_crypto/gpu/algorithms/test/lwe_programmable_bootstrapping.rs
@@ -26,7 +26,7 @@ fn lwe_encrypt_pbs_decrypt<
     let decomp_level_count = params.pbs_level;
 
     let gpu_index = 0;
-    let stream = CudaStreams::new_single_gpu(GpuIndex(gpu_index));
+    let stream = CudaStreams::new_single_gpu(GpuIndex::new(gpu_index));
 
     let mut rsc = TestResources::new();
 

--- a/tfhe/src/core_crypto/gpu/algorithms/test/noise_distribution/lwe_multi_bit_programmable_bootstrapping_noise.rs
+++ b/tfhe/src/core_crypto/gpu/algorithms/test/noise_distribution/lwe_multi_bit_programmable_bootstrapping_noise.rs
@@ -40,7 +40,7 @@ where
     let grouping_factor = params.grouping_factor;
     let number_of_messages = 1;
 
-    let gpu_index = GpuIndex(0);
+    let gpu_index = GpuIndex::new(0);
     let stream = CudaStreams::new_single_gpu(gpu_index);
 
     let modulus_as_f64 = if ciphertext_modulus.is_native_modulus() {

--- a/tfhe/src/core_crypto/gpu/algorithms/test/noise_distribution/lwe_programmable_bootstrapping_noise.rs
+++ b/tfhe/src/core_crypto/gpu/algorithms/test/noise_distribution/lwe_programmable_bootstrapping_noise.rs
@@ -33,7 +33,7 @@ where
     let pbs_decomposition_level_count = params.pbs_level;
     let number_of_messages = 1;
 
-    let gpu_index = GpuIndex(0);
+    let gpu_index = GpuIndex::new(0);
     let stream = CudaStreams::new_single_gpu(gpu_index);
 
     let modulus_as_f64 = if ciphertext_modulus.is_native_modulus() {

--- a/tfhe/src/core_crypto/gpu/entities/lwe_ciphertext_list.rs
+++ b/tfhe/src/core_crypto/gpu/entities/lwe_ciphertext_list.rs
@@ -128,7 +128,7 @@ impl<T: UnsignedInteger> CudaLweCiphertextList<T> {
                 first_item.0.d_vec.as_c_ptr(0),
                 size as u64,
                 streams.ptr[0],
-                streams.gpu_indexes[0].0,
+                streams.gpu_indexes[0].get(),
             );
             ptr = ptr.wrapping_byte_add(size);
             for list in cuda_ciphertexts_list_vec {
@@ -137,7 +137,7 @@ impl<T: UnsignedInteger> CudaLweCiphertextList<T> {
                     list.0.d_vec.as_c_ptr(0),
                     size as u64,
                     streams.ptr[0],
-                    streams.gpu_indexes[0].0,
+                    streams.gpu_indexes[0].get(),
                 );
                 ptr = ptr.wrapping_byte_add(size);
             }

--- a/tfhe/src/core_crypto/gpu/mod.rs
+++ b/tfhe/src/core_crypto/gpu/mod.rs
@@ -32,8 +32,8 @@ impl CudaStreams {
         let mut ptr_array = Vec::with_capacity(gpu_count as usize);
 
         for i in 0..gpu_count {
-            ptr_array.push(unsafe { cuda_create_stream(i as u32) });
-            gpu_indexes.push(GpuIndex(i as u32));
+            ptr_array.push(unsafe { cuda_create_stream(i) });
+            gpu_indexes.push(GpuIndex::new(i));
         }
         Self {
             ptr: ptr_array,
@@ -44,7 +44,7 @@ impl CudaStreams {
     /// as input
     pub fn new_single_gpu(gpu_index: GpuIndex) -> Self {
         Self {
-            ptr: vec![unsafe { cuda_create_stream(gpu_index.0) }],
+            ptr: vec![unsafe { cuda_create_stream(gpu_index.get()) }],
             gpu_indexes: vec![gpu_index],
         }
     }
@@ -52,7 +52,7 @@ impl CudaStreams {
     pub fn synchronize(&self) {
         for i in 0..self.len() {
             unsafe {
-                cuda_synchronize_stream(self.ptr[i], self.gpu_indexes[i].0);
+                cuda_synchronize_stream(self.ptr[i], self.gpu_indexes[i].get());
             }
         }
     }
@@ -61,7 +61,7 @@ impl CudaStreams {
         unsafe {
             cuda_synchronize_stream(
                 self.ptr[gpu_index as usize],
-                self.gpu_indexes[gpu_index as usize].0,
+                self.gpu_indexes[gpu_index as usize].get(),
             );
         }
     }
@@ -77,13 +77,19 @@ impl CudaStreams {
     pub fn gpu_indexes(&self) -> &[GpuIndex] {
         &self.gpu_indexes
     }
+
+    /// Returns a pointer the array of GpuIndex as u32
+    pub(crate) fn gpu_indexes_ptr(&self) -> *const u32 {
+        // The cast here is safe as GpuIndex is repr(transparent)
+        self.gpu_indexes.as_ptr().cast()
+    }
 }
 
 impl Drop for CudaStreams {
     fn drop(&mut self) {
         for (i, &s) in self.ptr.iter().enumerate() {
             unsafe {
-                cuda_destroy_stream(s, self.gpu_indexes[i].0);
+                cuda_destroy_stream(s, self.gpu_indexes[i].get());
             }
         }
     }
@@ -117,7 +123,7 @@ pub unsafe fn programmable_bootstrap_async<T: UnsignedInteger>(
     let mut pbs_buffer: *mut i8 = std::ptr::null_mut();
     scratch_cuda_programmable_bootstrap_64(
         streams.ptr[0],
-        streams.gpu_indexes[0].0,
+        streams.gpu_indexes[0].get(),
         std::ptr::addr_of_mut!(pbs_buffer),
         glwe_dimension.0 as u32,
         polynomial_size.0 as u32,
@@ -127,7 +133,7 @@ pub unsafe fn programmable_bootstrap_async<T: UnsignedInteger>(
     );
     cuda_programmable_bootstrap_lwe_ciphertext_vector_64(
         streams.ptr[0],
-        streams.gpu_indexes[0].0,
+        streams.gpu_indexes[0].get(),
         lwe_array_out.as_mut_c_ptr(0),
         lwe_out_indexes.as_c_ptr(0),
         test_vector.as_c_ptr(0),
@@ -147,7 +153,7 @@ pub unsafe fn programmable_bootstrap_async<T: UnsignedInteger>(
     );
     cleanup_cuda_programmable_bootstrap(
         streams.ptr[0],
-        streams.gpu_indexes[0].0,
+        streams.gpu_indexes[0].get(),
         std::ptr::addr_of_mut!(pbs_buffer),
     );
 }
@@ -181,7 +187,7 @@ pub unsafe fn programmable_bootstrap_multi_bit_async<T: UnsignedInteger>(
     let mut pbs_buffer: *mut i8 = std::ptr::null_mut();
     scratch_cuda_multi_bit_programmable_bootstrap_64(
         streams.ptr[0],
-        streams.gpu_indexes[0].0,
+        streams.gpu_indexes[0].get(),
         std::ptr::addr_of_mut!(pbs_buffer),
         glwe_dimension.0 as u32,
         polynomial_size.0 as u32,
@@ -191,7 +197,7 @@ pub unsafe fn programmable_bootstrap_multi_bit_async<T: UnsignedInteger>(
     );
     cuda_multi_bit_programmable_bootstrap_lwe_ciphertext_vector_64(
         streams.ptr[0],
-        streams.gpu_indexes[0].0,
+        streams.gpu_indexes[0].get(),
         lwe_array_out.as_mut_c_ptr(0),
         output_indexes.as_c_ptr(0),
         test_vector.as_c_ptr(0),
@@ -212,7 +218,7 @@ pub unsafe fn programmable_bootstrap_multi_bit_async<T: UnsignedInteger>(
     );
     cleanup_cuda_multi_bit_programmable_bootstrap(
         streams.ptr[0],
-        streams.gpu_indexes[0].0,
+        streams.gpu_indexes[0].get(),
         std::ptr::addr_of_mut!(pbs_buffer),
     );
 }
@@ -239,7 +245,7 @@ pub unsafe fn keyswitch_async<T: UnsignedInteger>(
 ) {
     cuda_keyswitch_lwe_ciphertext_vector_64(
         streams.ptr[0],
-        streams.gpu_indexes[0].0,
+        streams.gpu_indexes[0].get(),
         lwe_array_out.as_mut_c_ptr(0),
         lwe_out_indexes.as_c_ptr(0),
         lwe_array_in.as_c_ptr(0),
@@ -290,7 +296,7 @@ pub unsafe fn packing_keyswitch_list_async<T: UnsignedInteger>(
     let mut fp_ks_buffer: *mut i8 = std::ptr::null_mut();
     scratch_packing_keyswitch_lwe_list_to_glwe_64(
         streams.ptr[0],
-        streams.gpu_indexes[0].0,
+        streams.gpu_indexes[0].get(),
         std::ptr::addr_of_mut!(fp_ks_buffer),
         input_lwe_dimension.0 as u32,
         output_glwe_dimension.0 as u32,
@@ -300,7 +306,7 @@ pub unsafe fn packing_keyswitch_list_async<T: UnsignedInteger>(
     );
     cuda_packing_keyswitch_lwe_list_to_glwe_64(
         streams.ptr[0],
-        streams.gpu_indexes[0].0,
+        streams.gpu_indexes[0].get(),
         glwe_array_out.as_mut_c_ptr(0),
         lwe_array_in.as_c_ptr(0),
         packing_keyswitch_key.as_c_ptr(0),
@@ -314,7 +320,7 @@ pub unsafe fn packing_keyswitch_list_async<T: UnsignedInteger>(
     );
     cleanup_packing_keyswitch_lwe_list_to_glwe(
         streams.ptr[0],
-        streams.gpu_indexes[0].0,
+        streams.gpu_indexes[0].get(),
         std::ptr::addr_of_mut!(fp_ks_buffer),
     );
 }
@@ -340,7 +346,7 @@ pub unsafe fn convert_lwe_programmable_bootstrap_key_async<T: UnsignedInteger>(
         assert_eq!(dest.len() * std::mem::size_of::<T>(), size);
         cuda_convert_lwe_programmable_bootstrap_key_64(
             stream_ptr,
-            streams.gpu_indexes[i].0,
+            streams.gpu_indexes[i].get(),
             dest.as_mut_c_ptr(i as u32),
             src.as_ptr().cast(),
             input_lwe_dim.0 as u32,
@@ -373,7 +379,7 @@ pub unsafe fn convert_lwe_multi_bit_programmable_bootstrap_key_async<T: Unsigned
         assert_eq!(dest.len() * std::mem::size_of::<T>(), size);
         cuda_convert_lwe_multi_bit_programmable_bootstrap_key_64(
             stream_ptr,
-            streams.gpu_indexes[i].0,
+            streams.gpu_indexes[i].get(),
             dest.as_mut_c_ptr(i as u32),
             src.as_ptr().cast(),
             input_lwe_dim.0 as u32,
@@ -401,7 +407,7 @@ pub unsafe fn extract_lwe_samples_from_glwe_ciphertext_list_async<T: UnsignedInt
 ) {
     cuda_glwe_sample_extract_64(
         streams.ptr[0],
-        streams.gpu_indexes[0].0,
+        streams.gpu_indexes[0].get(),
         lwe_array_out.as_mut_c_ptr(0),
         glwe_array_in.as_c_ptr(0),
         nth_array.as_c_ptr(0).cast::<u32>(),
@@ -454,7 +460,7 @@ pub unsafe fn add_lwe_ciphertext_vector_async<T: UnsignedInteger>(
     };
     cuda_add_lwe_ciphertext_vector_64(
         streams.ptr[0],
-        streams.gpu_indexes[0].0,
+        streams.gpu_indexes[0].get(),
         &mut lwe_array_out_data,
         &lwe_array_in_1_data,
         &lwe_array_in_2_data,
@@ -494,7 +500,7 @@ pub unsafe fn add_lwe_ciphertext_vector_assign_async<T: UnsignedInteger>(
     };
     cuda_add_lwe_ciphertext_vector_64(
         streams.ptr[0],
-        streams.gpu_indexes[0].0,
+        streams.gpu_indexes[0].get(),
         &mut lwe_array_out_data,
         &lwe_array_out_data,
         &lwe_array_in_data,
@@ -517,7 +523,7 @@ pub unsafe fn add_lwe_ciphertext_vector_plaintext_vector_async<T: UnsignedIntege
 ) {
     cuda_add_lwe_ciphertext_vector_plaintext_vector_64(
         streams.ptr[0],
-        streams.gpu_indexes[0].0,
+        streams.gpu_indexes[0].get(),
         lwe_array_out.as_mut_c_ptr(0),
         lwe_array_in.as_c_ptr(0),
         plaintext_in.as_c_ptr(0),
@@ -542,7 +548,7 @@ pub unsafe fn add_lwe_ciphertext_vector_plaintext_scalar_async<T: UnsignedIntege
 ) {
     cuda_add_lwe_ciphertext_vector_plaintext_64(
         streams.ptr[0],
-        streams.gpu_indexes[0].0,
+        streams.gpu_indexes[0].get(),
         lwe_array_out.as_mut_c_ptr(0),
         lwe_array_in.as_c_ptr(0),
         plaintext_in,
@@ -566,7 +572,7 @@ pub unsafe fn add_lwe_ciphertext_vector_plaintext_vector_assign_async<T: Unsigne
 ) {
     cuda_add_lwe_ciphertext_vector_plaintext_vector_64(
         streams.ptr[0],
-        streams.gpu_indexes[0].0,
+        streams.gpu_indexes[0].get(),
         lwe_array_out.as_mut_c_ptr(0),
         lwe_array_out.as_c_ptr(0),
         plaintext_in.as_c_ptr(0),
@@ -590,7 +596,7 @@ pub unsafe fn negate_lwe_ciphertext_vector_async<T: UnsignedInteger>(
 ) {
     cuda_negate_lwe_ciphertext_vector_64(
         streams.ptr[0],
-        streams.gpu_indexes[0].0,
+        streams.gpu_indexes[0].get(),
         lwe_array_out.as_mut_c_ptr(0),
         lwe_array_in.as_c_ptr(0),
         lwe_dimension.0 as u32,
@@ -612,7 +618,7 @@ pub unsafe fn negate_lwe_ciphertext_vector_assign_async<T: UnsignedInteger>(
 ) {
     cuda_negate_lwe_ciphertext_vector_64(
         streams.ptr[0],
-        streams.gpu_indexes[0].0,
+        streams.gpu_indexes[0].get(),
         lwe_array_out.as_mut_c_ptr(0),
         lwe_array_out.as_c_ptr(0),
         lwe_dimension.0 as u32,
@@ -635,7 +641,7 @@ pub unsafe fn mult_lwe_ciphertext_vector_cleartext_vector_assign_async<T: Unsign
 ) {
     cuda_mult_lwe_ciphertext_vector_cleartext_vector_64(
         streams.ptr[0],
-        streams.gpu_indexes[0].0,
+        streams.gpu_indexes[0].get(),
         lwe_array.as_mut_c_ptr(0),
         lwe_array.as_c_ptr(0),
         cleartext_array_in.as_c_ptr(0),
@@ -660,7 +666,7 @@ pub unsafe fn mult_lwe_ciphertext_vector_cleartext_vector<T: UnsignedInteger>(
 ) {
     cuda_mult_lwe_ciphertext_vector_cleartext_vector_64(
         streams.ptr[0],
-        streams.gpu_indexes[0].0,
+        streams.gpu_indexes[0].get(),
         lwe_array_out.as_mut_c_ptr(0),
         lwe_array_in.as_c_ptr(0),
         cleartext_array_in.as_c_ptr(0),
@@ -714,13 +720,13 @@ impl<T: UnsignedInteger> CudaGlweList<T> {
     }
 }
 /// Get the number of GPUs on the machine
-pub fn get_number_of_gpus() -> i32 {
-    unsafe { cuda_get_number_of_gpus() }
+pub fn get_number_of_gpus() -> u32 {
+    unsafe { cuda_get_number_of_gpus() as u32 }
 }
 
 /// Setup multi-GPU and return the number of GPUs used
-pub fn setup_multi_gpu() -> i32 {
-    unsafe { cuda_setup_multi_gpu() }
+pub fn setup_multi_gpu() -> u32 {
+    unsafe { cuda_setup_multi_gpu() as u32 }
 }
 
 /// Synchronize device
@@ -752,7 +758,7 @@ mod tests {
     #[test]
     fn allocate_and_copy() {
         let vec = vec![1_u64, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
-        let stream = CudaStreams::new_single_gpu(GpuIndex(0));
+        let stream = CudaStreams::new_single_gpu(GpuIndex::new(0));
         unsafe {
             let mut d_vec: CudaVec<u64> = CudaVec::<u64>::new_async(vec.len(), &stream, 0);
             d_vec.copy_from_cpu_async(&vec, &stream, 0);

--- a/tfhe/src/core_crypto/gpu/slice.rs
+++ b/tfhe/src/core_crypto/gpu/slice.rs
@@ -106,7 +106,7 @@ where
                 src.as_c_ptr(index),
                 size as u64,
                 streams.ptr[index],
-                streams.gpu_indexes[index].0,
+                streams.gpu_indexes[index].get(),
             );
         }
     }
@@ -131,7 +131,7 @@ where
                 self.as_c_ptr(index),
                 size as u64,
                 streams.ptr[index],
-                streams.gpu_indexes[index].0,
+                streams.gpu_indexes[index].get(),
             );
         }
     }

--- a/tfhe/src/high_level_api/global_state.rs
+++ b/tfhe/src/high_level_api/global_state.rs
@@ -231,9 +231,10 @@ mod gpu {
         fn new() -> Self {
             Self {
                 multi: LazyCell::new(CudaStreams::new_multi_gpu),
-                single: (0..get_number_of_gpus() as u32)
+                single: (0..get_number_of_gpus())
                     .map(|index| {
-                        let ctor = Box::new(move || CudaStreams::new_single_gpu(GpuIndex(index)));
+                        let ctor =
+                            Box::new(move || CudaStreams::new_single_gpu(GpuIndex::new(index)));
                         LazyCell::new(ctor as Box<dyn Fn() -> CudaStreams>)
                     })
                     .collect(),
@@ -247,7 +248,7 @@ mod gpu {
         fn index(&self, indexes: &'a [GpuIndex]) -> &Self::Output {
             match indexes.len() {
                 0 => panic!("Internal error: Gpu indexes must not be empty"),
-                1 => &self.single[indexes[0].0 as usize],
+                1 => &self.single[indexes[0].get() as usize],
                 _ => &self.multi,
             }
         }
@@ -259,7 +260,7 @@ mod gpu {
         fn index(&self, choice: CudaGpuChoice) -> &Self::Output {
             match choice {
                 CudaGpuChoice::Multi => &self.multi,
-                CudaGpuChoice::Single(index) => &self.single[index.0 as usize],
+                CudaGpuChoice::Single(index) => &self.single[index.get() as usize],
             }
         }
     }

--- a/tfhe/src/high_level_api/tests/gpu_selection.rs
+++ b/tfhe/src/high_level_api/tests/gpu_selection.rs
@@ -14,7 +14,7 @@ fn test_gpu_selection() {
 
     let mut rng = rand::thread_rng();
 
-    let last_gpu = GpuIndex(get_number_of_gpus() as u32 - 1);
+    let last_gpu = GpuIndex::new(get_number_of_gpus() - 1);
 
     let clear_a: u32 = rng.gen();
     let clear_b: u32 = rng.gen();
@@ -73,8 +73,8 @@ fn test_gpu_selection_2() {
 
     let mut rng = rand::thread_rng();
 
-    let first_gpu = GpuIndex(0);
-    let last_gpu = GpuIndex(get_number_of_gpus() as u32 - 1);
+    let first_gpu = GpuIndex::new(0);
+    let last_gpu = GpuIndex::new(get_number_of_gpus() - 1);
 
     let clear_a: u32 = rng.gen();
     let clear_b: u32 = rng.gen();

--- a/tfhe/src/integer/gpu/list_compression/server_keys.rs
+++ b/tfhe/src/integer/gpu/list_compression/server_keys.rs
@@ -121,7 +121,7 @@ impl CudaCompressionKey {
                 ciphertext.d_blocks.0.d_vec.as_c_ptr(0),
                 size as u64,
                 streams.ptr[0],
-                streams.gpu_indexes[0].0,
+                streams.gpu_indexes[0].get(),
             );
 
             offset += ciphertext.d_blocks.0.d_vec.len;

--- a/tfhe/src/integer/gpu/mod.rs
+++ b/tfhe/src/integer/gpu/mod.rs
@@ -247,12 +247,7 @@ pub unsafe fn scalar_addition_integer_radix_assign_async<T: UnsignedInteger>(
     );
     cuda_scalar_addition_integer_radix_ciphertext_64_inplace(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         lwe_array.as_mut_c_ptr(0),
         scalar_input.as_c_ptr(0),
@@ -307,12 +302,7 @@ pub unsafe fn unchecked_scalar_mul_integer_radix_kb_async<T: UnsignedInteger, B:
     let mut mem_ptr: *mut i8 = std::ptr::null_mut();
     scratch_cuda_integer_scalar_mul_kb_64(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
         glwe_dimension.0 as u32,
@@ -332,12 +322,7 @@ pub unsafe fn unchecked_scalar_mul_integer_radix_kb_async<T: UnsignedInteger, B:
 
     cuda_scalar_multiplication_integer_radix_ciphertext_64_inplace(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         lwe_array.as_mut_c_ptr(0),
         decomposed_scalar.as_ptr().cast::<u64>(),
@@ -354,12 +339,7 @@ pub unsafe fn unchecked_scalar_mul_integer_radix_kb_async<T: UnsignedInteger, B:
 
     cleanup_cuda_integer_radix_scalar_mul(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
     );
@@ -404,12 +384,7 @@ pub unsafe fn compress_integer_radix_async<T: UnsignedInteger>(
     let mut mem_ptr: *mut i8 = std::ptr::null_mut();
     scratch_cuda_integer_compress_radix_ciphertext_64(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
         compression_glwe_dimension.0 as u32,
@@ -428,12 +403,7 @@ pub unsafe fn compress_integer_radix_async<T: UnsignedInteger>(
 
     cuda_integer_compress_radix_ciphertext_64(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         glwe_array_out.as_mut_c_ptr(0),
         lwe_array_in.as_c_ptr(0),
@@ -444,12 +414,7 @@ pub unsafe fn compress_integer_radix_async<T: UnsignedInteger>(
 
     cleanup_cuda_integer_compress_radix_ciphertext_64(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
     );
@@ -497,12 +462,7 @@ pub unsafe fn decompress_integer_radix_async<T: UnsignedInteger, B: Numeric>(
     let mut mem_ptr: *mut i8 = std::ptr::null_mut();
     scratch_cuda_integer_decompress_radix_ciphertext_64(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
         encryption_glwe_dimension.0 as u32,
@@ -523,12 +483,7 @@ pub unsafe fn decompress_integer_radix_async<T: UnsignedInteger, B: Numeric>(
 
     cuda_integer_decompress_radix_ciphertext_64(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         lwe_array_out.as_mut_c_ptr(0),
         glwe_in.as_c_ptr(0),
@@ -540,12 +495,7 @@ pub unsafe fn decompress_integer_radix_async<T: UnsignedInteger, B: Numeric>(
 
     cleanup_cuda_integer_decompress_radix_ciphertext_64(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
     );
@@ -613,7 +563,7 @@ pub unsafe fn unchecked_add_integer_radix_assign_async(
     );
     cuda_add_lwe_ciphertext_vector_64(
         streams.ptr[0],
-        streams.gpu_indexes[0].0,
+        streams.gpu_indexes[0].get(),
         &mut cuda_ffi_radix_lwe_left,
         &cuda_ffi_radix_lwe_left,
         &cuda_ffi_radix_lwe_right,
@@ -670,12 +620,7 @@ pub unsafe fn unchecked_mul_integer_radix_kb_assign_async<T: UnsignedInteger, B:
     let mut mem_ptr: *mut i8 = std::ptr::null_mut();
     scratch_cuda_integer_mult_radix_ciphertext_kb_64(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
         is_boolean_left,
@@ -696,12 +641,7 @@ pub unsafe fn unchecked_mul_integer_radix_kb_assign_async<T: UnsignedInteger, B:
     );
     cuda_integer_mult_radix_ciphertext_kb_64(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         radix_lwe_left.as_mut_c_ptr(0),
         radix_lwe_left.as_c_ptr(0),
@@ -716,12 +656,7 @@ pub unsafe fn unchecked_mul_integer_radix_kb_assign_async<T: UnsignedInteger, B:
     );
     cleanup_cuda_integer_mult(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
     );
@@ -776,12 +711,7 @@ pub unsafe fn unchecked_bitop_integer_radix_kb_assign_async<T: UnsignedInteger, 
     let mut mem_ptr: *mut i8 = std::ptr::null_mut();
     scratch_cuda_integer_radix_bitop_kb_64(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
         glwe_dimension.0 as u32,
@@ -802,12 +732,7 @@ pub unsafe fn unchecked_bitop_integer_radix_kb_assign_async<T: UnsignedInteger, 
     );
     cuda_bitop_integer_radix_ciphertext_kb_64(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         radix_lwe_left.as_mut_c_ptr(0),
         radix_lwe_left.as_c_ptr(0),
@@ -819,12 +744,7 @@ pub unsafe fn unchecked_bitop_integer_radix_kb_assign_async<T: UnsignedInteger, 
     );
     cleanup_cuda_integer_bitop(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
     );
@@ -882,12 +802,7 @@ pub unsafe fn unchecked_scalar_bitop_integer_radix_kb_assign_async<
     let mut mem_ptr: *mut i8 = std::ptr::null_mut();
     scratch_cuda_integer_radix_bitop_kb_64(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
         glwe_dimension.0 as u32,
@@ -908,12 +823,7 @@ pub unsafe fn unchecked_scalar_bitop_integer_radix_kb_assign_async<
     );
     cuda_scalar_bitop_integer_radix_ciphertext_kb_64(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         radix_lwe.as_mut_c_ptr(0),
         radix_lwe.as_mut_c_ptr(0),
@@ -927,12 +837,7 @@ pub unsafe fn unchecked_scalar_bitop_integer_radix_kb_assign_async<
     );
     cleanup_cuda_integer_bitop(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
     );
@@ -994,12 +899,7 @@ pub unsafe fn unchecked_comparison_integer_radix_kb_async<T: UnsignedInteger, B:
     let mut mem_ptr: *mut i8 = std::ptr::null_mut();
     scratch_cuda_integer_radix_comparison_kb_64(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
         glwe_dimension.0 as u32,
@@ -1022,12 +922,7 @@ pub unsafe fn unchecked_comparison_integer_radix_kb_async<T: UnsignedInteger, B:
 
     cuda_comparison_integer_radix_ciphertext_kb_64(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         radix_lwe_out.as_mut_c_ptr(0),
         radix_lwe_left.as_c_ptr(0),
@@ -1040,12 +935,7 @@ pub unsafe fn unchecked_comparison_integer_radix_kb_async<T: UnsignedInteger, B:
 
     cleanup_cuda_integer_comparison(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
     );
@@ -1108,12 +998,7 @@ pub unsafe fn unchecked_scalar_comparison_integer_radix_kb_async<T: UnsignedInte
     let mut mem_ptr: *mut i8 = std::ptr::null_mut();
     scratch_cuda_integer_radix_comparison_kb_64(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
         glwe_dimension.0 as u32,
@@ -1136,12 +1021,7 @@ pub unsafe fn unchecked_scalar_comparison_integer_radix_kb_async<T: UnsignedInte
 
     cuda_scalar_comparison_integer_radix_ciphertext_kb_64(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         radix_lwe_out.as_mut_c_ptr(0),
         radix_lwe_in.as_c_ptr(0),
@@ -1155,12 +1035,7 @@ pub unsafe fn unchecked_scalar_comparison_integer_radix_kb_async<T: UnsignedInte
 
     cleanup_cuda_integer_comparison(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
     );
@@ -1207,12 +1082,7 @@ pub unsafe fn full_propagate_assign_async<T: UnsignedInteger, B: Numeric>(
     let mut mem_ptr: *mut i8 = std::ptr::null_mut();
     scratch_cuda_full_propagation_64(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
         lwe_dimension.0 as u32,
@@ -1230,12 +1100,7 @@ pub unsafe fn full_propagate_assign_async<T: UnsignedInteger, B: Numeric>(
     );
     cuda_full_propagation_64_inplace(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         radix_lwe_input.as_mut_c_ptr(0),
         mem_ptr,
@@ -1245,12 +1110,7 @@ pub unsafe fn full_propagate_assign_async<T: UnsignedInteger, B: Numeric>(
     );
     cleanup_cuda_full_propagation(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
     );
@@ -1302,12 +1162,7 @@ pub(crate) unsafe fn propagate_single_carry_assign_async<T: UnsignedInteger, B: 
     let big_lwe_dimension: u32 = glwe_dimension.0 as u32 * polynomial_size.0 as u32;
     scratch_cuda_propagate_single_carry_kb_64_inplace(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
         glwe_dimension.0 as u32,
@@ -1329,12 +1184,7 @@ pub(crate) unsafe fn propagate_single_carry_assign_async<T: UnsignedInteger, B: 
     );
     cuda_propagate_single_carry_kb_64_inplace(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         radix_lwe_input.as_mut_c_ptr(0),
         carry_out.as_mut_c_ptr(0),
@@ -1348,12 +1198,7 @@ pub(crate) unsafe fn propagate_single_carry_assign_async<T: UnsignedInteger, B: 
     );
     cleanup_cuda_propagate_single_carry(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
     );
@@ -1411,12 +1256,7 @@ pub(crate) unsafe fn add_and_propagate_single_carry_assign_async<T: UnsignedInte
     let big_lwe_dimension: u32 = glwe_dimension.0 as u32 * polynomial_size.0 as u32;
     scratch_cuda_add_and_propagate_single_carry_kb_64_inplace(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
         glwe_dimension.0 as u32,
@@ -1438,12 +1278,7 @@ pub(crate) unsafe fn add_and_propagate_single_carry_assign_async<T: UnsignedInte
     );
     cuda_add_and_propagate_single_carry_kb_64_inplace(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         radix_lwe_lhs_input.as_mut_c_ptr(0),
         radix_lwe_rhs_input.as_c_ptr(0),
@@ -1458,12 +1293,7 @@ pub(crate) unsafe fn add_and_propagate_single_carry_assign_async<T: UnsignedInte
     );
     cleanup_cuda_add_and_propagate_single_carry(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
     );
@@ -1515,12 +1345,7 @@ pub unsafe fn unchecked_scalar_left_shift_integer_radix_kb_assign_async<
     let mut mem_ptr: *mut i8 = std::ptr::null_mut();
     scratch_cuda_integer_radix_logical_scalar_shift_kb_64(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
         glwe_dimension.0 as u32,
@@ -1541,12 +1366,7 @@ pub unsafe fn unchecked_scalar_left_shift_integer_radix_kb_assign_async<
     );
     cuda_integer_radix_logical_scalar_shift_kb_64_inplace(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         radix_lwe_left.as_mut_c_ptr(0),
         shift,
@@ -1557,12 +1377,7 @@ pub unsafe fn unchecked_scalar_left_shift_integer_radix_kb_assign_async<
     );
     cleanup_cuda_integer_radix_logical_scalar_shift(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
     );
@@ -1614,12 +1429,7 @@ pub unsafe fn unchecked_scalar_logical_right_shift_integer_radix_kb_assign_async
     let mut mem_ptr: *mut i8 = std::ptr::null_mut();
     scratch_cuda_integer_radix_logical_scalar_shift_kb_64(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
         glwe_dimension.0 as u32,
@@ -1640,12 +1450,7 @@ pub unsafe fn unchecked_scalar_logical_right_shift_integer_radix_kb_assign_async
     );
     cuda_integer_radix_logical_scalar_shift_kb_64_inplace(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         radix_lwe_left.as_mut_c_ptr(0),
         shift,
@@ -1656,12 +1461,7 @@ pub unsafe fn unchecked_scalar_logical_right_shift_integer_radix_kb_assign_async
     );
     cleanup_cuda_integer_radix_logical_scalar_shift(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
     );
@@ -1713,12 +1513,7 @@ pub unsafe fn unchecked_scalar_arithmetic_right_shift_integer_radix_kb_assign_as
     let mut mem_ptr: *mut i8 = std::ptr::null_mut();
     scratch_cuda_integer_radix_arithmetic_scalar_shift_kb_64(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
         glwe_dimension.0 as u32,
@@ -1739,12 +1534,7 @@ pub unsafe fn unchecked_scalar_arithmetic_right_shift_integer_radix_kb_assign_as
     );
     cuda_integer_radix_arithmetic_scalar_shift_kb_64_inplace(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         radix_lwe_left.as_mut_c_ptr(0),
         shift,
@@ -1755,12 +1545,7 @@ pub unsafe fn unchecked_scalar_arithmetic_right_shift_integer_radix_kb_assign_as
     );
     cleanup_cuda_integer_radix_arithmetic_scalar_shift(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
     );
@@ -1818,12 +1603,7 @@ pub unsafe fn unchecked_right_shift_integer_radix_kb_assign_async<
     let mut mem_ptr: *mut i8 = std::ptr::null_mut();
     scratch_cuda_integer_radix_shift_and_rotate_kb_64(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
         glwe_dimension.0 as u32,
@@ -1845,12 +1625,7 @@ pub unsafe fn unchecked_right_shift_integer_radix_kb_assign_async<
     );
     cuda_integer_radix_shift_and_rotate_kb_64_inplace(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         radix_lwe_left.as_mut_c_ptr(0),
         radix_shift.as_c_ptr(0),
@@ -1861,12 +1636,7 @@ pub unsafe fn unchecked_right_shift_integer_radix_kb_assign_async<
     );
     cleanup_cuda_integer_radix_shift_and_rotate(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
     );
@@ -1921,12 +1691,7 @@ pub unsafe fn unchecked_left_shift_integer_radix_kb_assign_async<T: UnsignedInte
     let mut mem_ptr: *mut i8 = std::ptr::null_mut();
     scratch_cuda_integer_radix_shift_and_rotate_kb_64(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
         glwe_dimension.0 as u32,
@@ -1948,12 +1713,7 @@ pub unsafe fn unchecked_left_shift_integer_radix_kb_assign_async<T: UnsignedInte
     );
     cuda_integer_radix_shift_and_rotate_kb_64_inplace(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         radix_lwe_left.as_mut_c_ptr(0),
         radix_shift.as_c_ptr(0),
@@ -1964,12 +1724,7 @@ pub unsafe fn unchecked_left_shift_integer_radix_kb_assign_async<T: UnsignedInte
     );
     cleanup_cuda_integer_radix_shift_and_rotate(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
     );
@@ -2027,12 +1782,7 @@ pub unsafe fn unchecked_rotate_right_integer_radix_kb_assign_async<
     let mut mem_ptr: *mut i8 = std::ptr::null_mut();
     scratch_cuda_integer_radix_shift_and_rotate_kb_64(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
         glwe_dimension.0 as u32,
@@ -2054,12 +1804,7 @@ pub unsafe fn unchecked_rotate_right_integer_radix_kb_assign_async<
     );
     cuda_integer_radix_shift_and_rotate_kb_64_inplace(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         radix_lwe_left.as_mut_c_ptr(0),
         radix_shift.as_c_ptr(0),
@@ -2070,12 +1815,7 @@ pub unsafe fn unchecked_rotate_right_integer_radix_kb_assign_async<
     );
     cleanup_cuda_integer_radix_shift_and_rotate(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
     );
@@ -2133,12 +1873,7 @@ pub unsafe fn unchecked_rotate_left_integer_radix_kb_assign_async<
     let mut mem_ptr: *mut i8 = std::ptr::null_mut();
     scratch_cuda_integer_radix_shift_and_rotate_kb_64(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
         glwe_dimension.0 as u32,
@@ -2160,12 +1895,7 @@ pub unsafe fn unchecked_rotate_left_integer_radix_kb_assign_async<
     );
     cuda_integer_radix_shift_and_rotate_kb_64_inplace(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         radix_lwe_left.as_mut_c_ptr(0),
         radix_shift.as_c_ptr(0),
@@ -2176,12 +1906,7 @@ pub unsafe fn unchecked_rotate_left_integer_radix_kb_assign_async<
     );
     cleanup_cuda_integer_radix_shift_and_rotate(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
     );
@@ -2325,12 +2050,7 @@ pub unsafe fn unchecked_cmux_integer_radix_kb_async<T: UnsignedInteger, B: Numer
     let mut mem_ptr: *mut i8 = std::ptr::null_mut();
     scratch_cuda_integer_radix_cmux_kb_64(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
         glwe_dimension.0 as u32,
@@ -2350,12 +2070,7 @@ pub unsafe fn unchecked_cmux_integer_radix_kb_async<T: UnsignedInteger, B: Numer
     );
     cuda_cmux_integer_radix_ciphertext_kb_64(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         &mut cuda_ffi_radix_lwe_out,
         &cuda_ffi_condition,
@@ -2367,12 +2082,7 @@ pub unsafe fn unchecked_cmux_integer_radix_kb_async<T: UnsignedInteger, B: Numer
     );
     cleanup_cuda_integer_radix_cmux(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
     );
@@ -2424,12 +2134,7 @@ pub unsafe fn unchecked_scalar_rotate_left_integer_radix_kb_assign_async<
     let mut mem_ptr: *mut i8 = std::ptr::null_mut();
     scratch_cuda_integer_radix_scalar_rotate_kb_64(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
         glwe_dimension.0 as u32,
@@ -2450,12 +2155,7 @@ pub unsafe fn unchecked_scalar_rotate_left_integer_radix_kb_assign_async<
     );
     cuda_integer_radix_scalar_rotate_kb_64_inplace(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         radix_lwe_left.as_mut_c_ptr(0),
         n,
@@ -2466,12 +2166,7 @@ pub unsafe fn unchecked_scalar_rotate_left_integer_radix_kb_assign_async<
     );
     cleanup_cuda_integer_radix_scalar_rotate(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
     );
@@ -2523,12 +2218,7 @@ pub unsafe fn unchecked_scalar_rotate_right_integer_radix_kb_assign_async<
     let mut mem_ptr: *mut i8 = std::ptr::null_mut();
     scratch_cuda_integer_radix_scalar_rotate_kb_64(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
         glwe_dimension.0 as u32,
@@ -2549,12 +2239,7 @@ pub unsafe fn unchecked_scalar_rotate_right_integer_radix_kb_assign_async<
     );
     cuda_integer_radix_scalar_rotate_kb_64_inplace(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         radix_lwe_left.as_mut_c_ptr(0),
         n,
@@ -2565,12 +2250,7 @@ pub unsafe fn unchecked_scalar_rotate_right_integer_radix_kb_assign_async<
     );
     cleanup_cuda_integer_radix_scalar_rotate(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
     );
@@ -2627,12 +2307,7 @@ pub unsafe fn unchecked_partial_sum_ciphertexts_integer_radix_kb_assign_async<
     let mut mem_ptr: *mut i8 = std::ptr::null_mut();
     scratch_cuda_integer_radix_partial_sum_ciphertexts_vec_kb_64(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
         glwe_dimension.0 as u32,
@@ -2652,12 +2327,7 @@ pub unsafe fn unchecked_partial_sum_ciphertexts_integer_radix_kb_assign_async<
     );
     cuda_integer_radix_partial_sum_ciphertexts_vec_kb_64(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         result.as_mut_c_ptr(0),
         radix_list.as_mut_c_ptr(0),
@@ -2669,12 +2339,7 @@ pub unsafe fn unchecked_partial_sum_ciphertexts_integer_radix_kb_assign_async<
     );
     cleanup_cuda_integer_radix_partial_sum_ciphertexts_vec(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
     );
@@ -2745,12 +2410,7 @@ pub unsafe fn apply_univariate_lut_kb_async<T: UnsignedInteger, B: Numeric>(
     );
     scratch_cuda_apply_univariate_lut_kb_64(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
         input_lut.as_ptr().cast(),
@@ -2771,12 +2431,7 @@ pub unsafe fn apply_univariate_lut_kb_async<T: UnsignedInteger, B: Numeric>(
     );
     cuda_apply_univariate_lut_kb_64(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         &mut cuda_ffi_output,
         &cuda_ffi_input,
@@ -2786,12 +2441,7 @@ pub unsafe fn apply_univariate_lut_kb_async<T: UnsignedInteger, B: Numeric>(
     );
     cleanup_cuda_apply_univariate_lut_kb_64(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
     );
@@ -2847,12 +2497,7 @@ pub unsafe fn apply_many_univariate_lut_kb_async<T: UnsignedInteger, B: Numeric>
     let mut mem_ptr: *mut i8 = std::ptr::null_mut();
     scratch_cuda_apply_many_univariate_lut_kb_64(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
         input_lut.as_ptr().cast(),
@@ -2873,12 +2518,7 @@ pub unsafe fn apply_many_univariate_lut_kb_async<T: UnsignedInteger, B: Numeric>
     );
     cuda_apply_many_univariate_lut_kb_64(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         radix_lwe_output.as_mut_c_ptr(0),
         radix_lwe_input.as_c_ptr(0),
@@ -2891,12 +2531,7 @@ pub unsafe fn apply_many_univariate_lut_kb_async<T: UnsignedInteger, B: Numeric>
     );
     cleanup_cuda_apply_univariate_lut_kb_64(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
     );
@@ -2957,12 +2592,7 @@ pub unsafe fn apply_bivariate_lut_kb_async<T: UnsignedInteger, B: Numeric>(
     let mut mem_ptr: *mut i8 = std::ptr::null_mut();
     scratch_cuda_apply_bivariate_lut_kb_64(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
         input_lut.as_ptr().cast(),
@@ -2982,12 +2612,7 @@ pub unsafe fn apply_bivariate_lut_kb_async<T: UnsignedInteger, B: Numeric>(
     );
     cuda_apply_bivariate_lut_kb_64(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         radix_lwe_output.as_mut_c_ptr(0),
         radix_lwe_input_1.as_c_ptr(0),
@@ -3000,12 +2625,7 @@ pub unsafe fn apply_bivariate_lut_kb_async<T: UnsignedInteger, B: Numeric>(
     );
     cleanup_cuda_apply_bivariate_lut_kb_64(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
     );
@@ -3042,12 +2662,7 @@ pub unsafe fn unchecked_div_rem_integer_radix_kb_assign_async<T: UnsignedInteger
     let mut mem_ptr: *mut i8 = std::ptr::null_mut();
     scratch_cuda_integer_div_rem_radix_ciphertext_kb_64(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         is_signed,
         std::ptr::addr_of_mut!(mem_ptr),
@@ -3068,12 +2683,7 @@ pub unsafe fn unchecked_div_rem_integer_radix_kb_assign_async<T: UnsignedInteger
     );
     cuda_integer_div_rem_radix_ciphertext_kb_64(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         quotient.as_mut_c_ptr(0),
         remainder.as_mut_c_ptr(0),
@@ -3087,12 +2697,7 @@ pub unsafe fn unchecked_div_rem_integer_radix_kb_assign_async<T: UnsignedInteger
     );
     cleanup_cuda_integer_div_rem(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
     );
@@ -3147,12 +2752,7 @@ pub unsafe fn compute_prefix_sum_hillis_steele_async<T: UnsignedInteger, B: Nume
     let mut mem_ptr: *mut i8 = std::ptr::null_mut();
     scratch_cuda_integer_compute_prefix_sum_hillis_steele_64(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
         input_lut.as_ptr().cast(),
@@ -3173,12 +2773,7 @@ pub unsafe fn compute_prefix_sum_hillis_steele_async<T: UnsignedInteger, B: Nume
 
     cuda_integer_compute_prefix_sum_hillis_steele_64(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         radix_lwe_output.as_mut_c_ptr(0),
         generates_or_propagates.as_mut_c_ptr(0),
@@ -3191,12 +2786,7 @@ pub unsafe fn compute_prefix_sum_hillis_steele_async<T: UnsignedInteger, B: Nume
 
     cleanup_cuda_integer_compute_prefix_sum_hillis_steele_64(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
     );
@@ -3224,7 +2814,7 @@ pub unsafe fn reverse_blocks_inplace_async<T: UnsignedInteger>(
             streams
                 .gpu_indexes
                 .iter()
-                .map(|i| i.0)
+                .map(|i| i.get())
                 .collect::<Vec<u32>>()
                 .as_ptr(),
             streams.len() as u32,
@@ -3285,12 +2875,7 @@ pub(crate) unsafe fn unchecked_unsigned_overflowing_sub_integer_radix_kb_assign_
     let big_lwe_dimension: u32 = glwe_dimension.0 as u32 * polynomial_size.0 as u32;
     scratch_cuda_integer_overflowing_sub_kb_64_inplace(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
         glwe_dimension.0 as u32,
@@ -3311,12 +2896,7 @@ pub(crate) unsafe fn unchecked_unsigned_overflowing_sub_integer_radix_kb_assign_
     );
     cuda_integer_overflowing_sub_kb_64_inplace(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         radix_lwe_input.as_mut_c_ptr(0),
         radix_rhs_input.as_c_ptr(0),
@@ -3331,12 +2911,7 @@ pub(crate) unsafe fn unchecked_unsigned_overflowing_sub_integer_radix_kb_assign_
     );
     cleanup_cuda_integer_overflowing_sub(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
     );
@@ -3377,12 +2952,7 @@ pub unsafe fn unchecked_signed_abs_radix_kb_assign_async<T: UnsignedInteger, B: 
     let mut cuda_ffi_ct = prepare_cuda_radix_ffi(ct, &mut ct_degrees, &mut ct_noise_levels);
     scratch_cuda_integer_abs_inplace_radix_ciphertext_kb_64(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
         true,
@@ -3403,12 +2973,7 @@ pub unsafe fn unchecked_signed_abs_radix_kb_assign_async<T: UnsignedInteger, B: 
     );
     cuda_integer_abs_inplace_radix_ciphertext_kb_64(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         &mut cuda_ffi_ct,
         mem_ptr,
@@ -3418,12 +2983,7 @@ pub unsafe fn unchecked_signed_abs_radix_kb_assign_async<T: UnsignedInteger, B: 
     );
     cleanup_cuda_integer_abs_inplace(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
     );
@@ -3480,12 +3040,7 @@ pub unsafe fn unchecked_is_at_least_one_comparisons_block_true_integer_radix_kb_
     let mut mem_ptr: *mut i8 = std::ptr::null_mut();
     scratch_cuda_integer_is_at_least_one_comparisons_block_true_kb_64(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
         glwe_dimension.0 as u32,
@@ -3506,12 +3061,7 @@ pub unsafe fn unchecked_is_at_least_one_comparisons_block_true_integer_radix_kb_
 
     cuda_integer_is_at_least_one_comparisons_block_true_kb_64(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         radix_lwe_out.as_mut_c_ptr(0),
         radix_lwe_in.as_c_ptr(0),
@@ -3523,12 +3073,7 @@ pub unsafe fn unchecked_is_at_least_one_comparisons_block_true_integer_radix_kb_
 
     cleanup_cuda_integer_is_at_least_one_comparisons_block_true(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
     );
@@ -3585,12 +3130,7 @@ pub unsafe fn unchecked_are_all_comparisons_block_true_integer_radix_kb_async<
     let mut mem_ptr: *mut i8 = std::ptr::null_mut();
     scratch_cuda_integer_are_all_comparisons_block_true_kb_64(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
         glwe_dimension.0 as u32,
@@ -3611,12 +3151,7 @@ pub unsafe fn unchecked_are_all_comparisons_block_true_integer_radix_kb_async<
 
     cuda_integer_are_all_comparisons_block_true_kb_64(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         radix_lwe_out.as_mut_c_ptr(0),
         radix_lwe_in.as_c_ptr(0),
@@ -3628,12 +3163,7 @@ pub unsafe fn unchecked_are_all_comparisons_block_true_integer_radix_kb_async<
 
     cleanup_cuda_integer_are_all_comparisons_block_true(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         std::ptr::addr_of_mut!(mem_ptr),
     );
@@ -3690,12 +3220,7 @@ pub unsafe fn unchecked_negate_integer_radix_async(
 
     cuda_negate_integer_radix_ciphertext_64(
         streams.ptr.as_ptr(),
-        streams
-            .gpu_indexes
-            .iter()
-            .map(|i| i.0)
-            .collect::<Vec<u32>>()
-            .as_ptr(),
+        streams.gpu_indexes_ptr(),
         streams.len() as u32,
         &mut cuda_ffi_radix_lwe_out,
         &cuda_ffi_radix_lwe_in,

--- a/tfhe/src/integer/gpu/server_key/radix/oprf.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/oprf.rs
@@ -582,7 +582,7 @@ pub(crate) mod test {
     #[test]
     fn oprf_compare_plain_ci_run_filter() {
         let gpu_index = 0;
-        let streams = CudaStreams::new_single_gpu(GpuIndex(gpu_index));
+        let streams = CudaStreams::new_single_gpu(GpuIndex::new(gpu_index));
         let (ck, gpu_sk) = gen_keys_gpu(
             PARAM_GPU_MULTI_BIT_GROUP_3_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64,
             &streams,
@@ -672,7 +672,7 @@ pub(crate) mod test {
 
         let p_value_limit: f64 = 0.000_01;
         let gpu_index = 0;
-        let streams = CudaStreams::new_single_gpu(GpuIndex(gpu_index));
+        let streams = CudaStreams::new_single_gpu(GpuIndex::new(gpu_index));
         let (ck, gpu_sk) = gen_keys_gpu(
             PARAM_GPU_MULTI_BIT_GROUP_3_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64,
             &streams,

--- a/tfhe/src/integer/gpu/server_key/radix/tests_long_run/mod.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/tests_long_run/mod.rs
@@ -1,5 +1,5 @@
 use crate::core_crypto::gpu::vec::GpuIndex;
-use crate::core_crypto::gpu::CudaStreams;
+use crate::core_crypto::gpu::{get_number_of_gpus, CudaStreams};
 use crate::integer::gpu::ciphertext::boolean_value::CudaBooleanBlock;
 use crate::integer::gpu::ciphertext::{CudaSignedRadixCiphertext, CudaUnsignedRadixCiphertext};
 use crate::integer::gpu::server_key::radix::tests_unsigned::GpuContext;
@@ -10,7 +10,6 @@ use crate::integer::{
 };
 use rand::Rng;
 use std::sync::Arc;
-use tfhe_cuda_backend::cuda_bind::cuda_get_number_of_gpus;
 
 pub(crate) mod test_erc20;
 pub(crate) mod test_random_op_sequence;
@@ -33,8 +32,8 @@ impl<F> GpuMultiDeviceFunctionExecutor<F> {
 
 impl<F> GpuMultiDeviceFunctionExecutor<F> {
     pub(crate) fn setup_from_keys(&mut self, cks: &RadixClientKey, _sks: &Arc<ServerKey>) {
-        let num_gpus = unsafe { cuda_get_number_of_gpus() } as u32;
-        let gpu_index = GpuIndex(rand::thread_rng().gen_range(0..num_gpus));
+        let num_gpus = get_number_of_gpus();
+        let gpu_index = GpuIndex::new(rand::thread_rng().gen_range(0..num_gpus));
         let streams = CudaStreams::new_single_gpu(gpu_index);
 
         let sks = CudaServerKey::new(cks.as_ref(), &streams);


### PR DESCRIPTION
This commit does 2 things:

* It adds to GpuIndex the invariant that the index corresponds to a valid GPU, to do so, the inner u32 is made private and new/try_new method are now used to construct a GpuIndex these methods checks that the index is valid
* It makes GpuIndex transparent, allowing to safely cast a *const GpuIndex to *const u32, this is to save same copies made to transform Vec<GpuIndex> to Vec<u32> that was used to get a *const u32

BREAKING CHANGES: GpuIndex(some_value) is no longer valid and GpuIndex::new(some_value) / GpuIndex::try_new(some_value) has to be used

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/2006)
<!-- Reviewable:end -->
