### PR TITLE
[backport] docs: change svg benchmark tables appearance

### DIFF
--- a/tfhe/docs/_static/cpu_gpu_integer_benchmark_fheuint64_tuniform_2m64_ciphertext.svg
+++ b/tfhe/docs/_static/cpu_gpu_integer_benchmark_fheuint64_tuniform_2m64_ciphertext.svg
@@ -1,100 +1,66 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="540.0" height="520" viewBox="0 0 540.0 520">
-    <!-- Header Row -->
-    <rect x="0" y="0" width="540.0" height="40" fill="black" />
-	<text x="10" y="24.0" fill="white" font-family="Arial" font-size="14">Operation \ Size</text>
-	<text x="385.0" y="24.0" fill="white" font-family="Arial" font-size="14">CPU</text>
-	<text x="477.0" y="24.0" fill="white" font-family="Arial" font-size="14">GPU</text>
-
-    <!-- Data Rows -->
-    <rect x="0" y="40" width="540.0" height="40" fill="#fbbc04" />
-	<text x="10" y="64.0" fill="black" font-family="Arial" font-size="14">Negation (`-`)</text>
-	<rect x="356.0" y="40" width="540.0" height="40" fill="#f3f3f3" />
-	<text x="383.0" y="64.0" fill="black" font-family="Arial" font-size="14">106 ms</text>
-	<rect x="448.0" y="40" width="540.0" height="40" fill="#f3f3f3" />
-	<text x="471.0" y="64.0" fill="black" font-family="Arial" font-size="14">25.2 ms</text>
-	<rect x="0" y="80" width="540.0" height="40" fill="#fbbc04" />
-	<text x="10" y="104.0" fill="black" font-family="Arial" font-size="14">Add / Sub (`+`,`-`)</text>
-	<rect x="356.0" y="80" width="540.0" height="40" fill="#f3f3f3" />
-	<text x="383.0" y="104.0" fill="black" font-family="Arial" font-size="14">105 ms</text>
-	<rect x="448.0" y="80" width="540.0" height="40" fill="#f3f3f3" />
-	<text x="471.0" y="104.0" fill="black" font-family="Arial" font-size="14">25.2 ms</text>
-	<rect x="0" y="120" width="540.0" height="40" fill="#fbbc04" />
-	<text x="10" y="144.0" fill="black" font-family="Arial" font-size="14">Mul (`x`)</text>
-	<rect x="356.0" y="120" width="540.0" height="40" fill="#f3f3f3" />
-	<text x="383.0" y="144.0" fill="black" font-family="Arial" font-size="14">401 ms</text>
-	<rect x="448.0" y="120" width="540.0" height="40" fill="#f3f3f3" />
-	<text x="475.0" y="144.0" fill="black" font-family="Arial" font-size="14">237 ms</text>
-	<rect x="0" y="160" width="540.0" height="40" fill="#fbbc04" />
-	<text x="10" y="184.0" fill="black" font-family="Arial" font-size="14">Equal / Not Equal (`eq`, `ne`)</text>
-	<rect x="356.0" y="160" width="540.0" height="40" fill="#f3f3f3" />
-	<text x="379.0" y="184.0" fill="black" font-family="Arial" font-size="14">81.2 ms</text>
-	<rect x="448.0" y="160" width="540.0" height="40" fill="#f3f3f3" />
-	<text x="471.0" y="184.0" fill="black" font-family="Arial" font-size="14">17.7 ms</text>
-	<rect x="0" y="200" width="540.0" height="40" fill="#fbbc04" />
-	<text x="10" y="224.0" fill="black" font-family="Arial" font-size="14">Comparisons  (`ge`, `gt`, `le`, `lt`)</text>
-	<rect x="356.0" y="200" width="540.0" height="40" fill="#f3f3f3" />
-	<text x="383.0" y="224.0" fill="black" font-family="Arial" font-size="14">102 ms</text>
-	<rect x="448.0" y="200" width="540.0" height="40" fill="#f3f3f3" />
-	<text x="471.0" y="224.0" fill="black" font-family="Arial" font-size="14">26.2 ms</text>
-	<rect x="0" y="240" width="540.0" height="40" fill="#fbbc04" />
-	<text x="10" y="264.0" fill="black" font-family="Arial" font-size="14">Max / Min   (`max`,`min`)</text>
-	<rect x="356.0" y="240" width="540.0" height="40" fill="#f3f3f3" />
-	<text x="383.0" y="264.0" fill="black" font-family="Arial" font-size="14">145 ms</text>
-	<rect x="448.0" y="240" width="540.0" height="40" fill="#f3f3f3" />
-	<text x="471.0" y="264.0" fill="black" font-family="Arial" font-size="14">43.6 ms</text>
-	<rect x="0" y="280" width="540.0" height="40" fill="#fbbc04" />
-	<text x="10" y="304.0" fill="black" font-family="Arial" font-size="14">Bitwise operations (`&#38;`, `&#124;`, `^`)</text>
-	<rect x="356.0" y="280" width="540.0" height="40" fill="#f3f3f3" />
-	<text x="379.0" y="304.0" fill="black" font-family="Arial" font-size="14">20.7 ms</text>
-	<rect x="448.0" y="280" width="540.0" height="40" fill="#f3f3f3" />
-	<text x="471.0" y="304.0" fill="black" font-family="Arial" font-size="14">5.97 ms</text>
-	<rect x="0" y="320" width="540.0" height="40" fill="#fbbc04" />
-	<text x="10" y="344.0" fill="black" font-family="Arial" font-size="14">Div / Rem  (`/`, `%`)</text>
-	<rect x="356.0" y="320" width="540.0" height="40" fill="#f3f3f3" />
-	<text x="383.0" y="344.0" fill="black" font-family="Arial" font-size="14">8.22 s</text>
-	<rect x="448.0" y="320" width="540.0" height="40" fill="#f3f3f3" />
-	<text x="475.0" y="344.0" fill="black" font-family="Arial" font-size="14">2.05 s</text>
-	<rect x="0" y="360" width="540.0" height="40" fill="#fbbc04" />
-	<text x="10" y="384.0" fill="black" font-family="Arial" font-size="14">Left / Right Shifts (`&#60;&#60;`, `&#62;&#62;`)</text>
-	<rect x="356.0" y="360" width="540.0" height="40" fill="#f3f3f3" />
-	<text x="383.0" y="384.0" fill="black" font-family="Arial" font-size="14">134 ms</text>
-	<rect x="448.0" y="360" width="540.0" height="40" fill="#f3f3f3" />
-	<text x="471.0" y="384.0" fill="black" font-family="Arial" font-size="14">86.7 ms</text>
-	<rect x="0" y="400" width="540.0" height="40" fill="#fbbc04" />
-	<text x="10" y="424.0" fill="black" font-family="Arial" font-size="14">Left / Right Rotations (`left_rotate`, `right_rotate`)</text>
-	<rect x="356.0" y="400" width="540.0" height="40" fill="#f3f3f3" />
-	<text x="383.0" y="424.0" fill="black" font-family="Arial" font-size="14">133 ms</text>
-	<rect x="448.0" y="400" width="540.0" height="40" fill="#f3f3f3" />
-	<text x="471.0" y="424.0" fill="black" font-family="Arial" font-size="14">86.8 ms</text>
-	<rect x="0" y="440" width="540.0" height="40" fill="#fbbc04" />
-	<text x="10" y="464.0" fill="black" font-family="Arial" font-size="14">Leading / Trailing zeros/ones</text>
-	<rect x="356.0" y="440" width="540.0" height="40" fill="#f3f3f3" />
-	<text x="383.0" y="464.0" fill="black" font-family="Arial" font-size="14">247 ms</text>
-	<rect x="448.0" y="440" width="540.0" height="40" fill="#f3f3f3" />
-	<text x="471.0" y="464.0" fill="black" font-family="Arial" font-size="14">62.3 ms</text>
-	<rect x="0" y="480" width="540.0" height="40" fill="#fbbc04" />
-	<text x="10" y="504.0" fill="black" font-family="Arial" font-size="14">Log2</text>
-	<rect x="356.0" y="480" width="540.0" height="40" fill="#f3f3f3" />
-	<text x="383.0" y="504.0" fill="black" font-family="Arial" font-size="14">267 ms</text>
-	<rect x="448.0" y="480" width="540.0" height="40" fill="#f3f3f3" />
-	<text x="471.0" y="504.0" fill="black" font-family="Arial" font-size="14">73.9 ms</text>
-
-    <!-- Borders -->
-    <line x1="0" y1="0" x2="0" y2="520" stroke="white" />
-	<line x1="356.0" y1="0" x2="356.0" y2="520" stroke="white" />
-	<line x1="448.0" y1="0" x2="448.0" y2="520" stroke="white" />
-	<line x1="0" y1="0" x2="540.0" y2="0" stroke="white" />
-	<line x1="0" y1="40" x2="540.0" y2="40" stroke="white" />
-	<line x1="0" y1="80" x2="540.0" y2="80" stroke="white" />
-	<line x1="0" y1="120" x2="540.0" y2="120" stroke="white" />
-	<line x1="0" y1="160" x2="540.0" y2="160" stroke="white" />
-	<line x1="0" y1="200" x2="540.0" y2="200" stroke="white" />
-	<line x1="0" y1="240" x2="540.0" y2="240" stroke="white" />
-	<line x1="0" y1="280" x2="540.0" y2="280" stroke="white" />
-	<line x1="0" y1="320" x2="540.0" y2="320" stroke="white" />
-	<line x1="0" y1="360" x2="540.0" y2="360" stroke="white" />
-	<line x1="0" y1="400" x2="540.0" y2="400" stroke="white" />
-	<line x1="0" y1="440" x2="540.0" y2="440" stroke="white" />
-	<line x1="0" y1="480" x2="540.0" y2="480" stroke="white" />
-	<line x1="0" y1="520" x2="540.0" y2="520" stroke="white" />
+<?xml version="1.0" ?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 560" preserveAspectRatio="meet" width="100%" height="560">
+	<rect x="0" y="0" width="720" height="40" fill="black"/>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="6" y="20.0">Operation \ Size</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="405.0" y="20.0">CPU</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="615.0" y="20.0">GPU</text>
+	<rect x="0" y="40" width="300" height="520" fill="#fbbc04"/>
+	<rect x="300" y="40" width="420" height="520" fill="#f3f3f3"/>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="60.0">Negation (-)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="405.0" y="60.0">106 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="615.0" y="60.0">25.2 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="100.0">Add / Sub (+,-)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="405.0" y="100.0">105 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="615.0" y="100.0">25.2 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="140.0">Mul (x)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="405.0" y="140.0">401 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="615.0" y="140.0">237 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="180.0">Equal / Not Equal (eq, ne)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="405.0" y="180.0">81.2 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="615.0" y="180.0">17.7 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="220.0">Comparisons (ge, gt, le, lt)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="405.0" y="220.0">102 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="615.0" y="220.0">26.2 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="260.0">Max / Min (max, min)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="405.0" y="260.0">145 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="615.0" y="260.0">43.6 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="300.0">Bitwise operations (&amp;, |, ^)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="405.0" y="300.0">20.7 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="615.0" y="300.0">5.97 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="340.0">Div / Rem  (/, %)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="405.0" y="340.0">8.22 s</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="615.0" y="340.0">2.05 s</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="380.0">Left / Right Shifts (&lt;&lt;, &gt;&gt;)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="405.0" y="380.0">134 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="615.0" y="380.0">86.7 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="420.0">Left / Right Rotations (left_rotate, right_rotate)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="405.0" y="420.0">133 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="615.0" y="420.0">86.8 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="460.0">Leading / Trailing zeros/ones</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="405.0" y="460.0">247 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="615.0" y="460.0">62.3 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="500.0">Log2</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="405.0" y="500.0">267 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="615.0" y="500.0">73.9 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="540.0">Select</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="405.0" y="540.0">32.6 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="615.0" y="540.0">17.5 ms</text>
+	<line stroke="white" stroke-width="2" x1="0" y1="0" x2="720" y2="0"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="40" x2="720" y2="40"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="80" x2="720" y2="80"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="120" x2="720" y2="120"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="160" x2="720" y2="160"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="200" x2="720" y2="200"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="240" x2="720" y2="240"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="280" x2="720" y2="280"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="320" x2="720" y2="320"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="360" x2="720" y2="360"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="400" x2="720" y2="400"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="440" x2="720" y2="440"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="480" x2="720" y2="480"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="520" x2="720" y2="520"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="0" x2="0" y2="560"/>
+	<line stroke="white" stroke-width="2" x1="300.0" y1="0" x2="300.0" y2="560"/>
+	<line stroke="white" stroke-width="2" x1="510.0" y1="0" x2="510.0" y2="560"/>
+	<line stroke="white" stroke-width="2" x1="720.0" y1="0" x2="720.0" y2="560"/>
 </svg>

