### PR TITLE
chore(ci): run cargo audit

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,12 @@
+[advisories]
+ignore = [
+    # Ignoring unmaintained 'paste' advisory as it is a widely used, low-risk build dependency.
+    "RUSTSEC-2024-0436",
+]
+
+[output]
+# Deny advisories that are warnings by default.
+# At the moment this works if we allow paste, we might want to disable this in the future if it
+# becomes too tedious
+deny = ["warnings"]
+quiet = false

--- a/.github/workflows/cargo_audit.yml
+++ b/.github/workflows/cargo_audit.yml
@@ -1,0 +1,40 @@
+# Run cargo audit
+on:
+  workflow_dispatch:
+  schedule:
+    # runs every day at 4am UTC
+    - cron: '0 4 * * *'
+
+env:
+  CARGO_TERM_COLOR: always
+  ACTION_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+  CHECKOUT_TOKEN: ${{ secrets.REPO_CHECKOUT_TOKEN || secrets.GITHUB_TOKEN }}
+  SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
+  SLACK_ICON: https://pbs.twimg.com/profile_images/1274014582265298945/OjBKP9kn_400x400.png
+  SLACK_USERNAME: ${{ secrets.BOT_USERNAME }}
+  SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+  SLACKIFY_MARKDOWN: true
+
+permissions: {}
+
+jobs:
+  audit:
+    name: cargo_audit/audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          persist-credentials: 'false'
+          token: ${{ env.CHECKOUT_TOKEN }}
+
+      - name: Audit dependencies
+        run: |
+          make audit_dependencies
+
+      - name: Slack Notification
+        if: ${{ failure() }}
+        continue-on-error: true
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661
+        env:
+          SLACK_COLOR: ${{ job.status }}
+          SLACK_MESSAGE: "cargo-audit finished with status: ${{ job.status }}. ([action run](${{ env.ACTION_RUN_URL }}))"

--- a/Makefile
+++ b/Makefile
@@ -160,8 +160,12 @@ install_tarpaulin: install_rs_build_toolchain
 	( echo "Unable to install cargo tarpaulin, unknown error." && exit 1 )
 
 .PHONY: install_cargo_dylint # Install custom tfhe-rs lints
-install_cargo_dylint:
+install_cargo_dylint: install_rs_build_toolchain
 	cargo install --locked cargo-dylint dylint-link
+
+.PHONY: install_cargo_audit # Check dependencies
+install_cargo_audit: install_rs_build_toolchain
+	cargo install --locked cargo-audit
 
 .PHONY: install_typos_checker # Install typos checker
 install_typos_checker: install_rs_build_toolchain
@@ -544,6 +548,10 @@ tfhe_lints: install_cargo_dylint
 		--features=boolean,shortint,integer,strings,zk-pok
 	RUSTFLAGS="$(RUSTFLAGS)" cargo dylint --all -p tfhe-zk-pok --no-deps -- \
 		--features=experimental
+
+.PHONY: audit_dependencies # Run cargo audit to check vulnerable dependencies
+audit_dependencies: install_rs_build_toolchain install_cargo_audit
+	cargo audit
 
 
 .PHONY: build_core # Build core_crypto without experimental features


### PR DESCRIPTION
closes: https://github.com/zama-ai/tfhe-rs-internal/issues/1132

### PR content/description
Not sure if this is really needed with dependabot, but it is fast and we can run it locally if we want.

I ignored the warning about paste being unmaintained because:
- paste is not considered broken but "finished" by its author
- alternatives are from lesser known authors, switch to an alternative would be more risky security wise
- it would be complicated to remove it, and it is also used by some of our dependencies anyway

I could also have left the warnings about unmaintained as "non deny" but this way at least we have to be explicit about if we accept the risk or not on a case by case basis. This can be changed later if it becomes too tedious.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/2771)
<!-- Reviewable:end -->
