### PR TITLE
fix(gpu): valgrind error on leaks

### DIFF
--- a/backends/tfhe-cuda-backend/cuda/include/integer/integer_utilities.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer/integer_utilities.h
@@ -923,9 +923,9 @@ struct int_radix_lut_custom_input_output {
       }
       ks_tmp_buf_vec.clear();
     }
-    /*free(h_lut_indexes);
+    free(h_lut_indexes);
     free(degrees);
-    free(max_degrees);*/
+    free(max_degrees);
   }
 };
 

--- a/scripts/check_memory_errors.sh
+++ b/scripts/check_memory_errors.sh
@@ -55,7 +55,10 @@ if [[ "${RUN_VALGRIND}" == "1" ]]; then
         echo "Running valgrind on: $t"
 
         VALGRIND_EXIT=0
-        valgrind --leak-check=full --show-leak-kinds=definite \
+        valgrind --leak-check=full \
+            --show-leak-kinds=definite,indirect \
+            --errors-for-leak-kinds=definite,indirect \
+            --error-exitcode=1 \
             "$EXECUTABLE" -- "$t" 2>&1 | tee /tmp/valgrind_output.log || VALGRIND_EXIT=$?
 
         # Fail if the test crashed (non-zero exit code from valgrind)
@@ -65,7 +68,7 @@ if [[ "${RUN_VALGRIND}" == "1" ]]; then
         fi
 
         # Also fail if memory errors reference tfhe/cuda code (not system libraries)
-        if grep -E "definitely lost|Invalid read|Invalid write|Invalid free|Mismatched free" /tmp/valgrind_output.log | \
+        if grep -E "definitely lost|indirectly lost|Invalid read|Invalid write|Invalid free|Mismatched free" /tmp/valgrind_output.log | \
            grep -q "tfhe\|cuda"; then
             ERROR_MESSAGES+=("Memory error detected in tfhe/cuda code for test: $t")
             RESULT=1


### PR DESCRIPTION
Make the valgrind script fail when leaks are detected. The leaks are detected in the valgrind log. A summary of failing tests is shown at the end of script execution.