### PR TITLE
refactor(csprng): move Seed backward compat in csprng

### DIFF
--- a/tfhe-csprng/src/seeders/backward_compatibility/mod.rs
+++ b/tfhe-csprng/src/seeders/backward_compatibility/mod.rs
@@ -1,8 +1,13 @@
 use tfhe_versionable::VersionsDispatch;
 
-use crate::seeders::XofSeed;
+use crate::seeders::{Seed, XofSeed};
 
 #[derive(VersionsDispatch)]
 pub enum XofSeedVersions {
     V0(XofSeed),
+}
+
+#[derive(VersionsDispatch)]
+pub enum SeedVersions {
+    V0(Seed),
 }

--- a/tfhe-csprng/src/seeders/mod.rs
+++ b/tfhe-csprng/src/seeders/mod.rs
@@ -6,7 +6,8 @@
 //! seeds that can accommodate varying scenarios.
 
 /// A seed value, used to initialize a generator.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize, Versionize)]
+#[versionize(SeedVersions)]
 pub struct Seed(pub u128);
 
 /// A Seed as described in the [Threshold (Fully) Homomorphic Encryption]
@@ -138,7 +139,7 @@ mod implem;
 pub use implem::*;
 use tfhe_versionable::Versionize;
 
-use crate::seeders::backward_compatibility::XofSeedVersions;
+use crate::seeders::backward_compatibility::{SeedVersions, XofSeedVersions};
 
 #[cfg(test)]
 mod generic_tests {

--- a/tfhe/src/core_crypto/backward_compatibility/commons/math/random/mod.rs
+++ b/tfhe/src/core_crypto/backward_compatibility/commons/math/random/mod.rs
@@ -1,4 +1,5 @@
-use tfhe_versionable::VersionsDispatch;
+use std::convert::Infallible;
+use tfhe_versionable::{Upgrade, VersionsDispatch};
 
 use crate::core_crypto::commons::math::random::*;
 use crate::core_crypto::prelude::{FloatingPoint, UnsignedInteger};
@@ -18,32 +19,78 @@ pub enum DynamicDistributionVersions<T: UnsignedInteger> {
     V0(DynamicDistribution<T>),
 }
 
-#[derive(Serialize)]
-pub enum CompressionSeedVersioned<'vers> {
-    V0(&'vers CompressionSeed),
-}
+// Between V0 and V1 one of the changes is that the Seed type
+// from tfhe_csprng now implements versionize, so the manual impl
+// that was done in tfhe::core_crypto is no longer necessary.
+//
+// However to keep structural compatibility (e.g CBOR format) we need
+// this boiler plate
+mod compression_seed_v0 {
+    use serde::{Deserialize, Serialize};
+    use tfhe_csprng::seeders::Seed;
+    use tfhe_versionable::{UnversionizeError, Version};
 
-impl<'vers> From<&'vers CompressionSeed> for CompressionSeedVersioned<'vers> {
-    fn from(value: &'vers CompressionSeed) -> Self {
-        Self::V0(value)
+    #[derive(Serialize, Deserialize, Copy, Clone)]
+    pub struct SeedSerdeDef(pub u128);
+
+    #[derive(Deserialize, Serialize)]
+    pub struct CompressionSeedV0Proxy {
+        pub seed: SeedSerdeDef,
     }
-}
 
-#[derive(Serialize, Deserialize)]
-pub enum CompressionSeedVersionedOwned {
-    V0(CompressionSeed),
-}
-
-impl From<CompressionSeed> for CompressionSeedVersionedOwned {
-    fn from(value: CompressionSeed) -> Self {
-        Self::V0(value)
-    }
-}
-
-impl From<CompressionSeedVersionedOwned> for CompressionSeed {
-    fn from(value: CompressionSeedVersionedOwned) -> Self {
-        match value {
-            CompressionSeedVersionedOwned::V0(v0) => v0,
+    impl From<CompressionSeedV0> for CompressionSeedV0Proxy {
+        fn from(value: CompressionSeedV0) -> Self {
+            let CompressionSeedV0 { seed } = value;
+            Self {
+                seed: SeedSerdeDef(seed.0),
+            }
         }
     }
+
+    impl<'a> From<&'a CompressionSeedV0> for CompressionSeedV0Proxy {
+        fn from(value: &'a CompressionSeedV0) -> Self {
+            let CompressionSeedV0 { seed } = value;
+            Self {
+                seed: SeedSerdeDef(seed.0),
+            }
+        }
+    }
+
+    impl TryInto<CompressionSeedV0> for CompressionSeedV0Proxy {
+        type Error = UnversionizeError;
+
+        fn try_into(self) -> Result<CompressionSeedV0, Self::Error> {
+            let Self { seed } = self;
+            Ok(CompressionSeedV0 { seed: Seed(seed.0) })
+        }
+    }
+
+    pub struct CompressionSeedV0 {
+        pub seed: Seed,
+    }
+
+    impl Version for CompressionSeedV0 {
+        type Ref<'vers>
+            = CompressionSeedV0Proxy
+        where
+            Self: 'vers;
+
+        type Owned = CompressionSeedV0Proxy;
+    }
+}
+use compression_seed_v0::CompressionSeedV0;
+
+impl Upgrade<CompressionSeed> for CompressionSeedV0 {
+    type Error = Infallible;
+
+    fn upgrade(self) -> Result<CompressionSeed, Self::Error> {
+        let Self { seed } = self;
+        Ok(CompressionSeed { seed })
+    }
+}
+
+#[derive(VersionsDispatch)]
+pub enum CompressionSeedVersions {
+    V0(CompressionSeedV0),
+    V1(CompressionSeed),
 }

--- a/tfhe/src/core_crypto/commons/math/random/mod.rs
+++ b/tfhe/src/core_crypto/commons/math/random/mod.rs
@@ -16,6 +16,7 @@
 use crate::core_crypto::backward_compatibility::commons::math::random::DynamicDistributionVersions;
 use crate::core_crypto::commons::dispersion::{DispersionParameter, StandardDev, Variance};
 use crate::core_crypto::commons::numeric::{FloatingPoint, UnsignedInteger};
+use serde::{Deserialize, Serialize};
 use std::ops::Bound;
 
 use crate::core_crypto::prelude::{CastInto, Numeric};

--- a/tfhe/src/core_crypto/gpu/algorithms/test/params.rs
+++ b/tfhe/src/core_crypto/gpu/algorithms/test/params.rs
@@ -1,10 +1,10 @@
-use crate::core_crypto::commons::math::random::{Deserialize, Serialize};
 use crate::core_crypto::prelude::{
     CiphertextModulus, DecompositionBaseLog, DecompositionLevelCount, DynamicDistribution,
     GlweDimension, LweBskGroupingFactor, LweDimension, MessageModulusLog, PolynomialSize,
     UnsignedInteger,
 };
 use crate::shortint::EncryptionKeyChoice;
+use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct MultiBitTestKS32Params<Scalar: UnsignedInteger> {

--- a/tfhe/src/high_level_api/compact_list.rs
+++ b/tfhe/src/high_level_api/compact_list.rs
@@ -1,6 +1,5 @@
 use crate::backward_compatibility::compact_list::CompactCiphertextListVersions;
 use crate::conformance::ParameterSetConformant;
-use crate::core_crypto::commons::math::random::{Deserialize, Serialize};
 use crate::core_crypto::prelude::Numeric;
 use crate::high_level_api::global_state;
 use crate::high_level_api::keys::InternalServerKeyRef;
@@ -15,6 +14,7 @@ use crate::named::Named;
 use crate::prelude::CiphertextList;
 use crate::shortint::MessageModulus;
 use crate::HlExpandable;
+use serde::{Deserialize, Serialize};
 use tfhe_versionable::Versionize;
 #[cfg(feature = "zk-pok")]
 pub use zk::ProvenCompactCiphertextList;

--- a/tfhe/src/high_level_api/compressed_ciphertext_list.rs
+++ b/tfhe/src/high_level_api/compressed_ciphertext_list.rs
@@ -8,7 +8,6 @@ use super::keys::InternalServerKey;
 #[cfg(feature = "gpu")]
 use super::GpuIndex;
 use crate::backward_compatibility::compressed_ciphertext_list::CompressedCiphertextListVersions;
-use crate::core_crypto::commons::math::random::{Deserialize, Serialize};
 #[cfg(feature = "gpu")]
 use crate::core_crypto::gpu::CudaStreams;
 use crate::high_level_api::booleans::InnerBoolean;
@@ -38,6 +37,7 @@ use crate::shortint::Ciphertext;
 #[cfg(feature = "gpu")]
 use crate::shortint::{CarryModulus, MessageModulus};
 use crate::{Device, FheBool, FheInt, FheUint, Tag};
+use serde::{Deserialize, Serialize};
 
 impl<Id: FheUintId> HlCompressible for FheUint<Id> {
     fn compress_into(self, messages: &mut Vec<(ToBeCompressed, DataKind)>) {

--- a/tfhe/src/integer/ciphertext/compressed_noise_squashed_ciphertext_list.rs
+++ b/tfhe/src/integer/ciphertext/compressed_noise_squashed_ciphertext_list.rs
@@ -3,7 +3,6 @@ use super::{
     SquashedNoiseSignedRadixCiphertext,
 };
 use crate::conformance::ParameterSetConformant;
-use crate::core_crypto::commons::math::random::{Deserialize, Serialize};
 #[cfg(feature = "gpu")]
 use crate::core_crypto::gpu::lwe_packing_keyswitch_key::CudaLwePackingKeyswitchKey;
 #[cfg(feature = "gpu")]
@@ -26,6 +25,7 @@ use crate::shortint::list_compression::{
 };
 use crate::shortint::parameters::NoiseSquashingCompressionParameters;
 use crate::Versionize;
+use serde::{Deserialize, Serialize};
 use std::num::NonZero;
 
 use crate::integer::backward_compatibility::list_compression::NoiseSquashingCompressionKeyVersions;


### PR DESCRIPTION
XofSeed had its backward_compatibility in the csprng crate where it originates from. The Seed type did not, and core_crypto had to do extra work to have this backward compatibility.

So we move the backward compatibility into csprng for consistency.

closes https://github.com/zama-ai/tfhe-rs-internal/issues/1140

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3225)
<!-- Reviewable:end -->
