### PR TITLE
docs: change svg benchmark tables appearance for pbs

### DIFF
--- a/tfhe/docs/_static/cpu_pbs_benchmark_tuniform_2m128.svg
+++ b/tfhe/docs/_static/cpu_pbs_benchmark_tuniform_2m128.svg
@@ -1,42 +1,30 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="562.0" height="120" viewBox="0 0 562.0 120">
-    <!-- Header Row -->
-    <rect x="0" y="0" width="562.0" height="40" fill="black" />
-	<text x="10" y="24.0" fill="white" font-family="Arial" font-size="14">Operation \ Precision(bits)</text>
-	<text x="241.0" y="24.0" fill="white" font-family="Arial" font-size="14">2</text>
-	<text x="333.0" y="24.0" fill="white" font-family="Arial" font-size="14">4</text>
-	<text x="425.0" y="24.0" fill="white" font-family="Arial" font-size="14">6</text>
-	<text x="517.0" y="24.0" fill="white" font-family="Arial" font-size="14">8</text>
-
-    <!-- Data Rows -->
-    <rect x="0" y="40" width="562.0" height="40" fill="#fbbc04" />
-	<text x="10" y="64.0" fill="black" font-family="Arial" font-size="14">PBS</text>
-	<rect x="194.0" y="40" width="562.0" height="40" fill="#f3f3f3" />
-	<text x="217.0" y="64.0" fill="black" font-family="Arial" font-size="14">9.61 ms</text>
-	<rect x="286.0" y="40" width="562.0" height="40" fill="#f3f3f3" />
-	<text x="309.0" y="64.0" fill="black" font-family="Arial" font-size="14">12.4 ms</text>
-	<rect x="378.0" y="40" width="562.0" height="40" fill="#f3f3f3" />
-	<text x="405.0" y="64.0" fill="black" font-family="Arial" font-size="14">111 ms</text>
-	<rect x="470.0" y="40" width="562.0" height="40" fill="#f3f3f3" />
-	<text x="501.0" y="64.0" fill="black" font-family="Arial" font-size="14">1.5 s</text>
-	<rect x="0" y="80" width="562.0" height="40" fill="#fbbc04" />
-	<text x="10" y="104.0" fill="black" font-family="Arial" font-size="14">KS - PBS</text>
-	<rect x="194.0" y="80" width="562.0" height="40" fill="#f3f3f3" />
-	<text x="217.0" y="104.0" fill="black" font-family="Arial" font-size="14">10.9 ms</text>
-	<rect x="286.0" y="80" width="562.0" height="40" fill="#f3f3f3" />
-	<text x="309.0" y="104.0" fill="black" font-family="Arial" font-size="14">14.6 ms</text>
-	<rect x="378.0" y="80" width="562.0" height="40" fill="#f3f3f3" />
-	<text x="405.0" y="104.0" fill="black" font-family="Arial" font-size="14">129 ms</text>
-	<rect x="470.0" y="80" width="562.0" height="40" fill="#f3f3f3" />
-	<text x="497.0" y="104.0" fill="black" font-family="Arial" font-size="14">1.44 s</text>
-
-    <!-- Borders -->
-    <line x1="0" y1="0" x2="0" y2="120" stroke="white" />
-	<line x1="194.0" y1="0" x2="194.0" y2="120" stroke="white" />
-	<line x1="286.0" y1="0" x2="286.0" y2="120" stroke="white" />
-	<line x1="378.0" y1="0" x2="378.0" y2="120" stroke="white" />
-	<line x1="470.0" y1="0" x2="470.0" y2="120" stroke="white" />
-	<line x1="0" y1="0" x2="562.0" y2="0" stroke="white" />
-	<line x1="0" y1="40" x2="562.0" y2="40" stroke="white" />
-	<line x1="0" y1="80" x2="562.0" y2="80" stroke="white" />
-	<line x1="0" y1="120" x2="562.0" y2="120" stroke="white" />
+<?xml version="1.0" ?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 120" preserveAspectRatio="meet" width="100%" height="120">
+	<rect x="0" y="0" width="720" height="40" fill="black"/>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="6" y="20.0">Operation \ Precision (bits)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="352.5" y="20.0">2</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="457.5" y="20.0">4</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="562.5" y="20.0">6</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="667.5" y="20.0">8</text>
+	<rect x="0" y="40" width="300" height="80" fill="#fbbc04"/>
+	<rect x="300" y="40" width="420" height="80" fill="#f3f3f3"/>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="60.0">PBS</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="352.5" y="60.0">9.61 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="457.5" y="60.0">12.4 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="562.5" y="60.0">111 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="667.5" y="60.0">1.5 s</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="100.0">KS - PBS</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="352.5" y="100.0">10.9 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="457.5" y="100.0">14.6 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="562.5" y="100.0">129 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="667.5" y="100.0">1.44 s</text>
+	<line stroke="white" stroke-width="2" x1="0" y1="0" x2="720" y2="0"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="40" x2="720" y2="40"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="80" x2="720" y2="80"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="0" x2="0" y2="120"/>
+	<line stroke="white" stroke-width="2" x1="300.0" y1="0" x2="300.0" y2="120"/>
+	<line stroke="white" stroke-width="2" x1="405.0" y1="0" x2="405.0" y2="120"/>
+	<line stroke="white" stroke-width="2" x1="510.0" y1="0" x2="510.0" y2="120"/>
+	<line stroke="white" stroke-width="2" x1="615.0" y1="0" x2="615.0" y2="120"/>
+	<line stroke="white" stroke-width="2" x1="720.0" y1="0" x2="720.0" y2="120"/>
 </svg>

