### PR TITLE
chore(ci): add svg generation for zk-pke benchmarks

### DIFF
--- a/ci/data_extractor/src/config.py
+++ b/ci/data_extractor/src/config.py
@@ -35,6 +35,8 @@ class UserConfig:
 
         self.bench_subset = BenchSubset.from_str(input_args.bench_subset)
 
+        self.name_suffix = input_args.name_suffix
+
         self.layer = Layer.from_str(input_args.layer.lower())
         self.pbs_kind = PBSKind.from_str(input_args.pbs_kind)
         self.grouping_factor = input_args.grouping_factor

--- a/ci/data_extractor/src/connector.py
+++ b/ci/data_extractor/src/connector.py
@@ -132,7 +132,7 @@ class PostgreConnector:
         operation_filter: list = None,
         layer: Layer = None,
         branch: str = None,
-        name_suffix: str = "_mean_avx512",
+        name_suffix: str = None,
         last_value_only: bool = True,
     ) -> dict[BenchDetails, list[int]]:
         """
@@ -155,7 +155,7 @@ class PostgreConnector:
         :type layer: Layer, optional
         :param branch: Optional branch filter, defaulting to the user's head branch if not specified.
         :type branch: str, optional
-        :param name_suffix: Suffix to match the test names, defaulting to "_mean_avx512".
+        :param name_suffix: Suffix to match the test names.
         :type name_suffix: str, optional
         :param last_value_only: A flag indicating whether to fetch only the most recent metric value for each benchmark.
         :type last_value_only: bool
@@ -169,6 +169,7 @@ class PostgreConnector:
         layer = layer if layer else user_config.layer
         version = user_config.project_version
         pbs_kind = user_config.pbs_kind
+        name_suffix = name_suffix if name_suffix else user_config.name_suffix
 
         timestamp_range_end = user_config.bench_date
         timestamp = datetime.datetime.fromisoformat(timestamp_range_end)

--- a/ci/data_extractor/src/data_extractor.py
+++ b/ci/data_extractor/src/data_extractor.py
@@ -24,6 +24,7 @@ import connector
 import formatters.core
 import formatters.hlapi
 import formatters.integer
+import formatters.wasm
 import regression
 from benchmark_specs import BenchSubset, BenchType, Layer, OperandType, RustType
 from formatters.common import BenchArray, CSVFormatter, MarkdownFormatter, SVGFormatter
@@ -136,12 +137,15 @@ parser.add_argument(
 parser.add_argument(
     "--bench-subset",
     dest="bench_subset",
-    choices=[
-        "all",
-        "erc20",
-    ],
+    choices=["all", "erc20", "zk"],
     default="all",
     help="Subset of benchmarks to filter against, dedicated formatting will be applied",
+)
+parser.add_argument(
+    "--name-suffix",
+    dest="name_suffix",
+    default="_mean_avx512",
+    help="Suffix to match the test names",
 )
 parser.add_argument(
     "--regression-profiles",
@@ -283,6 +287,8 @@ def get_formatter(layer: Layer, bench_subset: BenchSubset):
     match bench_subset:
         case BenchSubset.Erc20:
             return formatters.hlapi.Erc20Formatter
+        case BenchSubset.Zk:
+            return formatters.wasm.ZKFormatter
 
     match layer:
         case Layer.Integer:
@@ -425,6 +431,23 @@ def generate_files_from_arrays(
             )
 
 
+def get_operands_types(layer: Layer, bench_subset: BenchSubset = None):
+    ciphertext_only = (OperandType.CipherText,)
+
+    if layer == Layer.CoreCrypto:
+        return ciphertext_only
+    elif bench_subset:
+        match bench_subset:
+            case BenchSubset.Zk | BenchSubset.Erc20:
+                return ciphertext_only
+            case _:
+                raise NotImplementedError(
+                    f"operand types cannot be defined for bench subset '{bench_subset}'"
+                )
+    else:
+        return OperandType.CipherText, OperandType.PlainText
+
+
 if __name__ == "__main__":
     args = parser.parse_args()
     user_config = config.UserConfig(args)
@@ -472,17 +495,14 @@ if __name__ == "__main__":
         args.hardware_comp.lower().split(",") if args.hardware_comp else None
     )
 
-    for operand_type in (OperandType.CipherText, OperandType.PlainText):
+    operands_types = get_operands_types(layer, bench_subset)
+
+    for operand_type in operands_types:
         if hardware_list:
             perform_hardware_comparison(user_config, layer)
 
             if args.generate_markdown:
                 print("Markdown generation is not supported with comparisons")
-            continue
-
-        if (
-            layer == Layer.CoreCrypto or (layer == Layer.HLApi and bench_subset)
-        ) and operand_type == OperandType.PlainText:
             continue
 
         file_suffix = f"_{operand_type.lower()}"

--- a/ci/data_extractor/src/formatters/integer/integer.py
+++ b/ci/data_extractor/src/formatters/integer/integer.py
@@ -5,10 +5,17 @@ from benchmark_specs import (
     ALL_RUST_INTEGER_TYPES,
     Backend,
     BenchDetails,
+    BenchType,
     OperandType,
     RustType,
+    ZKOperation,
 )
-from formatters.common import OPERATION_SIZE_COLUMN_HEADER, BenchArray, GenericFormatter
+from formatters.common import (
+    OPERATION_SIZE_COLUMN_HEADER,
+    BenchArray,
+    GenericFormatter,
+    ZKGenericFormatter,
+)
 
 
 class OperationDisplayName(enum.StrEnum):
@@ -233,3 +240,21 @@ class IntegerFormatter(GenericFormatter):
         return [
             BenchArray(result_lines, self.layer),
         ]
+
+
+class ZKFormatter(ZKGenericFormatter):
+    @staticmethod
+    def _get_default_dict() -> collections.defaultdict:
+        return collections.defaultdict(
+            lambda: {
+                ZKOperation.Proof: "N/A",
+                ZKOperation.Verify: "N/A",
+                ZKOperation.VerifyAndExpand: "N/A",
+            }
+        )
+
+    @staticmethod
+    def _match_case_variation_filter(*args, **kwargs):
+        # At this layer, server-like ZK are performed there are no variations such as browser kind.
+        # Simply match all cases.
+        return True

--- a/ci/data_extractor/src/formatters/wasm/__init__.py
+++ b/ci/data_extractor/src/formatters/wasm/__init__.py
@@ -1,0 +1,1 @@
+from .wasm import *

--- a/ci/data_extractor/src/formatters/wasm/wasm.py
+++ b/ci/data_extractor/src/formatters/wasm/wasm.py
@@ -1,0 +1,83 @@
+import collections
+import enum
+from idlelib import browser
+
+from benchmark_specs import ZKOperation
+from formatters.common import ZKGenericFormatter
+
+
+class Browser(enum.StrEnum):
+    Chrome = "chrome"
+    Firefox = "firefox"
+
+    @staticmethod
+    def from_str(browser_name):
+        match browser_name.lower():
+            case "chrome":
+                return Browser.Chrome
+            case "firefox":
+                return Browser.Firefox
+            case _:
+                raise ValueError(f"Browser '{browser_name}' not supported")
+
+
+DEFAULT_BROWSER = Browser.Chrome
+
+
+class ZKFormatter(ZKGenericFormatter):
+    @staticmethod
+    def _get_default_dict() -> collections.defaultdict:
+        return collections.defaultdict(
+            lambda: {
+                ZKOperation.Proof: "N/A",
+            }
+        )
+
+    @staticmethod
+    def _parse_benchmarks_case_variation(case_variation: str):
+        parts = case_variation.split("_")
+        case = {
+            "packed_size": int(parts[0]),
+            "crs_size": int(parts[3]),
+            "compute_load": parts[8],
+            "sub_variation": {},
+        }
+        try:
+            sub_variation_parts = parts[9:]
+        except IndexError:
+            # No sub variation for this case
+            return case
+
+        try:
+            browser = Browser.from_str(sub_variation_parts[-1])
+            sub_variation_parts.pop()
+        except ValueError:
+            browser = None
+
+        version = None
+        if sub_variation_parts[0].lower().startswith("zkv"):
+            version = sub_variation_parts.pop(0)
+
+        details = sub_variation_parts[:]
+
+        case["sub_variation"] = {
+            "version": version,
+            "browser": browser,
+            "details": details,
+        }
+
+        return case
+
+    @staticmethod
+    def _match_case_variation_filter(case_variation: dict):
+        sub_variation = case_variation["sub_variation"]
+        try:
+            # No details must be specified, otherwise it could mean that a ciphertext
+            # size measurement or a non-threaded benchmark case.
+            return (
+                sub_variation["browser"] == DEFAULT_BROWSER
+                and sub_variation["details"] == []
+            )
+        except KeyError:
+            # At least we must have a browser specified.
+            return False


### PR DESCRIPTION
This handle SVG generation for both integer and WASM layers producing six tables. Here's the details of what's being generated:

* server-side computation
  * type: latency, througput
  * operation: proving, verifying, verify + expand
  * compute load: slow proof/fast verify, fast proof/slow verify

* client-side computation
  * type: latency
  * operation: proving
  * compute load: slow proof/fast verify, fast proof/slow verify

Results can be fetched using the `--tfhe-rs-layer [integer|wasm] --bench-subset zk` input arguments.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3290)
<!-- Reviewable:end -->
