### PR TITLE
fix(benches): fix hlapi dex benchmark transfer function

### DIFF
--- a/tfhe-benchmark/benches/high_level_api/dex.rs
+++ b/tfhe-benchmark/benches/high_level_api/dex.rs
@@ -208,8 +208,7 @@ where
 {
     let mut new_balance = old_balance.clone();
     if total_dex_other_token_in != 0 {
-        let (_, new_balance_tmp) =
-            transfer_whitepaper(current_dex_balance, old_balance, amount_out);
+        let (_, new_balance_tmp) = transfer_no_cmux(current_dex_balance, old_balance, amount_out);
         new_balance = new_balance_tmp;
     }
     new_balance


### PR DESCRIPTION
Small fix: the type of ERC20 transfer was missed and using whitepaper instead of no-cmux in the no-cmux variant.
