### PR TITLE
chore(ci): run erc20 and dex throughput bench only on demand

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1573,25 +1573,29 @@ bench_hlapi_hpu: install_rs_check_toolchain
 
 .PHONY: bench_hlapi_erc20 # Run benchmarks for ERC20 operations
 bench_hlapi_erc20: install_rs_check_toolchain
-	RUSTFLAGS="$(RUSTFLAGS)" cargo $(CARGO_RS_CHECK_TOOLCHAIN) bench \
+	RUSTFLAGS="$(RUSTFLAGS)" __TFHE_RS_BENCH_TYPE=$(BENCH_TYPE) \
+	cargo $(CARGO_RS_CHECK_TOOLCHAIN) bench \
 	--bench hlapi-erc20 \
 	--features=integer,internal-keycache,pbs-stats,nightly-avx512 -p tfhe-benchmark --
 
 .PHONY: bench_hlapi_erc20_gpu # Run benchmarks for ERC20 operations on GPU
 bench_hlapi_erc20_gpu: install_rs_check_toolchain
-	RUSTFLAGS="$(RUSTFLAGS)" cargo $(CARGO_RS_CHECK_TOOLCHAIN) bench \
+	RUSTFLAGS="$(RUSTFLAGS)" __TFHE_RS_BENCH_TYPE=$(BENCH_TYPE) \
+    cargo $(CARGO_RS_CHECK_TOOLCHAIN) bench \
 	--bench hlapi-erc20 \
 	--features=integer,gpu,internal-keycache,pbs-stats,nightly-avx512 -p tfhe-benchmark --profile release_lto_off --
 
 .PHONY: bench_hlapi_dex # Run benchmarks for DEX operations
 bench_hlapi_dex: install_rs_check_toolchain
-	RUSTFLAGS="$(RUSTFLAGS)" cargo $(CARGO_RS_CHECK_TOOLCHAIN) bench \
+	RUSTFLAGS="$(RUSTFLAGS)" __TFHE_RS_BENCH_TYPE=$(BENCH_TYPE) \
+	cargo $(CARGO_RS_CHECK_TOOLCHAIN) bench \
 	--bench hlapi-dex \
 	--features=integer,internal-keycache,pbs-stats,nightly-avx512 -p tfhe-benchmark --
 
 .PHONY: bench_hlapi_dex_gpu # Run benchmarks for DEX operations on GPU
 bench_hlapi_dex_gpu: install_rs_check_toolchain
-	RUSTFLAGS="$(RUSTFLAGS)" cargo $(CARGO_RS_CHECK_TOOLCHAIN) bench \
+	RUSTFLAGS="$(RUSTFLAGS)" __TFHE_RS_BENCH_TYPE=$(BENCH_TYPE) \
+	cargo $(CARGO_RS_CHECK_TOOLCHAIN) bench \
 	--bench hlapi-dex \
 	--features=integer,gpu,internal-keycache,pbs-stats,nightly-avx512 -p tfhe-benchmark --profile release_lto_off --
 
@@ -1599,7 +1603,7 @@ bench_hlapi_dex_gpu: install_rs_check_toolchain
 bench_hlapi_erc20_hpu: install_rs_check_toolchain
 	source ./setup_hpu.sh --config $(HPU_CONFIG); \
 	export V80_PCIE_DEV=${V80_PCIE_DEV}; \
-	RUSTFLAGS="$(RUSTFLAGS)" \
+	RUSTFLAGS="$(RUSTFLAGS)" __TFHE_RS_BENCH_TYPE=$(BENCH_TYPE) \
 	cargo $(CARGO_RS_CHECK_TOOLCHAIN) bench \
 	--bench hlapi-erc20 \
 	--features=integer,internal-keycache,hpu,hpu-v80,pbs-stats -p tfhe-benchmark --

--- a/tfhe-benchmark/benches/high_level_api/dex.rs
+++ b/tfhe-benchmark/benches/high_level_api/dex.rs
@@ -4,7 +4,7 @@ use benchmark::params_aliases::BENCH_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY
 use benchmark::params_aliases::BENCH_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
 #[cfg(feature = "gpu")]
 use benchmark::utilities::configure_gpu;
