### PR TITLE
fix(gpu):  change mininum number of elements in benches

### DIFF
--- a/backends/tfhe-cuda-backend/cuda/include/device.h
+++ b/backends/tfhe-cuda-backend/cuda/include/device.h
@@ -119,6 +119,8 @@ void cuda_memset_async(void *dest, uint64_t val, uint64_t size,
 
 int cuda_get_number_of_gpus();
 
+int cuda_get_number_of_sms();
+
 void cuda_synchronize_device(uint32_t gpu_index);
 
 void cuda_drop(void *ptr, uint32_t gpu_index);

--- a/backends/tfhe-cuda-backend/cuda/src/device.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/device.cu
@@ -329,6 +329,13 @@ int cuda_get_number_of_gpus() {
   return num_gpus;
 }
 
+int cuda_get_number_of_sms() {
+  int num_sms = 0;
+  check_cuda_error(
+      cudaDeviceGetAttribute(&num_sms, cudaDevAttrMultiProcessorCount, 0));
+  return num_sms;
+}
+
 /// Drop a cuda array
 void cuda_drop(void *ptr, uint32_t gpu_index) {
   cuda_set_device(gpu_index);

--- a/backends/tfhe-cuda-backend/src/cuda_bind.rs
+++ b/backends/tfhe-cuda-backend/src/cuda_bind.rs
@@ -88,6 +88,8 @@ extern "C" {
 
     pub fn cuda_get_number_of_gpus() -> i32;
 
+    pub fn cuda_get_number_of_sms() -> i32;
+
     pub fn cuda_synchronize_device(gpu_index: u32);
 
     pub fn cuda_drop(ptr: *mut c_void, gpu_index: u32);

--- a/tfhe-benchmark/src/utilities.rs
+++ b/tfhe-benchmark/src/utilities.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use std::sync::OnceLock;
 use std::{env, fs};
 #[cfg(feature = "gpu")]
-use tfhe::core_crypto::gpu::get_number_of_gpus;
+use tfhe::core_crypto::gpu::{get_number_of_gpus, get_number_of_sms};
 use tfhe::core_crypto::prelude::*;
 
 #[cfg(feature = "boolean")]
@@ -417,10 +417,6 @@ pub fn get_bench_type() -> &'static BenchmarkType {
     BENCH_TYPE.get_or_init(|| BenchmarkType::from_env().unwrap())
 }
 
-/// Number of streaming multiprocessors (SM) available on Nvidia H100 GPU
-#[cfg(feature = "gpu")]
-const H100_PCIE_SM_COUNT: u32 = 114;
-
 /// Generate a number of threads to use to saturate current machine for throughput measurements.
 pub fn throughput_num_threads(num_block: usize, op_pbs_count: u64) -> u64 {
     let ref_block_count = 32; // Represent a ciphertext of 64 bits for 2_2 parameters set
@@ -431,11 +427,19 @@ pub fn throughput_num_threads(num_block: usize, op_pbs_count: u64) -> u64 {
 
     #[cfg(feature = "gpu")]
     {
-        let total_num_sm = H100_PCIE_SM_COUNT * get_number_of_gpus();
+        let num_sms_per_gpu = get_number_of_sms();
+        let total_num_sm = num_sms_per_gpu * get_number_of_gpus();
+
+        let total_blocks_per_sm = 4u32; // Assume each SM can handle 4 blocks concurrently
+        let total_num_sm = total_blocks_per_sm * total_num_sm;
+        let min_num_waves = 4u64; //Enforce at least 4 waves in the GPU
+        let elements_per_wave = total_num_sm as u64 / (num_block as u64);
+
         let operation_loading = ((total_num_sm as u64 / op_pbs_count) as f64).max(minimum_loading);
         let elements = (total_num_sm as f64 * block_multiplicator * operation_loading) as u64;
-        elements.min(200) // This threshold is useful for operation with both a small number of
-                          // block and low PBs count.
+        elements.min(elements_per_wave * min_num_waves) // This threshold is useful for operation
+                                                        // with both a small number of
+                                                        // block and low PBs count.
     }
     #[cfg(feature = "hpu")]
     {

--- a/tfhe/src/core_crypto/gpu/mod.rs
+++ b/tfhe/src/core_crypto/gpu/mod.rs
@@ -1212,6 +1212,11 @@ pub fn get_number_of_gpus() -> u32 {
     unsafe { cuda_get_number_of_gpus() as u32 }
 }
 
+/// Get the number of sms on the GPU
+pub fn get_number_of_sms() -> u32 {
+    unsafe { cuda_get_number_of_sms() as u32 }
+}
+
 /// Setup multi-GPU and return the number of GPUs used
 pub fn setup_multi_gpu(device_0_id: GpuIndex) -> u32 {
     unsafe { cuda_setup_multi_gpu(device_0_id.get()) as u32 }


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description
The idea is to have a mininum workload based only in the number of radix blocks and specs on gpu.
The number of sms is now read from the gpu instead of using a hardcoded value
### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
