### PR TITLE
chore(ci): fix cpu weekly benchmarks schedule groups handling

### DIFF
--- a/.github/workflows/benchmark_cpu_common.yml
+++ b/.github/workflows/benchmark_cpu_common.yml
@@ -21,7 +21,7 @@ on:
         default: false
       additional_recipe: # Make recipes to run aside the benchmarks.
         type: string # Use comma separated values to generate an array
-      additional_file_to_parse: # Make recipes aditional to run aside the benchamrks. Use comma separated values to generate an array
+      additional_file_to_parse: # Other files to parse, located under tfhe-benchmark/ directory
         type: string # Use comma separated values to generate an array
       additional_results_type:
         type: string

--- a/.github/workflows/benchmark_cpu_weekly.yml
+++ b/.github/workflows/benchmark_cpu_weekly.yml
@@ -46,13 +46,13 @@ jobs:
           echo "is_quarterly_bench=${{ github.event.schedule == '0 4 25 MAR,JUN,SEP,DEC *' }}" >> "${GITHUB_OUTPUT}"
 
       - name: Weekly benchmarks
-        if: env.WEEKLY_BENCH_GROUP_1 || env.WEEKLY_BENCH_GROUP_2
+        if: steps.check_bench_group_1.outputs.is_weekly_bench_group_1 || steps.check_bench_group_2.outputs.is_weekly_bench_group_2
         run: |
           echo "OP_FLAVOR=[\"default\"]" >> "${GITHUB_ENV}"
           echo "ALL_PRECISIONS=false" >> "${GITHUB_ENV}"
 
       - name: Quarterly benchmarks
-        if: env.QUARTERLY_BENCH
+        if: steps.check_quarterly_bench.outputs.is_quarterly_bench
         run: |
           echo "OP_FLAVOR=[\"default\", \"unchecked\"]" >> "${GITHUB_ENV}"
           echo "ALL_PRECISIONS=true" >> "${GITHUB_ENV}"
@@ -190,7 +190,7 @@ jobs:
     with:
       command: boolean
       additional_recipe: measure_boolean_key_sizes
-      additional_file_to_parse: boolean_key_size.csv
+      additional_file_to_parse: boolean_key_sizes.csv
     secrets:
       BOT_USERNAME: ${{ secrets.BOT_USERNAME }}
       SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}


### PR DESCRIPTION
The steps responsible for setting the OP_FLAVOR and ALL_PRECISION variables were never executed due to usage of non-existing env variable.
This causes OP_FLAVOR value to be null and thus would trigger error on benchmarks that doesn't handle unknown values for BENCH_OP_FLAVOR.

Also fixes filename to parse for additional boolean benchmark.