### PR TITLE
test: use hamming weight = 1/2 for core noise tests

### DIFF
--- a/tfhe/src/core_crypto/algorithms/test/noise_distribution/lwe_encryption_noise.rs
+++ b/tfhe/src/core_crypto/algorithms/test/noise_distribution/lwe_encryption_noise.rs
@@ -137,9 +137,8 @@ fn lwe_compact_public_encrypt_noise_distribution_custom_mod<
     while msg != Scalar::ZERO {
         msg = msg.wrapping_sub(Scalar::ONE);
         for _ in 0..NB_TESTS {
-            let lwe_sk = allocate_and_generate_new_binary_lwe_secret_key(
+            let lwe_sk = test_allocate_and_generate_binary_lwe_secret_key_with_half_hamming_weight(
                 lwe_dimension,
-                &mut rsc.secret_random_generator,
             );
 
             let pk = allocate_and_generate_new_lwe_compact_public_key(

--- a/tfhe/src/core_crypto/algorithms/test/noise_distribution/lwe_hpu_noise.rs
+++ b/tfhe/src/core_crypto/algorithms/test/noise_distribution/lwe_hpu_noise.rs
@@ -222,11 +222,15 @@ fn hpu_noise_distribution(params: HpuTestParams) {
         ciphertext_modulus
     ));
 
-    let mut lwe_sk = LweSecretKeyOwned::new_empty_key(0, lwe_dimension);
+    let lwe_sk =
+        test_allocate_and_generate_binary_lwe_secret_key_with_half_hamming_weight(lwe_dimension);
 
-    let mut glwe_sk = GlweSecretKeyOwned::new_empty_key(0, glwe_dimension, polynomial_size);
+    let glwe_sk = test_allocate_and_generate_binary_glwe_secret_key_with_half_hamming_weight(
+        glwe_dimension,
+        polynomial_size,
+    );
 
-    let mut blwe_sk = glwe_sk.clone().into_lwe_secret_key();
+    let blwe_sk = glwe_sk.as_lwe_secret_key();
     let mut ksk_in_kskmod = LweKeyswitchKeyOwned::new(
         0,
         ks_decomp_base_log,
@@ -345,11 +349,6 @@ fn hpu_noise_distribution(params: HpuTestParams) {
     while msg != 0 {
         msg = msg.wrapping_sub(1);
         for i in 0..NB_HPU_TESTS {
-            // re-generate keys
-            generate_binary_lwe_secret_key(&mut lwe_sk, &mut rsc.secret_random_generator);
-            generate_binary_glwe_secret_key(&mut glwe_sk, &mut rsc.secret_random_generator);
-            blwe_sk = glwe_sk.clone().into_lwe_secret_key();
-
             // re-generate KSK
             generate_lwe_keyswitch_key(
                 &blwe_sk,

--- a/tfhe/src/core_crypto/algorithms/test/noise_distribution/lwe_keyswitch_noise.rs
+++ b/tfhe/src/core_crypto/algorithms/test/noise_distribution/lwe_keyswitch_noise.rs
@@ -55,15 +55,12 @@ fn lwe_encrypt_ks_decrypt_noise_distribution_custom_mod<Scalar: UnsignedTorus + 
     let num_samples = NB_TESTS * <Scalar as CastInto<usize>>::cast_into(msg);
     let mut noise_samples = Vec::with_capacity(num_samples);
 
-    let lwe_sk = allocate_and_generate_new_binary_lwe_secret_key(
-        lwe_dimension,
-        &mut rsc.secret_random_generator,
-    );
+    let lwe_sk =
+        test_allocate_and_generate_binary_lwe_secret_key_with_half_hamming_weight(lwe_dimension);
 
-    let glwe_sk = allocate_and_generate_new_binary_glwe_secret_key(
+    let glwe_sk = test_allocate_and_generate_binary_glwe_secret_key_with_half_hamming_weight(
         glwe_dimension,
         polynomial_size,
-        &mut rsc.secret_random_generator,
     );
 
     let big_lwe_sk = glwe_sk.into_lwe_secret_key();

--- a/tfhe/src/core_crypto/algorithms/test/noise_distribution/lwe_multi_bit_programmable_bootstrapping_noise.rs
+++ b/tfhe/src/core_crypto/algorithms/test/noise_distribution/lwe_multi_bit_programmable_bootstrapping_noise.rs
@@ -73,16 +73,16 @@ where
     let num_samples = NB_TESTS * <Scalar as CastInto<usize>>::cast_into(msg);
     let mut noise_samples = Vec::with_capacity(num_samples);
 
-    let input_lwe_secret_key = allocate_and_generate_new_binary_lwe_secret_key(
-        input_lwe_dimension,
-        &mut rsc.secret_random_generator,
-    );
+    let input_lwe_secret_key =
+        test_allocate_and_generate_binary_lwe_secret_key_with_half_hamming_weight(
+            input_lwe_dimension,
+        );
 
-    let output_glwe_secret_key = allocate_and_generate_new_binary_glwe_secret_key(
-        glwe_dimension,
-        polynomial_size,
-        &mut rsc.secret_random_generator,
-    );
+    let output_glwe_secret_key =
+        test_allocate_and_generate_binary_glwe_secret_key_with_half_hamming_weight(
+            glwe_dimension,
+            polynomial_size,
+        );
 
     let output_lwe_secret_key = output_glwe_secret_key.as_lwe_secret_key();
 

--- a/tfhe/src/core_crypto/algorithms/test/noise_distribution/lwe_programmable_bootstrapping_noise.rs
+++ b/tfhe/src/core_crypto/algorithms/test/noise_distribution/lwe_programmable_bootstrapping_noise.rs
@@ -51,16 +51,16 @@ where
     let num_samples = NB_TESTS * <Scalar as CastInto<usize>>::cast_into(msg);
     let mut noise_samples = Vec::with_capacity(num_samples);
 
-    let input_lwe_secret_key = allocate_and_generate_new_binary_lwe_secret_key(
-        input_lwe_dimension,
-        &mut rsc.secret_random_generator,
-    );
+    let input_lwe_secret_key =
+        test_allocate_and_generate_binary_lwe_secret_key_with_half_hamming_weight(
+            input_lwe_dimension,
+        );
 
-    let output_glwe_secret_key = allocate_and_generate_new_binary_glwe_secret_key(
-        glwe_dimension,
-        polynomial_size,
-        &mut rsc.secret_random_generator,
-    );
+    let output_glwe_secret_key =
+        test_allocate_and_generate_binary_glwe_secret_key_with_half_hamming_weight(
+            glwe_dimension,
+            polynomial_size,
+        );
 
     let output_lwe_secret_key = output_glwe_secret_key.as_lwe_secret_key();
 

--- a/tfhe/src/core_crypto/algorithms/test/noise_distribution/mod.rs
+++ b/tfhe/src/core_crypto/algorithms/test/noise_distribution/mod.rs
@@ -100,3 +100,40 @@ pub const NOISE_TEST_PARAMS_MULTI_BIT_GROUP_3_6_BITS_NATIVE_U64_132_BITS_GAUSSIA
     grouping_factor: LweBskGroupingFactor(3),
     thread_count: ThreadCount(12),
 };
+
+/// Use ONLY for noise distribution tests, this allows to have less variability and match exactly
+/// what noise formulas expect for uniform binary secret keys
+///
+/// Exactly half of the coefficients of the key are set to 1
+pub(crate) fn test_allocate_and_generate_binary_lwe_secret_key_with_half_hamming_weight<
+    Scalar: UnsignedInteger,
+>(
+    lwe_dimension: LweDimension,
+) -> LweSecretKeyOwned<Scalar> {
+    let mut res = LweSecretKeyOwned::new_empty_key(Scalar::ZERO, lwe_dimension);
+    res.as_mut()
+        .iter_mut()
+        .step_by(2)
+        .for_each(|x| *x = Scalar::ONE);
+
+    res
+}
+
+/// Use ONLY for noise distribution tests, this allows to have less variability and match exactly
+/// what noise formulas expect for uniform binary secret keys
+///
+/// Exactly half of the coefficients of the key are set to 1
+pub(crate) fn test_allocate_and_generate_binary_glwe_secret_key_with_half_hamming_weight<
+    Scalar: UnsignedInteger,
+>(
+    glwe_dimension: GlweDimension,
+    polynomial_size: PolynomialSize,
+) -> GlweSecretKeyOwned<Scalar> {
+    let mut res = GlweSecretKeyOwned::new_empty_key(Scalar::ZERO, glwe_dimension, polynomial_size);
+    res.as_mut()
+        .iter_mut()
+        .step_by(2)
+        .for_each(|x| *x = Scalar::ONE);
+
+    res
+}

--- a/tfhe/src/core_crypto/gpu/algorithms/test/noise_distribution/lwe_multi_bit_programmable_bootstrapping_noise.rs
+++ b/tfhe/src/core_crypto/gpu/algorithms/test/noise_distribution/lwe_multi_bit_programmable_bootstrapping_noise.rs
@@ -83,16 +83,16 @@ where
     let num_samples = NB_TESTS * <Scalar as CastInto<usize>>::cast_into(msg);
     let mut noise_samples = Vec::with_capacity(num_samples);
 
-    let input_lwe_secret_key = allocate_and_generate_new_binary_lwe_secret_key(
-        input_lwe_dimension,
-        &mut rsc.secret_random_generator,
-    );
+    let input_lwe_secret_key =
+        test_allocate_and_generate_binary_lwe_secret_key_with_half_hamming_weight(
+            input_lwe_dimension,
+        );
 
-    let output_glwe_secret_key = allocate_and_generate_new_binary_glwe_secret_key(
-        glwe_dimension,
-        polynomial_size,
-        &mut rsc.secret_random_generator,
-    );
+    let output_glwe_secret_key =
+        test_allocate_and_generate_binary_glwe_secret_key_with_half_hamming_weight(
+            glwe_dimension,
+            polynomial_size,
+        );
 
     let output_lwe_secret_key = output_glwe_secret_key.as_lwe_secret_key();
     let output_lwe_dimension = output_lwe_secret_key.lwe_dimension();

--- a/tfhe/src/core_crypto/gpu/algorithms/test/noise_distribution/lwe_programmable_bootstrapping_noise.rs
+++ b/tfhe/src/core_crypto/gpu/algorithms/test/noise_distribution/lwe_programmable_bootstrapping_noise.rs
@@ -62,16 +62,16 @@ where
     let num_samples = NB_TESTS * <Scalar as CastInto<usize>>::cast_into(msg);
     let mut noise_samples = Vec::with_capacity(num_samples);
 
-    let input_lwe_secret_key = allocate_and_generate_new_binary_lwe_secret_key(
-        input_lwe_dimension,
-        &mut rsc.secret_random_generator,
-    );
+    let input_lwe_secret_key =
+        test_allocate_and_generate_binary_lwe_secret_key_with_half_hamming_weight(
+            input_lwe_dimension,
+        );
 
-    let output_glwe_secret_key = allocate_and_generate_new_binary_glwe_secret_key(
-        glwe_dimension,
-        polynomial_size,
-        &mut rsc.secret_random_generator,
-    );
+    let output_glwe_secret_key =
+        test_allocate_and_generate_binary_glwe_secret_key_with_half_hamming_weight(
+            glwe_dimension,
+            polynomial_size,
+        );
 
     let output_lwe_secret_key = output_glwe_secret_key.as_lwe_secret_key();
     let output_lwe_dimension = output_lwe_secret_key.lwe_dimension();

--- a/tfhe/src/core_crypto/gpu/algorithms/test/noise_distribution/mod.rs
+++ b/tfhe/src/core_crypto/gpu/algorithms/test/noise_distribution/mod.rs
@@ -1,4 +1,8 @@
 use super::*;
+use crate::core_crypto::algorithms::test::noise_distribution::{
+    test_allocate_and_generate_binary_glwe_secret_key_with_half_hamming_weight,
+    test_allocate_and_generate_binary_lwe_secret_key_with_half_hamming_weight,
+};
 
 mod lwe_multi_bit_programmable_bootstrapping_noise;
 mod lwe_programmable_bootstrapping_noise;


### PR DESCRIPTION
- allows to have less variability and matches exactly what the noise formulas expect for uniform binary secret keys