### PR TITLE
feat(core): plug XofSeed in core's RNG

### DIFF
--- a/tfhe/src/core_crypto/commons/generators/encryption/mask_random_generator.rs
+++ b/tfhe/src/core_crypto/commons/generators/encryption/mask_random_generator.rs
@@ -3,7 +3,7 @@
 use super::PER_SAMPLE_TARGET_FAILURE_PROBABILITY_LOG2;
 use crate::core_crypto::commons::math::random::{
     ByteRandomGenerator, Distribution, ParallelByteRandomGenerator, RandomGenerable,
-    RandomGenerator, Seed, Uniform,
+    RandomGenerator, Uniform,
 };
 use crate::core_crypto::commons::numeric::UnsignedInteger;
 use crate::core_crypto::commons::parameters::{
@@ -11,6 +11,7 @@ use crate::core_crypto::commons::parameters::{
 };
 use rayon::prelude::*;
 use tfhe_csprng::generators::ForkError;
+use tfhe_csprng::seeders::SeedKind;
 
 #[derive(Clone, Copy, Debug)]
 pub struct MaskRandomGeneratorForkConfig {
@@ -97,7 +98,7 @@ pub struct MaskRandomGenerator<G: ByteRandomGenerator> {
 }
 
 impl<G: ByteRandomGenerator> MaskRandomGenerator<G> {
-    pub fn new(seed: Seed) -> Self {
+    pub fn new(seed: impl Into<SeedKind>) -> Self {
         Self {
             gen: RandomGenerator::new(seed),
         }

--- a/tfhe/src/core_crypto/commons/generators/encryption/mod.rs
+++ b/tfhe/src/core_crypto/commons/generators/encryption/mod.rs
@@ -6,7 +6,7 @@ pub(crate) mod noise_random_generator;
 mod test;
 
 use crate::core_crypto::commons::math::random::{
-    ByteRandomGenerator, Distribution, ParallelByteRandomGenerator, RandomGenerable, Seed, Seeder,
+    ByteRandomGenerator, Distribution, ParallelByteRandomGenerator, RandomGenerable, Seeder,
     Uniform,
 };
 use crate::core_crypto::commons::numeric::UnsignedInteger;
@@ -18,6 +18,7 @@ use mask_random_generator::{MaskRandomGenerator, MaskRandomGeneratorForkConfig};
 use noise_random_generator::{NoiseRandomGenerator, NoiseRandomGeneratorForkConfig};
 use rayon::prelude::*;
 use tfhe_csprng::generators::ForkError;
+use tfhe_csprng::seeders::SeedKind;
 
 pub const PER_SAMPLE_TARGET_FAILURE_PROBABILITY_LOG2: f64 = -128.;
 
@@ -95,10 +96,14 @@ pub struct EncryptionRandomGenerator<G: ByteRandomGenerator> {
 }
 
 impl<G: ByteRandomGenerator> EncryptionRandomGenerator<G> {
-    /// Create a new [`EncryptionRandomGenerator`], using the provided [`Seed`] to seed the public
-    /// mask generator and using the provided [`Seeder`] to privately seed the noise generator.
+    /// Create a new [`EncryptionRandomGenerator`], using the provided [`Seed`] or [`XofSeed`]
+    /// to seed the public mask generator and using the provided [`Seeder`] to privately seed the
+    /// noise generator.
+    ///
+    /// [`Seed`]: crate::core_crypto::commons::math::random::Seed
+    /// [`XofSeed`]: crate::core_crypto::commons::math::random::XofSeed
     // S is ?Sized to allow Box<dyn Seeder> to be passed.
-    pub fn new<S: Seeder + ?Sized>(seed: Seed, seeder: &mut S) -> Self {
+    pub fn new<S: Seeder + ?Sized>(seed: impl Into<SeedKind>, seeder: &mut S) -> Self {
         Self {
             mask: MaskRandomGenerator::new(seed),
             noise: NoiseRandomGenerator::new(seeder),

--- a/tfhe/src/core_crypto/commons/math/random/generator.rs
+++ b/tfhe/src/core_crypto/commons/math/random/generator.rs
@@ -13,7 +13,8 @@ use tfhe_csprng::generators::{BytesPerChild, ChildrenCount, ForkError};
 pub use tfhe_csprng::generators::{
     ParallelRandomGenerator as ParallelByteRandomGenerator, RandomGenerator as ByteRandomGenerator,
 };
-pub use tfhe_csprng::seeders::{Seed, Seeder};
+use tfhe_csprng::seeders::SeedKind;
+pub use tfhe_csprng::seeders::{Seed, Seeder, XofSeed};
 
 /// Module to proxy the serialization for `tfhe-csprng::Seed` to avoid adding serde as a
 /// dependency to `tfhe-csprng`
@@ -122,7 +123,7 @@ impl<G: ByteRandomGenerator> RandomGenerator<G> {
     /// use tfhe_csprng::seeders::Seed;
     /// let generator = RandomGenerator::<SoftwareRandomGenerator>::new(Seed(0));
     /// ```
-    pub fn new(seed: Seed) -> Self {
+    pub fn new(seed: impl Into<SeedKind>) -> Self {
         Self(G::new(seed))
     }
 


### PR DESCRIPTION
For tfhe-csprng's new XofSeed (and xof-init) to be useable for
tfhe::core_crypto API, some changes needs to be made

* RandomGenerator acceps T: impl Into<SeedKind>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/2426)
<!-- Reviewable:end -->
