### PR TITLE
chore(xof_key_set): make generate_with_pre_seeded_generator public

### DIFF
--- a/tfhe/src/high_level_api/xof_key_set/mod.rs
+++ b/tfhe/src/high_level_api/xof_key_set/mod.rs
@@ -129,7 +129,7 @@ impl CompressedXofKeySet {
         Ok((client_key, xof_key_set))
     }
 
-    fn generate_with_pre_seeded_generator<G>(
+    pub fn generate_with_pre_seeded_generator<G>(
         pub_seed: XofSeed,
         ck: &ClientKey,
         private_generator: RandomGenerator<G>,


### PR DESCRIPTION
MPC teams needs to be able to generate a CompressedXofKeySet from an existing ClientKey