### PR TITLE
chore: fix typo in classic.rs

### DIFF
--- a/tfhe/src/shortint/parameters/classic.rs
+++ b/tfhe/src/shortint/parameters/classic.rs
@@ -54,7 +54,7 @@ impl ClassicPBSParameters {
     ///
     /// # Warning
     ///
-    /// Failing to fix the parameters properly would yield incorrect and unsecure computation.
+    /// Failing to fix the parameters properly would yield incorrect and insecure computation.
     /// Unless you are a cryptographer who really knows the impact of each of those parameters, you
     /// __must__ stick with the provided parameters.
     #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
### PR content/description
Hey team! I looked through the files and found a typo
also if you have any recommendations, I'd be glad to hear them

### Check-list:
* [x] Docs have been added / updated (for bug fixes / features)


