### PR TITLE
fix(gpu): memory sanitizer ci

### DIFF
--- a/scripts/check_memory_errors.sh
+++ b/scripts/check_memory_errors.sh
@@ -33,7 +33,11 @@ RUSTFLAGS="$RUSTFLAGS" cargo nextest list --cargo-profile "${CARGO_PROFILE}" \
           --features=integer,internal-keycache,gpu-debug,zk-pok -p tfhe &> /tmp/test_list.txt
 
 if [[ "${RUN_VALGRIND}" == "1" ]]; then
-  TESTS_TO_RUN=$(sed -e $'s/\x1b\[[0-9;]*m//g' < /tmp/test_list.txt | grep -E 'high_level_api::.*gpu.*' | grep -v 'array' | grep -v 'flip')
+  # The tests are filtered using grep (to keep only HL) GPU tests.
+  # Since, when output is directed to a file, nextest outputs a list of `<executable name> <test name>` the `grep -o '[^ ]\+$'` filter
+  # will keep only the test name and the `tfhe` executable is assumed. To sanitize tests from another
+  # executable changes might be needed
+  TESTS_TO_RUN=$(sed -e $'s/\x1b\[[0-9;]*m//g' < /tmp/test_list.txt | grep -E 'high_level_api::.*gpu.*' | grep -v 'array' | grep -v 'flip' | grep -o '[^ ]\+$')
 
   # Build the tests but don't run them
   RUSTFLAGS="$RUSTFLAGS" cargo test --no-run --profile "${CARGO_PROFILE}" \
@@ -56,7 +60,11 @@ if [[ "${RUN_VALGRIND}" == "1" ]]; then
 fi
 
 if [[ "${RUN_COMPUTE_SANITIZER}" == "1" ]]; then
-  TESTS_TO_RUN=$(sed -e $'s/\x1b\[[0-9;]*m//g' < /tmp/test_list.txt | grep -E 'high_level_api::.*gpu.*|core_crypto::.*gpu.*' | grep -v 'array' | grep -v 'modulus_switch' | grep -v '3_3' | grep -v 'noise_distribution' | grep -v 'flip')
+  # The tests are filtered using grep (to keep only HL / corecrypto) GPU tests.
+  # Since, when output is directed to a file, nextest outputs a list of `<executable name> <test name>` the `grep -o '[^ ]\+$'` filter
+  # will keep only the test name and the `tfhe` executable is assumed. To sanitize tests from another
+  # executable changes might be needed
+  TESTS_TO_RUN=$(sed -e $'s/\x1b\[[0-9;]*m//g' < /tmp/test_list.txt | grep -E 'high_level_api::.*gpu.*|core_crypto::.*gpu.*' | grep -v 'array' | grep -v 'modulus_switch' | grep -v '3_3' | grep -v 'noise_distribution' | grep -v 'flip' | grep -o '[^ ]\+$')
   # Build the tests but don't run them
   RUSTFLAGS="$RUSTFLAGS" cargo test --no-run --profile "${CARGO_PROFILE}" \
     --features=integer,internal-keycache,gpu,zk-pok -p tfhe


### PR DESCRIPTION
New (>0.9.99) `nextest` versions, when output is directed to a file, produce a list tests in with the format `<executable name> <test name>`. An additional `grep -o '[^ ]\+$'` filter will keep only the test name, assuming `tfhe` as the executable, which is currently fine for our CI. To sanitize tests from another executable (zk?) changes might be needed.
  