### PR TITLE
fix: correct typo in InvalidRangeError message

### DIFF
--- a/tfhe/src/error.rs
+++ b/tfhe/src/error.rs
@@ -103,7 +103,7 @@ impl Display for InvalidRangeError {
                 "The upper bound of the range is greater than the size of the integer"
             ),
             Self::WrongOrder => {
-                write!(f, "The upper gound is smaller than the lower bound")
+                write!(f, "The upper bound is smaller than the lower bound")
             }
         }
     }


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description

Fixed a typo in the error message for InvalidRangeError::WrongOrder where "gound" was incorrectly used instead of "bound". This makes the error message consistent with the documentation and other error messages in the codebase, improving the overall user experience

### Check-list:

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
