### PR TITLE
chore(wasm): install wasm bindgen before using wasm pack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -650,7 +650,7 @@ build_web_js_api: install_rs_build_toolchain install_wasm_pack
 
 .PHONY: build_web_js_api_parallel # Build the js API targeting the web browser with parallelism support
 # parallel wasm requires specific build options, see https://github.com/rust-lang/rust/pull/147225
-build_web_js_api_parallel: install_rs_check_toolchain install_wasm_pack
+build_web_js_api_parallel: install_rs_check_toolchain install_wasm_pack install_wasm_bindgen_cli
 	cd tfhe && \
 	rustup component add rust-src --toolchain $(RS_CHECK_TOOLCHAIN) && \
 	RUSTFLAGS="$(WASM_RUSTFLAGS) -C target-feature=+atomics,+bulk-memory \


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description
Should fix https://github.com/zama-ai/tfhe-rs/actions/runs/19634899761/job/56223246117, hard to replicate the bug since it looks like some kind of race condition.
