### PR TITLE
chore(ci): fix audit workflow name

### DIFF
--- a/.github/workflows/cargo_audit.yml
+++ b/.github/workflows/cargo_audit.yml
@@ -1,4 +1,6 @@
 # Run cargo audit
+name: cargo_audit
+
 on:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description
I forgot to set the name of the workflow and now it displays weirdly

