### PR TITLE
fix(gpu): save state of trivium/kreyvium and fix noise

### DIFF
--- a/backends/tfhe-cuda-backend/cuda/include/kreyvium/kreyvium.h
+++ b/backends/tfhe-cuda-backend/cuda/include/kreyvium/kreyvium.h
@@ -4,21 +4,36 @@
 #include "../integer/integer.h"
 
 extern "C" {
-uint64_t scratch_cuda_kreyvium_generate_keystream_64_async(
+uint64_t scratch_cuda_kreyvium_init_async(
     CudaStreamsFFI streams, int8_t **mem_ptr,
     CudaLweBootstrapKeyParamsFFI bsk_params, uint32_t ks_level,
     uint32_t ks_base_log, uint32_t message_modulus, uint32_t carry_modulus,
     bool allocate_gpu_memory, PBS_MS_REDUCTION_T noise_reduction_type,
     uint32_t num_inputs);
+void cleanup_cuda_kreyvium_init(CudaStreamsFFI streams, int8_t **mem_ptr_void);
 
-void cuda_kreyvium_generate_keystream_64_async(
+uint64_t scratch_cuda_kreyvium_step_async(
+    CudaStreamsFFI streams, int8_t **mem_ptr,
+    CudaLweBootstrapKeyParamsFFI bsk_params, uint32_t ks_level,
+    uint32_t ks_base_log, uint32_t message_modulus, uint32_t carry_modulus,
+    bool allocate_gpu_memory, PBS_MS_REDUCTION_T noise_reduction_type,
+    uint32_t num_inputs);
+void cleanup_cuda_kreyvium_step(CudaStreamsFFI streams, int8_t **mem_ptr_void);
+
+void cuda_kreyvium_init_async(
+    CudaStreamsFFI streams, CudaRadixCiphertextFFI *a_reg,
+    CudaRadixCiphertextFFI *b_reg, CudaRadixCiphertextFFI *c_reg,
+    CudaRadixCiphertextFFI *k_reg, CudaRadixCiphertextFFI *iv_reg,
+    uint32_t *k_offset, uint32_t *iv_offset, const CudaRadixCiphertextFFI *key,
+    const CudaRadixCiphertextFFI *iv_in, uint32_t num_inputs, int8_t *mem_ptr,
+    void *const *bsks, void *const *ksks);
+void cuda_kreyvium_step_async(
     CudaStreamsFFI streams, CudaRadixCiphertextFFI *keystream_output,
-    const CudaRadixCiphertextFFI *key, const CudaRadixCiphertextFFI *iv,
+    CudaRadixCiphertextFFI *a_reg, CudaRadixCiphertextFFI *b_reg,
+    CudaRadixCiphertextFFI *c_reg, CudaRadixCiphertextFFI *k_reg,
+    CudaRadixCiphertextFFI *iv_reg, uint32_t *k_offset, uint32_t *iv_offset,
     uint32_t num_inputs, uint32_t num_steps, int8_t *mem_ptr, void *const *bsks,
     void *const *ksks);
-
-void cleanup_cuda_kreyvium_generate_keystream_64(CudaStreamsFFI streams,
-                                                 int8_t **mem_ptr_void);
 }
 
 #endif

--- a/backends/tfhe-cuda-backend/cuda/include/kreyvium/kreyvium_utilities.h
+++ b/backends/tfhe-cuda-backend/cuda/include/kreyvium/kreyvium_utilities.h
@@ -20,6 +20,22 @@ constexpr uint32_t KREYVIUM_NUM_AND_GATES = 3;
 // 3. New bit for Register C
 // 4. The Output Keystream bit
 constexpr uint32_t KREYVIUM_NUM_FLUSH_PATHS = 4;
+constexpr uint32_t KREYVIUM_REGISTER_A_BITS = 93;
+constexpr uint32_t KREYVIUM_REGISTER_B_BITS = 84;
+constexpr uint32_t KREYVIUM_REGISTER_C_BITS = 111;
+constexpr uint32_t KREYVIUM_KEY_BITS = 128;
+constexpr uint32_t KREYVIUM_IV_BITS = 128;
+
+// Standard Kreyvium warm-up: 1152 cycles before the first keystream bit is
+// emitted, processed in batches of KREYVIUM_BATCH_SIZE.
+constexpr uint32_t KREYVIUM_WARMUP_CYCLES = 1152;
+constexpr uint32_t KREYVIUM_WARMUP_BATCHES =
+    KREYVIUM_WARMUP_CYCLES / KREYVIUM_BATCH_SIZE;
+
+// During init, c[1..67] are set to 1 per the Kreyvium spec: 66 bits starting
+// at offset 1 in the 111-bit C register.
+constexpr uint32_t KREYVIUM_C_ONES_OFFSET = 1;
+constexpr uint32_t KREYVIUM_C_ONES_COUNT = 66;
 
 /// Struct to hold the LUTs.
 template <typename Torus> struct int_kreyvium_lut_buffers {
@@ -42,39 +58,33 @@ template <typename Torus> struct int_kreyvium_lut_buffers {
     uint32_t flush_ops =
         num_inputs * KREYVIUM_BATCH_SIZE * KREYVIUM_NUM_FLUSH_PATHS;
 
+    // BIVARIATE AND LUT
+    //
     this->and_lut = new int_radix_lut<Torus>(streams, params, 1, and_ops,
                                              allocate_gpu_memory, size_tracker);
 
     std::function<Torus(Torus, Torus)> and_lambda =
         [](Torus lhs, Torus rhs) -> Torus { return (lhs & 1) & (rhs & 1); };
 
-    generate_device_accumulator_bivariate<Torus>(
-        streams.stream(0), streams.gpu_index(0), this->and_lut->get_lut(0, 0),
-        this->and_lut->get_degree(0), this->and_lut->get_max_degree(0),
-        params.glwe_dimension, params.polynomial_size, params.message_modulus,
-        params.carry_modulus, and_lambda, allocate_gpu_memory);
-
     auto active_streams_and =
         streams.active_gpu_subset(and_ops, params.pbs_type);
-    this->and_lut->broadcast_lut(active_streams_and);
+
+    this->and_lut->generate_and_broadcast_bivariate_lut(
+        active_streams_and, {0}, {and_lambda}, LUT_0_FOR_ALL_BLOCKS);
     this->and_lut->setup_gemm_batch_ks_temp_buffers(size_tracker);
 
-    this->flush_lut = new int_radix_lut<Torus>(
-        streams, params, 1, flush_ops, allocate_gpu_memory, size_tracker);
-
+    // UNIVARIATE FLUSH LUTS
+    //
     std::function<Torus(Torus)> flush_lambda = [](Torus x) -> Torus {
       return x & 1;
     };
-
-    generate_device_accumulator<Torus>(
-        streams.stream(0), streams.gpu_index(0), this->flush_lut->get_lut(0, 0),
-        this->flush_lut->get_degree(0), this->flush_lut->get_max_degree(0),
-        params.glwe_dimension, params.polynomial_size, params.message_modulus,
-        params.carry_modulus, flush_lambda, allocate_gpu_memory);
-
+    this->flush_lut = new int_radix_lut<Torus>(
+        streams, params, 1, flush_ops, allocate_gpu_memory, size_tracker);
     auto active_streams_flush =
         streams.active_gpu_subset(flush_ops, params.pbs_type);
-    this->flush_lut->broadcast_lut(active_streams_flush);
+
+    this->flush_lut->generate_and_broadcast_lut(
+        active_streams_flush, {0}, {flush_lambda}, LUT_0_FOR_ALL_BLOCKS);
     this->flush_lut->setup_gemm_batch_ks_temp_buffers(size_tracker);
   }
 
@@ -91,115 +101,62 @@ template <typename Torus> struct int_kreyvium_lut_buffers {
   }
 };
 
-/// Struct to hold the Kreyvium internal state and temporary workspaces.
-template <typename Torus> struct int_kreyvium_state_workspaces {
-
-  CudaRadixCiphertextFFI *a_reg;
-  CudaRadixCiphertextFFI *b_reg;
-  CudaRadixCiphertextFFI *c_reg;
-  CudaRadixCiphertextFFI *k_reg;
-  CudaRadixCiphertextFFI *iv_reg;
-
-  // Shift Workspace
+// Holds the temporary GPU buffers and workspaces required during the
+// execution of the Kreyvium cipher. Registers a/b/c/k/iv are owned by the
+// caller (the persistent state) and passed in to each call.
+//
+template <typename Torus> struct int_kreyvium_workspaces {
   CudaRadixCiphertextFFI *shift_workspace;
-
-  // Temporary Update Buffers
   CudaRadixCiphertextFFI *temp_a;
   CudaRadixCiphertextFFI *temp_b;
   CudaRadixCiphertextFFI *temp_c;
-
   CudaRadixCiphertextFFI *packed_and_lhs;
   CudaRadixCiphertextFFI *packed_and_rhs;
   CudaRadixCiphertextFFI *packed_and_out;
-
-  // Flush/Cleanup Packing Buffers
   CudaRadixCiphertextFFI *packed_flush_in;
   CudaRadixCiphertextFFI *packed_flush_out;
 
-  uint32_t max_batch_blocks;
-  uint32_t k_offset;
-  uint32_t iv_offset;
-
-  int_kreyvium_state_workspaces(CudaStreams streams,
-                                const int_radix_params &params,
-                                bool allocate_gpu_memory, uint32_t num_inputs,
-                                uint64_t &size_tracker) {
-
+  int_kreyvium_workspaces(CudaStreams streams, const int_radix_params &params,
+                          bool allocate_gpu_memory, uint32_t num_inputs,
+                          uint64_t &size_tracker) {
     uint32_t batch_blocks = KREYVIUM_BATCH_SIZE * num_inputs;
-    this->max_batch_blocks = batch_blocks;
-    this->k_offset = 0;
-    this->iv_offset = 0;
-
-    this->a_reg = new CudaRadixCiphertextFFI;
-    create_zero_radix_ciphertext_async<Torus>(
-        streams.stream(0), streams.gpu_index(0), this->a_reg, 93 * num_inputs,
-        params.big_lwe_dimension, size_tracker, allocate_gpu_memory);
-
-    this->b_reg = new CudaRadixCiphertextFFI;
-    create_zero_radix_ciphertext_async<Torus>(
-        streams.stream(0), streams.gpu_index(0), this->b_reg, 84 * num_inputs,
-        params.big_lwe_dimension, size_tracker, allocate_gpu_memory);
-
-    this->c_reg = new CudaRadixCiphertextFFI;
-    create_zero_radix_ciphertext_async<Torus>(
-        streams.stream(0), streams.gpu_index(0), this->c_reg, 111 * num_inputs,
-        params.big_lwe_dimension, size_tracker, allocate_gpu_memory);
-
-    this->k_reg = new CudaRadixCiphertextFFI;
-    create_zero_radix_ciphertext_async<Torus>(
-        streams.stream(0), streams.gpu_index(0), this->k_reg, 128 * num_inputs,
-        params.big_lwe_dimension, size_tracker, allocate_gpu_memory);
-
-    this->iv_reg = new CudaRadixCiphertextFFI;
-    create_zero_radix_ciphertext_async<Torus>(
-        streams.stream(0), streams.gpu_index(0), this->iv_reg, 128 * num_inputs,
-        params.big_lwe_dimension, size_tracker, allocate_gpu_memory);
-
     this->shift_workspace = new CudaRadixCiphertextFFI;
     create_zero_radix_ciphertext_async<Torus>(
         streams.stream(0), streams.gpu_index(0), this->shift_workspace,
-        128 * num_inputs, params.big_lwe_dimension, size_tracker,
+        KREYVIUM_KEY_BITS * num_inputs, params.big_lwe_dimension, size_tracker,
         allocate_gpu_memory);
-
     this->temp_a = new CudaRadixCiphertextFFI;
     create_zero_radix_ciphertext_async<Torus>(
         streams.stream(0), streams.gpu_index(0), this->temp_a, batch_blocks,
         params.big_lwe_dimension, size_tracker, allocate_gpu_memory);
-
     this->temp_b = new CudaRadixCiphertextFFI;
     create_zero_radix_ciphertext_async<Torus>(
         streams.stream(0), streams.gpu_index(0), this->temp_b, batch_blocks,
         params.big_lwe_dimension, size_tracker, allocate_gpu_memory);
-
     this->temp_c = new CudaRadixCiphertextFFI;
     create_zero_radix_ciphertext_async<Torus>(
         streams.stream(0), streams.gpu_index(0), this->temp_c, batch_blocks,
         params.big_lwe_dimension, size_tracker, allocate_gpu_memory);
-
     this->packed_and_lhs = new CudaRadixCiphertextFFI;
     create_zero_radix_ciphertext_async<Torus>(
         streams.stream(0), streams.gpu_index(0), this->packed_and_lhs,
         KREYVIUM_NUM_AND_GATES * batch_blocks, params.big_lwe_dimension,
         size_tracker, allocate_gpu_memory);
-
     this->packed_and_rhs = new CudaRadixCiphertextFFI;
     create_zero_radix_ciphertext_async<Torus>(
         streams.stream(0), streams.gpu_index(0), this->packed_and_rhs,
         KREYVIUM_NUM_AND_GATES * batch_blocks, params.big_lwe_dimension,
         size_tracker, allocate_gpu_memory);
-
     this->packed_and_out = new CudaRadixCiphertextFFI;
     create_zero_radix_ciphertext_async<Torus>(
         streams.stream(0), streams.gpu_index(0), this->packed_and_out,
         KREYVIUM_NUM_AND_GATES * batch_blocks, params.big_lwe_dimension,
         size_tracker, allocate_gpu_memory);
-
     this->packed_flush_in = new CudaRadixCiphertextFFI;
     create_zero_radix_ciphertext_async<Torus>(
         streams.stream(0), streams.gpu_index(0), this->packed_flush_in,
         KREYVIUM_NUM_FLUSH_PATHS * batch_blocks, params.big_lwe_dimension,
         size_tracker, allocate_gpu_memory);
-
     this->packed_flush_out = new CudaRadixCiphertextFFI;
     create_zero_radix_ciphertext_async<Torus>(
         streams.stream(0), streams.gpu_index(0), this->packed_flush_out,
@@ -209,75 +166,41 @@ template <typename Torus> struct int_kreyvium_state_workspaces {
 
   void release(CudaStreams streams, bool allocate_gpu_memory) {
     release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0),
-                                   this->a_reg, allocate_gpu_memory);
-    delete this->a_reg;
-    this->a_reg = nullptr;
-
-    release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0),
-                                   this->b_reg, allocate_gpu_memory);
-    delete this->b_reg;
-    this->b_reg = nullptr;
-
-    release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0),
-                                   this->c_reg, allocate_gpu_memory);
-    delete this->c_reg;
-    this->c_reg = nullptr;
-
-    release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0),
-                                   this->k_reg, allocate_gpu_memory);
-    delete this->k_reg;
-    this->k_reg = nullptr;
-
-    release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0),
-                                   this->iv_reg, allocate_gpu_memory);
-    delete this->iv_reg;
-    this->iv_reg = nullptr;
-
-    release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0),
                                    this->shift_workspace, allocate_gpu_memory);
     delete this->shift_workspace;
     this->shift_workspace = nullptr;
-
     release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0),
                                    this->temp_a, allocate_gpu_memory);
     delete this->temp_a;
     this->temp_a = nullptr;
-
     release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0),
                                    this->temp_b, allocate_gpu_memory);
     delete this->temp_b;
     this->temp_b = nullptr;
-
     release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0),
                                    this->temp_c, allocate_gpu_memory);
     delete this->temp_c;
     this->temp_c = nullptr;
-
     release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0),
                                    this->packed_and_lhs, allocate_gpu_memory);
     delete this->packed_and_lhs;
     this->packed_and_lhs = nullptr;
-
     release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0),
                                    this->packed_and_rhs, allocate_gpu_memory);
     delete this->packed_and_rhs;
     this->packed_and_rhs = nullptr;
-
     release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0),
                                    this->packed_and_out, allocate_gpu_memory);
     delete this->packed_and_out;
     this->packed_and_out = nullptr;
-
     release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0),
                                    this->packed_flush_in, allocate_gpu_memory);
     delete this->packed_flush_in;
     this->packed_flush_in = nullptr;
-
     release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0),
                                    this->packed_flush_out, allocate_gpu_memory);
     delete this->packed_flush_out;
     this->packed_flush_out = nullptr;
-
     cuda_synchronize_stream(streams.stream(0), streams.gpu_index(0));
   }
 };
@@ -286,9 +209,8 @@ template <typename Torus> struct int_kreyvium_buffer {
   int_radix_params params;
   bool allocate_gpu_memory;
   uint32_t num_inputs;
-
   int_kreyvium_lut_buffers<Torus> *luts;
-  int_kreyvium_state_workspaces<Torus> *state;
+  int_kreyvium_workspaces<Torus> *ws;
 
   int_kreyvium_buffer(CudaStreams streams, const int_radix_params &params,
                       bool allocate_gpu_memory, uint32_t num_inputs,
@@ -296,11 +218,9 @@ template <typename Torus> struct int_kreyvium_buffer {
     this->params = params;
     this->allocate_gpu_memory = allocate_gpu_memory;
     this->num_inputs = num_inputs;
-
     this->luts = new int_kreyvium_lut_buffers<Torus>(
         streams, params, allocate_gpu_memory, num_inputs, size_tracker);
-
-    this->state = new int_kreyvium_state_workspaces<Torus>(
+    this->ws = new int_kreyvium_workspaces<Torus>(
         streams, params, allocate_gpu_memory, num_inputs, size_tracker);
   }
 
@@ -308,11 +228,9 @@ template <typename Torus> struct int_kreyvium_buffer {
     luts->release(streams);
     delete luts;
     luts = nullptr;
-
-    state->release(streams, allocate_gpu_memory);
-    delete state;
-    state = nullptr;
-
+    ws->release(streams, allocate_gpu_memory);
+    delete ws;
+    ws = nullptr;
     cuda_synchronize_stream(streams.stream(0), streams.gpu_index(0));
   }
 };

--- a/backends/tfhe-cuda-backend/cuda/include/trivium/trivium.h
+++ b/backends/tfhe-cuda-backend/cuda/include/trivium/trivium.h
@@ -4,21 +4,37 @@
 #include "../integer/integer.h"
 
 extern "C" {
-uint64_t scratch_cuda_trivium_generate_keystream_64_async(
+uint64_t scratch_cuda_trivium_init_async(
     CudaStreamsFFI streams, int8_t **mem_ptr,
     CudaLweBootstrapKeyParamsFFI bsk_params, uint32_t ks_level,
     uint32_t ks_base_log, uint32_t message_modulus, uint32_t carry_modulus,
     bool allocate_gpu_memory, PBS_MS_REDUCTION_T noise_reduction_type,
     uint32_t num_inputs);
 
-void cuda_trivium_generate_keystream_64_async(
-    CudaStreamsFFI streams, CudaRadixCiphertextFFI *keystream_output,
+void cuda_trivium_init_async(
+    CudaStreamsFFI streams, CudaRadixCiphertextFFI *a_reg,
+    CudaRadixCiphertextFFI *b_reg, CudaRadixCiphertextFFI *c_reg,
     const CudaRadixCiphertextFFI *key, const CudaRadixCiphertextFFI *iv,
-    uint32_t num_inputs, uint32_t num_steps, int8_t *mem_ptr, void *const *bsks,
-    void *const *ksks);
+    uint32_t num_inputs, int8_t *mem_ptr, void *const *bsks, void *const *ksks);
 
-void cleanup_cuda_trivium_generate_keystream_64(CudaStreamsFFI streams,
-                                                int8_t **mem_ptr_void);
+void cleanup_cuda_trivium_init(CudaStreamsFFI streams, int8_t **mem_ptr_void);
+
+uint64_t scratch_cuda_trivium_step_async(
+    CudaStreamsFFI streams, int8_t **mem_ptr,
+    CudaLweBootstrapKeyParamsFFI bsk_params, uint32_t ks_level,
+    uint32_t ks_base_log, uint32_t message_modulus, uint32_t carry_modulus,
+    bool allocate_gpu_memory, PBS_MS_REDUCTION_T noise_reduction_type,
+    uint32_t num_inputs);
+
+void cuda_trivium_step_async(CudaStreamsFFI streams,
+                             CudaRadixCiphertextFFI *keystream_output,
+                             CudaRadixCiphertextFFI *a_reg,
+                             CudaRadixCiphertextFFI *b_reg,
+                             CudaRadixCiphertextFFI *c_reg, uint32_t num_inputs,
+                             uint32_t num_steps, int8_t *mem_ptr,
+                             void *const *bsks, void *const *ksks);
+
+void cleanup_cuda_trivium_step(CudaStreamsFFI streams, int8_t **mem_ptr_void);
 }
 
 #endif

--- a/backends/tfhe-cuda-backend/cuda/include/trivium/trivium_utilities.h
+++ b/backends/tfhe-cuda-backend/cuda/include/trivium/trivium_utilities.h
@@ -2,6 +2,20 @@
 #define TRIVIUM_UTILITIES_H
 #include "../integer/integer_utilities.h"
 
+constexpr uint32_t TRIVIUM_BATCH_SIZE = 64;
+constexpr uint32_t TRIVIUM_NUM_AND_GATES = 3;
+constexpr uint32_t TRIVIUM_NUM_FLUSH_PATHS = 4;
+constexpr uint32_t TRIVIUM_REGISTER_A_BITS = 93;
+constexpr uint32_t TRIVIUM_REGISTER_B_BITS = 84;
+constexpr uint32_t TRIVIUM_REGISTER_C_BITS = 111;
+constexpr uint32_t TRIVIUM_KEY_BITS = 80;
+constexpr uint32_t TRIVIUM_IV_BITS = 80;
+// Standard Trivium warm-up: 1152 cycles (4 * 288 state bits) before the first
+// keystream bit is emitted, processed in batches of TRIVIUM_BATCH_SIZE.
+constexpr uint32_t TRIVIUM_WARMUP_CYCLES = 1152;
+constexpr uint32_t TRIVIUM_WARMUP_BATCHES =
+    TRIVIUM_WARMUP_CYCLES / TRIVIUM_BATCH_SIZE;
+
 /// Struct to hold the LUTs.
 template <typename Torus> struct int_trivium_lut_buffers {
   // Bivariate AND Gate LUT:
@@ -20,9 +34,8 @@ template <typename Torus> struct int_trivium_lut_buffers {
                           bool allocate_gpu_memory, uint32_t num_trivium_inputs,
                           uint64_t &size_tracker) {
 
-    constexpr uint32_t BATCH_SIZE = 64;
-    constexpr uint32_t MAX_AND_PER_STEP = 3;
-    uint32_t total_lut_ops = num_trivium_inputs * BATCH_SIZE * MAX_AND_PER_STEP;
+    uint32_t total_lut_ops =
+        num_trivium_inputs * TRIVIUM_BATCH_SIZE * TRIVIUM_NUM_AND_GATES;
 
     this->and_lut = new int_radix_lut<Torus>(streams, params, 1, total_lut_ops,
                                              allocate_gpu_memory, size_tracker);
@@ -36,7 +49,8 @@ template <typename Torus> struct int_trivium_lut_buffers {
         active_streams_and, {0}, {and_lambda}, LUT_0_FOR_ALL_BLOCKS);
     this->and_lut->setup_gemm_batch_ks_temp_buffers(size_tracker);
 
-    uint32_t total_flush_ops = num_trivium_inputs * BATCH_SIZE * 4;
+    uint32_t total_flush_ops =
+        num_trivium_inputs * TRIVIUM_BATCH_SIZE * TRIVIUM_NUM_FLUSH_PATHS;
 
     this->flush_lut = new int_radix_lut<Torus>(
         streams, params, 1, total_flush_ops, allocate_gpu_memory, size_tracker);
@@ -63,23 +77,10 @@ template <typename Torus> struct int_trivium_lut_buffers {
   }
 };
 
-/// Struct to hold the state and temporary workspaces required for
-/// Trivium execution on the GPU.
-///
-/// This struct manages the memory for the internal registers (A, B, C),
-/// temporary buffers used during the update function, and buffers used for
-/// packing data before and after PBS.
-template <typename Torus> struct int_trivium_state_workspaces {
-  // Trivium Internal State Registers:
-  // Register A: 93 bits
-  CudaRadixCiphertextFFI *a_reg;
-  // Register B: 84 bits
-  CudaRadixCiphertextFFI *b_reg;
-  // Register C: 111 bits
-  CudaRadixCiphertextFFI *c_reg;
-
-  // Shift Workspace:
-  // Used to manage bitshifting operations on the registers
+/// Holds the temporary GPU buffers and workspaces required during the
+/// execution of the Trivium cipher. Registers a/b/c are owned by the caller
+/// (the persistent state) and passed in to each call.
+template <typename Torus> struct int_trivium_workspaces {
   CudaRadixCiphertextFFI *shift_workspace;
 
   // Temporary Update Buffers:
@@ -105,33 +106,17 @@ template <typename Torus> struct int_trivium_state_workspaces {
   CudaRadixCiphertextFFI *packed_flush_in;
   CudaRadixCiphertextFFI *packed_flush_out;
 
-  int_trivium_state_workspaces(CudaStreams streams,
-                               const int_radix_params &params,
-                               bool allocate_gpu_memory, uint32_t num_inputs,
-                               uint64_t &size_tracker) {
+  int_trivium_workspaces(CudaStreams streams, const int_radix_params &params,
+                         bool allocate_gpu_memory, uint32_t num_inputs,
+                         uint64_t &size_tracker) {
 
-    this->a_reg = new CudaRadixCiphertextFFI;
-    create_zero_radix_ciphertext_async<Torus>(
-        streams.stream(0), streams.gpu_index(0), this->a_reg, 93 * num_inputs,
-        params.big_lwe_dimension, size_tracker, allocate_gpu_memory);
-
-    this->b_reg = new CudaRadixCiphertextFFI;
-    create_zero_radix_ciphertext_async<Torus>(
-        streams.stream(0), streams.gpu_index(0), this->b_reg, 84 * num_inputs,
-        params.big_lwe_dimension, size_tracker, allocate_gpu_memory);
-
-    this->c_reg = new CudaRadixCiphertextFFI;
-    create_zero_radix_ciphertext_async<Torus>(
-        streams.stream(0), streams.gpu_index(0), this->c_reg, 111 * num_inputs,
-        params.big_lwe_dimension, size_tracker, allocate_gpu_memory);
+    uint32_t batch_blocks = TRIVIUM_BATCH_SIZE * num_inputs;
 
     this->shift_workspace = new CudaRadixCiphertextFFI;
     create_zero_radix_ciphertext_async<Torus>(
         streams.stream(0), streams.gpu_index(0), this->shift_workspace,
-        128 * num_inputs, params.big_lwe_dimension, size_tracker,
-        allocate_gpu_memory);
-
-    uint32_t batch_blocks = 64 * num_inputs;
+        TRIVIUM_REGISTER_C_BITS * num_inputs, params.big_lwe_dimension,
+        size_tracker, allocate_gpu_memory);
 
     this->temp_t1 = new CudaRadixCiphertextFFI;
     create_zero_radix_ciphertext_async<Torus>(
@@ -166,47 +151,35 @@ template <typename Torus> struct int_trivium_state_workspaces {
     this->packed_pbs_lhs = new CudaRadixCiphertextFFI;
     create_zero_radix_ciphertext_async<Torus>(
         streams.stream(0), streams.gpu_index(0), this->packed_pbs_lhs,
-        3 * batch_blocks, params.big_lwe_dimension, size_tracker,
-        allocate_gpu_memory);
+        TRIVIUM_NUM_AND_GATES * batch_blocks, params.big_lwe_dimension,
+        size_tracker, allocate_gpu_memory);
 
     this->packed_pbs_rhs = new CudaRadixCiphertextFFI;
     create_zero_radix_ciphertext_async<Torus>(
         streams.stream(0), streams.gpu_index(0), this->packed_pbs_rhs,
-        3 * batch_blocks, params.big_lwe_dimension, size_tracker,
-        allocate_gpu_memory);
+        TRIVIUM_NUM_AND_GATES * batch_blocks, params.big_lwe_dimension,
+        size_tracker, allocate_gpu_memory);
 
     this->packed_pbs_out = new CudaRadixCiphertextFFI;
     create_zero_radix_ciphertext_async<Torus>(
         streams.stream(0), streams.gpu_index(0), this->packed_pbs_out,
-        3 * batch_blocks, params.big_lwe_dimension, size_tracker,
-        allocate_gpu_memory);
+        TRIVIUM_NUM_AND_GATES * batch_blocks, params.big_lwe_dimension,
+        size_tracker, allocate_gpu_memory);
 
     this->packed_flush_in = new CudaRadixCiphertextFFI;
     create_zero_radix_ciphertext_async<Torus>(
         streams.stream(0), streams.gpu_index(0), this->packed_flush_in,
-        4 * batch_blocks, params.big_lwe_dimension, size_tracker,
-        allocate_gpu_memory);
+        TRIVIUM_NUM_FLUSH_PATHS * batch_blocks, params.big_lwe_dimension,
+        size_tracker, allocate_gpu_memory);
 
     this->packed_flush_out = new CudaRadixCiphertextFFI;
     create_zero_radix_ciphertext_async<Torus>(
         streams.stream(0), streams.gpu_index(0), this->packed_flush_out,
-        4 * batch_blocks, params.big_lwe_dimension, size_tracker,
-        allocate_gpu_memory);
+        TRIVIUM_NUM_FLUSH_PATHS * batch_blocks, params.big_lwe_dimension,
+        size_tracker, allocate_gpu_memory);
   }
 
   void release(CudaStreams streams, bool allocate_gpu_memory) {
-    release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0),
-                                   this->a_reg, allocate_gpu_memory);
-    delete this->a_reg;
-
-    release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0),
-                                   this->b_reg, allocate_gpu_memory);
-    delete this->b_reg;
-
-    release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0),
-                                   this->c_reg, allocate_gpu_memory);
-    delete this->c_reg;
-
     release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0),
                                    this->shift_workspace, allocate_gpu_memory);
     delete this->shift_workspace;
