### PR TITLE
fix(core): improve FFT and NTT plan cache locking

### DIFF
--- a/tfhe/src/core_crypto/commons/math/ntt/ntt64.rs
+++ b/tfhe/src/core_crypto/commons/math/ntt/ntt64.rs
@@ -53,17 +53,23 @@ impl Ntt64 {
             })
         };
 
-        // could not find a plan of the given size, we lock the map again and try to insert it
-        let mut plans = global_plans.write().unwrap();
-        if let Entry::Vacant(v) = plans.entry(n) {
-            v.insert(Arc::new(OnceLock::new()));
-        }
+        get_plan().map_or_else(
+            || {
+                // If we don't find a plan for the given size, we insert a new OnceLock,
+                // drop the write lock on the map and then let get_plan() initialize the OnceLock
+                // (without holding the write lock on the map).
+                let mut plans = global_plans.write().unwrap();
+                if let Entry::Vacant(v) = plans.entry(n) {
+                    v.insert(Arc::new(OnceLock::new()));
+                }
+                drop(plans);
 
-        drop(plans);
-
-        Self {
-            plan: get_plan().unwrap(),
-        }
+                Self {
+                    plan: get_plan().unwrap(),
+                }
+            },
+            |plan| Self { plan },
+        )
     }
 }
 

--- a/tfhe/src/core_crypto/fft_impl/fft128/math/fft/mod.rs
+++ b/tfhe/src/core_crypto/fft_impl/fft128/math/fft/mod.rs
@@ -69,17 +69,23 @@ impl Fft128 {
             })
         };
 
-        // could not find a plan of the given size, we lock the map again and try to insert it
-        let mut plans = global_plans.write().unwrap();
-        if let Entry::Vacant(v) = plans.entry(n) {
-            v.insert(Arc::new(OnceLock::new()));
-        }
+        get_plan().map_or_else(
+            || {
+                // If we don't find a plan for the given size, we insert a new OnceLock,
+                // drop the write lock on the map and then let get_plan() initialize the OnceLock
+                // (without holding the write lock on the map).
+                let mut plans = global_plans.write().unwrap();
+                if let Entry::Vacant(v) = plans.entry(n) {
+                    v.insert(Arc::new(OnceLock::new()));
+                }
+                drop(plans);
 
-        drop(plans);
-
-        Self {
-            plan: get_plan().unwrap(),
-        }
+                Self {
+                    plan: get_plan().unwrap(),
+                }
+            },
+            |plan| Self { plan },
+        )
     }
 }
 


### PR DESCRIPTION
Instead of always write-locking the plan maps first, read-lock them and check if the entry for the given size is present. If not, write-lock and insert it.

That reduces contention on the map lock, allowing multiple threads to get an already created plan concurrently, without waiting on the write lock.