### PR TITLE
Ns/chore/fix zk thrpt elements

### DIFF
--- a/tfhe-benchmark/benches/integer/zk_pke.rs
+++ b/tfhe-benchmark/benches/integer/zk_pke.rs
@@ -72,18 +72,11 @@ fn cpu_pke_zk_proof(c: &mut Criterion) {
         .sample_size(15)
         .measurement_time(std::time::Duration::from_secs(60));
 
-    for (param_pke, _param_casting, param_fhe) in [
-        (
-            BENCH_PARAM_PKE_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
-            BENCH_PARAM_KEYSWITCH_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
-            BENCH_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
-        ),
-        (
-            BENCH_PARAM_PKE_TO_SMALL_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128_ZKV1,
-            BENCH_PARAM_KEYSWITCH_PKE_TO_SMALL_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128_ZKV1,
-            BENCH_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
-        ),
-    ] {
+    for (param_pke, _param_casting, param_fhe) in [(
+        BENCH_PARAM_PKE_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+        BENCH_PARAM_KEYSWITCH_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+        BENCH_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+    )] {
         let param_name = param_fhe.name();
         let param_name = param_name.as_str();
         let cks = ClientKey::new(param_fhe);
@@ -208,18 +201,11 @@ fn cpu_pke_zk_verify(c: &mut Criterion, results_file: &Path) {
         .open(results_file)
         .expect("cannot open results file");
 
-    for (param_pke, param_casting, param_fhe) in [
-        (
-            BENCH_PARAM_PKE_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
-            BENCH_PARAM_KEYSWITCH_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
-            BENCH_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
-        ),
-        (
-            BENCH_PARAM_PKE_TO_SMALL_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128_ZKV1,
-            BENCH_PARAM_KEYSWITCH_PKE_TO_SMALL_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128_ZKV1,
-            BENCH_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
-        ),
-    ] {
+    for (param_pke, param_casting, param_fhe) in [(
+        BENCH_PARAM_PKE_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+        BENCH_PARAM_KEYSWITCH_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+        BENCH_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+    )] {
         let param_name = param_fhe.name();
         let param_name = param_name.as_str();
         let cks = ClientKey::new(param_fhe);
@@ -406,7 +392,7 @@ fn cpu_pke_zk_verify(c: &mut Criterion, results_file: &Path) {
                                 ),
                             ).unwrap();
                             let pbs_count = get_pbs_count().max(1);
-                            let expand_elements = throughput_num_threads(num_block, pbs_count);
+                            let expand_elements = throughput_num_threads(num_block, pbs_count) * 2;
                             let verify_expand_elements = expand_elements.min(verify_elements);
 
                             bench_group.throughput(Throughput::Elements(verify_elements));


### PR DESCRIPTION
### PR content/description
Since the zk verification does not perform any pbs, the usual heuristic for throuhput elements count does not work. We use a different heuristic:
- zk verify is pooled (see https://github.com/zama-ai/tfhe-rs/pull/2310). On hpc7 we have 6 pools.
- We "fill" the pools with 64 elements, which experimentally gives a good throughput.

For `verify_and_expand`, we use the classical pbs count and we take the lowest value between both heuristics.

I also removed the zkv1 integer benches. This reduces a lot the bench time, allows to reduce clutter in the grafana dashboard and we bench zkv1 in the tfhe-zk-pok crates anyways

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/2933)
<!-- Reviewable:end -->
