### PR TITLE
Tm/fix user doc

### DIFF
--- a/.github/workflows/hpu_hlapi_tests.yml
+++ b/.github/workflows/hpu_hlapi_tests.yml
@@ -70,4 +70,5 @@ jobs:
           source setup_hpu.sh
           just -f mockups/tfhe-hpu-mockup/Justfile  BUILD_PROFILE=release mockup &
           make HPU_CONFIG=sim test_high_level_api_hpu
+          make HPU_CONFIG=sim test_user_doc_hpu
      

--- a/Makefile
+++ b/Makefile
@@ -935,8 +935,20 @@ test_user_doc: install_rs_build_toolchain
 .PHONY: test_user_doc_gpu # Run tests for GPU from the .md documentation
 test_user_doc_gpu: install_rs_build_toolchain
 	RUSTFLAGS="$(RUSTFLAGS)" cargo $(CARGO_RS_BUILD_TOOLCHAIN) test --profile $(CARGO_PROFILE) --doc \
-		--features=boolean,shortint,integer,internal-keycache,gpu,zk-pok -p $(TFHE_SPEC) \
+		--features=internal-keycache,integer,zk-pok,gpu -p $(TFHE_SPEC) \
 		-- test_user_docs::
+
+.PHONY: test_user_doc_hpu # Run tests for HPU from the .md documentation
+test_user_doc_hpu: install_rs_build_toolchain
+ifeq ($(HPU_CONFIG), v80)
+	RUSTFLAGS="$(RUSTFLAGS)" cargo $(CARGO_RS_BUILD_TOOLCHAIN) test --profile $(CARGO_PROFILE) --doc \
+		--features=internal-keycache,integer,hpu,hpu-v80 -p $(TFHE_SPEC) \
+		-- test_user_docs::
+else
+	RUSTFLAGS="$(RUSTFLAGS)" cargo $(CARGO_RS_BUILD_TOOLCHAIN) test --profile $(CARGO_PROFILE) --doc \
+		--features=internal-keycache,integer,hpu -p $(TFHE_SPEC) \
+		-- test_user_docs::
+endif
 
 
 

--- a/tfhe/docs/configuration/hpu_acceleration/run_on_hpu.md
+++ b/tfhe/docs/configuration/hpu_acceleration/run_on_hpu.md
@@ -43,7 +43,7 @@ Comparing to the [CPU example](../../getting_started/quick_start.md), HPU set up
 Here is a full example (combining the client and server parts):
 
 ```rust
-use tfhe::{ConfigBuilder, set_server_key, FheUint8, ClientKey, CompressedServerKey};
+use tfhe::{Config, set_server_key, FheUint8, ClientKey, CompressedServerKey};
 use tfhe::prelude::*;
 use tfhe::tfhe_hpu_backend::prelude::*;
 
@@ -106,7 +106,7 @@ The server first needs to set up its keys with `set_server_key((hpu_device, comp
 
 Then, homomorphic computations are performed using the same approach as the [CPU operations](../../fhe-computation/operations/README.md).
 
-``` rust
+``` Rust
     // Server-side
     let result = a + b;
 

--- a/tfhe/docs/configuration/hpu_acceleration/run_on_hpu.md
+++ b/tfhe/docs/configuration/hpu_acceleration/run_on_hpu.md
@@ -45,7 +45,7 @@ Here is a full example (combining the client and server parts):
 ```rust
 use tfhe::{ConfigBuilder, set_server_key, FheUint8, ClientKey, CompressedServerKey};
 use tfhe::prelude::*;
-use tfhe_hpu_backend::prelude::*;
+use tfhe::tfhe_hpu_backend::prelude::*;
 
 fn main() {
 
@@ -53,7 +53,7 @@ fn main() {
     // HPU configuration knobs are retrieved from a TOML configuration file. Prebuilt configurations could be find in `backends/tfhe-hpu-backend/config_store`
     // For ease of use a setup_hpu.sh script is available in repository root folder and it handle the required environment variables setup and driver initialisation
     // More details are available in `backends/tfhe-hpu-backend/README.md`
-    let hpu_device = HpuDevice::from_config(ShellString::new("${HPU_BACKEND_DIR}/config_store/${HPU_CONFIG}/hpu_config.toml".to_string()));
+    let hpu_device = HpuDevice::from_config(ShellString::new("${HPU_BACKEND_DIR}/config_store/${HPU_CONFIG}/hpu_config.toml".to_string()).expand().as_str());
 
     // Generate keys ----------------------------------------------------------
     let config = Config::from_hpu_device(&hpu_device);

--- a/tfhe/src/lib.rs
+++ b/tfhe/src/lib.rs
@@ -118,14 +118,7 @@ pub use shortint::server_key::pbs_stats::*;
 /// cbindgen:ignore
 mod js_on_wasm_api;
 
-#[cfg(all(
-    doctest,
-    feature = "shortint",
-    feature = "boolean",
-    feature = "integer",
-    feature = "zk-pok",
-    feature = "strings"
-))]
+#[cfg(doctest)]
 mod test_user_docs;
 
 #[cfg(feature = "strings")]

--- a/tfhe/src/test_user_docs.rs
+++ b/tfhe/src/test_user_docs.rs
@@ -1,4 +1,4 @@
-#[cfg(not(feature = "gpu"))]
+#[cfg(not(any(feature = "gpu", feature = "hpu")))]
 mod test_cpu_doc {
     use doc_comment::doctest;
 

--- a/tfhe/src/test_user_docs.rs
+++ b/tfhe/src/test_user_docs.rs
@@ -249,8 +249,4 @@ mod test_hpu_doc {
         "../docs/configuration/hpu_acceleration/run_on_hpu.md",
         configuration_hpu_acceleration_run_on_hpu
     );
-    doctest!(
-        "../docs/configuration/hpu_acceleration/benchmark.md",
-        configuration_hpu_acceleration_benchmark
-    );
 }


### PR DESCRIPTION
Due to #[cfg] before the test_user_docs module, the module would
not actually be compiled (thus run user doc test) unless all required
features where activated when running.

So we remove these cfg, as each hardware doc supports its own set of
features and its better to have a test fail because a feature is
missing rather than silently not run anything

Also, add commands and ci stuff to check HPU docs