### PR TITLE
chore(gpu): fix long run tests ranges

### DIFF
--- a/tfhe/src/integer/server_key/radix_parallel/tests_long_run/test_random_op_sequence.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_long_run/test_random_op_sequence.rs
@@ -519,26 +519,26 @@ pub(crate) fn random_op_sequence_test<P>(
         + div_rem_op.len()
         + scalar_div_rem_op.len()
         + log2_ops.len();
+    println!("Total num ops {total_num_ops}");
 
     let binary_ops_range = 0..binary_ops.len();
-    let unary_ops_range = binary_ops_range.end..binary_ops_range.len() + unary_ops.len();
+    let unary_ops_range = binary_ops_range.end..binary_ops_range.end + unary_ops.len();
     let scalar_binary_ops_range =
-        unary_ops_range.end..unary_ops_range.len() + scalar_binary_ops.len();
+        unary_ops_range.end..unary_ops_range.end + scalar_binary_ops.len();
     let overflowing_ops_range =
-        scalar_binary_ops_range.end..scalar_binary_ops_range.len() + overflowing_ops.len();
+        scalar_binary_ops_range.end..scalar_binary_ops_range.end + overflowing_ops.len();
     let scalar_overflowing_ops_range =
-        overflowing_ops_range.end..overflowing_ops_range.len() + scalar_overflowing_ops.len();
+        overflowing_ops_range.end..overflowing_ops_range.end + scalar_overflowing_ops.len();
     let comparison_ops_range =
-        scalar_overflowing_ops_range.end..scalar_overflowing_ops_range.len() + comparison_ops.len();
+        scalar_overflowing_ops_range.end..scalar_overflowing_ops_range.end + comparison_ops.len();
     let scalar_comparison_ops_range =
-        comparison_ops_range.end..comparison_ops_range.len() + scalar_comparison_ops.len();
+        comparison_ops_range.end..comparison_ops_range.end + scalar_comparison_ops.len();
     let select_op_range =
-        scalar_comparison_ops_range.end..scalar_comparison_ops_range.len() + select_op.len();
-    let div_rem_op_range = select_op_range.end..select_op_range.len() + div_rem_op.len();
+        scalar_comparison_ops_range.end..scalar_comparison_ops_range.end + select_op.len();
+    let div_rem_op_range = select_op_range.end..select_op_range.end + div_rem_op.len();
     let scalar_div_rem_op_range =
-        div_rem_op_range.end..div_rem_op_range.len() + scalar_div_rem_op.len();
-    let log2_ops_range =
-        scalar_div_rem_op_range.end..scalar_div_rem_op_range.len() + log2_ops.len();
+        div_rem_op_range.end..div_rem_op_range.end + scalar_div_rem_op.len();
+    let log2_ops_range = scalar_div_rem_op_range.end..scalar_div_rem_op_range.end + log2_ops.len();
 
     let mut clear_left_vec: Vec<u64> = (0..total_num_ops)
         .map(|_| rng.gen()) // Generate random u64 values

--- a/tfhe/src/integer/server_key/radix_parallel/tests_long_run/test_signed_random_op_sequence.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_long_run/test_signed_random_op_sequence.rs
@@ -612,27 +612,26 @@ pub(crate) fn signed_random_op_sequence_test<P>(
         + rotate_shift_ops.len()
         + scalar_rotate_shift_ops.len();
     let binary_ops_range = 0..binary_ops.len();
-    let unary_ops_range = binary_ops_range.end..binary_ops_range.len() + unary_ops.len();
+    let unary_ops_range = binary_ops_range.end..binary_ops_range.end + unary_ops.len();
     let scalar_binary_ops_range =
-        unary_ops_range.end..unary_ops_range.len() + scalar_binary_ops.len();
+        unary_ops_range.end..unary_ops_range.end + scalar_binary_ops.len();
     let overflowing_ops_range =
-        scalar_binary_ops_range.end..scalar_binary_ops_range.len() + overflowing_ops.len();
+        scalar_binary_ops_range.end..scalar_binary_ops_range.end + overflowing_ops.len();
     let scalar_overflowing_ops_range =
-        overflowing_ops_range.end..overflowing_ops_range.len() + scalar_overflowing_ops.len();
+        overflowing_ops_range.end..overflowing_ops_range.end + scalar_overflowing_ops.len();
     let comparison_ops_range =
-        scalar_overflowing_ops_range.end..scalar_overflowing_ops_range.len() + comparison_ops.len();
+        scalar_overflowing_ops_range.end..scalar_overflowing_ops_range.end + comparison_ops.len();
     let scalar_comparison_ops_range =
-        comparison_ops_range.end..comparison_ops_range.len() + scalar_comparison_ops.len();
+        comparison_ops_range.end..comparison_ops_range.end + scalar_comparison_ops.len();
     let select_op_range =
-        scalar_comparison_ops_range.end..scalar_comparison_ops_range.len() + select_op.len();
-    let div_rem_op_range = select_op_range.end..select_op_range.len() + div_rem_op.len();
+        scalar_comparison_ops_range.end..scalar_comparison_ops_range.end + select_op.len();
+    let div_rem_op_range = select_op_range.end..select_op_range.end + div_rem_op.len();
     let scalar_div_rem_op_range =
-        div_rem_op_range.end..div_rem_op_range.len() + scalar_div_rem_op.len();
-    let log2_ops_range =
-        scalar_div_rem_op_range.end..scalar_div_rem_op_range.len() + log2_ops.len();
-    let rotate_shift_ops_range = log2_ops_range.end..log2_ops_range.len() + rotate_shift_ops.len();
+        div_rem_op_range.end..div_rem_op_range.end + scalar_div_rem_op.len();
+    let log2_ops_range = scalar_div_rem_op_range.end..scalar_div_rem_op_range.end + log2_ops.len();
+    let rotate_shift_ops_range = log2_ops_range.end..log2_ops_range.end + rotate_shift_ops.len();
     let scalar_rotate_shift_ops_range =
-        rotate_shift_ops_range.end..rotate_shift_ops_range.len() + scalar_rotate_shift_ops.len();
+        rotate_shift_ops_range.end..rotate_shift_ops_range.end + scalar_rotate_shift_ops.len();
     let mut clear_left_vec: Vec<i64> = (0..total_num_ops)
         .map(|_| rng.gen()) // Generate random i64 values
         .collect();


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description

The operations ranges were computed incorrectly in signed & unsigned long run tests which led to only binary/unary ops being triggered.

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
