### PR TITLE
chore(gpu): multi-gpu debug target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,3 +54,10 @@ debug-assertions = false
 
 [workspace.metadata.dylint]
 libraries = [{ path = "utils/tfhe-lints" }]
+
+[profile.debug_lto_off]
+inherits = "dev"
+debug = true
+lto = "off"
+debug-assertions = false
+overflow-checks = false

--- a/Makefile
+++ b/Makefile
@@ -745,6 +745,16 @@ test_integer_short_run_gpu: install_rs_check_toolchain install_cargo_nextest
 	RUSTFLAGS="$(RUSTFLAGS)" cargo $(CARGO_RS_BUILD_TOOLCHAIN) test --profile $(CARGO_PROFILE) \
 		--features=integer,gpu -p tfhe -- integer::gpu::server_key::radix::tests_long_run::test_random_op_sequence integer::gpu::server_key::radix::tests_long_run::test_signed_random_op_sequence --test-threads=1 --nocapture
 
+.PHONY: build_debug_integer_short_run_gpu # Run the long run integer tests on the gpu backend
+build_debug_integer_short_run_gpu: install_rs_check_toolchain install_cargo_nextest
+	RUSTFLAGS="$(RUSTFLAGS)" cargo $(CARGO_RS_BUILD_TOOLCHAIN) test -vv --no-run --profile debug_lto_off \
+		--features=integer,gpu-debug-fake-multi-gpu -p tfhe
+	RUSTFLAGS="$(RUSTFLAGS)" cargo $(CARGO_RS_BUILD_TOOLCHAIN) test --profile debug_lto_off \
+		--features=integer,gpu-debug-fake-multi-gpu -p tfhe -- integer::gpu::server_key::radix::tests_long_run::test_random_op_sequence::test_gpu_short_random --list
+	@echo "To debug fake-multi-gpu short run tests run:"
+	@echo "TFHE_RS_TEST_LONG_TESTS_MINIMAL=TRUE <executable> integer::gpu::server_key::radix::tests_long_run::test_random_op_sequence::test_gpu_short_random_op_sequence_param_gpu_multi_bit_group_4_message_2_carry_2_ks_pbs_tuniform_2m128 --nocapture"
+	@echo "Where <executable> = the one printed in the () in the 'Running unittests src/lib.rs ()' line above"
+
 .PHONY: test_integer_compression
 test_integer_compression: install_rs_build_toolchain
 	RUSTFLAGS="$(RUSTFLAGS)" cargo $(CARGO_RS_BUILD_TOOLCHAIN) test --profile $(CARGO_PROFILE) \
@@ -1008,6 +1018,11 @@ test_list_gpu: install_rs_build_toolchain install_cargo_nextest
 build_one_hl_api_test_gpu: install_rs_build_toolchain
 	RUSTFLAGS="$(RUSTFLAGS)" cargo $(CARGO_RS_BUILD_TOOLCHAIN) test --no-run \
 		   --features=integer,gpu-debug -vv -p tfhe -- "$${TEST}" --test-threads=1 --nocapture
+
+.PHONY: build_one_hl_api_test_fake_multi_gpu
+build_one_hl_api_test_fake_multi_gpu: install_rs_build_toolchain
+	RUSTFLAGS="$(RUSTFLAGS)" cargo $(CARGO_RS_BUILD_TOOLCHAIN) test --no-run \
+		   --features=integer,gpu-debug-fake-multi-gpu -vv -p tfhe -- "$${TEST}" --test-threads=1 --nocapture
 
 test_high_level_api_hpu: install_rs_build_toolchain install_cargo_nextest
 ifeq ($(HPU_CONFIG), v80)

--- a/backends/tfhe-cuda-backend/Cargo.toml
+++ b/backends/tfhe-cuda-backend/Cargo.toml
@@ -20,3 +20,4 @@ bindgen = "0.71"
 experimental-multi-arch = []
 profile = []
 debug = []
+debug-fake-multi-gpu = []

