### PR TITLE
Tm/move rerand ksk params

### DIFF
--- a/tfhe/src/high_level_api/config.rs
+++ b/tfhe/src/high_level_api/config.rs
@@ -4,7 +4,8 @@ use crate::backward_compatibility::config::ConfigVersions;
 use crate::high_level_api::keys::IntegerConfig;
 use crate::shortint::parameters::list_compression::CompressionParameters;
 use crate::shortint::parameters::{
-    NoiseSquashingCompressionParameters, NoiseSquashingParameters, ShortintKeySwitchingParameters,
+    MetaParameters, NoiseSquashingCompressionParameters, NoiseSquashingParameters,
+    ShortintKeySwitchingParameters,
 };
 
 /// The config type
@@ -147,5 +148,28 @@ impl ConfigBuilder {
 impl From<ConfigBuilder> for Config {
     fn from(builder: ConfigBuilder) -> Self {
         builder.build()
+    }
+}
+
+impl From<MetaParameters> for Config {
+    fn from(meta_params: MetaParameters) -> Self {
+        Self {
+            inner: IntegerConfig {
+                block_parameters: meta_params.compute_parameters,
+                dedicated_compact_public_key_parameters: meta_params
+                    .dedicated_compact_public_key_parameters
+                    .map(|dedicated_p| (dedicated_p.pke_params, dedicated_p.ksk_params)),
+                compression_parameters: meta_params.compression_parameters,
+                noise_squashing_parameters: meta_params
+                    .noise_squashing_parameters
+                    .map(|ns_p| ns_p.parameters),
+                noise_squashing_compression_parameters: meta_params
+                    .noise_squashing_parameters
+                    .and_then(|ns_p| ns_p.compression_parameters),
+                cpk_re_randomization_ksk_params: meta_params
+                    .dedicated_compact_public_key_parameters
+                    .and_then(|dedicated_pke| dedicated_pke.re_randomization_parameters),
+            },
+        }
     }
 }

--- a/tfhe/src/shortint/parameters/meta.rs
+++ b/tfhe/src/shortint/parameters/meta.rs
@@ -11,6 +11,9 @@ pub struct DedicatedCompactPublicKeyParameters {
     /// Parameters used to key switch from the compact public key
     /// parameters to compute parameters
     pub ksk_params: ShortintKeySwitchingParameters,
+    /// Parameters to key switch from the compact public key
+    /// to rerand state
+    pub re_randomization_parameters: Option<ShortintKeySwitchingParameters>,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -25,6 +28,4 @@ pub struct MetaParameters {
     pub compression_parameters: Option<CompressionParameters>,
     /// Parameters for noise squashing
     pub noise_squashing_parameters: Option<MetaNoiseSquashingParameters>,
-    /// Parameters for ciphertext re-randomization
-    pub re_randomization_parameters: Option<ShortintKeySwitchingParameters>,
 }

--- a/tfhe/src/shortint/parameters/v1_4/meta/cpu.rs
+++ b/tfhe/src/shortint/parameters/v1_4/meta/cpu.rs
@@ -28,7 +28,6 @@ pub const V1_4_META_PARAM_CPU_1_1_KS_PBS_GAUSSIAN_2M40: MetaParameters = MetaPar
     dedicated_compact_public_key_parameters: None,
     compression_parameters: None,
     noise_squashing_parameters: None,
-    re_randomization_parameters: None,
 };
 
 pub const V1_4_META_PARAM_CPU_2_2_KS_PBS_GAUSSIAN_2M40: MetaParameters = MetaParameters {
@@ -39,7 +38,6 @@ pub const V1_4_META_PARAM_CPU_2_2_KS_PBS_GAUSSIAN_2M40: MetaParameters = MetaPar
     dedicated_compact_public_key_parameters: None,
     compression_parameters: None,
     noise_squashing_parameters: None,
-    re_randomization_parameters: None,
 };
 
 pub const V1_4_META_PARAM_CPU_3_3_KS_PBS_GAUSSIAN_2M40: MetaParameters = MetaParameters {
@@ -50,7 +48,6 @@ pub const V1_4_META_PARAM_CPU_3_3_KS_PBS_GAUSSIAN_2M40: MetaParameters = MetaPar
     dedicated_compact_public_key_parameters: None,
     compression_parameters: None,
     noise_squashing_parameters: None,
-    re_randomization_parameters: None,
 };
 
 pub const V1_4_META_PARAM_CPU_4_4_KS_PBS_GAUSSIAN_2M40: MetaParameters = MetaParameters {
@@ -61,7 +58,6 @@ pub const V1_4_META_PARAM_CPU_4_4_KS_PBS_GAUSSIAN_2M40: MetaParameters = MetaPar
     dedicated_compact_public_key_parameters: None,
     compression_parameters: None,
     noise_squashing_parameters: None,
-    re_randomization_parameters: None,
 };
 
 pub const V1_4_META_PARAM_CPU_1_1_KS_PBS_GAUSSIAN_2M64: MetaParameters = MetaParameters {
@@ -72,7 +68,6 @@ pub const V1_4_META_PARAM_CPU_1_1_KS_PBS_GAUSSIAN_2M64: MetaParameters = MetaPar
     dedicated_compact_public_key_parameters: None,
     compression_parameters: None,
     noise_squashing_parameters: None,
-    re_randomization_parameters: None,
 };
 
 pub const V1_4_META_PARAM_CPU_2_2_KS_PBS_GAUSSIAN_2M64: MetaParameters = MetaParameters {
@@ -83,7 +78,6 @@ pub const V1_4_META_PARAM_CPU_2_2_KS_PBS_GAUSSIAN_2M64: MetaParameters = MetaPar
     dedicated_compact_public_key_parameters: None,
     compression_parameters: Some(V1_4_COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_GAUSSIAN_2M64),
     noise_squashing_parameters: None,
-    re_randomization_parameters: None,
 };
 
 pub const V1_4_META_PARAM_CPU_3_3_KS_PBS_GAUSSIAN_2M64: MetaParameters = MetaParameters {
@@ -94,7 +88,6 @@ pub const V1_4_META_PARAM_CPU_3_3_KS_PBS_GAUSSIAN_2M64: MetaParameters = MetaPar
     dedicated_compact_public_key_parameters: None,
     compression_parameters: None,
     noise_squashing_parameters: None,
-    re_randomization_parameters: None,
 };
 
 pub const V1_4_META_PARAM_CPU_4_4_KS_PBS_GAUSSIAN_2M64: MetaParameters = MetaParameters {
@@ -105,7 +98,6 @@ pub const V1_4_META_PARAM_CPU_4_4_KS_PBS_GAUSSIAN_2M64: MetaParameters = MetaPar
     dedicated_compact_public_key_parameters: None,
     compression_parameters: None,
     noise_squashing_parameters: None,
-    re_randomization_parameters: None,
 };
 
 pub const V1_4_META_PARAM_CPU_1_1_KS_PBS_GAUSSIAN_2M128: MetaParameters = MetaParameters {
@@ -116,7 +108,6 @@ pub const V1_4_META_PARAM_CPU_1_1_KS_PBS_GAUSSIAN_2M128: MetaParameters = MetaPa
     dedicated_compact_public_key_parameters: None,
     compression_parameters: None,
     noise_squashing_parameters: None,
-    re_randomization_parameters: None,
 };
 
 pub const V1_4_META_PARAM_CPU_2_2_KS_PBS_GAUSSIAN_2M128: MetaParameters = MetaParameters {
@@ -127,7 +118,6 @@ pub const V1_4_META_PARAM_CPU_2_2_KS_PBS_GAUSSIAN_2M128: MetaParameters = MetaPa
     dedicated_compact_public_key_parameters: None,
     compression_parameters: Some(V1_4_COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_GAUSSIAN_2M128),
     noise_squashing_parameters: None,
-    re_randomization_parameters: None,
 };
 
 pub const V1_4_META_PARAM_CPU_3_3_KS_PBS_GAUSSIAN_2M128: MetaParameters = MetaParameters {
@@ -138,7 +128,6 @@ pub const V1_4_META_PARAM_CPU_3_3_KS_PBS_GAUSSIAN_2M128: MetaParameters = MetaPa
     dedicated_compact_public_key_parameters: None,
     compression_parameters: None,
     noise_squashing_parameters: None,
-    re_randomization_parameters: None,
 };
 
 pub const V1_4_META_PARAM_CPU_4_4_KS_PBS_GAUSSIAN_2M128: MetaParameters = MetaParameters {
@@ -149,7 +138,6 @@ pub const V1_4_META_PARAM_CPU_4_4_KS_PBS_GAUSSIAN_2M128: MetaParameters = MetaPa
     dedicated_compact_public_key_parameters: None,
     compression_parameters: None,
     noise_squashing_parameters: None,
-    re_randomization_parameters: None,
 };
 
 pub const V1_4_META_PARAM_CPU_1_1_KS_PBS_TUNIFORM_2M40: MetaParameters = MetaParameters {
@@ -160,7 +148,6 @@ pub const V1_4_META_PARAM_CPU_1_1_KS_PBS_TUNIFORM_2M40: MetaParameters = MetaPar
     dedicated_compact_public_key_parameters: None,
     compression_parameters: None,
     noise_squashing_parameters: None,
-    re_randomization_parameters: None,
 };
 
 pub const V1_4_META_PARAM_CPU_2_2_KS_PBS_TUNIFORM_2M40: MetaParameters = MetaParameters {
@@ -171,7 +158,6 @@ pub const V1_4_META_PARAM_CPU_2_2_KS_PBS_TUNIFORM_2M40: MetaParameters = MetaPar
     dedicated_compact_public_key_parameters: None,
     compression_parameters: None,
     noise_squashing_parameters: None,
-    re_randomization_parameters: None,
 };
 
 pub const V1_4_META_PARAM_CPU_3_3_KS_PBS_TUNIFORM_2M40: MetaParameters = MetaParameters {
@@ -182,7 +168,6 @@ pub const V1_4_META_PARAM_CPU_3_3_KS_PBS_TUNIFORM_2M40: MetaParameters = MetaPar
     dedicated_compact_public_key_parameters: None,
     compression_parameters: None,
     noise_squashing_parameters: None,
-    re_randomization_parameters: None,
 };
 
 pub const V1_4_META_PARAM_CPU_4_4_KS_PBS_TUNIFORM_2M40: MetaParameters = MetaParameters {
@@ -193,7 +178,6 @@ pub const V1_4_META_PARAM_CPU_4_4_KS_PBS_TUNIFORM_2M40: MetaParameters = MetaPar
     dedicated_compact_public_key_parameters: None,
     compression_parameters: None,
     noise_squashing_parameters: None,
-    re_randomization_parameters: None,
 };
 
 pub const V1_4_META_PARAM_CPU_1_1_KS_PBS_TUNIFORM_2M64: MetaParameters = MetaParameters {
@@ -204,7 +188,6 @@ pub const V1_4_META_PARAM_CPU_1_1_KS_PBS_TUNIFORM_2M64: MetaParameters = MetaPar
     dedicated_compact_public_key_parameters: None,
     compression_parameters: None,
     noise_squashing_parameters: None,
-    re_randomization_parameters: None,
 };
 
 pub const V1_4_META_PARAM_CPU_2_2_KS_PBS_TUNIFORM_2M64: MetaParameters = MetaParameters {
@@ -215,7 +198,6 @@ pub const V1_4_META_PARAM_CPU_2_2_KS_PBS_TUNIFORM_2M64: MetaParameters = MetaPar
     dedicated_compact_public_key_parameters: None,
     compression_parameters: Some(V1_4_COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64),
     noise_squashing_parameters: None,
-    re_randomization_parameters: None,
 };
 
 pub const V1_4_META_PARAM_CPU_3_3_KS_PBS_TUNIFORM_2M64: MetaParameters = MetaParameters {
@@ -226,7 +208,6 @@ pub const V1_4_META_PARAM_CPU_3_3_KS_PBS_TUNIFORM_2M64: MetaParameters = MetaPar
     dedicated_compact_public_key_parameters: None,
     compression_parameters: None,
     noise_squashing_parameters: None,
-    re_randomization_parameters: None,
 };
 
 pub const V1_4_META_PARAM_CPU_4_4_KS_PBS_TUNIFORM_2M64: MetaParameters = MetaParameters {
@@ -237,7 +218,6 @@ pub const V1_4_META_PARAM_CPU_4_4_KS_PBS_TUNIFORM_2M64: MetaParameters = MetaPar
     dedicated_compact_public_key_parameters: None,
     compression_parameters: None,
     noise_squashing_parameters: None,
-    re_randomization_parameters: None,
 };
 
 pub const V1_4_META_PARAM_CPU_1_1_KS_PBS_TUNIFORM_2M128: MetaParameters = MetaParameters {
@@ -248,7 +228,6 @@ pub const V1_4_META_PARAM_CPU_1_1_KS_PBS_TUNIFORM_2M128: MetaParameters = MetaPa
     dedicated_compact_public_key_parameters: None,
     compression_parameters: None,
     noise_squashing_parameters: None,
-    re_randomization_parameters: None,
 };
 
 pub const V1_4_META_PARAM_CPU_3_3_KS_PBS_TUNIFORM_2M128: MetaParameters = MetaParameters {
@@ -259,7 +238,6 @@ pub const V1_4_META_PARAM_CPU_3_3_KS_PBS_TUNIFORM_2M128: MetaParameters = MetaPa
     dedicated_compact_public_key_parameters: None,
     compression_parameters: None,
     noise_squashing_parameters: None,
-    re_randomization_parameters: None,
 };
 
 pub const V1_4_META_PARAM_CPU_4_4_KS_PBS_TUNIFORM_2M128: MetaParameters = MetaParameters {
@@ -270,7 +248,6 @@ pub const V1_4_META_PARAM_CPU_4_4_KS_PBS_TUNIFORM_2M128: MetaParameters = MetaPa
     dedicated_compact_public_key_parameters: None,
     compression_parameters: None,
     noise_squashing_parameters: None,
-    re_randomization_parameters: None,
 };
 
 pub const V1_4_META_PARAM_CPU_1_1_MULTI_BIT_GROUP_2_KS_PBS_GAUSSIAN_2M40: MetaParameters =
@@ -282,7 +259,6 @@ pub const V1_4_META_PARAM_CPU_1_1_MULTI_BIT_GROUP_2_KS_PBS_GAUSSIAN_2M40: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_2_2_MULTI_BIT_GROUP_2_KS_PBS_GAUSSIAN_2M40: MetaParameters =
@@ -294,7 +270,6 @@ pub const V1_4_META_PARAM_CPU_2_2_MULTI_BIT_GROUP_2_KS_PBS_GAUSSIAN_2M40: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_3_3_MULTI_BIT_GROUP_2_KS_PBS_GAUSSIAN_2M40: MetaParameters =
@@ -306,7 +281,6 @@ pub const V1_4_META_PARAM_CPU_3_3_MULTI_BIT_GROUP_2_KS_PBS_GAUSSIAN_2M40: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_4_4_MULTI_BIT_GROUP_2_KS_PBS_GAUSSIAN_2M40: MetaParameters =
@@ -318,7 +292,6 @@ pub const V1_4_META_PARAM_CPU_4_4_MULTI_BIT_GROUP_2_KS_PBS_GAUSSIAN_2M40: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_1_1_MULTI_BIT_GROUP_3_KS_PBS_GAUSSIAN_2M40: MetaParameters =
@@ -330,7 +303,6 @@ pub const V1_4_META_PARAM_CPU_1_1_MULTI_BIT_GROUP_3_KS_PBS_GAUSSIAN_2M40: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_2_2_MULTI_BIT_GROUP_3_KS_PBS_GAUSSIAN_2M40: MetaParameters =
@@ -342,7 +314,6 @@ pub const V1_4_META_PARAM_CPU_2_2_MULTI_BIT_GROUP_3_KS_PBS_GAUSSIAN_2M40: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_3_3_MULTI_BIT_GROUP_3_KS_PBS_GAUSSIAN_2M40: MetaParameters =
@@ -354,7 +325,6 @@ pub const V1_4_META_PARAM_CPU_3_3_MULTI_BIT_GROUP_3_KS_PBS_GAUSSIAN_2M40: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_4_4_MULTI_BIT_GROUP_3_KS_PBS_GAUSSIAN_2M40: MetaParameters =
@@ -366,7 +336,6 @@ pub const V1_4_META_PARAM_CPU_4_4_MULTI_BIT_GROUP_3_KS_PBS_GAUSSIAN_2M40: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_1_1_MULTI_BIT_GROUP_4_KS_PBS_GAUSSIAN_2M40: MetaParameters =
@@ -378,7 +347,6 @@ pub const V1_4_META_PARAM_CPU_1_1_MULTI_BIT_GROUP_4_KS_PBS_GAUSSIAN_2M40: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_2_2_MULTI_BIT_GROUP_4_KS_PBS_GAUSSIAN_2M40: MetaParameters =
@@ -390,7 +358,6 @@ pub const V1_4_META_PARAM_CPU_2_2_MULTI_BIT_GROUP_4_KS_PBS_GAUSSIAN_2M40: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_3_3_MULTI_BIT_GROUP_4_KS_PBS_GAUSSIAN_2M40: MetaParameters =
@@ -402,7 +369,6 @@ pub const V1_4_META_PARAM_CPU_3_3_MULTI_BIT_GROUP_4_KS_PBS_GAUSSIAN_2M40: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_4_4_MULTI_BIT_GROUP_4_KS_PBS_GAUSSIAN_2M40: MetaParameters =
@@ -414,7 +380,6 @@ pub const V1_4_META_PARAM_CPU_4_4_MULTI_BIT_GROUP_4_KS_PBS_GAUSSIAN_2M40: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_1_1_MULTI_BIT_GROUP_2_KS_PBS_GAUSSIAN_2M64: MetaParameters =
@@ -426,7 +391,6 @@ pub const V1_4_META_PARAM_CPU_1_1_MULTI_BIT_GROUP_2_KS_PBS_GAUSSIAN_2M64: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_2_2_MULTI_BIT_GROUP_2_KS_PBS_GAUSSIAN_2M64: MetaParameters =
@@ -438,7 +402,6 @@ pub const V1_4_META_PARAM_CPU_2_2_MULTI_BIT_GROUP_2_KS_PBS_GAUSSIAN_2M64: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_3_3_MULTI_BIT_GROUP_2_KS_PBS_GAUSSIAN_2M64: MetaParameters =
@@ -450,7 +413,6 @@ pub const V1_4_META_PARAM_CPU_3_3_MULTI_BIT_GROUP_2_KS_PBS_GAUSSIAN_2M64: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_4_4_MULTI_BIT_GROUP_2_KS_PBS_GAUSSIAN_2M64: MetaParameters =
@@ -462,7 +424,6 @@ pub const V1_4_META_PARAM_CPU_4_4_MULTI_BIT_GROUP_2_KS_PBS_GAUSSIAN_2M64: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_1_1_MULTI_BIT_GROUP_3_KS_PBS_GAUSSIAN_2M64: MetaParameters =
@@ -474,7 +435,6 @@ pub const V1_4_META_PARAM_CPU_1_1_MULTI_BIT_GROUP_3_KS_PBS_GAUSSIAN_2M64: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_2_2_MULTI_BIT_GROUP_3_KS_PBS_GAUSSIAN_2M64: MetaParameters =
@@ -486,7 +446,6 @@ pub const V1_4_META_PARAM_CPU_2_2_MULTI_BIT_GROUP_3_KS_PBS_GAUSSIAN_2M64: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_3_3_MULTI_BIT_GROUP_3_KS_PBS_GAUSSIAN_2M64: MetaParameters =
@@ -498,7 +457,6 @@ pub const V1_4_META_PARAM_CPU_3_3_MULTI_BIT_GROUP_3_KS_PBS_GAUSSIAN_2M64: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_4_4_MULTI_BIT_GROUP_3_KS_PBS_GAUSSIAN_2M64: MetaParameters =
@@ -510,7 +468,6 @@ pub const V1_4_META_PARAM_CPU_4_4_MULTI_BIT_GROUP_3_KS_PBS_GAUSSIAN_2M64: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_1_1_MULTI_BIT_GROUP_4_KS_PBS_GAUSSIAN_2M64: MetaParameters =
@@ -522,7 +479,6 @@ pub const V1_4_META_PARAM_CPU_1_1_MULTI_BIT_GROUP_4_KS_PBS_GAUSSIAN_2M64: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_2_2_MULTI_BIT_GROUP_4_KS_PBS_GAUSSIAN_2M64: MetaParameters =
@@ -534,7 +490,6 @@ pub const V1_4_META_PARAM_CPU_2_2_MULTI_BIT_GROUP_4_KS_PBS_GAUSSIAN_2M64: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_3_3_MULTI_BIT_GROUP_4_KS_PBS_GAUSSIAN_2M64: MetaParameters =
@@ -546,7 +501,6 @@ pub const V1_4_META_PARAM_CPU_3_3_MULTI_BIT_GROUP_4_KS_PBS_GAUSSIAN_2M64: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_4_4_MULTI_BIT_GROUP_4_KS_PBS_GAUSSIAN_2M64: MetaParameters =
@@ -558,7 +512,6 @@ pub const V1_4_META_PARAM_CPU_4_4_MULTI_BIT_GROUP_4_KS_PBS_GAUSSIAN_2M64: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_1_1_MULTI_BIT_GROUP_2_KS_PBS_GAUSSIAN_2M128: MetaParameters =
@@ -570,7 +523,6 @@ pub const V1_4_META_PARAM_CPU_1_1_MULTI_BIT_GROUP_2_KS_PBS_GAUSSIAN_2M128: MetaP
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_2_2_MULTI_BIT_GROUP_2_KS_PBS_GAUSSIAN_2M128: MetaParameters =
@@ -582,7 +534,6 @@ pub const V1_4_META_PARAM_CPU_2_2_MULTI_BIT_GROUP_2_KS_PBS_GAUSSIAN_2M128: MetaP
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_3_3_MULTI_BIT_GROUP_2_KS_PBS_GAUSSIAN_2M128: MetaParameters =
@@ -594,7 +545,6 @@ pub const V1_4_META_PARAM_CPU_3_3_MULTI_BIT_GROUP_2_KS_PBS_GAUSSIAN_2M128: MetaP
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_4_4_MULTI_BIT_GROUP_2_KS_PBS_GAUSSIAN_2M128: MetaParameters =
@@ -606,7 +556,6 @@ pub const V1_4_META_PARAM_CPU_4_4_MULTI_BIT_GROUP_2_KS_PBS_GAUSSIAN_2M128: MetaP
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_1_1_MULTI_BIT_GROUP_3_KS_PBS_GAUSSIAN_2M128: MetaParameters =
@@ -618,7 +567,6 @@ pub const V1_4_META_PARAM_CPU_1_1_MULTI_BIT_GROUP_3_KS_PBS_GAUSSIAN_2M128: MetaP
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_2_2_MULTI_BIT_GROUP_3_KS_PBS_GAUSSIAN_2M128: MetaParameters =
@@ -630,7 +578,6 @@ pub const V1_4_META_PARAM_CPU_2_2_MULTI_BIT_GROUP_3_KS_PBS_GAUSSIAN_2M128: MetaP
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_3_3_MULTI_BIT_GROUP_3_KS_PBS_GAUSSIAN_2M128: MetaParameters =
@@ -642,7 +589,6 @@ pub const V1_4_META_PARAM_CPU_3_3_MULTI_BIT_GROUP_3_KS_PBS_GAUSSIAN_2M128: MetaP
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_4_4_MULTI_BIT_GROUP_3_KS_PBS_GAUSSIAN_2M128: MetaParameters =
@@ -654,7 +600,6 @@ pub const V1_4_META_PARAM_CPU_4_4_MULTI_BIT_GROUP_3_KS_PBS_GAUSSIAN_2M128: MetaP
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_1_1_MULTI_BIT_GROUP_4_KS_PBS_GAUSSIAN_2M128: MetaParameters =
@@ -666,7 +611,6 @@ pub const V1_4_META_PARAM_CPU_1_1_MULTI_BIT_GROUP_4_KS_PBS_GAUSSIAN_2M128: MetaP
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_2_2_MULTI_BIT_GROUP_4_KS_PBS_GAUSSIAN_2M128: MetaParameters =
@@ -678,7 +622,6 @@ pub const V1_4_META_PARAM_CPU_2_2_MULTI_BIT_GROUP_4_KS_PBS_GAUSSIAN_2M128: MetaP
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_3_3_MULTI_BIT_GROUP_4_KS_PBS_GAUSSIAN_2M128: MetaParameters =
@@ -690,7 +633,6 @@ pub const V1_4_META_PARAM_CPU_3_3_MULTI_BIT_GROUP_4_KS_PBS_GAUSSIAN_2M128: MetaP
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_4_4_MULTI_BIT_GROUP_4_KS_PBS_GAUSSIAN_2M128: MetaParameters =
@@ -702,7 +644,6 @@ pub const V1_4_META_PARAM_CPU_4_4_MULTI_BIT_GROUP_4_KS_PBS_GAUSSIAN_2M128: MetaP
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_1_1_MULTI_BIT_GROUP_2_KS_PBS_TUNIFORM_2M40: MetaParameters =
@@ -714,7 +655,6 @@ pub const V1_4_META_PARAM_CPU_1_1_MULTI_BIT_GROUP_2_KS_PBS_TUNIFORM_2M40: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_2_2_MULTI_BIT_GROUP_2_KS_PBS_TUNIFORM_2M40: MetaParameters =
@@ -726,7 +666,6 @@ pub const V1_4_META_PARAM_CPU_2_2_MULTI_BIT_GROUP_2_KS_PBS_TUNIFORM_2M40: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_3_3_MULTI_BIT_GROUP_2_KS_PBS_TUNIFORM_2M40: MetaParameters =
@@ -738,7 +677,6 @@ pub const V1_4_META_PARAM_CPU_3_3_MULTI_BIT_GROUP_2_KS_PBS_TUNIFORM_2M40: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_4_4_MULTI_BIT_GROUP_2_KS_PBS_TUNIFORM_2M40: MetaParameters =
@@ -750,7 +688,6 @@ pub const V1_4_META_PARAM_CPU_4_4_MULTI_BIT_GROUP_2_KS_PBS_TUNIFORM_2M40: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_1_1_MULTI_BIT_GROUP_3_KS_PBS_TUNIFORM_2M40: MetaParameters =
@@ -762,7 +699,6 @@ pub const V1_4_META_PARAM_CPU_1_1_MULTI_BIT_GROUP_3_KS_PBS_TUNIFORM_2M40: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_2_2_MULTI_BIT_GROUP_3_KS_PBS_TUNIFORM_2M40: MetaParameters =
@@ -774,7 +710,6 @@ pub const V1_4_META_PARAM_CPU_2_2_MULTI_BIT_GROUP_3_KS_PBS_TUNIFORM_2M40: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_3_3_MULTI_BIT_GROUP_3_KS_PBS_TUNIFORM_2M40: MetaParameters =
@@ -786,7 +721,6 @@ pub const V1_4_META_PARAM_CPU_3_3_MULTI_BIT_GROUP_3_KS_PBS_TUNIFORM_2M40: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_4_4_MULTI_BIT_GROUP_3_KS_PBS_TUNIFORM_2M40: MetaParameters =
@@ -798,7 +732,6 @@ pub const V1_4_META_PARAM_CPU_4_4_MULTI_BIT_GROUP_3_KS_PBS_TUNIFORM_2M40: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_1_1_MULTI_BIT_GROUP_4_KS_PBS_TUNIFORM_2M40: MetaParameters =
@@ -810,7 +743,6 @@ pub const V1_4_META_PARAM_CPU_1_1_MULTI_BIT_GROUP_4_KS_PBS_TUNIFORM_2M40: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_2_2_MULTI_BIT_GROUP_4_KS_PBS_TUNIFORM_2M40: MetaParameters =
@@ -822,7 +754,6 @@ pub const V1_4_META_PARAM_CPU_2_2_MULTI_BIT_GROUP_4_KS_PBS_TUNIFORM_2M40: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_3_3_MULTI_BIT_GROUP_4_KS_PBS_TUNIFORM_2M40: MetaParameters =
@@ -834,7 +765,6 @@ pub const V1_4_META_PARAM_CPU_3_3_MULTI_BIT_GROUP_4_KS_PBS_TUNIFORM_2M40: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_4_4_MULTI_BIT_GROUP_4_KS_PBS_TUNIFORM_2M40: MetaParameters =
@@ -846,7 +776,6 @@ pub const V1_4_META_PARAM_CPU_4_4_MULTI_BIT_GROUP_4_KS_PBS_TUNIFORM_2M40: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_1_1_MULTI_BIT_GROUP_2_KS_PBS_TUNIFORM_2M64: MetaParameters =
@@ -858,7 +787,6 @@ pub const V1_4_META_PARAM_CPU_1_1_MULTI_BIT_GROUP_2_KS_PBS_TUNIFORM_2M64: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_2_2_MULTI_BIT_GROUP_2_KS_PBS_TUNIFORM_2M64: MetaParameters =
@@ -870,7 +798,6 @@ pub const V1_4_META_PARAM_CPU_2_2_MULTI_BIT_GROUP_2_KS_PBS_TUNIFORM_2M64: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_3_3_MULTI_BIT_GROUP_2_KS_PBS_TUNIFORM_2M64: MetaParameters =
@@ -882,7 +809,6 @@ pub const V1_4_META_PARAM_CPU_3_3_MULTI_BIT_GROUP_2_KS_PBS_TUNIFORM_2M64: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_4_4_MULTI_BIT_GROUP_2_KS_PBS_TUNIFORM_2M64: MetaParameters =
@@ -894,7 +820,6 @@ pub const V1_4_META_PARAM_CPU_4_4_MULTI_BIT_GROUP_2_KS_PBS_TUNIFORM_2M64: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_1_1_MULTI_BIT_GROUP_3_KS_PBS_TUNIFORM_2M64: MetaParameters =
@@ -906,7 +831,6 @@ pub const V1_4_META_PARAM_CPU_1_1_MULTI_BIT_GROUP_3_KS_PBS_TUNIFORM_2M64: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_2_2_MULTI_BIT_GROUP_3_KS_PBS_TUNIFORM_2M64: MetaParameters =
@@ -918,7 +842,6 @@ pub const V1_4_META_PARAM_CPU_2_2_MULTI_BIT_GROUP_3_KS_PBS_TUNIFORM_2M64: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_3_3_MULTI_BIT_GROUP_3_KS_PBS_TUNIFORM_2M64: MetaParameters =
@@ -930,7 +853,6 @@ pub const V1_4_META_PARAM_CPU_3_3_MULTI_BIT_GROUP_3_KS_PBS_TUNIFORM_2M64: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_4_4_MULTI_BIT_GROUP_3_KS_PBS_TUNIFORM_2M64: MetaParameters =
@@ -942,7 +864,6 @@ pub const V1_4_META_PARAM_CPU_4_4_MULTI_BIT_GROUP_3_KS_PBS_TUNIFORM_2M64: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_1_1_MULTI_BIT_GROUP_4_KS_PBS_TUNIFORM_2M64: MetaParameters =
@@ -954,7 +875,6 @@ pub const V1_4_META_PARAM_CPU_1_1_MULTI_BIT_GROUP_4_KS_PBS_TUNIFORM_2M64: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_2_2_MULTI_BIT_GROUP_4_KS_PBS_TUNIFORM_2M64: MetaParameters =
@@ -966,7 +886,6 @@ pub const V1_4_META_PARAM_CPU_2_2_MULTI_BIT_GROUP_4_KS_PBS_TUNIFORM_2M64: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_3_3_MULTI_BIT_GROUP_4_KS_PBS_TUNIFORM_2M64: MetaParameters =
@@ -978,7 +897,6 @@ pub const V1_4_META_PARAM_CPU_3_3_MULTI_BIT_GROUP_4_KS_PBS_TUNIFORM_2M64: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_4_4_MULTI_BIT_GROUP_4_KS_PBS_TUNIFORM_2M64: MetaParameters =
@@ -990,7 +908,6 @@ pub const V1_4_META_PARAM_CPU_4_4_MULTI_BIT_GROUP_4_KS_PBS_TUNIFORM_2M64: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_1_1_MULTI_BIT_GROUP_2_KS_PBS_TUNIFORM_2M128: MetaParameters =
@@ -1002,7 +919,6 @@ pub const V1_4_META_PARAM_CPU_1_1_MULTI_BIT_GROUP_2_KS_PBS_TUNIFORM_2M128: MetaP
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_2_2_MULTI_BIT_GROUP_2_KS_PBS_TUNIFORM_2M128: MetaParameters =
@@ -1014,7 +930,6 @@ pub const V1_4_META_PARAM_CPU_2_2_MULTI_BIT_GROUP_2_KS_PBS_TUNIFORM_2M128: MetaP
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_3_3_MULTI_BIT_GROUP_2_KS_PBS_TUNIFORM_2M128: MetaParameters =
@@ -1026,7 +941,6 @@ pub const V1_4_META_PARAM_CPU_3_3_MULTI_BIT_GROUP_2_KS_PBS_TUNIFORM_2M128: MetaP
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_4_4_MULTI_BIT_GROUP_2_KS_PBS_TUNIFORM_2M128: MetaParameters =
@@ -1038,7 +952,6 @@ pub const V1_4_META_PARAM_CPU_4_4_MULTI_BIT_GROUP_2_KS_PBS_TUNIFORM_2M128: MetaP
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_1_1_MULTI_BIT_GROUP_3_KS_PBS_TUNIFORM_2M128: MetaParameters =
@@ -1050,7 +963,6 @@ pub const V1_4_META_PARAM_CPU_1_1_MULTI_BIT_GROUP_3_KS_PBS_TUNIFORM_2M128: MetaP
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_2_2_MULTI_BIT_GROUP_3_KS_PBS_TUNIFORM_2M128: MetaParameters =
@@ -1062,7 +974,6 @@ pub const V1_4_META_PARAM_CPU_2_2_MULTI_BIT_GROUP_3_KS_PBS_TUNIFORM_2M128: MetaP
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_3_3_MULTI_BIT_GROUP_3_KS_PBS_TUNIFORM_2M128: MetaParameters =
@@ -1074,7 +985,6 @@ pub const V1_4_META_PARAM_CPU_3_3_MULTI_BIT_GROUP_3_KS_PBS_TUNIFORM_2M128: MetaP
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_4_4_MULTI_BIT_GROUP_3_KS_PBS_TUNIFORM_2M128: MetaParameters =
@@ -1086,7 +996,6 @@ pub const V1_4_META_PARAM_CPU_4_4_MULTI_BIT_GROUP_3_KS_PBS_TUNIFORM_2M128: MetaP
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_1_1_MULTI_BIT_GROUP_4_KS_PBS_TUNIFORM_2M128: MetaParameters =
@@ -1098,7 +1007,6 @@ pub const V1_4_META_PARAM_CPU_1_1_MULTI_BIT_GROUP_4_KS_PBS_TUNIFORM_2M128: MetaP
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_2_2_MULTI_BIT_GROUP_4_KS_PBS_TUNIFORM_2M128: MetaParameters =
@@ -1110,7 +1018,6 @@ pub const V1_4_META_PARAM_CPU_2_2_MULTI_BIT_GROUP_4_KS_PBS_TUNIFORM_2M128: MetaP
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_3_3_MULTI_BIT_GROUP_4_KS_PBS_TUNIFORM_2M128: MetaParameters =
@@ -1122,7 +1029,6 @@ pub const V1_4_META_PARAM_CPU_3_3_MULTI_BIT_GROUP_4_KS_PBS_TUNIFORM_2M128: MetaP
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_4_4_MULTI_BIT_GROUP_4_KS_PBS_TUNIFORM_2M128: MetaParameters =
@@ -1134,7 +1040,6 @@ pub const V1_4_META_PARAM_CPU_4_4_MULTI_BIT_GROUP_4_KS_PBS_TUNIFORM_2M128: MetaP
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_CPU_2_2_KS32_PBS_TUNIFORM_2M128: MetaParameters = MetaParameters {
@@ -1145,7 +1050,6 @@ pub const V1_4_META_PARAM_CPU_2_2_KS32_PBS_TUNIFORM_2M128: MetaParameters = Meta
     dedicated_compact_public_key_parameters: None,
     compression_parameters: None,
     noise_squashing_parameters: None,
-    re_randomization_parameters: None,
 };
 
 pub const V1_4_META_PARAM_CPU_2_2_KS_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128: MetaParameters =
@@ -1158,6 +1062,9 @@ pub const V1_4_META_PARAM_CPU_2_2_KS_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128: MetaP
             pke_params: V1_4_PARAM_PKE_TO_SMALL_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128_ZKV2,
             ksk_params:
                 V1_4_PARAM_KEYSWITCH_PKE_TO_SMALL_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128_ZKV2,
+            re_randomization_parameters: Some(
+                V1_4_PARAM_KEYSWITCH_PKE_TO_BIG_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128_ZKV2,
+            ),
         }),
         compression_parameters: Some(V1_4_COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128),
         noise_squashing_parameters: Some(MetaNoiseSquashingParameters {
@@ -1166,9 +1073,6 @@ pub const V1_4_META_PARAM_CPU_2_2_KS_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128: MetaP
                 V1_4_NOISE_SQUASHING_COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
             ),
         }),
