### PR TITLE
fix(cuda): correct radix block mismatch check in LWE array validation

### DIFF
--- a/backends/tfhe-cuda-backend/cuda/src/integer/comparison.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/comparison.cu
@@ -48,7 +48,7 @@ void cuda_comparison_integer_radix_ciphertext_kb_64(
     void *const *bsks, void *const *ksks,
     CudaModulusSwitchNoiseReductionKeyFFI const *ms_noise_reduction_key) {
   PUSH_RANGE("comparison")
-  if (lwe_array_1->num_radix_blocks != lwe_array_1->num_radix_blocks)
+  if (lwe_array_1->num_radix_blocks != lwe_array_2->num_radix_blocks)
     PANIC("Cuda error: input num radix blocks must be the same")
   // The output ciphertext might be a boolean block or a radix ciphertext
   // depending on the case (eq/gt vs max/min) so the amount of blocks to


### PR DESCRIPTION

### PR content/description

#### Changes:

Fixed a logical error in comparing the number of radix blocks between two LWE arrays: `lwe_array_1` and `lwe_array_2`. Previously, the condition compared `lwe_array_1->num_radix_blocks` to itself, which could never be true, even if the input arrays were incompatible.

#### Why it matters:

This bug prevented invalid input from being detected, potentially leading to incorrect operations on ciphertexts. The updated condition now correctly detects and handles mismatched radix block sizes between input arrays.

#### Modified:

```cpp
- if (lwe_array_1->num_radix_blocks != lwe_array_1->num_radix_blocks)
+ if (lwe_array_1->num_radix_blocks != lwe_array_2->num_radix_blocks)
```

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
