### PR TITLE
chore: bump dyn-stack to 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ rust-version = "1.91.1"
 [workspace.dependencies]
 aligned-vec = { version = "0.6", default-features = false }
 bytemuck = "1.24"
-dyn-stack = { version = "0.11", default-features = false }
+dyn-stack = { version = "0.13", default-features = false }
 itertools = "0.14"
 num-complex = "0.4"
 pulp = { version = "0.22", default-features = false }

--- a/tfhe-benchmark/benches/core_crypto/ks_pbs_bench.rs
+++ b/tfhe-benchmark/benches/core_crypto/ks_pbs_bench.rs
@@ -106,7 +106,6 @@ fn ks_pbs<Scalar: UnsignedTorus + CastInto<usize> + Serialize>(
                         fourier_bsk.polynomial_size(),
                         fft,
                     )
-                    .unwrap()
                     .unaligned_bytes_required(),
                 );
 
@@ -196,7 +195,6 @@ fn ks_pbs<Scalar: UnsignedTorus + CastInto<usize> + Serialize>(
                                     fourier_bsk.polynomial_size(),
                                     fft.as_view(),
                                 )
-                                .unwrap()
                                 .unaligned_bytes_required(),
                             );
 

--- a/tfhe-benchmark/benches/core_crypto/pbs128_bench.rs
+++ b/tfhe-benchmark/benches/core_crypto/pbs128_bench.rs
@@ -117,7 +117,6 @@ fn pbs_128(c: &mut Criterion) {
             fourier_bsk.polynomial_size(),
             fft
         )
-        .unwrap()
         .unaligned_bytes_required()
     ];
 

--- a/tfhe-benchmark/benches/core_crypto/pbs_bench.rs
+++ b/tfhe-benchmark/benches/core_crypto/pbs_bench.rs
@@ -92,7 +92,6 @@ fn mem_optimized_pbs<Scalar: UnsignedTorus + CastInto<usize> + Serialize>(
                         fourier_bsk.polynomial_size(),
                         fft,
                     )
-                    .unwrap()
                     .unaligned_bytes_required(),
                 );
 
@@ -165,7 +164,6 @@ fn mem_optimized_pbs<Scalar: UnsignedTorus + CastInto<usize> + Serialize>(
                                         fourier_bsk.polynomial_size(),
                                         fft.as_view(),
                                     )
-                                        .unwrap()
                                         .unaligned_bytes_required(),
                                 );
 
@@ -321,7 +319,6 @@ fn mem_optimized_batched_pbs<Scalar: UnsignedTorus + CastInto<usize> + Serialize
                 CiphertextCount(count),
                 fft,
             )
-            .unwrap()
             .unaligned_bytes_required(),
         );
 
@@ -404,7 +401,6 @@ fn mem_optimized_batched_pbs<Scalar: UnsignedTorus + CastInto<usize> + Serialize
                                         fourier_bsk.polynomial_size(),
                                         fft.as_view(),
                                     )
-                                        .unwrap()
                                         .unaligned_bytes_required(),
                                 );
 
@@ -772,9 +768,7 @@ fn mem_optimized_pbs_ntt(c: &mut Criterion) {
                         params.polynomial_size.unwrap(),
                         ntt,
                     )
-                    .unwrap()
-                    .try_unaligned_bytes_required()
-                    .unwrap();
+                    .unaligned_bytes_required();
 
                 buffers.resize(stack_size);
 
@@ -844,9 +838,7 @@ fn mem_optimized_pbs_ntt(c: &mut Criterion) {
                                     params.polynomial_size.unwrap(),
                                     ntt.as_view(),
                                 )
-                                    .unwrap()
-                                    .try_unaligned_bytes_required()
-                                    .unwrap();
+                                    .unaligned_bytes_required();
 
                                 buffer.resize(stack_size);
 

--- a/tfhe-fft/Cargo.toml
+++ b/tfhe-fft/Cargo.toml
@@ -24,7 +24,7 @@ js-sys = "0.3"
 default = ["std", "avx512"]
 fft128 = []
 avx512 = ["pulp/x86-v4"]
-std = ["pulp/std"]
+std = ["pulp/std", "dyn-stack/std", "dyn-stack/alloc"]
 serde = ["dep:serde", "num-complex/serde"]
 
 [dev-dependencies]
@@ -33,6 +33,7 @@ rand = { workspace = true }
 bincode = "1.3"
 more-asserts = "0.3.1"
 serde_json = "1.0.96"
+dyn-stack = { workspace = true, features = ["alloc"] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/tfhe-fft/README.md
+++ b/tfhe-fft/README.md
@@ -38,14 +38,14 @@ Additionally, an optional 128-bit negacyclic FFT module is provided.
 ```rust
 use tfhe_fft::c64;
 use tfhe_fft::ordered::{Method, Plan};
-use dyn_stack::{GlobalPodBuffer, PodStack};
+use dyn_stack::{PodBuffer, PodStack};
 use num_complex::ComplexFloat;
 use std::time::Duration;
 
 fn main() {
     const N: usize = 4;
     let plan = Plan::new(4, Method::Measure(Duration::from_millis(10)));
-    let mut scratch_memory = GlobalPodBuffer::new(plan.fft_scratch().unwrap());
+    let mut scratch_memory = PodBuffer::try_new(plan.fft_scratch()).unwrap();
     let stack = PodStack::new(&mut scratch_memory);
 
     let data = [

--- a/tfhe-fft/benches/fft.rs
+++ b/tfhe-fft/benches/fft.rs
@@ -124,11 +124,12 @@ pub fn bench_ffts(c: &mut Criterion) {
         1 << 15,
         1 << 16,
     ] {
-        let mut mem = dyn_stack::GlobalPodBuffer::new(StackReq::all_of([
+        let mut mem = dyn_stack::PodBuffer::try_new(StackReq::all_of(&[
             StackReq::new_aligned::<c64>(2 * n, 256), // scratch
             StackReq::new_aligned::<c64>(n, 256),     // src
             StackReq::new_aligned::<c64>(n, 256),     // dst
-        ]));
+        ]))
+        .unwrap();
         let stack = PodStack::new(&mut mem);
         let z = c64::new(0.0, 0.0);
 

--- a/tfhe-fft/src/fft128/f128_ops.rs
+++ b/tfhe-fft/src/fft128/f128_ops.rs
@@ -1025,7 +1025,9 @@ pub mod x86 {
 mod tests {
     use super::*;
     use more_asserts::assert_le;
-    use rug::{ops::Pow, Float, Integer};
+    #[cfg(feature = "std")]
+    use rug::ops::Pow;
+    use rug::{Float, Integer};
 
     const PREC: u32 = 1024;
 

--- a/tfhe-fft/src/lib.rs
+++ b/tfhe-fft/src/lib.rs
@@ -35,13 +35,13 @@
 #![cfg_attr(not(feature = "std"), doc = "```ignore")]
 //! use tfhe_fft::c64;
 //! use tfhe_fft::ordered::{Plan, Method};
-//! use dyn_stack::{PodStack, GlobalPodBuffer};
+//! use dyn_stack::{PodStack, PodBuffer};
 //! use num_complex::ComplexFloat;
 //! use std::time::Duration;
 //!
 //! const N: usize = 4;
 //! let plan = Plan::new(4, Method::Measure(Duration::from_millis(10)));
-//! let mut scratch_memory = GlobalPodBuffer::new(plan.fft_scratch().unwrap());
+//! let mut scratch_memory = PodBuffer::try_new(plan.fft_scratch()).unwrap();
 //! let stack = PodStack::new(&mut scratch_memory);
 //!
 //! let data = [

--- a/tfhe/src/boolean/engine/bootstrapping.rs
+++ b/tfhe/src/boolean/engine/bootstrapping.rs
@@ -371,7 +371,6 @@ impl Bootstrapper {
         let fft = fft.as_view();
         self.computation_buffers.resize(
             convert_standard_lwe_bootstrap_key_to_fourier_mem_optimized_requirement(fft)
-                .unwrap()
                 .unaligned_bytes_required(),
         );
 
@@ -467,7 +466,6 @@ impl Bootstrapper {
                 fourier_bsk.polynomial_size(),
                 fft,
             )
-            .unwrap()
             .unaligned_bytes_required(),
         );
         let stack = self.computation_buffers.stack();
@@ -509,7 +507,6 @@ impl Bootstrapper {
                 fourier_bsk.polynomial_size(),
                 fft,
             )
-            .unwrap()
             .unaligned_bytes_required(),
         );
         let stack = self.computation_buffers.stack();
