### PR TITLE
fix(shortint): make noise_level field of Ciphertext private again

### DIFF
--- a/tfhe/src/integer/gpu/ciphertext/boolean_value.rs
+++ b/tfhe/src/integer/gpu/ciphertext/boolean_value.rs
@@ -139,17 +139,17 @@ impl CudaBooleanBlock {
         let h_lwe_ciphertext_list = self.0.ciphertext.d_blocks.to_lwe_ciphertext_list(streams);
         let ciphertext_modulus = h_lwe_ciphertext_list.ciphertext_modulus();
 
-        let block = Ciphertext {
-            ct: LweCiphertextOwned::from_container(
+        let block = Ciphertext::new(
+            LweCiphertextOwned::from_container(
                 h_lwe_ciphertext_list.into_container(),
                 ciphertext_modulus,
             ),
-            degree: self.0.ciphertext.info.blocks[0].degree,
-            noise_level: self.0.ciphertext.info.blocks[0].noise_level,
-            message_modulus: self.0.ciphertext.info.blocks[0].message_modulus,
-            carry_modulus: self.0.ciphertext.info.blocks[0].carry_modulus,
-            pbs_order: self.0.ciphertext.info.blocks[0].pbs_order,
-        };
+            self.0.ciphertext.info.blocks[0].degree,
+            self.0.ciphertext.info.blocks[0].noise_level,
+            self.0.ciphertext.info.blocks[0].message_modulus,
+            self.0.ciphertext.info.blocks[0].carry_modulus,
+            self.0.ciphertext.info.blocks[0].pbs_order,
+        );
 
         BooleanBlock::new_unchecked(block)
     }

--- a/tfhe/src/integer/gpu/ciphertext/mod.rs
+++ b/tfhe/src/integer/gpu/ciphertext/mod.rs
@@ -161,13 +161,15 @@ impl CudaRadixCiphertext {
             .into_container()
             .chunks(lwe_size)
             .zip(&self.info.blocks)
-            .map(|(data, i)| Ciphertext {
-                ct: LweCiphertextOwned::from_container(data.to_vec(), ciphertext_modulus),
-                degree: i.degree,
-                noise_level: i.noise_level,
-                message_modulus: i.message_modulus,
-                carry_modulus: i.carry_modulus,
-                pbs_order: i.pbs_order,
+            .map(|(data, i)| {
+                Ciphertext::new(
+                    LweCiphertextOwned::from_container(data.to_vec(), ciphertext_modulus),
+                    i.degree,
+                    i.noise_level,
+                    i.message_modulus,
+                    i.carry_modulus,
+                    i.pbs_order,
+                )
             })
             .collect()
     }

--- a/tfhe/src/integer/server_key/crt/scalar_mul_crt.rs
+++ b/tfhe/src/integer/server_key/crt/scalar_mul_crt.rs
@@ -49,7 +49,7 @@ impl ServerKey {
                 && self
                     .key
                     .max_noise_level
-                    .validate(ct_i.noise_level * scalar)
+                    .validate(ct_i.noise_level() * scalar)
                     .is_ok()
             {
                 self.key.unchecked_scalar_mul_assign(ct_i, scalar_i);

--- a/tfhe/src/integer/server_key/crt_parallel/scalar_mul_crt.rs
+++ b/tfhe/src/integer/server_key/crt_parallel/scalar_mul_crt.rs
@@ -60,7 +60,7 @@ impl ServerKey {
                     && self
                         .key
                         .max_noise_level
-                        .validate(ct_i.noise_level * scalar)
+                        .validate(ct_i.noise_level() * scalar)
                         .is_ok()
                 {
                     self.key.unchecked_scalar_mul_assign(ct_i, scalar_i);

--- a/tfhe/src/integer/server_key/radix_parallel/block_shift.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/block_shift.rs
@@ -65,7 +65,7 @@ impl ServerKey {
             result
                 .blocks_mut()
                 .par_iter_mut()
-                .filter(|b| b.noise_level > NoiseLevel::NOMINAL)
+                .filter(|b| b.noise_level() > NoiseLevel::NOMINAL)
                 .for_each(|block| self.key.message_extract_assign(block));
             return result;
         }
@@ -81,7 +81,7 @@ impl ServerKey {
             ct.blocks().iter().all(|block| self
                 .key
                 .max_noise_level
-                .validate(block.noise_level + NoiseLevel::NOMINAL)
+                .validate(block.noise_level() + NoiseLevel::NOMINAL)
                 .is_ok()),
             "Blocks of ciphertext to be shifted has a noise level too high"
         );
@@ -152,7 +152,7 @@ impl ServerKey {
             assert!(current_blocks.iter().all(|block| {
                 self.key
                     .max_noise_level
-                    .validate(block.noise_level + shift_bit.noise_level())
+                    .validate(block.noise_level() + shift_bit.noise_level())
                     .is_ok()
             }));
 

--- a/tfhe/src/integer/server_key/radix_parallel/mod.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/mod.rs
@@ -240,7 +240,7 @@ impl ServerKey {
                 s.spawn(|_| {
                     to_be_cleaned
                         .par_iter_mut()
-                        .filter(|block| block.noise_level > NoiseLevel::NOMINAL)
+                        .filter(|block| block.noise_level() > NoiseLevel::NOMINAL)
                         .for_each(|block| self.key.message_extract_assign(block));
                 });
             }

--- a/tfhe/src/integer/server_key/radix_parallel/mul.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/mul.rs
@@ -169,7 +169,7 @@ impl ServerKey {
         if !ct1.block_carries_are_empty() {
             self.full_propagate_parallelized(ct1);
         }
-        if ct2.noise_level != NoiseLevel::NOMINAL || !ct2.carry_is_empty() {
+        if ct2.noise_level() != NoiseLevel::NOMINAL || !ct2.carry_is_empty() {
             self.key.message_extract_assign(ct2);
         }
 

--- a/tfhe/src/integer/server_key/radix_parallel/tests_cases_unsigned.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_cases_unsigned.rs
@@ -447,15 +447,15 @@ where
 
                 let encrypted_result = executor.execute((&ct, &shift));
                 for (i, b) in encrypted_result.blocks.iter().enumerate() {
-                    if b.noise_level > NoiseLevel::NOMINAL {
-                        println!("{i}: {:?}", b.noise_level);
+                    if b.noise_level() > NoiseLevel::NOMINAL {
+                        println!("{i}: {:?}", b.noise_level());
                     }
                 }
                 assert!(
                     encrypted_result
                         .blocks
                         .iter()
-                        .all(|b| b.noise_level <= NoiseLevel::NOMINAL),
+                        .all(|b| b.noise_level() <= NoiseLevel::NOMINAL),
                     "Expected all blocks to have at most NOMINAL noise level"
                 );
                 let decrypted_result: u64 = cks.decrypt_radix(&encrypted_result);
@@ -472,7 +472,7 @@ where
                     encrypted_result
                         .blocks
                         .iter()
-                        .all(|b| b.noise_level <= NoiseLevel::NOMINAL),
+                        .all(|b| b.noise_level() <= NoiseLevel::NOMINAL),
                     "Expected all blocks to have at most NOMINAL noise level"
                 );
                 let decrypted_result: u64 = cks.decrypt_radix(&encrypted_result);
@@ -530,7 +530,7 @@ where
                     encrypted_result
                         .blocks
                         .iter()
-                        .all(|b| b.noise_level <= NoiseLevel::NOMINAL),
+                        .all(|b| b.noise_level() <= NoiseLevel::NOMINAL),
                     "Expected all blocks to have at most NOMINAL noise level"
                 );
                 let decrypted_result: u64 = cks.decrypt_radix(&encrypted_result);
@@ -546,7 +546,7 @@ where
                     encrypted_result
                         .blocks
                         .iter()
-                        .all(|b| b.noise_level <= NoiseLevel::NOMINAL),
+                        .all(|b| b.noise_level() <= NoiseLevel::NOMINAL),
                     "Expected all blocks to have at most NOMINAL noise level"
                 );
                 let decrypted_result: u64 = cks.decrypt_radix(&encrypted_result);
@@ -606,7 +606,7 @@ where
                     encrypted_result
                         .blocks
                         .iter()
-                        .all(|b| b.noise_level <= NoiseLevel::NOMINAL),
+                        .all(|b| b.noise_level() <= NoiseLevel::NOMINAL),
                     "Expected all blocks to have at most NOMINAL noise level"
                 );
                 let expected = rotate_left_helper(clear, clear_shift, nb_bits);
@@ -622,7 +622,7 @@ where
                     encrypted_result
                         .blocks
                         .iter()
-                        .all(|b| b.noise_level <= NoiseLevel::NOMINAL),
+                        .all(|b| b.noise_level() <= NoiseLevel::NOMINAL),
                     "Expected all blocks to have at most NOMINAL noise level"
                 );
                 let decrypted_result: u64 = cks.decrypt_radix(&encrypted_result);
@@ -677,7 +677,7 @@ where
                     encrypted_result
                         .blocks
                         .iter()
-                        .all(|b| b.noise_level <= NoiseLevel::NOMINAL),
+                        .all(|b| b.noise_level() <= NoiseLevel::NOMINAL),
                     "Expected all blocks to have at most NOMINAL noise level"
                 );
                 let decrypted_result: u64 = cks.decrypt_radix(&encrypted_result);
@@ -694,7 +694,7 @@ where
                     encrypted_result
                         .blocks
                         .iter()
-                        .all(|b| b.noise_level <= NoiseLevel::NOMINAL),
+                        .all(|b| b.noise_level() <= NoiseLevel::NOMINAL),
                     "Expected all blocks to have at most NOMINAL noise level"
                 );
                 let decrypted_result: u64 = cks.decrypt_radix(&encrypted_result);
@@ -2421,7 +2421,7 @@ where
             assert!(res
                 .blocks
                 .iter()
-                .all(|b| b.noise_level <= NoiseLevel::NOMINAL));
+                .all(|b| b.noise_level() <= NoiseLevel::NOMINAL));
             assert_eq!(res, tmp);
 
             clear = clear.wrapping_mul(clear2.wrapping_mul(multiplier)) % modulus;
@@ -2821,7 +2821,7 @@ where
         assert!(
             ct.blocks
                 .iter()
-                .all(|b| b.noise_level <= NoiseLevel::NOMINAL),
+                .all(|b| b.noise_level() <= NoiseLevel::NOMINAL),
             "Invalid noise_level after propagation"
         );
 
@@ -2886,7 +2886,7 @@ where
         assert!(
             ct.blocks
                 .iter()
-                .all(|b| b.noise_level <= NoiseLevel::NOMINAL),
+                .all(|b| b.noise_level() <= NoiseLevel::NOMINAL),
             "Invalid noise_level after propagation"
         );
 
@@ -2968,7 +2968,7 @@ where
         assert!(
             ct.blocks
                 .iter()
-                .all(|b| b.noise_level <= NoiseLevel::NOMINAL),
+                .all(|b| b.noise_level() <= NoiseLevel::NOMINAL),
             "Invalid noise_level after propagation"
         );
 

--- a/tfhe/src/integer/server_key/radix_parallel/tests_long_run/test_random_op_sequence.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_long_run/test_random_op_sequence.rs
@@ -574,7 +574,7 @@ pub(crate) fn random_op_sequence_test<P>(
             );
             res.blocks.iter().enumerate().for_each(|(k, b)| {
                 assert!(
-                    b.noise_level <= NoiseLevel::NOMINAL,
+                    b.noise_level() <= NoiseLevel::NOMINAL,
                     "Noise level greater than nominal value on op {fn_name} for block {k}",
                 )
             });
@@ -624,7 +624,7 @@ pub(crate) fn random_op_sequence_test<P>(
             );
             res.blocks.iter().enumerate().for_each(|(k, b)| {
                 assert!(
-                    b.noise_level <= NoiseLevel::NOMINAL,
+                    b.noise_level() <= NoiseLevel::NOMINAL,
                     "Noise level greater than nominal value on op {fn_name} for block {k}",
                 )
             });
@@ -665,7 +665,7 @@ pub(crate) fn random_op_sequence_test<P>(
             );
             res.blocks.iter().enumerate().for_each(|(k, b)| {
                 assert!(
-                    b.noise_level <= NoiseLevel::NOMINAL,
+                    b.noise_level() <= NoiseLevel::NOMINAL,
                     "Noise level greater than nominal value on op {fn_name} for block {k}",
                 )
             });
@@ -707,12 +707,12 @@ pub(crate) fn random_op_sequence_test<P>(
             );
             res.blocks.iter().enumerate().for_each(|(k, b)| {
                 assert!(
-                    b.noise_level <= NoiseLevel::NOMINAL,
+                    b.noise_level() <= NoiseLevel::NOMINAL,
                     "Noise level greater than nominal value on op {fn_name} for block {k}",
                 )
             });
             assert!(
-                overflow.0.noise_level <= NoiseLevel::NOMINAL,
+                overflow.0.noise_level() <= NoiseLevel::NOMINAL,
                 "Noise level greater than nominal value on overflow for op {fn_name}",
             );
             // Determinism check
@@ -765,12 +765,12 @@ pub(crate) fn random_op_sequence_test<P>(
             );
             res.blocks.iter().enumerate().for_each(|(k, b)| {
                 assert!(
-                    b.noise_level <= NoiseLevel::NOMINAL,
+                    b.noise_level() <= NoiseLevel::NOMINAL,
                     "Noise level greater than nominal value on op {fn_name} for block {k}",
                 )
             });
             assert!(
-                overflow.0.noise_level <= NoiseLevel::NOMINAL,
+                overflow.0.noise_level() <= NoiseLevel::NOMINAL,
                 "Noise level greater than nominal value on overflow for op {fn_name}",
             );
             // Determinism check
@@ -815,7 +815,7 @@ pub(crate) fn random_op_sequence_test<P>(
 
             let res = comparison_op_executor.execute((&left_vec[i], &right_vec[i]));
             assert!(
-                res.0.noise_level <= NoiseLevel::NOMINAL,
+                res.0.noise_level() <= NoiseLevel::NOMINAL,
                 "Noise level greater than nominal value on op {fn_name}",
             );
             // Determinism check
@@ -852,7 +852,7 @@ pub(crate) fn random_op_sequence_test<P>(
 
             let res = scalar_comparison_op_executor.execute((&left_vec[i], clear_right_vec[i]));
             assert!(
-                res.0.noise_level <= NoiseLevel::NOMINAL,
+                res.0.noise_level() <= NoiseLevel::NOMINAL,
                 "Noise level greater than nominal value on op {fn_name}",
             );
             // Determinism check
@@ -895,7 +895,7 @@ pub(crate) fn random_op_sequence_test<P>(
             );
             res.blocks.iter().enumerate().for_each(|(k, b)| {
                 assert!(
-                    b.noise_level <= NoiseLevel::NOMINAL,
+                    b.noise_level() <= NoiseLevel::NOMINAL,
                     "Noise level greater than nominal value on op {fn_name} for block {k}",
                 )
             });
@@ -942,13 +942,13 @@ pub(crate) fn random_op_sequence_test<P>(
             );
             res_q.blocks.iter().enumerate().for_each(|(k, b)| {
                 assert!(
-                    b.noise_level <= NoiseLevel::NOMINAL,
+                    b.noise_level() <= NoiseLevel::NOMINAL,
                     "Noise level greater than nominal value on op {fn_name} for block {k}",
                 )
             });
             res_r.blocks.iter().enumerate().for_each(|(k, b)| {
                 assert!(
-                    b.noise_level <= NoiseLevel::NOMINAL,
+                    b.noise_level() <= NoiseLevel::NOMINAL,
                     "Noise level greater than nominal value on op {fn_name} for block {k}",
                 )
             });
@@ -1005,13 +1005,13 @@ pub(crate) fn random_op_sequence_test<P>(
             );
             res_q.blocks.iter().enumerate().for_each(|(k, b)| {
                 assert!(
-                    b.noise_level <= NoiseLevel::NOMINAL,
+                    b.noise_level() <= NoiseLevel::NOMINAL,
                     "Noise level greater than nominal value on op {fn_name} for block {k}",
                 )
             });
             res_r.blocks.iter().enumerate().for_each(|(k, b)| {
                 assert!(
-                    b.noise_level <= NoiseLevel::NOMINAL,
+                    b.noise_level() <= NoiseLevel::NOMINAL,
                     "Noise level greater than nominal value on op {fn_name} for block {k}",
                 )
             });
@@ -1073,7 +1073,7 @@ pub(crate) fn random_op_sequence_test<P>(
             );
             res.blocks.iter().enumerate().for_each(|(k, b)| {
                 assert!(
-                    b.noise_level <= NoiseLevel::NOMINAL,
+                    b.noise_level() <= NoiseLevel::NOMINAL,
                     "Noise level greater than nominal value on op {fn_name} for block {k}",
                 )
             });

--- a/tfhe/src/integer/server_key/radix_parallel/tests_long_run/test_signed_random_op_sequence.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_long_run/test_signed_random_op_sequence.rs
@@ -666,7 +666,7 @@ pub(crate) fn signed_random_op_sequence_test<P>(
             );
             res.blocks.iter().enumerate().for_each(|(k, b)| {
                 assert!(
-                    b.noise_level <= NoiseLevel::NOMINAL,
+                    b.noise_level() <= NoiseLevel::NOMINAL,
                     "Noise level greater than nominal value on op {fn_name} for block {k}",
                 )
             });
@@ -716,7 +716,7 @@ pub(crate) fn signed_random_op_sequence_test<P>(
             );
             res.blocks.iter().enumerate().for_each(|(k, b)| {
                 assert!(
-                    b.noise_level <= NoiseLevel::NOMINAL,
+                    b.noise_level() <= NoiseLevel::NOMINAL,
                     "Noise level greater than nominal value on op {fn_name} for block {k}",
                 )
             });
@@ -757,7 +757,7 @@ pub(crate) fn signed_random_op_sequence_test<P>(
             );
             res.blocks.iter().enumerate().for_each(|(k, b)| {
                 assert!(
-                    b.noise_level <= NoiseLevel::NOMINAL,
+                    b.noise_level() <= NoiseLevel::NOMINAL,
                     "Noise level greater than nominal value on op {fn_name} for block {k}",
                 )
             });
@@ -799,12 +799,12 @@ pub(crate) fn signed_random_op_sequence_test<P>(
             );
             res.blocks.iter().enumerate().for_each(|(k, b)| {
                 assert!(
-                    b.noise_level <= NoiseLevel::NOMINAL,
+                    b.noise_level() <= NoiseLevel::NOMINAL,
                     "Noise level greater than nominal value on op {fn_name} for block {k}",
                 )
             });
             assert!(
-                overflow.0.noise_level <= NoiseLevel::NOMINAL,
+                overflow.0.noise_level() <= NoiseLevel::NOMINAL,
                 "Noise level greater than nominal value on overflow for op {fn_name}",
             );
             // Determinism check
@@ -857,12 +857,12 @@ pub(crate) fn signed_random_op_sequence_test<P>(
             );
             res.blocks.iter().enumerate().for_each(|(k, b)| {
                 assert!(
-                    b.noise_level <= NoiseLevel::NOMINAL,
+                    b.noise_level() <= NoiseLevel::NOMINAL,
                     "Noise level greater than nominal value on op {fn_name} for block {k}",
                 )
             });
             assert!(
-                overflow.0.noise_level <= NoiseLevel::NOMINAL,
+                overflow.0.noise_level() <= NoiseLevel::NOMINAL,
                 "Noise level greater than nominal value on overflow for op {fn_name}",
             );
             // Determinism check
@@ -907,7 +907,7 @@ pub(crate) fn signed_random_op_sequence_test<P>(
 
             let res = comparison_op_executor.execute((&left_vec[i], &right_vec[i]));
             assert!(
-                res.0.noise_level <= NoiseLevel::NOMINAL,
+                res.0.noise_level() <= NoiseLevel::NOMINAL,
                 "Noise level greater than nominal value on op {fn_name}",
             );
             // Determinism check
@@ -944,7 +944,7 @@ pub(crate) fn signed_random_op_sequence_test<P>(
 
             let res = scalar_comparison_op_executor.execute((&left_vec[i], clear_right_vec[i]));
             assert!(
-                res.0.noise_level <= NoiseLevel::NOMINAL,
+                res.0.noise_level() <= NoiseLevel::NOMINAL,
                 "Noise level greater than nominal value on op {fn_name}",
             );
             // Determinism check
@@ -987,7 +987,7 @@ pub(crate) fn signed_random_op_sequence_test<P>(
             );
             res.blocks.iter().enumerate().for_each(|(k, b)| {
                 assert!(
-                    b.noise_level <= NoiseLevel::NOMINAL,
+                    b.noise_level() <= NoiseLevel::NOMINAL,
                     "Noise level greater than nominal value on op {fn_name} for block {k}",
                 )
             });
@@ -1034,13 +1034,13 @@ pub(crate) fn signed_random_op_sequence_test<P>(
             );
             res_q.blocks.iter().enumerate().for_each(|(k, b)| {
                 assert!(
-                    b.noise_level <= NoiseLevel::NOMINAL,
+                    b.noise_level() <= NoiseLevel::NOMINAL,
                     "Noise level greater than nominal value on op {fn_name} for block {k}",
                 )
             });
             res_r.blocks.iter().enumerate().for_each(|(k, b)| {
                 assert!(
-                    b.noise_level <= NoiseLevel::NOMINAL,
+                    b.noise_level() <= NoiseLevel::NOMINAL,
                     "Noise level greater than nominal value on op {fn_name} for block {k}",
                 )
             });
@@ -1097,13 +1097,13 @@ pub(crate) fn signed_random_op_sequence_test<P>(
             );
             res_q.blocks.iter().enumerate().for_each(|(k, b)| {
                 assert!(
-                    b.noise_level <= NoiseLevel::NOMINAL,
+                    b.noise_level() <= NoiseLevel::NOMINAL,
                     "Noise level greater than nominal value on op {fn_name} for block {k}",
                 )
             });
             res_r.blocks.iter().enumerate().for_each(|(k, b)| {
                 assert!(
-                    b.noise_level <= NoiseLevel::NOMINAL,
+                    b.noise_level() <= NoiseLevel::NOMINAL,
                     "Noise level greater than nominal value on op {fn_name} for block {k}",
                 )
             });
@@ -1165,7 +1165,7 @@ pub(crate) fn signed_random_op_sequence_test<P>(
             );
             res.blocks.iter().enumerate().for_each(|(k, b)| {
                 assert!(
-                    b.noise_level <= NoiseLevel::NOMINAL,
+                    b.noise_level() <= NoiseLevel::NOMINAL,
                     "Noise level greater than nominal value on op {fn_name} for block {k}",
                 )
             });
@@ -1208,7 +1208,7 @@ pub(crate) fn signed_random_op_sequence_test<P>(
             );
             res.blocks.iter().enumerate().for_each(|(k, b)| {
                 assert!(
-                    b.noise_level <= NoiseLevel::NOMINAL,
+                    b.noise_level() <= NoiseLevel::NOMINAL,
                     "Noise level greater than nominal value on op {fn_name} for block {k}",
                 )
             });
@@ -1251,7 +1251,7 @@ pub(crate) fn signed_random_op_sequence_test<P>(
             );
             res.blocks.iter().enumerate().for_each(|(k, b)| {
                 assert!(
-                    b.noise_level <= NoiseLevel::NOMINAL,
+                    b.noise_level() <= NoiseLevel::NOMINAL,
                     "Noise level greater than nominal value on op {fn_name} for block {k}",
                 )
             });

--- a/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/mod.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/mod.rs
@@ -248,7 +248,7 @@ fn panic_if_any_block_info_exceeds_max_degree_or_noise(
         first_block.degree
     );
     assert!(
-        max_noise_level.validate(first_block.noise_level).is_ok(),
+        max_noise_level.validate(first_block.noise_level()).is_ok(),
         "Block at index 0 has a noise level {:?} that exceeds max noise level ({max_noise_level:?})",
         first_block.degree
     );
@@ -260,7 +260,7 @@ fn panic_if_any_block_info_exceeds_max_degree_or_noise(
             block.degree
         );
         assert!(
-            max_noise_level.validate(block.noise_level).is_ok(),
+            max_noise_level.validate(block.noise_level()).is_ok(),
             "Block at index {i} has a noise level {:?} that exceeds max noise level ({max_noise_level:?})",
             block.degree
         );
@@ -283,10 +283,10 @@ where
 
     for (i, block) in ct.blocks.iter().enumerate() {
         assert_eq!(
-            block.noise_level,
+            block.noise_level(),
             NoiseLevel::NOMINAL,
             "Block at index {i} / {num_blocks} has a non nominal noise level: {:?}",
-            block.noise_level
+            block.noise_level()
         );
 
         assert!(
@@ -321,10 +321,10 @@ where
             continue;
         }
         assert_eq!(
-            block.noise_level,
+            block.noise_level(),
             NoiseLevel::NOMINAL,
             "Block at index {i} has a non nominal noise level: {:?}",
-            block.noise_level
+            block.noise_level()
         );
 
         assert!(
@@ -387,9 +387,10 @@ impl ExpectedNoiseLevels {
             .enumerate()
         {
             assert_eq!(
-                block.noise_level, expected_noise,
+                block.noise_level(),
+                expected_noise,
                 "Block at index {i} has noise level {:?}, but {expected_noise:?} was expected",
-                block.noise_level
+                block.noise_level()
             );
         }
     }

--- a/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_add.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_add.rs
@@ -251,7 +251,7 @@ impl ExpectedNoiseLevels {
             lhs.blocks
                 .iter()
                 .zip(rhs.blocks.iter())
-                .map(|(a, b)| a.noise_level + b.noise_level),
+                .map(|(a, b)| a.noise_level() + b.noise_level()),
         );
         self
     }

--- a/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_sub.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_sub.rs
@@ -171,7 +171,7 @@ impl ExpectedNoiseLevels {
             lhs.blocks
                 .iter()
                 .zip(rhs.blocks.iter())
-                .map(|(a, b)| a.noise_level + b.noise_level),
+                .map(|(a, b)| a.noise_level() + b.noise_level()),
         );
         self
     }

--- a/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_vector_find.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_vector_find.rs
@@ -397,7 +397,7 @@ where
             expected_degrees.panic_if_any_is_not_equal(&result);
             expected_noise_level.panic_if_any_is_not_equal(&result);
             assert_eq!(is_ok.0.degree.get(), 0);
-            assert_eq!(is_ok.0.noise_level.get(), 0);
+            assert_eq!(is_ok.0.noise_level().get(), 0);
 
             assert_eq!(cks.decrypt::<u64>(&result), 0);
             assert!(!cks.decrypt_bool(&is_ok));
@@ -456,7 +456,7 @@ where
 
         panic_if_any_block_is_not_clean_or_trivial(&result, &cks);
         assert_eq!(is_ok.0.degree, Degree::new(1));
-        assert_eq!(is_ok.0.noise_level, NoiseLevel::NOMINAL);
+        assert_eq!(is_ok.0.noise_level(), NoiseLevel::NOMINAL);
 
         let result = cks.decrypt::<u64>(&result);
         let is_ok = cks.decrypt_bool(&is_ok);
@@ -531,7 +531,7 @@ where
 
         panic_if_any_block_is_not_clean_or_trivial(&result, &cks);
         assert_eq!(is_ok.0.degree, Degree::new(1));
-        assert_eq!(is_ok.0.noise_level, NoiseLevel::NOMINAL);
+        assert_eq!(is_ok.0.noise_level(), NoiseLevel::NOMINAL);
 
         let result = cks.decrypt::<u64>(&result);
         let is_ok = cks.decrypt_bool(&is_ok);
@@ -743,7 +743,7 @@ where
 
             assert!(result.is_trivial());
             assert_eq!(result.0.degree, Degree::new(0));
-            assert_eq!(result.0.noise_level, NoiseLevel::ZERO);
+            assert_eq!(result.0.noise_level(), NoiseLevel::ZERO);
             assert!(!cks.decrypt_bool(&result));
         }
     }
@@ -776,7 +776,7 @@ where
         // If the mapping only contains numbers (output) that needs less than NB_CTXT
         // blocks, some trivial zeros will be appended
         assert_eq!(result.0.degree, Degree::new(1));
-        assert_eq!(result.0.noise_level, NoiseLevel::NOMINAL);
+        assert_eq!(result.0.noise_level(), NoiseLevel::NOMINAL);
 
         let result = cks.decrypt_bool(&result);
 
@@ -844,7 +844,7 @@ where
         // If the mapping only contains numbers (output) that needs less than NB_CTXT
         // blocks, some trivial zeros will be appended
         assert_eq!(result.0.degree, Degree::new(1));
-        assert_eq!(result.0.noise_level, NoiseLevel::NOMINAL);
+        assert_eq!(result.0.noise_level(), NoiseLevel::NOMINAL);
 
         let result = cks.decrypt_bool(&result);
 
@@ -877,7 +877,7 @@ where
 
         assert!(result.is_trivial());
         assert_eq!(result.0.degree, Degree::new(0));
-        assert_eq!(result.0.noise_level, NoiseLevel::ZERO);
+        assert_eq!(result.0.noise_level(), NoiseLevel::ZERO);
         assert!(!cks.decrypt_bool(&result));
     }
 
@@ -908,7 +908,7 @@ where
         // If the mapping only contains numbers (output) that needs less than NB_CTXT
         // blocks, some trivial zeros will be appended
         assert_eq!(result.0.degree, Degree::new(1));
-        assert_eq!(result.0.noise_level, NoiseLevel::NOMINAL);
+        assert_eq!(result.0.noise_level(), NoiseLevel::NOMINAL);
 
         let result = cks.decrypt_bool(&result);
         assert_eq!(result, expected_result);
@@ -972,7 +972,7 @@ where
         // If the mapping only contains numbers (output) that needs less than NB_CTXT
         // blocks, some trivial zeros will be appended
         assert_eq!(result.0.degree, Degree::new(1));
-        assert_eq!(result.0.noise_level, NoiseLevel::NOMINAL);
+        assert_eq!(result.0.noise_level(), NoiseLevel::NOMINAL);
 
         let result = cks.decrypt_bool(&result);
         assert_eq!(result, expected_result);
@@ -1004,7 +1004,7 @@ where
 
         assert!(result.is_trivial());
         assert_eq!(result.0.degree, Degree::new(0));
-        assert_eq!(result.0.noise_level, NoiseLevel::ZERO);
+        assert_eq!(result.0.noise_level(), NoiseLevel::ZERO);
         assert!(!cks.decrypt_bool(&result));
     }
 
@@ -1029,7 +1029,7 @@ where
         // If the mapping only contains numbers (output) that needs less than NB_CTXT
         // blocks, some trivial zeros will be appended
         assert_eq!(result.0.degree, Degree::new(1));
-        assert_eq!(result.0.noise_level, NoiseLevel::NOMINAL);
+        assert_eq!(result.0.noise_level(), NoiseLevel::NOMINAL);
 
         let result = cks.decrypt_bool(&result);
         assert_eq!(result, expected_result);
@@ -1087,7 +1087,7 @@ where
         // If the mapping only contains numbers (output) that needs less than NB_CTXT
         // blocks, some trivial zeros will be appended
         assert_eq!(result.0.degree, Degree::new(1));
-        assert_eq!(result.0.noise_level, NoiseLevel::NOMINAL);
+        assert_eq!(result.0.noise_level(), NoiseLevel::NOMINAL);
 
         let result = cks.decrypt_bool(&result);
         assert_eq!(result, expected_result);
@@ -1122,7 +1122,7 @@ where
 
         assert!(is_in.is_trivial());
         assert_eq!(is_in.0.degree, Degree::new(0));
-        assert_eq!(is_in.0.noise_level, NoiseLevel::ZERO);
+        assert_eq!(is_in.0.noise_level(), NoiseLevel::ZERO);
         assert!(!cks.decrypt_bool(&is_in));
     }
 
@@ -1152,7 +1152,7 @@ where
         assert_eq!(index, expected_index as u16);
 
         assert_eq!(is_in.0.degree, Degree::new(1));
-        assert_eq!(is_in.0.noise_level, NoiseLevel::NOMINAL);
+        assert_eq!(is_in.0.noise_level(), NoiseLevel::NOMINAL);
 
         let is_in = cks.decrypt_bool(&is_in);
         assert_eq!(is_in, expected_is_in);
@@ -1217,7 +1217,7 @@ where
         assert_eq!(index, expected_index as u16);
 
         assert_eq!(is_in.0.degree, Degree::new(1));
-        assert_eq!(is_in.0.noise_level, NoiseLevel::NOMINAL);
+        assert_eq!(is_in.0.noise_level(), NoiseLevel::NOMINAL);
 
         let is_in = cks.decrypt_bool(&is_in);
         assert_eq!(is_in, expected_is_in);
@@ -1252,7 +1252,7 @@ where
 
         assert!(is_in.is_trivial());
         assert_eq!(is_in.0.degree, Degree::new(0));
-        assert_eq!(is_in.0.noise_level, NoiseLevel::ZERO);
+        assert_eq!(is_in.0.noise_level(), NoiseLevel::ZERO);
         assert!(!cks.decrypt_bool(&is_in));
     }
 
@@ -1282,7 +1282,7 @@ where
         assert_eq!(index, expected_index as u16);
 
         assert_eq!(is_in.0.degree, Degree::new(1));
-        assert_eq!(is_in.0.noise_level, NoiseLevel::NOMINAL);
+        assert_eq!(is_in.0.noise_level(), NoiseLevel::NOMINAL);
 
         let is_in = cks.decrypt_bool(&is_in);
         assert_eq!(is_in, expected_is_in);
@@ -1346,7 +1346,7 @@ where
         assert_eq!(index, expected_index as u16);
 
         assert_eq!(is_in.0.degree, Degree::new(1));
-        assert_eq!(is_in.0.noise_level, NoiseLevel::NOMINAL);
+        assert_eq!(is_in.0.noise_level(), NoiseLevel::NOMINAL);
 
         let is_in = cks.decrypt_bool(&is_in);
         assert_eq!(is_in, expected_is_in);
@@ -1384,7 +1384,7 @@ where
 
         assert!(is_in.is_trivial());
         assert_eq!(is_in.0.degree, Degree::new(0));
-        assert_eq!(is_in.0.noise_level, NoiseLevel::ZERO);
+        assert_eq!(is_in.0.noise_level(), NoiseLevel::ZERO);
         assert!(!cks.decrypt_bool(&is_in));
     }
 