-use benchmark::utilities::{write_to_json, OperatorType};
+use benchmark::utilities::{get_bench_type, write_to_json, BenchmarkType, OperatorType};
 use criterion::measurement::WallTime;
 use criterion::{BenchmarkGroup, Criterion, Throughput};
 use rand::prelude::*;
@@ -1329,89 +1329,89 @@ fn main() {
         );
     }
 
-    // FheUint64 latency
-    {
-        let mut group = c.benchmark_group(bench_name);
-        bench_swap_request_latency(
-            &mut group,
-            &cks,
-            bench_name,
-            "FheUint64",
-            "swap_request::whitepaper",
-            swap_request_update_dex_balance_whitepaper::<FheUint64>,
-            swap_request_finalize::<FheUint64>,
-        );
-        bench_swap_request_latency(
-            &mut group,
-            &cks,
-            bench_name,
-            "FheUint64",
-            "swap_request::no_cmux",
-            swap_request_update_dex_balance_no_cmux::<FheUint64>,
-            swap_request_finalize::<FheUint64>,
-        );
-        bench_swap_claim_latency(
-            &mut group,
-            &cks,
-            bench_name,
-            "FheUint64",
-            "swap_claim::whitepaper",
-            swap_claim_prepare::<FheUint64, FheUint128>,
-            swap_claim_update_dex_balance_whitepaper::<FheUint64>,
-        );
-        bench_swap_claim_latency(
-            &mut group,
-            &cks,
-            bench_name,
-            "FheUint64",
-            "swap_claim::no_cmux",
-            swap_claim_prepare::<FheUint64, FheUint128>,
-            swap_claim_update_dex_balance_no_cmux::<FheUint64>,
-        );
+    match get_bench_type() {
+        BenchmarkType::Latency => {
+            let mut group = c.benchmark_group(bench_name);
+            bench_swap_request_latency(
+                &mut group,
+                &cks,
+                bench_name,
+                "FheUint64",
+                "swap_request::whitepaper",
+                swap_request_update_dex_balance_whitepaper::<FheUint64>,
+                swap_request_finalize::<FheUint64>,
+            );
+            bench_swap_request_latency(
+                &mut group,
+                &cks,
+                bench_name,
+                "FheUint64",
+                "swap_request::no_cmux",
+                swap_request_update_dex_balance_no_cmux::<FheUint64>,
+                swap_request_finalize::<FheUint64>,
+            );
+            bench_swap_claim_latency(
+                &mut group,
+                &cks,
+                bench_name,
+                "FheUint64",
+                "swap_claim::whitepaper",
+                swap_claim_prepare::<FheUint64, FheUint128>,
+                swap_claim_update_dex_balance_whitepaper::<FheUint64>,
+            );
+            bench_swap_claim_latency(
+                &mut group,
+                &cks,
+                bench_name,
+                "FheUint64",
+                "swap_claim::no_cmux",
+                swap_claim_prepare::<FheUint64, FheUint128>,
+                swap_claim_update_dex_balance_no_cmux::<FheUint64>,
+            );
 
-        group.finish();
-    }
-    // FheUint64 Throughput
-    {
-        let mut group = c.benchmark_group(bench_name);
-        bench_swap_request_throughput(
-            &mut group,
-            &cks,
-            bench_name,
-            "FheUint64",
-            "swap_request::whitepaper",
-            swap_request_update_dex_balance_whitepaper::<FheUint64>,
-            swap_request_finalize::<FheUint64>,
-        );
-        bench_swap_request_throughput(
-            &mut group,
-            &cks,
-            bench_name,
-            "FheUint64",
-            "swap_request::no_cmux",
-            swap_request_update_dex_balance_no_cmux::<FheUint64>,
-            swap_request_finalize::<FheUint64>,
-        );
-        bench_swap_claim_throughput(
-            &mut group,
-            &cks,
-            bench_name,
-            "FheUint64",
-            "swap_claim::whitepaper",
-            swap_claim_prepare::<FheUint64, FheUint128>,
-            swap_claim_update_dex_balance_whitepaper::<FheUint64>,
-        );
-        bench_swap_claim_throughput(
-            &mut group,
-            &cks,
-            bench_name,
-            "FheUint64",
-            "swap_claim::no_cmux",
-            swap_claim_prepare::<FheUint64, FheUint128>,
-            swap_claim_update_dex_balance_no_cmux::<FheUint64>,
-        );
-        group.finish();
-    }
+            group.finish();
+        }
+        BenchmarkType::Throughput => {
+            let mut group = c.benchmark_group(bench_name);
+            bench_swap_request_throughput(
+                &mut group,
+                &cks,
+                bench_name,
+                "FheUint64",
+                "swap_request::whitepaper",
+                swap_request_update_dex_balance_whitepaper::<FheUint64>,
+                swap_request_finalize::<FheUint64>,
+            );
+            bench_swap_request_throughput(
+                &mut group,
+                &cks,
+                bench_name,
+                "FheUint64",
+                "swap_request::no_cmux",
+                swap_request_update_dex_balance_no_cmux::<FheUint64>,
+                swap_request_finalize::<FheUint64>,
+            );
+            bench_swap_claim_throughput(
+                &mut group,
+                &cks,
+                bench_name,
+                "FheUint64",
+                "swap_claim::whitepaper",
+                swap_claim_prepare::<FheUint64, FheUint128>,
+                swap_claim_update_dex_balance_whitepaper::<FheUint64>,
+            );
+            bench_swap_claim_throughput(
+                &mut group,
+                &cks,
+                bench_name,
+                "FheUint64",
+                "swap_claim::no_cmux",
+                swap_claim_prepare::<FheUint64, FheUint128>,
+                swap_claim_update_dex_balance_no_cmux::<FheUint64>,
+            );
+            group.finish();
+        }
+    };
 
     c.final_summary();
 }
