### PR TITLE
fix(core): fix sanity check for scalar size before zk pke encryption

### DIFF
--- a/tfhe/src/core_crypto/algorithms/lwe_encryption.rs
+++ b/tfhe/src/core_crypto/algorithms/lwe_encryption.rs
@@ -1854,13 +1854,6 @@ where
     KeyCont: Container<Element = Scalar>,
 {
     let exclusive_max = crs.exclusive_max_noise();
-    if Scalar::BITS < 64 && (1u64 << Scalar::BITS) >= exclusive_max {
-        return Err(
-            "The given random distribution would create random values out \
-            of the expected bounds of given to the CRS"
-                .into(),
-        );
-    }
 
     if mask_noise_distribution.contains(exclusive_max.cast_into()) {
         // The proof expect noise bound between [-b, b) (aka -b..b)


### PR DESCRIPTION
Before proven public key encryption we have this check:
```rust
    if Scalar::BITS < 64 && (1u64 << Scalar::BITS) >= exclusive_max {
        return Err(
            "The given random distribution would create random values out \
            of the expected bounds of given to the CRS"
                .into(),
        );
    }
```
Where exclusive_max is the max noise allowed by the crs.

This check is not correct because Scalar must hold the noise + message so its size must be > exclusive max.
But I think reversing it does not make a lot of sense either because the encryption noise distribution bound must be <= exclusize_max, we allow encryption with a smaller bound than the one of the crs. So for example we might have:
- scalar u32
- crs exclusive_max 2**37
- encryption noise bound 2**17

that should be accepted