### PR TITLE
chore(ci): fix issue_comment trigger event for regression bench

### DIFF
--- a/.github/workflows/benchmark_perf_regression.yml
+++ b/.github/workflows/benchmark_perf_regression.yml
@@ -26,8 +26,7 @@ jobs:
     if: (github.event_name == 'pull_request' &&
       (contains(github.event.label.name, 'bench-perfs-cpu') ||
       contains(github.event.label.name, 'bench-perfs-gpu'))) ||
-      (github.event.issue_comment.pull_request &&
-      startsWith(github.event.comment.body, '/bench'))
+      (github.event.issue.pull_request && startsWith(github.event.comment.body, '/bench'))
     uses: ./.github/workflows/verify_commit_actor.yml
     secrets:
       ALLOWED_TEAM: ${{ secrets.RELEASE_TEAM }}


### PR DESCRIPTION
One limitation of GitHub, is the fact that `issue_comment` event **only** run on default branch.
So we need to merge this to see if it fixes the triggering issue.