### PR TITLE
feat(hpu): centered_modswitch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -514,6 +514,12 @@ clippy_hpu_backend: install_rs_check_toolchain
 	RUSTFLAGS="$(RUSTFLAGS)" cargo "$(CARGO_RS_CHECK_TOOLCHAIN)" clippy --all-targets \
 		-p tfhe-hpu-backend -- --no-deps -D warnings
 
+.PHONY: clippy_hpu_mockup # Run clippy lints on tfhe-hpu-mockup
+clippy_hpu: install_rs_check_toolchain
+	RUSTFLAGS="$(RUSTFLAGS)" cargo "$(CARGO_RS_CHECK_TOOLCHAIN)" clippy \
+		--all-targets \
+		-p tfhe-hpu-backend -- --no-deps -D warnings
+
 .PHONY: check_rust_bindings_did_not_change # Check rust bindings are up to date for tfhe-cuda-backend
 check_rust_bindings_did_not_change:
 	cargo build -p tfhe-cuda-backend && "$(MAKE)" fmt_gpu && \
@@ -1554,7 +1560,7 @@ pcc_gpu: check_rust_bindings_did_not_change clippy_rustdoc_gpu \
 clippy_gpu clippy_cuda_backend clippy_bench_gpu check_compile_tests_benches_gpu
 
 .PHONY: pcc_hpu # pcc stands for pre commit checks for HPU compilation
-pcc_hpu: clippy_hpu clippy_hpu_backend test_integer_hpu_mockup_ci_fast
+pcc_hpu: clippy_hpu clippy_hpu_backend clippy_hpu_mockup test_integer_hpu_mockup_ci_fast
 
 .PHONY: fpcc # pcc stands for pre commit checks, the f stands for fast
 fpcc: no_tfhe_typo no_dbg_log check_parameter_export_ok check_fmt check_typos lint_doc \

--- a/backends/tfhe-hpu-backend/config_store/sim/hpu_config.toml
+++ b/backends/tfhe-hpu-backend/config_store/sim/hpu_config.toml
@@ -13,7 +13,6 @@
   bpip_use = true
   bpip_use_opportunism = true
   bpip_timeout = 100_000
-  mod_switch_mean_comp = true
 
 [board]
   ct_mem = 32768

--- a/backends/tfhe-hpu-backend/config_store/u55c_gf64/hpu_config.toml
+++ b/backends/tfhe-hpu-backend/config_store/u55c_gf64/hpu_config.toml
@@ -11,7 +11,6 @@
   bpip_use = true
   bpip_use_opportunism = true
   bpip_timeout = 100_000
-  mod_switch_mean_comp = true
 
 [board]
   ct_mem = 4096

--- a/backends/tfhe-hpu-backend/config_store/v80/hpu_config.toml
+++ b/backends/tfhe-hpu-backend/config_store/v80/hpu_config.toml
@@ -16,7 +16,6 @@
   bpip_use = true
   bpip_use_opportunism = true
   bpip_timeout = 100_000
-  mod_switch_mean_comp = true
 
 [board]
   ct_mem = 32768

--- a/backends/tfhe-hpu-backend/config_store/v80_archives/psi64.hpu
+++ b/backends/tfhe-hpu-backend/config_store/v80_archives/psi64.hpu
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4c17c71cedd183daeabf93649b61b294619445b695754606066051b10ecef27c
-size 83001412
+oid sha256:0a0798a1170982be0ce714bbf0d4cdfbe3c069e328e8847053c20d7b9b347ef6
+size 83225193

--- a/backends/tfhe-hpu-backend/src/entities/mod.rs
+++ b/backends/tfhe-hpu-backend/src/entities/mod.rs
@@ -2,8 +2,9 @@ pub(crate) mod traits;
 
 pub mod parameters;
 pub use parameters::{
-    HpuIscParameters, HpuKeyswitchParameters, HpuNoiseDistributionInput, HpuNttCoreArch,
-    HpuNttParameters, HpuPBSParameters, HpuParameters, HpuPcParameters, HpuRegfileParameters,
+    HpuIscParameters, HpuKeyswitchParameters, HpuModulusSwitchType, HpuNoiseDistributionInput,
+    HpuNttCoreArch, HpuNttParameters, HpuPBSParameters, HpuParameters, HpuPcParameters,
+    HpuRegfileParameters,
 };
 
 pub mod glwe_ciphertext;

