### PR TITLE
feat(hl): create FheTypes from i32

### DIFF
--- a/tfhe/Cargo.toml
+++ b/tfhe/Cargo.toml
@@ -42,7 +42,6 @@ env_logger = "0.11"
 log = "0.4.19"
 hex = "0.4.3"
 # End regex-engine deps
-strum = { version = "0.26", features = ["derive"] }
 
 [build-dependencies]
 cbindgen = { version = "0.28", optional = true }
@@ -69,6 +68,7 @@ fs2 = { version = "0.4.3", optional = true }
 sha3 = { version = "0.10", optional = true }
 itertools = { workspace = true }
 rand_core = { version = "0.6.4", features = ["std"] }
+strum = { version = "0.27", features = ["derive"], optional = true }
 tfhe-zk-pok = { version = "0.5.0", path = "../tfhe-zk-pok", optional = true }
 tfhe-versionable = { version = "0.5.0", path = "../utils/tfhe-versionable" }
 
@@ -86,10 +86,10 @@ bytemuck = { workspace = true }
 [features]
 boolean = []
 shortint = ["dep:sha3"]
-integer = ["shortint"]
+integer = ["shortint", "dep:strum"]
 strings = ["integer"]
 internal-keycache = ["dep:fs2"]
-gpu = ["dep:tfhe-cuda-backend","shortint"]
+gpu = ["dep:tfhe-cuda-backend", "shortint"]
 zk-pok = ["dep:tfhe-zk-pok"]
 
 # Adds more FheUint/FheInt types to the HL

--- a/tfhe/src/high_level_api/mod.rs
+++ b/tfhe/src/high_level_api/mod.rs
@@ -48,6 +48,7 @@ macro_rules! export_concrete_array_types {
 
 pub use crate::core_crypto::commons::math::random::Seed;
 pub use crate::integer::server_key::MatchValues;
+use crate::{error, Error};
 pub use config::{Config, ConfigBuilder};
 #[cfg(feature = "gpu")]
 pub use global_state::CudaGpuChoice;
@@ -60,6 +61,7 @@ pub use keys::{
     generate_keys, ClientKey, CompactPublicKey, CompressedCompactPublicKey, CompressedPublicKey,
     CompressedServerKey, KeySwitchingKey, PublicKey, ServerKey,
 };
+use strum::FromRepr;
 
 #[cfg(test)]
 mod tests;
@@ -156,7 +158,7 @@ pub enum Device {
     CudaGpu,
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(FromRepr, Copy, Clone, PartialEq, Eq, Debug)]
 #[repr(i32)]
 #[cfg_attr(test, derive(strum::EnumIter))]
 pub enum FheTypes {
@@ -249,4 +251,12 @@ pub enum FheTypes {
     Int232 = 81,
     Int240 = 82,
     Int248 = 83,
+}
+
+impl TryFrom<i32> for FheTypes {
+    type Error = Error;
+
+    fn try_from(value: i32) -> Result<Self, Self::Error> {
+        Self::from_repr(value).ok_or_else(|| error!("Invalid value for FheTypes: {}", value))
+    }
 }


### PR DESCRIPTION
This PR adds a conversion method from i32 into FheTypes.
This is done using the `strum` crate. It could also be used later to remove some big matches on FheTypes in the C and JS APIs.