-        re_randomization_parameters: Some(
-            V1_4_PARAM_KEYSWITCH_PKE_TO_BIG_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128_ZKV2,
-        ),
     };
 
 pub const V1_4_META_PARAM_CPU_2_2_KS_PBS_PKE_TO_BIG_ZKV2_TUNIFORM_2M128: MetaParameters =
@@ -1181,6 +1085,9 @@ pub const V1_4_META_PARAM_CPU_2_2_KS_PBS_PKE_TO_BIG_ZKV2_TUNIFORM_2M128: MetaPar
             pke_params: V1_4_PARAM_PKE_TO_BIG_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128_ZKV2,
             ksk_params:
                 V1_4_PARAM_KEYSWITCH_PKE_TO_BIG_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128_ZKV2,
+            re_randomization_parameters: Some(
+                V1_4_PARAM_KEYSWITCH_PKE_TO_BIG_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128_ZKV2,
+            ),
         }),
         compression_parameters: Some(V1_4_COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128),
         noise_squashing_parameters: Some(MetaNoiseSquashingParameters {
@@ -1189,9 +1096,6 @@ pub const V1_4_META_PARAM_CPU_2_2_KS_PBS_PKE_TO_BIG_ZKV2_TUNIFORM_2M128: MetaPar
                 V1_4_NOISE_SQUASHING_COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
             ),
         }),
