### PR TITLE
Ns/chore/conformance unwrap

### DIFF
--- a/tfhe/src/core_crypto/commons/parameters.rs
+++ b/tfhe/src/core_crypto/commons/parameters.rs
@@ -60,7 +60,7 @@ pub struct GgswCiphertextCount(pub usize);
 pub struct LweSize(pub usize);
 
 impl LweSize {
-    /// Return the associated [`LweDimension`, Versionize].
+    /// Return the associated [`LweDimension`].
     pub fn to_lwe_dimension(&self) -> LweDimension {
         LweDimension(self.0 - 1)
     }

--- a/tfhe/src/error.rs
+++ b/tfhe/src/error.rs
@@ -91,7 +91,7 @@ impl From<std::convert::Infallible> for Error {
 pub enum InvalidRangeError {
     /// The upper bound of the range is greater than the size of the integer
     SliceTooBig,
-    /// The upper gound is smaller than the lower bound
+    /// The upper bound is smaller than the lower bound
     WrongOrder,
 }
 

--- a/tfhe/src/high_level_api/keys/inner.rs
+++ b/tfhe/src/high_level_api/keys/inner.rs
@@ -547,10 +547,12 @@ impl ParameterSetConformant for IntegerServerKey {
         ) {
             (None, None) => true,
             (Some((cpk_params, ks_params)), Some(cpk_key_switching_key_material)) => {
-                let cpk_param = (parameter_set.sk_param, *cpk_params, *ks_params)
-                    .try_into()
-                    .unwrap();
-                cpk_key_switching_key_material.is_conformant(&cpk_param)
+                if let Ok(cpk_param) = (parameter_set.sk_param, *cpk_params, *ks_params).try_into()
+                {
+                    cpk_key_switching_key_material.is_conformant(&cpk_param)
+                } else {
+                    return false;
+                }
             }
             _ => return false,
         };
@@ -593,10 +595,12 @@ impl ParameterSetConformant for IntegerCompressedServerKey {
         ) {
             (None, None) => true,
             (Some((cpk_params, ks_params)), Some(cpk_key_switching_key_material)) => {
-                let cpk_param = (parameter_set.sk_param, *cpk_params, *ks_params)
-                    .try_into()
-                    .unwrap();
-                cpk_key_switching_key_material.is_conformant(&cpk_param)
+                if let Ok(cpk_param) = (parameter_set.sk_param, *cpk_params, *ks_params).try_into()
+                {
+                    cpk_key_switching_key_material.is_conformant(&cpk_param)
+                } else {
+                    return false;
+                }
             }
             _ => return false,
         };

--- a/tfhe/src/integer/server_key/radix_parallel/modulus_switch_compression.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/modulus_switch_compression.rs
@@ -45,7 +45,7 @@ impl ServerKey {
     }
     /// Decompresses a signed compressed ciphertext
     /// This operation costs a PBS
-    ///     
+    ///
     /// See [`CompressedModulusSwitchedSignedRadixCiphertext#example`] for usage
     pub fn decompress_signed_parallelized(
         &self,

--- a/tfhe/src/shortint/key_switching_key/mod.rs
+++ b/tfhe/src/shortint/key_switching_key/mod.rs
@@ -1,6 +1,6 @@
 //! This module defines KeySwitchingKey
 //!
-//! - [KeySwitchingKey] allows switching the keys of a ciphertext, from a cleitn key to another.
+//! - [KeySwitchingKey] allows switching the keys of a ciphertext, from a client key to another.
 
 use crate::conformance::ParameterSetConformant;
 use crate::core_crypto::prelude::{


### PR DESCRIPTION
### PR content/description
Removes some unwraps in conformance check. It's not supposed to be reachable by a client but I think it would be good to be panic free in conformance.
This comes from https://github.com/zama-ai/tfhe-rs/pull/2024 but I made it a separate PR because it is not linked to the AP.
Also includes some typo fixes
