### PR TITLE
chore(gpu): add cuda debug target for integer tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -658,6 +658,14 @@ test_integer_gpu: install_rs_build_toolchain
 	RUSTFLAGS="$(RUSTFLAGS)" cargo $(CARGO_RS_BUILD_TOOLCHAIN) test --doc --profile $(CARGO_PROFILE) \
 		--features=integer,gpu -p $(TFHE_SPEC) -- integer::gpu::server_key::
 
+.PHONY: test_integer_gpu_debug # Run the tests of the integer module with Debug flags for CUDA
+test_integer_gpu_debug: install_rs_build_toolchain
+	RUSTFLAGS="$(RUSTFLAGS)" cargo $(CARGO_RS_BUILD_TOOLCHAIN) test --profile release_lto_off \
+		--features=integer,gpu-debug -vv -p $(TFHE_SPEC) -- integer::gpu::server_key:: --test-threads=1 --nocapture
+	RUSTFLAGS="$(RUSTFLAGS)" cargo $(CARGO_RS_BUILD_TOOLCHAIN) test --doc --profile release_lto_off \
+		--features=integer,gpu-debug -p $(TFHE_SPEC) -- integer::gpu::server_key::
+
+
 .PHONY: test_integer_long_run_gpu # Run the long run integer tests on the gpu backend
 test_integer_long_run_gpu: install_rs_check_toolchain install_cargo_nextest
 	BIG_TESTS_INSTANCE="$(BIG_TESTS_INSTANCE)" \

--- a/backends/tfhe-cuda-backend/Cargo.toml
+++ b/backends/tfhe-cuda-backend/Cargo.toml
@@ -19,3 +19,4 @@ bindgen = "0.71"
 [features]
 experimental-multi-arch = []
 profile = []
+debug = []

--- a/backends/tfhe-cuda-backend/build.rs
+++ b/backends/tfhe-cuda-backend/build.rs
@@ -53,6 +53,11 @@ fn main() {
             cmake_config.define("USE_NVTOOLS", "OFF");
         }
 
+        if cfg!(feature = "debug") {
+            cmake_config.define("CMAKE_BUILD_TYPE", "DEBUG");
+            cmake_config.define("CMAKE_CXX_FLAGS", "-Wuninitialized -O0");
+        }
+
         // Build the CMake project
         let dest = cmake_config.build();
         println!("cargo:rustc-link-search=native={}", dest.display());

--- a/backends/tfhe-cuda-backend/cuda/CMakeLists.txt
+++ b/backends/tfhe-cuda-backend/cuda/CMakeLists.txt
@@ -52,6 +52,8 @@ endif()
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
+else()
+  message("Building CUDA backend in ${CMAKE_BUILD_TYPE}")
 endif()
 
 # Add OpenMP support

--- a/tfhe/Cargo.toml
+++ b/tfhe/Cargo.toml
@@ -103,6 +103,7 @@ gpu-experimental-multi-arch = [
     "tfhe-cuda-backend/experimental-multi-arch",
 ]
 gpu-profile = ["gpu", "tfhe-cuda-backend/profile"]
+gpu-debug = ["gpu", "tfhe-cuda-backend/debug"]
 zk-pok = ["dep:tfhe-zk-pok"]
 # Start Fpga Hpu features
 hpu = ["dep:tfhe-hpu-backend", "shortint", "integer"]


### PR DESCRIPTION
Adds a makefile target `test_integer_gpu_debug` that enables Debug compilation of the CUDA backend