### PR TITLE
fix(gpu): fix bug in are_all_comparison_blocks_true when number of blocks is 0

### DIFF
--- a/backends/tfhe-cuda-backend/cuda/src/integer/comparison.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/comparison.cuh
@@ -76,6 +76,13 @@ __host__ void are_all_comparisons_block_true(
   auto message_modulus = params.message_modulus;
   auto carry_modulus = params.carry_modulus;
 
+  if (num_radix_blocks == 0) {
+    set_single_scalar_trivial_radix_ciphertext_async<Torus>(
+        streams.stream(0), streams.gpu_index(0), lwe_array_out, 1,
+        message_modulus, carry_modulus);
+    return;
+  }
+
   auto are_all_block_true_buffer =
       mem_ptr->eq_buffer->are_all_block_true_buffer;
   auto tmp_out = are_all_block_true_buffer->tmp_out;


### PR DESCRIPTION
### PR content/description

fix bug in are_all_comparison_blocks_true when number of blocks is 0

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
