### PR TITLE
doc: add svg tables to zero-knowledge benchmarks

### DIFF
--- a/tfhe/docs/.gitbook/assets/cpu-zk-benchmark-fast-proof-slow-verify-latency-wasm.svg
+++ b/tfhe/docs/.gitbook/assets/cpu-zk-benchmark-fast-proof-slow-verify-latency-wasm.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" ?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 160" preserveAspectRatio="meet" width="100%" height="160">
+	<rect x="0" y="0" width="720" height="40" fill="black"/>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="6" y="20.0">Inputs (fast proof / slow verify)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="510.0" y="20.0">Proving</text>
+	<rect x="0" y="40" width="300" height="120" fill="#fbbc04"/>
+	<rect x="300" y="40" width="420" height="120" fill="#f3f3f3"/>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="60.0">1xFheUint64 (64 bits)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="60.0">1.66 s</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="100.0">4xFheUint64 (256 bits) </text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="100.0">1.66 s</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="140.0">32xFheUint64 (2048 bits)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="140.0">1.8 s</text>
+	<line stroke="white" stroke-width="2" x1="0" y1="0" x2="720" y2="0"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="40" x2="720" y2="40"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="80" x2="720" y2="80"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="120" x2="720" y2="120"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="0" x2="0" y2="160"/>
+	<line stroke="white" stroke-width="2" x1="300.0" y1="0" x2="300.0" y2="160"/>
+	<line stroke="white" stroke-width="2" x1="720.0" y1="0" x2="720.0" y2="160"/>
+</svg>

--- a/tfhe/docs/.gitbook/assets/cpu-zk-benchmark-fast-proof-slow-verify-latency.svg
+++ b/tfhe/docs/.gitbook/assets/cpu-zk-benchmark-fast-proof-slow-verify-latency.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" ?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 160" preserveAspectRatio="meet" width="100%" height="160">
+	<rect x="0" y="0" width="720" height="40" fill="black"/>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="6" y="20.0">Inputs (fast proof / slow verify)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="370.0" y="20.0">Proving</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="510.0" y="20.0">Verifying</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="650.0" y="20.0">Verify + expand</text>
+	<rect x="0" y="40" width="300" height="120" fill="#fbbc04"/>
+	<rect x="300" y="40" width="420" height="120" fill="#f3f3f3"/>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="60.0">1xFheUint64 (64 bits)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="370.0" y="60.0">276 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="60.0">44.0 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="650.0" y="60.0">66.0 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="100.0">4xFheUint64 (256 bits) </text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="370.0" y="100.0">277 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="100.0">44.6 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="650.0" y="100.0">70.3 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="140.0">32xFheUint64 (2048 bits)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="370.0" y="140.0">293 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="140.0">49.1 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="650.0" y="140.0">184 ms</text>
+	<line stroke="white" stroke-width="2" x1="0" y1="0" x2="720" y2="0"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="40" x2="720" y2="40"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="80" x2="720" y2="80"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="120" x2="720" y2="120"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="0" x2="0" y2="160"/>
+	<line stroke="white" stroke-width="2" x1="300.0" y1="0" x2="300.0" y2="160"/>
+	<line stroke="white" stroke-width="2" x1="440.0" y1="0" x2="440.0" y2="160"/>
+	<line stroke="white" stroke-width="2" x1="580.0" y1="0" x2="580.0" y2="160"/>
+	<line stroke="white" stroke-width="2" x1="720.0" y1="0" x2="720.0" y2="160"/>
+</svg>

--- a/tfhe/docs/.gitbook/assets/cpu-zk-benchmark-fast-proof-slow-verify-throughput.svg
+++ b/tfhe/docs/.gitbook/assets/cpu-zk-benchmark-fast-proof-slow-verify-throughput.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" ?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 160" preserveAspectRatio="meet" width="100%" height="160">
+	<rect x="0" y="0" width="720" height="40" fill="black"/>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="6" y="20.0">Inputs (fast proof / slow verify)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="370.0" y="20.0">Proving</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="510.0" y="20.0">Verifying</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="650.0" y="20.0">Verify + expand</text>
+	<rect x="0" y="40" width="300" height="120" fill="#fbbc04"/>
+	<rect x="300" y="40" width="420" height="120" fill="#f3f3f3"/>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="60.0">1xFheUint64 (64 bits)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="370.0" y="60.0">7.9 ops/s</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="60.0">274 ops/s</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="650.0" y="60.0">131 ops/s</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="100.0">4xFheUint64 (256 bits) </text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="370.0" y="100.0">7.9 ops/s</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="100.0">277 ops/s</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="650.0" y="100.0">51.3 ops/s</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="140.0">32xFheUint64 (2048 bits)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="370.0" y="140.0">7.73 ops/s</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="140.0">242 ops/s</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="650.0" y="140.0">8.62 ops/s</text>
+	<line stroke="white" stroke-width="2" x1="0" y1="0" x2="720" y2="0"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="40" x2="720" y2="40"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="80" x2="720" y2="80"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="120" x2="720" y2="120"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="0" x2="0" y2="160"/>
+	<line stroke="white" stroke-width="2" x1="300.0" y1="0" x2="300.0" y2="160"/>
+	<line stroke="white" stroke-width="2" x1="440.0" y1="0" x2="440.0" y2="160"/>
+	<line stroke="white" stroke-width="2" x1="580.0" y1="0" x2="580.0" y2="160"/>
+	<line stroke="white" stroke-width="2" x1="720.0" y1="0" x2="720.0" y2="160"/>
+</svg>

