### PR TITLE
Ns/feat/noise squashed compression

### DIFF
--- a/tfhe/src/core_crypto/entities/lwe_packing_keyswitch_key.rs
+++ b/tfhe/src/core_crypto/entities/lwe_packing_keyswitch_key.rs
@@ -402,17 +402,19 @@ impl<Scalar: UnsignedInteger, C: ContainerMut<Element = Scalar>> ContiguousEntit
         Self: 'this;
 }
 
-pub struct LwePackingKeyswitchKeyConformanceParams {
+pub struct LwePackingKeyswitchKeyConformanceParams<Scalar: UnsignedInteger> {
     pub decomp_base_log: DecompositionBaseLog,
     pub decomp_level_count: DecompositionLevelCount,
     pub input_lwe_dimension: LweDimension,
     pub output_glwe_size: GlweSize,
     pub output_polynomial_size: PolynomialSize,
-    pub ciphertext_modulus: CiphertextModulus<u64>,
+    pub ciphertext_modulus: CiphertextModulus<Scalar>,
 }
 
-impl<C: Container<Element = u64>> ParameterSetConformant for LwePackingKeyswitchKey<C> {
-    type ParameterSet = LwePackingKeyswitchKeyConformanceParams;
+impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> ParameterSetConformant
+    for LwePackingKeyswitchKey<C>
+{
+    type ParameterSet = LwePackingKeyswitchKeyConformanceParams<Scalar>;
 
     fn is_conformant(&self, parameter_set: &Self::ParameterSet) -> bool {
         let Self {

--- a/tfhe/src/core_crypto/entities/packed_integers.rs
+++ b/tfhe/src/core_crypto/entities/packed_integers.rs
@@ -47,6 +47,8 @@ impl<Scalar: UnsignedInteger> PackedIntegers<Scalar> {
 
         let in_len = slice.len();
 
+        assert!(log_modulus <= Scalar::BITS);
+
         let number_bits_to_pack = in_len * log_modulus;
 
         let len = number_bits_to_pack.div_ceil(Scalar::BITS);

--- a/tfhe/src/core_crypto/entities/seeded_lwe_packing_keyswitch_key.rs
+++ b/tfhe/src/core_crypto/entities/seeded_lwe_packing_keyswitch_key.rs
@@ -461,8 +461,10 @@ impl<Scalar: UnsignedInteger, C: ContainerMut<Element = Scalar>> ContiguousEntit
         Self: 'this;
 }
 
-impl<C: Container<Element = u64>> ParameterSetConformant for SeededLwePackingKeyswitchKey<C> {
-    type ParameterSet = LwePackingKeyswitchKeyConformanceParams;
+impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> ParameterSetConformant
+    for SeededLwePackingKeyswitchKey<C>
+{
+    type ParameterSet = LwePackingKeyswitchKeyConformanceParams<Scalar>;
 
     fn is_conformant(&self, parameter_set: &Self::ParameterSet) -> bool {
         let Self {

--- a/tfhe/src/core_crypto/fft_impl/common.rs
+++ b/tfhe/src/core_crypto/fft_impl/common.rs
@@ -18,6 +18,11 @@ pub fn modulus_switch<Scalar: UnsignedInteger>(
     input: Scalar,
     log_modulus: CiphertextModulusLog,
 ) -> Scalar {
+    assert!(log_modulus.0 <= Scalar::BITS);
+    if log_modulus.0 == Scalar::BITS {
+        return input;
+    }
+
     // Flooring output_to_floor is equivalent to rounding the input
     let output_to_floor = input.wrapping_add(Scalar::ONE << (Scalar::BITS - log_modulus.0 - 1));
 

--- a/tfhe/src/integer/ciphertext/compressed_ciphertext_list.rs
+++ b/tfhe/src/integer/ciphertext/compressed_ciphertext_list.rs
@@ -170,6 +170,29 @@ mod tests {
     const NUM_BLOCKS: usize = 32;
 
     #[test]
+    fn test_empty_list_compression() {
+        let params = TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128.into();
+
+        let (cks, _) = gen_keys::<ShortintParameterSet>(params, IntegerKeyKind::Radix);
+
+        let private_compression_key = cks
+            .new_compression_private_key(TEST_COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128);
+
+        let (compression_key, decompression_key) =
+            cks.new_compression_decompression_keys(&private_compression_key);
+
+        let builder = CompressedCiphertextListBuilder::new();
+
+        let compressed = builder.build(&compression_key);
+
+        assert_eq!(compressed.len(), 0);
+        assert!(compressed
+            .get::<RadixCiphertext>(0, &decompression_key)
+            .unwrap()
+            .is_none())
+    }
+
+    #[test]
     fn test_ciphertext_compression() {
         for (params, comp_params) in [
             (

--- a/tfhe/src/shortint/backward_compatibility/ciphertext/mod.rs
+++ b/tfhe/src/shortint/backward_compatibility/ciphertext/mod.rs
@@ -257,3 +257,14 @@ pub enum CompressedCiphertextListVersions {
 pub enum SquashedNoiseCiphertextVersions {
     V0(SquashedNoiseCiphertext),
 }
+
+#[derive(VersionsDispatch)]
+pub enum CompressedSquashedNoiseCiphertextListVersions {
+    V0(CompressedSquashedNoiseCiphertextList),
+}
+
+#[derive(VersionsDispatch)]
+#[allow(dead_code)]
+pub(crate) enum CompressedSquashedNoiseCiphertextListMetaVersions {
+    V0(CompressedSquashedNoiseCiphertextListMeta),
+}

--- a/tfhe/src/shortint/backward_compatibility/list_compression.rs
+++ b/tfhe/src/shortint/backward_compatibility/list_compression.rs
@@ -2,8 +2,9 @@ use tfhe_versionable::deprecation::{Deprecable, Deprecated};
 use tfhe_versionable::VersionsDispatch;
 
 use crate::shortint::list_compression::{
-    CompressedCompressionKey, CompressedDecompressionKey, CompressionKey, CompressionPrivateKeys,
-    DecompressionKey,
+    CompressedCompressionKey, CompressedDecompressionKey, CompressedNoiseSquashingCompressionKey,
+    CompressionKey, CompressionPrivateKeys, DecompressionKey, NoiseSquashingCompressionKey,
+    NoiseSquashingCompressionPrivateKey,
 };
 
 #[derive(VersionsDispatch)]
@@ -42,4 +43,19 @@ pub enum CompressedDecompressionKeyVersions {
 #[derive(VersionsDispatch)]
 pub enum CompressionPrivateKeysVersions {
     V0(CompressionPrivateKeys),
+}
+
+#[derive(VersionsDispatch)]
+pub enum NoiseSquashingCompressionKeyVersions {
+    V0(NoiseSquashingCompressionKey),
+}
+
+#[derive(VersionsDispatch)]
+pub enum NoiseSquashingCompressionPrivateKeyVersions {
+    V0(NoiseSquashingCompressionPrivateKey),
+}
+
+#[derive(VersionsDispatch)]
+pub enum CompressedNoiseSquashingCompressionKeyVersions {
+    V0(CompressedNoiseSquashingCompressionKey),
 }

--- a/tfhe/src/shortint/backward_compatibility/parameters/noise_squashing.rs
+++ b/tfhe/src/shortint/backward_compatibility/parameters/noise_squashing.rs
@@ -1,7 +1,14 @@
-use crate::shortint::parameters::noise_squashing::NoiseSquashingParameters;
+use crate::shortint::parameters::noise_squashing::{
+    NoiseSquashingCompressionParameters, NoiseSquashingParameters,
+};
 use tfhe_versionable::VersionsDispatch;
 
 #[derive(VersionsDispatch)]
 pub enum NoiseSquashingParametersVersions {
     V0(NoiseSquashingParameters),
+}
+
+#[derive(VersionsDispatch)]
+pub enum NoiseSquashingCompressionParametersVersions {
+    V0(NoiseSquashingCompressionParameters),
 }

--- a/tfhe/src/shortint/ciphertext/compressed_ciphertext_list.rs
+++ b/tfhe/src/shortint/ciphertext/compressed_ciphertext_list.rs
@@ -3,9 +3,17 @@ use tfhe_versionable::Versionize;
 use self::compressed_modulus_switched_glwe_ciphertext::CompressedModulusSwitchedGlweCiphertext;
 use crate::conformance::ParameterSetConformant;
 use crate::core_crypto::prelude::*;
-use crate::shortint::backward_compatibility::ciphertext::CompressedCiphertextListVersions;
-use crate::shortint::parameters::{AtomicPatternKind, CompressedCiphertextConformanceParams};
-use crate::shortint::{CarryModulus, MessageModulus};
+use crate::error;
+use crate::shortint::backward_compatibility::ciphertext::{
+    CompressedCiphertextListVersions, CompressedSquashedNoiseCiphertextListMetaVersions,
+    CompressedSquashedNoiseCiphertextListVersions,
+};
+use crate::shortint::parameters::{
+    CompressedCiphertextConformanceParams, CompressedSquashedNoiseCiphertextConformanceParams,
+};
+use crate::shortint::{AtomicPatternKind, CarryModulus, MessageModulus};
+
+use super::SquashedNoiseCiphertext;
 
 #[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize, Versionize)]
 #[versionize(CompressedCiphertextListVersions)]
@@ -74,5 +82,126 @@ impl ParameterSetConformant for CompressedCiphertextList {
             && *message_modulus == params.message_modulus
             && *carry_modulus == params.carry_modulus
             && *atomic_pattern == params.atomic_pattern
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize, Versionize)]
+#[versionize(CompressedSquashedNoiseCiphertextListMetaVersions)]
+pub(crate) struct CompressedSquashedNoiseCiphertextListMeta {
+    pub(crate) message_modulus: MessageModulus,
+    pub(crate) carry_modulus: CarryModulus,
+    pub(crate) lwe_per_glwe: LweCiphertextCount,
+}
+
+/// A compressed list of [`SquashedNoiseCiphertext`].
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize, Versionize)]
+#[versionize(CompressedSquashedNoiseCiphertextListVersions)]
+pub struct CompressedSquashedNoiseCiphertextList {
+    pub(crate) glwe_ciphertext_list: Vec<CompressedModulusSwitchedGlweCiphertext<u128>>,
+    pub(crate) meta: Option<CompressedSquashedNoiseCiphertextListMeta>,
+}
+
+impl ParameterSetConformant for CompressedSquashedNoiseCiphertextList {
+    type ParameterSet = CompressedSquashedNoiseCiphertextConformanceParams;
+
+    fn is_conformant(&self, params: &CompressedSquashedNoiseCiphertextConformanceParams) -> bool {
+        let Self {
+            glwe_ciphertext_list,
+            meta,
+        } = self;
+
+        let len = glwe_ciphertext_list.len();
+
+        if len == 0 {
+            return true;
+        }
+
+        let Some(meta) = meta.as_ref() else {
+            return false;
+        };
+
+        let last_body_count = glwe_ciphertext_list.last().unwrap().bodies_count().0;
+
+        let count_is_ok = glwe_ciphertext_list[..len - 1]
+            .iter()
+            .all(|a| a.bodies_count() == params.lwe_per_glwe)
+            && last_body_count <= params.lwe_per_glwe.0;
+
+        count_is_ok
+            && glwe_ciphertext_list
+                .iter()
+                .all(|glwe| glwe.is_conformant(&params.ct_params))
+            && meta.lwe_per_glwe.0 <= params.ct_params.polynomial_size.0
+            && meta.lwe_per_glwe == params.lwe_per_glwe
+            && meta.message_modulus == params.message_modulus
+            && meta.carry_modulus == params.carry_modulus
+    }
+}
+
+impl CompressedSquashedNoiseCiphertextList {
+    pub fn len(&self) -> usize {
+        self.glwe_ciphertext_list
+            .iter()
+            .map(|comp_glwe| comp_glwe.bodies_count().0)
+            .sum()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Unpack a single ciphertext from the list.
+    ///
+    /// Return an error if the index is greater than the size of the list.
+    ///
+    /// After unpacking, the individual ciphertexts must be decrypted with the
+    /// [`NoiseSquashingPrivateKey`] derived from the [`NoiseSquashingCompressionPrivateKey`] used
+    /// for compression.
+    ///
+    /// [`NoiseSquashingPrivateKey`]: crate::shortint::noise_squashing::NoiseSquashingPrivateKey
+    /// [`NoiseSquashingCompressionPrivateKey`]: crate::shortint::list_compression::NoiseSquashingCompressionPrivateKey
+    pub fn unpack(&self, index: usize) -> Result<SquashedNoiseCiphertext, crate::Error> {
+        // Check this first to make sure we don't try to access the metadata if the list is empty
+        if index >= self.len() {
+            return Err(error!(
+                "Tried getting index {index} for CompressedSquashedNoiseCiphertextList \
+                with {} elements, out of bound access.",
+                self.len()
+            ));
+        }
+
+        let meta = self.meta.as_ref().ok_or_else(|| {
+            error!("Missing ciphertext metadata in CompressedSquashedNoiseCiphertextList")
+        })?;
+
+        let lwe_per_glwe = meta.lwe_per_glwe.0;
+        let glwe_idx = index / lwe_per_glwe;
+
+        let glwe = self.glwe_ciphertext_list[glwe_idx].extract();
+
+        let glwe_dimension = glwe.glwe_size().to_glwe_dimension();
+        let polynomial_size = glwe.polynomial_size();
+        let ciphertext_modulus = glwe.ciphertext_modulus();
+
+        let lwe_size = glwe_dimension
+            .to_equivalent_lwe_dimension(polynomial_size)
+            .to_lwe_size();
+
+        let monomial_degree = MonomialDegree(index % lwe_per_glwe);
+
+        let mut extracted_lwe = SquashedNoiseCiphertext::new_zero(
+            lwe_size,
+            ciphertext_modulus,
+            meta.message_modulus,
+            meta.carry_modulus,
+        );
+
+        extract_lwe_sample_from_glwe_ciphertext(
+            &glwe,
+            extracted_lwe.lwe_ciphertext_mut(),
+            monomial_degree,
+        );
+
+        Ok(extracted_lwe)
     }
 }

--- a/tfhe/src/shortint/ciphertext/compressed_ciphertext_list.rs
+++ b/tfhe/src/shortint/ciphertext/compressed_ciphertext_list.rs
@@ -10,13 +10,14 @@ use crate::shortint::{CarryModulus, MessageModulus};
 #[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize, Versionize)]
 #[versionize(CompressedCiphertextListVersions)]
 pub struct CompressedCiphertextList {
-    pub modulus_switched_glwe_ciphertext_list: Vec<CompressedModulusSwitchedGlweCiphertext<u64>>,
-    pub ciphertext_modulus: CiphertextModulus<u64>,
-    pub message_modulus: MessageModulus,
-    pub carry_modulus: CarryModulus,
-    pub atomic_pattern: AtomicPatternKind,
-    pub lwe_per_glwe: LweCiphertextCount,
-    pub count: CiphertextCount,
+    pub(crate) modulus_switched_glwe_ciphertext_list:
+        Vec<CompressedModulusSwitchedGlweCiphertext<u64>>,
+    pub(crate) ciphertext_modulus: CiphertextModulus<u64>,
+    pub(crate) message_modulus: MessageModulus,
+    pub(crate) carry_modulus: CarryModulus,
+    pub(crate) atomic_pattern: AtomicPatternKind,
+    pub(crate) lwe_per_glwe: LweCiphertextCount,
+    pub(crate) count: CiphertextCount,
 }
 
 impl CompressedCiphertextList {

--- a/tfhe/src/shortint/list_compression/compressed_server_keys.rs
+++ b/tfhe/src/shortint/list_compression/compressed_server_keys.rs
@@ -1,5 +1,7 @@
+use super::server_keys::NoiseSquashingCompressionKeyConformanceParams;
 use super::{
     CompressionKey, CompressionKeyConformanceParams, CompressionPrivateKeys, DecompressionKey,
+    NoiseSquashingCompressionKey,
 };
 use crate::conformance::ParameterSetConformant;
 use crate::core_crypto::fft_impl::fft64::crypto::bootstrap::LweBootstrapKeyConformanceParams;
@@ -12,6 +14,7 @@ use crate::core_crypto::prelude::{
 };
 use crate::shortint::backward_compatibility::list_compression::{
     CompressedCompressionKeyVersions, CompressedDecompressionKeyVersions,
+    CompressedNoiseSquashingCompressionKeyVersions,
 };
 use crate::shortint::client_key::atomic_pattern::AtomicPatternClientKey;
 use crate::shortint::client_key::ClientKey;
@@ -181,5 +184,51 @@ impl ParameterSetConformant for CompressedDecompressionKey {
         let params: LweBootstrapKeyConformanceParams<_> = (&params).into();
 
         blind_rotate_key.is_conformant(&params) && *lwe_per_glwe == parameter_set.lwe_per_glwe
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Versionize)]
+#[versionize(CompressedNoiseSquashingCompressionKeyVersions)]
+pub struct CompressedNoiseSquashingCompressionKey {
+    pub packing_key_switching_key: SeededLwePackingKeyswitchKey<Vec<u128>>,
+    pub lwe_per_glwe: LweCiphertextCount,
+}
+
+impl CompressedNoiseSquashingCompressionKey {
+    pub fn decompress(&self) -> NoiseSquashingCompressionKey {
+        let packing_key_switching_key = self
+            .packing_key_switching_key
+            .as_view()
+            .decompress_into_lwe_packing_keyswitch_key();
+
+        NoiseSquashingCompressionKey {
+            packing_key_switching_key,
+            lwe_per_glwe: self.lwe_per_glwe,
+        }
+    }
+}
+
+impl ParameterSetConformant for CompressedNoiseSquashingCompressionKey {
+    type ParameterSet = NoiseSquashingCompressionKeyConformanceParams;
+
+    fn is_conformant(&self, parameter_set: &Self::ParameterSet) -> bool {
+        let Self {
+            packing_key_switching_key,
+            lwe_per_glwe,
+        } = self;
+
+        let params = LwePackingKeyswitchKeyConformanceParams {
+            decomp_base_log: parameter_set.packing_ks_base_log,
+            decomp_level_count: parameter_set.packing_ks_level,
+            input_lwe_dimension: parameter_set
+                .uncompressed_glwe_dimension
+                .to_equivalent_lwe_dimension(parameter_set.uncompressed_polynomial_size),
+            output_glwe_size: parameter_set.packing_ks_glwe_dimension.to_glwe_size(),
+            output_polynomial_size: parameter_set.packing_ks_polynomial_size,
+            ciphertext_modulus: parameter_set.cipherext_modulus,
+        };
+
+        packing_key_switching_key.is_conformant(&params)
+            && *lwe_per_glwe == parameter_set.lwe_per_glwe
     }
 }

--- a/tfhe/src/shortint/list_compression/compression.rs
+++ b/tfhe/src/shortint/list_compression/compression.rs
@@ -12,7 +12,7 @@ use crate::shortint::server_key::{
     apply_programmable_bootstrap_no_ms_noise_reduction, generate_lookup_table_with_output_encoding,
     unchecked_scalar_mul_assign, LookupTableSize, ShortintBootstrappingKey,
 };
-use crate::shortint::{Ciphertext, MaxNoiseLevel};
+use crate::shortint::{AtomicPatternKind, Ciphertext, MaxNoiseLevel, PBSOrder};
 use rayon::iter::ParallelIterator;
 use rayon::slice::ParallelSlice;
 
@@ -21,16 +21,30 @@ impl CompressionKey {
         &self,
         ciphertexts: &[Ciphertext],
     ) -> CompressedCiphertextList {
+        let lwe_pksk = &self.packing_key_switching_key;
+        let lwe_per_glwe = self.lwe_per_glwe;
+        let ciphertext_modulus = lwe_pksk.ciphertext_modulus();
+
+        if ciphertexts.is_empty() {
+            return CompressedCiphertextList {
+                modulus_switched_glwe_ciphertext_list: Vec::new(),
+                // These values don't matter if the list is empty
+                message_modulus: MessageModulus(1),
+                carry_modulus: CarryModulus(1),
+                atomic_pattern: AtomicPatternKind::Standard(PBSOrder::KeyswitchBootstrap),
+                lwe_per_glwe,
+                count: CiphertextCount(0),
+                ciphertext_modulus,
+            };
+        }
+
         let count = CiphertextCount(ciphertexts.len());
 
         let lwe_pksk = &self.packing_key_switching_key;
 
         let polynomial_size = lwe_pksk.output_polynomial_size();
-        let ciphertext_modulus = lwe_pksk.ciphertext_modulus();
         let glwe_size = lwe_pksk.output_glwe_size();
         let lwe_size = lwe_pksk.input_key_lwe_dimension().to_lwe_size();
-
-        let lwe_per_glwe = self.lwe_per_glwe;
 
         assert!(
             lwe_per_glwe.0 <= polynomial_size.0,
@@ -133,19 +147,20 @@ impl DecompressionKey {
         packed: &CompressedCiphertextList,
         index: usize,
     ) -> Result<Ciphertext, crate::Error> {
-        if packed.message_modulus.0 != packed.carry_modulus.0 {
-            return Err(crate::Error::new(format!(
-                "Tried to unpack values from a list where message modulus \
-                ({:?}) is != carry modulus ({:?}), this is not supported.",
-                packed.message_modulus, packed.carry_modulus,
-            )));
-        }
-
+        // Check this first to make sure we don't try to access the metadata if the list is empty
         if index >= packed.count.0 {
             return Err(crate::Error::new(format!(
                 "Tried getting index {index} for CompressedCiphertextList \
                 with {} elements, out of bound access.",
                 packed.count.0
+            )));
+        }
+
+        if packed.message_modulus.0 != packed.carry_modulus.0 {
+            return Err(crate::Error::new(format!(
+                "Tried to unpack values from a list where message modulus \
+                ({:?}) is != carry modulus ({:?}), this is not supported.",
+                packed.message_modulus, packed.carry_modulus,
             )));
         }
 
@@ -269,7 +284,7 @@ mod test {
             let (compression_key, decompression_key) =
                 cks.new_compression_decompression_keys(&private_compression_key);
 
-            for number_to_pack in [1, 128] {
+            for number_to_pack in [0, 1, 128] {
                 let f = |x| (x + 1) % params.message_modulus().0;
 
                 test_packing_(

--- a/tfhe/src/shortint/list_compression/mod.rs
+++ b/tfhe/src/shortint/list_compression/mod.rs
@@ -1,8 +1,13 @@
 mod compressed_server_keys;
 mod compression;
+mod noise_squashing_compression;
 mod private_key;
 mod server_keys;
 
-pub use compressed_server_keys::{CompressedCompressionKey, CompressedDecompressionKey};
-pub use private_key::CompressionPrivateKeys;
-pub use server_keys::{CompressionKey, CompressionKeyConformanceParams, DecompressionKey};
+pub use compressed_server_keys::{
+    CompressedCompressionKey, CompressedDecompressionKey, CompressedNoiseSquashingCompressionKey,
+};
+pub use private_key::{CompressionPrivateKeys, NoiseSquashingCompressionPrivateKey};
+pub use server_keys::{
+    CompressionKey, CompressionKeyConformanceParams, DecompressionKey, NoiseSquashingCompressionKey,
+};

--- a/tfhe/src/shortint/list_compression/noise_squashing_compression.rs
+++ b/tfhe/src/shortint/list_compression/noise_squashing_compression.rs
@@ -1,0 +1,206 @@
+use rayon::iter::ParallelIterator;
+use rayon::slice::ParallelSlice;
+
+use crate::core_crypto::prelude::compressed_modulus_switched_glwe_ciphertext::CompressedModulusSwitchedGlweCiphertext;
+use crate::core_crypto::prelude::{
+    par_keyswitch_lwe_ciphertext_list_and_pack_in_glwe_ciphertext, GlweCiphertext,
+    LweCiphertextList,
+};
+use crate::shortint::ciphertext::{
+    CompressedSquashedNoiseCiphertextList, CompressedSquashedNoiseCiphertextListMeta,
+    SquashedNoiseCiphertext,
+};
+use crate::shortint::parameters::LweCiphertextCount;
+
+use super::server_keys::NoiseSquashingCompressionKey;
+
+impl NoiseSquashingCompressionKey {
+    /// Compress a list of [`SquashedNoiseCiphertext`] into a GLWE list.
+    ///
+    /// This is similar to
+    /// [`CompressionKey::compress_ciphertexts_into_list`](crate::shortint::list_compression::CompressionKey::compress_ciphertexts_into_list),
+    /// however it is possible to extract the ciphertexts without a PBS.
+    pub fn compress_noise_squashed_ciphertexts_into_list(
+        &self,
+        ciphertexts: &[SquashedNoiseCiphertext],
+    ) -> CompressedSquashedNoiseCiphertextList {
+        let lwe_pksk = &self.packing_key_switching_key;
+        let lwe_per_glwe = self.lwe_per_glwe;
+        let polynomial_size = lwe_pksk.output_polynomial_size();
+        let glwe_size = lwe_pksk.output_glwe_size();
+
+        if ciphertexts.is_empty() {
+            return CompressedSquashedNoiseCiphertextList {
+                glwe_ciphertext_list: Vec::new(),
+                meta: None,
+            };
+        }
+
+        let lwe_pksk = &self.packing_key_switching_key;
+
+        let lwe_size = lwe_pksk.input_key_lwe_dimension().to_lwe_size();
+
+        assert!(
+            lwe_per_glwe.0 <= polynomial_size.0,
+            "Cannot pack more than polynomial_size(={}) elements per glwe, {} requested",
+            polynomial_size.0,
+            lwe_per_glwe.0,
+        );
+
+        let first_ct = &ciphertexts[0];
+
+        let message_modulus = first_ct.message_modulus();
+        let carry_modulus = first_ct.carry_modulus();
+        let ciphertext_modulus = first_ct.lwe_ciphertext().ciphertext_modulus();
+
+        assert!(
+            ciphertext_modulus.is_power_of_two(),
+            "Squashed noise ciphertext modulus should be a power of 2 for compression, got {ciphertext_modulus:?}"
+
+        );
+
+        let ciphertext_modulus_log = ciphertext_modulus.into_modulus_log();
+
+        let glwe_ciphertext_list: Vec<_> = ciphertexts
+            .par_chunks(lwe_per_glwe.0)
+            .map(|ct_list| {
+                let mut list: Vec<_> = vec![];
+
+                for ct in ct_list {
+                    assert_eq!(
+                        lwe_size,
+                        ct.lwe_ciphertext().lwe_size(),
+                        "All ciphertexts do not have the same lwe size as the packing keyswitch key"
+                    );
+
+                    assert_eq!(
+                        message_modulus,
+                        ct.message_modulus(),
+                        "All ciphertexts do not have the same message modulus"
+                    );
+
+                    assert_eq!(
+                        carry_modulus,
+                        ct.carry_modulus(),
+                        "All ciphertexts do not have the same message modulus"
+                    );
+
+                    list.extend(ct.lwe_ciphertext().as_ref());
+                }
+
+                let list = LweCiphertextList::from_container(list, lwe_size, ciphertext_modulus);
+
+                let mut out =
+                    GlweCiphertext::new(0u128, glwe_size, polynomial_size, ciphertext_modulus);
+
+                par_keyswitch_lwe_ciphertext_list_and_pack_in_glwe_ciphertext(
+                    lwe_pksk, &list, &mut out,
+                );
+
+                CompressedModulusSwitchedGlweCiphertext::compress(
+                    &out,
+                    ciphertext_modulus_log,
+                    LweCiphertextCount(ct_list.len()),
+                )
+            })
+            .collect();
+
+        let meta = Some(CompressedSquashedNoiseCiphertextListMeta {
+            message_modulus,
+            carry_modulus,
+            lwe_per_glwe,
+        });
+
+        CompressedSquashedNoiseCiphertextList {
+            glwe_ciphertext_list,
+            meta,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::shortint::keycache::KEY_CACHE;
+    use crate::shortint::list_compression::private_key::NoiseSquashingCompressionPrivateKey;
+    use crate::shortint::noise_squashing::{NoiseSquashingKey, NoiseSquashingPrivateKey};
+    use crate::shortint::parameters::v1_3::V1_3_NOISE_SQUASHING_COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+    use crate::shortint::parameters::*;
+
+    use rand::prelude::*;
+    use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+
+    #[test]
+    fn test_noise_squashing_compression_ci_run_filter() {
+        let keycache_entry =
+            KEY_CACHE.get_from_param(PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128);
+        let (cks, sks) = (keycache_entry.client_key(), keycache_entry.server_key());
+        let noise_squashing_private_key = NoiseSquashingPrivateKey::new(
+            NOISE_SQUASHING_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+        );
+        let noise_squashing_key = NoiseSquashingKey::new(cks, &noise_squashing_private_key);
+
+        let compression_private_key = NoiseSquashingCompressionPrivateKey::new(
+            V1_3_NOISE_SQUASHING_COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+        );
+
+        let compression_key = noise_squashing_private_key
+            .new_noise_squashing_compression_key(&compression_private_key);
+
+        let mut rng = thread_rng();
+
+        let id_lut = sks.generate_lookup_table(|x| x);
+        let max_ct_count =
+            V1_3_NOISE_SQUASHING_COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128.lwe_per_glwe;
+
+        for ct_count in [0, 1, max_ct_count.0] {
+            // Generate random msgs
+            let msgs: Vec<_> = (0..ct_count)
+                .map(|_| {
+                    (
+                        rng.gen::<u64>() % cks.parameters().message_modulus().0,
+                        rng.gen::<u64>() % cks.parameters().message_modulus().0,
+                    )
+                })
+                .collect();
+
+            // Pack the ciphertext and apply noise squashing
+            let ct: Vec<_> = msgs
+                .par_iter()
+                .map(|(msg_1, msg_2)| {
+                    let mut ct_1 = cks.encrypt(*msg_1);
+                    let mut ct_2 = cks.encrypt(*msg_2);
+
+                    // Set ciphertext noise level to nominal
+                    rayon::join(
+                        || sks.apply_lookup_table_assign(&mut ct_1, &id_lut),
+                        || sks.apply_lookup_table_assign(&mut ct_2, &id_lut),
+                    );
+
+                    let packed = sks.unchecked_add(
+                        &sks.unchecked_scalar_mul(&ct_1, sks.message_modulus.0.try_into().unwrap()),
+                        &ct_2,
+                    );
+
+                    noise_squashing_key.squash_ciphertext_noise(&packed, sks)
+                })
+                .collect();
+
+            // Compress the ciphertexts in a list
+            let compressed = compression_key.compress_noise_squashed_ciphertexts_into_list(&ct);
+
+            // Extract from the list and decrypt
+            let decrypted_values =
+                compression_private_key.unpack_and_decrypt_squashed_noise_ciphertexts(&compressed);
+
+            for (idx, value) in decrypted_values.iter().enumerate() {
+                let dec_msg1 = value / (sks.message_modulus.0 as u128);
+                let dec_msg2 = value % (sks.message_modulus.0 as u128);
+
+                let msg = msgs[idx];
+
+                assert_eq!(dec_msg1, msg.0 as u128);
+                assert_eq!(dec_msg2, msg.1 as u128);
+            }
+        }
+    }
+}

--- a/tfhe/src/shortint/list_compression/private_key.rs
+++ b/tfhe/src/shortint/list_compression/private_key.rs
@@ -3,10 +3,14 @@ use tfhe_versionable::Versionize;
 use crate::core_crypto::prelude::{
     allocate_and_generate_new_binary_glwe_secret_key, GlweSecretKeyOwned,
 };
-use crate::shortint::backward_compatibility::list_compression::CompressionPrivateKeysVersions;
+use crate::shortint::backward_compatibility::list_compression::{
+    CompressionPrivateKeysVersions, NoiseSquashingCompressionPrivateKeyVersions,
+};
+use crate::shortint::ciphertext::CompressedSquashedNoiseCiphertextList;
 use crate::shortint::client_key::ClientKey;
 use crate::shortint::engine::ShortintEngine;
-use crate::shortint::parameters::list_compression::CompressionParameters;
+use crate::shortint::noise_squashing::NoiseSquashingPrivateKeyView;
+use crate::shortint::parameters::{CompressionParameters, NoiseSquashingCompressionParameters};
 use crate::shortint::EncryptionKeyChoice;
 use std::fmt::Debug;
 
@@ -43,5 +47,44 @@ impl ClientKey {
             post_packing_ks_key,
             params,
         }
+    }
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, Versionize)]
+#[versionize(NoiseSquashingCompressionPrivateKeyVersions)]
+pub struct NoiseSquashingCompressionPrivateKey {
+    pub(crate) post_packing_ks_key: GlweSecretKeyOwned<u128>,
+    pub(crate) params: NoiseSquashingCompressionParameters,
+}
+
+impl NoiseSquashingCompressionPrivateKey {
+    pub fn new(params: NoiseSquashingCompressionParameters) -> Self {
+        let post_packing_ks_key = ShortintEngine::with_thread_local_mut(|engine| {
+            allocate_and_generate_new_binary_glwe_secret_key(
+                params.packing_ks_glwe_dimension,
+                params.packing_ks_polynomial_size,
+                &mut engine.secret_generator,
+            )
+        });
+
+        Self {
+            post_packing_ks_key,
+            params,
+        }
+    }
+
+    /// Extract and decrypt all the ciphertexts in the list
+    pub fn unpack_and_decrypt_squashed_noise_ciphertexts(
+        &self,
+        compressed_list: &CompressedSquashedNoiseCiphertextList,
+    ) -> Vec<u128> {
+        let decryption_key = NoiseSquashingPrivateKeyView::from(self);
+        (0..compressed_list.len())
+            .map(|i| {
+                let ciphertext = compressed_list.unpack(i).unwrap(); // i is smaller than list size
+
+                decryption_key.decrypt_squashed_noise_ciphertext(&ciphertext)
+            })
+            .collect()
     }
 }

--- a/tfhe/src/shortint/list_compression/server_keys.rs
+++ b/tfhe/src/shortint/list_compression/server_keys.rs
@@ -1,14 +1,19 @@
+use super::private_key::NoiseSquashingCompressionPrivateKey;
 use super::CompressionPrivateKeys;
 use crate::conformance::ParameterSetConformant;
 use crate::core_crypto::prelude::*;
 use crate::shortint::atomic_pattern::AtomicPatternParameters;
 use crate::shortint::backward_compatibility::list_compression::{
-    CompressionKeyVersions, DecompressionKeyVersions,
+    CompressionKeyVersions, DecompressionKeyVersions, NoiseSquashingCompressionKeyVersions,
 };
 use crate::shortint::client_key::atomic_pattern::AtomicPatternClientKey;
 use crate::shortint::client_key::ClientKey;
 use crate::shortint::engine::ShortintEngine;
-use crate::shortint::parameters::{CompressionParameters, PolynomialSize};
+use crate::shortint::noise_squashing::NoiseSquashingPrivateKey;
+use crate::shortint::parameters::{
+    CompressionParameters, NoiseSquashingCompressionParameters, NoiseSquashingParameters,
+    PolynomialSize,
+};
 use crate::shortint::server_key::{
     PBSConformanceParams, PbsTypeConformanceParams, ShortintBootstrappingKey,
 };
@@ -203,5 +208,102 @@ impl From<&CompressionKeyConformanceParams> for PBSConformanceParams {
                 modulus_switch_noise_reduction: None,
             },
         }
+    }
+}
+
+/// A compression key used to compress a list of [`SquashedNoiseCiphertext`]
+///
+/// [`SquashedNoiseCiphertext`]: crate::shortint::ciphertext::SquashedNoiseCiphertext
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Versionize)]
+#[versionize(NoiseSquashingCompressionKeyVersions)]
+pub struct NoiseSquashingCompressionKey {
+    pub(super) packing_key_switching_key: LwePackingKeyswitchKey<Vec<u128>>,
+    pub(super) lwe_per_glwe: LweCiphertextCount,
+}
+
+impl NoiseSquashingPrivateKey {
+    pub fn new_noise_squashing_compression_key(
+        &self,
+        private_compression_key: &NoiseSquashingCompressionPrivateKey,
+    ) -> NoiseSquashingCompressionKey {
+        let params = &private_compression_key.params;
+
+        let packing_key_switching_key = ShortintEngine::with_thread_local_mut(|engine| {
+            allocate_and_generate_new_lwe_packing_keyswitch_key(
+                &self.post_noise_squashing_secret_key().as_lwe_secret_key(),
+                &private_compression_key.post_packing_ks_key,
+                params.packing_ks_base_log,
+                params.packing_ks_level,
+                params.packing_ks_key_noise_distribution,
+                params.ciphertext_modulus,
+                &mut engine.encryption_generator,
+            )
+        });
+
+        NoiseSquashingCompressionKey {
+            packing_key_switching_key,
+            lwe_per_glwe: params.lwe_per_glwe,
+        }
+    }
+}
+
+pub struct NoiseSquashingCompressionKeyConformanceParams {
+    pub packing_ks_level: DecompositionLevelCount,
+    pub packing_ks_base_log: DecompositionBaseLog,
+    pub packing_ks_polynomial_size: PolynomialSize,
+    pub packing_ks_glwe_dimension: GlweDimension,
+    pub lwe_per_glwe: LweCiphertextCount,
+    pub uncompressed_polynomial_size: PolynomialSize,
+    pub uncompressed_glwe_dimension: GlweDimension,
+    pub cipherext_modulus: CiphertextModulus<u128>,
+}
+
+impl
+    From<(
+        NoiseSquashingParameters,
+        NoiseSquashingCompressionParameters,
+    )> for NoiseSquashingCompressionKeyConformanceParams
+{
+    fn from(
+        (squashing_params, compression_params): (
+            NoiseSquashingParameters,
+            NoiseSquashingCompressionParameters,
+        ),
+    ) -> Self {
+        Self {
+            packing_ks_level: compression_params.packing_ks_level,
+            packing_ks_base_log: compression_params.packing_ks_base_log,
+            packing_ks_polynomial_size: compression_params.packing_ks_polynomial_size,
+            packing_ks_glwe_dimension: compression_params.packing_ks_glwe_dimension,
+            lwe_per_glwe: compression_params.lwe_per_glwe,
+            uncompressed_polynomial_size: squashing_params.polynomial_size,
+            uncompressed_glwe_dimension: squashing_params.glwe_dimension,
+            cipherext_modulus: compression_params.ciphertext_modulus,
+        }
+    }
+}
+
+impl ParameterSetConformant for NoiseSquashingCompressionKey {
+    type ParameterSet = NoiseSquashingCompressionKeyConformanceParams;
+
+    fn is_conformant(&self, parameter_set: &Self::ParameterSet) -> bool {
+        let Self {
+            packing_key_switching_key,
+            lwe_per_glwe,
+        } = self;
+
+        let params = LwePackingKeyswitchKeyConformanceParams {
+            decomp_base_log: parameter_set.packing_ks_base_log,
+            decomp_level_count: parameter_set.packing_ks_level,
+            input_lwe_dimension: parameter_set
+                .uncompressed_glwe_dimension
+                .to_equivalent_lwe_dimension(parameter_set.uncompressed_polynomial_size),
+            output_glwe_size: parameter_set.packing_ks_glwe_dimension.to_glwe_size(),
+            output_polynomial_size: parameter_set.packing_ks_polynomial_size,
+            ciphertext_modulus: parameter_set.cipherext_modulus,
+        };
+
+        packing_key_switching_key.is_conformant(&params)
+            && *lwe_per_glwe == parameter_set.lwe_per_glwe
     }
 }

--- a/tfhe/src/shortint/noise_squashing/mod.rs
+++ b/tfhe/src/shortint/noise_squashing/mod.rs
@@ -6,4 +6,5 @@ pub mod tests;
 
 pub use compressed_server_key::CompressedNoiseSquashingKey;
 pub use private_key::NoiseSquashingPrivateKey;
+pub(crate) use private_key::NoiseSquashingPrivateKeyView;
 pub use server_key::{NoiseSquashingKey, NoiseSquashingKeyConformanceParams};

--- a/tfhe/src/shortint/parameters/mod.rs
+++ b/tfhe/src/shortint/parameters/mod.rs
@@ -70,7 +70,7 @@ pub use coverage_parameters::*;
 pub use key_switching::ShortintKeySwitchingParameters;
 pub use ks32::KeySwitch32PBSParameters;
 pub use multi_bit::MultiBitPBSParameters;
-pub use noise_squashing::NoiseSquashingParameters;
+pub use noise_squashing::{NoiseSquashingCompressionParameters, NoiseSquashingParameters};
 pub use parameters_wopbs::*;
 #[cfg(test)]
 pub use test_params::TestParameters;
@@ -151,6 +151,17 @@ pub struct CompressedCiphertextConformanceParams {
     pub degree: Degree,
     pub noise_level: NoiseLevel,
     pub atomic_pattern: AtomicPatternKind,
+}
+
+/// Structure to store the expected properties of a compressed squashed noise ciphertext
+/// Can be used on a server to check if client inputs are well formed before running a computation
+/// on them
+#[derive(Copy, Clone)]
+pub struct CompressedSquashedNoiseCiphertextConformanceParams {
+    pub ct_params: GlweCiphertextConformanceParams<u128>,
+    pub lwe_per_glwe: LweCiphertextCount,
+    pub message_modulus: MessageModulus,
+    pub carry_modulus: CarryModulus,
 }
 
 /// Structure to store the expected properties of a ciphertext list

--- a/tfhe/src/shortint/parameters/noise_squashing.rs
+++ b/tfhe/src/shortint/parameters/noise_squashing.rs
@@ -1,8 +1,8 @@
-use crate::shortint::backward_compatibility::parameters::noise_squashing::NoiseSquashingParametersVersions;
+use crate::shortint::backward_compatibility::parameters::noise_squashing::*;
 use crate::shortint::parameters::{
     CarryModulus, CoreCiphertextModulus, DecompositionBaseLog, DecompositionLevelCount,
-    DynamicDistribution, GlweDimension, MessageModulus, ModulusSwitchNoiseReductionParams,
-    PolynomialSize,
+    DynamicDistribution, GlweDimension, LweCiphertextCount, MessageModulus,
+    ModulusSwitchNoiseReductionParams, PolynomialSize,
 };
 use serde::{Deserialize, Serialize};
 use tfhe_versionable::Versionize;
@@ -16,6 +16,20 @@ pub struct NoiseSquashingParameters {
     pub decomp_base_log: DecompositionBaseLog,
     pub decomp_level_count: DecompositionLevelCount,
     pub modulus_switch_noise_reduction_params: Option<ModulusSwitchNoiseReductionParams>,
+    pub message_modulus: MessageModulus,
+    pub carry_modulus: CarryModulus,
+    pub ciphertext_modulus: CoreCiphertextModulus<u128>,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize, Versionize)]
+#[versionize(NoiseSquashingCompressionParametersVersions)]
+pub struct NoiseSquashingCompressionParameters {
+    pub packing_ks_level: DecompositionLevelCount,
+    pub packing_ks_base_log: DecompositionBaseLog,
+    pub packing_ks_polynomial_size: PolynomialSize,
+    pub packing_ks_glwe_dimension: GlweDimension,
+    pub lwe_per_glwe: LweCiphertextCount,
+    pub packing_ks_key_noise_distribution: DynamicDistribution<u128>,
     pub message_modulus: MessageModulus,
     pub carry_modulus: CarryModulus,
     pub ciphertext_modulus: CoreCiphertextModulus<u128>,

--- a/tfhe/src/shortint/parameters/v1_3/mod.rs
+++ b/tfhe/src/shortint/parameters/v1_3/mod.rs
@@ -45,8 +45,8 @@ pub use hpu::*;
 
 use crate::shortint::parameters::{
     ClassicPBSParameters, CompactPublicKeyEncryptionParameters, CompressionParameters,
-    KeySwitch32PBSParameters, MultiBitPBSParameters, NoiseSquashingParameters,
-    ShortintKeySwitchingParameters,
+    KeySwitch32PBSParameters, MultiBitPBSParameters, NoiseSquashingCompressionParameters,
+    NoiseSquashingParameters, ShortintKeySwitchingParameters,
 };
 
 /// All [`ClassicPBSParameters`] in this module.
@@ -1692,6 +1692,15 @@ pub const VEC_ALL_COMPACT_PUBLIC_KEY_ENCRYPTION_PARAMETERS: [(
 pub const VEC_ALL_NOISE_SQUASHING_PARAMETERS: [(&NoiseSquashingParameters, &str); 1] = [(
     &V1_3_NOISE_SQUASHING_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
     "V1_3_NOISE_SQUASHING_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128",
+)];
+
+/// All [`NoiseSquashingCompressionParameters`] in this module.
+pub const VEC_ALL_NOISE_SQUASHING_COMPRESSION_PARAMETERS: [(
+    &NoiseSquashingCompressionParameters,
+    &str,
+); 1] = [(
+    &V1_3_NOISE_SQUASHING_COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+    "V1_3_NOISE_SQUASHING_COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128",
 )];
 
 pub const VEC_ALL_KS32_PARAMETERS: [(&KeySwitch32PBSParameters, &str); 1] = [(

--- a/tfhe/src/shortint/parameters/v1_3/noise_squashing/p_fail_2_minus_128/mod.rs
+++ b/tfhe/src/shortint/parameters/v1_3/noise_squashing/p_fail_2_minus_128/mod.rs
@@ -1,8 +1,9 @@
 use crate::shortint::parameters::{
     CarryModulus, CoreCiphertextModulus, DecompositionBaseLog, DecompositionLevelCount,
     DynamicDistribution, GlweDimension, LweCiphertextCount, MessageModulus,
-    ModulusSwitchNoiseReductionParams, NoiseEstimationMeasureBound, NoiseSquashingParameters,
-    PolynomialSize, RSigmaFactor, Variance,
+    ModulusSwitchNoiseReductionParams, NoiseEstimationMeasureBound,
+    NoiseSquashingCompressionParameters, NoiseSquashingParameters, PolynomialSize, RSigmaFactor,
+    Variance,
 };
 
 pub const V1_3_NOISE_SQUASHING_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128:
@@ -21,4 +22,17 @@ pub const V1_3_NOISE_SQUASHING_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128:
     message_modulus: MessageModulus(4),
     carry_modulus: CarryModulus(4),
     ciphertext_modulus: CoreCiphertextModulus::<u128>::new_native(),
+};
+
+pub const V1_3_NOISE_SQUASHING_COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128:
+    NoiseSquashingCompressionParameters = NoiseSquashingCompressionParameters {
+    packing_ks_level: DecompositionLevelCount(1),
+    packing_ks_base_log: DecompositionBaseLog(61),
+    packing_ks_polynomial_size: PolynomialSize(1024),
+    packing_ks_glwe_dimension: GlweDimension(6),
+    lwe_per_glwe: LweCiphertextCount(128),
+    packing_ks_key_noise_distribution: DynamicDistribution::new_t_uniform(3),
+    ciphertext_modulus: CoreCiphertextModulus::<u128>::new_native(),
+    message_modulus: MessageModulus(4),
+    carry_modulus: CarryModulus(4),
 };


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description
Adds GLWE compression of squashed noise ciphertexts. This is similar to the classical shortint compression except that the resulting ciphertexts are not modswitched.

The following types have been added:
- **NoiseSquashingCompressionParameters**:  similar to the CompressionParameters, without the BR params and the `storage_log_modulus` because the ciphertexts are not modswitched
- **NoiseSquashingCompressionPrivateKey**: used to generate a NoiseSquashingCompressionKey, and can be converted to a NoiseSquashingPrivateKey for decryption
- **NoiseSquashingCompressionKey**: Can be used to compress a SquashedNoiseCiphertext list by doing a packing keyswitch
- **CompressedSquashedNoiseCiphertextList**: result of the compression. Has an `unpack` method to extract a single SquashedNoiseCiphertext
- **CompressedNoiseSquashingCompressionKey**, **NoiseSquashingCompressionKeyConformanceParams**



### Check-list:

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [x] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/2193)
<!-- Reviewable:end -->
