### PR TITLE
feat(shortint): add ct compression for the ks32 atomic pattern

### DIFF
--- a/tfhe/src/high_level_api/compressed_ciphertext_list.rs
+++ b/tfhe/src/high_level_api/compressed_ciphertext_list.rs
@@ -957,13 +957,18 @@ pub mod gpu {
 mod tests {
     use crate::prelude::*;
     use crate::safe_serialization::{safe_deserialize, safe_serialize};
+    #[cfg(not(feature = "gpu"))]
+    use crate::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS32_PBS_TUNIFORM_2M128;
+    #[cfg(feature = "gpu")]
     use crate::shortint::parameters::{
         COMP_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
-        COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
         PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+    };
+    use crate::shortint::parameters::{
+        COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
         PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
     };
-    use crate::shortint::PBSParameters;
+    use crate::shortint::AtomicPatternParameters;
     #[cfg(feature = "gpu")]
     use crate::GpuIndex;
     use crate::{
@@ -974,26 +979,25 @@ mod tests {
     #[test]
     fn test_compressed_ct_list_cpu_gpu() {
         for (params, comp_params) in [
-            if cfg!(not(feature = "gpu")) {
-                (
-                    PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128.into(),
-                    COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
-                )
-            } else {
-                (
-                    crate::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128
-                        .into(),
-                    crate::shortint::parameters::COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
-                )
-            },
+            (
+                PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128.into(),
+                COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+            ),
+            #[cfg(not(feature = "gpu"))]
+            (
+                PARAM_MESSAGE_2_CARRY_2_KS32_PBS_TUNIFORM_2M128.into(),
+                COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+            ),
+            #[cfg(feature = "gpu")]
             (
                 PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128.into(),
                 COMP_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
             ),
         ] {
-            let config = crate::ConfigBuilder::with_custom_parameters::<PBSParameters>(params)
-                .enable_compression(comp_params)
-                .build();
+            let config =
+                crate::ConfigBuilder::with_custom_parameters::<AtomicPatternParameters>(params)
+                    .enable_compression(comp_params)
+                    .build();
 
             let ck = crate::ClientKey::generate(config);
             let sk = crate::CompressedServerKey::new(&ck);
@@ -1202,9 +1206,10 @@ mod tests {
                 COMP_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
             ),
         ] {
-            let config = crate::ConfigBuilder::with_custom_parameters::<PBSParameters>(params)
-                .enable_compression(comp_params)
-                .build();
+            let config =
+                crate::ConfigBuilder::with_custom_parameters::<AtomicPatternParameters>(params)
+                    .enable_compression(comp_params)
+                    .build();
 
             let ck = crate::ClientKey::generate(config);
             let sk = crate::CompressedServerKey::new(&ck);

--- a/tfhe/src/integer/ciphertext/compressed_ciphertext_list.rs
+++ b/tfhe/src/integer/ciphertext/compressed_ciphertext_list.rs
@@ -225,6 +225,7 @@ mod tests {
         TEST_COMP_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
         TEST_COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
         TEST_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+        TEST_PARAM_MESSAGE_2_CARRY_2_KS32_PBS_TUNIFORM_2M128,
         TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
     };
     use crate::shortint::ShortintParameterSet;
@@ -263,6 +264,10 @@ mod tests {
         for (params, comp_params) in [
             (
                 TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128.into(),
+                TEST_COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+            ),
+            (
+                TEST_PARAM_MESSAGE_2_CARRY_2_KS32_PBS_TUNIFORM_2M128.into(),
                 TEST_COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
             ),
             (

--- a/tfhe/src/integer/mod.rs
+++ b/tfhe/src/integer/mod.rs
@@ -175,7 +175,7 @@ where
             gen_keys_inner(shortint_parameters_set)
         } else {
             keycache::KEY_CACHE
-                .get_from_params(shortint_parameters_set.pbs_parameters().unwrap(), key_kind)
+                .get_from_params(shortint_parameters_set.ap_parameters().unwrap(), key_kind)
         }
     }
     #[cfg(all(not(test), not(feature = "internal-keycache")))]

--- a/tfhe/src/shortint/client_key/atomic_pattern/ks32.rs
+++ b/tfhe/src/shortint/client_key/atomic_pattern/ks32.rs
@@ -8,7 +8,13 @@ use crate::core_crypto::prelude::{
 use crate::shortint::backward_compatibility::client_key::atomic_pattern::KS32AtomicPatternClientKeyVersions;
 use crate::shortint::client_key::{GlweSecretKeyOwned, LweSecretKeyOwned, LweSecretKeyView};
 use crate::shortint::engine::ShortintEngine;
-use crate::shortint::parameters::{DynamicDistribution, KeySwitch32PBSParameters};
+use crate::shortint::list_compression::{
+    CompressedCompressionKey, CompressedDecompressionKey, CompressionKey, CompressionPrivateKeys,
+    DecompressionKey,
+};
+use crate::shortint::parameters::{
+    CompressionParameters, DynamicDistribution, KeySwitch32PBSParameters,
+};
 use crate::shortint::{AtomicPatternKind, ShortintParameterSet};
 
 use super::EncryptionAtomicPattern;
@@ -145,6 +151,48 @@ impl KS32AtomicPatternClientKey {
 
     pub fn small_lwe_secret_key(&self) -> LweSecretKeyView<'_, u32> {
         self.lwe_secret_key.as_view()
+    }
+
+    pub fn new_compression_key(
+        &self,
+        private_compression_key: &CompressionPrivateKeys,
+    ) -> CompressionKey {
+        private_compression_key.new_compression_key(&self.glwe_secret_key, self.parameters())
+    }
+
+    pub fn new_compressed_compression_key(
+        &self,
+        private_compression_key: &CompressionPrivateKeys,
+    ) -> CompressedCompressionKey {
+        private_compression_key
+            .new_compressed_compression_key(&self.glwe_secret_key, self.parameters())
+    }
+
+    pub fn new_decompression_key(
+        &self,
+        private_compression_key: &CompressionPrivateKeys,
+    ) -> DecompressionKey {
+        private_compression_key.new_decompression_key(&self.glwe_secret_key, self.parameters())
+    }
+
+    pub fn new_decompression_key_with_params(
+        &self,
+        private_compression_key: &CompressionPrivateKeys,
+        compression_params: CompressionParameters,
+    ) -> DecompressionKey {
+        private_compression_key.new_decompression_key_with_params(
+            &self.glwe_secret_key,
+            self.parameters(),
+            compression_params,
+        )
+    }
+
+    pub fn new_compressed_decompression_key(
+        &self,
+        private_compression_key: &CompressionPrivateKeys,
+    ) -> CompressedDecompressionKey {
+        private_compression_key
+            .new_compressed_decompression_key(&self.glwe_secret_key, self.parameters())
     }
 }
 

--- a/tfhe/src/shortint/client_key/atomic_pattern/mod.rs
+++ b/tfhe/src/shortint/client_key/atomic_pattern/mod.rs
@@ -6,7 +6,11 @@ use tfhe_versionable::Versionize;
 
 use crate::shortint::backward_compatibility::client_key::atomic_pattern::AtomicPatternClientKeyVersions;
 use crate::shortint::engine::ShortintEngine;
-use crate::shortint::parameters::DynamicDistribution;
+use crate::shortint::list_compression::{
+    CompressedCompressionKey, CompressedDecompressionKey, CompressionKey, CompressionPrivateKeys,
+    DecompressionKey,
+};
+use crate::shortint::parameters::{CompressionParameters, DynamicDistribution};
 use crate::shortint::{AtomicPatternKind, AtomicPatternParameters, ShortintParameterSet};
 
 use super::{LweSecretKeyOwned, LweSecretKeyView};
@@ -100,6 +104,70 @@ impl AtomicPatternClientKey {
             AtomicPatternParameters::KeySwitch32(ap_params) => Ok(Self::KeySwitch32(
                 KS32AtomicPatternClientKey::try_from_lwe_encryption_key(encryption_key, ap_params)?,
             )),
+        }
+    }
+
+    pub fn new_compression_key(
+        &self,
+        private_compression_key: &CompressionPrivateKeys,
+    ) -> CompressionKey {
+        match self {
+            Self::Standard(std_cks) => std_cks.new_compression_key(private_compression_key),
+            Self::KeySwitch32(ks32_cks) => ks32_cks.new_compression_key(private_compression_key),
+        }
+    }
+
+    pub fn new_compressed_compression_key(
+        &self,
+        private_compression_key: &CompressionPrivateKeys,
+    ) -> CompressedCompressionKey {
+        match self {
+            Self::Standard(std_cks) => {
+                std_cks.new_compressed_compression_key(private_compression_key)
+            }
+            Self::KeySwitch32(ks32_cks) => {
+                ks32_cks.new_compressed_compression_key(private_compression_key)
+            }
+        }
+    }
+
+    pub fn new_decompression_key(
+        &self,
+        private_compression_key: &CompressionPrivateKeys,
+    ) -> DecompressionKey {
+        match self {
+            Self::Standard(std_cks) => std_cks.new_decompression_key(private_compression_key),
+            Self::KeySwitch32(ks32_cks) => ks32_cks.new_decompression_key(private_compression_key),
+        }
+    }
+
+    /// Create a decompression key with different parameters than the one in the secret key.
+    ///
+    /// This allows for example to compress using cpu parameters and decompress with gpu parameters
+    pub fn new_decompression_key_with_params(
+        &self,
+        private_compression_key: &CompressionPrivateKeys,
+        compression_params: CompressionParameters,
+    ) -> DecompressionKey {
+        match self {
+            Self::Standard(std_cks) => std_cks
+                .new_decompression_key_with_params(private_compression_key, compression_params),
+            Self::KeySwitch32(ks32_cks) => ks32_cks
+                .new_decompression_key_with_params(private_compression_key, compression_params),
+        }
+    }
+
+    pub fn new_compressed_decompression_key(
+        &self,
+        private_compression_key: &CompressionPrivateKeys,
+    ) -> CompressedDecompressionKey {
+        match self {
+            Self::Standard(std_cks) => {
+                std_cks.new_compressed_decompression_key(private_compression_key)
+            }
+            Self::KeySwitch32(ks32_cks) => {
+                ks32_cks.new_compressed_decompression_key(private_compression_key)
+            }
         }
     }
 }

--- a/tfhe/src/shortint/client_key/atomic_pattern/standard.rs
+++ b/tfhe/src/shortint/client_key/atomic_pattern/standard.rs
@@ -8,7 +8,13 @@ use crate::core_crypto::prelude::{
 use crate::shortint::backward_compatibility::client_key::atomic_pattern::StandardAtomicPatternClientKeyVersions;
 use crate::shortint::client_key::{GlweSecretKeyOwned, LweSecretKeyOwned, LweSecretKeyView};
 use crate::shortint::engine::ShortintEngine;
-use crate::shortint::parameters::{DynamicDistribution, ShortintKeySwitchingParameters};
+use crate::shortint::list_compression::{
+    CompressedCompressionKey, CompressedDecompressionKey, CompressionKey, CompressionPrivateKeys,
+    DecompressionKey,
+};
+use crate::shortint::parameters::{
+    CompressionParameters, DynamicDistribution, ShortintKeySwitchingParameters,
+};
 use crate::shortint::{
     AtomicPatternKind, EncryptionKeyChoice, PBSParameters, ShortintParameterSet, WopbsParameters,
 };
@@ -236,6 +242,48 @@ impl StandardAtomicPatternClientKey {
                 self.parameters().lwe_noise_distribution(),
             ),
         }
+    }
+
+    pub fn new_compression_key(
+        &self,
+        private_compression_key: &CompressionPrivateKeys,
+    ) -> CompressionKey {
+        private_compression_key.new_compression_key(&self.glwe_secret_key, self.parameters())
+    }
+
+    pub fn new_compressed_compression_key(
+        &self,
+        private_compression_key: &CompressionPrivateKeys,
+    ) -> CompressedCompressionKey {
+        private_compression_key
+            .new_compressed_compression_key(&self.glwe_secret_key, self.parameters())
+    }
+
+    pub fn new_decompression_key(
+        &self,
+        private_compression_key: &CompressionPrivateKeys,
+    ) -> DecompressionKey {
+        private_compression_key.new_decompression_key(&self.glwe_secret_key, self.parameters())
+    }
+
+    pub fn new_decompression_key_with_params(
+        &self,
+        private_compression_key: &CompressionPrivateKeys,
+        compression_params: CompressionParameters,
+    ) -> DecompressionKey {
+        private_compression_key.new_decompression_key_with_params(
+            &self.glwe_secret_key,
+            self.parameters(),
+            compression_params,
+        )
+    }
+
+    pub fn new_compressed_decompression_key(
+        &self,
+        private_compression_key: &CompressionPrivateKeys,
+    ) -> CompressedDecompressionKey {
+        private_compression_key
+            .new_compressed_decompression_key(&self.glwe_secret_key, self.parameters())
     }
 }
 

--- a/tfhe/src/shortint/list_compression/server_keys.rs
+++ b/tfhe/src/shortint/list_compression/server_keys.rs
@@ -7,7 +7,6 @@ use crate::shortint::atomic_pattern::AtomicPatternParameters;
 use crate::shortint::backward_compatibility::list_compression::{
     CompressionKeyVersions, DecompressionKeyVersions, NoiseSquashingCompressionKeyVersions,
 };
-use crate::shortint::client_key::atomic_pattern::AtomicPatternClientKey;
 use crate::shortint::client_key::ClientKey;
 use crate::shortint::engine::ShortintEngine;
 use crate::shortint::list_compression::CompressedNoiseSquashingCompressionKey;
@@ -16,7 +15,6 @@ use crate::shortint::parameters::{
     CompressionParameters, NoiseSquashingCompressionParameters, NoiseSquashingParameters,
     PolynomialSize,
 };
-use crate::shortint::EncryptionKeyChoice;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 use tfhe_versionable::Versionize;
@@ -47,93 +45,28 @@ impl DecompressionKey {
 }
 
 impl ClientKey {
-    pub(crate) fn new_decompression_key_with_params(
+    /// Create a decompression key with different parameters than the one in the secret key.
+    ///
+    /// This allows for example to compress using cpu parameters and decompress with gpu parameters
+    pub fn new_decompression_key_with_params(
         &self,
         private_compression_key: &CompressionPrivateKeys,
         compression_params: CompressionParameters,
     ) -> DecompressionKey {
-        let AtomicPatternClientKey::Standard(std_cks) = &self.atomic_pattern else {
-            panic!("Only the standard atomic pattern supports compression")
-        };
-
-        let pbs_params = std_cks.parameters;
-
-        assert_eq!(
-            pbs_params.encryption_key_choice(),
-            EncryptionKeyChoice::Big,
-            "Compression is only compatible with ciphertext in post PBS dimension"
-        );
-
-        let blind_rotate_key = ShortintEngine::with_thread_local_mut(|engine| {
-            engine.new_classic_bootstrapping_key(
-                &private_compression_key
-                    .post_packing_ks_key
-                    .as_lwe_secret_key(),
-                &std_cks.glwe_secret_key,
-                pbs_params.glwe_noise_distribution(),
-                compression_params.br_base_log,
-                compression_params.br_level,
-                pbs_params.ciphertext_modulus(),
-            )
-        });
-
-        DecompressionKey {
-            blind_rotate_key,
-            lwe_per_glwe: compression_params.lwe_per_glwe,
-        }
+        self.atomic_pattern
+            .new_decompression_key_with_params(private_compression_key, compression_params)
     }
 
     pub fn new_compression_decompression_keys(
         &self,
         private_compression_key: &CompressionPrivateKeys,
     ) -> (CompressionKey, DecompressionKey) {
-        let AtomicPatternClientKey::Standard(std_cks) = &self.atomic_pattern else {
-            panic!("Only the standard atomic pattern supports compression")
-        };
-
-        let pbs_params = std_cks.parameters;
-
-        assert_eq!(
-            pbs_params.encryption_key_choice(),
-            EncryptionKeyChoice::Big,
-            "Compression is only compatible with ciphertext in post PBS dimension"
-        );
-
-        let compression_params = &private_compression_key.params;
-
-        assert!(
-            compression_params.storage_log_modulus.0
-                <= pbs_params
-                    .polynomial_size()
-                    .to_blind_rotation_input_modulus_log()
-                    .0,
-            "Compression parameters say to store more bits than useful"
-        );
-
-        let packing_key_switching_key = ShortintEngine::with_thread_local_mut(|engine| {
-            allocate_and_generate_new_lwe_packing_keyswitch_key(
-                &std_cks.large_lwe_secret_key(),
-                &private_compression_key.post_packing_ks_key,
-                compression_params.packing_ks_base_log,
-                compression_params.packing_ks_level,
-                compression_params.packing_ks_key_noise_distribution,
-                pbs_params.ciphertext_modulus(),
-                &mut engine.encryption_generator,
-            )
-        });
-
-        let glwe_compression_key = CompressionKey {
-            packing_key_switching_key,
-            lwe_per_glwe: compression_params.lwe_per_glwe,
-            storage_log_modulus: compression_params.storage_log_modulus,
-        };
-
-        let glwe_decompression_key = self.new_decompression_key_with_params(
-            private_compression_key,
-            private_compression_key.params,
-        );
-
-        (glwe_compression_key, glwe_decompression_key)
+        (
+            self.atomic_pattern
+                .new_compression_key(private_compression_key),
+            self.atomic_pattern
+                .new_decompression_key(private_compression_key),
+        )
     }
 }
 


### PR DESCRIPTION
this was almost already supported out of the box. We just needed to extract the glwe key but since compression is only supported for EncryptionKeyChoice::Big, this is actually the sks.encryption_key() which is available for all ap.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/2849)
<!-- Reviewable:end -->
