### PR TITLE
chore(bench): fix bench prefix pattern for hlapi ops

### DIFF
--- a/tfhe-benchmark/benches/high_level_api/bench.rs
+++ b/tfhe-benchmark/benches/high_level_api/bench.rs
@@ -39,12 +39,14 @@ fn bench_fhe_type<FheType>(
     for<'a> FheType: FheMin<&'a FheType, Output = FheType> + FheMax<&'a FheType, Output = FheType>,
 {
     let mut bench_group = c.benchmark_group(type_name);
-    let mut bench_prefix = "hlapi::ops".to_string();
+    let mut bench_prefix = "hlapi".to_string();
     if cfg!(feature = "gpu") {
         bench_prefix = format!("{}::cuda", bench_prefix);
     } else if cfg!(feature = "hpu") {
         bench_prefix = format!("{}::hpu", bench_prefix);
     }
+
+    bench_prefix = format!("{}::ops", bench_prefix);
 
     let mut rng = thread_rng();
 


### PR DESCRIPTION
To follow the standard used by other HLAPI benchmarks and ease parsing for data_extractor.
