### PR TITLE
chore(ci): use new heuristic for throughput benchmarks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -284,14 +284,14 @@ check_typos: install_typos_checker
 .PHONY: clippy_gpu # Run clippy lints on tfhe with "gpu" enabled
 clippy_gpu: install_rs_check_toolchain
 	RUSTFLAGS="$(RUSTFLAGS)" cargo "$(CARGO_RS_CHECK_TOOLCHAIN)" clippy \
-		--features=boolean,shortint,integer,internal-keycache,gpu \
+		--features=boolean,shortint,integer,internal-keycache,gpu,pbs-stats \
 		--all-targets \
 		-p $(TFHE_SPEC) -- --no-deps -D warnings
 
 .PHONY: check_gpu # Run check on tfhe with "gpu" enabled
 check_gpu: install_rs_check_toolchain
 	RUSTFLAGS="$(RUSTFLAGS)" cargo "$(CARGO_RS_CHECK_TOOLCHAIN)" check \
-		--features=boolean,shortint,integer,internal-keycache,gpu \
+		--features=boolean,shortint,integer,internal-keycache,gpu,pbs-stats \
 		--all-targets \
 		-p $(TFHE_SPEC)
 
@@ -407,10 +407,10 @@ clippy_trivium: install_rs_check_toolchain
 .PHONY: clippy_all_targets # Run clippy lints on all targets (benches, examples, etc.)
 clippy_all_targets: install_rs_check_toolchain
 	RUSTFLAGS="$(RUSTFLAGS)" cargo "$(CARGO_RS_CHECK_TOOLCHAIN)" clippy --all-targets \
-		--features=boolean,shortint,integer,internal-keycache,zk-pok,strings \
+		--features=boolean,shortint,integer,internal-keycache,zk-pok,strings,pbs-stats \
 		-p $(TFHE_SPEC) -- --no-deps -D warnings
 	RUSTFLAGS="$(RUSTFLAGS)" cargo "$(CARGO_RS_CHECK_TOOLCHAIN)" clippy --all-targets \
-		--features=boolean,shortint,integer,internal-keycache,zk-pok,strings,experimental \
+		--features=boolean,shortint,integer,internal-keycache,zk-pok,strings,pbs-stats,experimental \
 		-p $(TFHE_SPEC) -- --no-deps -D warnings
 
 .PHONY: clippy_tfhe_csprng # Run clippy lints on tfhe-csprng
@@ -1073,35 +1073,42 @@ bench_integer: install_rs_check_toolchain
 	RUSTFLAGS="$(RUSTFLAGS)" __TFHE_RS_BENCH_OP_FLAVOR=$(BENCH_OP_FLAVOR) __TFHE_RS_FAST_BENCH=$(FAST_BENCH) __TFHE_RS_BENCH_TYPE=$(BENCH_TYPE) \
 	cargo $(CARGO_RS_CHECK_TOOLCHAIN) bench \
 	--bench integer-bench \
-	--features=integer,internal-keycache,nightly-avx512 -p $(TFHE_SPEC) --
+	--features=integer,internal-keycache,nightly-avx512,pbs-stats -p $(TFHE_SPEC) --
 
 .PHONY: bench_signed_integer # Run benchmarks for signed integer
 bench_signed_integer: install_rs_check_toolchain
 	RUSTFLAGS="$(RUSTFLAGS)" __TFHE_RS_BENCH_OP_FLAVOR=$(BENCH_OP_FLAVOR) __TFHE_RS_FAST_BENCH=$(FAST_BENCH) __TFHE_RS_BENCH_TYPE=$(BENCH_TYPE) \
 	cargo $(CARGO_RS_CHECK_TOOLCHAIN) bench \
 	--bench integer-signed-bench \
-	--features=integer,internal-keycache,nightly-avx512 -p $(TFHE_SPEC) --
+	--features=integer,internal-keycache,nightly-avx512,pbs-stats -p $(TFHE_SPEC) --
 
 .PHONY: bench_integer_gpu # Run benchmarks for integer on GPU backend
 bench_integer_gpu: install_rs_check_toolchain
 	RUSTFLAGS="$(RUSTFLAGS)" __TFHE_RS_BENCH_OP_FLAVOR=$(BENCH_OP_FLAVOR) __TFHE_RS_FAST_BENCH=$(FAST_BENCH) __TFHE_RS_BENCH_TYPE=$(BENCH_TYPE) \
 	cargo $(CARGO_RS_CHECK_TOOLCHAIN) bench \
 	--bench integer-bench \
-	--features=integer,gpu,internal-keycache,nightly-avx512 -p $(TFHE_SPEC) --
+	--features=integer,gpu,internal-keycache,nightly-avx512,pbs-stats -p $(TFHE_SPEC) --
+
+.PHONY: bench_signed_integer_gpu # Run benchmarks for signed integer on GPU backend
+bench_signed_integer_gpu: install_rs_check_toolchain
+	RUSTFLAGS="$(RUSTFLAGS)" __TFHE_RS_BENCH_OP_FLAVOR=$(BENCH_OP_FLAVOR) __TFHE_RS_FAST_BENCH=$(FAST_BENCH) __TFHE_RS_BENCH_TYPE=$(BENCH_TYPE) \
+	cargo $(CARGO_RS_CHECK_TOOLCHAIN) bench \
+	--bench integer-signed-bench \
+	--features=integer,gpu,internal-keycache,nightly-avx512,pbs-stats -p $(TFHE_SPEC) --
 
 .PHONY: bench_integer_compression # Run benchmarks for unsigned integer compression
 bench_integer_compression: install_rs_check_toolchain
 	RUSTFLAGS="$(RUSTFLAGS)" __TFHE_RS_BENCH_TYPE=$(BENCH_TYPE) \
 	cargo $(CARGO_RS_CHECK_TOOLCHAIN) bench \
 	--bench	glwe_packing_compression-integer-bench \
-	--features=integer,internal-keycache,nightly-avx512 -p $(TFHE_SPEC) --
+	--features=integer,internal-keycache,nightly-avx512,pbs-stats -p $(TFHE_SPEC) --
 
 .PHONY: bench_integer_compression_gpu
 bench_integer_compression_gpu: install_rs_check_toolchain
 	RUSTFLAGS="$(RUSTFLAGS)" __TFHE_RS_BENCH_TYPE=$(BENCH_TYPE) \
 	cargo $(CARGO_RS_CHECK_TOOLCHAIN) bench \
 	--bench	glwe_packing_compression-integer-bench \
-	--features=integer,internal-keycache,gpu -p $(TFHE_SPEC) --
+	--features=integer,internal-keycache,gpu,pbs-stats -p $(TFHE_SPEC) --
 
 .PHONY: bench_integer_multi_bit # Run benchmarks for unsigned integer using multi-bit parameters
 bench_integer_multi_bit: install_rs_check_toolchain
@@ -1109,7 +1116,7 @@ bench_integer_multi_bit: install_rs_check_toolchain
 	__TFHE_RS_BENCH_OP_FLAVOR=$(BENCH_OP_FLAVOR) __TFHE_RS_FAST_BENCH=$(FAST_BENCH) \
 	cargo $(CARGO_RS_CHECK_TOOLCHAIN) bench \
 	--bench integer-bench \
-	--features=integer,internal-keycache,nightly-avx512 -p $(TFHE_SPEC) --
+	--features=integer,internal-keycache,nightly-avx512,pbs-stats -p $(TFHE_SPEC) --
 
 .PHONY: bench_signed_integer_multi_bit # Run benchmarks for signed integer using multi-bit parameters
 bench_signed_integer_multi_bit: install_rs_check_toolchain
@@ -1117,7 +1124,7 @@ bench_signed_integer_multi_bit: install_rs_check_toolchain
 	__TFHE_RS_BENCH_OP_FLAVOR=$(BENCH_OP_FLAVOR) __TFHE_RS_FAST_BENCH=$(FAST_BENCH) \
 	cargo $(CARGO_RS_CHECK_TOOLCHAIN) bench \
 	--bench integer-signed-bench \
-	--features=integer,internal-keycache,nightly-avx512 -p $(TFHE_SPEC) --
+	--features=integer,internal-keycache,nightly-avx512,pbs-stats -p $(TFHE_SPEC) --
 
 .PHONY: bench_integer_multi_bit_gpu # Run benchmarks for integer on GPU backend using multi-bit parameters
 bench_integer_multi_bit_gpu: install_rs_check_toolchain
@@ -1125,22 +1132,22 @@ bench_integer_multi_bit_gpu: install_rs_check_toolchain
 	__TFHE_RS_BENCH_OP_FLAVOR=$(BENCH_OP_FLAVOR) __TFHE_RS_FAST_BENCH=$(FAST_BENCH) __TFHE_RS_BENCH_TYPE=$(BENCH_TYPE) \
 	cargo $(CARGO_RS_CHECK_TOOLCHAIN) bench \
 	--bench integer-bench \
-	--features=integer,gpu,internal-keycache,nightly-avx512 -p $(TFHE_SPEC) --
+	--features=integer,gpu,internal-keycache,nightly-avx512,pbs-stats -p $(TFHE_SPEC) --
 
-.PHONY: bench_unsigned_integer_multi_bit_gpu # Run benchmarks for unsigned integer on GPU backend using multi-bit parameters
-bench_unsigned_integer_multi_bit_gpu: install_rs_check_toolchain
+.PHONY: bench_signed_integer_multi_bit_gpu # Run benchmarks for signed integer on GPU backend using multi-bit parameters
+bench_signed_integer_multi_bit_gpu: install_rs_check_toolchain
 	RUSTFLAGS="$(RUSTFLAGS)" __TFHE_RS_PARAM_TYPE=MULTI_BIT \
 	__TFHE_RS_BENCH_OP_FLAVOR=$(BENCH_OP_FLAVOR) __TFHE_RS_FAST_BENCH=$(FAST_BENCH) __TFHE_RS_BENCH_TYPE=$(BENCH_TYPE) \
 	cargo $(CARGO_RS_CHECK_TOOLCHAIN) bench \
-	--bench integer-bench \
-	--features=integer,gpu,internal-keycache,nightly-avx512 -p $(TFHE_SPEC) -- ::unsigned
+	--bench integer-signed-bench \
+	--features=integer,gpu,internal-keycache,nightly-avx512,pbs-stats -p $(TFHE_SPEC) --
 
 .PHONY: bench_integer_zk # Run benchmarks for integer encryption with ZK proofs
 bench_integer_zk: install_rs_check_toolchain
 	RUSTFLAGS="$(RUSTFLAGS)" __TFHE_RS_BENCH_TYPE=$(BENCH_TYPE) \
 	cargo $(CARGO_RS_CHECK_TOOLCHAIN) bench \
 	--bench zk-pke-bench \
-	--features=integer,internal-keycache,zk-pok,nightly-avx512 \
+	--features=integer,internal-keycache,zk-pok,nightly-avx512,pbs-stats \
 	-p $(TFHE_SPEC) --
 
 .PHONY: bench_shortint # Run benchmarks for shortint

--- a/tfhe/benches/integer/bench.rs
+++ b/tfhe/benches/integer/bench.rs
@@ -11,6 +11,7 @@ use crate::utilities::{
 use criterion::{criterion_group, Criterion, Throughput};
 use rand::prelude::*;
 use rayon::prelude::*;
+use std::cmp::max;
 use std::env;
 use tfhe::integer::keycache::KEY_CACHE;
 use tfhe::integer::prelude::*;
@@ -143,30 +144,47 @@ fn bench_server_key_binary_function_clean_inputs<F>(
                 });
             }
             BenchmarkType::Throughput => {
+                let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
+
+                // Execute the operation once to know its cost.
+                let clear_0 = gen_random_u256(&mut rng);
+                let mut ct_0 = cks.encrypt_radix(clear_0, num_block);
+                let clear_1 = gen_random_u256(&mut rng);
+                let mut ct_1 = cks.encrypt_radix(clear_1, num_block);
+
+                reset_pbs_count();
+                binary_op(&sks, &mut ct_0, &mut ct_1);
+                let pbs_count = max(get_pbs_count(), 1); // Operation might not perform any PBS, so we take 1 as default
+
                 bench_id = format!("{bench_name}::throughput::{param_name}::{bit_size}_bits");
                 bench_group
                     .sample_size(10)
                     .measurement_time(std::time::Duration::from_secs(30));
-                let elements = throughput_num_threads(num_block);
+                let elements = throughput_num_threads(num_block, pbs_count);
                 bench_group.throughput(Throughput::Elements(elements));
                 bench_group.bench_function(&bench_id, |b| {
-                    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
+                    let setup_encrypted_values = || {
+                        let cts_0 = (0..elements)
+                            .map(|_| cks.encrypt_radix(gen_random_u256(&mut rng), num_block))
+                            .collect::<Vec<_>>();
+                        let cts_1 = (0..elements)
+                            .map(|_| cks.encrypt_radix(gen_random_u256(&mut rng), num_block))
+                            .collect::<Vec<_>>();
 
-                    let mut cts_0 = (0..elements)
-                        .map(|_| cks.encrypt_radix(gen_random_u256(&mut rng), num_block))
-                        .collect::<Vec<_>>();
-                    let mut cts_1 = (0..elements)
-                        .map(|_| cks.encrypt_radix(gen_random_u256(&mut rng), num_block))
-                        .collect::<Vec<_>>();
+                        (cts_0, cts_1)
+                    };
 
-                    b.iter(|| {
-                        cts_0
-                            .par_iter_mut()
-                            .zip(cts_1.par_iter_mut())
-                            .for_each(|(ct_0, ct_1)| {
-                                binary_op(&sks, ct_0, ct_1);
-                            })
-                    })
+                    b.iter_batched(
+                        setup_encrypted_values,
+                        |(mut cts_0, mut cts_1)| {
+                            cts_0.par_iter_mut().zip(cts_1.par_iter_mut()).for_each(
+                                |(ct_0, ct_1)| {
+                                    binary_op(&sks, ct_0, ct_1);
+                                },
+                            )
+                        },
+                        criterion::BatchSize::SmallInput,
+                    )
                 });
             }
         }
@@ -294,24 +312,37 @@ fn bench_server_key_unary_function_clean_inputs<F>(
                 });
             }
             BenchmarkType::Throughput => {
+                let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
+
+                // Execute the operation once to know its cost.
+                let clear_0 = gen_random_u256(&mut rng);
+                let mut ct_0 = cks.encrypt_radix(clear_0, num_block);
+
+                reset_pbs_count();
+                unary_fn(&sks, &mut ct_0);
+                let pbs_count = max(get_pbs_count(), 1); // Operation might not perform any PBS, so we take 1 as default
+
                 bench_id = format!("{bench_name}::throughput::{param_name}::{bit_size}_bits");
                 bench_group
                     .sample_size(10)
                     .measurement_time(std::time::Duration::from_secs(30));
-                let elements = throughput_num_threads(num_block);
+                let elements = throughput_num_threads(num_block, pbs_count);
                 bench_group.throughput(Throughput::Elements(elements));
                 bench_group.bench_function(&bench_id, |b| {
-                    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
-
-                    let mut cts_0 = (0..elements)
-                        .map(|_| cks.encrypt_radix(gen_random_u256(&mut rng), num_block))
-                        .collect::<Vec<_>>();
-
-                    b.iter(|| {
-                        cts_0.par_iter_mut().for_each(|ct_0| {
-                            unary_fn(&sks, ct_0);
-                        })
-                    })
+                    let setup_encrypted_values = || {
+                        (0..elements)
+                            .map(|_| cks.encrypt_radix(gen_random_u256(&mut rng), num_block))
+                            .collect::<Vec<_>>()
+                    };
+                    b.iter_batched(
+                        setup_encrypted_values,
+                        |mut cts| {
+                            cts.par_iter_mut().for_each(|ct_0| {
+                                unary_fn(&sks, ct_0);
+                            })
+                        },
+                        criterion::BatchSize::SmallInput,
+                    )
                 });
             }
         }
