### PR TITLE
chore(zk): align wasm bench and integer bench

### DIFF
--- a/tfhe-benchmark/benches/integer/zk_pke.rs
+++ b/tfhe-benchmark/benches/integer/zk_pke.rs
@@ -33,8 +33,8 @@ impl ProofConfig {
 
 fn default_proof_config() -> Vec<ProofConfig> {
     vec![
-        ProofConfig::new(64usize, &[64usize]),
-        ProofConfig::new(2048, &[4 * 64, 10 * 64, 2048]),
+        ProofConfig::new(64, &[64]),
+        ProofConfig::new(2048, &[64, 4 * 64, 2048]),
         ProofConfig::new(4096, &[4096]),
     ]
 }

--- a/tfhe/web_wasm_parallel_tests/worker.js
+++ b/tfhe/web_wasm_parallel_tests/worker.js
@@ -683,9 +683,8 @@ async function compactPublicKeyZeroKnowledgeBench() {
     // Proof configuration:
     let proof_configs = [
       { crs_bit_size: 64, bits_to_encrypt: [64] },
-      { crs_bit_size: 640, bits_to_encrypt: [640] },
-      // 64 * 4 and 64 * 10 are production use-cases
-      { crs_bit_size: 2048, bits_to_encrypt: [4 * 64, 10 * 64, 2048] },
+      // 64 * 4 is a production use-case
+      { crs_bit_size: 2048, bits_to_encrypt: [64, 4 * 64, 2048] },
       { crs_bit_size: 4096, bits_to_encrypt: [4096] },
     ];
 


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description
Update wasm benches so that we bench the same thing that is benched in the integer benches. This means:
- remove zkv1 benches
- remove CRS 640
- add 640bits with CRS 2048.

See https://github.com/zama-ai/tfhe-rs/blob/main/tfhe-benchmark/benches/integer/zk_pke.rs for reference

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3126)
<!-- Reviewable:end -->