@@ -556,7 +553,6 @@ impl Bootstrapper {
                 fourier_bsk.polynomial_size(),
                 fft,
             )
-            .unwrap()
             .unaligned_bytes_required(),
         );
         let stack = self.computation_buffers.stack();

--- a/tfhe/src/core_crypto/algorithms/ggsw_conversion.rs
+++ b/tfhe/src/core_crypto/algorithms/ggsw_conversion.rs
@@ -7,7 +7,7 @@ use crate::core_crypto::commons::traits::*;
 use crate::core_crypto::entities::*;
 use crate::core_crypto::fft_impl::fft64::crypto::ggsw::fill_with_forward_fourier_scratch;
 use crate::core_crypto::fft_impl::fft64::math::fft::{Fft, FftView};
-use dyn_stack::{PodStack, SizeOverflow, StackReq};
+use dyn_stack::{PodStack, StackReq};
 use tfhe_fft::c64;
 
 /// Convert a [`GGSW ciphertext`](`GgswCiphertext`) with standard coefficients to the Fourier
@@ -29,7 +29,6 @@ pub fn convert_standard_ggsw_ciphertext_to_fourier<Scalar, InputCont, OutputCont
     let mut buffers = ComputationBuffers::new();
     buffers.resize(
         convert_standard_ggsw_ciphertext_to_fourier_mem_optimized_requirement(fft)
-            .unwrap()
             .unaligned_bytes_required(),
     );
 
@@ -63,6 +62,6 @@ pub fn convert_standard_ggsw_ciphertext_to_fourier_mem_optimized<Scalar, InputCo
 /// Return the required memory for [`convert_standard_ggsw_ciphertext_to_fourier_mem_optimized`].
 pub fn convert_standard_ggsw_ciphertext_to_fourier_mem_optimized_requirement(
     fft: FftView<'_>,
-) -> Result<StackReq, SizeOverflow> {
+) -> StackReq {
     fill_with_forward_fourier_scratch(fft)
 }

--- a/tfhe/src/core_crypto/algorithms/lwe_bootstrap_key_conversion.rs
+++ b/tfhe/src/core_crypto/algorithms/lwe_bootstrap_key_conversion.rs
@@ -9,7 +9,7 @@ use crate::core_crypto::entities::*;
 use crate::core_crypto::fft_impl::fft128::math::fft::Fft128;
 use crate::core_crypto::fft_impl::fft64::crypto::bootstrap::fill_with_forward_fourier_scratch;
 use crate::core_crypto::fft_impl::fft64::math::fft::{Fft, FftView};
-use dyn_stack::{PodStack, SizeOverflow, StackReq};
+use dyn_stack::{PodStack, StackReq};
 use rayon::prelude::*;
 use tfhe_fft::c64;
 
@@ -32,7 +32,6 @@ pub fn convert_standard_lwe_bootstrap_key_to_fourier<Scalar, InputCont, OutputCo
 
     buffers.resize(
         convert_standard_lwe_bootstrap_key_to_fourier_mem_optimized_requirement(fft)
-            .unwrap()
             .unaligned_bytes_required(),
     );
 
@@ -152,7 +151,7 @@ pub fn par_convert_standard_lwe_bootstrap_key_to_fourier<Scalar, InputCont, Outp
 /// Return the required memory for [`convert_standard_lwe_bootstrap_key_to_fourier_mem_optimized`].
 pub fn convert_standard_lwe_bootstrap_key_to_fourier_mem_optimized_requirement(
     fft: FftView<'_>,
-) -> Result<StackReq, SizeOverflow> {
+) -> StackReq {
     fill_with_forward_fourier_scratch(fft)
 }
 

--- a/tfhe/src/core_crypto/algorithms/lwe_multi_bit_bootstrap_key_conversion.rs
+++ b/tfhe/src/core_crypto/algorithms/lwe_multi_bit_bootstrap_key_conversion.rs
@@ -10,7 +10,7 @@ use crate::core_crypto::fft_impl::fft64::math::fft::{
     par_convert_polynomials_list_to_fourier, Fft, FftView,
 };
 
-use dyn_stack::{PodStack, SizeOverflow, StackReq};
+use dyn_stack::{PodStack, StackReq};
 use rayon::prelude::*;
 use tfhe_fft::c64;
 
@@ -33,7 +33,6 @@ pub fn convert_standard_lwe_multi_bit_bootstrap_key_to_fourier<Scalar, InputCont
 
     buffers.resize(
         convert_standard_lwe_multi_bit_bootstrap_key_to_fourier_mem_optimized_requirement(fft)
-            .unwrap()
             .unaligned_bytes_required(),
     );
 
@@ -80,7 +79,7 @@ pub fn convert_standard_lwe_multi_bit_bootstrap_key_to_fourier_mem_optimized<
 /// [`convert_standard_lwe_multi_bit_bootstrap_key_to_fourier_mem_optimized`].
 pub fn convert_standard_lwe_multi_bit_bootstrap_key_to_fourier_mem_optimized_requirement(
     fft: FftView<'_>,
-) -> Result<StackReq, SizeOverflow> {
+) -> StackReq {
     fft.forward_scratch()
 }
 

--- a/tfhe/src/core_crypto/algorithms/lwe_multi_bit_programmable_bootstrapping.rs
+++ b/tfhe/src/core_crypto/algorithms/lwe_multi_bit_programmable_bootstrapping.rs
@@ -577,7 +577,6 @@ pub fn multi_bit_non_deterministic_blind_rotate_assign<Scalar, OutputCont, KeyCo
                 multi_bit_bsk.polynomial_size(),
                 fft,
             )
-            .unwrap()
             .unaligned_bytes_required(),
         );
 
@@ -801,7 +800,6 @@ pub fn multi_bit_deterministic_blind_rotate_assign<Scalar, OutputCont, KeyCont>(
                 multi_bit_bsk.polynomial_size(),
                 fft,
             )
-            .unwrap()
             .unaligned_bytes_required(),
         );
 
