### PR TITLE
fix: BlockDecomposer

### DIFF
--- a/tfhe/src/integer/server_key/radix/scalar_sub.rs
+++ b/tfhe/src/integer/server_key/radix/scalar_sub.rs
@@ -1,5 +1,5 @@
 use crate::core_crypto::prelude::Numeric;
-use crate::integer::block_decomposition::{BlockDecomposer, DecomposableInto};
+use crate::integer::block_decomposition::{BlockDecomposer, DecomposableInto, PaddingBitValue};
 use crate::integer::ciphertext::{IntegerRadixCiphertext, RadixCiphertext};
 use crate::integer::server_key::CheckError;
 use crate::integer::ServerKey;
@@ -92,17 +92,12 @@ impl ServerKey {
         // The only case where these msb could become 0 after the addition
         // is if scalar == T::ZERO (=> !T::ZERO == T::MAX => T::MAX + 1 == overflow),
         // but this case has been handled earlier.
-        let padding_bit = 1u32; // To handle when bits is not a multiple of T::BITS
-                                // All bits of message set to one
         let pad_block = (1 << bits_in_message as u8) - 1;
 
-        let decomposer = BlockDecomposer::with_padding_bit(
-            neg_scalar,
-            bits_in_message,
-            Scalar::cast_from(padding_bit),
-        )
-        .iter_as::<u8>()
-        .chain(std::iter::repeat(pad_block));
+        let decomposer =
+            BlockDecomposer::with_padding_bit(neg_scalar, bits_in_message, PaddingBitValue::One)
+                .iter_as::<u8>()
+                .chain(std::iter::repeat(pad_block));
         Some(decomposer)
     }
 


### PR DESCRIPTION
The BlockDecomposer gave the possibility when the number of bits per block was not a multiple of the number of bits in the original integer to force the extra bits of the last block to a particular value.

However, the way this was done could only work when setting these bits to 1, when wanting to set them to 0 it would not work.

Good news is that we actually never wanted to set them to 0, but it should still be fixed for completeness, and allow other feature to be added without bugs


