### PR TITLE
chore: use pull request permissions to be able to post comments

### DIFF
--- a/.github/workflows/benchmark_perf_regression.yml
+++ b/.github/workflows/benchmark_perf_regression.yml
@@ -45,8 +45,8 @@ jobs:
       selected-regression-profile: ${{ steps.set_regression_details.outputs.selected-profile }}
       custom-env: ${{ steps.get_custom_env.outputs.custom_env }}
     permissions:
-      # Needed to react to benchmark command in issue comment
-      issues: write
+      # Needed to write a comment in a pull-request
+      pull-requests: write
     steps:
       - name: Checkout tfhe-rs repo
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8


### PR DESCRIPTION
- the "print URL" comment failed, while the "bench failed" comment worked difference is the former has an issues write permissions, and the latter a pull request write permissions

see https://github.com/zama-ai/tfhe-rs/pull/2928