### PR TITLE
Fix HPU fpga README link in documentation

### DIFF
--- a/tfhe/docs/configuration/hpu_acceleration/run_on_hpu.md
+++ b/tfhe/docs/configuration/hpu_acceleration/run_on_hpu.md
@@ -7,7 +7,7 @@ This guide explains how to update your existing program to leverage HPU accelera
 ## Prerequisites
 
 * An [AMD/Xilinx V80 board](https://www.amd.com/en/products/accelerators/alveo/v80.html) installed on a server running Linux with kernel 5.15.0-\*
-* A HPU bitstream that you can find (or build) in [HPU fpga repository](https://github.com/zama-ai/hpu_fpga) and load in V80 flash and FPGA using its [README](https://github.com/zama-ai/hpu_fpga/README.md)
+* A HPU bitstream that you can find (or build) in [HPU fpga repository](https://github.com/zama-ai/hpu_fpga) and load in V80 flash and FPGA using its [README](https://github.com/zama-ai/hpu_fpga/blob/main/README.md)
 * AMI linux device driver version from this [fork](https://github.com/zama-ai/AVED)
 * QDMA linux device driver version from this [fork](https://github.com/zama-ai/dma_ip_drivers)
 * Rust version - check this [page](../rust_configuration.md)


### PR DESCRIPTION
The link to the HPU fpga repository README was updated to point directly to https://github.com/zama-ai/hpu_fpga/blob/main/README.md for accuracy and to avoid 404 errors.