### PR TITLE
chore: revert backward compatibility change

### DIFF
--- a/tfhe-benchmark/benches/integer/rerand.rs
+++ b/tfhe-benchmark/benches/integer/rerand.rs
@@ -197,10 +197,10 @@ mod cuda {
     use tfhe::integer::ciphertext::ReRandomizationContext;
     use tfhe::integer::gpu::ciphertext::compressed_ciphertext_list::CudaCompressedCiphertextListBuilder;
     use tfhe::integer::gpu::ciphertext::{CudaIntegerRadixCiphertext, CudaUnsignedRadixCiphertext};
+    use tfhe::integer::gpu::key_switching_key::CudaKeySwitchingKeyMaterial;
     use tfhe::integer::key_switching_key::KeySwitchingKey;
     use tfhe::integer::{gen_keys_radix, CompactPrivateKey, CompactPublicKey};
     use tfhe::keycache::NamedParam;
-    use tfhe::shortint::key_switching_key::CudaKeySwitchingKeyMaterial;
 
     fn execute_gpu_re_randomize(c: &mut Criterion, bit_size: usize) {
         let bench_name = "integer::cuda::re_randomize";

--- a/tfhe/src/high_level_api/backward_compatibility/keys.rs
+++ b/tfhe/src/high_level_api/backward_compatibility/keys.rs
@@ -536,8 +536,8 @@ pub enum KeySwitchingKeyVersions {
 }
 
 #[derive(VersionsDispatch)]
-pub enum ReRandomizationKeySwitchingKeyVersions<KSK> {
-    V0(ReRandomizationKeySwitchingKey<KSK>),
+pub enum ReRandomizationKeySwitchingKeyVersions {
+    V0(ReRandomizationKeySwitchingKey),
 }
 
 #[derive(VersionsDispatch)]

--- a/tfhe/src/high_level_api/keys/cpk_re_randomization.rs
+++ b/tfhe/src/high_level_api/keys/cpk_re_randomization.rs
@@ -17,9 +17,9 @@ pub(crate) enum ReRandomizationKeyGenerationInfo<'a> {
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Versionize)]
 #[versionize(ReRandomizationKeySwitchingKeyVersions)]
-pub enum ReRandomizationKeySwitchingKey<KSK> {
+pub enum ReRandomizationKeySwitchingKey {
     UseCPKEncryptionKSK,
-    DedicatedKSK(KSK),
+    DedicatedKSK(crate::integer::key_switching_key::KeySwitchingKeyMaterial),
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Versionize)]
@@ -30,10 +30,7 @@ pub enum CompressedReRandomizationKeySwitchingKey {
 }
 
 impl CompressedReRandomizationKeySwitchingKey {
-    pub fn decompress(
-        &self,
-    ) -> ReRandomizationKeySwitchingKey<crate::integer::key_switching_key::KeySwitchingKeyMaterial>
-    {
+    pub fn decompress(&self) -> ReRandomizationKeySwitchingKey {
         match self {
             Self::UseCPKEncryptionKSK => ReRandomizationKeySwitchingKey::UseCPKEncryptionKSK,
             Self::DedicatedKSK(compressed_key_switching_key_material) => {
@@ -43,4 +40,10 @@ impl CompressedReRandomizationKeySwitchingKey {
             }
         }
     }
+}
+
+#[cfg(feature = "gpu")]
+pub(crate) enum CudaReRandomizationKeySwitchingKey {
+    UseCPKEncryptionKSK,
+    DedicatedKSK(crate::integer::gpu::key_switching_key::CudaKeySwitchingKeyMaterial),
 }

--- a/tfhe/src/high_level_api/keys/expanded.rs
+++ b/tfhe/src/high_level_api/keys/expanded.rs
@@ -38,9 +38,7 @@ pub struct IntegerExpandedServerKey {
     pub decompression_key: Option<ExpandedDecompressionKey>,
     pub noise_squashing_key: Option<ExpandedNoiseSquashingKey>,
     pub noise_squashing_compression_key: Option<NoiseSquashingCompressionKey>,
-    pub cpk_re_randomization_key_switching_key_material: Option<
-        ReRandomizationKeySwitchingKey<crate::integer::key_switching_key::KeySwitchingKeyMaterial>,
-    >,
+    pub cpk_re_randomization_key_switching_key_material: Option<ReRandomizationKeySwitchingKey>,
 }
 
 impl IntegerExpandedServerKey {
@@ -154,7 +152,9 @@ impl IntegerExpandedServerKey {
         &self,
         streams: &crate::core_crypto::gpu::CudaStreams,
     ) -> crate::Result<crate::high_level_api::keys::inner::IntegerCudaServerKey> {
-        use crate::high_level_api::keys::cpk_re_randomization::ReRandomizationKeySwitchingKey;
+        use crate::high_level_api::keys::cpk_re_randomization::{
+            CudaReRandomizationKeySwitchingKey, ReRandomizationKeySwitchingKey,
+        };
         use crate::integer::gpu::key_switching_key::CudaKeySwitchingKeyMaterial;
         use crate::integer::gpu::list_compression::server_keys::{
             CudaCompressionKey, CudaDecompressionKey, CudaNoiseSquashingCompressionKey,
@@ -214,10 +214,10 @@ impl IntegerExpandedServerKey {
                 .as_ref()
                 .map(|re_rand_ksk| match re_rand_ksk {
                     ReRandomizationKeySwitchingKey::UseCPKEncryptionKSK => {
-                        ReRandomizationKeySwitchingKey::UseCPKEncryptionKSK
+                        CudaReRandomizationKeySwitchingKey::UseCPKEncryptionKSK
                     }
                     ReRandomizationKeySwitchingKey::DedicatedKSK(ksk) => {
-                        ReRandomizationKeySwitchingKey::DedicatedKSK(
+                        CudaReRandomizationKeySwitchingKey::DedicatedKSK(
                             CudaKeySwitchingKeyMaterial::from_key_switching_key_material(
                                 &ksk.as_view(),
                                 streams,

--- a/tfhe/src/high_level_api/keys/inner.rs
+++ b/tfhe/src/high_level_api/keys/inner.rs
@@ -353,9 +353,8 @@ pub struct IntegerServerKey {
     pub(crate) decompression_key: Option<DecompressionKey>,
     pub(crate) noise_squashing_key: Option<NoiseSquashingKey>,
     pub(crate) noise_squashing_compression_key: Option<NoiseSquashingCompressionKey>,
-    pub(crate) cpk_re_randomization_key_switching_key_material: Option<
-        ReRandomizationKeySwitchingKey<crate::integer::key_switching_key::KeySwitchingKeyMaterial>,
-    >,
+    pub(crate) cpk_re_randomization_key_switching_key_material:
+        Option<ReRandomizationKeySwitchingKey>,
 }
 
 impl IntegerServerKey {
@@ -478,7 +477,6 @@ impl IntegerServerKey {
 #[cfg(feature = "gpu")]
 pub struct IntegerCudaServerKey {
     pub(crate) key: crate::integer::gpu::CudaServerKey,
-    #[allow(dead_code)]
     pub(crate) cpk_key_switching_key_material:
         Option<crate::integer::gpu::key_switching_key::CudaKeySwitchingKeyMaterial>,
     pub(crate) compression_key:
@@ -491,9 +489,7 @@ pub struct IntegerCudaServerKey {
         crate::integer::gpu::list_compression::server_keys::CudaNoiseSquashingCompressionKey,
     >,
     pub(crate) cpk_re_randomization_key_switching_key_material: Option<
-        ReRandomizationKeySwitchingKey<
-            crate::integer::gpu::key_switching_key::CudaKeySwitchingKeyMaterial,
-        >,
+        crate::high_level_api::keys::cpk_re_randomization::CudaReRandomizationKeySwitchingKey,
     >,
 }
 
@@ -502,13 +498,15 @@ impl IntegerCudaServerKey {
     pub(in crate::high_level_api) fn re_randomization_cpk_casting_key(
         &self,
     ) -> Option<&crate::integer::gpu::key_switching_key::CudaKeySwitchingKeyMaterial> {
+        use crate::high_level_api::keys::cpk_re_randomization::CudaReRandomizationKeySwitchingKey;
+
         self.cpk_re_randomization_key_switching_key_material
             .as_ref()
             .and_then(|key| match key {
-                ReRandomizationKeySwitchingKey::UseCPKEncryptionKSK => {
+                CudaReRandomizationKeySwitchingKey::UseCPKEncryptionKSK => {
                     self.cpk_key_switching_key_material.as_ref()
                 }
-                ReRandomizationKeySwitchingKey::DedicatedKSK(key_switching_key_material) => {
+                CudaReRandomizationKeySwitchingKey::DedicatedKSK(key_switching_key_material) => {
                     Some(key_switching_key_material)
                 }
             })

--- a/tfhe/src/high_level_api/keys/server.rs
+++ b/tfhe/src/high_level_api/keys/server.rs
@@ -66,11 +66,7 @@ impl ServerKey {
         Option<DecompressionKey>,
         Option<NoiseSquashingKey>,
         Option<NoiseSquashingCompressionKey>,
-        Option<
-            ReRandomizationKeySwitchingKey<
-                crate::integer::key_switching_key::KeySwitchingKeyMaterial,
-            >,
-        >,
+        Option<ReRandomizationKeySwitchingKey>,
         Tag,
     ) {
         let IntegerServerKey {
@@ -105,11 +101,7 @@ impl ServerKey {
         decompression_key: Option<DecompressionKey>,
         noise_squashing_key: Option<NoiseSquashingKey>,
         noise_squashing_compression_key: Option<NoiseSquashingCompressionKey>,
-        cpk_re_randomization_key_switching_key_material: Option<
-            ReRandomizationKeySwitchingKey<
-                crate::integer::key_switching_key::KeySwitchingKeyMaterial,
-            >,
-        >,
+        cpk_re_randomization_key_switching_key_material: Option<ReRandomizationKeySwitchingKey>,
         tag: Tag,
     ) -> Self {
         Self {

--- a/tfhe/src/integer/gpu/key_switching_key/mod.rs
+++ b/tfhe/src/integer/gpu/key_switching_key/mod.rs
@@ -2,7 +2,13 @@ use crate::core_crypto::gpu::lwe_keyswitch_key::CudaLweKeyswitchKey;
 use crate::core_crypto::gpu::CudaStreams;
 use crate::integer::gpu::CudaServerKey;
 use crate::integer::key_switching_key::{KeySwitchingKey, KeySwitchingKeyMaterialView};
-pub use crate::shortint::key_switching_key::CudaKeySwitchingKeyMaterial;
+use crate::shortint::EncryptionKeyChoice;
+
+pub struct CudaKeySwitchingKeyMaterial {
+    pub(crate) lwe_keyswitch_key: CudaLweKeyswitchKey<u64>,
+    pub(crate) cast_rshift: i8,
+    pub(crate) destination_key: EncryptionKeyChoice,
+}
 
 #[allow(dead_code)]
 pub struct CudaKeySwitchingKey<'key> {

--- a/tfhe/src/shortint/key_switching_key/mod.rs
+++ b/tfhe/src/shortint/key_switching_key/mod.rs
@@ -18,8 +18,6 @@ use super::server_key::{
 };
 use super::AtomicPatternKind;
 use crate::conformance::ParameterSetConformant;
-#[cfg(feature = "gpu")]
-use crate::core_crypto::gpu::lwe_keyswitch_key::CudaLweKeyswitchKey;
 use crate::core_crypto::prelude::{
     keyswitch_lwe_ciphertext, CastFrom, CastInto, Cleartext, LweCiphertext, LweCiphertextOwned,
     LweKeyswitchKeyConformanceParams, LweKeyswitchKeyOwned, SeededLweKeyswitchKeyOwned,
@@ -254,15 +252,6 @@ pub struct KeySwitchingKeyMaterialView<'key> {
     pub(crate) cast_rshift: i8,
     pub(crate) destination_key: EncryptionKeyChoice,
     pub(crate) destination_atomic_pattern: KeySwitchingKeyDestinationAtomicPattern,
-}
-
-#[derive(Clone)]
-#[allow(dead_code)]
-#[cfg(feature = "gpu")]
-pub struct CudaKeySwitchingKeyMaterial {
-    pub(crate) lwe_keyswitch_key: CudaLweKeyswitchKey<u64>,
-    pub(crate) cast_rshift: i8,
-    pub(crate) destination_key: EncryptionKeyChoice,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]


### PR DESCRIPTION
- this change should not have been needed and poses risks for backward compatibility
- HL CUDA: use dedicated type for the ReRand


This will be backported in 1.5 too

the gist:
- reverted a change on the CPU definition of the Key, moved the GPU primitive to the integer layer instead of shortint
- defined the type for GPU to be able to decorrelate the key types (since the enum is just to encode a key choice)