@@ -451,30 +482,45 @@ fn bench_server_key_binary_scalar_function_clean_inputs<F, G>(
                 });
             }
             BenchmarkType::Throughput => {
+                let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
+
+                // Execute the operation once to know its cost.
+                let clear_0 = gen_random_u256(&mut rng);
+                let mut ct_0 = cks.encrypt_radix(clear_0, num_block);
+                let clear_1 = rng_func(&mut rng, bit_size) & max_value_for_bit_size;
+
+                reset_pbs_count();
+                binary_op(&sks, &mut ct_0, clear_1);
+                let pbs_count = max(get_pbs_count(), 1); // Operation might not perform any PBS, so we take 1 as default
+
                 bench_id = format!("{bench_name}::throughput::{param_name}::{bit_size}_bits");
                 bench_group
                     .sample_size(10)
                     .measurement_time(std::time::Duration::from_secs(30));
-                let elements = throughput_num_threads(num_block);
+                let elements = throughput_num_threads(num_block, pbs_count);
                 bench_group.throughput(Throughput::Elements(elements));
                 bench_group.bench_function(&bench_id, |b| {
-                    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
+                    let setup_encrypted_values = || {
+                        let cts_0 = (0..elements)
+                            .map(|_| cks.encrypt_radix(gen_random_u256(&mut rng), num_block))
+                            .collect::<Vec<_>>();
+                        let clears_1 = (0..elements)
+                            .map(|_| rng_func(&mut rng, bit_size) & max_value_for_bit_size)
+                            .collect::<Vec<_>>();
 
-                    let mut cts_0 = (0..elements)
-                        .map(|_| cks.encrypt_radix(gen_random_u256(&mut rng), num_block))
-                        .collect::<Vec<_>>();
-                    let clears_1 = (0..elements)
-                        .map(|_| rng_func(&mut rng, bit_size) & max_value_for_bit_size)
-                        .collect::<Vec<_>>();
-
-                    b.iter(|| {
-                        cts_0
-                            .par_iter_mut()
-                            .zip(clears_1.par_iter())
-                            .for_each(|(ct_0, clear_1)| {
-                                binary_op(&sks, ct_0, *clear_1);
-                            })
-                    })
+                        (cts_0, clears_1)
+                    };
+                    b.iter_batched(
+                        setup_encrypted_values,
+                        |(mut cts_0, clears_1)| {
+                            cts_0.par_iter_mut().zip(clears_1.par_iter()).for_each(
+                                |(ct_0, clear_1)| {
+                                    binary_op(&sks, ct_0, *clear_1);
+                                },
+                            )
+                        },
+                        criterion::BatchSize::SmallInput,
+                    )
                 });
             }
         }
@@ -567,35 +613,56 @@ fn if_then_else_parallelized(c: &mut Criterion) {
                 });
             }
             BenchmarkType::Throughput => {
+                let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
+
+                // Execute the operation once to know its cost.
+                let clear_0 = gen_random_u256(&mut rng);
+                let true_ct = cks.encrypt_radix(clear_0, num_block);
+
+                let clear_1 = gen_random_u256(&mut rng);
+                let false_ct = cks.encrypt_radix(clear_1, num_block);
+
+                let condition = sks.create_trivial_boolean_block(rng.gen_bool(0.5));
+
+                reset_pbs_count();
+                sks.if_then_else_parallelized(&condition, &true_ct, &false_ct);
+                let pbs_count = max(get_pbs_count(), 1); // Operation might not perform any PBS, so we take 1 as default
+
                 bench_id = format!("{bench_name}::throughput::{param_name}::{bit_size}_bits");
                 bench_group
                     .sample_size(10)
                     .measurement_time(std::time::Duration::from_secs(30));
-                let elements = throughput_num_threads(num_block);
+                let elements = throughput_num_threads(num_block, pbs_count);
                 bench_group.throughput(Throughput::Elements(elements));
                 bench_group.bench_function(&bench_id, |b| {
-                    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
+                    let setup_encrypted_values = || {
+                        let cts_cond = (0..elements)
+                            .map(|_| sks.create_trivial_boolean_block(rng.gen_bool(0.5)))
+                            .collect::<Vec<_>>();
 
-                    let cts_cond = (0..elements)
-                        .map(|_| sks.create_trivial_boolean_block(rng.gen_bool(0.5)))
-                        .collect::<Vec<_>>();
+                        let cts_then = (0..elements)
+                            .map(|_| cks.encrypt_radix(gen_random_u256(&mut rng), num_block))
+                            .collect::<Vec<_>>();
+                        let cts_else = (0..elements)
+                            .map(|_| cks.encrypt_radix(gen_random_u256(&mut rng), num_block))
+                            .collect::<Vec<_>>();
 
-                    let cts_then = (0..elements)
-                        .map(|_| cks.encrypt_radix(gen_random_u256(&mut rng), num_block))
-                        .collect::<Vec<_>>();
-                    let cts_else = (0..elements)
-                        .map(|_| cks.encrypt_radix(gen_random_u256(&mut rng), num_block))
-                        .collect::<Vec<_>>();
+                        (cts_cond, cts_then, cts_else)
+                    };
 
-                    b.iter(|| {
-                        cts_cond
-                            .par_iter()
-                            .zip(cts_then.par_iter())
-                            .zip(cts_else.par_iter())
-                            .for_each(|((condition, true_ct), false_ct)| {
-                                sks.if_then_else_parallelized(condition, true_ct, false_ct);
-                            })
-                    })
+                    b.iter_batched(
+                        setup_encrypted_values,
+                        |(cts_cond, cts_then, cts_else)| {
+                            cts_cond
+                                .par_iter()
+                                .zip(cts_then.par_iter())
+                                .zip(cts_else.par_iter())
+                                .for_each(|((condition, true_ct), false_ct)| {
+                                    sks.if_then_else_parallelized(condition, true_ct, false_ct);
+                                })
+                        },
+                        criterion::BatchSize::SmallInput,
+                    );
                 });
             }
         }
@@ -663,41 +730,61 @@ fn ciphertexts_sum_parallelized(c: &mut Criterion) {
                     });
                 }
                 BenchmarkType::Throughput => {
+                    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
+
+                    // Execute the operation once to know its cost.
+                    let nb_ctxt = bit_size.div_ceil(param.message_modulus().0.ilog2() as usize);
+                    let cks = RadixClientKey::from((cks, nb_ctxt));
+
+                    let clears = (0..len)
+                        .map(|_| gen_random_u256(&mut rng) & max_for_bit_size)
+                        .collect::<Vec<_>>();
+                    let ctxts = clears
+                        .iter()
+                        .copied()
+                        .map(|clear| cks.encrypt(clear))
+                        .collect::<Vec<_>>();
+
+                    reset_pbs_count();
+                    sks.sum_ciphertexts_parallelized(&ctxts);
+                    let pbs_count = max(get_pbs_count(), 1); // Operation might not perform any PBS, so we take 1 as default
+
                     bench_id = format!(
                         "{bench_name}_{len}_ctxts::throughput::{param_name}::{bit_size}_bits"
                     );
                     bench_group
                         .sample_size(10)
                         .measurement_time(std::time::Duration::from_secs(30));
-                    let elements = throughput_num_threads(num_block);
+                    let elements = throughput_num_threads(num_block, pbs_count);
                     bench_group.throughput(Throughput::Elements(elements));
                     bench_group.bench_function(&bench_id, |b| {
-                        let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
+                        let setup_encrypted_values = || {
+                            (0..elements)
+                                .map(|_| {
+                                    let clears = (0..len)
+                                        .map(|_| gen_random_u256(&mut rng) & max_for_bit_size)
+                                        .collect::<Vec<_>>();
 
-                        let nb_ctxt = bit_size.div_ceil(param.message_modulus().0.ilog2() as usize);
-                        let cks = RadixClientKey::from((cks, nb_ctxt));
+                                    let ctxts = clears
+                                        .iter()
+                                        .copied()
+                                        .map(|clear| cks.encrypt(clear))
+                                        .collect::<Vec<_>>();
 
-                        let cts = (0..elements)
-                            .map(|_| {
-                                let clears = (0..len)
-                                    .map(|_| gen_random_u256(&mut rng) & max_for_bit_size)
-                                    .collect::<Vec<_>>();
+                                    ctxts
+                                })
+                                .collect::<Vec<_>>()
+                        };
 
-                                let ctxts = clears
-                                    .iter()
-                                    .copied()
-                                    .map(|clear| cks.encrypt(clear))
-                                    .collect::<Vec<_>>();
-
-                                ctxts
-                            })
-                            .collect::<Vec<_>>();
-
-                        b.iter(|| {
-                            cts.par_iter().for_each(|ctxts| {
-                                sks.sum_ciphertexts_parallelized(ctxts);
-                            })
-                        })
+                        b.iter_batched(
+                            setup_encrypted_values,
+                            |cts| {
+                                cts.par_iter().for_each(|ctxts| {
+                                    sks.sum_ciphertexts_parallelized(ctxts);
+                                })
+                            },
+                            criterion::BatchSize::SmallInput,
+                        );
                     });
                 }
             }
@@ -1307,20 +1394,25 @@ define_server_key_bench_default_fn!(
 #[cfg(feature = "gpu")]
 mod cuda {
     use super::*;
+    use crate::utilities::cuda_local_streams;
     use criterion::{black_box, criterion_group};
+    use std::cmp::max;
     use tfhe::core_crypto::gpu::CudaStreams;
     use tfhe::integer::gpu::ciphertext::boolean_value::CudaBooleanBlock;
     use tfhe::integer::gpu::ciphertext::CudaUnsignedRadixCiphertext;
     use tfhe::integer::gpu::server_key::CudaServerKey;
+    use tfhe::integer::{RadixCiphertext, ServerKey};
     use tfhe_csprng::seeders::Seed;
 
-    fn bench_cuda_server_key_unary_function_clean_inputs<F>(
+    fn bench_cuda_server_key_unary_function_clean_inputs<F, G>(
         c: &mut Criterion,
         bench_name: &str,
         display_name: &str,
         unary_op: F,
+        unary_op_cpu: G,
     ) where
         F: Fn(&CudaServerKey, &mut CudaUnsignedRadixCiphertext, &CudaStreams) + Sync,
+        G: Fn(&ServerKey, &mut RadixCiphertext) + Sync,
     {
         let mut bench_group = c.benchmark_group(bench_name);
         bench_group
@@ -1359,29 +1451,51 @@ mod cuda {
                     });
                 }
                 BenchmarkType::Throughput => {
+                    let (cks, cpu_sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
+                    let gpu_sks = CudaServerKey::new(&cks, &streams);
+
+                    let clear_0 = gen_random_u256(&mut rng);
+                    let mut ct_0 = cks.encrypt_radix(clear_0, num_block);
+
+                    reset_pbs_count();
+                    // Use CPU operation as pbs_count do not count PBS on GPU backend.
+                    unary_op_cpu(&cpu_sks, &mut ct_0);
+                    let pbs_count = max(get_pbs_count(), 1); // Operation might not perform any PBS, so we take 1 as default
+
                     bench_id = format!("{bench_name}::throughput::{param_name}::{bit_size}_bits");
                     bench_group
                         .sample_size(10)
                         .measurement_time(std::time::Duration::from_secs(30));
-                    let elements = throughput_num_threads(num_block);
+                    let elements = throughput_num_threads(num_block, pbs_count);
                     bench_group.throughput(Throughput::Elements(elements));
                     bench_group.bench_function(&bench_id, |b| {
-                        let (cks, _cpu_sks) =
-                            KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
-                        let gpu_sks = CudaServerKey::new(&cks, &streams);
+                        let setup_encrypted_values = || {
+                            let cts = (0..elements)
+                                .map(|_| {
+                                    let ct_0 =
+                                        cks.encrypt_radix(gen_random_u256(&mut rng), num_block);
+                                    CudaUnsignedRadixCiphertext::from_radix_ciphertext(
+                                        &ct_0, &streams,
+                                    )
+                                })
+                                .collect::<Vec<_>>();
 
-                        let mut cts_0 = (0..elements)
-                            .map(|_| {
-                                let ct_0 = cks.encrypt_radix(gen_random_u256(&mut rng), num_block);
-                                CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct_0, &streams)
-                            })
-                            .collect::<Vec<_>>();
+                            let local_streams = cuda_local_streams(num_block, elements as usize);
 
-                        b.iter(|| {
-                            cts_0.par_iter_mut().for_each(|ct_0| {
-                                unary_op(&gpu_sks, ct_0, &streams);
-                            })
-                        })
+                            (cts, local_streams)
+                        };
+
+                        b.iter_batched(
+                            setup_encrypted_values,
+                            |(mut cts, local_streams)| {
+                                cts.par_iter_mut().zip(local_streams.par_iter()).for_each(
+                                    |(ct_0, local_stream)| {
+                                        unary_op(&gpu_sks, ct_0, local_stream);
+                                    },
+                                )
+                            },
+                            criterion::BatchSize::SmallInput,
+                        )
                     });
                 }
             }
@@ -1402,11 +1516,12 @@ mod cuda {
 
     /// Base function to bench a server key function that is a binary operation, input ciphertext
     /// will contain only zero carries
-    fn bench_cuda_server_key_binary_function_clean_inputs<F>(
+    fn bench_cuda_server_key_binary_function_clean_inputs<F, G>(
         c: &mut Criterion,
         bench_name: &str,
         display_name: &str,
         binary_op: F,
+        binary_op_cpu: G,
     ) where
         F: Fn(
                 &CudaServerKey,
@@ -1414,6 +1529,7 @@ mod cuda {
                 &mut CudaUnsignedRadixCiphertext,
                 &CudaStreams,
             ) + Sync,
+        G: Fn(&ServerKey, &mut RadixCiphertext, &mut RadixCiphertext) + Sync,
     {
         let mut bench_group = c.benchmark_group(bench_name);
         bench_group
@@ -1458,37 +1574,65 @@ mod cuda {
                     });
                 }
                 BenchmarkType::Throughput => {
+                    let (cks, cpu_sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
+                    let gpu_sks = CudaServerKey::new(&cks, &streams);
+
+                    // Execute the operation once to know its cost.
+                    let clear_0 = gen_random_u256(&mut rng);
+                    let mut ct_0 = cks.encrypt_radix(clear_0, num_block);
+                    let clear_1 = gen_random_u256(&mut rng);
+                    let mut ct_1 = cks.encrypt_radix(clear_1, num_block);
+
+                    reset_pbs_count();
+                    // Use CPU operation as pbs_count do not count PBS on GPU backend.
+                    binary_op_cpu(&cpu_sks, &mut ct_0, &mut ct_1);
+                    let pbs_count = max(get_pbs_count(), 1); // Operation might not perform any PBS, so we take 1 as default
+
                     bench_id = format!("{bench_name}::throughput::{param_name}::{bit_size}_bits");
                     bench_group
                         .sample_size(10)
                         .measurement_time(std::time::Duration::from_secs(30));
-                    let elements = throughput_num_threads(num_block);
+                    let elements = throughput_num_threads(num_block, pbs_count);
                     bench_group.throughput(Throughput::Elements(elements));
                     bench_group.bench_function(&bench_id, |b| {
-                        let (cks, _cpu_sks) =
-                            KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
-                        let gpu_sks = CudaServerKey::new(&cks, &streams);
+                        let setup_encrypted_values = || {
+                            let cts_0 = (0..elements)
+                                .map(|_| {
+                                    let ct_0 =
+                                        cks.encrypt_radix(gen_random_u256(&mut rng), num_block);
+                                    CudaUnsignedRadixCiphertext::from_radix_ciphertext(
+                                        &ct_0, &streams,
+                                    )
+                                })
+                                .collect::<Vec<_>>();
+                            let cts_1 = (0..elements)
+                                .map(|_| {
+                                    let ct_1 =
+                                        cks.encrypt_radix(gen_random_u256(&mut rng), num_block);
+                                    CudaUnsignedRadixCiphertext::from_radix_ciphertext(
+                                        &ct_1, &streams,
+                                    )
+                                })
+                                .collect::<Vec<_>>();
 
-                        let mut cts_0 = (0..elements)
-                            .map(|_| {
-                                let ct_0 = cks.encrypt_radix(gen_random_u256(&mut rng), num_block);
-                                CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct_0, &streams)
-                            })
-                            .collect::<Vec<_>>();
-                        let mut cts_1 = (0..elements)
-                            .map(|_| {
-                                let ct_1 = cks.encrypt_radix(gen_random_u256(&mut rng), num_block);
-                                CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct_1, &streams)
-                            })
-                            .collect::<Vec<_>>();
+                            let local_streams = cuda_local_streams(num_block, elements as usize);
 
-                        b.iter(|| {
-                            cts_0.par_iter_mut().zip(cts_1.par_iter_mut()).for_each(
-                                |(ct_0, ct_1)| {
-                                    binary_op(&gpu_sks, ct_0, ct_1, &streams);
-                                },
-                            )
-                        })
+                            (cts_0, cts_1, local_streams)
+                        };
+
+                        b.iter_batched(
+                            setup_encrypted_values,
+                            |(mut cts_0, mut cts_1, local_streams)| {
+                                cts_0
+                                    .par_iter_mut()
+                                    .zip(cts_1.par_iter_mut())
+                                    .zip(local_streams.par_iter())
+                                    .for_each(|((ct_0, ct_1), local_stream)| {
+                                        binary_op(&gpu_sks, ct_0, ct_1, local_stream);
+                                    })
+                            },
+                            criterion::BatchSize::SmallInput,
+                        );
                     });
                 }
             }
@@ -1507,15 +1651,17 @@ mod cuda {
         bench_group.finish()
     }
 
-    fn bench_cuda_server_key_binary_scalar_function_clean_inputs<F, G>(
+    fn bench_cuda_server_key_binary_scalar_function_clean_inputs<F, G, H>(
         c: &mut Criterion,
         bench_name: &str,
         display_name: &str,
         binary_op: F,
-        rng_func: G,
+        binary_op_cpu: G,
+        rng_func: H,
     ) where
         F: Fn(&CudaServerKey, &mut CudaUnsignedRadixCiphertext, ScalarType, &CudaStreams) + Sync,
-        G: Fn(&mut ThreadRng, usize) -> ScalarType,
+        G: Fn(&ServerKey, &mut RadixCiphertext, ScalarType) + Sync,
+        H: Fn(&mut ThreadRng, usize) -> ScalarType,
     {
         let mut bench_group = c.benchmark_group(bench_name);
         let mut rng = rand::thread_rng();
@@ -1565,36 +1711,60 @@ mod cuda {
                     });
                 }
                 BenchmarkType::Throughput => {
+                    let (cks, cpu_sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
+                    let gpu_sks = CudaServerKey::new(&cks, &streams);
+
+                    // Execute the operation once to know its cost.
+                    let clear_0 = gen_random_u256(&mut rng);
+                    let mut ct_0 = cks.encrypt_radix(clear_0, num_block);
+                    let clear_1 = rng_func(&mut rng, bit_size) & max_value_for_bit_size;
+
+                    reset_pbs_count();
+                    // Use CPU operation as pbs_count do not count PBS on GPU backend.
+                    binary_op_cpu(&cpu_sks, &mut ct_0, clear_1);
+                    let pbs_count = max(get_pbs_count(), 1); // Operation might not perform any PBS, so we take 1 as default
+
                     bench_group
                         .sample_size(10)
                         .measurement_time(std::time::Duration::from_secs(30));
                     bench_id = format!(
                         "{bench_name}::throughput::{param_name}::{bit_size}_bits_scalar_{bit_size}"
                     );
-                    let elements = throughput_num_threads(num_block);
+                    let elements = throughput_num_threads(num_block, pbs_count);
                     bench_group.throughput(Throughput::Elements(elements));
                     bench_group.bench_function(&bench_id, |b| {
-                        let (cks, _cpu_sks) =
-                            KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
-                        let gpu_sks = CudaServerKey::new(&cks, &streams);
+                        let setup_encrypted_values = || {
+                            let cts_0 = (0..elements)
+                                .map(|_| {
+                                    let ct_0 =
+                                        cks.encrypt_radix(gen_random_u256(&mut rng), num_block);
+                                    CudaUnsignedRadixCiphertext::from_radix_ciphertext(
+                                        &ct_0, &streams,
+                                    )
+                                })
+                                .collect::<Vec<_>>();
+                            let clears_1 = (0..elements)
+                                .map(|_| rng_func(&mut rng, bit_size) & max_value_for_bit_size)
+                                .collect::<Vec<_>>();
 
-                        let mut cts_0 = (0..elements)
-                            .map(|_| {
-                                let ct_0 = cks.encrypt_radix(gen_random_u256(&mut rng), num_block);
-                                CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct_0, &streams)
-                            })
-                            .collect::<Vec<_>>();
-                        let clears_1 = (0..elements)
-                            .map(|_| rng_func(&mut rng, bit_size) & max_value_for_bit_size)
-                            .collect::<Vec<_>>();
+                            let local_streams = cuda_local_streams(num_block, elements as usize);
 
-                        b.iter(|| {
-                            cts_0.par_iter_mut().zip(clears_1.par_iter()).for_each(
-                                |(ct_0, clear_1)| {
-                                    binary_op(&gpu_sks, ct_0, *clear_1, &streams);
-                                },
-                            )
-                        })
+                            (cts_0, clears_1, local_streams)
+                        };
+
+                        b.iter_batched(
+                            setup_encrypted_values,
+                            |(mut cts_0, clears_1, local_streams)| {
+                                cts_0
+                                    .par_iter_mut()
+                                    .zip(clears_1.par_iter())
+                                    .zip(local_streams.par_iter())
+                                    .for_each(|((ct_0, clear_1), local_stream)| {
+                                        binary_op(&gpu_sks, ct_0, *clear_1, local_stream);
+                                    })
+                            },
+                            criterion::BatchSize::SmallInput,
+                        );
                     });
                 }
             }