-        re_randomization_parameters: Some(
-            V1_4_PARAM_KEYSWITCH_PKE_TO_BIG_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128_ZKV2,
-        ),
     };
 
 pub const V1_4_META_PARAM_CPU_2_2_KS_PBS_PKE_TO_SMALL_ZKV1_TUNIFORM_2M128: MetaParameters =
@@ -1204,6 +1108,9 @@ pub const V1_4_META_PARAM_CPU_2_2_KS_PBS_PKE_TO_SMALL_ZKV1_TUNIFORM_2M128: MetaP
             pke_params: V1_4_PARAM_PKE_TO_SMALL_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128_ZKV1,
             ksk_params:
                 V1_4_PARAM_KEYSWITCH_PKE_TO_SMALL_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128_ZKV1,
+            re_randomization_parameters: Some(
+                V1_4_PARAM_KEYSWITCH_PKE_TO_BIG_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128_ZKV1,
+            ),
         }),
         compression_parameters: Some(V1_4_COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128),
         noise_squashing_parameters: Some(MetaNoiseSquashingParameters {
@@ -1212,9 +1119,6 @@ pub const V1_4_META_PARAM_CPU_2_2_KS_PBS_PKE_TO_SMALL_ZKV1_TUNIFORM_2M128: MetaP
                 V1_4_NOISE_SQUASHING_COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
             ),
         }),
