### PR TITLE
refactor!: Use NonZero<T> in DataKind 

### DIFF
--- a/tfhe/src/high_level_api/compact_list.rs
+++ b/tfhe/src/high_level_api/compact_list.rs
@@ -45,7 +45,7 @@ impl crate::FheTypes {
         Some(match data_kind {
             DataKind::Unsigned(n) => {
                 let num_bits_per_block = message_modulus.0.ilog2() as usize;
-                let num_bits = n * num_bits_per_block;
+                let num_bits = n.get() * num_bits_per_block;
                 match num_bits {
                     2 => Self::Uint2,
                     4 => Self::Uint4,
@@ -93,7 +93,7 @@ impl crate::FheTypes {
             }
             DataKind::Signed(n) => {
                 let num_bits_per_block = message_modulus.0.ilog2() as usize;
-                let num_bits = n * num_bits_per_block;
+                let num_bits = n.get() * num_bits_per_block;
                 match num_bits {
                     2 => Self::Int2,
                     4 => Self::Int4,

--- a/tfhe/src/high_level_api/compressed_ciphertext_list.rs
+++ b/tfhe/src/high_level_api/compressed_ciphertext_list.rs
@@ -1,3 +1,4 @@
+use std::num::NonZero;
 use tfhe_versionable::{Unversionize, UnversionizeError, Versionize, VersionizeOwned};
 
 use super::details::MaybeCloned;
@@ -40,14 +41,18 @@ impl<Id: FheUintId> HlCompressible for FheUint<Id> {
         match self.ciphertext {
             crate::high_level_api::integers::unsigned::RadixCiphertext::Cpu(cpu_radix) => {
                 let blocks = cpu_radix.blocks;
-                let kind = DataKind::Unsigned(blocks.len());
-                messages.push((ToBeCompressed::Cpu(blocks), kind));
+                if let Some(n) = NonZero::new(blocks.len()) {
+                    let kind = DataKind::Unsigned(n);
+                    messages.push((ToBeCompressed::Cpu(blocks), kind));
+                }
             }
             #[cfg(feature = "gpu")]
             crate::high_level_api::integers::unsigned::RadixCiphertext::Cuda(gpu_radix) => {
                 let blocks = gpu_radix.ciphertext;
-                let kind = DataKind::Unsigned(blocks.info.blocks.len());
-                messages.push((ToBeCompressed::Cuda(blocks), kind));
+                if let Some(n) = NonZero::new(blocks.info.blocks.len()) {
+                    let kind = DataKind::Unsigned(n);
+                    messages.push((ToBeCompressed::Cuda(blocks), kind));
+                }
             }
             #[cfg(feature = "hpu")]
             crate::high_level_api::integers::unsigned::RadixCiphertext::Hpu(_) => {
@@ -61,14 +66,18 @@ impl<Id: FheIntId> HlCompressible for FheInt<Id> {
         match self.ciphertext {
             crate::high_level_api::integers::signed::SignedRadixCiphertext::Cpu(cpu_radix) => {
                 let blocks = cpu_radix.blocks;
-                let kind = DataKind::Signed(blocks.len());
-                messages.push((ToBeCompressed::Cpu(blocks), kind));
+                if let Some(n) = NonZero::new(blocks.len()) {
+                    let kind = DataKind::Signed(n);
+                    messages.push((ToBeCompressed::Cpu(blocks), kind));
+                }
             }
             #[cfg(feature = "gpu")]
             crate::high_level_api::integers::signed::SignedRadixCiphertext::Cuda(gpu_radix) => {
                 let blocks = gpu_radix.ciphertext;
-                let kind = DataKind::Signed(blocks.info.blocks.len());
-                messages.push((ToBeCompressed::Cuda(blocks), kind));
+                if let Some(n) = NonZero::new(blocks.info.blocks.len()) {
+                    let kind = DataKind::Signed(n);
+                    messages.push((ToBeCompressed::Cuda(blocks), kind));
+                }
             }
         }
     }
@@ -646,7 +655,7 @@ pub mod gpu {
             self,
             messages: &mut Vec<CudaRadixCiphertext>,
             streams: &CudaStreams,
-        ) -> DataKind {
+        ) -> Option<DataKind> {
             self.ciphertext
                 .into_gpu(streams)
                 .compress_into(messages, streams)
@@ -658,7 +667,7 @@ pub mod gpu {
             self,
             messages: &mut Vec<CudaRadixCiphertext>,
             streams: &CudaStreams,
-        ) -> DataKind {
+        ) -> Option<DataKind> {
             self.ciphertext
                 .into_gpu(streams)
                 .compress_into(messages, streams)
@@ -670,7 +679,7 @@ pub mod gpu {
             self,
             messages: &mut Vec<CudaRadixCiphertext>,
             streams: &CudaStreams,
-        ) -> DataKind {
+        ) -> Option<DataKind> {
             self.ciphertext
                 .into_gpu(streams)
                 .compress_into(messages, streams)

--- a/tfhe/src/high_level_api/strings/ascii/mod.rs
+++ b/tfhe/src/high_level_api/strings/ascii/mod.rs
@@ -432,10 +432,14 @@ impl crate::HlCompressible for FheAsciiString {
             AsciiDevice::Cpu(fhe_string) => {
                 let mut blocks = vec![];
                 let data_kind = fhe_string.compress_into(&mut blocks);
-                messages.push((
-                    crate::high_level_api::compressed_ciphertext_list::ToBeCompressed::Cpu(blocks),
-                    data_kind,
-                ));
+                if let Some(data_kind) = data_kind {
+                    messages.push((
+                        crate::high_level_api::compressed_ciphertext_list::ToBeCompressed::Cpu(
+                            blocks,
+                        ),
+                        data_kind,
+                    ));
+                }
             }
         }
     }

--- a/tfhe/src/integer/backward_compatibility/ciphertext/mod.rs
+++ b/tfhe/src/integer/backward_compatibility/ciphertext/mod.rs
@@ -1,7 +1,3 @@
-use std::convert::Infallible;
-
-use tfhe_versionable::{Upgrade, Version, VersionsDispatch};
-
 use crate::integer::ciphertext::{
     BaseCrtCiphertext, BaseRadixCiphertext, BaseSignedRadixCiphertext, CompactCiphertextList,
     CompressedCiphertextList, CompressedModulusSwitchedRadixCiphertext,
@@ -13,6 +9,9 @@ use crate::integer::BooleanBlock;
 #[cfg(feature = "zk-pok")]
 use crate::integer::ProvenCompactCiphertextList;
 use crate::shortint::ciphertext::CompressedModulusSwitchedCiphertext;
+use std::convert::Infallible;
+use std::num::NonZero;
+use tfhe_versionable::{Upgrade, Version, VersionsDispatch};
 
 #[derive(VersionsDispatch)]
 pub enum BaseRadixCiphertextVersions<Block> {
@@ -44,7 +43,10 @@ impl Upgrade<CompactCiphertextList> for CompactCiphertextListV0 {
         // Since we can't guess the type of data here, we set them by default as unsigned integer.
         // Since it this data comes from 0.6, if it is included in a homogeneous compact list it
         // will be converted to the right type at expand time.
-        let info = vec![DataKind::Unsigned(self.num_blocks_per_integer); radix_count];
+
+        let info = NonZero::new(self.num_blocks_per_integer)
+            .map(|n| vec![DataKind::Unsigned(n); radix_count])
+            .unwrap_or_default();
 
         Ok(CompactCiphertextList::from_raw_parts(self.ct_list, info))
     }
@@ -62,9 +64,40 @@ pub enum ProvenCompactCiphertextListVersions {
     V0(ProvenCompactCiphertextList),
 }
 
+#[derive(Version)]
+pub enum DataKindV0 {
+    /// The held value is a number of radix blocks.
+    Unsigned(usize),
+    /// The held value is a number of radix blocks.
+    Signed(usize),
+    Boolean,
+    String {
+        n_chars: u32,
+        padded: bool,
+    },
+}
+
 #[derive(VersionsDispatch)]
 pub enum DataKindVersions {
-    V0(DataKind),
+    V0(DataKindV0),
+    V1(DataKind),
+}
+
+impl Upgrade<DataKind> for DataKindV0 {
+    type Error = crate::Error;
+
+    fn upgrade(self) -> Result<DataKind, Self::Error> {
+        match self {
+            Self::Unsigned(n) => NonZero::new(n)
+                .ok_or_else(|| crate::error!("DataKind::Unsigned requires non-zero block count"))
+                .map(DataKind::Unsigned),
+            Self::Signed(n) => NonZero::new(n)
+                .ok_or_else(|| crate::error!("DataKind::Signed requires non-zero block count"))
+                .map(DataKind::Signed),
+            Self::Boolean => Ok(DataKind::Boolean),
+            Self::String { n_chars, padded } => Ok(DataKind::String { n_chars, padded }),
+        }
+    }
 }
 
 #[derive(VersionsDispatch)]

--- a/tfhe/src/integer/ciphertext/compressed_ciphertext_list.rs
+++ b/tfhe/src/integer/ciphertext/compressed_ciphertext_list.rs
@@ -6,40 +6,41 @@ use crate::shortint::ciphertext::CompressedCiphertextList as ShortintCompressedC
 use crate::shortint::Ciphertext;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
+use std::num::NonZero;
 use tfhe_versionable::Versionize;
 
 pub trait Compressible {
-    fn compress_into(self, messages: &mut Vec<Ciphertext>) -> DataKind;
+    fn compress_into(self, messages: &mut Vec<Ciphertext>) -> Option<DataKind>;
 }
 
 impl Compressible for BooleanBlock {
-    fn compress_into(self, messages: &mut Vec<Ciphertext>) -> DataKind {
+    fn compress_into(self, messages: &mut Vec<Ciphertext>) -> Option<DataKind> {
         messages.push(self.0);
-        DataKind::Boolean
+        Some(DataKind::Boolean)
     }
 }
 
 impl Compressible for RadixCiphertext {
-    fn compress_into(self, messages: &mut Vec<Ciphertext>) -> DataKind {
+    fn compress_into(self, messages: &mut Vec<Ciphertext>) -> Option<DataKind> {
         let num_blocks = self.blocks.len();
 
         for block in self.blocks {
             messages.push(block);
         }
 
-        DataKind::Unsigned(num_blocks)
+        NonZero::new(num_blocks).map(DataKind::Unsigned)
     }
 }
 
 impl Compressible for SignedRadixCiphertext {
-    fn compress_into(self, messages: &mut Vec<Ciphertext>) -> DataKind {
+    fn compress_into(self, messages: &mut Vec<Ciphertext>) -> Option<DataKind> {
         let num_blocks = self.blocks.len();
 
         for block in self.blocks {
             messages.push(block);
         }
 
-        DataKind::Signed(num_blocks)
+        NonZero::new(num_blocks).map(DataKind::Signed)
     }
 }
 
@@ -63,12 +64,38 @@ impl CompressedCiphertextListBuilder {
         T: Compressible,
     {
         let n = self.ciphertexts.len();
-        let kind = data.compress_into(&mut self.ciphertexts);
-        let num_blocks = self
-            .ciphertexts
-            .last()
-            .map_or(0, |ct| kind.num_blocks(ct.message_modulus));
+        let maybe_kind = data.compress_into(&mut self.ciphertexts);
+
+        let Some(modulus) = self.ciphertexts.last().map(|ct| ct.message_modulus) else {
+            // This means the list of blocks is still empty, so we assert the kind is None
+            // i.e no type pushed, except for strings as we allow empty strings
+            if matches!(maybe_kind, Some(DataKind::String { .. })) {
+                self.info.push(maybe_kind.unwrap());
+            } else {
+                assert!(
+                    maybe_kind.is_none(),
+                    "Internal error: Incoherent block count with regard to kind"
+                );
+            }
+
+            return self;
+        };
+
+        let Some(kind) = maybe_kind else {
+            assert_eq!(
+                n,
+                self.ciphertexts.len(),
+                "Internal error: Incoherent block count with regard to kind"
+            );
+            return self;
+        };
+
+        let num_blocks = kind.num_blocks(modulus);
+
+        // Check that the number of blocks that were added matches the
+        // number of blocks advertised by the DataKind
         assert_eq!(n + num_blocks, self.ciphertexts.len());
+
         self.info.push(kind);
         self
     }

--- a/tfhe/src/integer/ciphertext/utils.rs
+++ b/tfhe/src/integer/ciphertext/utils.rs
@@ -2,15 +2,16 @@ use super::{BooleanBlock, IntegerRadixCiphertext};
 use crate::integer::backward_compatibility::ciphertext::DataKindVersions;
 use crate::shortint::{Ciphertext, MessageModulus};
 use serde::{Deserialize, Serialize};
+use std::num::NonZeroUsize;
 use tfhe_versionable::Versionize;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Versionize)]
 #[versionize(DataKindVersions)]
 pub enum DataKind {
     /// The held value is a number of radix blocks.
-    Unsigned(usize),
+    Unsigned(NonZeroUsize),
     /// The held value is a number of radix blocks.
-    Signed(usize),
+    Signed(NonZeroUsize),
     Boolean,
     String {
         n_chars: u32,
@@ -21,7 +22,7 @@ pub enum DataKind {
 impl DataKind {
     pub fn num_blocks(self, message_modulus: MessageModulus) -> usize {
         match self {
-            Self::Unsigned(n) | Self::Signed(n) => n,
+            Self::Unsigned(n) | Self::Signed(n) => n.get(),
             Self::Boolean => 1,
             Self::String { n_chars, .. } => {
                 let blocks_per_char = 7u32.div_ceil(message_modulus.0.ilog2());

--- a/tfhe/src/integer/gpu/ciphertext/compact_list.rs
+++ b/tfhe/src/integer/gpu/ciphertext/compact_list.rs
@@ -248,8 +248,8 @@ impl CudaFlattenedVecCompactCiphertextList {
             .flat_map(|data_kind| {
                 let repetitions = match data_kind {
                     DataKind::Boolean => 1,
-                    DataKind::Signed(x) => *x,
-                    DataKind::Unsigned(x) => *x,
+                    DataKind::Signed(x) => x.get(),
+                    DataKind::Unsigned(x) => x.get(),
                     DataKind::String { .. } => panic!("DataKind not supported on GPUs"),
                 };
                 std::iter::repeat_n(matches!(data_kind, DataKind::Boolean), repetitions)

--- a/tfhe/src/integer/gpu/zk/mod.rs
+++ b/tfhe/src/integer/gpu/zk/mod.rs
@@ -155,6 +155,7 @@ mod tests {
         ProvenCompactCiphertextList,
     };
     use crate::shortint::parameters::test_params::TEST_PARAM_PKE_TO_BIG_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128_ZKV2;
+    use std::num::NonZero;
     // TODO test params update for the v1_3
     use crate::shortint::parameters::current_params::V1_3_PARAM_KEYSWITCH_PKE_TO_BIG_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
     use crate::shortint::parameters::{
@@ -426,8 +427,8 @@ mod tests {
             for _ in 0..infos_block_count {
                 let map_to_fake_boolean = random::<u8>() % 2 == 1;
                 if map_to_fake_boolean {
-                    if curr_block_count != 0 {
-                        new_infos.push(DataKind::Unsigned(curr_block_count));
+                    if let Some(count) = NonZero::new(curr_block_count) {
+                        new_infos.push(DataKind::Unsigned(count));
                         curr_block_count = 0;
                     }
                     new_infos.push(DataKind::Boolean);
@@ -435,8 +436,8 @@ mod tests {
                     curr_block_count += 1;
                 }
             }
-            if curr_block_count != 0 {
-                new_infos.push(DataKind::Unsigned(curr_block_count));
+            if let Some(count) = NonZero::new(curr_block_count) {
+                new_infos.push(DataKind::Unsigned(count));
             }
 
             assert_eq!(

--- a/tfhe/src/shortint/ciphertext/compact_list.rs
+++ b/tfhe/src/shortint/ciphertext/compact_list.rs
@@ -228,4 +228,8 @@ impl CompactCiphertextList {
     pub fn size_bytes(&self) -> usize {
         self.ct_list.size_bytes()
     }
+
+    pub fn is_packed(&self) -> bool {
+        self.degree.get() > self.message_modulus.corresponding_max_degree().get()
+    }
 }

--- a/tfhe/src/zk/mod.rs
+++ b/tfhe/src/zk/mod.rs
@@ -318,7 +318,7 @@ impl Named for SerializableCompactPkePublicParams {
     const NAME: &'static str = ZkCompactPkeV1PublicParams::NAME;
 }
 
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub enum ZkVerificationOutcome {
     /// The proof and its entity were valid
     Valid,

--- a/utils/tfhe-versionable/src/lib.rs
+++ b/utils/tfhe-versionable/src/lib.rs
@@ -18,7 +18,7 @@ use std::convert::Infallible;
 use std::error::Error;
 use std::fmt::Display;
 use std::marker::PhantomData;
-use std::num::Wrapping;
+use std::num::{NonZero, Wrapping};
 use std::sync::Arc;
 
 pub use derived_traits::{Version, VersionsDispatch};
@@ -267,6 +267,9 @@ impl_scalar_versionize!(f32);
 impl_scalar_versionize!(f64);
 
 impl_scalar_versionize!(char);
+
+impl_scalar_versionize!(NonZero<u32>);
+impl_scalar_versionize!(NonZero<usize>);
 
 impl<T: Versionize> Versionize for Wrapping<T> {
     type Versioned<'vers>


### PR DESCRIPTION
Change the type used to store a block count in
DataKind to NonZero. This makes it impossible to store
'empty' kinds such as DataKind::Unsigned(0), DataKind::Signed(0).

Also, when deserializing, if the count is zero and error will be
returned, adding an additional layer of sanitization.