### PR TITLE
fix(gpu): fix a linking problem on Hopper GPUs

### DIFF
--- a/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_classic.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_classic.cu
@@ -848,4 +848,7 @@ template uint64_t scratch_cuda_programmable_bootstrap_tbc<uint64_t>(
     uint32_t glwe_dimension, uint32_t polynomial_size, uint32_t level_count,
     uint32_t input_lwe_ciphertext_count, bool allocate_gpu_memory,
     bool allocate_ms_array);
+template bool
+supports_distributed_shared_memory_on_classic_programmable_bootstrap<
+    __uint128_t>(uint32_t polynomial_size, uint32_t max_shared_memory);
 #endif


### PR DESCRIPTION
This PR fixes the following linking error I've found On H100s:

```
error: linking with `cc` failed: exit status: 1
  |
  = note:  "cc" "-m64" "/tmp/rustcrKFJ93/symbols.o" "<257 object files omitted>" "-Wl,--as-needed" "-Wl,-Bstatic" "/home/ubuntu/tfhe-rs/target/devo/deps/{liblibm-141f30821a6c0b4d.rlib,libcsv-b35e97d7bd5c9620.rlib,libryu-180d0dd72cb1e814.rlib,libitoa-fde260a09059b063.rlib,libcsv_core-34c66b27cebd867d.rlib,libmemchr-601bf61f9ec36be1.rlib}.rlib" "<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/lib/{libtest-*,libgetopts-*,libunicode_width-*,librustc_std_workspace_std-*}.rlib" "/home/ubuntu/tfhe-rs/target/devo/deps/{libbincode-2bc09cfef3484eb1.rlib,libfs2-b766784dac8c60c7.rlib,libstrum-cde012d534346e2b.rlib,libsha3-22f69d81f5425efe.rlib,libkeccak-d0c375fec4692554.rlib,libdigest-99225299bf186e44.rlib,libblock_buffer-9d16f232cf3df191.rlib,libtfhe_cuda_backend-d99e84c527b8e222.rlib,libtfhe_ntt-428862444d7ff275.rlib,libtfhe_csprng-618f9cddeba97eeb.rlib,libaes-c4eac20e3b9e4b9a.rlib,libcpufeatures-56fa92b2cc93d82d.rlib,libcipher-f8cbdf0ac1f3f8af.rlib,libinout-07d51a0eedfb0372.rlib,libcrypto_common-127b64a32b0e5edb.rlib,libgeneric_array-8ec6799f228e49ba.rlib,libtfhe_versionable-60acc22a7feb0fe9.rlib,libstatrs-59003cd785e95bf1.rlib,libnalgebra-fec8567e04005fd3.rlib,librand_distr-16b21f9fff47749c.rlib,libmatrixmultiply-497ef575ff3b0215.rlib,librawpointer-bea8c2255e37990f.rlib,libnum_rational-25ab95a445bee5ee.rlib,libnum_integer-0ac7612d03508771.rlib,libtypenum-8a3eee430a40eb67.rlib,libsimba-ab1d2f9a24e4c635.rlib,libwide-b783186ee34aee72.rlib,libsafe_arch-1960e64f44270d7c.rlib,libapprox-973021917f214e8b.rlib,librand-9fe71ffed6437d03.rlib,librand_chacha-57c53d5887af9218.rlib,libppv_lite86-66d050ed610a0910.rlib,libzerocopy-fa91a9b8dc5b2729.rlib,librand_core-2231ccc8d1eebf3e.rlib,libgetrandom-c6491e3aa1b404ca.rlib,liblibc-5c1112541d99f496.rlib,libcfg_if-a3b57d7808e269c3.rlib,libitertools-7b968690a62b6a3a.rlib,librayon-e7736ee3f3884ca8.rlib,librayon_core-c04ede5a62dce60b.rlib,libcrossbeam_deque-26c71d2718866c24.rlib,libcrossbeam_epoch-fe0bdb95910e0d1c.rlib,libcrossbeam_utils-12f4392380625ce9.rlib,libeither-fbf515c960a1abdf.rlib,libtfhe_fft-f906e29dae0fcf74.rlib,libaligned_vec-eb498db58cef1c7c.rlib,libequator-a0f09611b28d080d.rlib,libpulp-c048d8096f1f7c32.rlib,libnum_complex-a05f78233a8a0139.rlib,libserde-72645ad1ccf6a362.rlib,libnum_traits-f8a96e247c23bde1.rlib,libdyn_stack-a7ba433bdd315605.rlib,libbytemuck-b3fb059244216637.rlib}.rlib" "<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/lib/{libstd-*,libpanic_unwind-*,libobject-*,libmemchr-*,libaddr2line-*,libgimli-*,librustc_demangle-*,libstd_detect-*,libhashbrown-*,librustc_std_workspace_alloc-*,libminiz_oxide-*,libadler2-*,libunwind-*,libcfg_if-*,liblibc-*,liballoc-*,librustc_std_workspace_core-*,libcore-*,libcompiler_builtins-*}.rlib" "-Wl,-Bdynamic" "-lgomp" "-lcudart" "-lstdc++" "-lgcc_s" "-lutil" "-lrt" "-lpthread" "-lm" "-ldl" "-lc" "-L" "/tmp/rustcrKFJ93/raw-dylibs" "-Wl,--eh-frame-hdr" "-Wl,-z,noexecstack" "-L" "/home/ubuntu/tfhe-rs/target/devo/build/tfhe-cuda-backend-eafb9deddf217d28/out" "-L" "/usr/local/cuda/lib64" "-L" "/usr/lib/x86_64-linux-gnu/" "-L" "<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/lib" "-o" "/home/ubuntu/tfhe-rs/target/devo/deps/tfhe-4b30889590cbb168" "-Wl,--gc-sections" "-pie" "-Wl,-z,relro,-z,now" "-Wl,-O1" "-nodefaultlibs"
  = note: some arguments are omitted. use `--verbose` to show all linker arguments
  = note: /usr/bin/ld: /home/ubuntu/tfhe-rs/target/devo/deps/libtfhe_cuda_backend-d99e84c527b8e222.rlib(programmable_bootstrap_classic_128.cu.o): in function `pbs_buffer_128<(PBS_TYPE)1>::pbs_buffer_128(CUstream_st*, unsigned int, unsigned int, unsigned int, unsigned int, unsigned int, unsigned int, PBS_VARIANT, bool, bool, unsigned long*)':
          /home/ubuntu/tfhe-rs/backends/tfhe-cuda-backend/cuda/include/pbs/pbs_utilities.h:364: undefined reference to `bool supports_distributed_shared_memory_on_classic_programmable_bootstrap<unsigned __int128>(unsigned int, unsigned int)'
          collect2: error: ld returned 1 exit status
          
  = note: some `extern` functions couldn't be found; some native libraries may need to be installed or have their path specified
  = note: use the `-l` flag to specify native libraries to link
  = note: use the `cargo:rustc-link-lib` directive to specify the native libraries to link with Cargo (see https://doc.rust-lang.org/cargo/reference/build-scripts.html#rustc-link-lib)

error: could not compile `tfhe` (lib test) due to 1 previous error

```

<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