@@ -1316,7 +1314,7 @@ pub fn std_multi_bit_non_deterministic_blind_rotate_assign<Scalar, OutputCont, K
         let produce_multi_bit_fourier_ggsw = |thread_id: usize, tx: mpsc::Sender<usize>| {
             let mut buffers = ComputationBuffers::new();
 
-            buffers.resize(fft.forward_scratch().unwrap().unaligned_bytes_required());
+            buffers.resize(fft.forward_scratch().unaligned_bytes_required());
 
             let mut std_ggsw_buffer = GgswCiphertext::new(
                 Scalar::ZERO,
@@ -1413,7 +1411,6 @@ pub fn std_multi_bit_non_deterministic_blind_rotate_assign<Scalar, OutputCont, K
                 multi_bit_bsk.polynomial_size(),
                 fft,
             )
-            .unwrap()
             .unaligned_bytes_required(),
         );
 
@@ -1579,7 +1576,7 @@ pub fn std_multi_bit_deterministic_blind_rotate_assign<Scalar, OutputCont, KeyCo
         let produce_multi_bit_fourier_ggsw = |thread_id| {
             let mut buffers = ComputationBuffers::new();
 
-            buffers.resize(fft.forward_scratch().unwrap().unaligned_bytes_required());
+            buffers.resize(fft.forward_scratch().unaligned_bytes_required());
 
             let mut std_ggsw_buffer = GgswCiphertext::new(
                 Scalar::ZERO,
@@ -1672,7 +1669,6 @@ pub fn std_multi_bit_deterministic_blind_rotate_assign<Scalar, OutputCont, KeyCo
                 multi_bit_bsk.polynomial_size(),
                 fft,
             )
-            .unwrap()
             .unaligned_bytes_required(),
         );
 
@@ -2091,7 +2087,6 @@ pub fn std_multi_bit_f128_deterministic_blind_rotate_assign<Scalar, OutputCont, 
                 multi_bit_bsk.polynomial_size(),
                 fft,
             )
-            .unwrap()
             .unaligned_bytes_required(),
         );
 
@@ -2513,7 +2508,6 @@ pub fn multi_bit_f128_deterministic_blind_rotate_assign<Scalar, OutputCont, KeyC
                 multi_bit_bsk.polynomial_size(),
                 fft,
             )
-            .unwrap()
             .unaligned_bytes_required(),
         );
 

--- a/tfhe/src/core_crypto/algorithms/lwe_programmable_bootstrapping/fft128_pbs.rs
+++ b/tfhe/src/core_crypto/algorithms/lwe_programmable_bootstrapping/fft128_pbs.rs
@@ -9,7 +9,7 @@ use crate::core_crypto::entities::*;
 use crate::core_crypto::fft_impl::fft128::crypto::bootstrap::bootstrap_scratch as bootstrap_scratch_f128;
 use crate::core_crypto::fft_impl::fft128::math::fft::{Fft128, Fft128View};
 use crate::core_crypto::prelude::ModulusSwitchedLweCiphertext;
-use dyn_stack::{PodStack, SizeOverflow, StackReq};
+use dyn_stack::{PodStack, StackReq};
 
 /// Perform a programmable bootstrap given an input [`LWE ciphertext`](`LweCiphertext`), a
 /// look-up table passed as a [`GLWE ciphertext`](`GlweCiphertext`) and an [`LWE bootstrap
@@ -208,7 +208,6 @@ pub fn programmable_bootstrap_f128_lwe_ciphertext<
             fourier_bsk.polynomial_size(),
             fft,
         )
-        .unwrap()
         .unaligned_bytes_required(),
     );
 
@@ -259,7 +258,7 @@ pub fn programmable_bootstrap_f128_lwe_ciphertext_mem_optimized_requirement<Scal
     glwe_size: GlweSize,
     polynomial_size: PolynomialSize,
     fft: Fft128View<'_>,
-) -> Result<StackReq, SizeOverflow> {
+) -> StackReq {
     bootstrap_scratch_f128::<Scalar>(glwe_size, polynomial_size, fft)
 }
 
@@ -408,7 +407,6 @@ pub fn programmable_bootstrap_f128_lwe_ciphertext_mem_optimized_requirement<Scal
 ///         fourier_bsk.polynomial_size(),
 ///         fft,
 ///     )
-///     .unwrap()
 ///     .unaligned_bytes_required(),
 /// );
 ///
@@ -465,7 +463,7 @@ pub fn blind_rotate_f128_lwe_ciphertext_mem_optimized_requirement<Scalar>(
     glwe_size: GlweSize,
     polynomial_size: PolynomialSize,
     fft: Fft128View<'_>,
-) -> Result<StackReq, SizeOverflow> {
+) -> StackReq {
     bootstrap_scratch_f128::<Scalar>(glwe_size, polynomial_size, fft)
 }
 

--- a/tfhe/src/core_crypto/algorithms/lwe_programmable_bootstrapping/fft64_pbs.rs
+++ b/tfhe/src/core_crypto/algorithms/lwe_programmable_bootstrapping/fft64_pbs.rs
@@ -17,7 +17,7 @@ use crate::core_crypto::fft_impl::fft64::crypto::ggsw::{
 };
 use crate::core_crypto::fft_impl::fft64::math::fft::{Fft, FftView};
 use crate::core_crypto::prelude::ModulusSwitchedLweCiphertext;
-use dyn_stack::{PodStack, SizeOverflow, StackReq};
+use dyn_stack::{PodStack, StackReq};
 use tfhe_fft::c64;
 
 /// Perform a blind rotation given an input [`modulus switched LWE
@@ -208,7 +208,6 @@ pub fn blind_rotate_assign<OutputScalar, OutputCont, KeyCont>(
             fourier_bsk.polynomial_size(),
             fft,
         )
-        .unwrap()
         .unaligned_bytes_required(),
     );
 
@@ -254,7 +253,7 @@ pub fn blind_rotate_assign_mem_optimized_requirement<OutputScalar>(
     glwe_size: GlweSize,
     polynomial_size: PolynomialSize,
     fft: FftView<'_>,
-) -> Result<StackReq, SizeOverflow> {
+) -> StackReq {
     blind_rotate_assign_scratch::<OutputScalar>(glwe_size, polynomial_size, fft)
 }
 
@@ -290,7 +289,6 @@ pub fn add_external_product_assign<Scalar, OutputGlweCont, InputGlweCont, GgswCo
             ggsw.polynomial_size(),
             fft,
         )
-        .unwrap()
         .unaligned_bytes_required(),
     );
 
@@ -382,12 +380,10 @@ pub fn add_external_product_assign<Scalar, OutputGlweCont, InputGlweCont, GgswCo
 ///     polynomial_size,
 ///     fft,
 /// )
-/// .unwrap()
 /// .unaligned_bytes_required();
 ///
 /// let buffer_size_req = buffer_size_req.max(
 ///     convert_standard_ggsw_ciphertext_to_fourier_mem_optimized_requirement(fft)
-///         .unwrap()
 ///         .unaligned_bytes_required(),
 /// );
 ///
@@ -478,7 +474,7 @@ pub fn add_external_product_assign_mem_optimized_requirement<Scalar>(
     glwe_size: GlweSize,
     polynomial_size: PolynomialSize,
     fft: FftView<'_>,
-) -> Result<StackReq, SizeOverflow> {
+) -> StackReq {
     impl_add_external_product_assign_scratch::<Scalar>(glwe_size, polynomial_size, fft)
 }
 