@@ -1468,90 +1468,90 @@ fn main() {
         );
     }
 
-    // FheUint64 latency
-    {
-        let mut group = c.benchmark_group(bench_name);
-        bench_swap_request_latency(
-            &mut group,
-            &cks,
-            bench_name,
-            "FheUint64",
-            "swap_request::whitepaper",
-            swap_request_update_dex_balance_whitepaper::<FheUint64>,
-            swap_request_finalize::<FheUint64>,
-        );
-        bench_swap_request_latency(
-            &mut group,
-            &cks,
-            bench_name,
-            "FheUint64",
-            "swap_request::no_cmux",
-            swap_request_update_dex_balance_no_cmux::<FheUint64>,
-            swap_request_finalize::<FheUint64>,
-        );
-        bench_swap_claim_latency(
-            &mut group,
-            &cks,
-            bench_name,
-            "FheUint64",
-            "swap_claim::whitepaper",
-            swap_claim_prepare::<FheUint64, FheUint128>,
-            swap_claim_update_dex_balance_whitepaper::<FheUint64>,
-        );
-        bench_swap_claim_latency(
-            &mut group,
-            &cks,
-            bench_name,
-            "FheUint64",
-            "swap_claim::no_cmux",
-            swap_claim_prepare::<FheUint64, FheUint128>,
-            swap_claim_update_dex_balance_no_cmux::<FheUint64>,
-        );
+    match get_bench_type() {
+        BenchmarkType::Latency => {
+            let mut group = c.benchmark_group(bench_name);
+            bench_swap_request_latency(
+                &mut group,
+                &cks,
+                bench_name,
+                "FheUint64",
+                "swap_request::whitepaper",
+                swap_request_update_dex_balance_whitepaper::<FheUint64>,
+                swap_request_finalize::<FheUint64>,
+            );
+            bench_swap_request_latency(
+                &mut group,
+                &cks,
+                bench_name,
+                "FheUint64",
+                "swap_request::no_cmux",
+                swap_request_update_dex_balance_no_cmux::<FheUint64>,
+                swap_request_finalize::<FheUint64>,
+            );
+            bench_swap_claim_latency(
+                &mut group,
+                &cks,
+                bench_name,
+                "FheUint64",
+                "swap_claim::whitepaper",
+                swap_claim_prepare::<FheUint64, FheUint128>,
+                swap_claim_update_dex_balance_whitepaper::<FheUint64>,
+            );
+            bench_swap_claim_latency(
+                &mut group,
+                &cks,
+                bench_name,
+                "FheUint64",
+                "swap_claim::no_cmux",
+                swap_claim_prepare::<FheUint64, FheUint128>,
+                swap_claim_update_dex_balance_no_cmux::<FheUint64>,
+            );
 
-        group.finish();
-    }
+            group.finish();
+        }
 
-    // FheUint64 Throughput
-    {
-        let mut group = c.benchmark_group(bench_name);
-        cuda_bench_swap_request_throughput(
-            &mut group,
-            &cks,
-            bench_name,
-            "FheUint64",
-            "swap_request::whitepaper",
-            swap_request_update_dex_balance_whitepaper::<FheUint64>,
-            swap_request_finalize::<FheUint64>,
-        );
-        cuda_bench_swap_request_throughput(
-            &mut group,
-            &cks,
-            bench_name,
-            "FheUint64",
-            "swap_request::no_cmux",
-            swap_request_update_dex_balance_no_cmux::<FheUint64>,
-            swap_request_finalize::<FheUint64>,
-        );
-        cuda_bench_swap_claim_throughput(
-            &mut group,
-            &cks,
-            bench_name,
-            "FheUint64",
-            "swap_claim::whitepaper",
-            swap_claim_prepare::<FheUint64, FheUint128>,
-            swap_claim_update_dex_balance_whitepaper::<FheUint64>,
-        );
-        cuda_bench_swap_claim_throughput(
-            &mut group,
-            &cks,
-            bench_name,
-            "FheUint64",
-            "swap_claim::no_cmux",
-            swap_claim_prepare::<FheUint64, FheUint128>,
-            swap_claim_update_dex_balance_no_cmux::<FheUint64>,
-        );
-        group.finish();
-    }
+        BenchmarkType::Throughput => {
+            let mut group = c.benchmark_group(bench_name);
+            cuda_bench_swap_request_throughput(
+                &mut group,
+                &cks,
+                bench_name,
+                "FheUint64",
+                "swap_request::whitepaper",
+                swap_request_update_dex_balance_whitepaper::<FheUint64>,
+                swap_request_finalize::<FheUint64>,
+            );
+            cuda_bench_swap_request_throughput(
+                &mut group,
+                &cks,
+                bench_name,
+                "FheUint64",
+                "swap_request::no_cmux",
+                swap_request_update_dex_balance_no_cmux::<FheUint64>,
+                swap_request_finalize::<FheUint64>,
+            );
+            cuda_bench_swap_claim_throughput(
+                &mut group,
+                &cks,
+                bench_name,
+                "FheUint64",
+                "swap_claim::whitepaper",
+                swap_claim_prepare::<FheUint64, FheUint128>,
+                swap_claim_update_dex_balance_whitepaper::<FheUint64>,
+            );
+            cuda_bench_swap_claim_throughput(
+                &mut group,
+                &cks,
+                bench_name,
+                "FheUint64",
+                "swap_claim::no_cmux",
+                swap_claim_prepare::<FheUint64, FheUint128>,
+                swap_claim_update_dex_balance_no_cmux::<FheUint64>,
+            );
+            group.finish();
+        }
+    };
 
     c.final_summary();
 }

