### PR TITLE
feat(hl): add AsRef implementation on ServerKey to access NoiseSquashingKey

### DIFF
--- a/tfhe/src/high_level_api/keys/server.rs
+++ b/tfhe/src/high_level_api/keys/server.rs
@@ -112,6 +112,12 @@ impl ServerKey {
         self.key.cpk_casting_key()
     }
 
+    pub fn noise_squashing_key(
+        &self,
+    ) -> Option<&crate::integer::noise_squashing::NoiseSquashingKey> {
+        self.key.noise_squashing_key.as_ref()
+    }
+
     pub(in crate::high_level_api) fn message_modulus(&self) -> MessageModulus {
         self.key.message_modulus()
     }


### PR DESCRIPTION
cc @kc1212 this one is going into main but the same patch will make it to release/1.1.x

to note that you likely will need to call

```rust
let sns_key: Option<&tfhe::integer::NoiseSquashingKey> = sk.as_ref().as_ref();
```

 the reason being that we can only return a reference to the internal option from the `AsRef` Implem, and then you call `Option::as_ref` to convert the `&Option<T>` to `Option<&T>`