### PR TITLE
chore(bench): add throughput operation on hlapi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1674,14 +1674,14 @@ bench_web_js_api_unsafe_coop_firefox_ci: setup_venv
 
 .PHONY: bench_hlapi_unsigned # Run benchmarks for integer operations
 bench_hlapi_unsigned: install_rs_check_toolchain
-	RUSTFLAGS="$(RUSTFLAGS)" __TFHE_RS_BENCH_BIT_SIZES_SET=$(BIT_SIZES_SET) __TFHE_RS_BENCH_TYPE=$(BENCH_TYPE) \
+	RUSTFLAGS="$(RUSTFLAGS)" __TFHE_RS_BENCH_BIT_SIZES_SET=$(BIT_SIZES_SET) __TFHE_RS_BENCH_TYPE=$(BENCH_TYPE) __TFHE_RS_BENCH_OP_FLAVOR=$(BENCH_OP_FLAVOR) \
 	cargo $(CARGO_RS_CHECK_TOOLCHAIN) bench \
 	--bench hlapi_unsigned \
 	--features=integer,internal-keycache,pbs-stats -p tfhe-benchmark --
 
 .PHONY: bench_hlapi_signed # Run benchmarks for signed integer operations
 bench_hlapi_signed: install_rs_check_toolchain
-	RUSTFLAGS="$(RUSTFLAGS)" __TFHE_RS_BENCH_BIT_SIZES_SET=$(BIT_SIZES_SET) __TFHE_RS_BENCH_TYPE=$(BENCH_TYPE) \
+	RUSTFLAGS="$(RUSTFLAGS)" __TFHE_RS_BENCH_BIT_SIZES_SET=$(BIT_SIZES_SET) __TFHE_RS_BENCH_TYPE=$(BENCH_TYPE) __TFHE_RS_BENCH_OP_FLAVOR=$(BENCH_OP_FLAVOR) \
 	cargo $(CARGO_RS_CHECK_TOOLCHAIN) bench \
 	--bench hlapi_signed \
 	--features=integer,internal-keycache,pbs-stats -p tfhe-benchmark --

