### PR TITLE
feat(gpu): enable lut generation with preallocated buffers

### DIFF
--- a/backends/tfhe-cuda-backend/cuda/src/integer/comparison.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/comparison.cuh
@@ -130,12 +130,13 @@ __host__ void are_all_comparisons_block_true(
         auto is_equal_to_num_blocks_lut_f = [chunk_length](Torus x) -> Torus {
           return x == chunk_length;
         };
-        generate_device_accumulator<Torus>(
+        generate_device_accumulator_with_cpu_prealloc<Torus>(
             streams[0], gpu_indexes[0], is_max_value_lut->get_lut(0, 1),
             is_max_value_lut->get_degree(1),
             is_max_value_lut->get_max_degree(1), glwe_dimension,
             polynomial_size, message_modulus, carry_modulus,
-            is_equal_to_num_blocks_lut_f, true);
+            is_equal_to_num_blocks_lut_f, true,
+            are_all_block_true_buffer->preallocated_h_lut);
 
         Torus *h_lut_indexes = is_max_value_lut->h_lut_indexes;
         for (int index = 0; index < num_chunks; index++) {
@@ -499,10 +500,11 @@ __host__ void tree_sign_reduction(
     y = x;
     f = sign_handler_f;
   }
-  generate_device_accumulator<Torus>(
+  generate_device_accumulator_with_cpu_prealloc<Torus>(
       streams[0], gpu_indexes[0], last_lut->get_lut(0, 0),
       last_lut->get_degree(0), last_lut->get_max_degree(0), glwe_dimension,
-      polynomial_size, message_modulus, carry_modulus, f, true);
+      polynomial_size, message_modulus, carry_modulus, f, true,
+      tree_buffer->preallocated_h_lut);
 
   auto active_gpu_count = get_active_gpu_count(1, gpu_count);
   last_lut->broadcast_lut(streams, gpu_indexes, active_gpu_count);

--- a/backends/tfhe-cuda-backend/cuda/src/integer/scalar_comparison.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/scalar_comparison.cuh
@@ -150,10 +150,11 @@ __host__ void integer_radix_unsigned_scalar_difference_check_kb(
     };
 
     auto lut = mem_ptr->diff_buffer->tree_buffer->tree_last_leaf_scalar_lut;
-    generate_device_accumulator<Torus>(
+    generate_device_accumulator_with_cpu_prealloc<Torus>(
         streams[0], gpu_indexes[0], lut->get_lut(0, 0), lut->get_degree(0),
         lut->get_max_degree(0), glwe_dimension, polynomial_size,
-        message_modulus, carry_modulus, scalar_last_leaf_lut_f, true);
+        message_modulus, carry_modulus, scalar_last_leaf_lut_f, true,
+        mem_ptr->diff_buffer->tree_buffer->preallocated_h_lut);
     auto active_gpu_count = get_active_gpu_count(1, gpu_count);
     lut->broadcast_lut(streams, gpu_indexes, active_gpu_count);
 
@@ -250,10 +251,11 @@ __host__ void integer_radix_unsigned_scalar_difference_check_kb(
     };
 
     auto lut = diff_buffer->tree_buffer->tree_last_leaf_scalar_lut;
-    generate_device_accumulator_bivariate<Torus>(
+    generate_device_accumulator_bivariate_with_cpu_prealloc<Torus>(
         streams[0], gpu_indexes[0], lut->get_lut(0, 0), lut->get_degree(0),
         lut->get_max_degree(0), glwe_dimension, polynomial_size,
-        message_modulus, carry_modulus, scalar_bivariate_last_leaf_lut_f, true);
+        message_modulus, carry_modulus, scalar_bivariate_last_leaf_lut_f, true,
+        mem_ptr->diff_buffer->tree_buffer->preallocated_h_lut);
     auto active_gpu_count = get_active_gpu_count(1, gpu_count);
     lut->broadcast_lut(streams, gpu_indexes, active_gpu_count);
 
@@ -283,11 +285,12 @@ __host__ void integer_radix_unsigned_scalar_difference_check_kb(
       int_radix_lut<Torus> *one_block_lut = new int_radix_lut<Torus>(
           streams, gpu_indexes, gpu_count, params, 1, 1, true, size);
 
-      generate_device_accumulator<Torus>(
+      generate_device_accumulator_with_cpu_prealloc<Torus>(
           streams[0], gpu_indexes[0], one_block_lut->get_lut(0, 0),
           one_block_lut->get_degree(0), one_block_lut->get_max_degree(0),
           params.glwe_dimension, params.polynomial_size, params.message_modulus,
-          params.carry_modulus, one_block_lut_f, true);
+          params.carry_modulus, one_block_lut_f, true,
+          mem_ptr->preallocated_h_lut);
       auto active_gpu_count = get_active_gpu_count(1, gpu_count);
       one_block_lut->broadcast_lut(streams, gpu_indexes, active_gpu_count);
 
@@ -432,10 +435,11 @@ __host__ void integer_radix_signed_scalar_difference_check_kb(
     };
 
     auto lut = mem_ptr->diff_buffer->tree_buffer->tree_last_leaf_scalar_lut;
-    generate_device_accumulator_bivariate<Torus>(
+    generate_device_accumulator_bivariate_with_cpu_prealloc<Torus>(
         streams[0], gpu_indexes[0], lut->get_lut(0, 0), lut->get_degree(0),
         lut->get_max_degree(0), glwe_dimension, polynomial_size,
-        message_modulus, carry_modulus, scalar_bivariate_last_leaf_lut_f, true);
+        message_modulus, carry_modulus, scalar_bivariate_last_leaf_lut_f, true,
+        mem_ptr->diff_buffer->tree_buffer->preallocated_h_lut);
     auto active_gpu_count = get_active_gpu_count(1, gpu_count);
     lut->broadcast_lut(streams, gpu_indexes, active_gpu_count);
 
@@ -538,11 +542,11 @@ __host__ void integer_radix_signed_scalar_difference_check_kb(
     };
 
     auto signed_msb_lut = mem_ptr->signed_msb_lut;
-    generate_device_accumulator_bivariate<Torus>(
+    generate_device_accumulator_bivariate_with_cpu_prealloc<Torus>(
         msb_streams[0], gpu_indexes[0], signed_msb_lut->get_lut(0, 0),
         signed_msb_lut->get_degree(0), signed_msb_lut->get_max_degree(0),
         params.glwe_dimension, params.polynomial_size, params.message_modulus,
-        params.carry_modulus, lut_f, true);
+        params.carry_modulus, lut_f, true, mem_ptr->preallocated_h_lut);
     auto active_gpu_count = get_active_gpu_count(1, gpu_count);
     signed_msb_lut->broadcast_lut(streams, gpu_indexes, active_gpu_count);
 
@@ -587,11 +591,12 @@ __host__ void integer_radix_signed_scalar_difference_check_kb(
       int_radix_lut<Torus> *one_block_lut = new int_radix_lut<Torus>(
           streams, gpu_indexes, gpu_count, params, 1, 1, true, size);
 
-      generate_device_accumulator<Torus>(
+      generate_device_accumulator_with_cpu_prealloc<Torus>(
           streams[0], gpu_indexes[0], one_block_lut->get_lut(0, 0),
           one_block_lut->get_degree(0), one_block_lut->get_max_degree(0),
           params.glwe_dimension, params.polynomial_size, params.message_modulus,
-          params.carry_modulus, one_block_lut_f, true);
+          params.carry_modulus, one_block_lut_f, true,
+          mem_ptr->preallocated_h_lut);
       auto active_gpu_count = get_active_gpu_count(1, gpu_count);
       one_block_lut->broadcast_lut(streams, gpu_indexes, active_gpu_count);
 


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description
The idea is to avoid synchronizaton in the comparison algo that uses streams.
host memory is preallocated in the mem structure and then used when generating the lut inside the integer operation.
### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
