### PR TITLE
feat: add clear - ciphertex

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -284,7 +284,7 @@ check_typos: install_typos_checker
 .PHONY: clippy_gpu # Run clippy lints on tfhe with "gpu" enabled
 clippy_gpu: install_rs_check_toolchain
 	RUSTFLAGS="$(RUSTFLAGS)" cargo "$(CARGO_RS_CHECK_TOOLCHAIN)" clippy \
-		--features=boolean,shortint,integer,internal-keycache,gpu,pbs-stats \
+		--features=boolean,shortint,integer,internal-keycache,gpu,pbs-stats,extended-types \
 		--all-targets \
 		-p $(TFHE_SPEC) -- --no-deps -D warnings
 

--- a/tfhe/src/high_level_api/integers/unsigned/scalar_ops.rs
+++ b/tfhe/src/high_level_api/integers/unsigned/scalar_ops.rs
@@ -17,7 +17,6 @@ use crate::high_level_api::traits::{
 };
 use crate::integer::bigint::{U1024, U2048, U512};
 use crate::integer::block_decomposition::DecomposableInto;
-use crate::integer::ciphertext::IntegerCiphertext;
 #[cfg(feature = "gpu")]
 use crate::integer::gpu::ciphertext::CudaUnsignedRadixCiphertext;
 use crate::integer::U256;
