### PR TITLE
fix: Correct minor typos in keyswitch components

### DIFF
--- a/backends/tfhe-cuda-backend/cuda/src/crypto/keyswitch.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/crypto/keyswitch.cuh
@@ -125,7 +125,7 @@ __host__ void host_keyswitch_lwe_ciphertext_vector(
 
   int shared_mem = sizeof(Torus) * num_threads_y * num_threads_x;
   if (num_blocks_per_sample > 65536)
-    PANIC("Cuda error (Keyswith): number of blocks per sample is too large");
+    PANIC("Cuda error (Keyswitch): number of blocks per sample is too large");
 
   // In multiplication of large integers (512, 1024, 2048), the number of
   // samples can be larger than 65536, so we need to set it in the first

--- a/tfhe/src/core_crypto/algorithms/glwe_keyswitch.rs
+++ b/tfhe/src/core_crypto/algorithms/glwe_keyswitch.rs
@@ -173,7 +173,7 @@ pub fn keyswitch_glwe_ciphertext_native_mod_compatible<Scalar, KSKCont, InputCon
     assert!(
         glwe_keyswitch_key.polynomial_size() == input_glwe_ciphertext.polynomial_size(),
         "Mismatched input PolynomialSize. \
-        GlweKeyswithcKey input PolynomialSize: {:?}, input GlweCiphertext PolynomialSize {:?}.",
+        GlweKeyswitchKey input PolynomialSize: {:?}, input GlweCiphertext PolynomialSize {:?}.",
         glwe_keyswitch_key.polynomial_size(),
         input_glwe_ciphertext.polynomial_size(),
     );
@@ -254,7 +254,7 @@ pub fn keyswitch_glwe_ciphertext_other_mod<Scalar, KSKCont, InputCont, OutputCon
     assert!(
         glwe_keyswitch_key.polynomial_size() == input_glwe_ciphertext.polynomial_size(),
         "Mismatched input PolynomialSize. \
-        GlweKeyswithcKey input PolynomialSize: {:?}, input GlweCiphertext PolynomialSize {:?}.",
+        GlweKeyswitchKey input PolynomialSize: {:?}, input GlweCiphertext PolynomialSize {:?}.",
         glwe_keyswitch_key.polynomial_size(),
         input_glwe_ciphertext.polynomial_size(),
     );


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description

This PR addresses a couple of minor typos found in keyswitch-related code across different modules.
Rust (`core_crypto`): Corrected `GlweKeyswithcKey` to `GlweKeyswitchKey `in an assertion message.
CUDA: Corrected `Keyswith `to `Keyswitch `in a PANIC error message.

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
