### PR TITLE
Benchmarking code refactor and automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ target/
 **/*.rmeta
 **/Cargo.lock
 **/*.bin
+**/.DS_Store
 
 # Some of our bench outputs
 /tfhe/benchmarks_parameters

--- a/tfhe-benchmark/.gitignore
+++ b/tfhe-benchmark/.gitignore
@@ -1,0 +1,1 @@
+benchmarks_parameters/*


### PR DESCRIPTION
This pull request refactors and streamlines the benchmarking code for the high-level API in `tfhe-benchmark`, making it more modular and easier to extend. The main change is the introduction of macros to generate and run benchmarks for various operations and types, replacing repetitive code with a more maintainable approach.

**Benchmarking code refactor and automation:**

- Introduced the `bench_fhe_type_op` function and supporting `BenchWait` trait to generalize benchmarking over arbitrary operations, enabling the same code to handle all binary operations and their result types.
- Added the `bench_type_op!` and `generate_typed_benches!` macros to automatically generate benchmark functions for each operation (add, sub, mul, bitwise, shift, rotate, min/max, etc.) and FHE integer type, replacing the previous manual approach.
- Added the `run_benches!` macro to succinctly invoke all generated benchmarks for a given set of types, further reducing boilerplate and improving maintainability.
- Updated the `main` function to use the new `run_benches!` macro, ensuring all benchmarks are executed for the relevant types depending on the configuration.

**Repository hygiene:**

- Updated `.gitignore` to exclude the `benchmarks_parameters` directory, preventing benchmark parameter files from being checked into version control.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3153)
<!-- Reviewable:end -->
