### PR TITLE
chore(ci): remove check on secret availability for params checks

### DIFF
--- a/.github/workflows/parameters_check.yml
+++ b/.github/workflows/parameters_check.yml
@@ -48,6 +48,11 @@ jobs:
           persist-credentials: 'false'
           token: ${{ secrets.REPO_CHECKOUT_TOKEN }}
 
+      - name: Install latest stable
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # zizmor: ignore[stale-action-refs] this action doesn't create releases
+        with:
+          toolchain: stable
+
       - name: Checkout lattice-estimator
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:


### PR DESCRIPTION
This is needed only when the triggering event is pull_request and PR comes from an external contributor.

