### PR TITLE
fix: remove duplicate word in setup_hpu.sh comment

### DIFF
--- a/setup_hpu.sh
+++ b/setup_hpu.sh
@@ -5,7 +5,7 @@ CUR_SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
 HPU_BACKEND_DIR=$CUR_SCRIPT_DIR/backends/tfhe-hpu-backend
 HPU_MOCKUP_DIR=$CUR_SCRIPT_DIR/mockups/tfhe-hpu-mockup
 
-# Default default bitstream
+# Default bitstream
 # Available options are:
 #  * sim: use with the mockup (i.e simulation)
 #  * u55c: use with u55c (latest bitstream with gf64 config)


### PR DESCRIPTION


### PR content/description
Remove redundant "default" word from comment "# Default default bitstream" to improve code readability and fix obvious typo.

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
