### PR TITLE
DO NOT MERGE wip wrappers cuda

### DIFF
--- a/backends/tfhe-cuda-backend/cuda/include/integer/integer_utilities.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer/integer_utilities.h
@@ -2,7 +2,7 @@
 #define CUDA_INTEGER_UTILITIES_H
 
 #include "integer.h"
-#include "integer/radix_ciphertext.cuh"
+#include "../../src/integer/radix_ciphertext.cuh"
 #include "integer/radix_ciphertext.h"
 #include "keyswitch/keyswitch.h"
 #include "pbs/programmable_bootstrap.cuh"

--- a/backends/tfhe-cuda-backend/cuda/include/zk/zk.h
+++ b/backends/tfhe-cuda-backend/cuda/include/zk/zk.h
@@ -3,6 +3,7 @@
 
 #include "../keyswitch/ks_enums.h"
 #include "../pbs/pbs_enums.h"
+#include "zk_utilities.h"
 #include <stdint.h>
 
 extern "C" {
@@ -13,6 +14,12 @@ void cuda_lwe_expand_64(void *const stream, uint32_t gpu_index,
                         const uint32_t *lwe_compact_input_indexes,
                         const uint32_t *output_body_id_per_compact_list);
 
+
+void alternate_cuda_lwe_expand_64(void *const stream, uint32_t gpu_index,
+                                  void *lwe_array_out,
+                                  uint32_t lwe_dimension, uint32_t num_lwe,
+                                  const expand_job<uint64_t> *jobs);
+
 uint64_t scratch_cuda_expand_without_verification_64(
     void *const *streams, uint32_t const *gpu_indexes, uint32_t gpu_count,
     int8_t **mem_ptr, uint32_t glwe_dimension, uint32_t polynomial_size,
@@ -21,6 +28,7 @@ uint64_t scratch_cuda_expand_without_verification_64(
     uint32_t casting_input_dimension, uint32_t casting_output_dimension,
     uint32_t casting_ks_level, uint32_t casting_ks_base_log, uint32_t pbs_level,
     uint32_t pbs_base_log, uint32_t grouping_factor,
+    uint64_t *flattened_lwe_compact_lists,
     const uint32_t *num_lwes_per_compact_list, const bool *is_boolean_array,
     uint32_t num_compact_lists, uint32_t message_modulus,
     uint32_t carry_modulus, PBS_TYPE pbs_type, KS_TYPE casting_key_type,

--- a/backends/tfhe-cuda-backend/cuda/src/integer/radix_ciphertext.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/radix_ciphertext.cuh
@@ -1,7 +1,7 @@
 #ifndef CUDA_INTEGER_RADIX_CIPHERTEXT_CUH
 #define CUDA_INTEGER_RADIX_CIPHERTEXT_CUH
 
-#include "device.h"
+#include "../../include/device.h"
 #include "integer/integer.h"
 #include "integer/radix_ciphertext.h"
 #include "utils/helper_profile.cuh"

--- a/backends/tfhe-cuda-backend/cuda/src/zk/expand.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/zk/expand.cu
@@ -63,3 +63,52 @@ void cuda_lwe_expand_64(void *const stream, uint32_t gpu_index,
     break;
   }
 }
+
+void alternate_cuda_lwe_expand_64(void *const stream, uint32_t gpu_index,
+                                  void *lwe_array_out,
+                                  uint32_t lwe_dimension, uint32_t num_lwe,
+                                  const expand_job<uint64_t> *jobs) {
+
+  switch (lwe_dimension) {
+  case 256:
+    alternate_host_lwe_expand<uint64_t, AmortizedDegree<256>>(
+        static_cast<cudaStream_t>(stream), gpu_index,
+        static_cast<uint64_t *>(lwe_array_out), num_lwe, jobs);
+    break;
+  case 512:
+    alternate_host_lwe_expand<uint64_t, AmortizedDegree<512>>(
+        static_cast<cudaStream_t>(stream), gpu_index,
+        static_cast<uint64_t *>(lwe_array_out), num_lwe, jobs);
+    break;
+  case 1024:
+    alternate_host_lwe_expand<uint64_t, AmortizedDegree<1024>>(
+        static_cast<cudaStream_t>(stream), gpu_index,
+        static_cast<uint64_t *>(lwe_array_out), num_lwe, jobs);
+    break;
+  case 2048:
+    alternate_host_lwe_expand<uint64_t, AmortizedDegree<2048>>(
+        static_cast<cudaStream_t>(stream), gpu_index,
+        static_cast<uint64_t *>(lwe_array_out), num_lwe, jobs);
+    break;
+  case 4096:
+    alternate_host_lwe_expand<uint64_t, AmortizedDegree<4096>>(
+        static_cast<cudaStream_t>(stream), gpu_index,
+        static_cast<uint64_t *>(lwe_array_out), num_lwe, jobs);
+    break;
+  case 8192:
+    alternate_host_lwe_expand<uint64_t, AmortizedDegree<8192>>(
+        static_cast<cudaStream_t>(stream), gpu_index,
+        static_cast<uint64_t *>(lwe_array_out), num_lwe, jobs);
+    break;
+  case 16384:
+    alternate_host_lwe_expand<uint64_t, AmortizedDegree<16384>>(
+        static_cast<cudaStream_t>(stream), gpu_index,
+        static_cast<uint64_t *>(lwe_array_out), num_lwe, jobs);
+    break;
+  default:
+    PANIC("CUDA error: lwe_dimension not supported."
+          "Supported n's are powers of two"
+          " in the interval [256..16384].");
+    break;
+  }
+}

--- a/backends/tfhe-cuda-backend/cuda/src/zk/expand.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/zk/expand.cuh
@@ -5,6 +5,7 @@
 #include "polynomial/functions.cuh"
 #include "polynomial/polynomial_math.cuh"
 #include "zk/zk.h"
+#include "zk/zk_utilities.h"
 #include <cstdint>
 
 #include "utils/helper.cuh"
@@ -66,6 +67,57 @@ void host_lwe_expand(cudaStream_t stream, int gpu_index, Torus *lwe_array_out,
   lwe_expand<Torus, params><<<num_blocks, threads_per_block, 0, stream>>>(
       lwe_compact_array_in, lwe_array_out, lwe_compact_input_indexes,
       output_body_id_per_compact_list);
+  check_cuda_error(cudaGetLastError());
+}
+
+// Expand a LweCompactCiphertextList into a LweCiphertextList
+// - Each x-block computes one output ciphertext
+template <typename Torus, class params>
+__global__ void alternative_lwe_expand(const expand_job<Torus> *jobs,
+                                       Torus *lwe_array_out) {
+  const auto lwe_output_id = blockIdx.x;
+  const auto lwe_dimension = params::degree;
+
+  const auto job = &jobs[lwe_output_id];
+
+  const auto input_mask = job->mask_to_use.mask;
+  const auto input_body = job->body_to_use.body;
+
+  auto output_mask = &lwe_array_out[(lwe_dimension + 1) * lwe_output_id];
+  auto output_body = &output_mask[lwe_dimension];
+
+  // We rotate the input mask by i to calculate the mask related to the i-th
+  // output
+  const auto monomial_degree = job->body_to_use.monomial_degree;
+  polynomial_accumulate_monic_monomial_mul<Torus>(
+      output_mask, input_mask, monomial_degree, threadIdx.x, lwe_dimension,
+      params::opt, true);
+
+  // The output body is just copied
+  if (threadIdx.x == 0)
+    *output_body = *input_body;
+}
+
+template <typename Torus, class params>
+void alternate_host_lwe_expand(cudaStream_t stream, int gpu_index,
+                               Torus *lwe_array_out, uint32_t num_lwes,
+                               const expand_job<Torus> *jobs) {
+  // Set the GPU device
+  cudaSetDevice(gpu_index);
+
+  uint32_t threads_per_block = params::degree / params::opt;
+  uint32_t num_blocks = num_lwes;
+  auto lwe_dimension = params::degree;
+
+  // Check if lwe_dimension is a power of 2
+  // For now, and probably forever, we only support lwe_dimension being a power
+  // of 2
+  if (!is_power_of_2(lwe_dimension))
+    PANIC("Error: lwe_dimension must be a power of 2");
+
+  // Launch the `lwe_expand` kernel
+  alternative_lwe_expand<Torus, params>
+      <<<num_blocks, threads_per_block, 0, stream>>>(jobs, lwe_array_out);
   check_cuda_error(cudaGetLastError());
 }
 #endif // EXPAND_CUH

--- a/backends/tfhe-cuda-backend/cuda/src/zk/zk.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/zk/zk.cu
@@ -8,6 +8,7 @@ uint64_t scratch_cuda_expand_without_verification_64(
     uint32_t casting_input_dimension, uint32_t casting_output_dimension,
     uint32_t casting_ks_level, uint32_t casting_ks_base_log, uint32_t pbs_level,
     uint32_t pbs_base_log, uint32_t grouping_factor,
+    uint64_t *flattened_lwe_compact_lists,
     const uint32_t *num_lwes_per_compact_list, const bool *is_boolean_array,
     uint32_t num_compact_lists, uint32_t message_modulus,
     uint32_t carry_modulus, PBS_TYPE pbs_type, KS_TYPE casting_key_type,
@@ -36,6 +37,7 @@ uint64_t scratch_cuda_expand_without_verification_64(
   return scratch_cuda_expand_without_verification<uint64_t>(
       (cudaStream_t *)streams, gpu_indexes, gpu_count,
       reinterpret_cast<zk_expand_mem<uint64_t> **>(mem_ptr),
+      flattened_lwe_compact_lists, casting_input_dimension,
       num_lwes_per_compact_list, is_boolean_array, num_compact_lists,
       computing_params, casting_params, casting_key_type, allocate_gpu_memory);
 }

--- a/backends/tfhe-cuda-backend/cuda/src/zk/zk.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/zk/zk.cuh
@@ -32,10 +32,16 @@ __host__ void host_expand_without_verification(
   auto d_lwe_compact_input_indexes = mem_ptr->d_lwe_compact_input_indexes;
   auto d_body_id_per_compact_list = mem_ptr->d_body_id_per_compact_list;
   if (sizeof(Torus) == 8) {
-    cuda_lwe_expand_64(streams[0], gpu_indexes[0], expanded_lwes,
-                       lwe_flattened_compact_array_in, lwe_dimension, num_lwes,
-                       d_lwe_compact_input_indexes, d_body_id_per_compact_list);
-
+    if (false) {
+      cuda_lwe_expand_64(streams[0], gpu_indexes[0], expanded_lwes,
+                         lwe_flattened_compact_array_in, lwe_dimension,
+                         num_lwes, d_lwe_compact_input_indexes,
+                         d_body_id_per_compact_list);
+    } else {
+      alternate_cuda_lwe_expand_64(streams[0], gpu_indexes[0], expanded_lwes,
+                                   lwe_dimension, num_lwes,
+                                   mem_ptr->d_expand_jobs);
+    }
   } else
     PANIC("Cuda error: expand is only supported on 64 bits")
 
@@ -85,6 +91,8 @@ template <typename Torus>
 __host__ uint64_t scratch_cuda_expand_without_verification(
     cudaStream_t const *streams, uint32_t const *gpu_indexes,
     uint32_t gpu_count, zk_expand_mem<Torus> **mem_ptr,
+    Torus *flattened_lwe_compact_lists,
+    const uint32_t flattened_lwe_compact_list_lwe_dimension,
     const uint32_t *num_lwes_per_compact_list, const bool *is_boolean_array,
     uint32_t num_compact_lists, int_radix_params computing_params,
     int_radix_params casting_params, KS_TYPE casting_key_type,
@@ -93,8 +101,9 @@ __host__ uint64_t scratch_cuda_expand_without_verification(
   uint64_t size_tracker = 0;
   *mem_ptr = new zk_expand_mem<Torus>(
       streams, gpu_indexes, gpu_count, computing_params, casting_params,
-      casting_key_type, num_lwes_per_compact_list, is_boolean_array,
-      num_compact_lists, allocate_gpu_memory, size_tracker);
+      casting_key_type, flattened_lwe_compact_lists,
+      flattened_lwe_compact_list_lwe_dimension, num_lwes_per_compact_list,
+      is_boolean_array, num_compact_lists, allocate_gpu_memory, size_tracker);
   return size_tracker;
 }
 

--- a/backends/tfhe-cuda-backend/src/bindings.rs
+++ b/backends/tfhe-cuda-backend/src/bindings.rs
@@ -1778,6 +1778,7 @@ unsafe extern "C" {
         pbs_level: u32,
         pbs_base_log: u32,
         grouping_factor: u32,
+        flattened_lwe_compact_lists: *mut u64,
         num_lwes_per_compact_list: *const u32,
         is_boolean_array: *const bool,
         num_compact_lists: u32,

--- a/tfhe/src/integer/gpu/mod.rs
+++ b/tfhe/src/integer/gpu/mod.rs
@@ -7463,6 +7463,7 @@ pub unsafe fn expand_async<T: UnsignedInteger, B: Numeric>(
         pbs_level.0 as u32,
         pbs_base_log.0 as u32,
         grouping_factor.0 as u32,
+        lwe_flattened_compact_array_in.as_c_ptr(0),
         num_lwes_per_compact_list.as_ptr(),
         is_boolean.as_ptr(),
         num_compact_lists as u32,


### PR DESCRIPTION
This is an attempt at simplifying the indexing logic in the expand cuda code, looks to be nearly working but I can't get around C++ header madness.

This proposal needs a better way of indexing in the flattened list (caching the result in the constructor) at the moment the algorithm re walks the list to find the start of each list which is not good.

My way of writing the wrapper structs naively probably means it's suboptimal for data copy, given some fields like `monomial_degree` for the `compact_lwe_body` are raw uint64_t, most likely meaning it's on the CPU side and CUDA has to make extra work to get the metadata to the GPU, this can likely be easily mitigated by having a pointer to data on the GPU where the proper information would be copied from the host, just a warning here that the code is a "this is the general idea, it needs refinement to fit the max performance requirements of the GPU"

I think this can be pushed further and remove the output pointer from the CUDA kernel and the kernel would only take a "jobs" struct pointer as input coming from the scratch struct. Each thread block fetches its own job with the pointer indexing already computed on the host side and stored in each of the jobs.

I think this is fine as a general idea given the scratch struct allocations are tightly coupled to the actual content of the compact list (said otherwise, the scratch is tailor made for the given compact list and can therefore not be reused for any other list).

Not sure it applies well to other cases given lwe_expand is apparently an outlier, but pushing the logic further, a scratch struct can be turned into a "task" struct that not only holds additional buffers, but also computes the indices for all required inputs by the kernels

cc @pdroalves 