--- a/backends/tfhe-hpu-backend/src/entities/parameters.rs
+++ b/backends/tfhe-hpu-backend/src/entities/parameters.rs
@@ -8,6 +8,12 @@ pub enum HpuNoiseDistributionInput {
     TUniformBound(u32),
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub enum HpuModulusSwitchType {
+    Standard,
+    CenteredMeanNoiseReduction,
+}
+
 /// Parameters related to Tfhe scheme computation
 /// Couldn't rely on ClassicPBSParameters to prevent dependency loop
 #[derive(Clone, Copy, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -24,7 +30,10 @@ pub struct HpuPBSParameters {
     pub message_width: usize,
     pub carry_width: usize,
     pub ciphertext_width: usize,
+    pub log2_p_fail: f64,
+    pub modulus_switch_type: HpuModulusSwitchType,
 }
+
 // Manual implementation of Eq trait
 // Indeed, we can handle strict comparison of f64
 impl std::cmp::Eq for HpuPBSParameters {}

--- a/backends/tfhe-hpu-backend/src/fw/fw_impl/llt/vardeg.rs
+++ b/backends/tfhe-hpu-backend/src/fw/fw_impl/llt/vardeg.rs
@@ -109,7 +109,7 @@ impl VecVarCellDeg {
         mut self,
         max_deg: &VarDeg,
     ) -> <Vec<Vec<VarCellDeg>> as IntoIterator>::IntoIter {
-        trace!(target: "ilp:deg_chunks", "len: {:?}, {:?}", self.len(), self.0);
+        trace!(target: "llt:deg_chunks", "len: {:?}, {:?}", self.len(), self.0);
 
         let mut res: Vec<Vec<VarCellDeg>> = Vec::new();
         let mut acc: VarDeg = VarDeg::default();
@@ -130,14 +130,16 @@ impl VecVarCellDeg {
                 acc = VarDeg::default();
                 chunk = Vec::new();
             }
-            trace!(target: "ilp:deg_chunks:loop", "len: {:?}, {:?}, chunk: {:?},
-                acc: {:?}", self.len(), self.0, chunk, acc);
+            trace!(target: "llt:deg_chunks:loop", "len: {:?}, {:?}, chunk: {:?}, acc: {:?}",
+                self.len(), self.0, chunk, acc);
         }
 
         // Any remaining chunk is appended
         if !chunk.is_empty() {
             res.push(chunk);
         }
+
+        trace!(target: "llt:deg_chunks:ret", "res: {:?}", res);
 
         res.into_iter()
     }

--- a/backends/tfhe-hpu-backend/src/interface/backend.rs
+++ b/backends/tfhe-hpu-backend/src/interface/backend.rs
@@ -165,26 +165,7 @@ impl HpuBackend {
             config.rtl.bpip_timeout,
         );
 
-        let ks_config_reg = regmap
-            .register()
-            .get("keyswitch::config")
-            .expect("Unknown register, check regmap definition");
-        hpu_hw.write_reg(
-            *ks_config_reg.offset() as u64,
-            ks_config_reg.from_field(
-                [(
-                    "mod_switch_mean_comp",
-                    config.rtl.mod_switch_mean_comp as u32,
-                )]
-                .into(),
-            ),
-        );
-
         info!("{params:?}");
