### PR TITLE
chore(ci): update cpu aws ami and install git-lfs

### DIFF
--- a/.github/workflows/aws_tfhe_backward_compat_tests.yml
+++ b/.github/workflows/aws_tfhe_backward_compat_tests.yml
@@ -66,10 +66,6 @@ jobs:
         with:
           toolchain: stable
 
-      - name: Install git-lfs
-        run: |
-          sudo apt update && sudo apt -y install git-lfs
-
       - name: Use specific data branch
         if: ${{ contains(github.event.pull_request.labels.*.name, 'data_PR') }}
         env:

--- a/ci/slab.toml
+++ b/ci/slab.toml
@@ -1,6 +1,6 @@
 [backend.aws.cpu-big]
 region = "eu-west-3"
-image_id = "ami-0cd5012d17ae64070"
+image_id = "ami-026259079be0efbca"
 instance_type = "m6i.32xlarge"
 user = "ubuntu"
 
@@ -12,7 +12,7 @@ user = "ubuntu"
 
 [backend.aws.cpu-small]
 region = "eu-west-3"
-image_id = "ami-0cd5012d17ae64070"
+image_id = "ami-026259079be0efbca"
 instance_type = "m6i.4xlarge"
 user = "ubuntu"
 


### PR DESCRIPTION
Several network errors occurred while trying to install git-lfs from within backward compatibility tests workflow. Having git-lfs installed directly in the Amazon Machine Image fix this issue.
