### PR TITLE
fix(shortint): decrypt with the intermediate key for the standard ap

### DIFF
--- a/tfhe/src/shortint/client_key/atomic_pattern/ks32.rs
+++ b/tfhe/src/shortint/client_key/atomic_pattern/ks32.rs
@@ -9,7 +9,7 @@ use crate::shortint::backward_compatibility::client_key::atomic_pattern::KS32Ato
 use crate::shortint::client_key::{GlweSecretKeyOwned, LweSecretKeyOwned, LweSecretKeyView};
 use crate::shortint::engine::ShortintEngine;
 use crate::shortint::parameters::{DynamicDistribution, KeySwitch32PBSParameters};
-use crate::shortint::{AtomicPatternKind, ShortintParameterSet};
+use crate::shortint::{AtomicPatternKind, EncryptionKeyChoice, ShortintParameterSet};
 
 use super::EncryptionAtomicPattern;
 
@@ -156,6 +156,14 @@ impl EncryptionAtomicPattern for KS32AtomicPatternClientKey {
     fn encryption_key(&self) -> LweSecretKeyView<'_, u64> {
         // The KS32 atomic pattern is only supported with the KsPbs order
         self.glwe_secret_key.as_lwe_secret_key()
+    }
+
+    fn intermediate_encryption_key(&self) -> LweSecretKeyView<'_, u64> {
+        panic!("KS32 AP does not support decrypting with the intermediate encryption key")
+    }
+
+    fn encryption_key_choice(&self) -> EncryptionKeyChoice {
+        self.parameters.encryption_key_choice()
     }
 
     fn encryption_noise(&self) -> DynamicDistribution<u64> {

--- a/tfhe/src/shortint/client_key/atomic_pattern/standard.rs
+++ b/tfhe/src/shortint/client_key/atomic_pattern/standard.rs
@@ -254,14 +254,26 @@ impl EncryptionAtomicPattern for StandardAtomicPatternClientKey {
     }
 
     fn encryption_key(&self) -> LweSecretKeyView<'_, u64> {
-        match self.parameters.encryption_key_choice() {
+        match self.encryption_key_choice() {
             EncryptionKeyChoice::Big => self.large_lwe_secret_key(),
             EncryptionKeyChoice::Small => self.small_lwe_secret_key(),
         }
     }
 
+    fn intermediate_encryption_key(&self) -> LweSecretKeyView<'_, u64> {
+        // Use the opposite key as the one used for encryption
+        match self.encryption_key_choice() {
+            EncryptionKeyChoice::Big => self.small_lwe_secret_key(),
+            EncryptionKeyChoice::Small => self.large_lwe_secret_key(),
+        }
+    }
+
+    fn encryption_key_choice(&self) -> EncryptionKeyChoice {
+        self.parameters.encryption_key_choice()
+    }
+
     fn encryption_noise(&self) -> DynamicDistribution<u64> {
-        match self.parameters.encryption_key_choice() {
+        match self.encryption_key_choice() {
             EncryptionKeyChoice::Big => self.parameters.glwe_noise_distribution(),
             EncryptionKeyChoice::Small => self.parameters.lwe_noise_distribution(),
         }

--- a/tfhe/src/shortint/client_key/mod.rs
+++ b/tfhe/src/shortint/client_key/mod.rs
@@ -429,7 +429,13 @@ impl<AP: EncryptionAtomicPattern> GenericClientKey<AP> {
     /// assert!((noise as i64).abs() < delta as i64 / 2);
     /// ```
     pub fn decrypt_no_decode(&self, ct: &Ciphertext) -> Plaintext<u64> {
-        let lwe_decryption_key = self.encryption_key();
+        let lwe_decryption_key = if ct.atomic_pattern.pbs_order()
+            == self.atomic_pattern.encryption_key_choice().into_pbs_order()
+        {
+            self.encryption_key()
+        } else {
+            self.atomic_pattern.intermediate_encryption_key()
+        };
 
         decrypt_lwe_ciphertext(&lwe_decryption_key, &ct.ct)
     }


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description
Allows to decrypt the "intermediate ct" for the standard AP. For example, for KS-PBS, we have:

```
(ct big key) -> KS -> (ct small key) -> PBS -> (ct big key)
```

Here the intermediate ct is "ct small key".

Technically I don't think it is possible from the shortint API to access an intermediate since "apply lut" is done in a single step, but a user could create one by other means and want to decrypt it.

Before 1.3 (or 1.2 ?) the decryption used the PbsOrder stored inside the ct, so decrypting an intermediate ct worked if the pbs order was set correctly. Now we use the encryption key choice of the client key so it does not work anymore.

An issue arises with the KS32 AP, because the intermediate ct and key use different scalar than the external ones (u32 instead of u64). For this reason, this PR is only a temporary fix and only works for the standard ap. Supporting decryption of the intermediate ct for KS32 would require a larger rework.