### PR TITLE
fix(gpu): allow to build with hpu feature enabled

### DIFF
--- a/.github/workflows/gpu_pcc.yml
+++ b/.github/workflows/gpu_pcc.yml
@@ -120,6 +120,10 @@ jobs:
         run: |
           make pcc_gpu
 
+      - name: Check build with hpu enabled
+        run: |
+          make clippy_gpu_hpu
+
       - name: Set pull-request URL
         if: ${{ failure() && github.event_name == 'pull_request' }}
         run: |

--- a/Makefile
+++ b/Makefile
@@ -312,6 +312,13 @@ clippy_hpu: install_rs_check_toolchain
 		--all-targets \
 		-p $(TFHE_SPEC) -- --no-deps -D warnings
 
+.PHONY: clippy_gpu_hpu # Run clippy lints on tfhe with "gpu" and "hpu" enabled
+clippy_gpu_hpu: install_rs_check_toolchain
+	RUSTFLAGS="$(RUSTFLAGS)" cargo "$(CARGO_RS_CHECK_TOOLCHAIN)" clippy \
+		--features=boolean,shortint,integer,internal-keycache,gpu,hpu,pbs-stats,extended-types \
+		--all-targets \
+		-p $(TFHE_SPEC) -- --no-deps -D warnings
+
 .PHONY: fix_newline # Fix newline at end of file issues to be UNIX compliant
 fix_newline: check_linelint_installed
 	linelint -a .
@@ -1214,7 +1221,7 @@ bench_integer_compression_gpu: install_rs_check_toolchain
 	cargo $(CARGO_RS_CHECK_TOOLCHAIN) bench \
 	--bench	glwe_packing_compression-integer-bench \
 	--features=integer,internal-keycache,gpu,pbs-stats -p tfhe-benchmark --
-	
+
 .PHONY: bench_integer_zk_gpu
 bench_integer_zk_gpu: install_rs_check_toolchain
 	RUSTFLAGS="$(RUSTFLAGS)" __TFHE_RS_BENCH_TYPE=$(BENCH_TYPE) \
@@ -1500,7 +1507,7 @@ pcc_gpu: check_rust_bindings_did_not_change clippy_rustdoc_gpu \
 clippy_gpu clippy_cuda_backend clippy_bench_gpu check_compile_tests_benches_gpu
 
 .PHONY: pcc_hpu # pcc stands for pre commit checks for HPU compilation
-pcc_hpu: clippy_hpu clippy_hpu_backend test_integer_hpu_mockup_ci_fast 
+pcc_hpu: clippy_hpu clippy_hpu_backend test_integer_hpu_mockup_ci_fast
 
 .PHONY: fpcc # pcc stands for pre commit checks, the f stands for fast
 fpcc: no_tfhe_typo no_dbg_log check_parameter_export_ok check_fmt check_typos lint_doc \

--- a/tfhe/src/high_level_api/booleans/inner.rs
+++ b/tfhe/src/high_level_api/booleans/inner.rs
@@ -160,15 +160,13 @@ impl InnerBoolean {
         &self,
         streams: &CudaStreams,
     ) -> MaybeCloned<'_, CudaUnsignedRadixCiphertext> {