-        re_randomization_parameters: Some(
-            V1_4_PARAM_KEYSWITCH_PKE_TO_BIG_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128_ZKV1,
-        ),
     };
 
 pub const V1_4_META_PARAM_CPU_2_2_KS_PBS_PKE_TO_BIG_ZKV1_TUNIFORM_2M128: MetaParameters =
@@ -1227,6 +1131,9 @@ pub const V1_4_META_PARAM_CPU_2_2_KS_PBS_PKE_TO_BIG_ZKV1_TUNIFORM_2M128: MetaPar
             pke_params: V1_4_PARAM_PKE_TO_BIG_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128_ZKV1,
             ksk_params:
                 V1_4_PARAM_KEYSWITCH_PKE_TO_BIG_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128_ZKV1,
+            re_randomization_parameters: Some(
+                V1_4_PARAM_KEYSWITCH_PKE_TO_BIG_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128_ZKV1,
+            ),
         }),
         compression_parameters: Some(V1_4_COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128),
         noise_squashing_parameters: Some(MetaNoiseSquashingParameters {
@@ -1235,7 +1142,4 @@ pub const V1_4_META_PARAM_CPU_2_2_KS_PBS_PKE_TO_BIG_ZKV1_TUNIFORM_2M128: MetaPar
                 V1_4_NOISE_SQUASHING_COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
             ),
         }),