--- a/tfhe/docs/_static/cpu_integer_benchmark_tuniform_2m128_ciphertext.svg
+++ b/tfhe/docs/_static/cpu_integer_benchmark_tuniform_2m128_ciphertext.svg
@@ -1,247 +1,116 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1268.0" height="560" viewBox="0 0 1268.0 560">
-    <!-- Header Row -->
-    <rect x="0" y="0" width="1268.0" height="40" fill="black" />
-	<text x="10" y="24.0" fill="white" font-family="Arial" font-size="14">Operation \ Size</text>
-	<text x="383.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint4</text>
-	<text x="515.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint8</text>
-	<text x="643.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint16</text>
-	<text x="775.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint32</text>
-	<text x="907.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint64</text>
-	<text x="1035.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint128</text>
-	<text x="1167.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint256</text>
-
-    <!-- Data Rows -->
-    <rect x="0" y="40" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="64.0" fill="black" font-family="Arial" font-size="14">Negation (`-`)</text>
-	<rect x="344.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="64.0" fill="black" font-family="Arial" font-size="14">33.4 ms</text>
-	<rect x="476.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="64.0" fill="black" font-family="Arial" font-size="14">48.9 ms</text>
-	<rect x="608.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="64.0" fill="black" font-family="Arial" font-size="14">57.4 ms</text>
-	<rect x="740.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="64.0" fill="black" font-family="Arial" font-size="14">79.7 ms</text>
-	<rect x="872.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="919.0" y="64.0" fill="black" font-family="Arial" font-size="14">105 ms</text>
-	<rect x="1004.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1051.0" y="64.0" fill="black" font-family="Arial" font-size="14">159 ms</text>
-	<rect x="1136.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1183.0" y="64.0" fill="black" font-family="Arial" font-size="14">183 ms</text>
-	<rect x="0" y="80" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="104.0" fill="black" font-family="Arial" font-size="14">Add / Sub (`+`,`-`)</text>
-	<rect x="344.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="104.0" fill="black" font-family="Arial" font-size="14">33.5 ms</text>
-	<rect x="476.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="104.0" fill="black" font-family="Arial" font-size="14">53.5 ms</text>
-	<rect x="608.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="104.0" fill="black" font-family="Arial" font-size="14">59.8 ms</text>
-	<rect x="740.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="104.0" fill="black" font-family="Arial" font-size="14">82.1 ms</text>
-	<rect x="872.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="919.0" y="104.0" fill="black" font-family="Arial" font-size="14">109 ms</text>
-	<rect x="1004.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1051.0" y="104.0" fill="black" font-family="Arial" font-size="14">165 ms</text>
-	<rect x="1136.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1183.0" y="104.0" fill="black" font-family="Arial" font-size="14">187 ms</text>
-	<rect x="0" y="120" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="144.0" fill="black" font-family="Arial" font-size="14">Mul (`x`)</text>
-	<rect x="344.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="144.0" fill="black" font-family="Arial" font-size="14">39.7 ms</text>
-	<rect x="476.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="144.0" fill="black" font-family="Arial" font-size="14">97.5 ms</text>
-	<rect x="608.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="655.0" y="144.0" fill="black" font-family="Arial" font-size="14">141 ms</text>
-	<rect x="740.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="787.0" y="144.0" fill="black" font-family="Arial" font-size="14">213 ms</text>
-	<rect x="872.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="919.0" y="144.0" fill="black" font-family="Arial" font-size="14">400 ms</text>
-	<rect x="1004.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1051.0" y="144.0" fill="black" font-family="Arial" font-size="14">1.14 s</text>
-	<rect x="1136.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1183.0" y="144.0" fill="black" font-family="Arial" font-size="14">3.79 s</text>
-	<rect x="0" y="160" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="184.0" fill="black" font-family="Arial" font-size="14">Equal / Not Equal (`eq`, `ne`)</text>
-	<rect x="344.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="184.0" fill="black" font-family="Arial" font-size="14">34.3 ms</text>
-	<rect x="476.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="184.0" fill="black" font-family="Arial" font-size="14">36.1 ms</text>
-	<rect x="608.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="184.0" fill="black" font-family="Arial" font-size="14">56.3 ms</text>
-	<rect x="740.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="184.0" fill="black" font-family="Arial" font-size="14">56.9 ms</text>
-	<rect x="872.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="184.0" fill="black" font-family="Arial" font-size="14">81.4 ms</text>
-	<rect x="1004.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1047.0" y="184.0" fill="black" font-family="Arial" font-size="14">82.0 ms</text>
-	<rect x="1136.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1183.0" y="184.0" fill="black" font-family="Arial" font-size="14">104 ms</text>
-	<rect x="0" y="200" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="224.0" fill="black" font-family="Arial" font-size="14">Comparisons  (`ge`, `gt`, `le`, `lt`)</text>
-	<rect x="344.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="224.0" fill="black" font-family="Arial" font-size="14">37.4 ms</text>
-	<rect x="476.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="224.0" fill="black" font-family="Arial" font-size="14">37.1 ms</text>
-	<rect x="608.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="224.0" fill="black" font-family="Arial" font-size="14">54.8 ms</text>
-	<rect x="740.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="224.0" fill="black" font-family="Arial" font-size="14">76.7 ms</text>
-	<rect x="872.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="224.0" fill="black" font-family="Arial" font-size="14">99.0 ms</text>
-	<rect x="1004.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1051.0" y="224.0" fill="black" font-family="Arial" font-size="14">145 ms</text>
-	<rect x="1136.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1183.0" y="224.0" fill="black" font-family="Arial" font-size="14">175 ms</text>
-	<rect x="0" y="240" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="264.0" fill="black" font-family="Arial" font-size="14">Max / Min   (`max`,`min`)</text>
-	<rect x="344.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="264.0" fill="black" font-family="Arial" font-size="14">75.6 ms</text>
-	<rect x="476.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="264.0" fill="black" font-family="Arial" font-size="14">76.9 ms</text>
-	<rect x="608.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="264.0" fill="black" font-family="Arial" font-size="14">97.6 ms</text>
-	<rect x="740.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="787.0" y="264.0" fill="black" font-family="Arial" font-size="14">121 ms</text>
-	<rect x="872.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="919.0" y="264.0" fill="black" font-family="Arial" font-size="14">148 ms</text>
-	<rect x="1004.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1051.0" y="264.0" fill="black" font-family="Arial" font-size="14">194 ms</text>
-	<rect x="1136.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1183.0" y="264.0" fill="black" font-family="Arial" font-size="14">244 ms</text>
-	<rect x="0" y="280" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="304.0" fill="black" font-family="Arial" font-size="14">Bitwise operations (`&#38;`, `&#124;`, `^`)</text>
-	<rect x="344.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="304.0" fill="black" font-family="Arial" font-size="14">20.2 ms</text>
-	<rect x="476.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="304.0" fill="black" font-family="Arial" font-size="14">18.7 ms</text>
-	<rect x="608.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="304.0" fill="black" font-family="Arial" font-size="14">19.7 ms</text>
-	<rect x="740.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="304.0" fill="black" font-family="Arial" font-size="14">20.6 ms</text>
-	<rect x="872.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="304.0" fill="black" font-family="Arial" font-size="14">22.9 ms</text>
-	<rect x="1004.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1047.0" y="304.0" fill="black" font-family="Arial" font-size="14">23.8 ms</text>
-	<rect x="1136.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1179.0" y="304.0" fill="black" font-family="Arial" font-size="14">26.3 ms</text>
-	<rect x="0" y="320" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="344.0" fill="black" font-family="Arial" font-size="14">Div / Rem  (`/`, `%`)</text>
-	<rect x="344.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="391.0" y="344.0" fill="black" font-family="Arial" font-size="14">295 ms</text>
-	<rect x="476.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="523.0" y="344.0" fill="black" font-family="Arial" font-size="14">644 ms</text>
-	<rect x="608.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="655.0" y="344.0" fill="black" font-family="Arial" font-size="14">1.49 s</text>
-	<rect x="740.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="787.0" y="344.0" fill="black" font-family="Arial" font-size="14">3.44 s</text>
-	<rect x="872.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="919.0" y="344.0" fill="black" font-family="Arial" font-size="14">8.49 s</text>
-	<rect x="1004.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1051.0" y="344.0" fill="black" font-family="Arial" font-size="14">20.9 s</text>
-	<rect x="1136.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1183.0" y="344.0" fill="black" font-family="Arial" font-size="14">54.6 s</text>
-	<rect x="0" y="360" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="384.0" fill="black" font-family="Arial" font-size="14">Left / Right Shifts (`&#60;&#60;`, `&#62;&#62;`)</text>
-	<rect x="344.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="384.0" fill="black" font-family="Arial" font-size="14">34.7 ms</text>
-	<rect x="476.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="384.0" fill="black" font-family="Arial" font-size="14">58.8 ms</text>
-	<rect x="608.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="384.0" fill="black" font-family="Arial" font-size="14">81.9 ms</text>
-	<rect x="740.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="787.0" y="384.0" fill="black" font-family="Arial" font-size="14">107 ms</text>
-	<rect x="872.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="919.0" y="384.0" fill="black" font-family="Arial" font-size="14">142 ms</text>
-	<rect x="1004.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1051.0" y="384.0" fill="black" font-family="Arial" font-size="14">178 ms</text>
-	<rect x="1136.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1183.0" y="384.0" fill="black" font-family="Arial" font-size="14">248 ms</text>
-	<rect x="0" y="400" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="424.0" fill="black" font-family="Arial" font-size="14">Left / Right Rotations (`left_rotate`, `right_rotate`)</text>
-	<rect x="344.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="424.0" fill="black" font-family="Arial" font-size="14">39.7 ms</text>
-	<rect x="476.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="424.0" fill="black" font-family="Arial" font-size="14">59.7 ms</text>
-	<rect x="608.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="424.0" fill="black" font-family="Arial" font-size="14">81.4 ms</text>
-	<rect x="740.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="787.0" y="424.0" fill="black" font-family="Arial" font-size="14">107 ms</text>
-	<rect x="872.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="919.0" y="424.0" fill="black" font-family="Arial" font-size="14">142 ms</text>
-	<rect x="1004.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1051.0" y="424.0" fill="black" font-family="Arial" font-size="14">186 ms</text>
-	<rect x="1136.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1183.0" y="424.0" fill="black" font-family="Arial" font-size="14">249 ms</text>
-	<rect x="0" y="440" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="464.0" fill="black" font-family="Arial" font-size="14">Leading / Trailing zeros/ones</text>
-	<rect x="344.0" y="440" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="464.0" fill="black" font-family="Arial" font-size="14">77.1 ms</text>
-	<rect x="476.0" y="440" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="464.0" fill="black" font-family="Arial" font-size="14">95.7 ms</text>
-	<rect x="608.0" y="440" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="655.0" y="464.0" fill="black" font-family="Arial" font-size="14">159 ms</text>
-	<rect x="740.0" y="440" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="787.0" y="464.0" fill="black" font-family="Arial" font-size="14">182 ms</text>
-	<rect x="872.0" y="440" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="919.0" y="464.0" fill="black" font-family="Arial" font-size="14">255 ms</text>
-	<rect x="1004.0" y="440" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1051.0" y="464.0" fill="black" font-family="Arial" font-size="14">304 ms</text>
-	<rect x="1136.0" y="440" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1183.0" y="464.0" fill="black" font-family="Arial" font-size="14">345 ms</text>
-	<rect x="0" y="480" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="504.0" fill="black" font-family="Arial" font-size="14">Log2</text>
-	<rect x="344.0" y="480" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="504.0" fill="black" font-family="Arial" font-size="14">90.4 ms</text>
-	<rect x="476.0" y="480" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="523.0" y="504.0" fill="black" font-family="Arial" font-size="14">114 ms</text>
-	<rect x="608.0" y="480" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="655.0" y="504.0" fill="black" font-family="Arial" font-size="14">173 ms</text>
-	<rect x="740.0" y="480" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="787.0" y="504.0" fill="black" font-family="Arial" font-size="14">199 ms</text>
-	<rect x="872.0" y="480" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="919.0" y="504.0" fill="black" font-family="Arial" font-size="14">280 ms</text>
-	<rect x="1004.0" y="480" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1051.0" y="504.0" fill="black" font-family="Arial" font-size="14">327 ms</text>
-	<rect x="1136.0" y="480" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1183.0" y="504.0" fill="black" font-family="Arial" font-size="14">369 ms</text>
-	<rect x="0" y="520" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="544.0" fill="black" font-family="Arial" font-size="14">Select</text>
-	<rect x="344.0" y="520" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="544.0" fill="black" font-family="Arial" font-size="14">27.8 ms</text>
-	<rect x="476.0" y="520" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="544.0" fill="black" font-family="Arial" font-size="14">29.7 ms</text>
-	<rect x="608.0" y="520" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="544.0" fill="black" font-family="Arial" font-size="14">32.0 ms</text>
-	<rect x="740.0" y="520" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="544.0" fill="black" font-family="Arial" font-size="14">33.0 ms</text>
-	<rect x="872.0" y="520" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="544.0" fill="black" font-family="Arial" font-size="14">36.1 ms</text>
-	<rect x="1004.0" y="520" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1047.0" y="544.0" fill="black" font-family="Arial" font-size="14">37.2 ms</text>
-	<rect x="1136.0" y="520" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1179.0" y="544.0" fill="black" font-family="Arial" font-size="14">49.6 ms</text>
-
-    <!-- Borders -->
-    <line x1="0" y1="0" x2="0" y2="560" stroke="white" />
-	<line x1="344.0" y1="0" x2="344.0" y2="560" stroke="white" />
-	<line x1="476.0" y1="0" x2="476.0" y2="560" stroke="white" />
-	<line x1="608.0" y1="0" x2="608.0" y2="560" stroke="white" />
-	<line x1="740.0" y1="0" x2="740.0" y2="560" stroke="white" />
-	<line x1="872.0" y1="0" x2="872.0" y2="560" stroke="white" />
-	<line x1="1004.0" y1="0" x2="1004.0" y2="560" stroke="white" />
-	<line x1="1136.0" y1="0" x2="1136.0" y2="560" stroke="white" />
-	<line x1="0" y1="0" x2="1268.0" y2="0" stroke="white" />
-	<line x1="0" y1="40" x2="1268.0" y2="40" stroke="white" />
-	<line x1="0" y1="80" x2="1268.0" y2="80" stroke="white" />
-	<line x1="0" y1="120" x2="1268.0" y2="120" stroke="white" />
-	<line x1="0" y1="160" x2="1268.0" y2="160" stroke="white" />
-	<line x1="0" y1="200" x2="1268.0" y2="200" stroke="white" />
-	<line x1="0" y1="240" x2="1268.0" y2="240" stroke="white" />
-	<line x1="0" y1="280" x2="1268.0" y2="280" stroke="white" />
-	<line x1="0" y1="320" x2="1268.0" y2="320" stroke="white" />
-	<line x1="0" y1="360" x2="1268.0" y2="360" stroke="white" />
-	<line x1="0" y1="400" x2="1268.0" y2="400" stroke="white" />
-	<line x1="0" y1="440" x2="1268.0" y2="440" stroke="white" />
-	<line x1="0" y1="480" x2="1268.0" y2="480" stroke="white" />
-	<line x1="0" y1="520" x2="1268.0" y2="520" stroke="white" />
-	<line x1="0" y1="560" x2="1268.0" y2="560" stroke="white" />
+<?xml version="1.0" ?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 560" preserveAspectRatio="meet" width="100%" height="560">
+	<rect x="0" y="0" width="720" height="40" fill="black"/>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="6" y="20.0">Operation \ Size</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="342.0" y="13.333333333333334">FheUint</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="342.0" y="29.666666666666668">8</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="426.0" y="13.333333333333334">FheUint</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="426.0" y="29.666666666666668">16</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="510.0" y="13.333333333333334">FheUint</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="510.0" y="29.666666666666668">32</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="594.0" y="13.333333333333334">FheUint</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="594.0" y="29.666666666666668">64</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="678.0" y="13.333333333333334">FheUint</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="678.0" y="29.666666666666668">128</text>
+	<rect x="0" y="40" width="300" height="520" fill="#fbbc04"/>
+	<rect x="300" y="40" width="420" height="520" fill="#f3f3f3"/>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="60.0">Negation (-)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="60.0">48.9 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="60.0">57.4 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="60.0">79.7 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="60.0">105 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="60.0">159 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="100.0">Add / Sub (+,-)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="100.0">53.5 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="100.0">59.8 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="100.0">82.1 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="100.0">109 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="100.0">165 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="140.0">Mul (x)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="140.0">97.5 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="140.0">141 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="140.0">213 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="140.0">400 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="140.0">1.14 s</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="180.0">Equal / Not Equal (eq, ne)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="180.0">36.1 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="180.0">56.3 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="180.0">56.9 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="180.0">81.4 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="180.0">82.0 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="220.0">Comparisons (ge, gt, le, lt)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="220.0">37.1 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="220.0">54.8 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="220.0">76.7 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="220.0">99.0 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="220.0">145 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="260.0">Max / Min (max, min)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="260.0">76.9 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="260.0">97.6 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="260.0">121 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="260.0">148 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="260.0">194 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="300.0">Bitwise operations (&amp;, |, ^)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="300.0">18.7 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="300.0">19.7 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="300.0">20.6 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="300.0">22.9 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="300.0">23.8 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="340.0">Div / Rem  (/, %)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="340.0">644 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="340.0">1.49 s</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="340.0">3.44 s</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="340.0">8.49 s</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="340.0">20.9 s</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="380.0">Left / Right Shifts (&lt;&lt;, &gt;&gt;)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="380.0">58.8 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="380.0">81.9 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="380.0">107 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="380.0">142 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="380.0">178 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="420.0">Left / Right Rotations (left_rotate, right_rotate)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="420.0">59.7 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="420.0">81.4 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="420.0">107 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="420.0">142 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="420.0">186 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="460.0">Leading / Trailing zeros/ones</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="460.0">95.7 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="460.0">159 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="460.0">182 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="460.0">255 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="460.0">304 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="500.0">Log2</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="500.0">114 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="500.0">173 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="500.0">199 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="500.0">280 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="500.0">327 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="540.0">Select</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="540.0">29.7 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="540.0">32.0 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="540.0">33.0 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="540.0">36.1 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="540.0">37.2 ms</text>
+	<line stroke="white" stroke-width="2" x1="0" y1="0" x2="720" y2="0"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="40" x2="720" y2="40"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="80" x2="720" y2="80"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="120" x2="720" y2="120"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="160" x2="720" y2="160"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="200" x2="720" y2="200"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="240" x2="720" y2="240"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="280" x2="720" y2="280"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="320" x2="720" y2="320"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="360" x2="720" y2="360"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="400" x2="720" y2="400"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="440" x2="720" y2="440"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="480" x2="720" y2="480"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="520" x2="720" y2="520"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="0" x2="0" y2="560"/>
+	<line stroke="white" stroke-width="2" x1="300.0" y1="0" x2="300.0" y2="560"/>
+	<line stroke="white" stroke-width="2" x1="384.0" y1="0" x2="384.0" y2="560"/>
+	<line stroke="white" stroke-width="2" x1="468.0" y1="0" x2="468.0" y2="560"/>
+	<line stroke="white" stroke-width="2" x1="552.0" y1="0" x2="552.0" y2="560"/>
+	<line stroke="white" stroke-width="2" x1="636.0" y1="0" x2="636.0" y2="560"/>
+	<line stroke="white" stroke-width="2" x1="720.0" y1="0" x2="720.0" y2="560"/>
 </svg>

--- a/tfhe/docs/_static/cpu_integer_benchmark_tuniform_2m128_plaintext.svg
+++ b/tfhe/docs/_static/cpu_integer_benchmark_tuniform_2m128_plaintext.svg
@@ -1,196 +1,95 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1268.0" height="440" viewBox="0 0 1268.0 440">
-    <!-- Header Row -->
-    <rect x="0" y="0" width="1268.0" height="40" fill="black" />
-	<text x="10" y="24.0" fill="white" font-family="Arial" font-size="14">Operation \ Size</text>
-	<text x="383.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint4</text>
-	<text x="515.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint8</text>
-	<text x="643.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint16</text>
-	<text x="775.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint32</text>
-	<text x="907.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint64</text>
-	<text x="1035.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint128</text>
-	<text x="1167.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint256</text>
-
-    <!-- Data Rows -->
-    <rect x="0" y="40" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="64.0" fill="black" font-family="Arial" font-size="14">Add / Sub (`+`,`-`)</text>
-	<rect x="344.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="64.0" fill="black" font-family="Arial" font-size="14">33.5 ms</text>
-	<rect x="476.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="64.0" fill="black" font-family="Arial" font-size="14">52.5 ms</text>
-	<rect x="608.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="64.0" fill="black" font-family="Arial" font-size="14">60.6 ms</text>
-	<rect x="740.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="64.0" fill="black" font-family="Arial" font-size="14">64.2 ms</text>
-	<rect x="872.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="64.0" fill="black" font-family="Arial" font-size="14">89.3 ms</text>
-	<rect x="1004.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1051.0" y="64.0" fill="black" font-family="Arial" font-size="14">111 ms</text>
-	<rect x="1136.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1183.0" y="64.0" fill="black" font-family="Arial" font-size="14">181 ms</text>
-	<rect x="0" y="80" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="104.0" fill="black" font-family="Arial" font-size="14">Mul (`x`)</text>
-	<rect x="344.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="104.0" fill="black" font-family="Arial" font-size="14">36.2 ms</text>
-	<rect x="476.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="104.0" fill="black" font-family="Arial" font-size="14">74.8 ms</text>
-	<rect x="608.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="655.0" y="104.0" fill="black" font-family="Arial" font-size="14">125 ms</text>
-	<rect x="740.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="787.0" y="104.0" fill="black" font-family="Arial" font-size="14">175 ms</text>
-	<rect x="872.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="919.0" y="104.0" fill="black" font-family="Arial" font-size="14">242 ms</text>
-	<rect x="1004.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1051.0" y="104.0" fill="black" font-family="Arial" font-size="14">453 ms</text>
-	<rect x="1136.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1183.0" y="104.0" fill="black" font-family="Arial" font-size="14">1.11 s</text>
-	<rect x="0" y="120" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="144.0" fill="black" font-family="Arial" font-size="14">Equal / Not Equal (`eq`, `ne`)</text>
-	<rect x="344.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="144.0" fill="black" font-family="Arial" font-size="14">18.8 ms</text>
-	<rect x="476.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="144.0" fill="black" font-family="Arial" font-size="14">32.2 ms</text>
-	<rect x="608.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="144.0" fill="black" font-family="Arial" font-size="14">35.2 ms</text>
-	<rect x="740.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="144.0" fill="black" font-family="Arial" font-size="14">55.2 ms</text>
-	<rect x="872.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="144.0" fill="black" font-family="Arial" font-size="14">58.2 ms</text>
-	<rect x="1004.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1047.0" y="144.0" fill="black" font-family="Arial" font-size="14">79.0 ms</text>
-	<rect x="1136.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1179.0" y="144.0" fill="black" font-family="Arial" font-size="14">81.2 ms</text>
-	<rect x="0" y="160" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="184.0" fill="black" font-family="Arial" font-size="14">Comparisons  (`ge`, `gt`, `le`, `lt`)</text>
-	<rect x="344.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="184.0" fill="black" font-family="Arial" font-size="14">15.1 ms</text>
-	<rect x="476.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="184.0" fill="black" font-family="Arial" font-size="14">37.2 ms</text>
-	<rect x="608.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="184.0" fill="black" font-family="Arial" font-size="14">36.6 ms</text>
-	<rect x="740.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="184.0" fill="black" font-family="Arial" font-size="14">56.0 ms</text>
-	<rect x="872.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="184.0" fill="black" font-family="Arial" font-size="14">78.9 ms</text>
-	<rect x="1004.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1051.0" y="184.0" fill="black" font-family="Arial" font-size="14">101 ms</text>
-	<rect x="1136.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1183.0" y="184.0" fill="black" font-family="Arial" font-size="14">145 ms</text>
-	<rect x="0" y="200" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="224.0" fill="black" font-family="Arial" font-size="14">Max / Min   (`max`,`min`)</text>
-	<rect x="344.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="224.0" fill="black" font-family="Arial" font-size="14">32.9 ms</text>
-	<rect x="476.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="224.0" fill="black" font-family="Arial" font-size="14">52.6 ms</text>
-	<rect x="608.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="224.0" fill="black" font-family="Arial" font-size="14">57.0 ms</text>
-	<rect x="740.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="224.0" fill="black" font-family="Arial" font-size="14">78.1 ms</text>
-	<rect x="872.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="919.0" y="224.0" fill="black" font-family="Arial" font-size="14">103 ms</text>
-	<rect x="1004.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1051.0" y="224.0" fill="black" font-family="Arial" font-size="14">123 ms</text>
-	<rect x="1136.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1183.0" y="224.0" fill="black" font-family="Arial" font-size="14">171 ms</text>
-	<rect x="0" y="240" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="264.0" fill="black" font-family="Arial" font-size="14">Bitwise operations (`&#38;`, `&#124;`, `^`)</text>
-	<rect x="344.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="264.0" fill="black" font-family="Arial" font-size="14">18.0 ms</text>
-	<rect x="476.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="264.0" fill="black" font-family="Arial" font-size="14">18.9 ms</text>
-	<rect x="608.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="264.0" fill="black" font-family="Arial" font-size="14">19.6 ms</text>
-	<rect x="740.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="264.0" fill="black" font-family="Arial" font-size="14">21.4 ms</text>
-	<rect x="872.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="264.0" fill="black" font-family="Arial" font-size="14">23.1 ms</text>
-	<rect x="1004.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1047.0" y="264.0" fill="black" font-family="Arial" font-size="14">24.1 ms</text>
-	<rect x="1136.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1179.0" y="264.0" fill="black" font-family="Arial" font-size="14">26.7 ms</text>
-	<rect x="0" y="280" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="304.0" fill="black" font-family="Arial" font-size="14">Div  (`/`)</text>
-	<rect x="344.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="304.0" fill="black" font-family="Arial" font-size="14">81.1 ms</text>
-	<rect x="476.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="523.0" y="304.0" fill="black" font-family="Arial" font-size="14">139 ms</text>
-	<rect x="608.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="655.0" y="304.0" fill="black" font-family="Arial" font-size="14">202 ms</text>
-	<rect x="740.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="787.0" y="304.0" fill="black" font-family="Arial" font-size="14">280 ms</text>
-	<rect x="872.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="919.0" y="304.0" fill="black" font-family="Arial" font-size="14">456 ms</text>
-	<rect x="1004.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1051.0" y="304.0" fill="black" font-family="Arial" font-size="14">912 ms</text>
-	<rect x="1136.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1183.0" y="304.0" fill="black" font-family="Arial" font-size="14">2.33 s</text>
-	<rect x="0" y="320" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="344.0" fill="black" font-family="Arial" font-size="14">Rem  (`%`)</text>
-	<rect x="344.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="391.0" y="344.0" fill="black" font-family="Arial" font-size="14">154 ms</text>
-	<rect x="476.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="523.0" y="344.0" fill="black" font-family="Arial" font-size="14">275 ms</text>
-	<rect x="608.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="655.0" y="344.0" fill="black" font-family="Arial" font-size="14">366 ms</text>
-	<rect x="740.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="787.0" y="344.0" fill="black" font-family="Arial" font-size="14">536 ms</text>
-	<rect x="872.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="919.0" y="344.0" fill="black" font-family="Arial" font-size="14">778 ms</text>
-	<rect x="1004.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1051.0" y="344.0" fill="black" font-family="Arial" font-size="14">1.37 s</text>
-	<rect x="1136.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1183.0" y="344.0" fill="black" font-family="Arial" font-size="14">3.13 s</text>
-	<rect x="0" y="360" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="384.0" fill="black" font-family="Arial" font-size="14">Left / Right Shifts (`&#60;&#60;`, `&#62;&#62;`)</text>
-	<rect x="344.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="384.0" fill="black" font-family="Arial" font-size="14">22.3 ms</text>
-	<rect x="476.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="384.0" fill="black" font-family="Arial" font-size="14">20.0 ms</text>
-	<rect x="608.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="384.0" fill="black" font-family="Arial" font-size="14">20.3 ms</text>
-	<rect x="740.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="384.0" fill="black" font-family="Arial" font-size="14">21.2 ms</text>
-	<rect x="872.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="384.0" fill="black" font-family="Arial" font-size="14">23.2 ms</text>
-	<rect x="1004.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1047.0" y="384.0" fill="black" font-family="Arial" font-size="14">24.2 ms</text>
-	<rect x="1136.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1179.0" y="384.0" fill="black" font-family="Arial" font-size="14">26.5 ms</text>
-	<rect x="0" y="400" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="424.0" fill="black" font-family="Arial" font-size="14">Left / Right Rotations (`left_rotate`, `right_rotate`)</text>
-	<rect x="344.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="424.0" fill="black" font-family="Arial" font-size="14">20.2 ms</text>
-	<rect x="476.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="424.0" fill="black" font-family="Arial" font-size="14">19.5 ms</text>
-	<rect x="608.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="424.0" fill="black" font-family="Arial" font-size="14">20.6 ms</text>
-	<rect x="740.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="424.0" fill="black" font-family="Arial" font-size="14">21.1 ms</text>
-	<rect x="872.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="424.0" fill="black" font-family="Arial" font-size="14">23.6 ms</text>
-	<rect x="1004.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1047.0" y="424.0" fill="black" font-family="Arial" font-size="14">24.1 ms</text>
-	<rect x="1136.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1179.0" y="424.0" fill="black" font-family="Arial" font-size="14">26.2 ms</text>
-
-    <!-- Borders -->
-    <line x1="0" y1="0" x2="0" y2="440" stroke="white" />
-	<line x1="344.0" y1="0" x2="344.0" y2="440" stroke="white" />
-	<line x1="476.0" y1="0" x2="476.0" y2="440" stroke="white" />
-	<line x1="608.0" y1="0" x2="608.0" y2="440" stroke="white" />
-	<line x1="740.0" y1="0" x2="740.0" y2="440" stroke="white" />
-	<line x1="872.0" y1="0" x2="872.0" y2="440" stroke="white" />
-	<line x1="1004.0" y1="0" x2="1004.0" y2="440" stroke="white" />
-	<line x1="1136.0" y1="0" x2="1136.0" y2="440" stroke="white" />
-	<line x1="0" y1="0" x2="1268.0" y2="0" stroke="white" />
-	<line x1="0" y1="40" x2="1268.0" y2="40" stroke="white" />
-	<line x1="0" y1="80" x2="1268.0" y2="80" stroke="white" />
-	<line x1="0" y1="120" x2="1268.0" y2="120" stroke="white" />
-	<line x1="0" y1="160" x2="1268.0" y2="160" stroke="white" />
-	<line x1="0" y1="200" x2="1268.0" y2="200" stroke="white" />
-	<line x1="0" y1="240" x2="1268.0" y2="240" stroke="white" />
-	<line x1="0" y1="280" x2="1268.0" y2="280" stroke="white" />
-	<line x1="0" y1="320" x2="1268.0" y2="320" stroke="white" />
-	<line x1="0" y1="360" x2="1268.0" y2="360" stroke="white" />
-	<line x1="0" y1="400" x2="1268.0" y2="400" stroke="white" />
-	<line x1="0" y1="440" x2="1268.0" y2="440" stroke="white" />
+<?xml version="1.0" ?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 440" preserveAspectRatio="meet" width="100%" height="440">
+	<rect x="0" y="0" width="720" height="40" fill="black"/>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="6" y="20.0">Operation \ Size</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="342.0" y="13.333333333333334">FheUint</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="342.0" y="29.666666666666668">8</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="426.0" y="13.333333333333334">FheUint</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="426.0" y="29.666666666666668">16</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="510.0" y="13.333333333333334">FheUint</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="510.0" y="29.666666666666668">32</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="594.0" y="13.333333333333334">FheUint</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="594.0" y="29.666666666666668">64</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="678.0" y="13.333333333333334">FheUint</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="678.0" y="29.666666666666668">128</text>
+	<rect x="0" y="40" width="300" height="400" fill="#fbbc04"/>
+	<rect x="300" y="40" width="420" height="400" fill="#f3f3f3"/>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="60.0">Add / Sub (+,-)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="60.0">52.5 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="60.0">60.6 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="60.0">64.2 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="60.0">89.3 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="60.0">111 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="100.0">Mul (x)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="100.0">74.8 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="100.0">125 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="100.0">175 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="100.0">242 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="100.0">453 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="140.0">Equal / Not Equal (eq, ne)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="140.0">32.2 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="140.0">35.2 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="140.0">55.2 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="140.0">58.2 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="140.0">79.0 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="180.0">Comparisons (ge, gt, le, lt)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="180.0">37.2 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="180.0">36.6 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="180.0">56.0 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="180.0">78.9 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="180.0">101 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="220.0">Max / Min (max, min)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="220.0">52.6 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="220.0">57.0 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="220.0">78.1 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="220.0">103 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="220.0">123 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="260.0">Bitwise operations (&amp;, |, ^)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="260.0">18.9 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="260.0">19.6 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="260.0">21.4 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="260.0">23.1 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="260.0">24.1 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="300.0">Div  (/)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="300.0">139 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="300.0">202 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="300.0">280 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="300.0">456 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="300.0">912 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="340.0">Rem  (%)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="340.0">275 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="340.0">366 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="340.0">536 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="340.0">778 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="340.0">1.37 s</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="380.0">Left / Right Shifts (&lt;&lt;, &gt;&gt;)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="380.0">20.0 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="380.0">20.3 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="380.0">21.2 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="380.0">23.2 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="380.0">24.2 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="420.0">Left / Right Rotations (left_rotate, right_rotate)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="420.0">19.5 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="420.0">20.6 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="420.0">21.1 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="420.0">23.6 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="420.0">24.1 ms</text>
+	<line stroke="white" stroke-width="2" x1="0" y1="0" x2="720" y2="0"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="40" x2="720" y2="40"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="80" x2="720" y2="80"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="120" x2="720" y2="120"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="160" x2="720" y2="160"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="200" x2="720" y2="200"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="240" x2="720" y2="240"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="280" x2="720" y2="280"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="320" x2="720" y2="320"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="360" x2="720" y2="360"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="400" x2="720" y2="400"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="0" x2="0" y2="440"/>
+	<line stroke="white" stroke-width="2" x1="300.0" y1="0" x2="300.0" y2="440"/>
+	<line stroke="white" stroke-width="2" x1="384.0" y1="0" x2="384.0" y2="440"/>
+	<line stroke="white" stroke-width="2" x1="468.0" y1="0" x2="468.0" y2="440"/>
+	<line stroke="white" stroke-width="2" x1="552.0" y1="0" x2="552.0" y2="440"/>
+	<line stroke="white" stroke-width="2" x1="636.0" y1="0" x2="636.0" y2="440"/>
+	<line stroke="white" stroke-width="2" x1="720.0" y1="0" x2="720.0" y2="440"/>
 </svg>

