### PR TITLE
chore(ci): add should-run to tfhe-fft and tfhe-ntt tests

### DIFF
--- a/.github/workflows/cargo_test_fft.yml
+++ b/.github/workflows/cargo_test_fft.yml
@@ -3,16 +3,46 @@ name: Cargo Test tfhe-fft
 
 on:
   pull_request:
+  push:
+    branches:
+      - main
 
 env:
   CARGO_TERM_COLOR: always
+  IS_PULL_REQUEST: ${{ github.event_name == 'pull_request' }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
   cancel-in-progress: true
 
 jobs:
+  should-run:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      fft_test: ${{ env.IS_PULL_REQUEST == 'false' || steps.changed-files.outputs.fft_any_changed }}
+    steps:
+      - name: Checkout tfhe-rs
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          fetch-depth: 0
+          persist-credentials: 'false'
+
+      - name: Check for file changes
+        id: changed-files
+        uses: tj-actions/changed-files@dcc7a0cba800f454d79fff4b993e8c3555bcc0a8
+        with:
+          files_yaml: |
+            fft:
+              - tfhe/Cargo.toml
+              - Makefile
+              - tfhe-fft/**
+              - '.github/workflows/cargo_test_fft.yml'
+
   cargo-tests-fft:
+    needs: should-run
+    if: needs.should-run.outputs.fft_test == 'true'
     runs-on: ${{ matrix.runner_type }}
     strategy:
       matrix:
@@ -39,6 +69,8 @@ jobs:
           make test_fft_no_std
 
   cargo-tests-fft-nightly:
+    needs: should-run
+    if: needs.should-run.outputs.fft_test == 'true'
     runs-on: ${{ matrix.runner_type }}
     strategy:
       matrix:
@@ -61,7 +93,9 @@ jobs:
           make test_fft_no_std_nightly
 
   cargo-tests-fft-node-js:
-    runs-on: "ubuntu-latest"
+    needs: should-run
+    if: needs.should-run.outputs.fft_test == 'true'
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
@@ -69,3 +103,30 @@ jobs:
         run: |
           make install_node
           make test_fft_node_js_ci
+
+  cargo-tests-fft-successful:
+    needs: [ should-run, cargo-tests-fft, cargo-tests-fft-nightly, cargo-tests-fft-node-js ]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Tests do not need to run
+        if: needs.should-run.outputs.fft_test == 'false'
+        run: |
+          echo "tfhe-fft files haven't changed tests don't need to run"
+
+      - name: Check all tests passed
+        if: needs.should-run.outputs.fft_test == 'true' &&
+          needs.cargo-tests-fft.result == 'success' &&
+          needs.cargo-tests-fft-nightly.result == 'success' &&
+          needs.cargo-tests-fft-node-js.result == 'success'
+        run: |
+          echo "All tfhe-fft test passed"
+
+      - name: Check tests failure
+        if: needs.should-run.outputs.fft_test == 'true' &&
+          (needs.cargo-tests-fft.result != 'success' ||
+          needs.cargo-tests-fft-nightly.result != 'success' ||
+          needs.cargo-tests-fft-node-js.result != 'success')
+        run: |
+          echo "Some tfhe-fft tests failed"
+          exit 1

--- a/.github/workflows/cargo_test_ntt.yml
+++ b/.github/workflows/cargo_test_ntt.yml
@@ -3,16 +3,46 @@ name: Cargo Test tfhe-ntt
 
 on:
   pull_request:
+  push:
+    branches:
+      - main
 
 env:
   CARGO_TERM_COLOR: always
+  IS_PULL_REQUEST: ${{ github.event_name == 'pull_request' }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
   cancel-in-progress: true
 
-jobs:
+jobs:  
+  should-run:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      ntt_test: ${{ env.IS_PULL_REQUEST == 'false' || steps.changed-files.outputs.ntt_any_changed }}
+    steps:
+      - name: Checkout tfhe-rs
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          fetch-depth: 0
+          persist-credentials: 'false'
+
+      - name: Check for file changes
+        id: changed-files
+        uses: tj-actions/changed-files@dcc7a0cba800f454d79fff4b993e8c3555bcc0a8
+        with:
+          files_yaml: |
+            ntt:
+              - tfhe/Cargo.toml
+              - Makefile
+              - tfhe-ntt/**
+              - '.github/workflows/cargo_test_ntt.yml'
+
   cargo-tests-ntt:
+    needs: should-run
+    if: needs.should-run.outputs.ntt_test == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -34,6 +64,8 @@ jobs:
         run: make test_ntt_no_std
 
   cargo-tests-ntt-nightly:
+    needs: should-run
+    if: needs.should-run.outputs.ntt_test == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -52,3 +84,28 @@ jobs:
 
       - name: Test no-std nightly
         run: make test_ntt_no_std_nightly
+
+  cargo-tests-ntt-successful:
+    needs: [ should-run, cargo-tests-ntt, cargo-tests-ntt-nightly ]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Tests do not need to run
+        if: needs.should-run.outputs.ntt_test == 'false'
+        run: |
+          echo "tfhe-ntt files haven't changed tests don't need to run"
+
+      - name: Check all tests success
+        if: needs.should-run.outputs.ntt_test == 'true' &&
+          needs.cargo-tests-ntt.result == 'success' &&
+          needs.cargo-tests-ntt-nightly.result == 'success'
+        run: |
+          echo "All tfhe-ntt tests passed"
+
+      - name: Check tests failure
+        if: needs.should-run.outputs.ntt_test == 'true' &&
+          (needs.cargo-tests-ntt.result != 'success' ||
+          needs.cargo-tests-ntt-nightly.result != 'success')
+        run: |
+          echo "Some tfhe-ntt tests failed"
+          exit 1


### PR DESCRIPTION
This is done to avoid testing tfhe-ftt/ntt crates if nothing changes in their source files.
However, these tests would be run unconditionally on each push on main branch.
