### PR TITLE
Fix version comparison logic for Rust minimum version check

### DIFF
--- a/scripts/check_cargo_min_ver.sh
+++ b/scripts/check_cargo_min_ver.sh
@@ -55,8 +55,10 @@ ver_minor="$(echo "${ver_string}" | cut -d '.' -f 2)"
 min_ver_major="$(echo "${MIN_RUST_VERSION}" | cut -d '.' -f 1)"
 min_ver_minor="$(echo "${MIN_RUST_VERSION}" | cut -d '.' -f 2)"
 
-if [[ "${ver_major}" -ge "${min_ver_major}" ]] && [[ "${ver_minor}" -ge "${min_ver_minor}" ]]; then
+if [[ "${ver_major}" -gt "${min_ver_major}" ]]; then
     exit 0
+elif [[ "${ver_major}" -eq "${min_ver_major}" ]] && [[ "${ver_minor}" -ge "${min_ver_minor}" ]]; then
+    exit 0
+else
+    exit 1
 fi
-
-exit 1


### PR DESCRIPTION
Corrected the logic for comparing Rust versions in the check_cargo_min_ver.sh script. Now, if the current major version is greater than the minimum required, the check passes immediately. If the major versions are equal, the minor version is compared. This prevents false negatives when using newer major Rust versions. Previously, the script could incorrectly fail if the current major version was higher but the minor version was lower than the minimum required.