### PR TITLE
chore: add CODEOWNERS file to avoid unwanted changes to core_crypto source

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+# Specifying a path without code owners means that path won't have owners and is akin to a negation
+# i.e. the `core_crypto` dir is owned and needs owner approval/review, but not the `gpu` sub dir
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file
+/tfhe/src/core_crypto/                  @IceTDrinker
+/tfhe/src/core_crypto/gpu


### PR DESCRIPTION
cc @agnesLeroy 

For now the reviews are not mandatory from code owners to avoid blocking people, but it likely will be enabled with a backup owner to avoid blocking people when both are on leave.