@@ -1420,7 +1420,7 @@ where
         assert_eq!(index, expected_index as u16);
 
         assert_eq!(is_in.0.degree, Degree::new(1));
-        assert_eq!(is_in.0.noise_level, NoiseLevel::NOMINAL);
+        assert_eq!(is_in.0.noise_level(), NoiseLevel::NOMINAL);
 
         let is_in = cks.decrypt_bool(&is_in);
         assert_eq!(is_in, expected_is_in);
@@ -1495,7 +1495,7 @@ where
         assert_eq!(index, expected_index as u16);
 
         assert_eq!(is_in.0.degree, Degree::new(1));
-        assert_eq!(is_in.0.noise_level, NoiseLevel::NOMINAL);
+        assert_eq!(is_in.0.noise_level(), NoiseLevel::NOMINAL);
 
         let is_in = cks.decrypt_bool(&is_in);
         assert_eq!(is_in, expected_is_in);
@@ -1529,7 +1529,7 @@ where
 
         assert!(is_in.is_trivial());
         assert_eq!(is_in.0.degree, Degree::new(0));
-        assert_eq!(is_in.0.noise_level, NoiseLevel::ZERO);
+        assert_eq!(is_in.0.noise_level(), NoiseLevel::ZERO);
         assert!(!cks.decrypt_bool(&is_in));
     }
 
