### PR TITLE
chore(ci): add runs-on configuration file

### DIFF
--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -1,0 +1,15 @@
+runners:
+  cpu-big:
+    family: m6i.32xlarge
+    image: cpu-tests-eu-west-3
+    volume: 200gb
+    spot: false
+  cpu-small:
+    family: m6i.4xlarge
+    image: cpu-tests-eu-west-3
+    volume: 200gb
+    spot: false
+
+images:
+  cpu-tests-eu-west-3:
+    ami: "ami-0a786ffdb1411fac4"  # Ubuntu 24.04


### PR DESCRIPTION
This is done before migrating the CI running on AWS to avoid inline runs-on configuration in each workflow file.

Runs-on rely on the presence of this file in the default branch. So it means any change must be merged into `main` before getting effective.