### PR TITLE
chore(gpu): remove use of duplicate async in hl api and non async integer ops

### DIFF
--- a/tfhe/src/high_level_api/booleans/squashed_noise.rs
+++ b/tfhe/src/high_level_api/booleans/squashed_noise.rs
@@ -269,15 +269,7 @@ impl SquashNoise for FheBool {
                     .ok_or(UninitializedNoiseSquashing)?;
 
                 let cuda_block = CudaBooleanBlock(match self.ciphertext.on_gpu(streams) {
-                    MaybeCloned::Borrowed(gpu_ct) => {
-                        unsafe {
-                            // SAFETY
-                            // The gpu_ct is a ref, meaning it belongs to the thing
-                            // that is being iterated on, so it will stay alive for the
-                            // whole function
-                            gpu_ct.duplicate_async(streams)
-                        }
-                    }
+                    MaybeCloned::Borrowed(gpu_ct) => gpu_ct.duplicate(streams),
                     MaybeCloned::Cloned(gpu_ct) => gpu_ct,
                 });
                 let cuda_squashed_block = noise_squashing_key.squash_boolean_block_noise(

--- a/tfhe/src/high_level_api/integers/signed/ops.rs
+++ b/tfhe/src/high_level_api/integers/signed/ops.rs
@@ -81,42 +81,30 @@ where
             }
             #[cfg(feature = "gpu")]
             InternalServerKey::Cuda(cuda_key) => {
-                {
-                    let streams = &cuda_key.streams;
-                    let cts = iter
-                        .map(|fhe_uint| {
-                            match fhe_uint.ciphertext.on_gpu(streams) {
-                                MaybeCloned::Borrowed(gpu_ct) => {
-                                    unsafe {
-                                        // SAFETY
-                                        // The gpu_ct is a ref, meaning it belongs to the thing
-                                        // that is being iterated on, so it will stay alive for the
-                                        // whole function
-                                        gpu_ct.duplicate_async(streams)
-                                    }
-                                }
-                                MaybeCloned::Cloned(gpu_ct) => gpu_ct,
-                            }
-                        })
-                        .collect::<Vec<_>>();
+                let streams = &cuda_key.streams;
+                let cts = iter
+                    .map(|fhe_uint| match fhe_uint.ciphertext.on_gpu(streams) {
+                        MaybeCloned::Borrowed(gpu_ct) => gpu_ct.duplicate(streams),
+                        MaybeCloned::Cloned(gpu_ct) => gpu_ct,
+                    })
+                    .collect::<Vec<_>>();
 
-                    let inner = cuda_key
-                        .key
-                        .key
-                        .sum_ciphertexts(cts, streams)
-                        .unwrap_or_else(|| {
-                            cuda_key.key.key.create_trivial_radix(
-                                0,
-                                Id::num_blocks(cuda_key.message_modulus()),
-                                streams,
-                            )
-                        });
-                    Self::new(
-                        inner,
-                        cuda_key.tag.clone(),
-                        ReRandomizationMetadata::default(),
-                    )
-                }
+                let inner = cuda_key
+                    .key
+                    .key
+                    .sum_ciphertexts(cts, streams)
+                    .unwrap_or_else(|| {
+                        cuda_key.key.key.create_trivial_radix(
+                            0,
+                            Id::num_blocks(cuda_key.message_modulus()),
+                            streams,
+                        )
+                    });
+                Self::new(
+                    inner,
+                    cuda_key.tag.clone(),
+                    ReRandomizationMetadata::default(),
+                )
             }
             #[cfg(feature = "hpu")]
             InternalServerKey::Hpu(_device) => {

--- a/tfhe/src/integer/gpu/ciphertext/compact_list.rs
+++ b/tfhe/src/integer/gpu/ciphertext/compact_list.rs
@@ -283,6 +283,7 @@ impl CudaFlattenedVecCompactCiphertextList {
             }
             d_flattened_d_vec
         };
+        streams.synchronize();
 
         Self {
             d_flattened_vec: d_flattened_d_vec,

--- a/tfhe/src/integer/gpu/server_key/radix/abs.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/abs.rs
@@ -76,7 +76,7 @@ impl CudaServerKey {
     where
         T: CudaIntegerRadixCiphertext,
     {
-        let mut res = unsafe { ct.duplicate_async(streams) };
+        let mut res = ct.duplicate(streams);
         if T::IS_SIGNED {
             unsafe { self.unchecked_abs_assign_async(&mut res, streams) };
         }
@@ -134,7 +134,7 @@ impl CudaServerKey {
     where
         T: CudaIntegerRadixCiphertext,
     {
-        let mut res = unsafe { ct.duplicate_async(streams) };
+        let mut res = ct.duplicate(streams);
         if !ct.block_carries_are_empty() {
             unsafe { self.full_propagate_assign_async(&mut res, streams) };
         }

--- a/tfhe/src/integer/gpu/server_key/radix/add.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/add.rs
@@ -72,7 +72,7 @@ impl CudaServerKey {
         ct_right: &T,
         streams: &CudaStreams,
     ) -> T {
-        let mut result = unsafe { ct_left.duplicate_async(streams) };
+        let mut result = ct_left.duplicate(streams);
         self.add_assign(&mut result, ct_right, streams);
         result
     }
@@ -104,7 +104,7 @@ impl CudaServerKey {
         ) {
             (true, true) => (ct_left, ct_right),
             (true, false) => {
-                tmp_rhs = ct_right.duplicate_async(streams);
+                tmp_rhs = ct_right.duplicate(streams);
                 self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (ct_left, &tmp_rhs)
             }
@@ -113,7 +113,7 @@ impl CudaServerKey {
                 (ct_left, ct_right)
             }
             (false, false) => {
-                tmp_rhs = ct_right.duplicate_async(streams);
+                tmp_rhs = ct_right.duplicate(streams);
 
                 self.full_propagate_assign_async(ct_left, streams);
                 self.full_propagate_assign_async(&mut tmp_rhs, streams);
@@ -281,7 +281,7 @@ impl CudaServerKey {
         ct_right: &T,
         streams: &CudaStreams,
     ) -> T {
-        let mut result = unsafe { ct_left.duplicate_async(streams) };
+        let mut result = ct_left.duplicate(streams);
         self.unchecked_add_assign(&mut result, ct_right, streams);
         result
     }
@@ -482,7 +482,7 @@ impl CudaServerKey {
             return None;
         }
 
-        let mut result = unsafe { ciphertexts[0].duplicate_async(streams) };
+        let mut result = ciphertexts[0].duplicate(streams);
 
         if ciphertexts.len() == 1 {
             streams.synchronize();
@@ -585,22 +585,22 @@ impl CudaServerKey {
             (true, true) => (ct_left, ct_right),
             (true, false) => {
                 unsafe {
-                    tmp_rhs = ct_right.duplicate_async(stream);
+                    tmp_rhs = ct_right.duplicate(stream);
                     self.full_propagate_assign_async(&mut tmp_rhs, stream);
                 }
                 (ct_left, &tmp_rhs)
             }
             (false, true) => {
                 unsafe {
-                    tmp_lhs = ct_left.duplicate_async(stream);
+                    tmp_lhs = ct_left.duplicate(stream);
                     self.full_propagate_assign_async(&mut tmp_lhs, stream);
                 }
                 (&tmp_lhs, ct_right)
             }
             (false, false) => {
                 unsafe {
-                    tmp_lhs = ct_left.duplicate_async(stream);
-                    tmp_rhs = ct_right.duplicate_async(stream);
+                    tmp_lhs = ct_left.duplicate(stream);
+                    tmp_rhs = ct_right.duplicate(stream);
 
                     self.full_propagate_assign_async(&mut tmp_lhs, stream);
                     self.full_propagate_assign_async(&mut tmp_rhs, stream);
@@ -649,7 +649,7 @@ impl CudaServerKey {
     ) -> (CudaUnsignedRadixCiphertext, CudaBooleanBlock) {
         let output_flag = OutputFlag::from_signedness(CudaUnsignedRadixCiphertext::IS_SIGNED);
 
-        let mut ct_res = lhs.duplicate_async(stream);
+        let mut ct_res = lhs.duplicate(stream);
         let mut carry_out: CudaUnsignedRadixCiphertext = self
             .add_and_propagate_single_carry_assign_async(
                 &mut ct_res,
@@ -685,7 +685,7 @@ impl CudaServerKey {
     ) -> (CudaSignedRadixCiphertext, CudaBooleanBlock) {
         let output_flag = OutputFlag::from_signedness(CudaSignedRadixCiphertext::IS_SIGNED);
 
-        let mut ct_res = lhs.duplicate_async(stream);
+        let mut ct_res = lhs.duplicate(stream);
         let carry_out: CudaSignedRadixCiphertext = self
             .add_and_propagate_single_carry_assign_async(
                 &mut ct_res,
@@ -754,22 +754,22 @@ impl CudaServerKey {
             (true, true) => (ct_left, ct_right),
             (true, false) => {
                 unsafe {
-                    tmp_rhs = ct_right.duplicate_async(stream);
+                    tmp_rhs = ct_right.duplicate(stream);
                     self.full_propagate_assign_async(&mut tmp_rhs, stream);
                 }
                 (ct_left, &tmp_rhs)
             }
             (false, true) => {
                 unsafe {
-                    tmp_lhs = ct_left.duplicate_async(stream);
+                    tmp_lhs = ct_left.duplicate(stream);
                     self.full_propagate_assign_async(&mut tmp_lhs, stream);
                 }
                 (&tmp_lhs, ct_right)
             }
             (false, false) => {
                 unsafe {
-                    tmp_lhs = ct_left.duplicate_async(stream);
-                    tmp_rhs = ct_right.duplicate_async(stream);
+                    tmp_lhs = ct_left.duplicate(stream);
+                    tmp_rhs = ct_right.duplicate(stream);
 
                     self.full_propagate_assign_async(&mut tmp_lhs, stream);
                     self.full_propagate_assign_async(&mut tmp_rhs, stream);

--- a/tfhe/src/integer/gpu/server_key/radix/bitwise_op.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/bitwise_op.rs
@@ -59,7 +59,7 @@ impl CudaServerKey {
         ct: &T,
         streams: &CudaStreams,
     ) -> T {
-        let mut result = unsafe { ct.duplicate_async(streams) };
+        let mut result = ct.duplicate(streams);
         self.unchecked_bitnot_assign(&mut result, streams);
         result
     }
@@ -180,7 +180,7 @@ impl CudaServerKey {
         ct_right: &T,
         streams: &CudaStreams,
     ) -> T {
-        let mut result = unsafe { ct_left.duplicate_async(streams) };
+        let mut result = ct_left.duplicate(streams);
         self.unchecked_bitand_assign(&mut result, ct_right, streams);
         result
     }
@@ -440,7 +440,7 @@ impl CudaServerKey {
         ct_right: &T,
         streams: &CudaStreams,
     ) -> T {
-        let mut result = unsafe { ct_left.duplicate_async(streams) };
+        let mut result = ct_left.duplicate(streams);
         self.unchecked_bitor_assign(&mut result, ct_right, streams);
         result
     }
@@ -506,7 +506,7 @@ impl CudaServerKey {
         ct_right: &T,
         streams: &CudaStreams,
     ) -> T {
-        let mut result = unsafe { ct_left.duplicate_async(streams) };
+        let mut result = ct_left.duplicate(streams);
         self.unchecked_bitxor_assign(&mut result, ct_right, streams);
         result
     }
@@ -572,7 +572,7 @@ impl CudaServerKey {
         ct_right: &T,
         streams: &CudaStreams,
     ) -> T {
-        let mut result = unsafe { ct_left.duplicate_async(streams) };
+        let mut result = ct_left.duplicate(streams);
         self.bitand_assign(&mut result, ct_right, streams);
         result
     }
@@ -596,7 +596,7 @@ impl CudaServerKey {
             ) {
                 (true, true) => (ct_left, ct_right),
                 (true, false) => {
-                    tmp_rhs = ct_right.duplicate_async(streams);
+                    tmp_rhs = ct_right.duplicate(streams);
                     self.full_propagate_assign_async(&mut tmp_rhs, streams);
                     (ct_left, &tmp_rhs)
                 }
@@ -605,7 +605,7 @@ impl CudaServerKey {
                     (ct_left, ct_right)
                 }
                 (false, false) => {
-                    tmp_rhs = ct_right.duplicate_async(streams);
+                    tmp_rhs = ct_right.duplicate(streams);
 
                     self.full_propagate_assign_async(ct_left, streams);
                     self.full_propagate_assign_async(&mut tmp_rhs, streams);
@@ -677,7 +677,7 @@ impl CudaServerKey {
         ct_right: &T,
         streams: &CudaStreams,
     ) -> T {
-        let mut result = unsafe { ct_left.duplicate_async(streams) };
+        let mut result = ct_left.duplicate(streams);
         self.bitor_assign(&mut result, ct_right, streams);
         result
     }
@@ -700,7 +700,7 @@ impl CudaServerKey {
         ) {
             (true, true) => (ct_left, ct_right),
             (true, false) => {
-                tmp_rhs = ct_right.duplicate_async(streams);
+                tmp_rhs = ct_right.duplicate(streams);
                 self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (ct_left, &tmp_rhs)
             }
@@ -709,7 +709,7 @@ impl CudaServerKey {
                 (ct_left, ct_right)
             }
             (false, false) => {
-                tmp_rhs = ct_right.duplicate_async(streams);
+                tmp_rhs = ct_right.duplicate(streams);
 
                 self.full_propagate_assign_async(ct_left, streams);
                 self.full_propagate_assign_async(&mut tmp_rhs, streams);
@@ -781,7 +781,7 @@ impl CudaServerKey {
         ct_right: &T,
         streams: &CudaStreams,
     ) -> T {
-        let mut result = unsafe { ct_left.duplicate_async(streams) };
+        let mut result = ct_left.duplicate(streams);
         self.bitxor_assign(&mut result, ct_right, streams);
         result
     }
@@ -804,7 +804,7 @@ impl CudaServerKey {
         ) {
             (true, true) => (ct_left, ct_right),
             (true, false) => {
-                tmp_rhs = ct_right.duplicate_async(streams);
+                tmp_rhs = ct_right.duplicate(streams);
                 self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (ct_left, &tmp_rhs)
             }
@@ -813,7 +813,7 @@ impl CudaServerKey {
                 (ct_left, ct_right)
             }
             (false, false) => {
-                tmp_rhs = ct_right.duplicate_async(streams);
+                tmp_rhs = ct_right.duplicate(streams);
 
                 self.full_propagate_assign_async(ct_left, streams);
                 self.full_propagate_assign_async(&mut tmp_rhs, streams);
@@ -877,7 +877,7 @@ impl CudaServerKey {
     /// assert_eq!(dec, !msg % 256);
     /// ```
     pub fn bitnot<T: CudaIntegerRadixCiphertext>(&self, ct: &T, streams: &CudaStreams) -> T {
-        let mut result = unsafe { ct.duplicate_async(streams) };
+        let mut result = ct.duplicate(streams);
         self.bitnot_assign(&mut result, streams);
         result
     }

--- a/tfhe/src/integer/gpu/server_key/radix/cmux.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/cmux.rs
@@ -116,7 +116,7 @@ impl CudaServerKey {
             if true_ct.block_carries_are_empty() {
                 true_ct
             } else {
-                tmp_true_ct = true_ct.duplicate_async(stream);
+                tmp_true_ct = true_ct.duplicate(stream);
                 self.full_propagate_assign_async(&mut tmp_true_ct, stream);
                 &tmp_true_ct
             }
@@ -126,7 +126,7 @@ impl CudaServerKey {
             if false_ct.block_carries_are_empty() {
                 false_ct
             } else {
-                tmp_false_ct = false_ct.duplicate_async(stream);
+                tmp_false_ct = false_ct.duplicate(stream);
                 self.full_propagate_assign_async(&mut tmp_false_ct, stream);
                 &tmp_false_ct
             }

--- a/tfhe/src/integer/gpu/server_key/radix/comparison.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/comparison.rs
@@ -277,18 +277,18 @@ impl CudaServerKey {
         ) {
             (true, true) => (ct_left, ct_right),
             (true, false) => {
-                tmp_rhs = ct_right.duplicate_async(streams);
+                tmp_rhs = ct_right.duplicate(streams);
                 self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (ct_left, &tmp_rhs)
             }
             (false, true) => {
-                tmp_lhs = ct_left.duplicate_async(streams);
+                tmp_lhs = ct_left.duplicate(streams);
                 self.full_propagate_assign_async(&mut tmp_lhs, streams);
                 (&tmp_lhs, ct_right)
             }
             (false, false) => {
-                tmp_lhs = ct_left.duplicate_async(streams);
-                tmp_rhs = ct_right.duplicate_async(streams);
+                tmp_lhs = ct_left.duplicate(streams);
+                tmp_rhs = ct_right.duplicate(streams);
 
                 self.full_propagate_assign_async(&mut tmp_lhs, streams);
                 self.full_propagate_assign_async(&mut tmp_rhs, streams);
@@ -487,18 +487,18 @@ impl CudaServerKey {
         ) {
             (true, true) => (ct_left, ct_right),
             (true, false) => {
-                tmp_rhs = ct_right.duplicate_async(streams);
+                tmp_rhs = ct_right.duplicate(streams);
                 self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (ct_left, &tmp_rhs)
             }
             (false, true) => {
-                tmp_lhs = ct_left.duplicate_async(streams);
+                tmp_lhs = ct_left.duplicate(streams);
                 self.full_propagate_assign_async(&mut tmp_lhs, streams);
                 (&tmp_lhs, ct_right)
             }
             (false, false) => {
-                tmp_lhs = ct_left.duplicate_async(streams);
-                tmp_rhs = ct_right.duplicate_async(streams);
+                tmp_lhs = ct_left.duplicate(streams);
+                tmp_rhs = ct_right.duplicate(streams);
 
                 self.full_propagate_assign_async(&mut tmp_lhs, streams);
                 self.full_propagate_assign_async(&mut tmp_rhs, streams);
@@ -666,18 +666,18 @@ impl CudaServerKey {
         ) {
             (true, true) => (ct_left, ct_right),
             (true, false) => {
-                tmp_rhs = ct_right.duplicate_async(streams);
+                tmp_rhs = ct_right.duplicate(streams);
                 self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (ct_left, &tmp_rhs)
             }
             (false, true) => {
-                tmp_lhs = ct_left.duplicate_async(streams);
+                tmp_lhs = ct_left.duplicate(streams);
                 self.full_propagate_assign_async(&mut tmp_lhs, streams);
                 (&tmp_lhs, ct_right)
             }
             (false, false) => {
-                tmp_lhs = ct_left.duplicate_async(streams);
-                tmp_rhs = ct_right.duplicate_async(streams);
+                tmp_lhs = ct_left.duplicate(streams);
+                tmp_rhs = ct_right.duplicate(streams);
 
                 self.full_propagate_assign_async(&mut tmp_lhs, streams);
                 self.full_propagate_assign_async(&mut tmp_rhs, streams);
@@ -774,18 +774,18 @@ impl CudaServerKey {
         ) {
             (true, true) => (ct_left, ct_right),
             (true, false) => {
-                tmp_rhs = ct_right.duplicate_async(streams);
+                tmp_rhs = ct_right.duplicate(streams);
                 self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (ct_left, &tmp_rhs)
             }
             (false, true) => {
-                tmp_lhs = ct_left.duplicate_async(streams);
+                tmp_lhs = ct_left.duplicate(streams);
                 self.full_propagate_assign_async(&mut tmp_lhs, streams);
                 (&tmp_lhs, ct_right)
             }
             (false, false) => {
-                tmp_lhs = ct_left.duplicate_async(streams);
-                tmp_rhs = ct_right.duplicate_async(streams);
+                tmp_lhs = ct_left.duplicate(streams);
+                tmp_rhs = ct_right.duplicate(streams);
 
                 self.full_propagate_assign_async(&mut tmp_lhs, streams);
                 self.full_propagate_assign_async(&mut tmp_rhs, streams);
@@ -898,18 +898,18 @@ impl CudaServerKey {
         ) {
             (true, true) => (ct_left, ct_right),
             (true, false) => {
-                tmp_rhs = ct_right.duplicate_async(streams);
+                tmp_rhs = ct_right.duplicate(streams);
                 self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (ct_left, &tmp_rhs)
             }
             (false, true) => {
-                tmp_lhs = ct_left.duplicate_async(streams);
+                tmp_lhs = ct_left.duplicate(streams);
                 self.full_propagate_assign_async(&mut tmp_lhs, streams);
                 (&tmp_lhs, ct_right)
             }
             (false, false) => {
-                tmp_lhs = ct_left.duplicate_async(streams);
-                tmp_rhs = ct_right.duplicate_async(streams);
+                tmp_lhs = ct_left.duplicate(streams);
+                tmp_rhs = ct_right.duplicate(streams);
 
                 self.full_propagate_assign_async(&mut tmp_lhs, streams);
                 self.full_propagate_assign_async(&mut tmp_rhs, streams);
@@ -1022,18 +1022,18 @@ impl CudaServerKey {
         ) {
             (true, true) => (ct_left, ct_right),
             (true, false) => {
-                tmp_rhs = ct_right.duplicate_async(streams);
+                tmp_rhs = ct_right.duplicate(streams);
                 self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (ct_left, &tmp_rhs)
             }
             (false, true) => {
-                tmp_lhs = ct_left.duplicate_async(streams);
+                tmp_lhs = ct_left.duplicate(streams);
                 self.full_propagate_assign_async(&mut tmp_lhs, streams);
                 (&tmp_lhs, ct_right)
             }
             (false, false) => {
-                tmp_lhs = ct_left.duplicate_async(streams);
-                tmp_rhs = ct_right.duplicate_async(streams);
+                tmp_lhs = ct_left.duplicate(streams);
+                tmp_rhs = ct_right.duplicate(streams);
 
                 self.full_propagate_assign_async(&mut tmp_lhs, streams);
                 self.full_propagate_assign_async(&mut tmp_rhs, streams);
@@ -1129,7 +1129,7 @@ impl CudaServerKey {
             ct_right.as_ref().d_blocks.lwe_ciphertext_count()
         );
 
-        let mut result = ct_left.duplicate_async(streams);
+        let mut result = ct_left.duplicate(streams);
 
         match &self.bootstrapping_key {
             CudaBootstrappingKey::Classic(d_bsk) => {
@@ -1225,7 +1225,7 @@ impl CudaServerKey {
             ct_right.as_ref().d_blocks.lwe_ciphertext_count()
         );
 
-        let mut result = ct_left.duplicate_async(streams);
+        let mut result = ct_left.duplicate(streams);
 
         match &self.bootstrapping_key {
             CudaBootstrappingKey::Classic(d_bsk) => {
@@ -1316,18 +1316,18 @@ impl CudaServerKey {
         ) {
             (true, true) => (ct_left, ct_right),
             (true, false) => {
-                tmp_rhs = ct_right.duplicate_async(streams);
+                tmp_rhs = ct_right.duplicate(streams);
                 self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (ct_left, &tmp_rhs)
             }
             (false, true) => {
-                tmp_lhs = ct_left.duplicate_async(streams);
+                tmp_lhs = ct_left.duplicate(streams);
                 self.full_propagate_assign_async(&mut tmp_lhs, streams);
                 (&tmp_lhs, ct_right)
             }
             (false, false) => {
-                tmp_lhs = ct_left.duplicate_async(streams);
-                tmp_rhs = ct_right.duplicate_async(streams);
+                tmp_lhs = ct_left.duplicate(streams);
+                tmp_rhs = ct_right.duplicate(streams);
 
                 self.full_propagate_assign_async(&mut tmp_lhs, streams);
                 self.full_propagate_assign_async(&mut tmp_rhs, streams);
@@ -1363,18 +1363,18 @@ impl CudaServerKey {
         ) {
             (true, true) => (ct_left, ct_right),
             (true, false) => {
-                tmp_rhs = ct_right.duplicate_async(streams);
+                tmp_rhs = ct_right.duplicate(streams);
                 self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (ct_left, &tmp_rhs)
             }
             (false, true) => {
-                tmp_lhs = ct_left.duplicate_async(streams);
+                tmp_lhs = ct_left.duplicate(streams);
                 self.full_propagate_assign_async(&mut tmp_lhs, streams);
                 (&tmp_lhs, ct_right)
             }
             (false, false) => {
-                tmp_lhs = ct_left.duplicate_async(streams);
-                tmp_rhs = ct_right.duplicate_async(streams);
+                tmp_lhs = ct_left.duplicate(streams);
+                tmp_rhs = ct_right.duplicate(streams);
 
                 self.full_propagate_assign_async(&mut tmp_lhs, streams);
                 self.full_propagate_assign_async(&mut tmp_rhs, streams);

--- a/tfhe/src/integer/gpu/server_key/radix/ilog2.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/ilog2.rs
@@ -402,7 +402,7 @@ impl CudaServerKey {
         let ct = if ct.block_carries_are_empty() {
             ct
         } else {
-            tmp = ct.duplicate_async(streams);
+            tmp = ct.duplicate(streams);
             self.full_propagate_assign_async(&mut tmp, streams);
             &tmp
         };
@@ -475,7 +475,7 @@ impl CudaServerKey {
         let ct = if ct.block_carries_are_empty() {
             ct
         } else {
-            tmp = ct.duplicate_async(streams);
+            tmp = ct.duplicate(streams);
             self.full_propagate_assign_async(&mut tmp, streams);
             &tmp
         };
@@ -548,7 +548,7 @@ impl CudaServerKey {
         let ct = if ct.block_carries_are_empty() {
             ct
         } else {
-            tmp = ct.duplicate_async(streams);
+            tmp = ct.duplicate(streams);
             self.full_propagate_assign_async(&mut tmp, streams);
             &tmp
         };
@@ -621,7 +621,7 @@ impl CudaServerKey {
         let ct = if ct.block_carries_are_empty() {
             ct
         } else {
-            tmp = ct.duplicate_async(streams);
+            tmp = ct.duplicate(streams);
             self.full_propagate_assign_async(&mut tmp, streams);
             &tmp
         };
@@ -687,7 +687,7 @@ impl CudaServerKey {
         let ct = if ct.block_carries_are_empty() {
             ct
         } else {
-            tmp = ct.duplicate_async(streams);
+            tmp = ct.duplicate(streams);
             self.full_propagate_assign_async(&mut tmp, streams);
             &tmp
         };
@@ -762,7 +762,7 @@ impl CudaServerKey {
         let ct = if ct.block_carries_are_empty() {
             ct
         } else {
-            tmp = ct.duplicate_async(streams);
+            tmp = ct.duplicate(streams);
             self.full_propagate_assign_async(&mut tmp, streams);
             &tmp
         };

--- a/tfhe/src/integer/gpu/server_key/radix/mod.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/mod.rs
@@ -413,7 +413,7 @@ impl CudaServerKey {
         streams: &CudaStreams,
     ) -> T {
         if num_blocks == 0 {
-            return ct.duplicate_async(streams);
+            return ct.duplicate(streams);
         }
         let new_num_blocks = ct.as_ref().d_blocks.lwe_ciphertext_count().0 + num_blocks;
         let ciphertext_modulus = ct.as_ref().d_blocks.ciphertext_modulus();
@@ -650,7 +650,7 @@ impl CudaServerKey {
         streams: &CudaStreams,
     ) -> T {
         if num_blocks == 0 {
-            return ct.duplicate_async(streams);
+            return ct.duplicate(streams);
         }
         let new_num_blocks = ct.as_ref().d_blocks.lwe_ciphertext_count().0 - num_blocks;
         let ciphertext_modulus = ct.as_ref().d_blocks.ciphertext_modulus();

--- a/tfhe/src/integer/gpu/server_key/radix/mul.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/mul.rs
@@ -59,7 +59,7 @@ impl CudaServerKey {
         ct_right: &T,
         streams: &CudaStreams,
     ) -> T {
-        let mut result = unsafe { ct_left.duplicate_async(streams) };
+        let mut result = ct_left.duplicate(streams);
         self.unchecked_mul_assign(&mut result, ct_right, streams);
         result
     }
@@ -193,7 +193,7 @@ impl CudaServerKey {
         ct_right: &T,
         streams: &CudaStreams,
     ) -> T {
-        let mut result = unsafe { ct_left.duplicate_async(streams) };
+        let mut result = ct_left.duplicate(streams);
         self.mul_assign(&mut result, ct_right, streams);
         result
     }
@@ -216,7 +216,7 @@ impl CudaServerKey {
         ) {
             (true, true) => (ct_left, ct_right),
             (true, false) => {
-                tmp_rhs = ct_right.duplicate_async(streams);
+                tmp_rhs = ct_right.duplicate(streams);
                 self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (ct_left, &tmp_rhs)
             }
@@ -225,7 +225,7 @@ impl CudaServerKey {
                 (ct_left, ct_right)
             }
             (false, false) => {
-                tmp_rhs = ct_right.duplicate_async(streams);
+                tmp_rhs = ct_right.duplicate(streams);
 
                 self.full_propagate_assign_async(ct_left, streams);
                 self.full_propagate_assign_async(&mut tmp_rhs, streams);

--- a/tfhe/src/integer/gpu/server_key/radix/neg.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/neg.rs
@@ -66,7 +66,7 @@ impl CudaServerKey {
         ctxt: &T,
         streams: &CudaStreams,
     ) -> T {
-        let mut ciphertext_out = ctxt.duplicate_async(streams);
+        let mut ciphertext_out = ctxt.duplicate(streams);
 
         let info = ctxt.as_ref().info.blocks.first().unwrap();
 
@@ -148,7 +148,7 @@ impl CudaServerKey {
         let ct = if ctxt.block_carries_are_empty() {
             ctxt
         } else {
-            tmp_ctxt = ctxt.duplicate_async(streams);
+            tmp_ctxt = ctxt.duplicate(streams);
             self.full_propagate_assign_async(&mut tmp_ctxt, streams);
             &mut tmp_ctxt
         };
@@ -172,9 +172,9 @@ impl CudaServerKey {
         T: CudaIntegerRadixCiphertext,
     {
         let mut ct = if ctxt.block_carries_are_empty() {
-            ctxt.duplicate_async(streams)
+            ctxt.duplicate(streams)
         } else {
-            let mut ct = ctxt.duplicate_async(streams);
+            let mut ct = ctxt.duplicate(streams);
             self.full_propagate_assign_async(&mut ct, streams);
             ct
         };

--- a/tfhe/src/integer/gpu/server_key/radix/rotate.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/rotate.rs
@@ -97,7 +97,7 @@ impl CudaServerKey {
     where
         T: CudaIntegerRadixCiphertext,
     {
-        let mut result = ct.duplicate_async(streams);
+        let mut result = ct.duplicate(streams);
         self.unchecked_rotate_right_assign_async(&mut result, rotate, streams);
         result
     }
@@ -218,7 +218,7 @@ impl CudaServerKey {
     where
         T: CudaIntegerRadixCiphertext,
     {
-        let mut result = ct.duplicate_async(streams);
+        let mut result = ct.duplicate(streams);
         self.unchecked_rotate_left_assign_async(&mut result, rotate, streams);
         result
     }
@@ -273,18 +273,18 @@ impl CudaServerKey {
         ) {
             (true, true) => (ct, rotate),
             (true, false) => {
-                tmp_rhs = rotate.duplicate_async(streams);
+                tmp_rhs = rotate.duplicate(streams);
                 self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (ct, &tmp_rhs)
             }
             (false, true) => {
-                tmp_lhs = ct.duplicate_async(streams);
+                tmp_lhs = ct.duplicate(streams);
                 self.full_propagate_assign_async(&mut tmp_lhs, streams);
                 (&tmp_lhs, rotate)
             }
             (false, false) => {
-                tmp_lhs = ct.duplicate_async(streams);
-                tmp_rhs = rotate.duplicate_async(streams);
+                tmp_lhs = ct.duplicate(streams);
+                tmp_rhs = rotate.duplicate(streams);
 
                 self.full_propagate_assign_async(&mut tmp_lhs, streams);
                 self.full_propagate_assign_async(&mut tmp_rhs, streams);
@@ -292,7 +292,7 @@ impl CudaServerKey {
             }
         };
 
-        let mut result = lhs.duplicate_async(streams);
+        let mut result = lhs.duplicate(streams);
         self.unchecked_rotate_right_assign_async(&mut result, rhs, streams);
         result
     }
@@ -318,18 +318,18 @@ impl CudaServerKey {
         ) {
             (true, true) => (ct, rotate),
             (true, false) => {
-                tmp_rhs = rotate.duplicate_async(streams);
+                tmp_rhs = rotate.duplicate(streams);
                 self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (ct, &tmp_rhs)
             }
             (false, true) => {
-                tmp_lhs = ct.duplicate_async(streams);
+                tmp_lhs = ct.duplicate(streams);
                 self.full_propagate_assign_async(&mut tmp_lhs, streams);
                 (&mut tmp_lhs, rotate)
             }
             (false, false) => {
-                tmp_lhs = ct.duplicate_async(streams);
-                tmp_rhs = rotate.duplicate_async(streams);
+                tmp_lhs = ct.duplicate(streams);
+                tmp_rhs = rotate.duplicate(streams);
 
                 self.full_propagate_assign_async(&mut tmp_lhs, streams);
                 self.full_propagate_assign_async(&mut tmp_rhs, streams);
@@ -427,18 +427,18 @@ impl CudaServerKey {
         ) {
             (true, true) => (ct, rotate),
             (true, false) => {
-                tmp_rhs = rotate.duplicate_async(streams);
+                tmp_rhs = rotate.duplicate(streams);
                 self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (ct, &tmp_rhs)
             }
             (false, true) => {
-                tmp_lhs = ct.duplicate_async(streams);
+                tmp_lhs = ct.duplicate(streams);
                 self.full_propagate_assign_async(&mut tmp_lhs, streams);
                 (&tmp_lhs, rotate)
             }
             (false, false) => {
-                tmp_lhs = ct.duplicate_async(streams);
-                tmp_rhs = rotate.duplicate_async(streams);
+                tmp_lhs = ct.duplicate(streams);
+                tmp_rhs = rotate.duplicate(streams);
 
                 self.full_propagate_assign_async(&mut tmp_lhs, streams);
                 self.full_propagate_assign_async(&mut tmp_rhs, streams);
@@ -446,7 +446,7 @@ impl CudaServerKey {
             }
         };
 
-        let mut result = lhs.duplicate_async(streams);
+        let mut result = lhs.duplicate(streams);
         self.unchecked_rotate_left_assign_async(&mut result, rhs, streams);
         result
     }
@@ -472,18 +472,18 @@ impl CudaServerKey {
         ) {
             (true, true) => (ct, rotate),
             (true, false) => {
-                tmp_rhs = rotate.duplicate_async(streams);
+                tmp_rhs = rotate.duplicate(streams);
                 self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (ct, &tmp_rhs)
             }
             (false, true) => {
-                tmp_lhs = ct.duplicate_async(streams);
+                tmp_lhs = ct.duplicate(streams);
                 self.full_propagate_assign_async(&mut tmp_lhs, streams);
                 (&mut tmp_lhs, rotate)
             }
             (false, false) => {
-                tmp_lhs = ct.duplicate_async(streams);
-                tmp_rhs = rotate.duplicate_async(streams);
+                tmp_lhs = ct.duplicate(streams);
+                tmp_rhs = rotate.duplicate(streams);
 
                 self.full_propagate_assign_async(&mut tmp_lhs, streams);
                 self.full_propagate_assign_async(&mut tmp_rhs, streams);

--- a/tfhe/src/integer/gpu/server_key/radix/scalar_bitwise_op.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/scalar_bitwise_op.rs
@@ -106,7 +106,7 @@ impl CudaServerKey {
         Scalar: DecomposableInto<u8>,
         T: CudaIntegerRadixCiphertext,
     {
-        let mut result = unsafe { ct.duplicate_async(streams) };
+        let mut result = ct.duplicate(streams);
         self.unchecked_scalar_bitand_assign(&mut result, rhs, streams);
         result
     }
@@ -131,7 +131,7 @@ impl CudaServerKey {
         Scalar: DecomposableInto<u8>,
         T: CudaIntegerRadixCiphertext,
     {
-        let mut result = unsafe { ct.duplicate_async(streams) };
+        let mut result = ct.duplicate(streams);
         self.unchecked_scalar_bitor_assign(&mut result, rhs, streams);
         result
     }
@@ -161,7 +161,7 @@ impl CudaServerKey {
         Scalar: DecomposableInto<u8>,
         T: CudaIntegerRadixCiphertext,
     {
-        let mut result = unsafe { ct.duplicate_async(streams) };
+        let mut result = ct.duplicate(streams);
         self.unchecked_scalar_bitxor_assign(&mut result, rhs, streams);
         result
     }
@@ -216,7 +216,7 @@ impl CudaServerKey {
         Scalar: DecomposableInto<u8>,
         T: CudaIntegerRadixCiphertext,
     {
-        let mut result = unsafe { ct.duplicate_async(streams) };
+        let mut result = ct.duplicate(streams);
         self.scalar_bitand_assign(&mut result, rhs, streams);
         result
     }
@@ -256,7 +256,7 @@ impl CudaServerKey {
         Scalar: DecomposableInto<u8>,
         T: CudaIntegerRadixCiphertext,
     {
-        let mut result = unsafe { ct.duplicate_async(streams) };
+        let mut result = ct.duplicate(streams);
         self.scalar_bitor_assign(&mut result, rhs, streams);
         result
     }
@@ -296,7 +296,7 @@ impl CudaServerKey {
         Scalar: DecomposableInto<u8>,
         T: CudaIntegerRadixCiphertext,
     {
-        let mut result = unsafe { ct.duplicate_async(streams) };
+        let mut result = ct.duplicate(streams);
         self.scalar_bitxor_assign(&mut result, rhs, streams);
         result
     }

--- a/tfhe/src/integer/gpu/server_key/radix/scalar_comparison.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/scalar_comparison.rs
@@ -331,7 +331,7 @@ impl CudaServerKey {
 
         let d_scalar_blocks: CudaVec<u64> = CudaVec::from_cpu_async(&scalar_blocks, streams, 0);
 
-        let mut result = ct.duplicate_async(streams);
+        let mut result = ct.duplicate(streams);
 
         match &self.bootstrapping_key {
             CudaBootstrappingKey::Classic(d_bsk) => {
@@ -590,7 +590,7 @@ impl CudaServerKey {
         let lhs = if ct.block_carries_are_empty() {
             ct
         } else {
-            tmp_lhs = ct.duplicate_async(streams);
+            tmp_lhs = ct.duplicate(streams);
             self.full_propagate_assign_async(&mut tmp_lhs, streams);
             &tmp_lhs
         };
@@ -671,7 +671,7 @@ impl CudaServerKey {
         let lhs = if ct.block_carries_are_empty() {
             ct
         } else {
-            tmp_lhs = ct.duplicate_async(streams);
+            tmp_lhs = ct.duplicate(streams);
             self.full_propagate_assign_async(&mut tmp_lhs, streams);
             &tmp_lhs
         };
@@ -911,7 +911,7 @@ impl CudaServerKey {
         let lhs = if ct.block_carries_are_empty() {
             ct
         } else {
-            tmp_lhs = ct.duplicate_async(streams);
+            tmp_lhs = ct.duplicate(streams);
             self.full_propagate_assign_async(&mut tmp_lhs, streams);
             &tmp_lhs
         };
@@ -952,7 +952,7 @@ impl CudaServerKey {
         let lhs = if ct.block_carries_are_empty() {
             ct
         } else {
-            tmp_lhs = ct.duplicate_async(streams);
+            tmp_lhs = ct.duplicate(streams);
             self.full_propagate_assign_async(&mut tmp_lhs, streams);
             &tmp_lhs
         };
@@ -993,7 +993,7 @@ impl CudaServerKey {
         let lhs = if ct.block_carries_are_empty() {
             ct
         } else {
-            tmp_lhs = ct.duplicate_async(streams);
+            tmp_lhs = ct.duplicate(streams);
             self.full_propagate_assign_async(&mut tmp_lhs, streams);
             &tmp_lhs
         };
@@ -1033,7 +1033,7 @@ impl CudaServerKey {
         let lhs = if ct.block_carries_are_empty() {
             ct
         } else {
-            tmp_lhs = ct.duplicate_async(streams);
+            tmp_lhs = ct.duplicate(streams);
             self.full_propagate_assign_async(&mut tmp_lhs, streams);
             &tmp_lhs
         };
@@ -1186,7 +1186,7 @@ impl CudaServerKey {
         let lhs = if ct.block_carries_are_empty() {
             ct
         } else {
-            tmp_lhs = ct.duplicate_async(streams);
+            tmp_lhs = ct.duplicate(streams);
             self.full_propagate_assign_async(&mut tmp_lhs, streams);
             &tmp_lhs
         };
@@ -1222,7 +1222,7 @@ impl CudaServerKey {
         let lhs = if ct.block_carries_are_empty() {
             ct
         } else {
-            tmp_lhs = ct.duplicate_async(streams);
+            tmp_lhs = ct.duplicate(streams);
             self.full_propagate_assign_async(&mut tmp_lhs, streams);
             &tmp_lhs
         };

--- a/tfhe/src/integer/gpu/server_key/radix/scalar_div_mod.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/scalar_div_mod.rs
@@ -102,7 +102,7 @@ impl CudaServerKey {
             Scalar::BITS
         );
 
-        let mut quotient = unsafe { numerator.duplicate_async(streams) };
+        let mut quotient = numerator.duplicate(streams);
 
         match &self.bootstrapping_key {
             CudaBootstrappingKey::Classic(d_bsk) => {
@@ -219,7 +219,7 @@ impl CudaServerKey {
         let numerator = if numerator.block_carries_are_empty() {
             numerator
         } else {
-            tmp_numerator = numerator.duplicate_async(streams);
+            tmp_numerator = numerator.duplicate(streams);
             self.full_propagate_assign_async(&mut tmp_numerator, streams);
             &tmp_numerator
         };
@@ -270,8 +270,7 @@ impl CudaServerKey {
             Scalar::BITS
         );
 
-        let mut quotient: CudaUnsignedRadixCiphertext =
-            unsafe { numerator.duplicate_async(streams) };
+        let mut quotient: CudaUnsignedRadixCiphertext = numerator.duplicate(streams);
         let mut remainder: CudaUnsignedRadixCiphertext = unsafe {
             self.create_trivial_zero_radix_async(
                 numerator.as_ref().d_blocks.lwe_ciphertext_count().0,
@@ -398,7 +397,7 @@ impl CudaServerKey {
         let numerator = if numerator.block_carries_are_empty() {
             numerator
         } else {
-            tmp_numerator = numerator.duplicate_async(streams);
+            tmp_numerator = numerator.duplicate(streams);
             self.full_propagate_assign_async(&mut tmp_numerator, streams);
             &tmp_numerator
         };
@@ -501,7 +500,7 @@ impl CudaServerKey {
         let numerator = if numerator.block_carries_are_empty() {
             numerator
         } else {
-            tmp_numerator = numerator.duplicate_async(streams);
+            tmp_numerator = numerator.duplicate(streams);
             self.full_propagate_assign_async(&mut tmp_numerator, streams);
             &tmp_numerator
         };
@@ -672,7 +671,7 @@ impl CudaServerKey {
         let numerator = if numerator.block_carries_are_empty() {
             numerator
         } else {
-            tmp_numerator = numerator.duplicate_async(streams);
+            tmp_numerator = numerator.duplicate(streams);
             self.full_propagate_assign_async(&mut tmp_numerator, streams);
             &tmp_numerator
         };
@@ -721,7 +720,7 @@ impl CudaServerKey {
 >= to the number of bits encrypted in the ciphertext"
         );
 
-        let mut quotient: CudaSignedRadixCiphertext = numerator.duplicate_async(streams);
+        let mut quotient: CudaSignedRadixCiphertext = numerator.duplicate(streams);
         let mut remainder: CudaSignedRadixCiphertext = self.create_trivial_zero_radix_async(
             numerator.as_ref().d_blocks.lwe_ciphertext_count().0,
             streams,
@@ -846,7 +845,7 @@ impl CudaServerKey {
         let numerator = if numerator.block_carries_are_empty() {
             numerator
         } else {
-            tmp_numerator = numerator.duplicate_async(streams);
+            tmp_numerator = numerator.duplicate(streams);
             self.full_propagate_assign_async(&mut tmp_numerator, streams);
             &tmp_numerator
         };
@@ -956,7 +955,7 @@ impl CudaServerKey {
         let numerator = if numerator.block_carries_are_empty() {
             numerator
         } else {
-            tmp_numerator = numerator.duplicate_async(streams);
+            tmp_numerator = numerator.duplicate(streams);
             self.full_propagate_assign_async(&mut tmp_numerator, streams);
             &tmp_numerator
         };

--- a/tfhe/src/integer/gpu/server_key/radix/scalar_mul.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/scalar_mul.rs
@@ -58,7 +58,7 @@ impl CudaServerKey {
         Scalar: ScalarMultiplier + DecomposableInto<u8> + CastInto<u64>,
         T: CudaIntegerRadixCiphertext,
     {
-        let mut result = unsafe { ct.duplicate_async(streams) };
+        let mut result = ct.duplicate(streams);
         self.unchecked_scalar_mul_assign(&mut result, scalar, streams);
         result
     }
@@ -222,7 +222,7 @@ impl CudaServerKey {
         Scalar: ScalarMultiplier + DecomposableInto<u8> + CastInto<u64>,
         T: CudaIntegerRadixCiphertext,
     {
-        let mut result = unsafe { ct.duplicate_async(streams) };
+        let mut result = ct.duplicate(streams);
         self.scalar_mul_assign(&mut result, scalar, streams);
         result
     }

--- a/tfhe/src/integer/gpu/server_key/radix/scalar_rotate.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/scalar_rotate.rs
@@ -26,7 +26,7 @@ impl CudaServerKey {
         Scalar: CastFrom<u32>,
         u32: CastFrom<Scalar>,
     {
-        let mut result = ct.duplicate_async(stream);
+        let mut result = ct.duplicate(stream);
         self.unchecked_scalar_rotate_left_assign_async(&mut result, n, stream);
         result
     }
@@ -135,7 +135,7 @@ impl CudaServerKey {
         Scalar: CastFrom<u32>,
         u32: CastFrom<Scalar>,
     {
-        let mut result = ct.duplicate_async(stream);
+        let mut result = ct.duplicate(stream);
         self.unchecked_scalar_rotate_right_assign_async(&mut result, n, stream);
         result
     }

--- a/tfhe/src/integer/gpu/server_key/radix/scalar_shift.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/scalar_shift.rs
@@ -28,7 +28,7 @@ impl CudaServerKey {
         u32: CastFrom<Scalar>,
         T: CudaIntegerRadixCiphertext,
     {
-        let mut result = ct.duplicate_async(streams);
+        let mut result = ct.duplicate(streams);
         self.unchecked_scalar_left_shift_assign_async(&mut result, shift, streams);
         result
     }
@@ -174,7 +174,7 @@ impl CudaServerKey {
         u32: CastFrom<Scalar>,
         T: CudaIntegerRadixCiphertext,
     {
-        let mut result = ct.duplicate_async(streams);
+        let mut result = ct.duplicate(streams);
         self.unchecked_scalar_right_shift_assign_async(&mut result, shift, streams);
         result
     }
@@ -398,7 +398,7 @@ impl CudaServerKey {
         u32: CastFrom<Scalar>,
         T: CudaIntegerRadixCiphertext,
     {
-        let mut result = ct.duplicate_async(streams);
+        let mut result = ct.duplicate(streams);
         self.scalar_right_shift_assign_async(&mut result, shift, streams);
         result
     }
@@ -486,7 +486,7 @@ impl CudaServerKey {
         u32: CastFrom<Scalar>,
         T: CudaIntegerRadixCiphertext,
     {
-        let mut result = ct.duplicate_async(streams);
+        let mut result = ct.duplicate(streams);
         self.scalar_left_shift_assign_async(&mut result, shift, streams);
         result
     }

--- a/tfhe/src/integer/gpu/server_key/radix/scalar_sub.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/scalar_sub.rs
@@ -56,7 +56,7 @@ impl CudaServerKey {
         Scalar: DecomposableInto<u8> + Numeric + TwosComplementNegation + CastInto<u64>,
         T: CudaIntegerRadixCiphertext,
     {
-        let mut result = unsafe { ct.duplicate_async(streams) };
+        let mut result = ct.duplicate(streams);
         self.unchecked_scalar_sub_assign(&mut result, scalar, streams);
         result
     }
@@ -135,7 +135,7 @@ impl CudaServerKey {
         Scalar: DecomposableInto<u8> + Numeric + TwosComplementNegation + CastInto<u64>,
         T: CudaIntegerRadixCiphertext,
     {
-        let mut result = unsafe { ct.duplicate_async(streams) };
+        let mut result = ct.duplicate(streams);
         self.scalar_sub_assign(&mut result, scalar, streams);
         result
     }
@@ -233,7 +233,7 @@ impl CudaServerKey {
     {
         let mut tmp_lhs;
         unsafe {
-            tmp_lhs = ct_left.duplicate_async(streams);
+            tmp_lhs = ct_left.duplicate(streams);
             if !tmp_lhs.block_carries_are_empty() {
                 self.full_propagate_assign_async(&mut tmp_lhs, streams);
             }

--- a/tfhe/src/integer/gpu/server_key/radix/shift.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/shift.rs
@@ -97,7 +97,7 @@ impl CudaServerKey {
     where
         T: CudaIntegerRadixCiphertext,
     {
-        let mut result = ct.duplicate_async(streams);
+        let mut result = ct.duplicate(streams);
         self.unchecked_right_shift_assign_async(&mut result, shift, streams);
         result
     }
@@ -216,7 +216,7 @@ impl CudaServerKey {
     where
         T: CudaIntegerRadixCiphertext,
     {
-        let mut result = ct.duplicate_async(streams);
+        let mut result = ct.duplicate(streams);
         self.unchecked_left_shift_assign_async(&mut result, shift, streams);
         result
     }
@@ -269,18 +269,18 @@ impl CudaServerKey {
         ) {
             (true, true) => (ct, shift),
             (true, false) => {
-                tmp_rhs = shift.duplicate_async(streams);
+                tmp_rhs = shift.duplicate(streams);
                 self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (ct, &tmp_rhs)
             }
             (false, true) => {
-                tmp_lhs = ct.duplicate_async(streams);
+                tmp_lhs = ct.duplicate(streams);
                 self.full_propagate_assign_async(&mut tmp_lhs, streams);
                 (&tmp_lhs, shift)
             }
             (false, false) => {
-                tmp_lhs = ct.duplicate_async(streams);
-                tmp_rhs = shift.duplicate_async(streams);
+                tmp_lhs = ct.duplicate(streams);
+                tmp_rhs = shift.duplicate(streams);
 
                 self.full_propagate_assign_async(&mut tmp_lhs, streams);
                 self.full_propagate_assign_async(&mut tmp_rhs, streams);
@@ -288,7 +288,7 @@ impl CudaServerKey {
             }
         };
 
-        let mut result = lhs.duplicate_async(streams);
+        let mut result = lhs.duplicate(streams);
         self.unchecked_right_shift_assign_async(&mut result, rhs, streams);
         result
     }
@@ -314,18 +314,18 @@ impl CudaServerKey {
         ) {
             (true, true) => (ct, shift),
             (true, false) => {
-                tmp_rhs = shift.duplicate_async(streams);
+                tmp_rhs = shift.duplicate(streams);
                 self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (ct, &tmp_rhs)
             }
             (false, true) => {
-                tmp_lhs = ct.duplicate_async(streams);
+                tmp_lhs = ct.duplicate(streams);
                 self.full_propagate_assign_async(&mut tmp_lhs, streams);
                 (&mut tmp_lhs, shift)
             }
             (false, false) => {
-                tmp_lhs = ct.duplicate_async(streams);
-                tmp_rhs = shift.duplicate_async(streams);
+                tmp_lhs = ct.duplicate(streams);
+                tmp_rhs = shift.duplicate(streams);
 
                 self.full_propagate_assign_async(&mut tmp_lhs, streams);
                 self.full_propagate_assign_async(&mut tmp_rhs, streams);
@@ -422,18 +422,18 @@ impl CudaServerKey {
         ) {
             (true, true) => (ct, shift),
             (true, false) => {
-                tmp_rhs = shift.duplicate_async(streams);
+                tmp_rhs = shift.duplicate(streams);
                 self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (ct, &tmp_rhs)
             }
             (false, true) => {
-                tmp_lhs = ct.duplicate_async(streams);
+                tmp_lhs = ct.duplicate(streams);
                 self.full_propagate_assign_async(&mut tmp_lhs, streams);
                 (&tmp_lhs, shift)
             }
             (false, false) => {
-                tmp_lhs = ct.duplicate_async(streams);
-                tmp_rhs = shift.duplicate_async(streams);
+                tmp_lhs = ct.duplicate(streams);
+                tmp_rhs = shift.duplicate(streams);
 
                 self.full_propagate_assign_async(&mut tmp_lhs, streams);
                 self.full_propagate_assign_async(&mut tmp_rhs, streams);
@@ -441,7 +441,7 @@ impl CudaServerKey {
             }
         };
 
-        let mut result = lhs.duplicate_async(streams);
+        let mut result = lhs.duplicate(streams);
         self.unchecked_left_shift_assign_async(&mut result, rhs, streams);
         result
     }
@@ -467,18 +467,18 @@ impl CudaServerKey {
         ) {
             (true, true) => (ct, shift),
             (true, false) => {
-                tmp_rhs = shift.duplicate_async(streams);
+                tmp_rhs = shift.duplicate(streams);
                 self.full_propagate_assign_async(&mut tmp_rhs, streams);
                 (ct, &tmp_rhs)
             }
             (false, true) => {
-                tmp_lhs = ct.duplicate_async(streams);
+                tmp_lhs = ct.duplicate(streams);
                 self.full_propagate_assign_async(&mut tmp_lhs, streams);
                 (&mut tmp_lhs, shift)
             }
             (false, false) => {
-                tmp_lhs = ct.duplicate_async(streams);
-                tmp_rhs = shift.duplicate_async(streams);
+                tmp_lhs = ct.duplicate(streams);
+                tmp_rhs = shift.duplicate(streams);
 
                 self.full_propagate_assign_async(&mut tmp_lhs, streams);
                 self.full_propagate_assign_async(&mut tmp_rhs, streams);

--- a/tfhe/src/integer/gpu/server_key/radix/sub.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/sub.rs
@@ -78,7 +78,7 @@ impl CudaServerKey {
         ct_right: &T,
         streams: &CudaStreams,
     ) -> T {
-        let mut result = ct_left.duplicate_async(streams);
+        let mut result = ct_left.duplicate(streams);
         self.unchecked_sub_assign_async(&mut result, ct_right, streams);
         result
     }
@@ -229,7 +229,7 @@ impl CudaServerKey {
         ct_right: &T,
         streams: &CudaStreams,
     ) -> T {
-        let mut result = ct_left.duplicate_async(streams);
+        let mut result = ct_left.duplicate(streams);
         self.sub_assign_async(&mut result, ct_right, streams);
         result
     }
@@ -372,7 +372,7 @@ impl CudaServerKey {
         rhs: &CudaUnsignedRadixCiphertext,
         stream: &CudaStreams,
     ) -> (CudaUnsignedRadixCiphertext, CudaBooleanBlock) {
-        let mut ct_res = lhs.duplicate_async(stream);
+        let mut ct_res = lhs.duplicate(stream);
 
         let compute_overflow = true;
         const INPUT_BORROW: Option<&CudaBooleanBlock> = None;
@@ -578,22 +578,22 @@ impl CudaServerKey {
             (true, true) => (ct_left, ct_right),
             (true, false) => {
                 unsafe {
-                    tmp_rhs = ct_right.duplicate_async(stream);
+                    tmp_rhs = ct_right.duplicate(stream);
                     self.full_propagate_assign_async(&mut tmp_rhs, stream);
                 }
                 (ct_left, &tmp_rhs)
             }
             (false, true) => {
                 unsafe {
-                    tmp_lhs = ct_left.duplicate_async(stream);
+                    tmp_lhs = ct_left.duplicate(stream);
                     self.full_propagate_assign_async(&mut tmp_lhs, stream);
                 }
                 (&tmp_lhs, ct_right)
             }
             (false, false) => {
                 unsafe {
-                    tmp_lhs = ct_left.duplicate_async(stream);
-                    tmp_rhs = ct_right.duplicate_async(stream);
+                    tmp_lhs = ct_left.duplicate(stream);
+                    tmp_rhs = ct_right.duplicate(stream);
 
                     self.full_propagate_assign_async(&mut tmp_lhs, stream);
                     self.full_propagate_assign_async(&mut tmp_rhs, stream);

--- a/tfhe/src/integer/gpu/server_key/radix/vector_find.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/vector_find.rs
@@ -1610,7 +1610,7 @@ impl CudaServerKey {
                     )
                 };
             }
-            let temp = unsafe { aggregated_vector.duplicate_async(streams) };
+            let temp = aggregated_vector.duplicate(streams);
 
             unsafe {
                 self.apply_lookup_table_async(
@@ -1643,7 +1643,7 @@ impl CudaServerKey {
         let mut carry_ct: T =
             unsafe { self.create_trivial_zero_radix_async(num_ct_blocks, streams) };
 
-        let temp = unsafe { aggregated_vector.duplicate_async(streams) };
+        let temp = aggregated_vector.duplicate(streams);
         unsafe {
             self.apply_lookup_table_async(
                 carry_ct.as_mut(),


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description

duplicate_async is still used in async integer ops but those should disappear little by little

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