--- a/tfhe/docs/_static/cpu_integer_benchmark_tuniform_2m64_ciphertext.svg
+++ b/tfhe/docs/_static/cpu_integer_benchmark_tuniform_2m64_ciphertext.svg
@@ -1,247 +1,116 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1268.0" height="560" viewBox="0 0 1268.0 560">
-    <!-- Header Row -->
-    <rect x="0" y="0" width="1268.0" height="40" fill="black" />
-	<text x="10" y="24.0" fill="white" font-family="Arial" font-size="14">Operation \ Size</text>
-	<text x="383.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint4</text>
-	<text x="515.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint8</text>
-	<text x="643.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint16</text>
-	<text x="775.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint32</text>
-	<text x="907.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint64</text>
-	<text x="1035.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint128</text>
-	<text x="1167.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint256</text>
-
-    <!-- Data Rows -->
-    <rect x="0" y="40" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="64.0" fill="black" font-family="Arial" font-size="14">Negation (`-`)</text>
-	<rect x="344.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="64.0" fill="black" font-family="Arial" font-size="14">33.1 ms</text>
-	<rect x="476.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="64.0" fill="black" font-family="Arial" font-size="14">48.7 ms</text>
-	<rect x="608.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="64.0" fill="black" font-family="Arial" font-size="14">57.6 ms</text>
-	<rect x="740.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="64.0" fill="black" font-family="Arial" font-size="14">81.2 ms</text>
-	<rect x="872.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="919.0" y="64.0" fill="black" font-family="Arial" font-size="14">106 ms</text>
-	<rect x="1004.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1051.0" y="64.0" fill="black" font-family="Arial" font-size="14">168 ms</text>
-	<rect x="1136.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1183.0" y="64.0" fill="black" font-family="Arial" font-size="14">189 ms</text>
-	<rect x="0" y="80" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="104.0" fill="black" font-family="Arial" font-size="14">Add / Sub (`+`,`-`)</text>
-	<rect x="344.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="104.0" fill="black" font-family="Arial" font-size="14">38.1 ms</text>
-	<rect x="476.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="104.0" fill="black" font-family="Arial" font-size="14">59.9 ms</text>
-	<rect x="608.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="104.0" fill="black" font-family="Arial" font-size="14">60.2 ms</text>
-	<rect x="740.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="104.0" fill="black" font-family="Arial" font-size="14">82.2 ms</text>
-	<rect x="872.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="919.0" y="104.0" fill="black" font-family="Arial" font-size="14">105 ms</text>
-	<rect x="1004.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1051.0" y="104.0" fill="black" font-family="Arial" font-size="14">168 ms</text>
-	<rect x="1136.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1183.0" y="104.0" fill="black" font-family="Arial" font-size="14">182 ms</text>
-	<rect x="0" y="120" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="144.0" fill="black" font-family="Arial" font-size="14">Mul (`x`)</text>
-	<rect x="344.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="144.0" fill="black" font-family="Arial" font-size="14">40.6 ms</text>
-	<rect x="476.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="523.0" y="144.0" fill="black" font-family="Arial" font-size="14">103 ms</text>
-	<rect x="608.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="655.0" y="144.0" fill="black" font-family="Arial" font-size="14">143 ms</text>
-	<rect x="740.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="787.0" y="144.0" fill="black" font-family="Arial" font-size="14">219 ms</text>
-	<rect x="872.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="919.0" y="144.0" fill="black" font-family="Arial" font-size="14">401 ms</text>
-	<rect x="1004.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1051.0" y="144.0" fill="black" font-family="Arial" font-size="14">1.15 s</text>
-	<rect x="1136.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1183.0" y="144.0" fill="black" font-family="Arial" font-size="14">3.84 s</text>
-	<rect x="0" y="160" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="184.0" fill="black" font-family="Arial" font-size="14">Equal / Not Equal (`eq`, `ne`)</text>
-	<rect x="344.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="184.0" fill="black" font-family="Arial" font-size="14">36.5 ms</text>
-	<rect x="476.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="184.0" fill="black" font-family="Arial" font-size="14">37.1 ms</text>
-	<rect x="608.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="184.0" fill="black" font-family="Arial" font-size="14">58.3 ms</text>
-	<rect x="740.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="184.0" fill="black" font-family="Arial" font-size="14">59.0 ms</text>
-	<rect x="872.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="184.0" fill="black" font-family="Arial" font-size="14">81.2 ms</text>
-	<rect x="1004.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1047.0" y="184.0" fill="black" font-family="Arial" font-size="14">82.3 ms</text>
-	<rect x="1136.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1183.0" y="184.0" fill="black" font-family="Arial" font-size="14">106 ms</text>
-	<rect x="0" y="200" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="224.0" fill="black" font-family="Arial" font-size="14">Comparisons  (`ge`, `gt`, `le`, `lt`)</text>
-	<rect x="344.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="224.0" fill="black" font-family="Arial" font-size="14">36.3 ms</text>
-	<rect x="476.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="224.0" fill="black" font-family="Arial" font-size="14">37.4 ms</text>
-	<rect x="608.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="224.0" fill="black" font-family="Arial" font-size="14">57.2 ms</text>
-	<rect x="740.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="224.0" fill="black" font-family="Arial" font-size="14">80.1 ms</text>
-	<rect x="872.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="919.0" y="224.0" fill="black" font-family="Arial" font-size="14">102 ms</text>
-	<rect x="1004.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1051.0" y="224.0" fill="black" font-family="Arial" font-size="14">145 ms</text>
-	<rect x="1136.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1183.0" y="224.0" fill="black" font-family="Arial" font-size="14">175 ms</text>
-	<rect x="0" y="240" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="264.0" fill="black" font-family="Arial" font-size="14">Max / Min   (`max`,`min`)</text>
-	<rect x="344.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="264.0" fill="black" font-family="Arial" font-size="14">79.4 ms</text>
-	<rect x="476.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="264.0" fill="black" font-family="Arial" font-size="14">79.8 ms</text>
-	<rect x="608.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="264.0" fill="black" font-family="Arial" font-size="14">99.8 ms</text>
-	<rect x="740.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="787.0" y="264.0" fill="black" font-family="Arial" font-size="14">122 ms</text>
-	<rect x="872.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="919.0" y="264.0" fill="black" font-family="Arial" font-size="14">145 ms</text>
-	<rect x="1004.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1051.0" y="264.0" fill="black" font-family="Arial" font-size="14">192 ms</text>
-	<rect x="1136.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1183.0" y="264.0" fill="black" font-family="Arial" font-size="14">246 ms</text>
-	<rect x="0" y="280" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="304.0" fill="black" font-family="Arial" font-size="14">Bitwise operations (`&#38;`, `&#124;`, `^`)</text>
-	<rect x="344.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="304.0" fill="black" font-family="Arial" font-size="14">19.8 ms</text>
-	<rect x="476.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="304.0" fill="black" font-family="Arial" font-size="14">19.4 ms</text>
-	<rect x="608.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="304.0" fill="black" font-family="Arial" font-size="14">19.6 ms</text>
-	<rect x="740.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="304.0" fill="black" font-family="Arial" font-size="14">20.5 ms</text>
-	<rect x="872.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="304.0" fill="black" font-family="Arial" font-size="14">20.7 ms</text>
-	<rect x="1004.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1047.0" y="304.0" fill="black" font-family="Arial" font-size="14">23.3 ms</text>
-	<rect x="1136.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1179.0" y="304.0" fill="black" font-family="Arial" font-size="14">26.0 ms</text>
-	<rect x="0" y="320" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="344.0" fill="black" font-family="Arial" font-size="14">Div / Rem  (`/`, `%`)</text>
-	<rect x="344.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="391.0" y="344.0" fill="black" font-family="Arial" font-size="14">291 ms</text>
-	<rect x="476.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="523.0" y="344.0" fill="black" font-family="Arial" font-size="14">693 ms</text>
-	<rect x="608.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="655.0" y="344.0" fill="black" font-family="Arial" font-size="14">1.56 s</text>
-	<rect x="740.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="787.0" y="344.0" fill="black" font-family="Arial" font-size="14">3.52 s</text>
-	<rect x="872.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="919.0" y="344.0" fill="black" font-family="Arial" font-size="14">8.22 s</text>
-	<rect x="1004.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1051.0" y="344.0" fill="black" font-family="Arial" font-size="14">21.1 s</text>
-	<rect x="1136.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1183.0" y="344.0" fill="black" font-family="Arial" font-size="14">55.2 s</text>
-	<rect x="0" y="360" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="384.0" fill="black" font-family="Arial" font-size="14">Left / Right Shifts (`&#60;&#60;`, `&#62;&#62;`)</text>
-	<rect x="344.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="384.0" fill="black" font-family="Arial" font-size="14">38.5 ms</text>
-	<rect x="476.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="384.0" fill="black" font-family="Arial" font-size="14">61.2 ms</text>
-	<rect x="608.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="384.0" fill="black" font-family="Arial" font-size="14">84.3 ms</text>
-	<rect x="740.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="787.0" y="384.0" fill="black" font-family="Arial" font-size="14">109 ms</text>
-	<rect x="872.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="919.0" y="384.0" fill="black" font-family="Arial" font-size="14">134 ms</text>
-	<rect x="1004.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1051.0" y="384.0" fill="black" font-family="Arial" font-size="14">174 ms</text>
-	<rect x="1136.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1183.0" y="384.0" fill="black" font-family="Arial" font-size="14">250 ms</text>
-	<rect x="0" y="400" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="424.0" fill="black" font-family="Arial" font-size="14">Left / Right Rotations (`left_rotate`, `right_rotate`)</text>
-	<rect x="344.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="424.0" fill="black" font-family="Arial" font-size="14">40.4 ms</text>
-	<rect x="476.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="424.0" fill="black" font-family="Arial" font-size="14">61.4 ms</text>
-	<rect x="608.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="424.0" fill="black" font-family="Arial" font-size="14">82.6 ms</text>
-	<rect x="740.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="787.0" y="424.0" fill="black" font-family="Arial" font-size="14">105 ms</text>
-	<rect x="872.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="919.0" y="424.0" fill="black" font-family="Arial" font-size="14">133 ms</text>
-	<rect x="1004.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1051.0" y="424.0" fill="black" font-family="Arial" font-size="14">184 ms</text>
-	<rect x="1136.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1183.0" y="424.0" fill="black" font-family="Arial" font-size="14">259 ms</text>
-	<rect x="0" y="440" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="464.0" fill="black" font-family="Arial" font-size="14">Leading / Trailing zeros/ones</text>
-	<rect x="344.0" y="440" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="464.0" fill="black" font-family="Arial" font-size="14">80.5 ms</text>
-	<rect x="476.0" y="440" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="523.0" y="464.0" fill="black" font-family="Arial" font-size="14">100 ms</text>
-	<rect x="608.0" y="440" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="655.0" y="464.0" fill="black" font-family="Arial" font-size="14">156 ms</text>
-	<rect x="740.0" y="440" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="787.0" y="464.0" fill="black" font-family="Arial" font-size="14">183 ms</text>
-	<rect x="872.0" y="440" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="919.0" y="464.0" fill="black" font-family="Arial" font-size="14">247 ms</text>
-	<rect x="1004.0" y="440" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1051.0" y="464.0" fill="black" font-family="Arial" font-size="14">298 ms</text>
-	<rect x="1136.0" y="440" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1183.0" y="464.0" fill="black" font-family="Arial" font-size="14">347 ms</text>
-	<rect x="0" y="480" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="504.0" fill="black" font-family="Arial" font-size="14">Log2</text>
-	<rect x="344.0" y="480" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="391.0" y="504.0" fill="black" font-family="Arial" font-size="14">100 ms</text>
-	<rect x="476.0" y="480" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="523.0" y="504.0" fill="black" font-family="Arial" font-size="14">121 ms</text>
-	<rect x="608.0" y="480" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="655.0" y="504.0" fill="black" font-family="Arial" font-size="14">182 ms</text>
-	<rect x="740.0" y="480" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="787.0" y="504.0" fill="black" font-family="Arial" font-size="14">205 ms</text>
-	<rect x="872.0" y="480" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="919.0" y="504.0" fill="black" font-family="Arial" font-size="14">267 ms</text>
-	<rect x="1004.0" y="480" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1051.0" y="504.0" fill="black" font-family="Arial" font-size="14">323 ms</text>
-	<rect x="1136.0" y="480" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1183.0" y="504.0" fill="black" font-family="Arial" font-size="14">369 ms</text>
-	<rect x="0" y="520" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="544.0" fill="black" font-family="Arial" font-size="14">Select</text>
-	<rect x="344.0" y="520" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="544.0" fill="black" font-family="Arial" font-size="14">27.6 ms</text>
-	<rect x="476.0" y="520" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="544.0" fill="black" font-family="Arial" font-size="14">30.9 ms</text>
-	<rect x="608.0" y="520" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="544.0" fill="black" font-family="Arial" font-size="14">32.2 ms</text>
-	<rect x="740.0" y="520" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="544.0" fill="black" font-family="Arial" font-size="14">33.3 ms</text>
-	<rect x="872.0" y="520" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="544.0" fill="black" font-family="Arial" font-size="14">32.6 ms</text>
-	<rect x="1004.0" y="520" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1047.0" y="544.0" fill="black" font-family="Arial" font-size="14">37.2 ms</text>
-	<rect x="1136.0" y="520" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1179.0" y="544.0" fill="black" font-family="Arial" font-size="14">51.0 ms</text>
-
-    <!-- Borders -->
-    <line x1="0" y1="0" x2="0" y2="560" stroke="white" />
-	<line x1="344.0" y1="0" x2="344.0" y2="560" stroke="white" />
-	<line x1="476.0" y1="0" x2="476.0" y2="560" stroke="white" />
-	<line x1="608.0" y1="0" x2="608.0" y2="560" stroke="white" />
-	<line x1="740.0" y1="0" x2="740.0" y2="560" stroke="white" />
-	<line x1="872.0" y1="0" x2="872.0" y2="560" stroke="white" />
-	<line x1="1004.0" y1="0" x2="1004.0" y2="560" stroke="white" />
-	<line x1="1136.0" y1="0" x2="1136.0" y2="560" stroke="white" />
-	<line x1="0" y1="0" x2="1268.0" y2="0" stroke="white" />
-	<line x1="0" y1="40" x2="1268.0" y2="40" stroke="white" />
-	<line x1="0" y1="80" x2="1268.0" y2="80" stroke="white" />
-	<line x1="0" y1="120" x2="1268.0" y2="120" stroke="white" />
-	<line x1="0" y1="160" x2="1268.0" y2="160" stroke="white" />
-	<line x1="0" y1="200" x2="1268.0" y2="200" stroke="white" />
-	<line x1="0" y1="240" x2="1268.0" y2="240" stroke="white" />
-	<line x1="0" y1="280" x2="1268.0" y2="280" stroke="white" />
-	<line x1="0" y1="320" x2="1268.0" y2="320" stroke="white" />
-	<line x1="0" y1="360" x2="1268.0" y2="360" stroke="white" />
-	<line x1="0" y1="400" x2="1268.0" y2="400" stroke="white" />
-	<line x1="0" y1="440" x2="1268.0" y2="440" stroke="white" />
-	<line x1="0" y1="480" x2="1268.0" y2="480" stroke="white" />
-	<line x1="0" y1="520" x2="1268.0" y2="520" stroke="white" />
-	<line x1="0" y1="560" x2="1268.0" y2="560" stroke="white" />
+<?xml version="1.0" ?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 560" preserveAspectRatio="meet" width="100%" height="560">
+	<rect x="0" y="0" width="720" height="40" fill="black"/>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="6" y="20.0">Operation \ Size</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="342.0" y="13.333333333333334">FheUint</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="342.0" y="29.666666666666668">8</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="426.0" y="13.333333333333334">FheUint</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="426.0" y="29.666666666666668">16</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="510.0" y="13.333333333333334">FheUint</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="510.0" y="29.666666666666668">32</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="594.0" y="13.333333333333334">FheUint</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="594.0" y="29.666666666666668">64</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="678.0" y="13.333333333333334">FheUint</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="678.0" y="29.666666666666668">128</text>
+	<rect x="0" y="40" width="300" height="520" fill="#fbbc04"/>
+	<rect x="300" y="40" width="420" height="520" fill="#f3f3f3"/>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="60.0">Negation (-)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="60.0">48.7 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="60.0">57.0 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="60.0">78.0 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="60.0">103 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="60.0">162 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="100.0">Add / Sub (+,-)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="100.0">52.5 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="100.0">58.1 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="100.0">79.9 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="100.0">101 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="100.0">161 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="140.0">Mul (x)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="140.0">94.4 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="140.0">136 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="140.0">210 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="140.0">381 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="140.0">1.1 s</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="180.0">Equal / Not Equal (eq, ne)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="180.0">36.3 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="180.0">55.6 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="180.0">55.0 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="180.0">76.3 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="180.0">77.6 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="220.0">Comparisons (ge, gt, le, lt)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="220.0">36.1 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="220.0">54.2 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="220.0">73.8 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="220.0">94.8 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="220.0">136 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="260.0">Max / Min (max, min)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="260.0">74.9 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="260.0">94.2 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="260.0">115 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="260.0">138 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="260.0">183 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="300.0">Bitwise operations (&amp;, |, ^)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="300.0">18.6 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="300.0">19.0 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="300.0">19.4 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="300.0">20.3 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="300.0">22.0 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="340.0">Div / Rem  (/, %)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="340.0">667 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="340.0">1.49 s</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="340.0">3.39 s</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="340.0">7.87 s</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="340.0">19.6 s</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="380.0">Left / Right Shifts (&lt;&lt;, &gt;&gt;)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="380.0">59.9 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="380.0">79.2 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="380.0">100 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="380.0">128 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="380.0">169 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="420.0">Left / Right Rotations (left_rotate, right_rotate)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="420.0">57.4 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="420.0">77.1 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="420.0">98.9 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="420.0">128 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="420.0">178 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="460.0">Leading / Trailing zeros/ones</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="460.0">96.5 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="460.0">153 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="460.0">172 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="460.0">234 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="460.0">291 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="500.0">Log2</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="500.0">114 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="500.0">170 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="500.0">195 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="500.0">256 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="500.0">312 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="540.0">Select</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="540.0">28.9 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="540.0">29.4 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="540.0">31.0 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="540.0">31.9 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="540.0">34.3 ms</text>
+	<line stroke="white" stroke-width="2" x1="0" y1="0" x2="720" y2="0"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="40" x2="720" y2="40"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="80" x2="720" y2="80"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="120" x2="720" y2="120"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="160" x2="720" y2="160"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="200" x2="720" y2="200"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="240" x2="720" y2="240"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="280" x2="720" y2="280"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="320" x2="720" y2="320"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="360" x2="720" y2="360"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="400" x2="720" y2="400"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="440" x2="720" y2="440"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="480" x2="720" y2="480"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="520" x2="720" y2="520"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="0" x2="0" y2="560"/>
+	<line stroke="white" stroke-width="2" x1="300.0" y1="0" x2="300.0" y2="560"/>
+	<line stroke="white" stroke-width="2" x1="384.0" y1="0" x2="384.0" y2="560"/>
+	<line stroke="white" stroke-width="2" x1="468.0" y1="0" x2="468.0" y2="560"/>
+	<line stroke="white" stroke-width="2" x1="552.0" y1="0" x2="552.0" y2="560"/>
+	<line stroke="white" stroke-width="2" x1="636.0" y1="0" x2="636.0" y2="560"/>
+	<line stroke="white" stroke-width="2" x1="720.0" y1="0" x2="720.0" y2="560"/>
 </svg>

