### PR TITLE
fix: remove redundant Clone bound from get()

### DIFF
--- a/tfhe/src/keycache/mod.rs
+++ b/tfhe/src/keycache/mod.rs
@@ -198,7 +198,7 @@ pub mod utils {
     where
         P: Copy + PartialEq + NamedParam,
         S: PersistentStorage<P, K>,
-        K: From<P> + Clone,
+        K: From<P>,
     {
         pub fn get(&self, param: P) -> SharedKey<K> {
             self.get_with_closure(param, &mut K::from)


### PR DESCRIPTION
The Clone bound on K in KeyCache<P, K, S>::get was unnecessary.
The method forwards &mut K::from to get_with_closure and returns SharedKey<K>,which is Arc<OnceLock<K)>-backed and does not require K: Clone. Removing the bound relaxes trait requirements without changing behavior or API guarantees.

Notes:
- In-memory cache holds SharedKey<K>, not K, so no cloning occurs.
- PersistentStorage only needs (de)serialization, not cloning.
