### PR TITLE
doc: fix specs description of aws hpc7a.96xlarge instance

### DIFF
--- a/tfhe/docs/getting-started/benchmarks/README.md
+++ b/tfhe/docs/getting-started/benchmarks/README.md
@@ -14,7 +14,7 @@ make print_doc_bench_parameters
 
 {% hint style="info" %}
 Benchmarks in the Table below were launched on: 
- * CPU: using an `AWS hpc7a.96xlarge` instance equipped with a 96-core `AMD EPYC 9R14 CPU @ 2.60GHz` and 740GB of RAM
+ * CPU: using an `AWS hpc7a.96xlarge` instance equipped with two 96-core `AMD EPYC 9R14 CPU @ 2.60GHz` and 740GB of RAM
  * GPU: using 8xH100 GPU, and rely on the multithreaded PBS algorithm
  * HPU: using 1xv80 Alveo board
 {% endhint %}

--- a/tfhe/docs/getting-started/benchmarks/cpu/README.md
+++ b/tfhe/docs/getting-started/benchmarks/cpu/README.md
@@ -5,7 +5,7 @@ This document details the CPU performance benchmarks of homomorphic operations u
 By their nature, homomorphic operations run slower than their cleartext equivalents.
 
 {% hint style="info" %}
-All CPU benchmarks were launched on an `AWS hpc7a.96xlarge` instance equipped with a 96-core `AMD EPYC 9R14 CPU @ 2.60GHz` and 740GB of RAM.
+All CPU benchmarks were launched on an `AWS hpc7a.96xlarge` instance equipped with two 96-core `AMD EPYC 9R14 CPU @ 2.60GHz` and 740GB of RAM.
 {% endhint %}
 
 * [Integer operations](cpu-integer-operations.md)

--- a/tfhe/docs/getting-started/benchmarks/cpu/cpu-integer-operations.md
+++ b/tfhe/docs/getting-started/benchmarks/cpu/cpu-integer-operations.md
@@ -5,7 +5,7 @@ This document details the CPU performance benchmarks of homomorphic operations o
 By their nature, homomorphic operations run slower than their cleartext equivalents.
 
 {% hint style="info" %}
-All CPU benchmarks were launched on an `AWS hpc7a.96xlarge` instance equipped with a 96-core `AMD EPYC 9R14 CPU @ 2.60GHz` and 740GB of RAM.
+All CPU benchmarks were launched on an `AWS hpc7a.96xlarge` instance equipped with two 96-core `AMD EPYC 9R14 CPU @ 2.60GHz` and 740GB of RAM.
 {% endhint %}
 
 The following tables benchmark the execution time of some operation sets using `FheUint` (unsigned integers). The `FheInt` (signed integers) performs similarly.

--- a/tfhe/docs/getting-started/benchmarks/cpu/cpu-programmable-bootstrapping.md
+++ b/tfhe/docs/getting-started/benchmarks/cpu/cpu-programmable-bootstrapping.md
@@ -3,7 +3,7 @@
 This document details the CPU performance benchmarks of programmable bootstrapping and keyswitch operations using **TFHE-rs**.
 
 {% hint style="info" %}
-All CPU benchmarks were launched on an `AWS hpc7a.96xlarge` instance equipped with a 96-core `AMD EPYC 9R14 CPU @ 2.60GHz` and 740GB of RAM.
+All CPU benchmarks were launched on an `AWS hpc7a.96xlarge` instance equipped with two 96-core `AMD EPYC 9R14 CPU @ 2.60GHz` and 740GB of RAM.
 {% endhint %}
 
 The next tables show the execution time of a single programmable bootstrapping as well as keyswitch followed by a programmable bootstrapping depending on the precision of the input message. The associated parameters set are given. The configuration is tfhe-fft + AVX-512.

--- a/tfhe/docs/getting-started/benchmarks/zk-proof-benchmarks.md
+++ b/tfhe/docs/getting-started/benchmarks/zk-proof-benchmarks.md
@@ -5,7 +5,7 @@ This document details the performance benchmarks of [zero-knowledge proofs](../.
 ## Server-side computation
 
 {% hint style="info" %}
-Benchmarks were launched on an `AWS hpc7a.96xlarge` instance equipped with a 96-core `AMD EPYC 9R14 CPU @ 2.60GHz` and 740GB of RAM.
+Benchmarks were launched on an `AWS hpc7a.96xlarge` instance equipped with two 96-core `AMD EPYC 9R14 CPU @ 2.60GHz` and 740GB of RAM.
 {% endhint %}
 
 Proving and verification are done with tfhe-rs native executable on a powerful server.


### PR DESCRIPTION
These instances have two sockets, each equipped with a 96-core CPU.
