### PR TITLE
feat(gpu): Avoid copy to host in sum ciphertexts

### DIFF
--- a/backends/tfhe-cuda-backend/cuda/src/integer/multiplication.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/multiplication.cuh
@@ -273,8 +273,12 @@ __global__ void fill_radix_from_lsb_msb(Torus *result_blocks, Torus *lsb_blocks,
   }
 }
 
-struct radix_columns {
+template <typename Torus> struct radix_columns {
+  std::vector<std::vector<Torus>> columns;
   std::vector<size_t> columns_counter;
+  std::vector<std::vector<Torus>> new_columns;
+  std::vector<size_t> new_columns_counter;
+
   size_t num_blocks;
   size_t num_radix_in_vec;
   size_t chunk_size;
@@ -284,14 +288,21 @@ struct radix_columns {
       : num_blocks(num_blocks), num_radix_in_vec(num_radix_in_vec),
         chunk_size(chunk_size) {
     needs_processing = false;
+    columns.resize(num_blocks);
     columns_counter.resize(num_blocks, 0);
+    new_columns.resize(num_blocks);
+    new_columns_counter.resize(num_blocks, 0);
+    for (size_t i = 0; i < num_blocks; ++i) {
+      new_columns[i].resize(num_radix_in_vec);
+    }
     for (size_t i = 0; i < num_radix_in_vec; ++i) {
       for (size_t j = 0; j < num_blocks; ++j) {
-        if (input_degrees[i * num_blocks + j])
-          columns_counter[j] += 1;
+        if (input_degrees[i * num_blocks + j]) {
+          columns[j].push_back(i * num_blocks + j);
+          columns_counter[j]++;
+        }
       }
     }
-
     for (size_t i = 0; i < num_blocks; ++i) {
       if (columns_counter[i] > chunk_size) {
         needs_processing = true;
@@ -300,42 +311,72 @@ struct radix_columns {
     }
   }
 
-  void next_accumulation(size_t &total_ciphertexts, size_t &message_ciphertexts,
-                         bool &needs_processing) {
+  void next_accumulation(Torus *h_indexes_in, Torus *h_indexes_out,
+                         Torus *h_lut_indexes, size_t &total_ciphertexts,
+                         size_t &message_ciphertexts, bool &needs_processing) {
     message_ciphertexts = 0;
     total_ciphertexts = 0;
     needs_processing = false;
-    for (int i = num_blocks - 1; i > 0; --i) {
-      size_t cur_count = columns_counter[i];
-      size_t prev_count = columns_counter[i - 1];
-      size_t new_count = 0;
 
-      // accumulated_blocks from current columns
-      new_count += cur_count / chunk_size;
-      // all accumulated message blocks needs pbs
-      message_ciphertexts += new_count;
-      // carry blocks from previous columns
-      new_count += prev_count / chunk_size;
-      // both carry and message blocks that needs pbs
-      total_ciphertexts += new_count;
-      // now add remaining non accumulated blocks that does not require pbs
-      new_count += cur_count % chunk_size;
-
-      columns_counter[i] = new_count;
-
-      if (new_count > chunk_size)
-        needs_processing = true;
+    size_t pbs_count = 0;
+    for (size_t c_id = 0; c_id < num_blocks; ++c_id) {
+      const size_t column_len = columns_counter[c_id];
+      new_columns_counter[c_id] = 0;
+      size_t ct_count = 0;
+      // add message cts into new columns
+      for (size_t i = 0; i + chunk_size <= column_len; i += chunk_size) {
+        const Torus in_index = columns[c_id][i];
+        new_columns[c_id][ct_count] = in_index;
+        h_indexes_in[pbs_count] = in_index;
+        h_indexes_out[pbs_count] = in_index;
+        h_lut_indexes[pbs_count] = 0;
+        ++pbs_count;
+        ++ct_count;
+        ++message_ciphertexts;
+      }
+      new_columns_counter[c_id] = ct_count;
     }
 
-    // now do it for 0th block
-    size_t new_count = columns_counter[0] / chunk_size;
-    message_ciphertexts += new_count;
-    total_ciphertexts += new_count;
-    new_count += columns_counter[0] % chunk_size;
-    columns_counter[0] = new_count;
+    for (size_t c_id = 0; c_id < num_blocks; ++c_id) {
+      const size_t column_len = columns_counter[c_id];
+      size_t ct_count = new_columns_counter[c_id];
+      // add carry cts into new columns
+      if (c_id > 0) {
+        const size_t prev_c_id = c_id - 1;
+        const size_t prev_column_len = columns_counter[prev_c_id];
+        for (size_t i = 0; i + chunk_size <= prev_column_len; i += chunk_size) {
+          const Torus in_index = columns[prev_c_id][i];
+          const Torus out_index = columns[prev_c_id][i + 1];
+          new_columns[c_id][ct_count] = out_index;
+          h_indexes_in[pbs_count] = in_index;
+          h_indexes_out[pbs_count] = out_index;
+          h_lut_indexes[pbs_count] = 1;
+          ++pbs_count;
+          ++ct_count;
+        }
+      }
+      // add remaining cts into new columns
+      const size_t start_index = column_len - column_len % chunk_size;
+      for (size_t i = start_index; i < column_len; ++i) {
+        new_columns[c_id][ct_count] = columns[c_id][i];
+        ++ct_count;
+      }
+      new_columns_counter[c_id] = ct_count;
+      if (ct_count > chunk_size) {
+        needs_processing = true;
+      }
+    }
+    total_ciphertexts = pbs_count;
+    swap(columns, new_columns);
+    swap(columns_counter, new_columns_counter);
+  }
 
-    if (new_count > chunk_size) {
-      needs_processing = true;
+  void final_calculation(Torus *h_indexes_in, Torus *h_indexes_out,
+                         Torus *h_lut_indexes) {
+    for (size_t idx = 0; idx < 2 * num_blocks; ++idx) {
+      h_indexes_in[idx] = idx % num_blocks;
+      h_indexes_out[idx] = idx + idx / num_blocks;
+      h_lut_indexes[idx] = idx / num_blocks;
     }
   }
 };
@@ -479,8 +520,9 @@ __host__ void host_integer_partial_sum_ciphertexts_vec_kb(
       num_radix_in_vec);
 
   bool needs_processing = false;
-  radix_columns current_columns(current_blocks->degrees, num_radix_blocks,
-                                num_radix_in_vec, chunk_size, needs_processing);
+  radix_columns<Torus> current_columns(current_blocks->degrees,
+                                       num_radix_blocks, num_radix_in_vec,
+                                       chunk_size, needs_processing);
   int number_of_threads = min(256, params::degree);
   int part_count = (big_lwe_size + number_of_threads - 1) / number_of_threads;
   const dim3 number_of_blocks_2d(num_radix_blocks, part_count, 1);
@@ -498,7 +540,10 @@ __host__ void host_integer_partial_sum_ciphertexts_vec_kb(
 
     size_t total_ciphertexts;
     size_t total_messages;
-    current_columns.next_accumulation(total_ciphertexts, total_messages,
+    current_columns.next_accumulation(luts_message_carry->h_lwe_indexes_in,
+                                      luts_message_carry->h_lwe_indexes_out,
+                                      luts_message_carry->h_lut_indexes,
+                                      total_ciphertexts, total_messages,
                                       needs_processing);
 
     auto active_gpu_count = get_active_gpu_count(total_ciphertexts, gpu_count);
@@ -521,32 +566,8 @@ __host__ void host_integer_partial_sum_ciphertexts_vec_kb(
           total_ciphertexts, mem_ptr->params.pbs_type, num_many_lut,
           lut_stride);
     } else {
-      Torus *h_lwe_indexes_in_pinned;
-      Torus *h_lwe_indexes_out_pinned;
-      cudaMallocHost((void **)&h_lwe_indexes_in_pinned,
-                     total_ciphertexts * sizeof(Torus));
-      cudaMallocHost((void **)&h_lwe_indexes_out_pinned,
-                     total_ciphertexts * sizeof(Torus));
-      for (uint32_t i = 0; i < total_ciphertexts; i++) {
-        h_lwe_indexes_in_pinned[i] = luts_message_carry->h_lwe_indexes_in[i];
-        h_lwe_indexes_out_pinned[i] = luts_message_carry->h_lwe_indexes_out[i];
-      }
-      cuda_memcpy_async_to_cpu(
-          h_lwe_indexes_in_pinned, luts_message_carry->lwe_indexes_in,
-          total_ciphertexts * sizeof(Torus), streams[0], gpu_indexes[0]);
-      cuda_memcpy_async_to_cpu(
-          h_lwe_indexes_out_pinned, luts_message_carry->lwe_indexes_out,
-          total_ciphertexts * sizeof(Torus), streams[0], gpu_indexes[0]);
-      cuda_synchronize_stream(streams[0], gpu_indexes[0]);
-      for (uint32_t i = 0; i < total_ciphertexts; i++) {
-        luts_message_carry->h_lwe_indexes_in[i] = h_lwe_indexes_in_pinned[i];
-        luts_message_carry->h_lwe_indexes_out[i] = h_lwe_indexes_out_pinned[i];
-      }
-      cudaFreeHost(h_lwe_indexes_in_pinned);
-      cudaFreeHost(h_lwe_indexes_out_pinned);
-
-      luts_message_carry->broadcast_lut(streams, gpu_indexes, 0);
       luts_message_carry->using_trivial_lwe_indexes = false;
+      luts_message_carry->broadcast_lut(streams, gpu_indexes, 0);
 
       integer_radix_apply_univariate_lookup_table_kb<Torus>(
           streams, gpu_indexes, active_gpu_count, current_blocks,
@@ -573,6 +594,9 @@ __host__ void host_integer_partial_sum_ciphertexts_vec_kb(
         (Torus *)(current_blocks->ptr) + big_lwe_size * num_radix_blocks, 0,
         big_lwe_size * sizeof(Torus), streams[0], gpu_indexes[0]);
 
+    current_columns.final_calculation(luts_message_carry->h_lwe_indexes_in,
+                                      luts_message_carry->h_lwe_indexes_out,
+                                      luts_message_carry->h_lut_indexes);
     auto active_gpu_count =
         get_active_gpu_count(2 * num_radix_blocks, gpu_count);
 
@@ -594,38 +618,13 @@ __host__ void host_integer_partial_sum_ciphertexts_vec_kb(
           2 * num_radix_blocks, mem_ptr->params.pbs_type, num_many_lut,
           lut_stride);
     } else {
-      uint32_t num_blocks_in_apply_lut = 2 * num_radix_blocks;
-      Torus *h_lwe_indexes_in_pinned;
-      Torus *h_lwe_indexes_out_pinned;
-      cudaMallocHost((void **)&h_lwe_indexes_in_pinned,
-                     num_blocks_in_apply_lut * sizeof(Torus));
-      cudaMallocHost((void **)&h_lwe_indexes_out_pinned,
-                     num_blocks_in_apply_lut * sizeof(Torus));
-      for (uint32_t i = 0; i < num_blocks_in_apply_lut; i++) {
-        h_lwe_indexes_in_pinned[i] = luts_message_carry->h_lwe_indexes_in[i];
-        h_lwe_indexes_out_pinned[i] = luts_message_carry->h_lwe_indexes_out[i];
-      }
-      cuda_memcpy_async_to_cpu(
-          h_lwe_indexes_in_pinned, luts_message_carry->lwe_indexes_in,
-          num_blocks_in_apply_lut * sizeof(Torus), streams[0], gpu_indexes[0]);
-      cuda_memcpy_async_to_cpu(
-          h_lwe_indexes_out_pinned, luts_message_carry->lwe_indexes_out,
-          num_blocks_in_apply_lut * sizeof(Torus), streams[0], gpu_indexes[0]);
-      cuda_synchronize_stream(streams[0], gpu_indexes[0]);
-      for (uint32_t i = 0; i < num_blocks_in_apply_lut; i++) {
-        luts_message_carry->h_lwe_indexes_in[i] = h_lwe_indexes_in_pinned[i];
-        luts_message_carry->h_lwe_indexes_out[i] = h_lwe_indexes_out_pinned[i];
-      }
-      cudaFreeHost(h_lwe_indexes_in_pinned);
-      cudaFreeHost(h_lwe_indexes_out_pinned);
-
       luts_message_carry->broadcast_lut(streams, gpu_indexes, 0);
       luts_message_carry->using_trivial_lwe_indexes = false;
 
       integer_radix_apply_univariate_lookup_table_kb<Torus>(
           streams, gpu_indexes, active_gpu_count, current_blocks, radix_lwe_out,
           bsks, ksks, ms_noise_reduction_key, luts_message_carry,
-          num_blocks_in_apply_lut);
+          2 * num_radix_blocks);
     }
     calculate_final_degrees(radix_lwe_out->degrees, terms->degrees,
                             num_radix_blocks, num_radix_in_vec, chunk_size,


### PR DESCRIPTION
### PR content/description

Avoid copying LWE and LUT indexes from device to host by computing them directly on the host side, allowing overlap with kernel execution.

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
