### PR TITLE
fix(gpu): add __syncthreads and threadIdx condition for sample_extract_body in all pbs versions

### DIFF
--- a/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_amortized.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_amortized.cuh
@@ -211,6 +211,8 @@ __global__ void device_programmable_bootstrap_amortized(
   // For the mask it's more complicated
   sample_extract_mask<Torus, params>(block_lwe_array_out, accumulator,
                                      glwe_dimension);
+
+  // No need to sync here, it is already synchronized after add_to_torus
   sample_extract_body<Torus, params>(block_lwe_array_out, accumulator,
                                      glwe_dimension);
 }

--- a/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_cg_classic.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_cg_classic.cuh
@@ -173,6 +173,7 @@ __global__ void device_programmable_bootstrap_cg(
         }
       }
     } else if (blockIdx.y == glwe_dimension) {
+      __syncthreads();
       sample_extract_body<Torus, params>(block_lwe_array_out, accumulator, 0);
       if (num_many_lut > 1) {
         for (int i = 1; i < num_many_lut; i++) {
@@ -184,7 +185,8 @@ __global__ void device_programmable_bootstrap_cg(
               &next_lwe_array_out[lwe_output_indexes[blockIdx.x] *
                                       (glwe_dimension * polynomial_size + 1) +
                                   blockIdx.y * polynomial_size];
-
+          // No need to sync, it is already synchronized before the first
+          // sample_extract_body call
           sample_extract_body<Torus, params>(next_block_lwe_array_out,
                                              accumulator, 0, i * lut_stride);
         }

--- a/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_cg_multibit.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_cg_multibit.cuh
@@ -151,9 +151,8 @@ __global__ void __launch_bounds__(params::degree / params::opt)
         }
 
       } else if (blockIdx.y == glwe_dimension) {
-
+        __syncthreads();
         sample_extract_body<Torus, params>(block_lwe_array_out, accumulator, 0);
-
         if (num_many_lut > 1) {
           for (int i = 1; i < num_many_lut; i++) {
 
@@ -165,6 +164,8 @@ __global__ void __launch_bounds__(params::degree / params::opt)
                                         (glwe_dimension * polynomial_size + 1) +
                                     blockIdx.y * polynomial_size];
 
+            // No need to sync, it is already synchronized before the first
+            // sample_extract_body call
             sample_extract_body<Torus, params>(next_block_lwe_array_out,
                                                accumulator, 0, i * lut_stride);
           }

--- a/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_classic.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_classic.cuh
@@ -239,6 +239,7 @@ __global__ void __launch_bounds__(params::degree / params::opt)
         }
       }
     } else if (blockIdx.y == glwe_dimension) {
+      __syncthreads();
       sample_extract_body<Torus, params>(block_lwe_array_out, accumulator, 0);
       if (num_many_lut > 1) {
         for (int i = 1; i < num_many_lut; i++) {
@@ -251,6 +252,8 @@ __global__ void __launch_bounds__(params::degree / params::opt)
                                       (glwe_dimension * polynomial_size + 1) +
                                   blockIdx.y * polynomial_size];
 
+          // No need to sync, it is already synchronized before the first
+          // sample_extract_body call
           sample_extract_body<Torus, params>(next_block_lwe_array_out,
                                              accumulator, 0, i * lut_stride);
         }

--- a/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_classic_128.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_classic_128.cuh
@@ -240,10 +240,13 @@ __global__ void __launch_bounds__(params::degree / params::opt)
       // in case they're not synchronized
       sample_extract_mask<Torus, params>(block_lwe_array_out, accumulator);
     } else if (blockIdx.y == glwe_dimension) {
+      __syncthreads();
       sample_extract_body<Torus, params>(block_lwe_array_out, accumulator, 0);
     }
   } else {
-    // Persist the updated accumulator
+    // We don't sync here because we use same indexes to read from `accumulator`
+    // as it was used in `add_to_torus_128` to write inside it Persist the
+    // updated accumulator
     tid = threadIdx.x;
     for (int i = 0; i < params::opt; i++) {
       global_slice[tid] = accumulator[tid];
@@ -395,6 +398,7 @@ __global__ void device_programmable_bootstrap_cg_128(
                                                accumulator);
 
     } else if (blockIdx.y == glwe_dimension) {
+      __syncthreads();
       sample_extract_body<__uint128_t, params>(block_lwe_array_out, accumulator,
                                                0);
     }

--- a/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_multibit.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_multibit.cuh
@@ -461,6 +461,7 @@ __global__ void __launch_bounds__(params::degree / params::opt)
         }
       }
     } else if (blockIdx.y == glwe_dimension) {
+      // No need to sync here, it is already synchronized after add_to_torus
       sample_extract_body<Torus, params>(block_lwe_array_out, global_slice, 0);
       if (num_many_lut > 1) {
         for (int i = 1; i < num_many_lut; i++) {
@@ -473,6 +474,7 @@ __global__ void __launch_bounds__(params::degree / params::opt)
                                       (glwe_dimension * polynomial_size + 1) +
                                   blockIdx.y * polynomial_size];
 
+          // No need to sync here, it is already synchronized after add_to_torus
           sample_extract_body<Torus, params>(next_block_lwe_array_out,
                                              global_slice, 0, i * lut_stride);
         }

--- a/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_multibit_128.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_multibit_128.cuh
@@ -333,6 +333,7 @@ __global__ void __launch_bounds__(params::degree / params::opt)
         }
       }
     } else if (blockIdx.y == glwe_dimension) {
+      __syncthreads();
       sample_extract_body<__uint128_t, params>(block_lwe_array_out,
                                                global_slice, 0);
       if (num_many_lut > 1) {
@@ -346,6 +347,8 @@ __global__ void __launch_bounds__(params::degree / params::opt)
                                       (glwe_dimension * polynomial_size + 1) +
                                   blockIdx.y * polynomial_size];
 
+          // No need to sync, it is already synchronized before the first
+          // sample_extract_body call
           sample_extract_body<__uint128_t, params>(
               next_block_lwe_array_out, global_slice, 0, i * lut_stride);
         }
