### PR TITLE
chore(core): use checked_mul for container indexing

### DIFF
--- a/tfhe/src/core_crypto/commons/traits/contiguous_entity_container.rs
+++ b/tfhe/src/core_crypto/commons/traits/contiguous_entity_container.rs
@@ -141,7 +141,7 @@ pub trait ContiguousEntityContainer: AsRef<[Self::Element]> {
         // mid here is the number of ref_elements, we need to multiply by the size of a single
         // element to know where to split the underlying container
 
-        let mid = mid * self.get_entity_view_pod_size();
+        let mid = mid.checked_mul(self.get_entity_view_pod_size()).unwrap();
         let self_meta = self.get_self_view_creation_metadata();
 
         let (container_left, container_right) = self.as_ref().split_at(mid);
@@ -156,7 +156,7 @@ pub trait ContiguousEntityContainer: AsRef<[Self::Element]> {
         // index here is the number of ref_elements, we need to multiply by the size of a single
         // element to know where to reference the underlying container
 
-        let start = index * self.get_entity_view_pod_size();
+        let start = index.checked_mul(self.get_entity_view_pod_size()).unwrap();
         let stop = start + self.get_entity_view_pod_size();
         let meta = self.get_entity_view_creation_metadata();
 
@@ -178,8 +178,12 @@ pub trait ContiguousEntityContainer: AsRef<[Self::Element]> {
             Bound::Unbounded => self.entity_count(),
         };
 
-        let start_index = entity_start_index * self.get_entity_view_pod_size();
-        let stop_index = entity_stop_index * self.get_entity_view_pod_size();
+        let start_index = entity_start_index
+            .checked_mul(self.get_entity_view_pod_size())
+            .unwrap();
+        let stop_index = entity_stop_index
+            .checked_mul(self.get_entity_view_pod_size())
+            .unwrap();
 
         let self_meta = self.get_self_view_creation_metadata();
 
@@ -214,7 +218,7 @@ pub trait ContiguousEntityContainer: AsRef<[Self::Element]> {
         let entity_count = self.entity_count();
 
         let entity_view_pod_size = self.get_entity_view_pod_size();
-        let pod_chunk_size = entity_view_pod_size * chunk_size;
+        let pod_chunk_size = entity_view_pod_size.checked_mul(chunk_size).unwrap();
 
         let meta = self.get_self_view_creation_metadata();
         self.as_ref()
@@ -235,7 +239,7 @@ pub trait ContiguousEntityContainer: AsRef<[Self::Element]> {
         );
 
         let entity_view_pod_size = self.get_entity_view_pod_size();
-        let pod_chunk_size = entity_view_pod_size * chunk_size;
+        let pod_chunk_size = entity_view_pod_size.checked_mul(chunk_size).unwrap();
 
         let meta = self.get_self_view_creation_metadata();
         self.as_ref()
@@ -273,7 +277,7 @@ pub trait ContiguousEntityContainer: AsRef<[Self::Element]> {
         let entity_count = self.entity_count();
 
         let entity_view_pod_size = self.get_entity_view_pod_size();
-        let pod_chunk_size = entity_view_pod_size * chunk_size;
+        let pod_chunk_size = entity_view_pod_size.checked_mul(chunk_size).unwrap();
 
         let meta = self.get_self_view_creation_metadata();
         self.as_ref()
@@ -299,7 +303,7 @@ pub trait ContiguousEntityContainer: AsRef<[Self::Element]> {
         );
 
         let entity_view_pod_size = self.get_entity_view_pod_size();
-        let pod_chunk_size = entity_view_pod_size * chunk_size;
+        let pod_chunk_size = entity_view_pod_size.checked_mul(chunk_size).unwrap();
 
         let meta = self.get_self_view_creation_metadata();
         self.as_ref()
@@ -386,8 +390,12 @@ pub trait ContiguousEntityContainerMut: ContiguousEntityContainer + AsMut<[Self:
             Bound::Unbounded => self.entity_count(),
         };
 
-        let start_index = entity_start_index * self.get_entity_view_pod_size();
-        let stop_index = entity_stop_index * self.get_entity_view_pod_size();
+        let start_index = entity_start_index
+            .checked_mul(self.get_entity_view_pod_size())
+            .unwrap();
+        let stop_index = entity_stop_index
+            .checked_mul(self.get_entity_view_pod_size())
+            .unwrap();
 
         let self_meta = self.get_self_view_creation_metadata();
 
@@ -412,7 +420,7 @@ pub trait ContiguousEntityContainerMut: ContiguousEntityContainer + AsMut<[Self:
         let entity_count = self.entity_count();
 
         let entity_view_pod_size = self.get_entity_view_pod_size();
-        let pod_chunk_size = entity_view_pod_size * chunk_size;
+        let pod_chunk_size = entity_view_pod_size.checked_mul(chunk_size).unwrap();
 
         let meta = self.get_self_view_creation_metadata();
         self.as_mut()
@@ -434,7 +442,7 @@ pub trait ContiguousEntityContainerMut: ContiguousEntityContainer + AsMut<[Self:
         );
 
         let entity_view_pod_size = self.get_entity_view_pod_size();
-        let pod_chunk_size = entity_view_pod_size * chunk_size;
+        let pod_chunk_size = entity_view_pod_size.checked_mul(chunk_size).unwrap();
 
         let meta = self.get_self_view_creation_metadata();
         self.as_mut()
@@ -487,7 +495,7 @@ pub trait ContiguousEntityContainerMut: ContiguousEntityContainer + AsMut<[Self:
         let entity_count = self.entity_count();
 
         let entity_view_pod_size = self.get_entity_view_pod_size();
-        let pod_chunk_size = entity_view_pod_size * chunk_size;
+        let pod_chunk_size = entity_view_pod_size.checked_mul(chunk_size).unwrap();
 
         let meta = self.get_self_view_creation_metadata();
         self.as_mut()
@@ -513,7 +521,7 @@ pub trait ContiguousEntityContainerMut: ContiguousEntityContainer + AsMut<[Self:
         );
 
         let entity_view_pod_size = self.get_entity_view_pod_size();
-        let pod_chunk_size = entity_view_pod_size * chunk_size;
+        let pod_chunk_size = entity_view_pod_size.checked_mul(chunk_size).unwrap();
 
         let meta = self.get_self_view_creation_metadata();
         self.as_mut()


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: https://github.com/zama-ai/tfhe-rs-internal/issues/1106

### PR content/description
Used unwrap everywhere to trigger a panic if the offset overflows

