### PR TITLE
chore: fix typo in seeder.rs

### DIFF
--- a/tfhe/src/core_crypto/commons/generators/seeder.rs
+++ b/tfhe/src/core_crypto/commons/generators/seeder.rs
@@ -10,7 +10,7 @@ use crate::core_crypto::commons::math::random::{
 /// ## Why this Seeder implementation?
 ///
 /// [`Seeder`] is a trait available to the external user, and we expect some of them to implement
-/// their own seeding strategy. Since this trait is public, it means that the implementor can be
+/// their own seeding strategy. Since this trait is public, it means that the implementer can be
 /// arbitrarily slow. For this reason, it is better to only use it once when we initialize the
 /// engine, and use the CSPRNG to generate other seeds when needed, because that gives us the
 /// control on the performances.


### PR DESCRIPTION


### PR content/description
Hi devs! Fixed typo in _seeder.rs_
`implementor` - `implementer`

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