@@ -1564,7 +1564,7 @@ where
         assert_eq!(index, expected_index as u16);
 
         assert_eq!(is_in.0.degree, Degree::new(1));
-        assert_eq!(is_in.0.noise_level, NoiseLevel::NOMINAL);
+        assert_eq!(is_in.0.noise_level(), NoiseLevel::NOMINAL);
 
         let is_in = cks.decrypt_bool(&is_in);
         assert_eq!(is_in, expected_is_in);
@@ -1630,7 +1630,7 @@ where
         assert_eq!(index, expected_index as u16);
 
         assert_eq!(is_in.0.degree, Degree::new(1));
-        assert_eq!(is_in.0.noise_level, NoiseLevel::NOMINAL);
+        assert_eq!(is_in.0.noise_level(), NoiseLevel::NOMINAL);
 
         let is_in = cks.decrypt_bool(&is_in);
         assert_eq!(is_in, expected_is_in);
@@ -1668,7 +1668,7 @@ where
 
         assert!(is_in.is_trivial());
         assert_eq!(is_in.0.degree, Degree::new(0));
-        assert_eq!(is_in.0.noise_level, NoiseLevel::ZERO);
+        assert_eq!(is_in.0.noise_level(), NoiseLevel::ZERO);
         assert!(!cks.decrypt_bool(&is_in));
     }
 
