### PR TITLE
chore(hlapi): export CompressedKVStore

### DIFF
--- a/tfhe/src/high_level_api/mod.rs
+++ b/tfhe/src/high_level_api/mod.rs
@@ -141,7 +141,7 @@ pub use tag::Tag;
 pub use traits::FheId;
 pub mod xof_key_set;
 
-pub use kv_store::KVStore;
+pub use kv_store::{CompressedKVStore, KVStore};
 
 mod booleans;
 mod compressed_ciphertext_list;


### PR DESCRIPTION
Without this, users cannot use the CompressedKVStore type that is required in the KVStore deserialization


