### PR TITLE
fix(gpu): widen uint32 products to size_t in allocation size computations

### DIFF
--- a/backends/tfhe-cuda-backend/cuda/include/aes/aes_utilities.h
+++ b/backends/tfhe-cuda-backend/cuda/include/aes/aes_utilities.h
@@ -179,11 +179,11 @@ template <typename Torus> struct int_aes_counter_workspaces {
         params.big_lwe_dimension, size_tracker, allocate_gpu_memory);
 
     this->h_counter_bits_buffer =
-        (Torus *)malloc(num_aes_inputs * sizeof(Torus));
-    size_tracker += num_aes_inputs * sizeof(Torus);
+        (Torus *)malloc(safe_mul_sizeof<Torus>(num_aes_inputs));
+    size_tracker += safe_mul_sizeof<Torus>(num_aes_inputs);
     this->d_counter_bits_buffer = (Torus *)cuda_malloc_with_size_tracking_async(
-        num_aes_inputs * sizeof(Torus), streams.stream(0), streams.gpu_index(0),
-        size_tracker, allocate_gpu_memory);
+        safe_mul_sizeof<Torus>(num_aes_inputs), streams.stream(0),
+        streams.gpu_index(0), size_tracker, allocate_gpu_memory);
   }
 
   void release(CudaStreams streams, bool allocate_gpu_memory) {

--- a/backends/tfhe-cuda-backend/cuda/include/checked_arithmetic.h
+++ b/backends/tfhe-cuda-backend/cuda/include/checked_arithmetic.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdio>
+
+#include "device.h"
+
+// Variadic checked multiplication of size_t values.
+// Folds left-to-right using __builtin_mul_overflow, returning true on overflow.
+// On overflow the value written to *out is unspecified.
+template <typename... Args>
+inline bool checked_mul(size_t *out, size_t first, Args... rest) {
+  size_t result = first;
+  for (size_t value : {static_cast<size_t>(rest)...}) {
+    if (__builtin_mul_overflow(result, value, &result))
+      return true;
+  }
+  *out = result;
+  return false;
+}
+
+// Variadic safe multiplication: computes the product and panics on overflow.
+template <typename... Args> inline size_t safe_mul(size_t first, Args... rest) {
+  size_t result;
+  bool overflow = checked_mul(&result, first, rest...);
+  PANIC_IF_FALSE(!overflow, "multiplication overflow wraps size_t");
+  return result;
+}
+
+// Variadic safe multiplication with an appended sizeof(T) factor.
+// Computes (args... * sizeof(T)) with overflow checking.
+template <typename T, typename... Args>
+inline size_t safe_mul_sizeof(Args... args) {
+  return safe_mul(args..., sizeof(T));
+}

--- a/backends/tfhe-cuda-backend/cuda/include/integer/comparison.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer/comparison.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "checked_arithmetic.h"
 #include "cmux.h"
 #include "integer_utilities.h"
 
@@ -39,8 +40,8 @@ template <typename Torus> struct int_are_all_block_true_buffer {
         max_chunks, params.big_lwe_dimension, size_tracker,
         allocate_gpu_memory);
 
-    preallocated_h_lut = (Torus *)malloc(
-        (params.glwe_dimension + 1) * params.polynomial_size * sizeof(Torus));
+    preallocated_h_lut = (Torus *)malloc(safe_mul_sizeof<Torus>(
+        params.glwe_dimension + 1, params.polynomial_size));
 
     is_max_value = new int_radix_lut<Torus>(streams, params, 2, max_chunks,
                                             allocate_gpu_memory, size_tracker);
@@ -214,8 +215,8 @@ template <typename Torus> struct int_tree_sign_reduction_buffer {
     tree_last_leaf_lut = new int_radix_lut<Torus>(
         streams, params, 1, 1, allocate_gpu_memory, size_tracker);
 
-    preallocated_h_lut = (Torus *)malloc(
-        (params.glwe_dimension + 1) * params.polynomial_size * sizeof(Torus));
+    preallocated_h_lut = (Torus *)malloc(safe_mul_sizeof<Torus>(
+        params.glwe_dimension + 1, params.polynomial_size));
 
     tree_last_leaf_scalar_lut = new int_radix_lut<Torus>(
         streams, params, 1, 1, allocate_gpu_memory, size_tracker);
@@ -307,10 +308,10 @@ template <typename Torus> struct int_comparison_diff_buffer {
     reduce_signs_lut =
         new int_radix_lut<Torus>(streams, params, 1, num_radix_blocks,
                                  allocate_gpu_memory, size_tracker);
-    preallocated_h_lut1 = (Torus *)malloc(
-        (params.glwe_dimension + 1) * params.polynomial_size * sizeof(Torus));
-    preallocated_h_lut2 = (Torus *)malloc(
-        (params.glwe_dimension + 1) * params.polynomial_size * sizeof(Torus));
+    preallocated_h_lut1 = (Torus *)malloc(safe_mul_sizeof<Torus>(
+        params.glwe_dimension + 1, params.polynomial_size));
+    preallocated_h_lut2 = (Torus *)malloc(safe_mul_sizeof<Torus>(
+        params.glwe_dimension + 1, params.polynomial_size));
   }
 
   void release(CudaStreams streams) {
@@ -502,8 +503,8 @@ template <typename Torus> struct int_comparison_buffer {
       signed_lut->generate_and_broadcast_bivariate_lut(
           active_streams, {0}, {signed_lut_f}, LUT_0_FOR_ALL_BLOCKS);
     }
-    preallocated_h_lut = (Torus *)malloc(
-        (params.glwe_dimension + 1) * params.polynomial_size * sizeof(Torus));
+    preallocated_h_lut = (Torus *)malloc(safe_mul_sizeof<Torus>(
+        params.glwe_dimension + 1, params.polynomial_size));
   }
 
   void release(CudaStreams streams) {

--- a/backends/tfhe-cuda-backend/cuda/include/integer/compression/compression_utilities.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer/compression/compression_utilities.h
@@ -32,13 +32,15 @@ template <typename Torus> struct int_compression {
     max_num_glwes = CEIL_DIV(num_radix_blocks, lwe_per_glwe);
 
     tmp_lwe = static_cast<Torus *>(cuda_malloc_with_size_tracking_async(
-        num_radix_blocks * (compression_params.small_lwe_dimension + 1) *
-            sizeof(Torus),
+        safe_mul_sizeof<Torus>(
+            (size_t)num_radix_blocks,
+            (size_t)(compression_params.small_lwe_dimension + 1)),
         streams.stream(0), streams.gpu_index(0), size_tracker,
         allocate_gpu_memory));
     tmp_glwe_array_out =
         static_cast<Torus *>(cuda_malloc_with_size_tracking_async(
-            max_num_glwes * glwe_accumulator_size * sizeof(Torus),
+            safe_mul_sizeof<Torus>((size_t)max_num_glwes,
+                                   glwe_accumulator_size),
             streams.stream(0), streams.gpu_index(0), size_tracker,
             allocate_gpu_memory));
 
@@ -93,14 +95,17 @@ template <typename Torus> struct int_decompression {
                                      1);
 
     tmp_extracted_glwe = (Torus *)cuda_malloc_with_size_tracking_async(
-        num_blocks_to_decompress * glwe_accumulator_size * sizeof(Torus),
+        safe_mul_sizeof<Torus>((size_t)num_blocks_to_decompress,
+                               glwe_accumulator_size),
         streams.stream(0), streams.gpu_index(0), size_tracker,
         allocate_gpu_memory);
     tmp_indexes_array = (uint32_t *)cuda_malloc_with_size_tracking_async(
-        num_blocks_to_decompress * sizeof(uint32_t), streams.stream(0),
-        streams.gpu_index(0), size_tracker, allocate_gpu_memory);
+        safe_mul_sizeof<uint32_t>((size_t)num_blocks_to_decompress),
+        streams.stream(0), streams.gpu_index(0), size_tracker,
+        allocate_gpu_memory);
     tmp_extracted_lwe = (Torus *)cuda_malloc_with_size_tracking_async(
-        num_blocks_to_decompress * lwe_accumulator_size * sizeof(Torus),
+        safe_mul_sizeof<Torus>((size_t)num_blocks_to_decompress,
+                               lwe_accumulator_size),
         streams.stream(0), streams.gpu_index(0), size_tracker,
         allocate_gpu_memory);
 

--- a/backends/tfhe-cuda-backend/cuda/include/integer/div_rem.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer/div_rem.h
@@ -433,30 +433,31 @@ template <typename Torus> struct unsigned_int_div_rem_2_2_memory {
       Torus ***second_indexes_ptr, Torus ***scalars_ptr, uint32_t num_blocks,
       bool allocate_gpu_memory, uint64_t &size_tracker) {
 
-    auto first_indexes = (Torus **)malloc(num_blocks * sizeof(Torus *));
-    auto second_indexes = (Torus **)malloc(num_blocks * sizeof(Torus *));
-    auto scalars = (Torus **)malloc(num_blocks * sizeof(Torus *));
+    auto first_indexes = (Torus **)malloc(safe_mul_sizeof<Torus *>(num_blocks));
+    auto second_indexes =
+        (Torus **)malloc(safe_mul_sizeof<Torus *>(num_blocks));
+    auto scalars = (Torus **)malloc(safe_mul_sizeof<Torus *>(num_blocks));
 
     for (int nb = 1; nb <= num_blocks; nb++) {
       first_indexes[nb - 1] = (Torus *)cuda_malloc_with_size_tracking_async(
-          nb * sizeof(Torus), stream, gpu_index, size_tracker,
+          safe_mul_sizeof<Torus>(nb), stream, gpu_index, size_tracker,
           allocate_gpu_memory);
       second_indexes[nb - 1] = (Torus *)cuda_malloc_with_size_tracking_async(
-          nb * sizeof(Torus), stream, gpu_index, size_tracker,
+          safe_mul_sizeof<Torus>(nb), stream, gpu_index, size_tracker,
           allocate_gpu_memory);
       scalars[nb - 1] = (Torus *)cuda_malloc_with_size_tracking_async(
-          nb * sizeof(Torus), stream, gpu_index, size_tracker,
+          safe_mul_sizeof<Torus>(nb), stream, gpu_index, size_tracker,
           allocate_gpu_memory);
 
       cuda_memcpy_with_size_tracking_async_gpu_to_gpu(
           first_indexes[nb - 1], first_indexes_for_overflow_sub_gpu_0[nb - 1],
-          nb * sizeof(Torus), stream, gpu_index, allocate_gpu_memory);
+          safe_mul_sizeof<Torus>(nb), stream, gpu_index, allocate_gpu_memory);
       cuda_memcpy_with_size_tracking_async_gpu_to_gpu(
           second_indexes[nb - 1], second_indexes_for_overflow_sub_gpu_0[nb - 1],
-          nb * sizeof(Torus), stream, gpu_index, allocate_gpu_memory);
+          safe_mul_sizeof<Torus>(nb), stream, gpu_index, allocate_gpu_memory);
       cuda_memcpy_with_size_tracking_async_gpu_to_gpu(
           scalars[nb - 1], scalars_for_overflow_sub_gpu_0[nb - 1],
-          nb * sizeof(Torus), stream, gpu_index, allocate_gpu_memory);
+          safe_mul_sizeof<Torus>(nb), stream, gpu_index, allocate_gpu_memory);
       *first_indexes_ptr = first_indexes;
       *second_indexes_ptr = second_indexes;
       *scalars_ptr = scalars;
@@ -470,21 +471,21 @@ template <typename Torus> struct unsigned_int_div_rem_2_2_memory {
     max_indexes_to_erase = num_blocks;
 
     first_indexes_for_overflow_sub_gpu_0 =
-        (Torus **)malloc(num_blocks * sizeof(Torus *));
+        (Torus **)malloc(safe_mul_sizeof<Torus *>(num_blocks));
     second_indexes_for_overflow_sub_gpu_0 =
-        (Torus **)malloc(num_blocks * sizeof(Torus *));
+        (Torus **)malloc(safe_mul_sizeof<Torus *>(num_blocks));
     scalars_for_overflow_sub_gpu_0 =
-        (Torus **)malloc(num_blocks * sizeof(Torus *));
+        (Torus **)malloc(safe_mul_sizeof<Torus *>(num_blocks));
 
-    Torus *h_lut_indexes = (Torus *)malloc(num_blocks * sizeof(Torus));
-    Torus *h_scalar = (Torus *)malloc(num_blocks * sizeof(Torus));
+    Torus *h_lut_indexes = (Torus *)malloc(safe_mul_sizeof<Torus>(num_blocks));
+    Torus *h_scalar = (Torus *)malloc(safe_mul_sizeof<Torus>(num_blocks));
 
     // Extra indexes for the luts in first step
     for (int nb = 1; nb <= num_blocks; nb++) {
       first_indexes_for_overflow_sub_gpu_0[nb - 1] =
           (Torus *)cuda_malloc_with_size_tracking_async(
-              nb * sizeof(Torus), streams.stream(0), streams.gpu_index(0),
-              size_tracker, allocate_gpu_memory);
+              safe_mul_sizeof<Torus>(nb), streams.stream(0),
+              streams.gpu_index(0), size_tracker, allocate_gpu_memory);
 
       auto index_generator = [nb, group_size](Torus *h_lut_indexes, uint32_t) {
         for (int index = 0; index < nb; index++) {
@@ -517,12 +518,12 @@ template <typename Torus> struct unsigned_int_div_rem_2_2_memory {
     for (int nb = 1; nb <= num_blocks; nb++) {
       second_indexes_for_overflow_sub_gpu_0[nb - 1] =
           (Torus *)cuda_malloc_with_size_tracking_async(
-              nb * sizeof(Torus), streams.stream(0), streams.gpu_index(0),
-              size_tracker, allocate_gpu_memory);
+              safe_mul_sizeof<Torus>(nb), streams.stream(0),
+              streams.gpu_index(0), size_tracker, allocate_gpu_memory);
       scalars_for_overflow_sub_gpu_0[nb - 1] =
           (Torus *)cuda_malloc_with_size_tracking_async(
-              nb * sizeof(Torus), streams.stream(0), streams.gpu_index(0),
-              size_tracker, allocate_gpu_memory);
+              safe_mul_sizeof<Torus>(nb), streams.stream(0),
+              streams.gpu_index(0), size_tracker, allocate_gpu_memory);
 
       auto index_generator = [nb, group_size, use_seq](Torus *h_lut_indexes,
                                                        uint32_t) {
@@ -569,8 +570,9 @@ template <typename Torus> struct unsigned_int_div_rem_2_2_memory {
         }
       }
       cuda_memcpy_with_size_tracking_async_to_gpu(
-          scalars_for_overflow_sub_gpu_0[nb - 1], h_scalar, nb * sizeof(Torus),
-          streams.stream(0), streams.gpu_index(0), allocate_gpu_memory);
+          scalars_for_overflow_sub_gpu_0[nb - 1], h_scalar,
+          safe_mul_sizeof<Torus>(nb), streams.stream(0), streams.gpu_index(0),
+          allocate_gpu_memory);
     }
     cuda_synchronize_stream(streams.stream(0), streams.gpu_index(0));
     free(h_lut_indexes);
@@ -1162,20 +1164,21 @@ template <typename Torus> struct unsigned_int_div_rem_memory {
     max_indexes_to_erase = num_blocks;
 
     first_indexes_for_overflow_sub =
-        (Torus **)malloc(num_blocks * sizeof(Torus *));
+        (Torus **)malloc(safe_mul_sizeof<Torus *>(num_blocks));
     second_indexes_for_overflow_sub =
-        (Torus **)malloc(num_blocks * sizeof(Torus *));
-    scalars_for_overflow_sub = (Torus **)malloc(num_blocks * sizeof(Torus *));
+        (Torus **)malloc(safe_mul_sizeof<Torus *>(num_blocks));
+    scalars_for_overflow_sub =
+        (Torus **)malloc(safe_mul_sizeof<Torus *>(num_blocks));
 
-    Torus *h_lut_indexes = (Torus *)malloc(num_blocks * sizeof(Torus));
-    Torus *h_scalar = (Torus *)malloc(num_blocks * sizeof(Torus));
+    Torus *h_lut_indexes = (Torus *)malloc(safe_mul_sizeof<Torus>(num_blocks));
+    Torus *h_scalar = (Torus *)malloc(safe_mul_sizeof<Torus>(num_blocks));
 
     // Extra indexes for the luts in first step
     for (int nb = 1; nb <= num_blocks; nb++) {
       first_indexes_for_overflow_sub[nb - 1] =
           (Torus *)cuda_malloc_with_size_tracking_async(
-              nb * sizeof(Torus), streams.stream(0), streams.gpu_index(0),
-              size_tracker, allocate_gpu_memory);
+              safe_mul_sizeof<Torus>(nb), streams.stream(0),
+              streams.gpu_index(0), size_tracker, allocate_gpu_memory);
 
       auto index_generator = [nb, group_size](Torus *h_lut_indexes, uint32_t) {
         for (int index = 0; index < nb; index++) {
@@ -1207,12 +1210,12 @@ template <typename Torus> struct unsigned_int_div_rem_memory {
     for (int nb = 1; nb <= num_blocks; nb++) {
       second_indexes_for_overflow_sub[nb - 1] =
           (Torus *)cuda_malloc_with_size_tracking_async(
-              nb * sizeof(Torus), streams.stream(0), streams.gpu_index(0),
-              size_tracker, allocate_gpu_memory);
+              safe_mul_sizeof<Torus>(nb), streams.stream(0),
+              streams.gpu_index(0), size_tracker, allocate_gpu_memory);
       scalars_for_overflow_sub[nb - 1] =
           (Torus *)cuda_malloc_with_size_tracking_async(
-              nb * sizeof(Torus), streams.stream(0), streams.gpu_index(0),
-              size_tracker, allocate_gpu_memory);
+              safe_mul_sizeof<Torus>(nb), streams.stream(0),
+              streams.gpu_index(0), size_tracker, allocate_gpu_memory);
 
       auto index_generator = [nb, group_size, use_seq](Torus *h_lut_indexes,
                                                        uint32_t) {
@@ -1258,8 +1261,9 @@ template <typename Torus> struct unsigned_int_div_rem_memory {
         }
       }
       cuda_memcpy_with_size_tracking_async_to_gpu(
-          scalars_for_overflow_sub[nb - 1], h_scalar, nb * sizeof(Torus),
-          streams.stream(0), streams.gpu_index(0), allocate_gpu_memory);
+          scalars_for_overflow_sub[nb - 1], h_scalar,
+          safe_mul_sizeof<Torus>(nb), streams.stream(0), streams.gpu_index(0),
+          allocate_gpu_memory);
     }
     free(h_lut_indexes);
     free(h_scalar);

--- a/backends/tfhe-cuda-backend/cuda/include/integer/oprf.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer/oprf.h
@@ -86,9 +86,10 @@ template <typename Torus> struct int_grouped_oprf_memory {
     // (handling both bounded and unbounded cases), which pre-computed LUT to
     // use, and the final plaintext correction to add.
     //
-    Torus *h_corrections =
-        (Torus *)calloc(num_blocks_to_process * lwe_size, sizeof(Torus));
-    this->h_lut_indexes = (Torus *)calloc(num_blocks_to_process, sizeof(Torus));
+    Torus *h_corrections = (Torus *)calloc(
+        1, safe_mul_sizeof<Torus>(num_blocks_to_process, lwe_size));
+    this->h_lut_indexes =
+        (Torus *)calloc(1, safe_mul_sizeof<Torus>(num_blocks_to_process));
 
     uint64_t bits_processed = 0;
     for (uint32_t i = 0; i < num_blocks_to_process; ++i) {
@@ -115,8 +116,8 @@ template <typename Torus> struct int_grouped_oprf_memory {
     // Copy the prepared plaintext corrections to the GPU.
     cuda_memcpy_with_size_tracking_async_to_gpu(
         this->plaintext_corrections->ptr, h_corrections,
-        num_blocks_to_process * lwe_size * sizeof(Torus), streams.stream(0),
-        streams.gpu_index(0), allocate_gpu_memory);
+        safe_mul_sizeof<Torus>(num_blocks_to_process, lwe_size),
+        streams.stream(0), streams.gpu_index(0), allocate_gpu_memory);
 
     // Copy the prepared LUT indexes to the GPU 0, before broadcast to all other
     // GPUs.

--- a/backends/tfhe-cuda-backend/cuda/include/integer/rerand_utilities.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer/rerand_utilities.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "checked_arithmetic.h"
 #include "integer_utilities.h"
 #include "keyswitch/ks_enums.h"
 #include "zk/expand.cuh"
@@ -29,34 +30,34 @@ template <typename Torus> struct int_rerand_mem {
         gpu_memory_allocated(allocate_gpu_memory) {
 
     tmp_zero_lwes = (Torus *)cuda_malloc_with_size_tracking_async(
-        num_lwes * (params.big_lwe_dimension + 1) * sizeof(Torus),
+        safe_mul_sizeof<Torus>(num_lwes, params.big_lwe_dimension + 1),
         streams.stream(0), streams.gpu_index(0), size_tracker,
         allocate_gpu_memory);
 
     tmp_ksed_zero_lwes = (Torus *)cuda_malloc_with_size_tracking_async(
-        num_lwes * (params.small_lwe_dimension + 1) * sizeof(Torus),
+        safe_mul_sizeof<Torus>(num_lwes, params.small_lwe_dimension + 1),
         streams.stream(0), streams.gpu_index(0), size_tracker,
         allocate_gpu_memory);
 
     d_expand_jobs =
         static_cast<expand_job<Torus> *>(cuda_malloc_with_size_tracking_async(
-            num_lwes * sizeof(expand_job<Torus>), streams.stream(0),
+            safe_mul_sizeof<expand_job<Torus>>(num_lwes), streams.stream(0),
             streams.gpu_index(0), size_tracker, allocate_gpu_memory));
 
     h_expand_jobs = static_cast<expand_job<Torus> *>(
-        malloc(num_lwes * sizeof(expand_job<Torus>)));
+        malloc(safe_mul_sizeof<expand_job<Torus>>(num_lwes)));
 
     auto h_lwe_trivial_indexes =
-        static_cast<Torus *>(malloc(num_lwes * sizeof(Torus)));
+        static_cast<Torus *>(malloc(safe_mul_sizeof<Torus>(num_lwes)));
     for (auto i = 0; i < num_lwes; ++i) {
       h_lwe_trivial_indexes[i] = i;
     }
     lwe_trivial_indexes = (Torus *)cuda_malloc_with_size_tracking_async(
-        num_lwes * sizeof(Torus), streams.stream(0), streams.gpu_index(0),
-        size_tracker, allocate_gpu_memory);
+        safe_mul_sizeof<Torus>(num_lwes), streams.stream(0),
+        streams.gpu_index(0), size_tracker, allocate_gpu_memory);
     cuda_memcpy_async_to_gpu(lwe_trivial_indexes, h_lwe_trivial_indexes,
-                             num_lwes * sizeof(Torus), streams.stream(0),
-                             streams.gpu_index(0));
+                             safe_mul_sizeof<Torus>(num_lwes),
+                             streams.stream(0), streams.gpu_index(0));
 
     cuda_synchronize_stream(streams.stream(0), streams.gpu_index(0));
 

--- a/backends/tfhe-cuda-backend/cuda/include/integer/subtraction.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer/subtraction.h
@@ -22,21 +22,22 @@ template <typename Torus> struct int_overflowing_sub_memory {
     auto message_modulus = params.message_modulus;
     auto carry_modulus = params.carry_modulus;
     auto big_lwe_size = (polynomial_size * glwe_dimension + 1);
-    auto big_lwe_size_bytes = big_lwe_size * sizeof(Torus);
+    auto total_size_bytes =
+        safe_mul_sizeof<Torus>((size_t)num_radix_blocks, big_lwe_size);
 
     // allocate memory for intermediate calculations
     generates_or_propagates = (Torus *)cuda_malloc_with_size_tracking_async(
-        num_radix_blocks * big_lwe_size_bytes, streams.stream(0),
-        streams.gpu_index(0), size_tracker, allocate_gpu_memory);
+        total_size_bytes, streams.stream(0), streams.gpu_index(0), size_tracker,
+        allocate_gpu_memory);
     step_output = (Torus *)cuda_malloc_with_size_tracking_async(
-        num_radix_blocks * big_lwe_size_bytes, streams.stream(0),
-        streams.gpu_index(0), size_tracker, allocate_gpu_memory);
+        total_size_bytes, streams.stream(0), streams.gpu_index(0), size_tracker,
+        allocate_gpu_memory);
     cuda_memset_with_size_tracking_async(
-        generates_or_propagates, 0, num_radix_blocks * big_lwe_size_bytes,
-        streams.stream(0), streams.gpu_index(0), allocate_gpu_memory);
+        generates_or_propagates, 0, total_size_bytes, streams.stream(0),
+        streams.gpu_index(0), allocate_gpu_memory);
     cuda_memset_with_size_tracking_async(
-        step_output, 0, num_radix_blocks * big_lwe_size_bytes,
-        streams.stream(0), streams.gpu_index(0), allocate_gpu_memory);
+        step_output, 0, total_size_bytes, streams.stream(0),
+        streams.gpu_index(0), allocate_gpu_memory);
 
     // declare functions for lut generation
     auto f_lut_does_block_generate_carry = [message_modulus](Torus x) -> Torus {

--- a/backends/tfhe-cuda-backend/cuda/include/integer/vector_find.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer/vector_find.h
@@ -534,7 +534,7 @@ template <typename Torus> struct int_unchecked_match_value_or_buffer {
     this->tmp_or_value = new CudaRadixCiphertextFFI;
 
     this->d_or_value = (Torus *)cuda_malloc_with_size_tracking_async(
-        num_final_blocks * sizeof(Torus), streams.stream(0),
+        safe_mul_sizeof<Torus>(num_final_blocks), streams.stream(0),
         streams.gpu_index(0), size_tracker, allocate_gpu_memory);
 
     create_zero_radix_ciphertext_async<Torus>(
@@ -712,8 +712,8 @@ template <typename Torus> struct int_unchecked_contains_clear_buffer {
         allocate_gpu_memory);
 
     this->d_clear_val = (Torus *)cuda_malloc_with_size_tracking_async(
-        num_blocks * sizeof(Torus), streams.stream(0), streams.gpu_index(0),
-        size_tracker, allocate_gpu_memory);
+        safe_mul_sizeof<Torus>(num_blocks), streams.stream(0),
+        streams.gpu_index(0), size_tracker, allocate_gpu_memory);
   }
 
   void release(CudaStreams streams) {
@@ -866,7 +866,7 @@ template <typename Torus> struct int_final_index_from_selectors_buffer {
     uint32_t num_bits_in_message = log2_int(params.message_modulus);
     uint32_t bits_per_packed_block = 2 * num_bits_in_message;
 
-    h_indices = new uint64_t[num_inputs * packed_len];
+    h_indices = new uint64_t[safe_mul((size_t)num_inputs, (size_t)packed_len)];
     for (uint32_t i = 0; i < num_inputs; i++) {
       uint64_t val = i;
       for (uint32_t b = 0; b < packed_len; b++) {
@@ -1128,15 +1128,16 @@ template <typename Torus> struct int_unchecked_first_index_of_clear_buffer {
         allocate_gpu_memory);
 
     this->d_clear_val = (Torus *)cuda_malloc_with_size_tracking_async(
-        num_blocks * sizeof(Torus), streams.stream(0), streams.gpu_index(0),
-        size_tracker, allocate_gpu_memory);
+        safe_mul_sizeof<Torus>(num_blocks), streams.stream(0),
+        streams.gpu_index(0), size_tracker, allocate_gpu_memory);
 
     h_indices = nullptr;
     if (allocate_gpu_memory) {
       uint32_t num_bits_in_message = log2_int(params.message_modulus);
       uint32_t bits_per_packed_block = 2 * num_bits_in_message;
 
-      h_indices = new uint64_t[num_inputs * packed_len];
+      h_indices =
+          new uint64_t[safe_mul((size_t)num_inputs, (size_t)packed_len)];
       for (uint32_t i = 0; i < num_inputs; i++) {
         uint64_t val = i;
         for (uint32_t b = 0; b < packed_len; b++) {
@@ -1316,7 +1317,8 @@ template <typename Torus> struct int_unchecked_first_index_of_buffer {
       uint32_t num_bits_in_message = log2_int(params.message_modulus);
       uint32_t bits_per_packed_block = 2 * num_bits_in_message;
 
-      h_indices = new uint64_t[num_inputs * packed_len];
+      h_indices =
+          new uint64_t[safe_mul((size_t)num_inputs, (size_t)packed_len)];
       for (uint32_t i = 0; i < num_inputs; i++) {
         uint64_t val = i;
         for (uint32_t b = 0; b < packed_len; b++) {

--- a/backends/tfhe-cuda-backend/cuda/src/aes/aes.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/aes/aes.cuh
@@ -1034,8 +1034,8 @@ __host__ void vectorized_aes_full_adder_inplace(
     }
     cuda_memcpy_async_to_gpu(mem->counter_workspaces->d_counter_bits_buffer,
                              mem->counter_workspaces->h_counter_bits_buffer,
-                             num_aes_inputs * sizeof(Torus), streams.stream(0),
-                             streams.gpu_index(0));
+                             safe_mul_sizeof<Torus>(num_aes_inputs),
+                             streams.stream(0), streams.gpu_index(0));
     set_trivial_radix_ciphertext_async<Torus>(
         streams.stream(0), streams.gpu_index(0), trivial_b_bits_vec,
         mem->counter_workspaces->d_counter_bits_buffer,

--- a/backends/tfhe-cuda-backend/cuda/src/crypto/ciphertext.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/crypto/ciphertext.cuh
@@ -1,6 +1,7 @@
 #ifndef CUDA_CIPHERTEXT_CUH
 #define CUDA_CIPHERTEXT_CUH
 
+#include "checked_arithmetic.h"
 #include "ciphertext.h"
 #include "device.h"
 #include "polynomial/functions.cuh"
@@ -12,7 +13,8 @@ void cuda_convert_lwe_ciphertext_vector_to_gpu(cudaStream_t stream,
                                                T *src, uint32_t number_of_cts,
                                                uint32_t lwe_dimension) {
   cuda_set_device(gpu_index);
-  uint64_t size = number_of_cts * (lwe_dimension + 1) * sizeof(T);
+  uint64_t size =
+      safe_mul_sizeof<T>((size_t)number_of_cts, (size_t)(lwe_dimension + 1));
   cuda_memcpy_async_to_gpu(dest, src, size, stream, gpu_index);
 }
 
@@ -22,7 +24,8 @@ void cuda_convert_lwe_ciphertext_vector_to_cpu(cudaStream_t stream,
                                                T *src, uint32_t number_of_cts,
                                                uint32_t lwe_dimension) {
   cuda_set_device(gpu_index);
-  uint64_t size = number_of_cts * (lwe_dimension + 1) * sizeof(T);
+  uint64_t size =
+      safe_mul_sizeof<T>((size_t)number_of_cts, (size_t)(lwe_dimension + 1));
   cuda_memcpy_async_to_cpu(dest, src, size, stream, gpu_index);
 }
 

--- a/backends/tfhe-cuda-backend/cuda/src/crypto/ggsw.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/crypto/ggsw.cuh
@@ -1,6 +1,7 @@
 #ifndef CNCRT_GGSW_CUH
 #define CNCRT_GGSW_CUH
 
+#include "checked_arithmetic.h"
 #include "device.h"
 #include "fft/bnsmfft.cuh"
 #include "polynomial/parameters.cuh"
@@ -60,7 +61,7 @@ void batch_fft_ggsw_vector(CudaStreams streams, double2 *dest, T *src,
 
   cuda_set_device(streams.gpu_index(0));
 
-  int shared_memory_size = sizeof(double) * polynomial_size;
+  int shared_memory_size = safe_mul_sizeof<double>(polynomial_size);
 
   int gridSize = r * (glwe_dim + 1) * (glwe_dim + 1) * level_count;
   int blockSize = polynomial_size / params::opt;

--- a/backends/tfhe-cuda-backend/cuda/src/crypto/packing_keyswitch.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/crypto/packing_keyswitch.cuh
@@ -108,8 +108,9 @@ __host__ void host_packing_keyswitch_lwe_list_to_glwe(
 
   // Set the scratch buffer to 0 as it is used to accumulate
   // decomposition temporary results
-  cuda_memset_async(d_mem_1, 0, num_lwes * memory_unit * sizeof(Torus), stream,
-                    gpu_index);
+  cuda_memset_async(
+      d_mem_1, 0, safe_mul_sizeof<Torus>((size_t)num_lwes, (size_t)memory_unit),
+      stream, gpu_index);
   check_cuda_error(cudaGetLastError());
 
   // decompose LWEs

--- a/backends/tfhe-cuda-backend/cuda/src/fft128/fft128.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/fft128/fft128.cuh
@@ -1,6 +1,7 @@
 #ifndef CUDA_FFT128_CUH
 #define CUDA_FFT128_CUH
 
+#include "checked_arithmetic.h"
 #include "f128.cuh"
 #include "fft/fft128.h"
 #include "polynomial/functions.cuh"
@@ -491,28 +492,31 @@ __host__ void host_fourier_transform_forward_as_integer_f128(
     const uint32_t number_of_samples) {
 
   // allocate device buffers
-  double *d_re0 =
-      (double *)cuda_malloc_async(N / 2 * sizeof(double), stream, gpu_index);
-  double *d_re1 =
-      (double *)cuda_malloc_async(N / 2 * sizeof(double), stream, gpu_index);
-  double *d_im0 =
-      (double *)cuda_malloc_async(N / 2 * sizeof(double), stream, gpu_index);
-  double *d_im1 =
-      (double *)cuda_malloc_async(N / 2 * sizeof(double), stream, gpu_index);
+  double *d_re0 = (double *)cuda_malloc_async(safe_mul_sizeof<double>(N / 2),
+                                              stream, gpu_index);
+  double *d_re1 = (double *)cuda_malloc_async(safe_mul_sizeof<double>(N / 2),
+                                              stream, gpu_index);
+  double *d_im0 = (double *)cuda_malloc_async(safe_mul_sizeof<double>(N / 2),
+                                              stream, gpu_index);
+  double *d_im1 = (double *)cuda_malloc_async(safe_mul_sizeof<double>(N / 2),
+                                              stream, gpu_index);
   __uint128_t *d_standard = (__uint128_t *)cuda_malloc_async(
-      N * sizeof(__uint128_t), stream, gpu_index);
+      safe_mul_sizeof<__uint128_t>(N), stream, gpu_index);
 
   // copy input into device
-  cuda_memcpy_async_to_gpu(d_standard, standard, N * sizeof(__uint128_t),
-                           stream, gpu_index);
+  cuda_memcpy_async_to_gpu(d_standard, standard,
+                           safe_mul_sizeof<__uint128_t>(N), stream, gpu_index);
 
   // setup launch parameters
-  size_t required_shared_memory_size = sizeof(double) * N / 2 * 4;
+  size_t required_shared_memory_size =
+      safe_mul_sizeof<double>((size_t)(N / 2), (size_t)4);
   int grid_size = number_of_samples;
   int block_size = params::degree / params::opt;
   bool full_sm =
       (required_shared_memory_size <= cuda_get_max_shared_memory(gpu_index));
-  size_t buffer_size = full_sm ? 0 : (size_t)number_of_samples * N / 2 * 4;
+  size_t buffer_size =
+      full_sm ? 0
+              : safe_mul((size_t)number_of_samples, (size_t)(N / 2), (size_t)4);
   size_t shared_memory_size = full_sm ? required_shared_memory_size : 0;
   double *buffer = (double *)cuda_malloc_async(buffer_size, stream, gpu_index);
 
@@ -544,13 +548,13 @@ __host__ void host_fourier_transform_forward_as_integer_f128(
   }
   check_cuda_error(cudaGetLastError());
 
-  cuda_memcpy_async_to_cpu(re0, d_re0, N / 2 * sizeof(double), stream,
+  cuda_memcpy_async_to_cpu(re0, d_re0, safe_mul_sizeof<double>(N / 2), stream,
                            gpu_index);
-  cuda_memcpy_async_to_cpu(re1, d_re1, N / 2 * sizeof(double), stream,
+  cuda_memcpy_async_to_cpu(re1, d_re1, safe_mul_sizeof<double>(N / 2), stream,
                            gpu_index);
-  cuda_memcpy_async_to_cpu(im0, d_im0, N / 2 * sizeof(double), stream,
+  cuda_memcpy_async_to_cpu(im0, d_im0, safe_mul_sizeof<double>(N / 2), stream,
                            gpu_index);
-  cuda_memcpy_async_to_cpu(im1, d_im1, N / 2 * sizeof(double), stream,
+  cuda_memcpy_async_to_cpu(im1, d_im1, safe_mul_sizeof<double>(N / 2), stream,
                            gpu_index);
 
   cuda_drop_async(d_standard, stream, gpu_index);
@@ -567,28 +571,31 @@ __host__ void host_fourier_transform_forward_as_torus_f128(
     const uint32_t number_of_samples) {
 
   // allocate device buffers
-  double *d_re0 =
-      (double *)cuda_malloc_async(N / 2 * sizeof(double), stream, gpu_index);
-  double *d_re1 =
-      (double *)cuda_malloc_async(N / 2 * sizeof(double), stream, gpu_index);
-  double *d_im0 =
-      (double *)cuda_malloc_async(N / 2 * sizeof(double), stream, gpu_index);
-  double *d_im1 =
-      (double *)cuda_malloc_async(N / 2 * sizeof(double), stream, gpu_index);
+  double *d_re0 = (double *)cuda_malloc_async(safe_mul_sizeof<double>(N / 2),
+                                              stream, gpu_index);
+  double *d_re1 = (double *)cuda_malloc_async(safe_mul_sizeof<double>(N / 2),
+                                              stream, gpu_index);
+  double *d_im0 = (double *)cuda_malloc_async(safe_mul_sizeof<double>(N / 2),
+                                              stream, gpu_index);
+  double *d_im1 = (double *)cuda_malloc_async(safe_mul_sizeof<double>(N / 2),
+                                              stream, gpu_index);
   __uint128_t *d_standard = (__uint128_t *)cuda_malloc_async(
-      N * sizeof(__uint128_t), stream, gpu_index);
+      safe_mul_sizeof<__uint128_t>(N), stream, gpu_index);
 
   // copy input into device
-  cuda_memcpy_async_to_gpu(d_standard, standard, N * sizeof(__uint128_t),
-                           stream, gpu_index);
+  cuda_memcpy_async_to_gpu(d_standard, standard,
+                           safe_mul_sizeof<__uint128_t>(N), stream, gpu_index);
 
   // setup launch parameters
-  size_t required_shared_memory_size = sizeof(double) * N / 2 * 4;
+  size_t required_shared_memory_size =
+      safe_mul_sizeof<double>((size_t)(N / 2), (size_t)4);
   int grid_size = number_of_samples;
   int block_size = params::degree / params::opt;
   bool full_sm =
       (required_shared_memory_size <= cuda_get_max_shared_memory(gpu_index));
-  size_t buffer_size = full_sm ? 0 : (size_t)number_of_samples * N / 2 * 4;
+  size_t buffer_size =
+      full_sm ? 0
+              : safe_mul((size_t)number_of_samples, (size_t)(N / 2), (size_t)4);
   size_t shared_memory_size = full_sm ? required_shared_memory_size : 0;
   double *buffer = (double *)cuda_malloc_async(buffer_size, stream, gpu_index);
 
@@ -618,13 +625,13 @@ __host__ void host_fourier_transform_forward_as_torus_f128(
             d_re0, d_re1, d_im0, d_im1, d_re0, d_re1, d_im0, d_im1, buffer);
   }
 
-  cuda_memcpy_async_to_cpu(re0, d_re0, N / 2 * sizeof(double), stream,
+  cuda_memcpy_async_to_cpu(re0, d_re0, safe_mul_sizeof<double>(N / 2), stream,
                            gpu_index);
-  cuda_memcpy_async_to_cpu(re1, d_re1, N / 2 * sizeof(double), stream,
+  cuda_memcpy_async_to_cpu(re1, d_re1, safe_mul_sizeof<double>(N / 2), stream,
                            gpu_index);
-  cuda_memcpy_async_to_cpu(im0, d_im0, N / 2 * sizeof(double), stream,
+  cuda_memcpy_async_to_cpu(im0, d_im0, safe_mul_sizeof<double>(N / 2), stream,
                            gpu_index);
-  cuda_memcpy_async_to_cpu(im1, d_im1, N / 2 * sizeof(double), stream,
+  cuda_memcpy_async_to_cpu(im1, d_im1, safe_mul_sizeof<double>(N / 2), stream,
                            gpu_index);
 
   cuda_drop_async(d_standard, stream, gpu_index);
@@ -641,34 +648,37 @@ __host__ void host_fourier_transform_backward_as_torus_f128(
     const uint32_t N, const uint32_t number_of_samples) {
 
   // allocate device buffers
-  double *d_re0 =
-      (double *)cuda_malloc_async(N / 2 * sizeof(double), stream, gpu_index);
-  double *d_re1 =
-      (double *)cuda_malloc_async(N / 2 * sizeof(double), stream, gpu_index);
-  double *d_im0 =
-      (double *)cuda_malloc_async(N / 2 * sizeof(double), stream, gpu_index);
-  double *d_im1 =
-      (double *)cuda_malloc_async(N / 2 * sizeof(double), stream, gpu_index);
+  double *d_re0 = (double *)cuda_malloc_async(safe_mul_sizeof<double>(N / 2),
+                                              stream, gpu_index);
+  double *d_re1 = (double *)cuda_malloc_async(safe_mul_sizeof<double>(N / 2),
+                                              stream, gpu_index);
+  double *d_im0 = (double *)cuda_malloc_async(safe_mul_sizeof<double>(N / 2),
+                                              stream, gpu_index);
+  double *d_im1 = (double *)cuda_malloc_async(safe_mul_sizeof<double>(N / 2),
+                                              stream, gpu_index);
   __uint128_t *d_standard = (__uint128_t *)cuda_malloc_async(
-      N * sizeof(__uint128_t), stream, gpu_index);
+      safe_mul_sizeof<__uint128_t>(N), stream, gpu_index);
 
   //  // copy input into device
-  cuda_memcpy_async_to_gpu(d_re0, re0, N / 2 * sizeof(double), stream,
+  cuda_memcpy_async_to_gpu(d_re0, re0, safe_mul_sizeof<double>(N / 2), stream,
                            gpu_index);
-  cuda_memcpy_async_to_gpu(d_re1, re1, N / 2 * sizeof(double), stream,
+  cuda_memcpy_async_to_gpu(d_re1, re1, safe_mul_sizeof<double>(N / 2), stream,
                            gpu_index);
-  cuda_memcpy_async_to_gpu(d_im0, im0, N / 2 * sizeof(double), stream,
+  cuda_memcpy_async_to_gpu(d_im0, im0, safe_mul_sizeof<double>(N / 2), stream,
                            gpu_index);
-  cuda_memcpy_async_to_gpu(d_im1, im1, N / 2 * sizeof(double), stream,
+  cuda_memcpy_async_to_gpu(d_im1, im1, safe_mul_sizeof<double>(N / 2), stream,
                            gpu_index);
 
   // setup launch parameters
-  size_t required_shared_memory_size = sizeof(double) * N / 2 * 4;
+  size_t required_shared_memory_size =
+      safe_mul_sizeof<double>((size_t)(N / 2), (size_t)4);
   int grid_size = number_of_samples;
   int block_size = params::degree / params::opt;
   bool full_sm =
       (required_shared_memory_size <= cuda_get_max_shared_memory(gpu_index));
-  size_t buffer_size = full_sm ? 0 : (size_t)number_of_samples * N / 2 * 4;
+  size_t buffer_size =
+      full_sm ? 0
+              : safe_mul((size_t)number_of_samples, (size_t)(N / 2), (size_t)4);
   size_t shared_memory_size = full_sm ? required_shared_memory_size : 0;
   double *buffer = (double *)cuda_malloc_async(buffer_size, stream, gpu_index);
 
@@ -693,8 +703,8 @@ __host__ void host_fourier_transform_backward_as_torus_f128(
       <<<grid_size, block_size, 0, stream>>>(d_standard, d_re0, d_re1, d_im0,
                                              d_im1);
 
-  cuda_memcpy_async_to_cpu(standard, d_standard, N * sizeof(__uint128_t),
-                           stream, gpu_index);
+  cuda_memcpy_async_to_cpu(standard, d_standard,
+                           safe_mul_sizeof<__uint128_t>(N), stream, gpu_index);
   cuda_drop_async(d_standard, stream, gpu_index);
   cuda_drop_async(d_re0, stream, gpu_index);
   cuda_drop_async(d_re1, stream, gpu_index);

--- a/backends/tfhe-cuda-backend/cuda/src/integer/bitwise_ops.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/bitwise_ops.cuh
@@ -56,14 +56,14 @@ __host__ void host_boolean_bitop(CudaStreams streams,
           lwe_array_1->num_radix_blocks, lwe_array_1, 0,
           lwe_array_1->num_radix_blocks);
       memcpy(lwe_array_out->degrees, lwe_array_1->degrees,
-             lwe_array_out->num_radix_blocks * sizeof(uint64_t));
+             safe_mul_sizeof<uint64_t>(lwe_array_out->num_radix_blocks));
     } else {
       copy_radix_ciphertext_slice_async<Torus>(
           streams.stream(0), streams.gpu_index(0), lwe_array_out, 0,
           lwe_array_2->num_radix_blocks, lwe_array_2, 0,
           lwe_array_2->num_radix_blocks);
       memcpy(lwe_array_out->degrees, lwe_array_2->degrees,
-             lwe_array_out->num_radix_blocks * sizeof(uint64_t));
+             safe_mul_sizeof<uint64_t>(lwe_array_out->num_radix_blocks));
     }
     return;
   }
@@ -75,14 +75,14 @@ __host__ void host_boolean_bitop(CudaStreams streams,
           lwe_array_2->num_radix_blocks, lwe_array_2, 0,
           lwe_array_2->num_radix_blocks);
       memcpy(lwe_array_out->degrees, lwe_array_2->degrees,
-             lwe_array_out->num_radix_blocks * sizeof(uint64_t));
+             safe_mul_sizeof<uint64_t>(lwe_array_out->num_radix_blocks));
     } else {
       copy_radix_ciphertext_slice_async<Torus>(
           streams.stream(0), streams.gpu_index(0), lwe_array_out, 0,
           lwe_array_1->num_radix_blocks, lwe_array_1, 0,
           lwe_array_1->num_radix_blocks);
       memcpy(lwe_array_out->degrees, lwe_array_1->degrees,
-             lwe_array_out->num_radix_blocks * sizeof(uint64_t));
+             safe_mul_sizeof<uint64_t>(lwe_array_out->num_radix_blocks));
     }
     return;
   }
@@ -158,7 +158,7 @@ __host__ void host_boolean_bitop(CudaStreams streams,
       lut, lwe_array_out->num_radix_blocks, 2);
 
   memcpy(lwe_array_out->degrees, degrees,
-         lwe_array_out->num_radix_blocks * sizeof(uint64_t));
+         safe_mul_sizeof<uint64_t>(lwe_array_out->num_radix_blocks));
 }
 
 // updates degrees based on `ct_message_modulus`
@@ -266,7 +266,7 @@ __host__ void host_bitop(CudaStreams streams,
       lwe_array_out->num_radix_blocks, lut->params.message_modulus);
 
   memcpy(lwe_array_out->degrees, degrees,
-         lwe_array_out->num_radix_blocks * sizeof(uint64_t));
+         safe_mul_sizeof<uint64_t>(lwe_array_out->num_radix_blocks));
 }
 
 template <typename Torus>

--- a/backends/tfhe-cuda-backend/cuda/src/integer/compression/compression.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/compression/compression.cuh
@@ -228,10 +228,12 @@ host_integer_compress(CudaStreams streams,
 
   // Keyswitch LWEs to GLWE
   auto tmp_glwe_array_out = mem_ptr->tmp_glwe_array_out;
-  cuda_memset_async(tmp_glwe_array_out, 0,
-                    num_glwes * (compression_params.glwe_dimension + 1) *
-                        compression_params.polynomial_size * sizeof(Torus),
-                    streams.stream(0), streams.gpu_index(0));
+  cuda_memset_async(
+      tmp_glwe_array_out, 0,
+      safe_mul_sizeof<Torus>((size_t)num_glwes,
+                             (size_t)(compression_params.glwe_dimension + 1),
+                             (size_t)compression_params.polynomial_size),
+      streams.stream(0), streams.gpu_index(0));
   auto fp_ks_buffer = mem_ptr->fp_ks_buffer;
   auto rem_lwes = glwe_array_out->total_lwe_bodies_count;
 
@@ -349,7 +351,8 @@ __host__ void host_extract(cudaStream_t stream, uint32_t gpu_index,
   // glwe_ciphertext_size)
   if (initial_out_len < glwe_ciphertext_size) {
     cuda_memset_async(glwe_array_out + initial_out_len, 0,
-                      (glwe_ciphertext_size - initial_out_len) * sizeof(Torus),
+                      safe_mul_sizeof<Torus>(
+                          (size_t)(glwe_ciphertext_size - initial_out_len)),
                       stream, gpu_index);
   }
 
@@ -377,7 +380,7 @@ host_integer_decompress(CudaStreams streams,
 
   auto d_indexes_array = h_mem_ptr->tmp_indexes_array;
   cuda_memcpy_async_to_gpu(d_indexes_array, (void *)h_indexes_array,
-                           num_blocks_to_decompress * sizeof(uint32_t),
+                           safe_mul_sizeof<uint32_t>(num_blocks_to_decompress),
                            streams.stream(0), streams.gpu_index(0));
 
   auto compression_params = h_mem_ptr->compression_params;

--- a/backends/tfhe-cuda-backend/cuda/src/integer/div_rem.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/div_rem.cuh
@@ -175,10 +175,11 @@ __host__ void host_unsigned_integer_div_rem_block_by_block_2_2(
       as_radix_ciphertext_slice<Torus>(&d_msb, d, slice_start, slice_end);
       comparison_blocks->num_radix_blocks = d_msb.num_radix_blocks;
       if (d_msb.num_radix_blocks == 0) {
-        cuda_memset_async(
-            (Torus *)out_boolean_block->ptr, 0,
-            sizeof(Torus) * (out_boolean_block->lwe_dimension + 1),
-            streams.stream(gpu_index), streams.gpu_index(gpu_index));
+        cuda_memset_async((Torus *)out_boolean_block->ptr, 0,
+                          safe_mul_sizeof<Torus>(
+                              (size_t)(out_boolean_block->lwe_dimension + 1)),
+                          streams.stream(gpu_index),
+                          streams.gpu_index(gpu_index));
       } else {
         host_compare_blocks_with_zero<Torus>(
             streams.get_ith(gpu_index), comparison_blocks, &d_msb,

--- a/backends/tfhe-cuda-backend/cuda/src/integer/multiplication.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/multiplication.cuh
@@ -350,7 +350,7 @@ __host__ void host_integer_partial_sum_ciphertexts_vec(
   }
 
   cuda_memcpy_async_to_gpu(d_degrees, current_blocks->degrees,
-                           total_blocks_in_vec * sizeof(uint64_t),
+                           safe_mul_sizeof<uint64_t>(total_blocks_in_vec),
                            streams.stream(0), streams.gpu_index(0));
 
   cuda_set_device(streams.gpu_index(0));

--- a/backends/tfhe-cuda-backend/cuda/src/integer/radix_ciphertext.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/radix_ciphertext.cu
@@ -30,9 +30,10 @@ void into_radix_ciphertext(CudaRadixCiphertextFFI *radix, void *lwe_array,
   radix->max_num_radix_blocks = num_radix_blocks;
   radix->ptr = lwe_array;
 
-  radix->degrees = (uint64_t *)(calloc(num_radix_blocks, sizeof(uint64_t)));
+  radix->degrees =
+      (uint64_t *)(calloc(1, safe_mul_sizeof<uint64_t>(num_radix_blocks)));
   radix->noise_levels =
-      (uint64_t *)(calloc(num_radix_blocks, sizeof(uint64_t)));
+      (uint64_t *)(calloc(1, safe_mul_sizeof<uint64_t>(num_radix_blocks)));
   if (radix->degrees == NULL || radix->noise_levels == NULL) {
     PANIC("Cuda error: degrees / noise levels not allocated correctly")
   }

--- a/backends/tfhe-cuda-backend/cuda/src/integer/rerand.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/rerand.cuh
@@ -49,7 +49,7 @@ void host_rerand_inplace(
   }
   cuda_memcpy_with_size_tracking_async_to_gpu(
       d_expand_jobs, h_expand_jobs,
-      compact_lwe_lists.total_num_lwes * sizeof(expand_job<Torus>),
+      safe_mul_sizeof<expand_job<Torus>>(compact_lwe_lists.total_num_lwes),
       streams.stream(0), streams.gpu_index(0), true);
 
   host_lwe_expand<Torus, params>(streams.stream(0), streams.gpu_index(0),

--- a/backends/tfhe-cuda-backend/cuda/src/integer/scalar_bitops.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/scalar_bitops.cuh
@@ -49,7 +49,8 @@ host_scalar_bitop(CudaStreams streams, CudaRadixCiphertextFFI *output,
 
     integer_radix_apply_univariate_lookup_table<Torus>(
         streams, output, input, bsks, ksks, lut, num_clear_blocks);
-    memcpy(output->degrees, degrees, num_clear_blocks * sizeof(uint64_t));
+    memcpy(output->degrees, degrees,
+           safe_mul_sizeof<uint64_t>(num_clear_blocks));
 
     if (op == SCALAR_BITAND && num_clear_blocks < num_radix_blocks) {
       set_zero_radix_ciphertext_slice_async<Torus>(

--- a/backends/tfhe-cuda-backend/cuda/src/integer/vector_find.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/vector_find.cuh
@@ -433,7 +433,7 @@ __host__ void host_unchecked_match_value_or(
                                     mem_ptr->match_buffer, bsks, ksks);
 
   cuda_memcpy_async_to_gpu(mem_ptr->d_or_value, h_or_value,
-                           mem_ptr->num_final_blocks * sizeof(Torus),
+                           safe_mul_sizeof<Torus>(mem_ptr->num_final_blocks),
                            streams.stream(0), streams.gpu_index(0));
 
   set_trivial_radix_ciphertext_async<Torus>(
@@ -521,8 +521,8 @@ __host__ void host_unchecked_contains_clear(
     Torus *const *ksks) {
 
   cuda_memcpy_async_to_gpu(mem_ptr->d_clear_val, h_clear_val,
-                           num_blocks * sizeof(Torus), streams.stream(0),
-                           streams.gpu_index(0));
+                           safe_mul_sizeof<Torus>(num_blocks),
+                           streams.stream(0), streams.gpu_index(0));
 
   set_trivial_radix_ciphertext_async<Torus>(
       streams.stream(0), streams.gpu_index(0), mem_ptr->tmp_clear_val,
@@ -751,8 +751,8 @@ __host__ void host_unchecked_first_index_of_clear(
     void *const *bsks, Torus *const *ksks) {
 
   cuda_memcpy_async_to_gpu(mem_ptr->d_clear_val, h_clear_val,
-                           num_blocks * sizeof(Torus), streams.stream(0),
-                           streams.gpu_index(0));
+                           safe_mul_sizeof<Torus>(num_blocks),
+                           streams.stream(0), streams.gpu_index(0));
 
   set_trivial_radix_ciphertext_async<Torus>(
       streams.stream(0), streams.gpu_index(0), mem_ptr->tmp_clear_val,

--- a/backends/tfhe-cuda-backend/cuda/src/linearalgebra/addition.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/linearalgebra/addition.cuh
@@ -4,6 +4,7 @@
 #ifdef __CDT_PARSER__
 #endif
 
+#include "checked_arithmetic.h"
 #include "device.h"
 #include "helper_multi_gpu.h"
 #include "integer/integer.h"
@@ -56,9 +57,10 @@ __host__ void host_addition_plaintext(cudaStream_t stream, uint32_t gpu_index,
   dim3 grid(num_blocks, 1, 1);
   dim3 thds(num_threads, 1, 1);
 
-  cuda_memcpy_async_gpu_to_gpu(
-      output, lwe_input, (lwe_dimension + 1) * lwe_ciphertext_count * sizeof(T),
-      stream, gpu_index);
+  cuda_memcpy_async_gpu_to_gpu(output, lwe_input,
+                               safe_mul_sizeof<T>((size_t)(lwe_dimension + 1),
+                                                  (size_t)lwe_ciphertext_count),
+                               stream, gpu_index);
   plaintext_addition<T><<<grid, thds, 0, stream>>>(
       output, lwe_input, plaintext_input, lwe_dimension, num_entries);
   check_cuda_error(cudaGetLastError());
@@ -77,9 +79,10 @@ __host__ void host_addition_plaintext_scalar(
   dim3 grid(num_blocks, 1, 1);
   dim3 thds(num_threads, 1, 1);
 
-  cuda_memcpy_async_gpu_to_gpu(
-      output, lwe_input, (lwe_dimension + 1) * lwe_ciphertext_count * sizeof(T),
-      stream, gpu_index);
+  cuda_memcpy_async_gpu_to_gpu(output, lwe_input,
+                               safe_mul_sizeof<T>((size_t)(lwe_dimension + 1),
+                                                  (size_t)lwe_ciphertext_count),
+                               stream, gpu_index);
   plaintext_addition_scalar<T><<<grid, thds, 0, stream>>>(
       output, lwe_input, plaintext_input, lwe_dimension, num_entries);
   check_cuda_error(cudaGetLastError());
@@ -261,10 +264,11 @@ __host__ void host_subtraction_plaintext(cudaStream_t stream,
   dim3 grid(num_blocks, 1, 1);
   dim3 thds(num_threads, 1, 1);
 
-  cuda_memcpy_async_gpu_to_gpu(output, lwe_input,
-                               input_lwe_ciphertext_count *
-                                   (input_lwe_dimension + 1) * sizeof(T),
-                               stream, gpu_index);
+  cuda_memcpy_async_gpu_to_gpu(
+      output, lwe_input,
+      safe_mul_sizeof<T>((size_t)input_lwe_ciphertext_count,
+                         (size_t)(input_lwe_dimension + 1)),
+      stream, gpu_index);
 
   radix_body_subtraction_inplace<T><<<grid, thds, 0, stream>>>(
       output, plaintext_input, input_lwe_dimension, num_entries);

--- a/backends/tfhe-cuda-backend/cuda/src/linearalgebra/multiplication.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/linearalgebra/multiplication.cuh
@@ -7,6 +7,7 @@
 #endif
 
 #include "../utils/helper.cuh"
+#include "checked_arithmetic.h"
 #include "device.h"
 #include "linear_algebra.h"
 #include <fstream>
@@ -88,7 +89,8 @@ const int BLOCK_SIZE_GEMM = 64;
 const int THREADS_GEMM = 8;
 
 template <typename Torus> uint64_t get_shared_mem_size_tgemm() {
-  return BLOCK_SIZE_GEMM * THREADS_GEMM * 2 * sizeof(Torus);
+  return safe_mul_sizeof<Torus>((size_t)BLOCK_SIZE_GEMM, (size_t)THREADS_GEMM,
+                                (size_t)2);
 }
 
 // Multiply matrices A, B of size (M, K), (K, N) respectively

--- a/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_amortized.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_amortized.cuh
@@ -220,18 +220,20 @@ __global__ void device_programmable_bootstrap_amortized(
 template <typename Torus>
 uint64_t get_buffer_size_full_sm_programmable_bootstrap_amortized(
     uint32_t polynomial_size, uint32_t glwe_dimension) {
-  return sizeof(Torus) * polynomial_size * (glwe_dimension + 1) + // accumulator
-         sizeof(Torus) * polynomial_size *
-             (glwe_dimension + 1) +              // accumulator rotated
-         sizeof(double2) * polynomial_size / 2 + // accumulator fft
-         sizeof(double2) * polynomial_size / 2 *
-             (glwe_dimension + 1); // res fft
+  return safe_mul_sizeof<Torus>((size_t)polynomial_size,
+                                (size_t)(glwe_dimension + 1)) + // accumulator
+         safe_mul_sizeof<Torus>(
+             (size_t)polynomial_size,
+             (size_t)(glwe_dimension + 1)) +             // accumulator rotated
+         safe_mul_sizeof<double2>(polynomial_size / 2) + // accumulator fft
+         safe_mul_sizeof<double2>((size_t)(polynomial_size / 2),
+                                  (size_t)(glwe_dimension + 1)); // res fft
 }
 
 template <typename Torus>
 uint64_t get_buffer_size_partial_sm_programmable_bootstrap_amortized(
     uint32_t polynomial_size) {
-  return sizeof(double2) * polynomial_size / 2; // accumulator fft
+  return safe_mul_sizeof<double2>(polynomial_size / 2); // accumulator fft
 }
 
 template <typename Torus>

--- a/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_cg_multibit.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_cg_multibit.cuh
@@ -182,12 +182,13 @@ __global__ void __launch_bounds__(params::degree / params::opt)
 template <typename Torus>
 uint64_t get_buffer_size_partial_sm_cg_multibit_programmable_bootstrap(
     uint32_t polynomial_size) {
-  return sizeof(Torus) * polynomial_size; // accumulator
+  return safe_mul_sizeof<Torus>(polynomial_size); // accumulator
 }
 template <typename Torus>
 uint64_t get_buffer_size_full_sm_cg_multibit_programmable_bootstrap(
     uint32_t polynomial_size) {
-  return sizeof(Torus) * polynomial_size * 2; // accumulator
+  return safe_mul_sizeof<Torus>((size_t)polynomial_size,
+                                (size_t)2); // accumulator
 }
 
 template <typename Torus>
@@ -197,14 +198,19 @@ uint64_t get_buffer_size_cg_multibit_programmable_bootstrap(
     uint32_t grouping_factor, uint64_t lwe_chunk_size) {
 
   uint64_t buffer_size = 0;
-  buffer_size += input_lwe_ciphertext_count * lwe_chunk_size * level_count *
-                 (glwe_dimension + 1) * (glwe_dimension + 1) *
-                 (polynomial_size / 2) * sizeof(double2); // keybundle fft
-  buffer_size += input_lwe_ciphertext_count * (glwe_dimension + 1) *
-                 level_count * (polynomial_size / 2) *
-                 sizeof(double2); // join buffer
-  buffer_size += input_lwe_ciphertext_count * (glwe_dimension + 1) *
-                 polynomial_size * sizeof(Torus); // global_accumulator
+  buffer_size += safe_mul_sizeof<double2>(
+      safe_mul((size_t)input_lwe_ciphertext_count, (size_t)lwe_chunk_size,
+               (size_t)level_count),
+      safe_mul((size_t)(glwe_dimension + 1), (size_t)(glwe_dimension + 1)),
+      (size_t)(polynomial_size / 2)); // keybundle fft
+  buffer_size +=
+      safe_mul_sizeof<double2>(safe_mul((size_t)input_lwe_ciphertext_count,
+                                        (size_t)(glwe_dimension + 1)),
+                               (size_t)level_count,
+                               (size_t)(polynomial_size / 2)); // join buffer
+  buffer_size += safe_mul_sizeof<Torus>(
+      (size_t)input_lwe_ciphertext_count, (size_t)(glwe_dimension + 1),
+      (size_t)polynomial_size); // global_accumulator
 
   return buffer_size + buffer_size % sizeof(double2);
 }

--- a/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_multibit.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_multibit.cu
@@ -1,4 +1,5 @@
 #include "../polynomial/parameters.cuh"
+#include "checked_arithmetic.h"
 #include "pbs/programmable_bootstrap_multibit.h"
 #include "programmable_bootstrap_cg_multibit.cuh"
 #include "programmable_bootstrap_multibit.cuh"
@@ -483,9 +484,10 @@ uint64_t get_lwe_chunk_size(uint32_t gpu_index, uint32_t max_num_pbs,
   size_t total_mem, free_mem;
   check_cuda_error(cudaMemGetInfo(&free_mem, &total_mem));
   // Estimate the size of one chunk
-  uint64_t size_one_chunk = (uint64_t)max_num_pbs * polynomial_size *
-                            (glwe_dimension + 1) * (glwe_dimension + 1) *
-                            level_count * sizeof(Torus);
+  uint64_t size_one_chunk = safe_mul_sizeof<Torus>(
+      safe_mul((size_t)max_num_pbs, (size_t)(glwe_dimension + 1),
+               (size_t)(glwe_dimension + 1)),
+      (size_t)polynomial_size, (size_t)level_count);
 
   // We calculate the maximum number of chunks that can fit in the 50% of free
   // memory. We don't want the pbs temp array uses more than 50% of the free

--- a/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_multibit.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_multibit.cuh
@@ -485,22 +485,23 @@ __global__ void __launch_bounds__(params::degree / params::opt)
 template <typename Torus>
 uint64_t get_buffer_size_full_sm_multibit_programmable_bootstrap_keybundle(
     uint32_t polynomial_size) {
-  return sizeof(double2) * polynomial_size / 2; // accumulator
+  return safe_mul_sizeof<double2>(polynomial_size / 2); // accumulator
 }
 template <typename Torus>
 uint64_t get_buffer_size_full_sm_multibit_programmable_bootstrap_step_one(
     uint32_t polynomial_size) {
-  return sizeof(Torus) * polynomial_size * 2; // accumulator
+  return safe_mul_sizeof<Torus>((size_t)polynomial_size,
+                                (size_t)2); // accumulator
 }
 template <typename Torus>
 uint64_t get_buffer_size_partial_sm_multibit_programmable_bootstrap_step_one(
     uint32_t polynomial_size) {
-  return sizeof(Torus) * polynomial_size; // accumulator
+  return safe_mul_sizeof<Torus>(polynomial_size); // accumulator
 }
 template <typename Torus>
 uint64_t get_buffer_size_full_sm_multibit_programmable_bootstrap_step_two(
     uint32_t polynomial_size) {
-  return sizeof(Torus) * polynomial_size; // accumulator
+  return safe_mul_sizeof<Torus>(polynomial_size); // accumulator
 }
 
 template <typename Torus, typename params>

--- a/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_multibit_128.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_multibit_128.cuh
@@ -14,7 +14,8 @@
 template <typename Torus>
 uint64_t get_buffer_size_full_sm_multibit_programmable_bootstrap_128_keybundle(
     uint32_t polynomial_size) {
-  return sizeof(__uint128_t) * polynomial_size * 2; // accumulator
+  return safe_mul_sizeof<__uint128_t>((size_t)polynomial_size,
+                                      (size_t)2); // accumulator
 }
 
 template <typename InputTorus, class params, sharedMemDegree SMD>

--- a/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_tbc_multibit.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_tbc_multibit.cuh
@@ -393,18 +393,19 @@ __global__ void __launch_bounds__(params::degree / params::opt)
 template <typename Torus>
 uint64_t get_buffer_size_sm_dsm_plus_tbc_multibit_programmable_bootstrap(
     uint32_t polynomial_size) {
-  return sizeof(Torus) * polynomial_size; // distributed shared memory
+  return safe_mul_sizeof<Torus>(polynomial_size); // distributed shared memory
 }
 
 template <typename Torus>
 uint64_t get_buffer_size_partial_sm_tbc_multibit_programmable_bootstrap(
     uint32_t polynomial_size) {
-  return sizeof(Torus) * polynomial_size; // accumulator
+  return safe_mul_sizeof<Torus>(polynomial_size); // accumulator
 }
 template <typename Torus>
 uint64_t get_buffer_size_full_sm_tbc_multibit_programmable_bootstrap(
     uint32_t polynomial_size) {
-  return sizeof(Torus) * polynomial_size * 2; // accumulator
+  return safe_mul_sizeof<Torus>((size_t)polynomial_size,
+                                (size_t)2); // accumulator
 }
 
 template <typename Torus, typename params>

--- a/backends/tfhe-cuda-backend/cuda/src/utils/helper_debug.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/utils/helper_debug.cuh
@@ -1,6 +1,7 @@
 #ifndef HELPER_DEBUG_CUH
 #define HELPER_DEBUG_CUH
 
+#include "checked_arithmetic.h"
 #include "cuComplex.h"
 #include "thrust/complex.h"
 #include <cstdint>
@@ -189,7 +190,8 @@ __host__ void dump_2d_gpu_to_file(const Torus *ptr, int row_size, int col_size,
            rand_prefix);
 
   cuda_memcpy_async_to_cpu((void *)&buf_cpu[0], ptr,
-                           buf_cpu.size() * sizeof(Torus), stream, gpu_index);
+                           safe_mul_sizeof<Torus>(buf_cpu.size()), stream,
+                           gpu_index);
   cuda_synchronize_device(gpu_index);
   print_2d_csv_to_file(buf_cpu, col_size, fname);
   // #endif
@@ -204,9 +206,11 @@ __host__ void compare_2d_arrays(const Torus *ptr1, const Torus *ptr2,
       buf_cpu2(row_size * col_size);
   ;
   cuda_memcpy_async_to_cpu((void *)&buf_cpu1[0], ptr1,
-                           buf_cpu1.size() * sizeof(Torus), stream, gpu_index);
+                           safe_mul_sizeof<Torus>(buf_cpu1.size()), stream,
+                           gpu_index);
   cuda_memcpy_async_to_cpu((void *)&buf_cpu2[0], ptr2,
-                           buf_cpu2.size() * sizeof(Torus), stream, gpu_index);
+                           safe_mul_sizeof<Torus>(buf_cpu2.size()), stream,
+                           gpu_index);
   cuda_synchronize_device(gpu_index);
 
   std::vector<uint32_t> non_matching_indexes;

--- a/backends/tfhe-cuda-backend/cuda/src/zk/zk.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/zk/zk.cuh
@@ -114,7 +114,7 @@ __host__ void host_expand_without_verification(
   }
   cuda_memcpy_with_size_tracking_async_to_gpu(
       d_expand_jobs, h_expand_jobs,
-      compact_lwe_lists.total_num_lwes * sizeof(expand_job<Torus>),
+      safe_mul_sizeof<expand_job<Torus>>(compact_lwe_lists.total_num_lwes),
       streams.stream(0), streams.gpu_index(0), true);
 
   host_lwe_expand<Torus, params>(streams.stream(0), streams.gpu_index(0),
@@ -152,7 +152,8 @@ __host__ void host_expand_without_verification(
 
   // Apply LUT
   cuda_memset_async(lwe_array_out, 0,
-                    (lwe_dimension + 1) * num_lwes * 2 * sizeof(Torus),
+                    safe_mul_sizeof<Torus>((size_t)(lwe_dimension + 1),
+                                           (size_t)num_lwes, (size_t)2),
                     streams.stream(0), streams.gpu_index(0));
   CudaRadixCiphertextFFI output;
   into_radix_ciphertext(&output, lwe_array_out, 2 * num_lwes, lwe_dimension);

--- a/backends/tfhe-cuda-backend/cuda/tests_and_benchmarks/tests/test_classical_pbs.cpp
+++ b/backends/tfhe-cuda-backend/cuda/tests_and_benchmarks/tests/test_classical_pbs.cpp
@@ -7,6 +7,8 @@
 #include <setup_and_teardown.h>
 #include <utils.h>
 
+#include "checked_arithmetic.h"
+
 typedef struct {
   int lwe_dimension;
   int glwe_dimension;
@@ -88,9 +90,9 @@ public:
         carry_modulus, &payload_modulus, &delta, number_of_inputs, repetitions,
         samples);
 
-    lwe_ct_out_array =
-        (uint64_t *)malloc((glwe_dimension * polynomial_size + 1) *
-                           number_of_inputs * sizeof(uint64_t));
+    lwe_ct_out_array = (uint64_t *)malloc(safe_mul_sizeof<uint64_t>(
+        safe_mul((size_t)glwe_dimension, (size_t)polynomial_size) + 1,
+        (size_t)number_of_inputs));
   }
 
   void TearDown() {
@@ -130,10 +132,12 @@ TEST_P(ClassicalProgrammableBootstrapTestPrimitives_u64, amortized_bootstrap) {
           lwe_dimension, glwe_dimension, polynomial_size, pbs_base_log,
           pbs_level, number_of_inputs);
       // Copy result back
-      cuda_memcpy_async_to_cpu(lwe_ct_out_array, d_lwe_ct_out_array,
-                               (glwe_dimension * polynomial_size + 1) *
-                                   number_of_inputs * sizeof(uint64_t),
-                               stream, gpu_index);
+      cuda_memcpy_async_to_cpu(
+          lwe_ct_out_array, d_lwe_ct_out_array,
+          safe_mul_sizeof<uint64_t>(
+              safe_mul((size_t)glwe_dimension, (size_t)polynomial_size) + 1,
+              (size_t)number_of_inputs),
+          stream, gpu_index);
 
       for (int j = 0; j < number_of_inputs; j++) {
         uint64_t *result =
@@ -195,10 +199,12 @@ TEST_P(ClassicalProgrammableBootstrapTestPrimitives_u64, bootstrap) {
           lwe_dimension, glwe_dimension, polynomial_size, pbs_base_log,
           pbs_level, number_of_inputs, num_many_lut, lut_stride);
       // Copy result back
-      cuda_memcpy_async_to_cpu(lwe_ct_out_array, d_lwe_ct_out_array,
-                               (glwe_dimension * polynomial_size + 1) *
-                                   number_of_inputs * sizeof(uint64_t),
-                               stream, gpu_index);
+      cuda_memcpy_async_to_cpu(
+          lwe_ct_out_array, d_lwe_ct_out_array,
+          safe_mul_sizeof<uint64_t>(
+              safe_mul((size_t)glwe_dimension, (size_t)polynomial_size) + 1,
+              (size_t)number_of_inputs),
+          stream, gpu_index);
 
       for (int j = 0; j < number_of_inputs; j++) {
         uint64_t *result =

--- a/backends/tfhe-cuda-backend/cuda/tests_and_benchmarks/tests/test_multibit_pbs.cpp
+++ b/backends/tfhe-cuda-backend/cuda/tests_and_benchmarks/tests/test_multibit_pbs.cpp
@@ -1,3 +1,4 @@
+#include "checked_arithmetic.h"
 #include "device.h"
 #include <cmath>
 #include <cstdint>
@@ -96,9 +97,9 @@ public:
         stream, gpu_index, &pbs_buffer, glwe_dimension, polynomial_size,
         pbs_level, number_of_inputs, true);
 
-    lwe_ct_out_array =
-        (uint64_t *)malloc((glwe_dimension * polynomial_size + 1) *
-                           number_of_inputs * sizeof(uint64_t));
+    lwe_ct_out_array = (uint64_t *)malloc(safe_mul_sizeof<uint64_t>(
+        safe_mul((size_t)glwe_dimension, (size_t)polynomial_size) + 1,
+        (size_t)number_of_inputs));
   }
 
   void TearDown() {
@@ -141,10 +142,12 @@ TEST_P(MultiBitProgrammableBootstrapTestPrimitives_u64,
           pbs_level, number_of_inputs, num_many_lut, lut_stride);
 
       // Copy result to the host memory
-      cuda_memcpy_async_to_cpu(lwe_ct_out_array, d_lwe_ct_out_array,
-                               (glwe_dimension * polynomial_size + 1) *
-                                   number_of_inputs * sizeof(uint64_t),
-                               stream, gpu_index);
+      cuda_memcpy_async_to_cpu(
+          lwe_ct_out_array, d_lwe_ct_out_array,
+          safe_mul_sizeof<uint64_t>(
+              safe_mul((size_t)glwe_dimension, (size_t)polynomial_size) + 1,
+              (size_t)number_of_inputs),
+          stream, gpu_index);
 
       for (int j = 0; j < number_of_inputs; j++) {
         uint64_t *result =

--- a/backends/tfhe-cuda-backend/cuda/tests_and_benchmarks/utils.cpp
+++ b/backends/tfhe-cuda-backend/cuda/tests_and_benchmarks/utils.cpp
@@ -9,6 +9,8 @@
 #include <random>
 #include <utils.h>
 
+#include "checked_arithmetic.h"
+
 void init_seed(Seed *seed) {
   seed->lo = 0;
   seed->hi = 0;
@@ -36,8 +38,8 @@ uint64_t *generate_plaintexts(uint64_t payload_modulus, uint64_t delta,
                               int number_of_inputs, const unsigned repetitions,
                               const unsigned samples) {
 
-  uint64_t *plaintext_array = (uint64_t *)malloc(
-      repetitions * samples * number_of_inputs * sizeof(uint64_t));
+  uint64_t *plaintext_array = (uint64_t *)malloc(safe_mul_sizeof<uint64_t>(
+      repetitions, samples, number_of_inputs));
   std::random_device rd;
   std::mt19937 gen(rd());
   std::uniform_int_distribution<unsigned long long> dis(
@@ -68,7 +70,7 @@ uint64_t *generate_identity_lut_pbs(int polynomial_size, int glwe_dimension,
 
   // Create the plaintext lut_pbs
   uint64_t *plaintext_lut_pbs =
-      (uint64_t *)malloc(polynomial_size * sizeof(uint64_t));
+      (uint64_t *)malloc(safe_mul_sizeof<uint64_t>(polynomial_size));
 
   // This plaintext_lut_pbs extracts the carry bits
   for (uint64_t i = 0; i < modulus_sup; i++) {
@@ -91,7 +93,7 @@ uint64_t *generate_identity_lut_pbs(int polynomial_size, int glwe_dimension,
 
   // Create the GLWE lut_pbs
   uint64_t *lut_pbs = (uint64_t *)malloc(
-      polynomial_size * (glwe_dimension + 1) * sizeof(uint64_t));
+      safe_mul_sizeof<uint64_t>(polynomial_size, glwe_dimension + 1));
   for (int i = 0; i < polynomial_size * glwe_dimension; i++) {
     lut_pbs[i] = 0;
   }
@@ -108,7 +110,7 @@ uint64_t *generate_identity_lut_pbs(int polynomial_size, int glwe_dimension,
 void generate_lwe_secret_keys(uint64_t **lwe_sk_array, int lwe_dimension,
                               Seed *seed, const unsigned repetitions) {
   *lwe_sk_array =
-      (uint64_t *)malloc(lwe_dimension * repetitions * sizeof(uint64_t));
+      (uint64_t *)malloc(safe_mul_sizeof<uint64_t>(lwe_dimension, repetitions));
   int shift = 0;
   for (uint r = 0; r < repetitions; r++) {
     // Generate the lwe secret key for each repetition
@@ -122,8 +124,8 @@ void generate_lwe_secret_keys(uint64_t **lwe_sk_array, int lwe_dimension,
 void generate_glwe_secret_keys(uint64_t **glwe_sk_array, int glwe_dimension,
                                int polynomial_size, Seed *seed,
                                const unsigned repetitions) {
-  int glwe_sk_array_size = glwe_dimension * polynomial_size * repetitions;
-  *glwe_sk_array = (uint64_t *)malloc(glwe_sk_array_size * sizeof(uint64_t));
+  size_t glwe_sk_array_size = safe_mul(glwe_dimension, polynomial_size, repetitions);
+  *glwe_sk_array = (uint64_t *)malloc(safe_mul_sizeof<uint64_t>(glwe_sk_array_size));
   int shift = 0;
   for (uint r = 0; r < repetitions; r++) {
     // Generate the lwe secret key for each repetition
@@ -143,13 +145,15 @@ void generate_lwe_programmable_bootstrap_keys(cudaStream_t stream, uint32_t gpu_
                                  int pbs_level, int pbs_base_log, Seed *seed,
                                  DynamicDistribution noise_distribution,
                                  const unsigned repetitions) {
-  int bsk_size = (glwe_dimension + 1) * (glwe_dimension + 1) * pbs_level *
-                 polynomial_size * (lwe_dimension + 1);
-  int bsk_array_size = bsk_size * repetitions;
+  size_t bsk_size = safe_mul(
+      safe_mul(glwe_dimension + 1, glwe_dimension + 1, pbs_level,
+                        polynomial_size),
+      (size_t)(lwe_dimension + 1));
+  size_t bsk_array_size = safe_mul(bsk_size, repetitions);
 
-  uint64_t *bsk_array = (uint64_t *)malloc(bsk_array_size * sizeof(uint64_t));
+  uint64_t *bsk_array = (uint64_t *)malloc(safe_mul_sizeof<uint64_t>(bsk_array_size));
   *d_fourier_bsk_array =
-      (double *)cuda_malloc_async(bsk_array_size * sizeof(double), stream, gpu_index);
+      (double *)cuda_malloc_async(safe_mul_sizeof<double>(bsk_array_size), stream, gpu_index);
   int shift_in = 0;
   int shift_out = 0;
   int shift_bsk = 0;
@@ -182,14 +186,22 @@ void generate_lwe_multi_bit_programmable_bootstrap_keys(
     DynamicDistribution noise_distribution,
     const unsigned repetitions) {
 
-  int bsk_size = lwe_dimension * pbs_level * (glwe_dimension + 1) *
-                 (glwe_dimension + 1) * polynomial_size *
-                 (1 << grouping_factor) / grouping_factor;
-  int bsk_array_size = bsk_size * repetitions;
-  uint64_t *bsk_array = (uint64_t *)malloc(bsk_array_size * sizeof(uint64_t));
+  // Multiply all factors first, then divide by grouping_factor at the end
+  // to preserve integer division semantics (the full product is always
+  // divisible by grouping_factor, but partial sub-products may not be)
+  size_t bsk_size =
+      safe_mul(
+          safe_mul((size_t)lwe_dimension, (size_t)pbs_level,
+                            (size_t)(glwe_dimension + 1),
+                            (size_t)(glwe_dimension + 1)),
+          safe_mul((size_t)polynomial_size,
+                            (size_t)(1 << grouping_factor))) /
+      grouping_factor;
+  size_t bsk_array_size = safe_mul(bsk_size, repetitions);
+  uint64_t *bsk_array = (uint64_t *)malloc(safe_mul_sizeof<uint64_t>(bsk_array_size));
 
   *d_bsk_array =
-      (uint64_t *)cuda_malloc_async(bsk_array_size * sizeof(uint64_t), stream, gpu_index);
+      (uint64_t *)cuda_malloc_async(safe_mul_sizeof<uint64_t>(bsk_array_size), stream, gpu_index);
   for (uint r = 0; r < repetitions; r++) {
     int shift_in = 0;
     int shift_out = 0;
@@ -219,12 +231,12 @@ void generate_lwe_keyswitch_keys(
     int output_lwe_dimension, int ksk_level, int ksk_base_log, Seed *seed,
     DynamicDistribution noise_distribution, const unsigned repetitions) {
 
-  int ksk_size = ksk_level * (output_lwe_dimension + 1) * input_lwe_dimension;
-  int ksk_array_size = ksk_size * repetitions;
+  size_t ksk_size = safe_mul(ksk_level, output_lwe_dimension + 1, input_lwe_dimension);
+  size_t ksk_array_size = safe_mul(ksk_size, repetitions);
 
-  uint64_t *ksk_array = (uint64_t *)malloc(ksk_array_size * sizeof(uint64_t));
+  uint64_t *ksk_array = (uint64_t *)malloc(safe_mul_sizeof<uint64_t>(ksk_array_size));
   *d_ksk_array =
-      (uint64_t *)cuda_malloc_async(ksk_array_size * sizeof(uint64_t), stream, gpu_index);
+      (uint64_t *)cuda_malloc_async(safe_mul_sizeof<uint64_t>(ksk_array_size), stream, gpu_index);
   int shift_in = 0;
   int shift_out = 0;
   int shift_ksk = 0;
@@ -238,7 +250,7 @@ void generate_lwe_keyswitch_keys(
         noise_distribution, seed->lo, seed->hi);
     uint64_t *d_ksk = *d_ksk_array + (ptrdiff_t)(shift_ksk);
     uint64_t *ksk = ksk_array + (ptrdiff_t)(shift_ksk);
-    cuda_memcpy_async_to_gpu(d_ksk, ksk, ksk_size * sizeof(uint64_t), stream, gpu_index);
+    cuda_memcpy_async_to_gpu(d_ksk, ksk, safe_mul_sizeof<uint64_t>(ksk_size), stream, gpu_index);
 
     shift_in += input_lwe_dimension;
     shift_out += output_lwe_dimension;


### PR DESCRIPTION
There is a common pattern in the CUDA backend to compute allocation sizes using uint32_t * uint32_t products that overflow before being widened to 64-bit by * sizeof(T). We were aware of a few samples in rerand scratch function but using Claude I was able to find others. This PR fixes all of them.

<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: https://github.com/zama-ai/tfhe-rs-internal/issues/1326

### PR content/description

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
