### PR TITLE
feat(tfhe-ntt,gf64) Add custom root-of-unity for Goldilock Prime

### DIFF
--- a/tfhe-ntt/Cargo.toml
+++ b/tfhe-ntt/Cargo.toml
@@ -20,6 +20,7 @@ pulp = { workspace = true }
 default = ["std"]
 std = ["pulp/std", "aligned-vec/std"]
 nightly = ["pulp/nightly"]
+gf64-ru64-8 = []
 
 [dev-dependencies]
 criterion = "0.5"

--- a/tfhe-ntt/src/prime64.rs
+++ b/tfhe-ntt/src/prime64.rs
@@ -157,7 +157,32 @@ impl crate::V4 {
 
 fn init_negacyclic_twiddles(p: u64, n: usize, twid: &mut [u64], inv_twid: &mut [u64]) {
     let div = Div64::new(p);
+
+    #[cfg(feature = "gf64-ru64-8")]
+    let w = if p == ((1_u128 << 64) - (1_u128 << 32) + 1) as u64 {
+        // Used custom root-of-unity with Goldilocks prime
+        // Those root-of-unity enable generation of friendly twiddle will low hamming weight
+        // and enable replacement of multiplication with simple shift
+        match n {
+            32 => 0x8_u64,
+            64 => 0x1fffdfffe00_u64,
+            128 => 0xc2ded1724375e12e_u64,
+            256 => 0xc843f1629460b551_u64,
+            512 => 0x3da05fee70c4f2ba_u64,
+            1024 => 0x7a591595e67c27e8_u64,
+            2048 => 0x984ec5194d005735_u64,
+            4096 => 0x10be59de450fc7cf_u64,
+            8192 => 0x97b0081f017531df_u64,
+            16384 => 0x2e4353dfce41deaf_u64,
+            32768 => 0xdc9218a86d10f3a3_u64,
+            _ => find_primitive_root64(div, 2 * n as u64).unwrap(),
+        }
+    } else {
+        find_primitive_root64(div, 2 * n as u64).unwrap()
+    };
+    #[cfg(not(feature = "gf64-ru64-8"))]
     let w = find_primitive_root64(div, 2 * n as u64).unwrap();
+
     let mut k = 0;
     let mut wk = 1u64;
 

--- a/tfhe/Cargo.toml
+++ b/tfhe/Cargo.toml
@@ -131,6 +131,8 @@ __profiling = []
 
 software-prng = ["tfhe-csprng/software-prng"]
 
+ntt-gf64-ru64-8 = ["tfhe-ntt/gf64-ru64-8"]
+
 [package.metadata.docs.rs]
 # TODO: manage builds for docs.rs based on their documentation https://docs.rs/about
 features = [


### PR DESCRIPTION
Those root-of-unity enable friendly twiddle generation with low hamming-weigth. And thus, enable to replace some multiplication with simple shift.

This is hide behind the feature flag "gf64-ru64-8" and exposed at tfhe level through "ntt-gf64-ru64-8".
