### PR TITLE
chore(bench): write params to file for each zk benchmark on gpu

### DIFF
--- a/tfhe-benchmark/benches/integer/zk_pke.rs
+++ b/tfhe-benchmark/benches/integer/zk_pke.rs
@@ -710,15 +710,21 @@ mod cuda {
                         }
                     }
 
-                    write_to_json::<u64, _>(
-                        &bench_id_verify_and_expand,
-                        shortint_params,
-                        param_name,
-                        "pke_zk_verify_and_expand",
-                        &OperatorType::Atomic,
-                        shortint_params.message_modulus().0 as u32,
-                        vec![shortint_params.message_modulus().0.ilog2(); num_block],
-                    );
+                    for (bench_id, display_name) in [
+                        (bench_id_verify, "pke_zk_verify"),
+                        (bench_id_expand_without_verify, "pke_zk_verify_only_expand"),
+                        (bench_id_verify_and_expand, "pke_zk_verify_and_expand"),
+                    ] {
+                        write_to_json::<u64, _>(
+                            &bench_id,
+                            shortint_params,
+                            param_name,
+                            display_name,
+                            &OperatorType::Atomic,
+                            shortint_params.message_modulus().0 as u32,
+                            vec![shortint_params.message_modulus().0.ilog2(); num_block],
+                        );
+                    }
                 }
             }
         }


### PR DESCRIPTION
To be parsable each benchmark criterion ID must have their crypto details written to a file.