### PR TITLE
fix(integer): rotations/shifts < 2 blocks

### DIFF
--- a/tfhe/src/integer/server_key/radix_parallel/block_shift.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/block_shift.rs
@@ -61,7 +61,13 @@ impl ServerKey {
         T: IntegerRadixCiphertext,
     {
         if d_range.is_empty() {
-            return ct.clone();
+            let mut result = ct.clone();
+            result
+                .blocks_mut()
+                .par_iter_mut()
+                .filter(|b| b.noise_level > NoiseLevel::NOMINAL)
+                .for_each(|block| self.key.message_extract_assign(block));
+            return result;
         }
 
         assert!(

--- a/tfhe/src/integer/server_key/radix_parallel/tests_cases_unsigned.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_cases_unsigned.rs
@@ -7,7 +7,7 @@ use crate::integer::block_decomposition::BlockDecomposer;
 use crate::integer::ciphertext::boolean_value::BooleanBlock;
 use crate::integer::keycache::KEY_CACHE;
 use crate::integer::{
-    IntegerKeyKind, IntegerRadixCiphertext, RadixCiphertext, RadixClientKey, ServerKey,
+    ClientKey, IntegerKeyKind, IntegerRadixCiphertext, RadixCiphertext, RadixClientKey, ServerKey,
 };
 use crate::shortint::parameters::*;
 use rand::Rng;
@@ -418,55 +418,77 @@ where
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, &'a RadixCiphertext), RadixCiphertext>,
 {
     let param = param.into();
-    let nb_tests = nb_tests_for_params(param);
+    let nb_tests = nb_tests_smaller_for_params(param);
     let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let sks = Arc::new(sks);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
     let mut rng = rand::thread_rng();
 
-    // message_modulus^vec_length
-    let modulus = cks.parameters().message_modulus().0.pow(NB_CTXT as u32);
-    assert!(modulus.is_power_of_two());
-    let nb_bits = modulus.ilog2();
-
     executor.setup(&cks, sks);
 
-    for _ in 0..nb_tests {
-        let clear = rng.gen::<u64>() % modulus;
-        let clear_shift = rng.gen::<u32>();
+    let cks: ClientKey = cks.into();
 
-        let ct = cks.encrypt(clear);
+    for num_blocks in 1..MAX_NB_CTXT {
+        // message_modulus^vec_length
+        let modulus = cks.parameters().message_modulus().0.pow(num_blocks as u32);
+        assert!(modulus.is_power_of_two());
+        let nb_bits = modulus.ilog2();
+        for _ in 0..nb_tests {
+            let clear = rng.gen::<u64>() % modulus;
+            let clear_shift = rng.gen::<u32>();
 
-        // case when 0 <= shift < nb_bits
-        {
-            let clear_shift = clear_shift % nb_bits;
-            let shift = cks.encrypt(clear_shift as u64);
+            let ct = cks.encrypt_radix(clear, num_blocks);
 
-            let encrypted_result = executor.execute((&ct, &shift));
-            let decrypted_result: u64 = cks.decrypt(&encrypted_result);
-            assert_eq!((clear << clear_shift) % modulus, decrypted_result);
-        }
+            // case when 0 <= shift < nb_bits
+            {
+                let clear_shift = clear_shift % nb_bits;
+                let shift = cks.encrypt_radix(clear_shift as u64, num_blocks);
 
-        // case when shift >= nb_bits
-        {
-            let clear_shift = clear_shift.saturating_add(nb_bits);
-            let shift = cks.encrypt(clear_shift as u64);
-
-            let encrypted_result = executor.execute((&ct, &shift));
-            let decrypted_result: u64 = cks.decrypt(&encrypted_result);
-            // When nb_bits is not a power of two
-            // then the behaviour is not the same
-            let mut nb_bits = modulus.ilog2();
-            if !nb_bits.is_power_of_two() {
-                nb_bits = nb_bits.next_power_of_two();
+                let encrypted_result = executor.execute((&ct, &shift));
+                for (i, b) in encrypted_result.blocks.iter().enumerate() {
+                    if b.noise_level > NoiseLevel::NOMINAL {
+                        println!("{i}: {:?}", b.noise_level);
+                    }
+                }
+                assert!(
+                    encrypted_result
+                        .blocks
+                        .iter()
+                        .all(|b| b.noise_level <= NoiseLevel::NOMINAL),
+                    "Expected all blocks to have at most NOMINAL noise level"
+                );
+                let decrypted_result: u64 = cks.decrypt_radix(&encrypted_result);
+                assert_eq!((clear << clear_shift) % modulus, decrypted_result);
             }
-            // We mimic wrapping_shl manually as we use a bigger type
-            // than the nb_bits we actually simulate in this test
-            assert_eq!(
-                (clear << (clear_shift % nb_bits)) % modulus,
-                decrypted_result
-            );
+
+            // case when shift >= nb_bits
+            {
+                let clear_shift = rng.gen_range(nb_bits..modulus as u32);
+                let shift = cks.encrypt_radix(clear_shift as u64, num_blocks);
+
+                let encrypted_result = executor.execute((&ct, &shift));
+                assert!(
+                    encrypted_result
+                        .blocks
+                        .iter()
+                        .all(|b| b.noise_level <= NoiseLevel::NOMINAL),
+                    "Expected all blocks to have at most NOMINAL noise level"
+                );
+                let decrypted_result: u64 = cks.decrypt_radix(&encrypted_result);
+                // When nb_bits is not a power of two
+                // then the behaviour is not the same
+                let mut nb_bits = modulus.ilog2();
+                if !nb_bits.is_power_of_two() {
+                    nb_bits = nb_bits.next_power_of_two();
+                }
+                // We mimic wrapping_shl manually as we use a bigger type
+                // than the nb_bits we actually simulate in this test
+                assert_eq!(
+                    (clear << (clear_shift % nb_bits)) % modulus,
+                    decrypted_result
+                );
+            }
         }
     }
 }
@@ -477,54 +499,71 @@ where
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, &'a RadixCiphertext), RadixCiphertext>,
 {
     let param = param.into();
-    let nb_tests = nb_tests_for_params(param);
+    let nb_tests = nb_tests_smaller_for_params(param);
     let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let sks = Arc::new(sks);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
     let mut rng = rand::thread_rng();
 
-    // message_modulus^vec_length
-    let modulus = cks.parameters().message_modulus().0.pow(NB_CTXT as u32);
-    assert!(modulus.is_power_of_two());
-    let nb_bits = modulus.ilog2();
-
     executor.setup(&cks, sks);
 
-    for _ in 0..nb_tests {
-        let clear = rng.gen::<u64>() % modulus;
-        let clear_shift = rng.gen::<u32>();
+    let cks: ClientKey = cks.into();
 
-        let ct = cks.encrypt(clear);
+    for num_blocks in 1..MAX_NB_CTXT {
+        // message_modulus^vec_length
+        let modulus = cks.parameters().message_modulus().0.pow(num_blocks as u32);
+        assert!(modulus.is_power_of_two());
+        let nb_bits = modulus.ilog2();
+        for _ in 0..nb_tests {
+            let clear = rng.gen::<u64>() % modulus;
+            let clear_shift = rng.gen::<u32>();
 
-        // case when 0 <= shift < nb_bits
-        {
-            let clear_shift = clear_shift % nb_bits;
-            let shift = cks.encrypt(clear_shift as u64);
-            let encrypted_result = executor.execute((&ct, &shift));
-            let decrypted_result: u64 = cks.decrypt(&encrypted_result);
-            assert_eq!((clear >> clear_shift) % modulus, decrypted_result);
-        }
+            let ct = cks.encrypt_radix(clear, num_blocks);
 
-        // case when shift >= nb_bits
-        {
-            let clear_shift = clear_shift.saturating_add(nb_bits);
-            let shift = cks.encrypt(clear_shift as u64);
-            let encrypted_result = executor.execute((&ct, &shift));
-            let decrypted_result: u64 = cks.decrypt(&encrypted_result);
-
-            // When nb_bits is not a power of two
-            // then the behaviour is not the same
-            let mut nb_bits = modulus.ilog2();
-            if !nb_bits.is_power_of_two() {
-                nb_bits = nb_bits.next_power_of_two();
+            // case when 0 <= shift < nb_bits
+            {
+                let clear_shift = clear_shift % nb_bits;
+                let shift = cks.encrypt_radix(clear_shift as u64, num_blocks);
+                let encrypted_result = executor.execute((&ct, &shift));
+                assert!(
+                    encrypted_result
+                        .blocks
+                        .iter()
+                        .all(|b| b.noise_level <= NoiseLevel::NOMINAL),
+                    "Expected all blocks to have at most NOMINAL noise level"
+                );
+                let decrypted_result: u64 = cks.decrypt_radix(&encrypted_result);
+                assert_eq!((clear >> clear_shift) % modulus, decrypted_result);
             }
-            // We mimic wrapping_shr manually as we use a bigger type
-            // than the nb_bits we actually simulate in this test
-            assert_eq!(
-                (clear >> (clear_shift % nb_bits)) % modulus,
-                decrypted_result
-            );
+
+            // case when shift >= nb_bits
+            {
+                let clear_shift = rng.gen_range(nb_bits..modulus as u32);
+                let shift = cks.encrypt_radix(clear_shift as u64, num_blocks);
+                let encrypted_result = executor.execute((&ct, &shift));
+                assert!(
+                    encrypted_result
+                        .blocks
+                        .iter()
+                        .all(|b| b.noise_level <= NoiseLevel::NOMINAL),
+                    "Expected all blocks to have at most NOMINAL noise level"
+                );
+                let decrypted_result: u64 = cks.decrypt_radix(&encrypted_result);
+
+                // When nb_bits is not a power of two
+                // then the behaviour is not the same
+                let mut nb_bits = modulus.ilog2();
+                if !nb_bits.is_power_of_two() {
+                    nb_bits = nb_bits.next_power_of_two();
+                }
+                // We mimic wrapping_shr manually as we use a bigger type
+                // than the nb_bits we actually simulate in this test
+                assert_eq!(
+                    (clear >> (clear_shift % nb_bits)) % modulus,
+                    decrypted_result
+                );
+            }
         }
     }
 }
@@ -535,51 +574,68 @@ where
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, &'a RadixCiphertext), RadixCiphertext>,
 {
     let param = param.into();
-    let nb_tests = nb_tests_for_params(param);
+    let nb_tests = nb_tests_smaller_for_params(param);
     let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let sks = Arc::new(sks);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
     let mut rng = rand::thread_rng();
 
-    // message_modulus^vec_length
-    let modulus = cks.parameters().message_modulus().0.pow(NB_CTXT as u32);
-    assert!(modulus.is_power_of_two());
-    let nb_bits = modulus.ilog2();
-
     executor.setup(&cks, sks);
 
-    for _ in 0..nb_tests {
-        let clear = rng.gen::<u64>() % modulus;
-        let clear_shift = rng.gen::<u32>();
+    let cks: ClientKey = cks.into();
 
-        let ct = cks.encrypt(clear);
+    for num_blocks in 1..MAX_NB_CTXT {
+        // message_modulus^vec_length
+        let modulus = cks.parameters().message_modulus().0.pow(num_blocks as u32);
+        assert!(modulus.is_power_of_two());
+        let nb_bits = modulus.ilog2();
+        for _ in 0..nb_tests {
+            let clear = rng.gen::<u64>() % modulus;
+            let clear_shift = rng.gen::<u32>();
 
-        // case when 0 <= rotate < nb_bits
-        {
-            let clear_shift = clear_shift % nb_bits;
-            let shift = cks.encrypt(clear_shift as u64);
-            let encrypted_result = executor.execute((&ct, &shift));
-            let decrypted_result: u64 = cks.decrypt(&encrypted_result);
-            let expected = rotate_left_helper(clear, clear_shift, nb_bits);
-            assert_eq!(expected, decrypted_result);
-        }
+            let ct = cks.encrypt_radix(clear, num_blocks);
 
-        // case when shift >= nb_bits
-        {
-            let clear_shift = clear_shift.saturating_add(nb_bits);
-            let shift = cks.encrypt(clear_shift as u64);
-            let encrypted_result = executor.execute((&ct, &shift));
-            let decrypted_result: u64 = cks.decrypt(&encrypted_result);
-            // When nb_bits is not a power of two
-            // then the behaviour is not the same
-            let true_nb_bits = nb_bits;
-            let mut nb_bits = nb_bits;
-            if !nb_bits.is_power_of_two() {
-                nb_bits = nb_bits.next_power_of_two();
+            // case when 0 <= rotate < nb_bits
+            {
+                let clear_shift = clear_shift % nb_bits;
+                let shift = cks.encrypt_radix(clear_shift as u64, num_blocks);
+                let encrypted_result = executor.execute((&ct, &shift));
+                let decrypted_result: u64 = cks.decrypt_radix(&encrypted_result);
+                assert!(
+                    encrypted_result
+                        .blocks
+                        .iter()
+                        .all(|b| b.noise_level <= NoiseLevel::NOMINAL),
+                    "Expected all blocks to have at most NOMINAL noise level"
+                );
+                let expected = rotate_left_helper(clear, clear_shift, nb_bits);
+                assert_eq!(expected, decrypted_result);
             }
-            let expected = rotate_left_helper(clear, clear_shift % nb_bits, true_nb_bits);
-            assert_eq!(expected, decrypted_result);
+
+            // case when shift >= nb_bits
+            {
+                let clear_shift = rng.gen_range(nb_bits..modulus as u32);
+                let shift = cks.encrypt_radix(clear_shift as u64, num_blocks);
+                let encrypted_result = executor.execute((&ct, &shift));
+                assert!(
+                    encrypted_result
+                        .blocks
+                        .iter()
+                        .all(|b| b.noise_level <= NoiseLevel::NOMINAL),
+                    "Expected all blocks to have at most NOMINAL noise level"
+                );
+                let decrypted_result: u64 = cks.decrypt_radix(&encrypted_result);
+                // When nb_bits is not a power of two
+                // then the behaviour is not the same
+                let true_nb_bits = nb_bits;
+                let mut nb_bits = nb_bits;
+                if !nb_bits.is_power_of_two() {
+                    nb_bits = nb_bits.next_power_of_two();
+                }
+                let expected = rotate_left_helper(clear, clear_shift % nb_bits, true_nb_bits);
+                assert_eq!(expected, decrypted_result);
+            }
         }
     }
 }
@@ -590,51 +646,68 @@ where
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, &'a RadixCiphertext), RadixCiphertext>,
 {
     let param = param.into();
-    let nb_tests = nb_tests_for_params(param);
+    let nb_tests = nb_tests_smaller_for_params(param);
     let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
     let sks = Arc::new(sks);
     let cks = RadixClientKey::from((cks, NB_CTXT));
 
     let mut rng = rand::thread_rng();
 
-    // message_modulus^vec_length
-    let modulus = cks.parameters().message_modulus().0.pow(NB_CTXT as u32);
-    assert!(modulus.is_power_of_two());
-    let nb_bits = modulus.ilog2();
-
     executor.setup(&cks, sks);
 
-    for _ in 0..nb_tests {
-        let clear = rng.gen::<u64>() % modulus;
-        let clear_shift = rng.gen::<u32>();
+    let cks: ClientKey = cks.into();
 
-        let ct = cks.encrypt(clear);
+    for num_blocks in 1..MAX_NB_CTXT {
+        // message_modulus^vec_length
+        let modulus = cks.parameters().message_modulus().0.pow(num_blocks as u32);
+        assert!(modulus.is_power_of_two());
+        let nb_bits = modulus.ilog2();
+        for _ in 0..nb_tests {
+            let clear = rng.gen::<u64>() % modulus;
+            let clear_shift = rng.gen::<u32>();
 
-        // case when 0 <= rotate < nb_bits
-        {
-            let clear_shift = clear_shift % nb_bits;
-            let shift = cks.encrypt(clear_shift as u64);
-            let encrypted_result = executor.execute((&ct, &shift));
-            let decrypted_result: u64 = cks.decrypt(&encrypted_result);
-            let expected = rotate_right_helper(clear, clear_shift, nb_bits);
-            assert_eq!(expected, decrypted_result);
-        }
+            let ct = cks.encrypt_radix(clear, num_blocks);
 
-        // case when shift >= nb_bits
-        {
-            let clear_shift = clear_shift.saturating_add(nb_bits);
-            let shift = cks.encrypt(clear_shift as u64);
-            let encrypted_result = executor.execute((&ct, &shift));
-            let decrypted_result: u64 = cks.decrypt(&encrypted_result);
-            // When nb_bits is not a power of two
-            // then the behaviour is not the same
-            let true_nb_bits = nb_bits;
-            let mut nb_bits = nb_bits;
-            if !nb_bits.is_power_of_two() {
-                nb_bits = nb_bits.next_power_of_two();
+            // case when 0 <= rotate < nb_bits
+            {
+                let clear_shift = clear_shift % nb_bits;
+                let shift = cks.encrypt_radix(clear_shift as u64, num_blocks);
+                let encrypted_result = executor.execute((&ct, &shift));
+                assert!(
+                    encrypted_result
+                        .blocks
+                        .iter()
+                        .all(|b| b.noise_level <= NoiseLevel::NOMINAL),
+                    "Expected all blocks to have at most NOMINAL noise level"
+                );
+                let decrypted_result: u64 = cks.decrypt_radix(&encrypted_result);
+                let expected = rotate_right_helper(clear, clear_shift, nb_bits);
+                assert_eq!(expected, decrypted_result);
             }
-            let expected = rotate_right_helper(clear, clear_shift % nb_bits, true_nb_bits);
-            assert_eq!(expected, decrypted_result);
+
+            // case when shift >= nb_bits
+            {
+                let clear_shift = rng.gen_range(nb_bits..modulus as u32);
+                let shift = cks.encrypt_radix(clear_shift as u64, num_blocks);
+                let encrypted_result = executor.execute((&ct, &shift));
+                assert!(
+                    encrypted_result
+                        .blocks
+                        .iter()
+                        .all(|b| b.noise_level <= NoiseLevel::NOMINAL),
+                    "Expected all blocks to have at most NOMINAL noise level"
+                );
+                let decrypted_result: u64 = cks.decrypt_radix(&encrypted_result);
+                // When nb_bits is not a power of two
+                // then the behaviour is not the same
+                let true_nb_bits = nb_bits;
+                let mut nb_bits = nb_bits;
+                if !nb_bits.is_power_of_two() {
+                    nb_bits = nb_bits.next_power_of_two();
+                }
+                let expected = rotate_right_helper(clear, clear_shift % nb_bits, true_nb_bits);
+                assert_eq!(expected, decrypted_result);
+            }
         }
     }
 }


### PR DESCRIPTION
This commit fixes a few bugs

* The shift/rotate functions used when blocks encrypt a number of bits that is a power of 2 was causing a panic when working on one block.
  - Also, when the number of blocks was low (e.g 2 blocks with 2_2 params) a noise cleaning step was wrongly skipped

* The function used when blocks encrypt non power of 2 number of bits also had a problem

The test have been updated to test with different block sizes and check the noise level

Overall these bugs only affected low block counts (e.g FheUint2, FheUint4) ciphertexts

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/2041)
<!-- Reviewable:end -->