--- a/tfhe/docs/_static/cpu_pbs_benchmark_tuniform_2m40.svg
+++ b/tfhe/docs/_static/cpu_pbs_benchmark_tuniform_2m40.svg
@@ -1,64 +1,42 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="562.0" height="200" viewBox="0 0 562.0 200">
-    <!-- Header Row -->
-    <rect x="0" y="0" width="562.0" height="40" fill="black" />
-	<text x="10" y="24.0" fill="white" font-family="Arial" font-size="14">Operation \ Precision(bits)</text>
-	<text x="241.0" y="24.0" fill="white" font-family="Arial" font-size="14">2</text>
-	<text x="333.0" y="24.0" fill="white" font-family="Arial" font-size="14">4</text>
-	<text x="425.0" y="24.0" fill="white" font-family="Arial" font-size="14">6</text>
-	<text x="517.0" y="24.0" fill="white" font-family="Arial" font-size="14">8</text>
-
-    <!-- Data Rows -->
-    <rect x="0" y="40" width="562.0" height="40" fill="#fbbc04" />
-	<text x="10" y="64.0" fill="black" font-family="Arial" font-size="14">PBS</text>
-	<rect x="194.0" y="40" width="562.0" height="40" fill="#f3f3f3" />
-	<text x="217.0" y="64.0" fill="black" font-family="Arial" font-size="14">6.04 ms</text>
-	<rect x="286.0" y="40" width="562.0" height="40" fill="#f3f3f3" />
-	<text x="309.0" y="64.0" fill="black" font-family="Arial" font-size="14">11.3 ms</text>
-	<rect x="378.0" y="40" width="562.0" height="40" fill="#f3f3f3" />
-	<text x="401.0" y="64.0" fill="black" font-family="Arial" font-size="14">98.7 ms</text>
-	<rect x="470.0" y="40" width="562.0" height="40" fill="#f3f3f3" />
-	<text x="497.0" y="64.0" fill="black" font-family="Arial" font-size="14">458 ms</text>
-	<rect x="0" y="80" width="562.0" height="40" fill="#fbbc04" />
-	<text x="10" y="104.0" fill="black" font-family="Arial" font-size="14">MB-PBS</text>
-	<rect x="194.0" y="80" width="562.0" height="40" fill="#f3f3f3" />
-	<text x="217.0" y="104.0" fill="black" font-family="Arial" font-size="14">3.41 ms</text>
-	<rect x="286.0" y="80" width="562.0" height="40" fill="#f3f3f3" />
-	<text x="309.0" y="104.0" fill="black" font-family="Arial" font-size="14">4.58 ms</text>
-	<rect x="378.0" y="80" width="562.0" height="40" fill="#f3f3f3" />
-	<text x="401.0" y="104.0" fill="black" font-family="Arial" font-size="14">37.1 ms</text>
-	<rect x="470.0" y="80" width="562.0" height="40" fill="#f3f3f3" />
-	<text x="497.0" y="104.0" fill="black" font-family="Arial" font-size="14">156 ms</text>
-	<rect x="0" y="120" width="562.0" height="40" fill="#fbbc04" />
-	<text x="10" y="144.0" fill="black" font-family="Arial" font-size="14">KS - PBS</text>
-	<rect x="194.0" y="120" width="562.0" height="40" fill="#f3f3f3" />
-	<text x="217.0" y="144.0" fill="black" font-family="Arial" font-size="14">7.79 ms</text>
-	<rect x="286.0" y="120" width="562.0" height="40" fill="#f3f3f3" />
-	<text x="309.0" y="144.0" fill="black" font-family="Arial" font-size="14">14.2 ms</text>
-	<rect x="378.0" y="120" width="562.0" height="40" fill="#f3f3f3" />
-	<text x="405.0" y="144.0" fill="black" font-family="Arial" font-size="14">114 ms</text>
-	<rect x="470.0" y="120" width="562.0" height="40" fill="#f3f3f3" />
-	<text x="497.0" y="144.0" fill="black" font-family="Arial" font-size="14">536 ms</text>
-	<rect x="0" y="160" width="562.0" height="40" fill="#fbbc04" />
-	<text x="10" y="184.0" fill="black" font-family="Arial" font-size="14">KS - MB-PBS</text>
-	<rect x="194.0" y="160" width="562.0" height="40" fill="#f3f3f3" />
-	<text x="217.0" y="184.0" fill="black" font-family="Arial" font-size="14">5.53 ms</text>
-	<rect x="286.0" y="160" width="562.0" height="40" fill="#f3f3f3" />
-	<text x="309.0" y="184.0" fill="black" font-family="Arial" font-size="14">7.51 ms</text>
-	<rect x="378.0" y="160" width="562.0" height="40" fill="#f3f3f3" />
-	<text x="401.0" y="184.0" fill="black" font-family="Arial" font-size="14">47.8 ms</text>
-	<rect x="470.0" y="160" width="562.0" height="40" fill="#f3f3f3" />
-	<text x="497.0" y="184.0" fill="black" font-family="Arial" font-size="14">244 ms</text>
-
-    <!-- Borders -->
-    <line x1="0" y1="0" x2="0" y2="200" stroke="white" />
-	<line x1="194.0" y1="0" x2="194.0" y2="200" stroke="white" />
-	<line x1="286.0" y1="0" x2="286.0" y2="200" stroke="white" />
-	<line x1="378.0" y1="0" x2="378.0" y2="200" stroke="white" />
-	<line x1="470.0" y1="0" x2="470.0" y2="200" stroke="white" />
-	<line x1="0" y1="0" x2="562.0" y2="0" stroke="white" />
-	<line x1="0" y1="40" x2="562.0" y2="40" stroke="white" />
-	<line x1="0" y1="80" x2="562.0" y2="80" stroke="white" />
-	<line x1="0" y1="120" x2="562.0" y2="120" stroke="white" />
-	<line x1="0" y1="160" x2="562.0" y2="160" stroke="white" />
-	<line x1="0" y1="200" x2="562.0" y2="200" stroke="white" />
+<?xml version="1.0" ?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 200" preserveAspectRatio="meet" width="100%" height="200">
+	<rect x="0" y="0" width="720" height="40" fill="black"/>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="6" y="20.0">Operation \ Precision (bits)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="352.5" y="20.0">2</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="457.5" y="20.0">4</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="562.5" y="20.0">6</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="667.5" y="20.0">8</text>
+	<rect x="0" y="40" width="300" height="160" fill="#fbbc04"/>
+	<rect x="300" y="40" width="420" height="160" fill="#f3f3f3"/>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="60.0">PBS</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="352.5" y="60.0">6.04 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="457.5" y="60.0">11.3 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="562.5" y="60.0">98.7 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="667.5" y="60.0">458 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="100.0">MB-PBS</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="352.5" y="100.0">3.41 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="457.5" y="100.0">4.58 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="562.5" y="100.0">37.1 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="667.5" y="100.0">156 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="140.0">KS-PBS</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="352.5" y="140.0">7.79 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="457.5" y="140.0">14.2 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="562.5" y="140.0">114 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="667.5" y="140.0">536 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="180.0">KS-MB-PBS</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="352.5" y="180.0">5.53 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="457.5" y="180.0">7.51 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="562.5" y="180.0">47.8 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="667.5" y="180.0">244 ms</text>
+	<line stroke="white" stroke-width="2" x1="0" y1="0" x2="720" y2="0"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="40" x2="720" y2="40"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="80" x2="720" y2="80"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="120" x2="720" y2="120"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="160" x2="720" y2="160"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="0" x2="0" y2="200"/>
+	<line stroke="white" stroke-width="2" x1="300.0" y1="0" x2="300.0" y2="200"/>
+	<line stroke="white" stroke-width="2" x1="405.0" y1="0" x2="405.0" y2="200"/>
+	<line stroke="white" stroke-width="2" x1="510.0" y1="0" x2="510.0" y2="200"/>
+	<line stroke="white" stroke-width="2" x1="615.0" y1="0" x2="615.0" y2="200"/>
+	<line stroke="white" stroke-width="2" x1="720.0" y1="0" x2="720.0" y2="200"/>
 </svg>

