### PR TITLE
feat(integer): truncate carry prop on trivial zeros

### DIFF
--- a/tfhe/src/integer/server_key/radix_parallel/mod.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/mod.rs
@@ -227,13 +227,37 @@ impl ServerKey {
         T: IntegerRadixCiphertext,
     {
         let num_blocks = ctxt.blocks().len();
+
+        // Start the propagation on the first block that has carries
         let start_index = ctxt
             .blocks()
             .iter()
             .position(|block| !block.carry_is_empty())
             .unwrap_or(num_blocks);
 
-        let (to_be_cleaned, to_be_propagated) = ctxt.blocks_mut().split_at_mut(start_index);
+        // End the propagation 2 blocks after the last non-trivial zero block.
+        // We end it 2 blocks after because, in the worst case:
+        // 1) the last block (block `n`) 'immediate' carry will be the block n+1
+        // 2) a carry may be propagated from a block `< n` to block `n + 2` because block n is full
+        //
+        // e.g., 2 blocks, 2_2, notation: 0bcarry|msg, block in little endian order
+        // input: [0b11|11, 0b11|11, 0b00|00, 0b00|00, 0b00|00] = (5 * 15) % (1024)
+        // msg  : [0b00|11, 0b00|11, 0b00|00, 0b00|00, 0b00|00] = 15
+        // carry: [0b00|00, 0b00|11, 0b00|11, 0b00|00, 0b00|00] = 60
+        // msg + carry = [0b00|11, 0b00|11+11, 0b00|11, 0b00|00, 0b00|00]
+        // msg + carry = [0b00|00, 0b00|10, 0b00|11+1, 0b00|00, 0b00|00]
+        // msg + carry = [0b00|00, 0b00|10, 0b00|00, 0b0|01, 0b00|00] = 75 = 5 * 15
+        // As we can see, the result is on n+2 = 4 block
+        // there is no need to consider the last block
+        let end_index = ctxt
+            .blocks()
+            .iter()
+            .rposition(|block| block.degree.get() != 0)
+            .map(|pos| (pos + 2).min(num_blocks))
+            .unwrap_or(num_blocks);
+
+        let blocks = &mut ctxt.blocks_mut()[..end_index];
+        let (to_be_cleaned, to_be_propagated) = blocks.split_at_mut(start_index);
 
         rayon::scope(|s| {
             if !to_be_propagated.is_empty() {

--- a/tfhe/src/integer/server_key/radix_parallel/tests_cases_unsigned.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_cases_unsigned.rs
@@ -1004,11 +1004,11 @@ where
                    expected {expected_result}, got {decrypted_result}"
             );
             assert_eq!(
-                   decrypted_overflowed,
-                   expected_overflowed,
-                   "Invalid overflow flag result for overflowing_mul, for ({clear_lhs} -{clear_rhs}) % {modulus}
+                decrypted_overflowed,
+                expected_overflowed,
+                "Invalid overflow flag result for overflowing_mul, for ({clear_lhs} -{clear_rhs}) % {modulus}
                     expected overflow flag {expected_overflowed}, got {decrypted_overflowed}"
-                );
+            );
             assert_eq!(result_overflowed.0.degree.get(), 1);
             assert_eq!(result_overflowed.0.noise_level(), NoiseLevel::NOMINAL);
         }
@@ -1708,11 +1708,11 @@ where
              expected {expected_result}, got {decrypted_result}"
             );
             assert_eq!(
-            decrypted_overflowed,
-            expected_overflowed,
-            "Invalid overflow flag result for overflowing_sub for ({clear_0} - {clear_1}) % {modulus} \
+                decrypted_overflowed,
+                expected_overflowed,
+                "Invalid overflow flag result for overflowing_sub for ({clear_0} - {clear_1}) % {modulus} \
              expected overflow flag {expected_overflowed}, got {decrypted_overflowed}"
-        );
+            );
             assert_eq!(result_overflowed.0.degree.get(), 1);
             assert_eq!(result_overflowed.0.noise_level(), NoiseLevel::NOMINAL);
 
@@ -1739,11 +1739,11 @@ where
                 expected {expected_result}, got {decrypted_result}"
                 );
                 assert_eq!(
-                decrypted_overflowed,
-                expected_overflowed,
-                "Invalid overflow flag result for overflowing_sub, for ({clear_lhs} - {clear_rhs}) % {modulus} \
+                    decrypted_overflowed,
+                    expected_overflowed,
+                    "Invalid overflow flag result for overflowing_sub, for ({clear_lhs} - {clear_rhs}) % {modulus} \
                 expected overflow flag {expected_overflowed}, got {decrypted_overflowed}"
-            );
+                );
                 assert_eq!(result_overflowed.0.degree.get(), 1);
                 assert_eq!(result_overflowed.0.noise_level(), NoiseLevel::NOMINAL);
             }
