### PR TITLE
feat(gpu): add circulant matrix for one vs many poly product

### DIFF
--- a/backends/tfhe-cuda-backend/cuda/CMakeLists.txt
+++ b/backends/tfhe-cuda-backend/cuda/CMakeLists.txt
@@ -99,7 +99,7 @@ endif()
 set(CMAKE_CUDA_FLAGS
     "${CMAKE_CUDA_FLAGS} -ccbin ${CMAKE_CXX_COMPILER} ${OPTIMIZATION_FLAGS}\
   -std=c++17 --no-exceptions  --expt-relaxed-constexpr -rdc=true \
-  --use_fast_math -Xcompiler -fPIC")
+  --use_fast_math -Xcompiler -fPIC ")
 
 set(INCLUDE_DIR include)
 

--- a/backends/tfhe-cuda-backend/cuda/include/linear_algebra.h
+++ b/backends/tfhe-cuda-backend/cuda/include/linear_algebra.h
@@ -42,6 +42,24 @@ void cuda_mult_lwe_ciphertext_vector_cleartext_vector_64(
     void const *lwe_array_in, void const *cleartext_array_in,
     const uint32_t input_lwe_dimension,
     const uint32_t input_lwe_ciphertext_count);
+
+void scratch_wrapping_polynomial_mul_one_to_many_64(void *stream,
+                                                    uint32_t gpu_index,
+                                                    uint32_t polynomial_size,
+                                                    int8_t **circulant_buf);
+
+void cleanup_wrapping_polynomial_mul_one_to_many_64(void *stream,
+                                                    uint32_t gpu_index,
+                                                    int8_t *circulant_buf);
+
+void cuda_wrapping_polynomial_mul_one_to_many_64(
+    void *stream, uint32_t gpu_index, void *result, void const *poly_lhs,
+    int8_t *circulant, void const *poly_rhs, uint32_t polynomial_size,
+    uint32_t n_rhs);
+void cuda_glwe_wrapping_polynomial_mul_one_to_many_64(
+    void *stream, uint32_t gpu_index, void *result, void const *poly_lhs,
+    int8_t *circulant, void const *poly_rhs, uint32_t polynomial_size,
+    uint32_t glwe_dimension, uint32_t n_rhs);
 void cuda_add_lwe_ciphertext_vector_plaintext_64(
     void *stream, uint32_t gpu_index, void *lwe_array_out,
     void const *lwe_array_in, const uint64_t plaintext_in,

--- a/backends/tfhe-cuda-backend/cuda/src/linearalgebra/multiplication.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/linearalgebra/multiplication.cu
@@ -1,4 +1,5 @@
 #include "linearalgebra/multiplication.cuh"
+#include "polynomial/dot_product.cuh"
 
 /*
  * Perform the multiplication of a u32 input LWE ciphertext vector with a u32
@@ -57,4 +58,42 @@ void cuda_mult_lwe_ciphertext_vector_cleartext_vector_64(
       static_cast<const uint64_t *>(lwe_array_in),
       static_cast<const uint64_t *>(cleartext_array_in), input_lwe_dimension,
       input_lwe_ciphertext_count);
+}
+
+void scratch_wrapping_polynomial_mul_one_to_many_64(void *stream,
+                                                    uint32_t gpu_index,
+                                                    uint32_t polynomial_size,
+                                                    int8_t **circulant_buf) {
+  scratch_wrapping_polynomial_mul_one_to_many<uint64_t>(
+      stream, gpu_index, polynomial_size, circulant_buf);
+}
+
+void cleanup_wrapping_polynomial_mul_one_to_many_64(void *stream,
+                                                    uint32_t gpu_index,
+                                                    int8_t *circulant_buf) {
+  cleanup_wrapping_polynomial_mul_one_to_many<uint64_t>(stream, gpu_index,
+                                                        circulant_buf);
+}
+
+void cuda_wrapping_polynomial_mul_one_to_many_64(
+    void *stream, uint32_t gpu_index, void *result, void const *poly_lhs,
+    int8_t *circulant, void const *poly_rhs, uint32_t polynomial_size,
+    uint32_t n_rhs) {
+
+  host_wrapping_polynomial_mul_one_to_many<uint64_t, ulonglong4>(
+      static_cast<cudaStream_t>(stream), gpu_index,
+      static_cast<uint64_t *>(result), static_cast<uint64_t const *>(poly_lhs),
+      circulant, static_cast<uint64_t const *>(poly_rhs), polynomial_size, 0,
+      n_rhs);
+}
+
+void cuda_glwe_wrapping_polynomial_mul_one_to_many_64(
+    void *stream, uint32_t gpu_index, void *result, void const *glwe_lhs,
+    int8_t *circulant, void const *poly_rhs, uint32_t polynomial_size,
+    uint32_t glwe_dimension, uint32_t n_rhs) {
+  host_glwe_wrapping_polynomial_mul_one_to_many<uint64_t, ulonglong4>(
+      static_cast<cudaStream_t>(stream), gpu_index,
+      static_cast<uint64_t *>(result), static_cast<uint64_t const *>(glwe_lhs),
+      circulant, static_cast<uint64_t const *>(poly_rhs), polynomial_size,
+      glwe_dimension, n_rhs);
 }

--- a/backends/tfhe-cuda-backend/cuda/src/linearalgebra/multiplication.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/linearalgebra/multiplication.cuh
@@ -86,4 +86,112 @@ host_cleartext_multiplication(cudaStream_t stream, uint32_t gpu_index,
   check_cuda_error(cudaGetLastError());
 }
 
+const int BLOCK_SIZE_GEMM = 64;
+const int THREADS_GEMM = 8;
+
+template <typename Torus> uint64_t get_shared_mem_size_tgemm() {
+  return BLOCK_SIZE_GEMM * THREADS_GEMM * 2 * sizeof(Torus);
+}
+
+// Multiply matrices A, B of size (M, K), (K, N) respectively
+// with K as the inner dimension.
+//
+// A block of threads processeds blocks of size (BLOCK_SIZE_GEMM,
+// BLOCK_SIZE_GEMM) splitting them in multiple tiles: (BLOCK_SIZE_GEMM,
+// THREADS_GEMM)-shaped tiles of values from A, and a (THREADS_GEMM,
+// BLOCK_SIZE_GEMM)-shaped tiles of values from B.
+//
+// This code is adapted by generalizing the 1d block-tiling
+// kernel from https://github.com/siboehm/SGEMM_CUDA
+// to any matrix dimension
+template <typename Torus>
+__global__ void tgemm(uint M, uint N, uint K, const Torus *A, const Torus *B,
+                      uint stride_B, Torus *C, uint stride_C) {
+
+  const int BM = BLOCK_SIZE_GEMM;
+  const int BN = BLOCK_SIZE_GEMM;
+  const int BK = THREADS_GEMM;
+  const int TM = THREADS_GEMM;
+
+  const uint cRow = blockIdx.y;
+  const uint cCol = blockIdx.x;
+
+  const int threadCol = threadIdx.x % BN;
+  const int threadRow = threadIdx.x / BN;
+
+  // Allocate space for the current block tile in shared memory
+  __shared__ Torus As[BM * BK];
+  __shared__ Torus Bs[BK * BN];
+
+  // Initialize the pointers to the input blocks from A, B
+  // Tiles from these blocks are loaded to shared memory
+  A += cRow * BM * K;
+  B += cCol * BN;
+
+  // Each thread will handle multiple sub-blocks
+  const uint innerColA = threadIdx.x % BK;
+  const uint innerRowA = threadIdx.x / BK;
+  const uint innerColB = threadIdx.x % BN;
+  const uint innerRowB = threadIdx.x / BN;
+
+  // allocate thread-local cache for results in registerfile
+  Torus threadResults[TM] = {0};
+
+  auto row_A = cRow * BM + innerRowA;
+  auto col_B = cCol * BN + innerColB;
+
+  // For each thread, loop over block tiles
+  for (uint bkIdx = 0; bkIdx < K; bkIdx += BK) {
+    auto col_A = bkIdx + innerColA;
+    auto row_B = bkIdx + innerRowB;
+
+    if (row_A < M && col_A < K) {
+      As[innerRowA * BK + innerColA] = A[innerRowA * K + innerColA];
+    } else {
+      As[innerRowA * BK + innerColA] = 0;
+    }
+
+    if (col_B < N && row_B < K) {
+      Bs[innerRowB * BN + innerColB] = B[innerRowB * stride_B + innerColB];
+    } else {
+      Bs[innerRowB * BN + innerColB] = 0;
+    }
+    __syncthreads();
+
+    // Advance blocktile for the next iteration of this loop
+    A += BK;
+    B += BK * stride_B;
+
+    // calculate per-thread results
+    for (uint dotIdx = 0; dotIdx < BK; ++dotIdx) {
+      // we make the dotproduct loop the outside loop, which facilitates
+      // reuse of the Bs entry, which we can cache in a tmp var.
+      Torus tmp = Bs[dotIdx * BN + threadCol];
+      for (uint resIdx = 0; resIdx < TM; ++resIdx) {
+        threadResults[resIdx] +=
+            As[(threadRow * TM + resIdx) * BK + dotIdx] * tmp;
+      }
+    }
+    __syncthreads();
+  }
+
+  // Initialize the pointer to the output block of size (BLOCK_SIZE_GEMM,
+  // BLOCK_SIZE_GEMM)
+  C += cRow * BM * stride_C + cCol * BN;
+
+  // write out the results
+  for (uint resIdx = 0; resIdx < TM; ++resIdx) {
+    int outRow = cRow * BM + threadRow * TM + resIdx;
+    int outCol = cCol * BN + threadCol;
+
+    if (outRow >= M)
+      continue;
+    if (outCol >= N)
+      continue;
+
+    C[(threadRow * TM + resIdx) * stride_C + threadCol] +=
+        threadResults[resIdx];
+  }
+}
+
 #endif // CUDA_MULT_H

--- a/backends/tfhe-cuda-backend/cuda/src/polynomial/dot_product.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/polynomial/dot_product.cuh
@@ -1,0 +1,113 @@
+#ifndef CUDA_CIRCULANT_DOT_CUH
+#define CUDA_CIRCULANT_DOT_CUH
+
+#include "crypto/torus.cuh"
+
+#define CEIL_DIV(M, N) ((M) + (N)-1) / (N)
+
+#define CIRCULANT_BLOCKTILE 32
+// Make a circulant matrix that serves to multiply a polynomial
+// with another one. Each thread loads a part of the original
+// polynomial into shared memory. Then each thread distributes
+// values into their new positions. The elements above the diagonal
+// are multiplied by -1
+template <typename Torus>
+__global__ void polynomial_make_circulant(Torus *result, const Torus *poly,
+                                          uint32_t polynomial_size) {
+  __shared__ Torus buf[2 * CIRCULANT_BLOCKTILE - 1];
+
+  int32_t block_start = blockIdx.x * CIRCULANT_BLOCKTILE * polynomial_size +
+                        blockIdx.y * CIRCULANT_BLOCKTILE;
+
+  int32_t tid = threadIdx.x * CIRCULANT_BLOCKTILE + threadIdx.y;
+
+  if (tid < 2 * CIRCULANT_BLOCKTILE - 1) {
+    int32_t read_idx_start = (blockIdx.y - blockIdx.x) * CIRCULANT_BLOCKTILE +
+                             tid - CIRCULANT_BLOCKTILE + 1;
+    if (read_idx_start < 0) {
+      read_idx_start = polynomial_size + read_idx_start;
+    }
+    buf[tid] = poly[read_idx_start];
+  }
+  __syncthreads();
+
+  Torus fact = blockIdx.x * CIRCULANT_BLOCKTILE + threadIdx.x >
+                       blockIdx.y * CIRCULANT_BLOCKTILE + threadIdx.y
+                   ? -1
+                   : 1;
+  result[block_start + threadIdx.x * polynomial_size + threadIdx.y] =
+      buf[threadIdx.y - threadIdx.x + CIRCULANT_BLOCKTILE - 1] * fact;
+}
+
+template <typename Torus>
+__host__ void
+scratch_wrapping_polynomial_mul_one_to_many(void *stream, uint32_t gpu_index,
+                                            uint32_t polynomial_size,
+                                            int8_t **circulant_buf) {
+  // allocate circulant matrix memory
+  *circulant_buf = (int8_t *)cuda_malloc_async(
+      sizeof(Torus) * polynomial_size * polynomial_size,
+      static_cast<cudaStream_t>(stream), gpu_index);
+}
+
+template <typename Torus>
+__host__ void
+cleanup_wrapping_polynomial_mul_one_to_many(void *stream, uint32_t gpu_index,
+                                            int8_t *circulant_buf) {
+  // free circulant matrix memory
+  cuda_drop_async(circulant_buf, static_cast<cudaStream_t>(stream), gpu_index);
+}
+
+// Multiply degree-N lhs polynomial with many rhs polynomials
+// modulo X^N+1. This method builds a circulant matrix
+// from the lhs and uses matrix multiplication to
+// compute the polynomial multiplication
+template <typename Torus, typename TorusVec>
+__host__ void host_wrapping_polynomial_mul_one_to_many(
+    cudaStream_t stream, uint32_t gpu_index, Torus *result,
+    const Torus *poly_lhs, int8_t *circulant, const Torus *poly_rhs,
+    uint32_t polynomial_size, uint32_t glwe_dimension, uint32_t n_rhs) {
+
+  if (polynomial_size % CIRCULANT_BLOCKTILE)
+    PANIC("CUDA polynomial multiplication one to many: expected "
+          "polynomial size to be a multiple of the block size");
+
+  // convert lhs poly to circulant matrix
+  dim3 grid_c(polynomial_size / CIRCULANT_BLOCKTILE,
+              polynomial_size / CIRCULANT_BLOCKTILE);
+  dim3 threads_c(CIRCULANT_BLOCKTILE, CIRCULANT_BLOCKTILE);
+  polynomial_make_circulant<Torus><<<grid_c, threads_c, 0, stream>>>(
+      (Torus *)circulant, poly_lhs, polynomial_size);
+  check_cuda_error(cudaGetLastError());
+
+  // matmul circulant matrix with poly list
+  dim3 grid_gemm(CEIL_DIV(polynomial_size, BLOCK_SIZE_GEMM),
+                 CEIL_DIV(polynomial_size, BLOCK_SIZE_GEMM));
+  dim3 threads_gemm(BLOCK_SIZE_GEMM * THREADS_GEMM);
+  uint32_t sharedMemSize = BLOCK_SIZE_GEMM * THREADS_GEMM * 2 * sizeof(Torus);
+  if (sharedMemSize > 8192)
+    PANIC("GEMM kernel error: shared memory required might be too large");
+
+  // Write the output with a stride of the GLWE total number of values
+  tgemm<Torus><<<grid_gemm, threads_gemm, sharedMemSize, stream>>>(
+      n_rhs, polynomial_size, polynomial_size, poly_rhs, (Torus *)circulant,
+      polynomial_size, result, (polynomial_size * (glwe_dimension + 1)));
+  check_cuda_error(cudaGetLastError());
+}
+
+template <typename Torus, typename TorusVec>
+__host__ void host_glwe_wrapping_polynomial_mul_one_to_many(
+    cudaStream_t stream, uint32_t gpu_index, Torus *result,
+    const Torus *glwe_lhs, int8_t *circulant, const Torus *poly_rhs,
+    uint32_t polynomial_size, uint32_t glwe_dimension, uint32_t n_rhs) {
+  uint64_t const *glwe_lhs_t = static_cast<uint64_t const *>(glwe_lhs);
+
+  for (unsigned i = 0; i < glwe_dimension + 1; ++i) {
+    host_wrapping_polynomial_mul_one_to_many<uint64_t, ulonglong4>(
+        stream, gpu_index, result + i * polynomial_size,
+        glwe_lhs + i * polynomial_size, circulant, poly_rhs, polynomial_size,
+        glwe_dimension, n_rhs);
+  }
+}
+
+#endif

--- a/backends/tfhe-cuda-backend/cuda/src/polynomial/polynomial_math.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/polynomial/polynomial_math.cuh
@@ -1,9 +1,14 @@
 #ifndef CUDA_POLYNOMIAL_MATH_CUH
 #define CUDA_POLYNOMIAL_MATH_CUH
 
+#include <stdio.h>
+
 #include "crypto/torus.cuh"
+#include "linearalgebra/multiplication.cuh"
 #include "parameters.cuh"
 #include "types/complex/operations.cuh"
+
+#define CEIL_DIV(M, N) ((M) + (N)-1) / (N)
 
 template <typename T>
 __device__ T *get_chunk(T *data, int chunk_num, int chunk_size) {
@@ -225,4 +230,5 @@ __device__ void polynomial_accumulate_monic_monomial_mul_on_regs(
     result[i] += x;
   }
 }
+
 #endif // CNCRT_POLYNOMIAL_MATH_H

--- a/backends/tfhe-cuda-backend/src/bindings.rs
+++ b/backends/tfhe-cuda-backend/src/bindings.rs
@@ -1561,6 +1561,46 @@ unsafe extern "C" {
     );
 }
 unsafe extern "C" {
+    pub fn scratch_wrapping_polynomial_mul_one_to_many_64(
+        stream: *mut ffi::c_void,
+        gpu_index: u32,
+        polynomial_size: u32,
+        circulant_buf: *mut *mut i8,
+    );
+}
+unsafe extern "C" {
+    pub fn cleanup_wrapping_polynomial_mul_one_to_many_64(
+        stream: *mut ffi::c_void,
+        gpu_index: u32,
+        circulant_buf: *mut i8,
+    );
+}
+unsafe extern "C" {
+    pub fn cuda_wrapping_polynomial_mul_one_to_many_64(
+        stream: *mut ffi::c_void,
+        gpu_index: u32,
+        result: *mut ffi::c_void,
+        poly_lhs: *const ffi::c_void,
+        circulant: *mut i8,
+        poly_rhs: *const ffi::c_void,
+        polynomial_size: u32,
+        n_rhs: u32,
+    );
+}
+unsafe extern "C" {
+    pub fn cuda_glwe_wrapping_polynomial_mul_one_to_many_64(
+        stream: *mut ffi::c_void,
+        gpu_index: u32,
+        result: *mut ffi::c_void,
+        poly_lhs: *const ffi::c_void,
+        circulant: *mut i8,
+        poly_rhs: *const ffi::c_void,
+        polynomial_size: u32,
+        glwe_dimension: u32,
+        n_rhs: u32,
+    );
+}
+unsafe extern "C" {
     pub fn cuda_add_lwe_ciphertext_vector_plaintext_64(
         stream: *mut ffi::c_void,
         gpu_index: u32,

--- a/tfhe/src/core_crypto/gpu/algorithms/glwe_linear_algebra.rs
+++ b/tfhe/src/core_crypto/gpu/algorithms/glwe_linear_algebra.rs
@@ -1,0 +1,171 @@
+use crate::core_crypto::gpu::glwe_ciphertext_list::CudaGlweCiphertextList;
+use crate::core_crypto::gpu::glwe_sample_extraction::cuda_extract_lwe_samples_from_glwe_ciphertext_list;
+use crate::core_crypto::gpu::lwe_ciphertext_list::CudaLweCiphertextList;
+use crate::core_crypto::gpu::vec::CudaVec;
+use crate::core_crypto::gpu::CudaStreams;
+use crate::core_crypto::prelude::{
+    GlweCiphertextCount, MonomialDegree, UnsignedInteger, UnsignedTorus,
+};
+use tfhe_cuda_backend::bindings::{
+    cleanup_wrapping_polynomial_mul_one_to_many_64,
+    cuda_glwe_wrapping_polynomial_mul_one_to_many_64, cuda_wrapping_polynomial_mul_one_to_many_64,
+    scratch_wrapping_polynomial_mul_one_to_many_64,
+};
+
+pub fn cuda_wrapping_polynomial_mul_one_to_many<Scalar>(
+    lhs: &CudaVec<Scalar>,
+    rhs: &CudaVec<Scalar>,
+    out: &mut CudaVec<Scalar>,
+    stream: &CudaStreams,
+) where
+    Scalar: UnsignedInteger,
+{
+    assert_eq!(
+        rhs.len() % lhs.len(),
+        0,
+        "CUDA polynomial multiplication one to many: the rhs
+        must contain multiple polynomials of the same size as the
+        lhs"
+    );
+
+    assert!(
+        lhs.len().is_power_of_two(),
+        "CUDA polynomial multiplication one to many: expected
+        the polynomial size to be a multiple of two"
+    );
+
+    let mut mem_ptr: *mut i8 = std::ptr::null_mut();
+
+    unsafe {
+        scratch_wrapping_polynomial_mul_one_to_many_64(
+            stream.ptr[0],
+            stream.gpu_indexes[0].get(),
+            lhs.len() as u32,
+            std::ptr::addr_of_mut!(mem_ptr),
+        );
+        cuda_wrapping_polynomial_mul_one_to_many_64(
+            stream.ptr[0],
+            stream.gpu_indexes[0].get(),
+            out.as_mut_c_ptr(0),
+            lhs.as_c_ptr(0),
+            mem_ptr,
+            rhs.as_c_ptr(0),
+            lhs.len() as u32,
+            (rhs.len() / lhs.len()) as u32,
+        );
+        cleanup_wrapping_polynomial_mul_one_to_many_64(
+            stream.ptr[0],
+            stream.gpu_indexes[0].get(),
+            mem_ptr,
+        )
+    }
+    stream.synchronize();
+}
+
+pub fn cuda_glwe_wrapping_polynomial_mul_one_to_many<Scalar>(
+    lhs: &CudaGlweCiphertextList<Scalar>,
+    rhs: &CudaVec<Scalar>,
+    out: &mut CudaGlweCiphertextList<Scalar>,
+    stream: &CudaStreams,
+) where
+    Scalar: UnsignedInteger,
+{
+    assert_eq!(
+        rhs.len() % lhs.polynomial_size().0,
+        0,
+        "CUDA GLWE multiplication with clear, one to many: the rhs
+        must contain multiple polynomials of the same size as the
+        lhs"
+    );
+
+    assert!(
+        lhs.polynomial_size().0.is_power_of_two(),
+        "CUDA GLWE polynomial multiplication one to many: expected
+        the polynomial size to be a multiple of two"
+    );
+
+    assert_eq!(
+        lhs.glwe_dimension().0,
+        1,
+        "CUDA GLWE polynomial multiplication one to many: expected
+        the GLWE to have glwe dimension of 1"
+    );
+
+    assert_eq!(
+        lhs.glwe_ciphertext_count().0,
+        1,
+        "CUDA GLWE polynomial multiplication one to many: expected
+        a single GLWE"
+    );
+
+    let mut mem_ptr: *mut i8 = std::ptr::null_mut();
+
+    unsafe {
+        scratch_wrapping_polynomial_mul_one_to_many_64(
+            stream.ptr[0],
+            stream.gpu_indexes[0].get(),
+            lhs.polynomial_size().0 as u32,
+            std::ptr::addr_of_mut!(mem_ptr),
+        );
+        cuda_glwe_wrapping_polynomial_mul_one_to_many_64(
+            stream.ptr[0],
+            stream.gpu_indexes[0].get(),
+            out.0.d_vec.as_mut_c_ptr(0),
+            lhs.0.d_vec.as_c_ptr(0),
+            mem_ptr,
+            rhs.as_c_ptr(0),
+            lhs.polynomial_size().0 as u32,
+            lhs.glwe_dimension().0 as u32,
+            (rhs.len() / lhs.polynomial_size().0) as u32,
+        );
+        cleanup_wrapping_polynomial_mul_one_to_many_64(
+            stream.ptr[0],
+            stream.gpu_indexes[0].get(),
+            mem_ptr,
+        )
+    }
+    stream.synchronize();
+}
+
+pub fn cuda_glwe_dot_product_with_clear_one_to_many<Scalar>(
+    lhs: &CudaGlweCiphertextList<Scalar>,
+    rhs: &CudaVec<Scalar>,
+    out: &mut CudaLweCiphertextList<Scalar>,
+    stream: &CudaStreams,
+) where
+    Scalar: UnsignedInteger + UnsignedTorus,
+{
+    assert_eq!(
+        rhs.len() % lhs.polynomial_size().0,
+        0,
+        "GLWE dot product rhs must have size a multiple of the polynomial size of the lhs"
+    );
+    let n_polys = rhs.len() / lhs.polynomial_size().0;
+    assert_eq!(
+        out.lwe_ciphertext_count().0,
+        n_polys,
+        "GLWE dot product output LWE list must have size equal to the number of clear polys"
+    );
+    assert_eq!(
+        lhs.glwe_ciphertext_count().0,
+        1,
+        "GLWE dot product implemented only for a single GLWE in the lhs list"
+    );
+
+    let mut glwe_list = CudaGlweCiphertextList::<Scalar>::new(
+        lhs.glwe_dimension(),
+        lhs.polynomial_size(),
+        GlweCiphertextCount(n_polys),
+        lhs.ciphertext_modulus(),
+        stream,
+    );
+
+    let nths: Vec<MonomialDegree> = (0usize..n_polys)
+        .map(|_i| MonomialDegree(lhs.polynomial_size().0 - 1))
+        .collect();
+
+    assert_eq!(nths.len(), n_polys, "Nths vector has the wrong size");
+
+    cuda_glwe_wrapping_polynomial_mul_one_to_many(lhs, rhs, &mut glwe_list, stream);
+    cuda_extract_lwe_samples_from_glwe_ciphertext_list(&glwe_list, out, nths.as_slice(), 1, stream);
+}

--- a/tfhe/src/core_crypto/gpu/algorithms/mod.rs
+++ b/tfhe/src/core_crypto/gpu/algorithms/mod.rs
@@ -1,6 +1,8 @@
+pub mod glwe_linear_algebra;
 pub mod glwe_sample_extraction;
 pub mod lwe_keyswitch;
 pub mod lwe_linear_algebra;
+
 pub mod lwe_multi_bit_programmable_bootstrapping;
 pub mod lwe_packing_keyswitch;
 pub mod lwe_programmable_bootstrapping;

--- a/tfhe/src/core_crypto/gpu/algorithms/test/glwe_dot_product_with_clear.rs
+++ b/tfhe/src/core_crypto/gpu/algorithms/test/glwe_dot_product_with_clear.rs
@@ -1,0 +1,356 @@
+use super::*;
+
+use crate::core_crypto::gpu::vec::{CudaVec, GpuIndex};
+use crate::core_crypto::gpu::CudaStreams;
+
+use crate::core_crypto::gpu::algorithms::glwe_linear_algebra::*;
+use crate::core_crypto::gpu::glwe_ciphertext_list::CudaGlweCiphertextList;
+use crate::core_crypto::prelude::polynomial_algorithms::polynomial_wrapping_mul;
+use crate::core_crypto::prelude::ContiguousEntityContainerMut;
+
+use rand::distributions::Uniform;
+use rand::Rng;
+
+pub fn encryption_delta<Scalar: UnsignedInteger>(
+    bits_reserved_for_computation: usize,
+    ciphertext_modulus: CiphertextModulus<Scalar>,
+) -> Scalar {
+    let modulus_for_computations = Scalar::ONE << bits_reserved_for_computation;
+    match ciphertext_modulus.kind() {
+        CiphertextModulusKind::Native => {
+            ((Scalar::ONE << (Scalar::BITS - 1)) / modulus_for_computations) << 1
+        }
+        CiphertextModulusKind::NonNativePowerOfTwo => {
+            let custom_mod = ciphertext_modulus
+                .get_custom_modulus_as_optional_scalar()
+                .unwrap();
+            custom_mod / modulus_for_computations
+        }
+        CiphertextModulusKind::Other => todo!("Only power of 2 moduli are supported"),
+    }
+}
+
+pub fn encode_data_for_encryption<Scalar, OutputCont>(
+    input: &[Scalar],
+    plaintext_list: &mut PlaintextList<OutputCont>,
+    bits_reserved_for_computation: usize,
+    ciphertext_modulus: CiphertextModulus<Scalar>,
+) where
+    Scalar: UnsignedInteger,
+    OutputCont: ContainerMut<Element = Scalar>,
+{
+    assert!(input.len() <= plaintext_list.entity_count());
+
+    let delta = encryption_delta(bits_reserved_for_computation, ciphertext_modulus);
+
+    for (plain, input) in plaintext_list.iter_mut().zip(input.iter()) {
+        *plain.0 = (*input) * delta;
+    }
+}
+
+pub fn decrypt_glwe<Scalar, InputCont, KeyCont>(
+    glwe_secret_key: &GlweSecretKey<KeyCont>,
+    glwe: &GlweCiphertext<InputCont>,
+    bits_reserved_for_computation: usize,
+) -> Vec<Scalar>
+where
+    Scalar: UnsignedTorus,
+    InputCont: Container<Element = Scalar>,
+    KeyCont: Container<Element = Scalar>,
+{
+    let mut decrypted = PlaintextList::new(Scalar::ZERO, PlaintextCount(glwe.polynomial_size().0));
+    decrypt_glwe_ciphertext(glwe_secret_key, glwe, &mut decrypted);
+
+    let mut decoded = vec![Scalar::ZERO; decrypted.plaintext_count().0];
+    let ciphertext_modulus = glwe.ciphertext_modulus();
+    let delta = encryption_delta(bits_reserved_for_computation, ciphertext_modulus);
+
+    let decomposer = SignedDecomposer::new(
+        DecompositionBaseLog(
+            bits_reserved_for_computation
+                + ciphertext_modulus
+                    .get_power_of_two_scaling_to_native_torus()
+                    .ilog2() as usize,
+        ),
+        DecompositionLevelCount(1),
+    );
+
+    let decryption_modulus = Scalar::ONE << bits_reserved_for_computation;
+
+    for (decoded_value, decrypted_value) in decoded.iter_mut().zip(decrypted.iter()) {
+        *decoded_value =
+            (decomposer.closest_representable(*decrypted_value.0) / delta) % decryption_modulus;
+
+        if *decoded_value >= decryption_modulus / Scalar::TWO {
+            *decoded_value = (decryption_modulus - *decoded_value).wrapping_neg();
+        }
+    }
+    decoded
+}
+
+pub fn decrypt_lwe<Scalar, InputCont, KeyCont>(
+    lwe_secret_key: &LweSecretKey<KeyCont>,
+    lwe: &LweCiphertext<InputCont>,
+    bits_reserved_for_computation: usize,
+) -> Scalar
+where
+    Scalar: UnsignedTorus,
+    InputCont: Container<Element = Scalar>,
+    KeyCont: Container<Element = Scalar>,
+{
+    let decrypted_value = decrypt_lwe_ciphertext(lwe_secret_key, lwe);
+
+    let ciphertext_modulus = lwe.ciphertext_modulus();
+    let delta = encryption_delta(bits_reserved_for_computation, ciphertext_modulus);
+
+    let decomposer = SignedDecomposer::new(
+        DecompositionBaseLog(
+            bits_reserved_for_computation
+                + ciphertext_modulus
+                    .get_power_of_two_scaling_to_native_torus()
+                    .ilog2() as usize,
+        ),
+        DecompositionLevelCount(1),
+    );
+
+    let decryption_modulus = Scalar::ONE << bits_reserved_for_computation;
+
+    let mut decoded_value =
+        (decomposer.closest_representable(decrypted_value.0) / delta) % decryption_modulus;
+
+    if decoded_value >= decryption_modulus / Scalar::TWO {
+        decoded_value = (decryption_modulus - decoded_value).wrapping_neg();
+    }
+
+    decoded_value
+}
+/// Test that a GLWE can be multiplied with a list of clear polynomials.
+/// This test does not add encryption noise to ensure deterministic
+/// results. The polynomials are stored in a single CudaVec on device.
+fn glwe_dot_product_with_clear<Scalar: UnsignedTorus + CastFrom<usize>>(
+    _params: ClassicTestParams<Scalar>,
+) {
+    let mut rng = rand::thread_rng();
+
+    let poly_size = 2 << rng.gen_range(8usize..12);
+    let n_polys_rhs = if rng.gen_range(0..2) == 0 {
+        poly_size
+    } else {
+        rng.gen_range(0..poly_size * 2)
+    };
+
+    let encryption_glwe_dimension = GlweDimension(1);
+    let glwe_size = encryption_glwe_dimension.to_glwe_size();
+    let polynomial_size = PolynomialSize(poly_size as usize);
+    let ciphertext_modulus = CiphertextModulus::new_native();
+    let glwe_noise_distribution = Gaussian::from_dispersion_parameter(StandardDev(0.0), 0.0);
+
+    let bits_reserved_for_computation = 27;
+
+    // This could be a method to generate a private key object
+    let mut seeder = new_seeder();
+    let seeder = seeder.as_mut();
+    let mut secret_rng = SecretRandomGenerator::<DefaultRandomGenerator>::new(seeder.seed());
+    let mut encryption_generator =
+        EncryptionRandomGenerator::<DefaultRandomGenerator>::new(seeder.seed(), seeder);
+
+    let glwe_secret_key = allocate_and_generate_new_binary_glwe_secret_key(
+        encryption_glwe_dimension,
+        polynomial_size,
+        &mut secret_rng,
+    );
+
+    // Generate list of polynomials
+    let clear_range: Vec<usize> = (0usize..(poly_size * n_polys_rhs)).collect();
+    let clear_polys: Vec<Scalar> = clear_range
+        .iter()
+        .map(|x| Scalar::cast_from(poly_size - 1 - x % poly_size))
+        .collect();
+
+    // Generate GLWE and list of polynomials
+    let mut glwe =
+        GlweCiphertext::new(Scalar::ZERO, glwe_size, polynomial_size, ciphertext_modulus);
+
+    let range = Uniform::new(0, 32);
+    let to_encrypt: Vec<usize> = (0usize..poly_size).map(|_| rng.sample(range)).collect();
+
+    let to_encrypt_vec: Vec<Scalar> = to_encrypt.iter().map(|&x| Scalar::cast_from(x)).collect();
+    let clear_poly_rhs = Polynomial::from_container(clear_polys[0..poly_size].to_vec());
+
+    // Encrypt GLWE
+    let mut plaintext_list = PlaintextList::new(
+        Scalar::ZERO,
+        PlaintextCount(glwe_secret_key.polynomial_size().0),
+    );
+
+    encode_data_for_encryption(
+        to_encrypt_vec.as_slice(),
+        &mut plaintext_list,
+        bits_reserved_for_computation,
+        ciphertext_modulus,
+    );
+
+    encrypt_glwe_ciphertext(
+        &glwe_secret_key,
+        &mut glwe,
+        &plaintext_list,
+        glwe_noise_distribution,
+        &mut encryption_generator,
+    );
+
+    // CPU polynomial product
+    // only a single GLWE vs poly product is computed as all the clear polys
+    // are the same
+    let mut out_cpu = GlweCiphertext::new(
+        Scalar::ZERO,
+        glwe.glwe_size(),
+        glwe.polynomial_size(),
+        glwe.ciphertext_modulus(),
+    );
+
+    for (mut out_poly, in_poly) in out_cpu
+        .as_mut_polynomial_list()
+        .iter_mut()
+        .zip(glwe.as_polynomial_list().iter())
+    {
+        polynomial_wrapping_mul(&mut out_poly, &in_poly, &clear_poly_rhs);
+    }
+
+    // GPU polynomial product
+    let gpu_index = 0;
+    let streams = CudaStreams::new_single_gpu(GpuIndex::new(gpu_index));
+
+    let d_input_glwe = CudaGlweCiphertextList::from_glwe_ciphertext(&glwe, &streams);
+
+    let mut d_output_lwe = CudaLweCiphertextList::<Scalar>::new(
+        LweDimension(poly_size),
+        LweCiphertextCount(n_polys_rhs),
+        ciphertext_modulus,
+        &streams,
+    );
+
+    assert_eq!(d_output_lwe.0.d_vec.len(), n_polys_rhs * (poly_size + 1));
+
+    unsafe {
+        let clear_gpu = CudaVec::from_cpu_async(clear_polys.as_ref(), &streams, 0);
+
+        cuda_glwe_dot_product_with_clear_one_to_many(
+            &d_input_glwe,
+            &clear_gpu,
+            &mut d_output_lwe,
+            &streams,
+        );
+    }
+
+    let output_lwe_list = d_output_lwe.to_lwe_ciphertext_list(&streams);
+
+    let result_lwe = output_lwe_list.get(0);
+
+    let glwe_secret_key_as_lwe_secret_key = glwe_secret_key.as_lwe_secret_key();
+
+    // On CPU we decrypt the entire GLWE and extract the Nth degree value in the clear
+    // on GPU we use GLWE sample extract to get the dot product result
+    let decrypted_result_gpu = decrypt_lwe(
+        &glwe_secret_key_as_lwe_secret_key,
+        &result_lwe,
+        bits_reserved_for_computation,
+    );
+    let decrypted_result_cpu =
+        decrypt_glwe(&glwe_secret_key, &out_cpu, bits_reserved_for_computation);
+
+    let dot_product_gpu = decrypted_result_gpu;
+    let dot_product_cpu = decrypted_result_cpu.last().unwrap();
+
+    assert_eq!(
+        dot_product_gpu, *dot_product_cpu,
+        "Error multiplying GLWE with polysize {poly_size} with {n_polys_rhs} clear polys",
+    );
+}
+
+use crate::core_crypto::gpu::lwe_ciphertext_list::CudaLweCiphertextList;
+
+/// Test direct modular polynomial multiplication on GPU.
+/// This test does not encrypt anything, it just checks
+/// that one lhs polynomial can be multiplied with many rhs polynomials,
+/// and finally checks that all coefficients in the GPU result
+/// match those in the CPU result
+fn poly_product_with_clear<Scalar: UnsignedTorus + CastFrom<usize>>(
+    _params: ClassicTestParams<Scalar>,
+) {
+    let mut rng = rand::thread_rng();
+    let poly_size = 2 << rng.gen_range(8usize..12);
+    let n_polys_rhs = if rng.gen_range(0..2) == 0 {
+        poly_size
+    } else {
+        rng.gen_range(0..poly_size * 2)
+    };
+    let polynomial_size = PolynomialSize(poly_size as usize);
+
+    let range = Uniform::new(0, 32);
+    let clear_range_lhs: Vec<usize> = (0usize..poly_size).map(|_| rng.sample(range)).collect();
+
+    let clear_lhs: Vec<Scalar> = clear_range_lhs
+        .iter()
+        .map(|&x| Scalar::cast_from(x))
+        .collect();
+
+    let clear_range_rhs: Vec<usize> = (0usize..(poly_size * n_polys_rhs)).collect();
+    let clear_rhs: Vec<Scalar> = clear_range_rhs
+        .iter()
+        .map(|x| Scalar::cast_from(x % poly_size))
+        .collect();
+
+    let poly_lhs = Polynomial::from_container(clear_lhs);
+    let poly_list_rhs = PolynomialList::from_container(clear_rhs, polynomial_size);
+    let mut result_reference_cpu = PolynomialList::new(
+        Scalar::ZERO,
+        polynomial_size,
+        poly_list_rhs.polynomial_count(),
+    );
+
+    for (rhs, mut out) in poly_list_rhs.iter().zip(result_reference_cpu.iter_mut()) {
+        polynomial_wrapping_mul(&mut out, &poly_lhs, &rhs);
+    }
+
+    let mut cpu_results = PolynomialList::new(
+        Scalar::ZERO,
+        polynomial_size,
+        poly_list_rhs.polynomial_count(),
+    );
+
+    let gpu_index = 0;
+    let streams = CudaStreams::new_single_gpu(GpuIndex::new(gpu_index));
+
+    unsafe {
+        let clear_gpu_lhs = CudaVec::from_cpu_async(poly_lhs.as_ref(), &streams, 0);
+        let clear_gpu_rhs = CudaVec::from_cpu_async(poly_list_rhs.as_ref(), &streams, 0);
+        let mut clear_result_gpu = CudaVec::new(result_reference_cpu.as_ref().len(), &streams, 0);
+
+        cuda_wrapping_polynomial_mul_one_to_many(
+            &clear_gpu_lhs, //d_input_glwe.0.d_vec,
+            &clear_gpu_rhs,
+            &mut clear_result_gpu,
+            &streams,
+        );
+
+        clear_result_gpu.copy_to_cpu_async(cpu_results.as_mut(), &streams, 0);
+        streams.synchronize();
+    }
+
+    assert_eq!(
+        cpu_results.polynomial_count().0,
+        result_reference_cpu.polynomial_count().0
+    );
+
+    let cnt = cpu_results
+        .as_ref()
+        .iter()
+        .zip(result_reference_cpu.get(0).iter())
+        .filter(|(x, y)| x != y)
+        .count();
+
+    assert_eq!(cnt, 0);
+}
+
+create_gpu_parameterized_test!(glwe_dot_product_with_clear);
+create_gpu_parameterized_test!(poly_product_with_clear);

--- a/tfhe/src/core_crypto/gpu/algorithms/test/mod.rs
+++ b/tfhe/src/core_crypto/gpu/algorithms/test/mod.rs
@@ -2,6 +2,7 @@ use crate::core_crypto::algorithms::test::*;
 use crate::core_crypto::prelude::*;
 
 mod fft;
+mod glwe_dot_product_with_clear;
 mod glwe_sample_extraction;
 mod lwe_keyswitch;
 mod lwe_linear_algebra;


### PR DESCRIPTION
To support encrypted GLWE  x clear matrix product, all polys of the GLWE are multiplied with the clear matrix. For each poly of the GLWE, this PR builds a circulant matrix that is multiplied with the clear matrix to obtain the polynomial product. Sample N of this product contains the matrix product of the original clear vector that was encrypted and the clear matrix. 

Now, with `make test_core_crypto_gpu` there are two new tests:

```
test core_crypto::gpu::algorithms::test::glwe_dot_product_with_clear::test_gpu_glwe_dot_product_with_clear_test_params_4_bits_native_u64 ... ok

test core_crypto::gpu::algorithms::test::glwe_dot_product_with_clear::test_gpu_poly_product_with_clear_test_params_4_bits_native_u64 ... ok

```

- Adds a Cargo config to enable GPU multi-architecture builds