### PR TITLE
feat(integer): add KVStore

### DIFF
--- a/tfhe/src/integer/server_key/mod.rs
+++ b/tfhe/src/integer/server_key/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod crt;
 mod crt_parallel;
 pub(crate) mod radix;
 pub(crate) mod radix_parallel;
+pub use radix_parallel::kv_store::KVStore;
 
 use super::backward_compatibility::server_key::{CompressedServerKeyVersions, ServerKeyVersions};
 use crate::conformance::ParameterSetConformant;

--- a/tfhe/src/integer/server_key/radix_parallel/kv_store.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/kv_store.rs
@@ -1,0 +1,354 @@
+use crate::integer::block_decomposition::{Decomposable, DecomposableInto};
+use crate::integer::prelude::ServerKeyDefaultCMux;
+use crate::integer::{BooleanBlock, IntegerRadixCiphertext, ServerKey};
+use crate::prelude::CastInto;
+use rayon::prelude::*;
+use std::collections::HashMap;
+use std::hash::Hash;
+use std::num::NonZeroUsize;
+
+pub struct KVStore<Key, Ct> {
+    data: HashMap<Key, Ct>,
+    block_count: Option<NonZeroUsize>,
+}
+
+impl<Key, Ct> KVStore<Key, Ct> {
+    pub fn new() -> Self {
+        Self {
+            data: HashMap::new(),
+            block_count: None,
+        }
+    }
+
+    pub fn get(&self, key: &Key) -> Option<&Ct>
+    where
+        Key: Eq + Hash,
+    {
+        self.data.get(key)
+    }
+
+    /// Inserts the value for the key
+    ///
+    /// Returns the previous value stored for the key if there was any
+    ///
+    /// # Notes
+    ///
+    /// If the value does not contain blocks, nothing is inserted and None is returned
+    ///
+    /// # Panics
+    ///
+    /// Panics if the number of blocks of the value is not the same as all other
+    /// values stored
+    pub fn insert(&mut self, key: Key, value: Ct) -> Option<Ct>
+    where
+        Key: PartialEq + Ord + Eq + Hash,
+        Ct: IntegerRadixCiphertext,
+    {
+        let n_blocks = value.blocks().len();
+        if n_blocks == 0 {
+            return None;
+        }
+
+        let n = self
+            .block_count
+            .get_or_insert_with(|| NonZeroUsize::new(n_blocks).unwrap());
+
+        assert_eq!(
+            n.get(),
+            n_blocks,
+            "All ciphertexts must have the same number of blocks"
+        );
+        self.data.insert(key, value)
+    }
+
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&Key, &Ct)>
+    where
+        Key: Eq + Hash + Sync,
+        Ct: Send,
+    {
+        self.data.iter()
+    }
+
+    fn par_iter_keys(&self) -> impl ParallelIterator<Item = &Key>
+    where
+        Key: Send + Sync + Hash + Eq,
+        Ct: Send + Sync,
+    {
+        self.data.par_iter().map(|(k, _)| k)
+    }
+}
+
+impl<Key, Ct> Default for KVStore<Key, Ct>
+where
+    Self: Sized,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ServerKey {
+    /// Internal function used to perform a binary operation
+    /// on an entry.
+    ///
+    /// `encrypted_key`: The key of the slot
+    /// `func`: function that receives to arguments:
+    ///     * A boolean block that encrypts `true` if the corresponding key is the same as the
+    ///       `encrypted_key`
+    ///     * a `& mut` to the ciphertext which stores the value
+    fn kv_store_binary_op_to_slot<Key, Ct, F>(
+        &self,
+        map: &mut KVStore<Key, Ct>,
+        encrypted_key: &Ct,
+        func: F,
+    ) where
+        Ct: IntegerRadixCiphertext,
+        Key: Decomposable + CastInto<usize> + Hash + Eq,
+        F: Fn(&BooleanBlock, &mut Ct) + Sync + Send,
+    {
+        let kv_vec: Vec<(&Key, &mut Ct)> = map.data.iter_mut().collect();
+
+        // For each clear key, get a boolean ciphertext that tells if it's
+        // equal to the encrypted key
+        let selectors =
+            self.compute_equality_selectors(encrypted_key, kv_vec.par_iter().map(|(k, _v)| **k));
+
+        kv_vec
+            .into_par_iter()
+            .zip(selectors.par_iter())
+            .for_each(|((_k, current_ct), selector)| func(selector, current_ct));
+    }
+
+    /// Performs an addition on an entry of the store
+    ///
+    /// `map[encrypted_key] += value`
+    ///
+    /// This finds the value that corresponds to the given `encrypted_key `
+    /// and adds `value` to it.
+    pub fn kv_store_add_to_slot<Key, Ct>(
+        &self,
+        map: &mut KVStore<Key, Ct>,
+        encrypted_key: &Ct,
+        value: &Ct,
+    ) where
+        Ct: IntegerRadixCiphertext,
+        Key: Decomposable + CastInto<usize> + Hash + Eq,
+    {
+        self.kv_store_binary_op_to_slot(map, encrypted_key, |selector, v| {
+            let mut ct_to_add = value.clone();
+            self.zero_out_if_condition_is_false(&mut ct_to_add, &selector.0);
+            self.add_assign_parallelized(v, &ct_to_add);
+        });
+    }
+
+    /// Performs an addition by a clear on an entry of the store
+    ///
+    /// `map[encrypted_key] += value`
+    ///
+    /// This finds the value that corresponds to the given `encrypted_key `
+    /// and adds `value` to it.
+    pub fn kv_store_scalar_add_to_slot<Key, Ct, Clear>(
+        &self,
+        map: &mut KVStore<Key, Ct>,
+        encrypted_key: &Ct,
+        value: Clear,
+    ) where
+        Ct: IntegerRadixCiphertext,
+        Key: Decomposable + CastInto<usize> + Hash + Eq,
+        Clear: DecomposableInto<u64>,
+    {
+        self.kv_store_binary_op_to_slot(map, encrypted_key, |selector, v| {
+            let ct_to_add =
+                self.scalar_cmux_parallelized(selector, value, Clear::ZERO, v.blocks().len());
+            self.add_assign_parallelized(v, &ct_to_add);
+        });
+    }
+
+    /// Performs a subtraction on an entry of the store
+    ///
+    /// `map[encrypted_key] -= value`
+    ///
+    /// This finds the value that corresponds to the given `encrypted_key`,
+    /// and subtracts `value` to it.
+    pub fn kv_store_sub_to_slot<Key, Ct>(
+        &self,
+        map: &mut KVStore<Key, Ct>,
+        encrypted_key: &Ct,
+        value: &Ct,
+    ) where
+        Ct: IntegerRadixCiphertext,
+        Key: Decomposable + CastInto<usize> + Hash + Eq,
+    {
+        self.kv_store_binary_op_to_slot(map, encrypted_key, |selector, v| {
+            let mut ct_to_sub = value.clone();
+            self.zero_out_if_condition_is_false(&mut ct_to_sub, &selector.0);
+            self.sub_assign_parallelized(v, &ct_to_sub);
+        });
+    }
+
+    /// Performs a multiplication on an entry of the store
+    ///
+    /// `map[encrypted_key] *= value`
+    ///
+    /// This finds the value that corresponds to the given `encrypted_key`,
+    /// and multiplies it by `value`.
+    pub fn kv_store_mul_to_slot<Key, Ct>(
+        &self,
+        map: &mut KVStore<Key, Ct>,
+        encrypted_key: &Ct,
+        value: &Ct,
+    ) where
+        Ct: IntegerRadixCiphertext,
+        Key: Decomposable + CastInto<usize> + Hash + Eq,
+        Self: for<'a> ServerKeyDefaultCMux<u64, &'a Ct, Output = Ct>,
+    {
+        self.kv_store_binary_op_to_slot(map, encrypted_key, |selector, v| {
+            let selector = self.boolean_bitnot(selector);
+            let ct_to_mul = self.if_then_else_parallelized(&selector, 1u64, value);
+            self.mul_assign_parallelized(v, &ct_to_mul);
+        });
+    }
+
+    /// Implementation of the get function that additionally returns the Vec of selectors
+    /// so it can be reused to avoid re-computing it.
+    fn kv_store_get_impl<Key, Ct>(
+        &self,
+        map: &KVStore<Key, Ct>,
+        encrypted_key: &Ct,
+    ) -> (Ct, BooleanBlock, Vec<BooleanBlock>)
+    where
+        Ct: IntegerRadixCiphertext,
+        Key: Decomposable + CastInto<usize> + Hash + Eq,
+    {
+        let selectors =
+            self.compute_equality_selectors(encrypted_key, map.par_iter_keys().copied());
+
+        let (result, check_block) = rayon::join(
+            || {
+                let kv_vec: Vec<(&Key, &Ct)> = map.data.iter().collect();
+                let one_hot = kv_vec
+                    .into_par_iter()
+                    .zip(selectors.par_iter())
+                    .map(|((_, v), s)| {
+                        let mut result = v.clone();
+                        self.zero_out_if_condition_is_false(&mut result, &s.0);
+                        result
+                    })
+                    .collect::<Vec<_>>();
+
+                self.aggregate_one_hot_vector(one_hot)
+            },
+            || {
+                let selectors = selectors.iter().map(|s| s.0.clone()).collect::<Vec<_>>();
+                BooleanBlock::new_unchecked(self.is_at_least_one_comparisons_block_true(selectors))
+            },
+        );
+
+        (result, check_block, selectors)
+    }
+
+    /// Returns the value at the given key
+    ///
+    /// `return map[encrypted_key]`
+    ///
+    /// This finds the value that corresponds to the given `encrypted_key`,
+    /// and returns it.
+    /// It also returns a boolean block that encrypts `true` if an entry for
+    /// the `encrypted_key` was found.
+    ///
+    /// If the key was not found, the returned value is an encryption of zero
+    pub fn kv_store_get<Key, Ct>(
+        &self,
+        map: &KVStore<Key, Ct>,
+        encrypted_key: &Ct,
+    ) -> (Ct, BooleanBlock)
+    where
+        Ct: IntegerRadixCiphertext,
+        Key: Decomposable + CastInto<usize> + Hash + Eq,
+    {
+        let (result, check_block, _selectors) = self.kv_store_get_impl(map, encrypted_key);
+        (result, check_block)
+    }
+
+    /// Updates the value at the given key by the given value
+    ///
+    /// `map[encrypted_key] = new_value`
+    ///
+    /// This finds the value that corresponds to the given `encrypted_key`,
+    /// then updates the value stored with the `new_value`.
+    ///
+    /// Returns a boolean block that encrypts `true` if an entry for
+    /// the `encrypted_key` was found, and thus the update was done
+    pub fn kv_store_update<Key, Ct>(
+        &self,
+        map: &mut KVStore<Key, Ct>,
+        encrypted_key: &Ct,
+        new_value: &Ct,
+    ) -> BooleanBlock
+    where
+        Ct: IntegerRadixCiphertext,
+        Key: Decomposable + CastInto<usize> + Hash + Eq,
+    {
+        let selectors =
+            self.compute_equality_selectors(encrypted_key, map.par_iter_keys().copied());
+
+        rayon::join(
+            || {
+                let kv_vec: Vec<(&Key, &mut Ct)> = map.data.iter_mut().collect();
+                kv_vec
+                    .into_par_iter()
+                    .zip(selectors.par_iter())
+                    .for_each(|((_, old_value), s)| {
+                        *old_value = self.if_then_else_parallelized(s, new_value, old_value);
+                    });
+            },
+            || {
+                let selectors = selectors.iter().map(|s| s.0.clone()).collect::<Vec<_>>();
+                BooleanBlock::new_unchecked(self.is_at_least_one_comparisons_block_true(selectors))
+            },
+        )
+        .1
+    }
+
+    /// Updates the value at the given key by applying a function
+    ///
+    /// `map[encrypted_key] = func(map[encrypted_value])`
+    ///
+    /// This finds the value that corresponds to the given `encrypted_key`, then
+    /// calls `func` then updates the value stored with the one returned by the `func`.
+    ///
+    /// Returns the new value and a boolean block that encrypts `true` if an entry for
+    /// the `encrypted_key` was found.
+    pub fn kv_store_map<Key, Ct, F>(
+        &self,
+        map: &mut KVStore<Key, Ct>,
+        encrypted_key: &Ct,
+        func: F,
+    ) -> (Ct, BooleanBlock)
+    where
+        Ct: IntegerRadixCiphertext,
+        Key: Decomposable + CastInto<usize> + Hash + Eq,
+        F: Fn(Ct) -> Ct,
+    {
+        let (result, check_block, selectors) = self.kv_store_get_impl(map, encrypted_key);
+        let new_value = func(result);
+
+        let kv_vec: Vec<(&Key, &mut Ct)> = map.data.iter_mut().collect();
+        kv_vec
+            .into_par_iter()
+            .zip(selectors.par_iter())
+            .for_each(|((_, old_value), s)| {
+                *old_value = self.if_then_else_parallelized(s, &new_value, old_value);
+            });
+
+        (new_value, check_block)
+    }
+}

