### PR TITLE
feat(gpu): create different threshold for multi-gpu pbs128

### DIFF
--- a/backends/tfhe-cuda-backend/cuda/include/helper_multi_gpu.h
+++ b/backends/tfhe-cuda-backend/cuda/include/helper_multi_gpu.h
@@ -10,7 +10,7 @@ extern std::mutex m;
 extern bool p2p_enabled;
 extern const int THRESHOLD_MULTI_GPU_WITH_MULTI_BIT_PARAMS;
 extern const int THRESHOLD_MULTI_GPU_WITH_CLASSICAL_PARAMS;
-
+extern const int THRESHOLD_MULTI_GPU_WITH_CLASSICAL_PARAMS_U128;
 // Define a variant type that can be either a vector or a single pointer
 template <typename Torus>
 using LweArrayVariant = std::variant<std::vector<Torus *>, Torus *>;
@@ -38,6 +38,8 @@ get_variant_element(const std::variant<std::vector<Torus>, Torus> &variant,
 
 uint32_t get_active_gpu_count(uint32_t num_inputs, uint32_t gpu_count,
                               PBS_TYPE pbs_type);
+uint32_t get_active_gpu_count_u128(uint32_t num_inputs, uint32_t gpu_count,
+                                   PBS_TYPE pbs_type);
 
 int get_num_inputs_on_gpu(int total_num_inputs, int gpu_index, int gpu_count);
 
@@ -76,7 +78,15 @@ public:
         _streams, _gpu_indexes,
         get_active_gpu_count(num_radix_blocks, _gpu_count, pbs_type));
   }
-
+  // Returns a subset of this set as an active subset for pbs128. An active
+  // subset is one that is temporarily used to perform some computation. For
+  // pbs128, the threshold is different, because the original threshold was
+  // designed for 2_2 params.
+  CudaStreams active_gpu_subset_u128(int num_radix_blocks, PBS_TYPE pbs_type) {
+    return CudaStreams(
+        _streams, _gpu_indexes,
+        get_active_gpu_count_u128(num_radix_blocks, _gpu_count, pbs_type));
+  }
   // Returns a CudaStreams struct containing only the ith stream
   CudaStreams get_ith(int i) const {
     return CudaStreams(&_streams[i], &_gpu_indexes[i], 1);

--- a/backends/tfhe-cuda-backend/cuda/src/integer/integer.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/integer.cuh
@@ -2337,7 +2337,7 @@ integer_radix_apply_noise_squashing(CudaStreams streams,
 
   // Since the radix ciphertexts are packed, we have to use the num_radix_blocks
   // from the output ct
-  auto active_streams = streams.active_gpu_subset(
+  auto active_streams = streams.active_gpu_subset_u128(
       lwe_array_out->num_radix_blocks, params.pbs_type);
   if (active_streams.count() == 1) {
     execute_keyswitch_async<InputTorus>(

--- a/backends/tfhe-cuda-backend/cuda/src/utils/helper_multi_gpu.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/utils/helper_multi_gpu.cu
@@ -7,12 +7,27 @@ std::mutex m;
 bool p2p_enabled = false;
 const int THRESHOLD_MULTI_GPU_WITH_MULTI_BIT_PARAMS = 12;
 const int THRESHOLD_MULTI_GPU_WITH_CLASSICAL_PARAMS = 68;
+const int THRESHOLD_MULTI_GPU_WITH_CLASSICAL_PARAMS_U128 = 12;
 
 uint32_t get_active_gpu_count(uint32_t num_inputs, uint32_t gpu_count,
                               PBS_TYPE pbs_type) {
   int threshold = (pbs_type == MULTI_BIT)
                       ? THRESHOLD_MULTI_GPU_WITH_MULTI_BIT_PARAMS
                       : THRESHOLD_MULTI_GPU_WITH_CLASSICAL_PARAMS;
+  uint32_t ceil_div_inputs =
+      std::max((uint32_t)1, (num_inputs + threshold - 1) / threshold);
+  uint32_t active_gpu_count = std::min(ceil_div_inputs, gpu_count);
+  return active_gpu_count;
+}
+
+// For pbs 128 we need to use the smaller threshold in both multi bit and
+// classical
+uint32_t get_active_gpu_count_u128(uint32_t num_inputs, uint32_t gpu_count,
+                                   PBS_TYPE pbs_type) {
+  int threshold = (pbs_type == MULTI_BIT)
+                      ? THRESHOLD_MULTI_GPU_WITH_MULTI_BIT_PARAMS
+                      : THRESHOLD_MULTI_GPU_WITH_CLASSICAL_PARAMS_U128;
+
   uint32_t ceil_div_inputs =
       std::max((uint32_t)1, (num_inputs + threshold - 1) / threshold);
   uint32_t active_gpu_count = std::min(ceil_div_inputs, gpu_count);

--- a/backends/tfhe-cuda-backend/cuda/src/utils/helper_multi_gpu.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/utils/helper_multi_gpu.cuh
@@ -62,10 +62,12 @@ void multi_gpu_alloc_lwe_async(CudaStreams streams, std::vector<Torus *> &dest,
                                PBS_TYPE pbs_type, bool allocate_gpu_memory) {
   PANIC_IF_FALSE(dest.empty(),
                  "Cuda error: Requested multi-GPU vector is already allocated");
-
+  int classical_threshold = sizeof(Torus) == 16
+                                ? THRESHOLD_MULTI_GPU_WITH_CLASSICAL_PARAMS_U128
+                                : THRESHOLD_MULTI_GPU_WITH_CLASSICAL_PARAMS;
   int threshold = (pbs_type == MULTI_BIT)
                       ? THRESHOLD_MULTI_GPU_WITH_MULTI_BIT_PARAMS
-                      : THRESHOLD_MULTI_GPU_WITH_CLASSICAL_PARAMS;
+                      : classical_threshold;
 
   dest.resize(streams.count());
   for (uint i = 0; i < streams.count(); i++) {
@@ -100,10 +102,12 @@ void multi_gpu_alloc_lwe_many_lut_output_async(
 
   PANIC_IF_FALSE(dest.empty(),
                  "Cuda error: Requested multi-GPU vector is already allocated");
-
+  int classical_threshold = sizeof(Torus) == 16
+                                ? THRESHOLD_MULTI_GPU_WITH_CLASSICAL_PARAMS_U128
+                                : THRESHOLD_MULTI_GPU_WITH_CLASSICAL_PARAMS;
   int threshold = (pbs_type == MULTI_BIT)
                       ? THRESHOLD_MULTI_GPU_WITH_MULTI_BIT_PARAMS
-                      : THRESHOLD_MULTI_GPU_WITH_CLASSICAL_PARAMS;
+                      : classical_threshold;
 
   dest.resize(streams.count());
   for (uint i = 0; i < streams.count(); i++) {


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description
The idea is to have a different threshold for classical pbs 128, considering that its params are totally different than 2_2 and we always call that one in the same configuration.

The classical pbs128+decomp after this change is restored to the 80ms range.
### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
