### PR TITLE
Ns/chore/compact list conformance

### DIFF
--- a/tfhe/docs/fhe-computation/data-handling/serialization.md
+++ b/tfhe/docs/fhe-computation/data-handling/serialization.md
@@ -105,15 +105,15 @@ fn main() {
     let msgs = [27, 188u8];
     let mut builder = CompactCiphertextList::builder(&public_key);
     builder.extend(msgs.iter().copied());
-    let compact_list = builder.build();
+    let compact_list = builder.build_packed();
 
     let mut buffer = vec![];
     safe_serialize(&compact_list, &mut buffer, 1 << 20).unwrap();
 
-    let conformance_params = CompactCiphertextListConformanceParams {
-        shortint_params: params_1.to_shortint_conformance_param(),
-        num_elements_constraint: ListSizeConstraint::exact_size(2),
-    };
+    let conformance_params =
+        CompactCiphertextListConformanceParams::from_parameters_and_size_constraint(
+           params_1.try_into().unwrap(),
+           ListSizeConstraint::exact_size(2));
     safe_deserialize_conformant::<CompactCiphertextList>(buffer.as_slice(), 1 << 20, &conformance_params)
         .unwrap();
 }

--- a/tfhe/src/high_level_api/integers/unsigned/tests/cpu.rs
+++ b/tfhe/src/high_level_api/integers/unsigned/tests/cpu.rs
@@ -534,10 +534,11 @@ fn test_safe_deserialize_conformant_compact_fhe_uint32() {
         .serialize_into(&a, &mut serialized)
         .unwrap();
 
-    let params = CompactCiphertextListConformanceParams {
-        shortint_params: block_params.to_shortint_conformance_param(),
-        num_elements_constraint: ListSizeConstraint::exact_size(clears.len()),
-    };
+    let params = CompactCiphertextListConformanceParams::from_parameters_and_size_constraint(
+        pk.parameters(),
+        ListSizeConstraint::exact_size(clears.len()),
+    )
+    .allow_unpacked();
     let deserialized_a = DeserializationConfig::new(1 << 20)
         .deserialize_from::<CompactCiphertextList>(serialized.as_slice(), &params)
         .unwrap();

--- a/tfhe/src/high_level_api/integers/unsigned/tests/gpu.rs
+++ b/tfhe/src/high_level_api/integers/unsigned/tests/gpu.rs
@@ -591,18 +591,21 @@ fn test_safe_deserialize_conformant_compact_fhe_uint32_gpu() {
             .unwrap();
 
         let params = if i == 0 {
-            CompactCiphertextListConformanceParams {
-                shortint_params: PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128
-                    .to_shortint_conformance_param(),
-                num_elements_constraint: ListSizeConstraint::exact_size(clears.len()),
-            }
+            CompactCiphertextListConformanceParams::from_parameters_and_size_constraint(
+                PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128
+                    .try_into()
+                    .unwrap(),
+                ListSizeConstraint::exact_size(clears.len()),
+            )
+            .allow_unpacked()
         } else if i == 1 {
-            CompactCiphertextListConformanceParams {
-                shortint_params:
-                    PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128
-                        .to_shortint_conformance_param(),
-                num_elements_constraint: ListSizeConstraint::exact_size(clears.len()),
-            }
+            CompactCiphertextListConformanceParams::from_parameters_and_size_constraint(
+                PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128
+                    .try_into()
+                    .unwrap(),
+                ListSizeConstraint::exact_size(clears.len()),
+            )
+            .allow_unpacked()
         } else {
             panic!("Unexpected parameter set")
         };

--- a/tfhe/src/integer/parameters/mod.rs
+++ b/tfhe/src/integer/parameters/mod.rs
@@ -3,7 +3,8 @@ use crate::conformance::ListSizeConstraint;
 use crate::integer::key_switching_key::KeySwitchingKeyView;
 use crate::integer::server_key::ServerKey;
 use crate::shortint::parameters::{
-    CarryModulus, CiphertextConformanceParams, EncryptionKeyChoice, MessageModulus,
+    CarryModulus, CiphertextConformanceParams, CompactCiphertextListExpansionKind,
+    CompactPublicKeyEncryptionParameters, EncryptionKeyChoice, MessageModulus,
 };
 pub use crate::shortint::parameters::{
     DecompositionBaseLog, DecompositionLevelCount, DynamicDistribution, GlweDimension,
@@ -171,16 +172,6 @@ pub struct RadixCiphertextConformanceParams {
 /// Can be used on a server to check if client inputs are well formed
 /// before running a computation on them
 impl RadixCiphertextConformanceParams {
-    pub fn to_ct_list_conformance_parameters(
-        &self,
-        list_constraint: ListSizeConstraint,
-    ) -> CompactCiphertextListConformanceParams {
-        CompactCiphertextListConformanceParams {
-            shortint_params: self.shortint_params,
-            num_elements_constraint: list_constraint,
-        }
-    }
-
     pub fn from_pbs_parameters<P: Into<PBSParameters>>(
         params: P,
         num_blocks_per_integer: usize,
@@ -198,6 +189,38 @@ impl RadixCiphertextConformanceParams {
 /// before running a computation on them
 #[derive(Copy, Clone)]
 pub struct CompactCiphertextListConformanceParams {
-    pub shortint_params: CiphertextConformanceParams,
+    pub encryption_lwe_dimension: LweDimension,
+    pub message_modulus: MessageModulus,
+    pub carry_modulus: CarryModulus,
+    pub ciphertext_modulus: CiphertextModulus,
+    pub expansion_kind: CompactCiphertextListExpansionKind,
     pub num_elements_constraint: ListSizeConstraint,
+    pub allow_unpacked: bool,
+}
+
+impl CompactCiphertextListConformanceParams {
+    pub fn from_parameters_and_size_constraint(
+        value: CompactPublicKeyEncryptionParameters,
+        num_elements_constraint: ListSizeConstraint,
+    ) -> Self {
+        Self {
+            encryption_lwe_dimension: value.encryption_lwe_dimension,
+            message_modulus: value.message_modulus,
+            carry_modulus: value.carry_modulus,
+            ciphertext_modulus: value.ciphertext_modulus,
+            expansion_kind: value.expansion_kind,
+            num_elements_constraint,
+            allow_unpacked: false,
+        }
+    }
+
+    /// Allow the list to be composed of unpacked ciphertexts.
+    ///
+    /// Note that this means that the ciphertexts won't be sanitized.
+    pub fn allow_unpacked(self) -> Self {
+        Self {
+            allow_unpacked: true,
+            ..self
+        }
+    }
 }

--- a/tfhe/src/safe_serialization.rs
+++ b/tfhe/src/safe_serialization.rs
@@ -718,17 +718,13 @@ mod test_integer {
     use crate::high_level_api::{generate_keys, ConfigBuilder};
     use crate::prelude::*;
     use crate::safe_serialization::{DeserializationConfig, SerializationConfig};
-    use crate::shortint::parameters::{
-        PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
-        PARAM_MESSAGE_3_CARRY_3_KS_PBS_GAUSSIAN_2M128,
-    };
+    use crate::shortint::parameters::PARAM_MESSAGE_3_CARRY_3_KS_PBS_GAUSSIAN_2M128;
     use crate::{
         set_server_key, CompactCiphertextList, CompactCiphertextListConformanceParams,
         CompactPublicKey, FheUint8,
     };
 
-    #[test]
-    fn safe_deserialization_ct_list() {
+    fn test_safe_deserialization_ct_list(is_packed: bool) {
         let (client_key, sks) = generate_keys(ConfigBuilder::default().build());
         set_server_key(sks);
 
@@ -736,11 +732,16 @@ mod test_integer {
 
         let msg = [27u8, 10, 3];
 
-        let ct_list = CompactCiphertextList::builder(&public_key)
-            .push(27u8)
-            .push(10u8)
-            .push(3u8)
-            .build();
+        let mut builder = CompactCiphertextList::builder(&public_key);
+        for value in msg {
+            builder.push(value);
+        }
+
+        let ct_list = if is_packed {
+            builder.build_packed()
+        } else {
+            builder.build()
+        };
 
         let mut buffer = vec![];
 
@@ -751,17 +752,33 @@ mod test_integer {
 
         assert_eq!(size as usize, buffer.len());
 
-        let to_param_set = |list_size_constraint| CompactCiphertextListConformanceParams {
-            shortint_params: PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128
-                .to_shortint_conformance_param(),
-            num_elements_constraint: list_size_constraint,
+        let to_param_set = |list_size_constraint| {
+            let params =
+                CompactCiphertextListConformanceParams::from_parameters_and_size_constraint(
+                    public_key.parameters(),
+                    list_size_constraint,
+                );
+
+            if is_packed {
+                params
+            } else {
+                params.allow_unpacked()
+            }
         };
 
+        let wrong_pke_params =
+            CompactCiphertextListConformanceParams::from_parameters_and_size_constraint(
+                PARAM_MESSAGE_3_CARRY_3_KS_PBS_GAUSSIAN_2M128
+                    .try_into()
+                    .unwrap(),
+                ListSizeConstraint::exact_size(3),
+            );
+
         for param_set in [
-            CompactCiphertextListConformanceParams {
-                shortint_params: PARAM_MESSAGE_3_CARRY_3_KS_PBS_GAUSSIAN_2M128
-                    .to_shortint_conformance_param(),
-                num_elements_constraint: ListSizeConstraint::exact_size(3),
+            if is_packed {
+                wrong_pke_params
+            } else {
+                wrong_pke_params.allow_unpacked()
             },
             to_param_set(ListSizeConstraint::exact_size(2)),
             to_param_set(ListSizeConstraint::exact_size(4)),
@@ -779,22 +796,14 @@ mod test_integer {
             ListSizeConstraint::try_size_in_range(3, 4).unwrap(),
             ListSizeConstraint::try_size_in_range(2, 4).unwrap(),
         ] {
-            let params = CompactCiphertextListConformanceParams {
-                shortint_params: PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128
-                    .to_shortint_conformance_param(),
-                num_elements_constraint: len_constraint,
-            };
+            let params = to_param_set(len_constraint);
 
             DeserializationConfig::new(1 << 20)
                 .deserialize_from::<CompactCiphertextList>(buffer.as_slice(), &params)
                 .unwrap();
         }
 
-        let params = CompactCiphertextListConformanceParams {
-            shortint_params: PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128
-                .to_shortint_conformance_param(),
-            num_elements_constraint: ListSizeConstraint::exact_size(3),
-        };
+        let params = to_param_set(ListSizeConstraint::exact_size(3));
         let ct2 = DeserializationConfig::new(1 << 20)
             .deserialize_from::<CompactCiphertextList>(buffer.as_slice(), &params)
             .unwrap();
@@ -808,6 +817,16 @@ mod test_integer {
         let dec: Vec<u8> = cts.iter().map(|a| a.decrypt(&client_key)).collect();
 
         assert_eq!(&msg[..], &dec);
+    }
+
+    #[test]
+    fn safe_deserialization_ct_list() {
+        test_safe_deserialization_ct_list(false);
+    }
+
+    #[test]
+    fn safe_deserialization_ct_list_packed() {
+        test_safe_deserialization_ct_list(true);
     }
 
     #[test]
@@ -834,18 +853,22 @@ mod test_integer {
 
         assert_eq!(size as usize, buffer.len());
 
-        let to_param_set = |list_size_constraint| CompactCiphertextListConformanceParams {
-            shortint_params: PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128
-                .to_shortint_conformance_param(),
-            num_elements_constraint: list_size_constraint,
+        let to_param_set = |list_size_constraint| {
+            CompactCiphertextListConformanceParams::from_parameters_and_size_constraint(
+                public_key.parameters(),
+                list_size_constraint,
+            )
+            .allow_unpacked()
         };
 
         for param_set in [
-            CompactCiphertextListConformanceParams {
-                shortint_params: PARAM_MESSAGE_3_CARRY_3_KS_PBS_GAUSSIAN_2M128
-                    .to_shortint_conformance_param(),
-                num_elements_constraint: ListSizeConstraint::exact_size(3),
-            },
+            CompactCiphertextListConformanceParams::from_parameters_and_size_constraint(
+                PARAM_MESSAGE_3_CARRY_3_KS_PBS_GAUSSIAN_2M128
+                    .try_into()
+                    .unwrap(),
+                ListSizeConstraint::exact_size(3),
+            )
+            .allow_unpacked(),
             to_param_set(ListSizeConstraint::exact_size(2)),
             to_param_set(ListSizeConstraint::exact_size(4)),
             to_param_set(ListSizeConstraint::try_size_in_range(1, 2).unwrap()),
@@ -862,22 +885,14 @@ mod test_integer {
             ListSizeConstraint::try_size_in_range(3, 4).unwrap(),
             ListSizeConstraint::try_size_in_range(2, 4).unwrap(),
         ] {
-            let params = CompactCiphertextListConformanceParams {
-                shortint_params: PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128
-                    .to_shortint_conformance_param(),
-                num_elements_constraint: len_constraint,
-            };
+            let params = to_param_set(len_constraint);
 
             DeserializationConfig::new(1 << 20)
                 .deserialize_from::<CompactCiphertextList>(buffer.as_slice(), &params)
                 .unwrap();
         }
 
-        let params = CompactCiphertextListConformanceParams {
-            shortint_params: PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128
-                .to_shortint_conformance_param(),
-            num_elements_constraint: ListSizeConstraint::exact_size(3),
-        };
+        let params = to_param_set(ListSizeConstraint::exact_size(3));
         let ct2 = DeserializationConfig::new(1 << 20)
             .deserialize_from::<CompactCiphertextList>(buffer.as_slice(), &params)
             .unwrap();

--- a/tfhe/src/shortint/parameters/mod.rs
+++ b/tfhe/src/shortint/parameters/mod.rs
@@ -5,7 +5,6 @@
 //! homomorphic evaluation of integer circuits as well as a list of secure cryptographic parameter
 //! sets.
 
-use crate::conformance::ListSizeConstraint;
 pub use crate::core_crypto::commons::dispersion::{StandardDev, Variance};
 use crate::core_crypto::commons::math::random::{CompressionSeed, Uniform};
 pub use crate::core_crypto::commons::parameters::{
@@ -196,25 +195,6 @@ pub struct CiphertextListConformanceParams {
     pub carry_modulus: CarryModulus,
     pub degree: Degree,
     pub expansion_kind: CompactCiphertextListExpansionKind,
-}
-
-impl CiphertextConformanceParams {
-    pub fn to_ct_list_conformance_parameters(
-        &self,
-        list_constraint: ListSizeConstraint,
-    ) -> CiphertextListConformanceParams {
-        CiphertextListConformanceParams {
-            ct_list_params: LweCiphertextListConformanceParams {
-                lwe_dim: self.ct_params.lwe_dim,
-                ct_modulus: self.ct_params.ct_modulus,
-                lwe_ciphertext_count_constraint: list_constraint,
-            },
-            message_modulus: self.message_modulus,
-            carry_modulus: self.carry_modulus,
-            degree: self.degree,
-            expansion_kind: self.atomic_pattern.into(),
-        }
-    }
 }
 
 impl From<ClassicPBSParameters> for PBSParameters {


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description
Small tweaks to compact list conformance:
- Detect degree in compact list conformance. Before this the compact list conformance params took their degree from the compute parameters they were derived from, but it was implicit and it was a bit hard to make it work with packed lists
- Create compact list conformance params from compact pke params instead of compute params
- reworked a bit CompactList conformance to make it behave more like ProvenCompactList conformance
- by default, disallow unpacked list. To accept them, it must be explicitly enabled in the conformance params

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3068)
<!-- Reviewable:end -->
