### PR TITLE
fix(core): use of deprecated rayon repeatn

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ itertools = "0.14"
 num-complex = "0.4"
 pulp = { version = "0.21", default-features = false }
 rand = "0.8"
-rayon = "1"
+rayon = "1.11"
 serde = { version = "1.0", default-features = false }
 wasm-bindgen = "0.2.100"
 

--- a/tfhe-csprng/src/generators/aes_ctr/parallel.rs
+++ b/tfhe-csprng/src/generators/aes_ctr/parallel.rs
@@ -43,7 +43,7 @@ impl<BlockCipher: AesBlockCipher> AesCtrGenerator<BlockCipher> {
         let first_index = self.state.table_index().incremented();
         let output = (0..n_children.0)
             .into_par_iter()
-            .zip(rayon::iter::repeatn(
+            .zip(rayon::iter::repeat_n(
                 (self.block_cipher.clone(), first_index, n_bytes),
                 n_children.0,
             ))

--- a/tfhe/src/core_crypto/commons/traits/contiguous_entity_container.rs
+++ b/tfhe/src/core_crypto/commons/traits/contiguous_entity_container.rs
@@ -257,7 +257,7 @@ pub trait ContiguousEntityContainer: AsRef<[Self::Element]> {
         let entity_view_pod_size = self.get_entity_view_pod_size();
         self.as_ref()
             .par_chunks_exact(entity_view_pod_size)
-            .zip(rayon::iter::repeatn(meta, entity_count))
+            .zip(rayon::iter::repeat_n(meta, entity_count))
             .map(|(elt, meta)| Self::EntityView::<'this>::create_from(elt, meta))
     }
 
@@ -278,7 +278,7 @@ pub trait ContiguousEntityContainer: AsRef<[Self::Element]> {
         let meta = self.get_self_view_creation_metadata();
         self.as_ref()
             .par_chunks(pod_chunk_size)
-            .zip(rayon::iter::repeatn(meta, entity_count))
+            .zip(rayon::iter::repeat_n(meta, entity_count))
             .map(|(elt, meta)| Self::SelfView::<'_>::create_from(elt, meta))
     }
 
@@ -304,7 +304,7 @@ pub trait ContiguousEntityContainer: AsRef<[Self::Element]> {
         let meta = self.get_self_view_creation_metadata();
         self.as_ref()
             .par_chunks_exact(pod_chunk_size)
-            .zip(rayon::iter::repeatn(meta, entity_count))
+            .zip(rayon::iter::repeat_n(meta, entity_count))
             .map(|(elt, meta)| Self::SelfView::<'_>::create_from(elt, meta))
     }
 }
@@ -471,7 +471,7 @@ pub trait ContiguousEntityContainerMut: ContiguousEntityContainer + AsMut<[Self:
         let entity_view_pod_size = self.get_entity_view_pod_size();
         self.as_mut()
             .par_chunks_exact_mut(entity_view_pod_size)
-            .zip(rayon::iter::repeatn(meta, entity_count))
+            .zip(rayon::iter::repeat_n(meta, entity_count))
             .map(|(elt, meta)| Self::EntityMutView::<'this>::create_from(elt, meta))
     }
 
@@ -492,7 +492,7 @@ pub trait ContiguousEntityContainerMut: ContiguousEntityContainer + AsMut<[Self:
         let meta = self.get_self_view_creation_metadata();
         self.as_mut()
             .par_chunks_mut(pod_chunk_size)
-            .zip(rayon::iter::repeatn(meta, entity_count))
+            .zip(rayon::iter::repeat_n(meta, entity_count))
             .map(|(elt, meta)| Self::SelfMutView::<'_>::create_from(elt, meta))
     }
 
@@ -518,7 +518,7 @@ pub trait ContiguousEntityContainerMut: ContiguousEntityContainer + AsMut<[Self:
         let meta = self.get_self_view_creation_metadata();
         self.as_mut()
             .par_chunks_exact_mut(pod_chunk_size)
-            .zip(rayon::iter::repeatn(meta, entity_count))
+            .zip(rayon::iter::repeat_n(meta, entity_count))
             .map(|(elt, meta)| Self::SelfMutView::<'_>::create_from(elt, meta))
     }
 }


### PR DESCRIPTION
currently the warning is blocking the ci: https://github.com/zama-ai/tfhe-rs/actions/runs/16932199296/job/47980172445?pr=2641

rayon 1.11 is needed because `repeat_n` does not exist in 1.10