--- a/tfhe/src/integer/server_key/radix_parallel/mod.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/mod.rs
@@ -24,6 +24,7 @@ mod sum;
 
 mod count_zeros_ones;
 pub(crate) mod ilog2;
+pub(crate) mod kv_store;
 mod reverse_bits;
 mod scalar_dot_prod;
 mod slice;

--- a/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/mod.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod test_comparison;
 mod test_count_zeros_ones;
 pub(crate) mod test_div_mod;
 pub(crate) mod test_ilog2;
+pub(crate) mod test_kv_store;
 pub(crate) mod test_mul;
 pub(crate) mod test_neg;
 pub(crate) mod test_rotate;

--- a/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_kv_store.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_kv_store.rs
@@ -1,0 +1,486 @@
+use crate::integer::keycache::KEY_CACHE;
+use crate::integer::server_key::radix_parallel::tests_cases_unsigned::FunctionExecutor;
+use crate::integer::server_key::radix_parallel::tests_unsigned::{CpuFunctionExecutor, NB_CTXT};
+use crate::integer::server_key::KVStore;
+use crate::integer::tests::create_parameterized_test;
+use crate::integer::{BooleanBlock, IntegerKeyKind, RadixCiphertext, RadixClientKey, ServerKey};
+use crate::shortint::parameters::test_params::*;
+use crate::shortint::parameters::{TestParameters, *};
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+create_parameterized_test!(integer_default_kv_store_add);
+create_parameterized_test!(integer_default_kv_store_sub);
+create_parameterized_test!(integer_default_kv_store_mul);
+create_parameterized_test!(integer_default_kv_store_get_update);
+create_parameterized_test!(integer_default_kv_store_map);
+
+fn integer_default_kv_store_add(params: impl Into<TestParameters>) {
+    let executor = CpuFunctionExecutor::new(&ServerKey::kv_store_add_to_slot);
+    default_kv_store_add_test(params, executor);
+}
+
+fn integer_default_kv_store_sub(params: impl Into<TestParameters>) {
+    let executor = CpuFunctionExecutor::new(&ServerKey::kv_store_sub_to_slot);
+    default_kv_store_sub_test(params, executor);
+}
+
+fn integer_default_kv_store_mul(params: impl Into<TestParameters>) {
+    let executor = CpuFunctionExecutor::new(&ServerKey::kv_store_mul_to_slot);
+    default_kv_store_mul_test(params, executor);
+}
+
+fn integer_default_kv_store_get_update(params: impl Into<TestParameters>) {
+    let get_executor = CpuFunctionExecutor::new(&ServerKey::kv_store_get);
+    let update_executor = CpuFunctionExecutor::new(&ServerKey::kv_store_update);
+    default_kv_store_get_update_test(params, get_executor, update_executor);
+}
+
+fn integer_default_kv_store_map(params: impl Into<TestParameters>) {
+    let closure = |sks: &ServerKey,
+                   store: &mut KVStore<u8, RadixCiphertext>,
+                   encrypted_key: &RadixCiphertext,
+                   func: &dyn Fn(RadixCiphertext) -> RadixCiphertext| {
+        sks.kv_store_map(store, encrypted_key, func)
+    };
+    let map_executor = CpuFunctionExecutor::new(closure);
+    default_kv_store_map_test(params, map_executor);
+}
+
+pub type KeyType = u8;
+
+fn default_kv_store_add_test<P, T>(params: P, mut kv_store_add: T)
+where
+    P: Into<TestParameters>,
+    T: for<'a> FunctionExecutor<
+        (
+            &'a mut KVStore<KeyType, RadixCiphertext>,
+            &'a RadixCiphertext,
+            &'a RadixCiphertext,
+        ),
+        (),
+    >,
+{
+    let params = params.into();
+    let (cks, mut sks) = KEY_CACHE.get_from_params(params, IntegerKeyKind::Radix);
+    let cks = RadixClientKey::from((cks, NB_CTXT));
+
+    sks.set_deterministic_pbs_execution(true);
+    let sks = Arc::new(sks);
+
+    let nb_blocks_key = get_num_block_for_key(params.message_modulus());
+
+    // message_modulus^vec_length
+    let modulus = cks.parameters().message_modulus().0.pow(NB_CTXT as u32);
+
+    kv_store_add.setup(&cks, sks);
+
+    let num_keys = 20usize;
+    let (mut map, mut clear_store) = create_filled_stores(num_keys, modulus, &cks);
+
+    // Test modifying a key that does not exist
+    for _ in 0..num_keys.div_ceil(2) {
+        let key = generate_unused_key(&clear_store);
+        let encrypted_key = cks.as_ref().encrypt_radix(key, nb_blocks_key);
+
+        let value_to_add = rand::random::<u64>() % modulus;
+        let encrypted_value_to_add: RadixCiphertext = cks.encrypt(value_to_add);
+        kv_store_add.execute((&mut map, &encrypted_key, &encrypted_value_to_add));
+
+        panic_if_not_the_same(&map, &clear_store, &cks);
+    }
+
+    // Test modifying a key that exists
+    for _ in 0..num_keys.div_ceil(2) {
+        let key_index = rand::random::<usize>() % num_keys;
+        let key_target = *clear_store.iter().nth(key_index).unwrap().0;
+        let encrypted_key = cks.as_ref().encrypt_radix(key_target, nb_blocks_key);
+
+        let value_to_add = rand::random::<u64>() % modulus;
+        let encrypted_value_to_add: RadixCiphertext = cks.encrypt(value_to_add);
+
+        kv_store_add.execute((&mut map, &encrypted_key, &encrypted_value_to_add));
+
+        let new_value = clear_store
+            .get(&key_target)
+            .map(|v| v.wrapping_add(value_to_add) % modulus)
+            .unwrap();
+        clear_store.insert(key_target, new_value);
+
+        panic_if_not_properly_updated(&map, &clear_store, key_target, &cks)
+    }
+}
+
+fn get_num_block_for_key(msg_mod: MessageModulus) -> usize {
+    KeyType::BITS.div_ceil(msg_mod.0.ilog2()) as usize
+}
+
+fn default_kv_store_sub_test<P, T>(params: P, mut kv_store_sub: T)
+where
+    P: Into<TestParameters>,
+    T: for<'a> FunctionExecutor<
+        (
+            &'a mut KVStore<KeyType, RadixCiphertext>,
+            &'a RadixCiphertext,
+            &'a RadixCiphertext,
+        ),
+        (),
+    >,
+{
+    let params = params.into();
+    let (cks, mut sks) = KEY_CACHE.get_from_params(params, IntegerKeyKind::Radix);
+    let cks = RadixClientKey::from((cks, NB_CTXT));
+
+    sks.set_deterministic_pbs_execution(true);
+    let sks = Arc::new(sks);
+
+    let nb_blocks_key = get_num_block_for_key(params.message_modulus());
+
+    // message_modulus^vec_length
+    let modulus = cks.parameters().message_modulus().0.pow(NB_CTXT as u32);
+
+    kv_store_sub.setup(&cks, sks);
+
+    let num_keys = 20usize;
+    let (mut map, mut clear_store) = create_filled_stores(num_keys, modulus, &cks);
+
+    // Test modifying a key that does not exist
+    for _ in 0..num_keys.div_ceil(2) {
+        let key = generate_unused_key(&clear_store);
+        let encrypted_key = cks.as_ref().encrypt_radix(key, nb_blocks_key);
+
+        let value_to_add = rand::random::<u64>() % modulus;
+        let encrypted_value_to_add: RadixCiphertext = cks.encrypt(value_to_add);
+        kv_store_sub.execute((&mut map, &encrypted_key, &encrypted_value_to_add));
+
+        panic_if_not_the_same(&map, &clear_store, &cks);
+    }
+
+    // Test modifying a key that exists
+    for _ in 0..num_keys.div_ceil(2) {
+        let key_index = rand::random::<usize>() % num_keys;
+        let key_target = *clear_store.iter().nth(key_index).unwrap().0;
+        let encrypted_key = cks.as_ref().encrypt_radix(key_target, nb_blocks_key);
+
+        let value_to_sub = rand::random::<u64>() % modulus;
+        let encrypted_value_to_add: RadixCiphertext = cks.encrypt(value_to_sub);
+
+        kv_store_sub.execute((&mut map, &encrypted_key, &encrypted_value_to_add));
+
+        let new_value = clear_store
+            .get(&key_target)
+            .map(|v| v.wrapping_sub(value_to_sub) % modulus)
+            .unwrap();
+        clear_store.insert(key_target, new_value);
+
+        panic_if_not_properly_updated(&map, &clear_store, key_target, &cks)
+    }
+}
+
+fn default_kv_store_mul_test<P, T>(params: P, mut kv_store_mul: T)
+where
+    P: Into<TestParameters>,
+    T: for<'a> FunctionExecutor<
+        (
+            &'a mut KVStore<KeyType, RadixCiphertext>,
+            &'a RadixCiphertext,
+            &'a RadixCiphertext,
+        ),
+        (),
+    >,
+{
+    let params = params.into();
+    let (cks, mut sks) = KEY_CACHE.get_from_params(params, IntegerKeyKind::Radix);
+    let cks = RadixClientKey::from((cks, NB_CTXT));
+
+    sks.set_deterministic_pbs_execution(true);
+    let sks = Arc::new(sks);
+
+    let nb_blocks_key = get_num_block_for_key(params.message_modulus());
+
+    // message_modulus^vec_length
+    let modulus = cks.parameters().message_modulus().0.pow(NB_CTXT as u32);
+
+    kv_store_mul.setup(&cks, sks);
+
+    let num_keys = 20usize;
+    let (mut map, mut clear_store) = create_filled_stores(num_keys, modulus, &cks);
+
+    // Test modifying a key that does not exist
+    for _ in 0..num_keys.div_ceil(2) {
+        let key = generate_unused_key(&clear_store);
+        let encrypted_key = cks.as_ref().encrypt_radix(key, nb_blocks_key);
+
+        let value_to_add = rand::random::<u64>() % modulus;
+        let encrypted_value_to_add: RadixCiphertext = cks.encrypt(value_to_add);
+        kv_store_mul.execute((&mut map, &encrypted_key, &encrypted_value_to_add));
+
+        panic_if_not_the_same(&map, &clear_store, &cks);
+    }
+
+    // Test modifying a key that exists
+    for _ in 0..num_keys.div_ceil(2) {
+        let key_index = rand::random::<usize>() % num_keys;
+        let key_target = *clear_store.iter().nth(key_index).unwrap().0;
+        let encrypted_key = cks.as_ref().encrypt_radix(key_target, nb_blocks_key);
+
+        let value_to_mul = rand::random::<u64>() % modulus;
+        let encrypted_value_to_add: RadixCiphertext = cks.encrypt(value_to_mul);
+
+        kv_store_mul.execute((&mut map, &encrypted_key, &encrypted_value_to_add));
+
+        let new_value = clear_store
+            .get(&key_target)
+            .map(|v| v.wrapping_mul(value_to_mul) % modulus)
+            .unwrap();
+        clear_store.insert(key_target, new_value);
+
+        panic_if_not_properly_updated(&map, &clear_store, key_target, &cks)
+    }
+}
+
+fn default_kv_store_get_update_test<P, T1, T2>(
+    params: P,
+    mut kv_store_get: T1,
+    mut kv_store_update: T2,
+) where
+    P: Into<TestParameters>,
+    T1: for<'a> FunctionExecutor<
+        (&'a KVStore<KeyType, RadixCiphertext>, &'a RadixCiphertext),
+        (RadixCiphertext, BooleanBlock),
+    >,
+    T2: for<'a> FunctionExecutor<
+        (
+            &'a mut KVStore<KeyType, RadixCiphertext>,
+            &'a RadixCiphertext,
+            &'a RadixCiphertext,
+        ),
+        BooleanBlock,
+    >,
+{
+    let params = params.into();
+    let (cks, mut sks) = KEY_CACHE.get_from_params(params, IntegerKeyKind::Radix);
+    let cks = RadixClientKey::from((cks, NB_CTXT));
+
+    sks.set_deterministic_pbs_execution(true);
+    let sks = Arc::new(sks);
+
+    let nb_blocks_key = get_num_block_for_key(params.message_modulus());
+
+    // message_modulus^vec_length
+    let modulus = cks.parameters().message_modulus().0.pow(NB_CTXT as u32);
+
+    kv_store_get.setup(&cks, sks.clone());
+    kv_store_update.setup(&cks, sks);
+
+    let num_keys = 20usize;
+    let (mut map, mut clear_store) = create_filled_stores(num_keys, modulus, &cks);
+
+    // Test modifying a key that does not exist
+    for _ in 0..num_keys.div_ceil(2) {
+        let key = generate_unused_key(&clear_store);
+        let encrypted_key = cks.as_ref().encrypt_radix(key, nb_blocks_key);
+
+        let (result, is_some) = kv_store_get.execute((&mut map, &encrypted_key));
+        assert!(!cks.decrypt_bool(&is_some));
+        assert_eq!(cks.decrypt::<u64>(&result), 0);
+
+        let new_value = rand::random::<u64>() % modulus;
+        let encrypted_new_value: RadixCiphertext = cks.encrypt(new_value);
+        let is_some = kv_store_update.execute((&mut map, &encrypted_key, &encrypted_new_value));
+        assert!(!cks.decrypt_bool(&is_some));
+
+        panic_if_not_the_same(&map, &clear_store, &cks);
+    }
+
+    // Test modifying a key that exists
+    for _ in 0..num_keys.div_ceil(2) {
+        let key_index = rand::random::<usize>() % num_keys;
+        let key_target = *clear_store.iter().nth(key_index).unwrap().0;
+        let encrypted_key = cks.as_ref().encrypt_radix(key_target, nb_blocks_key);
+
+        let expected_value = clear_store.get(&key_target).unwrap();
+
+        let (result, is_some) = kv_store_get.execute((&mut map, &encrypted_key));
+        assert!(cks.decrypt_bool(&is_some));
+        assert_eq!(cks.decrypt::<u64>(&result), *expected_value);
+
+        let new_value = rand::random::<u64>() % modulus;
+        let encrypted_new_value: RadixCiphertext = cks.encrypt(new_value);
+        let is_some = kv_store_update.execute((&mut map, &encrypted_key, &encrypted_new_value));
+        assert!(cks.decrypt_bool(&is_some));
+
+        clear_store.insert(key_target, new_value);
+
+        panic_if_not_properly_updated(&map, &clear_store, key_target, &cks);
+    }
+}
+
+fn default_kv_store_map_test<P, T>(params: P, mut kv_store_map: T)
+where
+    P: Into<TestParameters>,
+    T: for<'a> FunctionExecutor<
+        (
+            &'a mut KVStore<KeyType, RadixCiphertext>,
+            &'a RadixCiphertext,
+            &'a dyn Fn(RadixCiphertext) -> RadixCiphertext,
+        ),
+        (RadixCiphertext, BooleanBlock),
+    >,
+{
+    let params = params.into();
+    let (cks, mut sks) = KEY_CACHE.get_from_params(params, IntegerKeyKind::Radix);
+    let cks = RadixClientKey::from((cks, NB_CTXT));
+
+    sks.set_deterministic_pbs_execution(true);
+    let sks = Arc::new(sks);
+
+    let nb_blocks_key = get_num_block_for_key(params.message_modulus());
+
+    // message_modulus^vec_length
+    let modulus = cks.parameters().message_modulus().0.pow(NB_CTXT as u32);
+
+    kv_store_map.setup(&cks, sks);
+
+    let num_keys = 20usize;
+    let (mut map, mut clear_store) = create_filled_stores(num_keys, modulus, &cks);
+
+    let clear_function = |x: u64| -> u64 { x / 3 };
+    let function = Box::new(|input: RadixCiphertext| -> RadixCiphertext {
+        // Compute in the clear domain so that it is faster
+        let value = cks.decrypt::<u64>(&input);
+        let result = clear_function(value);
+        cks.encrypt(result)
+    });
+
+    // Test modifying a key that does not exist
+    for _ in 0..num_keys.div_ceil(2) {
+        let key = generate_unused_key(&clear_store);
+        let encrypted_key = cks.as_ref().encrypt_radix(key, nb_blocks_key);
+
+        let (_, is_some) = kv_store_map.execute((&mut map, &encrypted_key, &function));
+        assert!(!cks.decrypt_bool(&is_some));
+
+        panic_if_not_the_same(&map, &clear_store, &cks);
+    }
+
+    // Test modifying a key that exists
+    for _ in 0..num_keys.div_ceil(2) {
+        let key_index = rand::random::<usize>() % num_keys;
+        let key_target = *clear_store.iter().nth(key_index).unwrap().0;
+        let encrypted_key = cks.as_ref().encrypt_radix(key_target, nb_blocks_key);
+
+        let new_value = clear_store
+            .get(&key_target)
+            .copied()
+            .map(clear_function)
+            .unwrap();
+
+        let (result, is_some) = kv_store_map.execute((
+            &mut map,
+            &encrypted_key,
+            &function as &dyn Fn(RadixCiphertext) -> RadixCiphertext,
+        ));
+        assert!(cks.decrypt_bool(&is_some));
+        assert_eq!(cks.decrypt::<u64>(&result), new_value);
+        clear_store.insert(key_target, new_value);
+
+        panic_if_not_properly_updated(&map, &clear_store, key_target, &cks);
+    }
+}
+
+/// Creates a pair of stores (encrypted and clear) filled with random key-value pairs.
+///
+/// # Arguments
+/// * `num_keys` - Number of key-value pairs to generate
+/// * `modulus` - Maximum value for the random values
+/// * `cks` - Client key for encryption
+///
+/// # Returns
+/// A tuple containing the encrypted store and its clear counterpart
+fn create_filled_stores(
+    num_keys: usize,
+    modulus: u64,
+    cks: &RadixClientKey,
+) -> (KVStore<KeyType, RadixCiphertext>, BTreeMap<KeyType, u64>) {
+    let mut store = KVStore::new();
+    let mut clear_store = BTreeMap::<u8, u64>::new();
+    while clear_store.len() != num_keys {
+        let (key, value) = (rand::random::<u8>(), rand::random::<u64>() % modulus);
+        clear_store.insert(key, value);
+
+        let encrypted_value = cks.encrypt(value);
+        store.insert(key, encrypted_value);
+    }
+    assert_eq!(store.len(), clear_store.len());
+
+    (store, clear_store)
+}
+
+/// Panics if any of the key-value pairs of the encrypted store
+/// is not the same as the clear store.
+fn panic_if_not_the_same(
+    map: &KVStore<KeyType, RadixCiphertext>,
+    clear_store: &BTreeMap<KeyType, u64>,
+    cks: &RadixClientKey,
+) {
+    assert_eq!(
+        map.len(),
+        clear_store.len(),
+        "Stores do not have the same number of keys"
+    );
+
+    for (key, stored_value) in map.iter() {
+        let original_value = clear_store.get(key).unwrap();
+        let decrypted_value: u64 = cks.decrypt(stored_value);
+        assert_eq!(
+            decrypted_value, *original_value,
+            "Value is not the same for key={key}\
+             expected={original_value}, stored={decrypted_value}"
+        );
+    }
+}
+
+fn generate_unused_key(clear_store: &BTreeMap<KeyType, u64>) -> u8 {
+    loop {
+        let key = rand::random::<u8>();
+        if !clear_store.contains_key(&key) {
+            return key;
+        }
+    }
+}
+
+/// Panics if any of the key-value pairs of the encrypted store
+/// is not the same as the clear store.
+///
+/// To be used after updating a key.
+/// `update_key`, tells which key was last updated
+/// so that the panic message is clearer
+fn panic_if_not_properly_updated(
+    map: &KVStore<KeyType, RadixCiphertext>,
+    clear_store: &BTreeMap<KeyType, u64>,
+    updated_key: KeyType,
+    cks: &RadixClientKey,
+) {
+    assert_eq!(
+        map.len(),
+        clear_store.len(),
+        "Stores do not have the same number of keys"
+    );
+
+    for (key, stored_value) in map.iter() {
+        let expected_value = clear_store.get(key).unwrap();
+        let decrypted_value: u64 = cks.decrypt(stored_value);
+
+        if decrypted_value != *expected_value {
+            if key == &updated_key {
+                panic!(
+                    "Value for key={key} was not properly updated \
+                     expected={expected_value}, stored={decrypted_value}"
+                );
+            } else {
+                panic!("Value for key={key} was changed, but it shouldn't have been");
+            }
+        }
+    }
+}


### PR DESCRIPTION
The KVStore is a Hash Table, with homomorphic capabilities

The keys are meant to be clear integers, values are meant to be Radix/SignedRadix

The ServerKey now has functions to be able to do operations that modify an existing key,value pair using an encrypted key.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/2657)
<!-- Reviewable:end -->
