### PR TITLE
fix(gpu): rework compression to fix the GLWE addresses when lwe_per_glwe != polynomial_size

### DIFF
--- a/backends/tfhe-cuda-backend/cuda/include/ciphertext.h
+++ b/backends/tfhe-cuda-backend/cuda/include/ciphertext.h
@@ -19,7 +19,9 @@ void cuda_convert_lwe_ciphertext_vector_to_cpu_64(void *stream,
 void cuda_glwe_sample_extract_64(void *stream, uint32_t gpu_index,
                                  void *lwe_array_out, void const *glwe_array_in,
                                  uint32_t const *nth_array, uint32_t num_nths,
-                                 uint32_t lwe_per_glwe, uint32_t glwe_dimension,
+                                 uint32_t num_lwes_to_extract_per_glwe,
+                                 uint32_t num_lwes_stored_per_glwe,
+                                 uint32_t glwe_dimension,
                                  uint32_t polynomial_size);
 
 void cuda_modulus_switch_inplace_64(void *stream, uint32_t gpu_index,
@@ -38,6 +40,7 @@ void cuda_centered_modulus_switch_64(void *stream, uint32_t gpu_index,
 void cuda_glwe_sample_extract_128(
     void *stream, uint32_t gpu_index, void *lwe_array_out,
     void const *glwe_array_in, uint32_t const *nth_array, uint32_t num_nths,
-    uint32_t lwe_per_glwe, uint32_t glwe_dimension, uint32_t polynomial_size);
+    uint32_t num_lwes_to_extract_per_glwe, uint32_t num_lwes_stored_per_glwe,
+    uint32_t glwe_dimension, uint32_t polynomial_size);
 }
 #endif

--- a/backends/tfhe-cuda-backend/cuda/include/integer/compression/compression.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer/compression/compression.h
@@ -10,7 +10,8 @@ uint64_t scratch_cuda_integer_compress_radix_ciphertext_64(
     uint32_t compression_glwe_dimension, uint32_t compression_polynomial_size,
     uint32_t lwe_dimension, uint32_t ks_level, uint32_t ks_base_log,
     uint32_t num_radix_blocks, uint32_t message_modulus, uint32_t carry_modulus,
-    PBS_TYPE pbs_type, uint32_t lwe_per_glwe, bool allocate_gpu_memory);
+    PBS_TYPE pbs_type, uint32_t num_lwes_stored_per_glwe,
+    bool allocate_gpu_memory);
 
 uint64_t scratch_cuda_integer_decompress_radix_ciphertext_64(
     CudaStreamsFFI streams, int8_t **mem_ptr,
@@ -42,7 +43,8 @@ uint64_t scratch_cuda_integer_compress_radix_ciphertext_128(
     uint32_t compression_glwe_dimension, uint32_t compression_polynomial_size,
     uint32_t lwe_dimension, uint32_t ks_level, uint32_t ks_base_log,
     uint32_t num_radix_blocks, uint32_t message_modulus, uint32_t carry_modulus,
-    PBS_TYPE pbs_type, uint32_t lwe_per_glwe, bool allocate_gpu_memory);
+    PBS_TYPE pbs_type, uint32_t num_lwes_stored_per_glwe,
+    bool allocate_gpu_memory);
 
 uint64_t scratch_cuda_integer_decompress_radix_ciphertext_128(
     CudaStreamsFFI streams, int8_t **mem_ptr,

--- a/backends/tfhe-cuda-backend/cuda/include/integer/compression/compression_utilities.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer/compression/compression_utilities.h
@@ -10,26 +10,26 @@ template <typename Torus> struct int_compression {
   Torus *tmp_lwe;
   Torus *tmp_glwe_array_out;
   bool gpu_memory_allocated;
-  uint32_t lwe_per_glwe;
+  uint32_t num_lwes_stored_per_glwe;
   uint32_t max_num_glwes;
 
   // num_radix_blocks: total number of LWE ciphertexts (radix blocks) to
-  // compress lwe_per_glwe: max LWEs packed per GLWE (= polynomial_size),
-  // defined by the chosen parameter set
+  // compress num_lwes_stored_per_glwe: max LWEs packed per GLWE (<=
+  // polynomial_size), defined by the chosen parameter set
   int_compression(CudaStreams streams, int_radix_params compression_params,
-                  uint32_t num_radix_blocks, uint32_t lwe_per_glwe,
+                  uint32_t num_radix_blocks, uint32_t num_lwes_stored_per_glwe,
                   bool allocate_gpu_memory, uint64_t &size_tracker) {
     gpu_memory_allocated = allocate_gpu_memory;
     this->compression_params = compression_params;
-    this->lwe_per_glwe = lwe_per_glwe;
+    this->num_lwes_stored_per_glwe = num_lwes_stored_per_glwe;
 
     uint64_t glwe_accumulator_size = (compression_params.glwe_dimension + 1) *
                                      compression_params.polynomial_size;
 
     // Calculate the actual number of GLWEs needed based on total radix blocks.
     // This ensures we allocate enough memory when num_radix_blocks >
-    // lwe_per_glwe.
-    max_num_glwes = CEIL_DIV(num_radix_blocks, lwe_per_glwe);
+    // num_lwes_stored_per_glwe.
+    max_num_glwes = CEIL_DIV(num_radix_blocks, num_lwes_stored_per_glwe);
 
     tmp_lwe = static_cast<Torus *>(cuda_malloc_with_size_tracking_async(
         num_radix_blocks * (compression_params.small_lwe_dimension + 1) *

--- a/backends/tfhe-cuda-backend/cuda/include/integer/integer.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer/integer.h
@@ -95,12 +95,11 @@ typedef struct {
 typedef struct {
   void *ptr;
   uint32_t storage_log_modulus;
-  uint32_t lwe_per_glwe;
-  // Input LWEs are grouped by groups of `lwe_per_glwe`(the last group may be
-  // smaller)
-  // Each group is then packed into one GLWE with `lwe_per_glwe` bodies (one for
-  // each LWE of the group). In the end the total number of bodies is equal to
-  // the number of input LWE
+  uint32_t num_lwes_stored_per_glwe;
+  // Input LWEs are grouped by groups of `num_lwes_stored_per_glwe`(the last
+  // group may be smaller) Each group is then packed into one GLWE with
+  // `num_lwes_stored_per_glwe` bodies (one for each LWE of the group). In the
+  // end the total number of bodies is equal to the number of input LWE
   uint32_t total_lwe_bodies_count;
   uint32_t glwe_dimension;
   uint32_t polynomial_size;

--- a/backends/tfhe-cuda-backend/cuda/src/crypto/ciphertext.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/crypto/ciphertext.cu
@@ -24,7 +24,9 @@ void cuda_convert_lwe_ciphertext_vector_to_cpu_64(void *stream,
 void cuda_glwe_sample_extract_64(void *stream, uint32_t gpu_index,
                                  void *lwe_array_out, void const *glwe_array_in,
                                  uint32_t const *nth_array, uint32_t num_nths,
-                                 uint32_t lwe_per_glwe, uint32_t glwe_dimension,
+                                 uint32_t num_lwes_to_extract_per_glwe,
+                                 uint32_t num_lwes_stored_per_glwe,
+                                 uint32_t glwe_dimension,
                                  uint32_t polynomial_size) {
 
   switch (polynomial_size) {
@@ -32,43 +34,43 @@ void cuda_glwe_sample_extract_64(void *stream, uint32_t gpu_index,
     host_sample_extract<uint64_t, AmortizedDegree<256>>(
         static_cast<cudaStream_t>(stream), gpu_index, (uint64_t *)lwe_array_out,
         (uint64_t const *)glwe_array_in, (uint32_t const *)nth_array, num_nths,
-        lwe_per_glwe, glwe_dimension);
+        num_lwes_to_extract_per_glwe, num_lwes_stored_per_glwe, glwe_dimension);
     break;
   case 512:
     host_sample_extract<uint64_t, AmortizedDegree<512>>(
         static_cast<cudaStream_t>(stream), gpu_index, (uint64_t *)lwe_array_out,
         (uint64_t const *)glwe_array_in, (uint32_t const *)nth_array, num_nths,
-        lwe_per_glwe, glwe_dimension);
+        num_lwes_to_extract_per_glwe, num_lwes_stored_per_glwe, glwe_dimension);
     break;
   case 1024:
     host_sample_extract<uint64_t, AmortizedDegree<1024>>(
         static_cast<cudaStream_t>(stream), gpu_index, (uint64_t *)lwe_array_out,
         (uint64_t const *)glwe_array_in, (uint32_t const *)nth_array, num_nths,
-        lwe_per_glwe, glwe_dimension);
+        num_lwes_to_extract_per_glwe, num_lwes_stored_per_glwe, glwe_dimension);
     break;
   case 2048:
     host_sample_extract<uint64_t, AmortizedDegree<2048>>(
         static_cast<cudaStream_t>(stream), gpu_index, (uint64_t *)lwe_array_out,
         (uint64_t const *)glwe_array_in, (uint32_t const *)nth_array, num_nths,
-        lwe_per_glwe, glwe_dimension);
+        num_lwes_to_extract_per_glwe, num_lwes_stored_per_glwe, glwe_dimension);
     break;
   case 4096:
     host_sample_extract<uint64_t, AmortizedDegree<4096>>(
         static_cast<cudaStream_t>(stream), gpu_index, (uint64_t *)lwe_array_out,
         (uint64_t const *)glwe_array_in, (uint32_t const *)nth_array, num_nths,
-        lwe_per_glwe, glwe_dimension);
+        num_lwes_to_extract_per_glwe, num_lwes_stored_per_glwe, glwe_dimension);
     break;
   case 8192:
     host_sample_extract<uint64_t, AmortizedDegree<8192>>(
         static_cast<cudaStream_t>(stream), gpu_index, (uint64_t *)lwe_array_out,
         (uint64_t const *)glwe_array_in, (uint32_t const *)nth_array, num_nths,
-        lwe_per_glwe, glwe_dimension);
+        num_lwes_to_extract_per_glwe, num_lwes_stored_per_glwe, glwe_dimension);
     break;
   case 16384:
     host_sample_extract<uint64_t, AmortizedDegree<16384>>(
         static_cast<cudaStream_t>(stream), gpu_index, (uint64_t *)lwe_array_out,
         (uint64_t const *)glwe_array_in, (uint32_t const *)nth_array, num_nths,
-        lwe_per_glwe, glwe_dimension);
+        num_lwes_to_extract_per_glwe, num_lwes_stored_per_glwe, glwe_dimension);
     break;
   default:
     PANIC("Cuda error: unsupported polynomial size. Supported "
@@ -106,38 +108,44 @@ void cuda_centered_modulus_switch_64(void *stream, uint32_t gpu_index,
 void cuda_glwe_sample_extract_128(
     void *stream, uint32_t gpu_index, void *lwe_array_out,
     void const *glwe_array_in, uint32_t const *nth_array, uint32_t num_nths,
-    uint32_t lwe_per_glwe, uint32_t glwe_dimension, uint32_t polynomial_size) {
+    uint32_t num_lwes_to_extract_per_glwe, uint32_t num_lwes_stored_per_glwe,
+    uint32_t glwe_dimension, uint32_t polynomial_size) {
 
   switch (polynomial_size) {
   case 256:
     host_sample_extract<__uint128_t, AmortizedDegree<256>>(
         static_cast<cudaStream_t>(stream), gpu_index,
         (__uint128_t *)lwe_array_out, (__uint128_t const *)glwe_array_in,
-        (uint32_t const *)nth_array, num_nths, lwe_per_glwe, glwe_dimension);
+        (uint32_t const *)nth_array, num_nths, num_lwes_to_extract_per_glwe,
+        num_lwes_stored_per_glwe, glwe_dimension);
     break;
   case 512:
     host_sample_extract<__uint128_t, AmortizedDegree<512>>(
         static_cast<cudaStream_t>(stream), gpu_index,
         (__uint128_t *)lwe_array_out, (__uint128_t const *)glwe_array_in,
-        (uint32_t const *)nth_array, num_nths, lwe_per_glwe, glwe_dimension);
+        (uint32_t const *)nth_array, num_nths, num_lwes_to_extract_per_glwe,
+        num_lwes_stored_per_glwe, glwe_dimension);
     break;
   case 1024:
     host_sample_extract<__uint128_t, AmortizedDegree<1024>>(
         static_cast<cudaStream_t>(stream), gpu_index,
         (__uint128_t *)lwe_array_out, (__uint128_t const *)glwe_array_in,
-        (uint32_t const *)nth_array, num_nths, lwe_per_glwe, glwe_dimension);
+        (uint32_t const *)nth_array, num_nths, num_lwes_to_extract_per_glwe,
+        num_lwes_stored_per_glwe, glwe_dimension);
     break;
   case 2048:
     host_sample_extract<__uint128_t, AmortizedDegree<2048>>(
         static_cast<cudaStream_t>(stream), gpu_index,
         (__uint128_t *)lwe_array_out, (__uint128_t const *)glwe_array_in,
-        (uint32_t const *)nth_array, num_nths, lwe_per_glwe, glwe_dimension);
+        (uint32_t const *)nth_array, num_nths, num_lwes_to_extract_per_glwe,
+        num_lwes_stored_per_glwe, glwe_dimension);
     break;
   case 4096:
     host_sample_extract<__uint128_t, AmortizedDegree<4096>>(
         static_cast<cudaStream_t>(stream), gpu_index,
         (__uint128_t *)lwe_array_out, (__uint128_t const *)glwe_array_in,
-        (uint32_t const *)nth_array, num_nths, lwe_per_glwe, glwe_dimension);
+        (uint32_t const *)nth_array, num_nths, num_lwes_to_extract_per_glwe,
+        num_lwes_stored_per_glwe, glwe_dimension);
     break;
   default:
     PANIC("Cuda error: unsupported polynomial size. Supported "

--- a/backends/tfhe-cuda-backend/cuda/src/crypto/ciphertext.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/crypto/ciphertext.cuh
@@ -27,9 +27,10 @@ void cuda_convert_lwe_ciphertext_vector_to_cpu(cudaStream_t stream,
 }
 
 template <typename Torus, class params>
-__global__ void sample_extract(Torus *lwe_array_out, Torus const *glwe_array_in,
-                               uint32_t const *nth_array, uint32_t lwe_per_glwe,
-                               uint32_t glwe_dimension) {
+__global__ void
+sample_extract(Torus *lwe_array_out, Torus const *glwe_array_in,
+               uint32_t const *nth_array, uint32_t num_lwes_to_extract_per_glwe,
+               uint32_t num_lwes_stored_per_glwe, uint32_t glwe_dimension) {
 
   const int input_id = blockIdx.x;
 
@@ -38,29 +39,33 @@ __global__ void sample_extract(Torus *lwe_array_out, Torus const *glwe_array_in,
 
   auto lwe_out = lwe_array_out + input_id * lwe_output_size;
 
-  // We assume each GLWE will store the first polynomial_size inputs
-  auto glwe_in = glwe_array_in + (input_id / lwe_per_glwe) * glwe_input_size;
+  // Select the GLWE based on how many extractions are done per GLWE
+  auto glwe_in = glwe_array_in +
+                 (input_id / num_lwes_to_extract_per_glwe) * glwe_input_size;
 
-  // nth is ensured to be in [0, params::degree)
-  auto nth = nth_array[input_id] % params::degree;
+  // Compute the per-GLWE polynomial degree from the absolute index
+  auto nth = nth_array[input_id] % num_lwes_stored_per_glwe;
 
   sample_extract_mask<Torus, params>(lwe_out, glwe_in, glwe_dimension, nth);
   sample_extract_body<Torus, params>(lwe_out, glwe_in, glwe_dimension, nth);
 }
 
-// lwe_per_glwe LWEs will be extracted per GLWE ciphertext, thus we need to have
-// enough indexes
+// num_lwes_to_extract_per_glwe LWEs will be extracted per GLWE ciphertext, thus
+// we need to have enough indexes
 template <typename Torus, class params>
-__host__ void
-host_sample_extract(cudaStream_t stream, uint32_t gpu_index,
-                    Torus *lwe_array_out, Torus const *glwe_array_in,
-                    uint32_t const *nth_array, uint32_t num_nths,
-                    uint32_t lwe_per_glwe, uint32_t glwe_dimension) {
+__host__ void host_sample_extract(cudaStream_t stream, uint32_t gpu_index,
+                                  Torus *lwe_array_out,
+                                  Torus const *glwe_array_in,
+                                  uint32_t const *nth_array, uint32_t num_nths,
+                                  uint32_t num_lwes_to_extract_per_glwe,
+                                  uint32_t num_lwes_stored_per_glwe,
+                                  uint32_t glwe_dimension) {
   cuda_set_device(gpu_index);
   dim3 grid(num_nths);
   dim3 thds(params::degree / params::opt);
   sample_extract<Torus, params><<<grid, thds, 0, stream>>>(
-      lwe_array_out, glwe_array_in, nth_array, lwe_per_glwe, glwe_dimension);
+      lwe_array_out, glwe_array_in, nth_array, num_lwes_to_extract_per_glwe,
+      num_lwes_stored_per_glwe, glwe_dimension);
   check_cuda_error(cudaGetLastError());
 }
 

--- a/backends/tfhe-cuda-backend/cuda/src/integer/compression/compression.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/compression/compression.cu
@@ -5,7 +5,8 @@ uint64_t scratch_cuda_integer_compress_radix_ciphertext_64(
     uint32_t compression_glwe_dimension, uint32_t compression_polynomial_size,
     uint32_t lwe_dimension, uint32_t ks_level, uint32_t ks_base_log,
     uint32_t num_radix_blocks, uint32_t message_modulus, uint32_t carry_modulus,
-    PBS_TYPE pbs_type, uint32_t lwe_per_glwe, bool allocate_gpu_memory) {
+    PBS_TYPE pbs_type, uint32_t num_lwes_stored_per_glwe,
+    bool allocate_gpu_memory) {
 
   int_radix_params compression_params(
       pbs_type, compression_glwe_dimension, compression_polynomial_size,
@@ -15,7 +16,8 @@ uint64_t scratch_cuda_integer_compress_radix_ciphertext_64(
 
   return scratch_cuda_compress_ciphertext<uint64_t>(
       CudaStreams(streams), (int_compression<uint64_t> **)mem_ptr,
-      num_radix_blocks, compression_params, lwe_per_glwe, allocate_gpu_memory);
+      num_radix_blocks, compression_params, num_lwes_stored_per_glwe,
+      allocate_gpu_memory);
 }
 uint64_t scratch_cuda_integer_decompress_radix_ciphertext_64(
     CudaStreamsFFI streams, int8_t **mem_ptr,
@@ -85,7 +87,8 @@ uint64_t scratch_cuda_integer_compress_radix_ciphertext_128(
     uint32_t compression_glwe_dimension, uint32_t compression_polynomial_size,
     uint32_t lwe_dimension, uint32_t ks_level, uint32_t ks_base_log,
     uint32_t num_radix_blocks, uint32_t message_modulus, uint32_t carry_modulus,
-    PBS_TYPE pbs_type, uint32_t lwe_per_glwe, bool allocate_gpu_memory) {
+    PBS_TYPE pbs_type, uint32_t num_lwes_stored_per_glwe,
+    bool allocate_gpu_memory) {
 
   int_radix_params compression_params(
       pbs_type, compression_glwe_dimension, compression_polynomial_size,
@@ -95,7 +98,8 @@ uint64_t scratch_cuda_integer_compress_radix_ciphertext_128(
 
   return scratch_cuda_compress_ciphertext<__uint128_t>(
       CudaStreams(streams), (int_compression<__uint128_t> **)mem_ptr,
-      num_radix_blocks, compression_params, lwe_per_glwe, allocate_gpu_memory);
+      num_radix_blocks, compression_params, num_lwes_stored_per_glwe,
+      allocate_gpu_memory);
 }
 uint64_t scratch_cuda_integer_decompress_radix_ciphertext_128(
     CudaStreamsFFI streams, int8_t **mem_ptr,

--- a/backends/tfhe-cuda-backend/src/bindings.rs
+++ b/backends/tfhe-cuda-backend/src/bindings.rs
@@ -30,7 +30,8 @@ unsafe extern "C" {
         glwe_array_in: *const ffi::c_void,
         nth_array: *const u32,
         num_nths: u32,
-        lwe_per_glwe: u32,
+        num_lwes_to_extract_per_glwe: u32,
+        num_lwes_stored_per_glwe: u32,
         glwe_dimension: u32,
         polynomial_size: u32,
     );
@@ -72,7 +73,8 @@ unsafe extern "C" {
         glwe_array_in: *const ffi::c_void,
         nth_array: *const u32,
         num_nths: u32,
-        lwe_per_glwe: u32,
+        num_lwes_to_extract_per_glwe: u32,
+        num_lwes_stored_per_glwe: u32,
         glwe_dimension: u32,
         polynomial_size: u32,
     );
@@ -260,7 +262,7 @@ const _: () = {
 pub struct CudaPackedGlweCiphertextListFFI {
     pub ptr: *mut ffi::c_void,
     pub storage_log_modulus: u32,
-    pub lwe_per_glwe: u32,
+    pub num_lwes_stored_per_glwe: u32,
     pub total_lwe_bodies_count: u32,
     pub glwe_dimension: u32,
     pub polynomial_size: u32,
@@ -275,8 +277,10 @@ const _: () = {
         [::std::mem::offset_of!(CudaPackedGlweCiphertextListFFI, ptr) - 0usize];
     ["Offset of field: CudaPackedGlweCiphertextListFFI::storage_log_modulus"]
         [::std::mem::offset_of!(CudaPackedGlweCiphertextListFFI, storage_log_modulus) - 8usize];
-    ["Offset of field: CudaPackedGlweCiphertextListFFI::lwe_per_glwe"]
-        [::std::mem::offset_of!(CudaPackedGlweCiphertextListFFI, lwe_per_glwe) - 12usize];
+    ["Offset of field: CudaPackedGlweCiphertextListFFI::num_lwes_stored_per_glwe"][::std::mem::offset_of!(
+        CudaPackedGlweCiphertextListFFI,
+        num_lwes_stored_per_glwe
+    ) - 12usize];
     ["Offset of field: CudaPackedGlweCiphertextListFFI::total_lwe_bodies_count"]
         [::std::mem::offset_of!(CudaPackedGlweCiphertextListFFI, total_lwe_bodies_count) - 16usize];
     ["Offset of field: CudaPackedGlweCiphertextListFFI::glwe_dimension"]
@@ -2234,7 +2238,7 @@ unsafe extern "C" {
         message_modulus: u32,
         carry_modulus: u32,
         pbs_type: PBS_TYPE,
-        lwe_per_glwe: u32,
+        num_lwes_stored_per_glwe: u32,
         allocate_gpu_memory: bool,
     ) -> u64;
 }
@@ -2302,7 +2306,7 @@ unsafe extern "C" {
         message_modulus: u32,
         carry_modulus: u32,
         pbs_type: PBS_TYPE,
-        lwe_per_glwe: u32,
+        num_lwes_stored_per_glwe: u32,
         allocate_gpu_memory: bool,
     ) -> u64;
 }

--- a/tfhe/src/core_crypto/gpu/algorithms/glwe_linear_algebra.rs
+++ b/tfhe/src/core_crypto/gpu/algorithms/glwe_linear_algebra.rs
@@ -213,5 +213,11 @@ pub fn cuda_glwe_dot_product_with_clear_one_to_many<Scalar>(
     assert_eq!(nths.len(), n_polys, "Nths vector has the wrong size");
 
     cuda_glwe_wrapping_polynomial_mul_one_to_many(lhs, rhs, &mut glwe_list, stream);
-    cuda_extract_lwe_samples_from_glwe_ciphertext_list(&glwe_list, out, nths.as_slice(), 1, stream);
+    cuda_extract_lwe_samples_from_glwe_ciphertext_list(
+        &glwe_list,
+        out,
+        nths.as_slice(),
+        u32::try_from(lhs.polynomial_size().0).unwrap(),
+        stream,
+    );
 }

--- a/tfhe/src/core_crypto/gpu/mod.rs
+++ b/tfhe/src/core_crypto/gpu/mod.rs
@@ -827,7 +827,8 @@ pub unsafe fn extract_lwe_samples_from_glwe_ciphertext_list_async<T: UnsignedInt
     glwe_array_in: &CudaVec<T>,
     nth_array: &CudaVec<u32>,
     num_nths: u32,
-    lwe_per_glwe: u32,
+    num_lwes_to_extract_per_glwe: u32,
+    num_lwes_stored_per_glwe: u32,
     glwe_dimension: GlweDimension,
     polynomial_size: PolynomialSize,
 ) {
@@ -839,7 +840,8 @@ pub unsafe fn extract_lwe_samples_from_glwe_ciphertext_list_async<T: UnsignedInt
             glwe_array_in.as_c_ptr(0),
             nth_array.as_c_ptr(0).cast::<u32>(),
             num_nths,
-            lwe_per_glwe,
+            num_lwes_to_extract_per_glwe,
+            num_lwes_stored_per_glwe,
             glwe_dimension.0 as u32,
             polynomial_size.0 as u32,
         );
@@ -851,7 +853,8 @@ pub unsafe fn extract_lwe_samples_from_glwe_ciphertext_list_async<T: UnsignedInt
             glwe_array_in.as_c_ptr(0),
             nth_array.as_c_ptr(0).cast::<u32>(),
             num_nths,
-            lwe_per_glwe,
+            num_lwes_to_extract_per_glwe,
+            num_lwes_stored_per_glwe,
             glwe_dimension.0 as u32,
             polynomial_size.0 as u32,
         );

--- a/tfhe/src/integer/gpu/ffi.rs
+++ b/tfhe/src/integer/gpu/ffi.rs
@@ -138,7 +138,7 @@ fn prepare_cuda_packed_glwe_ct_ffi<T: UnsignedInteger>(
     CudaPackedGlweCiphertextListFFI {
         ptr: input.data.get_mut_c_ptr(0),
         storage_log_modulus: u32::try_from(input.meta.unwrap().storage_log_modulus.0).unwrap(),
-        lwe_per_glwe: u32::try_from(input.meta.unwrap().lwe_per_glwe.0).unwrap(),
+        num_lwes_stored_per_glwe: u32::try_from(input.meta.unwrap().lwe_per_glwe.0).unwrap(),
         total_lwe_bodies_count: u32::try_from(input.meta.unwrap().total_lwe_bodies_count).unwrap(),
         glwe_dimension: u32::try_from(input.meta.unwrap().glwe_dimension.0).unwrap(),
         polynomial_size: u32::try_from(input.meta.unwrap().polynomial_size.0).unwrap(),


### PR DESCRIPTION
The original implementation doesn't support the case when a GLWE is not full and `lwe_per_glwe < polynomial`.

```
  GLWE 0                                              GLWE 1
  ├──────────── 2048 elements ────────────┤           ├──────────── 2048 elements ────────────┤
  ┌───────────────┬────────┬──────────────┐           ┌───────────────┬────────┬──────────────┐
  │   mask0       │ body0  │   garbage    │           │   mask1       │ body1  │   garbage    │
  │  (1024 elems) │ (128)  │   (896)     │           │  (1024 elems) │ (128)  │   (896)     │
  └───────────────┴────────┴──────────────┘           └───────────────┴────────┴──────────────┘
   offset 0        1024     1152           2048        2048           3072     3200           4096
```
 This PR implement strides in compression and decompression to adjust the indexes on that case.



<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: https://github.com/zama-ai/tfhe-rs-internal/issues/1315

### PR content/description

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
