### PR TITLE
chore: fix bincode dependency version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ rayon = "1.11"
 serde = { version = "1.0", default-features = false }
 wasm-bindgen = "0.2.101"
 getrandom = "0.2.8"
+bincode = "=1.3.3"
 
 [profile.bench]
 lto = "fat"

--- a/backends/tfhe-hpu-backend/Cargo.toml
+++ b/backends/tfhe-hpu-backend/Cargo.toml
@@ -61,8 +61,8 @@ bitvec = { version = "1.0", optional = true }
 serde_json = { version = "1.0", optional = true }
 
 # Dependencies used for v80 pdi handling
-bincode ={ version = "1.3", optional = true}
-serde_derive ={ version = "1.0", optional = true}
+bincode = { workspace = true, optional = true }
+serde_derive = { version = "1.0", optional = true }
 
 # Binary for manual debugging
 # Enable to access Hpu register and drive some custom sequence by hand

--- a/tfhe-benchmark/Cargo.toml
+++ b/tfhe-benchmark/Cargo.toml
@@ -15,7 +15,7 @@ name = "benchmark"
 path = "src/lib.rs"
 
 [dependencies]
-bincode = "1.3.3"
+bincode = { workspace = true }
 # clap has to be pinned as its minimum supported rust version
 # changes often between minor releases, which breaks our CI
 clap = { version = "=4.5.30", features = ["derive"] }

--- a/tfhe-fft/Cargo.toml
+++ b/tfhe-fft/Cargo.toml
@@ -30,7 +30,7 @@ serde = ["dep:serde", "num-complex/serde"]
 [dev-dependencies]
 rustfft = "6.0"
 rand = { workspace = true }
-bincode = "1.3"
+bincode = { workspace = true }
 more-asserts = "0.3.1"
 serde_json = "1.0.96"
 dyn-stack = { workspace = true, features = ["alloc"] }

--- a/tfhe-zk-pok/Cargo.toml
+++ b/tfhe-zk-pok/Cargo.toml
@@ -31,7 +31,7 @@ experimental = []
 [dev-dependencies]
 serde_json = "~1.0"
 itertools = { workspace = true }
-bincode = "1.3.3"
+bincode = { workspace = true }
 criterion = "0.5.1"
 
 [[bench]]

--- a/tfhe/Cargo.toml
+++ b/tfhe/Cargo.toml
@@ -58,7 +58,7 @@ tfhe-csprng = { version = "0.8.0", path = "../tfhe-csprng", features = [
 ] }
 serde = { workspace = true, features = ["default", "derive"] }
 rayon = { workspace = true }
-bincode = "1.3.3"
+bincode = { workspace = true }
 tfhe-fft = { version = "0.10.0", path = "../tfhe-fft", features = [
     "serde",
     "fft128",

--- a/utils/tfhe-backward-compat-data/Cargo.toml
+++ b/utils/tfhe-backward-compat-data/Cargo.toml
@@ -8,7 +8,7 @@ license = "BSD-3-Clause-Clear"
 serde = { version = "1.0", features = ["derive"] }
 ron = { version = "0.8", features = ["integer128"] }
 ciborium = "0.2"
-bincode = "1.3"
+bincode = { workspace = true }
 strum = { version = "0.26", features = ["derive"] }
 semver = { version = "1.0" }
 clap = { version = "4.5", features = ["derive"] }

--- a/utils/tfhe-versionable/Cargo.toml
+++ b/utils/tfhe-versionable/Cargo.toml
@@ -17,7 +17,7 @@ static_assertions = "1.1"
 trybuild = { version = "1", features = ["diff"] }
 
 # used to test various serialization formats
-bincode = "1.3"
+bincode = { workspace = true }
 serde_json = "1.0"
 ciborium = "0.2"
 rmp-serde = "1.3"


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description
Pin bincode dependency version, since maintainer stated that the project is frozen and there will be no new release: https://github.com/zama-ai/kms/pull/339#issuecomment-3675503721:

> we have taken steps to ensure that none of us will ever be able to upload a release to the bincode crate on crates.io again, so if a new release ever does get uploaded, it very much should not be trusted.
