### PR TITLE
chore(ci): pin slsa-github-generator to a specific commit

### DIFF
--- a/.github/workflows/make_release_common.yml
+++ b/.github/workflows/make_release_common.yml
@@ -75,7 +75,7 @@ jobs:
     name: make_release_common/provenance
     if: ${{ !inputs.dry-run  }}
     needs: package
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
     permissions:
       actions: read # Needed to detect the GitHub Actions environment
       id-token: write # Needed to create the provenance via GitHub OIDC

--- a/.github/workflows/make_release_cuda.yml
+++ b/.github/workflows/make_release_cuda.yml
@@ -117,7 +117,7 @@ jobs:
     name: make_release_cuda/provenance
     if: ${{ !inputs.dry_run  }}
     needs: [package]
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
     permissions:
       actions: read # Needed to detect the GitHub Actions environment
       id-token: write # Needed to create the provenance via GitHub OIDC


### PR DESCRIPTION
Zizmor analysis didn't pick up this non-pinned action usage. It's now pinned to the commit of the `v2.1.0` of the action.