--- a/tfhe/docs/.gitbook/assets/cpu-zk-benchmark-slow-proof-fast-verify-latency-wasm.svg
+++ b/tfhe/docs/.gitbook/assets/cpu-zk-benchmark-slow-proof-fast-verify-latency-wasm.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" ?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 160" preserveAspectRatio="meet" width="100%" height="160">
+	<rect x="0" y="0" width="720" height="40" fill="black"/>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="6" y="20.0">Inputs (slow proof / fast verify)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="510.0" y="20.0">Proving</text>
+	<rect x="0" y="40" width="300" height="120" fill="#fbbc04"/>
+	<rect x="300" y="40" width="420" height="120" fill="#f3f3f3"/>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="60.0">1xFheUint64 (64 bits)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="60.0">1.94 s</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="100.0">4xFheUint64 (256 bits) </text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="100.0">1.96 s</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="140.0">32xFheUint64 (2048 bits)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="140.0">2.13 s</text>
+	<line stroke="white" stroke-width="2" x1="0" y1="0" x2="720" y2="0"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="40" x2="720" y2="40"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="80" x2="720" y2="80"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="120" x2="720" y2="120"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="0" x2="0" y2="160"/>
+	<line stroke="white" stroke-width="2" x1="300.0" y1="0" x2="300.0" y2="160"/>
+	<line stroke="white" stroke-width="2" x1="720.0" y1="0" x2="720.0" y2="160"/>
+</svg>

--- a/tfhe/docs/.gitbook/assets/cpu-zk-benchmark-slow-proof-fast-verify-latency.svg
+++ b/tfhe/docs/.gitbook/assets/cpu-zk-benchmark-slow-proof-fast-verify-latency.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" ?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 160" preserveAspectRatio="meet" width="100%" height="160">
+	<rect x="0" y="0" width="720" height="40" fill="black"/>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="6" y="20.0">Inputs (slow proof / fast verify)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="370.0" y="20.0">Proving</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="510.0" y="20.0">Verifying</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="650.0" y="20.0">Verify + expand</text>
+	<rect x="0" y="40" width="300" height="120" fill="#fbbc04"/>
+	<rect x="300" y="40" width="420" height="120" fill="#f3f3f3"/>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="60.0">1xFheUint64 (64 bits)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="370.0" y="60.0">292 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="60.0">31.4 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="650.0" y="60.0">51.8 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="100.0">4xFheUint64 (256 bits) </text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="370.0" y="100.0">294 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="100.0">31.6 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="650.0" y="100.0">56.2 ms</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="140.0">32xFheUint64 (2048 bits)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="370.0" y="140.0">317 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="140.0">33.8 ms</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="650.0" y="140.0">167 ms</text>
+	<line stroke="white" stroke-width="2" x1="0" y1="0" x2="720" y2="0"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="40" x2="720" y2="40"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="80" x2="720" y2="80"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="120" x2="720" y2="120"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="0" x2="0" y2="160"/>
+	<line stroke="white" stroke-width="2" x1="300.0" y1="0" x2="300.0" y2="160"/>
+	<line stroke="white" stroke-width="2" x1="440.0" y1="0" x2="440.0" y2="160"/>
+	<line stroke="white" stroke-width="2" x1="580.0" y1="0" x2="580.0" y2="160"/>
+	<line stroke="white" stroke-width="2" x1="720.0" y1="0" x2="720.0" y2="160"/>
+</svg>

