### PR TITLE
fix(ci): fix serde root crate in tfhe-lints

### DIFF
--- a/utils/tfhe-lints/Cargo.toml
+++ b/utils/tfhe-lints/Cargo.toml
@@ -10,12 +10,12 @@ crate-type = ["cdylib"]
 
 [dependencies]
 clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "334fb906aef13d20050987b13448f37391bb97a2" }
-dylint_linting = "4.0.0"
+dylint_linting = "4.1.0"
 
 [dev-dependencies]
-dylint_testing = "4.0.0"
+dylint_testing = "4.1.0"
 serde = { version = "1.0", features = ["derive"] }
-tfhe-versionable = "0.4.0"
+tfhe-versionable = "0.6.1"
 
 [package.metadata.rust-analyzer]
 rustc_private = true

--- a/utils/tfhe-lints/src/serialize_without_versionize.rs
+++ b/utils/tfhe-lints/src/serialize_without_versionize.rs
@@ -12,7 +12,9 @@ pub struct SerializeWithoutVersionizeInner {
 }
 
 const VERSIONIZE_TRAIT: [&str; 2] = ["tfhe_versionable", "Versionize"];
-const SERIALIZE_TRAIT: [&str; 3] = ["serde", "ser", "Serialize"];
+const SERIALIZE_TRAIT: [&str; 3] = ["serde_core", "ser", "Serialize"];
+// Serialize trait root definition has been moved from the serde crate to serde_core
+const SERIALIZE_TRAIT_LEGACY: [&str; 3] = ["serde", "ser", "Serialize"];
 const LINT_NAME: &str = "serialize_without_versionize";
 
 impl SerializeWithoutVersionizeInner {
@@ -86,7 +88,9 @@ impl<'tcx> LateLintPass<'tcx> for SerializeWithoutVersionize {
                 // Check if the implemented trait is `Serialize`
                 if let Some(def_id) = trait_ref.trait_def_id() {
                     let path = cx.get_def_path(def_id);
-                    if path == symbols_list_from_str(&SERIALIZE_TRAIT) {
+                    if path == symbols_list_from_str(&SERIALIZE_TRAIT)
+                        || path == symbols_list_from_str(&SERIALIZE_TRAIT_LEGACY)
+                    {
                         // Try to find an implementation of versionize for this type
                         let mut found_impl = false;
                         if let Some(versionize_trait) = self.0.versionize_trait(cx) {


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: 

### PR content/description
serde moved the root crate for the serialize trait from serde to serde_core, so it was not detected anymore
