### PR TITLE
Tm/fix signed decomposer

### DIFF
--- a/tfhe/src/integer/encryption.rs
+++ b/tfhe/src/integer/encryption.rs
@@ -92,9 +92,7 @@ where
 // We need to concretize the iterator type to be able to pass callbacks consuming the iterator,
 // having an opaque return impl Iterator does not allow to take callbacks at this moment, not sure
 // the Fn(impl Trait) syntax can be made to work nicely with the rest of the language
-pub(crate) type ClearRadixBlockIterator<T> = std::iter::Take<
-    std::iter::Chain<std::iter::Map<BlockDecomposer<T>, fn(T) -> u64>, std::iter::Repeat<u64>>,
->;
+pub(crate) type ClearRadixBlockIterator<T> = std::iter::Map<BlockDecomposer<T>, fn(T) -> u64>;
 
 pub(crate) fn create_clear_radix_block_iterator<T>(
     message: T,
@@ -105,12 +103,7 @@ where
     T: DecomposableInto<u64>,
 {
     let bits_in_block = message_modulus.0.ilog2();
-    let decomposer = BlockDecomposer::new(message, bits_in_block);
-
-    decomposer
-        .iter_as::<u64>()
-        .chain(std::iter::repeat(0u64))
-        .take(num_blocks)
+    BlockDecomposer::with_block_count(message, bits_in_block, num_blocks).iter_as::<u64>()
 }
 
 pub(crate) fn encrypt_crt<BlockKey, Block, CrtCiphertextType, F>(

--- a/tfhe/src/integer/gpu/server_key/radix/mod.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/mod.rs
@@ -187,10 +187,9 @@ impl CudaServerKey {
             PBSOrder::BootstrapKeyswitch => self.key_switching_key.output_key_lwe_size(),
         };
 
-        let decomposer = BlockDecomposer::new(scalar, self.message_modulus.0.ilog2())
-            .iter_as::<u64>()
-            .chain(std::iter::repeat(0))
-            .take(num_blocks);
+        let decomposer =
+            BlockDecomposer::with_block_count(scalar, self.message_modulus.0.ilog2(), num_blocks)
+                .iter_as::<u64>();
         let mut cpu_lwe_list = LweCiphertextList::new(
             0,
             lwe_size,

--- a/tfhe/src/integer/server_key/radix_parallel/scalar_add.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/scalar_add.rs
@@ -276,15 +276,13 @@ impl ServerKey {
             self.full_propagate_parallelized(ct);
         }
 
-        let scalar_blocks = BlockDecomposer::new(scalar, self.message_modulus().0.ilog2())
-            .iter_as::<u8>()
-            .chain(std::iter::repeat(if scalar < Scalar::ZERO {
-                (self.message_modulus().0 - 1) as u8
-            } else {
-                0
-            }))
-            .take(ct.blocks().len())
-            .collect();
+        let scalar_blocks = BlockDecomposer::with_block_count(
+            scalar,
+            self.message_modulus().0.ilog2(),
+            ct.blocks().len(),
+        )
+        .iter_as::<u8>()
+        .collect();
 
         const COMPUTE_OVERFLOW: bool = false;
         const INPUT_CARRY: bool = false;

--- a/tfhe/src/integer/server_key/radix_parallel/scalar_sub.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/scalar_sub.rs
@@ -640,16 +640,13 @@ impl ServerKey {
 
         const INPUT_CARRY: bool = true;
         let flipped_scalar = !scalar;
-        let decomposed_flipped_scalar =
-            BlockDecomposer::new(flipped_scalar, self.message_modulus().0.ilog2())
-                .iter_as::<u8>()
-                .chain(std::iter::repeat(if scalar < Scalar::ZERO {
-                    0
-                } else {
-                    (self.message_modulus().0 - 1) as u8
-                }))
-                .take(lhs.blocks.len())
-                .collect::<Vec<_>>();
+        let decomposed_flipped_scalar = BlockDecomposer::with_block_count(
+            flipped_scalar,
+            self.message_modulus().0.ilog2(),
+            lhs.blocks.len(),
+        )
+        .iter_as::<u8>()
+        .collect::<Vec<_>>();
         let maybe_overflow = self.add_assign_scalar_blocks_parallelized(
             lhs,
             decomposed_flipped_scalar,


### PR DESCRIPTION
Some parts of the code did not use the correct way to
decompose a clear integer into blocks which could be encrypted
or used in scalar ops.

The sign extension was not always properly done, leading for example
in the encryption of a negative integer stored on a i8 to a
SignedRadixCiphertext with a num_blocks greater than i8 to be incorrect:

```
let ct = cks.encrypt_signed(-1i8, 16) // 2_2 parameters
let d: i32 = cks.decrypt_signed(&ct);
assert_eq!(d, i32::from(-1i8)); // Fails
```

To fix, a BlockDecomposer::with_block_count function is added and used
This function will properly do the sign extension when needed

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/2133)
<!-- Reviewable:end -->