@@ -1709,7 +1709,7 @@ where
         assert_eq!(index, expected_index as u16);
 
         assert_eq!(is_in.0.degree, Degree::new(1));
-        assert_eq!(is_in.0.noise_level, NoiseLevel::NOMINAL);
+        assert_eq!(is_in.0.noise_level(), NoiseLevel::NOMINAL);
 
         let is_in = cks.decrypt_bool(&is_in);
         assert_eq!(is_in, expected_is_in);
@@ -1793,7 +1793,7 @@ where
         assert_eq!(index, expected_index as u16);
 
         assert_eq!(is_in.0.degree, Degree::new(1));
-        assert_eq!(is_in.0.noise_level, NoiseLevel::NOMINAL);
+        assert_eq!(is_in.0.noise_level(), NoiseLevel::NOMINAL);
 
         let is_in = cks.decrypt_bool(&is_in);
         assert_eq!(is_in, expected_is_in);
@@ -1827,7 +1827,7 @@ where
 
         assert!(is_in.is_trivial());
         assert_eq!(is_in.0.degree, Degree::new(0));
-        assert_eq!(is_in.0.noise_level, NoiseLevel::ZERO);
+        assert_eq!(is_in.0.noise_level(), NoiseLevel::ZERO);
         assert!(!cks.decrypt_bool(&is_in));
     }
 
