### PR TITLE
chore(ci): add svg generation for erc20 benchmarks

### DIFF
--- a/ci/data_extractor/src/benchmark_specs.py
+++ b/ci/data_extractor/src/benchmark_specs.py
@@ -279,9 +279,10 @@ class ErrorFailureProbability(enum.IntEnum):
         return self.to_str()
 
 
-class BenchType(enum.Enum):
-    Latency = 0
-    Throughput = 1
+class BenchType(enum.StrEnum):
+    Latency = "Latency"
+    Throughput = "Throughput"
+    Both = "Both"
 
     @staticmethod
     def from_str(bench_type):
@@ -290,8 +291,25 @@ class BenchType(enum.Enum):
                 return BenchType.Latency
             case "throughput":
                 return BenchType.Throughput
+            case "both":
+                return BenchType.Both
             case _:
                 raise ValueError(f"BenchType '{bench_type}' not supported")
+
+
+class BenchSubset(enum.StrEnum):
+    All = "all"
+    Erc20 = "erc20"
+
+    @staticmethod
+    def from_str(bench_subset):
+        match bench_subset.lower():
+            case "all":
+                return BenchSubset.All
+            case "erc20":
+                return BenchSubset.Erc20
+            case _:
+                raise ValueError(f"BenchSubset '{bench_subset}' not supported")
 
 
 class ParamsDefinition:

--- a/ci/data_extractor/src/config.py
+++ b/ci/data_extractor/src/config.py
@@ -1,7 +1,7 @@
 import argparse
 import pathlib
 
-from benchmark_specs import Backend, BenchType, Layer, PBSKind
+from benchmark_specs import Backend, BenchSubset, BenchType, Layer, PBSKind
 
 
 class UserConfig:
@@ -32,6 +32,8 @@ class UserConfig:
         self.time_span_days = input_args.time_span_days
 
         self.bench_type = BenchType.from_str(input_args.bench_type.lower())
+
+        self.bench_subset = BenchSubset.from_str(input_args.bench_subset)
 
         self.layer = Layer.from_str(input_args.layer.lower())
         self.pbs_kind = PBSKind.from_str(input_args.pbs_kind)

--- a/ci/data_extractor/src/connector.py
+++ b/ci/data_extractor/src/connector.py
@@ -228,6 +228,9 @@ class PostgreConnector:
                 filters.append("test.name NOT SIMILAR TO '%::throughput::%'")
             case BenchType.Throughput:
                 filters.append("test.name LIKE '%::throughput::%'")
