### PR TITLE
chore(gpu): fix overflow in div in long run tests

### DIFF
--- a/tfhe/src/integer/gpu/server_key/radix/tests_long_run/test_random_op_sequence.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/tests_long_run/test_random_op_sequence.rs
@@ -335,7 +335,7 @@ where
     // Div executor
     let div_rem_executor = GpuMultiDeviceFunctionExecutor::new(&CudaServerKey::div_rem);
     // Div Rem Clear functions
-    let clear_div_rem = |x: u64, y: u64| -> (u64, u64) { (x / y, x % y) };
+    let clear_div_rem = |x: u64, y: u64| -> (u64, u64) { (x.wrapping_div(y), x.wrapping_rem(y)) };
     #[allow(clippy::type_complexity)]
     let mut div_rem_op: Vec<(DivRemOpExecutor, &dyn Fn(u64, u64) -> (u64, u64), String)> = vec![(
         Box::new(div_rem_executor),

--- a/tfhe/src/integer/gpu/server_key/radix/tests_long_run/test_signed_random_op_sequence.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/tests_long_run/test_signed_random_op_sequence.rs
@@ -365,7 +365,7 @@ where
     // Div executor
     let div_rem_executor = GpuMultiDeviceFunctionExecutor::new(&CudaServerKey::div_rem);
     // Div Rem Clear functions
-    let clear_div_rem = |x: i64, y: i64| -> (i64, i64) { (x / y, x % y) };
+    let clear_div_rem = |x: i64, y: i64| -> (i64, i64) { (x.wrapping_div(y), x.wrapping_rem(y)) };
     #[allow(clippy::type_complexity)]
     let mut div_rem_op: Vec<(
         SignedDivRemOpExecutor,

--- a/tfhe/src/integer/server_key/radix_parallel/tests_long_run/test_random_op_sequence.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_long_run/test_random_op_sequence.rs
@@ -373,7 +373,7 @@ where
     // Div executor
     let div_rem_executor = CpuFunctionExecutor::new(&ServerKey::div_rem_parallelized);
     // Div Rem Clear functions
-    let clear_div_rem = |x: u64, y: u64| -> (u64, u64) { (x.wrapping_div(y), x % y) };
+    let clear_div_rem = |x: u64, y: u64| -> (u64, u64) { (x.wrapping_div(y), x.wrapping_rem(y)) };
     #[allow(clippy::type_complexity)]
     let mut div_rem_op: Vec<(DivRemOpExecutor, &dyn Fn(u64, u64) -> (u64, u64), String)> = vec![(
         Box::new(div_rem_executor),


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description

I was missing the GPU long run tests in the previous commits. Also I think all div/rem should be wrapping, even unsigned, because encrypted division/remainder are wrapping themselves.

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