--- a/backends/tfhe-cuda-backend/build.rs
+++ b/backends/tfhe-cuda-backend/build.rs
@@ -54,6 +54,10 @@ fn main() {
 
         if cfg!(feature = "debug") {
             cmake_config.define("CMAKE_BUILD_TYPE", "Debug");
+        } else if cfg!(feature = "debug-fake-multi-gpu") {
+            cmake_config.define("CMAKE_BUILD_TYPE", "DebugOnlyCpu");
+            cmake_config.define("CMAKE_VERBOSE_MAKEFILE", "ON");
+            cmake_config.define("FAKE_MULTI_GPU", "ON");
         }
 
         // Build the CMake project

--- a/backends/tfhe-cuda-backend/cuda/CMakeLists.txt
+++ b/backends/tfhe-cuda-backend/cuda/CMakeLists.txt
@@ -87,6 +87,9 @@ if(CMAKE_BUILD_TYPE_LOWERCASE STREQUAL "debug")
   add_definitions(-DDEBUG)
   set(OPTIMIZATION_FLAGS "${OPTIMIZATION_FLAGS} -O0 -G -g")
   set(USE_NVTOOLS 1)
+elseif(CMAKE_BUILD_TYPE_LOWERCASE STREQUAL "debugonlycpu")
+  message("Compiling GPU kernels in Release and CPU code in Debug")
+  set(OPTIMIZATION_FLAGS "${OPTIMIZATION_FLAGS} -O0 -g")
 else()
   # Release mode
   message("Compiling in Release mode")
@@ -97,6 +100,11 @@ endif()
 if(${USE_NVTOOLS})
   message(STATUS "USE_NVTOOLS is enabled")
   add_definitions(-DUSE_NVTOOLS)
+endif()
+
+if(${FAKE_MULTI_GPU})
+  message(STATUS "Fake multi-gpu debugging is enabled")
+  add_definitions(-DDEBUG_FAKE_MULTI_GPU)
 endif()
 
 # in production, should use -arch=sm_70 --ptxas-options=-v to see register spills -lineinfo for better debugging to use

--- a/tfhe/Cargo.toml
+++ b/tfhe/Cargo.toml
@@ -106,6 +106,7 @@ gpu-experimental-multi-arch = [
 ]
 gpu-profile = ["gpu", "tfhe-cuda-backend/profile"]
 gpu-debug = ["gpu", "tfhe-cuda-backend/debug"]
+gpu-debug-fake-multi-gpu = ["gpu", "tfhe-cuda-backend/debug-fake-multi-gpu"]
 zk-pok = ["dep:tfhe-zk-pok"]
 # Start Fpga Hpu features
 hpu = ["dep:tfhe-hpu-backend", "shortint", "integer"]

--- a/tfhe/src/high_level_api/keys/server.rs
+++ b/tfhe/src/high_level_api/keys/server.rs
@@ -407,7 +407,7 @@ impl CompressedServerKey {
                 noise_squashing_compression_key.decompress_to_cuda(&streams)
             });
 
-        synchronize_devices(streams.len() as u32);
+        synchronize_devices(&streams);
         CudaServerKey {
             key: Arc::new(IntegerCudaServerKey {
                 key,

--- a/tfhe/src/integer/gpu/server_key/radix/tests_long_run/mod.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/tests_long_run/mod.rs
@@ -25,9 +25,23 @@ fn seeded_shuffle(v: &mut [u32], datagen: &mut DeterministicSeeder<DefaultRandom
 fn make_random_gpu_set(datagen: &mut DeterministicSeeder<DefaultRandomGenerator>) -> CudaGpuChoice {
     // Sample a random subset of 1-N gpus, where N is the number of available GPUs
     // A GPU index should not appear twice in the subset
+    #[cfg(not(feature = "gpu-debug-fake-multi-gpu"))]
     let num_gpus = get_number_of_gpus();
-    //let mut rng = rand::thread_rng();
-    let num_gpus_to_use = (1 + datagen.seed().0 as u32 % (num_gpus - 1)) as usize;
+
+    #[cfg(feature = "gpu-debug-fake-multi-gpu")]
+    let num_gpus_to_use = 2;
+
+    #[cfg(not(feature = "gpu-debug-fake-multi-gpu"))]
+    let num_gpus_to_use = if num_gpus > 1 {
+        (1 + datagen.seed().0 as u32 % (num_gpus - 1)) as usize
+    } else {
+        1usize
+    };
+
+    #[cfg(feature = "gpu-debug-fake-multi-gpu")]
+    let mut all_gpu_indexes: Vec<u32> = vec![0; num_gpus_to_use];
+
+    #[cfg(not(feature = "gpu-debug-fake-multi-gpu"))]
     let mut all_gpu_indexes: Vec<u32> = (0..num_gpus).collect();
     seeded_shuffle(&mut all_gpu_indexes, datagen);
 


### PR DESCRIPTION
This PR adds a fake multi-gpu target that is only used for debugging and has no impact on normal compilation.

- Add a fake-multi gpu compilation config to enable multi-gpu debugging on single gpu machine. 
   - compiles Rust code in Debug without overflow panics
   - compiles C++ code in Debug
   - compiles GPU kernels in Release to avoid very slow computation preventing debugging
- New short run GPU tests that can be run on a single GPU laptop.
- Small refactoring of long run tests
- Makefile target to build a specific HL test and the new Short run tests in fake-multi-gpu to allow easy debugging in an IDE