+            case BenchType.Both:
+                # No need to add a filter.
+                pass
 
         select_parts = (
             "SELECT",

--- a/ci/data_extractor/src/formatters/common.py
+++ b/ci/data_extractor/src/formatters/common.py
@@ -269,10 +269,9 @@ class CSVFormatter(GenericFormatter):
             case Layer.CoreCrypto:
                 headers = ["Operation \\ Parameters set", *headers_values]
             case _:
-                print(
+                raise NotImplementedError(
                     f"tfhe-rs layer '{self.layer}' currently not supported for CSV writing"
                 )
-                raise NotImplementedError
 
         csv_data = [headers]
         csv_data.extend(
@@ -374,6 +373,14 @@ class SVGFormatter(GenericFormatter):
         for row_idx, type_ident in enumerate(headers):
             curr_x = op_name_col_width + row_idx * per_timing_col_width
 
+            header_one_row_span = self._build_svg_text(
+                curr_x + per_timing_col_width / 2,
+                row_height / 2,
+                type_ident,
+                fill=WHITE_COLOR,
+                font_weight="bold",
+            )
+
             match layer:
                 case Layer.Integer:
                     if type_ident.startswith("FheUint"):
@@ -399,28 +406,14 @@ class SVGFormatter(GenericFormatter):
                             ]
                         )
                     else:  # Backends comparison (CPU, GPU, HPU)
-                        header_elements.append(
-                            self._build_svg_text(
-                                curr_x + per_timing_col_width / 2,
-                                row_height / 2,
-                                type_ident,
-                                fill=WHITE_COLOR,
-                                font_weight="bold",
-                            )
-                        )
-                case Layer.CoreCrypto:
-                    header_elements.append(
-                        # Core_crypto arrays contains only ciphertext modulus size as headers
-                        self._build_svg_text(
-                            curr_x + per_timing_col_width / 2,
-                            row_height / 2,
-                            type_ident,
-                            fill=WHITE_COLOR,
-                            font_weight="bold",
-                        )
-                    )
+                        header_elements.append(header_one_row_span)
+                case Layer.HLApi | Layer.CoreCrypto:
+                    # Core_crypto arrays contains only ciphertext modulus size as headers
+                    header_elements.append(header_one_row_span)
                 case _:
-                    raise NotImplementedError
+                    raise NotImplementedError(
+                        f"svg header row generation not supported for '{layer}' layer"
+                    )
 
         return header_elements
 

--- a/ci/data_extractor/src/formatters/hlapi/hlapi.py
+++ b/ci/data_extractor/src/formatters/hlapi/hlapi.py
@@ -1,10 +1,16 @@
 import collections
 
-from benchmark_specs import BenchDetails
-from formatters.common import GenericFormatter
+from benchmark_specs import Backend, BenchDetails, BenchType
+from formatters.common import BenchArray, GenericFormatter
+
+import utils
 
 
 class HlApiFormatter(GenericFormatter):
+    """
+    Formatter for arithmetic operations benchmarks.
+    """
+
     @staticmethod
     def _format_data(data: dict[BenchDetails : list[int]], conversion_func):
         formatted = collections.defaultdict(
@@ -28,3 +34,56 @@ class HlApiFormatter(GenericFormatter):
             formatted[test_name][bit_width] = value
 
         return formatted
+
+
+TRANSFER_IMPLEM_COLUMN_HEADER = "Transfer implementation"
+
+
+class Erc20Formatter(HlApiFormatter):
+    """
+    Formatter for ERC20 benchmarks.
+    """
+
+    @staticmethod
+    def _format_data(data: dict[BenchDetails : list[int]], *args):
+        formatted = collections.defaultdict(
+            lambda: {
+                BenchType.Latency: "N/A",
+                BenchType.Throughput: "N/A",
+            }
+        )
+
+        for details, timings in data.items():
+            name_parts = details.operation_name.split("::")
+            test_name = name_parts[name_parts.index("transfer") + 1]
+            if "throughput" in name_parts:
+                bench_type = BenchType.Throughput
+                conversion_func = utils.convert_throughput_value_to_readable_text
+            else:
+                bench_type = BenchType.Latency
+                conversion_func = utils.convert_latency_value_to_readable_text
+
+            # For now ERC20 benchmarks are only made on 64-bit ciphertexts.
+            value = conversion_func(timings[-1])
+            formatted[test_name][bench_type] = value
+
+        return formatted
+
+    def _generate_arrays(self, data, *args, **kwargs):
+        first_column_header = TRANSFER_IMPLEM_COLUMN_HEADER
+
+        match self.backend:
+            case Backend.HPU:
+                op_names = ["whitepaper", "hpu_optim", "hpu_simd"]
+            case _:
+                op_names = ["whitepaper", "no_cmux", "overflow"]
+
+        result_lines = []
+        for op_name in op_names:
+            line = {first_column_header: op_name}
+            line.update({str(bench_type): v for bench_type, v in data[op_name].items()})
+            result_lines.append(line)
+
+        return [
+            BenchArray(result_lines, self.layer),
+        ]


### PR DESCRIPTION
This commit introduces the concept of a benchmark subset in the data_extractor. This allows a user to fetch only part of the benchmark results on a given layer. For now only HLAPI ERC20 benchmarks handling is implemented.

Also, the benchmark type 'both' has been added. It allows a user to fetch both latency and throughput results in the database. This is used in ERC20 SVG generation to display these two benchmark types within the same table.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3173)
<!-- Reviewable:end -->
