### PR TITLE
chore(zk): check that crs group element at index n is 0

### DIFF
--- a/tfhe-zk-pok/src/curve_api.rs
+++ b/tfhe-zk-pok/src/curve_api.rs
@@ -97,6 +97,7 @@ pub trait CurveGroupOps<Zp>:
     + core::ops::Sub<Self, Output = Self>
     + core::ops::Neg<Output = Self>
     + core::iter::Sum
+    + PartialEq
 {
     const ZERO: Self;
     const GENERATOR: Self;

--- a/tfhe-zk-pok/src/proofs/mod.rs
+++ b/tfhe-zk-pok/src/proofs/mod.rs
@@ -124,7 +124,14 @@ impl<G: Curve> GroupElements<G> {
     }
 
     /// Check if the elements are valid for their respective groups
-    pub fn is_valid(&self) -> bool {
+    pub fn is_valid(&self, n: usize) -> bool {
+        if self.g_list.0.len() != n * 2
+            || self.g_hat_list.0.len() != n
+            || G::G1::projective(self.g_list[n + 1]) != G::G1::ZERO
+        {
+            return false;
+        }
+
         let (g_list_valid, g_hat_list_valid) = rayon::join(
             || self.g_list.0.par_iter().all(G::G1::validate_affine),
             || self.g_hat_list.0.par_iter().all(G::G2::validate_affine),

--- a/tfhe-zk-pok/src/proofs/pke.rs
+++ b/tfhe-zk-pok/src/proofs/pke.rs
@@ -189,7 +189,7 @@ impl<G: Curve> PublicParams<G> {
     /// - valid points of the curve
     /// - in the correct subgroup
     pub fn is_usable(&self) -> bool {
-        self.g_lists.is_valid()
+        self.g_lists.is_valid(self.n)
     }
 }
 

--- a/tfhe-zk-pok/src/serialization.rs
+++ b/tfhe-zk-pok/src/serialization.rs
@@ -256,6 +256,7 @@ pub(crate) type SerializableFp12 = SerializableQuadExtField<SerializableFp6>;
 pub enum InvalidSerializedGroupElementsError {
     InvalidAffine(InvalidSerializedAffineError),
     InvalidGlistDimension(InvalidArraySizeError),
+    MissingPuncteredElement,
 }
 
 impl Display for InvalidSerializedGroupElementsError {
@@ -266,6 +267,9 @@ impl Display for InvalidSerializedGroupElementsError {
             }
             InvalidSerializedGroupElementsError::InvalidGlistDimension(arr_error) => {
                 write!(f, "invalid number of elements in g_list: {arr_error}")
+            }
+            InvalidSerializedGroupElementsError::MissingPuncteredElement => {
+                write!(f, "Element at index n in g_list should be 0")
             }
         }
     }
@@ -278,6 +282,7 @@ impl Error for InvalidSerializedGroupElementsError {
             InvalidSerializedGroupElementsError::InvalidGlistDimension(arr_error) => {
                 Some(arr_error)
             }
+            InvalidSerializedGroupElementsError::MissingPuncteredElement => None,
         }
     }
 }


### PR DESCRIPTION
Adds a check in the ZK CRS that the group element at index n+1 (one based) is equal to zero.
This is checked during decompression and in `PublicParam::is_usable`, which is used by crs conformance