### PR TITLE
chore(gpu): get decompress size on gpu without calling on_gpu

### DIFF
--- a/tfhe/src/integer/gpu/ciphertext/compressed_ciphertext_list.rs
+++ b/tfhe/src/integer/gpu/ciphertext/compressed_ciphertext_list.rs
@@ -125,7 +125,6 @@ impl CudaCompressedCiphertextList {
         ))
     }
 
-    #[allow(clippy::unnecessary_wraps)]
     fn get_blocks_of_size_on_gpu(
         &self,
         index: usize,
@@ -144,7 +143,7 @@ impl CudaCompressedCiphertextList {
 
         let end_block_index = start_block_index + current_info.num_blocks(message_modulus) - 1;
 
-        Some(decomp_key.get_unpack_size_on_gpu(
+        Some(decomp_key.get_gpu_list_unpack_size_on_gpu(
             &self.packed_list,
             start_block_index,
             end_block_index,


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description

In get_decompression_size_on_gpu, we used to do:
```
self.inner.on_gpu(streams).get_decompression_size_on_gpu(
                            index,
                            decompression_key,
                            streams,
```
The problem is that calling `on_gpu()` allocates and copies data to the GPU. 
It shouldn't be necessary to do this only to query decompression size. 
Also, this means the allocated GPU variable gets dropped at the end of `get_decompression_size_on_gpu` which means a
`cuda_device_synchronize` gets called, and this affects performance in the coprocessor.

This PR introduces an entry point for `get_decompression_size_on_gpu` when the input is on the CPU, using the CPU metadata to compute the size directly.

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
