### PR TITLE
feat(gpu): Implement 128-bit compression and add it to the integer API

### DIFF
--- a/backends/tfhe-cuda-backend/cuda/include/integer/compression/compression.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer/compression/compression.h
@@ -61,6 +61,41 @@ void cleanup_cuda_integer_compress_radix_ciphertext_64(
 void cleanup_cuda_integer_decompress_radix_ciphertext_64(
     void *const *streams, uint32_t const *gpu_indexes, uint32_t gpu_count,
     int8_t **mem_ptr_void);
+
+uint64_t scratch_cuda_integer_compress_radix_ciphertext_128(
+    void *const *streams, uint32_t const *gpu_indexes, uint32_t gpu_count,
+    int8_t **mem_ptr, uint32_t compression_glwe_dimension,
+    uint32_t compression_polynomial_size, uint32_t lwe_dimension,
+    uint32_t ks_level, uint32_t ks_base_log, uint32_t num_radix_blocks,
+    uint32_t message_modulus, uint32_t carry_modulus, PBS_TYPE pbs_type,
+    uint32_t lwe_per_glwe, bool allocate_gpu_memory);
+
+uint64_t scratch_cuda_integer_decompress_radix_ciphertext_128(
+    void *const *streams, uint32_t const *gpu_indexes, uint32_t gpu_count,
+    int8_t **mem_ptr, uint32_t compression_glwe_dimension,
+    uint32_t compression_polynomial_size, uint32_t lwe_dimension,
+    uint32_t num_radix_blocks, uint32_t message_modulus, uint32_t carry_modulus,
+    bool allocate_gpu_memory, bool allocate_ms_array);
+
+void cuda_integer_compress_radix_ciphertext_128(
+    void *const *streams, uint32_t const *gpu_indexes, uint32_t gpu_count,
+    CudaPackedGlweCiphertextListFFI *glwe_array_out,
+    CudaLweCiphertextListFFI const *lwe_array_in, void *const *fp_ksk,
+    int8_t *mem_ptr);
+
+void cuda_integer_decompress_radix_ciphertext_128(
+    void *const *streams, uint32_t const *gpu_indexes, uint32_t gpu_count,
+    CudaLweCiphertextListFFI *lwe_array_out,
+    CudaPackedGlweCiphertextListFFI const *glwe_in,
+    uint32_t const *indexes_array, int8_t *mem_ptr);
+
+void cleanup_cuda_integer_compress_radix_ciphertext_128(
+    void *const *streams, uint32_t const *gpu_indexes, uint32_t gpu_count,
+    int8_t **mem_ptr_void);
+
+void cleanup_cuda_integer_decompress_radix_ciphertext_128(
+    void *const *streams, uint32_t const *gpu_indexes, uint32_t gpu_count,
+    int8_t **mem_ptr_void);
 }
 
 #endif