@@ -533,7 +529,6 @@ pub fn cmux_assign<Scalar, Cont0, Cont1, GgswCont>(
             ggsw.polynomial_size(),
             fft,
         )
-        .unwrap()
         .unaligned_bytes_required(),
     );
 
@@ -646,12 +641,10 @@ pub fn cmux_assign<Scalar, Cont0, Cont1, GgswCont>(
 ///
 /// let buffer_size_req =
 ///     cmux_assign_mem_optimized_requirement::<u64>(glwe_size, polynomial_size, fft)
-///         .unwrap()
 ///         .unaligned_bytes_required();
 ///
 /// let buffer_size_req = buffer_size_req.max(
 ///     convert_standard_ggsw_ciphertext_to_fourier_mem_optimized_requirement(fft)
-///         .unwrap()
 ///         .unaligned_bytes_required(),
 /// );
 ///
@@ -768,7 +761,7 @@ pub fn cmux_assign_mem_optimized_requirement<Scalar>(
     glwe_size: GlweSize,
     polynomial_size: PolynomialSize,
     fft: FftView<'_>,
-) -> Result<StackReq, SizeOverflow> {
+) -> StackReq {
     cmux_scratch::<Scalar>(glwe_size, polynomial_size, fft)
 }
 
@@ -969,7 +962,6 @@ pub fn programmable_bootstrap_lwe_ciphertext<
             fourier_bsk.polynomial_size(),
             fft,
         )
-        .unwrap()
         .unaligned_bytes_required(),
     );
 
@@ -1051,7 +1043,7 @@ pub fn programmable_bootstrap_lwe_ciphertext_mem_optimized_requirement<OutputSca
     glwe_size: GlweSize,
     polynomial_size: PolynomialSize,
     fft: FftView<'_>,
-) -> Result<StackReq, SizeOverflow> {
+) -> StackReq {
     bootstrap_scratch::<OutputScalar>(glwe_size, polynomial_size, fft)
 }
 
@@ -1139,7 +1131,7 @@ pub fn batch_programmable_bootstrap_lwe_ciphertext_mem_optimized_requirement<Out
     polynomial_size: PolynomialSize,
     ciphertext_count: CiphertextCount,
     fft: FftView<'_>,
-) -> Result<StackReq, SizeOverflow> {
+) -> StackReq {
     batch_bootstrap_scratch::<OutputScalar>(glwe_size, polynomial_size, ciphertext_count, fft)
 }
 

--- a/tfhe/src/core_crypto/algorithms/lwe_programmable_bootstrapping/ntt64_bnf_pbs.rs
+++ b/tfhe/src/core_crypto/algorithms/lwe_programmable_bootstrapping/ntt64_bnf_pbs.rs
@@ -11,7 +11,7 @@ use crate::core_crypto::commons::utils::izip_eq;
 use crate::core_crypto::entities::*;
 use crate::core_crypto::prelude::{lwe_ciphertext_modulus_switch, ModulusSwitchedLweCiphertext};
 use aligned_vec::CACHELINE_ALIGN;
-use dyn_stack::{PodStack, SizeOverflow, StackReq};
+use dyn_stack::{PodStack, StackReq};
 
 /// Perform a blind rotation given an input [`LWE ciphertext`](`LweCiphertext`), modifying a look-up
 /// table passed as a [`GLWE ciphertext`](`GlweCiphertext`) and an [`LWE bootstrap
@@ -190,7 +190,6 @@ pub fn blind_rotate_ntt64_bnf_assign<OutputCont, KeyCont>(
             bsk.polynomial_size(),
             ntt,
         )
-        .unwrap()
         .unaligned_bytes_required(),
     );
 
@@ -452,7 +451,6 @@ pub fn programmable_bootstrap_ntt64_bnf_lwe_ciphertext<InputCont, OutputCont, Ac
             bsk.polynomial_size(),
             ntt,
         )
-        .unwrap()
         .unaligned_bytes_required(),
     );
 
@@ -732,22 +730,18 @@ pub(crate) fn ntt64_bnf_add_external_product_assign_scratch(
     glwe_size: GlweSize,
     polynomial_size: PolynomialSize,
     ntt: Ntt64View<'_>,
-) -> Result<StackReq, SizeOverflow> {
+) -> StackReq {
     let align = CACHELINE_ALIGN;
-    let standard_scratch =
-        StackReq::try_new_aligned::<u64>(glwe_size.0 * polynomial_size.0, align)?;
-    let decomp_sign_scratch =
-        StackReq::try_new_aligned::<u8>(glwe_size.0 * polynomial_size.0, align)?;
-    let ntt_scratch = StackReq::try_new_aligned::<u64>(glwe_size.0 * polynomial_size.0, align)?;
-    let ntt_scratch_single = StackReq::try_new_aligned::<u64>(polynomial_size.0, align)?;
+    let standard_scratch = StackReq::new_aligned::<u64>(glwe_size.0 * polynomial_size.0, align);
+    let decomp_sign_scratch = StackReq::new_aligned::<u8>(glwe_size.0 * polynomial_size.0, align);
+    let ntt_scratch = StackReq::new_aligned::<u64>(glwe_size.0 * polynomial_size.0, align);
+    let ntt_scratch_single = StackReq::new_aligned::<u64>(polynomial_size.0, align);
     let _ = &ntt;
 
     let substack2 = ntt_scratch_single;
-    let substack1 = substack2.try_and(standard_scratch)?;
-    let substack0 = substack1
-        .try_and(standard_scratch)?
-        .try_and(decomp_sign_scratch)?;
-    substack0.try_and(ntt_scratch)
+    let substack1 = substack2.and(standard_scratch);
+    let substack0 = substack1.and(standard_scratch).and(decomp_sign_scratch);
+    substack0.and(ntt_scratch)
 }
 
 /// Return the required memory for [`cmux_ntt64_bnf_assign`].
@@ -755,7 +749,7 @@ pub(crate) fn ntt64_bnf_cmux_scratch(
     glwe_size: GlweSize,
     polynomial_size: PolynomialSize,
     ntt: Ntt64View<'_>,
-) -> Result<StackReq, SizeOverflow> {
+) -> StackReq {
     ntt64_bnf_add_external_product_assign_scratch(glwe_size, polynomial_size, ntt)
 }
 
@@ -764,9 +758,9 @@ pub fn blind_rotate_ntt64_bnf_assign_mem_optimized_requirement(
     glwe_size: GlweSize,
     polynomial_size: PolynomialSize,
     ntt: Ntt64View<'_>,
-) -> Result<StackReq, SizeOverflow> {
-    StackReq::try_new_aligned::<u64>(glwe_size.0 * polynomial_size.0, CACHELINE_ALIGN)?
-        .try_and(ntt64_bnf_cmux_scratch(glwe_size, polynomial_size, ntt)?)
+) -> StackReq {
+    StackReq::new_aligned::<u64>(glwe_size.0 * polynomial_size.0, CACHELINE_ALIGN)
+        .and(ntt64_bnf_cmux_scratch(glwe_size, polynomial_size, ntt))
 }
 
 /// Return the required memory for
@@ -775,10 +769,8 @@ pub fn programmable_bootstrap_ntt64_bnf_lwe_ciphertext_mem_optimized_requirement
     glwe_size: GlweSize,
     polynomial_size: PolynomialSize,
     ntt: Ntt64View<'_>,