--- a/tfhe/docs/.gitbook/assets/cpu-zk-benchmark-slow-proof-fast-verify-throughput.svg
+++ b/tfhe/docs/.gitbook/assets/cpu-zk-benchmark-slow-proof-fast-verify-throughput.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" ?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 160" preserveAspectRatio="meet" width="100%" height="160">
+	<rect x="0" y="0" width="720" height="40" fill="black"/>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="6" y="20.0">Inputs (slow proof / fast verify)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="370.0" y="20.0">Proving</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="510.0" y="20.0">Verifying</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="white" x="650.0" y="20.0">Verify + expand</text>
+	<rect x="0" y="40" width="300" height="120" fill="#fbbc04"/>
+	<rect x="300" y="40" width="420" height="120" fill="#f3f3f3"/>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="60.0">1xFheUint64 (64 bits)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="370.0" y="60.0">7.3 ops/s</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="60.0">988 ops/s</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="650.0" y="60.0">201 ops/s</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="100.0">4xFheUint64 (256 bits) </text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="370.0" y="100.0">7.23 ops/s</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="100.0">987 ops/s</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="650.0" y="100.0">59.5 ops/s</text>
+	<text dominant-baseline="middle" text-anchor="start" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="6" y="140.0">32xFheUint64 (2048 bits)</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="370.0" y="140.0">7.1 ops/s</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="510.0" y="140.0">1.11 k.ops/s</text>
+	<text dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" font-weight="normal" fill="black" x="650.0" y="140.0">8.85 ops/s</text>
+	<line stroke="white" stroke-width="2" x1="0" y1="0" x2="720" y2="0"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="40" x2="720" y2="40"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="80" x2="720" y2="80"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="120" x2="720" y2="120"/>
+	<line stroke="white" stroke-width="2" x1="0" y1="0" x2="0" y2="160"/>
+	<line stroke="white" stroke-width="2" x1="300.0" y1="0" x2="300.0" y2="160"/>
+	<line stroke="white" stroke-width="2" x1="440.0" y1="0" x2="440.0" y2="160"/>
+	<line stroke="white" stroke-width="2" x1="580.0" y1="0" x2="580.0" y2="160"/>
+	<line stroke="white" stroke-width="2" x1="720.0" y1="0" x2="720.0" y2="160"/>
+</svg>

--- a/tfhe/docs/getting-started/benchmarks/zk-proof-benchmarks.md
+++ b/tfhe/docs/getting-started/benchmarks/zk-proof-benchmarks.md
@@ -2,6 +2,42 @@
 
 This document details the performance benchmarks of [zero-knowledge proofs](../../fhe-computation/advanced-features/zk-pok.md) for [compact public key encryption](../../fhe-computation/advanced-features/public-key.md) using **TFHE-rs**.
 
-Benchmarks for the zero-knowledge proofs have been run on a `m6i.4xlarge` with 16 cores to simulate a usual client configuration. The verifications are done on an `hpc7a.96xlarge` AWS instance to mimic a powerful server.
+## Server-side computation
 
-{% embed url="https://docs.google.com/spreadsheets/d/1x12I7Tkdx63Q6sNllygg6urSd5KC1sj1wj4L9jWiET4/edit?usp=sharing" %}
+{% hint style="info" %}
+Benchmarks were launched on an `AWS hpc7a.96xlarge` instance equipped with a 96-core `AMD EPYC 9R14 CPU @ 2.60GHz` and 740GB of RAM.
+{% endhint %}
+
+Proving and verification are done with tfhe-rs native executable on a powerful server.
+
+### Fast proof / slow verify latency
+
+![](../../.gitbook/assets/cpu-zk-benchmark-fast-proof-slow-verify-latency.svg)
+
+### Fast proof / slow verify throughput
+
+![](../../.gitbook/assets/cpu-zk-benchmark-fast-proof-slow-verify-throughput.svg)
+
+### Slow proof / fast verify latency
+
+![](../../.gitbook/assets/cpu-zk-benchmark-slow-proof-fast-verify-latency.svg)
+
+### Slow proof / fast verify throughput
+
+![](../../.gitbook/assets/cpu-zk-benchmark-slow-proof-fast-verify-throughput.svg)
+
+## Client-side computation
+
+{% hint style="info" %}
+Benchmarks were launched on an `AWS m6i.4xlarge` instance equipped with a 16-core from a hypervisored `Intel Xeon Platinum 8375C CPU @ 2.90GHz` and 64GB of RAM.
+{% endhint %}
+
+Proving is done on a 16-core machine using WASM executable run on a Chrome browser to simulate a typical client configuration.
+
+### Fast proof / slow verify latency
+
+![](../../.gitbook/assets/cpu-zk-benchmark-fast-proof-slow-verify-latency-wasm.svg)
+
+### Slow proof / fast verify latency
+
+![](../../.gitbook/assets/cpu-zk-benchmark-slow-proof-fast-verify-latency-wasm.svg)


### PR DESCRIPTION
This removes the embedded GSheet.
These SVGs display more operations and inputs that reflect real-use cases.
Throughput is available only for server-side computation as it's meaningless to perform multiple proof in parallel on the client-side.
