### PR TITLE
fix: fix the atomic pattern used to cast in trivium and a test in shortint

### DIFF
--- a/tfhe/src/shortint/key_switching_key/test.rs
+++ b/tfhe/src/shortint/key_switching_key/test.rs
@@ -129,7 +129,12 @@ fn gen_multi_keys_test_add_with_overflow_ci_run_filter() {
     let c3 = sk1.unchecked_scalar_mul(&c1, 2);
     let c4 = sk1.unchecked_add(&c3, &c2);
 
-    let output_of_cast = ksk.cast(&c4);
+    // The optimized atomic pattern requires a ciphertext with NoiseLevel::NOMINAL, i.e. a
+    // ciphertext fresh out of a bootstrap
+    let id_lut = sk1.generate_lookup_table(|x| x);
+    let c5 = sk1.apply_lookup_table(&c4, &id_lut);
+
+    let output_of_cast = ksk.cast(&c5);
     let clear = ck2.decrypt(&output_of_cast);
     assert_eq!(clear, 3);
     let ct_carry = sk2.carry_extract(&output_of_cast);


### PR DESCRIPTION
- parameters are optimized for a clean ciphertext, the ciphertext being keyswitched was noisy

Circuit is

```
        x = Input
        x = bootstrap(x, input_bootstrap_key)
        x = keyswitch(x, cast_keyswitch_key)
        x = bootstrap(x, output_bootstrap_key)
```

we were doing 

```
        x = Input
        x = bootstrap(x, input_bootstrap_key)
        x = x * 3
        x = keyswitch(x, cast_keyswitch_key)
        x = bootstrap(x, output_bootstrap_key)
```

for parameters with the drift mitigation this means that the noise after the multiplication by 3 is very large (as it gets mitigated right before the PBS)