-        re_randomization_parameters: Some(
-            V1_4_PARAM_KEYSWITCH_PKE_TO_BIG_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128_ZKV1,
-        ),
     };

--- a/tfhe/src/shortint/parameters/v1_4/meta/gpu.rs
+++ b/tfhe/src/shortint/parameters/v1_4/meta/gpu.rs
@@ -23,7 +23,6 @@ pub const V1_4_META_PARAM_GPU_1_1_MULTI_BIT_GROUP_2_KS_PBS_GAUSSIAN_2M40: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_2_2_MULTI_BIT_GROUP_2_KS_PBS_GAUSSIAN_2M40: MetaParameters =
@@ -35,7 +34,6 @@ pub const V1_4_META_PARAM_GPU_2_2_MULTI_BIT_GROUP_2_KS_PBS_GAUSSIAN_2M40: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_3_3_MULTI_BIT_GROUP_2_KS_PBS_GAUSSIAN_2M40: MetaParameters =
@@ -47,7 +45,6 @@ pub const V1_4_META_PARAM_GPU_3_3_MULTI_BIT_GROUP_2_KS_PBS_GAUSSIAN_2M40: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_4_4_MULTI_BIT_GROUP_2_KS_PBS_GAUSSIAN_2M40: MetaParameters =
@@ -59,7 +56,6 @@ pub const V1_4_META_PARAM_GPU_4_4_MULTI_BIT_GROUP_2_KS_PBS_GAUSSIAN_2M40: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_1_1_MULTI_BIT_GROUP_3_KS_PBS_GAUSSIAN_2M40: MetaParameters =
@@ -71,7 +67,6 @@ pub const V1_4_META_PARAM_GPU_1_1_MULTI_BIT_GROUP_3_KS_PBS_GAUSSIAN_2M40: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_2_2_MULTI_BIT_GROUP_3_KS_PBS_GAUSSIAN_2M40: MetaParameters =
@@ -83,7 +78,6 @@ pub const V1_4_META_PARAM_GPU_2_2_MULTI_BIT_GROUP_3_KS_PBS_GAUSSIAN_2M40: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_3_3_MULTI_BIT_GROUP_3_KS_PBS_GAUSSIAN_2M40: MetaParameters =
@@ -95,7 +89,6 @@ pub const V1_4_META_PARAM_GPU_3_3_MULTI_BIT_GROUP_3_KS_PBS_GAUSSIAN_2M40: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_4_4_MULTI_BIT_GROUP_3_KS_PBS_GAUSSIAN_2M40: MetaParameters =
@@ -107,7 +100,6 @@ pub const V1_4_META_PARAM_GPU_4_4_MULTI_BIT_GROUP_3_KS_PBS_GAUSSIAN_2M40: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_1_1_MULTI_BIT_GROUP_4_KS_PBS_GAUSSIAN_2M40: MetaParameters =
@@ -119,7 +111,6 @@ pub const V1_4_META_PARAM_GPU_1_1_MULTI_BIT_GROUP_4_KS_PBS_GAUSSIAN_2M40: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_2_2_MULTI_BIT_GROUP_4_KS_PBS_GAUSSIAN_2M40: MetaParameters =
@@ -131,7 +122,6 @@ pub const V1_4_META_PARAM_GPU_2_2_MULTI_BIT_GROUP_4_KS_PBS_GAUSSIAN_2M40: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_3_3_MULTI_BIT_GROUP_4_KS_PBS_GAUSSIAN_2M40: MetaParameters =
@@ -143,7 +133,6 @@ pub const V1_4_META_PARAM_GPU_3_3_MULTI_BIT_GROUP_4_KS_PBS_GAUSSIAN_2M40: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_4_4_MULTI_BIT_GROUP_4_KS_PBS_GAUSSIAN_2M40: MetaParameters =
@@ -155,7 +144,6 @@ pub const V1_4_META_PARAM_GPU_4_4_MULTI_BIT_GROUP_4_KS_PBS_GAUSSIAN_2M40: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_1_1_MULTI_BIT_GROUP_2_KS_PBS_GAUSSIAN_2M64: MetaParameters =
@@ -167,7 +155,6 @@ pub const V1_4_META_PARAM_GPU_1_1_MULTI_BIT_GROUP_2_KS_PBS_GAUSSIAN_2M64: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_2_2_MULTI_BIT_GROUP_2_KS_PBS_GAUSSIAN_2M64: MetaParameters =
@@ -179,7 +166,6 @@ pub const V1_4_META_PARAM_GPU_2_2_MULTI_BIT_GROUP_2_KS_PBS_GAUSSIAN_2M64: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_3_3_MULTI_BIT_GROUP_2_KS_PBS_GAUSSIAN_2M64: MetaParameters =
@@ -191,7 +177,6 @@ pub const V1_4_META_PARAM_GPU_3_3_MULTI_BIT_GROUP_2_KS_PBS_GAUSSIAN_2M64: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_4_4_MULTI_BIT_GROUP_2_KS_PBS_GAUSSIAN_2M64: MetaParameters =
@@ -203,7 +188,6 @@ pub const V1_4_META_PARAM_GPU_4_4_MULTI_BIT_GROUP_2_KS_PBS_GAUSSIAN_2M64: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_1_1_MULTI_BIT_GROUP_3_KS_PBS_GAUSSIAN_2M64: MetaParameters =
@@ -215,7 +199,6 @@ pub const V1_4_META_PARAM_GPU_1_1_MULTI_BIT_GROUP_3_KS_PBS_GAUSSIAN_2M64: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_2_2_MULTI_BIT_GROUP_3_KS_PBS_GAUSSIAN_2M64: MetaParameters =
@@ -227,7 +210,6 @@ pub const V1_4_META_PARAM_GPU_2_2_MULTI_BIT_GROUP_3_KS_PBS_GAUSSIAN_2M64: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_3_3_MULTI_BIT_GROUP_3_KS_PBS_GAUSSIAN_2M64: MetaParameters =
@@ -239,7 +221,6 @@ pub const V1_4_META_PARAM_GPU_3_3_MULTI_BIT_GROUP_3_KS_PBS_GAUSSIAN_2M64: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_4_4_MULTI_BIT_GROUP_3_KS_PBS_GAUSSIAN_2M64: MetaParameters =
@@ -251,7 +232,6 @@ pub const V1_4_META_PARAM_GPU_4_4_MULTI_BIT_GROUP_3_KS_PBS_GAUSSIAN_2M64: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_1_1_MULTI_BIT_GROUP_4_KS_PBS_GAUSSIAN_2M64: MetaParameters =
@@ -263,7 +243,6 @@ pub const V1_4_META_PARAM_GPU_1_1_MULTI_BIT_GROUP_4_KS_PBS_GAUSSIAN_2M64: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_2_2_MULTI_BIT_GROUP_4_KS_PBS_GAUSSIAN_2M64: MetaParameters =
@@ -277,7 +256,6 @@ pub const V1_4_META_PARAM_GPU_2_2_MULTI_BIT_GROUP_4_KS_PBS_GAUSSIAN_2M64: MetaPa
             V1_4_COMP_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_GAUSSIAN_2M64,
         ),
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_3_3_MULTI_BIT_GROUP_4_KS_PBS_GAUSSIAN_2M64: MetaParameters =
@@ -289,7 +267,6 @@ pub const V1_4_META_PARAM_GPU_3_3_MULTI_BIT_GROUP_4_KS_PBS_GAUSSIAN_2M64: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_4_4_MULTI_BIT_GROUP_4_KS_PBS_GAUSSIAN_2M64: MetaParameters =
@@ -301,7 +278,6 @@ pub const V1_4_META_PARAM_GPU_4_4_MULTI_BIT_GROUP_4_KS_PBS_GAUSSIAN_2M64: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_1_1_MULTI_BIT_GROUP_2_KS_PBS_GAUSSIAN_2M128: MetaParameters =
@@ -313,7 +289,6 @@ pub const V1_4_META_PARAM_GPU_1_1_MULTI_BIT_GROUP_2_KS_PBS_GAUSSIAN_2M128: MetaP
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_2_2_MULTI_BIT_GROUP_2_KS_PBS_GAUSSIAN_2M128: MetaParameters =
@@ -325,7 +300,6 @@ pub const V1_4_META_PARAM_GPU_2_2_MULTI_BIT_GROUP_2_KS_PBS_GAUSSIAN_2M128: MetaP
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_3_3_MULTI_BIT_GROUP_2_KS_PBS_GAUSSIAN_2M128: MetaParameters =
@@ -337,7 +311,6 @@ pub const V1_4_META_PARAM_GPU_3_3_MULTI_BIT_GROUP_2_KS_PBS_GAUSSIAN_2M128: MetaP
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_4_4_MULTI_BIT_GROUP_2_KS_PBS_GAUSSIAN_2M128: MetaParameters =
@@ -349,7 +322,6 @@ pub const V1_4_META_PARAM_GPU_4_4_MULTI_BIT_GROUP_2_KS_PBS_GAUSSIAN_2M128: MetaP
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_1_1_MULTI_BIT_GROUP_3_KS_PBS_GAUSSIAN_2M128: MetaParameters =
@@ -361,7 +333,6 @@ pub const V1_4_META_PARAM_GPU_1_1_MULTI_BIT_GROUP_3_KS_PBS_GAUSSIAN_2M128: MetaP
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_2_2_MULTI_BIT_GROUP_3_KS_PBS_GAUSSIAN_2M128: MetaParameters =
@@ -373,7 +344,6 @@ pub const V1_4_META_PARAM_GPU_2_2_MULTI_BIT_GROUP_3_KS_PBS_GAUSSIAN_2M128: MetaP
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_3_3_MULTI_BIT_GROUP_3_KS_PBS_GAUSSIAN_2M128: MetaParameters =
@@ -385,7 +355,6 @@ pub const V1_4_META_PARAM_GPU_3_3_MULTI_BIT_GROUP_3_KS_PBS_GAUSSIAN_2M128: MetaP
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_4_4_MULTI_BIT_GROUP_3_KS_PBS_GAUSSIAN_2M128: MetaParameters =
@@ -397,7 +366,6 @@ pub const V1_4_META_PARAM_GPU_4_4_MULTI_BIT_GROUP_3_KS_PBS_GAUSSIAN_2M128: MetaP
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_1_1_MULTI_BIT_GROUP_4_KS_PBS_GAUSSIAN_2M128: MetaParameters =
@@ -409,7 +377,6 @@ pub const V1_4_META_PARAM_GPU_1_1_MULTI_BIT_GROUP_4_KS_PBS_GAUSSIAN_2M128: MetaP
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_2_2_MULTI_BIT_GROUP_4_KS_PBS_GAUSSIAN_2M128: MetaParameters =
@@ -423,7 +390,6 @@ pub const V1_4_META_PARAM_GPU_2_2_MULTI_BIT_GROUP_4_KS_PBS_GAUSSIAN_2M128: MetaP
             V1_4_COMP_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_GAUSSIAN_2M128,
         ),
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_3_3_MULTI_BIT_GROUP_4_KS_PBS_GAUSSIAN_2M128: MetaParameters =
@@ -435,7 +401,6 @@ pub const V1_4_META_PARAM_GPU_3_3_MULTI_BIT_GROUP_4_KS_PBS_GAUSSIAN_2M128: MetaP
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_4_4_MULTI_BIT_GROUP_4_KS_PBS_GAUSSIAN_2M128: MetaParameters =
@@ -447,7 +412,6 @@ pub const V1_4_META_PARAM_GPU_4_4_MULTI_BIT_GROUP_4_KS_PBS_GAUSSIAN_2M128: MetaP
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_1_1_MULTI_BIT_GROUP_2_KS_PBS_TUNIFORM_2M40: MetaParameters =
@@ -459,7 +423,6 @@ pub const V1_4_META_PARAM_GPU_1_1_MULTI_BIT_GROUP_2_KS_PBS_TUNIFORM_2M40: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_2_2_MULTI_BIT_GROUP_2_KS_PBS_TUNIFORM_2M40: MetaParameters =
@@ -471,7 +434,6 @@ pub const V1_4_META_PARAM_GPU_2_2_MULTI_BIT_GROUP_2_KS_PBS_TUNIFORM_2M40: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_3_3_MULTI_BIT_GROUP_2_KS_PBS_TUNIFORM_2M40: MetaParameters =
@@ -483,7 +445,6 @@ pub const V1_4_META_PARAM_GPU_3_3_MULTI_BIT_GROUP_2_KS_PBS_TUNIFORM_2M40: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_4_4_MULTI_BIT_GROUP_2_KS_PBS_TUNIFORM_2M40: MetaParameters =
@@ -495,7 +456,6 @@ pub const V1_4_META_PARAM_GPU_4_4_MULTI_BIT_GROUP_2_KS_PBS_TUNIFORM_2M40: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_1_1_MULTI_BIT_GROUP_3_KS_PBS_TUNIFORM_2M40: MetaParameters =
@@ -507,7 +467,6 @@ pub const V1_4_META_PARAM_GPU_1_1_MULTI_BIT_GROUP_3_KS_PBS_TUNIFORM_2M40: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_2_2_MULTI_BIT_GROUP_3_KS_PBS_TUNIFORM_2M40: MetaParameters =
@@ -519,7 +478,6 @@ pub const V1_4_META_PARAM_GPU_2_2_MULTI_BIT_GROUP_3_KS_PBS_TUNIFORM_2M40: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_3_3_MULTI_BIT_GROUP_3_KS_PBS_TUNIFORM_2M40: MetaParameters =
@@ -531,7 +489,6 @@ pub const V1_4_META_PARAM_GPU_3_3_MULTI_BIT_GROUP_3_KS_PBS_TUNIFORM_2M40: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_4_4_MULTI_BIT_GROUP_3_KS_PBS_TUNIFORM_2M40: MetaParameters =
@@ -543,7 +500,6 @@ pub const V1_4_META_PARAM_GPU_4_4_MULTI_BIT_GROUP_3_KS_PBS_TUNIFORM_2M40: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_1_1_MULTI_BIT_GROUP_4_KS_PBS_TUNIFORM_2M40: MetaParameters =
@@ -555,7 +511,6 @@ pub const V1_4_META_PARAM_GPU_1_1_MULTI_BIT_GROUP_4_KS_PBS_TUNIFORM_2M40: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_2_2_MULTI_BIT_GROUP_4_KS_PBS_TUNIFORM_2M40: MetaParameters =
@@ -567,7 +522,6 @@ pub const V1_4_META_PARAM_GPU_2_2_MULTI_BIT_GROUP_4_KS_PBS_TUNIFORM_2M40: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_3_3_MULTI_BIT_GROUP_4_KS_PBS_TUNIFORM_2M40: MetaParameters =
@@ -579,7 +533,6 @@ pub const V1_4_META_PARAM_GPU_3_3_MULTI_BIT_GROUP_4_KS_PBS_TUNIFORM_2M40: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_4_4_MULTI_BIT_GROUP_4_KS_PBS_TUNIFORM_2M40: MetaParameters =
@@ -591,7 +544,6 @@ pub const V1_4_META_PARAM_GPU_4_4_MULTI_BIT_GROUP_4_KS_PBS_TUNIFORM_2M40: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_1_1_MULTI_BIT_GROUP_2_KS_PBS_TUNIFORM_2M64: MetaParameters =
@@ -603,7 +555,6 @@ pub const V1_4_META_PARAM_GPU_1_1_MULTI_BIT_GROUP_2_KS_PBS_TUNIFORM_2M64: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_2_2_MULTI_BIT_GROUP_2_KS_PBS_TUNIFORM_2M64: MetaParameters =
@@ -615,7 +566,6 @@ pub const V1_4_META_PARAM_GPU_2_2_MULTI_BIT_GROUP_2_KS_PBS_TUNIFORM_2M64: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_3_3_MULTI_BIT_GROUP_2_KS_PBS_TUNIFORM_2M64: MetaParameters =
@@ -627,7 +577,6 @@ pub const V1_4_META_PARAM_GPU_3_3_MULTI_BIT_GROUP_2_KS_PBS_TUNIFORM_2M64: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_4_4_MULTI_BIT_GROUP_2_KS_PBS_TUNIFORM_2M64: MetaParameters =
@@ -639,7 +588,6 @@ pub const V1_4_META_PARAM_GPU_4_4_MULTI_BIT_GROUP_2_KS_PBS_TUNIFORM_2M64: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_1_1_MULTI_BIT_GROUP_3_KS_PBS_TUNIFORM_2M64: MetaParameters =
@@ -651,7 +599,6 @@ pub const V1_4_META_PARAM_GPU_1_1_MULTI_BIT_GROUP_3_KS_PBS_TUNIFORM_2M64: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_2_2_MULTI_BIT_GROUP_3_KS_PBS_TUNIFORM_2M64: MetaParameters =
@@ -663,7 +610,6 @@ pub const V1_4_META_PARAM_GPU_2_2_MULTI_BIT_GROUP_3_KS_PBS_TUNIFORM_2M64: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_3_3_MULTI_BIT_GROUP_3_KS_PBS_TUNIFORM_2M64: MetaParameters =
@@ -675,7 +621,6 @@ pub const V1_4_META_PARAM_GPU_3_3_MULTI_BIT_GROUP_3_KS_PBS_TUNIFORM_2M64: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_4_4_MULTI_BIT_GROUP_3_KS_PBS_TUNIFORM_2M64: MetaParameters =
@@ -687,7 +632,6 @@ pub const V1_4_META_PARAM_GPU_4_4_MULTI_BIT_GROUP_3_KS_PBS_TUNIFORM_2M64: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_1_1_MULTI_BIT_GROUP_4_KS_PBS_TUNIFORM_2M64: MetaParameters =
@@ -699,7 +643,6 @@ pub const V1_4_META_PARAM_GPU_1_1_MULTI_BIT_GROUP_4_KS_PBS_TUNIFORM_2M64: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_2_2_MULTI_BIT_GROUP_4_KS_PBS_TUNIFORM_2M64: MetaParameters =
@@ -713,7 +656,6 @@ pub const V1_4_META_PARAM_GPU_2_2_MULTI_BIT_GROUP_4_KS_PBS_TUNIFORM_2M64: MetaPa
             V1_4_COMP_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64,
         ),
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_3_3_MULTI_BIT_GROUP_4_KS_PBS_TUNIFORM_2M64: MetaParameters =
@@ -725,7 +667,6 @@ pub const V1_4_META_PARAM_GPU_3_3_MULTI_BIT_GROUP_4_KS_PBS_TUNIFORM_2M64: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_4_4_MULTI_BIT_GROUP_4_KS_PBS_TUNIFORM_2M64: MetaParameters =
@@ -737,7 +678,6 @@ pub const V1_4_META_PARAM_GPU_4_4_MULTI_BIT_GROUP_4_KS_PBS_TUNIFORM_2M64: MetaPa
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_1_1_MULTI_BIT_GROUP_2_KS_PBS_TUNIFORM_2M128: MetaParameters =
@@ -749,7 +689,6 @@ pub const V1_4_META_PARAM_GPU_1_1_MULTI_BIT_GROUP_2_KS_PBS_TUNIFORM_2M128: MetaP
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_2_2_MULTI_BIT_GROUP_2_KS_PBS_TUNIFORM_2M128: MetaParameters =
@@ -761,7 +700,6 @@ pub const V1_4_META_PARAM_GPU_2_2_MULTI_BIT_GROUP_2_KS_PBS_TUNIFORM_2M128: MetaP
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_3_3_MULTI_BIT_GROUP_2_KS_PBS_TUNIFORM_2M128: MetaParameters =
@@ -773,7 +711,6 @@ pub const V1_4_META_PARAM_GPU_3_3_MULTI_BIT_GROUP_2_KS_PBS_TUNIFORM_2M128: MetaP
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_4_4_MULTI_BIT_GROUP_2_KS_PBS_TUNIFORM_2M128: MetaParameters =
@@ -785,7 +722,6 @@ pub const V1_4_META_PARAM_GPU_4_4_MULTI_BIT_GROUP_2_KS_PBS_TUNIFORM_2M128: MetaP
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_1_1_MULTI_BIT_GROUP_3_KS_PBS_TUNIFORM_2M128: MetaParameters =
@@ -797,7 +733,6 @@ pub const V1_4_META_PARAM_GPU_1_1_MULTI_BIT_GROUP_3_KS_PBS_TUNIFORM_2M128: MetaP
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_2_2_MULTI_BIT_GROUP_3_KS_PBS_TUNIFORM_2M128: MetaParameters =
@@ -809,7 +744,6 @@ pub const V1_4_META_PARAM_GPU_2_2_MULTI_BIT_GROUP_3_KS_PBS_TUNIFORM_2M128: MetaP
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_3_3_MULTI_BIT_GROUP_3_KS_PBS_TUNIFORM_2M128: MetaParameters =
@@ -821,7 +755,6 @@ pub const V1_4_META_PARAM_GPU_3_3_MULTI_BIT_GROUP_3_KS_PBS_TUNIFORM_2M128: MetaP
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_4_4_MULTI_BIT_GROUP_3_KS_PBS_TUNIFORM_2M128: MetaParameters =
@@ -833,7 +766,6 @@ pub const V1_4_META_PARAM_GPU_4_4_MULTI_BIT_GROUP_3_KS_PBS_TUNIFORM_2M128: MetaP
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_1_1_MULTI_BIT_GROUP_4_KS_PBS_TUNIFORM_2M128: MetaParameters =
@@ -845,7 +777,6 @@ pub const V1_4_META_PARAM_GPU_1_1_MULTI_BIT_GROUP_4_KS_PBS_TUNIFORM_2M128: MetaP
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_2_2_MULTI_BIT_GROUP_4_KS_PBS_PKE_TO_BIG_ZKV2_TUNIFORM_2M128: MetaParameters =
@@ -858,7 +789,10 @@ pub const V1_4_META_PARAM_GPU_2_2_MULTI_BIT_GROUP_4_KS_PBS_PKE_TO_BIG_ZKV2_TUNIF
             pke_params: V1_4_PARAM_PKE_TO_BIG_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128_ZKV2,
             ksk_params:
                 V1_4_PARAM_MULTI_BIT_GROUP_4_KEYSWITCH_PKE_TO_BIG_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