-        #[allow(clippy::match_wildcard_for_single_variants)]
-        let cpu_radix = match self {
-            Self::Cuda(gpu_radix) => {
-                if gpu_radix.gpu_indexes() == streams.gpu_indexes() {
-                    return MaybeCloned::Borrowed(&gpu_radix.0);
-                }
-                return MaybeCloned::Cloned(gpu_radix.duplicate(streams).0);
+        let cpu_radix = if let Self::Cuda(gpu_radix) = self {
+            if gpu_radix.gpu_indexes() == streams.gpu_indexes() {
+                return MaybeCloned::Borrowed(&gpu_radix.0);
             }
-            _ => self.on_cpu(),
+            return MaybeCloned::Cloned(gpu_radix.duplicate(streams).0);
+        } else {
+            self.on_cpu()
         };
 
         let gpu_radix = CudaBooleanBlock::from_boolean_block(&cpu_radix, streams);
@@ -177,10 +175,10 @@ impl InnerBoolean {
 
     #[cfg(feature = "hpu")]
     pub(crate) fn on_hpu(&self, device: &HpuTaggedDevice) -> MaybeCloned<'_, HpuRadixCiphertext> {
-        #[allow(clippy::match_wildcard_for_single_variants)]
-        let cpu_radix = match self {
-            Self::Hpu(hpu_radix) => return MaybeCloned::Borrowed(hpu_radix),
-            _ => self.on_cpu(),
+        let cpu_radix = if let Self::Hpu(hpu_radix) = self {
+            return MaybeCloned::Borrowed(hpu_radix);
+        } else {
+            self.on_cpu()
         };
 
         let hpu_ct = HpuRadixCiphertext::from_boolean_ciphertext(&cpu_radix, &device.device);
@@ -237,10 +235,10 @@ impl InnerBoolean {
 
     #[cfg(feature = "gpu")]
     pub(crate) fn into_gpu(self, streams: &CudaStreams) -> CudaBooleanBlock {
-        #[allow(clippy::match_wildcard_for_single_variants)]
-        let cpu_bool = match self {
-            Self::Cuda(gpu_bool) => return gpu_bool.move_to_stream(streams),
-            _ => self.into_cpu(),
+        let cpu_bool = if let Self::Cuda(gpu_bool) = self {
+            return gpu_bool.move_to_stream(streams);
+        } else {
+            self.into_cpu()
         };
         CudaBooleanBlock::from_boolean_block(&cpu_bool, streams)
     }

--- a/tfhe/src/high_level_api/integers/signed/ops.rs
+++ b/tfhe/src/high_level_api/integers/signed/ops.rs
@@ -2098,20 +2098,20 @@ where
 {
     fn get_add_size_on_gpu(&self, rhs: I) -> u64 {
         let rhs = rhs.borrow();
-        let mut tmp_buffer_size = 0;
-        global_state::with_internal_keys(|key| match key {
-            InternalServerKey::Cpu(_) => {
-                tmp_buffer_size = 0;
+
+        global_state::with_internal_keys(|key| {
+            if let InternalServerKey::Cuda(cuda_key) = key {
+                with_thread_local_cuda_streams(|streams| {
+                    cuda_key.key.key.get_add_size_on_gpu(
+                        &*self.ciphertext.on_gpu(streams),
+                        &rhs.ciphertext.on_gpu(streams),
+                        streams,
+                    )
+                })
+            } else {
+                0
             }
-            InternalServerKey::Cuda(cuda_key) => with_thread_local_cuda_streams(|streams| {
-                tmp_buffer_size = cuda_key.key.key.get_add_size_on_gpu(
-                    &*self.ciphertext.on_gpu(streams),
-                    &rhs.ciphertext.on_gpu(streams),
-                    streams,
-                );
-            }),
-        });
-        tmp_buffer_size
+        })
     }
 }
 
@@ -2123,20 +2123,20 @@ where
 {
     fn get_sub_size_on_gpu(&self, rhs: I) -> u64 {
         let rhs = rhs.borrow();
-        let mut tmp_buffer_size = 0;
-        global_state::with_internal_keys(|key| match key {
-            InternalServerKey::Cpu(_) => {
-                tmp_buffer_size = 0;
+
+        global_state::with_internal_keys(|key| {
+            if let InternalServerKey::Cuda(cuda_key) = key {
+                with_thread_local_cuda_streams(|streams| {
+                    cuda_key.key.key.get_sub_size_on_gpu(
+                        &*self.ciphertext.on_gpu(streams),
+                        &rhs.ciphertext.on_gpu(streams),
+                        streams,
+                    )
+                })
+            } else {
+                0
             }
-            InternalServerKey::Cuda(cuda_key) => with_thread_local_cuda_streams(|streams| {
-                tmp_buffer_size = cuda_key.key.key.get_sub_size_on_gpu(
-                    &*self.ciphertext.on_gpu(streams),
-                    &rhs.ciphertext.on_gpu(streams),
-                    streams,
-                );
-            }),
-        });
-        tmp_buffer_size
+        })
     }
 }
 
@@ -2146,14 +2146,17 @@ where
     Id: FheIntId,
 {
     fn get_size_on_gpu(&self) -> u64 {
-        global_state::with_internal_keys(|key| match key {
-            InternalServerKey::Cuda(cuda_key) => with_thread_local_cuda_streams(|streams| {
-                cuda_key
-                    .key
-                    .key
-                    .get_ciphertext_size_on_gpu(&*self.ciphertext.on_gpu(streams))
-            }),
-            InternalServerKey::Cpu(_) => 0,
+        global_state::with_internal_keys(|key| {
+            if let InternalServerKey::Cuda(cuda_key) = key {
+                with_thread_local_cuda_streams(|streams| {
+                    cuda_key
+                        .key
+                        .key
+                        .get_ciphertext_size_on_gpu(&*self.ciphertext.on_gpu(streams))
+                })
+            } else {
+                0
+            }
         })
     }
 }
@@ -2166,20 +2169,19 @@ where
 {
     fn get_bitand_size_on_gpu(&self, rhs: I) -> u64 {
         let rhs = rhs.borrow();
-        let mut tmp_buffer_size = 0;
-        global_state::with_internal_keys(|key| match key {
-            InternalServerKey::Cpu(_) => {
-                tmp_buffer_size = 0;
+        global_state::with_internal_keys(|key| {
+            if let InternalServerKey::Cuda(cuda_key) = key {
+                with_thread_local_cuda_streams(|streams| {
+                    cuda_key.key.key.get_bitand_size_on_gpu(
+                        &*self.ciphertext.on_gpu(streams),
+                        &rhs.ciphertext.on_gpu(streams),
+                        streams,
+                    )
+                })
+            } else {
+                0
             }
-            InternalServerKey::Cuda(cuda_key) => with_thread_local_cuda_streams(|streams| {
-                tmp_buffer_size = cuda_key.key.key.get_bitand_size_on_gpu(
-                    &*self.ciphertext.on_gpu(streams),
-                    &rhs.ciphertext.on_gpu(streams),
-                    streams,
-                );
-            }),
-        });
-        tmp_buffer_size
+        })
     }
 }
 
@@ -2191,20 +2193,19 @@ where
 {
     fn get_bitor_size_on_gpu(&self, rhs: I) -> u64 {
         let rhs = rhs.borrow();
-        let mut tmp_buffer_size = 0;
-        global_state::with_internal_keys(|key| match key {
-            InternalServerKey::Cpu(_) => {
-                tmp_buffer_size = 0;
+        global_state::with_internal_keys(|key| {
+            if let InternalServerKey::Cuda(cuda_key) = key {
+                with_thread_local_cuda_streams(|streams| {
+                    cuda_key.key.key.get_bitor_size_on_gpu(
+                        &*self.ciphertext.on_gpu(streams),
+                        &rhs.ciphertext.on_gpu(streams),
+                        streams,
+                    )
+                })
+            } else {
+                0
             }
-            InternalServerKey::Cuda(cuda_key) => with_thread_local_cuda_streams(|streams| {
-                tmp_buffer_size = cuda_key.key.key.get_bitor_size_on_gpu(
-                    &*self.ciphertext.on_gpu(streams),
-                    &rhs.ciphertext.on_gpu(streams),
-                    streams,
-                );
-            }),
-        });
-        tmp_buffer_size
+        })
     }
 }
 
@@ -2216,20 +2217,19 @@ where
 {
     fn get_bitxor_size_on_gpu(&self, rhs: I) -> u64 {
         let rhs = rhs.borrow();
-        let mut tmp_buffer_size = 0;
-        global_state::with_internal_keys(|key| match key {
-            InternalServerKey::Cpu(_) => {
-                tmp_buffer_size = 0;
+        global_state::with_internal_keys(|key| {
+            if let InternalServerKey::Cuda(cuda_key) = key {
+                with_thread_local_cuda_streams(|streams| {
+                    cuda_key.key.key.get_bitxor_size_on_gpu(
+                        &*self.ciphertext.on_gpu(streams),
+                        &rhs.ciphertext.on_gpu(streams),
+                        streams,
+                    )
+                })
+            } else {
+                0
             }
-            InternalServerKey::Cuda(cuda_key) => with_thread_local_cuda_streams(|streams| {
-                tmp_buffer_size = cuda_key.key.key.get_bitxor_size_on_gpu(
-                    &*self.ciphertext.on_gpu(streams),
-                    &rhs.ciphertext.on_gpu(streams),
-                    streams,
-                );
-            }),
-        });
-        tmp_buffer_size
+        })
     }
 }
 
@@ -2239,18 +2239,17 @@ where
     Id: FheIntId,
 {
     fn get_bitnot_size_on_gpu(&self) -> u64 {
-        let mut tmp_buffer_size = 0;
-        global_state::with_internal_keys(|key| match key {
-            InternalServerKey::Cpu(_) => {
-                tmp_buffer_size = 0;
+        global_state::with_internal_keys(|key| {
+            if let InternalServerKey::Cuda(cuda_key) = key {
+                with_thread_local_cuda_streams(|streams| {
+                    cuda_key
+                        .key
+                        .key
+                        .get_bitnot_size_on_gpu(&*self.ciphertext.on_gpu(streams), streams)
+                })
+            } else {
+                0
             }
-            InternalServerKey::Cuda(cuda_key) => with_thread_local_cuda_streams(|streams| {
-                tmp_buffer_size = cuda_key
-                    .key
-                    .key
-                    .get_bitnot_size_on_gpu(&*self.ciphertext.on_gpu(streams), streams);
-            }),
-        });
-        tmp_buffer_size
+        })
     }
 }

--- a/tfhe/src/high_level_api/integers/signed/scalar_ops.rs
+++ b/tfhe/src/high_level_api/integers/signed/scalar_ops.rs
@@ -864,19 +864,17 @@ macro_rules! define_scalar_ops {
             rust_trait: AddSizeOnGpu(get_add_size_on_gpu),
             implem: {
                 |lhs: &FheInt<_>, _rhs| {
-                    let mut tmp_buffer_size = 0;
-                    global_state::with_internal_keys(|key| match key {
-                        InternalServerKey::Cpu(_) => {
-                            tmp_buffer_size = 0;
-                        }
-                        InternalServerKey::Cuda(cuda_key) => with_thread_local_cuda_streams(|streams| {
-                            tmp_buffer_size = cuda_key.key.key.get_scalar_add_size_on_gpu(
-                                &*lhs.ciphertext.on_gpu(streams),
-                                streams,
-                            );
-                        }),
-                    });
-                    tmp_buffer_size
+                    global_state::with_internal_keys(|key|
+                        if let InternalServerKey::Cuda(cuda_key) = key {
+                            with_thread_local_cuda_streams(|streams| {
+                                cuda_key.key.key.get_scalar_add_size_on_gpu(
+                                    &*lhs.ciphertext.on_gpu(streams),
+                                    streams,
+                                )
+                            })
+                        } else {
+                            0
+                        })
                 }
             },
             fhe_and_scalar_type:
@@ -923,19 +921,17 @@ macro_rules! define_scalar_ops {
             rust_trait: SubSizeOnGpu(get_sub_size_on_gpu),
             implem: {
                 |lhs: &FheInt<_>, _rhs| {
-                    let mut tmp_buffer_size = 0;
-                    global_state::with_internal_keys(|key| match key {
-                        InternalServerKey::Cpu(_) => {
-                            tmp_buffer_size = 0;
-                        }
-                        InternalServerKey::Cuda(cuda_key) => with_thread_local_cuda_streams(|streams| {
-                            tmp_buffer_size = cuda_key.key.key.get_scalar_sub_size_on_gpu(
-                                &*lhs.ciphertext.on_gpu(streams),
-                                streams,
-                            );
-                        }),
-                    });
-                    tmp_buffer_size
+                    global_state::with_internal_keys(|key|
+                        if let InternalServerKey::Cuda(cuda_key) = key {
+                            with_thread_local_cuda_streams(|streams| {
+                                cuda_key.key.key.get_scalar_sub_size_on_gpu(
+                                    &*lhs.ciphertext.on_gpu(streams),
+                                    streams,
+                                )
+                            })
+                        } else {
+                            0
+                        })
                 }
             },
             fhe_and_scalar_type:
@@ -1016,19 +1012,17 @@ macro_rules! define_scalar_ops {
             rust_trait: BitAndSizeOnGpu(get_bitand_size_on_gpu),
             implem: {
                 |lhs: &FheInt<_>, _rhs| {
-                    let mut tmp_buffer_size = 0;
-                    global_state::with_internal_keys(|key| match key {
-                        InternalServerKey::Cpu(_) => {
-                            tmp_buffer_size = 0;
-                        }
-                        InternalServerKey::Cuda(cuda_key) => with_thread_local_cuda_streams(|streams| {
-                            tmp_buffer_size = cuda_key.key.key.get_scalar_bitand_size_on_gpu(
-                                &*lhs.ciphertext.on_gpu(streams),
-                                streams,
-                            );
-                        }),
-                    });
-                    tmp_buffer_size
+                    global_state::with_internal_keys(|key|
+                        if let InternalServerKey::Cuda(cuda_key) = key {
+                            with_thread_local_cuda_streams(|streams| {
+                                cuda_key.key.key.get_scalar_bitand_size_on_gpu(
+                                    &*lhs.ciphertext.on_gpu(streams),
+                                    streams,
+                                )
+                            })
+                        } else {
+                            0
+                        })
                 }
             },
             fhe_and_scalar_type:
@@ -1075,19 +1069,17 @@ macro_rules! define_scalar_ops {
             rust_trait: BitOrSizeOnGpu(get_bitor_size_on_gpu),
             implem: {
                 |lhs: &FheInt<_>, _rhs| {
-                    let mut tmp_buffer_size = 0;
-                    global_state::with_internal_keys(|key| match key {
-                        InternalServerKey::Cpu(_) => {
-                            tmp_buffer_size = 0;
-                        }
-                        InternalServerKey::Cuda(cuda_key) => with_thread_local_cuda_streams(|streams| {
-                            tmp_buffer_size = cuda_key.key.key.get_scalar_bitor_size_on_gpu(
-                                &*lhs.ciphertext.on_gpu(streams),
-                                streams,
-                            );
-                        }),
-                    });
-                    tmp_buffer_size
+                    global_state::with_internal_keys(|key|
+                        if let InternalServerKey::Cuda(cuda_key) = key {
+                            with_thread_local_cuda_streams(|streams| {
+                                cuda_key.key.key.get_scalar_bitor_size_on_gpu(
+                                    &*lhs.ciphertext.on_gpu(streams),
+                                    streams,
+                                )
+                            })
+                        } else {
+                            0
+                        })
                 }
             },
             fhe_and_scalar_type:
@@ -1135,19 +1127,17 @@ macro_rules! define_scalar_ops {
             rust_trait: BitXorSizeOnGpu(get_bitxor_size_on_gpu),
             implem: {
                 |lhs: &FheInt<_>, _rhs| {
-                    let mut tmp_buffer_size = 0;
-                    global_state::with_internal_keys(|key| match key {
-                        InternalServerKey::Cpu(_) => {
-                            tmp_buffer_size = 0;
-                        }
-                        InternalServerKey::Cuda(cuda_key) => with_thread_local_cuda_streams(|streams| {
-                            tmp_buffer_size = cuda_key.key.key.get_scalar_bitxor_size_on_gpu(
-                                &*lhs.ciphertext.on_gpu(streams),
-                                streams,
-                            );
-                        }),
-                    });
-                    tmp_buffer_size
+                    global_state::with_internal_keys(|key|
+                        if let InternalServerKey::Cuda(cuda_key) = key {
+                            with_thread_local_cuda_streams(|streams| {
+                                cuda_key.key.key.get_scalar_bitxor_size_on_gpu(
+                                    &*lhs.ciphertext.on_gpu(streams),
+                                    streams,
+                                )
+                            })
+                        } else {
+                            0
+                        })
                 }
             },
             fhe_and_scalar_type:
@@ -1245,19 +1235,17 @@ macro_rules! define_scalar_ops {
             rust_trait: AddSizeOnGpu(get_add_size_on_gpu),
             implem: {
                 |_lhs, rhs: &FheInt<_>| {
-                    let mut tmp_buffer_size = 0;
-                    global_state::with_internal_keys(|key| match key {
-                        InternalServerKey::Cpu(_) => {
-                            tmp_buffer_size = 0;
-                        }
-                        InternalServerKey::Cuda(cuda_key) => with_thread_local_cuda_streams(|streams| {
-                            tmp_buffer_size = cuda_key.key.key.get_scalar_add_size_on_gpu(
-                                &*rhs.ciphertext.on_gpu(streams),
-                                streams,
-                            );
-                        }),
-                    });
-                    tmp_buffer_size
+                    global_state::with_internal_keys(|key|
+                        if let InternalServerKey::Cuda(cuda_key) = key {
+                            with_thread_local_cuda_streams(|streams| {
+                                cuda_key.key.key.get_scalar_add_size_on_gpu(
+                                    &*rhs.ciphertext.on_gpu(streams),
+                                    streams,
+                                )
+                            })
+                        } else {
+                            0
+                        })
                 }
             },
             fhe_and_scalar_type:
@@ -1304,19 +1292,17 @@ macro_rules! define_scalar_ops {
             rust_trait: SubSizeOnGpu(get_sub_size_on_gpu),
             implem: {
                 |_lhs, rhs: &FheInt<_>| {
-                    let mut tmp_buffer_size = 0;
-                    global_state::with_internal_keys(|key| match key {
-                        InternalServerKey::Cpu(_) => {
-                            tmp_buffer_size = 0;
-                        }
-                        InternalServerKey::Cuda(cuda_key) => with_thread_local_cuda_streams(|streams| {
-                            tmp_buffer_size = cuda_key.key.key.get_scalar_sub_size_on_gpu(
-                                &*rhs.ciphertext.on_gpu(streams),
-                                streams,
-                            );
-                        }),
-                    });
-                    tmp_buffer_size
+                    global_state::with_internal_keys(|key|
+                        if let InternalServerKey::Cuda(cuda_key) = key {
+                            with_thread_local_cuda_streams(|streams| {
+                                cuda_key.key.key.get_scalar_sub_size_on_gpu(
+                                    &*rhs.ciphertext.on_gpu(streams),
+                                    streams,
+                                )
+                            })
+                        } else {
+                            0
+                        })
                 }
             },
             fhe_and_scalar_type:
@@ -1362,19 +1348,17 @@ macro_rules! define_scalar_ops {
             rust_trait: BitAndSizeOnGpu(get_bitand_size_on_gpu),
             implem: {
                 |_lhs, rhs: &FheInt<_>| {
-                    let mut tmp_buffer_size = 0;
-                    global_state::with_internal_keys(|key| match key {
-                        InternalServerKey::Cpu(_) => {
-                            tmp_buffer_size = 0;
-                        }
-                        InternalServerKey::Cuda(cuda_key) => with_thread_local_cuda_streams(|streams| {
-                            tmp_buffer_size = cuda_key.key.key.get_scalar_bitand_size_on_gpu(
-                                &*rhs.ciphertext.on_gpu(streams),
-                                streams,
-                            );
-                        }),
-                    });
-                    tmp_buffer_size
+                    global_state::with_internal_keys(|key|
+                        if let InternalServerKey::Cuda(cuda_key) = key {
+                            with_thread_local_cuda_streams(|streams| {
+                                cuda_key.key.key.get_scalar_bitand_size_on_gpu(
+                                    &*rhs.ciphertext.on_gpu(streams),
+                                    streams,
+                                )
+                            })
+                        } else {
+                            0
+                        })
                 }
             },
             fhe_and_scalar_type:
@@ -1403,19 +1387,17 @@ macro_rules! define_scalar_ops {
             rust_trait: BitOrSizeOnGpu(get_bitor_size_on_gpu),
             implem: {
                 |_lhs, rhs: &FheInt<_>| {
-                    let mut tmp_buffer_size = 0;
-                    global_state::with_internal_keys(|key| match key {
-                        InternalServerKey::Cpu(_) => {
-                            tmp_buffer_size = 0;
-                        }
-                        InternalServerKey::Cuda(cuda_key) => with_thread_local_cuda_streams(|streams| {
-                            tmp_buffer_size = cuda_key.key.key.get_scalar_bitor_size_on_gpu(
-                                &*rhs.ciphertext.on_gpu(streams),
-                                streams,
-                            );
-                        }),
-                    });
-                    tmp_buffer_size
+                    global_state::with_internal_keys(|key|
+                        if let InternalServerKey::Cuda(cuda_key) = key {
+                            with_thread_local_cuda_streams(|streams| {
+                                cuda_key.key.key.get_scalar_bitor_size_on_gpu(
+                                    &*rhs.ciphertext.on_gpu(streams),
+                                    streams,
+                                )
+                            })
+                        } else {
+                            0
+                        })
                 }
             },
             fhe_and_scalar_type:
@@ -1444,19 +1426,17 @@ macro_rules! define_scalar_ops {
             rust_trait: BitXorSizeOnGpu(get_bitxor_size_on_gpu),
             implem: {
                 |_lhs, rhs: &FheInt<_>| {
-                    let mut tmp_buffer_size = 0;
-                    global_state::with_internal_keys(|key| match key {
-                        InternalServerKey::Cpu(_) => {
-                            tmp_buffer_size = 0;
-                        }
-                        InternalServerKey::Cuda(cuda_key) => with_thread_local_cuda_streams(|streams| {
-                            tmp_buffer_size = cuda_key.key.key.get_scalar_bitxor_size_on_gpu(
-                                &*rhs.ciphertext.on_gpu(streams),
-                                streams,
-                            );
-                        }),
-                    });
-                    tmp_buffer_size
+                    global_state::with_internal_keys(|key|
+                        if let InternalServerKey::Cuda(cuda_key) = key {
+                            with_thread_local_cuda_streams(|streams| {
+                                cuda_key.key.key.get_scalar_bitxor_size_on_gpu(
+                                    &*rhs.ciphertext.on_gpu(streams),
+                                    streams,
+                                )
+                            })
+                        } else {
+                            0
+                        })
                 }
             },
             fhe_and_scalar_type:

--- a/tfhe/src/high_level_api/integers/unsigned/base.rs
+++ b/tfhe/src/high_level_api/integers/unsigned/base.rs
@@ -272,10 +272,10 @@ where
     /// slice is empty
     #[cfg(feature = "gpu")]
     pub fn gpu_indexes(&self) -> &[GpuIndex] {
-        #[allow(clippy::match_wildcard_for_single_variants)]
-        match &self.ciphertext {
-            RadixCiphertext::Cuda(cuda_ct) => cuda_ct.gpu_indexes(),
-            _ => &[],
+        if let RadixCiphertext::Cuda(cuda_ct) = &self.ciphertext {
+            cuda_ct.gpu_indexes()
+        } else {
+            &[]
         }
     }
     /// Returns a FheBool that encrypts `true` if the value is even

--- a/tfhe/src/high_level_api/integers/unsigned/ops.rs
+++ b/tfhe/src/high_level_api/integers/unsigned/ops.rs
@@ -2325,20 +2325,19 @@ where
 {
     fn get_add_size_on_gpu(&self, rhs: I) -> u64 {
         let rhs = rhs.borrow();
-        let mut tmp_buffer_size = 0;
-        global_state::with_internal_keys(|key| match key {
-            InternalServerKey::Cpu(_) => {
-                tmp_buffer_size = 0;
+        global_state::with_internal_keys(|key| {
+            if let InternalServerKey::Cuda(cuda_key) = key {
+                with_thread_local_cuda_streams(|streams| {
+                    cuda_key.key.key.get_add_size_on_gpu(
+                        &*self.ciphertext.on_gpu(streams),
+                        &rhs.ciphertext.on_gpu(streams),
+                        streams,
+                    )
+                })
+            } else {
+                0
             }
-            InternalServerKey::Cuda(cuda_key) => with_thread_local_cuda_streams(|streams| {
-                tmp_buffer_size = cuda_key.key.key.get_add_size_on_gpu(
-                    &*self.ciphertext.on_gpu(streams),
-                    &rhs.ciphertext.on_gpu(streams),
-                    streams,
-                );
-            }),
-        });
-        tmp_buffer_size
+        })
     }
 }
 
@@ -2350,20 +2349,19 @@ where
 {
     fn get_sub_size_on_gpu(&self, rhs: I) -> u64 {
         let rhs = rhs.borrow();
-        let mut tmp_buffer_size = 0;
-        global_state::with_internal_keys(|key| match key {
-            InternalServerKey::Cpu(_) => {
-                tmp_buffer_size = 0;
+        global_state::with_internal_keys(|key| {
+            if let InternalServerKey::Cuda(cuda_key) = key {
+                with_thread_local_cuda_streams(|streams| {
+                    cuda_key.key.key.get_sub_size_on_gpu(
+                        &*self.ciphertext.on_gpu(streams),
+                        &rhs.ciphertext.on_gpu(streams),
+                        streams,
+                    )
+                })
+            } else {
+                0
             }
-            InternalServerKey::Cuda(cuda_key) => with_thread_local_cuda_streams(|streams| {
-                tmp_buffer_size = cuda_key.key.key.get_sub_size_on_gpu(
-                    &*self.ciphertext.on_gpu(streams),
-                    &rhs.ciphertext.on_gpu(streams),
-                    streams,
-                );
-            }),
-        });
-        tmp_buffer_size
+        })
     }
 }
 #[cfg(feature = "gpu")]
@@ -2372,14 +2370,17 @@ where
     Id: FheUintId,
 {
     fn get_size_on_gpu(&self) -> u64 {
-        global_state::with_internal_keys(|key| match key {
-            InternalServerKey::Cuda(cuda_key) => with_thread_local_cuda_streams(|streams| {
-                cuda_key
-                    .key
-                    .key
-                    .get_ciphertext_size_on_gpu(&*self.ciphertext.on_gpu(streams))
-            }),
-            InternalServerKey::Cpu(_) => 0,
+        global_state::with_internal_keys(|key| {
+            if let InternalServerKey::Cuda(cuda_key) = key {
+                with_thread_local_cuda_streams(|streams| {
+                    cuda_key
+                        .key
+                        .key
+                        .get_ciphertext_size_on_gpu(&*self.ciphertext.on_gpu(streams))
+                })
+            } else {
+                0
+            }
         })
     }
 }
@@ -2391,20 +2392,20 @@ where
 {
     fn get_bitand_size_on_gpu(&self, rhs: I) -> u64 {
         let rhs = rhs.borrow();
-        let mut tmp_buffer_size = 0;
-        global_state::with_internal_keys(|key| match key {
-            InternalServerKey::Cpu(_) => {
-                tmp_buffer_size = 0;
+
+        global_state::with_internal_keys(|key| {
+            if let InternalServerKey::Cuda(cuda_key) = key {
+                with_thread_local_cuda_streams(|streams| {
+                    cuda_key.key.key.get_bitand_size_on_gpu(
+                        &*self.ciphertext.on_gpu(streams),
+                        &rhs.ciphertext.on_gpu(streams),
+                        streams,
+                    )
+                })
+            } else {
+                0
             }
-            InternalServerKey::Cuda(cuda_key) => with_thread_local_cuda_streams(|streams| {
-                tmp_buffer_size = cuda_key.key.key.get_bitand_size_on_gpu(
-                    &*self.ciphertext.on_gpu(streams),
-                    &rhs.ciphertext.on_gpu(streams),
-                    streams,
-                );
-            }),
-        });
-        tmp_buffer_size
+        })
     }
 }
 
@@ -2416,20 +2417,19 @@ where
 {
     fn get_bitor_size_on_gpu(&self, rhs: I) -> u64 {
         let rhs = rhs.borrow();
-        let mut tmp_buffer_size = 0;
-        global_state::with_internal_keys(|key| match key {
-            InternalServerKey::Cpu(_) => {
-                tmp_buffer_size = 0;
+        global_state::with_internal_keys(|key| {
+            if let InternalServerKey::Cuda(cuda_key) = key {
+                with_thread_local_cuda_streams(|streams| {
+                    cuda_key.key.key.get_bitor_size_on_gpu(
+                        &*self.ciphertext.on_gpu(streams),
+                        &rhs.ciphertext.on_gpu(streams),
+                        streams,
+                    )
+                })
+            } else {
+                0
             }
-            InternalServerKey::Cuda(cuda_key) => with_thread_local_cuda_streams(|streams| {
-                tmp_buffer_size = cuda_key.key.key.get_bitor_size_on_gpu(
-                    &*self.ciphertext.on_gpu(streams),
-                    &rhs.ciphertext.on_gpu(streams),
-                    streams,
-                );
-            }),
-        });
-        tmp_buffer_size
+        })
     }
 }
 
@@ -2441,20 +2441,19 @@ where
 {
     fn get_bitxor_size_on_gpu(&self, rhs: I) -> u64 {
         let rhs = rhs.borrow();
-        let mut tmp_buffer_size = 0;
-        global_state::with_internal_keys(|key| match key {
-            InternalServerKey::Cpu(_) => {
-                tmp_buffer_size = 0;
+        global_state::with_internal_keys(|key| {
+            if let InternalServerKey::Cuda(cuda_key) = key {
+                with_thread_local_cuda_streams(|streams| {
+                    cuda_key.key.key.get_bitxor_size_on_gpu(
+                        &*self.ciphertext.on_gpu(streams),
+                        &rhs.ciphertext.on_gpu(streams),
+                        streams,
+                    )
+                })
+            } else {
+                0
             }
-            InternalServerKey::Cuda(cuda_key) => with_thread_local_cuda_streams(|streams| {
-                tmp_buffer_size = cuda_key.key.key.get_bitxor_size_on_gpu(
-                    &*self.ciphertext.on_gpu(streams),
-                    &rhs.ciphertext.on_gpu(streams),
-                    streams,
-                );
-            }),
-        });
-        tmp_buffer_size
+        })
     }
 }
 
@@ -2464,18 +2463,17 @@ where
     Id: FheUintId,
 {
     fn get_bitnot_size_on_gpu(&self) -> u64 {
-        let mut tmp_buffer_size = 0;
-        global_state::with_internal_keys(|key| match key {
-            InternalServerKey::Cpu(_) => {
-                tmp_buffer_size = 0;
+        global_state::with_internal_keys(|key| {
+            if let InternalServerKey::Cuda(cuda_key) = key {
+                with_thread_local_cuda_streams(|streams| {
+                    cuda_key
+                        .key
+                        .key
+                        .get_bitnot_size_on_gpu(&*self.ciphertext.on_gpu(streams), streams)
+                })
+            } else {
+                0
             }
-            InternalServerKey::Cuda(cuda_key) => with_thread_local_cuda_streams(|streams| {
-                tmp_buffer_size = cuda_key
-                    .key
-                    .key
-                    .get_bitnot_size_on_gpu(&*self.ciphertext.on_gpu(streams), streams);
-            }),
-        });
-        tmp_buffer_size
+        })
     }
 }

--- a/tfhe/src/high_level_api/integers/unsigned/scalar_ops.rs
+++ b/tfhe/src/high_level_api/integers/unsigned/scalar_ops.rs
@@ -1152,19 +1152,17 @@ macro_rules! define_scalar_ops {
             rust_trait: AddSizeOnGpu(get_add_size_on_gpu),
             implem: {
                 |lhs: &FheUint<_>, _rhs| {
-                    let mut tmp_buffer_size = 0;
-                    global_state::with_internal_keys(|key| match key {
-                        InternalServerKey::Cpu(_) => {
-                            tmp_buffer_size = 0;
-                        }
-                        InternalServerKey::Cuda(cuda_key) => with_thread_local_cuda_streams(|streams| {
-                            tmp_buffer_size = cuda_key.key.key.get_scalar_add_size_on_gpu(
-                                &*lhs.ciphertext.on_gpu(streams),
-                                streams,
-                            );
-                        }),
-                    });
-                    tmp_buffer_size
+                    global_state::with_internal_keys(|key|
+                        if let InternalServerKey::Cuda(cuda_key) = key {
+                            with_thread_local_cuda_streams(|streams| {
+                                cuda_key.key.key.get_scalar_add_size_on_gpu(
+                                    &*lhs.ciphertext.on_gpu(streams),
+                                    streams,
+                                )
+                            })
+                        } else {
+                            0
+                        })
                 }
             },
             fhe_and_scalar_type:
@@ -1214,19 +1212,17 @@ macro_rules! define_scalar_ops {
             rust_trait: SubSizeOnGpu(get_sub_size_on_gpu),
             implem: {
                 |lhs: &FheUint<_>, _rhs| {
-                    let mut tmp_buffer_size = 0;
-                    global_state::with_internal_keys(|key| match key {
-                        InternalServerKey::Cpu(_) => {
-                            tmp_buffer_size = 0;
-                        }
-                        InternalServerKey::Cuda(cuda_key) => with_thread_local_cuda_streams(|streams| {
-                            tmp_buffer_size = cuda_key.key.key.get_scalar_sub_size_on_gpu(
-                                &*lhs.ciphertext.on_gpu(streams),
-                                streams,
-                            );
-                        }),
-                    });
-                    tmp_buffer_size
+                    global_state::with_internal_keys(|key|
+                        if let InternalServerKey::Cuda(cuda_key) = key {
+                            with_thread_local_cuda_streams(|streams| {
+                                cuda_key.key.key.get_scalar_sub_size_on_gpu(
+                                    &*lhs.ciphertext.on_gpu(streams),
+                                    streams,
+                                )
+                            })
+                        } else {
+                            0
+                        })
                 }
             },
             fhe_and_scalar_type:
@@ -1310,19 +1306,17 @@ macro_rules! define_scalar_ops {
             rust_trait: BitAndSizeOnGpu(get_bitand_size_on_gpu),
             implem: {
                 |lhs: &FheUint<_>, _rhs| {
-                    let mut tmp_buffer_size = 0;
-                    global_state::with_internal_keys(|key| match key {
-                        InternalServerKey::Cpu(_) => {
-                            tmp_buffer_size = 0;
-                        }
-                        InternalServerKey::Cuda(cuda_key) => with_thread_local_cuda_streams(|streams| {
-                            tmp_buffer_size = cuda_key.key.key.get_scalar_bitand_size_on_gpu(
-                                &*lhs.ciphertext.on_gpu(streams),
-                                streams,
-                            );
-                        }),
-                    });
-                    tmp_buffer_size
+                    global_state::with_internal_keys(|key|
+                        if let InternalServerKey::Cuda(cuda_key) = key {
+                            with_thread_local_cuda_streams(|streams| {
+                                cuda_key.key.key.get_scalar_bitand_size_on_gpu(
+                                    &*lhs.ciphertext.on_gpu(streams),
+                                    streams,
+                                )
+                            })
+                        } else {
+                            0
+                        })
                 }
             },
             fhe_and_scalar_type:
@@ -1369,19 +1363,17 @@ macro_rules! define_scalar_ops {
             rust_trait: BitOrSizeOnGpu(get_bitor_size_on_gpu),
             implem: {
                 |lhs: &FheUint<_>, _rhs| {
-                    let mut tmp_buffer_size = 0;
-                    global_state::with_internal_keys(|key| match key {
-                        InternalServerKey::Cpu(_) => {
-                            tmp_buffer_size = 0;
-                        }
-                        InternalServerKey::Cuda(cuda_key) => with_thread_local_cuda_streams(|streams| {
-                            tmp_buffer_size = cuda_key.key.key.get_scalar_bitor_size_on_gpu(
-                                &*lhs.ciphertext.on_gpu(streams),
-                                streams,
-                            );
-                        }),
-                    });
-                    tmp_buffer_size
+                    global_state::with_internal_keys(|key|
+                        if let InternalServerKey::Cuda(cuda_key) = key {
+                            with_thread_local_cuda_streams(|streams| {
+                                cuda_key.key.key.get_scalar_bitor_size_on_gpu(
+                                    &*lhs.ciphertext.on_gpu(streams),
+                                    streams,
+                                )
+                            })
+                        } else {
+                            0
+                        })
                 }
             },
             fhe_and_scalar_type:
@@ -1429,19 +1421,17 @@ macro_rules! define_scalar_ops {
             rust_trait: BitXorSizeOnGpu(get_bitxor_size_on_gpu),
             implem: {
                 |lhs: &FheUint<_>, _rhs| {
-                    let mut tmp_buffer_size = 0;
-                    global_state::with_internal_keys(|key| match key {
-                        InternalServerKey::Cpu(_) => {
-                            tmp_buffer_size = 0;
-                        }
-                        InternalServerKey::Cuda(cuda_key) => with_thread_local_cuda_streams(|streams| {
-                            tmp_buffer_size = cuda_key.key.key.get_scalar_bitxor_size_on_gpu(
-                                &*lhs.ciphertext.on_gpu(streams),
-                                streams,
-                            );
-                        }),
-                    });
-                    tmp_buffer_size
+                    global_state::with_internal_keys(|key|
+                        if let InternalServerKey::Cuda(cuda_key) = key {
+                            with_thread_local_cuda_streams(|streams| {
+                                cuda_key.key.key.get_scalar_bitxor_size_on_gpu(
+                                    &*lhs.ciphertext.on_gpu(streams),
+                                    streams,
+                                )
+                            })
+                        } else {
+                            0
+                        })
                 }
             },
             fhe_and_scalar_type:
@@ -1539,19 +1529,17 @@ macro_rules! define_scalar_ops {
             rust_trait: AddSizeOnGpu(get_add_size_on_gpu),
             implem: {
                 |_lhs, rhs: &FheUint<_>| {
-                    let mut tmp_buffer_size = 0;
-                    global_state::with_internal_keys(|key| match key {
-                        InternalServerKey::Cpu(_) => {
-                            tmp_buffer_size = 0;
-                        }
-                        InternalServerKey::Cuda(cuda_key) => with_thread_local_cuda_streams(|streams| {
-                            tmp_buffer_size = cuda_key.key.key.get_scalar_add_size_on_gpu(
-                                &*rhs.ciphertext.on_gpu(streams),
-                                streams,
-                            );
-                        }),
-                    });
-                    tmp_buffer_size
+                    global_state::with_internal_keys(|key|
+                        if let InternalServerKey::Cuda(cuda_key) = key {
+                            with_thread_local_cuda_streams(|streams| {
+                                cuda_key.key.key.get_scalar_add_size_on_gpu(
+                                    &*rhs.ciphertext.on_gpu(streams),
+                                    streams,
+                                )
+                            })
+                        } else {
+                            0
+                        })
                 }
             },
             fhe_and_scalar_type:
@@ -1597,19 +1585,17 @@ macro_rules! define_scalar_ops {
             rust_trait: SubSizeOnGpu(get_sub_size_on_gpu),
             implem: {
                 |_lhs, rhs: &FheUint<_>| {
-                    let mut tmp_buffer_size = 0;
-                    global_state::with_internal_keys(|key| match key {
-                        InternalServerKey::Cpu(_) => {
-                            tmp_buffer_size = 0;
-                        }
-                        InternalServerKey::Cuda(cuda_key) => with_thread_local_cuda_streams(|streams| {
-                            tmp_buffer_size = cuda_key.key.key.get_scalar_sub_size_on_gpu(
-                                &*rhs.ciphertext.on_gpu(streams),
-                                streams,
-                            );
-                        }),
-                    });
-                    tmp_buffer_size
+                    global_state::with_internal_keys(|key|
+                        if let InternalServerKey::Cuda(cuda_key) = key {
+                            with_thread_local_cuda_streams(|streams| {
+                                cuda_key.key.key.get_scalar_sub_size_on_gpu(
+                                    &*rhs.ciphertext.on_gpu(streams),
+                                    streams,
+                                )
+                            })
+                        } else {
+                            0
+                        })
                 }
             },
             fhe_and_scalar_type:
@@ -1655,19 +1641,17 @@ macro_rules! define_scalar_ops {
             rust_trait: BitAndSizeOnGpu(get_bitand_size_on_gpu),
             implem: {
                 |_lhs, rhs: &FheUint<_>| {
-                    let mut tmp_buffer_size = 0;
-                    global_state::with_internal_keys(|key| match key {
-                        InternalServerKey::Cpu(_) => {
-                            tmp_buffer_size = 0;
-                        }
-                        InternalServerKey::Cuda(cuda_key) => with_thread_local_cuda_streams(|streams| {
-                            tmp_buffer_size = cuda_key.key.key.get_scalar_bitand_size_on_gpu(
-                                &*rhs.ciphertext.on_gpu(streams),
-                                streams,
-                            );
-                        }),
-                    });
-                    tmp_buffer_size
+                    global_state::with_internal_keys(|key|
+                        if let InternalServerKey::Cuda(cuda_key) = key {
+                            with_thread_local_cuda_streams(|streams| {
+                                cuda_key.key.key.get_scalar_bitand_size_on_gpu(
+                                    &*rhs.ciphertext.on_gpu(streams),
+                                    streams,
+                                )
+                            })
+                        } else {
+                            0
+                        })
                 }
             },
             fhe_and_scalar_type:
@@ -1696,19 +1680,17 @@ macro_rules! define_scalar_ops {
             rust_trait: BitOrSizeOnGpu(get_bitor_size_on_gpu),
             implem: {
                 |_lhs, rhs: &FheUint<_>| {
-                    let mut tmp_buffer_size = 0;
-                    global_state::with_internal_keys(|key| match key {
-                        InternalServerKey::Cpu(_) => {
-                            tmp_buffer_size = 0;
-                        }
-                        InternalServerKey::Cuda(cuda_key) => with_thread_local_cuda_streams(|streams| {
-                            tmp_buffer_size = cuda_key.key.key.get_scalar_bitor_size_on_gpu(
-                                &*rhs.ciphertext.on_gpu(streams),
-                                streams,
-                            );
-                        }),
-                    });
-                    tmp_buffer_size
+                    global_state::with_internal_keys(|key|
+                        if let InternalServerKey::Cuda(cuda_key) = key {
+                            with_thread_local_cuda_streams(|streams| {
+                                cuda_key.key.key.get_scalar_bitor_size_on_gpu(
+                                    &*rhs.ciphertext.on_gpu(streams),
+                                    streams,
+                                )
+                            })
+                        } else {
+                            0
+                        })
                 }
             },
             fhe_and_scalar_type:
@@ -1737,19 +1719,17 @@ macro_rules! define_scalar_ops {
             rust_trait: BitXorSizeOnGpu(get_bitxor_size_on_gpu),
             implem: {
                 |_lhs, rhs: &FheUint<_>| {
-                    let mut tmp_buffer_size = 0;
-                    global_state::with_internal_keys(|key| match key {
-                        InternalServerKey::Cpu(_) => {
-                            tmp_buffer_size = 0;
-                        }
-                        InternalServerKey::Cuda(cuda_key) => with_thread_local_cuda_streams(|streams| {
-                            tmp_buffer_size = cuda_key.key.key.get_scalar_bitxor_size_on_gpu(
-                                &*rhs.ciphertext.on_gpu(streams),
-                                streams,
-                            );
-                        }),
-                    });
-                    tmp_buffer_size
+                    global_state::with_internal_keys(|key|
+                        if let InternalServerKey::Cuda(cuda_key) = key {
+                            with_thread_local_cuda_streams(|streams| {
+                                cuda_key.key.key.get_scalar_bitxor_size_on_gpu(
+                                    &*rhs.ciphertext.on_gpu(streams),
+                                    streams,
+                                )
+                            })
+                        } else {
+                            0
+                        })
                 }
             },
             fhe_and_scalar_type:


### PR DESCRIPTION
Fix tfhe build with gpu and hpu features enabled. Even if it is not officially supported, it can be useful to enable both at the same times (for example when looking for cross-refs with rust-analyzer).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/2358)
<!-- Reviewable:end -->
