### PR TITLE
chore(ci): fix artifact naming for hpu benchmarks

### DIFF
--- a/.github/workflows/benchmark_hpu_common.yml
+++ b/.github/workflows/benchmark_hpu_common.yml
@@ -187,7 +187,7 @@ jobs:
       - name: Upload parsed results artifact
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:
-          name: ${{ github.sha }}_${{ matrix.bench_type }}_integer_benchmarks
+          name: ${{ github.sha }}_${{ matrix.bench_type }}_${{ matrix.command }}_benchmarks
           path: ${{ env.RESULTS_FILENAME }}
 
       - name: Checkout Slab repo


### PR DESCRIPTION
Prior to this commit, all generated artifacts would be identified as integer benchmarks.
