### PR TITLE
chore: prepare alpha.2

### DIFF
--- a/backends/tfhe-cuda-backend/Cargo.toml
+++ b/backends/tfhe-cuda-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tfhe-cuda-backend"
-version = "0.12.0-alpha.1"
+version = "0.12.0-alpha.2"
 edition = "2021"
 authors = ["Zama team"]
 license = "BSD-3-Clause-Clear"

--- a/tfhe/Cargo.toml
+++ b/tfhe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tfhe"
-version = "1.4.0-alpha.1"
+version = "1.4.0-alpha.2"
 edition = "2021"
 readme = "../README.md"
 keywords = ["fully", "homomorphic", "encryption", "fhe", "cryptography"]
@@ -65,7 +65,7 @@ tfhe-fft = { version = "0.9.0", path = "../tfhe-fft", features = [
 ] }
 tfhe-ntt = { version = "0.6.1", path = "../tfhe-ntt" }
 pulp = { workspace = true, features = ["default"] }
-tfhe-cuda-backend = { version = "0.12.0-alpha.1", path = "../backends/tfhe-cuda-backend", optional = true }
+tfhe-cuda-backend = { version = "0.12.0-alpha.2", path = "../backends/tfhe-cuda-backend", optional = true }
 aligned-vec = { workspace = true, features = ["default", "serde"] }
 dyn-stack = { workspace = true, features = ["default"] }
 paste = "1.0.7"


### PR DESCRIPTION
- bump tfhe-cuda-backend to 0.12.0-alpha.2
- bump tfhe to 1.4.0-alpha.2
