### PR TITLE
chore(ci): add permission to github token to release crates

### DIFF
--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -87,7 +87,7 @@ jobs:
     # For provenance of npmjs publish
     permissions:
       contents: read
-      id-token: write
+      id-token: write # also needed for OIDC token exchange on crates.io
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/make_release_cuda.yml
+++ b/.github/workflows/make_release_cuda.yml
@@ -122,6 +122,9 @@ jobs:
     name: Publish CUDA Release
     needs: [setup-instance, package] # for comparing hashes
     runs-on: ${{ needs.setup-instance.outputs.runner-name }}
+    permissions:
+      # Needed for OIDC token exchange on crates.io
+      id-token: write
     strategy:
       fail-fast: false
       # explicit include-based build matrix, of known valid options

--- a/.github/workflows/make_release_hpu.yml
+++ b/.github/workflows/make_release_hpu.yml
@@ -66,6 +66,9 @@ jobs:
     name: Publish tfhe-hpu-backend Release
     runs-on: ubuntu-latest
     needs: [verify_tag, package] # for comparing hashes
+    permissions:
+      # Needed for OIDC token exchange on crates.io
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/make_release_tfhe_csprng.yml
+++ b/.github/workflows/make_release_tfhe_csprng.yml
@@ -67,6 +67,9 @@ jobs:
     name: Publish tfhe-csprng Release
     needs: [verify_tag, package]
     runs-on: ubuntu-latest
+    permissions:
+      # Needed for OIDC token exchange on crates.io
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/make_release_tfhe_fft.yml
+++ b/.github/workflows/make_release_tfhe_fft.yml
@@ -67,6 +67,9 @@ jobs:
     name: Publish tfhe-fft Release
     runs-on: ubuntu-latest
     needs: [verify_tag, package] # for comparing hashes
+    permissions:
+      # Needed for OIDC token exchange on crates.io
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/make_release_tfhe_ntt.yml
+++ b/.github/workflows/make_release_tfhe_ntt.yml
@@ -67,6 +67,9 @@ jobs:
     name: Publish tfhe-ntt Release
     runs-on: ubuntu-latest
     needs: [verify_tag, package] # for comparing hashes
+    permissions:
+      # Needed for OIDC token exchange on crates.io
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/make_release_tfhe_versionable.yml
+++ b/.github/workflows/make_release_tfhe_versionable.yml
@@ -60,6 +60,9 @@ jobs:
     name: Publish tfhe-versionable-derive Release
     needs: [ verify_tag, package-derive ] # for comparing hashes
     runs-on: ubuntu-latest
+    permissions:
+      # Needed for OIDC token exchange on crates.io
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/make_release_zk_pok.yml
+++ b/.github/workflows/make_release_zk_pok.yml
@@ -64,6 +64,9 @@ jobs:
     name: Publish tfhe-zk-pok Release
     needs: [verify_tag, package] # for comparing hashes
     runs-on: ubuntu-latest
+    permissions:
+      # Needed for OIDC token exchange on crates.io
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ itertools = "0.14"
 num-complex = "0.4"
 pulp = { version = "0.21", default-features = false }
 rand = "0.8"
-rayon = "1"
+rayon = "1.11"
 serde = { version = "1.0", default-features = false }
 wasm-bindgen = "0.2.100"
 

--- a/tfhe-csprng/src/generators/aes_ctr/parallel.rs
+++ b/tfhe-csprng/src/generators/aes_ctr/parallel.rs
@@ -43,7 +43,7 @@ impl<BlockCipher: AesBlockCipher> AesCtrGenerator<BlockCipher> {
         let first_index = self.state.table_index().incremented();
         let output = (0..n_children.0)
             .into_par_iter()
-            .zip(rayon::iter::repeatn(
+            .zip(rayon::iter::repeat_n(
                 (self.block_cipher.clone(), first_index, n_bytes),
                 n_children.0,
             ))

--- a/tfhe/src/core_crypto/commons/traits/contiguous_entity_container.rs
+++ b/tfhe/src/core_crypto/commons/traits/contiguous_entity_container.rs
@@ -257,7 +257,7 @@ pub trait ContiguousEntityContainer: AsRef<[Self::Element]> {
         let entity_view_pod_size = self.get_entity_view_pod_size();
         self.as_ref()
             .par_chunks_exact(entity_view_pod_size)
-            .zip(rayon::iter::repeatn(meta, entity_count))
+            .zip(rayon::iter::repeat_n(meta, entity_count))
             .map(|(elt, meta)| Self::EntityView::<'this>::create_from(elt, meta))
     }
 
@@ -278,7 +278,7 @@ pub trait ContiguousEntityContainer: AsRef<[Self::Element]> {
         let meta = self.get_self_view_creation_metadata();
         self.as_ref()
             .par_chunks(pod_chunk_size)
-            .zip(rayon::iter::repeatn(meta, entity_count))
+            .zip(rayon::iter::repeat_n(meta, entity_count))
             .map(|(elt, meta)| Self::SelfView::<'_>::create_from(elt, meta))
     }
 
@@ -304,7 +304,7 @@ pub trait ContiguousEntityContainer: AsRef<[Self::Element]> {
         let meta = self.get_self_view_creation_metadata();
         self.as_ref()
             .par_chunks_exact(pod_chunk_size)
-            .zip(rayon::iter::repeatn(meta, entity_count))
+            .zip(rayon::iter::repeat_n(meta, entity_count))
             .map(|(elt, meta)| Self::SelfView::<'_>::create_from(elt, meta))
     }
 }
@@ -471,7 +471,7 @@ pub trait ContiguousEntityContainerMut: ContiguousEntityContainer + AsMut<[Self:
         let entity_view_pod_size = self.get_entity_view_pod_size();
         self.as_mut()
             .par_chunks_exact_mut(entity_view_pod_size)
-            .zip(rayon::iter::repeatn(meta, entity_count))
+            .zip(rayon::iter::repeat_n(meta, entity_count))
             .map(|(elt, meta)| Self::EntityMutView::<'this>::create_from(elt, meta))
     }
 
@@ -492,7 +492,7 @@ pub trait ContiguousEntityContainerMut: ContiguousEntityContainer + AsMut<[Self:
         let meta = self.get_self_view_creation_metadata();
         self.as_mut()
             .par_chunks_mut(pod_chunk_size)
-            .zip(rayon::iter::repeatn(meta, entity_count))
+            .zip(rayon::iter::repeat_n(meta, entity_count))
             .map(|(elt, meta)| Self::SelfMutView::<'_>::create_from(elt, meta))
     }
 
@@ -518,7 +518,7 @@ pub trait ContiguousEntityContainerMut: ContiguousEntityContainer + AsMut<[Self:
         let meta = self.get_self_view_creation_metadata();
         self.as_mut()
             .par_chunks_exact_mut(pod_chunk_size)
-            .zip(rayon::iter::repeatn(meta, entity_count))
+            .zip(rayon::iter::repeat_n(meta, entity_count))
             .map(|(elt, meta)| Self::SelfMutView::<'_>::create_from(elt, meta))
     }
 }


### PR DESCRIPTION
When using crates.io trusted publishing feature GitHub token `id-token: write` permission to be able to authenticate the workflow on the registry.
