### PR TITLE
fix(core): fix success probability for Ternary Uniform generation

### DIFF
--- a/tfhe/src/core_crypto/commons/math/random/uniform_ternary.rs
+++ b/tfhe/src/core_crypto/commons/math/random/uniform_ternary.rs
@@ -28,7 +28,8 @@ macro_rules! implement_uniform_ternary {
                 _modulus: Option<Self::CustomModulus>,
             ) -> f64 {
                 // The modulus and parameters of the distribution do not impact generation success
-                1.0
+                // 4 possible cases in the generation, only 3 out of 4 yield a value, so 0.75
+                0.75
             }
 
             fn single_sample_required_random_byte_count(


### PR DESCRIPTION
- corrected from 1.0 to 0.75 given 3/4 of tries will yield a ternary value
- this would have caused a forked generator to fail almost certainly
