### PR TITLE
chore: fix various target issues for benchmarks following renames

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1379,14 +1379,14 @@ bench_integer_hpu: install_rs_check_toolchain
 bench_integer_compression: install_rs_check_toolchain
 	RUSTFLAGS="$(RUSTFLAGS)" __TFHE_RS_BENCH_TYPE=$(BENCH_TYPE) \
 	cargo $(CARGO_RS_CHECK_TOOLCHAIN) bench \
-	--bench	integer-glwe_packing_compression \
+	--bench integer-glwe_packing_compression \
 	--features=integer,internal-keycache,nightly-avx512,pbs-stats -p tfhe-benchmark --
 
 .PHONY: bench_integer_compression_gpu
 bench_integer_compression_gpu: install_rs_check_toolchain
 	RUSTFLAGS="$(RUSTFLAGS)" __TFHE_RS_BENCH_TYPE=$(BENCH_TYPE) \
 	cargo $(CARGO_RS_CHECK_TOOLCHAIN) bench \
-	--bench	integer-glwe_packing_compression \
+	--bench integer-glwe_packing_compression \
 	--features=integer,internal-keycache,gpu,pbs-stats -p tfhe-benchmark --
 
 .PHONY: bench_integer_zk_gpu
@@ -1440,20 +1440,20 @@ bench_integer_zk: install_rs_check_toolchain
 bench_shortint: install_rs_check_toolchain
 	RUSTFLAGS="$(RUSTFLAGS)" __TFHE_RS_BENCH_OP_FLAVOR=$(BENCH_OP_FLAVOR) __TFHE_RS_PARAMS_SET=$(BENCH_PARAMS_SET) __TFHE_RS_BENCH_TYPE=$(BENCH_TYPE) \
 	cargo $(CARGO_RS_CHECK_TOOLCHAIN) bench \
-	--bench shortint-bench \
+	--bench shortint \
 	--features=shortint,internal-keycache,nightly-avx512 -p tfhe-benchmark
 
 .PHONY: bench_shortint_oprf # Run benchmarks for shortint
 bench_shortint_oprf: install_rs_check_toolchain
 	RUSTFLAGS="$(RUSTFLAGS)" __TFHE_RS_PARAMS_SET=$(BENCH_PARAMS_SET) \
 	cargo $(CARGO_RS_CHECK_TOOLCHAIN) bench \
-	--bench oprf-shortint-bench \
+	--bench shortint-oprf \
 	--features=shortint,internal-keycache,nightly-avx512 -p tfhe-benchmark
 
 .PHONY: bench_boolean # Run benchmarks for boolean
 bench_boolean: install_rs_check_toolchain
 	RUSTFLAGS="$(RUSTFLAGS)" cargo $(CARGO_RS_CHECK_TOOLCHAIN) bench \
-	--bench boolean-bench \
+	--bench boolean \
 	--features=boolean,internal-keycache,nightly-avx512 -p tfhe-benchmark
 
 .PHONY: bench_ks # Run benchmarks for keyswitch

--- a/tfhe-benchmark/src/utilities.rs
+++ b/tfhe-benchmark/src/utilities.rs
@@ -470,7 +470,7 @@ pub fn throughput_num_threads(num_block: usize, op_pbs_count: u64) -> u64 {
 
 // Given an `Op` this returns how many more ops should be done in parallel
 // to saturate the CPU and have a better throughput measurement
-#[cfg(feature = "integer")]
+#[cfg(all(feature = "integer", feature = "pbs-stats"))]
 pub fn hlapi_throughput_num_ops<Op>(op: Op, cks: &tfhe::ClientKey) -> usize
 where
     Op: FnOnce(),


### PR DESCRIPTION
- renames were done to uniformize and make it easier to setup perf regression measurements, some names were not updated this PR fixes that