### PR TITLE
Fix typo in Event implementation comment

### DIFF
--- a/backends/tfhe-hpu-backend/src/fw/isc_sim/mod.rs
+++ b/backends/tfhe-hpu-backend/src/fw/isc_sim/mod.rs
@@ -39,7 +39,7 @@ impl Event {
     }
 }
 
-/// Event are stored in a BinaryHeap and we want to pop the smallest one firs
+/// Event are stored in a BinaryHeap and we want to pop the smallest one first
 /// Thuse Ord trait is implemented in a "reverse".
 impl Ord for Event {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {


### PR DESCRIPTION

### PR content/description
- Change "firs" to "first" in Event implementation comment

### Check-list:

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [x] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]