--- a/tfhe/docs/_static/cpu_integer_benchmark_tuniform_2m64_plaintext.svg
+++ b/tfhe/docs/_static/cpu_integer_benchmark_tuniform_2m64_plaintext.svg
@@ -1,196 +1,95 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1268.0" height="440" viewBox="0 0 1268.0 440">
-    <!-- Header Row -->
-    <rect x="0" y="0" width="1268.0" height="40" fill="black" />
-	<text x="10" y="24.0" fill="white" font-family="Arial" font-size="14">Operation \ Size</text>
-	<text x="383.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint4</text>
-	<text x="515.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint8</text>
-	<text x="643.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint16</text>
-	<text x="775.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint32</text>
-	<text x="907.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint64</text>
-	<text x="1035.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint128</text>
-	<text x="1167.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint256</text>
-
-    <!-- Data Rows -->
-    <rect x="0" y="40" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="64.0" fill="black" font-family="Arial" font-size="14">Add / Sub (`+`,`-`)</text>
-	<rect x="344.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="64.0" fill="black" font-family="Arial" font-size="14">39.8 ms</text>
-	<rect x="476.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="64.0" fill="black" font-family="Arial" font-size="14">56.3 ms</text>
-	<rect x="608.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="64.0" fill="black" font-family="Arial" font-size="14">61.5 ms</text>
-	<rect x="740.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="64.0" fill="black" font-family="Arial" font-size="14">63.8 ms</text>
-	<rect x="872.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="64.0" fill="black" font-family="Arial" font-size="14">88.4 ms</text>
-	<rect x="1004.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1051.0" y="64.0" fill="black" font-family="Arial" font-size="14">111 ms</text>
-	<rect x="1136.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1183.0" y="64.0" fill="black" font-family="Arial" font-size="14">178 ms</text>
-	<rect x="0" y="80" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="104.0" fill="black" font-family="Arial" font-size="14">Mul (`x`)</text>
-	<rect x="344.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="104.0" fill="black" font-family="Arial" font-size="14">40.9 ms</text>
-	<rect x="476.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="104.0" fill="black" font-family="Arial" font-size="14">80.3 ms</text>
-	<rect x="608.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="655.0" y="104.0" fill="black" font-family="Arial" font-size="14">128 ms</text>
-	<rect x="740.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="787.0" y="104.0" fill="black" font-family="Arial" font-size="14">173 ms</text>
-	<rect x="872.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="919.0" y="104.0" fill="black" font-family="Arial" font-size="14">231 ms</text>
-	<rect x="1004.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1051.0" y="104.0" fill="black" font-family="Arial" font-size="14">452 ms</text>
-	<rect x="1136.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1183.0" y="104.0" fill="black" font-family="Arial" font-size="14">1.11 s</text>
-	<rect x="0" y="120" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="144.0" fill="black" font-family="Arial" font-size="14">Equal / Not Equal (`eq`, `ne`)</text>
-	<rect x="344.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="144.0" fill="black" font-family="Arial" font-size="14">19.0 ms</text>
-	<rect x="476.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="144.0" fill="black" font-family="Arial" font-size="14">38.6 ms</text>
-	<rect x="608.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="144.0" fill="black" font-family="Arial" font-size="14">37.8 ms</text>
-	<rect x="740.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="144.0" fill="black" font-family="Arial" font-size="14">58.5 ms</text>
-	<rect x="872.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="144.0" fill="black" font-family="Arial" font-size="14">58.8 ms</text>
-	<rect x="1004.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1047.0" y="144.0" fill="black" font-family="Arial" font-size="14">81.7 ms</text>
-	<rect x="1136.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1179.0" y="144.0" fill="black" font-family="Arial" font-size="14">84.2 ms</text>
-	<rect x="0" y="160" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="184.0" fill="black" font-family="Arial" font-size="14">Comparisons  (`ge`, `gt`, `le`, `lt`)</text>
-	<rect x="344.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="184.0" fill="black" font-family="Arial" font-size="14">15.3 ms</text>
-	<rect x="476.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="184.0" fill="black" font-family="Arial" font-size="14">40.9 ms</text>
-	<rect x="608.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="184.0" fill="black" font-family="Arial" font-size="14">39.9 ms</text>
-	<rect x="740.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="184.0" fill="black" font-family="Arial" font-size="14">57.6 ms</text>
-	<rect x="872.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="184.0" fill="black" font-family="Arial" font-size="14">81.0 ms</text>
-	<rect x="1004.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1051.0" y="184.0" fill="black" font-family="Arial" font-size="14">103 ms</text>
-	<rect x="1136.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1183.0" y="184.0" fill="black" font-family="Arial" font-size="14">149 ms</text>
-	<rect x="0" y="200" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="224.0" fill="black" font-family="Arial" font-size="14">Max / Min   (`max`,`min`)</text>
-	<rect x="344.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="224.0" fill="black" font-family="Arial" font-size="14">32.9 ms</text>
-	<rect x="476.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="224.0" fill="black" font-family="Arial" font-size="14">59.1 ms</text>
-	<rect x="608.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="224.0" fill="black" font-family="Arial" font-size="14">60.0 ms</text>
-	<rect x="740.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="224.0" fill="black" font-family="Arial" font-size="14">81.6 ms</text>
-	<rect x="872.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="919.0" y="224.0" fill="black" font-family="Arial" font-size="14">103 ms</text>
-	<rect x="1004.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1051.0" y="224.0" fill="black" font-family="Arial" font-size="14">127 ms</text>
-	<rect x="1136.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1183.0" y="224.0" fill="black" font-family="Arial" font-size="14">175 ms</text>
-	<rect x="0" y="240" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="264.0" fill="black" font-family="Arial" font-size="14">Bitwise operations (`&#38;`, `&#124;`, `^`)</text>
-	<rect x="344.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="264.0" fill="black" font-family="Arial" font-size="14">19.0 ms</text>
-	<rect x="476.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="264.0" fill="black" font-family="Arial" font-size="14">19.5 ms</text>
-	<rect x="608.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="264.0" fill="black" font-family="Arial" font-size="14">20.5 ms</text>
-	<rect x="740.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="264.0" fill="black" font-family="Arial" font-size="14">21.0 ms</text>
-	<rect x="872.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="264.0" fill="black" font-family="Arial" font-size="14">22.4 ms</text>
-	<rect x="1004.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1047.0" y="264.0" fill="black" font-family="Arial" font-size="14">23.9 ms</text>
-	<rect x="1136.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1179.0" y="264.0" fill="black" font-family="Arial" font-size="14">26.3 ms</text>
-	<rect x="0" y="280" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="304.0" fill="black" font-family="Arial" font-size="14">Div  (`/`)</text>
-	<rect x="344.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="304.0" fill="black" font-family="Arial" font-size="14">81.7 ms</text>
-	<rect x="476.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="523.0" y="304.0" fill="black" font-family="Arial" font-size="14">149 ms</text>
-	<rect x="608.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="655.0" y="304.0" fill="black" font-family="Arial" font-size="14">188 ms</text>
-	<rect x="740.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="787.0" y="304.0" fill="black" font-family="Arial" font-size="14">281 ms</text>
-	<rect x="872.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="919.0" y="304.0" fill="black" font-family="Arial" font-size="14">453 ms</text>
-	<rect x="1004.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1051.0" y="304.0" fill="black" font-family="Arial" font-size="14">844 ms</text>
-	<rect x="1136.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1183.0" y="304.0" fill="black" font-family="Arial" font-size="14">2.45 s</text>
-	<rect x="0" y="320" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="344.0" fill="black" font-family="Arial" font-size="14">Rem  (`%`)</text>
-	<rect x="344.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="391.0" y="344.0" fill="black" font-family="Arial" font-size="14">165 ms</text>
-	<rect x="476.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="523.0" y="344.0" fill="black" font-family="Arial" font-size="14">278 ms</text>
-	<rect x="608.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="655.0" y="344.0" fill="black" font-family="Arial" font-size="14">360 ms</text>
-	<rect x="740.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="787.0" y="344.0" fill="black" font-family="Arial" font-size="14">503 ms</text>
-	<rect x="872.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="919.0" y="344.0" fill="black" font-family="Arial" font-size="14">806 ms</text>
-	<rect x="1004.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1051.0" y="344.0" fill="black" font-family="Arial" font-size="14">1.32 s</text>
-	<rect x="1136.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1183.0" y="344.0" fill="black" font-family="Arial" font-size="14">2.98 s</text>
-	<rect x="0" y="360" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="384.0" fill="black" font-family="Arial" font-size="14">Left / Right Shifts (`&#60;&#60;`, `&#62;&#62;`)</text>
-	<rect x="344.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="384.0" fill="black" font-family="Arial" font-size="14">18.8 ms</text>
-	<rect x="476.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="384.0" fill="black" font-family="Arial" font-size="14">20.4 ms</text>
-	<rect x="608.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="384.0" fill="black" font-family="Arial" font-size="14">20.4 ms</text>
-	<rect x="740.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="384.0" fill="black" font-family="Arial" font-size="14">20.9 ms</text>
-	<rect x="872.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="384.0" fill="black" font-family="Arial" font-size="14">21.8 ms</text>
-	<rect x="1004.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1047.0" y="384.0" fill="black" font-family="Arial" font-size="14">23.1 ms</text>
-	<rect x="1136.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1179.0" y="384.0" fill="black" font-family="Arial" font-size="14">26.2 ms</text>
-	<rect x="0" y="400" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="424.0" fill="black" font-family="Arial" font-size="14">Left / Right Rotations (`left_rotate`, `right_rotate`)</text>
-	<rect x="344.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="424.0" fill="black" font-family="Arial" font-size="14">21.0 ms</text>
-	<rect x="476.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="424.0" fill="black" font-family="Arial" font-size="14">20.2 ms</text>
-	<rect x="608.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="424.0" fill="black" font-family="Arial" font-size="14">20.5 ms</text>
-	<rect x="740.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="424.0" fill="black" font-family="Arial" font-size="14">21.0 ms</text>
-	<rect x="872.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="424.0" fill="black" font-family="Arial" font-size="14">21.7 ms</text>
-	<rect x="1004.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1047.0" y="424.0" fill="black" font-family="Arial" font-size="14">23.0 ms</text>
-	<rect x="1136.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1179.0" y="424.0" fill="black" font-family="Arial" font-size="14">26.0 ms</text>
-
-    <!-- Borders -->
-    <line x1="0" y1="0" x2="0" y2="440" stroke="white" />
-	<line x1="344.0" y1="0" x2="344.0" y2="440" stroke="white" />
-	<line x1="476.0" y1="0" x2="476.0" y2="440" stroke="white" />
-	<line x1="608.0" y1="0" x2="608.0" y2="440" stroke="white" />
-	<line x1="740.0" y1="0" x2="740.0" y2="440" stroke="white" />
-	<line x1="872.0" y1="0" x2="872.0" y2="440" stroke="white" />
-	<line x1="1004.0" y1="0" x2="1004.0" y2="440" stroke="white" />
-	<line x1="1136.0" y1="0" x2="1136.0" y2="440" stroke="white" />
-	<line x1="0" y1="0" x2="1268.0" y2="0" stroke="white" />
-	<line x1="0" y1="40" x2="1268.0" y2="40" stroke="white" />
-	<line x1="0" y1="80" x2="1268.0" y2="80" stroke="white" />
-	<line x1="0" y1="120" x2="1268.0" y2="120" stroke="white" />
-	<line x1="0" y1="160" x2="1268.0" y2="160" stroke="white" />
-	<line x1="0" y1="200" x2="1268.0" y2="200" stroke="white" />
-	<line x1="0" y1="240" x2="1268.0" y2="240" stroke="white" />
-	<line x1="0" y1="280" x2="1268.0" y2="280" stroke="white" />
-	<line x1="0" y1="320" x2="1268.0" y2="320" stroke="white" />
-	<line x1="0" y1="360" x2="1268.0" y2="360" stroke="white" />
-	<line x1="0" y1="400" x2="1268.0" y2="400" stroke="white" />
-	<line x1="0" y1="440" x2="1268.0" y2="440" stroke="white" />
+<?xml version="1.0" ?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 440" preserveAspectRatio="meet" width="100%" height="440">
+	<rect x="0" y="0" width="720" height="40" fill="black"/>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="6" y="20.0">Operation \ Size</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="342.0" y="13.333333333333334">FheUint</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="342.0" y="29.666666666666668">8</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="426.0" y="13.333333333333334">FheUint</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="426.0" y="29.666666666666668">16</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="510.0" y="13.333333333333334">FheUint</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="510.0" y="29.666666666666668">32</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="594.0" y="13.333333333333334">FheUint</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="594.0" y="29.666666666666668">64</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="678.0" y="13.333333333333334">FheUint</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="678.0" y="29.666666666666668">128</text>
+	<rect x="0" y="40" width="300" height="400" fill="#fbbc04"/>
+	<rect x="300" y="40" width="420" height="400" fill="#f3f3f3"/>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="60.0">Add / Sub (+,-)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="60.0">51.7 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="60.0">56.2 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="60.0">57.0 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="60.0">78.6 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="60.0">104 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="100.0">Mul (x)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="100.0">75.6 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="100.0">118 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="100.0">161 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="100.0">222 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="100.0">419 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="140.0">Equal / Not Equal (eq, ne)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="140.0">34.6 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="140.0">35.4 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="140.0">56.0 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="140.0">54.4 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="140.0">75.8 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="180.0">Comparisons (ge, gt, le, lt)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="180.0">36.4 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="180.0">35.2 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="180.0">53.7 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="180.0">73.4 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="180.0">94.5 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="220.0">Max / Min (max, min)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="220.0">55.0 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="220.0">55.7 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="220.0">74.6 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="220.0">95.0 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="220.0">117 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="260.0">Bitwise operations (&amp;, |, ^)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="260.0">19.0 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="260.0">19.1 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="260.0">19.7 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="260.0">21.3 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="260.0">22.7 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="300.0">Div  (/)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="300.0">137 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="300.0">189 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="300.0">269 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="300.0">451 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="300.0">833 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="340.0">Rem  (%)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="340.0">268 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="340.0">344 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="340.0">492 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="340.0">719 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="340.0">1.27 s</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="380.0">Left / Right Shifts (&lt;&lt;, &gt;&gt;)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="380.0">18.9 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="380.0">19.3 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="380.0">19.6 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="380.0">20.1 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="380.0">21.9 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="420.0">Left / Right Rotations (left_rotate, right_rotate)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="420.0">19.3 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="420.0">19.4 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="420.0">19.9 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="420.0">21.4 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="420.0">22.7 ms</text>
+	<line stroke="white" stroke-width="2" x1="0" y1="0" x2="720" y2="0"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="40" x2="720" y2="40"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="80" x2="720" y2="80"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="120" x2="720" y2="120"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="160" x2="720" y2="160"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="200" x2="720" y2="200"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="240" x2="720" y2="240"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="280" x2="720" y2="280"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="320" x2="720" y2="320"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="360" x2="720" y2="360"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="400" x2="720" y2="400"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="0" x2="0" y2="440"/>
+	<line stroke="white" stroke-width="2" x1="300.0" y1="0" x2="300.0" y2="440"/>
+	<line stroke="white" stroke-width="2" x1="384.0" y1="0" x2="384.0" y2="440"/>
+	<line stroke="white" stroke-width="2" x1="468.0" y1="0" x2="468.0" y2="440"/>
+	<line stroke="white" stroke-width="2" x1="552.0" y1="0" x2="552.0" y2="440"/>
+	<line stroke="white" stroke-width="2" x1="636.0" y1="0" x2="636.0" y2="440"/>
+	<line stroke="white" stroke-width="2" x1="720.0" y1="0" x2="720.0" y2="440"/>
 </svg>

