### PR TITLE
chore(ci): run user permissions check if job should run

### DIFF
--- a/.github/workflows/aws_tfhe_fast_tests.yml
+++ b/.github/workflows/aws_tfhe_fast_tests.yml
@@ -148,9 +148,11 @@ jobs:
   # Fail if the triggering actor is not part of Zama organization.
   # If pull_request_target is emitted and CI files have changed, skip this job. This would skip following jobs.
   check-user-permission:
-    needs: check-ci-files
+    needs: [ check-ci-files, should-run ]
     if: github.event_name != 'pull_request_target' ||
-      (github.event_name == 'pull_request_target' && needs.check-ci-files.outputs.ci_file_changed == 'false')
+      (github.event_name == 'pull_request_target' && 
+      needs.check-ci-files.outputs.ci_file_changed == 'false' &&
+      needs.should-run.outputs.any_file_changed == 'true')
     uses: ./.github/workflows/check_actor_permissions.yml
     secrets:
       TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/aws_tfhe_integer_tests.yml
+++ b/.github/workflows/aws_tfhe_integer_tests.yml
@@ -86,9 +86,11 @@ jobs:
   # Fail if the triggering actor is not part of Zama organization.
   # If pull_request_target is emitted and CI files have changed, skip this job. This would skip following jobs.
   check-user-permission:
-    needs: check-ci-files
+    needs: [ check-ci-files, should-run ]
     if: github.event_name != 'pull_request_target' ||
-      (github.event_name == 'pull_request_target' && needs.check-ci-files.outputs.ci_file_changed == 'false')
+      (github.event_name == 'pull_request_target' && 
+      needs.check-ci-files.outputs.ci_file_changed == 'false' &&
+      needs.should-run.outputs.integer_test == 'true')
     uses: ./.github/workflows/check_actor_permissions.yml
     secrets:
       TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/aws_tfhe_signed_integer_tests.yml
+++ b/.github/workflows/aws_tfhe_signed_integer_tests.yml
@@ -87,9 +87,11 @@ jobs:
   # Fail if the triggering actor is not part of Zama organization.
   # If pull_request_target is emitted and CI files have changed, skip this job. This would skip following jobs.
   check-user-permission:
-    needs: check-ci-files
+    needs: [ check-ci-files, should-run ]
     if: github.event_name != 'pull_request_target' ||
-      (github.event_name == 'pull_request_target' && needs.check-ci-files.outputs.ci_file_changed == 'false')
+      (github.event_name == 'pull_request_target' &&
+      needs.check-ci-files.outputs.ci_file_changed == 'false' &&
+      needs.should-run.outputs.integer_test == 'true')
     uses: ./.github/workflows/check_actor_permissions.yml
     secrets:
       TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/aws_tfhe_tests.yml
+++ b/.github/workflows/aws_tfhe_tests.yml
@@ -158,9 +158,11 @@ jobs:
   # Fail if the triggering actor is not part of Zama organization.
   # If pull_request_target is emitted and CI files have changed, skip this job. This would skip following jobs.
   check-user-permission:
-    needs: check-ci-files
+    needs: [ check-ci-files, should-run ]
     if: github.event_name != 'pull_request_target' ||
-      (github.event_name == 'pull_request_target' && needs.check-ci-files.outputs.ci_file_changed == 'false')
+      (github.event_name == 'pull_request_target' &&
+      needs.check-ci-files.outputs.ci_file_changed == 'false' &&
+      needs.should-run.outputs.any_file_changed == 'true')
     uses: ./.github/workflows/check_actor_permissions.yml
     secrets:
       TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gpu_fast_h100_tests.yml
+++ b/.github/workflows/gpu_fast_h100_tests.yml
@@ -83,9 +83,11 @@ jobs:
   # Fail if the triggering actor is not part of Zama organization.
   # If pull_request_target is emitted and CI files have changed, skip this job. This would skip following jobs.
   check-user-permission:
-    needs: check-ci-files
+    needs: [ check-ci-files, should-run ]
     if: github.event_name != 'pull_request_target' ||
-      (github.event_name == 'pull_request_target' && needs.check-ci-files.outputs.ci_file_changed == 'false')
+      (github.event_name == 'pull_request_target' &&
+      needs.check-ci-files.outputs.ci_file_changed == 'false' &&
+      needs.should-run.outputs.gpu_test == 'true')
     uses: ./.github/workflows/check_actor_permissions.yml
     secrets:
       TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gpu_fast_tests.yml
+++ b/.github/workflows/gpu_fast_tests.yml
@@ -81,9 +81,11 @@ jobs:
   # Fail if the triggering actor is not part of Zama organization.
   # If pull_request_target is emitted and CI files have changed, skip this job. This would skip following jobs.
   check-user-permission:
-    needs: check-ci-files
+    needs: [ check-ci-files, should-run ]
     if: github.event_name != 'pull_request_target' ||
-      (github.event_name == 'pull_request_target' && needs.check-ci-files.outputs.ci_file_changed == 'false')
+      (github.event_name == 'pull_request_target' &&
+      needs.check-ci-files.outputs.ci_file_changed == 'false' &&
+      needs.should-run.outputs.gpu_test == 'true')
     uses: ./.github/workflows/check_actor_permissions.yml
     secrets:
       TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gpu_full_multi_gpu_tests.yml
+++ b/.github/workflows/gpu_full_multi_gpu_tests.yml
@@ -83,9 +83,11 @@ jobs:
   # Fail if the triggering actor is not part of Zama organization.
   # If pull_request_target is emitted and CI files have changed, skip this job. This would skip following jobs.
   check-user-permission:
-    needs: check-ci-files
+    needs: [ check-ci-files, should-run ]
     if: github.event_name != 'pull_request_target' ||
