### PR TITLE
chore(ci):  log action to perform on approval for external pr

### DIFF
--- a/.github/workflows/approve_label.yml
+++ b/.github/workflows/approve_label.yml
@@ -34,3 +34,10 @@ jobs:
           # We need to use a PAT to be able to trigger `labeled` event for the other workflow.
           github_token: ${{ secrets.FHE_ACTIONS_TOKEN }}
           labels: approved
+
+      - name: Check if maintainer needs to handle label manually
+        if: ${{ failure() }}
+        run: |
+          echo "Pull-request from an external contributor."
+          echo "A maintainer need to manually add/remove the 'approved' label."
+          exit 1


### PR DESCRIPTION
~~`FHE_ACTIONS_TOKEN` was needed to display zama-bot as user who add/remove the `approved` label.
This had an inconvenient, PR from external contributor couldn't benefit from this automation, since secrets are not available from users that are not part of the organization.
Moreover, workflow that run on approval wouldn't be executed, unless someone manually add the 'approved' label. By using GitHub token we ensure that these workflows could run on approval.~~

External contributor don't have access to secrets so this workflow would fail when attempting to add/remove 'approved' label on pull-request from forks.
This simple log message is here to remind maintainers to handle 'approved' label manually to trigger the second CI pipeline.
