### PR TITLE
chore: add wasm_par_mq crate for unsafe coop wasm parallelism

### DIFF
--- a/.github/workflows/aws_tfhe_wasm_tests.yml
+++ b/.github/workflows/aws_tfhe_wasm_tests.yml
@@ -117,6 +117,8 @@ jobs:
         run: |
           make install_chrome_browser
           make install_chrome_web_driver
+          make install_firefox_browser
+          make install_firefox_web_driver
 
       - name: Run fmt checks
         run: |
@@ -129,6 +131,11 @@ jobs:
       - name: Run parallel wasm tests
         run: |
           make test_web_js_api_parallel_chrome_ci
+
+      - name: Run wasm_par_mq tests
+        run: |
+          make test_wasm_par_mq_chrome_ci
+          make test_wasm_par_mq_firefox_ci
 
       - name: Run x86_64/wasm zk compatibility tests
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ venv/
 web-test-runner/
 node_modules/
 package-lock.json
+utils/wasm-par-mq/examples/*/pkg/
 
 # Python .env
 .env

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ members = [
     "utils/tfhe-backward-compat-data",
     "utils/tfhe-backward-compat-data/crates/add_new_version",
     "utils/param_dedup",
+    "utils/wasm-par-mq",
+    "utils/wasm-par-mq/web_tests",
+    "utils/wasm-par-mq/examples/msm",
     "tests",
     "mockups/tfhe-hpu-mockup",
     "apps/test-vectors",
@@ -46,6 +49,9 @@ bincode = "=1.3.3"
 cmake = "0.1"
 pkg-config = "0.3"
 clap = { version = "4.5", features = ["derive"] }
+js-sys = "0.3"
+serde-wasm-bindgen = "0.6.5"
+paste = "1.0.15"
 
 [profile.bench]
 lto = "fat"

--- a/Makefile
+++ b/Makefile
@@ -534,6 +534,11 @@ clippy_param_dedup: install_rs_check_toolchain
 	RUSTFLAGS="$(RUSTFLAGS)" cargo "$(CARGO_RS_CHECK_TOOLCHAIN)" clippy --all-targets \
 		-p param_dedup -- --no-deps -D warnings
 
+.PHONY: clippy_wasm_par_mq # Run clippy lints on wasm-par-mq and its examples
+clippy_wasm_par_mq: install_rs_check_toolchain
+	RUSTFLAGS="$(RUSTFLAGS)" cargo "$(CARGO_RS_CHECK_TOOLCHAIN)" clippy --all-targets --all-features \
+		-p wasm-par-mq -p wasm-par-mq-web-tests -p wasm-par-mq-example-msm -- --no-deps -D warnings
+
 .PHONY: clippy_backward_compat_data # Run clippy lints on tfhe-backward-compat-data
 clippy_backward_compat_data: install_rs_check_toolchain # the toolchain is selected with toolchain.toml
 	@# Some old crates are x86 specific, only run in that case
@@ -559,7 +564,7 @@ clippy_test_vectors: install_rs_check_toolchain
 clippy_all: clippy_rustdoc clippy clippy_boolean clippy_shortint clippy_integer clippy_all_targets \
 clippy_c_api clippy_js_wasm_api clippy_tasks clippy_core clippy_tfhe_csprng clippy_zk_pok clippy_trivium \
 clippy_versionable clippy_tfhe_lints clippy_ws_tests clippy_bench clippy_param_dedup \
-clippy_test_vectors clippy_backward_compat_data
+clippy_test_vectors clippy_backward_compat_data clippy_wasm_par_mq
 
 .PHONY: clippy_fast # Run main clippy targets
 clippy_fast: clippy_rustdoc clippy clippy_all_targets clippy_c_api clippy_js_wasm_api clippy_tasks \
@@ -1099,7 +1104,7 @@ test_high_level_api_gpu_fast: install_cargo_nextest # Run all the GPU tests for 
 test_high_level_api_gpu: install_cargo_nextest # Run all the GPU tests for high_level_api
 	RUSTFLAGS="$(RUSTFLAGS)" cargo nextest run --cargo-profile $(CARGO_PROFILE) \
 		--test-threads=4 --features=integer,internal-keycache,gpu,zk-pok -p tfhe \
-  	-E "test(/high_level_api::.*gpu.*/)"
+		-E "test(/high_level_api::.*gpu.*/)"
 
 test_list_gpu: install_cargo_nextest
 	RUSTFLAGS="$(RUSTFLAGS)" cargo nextest list --cargo-profile $(CARGO_PROFILE) \
@@ -1396,6 +1401,54 @@ test_web_js_api_parallel_firefox_ci: setup_venv
 	nvm install $(NODE_VERSION) && \
 	nvm use $(NODE_VERSION) && \
 	$(MAKE) test_web_js_api_parallel_firefox
+
+WASM_PAR_MQ_TEST_DIR=utils/wasm-par-mq/web_tests
+
+.PHONY: build_wasm_par_mq_tests # Build the wasm-par-mq test WASM package
+build_wasm_par_mq_tests: install_wasm_pack
+	cd $(WASM_PAR_MQ_TEST_DIR) && \
+	RUSTFLAGS="$(WASM_RUSTFLAGS)" wasm-pack build --target=web --out-dir pkg
+
+# This is an internal target, not meant to be called on its own.
+run_wasm_par_mq_tests: build_wasm_par_mq_tests setup_venv
+	cd $(WASM_PAR_MQ_TEST_DIR) && npm install && npm run build
+	source venv/bin/activate && \
+	python ci/webdriver.py \
+	--browser-path $(browser_path) \
+	--driver-path $(driver_path) \
+	--browser-kind $(browser_kind) \
+	--server-cmd "npm run server" \
+	--server-workdir "$(WASM_PAR_MQ_TEST_DIR)" \
+	--index-path "$(WASM_PAR_MQ_TEST_DIR)/index.html" \
+	--id-pattern Test
+
+test_wasm_par_mq_chrome: browser_path = "$(WEB_RUNNER_DIR)/chrome/chrome-linux64/chrome"
+test_wasm_par_mq_chrome: driver_path = "$(WEB_RUNNER_DIR)/chrome/chromedriver-linux64/chromedriver"
+test_wasm_par_mq_chrome: browser_kind = chrome
+
+.PHONY: test_wasm_par_mq_chrome # Run wasm-par-mq tests on Chrome
+test_wasm_par_mq_chrome: run_wasm_par_mq_tests
+
+.PHONY: test_wasm_par_mq_chrome_ci # Run wasm-par-mq tests on Chrome in CI
+test_wasm_par_mq_chrome_ci: setup_venv
+	source ~/.nvm/nvm.sh && \
+	nvm install $(NODE_VERSION) && \
+	nvm use $(NODE_VERSION) && \
+	$(MAKE) test_wasm_par_mq_chrome
+
+test_wasm_par_mq_firefox: browser_path = "$(WEB_RUNNER_DIR)/firefox/firefox/firefox"
+test_wasm_par_mq_firefox: driver_path = "$(WEB_RUNNER_DIR)/firefox/geckodriver"
+test_wasm_par_mq_firefox: browser_kind = firefox
+
+.PHONY: test_wasm_par_mq_firefox # Run wasm-par-mq tests on Firefox
+test_wasm_par_mq_firefox: run_wasm_par_mq_tests
+
+.PHONY: test_wasm_par_mq_firefox_ci # Run wasm-par-mq tests on Firefox in CI
+test_wasm_par_mq_firefox_ci: setup_venv
+	source ~/.nvm/nvm.sh && \
+	nvm install $(NODE_VERSION) && \
+	nvm use $(NODE_VERSION) && \
+	$(MAKE) test_wasm_par_mq_firefox
 
 .PHONY: no_tfhe_typo # Check we did not invert the h and f in tfhe
 no_tfhe_typo:
@@ -2045,6 +2098,7 @@ pcc_batch_2:
 	$(call run_recipe_with_details,check_fmt_js)  # This needs to stay there, CI pipeline rely on this recipe to conditionally install Node
 	$(call run_recipe_with_details,clippy_test_vectors)
 	$(call run_recipe_with_details,check_test_vectors)
+	$(call run_recipe_with_details,clippy_wasm_par_mq)
 
 .PHONY: pcc_batch_3 # duration: 6'50''
 pcc_batch_3:

--- a/backends/tfhe-hpu-backend/Cargo.toml
+++ b/backends/tfhe-hpu-backend/Cargo.toml
@@ -31,7 +31,7 @@ tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 serde = { version = "1", features = ["derive"] }
 toml = { version = "0.8", features = [] }
-paste = "1.0.15"
+paste = { workspace = true }
 thiserror = "1.0.61"
 bytemuck = { workspace = true }
 anyhow = "1.0.82"

--- a/tasks/src/check_tfhe_docs_are_tested.rs
+++ b/tasks/src/check_tfhe_docs_are_tested.rs
@@ -5,13 +5,14 @@ use std::io::{Error, ErrorKind};
 // TODO use .gitignore or git to resolve ignored files
 const DIR_TO_IGNORE: [&str; 3] = [".git", "target", "apps/test-vectors"];
 
