### PR TITLE
fix(zk): handle limit cases in the four_squares algorithm

### DIFF
--- a/tfhe-zk-pok/src/proofs/mod.rs
+++ b/tfhe-zk-pok/src/proofs/mod.rs
@@ -144,7 +144,7 @@ impl<G: Curve> GroupElements<G> {
 
 /// Allows to compute proof with bad inputs for tests
 #[derive(Copy, Clone, PartialEq, Eq)]
-enum ProofSanityCheckMode {
+pub(crate) enum ProofSanityCheckMode {
     Panic,
     #[cfg(test)]
     Ignore,

--- a/tfhe-zk-pok/src/proofs/pke_v2/mod.rs
+++ b/tfhe-zk-pok/src/proofs/pke_v2/mod.rs
@@ -928,7 +928,7 @@ fn prove_impl<G: Curve>(
         )
         .collect::<Box<[_]>>();
 
-    let v = four_squares(B_squared - e_sqr_norm).map(|v| v as i64);
+    let v = four_squares(B_squared - e_sqr_norm, sanity_check_mode).map(|v| v as i64);
 
     let e1_zp = &*e1
         .iter()


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description
Fix issue with limit cases in the four_square algorithm. Before this pr, the algorithm would panic/overflow if `v = 2*4^n` (for any n) and run into an infinite loop if `v = k*4^n with k in [6, 10, 14, 22, 34, 38, 110]`.

Added a test to check these limit values



[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
