### PR TITLE
chore: make main compile with 2024 edition dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-resolver = "2"
+resolver = "3"
 members = [
     "tfhe",
     "tfhe-benchmark",

--- a/tfhe/Cargo.toml
+++ b/tfhe/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [
     "/js_on_wasm_tests/",
     "/web_wasm_parallel_tests/",
 ]
-rust-version = "1.84"
+rust-version = "1.85"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tfhe/src/core_crypto/algorithms/test/noise_distribution/variance_formula/secure_noise.rs
+++ b/tfhe/src/core_crypto/algorithms/test/noise_distribution/variance_formula/secure_noise.rs
@@ -39,6 +39,7 @@ pub fn minimal_lwe_variance_for_132_bits_security_tuniform(
     ))
 }
 
+#[allow(clippy::manual_midpoint)]
 pub fn minimal_variance_for_132_bits_security_gaussian_impl(
     lwe_dimension: f64,
     modulus: f64,


### PR DESCRIPTION
- resolver 3 makes sure that incompatible dependencies (rust version wise) are not selected