### PR TITLE
chore(ci): fix permanent instance selection condition

### DIFF
--- a/.github/workflows/benchmark_gpu_core_crypto.yml
+++ b/.github/workflows/benchmark_gpu_core_crypto.yml
@@ -45,7 +45,7 @@ jobs:
       # This will allow to fallback on permanent instances running on Hyperstack.
       - name: Use permanent remote instance
         id: use-permanent-instance
-        if: ${{ env.SECRETS_AVAILABLE == 'true' && failure() }}
+        if: env.SECRETS_AVAILABLE == 'true' && steps.start-remote-instance.outcome == 'failure'
         run: |
           echo "runner_group=h100x1" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/benchmark_gpu_erc20_common.yml
+++ b/.github/workflows/benchmark_gpu_erc20_common.yml
@@ -72,7 +72,9 @@ jobs:
       # This will allow to fallback on permanent instances running on Hyperstack.
       - name: Use permanent remote instance
         id: use-permanent-instance
-        if: ${{ env.SECRETS_AVAILABLE == 'true' && failure() && inputs.profile == 'single-h100' }}
+        if: env.SECRETS_AVAILABLE == 'true' &&
+          steps.start-remote-instance.outcome == 'failure' &&
+          inputs.profile == 'single-h100'
         run: |
           echo "runner_group=h100x1" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/benchmark_gpu_integer_common.yml
+++ b/.github/workflows/benchmark_gpu_integer_common.yml
@@ -136,7 +136,9 @@ jobs:
       # This will allow to fallback on permanent instances running on Hyperstack.
       - name: Use permanent remote instance
         id: use-permanent-instance
-        if: ${{ env.SECRETS_AVAILABLE == 'true' && failure() && inputs.profile == 'single-h100' }}
+        if: env.SECRETS_AVAILABLE == 'true' &&
+          steps.start-remote-instance.outcome == 'failure' &&
+          inputs.profile == 'single-h100'
         run: |
           echo "runner_group=h100x1" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/gpu_fast_h100_tests.yml
+++ b/.github/workflows/gpu_fast_h100_tests.yml
@@ -91,7 +91,7 @@ jobs:
       # This will allow to fallback on permanent instances running on Hyperstack.
       - name: Use permanent remote instance
         id: use-permanent-instance
-        if: ${{ env.SECRETS_AVAILABLE == 'true' && steps.start-remote-instance.outcome == 'failure' }}
+        if: env.SECRETS_AVAILABLE == 'true' && steps.start-remote-instance.outcome == 'failure'
         run: |
           echo "runner_group=h100x1" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/gpu_full_h100_tests.yml
+++ b/.github/workflows/gpu_full_h100_tests.yml
@@ -42,7 +42,7 @@ jobs:
       # This will allow to fallback on permanent instances running on Hyperstack.
       - name: Use permanent remote instance
         id: use-permanent-instance
-        if: ${{ env.SECRETS_AVAILABLE == 'true' && failure() }}
+        if: env.SECRETS_AVAILABLE == 'true' && steps.start-remote-instance.outcome == 'failure'
         run: |
           echo "runner_group=h100x1" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/gpu_signed_integer_h100_tests.yml
+++ b/.github/workflows/gpu_signed_integer_h100_tests.yml
@@ -92,7 +92,7 @@ jobs:
       # This will allow to fallback on permanent instances running on Hyperstack.
       - name: Use permanent remote instance
         id: use-permanent-instance
-        if: ${{ env.SECRETS_AVAILABLE == 'true' && failure() }}
+        if: env.SECRETS_AVAILABLE == 'true' && steps.start-remote-instance.outcome == 'failure'
         run: |
           echo "runner_group=h100x1" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/gpu_unsigned_integer_h100_tests.yml
+++ b/.github/workflows/gpu_unsigned_integer_h100_tests.yml
@@ -91,7 +91,7 @@ jobs:
       # This will allow to fallback on permanent instances running on Hyperstack.
       - name: Use permanent remote instance
         id: use-permanent-instance
-        if: ${{ env.SECRETS_AVAILABLE == 'true' && failure() }}
+        if: env.SECRETS_AVAILABLE == 'true' && steps.start-remote-instance.outcome == 'failure'
         run: |
           echo "runner_group=h100x1" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
Due to 'continue-on-error' directive 'use-permanent-instance' step could not rely on failure() function.

I've tested the behavior, and now it falls back on the permanent instance.
