### PR TITLE
chore(ci): update repositories before any other apt operation

### DIFF
--- a/.github/actions/gpu_setup/action.yml
+++ b/.github/actions/gpu_setup/action.yml
@@ -23,8 +23,8 @@ runs:
         echo "${CMAKE_SCRIPT_SHA} cmake-${CMAKE_VERSION}-linux-x86_64.sh" > checksum
         sha256sum -c checksum
         sudo bash cmake-"${CMAKE_VERSION}"-linux-x86_64.sh --skip-license --prefix=/usr/ --exclude-subdir
-        sudo apt remove -y unattended-upgrades
         sudo apt update
+        sudo apt remove -y unattended-upgrades
         sudo apt install -y cmake-format libclang-dev
       env:
         CMAKE_VERSION: 3.29.6


### PR DESCRIPTION
This is done to avoid failure on dependencies' installation.
