### PR TITLE
chore: move shortint expanded types into shortint mod

### DIFF
--- a/tfhe/src/high_level_api/keys/expanded.rs
+++ b/tfhe/src/high_level_api/keys/expanded.rs
@@ -9,234 +9,42 @@ use crate::core_crypto::prelude::*;
 use crate::integer::ciphertext::NoiseSquashingCompressionKey;
 use crate::integer::compression_keys::CompressionKey;
 
-use crate::shortint::atomic_pattern::compressed::{
-    CompressedAtomicPatternServerKey, CompressedKS32AtomicPatternServerKey,
-    CompressedStandardAtomicPatternServerKey,
-};
 use crate::shortint::noise_squashing::atomic_pattern::compressed::CompressedAtomicPatternNoiseSquashingKey;
-use crate::shortint::noise_squashing::{
-    CompressedShortint128BootstrappingKey, GenericNoiseSquashingKey, Shortint128BootstrappingKey,
-};
-use crate::shortint::server_key::{
-    GenericServerKey, ModulusSwitchConfiguration, ShortintBootstrappingKey,
-    ShortintCompressedBootstrappingKey,
-};
 
 use crate::high_level_api::keys::cpk_re_randomization::ReRandomizationKeySwitchingKey;
 use crate::integer::compression_keys::CompressedDecompressionKey;
 use crate::integer::noise_squashing::CompressedNoiseSquashingKey;
 
-/// Bootstrapping Key with elements in the standard (i.e not fourier) domain
-pub(crate) enum ShortintExpandedBootstrappingKey<Scalar, ModSwitchScalar>
-where
-    Scalar: UnsignedInteger,
-    ModSwitchScalar: UnsignedInteger,
-{
-    Classic {
-        bsk: LweBootstrapKey<Vec<Scalar>>,
-        modulus_switch_noise_reduction_key: ModulusSwitchConfiguration<ModSwitchScalar>,
-    },
-    MultiBit {
-        bsk: LweMultiBitBootstrapKey<Vec<Scalar>>,
-        thread_count: ThreadCount,
-        deterministic_execution: bool,
-    },
-}
+use crate::shortint::atomic_pattern::expanded::{
+    ExpandedAtomicPatternServerKey, ExpandedKS32AtomicPatternServerKey,
+    ExpandedStandardAtomicPatternServerKey,
+};
+pub use crate::shortint::noise_squashing::atomic_pattern::ExpandedAtomicPatternNoiseSquashingKey;
+pub use crate::shortint::noise_squashing::ExpandedNoiseSquashingKey;
+pub use crate::shortint::server_key::expanded::{
+    ShortintExpandedBootstrappingKey, ShortintExpandedServerKey,
+};
 
