### PR TITLE
chore(safe_ser): check serialization header version

### DIFF
--- a/tfhe/src/safe_serialization.rs
+++ b/tfhe/src/safe_serialization.rs
@@ -99,6 +99,13 @@ impl SerializationHeader {
 
     /// Checks the validity of the header
     fn validate<T: Named>(&self) -> Result<(), String> {
+        if self.header_version != SERIALIZATION_VERSION {
+            return Err(format!(
+                "On deserialization, expected serialization header version {SERIALIZATION_VERSION}, \
+got version {}", self.header_version
+            ));
+        }
+
         match &self.versioning_mode {
             SerializationVersioningMode::Versioned { versioning_version } => {
                 // For the moment there is only one versioning scheme, so another value is


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: https://github.com/zama-ai/tfhe-rs-internal/issues/1107

### PR content/description
Serialization version header was mostly used before the versioning, and there is as of today only one supported version, but it is still a good idea to verify it as a first sanity check.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/2702)
<!-- Reviewable:end -->
