### PR TITLE
chore(gpu): enhance scatter to check gpu count is ok

### DIFF
--- a/backends/tfhe-cuda-backend/cuda/src/integer/compression/compression.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/compression/compression.cuh
@@ -331,7 +331,8 @@ __host__ void host_integer_decompress(
     /// gather data to GPU 0 we can copy back to the original indexing
     multi_gpu_scatter_lwe_async<Torus>(
         streams, gpu_indexes, active_gpu_count, lwe_array_in_vec, extracted_lwe,
-        lut->h_lwe_indexes_in, lut->using_trivial_lwe_indexes, num_radix_blocks,
+        lut->h_lwe_indexes_in, lut->using_trivial_lwe_indexes,
+        lut->active_gpu_count, num_radix_blocks,
         compression_params.small_lwe_dimension + 1);
 
     /// Apply PBS

--- a/backends/tfhe-cuda-backend/cuda/src/integer/integer.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/integer.cuh
@@ -571,7 +571,7 @@ __host__ void integer_radix_apply_univariate_lookup_table_kb(
     multi_gpu_scatter_lwe_async<Torus>(
         streams, gpu_indexes, active_gpu_count, lwe_array_in_vec,
         (Torus *)lwe_array_in->ptr, lut->h_lwe_indexes_in,
-        lut->using_trivial_lwe_indexes, num_radix_blocks,
+        lut->using_trivial_lwe_indexes, lut->active_gpu_count, num_radix_blocks,
         big_lwe_dimension + 1);
 
     /// Apply KS to go from a big LWE dimension to a small LWE dimension
@@ -678,7 +678,7 @@ __host__ void integer_radix_apply_many_univariate_lookup_table_kb(
     multi_gpu_scatter_lwe_async<Torus>(
         streams, gpu_indexes, active_gpu_count, lwe_array_in_vec,
         (Torus *)lwe_array_in->ptr, lut->h_lwe_indexes_in,
-        lut->using_trivial_lwe_indexes, num_radix_blocks,
+        lut->using_trivial_lwe_indexes, lut->active_gpu_count, num_radix_blocks,
         big_lwe_dimension + 1);
 
     /// Apply KS to go from a big LWE dimension to a small LWE dimension
@@ -796,7 +796,7 @@ __host__ void integer_radix_apply_bivariate_lookup_table_kb(
     multi_gpu_scatter_lwe_async<Torus>(
         streams, gpu_indexes, active_gpu_count, lwe_array_in_vec,
         (Torus *)lwe_array_pbs_in->ptr, lut->h_lwe_indexes_in,
-        lut->using_trivial_lwe_indexes, num_radix_blocks,
+        lut->using_trivial_lwe_indexes, lut->active_gpu_count, num_radix_blocks,
         big_lwe_dimension + 1);
 
     /// Apply KS to go from a big LWE dimension to a small LWE dimension
@@ -2313,8 +2313,8 @@ __host__ void integer_radix_apply_noise_squashing_kb(
     multi_gpu_scatter_lwe_async<InputTorus>(
         streams, gpu_indexes, active_gpu_count, lwe_array_in_vec,
         (InputTorus *)lwe_array_pbs_in->ptr, lut->h_lwe_indexes_in,
-        lut->using_trivial_lwe_indexes, lwe_array_out->num_radix_blocks,
-        lut->input_big_lwe_dimension + 1);
+        lut->using_trivial_lwe_indexes, lut->active_gpu_count,
+        lwe_array_out->num_radix_blocks, lut->input_big_lwe_dimension + 1);
 
     execute_keyswitch_async<InputTorus>(
         streams, gpu_indexes, active_gpu_count, lwe_after_ks_vec,

--- a/backends/tfhe-cuda-backend/cuda/src/utils/helper_multi_gpu.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/utils/helper_multi_gpu.cuh
@@ -100,9 +100,13 @@ void multi_gpu_scatter_lwe_async(cudaStream_t const *streams,
                                  uint32_t const *gpu_indexes,
                                  uint32_t gpu_count, std::vector<Torus *> &dest,
                                  Torus const *src, Torus const *h_src_indexes,
-                                 bool is_trivial_index, uint32_t num_inputs,
-                                 uint32_t lwe_size) {
+                                 bool is_trivial_index,
+                                 uint32_t max_active_gpu_count,
+                                 uint32_t num_inputs, uint32_t lwe_size) {
 
+  if (max_active_gpu_count < gpu_count)
+    PANIC("Cuda error: number of gpus in scatter should be <= number of gpus "
+          "used to create the lut")
   cuda_synchronize_stream(streams[0], gpu_indexes[0]);
   dest.resize(gpu_count);
   for (uint i = 0; i < gpu_count; i++) {


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description

Taking a look at scatter, it can't be a function of int_radix_lut as it is also used for the noise squashing lut (which is a different struct). What I can do to avoid possible errors in the future is check that the gpu count given as input to scatter does not exceed the active gpu count used to create the lut. 

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
