### PR TITLE
chore: check packing is possible before packing in integer noise squashing

### DIFF
--- a/tfhe/src/integer/noise_squashing/keys.rs
+++ b/tfhe/src/integer/noise_squashing/keys.rs
@@ -306,7 +306,9 @@ impl NoiseSquashingKey {
             .blocks
             .par_chunks(2)
             .map(|two_values| {
-                let packed = src_server_key.pack_block_chunk(two_values);
+                let packed = src_server_key
+                    .can_pack_block_chunk(two_values)
+                    .map(|two_values| src_server_key.pack_block_chunk(two_values))?;
 
                 self.key
                     .checked_squash_ciphertext_noise(&packed, &src_server_key.key)


### PR DESCRIPTION
I'm open to other ways of writing the API, seemed ok like this but probably not required like that