@@ -265,7 +238,7 @@ template <typename Torus> struct int_trivium_buffer {
   uint32_t num_inputs;
 
   int_trivium_lut_buffers<Torus> *luts;
-  int_trivium_state_workspaces<Torus> *state;
+  int_trivium_workspaces<Torus> *ws;
 
   int_trivium_buffer(CudaStreams streams, const int_radix_params &params,
                      bool allocate_gpu_memory, uint32_t num_inputs,
@@ -277,7 +250,7 @@ template <typename Torus> struct int_trivium_buffer {
     this->luts = new int_trivium_lut_buffers<Torus>(
         streams, params, allocate_gpu_memory, num_inputs, size_tracker);
 
-    this->state = new int_trivium_state_workspaces<Torus>(
+    this->ws = new int_trivium_workspaces<Torus>(
         streams, params, allocate_gpu_memory, num_inputs, size_tracker);
   }
 
@@ -286,9 +259,9 @@ template <typename Torus> struct int_trivium_buffer {
     delete luts;
     luts = nullptr;
 
-    state->release(streams, allocate_gpu_memory);
-    delete state;
-    state = nullptr;
+    ws->release(streams, allocate_gpu_memory);
+    delete ws;
+    ws = nullptr;
 
     cuda_synchronize_stream(streams.stream(0), streams.gpu_index(0));
   }

--- a/backends/tfhe-cuda-backend/cuda/src/kreyvium/kreyvium.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/kreyvium/kreyvium.cu
@@ -1,42 +1,71 @@
 #include "../../include/kreyvium/kreyvium.h"
 #include "kreyvium.cuh"
 
-uint64_t scratch_cuda_kreyvium_generate_keystream_64_async(
+void cuda_kreyvium_init_async(
+    CudaStreamsFFI streams, CudaRadixCiphertextFFI *a_reg,
+    CudaRadixCiphertextFFI *b_reg, CudaRadixCiphertextFFI *c_reg,
+    CudaRadixCiphertextFFI *k_reg, CudaRadixCiphertextFFI *iv_reg,
+    uint32_t *k_offset, uint32_t *iv_offset, const CudaRadixCiphertextFFI *key,
+    const CudaRadixCiphertextFFI *iv_in, uint32_t num_inputs, int8_t *mem_ptr,
+    void *const *bsks, void *const *ksks) {
+  auto buffer = (int_kreyvium_buffer<uint64_t> *)mem_ptr;
+  host_kreyvium_init<uint64_t>(CudaStreams(streams), buffer, a_reg, b_reg,
+                               c_reg, k_reg, iv_reg, k_offset, iv_offset, key,
+                               iv_in, bsks, (uint64_t *const *)ksks);
+}
+
+void cuda_kreyvium_step_async(
+    CudaStreamsFFI streams, CudaRadixCiphertextFFI *keystream_output,
+    CudaRadixCiphertextFFI *a_reg, CudaRadixCiphertextFFI *b_reg,
+    CudaRadixCiphertextFFI *c_reg, CudaRadixCiphertextFFI *k_reg,
+    CudaRadixCiphertextFFI *iv_reg, uint32_t *k_offset, uint32_t *iv_offset,
+    uint32_t num_inputs, uint32_t num_steps, int8_t *mem_ptr, void *const *bsks,
+    void *const *ksks) {
+  auto buffer = (int_kreyvium_buffer<uint64_t> *)mem_ptr;
+  host_kreyvium_step<uint64_t>(CudaStreams(streams), keystream_output, a_reg,
+                               b_reg, c_reg, k_reg, iv_reg, k_offset, iv_offset,
+                               num_inputs, num_steps, buffer, bsks,
+                               (uint64_t *const *)ksks);
+}
+
+uint64_t scratch_cuda_kreyvium_init_async(
     CudaStreamsFFI streams, int8_t **mem_ptr,
     CudaLweBootstrapKeyParamsFFI bsk_params, uint32_t ks_level,
     uint32_t ks_base_log, uint32_t message_modulus, uint32_t carry_modulus,
     bool allocate_gpu_memory, PBS_MS_REDUCTION_T noise_reduction_type,
     uint32_t num_inputs) {
-
   int_radix_params params(bsk_params, ks_level, ks_base_log, message_modulus,
                           carry_modulus, noise_reduction_type);
-
   return scratch_cuda_kreyvium_encrypt<uint64_t>(
       CudaStreams(streams), (int_kreyvium_buffer<uint64_t> **)mem_ptr, params,
       allocate_gpu_memory, num_inputs);
 }
 
-void cuda_kreyvium_generate_keystream_64_async(
-    CudaStreamsFFI streams, CudaRadixCiphertextFFI *keystream_output,
-    const CudaRadixCiphertextFFI *key, const CudaRadixCiphertextFFI *iv,
-    uint32_t num_inputs, uint32_t num_steps, int8_t *mem_ptr, void *const *bsks,
-    void *const *ksks) {
-
-  auto buffer = (int_kreyvium_buffer<uint64_t> *)mem_ptr;
-
-  host_kreyvium_generate_keystream<uint64_t>(
-      CudaStreams(streams), keystream_output, key, iv, num_inputs, num_steps,
-      buffer, bsks, (uint64_t *const *)ksks);
-}
-
-void cleanup_cuda_kreyvium_generate_keystream_64(CudaStreamsFFI streams,
-                                                 int8_t **mem_ptr_void) {
-
+void cleanup_cuda_kreyvium_init(CudaStreamsFFI streams, int8_t **mem_ptr_void) {
   int_kreyvium_buffer<uint64_t> *mem_ptr =
       (int_kreyvium_buffer<uint64_t> *)(*mem_ptr_void);
-
   mem_ptr->release(CudaStreams(streams));
+  delete mem_ptr;
+  *mem_ptr_void = nullptr;
+}
 
+uint64_t scratch_cuda_kreyvium_step_async(
+    CudaStreamsFFI streams, int8_t **mem_ptr,
+    CudaLweBootstrapKeyParamsFFI bsk_params, uint32_t ks_level,
+    uint32_t ks_base_log, uint32_t message_modulus, uint32_t carry_modulus,
+    bool allocate_gpu_memory, PBS_MS_REDUCTION_T noise_reduction_type,
+    uint32_t num_inputs) {
+  int_radix_params params(bsk_params, ks_level, ks_base_log, message_modulus,
+                          carry_modulus, noise_reduction_type);
+  return scratch_cuda_kreyvium_encrypt<uint64_t>(
+      CudaStreams(streams), (int_kreyvium_buffer<uint64_t> **)mem_ptr, params,
+      allocate_gpu_memory, num_inputs);
+}
+
+void cleanup_cuda_kreyvium_step(CudaStreamsFFI streams, int8_t **mem_ptr_void) {
+  int_kreyvium_buffer<uint64_t> *mem_ptr =
+      (int_kreyvium_buffer<uint64_t> *)(*mem_ptr_void);
+  mem_ptr->release(CudaStreams(streams));
   delete mem_ptr;
   *mem_ptr_void = nullptr;
 }

--- a/backends/tfhe-cuda-backend/cuda/src/kreyvium/kreyvium.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/kreyvium/kreyvium.cuh
@@ -21,136 +21,137 @@ __host__ void slice_reg_batch_kreyvium(CudaRadixCiphertextFFI *slice,
 // Standard shift-and-insert for Kreyvium registers A, B, C.
 // Shifts the register and inserts new bits at the start.
 template <typename Torus>
-__host__ void shift_and_insert_batch_kreyvium(CudaStreams streams,
-                                              int_kreyvium_buffer<Torus> *mem,
-                                              CudaRadixCiphertextFFI *reg,
-                                              CudaRadixCiphertextFFI *new_bits,
-                                              uint32_t reg_size,
-                                              uint32_t num_inputs) {
+__host__ void shift_and_insert_batch_kreyvium(
+    CudaStreams streams, CudaRadixCiphertextFFI *shift_workspace,
+    CudaRadixCiphertextFFI *reg, CudaRadixCiphertextFFI *new_bits,
+    uint32_t reg_size, uint32_t num_inputs) {
   constexpr uint32_t BATCH = KREYVIUM_BATCH_SIZE;
-  CudaRadixCiphertextFFI *temp = mem->state->shift_workspace;
   uint32_t num_blocks_to_keep = (reg_size - BATCH) * num_inputs;
-
   copy_radix_ciphertext_slice_async<Torus>(
-      streams.stream(0), streams.gpu_index(0), temp, 0, num_blocks_to_keep, reg,
-      BATCH * num_inputs, reg_size * num_inputs);
-
+      streams.stream(0), streams.gpu_index(0), shift_workspace, 0,
+      num_blocks_to_keep, reg, BATCH * num_inputs, reg_size * num_inputs);
   copy_radix_ciphertext_slice_async<Torus>(
-      streams.stream(0), streams.gpu_index(0), temp, num_blocks_to_keep,
-      reg_size * num_inputs, new_bits, 0, BATCH * num_inputs);
-
+      streams.stream(0), streams.gpu_index(0), shift_workspace,
+      num_blocks_to_keep, reg_size * num_inputs, new_bits, 0,
+      BATCH * num_inputs);
   copy_radix_ciphertext_slice_async<Torus>(
       streams.stream(0), streams.gpu_index(0), reg, 0, reg_size * num_inputs,
-      temp, 0, reg_size * num_inputs);
+      shift_workspace, 0, reg_size * num_inputs);
 }
 
 // Reverses the order of blocks in a ciphertext buffer.
 // Essential for aligning Key/IV bit ordering.
 template <typename Torus>
-void reverse_bitsliced_radix_inplace_kreyvium(CudaStreams streams,
-                                              int_kreyvium_buffer<Torus> *mem,
-                                              CudaRadixCiphertextFFI *radix,
-                                              uint32_t num_bits_in_reg) {
-  uint32_t N = mem->num_inputs;
-  CudaRadixCiphertextFFI *temp = mem->state->shift_workspace;
-
+void reverse_bitsliced_radix_inplace_kreyvium(
+    CudaStreams streams, CudaRadixCiphertextFFI *shift_workspace,
+    CudaRadixCiphertextFFI *radix, uint32_t num_bits_in_reg,
+    uint32_t num_inputs) {
   for (uint32_t i = 0; i < num_bits_in_reg; i++) {
-    uint32_t src_start = i * N;
-    uint32_t src_end = (i + 1) * N;
-    uint32_t dest_start = (num_bits_in_reg - 1 - i) * N;
-    uint32_t dest_end = (num_bits_in_reg - i) * N;
-
+    uint32_t src_start = i * num_inputs;
+    uint32_t src_end = (i + 1) * num_inputs;
+    uint32_t dest_start = (num_bits_in_reg - 1 - i) * num_inputs;
+    uint32_t dest_end = (num_bits_in_reg - i) * num_inputs;
     copy_radix_ciphertext_slice_async<Torus>(
-        streams.stream(0), streams.gpu_index(0), temp, dest_start, dest_end,
-        radix, src_start, src_end);
+        streams.stream(0), streams.gpu_index(0), shift_workspace, dest_start,
+        dest_end, radix, src_start, src_end);
   }
-
   copy_radix_ciphertext_slice_async<Torus>(
-      streams.stream(0), streams.gpu_index(0), radix, 0, num_bits_in_reg * N,
-      temp, 0, num_bits_in_reg * N);
+      streams.stream(0), streams.gpu_index(0), radix, 0,
+      num_bits_in_reg * num_inputs, shift_workspace, 0,
+      num_bits_in_reg * num_inputs);
 }
 
-// Core Kreyvium step function: computes 64 steps in parallel.
-// Includes XORs, AND gates (via PBS), Key/IV rotation, and register updates.
+// Core evaluation function that advances the Kreyvium state by exactly 64
+// steps, applying linear updates and non-linear AND gates.
+//
 template <typename Torus>
-__host__ void
-kreyvium_compute_64_steps(CudaStreams streams, int_kreyvium_buffer<Torus> *mem,
-                          CudaRadixCiphertextFFI *output_dest,
-                          void *const *bsks, uint64_t *const *ksks) {
+__host__ void kreyvium_compute_64_steps(
+    CudaStreams streams, int_kreyvium_buffer<Torus> *mem,
+    CudaRadixCiphertextFFI *a_reg, CudaRadixCiphertextFFI *b_reg,
+    CudaRadixCiphertextFFI *c_reg, CudaRadixCiphertextFFI *k_reg,
+    CudaRadixCiphertextFFI *iv_reg, uint32_t *k_offset, uint32_t *iv_offset,
+    CudaRadixCiphertextFFI *output_dest, void *const *bsks,
+    uint64_t *const *ksks) {
 
   uint32_t N = mem->num_inputs;
   constexpr uint32_t BATCH = KREYVIUM_BATCH_SIZE;
   uint32_t batch_size_blocks = BATCH * N;
-  auto s = mem->state;
+  auto ws = mem->ws;
   auto luts = mem->luts;
 
   // Extract register taps for A (93-bit register)
   CudaRadixCiphertextFFI a65, a92, a91, a90, a68;
-  slice_reg_batch_kreyvium<Torus>(&a65, s->a_reg, 27, BATCH, N);
-  slice_reg_batch_kreyvium<Torus>(&a92, s->a_reg, 0, BATCH, N);
-  slice_reg_batch_kreyvium<Torus>(&a91, s->a_reg, 1, BATCH, N);
-  slice_reg_batch_kreyvium<Torus>(&a90, s->a_reg, 2, BATCH, N);
-  slice_reg_batch_kreyvium<Torus>(&a68, s->a_reg, 24, BATCH, N);
+  slice_reg_batch_kreyvium<Torus>(&a65, a_reg, 27, BATCH, N);
+  slice_reg_batch_kreyvium<Torus>(&a92, a_reg, 0, BATCH, N);
+  slice_reg_batch_kreyvium<Torus>(&a91, a_reg, 1, BATCH, N);
+  slice_reg_batch_kreyvium<Torus>(&a90, a_reg, 2, BATCH, N);
+  slice_reg_batch_kreyvium<Torus>(&a68, a_reg, 24, BATCH, N);
 
   // Extract register taps for B (84-bit register)
   CudaRadixCiphertextFFI b68, b83, b82, b81, b77;
-  slice_reg_batch_kreyvium<Torus>(&b68, s->b_reg, 15, BATCH, N);
-  slice_reg_batch_kreyvium<Torus>(&b83, s->b_reg, 0, BATCH, N);
-  slice_reg_batch_kreyvium<Torus>(&b82, s->b_reg, 1, BATCH, N);
-  slice_reg_batch_kreyvium<Torus>(&b81, s->b_reg, 2, BATCH, N);
-  slice_reg_batch_kreyvium<Torus>(&b77, s->b_reg, 6, BATCH, N);
+  slice_reg_batch_kreyvium<Torus>(&b68, b_reg, 15, BATCH, N);
+  slice_reg_batch_kreyvium<Torus>(&b83, b_reg, 0, BATCH, N);
+  slice_reg_batch_kreyvium<Torus>(&b82, b_reg, 1, BATCH, N);
+  slice_reg_batch_kreyvium<Torus>(&b81, b_reg, 2, BATCH, N);
+  slice_reg_batch_kreyvium<Torus>(&b77, b_reg, 6, BATCH, N);
 
   // Extract register taps for C (111-bit register)
   CudaRadixCiphertextFFI c65, c110, c109, c108, c86;
-  slice_reg_batch_kreyvium<Torus>(&c65, s->c_reg, 45, BATCH, N);
-  slice_reg_batch_kreyvium<Torus>(&c110, s->c_reg, 0, BATCH, N);
-  slice_reg_batch_kreyvium<Torus>(&c109, s->c_reg, 1, BATCH, N);
-  slice_reg_batch_kreyvium<Torus>(&c108, s->c_reg, 2, BATCH, N);
-  slice_reg_batch_kreyvium<Torus>(&c86, s->c_reg, 24, BATCH, N);
+  slice_reg_batch_kreyvium<Torus>(&c65, c_reg, 45, BATCH, N);
+  slice_reg_batch_kreyvium<Torus>(&c110, c_reg, 0, BATCH, N);
+  slice_reg_batch_kreyvium<Torus>(&c109, c_reg, 1, BATCH, N);
+  slice_reg_batch_kreyvium<Torus>(&c108, c_reg, 2, BATCH, N);
+  slice_reg_batch_kreyvium<Torus>(&c86, c_reg, 24, BATCH, N);
 
-  // Extract key and IV bits using virtual rotation offset
+  // Extract Key/IV bits using the virtual rotation offset and advance offsets
   CudaRadixCiphertextFFI k127, iv127;
-  slice_reg_batch_kreyvium<Torus>(&k127, s->k_reg, s->k_offset, 64, N);
-  slice_reg_batch_kreyvium<Torus>(&iv127, s->iv_reg, s->iv_offset, 64, N);
-  s->k_offset = (s->k_offset + 64) % 128;
-  s->iv_offset = (s->iv_offset + 64) % 128;
+  slice_reg_batch_kreyvium<Torus>(&k127, k_reg, *k_offset, KREYVIUM_BATCH_SIZE,
+                                  N);
+  slice_reg_batch_kreyvium<Torus>(&iv127, iv_reg, *iv_offset,
+                                  KREYVIUM_BATCH_SIZE, N);
+  *k_offset = (*k_offset + KREYVIUM_BATCH_SIZE) % KREYVIUM_KEY_BITS;
+  *iv_offset = (*iv_offset + KREYVIUM_BATCH_SIZE) % KREYVIUM_IV_BITS;
 
-  // Compute linear feedback terms:
-  // temp_a = a65 + a92
-  // temp_b = b68 + b83
-  // temp_c = c65 + c110 + k127
-  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), s->temp_a, &a65,
-                       &a92, s->temp_a->num_radix_blocks,
+  // Compute linear feedback terms
+  // temp_a <- a65 + a92
+  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), ws->temp_a,
+                       &a65, &a92, ws->temp_a->num_radix_blocks,
                        mem->params.message_modulus, mem->params.carry_modulus);
-  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), s->temp_b, &b68,
-                       &b83, s->temp_b->num_radix_blocks,
+  // temp_b <- b68 + b83
+  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), ws->temp_b,
+                       &b68, &b83, ws->temp_b->num_radix_blocks,
                        mem->params.message_modulus, mem->params.carry_modulus);