@@ -1867,7 +1867,7 @@ where
         assert_eq!(index, expected_index as u16);
 
         assert_eq!(is_in.0.degree, Degree::new(1));
-        assert_eq!(is_in.0.noise_level, NoiseLevel::NOMINAL);
+        assert_eq!(is_in.0.noise_level(), NoiseLevel::NOMINAL);
 
         let is_in = cks.decrypt_bool(&is_in);
         assert_eq!(is_in, expected_is_in);
@@ -1930,7 +1930,7 @@ where
         assert_eq!(index, expected_index as u16);
 
         assert_eq!(is_in.0.degree, Degree::new(1));
-        assert_eq!(is_in.0.noise_level, NoiseLevel::NOMINAL);
+        assert_eq!(is_in.0.noise_level(), NoiseLevel::NOMINAL);
 
         let is_in = cks.decrypt_bool(&is_in);
         assert_eq!(is_in, expected_is_in);

--- a/tfhe/src/shortint/ciphertext/compact_list.rs
+++ b/tfhe/src/shortint/ciphertext/compact_list.rs
@@ -128,14 +128,14 @@ impl CompactCiphertextList {
                             lwe_view.as_ref().to_vec(),
                             self.ct_list.ciphertext_modulus(),
                         );
-                        let shortint_ct_to_cast = Ciphertext {
-                            ct: lwe_to_cast,
-                            degree: self.degree,
-                            message_modulus: self.message_modulus,
-                            carry_modulus: self.carry_modulus,
+                        let shortint_ct_to_cast = Ciphertext::new(
+                            lwe_to_cast,
+                            self.degree,
+                            NoiseLevel::UNKNOWN,
+                            self.message_modulus,
+                            self.carry_modulus,
                             pbs_order,
-                            noise_level: NoiseLevel::UNKNOWN,
-                        };
+                        );
 
                         casting_key
                             .cast_and_apply_functions(&shortint_ct_to_cast, functions.as_deref())
