### PR TITLE
chore(ci): switch environment and add fallback for gpu profiles

### DIFF
--- a/ci/slab.toml
+++ b/ci/slab.toml
@@ -71,6 +71,12 @@ image_name = "Ubuntu Server 22.04 LTS R535 CUDA 12.2"
 flavor_name = "n3-H100-SXM5x8"
 user = "ubuntu"
 
+[backend.hyperstack.multi-h100-sxm5_fallback]
+environment_name = "us-1"
+image_name = "Ubuntu Server 22.04 LTS R535 CUDA 12.2"
+flavor_name = "n3-H100-SXM5x8"
+user = "ubuntu"
+
 [backend.hyperstack.multi-a100-nvlink]
 environment_name = "canada"
 image_name = "Ubuntu Server 22.04 LTS R535 CUDA 12.2"
@@ -87,4 +93,10 @@ user = "ubuntu"
 environment_name = "canada"
 image_name = "Ubuntu Server 22.04 LTS R535 CUDA 12.2"
 flavor_name = "n3-L40x1"
+user = "ubuntu"
+
+[backend.hyperstack.l40_fallback]
+environment_name = "canada"
+image_name = "Ubuntu Server 22.04 LTS R535 CUDA 12.2"
+flavor_name = "n3-RTX-A600x1"
 user = "ubuntu"


### PR DESCRIPTION
Switch n3-H100-SXM5x8 to US-1 as CANADA is out of stock on this instance.
Also L40 instances fallback on n3-RTX-A6000x1 to mitigate resource shortages issues.