-        }),        compression_parameters: Some(
+            re_randomization_parameters: Some(V1_4_PARAM_MULTI_BIT_GROUP_4_KEYSWITCH_PKE_TO_BIG_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128),
+
+        }),
+        compression_parameters: Some(
             V1_4_COMP_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
         ),
         noise_squashing_parameters: Some(MetaNoiseSquashingParameters {
@@ -867,7 +801,6 @@ pub const V1_4_META_PARAM_GPU_2_2_MULTI_BIT_GROUP_4_KS_PBS_PKE_TO_BIG_ZKV2_TUNIF
                 V1_4_NOISE_SQUASHING_COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
             ),
         }),
-        re_randomization_parameters: Some(V1_4_PARAM_MULTI_BIT_GROUP_4_KEYSWITCH_PKE_TO_BIG_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128),
     };
 
 pub const V1_4_META_PARAM_GPU_2_2_MULTI_BIT_GROUP_4_KS_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128: MetaParameters =
@@ -880,6 +813,7 @@ pub const V1_4_META_PARAM_GPU_2_2_MULTI_BIT_GROUP_4_KS_PBS_PKE_TO_SMALL_ZKV2_TUN
             pke_params: V1_4_PARAM_PKE_TO_SMALL_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128_ZKV2,
             ksk_params:
                 V1_4_PARAM_MULTI_BIT_GROUP_4_KEYSWITCH_PKE_TO_SMALL_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+            re_randomization_parameters: Some(V1_4_PARAM_MULTI_BIT_GROUP_4_KEYSWITCH_PKE_TO_BIG_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128),
         }),
         compression_parameters: Some(
             V1_4_COMP_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
@@ -890,7 +824,6 @@ pub const V1_4_META_PARAM_GPU_2_2_MULTI_BIT_GROUP_4_KS_PBS_PKE_TO_SMALL_ZKV2_TUN
                 V1_4_NOISE_SQUASHING_COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
             ),
         }),
