### PR TITLE
chore: bump tfhe-cuda-backend to 0.12.0-alpha.0

### DIFF
--- a/backends/tfhe-cuda-backend/Cargo.toml
+++ b/backends/tfhe-cuda-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tfhe-cuda-backend"
-version = "0.11.0"
+version = "0.12.0-alpha.0"
 edition = "2021"
 authors = ["Zama team"]
 license = "BSD-3-Clause-Clear"

--- a/tfhe/Cargo.toml
+++ b/tfhe/Cargo.toml
@@ -65,7 +65,7 @@ tfhe-fft = { version = "0.9.0", path = "../tfhe-fft", features = [
 ] }
 tfhe-ntt = { version = "0.6.1", path = "../tfhe-ntt" }
 pulp = { workspace = true, features = ["default"] }
-tfhe-cuda-backend = { version = "0.11.0", path = "../backends/tfhe-cuda-backend", optional = true }
+tfhe-cuda-backend = { version = "0.12.0-alpha.0", path = "../backends/tfhe-cuda-backend", optional = true }
 aligned-vec = { workspace = true, features = ["default", "serde"] }
 dyn-stack = { workspace = true, features = ["default"] }
 paste = "1.0.7"


### PR DESCRIPTION
required to releas tfhe alpha