### PR TITLE
fix(core): par_encrypt_and_prove was using sequential encryption

### DIFF
--- a/tfhe/src/core_crypto/algorithms/lwe_encryption.rs
+++ b/tfhe/src/core_crypto/algorithms/lwe_encryption.rs
@@ -3187,7 +3187,7 @@ where
         binary_random_vector,
         mask_noise,
         body_noise,
-    } = encrypt_lwe_compact_ciphertext_list_with_compact_public_key_impl(
+    } = par_encrypt_lwe_compact_ciphertext_list_with_compact_public_key_impl(
         lwe_compact_public_key,
         output,
         &encoded,


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description
use `par_encrypt_lwe_compact_ciphertext_list_with_compact_public_key_impl` in `par_encrypt_and_prove_lwe_compact_ciphertext_list_with_compact_public_key`. 

Before this pr there is no difference between `par_encrypt_and_prove_lwe_compact_ciphertext_list_with_compact_public_key` and `encrypt_and_prove_lwe_compact_ciphertext_list_with_compact_public_key`