### PR TITLE
fix(bench): store correct pfail from params

### DIFF
--- a/tfhe-benchmark/src/utilities.rs
+++ b/tfhe-benchmark/src/utilities.rs
@@ -71,6 +71,7 @@ pub mod shortint_utils {
                         .try_to()
                         .expect("failed to convert ciphertext modulus"),
                 ),
+                error_probability: Some(2f64.powf(params.log2_p_fail())),
                 ..Default::default()
             }
         }
@@ -134,6 +135,9 @@ pub mod shortint_utils {
                     comp_params.packing_ks_key_noise_distribution,
                 ),
                 ciphertext_modulus: Some(pbs_params.ciphertext_modulus()),
+                error_probability: pbs_params
+                    .log2_p_fail()
+                    .map(|log2_pfail| 2f64.powf(log2_pfail)),
                 ..Default::default()
             }
         }
@@ -175,6 +179,7 @@ pub struct CryptoParametersRecord<Scalar: UnsignedInteger> {
     pub ciphertext_modulus: Option<CiphertextModulus<Scalar>>,
     pub lwe_per_glwe: Option<LweCiphertextCount>,
     pub storage_log_modulus: Option<CiphertextModulusLog>,
+    pub error_probability: Option<f64>,
 }
 
 impl<Scalar: UnsignedInteger> CryptoParametersRecord<Scalar> {
@@ -291,7 +296,7 @@ pub fn write_to_json<
         bit_size,
         polynomial_multiplication: PolynomialMultiplication::Fft,
         precision: (params.message_modulus.unwrap_or(2) as u32).ilog2(),
-        error_probability: 2f64.powf(-41.0),
+        error_probability: params.error_probability.unwrap_or(2f64.powf(-41.0)),
         integer_representation: IntegerRepresentation::Radix,
         decomposition_basis,
         pbs_algorithm: None, // To be added in future version

--- a/tfhe/src/shortint/parameters/ks32.rs
+++ b/tfhe/src/shortint/parameters/ks32.rs
@@ -122,6 +122,10 @@ impl KeySwitch32PBSParameters {
             .to_equivalent_lwe_dimension(self.polynomial_size())
     }
 
+    pub const fn log2_p_fail(&self) -> f64 {
+        self.log2_p_fail
+    }
+
     pub fn to_shortint_conformance_param(&self) -> CiphertextConformanceParams {
         let expected_dim = self
             .glwe_dimension

--- a/tfhe/src/shortint/parameters/mod.rs
+++ b/tfhe/src/shortint/parameters/mod.rs
@@ -630,6 +630,15 @@ impl ShortintParameterSet {
         }
     }
 
+    pub const fn log2_p_fail(&self) -> Option<f64> {
+        match self.inner {
+            ShortintParameterSetInner::PBSOnly(params) => Some(params.log2_p_fail()),
+            ShortintParameterSetInner::WopbsOnly(_) => None,
+            ShortintParameterSetInner::PBSAndWopbs(params, _) => Some(params.log2_p_fail()),
+            ShortintParameterSetInner::KS32PBS(params) => Some(params.log2_p_fail()),
+        }
+    }
+
     pub const fn pbs_only(&self) -> bool {
         self.inner.is_pbs_only()
     }


### PR DESCRIPTION
pfail in bench metadata was hardcoded to 2^-41, this uses the correct pfail from the parameters
