### PR TITLE
chore(ci): ensure minimal permission for github default token

### DIFF
--- a/.github/workflows/aws_tfhe_backward_compat_tests.yml
+++ b/.github/workflows/aws_tfhe_backward_compat_tests.yml
@@ -23,8 +23,8 @@ on:
   workflow_dispatch:
   pull_request:
 
-
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   setup-instance:

--- a/.github/workflows/aws_tfhe_fast_tests.yml
+++ b/.github/workflows/aws_tfhe_fast_tests.yml
@@ -24,8 +24,8 @@ on:
   workflow_dispatch:
   pull_request:
 
-
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   should-run:

--- a/.github/workflows/aws_tfhe_integer_tests.yml
+++ b/.github/workflows/aws_tfhe_integer_tests.yml
@@ -30,8 +30,8 @@ on:
     branches:
       - main
 
-
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   should-run:

--- a/.github/workflows/aws_tfhe_signed_integer_tests.yml
+++ b/.github/workflows/aws_tfhe_signed_integer_tests.yml
@@ -30,8 +30,8 @@ on:
     branches:
       - main
 
-
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   should-run:

--- a/.github/workflows/aws_tfhe_tests.yml
+++ b/.github/workflows/aws_tfhe_tests.yml
@@ -27,8 +27,8 @@ on:
     # Nightly tests @ 1AM after each work day
     - cron: "0 1 * * MON-FRI"
 
-
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   should-run:

--- a/.github/workflows/aws_tfhe_wasm_tests.yml
+++ b/.github/workflows/aws_tfhe_wasm_tests.yml
@@ -23,8 +23,8 @@ on:
   pull_request:
     types: [ labeled ]
 
-
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   setup-instance:

--- a/.github/workflows/benchmark_gpu_4090.yml
+++ b/.github/workflows/benchmark_gpu_4090.yml
@@ -22,8 +22,8 @@ on:
     # Weekly benchmarks will be triggered each Friday at 9p.m.
     - cron: "0 21 * * 5"
 
-
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   cuda-integer-benchmarks:

--- a/.github/workflows/cargo_build.yml
+++ b/.github/workflows/cargo_build.yml
@@ -14,8 +14,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
   cancel-in-progress: true
 
-
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   cargo-builds:

--- a/.github/workflows/cargo_build_tfhe_fft.yml
+++ b/.github/workflows/cargo_build_tfhe_fft.yml
@@ -12,8 +12,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
   cancel-in-progress: true
 
-
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   cargo-builds-fft:

--- a/.github/workflows/cargo_build_tfhe_ntt.yml
+++ b/.github/workflows/cargo_build_tfhe_ntt.yml
@@ -12,8 +12,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
   cancel-in-progress: true
 
-
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   cargo-builds-ntt:

--- a/.github/workflows/cargo_test_fft.yml
+++ b/.github/workflows/cargo_test_fft.yml
@@ -16,8 +16,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
   cancel-in-progress: true
 
-
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   should-run:

--- a/.github/workflows/cargo_test_ntt.yml
+++ b/.github/workflows/cargo_test_ntt.yml
@@ -16,8 +16,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
   cancel-in-progress: true
 
-
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   should-run:

--- a/.github/workflows/check_commit.yml
+++ b/.github/workflows/check_commit.yml
@@ -3,8 +3,9 @@ name: Check commit and PR compliance
 on:
   pull_request:
 
-
-permissions: {}
+permissions:
+  contents: read
+  pull-requests: read # Permission needed to scan commits in a pull-request
 
 jobs:
   check-commit-pr:

--- a/.github/workflows/ci_lint.yml
+++ b/.github/workflows/ci_lint.yml
@@ -9,7 +9,8 @@ env:
   ACTIONLINT_CHECKSUM: "023070a287cd8cccd71515fedc843f1985bf96c436b7effaecce67290e7e0757"
   CHECKOUT_TOKEN: ${{ secrets.REPO_CHECKOUT_TOKEN || secrets.GITHUB_TOKEN }}
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   lint-check:

--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -17,8 +17,8 @@ on:
   workflow_dispatch:
   # Code coverage workflow is only run via workflow_dispatch event since execution duration is not stabilized yet.
 