-  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), s->temp_c, &c65,
-                       &c110, s->temp_c->num_radix_blocks,
+  // temp_c <- c65 + c110 + k127
+  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), ws->temp_c,
+                       &c65, &c110, ws->temp_c->num_radix_blocks,
                        mem->params.message_modulus, mem->params.carry_modulus);
-  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), s->temp_c,
-                       s->temp_c, &k127, s->temp_c->num_radix_blocks,
+  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), ws->temp_c,
+                       ws->temp_c, &k127, ws->temp_c->num_radix_blocks,
                        mem->params.message_modulus, mem->params.carry_modulus);
+
+  // Flush temp_c (extract message bits and reset noise) so it can be reused
+  // below
+  integer_radix_apply_univariate_lookup_table<Torus>(
+      streams, ws->temp_c, ws->temp_c, bsks, ksks, luts->flush_lut,
+      ws->temp_c->num_radix_blocks);
 
   // Pack AND gate inputs: (c109 & c108), (a91 & a90), (b82 & b81)
   CudaRadixCiphertextFFI *lhs_ptrs[] = {&c109, &a91, &b82};
   CudaRadixCiphertextFFI *rhs_ptrs[] = {&c108, &a90, &b81};
-
   for (uint32_t i = 0; i < KREYVIUM_NUM_AND_GATES; i++) {
     copy_radix_ciphertext_slice_async<Torus>(
-        streams.stream(0), streams.gpu_index(0), s->packed_and_lhs,
+        streams.stream(0), streams.gpu_index(0), ws->packed_and_lhs,
         i * batch_size_blocks, (i + 1) * batch_size_blocks, lhs_ptrs[i], 0,
         batch_size_blocks);
-
     copy_radix_ciphertext_slice_async<Torus>(
-        streams.stream(0), streams.gpu_index(0), s->packed_and_rhs,
+        streams.stream(0), streams.gpu_index(0), ws->packed_and_rhs,
         i * batch_size_blocks, (i + 1) * batch_size_blocks, rhs_ptrs[i], 0,
         batch_size_blocks);
   }
 
-  // Execute 3 AND gates in parallel via bivariate PBS
+  // Execute the 3 AND gates in parallel via bivariate PBS
   integer_radix_apply_bivariate_lookup_table<Torus>(
-      streams, s->packed_and_out, s->packed_and_lhs, s->packed_and_rhs, bsks,
+      streams, ws->packed_and_out, ws->packed_and_lhs, ws->packed_and_rhs, bsks,
       ksks, luts->and_lut, KREYVIUM_NUM_AND_GATES * batch_size_blocks,
       mem->params.message_modulus);
 
@@ -158,187 +159,211 @@ kreyvium_compute_64_steps(CudaStreams streams, int_kreyvium_buffer<Torus> *mem,
   CudaRadixCiphertextFFI and_c109_c108, and_a91_a90, and_b82_b81;
   CudaRadixCiphertextFFI *and_out_ptrs[] = {&and_c109_c108, &and_a91_a90,
                                             &and_b82_b81};
-
-  for (uint32_t i = 0; i < KREYVIUM_NUM_AND_GATES; i++) {
-    as_radix_ciphertext_slice<Torus>(and_out_ptrs[i], s->packed_and_out,
+  for (uint32_t i = 0; i < KREYVIUM_NUM_AND_GATES; i++)
+    as_radix_ciphertext_slice<Torus>(and_out_ptrs[i], ws->packed_and_out,
                                      i * batch_size_blocks,
                                      (i + 1) * batch_size_blocks);
-  }
 
-  // Create slices pointing directly into flush input buffer
-  // We utilize a loop here to slice the packed buffer into 4 distinct views
+  // Slice the packed flush input buffer into 4 distinct destination views
+  // (new_a, new_b, new_c, output) so we can write directly into it
   CudaRadixCiphertextFFI flush_new_a, flush_new_b, flush_new_c, flush_out;
   CudaRadixCiphertextFFI *flush_in_slices[] = {&flush_new_a, &flush_new_b,
                                                &flush_new_c, &flush_out};
-
-  for (uint32_t i = 0; i < KREYVIUM_NUM_FLUSH_PATHS; i++) {
-    as_radix_ciphertext_slice<Torus>(flush_in_slices[i], s->packed_flush_in,
+  for (uint32_t i = 0; i < KREYVIUM_NUM_FLUSH_PATHS; i++)
+    as_radix_ciphertext_slice<Torus>(flush_in_slices[i], ws->packed_flush_in,
                                      i * batch_size_blocks,
                                      (i + 1) * batch_size_blocks);
-  }
 
-  // new_a = (c109 & c108) + a68 + temp_c
+  // new_a <- (c109 & c108) + a68 + temp_c
   host_addition<Torus>(streams.stream(0), streams.gpu_index(0), &flush_new_a,
                        &and_c109_c108, &a68, batch_size_blocks,
                        mem->params.message_modulus, mem->params.carry_modulus);
   host_addition<Torus>(streams.stream(0), streams.gpu_index(0), &flush_new_a,
-                       &flush_new_a, s->temp_c, batch_size_blocks,
+                       &flush_new_a, ws->temp_c, batch_size_blocks,
                        mem->params.message_modulus, mem->params.carry_modulus);
 
-  // new_b = (a91 & a90) + b77 + temp_a + iv127
+  // new_b <- (a91 & a90) + b77 + temp_a + iv127
   host_addition<Torus>(streams.stream(0), streams.gpu_index(0), &flush_new_b,
                        &and_a91_a90, &b77, batch_size_blocks,
                        mem->params.message_modulus, mem->params.carry_modulus);
   host_addition<Torus>(streams.stream(0), streams.gpu_index(0), &flush_new_b,
-                       &flush_new_b, s->temp_a, batch_size_blocks,
+                       &flush_new_b, ws->temp_a, batch_size_blocks,
                        mem->params.message_modulus, mem->params.carry_modulus);
   host_addition<Torus>(streams.stream(0), streams.gpu_index(0), &flush_new_b,
                        &flush_new_b, &iv127, batch_size_blocks,
                        mem->params.message_modulus, mem->params.carry_modulus);
 
-  // new_c = (b82 & b81) + c86 + temp_b
+  // new_c <- (b82 & b81) + c86 + temp_b
   host_addition<Torus>(streams.stream(0), streams.gpu_index(0), &flush_new_c,
                        &and_b82_b81, &c86, batch_size_blocks,
                        mem->params.message_modulus, mem->params.carry_modulus);
   host_addition<Torus>(streams.stream(0), streams.gpu_index(0), &flush_new_c,
-                       &flush_new_c, s->temp_b, batch_size_blocks,
+                       &flush_new_c, ws->temp_b, batch_size_blocks,
                        mem->params.message_modulus, mem->params.carry_modulus);
 
-  // out = temp_a + temp_b + temp_c
+  // out <- temp_a + temp_b + temp_c
   host_addition<Torus>(streams.stream(0), streams.gpu_index(0), &flush_out,
-                       s->temp_a, s->temp_b, batch_size_blocks,
+                       ws->temp_a, ws->temp_b, batch_size_blocks,
                        mem->params.message_modulus, mem->params.carry_modulus);
   host_addition<Torus>(streams.stream(0), streams.gpu_index(0), &flush_out,
-                       &flush_out, s->temp_c, batch_size_blocks,
+                       &flush_out, ws->temp_c, batch_size_blocks,
                        mem->params.message_modulus, mem->params.carry_modulus);
 
-  // Apply flush PBS to extract message bits and reset noise
+  // Flush PBS: extract message bits and reset noise on new_a, new_b, new_c, out
   integer_radix_apply_univariate_lookup_table<Torus>(
-      streams, s->packed_flush_out, s->packed_flush_in, bsks, ksks,
-      luts->flush_lut, KREYVIUM_NUM_FLUSH_PATHS * batch_size_blocks);
+      streams, ws->packed_flush_out, ws->packed_flush_in, bsks, ksks,
+      luts->flush_lut, ws->packed_flush_out->num_radix_blocks);
 
   // Unpack flushed results
   CudaRadixCiphertextFFI flushed_new_a, flushed_new_b, flushed_new_c,
       flushed_out;
   CudaRadixCiphertextFFI *flush_out_slices[] = {&flushed_new_a, &flushed_new_b,
                                                 &flushed_new_c, &flushed_out};
-
-  for (uint32_t i = 0; i < KREYVIUM_NUM_FLUSH_PATHS; i++) {
-    as_radix_ciphertext_slice<Torus>(flush_out_slices[i], s->packed_flush_out,
+  for (uint32_t i = 0; i < KREYVIUM_NUM_FLUSH_PATHS; i++)
+    as_radix_ciphertext_slice<Torus>(flush_out_slices[i], ws->packed_flush_out,
                                      i * batch_size_blocks,
                                      (i + 1) * batch_size_blocks);
-  }
 
-  // Update registers: shift and insert new 64 bits
-  shift_and_insert_batch_kreyvium(streams, mem, s->a_reg, &flushed_new_a, 93,
-                                  N);
-  shift_and_insert_batch_kreyvium(streams, mem, s->b_reg, &flushed_new_b, 84,
-                                  N);
-  shift_and_insert_batch_kreyvium(streams, mem, s->c_reg, &flushed_new_c, 111,
-                                  N);
+  // Update registers in place: shift left by 64 and insert the new 64 bits
+  shift_and_insert_batch_kreyvium<Torus>(streams, ws->shift_workspace, a_reg,
+                                         &flushed_new_a,
+                                         KREYVIUM_REGISTER_A_BITS, N);
+  shift_and_insert_batch_kreyvium<Torus>(streams, ws->shift_workspace, b_reg,
+                                         &flushed_new_b,
+                                         KREYVIUM_REGISTER_B_BITS, N);
+  shift_and_insert_batch_kreyvium<Torus>(streams, ws->shift_workspace, c_reg,
+                                         &flushed_new_c,
+                                         KREYVIUM_REGISTER_C_BITS, N);
 
-  // Copy output keystream if destination provided
-  if (output_dest != nullptr) {
+  // Copy the keystream output if a destination is provided
+  if (output_dest != nullptr)
     copy_radix_ciphertext_slice_async<Torus>(
         streams.stream(0), streams.gpu_index(0), output_dest, 0,
         batch_size_blocks, &flushed_out, 0, batch_size_blocks);
-  }
 }
 
-// Initialization phase: Loads Key/IV, distributes bits to registers A, B, C,
-// and runs the warm-up loop.
+// Initializes the Kreyvium state by loading the Key and IV into the registers
+// and executing the standard 1152-cycle warmup phase.
+//
 template <typename Torus>
-__host__ void kreyvium_init(CudaStreams streams,
-                            int_kreyvium_buffer<Torus> *mem,
-                            CudaRadixCiphertextFFI const *key_bitsliced,
-                            CudaRadixCiphertextFFI const *iv_bitsliced,
-                            void *const *bsks, uint64_t *const *ksks) {
+__host__ void
+host_kreyvium_init(CudaStreams streams, int_kreyvium_buffer<Torus> *mem,
+                   CudaRadixCiphertextFFI *a_reg, CudaRadixCiphertextFFI *b_reg,
+                   CudaRadixCiphertextFFI *c_reg, CudaRadixCiphertextFFI *k_reg,
+                   CudaRadixCiphertextFFI *iv_reg, uint32_t *k_offset,
+                   uint32_t *iv_offset,
+                   CudaRadixCiphertextFFI const *key_bitsliced,
+                   CudaRadixCiphertextFFI const *iv_bitsliced,
+                   void *const *bsks, uint64_t *const *ksks) {
+
   uint32_t N = mem->num_inputs;
-  auto s = mem->state;
-  s->k_offset = 0;
-  s->iv_offset = 0;
+  *k_offset = 0;
+  *iv_offset = 0;
 
+  // k = key_bits.to_vec();
   CudaRadixCiphertextFFI src_key_slice;
-  slice_reg_batch_kreyvium<Torus>(&src_key_slice, key_bitsliced, 0, 128, N);
-
+  slice_reg_batch_kreyvium<Torus>(&src_key_slice, key_bitsliced, 0,
+                                  KREYVIUM_KEY_BITS, N);
   CudaRadixCiphertextFFI dest_k_reg_slice;
-  slice_reg_batch_kreyvium<Torus>(&dest_k_reg_slice, s->k_reg, 0, 128, N);
+  slice_reg_batch_kreyvium<Torus>(&dest_k_reg_slice, k_reg, 0,
+                                  KREYVIUM_KEY_BITS, N);
   copy_radix_ciphertext_async<Torus>(streams.stream(0), streams.gpu_index(0),
                                      &dest_k_reg_slice, &src_key_slice);
 
+  // a[0..93] = key[35..128]
   CudaRadixCiphertextFFI k_source_for_a;
-  slice_reg_batch_kreyvium<Torus>(&k_source_for_a, s->k_reg, 35, 93, N);
-
+  slice_reg_batch_kreyvium<Torus>(&k_source_for_a, k_reg,
+                                  KREYVIUM_KEY_BITS - KREYVIUM_REGISTER_A_BITS,
+                                  KREYVIUM_REGISTER_A_BITS, N);
   CudaRadixCiphertextFFI dest_a_slice;
-  slice_reg_batch_kreyvium<Torus>(&dest_a_slice, s->a_reg, 0, 93, N);
+  slice_reg_batch_kreyvium<Torus>(&dest_a_slice, a_reg, 0,
+                                  KREYVIUM_REGISTER_A_BITS, N);
   copy_radix_ciphertext_async<Torus>(streams.stream(0), streams.gpu_index(0),
                                      &dest_a_slice, &k_source_for_a);
 
-  reverse_bitsliced_radix_inplace_kreyvium<Torus>(streams, mem, s->k_reg, 128);
+  // k.reverse();
+  reverse_bitsliced_radix_inplace_kreyvium<Torus>(
+      streams, mem->ws->shift_workspace, k_reg, KREYVIUM_KEY_BITS, N);
 
+  // iv = iv_bits.to_vec();
   CudaRadixCiphertextFFI src_iv_slice;
-  slice_reg_batch_kreyvium<Torus>(&src_iv_slice, iv_bitsliced, 0, 128, N);
-
+  slice_reg_batch_kreyvium<Torus>(&src_iv_slice, iv_bitsliced, 0,
+                                  KREYVIUM_IV_BITS, N);
   CudaRadixCiphertextFFI dest_iv_reg_slice;
-  slice_reg_batch_kreyvium<Torus>(&dest_iv_reg_slice, s->iv_reg, 0, 128, N);
+  slice_reg_batch_kreyvium<Torus>(&dest_iv_reg_slice, iv_reg, 0,
+                                  KREYVIUM_IV_BITS, N);
   copy_radix_ciphertext_async<Torus>(streams.stream(0), streams.gpu_index(0),
                                      &dest_iv_reg_slice, &src_iv_slice);
 
+  // b[0..84] = iv[44..128]
   CudaRadixCiphertextFFI iv_source_for_b;
-  slice_reg_batch_kreyvium<Torus>(&iv_source_for_b, s->iv_reg, 44, 84, N);
-
+  slice_reg_batch_kreyvium<Torus>(&iv_source_for_b, iv_reg,
+                                  KREYVIUM_IV_BITS - KREYVIUM_REGISTER_B_BITS,
+                                  KREYVIUM_REGISTER_B_BITS, N);
   CudaRadixCiphertextFFI dest_b_slice;
-  slice_reg_batch_kreyvium<Torus>(&dest_b_slice, s->b_reg, 0, 84, N);
+  slice_reg_batch_kreyvium<Torus>(&dest_b_slice, b_reg, 0,
+                                  KREYVIUM_REGISTER_B_BITS, N);
   copy_radix_ciphertext_async<Torus>(streams.stream(0), streams.gpu_index(0),
                                      &dest_b_slice, &iv_source_for_b);
 
+  // c[67..111] = iv[0..44]
   CudaRadixCiphertextFFI iv_source_for_c;
-  slice_reg_batch_kreyvium<Torus>(&iv_source_for_c, s->iv_reg, 0, 44, N);
-
+  slice_reg_batch_kreyvium<Torus>(&iv_source_for_c, iv_reg, 0,
+                                  KREYVIUM_IV_BITS - KREYVIUM_REGISTER_B_BITS,
+                                  N);
   CudaRadixCiphertextFFI dest_c_iv_part;
-  slice_reg_batch_kreyvium<Torus>(&dest_c_iv_part, s->c_reg, 67, 44, N);
+  slice_reg_batch_kreyvium<Torus>(
+      &dest_c_iv_part, c_reg,
+      KREYVIUM_REGISTER_C_BITS - (KREYVIUM_IV_BITS - KREYVIUM_REGISTER_B_BITS),
+      KREYVIUM_IV_BITS - KREYVIUM_REGISTER_B_BITS, N);
   copy_radix_ciphertext_async<Torus>(streams.stream(0), streams.gpu_index(0),
                                      &dest_c_iv_part, &iv_source_for_c);
 
-  reverse_bitsliced_radix_inplace_kreyvium<Torus>(streams, mem, s->iv_reg, 128);
+  // iv.reverse();
+  reverse_bitsliced_radix_inplace_kreyvium<Torus>(
+      streams, mem->ws->shift_workspace, iv_reg, KREYVIUM_IV_BITS, N);
 
+  // for i in 0..66 { c[i + 1] = 1; }
   CudaRadixCiphertextFFI dest_c_ones;
-  slice_reg_batch_kreyvium<Torus>(&dest_c_ones, s->c_reg, 1, 66, N);
+  slice_reg_batch_kreyvium<Torus>(&dest_c_ones, c_reg, KREYVIUM_C_ONES_OFFSET,
+                                  KREYVIUM_C_ONES_COUNT, N);
   host_add_scalar_one_inplace<Torus>(streams, &dest_c_ones,
                                      mem->params.message_modulus,
                                      mem->params.carry_modulus);
-
   integer_radix_apply_univariate_lookup_table<Torus>(
       streams, &dest_c_ones, &dest_c_ones, bsks, ksks, mem->luts->flush_lut,
       dest_c_ones.num_radix_blocks);
 
-  for (int i = 0; i < 18; i++) {
-    kreyvium_compute_64_steps(streams, mem, nullptr, bsks, ksks);
-  }
+  // Standard Kreyvium warm-up: KREYVIUM_WARMUP_CYCLES (1152) cycles, processed
+  // in batches of KREYVIUM_BATCH_SIZE (64).
+  for (uint32_t i = 0; i < KREYVIUM_WARMUP_BATCHES; i++)
+    kreyvium_compute_64_steps(streams, mem, a_reg, b_reg, c_reg, k_reg, iv_reg,
+                              k_offset, iv_offset, nullptr, bsks, ksks);
 }
 
-// Main entry point: Generates keystream in batches of 64 steps.
+// Generates the requested number of keystream bits (in batches of 64) from an
+// existing state and updates the internal registers in place.
+//
 template <typename Torus>
-__host__ void host_kreyvium_generate_keystream(
+__host__ void host_kreyvium_step(
     CudaStreams streams, CudaRadixCiphertextFFI *keystream_output,
-    CudaRadixCiphertextFFI const *key_bitsliced,
-    CudaRadixCiphertextFFI const *iv_bitsliced, uint32_t num_inputs,
-    uint32_t num_steps, int_kreyvium_buffer<Torus> *mem, void *const *bsks,
-    uint64_t *const *ksks) {
+    CudaRadixCiphertextFFI *a_reg, CudaRadixCiphertextFFI *b_reg,
+    CudaRadixCiphertextFFI *c_reg, CudaRadixCiphertextFFI *k_reg,
+    CudaRadixCiphertextFFI *iv_reg, uint32_t *k_offset, uint32_t *iv_offset,
+    uint32_t num_inputs, uint32_t num_steps, int_kreyvium_buffer<Torus> *mem,
+    void *const *bsks, uint64_t *const *ksks) {
 
-  PANIC_IF_FALSE(
-      num_steps % KREYVIUM_BATCH_SIZE == 0,
-      "Kreyvium Error: num_steps must be a multiple of the batch size (64).\n");
-
-  kreyvium_init(streams, mem, key_bitsliced, iv_bitsliced, bsks, ksks);
-
+  PANIC_IF_FALSE(num_steps % KREYVIUM_BATCH_SIZE == 0,
+                 "Kreyvium Error: num_steps must be a multiple of 64.\n");
   uint32_t num_batches = num_steps / KREYVIUM_BATCH_SIZE;
   for (uint32_t i = 0; i < num_batches; i++) {
     CudaRadixCiphertextFFI batch_out_slice;
     slice_reg_batch_kreyvium<Torus>(&batch_out_slice, keystream_output,
                                     i * KREYVIUM_BATCH_SIZE,
                                     KREYVIUM_BATCH_SIZE, num_inputs);
-    kreyvium_compute_64_steps(streams, mem, &batch_out_slice, bsks, ksks);
+    kreyvium_compute_64_steps(streams, mem, a_reg, b_reg, c_reg, k_reg, iv_reg,
+                              k_offset, iv_offset, &batch_out_slice, bsks,
+                              ksks);
   }
 }
 
@@ -348,7 +373,6 @@ uint64_t scratch_cuda_kreyvium_encrypt(CudaStreams streams,
                                        int_radix_params params,
                                        bool allocate_gpu_memory,
                                        uint32_t num_inputs) {
-
   uint64_t size_tracker = 0;
   *mem_ptr = new int_kreyvium_buffer<Torus>(
       streams, params, allocate_gpu_memory, num_inputs, size_tracker);

--- a/backends/tfhe-cuda-backend/cuda/src/trivium/trivium.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/trivium/trivium.cu
@@ -1,7 +1,35 @@
 #include "../../include/trivium/trivium.h"
 #include "trivium.cuh"
 
-uint64_t scratch_cuda_trivium_generate_keystream_64_async(
+void cuda_trivium_init_async(CudaStreamsFFI streams,
+                             CudaRadixCiphertextFFI *a_reg,
+                             CudaRadixCiphertextFFI *b_reg,
+                             CudaRadixCiphertextFFI *c_reg,
+                             const CudaRadixCiphertextFFI *key,
+                             const CudaRadixCiphertextFFI *iv,
+                             uint32_t num_inputs, int8_t *mem_ptr,
+                             void *const *bsks, void *const *ksks) {
+
+  auto buffer = (int_trivium_buffer<uint64_t> *)mem_ptr;
+  host_trivium_init<uint64_t>(CudaStreams(streams), buffer, a_reg, b_reg, c_reg,
+                              key, iv, bsks, (uint64_t *const *)ksks);
+}
+
+void cuda_trivium_step_async(CudaStreamsFFI streams,
+                             CudaRadixCiphertextFFI *keystream_output,
+                             CudaRadixCiphertextFFI *a_reg,
+                             CudaRadixCiphertextFFI *b_reg,
+                             CudaRadixCiphertextFFI *c_reg, uint32_t num_inputs,
+                             uint32_t num_steps, int8_t *mem_ptr,
+                             void *const *bsks, void *const *ksks) {
+
+  auto buffer = (int_trivium_buffer<uint64_t> *)mem_ptr;
+  host_trivium_step<uint64_t>(CudaStreams(streams), keystream_output, a_reg,
+                              b_reg, c_reg, num_steps, buffer, bsks,
+                              (uint64_t *const *)ksks);
+}
+
+uint64_t scratch_cuda_trivium_init_async(
     CudaStreamsFFI streams, int8_t **mem_ptr,
     CudaLweBootstrapKeyParamsFFI bsk_params, uint32_t ks_level,
     uint32_t ks_base_log, uint32_t message_modulus, uint32_t carry_modulus,
@@ -16,27 +44,35 @@ uint64_t scratch_cuda_trivium_generate_keystream_64_async(
       allocate_gpu_memory, num_inputs);
 }
 
-void cuda_trivium_generate_keystream_64_async(
-    CudaStreamsFFI streams, CudaRadixCiphertextFFI *keystream_output,
-    const CudaRadixCiphertextFFI *key, const CudaRadixCiphertextFFI *iv,
-    uint32_t num_inputs, uint32_t num_steps, int8_t *mem_ptr, void *const *bsks,
-    void *const *ksks) {
-
-  auto buffer = (int_trivium_buffer<uint64_t> *)mem_ptr;
-
-  host_trivium_generate_keystream<uint64_t>(
-      CudaStreams(streams), keystream_output, key, iv, num_inputs, num_steps,
-      buffer, bsks, (uint64_t *const *)ksks);
-}
-
-void cleanup_cuda_trivium_generate_keystream_64(CudaStreamsFFI streams,
-                                                int8_t **mem_ptr_void) {
-
+void cleanup_cuda_trivium_init(CudaStreamsFFI streams, int8_t **mem_ptr_void) {
   int_trivium_buffer<uint64_t> *mem_ptr =
       (int_trivium_buffer<uint64_t> *)(*mem_ptr_void);
 
   mem_ptr->release(CudaStreams(streams));
+  delete mem_ptr;
+  *mem_ptr_void = nullptr;
+}
 
+uint64_t scratch_cuda_trivium_step_async(
+    CudaStreamsFFI streams, int8_t **mem_ptr,
+    CudaLweBootstrapKeyParamsFFI bsk_params, uint32_t ks_level,
+    uint32_t ks_base_log, uint32_t message_modulus, uint32_t carry_modulus,
+    bool allocate_gpu_memory, PBS_MS_REDUCTION_T noise_reduction_type,
+    uint32_t num_inputs) {
+
+  int_radix_params params(bsk_params, ks_level, ks_base_log, message_modulus,
+                          carry_modulus, noise_reduction_type);
+
+  return scratch_cuda_trivium_encrypt<uint64_t>(
+      CudaStreams(streams), (int_trivium_buffer<uint64_t> **)mem_ptr, params,
+      allocate_gpu_memory, num_inputs);
+}
+
+void cleanup_cuda_trivium_step(CudaStreamsFFI streams, int8_t **mem_ptr_void) {
+  int_trivium_buffer<uint64_t> *mem_ptr =
+      (int_trivium_buffer<uint64_t> *)(*mem_ptr_void);
+
+  mem_ptr->release(CudaStreams(streams));
   delete mem_ptr;
   *mem_ptr_void = nullptr;
 }

--- a/backends/tfhe-cuda-backend/cuda/src/trivium/trivium.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/trivium/trivium.cuh
@@ -7,33 +7,6 @@
 #include "../integer/scalar_addition.cuh"
 #include "../linearalgebra/addition.cuh"
 
-// Reverses the order of bits (blocks) in a ciphertext buffer.
-// Used to align the input Key/IV with the internal state format if needed.
-template <typename Torus>
-void reverse_bitsliced_radix_inplace(CudaStreams streams,
-                                     int_trivium_buffer<Torus> *mem,
-                                     CudaRadixCiphertextFFI *radix,
-                                     uint32_t num_bits_in_reg) {
-  uint32_t N = mem->num_inputs;
-  CudaRadixCiphertextFFI *temp = mem->state->shift_workspace;
-
-  for (uint32_t i = 0; i < num_bits_in_reg; i++) {
-    uint32_t src_start = i * N;
-    uint32_t src_end = (i + 1) * N;
-
-    uint32_t dest_start = (num_bits_in_reg - 1 - i) * N;
-    uint32_t dest_end = (num_bits_in_reg - i) * N;
-
-    copy_radix_ciphertext_slice_async<Torus>(
-        streams.stream(0), streams.gpu_index(0), temp, dest_start, dest_end,
-        radix, src_start, src_end);
-  }
-
-  copy_radix_ciphertext_slice_async<Torus>(
-      streams.stream(0), streams.gpu_index(0), radix, 0, num_bits_in_reg * N,
-      temp, 0, num_bits_in_reg * N);
-}
-
 // Creates a slice of specific bits in a register without copying data.
 template <typename Torus>
 __host__ void slice_reg_batch(CudaRadixCiphertextFFI *slice,
@@ -44,205 +17,252 @@ __host__ void slice_reg_batch(CudaRadixCiphertextFFI *slice,
                                    (start_bit_idx + num_bits) * num_inputs);
 }
 
+// Reverses the order of bits (blocks) in a ciphertext buffer.
+// Used to align the input Key/IV with the internal state format if needed.
+template <typename Torus>
+void reverse_bitsliced_radix_inplace(CudaStreams streams,
+                                     CudaRadixCiphertextFFI *shift_workspace,
+                                     CudaRadixCiphertextFFI *radix,
+                                     uint32_t num_bits_in_reg,
+                                     uint32_t num_inputs) {
+  uint32_t N = num_inputs;
+  for (uint32_t i = 0; i < num_bits_in_reg; i++) {
+    uint32_t src_start = i * N;
+    uint32_t src_end = (i + 1) * N;
+    uint32_t dest_start = (num_bits_in_reg - 1 - i) * N;
+    uint32_t dest_end = (num_bits_in_reg - i) * N;
+
+    copy_radix_ciphertext_slice_async<Torus>(
+        streams.stream(0), streams.gpu_index(0), shift_workspace, dest_start,
+        dest_end, radix, src_start, src_end);
+  }
+
+  copy_radix_ciphertext_slice_async<Torus>(
+      streams.stream(0), streams.gpu_index(0), radix, 0, num_bits_in_reg * N,
+      shift_workspace, 0, num_bits_in_reg * N);
+}
+
 // Handles the shift-register update: discards old bits, shifts the rest,
 // and inserts the newly computed bits at the beginning.
 template <typename Torus>
 __host__ void shift_and_insert_batch(CudaStreams streams,
-                                     int_trivium_buffer<Torus> *mem,
+                                     CudaRadixCiphertextFFI *shift_workspace,
                                      CudaRadixCiphertextFFI *reg,
                                      CudaRadixCiphertextFFI *new_bits,
                                      uint32_t reg_size, uint32_t num_inputs) {
-
-  constexpr uint32_t BATCH = 64;
-  CudaRadixCiphertextFFI *temp = mem->state->shift_workspace;
-
+  constexpr uint32_t BATCH = TRIVIUM_BATCH_SIZE;
   uint32_t num_blocks_to_keep = (reg_size - BATCH) * num_inputs;
 
   copy_radix_ciphertext_slice_async<Torus>(
-      streams.stream(0), streams.gpu_index(0), temp, 0, BATCH * num_inputs,
-      new_bits, 0, BATCH * num_inputs);
+      streams.stream(0), streams.gpu_index(0), shift_workspace, 0,
+      BATCH * num_inputs, new_bits, 0, BATCH * num_inputs);
 
   copy_radix_ciphertext_slice_async<Torus>(
-      streams.stream(0), streams.gpu_index(0), temp, BATCH * num_inputs,
-      reg_size * num_inputs, reg, 0, num_blocks_to_keep);
+      streams.stream(0), streams.gpu_index(0), shift_workspace,
+      BATCH * num_inputs, reg_size * num_inputs, reg, 0, num_blocks_to_keep);
 
   copy_radix_ciphertext_slice_async<Torus>(
       streams.stream(0), streams.gpu_index(0), reg, 0, reg_size * num_inputs,
-      temp, 0, reg_size * num_inputs);
+      shift_workspace, 0, reg_size * num_inputs);
 }
 
-// core logic: computes 64 parallel updates for the state registers.
-// It performs the XORs (additions) and the AND gates (using Bivariate PBS),
-// then updates the registers and writes to output if needed.
+// Core evaluation function: computes 64 parallel updates for the state
+// registers. Performs the XORs (additions) and the AND gates (Bivariate PBS),
+// updates the registers in place, and writes to output if requested.
 template <typename Torus>
-__host__ void
-trivium_compute_64_steps(CudaStreams streams, int_trivium_buffer<Torus> *mem,
-                         CudaRadixCiphertextFFI *output_dest, void *const *bsks,
-                         uint64_t *const *ksks) {
+__host__ void trivium_compute_64_steps(
+    CudaStreams streams, int_trivium_buffer<Torus> *buffer,
+    CudaRadixCiphertextFFI *a_reg, CudaRadixCiphertextFFI *b_reg,
+    CudaRadixCiphertextFFI *c_reg, CudaRadixCiphertextFFI *output_dest,
+    void *const *bsks, uint64_t *const *ksks) {
 
-  uint32_t N = mem->num_inputs;
-  constexpr uint32_t BATCH = 64;
+  uint32_t N = buffer->num_inputs;
+  constexpr uint32_t BATCH = TRIVIUM_BATCH_SIZE;
   uint32_t batch_size_blocks = BATCH * N;
-  auto s = mem->state;
+  auto ws = buffer->ws;
+  auto params = buffer->params;
 
+  // Extract register taps for A (93-bit register)
   CudaRadixCiphertextFFI a65_slice, a92_slice, a91_slice, a90_slice, a68_slice;
-  slice_reg_batch<Torus>(&a65_slice, s->a_reg, 2, BATCH, N);
-  slice_reg_batch<Torus>(&a92_slice, s->a_reg, 29, BATCH, N);
-  slice_reg_batch<Torus>(&a91_slice, s->a_reg, 28, BATCH, N);
-  slice_reg_batch<Torus>(&a90_slice, s->a_reg, 27, BATCH, N);
-  slice_reg_batch<Torus>(&a68_slice, s->a_reg, 5, BATCH, N);
+  slice_reg_batch<Torus>(&a65_slice, a_reg, 2, BATCH, N);
+  slice_reg_batch<Torus>(&a92_slice, a_reg, 29, BATCH, N);
+  slice_reg_batch<Torus>(&a91_slice, a_reg, 28, BATCH, N);
+  slice_reg_batch<Torus>(&a90_slice, a_reg, 27, BATCH, N);
+  slice_reg_batch<Torus>(&a68_slice, a_reg, 5, BATCH, N);
 
+  // Extract register taps for B (84-bit register)
   CudaRadixCiphertextFFI b68_slice, b83_slice, b82_slice, b81_slice, b77_slice;
-  slice_reg_batch<Torus>(&b68_slice, s->b_reg, 5, BATCH, N);
-  slice_reg_batch<Torus>(&b83_slice, s->b_reg, 20, BATCH, N);
-  slice_reg_batch<Torus>(&b82_slice, s->b_reg, 19, BATCH, N);
-  slice_reg_batch<Torus>(&b81_slice, s->b_reg, 18, BATCH, N);
-  slice_reg_batch<Torus>(&b77_slice, s->b_reg, 14, BATCH, N);
+  slice_reg_batch<Torus>(&b68_slice, b_reg, 5, BATCH, N);
+  slice_reg_batch<Torus>(&b83_slice, b_reg, 20, BATCH, N);
+  slice_reg_batch<Torus>(&b82_slice, b_reg, 19, BATCH, N);
+  slice_reg_batch<Torus>(&b81_slice, b_reg, 18, BATCH, N);
+  slice_reg_batch<Torus>(&b77_slice, b_reg, 14, BATCH, N);
 
+  // Extract register taps for C (111-bit register)
   CudaRadixCiphertextFFI c65_slice, c110_slice, c109_slice, c108_slice,
       c86_slice;
-  slice_reg_batch<Torus>(&c65_slice, s->c_reg, 2, BATCH, N);
-  slice_reg_batch<Torus>(&c110_slice, s->c_reg, 47, BATCH, N);
-  slice_reg_batch<Torus>(&c109_slice, s->c_reg, 46, BATCH, N);
-  slice_reg_batch<Torus>(&c108_slice, s->c_reg, 45, BATCH, N);
-  slice_reg_batch<Torus>(&c86_slice, s->c_reg, 23, BATCH, N);
+  slice_reg_batch<Torus>(&c65_slice, c_reg, 2, BATCH, N);
+  slice_reg_batch<Torus>(&c110_slice, c_reg, 47, BATCH, N);
+  slice_reg_batch<Torus>(&c109_slice, c_reg, 46, BATCH, N);
+  slice_reg_batch<Torus>(&c108_slice, c_reg, 45, BATCH, N);
+  slice_reg_batch<Torus>(&c86_slice, c_reg, 23, BATCH, N);
 
-  // t1 = a66 + a93
-  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), s->temp_t1,
-                       &a65_slice, &a92_slice, s->temp_t1->num_radix_blocks,
-                       mem->params.message_modulus, mem->params.carry_modulus);
+  // Compute linear feedback terms
+  // t1 <- a66 + a93
+  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), ws->temp_t1,
+                       &a65_slice, &a92_slice, ws->temp_t1->num_radix_blocks,
+                       params.message_modulus, params.carry_modulus);
 
-  // t2 = b69 + b84
-  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), s->temp_t2,
-                       &b68_slice, &b83_slice, s->temp_t2->num_radix_blocks,
-                       mem->params.message_modulus, mem->params.carry_modulus);
+  // t2 <- b69 + b84
+  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), ws->temp_t2,
+                       &b68_slice, &b83_slice, ws->temp_t2->num_radix_blocks,
+                       params.message_modulus, params.carry_modulus);
 