@@ -151,14 +151,14 @@ impl CompactCiphertextList {
                             lwe_view.as_ref().to_vec(),
                             self.ct_list.ciphertext_modulus(),
                         );
-                        Ciphertext {
+                        Ciphertext::new(
                             ct,
-                            degree: self.degree,
-                            message_modulus: self.message_modulus,
-                            carry_modulus: self.carry_modulus,
+                            self.degree,
+                            NoiseLevel::NOMINAL,
+                            self.message_modulus,
+                            self.carry_modulus,
                             pbs_order,
-                            noise_level: NoiseLevel::NOMINAL,
-                        }
+                        )
                     })
                     .collect::<Vec<_>>();
 

--- a/tfhe/src/shortint/ciphertext/compressed.rs
+++ b/tfhe/src/shortint/ciphertext/compressed.rs
@@ -56,14 +56,14 @@ impl CompressedCiphertext {
             noise_level,
         } = self;
 
-        Ciphertext {
-            ct: ct.decompress_into_lwe_ciphertext(),
-            degree: *degree,
-            message_modulus: *message_modulus,
-            carry_modulus: *carry_modulus,
-            pbs_order: *pbs_order,
-            noise_level: *noise_level,
-        }
+        Ciphertext::new(
+            ct.decompress_into_lwe_ciphertext(),
+            *degree,
+            *noise_level,
+            *message_modulus,
+            *carry_modulus,
+            *pbs_order,
+        )
     }
 
     /// Deconstruct a [`CompressedCiphertext`] into its constituents.

