### PR TITLE
fix(js): unsafe coop bench was overwritting mt one

### DIFF
--- a/tfhe/web_wasm_parallel_tests/worker.js
+++ b/tfhe/web_wasm_parallel_tests/worker.js
@@ -727,8 +727,15 @@ async function compactPublicKeyZeroKnowledgeBench() {
             serialized_size = list.safe_serialize(BigInt(10000000)).length;
           }
           const mean = timing / bench_loops;
+
+          let base_bench_str = "compact_fhe_uint_proven_encryption_";
+          let supportsThreads = await threads();
+          if (!supportsThreads) {
+            base_bench_str += "unsafe_coop_";
+          }
+
           const common_bench_str =
-            "compact_fhe_uint_proven_encryption_" +
+            base_bench_str +
             params.zk_scheme +
             "_" +
             bits_to_encrypt +


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description
In the workflow we run the multithread bench, then the unsafe coop. The same json is updated and then sent to grafana. Since the events have the same name they were overwritten.