-  // t3 = c66 + c111
-  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), s->temp_t3,
-                       &c65_slice, &c110_slice, s->temp_t3->num_radix_blocks,
-                       mem->params.message_modulus, mem->params.carry_modulus);
+  // t3 <- c66 + c111
+  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), ws->temp_t3,
+                       &c65_slice, &c110_slice, ws->temp_t3->num_radix_blocks,
+                       params.message_modulus, params.carry_modulus);
 
+  // Flush t3 (extract message bits and reset noise) so it can be reused below
+  integer_radix_apply_univariate_lookup_table<Torus>(
+      streams, ws->temp_t3, ws->temp_t3, bsks, ksks, buffer->luts->flush_lut,
+      ws->temp_t3->num_radix_blocks);
+
+  // Pack AND gate inputs: (c109 & c108), (a91 & a90), (b82 & b81)
   copy_radix_ciphertext_slice_async<Torus>(
-      streams.stream(0), streams.gpu_index(0), s->packed_pbs_lhs, 0,
+      streams.stream(0), streams.gpu_index(0), ws->packed_pbs_lhs, 0,
       batch_size_blocks, &c109_slice, 0, batch_size_blocks);
 
   copy_radix_ciphertext_slice_async<Torus>(
-      streams.stream(0), streams.gpu_index(0), s->packed_pbs_lhs,
+      streams.stream(0), streams.gpu_index(0), ws->packed_pbs_lhs,
       batch_size_blocks, 2 * batch_size_blocks, &a91_slice, 0,
       batch_size_blocks);
 
   copy_radix_ciphertext_slice_async<Torus>(
-      streams.stream(0), streams.gpu_index(0), s->packed_pbs_lhs,
+      streams.stream(0), streams.gpu_index(0), ws->packed_pbs_lhs,
       2 * batch_size_blocks, 3 * batch_size_blocks, &b82_slice, 0,
       batch_size_blocks);
 
   copy_radix_ciphertext_slice_async<Torus>(
-      streams.stream(0), streams.gpu_index(0), s->packed_pbs_rhs, 0,
+      streams.stream(0), streams.gpu_index(0), ws->packed_pbs_rhs, 0,
       batch_size_blocks, &c108_slice, 0, batch_size_blocks);
 
   copy_radix_ciphertext_slice_async<Torus>(
-      streams.stream(0), streams.gpu_index(0), s->packed_pbs_rhs,
+      streams.stream(0), streams.gpu_index(0), ws->packed_pbs_rhs,
       batch_size_blocks, 2 * batch_size_blocks, &a90_slice, 0,
       batch_size_blocks);
 
   copy_radix_ciphertext_slice_async<Torus>(
-      streams.stream(0), streams.gpu_index(0), s->packed_pbs_rhs,
+      streams.stream(0), streams.gpu_index(0), ws->packed_pbs_rhs,
       2 * batch_size_blocks, 3 * batch_size_blocks, &b81_slice, 0,
       batch_size_blocks);
 
+  // Execute the 3 AND gates in parallel via bivariate PBS
   integer_radix_apply_bivariate_lookup_table<Torus>(
-      streams, s->packed_pbs_out, s->packed_pbs_lhs, s->packed_pbs_rhs, bsks,
-      ksks, mem->luts->and_lut, 3 * batch_size_blocks,
-      mem->params.message_modulus);
+      streams, ws->packed_pbs_out, ws->packed_pbs_lhs, ws->packed_pbs_rhs, bsks,
+      ksks, buffer->luts->and_lut, 3 * batch_size_blocks,
+      params.message_modulus);
 
+  // Unpack AND results: and_res_a = c109 & c108, and_res_b = a91 & a90,
+  // and_res_c = b82 & b81
   CudaRadixCiphertextFFI and_res_a, and_res_b, and_res_c;
-  as_radix_ciphertext_slice<Torus>(&and_res_a, s->packed_pbs_out, 0,
+  as_radix_ciphertext_slice<Torus>(&and_res_a, ws->packed_pbs_out, 0,
                                    batch_size_blocks);
-  as_radix_ciphertext_slice<Torus>(&and_res_b, s->packed_pbs_out,
+  as_radix_ciphertext_slice<Torus>(&and_res_b, ws->packed_pbs_out,
                                    batch_size_blocks, 2 * batch_size_blocks);
-  as_radix_ciphertext_slice<Torus>(&and_res_c, s->packed_pbs_out,
+  as_radix_ciphertext_slice<Torus>(&and_res_c, ws->packed_pbs_out,
                                    2 * batch_size_blocks,
                                    3 * batch_size_blocks);
 
-  // a = t3 + a69 + and_res_a
-  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), s->new_a,
-                       s->temp_t3, &a68_slice, s->new_a->num_radix_blocks,
-                       mem->params.message_modulus, mem->params.carry_modulus);
-  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), s->new_a,
-                       s->new_a, &and_res_a, s->new_a->num_radix_blocks,
-                       mem->params.message_modulus, mem->params.carry_modulus);
+  // new_a <- t3 + a69 + and_res_a
+  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), ws->new_a,
+                       ws->temp_t3, &a68_slice, ws->new_a->num_radix_blocks,
+                       params.message_modulus, params.carry_modulus);
+  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), ws->new_a,
+                       ws->new_a, &and_res_a, ws->new_a->num_radix_blocks,
+                       params.message_modulus, params.carry_modulus);
 
-  // b = t1 + b78 + and_res_b
-  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), s->new_b,
-                       s->temp_t1, &b77_slice, s->new_b->num_radix_blocks,
-                       mem->params.message_modulus, mem->params.carry_modulus);
-  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), s->new_b,
-                       s->new_b, &and_res_b, s->new_b->num_radix_blocks,
-                       mem->params.message_modulus, mem->params.carry_modulus);
+  // new_b <- t1 + b78 + and_res_b
+  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), ws->new_b,
+                       ws->temp_t1, &b77_slice, ws->new_b->num_radix_blocks,
+                       params.message_modulus, params.carry_modulus);
+  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), ws->new_b,
+                       ws->new_b, &and_res_b, ws->new_b->num_radix_blocks,
+                       params.message_modulus, params.carry_modulus);
 
-  // c = t2 + c87 + and_res_c
-  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), s->new_c,
-                       s->temp_t2, &c86_slice, s->new_c->num_radix_blocks,
-                       mem->params.message_modulus, mem->params.carry_modulus);
-  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), s->new_c,
-                       s->new_c, &and_res_c, s->new_c->num_radix_blocks,
-                       mem->params.message_modulus, mem->params.carry_modulus);
+  // new_c <- t2 + c87 + and_res_c
+  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), ws->new_c,
+                       ws->temp_t2, &c86_slice, ws->new_c->num_radix_blocks,
+                       params.message_modulus, params.carry_modulus);
+  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), ws->new_c,
+                       ws->new_c, &and_res_c, ws->new_c->num_radix_blocks,
+                       params.message_modulus, params.carry_modulus);
 
   if (output_dest != nullptr) {
-    // z = t1 + t2 + t3
+    // z <- t1 + t2 + t3
     host_addition<Torus>(streams.stream(0), streams.gpu_index(0), output_dest,
-                         s->temp_t1, s->temp_t2, output_dest->num_radix_blocks,
-                         mem->params.message_modulus,
-                         mem->params.carry_modulus);
+                         ws->temp_t1, ws->temp_t2,
+                         output_dest->num_radix_blocks, params.message_modulus,
+                         params.carry_modulus);
     host_addition<Torus>(streams.stream(0), streams.gpu_index(0), output_dest,
-                         output_dest, s->temp_t3, output_dest->num_radix_blocks,
-                         mem->params.message_modulus,
-                         mem->params.carry_modulus);
+                         output_dest, ws->temp_t3,
+                         output_dest->num_radix_blocks, params.message_modulus,
+                         params.carry_modulus);
   }
 
+  // Pack new_a, new_b, new_c (and z when an output is requested) into a single
+  // buffer to flush them all in one PBS call
   copy_radix_ciphertext_slice_async<Torus>(
-      streams.stream(0), streams.gpu_index(0), s->packed_flush_in, 0,
-      batch_size_blocks, s->new_a, 0, batch_size_blocks);
+      streams.stream(0), streams.gpu_index(0), ws->packed_flush_in, 0,
+      batch_size_blocks, ws->new_a, 0, batch_size_blocks);
 
   copy_radix_ciphertext_slice_async<Torus>(
-      streams.stream(0), streams.gpu_index(0), s->packed_flush_in,
-      batch_size_blocks, 2 * batch_size_blocks, s->new_b, 0, batch_size_blocks);
+      streams.stream(0), streams.gpu_index(0), ws->packed_flush_in,
+      batch_size_blocks, 2 * batch_size_blocks, ws->new_b, 0,
+      batch_size_blocks);
 
   copy_radix_ciphertext_slice_async<Torus>(
-      streams.stream(0), streams.gpu_index(0), s->packed_flush_in,
-      2 * batch_size_blocks, 3 * batch_size_blocks, s->new_c, 0,
+      streams.stream(0), streams.gpu_index(0), ws->packed_flush_in,
+      2 * batch_size_blocks, 3 * batch_size_blocks, ws->new_c, 0,
       batch_size_blocks);
 
   uint32_t total_flush_blocks = 3 * batch_size_blocks;
 
   if (output_dest != nullptr) {
     copy_radix_ciphertext_slice_async<Torus>(
-        streams.stream(0), streams.gpu_index(0), s->packed_flush_in,
+        streams.stream(0), streams.gpu_index(0), ws->packed_flush_in,
         3 * batch_size_blocks, 4 * batch_size_blocks, output_dest, 0,
         batch_size_blocks);
     total_flush_blocks += batch_size_blocks;
   }
 
+  // Flush PBS: extract message bits and reset noise on new_a, new_b, new_c (and
+  // z if any)
   integer_radix_apply_univariate_lookup_table<Torus>(
-      streams, s->packed_flush_out, s->packed_flush_in, bsks, ksks,
-      mem->luts->flush_lut, total_flush_blocks);
+      streams, ws->packed_flush_out, ws->packed_flush_in, bsks, ksks,
+      buffer->luts->flush_lut, total_flush_blocks);
 