--- a/backends/tfhe-cuda-backend/cuda/include/integer/compression/compression_utilities.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer/compression/compression_utilities.h
@@ -10,6 +10,7 @@ template <typename Torus> struct int_compression {
   Torus *tmp_lwe;
   Torus *tmp_glwe_array_out;
   bool gpu_memory_allocated;
+  uint32_t lwe_per_glwe;
 
   int_compression(cudaStream_t const *streams, uint32_t const *gpu_indexes,
                   uint32_t gpu_count, int_radix_params compression_params,
@@ -21,15 +22,16 @@ template <typename Torus> struct int_compression {
     uint64_t glwe_accumulator_size = (compression_params.glwe_dimension + 1) *
                                      compression_params.polynomial_size;
 
-    tmp_lwe = (Torus *)cuda_malloc_with_size_tracking_async(
+    tmp_lwe = static_cast<Torus *>(cuda_malloc_with_size_tracking_async(
         num_radix_blocks * (compression_params.small_lwe_dimension + 1) *
             sizeof(Torus),
-        streams[0], gpu_indexes[0], size_tracker, allocate_gpu_memory);
-    tmp_glwe_array_out = (Torus *)cuda_malloc_with_size_tracking_async(
-        lwe_per_glwe * glwe_accumulator_size * sizeof(Torus), streams[0],
-        gpu_indexes[0], size_tracker, allocate_gpu_memory);
+        streams[0], gpu_indexes[0], size_tracker, allocate_gpu_memory));
+    tmp_glwe_array_out =
+        static_cast<Torus *>(cuda_malloc_with_size_tracking_async(
+            lwe_per_glwe * glwe_accumulator_size * sizeof(Torus), streams[0],
+            gpu_indexes[0], size_tracker, allocate_gpu_memory));
 
-    size_tracker += scratch_packing_keyswitch_lwe_list_to_glwe_64(
+    size_tracker += scratch_packing_keyswitch_lwe_list_to_glwe<Torus>(
         streams[0], gpu_indexes[0], &fp_ks_buffer,
         compression_params.small_lwe_dimension,
         compression_params.glwe_dimension, compression_params.polynomial_size,
@@ -73,9 +75,6 @@ template <typename Torus> struct int_decompression {
     uint64_t lwe_accumulator_size = (compression_params.glwe_dimension *
                                          compression_params.polynomial_size +
                                      1);
-    decompression_rescale_lut = new int_radix_lut<Torus>(
-        streams, gpu_indexes, gpu_count, encryption_params, 1,
-        num_blocks_to_decompress, allocate_gpu_memory, size_tracker);
 
     tmp_extracted_glwe = (Torus *)cuda_malloc_with_size_tracking_async(
         num_blocks_to_decompress * glwe_accumulator_size * sizeof(Torus),
@@ -87,28 +86,38 @@ template <typename Torus> struct int_decompression {
         num_blocks_to_decompress * lwe_accumulator_size * sizeof(Torus),
         streams[0], gpu_indexes[0], size_tracker, allocate_gpu_memory);
 
-    // Rescale is done using an identity LUT
-    // Here we do not divide by message_modulus
-    // Example: in the 2_2 case we are mapping a 2 bits message onto a 4 bits
-    // space, we want to keep the original 2 bits value in the 4 bits space,
-    // so we apply the identity and the encoding will rescale it for us.
-    auto decompression_rescale_f = [](Torus x) -> Torus { return x; };
+    // rescale is only needed on 64-bit decompression
+    if constexpr (std::is_same_v<Torus, uint64_t>) {
+      decompression_rescale_lut = new int_radix_lut<Torus>(
+          streams, gpu_indexes, gpu_count, encryption_params, 1,
+          num_blocks_to_decompress, allocate_gpu_memory, size_tracker);
 
-    auto effective_compression_message_modulus =
-        encryption_params.carry_modulus;
-    auto effective_compression_carry_modulus = 1;
+      // Rescale is done using an identity LUT
+      // Here we do not divide by message_modulus
+      // Example: in the 2_2 case we are mapping a 2-bit message onto a 4-bit
+      // space, we want to keep the original 2-bit value in the 4-bit space,
+      // so we apply the identity and the encoding will rescale it for us.
+      decompression_rescale_lut = new int_radix_lut<Torus>(
+          streams, gpu_indexes, gpu_count, encryption_params, 1,
+          num_blocks_to_decompress, allocate_gpu_memory, size_tracker);
+      auto decompression_rescale_f = [](Torus x) -> Torus { return x; };
 
-    generate_device_accumulator_with_encoding<Torus>(
-        streams[0], gpu_indexes[0], decompression_rescale_lut->get_lut(0, 0),
-        decompression_rescale_lut->get_degree(0),
-        decompression_rescale_lut->get_max_degree(0),
-        encryption_params.glwe_dimension, encryption_params.polynomial_size,
-        effective_compression_message_modulus,
-        effective_compression_carry_modulus, encryption_params.message_modulus,
-        encryption_params.carry_modulus, decompression_rescale_f,
-        gpu_memory_allocated);
+      auto effective_compression_message_modulus =
+          encryption_params.carry_modulus;
+      auto effective_compression_carry_modulus = 1;
 
-    decompression_rescale_lut->broadcast_lut(streams, gpu_indexes);
+      generate_device_accumulator_with_encoding<Torus>(
+          streams[0], gpu_indexes[0], decompression_rescale_lut->get_lut(0, 0),
+          decompression_rescale_lut->get_degree(0),
+          decompression_rescale_lut->get_max_degree(0),
+          encryption_params.glwe_dimension, encryption_params.polynomial_size,
+          effective_compression_message_modulus,
+          effective_compression_carry_modulus,
+          encryption_params.message_modulus, encryption_params.carry_modulus,
+          decompression_rescale_f, gpu_memory_allocated);
+
+      decompression_rescale_lut->broadcast_lut(streams, gpu_indexes);
+    }
   }
   void release(cudaStream_t const *streams, uint32_t const *gpu_indexes,
                uint32_t gpu_count) {
@@ -118,9 +127,11 @@ template <typename Torus> struct int_decompression {
                                        gpu_indexes[0], gpu_memory_allocated);
     cuda_drop_with_size_tracking_async(tmp_indexes_array, streams[0],
                                        gpu_indexes[0], gpu_memory_allocated);
-
-    decompression_rescale_lut->release(streams, gpu_indexes, gpu_count);
-    delete decompression_rescale_lut;
+    if constexpr (std::is_same_v<Torus, uint64_t>) {
+      decompression_rescale_lut->release(streams, gpu_indexes, gpu_count);
+      delete decompression_rescale_lut;
+      decompression_rescale_lut = nullptr;
+    }
   }
 };
 #endif

--- a/backends/tfhe-cuda-backend/cuda/src/crypto/packing_keyswitch.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/crypto/packing_keyswitch.cuh
@@ -202,10 +202,11 @@ __host__ void host_packing_keyswitch_lwe_list_to_glwe(
 
   auto stride_KSK_buffer = glwe_accumulator_size * level_count;
 
-  // Shared memory requirement is 8192 bytes for 64-bit Torus elements
+  // Shared memory requirement is 4096, 8192, and 16384 bytes respectively for
+  // 32, 64, and 128-bit Torus elements We want to keep this as a sanity check
   uint32_t shared_mem_size = get_shared_mem_size_tgemm<Torus>();
   // Sanity check: the shared memory size is a constant defined by the algorithm
-  GPU_ASSERT(shared_mem_size <= 8192,
+  GPU_ASSERT(shared_mem_size <= 1024 * sizeof(Torus),
              "GEMM kernel error: shared memory required might be too large");
 
   tgemm<Torus><<<grid_gemm, threads_gemm, shared_mem_size, stream>>>(

--- a/backends/tfhe-cuda-backend/cuda/src/integer/compression/compression.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/compression/compression.cu
@@ -67,7 +67,6 @@ void cuda_integer_decompress_radix_ciphertext_64(
       (cudaStream_t *)(streams), gpu_indexes, gpu_count, lwe_array_out, glwe_in,
       indexes_array, bsks, (int_decompression<uint64_t> *)mem_ptr);
 }
-
 void cleanup_cuda_integer_compress_radix_ciphertext_64(
     void *const *streams, uint32_t const *gpu_indexes, uint32_t gpu_count,
     int8_t **mem_ptr_void) {
@@ -76,7 +75,6 @@ void cleanup_cuda_integer_compress_radix_ciphertext_64(
       (int_compression<uint64_t> *)(*mem_ptr_void);
   mem_ptr->release((cudaStream_t *)(streams), gpu_indexes, gpu_count);
 }
-
 void cleanup_cuda_integer_decompress_radix_ciphertext_64(
     void *const *streams, uint32_t const *gpu_indexes, uint32_t gpu_count,
     int8_t **mem_ptr_void) {
@@ -84,4 +82,87 @@ void cleanup_cuda_integer_decompress_radix_ciphertext_64(
   int_decompression<uint64_t> *mem_ptr =
       (int_decompression<uint64_t> *)(*mem_ptr_void);
   mem_ptr->release((cudaStream_t *)(streams), gpu_indexes, gpu_count);
+}
+
+uint64_t scratch_cuda_integer_compress_radix_ciphertext_128(
+    void *const *streams, uint32_t const *gpu_indexes, uint32_t gpu_count,
+    int8_t **mem_ptr, uint32_t compression_glwe_dimension,
+    uint32_t compression_polynomial_size, uint32_t lwe_dimension,
+    uint32_t ks_level, uint32_t ks_base_log, uint32_t num_radix_blocks,
+    uint32_t message_modulus, uint32_t carry_modulus, PBS_TYPE pbs_type,
+    uint32_t lwe_per_glwe, bool allocate_gpu_memory) {
+
+  int_radix_params compression_params(
+      pbs_type, compression_glwe_dimension, compression_polynomial_size,
+      (compression_glwe_dimension + 1) * compression_polynomial_size,
+      lwe_dimension, ks_level, ks_base_log, 0, 0, 0, message_modulus,
+      carry_modulus, allocate_gpu_memory);
+
+  return scratch_cuda_compress_integer_radix_ciphertext<__uint128_t>(
+      (cudaStream_t *)(streams), gpu_indexes, gpu_count,
+      (int_compression<__uint128_t> **)mem_ptr, num_radix_blocks,
+      compression_params, lwe_per_glwe, allocate_gpu_memory);
+}
+uint64_t scratch_cuda_integer_decompress_radix_ciphertext_128(
+    void *const *streams, uint32_t const *gpu_indexes, uint32_t gpu_count,
+    int8_t **mem_ptr, uint32_t compression_glwe_dimension,
+    uint32_t compression_polynomial_size, uint32_t lwe_dimension,
+    uint32_t num_radix_blocks, uint32_t message_modulus, uint32_t carry_modulus,
+    bool allocate_gpu_memory, bool allocate_ms_array) {
+
+  // 128-bit decompression doesn't run PBSs, so we don't need encryption_params
+  int_radix_params compression_params(
+      PBS_TYPE::CLASSICAL, compression_glwe_dimension,
+      compression_polynomial_size,
+      compression_glwe_dimension * compression_polynomial_size, lwe_dimension,
+      0, 0, 0, 0, 0, message_modulus, carry_modulus, allocate_ms_array);
+
+  return scratch_cuda_integer_decompress_radix_ciphertext<__uint128_t>(
+      (cudaStream_t *)(streams), gpu_indexes, gpu_count,
+      (int_decompression<__uint128_t> **)mem_ptr, num_radix_blocks,
+      compression_params, compression_params, allocate_gpu_memory);
+}
+void cuda_integer_compress_radix_ciphertext_128(
+    void *const *streams, uint32_t const *gpu_indexes, uint32_t gpu_count,
+    CudaPackedGlweCiphertextListFFI *glwe_array_out,
+    CudaLweCiphertextListFFI const *lwe_array_in, void *const *fp_ksk,
+    int8_t *mem_ptr) {
+
+  host_integer_compress<__uint128_t>((cudaStream_t *)(streams), gpu_indexes,
+                                     gpu_count, glwe_array_out, lwe_array_in,
+                                     (__uint128_t *const *)(fp_ksk),
+                                     (int_compression<__uint128_t> *)mem_ptr);
+}
+void cuda_integer_decompress_radix_ciphertext_128(
+    void *const *streams, uint32_t const *gpu_indexes, uint32_t gpu_count,
+    CudaLweCiphertextListFFI *lwe_array_out,
+    CudaPackedGlweCiphertextListFFI const *glwe_in,
+    uint32_t const *indexes_array, int8_t *mem_ptr) {
+
+  host_integer_decompress<__uint128_t>(
+      (cudaStream_t *)(streams), gpu_indexes, gpu_count, lwe_array_out, glwe_in,
+      indexes_array, nullptr, (int_decompression<__uint128_t> *)mem_ptr);
+}
+void cleanup_cuda_integer_compress_radix_ciphertext_128(
+    void *const *streams, uint32_t const *gpu_indexes, uint32_t gpu_count,
+    int8_t **mem_ptr_void) {
+
+  int_compression<__uint128_t> *mem_ptr =
+      (int_compression<__uint128_t> *)(*mem_ptr_void);
+  mem_ptr->release((cudaStream_t *)(streams), gpu_indexes, gpu_count);
+
+  delete mem_ptr;
+  *mem_ptr_void = nullptr;
+}
+
+void cleanup_cuda_integer_decompress_radix_ciphertext_128(
+    void *const *streams, uint32_t const *gpu_indexes, uint32_t gpu_count,
+    int8_t **mem_ptr_void) {
+
+  int_decompression<__uint128_t> *mem_ptr =
+      (int_decompression<__uint128_t> *)(*mem_ptr_void);
+  mem_ptr->release((cudaStream_t *)(streams), gpu_indexes, gpu_count);
+
+  delete mem_ptr;
+  *mem_ptr_void = nullptr;
 }

--- a/backends/tfhe-cuda-backend/cuda/src/integer/compression/compression.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/compression/compression.cuh
@@ -15,7 +15,7 @@
 template <typename Torus>
 __global__ void pack(Torus *array_out, Torus *array_in, uint32_t log_modulus,
                      uint32_t num_coeffs, uint32_t in_len, uint32_t out_len) {
-  auto nbits = sizeof(Torus) * 8;
+  constexpr auto nbits = sizeof(Torus) * 8;
   auto tid = threadIdx.x + blockIdx.x * blockDim.x;
 
   auto glwe_index = tid / out_len;
@@ -86,18 +86,26 @@ host_integer_compress(cudaStream_t const *streams, uint32_t const *gpu_indexes,
                       CudaLweCiphertextListFFI const *lwe_array_in,
                       Torus *const *fp_ksk, int_compression<Torus> *mem_ptr) {
 
+  static_assert(std::is_same_v<Torus, uint64_t> ||
+                    std::is_same_v<Torus, __uint128_t>,
+                "Torus must be either uint64_t or __uint128_t");
+
   auto compression_params = mem_ptr->compression_params;
-  auto input_lwe_dimension = compression_params.small_lwe_dimension;
 
   // Shift
-  auto lwe_shifted = mem_ptr->tmp_lwe;
-  host_cleartext_multiplication<Torus>(
-      streams[0], gpu_indexes[0], lwe_shifted, lwe_array_in,
-      (uint64_t)compression_params.message_modulus);
+  auto lwe_pksk_input = (Torus *)lwe_array_in->ptr;
 
-  uint32_t lwe_in_size = input_lwe_dimension + 1;
+  if constexpr (std::is_same_v<Torus, uint64_t>) {
+    lwe_pksk_input = mem_ptr->tmp_lwe;
+    host_cleartext_multiplication<Torus>(
+        streams[0], gpu_indexes[0], lwe_pksk_input, lwe_array_in,
+        (uint64_t)compression_params.message_modulus);
+  }
+
+  uint32_t lwe_in_size = compression_params.small_lwe_dimension + 1;
   uint32_t glwe_out_size = (compression_params.glwe_dimension + 1) *
                            compression_params.polynomial_size;
+  // div_ceil
   uint32_t num_glwes = (glwe_array_out->total_lwe_bodies_count +
                         glwe_array_out->lwe_per_glwe - 1) /
                        glwe_array_out->lwe_per_glwe;
@@ -111,20 +119,20 @@ host_integer_compress(cudaStream_t const *streams, uint32_t const *gpu_indexes,
   auto fp_ks_buffer = mem_ptr->fp_ks_buffer;
   auto rem_lwes = glwe_array_out->total_lwe_bodies_count;
 
-  auto lwe_subset = lwe_shifted;
   auto glwe_out = tmp_glwe_array_out;
 
   while (rem_lwes > 0) {
     auto chunk_size = min(rem_lwes, glwe_array_out->lwe_per_glwe);
 
     host_packing_keyswitch_lwe_list_to_glwe<Torus>(
-        streams[0], gpu_indexes[0], glwe_out, lwe_subset, fp_ksk[0],
-        fp_ks_buffer, input_lwe_dimension, compression_params.glwe_dimension,
-        compression_params.polynomial_size, compression_params.ks_base_log,
-        compression_params.ks_level, chunk_size);
+        streams[0], gpu_indexes[0], glwe_out, lwe_pksk_input, fp_ksk[0],
+        fp_ks_buffer, compression_params.small_lwe_dimension,
+        compression_params.glwe_dimension, compression_params.polynomial_size,
+        compression_params.ks_base_log, compression_params.ks_level,
+        chunk_size);
 
     rem_lwes -= chunk_size;
-    lwe_subset += chunk_size * lwe_in_size;
+    lwe_pksk_input += chunk_size * lwe_in_size;
     glwe_out += glwe_out_size;
   }
 
@@ -246,6 +254,9 @@ host_integer_decompress(cudaStream_t const *streams,
                         uint32_t const *h_indexes_array, void *const *d_bsks,
                         int_decompression<Torus> *h_mem_ptr) {
 
+  static_assert(std::is_same_v<Torus, uint64_t> ||
+                    std::is_same_v<Torus, __uint128_t>,
+                "Torus must be either uint64_t or __uint128_t");
   auto num_blocks_to_decompress = h_mem_ptr->num_blocks_to_decompress;
 
   auto d_indexes_array = h_mem_ptr->tmp_indexes_array;
@@ -283,88 +294,112 @@ host_integer_decompress(cudaStream_t const *streams,
     }
   }
   // Sample extract all LWEs
-  Torus lwe_accumulator_size = compression_params.small_lwe_dimension + 1;
+  auto lwe_size = compression_params.small_lwe_dimension + 1;
 
-  auto extracted_lwe = h_mem_ptr->tmp_extracted_lwe;
+  Torus *extracted_lwe;
+  if constexpr (std::is_same_v<Torus, uint64_t>) {
+    // 64 bits
+    extracted_lwe = h_mem_ptr->tmp_extracted_lwe;
+  } else {
+    // 128 bits
+    // We skip the PBS at the end
+    extracted_lwe = static_cast<Torus *>(d_lwe_array_out->ptr);
+  }
   uint32_t current_idx = 0;
   auto d_indexes_array_chunk = d_indexes_array;
   for (const auto &max_idx_and_glwe : glwe_vec) {
     const auto num_lwes = max_idx_and_glwe.first;
     extracted_glwe = max_idx_and_glwe.second;
 
-    cuda_glwe_sample_extract_64(
-        streams[0], gpu_indexes[0], extracted_lwe, extracted_glwe,
-        d_indexes_array_chunk, num_lwes, compression_params.polynomial_size,
-        compression_params.glwe_dimension, compression_params.polynomial_size);
+    if constexpr (std::is_same_v<Torus, uint64_t>)
+      cuda_glwe_sample_extract_64(streams[0], gpu_indexes[0], extracted_lwe,
+                                  extracted_glwe, d_indexes_array_chunk,
+                                  num_lwes, compression_params.polynomial_size,
+                                  compression_params.glwe_dimension,
+                                  compression_params.polynomial_size);
+    else
+      // 128 bits
+      cuda_glwe_sample_extract_128(streams[0], gpu_indexes[0], extracted_lwe,
+                                   extracted_glwe, d_indexes_array_chunk,
+                                   num_lwes, compression_params.polynomial_size,
+                                   compression_params.glwe_dimension,
+                                   compression_params.polynomial_size);
+
     d_indexes_array_chunk += num_lwes;
-    extracted_lwe += num_lwes * lwe_accumulator_size;
+    extracted_lwe += num_lwes * lwe_size;
     current_idx += num_lwes;
   }
 
-  // Reset
-  extracted_lwe = h_mem_ptr->tmp_extracted_lwe;
+  if constexpr (std::is_same_v<Torus, uint64_t>) {
+    // Reset
+    extracted_lwe = h_mem_ptr->tmp_extracted_lwe;
 
-  // In the case of extracting a single LWE these parameters are dummy
-  uint32_t num_many_lut = 1;
-  uint32_t lut_stride = 0;
-  /// Apply PBS to apply a LUT, reduce the noise and go from a small LWE
-  /// dimension to a big LWE dimension
-  auto encryption_params = h_mem_ptr->encryption_params;
-  auto lut = h_mem_ptr->decompression_rescale_lut;
-  auto active_gpu_count =
-      get_active_gpu_count(num_blocks_to_decompress, gpu_count);
-  if (active_gpu_count == 1) {
-    execute_pbs_async<Torus>(
-        streams, gpu_indexes, active_gpu_count, (Torus *)d_lwe_array_out->ptr,
-        lut->lwe_indexes_out, lut->lut_vec, lut->lut_indexes_vec, extracted_lwe,
-        lut->lwe_indexes_in, d_bsks, nullptr, lut->buffer,
-        encryption_params.glwe_dimension,
-        compression_params.small_lwe_dimension,
-        encryption_params.polynomial_size, encryption_params.pbs_base_log,
-        encryption_params.pbs_level, encryption_params.grouping_factor,
-        num_blocks_to_decompress, encryption_params.pbs_type, num_many_lut,
-        lut_stride);
-  } else {
-    /// For multi GPU execution we create vectors of pointers for inputs and
-    /// outputs
-    std::vector<Torus *> lwe_array_in_vec = lut->lwe_array_in_vec;
-    std::vector<Torus *> lwe_after_pbs_vec = lut->lwe_after_pbs_vec;
-    std::vector<Torus *> lwe_trivial_indexes_vec = lut->lwe_trivial_indexes_vec;
+    // In the case of extracting a single LWE these parameters are dummy
+    uint32_t num_many_lut = 1;
+    uint32_t lut_stride = 0;
+    /// Apply PBS to apply a LUT, reduce the noise and go from a small LWE
+    /// dimension to a big LWE dimension
+    auto encryption_params = h_mem_ptr->encryption_params;
+    auto lut = h_mem_ptr->decompression_rescale_lut;
+    auto active_gpu_count =
+        get_active_gpu_count(num_blocks_to_decompress, gpu_count);
+    if (active_gpu_count == 1) {
+      execute_pbs_async<Torus>(
+          streams, gpu_indexes, active_gpu_count, (Torus *)d_lwe_array_out->ptr,
+          lut->lwe_indexes_out, lut->lut_vec, lut->lut_indexes_vec,
+          extracted_lwe, lut->lwe_indexes_in, d_bsks, nullptr, lut->buffer,
+          encryption_params.glwe_dimension,
+          compression_params.small_lwe_dimension,
+          encryption_params.polynomial_size, encryption_params.pbs_base_log,
+          encryption_params.pbs_level, encryption_params.grouping_factor,
+          num_blocks_to_decompress, encryption_params.pbs_type, num_many_lut,
+          lut_stride);
+    } else {
+      /// For multi GPU execution we create vectors of pointers for inputs and
+      /// outputs
+      std::vector<Torus *> lwe_array_in_vec = lut->lwe_array_in_vec;
+      std::vector<Torus *> lwe_after_pbs_vec = lut->lwe_after_pbs_vec;
+      std::vector<Torus *> lwe_trivial_indexes_vec =
+          lut->lwe_trivial_indexes_vec;
 
-    /// Make sure all data that should be on GPU 0 is indeed there
-    cuda_synchronize_stream(streams[0], gpu_indexes[0]);
+      /// Make sure all data that should be on GPU 0 is indeed there
+      cuda_synchronize_stream(streams[0], gpu_indexes[0]);
 
-    /// With multiple GPUs we push to the vectors on each GPU then when we
-    /// gather data to GPU 0 we can copy back to the original indexing
-    multi_gpu_scatter_lwe_async<Torus>(
-        streams, gpu_indexes, active_gpu_count, lwe_array_in_vec, extracted_lwe,
-        lut->h_lwe_indexes_in, lut->using_trivial_lwe_indexes,
-        lut->active_gpu_count, num_blocks_to_decompress,
-        compression_params.small_lwe_dimension + 1);
+      /// With multiple GPUs we push to the vectors on each GPU then when we
+      /// gather data to GPU 0 we can copy back to the original indexing
+      multi_gpu_scatter_lwe_async<Torus>(
+          streams, gpu_indexes, active_gpu_count, lwe_array_in_vec,
+          extracted_lwe, lut->h_lwe_indexes_in, lut->using_trivial_lwe_indexes,
+          lut->active_gpu_count, num_blocks_to_decompress,
+          compression_params.small_lwe_dimension + 1);
 
-    /// Apply PBS
-    execute_pbs_async<Torus>(
-        streams, gpu_indexes, active_gpu_count, lwe_after_pbs_vec,
-        lwe_trivial_indexes_vec, lut->lut_vec, lut->lut_indexes_vec,
-        lwe_array_in_vec, lwe_trivial_indexes_vec, d_bsks, nullptr, lut->buffer,
-        encryption_params.glwe_dimension,
-        compression_params.small_lwe_dimension,
-        encryption_params.polynomial_size, encryption_params.pbs_base_log,
-        encryption_params.pbs_level, encryption_params.grouping_factor,
-        num_blocks_to_decompress, encryption_params.pbs_type, num_many_lut,
-        lut_stride);
+      /// Apply PBS
+      execute_pbs_async<Torus>(
+          streams, gpu_indexes, active_gpu_count, lwe_after_pbs_vec,
+          lwe_trivial_indexes_vec, lut->lut_vec, lut->lut_indexes_vec,
+          lwe_array_in_vec, lwe_trivial_indexes_vec, d_bsks, nullptr,
+          lut->buffer, encryption_params.glwe_dimension,
+          compression_params.small_lwe_dimension,
+          encryption_params.polynomial_size, encryption_params.pbs_base_log,
+          encryption_params.pbs_level, encryption_params.grouping_factor,
+          num_blocks_to_decompress, encryption_params.pbs_type, num_many_lut,
+          lut_stride);
 
-    /// Copy data back to GPU 0 and release vecs
-    multi_gpu_gather_lwe_async<Torus>(
-        streams, gpu_indexes, active_gpu_count, (Torus *)d_lwe_array_out->ptr,
-        lwe_after_pbs_vec, lut->h_lwe_indexes_out,
-        lut->using_trivial_lwe_indexes, num_blocks_to_decompress,
-        encryption_params.big_lwe_dimension + 1);
+      /// Copy data back to GPU 0 and release vecs
+      multi_gpu_gather_lwe_async<Torus>(
+          streams, gpu_indexes, active_gpu_count, (Torus *)d_lwe_array_out->ptr,
+          lwe_after_pbs_vec, lut->h_lwe_indexes_out,
+          lut->using_trivial_lwe_indexes, num_blocks_to_decompress,
+          encryption_params.big_lwe_dimension + 1);
 
-    /// Synchronize all GPUs
-    for (uint i = 0; i < active_gpu_count; i++) {
-      cuda_synchronize_stream(streams[i], gpu_indexes[i]);
+      /// Synchronize all GPUs
+      for (uint i = 0; i < active_gpu_count; i++) {
+        cuda_synchronize_stream(streams[i], gpu_indexes[i]);
+      }
     }
+  } else {
+    static_assert(std::is_same_v<Torus, __uint128_t>,
+                  "Torus must be either uint64_t or __uint128_t");
   }
 }
 

--- a/backends/tfhe-cuda-backend/cuda/src/integer/scalar_addition.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/scalar_addition.cuh
@@ -7,7 +7,7 @@
 #endif
 
 #include "device.h"
-#include "integer/integer_utilities.h"
+#include "radix_ciphertext.cuh"
 #include "utils/kernel_dimensions.cuh"
 #include <stdio.h>
 

--- a/backends/tfhe-cuda-backend/src/bindings.rs
+++ b/backends/tfhe-cuda-backend/src/bindings.rs
@@ -233,6 +233,79 @@ unsafe extern "C" {
         mem_ptr_void: *mut *mut i8,
     );
 }
+unsafe extern "C" {
+    pub fn scratch_cuda_integer_compress_radix_ciphertext_128(
+        streams: *const *mut ffi::c_void,
+        gpu_indexes: *const u32,
+        gpu_count: u32,
+        mem_ptr: *mut *mut i8,
+        compression_glwe_dimension: u32,
+        compression_polynomial_size: u32,
+        lwe_dimension: u32,
+        ks_level: u32,
+        ks_base_log: u32,
+        num_radix_blocks: u32,
+        message_modulus: u32,
+        carry_modulus: u32,
+        pbs_type: PBS_TYPE,
+        lwe_per_glwe: u32,
+        allocate_gpu_memory: bool,
+    ) -> u64;
+}
+unsafe extern "C" {
+    pub fn scratch_cuda_integer_decompress_radix_ciphertext_128(
+        streams: *const *mut ffi::c_void,
+        gpu_indexes: *const u32,
+        gpu_count: u32,
+        mem_ptr: *mut *mut i8,
+        compression_glwe_dimension: u32,
+        compression_polynomial_size: u32,
+        lwe_dimension: u32,
+        num_radix_blocks: u32,
+        message_modulus: u32,
+        carry_modulus: u32,
+        allocate_gpu_memory: bool,
+        allocate_ms_array: bool,
+    ) -> u64;
+}
+unsafe extern "C" {
+    pub fn cuda_integer_compress_radix_ciphertext_128(
+        streams: *const *mut ffi::c_void,
+        gpu_indexes: *const u32,
+        gpu_count: u32,
+        glwe_array_out: *mut CudaPackedGlweCiphertextListFFI,
+        lwe_array_in: *const CudaLweCiphertextListFFI,
+        fp_ksk: *const *mut ffi::c_void,
+        mem_ptr: *mut i8,
+    );
+}
+unsafe extern "C" {
+    pub fn cuda_integer_decompress_radix_ciphertext_128(
+        streams: *const *mut ffi::c_void,
+        gpu_indexes: *const u32,
+        gpu_count: u32,
+        lwe_array_out: *mut CudaLweCiphertextListFFI,
+        glwe_in: *const CudaPackedGlweCiphertextListFFI,
+        indexes_array: *const u32,
+        mem_ptr: *mut i8,
+    );
+}
+unsafe extern "C" {
+    pub fn cleanup_cuda_integer_compress_radix_ciphertext_128(
+        streams: *const *mut ffi::c_void,
+        gpu_indexes: *const u32,
+        gpu_count: u32,
+        mem_ptr_void: *mut *mut i8,
+    );
+}
+unsafe extern "C" {
+    pub fn cleanup_cuda_integer_decompress_radix_ciphertext_128(
+        streams: *const *mut ffi::c_void,
+        gpu_indexes: *const u32,
+        gpu_count: u32,
+        mem_ptr_void: *mut *mut i8,
+    );
+}
 pub const SHIFT_OR_ROTATE_TYPE_LEFT_SHIFT: SHIFT_OR_ROTATE_TYPE = 0;
 pub const SHIFT_OR_ROTATE_TYPE_RIGHT_SHIFT: SHIFT_OR_ROTATE_TYPE = 1;
 pub const SHIFT_OR_ROTATE_TYPE_LEFT_ROTATE: SHIFT_OR_ROTATE_TYPE = 2;

--- a/tfhe-benchmark/benches/integer/glwe_packing_compression.rs
+++ b/tfhe-benchmark/benches/integer/glwe_packing_compression.rs
@@ -162,9 +162,15 @@ mod cuda {
     use itertools::Itertools;
     use std::cmp::max;
     use tfhe::core_crypto::gpu::CudaStreams;
+    use tfhe::integer::ciphertext::NoiseSquashingCompressionPrivateKey;
     use tfhe::integer::gpu::ciphertext::compressed_ciphertext_list::CudaCompressedCiphertextListBuilder;
-    use tfhe::integer::gpu::ciphertext::CudaUnsignedRadixCiphertext;
+    use tfhe::integer::gpu::ciphertext::squashed_noise::CudaSquashedNoiseRadixCiphertext;
+    use tfhe::integer::gpu::ciphertext::{
+        CudaCompressedSquashedNoiseCiphertextList, CudaUnsignedRadixCiphertext,
+    };
     use tfhe::integer::gpu::gen_keys_radix_gpu;
+    use tfhe::integer::gpu::list_compression::server_keys::CudaNoiseSquashingCompressionKey;
+    use tfhe::integer::noise_squashing::NoiseSquashingPrivateKey;
 
     fn gpu_glwe_packing(c: &mut Criterion) {
         let bench_name = "integer::cuda::packing_compression";
@@ -378,17 +384,215 @@ mod cuda {
         bench_group.finish()
     }
 
+    fn gpu_glwe_packing_128(c: &mut Criterion) {
+        let bench_name = "integer::cuda::128b_packing_compression";
+        let mut bench_group = c.benchmark_group(bench_name);
+        bench_group
+            .sample_size(15)
+            .measurement_time(std::time::Duration::from_secs(30));
+
+        let stream = CudaStreams::new_multi_gpu();
+
+        let param = BENCH_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+        let noise_squashing_compression_parameters =
+            BENCH_COMP_NOISE_SQUASHING_PARAM_GPU_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+        let noise_squashing_parameters =
+            BENCH_NOISE_SQUASHING_PARAM_GPU_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+
+        let log_message_modulus = param.message_modulus.0.ilog2() as usize;
+
+        let noise_squashing_compression_private_key =
+            NoiseSquashingCompressionPrivateKey::new(noise_squashing_compression_parameters);
+        let noise_squashing_private_key = NoiseSquashingPrivateKey::new(noise_squashing_parameters);
+        let noise_squashing_compression_key = noise_squashing_private_key
+            .new_noise_squashing_compression_key(&noise_squashing_compression_private_key);
+        let cuda_noise_squashing_compression_key =
+            CudaNoiseSquashingCompressionKey::from_noise_squashing_compression_key(
+                &noise_squashing_compression_key,
+                &stream,
+            );
+
+        for bit_size in [
+            2,
+            8,
+            16,
+            32,
+            64,
+            128,
+            // we don't need 256 here since
+            // noise_squashing_compression_parameters.lwe_per_glwe.0 * log_message_modulus == 256
+            // with current parameters 256,
+            noise_squashing_compression_parameters.lwe_per_glwe.0 * log_message_modulus,
+        ] {
+            assert_eq!(bit_size % log_message_modulus, 0);
+            let num_blocks = bit_size / log_message_modulus;
+
+            let bench_id_pack;
+            let bench_id_unpack;
+
+            // Generate and convert compression keys
+            let cks = ClientKey::new(param);
+            let (_, cuda_sks) = gen_keys_radix_gpu(param, num_blocks, &stream);
+            let compressed_noise_squashing_compression_key =
+                cks.new_compressed_noise_squashing_key(&noise_squashing_private_key);
+
+            match get_bench_type() {
+                BenchmarkType::Latency => {
+                    let cuda_noise_squashing_key =
+                        compressed_noise_squashing_compression_key.decompress_to_cuda(&stream);
+
+                    // Encrypt
+                    let ct = cks.encrypt_radix(0_u32, num_blocks);
+                    let d_ct = CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct, &stream);
+                    let d_ns_ct = cuda_noise_squashing_key
+                        .squash_radix_ciphertext_noise(&cuda_sks, &d_ct.ciphertext, &stream)
+                        .unwrap();
+
+                    // Benchmark
+                    let mut builder = CudaCompressedSquashedNoiseCiphertextList::builder();
+
+                    builder.push(d_ns_ct, &stream);
+
+                    bench_id_pack = format!("{bench_name}::pack_u{bit_size}");
+                    bench_group.bench_function(&bench_id_pack, |b| {
+                        b.iter(|| {
+                            let compressed =
+                                builder.build(&cuda_noise_squashing_compression_key, &stream);
+
+                            _ = black_box(compressed);
+                        })
+                    });
+
+                    let compressed = builder.build(&cuda_noise_squashing_compression_key, &stream);
+
+                    bench_id_unpack = format!("{bench_name}::unpack_u{bit_size}");
+                    bench_group.bench_function(&bench_id_unpack, |b| {
+                        b.iter(|| {
+                            let unpacked: CudaSquashedNoiseRadixCiphertext =
+                                compressed.get(0, &stream).unwrap().unwrap();
+
+                            _ = black_box(unpacked);
+                        })
+                    });
+                }
+                BenchmarkType::Throughput => {
+                    let num_block = (bit_size as f64 / (param.message_modulus.0 as f64).log(2.0))
+                        .ceil() as usize;
+                    let elements = 100;
+                    bench_group.throughput(Throughput::Elements(elements));
+
+                    // Encrypt
+                    let local_streams = cuda_local_streams(num_block, elements as usize);
+
+                    let cuda_compression_key_vec = local_streams
+                        .iter()
+                        .map(|local_stream| {
+                            compressed_noise_squashing_compression_key
+                                .decompress_to_cuda(local_stream)
+                        })
+                        .collect_vec();
+
+                    let cuda_noise_squashing_compression_key =
+                        CudaNoiseSquashingCompressionKey::from_noise_squashing_compression_key(
+                            &noise_squashing_compression_key,
+                            &stream,
+                        );
+
+                    // Benchmark
+                    let builders = (0..elements)
+                        .map(|i| {
+                            let ct = cks.encrypt_radix(0_u32, num_blocks);
+                            let local_stream = &local_streams[i as usize % local_streams.len()];
+                            let d_ct = CudaUnsignedRadixCiphertext::from_radix_ciphertext(
+                                &ct,
+                                local_stream,
+                            );
+                            let cuda_noise_squashing_key =
+                                &cuda_compression_key_vec[(i as usize) % local_streams.len()];
+                            let d_ns_ct = cuda_noise_squashing_key
+                                .squash_radix_ciphertext_noise(&cuda_sks, &d_ct.ciphertext, &stream)
+                                .unwrap();
+                            let mut builder = CudaCompressedSquashedNoiseCiphertextList::builder();
+                            builder.push(d_ns_ct, local_stream);
+
+                            builder
+                        })
+                        .collect::<Vec<_>>();
+
+                    bench_id_pack = format!("{bench_name}::throughput::pack_u{bit_size}");
+                    bench_group.bench_function(&bench_id_pack, |b| {
+                        b.iter(|| {
+                            builders.par_iter().enumerate().for_each(|(i, builder)| {
+                                let local_stream = &local_streams[i % local_streams.len()];
+
+                                builder.build(&cuda_noise_squashing_compression_key, local_stream);
+                            })
+                        })
+                    });
+
+                    let compressed = builders
+                        .iter()
+                        .enumerate()
+                        .map(|(i, builder)| {
+                            let local_stream = &local_streams[i % local_streams.len()];
+
+                            builder.build(&cuda_noise_squashing_compression_key, local_stream)
+                        })
+                        .collect::<Vec<_>>();
+
+                    bench_id_unpack = format!("{bench_name}::throughput::unpack_u{bit_size}");
+                    bench_group.bench_function(&bench_id_unpack, |b| {
+                        b.iter(|| {
+                            compressed.par_iter().enumerate().for_each(|(i, comp)| {
+                                let local_stream = &local_streams[i % local_streams.len()];
+
+                                comp.get::<CudaSquashedNoiseRadixCiphertext>(0, local_stream)
+                                    .unwrap()
+                                    .unwrap();
+                            })
+                        })
+                    });
+                }
+            }
+
+            write_to_json::<u64, _>(
+                &bench_id_pack,
+                (noise_squashing_compression_parameters, param),
+                noise_squashing_compression_parameters.name(),
+                "pack",
+                &OperatorType::Atomic,
+                bit_size as u32,
+                vec![param.message_modulus.0.ilog2(); num_blocks],
+            );
+
+            write_to_json::<u64, _>(
+                &bench_id_unpack,
+                (noise_squashing_compression_parameters, param),
+                noise_squashing_compression_parameters.name(),
+                "unpack",
+                &OperatorType::Atomic,
+                bit_size as u32,
+                vec![param.message_modulus.0.ilog2(); num_blocks],
+            );
+        }
+
+        bench_group.finish()
+    }
+
     criterion_group!(gpu_glwe_packing2, gpu_glwe_packing);
+    criterion_group!(gpu_glwe_packing_128_2, gpu_glwe_packing_128);
 }
 
 criterion_group!(cpu_glwe_packing2, cpu_glwe_packing);
 
 #[cfg(feature = "gpu")]
-use cuda::gpu_glwe_packing2;
+use cuda::{gpu_glwe_packing2, gpu_glwe_packing_128_2};
 
 fn main() {
     #[cfg(feature = "gpu")]
     gpu_glwe_packing2();
+    #[cfg(feature = "gpu")]
+    gpu_glwe_packing_128_2();
     #[cfg(not(feature = "gpu"))]
     cpu_glwe_packing2();
 

--- a/tfhe-benchmark/src/params_aliases.rs
+++ b/tfhe-benchmark/src/params_aliases.rs
@@ -5,7 +5,8 @@ pub mod shortint_params_aliases {
     use tfhe::shortint::parameters::KeySwitch32PBSParameters;
     use tfhe::shortint::parameters::{
         ClassicPBSParameters, CompactPublicKeyEncryptionParameters, CompressionParameters,
-        MultiBitPBSParameters, NoiseSquashingParameters, ShortintKeySwitchingParameters,
+        MultiBitPBSParameters, NoiseSquashingCompressionParameters, NoiseSquashingParameters,
+        ShortintKeySwitchingParameters,
     };
 
     // KS PBS Gaussian
@@ -142,6 +143,10 @@ pub mod shortint_params_aliases {
     pub const BENCH_NOISE_SQUASHING_PARAM_GPU_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128:
         NoiseSquashingParameters =
         V1_3_NOISE_SQUASHING_PARAM_GPU_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+
+    pub const BENCH_COMP_NOISE_SQUASHING_PARAM_GPU_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128:
+        NoiseSquashingCompressionParameters =
+        V1_3_NOISE_SQUASHING_COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
 
     #[cfg(feature = "hpu")]
     // KS PBS Gaussian for Hpu

--- a/tfhe/src/core_crypto/entities/compressed_modulus_switched_glwe_ciphertext.rs
+++ b/tfhe/src/core_crypto/entities/compressed_modulus_switched_glwe_ciphertext.rs
@@ -175,7 +175,7 @@ impl<Scalar: UnsignedInteger> CompressedModulusSwitchedGlweCiphertext<Scalar> {
 
         assert!(
             ct.ciphertext_modulus().is_power_of_two(),
-            "Modulus switch compression doe not support non power of 2 input moduli",
+            "Modulus switch compression does not support non power of 2 input moduli",
         );
 
         let uncompressed_ciphertext_modulus_log =

--- a/tfhe/src/core_crypto/gpu/entities/lwe_ciphertext_list.rs
+++ b/tfhe/src/core_crypto/gpu/entities/lwe_ciphertext_list.rs
@@ -209,6 +209,10 @@ impl<T: UnsignedInteger> CudaLweCiphertextList<T> {
         LweCiphertext::from_container(container, self.ciphertext_modulus())
     }
 
+    pub fn duplicate(&self, streams: &CudaStreams) -> Self {
+        Self(self.0.duplicate(streams))
+    }
+
     pub(crate) fn lwe_dimension(&self) -> LweDimension {
         self.0.lwe_dimension
     }

--- a/tfhe/src/integer/gpu/ciphertext/compressed_ciphertext_list.rs
+++ b/tfhe/src/integer/gpu/ciphertext/compressed_ciphertext_list.rs
@@ -72,7 +72,7 @@ impl CudaExpandable for CudaBooleanBlock {
     }
 }
 pub struct CudaCompressedCiphertextList {
-    pub(crate) packed_list: CudaPackedGlweCiphertextList,
+    pub(crate) packed_list: CudaPackedGlweCiphertextList<u64>,
     pub(crate) info: Vec<DataKind>,
 }
 

--- a/tfhe/src/integer/gpu/ciphertext/compressed_noise_squashed_ciphertext_list.rs
+++ b/tfhe/src/integer/gpu/ciphertext/compressed_noise_squashed_ciphertext_list.rs
@@ -1,0 +1,744 @@
+use crate::core_crypto::gpu::lwe_ciphertext_list::CudaLweCiphertextList;
+use crate::core_crypto::gpu::CudaStreams;
+use crate::core_crypto::prelude::LweCiphertextCount;
+use crate::error::error;
+use crate::integer::ciphertext::DataKind;
+use crate::integer::gpu::ciphertext::info::{CudaBlockInfo, CudaRadixCiphertextInfo};
+use crate::integer::gpu::ciphertext::squashed_noise::{
+    CudaSquashedNoiseBooleanBlock, CudaSquashedNoiseRadixCiphertext,
+    CudaSquashedNoiseSignedRadixCiphertext,
+};
+use crate::integer::gpu::decompress_integer_radix_async_128;
+use crate::integer::gpu::list_compression::server_keys::{
+    CudaNoiseSquashingCompressionKey, CudaPackedGlweCiphertextList,
+};
+use crate::shortint::ciphertext::{Degree, NoiseLevel};
+use crate::shortint::{AtomicPatternKind, PBSOrder};
+use itertools::Itertools;
+use std::num::NonZeroUsize;
+
+pub struct CudaCompressedSquashedNoiseCiphertextListBuilder {
+    pub(crate) ciphertexts: Vec<CudaSquashedNoiseRadixCiphertext>,
+    pub(crate) info: Vec<DataKind>,
+}
+
+pub struct CudaCompressedSquashedNoiseCiphertextList {
+    pub(crate) packed_list: CudaPackedGlweCiphertextList<u128>,
+    pub(crate) info: Vec<DataKind>,
+}
+
+pub trait CudaSquashedNoiseCompressible {
+    fn compress_into(
+        self,
+        messages: &mut Vec<CudaSquashedNoiseRadixCiphertext>,
+        streams: &CudaStreams,
+    ) -> Option<DataKind>;
+}
+
+impl CudaSquashedNoiseCompressible for CudaSquashedNoiseRadixCiphertext {
+    fn compress_into(
+        self,
+        messages: &mut Vec<CudaSquashedNoiseRadixCiphertext>,
+        streams: &CudaStreams,
+    ) -> Option<DataKind> {
+        let x = self.duplicate(streams);
+        let num_blocks = x.original_block_count;
+
+        let num_blocks = NonZeroUsize::new(num_blocks);
+        if num_blocks.is_some() {
+            messages.push(x)
+        }
+        num_blocks.map(DataKind::Unsigned)
+    }
+}
+
+impl CudaSquashedNoiseCompressible for CudaSquashedNoiseSignedRadixCiphertext {
+    fn compress_into(
+        self,
+        messages: &mut Vec<CudaSquashedNoiseRadixCiphertext>,
+        streams: &CudaStreams,
+    ) -> Option<DataKind> {
+        let x = self.duplicate(streams);
+        let num_blocks = x.ciphertext.original_block_count;
+
+        let num_blocks = NonZeroUsize::new(num_blocks);
+        if num_blocks.is_some() {
+            messages.push(x.ciphertext)
+        }
+        num_blocks.map(DataKind::Signed)
+    }
+}
+
+impl CudaSquashedNoiseCompressible for CudaSquashedNoiseBooleanBlock {
+    fn compress_into(
+        self,
+        messages: &mut Vec<CudaSquashedNoiseRadixCiphertext>,
+        streams: &CudaStreams,
+    ) -> Option<DataKind> {
+        let x = self.duplicate(streams);
+
+        messages.push(x.ciphertext);
+        Some(DataKind::Boolean)
+    }
+}
+
+impl CudaCompressedSquashedNoiseCiphertextListBuilder {
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        Self {
+            ciphertexts: vec![],
+            info: vec![],
+        }
+    }
+
+    pub fn push<T: CudaSquashedNoiseCompressible>(
+        &mut self,
+        data: T,
+        streams: &CudaStreams,
+    ) -> &mut Self {
+        if let Some(kind) = data.compress_into(&mut self.ciphertexts, streams) {
+            self.info.push(kind);
+        }
+        self
+    }
+
+    pub fn extend<T>(&mut self, values: impl Iterator<Item = T>, streams: &CudaStreams) -> &mut Self
+    where
+        T: CudaSquashedNoiseCompressible,
+    {
+        for value in values {
+            self.push(value, streams);
+        }
+        self
+    }
+
+    pub fn build(
+        &self,
+        comp_key: &CudaNoiseSquashingCompressionKey,
+        streams: &CudaStreams,
+    ) -> CudaCompressedSquashedNoiseCiphertextList {
+        let packed_list =
+            comp_key.compress_noise_squashed_ciphertexts_into_list(&self.ciphertexts, streams);
+        CudaCompressedSquashedNoiseCiphertextList {
+            packed_list,
+            info: self.info.clone(),
+        }
+    }
+}
+
+fn create_error_message(tried: DataKind, actual: DataKind) -> crate::Error {
+    fn name(kind: DataKind) -> &'static str {
+        match kind {
+            DataKind::Unsigned(_) => "CudaSquashedNoiseRadixCiphertext",
+            DataKind::Signed(_) => "CudaSquashedNoiseSignedRadixCiphertext",
+            DataKind::Boolean => "CudaSquashedNoiseBooleanBlock",
+            DataKind::String { .. } => "Unsupported type",
+        }
+    }
+    error!(
+        "Tried to expand a {}, but a {} is stored in this slot",
+        name(tried),
+        name(actual)
+    )
+}
+
+pub trait CudaSquashedNoiseExpandable: Sized {
+    fn from_expanded_blocks(
+        blocks: CudaLweCiphertextList<u128>,
+        info: CudaRadixCiphertextInfo,
+        kind: DataKind,
+    ) -> crate::Result<Self>;
+}
+
+impl CudaSquashedNoiseExpandable for CudaSquashedNoiseRadixCiphertext {
+    fn from_expanded_blocks(
+        blocks: CudaLweCiphertextList<u128>,
+        info: CudaRadixCiphertextInfo,
+        kind: DataKind,
+    ) -> crate::Result<Self> {
+        if let DataKind::Unsigned(block_count) = kind {
+            Ok(Self {
+                packed_d_blocks: blocks,
+                original_block_count: block_count.get(),
+                info,
+            })
+        } else {
+            Err(create_error_message(
+                DataKind::Unsigned(NonZeroUsize::new(0).unwrap()),
+                kind,
+            ))
+        }
+    }
+}
+
+impl CudaSquashedNoiseExpandable for CudaSquashedNoiseSignedRadixCiphertext {
+    fn from_expanded_blocks(
+        blocks: CudaLweCiphertextList<u128>,
+        info: CudaRadixCiphertextInfo,
+        kind: DataKind,
+    ) -> crate::Result<Self> {
+        if let DataKind::Signed(block_count) = kind {
+            Ok(Self {
+                ciphertext: CudaSquashedNoiseRadixCiphertext {
+                    packed_d_blocks: blocks,
+                    original_block_count: block_count.get(),
+                    info,
+                },
+            })
+        } else {
+            Err(create_error_message(
+                DataKind::Signed(NonZeroUsize::new(0).unwrap()),
+                kind,
+            ))
+        }
+    }
+}
+
+impl CudaSquashedNoiseExpandable for CudaSquashedNoiseBooleanBlock {
+    fn from_expanded_blocks(
+        blocks: CudaLweCiphertextList<u128>,
+        info: CudaRadixCiphertextInfo,
+        kind: DataKind,
+    ) -> crate::Result<Self> {
+        if kind == DataKind::Boolean {
+            Ok(Self {
+                ciphertext: CudaSquashedNoiseRadixCiphertext {
+                    packed_d_blocks: blocks,
+                    original_block_count: 1,
+                    info,
+                },
+            })
+        } else {
+            Err(create_error_message(DataKind::Boolean, kind))
+        }
+    }
+}
+
+impl CudaCompressedSquashedNoiseCiphertextList {
+    pub fn builder() -> CudaCompressedSquashedNoiseCiphertextListBuilder {
+        CudaCompressedSquashedNoiseCiphertextListBuilder::new()
+    }
+    pub fn unpack(
+        &self,
+        kind: DataKind,
+        start_block_index: usize,
+        end_block_index: usize,
+        streams: &CudaStreams,
+    ) -> Result<(CudaLweCiphertextList<u128>, CudaRadixCiphertextInfo), crate::Error> {
+        // Check this first to make sure we don't try to access the metadata if the list is empty
+        if end_block_index >= self.packed_list.bodies_count() {
+            return Err(error!(
+            "Tried getting index {end_block_index} for CudaCompressedSquashedNoiseCiphertextList \
+            with {} elements, out of bound access.",
+            self.packed_list.bodies_count()
+        ));
+        }
+
+        let meta = self.packed_list.meta.as_ref().ok_or_else(|| {
+            error!("Missing ciphertext metadata in CudaCompressedSquashedNoiseCiphertextList")
+        })?;
+
+        let indexes_array = (start_block_index..=end_block_index)
+            .map(|x| x as u32)
+            .collect_vec();
+
+        let compression_glwe_dimension = meta.glwe_dimension;
+        let compression_polynomial_size = meta.polynomial_size;
+        let indexes_array_len = LweCiphertextCount(indexes_array.len());
+
+        let message_modulus = meta.message_modulus;
+        let carry_modulus = meta.carry_modulus;
+        let ciphertext_modulus = meta.ciphertext_modulus;
+
+        let lwe_dimension = meta
+            .glwe_dimension
+            .to_equivalent_lwe_dimension(meta.polynomial_size);
+
+        let mut output_lwe = CudaLweCiphertextList::new(
+            lwe_dimension,
+            indexes_array_len,
+            ciphertext_modulus,
+            streams,
+        );
+
+        unsafe {
+            decompress_integer_radix_async_128(
+                streams,
+                &mut output_lwe,
+                &self.packed_list,
+                message_modulus,
+                carry_modulus,
+                compression_glwe_dimension,
+                compression_polynomial_size,
+                lwe_dimension,
+                indexes_array.as_slice(),
+                indexes_array_len.0 as u32,
+            );
+        }
+        streams.synchronize();
+        let degree = match kind {
+            DataKind::Unsigned(_) | DataKind::Signed(_) | DataKind::String { .. } => {
+                Degree::new(message_modulus.0 - 1)
+            }
+            DataKind::Boolean => Degree::new(1),
+        };
+
+        let first_block_info = CudaBlockInfo {
+            degree,
+            message_modulus,
+            carry_modulus,
+            atomic_pattern: AtomicPatternKind::Standard(PBSOrder::KeyswitchBootstrap),
+            noise_level: NoiseLevel::NOMINAL,
+        };
+
+        let blocks = vec![first_block_info; output_lwe.0.lwe_ciphertext_count.0];
+
+        Ok((output_lwe, CudaRadixCiphertextInfo { blocks }))
+    }
+
+    #[allow(clippy::unnecessary_wraps)]
+    fn blocks_of(
+        &self,
+        index: usize,
+        streams: &CudaStreams,
+    ) -> Option<(
+        CudaLweCiphertextList<u128>,
+        CudaRadixCiphertextInfo,
+        DataKind,
+    )> {
+        let preceding_infos = self.info.get(..index)?;
+        let current_data_kind = self.info.get(index).copied()?;
+        let message_modulus = self.packed_list.message_modulus()?;
+
+        // Squashed CTs have blocks packed in pairs
+        let start_block_index: usize = preceding_infos
+            .iter()
+            .copied()
+            .map(|kind| kind.num_blocks(message_modulus).div_ceil(2))
+            .sum();
+
+        let end_block_index =
+            start_block_index + current_data_kind.num_blocks(message_modulus).div_ceil(2) - 1;
+
+        let (unpacked, info) = self
+            .unpack(
+                current_data_kind,
+                start_block_index,
+                end_block_index,
+                streams,
+            )
+            .unwrap();
+        Some((unpacked, info, current_data_kind))
+    }
+
+    pub fn get<T>(&self, index: usize, streams: &CudaStreams) -> crate::Result<Option<T>>
+    where
+        T: CudaSquashedNoiseExpandable,
+    {
+        self.blocks_of(index, streams)
+            .map(|(blocks, info, kind)| T::from_expanded_blocks(blocks, info, kind))
+            .transpose()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::core_crypto::gpu::CudaStreams;
+    use crate::integer::ciphertext::NoiseSquashingCompressionPrivateKey;
+    use crate::integer::gpu::ciphertext::boolean_value::CudaBooleanBlock;
+    use crate::integer::gpu::ciphertext::squashed_noise::{
+        CudaSquashedNoiseBooleanBlock, CudaSquashedNoiseRadixCiphertext,
+        CudaSquashedNoiseSignedRadixCiphertext,
+    };
+    use crate::integer::gpu::ciphertext::{
+        CudaCompressedSquashedNoiseCiphertextList, CudaSignedRadixCiphertext,
+        CudaUnsignedRadixCiphertext,
+    };
+    use crate::integer::gpu::list_compression::server_keys::CudaNoiseSquashingCompressionKey;
+    use crate::integer::gpu::{gen_keys_radix_gpu, CudaServerKey};
+    use crate::integer::noise_squashing::NoiseSquashingPrivateKey;
+    use crate::integer::{ClientKey, CompressedServerKey};
+    use crate::shortint::parameters::test_params::{
+        TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+        TEST_PARAM_NOISE_SQUASHING_COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+        TEST_PARAM_NOISE_SQUASHING_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+    };
+    use crate::shortint::ShortintParameterSet;
+    use itertools::Itertools;
+    use rand::Rng;
+
+    #[test]
+    fn test_cuda_compressed_noise_squashed_ciphertext_list() {
+        let param = TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+        let noise_squashing_parameters =
+            TEST_PARAM_NOISE_SQUASHING_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+        let noise_squashing_compression_parameters =
+            TEST_PARAM_NOISE_SQUASHING_COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+
+        const NUM_BLOCKS: usize = 16;
+        let streams = CudaStreams::new_multi_gpu();
+
+        let cks = ClientKey::new(param);
+        let compressed_sks = CompressedServerKey::new_radix_compressed_server_key(&cks);
+        let cuda_sks = CudaServerKey::decompress_from_cpu(&compressed_sks, &streams);
+
+        let noise_squashing_private_key = NoiseSquashingPrivateKey::new(noise_squashing_parameters);
+
+        let compressed_noise_squashing_compression_key =
+            cks.new_compressed_noise_squashing_key(&noise_squashing_private_key);
+
+        let cuda_noise_squashing_key =
+            compressed_noise_squashing_compression_key.decompress_to_cuda(&streams);
+
+        let noise_squashing_compression_private_key =
+            NoiseSquashingCompressionPrivateKey::new(noise_squashing_compression_parameters);
+        let noise_squashing_compression_key = noise_squashing_private_key
+            .new_noise_squashing_compression_key(&noise_squashing_compression_private_key);
+        let cuda_noise_squashing_compression_key =
+            CudaNoiseSquashingCompressionKey::from_noise_squashing_compression_key(
+                &noise_squashing_compression_key,
+                &streams,
+            );
+
+        let mut rng = rand::thread_rng();
+
+        let clear_a = rng.gen_range(0..=i32::MAX);
+        let clear_b = rng.gen_range(i32::MIN..=-1);
+        let clear_c = rng.gen::<u32>();
+        let clear_d = rng.gen::<bool>();
+
+        let ct_a = cks.encrypt_signed_radix(clear_a, NUM_BLOCKS);
+        let ct_b = cks.encrypt_signed_radix(clear_b, NUM_BLOCKS);
+        let ct_c = cks.encrypt_radix(clear_c, NUM_BLOCKS);
+        let ct_d = cks.encrypt_bool(clear_d);
+
+        let d_ct_a = CudaSignedRadixCiphertext::from_signed_radix_ciphertext(&ct_a, &streams);
+        let d_ct_b = CudaSignedRadixCiphertext::from_signed_radix_ciphertext(&ct_b, &streams);
+        let d_ct_c = CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct_c, &streams);
+        let d_ct_d = CudaBooleanBlock::from_boolean_block(&ct_d, &streams);
+
+        let d_ns_ct_a = cuda_noise_squashing_key
+            .squash_signed_radix_ciphertext_noise(&cuda_sks, &d_ct_a, &streams)
+            .unwrap();
+        let d_ns_ct_b = cuda_noise_squashing_key
+            .squash_signed_radix_ciphertext_noise(&cuda_sks, &d_ct_b, &streams)
+            .unwrap();
+        let d_ns_ct_c = cuda_noise_squashing_key
+            .squash_radix_ciphertext_noise(&cuda_sks, &d_ct_c.ciphertext, &streams)
+            .unwrap();
+        let d_ns_ct_d = cuda_noise_squashing_key
+            .squash_boolean_block_noise(&cuda_sks, &d_ct_d, &streams)
+            .unwrap();
+
+        let cuda_list = CudaCompressedSquashedNoiseCiphertextList::builder()
+            .push(d_ns_ct_a, &streams)
+            .push(d_ns_ct_b, &streams)
+            .push(d_ns_ct_c, &streams)
+            .push(d_ns_ct_d, &streams)
+            .build(&cuda_noise_squashing_compression_key, &streams);
+
+        let d_decompressed_ns_ct_a: CudaSquashedNoiseSignedRadixCiphertext =
+            cuda_list.get(0, &streams).unwrap().unwrap();
+        let d_decompressed_ns_ct_b: CudaSquashedNoiseSignedRadixCiphertext =
+            cuda_list.get(1, &streams).unwrap().unwrap();
+        let d_decompressed_ns_ct_c: CudaSquashedNoiseRadixCiphertext =
+            cuda_list.get(2, &streams).unwrap().unwrap();
+        let d_decompressed_ns_ct_d: CudaSquashedNoiseBooleanBlock =
+            cuda_list.get(3, &streams).unwrap().unwrap();
+
+        let ns_ct_a = d_decompressed_ns_ct_a.to_squashed_noise_signed_radix_ciphertext(&streams);
+        let ns_ct_b = d_decompressed_ns_ct_b.to_squashed_noise_signed_radix_ciphertext(&streams);
+        let ns_ct_c = d_decompressed_ns_ct_c.to_squashed_noise_radix_ciphertext(&streams);
+        let ns_ct_d = d_decompressed_ns_ct_d.to_squashed_noise_boolean_block(&streams);
+
+        let decryption_key = noise_squashing_compression_private_key.private_key_view();
+
+        let d_clear_a: i32 = decryption_key.decrypt_signed_radix(&ns_ct_a).unwrap();
+        let d_clear_b: i32 = decryption_key.decrypt_signed_radix(&ns_ct_b).unwrap();
+        let d_clear_c: u32 = decryption_key.decrypt_radix(&ns_ct_c).unwrap();
+        let d_clear_d = decryption_key.decrypt_bool(&ns_ct_d).unwrap();
+
+        assert_eq!(clear_a, d_clear_a);
+        assert_eq!(clear_b, d_clear_b);
+        assert_eq!(clear_c, d_clear_c);
+        assert_eq!(clear_d, d_clear_d);
+    }
+
+    const NB_TESTS: usize = 5;
+    const NB_OPERATOR_TESTS: usize = 3;
+
+    #[test]
+    fn test_gpu_extended_compressed_noise_squashed_ciphertext_compression() {
+        const NUM_BLOCKS: usize = 16;
+        let streams = CudaStreams::new_multi_gpu();
+
+        for (params, noise_squashing_parameters, noise_squashing_compression_parameters) in [(
+            TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128.into(),
+            TEST_PARAM_NOISE_SQUASHING_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+            TEST_PARAM_NOISE_SQUASHING_COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+        )] {
+            let (radix_cks, sks) =
+                gen_keys_radix_gpu::<ShortintParameterSet>(params, NUM_BLOCKS, &streams);
+            let cks = radix_cks.as_ref();
+
+            let noise_squashing_private_key =
+                NoiseSquashingPrivateKey::new(noise_squashing_parameters);
+
+            let compressed_noise_squashing_compression_key =
+                cks.new_compressed_noise_squashing_key(&noise_squashing_private_key);
+
+            let cuda_noise_squashing_key =
+                compressed_noise_squashing_compression_key.decompress_to_cuda(&streams);
+
+            let noise_squashing_compression_private_key =
+                NoiseSquashingCompressionPrivateKey::new(noise_squashing_compression_parameters);
+            let noise_squashing_compression_key = noise_squashing_private_key
+                .new_noise_squashing_compression_key(&noise_squashing_compression_private_key);
+            let cuda_noise_squashing_compression_key =
+                CudaNoiseSquashingCompressionKey::from_noise_squashing_compression_key(
+                    &noise_squashing_compression_key,
+                    &streams,
+                );
+
+            let decryption_key = noise_squashing_compression_private_key.private_key_view();
+
+            let mut rng = rand::thread_rng();
+
+            // How many uints of NUM_BLOCKS we have to push in the list to ensure it
+            // internally has more than one packed GLWE
+            let max_nb_messages: usize =
+                1 + 2 * noise_squashing_compression_parameters.lwe_per_glwe.0 / NUM_BLOCKS;
+
+            let message_modulus: u128 = cks.parameters().message_modulus().0 as u128;
+
+            for _ in 0..NB_TESTS {
+                // Unsigned
+                let modulus = message_modulus.pow(NUM_BLOCKS as u32);
+                for _ in 0..NB_OPERATOR_TESTS {
+                    let nb_messages = rng.gen_range(1..=max_nb_messages as u64);
+                    let messages = (0..nb_messages)
+                        .map(|_| rng.gen::<u128>() % modulus)
+                        .collect::<Vec<_>>();
+
+                    let d_cts = messages
+                        .iter()
+                        .map(|message| {
+                            let ct = radix_cks.encrypt(*message);
+                            CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct, &streams)
+                        })
+                        .collect_vec();
+
+                    let mut builder = CudaCompressedSquashedNoiseCiphertextList::builder();
+
+                    for d_ct in d_cts {
+                        let d_and_ct = sks.bitand(&d_ct, &d_ct, &streams);
+                        let d_and_ns_ct = cuda_noise_squashing_key
+                            .squash_radix_ciphertext_noise(&sks, &d_and_ct.ciphertext, &streams)
+                            .unwrap();
+                        builder.push(d_and_ns_ct, &streams);
+                    }
+
+                    let cuda_compressed =
+                        builder.build(&cuda_noise_squashing_compression_key, &streams);
+
+                    for (i, message) in messages.iter().enumerate() {
+                        let d_decompressed_ns_ct: CudaSquashedNoiseRadixCiphertext =
+                            cuda_compressed.get(i, &streams).unwrap().unwrap();
+                        let decompressed_ns_ct =
+                            d_decompressed_ns_ct.to_squashed_noise_radix_ciphertext(&streams);
+                        let decrypted: u128 =
+                            decryption_key.decrypt_radix(&decompressed_ns_ct).unwrap();
+                        assert_eq!(decrypted, *message);
+                    }
+                }
+
+                // Signed
+                let modulus = message_modulus.pow((NUM_BLOCKS - 1) as u32) as i128;
+                for _ in 0..NB_OPERATOR_TESTS {
+                    let nb_messages = rng.gen_range(1..=max_nb_messages as u64);
+                    let messages = (0..nb_messages)
+                        .map(|_| rng.gen::<i128>() % modulus)
+                        .collect::<Vec<_>>();
+
+                    let d_cts = messages
+                        .iter()
+                        .map(|message| {
+                            let ct = radix_cks.encrypt_signed(*message);
+                            CudaSignedRadixCiphertext::from_signed_radix_ciphertext(&ct, &streams)
+                        })
+                        .collect_vec();
+
+                    let mut builder = CudaCompressedSquashedNoiseCiphertextList::builder();
+
+                    for d_ct in d_cts {
+                        let d_and_ct = sks.bitand(&d_ct, &d_ct, &streams);
+                        let d_and_ns_ct = cuda_noise_squashing_key
+                            .squash_signed_radix_ciphertext_noise(&sks, &d_and_ct, &streams)
+                            .unwrap();
+                        builder.push(d_and_ns_ct, &streams);
+                    }
+
+                    let cuda_compressed =
+                        builder.build(&cuda_noise_squashing_compression_key, &streams);
+
+                    for (i, message) in messages.iter().enumerate() {
+                        let d_decompressed_ns_ct: CudaSquashedNoiseSignedRadixCiphertext =
+                            cuda_compressed.get(i, &streams).unwrap().unwrap();
+                        let decompressed_ns_ct = d_decompressed_ns_ct
+                            .to_squashed_noise_signed_radix_ciphertext(&streams);
+                        let decrypted: i128 = decryption_key
+                            .decrypt_signed_radix(&decompressed_ns_ct)
+                            .unwrap();
+                        assert_eq!(decrypted, *message);
+                    }
+                }
+
+                // Boolean
+                for _ in 0..NB_OPERATOR_TESTS {
+                    let nb_messages = rng.gen_range(1..=max_nb_messages as u64);
+                    let messages = (0..nb_messages)
+                        .map(|_| rng.gen::<i64>() % 2 != 0)
+                        .collect::<Vec<_>>();
+
+                    let d_cts = messages
+                        .iter()
+                        .map(|message| {
+                            let ct = radix_cks.encrypt_bool(*message);
+                            CudaBooleanBlock::from_boolean_block(&ct, &streams)
+                        })
+                        .collect_vec();
+
+                    let mut builder = CudaCompressedSquashedNoiseCiphertextList::builder();
+
+                    for d_boolean_ct in d_cts {
+                        let d_ct = d_boolean_ct.0;
+                        let d_and_ct = sks.bitand(&d_ct, &d_ct, &streams);
+                        let d_and_boolean_ct =
+                            CudaBooleanBlock::from_cuda_radix_ciphertext(d_and_ct.ciphertext);
+                        let d_and_boolean_ns_ct = cuda_noise_squashing_key
+                            .squash_boolean_block_noise(&sks, &d_and_boolean_ct, &streams)
+                            .unwrap();
+                        builder.push(d_and_boolean_ns_ct, &streams);
+                    }
+
+                    let cuda_compressed =
+                        builder.build(&cuda_noise_squashing_compression_key, &streams);
+
+                    for (i, message) in messages.iter().enumerate() {
+                        let d_decompressed_ns_ct: CudaSquashedNoiseBooleanBlock =
+                            cuda_compressed.get(i, &streams).unwrap().unwrap();
+                        let decompressed_ns_ct =
+                            d_decompressed_ns_ct.to_squashed_noise_boolean_block(&streams);
+                        let decrypted = decryption_key.decrypt_bool(&decompressed_ns_ct).unwrap();
+                        assert_eq!(decrypted, *message);
+                    }
+                }
+
+                // Hybrid
+                enum MessageType {
+                    Unsigned(u128),
+                    Signed(i128),
+                    Boolean(bool),
+                }
+                for _ in 0..NB_OPERATOR_TESTS {
+                    let mut builder = CudaCompressedSquashedNoiseCiphertextList::builder();
+
+                    let nb_messages = rng.gen_range(1..=max_nb_messages as u64);
+                    let mut messages = vec![];
+                    for _ in 0..nb_messages {
+                        let case_selector = rng.gen_range(0..3);
+                        match case_selector {
+                            0 => {
+                                // Unsigned
+                                let modulus = message_modulus.pow(NUM_BLOCKS as u32);
+                                let message = rng.gen::<u128>() % modulus;
+                                let ct = radix_cks.encrypt(message);
+                                let d_ct = CudaUnsignedRadixCiphertext::from_radix_ciphertext(
+                                    &ct, &streams,
+                                );
+                                let d_and_ct = sks.bitand(&d_ct, &d_ct, &streams);
+                                let d_and_ns_ct = cuda_noise_squashing_key
+                                    .squash_radix_ciphertext_noise(
+                                        &sks,
+                                        &d_and_ct.ciphertext,
+                                        &streams,
+                                    )
+                                    .unwrap();
+                                builder.push(d_and_ns_ct, &streams);
+                                messages.push(MessageType::Unsigned(message));
+                            }
+                            1 => {
+                                // Signed
+                                let modulus = message_modulus.pow((NUM_BLOCKS - 1) as u32) as i128;
+                                let message = rng.gen::<i128>() % modulus;
+                                let ct = radix_cks.encrypt_signed(message);
+                                let d_ct = CudaSignedRadixCiphertext::from_signed_radix_ciphertext(
+                                    &ct, &streams,
+                                );
+                                let d_and_ct = sks.bitand(&d_ct, &d_ct, &streams);
+                                let d_and_ns_ct = cuda_noise_squashing_key
+                                    .squash_signed_radix_ciphertext_noise(&sks, &d_and_ct, &streams)
+                                    .unwrap();
+                                builder.push(d_and_ns_ct, &streams);
+                                messages.push(MessageType::Signed(message));
+                            }
+                            _ => {
+                                // Boolean
+                                let message = rng.gen::<i64>() % 2 != 0;
+                                let ct = radix_cks.encrypt_bool(message);
+                                let d_boolean_ct =
+                                    CudaBooleanBlock::from_boolean_block(&ct, &streams);
+                                let d_ct = d_boolean_ct.0;
+                                let d_and_ct = sks.bitand(&d_ct, &d_ct, &streams);
+                                let d_and_boolean_ct = CudaBooleanBlock::from_cuda_radix_ciphertext(
+                                    d_and_ct.ciphertext,
+                                );
+                                let d_and_ns_ct = cuda_noise_squashing_key
+                                    .squash_boolean_block_noise(&sks, &d_and_boolean_ct, &streams)
+                                    .unwrap();
+                                builder.push(d_and_ns_ct, &streams);
+                                messages.push(MessageType::Boolean(message));
+                            }
+                        }
+                    }
+
+                    let cuda_compressed =
+                        builder.build(&cuda_noise_squashing_compression_key, &streams);
+
+                    for (i, val) in messages.iter().enumerate() {
+                        match val {
+                            MessageType::Unsigned(message) => {
+                                let d_decompressed_ns_ct: CudaSquashedNoiseRadixCiphertext =
+                                    cuda_compressed.get(i, &streams).unwrap().unwrap();
+                                let decompressed_ns_ct = d_decompressed_ns_ct
+                                    .to_squashed_noise_radix_ciphertext(&streams);
+                                let decrypted: u128 =
+                                    decryption_key.decrypt_radix(&decompressed_ns_ct).unwrap();
+                                assert_eq!(decrypted, *message);
+                            }
+                            MessageType::Signed(message) => {
+                                let d_decompressed_ns_ct: CudaSquashedNoiseSignedRadixCiphertext =
+                                    cuda_compressed.get(i, &streams).unwrap().unwrap();
+                                let decompressed_ns_ct = d_decompressed_ns_ct
+                                    .to_squashed_noise_signed_radix_ciphertext(&streams);
+                                let decrypted: i128 = decryption_key
+                                    .decrypt_signed_radix(&decompressed_ns_ct)
+                                    .unwrap();
+                                assert_eq!(decrypted, *message);
+                            }
+                            MessageType::Boolean(message) => {
+                                let d_decompressed_ns_ct: CudaSquashedNoiseBooleanBlock =
+                                    cuda_compressed.get(i, &streams).unwrap().unwrap();
+                                let decompressed_ns_ct =
+                                    d_decompressed_ns_ct.to_squashed_noise_boolean_block(&streams);
+                                let decrypted: bool =
+                                    decryption_key.decrypt_bool(&decompressed_ns_ct).unwrap();
+                                assert_eq!(decrypted, *message);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tfhe/src/integer/gpu/ciphertext/info.rs
+++ b/tfhe/src/integer/gpu/ciphertext/info.rs
@@ -1,6 +1,7 @@
 use crate::shortint::ciphertext::{Degree, NoiseLevel};
 use crate::shortint::parameters::AtomicPatternKind;
 use crate::shortint::{CarryModulus, MessageModulus};
+use itertools::Itertools;
 
 #[derive(Clone, Copy)]
 pub struct CudaBlockInfo {
@@ -14,6 +15,15 @@ pub struct CudaBlockInfo {
 impl CudaBlockInfo {
     pub fn carry_is_empty(&self) -> bool {
         self.degree.get() < self.message_modulus.0
+    }
+    pub fn duplicate(&self) -> Self {
+        Self {
+            degree: self.degree,
+            message_modulus: self.message_modulus,
+            carry_modulus: self.carry_modulus,
+            atomic_pattern: self.atomic_pattern,
+            noise_level: self.noise_level,
+        }
     }
 }
 
@@ -87,5 +97,15 @@ impl CudaRadixCiphertextInfo {
             .blocks
             .extend(self.blocks[..num_blocks].iter().copied());
         new_block_info
+    }
+
+    pub fn duplicate(&self) -> Self {
+        Self {
+            blocks: self
+                .blocks
+                .iter()
+                .map(|block| block.duplicate())
+                .collect_vec(),
+        }
     }
 }

--- a/tfhe/src/integer/gpu/ciphertext/mod.rs
+++ b/tfhe/src/integer/gpu/ciphertext/mod.rs
@@ -1,6 +1,7 @@
 pub mod boolean_value;
 pub mod compact_list;
 pub mod compressed_ciphertext_list;
+pub mod compressed_noise_squashed_ciphertext_list;
 pub mod info;
 pub mod squashed_noise;
 
@@ -13,6 +14,8 @@ use crate::integer::parameters::LweDimension;
 use crate::integer::{IntegerCiphertext, RadixCiphertext, SignedRadixCiphertext};
 use crate::shortint::{Ciphertext, EncryptionKeyChoice};
 use crate::GpuIndex;
+
+pub use compressed_noise_squashed_ciphertext_list::*;
 
 pub trait CudaIntegerRadixCiphertext: Sized {
     const IS_SIGNED: bool;

--- a/tfhe/src/integer/gpu/ciphertext/squashed_noise.rs
+++ b/tfhe/src/integer/gpu/ciphertext/squashed_noise.rs
@@ -62,6 +62,14 @@ impl CudaSquashedNoiseRadixCiphertext {
         }
     }
 
+    pub fn duplicate(&self, streams: &CudaStreams) -> Self {
+        Self {
+            packed_d_blocks: self.packed_d_blocks.duplicate(streams),
+            info: self.info.duplicate(),
+            original_block_count: self.original_block_count,
+        }
+    }
+
     pub(crate) fn to_squashed_noise_radix_ciphertext(
         &self,
         streams: &CudaStreams,
@@ -106,6 +114,12 @@ impl CudaSquashedNoiseSignedRadixCiphertext {
             original_block_count: self.ciphertext.original_block_count,
         }
     }
+
+    pub(crate) fn duplicate(&self, streams: &CudaStreams) -> Self {
+        Self {
+            ciphertext: self.ciphertext.duplicate(streams),
+        }
+    }
 }
 
 impl CudaSquashedNoiseBooleanBlock {
@@ -119,6 +133,12 @@ impl CudaSquashedNoiseBooleanBlock {
                 .to_squashed_noise_radix_ciphertext(streams)
                 .packed_blocks[0]
                 .clone(),
+        }
+    }
+
+    pub(crate) fn duplicate(&self, streams: &CudaStreams) -> Self {
+        Self {
+            ciphertext: self.ciphertext.duplicate(streams),
         }
     }
 }

--- a/tfhe/src/integer/gpu/list_compression/server_keys.rs
+++ b/tfhe/src/integer/gpu/list_compression/server_keys.rs
@@ -4,16 +4,17 @@ use crate::core_crypto::gpu::vec::CudaVec;
 use crate::core_crypto::gpu::CudaStreams;
 use crate::core_crypto::prelude::{
     glwe_ciphertext_size, glwe_mask_size, CiphertextModulus, CiphertextModulusLog,
-    GlweCiphertextCount, LweCiphertextCount, PolynomialSize,
+    GlweCiphertextCount, LweCiphertextCount, PolynomialSize, UnsignedInteger,
 };
 use crate::error;
-use crate::integer::ciphertext::DataKind;
+use crate::integer::ciphertext::{DataKind, NoiseSquashingCompressionKey};
 use crate::integer::compression_keys::CompressionKey;
 use crate::integer::gpu::ciphertext::info::{CudaBlockInfo, CudaRadixCiphertextInfo};
+use crate::integer::gpu::ciphertext::squashed_noise::CudaSquashedNoiseRadixCiphertext;
 use crate::integer::gpu::ciphertext::CudaRadixCiphertext;
 use crate::integer::gpu::server_key::CudaBootstrappingKey;
 use crate::integer::gpu::{
-    compress_integer_radix_async, cuda_memcpy_async_gpu_to_gpu, decompress_integer_radix_async,
+    compress_integer_radix_async, cuda_memcpy_async_gpu_to_gpu, decompress_integer_radix_async_64,
     get_compression_size_on_gpu, get_decompression_size_on_gpu,
 };
 use crate::shortint::ciphertext::{Degree, NoiseLevel};
@@ -29,6 +30,11 @@ pub struct CudaCompressionKey {
     pub storage_log_modulus: CiphertextModulusLog,
 }
 
+pub struct CudaNoiseSquashingCompressionKey {
+    pub packing_key_switching_key: CudaLwePackingKeyswitchKey<u128>,
+    pub lwe_per_glwe: LweCiphertextCount,
+}
+
 pub struct CudaDecompressionKey {
     pub blind_rotate_key: CudaBootstrappingKey<u64>,
     pub lwe_per_glwe: LweCiphertextCount,
@@ -40,12 +46,12 @@ pub struct CudaDecompressionKey {
 }
 
 #[derive(Copy, Clone)]
-pub struct CudaPackedGlweCiphertextListMeta {
+pub struct CudaPackedGlweCiphertextListMeta<T: UnsignedInteger> {
     pub glwe_dimension: GlweDimension,
     pub polynomial_size: PolynomialSize,
     pub message_modulus: MessageModulus,
     pub carry_modulus: CarryModulus,
-    pub ciphertext_modulus: CiphertextModulus<u64>,
+    pub ciphertext_modulus: CiphertextModulus<T>,
     pub storage_log_modulus: CiphertextModulusLog,
     pub lwe_per_glwe: LweCiphertextCount,
     // Number of lwe bodies that are compressed in this list
@@ -55,13 +61,13 @@ pub struct CudaPackedGlweCiphertextListMeta {
     pub initial_len: usize,
 }
 
-pub struct CudaPackedGlweCiphertextList {
+pub struct CudaPackedGlweCiphertextList<T: UnsignedInteger> {
     // The compressed GLWE list's elements
-    pub data: CudaVec<u64>,
-    pub meta: Option<CudaPackedGlweCiphertextListMeta>,
+    pub data: CudaVec<T>,
+    pub meta: Option<CudaPackedGlweCiphertextListMeta<T>>,
 }
 
-impl CudaPackedGlweCiphertextList {
+impl<T: UnsignedInteger> CudaPackedGlweCiphertextList<T> {
     /// Returns the message modulus of the Ciphertexts in the list, or None if the list is empty
     pub fn message_modulus(&self) -> Option<MessageModulus> {
         self.meta.as_ref().map(|meta| meta.message_modulus)
@@ -93,7 +99,7 @@ impl CudaPackedGlweCiphertextList {
     }
 }
 
-impl Clone for CudaPackedGlweCiphertextList {
+impl<T: UnsignedInteger> Clone for CudaPackedGlweCiphertextList<T> {
     fn clone(&self) -> Self {
         Self {
             data: self.data.clone(),
@@ -161,7 +167,7 @@ impl CudaCompressionKey {
         &self,
         ciphertexts: &[CudaRadixCiphertext],
         streams: &CudaStreams,
-    ) -> CudaPackedGlweCiphertextList {
+    ) -> CudaPackedGlweCiphertextList<u64> {
         let lwe_pksk = &self.packing_key_switching_key;
 
         let ciphertext_modulus = lwe_pksk.ciphertext_modulus();
@@ -178,7 +184,7 @@ impl CudaCompressionKey {
             compressed_glwe_size.to_glwe_dimension(),
             compressed_polynomial_size,
         );
-        // The number of u64 (both mask and bodies)
+        // The total number of elements (both mask and bodies)
         let uncompressed_len = num_glwes * glwe_mask_size + num_lwes;
         let number_bits_to_pack = uncompressed_len * self.storage_log_modulus.0;
         let compressed_len = number_bits_to_pack.div_ceil(u64::BITS as usize);
@@ -267,7 +273,7 @@ impl CudaCompressionKey {
 impl CudaDecompressionKey {
     pub fn unpack(
         &self,
-        packed_list: &CudaPackedGlweCiphertextList,
+        packed_list: &CudaPackedGlweCiphertextList<u64>,
         kind: DataKind,
         start_block_index: usize,
         end_block_index: usize,
@@ -324,7 +330,7 @@ impl CudaDecompressionKey {
                 );
 
                 unsafe {
-                    decompress_integer_radix_async(
+                    decompress_integer_radix_async_64(
                         streams,
                         &mut output_lwe,
                         packed_list,
@@ -374,7 +380,7 @@ impl CudaDecompressionKey {
     }
     pub fn get_unpack_size_on_gpu(
         &self,
-        packed_list: &CudaPackedGlweCiphertextList,
+        packed_list: &CudaPackedGlweCiphertextList<u64>,
         start_block_index: usize,
         end_block_index: usize,
         streams: &CudaStreams,
@@ -426,5 +432,149 @@ impl CudaDecompressionKey {
                 panic! {"Compression is currently not compatible with Multi-Bit PBS"}
             }
         }
+    }
+}
+
+impl CudaNoiseSquashingCompressionKey {
+    pub fn from_noise_squashing_compression_key(
+        compression_key: &NoiseSquashingCompressionKey,
+        streams: &CudaStreams,
+    ) -> Self {
+        Self {
+            packing_key_switching_key: CudaLwePackingKeyswitchKey::from_lwe_packing_keyswitch_key(
+                compression_key.key.packing_key_switching_key(),
+                streams,
+            ),
+            lwe_per_glwe: compression_key.key.lwe_per_glwe(),
+        }
+    }
+
+    unsafe fn flatten_async(
+        ciphertexts_slice: &[CudaSquashedNoiseRadixCiphertext],
+        streams: &CudaStreams,
+    ) -> CudaLweCiphertextList<u128> {
+        let first_ct = &ciphertexts_slice.first().unwrap().packed_d_blocks;
+
+        // We assume all ciphertexts will have the same lwe dimension
+        let lwe_dimension = first_ct.lwe_dimension();
+        let ciphertext_modulus = first_ct.ciphertext_modulus();
+
+        // Compute total number of lwe ciphertexts we will be handling
+        let total_num_blocks: usize = ciphertexts_slice
+            .iter()
+            .map(|x| x.packed_d_blocks.lwe_ciphertext_count().0)
+            .sum();
+
+        let lwe_ciphertext_count = LweCiphertextCount(total_num_blocks);
+
+        let mut d_vec = CudaVec::new_async(
+            lwe_dimension.to_lwe_size().0 * lwe_ciphertext_count.0,
+            streams,
+            0,
+        );
+        let mut offset: usize = 0;
+        for ciphertext in ciphertexts_slice {
+            let dest_ptr = d_vec
+                .as_mut_c_ptr(0)
+                .add(offset * std::mem::size_of::<u128>());
+            let size = ciphertext.packed_d_blocks.0.d_vec.len * std::mem::size_of::<u128>();
+            cuda_memcpy_async_gpu_to_gpu(
+                dest_ptr,
+                ciphertext.packed_d_blocks.0.d_vec.as_c_ptr(0),
+                size as u64,
+                streams.ptr[0],
+                streams.gpu_indexes[0].get(),
+            );
+
+            offset += ciphertext.packed_d_blocks.0.d_vec.len;
+        }
+
+        CudaLweCiphertextList::from_cuda_vec(d_vec, lwe_ciphertext_count, ciphertext_modulus)
+    }
+
+    pub fn compress_noise_squashed_ciphertexts_into_list(
+        &self,
+        ciphertexts: &[CudaSquashedNoiseRadixCiphertext],
+        streams: &CudaStreams,
+    ) -> CudaPackedGlweCiphertextList<u128> {
+        let lwe_pksk = &self.packing_key_switching_key;
+
+        let first_ct = ciphertexts.first().unwrap();
+        let ciphertext_modulus = first_ct.packed_d_blocks.ciphertext_modulus();
+        let compressed_polynomial_size = lwe_pksk.output_polynomial_size();
+        let compressed_glwe_size = lwe_pksk.output_glwe_size();
+
+        let num_lwes: usize = ciphertexts
+            .iter()
+            .map(|x| x.packed_d_blocks.lwe_ciphertext_count().0)
+            .sum();
+
+        let num_glwes = num_lwes.div_ceil(self.lwe_per_glwe.0);
+        let glwe_mask_size = glwe_mask_size(
+            compressed_glwe_size.to_glwe_dimension(),
+            compressed_polynomial_size,
+        );
+        // The total number of elements (both mask and bodies)
+        let uncompressed_len = num_glwes * glwe_mask_size + num_lwes;
+        let ciphertext_modulus_log = ciphertext_modulus.into_modulus_log();
+        // The CPU implementation uses ciphertext_modulus_log instead of self.storage_log_modulus
+        // In the future the noise squash compression might include a modswitch so we will have to
+        // update to add a storage_log_modulus param and use this.
+        let number_bits_to_pack = uncompressed_len * ciphertext_modulus_log.0;
+        let compressed_len = number_bits_to_pack.div_ceil(u128::BITS as usize);
+        let packed_glwe_list = CudaVec::new(compressed_len, streams, 0);
+
+        if ciphertexts.is_empty() {
+            return CudaPackedGlweCiphertextList {
+                data: packed_glwe_list,
+                meta: None,
+            };
+        }
+
+        // Ok to unwrap because list is not empty
+        let first_ct_info = first_ct.info.blocks.first().unwrap();
+        let message_modulus = first_ct_info.message_modulus;
+        let carry_modulus = first_ct_info.carry_modulus;
+
+        let lwe_dimension = first_ct.packed_d_blocks.lwe_dimension();
+
+        let mut glwe_array_out = CudaPackedGlweCiphertextList {
+            data: packed_glwe_list,
+            meta: Some(CudaPackedGlweCiphertextListMeta {
+                glwe_dimension: compressed_glwe_size.to_glwe_dimension(),
+                polynomial_size: compressed_polynomial_size,
+                message_modulus,
+                carry_modulus,
+                ciphertext_modulus,
+                storage_log_modulus: ciphertext_modulus_log,
+                lwe_per_glwe: LweCiphertextCount(compressed_polynomial_size.0),
+                total_lwe_bodies_count: num_lwes,
+                initial_len: uncompressed_len,
+            }),
+        };
+
+        unsafe {
+            let input_lwes = Self::flatten_async(ciphertexts, streams);
+
+            compress_integer_radix_async(
+                streams,
+                &mut glwe_array_out,
+                &input_lwes,
+                &self.packing_key_switching_key.d_vec,
+                message_modulus,
+                carry_modulus,
+                compressed_glwe_size.to_glwe_dimension(),
+                compressed_polynomial_size,
+                lwe_dimension,
+                lwe_pksk.decomposition_base_log(),
+                lwe_pksk.decomposition_level_count(),
+                self.lwe_per_glwe.0 as u32,
+                num_lwes as u32,
+            );
+
+            streams.synchronize();
+        };
+
+        glwe_array_out
     }
 }


### PR DESCRIPTION
This PR also simplifies the call to 128-bit PBSs. Now we have a single entry point for all sizes.

The same underlying code is shared between 128 and 64-bit compression, only skipping the operations scalar multiplication and PBS in the former.

<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: https://github.com/zama-ai/tfhe-rs-internal/issues/1067

### PR content/description

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/2664)
<!-- Reviewable:end -->
