### PR TITLE
fix(ci): only check test vectors on x86

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1199,7 +1199,13 @@ gen_test_vectors:
 # `comm` is used to compare the checksums, and will also notify of any added file
 .PHONY: check_test_vectors
 check_test_vectors:
-	./scripts/test_vectors.sh check apps/test-vectors
+	@# Test vectors are not compatible between architectures
+	@if uname -a | grep -q x86; then \
+		./scripts/test_vectors.sh check apps/test-vectors; \
+	else \
+		echo "Cannot check test vectors on non x86 platform for now."; \
+	fi
+
 
 .PHONY: doc # Build rust doc
 doc: install_rs_check_toolchain

--- a/scripts/test_vectors.sh
+++ b/scripts/test_vectors.sh
@@ -8,6 +8,11 @@ MODE="$1"
 TARGET_DIR="$2"
 CHECKSUM_FILE="checksums.sha256"
 
+if [ -z "$(uname -a | grep x86)" ]; then
+	 echo "Wrong architecture for test vectors, only x86 is supported"
+	 exit 1
+fi
+
 if [ -z "$MODE" ] || [ -z "$TARGET_DIR" ]; then
     echo "Usage: $0 <mode> <target dir>"
     echo "Modes:"


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description
Only run check_test_vector on x86. Fix m1 failures: https://github.com/zama-ai/tfhe-rs/actions/runs/19685454965