+  // Unpack flushed results
   CudaRadixCiphertextFFI flushed_a, flushed_b, flushed_c;
-  as_radix_ciphertext_slice<Torus>(&flushed_a, s->packed_flush_out, 0,
+  as_radix_ciphertext_slice<Torus>(&flushed_a, ws->packed_flush_out, 0,
                                    batch_size_blocks);
-  as_radix_ciphertext_slice<Torus>(&flushed_b, s->packed_flush_out,
+  as_radix_ciphertext_slice<Torus>(&flushed_b, ws->packed_flush_out,
                                    batch_size_blocks, 2 * batch_size_blocks);
-  as_radix_ciphertext_slice<Torus>(&flushed_c, s->packed_flush_out,
+  as_radix_ciphertext_slice<Torus>(&flushed_c, ws->packed_flush_out,
                                    2 * batch_size_blocks,
                                    3 * batch_size_blocks);
 
-  shift_and_insert_batch(streams, mem, s->a_reg, &flushed_a, 93, N);
-  shift_and_insert_batch(streams, mem, s->b_reg, &flushed_b, 84, N);
-  shift_and_insert_batch(streams, mem, s->c_reg, &flushed_c, 111, N);
+  // Update registers in place: shift left by 64 and insert the new 64 bits
+  shift_and_insert_batch<Torus>(streams, ws->shift_workspace, a_reg, &flushed_a,
+                                TRIVIUM_REGISTER_A_BITS, N);
+  shift_and_insert_batch<Torus>(streams, ws->shift_workspace, b_reg, &flushed_b,
+                                TRIVIUM_REGISTER_B_BITS, N);
+  shift_and_insert_batch<Torus>(streams, ws->shift_workspace, c_reg, &flushed_c,
+                                TRIVIUM_REGISTER_C_BITS, N);
 
   if (output_dest != nullptr) {
     CudaRadixCiphertextFFI flushed_out;
-    as_radix_ciphertext_slice<Torus>(&flushed_out, s->packed_flush_out,
+    as_radix_ciphertext_slice<Torus>(&flushed_out, ws->packed_flush_out,
                                      3 * batch_size_blocks,
                                      4 * batch_size_blocks);
 
@@ -250,78 +270,87 @@ trivium_compute_64_steps(CudaStreams streams, int_trivium_buffer<Torus> *mem,
         streams.stream(0), streams.gpu_index(0), output_dest, 0,
         batch_size_blocks, &flushed_out, 0, batch_size_blocks);
 
-    reverse_bitsliced_radix_inplace<Torus>(streams, mem, output_dest, 64);
+    reverse_bitsliced_radix_inplace<Torus>(streams, ws->shift_workspace,
+                                           output_dest, BATCH, N);
   }
 }
 
 // Sets up the initial state: loads Key and IV, fixes constants,
 // and runs the warm-up phase (1152 steps).
 template <typename Torus>
-__host__ void trivium_init(CudaStreams streams, int_trivium_buffer<Torus> *mem,
-                           CudaRadixCiphertextFFI const *key_bitsliced,
-                           CudaRadixCiphertextFFI const *iv_bitsliced,
-                           void *const *bsks, uint64_t *const *ksks) {
-  uint32_t N = mem->num_inputs;
-  auto s = mem->state;
+__host__ void
+host_trivium_init(CudaStreams streams, int_trivium_buffer<Torus> *buffer,
+                  CudaRadixCiphertextFFI *a_reg, CudaRadixCiphertextFFI *b_reg,
+                  CudaRadixCiphertextFFI *c_reg,
+                  const CudaRadixCiphertextFFI *key_bitsliced,
+                  const CudaRadixCiphertextFFI *iv_bitsliced, void *const *bsks,
+                  uint64_t *const *ksks) {
+
+  uint32_t N = buffer->num_inputs;
+  auto ws = buffer->ws;
+  auto params = buffer->params;
 
   CudaRadixCiphertextFFI src_key_slice;
-  slice_reg_batch<Torus>(&src_key_slice, key_bitsliced, 0, 80, N);
+  slice_reg_batch<Torus>(&src_key_slice, key_bitsliced, 0, TRIVIUM_KEY_BITS, N);
 
   CudaRadixCiphertextFFI dest_a_slice;
-  slice_reg_batch<Torus>(&dest_a_slice, s->a_reg, 0, 80, N);
+  slice_reg_batch<Torus>(&dest_a_slice, a_reg, 0, TRIVIUM_KEY_BITS, N);
 
   copy_radix_ciphertext_async<Torus>(streams.stream(0), streams.gpu_index(0),
                                      &dest_a_slice, &src_key_slice);
 
-  reverse_bitsliced_radix_inplace<Torus>(streams, mem, s->a_reg, 80);
+  reverse_bitsliced_radix_inplace<Torus>(streams, ws->shift_workspace, a_reg,
+                                         TRIVIUM_KEY_BITS, N);
 
   CudaRadixCiphertextFFI src_iv_slice;
-  slice_reg_batch<Torus>(&src_iv_slice, iv_bitsliced, 0, 80, N);
+  slice_reg_batch<Torus>(&src_iv_slice, iv_bitsliced, 0, TRIVIUM_IV_BITS, N);
 
   CudaRadixCiphertextFFI dest_b_slice;
-  slice_reg_batch<Torus>(&dest_b_slice, s->b_reg, 0, 80, N);
+  slice_reg_batch<Torus>(&dest_b_slice, b_reg, 0, TRIVIUM_IV_BITS, N);
 
   copy_radix_ciphertext_async<Torus>(streams.stream(0), streams.gpu_index(0),
                                      &dest_b_slice, &src_iv_slice);
 
-  reverse_bitsliced_radix_inplace<Torus>(streams, mem, s->b_reg, 80);
+  reverse_bitsliced_radix_inplace<Torus>(streams, ws->shift_workspace, b_reg,
+                                         TRIVIUM_IV_BITS, N);
 
   CudaRadixCiphertextFFI dest_c_ones;
-  slice_reg_batch<Torus>(&dest_c_ones, s->c_reg, 108, 3, N);
+  slice_reg_batch<Torus>(&dest_c_ones, c_reg, TRIVIUM_REGISTER_C_BITS - 3, 3,
+                         N);
 
-  host_add_scalar_one_inplace<Torus>(streams, &dest_c_ones,
-                                     mem->params.message_modulus,
-                                     mem->params.carry_modulus);
+  host_add_scalar_one_inplace<Torus>(
+      streams, &dest_c_ones, params.message_modulus, params.carry_modulus);
   integer_radix_apply_univariate_lookup_table<Torus>(
-      streams, &dest_c_ones, &dest_c_ones, bsks, ksks, mem->luts->flush_lut,
+      streams, &dest_c_ones, &dest_c_ones, bsks, ksks, buffer->luts->flush_lut,
       dest_c_ones.num_radix_blocks);
 
-  for (int i = 0; i < 18; i++) {
-    trivium_compute_64_steps(streams, mem, nullptr, bsks, ksks);
+  for (uint32_t i = 0; i < TRIVIUM_WARMUP_BATCHES; i++) {
+    trivium_compute_64_steps(streams, buffer, a_reg, b_reg, c_reg, nullptr,
+                             bsks, ksks);
   }
 }
 
-// Main entry point: checks input validity, initializes state,
-// and loops to generate the keystream in batches of 64.
 template <typename Torus>
-__host__ void host_trivium_generate_keystream(
-    CudaStreams streams, CudaRadixCiphertextFFI *keystream_output,
-    CudaRadixCiphertextFFI const *key_bitsliced,
-    CudaRadixCiphertextFFI const *iv_bitsliced, uint32_t num_inputs,
-    uint32_t num_steps, int_trivium_buffer<Torus> *mem, void *const *bsks,
-    uint64_t *const *ksks) {
+__host__ void
+host_trivium_step(CudaStreams streams, CudaRadixCiphertextFFI *keystream_output,
+                  CudaRadixCiphertextFFI *a_reg, CudaRadixCiphertextFFI *b_reg,
+                  CudaRadixCiphertextFFI *c_reg, uint32_t num_steps,
+                  int_trivium_buffer<Torus> *buffer, void *const *bsks,
+                  uint64_t *const *ksks) {
 
-  PANIC_IF_FALSE(num_steps % 64 == 0,
-                 "Trivium Error: num_steps must be a multiple of 64.\n");
+  PANIC_IF_FALSE(
+      num_steps % TRIVIUM_BATCH_SIZE == 0,
+      "Trivium Error: num_steps must be a multiple of TRIVIUM_BATCH_SIZE.\n");
 
-  trivium_init(streams, mem, key_bitsliced, iv_bitsliced, bsks, ksks);
-
-  uint32_t num_batches = num_steps / 64;
+  uint32_t num_batches = num_steps / TRIVIUM_BATCH_SIZE;
   for (uint32_t i = 0; i < num_batches; i++) {
     CudaRadixCiphertextFFI batch_out_slice;
-    slice_reg_batch<Torus>(&batch_out_slice, keystream_output, i * 64, 64,
-                           num_inputs);
-    trivium_compute_64_steps(streams, mem, &batch_out_slice, bsks, ksks);
+    slice_reg_batch<Torus>(&batch_out_slice, keystream_output,
+                           i * TRIVIUM_BATCH_SIZE, TRIVIUM_BATCH_SIZE,
+                           buffer->num_inputs);
+
+    trivium_compute_64_steps(streams, buffer, a_reg, b_reg, c_reg,
+                             &batch_out_slice, bsks, ksks);
   }
 }
 

--- a/backends/tfhe-cuda-backend/src/bindings.rs
+++ b/backends/tfhe-cuda-backend/src/bindings.rs
@@ -2338,7 +2338,7 @@ unsafe extern "C" {
     );
 }
 unsafe extern "C" {
-    pub fn scratch_cuda_trivium_generate_keystream_64_async(
+    pub fn scratch_cuda_trivium_init_async(
         streams: CudaStreamsFFI,
         mem_ptr: *mut *mut i8,
         bsk_params: CudaLweBootstrapKeyParamsFFI,
@@ -2352,26 +2352,24 @@ unsafe extern "C" {
     ) -> u64;
 }
 unsafe extern "C" {
-    pub fn cuda_trivium_generate_keystream_64_async(
+    pub fn cuda_trivium_init_async(
         streams: CudaStreamsFFI,
-        keystream_output: *mut CudaRadixCiphertextFFI,
+        a_reg: *mut CudaRadixCiphertextFFI,
+        b_reg: *mut CudaRadixCiphertextFFI,
+        c_reg: *mut CudaRadixCiphertextFFI,
         key: *const CudaRadixCiphertextFFI,
         iv: *const CudaRadixCiphertextFFI,
         num_inputs: u32,
-        num_steps: u32,
         mem_ptr: *mut i8,
         bsks: *const *mut ffi::c_void,
         ksks: *const *mut ffi::c_void,
     );
 }
 unsafe extern "C" {
-    pub fn cleanup_cuda_trivium_generate_keystream_64(
-        streams: CudaStreamsFFI,
-        mem_ptr_void: *mut *mut i8,
-    );
+    pub fn cleanup_cuda_trivium_init(streams: CudaStreamsFFI, mem_ptr_void: *mut *mut i8);
 }
 unsafe extern "C" {
-    pub fn scratch_cuda_kreyvium_generate_keystream_64_async(
+    pub fn scratch_cuda_trivium_step_async(
         streams: CudaStreamsFFI,
         mem_ptr: *mut *mut i8,
         bsk_params: CudaLweBootstrapKeyParamsFFI,
@@ -2385,11 +2383,12 @@ unsafe extern "C" {
     ) -> u64;
 }
 unsafe extern "C" {
-    pub fn cuda_kreyvium_generate_keystream_64_async(
+    pub fn cuda_trivium_step_async(
         streams: CudaStreamsFFI,
         keystream_output: *mut CudaRadixCiphertextFFI,
-        key: *const CudaRadixCiphertextFFI,
-        iv: *const CudaRadixCiphertextFFI,
+        a_reg: *mut CudaRadixCiphertextFFI,
+        b_reg: *mut CudaRadixCiphertextFFI,
+        c_reg: *mut CudaRadixCiphertextFFI,
         num_inputs: u32,
         num_steps: u32,
         mem_ptr: *mut i8,
@@ -2398,9 +2397,76 @@ unsafe extern "C" {
     );
 }
 unsafe extern "C" {
-    pub fn cleanup_cuda_kreyvium_generate_keystream_64(
+    pub fn cleanup_cuda_trivium_step(streams: CudaStreamsFFI, mem_ptr_void: *mut *mut i8);
+}
+unsafe extern "C" {
+    pub fn scratch_cuda_kreyvium_init_async(
         streams: CudaStreamsFFI,
-        mem_ptr_void: *mut *mut i8,
+        mem_ptr: *mut *mut i8,
+        bsk_params: CudaLweBootstrapKeyParamsFFI,
+        ks_level: u32,
+        ks_base_log: u32,
+        message_modulus: u32,
+        carry_modulus: u32,
+        allocate_gpu_memory: bool,
+        noise_reduction_type: PBS_MS_REDUCTION_T,
+        num_inputs: u32,
+    ) -> u64;
+}
+unsafe extern "C" {
+    pub fn cleanup_cuda_kreyvium_init(streams: CudaStreamsFFI, mem_ptr_void: *mut *mut i8);
+}
+unsafe extern "C" {
+    pub fn scratch_cuda_kreyvium_step_async(
+        streams: CudaStreamsFFI,
+        mem_ptr: *mut *mut i8,
+        bsk_params: CudaLweBootstrapKeyParamsFFI,
+        ks_level: u32,
+        ks_base_log: u32,
+        message_modulus: u32,
+        carry_modulus: u32,
+        allocate_gpu_memory: bool,
+        noise_reduction_type: PBS_MS_REDUCTION_T,
+        num_inputs: u32,
+    ) -> u64;
+}
+unsafe extern "C" {
+    pub fn cleanup_cuda_kreyvium_step(streams: CudaStreamsFFI, mem_ptr_void: *mut *mut i8);
+}
+unsafe extern "C" {
+    pub fn cuda_kreyvium_init_async(
+        streams: CudaStreamsFFI,
+        a_reg: *mut CudaRadixCiphertextFFI,
+        b_reg: *mut CudaRadixCiphertextFFI,
+        c_reg: *mut CudaRadixCiphertextFFI,
+        k_reg: *mut CudaRadixCiphertextFFI,
+        iv_reg: *mut CudaRadixCiphertextFFI,
+        k_offset: *mut u32,
+        iv_offset: *mut u32,
+        key: *const CudaRadixCiphertextFFI,
+        iv_in: *const CudaRadixCiphertextFFI,
+        num_inputs: u32,
+        mem_ptr: *mut i8,
+        bsks: *const *mut ffi::c_void,
+        ksks: *const *mut ffi::c_void,
+    );
+}
+unsafe extern "C" {
+    pub fn cuda_kreyvium_step_async(
+        streams: CudaStreamsFFI,
+        keystream_output: *mut CudaRadixCiphertextFFI,
+        a_reg: *mut CudaRadixCiphertextFFI,
+        b_reg: *mut CudaRadixCiphertextFFI,
+        c_reg: *mut CudaRadixCiphertextFFI,
+        k_reg: *mut CudaRadixCiphertextFFI,
+        iv_reg: *mut CudaRadixCiphertextFFI,
+        k_offset: *mut u32,
+        iv_offset: *mut u32,
+        num_inputs: u32,
+        num_steps: u32,
+        mem_ptr: *mut i8,
+        bsks: *const *mut ffi::c_void,
+        ksks: *const *mut ffi::c_void,
     );
 }
 pub const KS_TYPE_BIG_TO_SMALL: KS_TYPE = 0;

--- a/scripts/check_scratch_cleanup.py
+++ b/scripts/check_scratch_cleanup.py
@@ -54,29 +54,29 @@ RUST_CALL_SITES = [
 # Bindings parsed from bindings.rs
 # Scratch functions: Two more than cleanup functions because of
 #  'scratch_cuda_programmable_bootstrap_32_async' and
-EXPECTED_SCRATCH_COUNT = 72
+EXPECTED_SCRATCH_COUNT = 74
 
 # Cuda operation functions
-EXPECTED_CUDA_COUNT = 113
+EXPECTED_CUDA_COUNT = 115
 
 # Cleanup functions
-EXPECTED_CLEANUP_COUNT = 72
+EXPECTED_CLEANUP_COUNT = 74
 
 # Check 3: Rust call-site scanning
 # Number of functions in ffi.rs files
-EXPECTED_CHECK3_RUST_FNS = 138
+EXPECTED_CHECK3_RUST_FNS = 140
 # Number of functions in ffi.rs files that
-EXPECTED_CHECK3_ASYNC_CUDA_CALLS = 94
+EXPECTED_CHECK3_ASYNC_CUDA_CALLS = 96
 
 # Number of instances of Rust calls to the scratch/cuda/cleanup in a
 # triplet sequence.
-EXPECTED_CHECK3_SCRATCH_CUDA_CLEANUP_TRIPLET_CALLS = 113
+EXPECTED_CHECK3_SCRATCH_CUDA_CLEANUP_TRIPLET_CALLS = 115
 
 # Check 5: Rust async-caller scanning
-EXPECTED_CHECK5_ASYNC_CALLERS = 122
+EXPECTED_CHECK5_ASYNC_CALLERS = 124
 
 # Check 6: Rust cleanup-caller scanning
-EXPECTED_CHECK6_CLEANUP_CALLERS = 110
+EXPECTED_CHECK6_CLEANUP_CALLERS = 112
 
 
 def check_paths_exist():

--- a/tfhe-benchmark/benches/integer/kreyvium.rs
+++ b/tfhe-benchmark/benches/integer/kreyvium.rs
@@ -2,7 +2,10 @@ use criterion::Criterion;
 
 #[cfg(feature = "gpu")]
 pub mod cuda {
-    use benchmark::params_aliases::BENCH_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+    use benchmark::params_aliases::{
+        BENCH_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+        BENCH_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+    };
     use benchmark::utilities::{write_to_json_unchecked, OperatorType};
     use criterion::{black_box, criterion_group, Criterion};
     use tfhe::core_crypto::gpu::CudaStreams;
@@ -30,46 +33,96 @@ pub mod cuda {
             .measurement_time(std::time::Duration::from_secs(60))
             .warm_up_time(std::time::Duration::from_secs(5));
 
-        let param = BENCH_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
-        let atomic_param: AtomicPatternParameters = param.into();
+        let params = [
+            (
+                BENCH_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128.into(),
+                BENCH_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128.name(),
+            ),
+            (
+                BENCH_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128.into(),
+                BENCH_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128.name(),
+            ),
+        ];
 
-        let key_bits = vec![0u64; 128];
-        let iv_bits = vec![0u64; 128];
+        for (atomic_param_val, param_name) in params {
+            let atomic_param: AtomicPatternParameters = atomic_param_val;
 
-        let param_name = param.name();
+            let key_bits = vec![0u64; 128];
+            let iv_bits = vec![0u64; 128];
 
-        let streams = CudaStreams::new_multi_gpu();
-        let (cpu_cks, _) = KEY_CACHE.get_from_params(atomic_param, IntegerKeyKind::Radix);
-        let sks = CudaServerKey::new(&cpu_cks, &streams);
-        let cks = RadixClientKey::from((cpu_cks, 1));
+            let streams = CudaStreams::new_multi_gpu();
+            let (cpu_cks, _) = KEY_CACHE.get_from_params(atomic_param, IntegerKeyKind::Radix);
+            let sks = CudaServerKey::new(&cpu_cks, &streams);
+            let cks = RadixClientKey::from((cpu_cks, 1));
 
-        let ct_key = encrypt_bits(&cks, &key_bits);
-        let ct_iv = encrypt_bits(&cks, &iv_bits);
+            let ct_key = encrypt_bits(&cks, &key_bits);
+            let ct_iv = encrypt_bits(&cks, &iv_bits);
 
-        let d_key = CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct_key, &streams);
-        let d_iv = CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct_iv, &streams);
+            let d_key = CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct_key, &streams);
+            let d_iv = CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct_iv, &streams);
 
-        for num_steps in [64, 512] {
-            let bench_id = format!("{bench_name}::{param_name}::generate_{num_steps}_bits");
-
-            bench_group.bench_function(&bench_id, |b| {
+            // 1. Benchmark: init
+            let init_bench_id = format!("{bench_name}::{param_name}::init");
+            bench_group.bench_function(&init_bench_id, |b| {
                 b.iter(|| {
-                    black_box(
-                        sks.kreyvium_generate_keystream(&d_key, &d_iv, num_steps, &streams)
-                            .unwrap(),
-                    );
+                    black_box(sks.kreyvium_init(&d_key, &d_iv, &streams).unwrap());
                 })
             });
 
             write_to_json_unchecked::<u64, _>(
-                &bench_id,
+                &init_bench_id,
                 atomic_param,
-                param.name(),
-                &format!("kreyvium_generation_{}_bits", num_steps),
+                param_name.clone(),
+                "kreyvium_init",
                 &OperatorType::Atomic,
                 128,
                 vec![atomic_param.message_modulus().0.ilog2(); 128],
             );
+
+            let mut state = sks.kreyvium_init(&d_key, &d_iv, &streams).unwrap();
+
+            for num_steps in [64, 512] {
+                // 2. Benchmark: next
+                let next_bench_id = format!("{bench_name}::{param_name}::next_{num_steps}_bits");
+
+                bench_group.bench_function(&next_bench_id, |b| {
+                    b.iter(|| {
+                        black_box(sks.kreyvium_next(&mut state, num_steps, &streams).unwrap());
+                    })
+                });
+
+                write_to_json_unchecked::<u64, _>(
+                    &next_bench_id,
+                    atomic_param,
+                    param_name.clone(),
+                    &format!("kreyvium_next_{}_bits", num_steps),
+                    &OperatorType::Atomic,
+                    128,
+                    vec![atomic_param.message_modulus().0.ilog2(); 128],
+                );
+
+                // 3. Benchmark: generate_keystream
+                let gen_bench_id = format!("{bench_name}::{param_name}::generate_{num_steps}_bits");
+
+                bench_group.bench_function(&gen_bench_id, |b| {
+                    b.iter(|| {
+                        black_box(
+                            sks.kreyvium_generate_keystream(&d_key, &d_iv, num_steps, &streams)
+                                .unwrap(),
+                        );
+                    })
+                });
+
+                write_to_json_unchecked::<u64, _>(
+                    &gen_bench_id,
+                    atomic_param,
+                    param_name.clone(),
+                    &format!("kreyvium_generation_{}_bits", num_steps),
+                    &OperatorType::Atomic,
+                    128,
+                    vec![atomic_param.message_modulus().0.ilog2(); 128],
+                );
+            }
         }
 
         bench_group.finish();

--- a/tfhe-benchmark/benches/integer/trivium.rs
+++ b/tfhe-benchmark/benches/integer/trivium.rs
@@ -2,7 +2,10 @@ use criterion::Criterion;
 
 #[cfg(feature = "gpu")]
 pub mod cuda {
-    use benchmark::params_aliases::BENCH_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+    use benchmark::params_aliases::{
+        BENCH_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+        BENCH_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+    };
     use benchmark::utilities::{write_to_json_unchecked, OperatorType};
     use criterion::{black_box, criterion_group, Criterion};
     use tfhe::core_crypto::gpu::CudaStreams;
@@ -11,13 +14,13 @@ pub mod cuda {
     use tfhe::integer::keycache::KEY_CACHE;
     use tfhe::integer::{IntegerKeyKind, RadixCiphertext, RadixClientKey};
     use tfhe::keycache::NamedParam;
-    use tfhe::shortint::AtomicPatternParameters;
+    use tfhe::shortint::{AtomicPatternParameters, Ciphertext};
 
-    fn encrypt_bit_stream(cks: &RadixClientKey, bits: &[u64]) -> RadixCiphertext {
+    fn encrypt_bits(cks: &RadixClientKey, bits: &[u64]) -> RadixCiphertext {
         RadixCiphertext::from(
             bits.iter()
                 .map(|&bit| cks.encrypt_one_block(bit))
-                .collect::<Vec<_>>(),
+                .collect::<Vec<Ciphertext>>(),
         )
     }
 
@@ -30,46 +33,96 @@ pub mod cuda {
             .measurement_time(std::time::Duration::from_secs(60))
             .warm_up_time(std::time::Duration::from_secs(5));
 
-        let param = BENCH_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
-        let atomic_param: AtomicPatternParameters = param.into();
+        let params = [
+            (
+                BENCH_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128.into(),
+                BENCH_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128.name(),
+            ),
+            (
+                BENCH_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128.into(),
+                BENCH_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128.name(),
+            ),
+        ];
 
-        let key_bits = vec![0u64; 80];
-        let iv_bits = vec![0u64; 80];
+        for (atomic_param_val, param_name) in params {
+            let atomic_param: AtomicPatternParameters = atomic_param_val;
 
-        let param_name = param.name();
+            let key_bits = vec![0u64; 80];
+            let iv_bits = vec![0u64; 80];
 
-        let streams = CudaStreams::new_multi_gpu();
-        let (cpu_cks, _) = KEY_CACHE.get_from_params(atomic_param, IntegerKeyKind::Radix);
-        let sks = CudaServerKey::new(&cpu_cks, &streams);
-        let cks = RadixClientKey::from((cpu_cks, 1));
+            let streams = CudaStreams::new_multi_gpu();
+            let (cpu_cks, _) = KEY_CACHE.get_from_params(atomic_param, IntegerKeyKind::Radix);
+            let sks = CudaServerKey::new(&cpu_cks, &streams);
+            let cks = RadixClientKey::from((cpu_cks, 1));
 
-        let ct_key = encrypt_bit_stream(&cks, &key_bits);
-        let ct_iv = encrypt_bit_stream(&cks, &iv_bits);
+            let ct_key = encrypt_bits(&cks, &key_bits);
+            let ct_iv = encrypt_bits(&cks, &iv_bits);
 
-        let d_key = CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct_key, &streams);
-        let d_iv = CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct_iv, &streams);
+            let d_key = CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct_key, &streams);
+            let d_iv = CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct_iv, &streams);
 
-        for num_steps in [64, 512] {
-            let bench_id = format!("{bench_name}::{param_name}::generate_{num_steps}_bits");
-
-            bench_group.bench_function(&bench_id, |b| {
+            // 1. Benchmark: init
+            let init_bench_id = format!("{bench_name}::{param_name}::init");
+            bench_group.bench_function(&init_bench_id, |b| {
                 b.iter(|| {
-                    black_box(
-                        sks.trivium_generate_keystream(&d_key, &d_iv, num_steps, &streams)
-                            .unwrap(),
-                    );
+                    black_box(sks.trivium_init(&d_key, &d_iv, &streams).unwrap());
                 })
             });
 
             write_to_json_unchecked::<u64, _>(
-                &bench_id,
+                &init_bench_id,
                 atomic_param,
-                param.name(),
-                &format!("trivium_generation_{}_bits", num_steps),
+                param_name.clone(),
+                "trivium_init",
                 &OperatorType::Atomic,
                 80,
                 vec![atomic_param.message_modulus().0.ilog2(); 80],
             );
+
+            let mut state = sks.trivium_init(&d_key, &d_iv, &streams).unwrap();
+
+            for num_steps in [64, 512] {
+                // 2. Benchmark: next
+                let next_bench_id = format!("{bench_name}::{param_name}::next_{num_steps}_bits");
+
+                bench_group.bench_function(&next_bench_id, |b| {
+                    b.iter(|| {
+                        black_box(sks.trivium_next(&mut state, num_steps, &streams).unwrap());
+                    })
+                });
+
+                write_to_json_unchecked::<u64, _>(
+                    &next_bench_id,
+                    atomic_param,
+                    param_name.clone(),
+                    &format!("trivium_next_{}_bits", num_steps),
+                    &OperatorType::Atomic,
+                    80,
+                    vec![atomic_param.message_modulus().0.ilog2(); 80],
+                );
+
+                // 3. Benchmark: generate_keystream
+                let gen_bench_id = format!("{bench_name}::{param_name}::generate_{num_steps}_bits");
+
+                bench_group.bench_function(&gen_bench_id, |b| {
+                    b.iter(|| {
+                        black_box(
+                            sks.trivium_generate_keystream(&d_key, &d_iv, num_steps, &streams)
+                                .unwrap(),
+                        );
+                    })
+                });
+
+                write_to_json_unchecked::<u64, _>(
+                    &gen_bench_id,
+                    atomic_param,
+                    param_name.clone(),
+                    &format!("trivium_generation_{}_bits", num_steps),
+                    &OperatorType::Atomic,
+                    80,
+                    vec![atomic_param.message_modulus().0.ilog2(); 80],
+                );
+            }
         }
 
         bench_group.finish();

--- a/tfhe/src/integer/gpu/ffi.rs
+++ b/tfhe/src/integer/gpu/ffi.rs
@@ -9488,15 +9488,25 @@ pub fn extract_glwe<T: UnsignedInteger>(
     }
 }
 
+const TRIVIUM_KEY_BITS: usize = 80;
+const KREYVIUM_KEY_BITS: usize = 128;
+const TRIVIUM_REGISTER_A_BITS: usize = 93;
+// 2_2 params mandatory
+const TRIVIUM_REQUIRED_MESSAGE_MODULUS: u64 = 4;
+const TRIVIUM_REQUIRED_CARRY_MODULUS: u64 = 4;
+const TRIVIUM_MAX_NUM_INPUTS: u32 = 65_000;
+
 #[allow(clippy::too_many_arguments)]
 /// # Safety
 ///
 /// - The data must not be moved or dropped while being used by the CUDA kernel.
 /// - This function assumes exclusive access to the passed data; violating this may lead to
 ///   undefined behavior.
-pub(crate) unsafe fn cuda_backend_trivium_generate_keystream<T: UnsignedInteger, B: Numeric>(
+pub(crate) unsafe fn cuda_backend_trivium_init<T: UnsignedInteger, B: Numeric>(
     streams: &CudaStreams,
-    keystream_output: &mut CudaRadixCiphertext,
+    a: &mut CudaRadixCiphertext,
+    b: &mut CudaRadixCiphertext,
+    c: &mut CudaRadixCiphertext,
     key: &CudaRadixCiphertext,
     iv: &CudaRadixCiphertext,
     bootstrapping_key: &CudaVec<B>,
@@ -9507,42 +9517,76 @@ pub(crate) unsafe fn cuda_backend_trivium_generate_keystream<T: UnsignedInteger,
     ks_level: DecompositionLevelCount,
     ks_base_log: DecompositionBaseLog,
     ms_noise_reduction_configuration: Option<&CudaModulusSwitchNoiseReductionConfiguration>,
-    num_steps: u32,
 ) {
+    assert_eq!(message_modulus.0, TRIVIUM_REQUIRED_MESSAGE_MODULUS);
+    assert_eq!(carry_modulus.0, TRIVIUM_REQUIRED_CARRY_MODULUS);
+
     let bsk_params = bsk.params_ffi();
-    let mut keystream_degrees = keystream_output
-        .info
-        .blocks
-        .iter()
-        .map(|b| b.degree.0)
-        .collect();
-    let mut keystream_noise_levels = keystream_output
+    let mut a_deg = a.info.blocks.iter().map(|b| b.degree.0).collect::<Vec<_>>();
+    let mut a_noise = a
         .info
         .blocks
         .iter()
         .map(|b| b.noise_level.0)
-        .collect();
-    let mut cuda_ffi_keystream = prepare_cuda_radix_ffi(
-        keystream_output,
-        &mut keystream_degrees,
-        &mut keystream_noise_levels,
-    );
+        .collect::<Vec<_>>();
+    let mut ffi_a = prepare_cuda_radix_ffi(a, &mut a_deg, &mut a_noise);
 
-    let mut key_degrees = key.info.blocks.iter().map(|b| b.degree.0).collect();
-    let mut key_noise_levels = key.info.blocks.iter().map(|b| b.noise_level.0).collect();
-    let cuda_ffi_key = prepare_cuda_radix_ffi(key, &mut key_degrees, &mut key_noise_levels);
+    let mut b_deg = b.info.blocks.iter().map(|b| b.degree.0).collect::<Vec<_>>();
+    let mut b_noise = b
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.noise_level.0)
+        .collect::<Vec<_>>();
+    let mut ffi_b = prepare_cuda_radix_ffi(b, &mut b_deg, &mut b_noise);
 
-    let mut iv_degrees = iv.info.blocks.iter().map(|b| b.degree.0).collect();
-    let mut iv_noise_levels = iv.info.blocks.iter().map(|b| b.noise_level.0).collect();
-    let cuda_ffi_iv = prepare_cuda_radix_ffi(iv, &mut iv_degrees, &mut iv_noise_levels);
+    let mut c_deg = c.info.blocks.iter().map(|b| b.degree.0).collect::<Vec<_>>();
+    let mut c_noise = c
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.noise_level.0)
+        .collect::<Vec<_>>();
+    let mut ffi_c = prepare_cuda_radix_ffi(c, &mut c_deg, &mut c_noise);
 
-    let num_inputs = u32::try_from(key.info.blocks.len() / 80).unwrap();
+    let mut key_deg = key
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.degree.0)
+        .collect::<Vec<_>>();
+    let mut key_noise = key
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.noise_level.0)
+        .collect::<Vec<_>>();
+    let ffi_key = prepare_cuda_radix_ffi(key, &mut key_deg, &mut key_noise);
+
+    let mut iv_deg = iv
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.degree.0)
+        .collect::<Vec<_>>();
+    let mut iv_noise = iv
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.noise_level.0)
+        .collect::<Vec<_>>();
+    let ffi_iv = prepare_cuda_radix_ffi(iv, &mut iv_deg, &mut iv_noise);
+
+    let key_len = key.info.blocks.len();
+    assert!(key_len > 0 && key_len.is_multiple_of(TRIVIUM_KEY_BITS));
+
+    let num_inputs = u32::try_from(key_len / TRIVIUM_KEY_BITS).unwrap();
+    assert!(num_inputs <= TRIVIUM_MAX_NUM_INPUTS);
 
     let noise_reduction_type = resolve_ms_noise_reduction_config(ms_noise_reduction_configuration);
-
     let mut mem_ptr: *mut i8 = std::ptr::null_mut();
 
-    scratch_cuda_trivium_generate_keystream_64_async(
+    scratch_cuda_trivium_init_async(
         streams.ffi(),
         std::ptr::addr_of_mut!(mem_ptr),
         bsk_params,
@@ -9554,22 +9598,23 @@ pub(crate) unsafe fn cuda_backend_trivium_generate_keystream<T: UnsignedInteger,
         noise_reduction_type as u32,
         num_inputs,
     );
-
-    cuda_trivium_generate_keystream_64_async(
+    cuda_trivium_init_async(
         streams.ffi(),
-        &raw mut cuda_ffi_keystream,
-        &raw const cuda_ffi_key,
-        &raw const cuda_ffi_iv,
+        &raw mut ffi_a,
+        &raw mut ffi_b,
+        &raw mut ffi_c,
+        &raw const ffi_key,
+        &raw const ffi_iv,
         num_inputs,
-        num_steps,
         mem_ptr,
         bootstrapping_key.ptr.as_ptr(),
         keyswitch_key.ptr.as_ptr(),
     );
+    cleanup_cuda_trivium_init(streams.ffi(), std::ptr::addr_of_mut!(mem_ptr));
 
-    cleanup_cuda_trivium_generate_keystream_64(streams.ffi(), std::ptr::addr_of_mut!(mem_ptr));
-
-    update_noise_degree(keystream_output, &cuda_ffi_keystream);
+    update_noise_degree(a, &ffi_a);
+    update_noise_degree(b, &ffi_b);
+    update_noise_degree(c, &ffi_c);
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -9578,11 +9623,13 @@ pub(crate) unsafe fn cuda_backend_trivium_generate_keystream<T: UnsignedInteger,
 /// - The data must not be moved or dropped while being used by the CUDA kernel.
 /// - This function assumes exclusive access to the passed data; violating this may lead to
 ///   undefined behavior.
-pub(crate) unsafe fn cuda_backend_kreyvium_generate_keystream<T: UnsignedInteger, B: Numeric>(
+pub(crate) unsafe fn cuda_backend_trivium_step<T: UnsignedInteger, B: Numeric>(
     streams: &CudaStreams,
     keystream_output: &mut CudaRadixCiphertext,
-    key: &CudaRadixCiphertext,
-    iv: &CudaRadixCiphertext,
+    a: &mut CudaRadixCiphertext,
+    b: &mut CudaRadixCiphertext,
+    c: &mut CudaRadixCiphertext,
+    num_steps: u32,
     bootstrapping_key: &CudaVec<B>,
     keyswitch_key: &CudaVec<T>,
     message_modulus: MessageModulus,
@@ -9591,42 +9638,62 @@ pub(crate) unsafe fn cuda_backend_kreyvium_generate_keystream<T: UnsignedInteger
     ks_level: DecompositionLevelCount,
     ks_base_log: DecompositionBaseLog,
     ms_noise_reduction_configuration: Option<&CudaModulusSwitchNoiseReductionConfiguration>,
-    num_steps: u32,
 ) {
+    assert_eq!(message_modulus.0, TRIVIUM_REQUIRED_MESSAGE_MODULUS);
+    assert_eq!(carry_modulus.0, TRIVIUM_REQUIRED_CARRY_MODULUS);
+
     let bsk_params = bsk.params_ffi();
-    let mut keystream_degrees = keystream_output
+    let mut out_deg = keystream_output
         .info
         .blocks
         .iter()
         .map(|b| b.degree.0)
-        .collect();
-    let mut keystream_noise_levels = keystream_output
+        .collect::<Vec<_>>();
+    let mut out_noise = keystream_output
         .info
         .blocks
         .iter()
         .map(|b| b.noise_level.0)
-        .collect();
-    let mut cuda_ffi_keystream = prepare_cuda_radix_ffi(
-        keystream_output,
-        &mut keystream_degrees,
-        &mut keystream_noise_levels,
-    );
+        .collect::<Vec<_>>();
+    let mut ffi_out = prepare_cuda_radix_ffi(keystream_output, &mut out_deg, &mut out_noise);
 
-    let mut key_degrees = key.info.blocks.iter().map(|b| b.degree.0).collect();
-    let mut key_noise_levels = key.info.blocks.iter().map(|b| b.noise_level.0).collect();
-    let cuda_ffi_key = prepare_cuda_radix_ffi(key, &mut key_degrees, &mut key_noise_levels);
+    let mut a_deg = a.info.blocks.iter().map(|b| b.degree.0).collect::<Vec<_>>();
+    let mut a_noise = a
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.noise_level.0)
+        .collect::<Vec<_>>();
+    let mut ffi_a = prepare_cuda_radix_ffi(a, &mut a_deg, &mut a_noise);
 
-    let mut iv_degrees = iv.info.blocks.iter().map(|b| b.degree.0).collect();
-    let mut iv_noise_levels = iv.info.blocks.iter().map(|b| b.noise_level.0).collect();
-    let cuda_ffi_iv = prepare_cuda_radix_ffi(iv, &mut iv_degrees, &mut iv_noise_levels);
+    let mut b_deg = b.info.blocks.iter().map(|b| b.degree.0).collect::<Vec<_>>();
+    let mut b_noise = b
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.noise_level.0)
+        .collect::<Vec<_>>();
+    let mut ffi_b = prepare_cuda_radix_ffi(b, &mut b_deg, &mut b_noise);
 
-    let num_inputs = u32::try_from(key.info.blocks.len() / 128).unwrap();
+    let mut c_deg = c.info.blocks.iter().map(|b| b.degree.0).collect::<Vec<_>>();
+    let mut c_noise = c
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.noise_level.0)
+        .collect::<Vec<_>>();
+    let mut ffi_c = prepare_cuda_radix_ffi(c, &mut c_deg, &mut c_noise);
+
+    let a_len = a.info.blocks.len();
+    assert!(a_len > 0 && a_len.is_multiple_of(TRIVIUM_REGISTER_A_BITS));
+
+    let num_inputs = u32::try_from(a_len / TRIVIUM_REGISTER_A_BITS).unwrap();
+    assert!(num_inputs <= TRIVIUM_MAX_NUM_INPUTS);
 
     let noise_reduction_type = resolve_ms_noise_reduction_config(ms_noise_reduction_configuration);
-
     let mut mem_ptr: *mut i8 = std::ptr::null_mut();
 
-    scratch_cuda_kreyvium_generate_keystream_64_async(
+    scratch_cuda_trivium_step_async(
         streams.ffi(),
         std::ptr::addr_of_mut!(mem_ptr),
         bsk_params,
@@ -9638,20 +9705,317 @@ pub(crate) unsafe fn cuda_backend_kreyvium_generate_keystream<T: UnsignedInteger
         noise_reduction_type as u32,
         num_inputs,
     );
-
-    cuda_kreyvium_generate_keystream_64_async(
+    cuda_trivium_step_async(
         streams.ffi(),
-        &raw mut cuda_ffi_keystream,
-        &raw const cuda_ffi_key,
-        &raw const cuda_ffi_iv,
+        &raw mut ffi_out,
+        &raw mut ffi_a,
+        &raw mut ffi_b,
+        &raw mut ffi_c,
         num_inputs,
         num_steps,
         mem_ptr,
         bootstrapping_key.ptr.as_ptr(),
         keyswitch_key.ptr.as_ptr(),
     );
+    cleanup_cuda_trivium_step(streams.ffi(), std::ptr::addr_of_mut!(mem_ptr));
 
-    cleanup_cuda_kreyvium_generate_keystream_64(streams.ffi(), std::ptr::addr_of_mut!(mem_ptr));
+    update_noise_degree(keystream_output, &ffi_out);
+    update_noise_degree(a, &ffi_a);
+    update_noise_degree(b, &ffi_b);
+    update_noise_degree(c, &ffi_c);
+}
 
-    update_noise_degree(keystream_output, &cuda_ffi_keystream);
+#[allow(clippy::too_many_arguments)]
+/// # Safety
+///
+/// - The data must not be moved or dropped while being used by the CUDA kernel.
+/// - This function assumes exclusive access to the passed data; violating this may lead to
+///   undefined behavior.
+pub(crate) unsafe fn cuda_backend_kreyvium_init<T: UnsignedInteger, B: Numeric>(
+    streams: &CudaStreams,
+    a: &mut CudaRadixCiphertext,
+    b: &mut CudaRadixCiphertext,
+    c: &mut CudaRadixCiphertext,
+    k_reg: &mut CudaRadixCiphertext,
+    iv_reg: &mut CudaRadixCiphertext,
+    k_offset: &mut u32,
+    iv_offset: &mut u32,
+    key: &CudaRadixCiphertext,
+    iv: &CudaRadixCiphertext,
+    bootstrapping_key: &CudaVec<B>,
+    keyswitch_key: &CudaVec<T>,
+    message_modulus: MessageModulus,
+    carry_modulus: CarryModulus,
+    bsk: &impl CudaBskParams,
+    ks_level: DecompositionLevelCount,
+    ks_base_log: DecompositionBaseLog,
+    ms_noise_reduction_configuration: Option<&CudaModulusSwitchNoiseReductionConfiguration>,
+) {
+    assert_eq!(message_modulus.0, TRIVIUM_REQUIRED_MESSAGE_MODULUS);
+    assert_eq!(carry_modulus.0, TRIVIUM_REQUIRED_CARRY_MODULUS);
+
+    let bsk_params = bsk.params_ffi();
+    let mut a_deg = a.info.blocks.iter().map(|b| b.degree.0).collect::<Vec<_>>();
+    let mut a_noise = a
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.noise_level.0)
+        .collect::<Vec<_>>();
+    let mut ffi_a = prepare_cuda_radix_ffi(a, &mut a_deg, &mut a_noise);
+    let mut b_deg = b.info.blocks.iter().map(|b| b.degree.0).collect::<Vec<_>>();
+    let mut b_noise = b
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.noise_level.0)
+        .collect::<Vec<_>>();
+    let mut ffi_b = prepare_cuda_radix_ffi(b, &mut b_deg, &mut b_noise);
+    let mut c_deg = c.info.blocks.iter().map(|b| b.degree.0).collect::<Vec<_>>();
+    let mut c_noise = c
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.noise_level.0)
+        .collect::<Vec<_>>();
+    let mut ffi_c = prepare_cuda_radix_ffi(c, &mut c_deg, &mut c_noise);
+    let mut k_deg = k_reg
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.degree.0)
+        .collect::<Vec<_>>();
+    let mut k_noise = k_reg
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.noise_level.0)
+        .collect::<Vec<_>>();
+    let mut ffi_k = prepare_cuda_radix_ffi(k_reg, &mut k_deg, &mut k_noise);
+    let mut iv_reg_deg = iv_reg
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.degree.0)
+        .collect::<Vec<_>>();
+    let mut iv_reg_noise = iv_reg
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.noise_level.0)
+        .collect::<Vec<_>>();
+    let mut ffi_iv_reg = prepare_cuda_radix_ffi(iv_reg, &mut iv_reg_deg, &mut iv_reg_noise);
+
+    let mut key_deg = key
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.degree.0)
+        .collect::<Vec<_>>();
+    let mut key_noise = key
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.noise_level.0)
+        .collect::<Vec<_>>();
+    let ffi_key = prepare_cuda_radix_ffi(key, &mut key_deg, &mut key_noise);
+    let mut iv_deg = iv
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.degree.0)
+        .collect::<Vec<_>>();
+    let mut iv_noise = iv
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.noise_level.0)
+        .collect::<Vec<_>>();
+    let ffi_iv = prepare_cuda_radix_ffi(iv, &mut iv_deg, &mut iv_noise);
+
+    let key_len = key.info.blocks.len();
+    assert!(key_len > 0 && key_len.is_multiple_of(KREYVIUM_KEY_BITS));
+
+    let num_inputs = u32::try_from(key_len / KREYVIUM_KEY_BITS).unwrap();
+    assert!(num_inputs <= TRIVIUM_MAX_NUM_INPUTS);
+
+    let noise_reduction_type = resolve_ms_noise_reduction_config(ms_noise_reduction_configuration);
+    let mut mem_ptr: *mut i8 = std::ptr::null_mut();
+
+    scratch_cuda_kreyvium_init_async(
+        streams.ffi(),
+        std::ptr::addr_of_mut!(mem_ptr),
+        bsk_params,
+        u32::try_from(ks_level.0).unwrap(),
+        u32::try_from(ks_base_log.0).unwrap(),
+        u32::try_from(message_modulus.0).unwrap(),
+        u32::try_from(carry_modulus.0).unwrap(),
+        true,
+        noise_reduction_type as u32,
+        num_inputs,
+    );
+    cuda_kreyvium_init_async(
+        streams.ffi(),
+        &raw mut ffi_a,
+        &raw mut ffi_b,
+        &raw mut ffi_c,
+        &raw mut ffi_k,
+        &raw mut ffi_iv_reg,
+        k_offset,
+        iv_offset,
+        &raw const ffi_key,
+        &raw const ffi_iv,
+        num_inputs,
+        mem_ptr,
+        bootstrapping_key.ptr.as_ptr(),
+        keyswitch_key.ptr.as_ptr(),
+    );
+    cleanup_cuda_kreyvium_init(streams.ffi(), std::ptr::addr_of_mut!(mem_ptr));
+
+    update_noise_degree(a, &ffi_a);
+    update_noise_degree(b, &ffi_b);
+    update_noise_degree(c, &ffi_c);
+    update_noise_degree(k_reg, &ffi_k);
+    update_noise_degree(iv_reg, &ffi_iv_reg);
+}
+
+#[allow(clippy::too_many_arguments)]
+/// # Safety
+///
+/// - The data must not be moved or dropped while being used by the CUDA kernel.
+/// - This function assumes exclusive access to the passed data; violating this may lead to
+///   undefined behavior.
+pub(crate) unsafe fn cuda_backend_kreyvium_step<T: UnsignedInteger, B: Numeric>(
+    streams: &CudaStreams,
+    keystream_output: &mut CudaRadixCiphertext,
+    a: &mut CudaRadixCiphertext,
+    b: &mut CudaRadixCiphertext,
+    c: &mut CudaRadixCiphertext,
+    k_reg: &mut CudaRadixCiphertext,
+    iv_reg: &mut CudaRadixCiphertext,
+    k_offset: &mut u32,
+    iv_offset: &mut u32,
+    num_steps: u32,
+    bootstrapping_key: &CudaVec<B>,
+    keyswitch_key: &CudaVec<T>,
+    message_modulus: MessageModulus,
+    carry_modulus: CarryModulus,
+    bsk: &impl CudaBskParams,
+    ks_level: DecompositionLevelCount,
+    ks_base_log: DecompositionBaseLog,
+    ms_noise_reduction_configuration: Option<&CudaModulusSwitchNoiseReductionConfiguration>,
+) {
+    assert_eq!(message_modulus.0, TRIVIUM_REQUIRED_MESSAGE_MODULUS);
+    assert_eq!(carry_modulus.0, TRIVIUM_REQUIRED_CARRY_MODULUS);
+
+    let bsk_params = bsk.params_ffi();
+    let mut out_deg = keystream_output
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.degree.0)
+        .collect::<Vec<_>>();
+    let mut out_noise = keystream_output
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.noise_level.0)
+        .collect::<Vec<_>>();
+    let mut ffi_out = prepare_cuda_radix_ffi(keystream_output, &mut out_deg, &mut out_noise);
+    let mut a_deg = a.info.blocks.iter().map(|b| b.degree.0).collect::<Vec<_>>();
+    let mut a_noise = a
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.noise_level.0)
+        .collect::<Vec<_>>();
+    let mut ffi_a = prepare_cuda_radix_ffi(a, &mut a_deg, &mut a_noise);
+    let mut b_deg = b.info.blocks.iter().map(|b| b.degree.0).collect::<Vec<_>>();
+    let mut b_noise = b
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.noise_level.0)
+        .collect::<Vec<_>>();
+    let mut ffi_b = prepare_cuda_radix_ffi(b, &mut b_deg, &mut b_noise);
+    let mut c_deg = c.info.blocks.iter().map(|b| b.degree.0).collect::<Vec<_>>();
+    let mut c_noise = c
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.noise_level.0)
+        .collect::<Vec<_>>();
+    let mut ffi_c = prepare_cuda_radix_ffi(c, &mut c_deg, &mut c_noise);
+    let mut k_deg = k_reg
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.degree.0)
+        .collect::<Vec<_>>();
+    let mut k_noise = k_reg
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.noise_level.0)
+        .collect::<Vec<_>>();
+    let mut ffi_k = prepare_cuda_radix_ffi(k_reg, &mut k_deg, &mut k_noise);
+    let mut iv_reg_deg = iv_reg
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.degree.0)
+        .collect::<Vec<_>>();
+    let mut iv_reg_noise = iv_reg
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.noise_level.0)
+        .collect::<Vec<_>>();
+    let mut ffi_iv_reg = prepare_cuda_radix_ffi(iv_reg, &mut iv_reg_deg, &mut iv_reg_noise);
+
+    let a_len = a.info.blocks.len();
+    assert!(a_len > 0 && a_len.is_multiple_of(TRIVIUM_REGISTER_A_BITS));
+
+    let num_inputs = u32::try_from(a_len / TRIVIUM_REGISTER_A_BITS).unwrap();
+    assert!(num_inputs <= TRIVIUM_MAX_NUM_INPUTS);
+
+    let noise_reduction_type = resolve_ms_noise_reduction_config(ms_noise_reduction_configuration);
+    let mut mem_ptr: *mut i8 = std::ptr::null_mut();
+
+    scratch_cuda_kreyvium_step_async(
+        streams.ffi(),
+        std::ptr::addr_of_mut!(mem_ptr),
+        bsk_params,
+        u32::try_from(ks_level.0).unwrap(),
+        u32::try_from(ks_base_log.0).unwrap(),
+        u32::try_from(message_modulus.0).unwrap(),
+        u32::try_from(carry_modulus.0).unwrap(),
+        true,
+        noise_reduction_type as u32,
+        num_inputs,
+    );
+    cuda_kreyvium_step_async(
+        streams.ffi(),
+        &raw mut ffi_out,
+        &raw mut ffi_a,
+        &raw mut ffi_b,
+        &raw mut ffi_c,
+        &raw mut ffi_k,
+        &raw mut ffi_iv_reg,
+        k_offset,
+        iv_offset,
+        num_inputs,
+        num_steps,
+        mem_ptr,
+        bootstrapping_key.ptr.as_ptr(),
+        keyswitch_key.ptr.as_ptr(),
+    );
+    cleanup_cuda_kreyvium_step(streams.ffi(), std::ptr::addr_of_mut!(mem_ptr));
+
+    update_noise_degree(keystream_output, &ffi_out);
+    update_noise_degree(a, &ffi_a);
+    update_noise_degree(b, &ffi_b);
+    update_noise_degree(c, &ffi_c);
+    update_noise_degree(k_reg, &ffi_k);
+    update_noise_degree(iv_reg, &ffi_iv_reg);
 }

