### PR TITLE
fix(cpu): fix corner case when estimating the num blocks required

### DIFF
--- a/tfhe/src/integer/gpu/server_key/mod.rs
+++ b/tfhe/src/integer/gpu/server_key/mod.rs
@@ -8,6 +8,7 @@ use crate::core_crypto::prelude::{
     LweMultiBitBootstrapKeyOwned,
 };
 use crate::integer::gpu::UnsignedInteger;
+use crate::integer::server_key::num_bits_to_represent_unsigned_value;
 use crate::integer::ClientKey;
 use crate::shortint::ciphertext::{MaxDegree, MaxNoiseLevel};
 use crate::shortint::engine::ShortintEngine;
@@ -252,30 +253,13 @@ impl CudaServerKey {
         }
     }
 
-    #[allow(clippy::unused_self)]
-    pub(crate) fn num_bits_to_represent_unsigned_value<Clear>(&self, clear: Clear) -> usize
-    where
-        Clear: UnsignedInteger,
-    {
-        if clear == Clear::MAX {
-            Clear::BITS
-        } else {
-            let bits = (clear + Clear::ONE).ceil_ilog2() as usize;
-            if bits == 0 {
-                1
-            } else {
-                bits
-            }
-        }
-    }
-
     /// Returns how many blocks a radix ciphertext should have to
     /// be able to represent the given unsigned integer
     pub(crate) fn num_blocks_to_represent_unsigned_value<Clear>(&self, clear: Clear) -> usize
     where
         Clear: UnsignedInteger,
     {
-        let num_bits_to_represent_output_value = self.num_bits_to_represent_unsigned_value(clear);
+        let num_bits_to_represent_output_value = num_bits_to_represent_unsigned_value(clear);
         let num_bits_in_message = self.message_modulus.0.ilog2();
         num_bits_to_represent_output_value.div_ceil(num_bits_in_message as usize)
     }

--- a/tfhe/src/integer/server_key/mod.rs
+++ b/tfhe/src/integer/server_key/mod.rs
@@ -211,24 +211,13 @@ impl ServerKey {
         self.key.carry_modulus
     }
 
-    pub fn num_bits_to_represent_unsigned_value<Clear>(&self, clear: Clear) -> usize
-    where
-        Clear: UnsignedInteger,
-    {
-        if clear == Clear::MAX {
-            Clear::BITS
-        } else {
-            (clear + Clear::ONE).ceil_ilog2() as usize
-        }
-    }
-
     /// Returns how many blocks a radix ciphertext should have to
     /// be able to represent the given unsigned integer
     pub fn num_blocks_to_represent_unsigned_value<Clear>(&self, clear: Clear) -> usize
     where
         Clear: UnsignedInteger,
     {
-        let num_bits_to_represent_output_value = self.num_bits_to_represent_unsigned_value(clear);
+        let num_bits_to_represent_output_value = num_bits_to_represent_unsigned_value(clear);
         let num_bits_in_message = self.message_modulus().0.ilog2();
         num_bits_to_represent_output_value.div_ceil(num_bits_in_message as usize)
     }
@@ -294,6 +283,22 @@ impl CompressedServerKey {
     /// Construct a [`CompressedServerKey`] from its constituents.
     pub fn from_raw_parts(key: crate::shortint::CompressedServerKey) -> Self {
         Self { key }
+    }
+}
+
+pub fn num_bits_to_represent_unsigned_value<Clear>(clear: Clear) -> usize
+where
+    Clear: UnsignedInteger,
+{
+    if clear == Clear::MAX {
+        Clear::BITS
+    } else {
+        let bits = (clear + Clear::ONE).ceil_ilog2() as usize;
+        if bits == 0 {
+            1
+        } else {
+            bits
+        }
     }
 }
 

--- a/tfhe/src/integer/server_key/radix_parallel/count_zeros_ones.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/count_zeros_ones.rs
@@ -1,4 +1,5 @@
 use super::ServerKey;
+use crate::integer::server_key::num_bits_to_represent_unsigned_value;
 use crate::integer::{IntegerRadixCiphertext, RadixCiphertext, SignedRadixCiphertext};
 use crate::shortint::ciphertext::Degree;
 
@@ -221,8 +222,7 @@ impl ServerKey {
             // But in the case of 1_X parameters, counting ones does not require to have
             // a LUT done on each block to count the number of ones, and to avoid having to do a
             // LUT to count zeros we prefer to change a bit the sum
-            let num_bits_needed =
-                self.num_bits_to_represent_unsigned_value(max_possible_bit_count) + 1;
+            let num_bits_needed = num_bits_to_represent_unsigned_value(max_possible_bit_count) + 1;
             let num_signed_blocks = num_bits_needed.div_ceil(num_bits_in_block as usize);
             assert!(num_signed_blocks >= num_unsigned_blocks);
 


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description
Corner case found when calculating the number of blocks required to store a clear value, when the clear value was 0 it was returning 0. 
### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