--- a/tfhe/docs/_static/gpu_integer_benchmark_h100x1_multi_bit_tuniform_2m64_ciphertext.svg
+++ b/tfhe/docs/_static/gpu_integer_benchmark_h100x1_multi_bit_tuniform_2m64_ciphertext.svg
@@ -1,247 +1,116 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1268.0" height="560" viewBox="0 0 1268.0 560">
-    <!-- Header Row -->
-    <rect x="0" y="0" width="1268.0" height="40" fill="black" />
-	<text x="10" y="24.0" fill="white" font-family="Arial" font-size="14">Operation \ Size</text>
-	<text x="383.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint4</text>
-	<text x="515.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint8</text>
-	<text x="643.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint16</text>
-	<text x="775.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint32</text>
-	<text x="907.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint64</text>
-	<text x="1035.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint128</text>
-	<text x="1167.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint256</text>
-
-    <!-- Data Rows -->
-    <rect x="0" y="40" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="64.0" fill="black" font-family="Arial" font-size="14">Negation (`-`)</text>
-	<rect x="344.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="64.0" fill="black" font-family="Arial" font-size="14">10.9 ms</text>
-	<rect x="476.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="64.0" fill="black" font-family="Arial" font-size="14">11.2 ms</text>
-	<rect x="608.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="64.0" fill="black" font-family="Arial" font-size="14">12.5 ms</text>
-	<rect x="740.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="64.0" fill="black" font-family="Arial" font-size="14">17.7 ms</text>
-	<rect x="872.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="64.0" fill="black" font-family="Arial" font-size="14">25.2 ms</text>
-	<rect x="1004.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1047.0" y="64.0" fill="black" font-family="Arial" font-size="14">51.1 ms</text>
-	<rect x="1136.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1179.0" y="64.0" fill="black" font-family="Arial" font-size="14">82.8 ms</text>
-	<rect x="0" y="80" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="104.0" fill="black" font-family="Arial" font-size="14">Add / Sub (`+`,`-`)</text>
-	<rect x="344.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="104.0" fill="black" font-family="Arial" font-size="14">11.0 ms</text>
-	<rect x="476.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="104.0" fill="black" font-family="Arial" font-size="14">11.3 ms</text>
-	<rect x="608.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="104.0" fill="black" font-family="Arial" font-size="14">12.5 ms</text>
-	<rect x="740.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="104.0" fill="black" font-family="Arial" font-size="14">17.7 ms</text>
-	<rect x="872.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="104.0" fill="black" font-family="Arial" font-size="14">25.2 ms</text>
-	<rect x="1004.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1047.0" y="104.0" fill="black" font-family="Arial" font-size="14">51.2 ms</text>
-	<rect x="1136.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1179.0" y="104.0" fill="black" font-family="Arial" font-size="14">82.8 ms</text>
-	<rect x="0" y="120" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="144.0" fill="black" font-family="Arial" font-size="14">Mul (`x`)</text>
-	<rect x="344.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="144.0" fill="black" font-family="Arial" font-size="14">18.0 ms</text>
-	<rect x="476.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="144.0" fill="black" font-family="Arial" font-size="14">23.1 ms</text>
-	<rect x="608.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="144.0" fill="black" font-family="Arial" font-size="14">37.2 ms</text>
-	<rect x="740.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="144.0" fill="black" font-family="Arial" font-size="14">76.4 ms</text>
-	<rect x="872.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="919.0" y="144.0" fill="black" font-family="Arial" font-size="14">237 ms</text>
-	<rect x="1004.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1051.0" y="144.0" fill="black" font-family="Arial" font-size="14">830 ms</text>
-	<rect x="1136.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1183.0" y="144.0" fill="black" font-family="Arial" font-size="14">3.24 s</text>
-	<rect x="0" y="160" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="184.0" fill="black" font-family="Arial" font-size="14">Equal / Not Equal (`eq`, `ne`)</text>
-	<rect x="344.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="184.0" fill="black" font-family="Arial" font-size="14">7.53 ms</text>
-	<rect x="476.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="184.0" fill="black" font-family="Arial" font-size="14">7.65 ms</text>
-	<rect x="608.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="184.0" fill="black" font-family="Arial" font-size="14">11.5 ms</text>
-	<rect x="740.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="184.0" fill="black" font-family="Arial" font-size="14">12.4 ms</text>
-	<rect x="872.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="184.0" fill="black" font-family="Arial" font-size="14">17.7 ms</text>
-	<rect x="1004.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1047.0" y="184.0" fill="black" font-family="Arial" font-size="14">24.1 ms</text>
-	<rect x="1136.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1179.0" y="184.0" fill="black" font-family="Arial" font-size="14">37.7 ms</text>
-	<rect x="0" y="200" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="224.0" fill="black" font-family="Arial" font-size="14">Comparisons  (`ge`, `gt`, `le`, `lt`)</text>
-	<rect x="344.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="224.0" fill="black" font-family="Arial" font-size="14">11.1 ms</text>
-	<rect x="476.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="224.0" fill="black" font-family="Arial" font-size="14">11.4 ms</text>
-	<rect x="608.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="224.0" fill="black" font-family="Arial" font-size="14">15.3 ms</text>
-	<rect x="740.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="224.0" fill="black" font-family="Arial" font-size="14">20.1 ms</text>
-	<rect x="872.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="224.0" fill="black" font-family="Arial" font-size="14">26.2 ms</text>
-	<rect x="1004.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1047.0" y="224.0" fill="black" font-family="Arial" font-size="14">38.0 ms</text>
-	<rect x="1136.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1179.0" y="224.0" fill="black" font-family="Arial" font-size="14">58.3 ms</text>
-	<rect x="0" y="240" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="264.0" fill="black" font-family="Arial" font-size="14">Max / Min   (`max`,`min`)</text>
-	<rect x="344.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="264.0" fill="black" font-family="Arial" font-size="14">18.3 ms</text>
-	<rect x="476.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="264.0" fill="black" font-family="Arial" font-size="14">18.9 ms</text>
-	<rect x="608.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="264.0" fill="black" font-family="Arial" font-size="14">24.0 ms</text>
-	<rect x="740.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="264.0" fill="black" font-family="Arial" font-size="14">30.6 ms</text>
-	<rect x="872.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="264.0" fill="black" font-family="Arial" font-size="14">43.6 ms</text>
-	<rect x="1004.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1047.0" y="264.0" fill="black" font-family="Arial" font-size="14">68.5 ms</text>
-	<rect x="1136.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1183.0" y="264.0" fill="black" font-family="Arial" font-size="14">107 ms</text>
-	<rect x="0" y="280" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="304.0" fill="black" font-family="Arial" font-size="14">Bitwise operations (`&#38;`, `&#124;`, `^`)</text>
-	<rect x="344.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="304.0" fill="black" font-family="Arial" font-size="14">3.45 ms</text>
-	<rect x="476.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="523.0" y="304.0" fill="black" font-family="Arial" font-size="14">3.6 ms</text>
-	<rect x="608.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="304.0" fill="black" font-family="Arial" font-size="14">4.01 ms</text>
-	<rect x="740.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="304.0" fill="black" font-family="Arial" font-size="14">4.58 ms</text>
-	<rect x="872.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="304.0" fill="black" font-family="Arial" font-size="14">5.97 ms</text>
-	<rect x="1004.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1047.0" y="304.0" fill="black" font-family="Arial" font-size="14">11.2 ms</text>
-	<rect x="1136.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1179.0" y="304.0" fill="black" font-family="Arial" font-size="14">18.9 ms</text>
-	<rect x="0" y="320" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="344.0" fill="black" font-family="Arial" font-size="14">Div / Rem  (`/`, `%`)</text>
-	<rect x="344.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="344.0" fill="black" font-family="Arial" font-size="14">78.1 ms</text>
-	<rect x="476.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="523.0" y="344.0" fill="black" font-family="Arial" font-size="14">154 ms</text>
-	<rect x="608.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="655.0" y="344.0" fill="black" font-family="Arial" font-size="14">318 ms</text>
-	<rect x="740.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="787.0" y="344.0" fill="black" font-family="Arial" font-size="14">763 ms</text>
-	<rect x="872.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="919.0" y="344.0" fill="black" font-family="Arial" font-size="14">2.05 s</text>
-	<rect x="1004.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1051.0" y="344.0" fill="black" font-family="Arial" font-size="14">6.35 s</text>
-	<rect x="1136.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1183.0" y="344.0" fill="black" font-family="Arial" font-size="14">22.8 s</text>
-	<rect x="0" y="360" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="384.0" fill="black" font-family="Arial" font-size="14">Left / Right Shifts (`&#60;&#60;`, `&#62;&#62;`)</text>
-	<rect x="344.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="384.0" fill="black" font-family="Arial" font-size="14">17.7 ms</text>
-	<rect x="476.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="384.0" fill="black" font-family="Arial" font-size="14">22.9 ms</text>
-	<rect x="608.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="384.0" fill="black" font-family="Arial" font-size="14">30.4 ms</text>
-	<rect x="740.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="384.0" fill="black" font-family="Arial" font-size="14">43.4 ms</text>
-	<rect x="872.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="384.0" fill="black" font-family="Arial" font-size="14">86.7 ms</text>
-	<rect x="1004.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1051.0" y="384.0" fill="black" font-family="Arial" font-size="14">162 ms</text>
-	<rect x="1136.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1183.0" y="384.0" fill="black" font-family="Arial" font-size="14">280 ms</text>
-	<rect x="0" y="400" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="424.0" fill="black" font-family="Arial" font-size="14">Left / Right Rotations (`left_rotate`, `right_rotate`)</text>
-	<rect x="344.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="424.0" fill="black" font-family="Arial" font-size="14">17.7 ms</text>
-	<rect x="476.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="424.0" fill="black" font-family="Arial" font-size="14">22.9 ms</text>
-	<rect x="608.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="424.0" fill="black" font-family="Arial" font-size="14">30.3 ms</text>
-	<rect x="740.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="424.0" fill="black" font-family="Arial" font-size="14">43.4 ms</text>
-	<rect x="872.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="424.0" fill="black" font-family="Arial" font-size="14">86.8 ms</text>
-	<rect x="1004.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1051.0" y="424.0" fill="black" font-family="Arial" font-size="14">162 ms</text>
-	<rect x="1136.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1183.0" y="424.0" fill="black" font-family="Arial" font-size="14">280 ms</text>
-	<rect x="0" y="440" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="464.0" fill="black" font-family="Arial" font-size="14">Leading / Trailing zeros/ones</text>
-	<rect x="344.0" y="440" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="464.0" fill="black" font-family="Arial" font-size="14">29.0 ms</text>
-	<rect x="476.0" y="440" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="464.0" fill="black" font-family="Arial" font-size="14">25.1 ms</text>
-	<rect x="608.0" y="440" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="464.0" fill="black" font-family="Arial" font-size="14">33.8 ms</text>
-	<rect x="740.0" y="440" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="464.0" fill="black" font-family="Arial" font-size="14">44.4 ms</text>
-	<rect x="872.0" y="440" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="464.0" fill="black" font-family="Arial" font-size="14">62.3 ms</text>
-	<rect x="1004.0" y="440" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1051.0" y="464.0" fill="black" font-family="Arial" font-size="14">105 ms</text>
-	<rect x="1136.0" y="440" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1183.0" y="464.0" fill="black" font-family="Arial" font-size="14">195 ms</text>
-	<rect x="0" y="480" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="504.0" fill="black" font-family="Arial" font-size="14">Log2</text>
-	<rect x="344.0" y="480" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="504.0" fill="black" font-family="Arial" font-size="14">31.9 ms</text>
-	<rect x="476.0" y="480" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="504.0" fill="black" font-family="Arial" font-size="14">35.5 ms</text>
-	<rect x="608.0" y="480" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="504.0" fill="black" font-family="Arial" font-size="14">48.2 ms</text>
-	<rect x="740.0" y="480" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="504.0" fill="black" font-family="Arial" font-size="14">55.2 ms</text>
-	<rect x="872.0" y="480" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="504.0" fill="black" font-family="Arial" font-size="14">73.9 ms</text>
-	<rect x="1004.0" y="480" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1051.0" y="504.0" fill="black" font-family="Arial" font-size="14">113 ms</text>
-	<rect x="1136.0" y="480" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1183.0" y="504.0" fill="black" font-family="Arial" font-size="14">210 ms</text>
-	<rect x="0" y="520" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="544.0" fill="black" font-family="Arial" font-size="14">Select</text>
-	<rect x="344.0" y="520" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="544.0" fill="black" font-family="Arial" font-size="14">7.16 ms</text>
-	<rect x="476.0" y="520" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="544.0" fill="black" font-family="Arial" font-size="14">7.76 ms</text>
-	<rect x="608.0" y="520" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="544.0" fill="black" font-family="Arial" font-size="14">8.72 ms</text>
-	<rect x="740.0" y="520" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="544.0" fill="black" font-family="Arial" font-size="14">10.7 ms</text>
-	<rect x="872.0" y="520" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="544.0" fill="black" font-family="Arial" font-size="14">17.5 ms</text>
-	<rect x="1004.0" y="520" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1047.0" y="544.0" fill="black" font-family="Arial" font-size="14">30.5 ms</text>
-	<rect x="1136.0" y="520" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1179.0" y="544.0" fill="black" font-family="Arial" font-size="14">48.8 ms</text>
-
-    <!-- Borders -->
-    <line x1="0" y1="0" x2="0" y2="560" stroke="white" />
-	<line x1="344.0" y1="0" x2="344.0" y2="560" stroke="white" />
-	<line x1="476.0" y1="0" x2="476.0" y2="560" stroke="white" />
-	<line x1="608.0" y1="0" x2="608.0" y2="560" stroke="white" />
-	<line x1="740.0" y1="0" x2="740.0" y2="560" stroke="white" />
-	<line x1="872.0" y1="0" x2="872.0" y2="560" stroke="white" />
-	<line x1="1004.0" y1="0" x2="1004.0" y2="560" stroke="white" />
-	<line x1="1136.0" y1="0" x2="1136.0" y2="560" stroke="white" />
-	<line x1="0" y1="0" x2="1268.0" y2="0" stroke="white" />
-	<line x1="0" y1="40" x2="1268.0" y2="40" stroke="white" />
-	<line x1="0" y1="80" x2="1268.0" y2="80" stroke="white" />
-	<line x1="0" y1="120" x2="1268.0" y2="120" stroke="white" />
-	<line x1="0" y1="160" x2="1268.0" y2="160" stroke="white" />
-	<line x1="0" y1="200" x2="1268.0" y2="200" stroke="white" />
-	<line x1="0" y1="240" x2="1268.0" y2="240" stroke="white" />
-	<line x1="0" y1="280" x2="1268.0" y2="280" stroke="white" />
-	<line x1="0" y1="320" x2="1268.0" y2="320" stroke="white" />
-	<line x1="0" y1="360" x2="1268.0" y2="360" stroke="white" />
-	<line x1="0" y1="400" x2="1268.0" y2="400" stroke="white" />
-	<line x1="0" y1="440" x2="1268.0" y2="440" stroke="white" />
-	<line x1="0" y1="480" x2="1268.0" y2="480" stroke="white" />
-	<line x1="0" y1="520" x2="1268.0" y2="520" stroke="white" />
-	<line x1="0" y1="560" x2="1268.0" y2="560" stroke="white" />
+<?xml version="1.0" ?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 560" preserveAspectRatio="meet" width="100%" height="560">
+	<rect x="0" y="0" width="720" height="40" fill="black"/>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="6" y="20.0">Operation \ Size</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="342.0" y="13.333333333333334">FheUint</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="342.0" y="29.666666666666668">8</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="426.0" y="13.333333333333334">FheUint</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="426.0" y="29.666666666666668">16</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="510.0" y="13.333333333333334">FheUint</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="510.0" y="29.666666666666668">32</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="594.0" y="13.333333333333334">FheUint</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="594.0" y="29.666666666666668">64</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="678.0" y="13.333333333333334">FheUint</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="678.0" y="29.666666666666668">128</text>
+	<rect x="0" y="40" width="300" height="520" fill="#fbbc04"/>
+	<rect x="300" y="40" width="420" height="520" fill="#f3f3f3"/>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="60.0">Negation (-)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="60.0">11.2 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="60.0">12.5 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="60.0">17.7 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="60.0">25.2 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="60.0">51.1 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="100.0">Add / Sub (+,-)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="100.0">11.3 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="100.0">12.5 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="100.0">17.7 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="100.0">25.2 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="100.0">51.2 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="140.0">Mul (x)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="140.0">23.1 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="140.0">37.2 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="140.0">76.4 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="140.0">237 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="140.0">830 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="180.0">Equal / Not Equal (eq, ne)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="180.0">7.65 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="180.0">11.5 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="180.0">12.4 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="180.0">17.7 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="180.0">24.1 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="220.0">Comparisons (ge, gt, le, lt)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="220.0">11.4 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="220.0">15.3 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="220.0">20.1 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="220.0">26.2 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="220.0">38.0 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="260.0">Max / Min (max, min)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="260.0">18.9 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="260.0">24.0 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="260.0">30.6 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="260.0">43.6 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="260.0">68.5 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="300.0">Bitwise operations (&amp;, |, ^)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="300.0">3.6 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="300.0">4.01 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="300.0">4.58 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="300.0">5.97 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="300.0">11.2 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="340.0">Div / Rem  (/, %)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="340.0">154 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="340.0">318 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="340.0">763 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="340.0">2.05 s</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="340.0">6.35 s</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="380.0">Left / Right Shifts (&lt;&lt;, &gt;&gt;)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="380.0">22.9 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="380.0">30.4 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="380.0">43.4 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="380.0">86.7 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="380.0">162 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="420.0">Left / Right Rotations (left_rotate, right_rotate)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="420.0">22.9 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="420.0">30.3 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="420.0">43.4 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="420.0">86.8 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="420.0">162 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="460.0">Leading / Trailing zeros/ones</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="460.0">25.1 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="460.0">33.8 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="460.0">44.4 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="460.0">62.3 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="460.0">105 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="500.0">Log2</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="500.0">35.5 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="500.0">48.2 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="500.0">55.2 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="500.0">73.9 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="500.0">113 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="540.0">Select</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="540.0">7.76 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="540.0">8.72 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="540.0">10.7 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="540.0">17.5 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="540.0">30.5 ms</text>
+	<line stroke="white" stroke-width="2" x1="0" y1="0" x2="720" y2="0"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="40" x2="720" y2="40"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="80" x2="720" y2="80"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="120" x2="720" y2="120"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="160" x2="720" y2="160"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="200" x2="720" y2="200"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="240" x2="720" y2="240"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="280" x2="720" y2="280"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="320" x2="720" y2="320"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="360" x2="720" y2="360"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="400" x2="720" y2="400"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="440" x2="720" y2="440"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="480" x2="720" y2="480"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="520" x2="720" y2="520"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="0" x2="0" y2="560"/>
+	<line stroke="white" stroke-width="2" x1="300.0" y1="0" x2="300.0" y2="560"/>
+	<line stroke="white" stroke-width="2" x1="384.0" y1="0" x2="384.0" y2="560"/>
+	<line stroke="white" stroke-width="2" x1="468.0" y1="0" x2="468.0" y2="560"/>
+	<line stroke="white" stroke-width="2" x1="552.0" y1="0" x2="552.0" y2="560"/>
+	<line stroke="white" stroke-width="2" x1="636.0" y1="0" x2="636.0" y2="560"/>
+	<line stroke="white" stroke-width="2" x1="720.0" y1="0" x2="720.0" y2="560"/>
 </svg>

