### PR TITLE
chore(ci): use builds result to pass branch protection

### DIFF
--- a/.github/workflows/cargo_build.yml
+++ b/.github/workflows/cargo_build.yml
@@ -141,22 +141,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check all builds success
-        if: needs.parallel-pcc-cpu.result == 'success' &&
-          needs.pcc-hpu.result == 'success' &&
-          needs.build-tfhe-full.result == 'success' &&
-          needs.build.result == 'success' &&
-          needs.build-layers.result == 'success' &&
-          needs.build-c-api.result == 'success'
+        if: needs.parallel-pcc-cpu.outputs.builds-result == 'success' &&
+          needs.pcc-hpu.outputs.builds-result == 'success' &&
+          needs.build-tfhe-full.outputs.builds-result == 'success' &&
+          needs.build.outputs.builds-result == 'success' &&
+          needs.build-layers.outputs.builds-result == 'success' &&
+          needs.build-c-api.outputs.builds-result == 'success'
         run: |
           echo "All tfhe-rs build checks passed"
 
       - name: Check builds failure
-        if: needs.parallel-pcc-cpu.result != 'success' ||
-          needs.pcc-hpu.result != 'success' ||
-          needs.build-tfhe-full.result != 'success' ||
-          needs.build.result != 'success' ||
-          needs.build-layers.result != 'success' ||
-          needs.build-c-api.result != 'success'
+        if: needs.parallel-pcc-cpu.outputs.builds-result != 'success' ||
+          needs.pcc-hpu.outputs.builds-result != 'success' ||
+          needs.build-tfhe-full.outputs.builds-result != 'success' ||
+          needs.build.outputs.builds-result != 'success' ||
+          needs.build-layers.outputs.builds-result != 'success' ||
+          needs.build-c-api.outputs.builds-result != 'success'
         run: |
           echo "Some tfhe-rs build checks failed"
           exit 1

--- a/.github/workflows/cargo_build_common.yml
+++ b/.github/workflows/cargo_build_common.yml
@@ -23,6 +23,10 @@ on:
       extra-runners-to-use: # Additional runners to run builds command against
         type: string # Use comma separated values to generate an array
         default: ""
+    outputs:
+      builds-result:
+        description: "Result of builds job"
+        value: ${{ jobs.builds.outputs.result }}
     secrets:
       REPO_CHECKOUT_TOKEN:
         required: true
@@ -114,6 +118,8 @@ jobs:
       matrix:
         runner: ${{ fromJSON(needs.prepare-matrix.outputs.runners) }}
       fail-fast: false
+    outputs:
+      result: ${{ steps.set_builds_result.outputs.result }}
     steps:
       - name: Checkout tfhe-rs repo
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
@@ -191,6 +197,12 @@ jobs:
 
       # The wasm build check is a bit annoying to set-up here and is done during the tests in
       # aws_tfhe_tests.yml
+
+      - name: Set result output
+        id: set_builds_result
+        if: ${{ always() }}
+        run: | # zizmor: ignore[template-injection] this context variable is safe
+          echo "result=${{ job.status }}" >> "${GITHUB_OUTPUT}"
 
   teardown-instance:
     name: cargo_build_common/teardown-instance


### PR DESCRIPTION
Instance teardown might fail regardless the result of build commands. To make CI green in pull-request we need to check the result of the build commands instead of the whole workflow result. Doing so ensure a PR could pass branch protection rules even if the teardown fails.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3010)
<!-- Reviewable:end -->
