### PR TITLE
chore: remove redundant Clone bound from get()

### DIFF
--- a/tfhe/src/keycache/mod.rs
+++ b/tfhe/src/keycache/mod.rs
@@ -198,7 +198,7 @@ pub mod utils {
     where
         P: Copy + PartialEq + NamedParam,
         S: PersistentStorage<P, K>,
-        K: From<P> + Clone,
+        K: From<P>,
     {
         pub fn get(&self, param: P) -> SharedKey<K> {
             self.get_with_closure(param, &mut K::from)


### PR DESCRIPTION
supersedes https://github.com/zama-ai/tfhe-rs/pull/2972