### PR TITLE
fix(gpu): more crypto param checks in cuda backend

### DIFF
--- a/tfhe/src/core_crypto/gpu/algorithms/glwe_sample_extraction.rs
+++ b/tfhe/src/core_crypto/gpu/algorithms/glwe_sample_extraction.rs
@@ -44,6 +44,12 @@ pub unsafe fn cuda_extract_lwe_samples_from_glwe_ciphertext_list_async<Scalar>(
         input_glwe_list.ciphertext_modulus(),
         output_lwe_list.ciphertext_modulus()
     );
+    assert!(
+        input_glwe_list
+            .ciphertext_modulus()
+            .is_compatible_with_native_modulus(),
+        "GPU sample extraction currently only supports power of 2 moduli"
+    );
     assert_eq!(
         streams.gpu_indexes[0],
         input_glwe_list.0.d_vec.gpu_index(0),

--- a/tfhe/src/core_crypto/gpu/algorithms/lwe_keyswitch.rs
+++ b/tfhe/src/core_crypto/gpu/algorithms/lwe_keyswitch.rs
@@ -79,6 +79,28 @@ pub unsafe fn cuda_keyswitch_lwe_ciphertext_async<Scalar, KSKScalar>(
         output_indexes.gpu_index(0).get(),
     );
 
+    // Modulus checks (mirroring keyswitch_lwe_ciphertext_native_mod_compatible)
+    assert_eq!(
+        lwe_keyswitch_key.ciphertext_modulus(),
+        output_lwe_ciphertext.ciphertext_modulus(),
+        "Mismatched CiphertextModulus. \
+        LweKeyswitchKey CiphertextModulus: {:?}, output LweCiphertext CiphertextModulus {:?}.",
+        lwe_keyswitch_key.ciphertext_modulus(),
+        output_lwe_ciphertext.ciphertext_modulus()
+    );
+    assert!(
+        output_lwe_ciphertext
+            .ciphertext_modulus()
+            .is_compatible_with_native_modulus(),
+        "GPU keyswitch currently only supports power of 2 moduli for the output ciphertext"
+    );
+    assert!(
+        input_lwe_ciphertext
+            .ciphertext_modulus()
+            .is_compatible_with_native_modulus(),
+        "GPU keyswitch currently only supports power of 2 moduli for the input ciphertext"
+    );
+
     let mut ks_tmp_buffer: *mut ffi::c_void = std::ptr::null_mut();
 
     let num_lwes_to_ks = min(

--- a/tfhe/src/core_crypto/gpu/algorithms/lwe_linear_algebra.rs
+++ b/tfhe/src/core_crypto/gpu/algorithms/lwe_linear_algebra.rs
@@ -114,6 +114,10 @@ pub unsafe fn cuda_lwe_ciphertext_add_assign_async<Scalar>(
         lhs.ciphertext_modulus(),
         rhs.ciphertext_modulus()
     );
+    assert!(
+        lhs.ciphertext_modulus().is_compatible_with_native_modulus(),
+        "GPU LWE ciphertext add currently only supports power of 2 moduli"
+    );
     assert_eq!(
         streams.gpu_indexes[0],
         lhs.0.d_vec.gpu_index(0),
@@ -213,6 +217,28 @@ pub unsafe fn cuda_lwe_ciphertext_plaintext_add_assign_async<Scalar>(
     let num_samples = lhs.lwe_ciphertext_count().0 as u32;
     let lwe_dimension = &lhs.lwe_dimension();
 
+    // GPU index checks
+    assert_eq!(
+        streams.gpu_indexes[0],
+        lhs.0.d_vec.gpu_index(0),
+        "GPU error: first stream is on GPU {}, first lhs pointer is on GPU {}",
+        streams.gpu_indexes[0].get(),
+        lhs.0.d_vec.gpu_index(0).get(),
+    );
+    assert_eq!(
+        streams.gpu_indexes[0],
+        rhs.gpu_index(0),
+        "GPU error: first stream is on GPU {}, first rhs pointer is on GPU {}",
+        streams.gpu_indexes[0].get(),
+        rhs.gpu_index(0).get(),
+    );
+
+    // Native modulus check
+    assert!(
+        lhs.ciphertext_modulus().is_compatible_with_native_modulus(),
+        "GPU LWE ciphertext plaintext add currently only supports power of 2 moduli"
+    );
+
     add_lwe_ciphertext_vector_plaintext_vector_assign_async(
         streams,
         &mut lhs.0.d_vec,
@@ -305,6 +331,19 @@ pub unsafe fn cuda_lwe_ciphertext_cleartext_mul_async<Scalar>(
         "Mismatched number of ciphertexts between input ({:?}) and output ({:?})",
         input.lwe_ciphertext_count(),
         output.lwe_ciphertext_count()
+    );
+    assert_eq!(
+        output.ciphertext_modulus(),
+        input.ciphertext_modulus(),
+        "Mismatched moduli between output ({:?}) and input ({:?}) LweCiphertext",
+        output.ciphertext_modulus(),
+        input.ciphertext_modulus()
+    );
+    assert!(
+        input
+            .ciphertext_modulus()
+            .is_compatible_with_native_modulus(),
+        "GPU LWE ciphertext cleartext mul currently only supports power of 2 moduli"
     );
     assert_eq!(
         streams.gpu_indexes[0],

--- a/tfhe/src/core_crypto/gpu/algorithms/lwe_packing_keyswitch.rs
+++ b/tfhe/src/core_crypto/gpu/algorithms/lwe_packing_keyswitch.rs
@@ -22,6 +22,60 @@ pub unsafe fn cuda_keyswitch_lwe_ciphertext_list_into_glwe_ciphertext_64_async<S
     let input_lwe_dimension = input_lwe_ciphertext_list.lwe_dimension();
     let output_glwe_dimension = output_glwe_ciphertext.glwe_dimension();
     let output_polynomial_size = output_glwe_ciphertext.polynomial_size();
+
+    // Parameter validation
+    assert!(
+        lwe_pksk.input_key_lwe_dimension() == input_lwe_dimension,
+        "Mismatched input LweDimension. \
+        LwePackingKeyswitchKey input LweDimension: {:?}, input LweCiphertext LweDimension {:?}.",
+        lwe_pksk.input_key_lwe_dimension(),
+        input_lwe_dimension
+    );
+    assert!(
+        lwe_pksk.output_glwe_size().to_glwe_dimension() == output_glwe_dimension,
+        "Mismatched output GlweDimension. \
+        LwePackingKeyswitchKey output GlweDimension: {:?}, \
+        output GlweCiphertext GlweDimension {:?}.",
+        lwe_pksk.output_glwe_size().to_glwe_dimension(),
+        output_glwe_dimension
+    );
+    assert!(
+        lwe_pksk.output_polynomial_size() == output_polynomial_size,
+        "Mismatched output PolynomialSize. \
+        LwePackingKeyswitchKey output PolynomialSize: {:?}, \
+        output GlweCiphertext PolynomialSize {:?}.",
+        lwe_pksk.output_polynomial_size(),
+        output_polynomial_size
+    );
+    assert!(
+        lwe_pksk.ciphertext_modulus() == input_lwe_ciphertext_list.ciphertext_modulus(),
+        "Mismatched CiphertextModulus. \
+        LwePackingKeyswitchKey CiphertextModulus: {:?}, input LweCiphertext CiphertextModulus {:?}.",
+        lwe_pksk.ciphertext_modulus(),
+        input_lwe_ciphertext_list.ciphertext_modulus()
+    );
+    assert!(
+        lwe_pksk.ciphertext_modulus() == output_glwe_ciphertext.ciphertext_modulus(),
+        "Mismatched CiphertextModulus. \
+        LwePackingKeyswitchKey CiphertextModulus: {:?}, \
+        output GlweCiphertext CiphertextModulus {:?}.",
+        lwe_pksk.ciphertext_modulus(),
+        output_glwe_ciphertext.ciphertext_modulus()
+    );
+    assert!(
+        input_lwe_ciphertext_list
+            .ciphertext_modulus()
+            .is_compatible_with_native_modulus(),
+        "GPU packing keyswitch currently only supports power of 2 moduli"
+    );
+    assert!(
+        input_lwe_ciphertext_list.lwe_ciphertext_count().0 <= output_polynomial_size.0,
+        "Input LWE ciphertext count ({}) exceeds output polynomial size ({})",
+        input_lwe_ciphertext_list.lwe_ciphertext_count().0,
+        output_polynomial_size.0
+    );
+
+    // GPU index checks
     assert_eq!(
         streams.gpu_indexes[0],
         input_lwe_ciphertext_list.0.d_vec.gpu_index(0),
@@ -93,6 +147,60 @@ pub unsafe fn cuda_keyswitch_lwe_ciphertext_list_into_glwe_ciphertext_128_async<
     let input_lwe_dimension = input_lwe_ciphertext_list.lwe_dimension();
     let output_glwe_dimension = output_glwe_ciphertext.glwe_dimension();
     let output_polynomial_size = output_glwe_ciphertext.polynomial_size();
+
+    // Parameter validation
+    assert!(
+        lwe_pksk.input_key_lwe_dimension() == input_lwe_dimension,
+        "Mismatched input LweDimension. \
+        LwePackingKeyswitchKey input LweDimension: {:?}, input LweCiphertext LweDimension {:?}.",
+        lwe_pksk.input_key_lwe_dimension(),
+        input_lwe_dimension
+    );
+    assert!(
+        lwe_pksk.output_glwe_size().to_glwe_dimension() == output_glwe_dimension,
+        "Mismatched output GlweDimension. \
+        LwePackingKeyswitchKey output GlweDimension: {:?}, \
+        output GlweCiphertext GlweDimension {:?}.",
+        lwe_pksk.output_glwe_size().to_glwe_dimension(),
+        output_glwe_dimension
+    );
+    assert!(
+        lwe_pksk.output_polynomial_size() == output_polynomial_size,
+        "Mismatched output PolynomialSize. \
+        LwePackingKeyswitchKey output PolynomialSize: {:?}, \
+        output GlweCiphertext PolynomialSize {:?}.",
+        lwe_pksk.output_polynomial_size(),
+        output_polynomial_size
+    );
+    assert!(
+        lwe_pksk.ciphertext_modulus() == input_lwe_ciphertext_list.ciphertext_modulus(),
+        "Mismatched CiphertextModulus. \
+        LwePackingKeyswitchKey CiphertextModulus: {:?}, input LweCiphertext CiphertextModulus {:?}.",
+        lwe_pksk.ciphertext_modulus(),
+        input_lwe_ciphertext_list.ciphertext_modulus()
+    );
+    assert!(
+        lwe_pksk.ciphertext_modulus() == output_glwe_ciphertext.ciphertext_modulus(),
+        "Mismatched CiphertextModulus. \
+        LwePackingKeyswitchKey CiphertextModulus: {:?}, \
+        output GlweCiphertext CiphertextModulus {:?}.",
+        lwe_pksk.ciphertext_modulus(),
+        output_glwe_ciphertext.ciphertext_modulus()
+    );
+    assert!(
+        input_lwe_ciphertext_list
+            .ciphertext_modulus()
+            .is_compatible_with_native_modulus(),
+        "GPU packing keyswitch currently only supports power of 2 moduli"
+    );
+    assert!(
+        input_lwe_ciphertext_list.lwe_ciphertext_count().0 <= output_polynomial_size.0,
+        "Input LWE ciphertext count ({}) exceeds output polynomial size ({})",
+        input_lwe_ciphertext_list.lwe_ciphertext_count().0,
+        output_polynomial_size.0
+    );
+
+    // GPU index checks
     assert_eq!(
         streams.gpu_indexes[0],
         input_lwe_ciphertext_list.0.d_vec.gpu_index(0),

--- a/tfhe/src/core_crypto/gpu/entities/lwe_keyswitch_key.rs
+++ b/tfhe/src/core_crypto/gpu/entities/lwe_keyswitch_key.rs
@@ -69,4 +69,8 @@ impl<T: UnsignedInteger> CudaLweKeyswitchKey<T> {
     pub(crate) fn decomposition_level_count(&self) -> DecompositionLevelCount {
         self.decomp_level_count
     }
+
+    pub(crate) fn ciphertext_modulus(&self) -> CiphertextModulus<T> {
+        self.ciphertext_modulus
+    }
 }


### PR DESCRIPTION
- Add missing parameter validation checks to GPU cryptographic operations to match the safety guarantees of their CPU counterparts                                 
  - Ensure GPU functions validate that ciphertext moduli are compatible with native modulus (power of 2), which is a requirement for the GPU kernels                 
  - Add consistency checks for modulus equality between inputs and outputs       