### PR TITLE
Pg/hpu bench fix

### DIFF
--- a/tfhe/examples/hpu/bench.rs
+++ b/tfhe/examples/hpu/bench.rs
@@ -265,7 +265,7 @@ pub fn main() {
                     std::hint::black_box(&res);
                     res
                 })
-                .next_back()
+                .last()
                 .expect("Iteration must be greater than 0");
 
             // let res_fhe = $fhe_type::from(res_hpu);

--- a/tfhe/examples/hpu/bench.rs
+++ b/tfhe/examples/hpu/bench.rs
@@ -259,6 +259,7 @@ pub fn main() {
             );
             let roi_start = Instant::now();
 
+            #[allow(clippy::double_ended_iterator_last)]
             let res_hpu = (0..args.iter)
                 .map(|_i| {
                     let res = HpuRadixCiphertext::exec(&proto, iop.opcode(), &srcs_enc, &imms);


### PR DESCRIPTION
Issue is appearing when running bench with iter > 1, for example:
`cargo run --profile devo --features=integer,internal-keycache,hpu-v80 --example hpu_bench -- --iter 10 --integer-w 64`
because of usage of .next_back() measured latency is only the latency of the 1st operation.

No emergency to merge.

