### PR TITLE
fix(gpu): fix ilog2 result when input is 0

### DIFF
--- a/backends/tfhe-cuda-backend/cuda/include/integer/integer_utilities.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer/integer_utilities.h
@@ -1564,7 +1564,7 @@ template <typename Torus> struct int_prop_simu_group_carries_memory {
   int_hs_group_prop_memory<Torus> *hs_group_prop_mem;
 
   uint32_t group_size;
-  bool use_sequential_algorithm_to_resolver_group_carries;
+  bool use_sequential_algorithm_to_resolve_group_carries;
 
   int_prop_simu_group_carries_memory(
       cudaStream_t const *streams, uint32_t const *gpu_indexes,
@@ -1622,10 +1622,10 @@ template <typename Torus> struct int_prop_simu_group_carries_memory {
       hillis_steel_depth = std::ceil(std::log2(num_carry_to_resolve));
     }
 
-    use_sequential_algorithm_to_resolver_group_carries =
+    use_sequential_algorithm_to_resolve_group_carries =
         sequential_depth <= hillis_steel_depth;
     uint32_t num_extra_luts = 0;
-    if (use_sequential_algorithm_to_resolver_group_carries) {
+    if (use_sequential_algorithm_to_resolve_group_carries) {
       num_extra_luts = (grouping_size - 1);
     } else {
       num_extra_luts = 1;
@@ -1696,7 +1696,7 @@ template <typename Torus> struct int_prop_simu_group_carries_memory {
           f_other_groupings_inner_propagation);
     }
 
-    if (use_sequential_algorithm_to_resolver_group_carries) {
+    if (use_sequential_algorithm_to_resolve_group_carries) {
       for (int index = 0; index < grouping_size - 1; index++) {
         uint32_t lut_id = index + 2 * grouping_size;
 
@@ -1748,7 +1748,7 @@ template <typename Torus> struct int_prop_simu_group_carries_memory {
       if (is_in_first_grouping) {
         h_second_lut_indexes[index] = index_in_grouping;
       } else if (index_in_grouping == (grouping_size - 1)) {
-        if (use_sequential_algorithm_to_resolver_group_carries) {
+        if (use_sequential_algorithm_to_resolve_group_carries) {
           int inner_index = (grouping_index - 1) % (grouping_size - 1);
           h_second_lut_indexes[index] = inner_index + 2 * grouping_size;
         } else {
@@ -1762,7 +1762,7 @@ template <typename Torus> struct int_prop_simu_group_carries_memory {
           !is_in_first_grouping && (index_in_grouping == grouping_size - 1);
 
       if (may_have_its_padding_bit_set) {
-        if (use_sequential_algorithm_to_resolver_group_carries) {
+        if (use_sequential_algorithm_to_resolve_group_carries) {
           h_scalar_array_cum_sum[index] =
               1 << ((grouping_index - 1) % (grouping_size - 1));
         } else {
@@ -1783,7 +1783,7 @@ template <typename Torus> struct int_prop_simu_group_carries_memory {
                              gpu_indexes[0]);
     luts_array_second_step->broadcast_lut(streams, gpu_indexes, 0);
 
-    if (use_sequential_algorithm_to_resolver_group_carries) {
+    if (use_sequential_algorithm_to_resolve_group_carries) {
 
       seq_group_prop_mem = new int_seq_group_prop_memory<Torus>(
           streams, gpu_indexes, gpu_count, params, grouping_size,
@@ -1832,7 +1832,7 @@ template <typename Torus> struct int_prop_simu_group_carries_memory {
 
     luts_array_second_step->release(streams, gpu_indexes, gpu_count);
 
-    if (use_sequential_algorithm_to_resolver_group_carries) {
+    if (use_sequential_algorithm_to_resolve_group_carries) {
       seq_group_prop_mem->release(streams, gpu_indexes, gpu_count);
       delete seq_group_prop_mem;
     } else {
@@ -1860,7 +1860,6 @@ template <typename Torus> struct int_sc_prop_memory {
   int_prop_simu_group_carries_memory<Torus> *prop_simu_group_carries_mem;
 
   int_radix_params params;
-  bool use_sequential_algorithm_to_resolver_group_carries;
   uint32_t requested_flag;
 
   uint32_t active_gpu_count;
@@ -4010,7 +4009,7 @@ template <typename Torus> struct unsigned_int_div_rem_memory {
         true);
     uint32_t group_size = overflow_sub_mem->group_size;
     bool use_seq = overflow_sub_mem->prop_simu_group_carries_mem
-                       ->use_sequential_algorithm_to_resolver_group_carries;
+                       ->use_sequential_algorithm_to_resolve_group_carries;
     create_indexes_for_overflow_sub(streams, gpu_indexes, num_blocks,
                                     group_size, use_seq);
 
@@ -4627,7 +4626,6 @@ template <typename Torus> struct int_div_rem_memory {
         allocate_gpu_memory);
 
     if (is_signed) {
-      uint32_t big_lwe_size = params.big_lwe_dimension + 1;
       Torus sign_bit_pos = 31 - __builtin_clz(params.message_modulus) - 1;
 
       // init memory objects for other integer operations
@@ -4794,4 +4792,5 @@ void update_degrees_after_scalar_bitxor(uint64_t *output_degrees,
                                         uint64_t *input_degrees,
                                         uint32_t num_clear_blocks);
 std::pair<bool, bool> get_invert_flags(COMPARISON_TYPE compare);
+void reverseArray(uint64_t arr[], size_t n);
 #endif // CUDA_INTEGER_UTILITIES_H

--- a/backends/tfhe-cuda-backend/cuda/src/integer/integer.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/integer.cu
@@ -315,11 +315,9 @@ void cuda_integer_compute_prefix_sum_hillis_steele_64(
     CudaRadixCiphertextFFI *generates_or_propagates, int8_t *mem_ptr,
     void *const *ksks, void *const *bsks, uint32_t num_radix_blocks) {
 
-  int_radix_params params = ((int_radix_lut<uint64_t> *)mem_ptr)->params;
-
   host_compute_prefix_sum_hillis_steele<uint64_t>(
       (cudaStream_t *)(streams), gpu_indexes, gpu_count, output_radix_lwe,
-      generates_or_propagates, params, (int_radix_lut<uint64_t> *)mem_ptr, bsks,
+      generates_or_propagates, (int_radix_lut<uint64_t> *)mem_ptr, bsks,
       (uint64_t **)(ksks), num_radix_blocks);
 }
 
@@ -337,4 +335,21 @@ void cuda_integer_reverse_blocks_64_inplace(void *const *streams,
 
   host_radix_blocks_reverse_inplace<uint64_t>((cudaStream_t *)(streams),
                                               gpu_indexes, lwe_array);
+}
+
+void reverseArray(uint64_t arr[], size_t n) {
+  size_t start = 0;
+  size_t end = n - 1;
+
+  // Swap elements from the start with elements from the end
+  while (start < end) {
+    // Swap arr[start] and arr[end]
+    uint64_t temp = arr[start];
+    arr[start] = arr[end];
+    arr[end] = temp;
+
+    // Move towards the middle
+    start++;
+    end--;
+  }
 }

--- a/backends/tfhe-cuda-backend/cuda/src/integer/multiplication.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/multiplication.cu
@@ -221,7 +221,11 @@ void cuda_integer_radix_partial_sum_ciphertexts_vec_kb_64(
   if (radix_lwe_vec->num_radix_blocks % radix_lwe_out->num_radix_blocks != 0)
     PANIC("Cuda error: input vector length should be a multiple of the "
           "output's number of radix blocks")
-
+  // FIXME: this should not be necessary, we should make sure sum_ctxt works in
+  // the general case
+  for (int i = 0; i < radix_lwe_vec->num_radix_blocks; i++) {
+    radix_lwe_vec->degrees[i] = mem->params.message_modulus - 1;
+  }
   switch (mem->params.polynomial_size) {
   case 512:
     host_integer_partial_sum_ciphertexts_vec_kb<uint64_t, AmortizedDegree<512>>(

--- a/tfhe/src/integer/gpu/mod.rs
+++ b/tfhe/src/integer/gpu/mod.rs
@@ -3516,6 +3516,7 @@ pub unsafe fn reverse_blocks_inplace_async(
             streams.len() as u32,
             &mut cuda_ffi_radix_lwe_output,
         );
+        update_noise_degree(radix_lwe_output, &cuda_ffi_radix_lwe_output);
     }
 }
 

--- a/tfhe/src/integer/gpu/server_key/radix/vector_find.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/vector_find.rs
@@ -1801,6 +1801,7 @@ impl CudaServerKey {
                 first_true.as_mut(),
                 clone_ct.as_mut(),
                 &lut_fn,
+                0..num_ct_blocks,
                 streams,
             );
         }


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description

This PR reverts ilog2 to how it was before the single carry propagation refactor 00037f3b14e5b1dbc363.
Before the refactor, prepare_count_consecutive_bits would return num_blocks * num_blocks ciphertexts in the output vec, which seems to be different from the CPU as far as I can see. When I changed prepare_count_consecutive_bits to return only num_blocks ciphertexts, ilog2(1) started not being equal to 0 anymore.

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
