### PR TITLE
chore(gpu): fix ci on H100

### DIFF
--- a/tfhe/src/high_level_api/compressed_ciphertext_list.rs
+++ b/tfhe/src/high_level_api/compressed_ciphertext_list.rs
@@ -1062,10 +1062,9 @@ mod tests {
             let mut compressed_list_builder = CompressedCiphertextListBuilder::new();
             let compressed_list_init = compressed_list_builder.push(ct1).push(ct2);
             let compression_size_on_gpu = compressed_list_init.get_size_on_gpu().unwrap();
-            assert!(check_valid_cuda_malloc(
-                compression_size_on_gpu,
-                GpuIndex::new(0)
-            ));
+            while !check_valid_cuda_malloc(compression_size_on_gpu, GpuIndex::new(0)) {
+                std::thread::sleep(std::time::Duration::from_millis(10));
+            }
             let compressed_list = compressed_list_init.build().unwrap();
             let decompress_ct1_size_on_gpu = compressed_list
                 .get_decompression_size_on_gpu(0)


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description

The error in the CI comes from the fact that when executing several tests in parallel we don't have enough memory to run compression. I propose to modify this part of the test with a wait, but we could also reduce test-threads for HL API tests, wdyt?

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