--- a/tfhe-benchmark/benches/high_level_api/erc20.rs
+++ b/tfhe-benchmark/benches/high_level_api/erc20.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "gpu")]
 use benchmark::utilities::configure_gpu;
-use benchmark::utilities::{write_to_json, OperatorType};
+use benchmark::utilities::{get_bench_type, write_to_json, BenchmarkType, OperatorType};
 use criterion::measurement::WallTime;
 use criterion::{BenchmarkGroup, Criterion, Throughput};
 use rand::prelude::*;
@@ -768,83 +768,83 @@ fn main() {
         print_transfer_pbs_counts(&cks, "FheUint64", "safe", par_transfer_safe::<FheUint64>);
     }
 
-    // FheUint64 latency
-    {
-        let mut group = c.benchmark_group(bench_name);
-        bench_transfer_latency(
-            &mut group,
-            &cks,
-            bench_name,
-            "FheUint64",
-            "transfer::whitepaper",
-            par_transfer_whitepaper::<FheUint64>,
-        );
-        bench_transfer_latency(
-            &mut group,
-            &cks,
-            bench_name,
-            "FheUint64",
-            "transfer::no_cmux",
-            par_transfer_no_cmux::<FheUint64>,
-        );
-        bench_transfer_latency(
-            &mut group,
-            &cks,
-            bench_name,
-            "FheUint64",
-            "transfer::overflow",
-            par_transfer_overflow::<FheUint64>,
-        );
-        bench_transfer_latency(
-            &mut group,
-            &cks,
-            bench_name,
-            "FheUint64",
-            "transfer::safe",
-            par_transfer_safe::<FheUint64>,
-        );
+    match get_bench_type() {
+        BenchmarkType::Latency => {
+            let mut group = c.benchmark_group(bench_name);
+            bench_transfer_latency(
+                &mut group,
+                &cks,
+                bench_name,
+                "FheUint64",
+                "transfer::whitepaper",
+                par_transfer_whitepaper::<FheUint64>,
+            );
+            bench_transfer_latency(
+                &mut group,
+                &cks,
+                bench_name,
+                "FheUint64",
+                "transfer::no_cmux",
+                par_transfer_no_cmux::<FheUint64>,
+            );
+            bench_transfer_latency(
+                &mut group,
+                &cks,
+                bench_name,
+                "FheUint64",
+                "transfer::overflow",
+                par_transfer_overflow::<FheUint64>,
+            );
+            bench_transfer_latency(
+                &mut group,
+                &cks,
+                bench_name,
+                "FheUint64",
+                "transfer::safe",
+                par_transfer_safe::<FheUint64>,
+            );
 
-        group.finish();
-    }
+            group.finish();
+        }
 
-    // FheUint64 Throughput
-    {
-        let mut group = c.benchmark_group(bench_name);
-        bench_transfer_throughput(
-            &mut group,
-            &cks,
-            bench_name,
-            "FheUint64",
-            "transfer::whitepaper",
-            par_transfer_whitepaper::<FheUint64>,
-        );
-        bench_transfer_throughput(
-            &mut group,
-            &cks,
-            bench_name,
-            "FheUint64",
-            "transfer::no_cmux",
-            par_transfer_no_cmux::<FheUint64>,
-        );
-        bench_transfer_throughput(
-            &mut group,
-            &cks,
-            bench_name,
-            "FheUint64",
-            "transfer::overflow",
-            par_transfer_overflow::<FheUint64>,
-        );
-        bench_transfer_throughput(
-            &mut group,
-            &cks,
-            bench_name,
-            "FheUint64",
-            "transfer::safe",
-            par_transfer_safe::<FheUint64>,
-        );
+        BenchmarkType::Throughput => {
+            let mut group = c.benchmark_group(bench_name);
+            bench_transfer_throughput(
+                &mut group,
+                &cks,
+                bench_name,
+                "FheUint64",
+                "transfer::whitepaper",
+                par_transfer_whitepaper::<FheUint64>,
+            );
+            bench_transfer_throughput(
+                &mut group,
+                &cks,
+                bench_name,
+                "FheUint64",
+                "transfer::no_cmux",
+                par_transfer_no_cmux::<FheUint64>,
+            );
+            bench_transfer_throughput(
+                &mut group,
+                &cks,
+                bench_name,
+                "FheUint64",
+                "transfer::overflow",
+                par_transfer_overflow::<FheUint64>,
+            );
+            bench_transfer_throughput(
+                &mut group,
+                &cks,
+                bench_name,
+                "FheUint64",
+                "transfer::safe",
+                par_transfer_safe::<FheUint64>,
+            );
 
-        group.finish();
-    }
+            group.finish();
+        }
+    };
 
     c.final_summary();
 }
