### PR TITLE
chore(deps): ignore unmaintained bincode cargo audit warning

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -2,6 +2,8 @@
 ignore = [
     # Ignoring unmaintained 'paste' advisory as it is a widely used, low-risk build dependency.
     "RUSTSEC-2024-0436",
+    # Ignoring unmaintained 'bincode' crate. Getting rid of it would be too complex on the short term.
+    "RUSTSEC-2025-0141",
 ]
 
 [output]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ rayon = "1.11"
 serde = { version = "1.0", default-features = false }
 wasm-bindgen = "0.2.101"
 getrandom = "0.2.8"
+# The project maintainers consider that this is the last version of the 1.3 branch, any newer version should not be trusted
 bincode = "=1.3.3"
 
 [profile.bench]


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description
Ignore cargo audit warning about bincode being unmaintained. The dependency should not be updated as the maintainers explicitly that any newer version should not be trusted (see: https://github.com/zama-ai/kms/pull/339#issuecomment-3675503721)