-) -> Result<StackReq, SizeOverflow> {
-    blind_rotate_ntt64_bnf_assign_mem_optimized_requirement(glwe_size, polynomial_size, ntt)?
-        .try_and(StackReq::try_new_aligned::<u64>(
-            glwe_size.0 * polynomial_size.0,
-            CACHELINE_ALIGN,
-        )?)
+) -> StackReq {
+    blind_rotate_ntt64_bnf_assign_mem_optimized_requirement(glwe_size, polynomial_size, ntt).and(
+        StackReq::new_aligned::<u64>(glwe_size.0 * polynomial_size.0, CACHELINE_ALIGN),
+    )
 }

--- a/tfhe/src/core_crypto/algorithms/lwe_wopbs.rs
+++ b/tfhe/src/core_crypto/algorithms/lwe_wopbs.rs
@@ -11,7 +11,7 @@ use crate::core_crypto::fft_impl::fft64::crypto::wop_pbs::{
     extract_bits, extract_bits_scratch,
 };
 use crate::core_crypto::fft_impl::fft64::math::fft::FftView;
-use dyn_stack::{PodStack, SizeOverflow, StackReq};
+use dyn_stack::{PodStack, StackReq};
 use rayon::prelude::*;
 use tfhe_fft::c64;
 
@@ -365,7 +365,7 @@ pub fn extract_bits_from_lwe_ciphertext_mem_optimized_requirement<Scalar>(
     glwe_size: GlweSize,
     polynomial_size: PolynomialSize,
     fft: FftView<'_>,
-) -> Result<StackReq, SizeOverflow> {
+) -> StackReq {
     extract_bits_scratch::<Scalar>(
         lwe_dimension,
         ksk_output_key_lwe_dimension,
@@ -514,7 +514,6 @@ pub fn extract_bits_from_lwe_ciphertext_mem_optimized_requirement<Scalar>(
 ///
 /// let buffer_size_req =
 ///     convert_standard_lwe_bootstrap_key_to_fourier_mem_optimized_requirement(fft)
-///         .unwrap()
 ///         .unaligned_bytes_required();
 /// let buffer_size_req = buffer_size_req.max(
 ///     extract_bits_from_lwe_ciphertext_mem_optimized_requirement::<u64>(
@@ -524,7 +523,6 @@ pub fn extract_bits_from_lwe_ciphertext_mem_optimized_requirement<Scalar>(
 ///         polynomial_size,
 ///         fft,
 ///     )
-///     .unwrap()
 ///     .unaligned_bytes_required(),
 /// );
 /// let buffer_size_req = buffer_size_req.max(
@@ -541,7 +539,6 @@ pub fn extract_bits_from_lwe_ciphertext_mem_optimized_requirement<Scalar>(
 ///         cbs_level_count,
 ///         fft,
 ///     )
-///     .unwrap()
 ///     .unaligned_bytes_required(),
 /// );
 ///
@@ -711,7 +708,7 @@ pub fn circuit_bootstrap_boolean_vertical_packing_lwe_ciphertext_list_mem_optimi
     fpksk_output_polynomial_size: PolynomialSize,
     level_cbs: DecompositionLevelCount,
     fft: FftView<'_>,
-) -> Result<StackReq, SizeOverflow> {
+) -> StackReq {
     circuit_bootstrap_boolean_vertical_packing_scratch::<Scalar>(
         lwe_list_in_count,
         lwe_list_out_count,

--- a/tfhe/src/core_crypto/algorithms/test/lwe_programmable_bootstrapping.rs
+++ b/tfhe/src/core_crypto/algorithms/test/lwe_programmable_bootstrapping.rs
@@ -268,7 +268,6 @@ where
                     CiphertextCount(ciphertext_count),
                     fft,
                 )
-                .unwrap()
                 .unaligned_bytes_required(),
             );
 
@@ -460,7 +459,6 @@ where
                 polynomial_size,
                 fft,
             )
-            .unwrap()
             .unaligned_bytes_required(),
         );
 
@@ -798,9 +796,7 @@ fn lwe_encrypt_pbs_ntt64_decrypt_custom_mod(params: ClassicTestParams<u64>) {
         polynomial_size,
         ntt,
     )
-    .unwrap()
-    .try_unaligned_bytes_required()
-    .unwrap();
+    .unaligned_bytes_required();
 
     buffers.resize(stack_size);
 
@@ -1097,9 +1093,7 @@ fn lwe_encrypt_pbs_ntt64_bnf_decrypt(params: ClassicTestParams<u64>) {
             polynomial_size,
             ntt,
         )
-        .unwrap()
-        .try_unaligned_bytes_required()
-        .unwrap();
+        .unaligned_bytes_required();
 
         buffers.resize(stack_size);
 

--- a/tfhe/src/core_crypto/algorithms/test/noise_distribution/lwe_hpu_noise.rs
+++ b/tfhe/src/core_crypto/algorithms/test/noise_distribution/lwe_hpu_noise.rs
@@ -340,9 +340,7 @@ fn hpu_noise_distribution(params: HpuTestParams) {
         polynomial_size,
         ntt,
     )
-    .unwrap()
-    .try_unaligned_bytes_required()
-    .unwrap();
+    .unaligned_bytes_required();
 
     buffers.resize(stack_size);
 

--- a/tfhe/src/core_crypto/experimental/algorithms/pseudo_ggsw_conversion.rs
+++ b/tfhe/src/core_crypto/experimental/algorithms/pseudo_ggsw_conversion.rs
@@ -9,7 +9,7 @@ use crate::core_crypto::experimental::entities::fourier_pseudo_ggsw_ciphertext::
 };
 use crate::core_crypto::experimental::entities::pseudo_ggsw_ciphertext::PseudoGgswCiphertext;
 use crate::core_crypto::fft_impl::fft64::math::fft::{Fft, FftView};
-use dyn_stack::{PodStack, SizeOverflow, StackReq};
+use dyn_stack::{PodStack, StackReq};
 use tfhe_fft::c64;
 
 /// Convert a [`pseudo GGSW ciphertext`](`PseudoGgswCiphertext`) with standard coefficients to the
@@ -31,7 +31,6 @@ pub fn convert_standard_pseudo_ggsw_ciphertext_to_fourier<Scalar, InputCont, Out
     let mut buffers = ComputationBuffers::new();
     buffers.resize(
         convert_standard_pseudo_ggsw_ciphertext_to_fourier_mem_optimized_requirement(fft)
-            .unwrap()
             .unaligned_bytes_required(),
     );
 
@@ -67,6 +66,6 @@ pub fn convert_standard_pseudo_ggsw_ciphertext_to_fourier_mem_optimized<
 /// [`convert_standard_pseudo_ggsw_ciphertext_to_fourier_mem_optimized`].
 pub fn convert_standard_pseudo_ggsw_ciphertext_to_fourier_mem_optimized_requirement(
     fft: FftView<'_>,
-) -> Result<StackReq, SizeOverflow> {
+) -> StackReq {
     fill_with_forward_fourier_scratch(fft)
 }

--- a/tfhe/src/core_crypto/experimental/algorithms/test/lwe_fast_keyswitch.rs
+++ b/tfhe/src/core_crypto/experimental/algorithms/test/lwe_fast_keyswitch.rs
@@ -147,21 +147,16 @@ fn lwe_encrypt_fast_ks_decrypt_custom_mod<
         ks1_polynomial_size,
         fft_ks,
     )
