### PR TITLE
fix(gpu): fix scalar eq bug

### DIFF
--- a/backends/tfhe-cuda-backend/cuda/src/integer/comparison.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/comparison.cuh
@@ -159,6 +159,16 @@ __host__ void are_all_comparisons_block_true(
       integer_radix_apply_univariate_lookup_table_kb<Torus>(
           streams, gpu_indexes, gpu_count, lwe_array_out, accumulator, bsks,
           ksks, lut, 1);
+      // Reset max_value_lut_indexes before returning, otherwise if the lut is
+      // reused the lut indexes will be wrong
+      Torus *h_lut_indexes = (Torus *)malloc(num_chunks * sizeof(Torus));
+      memset(h_lut_indexes, 0, num_chunks * sizeof(Torus));
+      cuda_memcpy_async_to_gpu(is_max_value_lut->get_lut_indexes(0, 0),
+                               h_lut_indexes, num_chunks * sizeof(Torus),
+                               streams[0], gpu_indexes[0]);
+      is_max_value_lut->broadcast_lut(streams, gpu_indexes, 0);
+      cuda_synchronize_stream(streams[0], gpu_indexes[0]);
+      free(h_lut_indexes);
       return;
     } else {
       integer_radix_apply_univariate_lookup_table_kb<Torus>(


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description

This PR fixes a bug in scalar eq, where `is_max_value_lut` is used twice but lut indexes were not reset between the two so we were applying to wrong lut to the first block for the second run of `are_all_comparisons_block_true`.

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
