### PR TITLE
doc(core): remove warning about glwe polynomial size of 1

### DIFF
--- a/tfhe/src/core_crypto/entities/glwe_ciphertext.rs
+++ b/tfhe/src/core_crypto/entities/glwe_ciphertext.rs
@@ -255,9 +255,6 @@ pub fn glwe_ciphertext_encryption_noise_sample_count(
 
 /// A [`GLWE ciphertext`](`GlweCiphertext`).
 ///
-/// **Remark:** GLWE ciphertexts generalize LWE ciphertexts by definition, however in this library,
-/// GLWE ciphertext entities do not generalize LWE ciphertexts, i.e., polynomial size cannot be 1.
-///
 /// # Formal Definition
 ///
 /// ## GLWE Ciphertext


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: https://github.com/zama-ai/tfhe-rs-internal/issues/1105

 Looks like a GLWE with a PolynomialSize(1) is fine here so the warning is actually not needed