### PR TITLE
chore(zk): use Shake256 XoF instead of rand to generate gamma values

### DIFF
--- a/tfhe-zk-pok/benches/pke_v1.rs
+++ b/tfhe-zk-pok/benches/pke_v1.rs
@@ -1,4 +1,5 @@
 use criterion::{criterion_group, criterion_main, Criterion};
+use rand::Rng;
 use tfhe_zk_pok::proofs::pke::{prove, verify};
 use tfhe_zk_pok::proofs::ComputeLoad;
 use utils::{write_to_json, PKEV1_TEST_PARAMS, PKEV2_TEST_PARAMS};
@@ -29,6 +30,8 @@ fn bench_pke_v1_prove(c: &mut Criterion) {
         for load in [ComputeLoad::Proof, ComputeLoad::Verify] {
             let bench_id = format!("{bench_name}::{param_name}_{bits}_bits_packed_{load}");
 
+            let seed: u128 = rng.gen();
+
             bench_group.bench_function(&bench_id, |b| {
                 b.iter(|| {
                     prove(
@@ -36,7 +39,7 @@ fn bench_pke_v1_prove(c: &mut Criterion) {
                         &private_commit,
                         &metadata,
                         load,
-                        rng,
+                        &seed.to_le_bytes(),
                     )
                 })
             });
@@ -67,12 +70,14 @@ fn bench_pke_v1_verify(c: &mut Criterion) {
         for load in [ComputeLoad::Proof, ComputeLoad::Verify] {
             let bench_id = format!("{bench_name}::{param_name}_{bits}_bits_packed_{load}");
 
+            let seed: u128 = rng.gen();
+
             let proof = prove(
                 (&public_param, &public_commit),
                 &private_commit,
                 &metadata,
                 load,
-                rng,
+                &seed.to_le_bytes(),
             );
 
             bench_group.bench_function(&bench_id, |b| {

--- a/tfhe-zk-pok/benches/pke_v2.rs
+++ b/tfhe-zk-pok/benches/pke_v2.rs
@@ -1,4 +1,5 @@
 use criterion::{criterion_group, criterion_main, Criterion};
+use rand::Rng;
 use tfhe_zk_pok::proofs::pke_v2::{prove, verify, Bound};
 use tfhe_zk_pok::proofs::ComputeLoad;
 use utils::{init_params_v2, write_to_json, PKEV1_TEST_PARAMS, PKEV2_TEST_PARAMS};
@@ -30,6 +31,8 @@ fn bench_pke_v2_prove(c: &mut Criterion) {
 
         let bench_id = format!("{bench_name}::{param_name}_{bits}_bits_packed_{load}_{bound:?}");
 
+        let seed: u128 = rng.gen();
+
         bench_group.bench_function(&bench_id, |b| {
             b.iter(|| {
                 prove(
@@ -37,7 +40,7 @@ fn bench_pke_v2_prove(c: &mut Criterion) {
                     &private_commit,
                     &metadata,
                     load,
-                    rng,
+                    &seed.to_le_bytes(),
                 )
             })
         });
@@ -70,12 +73,14 @@ fn bench_pke_v2_verify(c: &mut Criterion) {
 
         let bench_id = format!("{bench_name}::{param_name}_{bits}_bits_packed_{load}_{bound:?}");
 
+        let seed: u128 = rng.gen();
+
         let proof = prove(
             (&public_param, &public_commit),
             &private_commit,
             &metadata,
             load,
-            rng,
+            &seed.to_le_bytes(),
         );
 
         bench_group.bench_function(&bench_id, |b| {

--- a/tfhe-zk-pok/benches/utils.rs
+++ b/tfhe-zk-pok/benches/utils.rs
@@ -401,7 +401,6 @@ pub fn init_params_v1(
         testcase.m.clone(),
         testcase.e2.clone(),
         &public_param,
-        rng,
     );
 
     (
@@ -452,7 +451,6 @@ pub fn init_params_v2(
         testcase.m.clone(),
         testcase.e2.clone(),
         &public_param,
-        rng,
     );
 
     (

--- a/tfhe-zk-pok/src/backward_compatibility/mod.rs
+++ b/tfhe-zk-pok/src/backward_compatibility/mod.rs
@@ -8,6 +8,7 @@ use std::convert::Infallible;
 use std::error::Error;
 use std::fmt::Display;
 
+use sha3::digest::{ExtendableOutput, Update};
 use tfhe_versionable::{Upgrade, Version, VersionsDispatch};
 
 use crate::curve_api::Curve;
@@ -96,7 +97,7 @@ impl Upgrade<SerializablePKEv2PublicParams> for SerializablePKEv2PublicParamsV0 
     type Error = Infallible;
 
     fn upgrade(self) -> Result<SerializablePKEv2PublicParams, Self::Error> {
-        let domain_separators = SerializablePKEv2DomainSeparators {
+        let domain_separators = SerializablePKEv2DomainSeparatorsV0 {
             hash: self.hash,
             hash_R: self.hash_R,
             hash_t: self.hash_t,
@@ -122,7 +123,7 @@ impl Upgrade<SerializablePKEv2PublicParams> for SerializablePKEv2PublicParamsV0 
             msbs_zero_padding_bit_count: self.msbs_zero_padding_bit_count,
             bound_type: self.bound_type,
             sid: None,
-            domain_separators,
+            domain_separators: domain_separators.upgrade().unwrap(), // upgrade is infallible
         })
     }
 }
@@ -133,9 +134,62 @@ pub enum SerializablePKEv2PublicParamsVersions {
     V1(SerializablePKEv2PublicParams),
 }
 
+#[derive(Version)]
+pub struct SerializablePKEv2DomainSeparatorsV0 {
+    hash: Vec<u8>,
+    hash_R: Vec<u8>,
+    hash_t: Vec<u8>,
+    hash_w: Vec<u8>,
+    hash_agg: Vec<u8>,
+    hash_lmap: Vec<u8>,
+    hash_phi: Vec<u8>,
+    hash_xi: Vec<u8>,
+    hash_z: Vec<u8>,
+    hash_chi: Vec<u8>,
+}
+
+impl Upgrade<SerializablePKEv2DomainSeparators> for SerializablePKEv2DomainSeparatorsV0 {
+    type Error = Infallible;
+
+    fn upgrade(self) -> Result<SerializablePKEv2DomainSeparators, Self::Error> {
+        // V0 used an unspecified random for gamma anyways, so we can simply use a random DS.
+        // We use Shake256 XoF to get a reproducible value for a given CRS.
+        let mut hasher = sha3::Shake256::default();
+        for data in &[
+            &self.hash,
+            &self.hash_t,
+            &self.hash_w,
+            &self.hash_agg,
+            &self.hash_lmap,
+            &self.hash_z,
+        ] {
+            hasher.update(data);
+        }
+
+        let len = self.hash.len();
+        let mut hash_gamma = vec![0u8; len];
+        hasher.finalize_xof_into(&mut hash_gamma);
+
+        Ok(SerializablePKEv2DomainSeparators {
+            hash: self.hash,
+            hash_R: self.hash_R,
+            hash_t: self.hash_t,
+            hash_w: self.hash_w,
+            hash_agg: self.hash_agg,
+            hash_lmap: self.hash_lmap,
+            hash_phi: self.hash_phi,
+            hash_xi: self.hash_xi,
+            hash_z: self.hash_z,
+            hash_chi: self.hash_chi,
+            hash_gamma,
+        })
+    }
+}
+
 #[derive(VersionsDispatch)]
 pub enum SerializablePKEv2DomainSeparatorsVersions {
-    V0(SerializablePKEv2DomainSeparators),
+    V0(SerializablePKEv2DomainSeparatorsV0),
+    V1(SerializablePKEv2DomainSeparators),
 }
 
 #[derive(Version)]
@@ -162,7 +216,7 @@ impl Upgrade<SerializablePKEv1PublicParams> for SerializablePKEv1PublicParamsV0 
     type Error = Infallible;
 
     fn upgrade(self) -> Result<SerializablePKEv1PublicParams, Self::Error> {
-        let domain_separators = SerializablePKEv1DomainSeparators {
+        let domain_separators = SerializablePKEv1DomainSeparatorsV0 {
             hash: self.hash,
             hash_t: self.hash_t,
             hash_agg: self.hash_agg,
@@ -183,7 +237,7 @@ impl Upgrade<SerializablePKEv1PublicParams> for SerializablePKEv1PublicParamsV0 
             t: self.t,
             msbs_zero_padding_bit_count: self.msbs_zero_padding_bit_count,
             sid: None,
-            domain_separators,
+            domain_separators: domain_separators.upgrade().unwrap(), // upgrade is infallible
         })
     }
 }
@@ -194,9 +248,54 @@ pub enum SerializablePKEv1PublicParamsVersions {
     V1(SerializablePKEv1PublicParams),
 }
 
+#[derive(Version)]
+pub struct SerializablePKEv1DomainSeparatorsV0 {
+    hash: Vec<u8>,
+    hash_t: Vec<u8>,
+    hash_agg: Vec<u8>,
+    hash_lmap: Vec<u8>,
+    hash_w: Vec<u8>,
+    hash_z: Vec<u8>,
+}
+
+impl Upgrade<SerializablePKEv1DomainSeparators> for SerializablePKEv1DomainSeparatorsV0 {
+    type Error = Infallible;
+
+    fn upgrade(self) -> Result<SerializablePKEv1DomainSeparators, Self::Error> {
+        // V0 used an unspecified random for gamma anyways, so we can simply use a random DS.
+        // We use Shake256 XoF to get a reproducible value for a given CRS.
+        let mut hasher = sha3::Shake256::default();
+        for data in &[
+            &self.hash,
+            &self.hash_t,
+            &self.hash_w,
+            &self.hash_agg,
+            &self.hash_lmap,
+            &self.hash_z,
+        ] {
+            hasher.update(data);
+        }
+
+        let len = self.hash.len();
+        let mut hash_gamma = vec![0u8; len];
+        hasher.finalize_xof_into(&mut hash_gamma);
+
+        Ok(SerializablePKEv1DomainSeparators {
+            hash: self.hash,
+            hash_t: self.hash_t,
+            hash_w: self.hash_w,
+            hash_agg: self.hash_agg,
+            hash_lmap: self.hash_lmap,
+            hash_z: self.hash_z,
+            hash_gamma,
+        })
+    }
+}
+
 #[derive(VersionsDispatch)]
 pub enum SerializablePKEv1DomainSeparatorsVersions {
-    V0(SerializablePKEv1DomainSeparators),
+    V0(SerializablePKEv1DomainSeparatorsV0),
+    V1(SerializablePKEv1DomainSeparators),
 }
 
 #[derive(VersionsDispatch)]

--- a/tfhe-zk-pok/src/serialization.rs
+++ b/tfhe-zk-pok/src/serialization.rs
@@ -512,6 +512,7 @@ pub struct SerializablePKEv2DomainSeparators {
     pub(crate) hash_xi: Vec<u8>,
     pub(crate) hash_z: Vec<u8>,
     pub(crate) hash_chi: Vec<u8>,
+    pub(crate) hash_gamma: Vec<u8>,
 }
 
 impl From<PKEv2DomainSeparators> for SerializablePKEv2DomainSeparators {
@@ -527,6 +528,7 @@ impl From<PKEv2DomainSeparators> for SerializablePKEv2DomainSeparators {
             hash_xi: value.hash_xi().to_vec(),
             hash_z: value.hash_z().to_vec(),
             hash_chi: value.hash_chi().to_vec(),
+            hash_gamma: value.hash_gamma().to_vec(),
         }
     }
 }
@@ -546,6 +548,7 @@ impl TryFrom<SerializablePKEv2DomainSeparators> for LegacyPKEv2DomainSeparators 
             hash_xi,
             hash_z,
             hash_chi,
+            hash_gamma,
         } = value;
 
         Ok(Self {
@@ -559,6 +562,7 @@ impl TryFrom<SerializablePKEv2DomainSeparators> for LegacyPKEv2DomainSeparators 
             hash_xi: try_vec_to_array(hash_xi)?,
             hash_z: try_vec_to_array(hash_z)?,
             hash_chi: try_vec_to_array(hash_chi)?,
+            hash_gamma: try_vec_to_array(hash_gamma)?,
         })
     }
 }
@@ -578,6 +582,7 @@ impl TryFrom<SerializablePKEv2DomainSeparators> for ShortPKEv2DomainSeparators {
             hash_xi,
             hash_z,
             hash_chi,
+            hash_gamma,
         } = value;
 
         Ok(Self {
@@ -591,6 +596,7 @@ impl TryFrom<SerializablePKEv2DomainSeparators> for ShortPKEv2DomainSeparators {
             hash_xi: try_vec_to_array(hash_xi)?,
             hash_z: try_vec_to_array(hash_z)?,
             hash_chi: try_vec_to_array(hash_chi)?,
+            hash_gamma: try_vec_to_array(hash_gamma)?,
         })
     }
 }
@@ -714,6 +720,7 @@ pub struct SerializablePKEv1DomainSeparators {
     pub(crate) hash_lmap: Vec<u8>,
     pub(crate) hash_w: Vec<u8>,
     pub(crate) hash_z: Vec<u8>,
+    pub(crate) hash_gamma: Vec<u8>,
 }
 
 impl From<PKEv1DomainSeparators> for SerializablePKEv1DomainSeparators {
@@ -725,6 +732,7 @@ impl From<PKEv1DomainSeparators> for SerializablePKEv1DomainSeparators {
             hash_lmap: value.hash_lmap().to_vec(),
             hash_w: value.hash_w().to_vec(),
             hash_z: value.hash_z().to_vec(),
+            hash_gamma: value.hash_gamma().to_vec(),
         }
     }
 }
@@ -740,6 +748,7 @@ impl TryFrom<SerializablePKEv1DomainSeparators> for LegacyPKEv1DomainSeparators 
             hash_lmap,
             hash_w,
             hash_z,
+            hash_gamma,
         } = value;
 
         Ok(Self {
@@ -749,6 +758,7 @@ impl TryFrom<SerializablePKEv1DomainSeparators> for LegacyPKEv1DomainSeparators 
             hash_lmap: try_vec_to_array(hash_lmap)?,
             hash_w: try_vec_to_array(hash_w)?,
             hash_z: try_vec_to_array(hash_z)?,
+            hash_gamma: try_vec_to_array(hash_gamma)?,
         })
     }
 }
@@ -764,6 +774,7 @@ impl TryFrom<SerializablePKEv1DomainSeparators> for ShortPKEv1DomainSeparators {
             hash_lmap,
             hash_w,
             hash_z,
+            hash_gamma,
         } = value;
 
         Ok(Self {
@@ -773,6 +784,7 @@ impl TryFrom<SerializablePKEv1DomainSeparators> for ShortPKEv1DomainSeparators {
             hash_lmap: try_vec_to_array(hash_lmap)?,
             hash_w: try_vec_to_array(hash_w)?,
             hash_z: try_vec_to_array(hash_z)?,
+            hash_gamma: try_vec_to_array(hash_gamma)?,
         })
     }
 }

--- a/tfhe/src/zk/mod.rs
+++ b/tfhe/src/zk/mod.rs
@@ -539,6 +539,10 @@ impl CompactPkeCrs {
             .map(CastFrom::cast_from)
             .collect::<Vec<_>>();
 
+        // 128bits seed as defined in the NIST document
+        let mut seed = [0u8; 16];
+        random_generator.fill_bytes(&mut seed);
+
         match self {
             Self::PkeV1(public_params) => {
                 let (public_commit, private_commit) = commit_v1(
@@ -551,7 +555,6 @@ impl CompactPkeCrs {
                     messages,
                     body_noise,
                     public_params,
-                    random_generator,
                 );
 
                 let proof = prove_v1(
@@ -559,7 +562,7 @@ impl CompactPkeCrs {
                     &private_commit,
                     metadata,
                     load,
-                    random_generator,
+                    &seed,
                 );
 
                 CompactPkeProof::PkeV1(proof)
@@ -575,7 +578,6 @@ impl CompactPkeCrs {
                     messages,
                     body_noise,
                     public_params,
-                    random_generator,
                 );
 
                 let proof = prove_v2(
@@ -583,7 +585,7 @@ impl CompactPkeCrs {
                     &private_commit,
                     metadata,
                     load,
-                    random_generator,
+                    &seed,
                 );
 
                 CompactPkeProof::PkeV2(proof)


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description
Use Shake256 XoF function to generate the gamma coeffs in Pke V1/V2 prove. 

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/2421)
<!-- Reviewable:end -->