--- a/tfhe/docs/_static/gpu_integer_benchmark_h100x1_multi_bit_tuniform_2m64_plaintext.svg
+++ b/tfhe/docs/_static/gpu_integer_benchmark_h100x1_multi_bit_tuniform_2m64_plaintext.svg
@@ -1,196 +1,95 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1268.0" height="440" viewBox="0 0 1268.0 440">
-    <!-- Header Row -->
-    <rect x="0" y="0" width="1268.0" height="40" fill="black" />
-	<text x="10" y="24.0" fill="white" font-family="Arial" font-size="14">Operation \ Size</text>
-	<text x="383.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint4</text>
-	<text x="515.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint8</text>
-	<text x="643.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint16</text>
-	<text x="775.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint32</text>
-	<text x="907.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint64</text>
-	<text x="1035.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint128</text>
-	<text x="1167.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint256</text>
-
-    <!-- Data Rows -->
-    <rect x="0" y="40" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="64.0" fill="black" font-family="Arial" font-size="14">Add / Sub (`+`,`-`)</text>
-	<rect x="344.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="64.0" fill="black" font-family="Arial" font-size="14">11.1 ms</text>
-	<rect x="476.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="64.0" fill="black" font-family="Arial" font-size="14">11.4 ms</text>
-	<rect x="608.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="64.0" fill="black" font-family="Arial" font-size="14">12.6 ms</text>
-	<rect x="740.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="64.0" fill="black" font-family="Arial" font-size="14">17.8 ms</text>
-	<rect x="872.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="64.0" fill="black" font-family="Arial" font-size="14">25.4 ms</text>
-	<rect x="1004.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1047.0" y="64.0" fill="black" font-family="Arial" font-size="14">51.4 ms</text>
-	<rect x="1136.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1179.0" y="64.0" fill="black" font-family="Arial" font-size="14">83.1 ms</text>
-	<rect x="0" y="80" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="104.0" fill="black" font-family="Arial" font-size="14">Mul (`x`)</text>
-	<rect x="344.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="104.0" fill="black" font-family="Arial" font-size="14">11.4 ms</text>
-	<rect x="476.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="104.0" fill="black" font-family="Arial" font-size="14">18.1 ms</text>
-	<rect x="608.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="104.0" fill="black" font-family="Arial" font-size="14">26.1 ms</text>
-	<rect x="740.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="104.0" fill="black" font-family="Arial" font-size="14">46.6 ms</text>
-	<rect x="872.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="919.0" y="104.0" fill="black" font-family="Arial" font-size="14">109 ms</text>
-	<rect x="1004.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1051.0" y="104.0" fill="black" font-family="Arial" font-size="14">330 ms</text>
-	<rect x="1136.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1183.0" y="104.0" fill="black" font-family="Arial" font-size="14">1.17 s</text>
-	<rect x="0" y="120" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="144.0" fill="black" font-family="Arial" font-size="14">Equal / Not Equal (`eq`, `ne`)</text>
-	<rect x="344.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="144.0" fill="black" font-family="Arial" font-size="14">7.82 ms</text>
-	<rect x="476.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="144.0" fill="black" font-family="Arial" font-size="14">7.81 ms</text>
-	<rect x="608.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="144.0" fill="black" font-family="Arial" font-size="14">8.08 ms</text>
-	<rect x="740.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="144.0" fill="black" font-family="Arial" font-size="14">12.0 ms</text>
-	<rect x="872.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="144.0" fill="black" font-family="Arial" font-size="14">13.0 ms</text>
-	<rect x="1004.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1047.0" y="144.0" fill="black" font-family="Arial" font-size="14">18.8 ms</text>
-	<rect x="1136.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1179.0" y="144.0" fill="black" font-family="Arial" font-size="14">25.8 ms</text>
-	<rect x="0" y="160" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="184.0" fill="black" font-family="Arial" font-size="14">Comparisons  (`ge`, `gt`, `le`, `lt`)</text>
-	<rect x="344.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="184.0" fill="black" font-family="Arial" font-size="14">9.31 ms</text>
-	<rect x="476.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="184.0" fill="black" font-family="Arial" font-size="14">9.61 ms</text>
-	<rect x="608.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="184.0" fill="black" font-family="Arial" font-size="14">13.3 ms</text>
-	<rect x="740.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="184.0" fill="black" font-family="Arial" font-size="14">17.4 ms</text>
-	<rect x="872.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="184.0" fill="black" font-family="Arial" font-size="14">22.3 ms</text>
-	<rect x="1004.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1047.0" y="184.0" fill="black" font-family="Arial" font-size="14">29.0 ms</text>
-	<rect x="1136.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1179.0" y="184.0" fill="black" font-family="Arial" font-size="14">41.8 ms</text>
-	<rect x="0" y="200" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="224.0" fill="black" font-family="Arial" font-size="14">Max / Min   (`max`,`min`)</text>
-	<rect x="344.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="224.0" fill="black" font-family="Arial" font-size="14">16.5 ms</text>
-	<rect x="476.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="224.0" fill="black" font-family="Arial" font-size="14">17.3 ms</text>
-	<rect x="608.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="224.0" fill="black" font-family="Arial" font-size="14">21.9 ms</text>
-	<rect x="740.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="224.0" fill="black" font-family="Arial" font-size="14">28.1 ms</text>
-	<rect x="872.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="224.0" fill="black" font-family="Arial" font-size="14">39.7 ms</text>
-	<rect x="1004.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1047.0" y="224.0" fill="black" font-family="Arial" font-size="14">59.4 ms</text>
-	<rect x="1136.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1179.0" y="224.0" fill="black" font-family="Arial" font-size="14">90.7 ms</text>
-	<rect x="0" y="240" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="264.0" fill="black" font-family="Arial" font-size="14">Bitwise operations (`&#38;`, `&#124;`, `^`)</text>
-	<rect x="344.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="391.0" y="264.0" fill="black" font-family="Arial" font-size="14">3.3 ms</text>
-	<rect x="476.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="264.0" fill="black" font-family="Arial" font-size="14">3.63 ms</text>
-	<rect x="608.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="264.0" fill="black" font-family="Arial" font-size="14">4.11 ms</text>
-	<rect x="740.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="264.0" fill="black" font-family="Arial" font-size="14">4.65 ms</text>
-	<rect x="872.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="264.0" fill="black" font-family="Arial" font-size="14">6.03 ms</text>
-	<rect x="1004.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1047.0" y="264.0" fill="black" font-family="Arial" font-size="14">11.2 ms</text>
-	<rect x="1136.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1179.0" y="264.0" fill="black" font-family="Arial" font-size="14">19.0 ms</text>
-	<rect x="0" y="280" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="304.0" fill="black" font-family="Arial" font-size="14">Div  (`/`)</text>
-	<rect x="344.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="304.0" fill="black" font-family="Arial" font-size="14">16.3 ms</text>
-	<rect x="476.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="304.0" fill="black" font-family="Arial" font-size="14">28.4 ms</text>
-	<rect x="608.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="304.0" fill="black" font-family="Arial" font-size="14">41.6 ms</text>
-	<rect x="740.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="304.0" fill="black" font-family="Arial" font-size="14">83.7 ms</text>
-	<rect x="872.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="919.0" y="304.0" fill="black" font-family="Arial" font-size="14">214 ms</text>
-	<rect x="1004.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1051.0" y="304.0" fill="black" font-family="Arial" font-size="14">664 ms</text>
-	<rect x="1136.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1183.0" y="304.0" fill="black" font-family="Arial" font-size="14">2.34 s</text>
-	<rect x="0" y="320" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="344.0" fill="black" font-family="Arial" font-size="14">Rem  (`%`)</text>
-	<rect x="344.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="344.0" fill="black" font-family="Arial" font-size="14">35.5 ms</text>
-	<rect x="476.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="344.0" fill="black" font-family="Arial" font-size="14">56.5 ms</text>
-	<rect x="608.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="344.0" fill="black" font-family="Arial" font-size="14">80.6 ms</text>
-	<rect x="740.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="787.0" y="344.0" fill="black" font-family="Arial" font-size="14">149 ms</text>
-	<rect x="872.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="919.0" y="344.0" fill="black" font-family="Arial" font-size="14">351 ms</text>
-	<rect x="1004.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1051.0" y="344.0" fill="black" font-family="Arial" font-size="14">1.04 s</text>
-	<rect x="1136.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1183.0" y="344.0" fill="black" font-family="Arial" font-size="14">3.68 s</text>
-	<rect x="0" y="360" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="384.0" fill="black" font-family="Arial" font-size="14">Left / Right Shifts (`&#60;&#60;`, `&#62;&#62;`)</text>
-	<rect x="344.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="384.0" fill="black" font-family="Arial" font-size="14">3.49 ms</text>
-	<rect x="476.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="384.0" fill="black" font-family="Arial" font-size="14">3.63 ms</text>
-	<rect x="608.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="655.0" y="384.0" fill="black" font-family="Arial" font-size="14">4.1 ms</text>
-	<rect x="740.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="384.0" fill="black" font-family="Arial" font-size="14">4.63 ms</text>
-	<rect x="872.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="384.0" fill="black" font-family="Arial" font-size="14">6.03 ms</text>
-	<rect x="1004.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1047.0" y="384.0" fill="black" font-family="Arial" font-size="14">11.2 ms</text>
-	<rect x="1136.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1179.0" y="384.0" fill="black" font-family="Arial" font-size="14">19.0 ms</text>
-	<rect x="0" y="400" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="424.0" fill="black" font-family="Arial" font-size="14">Left / Right Rotations (`left_rotate`, `right_rotate`)</text>
-	<rect x="344.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="391.0" y="424.0" fill="black" font-family="Arial" font-size="14">3.5 ms</text>
-	<rect x="476.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="424.0" fill="black" font-family="Arial" font-size="14">3.63 ms</text>
-	<rect x="608.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="424.0" fill="black" font-family="Arial" font-size="14">4.11 ms</text>
-	<rect x="740.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="424.0" fill="black" font-family="Arial" font-size="14">4.64 ms</text>
-	<rect x="872.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="424.0" fill="black" font-family="Arial" font-size="14">6.03 ms</text>
-	<rect x="1004.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1047.0" y="424.0" fill="black" font-family="Arial" font-size="14">11.3 ms</text>
-	<rect x="1136.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1179.0" y="424.0" fill="black" font-family="Arial" font-size="14">19.0 ms</text>
-
-    <!-- Borders -->
-    <line x1="0" y1="0" x2="0" y2="440" stroke="white" />
-	<line x1="344.0" y1="0" x2="344.0" y2="440" stroke="white" />
-	<line x1="476.0" y1="0" x2="476.0" y2="440" stroke="white" />
-	<line x1="608.0" y1="0" x2="608.0" y2="440" stroke="white" />
-	<line x1="740.0" y1="0" x2="740.0" y2="440" stroke="white" />
-	<line x1="872.0" y1="0" x2="872.0" y2="440" stroke="white" />
-	<line x1="1004.0" y1="0" x2="1004.0" y2="440" stroke="white" />
-	<line x1="1136.0" y1="0" x2="1136.0" y2="440" stroke="white" />
-	<line x1="0" y1="0" x2="1268.0" y2="0" stroke="white" />
-	<line x1="0" y1="40" x2="1268.0" y2="40" stroke="white" />
-	<line x1="0" y1="80" x2="1268.0" y2="80" stroke="white" />
-	<line x1="0" y1="120" x2="1268.0" y2="120" stroke="white" />
-	<line x1="0" y1="160" x2="1268.0" y2="160" stroke="white" />
-	<line x1="0" y1="200" x2="1268.0" y2="200" stroke="white" />
-	<line x1="0" y1="240" x2="1268.0" y2="240" stroke="white" />
-	<line x1="0" y1="280" x2="1268.0" y2="280" stroke="white" />
-	<line x1="0" y1="320" x2="1268.0" y2="320" stroke="white" />
-	<line x1="0" y1="360" x2="1268.0" y2="360" stroke="white" />
-	<line x1="0" y1="400" x2="1268.0" y2="400" stroke="white" />
-	<line x1="0" y1="440" x2="1268.0" y2="440" stroke="white" />
+<?xml version="1.0" ?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 440" preserveAspectRatio="meet" width="100%" height="440">
+	<rect x="0" y="0" width="720" height="40" fill="black"/>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="6" y="20.0">Operation \ Size</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="342.0" y="13.333333333333334">FheUint</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="342.0" y="29.666666666666668">8</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="426.0" y="13.333333333333334">FheUint</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="426.0" y="29.666666666666668">16</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="510.0" y="13.333333333333334">FheUint</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="510.0" y="29.666666666666668">32</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="594.0" y="13.333333333333334">FheUint</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="594.0" y="29.666666666666668">64</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="678.0" y="13.333333333333334">FheUint</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="678.0" y="29.666666666666668">128</text>
+	<rect x="0" y="40" width="300" height="400" fill="#fbbc04"/>
+	<rect x="300" y="40" width="420" height="400" fill="#f3f3f3"/>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="60.0">Add / Sub (+,-)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="60.0">11.4 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="60.0">12.6 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="60.0">17.8 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="60.0">25.4 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="60.0">51.4 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="100.0">Mul (x)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="100.0">18.1 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="100.0">26.1 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="100.0">46.6 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="100.0">109 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="100.0">330 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="140.0">Equal / Not Equal (eq, ne)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="140.0">7.81 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="140.0">8.08 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="140.0">12.0 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="140.0">13.0 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="140.0">18.8 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="180.0">Comparisons (ge, gt, le, lt)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="180.0">9.61 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="180.0">13.3 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="180.0">17.4 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="180.0">22.3 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="180.0">29.0 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="220.0">Max / Min (max, min)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="220.0">17.3 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="220.0">21.9 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="220.0">28.1 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="220.0">39.7 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="220.0">59.4 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="260.0">Bitwise operations (&amp;, |, ^)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="260.0">3.63 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="260.0">4.11 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="260.0">4.65 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="260.0">6.03 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="260.0">11.2 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="300.0">Div  (/)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="300.0">28.4 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="300.0">41.6 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="300.0">83.7 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="300.0">214 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="300.0">664 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="340.0">Rem  (%)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="340.0">56.5 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="340.0">80.6 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="340.0">149 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="340.0">351 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="340.0">1.04 s</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="380.0">Left / Right Shifts (&lt;&lt;, &gt;&gt;)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="380.0">3.63 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="380.0">4.1 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="380.0">4.63 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="380.0">6.03 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="380.0">11.2 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="420.0">Left / Right Rotations (left_rotate, right_rotate)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="420.0">3.63 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="420.0">4.11 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="420.0">4.64 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="420.0">6.03 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="420.0">11.3 ms</text>
+	<line stroke="white" stroke-width="2" x1="0" y1="0" x2="720" y2="0"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="40" x2="720" y2="40"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="80" x2="720" y2="80"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="120" x2="720" y2="120"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="160" x2="720" y2="160"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="200" x2="720" y2="200"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="240" x2="720" y2="240"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="280" x2="720" y2="280"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="320" x2="720" y2="320"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="360" x2="720" y2="360"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="400" x2="720" y2="400"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="0" x2="0" y2="440"/>
+	<line stroke="white" stroke-width="2" x1="300.0" y1="0" x2="300.0" y2="440"/>
+	<line stroke="white" stroke-width="2" x1="384.0" y1="0" x2="384.0" y2="440"/>
+	<line stroke="white" stroke-width="2" x1="468.0" y1="0" x2="468.0" y2="440"/>
+	<line stroke="white" stroke-width="2" x1="552.0" y1="0" x2="552.0" y2="440"/>
+	<line stroke="white" stroke-width="2" x1="636.0" y1="0" x2="636.0" y2="440"/>
+	<line stroke="white" stroke-width="2" x1="720.0" y1="0" x2="720.0" y2="440"/>
 </svg>

