### PR TITLE
chore(core): size checks in Fourier128GgswCiphertext::from_container

### DIFF
--- a/tfhe/src/core_crypto/fft_impl/fft128/crypto/ggsw.rs
+++ b/tfhe/src/core_crypto/fft_impl/fft128/crypto/ggsw.rs
@@ -113,6 +113,9 @@ impl<C: Container<Element = f64>> Fourier128GgswCiphertext<C> {
             decomposition_level_count,
         );
         assert_eq!(data_re0.container_len(), container_len);
+        assert_eq!(data_re1.container_len(), container_len);
+        assert_eq!(data_im0.container_len(), container_len);
+        assert_eq!(data_im1.container_len(), container_len);
 
         Self {
             data_re0,


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: https://github.com/zama-ai/tfhe-rs-internal/issues/1101

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/2697)
<!-- Reviewable:end -->
