### PR TITLE
chore: remove redundant clones

### DIFF
--- a/tasks/src/check_tfhe_docs_are_tested.rs
+++ b/tasks/src/check_tfhe_docs_are_tested.rs
@@ -103,7 +103,7 @@ pub fn check_tfhe_docs_are_tested() -> Result<(), Error> {
             if path.is_file() && path.extension().is_some_and(|e| e == "md") {
                 let file_content = std::fs::read_to_string(&path).ok()?;
                 if file_content.contains("```rust") {
-                    Some(path.to_path_buf())
+                    Some(path)
                 } else {
                     None
                 }

--- a/tfhe-zk-pok/src/curve_api/bls12_446.rs
+++ b/tfhe-zk-pok/src/curve_api/bls12_446.rs
@@ -1508,7 +1508,7 @@ mod tests {
         let sum_zeroize = &zeroize1 + &zeroize2;
         let sum_zp = zp1 + zp2;
 
-        assert_eq!(sum_zp.inner, sum_zeroize.clone().into());
+        assert_eq!(sum_zp.inner, sum_zeroize.into());
 
         let sum_zeroize_zp = zp1 + &zeroize2;
 
@@ -1517,7 +1517,7 @@ mod tests {
         let prod_zeroize = &zeroize1 * &zeroize2;
         let prod_zp = zp1 * zp2;
 
-        assert_eq!(prod_zp.inner, prod_zeroize.clone().into());
+        assert_eq!(prod_zp.inner, prod_zeroize.into());
 
         let prod_zeroize_zp = zp1 * &zeroize2;
 

--- a/tfhe-zk-pok/src/proofs/pke.rs
+++ b/tfhe-zk-pok/src/proofs/pke.rs
@@ -1647,7 +1647,7 @@ mod tests {
 
         testcase_before_bound_e1.e1[bad_idx] = if rng.gen() { bad_term } else { -bad_term };
 
-        let mut testcase_before_bound_e2 = testcase.clone();
+        let mut testcase_before_bound_e2 = testcase;
         let bad_idx = rng.gen::<usize>() % k;
 
         testcase_before_bound_e2.e2[bad_idx] = if rng.gen() { bad_term } else { -bad_term };

--- a/tfhe/tests/hpu.rs
+++ b/tfhe/tests/hpu.rs
@@ -53,7 +53,7 @@ mod hpu_test {
     ) -> (std::sync::Mutex<HpuDevice>, tfhe::integer::ClientKey, u128) {
         // Hpu io dump for debug  -------------------------------------------------
         #[cfg(feature = "hpu-debug")]
-        if let Some(dump_path) = std::env::var("HPU_IO_DUMP").ok() {
+        if let Ok(dump_path) = std::env::var("HPU_IO_DUMP") {
             set_hpu_io_dump(&dump_path);
         }
 
@@ -941,8 +941,7 @@ mod hpu_test {
             );
             ntt_bsk
         };
-        let hpu_bsk =
-            HpuLweBootstrapKeyOwned::create_from(cpu_bsk_orig.as_view(), hpu_params.clone());
+        let hpu_bsk = HpuLweBootstrapKeyOwned::create_from(cpu_bsk_orig.as_view(), hpu_params);
 
         let cpu_bsk_lb = NttLweBootstrapKeyOwned::from(hpu_bsk.as_view());
 


### PR DESCRIPTION
supersedes https://github.com/zama-ai/tfhe-rs/pull/2996

removes some clones in some locations (test/utils)

Most of the removed clones have been kept: rationale being in some cases it's easier to have simple code in some locations and keep code visually consistent (notably for ZK tests) where everything is cloned

in a lot of cases the compiler can likely identify some useless clones and remove them for us.