@@ -1883,24 +1882,17 @@ generic_integer_impl_scalar_left_operation!(
     rust_trait: Sub(sub),
     implem: {
         |lhs, rhs: &FheUint<_>| {
-            // `-` is not commutative, so we resort to converting to trivial
-            // which should give same perf
-            global_state::with_internal_keys(|key| match key {
+             global_state::with_internal_keys(|key| match key {
                 InternalServerKey::Cpu(cpu_key) => {
-                    let mut result = cpu_key
-                        .pbs_key()
-                        .create_trivial_radix(lhs, rhs.ciphertext.on_cpu().blocks().len());
-                    cpu_key
-                        .pbs_key()
-                        .sub_assign_parallelized(&mut result, &*rhs.ciphertext.on_cpu());
+                    let result = cpu_key.pbs_key().left_scalar_sub_parallelized(lhs, &*rhs.ciphertext.on_cpu());
                     RadixCiphertext::Cpu(result)
                 },
                 #[cfg(feature = "gpu")]
                 InternalServerKey::Cuda(cuda_key) => {
                     with_thread_local_cuda_streams(|streams| {
-                        let mut result: CudaUnsignedRadixCiphertext = cuda_key.key.key.create_trivial_radix(
+                        let mut result: CudaUnsignedRadixCiphertext = cuda_key.pbs_key().create_trivial_radix(
                             lhs, rhs.ciphertext.on_gpu(streams).ciphertext.info.blocks.len(), streams);
-                        cuda_key.key.key.sub_assign(&mut result, &rhs.ciphertext.on_gpu(streams), streams);
+                        cuda_key.pbs_key().sub_assign(&mut result, &rhs.ciphertext.on_gpu(streams), streams);
                         RadixCiphertext::Cuda(result)
                     })
                 }
@@ -1938,24 +1930,17 @@ generic_integer_impl_scalar_left_operation!(
     rust_trait: Sub(sub),
     implem: {
         |lhs, rhs: &FheUint<_>| {
-            // `-` is not commutative, so we resort to converting to trivial
-            // which should give same perf
             global_state::with_internal_keys(|key| match key {
                 InternalServerKey::Cpu(cpu_key) => {
-                    let mut result = cpu_key
-                        .pbs_key()
-                        .create_trivial_radix(lhs, rhs.ciphertext.on_cpu().blocks().len());
-                    cpu_key
-                        .pbs_key()
-                        .sub_assign_parallelized(&mut result, &*rhs.ciphertext.on_cpu());
+                    let result = cpu_key.pbs_key().left_scalar_sub_parallelized(lhs, &*rhs.ciphertext.on_cpu());
                     RadixCiphertext::Cpu(result)
                 },
                 #[cfg(feature = "gpu")]
                 InternalServerKey::Cuda(cuda_key) => {
                     with_thread_local_cuda_streams(|streams| {
-                        let mut result: CudaUnsignedRadixCiphertext = cuda_key.key.key.create_trivial_radix(
+                        let mut result: CudaUnsignedRadixCiphertext = cuda_key.pbs_key().create_trivial_radix(
                             lhs, rhs.ciphertext.on_gpu(streams).ciphertext.info.blocks.len(), streams);
-                        cuda_key.key.key.sub_assign(&mut result, &rhs.ciphertext.on_gpu(streams), streams);
+                        cuda_key.pbs_key().sub_assign(&mut result, &rhs.ciphertext.on_gpu(streams), streams);
                         RadixCiphertext::Cuda(result)
                     })
                 }

--- a/tfhe/src/integer/server_key/radix/neg.rs
+++ b/tfhe/src/integer/server_key/radix/neg.rs
@@ -2,7 +2,6 @@ use crate::integer::ciphertext::IntegerRadixCiphertext;
 use crate::integer::server_key::CheckError;
 use crate::integer::ServerKey;
 use crate::shortint::ciphertext::{Degree, MaxDegree};
-#[cfg(test)]
 use crate::shortint::MessageModulus;
 
 /// Iterator that returns the new degree of blocks
@@ -10,13 +9,11 @@ use crate::shortint::MessageModulus;
 ///
 /// It takes as input an iterator that returns the degree of the blocks
 /// before negation as well as their message modulus.
-#[cfg(test)]
 pub(crate) struct NegatedDegreeIter<I> {
     iter: I,
     z_b: u64,
 }
 
-#[cfg(test)]
 impl<I> NegatedDegreeIter<I>
 where
     I: Iterator<Item = (Degree, MessageModulus)>,
@@ -26,7 +23,6 @@ where
     }
 }
 
-#[cfg(test)]
 impl<I> Iterator for NegatedDegreeIter<I>
 where
     I: Iterator<Item = (Degree, MessageModulus)>,

--- a/tfhe/src/integer/server_key/radix_parallel/tests_signed/test_scalar_sub.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_signed/test_scalar_sub.rs
@@ -1,11 +1,11 @@
 use crate::integer::keycache::KEY_CACHE;
 use crate::integer::server_key::radix_parallel::tests_cases_unsigned::FunctionExecutor;
 use crate::integer::server_key::radix_parallel::tests_signed::{
-    random_non_zero_value, signed_overflowing_add_under_modulus,
+    random_non_zero_value, signed_add_under_modulus, signed_overflowing_add_under_modulus,
     signed_overflowing_sub_under_modulus, signed_sub_under_modulus, NB_CTXT,
 };
 use crate::integer::server_key::radix_parallel::tests_unsigned::{
-    nb_tests_for_params, nb_tests_smaller_for_params, CpuFunctionExecutor,
+    nb_tests_for_params, nb_tests_smaller_for_params, CpuFunctionExecutor, MAX_NB_CTXT,
 };
 use crate::integer::tests::create_parameterized_test;
 use crate::integer::{
@@ -20,6 +20,9 @@ use std::sync::Arc;
 
 create_parameterized_test!(integer_signed_unchecked_scalar_sub);
 create_parameterized_test!(integer_signed_default_overflowing_scalar_sub);
+create_parameterized_test!(integer_signed_unchecked_left_scalar_sub);
+create_parameterized_test!(integer_signed_smart_left_scalar_sub);
+create_parameterized_test!(integer_signed_default_left_scalar_sub);
 
 fn integer_signed_unchecked_scalar_sub<P>(param: P)
 where
@@ -36,6 +39,31 @@ where
     let executor = CpuFunctionExecutor::new(&ServerKey::signed_overflowing_scalar_sub_parallelized);
     signed_default_overflowing_scalar_sub_test(param, executor);
 }
+
+fn integer_signed_unchecked_left_scalar_sub<P>(param: P)
+where
+    P: Into<PBSParameters>,
+{
+    let executor = CpuFunctionExecutor::new(&ServerKey::unchecked_left_scalar_sub);
+    signed_unchecked_left_scalar_sub_test(param, executor);
+}
+
+fn integer_signed_smart_left_scalar_sub<P>(param: P)
+where
+    P: Into<PBSParameters>,
+{
+    let executor = CpuFunctionExecutor::new(&ServerKey::smart_left_scalar_sub_parallelized);
+    signed_smart_left_scalar_sub_test(param, executor);
+}
+
+fn integer_signed_default_left_scalar_sub<P>(param: P)
+where
+    P: Into<PBSParameters>,
+{
+    let executor = CpuFunctionExecutor::new(&ServerKey::left_scalar_sub_parallelized);
+    signed_default_left_scalar_sub_test(param, executor);
+}
+
 pub(crate) fn signed_unchecked_scalar_sub_test<P, T>(param: P, mut executor: T)
 where
     P: Into<PBSParameters>,
@@ -259,5 +287,161 @@ where
         assert!(decrypted_overflowed); // Actually we know its an overflow case
         assert_eq!(encrypted_overflow.0.degree.get(), 1);
         assert_eq!(encrypted_overflow.0.noise_level(), NoiseLevel::ZERO);
+    }
+}
+
+pub(crate) fn signed_unchecked_left_scalar_sub_test<P, T>(param: P, mut executor: T)
+where
+    P: Into<PBSParameters>,
+    T: for<'a> FunctionExecutor<(i64, &'a SignedRadixCiphertext), SignedRadixCiphertext>,
+{
+    let param = param.into();
+    let nb_tests = nb_tests_for_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
+    let cks = RadixClientKey::from((cks, NB_CTXT));
+
+    sks.set_deterministic_pbs_execution(true);
+    let sks = Arc::new(sks);
+
+    let mut rng = rand::thread_rng();
+
+    executor.setup(&cks, sks.clone());
+
+    let cks: crate::integer::ClientKey = cks.into();
+
+    for num_blocks in 1..MAX_NB_CTXT {
+        // message_modulus^vec_length
+        let modulus = (cks.parameters().message_modulus().0.pow(num_blocks as u32) / 2) as i64;
+        if modulus <= 1 {
+            continue;
+        }
+
+        for _ in 0..nb_tests {
+            let clear_lhs = rng.gen::<i64>() % modulus;
+            let mut clear_rhs = rng.gen::<i64>() % modulus;
+
+            let mut ct_rhs = cks.encrypt_signed_radix(clear_rhs, num_blocks);
+
+            ct_rhs = executor.execute((clear_lhs, &ct_rhs));
+            clear_rhs = signed_sub_under_modulus(clear_lhs, clear_rhs, modulus);
+
+            let dec_res: i64 = cks.decrypt_signed_radix(&ct_rhs);
+            assert_eq!(dec_res, clear_rhs);
+
+            let mut clear_lhs = rng.gen::<i64>() % modulus;
+            while sks.is_left_scalar_sub_possible(clear_lhs, &ct_rhs).is_ok() {
+                ct_rhs = executor.execute((clear_lhs, &ct_rhs));
+                clear_rhs = signed_sub_under_modulus(clear_lhs, clear_rhs, modulus);
+                let dec_res: i64 = cks.decrypt_signed_radix(&ct_rhs);
+                assert_eq!(dec_res, clear_rhs);
+                clear_lhs = rng.gen::<i64>() % modulus;
+            }
+        }
+    }
+}
+
+pub(crate) fn signed_smart_left_scalar_sub_test<P, T>(param: P, mut executor: T)
+where
+    P: Into<PBSParameters>,
+    T: for<'a> FunctionExecutor<(i64, &'a mut SignedRadixCiphertext), SignedRadixCiphertext>,
+{
+    let param = param.into();
+    let nb_tests = nb_tests_for_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
+    let cks = RadixClientKey::from((cks, NB_CTXT));
+
+    sks.set_deterministic_pbs_execution(true);
+    let sks = Arc::new(sks);
+
+    let mut rng = rand::thread_rng();
+
+    executor.setup(&cks, sks);
+
+    let cks: crate::integer::ClientKey = cks.into();
+
+    for num_blocks in 1..MAX_NB_CTXT {
+        // message_modulus^vec_length
+        let modulus = (cks.parameters().message_modulus().0.pow(num_blocks as u32) / 2) as i64;
+        if modulus <= 1 {
+            continue;
+        }
+
+        let clear_lhs = rng.gen::<i64>() % modulus;
+        let mut clear_rhs = rng.gen::<i64>() % modulus;
+
+        let mut ct_rhs = cks.encrypt_signed_radix(clear_rhs, num_blocks);
+
+        ct_rhs = executor.execute((clear_lhs, &mut ct_rhs));
+        clear_rhs = signed_sub_under_modulus(clear_lhs, clear_rhs, modulus);
+
+        let dec_res: i64 = cks.decrypt_signed_radix(&ct_rhs);
+        assert_eq!(dec_res, clear_rhs);
+        for _ in 0..nb_tests {
+            let clear_lhs = rng.gen::<i64>() % modulus;
+
+            ct_rhs = executor.execute((clear_lhs, &mut ct_rhs));
+            clear_rhs = signed_sub_under_modulus(clear_lhs, clear_rhs, modulus);
+            let dec_res: i64 = cks.decrypt_signed_radix(&ct_rhs);
+            assert_eq!(dec_res, clear_rhs);
+        }
+    }
+}
+
+pub(crate) fn signed_default_left_scalar_sub_test<P, T>(param: P, mut executor: T)
+where
+    P: Into<PBSParameters>,
+    T: for<'a> FunctionExecutor<(i64, &'a SignedRadixCiphertext), SignedRadixCiphertext>,
+{
+    let param = param.into();
+    let nb_tests = nb_tests_for_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
+    let cks = RadixClientKey::from((cks, NB_CTXT));
+
+    sks.set_deterministic_pbs_execution(true);
+    let sks = Arc::new(sks);
+
+    let mut rng = rand::thread_rng();
+
+    executor.setup(&cks, sks.clone());
+
+    let cks: crate::integer::ClientKey = cks.into();
+
+    for num_blocks in 1..MAX_NB_CTXT {
+        // message_modulus^vec_length
+        let modulus = (cks.parameters().message_modulus().0.pow(num_blocks as u32) / 2) as i64;
+        if modulus <= 1 {
+            continue;
+        }
+
+        for _ in 0..nb_tests {
+            let clear_0 = rng.gen::<i64>() % modulus;
+            let clear_1 = rng.gen::<i64>() % modulus;
+
+            let ctxt_1 = cks.encrypt_signed_radix(clear_1, num_blocks);
+
+            let ct_res = executor.execute((clear_0, &ctxt_1));
+            assert!(ct_res.block_carries_are_empty());
+
+            let tmp = executor.execute((clear_0, &ctxt_1));
+            assert_eq!(ct_res, tmp, "Operation is not deterministic");
+
+            let dec_res: i64 = cks.decrypt_signed_radix(&ct_res);
+            assert_eq!(dec_res, signed_sub_under_modulus(clear_0, clear_1, modulus));
+
+            let non_zero = random_non_zero_value(&mut rng, modulus);
+            let non_clean = sks.unchecked_scalar_add(&ctxt_1, non_zero);
+            let ct_res = executor.execute((clear_0, &non_clean));
+            assert!(ct_res.block_carries_are_empty());
+            let dec_res: i64 = cks.decrypt_signed_radix(&ct_res);
+            let expected = signed_sub_under_modulus(
+                clear_0,
+                signed_add_under_modulus(clear_1, non_zero, modulus),
+                modulus,
+            );
+            assert_eq!(dec_res, expected);
+
+            let ct_res2 = executor.execute((clear_0, &non_clean));
+            assert_eq!(ct_res, ct_res2, "Failed determinism check");
+        }
     }
 }

--- a/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_scalar_sub.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_scalar_sub.rs
@@ -1,16 +1,28 @@
+use std::sync::Arc;
+
+use crate::integer::keycache::KEY_CACHE;
 use crate::integer::server_key::radix_parallel::tests_cases_unsigned::{
     default_overflowing_scalar_sub_test, default_scalar_sub_test, smart_scalar_sub_test,
+    FunctionExecutor,
 };
-use crate::integer::server_key::radix_parallel::tests_unsigned::CpuFunctionExecutor;
+use crate::integer::server_key::radix_parallel::tests_unsigned::{
+    nb_tests_for_params, random_non_zero_value, CpuFunctionExecutor,
+};
 use crate::integer::tests::create_parameterized_test;
-use crate::integer::ServerKey;
+use crate::integer::{IntegerKeyKind, RadixCiphertext, RadixClientKey, ServerKey};
 #[cfg(tarpaulin)]
 use crate::shortint::parameters::coverage_parameters::*;
 use crate::shortint::parameters::test_params::*;
 use crate::shortint::parameters::*;
+use rand::prelude::*;
+
+use super::{MAX_NB_CTXT, NB_CTXT};
 
 create_parameterized_test!(integer_smart_scalar_sub);
 create_parameterized_test!(integer_default_scalar_sub);
+create_parameterized_test!(integer_unchecked_left_scalar_sub);
+create_parameterized_test!(integer_smart_left_scalar_sub);
+create_parameterized_test!(integer_default_left_scalar_sub);
 create_parameterized_test!(integer_default_overflowing_scalar_sub);
 
 fn integer_smart_scalar_sub<P>(param: P)
@@ -29,6 +41,30 @@ where
     default_scalar_sub_test(param, executor);
 }
 
+fn integer_unchecked_left_scalar_sub<P>(param: P)
+where
+    P: Into<PBSParameters>,
+{
+    let executor = CpuFunctionExecutor::new(&ServerKey::unchecked_left_scalar_sub);
+    unchecked_left_scalar_sub_test(param, executor);
+}
+
+fn integer_smart_left_scalar_sub<P>(param: P)
+where
+    P: Into<PBSParameters>,
+{
+    let executor = CpuFunctionExecutor::new(&ServerKey::smart_left_scalar_sub_parallelized);
+    smart_left_scalar_sub_test(param, executor);
+}
+
+fn integer_default_left_scalar_sub<P>(param: P)
+where
+    P: Into<PBSParameters>,
+{
+    let executor = CpuFunctionExecutor::new(&ServerKey::left_scalar_sub_parallelized);
+    default_left_scalar_sub_test(param, executor);
+}
+
 fn integer_default_overflowing_scalar_sub<P>(param: P)
 where
     P: Into<PBSParameters>,
@@ -36,4 +72,149 @@ where
     let executor =
         CpuFunctionExecutor::new(&ServerKey::unsigned_overflowing_scalar_sub_parallelized);
     default_overflowing_scalar_sub_test(param, executor);
+}
+
+pub(crate) fn unchecked_left_scalar_sub_test<P, T>(param: P, mut executor: T)
+where
+    P: Into<PBSParameters>,
+    T: for<'a> FunctionExecutor<(u64, &'a RadixCiphertext), RadixCiphertext>,
+{
+    let param = param.into();
+    let nb_tests = nb_tests_for_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
+    let cks = RadixClientKey::from((cks, NB_CTXT));
+
+    sks.set_deterministic_pbs_execution(true);
+    let sks = Arc::new(sks);
+
+    let mut rng = thread_rng();
+
+    executor.setup(&cks, sks.clone());
+
+    let cks: crate::integer::ClientKey = cks.into();
+
+    for num_blocks in 1..MAX_NB_CTXT {
+        // message_modulus^vec_length
+        let modulus = cks.parameters().message_modulus().0.pow(num_blocks as u32);
+
+        for _ in 0..nb_tests {
+            let clear_lhs = rng.gen::<u64>() % modulus;
+            let mut clear_rhs = rng.gen::<u64>() % modulus;
+
+            let mut ct_rhs = cks.encrypt_radix(clear_rhs, num_blocks);
+
+            ct_rhs = executor.execute((clear_lhs, &ct_rhs));
+            clear_rhs = clear_lhs.wrapping_sub(clear_rhs) % modulus;
+
+            let dec_res: u64 = cks.decrypt_radix(&ct_rhs);
+            assert_eq!(dec_res, clear_rhs);
+
+            let mut clear_lhs = rng.gen::<u64>() % modulus;
+            while sks.is_left_scalar_sub_possible(clear_lhs, &ct_rhs).is_ok() {
+                ct_rhs = executor.execute((clear_lhs, &ct_rhs));
+                clear_rhs = clear_lhs.wrapping_sub(clear_rhs) % modulus;
+                let dec_res: u64 = cks.decrypt_radix(&ct_rhs);
+                assert_eq!(dec_res, clear_rhs);
+                clear_lhs = rng.gen::<u64>() % modulus;
+            }
+        }
+    }
+}
+
+pub(crate) fn smart_left_scalar_sub_test<P, T>(param: P, mut executor: T)
+where
+    P: Into<PBSParameters>,
+    T: for<'a> FunctionExecutor<(u64, &'a mut RadixCiphertext), RadixCiphertext>,
+{
+    let param = param.into();
+    let nb_tests = nb_tests_for_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
+    let cks = RadixClientKey::from((cks, NB_CTXT));
+
+    sks.set_deterministic_pbs_execution(true);
+    let sks = Arc::new(sks);
+
+    let mut rng = thread_rng();
+
+    executor.setup(&cks, sks);
+
+    let cks: crate::integer::ClientKey = cks.into();
+
+    for num_blocks in 1..MAX_NB_CTXT {
+        // message_modulus^vec_length
+        let modulus = cks.parameters().message_modulus().0.pow(num_blocks as u32);
+
+        let clear_lhs = rng.gen::<u64>() % modulus;
+        let mut clear_rhs = rng.gen::<u64>() % modulus;
+
+        let mut ct_rhs = cks.encrypt_radix(clear_rhs, num_blocks);
+
+        ct_rhs = executor.execute((clear_lhs, &mut ct_rhs));
+        clear_rhs = clear_lhs.wrapping_sub(clear_rhs) % modulus;
+
+        let dec_res: u64 = cks.decrypt_radix(&ct_rhs);
+        assert_eq!(dec_res, clear_rhs);
+        for _ in 0..nb_tests {
+            let clear_lhs = rng.gen::<u64>() % modulus;
+
+            ct_rhs = executor.execute((clear_lhs, &mut ct_rhs));
+            clear_rhs = clear_lhs.wrapping_sub(clear_rhs) % modulus;
+            let dec_res: u64 = cks.decrypt_radix(&ct_rhs);
+            assert_eq!(dec_res, clear_rhs);
+        }
+    }
+}
+
+pub(crate) fn default_left_scalar_sub_test<P, T>(param: P, mut executor: T)
+where
+    P: Into<PBSParameters>,
+    T: for<'a> FunctionExecutor<(u64, &'a RadixCiphertext), RadixCiphertext>,
+{
+    let param = param.into();
+    let nb_tests = nb_tests_for_params(param);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
+    let cks = RadixClientKey::from((cks, NB_CTXT));
+
+    sks.set_deterministic_pbs_execution(true);
+    let sks = Arc::new(sks);
+
+    let mut rng = thread_rng();
+
+    executor.setup(&cks, sks.clone());
+
+    let cks: crate::integer::ClientKey = cks.into();
+
+    for num_blocks in 1..MAX_NB_CTXT {
+        // message_modulus^vec_length
+        let modulus = cks.parameters().message_modulus().0.pow(num_blocks as u32);
+
+        for _ in 0..nb_tests {
+            let clear_0 = rng.gen::<u64>() % modulus;
+            let clear_1 = rng.gen::<u64>() % modulus;
+
+            let ctxt_1 = cks.encrypt_radix(clear_1, num_blocks);
+
+            let ct_res = executor.execute((clear_0, &ctxt_1));
+            assert!(ct_res.block_carries_are_empty());
+
+            let tmp = executor.execute((clear_0, &ctxt_1));
+            assert_eq!(ct_res, tmp, "Operation is not deterministic");
+
+            let dec_res: u64 = cks.decrypt_radix(&ct_res);
+            assert_eq!(dec_res, (clear_0.wrapping_sub(clear_1)) % modulus);
+
+            let non_zero = random_non_zero_value(&mut rng, modulus);
+            let non_clean = sks.unchecked_scalar_add(&ctxt_1, non_zero);
+            let ct_res = executor.execute((clear_0, &non_clean));
+            assert!(ct_res.block_carries_are_empty());
+            let dec_res: u64 = cks.decrypt_radix(&ct_res);
+            assert_eq!(
+                dec_res,
+                (clear_0.wrapping_sub(clear_1.wrapping_add(non_zero))) % modulus
+            );
+
+            let ct_res2 = executor.execute((clear_0, &non_clean));
+            assert_eq!(ct_res, ct_res2, "Failed determinism check");
+        }
+    }
 }


### PR DESCRIPTION
Add integer and hlapi function to perform
`clear - ciphertext`

As subtraction is not commutative having a specialized version is better.

As can be seen from the code, the real benefit is for the default version where the cost of `clear - ciphertext` is the same as `clear + ciphertex` which is better that transforming the clear into a trivial ciphertext to perform the subtract algorithm

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/2210)
<!-- Reviewable:end -->
