### PR TITLE
refactor(gpu): remove lwe_input_indexes, lwe_output_indexes and lut_vector_indexes for pbs128

### DIFF
--- a/backends/tfhe-cuda-backend/cuda/include/pbs/programmable_bootstrap.h
+++ b/backends/tfhe-cuda-backend/cuda/include/pbs/programmable_bootstrap.h
@@ -92,12 +92,10 @@ void cuda_programmable_bootstrap_lwe_ciphertext_vector_64(
 
 void cuda_programmable_bootstrap_lwe_ciphertext_vector_128(
     void *stream, uint32_t gpu_index, void *lwe_array_out,
-    void const *lwe_output_indexes, void const *lut_vector,
-    void const *lut_vector_indexes, void const *lwe_array_in,
-    void const *lwe_input_indexes, void const *bootstrapping_key,
-    int8_t *buffer, uint32_t lwe_dimension, uint32_t glwe_dimension,
-    uint32_t polynomial_size, uint32_t base_log, uint32_t level_count,
-    uint32_t num_samples, uint32_t num_many_lut, uint32_t lut_stride);
+    void const *lut_vector, void const *lwe_array_in,
+    void const *bootstrapping_key, int8_t *buffer, uint32_t lwe_dimension,
+    uint32_t glwe_dimension, uint32_t polynomial_size, uint32_t base_log,
+    uint32_t level_count, uint32_t num_samples);
 
 void cleanup_cuda_programmable_bootstrap(void *stream, uint32_t gpu_index,
                                          int8_t **pbs_buffer);

--- a/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_classic_128.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_classic_128.cu
@@ -52,131 +52,108 @@ void scratch_cuda_programmable_bootstrap_128(
 template <typename Torus>
 void executor_cuda_programmable_bootstrap_lwe_ciphertext_vector_128(
     void *stream, uint32_t gpu_index, Torus *lwe_array_out,
-    Torus const *lwe_output_indexes, Torus const *lut_vector,
-    Torus const *lut_vector_indexes, Torus const *lwe_array_in,
-    Torus const *lwe_input_indexes, double const *bootstrapping_key,
-    pbs_buffer_128<CLASSICAL> *buffer, uint32_t lwe_dimension,
-    uint32_t glwe_dimension, uint32_t polynomial_size, uint32_t base_log,
-    uint32_t level_count, uint32_t num_samples, uint32_t num_many_lut,
-    uint32_t lut_stride) {
+    Torus const *lut_vector, Torus const *lwe_array_in,
+    double const *bootstrapping_key, pbs_buffer_128<CLASSICAL> *buffer,
+    uint32_t lwe_dimension, uint32_t glwe_dimension, uint32_t polynomial_size,
+    uint32_t base_log, uint32_t level_count, uint32_t num_samples) {
 
   switch (polynomial_size) {
   case 256:
     host_programmable_bootstrap_128<AmortizedDegree<256>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, base_log, level_count, num_samples,
-        num_many_lut, lut_stride);
+        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out, lut_vector,
+        lwe_array_in, bootstrapping_key, buffer, glwe_dimension, lwe_dimension,
+        polynomial_size, base_log, level_count, num_samples);
     break;
   case 512:
     host_programmable_bootstrap_128<AmortizedDegree<512>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, base_log, level_count, num_samples,
-        num_many_lut, lut_stride);
+        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out, lut_vector,
+        lwe_array_in, bootstrapping_key, buffer, glwe_dimension, lwe_dimension,
+        polynomial_size, base_log, level_count, num_samples);
     break;
   case 1024:
     host_programmable_bootstrap_128<AmortizedDegree<1024>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, base_log, level_count, num_samples,
-        num_many_lut, lut_stride);
+        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out, lut_vector,
+        lwe_array_in, bootstrapping_key, buffer, glwe_dimension, lwe_dimension,
+        polynomial_size, base_log, level_count, num_samples);
     break;
   case 2048:
     host_programmable_bootstrap_128<AmortizedDegree<2048>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, base_log, level_count, num_samples,
-        num_many_lut, lut_stride);
+        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out, lut_vector,
+        lwe_array_in, bootstrapping_key, buffer, glwe_dimension, lwe_dimension,
+        polynomial_size, base_log, level_count, num_samples);
     break;
   case 4096:
     host_programmable_bootstrap_128<AmortizedDegree<4096>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, base_log, level_count, num_samples,
-        num_many_lut, lut_stride);
+        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out, lut_vector,
+        lwe_array_in, bootstrapping_key, buffer, glwe_dimension, lwe_dimension,
+        polynomial_size, base_log, level_count, num_samples);
     break;
   default:
-    PANIC("Cuda error (classical PBS): unsupported polynomial size. "
+    PANIC("Cuda error (classical PBS128): unsupported polynomial size. "
           "Supported N's are powers of two"
           " in the interval [256..4096].")
   }
 }
 
