### PR TITLE
chore(gpu): reduce long run tests number of inputs to avoid timeout on 4090

### DIFF
--- a/tfhe/src/integer/server_key/radix_parallel/tests_long_run/mod.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_long_run/mod.rs
@@ -16,7 +16,7 @@ pub(crate) mod test_signed_erc20;
 pub(crate) mod test_signed_random_op_sequence;
 
 pub(crate) const NB_CTXT_LONG_RUN: usize = 32;
-pub(crate) const NB_TESTS_LONG_RUN: usize = 20000;
+pub(crate) const NB_TESTS_LONG_RUN: usize = 8000;
 pub(crate) const NB_TESTS_LONG_RUN_MINIMAL: usize = 200;
 
 pub(crate) fn get_user_defined_seed() -> Option<Seed> {


### PR DESCRIPTION

<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description

Since we added classical PBS long run tests CI time has increased, this causes timeout on 4090 after 24h. We need to reduce the batch size to avoid the timeout.

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
