### PR TITLE
chore: homogenize conformance parameters

### DIFF
--- a/tfhe/src/core_crypto/entities/compressed_modulus_switched_glwe_ciphertext.rs
+++ b/tfhe/src/core_crypto/entities/compressed_modulus_switched_glwe_ciphertext.rs
@@ -195,12 +195,9 @@ impl<Scalar: UnsignedTorus> CompressedModulusSwitchedGlweCiphertext<Scalar> {
 impl<Scalar: UnsignedInteger> ParameterSetConformant
     for CompressedModulusSwitchedGlweCiphertext<Scalar>
 {
-    type ParameterSet = GlweCiphertextConformanceParameters<Scalar>;
+    type ParameterSet = GlweCiphertextConformanceParams<Scalar>;
 
-    fn is_conformant(
-        &self,
-        lwe_ct_parameters: &GlweCiphertextConformanceParameters<Scalar>,
-    ) -> bool {
+    fn is_conformant(&self, lwe_ct_parameters: &GlweCiphertextConformanceParams<Scalar>) -> bool {
         let Self {
             packed_integers,
             glwe_dimension,

--- a/tfhe/src/core_crypto/entities/compressed_modulus_switched_lwe_ciphertext.rs
+++ b/tfhe/src/core_crypto/entities/compressed_modulus_switched_lwe_ciphertext.rs
@@ -144,9 +144,9 @@ impl<Scalar: UnsignedTorus> CompressedModulusSwitchedLweCiphertext<Scalar> {
 impl<Scalar: UnsignedInteger> ParameterSetConformant
     for CompressedModulusSwitchedLweCiphertext<Scalar>
 {
-    type ParameterSet = LweCiphertextParameters<Scalar>;
+    type ParameterSet = LweCiphertextConformanceParams<Scalar>;
 
-    fn is_conformant(&self, lwe_ct_parameters: &LweCiphertextParameters<Scalar>) -> bool {
+    fn is_conformant(&self, lwe_ct_parameters: &LweCiphertextConformanceParams<Scalar>) -> bool {
         let Self {
             packed_integers,
             lwe_dimension,

--- a/tfhe/src/core_crypto/entities/compressed_modulus_switched_multi_bit_lwe_ciphertext.rs
+++ b/tfhe/src/core_crypto/entities/compressed_modulus_switched_multi_bit_lwe_ciphertext.rs
@@ -402,9 +402,9 @@ impl MultiBitModulusSwitchedCt for FromCompressionMultiBitModulusSwitchedCt {
 impl<Scalar: UnsignedInteger + CastInto<usize> + CastFrom<usize>> ParameterSetConformant
     for CompressedModulusSwitchedMultiBitLweCiphertext<Scalar>
 {
-    type ParameterSet = LweCiphertextParameters<Scalar>;
+    type ParameterSet = LweCiphertextConformanceParams<Scalar>;
 
-    fn is_conformant(&self, lwe_ct_parameters: &LweCiphertextParameters<Scalar>) -> bool {
+    fn is_conformant(&self, lwe_ct_parameters: &LweCiphertextConformanceParams<Scalar>) -> bool {
         let Self {
             body,
             packed_mask,

--- a/tfhe/src/core_crypto/entities/glwe_ciphertext.rs
+++ b/tfhe/src/core_crypto/entities/glwe_ciphertext.rs
@@ -633,7 +633,7 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> CreateFrom<C> for 
 /// Can be used on a server to check if client inputs are well formed
 /// before running a computation on them
 #[derive(Copy, Clone)]
-pub struct GlweCiphertextConformanceParameters<T: UnsignedInteger> {
+pub struct GlweCiphertextConformanceParams<T: UnsignedInteger> {
     pub glwe_dim: GlweDimension,
     pub polynomial_size: PolynomialSize,
     pub ct_modulus: CiphertextModulus<T>,
@@ -643,11 +643,11 @@ impl<C: Container> ParameterSetConformant for GlweCiphertext<C>
 where
     C::Element: UnsignedInteger,
 {
-    type ParameterSet = GlweCiphertextConformanceParameters<C::Element>;
+    type ParameterSet = GlweCiphertextConformanceParams<C::Element>;
 
     fn is_conformant(
         &self,
-        glwe_ct_parameters: &GlweCiphertextConformanceParameters<C::Element>,
+        glwe_ct_parameters: &GlweCiphertextConformanceParams<C::Element>,
     ) -> bool {
         let Self {
             data,

--- a/tfhe/src/core_crypto/entities/lwe_ciphertext.rs
+++ b/tfhe/src/core_crypto/entities/lwe_ciphertext.rs
@@ -750,7 +750,7 @@ pub type LweCiphertextMutView<'data, Scalar> = LweCiphertext<&'data mut [Scalar]
 /// Can be used on a server to check if client inputs are well formed
 /// before running a computation on them
 #[derive(Copy, Clone)]
-pub struct LweCiphertextParameters<T: UnsignedInteger> {
+pub struct LweCiphertextConformanceParams<T: UnsignedInteger> {
     pub lwe_dim: LweDimension,
     pub ct_modulus: CiphertextModulus<T>,
     pub ms_decompression_method: MsDecompressionType,
@@ -766,9 +766,12 @@ impl<C: Container> ParameterSetConformant for LweCiphertext<C>
 where
     C::Element: UnsignedInteger,
 {
-    type ParameterSet = LweCiphertextParameters<C::Element>;
+    type ParameterSet = LweCiphertextConformanceParams<C::Element>;
 
-    fn is_conformant(&self, lwe_ct_parameters: &LweCiphertextParameters<C::Element>) -> bool {
+    fn is_conformant(
+        &self,
+        lwe_ct_parameters: &LweCiphertextConformanceParams<C::Element>,
+    ) -> bool {
         let Self {
             data,
             ciphertext_modulus,

--- a/tfhe/src/core_crypto/entities/lwe_compact_ciphertext_list.rs
+++ b/tfhe/src/core_crypto/entities/lwe_compact_ciphertext_list.rs
@@ -334,16 +334,16 @@ pub type LweCompactCiphertextListMutView<'data, Scalar> =
 /// Can be used on a server to check if client inputs are well formed
 /// before running a computation on them
 #[derive(Copy, Clone)]
-pub struct LweCiphertextListParameters<T: UnsignedInteger> {
+pub struct LweCiphertextListConformanceParams<T: UnsignedInteger> {
     pub lwe_dim: LweDimension,
     pub lwe_ciphertext_count_constraint: ListSizeConstraint,
     pub ct_modulus: CiphertextModulus<T>,
 }
 
 impl<T: UnsignedInteger> ParameterSetConformant for LweCompactCiphertextListOwned<T> {
-    type ParameterSet = LweCiphertextListParameters<T>;
+    type ParameterSet = LweCiphertextListConformanceParams<T>;
 
-    fn is_conformant(&self, param: &LweCiphertextListParameters<T>) -> bool {
+    fn is_conformant(&self, param: &LweCiphertextListConformanceParams<T>) -> bool {
         let Self {
             data,
             lwe_size,

--- a/tfhe/src/core_crypto/entities/lwe_compact_public_key.rs
+++ b/tfhe/src/core_crypto/entities/lwe_compact_public_key.rs
@@ -186,7 +186,7 @@ impl<Scalar: UnsignedInteger> LweCompactPublicKeyOwned<Scalar> {
 }
 
 #[derive(Clone, Copy)]
-pub struct LweCompactPublicKeyEncryptionParameters<Scalar: UnsignedInteger> {
+pub struct LweCompactPublicKeyConformanceParams<Scalar: UnsignedInteger> {
     pub encryption_lwe_dimension: LweDimension,
     pub ciphertext_modulus: CiphertextModulus<Scalar>,
 }
@@ -195,7 +195,7 @@ impl<C: Container> ParameterSetConformant for LweCompactPublicKey<C>
 where
     C::Element: UnsignedInteger,
 {
-    type ParameterSet = LweCompactPublicKeyEncryptionParameters<C::Element>;
+    type ParameterSet = LweCompactPublicKeyConformanceParams<C::Element>;
 
     fn is_conformant(&self, parameter_set: &Self::ParameterSet) -> bool {
         let Self { glwe_ciphertext } = self;
@@ -204,7 +204,7 @@ where
             return false;
         }
 
-        let glwe_ciphertext_conformance_parameters = GlweCiphertextConformanceParameters {
+        let glwe_ciphertext_conformance_parameters = GlweCiphertextConformanceParams {
             glwe_dim: GlweDimension(1),
             polynomial_size: PolynomialSize(parameter_set.encryption_lwe_dimension.0),
             ct_modulus: parameter_set.ciphertext_modulus,

--- a/tfhe/src/core_crypto/entities/lwe_keyswitch_key.rs
+++ b/tfhe/src/core_crypto/entities/lwe_keyswitch_key.rs
@@ -435,7 +435,7 @@ impl<Scalar: UnsignedInteger, C: ContainerMut<Element = Scalar>> ContiguousEntit
         Self: 'this;
 }
 
-pub struct KeyswitchKeyConformanceParams {
+pub struct LweKeyswitchKeyConformanceParams {
     pub decomp_base_log: DecompositionBaseLog,
     pub decomp_level_count: DecompositionLevelCount,
     pub output_lwe_size: LweSize,
@@ -444,7 +444,7 @@ pub struct KeyswitchKeyConformanceParams {
 }
 
 impl<C: Container<Element = u64>> ParameterSetConformant for LweKeyswitchKey<C> {
-    type ParameterSet = KeyswitchKeyConformanceParams;
+    type ParameterSet = LweKeyswitchKeyConformanceParams;
 
     fn is_conformant(&self, parameter_set: &Self::ParameterSet) -> bool {
         let Self {

--- a/tfhe/src/core_crypto/entities/lwe_packing_keyswitch_key.rs
+++ b/tfhe/src/core_crypto/entities/lwe_packing_keyswitch_key.rs
@@ -402,7 +402,7 @@ impl<Scalar: UnsignedInteger, C: ContainerMut<Element = Scalar>> ContiguousEntit
         Self: 'this;
 }
 
-pub struct PackingKeyswitchConformanceParams {
+pub struct LwePackingKeyswitchKeyConformanceParams {
     pub decomp_base_log: DecompositionBaseLog,
     pub decomp_level_count: DecompositionLevelCount,
     pub input_lwe_dimension: LweDimension,
@@ -412,7 +412,7 @@ pub struct PackingKeyswitchConformanceParams {
 }
 
 impl<C: Container<Element = u64>> ParameterSetConformant for LwePackingKeyswitchKey<C> {
-    type ParameterSet = PackingKeyswitchConformanceParams;
+    type ParameterSet = LwePackingKeyswitchKeyConformanceParams;
 
     fn is_conformant(&self, parameter_set: &Self::ParameterSet) -> bool {
         let Self {

--- a/tfhe/src/core_crypto/entities/seeded_ggsw_ciphertext_list.rs
+++ b/tfhe/src/core_crypto/entities/seeded_ggsw_ciphertext_list.rs
@@ -12,7 +12,7 @@ use crate::core_crypto::commons::math::random::{
 use crate::core_crypto::commons::parameters::*;
 use crate::core_crypto::commons::traits::*;
 use crate::core_crypto::entities::*;
-use crate::core_crypto::fft_impl::fft64::crypto::bootstrap::BootstrapKeyConformanceParams;
+use crate::core_crypto::fft_impl::fft64::crypto::bootstrap::LweBootstrapKeyConformanceParams;
 use tfhe_versionable::Versionize;
 
 /// A contiguous list containing
@@ -472,7 +472,7 @@ impl<Scalar: UnsignedInteger, C: ContainerMut<Element = Scalar>> ContiguousEntit
         Self: 'this;
 }
 
-pub struct GgswCiphertextListConformanceParameters {
+pub struct GgswCiphertextListConformanceParams {
     pub len: usize,
     pub glwe_size: GlweSize,
     pub polynomial_size: PolynomialSize,
@@ -481,7 +481,7 @@ pub struct GgswCiphertextListConformanceParameters {
     pub ciphertext_modulus: CiphertextModulus<u64>,
 }
 
-impl TryFrom<&MultiBitBootstrapKeyConformanceParams> for GgswCiphertextListConformanceParameters {
+impl TryFrom<&MultiBitBootstrapKeyConformanceParams> for GgswCiphertextListConformanceParams {
     type Error = ();
 
     fn try_from(value: &MultiBitBootstrapKeyConformanceParams) -> Result<Self, ()> {
@@ -502,8 +502,8 @@ impl TryFrom<&MultiBitBootstrapKeyConformanceParams> for GgswCiphertextListConfo
     }
 }
 
-impl From<&BootstrapKeyConformanceParams> for GgswCiphertextListConformanceParameters {
-    fn from(value: &BootstrapKeyConformanceParams) -> Self {
+impl From<&LweBootstrapKeyConformanceParams> for GgswCiphertextListConformanceParams {
+    fn from(value: &LweBootstrapKeyConformanceParams) -> Self {
         Self {
             len: value.input_lwe_dimension.0,
             glwe_size: value.output_glwe_size,
@@ -516,7 +516,7 @@ impl From<&BootstrapKeyConformanceParams> for GgswCiphertextListConformanceParam
 }
 
 impl<C: Container<Element = u64>> ParameterSetConformant for SeededGgswCiphertextList<C> {
-    type ParameterSet = GgswCiphertextListConformanceParameters;
+    type ParameterSet = GgswCiphertextListConformanceParams;
 
     fn is_conformant(&self, parameter_set: &Self::ParameterSet) -> bool {
         let Self {

--- a/tfhe/src/core_crypto/entities/seeded_glwe_ciphertext.rs
+++ b/tfhe/src/core_crypto/entities/seeded_glwe_ciphertext.rs
@@ -303,11 +303,11 @@ impl<C: Container> ParameterSetConformant for SeededGlweCiphertext<C>
 where
     C::Element: UnsignedInteger,
 {
-    type ParameterSet = GlweCiphertextConformanceParameters<C::Element>;
+    type ParameterSet = GlweCiphertextConformanceParams<C::Element>;
 
     fn is_conformant(
         &self,
-        glwe_ct_parameters: &GlweCiphertextConformanceParameters<C::Element>,
+        glwe_ct_parameters: &GlweCiphertextConformanceParams<C::Element>,
     ) -> bool {
         let Self {
             compression_seed: _,

--- a/tfhe/src/core_crypto/entities/seeded_lwe_bootstrap_key.rs
+++ b/tfhe/src/core_crypto/entities/seeded_lwe_bootstrap_key.rs
@@ -9,7 +9,7 @@ use crate::core_crypto::commons::math::random::{CompressionSeed, DefaultRandomGe
 use crate::core_crypto::commons::parameters::*;
 use crate::core_crypto::commons::traits::*;
 use crate::core_crypto::entities::*;
-use crate::core_crypto::fft_impl::fft64::crypto::bootstrap::BootstrapKeyConformanceParams;
+use crate::core_crypto::fft_impl::fft64::crypto::bootstrap::LweBootstrapKeyConformanceParams;
 
 /// A [`seeded LWE bootstrap key`](`SeededLweBootstrapKey`).
 ///
@@ -324,7 +324,7 @@ impl<Scalar: UnsignedInteger> SeededLweBootstrapKeyOwned<Scalar> {
 }
 
 impl<C: Container<Element = u64>> ParameterSetConformant for SeededLweBootstrapKey<C> {
-    type ParameterSet = BootstrapKeyConformanceParams;
+    type ParameterSet = LweBootstrapKeyConformanceParams;
 
     fn is_conformant(&self, parameter_set: &Self::ParameterSet) -> bool {
         let Self { ggsw_list } = self;

--- a/tfhe/src/core_crypto/entities/seeded_lwe_ciphertext.rs
+++ b/tfhe/src/core_crypto/entities/seeded_lwe_ciphertext.rs
@@ -22,9 +22,9 @@ pub struct SeededLweCiphertext<Scalar: UnsignedInteger> {
 }
 
 impl<T: UnsignedInteger> ParameterSetConformant for SeededLweCiphertext<T> {
-    type ParameterSet = LweCiphertextParameters<T>;
+    type ParameterSet = LweCiphertextConformanceParams<T>;
 
-    fn is_conformant(&self, lwe_ct_parameters: &LweCiphertextParameters<T>) -> bool {
+    fn is_conformant(&self, lwe_ct_parameters: &LweCiphertextConformanceParams<T>) -> bool {
         let Self {
             data,
             lwe_size,

--- a/tfhe/src/core_crypto/entities/seeded_lwe_compact_public_key.rs
+++ b/tfhe/src/core_crypto/entities/seeded_lwe_compact_public_key.rs
@@ -235,7 +235,7 @@ impl<C: Container> ParameterSetConformant for SeededLweCompactPublicKey<C>
 where
     C::Element: UnsignedInteger,
 {
-    type ParameterSet = LweCompactPublicKeyEncryptionParameters<C::Element>;
+    type ParameterSet = LweCompactPublicKeyConformanceParams<C::Element>;
 
     fn is_conformant(&self, parameter_set: &Self::ParameterSet) -> bool {
         let Self {
@@ -246,7 +246,7 @@ where
             return false;
         }
 
-        let glwe_ciphertext_conformance_parameters = GlweCiphertextConformanceParameters {
+        let glwe_ciphertext_conformance_parameters = GlweCiphertextConformanceParams {
             glwe_dim: GlweDimension(1),
             polynomial_size: PolynomialSize(parameter_set.encryption_lwe_dimension.0),
             ct_modulus: parameter_set.ciphertext_modulus,

--- a/tfhe/src/core_crypto/entities/seeded_lwe_keyswitch_key.rs
+++ b/tfhe/src/core_crypto/entities/seeded_lwe_keyswitch_key.rs
@@ -426,7 +426,7 @@ impl<Scalar: UnsignedInteger, C: ContainerMut<Element = Scalar>> ContiguousEntit
 }
 
 impl<C: Container<Element = u64>> ParameterSetConformant for SeededLweKeyswitchKey<C> {
-    type ParameterSet = KeyswitchKeyConformanceParams;
+    type ParameterSet = LweKeyswitchKeyConformanceParams;
 
     fn is_conformant(&self, parameter_set: &Self::ParameterSet) -> bool {
         let Self {

--- a/tfhe/src/core_crypto/entities/seeded_lwe_packing_keyswitch_key.rs
+++ b/tfhe/src/core_crypto/entities/seeded_lwe_packing_keyswitch_key.rs
@@ -462,7 +462,7 @@ impl<Scalar: UnsignedInteger, C: ContainerMut<Element = Scalar>> ContiguousEntit
 }
 
 impl<C: Container<Element = u64>> ParameterSetConformant for SeededLwePackingKeyswitchKey<C> {
-    type ParameterSet = PackingKeyswitchConformanceParams;
+    type ParameterSet = LwePackingKeyswitchKeyConformanceParams;
 
     fn is_conformant(&self, parameter_set: &Self::ParameterSet) -> bool {
         let Self {

--- a/tfhe/src/core_crypto/fft_impl/fft64/crypto/bootstrap.rs
+++ b/tfhe/src/core_crypto/fft_impl/fft64/crypto/bootstrap.rs
@@ -620,7 +620,7 @@ where
     }
 }
 
-pub struct BootstrapKeyConformanceParams {
+pub struct LweBootstrapKeyConformanceParams {
     pub decomp_base_log: DecompositionBaseLog,
     pub decomp_level_count: DecompositionLevelCount,
     pub input_lwe_dimension: LweDimension,
@@ -630,7 +630,7 @@ pub struct BootstrapKeyConformanceParams {
 }
 
 impl<C: Container<Element = c64>> ParameterSetConformant for FourierLweBootstrapKey<C> {
-    type ParameterSet = BootstrapKeyConformanceParams;
+    type ParameterSet = LweBootstrapKeyConformanceParams;
 
     fn is_conformant(&self, parameter_set: &Self::ParameterSet) -> bool {
         let Self {

--- a/tfhe/src/high_level_api/keys/inner.rs
+++ b/tfhe/src/high_level_api/keys/inner.rs
@@ -1,6 +1,6 @@
 use crate::conformance::ParameterSetConformant;
 use crate::core_crypto::commons::generators::DeterministicSeeder;
-use crate::core_crypto::prelude::{DefaultRandomGenerator, KeyswitchKeyConformanceParams};
+use crate::core_crypto::prelude::{DefaultRandomGenerator, LweKeyswitchKeyConformanceParams};
 use crate::high_level_api::backward_compatibility::keys::*;
 use crate::integer::compression_keys::{
     CompressedCompressionKey, CompressedDecompressionKey, CompressionKey, CompressionPrivateKeys,
@@ -517,7 +517,7 @@ impl
         .try_into()?;
 
         Ok(Self {
-            keyswitch_key_conformance_params: KeyswitchKeyConformanceParams {
+            keyswitch_key_conformance_params: LweKeyswitchKeyConformanceParams {
                 decomp_base_log: ks_params.ks_base_log,
                 decomp_level_count: ks_params.ks_level,
                 output_lwe_size,

--- a/tfhe/src/integer/compression_keys.rs
+++ b/tfhe/src/integer/compression_keys.rs
@@ -120,10 +120,10 @@ impl ClientKey {
     }
 }
 
-use crate::shortint::list_compression::CompressionConformanceParameters;
+use crate::shortint::list_compression::CompressionKeyConformanceParams;
 
 impl ParameterSetConformant for CompressionKey {
-    type ParameterSet = CompressionConformanceParameters;
+    type ParameterSet = CompressionKeyConformanceParams;
 
     fn is_conformant(&self, parameter_set: &Self::ParameterSet) -> bool {
         let Self { key } = self;
@@ -133,7 +133,7 @@ impl ParameterSetConformant for CompressionKey {
 }
 
 impl ParameterSetConformant for DecompressionKey {
-    type ParameterSet = CompressionConformanceParameters;
+    type ParameterSet = CompressionKeyConformanceParams;
 
     fn is_conformant(&self, parameter_set: &Self::ParameterSet) -> bool {
         let Self { key } = self;
@@ -143,7 +143,7 @@ impl ParameterSetConformant for DecompressionKey {
 }
 
 impl ParameterSetConformant for CompressedCompressionKey {
-    type ParameterSet = CompressionConformanceParameters;
+    type ParameterSet = CompressionKeyConformanceParams;
 
     fn is_conformant(&self, parameter_set: &Self::ParameterSet) -> bool {
         let Self { key } = self;
@@ -153,7 +153,7 @@ impl ParameterSetConformant for CompressedCompressionKey {
 }
 
 impl ParameterSetConformant for CompressedDecompressionKey {
-    type ParameterSet = CompressionConformanceParameters;
+    type ParameterSet = CompressionKeyConformanceParams;
 
     fn is_conformant(&self, parameter_set: &Self::ParameterSet) -> bool {
         let Self { key } = self;

--- a/tfhe/src/shortint/ciphertext/compressed_modulus_switched_ciphertext.rs
+++ b/tfhe/src/shortint/ciphertext/compressed_modulus_switched_ciphertext.rs
@@ -4,7 +4,7 @@ use super::common::*;
 use crate::conformance::ParameterSetConformant;
 use crate::core_crypto::prelude::compressed_modulus_switched_lwe_ciphertext::CompressedModulusSwitchedLweCiphertext;
 use crate::core_crypto::prelude::compressed_modulus_switched_multi_bit_lwe_ciphertext::CompressedModulusSwitchedMultiBitLweCiphertext;
-use crate::core_crypto::prelude::LweCiphertextParameters;
+use crate::core_crypto::prelude::LweCiphertextConformanceParams;
 use crate::shortint::backward_compatibility::ciphertext::{
     CompressedModulusSwitchedCiphertextVersions,
     InternalCompressedModulusSwitchedCiphertextVersions,
@@ -76,9 +76,9 @@ pub(crate) enum InternalCompressedModulusSwitchedCiphertext {
 }
 
 impl ParameterSetConformant for InternalCompressedModulusSwitchedCiphertext {
-    type ParameterSet = LweCiphertextParameters<u64>;
+    type ParameterSet = LweCiphertextConformanceParams<u64>;
 
-    fn is_conformant(&self, param: &LweCiphertextParameters<u64>) -> bool {
+    fn is_conformant(&self, param: &LweCiphertextConformanceParams<u64>) -> bool {
         match self {
             Self::Classic(a) => a.is_conformant(param),
             Self::MultiBit(a) => a.is_conformant(param),

--- a/tfhe/src/shortint/ciphertext/zk.rs
+++ b/tfhe/src/shortint/ciphertext/zk.rs
@@ -1,7 +1,7 @@
 use super::Degree;
 use crate::conformance::{ListSizeConstraint, ParameterSetConformant};
 use crate::core_crypto::algorithms::verify_lwe_compact_ciphertext_list;
-use crate::core_crypto::prelude::{LweCiphertextCount, LweCiphertextListParameters};
+use crate::core_crypto::prelude::{LweCiphertextCount, LweCiphertextListConformanceParams};
 use crate::shortint::backward_compatibility::ciphertext::ProvenCompactCiphertextListVersions;
 use crate::shortint::ciphertext::CompactCiphertextList;
 use crate::shortint::parameters::{
@@ -270,7 +270,7 @@ impl ParameterSetConformant for ProvenCompactCiphertextList {
             }
 
             let params = CiphertextListConformanceParams {
-                ct_list_params: LweCiphertextListParameters {
+                ct_list_params: LweCiphertextListConformanceParams {
                     lwe_dim: *encryption_lwe_dimension,
                     lwe_ciphertext_count_constraint: ListSizeConstraint::exact_size(expected_len),
                     ct_modulus: *ciphertext_modulus,

--- a/tfhe/src/shortint/key_switching_key/mod.rs
+++ b/tfhe/src/shortint/key_switching_key/mod.rs
@@ -4,7 +4,7 @@
 
 use crate::conformance::ParameterSetConformant;
 use crate::core_crypto::prelude::{
-    keyswitch_lwe_ciphertext, Cleartext, KeyswitchKeyConformanceParams, LweKeyswitchKeyOwned,
+    keyswitch_lwe_ciphertext, Cleartext, LweKeyswitchKeyConformanceParams, LweKeyswitchKeyOwned,
     SeededLweKeyswitchKeyOwned,
 };
 use crate::shortint::ciphertext::Degree;
@@ -1015,7 +1015,7 @@ impl CompressedKeySwitchingKey {
 }
 
 pub struct KeySwitchingKeyConformanceParams {
-    pub keyswitch_key_conformance_params: KeyswitchKeyConformanceParams,
+    pub keyswitch_key_conformance_params: LweKeyswitchKeyConformanceParams,
     pub cast_rshift: i8,
     pub destination_key: EncryptionKeyChoice,
 }

--- a/tfhe/src/shortint/list_compression/compressed_server_keys.rs
+++ b/tfhe/src/shortint/list_compression/compressed_server_keys.rs
@@ -1,13 +1,13 @@
 use super::{
-    CompressionConformanceParameters, CompressionKey, CompressionPrivateKeys, DecompressionKey,
+    CompressionKey, CompressionKeyConformanceParams, CompressionPrivateKeys, DecompressionKey,
 };
 use crate::conformance::ParameterSetConformant;
-use crate::core_crypto::fft_impl::fft64::crypto::bootstrap::BootstrapKeyConformanceParams;
+use crate::core_crypto::fft_impl::fft64::crypto::bootstrap::LweBootstrapKeyConformanceParams;
 use crate::core_crypto::prelude::{
     allocate_and_generate_new_seeded_lwe_packing_keyswitch_key,
     par_allocate_and_generate_new_seeded_lwe_bootstrap_key,
     par_convert_standard_lwe_bootstrap_key_to_fourier, CiphertextModulusLog,
-    FourierLweBootstrapKey, LweCiphertextCount, PackingKeyswitchConformanceParams,
+    FourierLweBootstrapKey, LweCiphertextCount, LwePackingKeyswitchKeyConformanceParams,
     SeededLweBootstrapKeyOwned, SeededLwePackingKeyswitchKey,
 };
 use crate::shortint::backward_compatibility::list_compression::{
@@ -15,7 +15,7 @@ use crate::shortint::backward_compatibility::list_compression::{
 };
 use crate::shortint::client_key::ClientKey;
 use crate::shortint::engine::ShortintEngine;
-use crate::shortint::server_key::{PBSConformanceParameters, ShortintBootstrappingKey};
+use crate::shortint::server_key::{PBSConformanceParams, ShortintBootstrappingKey};
 use crate::shortint::EncryptionKeyChoice;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
@@ -137,7 +137,7 @@ impl ClientKey {
 }
 
 impl ParameterSetConformant for CompressedCompressionKey {
-    type ParameterSet = CompressionConformanceParameters;
+    type ParameterSet = CompressionKeyConformanceParams;
 
     fn is_conformant(&self, parameter_set: &Self::ParameterSet) -> bool {
         let Self {
@@ -146,7 +146,7 @@ impl ParameterSetConformant for CompressedCompressionKey {
             storage_log_modulus,
         } = self;
 
-        let params = PackingKeyswitchConformanceParams {
+        let params = LwePackingKeyswitchKeyConformanceParams {
             decomp_base_log: parameter_set.packing_ks_base_log,
             decomp_level_count: parameter_set.packing_ks_level,
             input_lwe_dimension: parameter_set
@@ -164,7 +164,7 @@ impl ParameterSetConformant for CompressedCompressionKey {
 }
 
 impl ParameterSetConformant for CompressedDecompressionKey {
-    type ParameterSet = CompressionConformanceParameters;
+    type ParameterSet = CompressionKeyConformanceParams;
 
     fn is_conformant(&self, parameter_set: &Self::ParameterSet) -> bool {
         let Self {
@@ -172,9 +172,9 @@ impl ParameterSetConformant for CompressedDecompressionKey {
             lwe_per_glwe,
         } = self;
 
-        let params: PBSConformanceParameters = parameter_set.into();
+        let params: PBSConformanceParams = parameter_set.into();
 
-        let params: BootstrapKeyConformanceParams = (&params).into();
+        let params: LweBootstrapKeyConformanceParams = (&params).into();
 
         blind_rotate_key.is_conformant(&params) && *lwe_per_glwe == parameter_set.lwe_per_glwe
     }

--- a/tfhe/src/shortint/list_compression/mod.rs
+++ b/tfhe/src/shortint/list_compression/mod.rs
@@ -5,4 +5,4 @@ mod server_keys;
 
 pub use compressed_server_keys::{CompressedCompressionKey, CompressedDecompressionKey};
 pub use private_key::CompressionPrivateKeys;
-pub use server_keys::{CompressionConformanceParameters, CompressionKey, DecompressionKey};
+pub use server_keys::{CompressionKey, CompressionKeyConformanceParams, DecompressionKey};

--- a/tfhe/src/shortint/parameters/mod.rs
+++ b/tfhe/src/shortint/parameters/mod.rs
@@ -11,10 +11,10 @@ pub use crate::core_crypto::commons::parameters::{
     CiphertextModulus as CoreCiphertextModulus, DecompositionBaseLog, DecompositionLevelCount,
     DynamicDistribution, GlweDimension, LweBskGroupingFactor, LweDimension, PolynomialSize,
 };
-use crate::core_crypto::fft_impl::fft64::crypto::bootstrap::BootstrapKeyConformanceParams;
+use crate::core_crypto::fft_impl::fft64::crypto::bootstrap::LweBootstrapKeyConformanceParams;
 use crate::core_crypto::prelude::{
-    GlweCiphertextConformanceParameters, KeyswitchKeyConformanceParams, LweCiphertextCount,
-    LweCiphertextListParameters, LweCiphertextParameters, MsDecompressionType,
+    GlweCiphertextConformanceParams, LweCiphertextConformanceParams, LweCiphertextCount,
+    LweCiphertextListConformanceParams, LweKeyswitchKeyConformanceParams, MsDecompressionType,
     NoiseEstimationMeasureBound, RSigmaFactor, Variance,
 };
 use crate::shortint::backward_compatibility::parameters::*;
@@ -39,7 +39,7 @@ pub mod v0_11;
 
 use super::backward_compatibility::parameters::modulus_switch_noise_reduction::ModulusSwitchNoiseReductionParamsVersions;
 pub use super::ciphertext::{Degree, MaxNoiseLevel, NoiseLevel};
-use super::server_key::PBSConformanceParameters;
+use super::server_key::PBSConformanceParams;
 pub use super::PBSOrder;
 pub use crate::core_crypto::commons::parameters::EncryptionKeyChoice;
 use crate::shortint::ciphertext::MaxDegree;
@@ -211,7 +211,7 @@ impl ClassicPBSParameters {
         let noise_level = NoiseLevel::NOMINAL;
 
         CiphertextConformanceParams {
-            ct_params: LweCiphertextParameters {
+            ct_params: LweCiphertextConformanceParams {
                 lwe_dim: expected_dim,
                 ct_modulus: ciphertext_modulus,
                 ms_decompression_method: MsDecompressionType::ClassicPbs,
@@ -225,8 +225,8 @@ impl ClassicPBSParameters {
     }
 }
 
-impl From<&PBSConformanceParameters> for BootstrapKeyConformanceParams {
-    fn from(value: &PBSConformanceParameters) -> Self {
+impl From<&PBSConformanceParams> for LweBootstrapKeyConformanceParams {
+    fn from(value: &PBSConformanceParams) -> Self {
         Self {
             decomp_base_log: value.base_log,
             decomp_level_count: value.level,
@@ -250,7 +250,7 @@ pub enum PBSParameters {
 /// before running a computation on them
 #[derive(Copy, Clone)]
 pub struct CiphertextConformanceParams {
-    pub ct_params: LweCiphertextParameters<u64>,
+    pub ct_params: LweCiphertextConformanceParams<u64>,
     pub message_modulus: MessageModulus,
     pub carry_modulus: CarryModulus,
     pub degree: Degree,
@@ -263,7 +263,7 @@ pub struct CiphertextConformanceParams {
 /// before running a computation on them
 #[derive(Copy, Clone)]
 pub struct CompressedCiphertextConformanceParams {
-    pub ct_params: GlweCiphertextConformanceParameters<u64>,
+    pub ct_params: GlweCiphertextConformanceParams<u64>,
     pub lwe_per_glwe: LweCiphertextCount,
     pub message_modulus: MessageModulus,
     pub carry_modulus: CarryModulus,
@@ -277,7 +277,7 @@ pub struct CompressedCiphertextConformanceParams {
 /// before running a computation on them
 #[derive(Copy, Clone)]
 pub struct CiphertextListConformanceParams {
-    pub ct_list_params: LweCiphertextListParameters<u64>,
+    pub ct_list_params: LweCiphertextListConformanceParams<u64>,
     pub message_modulus: MessageModulus,
     pub carry_modulus: CarryModulus,
     pub degree: Degree,
@@ -290,7 +290,7 @@ impl CiphertextConformanceParams {
         list_constraint: ListSizeConstraint,
     ) -> CiphertextListConformanceParams {
         CiphertextListConformanceParams {
-            ct_list_params: LweCiphertextListParameters {
+            ct_list_params: LweCiphertextListConformanceParams {
                 lwe_dim: self.ct_params.lwe_dim,
                 ct_modulus: self.ct_params.ct_modulus,
                 lwe_ciphertext_count_constraint: list_constraint,
@@ -315,7 +315,7 @@ impl From<MultiBitPBSParameters> for PBSParameters {
     }
 }
 
-impl From<&PBSParameters> for KeyswitchKeyConformanceParams {
+impl From<&PBSParameters> for LweKeyswitchKeyConformanceParams {
     fn from(value: &PBSParameters) -> Self {
         Self {
             decomp_base_log: value.ks_base_log(),

--- a/tfhe/src/shortint/parameters/multi_bit/mod.rs
+++ b/tfhe/src/shortint/parameters/multi_bit/mod.rs
@@ -1,6 +1,6 @@
 use crate::core_crypto::commons::math::random::{Deserialize, Serialize};
 use crate::core_crypto::entities::{
-    LweCiphertextParameters, MsDecompressionType, MultiBitBootstrapKeyConformanceParams,
+    LweCiphertextConformanceParams, MsDecompressionType, MultiBitBootstrapKeyConformanceParams,
 };
 use crate::core_crypto::prelude::{DynamicDistribution, LweBskGroupingFactor};
 use crate::shortint::ciphertext::{Degree, NoiseLevel};
@@ -100,7 +100,7 @@ use crate::shortint::parameters::multi_bit::tuniform::p_fail_2_minus_64::ks_pbs_
 };
 use crate::shortint::parameters::{CiphertextConformanceParams, MultiBitPBSParametersVersions};
 use crate::shortint::prelude::*;
-use crate::shortint::server_key::PBSConformanceParameters;
+use crate::shortint::server_key::PBSConformanceParams;
 use crate::shortint::{
     CarryModulus, CiphertextModulus, EncryptionKeyChoice, MaxNoiseLevel, MessageModulus, PBSOrder,
 };
@@ -168,7 +168,7 @@ impl MultiBitPBSParameters {
         let noise_level = NoiseLevel::NOMINAL;
 
         CiphertextConformanceParams {
-            ct_params: LweCiphertextParameters {
+            ct_params: LweCiphertextConformanceParams {
                 lwe_dim: expected_dim,
                 ct_modulus: ciphertext_modulus,
                 ms_decompression_method: MsDecompressionType::MultiBitPbs(self.grouping_factor),
@@ -182,10 +182,10 @@ impl MultiBitPBSParameters {
     }
 }
 
-impl TryFrom<&PBSConformanceParameters> for MultiBitBootstrapKeyConformanceParams {
+impl TryFrom<&PBSConformanceParams> for MultiBitBootstrapKeyConformanceParams {
     type Error = ();
 
-    fn try_from(value: &PBSConformanceParameters) -> Result<Self, ()> {
+    fn try_from(value: &PBSConformanceParams) -> Result<Self, ()> {
         Ok(Self {
             decomp_base_log: value.base_log,
             decomp_level_count: value.level,
@@ -193,10 +193,10 @@ impl TryFrom<&PBSConformanceParameters> for MultiBitBootstrapKeyConformanceParam
             output_glwe_size: value.out_glwe_dimension.to_glwe_size(),
             polynomial_size: value.out_polynomial_size,
             grouping_factor: match value.pbs_type {
-                crate::shortint::server_key::PbsTypeConformanceParameters::Classic { .. } => {
+                crate::shortint::server_key::PbsTypeConformanceParams::Classic { .. } => {
                     return Err(());
                 }
-                crate::shortint::server_key::PbsTypeConformanceParameters::MultiBit {
+                crate::shortint::server_key::PbsTypeConformanceParams::MultiBit {
                     lwe_bsk_grouping_factor,
                 } => lwe_bsk_grouping_factor,
             },

--- a/tfhe/src/shortint/public_key/compact.rs
+++ b/tfhe/src/shortint/public_key/compact.rs
@@ -3,7 +3,7 @@ use crate::core_crypto::prelude::{
     allocate_and_generate_new_binary_lwe_secret_key,
     allocate_and_generate_new_seeded_lwe_compact_public_key, generate_lwe_compact_public_key,
     Cleartext, Container, LweCiphertextCount, LweCompactCiphertextListOwned,
-    LweCompactPublicKeyEncryptionParameters, LweCompactPublicKeyOwned, LweSecretKey, Plaintext,
+    LweCompactPublicKeyConformanceParams, LweCompactPublicKeyOwned, LweSecretKey, Plaintext,
     PlaintextList, SeededLweCompactPublicKeyOwned,
 };
 use crate::shortint::backward_compatibility::public_key::{
@@ -564,7 +564,7 @@ impl ParameterSetConformant for CompactPublicKey {
     fn is_conformant(&self, parameter_set: &Self::ParameterSet) -> bool {
         let Self { key, parameters } = self;
 
-        let core_params = LweCompactPublicKeyEncryptionParameters {
+        let core_params = LweCompactPublicKeyConformanceParams {
             encryption_lwe_dimension: parameter_set.encryption_lwe_dimension,
             ciphertext_modulus: parameter_set.ciphertext_modulus,
         };
@@ -579,7 +579,7 @@ impl ParameterSetConformant for CompressedCompactPublicKey {
     fn is_conformant(&self, parameter_set: &Self::ParameterSet) -> bool {
         let Self { key, parameters } = self;
 
-        let core_params = LweCompactPublicKeyEncryptionParameters {
+        let core_params = LweCompactPublicKeyConformanceParams {
             encryption_lwe_dimension: parameter_set.encryption_lwe_dimension,
             ciphertext_modulus: parameter_set.ciphertext_modulus,
         };

--- a/tfhe/src/shortint/server_key/compressed.rs
+++ b/tfhe/src/shortint/server_key/compressed.rs
@@ -2,11 +2,11 @@
 
 use super::{
     CompressedModulusSwitchNoiseReductionKey, MaxDegree,
-    ModulusSwitchNoiseReductionKeyConformanceParameters, PBSConformanceParameters,
-    PbsTypeConformanceParameters,
+    ModulusSwitchNoiseReductionKeyConformanceParams, PBSConformanceParams,
+    PbsTypeConformanceParams,
 };
 use crate::conformance::ParameterSetConformant;
-use crate::core_crypto::fft_impl::fft64::crypto::bootstrap::BootstrapKeyConformanceParams;
+use crate::core_crypto::fft_impl::fft64::crypto::bootstrap::LweBootstrapKeyConformanceParams;
 use crate::core_crypto::prelude::*;
 use crate::shortint::backward_compatibility::server_key::{
     CompressedServerKeyVersions, ShortintCompressedBootstrappingKeyVersions,
@@ -397,7 +397,7 @@ impl CompressedServerKey {
 }
 
 impl ParameterSetConformant for ShortintCompressedBootstrappingKey {
-    type ParameterSet = PBSConformanceParameters;
+    type ParameterSet = PBSConformanceParams;
 
     fn is_conformant(&self, parameter_set: &Self::ParameterSet) -> bool {
         match (self, parameter_set.pbs_type) {
@@ -406,11 +406,11 @@ impl ParameterSetConformant for ShortintCompressedBootstrappingKey {
                     bsk,
                     modulus_switch_noise_reduction_key,
                 },
-                PbsTypeConformanceParameters::Classic { .. },
+                PbsTypeConformanceParams::Classic { .. },
             ) => {
                 let modulus_switch_noise_reduction_key_conformant = match (
                     modulus_switch_noise_reduction_key,
-                    ModulusSwitchNoiseReductionKeyConformanceParameters::try_from(parameter_set),
+                    ModulusSwitchNoiseReductionKeyConformanceParams::try_from(parameter_set),
                 ) {
                     (None, Err(())) => true,
                     (Some(modulus_switch_noise_reduction_key), Ok(param)) => {
@@ -419,7 +419,7 @@ impl ParameterSetConformant for ShortintCompressedBootstrappingKey {
                     _ => false,
                 };
 
-                let param: BootstrapKeyConformanceParams = parameter_set.into();
+                let param: LweBootstrapKeyConformanceParams = parameter_set.into();
 
                 bsk.is_conformant(&param) && modulus_switch_noise_reduction_key_conformant
             }
@@ -428,7 +428,7 @@ impl ParameterSetConformant for ShortintCompressedBootstrappingKey {
                     seeded_bsk,
                     deterministic_execution: _,
                 },
-                PbsTypeConformanceParameters::MultiBit { .. },
+                PbsTypeConformanceParams::MultiBit { .. },
             ) => {
                 let param: MultiBitBootstrapKeyConformanceParams =
                     parameter_set.try_into().unwrap();
@@ -455,11 +455,11 @@ impl ParameterSetConformant for CompressedServerKey {
             pbs_order,
         } = self;
 
-        let params: PBSConformanceParameters = parameter_set.into();
+        let params: PBSConformanceParams = parameter_set.into();
 
         let pbs_key_ok = bootstrapping_key.is_conformant(&params);
 
-        let param: KeyswitchKeyConformanceParams = parameter_set.into();
+        let param: LweKeyswitchKeyConformanceParams = parameter_set.into();
 
         let ks_key_ok = key_switching_key.is_conformant(&param);
 

--- a/tfhe/src/shortint/server_key/modulus_switch_noise_reduction.rs
+++ b/tfhe/src/shortint/server_key/modulus_switch_noise_reduction.rs
@@ -1,4 +1,4 @@
-use super::{PBSConformanceParameters, PbsTypeConformanceParameters};
+use super::{PBSConformanceParams, PbsTypeConformanceParams};
 use crate::conformance::ParameterSetConformant;
 use crate::core_crypto::algorithms::*;
 use crate::core_crypto::commons::math::random::{CompressionSeed, DynamicDistribution};
@@ -18,17 +18,17 @@ use std::fmt::Debug;
 use tfhe_versionable::Versionize;
 
 #[derive(Copy, Clone)]
-pub struct ModulusSwitchNoiseReductionKeyConformanceParameters {
+pub struct ModulusSwitchNoiseReductionKeyConformanceParams {
     pub modulus_switch_noise_reduction_params: ModulusSwitchNoiseReductionParams,
     pub lwe_dimension: LweDimension,
 }
 
-impl TryFrom<&PBSConformanceParameters> for ModulusSwitchNoiseReductionKeyConformanceParameters {
+impl TryFrom<&PBSConformanceParams> for ModulusSwitchNoiseReductionKeyConformanceParams {
     type Error = ();
 
-    fn try_from(value: &PBSConformanceParameters) -> Result<Self, ()> {
+    fn try_from(value: &PBSConformanceParams) -> Result<Self, ()> {
         match &value.pbs_type {
-            PbsTypeConformanceParameters::Classic {
+            PbsTypeConformanceParams::Classic {
                 modulus_switch_noise_reduction,
             } => modulus_switch_noise_reduction.map_or(Err(()), |modulus_switch_noise_reduction| {
                 Ok(Self {
@@ -36,7 +36,7 @@ impl TryFrom<&PBSConformanceParameters> for ModulusSwitchNoiseReductionKeyConfor
                     lwe_dimension: value.in_lwe_dimension,
                 })
             }),
-            PbsTypeConformanceParameters::MultiBit { .. } => Err(()),
+            PbsTypeConformanceParams::MultiBit { .. } => Err(()),
         }
     }
 }
@@ -60,7 +60,7 @@ pub struct ModulusSwitchNoiseReductionKey {
 }
 
 impl ParameterSetConformant for ModulusSwitchNoiseReductionKey {
-    type ParameterSet = ModulusSwitchNoiseReductionKeyConformanceParameters;
+    type ParameterSet = ModulusSwitchNoiseReductionKeyConformanceParams;
 
     fn is_conformant(&self, parameter_set: &Self::ParameterSet) -> bool {
         let Self {
@@ -70,7 +70,7 @@ impl ParameterSetConformant for ModulusSwitchNoiseReductionKey {
             ms_input_variance,
         } = self;
 
-        let ModulusSwitchNoiseReductionKeyConformanceParameters {
+        let ModulusSwitchNoiseReductionKeyConformanceParams {
             modulus_switch_noise_reduction_params,
             lwe_dimension,
         } = parameter_set;
@@ -119,7 +119,7 @@ pub struct CompressedModulusSwitchNoiseReductionKey {
 }
 
 impl ParameterSetConformant for CompressedModulusSwitchNoiseReductionKey {
-    type ParameterSet = ModulusSwitchNoiseReductionKeyConformanceParameters;
+    type ParameterSet = ModulusSwitchNoiseReductionKeyConformanceParams;
 
     fn is_conformant(&self, parameter_set: &Self::ParameterSet) -> bool {
         let Self {
@@ -129,7 +129,7 @@ impl ParameterSetConformant for CompressedModulusSwitchNoiseReductionKey {
             ms_input_variance,
         } = self;
 
-        let ModulusSwitchNoiseReductionKeyConformanceParameters {
+        let ModulusSwitchNoiseReductionKeyConformanceParams {
             modulus_switch_noise_reduction_params,
             lwe_dimension,
         } = parameter_set;


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description
Homogenize the names of the conformance parameters:
- use the suffix `ConformanceParams` everywhere
- use the name of the main type as a prefix except when the parameters are reused from another type

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