--- a/tfhe/docs/_static/gpu_integer_benchmark_h100x2_multi_bit_tuniform_2m64_ciphertext.svg
+++ b/tfhe/docs/_static/gpu_integer_benchmark_h100x2_multi_bit_tuniform_2m64_ciphertext.svg
@@ -1,247 +1,116 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1268.0" height="560" viewBox="0 0 1268.0 560">
-    <!-- Header Row -->
-    <rect x="0" y="0" width="1268.0" height="40" fill="black" />
-	<text x="10" y="24.0" fill="white" font-family="Arial" font-size="14">Operation \ Size</text>
-	<text x="383.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint4</text>
-	<text x="515.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint8</text>
-	<text x="643.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint16</text>
-	<text x="775.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint32</text>
-	<text x="907.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint64</text>
-	<text x="1035.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint128</text>
-	<text x="1167.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint256</text>
-
-    <!-- Data Rows -->
-    <rect x="0" y="40" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="64.0" fill="black" font-family="Arial" font-size="14">Negation (`-`)</text>
-	<rect x="344.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="64.0" fill="black" font-family="Arial" font-size="14">11.2 ms</text>
-	<rect x="476.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="64.0" fill="black" font-family="Arial" font-size="14">11.4 ms</text>
-	<rect x="608.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="64.0" fill="black" font-family="Arial" font-size="14">11.6 ms</text>
-	<rect x="740.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="64.0" fill="black" font-family="Arial" font-size="14">16.4 ms</text>
-	<rect x="872.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="64.0" fill="black" font-family="Arial" font-size="14">21.9 ms</text>
-	<rect x="1004.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1047.0" y="64.0" fill="black" font-family="Arial" font-size="14">36.7 ms</text>
-	<rect x="1136.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1179.0" y="64.0" fill="black" font-family="Arial" font-size="14">57.6 ms</text>
-	<rect x="0" y="80" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="104.0" fill="black" font-family="Arial" font-size="14">Add / Sub (`+`,`-`)</text>
-	<rect x="344.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="104.0" fill="black" font-family="Arial" font-size="14">11.2 ms</text>
-	<rect x="476.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="104.0" fill="black" font-family="Arial" font-size="14">11.4 ms</text>
-	<rect x="608.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="104.0" fill="black" font-family="Arial" font-size="14">11.7 ms</text>
-	<rect x="740.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="104.0" fill="black" font-family="Arial" font-size="14">16.4 ms</text>
-	<rect x="872.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="104.0" fill="black" font-family="Arial" font-size="14">21.9 ms</text>
-	<rect x="1004.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1047.0" y="104.0" fill="black" font-family="Arial" font-size="14">36.7 ms</text>
-	<rect x="1136.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1179.0" y="104.0" fill="black" font-family="Arial" font-size="14">57.6 ms</text>
-	<rect x="0" y="120" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="144.0" fill="black" font-family="Arial" font-size="14">Mul (`x`)</text>
-	<rect x="344.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="144.0" fill="black" font-family="Arial" font-size="14">18.4 ms</text>
-	<rect x="476.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="144.0" fill="black" font-family="Arial" font-size="14">22.7 ms</text>
-	<rect x="608.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="144.0" fill="black" font-family="Arial" font-size="14">31.3 ms</text>
-	<rect x="740.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="144.0" fill="black" font-family="Arial" font-size="14">63.4 ms</text>
-	<rect x="872.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="919.0" y="144.0" fill="black" font-family="Arial" font-size="14">164 ms</text>
-	<rect x="1004.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1051.0" y="144.0" fill="black" font-family="Arial" font-size="14">545 ms</text>
-	<rect x="1136.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1183.0" y="144.0" fill="black" font-family="Arial" font-size="14">2.11 s</text>
-	<rect x="0" y="160" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="184.0" fill="black" font-family="Arial" font-size="14">Equal / Not Equal (`eq`, `ne`)</text>
-	<rect x="344.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="184.0" fill="black" font-family="Arial" font-size="14">7.81 ms</text>
-	<rect x="476.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="184.0" fill="black" font-family="Arial" font-size="14">7.95 ms</text>
-	<rect x="608.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="184.0" fill="black" font-family="Arial" font-size="14">11.6 ms</text>
-	<rect x="740.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="184.0" fill="black" font-family="Arial" font-size="14">12.3 ms</text>
-	<rect x="872.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="184.0" fill="black" font-family="Arial" font-size="14">16.8 ms</text>
-	<rect x="1004.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1047.0" y="184.0" fill="black" font-family="Arial" font-size="14">19.2 ms</text>
-	<rect x="1136.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1179.0" y="184.0" fill="black" font-family="Arial" font-size="14">30.2 ms</text>
-	<rect x="0" y="200" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="224.0" fill="black" font-family="Arial" font-size="14">Comparisons  (`ge`, `gt`, `le`, `lt`)</text>
-	<rect x="344.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="224.0" fill="black" font-family="Arial" font-size="14">11.6 ms</text>
-	<rect x="476.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="224.0" fill="black" font-family="Arial" font-size="14">11.7 ms</text>
-	<rect x="608.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="224.0" fill="black" font-family="Arial" font-size="14">15.3 ms</text>
-	<rect x="740.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="224.0" fill="black" font-family="Arial" font-size="14">19.7 ms</text>
-	<rect x="872.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="224.0" fill="black" font-family="Arial" font-size="14">24.6 ms</text>
-	<rect x="1004.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1047.0" y="224.0" fill="black" font-family="Arial" font-size="14">31.6 ms</text>
-	<rect x="1136.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1179.0" y="224.0" fill="black" font-family="Arial" font-size="14">45.8 ms</text>
-	<rect x="0" y="240" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="264.0" fill="black" font-family="Arial" font-size="14">Max / Min   (`max`,`min`)</text>
-	<rect x="344.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="264.0" fill="black" font-family="Arial" font-size="14">18.7 ms</text>
-	<rect x="476.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="264.0" fill="black" font-family="Arial" font-size="14">18.9 ms</text>
-	<rect x="608.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="264.0" fill="black" font-family="Arial" font-size="14">23.3 ms</text>
-	<rect x="740.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="264.0" fill="black" font-family="Arial" font-size="14">28.7 ms</text>
-	<rect x="872.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="264.0" fill="black" font-family="Arial" font-size="14">35.9 ms</text>
-	<rect x="1004.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1047.0" y="264.0" fill="black" font-family="Arial" font-size="14">50.0 ms</text>
-	<rect x="1136.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1179.0" y="264.0" fill="black" font-family="Arial" font-size="14">77.4 ms</text>
-	<rect x="0" y="280" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="304.0" fill="black" font-family="Arial" font-size="14">Bitwise operations (`&#38;`, `&#124;`, `^`)</text>
-	<rect x="344.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="304.0" fill="black" font-family="Arial" font-size="14">3.52 ms</text>
-	<rect x="476.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="304.0" fill="black" font-family="Arial" font-size="14">3.54 ms</text>
-	<rect x="608.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="304.0" fill="black" font-family="Arial" font-size="14">3.66 ms</text>
-	<rect x="740.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="304.0" fill="black" font-family="Arial" font-size="14">4.24 ms</text>
-	<rect x="872.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="304.0" fill="black" font-family="Arial" font-size="14">4.82 ms</text>
-	<rect x="1004.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1047.0" y="304.0" fill="black" font-family="Arial" font-size="14">6.43 ms</text>
-	<rect x="1136.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1179.0" y="304.0" fill="black" font-family="Arial" font-size="14">12.0 ms</text>
-	<rect x="0" y="320" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="344.0" fill="black" font-family="Arial" font-size="14">Div / Rem  (`/`, `%`)</text>
-	<rect x="344.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="391.0" y="344.0" fill="black" font-family="Arial" font-size="14">122 ms</text>
-	<rect x="476.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="523.0" y="344.0" fill="black" font-family="Arial" font-size="14">273 ms</text>
-	<rect x="608.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="655.0" y="344.0" fill="black" font-family="Arial" font-size="14">580 ms</text>
-	<rect x="740.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="787.0" y="344.0" fill="black" font-family="Arial" font-size="14">1.28 s</text>
-	<rect x="872.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="919.0" y="344.0" fill="black" font-family="Arial" font-size="14">2.97 s</text>
-	<rect x="1004.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1051.0" y="344.0" fill="black" font-family="Arial" font-size="14">7.41 s</text>
-	<rect x="1136.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1183.0" y="344.0" fill="black" font-family="Arial" font-size="14">20.4 s</text>
-	<rect x="0" y="360" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="384.0" fill="black" font-family="Arial" font-size="14">Left / Right Shifts (`&#60;&#60;`, `&#62;&#62;`)</text>
-	<rect x="344.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="384.0" fill="black" font-family="Arial" font-size="14">17.9 ms</text>
-	<rect x="476.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="384.0" fill="black" font-family="Arial" font-size="14">21.8 ms</text>
-	<rect x="608.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="384.0" fill="black" font-family="Arial" font-size="14">27.9 ms</text>
-	<rect x="740.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="384.0" fill="black" font-family="Arial" font-size="14">36.5 ms</text>
-	<rect x="872.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="384.0" fill="black" font-family="Arial" font-size="14">53.1 ms</text>
-	<rect x="1004.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1051.0" y="384.0" fill="black" font-family="Arial" font-size="14">106 ms</text>
-	<rect x="1136.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1183.0" y="384.0" fill="black" font-family="Arial" font-size="14">197 ms</text>
-	<rect x="0" y="400" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="424.0" fill="black" font-family="Arial" font-size="14">Left / Right Rotations (`left_rotate`, `right_rotate`)</text>
-	<rect x="344.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="424.0" fill="black" font-family="Arial" font-size="14">17.9 ms</text>
-	<rect x="476.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="424.0" fill="black" font-family="Arial" font-size="14">21.8 ms</text>
-	<rect x="608.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="424.0" fill="black" font-family="Arial" font-size="14">27.9 ms</text>
-	<rect x="740.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="424.0" fill="black" font-family="Arial" font-size="14">36.5 ms</text>
-	<rect x="872.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="424.0" fill="black" font-family="Arial" font-size="14">53.2 ms</text>
-	<rect x="1004.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1051.0" y="424.0" fill="black" font-family="Arial" font-size="14">106 ms</text>
-	<rect x="1136.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1183.0" y="424.0" fill="black" font-family="Arial" font-size="14">197 ms</text>
-	<rect x="0" y="440" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="464.0" fill="black" font-family="Arial" font-size="14">Leading / Trailing zeros/ones</text>
-	<rect x="344.0" y="440" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="464.0" fill="black" font-family="Arial" font-size="14">29.5 ms</text>
-	<rect x="476.0" y="440" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="464.0" fill="black" font-family="Arial" font-size="14">25.5 ms</text>
-	<rect x="608.0" y="440" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="464.0" fill="black" font-family="Arial" font-size="14">32.9 ms</text>
-	<rect x="740.0" y="440" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="464.0" fill="black" font-family="Arial" font-size="14">42.9 ms</text>
-	<rect x="872.0" y="440" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="464.0" fill="black" font-family="Arial" font-size="14">56.5 ms</text>
-	<rect x="1004.0" y="440" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1047.0" y="464.0" fill="black" font-family="Arial" font-size="14">78.5 ms</text>
-	<rect x="1136.0" y="440" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1183.0" y="464.0" fill="black" font-family="Arial" font-size="14">136 ms</text>
-	<rect x="0" y="480" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="504.0" fill="black" font-family="Arial" font-size="14">Log2</text>
-	<rect x="344.0" y="480" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="504.0" fill="black" font-family="Arial" font-size="14">32.6 ms</text>
-	<rect x="476.0" y="480" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="504.0" fill="black" font-family="Arial" font-size="14">43.8 ms</text>
-	<rect x="608.0" y="480" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="504.0" fill="black" font-family="Arial" font-size="14">57.7 ms</text>
-	<rect x="740.0" y="480" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="504.0" fill="black" font-family="Arial" font-size="14">99.5 ms</text>
-	<rect x="872.0" y="480" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="919.0" y="504.0" fill="black" font-family="Arial" font-size="14">280 ms</text>
-	<rect x="1004.0" y="480" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1051.0" y="504.0" fill="black" font-family="Arial" font-size="14">962 ms</text>
-	<rect x="1136.0" y="480" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1183.0" y="504.0" fill="black" font-family="Arial" font-size="14">4.78 s</text>
-	<rect x="0" y="520" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="544.0" fill="black" font-family="Arial" font-size="14">Select</text>
-	<rect x="344.0" y="520" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="544.0" fill="black" font-family="Arial" font-size="14">7.08 ms</text>
-	<rect x="476.0" y="520" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="544.0" fill="black" font-family="Arial" font-size="14">7.38 ms</text>
-	<rect x="608.0" y="520" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="544.0" fill="black" font-family="Arial" font-size="14">7.98 ms</text>
-	<rect x="740.0" y="520" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="544.0" fill="black" font-family="Arial" font-size="14">9.02 ms</text>
-	<rect x="872.0" y="520" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="544.0" fill="black" font-family="Arial" font-size="14">11.3 ms</text>
-	<rect x="1004.0" y="520" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1047.0" y="544.0" fill="black" font-family="Arial" font-size="14">18.6 ms</text>
-	<rect x="1136.0" y="520" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1179.0" y="544.0" fill="black" font-family="Arial" font-size="14">32.8 ms</text>
-
-    <!-- Borders -->
-    <line x1="0" y1="0" x2="0" y2="560" stroke="white" />
-	<line x1="344.0" y1="0" x2="344.0" y2="560" stroke="white" />
-	<line x1="476.0" y1="0" x2="476.0" y2="560" stroke="white" />
-	<line x1="608.0" y1="0" x2="608.0" y2="560" stroke="white" />
-	<line x1="740.0" y1="0" x2="740.0" y2="560" stroke="white" />
-	<line x1="872.0" y1="0" x2="872.0" y2="560" stroke="white" />
-	<line x1="1004.0" y1="0" x2="1004.0" y2="560" stroke="white" />
-	<line x1="1136.0" y1="0" x2="1136.0" y2="560" stroke="white" />
-	<line x1="0" y1="0" x2="1268.0" y2="0" stroke="white" />
-	<line x1="0" y1="40" x2="1268.0" y2="40" stroke="white" />
-	<line x1="0" y1="80" x2="1268.0" y2="80" stroke="white" />
-	<line x1="0" y1="120" x2="1268.0" y2="120" stroke="white" />
-	<line x1="0" y1="160" x2="1268.0" y2="160" stroke="white" />
-	<line x1="0" y1="200" x2="1268.0" y2="200" stroke="white" />
-	<line x1="0" y1="240" x2="1268.0" y2="240" stroke="white" />
-	<line x1="0" y1="280" x2="1268.0" y2="280" stroke="white" />
-	<line x1="0" y1="320" x2="1268.0" y2="320" stroke="white" />
-	<line x1="0" y1="360" x2="1268.0" y2="360" stroke="white" />
-	<line x1="0" y1="400" x2="1268.0" y2="400" stroke="white" />
-	<line x1="0" y1="440" x2="1268.0" y2="440" stroke="white" />
-	<line x1="0" y1="480" x2="1268.0" y2="480" stroke="white" />
-	<line x1="0" y1="520" x2="1268.0" y2="520" stroke="white" />
-	<line x1="0" y1="560" x2="1268.0" y2="560" stroke="white" />
+<?xml version="1.0" ?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 560" preserveAspectRatio="meet" width="100%" height="560">
+	<rect x="0" y="0" width="720" height="40" fill="black"/>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="6" y="20.0">Operation \ Size</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="342.0" y="13.333333333333334">FheUint</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="342.0" y="29.666666666666668">8</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="426.0" y="13.333333333333334">FheUint</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="426.0" y="29.666666666666668">16</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="510.0" y="13.333333333333334">FheUint</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="510.0" y="29.666666666666668">32</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="594.0" y="13.333333333333334">FheUint</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="594.0" y="29.666666666666668">64</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="678.0" y="13.333333333333334">FheUint</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="678.0" y="29.666666666666668">128</text>
+	<rect x="0" y="40" width="300" height="520" fill="#fbbc04"/>
+	<rect x="300" y="40" width="420" height="520" fill="#f3f3f3"/>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="60.0">Negation (-)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="60.0">11.4 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="60.0">11.6 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="60.0">16.4 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="60.0">21.9 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="60.0">36.7 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="100.0">Add / Sub (+,-)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="100.0">11.4 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="100.0">11.7 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="100.0">16.4 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="100.0">21.9 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="100.0">36.7 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="140.0">Mul (x)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="140.0">22.7 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="140.0">31.3 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="140.0">63.4 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="140.0">164 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="140.0">545 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="180.0">Equal / Not Equal (eq, ne)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="180.0">7.95 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="180.0">11.6 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="180.0">12.3 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="180.0">16.8 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="180.0">19.2 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="220.0">Comparisons (ge, gt, le, lt)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="220.0">11.7 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="220.0">15.3 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="220.0">19.7 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="220.0">24.6 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="220.0">31.6 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="260.0">Max / Min (max, min)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="260.0">18.9 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="260.0">23.3 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="260.0">28.7 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="260.0">35.9 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="260.0">50.0 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="300.0">Bitwise operations (&amp;, |, ^)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="300.0">3.54 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="300.0">3.66 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="300.0">4.24 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="300.0">4.82 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="300.0">6.43 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="340.0">Div / Rem  (/, %)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="340.0">273 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="340.0">580 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="340.0">1.28 s</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="340.0">2.97 s</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="340.0">7.41 s</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="380.0">Left / Right Shifts (&lt;&lt;, &gt;&gt;)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="380.0">21.8 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="380.0">27.9 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="380.0">36.5 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="380.0">53.1 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="380.0">106 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="420.0">Left / Right Rotations (left_rotate, right_rotate)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="420.0">21.8 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="420.0">27.9 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="420.0">36.5 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="420.0">53.2 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="420.0">106 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="460.0">Leading / Trailing zeros/ones</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="460.0">25.5 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="460.0">32.9 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="460.0">42.9 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="460.0">56.5 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="460.0">78.5 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="500.0">Log2</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="500.0">43.8 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="500.0">57.7 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="500.0">99.5 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="500.0">280 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="500.0">962 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="540.0">Select</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="540.0">7.38 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="540.0">7.98 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="540.0">9.02 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="540.0">11.3 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="540.0">18.6 ms</text>
+	<line stroke="white" stroke-width="2" x1="0" y1="0" x2="720" y2="0"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="40" x2="720" y2="40"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="80" x2="720" y2="80"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="120" x2="720" y2="120"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="160" x2="720" y2="160"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="200" x2="720" y2="200"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="240" x2="720" y2="240"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="280" x2="720" y2="280"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="320" x2="720" y2="320"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="360" x2="720" y2="360"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="400" x2="720" y2="400"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="440" x2="720" y2="440"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="480" x2="720" y2="480"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="520" x2="720" y2="520"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="0" x2="0" y2="560"/>
+	<line stroke="white" stroke-width="2" x1="300.0" y1="0" x2="300.0" y2="560"/>
+	<line stroke="white" stroke-width="2" x1="384.0" y1="0" x2="384.0" y2="560"/>
+	<line stroke="white" stroke-width="2" x1="468.0" y1="0" x2="468.0" y2="560"/>
+	<line stroke="white" stroke-width="2" x1="552.0" y1="0" x2="552.0" y2="560"/>
+	<line stroke="white" stroke-width="2" x1="636.0" y1="0" x2="636.0" y2="560"/>
+	<line stroke="white" stroke-width="2" x1="720.0" y1="0" x2="720.0" y2="560"/>
 </svg>

