### PR TITLE
chore(ci): fix benchmark matrix parameters generation

### DIFF
--- a/.github/workflows/benchmark_gpu_common.yml
+++ b/.github/workflows/benchmark_gpu_common.yml
@@ -122,31 +122,23 @@ jobs:
 
       - name: Set command output
         id: set_command
-        run: |
-          echo "command=${COMMAND_OUTPUT}" >> "${GITHUB_OUTPUT}"
-        env:
-          COMMAND_OUTPUT: ${{ toJSON(env.COMMAND) }}
+        run: | # zizmor: ignore[template-injection] this env variable is safe
+          echo "command=${{ toJSON(env.COMMAND) }}" >> "${GITHUB_OUTPUT}"
 
       - name: Set operation flavor output
         id: set_op_flavor
-        run: |
-          echo "op_flavor=${OP_FLAVOR_OUTPUT}" >> "${GITHUB_OUTPUT}"
-        env:
-          OP_FLAVOR_OUTPUT: ${{ toJSON(env.OP_FLAVOR) }}
+        run: | # zizmor: ignore[template-injection] this env variable is safe
+          echo "op_flavor=${{ toJSON(env.OP_FLAVOR) }}" >> "${GITHUB_OUTPUT}"
 
       - name: Set benchmark types output
         id: set_bench_type
-        run: |
-          echo "bench_type=${BENCH_TYPE_OUTPUT}" >> "${GITHUB_OUTPUT}"
-        env:
-          BENCH_TYPE_OUTPUT: ${{ toJSON(env.BENCH_TYPE) }}
+        run: | # zizmor: ignore[template-injection] this env variable is safe
+          echo "bench_type=${{ toJSON(env.BENCH_TYPE) }}" >> "${GITHUB_OUTPUT}"
 
       - name: Set parameters types output
         id: set_params_type
-        run: |
-          echo "params_type=${PARAMS_TYPE_OUTPUT}" >> "${GITHUB_OUTPUT}"
-        env:
-          PARAMS_TYPE_OUTPUT: ${{ toJSON(env.PARAMS_TYPE) }}
+        run: | # zizmor: ignore[template-injection] this env variable is safe
+          echo "params_type=${{ toJSON(env.PARAMS_TYPE) }}" >> "${GITHUB_OUTPUT}"
 
   setup-instance:
     name: Setup instance (cuda-${{ inputs.profile }}-benchmarks)

--- a/.github/workflows/benchmark_integer.yml
+++ b/.github/workflows/benchmark_integer.yml
@@ -78,17 +78,13 @@ jobs:
 
       - name: Set operation flavor output
         id: set_op_flavor
-        run: |
-          echo "op_flavor=${OP_FLAVOR_OUTPUT}" >> "${GITHUB_OUTPUT}"
-        env:
-          OP_FLAVOR_OUTPUT: ${{ toJSON(env.OP_FLAVOR) }}
+        run: | # zizmor: ignore[template-injection] this env variable is safe
+          echo "op_flavor=${{ toJSON(env.OP_FLAVOR) }}" >> "${GITHUB_OUTPUT}"
 
       - name: Set benchmark types output
         id: set_bench_type
-        run: |
-          echo "bench_type=${BENCH_TYPE_OUTPUT}" >> "${GITHUB_OUTPUT}"
-        env:
-          BENCH_TYPE_OUTPUT: ${{ toJSON(env.BENCH_TYPE) }}
+        run: | # zizmor: ignore[template-injection] this env variable is safe
+          echo "bench_type=${{ toJSON(env.BENCH_TYPE) }}" >> "${GITHUB_OUTPUT}"
 
   setup-instance:
     name: Setup instance (integer-benchmarks)

--- a/.github/workflows/benchmark_shortint.yml
+++ b/.github/workflows/benchmark_shortint.yml
@@ -47,10 +47,8 @@ jobs:
 
       - name: Set operation flavor output
         id: set_op_flavor
-        run: |
-          echo "op_flavor=${OP_FLAVOR_OUTPUT}" >> "${GITHUB_OUTPUT}"
-        env:
-          OP_FLAVOR_OUTPUT: ${{ toJSON(env.OP_FLAVOR) }}
+        run: | # zizmor: ignore[template-injection] this env variable is safe
+          echo "op_flavor=${{ toJSON(env.OP_FLAVOR) }}" >> "${GITHUB_OUTPUT}"
 
   setup-instance:
     name: Setup instance (shortint-benchmarks)

--- a/.github/workflows/benchmark_signed_integer.yml
+++ b/.github/workflows/benchmark_signed_integer.yml
@@ -78,17 +78,13 @@ jobs:
 
       - name: Set operation flavor output
         id: set_op_flavor
-        run: |
-          echo "op_flavor=${OP_FLAVOR_OUTPUT}" >> "${GITHUB_OUTPUT}"
-        env:
-          OP_FLAVOR_OUTPUT: ${{ toJSON(env.OP_FLAVOR) }}
+        run: | # zizmor: ignore[template-injection] this env variable is safe
+          echo "op_flavor=${{ toJSON(env.OP_FLAVOR) }}" >> "${GITHUB_OUTPUT}"
 
       - name: Set benchmark types output
         id: set_bench_type
-        run: |
-          echo "bench_type=${BENCH_TYPE_OUTPUT}" >> "${GITHUB_OUTPUT}"
-        env:
-          BENCH_TYPE_OUTPUT: ${{ toJSON(env.BENCH_TYPE) }}
+        run: | # zizmor: ignore[template-injection] this env variable is safe
+          echo "bench_type=${{ toJSON(env.BENCH_TYPE) }}" >> "${GITHUB_OUTPUT}"
 
   setup-instance:
     name: Setup instance (signed-integer-benchmarks)

--- a/.github/workflows/benchmark_zk_pke.yml
+++ b/.github/workflows/benchmark_zk_pke.yml
@@ -92,10 +92,8 @@ jobs:
 
       - name: Set benchmark types output
         id: set_bench_type
-        run: |
-          echo "bench_type=${BENCH_TYPE_OUTPUT}" >> "${GITHUB_OUTPUT}"
-        env:
-          BENCH_TYPE_OUTPUT: ${{ toJSON(env.BENCH_TYPE) }}
+        run: | # zizmor: ignore[template-injection] this env variable is safe
+          echo "bench_type=${{ toJSON(env.BENCH_TYPE) }}" >> "${GITHUB_OUTPUT}"
 
   setup-instance:
     name: Setup instance (pke-zk-benchmarks)


### PR DESCRIPTION
Previous implementation was done to please Zizmor and avoid template-injection findings during analysis. This had a downside, using `env` directive implies a double-interpolation that messes with `fromJSON()` later and build badly formatted matrix parameters.
