### PR TITLE
chore(ci): remove misleading continue-on-error

### DIFF
--- a/.github/workflows/benchmark_boolean.yml
+++ b/.github/workflows/benchmark_boolean.yml
@@ -48,7 +48,6 @@ jobs:
     concurrency:
       group: ${{ github.workflow_ref }}
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
-    continue-on-error: true
     steps:
       - name: Checkout tfhe-rs repo with tags
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/.github/workflows/benchmark_dex.yml
+++ b/.github/workflows/benchmark_dex.yml
@@ -47,7 +47,6 @@ jobs:
     concurrency:
       group: ${{ github.workflow_ref }}
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
-    continue-on-error: true
     timeout-minutes: 720  # 12 hours
     steps:
       - name: Checkout tfhe-rs repo with tags

--- a/.github/workflows/benchmark_erc20.yml
+++ b/.github/workflows/benchmark_erc20.yml
@@ -48,7 +48,6 @@ jobs:
     concurrency:
       group: ${{ github.workflow_ref }}
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
-    continue-on-error: true
     timeout-minutes: 720  # 12 hours
     steps:
       - name: Checkout tfhe-rs repo with tags

--- a/.github/workflows/benchmark_gpu_common.yml
+++ b/.github/workflows/benchmark_gpu_common.yml
@@ -215,7 +215,6 @@ jobs:
     needs: [ prepare-matrix, setup-instance, install-dependencies ]
     runs-on: ${{ needs.setup-instance.outputs.runner-name }}
     timeout-minutes: 1440 # 24 hours
-    continue-on-error: true
     strategy:
       fail-fast: false
       max-parallel: 1

--- a/.github/workflows/benchmark_integer.yml
+++ b/.github/workflows/benchmark_integer.yml
@@ -111,7 +111,6 @@ jobs:
     concurrency:
       group: ${{ github.workflow_ref }}
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
-    continue-on-error: true
     timeout-minutes: 1440  # 24 hours
     strategy:
       max-parallel: 1

--- a/.github/workflows/benchmark_shortint.yml
+++ b/.github/workflows/benchmark_shortint.yml
@@ -75,7 +75,6 @@ jobs:
     concurrency:
       group: ${{ github.workflow_ref }}
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
-    continue-on-error: true
     strategy:
       max-parallel: 1
       matrix:

--- a/.github/workflows/benchmark_signed_integer.yml
+++ b/.github/workflows/benchmark_signed_integer.yml
@@ -111,7 +111,6 @@ jobs:
     concurrency:
       group: ${{ github.workflow_ref }}
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
-    continue-on-error: true
     timeout-minutes: 1440  # 24 hours
     strategy:
       max-parallel: 1


### PR DESCRIPTION
These continue-on-error would lead to misleading report in Action tab since it would display a successful workflow on the global status page while a job may have failed inside.