### PR TITLE
fix(gpu): Fix expand bench on multi-gpus

### DIFF
--- a/tfhe/src/integer/gpu/ciphertext/compact_list.rs
+++ b/tfhe/src/integer/gpu/ciphertext/compact_list.rs
@@ -8,12 +8,10 @@ use crate::core_crypto::prelude::{
 use crate::integer::ciphertext::{CompactCiphertextListExpander, DataKind};
 use crate::integer::gpu::ciphertext::compressed_ciphertext_list::CudaExpandable;
 use crate::integer::gpu::ciphertext::info::{CudaBlockInfo, CudaRadixCiphertextInfo};
-use crate::integer::gpu::ciphertext::{
-    expand_async, CudaRadixCiphertext, CudaVec, KsType, LweDimension,
-};
+use crate::integer::gpu::ciphertext::{CudaRadixCiphertext, CudaVec, KsType, LweDimension};
 use crate::integer::gpu::key_switching_key::CudaKeySwitchingKey;
 use crate::integer::gpu::server_key::CudaBootstrappingKey;
-use crate::integer::gpu::PBSType;
+use crate::integer::gpu::{expand_async, PBSType};
 use crate::shortint::ciphertext::CompactCiphertextList;
 use crate::shortint::parameters::{
     CompactCiphertextListExpansionKind, Degree, LweBskGroupingFactor, NoiseLevel,

--- a/tfhe/src/integer/gpu/ciphertext/mod.rs
+++ b/tfhe/src/integer/gpu/ciphertext/mod.rs
@@ -4,27 +4,15 @@ pub mod compressed_ciphertext_list;
 pub mod info;
 pub mod squashed_noise;
 
-use crate::core_crypto::gpu::lwe_bootstrap_key::{
-    prepare_cuda_ms_noise_reduction_key_ffi, CudaModulusSwitchNoiseReductionKey,
-};
 use crate::core_crypto::gpu::lwe_ciphertext_list::CudaLweCiphertextList;
 use crate::core_crypto::gpu::vec::CudaVec;
 use crate::core_crypto::gpu::CudaStreams;
-use crate::core_crypto::prelude::{
-    LweBskGroupingFactor, LweCiphertextList, LweCiphertextOwned, Numeric, UnsignedInteger,
-};
+use crate::core_crypto::prelude::{LweCiphertextList, LweCiphertextOwned};
 use crate::integer::gpu::ciphertext::info::{CudaBlockInfo, CudaRadixCiphertextInfo};
-use crate::integer::gpu::PBSType;
-use crate::integer::parameters::{
-    DecompositionBaseLog, DecompositionLevelCount, GlweDimension, LweDimension, PolynomialSize,
-};
+use crate::integer::parameters::LweDimension;
 use crate::integer::{IntegerCiphertext, RadixCiphertext, SignedRadixCiphertext};
-use crate::shortint::{CarryModulus, Ciphertext, EncryptionKeyChoice, MessageModulus};
+use crate::shortint::{Ciphertext, EncryptionKeyChoice};
 use crate::GpuIndex;
-use tfhe_cuda_backend::bindings::{
-    cleanup_expand_without_verification_64, cuda_expand_without_verification_64,
-    scratch_cuda_expand_without_verification_64,
-};
 
 pub trait CudaIntegerRadixCiphertext: Sized {
     const IS_SIGNED: bool;
@@ -526,101 +514,4 @@ impl From<EncryptionKeyChoice> for KsType {
             EncryptionKeyChoice::Small => Self::BigToSmall,
         }
     }
-}
-
-#[allow(clippy::too_many_arguments)]
-/// # Safety
-///
-/// - `stream` __must__ be synchronized to guarantee computation has finished, and inputs must not
-///   be dropped until stream is synchronised
-///
-///
-/// In this method, the input `lwe_flattened_compact_array_in` represents a flattened compact list.
-/// Instead of receiving a `Vec<CompactCiphertextList>`, it takes a concatenation of all LWEs
-/// that were inside that vector of compact list. Handling the input this way removes the need
-/// to process multiple compact lists separately, simplifying GPU-based operations. The variable
-/// name `lwe_flattened_compact_array_in` makes this intent explicit.
-pub unsafe fn expand_async<T: UnsignedInteger, B: Numeric>(
-    streams: &CudaStreams,
-    lwe_array_out: &mut CudaLweCiphertextList<T>,
-    lwe_flattened_compact_array_in: &CudaVec<T>,
-    bootstrapping_key: &CudaVec<B>,
-    computing_ks_key: &CudaVec<T>,
-    casting_key: &CudaVec<T>,
-    message_modulus: MessageModulus,
-    carry_modulus: CarryModulus,
-    computing_glwe_dimension: GlweDimension,
-    computing_polynomial_size: PolynomialSize,
-    computing_lwe_dimension: LweDimension,
-    computing_ks_level: DecompositionLevelCount,
-    computing_ks_base_log: DecompositionBaseLog,
-    casting_input_lwe_dimension: LweDimension,
-    casting_output_lwe_dimension: LweDimension,
-    casting_ks_level: DecompositionLevelCount,
-    casting_ks_base_log: DecompositionBaseLog,
-    pbs_level: DecompositionLevelCount,
-    pbs_base_log: DecompositionBaseLog,
-    pbs_type: PBSType,
-    casting_key_type: KsType,
-    grouping_factor: LweBskGroupingFactor,
-    num_lwes_per_compact_list: &[u32],
-    is_boolean: &[bool],
-    noise_reduction_key: Option<&CudaModulusSwitchNoiseReductionKey>,
-) {
-    let ct_modulus = lwe_array_out.ciphertext_modulus().raw_modulus_float();
-    let mut mem_ptr: *mut i8 = std::ptr::null_mut();
-    let num_compact_lists = num_lwes_per_compact_list.len();
-
-    let ms_noise_reduction_key_ffi =
-        prepare_cuda_ms_noise_reduction_key_ffi(noise_reduction_key, ct_modulus);
-    let allocate_ms_noise_array = noise_reduction_key.is_some();
-
-    scratch_cuda_expand_without_verification_64(
-        streams.ptr.as_ptr(),
-        streams.gpu_indexes_ptr(),
-        streams.len() as u32,
-        std::ptr::addr_of_mut!(mem_ptr),
-        computing_glwe_dimension.0 as u32,
-        computing_polynomial_size.0 as u32,
-        computing_glwe_dimension
-            .to_equivalent_lwe_dimension(computing_polynomial_size)
-            .0 as u32,
-        computing_lwe_dimension.0 as u32,
-        computing_ks_level.0 as u32,
-        computing_ks_base_log.0 as u32,
-        casting_input_lwe_dimension.0 as u32,
-        casting_output_lwe_dimension.0 as u32,
-        casting_ks_level.0 as u32,
-        casting_ks_base_log.0 as u32,
-        pbs_level.0 as u32,
-        pbs_base_log.0 as u32,
-        grouping_factor.0 as u32,
-        num_lwes_per_compact_list.as_ptr(),
-        is_boolean.as_ptr(),
-        num_compact_lists as u32,
-        message_modulus.0 as u32,
-        carry_modulus.0 as u32,
-        pbs_type as u32,
-        casting_key_type as u32,
-        true,
-        allocate_ms_noise_array,
-    );
-    cuda_expand_without_verification_64(
-        streams.ptr.as_ptr(),
-        streams.gpu_indexes_ptr(),
-        streams.len() as u32,
-        lwe_array_out.0.d_vec.as_mut_c_ptr(0),
-        lwe_flattened_compact_array_in.as_c_ptr(0),
-        mem_ptr,
-        bootstrapping_key.ptr.as_ptr(),
-        computing_ks_key.ptr.as_ptr(),
-        casting_key.ptr.as_ptr(),
-        &raw const ms_noise_reduction_key_ffi,
-    );
-    cleanup_expand_without_verification_64(
-        streams.ptr.as_ptr(),
-        streams.gpu_indexes_ptr(),
-        streams.len() as u32,
-        std::ptr::addr_of_mut!(mem_ptr),
-    );
 }

--- a/tfhe/src/integer/gpu/mod.rs
+++ b/tfhe/src/integer/gpu/mod.rs
@@ -10,6 +10,7 @@ pub mod zk;
 use crate::core_crypto::gpu::lwe_bootstrap_key::{
     prepare_cuda_ms_noise_reduction_key_ffi, CudaModulusSwitchNoiseReductionKey,
 };
+use crate::core_crypto::gpu::lwe_ciphertext_list::CudaLweCiphertextList;
 use crate::core_crypto::gpu::slice::{CudaSlice, CudaSliceMut};
 use crate::core_crypto::gpu::vec::CudaVec;
 use crate::core_crypto::gpu::CudaStreams;
@@ -19,7 +20,7 @@ use crate::core_crypto::prelude::{
 };
 use crate::integer::block_decomposition::{BlockDecomposer, DecomposableInto};
 use crate::integer::gpu::ciphertext::boolean_value::CudaBooleanBlock;
-use crate::integer::gpu::ciphertext::CudaRadixCiphertext;
+use crate::integer::gpu::ciphertext::{CudaRadixCiphertext, KsType};
 use crate::integer::server_key::radix_parallel::OutputFlag;
 use crate::integer::server_key::ScalarMultiplier;
 use crate::integer::{ClientKey, RadixClientKey};
@@ -6637,6 +6638,138 @@ pub unsafe fn noise_squashing_async<T: UnsignedInteger, B: Numeric>(
     );
 
     cleanup_cuda_apply_noise_squashing_kb(
+        streams.ptr.as_ptr(),
+        streams.gpu_indexes_ptr(),
+        streams.len() as u32,
+        std::ptr::addr_of_mut!(mem_ptr),
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+/// # Safety
+///
+/// - `stream` __must__ be synchronized to guarantee computation has finished, and inputs must not
+///   be dropped until stream is synchronised
+///
+///
+/// In this method, the input `lwe_flattened_compact_array_in` represents a flattened compact list.
+/// Instead of receiving a `Vec<CompactCiphertextList>`, it takes a concatenation of all LWEs
+/// that were inside that vector of compact list. Handling the input this way removes the need
+/// to process multiple compact lists separately, simplifying GPU-based operations. The variable
+/// name `lwe_flattened_compact_array_in` makes this intent explicit.
+pub unsafe fn expand_async<T: UnsignedInteger, B: Numeric>(
+    streams: &CudaStreams,
+    lwe_array_out: &mut CudaLweCiphertextList<T>,
+    lwe_flattened_compact_array_in: &CudaVec<T>,
+    bootstrapping_key: &CudaVec<B>,
+    computing_ks_key: &CudaVec<T>,
+    casting_key: &CudaVec<T>,
+    message_modulus: MessageModulus,
+    carry_modulus: CarryModulus,
+    computing_glwe_dimension: GlweDimension,
+    computing_polynomial_size: PolynomialSize,
+    computing_lwe_dimension: LweDimension,
+    computing_ks_level: DecompositionLevelCount,
+    computing_ks_base_log: DecompositionBaseLog,
+    casting_input_lwe_dimension: LweDimension,
+    casting_output_lwe_dimension: LweDimension,
+    casting_ks_level: DecompositionLevelCount,
+    casting_ks_base_log: DecompositionBaseLog,
+    pbs_level: DecompositionLevelCount,
+    pbs_base_log: DecompositionBaseLog,
+    pbs_type: PBSType,
+    casting_key_type: KsType,
+    grouping_factor: LweBskGroupingFactor,
+    num_lwes_per_compact_list: &[u32],
+    is_boolean: &[bool],
+    noise_reduction_key: Option<&CudaModulusSwitchNoiseReductionKey>,
+) {
+    assert_eq!(
+        streams.gpu_indexes[0],
+        lwe_array_out.0.d_vec.gpu_index(0),
+        "GPU error: first stream is on GPU {}, first output pointer is on GPU {}",
+        streams.gpu_indexes[0].get(),
+        lwe_array_out.0.d_vec.gpu_index(0).get(),
+    );
+    assert_eq!(
+        streams.gpu_indexes[0],
+        lwe_flattened_compact_array_in.gpu_index(0),
+        "GPU error: first stream is on GPU {}, first output pointer is on GPU {}",
+        streams.gpu_indexes[0].get(),
+        lwe_flattened_compact_array_in.gpu_index(0).get(),
+    );
+    assert_eq!(
+        streams.gpu_indexes[0],
+        bootstrapping_key.gpu_indexes[0],
+        "GPU error: first stream is on GPU {}, first output pointer is on GPU {}",
+        streams.gpu_indexes[0].get(),
+        bootstrapping_key.gpu_indexes[0].get(),
+    );
+    assert_eq!(
+        streams.gpu_indexes[0],
+        computing_ks_key.gpu_indexes[0],
+        "GPU error: first stream is on GPU {}, first output pointer is on GPU {}",
+        streams.gpu_indexes[0].get(),
+        computing_ks_key.gpu_indexes[0].get(),
+    );
+    assert_eq!(
+        streams.gpu_indexes[0],
+        casting_key.gpu_indexes[0],
+        "GPU error: first stream is on GPU {}, first output pointer is on GPU {}",
+        streams.gpu_indexes[0].get(),
+        casting_key.gpu_indexes[0].get(),
+    );
+    let ct_modulus = lwe_array_out.ciphertext_modulus().raw_modulus_float();
+    let mut mem_ptr: *mut i8 = std::ptr::null_mut();
+    let num_compact_lists = num_lwes_per_compact_list.len();
+
+    let ms_noise_reduction_key_ffi =
+        prepare_cuda_ms_noise_reduction_key_ffi(noise_reduction_key, ct_modulus);
+    let allocate_ms_noise_array = noise_reduction_key.is_some();
+
+    scratch_cuda_expand_without_verification_64(
+        streams.ptr.as_ptr(),
+        streams.gpu_indexes_ptr(),
+        streams.len() as u32,
+        std::ptr::addr_of_mut!(mem_ptr),
+        computing_glwe_dimension.0 as u32,
+        computing_polynomial_size.0 as u32,
+        computing_glwe_dimension
+            .to_equivalent_lwe_dimension(computing_polynomial_size)
+            .0 as u32,
+        computing_lwe_dimension.0 as u32,
+        computing_ks_level.0 as u32,
+        computing_ks_base_log.0 as u32,
+        casting_input_lwe_dimension.0 as u32,
+        casting_output_lwe_dimension.0 as u32,
+        casting_ks_level.0 as u32,
+        casting_ks_base_log.0 as u32,
+        pbs_level.0 as u32,
+        pbs_base_log.0 as u32,
+        grouping_factor.0 as u32,
+        num_lwes_per_compact_list.as_ptr(),
+        is_boolean.as_ptr(),
+        num_compact_lists as u32,
+        message_modulus.0 as u32,
+        carry_modulus.0 as u32,
+        pbs_type as u32,
+        casting_key_type as u32,
+        true,
+        allocate_ms_noise_array,
+    );
+    cuda_expand_without_verification_64(
+        streams.ptr.as_ptr(),
+        streams.gpu_indexes_ptr(),
+        streams.len() as u32,
+        lwe_array_out.0.d_vec.as_mut_c_ptr(0),
+        lwe_flattened_compact_array_in.as_c_ptr(0),
+        mem_ptr,
+        bootstrapping_key.ptr.as_ptr(),
+        computing_ks_key.ptr.as_ptr(),
+        casting_key.ptr.as_ptr(),
+        &raw const ms_noise_reduction_key_ffi,
+    );
+    cleanup_expand_without_verification_64(
         streams.ptr.as_ptr(),
         streams.gpu_indexes_ptr(),
         streams.len() as u32,


### PR DESCRIPTION
This PR also changes number of elements used to compute throughput. The previous one was 7, which is too low.

```
Generating proven ciphertexts list (compute_load_proof)... 
zk::cuda::pke_zk_verify/zk::cuda::pke_zk_verify_only_expand::throughput::10_elemns_V1_3_PARAM_MULTI_...
                        time:   [438.77 ms 441.35 ms 443.91 ms]
                        thrpt:  [22.527  elem/s 22.658  elem/s 22.791  elem/s]
Found 2 outliers among 15 measurements (13.33%)
  1 (6.67%) low mild
  1 (6.67%) high severe
Generating proven ciphertexts list (compute_load_proof)... 
zk::cuda::pke_zk_verify/zk::cuda::pke_zk_verify_only_expand::throughput::50_elemns_V1_3_PARAM_MULTI_...
                        time:   [1.5834 s 1.6024 s 1.6215 s]
                        thrpt:  [30.837  elem/s 31.203  elem/s 31.577  elem/s]
Generating proven ciphertexts list (compute_load_proof)... 
zk::cuda::pke_zk_verify/zk::cuda::pke_zk_verify_only_expand::throughput::100_elemns_V1_3_PARAM_MULTI...
                        time:   [2.9559 s 2.9873 s 3.0208 s]
                        thrpt:  [33.104  elem/s 33.475  elem/s 33.831  elem/s]
Generating proven ciphertexts list (compute_load_proof)... 
Benchmarking zk::cuda::pke_zk_verify/zk::cuda::pke_zk_verify_only_expand::throughput::500_elemns_V1_3_PARAM_MULTI...: Warming up for 3.0000 s
Warning: Unable to complete 15 samples in 60.0s. You may wish to increase target time to 202.5s, or reduce sample count to 10.
zk::cuda::pke_zk_verify/zk::cuda::pke_zk_verify_only_expand::throughput::500_elemns_V1_3_PARAM_MULTI...
                        time:   [13.958 s 14.093 s 14.218 s]
                        thrpt:  [35.166  elem/s 35.478  elem/s 35.823  elem/s]
Generating proven ciphertexts list (compute_load_proof)... 
Benchmarking zk::cuda::pke_zk_verify/zk::cuda::pke_zk_verify_only_expand::throughput::1000_elemns_V1_3_PARAM_MULT...: Warming up for 3.0000 s
Warning: Unable to complete 15 samples in 60.0s. You may wish to increase target time to 389.8s, or reduce sample count to 10.
zk::cuda::pke_zk_verify/zk::cuda::pke_zk_verify_only_expand::throughput::1000_elemns_V1_3_PARAM_MULT...
                        time:   [26.825 s 27.120 s 27.368 s]
                        thrpt:  [36.539  elem/s 36.874  elem/s 37.279  elem/s]
Found 1 outliers among 15 measurements (6.67%)
  1 (6.67%) low mild
Generating proven ciphertexts list (compute_load_proof)... 
```

So I'm setting `num_gpus * 100`, which seems to be optimal.

```
zk::cuda::pke_zk_verify/zk::cuda::pke_zk_verify_only_expand::throughput::V1_3_PARAM_MULTI_BIT_GROUP_...
                        time:   [21.840 s 22.020 s 22.193 s]
                        thrpt:  [36.048  elem/s 36.330  elem/s 36.630  elem/s]
                 change:
                        time:   [+563.40% +572.24% +580.72%] (p = 0.00 < 0.05)
                        thrpt:  [-85.310% -85.124% -84.926%]
                        Performance has regressed.
Found 1 outliers among 15 measurements (6.67%)
```


<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: https://github.com/zama-ai/tfhe-rs-internal/issues/1056

### PR content/description

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
