### PR TITLE
fix(zk): missing compressed proof version

### DIFF
--- a/tfhe-zk-pok/src/backward_compatibility/pke_v2.rs
+++ b/tfhe-zk-pok/src/backward_compatibility/pke_v2.rs
@@ -278,7 +278,8 @@ where
     G::G2: Compressible,
 {
     V0(CompressedProofV0<G>),
-    V1(CompressedProof<G>),
+    V1(CompressedProofV1<G>),
+    V2(CompressedProof<G>),
 }
 
 #[derive(VersionsDispatch)]

--- a/tfhe-zk-pok/src/proofs/pke_v2/mod.rs
+++ b/tfhe-zk-pok/src/proofs/pke_v2/mod.rs
@@ -2095,6 +2095,7 @@ mod tests {
     use super::*;
     use rand::rngs::StdRng;
     use rand::{thread_rng, Rng, SeedableRng};
+    use tfhe_versionable::Unversionize;
 
     type Curve = curve_api::Bls12_446;
 
@@ -3148,9 +3149,12 @@ mod tests {
                 &seed.to_le_bytes(),
             );
 
-            let compressed_proof = bincode::serialize(&proof.compress()).unwrap();
-            let proof =
-                Proof::uncompress(bincode::deserialize(&compressed_proof).unwrap()).unwrap();
+            let compressed_proof = bincode::serialize(&proof.compress().versionize()).unwrap();
+            let proof = Proof::uncompress(
+                CompressedProof::unversionize(bincode::deserialize(&compressed_proof).unwrap())
+                    .unwrap(),
+            )
+            .unwrap();
 
             verify(&proof, (&public_param, &public_commit), &testcase.metadata).unwrap()
         }


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description
Fix a missing version in the zk pke v2 CompressedProof. The missing version did not trigger a compilation error but it made the bound on the `Versionize` derived impl not satisfiable. Which was not detected because the CompressedProof is not used in any higher level type.
Thus this fix is technically not breaking since the badly versioned object was impossible to create.

I added a call to versionize in the compression test to check that this is not broken again in the future.
