### PR TITLE
chore(ci): deduplicate parameters set to send to lattice estimator

### DIFF
--- a/ci/lattice_estimator.sage
+++ b/ci/lattice_estimator.sage
@@ -34,12 +34,17 @@ def check_security(filename):
     to_update = []
     to_watch = []
 
-    for param in all_params:
-        if param.tag.startswith("TFHE_LIB_PARAMETERS"):
+    for group_index, param in enumerate(all_params):
+        if "TFHE_LIB_PARAMETERS_lwe" in param.tag or "TFHE_LIB_PARAMETERS_glwe" in param.tag:
             # This third-party parameters set is known to be less secure, just skip the analysis.
             continue
 
-        print(f"\t{param.tag}...\t", end="")
+        print(f"\tParameters group #{group_index}:")
+        for param_name in sorted(param.tag):
+            print(
+                f"\t\t{param_name}\t",
+            )
+        print(f"\tParameters group #{group_index}...\t", end="")
 
         is_n_size_too_low = param.n <= 450
         is_noise_level_too_low = param.Xe.stddev < 4.0
@@ -102,7 +107,9 @@ if __name__ == "__main__":
         print("Some parameters need attention")
         print("------------------------------")
         for param, reason in params_to_watch:
-            print(f"[{param.tag}] reason: {reason} (param: {param})")
+            params = ",\n\t".join(param.tag)
+            print("[\n\t", params, "\n]", sep="")
+            print(f"--> reason: {reason} (param: {param})\n")
 
     if params_to_update:
         if params_to_watch:
@@ -111,7 +118,9 @@ if __name__ == "__main__":
         print("Some parameters need update")
         print("---------------------------")
         for param, reason in params_to_update:
-            print(f"[{param.tag}] reason: {reason} (param: {param})")
+            params = ",\n\t".join(param.tag)
+            print("[\n\t", params, "\n]", sep="")
+            print(f"--> reason: {reason} (param: {param})\n")
         sys.exit(int(1))  # Explicit conversion is needed to make this call work
     else:
         print("All parameters passed the security check")

--- a/tfhe/src/core_crypto/commons/parameters.rs
+++ b/tfhe/src/core_crypto/commons/parameters.rs
@@ -68,7 +68,7 @@ impl LweSize {
 
 /// The number of scalar in an LWE mask, or the length of an LWE secret key.
 #[derive(
-    Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Serialize, Deserialize, Versionize,
+    Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash, Serialize, Deserialize, Versionize,
 )]
 #[versionize(LweDimensionVersions)]
 pub struct LweDimension(pub usize);


### PR DESCRIPTION
From SageMath point of view some tfhe-rs parameters set are equivalent. We deduplicate those by storing their name in the tag field. Grouping them that way we decrease analysis time dramatically.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/2061)
<!-- Reviewable:end -->
