### PR TITLE
chore(ci): install dependencies as standalone job

### DIFF
--- a/.github/workflows/benchmark_gpu_common.yml
+++ b/.github/workflows/benchmark_gpu_common.yml
@@ -136,32 +136,24 @@ jobs:
       # This will allow to fallback on permanent instances running on Hyperstack.
       - name: Use permanent remote instance
         id: use-permanent-instance
-        if: env.SECRETS_AVAILABLE == 'true' &&
-          steps.start-remote-instance.outcome == 'failure' &&
+        if: steps.start-remote-instance.outcome == 'failure' &&
           inputs.profile == 'single-h100'
         run: |
           echo "runner_group=h100x1" >> "$GITHUB_OUTPUT"
 
-  cuda-benchmarks:
-    name: Cuda benchmarks (${{ inputs.profile }})
-    needs: [ prepare-matrix, setup-instance ]
+  # Install dependencies only once since cuda-benchmarks uses a matrix strategy, thus running multiple times.
+  install-dependencies:
+    name: Install dependencies
+    needs: [ setup-instance ]
     runs-on: ${{ needs.setup-instance.outputs.runner-name }}
-    timeout-minutes: 1440 # 24 hours
-    continue-on-error: true
     strategy:
-      fail-fast: false
-      max-parallel: 1
       matrix:
-        command: ${{ fromJSON(needs.prepare-matrix.outputs.command) }}
-        op_flavor: ${{ fromJSON(needs.prepare-matrix.outputs.op_flavor) }}
-        bench_type: ${{ fromJSON(needs.prepare-matrix.outputs.bench_type) }}
         # explicit include-based build matrix, of known valid options
         include:
-          - os: ubuntu-22.04
-            cuda: "12.2"
+          - cuda: "12.2"
             gcc: 11
     steps:
-      - name: Checkout tfhe-rs repo with tags
+      - name: Checkout tfhe-rs repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
@@ -175,12 +167,56 @@ jobs:
           cuda-version: ${{ matrix.cuda }}
           gcc-version: ${{ matrix.gcc }}
 
+  cuda-benchmarks:
+    name: Cuda benchmarks (${{ inputs.profile }})
+    needs: [ prepare-matrix, setup-instance, install-dependencies ]
+    runs-on: ${{ needs.setup-instance.outputs.runner-name }}
+    timeout-minutes: 1440 # 24 hours
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        command: ${{ fromJSON(needs.prepare-matrix.outputs.command) }}
+        op_flavor: ${{ fromJSON(needs.prepare-matrix.outputs.op_flavor) }}
+        bench_type: ${{ fromJSON(needs.prepare-matrix.outputs.bench_type) }}
+        include:
+          - cuda: "12.2"
+            gcc: 11
+    steps:
+      - name: Checkout tfhe-rs repo with tags
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          fetch-depth: 0
+          persist-credentials: 'false'
+          token: ${{ secrets.REPO_CHECKOUT_TOKEN }}
+
       - name: Get benchmark details
         run: |
           {
             echo "BENCH_DATE=$(date --iso-8601=seconds)";
             echo "COMMIT_DATE=$(git --no-pager show -s --format=%cd --date=iso8601-strict ${{ github.sha }})";
             echo "COMMIT_HASH=$(git describe --tags --dirty)";
+          } >> "${GITHUB_ENV}"
+
+      # Re-export environment variables as dependencies setup perform this task in the previous job.
+      # Local env variables are cleaned at the end of each job.
+      - name: Export CUDA variables
+        shell: bash
+        run: |
+          CUDA_PATH=/usr/local/cuda-${{ matrix.cuda }}
+          echo "CUDA_PATH=$CUDA_PATH" >> "${GITHUB_ENV}"
+          echo "PATH=$PATH:$CUDA_PATH/bin" >> "${GITHUB_PATH}"
+          echo "LD_LIBRARY_PATH=$CUDA_PATH/lib64:$LD_LIBRARY_PATH" >> "${GITHUB_ENV}"
+          echo "CUDA_MODULE_LOADER=EAGER" >> "${GITHUB_ENV}"
+
+      - name: Export gcc and g++ variables
+        shell: bash
+        run: |
+          {
+          echo "CC=/usr/bin/gcc-${{ matrix.gcc }}";
+          echo "CXX=/usr/bin/g++-${{ matrix.gcc }}";
+          echo "CUDAHOSTCXX=/usr/bin/g++-${{ matrix.gcc }}";
           } >> "${GITHUB_ENV}"
 
       - name: Install rust


### PR DESCRIPTION
Installing dependencies several times, due to matrix strategy, lead to job failure. Now, if the workflow uses the remote instance, the dependencies will be installed only once.
