### PR TITLE
chore(ci): use run-name to distinguish benchmark runs

### DIFF
--- a/.github/workflows/benchmark_cpu.yml
+++ b/.github/workflows/benchmark_cpu.yml
@@ -1,6 +1,8 @@
 # Run benchmarks on an AWS instance and return parsed results to Slab CI bot.
 name: benchmark_cpu
 
+run-name: ${{ inputs.command }}::${{ inputs.bench_type}} (${{ inputs.op_flavor }}, ${{ inputs.precisions_set }}, ${{ inputs.params_type }})
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/benchmark_gpu.yml
+++ b/.github/workflows/benchmark_gpu.yml
@@ -1,6 +1,8 @@
 # Run CUDA benchmarks on a Hyperstack VM and return parsed results to Slab CI bot.
 name: benchmark_gpu
 
+run-name: ${{ inputs.command }}::${{ inputs.bench_type}} (${{ inputs.profile }}, ${{ inputs.op_flavor }}, ${{ inputs.precisions_set }}, ${{ inputs.params_type }})
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/benchmark_hpu.yml
+++ b/.github/workflows/benchmark_hpu.yml
@@ -1,6 +1,8 @@
 # Run benchmarks on a permanent HPU instance and return parsed results to Slab CI bot.
 name: benchmark_hpu
 
+run-name: ${{ inputs.command }}::${{ inputs.bench_type}} (${{ inputs.op_flavor }}, ${{ inputs.precisions_set }})
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
This would create a run name in the GitHub Actions tabs that will be based on the inputs provided rather than just displaying the workflow filename.