-    .unwrap()
-    .try_unaligned_bytes_required()
-    .unwrap();
+    .unaligned_bytes_required();
 
     let ks_buffer_size_req = ks_buffer_size_req.max(
         convert_standard_ggsw_ciphertext_to_fourier_mem_optimized_requirement(fft_ks)
-            .unwrap()
             .unaligned_bytes_required(),
     );
     let pbs_buffer_size_req = programmable_bootstrap_lwe_ciphertext_mem_optimized_requirement::<
         Scalar,
     >(glwe_dimension.to_glwe_size(), polynomial_size, fft_pbs)
-    .unwrap()
-    .try_unaligned_bytes_required()
-    .unwrap();
+    .unaligned_bytes_required();
 
     ks_buffers.resize(ks_buffer_size_req);
     pbs_buffers.resize(pbs_buffer_size_req);

--- a/tfhe/src/core_crypto/experimental/entities/fourier_pseudo_ggsw_ciphertext.rs
+++ b/tfhe/src/core_crypto/experimental/entities/fourier_pseudo_ggsw_ciphertext.rs
@@ -11,7 +11,7 @@ use crate::core_crypto::fft_impl::fft64::math::decomposition::DecompositionLevel
 use crate::core_crypto::fft_impl::fft64::math::fft::{FftView, FourierPolynomialList};
 use crate::core_crypto::fft_impl::fft64::math::polynomial::FourierPolynomialMutView;
 use aligned_vec::{avec, ABox};
-use dyn_stack::{PodStack, SizeOverflow, StackReq};
+use dyn_stack::{PodStack, StackReq};
 use tfhe_fft::c64;
 
 /// A pseudo GGSW ciphertext in the Fourier domain.
