### PR TITLE
chore(gpu): add short op sequence test for GPU on PRs

### DIFF
--- a/.github/workflows/gpu_integer_long_run_tests.yml
+++ b/.github/workflows/gpu_integer_long_run_tests.yml
@@ -11,6 +11,7 @@ env:
   SLACK_USERNAME: ${{ secrets.BOT_USERNAME }}
   SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
   CHECKOUT_TOKEN: ${{ secrets.REPO_CHECKOUT_TOKEN || secrets.GITHUB_TOKEN }}
+  IS_PR: ${{ github.event_name == 'pull_request' }}
 
 on:
   # Allows you to run this workflow manually from the Actions tab as an alternative.
@@ -18,6 +19,8 @@ on:
   schedule:
     # Nightly tests will be triggered each evening 8p.m.
     - cron: "0 20 * * *"
+  pull_request:
+
 
 permissions:
   contents: read
@@ -78,7 +81,11 @@ jobs:
 
       - name: Run tests
         run: |
-          make test_integer_long_run_gpu
+          if [[ "${IS_PR}" == "true" ]]; then
+            make test_integer_short_run_gpu
+          else
+            make test_integer_long_run_gpu
+          fi
 
   slack-notify:
     name: Slack Notification

--- a/Makefile
+++ b/Makefile
@@ -692,6 +692,12 @@ test_integer_long_run_gpu: install_rs_check_toolchain install_cargo_nextest
 		--cargo-profile "$(CARGO_PROFILE)" --avx512-support "$(AVX512_SUPPORT)" \
 		--tfhe-package "$(TFHE_SPEC)" --backend "gpu"
 
+.PHONY: test_integer_short_run_gpu # Run the long run integer tests on the gpu backend
+test_integer_short_run_gpu: install_rs_check_toolchain install_cargo_nextest
+	TFHE_RS_TEST_LONG_TESTS_MINIMAL=TRUE \
+	RUSTFLAGS="$(RUSTFLAGS)" cargo $(CARGO_RS_BUILD_TOOLCHAIN) test --profile $(CARGO_PROFILE) \
+		--features=integer,gpu -p $(TFHE_SPEC) -- integer::gpu::server_key::radix::tests_long_run::test_random_op_sequence integer::gpu::server_key::radix::tests_long_run::test_signed_random_op_sequence --test-threads=1 --nocapture
+
 .PHONY: test_integer_compression
 test_integer_compression: install_rs_build_toolchain
 	RUSTFLAGS="$(RUSTFLAGS)" cargo $(CARGO_RS_BUILD_TOOLCHAIN) test --profile $(CARGO_PROFILE) \

--- a/tfhe/src/integer/gpu/server_key/radix/tests_long_run/mod.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/tests_long_run/mod.rs
@@ -8,6 +8,7 @@ use crate::integer::server_key::radix_parallel::tests_cases_unsigned::FunctionEx
 use crate::integer::{
     BooleanBlock, RadixCiphertext, RadixClientKey, ServerKey, SignedRadixCiphertext, U256,
 };
+use rand::seq::SliceRandom;
 use rand::Rng;
 use std::sync::Arc;
 
