### PR TITLE
chore: update tfhe-fft and tfhe-ntt minor version

### DIFF
--- a/tfhe-fft/Cargo.toml
+++ b/tfhe-fft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tfhe-fft"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 description = "tfhe-fft is a pure Rust high performance fast Fourier transform library."
 readme = "README.md"

--- a/tfhe-ntt/Cargo.toml
+++ b/tfhe-ntt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tfhe-ntt"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "tfhe-ntt is a pure Rust high performance number theoretic transform library."
 readme = "README.md"

--- a/tfhe/Cargo.toml
+++ b/tfhe/Cargo.toml
@@ -54,11 +54,11 @@ tfhe-csprng = { version = "0.5.0", path = "../tfhe-csprng", features = [
 serde = { workspace = true, features = ["default", "derive"] }
 rayon = { workspace = true }
 bincode = "1.3.3"
-tfhe-fft = { version = "0.8.0", path = "../tfhe-fft", features = [
+tfhe-fft = { version = "0.9.0", path = "../tfhe-fft", features = [
     "serde",
     "fft128",
 ] }
-tfhe-ntt = { version = "0.5.0", path = "../tfhe-ntt" }
+tfhe-ntt = { version = "0.6.0", path = "../tfhe-ntt" }
 pulp = { workspace = true, features = ["default"] }
 tfhe-cuda-backend = { version = "0.9.0-alpha.0", path = "../backends/tfhe-cuda-backend", optional = true }
 aligned-vec = { workspace = true, features = ["default", "serde"] }


### PR DESCRIPTION
This is done to get the current version of dependencies defined in workspace, especially pulp.
