### PR TITLE
chore(zk): use 8 bytes dsep and 128bits SID in hash functions

### DIFF
--- a/.github/workflows/aws_tfhe_fast_tests.yml
+++ b/.github/workflows/aws_tfhe_fast_tests.yml
@@ -185,7 +185,8 @@ jobs:
           make test_tfhe_csprng_big_endian
 
       - name: Run tfhe-zk-pok tests
-        if: needs.should-run.outputs.zk_pok_test == 'true'
+        # Always run it to catch non deterministic bugs earlier
+        # if: needs.should-run.outputs.zk_pok_test == 'true'
         run: |
           make test_zk_pok
 

--- a/tfhe-zk-pok/src/proofs/binary.rs
+++ b/tfhe-zk-pok/src/proofs/binary.rs
@@ -3,18 +3,18 @@ use super::*;
 #[derive(Clone, Debug)]
 pub struct PublicParams<G: Curve> {
     g_lists: GroupElements<G>,
-    hash: [u8; HASH_METADATA_LEN_BYTES],
-    hash_t: [u8; HASH_METADATA_LEN_BYTES],
-    hash_agg: [u8; HASH_METADATA_LEN_BYTES],
+    hash: [u8; LEGACY_HASH_DS_LEN_BYTES],
+    hash_t: [u8; LEGACY_HASH_DS_LEN_BYTES],
+    hash_agg: [u8; LEGACY_HASH_DS_LEN_BYTES],
 }
 
 impl<G: Curve> PublicParams<G> {
     pub fn from_vec(
         g_list: Vec<Affine<G::Zp, G::G1>>,
         g_hat_list: Vec<Affine<G::Zp, G::G2>>,
-        hash: [u8; HASH_METADATA_LEN_BYTES],
-        hash_t: [u8; HASH_METADATA_LEN_BYTES],
-        hash_agg: [u8; HASH_METADATA_LEN_BYTES],
+        hash: [u8; LEGACY_HASH_DS_LEN_BYTES],
+        hash_t: [u8; LEGACY_HASH_DS_LEN_BYTES],
+        hash_agg: [u8; LEGACY_HASH_DS_LEN_BYTES],
     ) -> Self {
         Self {
             g_lists: GroupElements::from_vec(g_list, g_hat_list),

--- a/tfhe-zk-pok/src/proofs/mod.rs
+++ b/tfhe-zk-pok/src/proofs/mod.rs
@@ -294,7 +294,36 @@ where
     }
 }
 
-pub const HASH_METADATA_LEN_BYTES: usize = 256;
+/// Len of the "domain separator" fields used with the sha3 XoF PRNG
+pub const HASH_DS_LEN_BYTES: usize = 8;
+
+pub const LEGACY_HASH_DS_LEN_BYTES: usize = 256;
+
+/// A unique id that is used to tie the hash functions to a specific CRS
+#[derive(Debug, Clone, Copy)]
+// This is an option for backward compatibility reasons
+pub(crate) struct Sid(pub(crate) Option<u128>);
+
+impl Sid {
+    fn new(rng: &mut dyn RngCore) -> Self {
+        Self(Some(rng.gen()))
+    }
+
+    fn to_le_bytes(self) -> SidBytes {
+        self.0
+            .map(|val| SidBytes(Some(val.to_le_bytes())))
+            .unwrap_or_default()
+    }
+}
+
+#[derive(Default)]
+struct SidBytes(Option<[u8; 16]>);
+
+impl SidBytes {
+    fn as_slice(&self) -> &[u8] {
+        self.0.as_ref().map(|val| val.as_slice()).unwrap_or(&[])
+    }
+}
 
 // The verifier is meant to be executed on a large server with a high number of core. However, some
 // arkworks operations do not scale well in that case, and we actually see decreased performance

--- a/tfhe-zk-pok/src/proofs/mod.rs
+++ b/tfhe-zk-pok/src/proofs/mod.rs
@@ -415,6 +415,8 @@ pub mod rlwe;
 mod test {
     #![allow(non_snake_case)]
     use std::fmt::Display;
+    use std::num::Wrapping;
+    use std::ops::Sub;
 
     use ark_ec::{short_weierstrass, CurveConfig};
     use ark_ff::UniformRand;
@@ -469,6 +471,17 @@ mod test {
         }
 
         c
+    }
+
+    /// Wrapper that panics on overflow even in release mode
+    pub(super) struct Strict<Num>(pub Num);
+
+    impl Sub for Strict<u128> {
+        type Output = Strict<u128>;
+
+        fn sub(self, rhs: Self) -> Self::Output {
+            Strict(self.0.checked_sub(rhs.0).unwrap())
+        }
     }
 
     /// Parameters needed for a PKE zk proof test
@@ -575,7 +588,13 @@ mod test {
 
             let mut a = (0..d).map(|_| rng.gen::<i64>()).collect::<Vec<_>>();
 
-            let b = a.iter().zip(&self.s).map(|(ai, si)| ai * si).sum::<i64>() + e;
+            let b = a
+                .iter()
+                .zip(&self.s)
+                .map(|(ai, si)| Wrapping(ai * si))
+                .sum::<Wrapping<i64>>()
+                .0
+                + e;
 
             a.push(b);
             a

--- a/tfhe-zk-pok/src/proofs/pke.rs
+++ b/tfhe-zk-pok/src/proofs/pke.rs
@@ -1336,7 +1336,7 @@ mod tests {
     use super::super::test::*;
     use super::*;
     use rand::rngs::StdRng;
-    use rand::{Rng, SeedableRng};
+    use rand::{thread_rng, Rng, SeedableRng};
 
     type Curve = curve_api::Bls12_446;
 
@@ -1374,7 +1374,9 @@ mod tests {
 
         let effective_cleartext_t = t >> msbs_zero_padding_bit_count;
 
-        let rng = &mut StdRng::seed_from_u64(0);
+        let seed = thread_rng().gen();
+        println!("pke seed: {seed:x}");
+        let rng = &mut StdRng::seed_from_u64(seed);
 
         let testcase = PkeTestcase::gen(rng, PKEV1_TEST_PARAMS);
 
@@ -1550,7 +1552,9 @@ mod tests {
             msbs_zero_padding_bit_count,
         } = PKEV1_TEST_PARAMS;
 
-        let rng = &mut StdRng::seed_from_u64(0);
+        let seed = thread_rng().gen();
+        println!("pke_bad_noise seed: {seed:x}");
+        let rng = &mut StdRng::seed_from_u64(seed);
 
         let testcase = PkeTestcase::gen(rng, PKEV1_TEST_PARAMS);
 
@@ -1716,7 +1720,9 @@ mod tests {
 
         let effective_cleartext_t = t >> msbs_zero_padding_bit_count;
 
-        let rng = &mut StdRng::seed_from_u64(0);
+        let seed = thread_rng().gen();
+        println!("pke_w_padding_fail_verify seed: {seed:x}");
+        let rng = &mut StdRng::seed_from_u64(seed);
 
         let mut testcase = PkeTestcase::gen(rng, PKEV1_TEST_PARAMS);
 
@@ -1778,7 +1784,9 @@ mod tests {
 
         let effective_cleartext_t = t >> msbs_zero_padding_bit_count;
 
-        let rng = &mut StdRng::seed_from_u64(0);
+        let seed = thread_rng().gen();
+        println!("pke_bad_ct seed: {seed:x}");
+        let rng = &mut StdRng::seed_from_u64(seed);
 
         let testcase = PkeTestcase::gen(rng, PKEV1_TEST_PARAMS_SINGLE);
         let ct = testcase.encrypt(PKEV1_TEST_PARAMS_SINGLE);
@@ -1901,7 +1909,9 @@ mod tests {
 
         let effective_cleartext_t = t >> msbs_zero_padding_bit_count;
 
-        let rng = &mut StdRng::seed_from_u64(0);
+        let seed = thread_rng().gen();
+        println!("pke_bad_delta seed: {seed:x}");
+        let rng = &mut StdRng::seed_from_u64(seed);
 
         let testcase = PkeTestcase::gen(rng, PKEV1_TEST_PARAMS);
         let mut testcase_bad_delta = testcase.clone();
@@ -1944,7 +1954,9 @@ mod tests {
             msbs_zero_padding_bit_count,
         } = PKEV1_TEST_PARAMS;
 
-        let rng = &mut StdRng::seed_from_u64(0);
+        let seed = thread_rng().gen();
+        println!("pke_proof_compression seed: {seed:x}");
+        let rng = &mut StdRng::seed_from_u64(seed);
 
         let testcase = PkeTestcase::gen(rng, PKEV1_TEST_PARAMS);
         let ct = testcase.encrypt(PKEV1_TEST_PARAMS);
@@ -1995,7 +2007,9 @@ mod tests {
             msbs_zero_padding_bit_count,
         } = PKEV1_TEST_PARAMS;
 
-        let rng = &mut StdRng::seed_from_u64(0);
+        let seed = thread_rng().gen();
+        println!("pke_proof_usable seed: {seed:x}");
+        let rng = &mut StdRng::seed_from_u64(seed);
 
         let testcase = PkeTestcase::gen(rng, PKEV1_TEST_PARAMS);
         let ct = testcase.encrypt(PKEV1_TEST_PARAMS);

--- a/tfhe-zk-pok/src/proofs/pke_v2.rs
+++ b/tfhe-zk-pok/src/proofs/pke_v2.rs
@@ -2536,7 +2536,7 @@ mod tests {
     use super::super::test::*;
     use super::*;
     use rand::rngs::StdRng;
-    use rand::{Rng, SeedableRng};
+    use rand::{thread_rng, Rng, SeedableRng};
 
     type Curve = curve_api::Bls12_446;
 
@@ -2595,7 +2595,9 @@ mod tests {
 
         let effective_cleartext_t = t >> msbs_zero_padding_bit_count;
 
-        let rng = &mut StdRng::seed_from_u64(0);
+        let seed = thread_rng().gen();
+        println!("pkev2 seed: {seed:x}");
+        let rng = &mut StdRng::seed_from_u64(seed);
 
         let testcase = PkeTestcase::gen(rng, PKEV2_TEST_PARAMS);
         let ct = testcase.encrypt(PKEV2_TEST_PARAMS);
@@ -2945,7 +2947,9 @@ mod tests {
             msbs_zero_padding_bit_count,
         } = PKEV2_TEST_PARAMS;
 
-        let rng = &mut StdRng::seed_from_u64(0);
+        let seed = thread_rng().gen();
+        println!("pkev2_bad_noise seed: {seed:x}");
+        let rng = &mut StdRng::seed_from_u64(seed);
 
         let testcase = PkeTestcase::gen(rng, PKEV2_TEST_PARAMS);
 
@@ -3076,7 +3080,9 @@ mod tests {
 
         let effective_cleartext_t = t >> msbs_zero_padding_bit_count;
 
-        let rng = &mut StdRng::seed_from_u64(0);
+        let seed = thread_rng().gen();
+        println!("pkev2_w_padding_fail_verify seed: {seed:x}");
+        let rng = &mut StdRng::seed_from_u64(seed);
 
         let mut testcase = PkeTestcase::gen(rng, PKEV2_TEST_PARAMS);
         // Generate messages with padding set to fail verification
@@ -3137,7 +3143,9 @@ mod tests {
 
         let effective_cleartext_t = t >> msbs_zero_padding_bit_count;
 
-        let rng = &mut StdRng::seed_from_u64(0);
+        let seed = thread_rng().gen();
+        println!("pkev2_bad_ct seed: {seed:x}");
+        let rng = &mut StdRng::seed_from_u64(seed);
 
         let testcase = PkeTestcase::gen(rng, PKEV2_TEST_PARAMS_SINGLE);
         let ct = testcase.encrypt(PKEV2_TEST_PARAMS_SINGLE);
@@ -3260,7 +3268,9 @@ mod tests {
 
         let effective_cleartext_t = t >> msbs_zero_padding_bit_count;
 
-        let rng = &mut StdRng::seed_from_u64(0);
+        let seed = thread_rng().gen();
+        println!("pkev2_bad_delta seed: {seed:x}");
+        let rng = &mut StdRng::seed_from_u64(seed);
 
         let testcase = PkeTestcase::gen(rng, PKEV2_TEST_PARAMS);
         let mut testcase_bad_delta = testcase.clone();
@@ -3294,7 +3304,9 @@ mod tests {
     /// Test encryption of a message with params that are at the limits of what is supported
     #[test]
     fn test_big_params() {
-        let rng = &mut StdRng::seed_from_u64(0);
+        let seed = thread_rng().gen();
+        println!("pkev2_big_params seed: {seed:x}");
+        let rng = &mut StdRng::seed_from_u64(seed);
 
         for bound in [Bound::CS, Bound::GHL] {
             let params = match bound {
@@ -3343,7 +3355,9 @@ mod tests {
             msbs_zero_padding_bit_count,
         } = PKEV2_TEST_PARAMS;
 
-        let rng = &mut StdRng::seed_from_u64(0);
+        let seed = thread_rng().gen();
+        println!("pkev2_proof_compression seed: {seed:x}");
+        let rng = &mut StdRng::seed_from_u64(seed);
 
         let testcase = PkeTestcase::gen(rng, PKEV2_TEST_PARAMS);
         let ct = testcase.encrypt(PKEV2_TEST_PARAMS);
@@ -3394,7 +3408,9 @@ mod tests {
             msbs_zero_padding_bit_count,
         } = PKEV2_TEST_PARAMS;
 
-        let rng = &mut StdRng::seed_from_u64(0);
+        let seed = thread_rng().gen();
+        println!("pkev2_crs_usable seed: {seed:x}");
+        let rng = &mut StdRng::seed_from_u64(seed);
 
         let crs_k = k + 1 + (rng.gen::<usize>() % (d - k));
 
@@ -3425,7 +3441,9 @@ mod tests {
             msbs_zero_padding_bit_count,
         } = PKEV2_TEST_PARAMS;
 
-        let rng = &mut StdRng::seed_from_u64(0);
+        let seed = thread_rng().gen();
+        println!("pkev2_proof_usable seed: {seed:x}");
+        let rng = &mut StdRng::seed_from_u64(seed);
 
         let testcase = PkeTestcase::gen(rng, PKEV2_TEST_PARAMS);
         let ct = testcase.encrypt(PKEV2_TEST_PARAMS);

--- a/tfhe-zk-pok/src/proofs/range.rs
+++ b/tfhe-zk-pok/src/proofs/range.rs
@@ -3,20 +3,20 @@ use super::*;
 #[derive(Clone, Debug)]
 pub struct PublicParams<G: Curve> {
     g_lists: GroupElements<G>,
-    hash: [u8; HASH_METADATA_LEN_BYTES],
-    hash_s: [u8; HASH_METADATA_LEN_BYTES],
-    hash_t: [u8; HASH_METADATA_LEN_BYTES],
-    hash_agg: [u8; HASH_METADATA_LEN_BYTES],
+    hash: [u8; LEGACY_HASH_DS_LEN_BYTES],
+    hash_s: [u8; LEGACY_HASH_DS_LEN_BYTES],
+    hash_t: [u8; LEGACY_HASH_DS_LEN_BYTES],
+    hash_agg: [u8; LEGACY_HASH_DS_LEN_BYTES],
 }
 
 impl<G: Curve> PublicParams<G> {
     pub fn from_vec(
         g_list: Vec<Affine<G::Zp, G::G1>>,
         g_hat_list: Vec<Affine<G::Zp, G::G2>>,
-        hash: [u8; HASH_METADATA_LEN_BYTES],
-        hash_s: [u8; HASH_METADATA_LEN_BYTES],
-        hash_t: [u8; HASH_METADATA_LEN_BYTES],
-        hash_agg: [u8; HASH_METADATA_LEN_BYTES],
+        hash: [u8; LEGACY_HASH_DS_LEN_BYTES],
+        hash_s: [u8; LEGACY_HASH_DS_LEN_BYTES],
+        hash_t: [u8; LEGACY_HASH_DS_LEN_BYTES],
+        hash_agg: [u8; LEGACY_HASH_DS_LEN_BYTES],
     ) -> Self {
         Self {
             g_lists: GroupElements::from_vec(g_list, g_hat_list),

--- a/tfhe-zk-pok/src/proofs/rlwe.rs
+++ b/tfhe-zk-pok/src/proofs/rlwe.rs
@@ -15,12 +15,12 @@ pub struct PublicParams<G: Curve> {
     big_m: usize,
     b_i: u64,
     q: u64,
-    hash: [u8; HASH_METADATA_LEN_BYTES],
-    hash_t: [u8; HASH_METADATA_LEN_BYTES],
-    hash_agg: [u8; HASH_METADATA_LEN_BYTES],
-    hash_lmap: [u8; HASH_METADATA_LEN_BYTES],
-    hash_z: [u8; HASH_METADATA_LEN_BYTES],
-    hash_w: [u8; HASH_METADATA_LEN_BYTES],
+    hash: [u8; LEGACY_HASH_DS_LEN_BYTES],
+    hash_t: [u8; LEGACY_HASH_DS_LEN_BYTES],
+    hash_agg: [u8; LEGACY_HASH_DS_LEN_BYTES],
+    hash_lmap: [u8; LEGACY_HASH_DS_LEN_BYTES],
+    hash_z: [u8; LEGACY_HASH_DS_LEN_BYTES],
+    hash_w: [u8; LEGACY_HASH_DS_LEN_BYTES],
 }
 
 impl<G: Curve> PublicParams<G> {
@@ -33,12 +33,12 @@ impl<G: Curve> PublicParams<G> {
         big_m: usize,
         b_i: u64,
         q: u64,
-        hash: [u8; HASH_METADATA_LEN_BYTES],
-        hash_t: [u8; HASH_METADATA_LEN_BYTES],
-        hash_agg: [u8; HASH_METADATA_LEN_BYTES],
-        hash_lmap: [u8; HASH_METADATA_LEN_BYTES],
-        hash_z: [u8; HASH_METADATA_LEN_BYTES],
-        hash_w: [u8; HASH_METADATA_LEN_BYTES],
+        hash: [u8; LEGACY_HASH_DS_LEN_BYTES],
+        hash_t: [u8; LEGACY_HASH_DS_LEN_BYTES],
+        hash_agg: [u8; LEGACY_HASH_DS_LEN_BYTES],
+        hash_lmap: [u8; LEGACY_HASH_DS_LEN_BYTES],
+        hash_z: [u8; LEGACY_HASH_DS_LEN_BYTES],
+        hash_w: [u8; LEGACY_HASH_DS_LEN_BYTES],
     ) -> Self {
         Self {
             g_lists: GroupElements::from_vec(g_list, g_hat_list),

--- a/tfhe/src/shortint/parameters/mod.rs
+++ b/tfhe/src/shortint/parameters/mod.rs
@@ -676,6 +676,16 @@ impl TryFrom<SupportedCompactPkeZkScheme> for CompactPkeZkScheme {
     }
 }
 
+#[cfg(feature = "zk-pok")]
+impl From<CompactPkeZkScheme> for SupportedCompactPkeZkScheme {
+    fn from(value: CompactPkeZkScheme) -> Self {
+        match value {
+            CompactPkeZkScheme::V1 => Self::V1,
+            CompactPkeZkScheme::V2 => Self::V2,
+        }
+    }
+}
+
 #[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize, Versionize)]
 #[versionize(ModulusSwitchNoiseReductionParamsVersions)]
 pub struct ModulusSwitchNoiseReductionParams {

--- a/tfhe/src/zk/backward_compatibility.rs
+++ b/tfhe/src/zk/backward_compatibility.rs
@@ -2,7 +2,7 @@ use std::convert::Infallible;
 
 use tfhe_versionable::{Upgrade, Version, VersionsDispatch};
 use tfhe_zk_pok::backward_compatibility::pke::ProofV0;
-use tfhe_zk_pok::backward_compatibility::IncompleteProof;
+use tfhe_zk_pok::backward_compatibility::{IncompleteProof, SerializablePKEv1PublicParamsV0};
 use tfhe_zk_pok::proofs::pke::Proof;
 use tfhe_zk_pok::serialization::InvalidSerializedPublicParamsError;
 
@@ -14,13 +14,18 @@ use super::{
 
 #[derive(Version)]
 #[repr(transparent)]
-pub struct CompactPkeCrsV0(SerializableCompactPkePublicParams);
+pub struct CompactPkeCrsV0(SerializablePKEv1PublicParamsV0);
 
 impl Upgrade<CompactPkeCrs> for CompactPkeCrsV0 {
     type Error = InvalidSerializedPublicParamsError;
 
     fn upgrade(self) -> Result<CompactPkeCrs, Self::Error> {
-        Ok(CompactPkeCrs::PkeV1(self.0.try_into()?))
+        Ok(CompactPkeCrs::PkeV1(
+            self.0
+                .upgrade()
+                .unwrap() // update is infallible so it is ok to unwrap
+                .try_into()?,
+        ))
     }
 }
 


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: https://github.com/zama-ai/tfhe-rs-internal/issues/1004

### PR content/description
- Use 8 bytes (instead of 256) for the domain separators used by hash functions
- Adds a random 128bits sid in all the hashes. The SID is defined by the CRS

These changes are made backward compatible, which means:
- the SID is an option, set to None for old CRS
- the 256 bytes domain separators are still supported

This PR also fixes a bug in the `bad_noise` test where the generated noise for the test ended up within the bounds if the tested noise coeff was negative (this is bad because we want to test that proofs are correctly rejected with "out of bound" noise). This was not detected because the test vectors are seeded and the seed always generated a positive coeff.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/2400)
<!-- Reviewable:end -->
