### PR TITLE
feat(zk): add ZeroizeZp type that is automatically zeroized on drop

### DIFF
--- a/tfhe-zk-pok/Cargo.toml
+++ b/tfhe-zk-pok/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tfhe-zk-pok"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 keywords = ["zero", "knowledge", "proof", "vector-commitments"]
 homepage = "https://zama.ai/"

--- a/tfhe-zk-pok/src/curve_api/bls12_446.rs
+++ b/tfhe-zk-pok/src/curve_api/bls12_446.rs
@@ -174,6 +174,12 @@ mod g1 {
             }
         }
 
+        pub fn mul_scalar_zeroize(self, scalar: &ZeroizeZp) -> Self {
+            Self {
+                inner: scalar.mul_point(self.inner),
+            }
+        }
+
         #[track_caller]
         pub fn multi_mul_scalar(bases: &[Self], scalars: &[Zp]) -> Self {
             use rayon::prelude::*;
@@ -531,6 +537,12 @@ mod g2 {
         pub fn mul_scalar(self, scalar: Zp) -> Self {
             Self {
                 inner: mul_zp(self.inner, scalar),
+            }
+        }
+
+        pub fn mul_scalar_zeroize(self, scalar: &ZeroizeZp) -> Self {
+            Self {
+                inner: scalar.mul_point(self.inner),
             }
         }
 
@@ -945,12 +957,13 @@ mod gt {
 
 mod zp {
     use super::*;
+    use crate::curve_446::FrConfig;
     use crate::serialization::InvalidArraySizeError;
-    use ark_ff::Fp;
+    use ark_ff::{Fp, FpConfig, MontBackend, PrimeField};
     use tfhe_versionable::Versionize;
-    use zeroize::Zeroize;
+    use zeroize::{Zeroize, ZeroizeOnDrop};
 
-    fn redc(n: [u64; 5], nprime: u64, mut t: [u64; 7]) -> [u64; 5] {
+    fn redc(n: [u64; 5], nprime: u64, t: &mut [u64; 7], out: &mut [u64; 5]) {
         for i in 0..2 {
             let mut c = 0u64;
             let m = u64::wrapping_mul(t[i], nprime);
@@ -968,20 +981,22 @@ mod zp {
             }
         }
 
-        let mut t = [t[2], t[3], t[4], t[5], t[6]];
+        out[0] = t[2];
+        out[1] = t[3];
+        out[2] = t[4];
+        out[3] = t[5];
+        out[4] = t[6];
 
-        if t.into_iter().rev().ge(n.into_iter().rev()) {
+        if out.iter().rev().ge(n.iter().rev()) {
             let mut o = false;
             for i in 0..5 {
-                let (ti, o0) = u64::overflowing_sub(t[i], n[i]);
+                let (ti, o0) = u64::overflowing_sub(out[i], n[i]);
                 let (ti, o1) = u64::overflowing_sub(ti, o as u64);
                 o = o0 | o1;
-                t[i] = ti;
+                out[i] = ti;
             }
         }
-        assert!(t.into_iter().rev().lt(n.into_iter().rev()));
-
-        t
+        assert!(out.iter().rev().lt(n.iter().rev()));
     }
 
     #[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Versionize, Hash, Zeroize)]
@@ -1066,11 +1081,10 @@ mod zp {
             let mut n = n;
             // zero the 22 leading bits, so the result is <= MODULUS * 2^128
             n[6] &= (1 << 42) - 1;
+            let mut res = [0; 5];
+            redc(MODULUS.0, MODULUS_MONTGOMERY, &mut n, &mut res);
             Zp {
-                inner: Fp(
-                    BigInt(redc(MODULUS.0, MODULUS_MONTGOMERY, n)),
-                    core::marker::PhantomData,
-                ),
+                inner: Fp(BigInt(res), core::marker::PhantomData),
             }
         }
 
@@ -1195,18 +1209,131 @@ mod zp {
             iter.fold(Zp::ZERO, Add::add)
         }
     }
+
+    /// This is like [`Zp`] but will automatically be zeroized on drop, at the cost of not being
+    /// Copy
+    #[derive(Clone, PartialEq, Eq, Hash, ZeroizeOnDrop)]
+    pub struct ZeroizeZp {
+        inner: crate::curve_446::Fr,
+    }
+
+    #[cfg(test)]
+    impl From<ZeroizeZp> for crate::curve_446::Fr {
+        fn from(value: ZeroizeZp) -> Self {
+            value.inner
+        }
+    }
+
+    impl Mul<&ZeroizeZp> for &ZeroizeZp {
+        type Output = ZeroizeZp;
+
+        #[inline]
+        fn mul(self, rhs: &ZeroizeZp) -> Self::Output {
+            let mut result = self.clone();
+            MontBackend::<FrConfig, 5>::mul_assign(&mut result.inner, &rhs.inner);
+            result
+        }
+    }
+
+    impl Mul<&ZeroizeZp> for Zp {
+        type Output = Zp;
+
+        #[inline]
+        fn mul(mut self, rhs: &ZeroizeZp) -> Self::Output {
+            MontBackend::<FrConfig, 5>::mul_assign(&mut self.inner, &rhs.inner);
+            self
+        }
+    }
+
+    impl Add<&ZeroizeZp> for &ZeroizeZp {
+        type Output = ZeroizeZp;
+
+        #[inline]
+        fn add(self, rhs: &ZeroizeZp) -> Self::Output {
+            let mut result = self.clone();
+            MontBackend::<FrConfig, 5>::add_assign(&mut result.inner, &rhs.inner);
+            result
+        }
+    }
+
+    impl Add<&ZeroizeZp> for Zp {
+        type Output = Zp;
+
+        #[inline]
+        fn add(mut self, rhs: &ZeroizeZp) -> Self::Output {
+            MontBackend::<FrConfig, 5>::add_assign(&mut self.inner, &rhs.inner);
+            self
+        }
+    }
+
+    impl ZeroizeZp {
+        pub const ZERO: Self = Self {
+            inner: MontFp!("0"),
+        };
+
+        pub const ONE: Self = Self {
+            inner: MontFp!("1"),
+        };
+
+        fn reduce_from_raw_u64x7(n: &mut [u64; 7], out: &mut [u64; 5]) {
+            const MODULUS: BigInt<5> = BigInt!(
+                "645383785691237230677916041525710377746967055506026847120930304831624105190538527824412673"
+            );
+
+            const MODULUS_MONTGOMERY: u64 = 272467794636046335;
+
+            // zero the 22 leading bits, so the result is <= MODULUS * 2^128
+            n[6] &= (1 << 42) - 1;
+
+            redc(MODULUS.0, MODULUS_MONTGOMERY, n, out);
+        }
+
+        /// Replace the content of the provided element with a random but valid one
+        pub fn rand_in_place(&mut self, rng: &mut dyn rand::RngCore) {
+            use rand::Rng;
+
+            let mut values = [0; 7];
+            rng.fill(&mut values);
+            Self::reduce_from_raw_u64x7(&mut values, &mut self.inner.0 .0);
+            values.zeroize();
+        }
+
+        pub fn mul_point<T: Copy + Zero + Add<Output = T> + Group>(&self, x: T) -> T {
+            let zero = T::zero();
+            let mut n = self.clone().inner.into_bigint();
+
+            if n.0 == [0; 5] {
+                return zero;
+            }
+
+            let mut y = zero;
+            let mut x = x;
+
+            for word in &n.0 {
+                for idx in 0..64 {
+                    let bit = (word >> idx) & 1;
+                    if bit == 1 {
+                        y += x;
+                    }
+                    x.double_in_place();
+                }
+            }
+            n.zeroize();
+            y
+        }
+    }
 }
 
 pub use g1::{G1Affine, G1};
 pub use g2::{G2Affine, G2};
 pub use gt::Gt;
-pub use zp::Zp;
+pub use zp::{ZeroizeZp, Zp};
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use rand::rngs::StdRng;
-    use rand::SeedableRng;
+    use rand::{thread_rng, Rng, SeedableRng};
     use std::collections::HashMap;
 
     #[test]
@@ -1357,5 +1484,55 @@ mod tests {
         assert_eq!(hm.len(), 1);
         hm.insert(a_affine, 2);
         assert_eq!(hm.len(), 1);
+    }
+
+    /// Test that ZeroizeZp is equivalent to Zp
+    #[test]
+    fn test_zeroize_equivalency() {
+        let seed = thread_rng().gen();
+        println!("zeroize_equivalency seed: {seed:x}");
+        let rng = &mut StdRng::seed_from_u64(seed);
+
+        let mut zeroize1 = ZeroizeZp::ZERO;
+        ZeroizeZp::rand_in_place(&mut zeroize1, rng);
+        let mut zeroize2 = ZeroizeZp::ZERO;
+        ZeroizeZp::rand_in_place(&mut zeroize2, rng);
+
+        let rng = &mut StdRng::seed_from_u64(seed);
+        let zp1 = Zp::rand(rng);
+        let zp2 = Zp::rand(rng);
+
+        assert_eq!(zp1.inner, zeroize1.clone().into());
+        assert_eq!(zp2.inner, zeroize2.clone().into());
+
+        let sum_zeroize = &zeroize1 + &zeroize2;
+        let sum_zp = zp1 + zp2;
+
+        assert_eq!(sum_zp.inner, sum_zeroize.clone().into());
+
+        let sum_zeroize_zp = zp1 + &zeroize2;
+
+        assert_eq!(sum_zp.inner, sum_zeroize_zp.inner);
+
+        let prod_zeroize = &zeroize1 * &zeroize2;
+        let prod_zp = zp1 * zp2;
+
+        assert_eq!(prod_zp.inner, prod_zeroize.clone().into());
+
+        let prod_zeroize_zp = zp1 * &zeroize2;
+
+        assert_eq!(prod_zp.inner, prod_zeroize_zp.inner);
+
+        let g1 = G1::GENERATOR;
+        let g1_zeroize = g1.mul_scalar_zeroize(&zeroize1);
+        let g1_zp = g1.mul_scalar(zp1);
+
+        assert_eq!(g1_zp, g1_zeroize);
+
+        let g2 = G2::GENERATOR;
+        let g2_zeroize = g2.mul_scalar_zeroize(&zeroize1);
+        let g2_zp = g2.mul_scalar(zp1);
+
+        assert_eq!(g2_zp, g2_zeroize);
     }
 }

--- a/tfhe/Cargo.toml
+++ b/tfhe/Cargo.toml
@@ -75,7 +75,7 @@ sha3 = { version = "0.10", optional = true }
 itertools = { workspace = true }
 rand_core = { version = "0.6.4", features = ["std"] }
 strum = { version = "0.27", features = ["derive"], optional = true }
-tfhe-zk-pok = { version = "0.7.0", path = "../tfhe-zk-pok", optional = true }
+tfhe-zk-pok = { version = "0.7.1", path = "../tfhe-zk-pok", optional = true }
 tfhe-versionable = { version = "0.6.1", path = "../utils/tfhe-versionable" }
 
 # wasm deps


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description
add ZeroizeZp type that is automatically zeroized on drop by deriving ZeroizeOnDrop. The tradeoff is that this type is not Copy.
This can be used to remove "toxic waste" secret data after they are used. This is a need for the kms crs generation.
Zp already derives Zeroize but is also Copy. This means that the user must manually track and zeroize all copies, which is error prone.

ZeroizeOnDrop is not a silver bullet and is not a guarantee that memory won't be present in memory. In particular:
- "moves" create memory copies, so data must be passed by reference
- ZeroizeZp is still a wrapper of a type from arkworks, so upstream code might create copies
- the compiler is still free to create copies, for example through register spills. In the end ZeroizeZp is just a wrapper for a `[u64; 5]`.

### Test bench
I did some tests here: https://github.com/zama-ai/test_zeroize. The idea is to run the kms code and scan the stack to try to find traces of toxic values. `tau`, `powers of tau` and `r` are variables that should be zeroized. `tau_unreduced` is an intermediate value from tau generation that can be used to recover tau.

#### Debug mode
```
[000] 0x7ffc4eb370d0 (pad_stack_and_run)
[001] 0x7ffc4ea370b0 (pad_stack)
[002] 0x7ffc4ea37090 (run)
=====
scanning memory between 0x7ffc4ea370b0 and 0x7ffc4e9370b0 for 0xa0a7a660701aa434 (tau_unreduced)
magic found 0 times
=====
scanning memory between 0x7ffc4ea370b0 and 0x7ffc4e9370b0 for 0xcd7c17eb4cacfc2f (tau)
found value at 0x7ffc4ea359f8
found value at 0x7ffc4ea359d0
found value at 0x7ffc4ea35978
found value at 0x7ffc4ea35950
magic found 4 times
=====
scanning memory between 0x7ffc4ea370b0 and 0x7ffc4e9370b0 for 0xf1746b4f08981e (tau_power_2)
magic found 0 times
=====
scanning memory between 0x7ffc4ea370b0 and 0x7ffc4e9370b0 for 0xbdfc01e6906b13a6 (tau_power_1)
magic found 0 times
=====
scanning memory between 0x7ffc4ea370b0 and 0x7ffc4e9370b0 for 0x1a3e7868d156d48 (tau_power_0)
magic found 0 times
=====
scanning memory between 0x7ffc4ea370b0 and 0x7ffc4e9370b0 for 0xe4c9521cc8306815 (r)
magic found 0 times
```

#### Release mode
```
[000] 0x7fff8740b940 (pad_stack_and_run)
[001] 0x7fff8730b940 (pad_stack)
[002] 0x7fff8730b920 (run)
=====
scanning memory between 0x7fff8730b940 and 0x7fff8720b940 for 0xa0a7a660701aa434 (tau_unreduced)
magic found 0 times
=====
scanning memory between 0x7fff8730b940 and 0x7fff8720b940 for 0xcd7c17eb4cacfc2f (tau)
magic found 0 times
=====
scanning memory between 0x7fff8730b940 and 0x7fff8720b940 for 0xf1746b4f08981e (tau_power_2)
magic found 0 times
=====
scanning memory between 0x7fff8730b940 and 0x7fff8720b940 for 0xbdfc01e6906b13a6 (tau_power_1)
magic found 0 times
=====
scanning memory between 0x7fff8730b940 and 0x7fff8720b940 for 0x1a3e7868d156d48 (tau_power_0)
magic found 0 times
=====
scanning memory between 0x7fff8730b940 and 0x7fff8720b940 for 0xe4c9521cc8306815 (r)
magic found 0 times
```

#### Comments
in debug mode, `tau` is found 4 times in memory. Using a gdb watchpoint I found that these are all written by this line:
```rust
    let s_pok = h_pok * tau + r;
```
The copies are added by the multiplication generated from an arkworks macro in tfhe-rs (**tfhe-zk-pok/src/curve_446/mod.rs**):
```rust
#[derive(MontConfig)]
#[modulus = "645383785691237230677916041525710377746967055506026847120930304831624105190538527824412673"]
#[generator = "7"]
#[small_subgroup_base = "3"]
#[small_subgroup_power = "1"]
pub struct FrConfig;
```
These copies are removed by the compiler when building in release mode.

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/2665)
<!-- Reviewable:end -->
