### PR TITLE
fix(hpu): modernize logger interface

### DIFF
--- a/backends/tfhe-hpu-backend/python/lib/isctrace/hw.py
+++ b/backends/tfhe-hpu-backend/python/lib/isctrace/hw.py
@@ -71,7 +71,7 @@ class Trace:
                 del id_map[event.sync_id]
 
         if len(id_map):
-            logging.warn("The trace contains incomplete IOPs")
+            logging.warning("The trace contains incomplete IOPs")
 
     def to_analysis(self) -> Iterator['analysis.Event']:
         return analysis.Trace(x.to_analysis() for x in self)


### PR DESCRIPTION
### PR content/description
The `logger.warn()` method is deprecated since Python2.7 and replaced with `logger.warning()`. It leads to those warnings:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