@@ -262,7 +262,7 @@ impl<'a> PseudoFourierGgswCiphertextView<'a> {
 
 /// Return the required memory for
 /// [`PseudoFourierGgswCiphertextMutView::fill_with_forward_fourier`].
-pub fn fill_with_forward_fourier_scratch(fft: FftView<'_>) -> Result<StackReq, SizeOverflow> {
+pub fn fill_with_forward_fourier_scratch(fft: FftView<'_>) -> StackReq {
     fft.forward_scratch()
 }
 

--- a/tfhe/src/core_crypto/fft_impl/common.rs
+++ b/tfhe/src/core_crypto/fft_impl/common.rs
@@ -5,7 +5,7 @@ use crate::core_crypto::commons::parameters::{
 use crate::core_crypto::commons::traits::Container;
 use crate::core_crypto::entities::*;
 use crate::core_crypto::prelude::{CiphertextModulusLog, ContainerMut};
-use dyn_stack::{PodStack, SizeOverflow, StackReq};
+use dyn_stack::{PodStack, StackReq};
 
 pub fn modulus_switch<Scalar: UnsignedInteger>(
     input: Scalar,
@@ -35,7 +35,7 @@ pub trait FourierBootstrapKey<Scalar: UnsignedInteger> {
         decomposition_level_count: DecompositionLevelCount,
     ) -> Self;
 
-    fn fill_with_forward_fourier_scratch(fft: &Self::Fft) -> Result<StackReq, SizeOverflow>;
+    fn fill_with_forward_fourier_scratch(fft: &Self::Fft) -> StackReq;
 
     fn fill_with_forward_fourier<ContBsk>(
         &mut self,
@@ -49,7 +49,7 @@ pub trait FourierBootstrapKey<Scalar: UnsignedInteger> {
         glwe_size: GlweSize,
         polynomial_size: PolynomialSize,
         fft: &Self::Fft,
-    ) -> Result<StackReq, SizeOverflow>;
+    ) -> StackReq;
 
     fn bootstrap<ContLweOut, ContLweIn, ContAcc>(
         &self,
@@ -72,7 +72,7 @@ pub mod tests {
     use crate::core_crypto::fft_impl::common::FourierBootstrapKey;
     use crate::core_crypto::keycache::KeyCacheAccess;
     use crate::core_crypto::prelude::*;
-    use dyn_stack::{GlobalPodBuffer, PodStack};
+    use dyn_stack::{PodBuffer, PodStack};
     use serde::de::DeserializeOwned;
     use serde::Serialize;
 
@@ -160,9 +160,9 @@ pub mod tests {
         fourier_bsk.fill_with_forward_fourier(
             &std_bootstrapping_key,
             &fft,
-            PodStack::new(&mut GlobalPodBuffer::new(
-                K::fill_with_forward_fourier_scratch(&fft).unwrap(),
-            )),
+            PodStack::new(
+                &mut PodBuffer::try_new(K::fill_with_forward_fourier_scratch(&fft)).unwrap(),
+            ),
         );
 
         // Our 4 bits message space
@@ -209,14 +209,14 @@ pub mod tests {
             &lwe_ciphertext_in,
             &accumulator,
             &fft,
-            PodStack::new(&mut GlobalPodBuffer::new(
-                K::bootstrap_scratch(
+            PodStack::new(
+                &mut PodBuffer::try_new(K::bootstrap_scratch(
                     std_bootstrapping_key.glwe_size(),
                     std_bootstrapping_key.polynomial_size(),
                     &fft,
-                )
+                ))
                 .unwrap(),
-            )),
+            ),
         );
 
         // Decrypt the PBS result

--- a/tfhe/src/core_crypto/fft_impl/fft128/math/fft/mod.rs
+++ b/tfhe/src/core_crypto/fft_impl/fft128/math/fft/mod.rs
@@ -3,7 +3,7 @@ use crate::core_crypto::commons::numeric::{CastFrom, CastInto, UnsignedInteger};
 use crate::core_crypto::commons::parameters::PolynomialSize;
 use crate::core_crypto::commons::utils::izip_eq;
 use core::any::TypeId;
-use dyn_stack::{PodStack, SizeOverflow, StackReq};
+use dyn_stack::{PodStack, StackReq};
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::sync::{Arc, OnceLock, RwLock};
@@ -358,12 +358,12 @@ impl Fft128View<'_> {
     }
 
     /// Return the memory required for a backward negacyclic FFT.
-    pub fn backward_scratch(self) -> Result<StackReq, SizeOverflow> {
-        let one = StackReq::try_new_aligned::<f64>(
+    pub fn backward_scratch(self) -> StackReq {
+        let one = StackReq::new_aligned::<f64>(
             self.polynomial_size().0 / 2,
             aligned_vec::CACHELINE_ALIGN,
-        )?;
-        StackReq::try_all_of([one; 4])
+        );
+        StackReq::all_of(&[one; 4])
     }
 
     pub fn forward_as_torus<Scalar: UnsignedTorus>(

--- a/tfhe/src/core_crypto/fft_impl/fft128/math/fft/tests.rs
+++ b/tfhe/src/core_crypto/fft_impl/fft128/math/fft/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::core_crypto::commons::test_tools::{modular_distance, new_random_generator};
 use aligned_vec::avec;
-use dyn_stack::GlobalPodBuffer;
+use dyn_stack::PodBuffer;
 
 fn test_roundtrip<Scalar: UnsignedTorus>() {
     let mut generator = new_random_generator();
@@ -23,7 +23,7 @@ fn test_roundtrip<Scalar: UnsignedTorus>() {
             *x = generator.random_uniform();
         }
 
-        let mut mem = GlobalPodBuffer::new(fft.backward_scratch().unwrap());
+        let mut mem = PodBuffer::try_new(fft.backward_scratch()).unwrap();
         let stack = PodStack::new(&mut mem);
 
         fft.forward_as_torus(
@@ -110,7 +110,7 @@ fn test_product<Scalar: UnsignedTorus>() {
                 *y >>= Scalar::BITS - integer_magnitude;
             }
 
-            let mut mem = GlobalPodBuffer::new(fft.backward_scratch().unwrap());
+            let mut mem = PodBuffer::try_new(fft.backward_scratch()).unwrap();
             let stack = PodStack::new(&mut mem);
 
             fft.forward_as_torus(

--- a/tfhe/src/core_crypto/fft_impl/fft128_u128/crypto/tests.rs
+++ b/tfhe/src/core_crypto/fft_impl/fft128_u128/crypto/tests.rs
@@ -7,7 +7,7 @@ use crate::core_crypto::fft_impl::common::tests::{
 use crate::core_crypto::prelude::test::{TestResources, FFT128_U128_PARAMS};
 use crate::core_crypto::prelude::*;
 use aligned_vec::CACHELINE_ALIGN;
-use dyn_stack::{GlobalPodBuffer, PodStack};
+use dyn_stack::{PodBuffer, PodStack};
 
 #[test]
 fn test_split_external_product() {
@@ -83,14 +83,14 @@ fn test_split_external_product() {
         &ggsw,
         &glwe,
         fft,
-        PodStack::new(&mut GlobalPodBuffer::new(
-            fft128::crypto::ggsw::add_external_product_assign_scratch::<u128>(
-                glwe_dimension.to_glwe_size(),
-                polynomial_size,
-                fft,
-            )
+        PodStack::new(
+            &mut PodBuffer::try_new(fft128::crypto::ggsw::add_external_product_assign_scratch::<
+                u128,
+            >(
+                glwe_dimension.to_glwe_size(), polynomial_size, fft
+            ))
             .unwrap(),
-        )),
+        ),
     );
 
     let mut out_lo = GlweCiphertext::new(
@@ -113,14 +113,14 @@ fn test_split_external_product() {
         &glwe_lo,
         &glwe_hi,
         fft,
-        PodStack::new(&mut GlobalPodBuffer::new(
-            fft128::crypto::ggsw::add_external_product_assign_scratch::<u128>(
-                glwe_dimension.to_glwe_size(),
-                polynomial_size,
-                fft,
-            )
+        PodStack::new(
+            &mut PodBuffer::try_new(fft128::crypto::ggsw::add_external_product_assign_scratch::<
+                u128,
+            >(
+                glwe_dimension.to_glwe_size(), polynomial_size, fft
+            ))
             .unwrap(),
-        )),
+        ),
     );
 
     for ((lo, hi), val) in out_lo
@@ -170,14 +170,12 @@ fn test_split_pbs() {
         ciphertext_modulus,
     );
 
-    let mut mem = GlobalPodBuffer::new(
-        fft128::crypto::bootstrap::bootstrap_scratch::<u128>(
-            glwe_dimension.to_glwe_size(),
-            polynomial_size,
-            fft,
-        )
-        .unwrap(),
-    );
+    let mut mem = PodBuffer::try_new(fft128::crypto::bootstrap::bootstrap_scratch::<u128>(
+        glwe_dimension.to_glwe_size(),
+        polynomial_size,
+        fft,
+    ))
+    .unwrap();
     let stack = PodStack::new(&mut mem);
 
     for _ in 0..20 {

--- a/tfhe/src/core_crypto/fft_impl/fft64/crypto/wop_pbs/tests.rs
+++ b/tfhe/src/core_crypto/fft_impl/fft64/crypto/wop_pbs/tests.rs
@@ -11,7 +11,7 @@ use crate::core_crypto::prelude::test::{
     TestResources, FFT_WOPBS_N1024_PARAMS, FFT_WOPBS_N2048_PARAMS, FFT_WOPBS_N512_PARAMS,
     FFT_WOPBS_PARAMS,
 };
-use dyn_stack::GlobalPodBuffer;
+use dyn_stack::PodBuffer;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
@@ -159,19 +159,19 @@ pub fn test_extract_bits() {
     let input_lwe_dimension = lwe_big_sk.lwe_dimension();
 
     let req = || {
-        StackReq::try_any_of([
-            fill_with_forward_fourier_scratch(fft)?,
+        StackReq::any_of(&[
+            fill_with_forward_fourier_scratch(fft),
             extract_bits_scratch::<u64>(
                 input_lwe_dimension,
                 ksk_lwe_big_to_small.output_key_lwe_dimension(),
                 glwe_dimension.to_glwe_size(),
                 polynomial_size,
                 fft,
-            )?,
+            ),
         ])
     };
-    let req = req().unwrap();
-    let mut mem = GlobalPodBuffer::new(req);
+    let req = req();
+    let mut mem = PodBuffer::try_new(req).unwrap();
     let stack = PodStack::new(&mut mem);
 
     fourier_bsk
@@ -348,16 +348,14 @@ fn test_circuit_bootstrapping_binary() {
             ciphertext_modulus,
         );
 
-        let mut mem = GlobalPodBuffer::new(
-            circuit_bootstrap_boolean_scratch::<u64>(
-                lwe_in.lwe_size(),
-                fourier_bsk.output_lwe_dimension().to_lwe_size(),
-                glwe_dimension.to_glwe_size(),
-                polynomial_size,
-                fft,
-            )
-            .unwrap(),
-        );
+        let mut mem = PodBuffer::try_new(circuit_bootstrap_boolean_scratch::<u64>(
+            lwe_in.lwe_size(),
+            fourier_bsk.output_lwe_dimension().to_lwe_size(),
+            glwe_dimension.to_glwe_size(),
+            polynomial_size,
+            fft,
+        ))
+        .unwrap();
         let stack = PodStack::new(&mut mem);
         // Execute the CBS
         circuit_bootstrap_boolean(
@@ -539,7 +537,7 @@ pub fn test_cmux_tree() {
                 &mut rsc.encryption_random_generator,
             );
 
-            let mut mem = GlobalPodBuffer::new(fill_with_forward_fourier_scratch(fft).unwrap());
+            let mut mem = PodBuffer::try_new(fill_with_forward_fourier_scratch(fft)).unwrap();
             let stack = PodStack::new(&mut mem);
             fourier_ggsw
                 .as_mut_view()
@@ -548,10 +546,13 @@ pub fn test_cmux_tree() {
 
         let mut result_cmux_tree =
             GlweCiphertext::new(0_u64, glwe_size, polynomial_size, ciphertext_modulus);
-        let mut mem = GlobalPodBuffer::new(
-            cmux_tree_memory_optimized_scratch::<u64>(glwe_size, polynomial_size, nb_ggsw, fft)
-                .unwrap(),
-        );
+        let mut mem = PodBuffer::try_new(cmux_tree_memory_optimized_scratch::<u64>(
+            glwe_size,
+            polynomial_size,
+            nb_ggsw,
+            fft,
+        ))
+        .unwrap();
         cmux_tree_memory_optimized(
             result_cmux_tree.as_mut_view(),
             lut.as_view(),
@@ -656,16 +657,14 @@ pub fn test_extract_bit_circuit_bootstrapping_vertical_packing() {
             ciphertext_modulus,
         );
 
-        let mut mem = GlobalPodBuffer::new(
-            extract_bits_scratch::<u64>(
-                input_lwe_dimension,
-                ksk_lwe_big_to_small.output_key_lwe_dimension(),
-                fourier_bsk.glwe_size(),
-                polynomial_size,
-                fft,
-            )
-            .unwrap(),
-        );
+        let mut mem = PodBuffer::try_new(extract_bits_scratch::<u64>(
+            input_lwe_dimension,
+            ksk_lwe_big_to_small.output_key_lwe_dimension(),
+            fourier_bsk.glwe_size(),
+            polynomial_size,
+            fft,
+        ))
+        .unwrap();
         extract_bits(
             extracted_bits_lwe_list.as_mut_view(),
             lwe_in.as_view(),
@@ -729,8 +728,8 @@ pub fn test_extract_bit_circuit_bootstrapping_vertical_packing() {
         );
 
         // Perform circuit bootstrap + vertical packing
-        let mut mem = GlobalPodBuffer::new(
-            circuit_bootstrap_boolean_vertical_packing_scratch::<u64>(
+        let mut mem =
+            PodBuffer::try_new(circuit_bootstrap_boolean_vertical_packing_scratch::<u64>(
                 extracted_bits_lwe_list.lwe_ciphertext_count(),
                 vertical_packing_lwe_list_out.lwe_ciphertext_count(),
                 extracted_bits_lwe_list.lwe_size(),
@@ -740,9 +739,8 @@ pub fn test_extract_bit_circuit_bootstrapping_vertical_packing() {
                 vec_pfpksk.output_polynomial_size(),
                 level_cbs,
                 fft,
-            )
-            .unwrap(),
-        );
+            ))
+            .unwrap();
         circuit_bootstrap_boolean_vertical_packing(
             lut_poly_list.as_view(),
             fourier_bsk.as_view(),
@@ -864,20 +862,17 @@ fn test_wop_add_one(params: FftWopPbsTestParams<u64>) {
         let lut_as_polynomial_list = PolynomialList::from_container(lut, polynomial_size);
 
         // Perform circuit bootstrap + vertical packing
-        let mut mem = GlobalPodBuffer::new(
-            circuit_bootstrap_boolean_vertical_packing_scratch::<u64>(
-                extracted_bits.lwe_ciphertext_count(),
-                output_cbs_vp.lwe_ciphertext_count(),
-                extracted_bits.lwe_size(),
-                lut_as_polynomial_list.polynomial_count(),
-                fourier_bsk.output_lwe_dimension().to_lwe_size(),
-                fourier_bsk.glwe_size(),
-                cbs_pfpksk.output_polynomial_size(),
-                level_cbs,
-                fft,
-            )
-            .unwrap(),
-        );
+        let mut mem = PodBuffer::new(circuit_bootstrap_boolean_vertical_packing_scratch::<u64>(
+            extracted_bits.lwe_ciphertext_count(),
+            output_cbs_vp.lwe_ciphertext_count(),
+            extracted_bits.lwe_size(),
+            lut_as_polynomial_list.polynomial_count(),
+            fourier_bsk.output_lwe_dimension().to_lwe_size(),
+            fourier_bsk.glwe_size(),
+            cbs_pfpksk.output_polynomial_size(),
+            level_cbs,
+            fft,
+        ));
         circuit_bootstrap_boolean_vertical_packing(
             lut_as_polynomial_list.as_view(),
             fourier_bsk.as_view(),

--- a/tfhe/src/core_crypto/fft_impl/fft64/math/fft/tests.rs
+++ b/tfhe/src/core_crypto/fft_impl/fft64/math/fft/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::core_crypto::commons::test_tools::{modular_distance, new_random_generator};
 use aligned_vec::avec;
-use dyn_stack::GlobalPodBuffer;
+use dyn_stack::PodBuffer;
 
 fn test_roundtrip<Scalar: UnsignedTorus>() {
     let mut generator = new_random_generator();
@@ -23,11 +23,8 @@ fn test_roundtrip<Scalar: UnsignedTorus>() {
             *x = generator.random_uniform();
         }
 
-        let mut mem = GlobalPodBuffer::new(
-            fft.forward_scratch()
-                .unwrap()
-                .and(fft.backward_scratch().unwrap()),
-        );
+        let mut mem =
+            PodBuffer::try_new(fft.forward_scratch().and(fft.backward_scratch())).unwrap();
         let stack = PodStack::new(&mut mem);
 
         // Simple roundtrip
@@ -125,11 +122,8 @@ fn test_product<Scalar: UnsignedTorus>() {
                 *y >>= Scalar::BITS - integer_magnitude;
             }
 
-            let mut mem = GlobalPodBuffer::new(
-                fft.forward_scratch()
-                    .unwrap()
-                    .and(fft.backward_scratch().unwrap()),
-            );
+            let mut mem =
+                PodBuffer::try_new(fft.forward_scratch().and(fft.backward_scratch())).unwrap();
             let stack = PodStack::new(&mut mem);
 
             fft.forward_as_torus(fourier0.as_mut_view(), poly0.as_view(), stack);

--- a/tfhe/src/shortint/server_key/mod.rs
+++ b/tfhe/src/shortint/server_key/mod.rs
@@ -1510,7 +1510,6 @@ pub(crate) fn apply_standard_blind_rotate<OutputScalar, OutputCont>(
             poly_size,
             fft,
         )
-        .unwrap()
         .unaligned_bytes_required(),
     );
 
@@ -1588,9 +1587,7 @@ pub(crate) fn apply_programmable_bootstrap_128<InputScalar, InputCont, OutputSca
                     bsk_polynomial_size,
                     fft,
                 )
-                .unwrap()
-                .try_unaligned_bytes_required()
-                .unwrap();
+                .unaligned_bytes_required();
 
             let br_input_modulus_log = bsk.polynomial_size().to_blind_rotation_input_modulus_log();
             let lwe_ciphertext_to_squash_noise = modulus_switch_noise_reduction_key

--- a/tfhe/src/shortint/wopbs/mod.rs
+++ b/tfhe/src/shortint/wopbs/mod.rs
@@ -720,7 +720,6 @@ mod experimental {
                         bsk.polynomial_size(),
                         fft,
                     )
-                    .unwrap()
                     .unaligned_bytes_required(),
                 );
 
@@ -821,7 +820,6 @@ mod experimental {
                                 fourier_bsk.polynomial_size(),
                                 fft,
                             )
-                            .unwrap()
                             .unaligned_bytes_required(),
                         );
                         let stack = buffers.stack();
@@ -927,7 +925,6 @@ mod experimental {
                         self.param.cbs_level,
                         fft,
                     )
-                        .unwrap()
                         .unaligned_bytes_required(),
                 );
 


### PR DESCRIPTION
Notable changes:
- StackReq methods no longer returns Result<StackReq, SizeOverflow> instead, StackReq contains the invalid state. Now, its when we create a PodBuffer that we can check/catch if the size req is invalid by catching errors when calling `PodBuffer::try_new`. Its also possible to manually check that `stack_req != StackReq::OVERFLOW`

- GlobalaPodBuffer is now PodBuffer

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3103)
<!-- Reviewable:end -->