@@ -1668,52 +1838,77 @@ mod cuda {
                     });
                 }
                 BenchmarkType::Throughput => {
+                    let (cks, cpu_sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
+                    let gpu_sks = CudaServerKey::new(&cks, &stream);
+
+                    // Execute the operation once to know its cost.
+                    let clear_0 = gen_random_u256(&mut rng);
+                    let ct_then = cks.encrypt_radix(clear_0, num_block);
+                    let clear_1 = gen_random_u256(&mut rng);
+                    let ct_else = cks.encrypt_radix(clear_1, num_block);
+                    let ct_cond = cpu_sks.create_trivial_boolean_block(rng.gen_bool(0.5));
+
+                    reset_pbs_count();
+                    // Use CPU operation as pbs_count do not count PBS on GPU backend.
+                    cpu_sks.if_then_else_parallelized(&ct_cond, &ct_then, &ct_else);
+                    let pbs_count = max(get_pbs_count(), 1); // Operation might not perform any PBS, so we take 1 as default
+
                     bench_id = format!("{bench_name}::throughput::{param_name}::{bit_size}_bits");
                     bench_group
                         .sample_size(10)
                         .measurement_time(std::time::Duration::from_secs(30));
-                    let elements = throughput_num_threads(num_block);
+                    let elements = throughput_num_threads(num_block, pbs_count);
                     bench_group.throughput(Throughput::Elements(elements));
                     bench_group.bench_function(&bench_id, |b| {
-                        let (cks, _cpu_sks) =
-                            KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
-                        let gpu_sks = CudaServerKey::new(&cks, &stream);
-
-                        let cts_cond = (0..elements)
-                            .map(|_| {
-                                let ct_cond = cks.encrypt_bool(rng.gen::<bool>());
-                                CudaBooleanBlock::from_boolean_block(&ct_cond, &stream)
-                            })
-                            .collect::<Vec<_>>();
-                        let cts_then = (0..elements)
-                            .map(|_| {
-                                let ct_then =
-                                    cks.encrypt_radix(gen_random_u256(&mut rng), num_block);
-                                CudaUnsignedRadixCiphertext::from_radix_ciphertext(
-                                    &ct_then, &stream,
-                                )
-                            })
-                            .collect::<Vec<_>>();
-                        let cts_else = (0..elements)
-                            .map(|_| {
-                                let ct_else =
-                                    cks.encrypt_radix(gen_random_u256(&mut rng), num_block);
-                                CudaUnsignedRadixCiphertext::from_radix_ciphertext(
-                                    &ct_else, &stream,
-                                )
-                            })
-                            .collect::<Vec<_>>();
-
-                        b.iter(|| {
-                            cts_cond
-                                .par_iter()
-                                .zip(cts_then.par_iter())
-                                .zip(cts_else.par_iter())
-                                .for_each(|((ct_cond, ct_then), ct_else)| {
-                                    let _ =
-                                        gpu_sks.if_then_else(ct_cond, ct_then, ct_else, &stream);
+                        let setup_encrypted_values = || {
+                            let cts_cond = (0..elements)
+                                .map(|_| {
+                                    let ct_cond = cks.encrypt_bool(rng.gen::<bool>());
+                                    CudaBooleanBlock::from_boolean_block(&ct_cond, &stream)
                                 })
-                        })
+                                .collect::<Vec<_>>();
+                            let cts_then = (0..elements)
+                                .map(|_| {
+                                    let ct_then =
+                                        cks.encrypt_radix(gen_random_u256(&mut rng), num_block);
+                                    CudaUnsignedRadixCiphertext::from_radix_ciphertext(
+                                        &ct_then, &stream,
+                                    )
+                                })
+                                .collect::<Vec<_>>();
+                            let cts_else = (0..elements)
+                                .map(|_| {
+                                    let ct_else =
+                                        cks.encrypt_radix(gen_random_u256(&mut rng), num_block);
+                                    CudaUnsignedRadixCiphertext::from_radix_ciphertext(
+                                        &ct_else, &stream,
+                                    )
+                                })
+                                .collect::<Vec<_>>();
+
+                            let local_streams = cuda_local_streams(num_block, elements as usize);
+
+                            (cts_cond, cts_then, cts_else, local_streams)
+                        };
+                        b.iter_batched(
+                            setup_encrypted_values,
+                            |(cts_cond, cts_then, cts_else, local_streams)| {
+                                cts_cond
+                                    .par_iter()
+                                    .zip(cts_then.par_iter())
+                                    .zip(cts_else.par_iter())
+                                    .zip(local_streams.par_iter())
+                                    .for_each(|(((ct_cond, ct_then), ct_else), local_stream)| {
+                                        let _ = gpu_sks.if_then_else(
+                                            ct_cond,
+                                            ct_then,
+                                            ct_else,
+                                            local_stream,
+                                        );
+                                    })
+                            },
+                            criterion::BatchSize::SmallInput,
+                        );
                     });
                 }
             }
@@ -1769,15 +1964,22 @@ mod cuda {
                     });
                 }
                 BenchmarkType::Throughput => {
+                    let (cks, cpu_sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
+                    let gpu_sks = CudaServerKey::new(&cks, &streams);
+
+                    // Execute the operation once to know its cost.
+                    reset_pbs_count();
+                    cpu_sks.par_generate_oblivious_pseudo_random_unsigned_integer_bounded(
+                        Seed(0),
+                        bit_size as u64,
+                        num_block as u64,
+                    );
+                    let pbs_count = max(get_pbs_count(), 1); // Operation might not perform any PBS, so we take 1 as default
+
                     bench_id = format!("{bench_name}::throughput::{param_name}::{bit_size}_bits");
-                    let elements = throughput_num_threads(num_block);
+                    let elements = throughput_num_threads(num_block, pbs_count);
                     bench_group.throughput(Throughput::Elements(elements));
-
                     bench_group.bench_function(&bench_id, |b| {
-                        let (cks, _cpu_sks) =
-                            KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
-                        let gpu_sks = CudaServerKey::new(&cks, &streams);
-
                         b.iter(|| {
                             (0..elements).into_par_iter().for_each(|i| {
                                 let selected_gpu =
@@ -1811,7 +2013,7 @@ mod cuda {
     }
 
     macro_rules! define_cuda_server_key_bench_clean_input_unary_fn (
-        (method_name: $server_key_method:ident, display_name:$name:ident) => {
+        (method_name: $server_key_method:ident, method_name_cpu: $server_key_method_cpu:ident, display_name: $name:ident) => {
             ::paste::paste!{
                 fn [<cuda_ $server_key_method>](c: &mut Criterion) {
                     bench_cuda_server_key_unary_function_clean_inputs(
@@ -1820,6 +2022,9 @@ mod cuda {
                         stringify!($name),
                         |server_key, lhs, stream| {
                             server_key.$server_key_method(lhs, stream);
+                        },
+                        |server_key_cpu, lhs| {
+                            server_key_cpu.$server_key_method_cpu(lhs);
                         }
                     )
                 }
@@ -1827,7 +2032,7 @@ mod cuda {
         });
 
     macro_rules! define_cuda_server_key_bench_clean_input_fn (
-        (method_name: $server_key_method:ident, display_name:$name:ident) => {
+        (method_name: $server_key_method:ident, method_name_cpu: $server_key_method_cpu:ident, display_name:$name:ident) => {
             ::paste::paste!{
                 fn [<cuda_ $server_key_method>](c: &mut Criterion) {
                     bench_cuda_server_key_binary_function_clean_inputs(
@@ -1836,6 +2041,9 @@ mod cuda {
                         stringify!($name),
                         |server_key, lhs, rhs, stream| {
                             server_key.$server_key_method(lhs, rhs, stream);
+                        },
+                        |server_key_cpu, lhs, rhs| {
+                            server_key_cpu.$server_key_method_cpu(lhs, rhs);
                         }
                     )
                 }
@@ -1844,7 +2052,7 @@ mod cuda {
     );
 
     macro_rules! define_cuda_server_key_bench_clean_input_scalar_fn (
-        (method_name: $server_key_method:ident, display_name:$name:ident, rng_func:$($rng_fn:tt)*) => {
+        (method_name: $server_key_method:ident,  method_name_cpu: $server_key_method_cpu:ident, display_name:$name:ident, rng_func:$($rng_fn:tt)*) => {
             ::paste::paste!{
                 fn [<cuda_ $server_key_method>](c: &mut Criterion) {
                     bench_cuda_server_key_binary_scalar_function_clean_inputs(
@@ -1853,6 +2061,9 @@ mod cuda {
                         stringify!($name),
                         |server_key, lhs, rhs, stream| {
                             server_key.$server_key_method(lhs, rhs, stream);
+                        },
+                        |server_key_cpu, lhs, rhs| {
+                            server_key_cpu.$server_key_method_cpu(lhs, rhs);
                         },
                         $($rng_fn)*
                     )
@@ -1866,222 +2077,262 @@ mod cuda {
     //===========================================
     define_cuda_server_key_bench_clean_input_unary_fn!(
         method_name: unchecked_neg,
+        method_name_cpu: unchecked_neg,
         display_name: negation
     );
 
     define_cuda_server_key_bench_clean_input_fn!(
         method_name: unchecked_bitand,
+        method_name_cpu: unchecked_bitand,
         display_name: bitand
     );
 
     define_cuda_server_key_bench_clean_input_fn!(
         method_name: unchecked_bitor,
+        method_name_cpu: unchecked_bitor,
         display_name: bitor
     );
 
     define_cuda_server_key_bench_clean_input_fn!(
         method_name: unchecked_bitxor,
+        method_name_cpu: unchecked_bitxor,
         display_name: bitxor
     );
 
     define_cuda_server_key_bench_clean_input_unary_fn!(
         method_name: unchecked_bitnot,
+        method_name_cpu: bitnot,
         display_name: bitnot
     );
 
     define_cuda_server_key_bench_clean_input_fn!(
         method_name: unchecked_mul,
+        method_name_cpu: unchecked_mul_parallelized,
         display_name: mul
     );
 
     define_cuda_server_key_bench_clean_input_fn!(
         method_name: unchecked_div_rem,
+        method_name_cpu: unchecked_div_rem_parallelized,
         display_name: div_mod
     );
 
     define_cuda_server_key_bench_clean_input_fn!(
         method_name: unchecked_add,
+        method_name_cpu: unchecked_add_parallelized,
         display_name: add
     );
 
     define_cuda_server_key_bench_clean_input_fn!(
         method_name: unchecked_sub,
+        method_name_cpu: unchecked_sub,
         display_name: sub
     );
 
     define_cuda_server_key_bench_clean_input_fn!(
         method_name: unchecked_unsigned_overflowing_sub,
+        method_name_cpu: unchecked_unsigned_overflowing_sub_parallelized,
         display_name: overflowing_sub
     );
 
     define_cuda_server_key_bench_clean_input_fn!(
         method_name: unchecked_unsigned_overflowing_add,
+        method_name_cpu: unsigned_overflowing_add_parallelized,
         display_name: overflowing_add
     );
 
     define_cuda_server_key_bench_clean_input_fn!(
         method_name: unchecked_eq,
+        method_name_cpu: unchecked_eq,
         display_name: equal
     );
 
     define_cuda_server_key_bench_clean_input_fn!(
         method_name: unchecked_ne,
+        method_name_cpu: unchecked_ne,
         display_name: not_equal
     );
 
     define_cuda_server_key_bench_clean_input_fn!(
         method_name: unchecked_left_shift,
+        method_name_cpu: unchecked_left_shift_parallelized,
         display_name: left_shift
     );
 
     define_cuda_server_key_bench_clean_input_fn!(
         method_name: unchecked_right_shift,
+        method_name_cpu: unchecked_right_shift_parallelized,
         display_name: right_shift
     );
 
     define_cuda_server_key_bench_clean_input_fn!(
         method_name: unchecked_rotate_left,
+        method_name_cpu: unchecked_rotate_left_parallelized,
         display_name: rotate_left
     );
 
     define_cuda_server_key_bench_clean_input_fn!(
         method_name: unchecked_rotate_right,
+        method_name_cpu: unchecked_rotate_right_parallelized,
         display_name: rotate_right
     );
 
     define_cuda_server_key_bench_clean_input_unary_fn!(
         method_name: unchecked_ilog2,
+        method_name_cpu: unchecked_ilog2_parallelized,
         display_name: ilog2
     );
 
     define_cuda_server_key_bench_clean_input_scalar_fn!(
         method_name: unchecked_scalar_bitand,
+        method_name_cpu: unchecked_scalar_bitand_parallelized,
         display_name: bitand,
         rng_func: default_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_fn!(
         method_name: unchecked_scalar_bitor,
+        method_name_cpu: unchecked_scalar_bitor_parallelized,
         display_name: bitand,
         rng_func: default_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_fn!(
         method_name: unchecked_scalar_bitxor,
+        method_name_cpu: unchecked_scalar_bitxor_parallelized,
         display_name: bitand,
         rng_func: default_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_fn!(
         method_name: unchecked_scalar_add,
+        method_name_cpu: unchecked_scalar_add,
         display_name: add,
         rng_func: default_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_fn!(
         method_name: unchecked_scalar_mul,
+        method_name_cpu: unchecked_scalar_mul_parallelized,
         display_name: mul,
         rng_func: mul_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_fn!(
         method_name: unchecked_scalar_sub,
+        method_name_cpu: unchecked_scalar_sub,
         display_name: sub,
         rng_func: default_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_fn!(
         method_name: unchecked_scalar_left_shift,
+        method_name_cpu: unchecked_scalar_left_shift_parallelized,
         display_name: left_shift,
         rng_func: shift_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_fn!(
         method_name: unchecked_scalar_right_shift,
+        method_name_cpu: unchecked_scalar_right_shift_parallelized,
         display_name: right_shift,
         rng_func: shift_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_fn!(
         method_name: unchecked_scalar_rotate_left,
+        method_name_cpu: unchecked_scalar_rotate_left_parallelized,
         display_name: rotate_left,
         rng_func: shift_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_fn!(
         method_name: unchecked_scalar_rotate_right,
+        method_name_cpu: unchecked_scalar_rotate_right_parallelized,
         display_name: rotate_right,
         rng_func: shift_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_fn!(
         method_name: unchecked_scalar_eq,
+        method_name_cpu: unchecked_scalar_eq_parallelized,
         display_name: equal,
         rng_func: default_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_fn!(
         method_name: unchecked_scalar_ne,
+        method_name_cpu: unchecked_scalar_ne_parallelized,
         display_name: not_equal,
         rng_func: default_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_fn!(
         method_name: unchecked_scalar_gt,
+        method_name_cpu: unchecked_scalar_gt_parallelized,
         display_name: greater_than,
         rng_func: default_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_fn!(
         method_name: unchecked_scalar_ge,
+        method_name_cpu: unchecked_scalar_ge_parallelized,
         display_name: greater_or_equal,
         rng_func: default_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_fn!(
         method_name: unchecked_scalar_lt,
+        method_name_cpu: unchecked_scalar_lt_parallelized,
         display_name: less_than,
         rng_func: default_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_fn!(
         method_name: unchecked_scalar_le,
+        method_name_cpu: unchecked_scalar_le_parallelized,
         display_name: less_or_equal,
         rng_func: default_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_fn!(
         method_name: unchecked_scalar_max,
+        method_name_cpu: unchecked_scalar_max_parallelized,
         display_name: max,
         rng_func: default_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_fn!(
         method_name: unchecked_scalar_min,
+        method_name_cpu: unchecked_scalar_min_parallelized,
         display_name: min,
         rng_func: default_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_fn!(
         method_name: unchecked_scalar_div_rem,
+        method_name_cpu: unchecked_scalar_div_rem_parallelized,
         display_name: div_mod,
         rng_func: div_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_fn!(
         method_name: unchecked_scalar_div,
+        method_name_cpu: unchecked_scalar_div_parallelized,
         display_name: div,
         rng_func: div_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_fn!(
         method_name: unchecked_scalar_rem,
+        method_name_cpu: unchecked_scalar_rem_parallelized,
         display_name: modulo,
         rng_func: div_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_fn!(
         method_name: unchecked_unsigned_overflowing_scalar_add,
+        method_name_cpu: unsigned_overflowing_scalar_add_parallelized,
         display_name: overflowing_add,
         rng_func: default_scalar
     );
@@ -2092,282 +2343,334 @@ mod cuda {
 
     define_cuda_server_key_bench_clean_input_unary_fn!(
         method_name: neg,
+        method_name_cpu: neg_parallelized,
         display_name: negation
     );
 
     define_cuda_server_key_bench_clean_input_fn!(
         method_name: add,
+        method_name_cpu: add_parallelized,
         display_name: add
     );
 
     define_cuda_server_key_bench_clean_input_fn!(
         method_name: sub,
+        method_name_cpu: sub_parallelized,
         display_name: sub
     );
 
     define_cuda_server_key_bench_clean_input_fn!(
         method_name: unsigned_overflowing_sub,
+        method_name_cpu: unsigned_overflowing_sub_parallelized,
         display_name: overflowing_sub
     );
 
     define_cuda_server_key_bench_clean_input_fn!(
         method_name: unsigned_overflowing_add,
+        method_name_cpu: unsigned_overflowing_add_parallelized,
         display_name: overflowing_add
     );
 
     define_cuda_server_key_bench_clean_input_fn!(
         method_name: mul,
+        method_name_cpu: mul_parallelized,
         display_name: mul
     );
 
     define_cuda_server_key_bench_clean_input_fn!(
         method_name: div_rem,
+        method_name_cpu: div_rem_parallelized,
         display_name: div_mod
     );
 
     define_cuda_server_key_bench_clean_input_fn!(
         method_name: div,
+        method_name_cpu: div_parallelized,
         display_name: div
     );
 
     define_cuda_server_key_bench_clean_input_fn!(
         method_name: rem,
+        method_name_cpu: rem_parallelized,
         display_name: modulo
     );
 
     define_cuda_server_key_bench_clean_input_fn!(
         method_name: ne,
+        method_name_cpu: ne_parallelized,
         display_name: not_equal
     );
 
     define_cuda_server_key_bench_clean_input_fn!(
         method_name: eq,
+        method_name_cpu: eq_parallelized,
         display_name: equal
     );
 
     define_cuda_server_key_bench_clean_input_fn!(
         method_name: bitand,
+        method_name_cpu: bitand_parallelized,
         display_name: bitand
     );
 
     define_cuda_server_key_bench_clean_input_fn!(
         method_name: bitor,
+        method_name_cpu: bitor_parallelized,
         display_name: bitor
     );
 
     define_cuda_server_key_bench_clean_input_fn!(
         method_name: bitxor,
+        method_name_cpu: bitxor_parallelized,
         display_name: bitxor
     );
 
     define_cuda_server_key_bench_clean_input_unary_fn!(
         method_name: bitnot,
+        method_name_cpu: bitnot,
         display_name: bitnot
     );
 
     define_cuda_server_key_bench_clean_input_fn!(
         method_name: gt,
+        method_name_cpu: gt_parallelized,
         display_name: greater_than
     );
 
     define_cuda_server_key_bench_clean_input_fn!(
         method_name: ge,
+        method_name_cpu: ge_parallelized,
         display_name: greater_or_equal
     );
 
     define_cuda_server_key_bench_clean_input_fn!(
         method_name: lt,
+        method_name_cpu: lt_parallelized,
         display_name: less_than
     );
 
     define_cuda_server_key_bench_clean_input_fn!(
         method_name: le,
+        method_name_cpu: le_parallelized,
         display_name: less_or_equal
     );
 
     define_cuda_server_key_bench_clean_input_fn!(
         method_name: max,
+        method_name_cpu: max_parallelized,
         display_name: max
     );
 
     define_cuda_server_key_bench_clean_input_fn!(
         method_name: min,
+        method_name_cpu: min_parallelized,
         display_name: min
     );
 
     define_cuda_server_key_bench_clean_input_fn!(
         method_name: left_shift,
+        method_name_cpu: left_shift_parallelized,
         display_name: left_shift
     );
 
     define_cuda_server_key_bench_clean_input_fn!(
         method_name: right_shift,
+        method_name_cpu: right_shift_parallelized,
         display_name: right_shift
     );
 
     define_cuda_server_key_bench_clean_input_fn!(
         method_name: rotate_left,
+        method_name_cpu: rotate_left_parallelized,
         display_name: rotate_left
     );
 
     define_cuda_server_key_bench_clean_input_fn!(
         method_name: rotate_right,
+        method_name_cpu: rotate_right_parallelized,
         display_name: rotate_right
     );
 
     define_cuda_server_key_bench_clean_input_unary_fn!(
         method_name: leading_zeros,
+        method_name_cpu: leading_zeros_parallelized,
         display_name: leading_zeros
     );
 
     define_cuda_server_key_bench_clean_input_unary_fn!(
         method_name: leading_ones,
+        method_name_cpu: leading_ones_parallelized,
         display_name: leading_ones
     );
 
     define_cuda_server_key_bench_clean_input_unary_fn!(
         method_name: trailing_zeros,
+        method_name_cpu: trailing_zeros_parallelized,
         display_name: trailing_zeros
     );
 
     define_cuda_server_key_bench_clean_input_unary_fn!(
         method_name: trailing_ones,
+        method_name_cpu: trailing_ones_parallelized,
         display_name: trailing_ones
     );
 
     define_cuda_server_key_bench_clean_input_unary_fn!(
         method_name: ilog2,
+        method_name_cpu: ilog2_parallelized,
         display_name: ilog2
     );
 
     define_cuda_server_key_bench_clean_input_scalar_fn!(
         method_name: scalar_sub,
+        method_name_cpu: scalar_sub_parallelized,
         display_name: sub,
         rng_func: default_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_fn!(
         method_name: scalar_add,
+        method_name_cpu: scalar_add_parallelized,
         display_name: add,
         rng_func: default_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_fn!(
         method_name: scalar_mul,
+        method_name_cpu: scalar_mul_parallelized,
         display_name: mul,
         rng_func: mul_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_fn!(
         method_name: scalar_left_shift,
+        method_name_cpu: scalar_left_shift_parallelized,
         display_name: left_shift,
         rng_func: shift_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_fn!(
         method_name: scalar_right_shift,
+        method_name_cpu: scalar_right_shift_parallelized,
         display_name: right_shift,
         rng_func: shift_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_fn!(
         method_name: scalar_rotate_left,
+        method_name_cpu: scalar_rotate_left_parallelized,
         display_name: rotate_left,
         rng_func: shift_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_fn!(
         method_name: scalar_rotate_right,
+        method_name_cpu: scalar_rotate_right_parallelized,
         display_name: rotate_right,
         rng_func: shift_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_fn!(
         method_name: scalar_bitand,
+        method_name_cpu: scalar_bitand_parallelized,
         display_name: bitand,
         rng_func: default_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_fn!(
         method_name: scalar_bitor,
+        method_name_cpu: scalar_bitor_parallelized,
         display_name: bitor,
         rng_func: default_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_fn!(
         method_name: scalar_bitxor,
+        method_name_cpu: scalar_bitxor_parallelized,
         display_name: bitxor,
         rng_func: default_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_fn!(
         method_name: scalar_eq,
+        method_name_cpu: scalar_eq_parallelized,
         display_name: equal,
         rng_func: default_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_fn!(
         method_name: scalar_ne,
+        method_name_cpu: scalar_ne_parallelized,
         display_name: not_equal,
         rng_func: default_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_fn!(
         method_name: scalar_gt,
+        method_name_cpu: scalar_gt_parallelized,
         display_name: greater_than,
         rng_func: default_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_fn!(
         method_name: scalar_ge,
+        method_name_cpu: scalar_ge_parallelized,
         display_name: greater_or_equal,
         rng_func: default_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_fn!(
         method_name: scalar_lt,
+        method_name_cpu: scalar_lt_parallelized,
         display_name: less_than,
         rng_func: default_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_fn!(
         method_name: scalar_le,
+        method_name_cpu: scalar_le_parallelized,
         display_name: less_or_equal,
         rng_func: default_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_fn!(
         method_name: scalar_max,
+        method_name_cpu: scalar_max_parallelized,
         display_name: max,
         rng_func: default_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_fn!(
         method_name: scalar_min,
+        method_name_cpu: scalar_min_parallelized,
         display_name: min,
         rng_func: default_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_fn!(
         method_name: scalar_div_rem,
+        method_name_cpu: scalar_div_rem_parallelized,
         display_name: div_mod,
         rng_func: div_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_fn!(
         method_name: scalar_div,
+        method_name_cpu: scalar_div_parallelized,
         display_name: div,
         rng_func: div_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_fn!(
         method_name: scalar_rem,
+        method_name_cpu: scalar_rem_parallelized,
         display_name: modulo,
         rng_func: div_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_fn!(
         method_name: unsigned_overflowing_scalar_add,
+        method_name_cpu: unsigned_overflowing_scalar_add_parallelized,
         display_name: overflowing_add,
         rng_func: default_scalar
     );
@@ -2597,6 +2900,7 @@ use cuda::{
     cuda_cast_ops, default_cuda_dedup_ops, default_cuda_ops, default_scalar_cuda_ops,
     unchecked_cuda_ops, unchecked_scalar_cuda_ops,
 };
+use tfhe::{get_pbs_count, reset_pbs_count};
 
 criterion_group!(
     smart_ops,

--- a/tfhe/benches/integer/glwe_packing_compression.rs
+++ b/tfhe/benches/integer/glwe_packing_compression.rs
@@ -6,6 +6,7 @@ use crate::utilities::{
 };
 use criterion::{black_box, criterion_group, Criterion, Throughput};
 use rayon::prelude::*;
+use std::cmp::max;
 use tfhe::integer::ciphertext::CompressedCiphertextListBuilder;
 use tfhe::integer::{ClientKey, RadixCiphertext};
 use tfhe::keycache::NamedParam;
@@ -79,9 +80,19 @@ fn cpu_glwe_packing(c: &mut Criterion) {
                 });
             }
             BenchmarkType::Throughput => {
+                // Execute the operation once to know its cost.
+                let ct = cks.encrypt_radix(0_u32, num_blocks);
+                let mut builder = CompressedCiphertextListBuilder::new();
+                builder.push(ct);
+                let compressed = builder.build(&compression_key);
+
+                reset_pbs_count();
+                let _: RadixCiphertext = compressed.get(0, &decompression_key).unwrap().unwrap();
+                let pbs_count = max(get_pbs_count(), 1); // Operation might not perform any PBS, so we take 1 as default
+
                 let num_block =
                     (bit_size as f64 / (param.message_modulus.0 as f64).log(2.0)).ceil() as usize;
-                let elements = throughput_num_threads(num_block);
+                let elements = throughput_num_threads(num_block, pbs_count);
                 // FIXME thread usage seemed to be somewhat more "efficient".
                 //  For example, with bit_size = 2, my laptop is only using around 2/3 of the
                 // available threads  Thread usage increases with bit_size = 8 but
@@ -152,6 +163,8 @@ fn cpu_glwe_packing(c: &mut Criterion) {
 #[cfg(feature = "gpu")]
 mod cuda {
     use super::*;
+    use crate::utilities::cuda_local_streams;
+    use std::cmp::max;
     use tfhe::core_crypto::gpu::CudaStreams;
     use tfhe::integer::gpu::ciphertext::compressed_ciphertext_list::CudaCompressedCiphertextListBuilder;
     use tfhe::integer::gpu::ciphertext::CudaUnsignedRadixCiphertext;
@@ -207,8 +220,6 @@ mod cuda {
 
             match BENCH_TYPE.get().unwrap() {
                 BenchmarkType::Latency => {
-                    // Generate private compression key
-
                     // Encrypt
                     let ct = cks.encrypt_radix(0_u32, num_blocks);
                     let d_ct = CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct, &stream);
@@ -242,9 +253,23 @@ mod cuda {
                     });
                 }
                 BenchmarkType::Throughput => {
+                    // Execute the operation once to know its cost.
+                    let (cpu_compression_key, cpu_decompression_key) =
+                        cks.new_compression_decompression_keys(&private_compression_key);
+                    let ct = cks.encrypt_radix(0_u32, num_blocks);
+                    let mut builder = CompressedCiphertextListBuilder::new();
+                    builder.push(ct);
+                    let compressed = builder.build(&cpu_compression_key);
+
+                    reset_pbs_count();
+                    // Use CPU operation as pbs_count do not count PBS on GPU backend.
+                    let _: RadixCiphertext =
+                        compressed.get(0, &cpu_decompression_key).unwrap().unwrap();
+                    let pbs_count = max(get_pbs_count(), 1); // Operation might not perform any PBS, so we take 1 as default
+
                     let num_block = (bit_size as f64 / (param.message_modulus.0 as f64).log(2.0))
                         .ceil() as usize;
-                    let elements = throughput_num_threads(num_block);
+                    let elements = throughput_num_threads(num_block, pbs_count);
                     bench_group.throughput(Throughput::Elements(elements));
 
                     // Encrypt
@@ -268,12 +293,16 @@ mod cuda {
                         })
                         .collect::<Vec<_>>();
 
+                    let local_streams = cuda_local_streams(num_block, elements as usize);
+
                     bench_id_pack = format!("{bench_name}::throughput::pack_u{bit_size}");
                     bench_group.bench_function(&bench_id_pack, |b| {
                         b.iter(|| {
-                            builders.par_iter().for_each(|builder| {
-                                builder.build(&cuda_compression_key, &stream);
-                            })
+                            builders.par_iter().zip(local_streams.par_iter()).for_each(
+                                |(builder, local_stream)| {
+                                    builder.build(&cuda_compression_key, local_stream);
+                                },
+                            )
                         })
                     });
 
@@ -285,15 +314,18 @@ mod cuda {
                     bench_id_unpack = format!("{bench_name}::throughput::unpack_u{bit_size}");
                     bench_group.bench_function(&bench_id_unpack, |b| {
                         b.iter(|| {
-                            compressed.par_iter().for_each(|comp| {
-                                comp.get::<CudaUnsignedRadixCiphertext>(
-                                    0,
-                                    &cuda_decompression_key,
-                                    &stream,
-                                )
-                                .unwrap()
-                                .unwrap();
-                            })
+                            compressed
+                                .par_iter()
+                                .zip(local_streams.par_iter())
+                                .for_each(|(comp, local_stream)| {
+                                    comp.get::<CudaUnsignedRadixCiphertext>(
+                                        0,
+                                        &cuda_decompression_key,
+                                        local_stream,
+                                    )
+                                    .unwrap()
+                                    .unwrap();
+                                })
                         })
                     });
                 }
@@ -330,6 +362,7 @@ criterion_group!(cpu_glwe_packing2, cpu_glwe_packing);
 
 #[cfg(feature = "gpu")]
 use cuda::gpu_glwe_packing2;
+use tfhe::{get_pbs_count, reset_pbs_count};
 
 fn main() {
     BENCH_TYPE.get_or_init(|| BenchmarkType::from_env().unwrap());

--- a/tfhe/benches/integer/signed_bench.rs
+++ b/tfhe/benches/integer/signed_bench.rs
@@ -8,6 +8,7 @@ use crate::utilities::{
 use criterion::{criterion_group, Criterion, Throughput};
 use rand::prelude::*;
 use rayon::prelude::*;
+use std::cmp::max;
 use std::env;
 use tfhe::integer::keycache::KEY_CACHE;
 use tfhe::integer::prelude::*;
@@ -66,27 +67,42 @@ fn bench_server_key_signed_binary_function_clean_inputs<F>(
                 });
             }
             BenchmarkType::Throughput => {
+                let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
+
+                // Execute the operation once to know its cost.
+                let ct_0 = cks.encrypt_signed_radix(gen_random_i256(&mut rng), num_block);
+                let ct_1 = cks.encrypt_signed_radix(gen_random_i256(&mut rng), num_block);
+
+                reset_pbs_count();
+                binary_op(&sks, &ct_0, &ct_1);
+                let pbs_count = max(get_pbs_count(), 1); // Operation might not perform any PBS, so we take 1 as default
+
                 bench_id = format!("{bench_name}::throughput::{param_name}::{bit_size}_bits");
-                let elements = throughput_num_threads(num_block);
+                let elements = throughput_num_threads(num_block, pbs_count);
                 bench_group.throughput(Throughput::Elements(elements));
                 bench_group.bench_function(&bench_id, |b| {
-                    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
+                    let setup_encrypted_values = || {
+                        let cts_0 = (0..elements)
+                            .map(|_| cks.encrypt_signed_radix(gen_random_i256(&mut rng), num_block))
+                            .collect::<Vec<_>>();
+                        let cts_1 = (0..elements)
+                            .map(|_| cks.encrypt_signed_radix(gen_random_i256(&mut rng), num_block))
+                            .collect::<Vec<_>>();
 
-                    let mut cts_0 = (0..elements)
-                        .map(|_| cks.encrypt_signed_radix(gen_random_i256(&mut rng), num_block))
-                        .collect::<Vec<_>>();
-                    let mut cts_1 = (0..elements)
-                        .map(|_| cks.encrypt_signed_radix(gen_random_i256(&mut rng), num_block))
-                        .collect::<Vec<_>>();
+                        (cts_0, cts_1)
+                    };
 
-                    b.iter(|| {
-                        cts_0
-                            .par_iter_mut()
-                            .zip(cts_1.par_iter_mut())
-                            .for_each(|(ct_0, ct_1)| {
-                                binary_op(&sks, ct_0, ct_1);
-                            })
-                    })
+                    b.iter_batched(
+                        setup_encrypted_values,
+                        |(mut cts_0, mut cts_1)| {
+                            cts_0.par_iter_mut().zip(cts_1.par_iter_mut()).for_each(
+                                |(ct_0, ct_1)| {
+                                    binary_op(&sks, ct_0, ct_1);
+                                },
+                            )
+                        },
+                        criterion::BatchSize::SmallInput,
+                    )
                 });
             }
         }
@@ -117,7 +133,7 @@ fn bench_server_key_signed_shift_function_clean_inputs<F>(
 {
     let mut bench_group = c.benchmark_group(bench_name);
     bench_group
-        .sample_size(15)
+        .sample_size(10)
         .measurement_time(std::time::Duration::from_secs(60));
     let mut rng = rand::thread_rng();
 
@@ -151,29 +167,45 @@ fn bench_server_key_signed_shift_function_clean_inputs<F>(
                 });
             }
             BenchmarkType::Throughput => {
+                let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
+
+                // Execute the operation once to know its cost.
+                let clear_1 = rng.gen_range(0u128..bit_size as u128);
+                let ct_0 = cks.encrypt_signed_radix(gen_random_i256(&mut rng), num_block);
+                let ct_1 = cks.encrypt_radix(clear_1, num_block);
+
+                reset_pbs_count();
+                binary_op(&sks, &ct_0, &ct_1);
+                let pbs_count = max(get_pbs_count(), 1); // Operation might not perform any PBS, so we take 1 as default
+
                 bench_id = format!("{bench_name}::throughput::{param_name}::{bit_size}_bits");
-                let elements = throughput_num_threads(num_block);
+                let elements = throughput_num_threads(num_block, pbs_count);
                 bench_group.throughput(Throughput::Elements(elements));
                 bench_group.bench_function(&bench_id, |b| {
-                    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
-
-                    let mut cts_0 = (0..elements)
-                        .map(|_| cks.encrypt_signed_radix(gen_random_i256(&mut rng), num_block))
-                        .collect::<Vec<_>>();
-                    let mut cts_1 = (0..elements)
-                        .map(|_| {
-                            cks.encrypt_radix(rng.gen_range(0u128..bit_size as u128), num_block)
-                        })
-                        .collect::<Vec<_>>();
-
-                    b.iter(|| {
-                        cts_0
-                            .par_iter_mut()
-                            .zip(cts_1.par_iter_mut())
-                            .for_each(|(ct_0, ct_1)| {
-                                binary_op(&sks, ct_0, ct_1);
+                    let setup_encrypted_values = || {
+                        let cts_0 = (0..elements)
+                            .map(|_| cks.encrypt_signed_radix(gen_random_i256(&mut rng), num_block))
+                            .collect::<Vec<_>>();
+                        let cts_1 = (0..elements)
+                            .map(|_| {
+                                cks.encrypt_radix(rng.gen_range(0u128..bit_size as u128), num_block)
                             })
-                    })
+                            .collect::<Vec<_>>();
+
+                        (cts_0, cts_1)
+                    };
+
+                    b.iter_batched(
+                        setup_encrypted_values,
+                        |(mut cts_0, mut cts_1)| {
+                            cts_0.par_iter_mut().zip(cts_1.par_iter_mut()).for_each(
+                                |(ct_0, ct_1)| {
+                                    binary_op(&sks, ct_0, ct_1);
+                                },
+                            )
+                        },
+                        criterion::BatchSize::SmallInput,
+                    )
                 });
             }
         }
@@ -204,7 +236,7 @@ fn bench_server_key_unary_function_clean_inputs<F>(
 {
     let mut bench_group = c.benchmark_group(bench_name);
     bench_group
-        .sample_size(15)
+        .sample_size(10)
         .measurement_time(std::time::Duration::from_secs(60));
 
     let mut rng = rand::thread_rng();
@@ -233,21 +265,34 @@ fn bench_server_key_unary_function_clean_inputs<F>(
                 });
             }
             BenchmarkType::Throughput => {
+                let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
+
+                // Execute the operation once to know its cost.
+                let ct_0 = cks.encrypt_signed_radix(gen_random_i256(&mut rng), num_block);
+
+                reset_pbs_count();
+                unary_fn(&sks, &ct_0);
+                let pbs_count = max(get_pbs_count(), 1); // Operation might not perform any PBS, so we take 1 as default
+
                 bench_id = format!("{bench_name}::throughput::{param_name}::{bit_size}_bits");
-                let elements = throughput_num_threads(num_block);
+                let elements = throughput_num_threads(num_block, pbs_count);
                 bench_group.throughput(Throughput::Elements(elements));
                 bench_group.bench_function(&bench_id, |b| {
-                    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
+                    let setup_encrypted_values = || {
+                        (0..elements)
+                            .map(|_| cks.encrypt_signed_radix(gen_random_i256(&mut rng), num_block))
+                            .collect::<Vec<_>>()
+                    };
 
-                    let mut cts_0 = (0..elements)
-                        .map(|_| cks.encrypt_signed_radix(gen_random_i256(&mut rng), num_block))
-                        .collect::<Vec<_>>();
-
-                    b.iter(|| {
-                        cts_0.par_iter_mut().for_each(|ct_0| {
-                            unary_fn(&sks, ct_0);
-                        })
-                    })
+                    b.iter_batched(
+                        setup_encrypted_values,
+                        |mut cts| {
+                            cts.par_iter_mut().for_each(|ct_0| {
+                                unary_fn(&sks, ct_0);
+                            })
+                        },
+                        criterion::BatchSize::SmallInput,
+                    )
                 });
             }
         }
@@ -272,7 +317,7 @@ fn signed_if_then_else_parallelized(c: &mut Criterion) {
 
     let mut bench_group = c.benchmark_group(bench_name);
     bench_group
-        .sample_size(15)
+        .sample_size(10)
         .measurement_time(std::time::Duration::from_secs(60));
     let mut rng = rand::thread_rng();
 
@@ -307,32 +352,49 @@ fn signed_if_then_else_parallelized(c: &mut Criterion) {
                 });
             }
             BenchmarkType::Throughput => {
+                let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
+
+                // Execute the operation once to know its cost.
+                let cond = sks.create_trivial_boolean_block(rng.gen_bool(0.5));
+                let ct_then = cks.encrypt_signed_radix(gen_random_i256(&mut rng), num_block);
+                let ct_else = cks.encrypt_signed_radix(gen_random_i256(&mut rng), num_block);
+
+                reset_pbs_count();
+                sks.if_then_else_parallelized(&cond, &ct_then, &ct_else);
+                let pbs_count = max(get_pbs_count(), 1); // Operation might not perform any PBS, so we take 1 as default
+
                 bench_id = format!("{bench_name}::throughput::{param_name}::{bit_size}_bits");
-                let elements = throughput_num_threads(num_block);
+                let elements = throughput_num_threads(num_block, pbs_count);
                 bench_group.throughput(Throughput::Elements(elements));
                 bench_group.bench_function(&bench_id, |b| {
-                    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
+                    let setup_encrypted_values = || {
+                        let cts_cond = (0..elements)
+                            .map(|_| sks.create_trivial_boolean_block(rng.gen_bool(0.5)))
+                            .collect::<Vec<_>>();
 
-                    let cts_cond = (0..elements)
-                        .map(|_| sks.create_trivial_boolean_block(rng.gen_bool(0.5)))
-                        .collect::<Vec<_>>();
+                        let cts_then = (0..elements)
+                            .map(|_| cks.encrypt_signed_radix(gen_random_i256(&mut rng), num_block))
+                            .collect::<Vec<_>>();
+                        let cts_else = (0..elements)
+                            .map(|_| cks.encrypt_signed_radix(gen_random_i256(&mut rng), num_block))
+                            .collect::<Vec<_>>();
 
-                    let cts_then = (0..elements)
-                        .map(|_| cks.encrypt_signed_radix(gen_random_i256(&mut rng), num_block))
-                        .collect::<Vec<_>>();
-                    let cts_else = (0..elements)
-                        .map(|_| cks.encrypt_signed_radix(gen_random_i256(&mut rng), num_block))
-                        .collect::<Vec<_>>();
+                        (cts_cond, cts_then, cts_else)
+                    };
 
-                    b.iter(|| {
-                        cts_cond
-                            .par_iter()
-                            .zip(cts_then.par_iter())
-                            .zip(cts_else.par_iter())
-                            .for_each(|((condition, true_ct), false_ct)| {
-                                sks.if_then_else_parallelized(condition, true_ct, false_ct);
-                            })
-                    })
+                    b.iter_batched(
+                        setup_encrypted_values,
+                        |(cts_cond, cts_then, cts_else)| {
+                            cts_cond
+                                .par_iter()
+                                .zip(cts_then.par_iter())
+                                .zip(cts_else.par_iter())
+                                .for_each(|((condition, true_ct), false_ct)| {
+                                    sks.if_then_else_parallelized(condition, true_ct, false_ct);
+                                })
+                        },
+                        criterion::BatchSize::SmallInput,
+                    )
                 });
             }
         }
@@ -786,7 +848,7 @@ fn bench_server_key_binary_scalar_function_clean_inputs<F, G>(
 {
     let mut bench_group = c.benchmark_group(bench_name);
     bench_group
-        .sample_size(15)
+        .sample_size(10)
         .measurement_time(std::time::Duration::from_secs(60));
     let mut rng = rand::thread_rng();
 
@@ -830,36 +892,51 @@ fn bench_server_key_binary_scalar_function_clean_inputs<F, G>(
                 });
             }
             BenchmarkType::Throughput => {
+                let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
+
+                // Execute the operation once to know its cost.
+                let mut ct_0 = cks.encrypt_signed_radix(gen_random_i256(&mut rng), num_block);
+                let clear_1 = rng_func(&mut rng, bit_size);
+
+                reset_pbs_count();
+                binary_op(&sks, &mut ct_0, clear_1);
+                let pbs_count = max(get_pbs_count(), 1); // Operation might not perform any PBS, so we take 1 as default
+
                 bench_id = format!("{bench_name}::throughput::{param_name}::{bit_size}_bits");
-                let elements = throughput_num_threads(num_block);
+                let elements = throughput_num_threads(num_block, pbs_count);
                 bench_group.throughput(Throughput::Elements(elements));
                 bench_group.bench_function(&bench_id, |b| {
-                    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
-
-                    let mut cts_0 = (0..elements)
-                        .map(|_| cks.encrypt_signed_radix(gen_random_i256(&mut rng), num_block))
-                        .collect::<Vec<_>>();
-                    let clears_1 = (0..elements)
-                        .map(|_| {
-                            let clear_1 = rng_func(&mut rng, bit_size);
-                            assert!(
-                                range.contains(&clear_1),
-                                "{:?} is not within the range {:?}",
-                                clear_1,
-                                range
-                            );
-                            clear_1
-                        })
-                        .collect::<Vec<_>>();
-
-                    b.iter(|| {
-                        cts_0
-                            .par_iter_mut()
-                            .zip(clears_1.par_iter())
-                            .for_each(|(ct_0, clear_1)| {
-                                binary_op(&sks, ct_0, *clear_1);
+                    let setup_encrypted_values = || {
+                        let cts_0 = (0..elements)
+                            .map(|_| cks.encrypt_signed_radix(gen_random_i256(&mut rng), num_block))
+                            .collect::<Vec<_>>();
+                        let clears_1 = (0..elements)
+                            .map(|_| {
+                                let clear_1 = rng_func(&mut rng, bit_size);
+                                assert!(
+                                    range.contains(&clear_1),
+                                    "{:?} is not within the range {:?}",
+                                    clear_1,
+                                    range
+                                );
+                                clear_1
                             })
-                    })
+                            .collect::<Vec<_>>();
+
+                        (cts_0, clears_1)
+                    };
+
+                    b.iter_batched(
+                        setup_encrypted_values,
+                        |(mut cts_0, clears_1)| {
+                            cts_0.par_iter_mut().zip(clears_1.par_iter()).for_each(
+                                |(ct_0, clear_1)| {
+                                    binary_op(&sks, ct_0, *clear_1);
+                                },
+                            )
+                        },
+                        criterion::BatchSize::SmallInput,
+                    )
                 });
             }
         }
@@ -1256,7 +1333,7 @@ fn bench_server_key_signed_cast_function<F>(
 {
     let mut bench_group = c.benchmark_group(bench_name);
     bench_group
-        .sample_size(15)
+        .sample_size(10)
         .measurement_time(std::time::Duration::from_secs(30));
     let mut rng = rand::thread_rng();
 
@@ -1326,8 +1403,10 @@ criterion_group!(cast_ops, cast_to_unsigned, cast_to_signed);
 #[cfg(feature = "gpu")]
 mod cuda {
     use super::*;
+    use crate::utilities::cuda_local_streams;
     use criterion::criterion_group;
     use rayon::iter::IntoParallelRefIterator;
+    use std::cmp::max;
     use tfhe::core_crypto::gpu::CudaStreams;
     use tfhe::integer::gpu::ciphertext::boolean_value::CudaBooleanBlock;
     use tfhe::integer::gpu::ciphertext::{CudaSignedRadixCiphertext, CudaUnsignedRadixCiphertext};
@@ -1335,11 +1414,12 @@ mod cuda {
 
     /// Base function to bench a server key function that is a binary operation, input ciphertext
     /// will contain only zero carries
-    fn bench_cuda_server_key_binary_signed_function_clean_inputs<F>(
+    fn bench_cuda_server_key_binary_signed_function_clean_inputs<F, G>(
         c: &mut Criterion,
         bench_name: &str,
         display_name: &str,
         binary_op: F,
+        binary_op_cpu: G,
     ) where
         F: Fn(
                 &CudaServerKey,
@@ -1347,10 +1427,11 @@ mod cuda {
                 &mut CudaSignedRadixCiphertext,
                 &CudaStreams,
             ) + Sync,
+        G: Fn(&ServerKey, &SignedRadixCiphertext, &SignedRadixCiphertext) + Sync,
     {
         let mut bench_group = c.benchmark_group(bench_name);
         bench_group
-            .sample_size(15)
+            .sample_size(10)
             .measurement_time(std::time::Duration::from_secs(30));
         let mut rng = rand::thread_rng();
 
@@ -1401,46 +1482,75 @@ mod cuda {
                     });
                 }
                 BenchmarkType::Throughput => {
+                    let (cks, cpu_sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
+                    let gpu_sks = CudaServerKey::new(&cks, &stream);
+
+                    // Execute the operation once to know its cost.
+                    let mut ct_0 = cks.encrypt_signed_radix(gen_random_i256(&mut rng), num_block);
+                    let mut ct_1 = cks.encrypt_signed_radix(gen_random_i256(&mut rng), num_block);
+
+                    reset_pbs_count();
+                    // Use CPU operation as pbs_count do not count PBS on GPU backend.
+                    binary_op_cpu(&cpu_sks, &mut ct_0, &mut ct_1);
+                    let pbs_count = max(get_pbs_count(), 1); // Operation might not perform any PBS, so we take 1 as default
+
                     bench_id = format!("{bench_name}::throughput::{param_name}::{bit_size}_bits");
-                    let elements = throughput_num_threads(num_block);
+                    let elements = throughput_num_threads(num_block, pbs_count);
                     bench_group.throughput(Throughput::Elements(elements));
                     bench_group.bench_function(&bench_id, |b| {
-                        let (cks, _cpu_sks) =
-                            KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
-                        let gpu_sks = CudaServerKey::new(&cks, &stream);
+                        let setup_encrypted_values = || {
+                            let cts_0 = (0..elements)
+                                .map(|_| {
+                                    let clearlow = rng.gen::<u128>();
+                                    let clearhigh = rng.gen::<u128>();
+                                    let clear_0 = tfhe::integer::I256::from((clearlow, clearhigh));
+                                    let ct_0 = cks.encrypt_signed_radix(clear_0, num_block);
 
-                        let mut cts_0 = (0..elements)
-                            .map(|_| {
-                                let clearlow = rng.gen::<u128>();
-                                let clearhigh = rng.gen::<u128>();
-                                let clear_0 = tfhe::integer::I256::from((clearlow, clearhigh));
-                                let ct_0 = cks.encrypt_signed_radix(clear_0, num_block);
+                                    CudaSignedRadixCiphertext::from_signed_radix_ciphertext(
+                                        &ct_0, &stream,
+                                    )
+                                })
+                                .collect::<Vec<_>>();
+                            let cts_1 = (0..elements)
+                                .map(|_| {
+                                    let clearlow = rng.gen::<u128>();
+                                    let clearhigh = rng.gen::<u128>();
+                                    let clear_0 = tfhe::integer::I256::from((clearlow, clearhigh));
+                                    let ct_0 = cks.encrypt_signed_radix(clear_0, num_block);
 
-                                CudaSignedRadixCiphertext::from_signed_radix_ciphertext(
-                                    &ct_0, &stream,
-                                )
-                            })
-                            .collect::<Vec<_>>();
-                        let mut cts_1 = (0..elements)
-                            .map(|_| {
-                                let clearlow = rng.gen::<u128>();
-                                let clearhigh = rng.gen::<u128>();
-                                let clear_0 = tfhe::integer::I256::from((clearlow, clearhigh));
-                                let ct_0 = cks.encrypt_signed_radix(clear_0, num_block);
+                                    CudaSignedRadixCiphertext::from_signed_radix_ciphertext(
+                                        &ct_0, &stream,
+                                    )
+                                })
+                                .collect::<Vec<_>>();
 
-                                CudaSignedRadixCiphertext::from_signed_radix_ciphertext(
-                                    &ct_0, &stream,
-                                )
-                            })
-                            .collect::<Vec<_>>();
+                            let local_streams = cuda_local_streams(num_block, elements as usize);
+                            // let local_streams = (0..cuda_num_streams(num_block))
+                            //     .map(|i| {
+                            //         CudaStreams::new_single_gpu(GpuIndex::new(
+                            //             (i % get_number_of_gpus() as u64) as u32,
+                            //         ))
+                            //     })
+                            //     .cycle()
+                            //     .take(elements as usize)
+                            //     .collect::<Vec<_>>();
 
-                        b.iter(|| {
-                            cts_0.par_iter_mut().zip(cts_1.par_iter_mut()).for_each(
-                                |(ct_0, ct_1)| {
-                                    binary_op(&gpu_sks, ct_0, ct_1, &stream);
-                                },
-                            )
-                        })
+                            (cts_0, cts_1, local_streams)
+                        };
+
+                        b.iter_batched(
+                            setup_encrypted_values,
+                            |(mut cts_0, mut cts_1, local_streams)| {
+                                cts_0
+                                    .par_iter_mut()
+                                    .zip(cts_1.par_iter_mut())
+                                    .zip(local_streams.par_iter())
+                                    .for_each(|((ct_0, ct_1), local_stream)| {
+                                        binary_op(&gpu_sks, ct_0, ct_1, local_stream);
+                                    })
+                            },
+                            criterion::BatchSize::SmallInput,
+                        )
                     });
                 }
             }
@@ -1460,7 +1570,7 @@ mod cuda {
     }
 
     macro_rules! define_cuda_server_key_bench_clean_input_signed_fn (
-        (method_name: $server_key_method:ident, display_name:$name:ident) => {
+        (method_name: $server_key_method:ident, method_name_cpu: $server_key_method_cpu:ident, display_name:$name:ident) => {
             ::paste::paste!{
                 fn [<cuda_ $server_key_method>](c: &mut Criterion) {
                     bench_cuda_server_key_binary_signed_function_clean_inputs(
@@ -1469,6 +1579,9 @@ mod cuda {
                         stringify!($name),
                         |server_key, lhs, rhs, stream| {
                             server_key.$server_key_method(lhs, rhs, stream);
+                        },
+                        |server_key_cpu, lhs, rhs| {
+                            server_key_cpu.$server_key_method_cpu(lhs, rhs);
                         }
                     )
                 }
@@ -1478,17 +1591,19 @@ mod cuda {
 
     /// Base function to bench a server key function that is a unary operation, input ciphertext
     /// will contain only zero carries
-    fn bench_cuda_server_key_unary_signed_function_clean_inputs<F>(
+    fn bench_cuda_server_key_unary_signed_function_clean_inputs<F, G>(
         c: &mut Criterion,
         bench_name: &str,
         display_name: &str,
         unary_op: F,
+        unary_op_cpu: G,
     ) where
         F: Fn(&CudaServerKey, &mut CudaSignedRadixCiphertext, &CudaStreams) + Sync,
+        G: Fn(&ServerKey, &SignedRadixCiphertext) + Sync,
     {
         let mut bench_group = c.benchmark_group(bench_name);
         bench_group
-            .sample_size(15)
+            .sample_size(10)
             .measurement_time(std::time::Duration::from_secs(30));
         let mut rng = rand::thread_rng();
 
@@ -1527,32 +1642,51 @@ mod cuda {
                     });
                 }
                 BenchmarkType::Throughput => {
+                    let (cks, cpu_sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
+                    let gpu_sks = CudaServerKey::new(&cks, &stream);
+
+                    // Execute the operation once to know its cost.
+                    let ct_0 = cks.encrypt_signed_radix(gen_random_i256(&mut rng), num_block);
+
+                    reset_pbs_count();
+                    // Use CPU operation as pbs_count do not count PBS on GPU backend.
+                    unary_op_cpu(&cpu_sks, &ct_0);
+                    let pbs_count = max(get_pbs_count(), 1); // Operation might not perform any PBS, so we take 1 as default
+
                     bench_id = format!("{bench_name}::throughput::{param_name}::{bit_size}_bits");
-                    let elements = throughput_num_threads(num_block);
+                    let elements = throughput_num_threads(num_block, pbs_count);
                     bench_group.throughput(Throughput::Elements(elements));
                     bench_group.bench_function(&bench_id, |b| {
-                        let (cks, _cpu_sks) =
-                            KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
-                        let gpu_sks = CudaServerKey::new(&cks, &stream);
+                        let setup_encrypted_values = || {
+                            let cts = (0..elements)
+                                .map(|_| {
+                                    let clearlow = rng.gen::<u128>();
+                                    let clearhigh = rng.gen::<u128>();
+                                    let clear_0 = tfhe::integer::I256::from((clearlow, clearhigh));
+                                    let ct_0 = cks.encrypt_signed_radix(clear_0, num_block);
 
-                        let mut cts_0 = (0..elements)
-                            .map(|_| {
-                                let clearlow = rng.gen::<u128>();
-                                let clearhigh = rng.gen::<u128>();
-                                let clear_0 = tfhe::integer::I256::from((clearlow, clearhigh));
-                                let ct_0 = cks.encrypt_signed_radix(clear_0, num_block);
+                                    CudaSignedRadixCiphertext::from_signed_radix_ciphertext(
+                                        &ct_0, &stream,
+                                    )
+                                })
+                                .collect::<Vec<_>>();
 
-                                CudaSignedRadixCiphertext::from_signed_radix_ciphertext(
-                                    &ct_0, &stream,
+                            let local_streams = cuda_local_streams(num_block, elements as usize);
+
+                            (cts, local_streams)
+                        };
+
+                        b.iter_batched(
+                            setup_encrypted_values,
+                            |(mut cts, local_streams)| {
+                                cts.par_iter_mut().zip(local_streams.par_iter()).for_each(
+                                    |(ct_0, local_stream)| {
+                                        unary_op(&gpu_sks, ct_0, local_stream);
+                                    },
                                 )
-                            })
-                            .collect::<Vec<_>>();
-
-                        b.iter(|| {
-                            cts_0.par_iter_mut().for_each(|ct_0| {
-                                unary_op(&gpu_sks, ct_0, &stream);
-                            })
-                        })
+                            },
+                            criterion::BatchSize::SmallInput,
+                        )
                     });
                 }
             }
@@ -1572,7 +1706,7 @@ mod cuda {
     }
 
     macro_rules! define_cuda_server_key_bench_clean_input_signed_unary_fn (
-        (method_name: $server_key_method:ident, display_name:$name:ident) => {
+        (method_name: $server_key_method:ident, method_name_cpu: $server_key_method_cpu:ident, display_name:$name:ident) => {
             ::paste::paste!{
                 fn [<cuda_ $server_key_method>](c: &mut Criterion) {
                     bench_cuda_server_key_unary_signed_function_clean_inputs(
@@ -1581,6 +1715,9 @@ mod cuda {
                         stringify!($name),
                         |server_key, input, stream| {
                             server_key.$server_key_method(input, stream);
+                        },
+                        |server_key_cpu, lhs| {
+                            server_key_cpu.$server_key_method_cpu(lhs);
                         }
                     )
                 }
@@ -1588,19 +1725,21 @@ mod cuda {
         }
     );
 
-    fn bench_cuda_server_key_binary_scalar_signed_function_clean_inputs<F, G>(
+    fn bench_cuda_server_key_binary_scalar_signed_function_clean_inputs<F, G, H>(
         c: &mut Criterion,
         bench_name: &str,
         display_name: &str,
         binary_op: F,
-        rng_func: G,
+        binary_op_cpu: G,
+        rng_func: H,
     ) where
         F: Fn(&CudaServerKey, &mut CudaSignedRadixCiphertext, ScalarType, &CudaStreams) + Sync,
-        G: Fn(&mut ThreadRng, usize) -> ScalarType,
+        G: Fn(&ServerKey, &mut SignedRadixCiphertext, ScalarType) + Sync,
+        H: Fn(&mut ThreadRng, usize) -> ScalarType,
     {
         let mut bench_group = c.benchmark_group(bench_name);
         bench_group
-            .sample_size(15)
+            .sample_size(10)
             .measurement_time(std::time::Duration::from_secs(30));
         let mut rng = rand::thread_rng();
 
@@ -1650,39 +1789,59 @@ mod cuda {
                     });
                 }
                 BenchmarkType::Throughput => {
+                    let (cks, cpu_sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
+                    let gpu_sks = CudaServerKey::new(&cks, &stream);
+
+                    // Execute the operation once to know its cost.
+                    let mut ct_0 = cks.encrypt_signed_radix(gen_random_i256(&mut rng), num_block);
+                    let clear_0 = rng_func(&mut rng, bit_size);
+
+                    reset_pbs_count();
+                    // Use CPU operation as pbs_count do not count PBS on GPU backend.
+                    binary_op_cpu(&cpu_sks, &mut ct_0, clear_0);
+                    let pbs_count = max(get_pbs_count(), 1); // Operation might not perform any PBS, so we take 1 as default
+
                     bench_id = format!(
                         "{bench_name}::throughput::{param_name}::{bit_size}_bits_scalar_{bit_size}"
                     );
-                    let elements = throughput_num_threads(num_block);
+                    let elements = throughput_num_threads(num_block, pbs_count);
                     bench_group.throughput(Throughput::Elements(elements));
                     bench_group.bench_function(&bench_id, |b| {
-                        let (cks, _cpu_sks) =
-                            KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
-                        let gpu_sks = CudaServerKey::new(&cks, &stream);
+                        let setup_encrypted_values = || {
+                            let cts_0 = (0..elements)
+                                .map(|_| {
+                                    let clearlow = rng.gen::<u128>();
+                                    let clearhigh = rng.gen::<u128>();
+                                    let clear_0 = tfhe::integer::I256::from((clearlow, clearhigh));
+                                    let ct_0 = cks.encrypt_signed_radix(clear_0, num_block);
 
-                        let mut cts_0 = (0..elements)
-                            .map(|_| {
-                                let clearlow = rng.gen::<u128>();
-                                let clearhigh = rng.gen::<u128>();
-                                let clear_0 = tfhe::integer::I256::from((clearlow, clearhigh));
-                                let ct_0 = cks.encrypt_signed_radix(clear_0, num_block);
+                                    CudaSignedRadixCiphertext::from_signed_radix_ciphertext(
+                                        &ct_0, &stream,
+                                    )
+                                })
+                                .collect::<Vec<_>>();
+                            let clears_1 = (0..elements)
+                                .map(|_| rng_func(&mut rng, bit_size) & max_value_for_bit_size)
+                                .collect::<Vec<_>>();
 
-                                CudaSignedRadixCiphertext::from_signed_radix_ciphertext(
-                                    &ct_0, &stream,
-                                )
-                            })
-                            .collect::<Vec<_>>();
-                        let clears_1 = (0..elements)
-                            .map(|_| rng_func(&mut rng, bit_size) & max_value_for_bit_size)
-                            .collect::<Vec<_>>();
+                            let local_streams = cuda_local_streams(num_block, elements as usize);
 
-                        b.iter(|| {
-                            cts_0.par_iter_mut().zip(clears_1.par_iter()).for_each(
-                                |(ct_0, clear_1)| {
-                                    binary_op(&gpu_sks, ct_0, *clear_1, &stream);
-                                },
-                            )
-                        })
+                            (cts_0, clears_1, local_streams)
+                        };
+
+                        b.iter_batched(
+                            setup_encrypted_values,
+                            |(mut cts_0, clears_1, local_streams)| {
+                                cts_0
+                                    .par_iter_mut()
+                                    .zip(clears_1.par_iter())
+                                    .zip(local_streams.par_iter())
+                                    .for_each(|((ct_0, clear_1), local_stream)| {
+                                        binary_op(&gpu_sks, ct_0, *clear_1, local_stream);
+                                    })
+                            },
+                            criterion::BatchSize::SmallInput,
+                        )
                     });
                 }
             }
@@ -1702,7 +1861,7 @@ mod cuda {
     }
 
     macro_rules! define_cuda_server_key_bench_clean_input_scalar_signed_fn (
-        (method_name: $server_key_method:ident, display_name:$name:ident, rng_func:$($rng_fn:tt)*) => {
+        (method_name: $server_key_method:ident, method_name_cpu: $server_key_method_cpu:ident, display_name:$name:ident, rng_func:$($rng_fn:tt)*) => {
             ::paste::paste!{
                 fn [<cuda_ $server_key_method>](c: &mut Criterion) {
                     bench_cuda_server_key_binary_scalar_signed_function_clean_inputs(
@@ -1711,6 +1870,9 @@ mod cuda {
                         stringify!($name),
                         |server_key, lhs, rhs, stream| {
                             server_key.$server_key_method(lhs, rhs, stream);
+                        },
+                        |server_key_cpu, lhs, rhs| {
+                            server_key_cpu.$server_key_method_cpu(lhs, rhs);
                         },
                         $($rng_fn)*
                     )
@@ -1721,11 +1883,12 @@ mod cuda {
 
     /// Base function to bench a server key function that is a binary operation for shift/rotate,
     /// input ciphertext will contain only zero carries
-    fn bench_cuda_server_key_shift_rotate_signed_function_clean_inputs<F>(
+    fn bench_cuda_server_key_shift_rotate_signed_function_clean_inputs<F, G>(
         c: &mut Criterion,
         bench_name: &str,
         display_name: &str,
         binary_op: F,
+        binary_op_cpu: G,
     ) where
         F: Fn(
                 &CudaServerKey,
@@ -1733,10 +1896,11 @@ mod cuda {
                 &mut CudaUnsignedRadixCiphertext,
                 &CudaStreams,
             ) + Sync,
+        G: Fn(&ServerKey, &SignedRadixCiphertext, &RadixCiphertext) + Sync,
     {
         let mut bench_group = c.benchmark_group(bench_name);
         bench_group
-            .sample_size(15)
+            .sample_size(10)
             .measurement_time(std::time::Duration::from_secs(30));
         let mut rng = rand::thread_rng();
 
@@ -1786,44 +1950,67 @@ mod cuda {
                     });
                 }
                 BenchmarkType::Throughput => {
+                    let (cks, cpu_sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
+                    let gpu_sks = CudaServerKey::new(&cks, &stream);
+
+                    // Execute the operation once to know its cost.
+                    let clear_1 = rng.gen_range(0u128..bit_size as u128);
+                    let ct_0 = cks.encrypt_signed_radix(gen_random_i256(&mut rng), num_block);
+                    let ct_1 = cks.encrypt_radix(clear_1, num_block);
+
+                    reset_pbs_count();
+                    // Use CPU operation as pbs_count do not count PBS on GPU backend.
+                    binary_op_cpu(&cpu_sks, &ct_0, &ct_1);
+                    let pbs_count = max(get_pbs_count(), 1); // Operation might not perform any PBS, so we take 1 as default
+
                     bench_id = format!("{bench_name}::throughput::{param_name}::{bit_size}_bits");
-                    let elements = throughput_num_threads(num_block);
+                    let elements = throughput_num_threads(num_block, pbs_count);
                     bench_group.throughput(Throughput::Elements(elements));
                     bench_group.bench_function(&bench_id, |b| {
-                        let (cks, _cpu_sks) =
-                            KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
-                        let gpu_sks = CudaServerKey::new(&cks, &stream);
+                        let setup_encrypted_values = || {
+                            let cts_0 = (0..elements)
+                                .map(|_| {
+                                    let clearlow = rng.gen::<u128>();
+                                    let clearhigh = rng.gen::<u128>();
+                                    let clear_0 = tfhe::integer::I256::from((clearlow, clearhigh));
+                                    let ct_0 = cks.encrypt_signed_radix(clear_0, num_block);
 
-                        let mut cts_0 = (0..elements)
-                            .map(|_| {
-                                let clearlow = rng.gen::<u128>();
-                                let clearhigh = rng.gen::<u128>();
-                                let clear_0 = tfhe::integer::I256::from((clearlow, clearhigh));
-                                let ct_0 = cks.encrypt_signed_radix(clear_0, num_block);
+                                    CudaSignedRadixCiphertext::from_signed_radix_ciphertext(
+                                        &ct_0, &stream,
+                                    )
+                                })
+                                .collect::<Vec<_>>();
+                            let cts_1 = (0..elements)
+                                .map(|_| {
+                                    let clearlow = rng.gen::<u128>();
+                                    let clearhigh = rng.gen::<u128>();
+                                    let clear_1 = tfhe::integer::U256::from((clearlow, clearhigh));
+                                    let ct_1 = cks.encrypt_radix(clear_1, num_block);
 
-                                CudaSignedRadixCiphertext::from_signed_radix_ciphertext(
-                                    &ct_0, &stream,
-                                )
-                            })
-                            .collect::<Vec<_>>();
-                        let mut cts_1 = (0..elements)
-                            .map(|_| {
-                                let clearlow = rng.gen::<u128>();
-                                let clearhigh = rng.gen::<u128>();
-                                let clear_1 = tfhe::integer::U256::from((clearlow, clearhigh));
-                                let ct_1 = cks.encrypt_radix(clear_1, num_block);
+                                    CudaUnsignedRadixCiphertext::from_radix_ciphertext(
+                                        &ct_1, &stream,
+                                    )
+                                })
+                                .collect::<Vec<_>>();
 
-                                CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct_1, &stream)
-                            })
-                            .collect::<Vec<_>>();
+                            let local_streams = cuda_local_streams(num_block, elements as usize);
 
-                        b.iter(|| {
-                            cts_0.par_iter_mut().zip(cts_1.par_iter_mut()).for_each(
-                                |(ct_0, ct_1)| {
-                                    binary_op(&gpu_sks, ct_0, ct_1, &stream);
-                                },
-                            )
-                        })
+                            (cts_0, cts_1, local_streams)
+                        };
+
+                        b.iter_batched(
+                            setup_encrypted_values,
+                            |(mut cts_0, mut cts_1, local_streams)| {
+                                cts_0
+                                    .par_iter_mut()
+                                    .zip(cts_1.par_iter_mut())
+                                    .zip(local_streams.par_iter())
+                                    .for_each(|((ct_0, ct_1), local_stream)| {
+                                        binary_op(&gpu_sks, ct_0, ct_1, local_stream);
+                                    })
+                            },
+                            criterion::BatchSize::SmallInput,
+                        )
                     });
                 }
             }
@@ -1843,7 +2030,7 @@ mod cuda {
     }
 
     macro_rules! define_cuda_server_key_bench_clean_input_signed_shift_rotate (
-        (method_name: $server_key_method:ident, display_name:$name:ident) => {
+        (method_name: $server_key_method:ident, method_name_cpu: $server_key_method_cpu:ident, display_name:$name:ident) => {
             ::paste::paste!{
                 fn [<cuda_ $server_key_method>](c: &mut Criterion) {
                     bench_cuda_server_key_shift_rotate_signed_function_clean_inputs(
@@ -1852,6 +2039,9 @@ mod cuda {
                         stringify!($name),
                         |server_key, lhs, rhs, stream| {
                             server_key.$server_key_method(lhs, rhs, stream);
+                        },
+                        |server_key_cpu, lhs, rhs| {
+                            server_key_cpu.$server_key_method_cpu(lhs, rhs);
                         }
                     )
                 }
@@ -1863,7 +2053,7 @@ mod cuda {
         let bench_name = "integer::cuda::signed::if_then_else";
         let mut bench_group = c.benchmark_group(bench_name);
         bench_group
-            .sample_size(15)
+            .sample_size(10)
             .measurement_time(std::time::Duration::from_secs(30));
         let mut rng = rand::thread_rng();
 
@@ -1916,49 +2106,73 @@ mod cuda {
                     });
                 }
                 BenchmarkType::Throughput => {
+                    let (cks, cpu_sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
+                    let gpu_sks = CudaServerKey::new(&cks, &stream);
+
+                    // Execute the operation once to know its cost.
+                    let cond = cpu_sks.create_trivial_boolean_block(rng.gen_bool(0.5));
+                    let ct_then = cks.encrypt_signed_radix(gen_random_i256(&mut rng), num_block);
+                    let ct_else = cks.encrypt_signed_radix(gen_random_i256(&mut rng), num_block);
+
+                    reset_pbs_count();
+                    // Use CPU operation as pbs_count do not count PBS on GPU backend.
+                    cpu_sks.if_then_else_parallelized(&cond, &ct_then, &ct_else);
+                    let pbs_count = max(get_pbs_count(), 1); // Operation might not perform any PBS, so we take 1 as default
+
                     bench_id = format!("{bench_name}::throughput::{param_name}::{bit_size}_bits");
-                    let elements = throughput_num_threads(num_block);
+                    let elements = throughput_num_threads(num_block, pbs_count);
                     bench_group.throughput(Throughput::Elements(elements));
                     bench_group.bench_function(&bench_id, |b| {
-                        let (cks, _cpu_sks) =
-                            KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
-                        let gpu_sks = CudaServerKey::new(&cks, &stream);
-
-                        let cts_cond = (0..elements)
-                            .map(|_| {
-                                let ct_cond = cks.encrypt_bool(rng.gen::<bool>());
-                                CudaBooleanBlock::from_boolean_block(&ct_cond, &stream)
-                            })
-                            .collect::<Vec<_>>();
-                        let cts_then = (0..elements)
-                            .map(|_| {
-                                let ct_then =
-                                    cks.encrypt_signed_radix(gen_random_i256(&mut rng), num_block);
-                                CudaSignedRadixCiphertext::from_signed_radix_ciphertext(
-                                    &ct_then, &stream,
-                                )
-                            })
-                            .collect::<Vec<_>>();
-                        let cts_else = (0..elements)
-                            .map(|_| {
-                                let ct_else =
-                                    cks.encrypt_signed_radix(gen_random_i256(&mut rng), num_block);
-                                CudaSignedRadixCiphertext::from_signed_radix_ciphertext(
-                                    &ct_else, &stream,
-                                )
-                            })
-                            .collect::<Vec<_>>();
-
-                        b.iter(|| {
-                            cts_cond
-                                .par_iter()
-                                .zip(cts_then.par_iter())
-                                .zip(cts_else.par_iter())
-                                .for_each(|((ct_cond, ct_then), ct_else)| {
-                                    let _ =
-                                        gpu_sks.if_then_else(ct_cond, ct_then, ct_else, &stream);
+                        let setup_encrypted_values = || {
+                            let cts_cond = (0..elements)
+                                .map(|_| {
+                                    let ct_cond = cks.encrypt_bool(rng.gen::<bool>());
+                                    CudaBooleanBlock::from_boolean_block(&ct_cond, &stream)
                                 })
-                        })
+                                .collect::<Vec<_>>();
+                            let cts_then = (0..elements)
+                                .map(|_| {
+                                    let ct_then = cks
+                                        .encrypt_signed_radix(gen_random_i256(&mut rng), num_block);
+                                    CudaSignedRadixCiphertext::from_signed_radix_ciphertext(
+                                        &ct_then, &stream,
+                                    )
+                                })
+                                .collect::<Vec<_>>();
+                            let cts_else = (0..elements)
+                                .map(|_| {
+                                    let ct_else = cks
+                                        .encrypt_signed_radix(gen_random_i256(&mut rng), num_block);
+                                    CudaSignedRadixCiphertext::from_signed_radix_ciphertext(
+                                        &ct_else, &stream,
+                                    )
+                                })
+                                .collect::<Vec<_>>();
+
+                            let local_streams = cuda_local_streams(num_block, elements as usize);
+
+                            (cts_cond, cts_then, cts_else, local_streams)
+                        };
+
+                        b.iter_batched(
+                            setup_encrypted_values,
+                            |(cts_cond, cts_then, cts_else, local_streams)| {
+                                cts_cond
+                                    .par_iter()
+                                    .zip(cts_then.par_iter())
+                                    .zip(cts_else.par_iter())
+                                    .zip(local_streams.par_iter())
+                                    .for_each(|(((ct_cond, ct_then), ct_else), local_stream)| {
+                                        let _ = gpu_sks.if_then_else(
+                                            ct_cond,
+                                            ct_then,
+                                            ct_else,
+                                            local_stream,
+                                        );
+                                    })
+                            },
+                            criterion::BatchSize::SmallInput,
+                        )
                     });
                 }
             }
@@ -1997,246 +2211,291 @@ mod cuda {
 
     define_cuda_server_key_bench_clean_input_signed_fn!(
         method_name: unchecked_add,
+        method_name_cpu: unchecked_add_parallelized,
         display_name: add
     );
 
     define_cuda_server_key_bench_clean_input_signed_fn!(
         method_name: unchecked_sub,
+        method_name_cpu: unchecked_sub,
         display_name: sub
     );
 
     define_cuda_server_key_bench_clean_input_signed_unary_fn!(
         method_name: unchecked_neg,
+        method_name_cpu: unchecked_neg,
         display_name: neg
     );
 
     define_cuda_server_key_bench_clean_input_signed_unary_fn!(
         method_name: unchecked_abs,
+        method_name_cpu: unchecked_abs_parallelized,
         display_name: abs
     );
 
     define_cuda_server_key_bench_clean_input_signed_fn!(
         method_name: unchecked_mul,
+        method_name_cpu: unchecked_mul_parallelized,
         display_name: mul
     );
 
     define_cuda_server_key_bench_clean_input_signed_fn!(
         method_name: unchecked_div_rem,
+        method_name_cpu: unchecked_div_rem_parallelized,
         display_name: div_mod
     );
 
     define_cuda_server_key_bench_clean_input_signed_fn!(
         method_name: unchecked_bitand,
+        method_name_cpu: unchecked_bitand_parallelized,
         display_name: bitand
     );
 
     define_cuda_server_key_bench_clean_input_signed_fn!(
         method_name: unchecked_bitor,
+        method_name_cpu: unchecked_bitor_parallelized,
         display_name: bitor
     );
 
     define_cuda_server_key_bench_clean_input_signed_fn!(
         method_name: unchecked_bitxor,
+        method_name_cpu: unchecked_bitxor_parallelized,
         display_name: bitxor
     );
 
     define_cuda_server_key_bench_clean_input_signed_unary_fn!(
         method_name: unchecked_bitnot,
+        method_name_cpu: bitnot,
         display_name: bitnot
     );
 
     define_cuda_server_key_bench_clean_input_signed_shift_rotate!(
         method_name: unchecked_rotate_left,
+        method_name_cpu: unchecked_rotate_left_parallelized,
         display_name: rotate_left
     );
 
     define_cuda_server_key_bench_clean_input_signed_shift_rotate!(
         method_name: unchecked_rotate_right,
+        method_name_cpu: unchecked_rotate_right_parallelized,
         display_name: rotate_right
     );
 
     define_cuda_server_key_bench_clean_input_signed_shift_rotate!(
         method_name: unchecked_left_shift,
+        method_name_cpu: unchecked_left_shift_parallelized,
         display_name: left_shift
     );
 
     define_cuda_server_key_bench_clean_input_signed_shift_rotate!(
         method_name: unchecked_right_shift,
+        method_name_cpu: unchecked_right_shift_parallelized,
         display_name: right_shift
     );
 
     define_cuda_server_key_bench_clean_input_signed_fn!(
         method_name: unchecked_eq,
+        method_name_cpu: unchecked_eq_parallelized,
         display_name: eq
     );
 
     define_cuda_server_key_bench_clean_input_signed_fn!(
         method_name: unchecked_ne,
+        method_name_cpu: unchecked_ne_parallelized,
         display_name: ne
     );
 
     define_cuda_server_key_bench_clean_input_signed_fn!(
         method_name: unchecked_gt,
+        method_name_cpu: unchecked_gt_parallelized,
         display_name: gt
     );
 
     define_cuda_server_key_bench_clean_input_signed_fn!(
         method_name: unchecked_ge,
+        method_name_cpu: unchecked_ge_parallelized,
         display_name: ge
     );
 
     define_cuda_server_key_bench_clean_input_signed_fn!(
         method_name: unchecked_lt,
+        method_name_cpu: unchecked_lt_parallelized,
         display_name: lt
     );
 
     define_cuda_server_key_bench_clean_input_signed_fn!(
         method_name: unchecked_le,
+        method_name_cpu: unchecked_le_parallelized,
         display_name: le
     );
 
     define_cuda_server_key_bench_clean_input_signed_fn!(
         method_name: unchecked_min,
+        method_name_cpu: unchecked_min_parallelized,
         display_name: min
     );
 
     define_cuda_server_key_bench_clean_input_signed_fn!(
         method_name: unchecked_max,
+        method_name_cpu: unchecked_max_parallelized,
         display_name: max
     );
 
     define_cuda_server_key_bench_clean_input_signed_fn!(
         method_name: unchecked_signed_overflowing_add,
+        method_name_cpu: unchecked_signed_overflowing_add_parallelized,
         display_name: overflowing_add
     );
 
     define_cuda_server_key_bench_clean_input_signed_fn!(
         method_name: unchecked_signed_overflowing_sub,
+        method_name_cpu: unchecked_signed_overflowing_sub_parallelized,
         display_name: overflowing_sub
     );
 
     define_cuda_server_key_bench_clean_input_scalar_signed_fn!(
         method_name: unchecked_scalar_add,
+        method_name_cpu: unchecked_scalar_add,
         display_name: add,
         rng_func: default_signed_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_signed_fn!(
         method_name: unchecked_scalar_mul,
+        method_name_cpu: unchecked_scalar_mul_parallelized,
         display_name: mul,
         rng_func: mul_signed_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_signed_fn!(
         method_name: unchecked_scalar_sub,
+        method_name_cpu: unchecked_scalar_sub,
         display_name: sub,
         rng_func: default_signed_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_signed_fn!(
         method_name: unchecked_scalar_bitand,
+        method_name_cpu: unchecked_scalar_bitand_parallelized,
         display_name: bitand,
         rng_func: default_signed_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_signed_fn!(
         method_name: unchecked_scalar_bitor,
+        method_name_cpu: unchecked_scalar_bitor_parallelized,
         display_name: bitor,
         rng_func: default_signed_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_signed_fn!(
         method_name: unchecked_scalar_bitxor,
+        method_name_cpu: unchecked_scalar_bitxor_parallelized,
         display_name: bitxor,
         rng_func: default_signed_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_signed_fn!(
         method_name: unchecked_scalar_right_shift,
+        method_name_cpu: unchecked_scalar_right_shift_parallelized,
         display_name: right_shift,
         rng_func: default_signed_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_signed_fn!(
         method_name: unchecked_scalar_left_shift,
+        method_name_cpu: unchecked_scalar_left_shift_parallelized,
         display_name: left_shift,
         rng_func: shift_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_signed_fn!(
         method_name: unchecked_scalar_rotate_right,
+        method_name_cpu: unchecked_scalar_rotate_right_parallelized,
         display_name: rotate_right,
         rng_func: shift_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_signed_fn!(
         method_name: unchecked_scalar_rotate_left,
+        method_name_cpu: unchecked_scalar_rotate_left_parallelized,
         display_name: rotate_left,
         rng_func: shift_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_signed_fn!(
         method_name: unchecked_scalar_eq,
+        method_name_cpu: unchecked_scalar_eq_parallelized,
         display_name: eq,
         rng_func: default_signed_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_signed_fn!(
         method_name: unchecked_scalar_ne,
+        method_name_cpu: unchecked_scalar_ne_parallelized,
         display_name: ne,
         rng_func: default_signed_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_signed_fn!(
         method_name: unchecked_scalar_gt,
+        method_name_cpu: unchecked_scalar_gt_parallelized,
         display_name: gt,
         rng_func: default_signed_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_signed_fn!(
         method_name: unchecked_scalar_ge,
+        method_name_cpu: unchecked_scalar_ge_parallelized,
         display_name: ge,
         rng_func: default_signed_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_signed_fn!(
         method_name: unchecked_scalar_lt,
+        method_name_cpu: unchecked_scalar_lt_parallelized,
         display_name: lt,
         rng_func: default_signed_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_signed_fn!(
         method_name: unchecked_scalar_le,
+        method_name_cpu: unchecked_scalar_le_parallelized,
         display_name: le,
         rng_func: default_signed_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_signed_fn!(
         method_name: unchecked_scalar_min,
+        method_name_cpu: unchecked_scalar_min_parallelized,
         display_name: min,
         rng_func: default_signed_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_signed_fn!(
         method_name: unchecked_scalar_max,
+        method_name_cpu: unchecked_scalar_max_parallelized,
         display_name: max,
         rng_func: default_signed_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_signed_fn!(
         method_name: signed_overflowing_scalar_add,
+        method_name_cpu: signed_overflowing_scalar_add_parallelized,
         display_name: overflowing_add,
         rng_func: default_signed_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_signed_fn!(
         method_name: signed_overflowing_scalar_sub,
+        method_name_cpu: signed_overflowing_scalar_sub_parallelized,
         display_name: overflowing_sub,
         rng_func: default_signed_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_signed_fn!(
         method_name: unchecked_signed_scalar_div_rem,
+        method_name_cpu: unchecked_signed_scalar_div_rem_parallelized,
         display_name: div_rem,
         rng_func: div_scalar
     );
@@ -2247,234 +2506,277 @@ mod cuda {
 
     define_cuda_server_key_bench_clean_input_signed_fn!(
         method_name: add,
+        method_name_cpu: add_parallelized,
         display_name: add
     );
 
     define_cuda_server_key_bench_clean_input_signed_fn!(
         method_name: sub,
+        method_name_cpu: sub_parallelized,
         display_name: sub
     );
 
     define_cuda_server_key_bench_clean_input_signed_unary_fn!(
         method_name: neg,
+        method_name_cpu: neg_parallelized,
         display_name: neg
     );
 
     define_cuda_server_key_bench_clean_input_signed_unary_fn!(
         method_name: abs,
+        method_name_cpu: abs_parallelized,
         display_name: abs
     );
 
     define_cuda_server_key_bench_clean_input_signed_fn!(
         method_name: mul,
+        method_name_cpu: mul_parallelized,
         display_name: mul
     );
 
     define_cuda_server_key_bench_clean_input_signed_fn!(
         method_name: div_rem,
+        method_name_cpu: div_rem_parallelized,
         display_name: div_mod
     );
 
     define_cuda_server_key_bench_clean_input_signed_fn!(
         method_name: bitand,
+        method_name_cpu: bitand_parallelized,
         display_name: bitand
     );
 
     define_cuda_server_key_bench_clean_input_signed_unary_fn!(
         method_name: bitnot,
+        method_name_cpu: bitnot,
         display_name: bitnot
     );
 
     define_cuda_server_key_bench_clean_input_signed_fn!(
         method_name: bitor,
+        method_name_cpu: bitor_parallelized,
         display_name: bitor
     );
 
     define_cuda_server_key_bench_clean_input_signed_fn!(
         method_name: bitxor,
+        method_name_cpu: bitxor_parallelized,
         display_name: bitxor
     );
 
     define_cuda_server_key_bench_clean_input_signed_shift_rotate!(
         method_name: rotate_left,
+        method_name_cpu: rotate_left_parallelized,
         display_name: rotate_left
     );
 
     define_cuda_server_key_bench_clean_input_signed_shift_rotate!(
         method_name: rotate_right,
+        method_name_cpu: rotate_right_parallelized,
         display_name: rotate_right
     );
 
     define_cuda_server_key_bench_clean_input_signed_shift_rotate!(
         method_name: left_shift,
+        method_name_cpu: left_shift_parallelized,
         display_name: left_shift
     );
 
     define_cuda_server_key_bench_clean_input_signed_shift_rotate!(
         method_name: right_shift,
+        method_name_cpu: right_shift_parallelized,
         display_name: right_shift
     );
 
     define_cuda_server_key_bench_clean_input_signed_fn!(
         method_name: eq,
+        method_name_cpu: eq_parallelized,
         display_name: eq
     );
 
     define_cuda_server_key_bench_clean_input_signed_fn!(
         method_name: ne,
+        method_name_cpu: ne_parallelized,
         display_name: ne
     );
 
     define_cuda_server_key_bench_clean_input_signed_fn!(
         method_name: gt,
+        method_name_cpu: gt_parallelized,
         display_name: gt
     );
 
     define_cuda_server_key_bench_clean_input_signed_fn!(
         method_name: ge,
+        method_name_cpu: ge_parallelized,
         display_name: ge
     );
 
     define_cuda_server_key_bench_clean_input_signed_fn!(
         method_name: lt,
+        method_name_cpu: lt_parallelized,
         display_name: lt
     );
 
     define_cuda_server_key_bench_clean_input_signed_fn!(
         method_name: le,
+        method_name_cpu: le_parallelized,
         display_name: le
     );
 
     define_cuda_server_key_bench_clean_input_signed_fn!(
         method_name: min,
+        method_name_cpu: min_parallelized,
         display_name: min
     );
 
     define_cuda_server_key_bench_clean_input_signed_fn!(
         method_name: max,
+        method_name_cpu: max_parallelized,
         display_name: max
     );
 
     define_cuda_server_key_bench_clean_input_signed_fn!(
         method_name: signed_overflowing_add,
+        method_name_cpu: signed_overflowing_add_parallelized,
         display_name: overflowing_add
     );
 
     define_cuda_server_key_bench_clean_input_signed_fn!(
         method_name: signed_overflowing_sub,
+        method_name_cpu: signed_overflowing_sub_parallelized,
         display_name: overflowing_sub
     );
 
     define_cuda_server_key_bench_clean_input_scalar_signed_fn!(
         method_name: scalar_add,
+        method_name_cpu: scalar_add_parallelized,
         display_name: add,
         rng_func: default_signed_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_signed_fn!(
         method_name: scalar_mul,
+        method_name_cpu: scalar_mul_parallelized,
         display_name: mul,
         rng_func: mul_signed_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_signed_fn!(
         method_name: scalar_sub,
+        method_name_cpu: scalar_sub_parallelized,
         display_name: sub,
         rng_func: default_signed_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_signed_fn!(
         method_name: scalar_bitand,
+        method_name_cpu: scalar_bitand_parallelized,
         display_name: bitand,
         rng_func: default_signed_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_signed_fn!(
         method_name: scalar_bitor,
+        method_name_cpu: scalar_bitor_parallelized,
         display_name: bitor,
         rng_func: default_signed_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_signed_fn!(
         method_name: scalar_bitxor,
+        method_name_cpu: scalar_bitxor_parallelized,
         display_name: bitxor,
         rng_func: default_signed_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_signed_fn!(
         method_name: scalar_left_shift,
+        method_name_cpu: scalar_left_shift_parallelized,
         display_name: left_shift,
         rng_func: shift_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_signed_fn!(
         method_name: scalar_right_shift,
+        method_name_cpu: scalar_right_shift_parallelized,
         display_name: right_shift,
         rng_func: shift_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_signed_fn!(
         method_name: scalar_rotate_left,
+        method_name_cpu: scalar_rotate_left_parallelized,
         display_name: rotate_left,
         rng_func: shift_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_signed_fn!(
         method_name: scalar_rotate_right,
+        method_name_cpu: scalar_rotate_right_parallelized,
         display_name: rotate_right,
         rng_func: shift_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_signed_fn!(
         method_name: scalar_eq,
+        method_name_cpu: scalar_eq_parallelized,
         display_name: eq,
         rng_func: default_signed_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_signed_fn!(
         method_name: scalar_ne,
+        method_name_cpu: scalar_ne_parallelized,
         display_name: ne,
         rng_func: default_signed_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_signed_fn!(
         method_name: scalar_gt,
+        method_name_cpu: scalar_gt_parallelized,
         display_name: gt,
         rng_func: default_signed_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_signed_fn!(
         method_name: scalar_ge,
+        method_name_cpu: scalar_ge_parallelized,
         display_name: ge,
         rng_func: default_signed_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_signed_fn!(
         method_name: scalar_lt,
+        method_name_cpu: scalar_lt_parallelized,
         display_name: lt,
         rng_func: default_signed_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_signed_fn!(
         method_name: scalar_le,
+        method_name_cpu: scalar_le_parallelized,
         display_name: le,
         rng_func: default_signed_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_signed_fn!(
         method_name: scalar_min,
+        method_name_cpu: scalar_min_parallelized,
         display_name: min,
         rng_func: default_signed_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_signed_fn!(
         method_name: scalar_max,
+        method_name_cpu: scalar_max_parallelized,
         display_name: max,
         rng_func: default_signed_scalar
     );
 
     define_cuda_server_key_bench_clean_input_scalar_signed_fn!(
         method_name: signed_scalar_div_rem,
+        method_name_cpu: signed_scalar_div_rem_parallelized,
         display_name: div_rem,
         rng_func: div_scalar
     );
@@ -2609,7 +2911,7 @@ mod cuda {
     {
         let mut bench_group = c.benchmark_group(bench_name);
         bench_group
-            .sample_size(15)
+            .sample_size(10)
             .measurement_time(std::time::Duration::from_secs(30));
         let mut rng = rand::thread_rng();
 
@@ -2697,6 +2999,7 @@ use cuda::{
     cuda_cast_ops, default_cuda_dedup_ops, default_cuda_ops, default_scalar_cuda_ops,
     unchecked_cuda_ops, unchecked_scalar_cuda_ops,
 };
+use tfhe::{get_pbs_count, reset_pbs_count};
 
 #[cfg(feature = "gpu")]
 fn go_through_gpu_bench_groups(val: &str) {

--- a/tfhe/benches/utilities.rs
+++ b/tfhe/benches/utilities.rs
@@ -591,27 +591,69 @@ pub mod integer_utils {
     use super::*;
     use std::sync::OnceLock;
     #[cfg(feature = "gpu")]
-    use tfhe_cuda_backend::cuda_bind::cuda_get_number_of_gpus;
+    use tfhe::core_crypto::gpu::vec::GpuIndex;
+    #[cfg(feature = "gpu")]
+    use tfhe::core_crypto::gpu::{get_number_of_gpus, CudaStreams};
+
+    /// Number of streaming multiprocessors (SM) available on Nvidia H100 GPU
+    #[allow(dead_code)]
+    const H100_PCIE_SM_COUNT: u32 = 132;
 
     /// Generate a number of threads to use to saturate current machine for throughput measurements.
     #[allow(dead_code)]
-    pub fn throughput_num_threads(num_block: usize) -> u64 {
+    pub fn throughput_num_threads(num_block: usize, op_pbs_count: u64) -> u64 {
         let ref_block_count = 32; // Represent a ciphertext of 64 bits for 2_2 parameters set
-        let block_multiplicator = (ref_block_count as f64 / num_block as f64).ceil();
+        let block_multiplicator = (ref_block_count as f64 / num_block as f64).ceil().min(1.0);
+        // Some operations with a high serial workload (e.g. division) would yield an operation
+        // loading value so low that the number of elements in the end wouldn't be meaningful.
+        let minimum_loading = if num_block < 64 { 0.2 } else { 0.1 };
 
         #[cfg(feature = "gpu")]
         {
-            // This value is for Nvidia H100 GPU
-            let streaming_multiprocessors = 132;
-            let num_gpus = unsafe { cuda_get_number_of_gpus() };
-            ((streaming_multiprocessors * num_gpus) as f64 * block_multiplicator) as u64
+            let total_num_sm = H100_PCIE_SM_COUNT * get_number_of_gpus();
+            let operation_loading =
+                ((total_num_sm as u64 / op_pbs_count) as f64).max(minimum_loading);
+            let elements = (total_num_sm as f64 * block_multiplicator * operation_loading) as u64;
+            elements.min(1500) // This threshold is useful for operation with both a small number of
+                               // block and low PBs count.
         }
         #[cfg(not(feature = "gpu"))]
         {
             let num_threads = rayon::current_num_threads() as f64;
+            let operation_loading = (num_threads / (op_pbs_count as f64)).max(minimum_loading);
             // Add 20% more to maximum threads available.
-            ((num_threads + (num_threads * 0.2)) * block_multiplicator) as u64
+            ((num_threads + (num_threads * 0.2)) * block_multiplicator.min(1.0) * operation_loading)
+                as u64
         }
+    }
+
+    /// Get number of streams usable for CUDA throughput benchmarks
+    #[cfg(feature = "gpu")]
+    fn cuda_num_streams(num_block: usize) -> u64 {
+        let num_streams_per_gpu: u32 = match num_block {
+            2 => 64,
+            4 => 32,
+            8 => 16,
+            16 => 8,
+            32 => 4,
+            64 => 2,
+            128 => 1,
+            _ => 8,
+        };
+        (num_streams_per_gpu * get_number_of_gpus()) as u64
+    }
+
+    /// Get vector of CUDA streams that can be directly used for throughput benchmarks.
+    #[allow(dead_code)]
+    #[cfg(feature = "gpu")]
+    pub fn cuda_local_streams(num_block: usize, throughput_elements: usize) -> Vec<CudaStreams> {
+        (0..cuda_num_streams(num_block))
+            .map(|i| {
+                CudaStreams::new_single_gpu(GpuIndex::new((i % get_number_of_gpus() as u64) as u32))
+            })
+            .cycle()
+            .take(throughput_elements)
+            .collect::<Vec<_>>()
     }
 
     #[allow(dead_code)]

--- a/tfhe/src/integer/gpu/ciphertext/boolean_value.rs
+++ b/tfhe/src/integer/gpu/ciphertext/boolean_value.rs
@@ -176,7 +176,7 @@ impl CudaBooleanBlock {
         })
     }
 
-    pub(crate) fn duplicate(&self, streams: &CudaStreams) -> Self {
+    pub fn duplicate(&self, streams: &CudaStreams) -> Self {
         let ct = unsafe { self.duplicate_async(streams) };
         streams.synchronize();
         ct


### PR DESCRIPTION
This is done to load benchmarks machine in smarter way. This makes sure to saturate compute load of the benchmark machine while keeping execution time reasonable.

iter_batched() criterion method is used instead of iter() so that benchmarks are compatible with other flavors of operations (unchecked_* or smart_*).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/2112)
<!-- Reviewable:end -->