@@ -1769,11 +1769,11 @@ where
                 expected {expected_result}, got {decrypted_result}"
             );
             assert_eq!(
-            decrypted_overflowed,
-            expected_overflowed,
-            "Invalid overflow flag result for overflowing_sub, for ({clear_0} - {clear_1}) % {modulus} \
+                decrypted_overflowed,
+                expected_overflowed,
+                "Invalid overflow flag result for overflowing_sub, for ({clear_0} - {clear_1}) % {modulus} \
                 expected overflow flag {expected_overflowed}, got {decrypted_overflowed}"
-        );
+            );
             assert_eq!(encrypted_overflow.0.degree.get(), 1);
             assert_eq!(encrypted_overflow.0.noise_level(), NoiseLevel::ZERO);
         }
@@ -1798,11 +1798,11 @@ where
                 expected {expected_result}, got {decrypted_result}"
             );
             assert_eq!(
-            decrypted_overflowed,
-            expected_overflowed,
-            "Invalid overflow flag result for overflowing_sub, for ({clear_0} - {clear_1}) % {modulus} \
+                decrypted_overflowed,
+                expected_overflowed,
+                "Invalid overflow flag result for overflowing_sub, for ({clear_0} - {clear_1}) % {modulus} \
                 expected overflow flag {expected_overflowed}, got {decrypted_overflowed}"
-        );
+            );
             assert!(decrypted_overflowed); // Actually we know its an overflow case
             assert_eq!(encrypted_overflow.0.degree.get(), 1);
             assert_eq!(encrypted_overflow.0.noise_level(), NoiseLevel::ZERO);
@@ -2598,5 +2598,44 @@ where
         assert_eq!(ct.blocks[1].noise_degree(), clean_noise_degree);
         assert_eq!(ct.blocks[2].noise_degree(), clean_noise_degree);
         assert_eq!(ct.blocks[3].noise_degree(), clean_noise_degree);
+    }
+
+    // Here we want to test that propagating a radix which has trivial zeros in its MSB
+    // yields correct results. We do this test as our implementation skips the propagation
+    // on the MSB when they are trivial zeros
+    {
+        let nb_blocks = 4;
+        let num_bits_in_msg = sks.message_modulus().0.ilog2();
+        let ct_num_bits = 4 * num_bits_in_msg;
+
+        // The maximum encryptable value, i.e. all bits set to 1
+        let clear_a = (1u32 << num_bits_in_msg) - 1;
+        // The most significant block is full of 1, the least significant bit is 1
+        // all other bits are 0
+        let clear_b = ((1 << num_bits_in_msg) - 1) << (num_bits_in_msg * (nb_blocks - 1)) | 1u32;
+
+        let a = cks.as_ref().encrypt_radix(clear_a, nb_blocks as usize);
+        let b = cks.as_ref().encrypt_radix(clear_b, nb_blocks as usize);
+
+        // Cast to double precision, making the top nb_blocks be trivial zeros
+        let mut a = sks.cast_to_unsigned(a, 2 * nb_blocks as usize);
+        let b = sks.cast_to_unsigned(b, 2 * nb_blocks as usize);
+
+        sks.unchecked_add_assign(&mut a, &b);
+        executor.execute(&mut a);
+
+        assert!(a.block_carries_are_empty());
+        assert!(a
+            .blocks
+            .iter()
+            .all(|b| b.noise_level() <= NoiseLevel::NOMINAL));
+
+        let result: u32 = cks.as_ref().decrypt_radix(&a);
+        let expected = clear_a + clear_b;
+        assert_eq!(
+            result,
+            clear_a + clear_b,
+            "Invalid full propagation result for {clear_a} + {clear_b}, expected {expected}, got {result}"
+        );
     }
 }


### PR DESCRIPTION
This changes the full_propagate_parallelized to not propagate most significant blocks which are trivial zeros.

This is a small performance improvement, especially interesting when having a bunch of FheUintX data, casted to FheUintY (Y > X) and summing them (e.g. n FheUint2, casted to FheUint32  and doing the sum to get the result on 32 bit)

