### PR TITLE
chore(c-api): add missing docs for some C function

### DIFF
--- a/tfhe/c_api_tests/test_c_doc.c
+++ b/tfhe/c_api_tests/test_c_doc.c
@@ -58,6 +58,7 @@ int main(void) {
   // Destroy the keys
   client_key_destroy(client_key);
   server_key_destroy(server_key);
+  unset_server_key();
 
   printf("FHE computation successful!\n");
   return EXIT_SUCCESS;

--- a/tfhe/c_api_tests/test_compressed_list.c
+++ b/tfhe/c_api_tests/test_compressed_list.c
@@ -148,5 +148,8 @@ int main(void) {
   fhe_bool_destroy(c);
   fhe_uint2_destroy(d);
   client_key_destroy(client_key);
+  server_key_destroy(server_key);
+  unset_server_key();
+
   return EXIT_SUCCESS;
 }

--- a/tfhe/c_api_tests/test_high_level_128_bits.c
+++ b/tfhe/c_api_tests/test_high_level_128_bits.c
@@ -118,5 +118,6 @@ int main(void) {
   client_key_destroy(client_key);
   public_key_destroy(public_key);
   server_key_destroy(server_key);
+  unset_server_key();
   return ok;
 }

--- a/tfhe/c_api_tests/test_high_level_2048.c
+++ b/tfhe/c_api_tests/test_high_level_2048.c
@@ -61,5 +61,7 @@ int main(void) {
   client_key_destroy(client_key);
   public_key_destroy(public_key);
   server_key_destroy(server_key);
+  unset_server_key();
+
   return ok;
 }

--- a/tfhe/c_api_tests/test_high_level_256_bits.c
+++ b/tfhe/c_api_tests/test_high_level_256_bits.c
@@ -263,5 +263,7 @@ int main(void) {
   client_key_destroy(client_key);
   public_key_destroy(public_key);
   server_key_destroy(server_key);
+  unset_server_key();
+  
   return ok;
 }

--- a/tfhe/c_api_tests/test_high_level_array.c
+++ b/tfhe/c_api_tests/test_high_level_array.c
@@ -119,5 +119,7 @@ int main(void) {
 
   client_key_destroy(client_key);
   server_key_destroy(server_key);
+  unset_server_key();
+
   return 0;
 }

--- a/tfhe/c_api_tests/test_high_level_boolean.c
+++ b/tfhe/c_api_tests/test_high_level_boolean.c
@@ -121,6 +121,7 @@ int main(void) {
   client_key_destroy(client_key);
   public_key_destroy(public_key);
   server_key_destroy(server_key);
+  unset_server_key();
 
   return EXIT_SUCCESS;
 }

--- a/tfhe/c_api_tests/test_high_level_compact_list.c
+++ b/tfhe/c_api_tests/test_high_level_compact_list.c
@@ -124,6 +124,7 @@ int cpk_use_case(Config *config) {
   server_key_destroy(server_key);
   compact_public_key_destroy(public_key);
   compact_ciphertext_list_destroy(compact_list);
+  unset_server_key();
 
   return ok;
 }

--- a/tfhe/c_api_tests/test_high_level_custom_integers.c
+++ b/tfhe/c_api_tests/test_high_level_custom_integers.c
@@ -263,6 +263,7 @@ int main(void) {
     client_key_destroy(client_key);
     compressed_compact_public_key_destroy(compressed_public_key);
     server_key_destroy(server_key);
+    unset_server_key();
   }
   return ok;
 }

--- a/tfhe/c_api_tests/test_high_level_error.c
+++ b/tfhe/c_api_tests/test_high_level_error.c
@@ -55,6 +55,7 @@ int main(void) {
   // Destroy the keys
   client_key_destroy(client_key);
   server_key_destroy(server_key);
+  unset_server_key();
 
   return EXIT_SUCCESS;
 }

--- a/tfhe/c_api_tests/test_high_level_integers.c
+++ b/tfhe/c_api_tests/test_high_level_integers.c
@@ -680,6 +680,7 @@ int main(void) {
     client_key_destroy(client_key);
     public_key_destroy(public_key);
     server_key_destroy(server_key);
+    unset_server_key();
   }
 
   return ok;

--- a/tfhe/c_api_tests/test_high_level_integers_cuda.c
+++ b/tfhe/c_api_tests/test_high_level_integers_cuda.c
@@ -87,6 +87,8 @@ int main(void) {
     client_key_destroy(client_key);
     compressed_server_key_destroy(compressed_sks);
     cuda_server_key_destroy(cuda_server_key);
+    unset_server_key();
+
   }
 
   return ok;

--- a/tfhe/c_api_tests/test_high_level_threading.c
+++ b/tfhe/c_api_tests/test_high_level_threading.c
@@ -165,6 +165,7 @@ int main(void) {
 
   client_key_destroy(client_key);
   server_key_destroy(server_key);
+  unset_server_key();
 
   return ok;
 }

--- a/tfhe/c_api_tests/test_high_level_zk.c
+++ b/tfhe/c_api_tests/test_high_level_zk.c
@@ -133,6 +133,7 @@ int main(void) {
   server_key_destroy(server_key);
   compact_public_key_destroy(pk);
   compact_pke_crs_destroy(crs);
+  unset_server_key();
 
   return EXIT_SUCCESS;
 }

--- a/tfhe/src/c_api/high_level_api/config.rs
+++ b/tfhe/src/c_api/high_level_api/config.rs
@@ -9,6 +9,7 @@ pub struct Config(pub(in crate::c_api) crate::high_level_api::Config);
 impl_destroy_on_type!(ConfigBuilder);
 impl_destroy_on_type!(Config);
 
+/// Create a ConfigBuilder with default parameters
 #[no_mangle]
 pub unsafe extern "C" fn config_builder_default(result: *mut *mut ConfigBuilder) -> c_int {
     catch_panic(|| {
@@ -20,6 +21,7 @@ pub unsafe extern "C" fn config_builder_default(result: *mut *mut ConfigBuilder)
     })
 }
 
+/// Clone the `input` builder into the `result`
 #[no_mangle]
 pub unsafe extern "C" fn config_builder_clone(
     input: *const ConfigBuilder,
@@ -67,7 +69,10 @@ pub unsafe extern "C" fn use_dedicated_compact_public_key_parameters(
     })
 }
 
-/// Takes ownership of the builder
+/// Builds a Config using the builder
+///
+/// This moves/takes ownership of the builder, meaning
+/// it MUST NOT be used or freed after this call.
 #[no_mangle]
 pub unsafe extern "C" fn config_builder_build(
     builder: *mut ConfigBuilder,
@@ -96,5 +101,17 @@ pub unsafe extern "C" fn config_builder_enable_compression(
             .0
             .enable_compression(compression_parameters.0);
         *builder = Box::into_raw(Box::new(ConfigBuilder(inner)));
+    })
+}
+
+/// Clone the `input` Config into the `result`
+#[no_mangle]
+pub unsafe extern "C" fn config_clone(input: *const Config, result: *mut *mut Config) -> c_int {
+    catch_panic(|| {
+        check_ptr_is_non_null_and_aligned(result).unwrap();
+
+        let copied = get_ref_checked(input).unwrap().0;
+
+        *result = Box::into_raw(Box::new(Config(copied)));
     })
 }


### PR DESCRIPTION
Add explanations on the fact that config and config buider do not need to be freed/