--- a/tfhe/docs/_static/cpu_pbs_benchmark_tuniform_2m64.svg
+++ b/tfhe/docs/_static/cpu_pbs_benchmark_tuniform_2m64.svg
@@ -1,64 +1,42 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="562.0" height="200" viewBox="0 0 562.0 200">
-    <!-- Header Row -->
-    <rect x="0" y="0" width="562.0" height="40" fill="black" />
-	<text x="10" y="24.0" fill="white" font-family="Arial" font-size="14">Operation \ Precision(bits)</text>
-	<text x="241.0" y="24.0" fill="white" font-family="Arial" font-size="14">2</text>
-	<text x="333.0" y="24.0" fill="white" font-family="Arial" font-size="14">4</text>
-	<text x="425.0" y="24.0" fill="white" font-family="Arial" font-size="14">6</text>
-	<text x="517.0" y="24.0" fill="white" font-family="Arial" font-size="14">8</text>
-
-    <!-- Data Rows -->
-    <rect x="0" y="40" width="562.0" height="40" fill="#fbbc04" />
-	<text x="10" y="64.0" fill="black" font-family="Arial" font-size="14">PBS</text>
-	<rect x="194.0" y="40" width="562.0" height="40" fill="#f3f3f3" />
-	<text x="221.0" y="64.0" fill="black" font-family="Arial" font-size="14">8.9 ms</text>
-	<rect x="286.0" y="40" width="562.0" height="40" fill="#f3f3f3" />
-	<text x="309.0" y="64.0" fill="black" font-family="Arial" font-size="14">11.8 ms</text>
-	<rect x="378.0" y="40" width="562.0" height="40" fill="#f3f3f3" />
-	<text x="405.0" y="64.0" fill="black" font-family="Arial" font-size="14">102 ms</text>
-	<rect x="470.0" y="40" width="562.0" height="40" fill="#f3f3f3" />
-	<text x="497.0" y="64.0" fill="black" font-family="Arial" font-size="14">649 ms</text>
-	<rect x="0" y="80" width="562.0" height="40" fill="#fbbc04" />
-	<text x="10" y="104.0" fill="black" font-family="Arial" font-size="14">MB-PBS</text>
-	<rect x="194.0" y="80" width="562.0" height="40" fill="#f3f3f3" />
-	<text x="221.0" y="104.0" fill="black" font-family="Arial" font-size="14">4.4 ms</text>
-	<rect x="286.0" y="80" width="562.0" height="40" fill="#f3f3f3" />
-	<text x="309.0" y="104.0" fill="black" font-family="Arial" font-size="14">4.43 ms</text>
-	<rect x="378.0" y="80" width="562.0" height="40" fill="#f3f3f3" />
-	<text x="401.0" y="104.0" fill="black" font-family="Arial" font-size="14">27.5 ms</text>
-	<rect x="470.0" y="80" width="562.0" height="40" fill="#f3f3f3" />
-	<text x="497.0" y="104.0" fill="black" font-family="Arial" font-size="14">248 ms</text>
-	<rect x="0" y="120" width="562.0" height="40" fill="#fbbc04" />
-	<text x="10" y="144.0" fill="black" font-family="Arial" font-size="14">KS - PBS</text>
-	<rect x="194.0" y="120" width="562.0" height="40" fill="#f3f3f3" />
-	<text x="217.0" y="144.0" fill="black" font-family="Arial" font-size="14">11.0 ms</text>
-	<rect x="286.0" y="120" width="562.0" height="40" fill="#f3f3f3" />
-	<text x="309.0" y="144.0" fill="black" font-family="Arial" font-size="14">14.9 ms</text>
-	<rect x="378.0" y="120" width="562.0" height="40" fill="#f3f3f3" />
-	<text x="405.0" y="144.0" fill="black" font-family="Arial" font-size="14">118 ms</text>
-	<rect x="470.0" y="120" width="562.0" height="40" fill="#f3f3f3" />
-	<text x="497.0" y="144.0" fill="black" font-family="Arial" font-size="14">873 ms</text>
-	<rect x="0" y="160" width="562.0" height="40" fill="#fbbc04" />
-	<text x="10" y="184.0" fill="black" font-family="Arial" font-size="14">KS - MB-PBS</text>
-	<rect x="194.0" y="160" width="562.0" height="40" fill="#f3f3f3" />
-	<text x="217.0" y="184.0" fill="black" font-family="Arial" font-size="14">5.97 ms</text>
-	<rect x="286.0" y="160" width="562.0" height="40" fill="#f3f3f3" />
-	<text x="309.0" y="184.0" fill="black" font-family="Arial" font-size="14">7.55 ms</text>
-	<rect x="378.0" y="160" width="562.0" height="40" fill="#f3f3f3" />
-	<text x="401.0" y="184.0" fill="black" font-family="Arial" font-size="14">44.0 ms</text>
-	<rect x="470.0" y="160" width="562.0" height="40" fill="#f3f3f3" />
-	<text x="497.0" y="184.0" fill="black" font-family="Arial" font-size="14">453 ms</text>
-
-    <!-- Borders -->
-    <line x1="0" y1="0" x2="0" y2="200" stroke="white" />
-	<line x1="194.0" y1="0" x2="194.0" y2="200" stroke="white" />
-	<line x1="286.0" y1="0" x2="286.0" y2="200" stroke="white" />
-	<line x1="378.0" y1="0" x2="378.0" y2="200" stroke="white" />
-	<line x1="470.0" y1="0" x2="470.0" y2="200" stroke="white" />
-	<line x1="0" y1="0" x2="562.0" y2="0" stroke="white" />
-	<line x1="0" y1="40" x2="562.0" y2="40" stroke="white" />
-	<line x1="0" y1="80" x2="562.0" y2="80" stroke="white" />
-	<line x1="0" y1="120" x2="562.0" y2="120" stroke="white" />
-	<line x1="0" y1="160" x2="562.0" y2="160" stroke="white" />
-	<line x1="0" y1="200" x2="562.0" y2="200" stroke="white" />
+<?xml version="1.0" ?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 200" preserveAspectRatio="meet" width="100%" height="200">
+	<rect x="0" y="0" width="720" height="40" fill="black"/>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="6" y="20.0">Operation \ Precision (bits)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="352.5" y="20.0">2</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="457.5" y="20.0">4</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="562.5" y="20.0">6</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="667.5" y="20.0">8</text>
+	<rect x="0" y="40" width="300" height="160" fill="#fbbc04"/>
+	<rect x="300" y="40" width="420" height="160" fill="#f3f3f3"/>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="60.0">PBS</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="352.5" y="60.0">8.9 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="457.5" y="60.0">11.8 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="562.5" y="60.0">102 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="667.5" y="60.0">649 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="100.0">MB-PBS</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="352.5" y="100.0">4.4 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="457.5" y="100.0">4.43 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="562.5" y="100.0">27.5 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="667.5" y="100.0">248 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="140.0">KS-PBS</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="352.5" y="140.0">11.0 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="457.5" y="140.0">14.9 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="562.5" y="140.0">118 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="667.5" y="140.0">873 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="180.0">KS-MB-PBS</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="352.5" y="180.0">5.97 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="457.5" y="180.0">7.55 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="562.5" y="180.0">44.0 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="667.5" y="180.0">453 ms</text>
+	<line stroke="white" stroke-width="2" x1="0" y1="0" x2="720" y2="0"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="40" x2="720" y2="40"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="80" x2="720" y2="80"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="120" x2="720" y2="120"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="160" x2="720" y2="160"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="0" x2="0" y2="200"/>
+	<line stroke="white" stroke-width="2" x1="300.0" y1="0" x2="300.0" y2="200"/>
+	<line stroke="white" stroke-width="2" x1="405.0" y1="0" x2="405.0" y2="200"/>
+	<line stroke="white" stroke-width="2" x1="510.0" y1="0" x2="510.0" y2="200"/>
+	<line stroke="white" stroke-width="2" x1="615.0" y1="0" x2="615.0" y2="200"/>
+	<line stroke="white" stroke-width="2" x1="720.0" y1="0" x2="720.0" y2="200"/>
 </svg>

