### PR TITLE
refactor!: rename to_approximate_recomposition_summand

### DIFF
--- a/tfhe/src/core_crypto/algorithms/ggsw_encryption.rs
+++ b/tfhe/src/core_crypto/algorithms/ggsw_encryption.rs
@@ -30,7 +30,7 @@ pub fn ggsw_encryption_multiplicative_factor<Scalar: UnsignedInteger>(
             cleartext.0.wrapping_neg(),
             ciphertext_modulus,
         )
-        .to_approximate_recomposition_summand(),
+        .to_recomposition_summand(),
         CiphertextModulusKind::Native | CiphertextModulusKind::NonNativePowerOfTwo => {
             let native_decomp_term =
                 DecompositionTerm::new(decomp_level, decomp_base_log, cleartext.0.wrapping_neg())
@@ -906,7 +906,7 @@ where
                 Scalar::ONE,
                 ciphertext_modulus,
             )
-            .to_approximate_recomposition_summand();
+            .to_recomposition_summand();
 
             let decoded = divide_round(*cleartext_ref.0, delta)
                 .wrapping_rem(Scalar::ONE << (decomp_level.0 * decomp_base_log.0));

--- a/tfhe/src/core_crypto/algorithms/glwe_keyswitch_key_generation.rs
+++ b/tfhe/src/core_crypto/algorithms/glwe_keyswitch_key_generation.rs
@@ -290,7 +290,7 @@ pub fn generate_glwe_keyswitch_key_other_mod<
                 input_key_polynomial.as_ref(),
                 ciphertext_modulus,
             );
-            term.to_approximate_recomposition_summand(message_polynomial.as_mut());
+            term.to_recomposition_summand(message_polynomial.as_mut());
         }
 
         let decomposition_plaintexts_buffer =

--- a/tfhe/src/core_crypto/algorithms/lwe_keyswitch_key_generation.rs
+++ b/tfhe/src/core_crypto/algorithms/lwe_keyswitch_key_generation.rs
@@ -274,7 +274,7 @@ pub fn generate_lwe_keyswitch_key_other_mod<
                 CastInto::<OutputScalar>::cast_into(*input_key_element),
                 ciphertext_modulus,
             )
-            .to_approximate_recomposition_summand();
+            .to_recomposition_summand();
         }
 
         encrypt_lwe_ciphertext_list(
@@ -1026,7 +1026,7 @@ pub fn generate_chunked_lwe_keyswitch_key_other_mod<
                 CastInto::<OutputScalar>::cast_into(*input_key_element),
                 ciphertext_modulus,
             )
-            .to_approximate_recomposition_summand();
+            .to_recomposition_summand();
         }
 
         encrypt_lwe_ciphertext_list(

--- a/tfhe/src/core_crypto/commons/math/decomposition/decomposer.rs
+++ b/tfhe/src/core_crypto/commons/math/decomposition/decomposer.rs
@@ -637,7 +637,7 @@ where
         if decomp.is_fresh() {
             Some(decomp.fold(Scalar::ZERO, |acc, term| {
                 acc.wrapping_add_custom_mod(
-                    term.to_approximate_recomposition_summand(),
+                    term.to_recomposition_summand(),
                     ciphertext_modulus_as_scalar,
                 )
             }))

--- a/tfhe/src/core_crypto/commons/math/decomposition/term.rs
+++ b/tfhe/src/core_crypto/commons/math/decomposition/term.rs
@@ -129,7 +129,7 @@ where
         }
     }
 
-    /// Turn this term into a summand.
+    /// Turn this term into a summand. The returned value is under the provided modulus.
     ///
     /// If our member represents one $\tilde{\theta}\_i$ of the decomposition, this method returns
     /// $\tilde{\theta}\_i\frac{v}{B^i}$ where $\lambda = \lceil{\log_2{q}}\rceil$ and
@@ -148,9 +148,9 @@ where
     ///     CiphertextModulus::try_new((1 << 64) - (1 << 32) + 1).unwrap(),
     /// );
     /// let output = decomposer.decompose(2u64.pow(52)).next().unwrap();
-    /// assert_eq!(output.to_approximate_recomposition_summand(), 2u64.pow(52));
+    /// assert_eq!(output.to_recomposition_summand(), 2u64.pow(52));
     /// ```
-    pub fn to_approximate_recomposition_summand(&self) -> T {
+    pub fn to_recomposition_summand(&self) -> T {
         let modulus_as_t = T::cast_from(self.ciphertext_modulus.get_custom_modulus());
         let ciphertext_modulus_bit_count: usize = modulus_as_t.ceil_ilog2().try_into().unwrap();
         let shift: usize = ciphertext_modulus_bit_count - self.base_log * self.level;
@@ -359,7 +359,8 @@ where
         }
     }
 
-    /// Fills the output tensor with the terms turned to summands.
+    /// Fills the output tensor with the terms turned to summands. The values are under the provided
+    /// modulus.
     ///
     /// If our term tensor represents a set of $(\tilde{\theta}^{(a)}\_i)\_{a\in\mathbb{N}}$ of the
     /// decomposition, this method fills the output tensor with a set of
@@ -381,10 +382,10 @@ where
     /// let mut decomp = decomposer.decompose_slice(&input);
     /// let term = decomp.next_term().unwrap();
     /// let mut output = vec![0; 2];
-    /// term.to_approximate_recomposition_summand(&mut output);
+    /// term.to_recomposition_summand(&mut output);
     /// assert!(output.iter().all(|&x| x == 1048576));
     /// ```
-    pub fn to_approximate_recomposition_summand(&self, output: &mut [T]) {
+    pub fn to_recomposition_summand(&self, output: &mut [T]) {
         assert_eq!(self.slice.len(), output.len());
         let modulus_as_t = T::cast_from(self.ciphertext_modulus.get_custom_modulus());
         let ciphertext_modulus_bit_count: usize = modulus_as_t.ceil_ilog2().try_into().unwrap();


### PR DESCRIPTION
- this function was named at a time where the decomposition algorithms had a completely different look for the non native case, when you look at what the code is doing it is merely returning the value under the correct modulus, there is nothing approximate about it
- the DecomposerNonNative has a debug assert checking that the modulus has strictly more bits than are being decomposed i.e.
ceil(log2(modulus)) > base_log * level_count
- a single decomposed value can have at most base_log bits, which will always fit in the modulus given the above constraints, so there was no correctness concern
- the original decomposer does not have that concern, it uses a native modulus (and now power of two moduli) which naturally matches the contained values (2's complement representation of CPUs is just mod 2^{reg_size})