@@ -888,82 +888,82 @@ fn main() {
         print_transfer_pbs_counts(&cks, "FheUint64", "safe", par_transfer_safe::<FheUint64>);
     }
 
-    // FheUint64 latency
-    {
-        let mut group = c.benchmark_group(bench_name);
-        bench_transfer_latency(
-            &mut group,
-            &cks,
-            bench_name,
-            "FheUint64",
-            "transfer::whitepaper",
-            par_transfer_whitepaper::<FheUint64>,
-        );
-        bench_transfer_latency(
-            &mut group,
-            &cks,
-            bench_name,
-            "FheUint64",
-            "transfer::no_cmux",
-            par_transfer_no_cmux::<FheUint64>,
-        );
-        bench_transfer_latency(
-            &mut group,
-            &cks,
-            bench_name,
-            "FheUint64",
-            "transfer::overflow",
-            par_transfer_overflow::<FheUint64>,
-        );
-        bench_transfer_latency(
-            &mut group,
-            &cks,
-            bench_name,
-            "FheUint64",
-            "transfer::safe",
-            par_transfer_safe::<FheUint64>,
-        );
+    match get_bench_type() {
+        BenchmarkType::Latency => {
+            let mut group = c.benchmark_group(bench_name);
+            bench_transfer_latency(
+                &mut group,
+                &cks,
+                bench_name,
+                "FheUint64",
+                "transfer::whitepaper",
+                par_transfer_whitepaper::<FheUint64>,
+            );
+            bench_transfer_latency(
+                &mut group,
+                &cks,
+                bench_name,
+                "FheUint64",
+                "transfer::no_cmux",
+                par_transfer_no_cmux::<FheUint64>,
+            );
+            bench_transfer_latency(
+                &mut group,
+                &cks,
+                bench_name,
+                "FheUint64",
+                "transfer::overflow",
+                par_transfer_overflow::<FheUint64>,
+            );
+            bench_transfer_latency(
+                &mut group,
+                &cks,
+                bench_name,
+                "FheUint64",
+                "transfer::safe",
+                par_transfer_safe::<FheUint64>,
+            );
 
-        group.finish();
-    }
+            group.finish();
+        }
 
-    // FheUint64 Throughput
-    {
-        let mut group = c.benchmark_group(bench_name);
-        cuda_bench_transfer_throughput(
-            &mut group,
-            &cks,
-            bench_name,
-            "FheUint64",
-            "transfer::whitepaper",
-            transfer_whitepaper::<FheUint64>,
-        );
-        cuda_bench_transfer_throughput(
-            &mut group,
-            &cks,
-            bench_name,
-            "FheUint64",
-            "transfer::no_cmux",
-            transfer_no_cmux::<FheUint64>,
-        );
-        cuda_bench_transfer_throughput(
-            &mut group,
-            &cks,
-            bench_name,
-            "FheUint64",
-            "transfer::overflow",
-            transfer_overflow::<FheUint64>,
-        );
-        cuda_bench_transfer_throughput(
-            &mut group,
-            &cks,
-            bench_name,
-            "FheUint64",
-            "transfer::safe",
-            transfer_safe::<FheUint64>,
-        );
-        group.finish();
-    }
+        BenchmarkType::Throughput => {
+            let mut group = c.benchmark_group(bench_name);
+            cuda_bench_transfer_throughput(
+                &mut group,
+                &cks,
+                bench_name,
+                "FheUint64",
+                "transfer::whitepaper",
+                transfer_whitepaper::<FheUint64>,
+            );
+            cuda_bench_transfer_throughput(
+                &mut group,
+                &cks,
+                bench_name,
+                "FheUint64",
+                "transfer::no_cmux",
+                transfer_no_cmux::<FheUint64>,
+            );
+            cuda_bench_transfer_throughput(
+                &mut group,
+                &cks,
+                bench_name,
+                "FheUint64",
+                "transfer::overflow",
+                transfer_overflow::<FheUint64>,
+            );
+            cuda_bench_transfer_throughput(
+                &mut group,
+                &cks,
+                bench_name,
+                "FheUint64",
+                "transfer::safe",
+                transfer_safe::<FheUint64>,
+            );
+            group.finish();
+        }
+    };
 
     c.final_summary();
 }