--- a/tfhe/docs/_static/gpu_pbs_benchmark_tuniform_2m40.svg
+++ b/tfhe/docs/_static/gpu_pbs_benchmark_tuniform_2m40.svg
@@ -1,42 +1,30 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="550.0" height="120" viewBox="0 0 550.0 120">
-    <!-- Header Row -->
-    <rect x="0" y="0" width="550.0" height="40" fill="black" />
-	<text x="10" y="24.0" fill="white" font-family="Arial" font-size="14">Operation \ Precision(bits)</text>
-	<text x="229.0" y="24.0" fill="white" font-family="Arial" font-size="14">2</text>
-	<text x="321.0" y="24.0" fill="white" font-family="Arial" font-size="14">4</text>
-	<text x="413.0" y="24.0" fill="white" font-family="Arial" font-size="14">6</text>
-	<text x="505.0" y="24.0" fill="white" font-family="Arial" font-size="14">8</text>
-
-    <!-- Data Rows -->
-    <rect x="0" y="40" width="550.0" height="40" fill="#fbbc04" />
-	<text x="10" y="64.0" fill="black" font-family="Arial" font-size="14">MB-PBS</text>
-	<rect x="182.0" y="40" width="550.0" height="40" fill="#f3f3f3" />
-	<text x="209.0" y="64.0" fill="black" font-family="Arial" font-size="14">3.2 ms</text>
-	<rect x="274.0" y="40" width="550.0" height="40" fill="#f3f3f3" />
-	<text x="297.0" y="64.0" fill="black" font-family="Arial" font-size="14">4.03 ms</text>
-	<rect x="366.0" y="40" width="550.0" height="40" fill="#f3f3f3" />
-	<text x="389.0" y="64.0" fill="black" font-family="Arial" font-size="14">22.1 ms</text>
-	<rect x="458.0" y="40" width="550.0" height="40" fill="#f3f3f3" />
-	<text x="497.0" y="64.0" fill="black" font-family="Arial" font-size="14">N/A</text>
-	<rect x="0" y="80" width="550.0" height="40" fill="#fbbc04" />
-	<text x="10" y="104.0" fill="black" font-family="Arial" font-size="14">KS - MB-PBS</text>
-	<rect x="182.0" y="80" width="550.0" height="40" fill="#f3f3f3" />
-	<text x="205.0" y="104.0" fill="black" font-family="Arial" font-size="14">3.22 ms</text>
-	<rect x="274.0" y="80" width="550.0" height="40" fill="#f3f3f3" />
-	<text x="297.0" y="104.0" fill="black" font-family="Arial" font-size="14">4.02 ms</text>
-	<rect x="366.0" y="80" width="550.0" height="40" fill="#f3f3f3" />
-	<text x="389.0" y="104.0" fill="black" font-family="Arial" font-size="14">22.2 ms</text>
-	<rect x="458.0" y="80" width="550.0" height="40" fill="#f3f3f3" />
-	<text x="497.0" y="104.0" fill="black" font-family="Arial" font-size="14">N/A</text>
-
-    <!-- Borders -->
-    <line x1="0" y1="0" x2="0" y2="120" stroke="white" />
-	<line x1="182.0" y1="0" x2="182.0" y2="120" stroke="white" />
-	<line x1="274.0" y1="0" x2="274.0" y2="120" stroke="white" />
-	<line x1="366.0" y1="0" x2="366.0" y2="120" stroke="white" />
-	<line x1="458.0" y1="0" x2="458.0" y2="120" stroke="white" />
-	<line x1="0" y1="0" x2="550.0" y2="0" stroke="white" />
-	<line x1="0" y1="40" x2="550.0" y2="40" stroke="white" />
-	<line x1="0" y1="80" x2="550.0" y2="80" stroke="white" />
-	<line x1="0" y1="120" x2="550.0" y2="120" stroke="white" />
+<?xml version="1.0" ?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 120" preserveAspectRatio="meet" width="100%" height="120">
+	<rect x="0" y="0" width="720" height="40" fill="black"/>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="6" y="20.0">Operation \ Precision (bits)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="352.5" y="20.0">2</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="457.5" y="20.0">4</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="562.5" y="20.0">6</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="667.5" y="20.0">8</text>
+	<rect x="0" y="40" width="300" height="80" fill="#fbbc04"/>
+	<rect x="300" y="40" width="420" height="80" fill="#f3f3f3"/>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="60.0">MB-PBS</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="352.5" y="60.0">3.2 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="457.5" y="60.0">4.03 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="562.5" y="60.0">22.1 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="667.5" y="60.0">N/A</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="100.0">KS - MB-PBS</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="352.5" y="100.0">3.22 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="457.5" y="100.0">4.02 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="562.5" y="100.0">22.2 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="667.5" y="100.0">N/A</text>
+	<line stroke="white" stroke-width="2" x1="0" y1="0" x2="720" y2="0"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="40" x2="720" y2="40"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="80" x2="720" y2="80"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="0" x2="0" y2="120"/>
+	<line stroke="white" stroke-width="2" x1="300.0" y1="0" x2="300.0" y2="120"/>
+	<line stroke="white" stroke-width="2" x1="405.0" y1="0" x2="405.0" y2="120"/>
+	<line stroke="white" stroke-width="2" x1="510.0" y1="0" x2="510.0" y2="120"/>
+	<line stroke="white" stroke-width="2" x1="615.0" y1="0" x2="615.0" y2="120"/>
+	<line stroke="white" stroke-width="2" x1="720.0" y1="0" x2="720.0" y2="120"/>
 </svg>