-        re_randomization_parameters: Some(V1_4_PARAM_MULTI_BIT_GROUP_4_KEYSWITCH_PKE_TO_BIG_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128),
     };
 
 pub const V1_4_META_PARAM_GPU_3_3_MULTI_BIT_GROUP_4_KS_PBS_TUNIFORM_2M128: MetaParameters =
@@ -902,7 +835,6 @@ pub const V1_4_META_PARAM_GPU_3_3_MULTI_BIT_GROUP_4_KS_PBS_TUNIFORM_2M128: MetaP
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };
 
 pub const V1_4_META_PARAM_GPU_4_4_MULTI_BIT_GROUP_4_KS_PBS_TUNIFORM_2M128: MetaParameters =
@@ -914,5 +846,4 @@ pub const V1_4_META_PARAM_GPU_4_4_MULTI_BIT_GROUP_4_KS_PBS_TUNIFORM_2M128: MetaP
         dedicated_compact_public_key_parameters: None,
         compression_parameters: None,
         noise_squashing_parameters: None,
-        re_randomization_parameters: None,
     };


### PR DESCRIPTION
Re-Randomization is something that requires a
dedicated public key.

Thus we move the parameters of the KSK
into the struct for dedicated PKE parameters

BREAKING CHANGE: This is breaking change regarding the latest alpha
released. But MetaParameters did not seem to be used directly in
fhevm/kms

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/2844)
<!-- Reviewable:end -->