-const FILES_TO_IGNORE: [&str; 10] = [
+const FILES_TO_IGNORE: [&str; 11] = [
     // This contains fragments of code that are unrelated to TFHE-rs
     "tfhe/docs/tutorials/sha256-bool.md",
     // TODO: This contains code that could be executed as a trivium docstring
     "apps/trivium/README.md",
     // TODO: should we test this ?
     "utils/tfhe-versionable/README.md",
+    "utils/wasm-par-mq/README.md",
     // TODO: find a way to test the tfhe-fft readme
     "tfhe-fft/README.md",
     // TODO: find a way to test the tfhe-ntt readme

--- a/tfhe-benchmark/Cargo.toml
+++ b/tfhe-benchmark/Cargo.toml
@@ -24,7 +24,7 @@ dyn-stack = { workspace = true, features = ["default"] }
 itertools = "0.14"
 serde = { version = "1.0", default-features = false }
 serde_json = "1.0.94"
-paste = "1.0.7"
+paste = { workspace = true }
 rand = { workspace = true }
 rayon = { workspace = true }
 tfhe = { path = "../tfhe", default-features = false }

--- a/tfhe-fft/Cargo.toml
+++ b/tfhe-fft/Cargo.toml
@@ -18,7 +18,7 @@ pulp = { workspace = true }
 serde = { workspace = true, optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-js-sys = "0.3"
+js-sys = { workspace = true }
 
 [features]
 default = ["std", "avx512"]

--- a/tfhe-zk-pok/Cargo.toml
+++ b/tfhe-zk-pok/Cargo.toml
@@ -14,8 +14,8 @@ rust-version.workspace = true
 
 [dependencies]
 ark-bls12-381 = "0.5.0"
-ark-ec = { version = "0.5.0", features = ["parallel"] }
-ark-ff = { version = "0.5.0", features = ["parallel"] }
+ark-ec = { workspace = true, features = ["parallel"] }
+ark-ff = { workspace = true, features = ["parallel"] }
 ark-poly = { version = "0.5.0", features = ["parallel"] }
 rand = { workspace = true }
 rayon = { workspace = true }

--- a/tfhe/Cargo.toml
+++ b/tfhe/Cargo.toml
@@ -69,7 +69,7 @@ pulp = { workspace = true, features = ["default"] }
 tfhe-cuda-backend = { version = "0.13.0", path = "../backends/tfhe-cuda-backend", optional = true }
 aligned-vec = { workspace = true, features = ["default", "serde"] }
 dyn-stack = { workspace = true, features = ["default"] }
-paste = "1.0.7"
+paste = { workspace = true }
 fs2 = { version = "0.4.3", optional = true }
 # Used for OPRF in shortint and rerand
 sha3 = { version = "0.10", optional = true }
@@ -86,9 +86,9 @@ wasm-bindgen = { workspace = true, features = [
     "serde-serialize",
 ], optional = true }
 wasm-bindgen-rayon = { version = "1.3.0", optional = true }
-js-sys = { version = "0.3", optional = true }
+js-sys = { workspace = true, optional = true }
 console_error_panic_hook = { version = "0.1.7", optional = true }
-serde-wasm-bindgen = { version = "0.6.0", optional = true }
+serde-wasm-bindgen = { workspace = true, optional = true }
 getrandom = { workspace = true, optional = true }
 bytemuck = { workspace = true }
 

--- a/utils/wasm-par-mq/Cargo.toml
+++ b/utils/wasm-par-mq/Cargo.toml
@@ -1,0 +1,65 @@
+[package]
+name = "wasm-par-mq"
+version = "0.1.0"
+edition = "2024"
+keywords = ["wasm", "parallel", "web-workers"]
+homepage = "https://zama.ai/"
+documentation = "https://docs.rs/wasm-par-mq"
+repository = "https://github.com/zama-ai/tfhe-rs"
+license = "BSD-3-Clause-Clear"
+description = "Parallel execution on WebAssembly using Web Workers and message passing"
+rust-version.workspace = true
+
+[features]
+default = ["sync-api"]
+sync-api = [
+    # Coordinator (Service Worker)
+    "web-sys/ServiceWorkerGlobalScope",
+    "web-sys/ExtendableEvent",
+    "web-sys/FetchEvent",
+    "web-sys/Request",
+    "web-sys/RequestInit",
+    "web-sys/Response",
+    "web-sys/ResponseInit",
+    "web-sys/Headers",
+    "web-sys/Clients",
+    # SyncExecutor
+    "web-sys/XmlHttpRequest",
+    "web-sys/WorkerLocation",
+    "web-sys/WorkerGlobalScope",
+    "web-sys/WorkerNavigator",
+    "web-sys/UrlSearchParams",
+    # Service Worker Registration (from main thread)
+    "web-sys/ServiceWorker",
+    "web-sys/ServiceWorkerContainer",
+    "web-sys/ServiceWorkerRegistration",
+    "web-sys/RegistrationOptions",
+]
+
+[dependencies]
+wasm-bindgen = { workspace = true }
+wasm-bindgen-futures = "0.4"
+web-sys = { version = "0.3", features = [
+    "Blob",
+    "BlobPropertyBag",
+    "DedicatedWorkerGlobalScope",
+    "ErrorEvent",
+    "Location",
+    "MessageEvent",
+    "Navigator",
+    "Url",
+    "Window",
+    "Worker",
+    "console",
+] }
+js-sys = { workspace = true }
+postcard = { version = "1.0", features = ["alloc"] }
+serde = { workspace = true, features = ["default", "derive"] }
+serde_json = "1.0"
+serde-wasm-bindgen = { workspace = true }
+futures = "0.3"
+paste = { workspace = true }
+inventory = "0.3.21"
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3"

--- a/utils/wasm-par-mq/README.md
+++ b/utils/wasm-par-mq/README.md
@@ -1,0 +1,276 @@
+# wasm-par-mq
+
+Rayon-like parallel iterators for WebAssembly using web workers and message passing.
+
+## Overview
+
+`wasm-par-mq` provides Rayon-like parallel iterators for web environments where COOP/COEP headers cannot be set and `SharedArrayBuffer` is unavailable. It spawns web workers and dispatches work through message queues, which incurs some serialization overhead.
+
+## Features
+
+- **Parallel Iterators** - Familiar Rayon-like API with `par_iter()`, `into_par_iter()`, `map()`, and `collect_vec()`
+- **Universal** - No specific server side headers required
+- **Compile-time Function Registration** - Type-safe function registration using macros
+- **Web Worker Pool** - Automatic worker management with round-robin task distribution
+- **Async Execution** - Non-blocking parallel operations using async/await
+- **Sync Mode** - Optional blocking mode for easier integration with synchronous code
+
+## Usage
+
+### 1. Register your functions
+
+Since workers do not share memory and cannot exchange pointers, a global registry is used to dispatch work.
+Functions must be registered at compile time to be used in parallel operations:
+
+```rust
+use wasm_par_mq::register_fn;
+
+fn double(x: u32) -> u32 {
+    x * 2
+}
+// Arguments: function name, input type, return type
+register_fn!(double, u32, u32);
+```
+
+Current limitations (may be lifted in the future):
+- Closures are not supported
+- Only functions with exactly one parameter are supported
+
+### 2. Run parallel operations
+At the call site, wrap the function in the `par_fn!` macro to retrieve its registry ID:
+
+```rust
+use wasm_par_mq::{par_fn, ParallelSlice};
+
+let data: Vec<u32> = (0..1000).collect();
+
+let results = data
+    .par_iter()
+    .map(par_fn!(double))
+    .collect_vec()
+    .await;
+```
+
+### 3. Initialize the worker pool
+
+```rust
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub async fn init_parallel(
+    num_workers: u32,
+    wasm_url: &str,
+    bindgen_url: &str,
+) -> Result<(), JsValue> {
+    wasm_par_mq::init_pool_async(Some(num_workers), wasm_url, bindgen_url)
+        .await
+        .map_err(|e| JsValue::from_str(&e))
+}
+```
+
+```javascript
+import init, { init_parallel } from './pkg/your_crate.js';
+
+await init();
+await init_parallel(4, './pkg/your_crate_bg.wasm', './pkg/your_crate.js');
+```
+
+## Sync Executor
+
+The default async mode (`collect_vec().await`) requires the calling code to be async.
+The sync executor provides a blocking alternative (`collect_vec_sync()`) so that parallel
+iterators can be used from synchronous Rust code compiled to WASM.
+
+### How it works
+
+Web workers have no built-in mechanism to synchronously wait for a message from
+another worker, so the sync executor uses synchronous XMLHttpRequests (XHR) to a
+service worker as its blocking primitive.
+
+The sync executor introduces a few concepts:
+
+- **SyncExecutor**: a dedicated web worker that runs jobs and blocks until results
+  are ready. Because synchronous XHR is forbidden on the main thread, blocking must
+  happen inside a worker. The SyncExecutor fills that role: it receives jobs from
+  the main thread, dispatches chunks to compute workers, and blocks on the
+  Coordinator until all chunks complete.
+- **Job**: a call to a registered function that runs inside the SyncExecutor worker.
+  The job receives a serialized input from the main thread; it can be kept small to
+  minimize the data transferred between threads. The function body can then build or
+  load larger data sets and call `par_iter().collect_vec_sync()` on them.
+- **Chunk**: when `collect_vec_sync()` is called inside a job, the iterator's data is
+  split into chunks that are distributed across compute workers.
+- **Coordinator**: a service worker that tracks chunk completion. The SyncExecutor
+  blocks on a **synchronous XMLHttpRequest** to the Coordinator, which only responds
+  once every chunk has been processed.
+
+```
+                                                  Coordinator
+  Main Thread        SyncExecutor Worker        (Service Worker)      Workers
+  ───────────        ───────────────────        ────────────────      ───────
+       │  postMessage(job)  │                         │                  │
+       │───────────────────>│                         │                  │
+       │                    ├ run job func.           │                  │
+       │                    ├ call par_iter()         │                  │
+       │                    │                         │                  │
+       │                    │  postMessage(chunks)    │                  │
+       │                    │─────────────────────────│─────────────────>│
+       │                    │                         │                  │
+       │                    │  sync XHR GET /wait     │                  │
+       │                    │────────────────────────>│                  │
+       │                    │                         │    POST /done    │
+       │                    │                         │    (chunk res.)  │
+       │                    │       (blocked)         │<─────────────────│
+       │                    │                         │<─────────────────│
+       │                    │                         │                  │
+       │                    │<────────────────────────│                  │
+       │                    │   (all chunks done)     │                  │
+       │  postMessage       │                         │                  │
+       │  (result)          │                         │                  │
+       │<───────────────────│                         │                  │
+```
+
+1. The main thread sends a job (function ID + serialized input) to the SyncExecutor
+   via `postMessage`.
+2. The SyncExecutor deserializes the input and runs the registered function.
+3. When the function calls `collect_vec_sync()`, the data is split into chunks and
+   sent to compute workers.
+4. Each compute worker processes its chunk and POSTs the result to the Coordinator.
+5. Meanwhile the SyncExecutor performs a **synchronous XHR GET** to the Coordinator,
+   which blocks until every chunk result has been received.
+6. The Coordinator responds with the aggregated results, and the SyncExecutor
+   sends the job output back to the main thread.
+
+### Usage
+
+#### 1. Write a sync wrapper for your parallel operation
+
+The function that calls `collect_vec_sync()` runs inside the SyncExecutor worker.
+Register it like any other function:
+
+```rust
+use wasm_par_mq::{register_fn, par_fn, ParallelIterator, ParallelSlice};
+
+fn double(x: i32) -> i32 { x * 2 }
+register_fn!(double, i32, i32);
+
+// This function runs inside the SyncExecutor — it can block.
+fn double_all_impl(data: Vec<i32>) -> Vec<i32> {
+    data.par_iter().map(par_fn!(double)).collect_vec_sync()
+}
+register_fn!(double_all_impl, Vec<i32>, Vec<i32>);
+```
+
+#### 2. Expose it to JavaScript
+
+Although the job itself runs synchronously inside the SyncExecutor, you still need an
+async wrapper on the main thread to avoid blocking it. `execute_async` sends the job
+to the SyncExecutor via `postMessage` and returns a `Future` that resolves when the
+result comes back. The `sync_fn!` macro retrieves the registry ID of the job function,
+similar to what `par_fn!` does for iterator functions:
+
+```rust
+use wasm_bindgen::prelude::*;
+use wasm_par_mq::{execute_async, sync_fn};
+
+#[wasm_bindgen]
+pub async fn double_all_sync(data: Vec<i32>) -> Result<Vec<i32>, JsValue> {
+    execute_async(sync_fn!(double_all_impl), &data)
+        .await
+        .map_err(|e| JsValue::from_str(&e))
+}
+```
+
+From JavaScript, this is called like any other async WASM export: the main thread
+stays responsive while the SyncExecutor does the blocking work in the background.
+
+If your code is already running on a dedicated worker and you used
+`init_pool_sync_from_worker`, you don't need `execute_async` or the `sync_fn!`
+macro. You can call `collect_vec_sync()` directly since the current worker acts as
+the SyncExecutor.
+
+#### 3. Deploy the Coordinator Service Worker
+
+Sync mode uses a Service Worker to coordinate blocking XHR. You need to create a
+small Service Worker file whose scope covers your page. The scope defaults to the
+directory where the SW file is served, so placing it next to your page is sufficient.
+
+Create a `sw.js`:
+
+```javascript
+// sw.js
+import { setupCoordinator } from './pkg/coordinator.js';
+setupCoordinator();
+```
+
+`coordinator.js` ships with the npm package (or can be copied from `js/coordinator.js`
+in this repository). It must be served at the path you import from above.
+
+**Bundler users** (Vite, webpack, etc.): the bundler resolves the import, so
+`coordinator.js` is inlined automatically, no extra file to deploy.
+
+**Static file users**: copy `coordinator.js` next to your wasm-bindgen output
+(e.g. into `pkg/`) and adjust the import path in `sw.js` accordingly.
+
+#### 4. Initialize in sync mode
+
+```rust
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub async fn init_parallel_sync(
+    num_workers: u32,
+    wasm_url: &str,
+    bindgen_url: &str,
+    coordinator_url: &str,
+) -> Result<(), JsValue> {
+    // register_coordinator must be called from the main thread.
+    //
+    // You can then either:
+    // - call init_pool_sync here (from the main thread), which spawns a
+    //   dedicated SyncExecutor worker, or
+    // - call init_pool_sync_from_worker from a worker you manage yourself,
+    //   which reuses that worker as the SyncExecutor. This avoids the extra
+    //   SyncExecutor worker and the message-passing round-trip between the
+    //   main thread and the executor.
+    wasm_par_mq::register_coordinator(coordinator_url)
+        .await
+        .map_err(|e| JsValue::from_str(&e))?;
+    wasm_par_mq::init_pool_sync(Some(num_workers), wasm_url, bindgen_url)
+        .await
+        .map_err(|e| JsValue::from_str(&e))
+}
+```
+
+```javascript
+import init, { init_parallel_sync } from './pkg/your_crate.js';
+
+await init();
+// The coordinator_url must point to the SW file created above.
+await init_parallel_sync(4, './pkg/your_crate_bg.wasm', './pkg/your_crate.js', '/sw.js');
+```
+
+## API
+
+### Macros
+
+- `register_fn!(fn_name, InputType, OutputType)` - Register a function for parallel execution
+- `par_fn!(fn_name)` - Get a registered function for use with parallel iterators
+
+### Traits
+
+- `ParallelIterator` - Core trait for parallel iteration
+- `IntoParallelIterator` - Convert collections into parallel iterators
+- `ParallelSlice` - Extension trait adding `par_iter()` to slices
+
+### Functions
+
+- `init_pool_async(num_workers, wasm_url, bindgen_url)` - Initialize the worker pool in async mode
+- `register_coordinator(coordinator_url)` - Register the coordinator service worker (sync mode)
+- `init_pool_sync(num_workers, wasm_url, bindgen_url)` - Initialize the worker pool in sync mode (coordinator must be registered first)
+- `init_pool_sync_from_worker(num_workers, wasm_url, bindgen_url)` - Initialize in sync mode, reusing the current worker as SyncExecutor
+- `start_worker()` - Entry point for compute workers
+
+## Examples
+
+See `examples/msm` for a complete example.

--- a/utils/wasm-par-mq/examples/msm/.gitignore
+++ b/utils/wasm-par-mq/examples/msm/.gitignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/utils/wasm-par-mq/examples/msm/Cargo.toml
+++ b/utils/wasm-par-mq/examples/msm/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "wasm-par-mq-example-msm"
+version = "0.1.0"
+edition = "2024"
+rust-version.workspace = true
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wasm-par-mq = { path = "../..", features = ["sync-api"] }
+wasm-bindgen = { workspace = true }
+wasm-bindgen-futures = "0.4"
+serde = { workspace = true, features = ["derive"] }
+console_error_panic_hook = "0.1"
+
+ark-ec = { workspace = true }
+ark-ff = { workspace = true }
+serde-wasm-bindgen = { workspace = true }
+web-sys = "0.3.83"
+rand = { workspace = true }
+getrandom = { workspace = true, features = ["js"] }
+web-time = "1.1.0"

--- a/utils/wasm-par-mq/examples/msm/build.sh
+++ b/utils/wasm-par-mq/examples/msm/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+echo "Building WASM..."
+# Use web target for ES modules (workers use dynamic import())
+wasm-pack build --target web --out-dir pkg
+
+echo "Copying JS files..."
+# worker.js and sync_executor.js are embedded in the WASM (no need to copy)
+# coordinator.js is imported by sw.js (the user's Service Worker)
+cp ../../js/coordinator.js pkg/
+
+echo ""
+echo "Build complete! To run:"
+echo "  python3 -m http.server 8080"
+echo "  # or: npx serve ."
+echo ""
+echo "Then open http://localhost:8080 in your browser"

--- a/utils/wasm-par-mq/examples/msm/index.html
+++ b/utils/wasm-par-mq/examples/msm/index.html
@@ -1,0 +1,314 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>wasm-par-mq - MSM Benchmark</title>
+    <style>
+        body {
+            font-family: system-ui, sans-serif;
+            max-width: 800px;
+            margin: 50px auto;
+            padding: 20px;
+        }
+        h1 { color: #333; }
+        .test-section {
+            background: #f5f5f5;
+            padding: 20px;
+            margin: 20px 0;
+            border-radius: 8px;
+        }
+        button {
+            background: #007bff;
+            color: white;
+            border: none;
+            padding: 10px 20px;
+            border-radius: 4px;
+            cursor: pointer;
+            margin: 5px;
+        }
+        button:hover { background: #0056b3; }
+        button:disabled { background: #ccc; }
+        label {
+            margin-right: 20px;
+        }
+        select {
+            padding: 5px 10px;
+            border-radius: 4px;
+            border: 1px solid #ccc;
+        }
+        .result {
+            background: #e8f5e9;
+            padding: 10px;
+            margin-top: 10px;
+            border-radius: 4px;
+            font-family: monospace;
+            white-space: pre-wrap;
+        }
+        .error {
+            background: #ffebee;
+            color: #c62828;
+        }
+        #status {
+            padding: 10px;
+            margin: 10px 0;
+            border-radius: 4px;
+        }
+        .status-loading { background: #fff3e0; }
+        .status-ready { background: #e8f5e9; }
+        .status-error { background: #ffebee; }
+    </style>
+</head>
+<body>
+    <h1>wasm-par-mq - MSM Benchmark</h1>
+
+    <div id="status" class="status-loading">Loading WASM...</div>
+
+    <div class="test-section">
+        <h2>Configuration</h2>
+        <label>
+            Number of workers:
+            <select id="worker-count">
+                <option value="1">1 worker</option>
+                <option value="2">2 workers</option>
+                <option value="4" selected>4 workers</option>
+                <option value="8">8 workers</option>
+                <option value="16">16 workers</option>
+            </select>
+        </label>
+        <label>
+            Mode:
+            <select id="pool-mode">
+                <option value="async" selected>Async</option>
+                <option value="sync">Sync Executor</option>
+            </select>
+        </label>
+        <span id="pool-status"></span>
+    </div>
+
+    <div class="test-section">
+        <h2>Multi-Scalar Multiplication (MSM)</h2>
+        <p>Compute MSM on a set of points and scalars</p>
+        <label>
+            Number of elements:
+            <select id="msm-len">
+                <option value="1000">1,000</option>
+                <option value="5000">5,000</option>
+                <option value="10000" selected>10,000</option>
+                <option value="50000">50,000</option>
+                <option value="100000">100,000</option>
+            </select>
+        </label>
+        <br><br>
+        <button id="btn-msm-parallel" disabled>Run Parallel (workers)</button>
+        <button id="btn-msm-sync" disabled>Run Sync Executor</button>
+        <button id="btn-msm-sequential" disabled>Run Sequential (main thread)</button>
+        <button id="btn-msm-compare" disabled>Compare Results</button>
+        <div id="result-msm" class="result" hidden></div>
+    </div>
+
+    <script type="module">
+        import init, * as wasm_bindgen from './pkg/msm_example.js';
+
+        const status = document.getElementById('status');
+        const poolStatus = document.getElementById('pool-status');
+        const workerCountSelect = document.getElementById('worker-count');
+        const poolModeSelect = document.getElementById('pool-mode');
+
+        // Read mode and worker count from URL parameters (for persistence across reloads)
+        const urlParams = new URLSearchParams(window.location.search);
+        if (urlParams.has('mode')) {
+            poolModeSelect.value = urlParams.get('mode');
+        }
+        if (urlParams.has('workers')) {
+            workerCountSelect.value = urlParams.get('workers');
+        }
+        const msmLenSelect = document.getElementById('msm-len');
+        const buttons = {
+            msmParallel: document.getElementById('btn-msm-parallel'),
+            msmSync: document.getElementById('btn-msm-sync'),
+            msmSequential: document.getElementById('btn-msm-sequential'),
+            msmCompare: document.getElementById('btn-msm-compare'),
+        };
+        const results = {
+            msm: document.getElementById('result-msm'),
+        };
+
+        let currentWorkerCount = 4;
+        let currentPoolMode = 'async';
+
+        function showResult(el, text, isError = false) {
+            el.textContent = text;
+            el.hidden = false;
+            el.classList.toggle('error', isError);
+        }
+
+        async function initPool(numWorkers, mode) {
+            currentWorkerCount = numWorkers;
+            currentPoolMode = mode;
+            poolStatus.textContent = `(${numWorkers} workers, ${mode} mode)`;
+            status.textContent = `Starting worker pool (${mode} mode)...`;
+
+            if (mode === 'sync') {
+                await wasm_bindgen.init_parallel_sync(
+                    numWorkers,
+                    './pkg/msm_example_bg.wasm',
+                    './pkg/msm_example.js',
+                    '/sw.js'
+                );
+            } else {
+                await wasm_bindgen.init_parallel(
+                    numWorkers,
+                    './pkg/msm_example_bg.wasm',
+                    './pkg/msm_example.js'
+                );
+            }
+            status.textContent = 'Ready! Click a button to test.';
+            status.className = 'status-ready';
+        }
+
+        function updateButtonStates() {
+            const isSyncMode = currentPoolMode === 'sync';
+            // Sync executor button only works in sync mode
+            buttons.msmSync.disabled = !isSyncMode;
+            // Async parallel buttons only work in async mode
+            buttons.msmParallel.disabled = isSyncMode;
+            buttons.msmCompare.disabled = isSyncMode;
+        }
+
+        async function main() {
+            try {
+                // Initialize WASM (web target uses ES module default export)
+                status.textContent = 'Initializing WASM...';
+                await init('./pkg/msm_example_bg.wasm');
+
+                // Initialize the parallel pool
+                const numWorkers = parseInt(workerCountSelect.value, 10);
+                const mode = poolModeSelect.value;
+                await initPool(numWorkers, mode);
+
+                // Enable buttons
+                Object.values(buttons).forEach(btn => btn.disabled = false);
+
+                // Update button states based on mode
+                updateButtonStates();
+
+            } catch (e) {
+                status.textContent = `Error: ${e}`;
+                status.className = 'status-error';
+                console.error(e);
+            }
+        }
+
+        // Button handlers
+        buttons.msmParallel.onclick = async () => {
+            buttons.msmParallel.disabled = true;
+            try {
+                const len = parseInt(msmLenSelect.value, 10);
+
+                status.textContent = 'Generating test data...';
+                const data = wasm_bindgen.generate_test_data(len);
+
+                status.textContent = 'Running parallel MSM...';
+                const start = performance.now();
+                const result = await wasm_bindgen.run_msm_parallel(data);
+                const elapsed = (performance.now() - start).toFixed(2);
+
+                status.textContent = 'Ready! Click a button to test.';
+                showResult(results.msm,
+                    `[PARALLEL - ${currentWorkerCount} workers]\n` +
+                    `Elements: ${len}\n` +
+                    `Result: ${JSON.stringify(result)}\n` +
+                    `Time: ${elapsed}ms`
+                );
+            } catch (e) {
+                status.textContent = 'Ready! Click a button to test.';
+                showResult(results.msm, `Error: ${e}`, true);
+            }
+            buttons.msmParallel.disabled = false;
+        };
+
+        buttons.msmSync.onclick = async () => {
+            buttons.msmSync.disabled = true;
+            try {
+                const len = parseInt(msmLenSelect.value, 10);
+
+                status.textContent = 'Generating test data...';
+                const data = wasm_bindgen.generate_test_data(len);
+
+                status.textContent = 'Running sync executor MSM...';
+                const start = performance.now();
+                const result = await wasm_bindgen.run_msm_sync(data);
+                const elapsed = (performance.now() - start).toFixed(2);
+
+                status.textContent = 'Ready! Click a button to test.';
+                showResult(results.msm,
+                    `[SYNC EXECUTOR - ${currentWorkerCount} workers]\n` +
+                    `Elements: ${len}\n` +
+                    `Result: ${JSON.stringify(result)}\n` +
+                    `Time: ${elapsed}ms`
+                );
+            } catch (e) {
+                status.textContent = 'Ready! Click a button to test.';
+                showResult(results.msm, `Error: ${e}`, true);
+            }
+            buttons.msmSync.disabled = false;
+        };
+
+        buttons.msmSequential.onclick = () => {
+            buttons.msmSequential.disabled = true;
+            try {
+                const len = parseInt(msmLenSelect.value, 10);
+
+                status.textContent = 'Generating test data...';
+                const data = wasm_bindgen.generate_test_data(len);
+
+                status.textContent = 'Running sequential MSM...';
+                const start = performance.now();
+                const result = wasm_bindgen.run_msm_sequential(data);
+                const elapsed = (performance.now() - start).toFixed(2);
+
+                status.textContent = 'Ready! Click a button to test.';
+                showResult(results.msm,
+                    `[SEQUENTIAL]\n` +
+                    `Elements: ${len}\n` +
+                    `Result: ${JSON.stringify(result)}\n` +
+                    `Time: ${elapsed}ms`
+                );
+            } catch (e) {
+                status.textContent = 'Ready! Click a button to test.';
+                showResult(results.msm, `Error: ${e}`, true);
+            }
+            buttons.msmSequential.disabled = false;
+        };
+
+        buttons.msmCompare.onclick = async () => {
+            buttons.msmCompare.disabled = true;
+            try {
+                const len = parseInt(msmLenSelect.value, 10);
+
+                status.textContent = 'Generating test data...';
+                const data = wasm_bindgen.generate_test_data(len);
+
+                status.textContent = 'Running sequential then parallel MSM...';
+                const start = performance.now();
+                const result = await wasm_bindgen.run_msm_compare(data);
+                const elapsed = (performance.now() - start).toFixed(2);
+
+                status.textContent = 'Ready! Click a button to test.';
+                showResult(results.msm,
+                    `[COMPARE - ${currentWorkerCount} workers]\n` +
+                    `Elements: ${len}\n` +
+                    `${result}\n` +
+                    `Total time: ${elapsed}ms`
+                );
+            } catch (e) {
+                status.textContent = 'Ready! Click a button to test.';
+                showResult(results.msm, `Error: ${e}`, true);
+            }
+            buttons.msmCompare.disabled = false;
+        };
+
+        main();
+    </script>
+</body>
+</html>

--- a/utils/wasm-par-mq/examples/msm/src/curve_446.rs
+++ b/utils/wasm-par-mq/examples/msm/src/curve_446.rs
@@ -1,0 +1,453 @@
+#![allow(unexpected_cfgs)]
+// This is a bug/unwanted behavior from ark-ff macro, for now warn instead of erroring
+
+use ark_ec::bls12::{Bls12Config, TwistType};
+use ark_ff::MontFp;
+use ark_ff::fields::*;
+
+#[derive(MontConfig)]
+#[modulus = "645383785691237230677916041525710377746967055506026847120930304831624105190538527824412673"]
+#[generator = "7"]
+#[small_subgroup_base = "3"]
+#[small_subgroup_power = "1"]
+pub struct FrConfig;
+pub type Fr = Fp320<MontBackend<FrConfig, 5>>;
+
+#[derive(MontConfig)]
+#[modulus = "172824703542857155980071276579495962243492693522789898437834836356385656662277472896902502740297183690175962001546428467344062165330603"]
+#[generator = "2"]
+#[small_subgroup_base = "3"]
+#[small_subgroup_power = "1"]
+pub struct FqConfig;
+pub type Fq = Fp448<MontBackend<FqConfig, 7>>;
+
+pub type Fq2 = Fp2<Fq2Config>;
+
+pub struct Fq2Config;
+
+impl Fp2Config for Fq2Config {
+    type Fp = Fq;
+
+    /// NONRESIDUE = -1
+    const NONRESIDUE: Fq = MontFp!("-1");
+
+    /// Coefficients for the Frobenius automorphism.
+    const FROBENIUS_COEFF_FP2_C1: &'static [Fq] = &[
+        // Fq(-1)**(((q^0) - 1) / 2)
+        Fq::ONE,
+        // Fq(-1)**(((q^1) - 1) / 2)
+        MontFp!("-1"),
+    ];
+
+    #[inline(always)]
+    fn mul_fp_by_nonresidue_in_place(fp: &mut Self::Fp) -> &mut Self::Fp {
+        fp.neg_in_place()
+    }
+
+    #[inline(always)]
+    fn sub_and_mul_fp_by_nonresidue(y: &mut Self::Fp, x: &Self::Fp) {
+        *y += x;
+    }
+
+    #[inline(always)]
+    fn mul_fp_by_nonresidue_plus_one_and_add(y: &mut Self::Fp, x: &Self::Fp) {
+        *y = *x;
+    }
+
+    fn mul_fp_by_nonresidue_and_add(y: &mut Self::Fp, x: &Self::Fp) {
+        y.neg_in_place();
+        *y += x;
+    }
+}
+
+pub type Fq6 = Fp6<Fq6Config>;
+
+#[derive(Clone, Copy)]
+pub struct Fq6Config;
+
+impl Fp6Config for Fq6Config {
+    type Fp2Config = Fq2Config;
+
+    /// NONRESIDUE = (U + 1)
+    const NONRESIDUE: Fq2 = Fq2::new(Fq::ONE, Fq::ONE);
+
+    const FROBENIUS_COEFF_FP6_C1: &'static [Fq2] = &[
+        // Fp2::NONRESIDUE^(((q^0) - 1) / 3)
+        Fq2::new(Fq::ONE, Fq::ZERO),
+        // Fp2::NONRESIDUE^(((q^1) - 1) / 3)
+        Fq2::new(
+            Fq::ZERO,
+            MontFp!(
+                "-18292478899820133222385880210918854254706405831091403105831645830694649873798259945392135397923436410689931051013"
+            ),
+        ),
+        // Fp2::NONRESIDUE^(((q^2) - 1) / 3)
+        Fq2::new(
+            MontFp!(
+                "18292478899820133222385880210918854254706405831091403105831645830694649873798259945392135397923436410689931051012"
+            ),
+            Fq::ZERO,
+        ),
+        // Fp2::NONRESIDUE^(((q^3) - 1) / 3)
+        Fq2::new(Fq::ZERO, Fq::ONE),
+        // Fp2::NONRESIDUE^(((q^4) - 1) / 3)
+        Fq2::new(
+            MontFp!(
+                "-18292478899820133222385880210918854254706405831091403105831645830694649873798259945392135397923436410689931051013"
+            ),
+            Fq::ZERO,
+        ),
+        // Fp2::NONRESIDUE^(((q^5) - 1) / 3)
+        Fq2::new(
+            Fq::ZERO,
+            MontFp!(
+                "18292478899820133222385880210918854254706405831091403105831645830694649873798259945392135397923436410689931051012"
+            ),
+        ),
+    ];
+
+    const FROBENIUS_COEFF_FP6_C2: &'static [Fq2] = &[
+        // Fq2(u + 1)**(((2q^0) - 2) / 3)
+        Fq2::new(Fq::ONE, Fq::ZERO),
+        // Fq2(u + 1)**(((2q^1) - 2) / 3)
+        Fq2::new(
+            MontFp!(
+                "-18292478899820133222385880210918854254706405831091403105831645830694649873798259945392135397923436410689931051012"
+            ),
+            Fq::ZERO,
+        ),
+        // Fq2(u + 1)**(((2q^2) - 2) / 3)
+        Fq2::new(
+            MontFp!(
+                "-18292478899820133222385880210918854254706405831091403105831645830694649873798259945392135397923436410689931051013"
+            ),
+            Fq::ZERO,
+        ),
+        // Fq2(u + 1)**(((2q^3) - 2) / 3)
+        Fq2::new(MontFp!("-1"), Fq::ZERO),
+        // Fq2(u + 1)**(((2q^4) - 2) / 3)
+        Fq2::new(
+            MontFp!(
+                "18292478899820133222385880210918854254706405831091403105831645830694649873798259945392135397923436410689931051012"
+            ),
+            Fq::ZERO,
+        ),
+        // Fq2(u + 1)**(((2q^5) - 2) / 3)
+        Fq2::new(
+            MontFp!(
+                "18292478899820133222385880210918854254706405831091403105831645830694649873798259945392135397923436410689931051013"
+            ),
+            Fq::ZERO,
+        ),
+    ];
+
+    /// Multiply this element by the quadratic nonresidue 1 + u.
+    /// Make this generic.
+    fn mul_fp2_by_nonresidue_in_place(fe: &mut Fq2) -> &mut Fq2 {
+        let t0 = fe.c0;
+        fe.c0 -= &fe.c1;
+        fe.c1 += &t0;
+        fe
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct Fq12Config;
+
+impl Fp12Config for Fq12Config {
+    type Fp6Config = Fq6Config;
+
+    const NONRESIDUE: Fq6 = Fq6::new(Fq2::ZERO, Fq2::ONE, Fq2::ZERO);
+
+    const FROBENIUS_COEFF_FP12_C1: &'static [Fq2] = &[
+        // Fp2::NONRESIDUE^(((q^0) - 1) / 6)
+        Fq2::new(Fq::ONE, Fq::ZERO),
+        // Fp2::NONRESIDUE^(((q^1) - 1) / 6)
+        Fq2::new(
+            MontFp!(
+                "22118644822122453894295732432166425368368980329889476319266915965514828099635526724748286229964921634997234117686841299669336163301597"
+            ),
+            MontFp!(
+                "-22118644822122453894295732432166425368368980329889476319266915965514828099635526724748286229964921634997234117686841299669336163301597"
+            ),
+        ),
+        // Fp2::NONRESIDUE^(((q^2) - 1) / 6)
+        Fq2::new(
+            MontFp!(
+                "18292478899820133222385880210918854254706405831091403105831645830694649873798259945392135397923436410689931051013"
+            ),
+            Fq::ZERO,
+        ),
+        // Fp2::NONRESIDUE^(((q^3) - 1) / 6)
+        Fq2::new(
+            MontFp!(
+                "-84459159508829117195668840503504856816171858703899096210464197465513610215112549935889502423482516188066933947513637464187184810836060"
+            ),
+            MontFp!(
+                "84459159508829117195668840503504856816171858703899096210464197465513610215112549935889502423482516188066933947513637464187184810836060"
+            ),
+        ),
+        // Fp2::NONRESIDUE^(((q^4) - 1) / 6)
+        Fq2::new(
+            MontFp!(
+                "18292478899820133222385880210918854254706405831091403105831645830694649873798259945392135397923436410689931051012"
+            ),
+            Fq::ZERO,
+        ),
+        // Fp2::NONRESIDUE^(((q^5) - 1) / 6)
+        Fq2::new(
+            MontFp!(
+                "66246899211905584890106703643824680058951854489001325908103722925357218347529396236264714086849745867111793936345949703487541191192946"
+            ),
+            MontFp!(
+                "-66246899211905584890106703643824680058951854489001325908103722925357218347529396236264714086849745867111793936345949703487541191192946"
+            ),
+        ),
+        // Fp2::NONRESIDUE^(((q^6) - 1) / 6)
+        Fq2::new(MontFp!("-1"), Fq::ZERO),
+        // Fp2::NONRESIDUE^(((q^7) - 1) / 6)
+        Fq2::new(
+            MontFp!(
+                "-22118644822122453894295732432166425368368980329889476319266915965514828099635526724748286229964921634997234117686841299669336163301597"
+            ),
+            MontFp!(
+                "22118644822122453894295732432166425368368980329889476319266915965514828099635526724748286229964921634997234117686841299669336163301597"
+            ),
+        ),
+        // Fp2::NONRESIDUE^(((q^8) - 1) / 6)
+        Fq2::new(
+            MontFp!(
+                "-18292478899820133222385880210918854254706405831091403105831645830694649873798259945392135397923436410689931051013"
+            ),
+            Fq::ZERO,
+        ),
+        // Fp2::NONRESIDUE^(((q^9) - 1) / 6)
+        Fq2::new(
+            MontFp!(
+                "84459159508829117195668840503504856816171858703899096210464197465513610215112549935889502423482516188066933947513637464187184810836060"
+            ),
+            MontFp!(
+                "-84459159508829117195668840503504856816171858703899096210464197465513610215112549935889502423482516188066933947513637464187184810836060"
+            ),
+        ),
+        // Fp2::NONRESIDUE^(((q^10) - 1) / 6)
+        Fq2::new(
+            MontFp!(
+                "-18292478899820133222385880210918854254706405831091403105831645830694649873798259945392135397923436410689931051012"
+            ),
+            Fq::ZERO,
+        ),
+        // Fp2::NONRESIDUE^(((q^11) - 1) / 6)
+        Fq2::new(
+            MontFp!(
+                "-66246899211905584890106703643824680058951854489001325908103722925357218347529396236264714086849745867111793936345949703487541191192946"
+            ),
+            MontFp!(
+                "66246899211905584890106703643824680058951854489001325908103722925357218347529396236264714086849745867111793936345949703487541191192946"
+            ),
+        ),
+    ];
+}
+
+pub struct Config;
+
+impl Bls12Config for Config {
+    const X: &'static [u64] = &[0x8204000000020001, 0x600];
+    const X_IS_NEGATIVE: bool = true;
+    const TWIST_TYPE: TwistType = TwistType::M;
+    type Fp = Fq;
+    type Fp2Config = Fq2Config;
+    type Fp6Config = Fq6Config;
+    type Fp12Config = Fq12Config;
+    type G1Config = g1::Config;
+    type G2Config = g2::Config;
+}
+
+pub mod g1 {
+    use super::{Fq, Fr};
+    use ark_ec::bls12::Bls12Config;
+    use ark_ec::models::CurveConfig;
+    use ark_ec::short_weierstrass::{Affine, SWCurveConfig};
+    use ark_ec::{AdditiveGroup, AffineRepr, PrimeGroup, bls12};
+    use ark_ff::{MontFp, One, PrimeField, Zero};
+    use core::ops::Neg;
+
+    #[derive(Clone, Default, PartialEq, Eq)]
+    pub struct Config;
+
+    impl CurveConfig for Config {
+        type BaseField = Fq;
+        type ScalarField = Fr;
+
+        /// COFACTOR = (x - 1)^2 / 3  = 267785939737784928360481681640896166738700972
+        const COFACTOR: &'static [u64] = &[0xad5aaaac0002aaac, 0x2602b0055d560ab0, 0xc0208];
+
+        /// COFACTOR_INV = COFACTOR^{-1} mod r
+        /// = 645383785691237230677779421366207365261112665008071669867241543525136277620937226389553150
+        const COFACTOR_INV: Fr = MontFp!(
+            "645383785691237230677779421366207365261112665008071669867241543525136277620937226389553150"
+        );
+    }
+
+    pub type G1Affine = bls12::G1Affine<super::Config>;
+    pub type G1Projective = bls12::G1Projective<super::Config>;
+
+    impl SWCurveConfig for Config {
+        /// COEFF_A = 0
+        const COEFF_A: Fq = Fq::ZERO;
+
+        /// COEFF_B = 1
+        const COEFF_B: Fq = MontFp!("1");
+
+        /// AFFINE_GENERATOR_COEFFS = (G1_GENERATOR_X, G1_GENERATOR_Y)
+        const GENERATOR: G1Affine = G1Affine::new_unchecked(G1_GENERATOR_X, G1_GENERATOR_Y);
+
+        #[inline(always)]
+        fn mul_by_a(_: Self::BaseField) -> Self::BaseField {
+            Self::BaseField::zero()
+        }
+
+        #[inline]
+        fn is_in_correct_subgroup_assuming_on_curve(p: &G1Affine) -> bool {
+            // Algorithm from Section 6 of https://eprint.iacr.org/2021/1130.
+            //
+            // Check that endomorphism_p(P) == -[X^2]P
+
+            // An early-out optimization described in Section 6.
+            // If uP == P but P != point of infinity, then the point is not in the right
+            // subgroup.
+            let x_times_p = p.mul_bigint(super::Config::X);
+            if x_times_p.eq(p) && !p.infinity {
+                return false;
+            }
+
+            let minus_x_squared_times_p = x_times_p.mul_bigint(super::Config::X).neg();
+            let endomorphism_p = endomorphism(p);
+            minus_x_squared_times_p.eq(&endomorphism_p)
+        }
+
+        #[inline]
+        fn clear_cofactor(p: &G1Affine) -> G1Affine {
+            // Using the effective cofactor, as explained in
+            // Section 5 of https://eprint.iacr.org/2019/403.pdf.
+            //
+            // It is enough to multiply by (1 - x), instead of (x - 1)^2 / 3
+            let h_eff = one_minus_x().into_bigint();
+            Config::mul_affine(p, h_eff.as_ref()).into()
+        }
+    }
+
+    fn one_minus_x() -> Fr {
+        const X: Fr = Fr::from_sign_and_limbs(!super::Config::X_IS_NEGATIVE, super::Config::X);
+        Fr::one() - X
+    }
+
+    /// G1_GENERATOR_X =
+    /// 143189966182216199425404656824735381247272236095050141599848381692039676741476615087722874458136990266833440576646963466074693171606778
+    pub const G1_GENERATOR_X: Fq = MontFp!(
+        "143189966182216199425404656824735381247272236095050141599848381692039676741476615087722874458136990266833440576646963466074693171606778"
+    );
+
+    /// G1_GENERATOR_Y =
+    /// 75202396197342917254523279069469674666303680671605970245803554133573745859131002231546341942288521574682619325841484506619191207488304
+    pub const G1_GENERATOR_Y: Fq = MontFp!(
+        "75202396197342917254523279069469674666303680671605970245803554133573745859131002231546341942288521574682619325841484506619191207488304"
+    );
+
+    /// BETA is a non-trivial cubic root of unity in Fq.
+    pub const BETA: Fq = MontFp!(
+        "18292478899820133222385880210918854254706405831091403105831645830694649873798259945392135397923436410689931051012"
+    );
+
+    pub fn endomorphism(p: &Affine<Config>) -> Affine<Config> {
+        // Endomorphism of the points on the curve.
+        // endomorphism_p(x,y) = (BETA * x, y)
+        // where BETA is a non-trivial cubic root of unity in Fq.
+        let mut res = *p;
+        res.x *= BETA;
+        res
+    }
+}
+
+pub mod g2 {
+    use super::*;
+    use ark_ec::bls12;
+    use ark_ec::models::CurveConfig;
+    use ark_ec::short_weierstrass::SWCurveConfig;
+    use ark_ff::MontFp;
+
+    pub type G2Affine = bls12::G2Affine<super::Config>;
+
+    #[derive(Clone, Default, PartialEq, Eq)]
+    pub struct Config;
+
+    impl CurveConfig for Config {
+        type BaseField = Fq2;
+        type ScalarField = Fr;
+
+        /// COFACTOR = (x^8 - 4 x^7 + 5 x^6) - (4 x^4 + 6 x^3 - 4 x^2 - 4 x + 13) //
+        /// 9
+        /// = 46280025648128091779281203587029183771098593081950199160533444883894201638329761721685747232785203763275581499269893683911356926248942802726857101798724933488377584092259436345573
+        const COFACTOR: &'static [u64] = &[
+            0xce555594000638e5,
+            0xa75088593e6a92ef,
+            0xc81e026dd55b51d6,
+            0x47f8e24b79369c54,
+            0x74c3560ced298d51,
+            0x7cefe5c3dd2555cb,
+            0x657742bf55690156,
+            0x5780484639bf731d,
+            0x3988a06f1bb3444d,
+            0x2daee,
+        ];
+
+        /// COFACTOR_INV = COFACTOR^{-1} mod r
+        /// 420747440395392227734782296805460539842466911252881029283882861015362447833828968293150382
+        const COFACTOR_INV: Fr = MontFp!(
+            "420747440395392227734782296805460539842466911252881029283882861015362447833828968293150382"
+        );
+    }
+
+    impl SWCurveConfig for Config {
+        /// COEFF_A = [0, 0]
+        const COEFF_A: Fq2 = Fq2::new(g1::Config::COEFF_A, g1::Config::COEFF_A);
+
+        /// COEFF_B = [1, 1]
+        const COEFF_B: Fq2 = Fq2::new(g1::Config::COEFF_B, g1::Config::COEFF_B);
+
+        /// AFFINE_GENERATOR_COEFFS = (G2_GENERATOR_X, G2_GENERATOR_Y)
+        const GENERATOR: G2Affine = G2Affine::new_unchecked(G2_GENERATOR_X, G2_GENERATOR_Y);
+
+        #[inline(always)]
+        fn mul_by_a(_: Self::BaseField) -> Self::BaseField {
+            Self::BaseField::zero()
+        }
+    }
+
+    pub const G2_GENERATOR_X: Fq2 = Fq2::new(G2_GENERATOR_X_C0, G2_GENERATOR_X_C1);
+    pub const G2_GENERATOR_Y: Fq2 = Fq2::new(G2_GENERATOR_Y_C0, G2_GENERATOR_Y_C1);
+
+    /// G2_GENERATOR_X_C0 =
+    /// 96453755443802578867745476081903764610578492683850270111202389209355548711427786327510993588141991264564812146530214503491136289085725
+    pub const G2_GENERATOR_X_C0: Fq = MontFp!(
+        "96453755443802578867745476081903764610578492683850270111202389209355548711427786327510993588141991264564812146530214503491136289085725"
+    );
+
+    /// G2_GENERATOR_X_C1 =
+    /// 85346509177292795277012009839788781950274202400882571466460158277083221521663169974265433098009350061415973662678938824527658049065530
+    pub const G2_GENERATOR_X_C1: Fq = MontFp!(
+        "85346509177292795277012009839788781950274202400882571466460158277083221521663169974265433098009350061415973662678938824527658049065530"
+    );
+
+    /// G2_GENERATOR_Y_C0 =
+    /// 49316184343270950587272132771103279293158283984999436491292404103501221698714795975575879957605051223501287444864258801515822358837529
+    pub const G2_GENERATOR_Y_C0: Fq = MontFp!(
+        "49316184343270950587272132771103279293158283984999436491292404103501221698714795975575879957605051223501287444864258801515822358837529"
+    );
+
+    /// G2_GENERATOR_Y_C1 =
+    /// 107680854723992552431070996218129928499826544031468382031848626814251381379173928074140221537929995580031433096217223703806029068859074
+    pub const G2_GENERATOR_Y_C1: Fq = MontFp!(
+        "107680854723992552431070996218129928499826544031468382031848626814251381379173928074140221537929995580031433096217223703806029068859074"
+    );
+}

--- a/utils/wasm-par-mq/examples/msm/src/lib.rs
+++ b/utils/wasm-par-mq/examples/msm/src/lib.rs
@@ -1,0 +1,216 @@
+use std::convert::Infallible;
+use std::marker::PhantomData;
+
+use ark_ec::short_weierstrass::{Affine, SWCurveConfig};
+use ark_ec::{AffineRepr, CurveGroup};
+use ark_ff::{BigInt, Field, Fp, FpConfig, UniformRand};
+use curve_446::Fr;
+use curve_446::g1::G1Affine;
+use msm::{MsmSyncInput, msm_wnaf_g1_446, msm_wnaf_g1_446_parallel, msm_wnaf_g1_446_parallel_sync};
+use serde::{Deserialize, Serialize};
+use wasm_bindgen::prelude::*;
+use wasm_par_mq::{execute_async, sync_fn};
+
+mod curve_446;
+mod msm;
+
+/// Serialization equivalent of the [`Fp`] struct, where the bigint is split into
+/// multiple u64.
+#[derive(Serialize, Deserialize, Clone)]
+pub struct SerializableFp {
+    val: Vec<u64>, // Use a Vec<u64> since serde does not support fixed size arrays with a generic
+}
+
+impl<P: FpConfig<N>, const N: usize> From<Fp<P, N>> for SerializableFp {
+    fn from(value: Fp<P, N>) -> Self {
+        Self {
+            val: value.0.0.to_vec(),
+        }
+    }
+}
+
+impl<P: FpConfig<N>, const N: usize> From<SerializableFp> for Fp<P, N> {
+    fn from(value: SerializableFp) -> Self {
+        Fp(BigInt(value.val.try_into().unwrap()), PhantomData)
+    }
+}
+
+/// Serialization equivalent to the [`Affine`], which support an optional compression mode
+/// where only the `x` coordinate is stored, and the `y` is computed on load.
+#[derive(Serialize, Deserialize, Clone)]
+pub enum SerializableAffine<F> {
+    Infinity,
+    Compressed { x: F, take_largest_y: bool },
+    Uncompressed { x: F, y: F },
+}
+
+impl<F> SerializableAffine<F> {
+    #[allow(unused)]
+    pub fn uncompressed<BaseField: Into<F> + Field, C: SWCurveConfig<BaseField = BaseField>>(
+        value: Affine<C>,
+    ) -> Self {
+        if value.is_zero() {
+            Self::Infinity
+        } else {
+            Self::Uncompressed {
+                x: value.x.into(),
+                y: value.y.into(),
+            }
+        }
+    }
+
+    pub fn compressed<BaseField: Into<F> + Field, C: SWCurveConfig<BaseField = BaseField>>(
+        value: Affine<C>,
+    ) -> Self {
+        if value.is_zero() {
+            Self::Infinity
+        } else {
+            let take_largest_y = value.y > -value.y;
+            Self::Compressed {
+                x: value.x.into(),
+                take_largest_y,
+            }
+        }
+    }
+}
+
+impl<F, C: SWCurveConfig> From<SerializableAffine<F>> for Affine<C>
+where
+    F: TryInto<C::BaseField, Error = Infallible>,
+{
+    fn from(value: SerializableAffine<F>) -> Self {
+        match value {
+            SerializableAffine::Infinity => Self::zero(),
+            SerializableAffine::Compressed { x, take_largest_y } => {
+                Self::get_point_from_x_unchecked(x.try_into().unwrap(), take_largest_y).unwrap()
+            }
+
+            SerializableAffine::Uncompressed { x, y } => {
+                Self::new_unchecked(x.try_into().unwrap(), y.try_into().unwrap())
+            }
+        }
+    }
+}
+
+pub(crate) type SerializableG1Affine = SerializableAffine<SerializableFp>;
+
+// Set up panic hook for better error messages
+#[wasm_bindgen(start)]
+pub fn init() {
+    console_error_panic_hook::set_once();
+}
+
+/// Initialize the parallel execution pool
+#[wasm_bindgen]
+pub async fn init_parallel(
+    num_workers: u32,
+    wasm_url: &str,
+    bindgen_url: &str,
+) -> Result<(), JsValue> {
+    wasm_par_mq::init_pool_async(Some(num_workers), wasm_url, bindgen_url)
+        .await
+        .map_err(|e| JsValue::from_str(&e.to_string()))
+}
+
+#[wasm_bindgen]
+pub fn generate_test_data(count: i32) -> JsValue {
+    let mut rng = rand::thread_rng();
+    web_sys::console::log_1(&format!("count: {count}").into());
+    let mut bases = Vec::new();
+    bases.resize_with(count as usize, || {
+        SerializableG1Affine::uncompressed(G1Affine::rand(&mut rng))
+    });
+
+    let mut scalars = Vec::new();
+    scalars.resize_with(count as usize, || SerializableFp::from(Fr::rand(&mut rng)));
+    let serializer =
+        serde_wasm_bindgen::Serializer::new().serialize_large_number_types_as_bigints(true);
+    (bases, scalars).serialize(&serializer).unwrap()
+}
+
+#[wasm_bindgen]
+pub fn run_msm_sequential(data: JsValue) -> Result<String, JsValue> {
+    let (bases, scalars): (Vec<SerializableG1Affine>, Vec<SerializableFp>) =
+        serde_wasm_bindgen::from_value(data).map_err(|e| JsValue::from_str(&e.to_string()))?;
+
+    let count = bases.len();
+    let bases: Vec<_> = bases.into_iter().map(|b| b.into()).collect();
+    let scalars: Vec<_> = scalars.into_iter().map(|b| b.into()).collect();
+    let _res = msm_wnaf_g1_446(&bases, &scalars).into_affine();
+    Ok(format!("MSM completed for {} points", count))
+}
+
+#[wasm_bindgen]
+pub async fn run_msm_parallel(data: JsValue) -> Result<String, JsValue> {
+    let (bases, scalars): (Vec<SerializableG1Affine>, Vec<SerializableFp>) =
+        serde_wasm_bindgen::from_value(data).map_err(|e| JsValue::from_str(&e.to_string()))?;
+
+    let count = bases.len();
+    let _result = msm_wnaf_g1_446_parallel(bases, scalars).await;
+
+    Ok(format!("Parallel MSM completed for {} points", count))
+}
+
+/// Run both sequential and parallel MSM and compare results
+#[wasm_bindgen]
+pub async fn run_msm_compare(data: JsValue) -> Result<String, JsValue> {
+    let (bases, scalars): (Vec<SerializableG1Affine>, Vec<SerializableFp>) =
+        serde_wasm_bindgen::from_value(data).map_err(|e| JsValue::from_str(&e.to_string()))?;
+
+    let count = bases.len();
+
+    // Run sequential
+    let seq_bases: Vec<G1Affine> = bases.iter().cloned().map(|b| b.into()).collect();
+    let seq_scalars: Vec<Fr> = scalars.iter().cloned().map(|s| s.into()).collect();
+    let seq_result = msm_wnaf_g1_446(&seq_bases, &seq_scalars).into_affine();
+
+    // Run parallel
+    let par_result = msm_wnaf_g1_446_parallel(bases, scalars).await.into_affine();
+
+    // Compare results
+    let match_status = if seq_result == par_result {
+        "MATCH ✓"
+    } else {
+        "MISMATCH ✗"
+    };
+
+    Ok(format!(
+        "MSM comparison for {} points: {}",
+        count, match_status
+    ))
+}
+
+// === Sync Executor Mode Functions ===
+
+/// Initialize the parallel execution pool in sync mode
+#[wasm_bindgen]
+pub async fn init_parallel_sync(
+    num_workers: u32,
+    wasm_url: &str,
+    bindgen_url: &str,
+    coordinator_url: &str,
+) -> Result<(), JsValue> {
+    wasm_par_mq::register_coordinator(coordinator_url)
+        .await
+        .map_err(|e| JsValue::from_str(&e.to_string()))?;
+    wasm_par_mq::init_pool_sync(Some(num_workers), wasm_url, bindgen_url)
+        .await
+        .map_err(|e| JsValue::from_str(&e.to_string()))
+}
+
+/// Run MSM using the sync executor (dispatched from main thread)
+#[wasm_bindgen]
+pub async fn run_msm_sync(data: JsValue) -> Result<String, JsValue> {
+    let (bases, scalars): (Vec<SerializableG1Affine>, Vec<SerializableFp>) =
+        serde_wasm_bindgen::from_value(data).map_err(|e| JsValue::from_str(&e.to_string()))?;
+
+    let count = bases.len();
+    let input = MsmSyncInput { bases, scalars };
+
+    let _result: SerializableG1Affine =
+        execute_async(sync_fn!(msm_wnaf_g1_446_parallel_sync), &input)
+            .await
+            .map_err(|e| JsValue::from_str(&e))?;
+
+    Ok(format!("Sync MSM completed for {} points", count))
+}

--- a/utils/wasm-par-mq/examples/msm/src/msm.rs
+++ b/utils/wasm-par-mq/examples/msm/src/msm.rs
@@ -1,0 +1,384 @@
+use web_time::Instant;
+
+use ark_ec::short_weierstrass::Affine;
+use ark_ec::{AffineRepr, CurveGroup};
+use ark_ff::{AdditiveGroup, BigInteger, Field, Fp, PrimeField};
+use serde::{Deserialize, Serialize};
+use wasm_par_mq::{IntoParallelIterator, ParallelIterator, par_fn, register_fn};
+
+use crate::curve_446::g1::G1Projective;
+use crate::{SerializableFp, SerializableG1Affine};
+
+use super::curve_446;
+
+fn make_digits(a: &impl BigInteger, w: usize, num_bits: usize) -> impl Iterator<Item = i64> + '_ {
+    let scalar = a.as_ref();
+    let radix: u64 = 1 << w;
+    let window_mask: u64 = radix - 1;
+
+    let mut carry = 0u64;
+    let num_bits = if num_bits == 0 {
+        a.num_bits() as usize
+    } else {
+        num_bits
+    };
+    let digits_count = num_bits.div_ceil(w);
+
+    (0..digits_count).map(move |i| {
+        // Construct a buffer of bits of the scalar, starting at `bit_offset`.
+        let bit_offset = i * w;
+        let u64_idx = bit_offset / 64;
+        let bit_idx = bit_offset % 64;
+        // Read the bits from the scalar
+        let bit_buf = if bit_idx < 64 - w || u64_idx == scalar.len() - 1 {
+            // This window's bits are contained in a single u64,
+            // or it's the last u64 anyway.
+            scalar[u64_idx] >> bit_idx
+        } else {
+            // Combine the current u64's bits with the bits from the next u64
+            (scalar[u64_idx] >> bit_idx) | (scalar[1 + u64_idx] << (64 - bit_idx))
+        };
+
+        // Read the actual coefficient value from the window
+        let coef = carry + (bit_buf & window_mask); // coef = [0, 2^r)
+
+        // Recenter coefficients from [0,2^w) to [-2^w/2, 2^w/2)
+        carry = (coef + radix / 2) >> w;
+        let mut digit = (coef as i64) - (carry << w) as i64;
+
+        if i == digits_count - 1 {
+            digit += (carry << w) as i64;
+        }
+        digit
+    })
+}
+
+pub fn compute_window(
+    i: usize,
+    bases: &[curve_446::g1::G1Affine],
+    scalar_digits: &[i64],
+    digits_count: usize,
+) -> G1Projective {
+    type BaseField = Fp<ark_ff::MontBackend<crate::curve_446::FqConfig, 7>, 7>;
+
+    let zero = Affine::zero();
+    let size = bases.len();
+
+    let c = if size < 32 {
+        3
+    } else {
+        // natural log approx
+        (size.ilog2() as usize * 69 / 100) + 2
+    };
+
+    let n = 1 << c;
+    let mut indices = vec![vec![]; n];
+    let mut d = vec![BaseField::ZERO; n + 1];
+    let mut e = vec![BaseField::ZERO; n + 1];
+
+    for (idx, digits) in scalar_digits.chunks(digits_count).enumerate() {
+        use core::cmp::Ordering;
+        // digits is the digits thing of the first scalar?
+        let scalar = digits[i];
+        match 0.cmp(&scalar) {
+            Ordering::Less => indices[(scalar - 1) as usize].push(idx),
+            Ordering::Greater => indices[(-scalar - 1) as usize].push(!idx),
+            Ordering::Equal => (),
+        }
+    }
+
+    let mut buckets = vec![zero; 1 << c];
+
+    loop {
+        d[0] = BaseField::ONE;
+        for (k, (bucket, idx)) in core::iter::zip(&mut buckets, &mut indices).enumerate() {
+            if let Some(idx) = idx.last().copied() {
+                let value = if idx >> (usize::BITS - 1) == 1 {
+                    let mut val = bases[!idx];
+                    val.y = -val.y;
+                    val
+                } else {
+                    bases[idx]
+                };
+
+                if !bucket.infinity {
+                    let a = value.x - bucket.x;
+                    if a != BaseField::ZERO {
+                        d[k + 1] = d[k] * a;
+                    } else if value.y == bucket.y {
+                        d[k + 1] = d[k] * value.y.double();
+                    } else {
+                        d[k + 1] = d[k];
+                    }
+                    continue;
+                }
+            }
+            d[k + 1] = d[k];
+        }
+        e[n] = d[n].inverse().unwrap();
+
+        for (k, (bucket, idx)) in core::iter::zip(&mut buckets, &mut indices)
+            .enumerate()
+            .rev()
+        {
+            if let Some(idx) = idx.last().copied() {
+                let value = if idx >> (usize::BITS - 1) == 1 {
+                    let mut val = bases[!idx];
+                    val.y = -val.y;
+                    val
+                } else {
+                    bases[idx]
+                };
+
+                if !bucket.infinity {
+                    let a = value.x - bucket.x;
+                    if a != BaseField::ZERO {
+                        e[k] = e[k + 1] * a;
+                    } else if value.y == bucket.y {
+                        e[k] = e[k + 1] * value.y.double();
+                    } else {
+                        e[k] = e[k + 1];
+                    }
+                    continue;
+                }
+            }
+            e[k] = e[k + 1];
+        }
+
+        let d = &d[..n];
+        let e = &e[1..];
+
+        let mut empty = true;
+        for ((&d, &e), (bucket, idx)) in core::iter::zip(
+            core::iter::zip(d, e),
+            core::iter::zip(&mut buckets, &mut indices),
+        ) {
+            empty &= idx.len() <= 1;
+            if let Some(idx) = idx.pop() {
+                let value = if idx >> (usize::BITS - 1) == 1 {
+                    let mut val = bases[!idx];
+                    val.y = -val.y;
+                    val
+                } else {
+                    bases[idx]
+                };
+
+                if !bucket.infinity {
+                    let x1: BaseField = bucket.x;
+                    let x2 = value.x;
+                    let y1 = bucket.y;
+                    let y2 = value.y;
+
+                    let eq_x = x1 == x2;
+
+                    if eq_x && y1 != y2 {
+                        bucket.infinity = true;
+                    } else {
+                        let r = d * e;
+                        let m = if eq_x {
+                            let x1 = x1.square();
+                            x1 + x1.double()
+                        } else {
+                            y2 - y1
+                        };
+                        let m = m * r;
+
+                        let x3 = m.square() - x1 - x2;
+                        let y3 = m * (x1 - x3) - y1;
+                        bucket.x = x3;
+                        bucket.y = y3;
+                    }
+                } else {
+                    *bucket = value;
+                }
+            }
+        }
+
+        if empty {
+            break;
+        }
+    }
+
+    let mut running_sum = G1Projective::ZERO;
+    let mut res = G1Projective::ZERO;
+    buckets.into_iter().rev().for_each(|b| {
+        running_sum += b;
+        res += running_sum;
+    });
+    res
+}
+
+// Compute msm using windowed non-adjacent form
+#[track_caller]
+pub fn msm_wnaf_g1_446(
+    bases: &[curve_446::g1::G1Affine],
+    scalars: &[curve_446::Fr],
+) -> G1Projective {
+    let num_bits = 299usize;
+
+    assert_eq!(bases.len(), scalars.len());
+
+    let size = bases.len();
+    let scalars = &*scalars.iter().map(|x| x.into_bigint()).collect::<Vec<_>>();
+
+    let c = if size < 32 {
+        3
+    } else {
+        // natural log approx
+        (size.ilog2() as usize * 69 / 100) + 2
+    };
+
+    let digits_count = num_bits.div_ceil(c);
+    let scalar_digits = scalars
+        .iter()
+        .flat_map(|s| make_digits(s, c, num_bits))
+        .collect::<Vec<_>>();
+
+    let window_sums: Vec<_> = (0..digits_count)
+        .map(|i| compute_window(i, bases, &scalar_digits, digits_count))
+        .collect();
+
+    // We store the sum for the lowest window.
+    let lowest = *window_sums.first().unwrap();
+
+    // We're traversing windows from high to low.
+    lowest
+        + window_sums[1..]
+            .iter()
+            .rev()
+            .fold(G1Projective::ZERO, |mut total, &sum_i| {
+                total += sum_i;
+                for _ in 0..c {
+                    total = total.double();
+                }
+                total
+            })
+}
+
+/// Input for parallel MSM: a chunk of bases and scalars
+/// Each worker computes a partial MSM on its subset, then results are summed.
+/// This approach scales better because each worker only gets 1/N of the data.
+#[derive(Serialize, Deserialize, Clone)]
+pub struct MsmChunkInput {
+    pub chunk_id: usize,
+    pub bases: Vec<SerializableG1Affine>,
+    pub scalars: Vec<SerializableFp>,
+}
+
+/// Worker function that computes MSM on a chunk of bases/scalars
+pub fn msm_chunk_worker(input: MsmChunkInput) -> SerializableG1Affine {
+    let start = Instant::now();
+    let bases: Vec<curve_446::g1::G1Affine> = input.bases.into_iter().map(|b| b.into()).collect();
+    let scalars: Vec<curve_446::Fr> = input.scalars.into_iter().map(|s| s.into()).collect();
+
+    let result = msm_wnaf_g1_446(&bases, &scalars);
+    let res = SerializableG1Affine::uncompressed(result.into_affine());
+    web_sys::console::log_1(
+        &format!("msm_chunk #{}: {:#?}", input.chunk_id, start.elapsed()).into(),
+    );
+    res
+}
+register_fn!(msm_chunk_worker, MsmChunkInput, SerializableG1Affine);
+
+/// Parallel version of msm_wnaf_g1_446 that distributes base/scalar chunks across workers.
+/// Each worker computes a partial MSM, then results are summed.
+pub async fn msm_wnaf_g1_446_parallel(
+    bases: Vec<SerializableG1Affine>,
+    scalars: Vec<SerializableFp>,
+) -> G1Projective {
+    assert_eq!(bases.len(), scalars.len());
+
+    // Get number of workers to determine chunking
+    let num_workers = wasm_par_mq::num_workers().max(1);
+    let chunk_size = bases.len().div_ceil(num_workers as usize);
+
+    // Zip bases and scalars, then split into chunks for each worker
+    let start = Instant::now();
+    let inputs: Vec<MsmChunkInput> = bases
+        .chunks(chunk_size)
+        .zip(scalars.chunks(chunk_size))
+        .enumerate()
+        .map(|(chunk_id, (bases, scalars))| MsmChunkInput {
+            bases: bases.to_vec(),
+            scalars: scalars.to_vec(),
+            chunk_id,
+        })
+        .collect();
+    web_sys::console::log_1(&format!("prepoc: {:#?}", start.elapsed()).into());
+
+    // Execute chunks in parallel across workers
+    let chunk_results: Vec<SerializableG1Affine> = inputs
+        .into_par_iter()
+        .map(par_fn!(msm_chunk_worker))
+        .collect_vec()
+        .await;
+    web_sys::console::log_1(&format!("msm_chunk: {:#?}", start.elapsed()).into());
+
+    // Sum partial results from each worker
+    let res = chunk_results
+        .into_iter()
+        .map(|r| {
+            let affine: curve_446::g1::G1Affine = r.into();
+            G1Projective::from(affine)
+        })
+        .fold(G1Projective::ZERO, |acc, p| acc + p);
+
+    web_sys::console::log_1(&format!("sum: {:#?}", start.elapsed()).into());
+    res
+}
+
+/// Input for sync parallel MSM execution (public for use in lib.rs)
+#[derive(Serialize, Deserialize, Clone)]
+pub struct MsmSyncInput {
+    pub bases: Vec<SerializableG1Affine>,
+    pub scalars: Vec<SerializableFp>,
+}
+
+/// Sync version of the parallel MSM that uses collect_vec_sync()
+/// This runs inside the SyncExecutor worker
+pub fn msm_wnaf_g1_446_parallel_sync(input: MsmSyncInput) -> SerializableG1Affine {
+    let bases = input.bases;
+    let scalars = input.scalars;
+
+    // Get number of workers to determine chunking
+    let num_workers = wasm_par_mq::num_workers().max(1);
+    let chunk_size = bases.len().div_ceil(num_workers as usize);
+
+    // Zip bases and scalars, then split into chunks for each worker
+    let start = Instant::now();
+    let inputs: Vec<MsmChunkInput> = bases
+        .chunks(chunk_size)
+        .zip(scalars.chunks(chunk_size))
+        .enumerate()
+        .map(|(chunk_id, (bases, scalars))| MsmChunkInput {
+            bases: bases.to_vec(),
+            scalars: scalars.to_vec(),
+            chunk_id,
+        })
+        .collect();
+    web_sys::console::log_1(&format!("[sync] preproc: {:#?}", start.elapsed()).into());
+
+    // Execute chunks in parallel using sync blocking API
+    let chunk_results: Vec<SerializableG1Affine> = inputs
+        .into_par_iter()
+        .map(par_fn!(msm_chunk_worker))
+        .collect_vec_sync();
+    web_sys::console::log_1(&format!("[sync] msm_chunk: {:#?}", start.elapsed()).into());
+
+    // Sum partial results from each worker
+    let res = chunk_results
+        .into_iter()
+        .map(|r| {
+            let affine: curve_446::g1::G1Affine = r.into();
+            G1Projective::from(affine)
+        })
+        .fold(G1Projective::ZERO, |acc, p| acc + p);
+
+    web_sys::console::log_1(&format!("[sync] sum: {:#?}", start.elapsed()).into());
+    SerializableG1Affine::uncompressed(res.into_affine())
+}
+register_fn!(
+    msm_wnaf_g1_446_parallel_sync,
+    MsmSyncInput,
+    SerializableG1Affine
+);

--- a/utils/wasm-par-mq/examples/msm/sw.js
+++ b/utils/wasm-par-mq/examples/msm/sw.js
@@ -1,0 +1,2 @@
+import { setupCoordinator } from './pkg/coordinator.js';
+setupCoordinator();

--- a/utils/wasm-par-mq/js/coordinator.js
+++ b/utils/wasm-par-mq/js/coordinator.js
@@ -1,0 +1,120 @@
+// Coordinator Service Worker
+//
+// Implemented in JavaScript rather than Rust to avoid WASM compilation
+// latency on Service Worker startup (browsers may kill and restart SWs at any
+// time). The coordinator only does lightweight coordination (task tracking,
+// JSON parsing, promise resolution) which doesn't benefit from WASM.
+
+const tasks = new Map(); // task_id -> { expected, completed, resolver, results }
+
+export function setupCoordinator() {
+   self.addEventListener('install', (_event) => {
+       self.skipWaiting();
+   });
+
+   self.addEventListener('activate', (event) => {
+       event.waitUntil(self.clients.claim());
+   });
+
+   self.addEventListener('fetch', (event) => {
+       const url = new URL(event.request.url);
+       const pathname = url.pathname;
+
+       if (!pathname.startsWith('/__wasm_par__/')) {
+           return;
+       }
+
+       const response = handleRequest(event.request, pathname);
+       if (response) {
+           event.respondWith(response);
+       }
+   });
+
+}
+
+function handleRequest(request, pathname) {
+    const method = request.method;
+
+    // (from sync_executor) ping to check that the coordinator is up
+    if (method === 'GET' && pathname === '/__wasm_par__/ping') {
+        return Promise.resolve(jsonResponse(200, {}));
+    }
+
+    // (from sync_executor) Register a new task
+    if (method === 'POST' && pathname === '/__wasm_par__/task') {
+        return request.json().then(body => {
+            const { task_id, num_chunks } = body;
+            tasks.set(task_id, { expected: num_chunks, completed: 0, resolver: null, results: [] });
+            return jsonResponse(200, {});
+        }).catch(e => jsonResponse(500, { message: e.toString() }));
+    }
+
+    // (from worker) Signal that a task is done
+    if (method === 'POST' && pathname === '/__wasm_par__/done') {
+        return request.json().then(body => {
+            const { task_id, chunk_id, result } = body;
+            const task = tasks.get(task_id);
+            if (!task) {
+                return jsonResponse(404, { message: 'Task not found' });
+            }
+            task.results.push({ chunk_id, result })
+            task.completed += 1;
+
+            // Return early on error
+            if (result.Err !== undefined && task.resolver) {
+                task.resolver(jsonResponse(200, { results: task.results }));
+                tasks.delete(task_id);
+                return jsonResponse(200, {});
+            }
+
+            if (task.completed >= task.expected && task.resolver) {
+                task.resolver(jsonResponse(200, { results: task.results }));
+                tasks.delete(task_id);
+            }
+            return jsonResponse(200, {});
+        }).catch(e => jsonResponse(500, { message: e.toString() }));
+    }
+
+    // (from sync executor) block on a task until completion
+    if (method === 'GET' && pathname.startsWith('/__wasm_par__/wait/')) {
+        const task_id = parseInt(pathname.split('/').pop(), 10);
+        const task = tasks.get(task_id);
+
+        if (!task) {
+            return Promise.resolve(jsonResponse(404, { message: 'Task not found' }));
+        }
+
+        // Return early if the task already completed
+        if (task.completed >= task.expected) {
+            tasks.delete(task_id);
+            return Promise.resolve(jsonResponse(200, { results: task.results }));
+        }
+
+        return new Promise(resolve => {
+            task.resolver = resolve;
+        });
+    }
+
+    // (from sync executor) cancel a registered task
+    if (method === 'GET' && pathname.startsWith('/__wasm_par__/cancel/')) {
+        const task_id = parseInt(pathname.split('/').pop(), 10);
+        const task = tasks.get(task_id);
+
+        if (!task) {
+            return Promise.resolve(jsonResponse(404, { message: 'Task not found' }));
+        }
+
+        tasks.delete(task_id);
+        return Promise.resolve(jsonResponse(200, {}));
+    }
+
+
+    return Promise.resolve(jsonResponse(404, { message: 'Not found' }));
+}
+
+function jsonResponse(status, body) {
+    return new Response(JSON.stringify(body), {
+        status: status,
+        headers: { 'Content-Type': 'application/json' }
+    });
+}

--- a/utils/wasm-par-mq/js/sync_executor.js
+++ b/utils/wasm-par-mq/js/sync_executor.js
@@ -1,0 +1,10 @@
+// Minimal sync executor bootstrap - all logic is in Rust
+// URLs and config are injected at runtime via string replacement
+const wasmUrl = "__WASM_URL__";
+const bindgenUrl = "__BINDGEN_URL__";
+const numWorkers = __WORKERS__;
+
+import(bindgenUrl).then(async (module) => {
+    await module.default(wasmUrl);
+    module.start_sync_executor(wasmUrl, bindgenUrl, numWorkers);
+}).catch(e => console.error('SyncExecutor init failed:', e));

--- a/utils/wasm-par-mq/js/worker.js
+++ b/utils/wasm-par-mq/js/worker.js
@@ -1,0 +1,9 @@
+// Minimal worker bootstrap - all logic is in Rust
+// URLs are injected at runtime via string replacement
+const wasmUrl = "__WASM_URL__";
+const bindgenUrl = "__BINDGEN_URL__";
+
+import(bindgenUrl).then(async (module) => {
+    await module.default(wasmUrl);
+    module.start_worker(new URL(wasmUrl).origin);
+}).catch(e => console.error('Worker init failed:', e));

--- a/utils/wasm-par-mq/src/coordinator.rs
+++ b/utils/wasm-par-mq/src/coordinator.rs
@@ -1,0 +1,314 @@
+//! Coordinator (Service Worker) client for sync API.
+//!
+//! The coordinator is a Service Worker that tracks task completion and holds requests until all
+//! chunks are done. The actual service worker logic is implemented in JavaScript
+//! (`js/coordinator.js`) and exported as `setupCoordinator()` — end users import it into their
+//! own Service Worker file. This Rust module provides the client side: registering the SW and
+//! communicating with it via synchronous XHR.
+//!
+//! This module provides:
+//! - Registration of the coordinator from the main thread
+//! - Sync XHR helpers to communicate with the coordinator from the SyncExecutor
+
+use std::cell::RefCell;
+
+use serde_json::json;
+use wasm_bindgen::{JsCast, JsValue};
+use web_sys::{DedicatedWorkerGlobalScope, Request, RequestInit, XmlHttpRequest};
+
+use crate::global_this;
+use crate::messages::{ChunkOutcome, CoordinatorToSyncExecutor, WorkerToCoordinator};
+
+thread_local! {
+    static COORDINATOR_URL: RefCell<Option<CoordinatorUrl>> = const { RefCell::new(None) };
+}
+
+/// Store origin at runtime for making absolute URLs (workers in blob context can't use relative
+/// URLs)
+pub(crate) struct CoordinatorUrl {
+    origin: String,
+}
+
+impl CoordinatorUrl {
+    const COORDINATOR_PATH: &str = "/__wasm_par__";
+
+    fn with<F, R>(f: F) -> R
+    where
+        F: FnOnce(&Self) -> R,
+    {
+        COORDINATOR_URL.with(|coord| {
+            f(coord
+                .borrow()
+                .as_ref()
+                .expect("coordinator url should be set at this point"))
+        })
+    }
+
+    /// Setup the absolute url for the coordinator service worker.
+    ///
+    /// This needs to be called inside any worker that will have to reach the coordinator
+    /// (ie: sync executor and compute workers)
+    pub(crate) fn set(origin: &str) {
+        COORDINATOR_URL.with(|url| *url.borrow_mut() = Some(Self::new(origin)));
+    }
+
+    fn new(origin: &str) -> Self {
+        Self {
+            origin: origin.to_string(),
+        }
+    }
+
+    /// Build the full url for a given endpoint
+    fn url(endpoint: &str) -> String {
+        Self::with(|coord| format!("{}{}{}", coord.origin, Self::COORDINATOR_PATH, endpoint))
+    }
+
+    /// The url for the /ping endpoint
+    fn ping() -> String {
+        Self::url("/ping")
+    }
+
+    /// The url for the /wait endpoint
+    fn wait(task_id: u64) -> String {
+        Self::url(&format!("{}/{}", "/wait", task_id))
+    }
+
+    /// The url for the /done endpoint
+    fn done() -> String {
+        Self::url("/done")
+    }
+
+    /// The url for the /task endpoint
+    fn task() -> String {
+        Self::url("/task")
+    }
+
+    /// The url for the /cancel endpoint
+    fn cancel(task_id: u64) -> String {
+        Self::url(&format!("{}/{}", "/cancel", task_id))
+    }
+}
+
+/// Register the coordinator service worker.
+pub async fn register_coordinator(coordinator_url: &str) -> Result<(), String> {
+    let window = web_sys::window()
+        .ok_or_else(|| "no window object (sync mode requires main thread)".to_string())?;
+
+    let navigator = window.navigator();
+    let service_worker = navigator.service_worker();
+
+    let options = web_sys::RegistrationOptions::new();
+    // The coordinator is defined as a "module" service worker that can be embedded by the end-user
+    // in its own code.
+    options.set_type("module");
+    let promise = service_worker.register_with_options(coordinator_url, &options);
+
+    wasm_bindgen_futures::JsFuture::from(promise)
+        .await
+        .map_err(|e| format!("failed to register coordinator: {e:?}"))?;
+
+    // Wait for the service worker to be ready
+    let ready_promise = service_worker
+        .ready()
+        .map_err(|e| format!("failed to get service worker ready promise: {e:?}"))?;
+
+    wasm_bindgen_futures::JsFuture::from(ready_promise)
+        .await
+        .map_err(|e| format!("service worker not ready: {e:?}"))?;
+
+    // Wait until the service worker has claimed this page as a client.
+    // The `ready` promise resolves when there's an active worker, but
+    // `clients.claim()` in the activate event may still be pending.
+    // We poll until `navigator.serviceWorker.controller` is set.
+    let mut attempts = 0;
+    const MAX_ATTEMPTS: u32 = 50; // 50 * 20ms = 1 second max
+    while service_worker.controller().is_none() {
+        if attempts >= MAX_ATTEMPTS {
+            return Err("Service worker did not claim this page in time".to_string());
+        }
+        // Sleep for 20ms
+        let promise = js_sys::Promise::new(&mut |resolve, _| {
+            let window = web_sys::window().unwrap();
+            window
+                .set_timeout_with_callback_and_timeout_and_arguments_0(&resolve, 20)
+                .unwrap();
+        });
+        wasm_bindgen_futures::JsFuture::from(promise).await.ok();
+        attempts += 1;
+    }
+
+    Ok(())
+}
+
+/// Perform a synchronous GET request. Blocks until response is received.
+fn sync_xhr_get(url: &str) -> Result<String, String> {
+    let xhr = XmlHttpRequest::new().map_err(|e| format!("XHR new failed: {e:?}"))?;
+    xhr.open_with_async("GET", url, false)
+        .map_err(|e| format!("XHR open failed: {e:?}"))?;
+    xhr.send().map_err(|e| format!("XHR send failed: {e:?}"))?;
+
+    let status = xhr
+        .status()
+        .map_err(|e| format!("XHR status failed: {e:?}"))?;
+    if status != 200 {
+        if let Ok(Some(message)) = xhr.response_text() {
+            return Err(format!("XHR failed with status {status}: {message}"));
+        } else {
+            return Err(format!("XHR failed with status {status}"));
+        }
+    }
+
+    xhr.response_text()
+        .map_err(|e| format!("failed to get XHR response: {e:?}"))?
+        .ok_or_else(|| "XHR returned no response text".to_string())
+}
+
+/// Perform a synchronous POST request with JSON body. Blocks until response is received.
+fn sync_xhr_post(url: &str, body: &str) -> Result<String, String> {
+    let xhr = XmlHttpRequest::new().map_err(|e| format!("XHR new failed: {e:?}"))?;
+    xhr.open_with_async("POST", url, false)
+        .map_err(|e| format!("XHR open failed: {e:?}"))?;
+    xhr.set_request_header("Content-Type", "application/json")
+        .map_err(|e| format!("XHR set_request_header failed: {e:?}"))?;
+    xhr.send_with_opt_str(Some(body))
+        .map_err(|e| format!("XHR send failed: {e:?}"))?;
+
+    let status = xhr
+        .status()
+        .map_err(|e| format!("XHR status failed: {e:?}"))?;
+    if status != 200 {
+        if let Ok(Some(message)) = xhr.response_text() {
+            return Err(format!("XHR failed with status {status}: {message}"));
+        } else {
+            return Err(format!("XHR failed with status {status}"));
+        }
+    }
+
+    xhr.response_text()
+        .map_err(|e| format!("XHR response_text failed: {e:?}"))?
+        .ok_or_else(|| "XHR returned no response text".to_string())
+}
+
+/// Wait for the Service Worker coordinator to start intercepting requests.
+///
+/// When a worker is first created, there's a brief window where it's not yet registered as a
+/// client of the Service Worker, so requests would go to the actual server. This function polls
+/// the coordinator's ping endpoint until it responds, with a timeout of 5 seconds.
+pub(crate) async fn wait_for_coordinator() -> Result<(), String> {
+    let mut attempts = 0;
+    const MAX_ATTEMPTS: u32 = 100; // 100 * 50ms = 5 seconds max
+    loop {
+        if ping_coordinator().is_ok() {
+            return Ok(());
+        }
+        attempts += 1;
+        if attempts >= MAX_ATTEMPTS {
+            return Err("Service Worker not intercepting requests after timeout".to_string());
+        }
+        let promise = js_sys::Promise::new(&mut |resolve, _| {
+            let global: DedicatedWorkerGlobalScope = global_this().unchecked_into();
+            global
+                .set_timeout_with_callback_and_timeout_and_arguments_0(&resolve, 50)
+                .unwrap();
+        });
+        wasm_bindgen_futures::JsFuture::from(promise).await.ok();
+    }
+}
+
+/// Ping the coordinator to verify it's intercepting requests from this context.
+fn ping_coordinator() -> Result<(), String> {
+    let xhr = XmlHttpRequest::new().map_err(|e| format!("XHR new failed: {e:?}"))?;
+    let url = CoordinatorUrl::ping();
+    xhr.open_with_async("GET", &url, false)
+        .map_err(|e| format!("XHR open failed: {e:?}"))?;
+    xhr.send().map_err(|e| format!("XHR send failed: {e:?}"))?;
+
+    let status = xhr
+        .status()
+        .map_err(|e| format!("XHR status failed: {e:?}"))?;
+
+    if status == 200 {
+        Ok(())
+    } else {
+        Err(format!("Ping failed with status {status}"))
+    }
+}
+
+pub(crate) fn register_task(task_id: u64, num_chunks: usize) -> Result<(), String> {
+    let url = CoordinatorUrl::task();
+    sync_xhr_post(
+        &url,
+        &json!({
+            "task_id": task_id,
+            "num_chunks": num_chunks
+        })
+        .to_string(),
+    )?;
+
+    Ok(())
+}
+
+pub(crate) fn wait_task(task_id: u64) -> Result<Vec<Vec<u8>>, String> {
+    let url = CoordinatorUrl::wait(task_id);
+    let response = sync_xhr_get(&url)?;
+
+    let parsed: CoordinatorToSyncExecutor = serde_json::from_str(&response)
+        .map_err(|e| format!("Failed to deserialize task {task_id} result: {e}"))?;
+
+    // Sort by chunk_id
+    let mut outcomes = parsed.results;
+    outcomes.sort_by_key(|r| r.chunk_id);
+
+    // Early return if any chunk returned an error
+    let outcomes = outcomes
+        .into_iter()
+        .map(|outcome| {
+            outcome
+                .result
+                .map_err(|err| format!("Chunk {} failed: {}", outcome.chunk_id, err))
+        })
+        // At this point we have Vec<Result>, we use collect to convert to Result<Vec>
+        .collect::<Result<Vec<_>, _>>()?;
+
+    // If there is no error, return the data in order
+    Ok(outcomes)
+}
+
+pub(crate) fn cancel_task(task_id: u64) -> Result<(), String> {
+    let url = CoordinatorUrl::cancel(task_id);
+    sync_xhr_get(&url).map(|_| ())
+}
+
+/// Signal to the coordinator that work on a chunk is finished
+pub(crate) fn signal_done_to_coordinator(task_id: u64, outcome: ChunkOutcome) {
+    let req = WorkerToCoordinator { task_id, outcome };
+    let Ok(body) = serde_json::to_string(&req).inspect_err(|e| {
+        web_sys::console::error_1(&format!("Failed to serialize done request: {e}").into());
+    }) else {
+        return;
+    };
+
+    let init = RequestInit::new();
+    init.set_method("POST");
+    init.set_body(&JsValue::from_str(&body));
+
+    let url = CoordinatorUrl::done();
+    let Ok(request) = Request::new_with_str_and_init(&url, &init).inspect_err(|e| {
+        web_sys::console::error_1(&format!("Failed to create request: {e:?}").into())
+    }) else {
+        return;
+    };
+
+    if let Err(e) = request.headers().set("Content-Type", "application/json") {
+        web_sys::console::error_1(&format!("Failed to set request header: {e:?}").into());
+        return;
+    }
+
+    wasm_bindgen_futures::spawn_local(async move {
+        let global: DedicatedWorkerGlobalScope = global_this().unchecked_into();
+        let promise = global.fetch_with_request(&request);
+        if let Err(e) = wasm_bindgen_futures::JsFuture::from(promise).await {
+            web_sys::console::error_1(&format!("Failed to signal done: {e:?}").into());
+        }
+    });
+}

--- a/utils/wasm-par-mq/src/iterator.rs
+++ b/utils/wasm-par-mq/src/iterator.rs
@@ -1,0 +1,230 @@
+use crate::pool::execute_par_map;
+#[cfg(feature = "sync-api")]
+use crate::pool::execute_par_map_sync;
+use crate::registry::{FnEntry, RegisteredFn};
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+
+pub trait ParallelIterator {
+    type Item;
+
+    fn map<F, R>(self, f: FnEntry<F>) -> ParMap<F, Self, R>
+    where
+        F: RegisteredFn<Input = Self::Item, Output = R>,
+        Self: Sized;
+}
+
+/// A parallel iterator that distributes work across web workers.
+pub struct Iter<'data, T> {
+    slice: &'data [T],
+}
+
+impl<'data, T> Iter<'data, T> {
+    /// Create a new parallel iterator from a slice
+    pub(crate) fn new(slice: &'data [T]) -> Self {
+        Self { slice }
+    }
+
+    /// Get the number of elements
+    pub fn len(&self) -> usize {
+        self.slice.len()
+    }
+
+    /// Check if empty
+    pub fn is_empty(&self) -> bool {
+        self.slice.is_empty()
+    }
+}
+
+impl<'data, T> ParallelIterator for Iter<'data, T> {
+    type Item = T;
+
+    /// Apply a registered function to each element in parallel.
+    ///
+    /// The function must be registered with `register_fn!` before use.
+    /// This method is lazy - it returns a `ParMap` that must be collected.
+    ///
+    /// # Example
+    /// ```ignore
+    /// fn double(x: i32) -> i32 { x * 2 }
+    /// register_fn!(double);
+    ///
+    /// let results = vec![1, 2, 3, 4]
+    ///     .into_par_iter()
+    ///     .par_map(double)
+    ///     .collect_vec()
+    ///     .await;
+    /// ```
+    fn map<F, R>(self, f: FnEntry<F>) -> ParMap<F, Self, R> {
+        ParMap {
+            base: self,
+            f,
+            _marker: std::marker::PhantomData,
+        }
+    }
+}
+
+pub struct IntoIter<T> {
+    data: Vec<T>,
+}
+
+impl<T> IntoIter<T> {
+    /// Create a new parallel iterator from a vector
+    pub(crate) fn new(data: Vec<T>) -> Self {
+        Self { data }
+    }
+
+    /// Get the number of elements
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    /// Check if empty
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+}
+
+impl<T> ParallelIterator for IntoIter<T> {
+    type Item = T;
+
+    fn map<F, R>(self, f: FnEntry<F>) -> ParMap<F, Self, R> {
+        ParMap {
+            base: self,
+            f,
+            _marker: std::marker::PhantomData,
+        }
+    }
+}
+
+/// A parallel map operation (lazy - doesn't execute until collected)
+pub struct ParMap<F, I, R> {
+    base: I,
+    f: FnEntry<F>,
+    _marker: std::marker::PhantomData<R>,
+}
+
+impl<F, I, O> ParMap<F, Iter<'_, I>, O>
+where
+    I: Serialize,
+    O: DeserializeOwned,
+    F: RegisteredFn<Input = I, Output = O>,
+{
+    /// Collect the results of the parallel map operation.
+    ///
+    /// This is an **async** operation that dispatches work to workers
+    /// and waits for all results.
+    ///
+    /// # Panics
+    /// Panics if the worker pool has not been initialized.
+    pub async fn collect_vec(self) -> Vec<O> {
+        self.try_collect_vec().await.expect("parallel map failed")
+    }
+
+    /// Collect results, returning an error on failure instead of panicking
+    pub async fn try_collect_vec(self) -> Result<Vec<O>, String> {
+        execute_par_map(self.f, self.base.slice).await
+    }
+    /// Collect the results of the parallel map operation.
+    ///
+    /// This is a **sync** operation that dispatches work to workers
+    /// and blocks until they all return.
+    ///
+    /// # Panics
+    /// Panics if the worker pool has not been initialized.
+    #[cfg(feature = "sync-api")]
+    pub fn collect_vec_sync(self) -> Vec<O> {
+        self.try_collect_vec_sync().expect("parallel map failed")
+    }
+
+    /// Collect results, returning an error on failure instead of panicking
+    #[cfg(feature = "sync-api")]
+    pub fn try_collect_vec_sync(self) -> Result<Vec<O>, String> {
+        execute_par_map_sync(self.f, self.base.slice)
+    }
+}
+
+impl<F, I, O> ParMap<F, IntoIter<I>, O>
+where
+    I: Serialize,
+    O: DeserializeOwned,
+    F: RegisteredFn<Input = I, Output = O>,
+{
+    /// Collect the results of the parallel map operation.
+    ///
+    /// This is an **async** operation that dispatches work to workers
+    /// and waits for all results.
+    ///
+    /// # Panics
+    /// Panics if the worker pool has not been initialized.
+    pub async fn collect_vec(self) -> Vec<O> {
+        self.try_collect_vec().await.expect("parallel map failed")
+    }
+
+    /// Collect results, returning an error on failure instead of panicking
+    pub async fn try_collect_vec(self) -> Result<Vec<O>, String> {
+        execute_par_map(self.f, &self.base.data).await
+    }
+
+    /// Collect the results of the parallel map operation.
+    ///
+    /// This is a **sync** operation that dispatches work to workers
+    /// and blocks until they all return.
+    ///
+    /// # Panics
+    /// Panics if the worker pool has not been initialized.
+    #[cfg(feature = "sync-api")]
+    pub fn collect_vec_sync(self) -> Vec<O> {
+        self.try_collect_vec_sync().expect("parallel map failed")
+    }
+
+    /// Collect results, returning an error on failure instead of panicking
+    #[cfg(feature = "sync-api")]
+    pub fn try_collect_vec_sync(self) -> Result<Vec<O>, String> {
+        execute_par_map_sync(self.f, &self.base.data)
+    }
+}
+
+/// Extension trait to convert collections into parallel iterators
+pub trait IntoParallelIterator {
+    type Item;
+    type Iter: ParallelIterator<Item = Self::Item>;
+
+    /// Convert this collection into a parallel iterator
+    fn into_par_iter(self) -> Self::Iter;
+}
+
+impl<T> IntoParallelIterator for Vec<T> {
+    type Item = T;
+    type Iter = IntoIter<T>;
+
+    fn into_par_iter(self) -> Self::Iter {
+        IntoIter::new(self)
+    }
+}
+
+impl<'data, T: Serialize> IntoParallelIterator for &'data [T] {
+    type Item = T;
+    type Iter = Iter<'data, T>;
+
+    fn into_par_iter(self) -> Self::Iter {
+        Iter::new(self)
+    }
+}
+
+/// Extension trait that mirrors rayon's par_iter() method on slices
+pub trait ParallelSlice<T> {
+    fn par_iter(&'_ self) -> Iter<'_, T>;
+}
+
+impl<T> ParallelSlice<T> for [T] {
+    fn par_iter(&'_ self) -> Iter<'_, T> {
+        Iter::new(self)
+    }
+}
+
+impl<T> ParallelSlice<T> for Vec<T> {
+    fn par_iter(&'_ self) -> Iter<'_, T> {
+        Iter::new(self)
+    }
+}

--- a/utils/wasm-par-mq/src/lib.rs
+++ b/utils/wasm-par-mq/src/lib.rs
@@ -1,0 +1,45 @@
+use wasm_bindgen::prelude::*;
+
+// Direct binding to `globalThis`
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(thread_local_v2, js_name = "globalThis")]
+    static GLOBAL_THIS: JsValue;
+}
+
+pub(crate) fn global_this() -> JsValue {
+    GLOBAL_THIS.with(JsValue::clone)
+}
+
+#[cfg(feature = "sync-api")]
+pub(crate) mod coordinator;
+pub(crate) mod iterator;
+pub(crate) mod messages;
+pub(crate) mod pool;
+pub(crate) mod registry;
+#[cfg(feature = "sync-api")]
+pub(crate) mod sync_executor;
+pub(crate) mod worker;
+
+#[cfg(feature = "sync-api")]
+pub use coordinator::register_coordinator;
+pub use iterator::{IntoIter, IntoParallelIterator, Iter, ParMap, ParallelIterator, ParallelSlice};
+pub use pool::{init_pool_async, is_pool_initialized, num_workers};
+#[cfg(feature = "sync-api")]
+pub use pool::{init_pool_sync, init_pool_sync_from_worker};
+#[cfg(feature = "sync-api")]
+pub use sync_executor::{execute_async, start_sync_executor};
+pub use worker::start_worker;
+
+/// Internal module for macro implementation details. Do not use directly.
+#[doc(hidden)]
+pub mod __private {
+    // Re-export macros so that users don't have to add them as dependencies
+    pub use inventory::submit as submit_fn_entry;
+    pub use paste::paste;
+
+    // Re-export registry internals for macros
+    pub use crate::registry::{
+        FnEntry, NewFnEntry, RegisteredFn, deserialize_input_chunk, serialize_output_chunk,
+    };
+}

--- a/utils/wasm-par-mq/src/messages/coordinator.rs
+++ b/utils/wasm-par-mq/src/messages/coordinator.rs
@@ -1,0 +1,19 @@
+//! Messages for coordinator (Service Worker) communication.
+
+use serde::{Deserialize, Serialize};
+
+use super::ChunkOutcome;
+
+/// Sent by the coordinator the the Sync Executor when all the chunks in a task are done
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct CoordinatorToSyncExecutor {
+    pub results: Vec<ChunkOutcome>,
+}
+
+/// Sent by the workers to the coordinator when a chunk is done
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct WorkerToCoordinator {
+    pub task_id: u64,
+    #[serde(flatten)]
+    pub outcome: ChunkOutcome,
+}

--- a/utils/wasm-par-mq/src/messages/mod.rs
+++ b/utils/wasm-par-mq/src/messages/mod.rs
@@ -1,0 +1,29 @@
+//! Message types and serialization helpers for worker communication.
+
+mod worker;
+pub(crate) use worker::{ChunkOutcome, MainToWorker, WorkerToMain};
+
+#[cfg(feature = "sync-api")]
+mod coordinator;
+#[cfg(feature = "sync-api")]
+pub(crate) use coordinator::{CoordinatorToSyncExecutor, WorkerToCoordinator};
+
+#[cfg(feature = "sync-api")]
+mod sync_executor;
+#[cfg(feature = "sync-api")]
+pub(crate) use sync_executor::{JobOutcome, MainToSyncExecutor, SyncExecutorToMain};
+
+use serde::{Deserialize, Serialize};
+
+/// Deserialize a JsValue into a message type
+pub(crate) fn from_js<T: for<'de> Deserialize<'de>>(
+    value: wasm_bindgen::JsValue,
+) -> Result<T, String> {
+    serde_wasm_bindgen::from_value(value).map_err(|e| e.to_string())
+}
+
+/// Serialize a message to JsValue
+pub(crate) fn to_js<T: Serialize>(value: &T) -> Result<wasm_bindgen::JsValue, String> {
+    let ser = serde_wasm_bindgen::Serializer::new().serialize_large_number_types_as_bigints(true);
+    value.serialize(&ser).map_err(|e| e.to_string())
+}

--- a/utils/wasm-par-mq/src/messages/sync_executor.rs
+++ b/utils/wasm-par-mq/src/messages/sync_executor.rs
@@ -1,0 +1,29 @@
+//! Messages for sync executor communication.
+
+use serde::{Deserialize, Serialize};
+
+use crate::registry::FunctionId;
+
+/// Messages from main thread to sync executor
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) enum MainToSyncExecutor {
+    /// Request to start a new job
+    Job {
+        job_id: u64,
+        fn_id: FunctionId,
+        data: Vec<u8>,
+    },
+}
+
+/// Messages from sync executor to main thread
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) enum SyncExecutorToMain {
+    Ready,
+    Done(JobOutcome),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct JobOutcome {
+    pub(crate) job_id: u64,
+    pub(crate) result: Result<Vec<u8>, String>,
+}

--- a/utils/wasm-par-mq/src/messages/worker.rs
+++ b/utils/wasm-par-mq/src/messages/worker.rs
@@ -1,0 +1,29 @@
+//! Messages for compute worker communication.
+
+use serde::{Deserialize, Serialize};
+
+use crate::registry::FunctionId;
+
+/// Messages from pool owner (main thread or SyncExecutor) to worker
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct MainToWorker {
+    pub chunk_id: u64,
+    pub fn_id: FunctionId,
+    pub data: Vec<u8>,
+    // In sync mode, we also need to register the task this chunk belongs to
+    #[cfg(feature = "sync-api")]
+    pub task_id: Option<u64>,
+}
+
+/// Messages from worker to main thread
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) enum WorkerToMain {
+    Ready,
+    Done(ChunkOutcome),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct ChunkOutcome {
+    pub chunk_id: u64,
+    pub result: Result<Vec<u8>, String>,
+}

--- a/utils/wasm-par-mq/src/pool.rs
+++ b/utils/wasm-par-mq/src/pool.rs
@@ -1,0 +1,524 @@
+//! Worker pool for parallel execution.
+//!
+//! Manages a pool of web workers and distributes tasks across them.
+//! Supports both async (main thread) and sync (SyncExecutor) result handling.
+
+#[cfg(feature = "sync-api")]
+use crate::coordinator::{
+    CoordinatorUrl, cancel_task, register_task, wait_for_coordinator, wait_task,
+};
+use crate::global_this;
+use crate::messages::{self, MainToWorker, WorkerToMain};
+use crate::registry::{FnEntry, RegisteredFn, init_registry};
+#[cfg(feature = "sync-api")]
+use crate::sync_executor::register_sync_executor;
+use crate::worker::{create_worker_url, resolve_url};
+use futures::channel::oneshot;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+use wasm_bindgen::prelude::*;
+use web_sys::Worker;
+
+pub(crate) type ReadySender = Rc<RefCell<Option<oneshot::Sender<Result<(), String>>>>>;
+
+thread_local! {
+    static POOL: RefCell<Option<WorkerPool>> = const { RefCell::new(None) };
+}
+
+/// Get the number of logical CPUs via `navigator.hardwareConcurrency`.
+fn get_hardware_concurrency() -> u32 {
+    // Try with Window (main thread)
+    if let Some(window) = web_sys::window() {
+        return window.navigator().hardware_concurrency() as u32;
+    }
+
+    // Try with DedicatedWorkerGlobalScope (SyncExecutor)
+    #[cfg(feature = "sync-api")]
+    if let Ok(worker) = global_this().dyn_into::<web_sys::DedicatedWorkerGlobalScope>() {
+        return worker.navigator().hardware_concurrency() as u32;
+    }
+
+    // Fallback
+    4
+}
+
+/// How results are delivered to the caller
+pub(crate) struct AsyncResultHandler {
+    /// Results are delivered via oneshot channels
+    waiters: HashMap<u64, oneshot::Sender<Result<Vec<u8>, String>>>,
+}
+
+impl AsyncResultHandler {
+    fn new() -> Self {
+        Self {
+            waiters: HashMap::new(),
+        }
+    }
+
+    /// Handle an incoming result from a worker
+    fn handle_result(&mut self, chunk_id: u64, result: Result<Vec<u8>, String>) {
+        if let Some(tx) = self.waiters.remove(&chunk_id) {
+            let _ = tx.send(result);
+        }
+    }
+
+    /// Register an async waiter for a chunk (only valid in Async mode)
+    fn register_waiter(&mut self, chunk_id: u64, tx: oneshot::Sender<Result<Vec<u8>, String>>) {
+        self.waiters.insert(chunk_id, tx);
+    }
+}
+
+struct WorkerPool {
+    workers: Vec<Worker>,
+    // In async mode, the result handle is used to send the results to the correct task
+    result_handler: Option<AsyncResultHandler>,
+    // In sync mode, the coordinator needs a task id to be able to send back results
+    // to the correct task
+    #[cfg(feature = "sync-api")]
+    next_task_id: u64,
+    next_chunk_id: u64,
+    next_worker: u32,
+}
+
+impl WorkerPool {
+    fn new(result_handler: Option<AsyncResultHandler>) -> Self {
+        Self {
+            workers: Vec::new(),
+            result_handler,
+            #[cfg(feature = "sync-api")]
+            next_task_id: 0,
+            next_chunk_id: 0,
+            next_worker: 0,
+        }
+    }
+
+    fn num_workers(&self) -> u32 {
+        self.workers
+            .len()
+            .try_into()
+            .expect("workers len should not be > u32::MAX and usize is 32b on wasm")
+    }
+
+    #[cfg(feature = "sync-api")]
+    fn next_task_id(&mut self) -> u64 {
+        let id = self.next_task_id;
+        self.next_task_id = self.next_task_id.checked_add(1).expect("task id overflow");
+        id
+    }
+
+    fn next_chunk_id(&mut self) -> u64 {
+        let id = self.next_chunk_id;
+        self.next_chunk_id = self
+            .next_chunk_id
+            .checked_add(1)
+            .expect("chunk id overflow");
+        id
+    }
+
+    fn next_worker_idx(&mut self) -> u32 {
+        let num = self.num_workers();
+        if num == 0 {
+            return 0;
+        }
+        let idx = self.next_worker;
+        self.next_worker = idx.checked_add(1).expect("worker idx overflow") % num;
+        idx
+    }
+}
+
+/// Initialize the parallel execution pool in async mode.
+///
+/// Workers are spawned directly from the main thread and results are delivered
+/// via async/await.
+///
+/// The compute workers are automatically embedded (no need to serve worker.js).
+///
+/// # Arguments
+/// * `num_workers` - Number of workers. If `None`, auto-detects via `hardwareConcurrency`.
+/// * `wasm_url` - URL to the WASM module
+/// * `bindgen_url` - URL to the wasm-bindgen JS glue
+///
+/// # Example
+/// ```ignore
+/// init_pool_async(None, "/pkg/app_bg.wasm", "/pkg/app.js").await?;
+/// ```
+pub async fn init_pool_async(
+    num_workers: Option<u32>,
+    wasm_url: &str,
+    bindgen_url: &str,
+) -> Result<(), String> {
+    // Resolve relative URLs to absolute - required because blob URL workers
+    // cannot resolve relative imports
+    let wasm_url = resolve_url(wasm_url);
+    let bindgen_url = resolve_url(bindgen_url);
+    // Create blob URL with embedded absolute URLs
+    let worker_url = create_worker_url(&wasm_url, &bindgen_url);
+    init_pool_with_handler(num_workers, &worker_url, Some(AsyncResultHandler::new())).await
+}
+
+/// Initialize the pool with a custom result handler.
+///
+/// Used internally by `init_pool_async` and `SyncExecutor` (sync).
+pub(crate) async fn init_pool_with_handler(
+    num_workers: Option<u32>,
+    worker_url: &str,
+    result_handler: Option<AsyncResultHandler>,
+) -> Result<(), String> {
+    init_registry();
+
+    let num_workers = num_workers.unwrap_or_else(get_hardware_concurrency);
+
+    let already_initialized = POOL.with(|pool| {
+        if pool.borrow().is_some() {
+            return true;
+        }
+        *pool.borrow_mut() = Some(WorkerPool::new(result_handler));
+        false
+    });
+
+    if already_initialized {
+        return Ok(());
+    }
+
+    // These will be captured by the closure, so that variables can be set when we receive the
+    // responses from workers
+    let workers_ready = Rc::new(RefCell::new(0));
+    let (ready_tx, ready_rx) = oneshot::channel::<Result<(), String>>();
+    let ready_tx = Rc::new(RefCell::new(Some(ready_tx)));
+
+    for i in 0..num_workers {
+        // worker_url is a blob URL with wasm/bindgen URLs already embedded
+        let worker =
+            Worker::new(worker_url).map_err(|e| format!("failed to create worker: {e:?}"))?;
+
+        // Set up message handler
+        let workers_ready = workers_ready.clone();
+        let ready_tx_clone = ready_tx.clone();
+        let onmessage = Closure::wrap(Box::new(move |event: web_sys::MessageEvent| {
+            handle_worker_message(event, &workers_ready, &ready_tx_clone, num_workers);
+        }) as Box<dyn FnMut(_)>);
+
+        worker.set_onmessage(Some(onmessage.as_ref().unchecked_ref()));
+        onmessage.forget();
+
+        // Set up error handler
+        let onerror = Closure::wrap(Box::new(move |e: web_sys::ErrorEvent| {
+            web_sys::console::error_1(
+                &format!(
+                    "Worker {} error: {} at {}:{}",
+                    i,
+                    e.message(),
+                    e.filename(),
+                    e.lineno()
+                )
+                .into(),
+            );
+        }) as Box<dyn FnMut(web_sys::ErrorEvent)>);
+
+        worker.set_onerror(Some(onerror.as_ref().unchecked_ref()));
+        onerror.forget();
+
+        POOL.with(|pool| {
+            pool.borrow_mut()
+                .as_mut()
+                .expect("pool exists at this point")
+                .workers
+                .push(worker);
+        });
+    }
+
+    // Wait for all workers to be ready
+    ready_rx
+        .await
+        .map_err(|_| "worker channel closed".to_string())?
+        .map_err(|e| format!("worker init failed: {e}"))?;
+
+    Ok(())
+}
+
+/// Initialize pool in sync mode.
+///
+/// Spawns a SyncExecutor worker which manages compute workers.
+/// Enables blocking `collect_vec_sync()` calls.
+///
+/// # Arguments
+/// * `num_workers` - Number of workers. If `None`, auto-detects via `hardwareConcurrency`.
+/// * `wasm_url` - URL to the WASM module
+/// * `bindgen_url` - URL to the wasm-bindgen JS glue
+///
+/// # Warning
+/// The coordinator Service Worker must already be registered from the main
+/// thread (via [`register_coordinator`]) before calling this.
+#[cfg(feature = "sync-api")]
+pub async fn init_pool_sync(
+    num_workers: Option<u32>,
+    wasm_url: &str,
+    bindgen_url: &str,
+) -> Result<(), String> {
+    // Resolve relative URLs to absolute - required because blob URL workers
+    // cannot resolve relative imports
+    let wasm_url = resolve_url(wasm_url);
+    let bindgen_url = resolve_url(bindgen_url);
+    register_sync_executor(num_workers, &wasm_url, &bindgen_url).await?;
+
+    Ok(())
+}
+
+/// Initialize pool in sync mode, reusing the current worker as SyncExecutor.
+///
+/// Use this when your code is already running in a dedicated worker and you
+/// want to call `collect_vec_sync()` directly, without spawning a separate
+/// SyncExecutor worker.
+///
+/// # Arguments
+/// * `num_workers` - Number of workers. If `None`, auto-detects via `hardwareConcurrency`.
+/// * `wasm_url` - URL to the WASM module
+/// * `bindgen_url` - URL to the wasm-bindgen JS glue
+///
+/// # Warning
+/// The coordinator Service Worker must already be registered from the main
+/// thread (via [`register_coordinator`]) before calling this.
+#[cfg(feature = "sync-api")]
+pub async fn init_pool_sync_from_worker(
+    num_workers: Option<u32>,
+    wasm_url: &str,
+    bindgen_url: &str,
+) -> Result<(), String> {
+    let origin = web_sys::Url::new(wasm_url)
+        .map(|u| u.origin())
+        .unwrap_or_default();
+
+    CoordinatorUrl::set(&origin);
+
+    wait_for_coordinator().await?;
+
+    let worker_url = create_worker_url(wasm_url, bindgen_url);
+    init_pool_with_handler(num_workers, &worker_url, None).await
+}
+
+fn handle_worker_message(
+    event: web_sys::MessageEvent,
+    workers_ready: &Rc<RefCell<u32>>,
+    ready_tx: &ReadySender,
+    num_workers: u32,
+) {
+    let msg: WorkerToMain = match messages::from_js(event.data()) {
+        Ok(m) => m,
+        Err(e) => {
+            web_sys::console::error_1(&format!("Failed to parse worker message: {e}").into());
+            return;
+        }
+    };
+
+    match msg {
+        WorkerToMain::Ready => {
+            let mut ready_count = workers_ready.borrow_mut();
+            *ready_count += 1;
+            if *ready_count == num_workers
+                && let Some(tx) = ready_tx.borrow_mut().take()
+            {
+                let _ = tx.send(Ok(()));
+            }
+        }
+        WorkerToMain::Done(chunk_outcome) => {
+            POOL.with(|pool| {
+                if let Some(ref mut p) = *pool.borrow_mut()
+                    && let Some(handler) = p.result_handler.as_mut()
+                {
+                    handler.handle_result(chunk_outcome.chunk_id, chunk_outcome.result)
+                } else {
+                    // Not a lot to do here apart from logging
+                    web_sys::console::warn_1(
+                        &format!(
+                            "Pool: dropping result for chunk {}, no handler available",
+                            chunk_outcome.chunk_id
+                        )
+                        .into(),
+                    );
+                }
+            });
+        }
+    }
+}
+
+fn send_to_worker(worker: &Worker, msg: &MainToWorker) -> Result<(), String> {
+    let js_msg = messages::to_js(msg)?;
+    worker.post_message(&js_msg).map_err(|e| format!("{e:?}"))
+}
+
+/// Check if the pool has been initialized
+pub fn is_pool_initialized() -> bool {
+    POOL.with(|pool| pool.borrow().is_some())
+}
+
+/// Get the number of workers in the pool
+pub fn num_workers() -> u32 {
+    POOL.with(|pool| pool.borrow().as_ref().map(|p| p.num_workers()).unwrap_or(0))
+}
+
+/// Submit a task to a worker and return a receiver for the result
+fn submit_chunk<F: RegisteredFn>(
+    f: FnEntry<F>,
+    data: Vec<u8>,
+) -> Result<oneshot::Receiver<Result<Vec<u8>, String>>, String> {
+    POOL.with(|pool| {
+        let mut pool = pool.borrow_mut();
+        let pool = pool.as_mut().ok_or("pool not initialized")?;
+
+        let chunk_id = pool.next_chunk_id();
+        let (tx, rx) = oneshot::channel();
+        let handler = pool
+            .result_handler
+            .as_mut()
+            // Async submission requires result_handler (oneshot channels).
+            // In sync mode, results go through the coordinator instead; mixing is not supported.
+            // Maybe at some point we could add some static typing tricks to check that they are
+            // not mixed but it would require a larger refactor.
+            .ok_or("pool initialized in sync mode, but called async API (collect_vec). Use collect_vec_sync instead.")?;
+        handler.register_waiter(chunk_id, tx);
+
+        let worker_idx = pool.next_worker_idx();
+        if let Some(worker) = pool.workers.get(worker_idx as usize) {
+            send_to_worker(
+                worker,
+                &MainToWorker {
+                    chunk_id,
+                    fn_id: f.id().clone(),
+                    data,
+                    #[cfg(feature = "sync-api")]
+                    task_id: None,
+                },
+            )?;
+        }
+
+        Ok(rx)
+    })
+}
+
+/// Submit a task without waiting for the result (sync mode).
+/// Returns the chunk_id for later retrieval.
+#[cfg(feature = "sync-api")]
+pub(crate) fn submit_chunk_sync<F: RegisteredFn>(
+    f: FnEntry<F>,
+    data: Vec<u8>,
+    task_id: u64,
+) -> Result<(), String> {
+    POOL.with(|pool| {
+        let mut pool = pool.borrow_mut();
+        let pool = pool.as_mut().ok_or("pool not initialized")?;
+
+        let chunk_id = pool.next_chunk_id();
+
+        let worker_idx = pool.next_worker_idx();
+        if let Some(worker) = pool.workers.get(worker_idx as usize) {
+            send_to_worker(
+                worker,
+                &MainToWorker {
+                    chunk_id,
+                    fn_id: f.id().clone(),
+                    data,
+                    task_id: Some(task_id),
+                },
+            )?;
+        }
+
+        Ok(())
+    })
+}
+
+/// Execute a parallel map operation across workers
+pub(crate) async fn execute_par_map<F, I, O>(f: FnEntry<F>, data: &[I]) -> Result<Vec<O>, String>
+where
+    I: serde::Serialize,
+    O: serde::de::DeserializeOwned,
+    F: RegisteredFn<Input = I, Output = O>,
+{
+    if data.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let num_workers = num_workers();
+
+    if num_workers == 0 {
+        return Err("No workers initialized".to_string());
+    }
+
+    let chunk_size = data.len().div_ceil(num_workers as usize);
+    let chunks = data.chunks(chunk_size);
+
+    let mut receivers = Vec::with_capacity(chunks.len());
+    for chunk in chunks {
+        let chunk_bytes =
+            postcard::to_allocvec(&chunk).map_err(|e| format!("serialize chunk error: {e}"))?;
+        let rx = submit_chunk::<F>(f.clone(), chunk_bytes)?;
+        receivers.push(rx);
+    }
+
+    let mut results = Vec::with_capacity(data.len());
+    for rx in receivers {
+        let result_bytes = rx.await.map_err(|_| "task channel closed".to_string())??;
+        let chunk_results: Vec<O> =
+            postcard::from_bytes(&result_bytes).map_err(|e| format!("deserialize result: {e}"))?;
+        results.extend(chunk_results);
+    }
+
+    Ok(results)
+}
+
+#[cfg(feature = "sync-api")]
+pub(crate) fn execute_par_map_sync<F, I, O>(f: FnEntry<F>, data: &[I]) -> Result<Vec<O>, String>
+where
+    I: serde::Serialize,
+    O: serde::de::DeserializeOwned,
+    F: RegisteredFn<Input = I, Output = O>,
+{
+    if data.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let num_workers = num_workers();
+
+    if num_workers == 0 {
+        return Err("No workers initialized".to_string());
+    }
+
+    let task_id = next_task_id()?;
+
+    let chunk_size = data.len().div_ceil(num_workers as usize);
+    let chunks = data.chunks(chunk_size);
+    // Register the task in the coordinator
+    register_task(task_id, chunks.len())?;
+
+    // Send all chunks to workers
+    for chunk in chunks {
+        let chunk_res = postcard::to_allocvec(&chunk)
+            .map_err(|e| format!("serialize chunk error: {e}"))
+            .and_then(|chunk_bytes| submit_chunk_sync::<F>(f.clone(), chunk_bytes, task_id));
+        if let Err(e) = chunk_res {
+            cancel_task(task_id)?;
+            return Err(e);
+        }
+    }
+
+    // Block on the coordinator until the task completes
+    let res_chunks = wait_task(task_id)?;
+
+    let mut results = Vec::with_capacity(data.len());
+    for result_bytes in res_chunks {
+        let chunk_results: Vec<O> =
+            postcard::from_bytes(&result_bytes).map_err(|e| format!("deserialize result: {e}"))?;
+        results.extend(chunk_results);
+    }
+
+    Ok(results)
+}
+
+#[cfg(feature = "sync-api")]
+pub(crate) fn next_task_id() -> Result<u64, String> {
+    POOL.with(|pool| {
+        let mut pool = pool.borrow_mut();
+        let pool = pool.as_mut().ok_or("pool not initialized")?;
+        Ok(pool.next_task_id())
+    })
+}

--- a/utils/wasm-par-mq/src/registry.rs
+++ b/utils/wasm-par-mq/src/registry.rs
@@ -1,0 +1,271 @@
+/// Global registry of functions that can be called as worker tasks.
+///
+/// Since workers communicate with message passing, all the data needs to be serializable.
+/// This means that the function to be run in a task cannot simply be given as an argument. To
+/// circumvent this, we register a list of functions that can be called in this global
+/// registry, along with their names. This registration happens in the main wasm thread and in
+/// the workers, and only depends on compile time information, such that they will all end up
+/// with the exact same registry.
+/// The main thread will thus only have to send the name of the function to call, and the
+/// workers will be able to call them through their local registry.
+///
+/// # Example
+/// ```ignore
+/// use wasm_par_mq::{ParallelIterator, ParallelSlice, par_fn, register_fn};
+/// fn double(x: i32) -> i32 { x * 2 }
+/// register_fn!(double, i32, i32);
+///
+/// #[wasm_bindgen]
+/// pub async fn double_all(data: Vec<i32>) -> Vec<i32> {
+///     data.par_iter().map(par_fn!(double)).collect_vec().await
+/// }
+/// ```
+use serde::Deserialize;
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+
+use std::borrow::Cow;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::hash::Hash;
+use std::marker::PhantomData;
+
+/// A unique id for a function, used as a key in the registry
+///
+/// Even if this type is Serialize, it should not be shared between different compiled binaries
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+pub(crate) struct FunctionId(Cow<'static, str>);
+
+impl FunctionId {
+    pub(crate) const fn from_name(name: &'static str) -> Self {
+        Self(Cow::Borrowed(name))
+    }
+}
+
+/// Type-erased function that operates on a serialized chunk and returns serialized results.
+/// The function processes each item in the chunk and returns a Vec of results.
+type ErasedChunkFn = Box<dyn Fn(&[u8]) -> Result<Vec<u8>, String>>;
+
+/// A function entry that will be inserted in the registry.
+// Needs to be const constructible because the registry is populated with `inventory`
+pub struct NewFnEntry {
+    // In theory, there are a few solutions to create a new ID:
+    // - the `stringify!` macro, but it is not unique
+    // - TypeId, but it is opaque (worse for debug) and not serializable
+    // - type_name, which is unique and user friendly.
+    // However type_name is not const as of rust 1.93, so instead of the name we store a function
+    // pointer that can be called later at runtime.
+    name_fn: fn() -> &'static str,
+    handler: fn(&[u8]) -> Result<Vec<u8>, String>,
+}
+
+impl NewFnEntry {
+    /// Create a new function entry to be inserted in the registry.
+    ///
+    /// SHOULD NOT be called directly, use the [`register_fn!`] macro
+    // Made pub because it will be called in the macro that lives in user code.
+    pub const fn new(
+        handler: fn(&[u8]) -> Result<Vec<u8>, String>,
+        name_fn: fn() -> &'static str,
+    ) -> Self {
+        Self { name_fn, handler }
+    }
+}
+
+/// An entry in the Registry. Can be used to send a task function to call to the workers
+// A wrapper for the FunctionId, with type information for compile time checks
+pub struct FnEntry<F> {
+    fn_id: FunctionId,
+    _phantom: PhantomData<F>,
+}
+
+impl<F: RegisteredFn> FnEntry<F> {
+    /// Returns the associated entry for an already registered function.
+    ///
+    /// SHOULD NOT be called directly, use the [`par_fn!`] macro
+    pub fn new() -> Self {
+        Self {
+            fn_id: FunctionId::from_name(F::name()),
+            _phantom: PhantomData,
+        }
+    }
+
+    pub(crate) fn id(&self) -> &FunctionId {
+        &self.fn_id
+    }
+}
+
+impl<F: RegisteredFn> Default for FnEntry<F> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<F> Clone for FnEntry<F> {
+    fn clone(&self) -> Self {
+        Self {
+            fn_id: self.fn_id.clone(),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+/// Marker trait for a function that has been added to the registry.
+///
+/// This SHOULD NOT be implemented manually, use the [`register_fn!`] macro
+// Trait needs to be pub and cannot be sealed because it will be called by the macro from user code
+pub trait RegisteredFn {
+    type Input;
+    type Output;
+
+    fn name() -> &'static str {
+        std::any::type_name::<Self>()
+    }
+}
+
+/// Deserialize as a Vec of items
+///
+/// SHOULD NOT be called directly, use the [`register_fn!`] macro
+// Made pub because it will be called in the macro that lives in user code.
+pub fn deserialize_input_chunk<I: DeserializeOwned>(input_chunk: &[u8]) -> Result<Vec<I>, String> {
+    postcard::from_bytes(input_chunk).map_err(|e| format!("deserialize chunk error: {e}"))
+}
+
+/// Serialize the results
+///
+/// SHOULD NOT be called directly, use the [`register_fn!`] macro
+// Made pub because it will be called in the macro that lives in user code.
+pub fn serialize_output_chunk<O: Serialize>(output_chunk: Vec<O>) -> Result<Vec<u8>, String> {
+    postcard::to_allocvec(&output_chunk).map_err(|e| format!("serialize results error: {e}"))
+}
+
+// Collect all the NewFnEntry objects registered by user code
+inventory::collect!(NewFnEntry);
+
+thread_local! {
+    /// Global registry for chunk-processing functions (used by workers)
+    static REGISTRY: RefCell<HashMap<FunctionId, ErasedChunkFn>> = RefCell::new(HashMap::new());
+}
+
+/// Initializes the registry with user defined functions, registered with the `register_fn` macro.
+///
+/// This should be called once at program startup.
+pub(crate) fn init_registry() {
+    REGISTRY.with(|registry| {
+        let mut registry = registry.borrow_mut();
+
+        // The inventory doc advises calling `__wasm_call_ctors` before iterating. However, when
+        // using wasm-bindgen, ctors are handled automatically, so no manual call is needed. Calling
+        // it twice could be dangerous if other dependencies add non-idempotent ctors.
+        for entry in inventory::iter::<NewFnEntry> {
+            registry.insert(
+                FunctionId::from_name((entry.name_fn)()),
+                Box::new(entry.handler),
+            );
+        }
+    });
+}
+
+/// Execute a registered chunk function by name with serialized input data.
+/// The input should be a serialized Vec of items, and the output is a serialized Vec of results.
+pub(crate) fn execute(fn_id: FunctionId, data: &[u8]) -> Result<Vec<u8>, String> {
+    REGISTRY.with(|registry| {
+        let registry = registry.borrow();
+        let f = registry
+            .get(&fn_id)
+            .ok_or_else(|| format!("function {} not found in registry", fn_id.0))?;
+        f(data)
+    })
+}
+
+/// Macro to register a function that processes individual items.
+/// The function will be applied to each element in a chunk.
+///
+/// # Example
+/// ```ignore
+/// fn double(x: i32) -> i32 { x * 2 }
+/// register_fn!(double, i32, i32);
+/// ```
+#[macro_export]
+macro_rules! register_fn {
+    ($fn:ident, $input:ty, $output:ty) => {
+        $crate::__private::paste! {
+            fn [<__handler_ $fn>](data: &[u8]) -> Result<Vec<u8>, String> {
+                let inputs: Vec<$input> = $crate::__private::deserialize_input_chunk(data)?;
+                let outputs: Vec<$output> = inputs.into_iter().map($fn).collect();
+                $crate::__private::serialize_output_chunk(outputs)
+            }
+
+            // Create a type with the same name as the function. Since types and values live in
+            // different namespaces, it will not clash.
+            //
+            // This type is used as a marker type that will be used to add a compile time checks
+            // that a function called with `par_fn!` has previously been registered.
+            // The error message is not really good but at least it will refuse to compile.
+            #[doc(hidden)]
+            #[allow(non_camel_case_types)]
+            pub struct $fn {}
+            impl $crate::__private::RegisteredFn for $fn {
+                type Input = $input;
+                type Output = $output;
+            }
+
+            $crate::__private::submit_fn_entry! {
+                $crate::__private::NewFnEntry::new([<__handler_ $fn>],
+                    <$fn as $crate::__private::RegisteredFn>::name)
+            }
+        }
+    };
+}
+
+/// This macro is used to wrap a function that can be called inside a parallel map.
+///
+/// # Warning
+/// The function must have been registered with `register_fn!` before
+///
+/// # Example
+/// ```ignore
+/// fn double(x: i32) -> i32 { x * 2 }
+/// register_fn!(double, i32, i32);
+///
+/// #[wasm_bindgen]
+/// pub async fn double_all(data: Vec<i32>) -> Vec<i32> {
+///     data.par_iter().map(par_fn!(double)).collect_vec().await
+/// }
+/// ```
+#[macro_export]
+macro_rules! par_fn {
+    ($fn: ident) => {
+        $crate::__private::FnEntry::<$fn>::new()
+    };
+}
+
+/// This macro is used to wrap a sync function that can be called with execute_async,
+/// and will call `collect_vec_sync`.
+///
+/// # Warning
+/// The function must have been registered with `register_fn!` before
+///
+/// # Example
+/// ```ignore
+/// fn double(x: i32) -> i32 { x * 2 }
+/// register_fn!(double, i32, i32);
+///
+/// fn double_all(data: Vec<i32>) -> Vec<i32> {
+///     data.par_iter().map(par_fn!(double)).collect_vec_sync()
+/// }
+/// register_fn!(double_all, Vec<i32>, Vec<i32>);
+///
+/// #[wasm_bindgen]
+/// pub async fn double_all_sync(data: Vec<i32>) -> Result<Vec<i32>, JsValue> {
+///     execute_async(sync_fn!(double_all_impl), &data)
+///         .await
+///         .map_err(|e| JsValue::from_str(&e))
+/// }
+/// ```
+#[macro_export]
+macro_rules! sync_fn {
+    ($fn: ident) => {
+        $crate::__private::FnEntry::<$fn>::new()
+    };
+}

--- a/utils/wasm-par-mq/src/sync_executor.rs
+++ b/utils/wasm-par-mq/src/sync_executor.rs
@@ -1,0 +1,319 @@
+//! A dedicated worker that runs user's synchronous parallel code.
+//!
+//! The SyncExecutor is spawned by the main thread and initializes the worker
+//! pool with a sync result handler. It receives work requests from the main
+//! thread, executes user code that may call `collect_vec_sync()`, and returns
+//! results.
+//!
+//! The sync blocking is achieved by:
+//! 1. Dispatching chunks to compute workers via postMessage
+//! 2. Blocking on a sync XHR to the Coordinator (Service Worker)
+//! 3. When XHR returns, the queued postMessage results are processed
+//! 4. Results are collected and returned
+//!
+//! The SyncExecutor is required for this, since modern browsers reject sync
+//! XHR requests from the main thread.
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+use futures::channel::oneshot;
+use wasm_bindgen::prelude::*;
+use web_sys::{DedicatedWorkerGlobalScope, MessageEvent, Worker};
+
+use crate::coordinator::CoordinatorUrl;
+use crate::global_this;
+use crate::messages::{self, JobOutcome, MainToSyncExecutor, SyncExecutorToMain};
+use crate::pool::{self, ReadySender};
+use crate::registry::{FnEntry, RegisteredFn};
+use crate::worker::create_worker_url;
+
+thread_local! {
+    static SYNC_EXECUTOR: RefCell<Option<SyncExecutor>> = const { RefCell::new(None) };
+}
+
+struct SyncExecutor {
+    worker: Worker,
+    waiters: HashMap<u64, oneshot::Sender<Result<Vec<u8>, String>>>,
+    next_job_id: u64,
+}
+
+impl SyncExecutor {
+    pub fn new(worker: Worker) -> Self {
+        Self {
+            worker,
+            waiters: HashMap::new(),
+            next_job_id: 0,
+        }
+    }
+
+    fn next_job_id(&mut self) -> u64 {
+        let id = self.next_job_id;
+        self.next_job_id = self.next_job_id.checked_add(1).expect("job id overflow");
+        id
+    }
+}
+
+const SYNC_EXECUTOR_JS_TEMPLATE: &str = include_str!("../js/sync_executor.js");
+
+/// Create a blob URL for the sync executor script with the given URLs embedded.
+pub(crate) fn create_sync_executor_url(
+    wasm_url: &str,
+    bindgen_url: &str,
+    num_workers: Option<u32>,
+) -> String {
+    let js_code = SYNC_EXECUTOR_JS_TEMPLATE
+        .replace("__WASM_URL__", wasm_url)
+        .replace("__BINDGEN_URL__", bindgen_url)
+        .replace(
+            "__WORKERS__",
+            &num_workers
+                .map(|n| n.to_string())
+                .unwrap_or(String::from("undefined")),
+        );
+
+    let prop = web_sys::BlobPropertyBag::new();
+    prop.set_type("application/javascript");
+    let blob = web_sys::Blob::new_with_str_sequence_and_options(
+        &js_sys::Array::of1(&js_code.into()),
+        &prop,
+    )
+    .unwrap();
+    web_sys::Url::create_object_url_with_blob(&blob).unwrap()
+}
+
+pub(crate) async fn register_sync_executor(
+    num_workers: Option<u32>,
+    wasm_url: &str,
+    bindgen_url: &str,
+) -> Result<(), String> {
+    let (ready_tx, ready_rx) = oneshot::channel::<Result<(), String>>();
+    let ready_tx = Rc::new(RefCell::new(Some(ready_tx)));
+
+    let sync_executor_url = create_sync_executor_url(wasm_url, bindgen_url, num_workers);
+
+    let executor = Worker::new(&sync_executor_url)
+        .map_err(|e| format!("failed to create SyncExecutor: {e:?}"))?;
+
+    // Set up message handler to wait for ready signal
+    let ready_tx = ready_tx.clone();
+    let onmessage = Closure::wrap(Box::new(move |event: web_sys::MessageEvent| {
+        handle_sync_executor_message(event, &ready_tx)
+    }) as Box<dyn FnMut(_)>);
+
+    executor.set_onmessage(Some(onmessage.as_ref().unchecked_ref()));
+    onmessage.forget();
+
+    // Set up error handler
+    let onerror = Closure::wrap(Box::new(move |e: web_sys::ErrorEvent| {
+        web_sys::console::error_1(
+            &format!(
+                "SyncExecutor error: {} at {}:{}",
+                e.message(),
+                e.filename(),
+                e.lineno()
+            )
+            .into(),
+        );
+    }) as Box<dyn FnMut(_)>);
+    executor.set_onerror(Some(onerror.as_ref().unchecked_ref()));
+    onerror.forget();
+
+    // Store executor reference
+    SYNC_EXECUTOR.set(Some(SyncExecutor::new(executor)));
+
+    // Wait for SyncExecutor to be ready
+    ready_rx
+        .await
+        .map_err(|_| "SyncExecutor channel closed".to_string())?
+        .map_err(|e| format!("SyncExecutor init failed: {e}"))?;
+
+    Ok(())
+}
+
+fn handle_sync_executor_message(event: web_sys::MessageEvent, ready_tx: &ReadySender) {
+    {
+        let msg: SyncExecutorToMain = match messages::from_js(event.data()) {
+            Ok(m) => m,
+            Err(e) => {
+                web_sys::console::error_1(
+                    &format!("Failed to parse SyncExecutor message: {e}").into(),
+                );
+                return;
+            }
+        };
+        match msg {
+            SyncExecutorToMain::Ready => {
+                if let Some(tx) = ready_tx.borrow_mut().take() {
+                    let _ = tx.send(Ok(()));
+                }
+            }
+            SyncExecutorToMain::Done(outcome) => {
+                SYNC_EXECUTOR.with(|executor| {
+                    if let Some(ref mut executor) = *executor.borrow_mut()
+                        && let Some(tx) = executor.waiters.remove(&outcome.job_id)
+                    {
+                        let _ = tx.send(outcome.result);
+                    } else {
+                        web_sys::console::warn_1(
+                            &format!(
+                                "SyncExecutor: dropping result for job {}, no waiter",
+                                outcome.job_id
+                            )
+                            .into(),
+                        );
+                    }
+                });
+            }
+        }
+    }
+}
+
+/// Entry point called from sync_executor.js bootstrap.
+#[wasm_bindgen]
+pub fn start_sync_executor(wasm_url: &str, bindgen_url: &str, num_workers: Option<u32>) {
+    let origin = web_sys::Url::new(wasm_url)
+        .map(|u| u.origin())
+        .unwrap_or_default();
+
+    CoordinatorUrl::set(&origin);
+
+    let global: DedicatedWorkerGlobalScope = global_this().unchecked_into();
+
+    // Create blob URL for compute workers (URLs already absolute from main thread)
+    let worker_url = create_worker_url(wasm_url, bindgen_url);
+
+    // Initialize the pool with sync result handler
+    // We use spawn_local since init_pool_with_handler is async (waits for workers to be ready)
+    wasm_bindgen_futures::spawn_local(async move {
+        // Wait until the Service Worker is intercepting our requests.
+        if let Err(e) = crate::coordinator::wait_for_coordinator().await {
+            web_sys::console::error_1(&format!("SyncExecutor: {e}").into());
+            return;
+        }
+
+        if let Err(e) = pool::init_pool_with_handler(num_workers, &worker_url, None).await {
+            web_sys::console::error_1(&format!("Failed to init pool: {e}").into());
+            return;
+        }
+
+        // Signal ready to main thread
+        send_to_main(&SyncExecutorToMain::Ready);
+    });
+
+    // Set up message handler for work requests from main thread
+    let onmessage = Closure::wrap(Box::new(handle_job_message) as Box<dyn FnMut(_)>);
+    global.set_onmessage(Some(onmessage.as_ref().unchecked_ref()));
+    onmessage.forget();
+}
+
+/// Handle messages from the main thread.
+fn handle_job_message(event: MessageEvent) {
+    let msg: MainToSyncExecutor = match messages::from_js(event.data()) {
+        Ok(m) => m,
+        Err(e) => {
+            web_sys::console::error_1(
+                &format!("SyncExecutor: failed to parse message: {e}").into(),
+            );
+            return;
+        }
+    };
+
+    match msg {
+        MainToSyncExecutor::Job {
+            job_id,
+            fn_id,
+            data,
+        } => {
+            // Execute the registered function
+            let result = crate::registry::execute(fn_id, &data);
+            let outcome = JobOutcome { job_id, result };
+            send_to_main(&SyncExecutorToMain::Done(outcome));
+        }
+    }
+}
+
+/// Send a message to the main thread.
+fn send_to_main(msg: &SyncExecutorToMain) {
+    let global: DedicatedWorkerGlobalScope = global_this().unchecked_into();
+    match messages::to_js(msg) {
+        Ok(js_msg) => {
+            if let Err(e) = global.post_message(&js_msg) {
+                web_sys::console::error_1(
+                    &format!("SyncExecutor: failed to post message: {e:?}").into(),
+                );
+            }
+        }
+        Err(e) => {
+            web_sys::console::error_1(
+                &format!("SyncExecutor: failed to serialize message: {e}").into(),
+            );
+        }
+    }
+}
+
+fn send_to_sync_executor(msg: &MainToSyncExecutor) -> Result<(), String> {
+    let js_msg = messages::to_js(msg)?;
+    SYNC_EXECUTOR.with(|se_worker| {
+        se_worker
+            .borrow()
+            .as_ref()
+            .ok_or("pool not initialized")?
+            .worker
+            .post_message(&js_msg)
+            .map_err(|e| format!("{e:?}"))
+    })
+}
+
+pub async fn execute_async<F, I, O>(f: FnEntry<F>, input: &I) -> Result<O, String>
+where
+    I: serde::Serialize,
+    O: serde::de::DeserializeOwned,
+    F: RegisteredFn<Input = I, Output = O>,
+{
+    // Wrap input in a single-element Vec to match the chunk-based registry format.
+    // The registered handler expects Vec<Input> and returns Vec<Output>.
+    // We use Vec (not array) because postcard serializes arrays without length prefix,
+    // but Vec deserialization expects one.
+    let wrapped_input = vec![input];
+    let data =
+        postcard::to_allocvec(&wrapped_input).map_err(|e| format!("serialize input error: {e}"))?;
+
+    let (tx, rx) = oneshot::channel();
+    let job_id = next_job_id()?;
+
+    SYNC_EXECUTOR.with(|executor| -> Result<(), String> {
+        let mut executor = executor.borrow_mut();
+        let executor = executor.as_mut().ok_or("Sync Executor not initialized")?;
+
+        executor.waiters.insert(job_id, tx);
+
+        Ok(())
+    })?;
+
+    let job = MainToSyncExecutor::Job {
+        job_id,
+        fn_id: f.id().clone(),
+        data,
+    };
+    send_to_sync_executor(&job).map_err(|e| format!("Failed to run job on sync executor {e}"))?;
+
+    let result_bytes: Vec<u8> = rx.await.map_err(|_| "task channel closed".to_string())??;
+
+    // Unwrap the Vec<Output> to get the single result
+    let results: Vec<O> =
+        postcard::from_bytes(&result_bytes).map_err(|e| format!("deserialize result: {e}"))?;
+    results
+        .into_iter()
+        .next()
+        .ok_or_else(|| "empty result from sync executor".to_string())
+}
+
+pub(crate) fn next_job_id() -> Result<u64, String> {
+    SYNC_EXECUTOR.with(|executor| {
+        let mut executor = executor.borrow_mut();
+        let executor = executor.as_mut().ok_or("Sync Executor not initialized")?;
+        Ok(executor.next_job_id())
+    })
+}

--- a/utils/wasm-par-mq/src/worker.rs
+++ b/utils/wasm-par-mq/src/worker.rs
@@ -1,0 +1,115 @@
+#[cfg(feature = "sync-api")]
+use crate::coordinator::{CoordinatorUrl, signal_done_to_coordinator};
+use crate::global_this;
+use crate::messages::{ChunkOutcome, MainToWorker, WorkerToMain, from_js, to_js};
+use crate::registry::{self, init_registry};
+
+use wasm_bindgen::prelude::*;
+use web_sys::{DedicatedWorkerGlobalScope, MessageEvent};
+
+/// Entry point called from worker.js bootstrap.
+/// Sets up message handling for task execution.
+#[wasm_bindgen]
+pub fn start_worker(origin: &str) {
+    init_registry();
+
+    #[cfg(feature = "sync-api")]
+    CoordinatorUrl::set(origin);
+
+    #[cfg(not(feature = "sync-api"))]
+    let _ = origin;
+
+    let global: DedicatedWorkerGlobalScope = global_this().unchecked_into();
+
+    let onmessage = Closure::wrap(Box::new(handle_chunk_message) as Box<dyn FnMut(MessageEvent)>);
+    global.set_onmessage(Some(onmessage.as_ref().unchecked_ref()));
+    onmessage.forget();
+
+    // Signal ready to parent (main thread or SyncExecutor)
+    send_to_main(&WorkerToMain::Ready);
+}
+
+const WORKER_JS_TEMPLATE: &str = include_str!("../js/worker.js");
+
+/// Create a blob URL for the worker script with the given wasm and bindgen URLs embedded.
+pub(crate) fn create_worker_url(wasm_url: &str, bindgen_url: &str) -> String {
+    // Substitute values into the template
+    let js_code = WORKER_JS_TEMPLATE
+        .replace("__WASM_URL__", wasm_url)
+        .replace("__BINDGEN_URL__", bindgen_url);
+
+    let prop = web_sys::BlobPropertyBag::new();
+    prop.set_type("application/javascript");
+    let blob = web_sys::Blob::new_with_str_sequence_and_options(
+        &js_sys::Array::of1(&js_code.into()),
+        &prop,
+    )
+    .unwrap();
+    web_sys::Url::create_object_url_with_blob(&blob).unwrap()
+}
+
+/// Resolve a potentially relative URL to an absolute URL using the current location as base.
+pub(crate) fn resolve_url(url: &str) -> String {
+    let base = {
+        let global = global_this();
+        js_sys::Reflect::get(&global, &"location".into())
+            .ok()
+            .and_then(|loc| {
+                js_sys::Reflect::get(&loc, &"href".into())
+                    .ok()
+                    .and_then(|href| href.as_string())
+            })
+    };
+
+    match base {
+        Some(base) => web_sys::Url::new_with_base(url, &base)
+            .map(|u| u.href())
+            .unwrap_or_else(|_| url.to_string()),
+        None => url.to_string(),
+    }
+}
+
+fn handle_chunk_message(event: MessageEvent) {
+    let msg: MainToWorker = match from_js(event.data()) {
+        Ok(m) => m,
+        Err(e) => {
+            web_sys::console::error_1(&format!("Failed to parse message: {e}").into());
+            return;
+        }
+    };
+
+    let MainToWorker {
+        chunk_id,
+        fn_id,
+        data,
+        #[cfg(feature = "sync-api")]
+        task_id,
+    } = msg;
+
+    let result = registry::execute(fn_id, &data);
+    let outcome = ChunkOutcome { chunk_id, result };
+
+    #[cfg(feature = "sync-api")]
+    // If there is a task id, it means that the pool is running in sync mode
+    if let Some(task_id) = task_id {
+        signal_done_to_coordinator(task_id, outcome);
+    } else {
+        send_to_main(&WorkerToMain::Done(outcome));
+    }
+
+    #[cfg(not(feature = "sync-api"))]
+    send_to_main(&WorkerToMain::Done(outcome));
+}
+
+/// Send a message to the main thread.
+pub(crate) fn send_to_main(msg: &WorkerToMain) {
+    let global: DedicatedWorkerGlobalScope = global_this().unchecked_into();
+    match to_js(msg) {
+        Ok(js_msg) => {
+            let _ = global.post_message(&js_msg);
+        }
+        Err(e) => {
+            web_sys::console::error_1(&format!("Failed to serialize message: {e}").into());
+        }
+    }
+}

--- a/utils/wasm-par-mq/web_tests/.gitignore
+++ b/utils/wasm-par-mq/web_tests/.gitignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/utils/wasm-par-mq/web_tests/Cargo.toml
+++ b/utils/wasm-par-mq/web_tests/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "wasm-par-mq-web-tests"
+version = "0.1.0"
+edition = "2024"
+rust-version.workspace = true
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wasm-par-mq = { path = "..", features = ["sync-api"] }
+wasm-bindgen = { workspace = true }
+wasm-bindgen-futures = "0.4"
+serde = { workspace = true, features = ["derive"] }
+serde-wasm-bindgen = { workspace = true }
+console_error_panic_hook = "0.1"

--- a/utils/wasm-par-mq/web_tests/index.html
+++ b/utils/wasm-par-mq/web_tests/index.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>wasm-par-mq Web Tests</title>
+    <link rel="icon" href="data:,">
+</head>
+<body>
+    <h1>wasm-par-mq Web Tests</h1>
+    <input type="checkbox" id="testSuccess" disabled />
+    <input type="text" id="benchmarkResults" disabled />
+
+    <input type="button" id="doubleAllAsyncTest" value="doubleAllAsyncTest" disabled />
+    <input type="button" id="doubleThenSquareAsyncTest" value="doubleThenSquareAsyncTest" disabled />
+    <input type="button" id="doubleAllSyncTest" value="doubleAllSyncTest" disabled max="120" />
+
+    <script type="module">
+        import init, * as wasm from './pkg/wasm_par_mq_web_tests.js';
+
+        const WASM_URL = './pkg/wasm_par_mq_web_tests_bg.wasm';
+        const BINDGEN_URL = './pkg/wasm_par_mq_web_tests.js';
+        const NUM_WORKERS = 4;
+
+        function arraysEqual(a, b) {
+            if (a.length !== b.length) return false;
+            for (let i = 0; i < a.length; i++) {
+                if (a[i] !== b[i]) return false;
+            }
+            return true;
+        }
+
+        function assert(condition, message) {
+            if (!condition) {
+                throw new Error(`Assertion failed: ${message}`);
+            }
+        }
+
+        async function initWasmAsync() {
+            await init(WASM_URL);
+            await wasm.init_async(NUM_WORKERS, WASM_URL, BINDGEN_URL);
+        }
+
+        async function initWasmSync() {
+            await init(WASM_URL);
+            await wasm.init_sync(NUM_WORKERS, WASM_URL, BINDGEN_URL, '/sw.js');
+        }
+
+        // --- Test implementations ---
+
+        async function doubleAllAsyncTest() {
+            await initWasmAsync();
+
+            const input = Array.from({ length: 100 }, (_, i) => i + 1);
+            const result = await wasm.double_all(input);
+            const expected = input.map(x => x * 2);
+            assert(arraysEqual(result, expected),
+                `double_all: expected [${expected.slice(0, 5)}...] got [${result.slice(0, 5)}...]`);
+            console.log('PASS: doubleAllAsyncTest');
+        }
+
+        async function doubleThenSquareAsyncTest() {
+            await initWasmAsync();
+
+            const input = [1, 2, 3, 4, 5];
+            const result = await wasm.double_then_square(input);
+            const expected = [4, 16, 36, 64, 100]; // (x*2)^2
+            assert(arraysEqual(result, expected),
+                `double_then_square: expected [${expected}] got [${result}]`);
+            console.log('PASS: doubleThenSquareAsyncTest');
+        }
+
+        async function doubleAllSyncTest() {
+            await initWasmSync();
+
+            const input = Array.from({ length: 100 }, (_, i) => i + 1);
+            const result = await wasm.double_all_sync(input);
+            const expected = input.map(x => x * 2);
+            assert(arraysEqual(result, expected),
+                `double_all_sync: expected [${expected.slice(0, 5)}...] got [${result.slice(0, 5)}...]`);
+            console.log('PASS: doubleAllSyncTest');
+        }
+
+        // --- Wire up buttons ---
+
+        const tests = {
+            doubleAllAsyncTest,
+            doubleThenSquareAsyncTest,
+            doubleAllSyncTest,
+        };
+
+        for (const [id, fn] of Object.entries(tests)) {
+            const button = document.getElementById(id);
+            button.onclick = async () => {
+                document.getElementById('testSuccess').checked = false;
+                try {
+                    await fn();
+                    document.getElementById('testSuccess').checked = true;
+                } catch (error) {
+                    console.error(`FAIL: ${id}: ${error}`);
+                    document.getElementById('testSuccess').checked = false;
+                }
+            };
+            button.disabled = false;
+        }
+    </script>
+</body>
+</html>

--- a/utils/wasm-par-mq/web_tests/package.json
+++ b/utils/wasm-par-mq/web_tests/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "wasm-par-mq-web-tests",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build": "cp ../js/coordinator.js pkg/ && mkdir -p dist && cp index.html dist/ && cp sw.js dist/ && cp -r pkg dist/",
+    "server": "serve --config ../serve.json dist/"
+  },
+  "devDependencies": {
+    "serve": "^14.2.5"
+  }
+}

--- a/utils/wasm-par-mq/web_tests/serve.json
+++ b/utils/wasm-par-mq/web_tests/serve.json
@@ -1,0 +1,11 @@
+{
+  "headers": [
+    {
+      "source": "**/*.@(js|html)",
+      "headers": [
+        { "key": "Cross-Origin-Embedder-Policy", "value": "unsafe-none" },
+        { "key": "Cross-Origin-Opener-Policy", "value": "unsafe-none" }
+      ]
+    }
+  ]
+}

--- a/utils/wasm-par-mq/web_tests/src/lib.rs
+++ b/utils/wasm-par-mq/web_tests/src/lib.rs
@@ -1,0 +1,71 @@
+use wasm_bindgen::prelude::*;
+use wasm_par_mq::{ParallelIterator, ParallelSlice, execute_async, par_fn, register_fn, sync_fn};
+
+#[wasm_bindgen(start)]
+pub fn init() {
+    console_error_panic_hook::set_once();
+}
+
+fn double(x: i32) -> i32 {
+    x * 2
+}
+register_fn!(double, i32, i32);
+
+fn square(x: i32) -> i32 {
+    x * x
+}
+register_fn!(square, i32, i32);
+
+/// Double all numbers using async workers.
+#[wasm_bindgen]
+pub async fn double_all(data: Vec<i32>) -> Vec<i32> {
+    data.par_iter().map(par_fn!(double)).collect_vec().await
+}
+
+/// Chain two parallel operations: double then square.
+#[wasm_bindgen]
+pub async fn double_then_square(data: Vec<i32>) -> Vec<i32> {
+    let doubled: Vec<i32> = data.par_iter().map(par_fn!(double)).collect_vec().await;
+    doubled.par_iter().map(par_fn!(square)).collect_vec().await
+}
+
+/// Double all numbers using the sync executor.
+fn double_all_impl(data: Vec<i32>) -> Vec<i32> {
+    data.par_iter().map(par_fn!(double)).collect_vec_sync()
+}
+register_fn!(double_all_impl, Vec<i32>, Vec<i32>);
+
+#[wasm_bindgen]
+pub async fn double_all_sync(data: Vec<i32>) -> Result<Vec<i32>, JsValue> {
+    execute_async(sync_fn!(double_all_impl), &data)
+        .await
+        .map_err(|e| JsValue::from_str(&e))
+}
+
+/// Initialize pool in async mode.
+#[wasm_bindgen]
+pub async fn init_async(
+    num_workers: u32,
+    wasm_url: &str,
+    bindgen_url: &str,
+) -> Result<(), JsValue> {
+    wasm_par_mq::init_pool_async(Some(num_workers), wasm_url, bindgen_url)
+        .await
+        .map_err(|e| JsValue::from_str(&e.to_string()))
+}
+
+/// Initialize pool in sync executor mode.
+#[wasm_bindgen]
+pub async fn init_sync(
+    num_workers: u32,
+    wasm_url: &str,
+    bindgen_url: &str,
+    coordinator_url: &str,
+) -> Result<(), JsValue> {
+    wasm_par_mq::register_coordinator(coordinator_url)
+        .await
+        .map_err(|e| JsValue::from_str(&e.to_string()))?;
+    wasm_par_mq::init_pool_sync(Some(num_workers), wasm_url, bindgen_url)
+        .await
+        .map_err(|e| JsValue::from_str(&e.to_string()))
+}

--- a/utils/wasm-par-mq/web_tests/sw.js
+++ b/utils/wasm-par-mq/web_tests/sw.js
@@ -1,0 +1,2 @@
+import { setupCoordinator } from './pkg/coordinator.js';
+setupCoordinator();


### PR DESCRIPTION
this is a first step to implement a proper solution for this issue: https://github.com/zama-ai/tfhe-rs-internal/issues/1232

### PR content/description
#### Context
For more context, see the linked issue. The wasm encryption and zk proof currently require specific server side headers to be parallelized ([COOP](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cross-Origin-Opener-Policy) / [COEP](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cross-Origin-Embedder-Policy)). The issue is that these headers put some restriction on the contexts in which the crate can be used.

This is caused by [wasm-bindgen-rayon](https://github.com/RReverser/wasm-bindgen-rayon?tab=readme-ov-file#setting-up), more specifically by the use of [SharedArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer). The goal of this PR is to introduce a way to have wasm parallelism without SharedArrayBuffer.

This pr introduces a new crate, `wasm-par-mq`, that provides a parallel api without SharedArrayBuffer. This pr is only for this crate, the actual usage in `tfhe-zk-pok` will come in a following pr.

#### How it works
The main idea is that we can still use web workers, but are limited in the way we are allowed to communicate between them and the main thread, since without SharedArrayBuffer they cannot share memory. But this is just a limitation about how workers can communicate, not about what they can do.

To circumvent this, the solution used here is to communicate with [message queues](https://developer.mozilla.org/en-US/docs/Web/API/Worker/postMessage). The task input is split into chunks, and each chunk is serialized and sent to an available worker.

#### Sync mode
By default, the API is async since the main thread cannot be blocked in js. This means that code using this crate must be async too. The crate also supports a sync mode, that is a bit more complex. The trick is to execute the user code in a parent worker, called the `SyncExecutor`, that is allowed to block. To block until the compute workers are done, we use a [Service Worker](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) called the `Coordinator`. We do a blocking request from the SyncExecutor to the Coordinator that only returns when all the work has completed. Since it adds a level of indirection, the code that is sent to the SyncExecutor should ideally be as large as possible, with small inputs, to avoid costly back and forth.

For more information, see the README of the new crate: https://github.com/zama-ai/tfhe-rs/tree/ns/chore/wasm_par_mq/utils/wasm_par_mq
You can see an example of it being used in a slightly realistic situation here: https://github.com/zama-ai/tfhe-rs/tree/ns/chore/wasm_par_mq/utils/wasm_par_mq/examples/msm/src

### AI usage
AI (claude code) was used to:
- help me design this and answer my questions about wasm/js/browser world
- add tests, doc and example

### Check-list:

* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [x] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3296)
<!-- Reviewable:end -->