-#[cfg(feature = "gpu")]
-impl<Scalar, ModSwitchScalar> ShortintExpandedBootstrappingKey<Scalar, ModSwitchScalar>
-where
-    Scalar: UnsignedInteger,
-    ModSwitchScalar: UnsignedInteger,
-{
-    pub(crate) fn glwe_dimension(&self) -> GlweDimension {
-        match self {
-            Self::Classic { bsk, .. } => bsk.glwe_size().to_glwe_dimension(),
-            Self::MultiBit { bsk, .. } => bsk.glwe_size().to_glwe_dimension(),
-        }
-    }
-
-    pub(crate) fn polynomial_size(&self) -> PolynomialSize {
-        match self {
-            Self::Classic { bsk, .. } => bsk.polynomial_size(),
-            Self::MultiBit { bsk, .. } => bsk.polynomial_size(),
-        }
-    }
-}
-
-impl<ModSwitchScalar> ShortintExpandedBootstrappingKey<u64, ModSwitchScalar>
-where
-    ModSwitchScalar: UnsignedInteger,
-{
-    pub(in crate::high_level_api) fn into_fourier(
-        self,
-    ) -> ShortintBootstrappingKey<ModSwitchScalar> {
-        match self {
-            Self::Classic {
-                bsk,
-                modulus_switch_noise_reduction_key,
-            } => {
-                let mut fourier_bsk = FourierLweBootstrapKey::new(
-                    bsk.input_lwe_dimension(),
-                    bsk.glwe_size(),
-                    bsk.polynomial_size(),
-                    bsk.decomposition_base_log(),
-                    bsk.decomposition_level_count(),
-                );
-                par_convert_standard_lwe_bootstrap_key_to_fourier(&bsk, &mut fourier_bsk);
-                ShortintBootstrappingKey::Classic {
-                    bsk: fourier_bsk,
-                    modulus_switch_noise_reduction_key,
-                }
-            }
-            Self::MultiBit {
-                bsk,
-                thread_count,
-                deterministic_execution,
-            } => {
-                let mut fourier_bsk = FourierLweMultiBitBootstrapKeyOwned::new(
-                    bsk.input_lwe_dimension(),
-                    bsk.glwe_size(),
-                    bsk.polynomial_size(),
-                    bsk.decomposition_base_log(),
-                    bsk.decomposition_level_count(),
-                    bsk.grouping_factor(),
-                );
-                par_convert_standard_lwe_multi_bit_bootstrap_key_to_fourier(&bsk, &mut fourier_bsk);
-                ShortintBootstrappingKey::MultiBit {
-                    fourier_bsk,
-                    thread_count,
-                    deterministic_execution,
-                }
-            }
-        }
-    }
-}
-
-impl<ModSwitchScalar> ShortintExpandedBootstrappingKey<u128, ModSwitchScalar>
-where
-    ModSwitchScalar: UnsignedInteger,
-{
-    pub(in crate::high_level_api) fn into_fourier(
-        self,
-    ) -> Shortint128BootstrappingKey<ModSwitchScalar> {
-        match self {
-            Self::Classic {
-                bsk,
-                modulus_switch_noise_reduction_key,
-            } => {
-                let mut fourier_bsk = Fourier128LweBootstrapKeyOwned::new(
-                    bsk.input_lwe_dimension(),
-                    bsk.glwe_size(),
-                    bsk.polynomial_size(),
-                    bsk.decomposition_base_log(),
-                    bsk.decomposition_level_count(),
-                );
-                par_convert_standard_lwe_bootstrap_key_to_fourier_128(&bsk, &mut fourier_bsk);
-                Shortint128BootstrappingKey::Classic {
-                    bsk: fourier_bsk,
-                    modulus_switch_noise_reduction_key,
-                }
-            }
-            Self::MultiBit {
-                bsk,
-                thread_count,
-                deterministic_execution,
-            } => {
-                let mut fourier_bsk = Fourier128LweMultiBitBootstrapKey::new(
-                    bsk.input_lwe_dimension(),
-                    bsk.glwe_size(),
-                    bsk.polynomial_size(),
-                    bsk.decomposition_base_log(),
-                    bsk.decomposition_level_count(),
-                    bsk.grouping_factor(),
-                );
-
-                par_convert_standard_lwe_multi_bit_bootstrap_key_to_fourier_128(
-                    &bsk,
-                    &mut fourier_bsk,
-                );
-
-                Shortint128BootstrappingKey::MultiBit {
-                    bsk: fourier_bsk,
-                    thread_count,
-                    deterministic_execution,
-                }
-            }
-        }
-    }
-}
-
-pub(crate) struct ExpandedDecompressionKey {
+pub struct ExpandedDecompressionKey {
     pub bsk: ShortintExpandedBootstrappingKey<u64, u64>,
     pub lwe_per_glwe: LweCiphertextCount,
 }
 
-pub(crate) struct ExpandedStandardAtomicPatternServerKey {
-    pub key_switching_key: LweKeyswitchKeyOwned<u64>,
-    pub bootstrapping_key: ShortintExpandedBootstrappingKey<u64, u64>,
-    pub pbs_order: PBSOrder,
-}
-
-pub(crate) struct ExpandedKS32AtomicPatternServerKey {
-    pub key_switching_key: LweKeyswitchKeyOwned<u32>,
-    pub bootstrapping_key: ShortintExpandedBootstrappingKey<u64, u32>,
-    pub ciphertext_modulus: CiphertextModulus<u64>,
-}
-
-pub(crate) enum ExpandedAtomicPatternServerKey {
-    Standard(ExpandedStandardAtomicPatternServerKey),
-    KeySwitch32(ExpandedKS32AtomicPatternServerKey),
-}
-
-pub(crate) type ShortintExpandedServerKey = GenericServerKey<ExpandedAtomicPatternServerKey>;
-
-#[cfg(feature = "gpu")]
-impl ShortintExpandedServerKey {
-    pub(crate) fn glwe_dimension(&self) -> GlweDimension {
-        match &self.atomic_pattern {
-            ExpandedAtomicPatternServerKey::Standard(std) => std.bootstrapping_key.glwe_dimension(),
-            ExpandedAtomicPatternServerKey::KeySwitch32(ks32) => {
-                ks32.bootstrapping_key.glwe_dimension()
-            }
-        }
-    }
-
-    pub(crate) fn polynomial_size(&self) -> PolynomialSize {
-        match &self.atomic_pattern {
-            ExpandedAtomicPatternServerKey::Standard(std) => {
-                std.bootstrapping_key.polynomial_size()
-            }
-            ExpandedAtomicPatternServerKey::KeySwitch32(ks32) => {
-                ks32.bootstrapping_key.polynomial_size()
-            }
-        }
-    }
-}
-
-pub(crate) enum ExpandedAtomicPatternNoiseSquashingKey {
-    Standard(ShortintExpandedBootstrappingKey<u128, u64>),
-    KeySwitch32(ShortintExpandedBootstrappingKey<u128, u32>),
-}
-
-pub(crate) type ExpandedNoiseSquashingKey =
-    GenericNoiseSquashingKey<ExpandedAtomicPatternNoiseSquashingKey>;
-
-pub(crate) struct IntegerExpandedServerKey {
-    pub(crate) compute_key: ShortintExpandedServerKey,
-    pub(crate) cpk_key_switching_key_material:
+pub struct IntegerExpandedServerKey {
+    pub compute_key: ShortintExpandedServerKey,
+    pub cpk_key_switching_key_material:
         Option<crate::integer::key_switching_key::KeySwitchingKeyMaterial>,
-    pub(crate) compression_key: Option<CompressionKey>,
-    pub(crate) decompression_key: Option<ExpandedDecompressionKey>,
-    pub(crate) noise_squashing_key: Option<ExpandedNoiseSquashingKey>,
-    pub(crate) noise_squashing_compression_key: Option<NoiseSquashingCompressionKey>,
-    pub(crate) cpk_re_randomization_key_switching_key_material: Option<
+    pub compression_key: Option<CompressionKey>,
+    pub decompression_key: Option<ExpandedDecompressionKey>,
+    pub noise_squashing_key: Option<ExpandedNoiseSquashingKey>,
+    pub noise_squashing_compression_key: Option<NoiseSquashingCompressionKey>,
+    pub cpk_re_randomization_key_switching_key_material: Option<
         ReRandomizationKeySwitchingKey<crate::integer::key_switching_key::KeySwitchingKeyMaterial>,
     >,
 }
 
 impl IntegerExpandedServerKey {
-    pub(crate) fn convert_to_cpu(self) -> crate::high_level_api::keys::IntegerServerKey {
+    pub fn convert_to_cpu(self) -> crate::high_level_api::keys::IntegerServerKey {
         use crate::high_level_api::keys::IntegerServerKey;
         use crate::shortint::atomic_pattern::{
             AtomicPatternServerKey, KS32AtomicPatternServerKey, StandardAtomicPatternServerKey,
@@ -342,7 +150,7 @@ impl IntegerExpandedServerKey {
 
 #[cfg(feature = "gpu")]
 impl IntegerExpandedServerKey {
-    pub(crate) fn convert_to_gpu(
+    pub fn convert_to_gpu(
         &self,
         streams: &crate::core_crypto::gpu::CudaStreams,
     ) -> crate::Result<crate::high_level_api::keys::inner::IntegerCudaServerKey> {
@@ -430,140 +238,9 @@ impl IntegerExpandedServerKey {
     }
 }
 
-impl<ModSwitchScalar> ShortintCompressedBootstrappingKey<ModSwitchScalar>
-where
-    ModSwitchScalar: UnsignedTorus,
-{
-    /// Expand the compressed bootstrapping key to the standard (non-Fourier) domain.
-    pub(crate) fn expand(&self) -> ShortintExpandedBootstrappingKey<u64, ModSwitchScalar> {
-        match self {
-            Self::Classic {
-                bsk,
-                modulus_switch_noise_reduction_key,
-            } => {
-                let core_bsk = bsk.as_view().par_decompress_into_lwe_bootstrap_key();
-                let modulus_switch_noise_reduction_key =
-                    modulus_switch_noise_reduction_key.decompress();
-                ShortintExpandedBootstrappingKey::Classic {
-                    bsk: core_bsk,
-                    modulus_switch_noise_reduction_key,
-                }
-            }
-            Self::MultiBit {
-                seeded_bsk,
-                deterministic_execution,
-            } => {
-                let core_bsk = seeded_bsk
-                    .as_view()
-                    .par_decompress_into_lwe_multi_bit_bootstrap_key();
-
-                let thread_count =
-                    crate::shortint::engine::ShortintEngine::get_thread_count_for_multi_bit_pbs(
-                        core_bsk.input_lwe_dimension(),
-                        core_bsk.glwe_size().to_glwe_dimension(),
-                        core_bsk.polynomial_size(),
-                        core_bsk.decomposition_base_log(),
-                        core_bsk.decomposition_level_count(),
-                        core_bsk.grouping_factor(),
-                    );
-
-                ShortintExpandedBootstrappingKey::MultiBit {
-                    bsk: core_bsk,
-                    thread_count,
-                    deterministic_execution: *deterministic_execution,
-                }
-            }
-        }
-    }
-}
-
-impl<ModSwitchScalar> CompressedShortint128BootstrappingKey<ModSwitchScalar>
-where
-    ModSwitchScalar: UnsignedTorus,
-{
-    /// Expand the compressed 128-bit bootstrapping key to the standard (non-Fourier) domain.
-    pub(crate) fn expand(&self) -> ShortintExpandedBootstrappingKey<u128, ModSwitchScalar> {
-        match self {
-            Self::Classic {
-                bsk,
-                modulus_switch_noise_reduction_key,
-            } => {
-                let core_bsk = bsk.as_view().par_decompress_into_lwe_bootstrap_key();
-                let modulus_switch_noise_reduction_key =
-                    modulus_switch_noise_reduction_key.decompress();
-                ShortintExpandedBootstrappingKey::Classic {
-                    bsk: core_bsk,
-                    modulus_switch_noise_reduction_key,
-                }
-            }
-            Self::MultiBit {
-                bsk,
-                thread_count,
-                deterministic_execution,
-            } => {
-                let core_bsk = bsk
-                    .as_view()
-                    .par_decompress_into_lwe_multi_bit_bootstrap_key();
-
-                ShortintExpandedBootstrappingKey::MultiBit {
-                    bsk: core_bsk,
-                    thread_count: *thread_count,
-                    deterministic_execution: *deterministic_execution,
-                }
-            }
-        }
-    }
-}
-
-impl CompressedStandardAtomicPatternServerKey {
-    /// Expand to standard domain without Fourier conversion.
-    pub(crate) fn expand(&self) -> ExpandedStandardAtomicPatternServerKey {
-        let key_switching_key = self
-            .key_switching_key()
-            .as_view()
-            .par_decompress_into_lwe_keyswitch_key();
-        let bootstrapping_key = self.bootstrapping_key().expand();
-
-        ExpandedStandardAtomicPatternServerKey {
-            key_switching_key,
-            bootstrapping_key,
-            pbs_order: self.pbs_order(),
-        }
-    }
-}
-
-impl CompressedKS32AtomicPatternServerKey {
-    /// Expand to standard domain without Fourier conversion.
-    pub(crate) fn expand(&self) -> ExpandedKS32AtomicPatternServerKey {
-        let ciphertext_modulus = self.bootstrapping_key().ciphertext_modulus();
-
-        let key_switching_key = self
-            .key_switching_key()
-            .as_view()
-            .par_decompress_into_lwe_keyswitch_key();
-        let bootstrapping_key = self.bootstrapping_key().expand();
-
-        ExpandedKS32AtomicPatternServerKey {
-            key_switching_key,
-            bootstrapping_key,
-            ciphertext_modulus,
-        }
-    }
-}
-
-impl CompressedAtomicPatternServerKey {
-    /// Expand to standard domain without Fourier conversion.
-    pub(crate) fn expand(&self) -> ExpandedAtomicPatternServerKey {
-        match self {
-            Self::Standard(std) => ExpandedAtomicPatternServerKey::Standard(std.expand()),
-            Self::KeySwitch32(ks32) => ExpandedAtomicPatternServerKey::KeySwitch32(ks32.expand()),
-        }
-    }
-}
-
 impl CompressedDecompressionKey {
     /// Expand to standard domain without Fourier conversion.
-    pub(crate) fn expand(&self) -> ExpandedDecompressionKey {
+    pub fn expand(&self) -> ExpandedDecompressionKey {
         ExpandedDecompressionKey {
             bsk: self.key.bsk.expand(),
             lwe_per_glwe: self.key.lwe_per_glwe,
@@ -573,7 +250,7 @@ impl CompressedDecompressionKey {
 
 impl CompressedNoiseSquashingKey {
     /// Expand to standard domain without Fourier conversion.
-    pub(crate) fn expand(&self) -> ExpandedNoiseSquashingKey {
+    pub fn expand(&self) -> ExpandedNoiseSquashingKey {
         let expanded_ap = match self.key.atomic_pattern() {
             CompressedAtomicPatternNoiseSquashingKey::Standard(compressed_std) => {
                 ExpandedAtomicPatternNoiseSquashingKey::Standard(

--- a/tfhe/src/high_level_api/xof_key_set/internal.rs
+++ b/tfhe/src/high_level_api/xof_key_set/internal.rs
@@ -36,12 +36,14 @@ use crate::{
 
 use crate::core_crypto::commons::ciphertext_modulus::CiphertextModulus as CoreCiphertextModulus;
 use crate::high_level_api::keys::expanded::{
-    ExpandedAtomicPatternNoiseSquashingKey, ExpandedAtomicPatternServerKey,
-    ExpandedDecompressionKey, ExpandedKS32AtomicPatternServerKey, ExpandedNoiseSquashingKey,
-    ExpandedStandardAtomicPatternServerKey, IntegerExpandedServerKey,
-    ShortintExpandedBootstrappingKey, ShortintExpandedServerKey,
+    ExpandedAtomicPatternNoiseSquashingKey, ExpandedDecompressionKey, ExpandedNoiseSquashingKey,
+    IntegerExpandedServerKey, ShortintExpandedBootstrappingKey, ShortintExpandedServerKey,
 };
 use crate::high_level_api::keys::{CompactPrivateKey, ReRandomizationKeyGenerationInfo};
+use crate::shortint::atomic_pattern::expanded::{
+    ExpandedAtomicPatternServerKey, ExpandedKS32AtomicPatternServerKey,
+    ExpandedStandardAtomicPatternServerKey,
+};
 use crate::shortint::key_switching_key::KeySwitchingKeyDestinationAtomicPattern;
 use crate::shortint::noise_squashing::atomic_pattern::compressed::standard::CompressedStandardAtomicPatternNoiseSquashingKey;
 use crate::shortint::parameters::ModulusSwitchNoiseReductionParams;

--- a/tfhe/src/integer/gpu/server_key/mod.rs
+++ b/tfhe/src/integer/gpu/server_key/mod.rs
@@ -10,13 +10,15 @@ use crate::core_crypto::prelude::{
     LweMultiBitBootstrapKeyOwned,
 };
 use crate::high_level_api::keys::expanded::{
-    ExpandedAtomicPatternServerKey, ExpandedKS32AtomicPatternServerKey,
-    ExpandedStandardAtomicPatternServerKey, ShortintExpandedBootstrappingKey,
-    ShortintExpandedServerKey,
+    ShortintExpandedBootstrappingKey, ShortintExpandedServerKey,
 };
 use crate::integer::gpu::UnsignedInteger;
 use crate::integer::server_key::num_bits_to_represent_unsigned_value;
 use crate::integer::ClientKey;
+use crate::shortint::atomic_pattern::expanded::{
+    ExpandedAtomicPatternServerKey, ExpandedKS32AtomicPatternServerKey,
+    ExpandedStandardAtomicPatternServerKey,
+};
 use crate::shortint::ciphertext::{MaxDegree, MaxNoiseLevel};
 use crate::shortint::client_key::atomic_pattern::AtomicPatternClientKey;
 use crate::shortint::engine::ShortintEngine;

--- a/tfhe/src/shortint/atomic_pattern/compressed/mod.rs
+++ b/tfhe/src/shortint/atomic_pattern/compressed/mod.rs
@@ -3,6 +3,7 @@ pub mod standard;
 pub use ks32::*;
 pub use standard::*;
 
+use super::expanded::ExpandedAtomicPatternServerKey;
 use super::AtomicPatternServerKey;
 use crate::conformance::ParameterSetConformant;
 use crate::shortint::backward_compatibility::atomic_pattern::CompressedAtomicPatternServerKeyVersions;
@@ -73,6 +74,14 @@ impl CompressedAtomicPatternServerKey {
                     compressed_ks32_atomic_pattern_server_key.decompress(),
                 )
             }
+        }
+    }
+
+    /// Expand to standard domain without Fourier conversion.
+    pub fn expand(&self) -> ExpandedAtomicPatternServerKey {
+        match self {
+            Self::Standard(std) => ExpandedAtomicPatternServerKey::Standard(std.expand()),
+            Self::KeySwitch32(ks32) => ExpandedAtomicPatternServerKey::KeySwitch32(ks32.expand()),
         }
     }
 }

--- a/tfhe/src/shortint/atomic_pattern/compressed/standard.rs
+++ b/tfhe/src/shortint/atomic_pattern/compressed/standard.rs
@@ -1,6 +1,7 @@
 use crate::conformance::ParameterSetConformant;
 use crate::core_crypto::algorithms::lwe_keyswitch_key_generation::allocate_and_generate_new_seeded_lwe_keyswitch_key;
 use crate::core_crypto::entities::seeded_lwe_keyswitch_key::SeededLweKeyswitchKeyOwned;
+use crate::shortint::atomic_pattern::expanded::ExpandedStandardAtomicPatternServerKey;
 use crate::shortint::atomic_pattern::standard::StandardAtomicPatternServerKey;
 use crate::shortint::backward_compatibility::atomic_pattern::CompressedStandardAtomicPatternServerKeyVersions;
 use crate::shortint::client_key::atomic_pattern::StandardAtomicPatternClientKey;
@@ -126,6 +127,21 @@ impl CompressedStandardAtomicPatternServerKey {
 
     pub fn ciphertext_modulus(&self) -> CiphertextModulus {
         self.bootstrapping_key.ciphertext_modulus()
+    }
+
+    /// Expand to standard domain without Fourier conversion.
+    pub fn expand(&self) -> ExpandedStandardAtomicPatternServerKey {
+        let key_switching_key = self
+            .key_switching_key()
+            .as_view()
+            .par_decompress_into_lwe_keyswitch_key();
+        let bootstrapping_key = self.bootstrapping_key().expand();
+
+        ExpandedStandardAtomicPatternServerKey {
+            key_switching_key,
+            bootstrapping_key,
+            pbs_order: self.pbs_order(),
+        }
     }
 
     pub fn decompress(&self) -> StandardAtomicPatternServerKey {

--- a/tfhe/src/shortint/atomic_pattern/expanded.rs
+++ b/tfhe/src/shortint/atomic_pattern/expanded.rs
@@ -1,0 +1,20 @@
+use crate::core_crypto::prelude::{CiphertextModulus, LweKeyswitchKeyOwned, PBSOrder};
+
+use crate::shortint::server_key::expanded::ShortintExpandedBootstrappingKey;
+
+pub struct ExpandedStandardAtomicPatternServerKey {
+    pub key_switching_key: LweKeyswitchKeyOwned<u64>,
+    pub bootstrapping_key: ShortintExpandedBootstrappingKey<u64, u64>,
+    pub pbs_order: PBSOrder,
+}
+
+pub struct ExpandedKS32AtomicPatternServerKey {
+    pub key_switching_key: LweKeyswitchKeyOwned<u32>,
+    pub bootstrapping_key: ShortintExpandedBootstrappingKey<u64, u32>,
+    pub ciphertext_modulus: CiphertextModulus<u64>,
+}
+
+pub enum ExpandedAtomicPatternServerKey {
+    Standard(ExpandedStandardAtomicPatternServerKey),
+    KeySwitch32(ExpandedKS32AtomicPatternServerKey),
+}

--- a/tfhe/src/shortint/atomic_pattern/mod.rs
+++ b/tfhe/src/shortint/atomic_pattern/mod.rs
@@ -5,8 +5,14 @@
 //! Keyswitch and a PBS.
 
 pub mod compressed;
+pub mod expanded;
 pub mod ks32;
 pub mod standard;
+
+pub use expanded::{
+    ExpandedAtomicPatternServerKey, ExpandedKS32AtomicPatternServerKey,
+    ExpandedStandardAtomicPatternServerKey,
+};
 
 use std::any::Any;
 

--- a/tfhe/src/shortint/noise_squashing/atomic_pattern/expanded.rs
+++ b/tfhe/src/shortint/noise_squashing/atomic_pattern/expanded.rs
@@ -1,0 +1,6 @@
+use crate::shortint::server_key::expanded::ShortintExpandedBootstrappingKey;
+
+pub enum ExpandedAtomicPatternNoiseSquashingKey {
+    Standard(ShortintExpandedBootstrappingKey<u128, u64>),
+    KeySwitch32(ShortintExpandedBootstrappingKey<u128, u32>),
+}

--- a/tfhe/src/shortint/noise_squashing/atomic_pattern/mod.rs
+++ b/tfhe/src/shortint/noise_squashing/atomic_pattern/mod.rs
@@ -14,8 +14,11 @@ use crate::shortint::{CarryModulus, Ciphertext, MessageModulus};
 use super::NoiseSquashingPrivateKey;
 
 pub mod compressed;
+pub mod expanded;
 pub mod ks32;
 pub mod standard;
+
+pub use expanded::ExpandedAtomicPatternNoiseSquashingKey;
 
 pub trait NoiseSquashingAtomicPattern {
     fn squash_ciphertext_noise(

--- a/tfhe/src/shortint/noise_squashing/mod.rs
+++ b/tfhe/src/shortint/noise_squashing/mod.rs
@@ -11,7 +11,7 @@ pub use compressed_server_key::{
 pub use private_key::NoiseSquashingPrivateKey;
 pub(crate) use private_key::NoiseSquashingPrivateKeyView;
 pub use server_key::{
-    GenericNoiseSquashingKey, NoiseSquashingKey, NoiseSquashingKeyConformanceParams,
-    NoiseSquashingKeyView, Shortint128BootstrappingKey, StandardNoiseSquashingKey,
-    StandardNoiseSquashingKeyView,
+    ExpandedNoiseSquashingKey, GenericNoiseSquashingKey, NoiseSquashingKey,
+    NoiseSquashingKeyConformanceParams, NoiseSquashingKeyView, Shortint128BootstrappingKey,
+    StandardNoiseSquashingKey, StandardNoiseSquashingKeyView,
 };

--- a/tfhe/src/shortint/noise_squashing/server_key.rs
+++ b/tfhe/src/shortint/noise_squashing/server_key.rs
@@ -261,6 +261,9 @@ pub type NoiseSquashingKeyView<'key> =
 pub type StandardNoiseSquashingKeyView<'key> =
     GenericNoiseSquashingKey<&'key StandardAtomicPatternNoiseSquashingKey>;
 
+pub type ExpandedNoiseSquashingKey =
+    GenericNoiseSquashingKey<super::atomic_pattern::ExpandedAtomicPatternNoiseSquashingKey>;
+
 impl<'key> TryFrom<NoiseSquashingKeyView<'key>> for StandardNoiseSquashingKeyView<'key> {
     type Error = UnsupportedOperation;
 

--- a/tfhe/src/shortint/server_key/expanded.rs
+++ b/tfhe/src/shortint/server_key/expanded.rs
@@ -1,0 +1,165 @@
+use crate::core_crypto::prelude::*;
+
+use super::{GenericServerKey, ModulusSwitchConfiguration, ShortintBootstrappingKey};
+use crate::shortint::atomic_pattern::expanded::ExpandedAtomicPatternServerKey;
+use crate::shortint::noise_squashing::Shortint128BootstrappingKey;
+
+pub type ShortintExpandedServerKey = GenericServerKey<ExpandedAtomicPatternServerKey>;
+
+/// Bootstrapping Key with elements in the standard (i.e not fourier) domain
+pub enum ShortintExpandedBootstrappingKey<Scalar, ModSwitchScalar>
+where
+    Scalar: UnsignedInteger,
+    ModSwitchScalar: UnsignedInteger,
+{
+    Classic {
+        bsk: LweBootstrapKey<Vec<Scalar>>,
+        modulus_switch_noise_reduction_key: ModulusSwitchConfiguration<ModSwitchScalar>,
+    },
+    MultiBit {
+        bsk: LweMultiBitBootstrapKey<Vec<Scalar>>,
+        thread_count: ThreadCount,
+        deterministic_execution: bool,
+    },
+}
+
+impl<Scalar, ModSwitchScalar> ShortintExpandedBootstrappingKey<Scalar, ModSwitchScalar>
+where
+    Scalar: UnsignedInteger,
+    ModSwitchScalar: UnsignedInteger,
+{
+    pub fn glwe_dimension(&self) -> GlweDimension {
+        match self {
+            Self::Classic { bsk, .. } => bsk.glwe_size().to_glwe_dimension(),
+            Self::MultiBit { bsk, .. } => bsk.glwe_size().to_glwe_dimension(),
+        }
+    }
+
+    pub fn polynomial_size(&self) -> PolynomialSize {
+        match self {
+            Self::Classic { bsk, .. } => bsk.polynomial_size(),
+            Self::MultiBit { bsk, .. } => bsk.polynomial_size(),
+        }
+    }
+}
+
+impl<ModSwitchScalar> ShortintExpandedBootstrappingKey<u64, ModSwitchScalar>
+where
+    ModSwitchScalar: UnsignedInteger,
+{
+    pub fn into_fourier(self) -> ShortintBootstrappingKey<ModSwitchScalar> {
+        match self {
+            Self::Classic {
+                bsk,
+                modulus_switch_noise_reduction_key,
+            } => {
+                let mut fourier_bsk = FourierLweBootstrapKey::new(
+                    bsk.input_lwe_dimension(),
+                    bsk.glwe_size(),
+                    bsk.polynomial_size(),
+                    bsk.decomposition_base_log(),
+                    bsk.decomposition_level_count(),
+                );
+                par_convert_standard_lwe_bootstrap_key_to_fourier(&bsk, &mut fourier_bsk);
+                ShortintBootstrappingKey::Classic {
+                    bsk: fourier_bsk,
+                    modulus_switch_noise_reduction_key,
+                }
+            }
+            Self::MultiBit {
+                bsk,
+                thread_count,
+                deterministic_execution,
+            } => {
+                let mut fourier_bsk = FourierLweMultiBitBootstrapKeyOwned::new(
+                    bsk.input_lwe_dimension(),
+                    bsk.glwe_size(),
+                    bsk.polynomial_size(),
+                    bsk.decomposition_base_log(),
+                    bsk.decomposition_level_count(),
+                    bsk.grouping_factor(),
+                );
+                par_convert_standard_lwe_multi_bit_bootstrap_key_to_fourier(&bsk, &mut fourier_bsk);
+                ShortintBootstrappingKey::MultiBit {
+                    fourier_bsk,
+                    thread_count,
+                    deterministic_execution,
+                }
+            }
+        }
+    }
+}
+
+impl<ModSwitchScalar> ShortintExpandedBootstrappingKey<u128, ModSwitchScalar>
+where
+    ModSwitchScalar: UnsignedInteger,
+{
+    pub fn into_fourier(self) -> Shortint128BootstrappingKey<ModSwitchScalar> {
+        match self {
+            Self::Classic {
+                bsk,
+                modulus_switch_noise_reduction_key,
+            } => {
+                let mut fourier_bsk = Fourier128LweBootstrapKeyOwned::new(
+                    bsk.input_lwe_dimension(),
+                    bsk.glwe_size(),
+                    bsk.polynomial_size(),
+                    bsk.decomposition_base_log(),
+                    bsk.decomposition_level_count(),
+                );
+                par_convert_standard_lwe_bootstrap_key_to_fourier_128(&bsk, &mut fourier_bsk);
+                Shortint128BootstrappingKey::Classic {
+                    bsk: fourier_bsk,
+                    modulus_switch_noise_reduction_key,
+                }
+            }
+            Self::MultiBit {
+                bsk,
+                thread_count,
+                deterministic_execution,
+            } => {
+                let mut fourier_bsk = Fourier128LweMultiBitBootstrapKey::new(
+                    bsk.input_lwe_dimension(),
+                    bsk.glwe_size(),
+                    bsk.polynomial_size(),
+                    bsk.decomposition_base_log(),
+                    bsk.decomposition_level_count(),
+                    bsk.grouping_factor(),
+                );
+
+                par_convert_standard_lwe_multi_bit_bootstrap_key_to_fourier_128(
+                    &bsk,
+                    &mut fourier_bsk,
+                );
+
+                Shortint128BootstrappingKey::MultiBit {
+                    bsk: fourier_bsk,
+                    thread_count,
+                    deterministic_execution,
+                }
+            }
+        }
+    }
+}
+
+impl ShortintExpandedServerKey {
+    pub fn glwe_dimension(&self) -> GlweDimension {
+        match &self.atomic_pattern {
+            ExpandedAtomicPatternServerKey::Standard(std) => std.bootstrapping_key.glwe_dimension(),
+            ExpandedAtomicPatternServerKey::KeySwitch32(ks32) => {
+                ks32.bootstrapping_key.glwe_dimension()
+            }
+        }
+    }
+
+    pub fn polynomial_size(&self) -> PolynomialSize {
+        match &self.atomic_pattern {
+            ExpandedAtomicPatternServerKey::Standard(std) => {
+                std.bootstrapping_key.polynomial_size()
+            }
+            ExpandedAtomicPatternServerKey::KeySwitch32(ks32) => {
+                ks32.bootstrapping_key.polynomial_size()
+            }
+        }
+    }
+}

--- a/tfhe/src/shortint/server_key/mod.rs
+++ b/tfhe/src/shortint/server_key/mod.rs
@@ -20,6 +20,9 @@ mod shift;
 mod sub;
 
 pub mod compressed;
+pub mod expanded;
+
+pub use expanded::{ShortintExpandedBootstrappingKey, ShortintExpandedServerKey};
 
 pub use bivariate_pbs::{
     BivariateLookupTableMutView, BivariateLookupTableOwned, BivariateLookupTableView,


### PR DESCRIPTION
The expanded types definitions were in the high level API as it was originally related to the XofKeySet feature.

However, since it's now used even in non-xof setting we decided to move these types to shortint module
where they conceptually belong

Note that now expanded types and `expand` functions are pub not pub(crate)

Follow up of https://github.com/zama-ai/tfhe-rs/pull/3215

AI was used to move the code

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3251)
<!-- Reviewable:end -->
