### PR TITLE
fix(shortint): store correct ap in ciphertext during encryption

### DIFF
--- a/tfhe/src/core_crypto/commons/parameters.rs
+++ b/tfhe/src/core_crypto/commons/parameters.rs
@@ -289,12 +289,18 @@ pub enum EncryptionKeyChoice {
     Small,
 }
 
+impl EncryptionKeyChoice {
+    pub const fn into_pbs_order(self) -> PBSOrder {
+        match self {
+            Self::Big => PBSOrder::KeyswitchBootstrap,
+            Self::Small => PBSOrder::BootstrapKeyswitch,
+        }
+    }
+}
+
 impl From<EncryptionKeyChoice> for PBSOrder {
     fn from(value: EncryptionKeyChoice) -> Self {
-        match value {
-            EncryptionKeyChoice::Big => Self::KeyswitchBootstrap,
-            EncryptionKeyChoice::Small => Self::BootstrapKeyswitch,
-        }
+        value.into_pbs_order()
     }
 }
 

--- a/tfhe/src/shortint/client_key/mod.rs
+++ b/tfhe/src/shortint/client_key/mod.rs
@@ -251,8 +251,6 @@ impl ClientKey {
 
     #[cfg(test)]
     pub fn unchecked_create_trivial(&self, value: u64) -> Ciphertext {
-        use crate::shortint::parameters::AtomicPatternKind;
-
         let params = self.parameters;
 
         let lwe_size = params.encryption_lwe_dimension().to_lwe_size();
@@ -262,7 +260,7 @@ impl ClientKey {
             lwe_size,
             params.message_modulus(),
             params.carry_modulus(),
-            AtomicPatternKind::Standard(PBSOrder::from(params.encryption_key_choice())),
+            params.atomic_pattern(),
             params.ciphertext_modulus(),
         )
     }

--- a/tfhe/src/shortint/engine/client_side.rs
+++ b/tfhe/src/shortint/engine/client_side.rs
@@ -5,7 +5,7 @@ use crate::core_crypto::algorithms::*;
 use crate::core_crypto::commons::math::random::{Distribution, RandomGenerable};
 use crate::core_crypto::entities::*;
 use crate::shortint::ciphertext::{Degree, NoiseLevel};
-use crate::shortint::parameters::{AtomicPatternKind, CarryModulus, MessageModulus};
+use crate::shortint::parameters::{CarryModulus, MessageModulus};
 use crate::shortint::{
     Ciphertext, ClientKey, CompressedCiphertext, PaddingBit, ShortintEncoding, ShortintParameterSet,
 };
@@ -86,8 +86,7 @@ impl ShortintEngine {
         message: u64,
         message_modulus: MessageModulus,
     ) -> Ciphertext {
-        let params_atomic_pattern =
-            AtomicPatternKind::Standard(client_key.parameters.encryption_key_choice().into());
+        let params_atomic_pattern = client_key.parameters.atomic_pattern();
 
         let (encryption_lwe_sk, encryption_noise_distribution) =
             client_key.encryption_key_and_noise();
@@ -131,8 +130,7 @@ impl ShortintEngine {
             smaller or equal to the max given by the parameter set."
         );
 
-        let atomic_pattern =
-            AtomicPatternKind::Standard(client_key.parameters.encryption_key_choice().into());
+        let atomic_pattern = client_key.parameters.atomic_pattern();
 
         let (encryption_lwe_sk, encryption_noise_distribution) =
             client_key.encryption_key_and_noise();
@@ -172,8 +170,7 @@ impl ShortintEngine {
         let encoded =
             ShortintEncoding::from_parameters(client_key.parameters, PaddingBit::Yes).encode(m);
 
-        let atomic_pattern =
-            AtomicPatternKind::Standard(client_key.parameters.encryption_key_choice().into());
+        let atomic_pattern = client_key.parameters.atomic_pattern();
 
         let (encryption_lwe_sk, encryption_noise_distribution) =
             client_key.encryption_key_and_noise();
@@ -197,8 +194,7 @@ impl ShortintEngine {
     }
 
     pub(crate) fn unchecked_encrypt(&mut self, client_key: &ClientKey, message: u64) -> Ciphertext {
-        let atomic_pattern =
-            AtomicPatternKind::Standard(client_key.parameters.encryption_key_choice().into());
+        let atomic_pattern = client_key.parameters.atomic_pattern();
 
         let (encryption_lwe_sk, encryption_noise_distribution) =
             client_key.encryption_key_and_noise();
@@ -235,8 +231,7 @@ impl ShortintEngine {
         let encoded = ShortintEncoding::from_parameters(client_key.parameters, PaddingBit::No)
             .encode(Cleartext(message));
 
-        let atomic_pattern =
-            AtomicPatternKind::Standard(client_key.parameters.encryption_key_choice().into());
+        let atomic_pattern = client_key.parameters.atomic_pattern();
 
         let (encryption_lwe_sk, encryption_noise_distribution) =
             client_key.encryption_key_and_noise();
@@ -267,8 +262,7 @@ impl ShortintEngine {
         let encoded = ShortintEncoding::from_parameters(client_key.parameters, PaddingBit::No)
             .encode(Cleartext(message));
 
-        let atomic_pattern =
-            AtomicPatternKind::Standard(client_key.parameters.encryption_key_choice().into());
+        let atomic_pattern = client_key.parameters.atomic_pattern();
 
         let (encryption_lwe_sk, encryption_noise_distribution) =
             client_key.encryption_key_and_noise();
@@ -303,8 +297,7 @@ impl ShortintEngine {
 
         let encoded = Plaintext(shifted_message);
 
-        let atomic_pattern =
-            AtomicPatternKind::Standard(client_key.parameters.encryption_key_choice().into());
+        let atomic_pattern = client_key.parameters.atomic_pattern();
 
         let (encryption_lwe_sk, encryption_noise_distribution) =
             client_key.encryption_key_and_noise();
@@ -339,8 +332,7 @@ impl ShortintEngine {
 
         let encoded = Plaintext(shifted_message);
 
-        let atomic_pattern =
-            AtomicPatternKind::Standard(client_key.parameters.encryption_key_choice().into());
+        let atomic_pattern = client_key.parameters.atomic_pattern();
 
         let (encryption_lwe_sk, encryption_noise_distribution) =
             client_key.encryption_key_and_noise();

--- a/tfhe/src/shortint/parameters/mod.rs
+++ b/tfhe/src/shortint/parameters/mod.rs
@@ -291,6 +291,7 @@ impl PBSParameters {
             Self::MultiBitPBS(params) => params.encryption_key_choice,
         }
     }
+
     pub const fn grouping_factor(&self) -> LweBskGroupingFactor {
         match self {
             Self::PBS(_) => {
@@ -548,6 +549,21 @@ impl ShortintParameterSet {
             ShortintParameterSetInner::WopbsOnly(params) => params.ciphertext_modulus,
             ShortintParameterSetInner::PBSAndWopbs(params, _) => params.ciphertext_modulus(),
             ShortintParameterSetInner::KS32PBS(params) => params.ciphertext_modulus(),
+        }
+    }
+
+    pub const fn atomic_pattern(&self) -> AtomicPatternKind {
+        match self.inner {
+            ShortintParameterSetInner::PBSOnly(params) => {
+                AtomicPatternKind::Standard(params.encryption_key_choice().into_pbs_order())
+            }
+            ShortintParameterSetInner::WopbsOnly(_params) => {
+                panic!("WopbsOnly parameters do not support Atomic Patterns")
+            }
+            ShortintParameterSetInner::PBSAndWopbs(params, _) => {
+                AtomicPatternKind::Standard(params.encryption_key_choice().into_pbs_order())
+            }
+            ShortintParameterSetInner::KS32PBS(_params) => AtomicPatternKind::KeySwitch32,
         }
     }
 


### PR DESCRIPTION
During encryption the AP inside the ciphertext was always hardcoded to standard
