### PR TITLE
fix: couple of typos in comment 

### DIFF
--- a/backends/tfhe-cuda-backend/cuda/include/zk/zk_utilities.h
+++ b/backends/tfhe-cuda-backend/cuda/include/zk/zk_utilities.h
@@ -138,7 +138,7 @@ template <typename Torus> struct zk_expand_mem {
     auto compact_list_id = 0;
     auto idx = 0;
     auto count = 0;
-    // During flatenning, all num_lwes LWEs from all compact lists are stored
+    // During flattening, all num_lwes LWEs from all compact lists are stored
     // sequentially on a Torus array. h_lwe_compact_input_indexes stores the
     // index of the first LWE related to the compact list that contains the i-th
     // LWE

--- a/backends/tfhe-cuda-backend/cuda/src/crypto/packing_keyswitch.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/crypto/packing_keyswitch.cuh
@@ -55,7 +55,7 @@ __global__ void decompose_vectorize_init(Torus const *lwe_in, Torus *lwe_out,
   lwe_out[write_state_idx] = state;
 }
 
-// Continue decomposiion of an array of Torus elements in place. Supposes
+// Continue decomposition of an array of Torus elements in place. Supposes
 // that the array contains already decomposed elements and
 // computes the new decomposed level in place.
 template <typename Torus>


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description

- `backends/tfhe-cuda-backend/cuda/include/zk/zk_utilities.h` - flatenning to [flattening](https://en.wikipedia.org/wiki/Flattening)
-  `backends/tfhe-cuda-backend/cuda/src/crypto/packing_keyswitch.cuh` - decomposiion to decomposition 
### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