--- a/tfhe/docs/_static/gpu_pbs_benchmark_tuniform_2m64.svg
+++ b/tfhe/docs/_static/gpu_pbs_benchmark_tuniform_2m64.svg
@@ -1,42 +1,30 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="550.0" height="120" viewBox="0 0 550.0 120">
-    <!-- Header Row -->
-    <rect x="0" y="0" width="550.0" height="40" fill="black" />
-	<text x="10" y="24.0" fill="white" font-family="Arial" font-size="14">Operation \ Precision(bits)</text>
-	<text x="229.0" y="24.0" fill="white" font-family="Arial" font-size="14">2</text>
-	<text x="321.0" y="24.0" fill="white" font-family="Arial" font-size="14">4</text>
-	<text x="413.0" y="24.0" fill="white" font-family="Arial" font-size="14">6</text>
-	<text x="505.0" y="24.0" fill="white" font-family="Arial" font-size="14">8</text>
-
-    <!-- Data Rows -->
-    <rect x="0" y="40" width="550.0" height="40" fill="#fbbc04" />
-	<text x="10" y="64.0" fill="black" font-family="Arial" font-size="14">MB-PBS</text>
-	<rect x="182.0" y="40" width="550.0" height="40" fill="#f3f3f3" />
-	<text x="205.0" y="64.0" fill="black" font-family="Arial" font-size="14">3.38 ms</text>
-	<rect x="274.0" y="40" width="550.0" height="40" fill="#f3f3f3" />
-	<text x="297.0" y="64.0" fill="black" font-family="Arial" font-size="14">4.22 ms</text>
-	<rect x="366.0" y="40" width="550.0" height="40" fill="#f3f3f3" />
-	<text x="389.0" y="64.0" fill="black" font-family="Arial" font-size="14">23.0 ms</text>
-	<rect x="458.0" y="40" width="550.0" height="40" fill="#f3f3f3" />
-	<text x="497.0" y="64.0" fill="black" font-family="Arial" font-size="14">N/A</text>
-	<rect x="0" y="80" width="550.0" height="40" fill="#fbbc04" />
-	<text x="10" y="104.0" fill="black" font-family="Arial" font-size="14">KS - MB-PBS</text>
-	<rect x="182.0" y="80" width="550.0" height="40" fill="#f3f3f3" />
-	<text x="205.0" y="104.0" fill="black" font-family="Arial" font-size="14">3.38 ms</text>
-	<rect x="274.0" y="80" width="550.0" height="40" fill="#f3f3f3" />
-	<text x="297.0" y="104.0" fill="black" font-family="Arial" font-size="14">4.22 ms</text>
-	<rect x="366.0" y="80" width="550.0" height="40" fill="#f3f3f3" />
-	<text x="389.0" y="104.0" fill="black" font-family="Arial" font-size="14">23.1 ms</text>
-	<rect x="458.0" y="80" width="550.0" height="40" fill="#f3f3f3" />
-	<text x="497.0" y="104.0" fill="black" font-family="Arial" font-size="14">N/A</text>
-
-    <!-- Borders -->
-    <line x1="0" y1="0" x2="0" y2="120" stroke="white" />
-	<line x1="182.0" y1="0" x2="182.0" y2="120" stroke="white" />
-	<line x1="274.0" y1="0" x2="274.0" y2="120" stroke="white" />
-	<line x1="366.0" y1="0" x2="366.0" y2="120" stroke="white" />
-	<line x1="458.0" y1="0" x2="458.0" y2="120" stroke="white" />
-	<line x1="0" y1="0" x2="550.0" y2="0" stroke="white" />
-	<line x1="0" y1="40" x2="550.0" y2="40" stroke="white" />
-	<line x1="0" y1="80" x2="550.0" y2="80" stroke="white" />
-	<line x1="0" y1="120" x2="550.0" y2="120" stroke="white" />
+<?xml version="1.0" ?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 120" preserveAspectRatio="meet" width="100%" height="120">
+	<rect x="0" y="0" width="720" height="40" fill="black"/>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="6" y="20.0">Operation \ Precision (bits)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="352.5" y="20.0">2</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="457.5" y="20.0">4</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="562.5" y="20.0">6</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="667.5" y="20.0">8</text>
+	<rect x="0" y="40" width="300" height="80" fill="#fbbc04"/>
+	<rect x="300" y="40" width="420" height="80" fill="#f3f3f3"/>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="60.0">MB-PBS</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="352.5" y="60.0">3.38 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="457.5" y="60.0">4.22 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="562.5" y="60.0">23.0 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="667.5" y="60.0">N/A</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="100.0">KS - MB-PBS</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="352.5" y="100.0">3.38 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="457.5" y="100.0">4.22 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="562.5" y="100.0">23.1 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="667.5" y="100.0">N/A</text>
+	<line stroke="white" stroke-width="2" x1="0" y1="0" x2="720" y2="0"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="40" x2="720" y2="40"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="80" x2="720" y2="80"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="0" x2="0" y2="120"/>
+	<line stroke="white" stroke-width="2" x1="300.0" y1="0" x2="300.0" y2="120"/>
+	<line stroke="white" stroke-width="2" x1="405.0" y1="0" x2="405.0" y2="120"/>
+	<line stroke="white" stroke-width="2" x1="510.0" y1="0" x2="510.0" y2="120"/>
+	<line stroke="white" stroke-width="2" x1="615.0" y1="0" x2="615.0" y2="120"/>
+	<line stroke="white" stroke-width="2" x1="720.0" y1="0" x2="720.0" y2="120"/>
 </svg>


### PR DESCRIPTION
Fresh SVGs for PBS benchmarks results.
I'm wondering if we should keep these new tables with the same overall size in width than integer ones, or if we should make it more fitted ? @yuxizama 