--- a/tfhe-benchmark/benches/high_level_api/bench_signed.rs
+++ b/tfhe-benchmark/benches/high_level_api/bench_signed.rs
@@ -4,6 +4,7 @@ use benchmark::high_level_api::random_generator::{random_non_zero, random_not_po
 use benchmark::utilities::{BitSizesSet, EnvConfig, OperandType};
 use criterion::Criterion;
 use oprf::oprf_any_range2;
+use std::env;
 use std::marker::PhantomData;
 use std::ops::*;
 use tfhe::core_crypto::prelude::Numeric;
@@ -76,16 +77,43 @@ fn main() {
 
     match env_config.bit_sizes_set {
         BitSizesSet::Fast => {
-            run_benches!(&mut c, &cks, FheInt64);
+            match env::var("__TFHE_RS_BENCH_OP_FLAVOR").as_deref() {
+                // Call all benchmarks for all types
+                Ok("fast_default") => {
+                    run_benches_dedup!(&mut c, &cks, FheInt64,);
+                    run_scalar_benches_dedup!(&mut c, &cks, FheInt64,);
+                }
+                _ => {
+                    run_benches!(&mut c, &cks, FheInt64,);
+                    run_scalar_benches!(&mut c, &cks, FheInt64,);
+                }
+            }
         }
         _ => {
             // Call all benchmarks for all types
-            run_benches!(
-                &mut c, &cks, FheInt2, FheInt4, FheInt8, FheInt16, FheInt32, FheInt64, FheInt128
-            );
-            run_scalar_benches!(
-                &mut c, &cks, FheInt2, FheInt4, FheInt8, FheInt16, FheInt32, FheInt64, FheInt128
-            );
+            match env::var("__TFHE_RS_BENCH_OP_FLAVOR").as_deref() {
+                // Call all benchmarks for all types
+                Ok("fast_default") => {
+                    run_benches_dedup!(
+                        &mut c, &cks, FheInt2, FheInt4, FheInt8, FheInt16, FheInt32, FheInt64,
+                        FheInt128,
+                    );
+                    run_scalar_benches_dedup!(
+                        &mut c, &cks, FheInt2, FheInt4, FheInt8, FheInt16, FheInt32, FheInt64,
+                        FheInt128,
+                    );
+                }
+                _ => {
+                    run_benches!(
+                        &mut c, &cks, FheInt2, FheInt4, FheInt8, FheInt16, FheInt32, FheInt64,
+                        FheInt128,
+                    );
+                    run_scalar_benches!(
+                        &mut c, &cks, FheInt2, FheInt4, FheInt8, FheInt16, FheInt32, FheInt64,
+                        FheInt128,
+                    );
+                }
+            }
         }
     }
 

--- a/tfhe-benchmark/src/high_level_api/benchmark_op.rs
+++ b/tfhe-benchmark/src/high_level_api/benchmark_op.rs
@@ -7,7 +7,7 @@ use tfhe::{ClientKey, FheBool};
 
 pub trait BenchmarkOp<FheType> {
     type Output: BenchWait;
-    type Inputs: Sync;
+    type Inputs: Sync + Send;
 
     /// Setup the encrypted inputs for the operation
     fn setup_inputs(&self, client_key: &ClientKey, rng: &mut ThreadRng) -> Self::Inputs;
@@ -25,7 +25,7 @@ impl<FheType, F, R, EncryptType> BenchmarkOp<FheType> for UnaryOp<F, EncryptType
 where
     F: Fn(&FheType) -> R,
     R: BenchWait,
-    FheType: FheEncrypt<EncryptType, ClientKey> + Sync,
+    FheType: FheEncrypt<EncryptType, ClientKey> + Send + Sync,
     Standard: Distribution<EncryptType>,
 {
     type Output = R;
@@ -51,9 +51,9 @@ where
     F: Fn(&FheType, &T) -> R,
     R: BenchWait,
     G: Fn() -> T,
-    FheType: FheEncrypt<EncryptType, ClientKey> + Sync,
+    FheType: FheEncrypt<EncryptType, ClientKey> + Sync + Send,
     Standard: Distribution<EncryptType>,
-    T: Sync,
+    T: Sync + Send,
 {
     type Output = R;
     type Inputs = (FheType, T);
@@ -82,8 +82,8 @@ impl<FheType, FheRhsType, F, R, EncryptLhsType, EncryptRhsType> BenchmarkOp<FheT
 where
     F: Fn(&FheType, &FheRhsType) -> R,
     R: BenchWait,
-    FheType: FheEncrypt<EncryptLhsType, ClientKey> + Sync,
-    FheRhsType: FheEncrypt<EncryptRhsType, ClientKey> + Sync,
+    FheType: FheEncrypt<EncryptLhsType, ClientKey> + Sync + Send,
+    FheRhsType: FheEncrypt<EncryptRhsType, ClientKey> + Sync + Send,
     Standard: Distribution<EncryptLhsType>,
     Standard: Distribution<EncryptRhsType>,
 {
@@ -111,7 +111,7 @@ impl<FheType, F, R, EncryptType> BenchmarkOp<FheType> for TernaryOp<F, EncryptTy
 where
     F: Fn(&FheBool, &FheType, &FheType) -> R,
     R: BenchWait,
-    FheType: FheEncrypt<EncryptType, ClientKey> + Sync,
+    FheType: FheEncrypt<EncryptType, ClientKey> + Sync + Send,
     Standard: Distribution<EncryptType>,
 {
     type Output = R;
@@ -139,7 +139,7 @@ pub struct ArrayOp<F, EncryptType> {
 impl<FheType, F, EncryptType> BenchmarkOp<FheType> for ArrayOp<F, EncryptType>
 where
     F: for<'a> Fn(std::slice::Iter<'a, FheType>) -> FheType,
-    FheType: FheEncrypt<EncryptType, ClientKey> + Clone + BenchWait + Sync,
+    FheType: FheEncrypt<EncryptType, ClientKey> + Clone + BenchWait + Sync + Send,
     Standard: Distribution<EncryptType>,
 {
     type Output = FheType;


### PR DESCRIPTION
This pull request enhance the benchmarking framework for high-level API operations by introducing support for throughput benchmarks.

Also add the possibility to run the throughput directly from the makefile like `make BENCH_TYPE=throughput bench_hlapi_unsigned`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3218)
<!-- Reviewable:end -->