-
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   setup-instance:

--- a/.github/workflows/csprng_randomness_tests.yml
+++ b/.github/workflows/csprng_randomness_tests.yml
@@ -21,8 +21,8 @@ on:
   pull_request:
     types: [ labeled ]
 
-
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   setup-instance:

--- a/.github/workflows/gpu_4090_tests.yml
+++ b/.github/workflows/gpu_4090_tests.yml
@@ -22,8 +22,8 @@ on:
     # Nightly tests @ 1AM after each work day
     - cron: "0 1 * * MON-FRI"
 
-
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   cuda-tests-linux:

--- a/.github/workflows/gpu_fast_h100_tests.yml
+++ b/.github/workflows/gpu_fast_h100_tests.yml
@@ -25,8 +25,8 @@ on:
   pull_request:
     types: [ labeled ]
 
-
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   should-run:

--- a/.github/workflows/gpu_fast_tests.yml
+++ b/.github/workflows/gpu_fast_tests.yml
@@ -24,8 +24,8 @@ on:
   workflow_dispatch:
   pull_request:
 
-
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   should-run:

--- a/.github/workflows/gpu_full_multi_gpu_tests.yml
+++ b/.github/workflows/gpu_full_multi_gpu_tests.yml
@@ -25,8 +25,8 @@ on:
   pull_request:
     types: [ labeled ]
 
-
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   should-run:

--- a/.github/workflows/gpu_integer_long_run_tests.yml
+++ b/.github/workflows/gpu_integer_long_run_tests.yml
@@ -19,8 +19,8 @@ on:
     # Nightly tests will be triggered each evening 8p.m.
     - cron: "0 20 * * *"
 
-
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   setup-instance:

--- a/.github/workflows/gpu_pcc.yml
+++ b/.github/workflows/gpu_pcc.yml
@@ -23,8 +23,8 @@ env:
 on:
   pull_request:
 
-
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   setup-instance:

--- a/.github/workflows/gpu_signed_integer_classic_tests.yml
+++ b/.github/workflows/gpu_signed_integer_classic_tests.yml
@@ -25,8 +25,8 @@ on:
   pull_request:
     types: [ labeled ]
 
-
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   should-run:

--- a/.github/workflows/gpu_signed_integer_h100_tests.yml
+++ b/.github/workflows/gpu_signed_integer_h100_tests.yml
@@ -25,9 +25,8 @@ on:
   pull_request:
     types: [ labeled ]
 
-
-
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   should-run:

--- a/.github/workflows/gpu_signed_integer_tests.yml
+++ b/.github/workflows/gpu_signed_integer_tests.yml
@@ -29,8 +29,8 @@ on:
     # Nightly tests @ 1AM after each work day
     - cron: "0 1 * * MON-FRI"
 
-
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   should-run:

--- a/.github/workflows/gpu_unsigned_integer_classic_tests.yml
+++ b/.github/workflows/gpu_unsigned_integer_classic_tests.yml
@@ -25,9 +25,8 @@ on:
   pull_request:
     types: [ labeled ]
 
-
-
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   should-run:

--- a/.github/workflows/gpu_unsigned_integer_h100_tests.yml
+++ b/.github/workflows/gpu_unsigned_integer_h100_tests.yml
@@ -25,8 +25,8 @@ on:
   pull_request:
     types: [ labeled ]
 
-
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   should-run:

--- a/.github/workflows/gpu_unsigned_integer_tests.yml
+++ b/.github/workflows/gpu_unsigned_integer_tests.yml
@@ -29,8 +29,8 @@ on:
     # Nightly tests @ 1AM after each work day
     - cron: "0 1 * * MON-FRI"
 
-
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   should-run:

--- a/.github/workflows/m1_tests.yml
+++ b/.github/workflows/m1_tests.yml
@@ -27,7 +27,8 @@ concurrency:
   group: ${{ github.workflow_ref }}
   cancel-in-progress: true
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   cargo-builds-m1:


### PR DESCRIPTION
With recent enforcing of the least permissions for GITHUB_TOKEN, pull-request from external contributors would trigger systematic error (i.e. on repository checkout) in the continuous integration pipeline.
Allowing `contents:read` fixes this behavior.
