### PR TITLE
feat(hpu): HPU backend uses a shared atomic counter to rcv ack & mmap HPU registers from BAR0

### DIFF
--- a/backends/tfhe-hpu-backend/Cargo.toml
+++ b/backends/tfhe-hpu-backend/Cargo.toml
@@ -22,6 +22,7 @@ cxx-build = "1.0"
 
 [dependencies]
 cxx = "1.0"
+libc = "0.2"
 hw_regmap = "0.2.1"
 
 strum = { version = "0.26.2", features = ["derive"] }

--- a/backends/tfhe-hpu-backend/Cargo.toml
+++ b/backends/tfhe-hpu-backend/Cargo.toml
@@ -53,7 +53,7 @@ ipc-channel = "0.18.3"
 num-traits = { version = "0.2", optional = true }
 clap = { version = "4.4.4", features = ["derive"], optional = true }
 clap-num = { version = "1.1.1", optional = true }
-nix = { version = "0.29.0", features = ["ioctl", "uio", "fs"] }
+nix = { version = "0.29.0", features = ["mman", "ioctl", "uio", "fs"] }
 
 # Dependencies used for rtl_graph features
 dot2 = { version = "1.0", optional = true }

--- a/backends/tfhe-hpu-backend/src/ffi/mod.rs
+++ b/backends/tfhe-hpu-backend/src/ffi/mod.rs
@@ -228,6 +228,11 @@ impl HpuHw {
     pub fn iop_ack_rd(&mut self) -> u32 {
         self.0.ami.iop_ackq_rd()
     }
+
+    #[cfg(feature = "hw-v80")]
+    pub fn map_bar_reg(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        self.0.ami.map_bar_reg()
+    }
 }
 
 pub struct MemZone(

--- a/backends/tfhe-hpu-backend/src/ffi/v80/ami.rs
+++ b/backends/tfhe-hpu-backend/src/ffi/v80/ami.rs
@@ -131,6 +131,23 @@ impl AmiDriver {
         }
     }
 
+    pub fn munmap_cnt(&self) -> Result<(), Box<dyn Error>> {
+        let cnt_addr = self.iop_ack_atomic_ptr.as_ptr() as *mut libc::c_void;
+        unsafe {
+            let retc = libc::munmap(cnt_addr, 4096);
+
+            if retc == 0 {
+                Ok(())
+            } else {
+                Err(format!(
+                    "Could not unmap the atomic shared cnt (mumap returned {})",
+                    retc
+                )
+                .into())
+            }
+        }
+    }
+
     /// Read currently loaded UUID in BAR
     pub fn uuid(&self) -> String {
         let ami_fd = self.ami_dev.as_raw_fd();

--- a/backends/tfhe-hpu-backend/src/ffi/v80/mod.rs
+++ b/backends/tfhe-hpu-backend/src/ffi/v80/mod.rs
@@ -103,6 +103,7 @@ impl HpuHw {
             tracing::info!("Current pdi -> [\n{uuid}]");
             Ok(hw)
         } else {
+            hw.ami.munmap_cnt().unwrap();
             Err(format!(
                 "UUID mismatch loaded {:?} expected {:?}",
                 current_uuid,

--- a/backends/tfhe-hpu-backend/src/interface/device.rs
+++ b/backends/tfhe-hpu-backend/src/interface/device.rs
@@ -94,6 +94,18 @@ impl HpuDevice {
     ) where
         F: Fn(HpuParameters, &crate::asm::Pbs) -> HpuGlweLookuptableOwned<u64>,
     {
+        // print HPU version
+        #[cfg(feature = "hw-v80")]
+        {
+            let mut backend = self.backend.lock().unwrap();
+            let (major, minor) = backend.get_hpu_version();
+            tracing::info!("HPU version -> {}.{}", major, minor);
+
+            if major >= 2 && minor >= 3 {
+                backend.map_bar_reg().unwrap();
+            }
+        }
+
         // Properly reset keys
         self.bsk_unset();
         self.ksk_unset();


### PR DESCRIPTION
to get IOp ack from AMI driver
requires AMI driver 3.2.0 currently in PR https://github.com/zama-ai/AVED/pull/10
does not seem to have deep impact on bench performance because but still better than while (1) { open - read - close }

tested on simple run of hpu_bench, integer & erc20 throughput tests
