### PR TITLE
chore: use common msrv for the workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,10 @@ exclude = [
     "utils/tfhe-lints",
     "apps/trivium",
 ]
+
+[workspace.package]
+rust-version = "1.85"
+
 [workspace.dependencies]
 aligned-vec = { version = "0.6", default-features = false }
 bytemuck = "<1.24"

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ CPU_COUNT=$(shell ./scripts/cpu_count.sh)
 RS_BUILD_TOOLCHAIN:=stable
 CARGO_RS_BUILD_TOOLCHAIN:=+$(RS_BUILD_TOOLCHAIN)
 CARGO_PROFILE?=release
-MIN_RUST_VERSION:=$(shell grep '^rust-version[[:space:]]*=' tfhe/Cargo.toml | cut -d '=' -f 2 | xargs)
+MIN_RUST_VERSION:=$(shell grep '^rust-version[[:space:]]*=' Cargo.toml | cut -d '=' -f 2 | xargs)
 AVX512_SUPPORT?=OFF
 WASM_RUSTFLAGS:=
 BIG_TESTS_INSTANCE?=FALSE

--- a/tfhe-benchmark/Cargo.toml
+++ b/tfhe-benchmark/Cargo.toml
@@ -7,7 +7,7 @@ documentation = "https://docs.zama.ai/tfhe-rs"
 repository = "https://github.com/zama-ai/tfhe-rs"
 license = "BSD-3-Clause-Clear"
 description = "tfhe-benchmark: Performances measurements facility for tfhe-rs."
-rust-version = "1.84"
+rust-version.workspace = true
 publish = false
 
 [lib]

--- a/tfhe-csprng/Cargo.toml
+++ b/tfhe-csprng/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tfhe-csprng"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 license = "BSD-3-Clause-Clear"
 description = "Cryptographically Secure PRNG used in the TFHE-rs library."
@@ -9,7 +9,7 @@ documentation = "https://docs.zama.ai/tfhe-rs"
 repository = "https://github.com/zama-ai/tfhe-rs"
 readme = "README.md"
 keywords = ["fully", "homomorphic", "encryption", "fhe", "cryptography"]
-rust-version = "1.72"
+rust-version.workspace = true
 
 [dependencies]
 aes = "0.8.2"

--- a/tfhe-ntt/Cargo.toml
+++ b/tfhe-ntt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tfhe-ntt"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 description = "tfhe-ntt is a pure Rust high performance number theoretic transform library."
 readme = "README.md"
@@ -8,7 +8,7 @@ repository = "https://github.com/zama-ai/tfhe-rs"
 license = "BSD-3-Clause-Clear"
 homepage = "https://zama.ai/"
 keywords = ["ntt"]
-rust-version = "1.67"
+rust-version.workspace = true
 
 
 [dependencies]

--- a/tfhe-ntt/src/roots.rs
+++ b/tfhe-ntt/src/roots.rs
@@ -32,7 +32,7 @@ pub const fn sqrt_mod_ex64(p: Div64, q: u64, s: u64, z: u64, n: u64) -> Option<u
     let mut m = s;
     let mut c = exp_mod64(p, z, q);
     let mut t = exp_mod64(p, n, q);
-    let mut r = exp_mod64(p, n, (q + 1) / 2);
+    let mut r = exp_mod64(p, n, q.div_ceil(2));
 
     loop {
         if t == 0 {

--- a/tfhe-zk-pok/Cargo.toml
+++ b/tfhe-zk-pok/Cargo.toml
@@ -8,7 +8,7 @@ documentation = "https://docs.zama.ai/tfhe-rs"
 repository = "https://github.com/zama-ai/tfhe-rs"
 license = "BSD-3-Clause-Clear"
 description = "tfhe-zk-pok: An implementation of zero-knowledge proofs of encryption for TFHE."
-rust-version = "1.84"
+rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tfhe/Cargo.toml
+++ b/tfhe/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [
     "/js_on_wasm_tests/",
     "/web_wasm_parallel_tests/",
 ]
-rust-version = "1.85"
+rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/utils/tfhe-versionable/Cargo.toml
+++ b/utils/tfhe-versionable/Cargo.toml
@@ -8,7 +8,7 @@ documentation = "https://docs.rs/tfhe_versionable"
 repository = "https://github.com/zama-ai/tfhe-rs"
 license = "BSD-3-Clause-Clear"
 description = "tfhe-versionable: Add versioning informations/backward compatibility on rust types used for serialization"
-rust-version = "1.81"
+rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Since cargo commands create a lock using the smallest msrv in the workspace, it can prevent getting up-to-date dependencies

<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description
Cargo commands will create a lockfile using the smallest msrv in the workspace. 
This leads to a situation where crate A with a high msrv will be restrained to dependencies compatible with a low msrv because of an unrelated crate B in the workspace.
To simplify this, we set a common msrv for the workspace.

I did not update the version of zk-pok and versionable because they are already updated by https://github.com/zama-ai/tfhe-rs/pull/2950

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/2965)
<!-- Reviewable:end -->