--- a/tfhe/src/shortint/ciphertext/standard.rs
+++ b/tfhe/src/shortint/ciphertext/standard.rs
@@ -17,7 +17,9 @@ use tfhe_versionable::Versionize;
 pub struct Ciphertext {
     pub ct: LweCiphertextOwned<u64>,
     pub degree: Degree,
-    pub(crate) noise_level: NoiseLevel,
+    // For correctness reasons this field MUST remain private, this forces the use of the accessor
+    // which has noise checks enabled on demand
+    noise_level: NoiseLevel,
     pub message_modulus: MessageModulus,
     pub carry_modulus: CarryModulus,
     pub pbs_order: PBSOrder,

--- a/tfhe/src/shortint/oprf.rs
+++ b/tfhe/src/shortint/oprf.rs
@@ -170,14 +170,14 @@ impl ServerKey {
             }
         };
 
-        Ciphertext {
+        Ciphertext::new(
             ct,
-            degree: Degree::new(p - 1),
-            noise_level: NoiseLevel::NOMINAL,
-            message_modulus: self.message_modulus,
-            carry_modulus: self.carry_modulus,
-            pbs_order: self.pbs_order,
-        }
+            Degree::new(p - 1),
+            NoiseLevel::NOMINAL,
+            self.message_modulus,
+            self.carry_modulus,
+            self.pbs_order,
+        )
     }
 }
 