-        debug!(
-            "Keyswitch registers {:?}",
-            rtl::runtime::InfoKeyswitch::from_rtl(&mut hpu_hw, &regmap)
-        );
         debug!(
             "Isc registers {:?}",
             rtl::runtime::InfoIsc::from_rtl(&mut hpu_hw, &regmap)

--- a/backends/tfhe-hpu-backend/src/interface/config.rs
+++ b/backends/tfhe-hpu-backend/src/interface/config.rs
@@ -77,8 +77,6 @@ pub struct RtlConfig {
     pub bpip_use_opportunism: bool,
     /// Timeout value to start Bpip even if batch isn't full
     pub bpip_timeout: u32,
-    /// Use modulus switch mean compensation
-    pub mod_switch_mean_comp: bool,
 }
 
 /// On-board memory configuration

--- a/backends/tfhe-hpu-backend/src/interface/rtl/params.rs
+++ b/backends/tfhe-hpu-backend/src/interface/rtl/params.rs
@@ -286,6 +286,8 @@ pub const CONCRETE_BOOLEAN: HpuPBSParameters = HpuPBSParameters {
     message_width: 1,
     carry_width: 0,
     ciphertext_width: 32,
+    log2_p_fail: -64.0,
+    modulus_switch_type: parameters::HpuModulusSwitchType::Standard,
 };
 
 pub const MSG2_CARRY2: HpuPBSParameters = HpuPBSParameters {
@@ -301,6 +303,8 @@ pub const MSG2_CARRY2: HpuPBSParameters = HpuPBSParameters {
     message_width: 2,
     carry_width: 2,
     ciphertext_width: u64::BITS as usize,
+    log2_p_fail: -64.0,
+    modulus_switch_type: parameters::HpuModulusSwitchType::Standard,
 };
 
 pub const MSG2_CARRY2_64B: HpuPBSParameters = HpuPBSParameters {
@@ -316,6 +320,8 @@ pub const MSG2_CARRY2_64B: HpuPBSParameters = HpuPBSParameters {
     message_width: 2,
     carry_width: 2,
     ciphertext_width: u64::BITS as usize,
+    log2_p_fail: -64.0,
+    modulus_switch_type: parameters::HpuModulusSwitchType::Standard,
 };
 
 pub const MSG2_CARRY2_44B: HpuPBSParameters = HpuPBSParameters {
@@ -333,6 +339,8 @@ pub const MSG2_CARRY2_44B: HpuPBSParameters = HpuPBSParameters {
     message_width: 2,
     carry_width: 2,
     ciphertext_width: 44,
+    log2_p_fail: -64.0,
+    modulus_switch_type: parameters::HpuModulusSwitchType::Standard,
 };
 
 pub const MSG2_CARRY2_64B_FAKE: HpuPBSParameters = HpuPBSParameters {
@@ -350,6 +358,8 @@ pub const MSG2_CARRY2_64B_FAKE: HpuPBSParameters = HpuPBSParameters {
     message_width: 2,
     carry_width: 2,
     ciphertext_width: 64,
+    log2_p_fail: -64.0,
+    modulus_switch_type: parameters::HpuModulusSwitchType::Standard,
 };
 
 pub const MSG2_CARRY2_GAUSSIAN: HpuPBSParameters = HpuPBSParameters {
@@ -367,6 +377,8 @@ pub const MSG2_CARRY2_GAUSSIAN: HpuPBSParameters = HpuPBSParameters {
     message_width: 2,
     carry_width: 2,
     ciphertext_width: 64,
+    log2_p_fail: -64.0,
+    modulus_switch_type: parameters::HpuModulusSwitchType::Standard,
 };
 
 pub const MSG2_CARRY2_TUNIFORM: HpuPBSParameters = HpuPBSParameters {
@@ -384,6 +396,8 @@ pub const MSG2_CARRY2_TUNIFORM: HpuPBSParameters = HpuPBSParameters {
     message_width: 2,
     carry_width: 2,
     ciphertext_width: 64,
+    log2_p_fail: -64.0,
+    modulus_switch_type: parameters::HpuModulusSwitchType::Standard,
 };
 
 pub const MSG2_CARRY2_PFAIL64_132B_GAUSSIAN_1F72DBA: HpuPBSParameters = HpuPBSParameters {
@@ -399,6 +413,8 @@ pub const MSG2_CARRY2_PFAIL64_132B_GAUSSIAN_1F72DBA: HpuPBSParameters = HpuPBSPa
     message_width: 2,
     carry_width: 2,
     ciphertext_width: 64,
+    log2_p_fail: -64.0,
+    modulus_switch_type: parameters::HpuModulusSwitchType::Standard,
 };
 
 pub const MSG2_CARRY2_PFAIL64_132B_TUNIFORM_7E47D8C: HpuPBSParameters = HpuPBSParameters {
@@ -414,6 +430,8 @@ pub const MSG2_CARRY2_PFAIL64_132B_TUNIFORM_7E47D8C: HpuPBSParameters = HpuPBSPa
     message_width: 2,
     carry_width: 2,
     ciphertext_width: 64,
+    log2_p_fail: -64.0,
+    modulus_switch_type: parameters::HpuModulusSwitchType::Standard,
 };
 
 pub const MSG2_CARRY2_PFAIL128_132B_TUNIFORM_144A47: HpuPBSParameters = HpuPBSParameters {
@@ -429,6 +447,8 @@ pub const MSG2_CARRY2_PFAIL128_132B_TUNIFORM_144A47: HpuPBSParameters = HpuPBSPa
     message_width: 2,
     carry_width: 2,
     ciphertext_width: 64,
+    log2_p_fail: -128.0,
+    modulus_switch_type: parameters::HpuModulusSwitchType::CenteredMeanNoiseReduction,
 };
 
 impl FromRtl for HpuPBSParameters {

--- a/backends/tfhe-hpu-backend/src/interface/rtl/runtime.rs
+++ b/backends/tfhe-hpu-backend/src/interface/rtl/runtime.rs
@@ -932,33 +932,3 @@ impl ErrorHpu {
         self.error_3in3 = ffi_hw.read_reg(*reg.offset() as u64);
     }
 }
-
-#[derive(Debug, Default)]
-pub struct InfoKeyswitch {
-    /// Use modulus switch mean compensation
-    mod_switch_mean_comp: bool,
-}
-
-impl FromRtl for InfoKeyswitch {
-    fn from_rtl(ffi_hw: &mut ffi::HpuHw, regmap: &FlatRegmap) -> Self {
-        // Info structure have method to update
-        // Instead of redefine parsing here, use a default construct and update methods
-        let mut infos = Self::default();
-        infos.update(ffi_hw, regmap);
-        infos
-    }
-}
-
-impl InfoKeyswitch {
-    pub fn update_mod_switch_mean_comp(&mut self, ffi_hw: &mut ffi::HpuHw, regmap: &FlatRegmap) {
-        let reg = regmap
-            .register()
-            .get("keyswitch::config")
-            .expect("Unknown register, check regmap definition");
-        self.mod_switch_mean_comp = ffi_hw.read_reg(*reg.offset() as u64) != 0;
-    }
-
-    pub fn update(&mut self, ffi_hw: &mut ffi::HpuHw, regmap: &FlatRegmap) {
-        self.update_mod_switch_mean_comp(ffi_hw, regmap);
-    }
-}

--- a/mockups/tfhe-hpu-mockup/params/gaussian_44b.toml
+++ b/mockups/tfhe-hpu-mockup/params/gaussian_44b.toml
@@ -11,6 +11,8 @@
     message_width= 2
     carry_width= 2
     ciphertext_width= 44
+    log2_p_fail=-64 
+    modulus_switch_type= "Standard"
 
 [ntt_params]
     core_arch="WmmUnfoldPcg"

--- a/mockups/tfhe-hpu-mockup/params/gaussian_44b_fast.toml
+++ b/mockups/tfhe-hpu-mockup/params/gaussian_44b_fast.toml
@@ -11,6 +11,8 @@
     message_width=2
     carry_width=2
     ciphertext_width=44
+    log2_p_fail=-64 
+    modulus_switch_type= "Standard"
 
 [ntt_params]
     core_arch="WmmCompactPcg"

--- a/mockups/tfhe-hpu-mockup/params/gaussian_64b.toml
+++ b/mockups/tfhe-hpu-mockup/params/gaussian_64b.toml
@@ -11,6 +11,8 @@
     message_width= 2
     carry_width= 2
     ciphertext_width= 64
+    log2_p_fail=-64 
+    modulus_switch_type= "Standard"
 
 [ntt_params]
     core_arch= {GF64=[5,5]}

--- a/mockups/tfhe-hpu-mockup/params/gaussian_64b_fast.toml
+++ b/mockups/tfhe-hpu-mockup/params/gaussian_64b_fast.toml
@@ -11,6 +11,8 @@
     message_width=2
     carry_width=2
     ciphertext_width=64
+    log2_p_fail=-64 
+    modulus_switch_type= "Standard"
 
 [ntt_params]
     core_arch= {GF64=[5,5]}

--- a/mockups/tfhe-hpu-mockup/params/gaussian_64b_pfail64.toml
+++ b/mockups/tfhe-hpu-mockup/params/gaussian_64b_pfail64.toml
@@ -11,6 +11,8 @@
     message_width= 2
     carry_width= 2
     ciphertext_width= 64
+    log2_p_fail=-64 
+    modulus_switch_type= "Standard"
 
 [ntt_params]
     core_arch= {GF64=[5,6]}

--- a/mockups/tfhe-hpu-mockup/params/gaussian_64b_pfail64_psi64.toml
+++ b/mockups/tfhe-hpu-mockup/params/gaussian_64b_pfail64_psi64.toml
@@ -12,6 +12,8 @@
     carry_width= 2
     ciphertext_width= 64
     opportunistic=true
+    log2_p_fail=-64 
+    modulus_switch_type= "Standard"
 
 [ntt_params]
     core_arch= {GF64=[5,6]}

--- a/mockups/tfhe-hpu-mockup/params/tuniform_64b_fast.toml
+++ b/mockups/tfhe-hpu-mockup/params/tuniform_64b_fast.toml
@@ -11,6 +11,8 @@
     message_width=2
     carry_width=2
     ciphertext_width=64
+    log2_p_fail=-64 
+    modulus_switch_type= "Standard"
 
 [ntt_params]
     core_arch= {GF64=[5,6]}

--- a/mockups/tfhe-hpu-mockup/params/tuniform_64b_pfail128_psi64.toml
+++ b/mockups/tfhe-hpu-mockup/params/tuniform_64b_pfail128_psi64.toml
@@ -12,6 +12,8 @@
     carry_width= 2
     ciphertext_width= 64
     opportunistic=true
+    log2_p_fail=-128
+    modulus_switch_type= "CenteredMeanNoiseReduction"
 
 [ntt_params]
     core_arch= {GF64=[5,6]}

--- a/mockups/tfhe-hpu-mockup/params/tuniform_64b_pfail64_psi64.toml
+++ b/mockups/tfhe-hpu-mockup/params/tuniform_64b_pfail64_psi64.toml
@@ -12,6 +12,8 @@
     carry_width= 2
     ciphertext_width= 64
     opportunistic=true
+    log2_p_fail=-64 
+    modulus_switch_type= "Standard"
 
 [ntt_params]
     core_arch= {GF64=[5,6]}

--- a/mockups/tfhe-hpu-mockup/src/lib.rs
+++ b/mockups/tfhe-hpu-mockup/src/lib.rs
@@ -257,7 +257,7 @@ impl HpuSim {
                     let asm_p = format!("{dump_path}/iop/iop_{}.asm", self.iop_nb);
                     let hex_p = format!("{dump_path}/iop/iop_{}.hex", self.iop_nb);
                     let mut iop_prog = hpu_asm::Program::default();
-                    iop_prog.push_comment(format!("{}", iop));
+                    iop_prog.push_comment(format!("{iop}"));
                     iop_prog.push_stmt(iop.clone());
                     iop_prog.write_asm(&asm_p).unwrap();
                     iop_prog.write_hex(&hex_p).unwrap();
@@ -389,7 +389,7 @@ impl HpuSim {
                 tracing::info!("{pe_rpt}");
 
                 if let Some(mut rpt_file) = self.options.report_file((&iop).into()) {
-                    writeln!(rpt_file, "Report for IOp: {}", iop).unwrap();
+                    writeln!(rpt_file, "Report for IOp: {iop}").unwrap();
                     writeln!(rpt_file, "{time_rpt:?}").unwrap();
                     writeln!(rpt_file, "{dop_rpt}").unwrap();
                     writeln!(rpt_file, "{pe_rpt}").unwrap();
@@ -400,7 +400,7 @@ impl HpuSim {
                 if let Some(mut trace_file) = self.options.report_trace((&iop).into()) {
                     let json_string =
                         serde_json::to_string(&trace).expect("Could not serialize trace");
-                    writeln!(trace_file, "{}", json_string).unwrap();
+                    writeln!(trace_file, "{json_string}").unwrap();
                 }
             }
             hpu_asm::DOp::LD(op_impl) => {
@@ -909,10 +909,10 @@ impl HpuSim {
             .enumerate()
             .for_each(|(i, slice)| {
                 // Create file-path
-                let file_path = format!("{base_path}_{:0>1x}.hex", i);
+                let file_path = format!("{base_path}_{i:0>1x}.hex");
                 let mut wr_f = MockupOptions::open_wr_file(&file_path);
 
-                writeln!(&mut wr_f, "# LweCiphertext slice #{}", i).unwrap();
+                writeln!(&mut wr_f, "# LweCiphertext slice #{i}").unwrap();
                 // Compact Blwe on 32b if possible
                 if self.params.rtl_params.ntt_params.ct_width <= u32::BITS {
                     let slice_32b = slice.iter().map(|x| *x as u32).collect::<Vec<u32>>();

--- a/tfhe-benchmark/src/params.rs
+++ b/tfhe-benchmark/src/params.rs
@@ -444,7 +444,7 @@ mod integer_params {
                 // FIXME One set of parameter is tested since we want to benchmark only quickest
                 // operations.
                 #[cfg(feature = "hpu")]
-                let params = vec![BENCH_HPU_PARAM_MESSAGE_2_CARRY_2_KS32_PBS_TUNIFORM_2M64.into()];
+                let params = vec![BENCH_HPU_PARAM_MESSAGE_2_CARRY_2_KS32_PBS_TUNIFORM_2M128.into()];
                 #[cfg(not(feature = "hpu"))]
                 let params = vec![BENCH_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128.into()];
 

--- a/tfhe-benchmark/src/params_aliases.rs
+++ b/tfhe-benchmark/src/params_aliases.rs
@@ -147,6 +147,10 @@ pub mod shortint_params_aliases {
     // KS PBS TUniform
     pub const BENCH_HPU_PARAM_MESSAGE_2_CARRY_2_KS32_PBS_TUNIFORM_2M64: KeySwitch32PBSParameters =
         V1_3_HPU_PARAM_MESSAGE_2_CARRY_2_KS32_PBS_TUNIFORM_2M64;
+    #[cfg(feature = "hpu")]
+    // KS PBS TUniform pfail -128
+    pub const BENCH_HPU_PARAM_MESSAGE_2_CARRY_2_KS32_PBS_TUNIFORM_2M128: KeySwitch32PBSParameters =
+        V1_3_HPU_PARAM_MESSAGE_2_CARRY_2_KS32_PBS_TUNIFORM_2M128;
 }
 
 #[cfg(any(feature = "shortint", feature = "integer"))]

--- a/tfhe/src/core_crypto/algorithms/modulus_switch.rs
+++ b/tfhe/src/core_crypto/algorithms/modulus_switch.rs
@@ -41,8 +41,7 @@ where
     assert!(log_modulus.0 <= Scalar::BITS);
     assert!(log_modulus.0 <= SwitchedScalar::BITS);
 
-    let body_correction_to_add =
-        centered_binary_ms_body_correction_to_add(&lwe_in, log_modulus, true);
+    let body_correction_to_add = centered_binary_ms_body_correction_to_add(&lwe_in, log_modulus);
 
     LazyStandardModulusSwitchedLweCiphertext::from_raw_parts(
         lwe_in,
@@ -51,12 +50,9 @@ where
     )
 }
 
-// TODO: potentially remove the flag to choose whether to apply the half case correction
-// This was added to have matching algorithms for the HPU implementation
-pub(crate) fn centered_binary_ms_body_correction_to_add<Scalar, Cont>(
+fn centered_binary_ms_body_correction_to_add<Scalar, Cont>(
     lwe_in: &LweCiphertext<Cont>,
     log_modulus: CiphertextModulusLog,
-    do_half_case_correction: bool,
 ) -> Scalar
 where
     Scalar: UnsignedInteger,
@@ -93,11 +89,7 @@ where
     // sum(half_error_theoretical) = sum(half_error) - sum(halving_error_doubled)/2
     let sum_half_mask_round_errors = sum_half_mask_round_errors.wrapping_sub(sum_halving_errors);
 
-    let half_case = if do_half_case_correction {
-        Scalar::ONE << (Scalar::BITS - log_modulus.0 - 1)
-    } else {
-        Scalar::ZERO
-    };
+    let half_case = Scalar::ONE << (Scalar::BITS - log_modulus.0 - 1);
 
     // E(e_MMS) = - sum(mask_round_error / 2)
     // body_centered = body_input - E(e_MMS) - half_case
@@ -324,7 +316,7 @@ mod tests {
                     }),
                     {
                         let centered_binary_ms_body_correction_to_add =
-                            centered_binary_ms_body_correction_to_add(&lwe, log_modulus, true);
+                            centered_binary_ms_body_correction_to_add(&lwe, log_modulus);
 
                         measure_noise_added_by_message_preserving_operation(&sk, lwe, |ct| {
                             *ct.get_mut_body().data = ct

--- a/tfhe/src/core_crypto/hpu/algorithms/modswitch.rs
+++ b/tfhe/src/core_crypto/hpu/algorithms/modswitch.rs
@@ -1,7 +1,4 @@
-use crate::core_crypto::prelude::{
-    centered_binary_ms_body_correction_to_add, CastInto, CiphertextModulusLog, Container,
-    LazyStandardModulusSwitchedLweCiphertext, LweCiphertext, UnsignedInteger,
-};
+use crate::core_crypto::prelude::UnsignedInteger;
 use tfhe_hpu_backend::prelude::HpuParameters;
 
 /// This function change information position in value
@@ -37,29 +34,4 @@ pub fn lsb2msb_align<Scalar: UnsignedInteger>(params: &HpuParameters, data: &mut
     for val in data.iter_mut() {
         *val <<= storage_width - ct_width;
     }
-}
-
-// Temporary implementation without half case correction which is not currently implemented
-// Once implemented revert back to CPU implem
-pub fn hpu_lwe_ciphertext_centered_binary_modulus_switch<Scalar, SwitchedScalar, Cont>(
-    lwe_in: LweCiphertext<Cont>,
-    log_modulus: CiphertextModulusLog,
-) -> LazyStandardModulusSwitchedLweCiphertext<Scalar, SwitchedScalar, Cont>
-where
-    Scalar: UnsignedInteger + CastInto<SwitchedScalar>,
-    SwitchedScalar: UnsignedInteger,
-    Cont: Container<Element = Scalar>,
-{
-    assert!(log_modulus.0 <= Scalar::BITS);
-    assert!(log_modulus.0 <= SwitchedScalar::BITS);
-
-    let body_correction_to_add =
-        // false here disables the half case correction
-        centered_binary_ms_body_correction_to_add(&lwe_in, log_modulus, false);
-
-    LazyStandardModulusSwitchedLweCiphertext::from_raw_parts(
-        lwe_in,
-        body_correction_to_add,
-        log_modulus,
-    )
 }

--- a/tfhe/src/shortint/keycache.rs
+++ b/tfhe/src/shortint/keycache.rs
@@ -412,6 +412,8 @@ named_params_impl!( ShortintParameterSet =>
     V1_3_HPU_PARAM_MESSAGE_2_CARRY_2_KS32_PBS_GAUSSIAN_2M64,
     #[cfg(feature ="hpu")]
     V1_3_HPU_PARAM_MESSAGE_2_CARRY_2_KS32_PBS_TUNIFORM_2M64,
+    #[cfg(feature ="hpu")]
+    V1_3_HPU_PARAM_MESSAGE_2_CARRY_2_KS32_PBS_TUNIFORM_2M128,
 );
 
 impl NamedParam for ClassicPBSParameters {

--- a/tfhe/src/shortint/parameters/hpu.rs
+++ b/tfhe/src/shortint/parameters/hpu.rs
@@ -6,6 +6,15 @@ use crate::shortint::parameters::{
 };
 use crate::shortint::prelude::*;
 
+impl From<&HpuModulusSwitchType> for ModulusSwitchType {
+    fn from(value: &HpuModulusSwitchType) -> Self {
+        match value {
+            HpuModulusSwitchType::Standard => Self::Standard,
+            HpuModulusSwitchType::CenteredMeanNoiseReduction => Self::CenteredMeanNoiseReduction,
+        }
+    }
+}
+
 #[allow(clippy::fallible_impl_from)]
 impl From<&HpuParameters> for KeySwitch32PBSParameters {
     fn from(value: &HpuParameters) -> Self {
@@ -39,7 +48,7 @@ impl From<&HpuParameters> for KeySwitch32PBSParameters {
             message_modulus: MessageModulus(1 << value.pbs_params.message_width),
             carry_modulus: CarryModulus(1 << value.pbs_params.carry_width),
             max_noise_level: MaxNoiseLevel::new(5),
-            log2_p_fail: -64.0, // TODO fixme
+            log2_p_fail: value.pbs_params.log2_p_fail,
             post_keyswitch_ciphertext_modulus: CiphertextModulus32::try_new_power_of_2(
                 value.ks_params.width,
             )
@@ -48,7 +57,9 @@ impl From<&HpuParameters> for KeySwitch32PBSParameters {
                 value.pbs_params.ciphertext_width,
             )
             .unwrap(),
-            modulus_switch_noise_reduction_params: ModulusSwitchType::Standard,
+            modulus_switch_noise_reduction_params: ModulusSwitchType::from(
+                &value.pbs_params.modulus_switch_type,
+            ),
         }
     }
 }

--- a/tfhe/src/shortint/parameters/v1_3/hpu.rs
+++ b/tfhe/src/shortint/parameters/v1_3/hpu.rs
@@ -7,7 +7,7 @@ use crate::shortint::prelude::{
 };
 use crate::shortint::{CarryModulus, CiphertextModulus, MaxNoiseLevel, MessageModulus};
 
-// Gaussian parameters set
+// Gaussian parameters set with pfail 2^-64
 pub const V1_3_HPU_PARAM_MESSAGE_2_CARRY_2_KS32_PBS_GAUSSIAN_2M64: KeySwitch32PBSParameters =
     KeySwitch32PBSParameters {
         lwe_dimension: LweDimension(804),
@@ -32,7 +32,7 @@ pub const V1_3_HPU_PARAM_MESSAGE_2_CARRY_2_KS32_PBS_GAUSSIAN_2M64: KeySwitch32PB
         modulus_switch_noise_reduction_params: ModulusSwitchType::Standard,
     };
 
-// TUniform parameters set
+// TUniform parameters set with pfail 2^-64
 pub const V1_3_HPU_PARAM_MESSAGE_2_CARRY_2_KS32_PBS_TUNIFORM_2M64: KeySwitch32PBSParameters =
     KeySwitch32PBSParameters {
         lwe_dimension: LweDimension(839),
@@ -51,4 +51,25 @@ pub const V1_3_HPU_PARAM_MESSAGE_2_CARRY_2_KS32_PBS_TUNIFORM_2M64: KeySwitch32PB
         post_keyswitch_ciphertext_modulus: CiphertextModulus32::new(1 << 21),
         ciphertext_modulus: CiphertextModulus::new_native(),
         modulus_switch_noise_reduction_params: ModulusSwitchType::Standard,
+    };
+
+// TUniform parameters set with pfail 2^-128
+pub const V1_3_HPU_PARAM_MESSAGE_2_CARRY_2_KS32_PBS_TUNIFORM_2M128: KeySwitch32PBSParameters =
+    KeySwitch32PBSParameters {
+        lwe_dimension: LweDimension(879),
+        glwe_dimension: GlweDimension(1),
+        polynomial_size: PolynomialSize(2048),
+        lwe_noise_distribution: DynamicDistribution::new_t_uniform(3),
+        glwe_noise_distribution: DynamicDistribution::new_t_uniform(17),
+        pbs_base_log: DecompositionBaseLog(23),
+        pbs_level: DecompositionLevelCount(1),
+        ks_base_log: DecompositionBaseLog(2),
+        ks_level: DecompositionLevelCount(8),
+        message_modulus: MessageModulus(4),
+        carry_modulus: CarryModulus(4),
+        max_noise_level: MaxNoiseLevel::new(5),
+        log2_p_fail: -128.0,
+        post_keyswitch_ciphertext_modulus: CiphertextModulus32::new(1 << 21),
+        ciphertext_modulus: CiphertextModulus::new_native(),
+        modulus_switch_noise_reduction_params: ModulusSwitchType::CenteredMeanNoiseReduction,
     };

--- a/tfhe/src/shortint/parameters/v1_3/mod.rs
+++ b/tfhe/src/shortint/parameters/v1_3/mod.rs
@@ -1712,7 +1712,7 @@ pub const VEC_ALL_KS32_PARAMETERS: [(&KeySwitch32PBSParameters, &str); 1] = [(
 pub mod hpu;
 
 #[cfg(feature = "hpu")]
-pub const VEC_ALL_HPU_PARAMETERS: [(&KeySwitch32PBSParameters, &str); 2] = [
+pub const VEC_ALL_HPU_PARAMETERS: [(&KeySwitch32PBSParameters, &str); 3] = [
     (
         &V1_3_HPU_PARAM_MESSAGE_2_CARRY_2_KS32_PBS_GAUSSIAN_2M64,
         "V1_3_HPU_PARAM_MESSAGE_2_CARRY_2_KS32_PBS_GAUSSIAN_2M64",
@@ -1720,5 +1720,9 @@ pub const VEC_ALL_HPU_PARAMETERS: [(&KeySwitch32PBSParameters, &str); 2] = [
     (
         &V1_3_HPU_PARAM_MESSAGE_2_CARRY_2_KS32_PBS_TUNIFORM_2M64,
         "V1_3_HPU_PARAM_MESSAGE_2_CARRY_2_KS32_PBS_TUNIFORM_2M64",
+    ),
+    (
+        &V1_3_HPU_PARAM_MESSAGE_2_CARRY_2_KS32_PBS_TUNIFORM_2M128,
+        "V1_3_HPU_PARAM_MESSAGE_2_CARRY_2_KS32_PBS_TUNIFORM_2M128",
     ),
 ];


### PR DESCRIPTION
Add support for centered modswitch with mean compensation in Hpu.
Also add various fix and update v1_3 parameters set.

We are almost ready, only have some final tests to run on board but it doesn't prevent to start the review.
NB: We revert the commit from Arthur for support of modswitch with mean compensation without the shift. Indeed, it's not needed anymore since we support the centered modswitch now.
