### PR TITLE
test(noise): add an output json file with all the test information

### DIFF
--- a/backends/zk-cuda-backend/Cargo.toml
+++ b/backends/zk-cuda-backend/Cargo.toml
@@ -28,4 +28,4 @@ tfhe-cuda-backend = { version = "0.13.0", path = "../tfhe-cuda-backend" }
 
 [features]
 default = []
-validate_points = []  # Enable on-curve validation for points
+validate_points = [] # Enable on-curve validation for points

--- a/tfhe/.gitignore
+++ b/tfhe/.gitignore
@@ -1,1 +1,2 @@
 build/
+tests_results/*

--- a/tfhe/src/integer/gpu/server_key/radix/tests_noise_distribution/br_dp_ks_ms.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/tests_noise_distribution/br_dp_ks_ms.rs
@@ -9,7 +9,7 @@ use crate::core_crypto::gpu::vec::GpuIndex;
 use crate::core_crypto::gpu::CudaStreams;
 use crate::core_crypto::prelude::LweCiphertext;
 use crate::integer::gpu::ciphertext::CudaUnsignedRadixCiphertext;
-use crate::integer::gpu::server_key::radix::tests_unsigned::create_gpu_parameterized_test;
+use crate::integer::gpu::server_key::radix::tests_unsigned::create_gpu_parameterized_stringified_test;
 use crate::integer::gpu::server_key::radix::CudaBlockInfo;
 use crate::integer::gpu::server_key::CudaServerKey;
 use crate::integer::gpu::unchecked_small_scalar_mul_integer;
@@ -17,7 +17,6 @@ use crate::integer::{CompressedServerKey, IntegerCiphertext};
 use crate::shortint::ciphertext::NoiseLevel;
 use crate::shortint::client_key::atomic_pattern::AtomicPatternClientKey;
 use crate::shortint::encoding::{PaddingBit, ShortintEncoding};
-
 use crate::shortint::parameters::test_params::{
     TEST_META_PARAM_CPU_2_2_KS_PBS_GAUSSIAN_2M128,
     TEST_META_PARAM_CPU_2_2_KS_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128,
@@ -29,10 +28,14 @@ use crate::shortint::server_key::tests::noise_distribution::utils::noise_simulat
     NoiseSimulationGenericBootstrapKey, NoiseSimulationGlwe, NoiseSimulationLwe,
     NoiseSimulationLweKeyswitchKey, NoiseSimulationModulus,
 };
+use crate::shortint::server_key::tests::noise_distribution::utils::to_json::{
+    write_empty_json_file, write_to_json_file, NoiseCheckWithNormalityCheck, TestResult,
+};
 use crate::shortint::server_key::tests::noise_distribution::utils::{
     mean_and_variance_check, normality_check, pfail_check, update_ap_params_for_pfail,
     DecryptionAndNoiseResult, NoiseSample, PfailTestMeta, PfailTestResult,
 };
+use crate::this_function_name;
 
 use crate::shortint::server_key::tests::noise_distribution::should_run_short_pfail_tests_debug;
 use crate::shortint::server_key::tests::noise_distribution::utils::noise_simulation::NoiseSimulationModulusSwitchConfig;
@@ -40,7 +43,13 @@ use crate::shortint::{CarryModulus, Ciphertext, ClientKey, ShortintParameterSet}
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 /// Test function to verify that the noise checking tools match the actual atomic patterns
 /// implemented in shortint for GPU
-fn sanity_check_encrypt_br_dp_ks_pbs_gpu(meta_params: MetaParameters) {
+fn sanity_check_encrypt_br_dp_ks_pbs_gpu(meta_params: MetaParameters, filename_suffix: &str) {
+    write_empty_json_file(
+        &meta_params,
+        filename_suffix,
+        this_function_name!().as_str(),
+    )
+    .unwrap();
     let atomic_params = meta_params.compute_parameters;
     let gpu_index = 0;
     let streams = CudaStreams::new_single_gpu(GpuIndex::new(gpu_index));
@@ -52,7 +61,6 @@ fn sanity_check_encrypt_br_dp_ks_pbs_gpu(meta_params: MetaParameters) {
 
     let modulus_switch_config = cuda_sks.noise_simulation_modulus_switch_config();
     let br_input_modulus_log = cuda_sks.br_input_modulus_log();
-
     let max_scalar_mul = cuda_sks.max_noise_level.get();
 
     let id_lut = cuda_sks.generate_lookup_table(|x| x);
@@ -67,6 +75,9 @@ fn sanity_check_encrypt_br_dp_ks_pbs_gpu(meta_params: MetaParameters) {
     };
 
     let mut cuda_side_resources = CudaSideResources::new(&streams, block_info);
+
+    type SanityVec = (LweCiphertext<Vec<u64>>, LweCiphertext<Vec<u64>>);
+    let mut results: Vec<SanityVec> = Vec::new();
 
     for _ in 0..10 {
         let input_zero_as_lwe = cks
@@ -154,11 +165,30 @@ fn sanity_check_encrypt_br_dp_ks_pbs_gpu(meta_params: MetaParameters) {
             shortint_res_list.ciphertext_modulus(),
         );
 
+        results.push((after_pbs_ct, shortint_res_ct));
+    }
+
+    let res_cond = results
+        .iter()
+        .all(|(lhs, rhs)| lhs.as_view() == rhs.as_view());
+
+    write_to_json_file(
+        &meta_params,
+        filename_suffix,
+        this_function_name!().as_str(),
+        res_cond,
+        None,
+        TestResult::Empty {},
+    )
+    .unwrap();
+
+    // We check each step to preserve failure details and print the invalid case if one occurs
+    for (after_pbs_ct, shortint_res_ct) in results.iter() {
         assert_eq!(after_pbs_ct.as_view(), shortint_res_ct.as_view());
     }
 }
 
-create_gpu_parameterized_test!(sanity_check_encrypt_br_dp_ks_pbs_gpu {
+create_gpu_parameterized_stringified_test!(sanity_check_encrypt_br_dp_ks_pbs_gpu {
     TEST_META_PARAM_CPU_2_2_KS_PBS_GAUSSIAN_2M128,
     TEST_META_PARAM_CPU_2_2_KS_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128,
 });
@@ -349,8 +379,14 @@ fn encrypt_br_dp_ks_any_ms_pfail_helper_gpu(
     after_ms
 }
 
-fn noise_check_encrypt_br_dp_ks_ms_noise(params: MetaParameters) {
-    let params: AtomicPatternParameters = params.compute_parameters;
+fn noise_check_encrypt_br_dp_ks_ms_noise(meta_params: MetaParameters, filename_suffix: &str) {
+    write_empty_json_file(
+        &meta_params,
+        filename_suffix,
+        this_function_name!().as_str(),
+    )
+    .unwrap();
+    let params: AtomicPatternParameters = meta_params.compute_parameters;
 
     let noise_simulation_ksk =
         NoiseSimulationLweKeyswitchKey::new_from_atomic_pattern_parameters(params);
@@ -478,25 +514,53 @@ fn noise_check_encrypt_br_dp_ks_ms_noise(params: MetaParameters) {
     }
     let before_ms_normality = normality_check(&noise_samples_before_ms, "before ms", 0.01);
 
-    let after_ms_is_ok = mean_and_variance_check(
-        &noise_samples_after_ms,
-        "after_ms",
-        expected_average_after_ms,
-        after_ms_sim.variance(),
-        params.lwe_noise_distribution(),
-        after_ms_sim.lwe_dimension(),
-        after_ms_sim.modulus().as_f64(),
-    );
+    let (after_ms_is_ok, bounded_variance_measurement, bounded_mean_measurement) =
+        mean_and_variance_check(
+            &noise_samples_after_ms,
+            "after_ms",
+            expected_average_after_ms,
+            after_ms_sim.variance(),
+            params.lwe_noise_distribution(),
+            after_ms_sim.lwe_dimension(),
+            after_ms_sim.modulus().as_f64(),
+        );
 
-    assert!(before_ms_normality.null_hypothesis_is_valid && after_ms_is_ok);
+    let before_ms_normality_valid = before_ms_normality.null_hypothesis_is_valid;
+
+    let sanity_check_valid = before_ms_normality_valid && after_ms_is_ok;
+
+    let noise_check =
+        TestResult::NoiseCheckWithNormalityCheck(Box::new(NoiseCheckWithNormalityCheck::new(
+            bounded_variance_measurement,
+            bounded_mean_measurement,
+            before_ms_normality_valid,
+        )));
+
+    write_to_json_file(
+        &meta_params,
+        filename_suffix,
+        this_function_name!().as_str(),
+        sanity_check_valid,
+        None,
+        noise_check,
+    )
+    .unwrap();
+
+    assert!(sanity_check_valid);
 }
 
-create_gpu_parameterized_test!(noise_check_encrypt_br_dp_ks_ms_noise {
+create_gpu_parameterized_stringified_test!(noise_check_encrypt_br_dp_ks_ms_noise {
     TEST_META_PARAM_CPU_2_2_KS_PBS_GAUSSIAN_2M128,
     TEST_META_PARAM_CPU_2_2_KS_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128,
 });
 
-fn noise_check_encrypt_br_dp_ks_ms_pfail_gpu(meta_params: MetaParameters) {
+fn noise_check_encrypt_br_dp_ks_ms_pfail_gpu(meta_params: MetaParameters, filename_suffix: &str) {
+    write_empty_json_file(
+        &meta_params,
+        filename_suffix,
+        this_function_name!().as_str(),
+    )
+    .unwrap();
     let (pfail_test_meta, params) = {
         let mut ap_params: AtomicPatternParameters = meta_params.compute_parameters;
 
@@ -574,10 +638,16 @@ fn noise_check_encrypt_br_dp_ks_ms_pfail_gpu(meta_params: MetaParameters) {
         .sum();
     let test_result = PfailTestResult { measured_fails };
 
-    pfail_check(&pfail_test_meta, test_result);
+    pfail_check(
+        &pfail_test_meta,
+        test_result,
+        &meta_params,
+        filename_suffix,
+        this_function_name!().as_str(),
+    );
 }
 
-create_gpu_parameterized_test!(noise_check_encrypt_br_dp_ks_ms_pfail_gpu {
+create_gpu_parameterized_stringified_test!(noise_check_encrypt_br_dp_ks_ms_pfail_gpu {
     TEST_META_PARAM_CPU_2_2_KS_PBS_GAUSSIAN_2M128,
     TEST_META_PARAM_CPU_2_2_KS_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128,
 });

--- a/tfhe/src/integer/gpu/server_key/radix/tests_noise_distribution/br_dp_packingks_ms.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/tests_noise_distribution/br_dp_packingks_ms.rs
@@ -6,7 +6,7 @@ use crate::core_crypto::prelude::{GlweCiphertext, LweCiphertext};
 use crate::integer::compression_keys::CompressionPrivateKeys;
 use crate::integer::gpu::list_compression::server_keys::CudaCompressionKey;
 use crate::integer::gpu::server_key::radix::tests_noise_distribution::utils::noise_simulation::cuda_glwe_list_to_glwe_ciphertext;
-use crate::integer::gpu::server_key::radix::tests_unsigned::create_gpu_parameterized_test;
+use crate::integer::gpu::server_key::radix::tests_unsigned::create_gpu_parameterized_stringified_test;
 use crate::integer::gpu::server_key::radix::CudaUnsignedRadixCiphertext;
 use crate::integer::gpu::CudaServerKey;
 use crate::integer::{ClientKey, CompressedServerKey, IntegerCiphertext};
@@ -20,6 +20,9 @@ use crate::shortint::server_key::tests::noise_distribution::utils::noise_simulat
     NoiseSimulationGenericBootstrapKey, NoiseSimulationGlwe, NoiseSimulationLwe,
     NoiseSimulationLwePackingKeyswitchKey, NoiseSimulationModulus,
 };
+use crate::shortint::server_key::tests::noise_distribution::utils::to_json::{
+    write_empty_json_file, write_to_json_file, NoiseCheckWithNormalityCheck, TestResult,
+};
 use crate::shortint::server_key::tests::noise_distribution::utils::{
     expected_pfail_for_precision, mean_and_variance_check, normality_check, pfail_check,
     precision_with_padding, update_ap_params_msg_and_carry_moduli, DecryptionAndNoiseResult,
@@ -31,12 +34,18 @@ use crate::shortint::server_key::tests::noise_distribution::{
 use crate::shortint::{
     AtomicPatternParameters, CarryModulus, MessageModulus, ShortintEncoding, ShortintParameterSet,
 };
-use crate::GpuIndex;
+use crate::{this_function_name, GpuIndex};
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
 pub const SAMPLES_PER_MSG_PACKING_KS_NOISE: usize = 1000;
 
-fn sanity_check_encrypt_br_dp_packing_ks_ms(meta_params: MetaParameters) {
+fn sanity_check_encrypt_br_dp_packing_ks_ms(meta_params: MetaParameters, filename_suffix: &str) {
+    write_empty_json_file(
+        &meta_params,
+        filename_suffix,
+        this_function_name!().as_str(),
+    )
+    .unwrap();
     let (params, comp_params) = (
         meta_params.compute_parameters,
         meta_params.compression_parameters.unwrap(),
@@ -139,10 +148,20 @@ fn sanity_check_encrypt_br_dp_packing_ks_ms(meta_params: MetaParameters) {
     // Bodies that were not filled are discarded
     after_ms.get_mut_body().as_mut()[lwe_per_glwe.0..].fill(0);
 
+    write_to_json_file(
+        &meta_params,
+        filename_suffix,
+        this_function_name!().as_str(),
+        after_ms.as_view() == extracted_glwe.as_view(),
+        None,
+        TestResult::Empty {},
+    )
+    .unwrap();
+
     assert_eq!(after_ms.as_view(), extracted_glwe.as_view());
 }
 
-create_gpu_parameterized_test!(sanity_check_encrypt_br_dp_packing_ks_ms {
+create_gpu_parameterized_stringified_test!(sanity_check_encrypt_br_dp_packing_ks_ms {
     TEST_META_PARAM_CPU_2_2_KS_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128,
 });
 
@@ -392,7 +411,16 @@ fn encrypt_br_dp_packing_ks_ms_pfail_helper_gpu(
     after_ms
 }
 
-fn noise_check_encrypt_br_dp_packing_ks_ms_noise_gpu(meta_params: MetaParameters) {
+fn noise_check_encrypt_br_dp_packing_ks_ms_noise_gpu(
+    meta_params: MetaParameters,
+    filename_suffix: &str,
+) {
+    write_empty_json_file(
+        &meta_params,
+        filename_suffix,
+        this_function_name!().as_str(),
+    )
+    .unwrap();
     let (params, comp_params) = (
         meta_params.compute_parameters,
         meta_params.compression_parameters.unwrap(),
@@ -558,25 +586,56 @@ fn noise_check_encrypt_br_dp_packing_ks_ms_noise_gpu(meta_params: MetaParameters
     let before_ms_normality =
         normality_check(&noise_samples_before_ms_flattened, "before ms", 0.01);
 
-    let after_ms_is_ok = mean_and_variance_check(
-        &noise_samples_after_ms_flattened,
-        "after_ms",
-        0.0,
-        after_ms_sim.variance_per_occupied_slot(),
-        comp_params.packing_ks_key_noise_distribution(),
-        after_ms_sim
-            .glwe_dimension()
-            .to_equivalent_lwe_dimension(after_ms_sim.polynomial_size()),
-        after_ms_sim.modulus().as_f64(),
-    );
+    let (after_ms_is_ok, bounded_variance_measurement, bounded_mean_measurement) =
+        mean_and_variance_check(
+            &noise_samples_after_ms_flattened,
+            "after_ms",
+            0.0,
+            after_ms_sim.variance_per_occupied_slot(),
+            comp_params.packing_ks_key_noise_distribution(),
+            after_ms_sim
+                .glwe_dimension()
+                .to_equivalent_lwe_dimension(after_ms_sim.polynomial_size()),
+            after_ms_sim.modulus().as_f64(),
+        );
 
-    assert!(before_ms_normality.null_hypothesis_is_valid && after_ms_is_ok);
+    let before_ms_normality_valid = before_ms_normality.null_hypothesis_is_valid;
+
+    let sanity_check_valid = before_ms_normality_valid && after_ms_is_ok;
+
+    let noise_check =
+        TestResult::NoiseCheckWithNormalityCheck(Box::new(NoiseCheckWithNormalityCheck::new(
+            bounded_variance_measurement,
+            bounded_mean_measurement,
+            before_ms_normality_valid,
+        )));
+
+    write_to_json_file(
+        &meta_params,
+        filename_suffix,
+        this_function_name!().as_str(),
+        sanity_check_valid,
+        None,
+        noise_check,
+    )
+    .unwrap();
+
+    assert!(sanity_check_valid);
 }
-create_gpu_parameterized_test!(noise_check_encrypt_br_dp_packing_ks_ms_noise_gpu {
+create_gpu_parameterized_stringified_test!(noise_check_encrypt_br_dp_packing_ks_ms_noise_gpu {
     TEST_META_PARAM_CPU_2_2_KS_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128,
 });
 
-fn noise_check_encrypt_br_dp_packing_ks_ms_pfail_gpu(meta_params: MetaParameters) {
+fn noise_check_encrypt_br_dp_packing_ks_ms_pfail_gpu(
+    meta_params: MetaParameters,
+    filename_suffix: &str,
+) {
+    write_empty_json_file(
+        &meta_params,
+        filename_suffix,
+        this_function_name!().as_str(),
+    )
+    .unwrap();
     let (pfail_test_meta, params, comp_params) = {
         let (mut params, comp_params) = (
             meta_params.compute_parameters,
@@ -749,9 +808,15 @@ fn noise_check_encrypt_br_dp_packing_ks_ms_pfail_gpu(meta_params: MetaParameters
 
     let test_result = PfailTestResult { measured_fails };
 
-    pfail_check(&pfail_test_meta, test_result);
+    pfail_check(
+        &pfail_test_meta,
+        test_result,
+        &meta_params,
+        filename_suffix,
+        this_function_name!().as_str(),
+    );
 }
 
-create_gpu_parameterized_test!(noise_check_encrypt_br_dp_packing_ks_ms_pfail_gpu {
+create_gpu_parameterized_stringified_test!(noise_check_encrypt_br_dp_packing_ks_ms_pfail_gpu {
     TEST_META_PARAM_CPU_2_2_KS_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128,
 });

--- a/tfhe/src/integer/gpu/server_key/radix/tests_noise_distribution/dp_ks_ms.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/tests_noise_distribution/dp_ks_ms.rs
@@ -2,25 +2,22 @@ use super::utils::noise_simulation::CudaSideResources;
 use crate::core_crypto::commons::noise_formulas::noise_simulation::traits::{
     AllocateLweBootstrapResult, LweClassicFftBootstrap,
 };
+use crate::core_crypto::commons::numeric::Numeric;
 use crate::core_crypto::commons::parameters::CiphertextModulusLog;
+use crate::core_crypto::gpu::glwe_ciphertext_list::CudaGlweCiphertextList;
 use crate::core_crypto::gpu::lwe_ciphertext_list::CudaLweCiphertextList;
 use crate::core_crypto::gpu::vec::{CudaVec, GpuIndex};
 use crate::core_crypto::gpu::CudaStreams;
+use crate::core_crypto::prelude::{CastInto, LweCiphertext};
 use crate::integer::gpu::ciphertext::CudaUnsignedRadixCiphertext;
+use crate::integer::gpu::server_key::radix::tests_noise_distribution::utils::noise_simulation::CudaDynLwe;
+use crate::integer::gpu::server_key::radix::tests_unsigned::create_gpu_parameterized_stringified_test;
 use crate::integer::gpu::server_key::radix::CudaBlockInfo;
 use crate::integer::gpu::server_key::CudaServerKey;
-use crate::integer::IntegerCiphertext;
-use crate::shortint::encoding::{PaddingBit, ShortintEncoding};
-
-use crate::core_crypto::commons::numeric::Numeric;
-use crate::core_crypto::gpu::glwe_ciphertext_list::CudaGlweCiphertextList;
-use crate::core_crypto::prelude::LweCiphertext;
-use crate::integer::gpu::server_key::radix::tests_noise_distribution::utils::noise_simulation::CudaDynLwe;
-use crate::integer::gpu::server_key::radix::tests_unsigned::create_gpu_parameterized_test;
 use crate::integer::gpu::unchecked_small_scalar_mul_integer;
-use crate::integer::CompressedServerKey;
-use crate::prelude::CastInto;
+use crate::integer::{CompressedServerKey, IntegerCiphertext};
 use crate::shortint::client_key::atomic_pattern::AtomicPatternClientKey;
+use crate::shortint::encoding::{PaddingBit, ShortintEncoding};
 use crate::shortint::parameters::test_params::{
     TEST_META_PARAM_CPU_2_2_KS_PBS_GAUSSIAN_2M128,
     TEST_META_PARAM_CPU_2_2_KS_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128,
@@ -30,6 +27,9 @@ use crate::shortint::server_key::tests::noise_distribution::dp_ks_ms::dp_ks_any_
 use crate::shortint::server_key::tests::noise_distribution::utils::noise_simulation::{
     NoiseSimulationLwe, NoiseSimulationLweKeyswitchKey, NoiseSimulationModulusSwitchConfig,
 };
+use crate::shortint::server_key::tests::noise_distribution::utils::to_json::{
+    write_empty_json_file, write_to_json_file, NoiseCheckWithNormalityCheck, TestResult,
+};
 use crate::shortint::server_key::tests::noise_distribution::utils::{
     mean_and_variance_check, normality_check, pfail_check, update_ap_params_for_pfail,
     DecryptionAndNoiseResult, NoiseSample, PfailTestMeta, PfailTestResult,
@@ -38,12 +38,19 @@ use crate::shortint::server_key::tests::noise_distribution::{
     should_run_short_pfail_tests_debug, should_use_single_key_debug,
 };
 use crate::shortint::{ClientKey, ShortintParameterSet};
+use crate::this_function_name;
 use itertools::Itertools;
 use rayon::prelude::*;
 
 /// Test function to verify that the noise checking tools match the actual atomic patterns
 /// implemented in shortint
-fn sanity_check_encrypt_dp_ks_pbs_gpu(meta_params: MetaParameters) {
+fn sanity_check_encrypt_dp_ks_pbs_gpu(meta_params: MetaParameters, filename_suffix: &str) {
+    write_empty_json_file(
+        &meta_params,
+        filename_suffix,
+        this_function_name!().as_str(),
+    )
+    .unwrap();
     let block_params = meta_params.compute_parameters;
     let gpu_index = 0;
     let streams = CudaStreams::new_single_gpu(GpuIndex::new(gpu_index));
@@ -89,6 +96,9 @@ fn sanity_check_encrypt_dp_ks_pbs_gpu(meta_params: MetaParameters) {
     };
 
     let mut cuda_side_resources = CudaSideResources::new(&streams, block_info);
+
+    type SanityVec = (LweCiphertext<Vec<u64>>, LweCiphertext<Vec<u64>>);
+    let mut results: Vec<SanityVec> = Vec::new();
 
     for _ in 0..10 {
         let ct_input = cks.key.encrypt(0);
@@ -152,11 +162,31 @@ fn sanity_check_encrypt_dp_ks_pbs_gpu(meta_params: MetaParameters) {
             shortint_res_list.clone().into_container(),
             shortint_res_list.ciphertext_modulus(),
         );
+
+        results.push((after_pbs_ct, shortint_res_ct));
+    }
+
+    let res_cond = results
+        .iter()
+        .all(|(lhs, rhs)| lhs.as_view() == rhs.as_view());
+
+    write_to_json_file(
+        &meta_params,
+        filename_suffix,
+        this_function_name!().as_str(),
+        res_cond,
+        None,
+        TestResult::Empty {},
+    )
+    .unwrap();
+
+    // We check each step to preserve failure details and print the invalid case if one occurs
+    for (after_pbs_ct, shortint_res_ct) in results.iter() {
         assert_eq!(after_pbs_ct.as_view(), shortint_res_ct.as_view());
     }
 }
 
-create_gpu_parameterized_test!(sanity_check_encrypt_dp_ks_pbs_gpu {
+create_gpu_parameterized_stringified_test!(sanity_check_encrypt_dp_ks_pbs_gpu {
     TEST_META_PARAM_CPU_2_2_KS_PBS_GAUSSIAN_2M128,
     TEST_META_PARAM_CPU_2_2_KS_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128,
 });
@@ -330,8 +360,14 @@ fn encrypt_dp_ks_any_ms_pfail_helper_gpu(
 }
 
 /// GPU version of the noise checking test
-fn noise_check_encrypt_dp_ks_ms_noise_gpu(params: MetaParameters) {
-    let params = params.compute_parameters;
+fn noise_check_encrypt_dp_ks_ms_noise_gpu(meta_params: MetaParameters, filename_suffix: &str) {
+    write_empty_json_file(
+        &meta_params,
+        filename_suffix,
+        this_function_name!().as_str(),
+    )
+    .unwrap();
+    let params = meta_params.compute_parameters;
     let noise_simulation_ksk =
         NoiseSimulationLweKeyswitchKey::new_from_atomic_pattern_parameters(params);
     let noise_simulation_modulus_switch_config =
@@ -434,25 +470,53 @@ fn noise_check_encrypt_dp_ks_ms_noise_gpu(params: MetaParameters) {
 
     let before_ms_normality = normality_check(&noise_samples_before_ms, "before ms", 0.01);
 
-    let after_ms_is_ok = mean_and_variance_check(
-        &noise_samples_after_ms,
-        "after_ms",
-        expected_average_after_ms,
-        after_ms_sim.variance(),
-        params.lwe_noise_distribution(),
-        after_ms_sim.lwe_dimension(),
-        after_ms_sim.modulus().as_f64(),
-    );
+    let (after_ms_is_ok, bounded_variance_measurement, bounded_mean_measurement) =
+        mean_and_variance_check(
+            &noise_samples_after_ms,
+            "after_ms",
+            expected_average_after_ms,
+            after_ms_sim.variance(),
+            params.lwe_noise_distribution(),
+            after_ms_sim.lwe_dimension(),
+            after_ms_sim.modulus().as_f64(),
+        );
 
-    assert!(before_ms_normality.null_hypothesis_is_valid && after_ms_is_ok);
+    let before_ms_normality_valid = before_ms_normality.null_hypothesis_is_valid;
+
+    let sanity_check_valid = before_ms_normality_valid && after_ms_is_ok;
+
+    let noise_check =
+        TestResult::NoiseCheckWithNormalityCheck(Box::new(NoiseCheckWithNormalityCheck::new(
+            bounded_variance_measurement,
+            bounded_mean_measurement,
+            before_ms_normality_valid,
+        )));
+
+    write_to_json_file(
+        &meta_params,
+        filename_suffix,
+        this_function_name!().as_str(),
+        sanity_check_valid,
+        None,
+        noise_check,
+    )
+    .unwrap();
+
+    assert!(sanity_check_valid);
 }
 
-create_gpu_parameterized_test!(noise_check_encrypt_dp_ks_ms_noise_gpu {
+create_gpu_parameterized_stringified_test!(noise_check_encrypt_dp_ks_ms_noise_gpu {
     TEST_META_PARAM_CPU_2_2_KS_PBS_GAUSSIAN_2M128,
     TEST_META_PARAM_CPU_2_2_KS_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128,
 });
 
-fn noise_check_encrypt_dp_ks_ms_pfail_gpu(meta_params: MetaParameters) {
+fn noise_check_encrypt_dp_ks_ms_pfail_gpu(meta_params: MetaParameters, filename_suffix: &str) {
+    write_empty_json_file(
+        &meta_params,
+        filename_suffix,
+        this_function_name!().as_str(),
+    )
+    .unwrap();
     let mut ap_params = meta_params.compute_parameters;
     let (pfail_test_meta, params) = {
         let original_message_modulus = ap_params.message_modulus();
@@ -529,10 +593,16 @@ fn noise_check_encrypt_dp_ks_ms_pfail_gpu(meta_params: MetaParameters) {
         .sum();
     let test_result = PfailTestResult { measured_fails };
 
-    pfail_check(&pfail_test_meta, test_result);
+    pfail_check(
+        &pfail_test_meta,
+        test_result,
+        &meta_params,
+        filename_suffix,
+        this_function_name!().as_str(),
+    );
 }
 
-create_gpu_parameterized_test!(noise_check_encrypt_dp_ks_ms_pfail_gpu {
+create_gpu_parameterized_stringified_test!(noise_check_encrypt_dp_ks_ms_pfail_gpu {
     TEST_META_PARAM_CPU_2_2_KS_PBS_GAUSSIAN_2M128,
     TEST_META_PARAM_CPU_2_2_KS_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128,
 });

--- a/tfhe/src/integer/gpu/server_key/radix/tests_noise_distribution/dp_ks_pbs_128_packingks.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/tests_noise_distribution/dp_ks_pbs_128_packingks.rs
@@ -11,7 +11,7 @@ use crate::core_crypto::commons::parameters::CiphertextModulusLog;
 use crate::core_crypto::prelude::generate_programmable_bootstrap_glwe_lut;
 use crate::integer::ciphertext::NoiseSquashingCompressionPrivateKey;
 use crate::integer::gpu::list_compression::server_keys::CudaNoiseSquashingCompressionKey;
-use crate::integer::gpu::server_key::radix::tests_unsigned::create_gpu_parameterized_test;
+use crate::integer::gpu::server_key::radix::tests_unsigned::create_gpu_parameterized_stringified_test;
 use crate::integer::gpu::server_key::radix::{CudaNoiseSquashingKey, CudaUnsignedRadixCiphertext};
 use crate::integer::gpu::unchecked_small_scalar_mul_integer;
 use crate::integer::IntegerCiphertext;
@@ -30,16 +30,28 @@ use crate::shortint::server_key::tests::noise_distribution::utils::noise_simulat
     NoiseSimulationLweFourierBsk, NoiseSimulationLweKeyswitchKey,
     NoiseSimulationModulusSwitchConfig,
 };
+use crate::shortint::server_key::tests::noise_distribution::utils::to_json::{
+    write_empty_json_file, write_to_json_file, NoiseCheckWithoutNormalityCheck, TestResult,
+};
 use crate::shortint::server_key::tests::noise_distribution::utils::{
     mean_and_variance_check, DecryptionAndNoiseResult, NoiseSample,
 };
 use crate::shortint::{PaddingBit, ShortintEncoding, ShortintParameterSet};
-use crate::GpuIndex;
+use crate::{this_function_name, GpuIndex};
 use rayon::prelude::*;
 
 /// Test function to verify that the noise checking tools match the actual atomic patterns
 /// implemented in shortint for GPU
-fn sanity_check_encrypt_dp_ks_standard_pbs128_packing_ks_gpu(meta_params: MetaParameters) {
+fn sanity_check_encrypt_dp_ks_standard_pbs128_packing_ks_gpu(
+    meta_params: MetaParameters,
+    filename_suffix: &str,
+) {
+    write_empty_json_file(
+        &meta_params,
+        filename_suffix,
+        this_function_name!().as_str(),
+    )
+    .unwrap();
     let (atomic_params, noise_squashing_params, noise_squashing_compression_params) = {
         let meta_noise_squashing_params = meta_params.noise_squashing_parameters.unwrap();
         (
@@ -177,12 +189,31 @@ fn sanity_check_encrypt_dp_ks_standard_pbs128_packing_ks_gpu(meta_params: MetaPa
     // Bodies that were not filled are discarded
     after_packing.get_mut_body().as_mut()[lwe_per_glwe.0..].fill(0);
 
+    write_to_json_file(
+        &meta_params,
+        filename_suffix,
+        this_function_name!().as_str(),
+        after_packing.as_view() == extracted_glwe.as_view(),
+        None,
+        TestResult::Empty {},
+    )
+    .unwrap();
+
     assert_eq!(after_packing.as_view(), extracted_glwe.as_view());
 }
 
 /// Test function to verify that the noise checking tools match the actual atomic patterns
 /// implemented in shortint for GPU
-fn sanity_check_encrypt_dp_ks_standard_pbs128_gpu(meta_params: MetaParameters) {
+fn sanity_check_encrypt_dp_ks_standard_pbs128_gpu(
+    meta_params: MetaParameters,
+    filename_suffix: &str,
+) {
+    write_empty_json_file(
+        &meta_params,
+        filename_suffix,
+        this_function_name!().as_str(),
+    )
+    .unwrap();
     let (params, noise_squashing_params) = {
         let meta_noise_squashing_params = meta_params.noise_squashing_parameters.unwrap();
         (
@@ -329,6 +360,16 @@ fn sanity_check_encrypt_dp_ks_standard_pbs128_gpu(meta_params: MetaParameters) {
                 .clone()
         })
         .collect();
+
+    write_to_json_file(
+        &meta_params,
+        filename_suffix,
+        this_function_name!().as_str(),
+        vector_pattern_cpu == vector_non_pattern_cpu,
+        None,
+        TestResult::Empty {},
+    )
+    .unwrap();
 
     // Compare that all the results are equivalent
     assert_eq!(vector_pattern_cpu, vector_non_pattern_cpu);
@@ -671,7 +712,16 @@ fn encrypt_dp_ks_standard_pbs128_packing_ks_noise_helper_gpu(
     )
 }
 
-fn noise_check_encrypt_dp_ks_standard_pbs128_packing_ks_noise_gpu(meta_params: MetaParameters) {
+fn noise_check_encrypt_dp_ks_standard_pbs128_packing_ks_noise_gpu(
+    meta_params: MetaParameters,
+    filename_suffix: &str,
+) {
+    write_empty_json_file(
+        &meta_params,
+        filename_suffix,
+        this_function_name!().as_str(),
+    )
+    .unwrap();
     let (atomic_params, noise_squashing_params, noise_squashing_compression_params) = {
         let meta_noise_squashing_params = meta_params.noise_squashing_parameters.unwrap();
         (
@@ -835,29 +885,49 @@ fn noise_check_encrypt_dp_ks_standard_pbs128_packing_ks_noise_gpu(meta_params: M
         .map(|x| x.value)
         .collect();
 
-    let after_packing_is_ok = mean_and_variance_check(
-        &noise_samples_after_packing_flattened,
-        "after_packing",
-        0.0,
-        after_packing_sim.variance(),
-        noise_squashing_compression_params.packing_ks_key_noise_distribution,
-        after_packing_sim.lwe_dimension(),
-        after_packing_sim.modulus().as_f64(),
-    );
+    let (after_packing_is_ok, bounded_variance_measurement, bounded_mean_measurement) =
+        mean_and_variance_check(
+            &noise_samples_after_packing_flattened,
+            "after_packing",
+            0.0,
+            after_packing_sim.variance(),
+            noise_squashing_compression_params.packing_ks_key_noise_distribution,
+            after_packing_sim.lwe_dimension(),
+            after_packing_sim.modulus().as_f64(),
+        );
+
+    let noise_check = TestResult::NoiseCheckWithoutNormalityCheck(Box::new(
+        NoiseCheckWithoutNormalityCheck::new(
+            bounded_variance_measurement,
+            bounded_mean_measurement,
+        ),
+    ));
+
+    write_to_json_file(
+        &meta_params,
+        filename_suffix,
+        this_function_name!().as_str(),
+        after_packing_is_ok,
+        None,
+        noise_check,
+    )
+    .unwrap();
 
     assert!(after_packing_is_ok);
 }
 
-create_gpu_parameterized_test!(
+create_gpu_parameterized_stringified_test!(
     noise_check_encrypt_dp_ks_standard_pbs128_packing_ks_noise_gpu {
         TEST_META_PARAM_CPU_2_2_KS_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128,
     }
 );
 
-create_gpu_parameterized_test!(sanity_check_encrypt_dp_ks_standard_pbs128_packing_ks_gpu {
-    TEST_META_PARAM_CPU_2_2_KS_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128,
-});
+create_gpu_parameterized_stringified_test!(
+    sanity_check_encrypt_dp_ks_standard_pbs128_packing_ks_gpu {
+        TEST_META_PARAM_CPU_2_2_KS_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128,
+    }
+);
 
-create_gpu_parameterized_test!(sanity_check_encrypt_dp_ks_standard_pbs128_gpu {
+create_gpu_parameterized_stringified_test!(sanity_check_encrypt_dp_ks_standard_pbs128_gpu {
     TEST_META_PARAM_CPU_2_2_KS_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128,
 });

--- a/tfhe/src/integer/gpu/server_key/radix/tests_unsigned/mod.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/tests_unsigned/mod.rs
@@ -54,9 +54,22 @@ macro_rules! create_gpu_parameterized_test{
     };
 }
 
+macro_rules! create_gpu_parameterized_stringified_test{
+    ($name:ident { $($param:ident),* $(,)? }) => {
+        ::paste::paste! {
+            $(
+            #[test]
+            fn [<test_gpu_ $name _ $param:lower>]() {
+                $name($param, stringify!($param))
+            }
+            )*
+        }
+    };
+}
+
 use crate::integer::gpu::server_key::radix::tests_signed::GpuMultiDeviceFunctionExecutor;
-pub(crate) use create_gpu_parameterized_test;
 use tfhe_csprng::seeders::Seed;
+pub(crate) use {create_gpu_parameterized_stringified_test, create_gpu_parameterized_test};
 
 pub(crate) struct GpuContext {
     pub(crate) streams: CudaStreams,

--- a/tfhe/src/shortint/server_key/tests/noise_distribution/br_dp_packingks_ms.rs
+++ b/tfhe/src/shortint/server_key/tests/noise_distribution/br_dp_packingks_ms.rs
@@ -1,4 +1,5 @@
 use super::utils::noise_simulation::*;
+use super::utils::to_json::{write_to_json_file, TestResult};
 use super::utils::traits::*;
 use super::utils::{
     expected_pfail_for_precision, mean_and_variance_check, normality_check, pfail_check,
@@ -20,9 +21,11 @@ use crate::shortint::parameters::{
     AtomicPatternParameters, CarryModulus, CiphertextModulusLog, CompressionParameters,
     MessageModulus, MetaParameters, Variance,
 };
-use crate::shortint::server_key::tests::parameterized_test::create_parameterized_test;
+use crate::shortint::server_key::tests::noise_distribution::utils::to_json::write_empty_json_file;
+use crate::shortint::server_key::tests::parameterized_test::create_parameterized_stringified_test;
 use crate::shortint::server_key::ServerKey;
 use crate::shortint::{PaddingBit, ShortintEncoding};
+use crate::this_function_name;
 use rayon::prelude::*;
 
 #[allow(clippy::too_many_arguments)]
@@ -95,7 +98,13 @@ where
     (res, packing_result, ms_result)
 }
 
-fn sanity_check_encrypt_br_dp_packing_ks_ms(meta_params: MetaParameters) {
+fn sanity_check_encrypt_br_dp_packing_ks_ms(meta_params: MetaParameters, filename_suffix: &str) {
+    write_empty_json_file(
+        &meta_params,
+        filename_suffix,
+        this_function_name!().as_str(),
+    )
+    .unwrap();
     let (params, comp_params) = (
         meta_params
             .compute_parameters
@@ -156,10 +165,22 @@ fn sanity_check_encrypt_br_dp_packing_ks_ms(meta_params: MetaParameters) {
     // Bodies that were not filled are discarded
     after_ms.get_mut_body().as_mut()[lwe_per_glwe.0..].fill(0);
 
+    let sanity_check_valid = after_ms.as_view() == extracted.as_view();
+
+    write_to_json_file(
+        &meta_params,
+        filename_suffix,
+        this_function_name!().as_str(),
+        sanity_check_valid,
+        None,
+        TestResult::Empty {},
+    )
+    .unwrap();
+
     assert_eq!(after_ms.as_view(), extracted.as_view());
 }
 
-create_parameterized_test!(sanity_check_encrypt_br_dp_packing_ks_ms {
+create_parameterized_stringified_test!(sanity_check_encrypt_br_dp_packing_ks_ms {
     TEST_META_PARAM_CPU_2_2_KS_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128,
     TEST_META_PARAM_CPU_2_2_KS32_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128,
     TEST_META_PARAM_GPU_2_2_MULTI_BIT_GROUP_4_KS_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128,
@@ -376,7 +397,16 @@ fn encrypt_br_dp_packing_ks_ms_pfail_helper(
     after_ms
 }
 
-fn noise_check_encrypt_br_dp_packing_ks_ms_noise(meta_params: MetaParameters) {
+fn noise_check_encrypt_br_dp_packing_ks_ms_noise(
+    meta_params: MetaParameters,
+    filename_suffix: &str,
+) {
+    write_empty_json_file(
+        &meta_params,
+        filename_suffix,
+        this_function_name!().as_str(),
+    )
+    .unwrap();
     let (params, comp_params) = (
         meta_params
             .compute_parameters
@@ -491,27 +521,59 @@ fn noise_check_encrypt_br_dp_packing_ks_ms_noise(meta_params: MetaParameters) {
 
     let before_ms_normality = normality_check(&noise_samples_before_ms, "before ms", 0.01);
 
-    let after_ms_is_ok = mean_and_variance_check(
-        &noise_samples_after_ms,
-        "after_ms",
-        0.0,
-        after_ms_sim.variance_per_occupied_slot(),
-        comp_params.packing_ks_key_noise_distribution(),
-        after_ms_sim
-            .glwe_dimension()
-            .to_equivalent_lwe_dimension(after_ms_sim.polynomial_size()),
-        after_ms_sim.modulus().as_f64(),
-    );
+    let (after_ms_is_ok, bounded_variance_measurement, bounded_mean_measurement) =
+        mean_and_variance_check(
+            &noise_samples_after_ms,
+            "after_ms",
+            0.0,
+            after_ms_sim.variance_per_occupied_slot(),
+            comp_params.packing_ks_key_noise_distribution(),
+            after_ms_sim
+                .glwe_dimension()
+                .to_equivalent_lwe_dimension(after_ms_sim.polynomial_size()),
+            after_ms_sim.modulus().as_f64(),
+        );
 
-    assert!(before_ms_normality.null_hypothesis_is_valid && after_ms_is_ok);
+    let before_ms_normality_valid = before_ms_normality.null_hypothesis_is_valid;
+
+    let noise_check_valid = before_ms_normality_valid && after_ms_is_ok;
+
+    let noise_check = TestResult::NoiseCheckWithNormalityCheck(Box::new(
+        super::utils::to_json::NoiseCheckWithNormalityCheck::new(
+            bounded_variance_measurement,
+            bounded_mean_measurement,
+            before_ms_normality_valid,
+        ),
+    ));
+
+    write_to_json_file(
+        &meta_params,
+        filename_suffix,
+        this_function_name!().as_str(),
+        noise_check_valid,
+        None,
+        noise_check,
+    )
+    .unwrap();
+
+    assert!(noise_check_valid);
 }
-create_parameterized_test!(noise_check_encrypt_br_dp_packing_ks_ms_noise {
+create_parameterized_stringified_test!(noise_check_encrypt_br_dp_packing_ks_ms_noise {
     TEST_META_PARAM_CPU_2_2_KS_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128,
     TEST_META_PARAM_CPU_2_2_KS32_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128,
     TEST_META_PARAM_GPU_2_2_MULTI_BIT_GROUP_4_KS_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128,
 });
 
-fn noise_check_encrypt_br_dp_packing_ks_ms_pfail(meta_params: MetaParameters) {
+fn noise_check_encrypt_br_dp_packing_ks_ms_pfail(
+    meta_params: MetaParameters,
+    filename_suffix: &str,
+) {
+    write_empty_json_file(
+        &meta_params,
+        filename_suffix,
+        this_function_name!().as_str(),
+    )
+    .unwrap();
     let (pfail_test_meta, params, comp_params) = {
         let (mut params, comp_params) = (
             meta_params
@@ -670,10 +732,16 @@ fn noise_check_encrypt_br_dp_packing_ks_ms_pfail(meta_params: MetaParameters) {
 
     let test_result = PfailTestResult { measured_fails };
 
-    pfail_check(&pfail_test_meta, test_result);
+    pfail_check(
+        &pfail_test_meta,
+        test_result,
+        &meta_params,
+        filename_suffix,
+        this_function_name!().as_str(),
+    );
 }
 
-create_parameterized_test!(noise_check_encrypt_br_dp_packing_ks_ms_pfail {
+create_parameterized_stringified_test!(noise_check_encrypt_br_dp_packing_ks_ms_pfail {
     TEST_META_PARAM_CPU_2_2_KS_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128,
     TEST_META_PARAM_CPU_2_2_KS32_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128,
     TEST_META_PARAM_GPU_2_2_MULTI_BIT_GROUP_4_KS_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128,

--- a/tfhe/src/shortint/server_key/tests/noise_distribution/br_rerand_dp_ks_ms.rs
+++ b/tfhe/src/shortint/server_key/tests/noise_distribution/br_rerand_dp_ks_ms.rs
@@ -3,6 +3,7 @@ use super::utils::noise_simulation::{
     DynLwe, DynLweSecretKeyView, NoiseSimulationGenericBootstrapKey, NoiseSimulationGlwe,
     NoiseSimulationLwe, NoiseSimulationLweKeyswitchKey, NoiseSimulationModulusSwitchConfig,
 };
+use super::utils::to_json::{write_to_json_file, TestResult};
 use super::utils::traits::*;
 use super::utils::{
     mean_and_variance_check, normality_check, pfail_check, update_ap_params_for_pfail,
@@ -39,9 +40,11 @@ use crate::shortint::parameters::{
 };
 use crate::shortint::public_key::compact::{CompactPrivateKey, CompactPublicKey};
 use crate::shortint::server_key::tests::noise_distribution::utils::noise_simulation::NoiseSimulationModulus;
-use crate::shortint::server_key::tests::parameterized_test::create_parameterized_test;
+use crate::shortint::server_key::tests::noise_distribution::utils::to_json::write_empty_json_file;
+use crate::shortint::server_key::tests::parameterized_test::create_parameterized_stringified_test;
 use crate::shortint::server_key::ServerKey;
-use crate::shortint::PaddingBit;
+use crate::shortint::{Ciphertext, PaddingBit};
+use crate::this_function_name;
 use rayon::prelude::*;
 
 #[allow(clippy::too_many_arguments)]
@@ -479,7 +482,16 @@ fn encrypt_br_rerand_dp_ks_any_ms_pfail_helper(
     after_ms
 }
 
-fn noise_check_encrypt_br_rerand_dp_ks_ms_noise(meta_params: MetaParameters) {
+fn noise_check_encrypt_br_rerand_dp_ks_ms_noise(
+    meta_params: MetaParameters,
+    filename_suffix: &str,
+) {
+    write_empty_json_file(
+        &meta_params,
+        filename_suffix,
+        this_function_name!().as_str(),
+    )
+    .unwrap();
     let (params, cpk_params, rerand_ksk_params, compression_params) = {
         let compute_params = meta_params
             .compute_parameters
@@ -669,26 +681,58 @@ fn noise_check_encrypt_br_rerand_dp_ks_ms_noise(meta_params: MetaParameters) {
 
     let before_ms_normality = normality_check(&noise_samples_before_ms, "before ms", 0.01);
 
-    let after_ms_is_ok = mean_and_variance_check(
-        &noise_samples_after_ms,
-        "after_ms",
-        expected_average_after_ms,
-        after_ms_sim.variance(),
-        params.lwe_noise_distribution(),
-        after_ms_sim.lwe_dimension(),
-        after_ms_sim.modulus().as_f64(),
-    );
+    let (after_ms_is_ok, bounded_variance_measurement, bounded_mean_measurement) =
+        mean_and_variance_check(
+            &noise_samples_after_ms,
+            "after_ms",
+            expected_average_after_ms,
+            after_ms_sim.variance(),
+            params.lwe_noise_distribution(),
+            after_ms_sim.lwe_dimension(),
+            after_ms_sim.modulus().as_f64(),
+        );
 
-    assert!(before_ms_normality.null_hypothesis_is_valid && after_ms_is_ok);
+    let before_ms_normality_valid = before_ms_normality.null_hypothesis_is_valid;
+
+    let noise_check_valid = before_ms_normality_valid && after_ms_is_ok;
+
+    let noise_check = TestResult::NoiseCheckWithNormalityCheck(Box::new(
+        super::utils::to_json::NoiseCheckWithNormalityCheck::new(
+            bounded_variance_measurement,
+            bounded_mean_measurement,
+            before_ms_normality_valid,
+        ),
+    ));
+
+    write_to_json_file(
+        &meta_params,
+        filename_suffix,
+        this_function_name!().as_str(),
+        noise_check_valid,
+        None,
+        noise_check,
+    )
+    .unwrap();
+
+    assert!(noise_check_valid);
 }
 
-create_parameterized_test!(noise_check_encrypt_br_rerand_dp_ks_ms_noise {
+create_parameterized_stringified_test!(noise_check_encrypt_br_rerand_dp_ks_ms_noise {
     TEST_META_PARAM_CPU_2_2_KS_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128,
     TEST_META_PARAM_CPU_2_2_KS32_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128,
     TEST_META_PARAM_GPU_2_2_MULTI_BIT_GROUP_4_KS_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128,
 });
 
-fn noise_check_encrypt_br_rerand_dp_ks_ms_pfail(meta_params: MetaParameters) {
+fn noise_check_encrypt_br_rerand_dp_ks_ms_pfail(
+    meta_params: MetaParameters,
+    filename_suffix: &str,
+) {
+    write_empty_json_file(
+        &meta_params,
+        filename_suffix,
+        this_function_name!().as_str(),
+    )
+    .unwrap();
     let (params, cpk_params, rerand_ksk_params, compression_params) = {
         let compute_params = meta_params
             .compute_parameters
@@ -789,16 +833,28 @@ fn noise_check_encrypt_br_rerand_dp_ks_ms_pfail(meta_params: MetaParameters) {
 
     let test_result = PfailTestResult { measured_fails };
 
-    pfail_check(&pfail_test_meta, test_result);
+    pfail_check(
+        &pfail_test_meta,
+        test_result,
+        &meta_params,
+        filename_suffix,
+        this_function_name!().as_str(),
+    );
 }
 
-create_parameterized_test!(noise_check_encrypt_br_rerand_dp_ks_ms_pfail {
+create_parameterized_stringified_test!(noise_check_encrypt_br_rerand_dp_ks_ms_pfail {
     TEST_META_PARAM_CPU_2_2_KS_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128,
     TEST_META_PARAM_CPU_2_2_KS32_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128,
     TEST_META_PARAM_GPU_2_2_MULTI_BIT_GROUP_4_KS_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128,
 });
 
-fn sanity_check_encrypt_br_rerand_dp_ks_ms_pbs(meta_params: MetaParameters) {
+fn sanity_check_encrypt_br_rerand_dp_ks_ms_pbs(meta_params: MetaParameters, filename_suffix: &str) {
+    write_empty_json_file(
+        &meta_params,
+        filename_suffix,
+        this_function_name!().as_str(),
+    )
+    .unwrap();
     let (params, cpk_params, rerand_ksk_params, compression_params) = {
         let compute_params = meta_params
             .compute_parameters
@@ -849,6 +905,8 @@ fn sanity_check_encrypt_br_rerand_dp_ks_ms_pbs(meta_params: MetaParameters) {
     let storage_modulus = comp_private_key.params.storage_log_modulus();
 
     let id_lut = sks.generate_lookup_table(|x| x);
+
+    let mut results: Vec<(DynLwe, Ciphertext)> = Vec::new();
 
     for idx in 0..10 {
         let seed_bytes = vec![idx as u8; 256 / 8];
@@ -952,11 +1010,30 @@ fn sanity_check_encrypt_br_rerand_dp_ks_ms_pbs(meta_params: MetaParameters) {
         let mut pbs_result = id_lut.allocate_lwe_bootstrap_result(&mut ());
         sks.apply_generic_blind_rotation(&after_ms, &mut pbs_result, &id_lut);
 
+        results.push((pbs_result, shortint_res));
+    }
+
+    let all_result_match = results
+        .iter()
+        .all(|(lhs, rhs)| lhs.as_lwe_64() == rhs.ct.as_view());
+
+    write_to_json_file(
+        &meta_params,
+        filename_suffix,
+        this_function_name!().as_str(),
+        all_result_match,
+        None,
+        TestResult::Empty {},
+    )
+    .unwrap();
+
+    // We check each step to preserve failure details and print the invalid case if one occurs
+    for (pbs_result, shortint_res) in results.iter() {
         assert_eq!(pbs_result.as_lwe_64(), shortint_res.ct.as_view());
     }
 }
 
-create_parameterized_test!(sanity_check_encrypt_br_rerand_dp_ks_ms_pbs {
+create_parameterized_stringified_test!(sanity_check_encrypt_br_rerand_dp_ks_ms_pbs {
     TEST_META_PARAM_CPU_2_2_KS_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128,
     TEST_META_PARAM_CPU_2_2_KS32_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128,
     TEST_META_PARAM_GPU_2_2_MULTI_BIT_GROUP_4_KS_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128,

--- a/tfhe/src/shortint/server_key/tests/noise_distribution/dp_ks_ms.rs
+++ b/tfhe/src/shortint/server_key/tests/noise_distribution/dp_ks_ms.rs
@@ -1,4 +1,5 @@
 use super::utils::noise_simulation::*;
+use super::utils::to_json::{write_to_json_file, TestResult};
 use super::utils::traits::*;
 use super::utils::{
     mean_and_variance_check, normality_check, pfail_check, update_ap_params_for_pfail,
@@ -15,8 +16,11 @@ use crate::shortint::parameters::test_params::{
     TEST_META_PARAM_GPU_2_2_MULTI_BIT_GROUP_4_KS_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128,
 };
 use crate::shortint::parameters::{AtomicPatternParameters, CarryModulus, MetaParameters};
-use crate::shortint::server_key::tests::parameterized_test::create_parameterized_test;
+use crate::shortint::server_key::tests::noise_distribution::utils::to_json::write_empty_json_file;
+use crate::shortint::server_key::tests::parameterized_test::create_parameterized_stringified_test;
 use crate::shortint::server_key::ServerKey;
+use crate::shortint::Ciphertext;
+use crate::this_function_name;
 use rayon::prelude::*;
 
 pub fn any_ms<InputCt, DriftTechniqueResult, MsResult, DriftKey, Resources>(
@@ -165,7 +169,13 @@ where
 
 /// Test function to verify that the noise checking tools match the actual atomic patterns
 /// implemented in shortint
-fn sanity_check_encrypt_dp_ks_pbs(meta_params: MetaParameters) {
+fn sanity_check_encrypt_dp_ks_pbs(meta_params: MetaParameters, filename_suffix: &str) {
+    write_empty_json_file(
+        &meta_params,
+        filename_suffix,
+        this_function_name!().as_str(),
+    )
+    .unwrap();
     let params = meta_params
         .compute_parameters
         .with_deterministic_execution();
@@ -178,6 +188,8 @@ fn sanity_check_encrypt_dp_ks_pbs(meta_params: MetaParameters) {
 
     let br_input_modulus_log = sks.br_input_modulus_log();
     let modulus_switch_config = sks.noise_simulation_modulus_switch_config();
+
+    let mut results: Vec<(DynLwe, Ciphertext)> = Vec::new();
 
     for _ in 0..10 {
         let input_zero = cks.encrypt(0);
@@ -200,11 +212,30 @@ fn sanity_check_encrypt_dp_ks_pbs(meta_params: MetaParameters) {
             sks.unchecked_scalar_mul(&input_zero, max_scalar_mul.try_into().unwrap());
         sks.apply_lookup_table_assign(&mut shortint_res, &id_lut);
 
+        results.push((pbs_result, shortint_res));
+    }
+
+    let all_result_match = results
+        .iter()
+        .all(|(lhs, rhs)| lhs.as_lwe_64() == rhs.ct.as_view());
+
+    write_to_json_file(
+        &meta_params,
+        filename_suffix,
+        this_function_name!().as_str(),
+        all_result_match,
+        None,
+        TestResult::Empty {},
+    )
+    .unwrap();
+
+    // We check each step to preserve failure details and print the invalid case if one occurs
+    for (pbs_result, shortint_res) in results.iter() {
         assert_eq!(pbs_result.as_lwe_64(), shortint_res.ct.as_view());
     }
 }
 
-create_parameterized_test!(sanity_check_encrypt_dp_ks_pbs {
+create_parameterized_stringified_test!(sanity_check_encrypt_dp_ks_pbs {
     TEST_META_PARAM_CPU_2_2_KS_PBS_GAUSSIAN_2M128,
     TEST_META_PARAM_CPU_2_2_KS_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128,
     TEST_META_PARAM_CPU_2_2_KS32_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128,
@@ -326,7 +357,13 @@ fn encrypt_dp_ks_any_ms_pfail_helper(
     after_ms
 }
 
-fn noise_check_encrypt_dp_ks_ms_noise(meta_params: MetaParameters) {
+fn noise_check_encrypt_dp_ks_ms_noise(meta_params: MetaParameters, filename_suffix: &str) {
+    write_empty_json_file(
+        &meta_params,
+        filename_suffix,
+        this_function_name!().as_str(),
+    )
+    .unwrap();
     let params = meta_params
         .compute_parameters
         .with_deterministic_execution();
@@ -404,27 +441,56 @@ fn noise_check_encrypt_dp_ks_ms_noise(meta_params: MetaParameters) {
 
     let before_ms_normality = normality_check(&noise_samples_before_ms, "before ms", 0.01);
 
-    let after_ms_is_ok = mean_and_variance_check(
-        &noise_samples_after_ms,
-        "after_ms",
-        expected_average_after_ms,
-        after_ms_sim.variance(),
-        params.lwe_noise_distribution(),
-        after_ms_sim.lwe_dimension(),
-        after_ms_sim.modulus().as_f64(),
-    );
+    let (after_ms_is_ok, bounded_variance_measurement, bounded_mean_measurement) =
+        mean_and_variance_check(
+            &noise_samples_after_ms,
+            "after_ms",
+            expected_average_after_ms,
+            after_ms_sim.variance(),
+            params.lwe_noise_distribution(),
+            after_ms_sim.lwe_dimension(),
+            after_ms_sim.modulus().as_f64(),
+        );
 
-    assert!(before_ms_normality.null_hypothesis_is_valid && after_ms_is_ok);
+    let before_ms_normality_valid = before_ms_normality.null_hypothesis_is_valid;
+
+    let noise_check_valid = before_ms_normality_valid && after_ms_is_ok;
+
+    let noise_check = TestResult::NoiseCheckWithNormalityCheck(Box::new(
+        super::utils::to_json::NoiseCheckWithNormalityCheck::new(
+            bounded_variance_measurement,
+            bounded_mean_measurement,
+            before_ms_normality_valid,
+        ),
+    ));
+
+    write_to_json_file(
+        &meta_params,
+        filename_suffix,
+        this_function_name!().as_str(),
+        noise_check_valid,
+        None,
+        noise_check,
+    )
+    .unwrap();
+
+    assert!(noise_check_valid);
 }
 
-create_parameterized_test!(noise_check_encrypt_dp_ks_ms_noise {
+create_parameterized_stringified_test!(noise_check_encrypt_dp_ks_ms_noise {
     TEST_META_PARAM_CPU_2_2_KS_PBS_GAUSSIAN_2M128,
     TEST_META_PARAM_CPU_2_2_KS_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128,
     TEST_META_PARAM_CPU_2_2_KS32_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128,
     TEST_META_PARAM_GPU_2_2_MULTI_BIT_GROUP_4_KS_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128,
 });
 
-fn noise_check_encrypt_dp_ks_ms_pfail(meta_params: MetaParameters) {
+fn noise_check_encrypt_dp_ks_ms_pfail(meta_params: MetaParameters, filename_suffix: &str) {
+    write_empty_json_file(
+        &meta_params,
+        filename_suffix,
+        this_function_name!().as_str(),
+    )
+    .unwrap();
     let (pfail_test_meta, params) = {
         let mut ap_params = meta_params
             .compute_parameters
@@ -483,10 +549,16 @@ fn noise_check_encrypt_dp_ks_ms_pfail(meta_params: MetaParameters) {
 
     let test_result = PfailTestResult { measured_fails };
 
-    pfail_check(&pfail_test_meta, test_result);
+    pfail_check(
+        &pfail_test_meta,
+        test_result,
+        &meta_params,
+        filename_suffix,
+        this_function_name!().as_str(),
+    );
 }
 
-create_parameterized_test!(noise_check_encrypt_dp_ks_ms_pfail {
+create_parameterized_stringified_test!(noise_check_encrypt_dp_ks_ms_pfail {
     TEST_META_PARAM_CPU_2_2_KS_PBS_GAUSSIAN_2M128,
     TEST_META_PARAM_CPU_2_2_KS_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128,
     TEST_META_PARAM_CPU_2_2_KS32_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128,

--- a/tfhe/src/shortint/server_key/tests/noise_distribution/utils/mod.rs
+++ b/tfhe/src/shortint/server_key/tests/noise_distribution/utils/mod.rs
@@ -1,4 +1,5 @@
 pub mod noise_simulation;
+pub mod to_json;
 pub mod traits;
 
 use crate::core_crypto::algorithms::glwe_encryption::decrypt_glwe_ciphertext;
@@ -35,10 +36,15 @@ use crate::core_crypto::entities::lwe_secret_key::LweSecretKey;
 use crate::core_crypto::entities::{Cleartext, Plaintext, PlaintextList};
 use crate::shortint::encoding::ShortintEncoding;
 use crate::shortint::parameters::{
-    AtomicPatternParameters, CarryModulus, MessageModulus, PBSParameters,
+    AtomicPatternParameters, CarryModulus, MessageModulus, MetaParameters, PBSParameters,
 };
 use crate::shortint::server_key::tests::noise_distribution::utils::noise_simulation::{
     DynLwe, DynLweSecretKeyView, DynModSwitchedLwe, DynStandardMultiBitModulusSwitchedCt,
+};
+use crate::shortint::server_key::tests::noise_distribution::utils::to_json::{
+    write_to_json_file, BoundedLog2Measurement, BoundedMeasurement, ConfidenceInterval,
+    ConfidenceIntervalWithLog2, Measurement, NoBounds, PfailMetadata, PfailTestResultJson,
+    StringConfidenceInterval, StringConfidenceIntervalWithLog2, ValueWithLog2,
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -71,7 +77,7 @@ pub fn mean_and_variance_check<Scalar: UnsignedInteger>(
     noise_distribution_used_for_encryption: DynamicDistribution<Scalar>,
     decryption_key_lwe_dimension: LweDimension,
     modulus_as_f64: f64,
-) -> bool {
+) -> (bool, BoundedMeasurement, BoundedMeasurement) {
     assert!(expected_mean.is_finite(), "Expected mean is infinite");
     assert!(
         expected_variance.0.is_finite(),
@@ -100,6 +106,29 @@ pub fn mean_and_variance_check<Scalar: UnsignedInteger>(
     println!("expected_mean_{suffix}={expected_mean:?}");
     println!("mean_{suffix}_lower_bound={:?}", mean_ci.lower_bound());
     println!("mean_{suffix}_upper_bound={:?}", mean_ci.upper_bound());
+
+    let bounded_variance_measurement = BoundedMeasurement::new(
+        measured_variance.0.to_string(),
+        expected_variance.0.to_string(),
+        ConfidenceInterval::Bounded(
+            StringConfidenceInterval::builder()
+                .lower(variance_ci.lower_bound().0.to_string())
+                .upper(variance_ci.upper_bound().0.to_string())
+                .build()
+                .unwrap(),
+        ),
+    );
+    let bounded_mean_measurement = BoundedMeasurement::new(
+        measured_mean.to_string(),
+        expected_mean.to_string(),
+        ConfidenceInterval::Bounded(
+            StringConfidenceInterval::builder()
+                .lower(mean_ci.lower_bound().to_string())
+                .upper(mean_ci.upper_bound().to_string())
+                .build()
+                .unwrap(),
+        ),
+    );
 
     // Expected mean is 0
     let mean_is_in_interval = mean_ci.mean_is_in_interval(expected_mean);
@@ -168,7 +197,11 @@ pub fn mean_and_variance_check<Scalar: UnsignedInteger>(
         interval_ok
     };
 
-    mean_is_in_interval && variance_is_ok
+    (
+        mean_is_in_interval && variance_is_ok,
+        bounded_variance_measurement,
+        bounded_mean_measurement,
+    )
 }
 
 pub fn encrypt_new_noiseless_lwe<
@@ -260,6 +293,21 @@ impl PfailTestMeta {
         }
     }
 
+    pub fn generate_serializable_data(self) -> PfailMetadata {
+        PfailMetadata::new(
+            ValueWithLog2::new(
+                self.original_pfail_and_precision.pfail().to_string(),
+                self.original_pfail_and_precision.pfail().log2().to_string(),
+            ),
+            ValueWithLog2::new(
+                self.new_pfail_and_precision.pfail().to_string(),
+                self.new_pfail_and_precision.pfail().log2().to_string(),
+            ),
+            self.expected_fails.to_string(),
+            self.total_runs_for_expected_fails.to_string(),
+        )
+    }
+
     pub fn new_with_total_runs(
         original_pfail_and_precision: PfailAndPrecision,
         new_pfail_and_precision: PfailAndPrecision,
@@ -298,7 +346,13 @@ pub struct PfailTestResult {
     pub measured_fails: f64,
 }
 
-pub fn pfail_check(pfail_test_meta: &PfailTestMeta, pfail_test_result: PfailTestResult) {
+pub fn pfail_check(
+    pfail_test_meta: &PfailTestMeta,
+    pfail_test_result: PfailTestResult,
+    param_name: &MetaParameters,
+    test_name: &str,
+    test_module_path: &str,
+) {
     let measured_fails = pfail_test_result.measured_fails;
     let total_runs_for_expected_fails = pfail_test_meta.total_runs_for_expected_fails;
     let expected_fails = pfail_test_meta.expected_fails();
@@ -334,6 +388,54 @@ pub fn pfail_check(pfail_test_meta: &PfailTestMeta, pfail_test_result: PfailTest
     );
     println!("original_expected_pfail_log2  ={}", original_pfail.log2());
 
+    let pfail_meta_serialized = pfail_test_meta.generate_serializable_data();
+
+    let fails_serialized = Measurement::new(measured_fails.to_string(), expected_fails.to_string());
+
+    let pfail_serialized_closure = |confidence_interval: ConfidenceInterval| {
+        BoundedMeasurement::new(
+            measured_pfail.to_string(),
+            expected_pfail.to_string(),
+            confidence_interval,
+        )
+    };
+
+    let pfail_original_serialized_closure =
+        |confidence_interval_with_log2: ConfidenceIntervalWithLog2| {
+            BoundedLog2Measurement::new(
+                ValueWithLog2::new(
+                    equivalent_measured_pfail.to_string(),
+                    equivalent_measured_pfail.log2().to_string(),
+                ),
+                ValueWithLog2::new(
+                    original_pfail.to_string(),
+                    original_pfail.log2().to_string(),
+                ),
+                confidence_interval_with_log2,
+            )
+        };
+
+    let write_json = |warning: Option<String>,
+                      pass: bool,
+                      pfail_serialized: BoundedMeasurement,
+                      pfail_original_serialized: BoundedLog2Measurement| {
+        write_to_json_file(
+            param_name,
+            test_name,
+            test_module_path,
+            pass,
+            warning,
+            PfailTestResultJson::new(
+                pfail_meta_serialized.clone(),
+                fails_serialized.clone(),
+                pfail_serialized,
+                pfail_original_serialized,
+            )
+            .into_test_result(),
+        )
+        .unwrap();
+    };
+
     if measured_fails > 0.0 {
         let pfail_confidence_interval = pfail_clopper_pearson_exact_confidence_interval(
             total_runs_for_expected_fails as f64,
@@ -343,8 +445,6 @@ pub fn pfail_check(pfail_test_meta: &PfailTestMeta, pfail_test_result: PfailTest
 
         let pfail_lower_bound = pfail_confidence_interval.lower_bound();
         let pfail_upper_bound = pfail_confidence_interval.upper_bound();
-        println!("pfail_lower_bound={pfail_lower_bound}");
-        println!("pfail_upper_bound={pfail_upper_bound}");
 
         let equivalent_pfail_lower_bound = equivalent_pfail_gaussian_noise(
             new_precision_with_padding.value,
@@ -357,6 +457,29 @@ pub fn pfail_check(pfail_test_meta: &PfailTestMeta, pfail_test_result: PfailTest
             original_precision_with_padding.value,
         );
 
+        let confidence_interval = ConfidenceInterval::Bounded(
+            StringConfidenceInterval::builder()
+                .lower(pfail_lower_bound.to_string())
+                .upper(pfail_upper_bound.to_string())
+                .build()
+                .unwrap(),
+        );
+        let confidence_interval_with_log2 = ConfidenceIntervalWithLog2::Bounded(
+            StringConfidenceIntervalWithLog2::builder()
+                .lower(ValueWithLog2::new(
+                    equivalent_pfail_lower_bound.to_string(),
+                    equivalent_pfail_lower_bound.log2().to_string(),
+                ))
+                .upper(ValueWithLog2::new(
+                    equivalent_pfail_upper_bound.to_string(),
+                    equivalent_pfail_upper_bound.log2().to_string(),
+                ))
+                .build()
+                .unwrap(),
+        );
+        println!("pfail_lower_bound={pfail_lower_bound}");
+        println!("pfail_upper_bound={pfail_upper_bound}");
+
         println!("equivalent_pfail_lower_bound={equivalent_pfail_lower_bound}");
         println!("equivalent_pfail_upper_bound={equivalent_pfail_upper_bound}");
         println!(
@@ -368,29 +491,58 @@ pub fn pfail_check(pfail_test_meta: &PfailTestMeta, pfail_test_result: PfailTest
             equivalent_pfail_upper_bound.log2()
         );
 
+        let pfail_serialized = pfail_serialized_closure(confidence_interval);
+        let pfail_original_serialized =
+            pfail_original_serialized_closure(confidence_interval_with_log2);
+
         if measured_pfail <= expected_pfail {
+            let mut warning = None;
             if !pfail_confidence_interval.mean_is_in_interval(expected_pfail) {
-                println!(
-                    "\n==========\n\
-                    WARNING: measured pfail is smaller than expected pfail \
-                    and out of the confidence interval\n\
-                    the optimizer might be pessimistic when generating parameters.\n\
-                    ==========\n"
-                );
+                let warning_raw = "measured pfail is smaller than expected pfail \
+                    and out of the confidence interval. \n\
+                    the optimizer might be pessimistic when generating parameters.";
+                let warning_message = format_warning_message(warning_raw);
+                warning = Some(format_json_warning_message(warning_raw));
+                println!("{warning_message}");
             }
+            write_json(warning, true, pfail_serialized, pfail_original_serialized)
         } else {
-            assert!(pfail_confidence_interval.mean_is_in_interval(expected_pfail));
+            let cond = pfail_confidence_interval.mean_is_in_interval(expected_pfail);
+            write_json(None, cond, pfail_serialized, pfail_original_serialized);
+            assert!(cond);
         }
     } else {
-        println!(
-            "\n==========\n\
-            WARNING: measured pfail is 0, it is either a bug or \
-            it is way smaller than the expected pfail\n\
+        let confidence_interval = ConfidenceInterval::NoBounds(NoBounds::new(
+            "Unable to compute bounds, 0 fails measured",
+        ));
+        let confidence_interval_with_log2 = ConfidenceIntervalWithLog2::NoBounds(NoBounds::new(
+            "Unable to compute bounds, 0 fails measured",
+        ));
+        let warning_raw = "measured pfail is 0, it is either a bug or \
+            it is way smaller than the expected pfail. \n\
             the optimizer might be pessimistic when generating parameters, \
-            or some hypothesis does not hold.\n\
-            ==========\n"
+            or some hypothesis does not hold.";
+        let warning = format_warning_message(warning_raw);
+        write_json(
+            Some(format_json_warning_message(warning_raw)),
+            true,
+            pfail_serialized_closure(confidence_interval),
+            pfail_original_serialized_closure(confidence_interval_with_log2),
         );
+        println!("{warning}");
     }
+}
+
+fn format_json_warning_message(m: &str) -> String {
+    m.replace(['\n', '\\'], "")
+}
+
+fn format_warning_message(to_print: &str) -> String {
+    format!(
+        "\n==========\n\
+    WARNING: {to_print}\n\
+    ==========\n"
+    )
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -623,7 +775,7 @@ pub fn update_ap_params_for_pfail(
     new_message_modulus: MessageModulus,
     new_carry_modulus: CarryModulus,
 ) -> (PfailAndPrecision, PfailAndPrecision) {
-    let orig_pfail_and_precision = PfailAndPrecision::new_from_ap_params(&*ap_params);
+    let orig_pfail_and_precision = PfailAndPrecision::new_from_ap_params(ap_params);
 
     println!("original_pfail: {}", orig_pfail_and_precision.pfail());
     println!(

--- a/tfhe/src/shortint/server_key/tests/noise_distribution/utils/to_json.rs
+++ b/tfhe/src/shortint/server_key/tests/noise_distribution/utils/to_json.rs
@@ -1,0 +1,363 @@
+use crate::shortint::parameters::MetaParameters;
+use serde::Serialize;
+use std::fs;
+use std::path::PathBuf;
+
+#[derive(Serialize)]
+#[serde(untagged)] // https://serde.rs/enum-representations.html#untagged
+pub enum TestResult {
+    NoiseCheckWithNormalityCheck(Box<NoiseCheckWithNormalityCheck>),
+    NoiseCheckWithoutNormalityCheck(Box<NoiseCheckWithoutNormalityCheck>),
+    PfailTestResultJson(Box<PfailTestResultJson>),
+    Empty {},
+}
+
+/// String is used to make it easier to parse from other languages like js
+#[derive(Serialize, Clone)]
+pub struct Measurement {
+    measured: String,
+    expected: String,
+}
+
+impl Measurement {
+    pub fn new(measured: String, expected: String) -> Self {
+        Self { measured, expected }
+    }
+}
+
+#[derive(Serialize, Clone)]
+pub struct Log2Measurement {
+    measured: ValueWithLog2,
+    expected: ValueWithLog2,
+}
+
+impl Log2Measurement {
+    pub fn new(measured: ValueWithLog2, expected: ValueWithLog2) -> Self {
+        Self { measured, expected }
+    }
+}
+
+#[derive(Serialize, Clone)]
+#[serde(untagged)] // https://serde.rs/enum-representations.html#untagged
+pub enum ConfidenceInterval {
+    Bounded(StringConfidenceInterval),
+    NoBounds(NoBounds),
+}
+
+#[derive(Serialize, Clone)]
+pub struct StringConfidenceInterval {
+    lower: String,
+    upper: String,
+}
+
+pub struct StringConfidenceIntervalBuilder {
+    lower: Option<String>,
+    upper: Option<String>,
+}
+
+impl StringConfidenceInterval {
+    pub fn builder() -> StringConfidenceIntervalBuilder {
+        StringConfidenceIntervalBuilder {
+            lower: None,
+            upper: None,
+        }
+    }
+}
+
+impl StringConfidenceIntervalBuilder {
+    pub fn lower(mut self, lower: String) -> Self {
+        self.lower = Some(lower);
+        self
+    }
+
+    pub fn upper(mut self, upper: String) -> Self {
+        self.upper = Some(upper);
+        self
+    }
+
+    pub fn build(self) -> Result<StringConfidenceInterval, &'static str> {
+        match (self.lower, self.upper) {
+            (Some(lower), Some(upper)) => Ok(StringConfidenceInterval { lower, upper }),
+            _ => Err("Both lower and upper bounds must be set"),
+        }
+    }
+}
+
+#[derive(Serialize, Clone)]
+pub struct NoBounds {
+    reason: String,
+}
+
+impl NoBounds {
+    pub fn new(reason: &str) -> Self {
+        Self {
+            reason: reason.to_string(),
+        }
+    }
+}
+
+/// String is used to make it easier to parse from other languages like js
+#[derive(Serialize, Clone)]
+pub struct BoundedMeasurement {
+    value: Measurement,
+    confidence_interval: ConfidenceInterval,
+}
+
+impl BoundedMeasurement {
+    pub fn new(
+        measured: String,
+        expected: String,
+        confidence_interval: ConfidenceInterval,
+    ) -> Self {
+        Self {
+            value: Measurement::new(measured, expected),
+            confidence_interval,
+        }
+    }
+}
+
+#[derive(Serialize, Clone)]
+#[serde(untagged)] // untagged removed useless precision of the enum in the json file
+pub enum ConfidenceIntervalWithLog2 {
+    Bounded(StringConfidenceIntervalWithLog2),
+    NoBounds(NoBounds),
+}
+
+#[derive(Serialize, Clone)]
+pub struct StringConfidenceIntervalWithLog2 {
+    lower: ValueWithLog2,
+    upper: ValueWithLog2,
+}
+
+#[derive(Serialize)]
+pub struct StringConfidenceIntervalWithLog2Builder {
+    lower: Option<ValueWithLog2>,
+    upper: Option<ValueWithLog2>,
+}
+
+impl StringConfidenceIntervalWithLog2 {
+    pub fn builder() -> StringConfidenceIntervalWithLog2Builder {
+        StringConfidenceIntervalWithLog2Builder {
+            lower: None,
+            upper: None,
+        }
+    }
+}
+
+impl StringConfidenceIntervalWithLog2Builder {
+    pub fn lower(mut self, lower: ValueWithLog2) -> Self {
+        self.lower = Some(lower);
+        self
+    }
+
+    pub fn upper(mut self, upper: ValueWithLog2) -> Self {
+        self.upper = Some(upper);
+        self
+    }
+
+    pub fn build(self) -> Result<StringConfidenceIntervalWithLog2, &'static str> {
+        match (self.lower, self.upper) {
+            (Some(lower), Some(upper)) => Ok(StringConfidenceIntervalWithLog2 { lower, upper }),
+            _ => Err("Both lower and upper bounds must be set"),
+        }
+    }
+}
+
+#[derive(Serialize, Clone)]
+pub struct BoundedLog2Measurement {
+    value: Log2Measurement,
+    confidence_interval: ConfidenceIntervalWithLog2,
+}
+
+impl BoundedLog2Measurement {
+    pub fn new(
+        measured: ValueWithLog2,
+        expected: ValueWithLog2,
+        confidence_interval: ConfidenceIntervalWithLog2,
+    ) -> Self {
+        Self {
+            value: Log2Measurement::new(measured, expected),
+            confidence_interval,
+        }
+    }
+}
+
+/// String is used to make it easier to parse from other languages like js
+#[derive(Serialize, Clone)]
+pub struct ValueWithLog2 {
+    raw: String,
+    log2: String,
+}
+
+impl ValueWithLog2 {
+    pub fn new(raw: String, log2: String) -> Self {
+        Self { raw, log2 }
+    }
+}
+
+#[derive(Serialize)]
+pub struct NoiseCheckWithNormalityCheck {
+    after_ms_variance: BoundedMeasurement,
+    after_ms_mean: BoundedMeasurement,
+    before_ms_normality_check: bool,
+}
+
+impl NoiseCheckWithNormalityCheck {
+    pub fn new(
+        variance: BoundedMeasurement,
+        mean: BoundedMeasurement,
+        normality_check: bool,
+    ) -> Self {
+        Self {
+            after_ms_variance: variance,
+            after_ms_mean: mean,
+            before_ms_normality_check: normality_check,
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub struct NoiseCheckWithoutNormalityCheck {
+    after_ms_variance: BoundedMeasurement,
+    after_ms_mean: BoundedMeasurement,
+}
+
+impl NoiseCheckWithoutNormalityCheck {
+    pub fn new(variance: BoundedMeasurement, mean: BoundedMeasurement) -> Self {
+        Self {
+            after_ms_variance: variance,
+            after_ms_mean: mean,
+        }
+    }
+}
+
+#[derive(Serialize, Clone)]
+pub struct PfailMetadata {
+    pfail_with_original_precision: ValueWithLog2,
+    pfail_with_test_precision: ValueWithLog2,
+    expected_fails_with_test_precision: String,
+    total_runs: String,
+}
+
+impl PfailMetadata {
+    pub fn new(
+        pfail_with_original_precision: ValueWithLog2,
+        pfail_with_test_precision: ValueWithLog2,
+        expected_fails_with_test_precision: String,
+        total_runs: String,
+    ) -> Self {
+        Self {
+            pfail_with_original_precision,
+            pfail_with_test_precision,
+            expected_fails_with_test_precision,
+            total_runs,
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub struct PfailTestResultJson {
+    pfail_parameters: PfailMetadata,
+    fails: Measurement,
+    pfail_with_test_precision: BoundedMeasurement,
+    equivalent_pfail_with_original_precision: BoundedLog2Measurement,
+}
+
+impl PfailTestResultJson {
+    pub fn new(
+        pfail_parameters: PfailMetadata,
+        fails: Measurement,
+        pfail_with_test_precision: BoundedMeasurement,
+        equivalent_pfail_with_original_precision: BoundedLog2Measurement,
+    ) -> Self {
+        Self {
+            pfail_parameters,
+            fails,
+            pfail_with_test_precision,
+            equivalent_pfail_with_original_precision,
+        }
+    }
+
+    pub fn into_test_result(self) -> TestResult {
+        TestResult::PfailTestResultJson(Box::new(self))
+    }
+}
+
+#[derive(Serialize)]
+struct TestJsonOutput<'a> {
+    test: &'a str,
+    name: &'a str,
+    pass: bool,
+    warning: Option<String>,
+    parameters: &'a MetaParameters,
+    results: TestResult,
+}
+
+impl<'a> TestJsonOutput<'a> {
+    pub fn new(
+        test: &'a str,
+        name: &'a str,
+        pass: bool,
+        warning: Option<String>,
+        parameters: &'a MetaParameters,
+        results: TestResult,
+    ) -> Self {
+        Self {
+            test,
+            name,
+            pass,
+            warning,
+            parameters,
+            results,
+        }
+    }
+}
+
+/// Returns the name of the function from which it is called.
+#[macro_export]
+macro_rules! this_function_name {
+    () => {{
+        struct Local;
+        let name = std::any::type_name::<Local>();
+        let first = name.split("::").nth(1).unwrap_or(name);
+        let before_last = name.rsplit("::").nth(1).unwrap_or(name);
+        format!("{}::{}", first, before_last)
+    }};
+}
+
+pub fn write_empty_json_file(
+    meta_param: &MetaParameters,
+    test_name: &str,
+    test_module_path: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    write_to_json_file(
+        meta_param,
+        test_name,
+        test_module_path,
+        false,
+        None,
+        TestResult::Empty {},
+    )
+}
+
+pub fn write_to_json_file(
+    meta_param: &MetaParameters,
+    test_name: &str,
+    test_module_path: &str,
+    pass: bool,
+    warning: Option<String>,
+    results: TestResult,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let test_id = format!("{test_module_path}::{test_name}").to_lowercase();
+    let short_name = test_module_path
+        .rsplit_once("::")
+        .map_or(test_module_path, |(_, p)| p);
+    let output_data = TestJsonOutput::new(&test_id, short_name, pass, warning, meta_param, results);
+    let serialized_output = serde_json::to_string_pretty(&output_data)?;
+    let mut path = PathBuf::new();
+    path.push("tests_results");
+    fs::create_dir_all(&path)?;
+    path.push(format!("{test_id}.json"));
+    fs::write(&path, serialized_output)?;
+    Ok(())
+}

--- a/tfhe/src/shortint/server_key/tests/parameterized_test.rs
+++ b/tfhe/src/shortint/server_key/tests/parameterized_test.rs
@@ -61,6 +61,19 @@ macro_rules! create_parameterized_test{
     };
 }
 
+macro_rules! create_parameterized_stringified_test{
+    ($name:ident { $($param:ident),* $(,)? }) => {
+        ::paste::paste! {
+            $(
+            #[test]
+            fn [<test_ $name _ $param:lower>]() {
+                $name($param, stringify!($param))
+            }
+            )*
+        }
+    };
+}
+
 // Test against a small subset of parameters to speed up coverage tests
 #[cfg(tarpaulin)]
 macro_rules! create_parameterized_test{
@@ -84,7 +97,7 @@ macro_rules! create_parameterized_test{
     };
 }
 
-pub(crate) use create_parameterized_test;
+pub(crate) use {create_parameterized_stringified_test, create_parameterized_test};
 
 //These functions are compatible with all parameter sets.
 create_parameterized_test!(shortint_encrypt_decrypt);


### PR DESCRIPTION
Added the possibility to generate a JSON file as output for the noise distribution test.
[json example](https://github.com/user-attachments/files/25185353/shortint.noise_check_encrypt_dp_ks_ms_pfail.test_meta_param_cpu_2_2_ks_pbs_gaussian_2m128.json)

This was implemented in a defensive way by generating an empty JSON file with all preconditions set to false.
For meaningful conditions, the JSON contains detailed information, with the possibility of printing warnings.

All new types always use strings as values to avoid parsing issues in other languages, such as JavaScript.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3269)
<!-- Reviewable:end -->