--- a/tfhe/src/shortint/server_key/tests/modulus_switch_compression.rs
+++ b/tfhe/src/shortint/server_key/tests/modulus_switch_compression.rs
@@ -35,7 +35,7 @@ where
             assert_eq!(clear, dec);
 
             assert_eq!(ctxt.degree, decompressed_ct.degree);
-            assert_eq!(decompressed_ct.noise_level, NoiseLevel::NOMINAL);
+            assert_eq!(decompressed_ct.noise_level(), NoiseLevel::NOMINAL);
             assert_eq!(ctxt.message_modulus, decompressed_ct.message_modulus);
             assert_eq!(ctxt.carry_modulus, decompressed_ct.carry_modulus);
             assert_eq!(ctxt.pbs_order, decompressed_ct.pbs_order);
@@ -50,7 +50,7 @@ where
 
             assert_eq!((clear + 1) % modulus, dec % modulus);
 
-            assert_eq!(decompressed_ct.noise_level, NoiseLevel::NOMINAL);
+            assert_eq!(decompressed_ct.noise_level(), NoiseLevel::NOMINAL);
             assert_eq!(ctxt.message_modulus, decompressed_ct.message_modulus);
             assert_eq!(ctxt.carry_modulus, decompressed_ct.carry_modulus);
             assert_eq!(ctxt.pbs_order, decompressed_ct.pbs_order);


### PR DESCRIPTION
- this is required to make sure we have correctness checks on noise_level updates if we enable them