### PR TITLE
fix: CompactCiphertextList expansion when params are KS32

### DIFF
--- a/tfhe/src/core_crypto/entities/lwe_compact_ciphertext_list.rs
+++ b/tfhe/src/core_crypto/entities/lwe_compact_ciphertext_list.rs
@@ -356,7 +356,6 @@ impl<T: UnsignedInteger> ParameterSetConformant for LweCompactCiphertextListOwne
             lwe_ciphertext_count,
             ciphertext_modulus,
         } = self;
-
         param
             .lwe_ciphertext_count_constraint
             .is_valid(lwe_ciphertext_count.0)

--- a/tfhe/src/high_level_api/integers/unsigned/tests/cpu.rs
+++ b/tfhe/src/high_level_api/integers/unsigned/tests/cpu.rs
@@ -524,17 +524,54 @@ fn test_safe_deserialize_conformant_compressed_fhe_uint32() {
 }
 
 #[test]
-fn test_safe_deserialize_conformant_compact_fhe_uint32() {
-    let block_params = PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+fn test_safe_deserialize_conformant_compact_packed_fhe_uint32_ks_pbs() {
+    test_safe_deserialize_conformant_compact_fhe_uint32(
+        PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+        true,
+    );
+}
+
+#[test]
+fn test_safe_deserialize_conformant_compact_packed_fhe_uint32_ks32() {
+    test_safe_deserialize_conformant_compact_fhe_uint32(
+        PARAM_MESSAGE_2_CARRY_2_KS32_PBS_TUNIFORM_2M128,
+        true,
+    );
+}
+
+#[test]
+fn test_safe_deserialize_conformant_compact_fhe_uint32_ks_pbs() {
+    test_safe_deserialize_conformant_compact_fhe_uint32(
+        PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+        false,
+    );
+}
+
+#[test]
+fn test_safe_deserialize_conformant_compact_fhe_uint32_ks32() {
+    test_safe_deserialize_conformant_compact_fhe_uint32(
+        PARAM_MESSAGE_2_CARRY_2_KS32_PBS_TUNIFORM_2M128,
+        false,
+    );
+}
+
+fn test_safe_deserialize_conformant_compact_fhe_uint32(
+    block_params: impl Into<crate::shortint::atomic_pattern::AtomicPatternParameters>,
+    build_packed: bool,
+) {
     let (client_key, server_key) =
         generate_keys(ConfigBuilder::with_custom_parameters(block_params));
     set_server_key(server_key);
     let pk = CompactPublicKey::new(&client_key);
 
     let clears = [random::<u32>(), random::<u32>(), random::<u32>()];
-    let a = CompactCiphertextList::builder(&pk)
-        .extend(clears.iter().copied())
-        .build();
+    let mut builder = CompactCiphertextList::builder(&pk);
+    builder.extend(clears.iter().copied());
+    let a = if build_packed {
+        builder.build_packed()
+    } else {
+        builder.build()
+    };
     let mut serialized = vec![];
     SerializationConfig::new(1 << 20)
         .serialize_into(&a, &mut serialized)

--- a/tfhe/src/high_level_api/tests/noise_distribution/encryption_noise.rs
+++ b/tfhe/src/high_level_api/tests/noise_distribution/encryption_noise.rs
@@ -121,7 +121,7 @@ fn noise_check_compact_public_key_encryption_noise_tuniform(
 ) {
     // Hack to avoid server key needs and get the ciphertext directly
     cpke_params.expansion_kind =
-        CompactCiphertextListExpansionKind::NoCasting(block_params.encryption_key_choice.into());
+        CompactCiphertextListExpansionKind::NoCasting(block_params.atomic_pattern());
 
     let modulus_as_f64 = cpke_params.ciphertext_modulus.raw_modulus_float();
 

--- a/tfhe/src/integer/gpu/server_key/radix/tests_noise_distribution/cpk_ks_ms.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/tests_noise_distribution/cpk_ks_ms.rs
@@ -287,9 +287,8 @@ fn noise_check_encrypt_cpk_ks_ms_noise_gpu(meta_params: MetaParameters, filename
         // expand
         let cpk_params = {
             let mut cpk_params = dedicated_cpk_params.pke_params;
-            cpk_params.expansion_kind = CompactCiphertextListExpansionKind::NoCasting(
-                compute_params.encryption_key_choice().into_pbs_order(),
-            );
+            cpk_params.expansion_kind =
+                CompactCiphertextListExpansionKind::NoCasting(compute_params.atomic_pattern());
             cpk_params
         };
 
@@ -478,9 +477,8 @@ fn noise_check_encrypt_cpk_ks_ms_pfail_gpu(meta_params: MetaParameters, filename
         // expand
         let cpk_params = {
             let mut cpk_params = dedicated_cpk_params.pke_params;
-            cpk_params.expansion_kind = CompactCiphertextListExpansionKind::NoCasting(
-                compute_params.encryption_key_choice().into_pbs_order(),
-            );
+            cpk_params.expansion_kind =
+                CompactCiphertextListExpansionKind::NoCasting(compute_params.atomic_pattern());
             cpk_params
         };
 
@@ -604,9 +602,8 @@ fn sanity_check_encrypt_cpk_ks_ms_pbs_gpu(meta_params: MetaParameters, filename_
         let (cpk_params, orig_cast_mode) = {
             let mut cpk_params = dedicated_cpk_params.pke_params;
             let orig_cast_mode = cpk_params.expansion_kind;
-            cpk_params.expansion_kind = CompactCiphertextListExpansionKind::NoCasting(
-                compute_params.encryption_key_choice().into_pbs_order(),
-            );
+            cpk_params.expansion_kind =
+                CompactCiphertextListExpansionKind::NoCasting(compute_params.atomic_pattern());
             (cpk_params, orig_cast_mode)
         };
 

--- a/tfhe/src/shortint/backward_compatibility/ciphertext/mod.rs
+++ b/tfhe/src/shortint/backward_compatibility/ciphertext/mod.rs
@@ -82,7 +82,9 @@ impl Upgrade<CompactCiphertextListV1> for CompactCiphertextListV0 {
             degree: self.degree,
             message_modulus: self.message_modulus,
             carry_modulus: self.carry_modulus,
-            expansion_kind: CompactCiphertextListExpansionKind::NoCasting(self.pbs_order),
+            expansion_kind: CompactCiphertextListExpansionKind::NoCasting(
+                AtomicPatternKind::Standard(self.pbs_order),
+            ),
             noise_level: self.noise_level,
         })
     }

--- a/tfhe/src/shortint/backward_compatibility/parameters/compact_public_key_only.rs
+++ b/tfhe/src/shortint/backward_compatibility/parameters/compact_public_key_only.rs
@@ -4,13 +4,34 @@ use tfhe_versionable::{Upgrade, Version, VersionsDispatch};
 
 use super::parameters::compact_public_key_only::CompactPublicKeyEncryptionParameters;
 use super::parameters::{
-    CompactCiphertextListExpansionKind, DynamicDistribution, SupportedCompactPkeZkScheme,
+    AtomicPatternKind, CompactCiphertextListExpansionKind, DynamicDistribution, PBSOrder,
+    SupportedCompactPkeZkScheme,
 };
 use super::prelude::*;
 
+#[derive(Version)]
+pub enum CompactCiphertextListExpansionKindV0 {
+    RequiresCasting,
+    NoCasting(PBSOrder),
+}
+
+impl Upgrade<CompactCiphertextListExpansionKind> for CompactCiphertextListExpansionKindV0 {
+    type Error = Infallible;
+
+    fn upgrade(self) -> Result<CompactCiphertextListExpansionKind, Self::Error> {
+        match self {
+            Self::RequiresCasting => Ok(CompactCiphertextListExpansionKind::RequiresCasting),
+            Self::NoCasting(pbs_order) => Ok(CompactCiphertextListExpansionKind::NoCasting(
+                AtomicPatternKind::Standard(pbs_order),
+            )),
+        }
+    }
+}
+
 #[derive(VersionsDispatch)]
 pub enum CompactCiphertextListExpansionKindVersions {
-    V0(CompactCiphertextListExpansionKind),
+    V0(CompactCiphertextListExpansionKindV0),
+    V1(CompactCiphertextListExpansionKind),
 }
 
 #[derive(Version)]

--- a/tfhe/src/shortint/ciphertext/compact_list.rs
+++ b/tfhe/src/shortint/ciphertext/compact_list.rs
@@ -9,7 +9,7 @@ use crate::shortint::atomic_pattern::AtomicPattern;
 use crate::shortint::backward_compatibility::ciphertext::CompactCiphertextListVersions;
 pub use crate::shortint::parameters::ShortintCompactCiphertextListCastingMode;
 use crate::shortint::parameters::{
-    AtomicPatternKind, CarryModulus, CompactCiphertextListExpansionKind, MessageModulus,
+    CarryModulus, CompactCiphertextListExpansionKind, MessageModulus,
 };
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -144,7 +144,7 @@ impl CompactCiphertextList {
                     .collect::<Vec<_>>();
                 Ok(res)
             }
-            (CompactCiphertextListExpansionKind::NoCasting(pbs_order), _) => {
+            (CompactCiphertextListExpansionKind::NoCasting(atomic_pattern), _) => {
                 let res = output_lwe_ciphertext_list
                     .iter()
                     .map(|lwe_view| {
@@ -152,7 +152,6 @@ impl CompactCiphertextList {
                             lwe_view.as_ref().to_vec(),
                             self.ct_list.ciphertext_modulus(),
                         );
-                        let atomic_pattern = AtomicPatternKind::Standard(pbs_order);
 
                         Ciphertext::new(
                             ct,

--- a/tfhe/src/shortint/parameters/classic.rs
+++ b/tfhe/src/shortint/parameters/classic.rs
@@ -101,16 +101,12 @@ impl ClassicPBSParameters {
     }
 
     pub fn to_shortint_conformance_param(&self) -> CiphertextConformanceParams {
-        let (atomic_pattern, expected_dim) = match self.encryption_key_choice {
-            EncryptionKeyChoice::Big => (
-                AtomicPatternKind::Standard(PBSOrder::KeyswitchBootstrap),
-                self.glwe_dimension
-                    .to_equivalent_lwe_dimension(self.polynomial_size),
-            ),
-            EncryptionKeyChoice::Small => (
-                AtomicPatternKind::Standard(PBSOrder::BootstrapKeyswitch),
-                self.lwe_dimension,
-            ),
+        let atomic_pattern = self.atomic_pattern();
+        let expected_dim = match self.encryption_key_choice {
+            EncryptionKeyChoice::Big => self
+                .glwe_dimension
+                .to_equivalent_lwe_dimension(self.polynomial_size),
+            EncryptionKeyChoice::Small => self.lwe_dimension,
         };
 
         let message_modulus = self.message_modulus;
@@ -137,16 +133,12 @@ impl ClassicPBSParameters {
     pub fn to_compressed_modswitched_conformance_param(
         &self,
     ) -> CompressedModulusSwitchedCiphertextConformanceParams {
-        let (atomic_pattern, expected_dim) = match self.encryption_key_choice {
-            EncryptionKeyChoice::Big => (
-                AtomicPatternKind::Standard(PBSOrder::KeyswitchBootstrap),
-                self.glwe_dimension
-                    .to_equivalent_lwe_dimension(self.polynomial_size),
-            ),
-            EncryptionKeyChoice::Small => (
-                AtomicPatternKind::Standard(PBSOrder::BootstrapKeyswitch),
-                self.lwe_dimension,
-            ),
+        let atomic_pattern = self.atomic_pattern();
+        let expected_dim = match self.encryption_key_choice {
+            EncryptionKeyChoice::Big => self
+                .glwe_dimension
+                .to_equivalent_lwe_dimension(self.polynomial_size),
+            EncryptionKeyChoice::Small => self.lwe_dimension,
         };
 
         let message_modulus = self.message_modulus;
@@ -176,5 +168,10 @@ impl ClassicPBSParameters {
 
     pub const fn pbs_order(&self) -> PBSOrder {
         self.encryption_key_choice.into_pbs_order()
+    }
+
+    /// Returns [`AtomicPatternKind::Standard`] derived from the PBS order.
+    pub const fn atomic_pattern(&self) -> AtomicPatternKind {
+        AtomicPatternKind::Standard(self.pbs_order())
     }
 }

--- a/tfhe/src/shortint/parameters/compact_public_key_only.rs
+++ b/tfhe/src/shortint/parameters/compact_public_key_only.rs
@@ -4,8 +4,8 @@ use crate::shortint::backward_compatibility::parameters::compact_public_key_only
 };
 use crate::shortint::parameters::{
     AtomicPatternKind, CarryModulus, CiphertextModulus, ClassicPBSParameters, DynamicDistribution,
-    LweDimension, MessageModulus, MultiBitPBSParameters, PBSOrder, PBSParameters,
-    ShortintParameterSet, SupportedCompactPkeZkScheme,
+    LweDimension, MessageModulus, MultiBitPBSParameters, PBSParameters, ShortintParameterSet,
+    SupportedCompactPkeZkScheme,
 };
 use crate::shortint::{KeySwitchingKeyView, PaddingBit, ShortintEncoding};
 use crate::Error;
@@ -16,7 +16,7 @@ use tfhe_versionable::Versionize;
 #[versionize(CompactCiphertextListExpansionKindVersions)]
 pub enum CompactCiphertextListExpansionKind {
     RequiresCasting,
-    NoCasting(PBSOrder),
+    NoCasting(AtomicPatternKind),
 }
 
 pub type CastingFunctionsOwned<'functions> =
@@ -35,10 +35,7 @@ pub enum ShortintCompactCiphertextListCastingMode<'a> {
 
 impl From<AtomicPatternKind> for CompactCiphertextListExpansionKind {
     fn from(value: AtomicPatternKind) -> Self {
-        match value {
-            AtomicPatternKind::Standard(pbsorder) => Self::NoCasting(pbsorder),
-            AtomicPatternKind::KeySwitch32 => Self::NoCasting(PBSOrder::KeyswitchBootstrap),
-        }
+        Self::NoCasting(value)
     }
 }
 
@@ -129,9 +126,7 @@ impl TryFrom<ShortintParameterSet> for CompactPublicKeyEncryptionParameters {
         let message_modulus = parameters.message_modulus();
         let carry_modulus = parameters.carry_modulus();
         let ciphertext_modulus = parameters.ciphertext_modulus();
-        let output_ciphertext_kind = CompactCiphertextListExpansionKind::NoCasting(
-            parameters.encryption_key_choice().into(),
-        );
+        let output_ciphertext_kind = parameters.atomic_pattern().into();
 
         Self::try_new(
             encryption_lwe_dimension,

--- a/tfhe/src/shortint/parameters/mod.rs
+++ b/tfhe/src/shortint/parameters/mod.rs
@@ -321,6 +321,11 @@ impl PBSParameters {
         }
     }
 
+    /// Returns [`AtomicPatternKind::Standard`] derived from the encryption key choice.
+    pub const fn atomic_pattern(&self) -> AtomicPatternKind {
+        AtomicPatternKind::Standard(self.encryption_key_choice().into_pbs_order())
+    }
+
     pub const fn encryption_lwe_dimension(&self) -> LweDimension {
         match self.encryption_key_choice() {
             EncryptionKeyChoice::Big => self
@@ -601,15 +606,11 @@ impl ShortintParameterSet {
 
     pub const fn atomic_pattern(&self) -> AtomicPatternKind {
         match self.inner {
-            ShortintParameterSetInner::PBSOnly(params) => {
-                AtomicPatternKind::Standard(params.encryption_key_choice().into_pbs_order())
-            }
+            ShortintParameterSetInner::PBSOnly(params) => params.atomic_pattern(),
             ShortintParameterSetInner::WopbsOnly(_params) => {
                 panic!("WopbsOnly parameters do not support Atomic Patterns")
             }
-            ShortintParameterSetInner::PBSAndWopbs(params, _) => {
-                AtomicPatternKind::Standard(params.encryption_key_choice().into_pbs_order())
-            }
+            ShortintParameterSetInner::PBSAndWopbs(params, _) => params.atomic_pattern(),
             ShortintParameterSetInner::KS32PBS(_params) => AtomicPatternKind::KeySwitch32,
         }
     }

--- a/tfhe/src/shortint/server_key/tests/noise_distribution/br_rerand_dp_ks_ms.rs
+++ b/tfhe/src/shortint/server_key/tests/noise_distribution/br_rerand_dp_ks_ms.rs
@@ -501,9 +501,8 @@ fn noise_check_encrypt_br_rerand_dp_ks_ms_noise(
         // expand
         let cpk_params = {
             let mut cpk_params = dedicated_cpk_params.pke_params;
-            cpk_params.expansion_kind = CompactCiphertextListExpansionKind::NoCasting(
-                compute_params.encryption_key_choice().into_pbs_order(),
-            );
+            cpk_params.expansion_kind =
+                CompactCiphertextListExpansionKind::NoCasting(compute_params.atomic_pattern());
             cpk_params
         };
 
@@ -742,9 +741,8 @@ fn noise_check_encrypt_br_rerand_dp_ks_ms_pfail(
         // expand
         let cpk_params = {
             let mut cpk_params = dedicated_cpk_params.pke_params;
-            cpk_params.expansion_kind = CompactCiphertextListExpansionKind::NoCasting(
-                compute_params.encryption_key_choice().into_pbs_order(),
-            );
+            cpk_params.expansion_kind =
+                CompactCiphertextListExpansionKind::NoCasting(compute_params.atomic_pattern());
             cpk_params
         };
 
@@ -864,9 +862,8 @@ fn sanity_check_encrypt_br_rerand_dp_ks_ms_pbs(meta_params: MetaParameters, file
         // expand
         let cpk_params = {
             let mut cpk_params = dedicated_cpk_params.pke_params;
-            cpk_params.expansion_kind = CompactCiphertextListExpansionKind::NoCasting(
-                compute_params.encryption_key_choice().into_pbs_order(),
-            );
+            cpk_params.expansion_kind =
+                CompactCiphertextListExpansionKind::NoCasting(compute_params.atomic_pattern());
             cpk_params
         };
 

--- a/tfhe/src/shortint/server_key/tests/noise_distribution/cpk_ks_ms.rs
+++ b/tfhe/src/shortint/server_key/tests/noise_distribution/cpk_ks_ms.rs
@@ -267,9 +267,8 @@ fn noise_check_encrypt_cpk_ks_ms_noise(meta_params: MetaParameters, filename_suf
         // expand
         let cpk_params = {
             let mut cpk_params = dedicated_cpk_params.pke_params;
-            cpk_params.expansion_kind = CompactCiphertextListExpansionKind::NoCasting(
-                compute_params.encryption_key_choice().into_pbs_order(),
-            );
+            cpk_params.expansion_kind =
+                CompactCiphertextListExpansionKind::NoCasting(compute_params.atomic_pattern());
             cpk_params
         };
 
@@ -430,9 +429,8 @@ fn noise_check_encrypt_cpk_ks_ms_pfail(meta_params: MetaParameters, filename_suf
         // expand
         let cpk_params = {
             let mut cpk_params = dedicated_cpk_params.pke_params;
-            cpk_params.expansion_kind = CompactCiphertextListExpansionKind::NoCasting(
-                compute_params.encryption_key_choice().into_pbs_order(),
-            );
+            cpk_params.expansion_kind =
+                CompactCiphertextListExpansionKind::NoCasting(compute_params.atomic_pattern());
             cpk_params
         };
 
@@ -540,9 +538,8 @@ fn sanity_check_encrypt_cpk_ks_ms_pbs(meta_params: MetaParameters, filename_suff
         let (cpk_params, orig_cast_mode) = {
             let mut cpk_params = dedicated_cpk_params.pke_params;
             let orig_cast_mode = cpk_params.expansion_kind;
-            cpk_params.expansion_kind = CompactCiphertextListExpansionKind::NoCasting(
-                compute_params.encryption_key_choice().into_pbs_order(),
-            );
+            cpk_params.expansion_kind =
+                CompactCiphertextListExpansionKind::NoCasting(compute_params.atomic_pattern());
             (cpk_params, orig_cast_mode)
         };
 


### PR DESCRIPTION
The expansion was still PBS-KS/KS-PBS only, which made the expand method fail some conformance check

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3367)
<!-- Reviewable:end -->
