### PR TITLE
chore(bench): remove 2-bits size for full precision bench on gpu

### DIFF
--- a/tfhe-benchmark/src/utilities.rs
+++ b/tfhe-benchmark/src/utilities.rs
@@ -348,7 +348,10 @@ pub fn write_to_json<
 }
 
 const FAST_BENCH_BIT_SIZES: [usize; 1] = [64];
+#[cfg(not(feature = "gpu"))]
 const BENCH_BIT_SIZES: [usize; 8] = [2, 8, 16, 32, 40, 64, 128, 256];
+#[cfg(feature = "gpu")]
+const BENCH_BIT_SIZES: [usize; 7] = [8, 16, 32, 40, 64, 128, 256];
 const HPU_BENCH_BIT_SIZES: [usize; 5] = [8, 16, 32, 64, 128];
 const MULTI_BIT_CPU_SIZES: [usize; 5] = [8, 16, 32, 40, 64];
 


### PR DESCRIPTION
GPU backend cannot accept less than 2 blocks for integer benchmarks. Since 2-bits precision benchmarks are run with *_MESSAGE_2_CARRY_2_* parameters, it will create only one block of ciphertext, thus making the benchmarks unsuitable for GPU backend.
