### PR TITLE
chore: fix some warnings appearing during compilation with 1.89

### DIFF
--- a/tfhe/src/core_crypto/entities/lwe_ciphertext.rs
+++ b/tfhe/src/core_crypto/entities/lwe_ciphertext.rs
@@ -70,7 +70,7 @@ impl<'data, T: UnsignedInteger> CreateFrom<&'data [T]> for LweBodyRef<'data, T> 
     type Metadata = LweBodyCreationMetadata<T>;
 
     #[inline]
-    fn create_from(from: &[T], meta: Self::Metadata) -> LweBodyRef<T> {
+    fn create_from(from: &[T], meta: Self::Metadata) -> LweBodyRef<'_, T> {
         let LweBodyCreationMetadata { ciphertext_modulus } = meta;
         LweBodyRef {
             data: &from[0],
@@ -83,7 +83,7 @@ impl<'data, T: UnsignedInteger> CreateFrom<&'data mut [T]> for LweBodyRefMut<'da
     type Metadata = LweBodyCreationMetadata<T>;
 
     #[inline]
-    fn create_from(from: &mut [T], meta: Self::Metadata) -> LweBodyRefMut<T> {
+    fn create_from(from: &mut [T], meta: Self::Metadata) -> LweBodyRefMut<'_, T> {
         let LweBodyCreationMetadata { ciphertext_modulus } = meta;
         LweBodyRefMut {
             data: &mut from[0],

--- a/tfhe/src/high_level_api/compressed_ciphertext_list.rs
+++ b/tfhe/src/high_level_api/compressed_ciphertext_list.rs
@@ -357,7 +357,7 @@ impl InnerCompressedCiphertextList {
         }
     }
 
-    fn on_cpu(&self) -> MaybeCloned<crate::integer::ciphertext::CompressedCiphertextList> {
+    fn on_cpu(&self) -> MaybeCloned<'_, crate::integer::ciphertext::CompressedCiphertextList> {
         match self {
             Self::Cpu(cpu_ct) => MaybeCloned::Borrowed(cpu_ct),
             #[cfg(feature = "gpu")]

--- a/tfhe/src/high_level_api/keys/inner.rs
+++ b/tfhe/src/high_level_api/keys/inner.rs
@@ -346,7 +346,7 @@ impl IntegerServerKey {
 
     pub(in crate::high_level_api) fn cpk_casting_key(
         &self,
-    ) -> Option<crate::integer::key_switching_key::KeySwitchingKeyView> {
+    ) -> Option<crate::integer::key_switching_key::KeySwitchingKeyView<'_>> {
         self.cpk_key_switching_key_material.as_ref().map(|k| {
             crate::integer::key_switching_key::KeySwitchingKeyView::from_keyswitching_key_material(
                 k.as_view(),

--- a/tfhe/src/high_level_api/keys/server.rs
+++ b/tfhe/src/high_level_api/keys/server.rs
@@ -122,7 +122,7 @@ impl ServerKey {
 
     pub(in crate::high_level_api) fn cpk_casting_key(
         &self,
-    ) -> Option<crate::integer::key_switching_key::KeySwitchingKeyView> {
+    ) -> Option<crate::integer::key_switching_key::KeySwitchingKeyView<'_>> {
         self.key.cpk_casting_key()
     }
 
@@ -138,7 +138,7 @@ impl ServerKey {
 
     pub(in crate::high_level_api) fn integer_compact_ciphertext_list_expansion_mode(
         &self,
-    ) -> IntegerCompactCiphertextListExpansionMode {
+    ) -> IntegerCompactCiphertextListExpansionMode<'_> {
         self.cpk_casting_key().map_or_else(
             || {
                 IntegerCompactCiphertextListExpansionMode::UnpackAndSanitizeIfNecessary(

--- a/tfhe/src/integer/ciphertext/compressed_noise_squashed_ciphertext_list.rs
+++ b/tfhe/src/integer/ciphertext/compressed_noise_squashed_ciphertext_list.rs
@@ -42,7 +42,7 @@ impl NoiseSquashingCompressionPrivateKey {
         Self { key }
     }
 
-    pub fn private_key_view(&self) -> NoiseSquashingPrivateKeyView {
+    pub fn private_key_view(&self) -> NoiseSquashingPrivateKeyView<'_> {
         NoiseSquashingPrivateKeyView {
             key: (&self.key).into(),
         }

--- a/tfhe/src/integer/noise_squashing/keys.rs
+++ b/tfhe/src/integer/noise_squashing/keys.rs
@@ -248,7 +248,7 @@ impl NoiseSquashingPrivateKey {
         }
     }
 
-    pub(crate) fn as_view(&self) -> NoiseSquashingPrivateKeyView {
+    pub(crate) fn as_view(&self) -> NoiseSquashingPrivateKeyView<'_> {
         NoiseSquashingPrivateKeyView {
             key: self.key.as_view(),
         }


### PR DESCRIPTION
- linked to new lints/warnings for elided lifetimes our old nightly toolchain does not know about