--- a/tfhe/src/integer/gpu/server_key/radix/kreyvium.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/kreyvium.rs
@@ -1,11 +1,31 @@
 use crate::core_crypto::gpu::CudaStreams;
 use crate::integer::gpu::ciphertext::{CudaIntegerRadixCiphertext, CudaUnsignedRadixCiphertext};
-use crate::integer::gpu::cuda_backend_kreyvium_generate_keystream;
 use crate::integer::gpu::server_key::{
     CudaBootstrappingKey, CudaDynamicKeyswitchingKey, CudaServerKey,
 };
+use crate::integer::gpu::{cuda_backend_kreyvium_init, cuda_backend_kreyvium_step};
+
+const KREYVIUM_KEY_BITS: usize = 128;
+const KREYVIUM_IV_BITS: usize = 128;
+const REGISTER_A_BITS: usize = 93;
+const REGISTER_B_BITS: usize = 84;
+const REGISTER_C_BITS: usize = 111;
+const BATCH_SIZE: usize = 64;
+
+pub struct CudaKreyviumState {
+    pub a: CudaUnsignedRadixCiphertext,  // REGISTER_A_BITS
+    pub b: CudaUnsignedRadixCiphertext,  // REGISTER_B_BITS
+    pub c: CudaUnsignedRadixCiphertext,  // REGISTER_C_BITS
+    pub k: CudaUnsignedRadixCiphertext,  // KREYVIUM_KEY_BITS
+    pub iv: CudaUnsignedRadixCiphertext, // KREYVIUM_IV_BITS
+    pub k_offset: u32,
+    pub iv_offset: u32,
+}
 
 impl CudaServerKey {
+    // Generates a Kreyvium keystream in a single call.
+    // Initializes a transient state, runs the warmup, generates the keystream,
+    // then drops the state.
     pub fn kreyvium_generate_keystream(
         &self,
         key: &CudaUnsignedRadixCiphertext,
@@ -13,38 +33,36 @@ impl CudaServerKey {
         num_steps: usize,
         streams: &CudaStreams,
     ) -> crate::Result<CudaUnsignedRadixCiphertext> {
-        let num_key_bits = 128;
-        let num_iv_bits = 128;
-        let batch_size = 64;
+        let mut state = self.kreyvium_init(key, iv, streams)?;
+        self.kreyvium_next(&mut state, num_steps, streams)
+    }
 
-        if key.as_ref().d_blocks.lwe_ciphertext_count().0 != num_key_bits {
+    // Initializes the Kreyvium state for stateful keystream generation.
+    // It loads the key and IV, executes the warmup steps, and returns the persistent state.
+    //
+    pub fn kreyvium_init(
+        &self,
+        key: &CudaUnsignedRadixCiphertext,
+        iv: &CudaUnsignedRadixCiphertext,
+        streams: &CudaStreams,
+    ) -> crate::Result<CudaKreyviumState> {
+        if key.as_ref().d_blocks.lwe_ciphertext_count().0 != KREYVIUM_KEY_BITS
+            || iv.as_ref().d_blocks.lwe_ciphertext_count().0 != KREYVIUM_IV_BITS
+        {
             return Err(format!(
-                "Input key must contain {} encrypted bits, but contains {}",
-                num_key_bits,
-                key.as_ref().d_blocks.lwe_ciphertext_count().0
-            )
-            .into());
+                "Input key must contain {KREYVIUM_KEY_BITS} and IV must contain {KREYVIUM_IV_BITS} encrypted bits."
+            ).into());
         }
 
-        if iv.as_ref().d_blocks.lwe_ciphertext_count().0 != num_iv_bits {
-            return Err(format!(
-                "Input IV must contain {} encrypted bits, but contains {}",
-                num_iv_bits,
-                iv.as_ref().d_blocks.lwe_ciphertext_count().0
-            )
-            .into());
-        }
-
-        if !num_steps.is_multiple_of(batch_size) {
-            return Err(format!(
-                "The number of steps must be a multiple of {batch_size}, but is {num_steps}"
-            )
-            .into());
-        }
-
-        let num_output_bits = num_steps;
-        let mut keystream: CudaUnsignedRadixCiphertext =
-            self.create_trivial_zero_radix(num_output_bits, streams);
+        let mut state = CudaKreyviumState {
+            a: self.create_trivial_zero_radix(REGISTER_A_BITS, streams),
+            b: self.create_trivial_zero_radix(REGISTER_B_BITS, streams),
+            c: self.create_trivial_zero_radix(REGISTER_C_BITS, streams),
+            k: self.create_trivial_zero_radix(KREYVIUM_KEY_BITS, streams),
+            iv: self.create_trivial_zero_radix(KREYVIUM_IV_BITS, streams),
+            k_offset: 0,
+            iv_offset: 0,
+        };
 
         let CudaDynamicKeyswitchingKey::Standard(computing_ks_key) = &self.key_switching_key else {
             panic!("Only the standard atomic pattern is supported on GPU")
@@ -53,9 +71,15 @@ impl CudaServerKey {
         unsafe {
             match &self.bootstrapping_key {
                 CudaBootstrappingKey::Classic(d_bsk) => {
-                    cuda_backend_kreyvium_generate_keystream(
+                    cuda_backend_kreyvium_init(
                         streams,
-                        keystream.as_mut(),
+                        state.a.as_mut(),
+                        state.b.as_mut(),
+                        state.c.as_mut(),
+                        state.k.as_mut(),
+                        state.iv.as_mut(),
+                        &mut state.k_offset,
+                        &mut state.iv_offset,
                         key.as_ref(),
                         iv.as_ref(),
                         &d_bsk.d_vec,
@@ -66,13 +90,18 @@ impl CudaServerKey {
                         computing_ks_key.decomposition_level_count(),
                         computing_ks_key.decomposition_base_log(),
                         d_bsk.ms_noise_reduction_configuration.as_ref(),
-                        num_steps as u32,
                     );
                 }
                 CudaBootstrappingKey::MultiBit(d_multibit_bsk) => {
-                    cuda_backend_kreyvium_generate_keystream(
+                    cuda_backend_kreyvium_init(
                         streams,
-                        keystream.as_mut(),
+                        state.a.as_mut(),
+                        state.b.as_mut(),
+                        state.c.as_mut(),
+                        state.k.as_mut(),
+                        state.iv.as_mut(),
+                        &mut state.k_offset,
+                        &mut state.iv_offset,
                         key.as_ref(),
                         iv.as_ref(),
                         &d_multibit_bsk.d_vec,
@@ -83,7 +112,75 @@ impl CudaServerKey {
                         computing_ks_key.decomposition_level_count(),
                         computing_ks_key.decomposition_base_log(),
                         None,
+                    );
+                }
+            }
+        }
+        Ok(state)
+    }
+
+    // Generates the next chunk of keystream bits from an existing Kreyvium state.
+    // Updates the state in place, allowing consecutive calls to produce a continuous stream.
+    //
+    pub fn kreyvium_next(
+        &self,
+        state: &mut CudaKreyviumState,
+        num_steps: usize,
+        streams: &CudaStreams,
+    ) -> crate::Result<CudaUnsignedRadixCiphertext> {
+        if !num_steps.is_multiple_of(BATCH_SIZE) {
+            return Err(format!("The number of steps must be a multiple of {BATCH_SIZE}.").into());
+        }
+        let mut keystream: CudaUnsignedRadixCiphertext =
+            self.create_trivial_zero_radix(num_steps, streams);
+        let CudaDynamicKeyswitchingKey::Standard(computing_ks_key) = &self.key_switching_key else {
+            panic!("Only the standard atomic pattern is supported on GPU")
+        };
+
+        unsafe {
+            match &self.bootstrapping_key {
+                CudaBootstrappingKey::Classic(d_bsk) => {
+                    cuda_backend_kreyvium_step(
+                        streams,
+                        keystream.as_mut(),
+                        state.a.as_mut(),
+                        state.b.as_mut(),
+                        state.c.as_mut(),
+                        state.k.as_mut(),
+                        state.iv.as_mut(),
+                        &mut state.k_offset,
+                        &mut state.iv_offset,
                         num_steps as u32,
+                        &d_bsk.d_vec,
+                        &computing_ks_key.d_vec,
+                        self.message_modulus,
+                        self.carry_modulus,
+                        d_bsk,
+                        computing_ks_key.decomposition_level_count(),
+                        computing_ks_key.decomposition_base_log(),
+                        d_bsk.ms_noise_reduction_configuration.as_ref(),
+                    );
+                }
+                CudaBootstrappingKey::MultiBit(d_multibit_bsk) => {
+                    cuda_backend_kreyvium_step(
+                        streams,
+                        keystream.as_mut(),
+                        state.a.as_mut(),
+                        state.b.as_mut(),
+                        state.c.as_mut(),
+                        state.k.as_mut(),
+                        state.iv.as_mut(),
+                        &mut state.k_offset,
+                        &mut state.iv_offset,
+                        num_steps as u32,
+                        &d_multibit_bsk.d_vec,
+                        &computing_ks_key.d_vec,
+                        self.message_modulus,
+                        self.carry_modulus,
+                        d_multibit_bsk,
+                        computing_ks_key.decomposition_level_count(),
+                        computing_ks_key.decomposition_base_log(),
+                        None,
                     );
                 }
             }

--- a/tfhe/src/integer/gpu/server_key/radix/tests_unsigned/mod.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/tests_unsigned/mod.rs
@@ -106,6 +106,53 @@ impl<F> GpuFunctionExecutor<F> {
     }
 }
 
+impl<'a, S, FInit, FNext>
+    FunctionExecutor<
+        (&'a RadixCiphertext, &'a RadixCiphertext, &'a [usize]),
+        crate::Result<Vec<RadixCiphertext>>,
+    > for GpuFunctionExecutor<(FInit, FNext)>
+where
+    FInit: Fn(
+        &CudaServerKey,
+        &CudaUnsignedRadixCiphertext,
+        &CudaUnsignedRadixCiphertext,
+        &CudaStreams,
+    ) -> crate::Result<S>,
+    FNext: Fn(
+        &CudaServerKey,
+        &mut S,
+        usize,
+        &CudaStreams,
+    ) -> crate::Result<CudaUnsignedRadixCiphertext>,
+{
+    fn setup(&mut self, cks: &RadixClientKey, sks: Arc<ServerKey>) {
+        self.setup_from_keys(cks, &sks);
+    }
+
+    fn execute(
+        &mut self,
+        input: (&'a RadixCiphertext, &'a RadixCiphertext, &'a [usize]),
+    ) -> crate::Result<Vec<RadixCiphertext>> {
+        let context = self
+            .context
+            .as_ref()
+            .expect("setup was not properly called");
+
+        let d_key = CudaUnsignedRadixCiphertext::from_radix_ciphertext(input.0, &context.streams);
+        let d_iv = CudaUnsignedRadixCiphertext::from_radix_ciphertext(input.1, &context.streams);
+
+        let mut state = (self.func.0)(&context.sks, &d_key, &d_iv, &context.streams)?;
+
+        let mut results = Vec::with_capacity(input.2.len());
+        for &steps in input.2 {
+            let d_res = (self.func.1)(&context.sks, &mut state, steps, &context.streams)?;
+            results.push(d_res.to_radix_ciphertext(&context.streams));
+        }
+
+        Ok(results)
+    }
+}
+
 impl<'a, F>
     FunctionExecutor<
         (&'a RadixCiphertext, &'a RadixCiphertext, usize),

--- a/tfhe/src/integer/gpu/server_key/radix/tests_unsigned/test_kreyvium.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/tests_unsigned/test_kreyvium.rs
@@ -3,7 +3,7 @@ use crate::integer::gpu::server_key::radix::tests_unsigned::{
 };
 use crate::integer::gpu::CudaServerKey;
 use crate::integer::server_key::radix_parallel::tests_unsigned::test_kreyvium::{
-    kreyvium_comparison_test, kreyvium_test_vector_1_test,
+    kreyvium_comparison_test, kreyvium_stateful_comparison_test, kreyvium_test_vector_1_test,
 };
 use crate::shortint::parameters::{
     TestParameters, PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
@@ -14,6 +14,10 @@ create_gpu_parameterized_test!(integer_kreyvium_test_vector_1 {
 });
 
 create_gpu_parameterized_test!(integer_kreyvium_comparison {
+    PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128
+});
+
+create_gpu_parameterized_test!(integer_kreyvium_stateful_comparison {
     PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128
 });
 
@@ -31,4 +35,13 @@ where
 {
     let executor = GpuFunctionExecutor::new(&CudaServerKey::kreyvium_generate_keystream);
     kreyvium_comparison_test(param, executor);
+}
+
+fn integer_kreyvium_stateful_comparison<P>(param: P)
+where
+    P: Into<TestParameters>,
+{
+    let executor =
+        GpuFunctionExecutor::new((CudaServerKey::kreyvium_init, CudaServerKey::kreyvium_next));
+    kreyvium_stateful_comparison_test(param, executor);
 }

--- a/tfhe/src/integer/gpu/server_key/radix/tests_unsigned/test_trivium.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/tests_unsigned/test_trivium.rs
@@ -3,7 +3,9 @@ use crate::integer::gpu::server_key::radix::tests_unsigned::{
 };
 use crate::integer::gpu::CudaServerKey;
 use crate::integer::server_key::radix_parallel::tests_unsigned::test_trivium::{
-    trivium_comparison_test, trivium_test_vector_1_test, trivium_test_vector_2_test,
+    trivium_comparison_test, trivium_stateful_comparison_test, trivium_stateful_test_vector_1_test,
+    trivium_stateful_test_vector_2_test, trivium_stateful_test_vector_3_test,
+    trivium_stateful_test_vector_4_test, trivium_test_vector_1_test, trivium_test_vector_2_test,
     trivium_test_vector_3_test, trivium_test_vector_4_test,
 };
 use crate::shortint::parameters::{
@@ -27,6 +29,26 @@ create_gpu_parameterized_test!(integer_trivium_test_vector_4 {
 });
 
 create_gpu_parameterized_test!(integer_trivium_comparison {
+    PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128
+});
+
+create_gpu_parameterized_test!(integer_trivium_stateful_test_vector_1 {
+    PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128
+});
+
+create_gpu_parameterized_test!(integer_trivium_stateful_test_vector_2 {
+    PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128
+});
+
+create_gpu_parameterized_test!(integer_trivium_stateful_test_vector_3 {
+    PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128
+});
+
+create_gpu_parameterized_test!(integer_trivium_stateful_test_vector_4 {
+    PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128
+});
+
+create_gpu_parameterized_test!(integer_trivium_stateful_comparison {
     PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128
 });
 
@@ -68,4 +90,49 @@ where
 {
     let executor = GpuFunctionExecutor::new(&CudaServerKey::trivium_generate_keystream);
     trivium_comparison_test(param, executor);
+}
+
+fn integer_trivium_stateful_test_vector_1<P>(param: P)
+where
+    P: Into<TestParameters>,
+{
+    let executor =
+        GpuFunctionExecutor::new((CudaServerKey::trivium_init, CudaServerKey::trivium_next));
+    trivium_stateful_test_vector_1_test(param, executor);
+}
+
+fn integer_trivium_stateful_test_vector_2<P>(param: P)
+where
+    P: Into<TestParameters>,
+{
+    let executor =
+        GpuFunctionExecutor::new((CudaServerKey::trivium_init, CudaServerKey::trivium_next));
+    trivium_stateful_test_vector_2_test(param, executor);
+}
+
+fn integer_trivium_stateful_test_vector_3<P>(param: P)
+where
+    P: Into<TestParameters>,
+{
+    let executor =
+        GpuFunctionExecutor::new((CudaServerKey::trivium_init, CudaServerKey::trivium_next));
+    trivium_stateful_test_vector_3_test(param, executor);
+}
+
+fn integer_trivium_stateful_test_vector_4<P>(param: P)
+where
+    P: Into<TestParameters>,
+{
+    let executor =
+        GpuFunctionExecutor::new((CudaServerKey::trivium_init, CudaServerKey::trivium_next));
+    trivium_stateful_test_vector_4_test(param, executor);
+}
+
+fn integer_trivium_stateful_comparison<P>(param: P)
+where
+    P: Into<TestParameters>,
+{
+    let executor =
+        GpuFunctionExecutor::new((CudaServerKey::trivium_init, CudaServerKey::trivium_next));
+    trivium_stateful_comparison_test(param, executor);
 }

--- a/tfhe/src/integer/gpu/server_key/radix/trivium.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/trivium.rs
@@ -1,18 +1,27 @@
 use crate::core_crypto::gpu::CudaStreams;
 use crate::integer::gpu::ciphertext::{CudaIntegerRadixCiphertext, CudaUnsignedRadixCiphertext};
-use crate::integer::gpu::cuda_backend_trivium_generate_keystream;
 use crate::integer::gpu::server_key::{
     CudaBootstrappingKey, CudaDynamicKeyswitchingKey, CudaServerKey,
 };
+use crate::integer::gpu::{cuda_backend_trivium_init, cuda_backend_trivium_step};
+
+const TRIVIUM_KEY_BITS: usize = 80;
+const TRIVIUM_IV_BITS: usize = 80;
+const REGISTER_A_BITS: usize = 93;
+const REGISTER_B_BITS: usize = 84;
+const REGISTER_C_BITS: usize = 111;
+const BATCH_SIZE: usize = 64;
+
+pub struct CudaTriviumState {
+    pub a: CudaUnsignedRadixCiphertext, // REGISTER_A_BITS
+    pub b: CudaUnsignedRadixCiphertext, // REGISTER_B_BITS
+    pub c: CudaUnsignedRadixCiphertext, // REGISTER_C_BITS
+}
 
 impl CudaServerKey {
-    /// Generates a Trivium keystream homomorphically on the GPU.
-    ///
-    /// # Arguments
-    /// * `key` - The encrypted secret key.
-    /// * `iv` - The encrypted initialization vector.
-    /// * `num_steps` - The number of keystream bits to generate per input.
-    /// * `streams` - The CUDA streams to use for execution.
+    /// Generates a Trivium keystream homomorphically on the GPU in a single
+    /// call. Initializes a transient state, runs the warmup, generates the
+    /// keystream, then drops the state.
     pub fn trivium_generate_keystream(
         &self,
         key: &CudaUnsignedRadixCiphertext,
@@ -20,38 +29,29 @@ impl CudaServerKey {
         num_steps: usize,
         streams: &CudaStreams,
     ) -> crate::Result<CudaUnsignedRadixCiphertext> {
-        let num_key_bits = 80;
-        let num_iv_bits = 80;
-        let batch_size = 64;
+        let mut state = self.trivium_init(key, iv, streams)?;
+        self.trivium_next(&mut state, num_steps, streams)
+    }
 
-        if key.as_ref().d_blocks.lwe_ciphertext_count().0 != num_key_bits {
+    pub fn trivium_init(
+        &self,
+        key: &CudaUnsignedRadixCiphertext,
+        iv: &CudaUnsignedRadixCiphertext,
+        streams: &CudaStreams,
+    ) -> crate::Result<CudaTriviumState> {
+        if key.as_ref().d_blocks.lwe_ciphertext_count().0 != TRIVIUM_KEY_BITS
+            || iv.as_ref().d_blocks.lwe_ciphertext_count().0 != TRIVIUM_IV_BITS
+        {
             return Err(format!(
-                "Input key must contain {} encrypted bits, but contains {}",
-                num_key_bits,
-                key.as_ref().d_blocks.lwe_ciphertext_count().0
-            )
-            .into());
+                "Input key must contain {TRIVIUM_KEY_BITS} and IV must contain {TRIVIUM_IV_BITS} encrypted bits."
+            ).into());
         }
 
-        if iv.as_ref().d_blocks.lwe_ciphertext_count().0 != num_iv_bits {
-            return Err(format!(
-                "Input IV must contain {} encrypted bits, but contains {}",
-                num_iv_bits,
-                iv.as_ref().d_blocks.lwe_ciphertext_count().0
-            )
-            .into());
-        }
-
-        if !num_steps.is_multiple_of(batch_size) {
-            return Err(format!(
-                "The number of steps must be a multiple of {batch_size}, but is {num_steps}"
-            )
-            .into());
-        }
-
-        let num_output_bits = num_steps;
-        let mut keystream: CudaUnsignedRadixCiphertext =
-            self.create_trivial_zero_radix(num_output_bits, streams);
+        let mut state = CudaTriviumState {
+            a: self.create_trivial_zero_radix(REGISTER_A_BITS, streams),
+            b: self.create_trivial_zero_radix(REGISTER_B_BITS, streams),
+            c: self.create_trivial_zero_radix(REGISTER_C_BITS, streams),
+        };
 
         let CudaDynamicKeyswitchingKey::Standard(computing_ks_key) = &self.key_switching_key else {
             panic!("Only the standard atomic pattern is supported on GPU")
@@ -60,9 +60,11 @@ impl CudaServerKey {
         unsafe {
             match &self.bootstrapping_key {
                 CudaBootstrappingKey::Classic(d_bsk) => {
-                    cuda_backend_trivium_generate_keystream(
+                    cuda_backend_trivium_init(
                         streams,
-                        keystream.as_mut(),
+                        state.a.as_mut(),
+                        state.b.as_mut(),
+                        state.c.as_mut(),
                         key.as_ref(),
                         iv.as_ref(),
                         &d_bsk.d_vec,
@@ -73,13 +75,14 @@ impl CudaServerKey {
                         computing_ks_key.decomposition_level_count(),
                         computing_ks_key.decomposition_base_log(),
                         d_bsk.ms_noise_reduction_configuration.as_ref(),
-                        num_steps as u32,
                     );
                 }
                 CudaBootstrappingKey::MultiBit(d_multibit_bsk) => {
-                    cuda_backend_trivium_generate_keystream(
+                    cuda_backend_trivium_init(
                         streams,
-                        keystream.as_mut(),
+                        state.a.as_mut(),
+                        state.b.as_mut(),
+                        state.c.as_mut(),
                         key.as_ref(),
                         iv.as_ref(),
                         &d_multibit_bsk.d_vec,
@@ -90,7 +93,66 @@ impl CudaServerKey {
                         computing_ks_key.decomposition_level_count(),
                         computing_ks_key.decomposition_base_log(),
                         None,
+                    );
+                }
+            }
+        }
+        Ok(state)
+    }
+
+    pub fn trivium_next(
+        &self,
+        state: &mut CudaTriviumState,
+        num_steps: usize,
+        streams: &CudaStreams,
+    ) -> crate::Result<CudaUnsignedRadixCiphertext> {
+        if !num_steps.is_multiple_of(BATCH_SIZE) {
+            return Err(format!("The number of steps must be a multiple of {BATCH_SIZE}.").into());
+        }
+
+        let mut keystream: CudaUnsignedRadixCiphertext =
+            self.create_trivial_zero_radix(num_steps, streams);
+
+        let CudaDynamicKeyswitchingKey::Standard(computing_ks_key) = &self.key_switching_key else {
+            panic!("Only the standard atomic pattern is supported on GPU")
+        };
+
+        unsafe {
+            match &self.bootstrapping_key {
+                CudaBootstrappingKey::Classic(d_bsk) => {
+                    cuda_backend_trivium_step(
+                        streams,
+                        keystream.as_mut(),
+                        state.a.as_mut(),
+                        state.b.as_mut(),
+                        state.c.as_mut(),
                         num_steps as u32,
+                        &d_bsk.d_vec,
+                        &computing_ks_key.d_vec,
+                        self.message_modulus,
+                        self.carry_modulus,
+                        d_bsk,
+                        computing_ks_key.decomposition_level_count(),
+                        computing_ks_key.decomposition_base_log(),
+                        d_bsk.ms_noise_reduction_configuration.as_ref(),
+                    );
+                }
+                CudaBootstrappingKey::MultiBit(d_multibit_bsk) => {
+                    cuda_backend_trivium_step(
+                        streams,
+                        keystream.as_mut(),
+                        state.a.as_mut(),
+                        state.b.as_mut(),
+                        state.c.as_mut(),
+                        num_steps as u32,
+                        &d_multibit_bsk.d_vec,
+                        &computing_ks_key.d_vec,
+                        self.message_modulus,
+                        self.carry_modulus,
+                        d_multibit_bsk,
+                        computing_ks_key.decomposition_level_count(),
+                        computing_ks_key.decomposition_base_log(),
+                        None,
                     );
                 }
             }

--- a/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_kreyvium.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_kreyvium.rs
@@ -263,3 +263,53 @@ where
         assert_eq!(fhe_output, cpu_output);
     }
 }
+
+// Integration test verifying the correctness of the stateful FHE Kreyvium implementation by
+// comparing consecutive keystream chunks against a cleartext CPU reference.
+//
+pub fn kreyvium_stateful_comparison_test<P, E>(param: P, mut executor: E)
+where
+    P: Into<TestParameters>,
+    E: for<'a> FunctionExecutor<
+        (&'a RadixCiphertext, &'a RadixCiphertext, &'a [usize]),
+        crate::Result<Vec<RadixCiphertext>>,
+    >,
+{
+    let param = param.into();
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
+    let cks = RadixClientKey::from((cks, 1));
+    let sks = Arc::new(sks);
+    executor.setup(&cks, sks);
+
+    let step_chunks = vec![64, 128, 64, 192];
+    let total_steps: usize = step_chunks.iter().sum();
+
+    let mut rng = rand::thread_rng();
+
+    let mut key_bits = vec![0u64; 128];
+    let mut iv_bits = vec![0u64; 128];
+
+    for i in 0..128 {
+        key_bits[i] = rng.gen_range(0..2);
+        iv_bits[i] = rng.gen_range(0..2);
+    }
+
+    let ct_key = encrypt_bits(&cks, &key_bits);
+    let ct_iv = encrypt_bits(&cks, &iv_bits);
+
+    let mut ref_kreyvium = KreyviumRef::new(&key_bits, &iv_bits);
+    let mut cpu_output = Vec::with_capacity(total_steps);
+    for _ in 0..total_steps {
+        cpu_output.push(ref_kreyvium.next_bit());
+    }
+
+    let output_radixes = executor.execute((&ct_key, &ct_iv, &step_chunks)).unwrap();
+
+    let mut fhe_output = Vec::new();
+    for out_radix in output_radixes {
+        fhe_output.extend(decrypt_bits(&cks, &out_radix));
+    }
+
+    assert_eq!(fhe_output.len(), cpu_output.len());
+    assert_eq!(fhe_output, cpu_output);
+}

--- a/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_trivium.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_trivium.rs
@@ -120,6 +120,10 @@ fn get_hexadecimal_string_from_lsb_first_stream(a: &[u8]) -> String {
     hexadecimal
 }
 
+// -----------------------------------------------------------------------------
+// MONOLITHIC TESTS
+// -----------------------------------------------------------------------------
+
 pub fn trivium_test_vector_1_test<P, E>(param: P, mut executor: E)
 where
     P: Into<TestParameters>,
@@ -299,6 +303,216 @@ where
 
         let output_radix = executor.execute((&ct_key, &ct_iv, num_steps)).unwrap();
         let fhe_output = decrypt_bits(&cks, &output_radix);
+
+        assert_eq!(cpu_output.len(), fhe_output.len());
+        assert_eq!(cpu_output, fhe_output, "Mismatch at iteration {i}");
+    }
+}
+
+// -----------------------------------------------------------------------------
+// STATEFUL TESTS
+// -----------------------------------------------------------------------------
+
+pub fn trivium_stateful_test_vector_1_test<P, E>(param: P, mut executor: E)
+where
+    P: Into<TestParameters>,
+    E: for<'a> FunctionExecutor<
+        (&'a RadixCiphertext, &'a RadixCiphertext, &'a [usize]),
+        crate::Result<Vec<RadixCiphertext>>,
+    >,
+{
+    let param = param.into();
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
+    let cks = RadixClientKey::from((cks, 1));
+    let sks = Arc::new(sks);
+    executor.setup(&cks, sks);
+
+    let key = vec![0u64; 80];
+    let iv = vec![0u64; 80];
+
+    let expected_output_0_63 = "FBE0BF265859051B517A2E4E239FC97F563203161907CF2DE7A8790FA1B2E9CDF75292030268B7382B4C1A759AA2599A285549986E74805903801A4CB5A5D4F2";
+
+    let ct_key = encrypt_bits(&cks, &key);
+    let ct_iv = encrypt_bits(&cks, &iv);
+
+    // Testing multiple chunks
+    let steps = [64, 128, 64, 256];
+    let output_radix_vec = executor.execute((&ct_key, &ct_iv, &steps[..])).unwrap();
+
+    let mut decrypted_bits = Vec::new();
+    for ct in output_radix_vec {
+        decrypted_bits.extend(decrypt_bits(&cks, &ct));
+    }
+
+    let hex_string = get_hexadecimal_string_from_lsb_first_stream(&decrypted_bits);
+
+    assert_eq!(expected_output_0_63, &hex_string[0..64 * 2]);
+}
+
+pub fn trivium_stateful_test_vector_2_test<P, E>(param: P, mut executor: E)
+where
+    P: Into<TestParameters>,
+    E: for<'a> FunctionExecutor<
+        (&'a RadixCiphertext, &'a RadixCiphertext, &'a [usize]),
+        crate::Result<Vec<RadixCiphertext>>,
+    >,
+{
+    let param = param.into();
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
+    let cks = RadixClientKey::from((cks, 1));
+    let sks = Arc::new(sks);
+    executor.setup(&cks, sks);
+
+    let mut key = vec![0u64; 80];
+    let iv = vec![0u64; 80];
+    key[7] = 1;
+
+    let expected_output_0_63 = "38EB86FF730D7A9CAF8DF13A4420540DBB7B651464C87501552041C249F29A64D2FBF515610921EBE06C8F92CECF7F8098FF20CCCC6A62B97BE8EF7454FC80F9";
+
+    let ct_key = encrypt_bits(&cks, &key);
+    let ct_iv = encrypt_bits(&cks, &iv);
+
+    let steps = [64, 128, 64, 256];
+    let output_radix_vec = executor.execute((&ct_key, &ct_iv, &steps[..])).unwrap();
+
+    let mut decrypted_bits = Vec::new();
+    for ct in output_radix_vec {
+        decrypted_bits.extend(decrypt_bits(&cks, &ct));
+    }
+
+    let hex_string = get_hexadecimal_string_from_lsb_first_stream(&decrypted_bits);
+
+    assert_eq!(expected_output_0_63, &hex_string[0..64 * 2]);
+}
+
+pub fn trivium_stateful_test_vector_3_test<P, E>(param: P, mut executor: E)
+where
+    P: Into<TestParameters>,
+    E: for<'a> FunctionExecutor<
+        (&'a RadixCiphertext, &'a RadixCiphertext, &'a [usize]),
+        crate::Result<Vec<RadixCiphertext>>,
+    >,
+{
+    let param = param.into();
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
+    let cks = RadixClientKey::from((cks, 1));
+    let sks = Arc::new(sks);
+    executor.setup(&cks, sks);
+
+    let key = vec![0u64; 80];
+    let mut iv = vec![0u64; 80];
+    iv[7] = 1;
+
+    let expected_output_0_63 = "F8901736640549E3BA7D42EA2D07B9F49233C18D773008BD755585B1A8CBAB86C1E9A9B91F1AD33483FD6EE3696D659C9374260456A36AAE11F033A519CBD5D7";
+
+    let ct_key = encrypt_bits(&cks, &key);
+    let ct_iv = encrypt_bits(&cks, &iv);
+
+    let steps = [64, 128, 64, 256];
+    let output_radix_vec = executor.execute((&ct_key, &ct_iv, &steps[..])).unwrap();
+
+    let mut decrypted_bits = Vec::new();
+    for ct in output_radix_vec {
+        decrypted_bits.extend(decrypt_bits(&cks, &ct));
+    }
+
+    let hex_string = get_hexadecimal_string_from_lsb_first_stream(&decrypted_bits);
+
+    assert_eq!(expected_output_0_63, &hex_string[0..64 * 2]);
+}
+
+pub fn trivium_stateful_test_vector_4_test<P, E>(param: P, mut executor: E)
+where
+    P: Into<TestParameters>,
+    E: for<'a> FunctionExecutor<
+        (&'a RadixCiphertext, &'a RadixCiphertext, &'a [usize]),
+        crate::Result<Vec<RadixCiphertext>>,
+    >,
+{
+    let param = param.into();
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
+    let cks = RadixClientKey::from((cks, 1));
+    let sks = Arc::new(sks);
+    executor.setup(&cks, sks);
+
+    let key_string = "0053A6F94C9FF24598EB";
+    let mut key = vec![0u64; 80];
+    for i in (0..key_string.len()).step_by(2) {
+        let mut val = u8::from_str_radix(&key_string[i..i + 2], 16).unwrap();
+        for j in 0..8 {
+            key[8 * (i >> 1) + j] = (val % 2) as u64;
+            val >>= 1;
+        }
+    }
+
+    let iv_string = "0D74DB42A91077DE45AC";
+    let mut iv = vec![0u64; 80];
+    for i in (0..iv_string.len()).step_by(2) {
+        let mut val = u8::from_str_radix(&iv_string[i..i + 2], 16).unwrap();
+        for j in 0..8 {
+            iv[8 * (i >> 1) + j] = (val % 2) as u64;
+            val >>= 1;
+        }
+    }
+
+    let expected_output_0_63 = "F4CD954A717F26A7D6930830C4E7CF0819F80E03F25F342C64ADC66ABA7F8A8E6EAA49F23632AE3CD41A7BD290A0132F81C6D4043B6E397D7388F3A03B5FE358";
+
+    let ct_key = encrypt_bits(&cks, &key);
+    let ct_iv = encrypt_bits(&cks, &iv);
+
+    let steps = [64, 128, 64, 256];
+    let output_radix_vec = executor.execute((&ct_key, &ct_iv, &steps[..])).unwrap();
+
+    let mut decrypted_bits = Vec::new();
+    for ct in output_radix_vec {
+        decrypted_bits.extend(decrypt_bits(&cks, &ct));
+    }
+
+    let hex_string = get_hexadecimal_string_from_lsb_first_stream(&decrypted_bits);
+
+    assert_eq!(expected_output_0_63, &hex_string[0..64 * 2]);
+}
+
+pub fn trivium_stateful_comparison_test<P, E>(param: P, mut executor: E)
+where
+    P: Into<TestParameters>,
+    E: for<'a> FunctionExecutor<
+        (&'a RadixCiphertext, &'a RadixCiphertext, &'a [usize]),
+        crate::Result<Vec<RadixCiphertext>>,
+    >,
+{
+    let param = param.into();
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
+    let cks = RadixClientKey::from((cks, 1));
+    let sks = Arc::new(sks);
+    executor.setup(&cks, sks);
+
+    let num_runs = 5;
+    let steps = [64, 128, 64, 256];
+    let num_steps: usize = steps.iter().sum();
+
+    for i in 0..num_runs {
+        let mut rng = rand::thread_rng();
+        let plain_key: Vec<u8> = (0..80).map(|_| rng.gen_range(0..=1)).collect();
+        let plain_iv: Vec<u8> = (0..80).map(|_| rng.gen_range(0..=1)).collect();
+
+        let key_bits_u64: Vec<u64> = plain_key.iter().map(|&x| x as u64).collect();
+        let iv_bits_u64: Vec<u64> = plain_iv.iter().map(|&x| x as u64).collect();
+
+        let ct_key = encrypt_bits(&cks, &key_bits_u64);
+        let ct_iv = encrypt_bits(&cks, &iv_bits_u64);
+
+        let mut cpu_trivium = TriviumRef::new(&plain_key, &plain_iv);
+        let mut cpu_output = Vec::with_capacity(num_steps);
+        for _ in 0..num_steps {
+            cpu_output.push(cpu_trivium.next());
+        }
+
+        let output_radix_vec = executor.execute((&ct_key, &ct_iv, &steps[..])).unwrap();
+        let mut fhe_output = Vec::new();
+        for ct in output_radix_vec {
+            fhe_output.extend(decrypt_bits(&cks, &ct));
+        }
 
         assert_eq!(cpu_output.len(), fhe_output.len());
         assert_eq!(cpu_output, fhe_output, "Mismatch at iteration {i}");


### PR DESCRIPTION
This PR contains

about **Kreyvium** and **Trivium**:
- Noise fix, before 6 additions were performed.
- Persistant version implemented
- Bench for monolithic and persistant version in classical and multibit params

```
+-----------+-----------+-------------------+-----------+-----------+-----------+---------+
| Algorithm | Parameter | Operation         | 8 GPUs    | 2 GPUs    | 1 GPU     | CPU     |
+-----------+-----------+-------------------+-----------+-----------+-----------+---------+
| Kreyvium  | MULTIBIT  | init              | 144.15 ms | 338.72 ms | 557.69 ms | -       |
|           |           | next_64_bits      | 8.8543 ms | 18.991 ms | 30.952 ms | -       |
|           |           | generate_64_bits  | 151.07 ms | 356.39 ms | 587.76 ms | -       |
|           |           | next_512_bits     | 63.829 ms | 149.35 ms | 246.03 ms | -       |
|           |           | generate_512_bits | 206.08 ms | 484.95 ms | 802.53 ms | -       |
|           |-----------+-------------------+-----------+-----------+-----------+---------+
|           | CLASSICAL | init              | 272.05 ms | 364.72 ms | 529.14 ms | 2883 ms |
|           |           | next_64_bits      | 15.244 ms | 20.286 ms | 29.341 ms | 150 ms  |
|           |           | generate_64_bits  | 286.98 ms | 383.77 ms | 557.45 ms | -       |
|           |           | next_512_bits     | 119.56 ms | 160.09 ms | 233.33 ms | -       |
|           |           | generate_512_bits | 391.24 ms | 523.58 ms | 761.30 ms | -       |
+-----------+-----------+-------------------+-----------+-----------+-----------+---------+
| Trivium   | MULTIBIT  | init              | 134.41 ms | 304.24 ms | 499.71 ms | -       |
|           |           | next_64_bits      | 9.0586 ms | 19.043 ms | 31.134 ms | -       |
|           |           | generate_64_bits  | 141.92 ms | 324.12 ms | 530.28 ms | -       |
|           |           | next_512_bits     | 65.126 ms | 150.61 ms | 247.11 ms | -       |
|           |           | generate_512_bits | 197.95 ms | 455.34 ms | 746.11 ms | -       |
|           |-----------+-------------------+-----------+-----------+-----------+---------+
|           | CLASSICAL | init              | 269.61 ms | 356.23 ms | 479.12 ms | 2259 ms |
|           |           | next_64_bits      | 15.439 ms | 20.452 ms | 29.361 ms | 121 ms  |
|           |           | generate_64_bits  | 284.63 ms | 375.42 ms | 507.73 ms | 3550 ms |
|           |           | next_512_bits     | 121.02 ms | 161.48 ms | 233.21 ms | -       |
|           |           | generate_512_bits | 390.50 ms | 516.54 ms | 711.71 ms | 4869 ms |
+-----------+-----------+-------------------+-----------+-----------+-----------+---------+
```


```
================================================================================
                    BEFORE: MONOLITHIC ARCHITECTURE
================================================================================

Request: Generate N bits
------------------------
[ Rust Client ] ----(Key, IV, N)----> [ GPU Backend ]
                                            |
                                            |-- 1. Allocate massive VRAM buffers
                                            |-- 2. WARMUP (1152 steps)
                                            |-- 3. GENERATE (N steps)
                                            |-- 4. Free VRAM buffers
                                            v
[ Rust Client ] <-----(N bits)------- [ GPU Backend ]

* Problem: Want M more bits ? You must call it again, wait for another 
  1152-step warmup, and allocate buffers for N+M bits.


================================================================================
                    NEW: STATEFUL ARCHITECTURE
================================================================================

WHAT IS "STATE" ?
-----------------------
  The State is a persistent object kept in the Client's 
  CPU RAM between calls. It contains the fully encrypted internal memory of 
  the Kreyvium stream cipher at a given time T:
   - FHE Registers : A (93 bits), B (84 bits), C (111 bits)
   - FHE Key & IV  : (128 bits each) + their current rotation offsets
   
  It acts as a "bookmark" allowing the stateless GPU to resume calculation 
  exactly where it left off, without leaking memory.

PHASE 1: Initialization
-----------------------
[ Rust Client ] -----(Key, IV)------> [ GPU Backend ]
                                            |
                                            |-- 1. Allocate temporary VRAM
                                            |-- 2. WARMUP (1152 steps)
                                            |-- 3. Free VRAM
                                            v
[ Rust Client ] <----(State T0)------ [ GPU Backend ]
  (Keeps State T0 in RAM)


PHASE 2: Continuous Generation (Call 1)
---------------------------------------
[ Rust Client ] -----(State T0, N)--> [ GPU Backend ]
                                            |
                                            |-- 1. Allocate VRAM for N bits
                                            |-- 2. Inject State T0
                                            |-- 3. GENERATE (N steps)
                                            |-- 4. Extract new State T1
                                            |-- 5. Free VRAM
                                            v
[ Rust Client ] <----(N bits + State T1)- [ GPU Backend ]
  (Updates RAM to State T1)


PHASE 3: Continuous Generation (Call 2)
---------------------------------------
[ Rust Client ] -----(State T1, M)--> [ GPU Backend ]
                                            |
                                            |-- 1. Allocate VRAM for M bits
                                            |-- 2. Inject State T1
                                            |-- 3. GENERATE (M steps)
                                            |-- 4. Extract new State T2
                                            |-- 5. Free VRAM
                                            v
[ Rust Client ] <----(M bits + State T2)- [ GPU Backend ]
```