### PR TITLE
fix(wasm): benchmark compilation for wasm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1371,6 +1371,9 @@ clippy_bench: install_rs_check_toolchain
 	RUSTFLAGS="$(RUSTFLAGS)" cargo "$(CARGO_RS_CHECK_TOOLCHAIN)" clippy --all-targets \
 		--features=boolean,shortint,integer,internal-keycache,pbs-stats,zk-pok \
 		-p tfhe-benchmark -- --no-deps -D warnings
+	RUSTFLAGS="$(RUSTFLAGS)" cargo "$(CARGO_RS_CHECK_TOOLCHAIN)" clippy --all-targets \
+	  --features=shortint,internal-keycache \
+		-p tfhe-benchmark -- --no-deps -D warnings
 
 .PHONY: clippy_bench_gpu # Run clippy lints on tfhe-benchmark
 clippy_bench_gpu: install_rs_check_toolchain

--- a/tfhe-benchmark/src/lib.rs
+++ b/tfhe-benchmark/src/lib.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "integer")]
 pub mod high_level_api;
 pub mod params;
 pub mod params_aliases;


### PR DESCRIPTION
This pull request introduces a small but meaningful update to the codebase. The main changes are the addition of conditional compilation for the `high_level_api` module in the benchmark library and an update to the Clippy linting commands for the `tfhe-benchmark` crate. These changes improve build flexibility and code quality checks.

**Build and linting improvements:**

* Added a new Clippy linting command in the `Makefile` to run with only the `shortint` and `internal-keycache` features enabled for the `tfhe-benchmark` crate, ensuring targeted lint checks for these feature combinations.

**Code organization:**

* Made the `high_level_api` module in `tfhe-benchmark/src/lib.rs` only available when the `integer` feature is enabled, improving modularity and reducing unnecessary compilation.

Following text generated with the help of AI