### PR TITLE
refactor(xof_key_set): split decompression into expansion and conversion

### DIFF
--- a/tfhe/src/high_level_api/xof_key_set/mod.rs
+++ b/tfhe/src/high_level_api/xof_key_set/mod.rs
@@ -1,0 +1,389 @@
+mod internal;
+#[cfg(test)]
+mod test;
+
+use crate::shortint::client_key::atomic_pattern::EncryptionAtomicPattern;
+
+use crate::backward_compatibility::xof_key_set::CompressedXofKeySetVersions;
+use crate::core_crypto::commons::generators::MaskRandomGenerator;
+
+use crate::core_crypto::commons::math::random::RandomGenerator;
+use crate::core_crypto::prelude::*;
+
+use crate::integer::ciphertext::CompressedNoiseSquashingCompressionKey;
+use crate::integer::noise_squashing::CompressedNoiseSquashingKey;
+
+use crate::named::Named;
+
+use crate::{
+    integer, shortint, ClientKey, CompactPublicKey, CompressedCompactPublicKey,
+    CompressedReRandomizationKeySwitchingKey, CompressedServerKey, Config, ServerKey, Tag,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::core_crypto::commons::generators::NoiseRandomGenerator;
+use crate::shortint::atomic_pattern::compressed::CompressedAtomicPatternServerKey;
+use crate::shortint::ciphertext::MaxDegree;
+use crate::shortint::client_key::atomic_pattern::AtomicPatternClientKey;
+use crate::shortint::ShortintParameterSet;
+use tfhe_csprng::seeders::XofSeed;
+use tfhe_versionable::Versionize;
+
+use crate::high_level_api::backward_compatibility::xof_key_set::XofKeySetVersions;
+use crate::integer::key_switching_key::CompressedKeySwitchingKeyMaterial;
+
+use internal::IntegerExpandedServerKey;
+
+// Generation order:
+//
+// 1) Public key (enc params)
+// 2) Compression key
+// 3) Decompression key
+// 4) KSK (compute params)
+// 5) BSK (compute params)
+// 6) Mod Switch Key (compute params)
+// 7) BSK (SnS params)
+// 8) Mod Switch Key (SnS params)
+// 9) KSK (encryption params to compute params)
+// 10) Re-Rand KSK
+// 11) SNS Compression Key
+
+/// Compressed KeySet which respects the [Threshold (Fully) Homomorphic Encryption]
+/// regarding the random generator used, and the order of key generation
+///
+/// [Threshold (Fully) Homomorphic Encryption]: https://eprint.iacr.org/2025/699
+#[derive(Clone, Serialize, Deserialize, Versionize)]
+#[versionize(CompressedXofKeySetVersions)]
+pub struct CompressedXofKeySet {
+    seed: XofSeed,
+    compressed_public_key: CompressedCompactPublicKey,
+    compressed_server_key: CompressedServerKey,
+}
+
+impl Named for CompressedXofKeySet {
+    const NAME: &'static str = "high_level_api::CompressedXofKeySet";
+}
+
+impl CompressedXofKeySet {
+    /// Generates a pair of ClientKey and CompressedXofKeySet
+    ///
+    /// This uses the domain separators as they are defined in the original paper.
+    ///
+    /// * `config` must use a dedicated public key
+    pub fn generate(
+        config: Config,
+        private_seed_bytes: Vec<u8>,
+        security_bits: u32,
+        max_norm_hwt: NormalizedHammingWeightBound,
+        tag: Tag,
+    ) -> crate::Result<(ClientKey, Self)> {
+        let private_separator = *b"TFHEKGen";
+        let public_separator = *b"TFHE_GEN";
+        let private_seed = XofSeed::new(private_seed_bytes, private_separator);
+
+        Self::generate_with_separators(
+            config,
+            private_seed,
+            public_separator,
+            security_bits,
+            max_norm_hwt,
+            tag,
+        )
+    }
+
+    /// Generates a pair of ClientKey and CompressedXofKeySet
+    ///
+    /// This function allows to use different domain separators than
+    /// the ones defined in the original paper.
+    ///
+    /// * `config` must use a dedicated public key
+    pub fn generate_with_separators(
+        config: Config,
+        private_seed: XofSeed,
+        public_seed_separator: [u8; XofSeed::DOMAIN_SEP_LEN],
+        security_bits: u32,
+        max_norm_hwt: NormalizedHammingWeightBound,
+        tag: Tag,
+    ) -> crate::Result<(ClientKey, Self)> {
+        let mut private_generator = RandomGenerator::<DefaultRandomGenerator>::new(private_seed);
+
+        let mut public_seed_bytes = vec![0u8; security_bits as usize / 8];
+        private_generator.fill_slice_with_random_uniform(&mut public_seed_bytes);
+        let public_seed = XofSeed::new(public_seed_bytes, public_seed_separator);
+
+        let mut secret_generator = SecretRandomGenerator::from_raw_parts(private_generator);
+
+        let client_key = ClientKey::generate_with_pre_seeded_generator(
+            config,
+            max_norm_hwt,
+            tag,
+            &mut secret_generator,
+        )?;
+
+        let xof_key_set = Self::generate_with_pre_seeded_generator(
+            public_seed,
+            &client_key,
+            secret_generator.into_raw_parts(),
+        )?;
+
+        Ok((client_key, xof_key_set))
+    }
+
+    fn generate_with_pre_seeded_generator<G>(
+        pub_seed: XofSeed,
+        ck: &ClientKey,
+        private_generator: RandomGenerator<G>,
+    ) -> crate::Result<Self>
+    where
+        G: ByteRandomGenerator + ParallelByteRandomGenerator,
+    {
+        let Some(dedicated_pk_key) = ck.key.dedicated_compact_private_key.as_ref() else {
+            return Err(crate::error!("Dedicated compact private key is required"));
+        };
+
+        let mask_random_generator = MaskRandomGenerator::<G>::new(pub_seed.clone());
+        let noise_random_generator = NoiseRandomGenerator::from_raw_parts(private_generator);
+        let mut encryption_rand_gen = EncryptionRandomGenerator::from_raw_parts(
+            mask_random_generator,
+            noise_random_generator,
+        );
+
+        let computation_parameters: ShortintParameterSet = ck.key.key.parameters().into();
+        let shortint_client_key = &ck.key.key.key;
+
+        // First, the public key used to encrypt
+        // It uses separate parameters from the computation ones
+        let compressed_public_key = CompressedCompactPublicKey::generate_with_pre_seeded_generator(
+            dedicated_pk_key,
+            ck.tag.clone(),
+            &mut encryption_rand_gen,
+        );
+
+        let glwe_secret_key = match &shortint_client_key.atomic_pattern {
+            AtomicPatternClientKey::Standard(ap) => &ap.glwe_secret_key,
+            AtomicPatternClientKey::KeySwitch32(ks32_ap) => &ks32_ap.glwe_secret_key,
+        };
+
+        let compression_key = ck
+                .key
+                .compression_key
+                .as_ref()
+                .map(|private_compression_key| {
+                    // Compression requires EncryptionKey::Big, but if that was not the case,
+                    // the private_compression_key would not have been generated
+                    integer::compression_keys::CompressedCompressionKey::generate_with_pre_seeded_generator(
+                        private_compression_key,
+                        glwe_secret_key,
+                        computation_parameters.ciphertext_modulus(),
+                        &mut encryption_rand_gen,
+                    )
+                });
+
+        let decompression_key = ck
+                .key
+                .compression_key
+                .as_ref()
+                .map(|private_compression_key| {
+                    integer::compression_keys::CompressedDecompressionKey::generate_with_pre_seeded_generator(
+                        private_compression_key,
+                        glwe_secret_key,
+                        computation_parameters,
+                        &mut encryption_rand_gen,
+                    )
+                });
+
+        // Now, we generate the server key (ksk, then bsk)
+        let integer_compressed_server_key = {
+            let compressed_ap_server_key =
+                CompressedAtomicPatternServerKey::generate_with_pre_seeded_generator(
+                    &shortint_client_key.atomic_pattern,
+                    &mut encryption_rand_gen,
+                );
+
+            let max_degree = MaxDegree::integer_radix_server_key(
+                computation_parameters.message_modulus(),
+                computation_parameters.carry_modulus(),
+            );
+
+            integer::CompressedServerKey::from_raw_parts(
+                shortint::CompressedServerKey::from_raw_parts(
+                    compressed_ap_server_key,
+                    computation_parameters.message_modulus(),
+                    computation_parameters.carry_modulus(),
+                    max_degree,
+                    computation_parameters.max_noise_level(),
+                ),
+            )
+        };
+
+        let noise_squashing_bs_key =
+            ck.key
+                .noise_squashing_private_key
+                .as_ref()
+                .map(|noise_squashing_key| {
+                    CompressedNoiseSquashingKey::generate_with_pre_seeded_generator(
+                        noise_squashing_key,
+                        &shortint_client_key.atomic_pattern,
+                        &mut encryption_rand_gen,
+                    )
+                });
+
+        // Generate the key switching material that will allow going from
+        // the public key's dedicated parameters to the computation parameters
+        let pk_to_sk_ksk_params = dedicated_pk_key.1;
+
+        let integer_ksk_material = {
+            let noise_distrib = computation_parameters
+                .noise_distribution_for_key_choice(pk_to_sk_ksk_params.destination_key);
+
+            let key_switching_key = match &ck.key.key.key.atomic_pattern {
+                AtomicPatternClientKey::Standard(std_ap) => {
+                    let target_private_key = match pk_to_sk_ksk_params.destination_key {
+                        EncryptionKeyChoice::Big => std_ap.glwe_secret_key.as_lwe_secret_key(),
+                        EncryptionKeyChoice::Small => std_ap.lwe_secret_key.as_view(),
+                    };
+
+                    allocate_and_generate_new_seeded_lwe_key_switching_key_with_pre_seeded_generator(
+                        &dedicated_pk_key.0.key.key(),
+                        &target_private_key,
+                        pk_to_sk_ksk_params.ks_base_log,
+                        pk_to_sk_ksk_params.ks_level,
+                        noise_distrib,
+                        computation_parameters.ciphertext_modulus(),
+                        &mut encryption_rand_gen,
+                    )
+                }
+                AtomicPatternClientKey::KeySwitch32(ks32_ap) => ks32_ap
+                    .generate_seeded_key_switching_key_with_pre_seeded_generator(
+                        &dedicated_pk_key.0.key.key(),
+                        &pk_to_sk_ksk_params,
+                        &mut encryption_rand_gen,
+                    ),
+            };
+
+            CompressedKeySwitchingKeyMaterial {
+                material: shortint::key_switching_key::CompressedKeySwitchingKeyMaterial {
+                    key_switching_key,
+                    cast_rshift: 0,
+                    destination_key: dedicated_pk_key.1.destination_key,
+                    destination_atomic_pattern: ck.key.key.key.atomic_pattern.kind().into(),
+                },
+            }
+        };
+
+        // Generate the key switching material that will allow going from
+        // the public key's dedicated parameters to the re-rand
+        let cpk_re_randomization_key_switching_key_material = ck
+            .key
+            .re_randomization_ksk_gen_info()?
+            .as_ref()
+            .map(|key_gen_info| {
+                CompressedReRandomizationKeySwitchingKey::generate_with_pre_seeded_generator(
+                    glwe_secret_key,
+                    computation_parameters.glwe_noise_distribution(),
+                    computation_parameters.ciphertext_modulus(),
+                    computation_parameters.atomic_pattern().into(),
+                    key_gen_info,
+                    &mut encryption_rand_gen,
+                )
+            });
+
+        let noise_squashing_compression_key =
+            ck.key.noise_squashing_compression_private_key.as_ref().map(
+                |ns_compression_priv_key| {
+                    CompressedNoiseSquashingCompressionKey::generate_with_pre_seeded_generator(
+                        ns_compression_priv_key,
+                        ck.key.noise_squashing_private_key.as_ref().unwrap(),
+                        &mut encryption_rand_gen,
+                    )
+                },
+            );
+
+        let compressed_server_key = CompressedServerKey::from_raw_parts(
+            integer_compressed_server_key,
+            Some(integer_ksk_material),
+            compression_key,
+            decompression_key,
+            noise_squashing_bs_key,
+            noise_squashing_compression_key,
+            cpk_re_randomization_key_switching_key_material,
+            ck.tag.clone(),
+        );
+
+        Ok(Self {
+            seed: pub_seed,
+            compressed_public_key,
+            compressed_server_key,
+        })
+    }
+
+    /// Decompress the KeySet
+    pub fn decompress(self) -> crate::Result<XofKeySet> {
+        let (public_key, expanded_server_key) = self.expand();
+        let server_key = expanded_server_key.convert_to_cpu();
+
+        Ok(XofKeySet {
+            public_key,
+            server_key,
+        })
+    }
+
+    fn expand(self) -> (CompactPublicKey, IntegerExpandedServerKey) {
+        let mut mask_generator = MaskRandomGenerator::<DefaultRandomGenerator>::new(self.seed);
+
+        let public_key = self
+            .compressed_public_key
+            .decompress_with_pre_seeded_generator(&mut mask_generator);
+
+        let server_key = self
+            .compressed_server_key
+            .decompress_with_pre_seeded_generator(&mut mask_generator);
+
+        (public_key, server_key)
+    }
+
+    pub fn from_raw_parts(
+        pub_seed: XofSeed,
+        compressed_public_key: CompressedCompactPublicKey,
+        compressed_server_key: CompressedServerKey,
+    ) -> Self {
+        Self {
+            seed: pub_seed,
+            compressed_public_key,
+            compressed_server_key,
+        }
+    }
+
+    pub fn into_raw_parts(self) -> (XofSeed, CompressedCompactPublicKey, CompressedServerKey) {
+        let Self {
+            seed,
+            compressed_public_key,
+            compressed_server_key,
+        } = self;
+
+        (seed, compressed_public_key, compressed_server_key)
+    }
+}
+
+/// KeySet which contains the public material (public key and server key)
+/// of the [Threshold (Fully) Homomorphic Encryption]
+///
+/// To create such key set, first create a [CompressedXofKeySet] then decompress it
+///
+/// [Threshold (Fully) Homomorphic Encryption]: https://eprint.iacr.org/2025/699
+#[derive(Clone, Serialize, Deserialize, Versionize)]
+#[versionize(XofKeySetVersions)]
+pub struct XofKeySet {
+    public_key: CompactPublicKey,
+    server_key: ServerKey,
+}
+
+impl Named for XofKeySet {
+    const NAME: &'static str = "high_level_api::XofKeySet";
+}
+
+impl XofKeySet {
+    pub fn into_raw_parts(self) -> (CompactPublicKey, ServerKey) {
+        (self.public_key, self.server_key)
+    }
+}

--- a/tfhe/src/high_level_api/xof_key_set/test.rs
+++ b/tfhe/src/high_level_api/xof_key_set/test.rs
@@ -1,0 +1,254 @@
+use super::*;
+use crate::core_crypto::prelude::new_seeder;
+use crate::prelude::*;
+use crate::xof_key_set::{CompressedXofKeySet, XofKeySet};
+use crate::*;
+
+#[test]
+fn test_xof_key_set_classic_params() {
+    let params =
+        shortint::parameters::test_params::TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+    let cpk_params =
+        shortint::parameters::test_params::TEST_PARAM_PKE_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+    let casting_params = shortint::parameters::test_params::TEST_PARAM_KEYSWITCH_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+    let noise_squashing_params = shortint::parameters::test_params::TEST_PARAM_NOISE_SQUASHING_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+    let compression_params =
+        shortint::parameters::test_params::TEST_COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+    let re_rand_ksk_params = shortint::parameters::test_params::TEST_PARAM_KEYSWITCH_PKE_TO_BIG_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+    let noise_squashing_compression_params = shortint::parameters::test_params::TEST_PARAM_NOISE_SQUASHING_COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+
+    let config = ConfigBuilder::with_custom_parameters(params)
+        .use_dedicated_compact_public_key_parameters((cpk_params, casting_params))
+        .enable_noise_squashing(noise_squashing_params)
+        .enable_noise_squashing_compression(noise_squashing_compression_params)
+        .enable_compression(compression_params)
+        .enable_ciphertext_re_randomization(re_rand_ksk_params)
+        .build();
+
+    let mut seeder = new_seeder();
+    let private_seed_bytes = seeder.seed().0.to_le_bytes().to_vec();
+    let security_bits = 128;
+    let max_norm_hwt = NormalizedHammingWeightBound::new(0.8).unwrap();
+    let tag = Tag::from("classic_2_2");
+
+    let (cks, compressed_key_set) = CompressedXofKeySet::generate(
+        config,
+        private_seed_bytes,
+        security_bits,
+        max_norm_hwt,
+        tag.clone(),
+    )
+    .unwrap();
+
+    assert_eq!(cks.tag(), compressed_key_set.compressed_public_key.tag());
+    assert_eq!(cks.tag(), &tag);
+    test_xof_key_set(&compressed_key_set, config, &cks);
+}
+
+#[test]
+fn test_xof_key_set_ks32_params_big_pke() {
+    let params =
+        shortint::parameters::test_params::TEST_PARAM_MESSAGE_2_CARRY_2_KS32_PBS_TUNIFORM_2M128;
+    let cpk_params = shortint::parameters::test_params::TEST_PARAM_PKE_TO_BIG_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128_ZKV2;
+    let casting_params = shortint::parameters::test_params::TEST_PARAM_KEYSWITCH_PKE_TO_BIG_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+    let noise_squashing_params = shortint::parameters::test_params::TEST_PARAM_NOISE_SQUASHING_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+    let compression_params =
+        shortint::parameters::test_params::TEST_COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+    let re_rand_ksk_params = shortint::parameters::test_params::TEST_PARAM_KEYSWITCH_PKE_TO_BIG_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+    let noise_squashing_compression_params = shortint::parameters::test_params::TEST_PARAM_NOISE_SQUASHING_COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+
+    let config = ConfigBuilder::with_custom_parameters(params)
+        .use_dedicated_compact_public_key_parameters((cpk_params, casting_params))
+        .enable_noise_squashing(noise_squashing_params)
+        .enable_noise_squashing_compression(noise_squashing_compression_params)
+        .enable_compression(compression_params)
+        .enable_ciphertext_re_randomization(re_rand_ksk_params)
+        .build();
+
+    let mut seeder = new_seeder();
+    let private_seed_bytes = seeder.seed().0.to_le_bytes().to_vec();
+    let security_bits = 128;
+    let max_norm_hwt = NormalizedHammingWeightBound::new(0.8).unwrap();
+    let tag = Tag::from("ks32 big pke");
+
+    let (cks, compressed_key_set) = CompressedXofKeySet::generate(
+        config,
+        private_seed_bytes,
+        security_bits,
+        max_norm_hwt,
+        tag.clone(),
+    )
+    .unwrap();
+
+    assert_eq!(cks.tag(), compressed_key_set.compressed_public_key.tag());
+    assert_eq!(cks.tag(), &tag);
+    test_xof_key_set(&compressed_key_set, config, &cks);
+}
+
+#[test]
+fn test_xof_key_set_ks32_params_small_pke() {
+    let params =
+        shortint::parameters::test_params::TEST_PARAM_MESSAGE_2_CARRY_2_KS32_PBS_TUNIFORM_2M128;
+    let cpk_params = shortint::parameters::test_params::TEST_PARAM_PKE_TO_SMALL_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128_ZKV2;
+    let casting_params = shortint::parameters::test_params::TEST_PARAM_KEYSWITCH_PKE_TO_SMALL_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+    let noise_squashing_params = shortint::parameters::test_params::TEST_PARAM_NOISE_SQUASHING_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+    let compression_params =
+        shortint::parameters::test_params::TEST_COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+    let re_rand_ksk_params = shortint::parameters::test_params::TEST_PARAM_KEYSWITCH_PKE_TO_BIG_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+    let noise_squashing_compression_params = shortint::parameters::test_params::TEST_PARAM_NOISE_SQUASHING_COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+
+    let config = ConfigBuilder::with_custom_parameters(params)
+        .use_dedicated_compact_public_key_parameters((cpk_params, casting_params))
+        .enable_noise_squashing(noise_squashing_params)
+        .enable_noise_squashing_compression(noise_squashing_compression_params)
+        .enable_compression(compression_params)
+        .enable_ciphertext_re_randomization(re_rand_ksk_params)
+        .build();
+
+    let mut seeder = new_seeder();
+    let private_seed_bytes = seeder.seed().0.to_le_bytes().to_vec();
+    let security_bits = 128;
+    let max_norm_hwt = NormalizedHammingWeightBound::new(0.8).unwrap();
+    let tag = Tag::from("ks32 small pke");
+
+    let (cks, compressed_key_set) = CompressedXofKeySet::generate(
+        config,
+        private_seed_bytes,
+        security_bits,
+        max_norm_hwt,
+        tag.clone(),
+    )
+    .unwrap();
+
+    assert_eq!(cks.tag(), compressed_key_set.compressed_public_key.tag());
+    assert_eq!(cks.tag(), &tag);
+    test_xof_key_set(&compressed_key_set, config, &cks);
+}
+
+fn test_xof_key_set(compressed_key_set: &CompressedXofKeySet, config: Config, cks: &ClientKey) {
+    let compressed_size_limit = 1 << 30;
+    let mut data = vec![];
+    crate::safe_serialization::safe_serialize(compressed_key_set, &mut data, compressed_size_limit)
+        .unwrap();
+    let compressed_key_set: CompressedXofKeySet =
+        crate::safe_serialization::safe_deserialize(data.as_slice(), compressed_size_limit)
+            .unwrap();
+
+    let expected_pk_tag = compressed_key_set.compressed_public_key.tag().clone();
+    let expected_sk_tag = compressed_key_set.compressed_server_key.tag().clone();
+    let key_set = compressed_key_set.decompress().unwrap();
+
+    let size_limit = 1 << 32;
+    let mut data = vec![];
+    crate::safe_serialization::safe_serialize(&key_set, &mut data, size_limit).unwrap();
+    let key_set: XofKeySet =
+        crate::safe_serialization::safe_deserialize(data.as_slice(), size_limit).unwrap();
+
+    let (pk, sk) = key_set.into_raw_parts();
+    assert_eq!(pk.tag(), &expected_pk_tag);
+    assert_eq!(sk.tag(), &expected_sk_tag);
+
+    assert!(sk.is_conformant(&config.into()));
+
+    set_server_key(sk);
+
+    let clear_a = rand::random::<u32>();
+    let clear_b = rand::random::<u32>();
+
+    {
+        let a = FheUint32::encrypt(clear_a, cks);
+        let b = FheUint32::encrypt(clear_b, cks);
+
+        let c = &a * &b;
+        let d = &a & &b;
+
+        let c_dec: u32 = c.decrypt(cks);
+        let d_dec: u32 = d.decrypt(cks);
+
+        assert_eq!(clear_a.wrapping_mul(clear_b), c_dec);
+        assert_eq!(clear_a & clear_b, d_dec);
+    }
+
+    let list = CompactCiphertextList::builder(&pk)
+        .push(clear_a)
+        .push(clear_b)
+        .build();
+    let expander = list.expand().unwrap();
+    let mut a = expander.get::<FheUint32>(0).unwrap().unwrap();
+    let mut b = expander.get::<FheUint32>(1).unwrap().unwrap();
+
+    // Test re-randomization
+    {
+        // Simulate a 256 bits nonce
+        let nonce: [u8; 256 / 8] = core::array::from_fn(|_| rand::random());
+        let compact_public_encryption_domain_separator = *b"TFHE_Enc";
+        let rerand_domain_separator = *b"TFHE_Rrd";
+
+        let mut re_rand_context = ReRandomizationContext::new(
+            rerand_domain_separator,
+            // First is the function description, second is a nonce
+            [b"FheUint32 bin ops".as_slice(), nonce.as_slice()],
+            compact_public_encryption_domain_separator,
+        );
+
+        re_rand_context.add_ciphertext(&a);
+        re_rand_context.add_ciphertext(&b);
+
+        let mut seed_gen = re_rand_context.finalize();
+
+        a.re_randomize(&pk, seed_gen.next_seed().unwrap()).unwrap();
+
+        b.re_randomize(&pk, seed_gen.next_seed().unwrap()).unwrap();
+    }
+
+    let c = &a * &b;
+    let d = &a & &b;
+
+    let c_dec: u32 = c.decrypt(cks);
+    let d_dec: u32 = d.decrypt(cks);
+
+    assert_eq!(clear_a.wrapping_mul(clear_b), c_dec);
+    assert_eq!(clear_a & clear_b, d_dec);
+
+    let ns_c = c.squash_noise().unwrap();
+    let ns_c_dec: u32 = ns_c.decrypt(cks);
+    assert_eq!(clear_a.wrapping_mul(clear_b), ns_c_dec);
+
+    let ns_d = d.squash_noise().unwrap();
+    let ns_d_dec: u32 = ns_d.decrypt(cks);
+    assert_eq!(clear_a & clear_b, ns_d_dec);
+
+    let compressed_list = CompressedCiphertextListBuilder::new()
+        .push(a)
+        .push(b)
+        .push(c)
+        .push(d)
+        .build()
+        .unwrap();
+
+    let a: FheUint32 = compressed_list.get(0).unwrap().unwrap();
+    let da: u32 = a.decrypt(cks);
+    assert_eq!(da, clear_a);
+    let b: FheUint32 = compressed_list.get(1).unwrap().unwrap();
+    let db: u32 = b.decrypt(cks);
+    assert_eq!(db, clear_b);
+    let c: FheUint32 = compressed_list.get(2).unwrap().unwrap();
+    let dc: u32 = c.decrypt(cks);
+    assert_eq!(dc, clear_a.wrapping_mul(clear_b));
+    let d: FheUint32 = compressed_list.get(3).unwrap().unwrap();
+    let db: u32 = d.decrypt(cks);
+    assert_eq!(db, clear_a & clear_b);
+
+    let ns_compressed_list = CompressedSquashedNoiseCiphertextListBuilder::new()
+        .push(ns_c)
+        .push(ns_d)
+        .build()
+        .unwrap();
+
+    let ns_c: SquashedNoiseFheUint = ns_compressed_list.get(0).unwrap().unwrap();
+    let dc: u32 = ns_c.decrypt(cks);
+    assert_eq!(dc, clear_a.wrapping_mul(clear_b));
+    let ns_d: SquashedNoiseFheUint = ns_compressed_list.get(1).unwrap().unwrap();
+    let db: u32 = ns_d.decrypt(cks);
+    assert_eq!(db, clear_a & clear_b);
+}


### PR DESCRIPTION
Introduce IntegerExpandedServerKey as an intermediate representation between compressed (seeded) keys and backend-specific formats. Decompression is now a two-step process:

1. Seed expansion: decompress seeded keys into standard domain representations (e.g., LweBootstrapKey instead of FourierLweBootstrapKey)
2. Backend conversion: convert to target backend format (CPU Fourier, GPU, etc.)

This separation allows sharing the expansion step across backends while specializing only the final conversion, as for this XOF based expansion the order is important

Changes:
- Split xof_key_set.rs into module structure (mod.rs, internal.rs, test.rs)
- Add intermediate types, that contains the expanded, but not converted data


First step for https://github.com/zama-ai/tfhe-rs-internal/issues/1271

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3192)
<!-- Reviewable:end -->