@@ -505,10 +508,9 @@ __global__ void __launch_bounds__(params::degree / params::opt)
         }
 
       } else if (blockIdx.y == glwe_dimension) {
-
+        __syncthreads();
         sample_extract_body<__uint128_t, params>(block_lwe_array_out,
                                                  accumulator, 0);
-
         if (num_many_lut > 1) {
           for (int i = 1; i < num_many_lut; i++) {
 
@@ -519,7 +521,8 @@ __global__ void __launch_bounds__(params::degree / params::opt)
                 &next_lwe_array_out[lwe_output_indexes[blockIdx.x] *
                                         (glwe_dimension * polynomial_size + 1) +
                                     blockIdx.y * polynomial_size];
-
+            // No need to sync, it is already synchronized before the first
+            // sample_extract_body call
             sample_extract_body<__uint128_t, params>(
                 next_block_lwe_array_out, accumulator, 0, i * lut_stride);
           }

--- a/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_tbc_classic.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_tbc_classic.cuh
@@ -179,6 +179,7 @@ __global__ void device_programmable_bootstrap_tbc(
         }
       }
     } else if (blockIdx.y == glwe_dimension) {
+      __syncthreads();
       sample_extract_body<Torus, params>(block_lwe_array_out, accumulator, 0);
 
       if (num_many_lut > 1) {
@@ -191,7 +192,8 @@ __global__ void device_programmable_bootstrap_tbc(
               &next_lwe_array_out[lwe_output_indexes[blockIdx.x] *
                                       (glwe_dimension * polynomial_size + 1) +
                                   blockIdx.y * polynomial_size];
-
+          // No need to sync, it is already synchronized before the first
+          // sample_extract_body call
           sample_extract_body<Torus, params>(next_block_lwe_array_out,
                                              accumulator, 0, i * lut_stride);
         }
@@ -360,6 +362,7 @@ __global__ void device_programmable_bootstrap_tbc_2_2_params(
         }
       }
     } else if (blockIdx.y == glwe_dimension) {
+      // No need to sync here, it is already synchronized after add_to_torus
       sample_extract_body<Torus, params>(block_lwe_array_out, accumulator, 0);
 
       if (num_many_lut > 1) {
@@ -373,6 +376,7 @@ __global__ void device_programmable_bootstrap_tbc_2_2_params(
                                       (glwe_dimension * polynomial_size + 1) +
                                   blockIdx.y * polynomial_size];
 
+          // No need to sync here, it is already synchronized after add_to_torus
           sample_extract_body<Torus, params>(next_block_lwe_array_out,
                                              accumulator, 0, i * lut_stride);
         }

--- a/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_tbc_multibit.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_tbc_multibit.cuh
@@ -156,6 +156,7 @@ __global__ void __launch_bounds__(params::degree / params::opt)
           }
         }
       } else if (blockIdx.y == glwe_dimension) {
+        __syncthreads();
         sample_extract_body<Torus, params>(block_lwe_array_out, accumulator, 0);
         if (num_many_lut > 1) {
           for (int i = 1; i < num_many_lut; i++) {
@@ -167,7 +168,8 @@ __global__ void __launch_bounds__(params::degree / params::opt)
                 &next_lwe_array_out[lwe_output_indexes[blockIdx.x] *
                                         (glwe_dimension * polynomial_size + 1) +
                                     blockIdx.y * polynomial_size];
-
+            // No need to sync, it is already synchronized before the first
+            // sample_extract_body call
             sample_extract_body<Torus, params>(next_block_lwe_array_out,
                                                accumulator, 0, i * lut_stride);
           }
@@ -356,6 +358,7 @@ __global__ void __launch_bounds__(params::degree / params::opt)
         }
       }
     } else if (blockIdx.y == glwe_dimension) {
+      // No need to sync here, it is already synchronized after add_to_torus
       sample_extract_body<Torus, params>(block_lwe_array_out, accumulator, 0);
       if (num_many_lut > 1) {
         for (int i = 1; i < num_many_lut; i++) {
@@ -367,7 +370,8 @@ __global__ void __launch_bounds__(params::degree / params::opt)
               &next_lwe_array_out[lwe_output_indexes[blockIdx.x] *
                                       (glwe_dimension * polynomial_size + 1) +
                                   blockIdx.y * polynomial_size];
-
+          // No need to sync here, it is already synchronized after
+          // add_to_torus
           sample_extract_body<Torus, params>(next_block_lwe_array_out,
                                              accumulator, 0, i * lut_stride);
         }

--- a/backends/tfhe-cuda-backend/cuda/src/polynomial/functions.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/polynomial/functions.cuh
@@ -339,8 +339,10 @@ template <typename Torus, class params>
 __device__ void sample_extract_body(Torus *lwe_array_out, Torus const *glwe,
                                     uint32_t glwe_dimension, uint32_t nth = 0) {
   // Set first coefficient of the glwe as the body of the LWE sample
-  lwe_array_out[glwe_dimension * params::degree] =
-      glwe[glwe_dimension * params::degree + nth];
+  if (threadIdx.x == 0) {
+    lwe_array_out[glwe_dimension * params::degree] =
+        glwe[glwe_dimension * params::degree + nth];
+  }
 }
 
 // Extracts the mask from the nth-LWE in a GLWE.


### PR DESCRIPTION
### PR content/description
In some versions of PBS there is no synchronization after `add_to_torus`  that can cause race condition for `sample_extract_body`, this pr adds synchronizations and thread id check for `sample_extract_body` since its modifying only one coefficient would be good if only one thread is responsible to process it.

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