@@ -32,9 +33,21 @@ impl<F> GpuMultiDeviceFunctionExecutor<F> {
 
 impl<F> GpuMultiDeviceFunctionExecutor<F> {
     pub(crate) fn setup_from_keys(&mut self, cks: &RadixClientKey, _sks: &Arc<ServerKey>) {
+        // Sample a random subset of 1-N gpus, where N is the number of available GPUs
+        // A GPU index should not appear twice in the subset
         let num_gpus = get_number_of_gpus();
-        let gpu_index = GpuIndex::new(rand::thread_rng().gen_range(0..num_gpus));
-        let streams = CudaStreams::new_single_gpu(gpu_index);
+        let mut rng = rand::thread_rng();
+        let num_gpus_to_use = rng.gen_range(1..=num_gpus as usize);
+        let mut all_gpu_indexes: Vec<u32> = (0..num_gpus).collect();
+        all_gpu_indexes.shuffle(&mut rng);
+        let gpu_indexes_to_use = &all_gpu_indexes[..num_gpus_to_use];
+        let gpu_indexes: Vec<GpuIndex> = gpu_indexes_to_use
+            .iter()
+            .map(|idx| GpuIndex::new(*idx))
+            .collect();
+        println!("Setting up server key on GPUs: [{gpu_indexes_to_use:?}]");
+
+        let streams = CudaStreams::new_multi_gpu_with_indexes(&gpu_indexes);
 
         let sks = CudaServerKey::new(cks.as_ref(), &streams);
         streams.synchronize();

--- a/tfhe/src/integer/gpu/server_key/radix/tests_long_run/test_random_op_sequence.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/tests_long_run/test_random_op_sequence.rs
@@ -16,6 +16,8 @@ fn random_op_sequence<P>(param: P)
 where
     P: Into<TestParameters> + Clone,
 {
+    println!("Running random op sequence test");
+
     // Binary Ops Executors
     let add_executor = GpuMultiDeviceFunctionExecutor::new(&CudaServerKey::add);
     let sub_executor = GpuMultiDeviceFunctionExecutor::new(&CudaServerKey::sub);

--- a/tfhe/src/integer/server_key/radix_parallel/tests_long_run/mod.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_long_run/mod.rs
@@ -1,6 +1,299 @@
+use crate::core_crypto::commons::generators::DeterministicSeeder;
+use crate::core_crypto::prelude::CastFrom;
+use crate::integer::block_decomposition::DecomposableInto;
+use crate::integer::{
+    BooleanBlock, IntegerCiphertext, RadixCiphertext, RadixClientKey, SignedRadixCiphertext,
+};
+use crate::shortint::parameters::NoiseLevel;
+use rand::Rng;
+use tfhe_csprng::generators::DefaultRandomGenerator;
+use tfhe_csprng::seeders::{Seed, Seeder};
+
 pub(crate) mod test_erc20;
 pub(crate) mod test_random_op_sequence;
 pub(crate) mod test_signed_erc20;
 pub(crate) mod test_signed_random_op_sequence;
 pub(crate) const NB_CTXT_LONG_RUN: usize = 32;
 pub(crate) const NB_TESTS_LONG_RUN: usize = 20000;
+pub(crate) const NB_TESTS_LONG_RUN_MINIMAL: usize = 200;
+
+pub(crate) fn get_long_test_iterations() -> usize {
+    static ENV_KEY_LONG_TESTS: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+
+    let is_long_tests_minimal = *ENV_KEY_LONG_TESTS.get_or_init(|| {
+        std::env::var("TFHE_RS_TEST_LONG_TESTS_MINIMAL")
+            .is_ok_and(|val| val.to_uppercase() == "TRUE")
+    });
+
+    if is_long_tests_minimal {
+        NB_TESTS_LONG_RUN_MINIMAL
+    } else {
+        NB_TESTS_LONG_RUN
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct TestDataSample<P, C> {
+    pub(crate) p: P,
+    pub(crate) c: C,
+    pub(crate) producer: (String, usize),
+}
+
+pub trait RadixEncryptable {
+    type Output;
+
+    fn encrypt(&self, key: &RadixClientKey) -> Self::Output;
+}
+
+impl RadixEncryptable for u64 {
+    type Output = RadixCiphertext;
+
+    fn encrypt(&self, key: &RadixClientKey) -> Self::Output {
+        key.encrypt(*self)
+    }
+}
+
+impl RadixEncryptable for i64 {
+    type Output = SignedRadixCiphertext;
+
+    fn encrypt(&self, key: &RadixClientKey) -> Self::Output {
+        key.encrypt_signed(*self)
+    }
+}
+
+struct RandomOpSequenceDataGenerator<P, C> {
+    pub(crate) lhs: Vec<TestDataSample<P, C>>,
+    pub(crate) rhs: Vec<TestDataSample<P, C>>,
+    deterministic_seeder: DeterministicSeeder<DefaultRandomGenerator>,
+    seed: Seed,
+    cks: RadixClientKey,
+    op_counter: usize,
+}
+
+impl<
+        P: RadixEncryptable<Output = C> + DecomposableInto<u64> + CastFrom<u128> + std::fmt::Display,
+        C: IntegerCiphertext,
+    > RandomOpSequenceDataGenerator<P, C>
+{
+    fn new(total_num_ops: usize, cks: &RadixClientKey) -> Self {
+        let mut rng = rand::thread_rng();
+
+        let seed: u128 = rng.gen();
+        Self::new_with_seed(total_num_ops, Seed(seed), cks)
+    }
+
+    fn make_data_sample_vector(
+        deterministic_seeder: &mut DeterministicSeeder<DefaultRandomGenerator>,
+        total_num_ops: usize,
+        cks: &RadixClientKey,
+    ) -> Vec<TestDataSample<P, C>> {
+        (0..total_num_ops)
+            .map(|_| {
+                let plain: P = P::cast_from(deterministic_seeder.seed().0);
+                let cipher: C = plain.encrypt(cks);
+                TestDataSample {
+                    p: plain,
+                    c: cipher,
+                    producer: ("encrypt".to_string(), 0),
+                }
+            }) // Generate random i64 values and encrypt them
+            .collect()
+    }
+    fn new_with_seed(total_num_ops: usize, seed: Seed, cks: &RadixClientKey) -> Self {
+        let mut deterministic_seeder = DeterministicSeeder::<DefaultRandomGenerator>::new(seed);
+
+        Self {
+            lhs: Self::make_data_sample_vector(&mut deterministic_seeder, total_num_ops, cks),
+            rhs: Self::make_data_sample_vector(&mut deterministic_seeder, total_num_ops, cks),
+            deterministic_seeder,
+            seed,
+            cks: cks.clone(),
+            op_counter: 0,
+        }
+    }
+
+    fn get_seed(&self) -> Seed {
+        self.seed
+    }
+
+    fn gen_op_index(&mut self) -> (usize, usize) {
+        let op_count = self.op_counter;
+        self.op_counter += 1;
+        (
+            self.deterministic_seeder.seed().0 as usize % self.lhs.len(),
+            op_count,
+        )
+    }
+    fn gen_op_operands(
+        &mut self,
+        op_idx: usize,
+        op_name: &str,
+    ) -> (TestDataSample<P, C>, TestDataSample<P, C>) {
+        let i = self.deterministic_seeder.seed().0 as usize % self.lhs.len();
+        let j = self.deterministic_seeder.seed().0 as usize % self.rhs.len();
+
+        let input_degrees_left: Vec<u64> =
+            self.lhs[i].c.blocks().iter().map(|b| b.degree.0).collect();
+        let input_degrees_right: Vec<u64> =
+            self.rhs[j].c.blocks().iter().map(|b| b.degree.0).collect();
+
+        println!("{op_idx}: Start {op_name} lhs[{i}]={} deg={input_degrees_left:?} (prod: {}:{}), rhs[{j}]={} deg={input_degrees_right:?} (prod: {}:{})",
+            self.lhs[i].p, self.lhs[i].producer.1, self.lhs[i].producer.0, self.rhs[j].p, self.rhs[j].producer.1, self.rhs[j].producer.0,
+        );
+
+        (self.lhs[i].clone(), self.rhs[j].clone())
+    }
+
+    fn gen_op_single_operand(&mut self, op_idx: usize, op_name: &str) -> TestDataSample<P, C> {
+        let side = self.deterministic_seeder.seed().0 % 2;
+
+        let i = self.deterministic_seeder.seed().0 as usize % self.lhs.len();
+        let j = self.deterministic_seeder.seed().0 as usize % self.rhs.len();
+
+        let (operand, side_str, operand_idx) = if side == 0 {
+            (&self.lhs[i], "left", i)
+        } else {
+            (&self.rhs[j], "right", j)
+        };
+
+        let input_degrees: Vec<u64> = operand.c.blocks().iter().map(|b| b.degree.0).collect();
+
+        println!(
+            "{op_idx}: Start {op_name} {side_str}[{operand_idx}]={} deg={input_degrees:?} (prod: {}:{})",
+            operand.p,
+            operand.producer.1, operand.producer.0
+        );
+
+        operand.clone()
+    }
+
+    fn put_op_result_random_side(
+        &mut self,
+        clear: P,
+        encrypted: &C,
+        op_name: &String,
+        op_index: usize,
+    ) {
+        let output_degrees: Vec<u64> = encrypted.blocks().iter().map(|b| b.degree.0).collect();
+
+        let side = self.deterministic_seeder.seed().0 % 2;
+
+        let (out, side_str) = if side == 0 {
+            (&mut self.lhs, "left")
+        } else {
+            (&mut self.rhs, "right")
+        };
+
+        let outindex = self.deterministic_seeder.seed().0 as usize % out.len();
+
+        println!("{op_index}: Executed {op_name}: out degrees {output_degrees:?}. Writing result to {side_str}:{outindex}");
+
+        out[outindex] = TestDataSample {
+            p: clear,
+            c: encrypted.clone(),
+            producer: (op_name.clone(), op_index),
+        };
+    }
+
+    fn gen_encrypted_bool(&mut self) -> (bool, BooleanBlock) {
+        let val = self.deterministic_seeder.seed().0 % 2;
+        (val == 1, self.cks.encrypt_bool(val == 1))
+    }
+}
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn sanity_check_op_sequence_result_u64(
+    op_index: usize,
+    fn_name: &str,
+    fn_index: usize,
+    res: &RadixCiphertext,
+    res1: &RadixCiphertext,
+    decrypted: u64,
+    expected: u64,
+    lhs_p: u64,
+    rhs_p: u64,
+) {
+    // Check carries are empty and noise level is lower or equal to nominal
+    assert!(
+        res.block_carries_are_empty(),
+        "{op_index}: Non empty carries on op {fn_name}",
+    );
+    res.blocks.iter().enumerate().for_each(|(k, b)| {
+        assert!(
+            b.noise_level() <= NoiseLevel::NOMINAL,
+            "{op_index}: Noise level greater than nominal value on op {fn_name} for block {k}",
+        )
+    });
+    // Determinism check
+    assert_eq!(
+        res, res1,
+        "{op_index}: Determinism check failed on binary op {fn_name} with clear inputs {lhs_p} and {rhs_p}.",
+    );
+    // Correctness check
+    assert_eq!(
+        decrypted, expected,
+        "{op_index}: Invalid result on binary op {fn_name} with clear inputs {lhs_p} and {rhs_p} at iteration {fn_index}.",
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn sanity_check_op_sequence_result_bool<P: std::fmt::Display>(
+    op_index: usize,
+    fn_name: &str,
+    fn_index: usize,
+    res: &BooleanBlock,
+    res1: &BooleanBlock,
+    decrypted: bool,
+    expected: bool,
+    lhs_p: P,
+    rhs_p: P,
+) {
+    assert!(
+        res.0.noise_level() <= NoiseLevel::NOMINAL,
+        "{op_index}: Noise level greater than nominal value on op {fn_name}",
+    );
+    // Determinism check
+    assert_eq!(
+        res, res1,
+        "{op_index}: Determinism check failed on binary op {fn_name} with clear inputs {lhs_p} and {rhs_p}.",
+    );
+    // Correctness check
+    assert_eq!(
+        decrypted, expected,
+        "{op_index}: Invalid result on binary op {fn_name} with clear inputs {lhs_p} and {rhs_p} at iteration {fn_index}.",
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn sanity_check_op_sequence_result_i64(
+    op_index: usize,
+    fn_name: &str,
+    fn_index: usize,
+    res: &SignedRadixCiphertext,
+    res1: &SignedRadixCiphertext,
+    decrypted: i64,
+    expected: i64,
+    lhs_p: i64,
+    rhs_p: i64,
+) {
+    // Check carries are empty and noise level is lower or equal to nominal
+    assert!(
+        res.block_carries_are_empty(),
+        "{op_index}: Non empty carries on op {fn_name}",
+    );
+    res.blocks.iter().enumerate().for_each(|(k, b)| {
+        assert!(
+            b.noise_level() <= NoiseLevel::NOMINAL,
+            "{op_index}: Noise level greater than nominal value on op {fn_name} for block {k}",
+        )
+    });
+    // Determinism check
+    assert_eq!(
+        res, res1,
+        "{op_index}: Determinism check failed on binary op {fn_name} with clear inputs {lhs_p} and {rhs_p}.",
+    );
+    // Correctness check
+    assert_eq!(
+        decrypted, expected,
+        "{op_index}: Invalid result on binary op {fn_name} with clear inputs {lhs_p} and {rhs_p} at iteration {fn_index}.",
+    );
+}

--- a/tfhe/src/integer/server_key/radix_parallel/tests_long_run/test_random_op_sequence.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_long_run/test_random_op_sequence.rs
@@ -1,17 +1,21 @@
 use crate::integer::keycache::KEY_CACHE;
 use crate::integer::server_key::radix_parallel::tests_cases_unsigned::FunctionExecutor;
 use crate::integer::server_key::radix_parallel::tests_long_run::{
-    NB_CTXT_LONG_RUN, NB_TESTS_LONG_RUN,
+    get_long_test_iterations, sanity_check_op_sequence_result_bool,
+    sanity_check_op_sequence_result_u64, RandomOpSequenceDataGenerator, NB_CTXT_LONG_RUN,
 };
 use crate::integer::server_key::radix_parallel::tests_unsigned::CpuFunctionExecutor;
 use crate::integer::tests::create_parameterized_test;
 use crate::integer::{BooleanBlock, IntegerKeyKind, RadixCiphertext, RadixClientKey, ServerKey};
 use crate::shortint::parameters::*;
-use rand::Rng;
 use std::cmp::{max, min};
 use std::sync::Arc;
 
 create_parameterized_test!(random_op_sequence {
+    PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128
+});
+
+create_parameterized_test!(random_op_sequence_data_generator {
     PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128
 });
 
@@ -473,7 +477,7 @@ pub(crate) fn random_op_sequence_test<P>(
     let sks = Arc::new(sks);
     let cks = RadixClientKey::from((cks, NB_CTXT_LONG_RUN));
 
-    let mut rng = rand::thread_rng();
+    println!("Setting up operations");
 
     for x in binary_ops.iter_mut() {
         x.0.setup(&cks, sks.clone());
@@ -540,596 +544,417 @@ pub(crate) fn random_op_sequence_test<P>(
         div_rem_op_range.end..div_rem_op_range.end + scalar_div_rem_op.len();
     let log2_ops_range = scalar_div_rem_op_range.end..scalar_div_rem_op_range.end + log2_ops.len();
 
-    let mut clear_left_vec: Vec<u64> = (0..total_num_ops)
-        .map(|_| rng.gen()) // Generate random u64 values
-        .collect();
-    let mut clear_right_vec: Vec<u64> = (0..total_num_ops)
-        .map(|_| rng.gen()) // Generate random u64 values
-        .collect();
-    let mut left_vec: Vec<RadixCiphertext> = clear_left_vec
-        .iter()
-        .map(|&m| cks.encrypt(m)) // Generate random u64 values
-        .collect();
-    let mut right_vec: Vec<RadixCiphertext> = clear_right_vec
-        .iter()
-        .map(|&m| cks.encrypt(m)) // Generate random u64 values
-        .collect();
-    for fn_index in 0..NB_TESTS_LONG_RUN {
-        let i = rng.gen_range(0..total_num_ops);
-        let j = rng.gen_range(0..total_num_ops);
+    let mut datagen =
+        RandomOpSequenceDataGenerator::<u64, RadixCiphertext>::new(total_num_ops, &cks);
+    println!("random_op_sequence_test::seed = {}", datagen.get_seed().0);
+
+    for fn_index in 0..get_long_test_iterations() {
+        let (i, idx) = datagen.gen_op_index();
 
         if binary_ops_range.contains(&i) {
             let index = i - binary_ops_range.start;
             let (binary_op_executor, clear_fn, fn_name) = &mut binary_ops[index];
-            println!("Execute {fn_name}");
+            let (lhs, rhs) = datagen.gen_op_operands(idx, fn_name);
 
-            let clear_left = clear_left_vec[i];
-            let clear_right = clear_right_vec[i];
-
-            let res = binary_op_executor.execute((&left_vec[i], &right_vec[i]));
-            // Check carries are empty and noise level is nominal
-            assert!(
-                res.block_carries_are_empty(),
-                "Non empty carries on op {fn_name}"
-            );
-            res.blocks.iter().enumerate().for_each(|(k, b)| {
-                assert!(
-                    b.noise_level() <= NoiseLevel::NOMINAL,
-                    "Noise level greater than nominal value on op {fn_name} for block {k}",
-                )
-            });
+            let res = binary_op_executor.execute((&lhs.c, &rhs.c));
             // Determinism check
-            let res_1 = binary_op_executor.execute((&left_vec[i], &right_vec[i]));
-            assert_eq!(
-                res, res_1,
-                "Determinism check failed on binary op {fn_name} with clear inputs {clear_left} and {clear_right}.",
-            );
-            let input_degrees_left: Vec<u64> =
-                left_vec[i].blocks.iter().map(|b| b.degree.0).collect();
-            let input_degrees_right: Vec<u64> =
-                right_vec[i].blocks.iter().map(|b| b.degree.0).collect();
+            let res_1 = binary_op_executor.execute((&lhs.c, &rhs.c));
             let decrypted_res: u64 = cks.decrypt(&res);
-            let expected_res: u64 = clear_fn(clear_left, clear_right);
+            let expected_res: u64 = clear_fn(lhs.p, rhs.p);
 
-            if i % 2 == 0 {
-                left_vec[j] = res.clone();
-                clear_left_vec[j] = expected_res;
-            } else {
-                right_vec[j] = res.clone();
-                clear_right_vec[j] = expected_res;
-            }
+            datagen.put_op_result_random_side(expected_res, &res, fn_name, idx);
 
-            // Correctness check
-            assert_eq!(
-                decrypted_res, expected_res,
-                "Invalid result on binary op {fn_name} with clear inputs {clear_left} and {clear_right} at iteration {fn_index}. \
-                with input degrees {input_degrees_left:?} and {input_degrees_right:?}",
+            sanity_check_op_sequence_result_u64(
+                idx,
+                fn_name,
+                fn_index,
+                &res,
+                &res_1,
+                decrypted_res,
+                expected_res,
+                lhs.p,
+                rhs.p,
             );
         } else if unary_ops_range.contains(&i) {
             let index = i - unary_ops_range.start;
             let (unary_op_executor, clear_fn, fn_name) = &mut unary_ops[index];
-            println!("Execute {fn_name}");
+            let operand = datagen.gen_op_single_operand(idx, fn_name);
 
-            let input = if i % 2 == 0 {
-                &left_vec[i]
-            } else {
-                &right_vec[i]
-            };
-            let clear_input = if i % 2 == 0 {
-                clear_left_vec[i]
-            } else {
-                clear_right_vec[i]
-            };
+            let res = unary_op_executor.execute(&operand.c);
 
-            let res = unary_op_executor.execute(input);
-            // Check carries are empty and noise level is nominal
-            assert!(
-                res.block_carries_are_empty(),
-                "Non empty carries on op {fn_name}",
-            );
-            res.blocks.iter().enumerate().for_each(|(k, b)| {
-                assert!(
-                    b.noise_level() <= NoiseLevel::NOMINAL,
-                    "Noise level greater than nominal value on op {fn_name} for block {k}",
-                )
-            });
             // Determinism check
-            let res_1 = unary_op_executor.execute(input);
-            assert_eq!(
-                res, res_1,
-                "Determinism check failed on unary op {fn_name} with clear input {clear_input}.",
-            );
-            let input_degrees: Vec<u64> = input.blocks.iter().map(|b| b.degree.0).collect();
-            let decrypted_res: u64 = cks.decrypt(&res);
-            let expected_res: u64 = clear_fn(clear_input);
-            if i % 2 == 0 {
-                left_vec[j] = res.clone();
-                clear_left_vec[j] = expected_res;
-            } else {
-                right_vec[j] = res.clone();
-                clear_right_vec[j] = expected_res;
-            }
+            let res_1 = unary_op_executor.execute(&operand.c);
 
-            // Correctness check
-            assert_eq!(
-                decrypted_res, expected_res,
-                "Invalid result on unary op {fn_name} with clear input {clear_input} at iteration {fn_index}, with input degree {input_degrees:?}.",
+            let decrypted_res: u64 = cks.decrypt(&res);
+            let expected_res: u64 = clear_fn(operand.p);
+
+            datagen.put_op_result_random_side(expected_res, &res, fn_name, idx);
+
+            sanity_check_op_sequence_result_u64(
+                idx,
+                fn_name,
+                fn_index,
+                &res,
+                &res_1,
+                decrypted_res,
+                expected_res,
+                operand.p,
+                operand.p,
             );
         } else if scalar_binary_ops_range.contains(&i) {
             let index = i - scalar_binary_ops_range.start;
             let (scalar_binary_op_executor, clear_fn, fn_name) = &mut scalar_binary_ops[index];
-            println!("Execute {fn_name}");
+            let (lhs, rhs) = datagen.gen_op_operands(idx, fn_name);
 
-            let clear_left = clear_left_vec[i];
-            let clear_right = clear_right_vec[i];
+            let res = scalar_binary_op_executor.execute((&lhs.c, rhs.p));
+            let res_1 = scalar_binary_op_executor.execute((&lhs.c, rhs.p));
 
-            let res = scalar_binary_op_executor.execute((&left_vec[i], clear_right_vec[i]));
-            // Check carries are empty and noise level is lower or equal to nominal
-            assert!(
-                res.block_carries_are_empty(),
-                "Non empty carries on op {fn_name}",
-            );
-            res.blocks.iter().enumerate().for_each(|(k, b)| {
-                assert!(
-                    b.noise_level() <= NoiseLevel::NOMINAL,
-                    "Noise level greater than nominal value on op {fn_name} for block {k}",
-                )
-            });
-            // Determinism check
-            let res_1 = scalar_binary_op_executor.execute((&left_vec[i], clear_right_vec[i]));
-            assert_eq!(
-                res, res_1,
-                "Determinism check failed on binary op {fn_name} with clear inputs {clear_left} and {clear_right}.",
-            );
             let decrypted_res: u64 = cks.decrypt(&res);
-            let expected_res: u64 = clear_fn(clear_left, clear_right);
-            let input_degrees_left: Vec<u64> =
-                left_vec[i].blocks.iter().map(|b| b.degree.0).collect();
+            let expected_res: u64 = clear_fn(lhs.p, rhs.p);
 
-            if i % 2 == 0 {
-                left_vec[j] = res.clone();
-                clear_left_vec[j] = expected_res;
-            } else {
-                right_vec[j] = res.clone();
-                clear_right_vec[j] = expected_res;
-            }
+            datagen.put_op_result_random_side(expected_res, &res, fn_name, idx);
 
-            // Correctness check
-            assert_eq!(
-                decrypted_res, expected_res,
-                "Invalid result on binary op {fn_name} with clear inputs {clear_left} and {clear_right} at iteration {fn_index} and input degree {input_degrees_left:?}",
+            sanity_check_op_sequence_result_u64(
+                idx,
+                fn_name,
+                fn_index,
+                &res,
+                &res_1,
+                decrypted_res,
+                expected_res,
+                lhs.p,
+                rhs.p,
             );
         } else if overflowing_ops_range.contains(&i) {
             let index = i - overflowing_ops_range.start;
             let (overflowing_op_executor, clear_fn, fn_name) = &mut overflowing_ops[index];
-            println!("Execute {fn_name}");
 
-            let clear_left = clear_left_vec[i];
-            let clear_right = clear_right_vec[i];
+            let (lhs, rhs) = datagen.gen_op_operands(idx, fn_name);
 
-            let (res, overflow) = overflowing_op_executor.execute((&left_vec[i], &right_vec[i]));
-            // Check carries are empty and noise level is lower or equal to nominal
-            assert!(
-                res.block_carries_are_empty(),
-                "Non empty carries on op {fn_name}",
-            );
-            res.blocks.iter().enumerate().for_each(|(k, b)| {
-                assert!(
-                    b.noise_level() <= NoiseLevel::NOMINAL,
-                    "Noise level greater than nominal value on op {fn_name} for block {k}",
-                )
-            });
-            assert!(
-                overflow.0.noise_level() <= NoiseLevel::NOMINAL,
-                "Noise level greater than nominal value on overflow for op {fn_name}",
-            );
+            let (res, overflow) = overflowing_op_executor.execute((&lhs.c, &rhs.c));
             // Determinism check
-            let (res_1, overflow_1) =
-                overflowing_op_executor.execute((&left_vec[i], &right_vec[i]));
-            assert_eq!(
-                res, res_1,
-                "Determinism check failed on binary op {fn_name} with clear inputs {clear_left} and {clear_right}.",
-            );
-            assert_eq!(
-                overflow, overflow_1,
-                "Determinism check failed on binary op {fn_name} with clear inputs {clear_left} and {clear_right} on the overflow.",
-            );
-            let input_degrees_left: Vec<u64> =
-                left_vec[i].blocks.iter().map(|b| b.degree.0).collect();
-            let input_degrees_right: Vec<u64> =
-                right_vec[i].blocks.iter().map(|b| b.degree.0).collect();
+            let (res_1, overflow_1) = overflowing_op_executor.execute((&lhs.c, &rhs.c));
+
             let decrypted_res: u64 = cks.decrypt(&res);
             let decrypted_overflow = cks.decrypt_bool(&overflow);
-            let (expected_res, expected_overflow) = clear_fn(clear_left, clear_right);
+            let (expected_res, expected_overflow) = clear_fn(lhs.p, rhs.p);
 
-            if i % 2 == 0 {
-                left_vec[j] = res.clone();
-                clear_left_vec[j] = expected_res;
-            } else {
-                right_vec[j] = res.clone();
-                clear_right_vec[j] = expected_res;
-            }
+            datagen.put_op_result_random_side(expected_res, &res, fn_name, idx);
 
-            // Correctness check
-            assert_eq!(
-                decrypted_res, expected_res,
-                "Invalid result on op {fn_name} with clear inputs {clear_left} and {clear_right} at iteration {fn_index}, with input degrees {input_degrees_left:?} and {input_degrees_right:?}.",
+            sanity_check_op_sequence_result_u64(
+                idx,
+                fn_name,
+                fn_index,
+                &res,
+                &res_1,
+                decrypted_res,
+                expected_res,
+                lhs.p,
+                rhs.p,
             );
-            assert_eq!(
-                decrypted_overflow, expected_overflow,
-                "Invalid overflow on op {fn_name} with clear inputs {clear_left} and {clear_right}.",
+
+            sanity_check_op_sequence_result_bool(
+                idx,
+                fn_name,
+                fn_index,
+                &overflow,
+                &overflow_1,
+                decrypted_overflow,
+                expected_overflow,
+                lhs.p,
+                rhs.p,
             );
         } else if scalar_overflowing_ops_range.contains(&i) {
             let index = i - scalar_overflowing_ops_range.start;
             let (scalar_overflowing_op_executor, clear_fn, fn_name) =
                 &mut scalar_overflowing_ops[index];
-            println!("Execute {fn_name}");
 
-            let clear_left = clear_left_vec[i];
-            let clear_right = clear_right_vec[i];
+            let (lhs, rhs) = datagen.gen_op_operands(idx, fn_name);
 
-            let (res, overflow) =
-                scalar_overflowing_op_executor.execute((&left_vec[i], clear_right_vec[i]));
+            let (res, overflow) = scalar_overflowing_op_executor.execute((&lhs.c, rhs.p));
             // Check carries are empty and noise level is lower or equal to nominal
-            assert!(
-                res.block_carries_are_empty(),
-                "Non empty carries on op {fn_name}",
-            );
-            res.blocks.iter().enumerate().for_each(|(k, b)| {
-                assert!(
-                    b.noise_level() <= NoiseLevel::NOMINAL,
-                    "Noise level greater than nominal value on op {fn_name} for block {k}",
-                )
-            });
-            assert!(
-                overflow.0.noise_level() <= NoiseLevel::NOMINAL,
-                "Noise level greater than nominal value on overflow for op {fn_name}",
-            );
-            let input_degrees_left: Vec<u64> =
-                left_vec[i].blocks.iter().map(|b| b.degree.0).collect();
+
             // Determinism check
-            let (res_1, overflow_1) =
-                scalar_overflowing_op_executor.execute((&left_vec[i], clear_right_vec[i]));
-            assert_eq!(
-                res, res_1,
-                "Determinism check failed on binary op {fn_name} with clear inputs {clear_left} and {clear_right} with input degrees {input_degrees_left:?}.",
-            );
-            assert_eq!(
-                overflow, overflow_1,
-                "Determinism check failed on binary op {fn_name} with clear inputs {clear_left} and {clear_right} on the overflow.",
-            );
+            let (res_1, overflow_1) = scalar_overflowing_op_executor.execute((&lhs.c, rhs.p));
+
             let decrypted_res: u64 = cks.decrypt(&res);
             let decrypted_overflow = cks.decrypt_bool(&overflow);
-            let (expected_res, expected_overflow) = clear_fn(clear_left, clear_right);
+            let (expected_res, expected_overflow) = clear_fn(lhs.p, rhs.p);
 
-            if i % 2 == 0 {
-                left_vec[j] = res.clone();
-                clear_left_vec[j] = expected_res;
-            } else {
-                right_vec[j] = res.clone();
-                clear_right_vec[j] = expected_res;
-            }
+            datagen.put_op_result_random_side(expected_res, &res, fn_name, idx);
 
-            // Correctness check
-            assert_eq!(
-                decrypted_res, expected_res,
-                "Invalid result on op {fn_name} with clear inputs {clear_left} and {clear_right} at iteration {fn_index}.",
+            sanity_check_op_sequence_result_u64(
+                idx,
+                fn_name,
+                fn_index,
+                &res,
+                &res_1,
+                decrypted_res,
+                expected_res,
+                lhs.p,
+                rhs.p,
             );
-            assert_eq!(
-                decrypted_overflow, expected_overflow,
-                "Invalid overflow on op {fn_name} with clear inputs {clear_left} and {clear_right}.",
+
+            sanity_check_op_sequence_result_bool(
+                idx,
+                fn_name,
+                fn_index,
+                &overflow,
+                &overflow_1,
+                decrypted_overflow,
+                expected_overflow,
+                lhs.p,
+                rhs.p,
             );
         } else if comparison_ops_range.contains(&i) {
             let index = i - comparison_ops_range.start;
             let (comparison_op_executor, clear_fn, fn_name) = &mut comparison_ops[index];
-            println!("Execute {fn_name}");
 
-            let clear_left = clear_left_vec[i];
-            let clear_right = clear_right_vec[i];
+            let (lhs, rhs) = datagen.gen_op_operands(idx, fn_name);
 
-            let res = comparison_op_executor.execute((&left_vec[i], &right_vec[i]));
-            assert!(
-                res.0.noise_level() <= NoiseLevel::NOMINAL,
-                "Noise level greater than nominal value on op {fn_name}",
-            );
-            // Determinism check
-            let res_1 = comparison_op_executor.execute((&left_vec[i], &right_vec[i]));
-            assert_eq!(
-                res, res_1,
-                "Determinism check failed on binary op {fn_name} with clear inputs {clear_left} and {clear_right}.",
-            );
-            let input_degrees_left: Vec<u64> =
-                left_vec[i].blocks.iter().map(|b| b.degree.0).collect();
-            let input_degrees_right: Vec<u64> =
-                right_vec[i].blocks.iter().map(|b| b.degree.0).collect();
+            let res = comparison_op_executor.execute((&lhs.c, &rhs.c));
+            let res_1 = comparison_op_executor.execute((&lhs.c, &rhs.c));
             let decrypted_res = cks.decrypt_bool(&res);
-            let expected_res = clear_fn(clear_left, clear_right);
+            let expected_res = clear_fn(lhs.p, rhs.p);
 
-            // Correctness check
-            assert_eq!(
-                decrypted_res, expected_res,
-                "Invalid result on binary op {fn_name} with clear inputs {clear_left} and {clear_right} at iteration {fn_index} with input degrees {input_degrees_left:?} and {input_degrees_right:?}.",
+            let res_ct = sks.cast_to_unsigned(
+                res.clone().into_radix::<RadixCiphertext>(1, &sks),
+                NB_CTXT_LONG_RUN,
             );
+            datagen.put_op_result_random_side(expected_res as u64, &res_ct, fn_name, idx);
 
-            let res_ct: RadixCiphertext = res.into_radix(1, &sks);
-            if i % 2 == 0 {
-                left_vec[j] = sks.cast_to_unsigned(res_ct, NB_CTXT_LONG_RUN);
-                clear_left_vec[j] = expected_res as u64;
-            } else {
-                right_vec[j] = sks.cast_to_unsigned(res_ct, NB_CTXT_LONG_RUN);
-                clear_right_vec[j] = expected_res as u64;
-            }
+            sanity_check_op_sequence_result_bool(
+                idx,
+                fn_name,
+                fn_index,
+                &res,
+                &res_1,
+                decrypted_res,
+                expected_res,
+                lhs.p,
+                rhs.p,
+            );
         } else if scalar_comparison_ops_range.contains(&i) {
             let index = i - scalar_comparison_ops_range.start;
             let (scalar_comparison_op_executor, clear_fn, fn_name) =
                 &mut scalar_comparison_ops[index];
-            println!("Execute {fn_name}");
 
-            let clear_left = clear_left_vec[i];
-            let clear_right = clear_right_vec[i];
+            let (lhs, rhs) = datagen.gen_op_operands(idx, fn_name);
 
-            let res = scalar_comparison_op_executor.execute((&left_vec[i], clear_right_vec[i]));
-            assert!(
-                res.0.noise_level() <= NoiseLevel::NOMINAL,
-                "Noise level greater than nominal value on op {fn_name}",
-            );
+            let res = scalar_comparison_op_executor.execute((&lhs.c, rhs.p));
             // Determinism check
-            let res_1 = scalar_comparison_op_executor.execute((&left_vec[i], clear_right_vec[i]));
-            assert_eq!(
-                res, res_1,
-                "Determinism check failed on binary op {fn_name} with clear inputs {clear_left} and {clear_right}.",
-            );
-            let input_degrees_left: Vec<u64> =
-                left_vec[i].blocks.iter().map(|b| b.degree.0).collect();
-            let decrypted_res = cks.decrypt_bool(&res);
-            let expected_res = clear_fn(clear_left, clear_right);
+            let res_1 = scalar_comparison_op_executor.execute((&lhs.c, rhs.p));
 
-            // Correctness check
-            assert_eq!(
-                decrypted_res, expected_res,
-                "Invalid result on binary op {fn_name} with clear inputs {clear_left} and {clear_right} at iteration {fn_index} with input degrees {input_degrees_left:?}.",
+            let decrypted_res = cks.decrypt_bool(&res);
+            let expected_res = clear_fn(lhs.p, rhs.p);
+
+            let res_ct: RadixCiphertext = sks.cast_to_unsigned(
+                res.clone().into_radix::<RadixCiphertext>(1, &sks),
+                NB_CTXT_LONG_RUN,
             );
-            let res_ct: RadixCiphertext = res.into_radix(1, &sks);
-            if i % 2 == 0 {
-                left_vec[j] = sks.cast_to_unsigned(res_ct, NB_CTXT_LONG_RUN);
-                clear_left_vec[j] = expected_res as u64;
-            } else {
-                right_vec[j] = sks.cast_to_unsigned(res_ct, NB_CTXT_LONG_RUN);
-                clear_right_vec[j] = expected_res as u64;
-            }
+            datagen.put_op_result_random_side(expected_res as u64, &res_ct, fn_name, idx);
+
+            sanity_check_op_sequence_result_bool(
+                idx,
+                fn_name,
+                fn_index,
+                &res,
+                &res_1,
+                decrypted_res,
+                expected_res,
+                lhs.p,
+                rhs.p,
+            );
         } else if select_op_range.contains(&i) {
             let index = i - select_op_range.start;
             let (select_op_executor, clear_fn, fn_name) = &mut select_op[index];
-            println!("Execute {fn_name}");
 
-            let clear_left = clear_left_vec[i];
-            let clear_right = clear_right_vec[i];
-            let clear_bool: bool = rng.gen_bool(0.5);
-            let bool_input = cks.encrypt_bool(clear_bool);
+            let (lhs, rhs) = datagen.gen_op_operands(idx, fn_name);
 
-            let res = select_op_executor.execute((&bool_input, &left_vec[i], &right_vec[i]));
-            // Check carries are empty and noise level is lower or equal to nominal
-            assert!(
-                res.block_carries_are_empty(),
-                "Non empty carries on op {fn_name}",
-            );
-            res.blocks.iter().enumerate().for_each(|(k, b)| {
-                assert!(
-                    b.noise_level() <= NoiseLevel::NOMINAL,
-                    "Noise level greater than nominal value on op {fn_name} for block {k}",
-                )
-            });
+            let (clear_bool, bool_input) = datagen.gen_encrypted_bool();
+
+            let res = select_op_executor.execute((&bool_input, &lhs.c, &rhs.c));
             // Determinism check
-            let res_1 = select_op_executor.execute((&bool_input, &left_vec[i], &right_vec[i]));
-            assert_eq!(
-                res, res_1,
-                "Determinism check failed on binary op {fn_name} with clear inputs {clear_left}, {clear_right} and {clear_bool}.",
-            );
-            let input_degrees_left: Vec<u64> =
-                left_vec[i].blocks.iter().map(|b| b.degree.0).collect();
-            let input_degrees_right: Vec<u64> =
-                right_vec[i].blocks.iter().map(|b| b.degree.0).collect();
-            let decrypted_res: u64 = cks.decrypt(&res);
-            let expected_res = clear_fn(clear_bool, clear_left, clear_right);
+            let res_1 = select_op_executor.execute((&bool_input, &lhs.c, &rhs.c));
 
-            // Correctness check
-            assert_eq!(
-                decrypted_res, expected_res,
-                "Invalid result on op {fn_name} with clear inputs {clear_left}, {clear_right} and {clear_bool} at iteration {fn_index} with input degrees {input_degrees_left:?} and {input_degrees_right:?}.",
+            let decrypted_res: u64 = cks.decrypt(&res);
+            let expected_res = clear_fn(clear_bool, lhs.p, rhs.p);
+
+            datagen.put_op_result_random_side(expected_res, &res, fn_name, idx);
+
+            sanity_check_op_sequence_result_u64(
+                idx,
+                fn_name,
+                fn_index,
+                &res,
+                &res_1,
+                decrypted_res,
+                expected_res,
+                lhs.p,
+                rhs.p,
             );
-            if i % 2 == 0 {
-                left_vec[j] = res.clone();
-                clear_left_vec[j] = expected_res;
-            } else {
-                right_vec[j] = res.clone();
-                clear_right_vec[j] = expected_res;
-            }
         } else if div_rem_op_range.contains(&i) {
             let index = i - div_rem_op_range.start;
             let (div_rem_op_executor, clear_fn, fn_name) = &mut div_rem_op[index];
-            println!("Execute {fn_name}");
 
-            let clear_left = clear_left_vec[i];
-            let clear_right = clear_right_vec[i];
-            if clear_right == 0 {
+            let (lhs, rhs) = datagen.gen_op_operands(idx, fn_name);
+
+            if rhs.p == 0 {
+                println!("{idx}: {fn_name} execution skipped because scalar is 0.");
                 continue;
             }
-            let (res_q, res_r) = div_rem_op_executor.execute((&left_vec[i], &right_vec[i]));
+            let (res_q, res_r) = div_rem_op_executor.execute((&lhs.c, &rhs.c));
             // Check carries are empty and noise level is lower or equal to nominal
-            assert!(
-                res_q.block_carries_are_empty(),
-                "Non empty carries on op {fn_name}",
-            );
-            assert!(
-                res_r.block_carries_are_empty(),
-                "Non empty carries on op {fn_name}",
-            );
-            res_q.blocks.iter().enumerate().for_each(|(k, b)| {
-                assert!(
-                    b.noise_level() <= NoiseLevel::NOMINAL,
-                    "Noise level greater than nominal value on op {fn_name} for block {k}",
-                )
-            });
-            res_r.blocks.iter().enumerate().for_each(|(k, b)| {
-                assert!(
-                    b.noise_level() <= NoiseLevel::NOMINAL,
-                    "Noise level greater than nominal value on op {fn_name} for block {k}",
-                )
-            });
+
             // Determinism check
-            let (res_q1, res_r1) = div_rem_op_executor.execute((&left_vec[i], &right_vec[i]));
-            assert_eq!(
-                res_q, res_q1,
-                "Determinism check failed on binary op {fn_name} with clear inputs {clear_left} and {clear_right}.",
-            );
-            assert_eq!(
-                res_r, res_r1,
-                "Determinism check failed on binary op {fn_name} with clear inputs {clear_left} and {clear_right}.",
-            );
-            let input_degrees_left: Vec<u64> =
-                left_vec[i].blocks.iter().map(|b| b.degree.0).collect();
-            let input_degrees_right: Vec<u64> =
-                right_vec[i].blocks.iter().map(|b| b.degree.0).collect();
+            let (res_q1, res_r1) = div_rem_op_executor.execute((&lhs.c, &rhs.c));
+
             let decrypted_res_q: u64 = cks.decrypt(&res_q);
             let decrypted_res_r: u64 = cks.decrypt(&res_r);
-            let (expected_res_q, expected_res_r) = clear_fn(clear_left, clear_right);
+            let (expected_res_q, expected_res_r) = clear_fn(lhs.p, rhs.p);
 
-            // Correctness check
-            assert_eq!(
-                decrypted_res_q, expected_res_q,
-                "Invalid result on op {fn_name} with clear inputs {clear_left}, {clear_right} at iteration {fn_index} with input degrees {input_degrees_left:?} and {input_degrees_right:?}",
+            datagen.put_op_result_random_side(expected_res_q, &res_q, fn_name, idx);
+
+            sanity_check_op_sequence_result_u64(
+                idx,
+                fn_name,
+                fn_index,
+                &res_r,
+                &res_r1,
+                decrypted_res_r,
+                expected_res_r,
+                lhs.p,
+                rhs.p,
             );
-            assert_eq!(
-                decrypted_res_r, expected_res_r,
-                "Invalid result on op {fn_name} with clear inputs {clear_left}, {clear_right} at iteration {fn_index} with input degrees {input_degrees_left:?} and {input_degrees_right:?}",
+
+            sanity_check_op_sequence_result_u64(
+                idx,
+                fn_name,
+                fn_index,
+                &res_q,
+                &res_q1,
+                decrypted_res_q,
+                expected_res_q,
+                lhs.p,
+                rhs.p,
             );
-            if i % 2 == 0 {
-                left_vec[j] = res_q.clone();
-                clear_left_vec[j] = expected_res_q;
-            } else {
-                right_vec[j] = res_q.clone();
-                clear_right_vec[j] = expected_res_q;
-            }
         } else if scalar_div_rem_op_range.contains(&i) {
             let index = i - scalar_div_rem_op_range.start;
             let (scalar_div_rem_op_executor, clear_fn, fn_name) = &mut scalar_div_rem_op[index];
-            println!("Execute {fn_name}");
+            let (lhs, rhs) = datagen.gen_op_operands(idx, fn_name);
 
-            let clear_left = clear_left_vec[i];
-            let clear_right = clear_right_vec[i];
-            if clear_right == 0 {
+            if rhs.p == 0 {
+                println!("{idx}: {fn_name} execution skipped because scalar is 0.");
                 continue;
             }
-            let (res_q, res_r) =
-                scalar_div_rem_op_executor.execute((&left_vec[i], clear_right_vec[i]));
+            let (res_q, res_r) = scalar_div_rem_op_executor.execute((&lhs.c, rhs.p));
             // Check carries are empty and noise level is lower or equal to nominal
-            assert!(
-                res_q.block_carries_are_empty(),
-                "Non empty carries on op {fn_name}",
-            );
-            assert!(
-                res_r.block_carries_are_empty(),
-                "Non empty carries on op {fn_name}",
-            );
-            res_q.blocks.iter().enumerate().for_each(|(k, b)| {
-                assert!(
-                    b.noise_level() <= NoiseLevel::NOMINAL,
-                    "Noise level greater than nominal value on op {fn_name} for block {k}",
-                )
-            });
-            res_r.blocks.iter().enumerate().for_each(|(k, b)| {
-                assert!(
-                    b.noise_level() <= NoiseLevel::NOMINAL,
-                    "Noise level greater than nominal value on op {fn_name} for block {k}",
-                )
-            });
+
             // Determinism check
-            let (res_q1, res_r1) =
-                scalar_div_rem_op_executor.execute((&left_vec[i], clear_right_vec[i]));
-            assert_eq!(
-                res_q, res_q1,
-                "Determinism check failed on binary op {fn_name} with clear inputs {clear_left} and {clear_right}.",
-            );
-            assert_eq!(
-                res_r, res_r1,
-                "Determinism check failed on binary op {fn_name} with clear inputs {clear_left} and {clear_right}.",
-            );
-            let input_degrees_left: Vec<u64> =
-                left_vec[i].blocks.iter().map(|b| b.degree.0).collect();
+            let (res_q1, res_r1) = scalar_div_rem_op_executor.execute((&lhs.c, rhs.p));
+
             let decrypted_res_q: u64 = cks.decrypt(&res_q);
             let decrypted_res_r: u64 = cks.decrypt(&res_r);
-            let (expected_res_q, expected_res_r) = clear_fn(clear_left, clear_right);
+            let (expected_res_q, expected_res_r) = clear_fn(lhs.p, rhs.p);
 
-            // Correctness check
-            assert_eq!(
-                decrypted_res_q, expected_res_q,
-                "Invalid result on op {fn_name} with clear inputs {clear_left}, {clear_right} at iteration {fn_index} with input degrees {input_degrees_left:?}.",
+            datagen.put_op_result_random_side(expected_res_r, &res_r, fn_name, idx);
+
+            sanity_check_op_sequence_result_u64(
+                idx,
+                fn_name,
+                fn_index,
+                &res_r,
+                &res_r1,
+                decrypted_res_r,
+                expected_res_r,
+                lhs.p,
+                rhs.p,
             );
-            assert_eq!(
-                decrypted_res_r, expected_res_r,
-                "Invalid result on op {fn_name} with clear inputs {clear_left}, {clear_right} at iteration {fn_index} with input degrees {input_degrees_left:?}.",
+
+            sanity_check_op_sequence_result_u64(
+                idx,
+                fn_name,
+                fn_index,
+                &res_q,
+                &res_q1,
+                decrypted_res_q,
+                expected_res_q,
+                lhs.p,
+                rhs.p,
             );
-            if i % 2 == 0 {
-                left_vec[j] = res_r.clone();
-                clear_left_vec[j] = expected_res_r;
-            } else {
-                right_vec[j] = res_r.clone();
-                clear_right_vec[j] = expected_res_r;
-            }
         } else if log2_ops_range.contains(&i) {
             let index = i - log2_ops_range.start;
             let (log2_executor, clear_fn, fn_name) = &mut log2_ops[index];
-            println!("Execute {fn_name}");
 
-            let input = if i % 2 == 0 {
-                &left_vec[i]
-            } else {
-                &right_vec[i]
-            };
-            let clear_input = if i % 2 == 0 {
-                clear_left_vec[i]
-            } else {
-                clear_right_vec[i]
-            };
-            if clear_input == 0 {
+            let mut operand = datagen.gen_op_single_operand(idx, fn_name);
+
+            let mut iters = 0;
+            while operand.p == 0 && iters < 10 {
+                operand = datagen.gen_op_single_operand(idx, fn_name);
+                iters += 1;
+            }
+
+            if operand.p == 0 {
+                println!("{idx}: {fn_name} execution skipped because input is 0.");
                 continue;
             }
 
-            let res = log2_executor.execute(input);
-            // Check carries are empty and noise level is lower or equal to nominal
-            assert!(
-                res.block_carries_are_empty(),
-                "Non empty carries on op {fn_name}",
-            );
-            res.blocks.iter().enumerate().for_each(|(k, b)| {
-                assert!(
-                    b.noise_level() <= NoiseLevel::NOMINAL,
-                    "Noise level greater than nominal value on op {fn_name} for block {k}",
-                )
-            });
+            let res = log2_executor.execute(&operand.c);
             // Determinism check
-            let res_1 = log2_executor.execute(input);
-            assert_eq!(
-                res, res_1,
-                "Determinism check failed on op {fn_name} with clear input {clear_input}.",
-            );
-            let input_degrees: Vec<u64> = input.blocks.iter().map(|b| b.degree.0).collect();
-            let cast_res = sks.cast_to_unsigned(res, NB_CTXT_LONG_RUN);
-            let decrypted_res: u64 = cks.decrypt(&cast_res);
-            let expected_res = clear_fn(clear_input);
+            let res_1 = log2_executor.execute(&operand.c);
 
-            // Correctness check
-            assert_eq!(
-                decrypted_res, expected_res,
-                "Invalid result on op {fn_name} with clear input {clear_input} at iteration {fn_index} with input degrees {input_degrees:?}.",
+            let cast_res = sks.cast_to_unsigned(res.clone(), NB_CTXT_LONG_RUN);
+            let decrypted_res: u64 = cks.decrypt(&cast_res);
+            let expected_res = clear_fn(operand.p);
+
+            datagen.put_op_result_random_side(expected_res, &cast_res, fn_name, idx);
+
+            sanity_check_op_sequence_result_u64(
+                idx,
+                fn_name,
+                fn_index,
+                &res,
+                &res_1,
+                decrypted_res,
+                expected_res,
+                operand.p,
+                operand.p,
             );
-            if i % 2 == 0 {
-                left_vec[j] = cast_res.clone();
-                clear_left_vec[j] = expected_res;
-            } else {
-                right_vec[j] = cast_res.clone();
-                clear_right_vec[j] = expected_res;
-            }
         }
+    }
+}
+
+pub(crate) fn random_op_sequence_data_generator<P>(param: P)
+where
+    P: Into<TestParameters> + Clone,
+{
+    let param = param.into();
+    let (cks, _sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
+    let cks = RadixClientKey::from((cks, NB_CTXT_LONG_RUN));
+
+    let datagen = RandomOpSequenceDataGenerator::<u64, RadixCiphertext>::new(1000, &cks);
+
+    let datagen2 = RandomOpSequenceDataGenerator::<u64, RadixCiphertext>::new_with_seed(
+        1000,
+        datagen.get_seed(),
+        &cks,
+    );
+
+    for (v1, v2) in datagen.lhs.iter().zip(datagen2.lhs.iter()) {
+        assert_eq!(v1.p, v2.p);
+    }
+
+    for (v1, v2) in datagen.rhs.iter().zip(datagen2.rhs.iter()) {
+        assert_eq!(v1.p, v2.p);
+    }
+
+    let datagen = RandomOpSequenceDataGenerator::<u64, RadixCiphertext>::new(1000, &cks);
+
+    for (v1, v2) in datagen.lhs.iter().zip(datagen2.lhs.iter()) {
+        assert_ne!(v1.p, v2.p);
+    }
+
+    for (v1, v2) in datagen.rhs.iter().zip(datagen2.rhs.iter()) {
+        assert_ne!(v1.p, v2.p);
     }
 }


### PR DESCRIPTION
Adds the long run tests workflow on PRs with a new flag that reduces the number of test iterations (to 20 instead of 20 000).  I also added random GPU subset selection

Closes https://github.com/zama-ai/tfhe-rs-internal/issues/1031

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/2492)
<!-- Reviewable:end -->

TODO:
- refactor last asserts in unsigned test
- display producer for single input functions
- fix slack notification