-/* Perform bootstrapping on a batch of input u128 LWE ciphertexts.
+/* Perform bootstrapping on a batch of input u128 LWE ciphertexts, storing the
+ * result in the same index for each ciphertext.
  *
- * - `v_stream` is a void pointer to the Cuda stream to be used in the kernel
- * launch
+ * - `v_stream` is a void pointer to the CUDA stream used in the kernel launch
  * - `gpu_index` is the index of the GPU to be used in the kernel launch
- *  - lwe_array_out: output batch of num_samples bootstrapped ciphertexts c =
- * (a0,..an-1,b) where n is the LWE dimension
- *  - lut_vector: should hold as many luts of size polynomial_size
- * as there are input ciphertexts, but actually holds
- * num_luts vectors to reduce memory usage
- *  - lut_vector_indexes: stores the index corresponding to
- * which lut to use for each sample in
- * lut_vector
- *  - lwe_array_in: input batch of num_samples LWE ciphertexts, containing n
- * mask values + 1 body value
- *  - bootstrapping_key: GGSW encryption of the LWE secret key sk1
- * under secret key sk2
- * bsk = Z + sk1 H
- * where H is the gadget matrix and Z is a matrix (k+1).l
- * containing GLWE encryptions of 0 under sk2.
- * bsk is thus a tensor of size (k+1)^2.l.N.n
- * where l is the number of decomposition levels and
- * k is the GLWE dimension, N is the polynomial size for
- * GLWE. The polynomial size for GLWE and the lut
- * are the same because they have to be in the same ring
- * to be multiplied.
- * - lwe_dimension: size of the Torus vector used to encrypt the input
- * LWE ciphertexts - referred to as n above (~ 600)
- * - glwe_dimension: size of the polynomial vector used to encrypt the LUT
- * GLWE ciphertexts - referred to as k above. Only the value 1 is supported for
- * this parameter.
- * - polynomial_size: size of the test polynomial (lut) and size of the
- * GLWE polynomial (~1024)
- * - base_log: log base used for the gadget matrix - B = 2^base_log (~8)
- * - level_count: number of decomposition levels in the gadget matrix (~4)
- * - num_samples: number of encrypted input messages
+ * - `lwe_array_out`: output batch of `num_samples` bootstrapped ciphertexts
+ *   c = (a0, .., a(n−1), b), where n is the LWE dimension
+ * - `lut_vector`: must contain exactly one LUT (of size `polynomial_size`) that
+ *   will be applied uniformly to every input ciphertext
+ * - `lwe_array_in`: input batch of `num_samples` LWE ciphertexts, each
+ * containing n mask values + 1 body value
+ * - `bootstrapping_key`: GGSW encryption of the LWE secret key sk1 under secret
+ * key sk2
+ *
+ *    bsk = Z + sk1 * H
+ *
+ *   where H is the gadget matrix and Z is a matrix (k+1)*l containing GLWE
+ * encryptions of 0 under sk2. bsk is thus a tensor of size (k+1)^2 * l * N * n,
+ * where l is the number of decomposition levels, k is the GLWE dimension, and N
+ * is the polynomial size. (The polynomial size for GLWE and the LUT must match
+ * so they live in the same ring.)
+ *
+ * - `lwe_dimension`: size of the Torus vector used to encrypt the input LWE
+ * ciphertexts (referred to as n, typically ~600)
+ * - `glwe_dimension`: size of the polynomial vector used to encrypt the LUT
+ * GLWE ciphertexts (referred to as k). Currently only k=1 is supported.
+ * - `polynomial_size`: size of the test polynomial (LUT) and the GLWE
+ * polynomial (~1024)
+ * - `base_log`: logarithm of the base used for the gadget matrix (B =
+ * 2^base_log, ~8)
+ * - `level_count`: number of decomposition levels in the gadget matrix (~4)
+ * - `num_samples`: number of encrypted input messages
  *
  * This function calls a wrapper to a device kernel that performs the
  * bootstrapping:
- * 	- the kernel is templatized based on integer discretization and
- * polynomial degree
- * 	- num_samples * level_count * (glwe_dimension + 1) blocks of threads are
- * launched, where each thread	is going to handle one or more polynomial
- * coefficients at each stage, for a given level of decomposition, either for
- * the LUT mask or its body:
- * 		- perform the blind rotation
- * 		- round the result
- * 		- get the decomposition for the current level
- * 		- switch to the FFT domain
- * 		- multiply with the bootstrapping key
- * 		- come back to the coefficients representation
- * 	- between each stage a synchronization of the threads is necessary (some
- * synchronizations happen at the block level, some happen between blocks, using
- * cooperative groups).
- * 	- in case the device has enough shared memory, temporary arrays used for
- * the different stages (accumulators) are stored into the shared memory
- * 	- the accumulators serve to combine the results for all decomposition
- * levels
- * 	- the constant memory (64K) is used for storing the roots of identity
- * values for the FFT
+ *   - The kernel is templated based on integer discretization and polynomial
+ * degree.
+ *   - `num_samples * level_count * (glwe_dimension + 1)` blocks of threads are
+ *     launched, where each thread handles one or more polynomial coefficients
+ * at each stage (for a given decomposition level), either for the LUT mask or
+ * its body: • Perform the blind rotation • Round the result • Decompose the
+ * current level • Switch to the FFT domain • Multiply with the bootstrapping
+ * key • Come back to the coefficient representation
+ *   - Between stages, some synchronizations happen at block level and between
+ * blocks (using cooperative groups).
+ *   - If the device has sufficient shared memory, temporary arrays for
+ * intermediate results (accumulators) are stored in shared memory.
+ *   - These accumulators serve to combine the results for all decomposition
+ * levels.
+ *   - The 64 KB of constant memory is used for storing the roots of unity for
+ * the FFT.
  */
