### PR TITLE
chore(bench): add 2 bits integer to full benchmarks

### DIFF
--- a/tfhe-benchmark/src/utilities.rs
+++ b/tfhe-benchmark/src/utilities.rs
@@ -316,7 +316,7 @@ pub fn write_to_json<
 }
 
 const FAST_BENCH_BIT_SIZES: [usize; 1] = [64];
-const BENCH_BIT_SIZES: [usize; 7] = [8, 16, 32, 40, 64, 128, 256];
+const BENCH_BIT_SIZES: [usize; 8] = [2, 8, 16, 32, 40, 64, 128, 256];
 const HPU_BENCH_BIT_SIZES: [usize; 5] = [8, 16, 32, 64, 128];
 const MULTI_BIT_CPU_SIZES: [usize; 5] = [8, 16, 32, 40, 64];
 


### PR DESCRIPTION
This is done to measure execution time on FheBool equivalent on all operations.
