### PR TITLE
fix(gpu): fix memory leak in count consecutive bits

### DIFF
--- a/backends/tfhe-cuda-backend/cuda/include/integer/integer_utilities.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer/integer_utilities.h
@@ -5902,6 +5902,10 @@ template <typename Torus> struct int_count_of_consecutive_bits_buffer {
     delete sum_mem;
     sum_mem = nullptr;
 
+    propagate_mem->release(streams, gpu_indexes, gpu_count);
+    delete propagate_mem;
+    propagate_mem = nullptr;
+
     release_radix_ciphertext_async(streams[0], gpu_indexes[0], cts,
                                    allocate_gpu_memory);
     delete cts;


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description
it was missing the release of the carry propagation struct
### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