+
 void cuda_programmable_bootstrap_lwe_ciphertext_vector_128(
     void *stream, uint32_t gpu_index, void *lwe_array_out,
-    void const *lwe_output_indexes, void const *lut_vector,
-    void const *lut_vector_indexes, void const *lwe_array_in,
-    void const *lwe_input_indexes, void const *bootstrapping_key,
-    int8_t *mem_ptr, uint32_t lwe_dimension, uint32_t glwe_dimension,
-    uint32_t polynomial_size, uint32_t base_log, uint32_t level_count,
-    uint32_t num_samples, uint32_t num_many_lut, uint32_t lut_stride) {
+    void const *lut_vector, void const *lwe_array_in,
+    void const *bootstrapping_key, int8_t *mem_ptr, uint32_t lwe_dimension,
+    uint32_t glwe_dimension, uint32_t polynomial_size, uint32_t base_log,
+    uint32_t level_count, uint32_t num_samples) {
   if (base_log > 64)
     PANIC("Cuda error (classical PBS): base log should be <= 64")
 
@@ -184,14 +161,10 @@ void cuda_programmable_bootstrap_lwe_ciphertext_vector_128(
 
   executor_cuda_programmable_bootstrap_lwe_ciphertext_vector_128<__uint128_t>(
       stream, gpu_index, static_cast<__uint128_t *>(lwe_array_out),
-      static_cast<const __uint128_t *>(lwe_output_indexes),
       static_cast<const __uint128_t *>(lut_vector),
-      static_cast<const __uint128_t *>(lut_vector_indexes),
       static_cast<const __uint128_t *>(lwe_array_in),
-      static_cast<const __uint128_t *>(lwe_input_indexes),
       static_cast<const double *>(bootstrapping_key), buffer, lwe_dimension,
-      glwe_dimension, polynomial_size, base_log, level_count, num_samples,
-      num_many_lut, lut_stride);
+      glwe_dimension, polynomial_size, base_log, level_count, num_samples);
 }
 
 /*

--- a/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_classic_128.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_classic_128.cuh
@@ -21,9 +21,7 @@ template <typename Torus, class params, sharedMemDegree SMD>
 __global__ void __launch_bounds__(params::degree / params::opt)
     device_programmable_bootstrap_step_one_128(
         const Torus *__restrict__ lut_vector,
-        const Torus *__restrict__ lut_vector_indexes,
         const Torus *__restrict__ lwe_array_in,
-        const Torus *__restrict__ lwe_input_indexes,
         const double *__restrict__ bootstrapping_key, Torus *global_accumulator,
         double *global_join_buffer, uint32_t lwe_iteration,
         uint32_t lwe_dimension, uint32_t polynomial_size, uint32_t base_log,
@@ -56,11 +54,9 @@ __global__ void __launch_bounds__(params::degree / params::opt)
   // The third dimension of the block is used to determine on which ciphertext
   // this block is operating, in the case of batch bootstraps
   const Torus *block_lwe_array_in =
-      &lwe_array_in[lwe_input_indexes[blockIdx.x] * (lwe_dimension + 1)];
+      &lwe_array_in[blockIdx.x * (lwe_dimension + 1)];
 
-  const Torus *block_lut_vector =
-      &lut_vector[lut_vector_indexes[blockIdx.x] * params::degree *
-                  (glwe_dimension + 1)];
+  const Torus *block_lut_vector = lut_vector;
 
   Torus *global_slice =
       global_accumulator +
@@ -148,15 +144,11 @@ __global__ void __launch_bounds__(params::degree / params::opt)
 template <typename Torus, class params, sharedMemDegree SMD>
 __global__ void __launch_bounds__(params::degree / params::opt)
     device_programmable_bootstrap_step_two_128(
-        Torus *lwe_array_out, const Torus *__restrict__ lwe_output_indexes,
-        const Torus *__restrict__ lut_vector,
-        const Torus *__restrict__ lut_vector_indexes,
-        const double *__restrict__ bootstrapping_key, Torus *global_accumulator,
-        double *global_join_buffer, uint32_t lwe_iteration,
-        uint32_t lwe_dimension, uint32_t polynomial_size, uint32_t base_log,
-        uint32_t level_count, int8_t *device_mem,
-        uint64_t device_memory_size_per_block, uint32_t num_many_lut,
-        uint32_t lut_stride) {
+        Torus *lwe_array_out, const double *__restrict__ bootstrapping_key,
+        Torus *global_accumulator, double *global_join_buffer,
+        uint32_t lwe_iteration, uint32_t lwe_dimension,
+        uint32_t polynomial_size, uint32_t base_log, uint32_t level_count,
+        int8_t *device_mem, uint64_t device_memory_size_per_block) {
 
   // We use shared memory for the polynomials that are used often during the
   // bootstrap, since shared memory is kept in L1 cache and accessing it is
@@ -231,8 +223,7 @@ __global__ void __launch_bounds__(params::degree / params::opt)
   if (lwe_iteration + 1 == lwe_dimension) {
     // Last iteration
     auto block_lwe_array_out =
-        &lwe_array_out[lwe_output_indexes[blockIdx.x] *
-                           (glwe_dimension * polynomial_size + 1) +
+        &lwe_array_out[blockIdx.x * (glwe_dimension * polynomial_size + 1) +
                        blockIdx.y * polynomial_size];
 
     if (blockIdx.y < glwe_dimension) {
@@ -240,37 +231,8 @@ __global__ void __launch_bounds__(params::degree / params::opt)
       // but we do the computation at block 0 to avoid waiting for extra blocks,
       // in case they're not synchronized
       sample_extract_mask<Torus, params>(block_lwe_array_out, accumulator);
-      if (num_many_lut > 1) {
-        for (int i = 1; i < num_many_lut; i++) {
-          auto next_lwe_array_out =
-              lwe_array_out +
-              (i * gridDim.x * (glwe_dimension * polynomial_size + 1));
-          auto next_block_lwe_array_out =
-              &next_lwe_array_out[lwe_output_indexes[blockIdx.x] *
-                                      (glwe_dimension * polynomial_size + 1) +
-                                  blockIdx.y * polynomial_size];
-
-          sample_extract_mask<Torus, params>(next_block_lwe_array_out,
-                                             accumulator, 1, i * lut_stride);
-        }
-      }
     } else if (blockIdx.y == glwe_dimension) {
       sample_extract_body<Torus, params>(block_lwe_array_out, accumulator, 0);
-      if (num_many_lut > 1) {
-        for (int i = 1; i < num_many_lut; i++) {
-
-          auto next_lwe_array_out =
-              lwe_array_out +
-              (i * gridDim.x * (glwe_dimension * polynomial_size + 1));
-          auto next_block_lwe_array_out =
-              &next_lwe_array_out[lwe_output_indexes[blockIdx.x] *
-                                      (glwe_dimension * polynomial_size + 1) +
-                                  blockIdx.y * polynomial_size];
-
-          sample_extract_body<Torus, params>(next_block_lwe_array_out,
-                                             accumulator, 0, i * lut_stride);
-        }
-      }
     }
   } else {
     // Persist the updated accumulator
@@ -351,8 +313,7 @@ __host__ void scratch_programmable_bootstrap_128(
 template <class params>
 __host__ void execute_step_one_128(
     cudaStream_t stream, uint32_t gpu_index, __uint128_t const *lut_vector,
-    __uint128_t const *lut_vector_indexes, __uint128_t const *lwe_array_in,
-    __uint128_t const *lwe_input_indexes, double const *bootstrapping_key,
+    __uint128_t const *lwe_array_in, double const *bootstrapping_key,
     __uint128_t *global_accumulator, double *global_join_buffer,
     uint32_t input_lwe_ciphertext_count, uint32_t lwe_dimension,
     uint32_t glwe_dimension, uint32_t polynomial_size, uint32_t base_log,
@@ -367,24 +328,21 @@ __host__ void execute_step_one_128(
   if (max_shared_memory < partial_sm) {
     device_programmable_bootstrap_step_one_128<__uint128_t, params, NOSM>
         <<<grid, thds, 0, stream>>>(
-            lut_vector, lut_vector_indexes, lwe_array_in, lwe_input_indexes,
-            bootstrapping_key, global_accumulator, global_join_buffer,
-            lwe_iteration, lwe_dimension, polynomial_size, base_log,
-            level_count, d_mem, full_dm);
+            lut_vector, lwe_array_in, bootstrapping_key, global_accumulator,
+            global_join_buffer, lwe_iteration, lwe_dimension, polynomial_size,
+            base_log, level_count, d_mem, full_dm);
   } else if (max_shared_memory < full_sm) {
     device_programmable_bootstrap_step_one_128<__uint128_t, params, PARTIALSM>
         <<<grid, thds, partial_sm, stream>>>(
-            lut_vector, lut_vector_indexes, lwe_array_in, lwe_input_indexes,
-            bootstrapping_key, global_accumulator, global_join_buffer,
-            lwe_iteration, lwe_dimension, polynomial_size, base_log,
-            level_count, d_mem, partial_dm);
+            lut_vector, lwe_array_in, bootstrapping_key, global_accumulator,
+            global_join_buffer, lwe_iteration, lwe_dimension, polynomial_size,
+            base_log, level_count, d_mem, partial_dm);
   } else {
     device_programmable_bootstrap_step_one_128<__uint128_t, params, FULLSM>
         <<<grid, thds, full_sm, stream>>>(
-            lut_vector, lut_vector_indexes, lwe_array_in, lwe_input_indexes,
-            bootstrapping_key, global_accumulator, global_join_buffer,
-            lwe_iteration, lwe_dimension, polynomial_size, base_log,
-            level_count, d_mem, 0);
+            lut_vector, lwe_array_in, bootstrapping_key, global_accumulator,
+            global_join_buffer, lwe_iteration, lwe_dimension, polynomial_size,
+            base_log, level_count, d_mem, 0);
   }
   check_cuda_error(cudaGetLastError());
 }
@@ -392,14 +350,12 @@ __host__ void execute_step_one_128(
 template <class params>
 __host__ void execute_step_two_128(
     cudaStream_t stream, uint32_t gpu_index, __uint128_t *lwe_array_out,
-    __uint128_t const *lwe_output_indexes, __uint128_t const *lut_vector,
-    __uint128_t const *lut_vector_indexes, double const *bootstrapping_key,
-    __uint128_t *global_accumulator, double *global_join_buffer,
-    uint32_t input_lwe_ciphertext_count, uint32_t lwe_dimension,
-    uint32_t glwe_dimension, uint32_t polynomial_size, uint32_t base_log,
-    uint32_t level_count, int8_t *d_mem, int lwe_iteration, uint64_t partial_sm,
-    uint64_t partial_dm, uint64_t full_sm, uint64_t full_dm,
-    uint32_t num_many_lut, uint32_t lut_stride) {
+    double const *bootstrapping_key, __uint128_t *global_accumulator,
+    double *global_join_buffer, uint32_t input_lwe_ciphertext_count,
+    uint32_t lwe_dimension, uint32_t glwe_dimension, uint32_t polynomial_size,
+    uint32_t base_log, uint32_t level_count, int8_t *d_mem, int lwe_iteration,
+    uint64_t partial_sm, uint64_t partial_dm, uint64_t full_sm,
+    uint64_t full_dm) {
 
   int max_shared_memory = cuda_get_max_shared_memory(gpu_index);
   cuda_set_device(gpu_index);
@@ -409,24 +365,21 @@ __host__ void execute_step_two_128(
   if (max_shared_memory < partial_sm) {
     device_programmable_bootstrap_step_two_128<__uint128_t, params, NOSM>
         <<<grid, thds, 0, stream>>>(
-            lwe_array_out, lwe_output_indexes, lut_vector, lut_vector_indexes,
-            bootstrapping_key, global_accumulator, global_join_buffer,
-            lwe_iteration, lwe_dimension, polynomial_size, base_log,
-            level_count, d_mem, full_dm, num_many_lut, lut_stride);
+            lwe_array_out, bootstrapping_key, global_accumulator,
+            global_join_buffer, lwe_iteration, lwe_dimension, polynomial_size,
+            base_log, level_count, d_mem, full_dm);
   } else if (max_shared_memory < full_sm) {
     device_programmable_bootstrap_step_two_128<__uint128_t, params, PARTIALSM>
         <<<grid, thds, partial_sm, stream>>>(
-            lwe_array_out, lwe_output_indexes, lut_vector, lut_vector_indexes,
-            bootstrapping_key, global_accumulator, global_join_buffer,
-            lwe_iteration, lwe_dimension, polynomial_size, base_log,
-            level_count, d_mem, partial_dm, num_many_lut, lut_stride);
+            lwe_array_out, bootstrapping_key, global_accumulator,
+            global_join_buffer, lwe_iteration, lwe_dimension, polynomial_size,
+            base_log, level_count, d_mem, partial_dm);
   } else {
     device_programmable_bootstrap_step_two_128<__uint128_t, params, FULLSM>
         <<<grid, thds, full_sm, stream>>>(
-            lwe_array_out, lwe_output_indexes, lut_vector, lut_vector_indexes,
-            bootstrapping_key, global_accumulator, global_join_buffer,
-            lwe_iteration, lwe_dimension, polynomial_size, base_log,
-            level_count, d_mem, 0, num_many_lut, lut_stride);
+            lwe_array_out, bootstrapping_key, global_accumulator,
+            global_join_buffer, lwe_iteration, lwe_dimension, polynomial_size,
+            base_log, level_count, d_mem, 0);
   }
   check_cuda_error(cudaGetLastError());
 }
@@ -437,13 +390,11 @@ __host__ void execute_step_two_128(
 template <class params>
 __host__ void host_programmable_bootstrap_128(
     cudaStream_t stream, uint32_t gpu_index, __uint128_t *lwe_array_out,
-    __uint128_t const *lwe_output_indexes, __uint128_t const *lut_vector,
-    __uint128_t const *lut_vector_indexes, __uint128_t const *lwe_array_in,
-    __uint128_t const *lwe_input_indexes, double const *bootstrapping_key,
-    pbs_buffer_128<CLASSICAL> *pbs_buffer, uint32_t glwe_dimension,
-    uint32_t lwe_dimension, uint32_t polynomial_size, uint32_t base_log,
-    uint32_t level_count, uint32_t input_lwe_ciphertext_count,
-    uint32_t num_many_lut, uint32_t lut_stride) {
+    __uint128_t const *lut_vector, __uint128_t const *lwe_array_in,
+    double const *bootstrapping_key, pbs_buffer_128<CLASSICAL> *pbs_buffer,
+    uint32_t glwe_dimension, uint32_t lwe_dimension, uint32_t polynomial_size,
+    uint32_t base_log, uint32_t level_count,
+    uint32_t input_lwe_ciphertext_count) {
   cuda_set_device(gpu_index);
 
   // With SM each block corresponds to either the mask or body, no need to
@@ -470,18 +421,16 @@ __host__ void host_programmable_bootstrap_128(
 
   for (int i = 0; i < lwe_dimension; i++) {
     execute_step_one_128<params>(
-        stream, gpu_index, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, global_accumulator,
-        global_join_buffer, input_lwe_ciphertext_count, lwe_dimension,
-        glwe_dimension, polynomial_size, base_log, level_count, d_mem, i,
-        partial_sm, partial_dm_step_one, full_sm_step_one, full_dm_step_one);
+        stream, gpu_index, lut_vector, lwe_array_in, bootstrapping_key,
+        global_accumulator, global_join_buffer, input_lwe_ciphertext_count,
+        lwe_dimension, glwe_dimension, polynomial_size, base_log, level_count,
+        d_mem, i, partial_sm, partial_dm_step_one, full_sm_step_one,
+        full_dm_step_one);
     execute_step_two_128<params>(
-        stream, gpu_index, lwe_array_out, lwe_output_indexes, lut_vector,
-        lut_vector_indexes, bootstrapping_key, global_accumulator,
+        stream, gpu_index, lwe_array_out, bootstrapping_key, global_accumulator,
         global_join_buffer, input_lwe_ciphertext_count, lwe_dimension,
         glwe_dimension, polynomial_size, base_log, level_count, d_mem, i,
-        partial_sm, partial_dm_step_two, full_sm_step_two, full_dm_step_two,
-        num_many_lut, lut_stride);
+        partial_sm, partial_dm_step_two, full_sm_step_two, full_dm_step_two);
   }
 }
 

--- a/backends/tfhe-cuda-backend/src/bindings.rs
+++ b/backends/tfhe-cuda-backend/src/bindings.rs
@@ -1602,11 +1602,8 @@ unsafe extern "C" {
         stream: *mut ffi::c_void,
         gpu_index: u32,
         lwe_array_out: *mut ffi::c_void,
-        lwe_output_indexes: *const ffi::c_void,
         lut_vector: *const ffi::c_void,
-        lut_vector_indexes: *const ffi::c_void,
         lwe_array_in: *const ffi::c_void,
-        lwe_input_indexes: *const ffi::c_void,
         bootstrapping_key: *const ffi::c_void,
         buffer: *mut i8,
         lwe_dimension: u32,
@@ -1615,8 +1612,6 @@ unsafe extern "C" {
         base_log: u32,
         level_count: u32,
         num_samples: u32,
-        num_many_lut: u32,
-        lut_stride: u32,
     );
 }
 unsafe extern "C" {

--- a/tfhe/benches/core_crypto/pbs128_bench.rs
+++ b/tfhe/benches/core_crypto/pbs128_bench.rs
@@ -164,8 +164,8 @@ mod cuda {
     use tfhe::core_crypto::gpu::glwe_ciphertext_list::CudaGlweCiphertextList;
     use tfhe::core_crypto::gpu::lwe_bootstrap_key::CudaLweBootstrapKey;
     use tfhe::core_crypto::gpu::lwe_ciphertext_list::CudaLweCiphertextList;
-    use tfhe::core_crypto::gpu::vec::{CudaVec, GpuIndex};
-    use tfhe::core_crypto::gpu::{cuda_programmable_bootstrap_lwe_ciphertext, CudaStreams};
+    use tfhe::core_crypto::gpu::vec::GpuIndex;
+    use tfhe::core_crypto::gpu::{cuda_programmable_bootstrap_128_lwe_ciphertext, CudaStreams};
     use tfhe::core_crypto::prelude::*;
     use tfhe::shortint::parameters::{
         DecompositionBaseLog, DecompositionLevelCount, DynamicDistribution, GlweDimension,
@@ -258,28 +258,15 @@ mod cuda {
             ciphertext_modulus,
         );
         let mut out_pbs_ct_gpu = CudaLweCiphertextList::from_lwe_ciphertext(&out_pbs_ct, &stream);
-        let h_indexes = &[Scalar::ZERO];
-        let mut d_input_indexes = unsafe { CudaVec::<Scalar>::new_async(1, &stream, 0) };
-        let mut d_output_indexes = unsafe { CudaVec::<Scalar>::new_async(1, &stream, 0) };
-        let mut d_lut_indexes = unsafe { CudaVec::<Scalar>::new_async(1, &stream, 0) };
-        unsafe {
-            d_input_indexes.copy_from_cpu_async(h_indexes.as_ref(), &stream, 0);
-            d_output_indexes.copy_from_cpu_async(h_indexes.as_ref(), &stream, 0);
-            d_lut_indexes.copy_from_cpu_async(h_indexes.as_ref(), &stream, 0);
-        }
-        stream.synchronize();
 
         let id = format!("{bench_name}::{params_name}");
         {
             bench_group.bench_function(&id, |b| {
                 b.iter(|| {
-                    cuda_programmable_bootstrap_lwe_ciphertext(
+                    cuda_programmable_bootstrap_128_lwe_ciphertext(
                         &lwe_ciphertext_in_gpu,
                         &mut out_pbs_ct_gpu,
                         &accumulator_gpu,
-                        &d_lut_indexes,
-                        &d_output_indexes,
-                        &d_input_indexes,
                         LweCiphertextCount(1),
                         &bsk_gpu,
                         &stream,

--- a/tfhe/src/core_crypto/gpu/algorithms/lwe_programmable_bootstrapping.rs
+++ b/tfhe/src/core_crypto/gpu/algorithms/lwe_programmable_bootstrapping.rs
@@ -2,7 +2,9 @@ use crate::core_crypto::gpu::entities::glwe_ciphertext_list::CudaGlweCiphertextL
 use crate::core_crypto::gpu::entities::lwe_bootstrap_key::CudaLweBootstrapKey;
 use crate::core_crypto::gpu::entities::lwe_ciphertext_list::CudaLweCiphertextList;
 use crate::core_crypto::gpu::vec::CudaVec;
-use crate::core_crypto::gpu::{programmable_bootstrap_async, CudaStreams};
+use crate::core_crypto::gpu::{
+    programmable_bootstrap_128_async, programmable_bootstrap_async, CudaStreams,
+};
 use crate::core_crypto::prelude::{CastInto, LweCiphertextCount, UnsignedTorus};
 
 /// # Safety
@@ -143,6 +145,133 @@ pub unsafe fn cuda_programmable_bootstrap_lwe_ciphertext_async<Scalar>(
     );
 }
 
+/// # Safety
+///
+/// - `streams` __must__ be synchronized to guarantee computation has finished, and inputs must not
+///   be dropped until streams is synchronised
+#[allow(clippy::too_many_arguments)]
+pub unsafe fn cuda_programmable_bootstrap_128_lwe_ciphertext_async<Scalar>(
+    input: &CudaLweCiphertextList<Scalar>,
+    output: &mut CudaLweCiphertextList<Scalar>,
+    accumulator: &CudaGlweCiphertextList<Scalar>,
+    num_samples: LweCiphertextCount,
+    bsk: &CudaLweBootstrapKey,
+    streams: &CudaStreams,
+) where
+    // CastInto required for PBS128 modulus switch which returns a usize
+    Scalar: UnsignedTorus + CastInto<usize>,
+{
+    assert_eq!(
+        size_of::<Scalar>(),
+        16,
+        "Wrong Scalar size: {:?}. \
+        Required Scalar size: 16.",
+        size_of::<Scalar>(),
+    );
+
+    assert_eq!(
+        accumulator.0.glwe_ciphertext_count.0,
+        1,
+        "Wrong lut count: {:?}. \
+        Required lut count: 1.",
+        size_of::<Scalar>(),
+    );
+
+    assert_eq!(
+        input.lwe_dimension(),
+        bsk.input_lwe_dimension(),
+        "Mismatched input LweDimension. LweCiphertext input LweDimension {:?}. \
+        FourierLweMultiBitBootstrapKey input LweDimension {:?}.",
+        input.lwe_dimension(),
+        bsk.input_lwe_dimension(),
+    );
+
+    assert_eq!(
+        output.lwe_dimension(),
+        bsk.output_lwe_dimension(),
+        "Mismatched output LweDimension. LweCiphertext output LweDimension {:?}. \
+        FourierLweMultiBitBootstrapKey output LweDimension {:?}.",
+        output.lwe_dimension(),
+        bsk.output_lwe_dimension(),
+    );
+
+    assert_eq!(
+        accumulator.glwe_dimension(),
+        bsk.glwe_dimension(),
+        "Mismatched GlweSize. Accumulator GlweSize {:?}. \
+        FourierLweMultiBitBootstrapKey GlweSize {:?}.",
+        accumulator.glwe_dimension(),
+        bsk.glwe_dimension(),
+    );
+
+    assert_eq!(
+        accumulator.polynomial_size(),
+        bsk.polynomial_size(),
+        "Mismatched PolynomialSize. Accumulator PolynomialSize {:?}. \
+        FourierLweMultiBitBootstrapKey PolynomialSize {:?}.",
+        accumulator.polynomial_size(),
+        bsk.polynomial_size(),
+    );
+
+    assert_eq!(
+        input.ciphertext_modulus(),
+        output.ciphertext_modulus(),
+        "Mismatched CiphertextModulus between input ({:?}) and output ({:?})",
+        input.ciphertext_modulus(),
+        output.ciphertext_modulus(),
+    );
+
+    assert_eq!(
+        input.ciphertext_modulus(),
+        accumulator.ciphertext_modulus(),
+        "Mismatched CiphertextModulus between input ({:?}) and accumulator ({:?})",
+        input.ciphertext_modulus(),
+        accumulator.ciphertext_modulus(),
+    );
+    assert_eq!(
+        streams.gpu_indexes[0],
+        bsk.d_vec.gpu_index(0),
+        "GPU error: first stream is on GPU {}, first bsk pointer is on GPU {}",
+        streams.gpu_indexes[0].get(),
+        bsk.d_vec.gpu_index(0).get(),
+    );
+    assert_eq!(
+        streams.gpu_indexes[0],
+        input.0.d_vec.gpu_index(0),
+        "GPU error: first stream is on GPU {}, first input pointer is on GPU {}",
+        streams.gpu_indexes[0].get(),
+        input.0.d_vec.gpu_index(0).get(),
+    );
+    assert_eq!(
+        streams.gpu_indexes[0],
+        output.0.d_vec.gpu_index(0),
+        "GPU error: first stream is on GPU {}, first output pointer is on GPU {}",
+        streams.gpu_indexes[0].get(),
+        output.0.d_vec.gpu_index(0).get(),
+    );
+    assert_eq!(
+        streams.gpu_indexes[0],
+        accumulator.0.d_vec.gpu_index(0),
+        "GPU error: first stream is on GPU {}, first accumulator pointer is on GPU {}",
+        streams.gpu_indexes[0].get(),
+        accumulator.0.d_vec.gpu_index(0).get(),
+    );
+
+    programmable_bootstrap_128_async(
+        streams,
+        &mut output.0.d_vec,
+        &accumulator.0.d_vec,
+        &input.0.d_vec,
+        &bsk.d_vec,
+        input.lwe_dimension(),
+        bsk.glwe_dimension(),
+        bsk.polynomial_size(),
+        bsk.decomp_base_log(),
+        bsk.decomp_level_count(),
+        num_samples.0 as u32,
+    );
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn cuda_programmable_bootstrap_lwe_ciphertext<Scalar>(
     input: &CudaLweCiphertextList<Scalar>,
@@ -155,7 +284,6 @@ pub fn cuda_programmable_bootstrap_lwe_ciphertext<Scalar>(
     bsk: &CudaLweBootstrapKey,
     streams: &CudaStreams,
 ) where
-    // CastInto required for PBS modulus switch which returns a usize
     Scalar: UnsignedTorus + CastInto<usize>,
 {
     unsafe {
@@ -166,6 +294,41 @@ pub fn cuda_programmable_bootstrap_lwe_ciphertext<Scalar>(
             lut_indexes,
             output_indexes,
             input_indexes,
+            num_samples,
+            bsk,
+            streams,
+        );
+    }
+    streams.synchronize();
+}
+
+/// Performs a programmable bootstrap (PBS) on a list of 128-bit LWE ciphertexts,
+/// storing the result back into the provided `output` list at matching indices.
+///
+/// # Behavior
+///
+/// - **Single-GLWE requirement**: The `accumulator` must contain exactly **one** GLWE ciphertext
+///   (i.e., one LUT).
+/// - **One LUT for all inputs**: That single LUT is applied uniformly to every LWE ciphertext in
+///   `input`.
+/// - **Index matching**: Each LWE ciphertext in `input` is transformed and stored at the **same
+///   index** in `output`.
+#[allow(clippy::too_many_arguments)]
+pub fn cuda_programmable_bootstrap_128_lwe_ciphertext<Scalar>(
+    input: &CudaLweCiphertextList<Scalar>,
+    output: &mut CudaLweCiphertextList<Scalar>,
+    accumulator: &CudaGlweCiphertextList<Scalar>,
+    num_samples: LweCiphertextCount,
+    bsk: &CudaLweBootstrapKey,
+    streams: &CudaStreams,
+) where
+    Scalar: UnsignedTorus + CastInto<usize>,
+{
+    unsafe {
+        cuda_programmable_bootstrap_128_lwe_ciphertext_async(
+            input,
+            output,
+            accumulator,
             num_samples,
             bsk,
             streams,

--- a/tfhe/src/core_crypto/gpu/mod.rs
+++ b/tfhe/src/core_crypto/gpu/mod.rs
@@ -122,83 +122,99 @@ pub unsafe fn programmable_bootstrap_async<T: UnsignedInteger>(
     let lut_stride = 0u32;
     let mut pbs_buffer: *mut i8 = std::ptr::null_mut();
 
-    if size_of::<T>() == 16 {
-        scratch_cuda_programmable_bootstrap_128(
-            streams.ptr[0],
-            streams.gpu_indexes[0].get(),
-            std::ptr::addr_of_mut!(pbs_buffer),
-            glwe_dimension.0 as u32,
-            polynomial_size.0 as u32,
-            level.0 as u32,
-            num_samples,
-            true,
-        );
+    scratch_cuda_programmable_bootstrap_64(
+        streams.ptr[0],
+        streams.gpu_indexes[0].get(),
+        std::ptr::addr_of_mut!(pbs_buffer),
+        glwe_dimension.0 as u32,
+        polynomial_size.0 as u32,
+        level.0 as u32,
+        num_samples,
+        true,
+    );
 
-        cuda_programmable_bootstrap_lwe_ciphertext_vector_128(
-            streams.ptr[0],
-            streams.gpu_indexes[0].get(),
-            lwe_array_out.as_mut_c_ptr(0),
-            lwe_out_indexes.as_c_ptr(0),
-            test_vector.as_c_ptr(0),
-            test_vector_indexes.as_c_ptr(0),
-            lwe_array_in.as_c_ptr(0),
-            lwe_in_indexes.as_c_ptr(0),
-            bootstrapping_key.as_c_ptr(0),
-            pbs_buffer,
-            lwe_dimension.0 as u32,
-            glwe_dimension.0 as u32,
-            polynomial_size.0 as u32,
-            base_log.0 as u32,
-            level.0 as u32,
-            num_samples,
-            num_many_lut,
-            lut_stride,
-        );
+    cuda_programmable_bootstrap_lwe_ciphertext_vector_64(
+        streams.ptr[0],
+        streams.gpu_indexes[0].get(),
+        lwe_array_out.as_mut_c_ptr(0),
+        lwe_out_indexes.as_c_ptr(0),
+        test_vector.as_c_ptr(0),
+        test_vector_indexes.as_c_ptr(0),
+        lwe_array_in.as_c_ptr(0),
+        lwe_in_indexes.as_c_ptr(0),
+        bootstrapping_key.as_c_ptr(0),
+        pbs_buffer,
+        lwe_dimension.0 as u32,
+        glwe_dimension.0 as u32,
+        polynomial_size.0 as u32,
+        base_log.0 as u32,
+        level.0 as u32,
+        num_samples,
+        num_many_lut,
+        lut_stride,
+    );
 
-        cleanup_cuda_programmable_bootstrap_128(
-            streams.ptr[0],
-            streams.gpu_indexes[0].get(),
-            std::ptr::addr_of_mut!(pbs_buffer),
-        );
-    } else {
-        scratch_cuda_programmable_bootstrap_64(
-            streams.ptr[0],
-            streams.gpu_indexes[0].get(),
-            std::ptr::addr_of_mut!(pbs_buffer),
-            glwe_dimension.0 as u32,
-            polynomial_size.0 as u32,
-            level.0 as u32,
-            num_samples,
-            true,
-        );
+    cleanup_cuda_programmable_bootstrap(
+        streams.ptr[0],
+        streams.gpu_indexes[0].get(),
+        std::ptr::addr_of_mut!(pbs_buffer),
+    );
+}
 
-        cuda_programmable_bootstrap_lwe_ciphertext_vector_64(
-            streams.ptr[0],
-            streams.gpu_indexes[0].get(),
-            lwe_array_out.as_mut_c_ptr(0),
-            lwe_out_indexes.as_c_ptr(0),
-            test_vector.as_c_ptr(0),
-            test_vector_indexes.as_c_ptr(0),
-            lwe_array_in.as_c_ptr(0),
-            lwe_in_indexes.as_c_ptr(0),
-            bootstrapping_key.as_c_ptr(0),
-            pbs_buffer,
-            lwe_dimension.0 as u32,
-            glwe_dimension.0 as u32,
-            polynomial_size.0 as u32,
-            base_log.0 as u32,
-            level.0 as u32,
-            num_samples,
-            num_many_lut,
-            lut_stride,
-        );
+/// Programmable bootstrap on a vector of 128 bit LWE ciphertexts
+///
+/// # Safety
+///
+/// [CudaStreams::synchronize] __must__ be called as soon as synchronization is
+/// required
+#[allow(clippy::too_many_arguments)]
+pub unsafe fn programmable_bootstrap_128_async<T: UnsignedInteger>(
+    streams: &CudaStreams,
+    lwe_array_out: &mut CudaVec<T>,
+    test_vector: &CudaVec<T>,
+    lwe_array_in: &CudaVec<T>,
+    bootstrapping_key: &CudaVec<f64>,
+    lwe_dimension: LweDimension,
+    glwe_dimension: GlweDimension,
+    polynomial_size: PolynomialSize,
+    base_log: DecompositionBaseLog,
+    level: DecompositionLevelCount,
+    num_samples: u32,
+) {
+    let mut pbs_buffer: *mut i8 = std::ptr::null_mut();
 
-        cleanup_cuda_programmable_bootstrap(
-            streams.ptr[0],
-            streams.gpu_indexes[0].get(),
-            std::ptr::addr_of_mut!(pbs_buffer),
-        );
-    }
+    scratch_cuda_programmable_bootstrap_128(
+        streams.ptr[0],
+        streams.gpu_indexes[0].get(),
+        std::ptr::addr_of_mut!(pbs_buffer),
+        glwe_dimension.0 as u32,
+        polynomial_size.0 as u32,
+        level.0 as u32,
+        num_samples,
+        true,
+    );
+
+    cuda_programmable_bootstrap_lwe_ciphertext_vector_128(
+        streams.ptr[0],
+        streams.gpu_indexes[0].get(),
+        lwe_array_out.as_mut_c_ptr(0),
+        test_vector.as_c_ptr(0),
+        lwe_array_in.as_c_ptr(0),
+        bootstrapping_key.as_c_ptr(0),
+        pbs_buffer,
+        lwe_dimension.0 as u32,
+        glwe_dimension.0 as u32,
+        polynomial_size.0 as u32,
+        base_log.0 as u32,
+        level.0 as u32,
+        num_samples,
+    );
+
+    cleanup_cuda_programmable_bootstrap_128(
+        streams.ptr[0],
+        streams.gpu_indexes[0].get(),
+        std::ptr::addr_of_mut!(pbs_buffer),
+    );
 }
 
 /// Programmable multi-bit bootstrap on a vector of LWE ciphertexts


### PR DESCRIPTION
### PR content/description

Remove lwe_input_indexes, lwe_output_indexes and lut_vector_indexes for pbs128.

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
