### PR TITLE
chore(gpu): prevent nvToolsExt inclusion when not profiling

### DIFF
--- a/backends/tfhe-cuda-backend/cuda/src/utils/helper_profile.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/utils/helper_profile.cu
@@ -1,4 +1,5 @@
 #include "helper_profile.cuh"
+#include <stdint.h>
 
 uint32_t adler32(const unsigned char *data) {
   const uint32_t MOD_ADLER = 65521;

--- a/backends/tfhe-cuda-backend/cuda/src/utils/helper_profile.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/utils/helper_profile.cuh
@@ -1,6 +1,9 @@
 #ifndef HELPER_PROFILE
 #define HELPER_PROFILE
+
+#ifdef USE_NVTOOLS
 #include <nvToolsExt.h>
+#endif
 
 void cuda_nvtx_label_with_color(const char *name);
 void cuda_nvtx_pop();


### PR DESCRIPTION
When the `profile` feature is not activated, the `USE_NVTOOLS` is not defined. This prevents compilation of some profiling helper functions but doesn't disable inclusion of `nvToolsExt.h` which doesn't exist for some cuda installations. This PR removes the include when the flag is off. 