@@ -992,69 +992,69 @@ fn main() {
 
     let bench_name = "hlapi::hpu::erc20::transfer";
 
-    // FheUint64 latency
-    {
-        let mut group = c.benchmark_group(bench_name);
-        bench_transfer_latency(
-            &mut group,
-            &cks,
-            bench_name,
-            "FheUint64",
-            "whitepaper",
-            transfer_whitepaper::<FheUint64>,
-        );
-        // Erc20 optimized instruction only available on Hpu
-        bench_transfer_latency(
-            &mut group,
-            &cks,
-            bench_name,
-            "FheUint64",
-            "hpu_optim",
-            transfer_hpu::<FheUint64>,
-        );
-        // Erc20 SIMD instruction only available on Hpu
-        bench_transfer_latency_simd(
-            &mut group,
-            &cks,
-            bench_name,
-            "FheUint64",
-            "hpu_simd",
-            transfer_hpu_simd::<FheUint64>,
-        );
-        group.finish();
-    }
+    match get_bench_type() {
+        BenchmarkType::Latency => {
+            let mut group = c.benchmark_group(bench_name);
+            bench_transfer_latency(
+                &mut group,
+                &cks,
+                bench_name,
+                "FheUint64",
+                "whitepaper",
+                transfer_whitepaper::<FheUint64>,
+            );
+            // Erc20 optimized instruction only available on Hpu
+            bench_transfer_latency(
+                &mut group,
+                &cks,
+                bench_name,
+                "FheUint64",
+                "hpu_optim",
+                transfer_hpu::<FheUint64>,
+            );
+            // Erc20 SIMD instruction only available on Hpu
+            bench_transfer_latency_simd(
+                &mut group,
+                &cks,
+                bench_name,
+                "FheUint64",
+                "hpu_simd",
+                transfer_hpu_simd::<FheUint64>,
+            );
+            group.finish();
+        }
 
-    // FheUint64 Throughput
-    {
-        let mut group = c.benchmark_group(bench_name);
-        hpu_bench_transfer_throughput(
-            &mut group,
-            &cks,
-            bench_name,
-            "FheUint64",
-            "whitepaper",
-            transfer_whitepaper::<FheUint64>,
-        );
-        // Erc20 optimized instruction only available on Hpu
-        hpu_bench_transfer_throughput(
-            &mut group,
-            &cks,
-            bench_name,
-            "FheUint64",
-            "hpu_optim",
-            transfer_hpu::<FheUint64>,
-        );
-        // Erc20 SIMD instruction only available on Hpu
-        hpu_bench_transfer_throughput_simd(
-            &mut group,
-            &cks,
-            bench_name,
-            "FheUint64",
-            "hpu_simd",
-            transfer_hpu_simd::<FheUint64>,
-        );
-        group.finish();
-    }
+        BenchmarkType::Throughput => {
+            let mut group = c.benchmark_group(bench_name);
+            hpu_bench_transfer_throughput(
+                &mut group,
+                &cks,
+                bench_name,
+                "FheUint64",
+                "whitepaper",
+                transfer_whitepaper::<FheUint64>,
+            );
+            // Erc20 optimized instruction only available on Hpu
+            hpu_bench_transfer_throughput(
+                &mut group,
+                &cks,
+                bench_name,
+                "FheUint64",
+                "hpu_optim",
+                transfer_hpu::<FheUint64>,
+            );
+            // Erc20 SIMD instruction only available on Hpu
+            hpu_bench_transfer_throughput_simd(
+                &mut group,
+                &cks,
+                bench_name,
+                "FheUint64",
+                "hpu_simd",
+                transfer_hpu_simd::<FheUint64>,
+            );
+            group.finish();
+        }
+    };
 
     c.final_summary();
 }


### PR DESCRIPTION
Following the same pattern as other benchmarks.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/2961)
<!-- Reviewable:end -->