--- a/tfhe/docs/_static/gpu_integer_benchmark_h100x2_multi_bit_tuniform_2m64_plaintext.svg
+++ b/tfhe/docs/_static/gpu_integer_benchmark_h100x2_multi_bit_tuniform_2m64_plaintext.svg
@@ -1,196 +1,95 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1268.0" height="440" viewBox="0 0 1268.0 440">
-    <!-- Header Row -->
-    <rect x="0" y="0" width="1268.0" height="40" fill="black" />
-	<text x="10" y="24.0" fill="white" font-family="Arial" font-size="14">Operation \ Size</text>
-	<text x="383.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint4</text>
-	<text x="515.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint8</text>
-	<text x="643.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint16</text>
-	<text x="775.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint32</text>
-	<text x="907.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint64</text>
-	<text x="1035.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint128</text>
-	<text x="1167.0" y="24.0" fill="white" font-family="Arial" font-size="14">FheUint256</text>
-
-    <!-- Data Rows -->
-    <rect x="0" y="40" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="64.0" fill="black" font-family="Arial" font-size="14">Add / Sub (`+`,`-`)</text>
-	<rect x="344.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="64.0" fill="black" font-family="Arial" font-size="14">11.2 ms</text>
-	<rect x="476.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="64.0" fill="black" font-family="Arial" font-size="14">11.4 ms</text>
-	<rect x="608.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="64.0" fill="black" font-family="Arial" font-size="14">11.7 ms</text>
-	<rect x="740.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="64.0" fill="black" font-family="Arial" font-size="14">16.5 ms</text>
-	<rect x="872.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="64.0" fill="black" font-family="Arial" font-size="14">22.0 ms</text>
-	<rect x="1004.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1047.0" y="64.0" fill="black" font-family="Arial" font-size="14">36.8 ms</text>
-	<rect x="1136.0" y="40" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1179.0" y="64.0" fill="black" font-family="Arial" font-size="14">57.8 ms</text>
-	<rect x="0" y="80" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="104.0" fill="black" font-family="Arial" font-size="14">Mul (`x`)</text>
-	<rect x="344.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="104.0" fill="black" font-family="Arial" font-size="14">11.5 ms</text>
-	<rect x="476.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="104.0" fill="black" font-family="Arial" font-size="14">18.1 ms</text>
-	<rect x="608.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="104.0" fill="black" font-family="Arial" font-size="14">24.9 ms</text>
-	<rect x="740.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="104.0" fill="black" font-family="Arial" font-size="14">41.7 ms</text>
-	<rect x="872.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="104.0" fill="black" font-family="Arial" font-size="14">93.5 ms</text>
-	<rect x="1004.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1051.0" y="104.0" fill="black" font-family="Arial" font-size="14">271 ms</text>
-	<rect x="1136.0" y="80" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1183.0" y="104.0" fill="black" font-family="Arial" font-size="14">991 ms</text>
-	<rect x="0" y="120" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="144.0" fill="black" font-family="Arial" font-size="14">Equal / Not Equal (`eq`, `ne`)</text>
-	<rect x="344.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="144.0" fill="black" font-family="Arial" font-size="14">8.04 ms</text>
-	<rect x="476.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="144.0" fill="black" font-family="Arial" font-size="14">8.26 ms</text>
-	<rect x="608.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="144.0" fill="black" font-family="Arial" font-size="14">8.53 ms</text>
-	<rect x="740.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="144.0" fill="black" font-family="Arial" font-size="14">12.4 ms</text>
-	<rect x="872.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="144.0" fill="black" font-family="Arial" font-size="14">13.2 ms</text>
-	<rect x="1004.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1047.0" y="144.0" fill="black" font-family="Arial" font-size="14">18.0 ms</text>
-	<rect x="1136.0" y="120" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1179.0" y="144.0" fill="black" font-family="Arial" font-size="14">21.3 ms</text>
-	<rect x="0" y="160" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="184.0" fill="black" font-family="Arial" font-size="14">Comparisons  (`ge`, `gt`, `le`, `lt`)</text>
-	<rect x="344.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="391.0" y="184.0" fill="black" font-family="Arial" font-size="14">9.6 ms</text>
-	<rect x="476.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="184.0" fill="black" font-family="Arial" font-size="14">9.95 ms</text>
-	<rect x="608.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="184.0" fill="black" font-family="Arial" font-size="14">13.7 ms</text>
-	<rect x="740.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="184.0" fill="black" font-family="Arial" font-size="14">17.4 ms</text>
-	<rect x="872.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="184.0" fill="black" font-family="Arial" font-size="14">21.7 ms</text>
-	<rect x="1004.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1047.0" y="184.0" fill="black" font-family="Arial" font-size="14">27.4 ms</text>
-	<rect x="1136.0" y="160" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1179.0" y="184.0" fill="black" font-family="Arial" font-size="14">35.3 ms</text>
-	<rect x="0" y="200" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="224.0" fill="black" font-family="Arial" font-size="14">Max / Min   (`max`,`min`)</text>
-	<rect x="344.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="224.0" fill="black" font-family="Arial" font-size="14">16.8 ms</text>
-	<rect x="476.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="224.0" fill="black" font-family="Arial" font-size="14">17.0 ms</text>
-	<rect x="608.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="224.0" fill="black" font-family="Arial" font-size="14">21.6 ms</text>
-	<rect x="740.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="224.0" fill="black" font-family="Arial" font-size="14">26.4 ms</text>
-	<rect x="872.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="224.0" fill="black" font-family="Arial" font-size="14">33.4 ms</text>
-	<rect x="1004.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1047.0" y="224.0" fill="black" font-family="Arial" font-size="14">46.2 ms</text>
-	<rect x="1136.0" y="200" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1179.0" y="224.0" fill="black" font-family="Arial" font-size="14">68.1 ms</text>
-	<rect x="0" y="240" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="264.0" fill="black" font-family="Arial" font-size="14">Bitwise operations (`&#38;`, `&#124;`, `^`)</text>
-	<rect x="344.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="264.0" fill="black" font-family="Arial" font-size="14">3.41 ms</text>
-	<rect x="476.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="264.0" fill="black" font-family="Arial" font-size="14">3.64 ms</text>
-	<rect x="608.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="264.0" fill="black" font-family="Arial" font-size="14">3.79 ms</text>
-	<rect x="740.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="264.0" fill="black" font-family="Arial" font-size="14">4.36 ms</text>
-	<rect x="872.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="264.0" fill="black" font-family="Arial" font-size="14">4.91 ms</text>
-	<rect x="1004.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1047.0" y="264.0" fill="black" font-family="Arial" font-size="14">6.54 ms</text>
-	<rect x="1136.0" y="240" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1179.0" y="264.0" fill="black" font-family="Arial" font-size="14">12.1 ms</text>
-	<rect x="0" y="280" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="304.0" fill="black" font-family="Arial" font-size="14">Div  (`/`)</text>
-	<rect x="344.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="304.0" fill="black" font-family="Arial" font-size="14">15.7 ms</text>
-	<rect x="476.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="304.0" fill="black" font-family="Arial" font-size="14">26.7 ms</text>
-	<rect x="608.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="304.0" fill="black" font-family="Arial" font-size="14">39.4 ms</text>
-	<rect x="740.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="304.0" fill="black" font-family="Arial" font-size="14">71.8 ms</text>
-	<rect x="872.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="919.0" y="304.0" fill="black" font-family="Arial" font-size="14">176 ms</text>
-	<rect x="1004.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1051.0" y="304.0" fill="black" font-family="Arial" font-size="14">544 ms</text>
-	<rect x="1136.0" y="280" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1183.0" y="304.0" fill="black" font-family="Arial" font-size="14">1.99 s</text>
-	<rect x="0" y="320" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="344.0" fill="black" font-family="Arial" font-size="14">Rem  (`%`)</text>
-	<rect x="344.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="344.0" fill="black" font-family="Arial" font-size="14">36.4 ms</text>
-	<rect x="476.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="344.0" fill="black" font-family="Arial" font-size="14">56.9 ms</text>
-	<rect x="608.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="344.0" fill="black" font-family="Arial" font-size="14">77.4 ms</text>
-	<rect x="740.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="787.0" y="344.0" fill="black" font-family="Arial" font-size="14">131 ms</text>
-	<rect x="872.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="919.0" y="344.0" fill="black" font-family="Arial" font-size="14">292 ms</text>
-	<rect x="1004.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1051.0" y="344.0" fill="black" font-family="Arial" font-size="14">839 ms</text>
-	<rect x="1136.0" y="320" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1183.0" y="344.0" fill="black" font-family="Arial" font-size="14">2.97 s</text>
-	<rect x="0" y="360" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="384.0" fill="black" font-family="Arial" font-size="14">Left / Right Shifts (`&#60;&#60;`, `&#62;&#62;`)</text>
-	<rect x="344.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="384.0" fill="black" font-family="Arial" font-size="14">3.54 ms</text>
-	<rect x="476.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="384.0" fill="black" font-family="Arial" font-size="14">3.55 ms</text>
-	<rect x="608.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="655.0" y="384.0" fill="black" font-family="Arial" font-size="14">3.7 ms</text>
-	<rect x="740.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="384.0" fill="black" font-family="Arial" font-size="14">4.28 ms</text>
-	<rect x="872.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="384.0" fill="black" font-family="Arial" font-size="14">4.82 ms</text>
-	<rect x="1004.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1047.0" y="384.0" fill="black" font-family="Arial" font-size="14">6.45 ms</text>
-	<rect x="1136.0" y="360" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1179.0" y="384.0" fill="black" font-family="Arial" font-size="14">11.9 ms</text>
-	<rect x="0" y="400" width="1268.0" height="40" fill="#fbbc04" />
-	<text x="10" y="424.0" fill="black" font-family="Arial" font-size="14">Left / Right Rotations (`left_rotate`, `right_rotate`)</text>
-	<rect x="344.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="387.0" y="424.0" fill="black" font-family="Arial" font-size="14">3.54 ms</text>
-	<rect x="476.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="519.0" y="424.0" fill="black" font-family="Arial" font-size="14">3.55 ms</text>
-	<rect x="608.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="651.0" y="424.0" fill="black" font-family="Arial" font-size="14">3.71 ms</text>
-	<rect x="740.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="783.0" y="424.0" fill="black" font-family="Arial" font-size="14">4.28 ms</text>
-	<rect x="872.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="915.0" y="424.0" fill="black" font-family="Arial" font-size="14">4.82 ms</text>
-	<rect x="1004.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1047.0" y="424.0" fill="black" font-family="Arial" font-size="14">6.46 ms</text>
-	<rect x="1136.0" y="400" width="1268.0" height="40" fill="#f3f3f3" />
-	<text x="1179.0" y="424.0" fill="black" font-family="Arial" font-size="14">12.0 ms</text>
-
-    <!-- Borders -->
-    <line x1="0" y1="0" x2="0" y2="440" stroke="white" />
-	<line x1="344.0" y1="0" x2="344.0" y2="440" stroke="white" />
-	<line x1="476.0" y1="0" x2="476.0" y2="440" stroke="white" />
-	<line x1="608.0" y1="0" x2="608.0" y2="440" stroke="white" />
-	<line x1="740.0" y1="0" x2="740.0" y2="440" stroke="white" />
-	<line x1="872.0" y1="0" x2="872.0" y2="440" stroke="white" />
-	<line x1="1004.0" y1="0" x2="1004.0" y2="440" stroke="white" />
-	<line x1="1136.0" y1="0" x2="1136.0" y2="440" stroke="white" />
-	<line x1="0" y1="0" x2="1268.0" y2="0" stroke="white" />
-	<line x1="0" y1="40" x2="1268.0" y2="40" stroke="white" />
-	<line x1="0" y1="80" x2="1268.0" y2="80" stroke="white" />
-	<line x1="0" y1="120" x2="1268.0" y2="120" stroke="white" />
-	<line x1="0" y1="160" x2="1268.0" y2="160" stroke="white" />
-	<line x1="0" y1="200" x2="1268.0" y2="200" stroke="white" />
-	<line x1="0" y1="240" x2="1268.0" y2="240" stroke="white" />
-	<line x1="0" y1="280" x2="1268.0" y2="280" stroke="white" />
-	<line x1="0" y1="320" x2="1268.0" y2="320" stroke="white" />
-	<line x1="0" y1="360" x2="1268.0" y2="360" stroke="white" />
-	<line x1="0" y1="400" x2="1268.0" y2="400" stroke="white" />
-	<line x1="0" y1="440" x2="1268.0" y2="440" stroke="white" />
+<?xml version="1.0" ?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 440" preserveAspectRatio="meet" width="100%" height="440">
+	<rect x="0" y="0" width="720" height="40" fill="black"/>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="6" y="20.0">Operation \ Size</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="342.0" y="13.333333333333334">FheUint</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="342.0" y="29.666666666666668">8</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="426.0" y="13.333333333333334">FheUint</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="426.0" y="29.666666666666668">16</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="510.0" y="13.333333333333334">FheUint</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="510.0" y="29.666666666666668">32</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="594.0" y="13.333333333333334">FheUint</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="594.0" y="29.666666666666668">64</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="678.0" y="13.333333333333334">FheUint</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="678.0" y="29.666666666666668">128</text>
+	<rect x="0" y="40" width="300" height="400" fill="#fbbc04"/>
+	<rect x="300" y="40" width="420" height="400" fill="#f3f3f3"/>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="60.0">Add / Sub (+,-)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="60.0">11.4 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="60.0">11.7 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="60.0">16.5 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="60.0">22.0 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="60.0">36.8 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="100.0">Mul (x)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="100.0">18.1 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="100.0">24.9 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="100.0">41.7 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="100.0">93.5 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="100.0">271 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="140.0">Equal / Not Equal (eq, ne)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="140.0">8.26 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="140.0">8.53 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="140.0">12.4 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="140.0">13.2 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="140.0">18.0 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="180.0">Comparisons (ge, gt, le, lt)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="180.0">9.95 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="180.0">13.7 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="180.0">17.4 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="180.0">21.7 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="180.0">27.4 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="220.0">Max / Min (max, min)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="220.0">17.0 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="220.0">21.6 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="220.0">26.4 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="220.0">33.4 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="220.0">46.2 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="260.0">Bitwise operations (&amp;, |, ^)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="260.0">3.64 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="260.0">3.79 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="260.0">4.36 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="260.0">4.91 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="260.0">6.54 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="300.0">Div  (/)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="300.0">26.7 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="300.0">39.4 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="300.0">71.8 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="300.0">176 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="300.0">544 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="340.0">Rem  (%)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="340.0">56.9 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="340.0">77.4 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="340.0">131 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="340.0">292 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="340.0">839 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="380.0">Left / Right Shifts (&lt;&lt;, &gt;&gt;)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="380.0">3.55 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="380.0">3.7 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="380.0">4.28 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="380.0">4.82 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="380.0">6.45 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="420.0">Left / Right Rotations (left_rotate, right_rotate)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="342.0" y="420.0">3.55 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="426.0" y="420.0">3.71 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="420.0">4.28 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="594.0" y="420.0">4.82 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="678.0" y="420.0">6.46 ms</text>
+	<line stroke="white" stroke-width="2" x1="0" y1="0" x2="720" y2="0"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="40" x2="720" y2="40"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="80" x2="720" y2="80"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="120" x2="720" y2="120"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="160" x2="720" y2="160"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="200" x2="720" y2="200"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="240" x2="720" y2="240"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="280" x2="720" y2="280"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="320" x2="720" y2="320"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="360" x2="720" y2="360"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="400" x2="720" y2="400"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="0" x2="0" y2="440"/>
+	<line stroke="white" stroke-width="2" x1="300.0" y1="0" x2="300.0" y2="440"/>
+	<line stroke="white" stroke-width="2" x1="384.0" y1="0" x2="384.0" y2="440"/>
+	<line stroke="white" stroke-width="2" x1="468.0" y1="0" x2="468.0" y2="440"/>
+	<line stroke="white" stroke-width="2" x1="552.0" y1="0" x2="552.0" y2="440"/>
+	<line stroke="white" stroke-width="2" x1="636.0" y1="0" x2="636.0" y2="440"/>
+	<line stroke="white" stroke-width="2" x1="720.0" y1="0" x2="720.0" y2="440"/>
 </svg>

--- a/tfhe/docs/getting_started/benchmarks/README.md
+++ b/tfhe/docs/getting_started/benchmarks/README.md
@@ -12,4 +12,4 @@ make print_doc_bench_parameters
 
 ### Operation time over FheUint 64
 
-![Click to enlarge](../../_static/cpu_gpu_integer_benchmark_fheuint64_tuniform_2m64_ciphertext.svg)
+![](../../_static/cpu_gpu_integer_benchmark_fheuint64_tuniform_2m64_ciphertext.svg)

--- a/tfhe/docs/getting_started/benchmarks/cpu/cpu_integer_operations.md
+++ b/tfhe/docs/getting_started/benchmarks/cpu/cpu_integer_operations.md
@@ -14,21 +14,21 @@ The following tables benchmark the execution time of some operation sets using `
 
 The next table shows the operation timings on CPU when all inputs are encrypted:
 
-![Click to enlarge](../../../_static/cpu_integer_benchmark_tuniform_2m64_ciphertext.svg)
+![](../../../_static/cpu_integer_benchmark_tuniform_2m64_ciphertext.svg)
 
 The next table shows the operation timings on CPU when the left input is encrypted and the right is a clear scalar of the same size:
 
-![Click to enlarge](../../../_static/cpu_integer_benchmark_tuniform_2m64_plaintext.svg)
+![](../../../_static/cpu_integer_benchmark_tuniform_2m64_plaintext.svg)
 
 ## Pfail: $$2^{-128}$$
 
 The next table shows the operation timings on CPU when all inputs are encrypted:
 
-![Click to enlarge](../../../_static/cpu_integer_benchmark_tuniform_2m128_ciphertext.svg)
+![](../../../_static/cpu_integer_benchmark_tuniform_2m128_ciphertext.svg)
 
 The next table shows the operation timings on CPU when the left input is encrypted and the right is a clear scalar of the same size:
 
-![Click to enlarge](../../../_static/cpu_integer_benchmark_tuniform_2m128_plaintext.svg)
+![](../../../_static/cpu_integer_benchmark_tuniform_2m128_plaintext.svg)
 
 All timings are based on parallelized Radix-based integer operations where each block is encrypted using the default parameters `PARAM_MESSAGE_2_CARRY_2_KS_PBS`. To ensure predictable timings, we perform operations in the `default` mode, which ensures that the input and output encoding are similar (i.e., the carries are always emptied).
 

--- a/tfhe/docs/getting_started/benchmarks/cpu/cpu_programmable_bootstrapping.md
+++ b/tfhe/docs/getting_started/benchmarks/cpu/cpu_programmable_bootstrapping.md
@@ -13,15 +13,15 @@ Note that these benchmarks use Gaussian parameters. `MB-PBS` stands for multi-bi
 
 ## P-fail: $$2^{-40}$$
 
-![Click to enlarge](../../../_static/cpu_pbs_benchmark_tuniform_2m40.svg)
+![](../../../_static/cpu_pbs_benchmark_tuniform_2m40.svg)
 
 ## P-fail: $$2^{-64}$$
 
-![Click to enlarge](../../../_static/cpu_pbs_benchmark_tuniform_2m64.svg)
+![](../../../_static/cpu_pbs_benchmark_tuniform_2m64.svg)
 
 ## P-fail: $$2^{-128}$$
 
-![Click to enlarge](../../../_static/cpu_pbs_benchmark_tuniform_2m128.svg)
+![](../../../_static/cpu_pbs_benchmark_tuniform_2m128.svg)
 
 ## Reproducing TFHE-rs benchmarks
 

--- a/tfhe/docs/getting_started/benchmarks/gpu/gpu_integer_operations.md
+++ b/tfhe/docs/getting_started/benchmarks/gpu/gpu_integer_operations.md
@@ -12,22 +12,22 @@ The cryptographic parameters `PARAM_GPU_MULTI_BIT_MESSAGE_2_CARRY_2_GROUP_3_KS_P
 Below come the results for the execution on a single H100.
 The following table shows the performance when the inputs of the benchmarked operation are encrypted:
 
-![Click to enlarge](../../../_static/gpu_integer_benchmark_h100x1_multi_bit_tuniform_2m64_ciphertext.svg)
+![](../../../_static/gpu_integer_benchmark_h100x1_multi_bit_tuniform_2m64_ciphertext.svg)
 
 The following table shows the performance when the left input of the benchmarked operation is encrypted and the other is a clear scalar of the same size:
 
-![Click to enlarge](../../../_static/gpu_integer_benchmark_h100x1_multi_bit_tuniform_2m64_plaintext.svg)
+![](../../../_static/gpu_integer_benchmark_h100x1_multi_bit_tuniform_2m64_plaintext.svg)
 
 ## 2xH100
 
 Below come the results for the execution on two H100's.
 The following table shows the performance when the inputs of the benchmarked operation are encrypted:
 
-![Click to enlarge](../../../_static/gpu_integer_benchmark_h100x2_multi_bit_tuniform_2m64_ciphertext.svg)
+![](../../../_static/gpu_integer_benchmark_h100x2_multi_bit_tuniform_2m64_ciphertext.svg)
 
 The following table shows the performance when the left input of the benchmarked operation is encrypted and the other is a clear scalar of the same size:
 
-![Click to enlarge](../../../_static/gpu_integer_benchmark_h100x2_multi_bit_tuniform_2m64_plaintext.svg)
+![](../../../_static/gpu_integer_benchmark_h100x2_multi_bit_tuniform_2m64_plaintext.svg)
 
 ## Reproducing TFHE-rs benchmarks
 

--- a/tfhe/docs/getting_started/benchmarks/gpu/gpu_programmable_bootstrapping.md
+++ b/tfhe/docs/getting_started/benchmarks/gpu/gpu_programmable_bootstrapping.md
@@ -8,11 +8,11 @@ All GPU benchmarks were launched on H100 GPUs, and rely on the multithreaded PBS
 
 ## P-fail: $$2^{-40}$$
 
-![Click to enlarge](../../../_static/gpu_pbs_benchmark_tuniform_2m40.svg)
+![](../../../_static/gpu_pbs_benchmark_tuniform_2m40.svg)
 
 ## P-fail: $$2^{-64}$$
 
-![Click to enlarge](../../../_static/gpu_pbs_benchmark_tuniform_2m64.svg)
+![](../../../_static/gpu_pbs_benchmark_tuniform_2m64.svg)
 
 ## Reproducing TFHE-rs benchmarks
 


### PR DESCRIPTION
Reduce number of FheUint types displayed in the integer benchmark tables. Increase policy size and better columns fitting. Remove link to enlarge image.