-      (github.event_name == 'pull_request_target' && needs.check-ci-files.outputs.ci_file_changed == 'false')
+      (github.event_name == 'pull_request_target' &&
+      needs.check-ci-files.outputs.ci_file_changed == 'false' &&
+      needs.should-run.outputs.gpu_test == 'true')
     uses: ./.github/workflows/check_actor_permissions.yml
     secrets:
       TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gpu_signed_integer_classic_tests.yml
+++ b/.github/workflows/gpu_signed_integer_classic_tests.yml
@@ -83,9 +83,11 @@ jobs:
   # Fail if the triggering actor is not part of Zama organization.
   # If pull_request_target is emitted and CI files have changed, skip this job. This would skip following jobs.
   check-user-permission:
-    needs: check-ci-files
+    needs: [ check-ci-files, should-run ]
     if: github.event_name != 'pull_request_target' ||
-      (github.event_name == 'pull_request_target' && needs.check-ci-files.outputs.ci_file_changed == 'false')
+      (github.event_name == 'pull_request_target' &&
+      needs.check-ci-files.outputs.ci_file_changed == 'false' &&
+      needs.should-run.outputs.gpu_test == 'true')
     uses: ./.github/workflows/check_actor_permissions.yml
     secrets:
       TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gpu_signed_integer_h100_tests.yml
+++ b/.github/workflows/gpu_signed_integer_h100_tests.yml
@@ -83,9 +83,11 @@ jobs:
   # Fail if the triggering actor is not part of Zama organization.
   # If pull_request_target is emitted and CI files have changed, skip this job. This would skip following jobs.
   check-user-permission:
-    needs: check-ci-files
+    needs: [ check-ci-files, should-run ]
     if: github.event_name != 'pull_request_target' ||
-      (github.event_name == 'pull_request_target' && needs.check-ci-files.outputs.ci_file_changed == 'false')
+      (github.event_name == 'pull_request_target' &&
+      needs.check-ci-files.outputs.ci_file_changed == 'false' &&
+      needs.should-run.outputs.gpu_test == 'true')
     uses: ./.github/workflows/check_actor_permissions.yml
     secrets:
       TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gpu_signed_integer_tests.yml
+++ b/.github/workflows/gpu_signed_integer_tests.yml
@@ -86,9 +86,11 @@ jobs:
   # Fail if the triggering actor is not part of Zama organization.
   # If pull_request_target is emitted and CI files have changed, skip this job. This would skip following jobs.
   check-user-permission:
-    needs: check-ci-files
+    needs: [ check-ci-files, should-run ]
     if: github.event_name != 'pull_request_target' ||
-      (github.event_name == 'pull_request_target' && needs.check-ci-files.outputs.ci_file_changed == 'false')
+      (github.event_name == 'pull_request_target' &&
+      needs.check-ci-files.outputs.ci_file_changed == 'false' &&
+      needs.should-run.outputs.gpu_test == 'true')
     uses: ./.github/workflows/check_actor_permissions.yml
     secrets:
       TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gpu_unsigned_integer_classic_tests.yml
+++ b/.github/workflows/gpu_unsigned_integer_classic_tests.yml
@@ -83,9 +83,11 @@ jobs:
   # Fail if the triggering actor is not part of Zama organization.
   # If pull_request_target is emitted and CI files have changed, skip this job. This would skip following jobs.
   check-user-permission:
-    needs: check-ci-files
+    needs: [ check-ci-files, should-run ]
     if: github.event_name != 'pull_request_target' ||
-      (github.event_name == 'pull_request_target' && needs.check-ci-files.outputs.ci_file_changed == 'false')
+      (github.event_name == 'pull_request_target' &&
+      needs.check-ci-files.outputs.ci_file_changed == 'false' &&
+      needs.should-run.outputs.gpu_test == 'true')
     uses: ./.github/workflows/check_actor_permissions.yml
     secrets:
       TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gpu_unsigned_integer_h100_tests.yml
+++ b/.github/workflows/gpu_unsigned_integer_h100_tests.yml
@@ -83,9 +83,11 @@ jobs:
   # Fail if the triggering actor is not part of Zama organization.
   # If pull_request_target is emitted and CI files have changed, skip this job. This would skip following jobs.
   check-user-permission:
-    needs: check-ci-files
+    needs: [ check-ci-files, should-run ]
     if: github.event_name != 'pull_request_target' ||
-      (github.event_name == 'pull_request_target' && needs.check-ci-files.outputs.ci_file_changed == 'false')
+      (github.event_name == 'pull_request_target' &&
+      needs.check-ci-files.outputs.ci_file_changed == 'false' &&
+      needs.should-run.outputs.gpu_test == 'true')
     uses: ./.github/workflows/check_actor_permissions.yml
     secrets:
       TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gpu_unsigned_integer_tests.yml
+++ b/.github/workflows/gpu_unsigned_integer_tests.yml
@@ -87,9 +87,11 @@ jobs:
   # Fail if the triggering actor is not part of Zama organization.
   # If pull_request_target is emitted and CI files have changed, skip this job. This would skip following jobs.
   check-user-permission:
-    needs: check-ci-files
+    needs: [ check-ci-files, should-run ]
     if: github.event_name != 'pull_request_target' ||
-      (github.event_name == 'pull_request_target' && needs.check-ci-files.outputs.ci_file_changed == 'false')
+      (github.event_name == 'pull_request_target' &&
+      needs.check-ci-files.outputs.ci_file_changed == 'false' &&
+      needs.should-run.outputs.gpu_test == 'true')
     uses: ./.github/workflows/check_actor_permissions.yml
     secrets:
       TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
A small workflow optimization by running user permissions check only if a job is supposed to run.

