### PR TITLE
feat: add bitonic_shuffle

### DIFF
--- a/tfhe-benchmark/Cargo.toml
+++ b/tfhe-benchmark/Cargo.toml
@@ -99,6 +99,12 @@ harness = false
 required-features = ["integer", "internal-keycache"]
 
 [[bench]]
+name = "hlapi-bitonic-shuffle"
+path = "benches/high_level_api/bitonic_shuffle.rs"
+harness = false
+required-features = ["integer", "internal-keycache"]
+
+[[bench]]
 name = "hlapi-dex"
 path = "benches/high_level_api/dex.rs"
 harness = false

--- a/tfhe-benchmark/benches/high_level_api/bitonic_shuffle.rs
+++ b/tfhe-benchmark/benches/high_level_api/bitonic_shuffle.rs
@@ -1,0 +1,52 @@
+use benchmark::params_aliases::BENCH_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+use criterion::{black_box, criterion_group, Criterion};
+use rand::Rng;
+use tfhe::prelude::*;
+use tfhe::{bitonic_shuffle, set_server_key, ClientKey, ConfigBuilder, FheUint64, Seed, ServerKey};
+
+fn bitonic_shuffle_bench(c: &mut Criterion, bench_name: &str, cks: &ClientKey) {
+    let mut bench_group = c.benchmark_group(bench_name);
+    bench_group.sample_size(10);
+
+    let mut rng = rand::thread_rng();
+
+    for num_elements in [16, 32] {
+        let clear_values: Vec<u64> = (0..num_elements).map(|_| rng.gen()).collect();
+        let encrypted: Vec<FheUint64> = clear_values
+            .iter()
+            .map(|&v| FheUint64::encrypt(v, cks))
+            .collect();
+
+        let bench_id = format!("{bench_name}::n_{num_elements}");
+
+        let seed = Seed(0);
+        bench_group.bench_function(&bench_id, |b| {
+            b.iter(|| {
+                let result = bitonic_shuffle(
+                    encrypted.clone(),
+                    tfhe::integer::server_key::BitonicShuffleKeySize::NumBits(32),
+                    seed,
+                )
+                .expect("shuffle failed");
+                black_box(result);
+            })
+        });
+    }
+
+    bench_group.finish();
+}
+
+pub fn bitonic_shuffle_cpu(c: &mut Criterion) {
+    let param = BENCH_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+    let config = ConfigBuilder::with_custom_parameters(param).build();
+    let cks = ClientKey::generate(config);
+    let sks = ServerKey::new(&cks);
+
+    rayon::broadcast(|_| set_server_key(sks.clone()));
+    set_server_key(sks);
+
+    bitonic_shuffle_bench(c, "hlapi::bitonic_shuffle_cpu", &cks);
+}
+
+criterion_group!(bitonic_shuffle_group, bitonic_shuffle_cpu);
+criterion::criterion_main!(bitonic_shuffle_group);

--- a/tfhe/src/high_level_api/integers/mod.rs
+++ b/tfhe/src/high_level_api/integers/mod.rs
@@ -49,6 +49,7 @@ pub use signed::{CompressedFheInt, FheInt, FheIntId, SquashedNoiseFheInt};
 pub use unsigned::{CompressedFheUint, FheUint, FheUintId, SquashedNoiseFheUint};
 
 pub mod oprf;
+pub mod shuffle;
 pub(super) mod signed;
 pub(super) mod unsigned;
 

--- a/tfhe/src/high_level_api/integers/shuffle.rs
+++ b/tfhe/src/high_level_api/integers/shuffle.rs
@@ -1,0 +1,132 @@
+use crate::high_level_api::global_state;
+use crate::high_level_api::integers::FheIntegerType;
+use crate::high_level_api::keys::InternalServerKey;
+use crate::high_level_api::re_randomization::ReRandomizationMetadata;
+use crate::integer::server_key::radix_parallel::bitonic_shuffle::BitonicShuffleKeySize;
+use crate::OprfSeed;
+
+/// Shuffles `data` into a uniformly random permutation using a bitonic
+/// sorting network with OPRF-generated random keys.
+///
+/// `key_size` controls the bit-width of the random sort keys used internally,
+/// either by specifying a target collision probability or by passing a raw
+/// bit count. Larger keys reduce collision probability (improving shuffle
+/// uniformity) at the cost of more computation per comparison.
+///
+/// The re-randomization metadata of the input elements is not preserved
+/// through the shuffle.
+///
+/// # Errors
+///
+/// Returns an error if the resolved key block count is 0
+pub fn bitonic_shuffle<T, S>(
+    data: Vec<T>,
+    key_size: BitonicShuffleKeySize,
+    seed: S,
+) -> Result<Vec<T>, crate::Error>
+where
+    T: FheIntegerType,
+    S: OprfSeed,
+{
+    global_state::with_internal_keys(|key| match key {
+        InternalServerKey::Cpu(cpu_key) => {
+            let inner = data.into_iter().map(|v| v.into_cpu()).collect();
+            let result =
+                cpu_key
+                    .pbs_key()
+                    .bitonic_shuffle(&cpu_key.oprf_key(), inner, key_size, seed)?;
+            Ok(result
+                .into_iter()
+                .map(|ct| T::from_cpu(ct, cpu_key.tag.clone(), ReRandomizationMetadata::default()))
+                .collect())
+        }
+        #[cfg(feature = "gpu")]
+        InternalServerKey::Cuda(_) => Err(crate::Error::new(
+            "bitonic_shuffle is not supported on Cuda".to_string(),
+        )),
+        #[cfg(feature = "hpu")]
+        InternalServerKey::Hpu(_) => Err(crate::Error::new(
+            "bitonic_shuffle is not supported on Hpu".to_string(),
+        )),
+    })
+}
+
+#[cfg(test)]
+mod test {
+    use super::{bitonic_shuffle, BitonicShuffleKeySize};
+    use crate::core_crypto::prelude::new_seeder;
+    use crate::high_level_api::prelude::*;
+    use crate::high_level_api::tests::setup_default_cpu;
+    use crate::{FheInt8, FheUint8};
+    use rand::Rng;
+
+    #[test]
+    fn test_bitonic_shuffle_fheuint() {
+        let cks = setup_default_cpu();
+        let mut rng = rand::thread_rng();
+        let mut clear_values: Vec<u8> = (0..15).map(|_| rng.gen()).collect();
+
+        let encrypted: Vec<FheUint8> = clear_values
+            .iter()
+            .map(|&v| FheUint8::try_encrypt(v, &cks).unwrap())
+            .collect();
+
+        let seed = new_seeder().seed();
+        println!("seed: {seed:?}");
+        let shuffled =
+            bitonic_shuffle(encrypted, BitonicShuffleKeySize::num_bits(32), seed).unwrap();
+
+        let mut decrypted: Vec<u8> = shuffled.iter().map(|ct| ct.decrypt(&cks)).collect();
+
+        clear_values.sort_unstable();
+        decrypted.sort_unstable();
+        assert_eq!(decrypted, clear_values);
+    }
+
+    #[test]
+    fn test_bitonic_shuffle_fheint() {
+        let cks = setup_default_cpu();
+        let mut rng = rand::thread_rng();
+        let mut clear_values: Vec<i8> = (0..15).map(|_| rng.gen()).collect();
+
+        let encrypted: Vec<FheInt8> = clear_values
+            .iter()
+            .map(|&v| FheInt8::try_encrypt(v, &cks).unwrap())
+            .collect();
+
+        let seed = new_seeder().seed();
+        println!("seed: {seed:?}");
+        let shuffled =
+            bitonic_shuffle(encrypted, BitonicShuffleKeySize::num_bits(32), seed).unwrap();
+
+        let mut decrypted: Vec<i8> = shuffled.iter().map(|ct| ct.decrypt(&cks)).collect();
+
+        clear_values.sort_unstable();
+        decrypted.sort_unstable();
+        assert_eq!(decrypted, clear_values);
+    }
+
+    #[test]
+    fn test_bitonic_shuffle_collision_probability() {
+        let cks = setup_default_cpu();
+        let mut rng = rand::thread_rng();
+        let mut clear_values: Vec<u8> = (0..15).map(|_| rng.gen()).collect();
+
+        let encrypted: Vec<FheUint8> = clear_values
+            .iter()
+            .map(|&v| FheUint8::try_encrypt(v, &cks).unwrap())
+            .collect();
+
+        let seed = new_seeder().seed();
+        println!("seed: {seed:?}");
+        // For n = 15, ceil(log2(15^2 / (2 * 4e-8))) = 32 bits of key.
+        let key_size = BitonicShuffleKeySize::collision_probability(4e-8);
+        let shuffled = bitonic_shuffle(encrypted, key_size, seed).unwrap();
+
+        let mut decrypted: Vec<u8> = shuffled.iter().map(|ct| ct.decrypt(&cks)).collect();
+
+        clear_values.sort_unstable();
+        decrypted.sort_unstable();
+        assert_eq!(decrypted, clear_values);
+    }
+}

--- a/tfhe/src/high_level_api/mod.rs
+++ b/tfhe/src/high_level_api/mod.rs
@@ -47,8 +47,9 @@ macro_rules! export_concrete_array_types {
     };
 }
 
-pub use crate::core_crypto::commons::math::random::{Seed, XofSeed};
+pub use crate::core_crypto::commons::math::random::{Seed, Seeder, XofSeed};
 pub use crate::high_level_api::integers::oprf::RangeForRandom;
+pub use crate::high_level_api::integers::shuffle::bitonic_shuffle;
 pub use crate::integer::server_key::MatchValues;
 pub use crate::shortint::OprfSeed;
 use crate::{error, Error, Versionize};

--- a/tfhe/src/integer/gpu/server_key/radix/oprf.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/oprf.rs
@@ -443,16 +443,16 @@ where
         let in_lwe_size = input_lwe_dimension.to_lwe_size();
         let message_bits_count = target_sks.message_modulus.0.ilog2();
 
-        let (seeded, _last_block_bits) = create_random_from_seed_modulus_switched(
+        let seeded = create_random_from_seed_modulus_switched(
             seed,
             in_lwe_size,
             polynomial_size,
-            total_random_bits,
+            &[total_random_bits],
             message_bits_count as u64,
         );
         let h_seeded_lwe_list: Vec<u64> = seeded
             .into_iter()
-            .flat_map(|seeded| {
+            .flat_map(|(seeded, _bits)| {
                 raw_seeded_msed_to_lwe(&seeded, target_sks.ciphertext_modulus).into_container()
             })
             .collect();
@@ -558,17 +558,17 @@ where
             .iter_as::<u64>()
             .collect::<Vec<_>>();
 
-        let (seeded, _last_block_bits) = create_random_from_seed_modulus_switched(
+        let seeded = create_random_from_seed_modulus_switched(
             seed,
             in_lwe_size,
             polynomial_size,
-            num_input_random_bits,
+            &[num_input_random_bits],
             message_bits_count,
         );
 
         let h_seeded_lwe_list: Vec<u64> = seeded
             .into_iter()
-            .flat_map(|seeded| {
+            .flat_map(|(seeded, _bits)| {
                 raw_seeded_msed_to_lwe(&seeded, target_sks.ciphertext_modulus).into_container()
             })
             .collect();

--- a/tfhe/src/integer/server_key/mod.rs
+++ b/tfhe/src/integer/server_key/mod.rs
@@ -20,7 +20,9 @@ pub use crate::shortint::CheckError;
 use crate::shortint::{CarryModulus, MessageModulus};
 pub use radix::scalar_mul::ScalarMultiplier;
 pub use radix::scalar_sub::TwosComplementNegation;
-pub use radix_parallel::{MatchValues, MiniUnsignedInteger, Reciprocable};
+pub use radix_parallel::{
+    BitonicShuffleKeySize, CollisionProbability, MatchValues, MiniUnsignedInteger, Reciprocable,
+};
 use serde::{Deserialize, Serialize};
 use tfhe_versionable::Versionize;
 

--- a/tfhe/src/integer/server_key/radix/mod.rs
+++ b/tfhe/src/integer/server_key/radix/mod.rs
@@ -247,14 +247,15 @@ impl ServerKey {
     /// let res: u64 = cks.decrypt(&ct1);
     /// assert_eq!(7, res);
     /// ```
-    pub fn extend_radix_with_trivial_zero_blocks_msb_assign(
-        &self,
-        ct: &mut RadixCiphertext,
-        num_blocks: usize,
-    ) {
+    pub fn extend_radix_with_trivial_zero_blocks_msb_assign<T>(&self, ct: &mut T, num_blocks: usize)
+    where
+        T: IntegerRadixCiphertext,
+    {
+        // Swap out blocks via a no-alloc empty sentinel (blocks_mut is a slice, can't resize)
+        let mut blocks = std::mem::replace(ct, T::from_blocks(vec![])).into_blocks();
         let block_trivial_zero = self.key.create_trivial(0);
-        ct.blocks
-            .resize(ct.blocks.len() + num_blocks, block_trivial_zero);
+        blocks.resize(blocks.len() + num_blocks, block_trivial_zero);
+        *ct = T::from_blocks(blocks);
     }
 
     /// Append trivial zero MSB blocks to an existing [`RadixCiphertext`] and returns the result as

--- a/tfhe/src/integer/server_key/radix_parallel/bitonic_shuffle.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/bitonic_shuffle.rs
@@ -1,0 +1,317 @@
+//! Bitonic sorting network generator.
+//!
+//! A bitonic sorting network for n=2^k elements has k*(k+1)/2 stages,
+//! each with n/2 comparators. It sorts any input sequence.
+use crate::core_crypto::prelude::Container;
+use crate::integer::oprf::GenericOprfServerKey;
+use crate::integer::prelude::ServerKeyDefaultCMux;
+use crate::integer::{IntegerRadixCiphertext, RadixCiphertext, ServerKey};
+use crate::shortint::MessageModulus;
+use crate::OprfSeed;
+use rayon::prelude::*;
+use tfhe_fft::c64;
+
+/// Generates a bitonic sorting network for n elements (n must be a power of 2).
+///
+/// Returns a list of stages, where each stage contains disjoint (i, j, ascending) triples.
+/// Each triple represents a compare-and-swap: if ascending, put the smaller element at i;
+/// if descending, put the larger element at i.
+pub(crate) fn bitonic_network(n: usize) -> Vec<Vec<(usize, usize, bool)>> {
+    assert!(
+        n.is_power_of_two() && n >= 2,
+        "bitonic_network requires n to be a power of 2 and >= 2, got n={n}"
+    );
+    let log_n = n.trailing_zeros() as usize;
+    let mut stages = Vec::with_capacity(log_n * (log_n + 1) / 2);
+
+    // Bitonic network indexing trick
+    //
+    //   - At step `step` of phase `phase`, comparator partners differ in exactly bit `step` of
+    //     their index, so `j = i ^ (1 << step)`.
+    //   - The `j > i` filter ensures bit `step` of `i` is 0, so each unordered pair {i, j} is
+    //     emitted exactly once.
+    //   - A "sequence" (the bitonic subsequence being merged in this phase) has length `2^(phase +
+    //     1)`, so `i >> (phase + 1)` is its index; even-indexed sequences sort ascending,
+    //     odd-indexed descending.
+    for phase in 0..log_n {
+        for step in (0..=phase).rev() {
+            let mut comparators = Vec::with_capacity(n / 2);
+            for i in 0..n {
+                let j = i ^ (1 << step);
+                if j > i {
+                    let ascending = (i >> (phase + 1)) & 1 == 0;
+                    comparators.push((i, j, ascending));
+                }
+            }
+            stages.push(comparators);
+        }
+    }
+
+    stages
+}
+
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub struct CollisionProbability(f64);
+
+impl CollisionProbability {
+    pub fn try_new(proba: f64) -> Option<Self> {
+        if 0.0 < proba && proba < 1.0 {
+            Some(Self(proba))
+        } else {
+            None
+        }
+    }
+
+    pub fn new(proba: f64) -> Self {
+        Self::try_new(proba).expect("Invalid probability, it must be in ]0, 1.0[")
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub enum BitonicShuffleKeySize {
+    CollisionProbability(CollisionProbability),
+    NumBits(u32),
+}
+
+impl BitonicShuffleKeySize {
+    pub fn try_collision_probability(proba: f64) -> Option<Self> {
+        CollisionProbability::try_new(proba).map(Self::CollisionProbability)
+    }
+
+    pub fn collision_probability(proba: f64) -> Self {
+        Self::CollisionProbability(CollisionProbability::new(proba))
+    }
+
+    pub fn num_bits(num_bits: u32) -> Self {
+        Self::NumBits(num_bits)
+    }
+
+    fn num_blocks_of_keys(&self, num_elements: usize, msg_mod: MessageModulus) -> u32 {
+        let bits = match self {
+            Self::CollisionProbability(CollisionProbability(proba)) => {
+                let n_squared = (num_elements * num_elements) as f64;
+                (n_squared / (2.0 * proba)).log2().ceil() as u32
+            }
+            Self::NumBits(n) => *n,
+        };
+        bits.div_ceil(msg_mod.0.ilog2())
+    }
+}
+
+impl ServerKey {
+    /// Shuffles `data` into a uniformly random permutation using a bitonic sorting network
+    /// with random sort keys.
+    ///
+    /// `key_size` controls the bit-width of the random sort keys used internally, either
+    /// by specifying a target collision probability or by passing a raw bit count.
+    /// The bit count is rounded up to a multiple of `log2(message_modulus)` so each
+    /// OPRF-generated random block is fully consumed. Larger keys reduce collision
+    /// probability — and thus improve shuffle uniformity — at the cost of more
+    /// computation per comparison/swap.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the resolved key block count is 0.
+    pub fn bitonic_shuffle<T, S, C>(
+        &self,
+        oprf_key: &GenericOprfServerKey<C>,
+        data: Vec<T>,
+        key_size: BitonicShuffleKeySize,
+        seed: S,
+    ) -> Result<Vec<T>, crate::Error>
+    where
+        T: IntegerRadixCiphertext,
+        S: OprfSeed,
+        C: Container<Element = c64> + Sync,
+    {
+        let key_num_blocks = key_size.num_blocks_of_keys(data.len(), self.message_modulus()) as u64;
+
+        if key_num_blocks == 0 {
+            return Err(crate::Error::new(
+                "key_num_blocks must be at least 1".to_string(),
+            ));
+        }
+
+        if data.len() <= 1 {
+            return Ok(data);
+        }
+
+        let key_num_bits = key_num_blocks * self.message_modulus().0.ilog2() as u64;
+
+        let chunks = vec![key_num_bits; data.len()];
+        let block_chunks = oprf_key
+            .key
+            .generate_oblivious_pseudo_random_bits_chunks(seed, &chunks, &self.key);
+
+        let keys = block_chunks
+            .into_iter()
+            .map(RadixCiphertext::from)
+            .collect::<Vec<_>>();
+
+        self.bitonic_shuffle_with_keys(data, keys)
+    }
+
+    /// Shuffles `data` using a bitonic sorting network keyed by `keys`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `data` and `keys` have different lengths, or if
+    /// elements within `data` (or within `keys`) have inconsistent block counts.
+    pub fn bitonic_shuffle_with_keys<T>(
+        &self,
+        mut data: Vec<T>,
+        mut keys: Vec<RadixCiphertext>,
+    ) -> Result<Vec<T>, crate::Error>
+    where
+        T: IntegerRadixCiphertext,
+    {
+        if data.len() != keys.len() {
+            return Err(crate::Error::new(format!(
+                "data and keys must have the same length, got {} and {}",
+                data.len(),
+                keys.len()
+            )));
+        }
+
+        if data.len() <= 1 {
+            return Ok(data);
+        }
+
+        let data_num_blocks = data[0].blocks().len();
+        if data[1..]
+            .iter()
+            .any(|d| d.blocks().len() != data_num_blocks)
+        {
+            return Err(crate::Error::new(
+                "all data elements must have the same number of blocks".to_string(),
+            ));
+        }
+        let key_num_blocks = keys[0].blocks.len();
+        if keys[1..].iter().any(|k| k.blocks.len() != key_num_blocks) {
+            return Err(crate::Error::new(
+                "all keys must have the same number of blocks".to_string(),
+            ));
+        }
+
+        rayon::join(
+            || {
+                data.par_iter_mut()
+                    .for_each(|value| self.clean_inplace_for_default_op(value));
+            },
+            || {
+                keys.par_iter_mut()
+                    .for_each(|value| self.clean_inplace_for_default_op(value));
+            },
+        );
+
+        let mut data = self.unchecked_bitonic_shuffle_with_keys(data, keys);
+
+        data.par_iter_mut().for_each(|radix| {
+            radix
+                .blocks_mut()
+                .par_iter_mut()
+                .for_each(|block| self.key.message_extract_assign(block))
+        });
+
+        Ok(data)
+    }
+
+    /// Performs a bitonic shuffle without cleaning inputs or outputs.
+    ///
+    /// # Preconditions
+    ///
+    /// * `data` and `keys` must have the same length and consistent block counts.
+    /// * Data blocks must have no carries and noise budget for `unchecked_flip_parallelized`.
+    /// * Key blocks must have no carries and noise budget for `unchecked_lt/gt`.
+    ///
+    /// Output blocks have no carries but non-nominal noise level.
+    pub fn unchecked_bitonic_shuffle_with_keys<T>(
+        &self,
+        mut data: Vec<T>,
+        mut keys: Vec<RadixCiphertext>,
+    ) -> Vec<T>
+    where
+        T: IntegerRadixCiphertext,
+    {
+        assert_eq!(
+            data.len(),
+            keys.len(),
+            "data.len()={} != keys.len()={}",
+            data.len(),
+            keys.len()
+        );
+        let n = data.len();
+        if n <= 1 {
+            return data;
+        }
+
+        let padded_n = n.next_power_of_two();
+        let network = bitonic_network(padded_n);
+
+        let mut key_num_blocks = keys[0].blocks.len();
+        let data_num_blocks = data[0].blocks().len();
+
+        let pad = padded_n - n;
+        if pad > 0 {
+            // We need to pad with some trivial (key=MAX, data=0)
+            // However it could be that a key is already=MAX, so to protect us from that case
+            // we add an extra block to the keys
+            key_num_blocks += 1;
+            for key in &mut keys {
+                self.extend_radix_with_trivial_zero_blocks_msb_assign(key, 1);
+            }
+
+            for _ in 0..pad {
+                keys.push(self.create_trivial_max_radix(key_num_blocks));
+                data.push(self.create_trivial_zero_radix(data_num_blocks));
+            }
+        }
+
+        let mut stage_results = Vec::with_capacity(padded_n / 2);
+        for stage in network {
+            stage
+                .into_par_iter()
+                .map(|(i, j, ascending)| {
+                    let cmp = if ascending {
+                        self.unchecked_gt_parallelized(&keys[i], &keys[j])
+                    } else {
+                        self.unchecked_lt_parallelized(&keys[i], &keys[j])
+                    };
+
+                    // If we use unchecked_flip, both outputs will have noise_level = 2
+                    // many of the operation that they are used in require to have max_noise_level
+                    // >= 4 in order to accept these inputs. So if it's not the
+                    // case, we have to use default flip which cleans the output
+                    let ((new_ki, new_kj), (new_di, new_dj)) = rayon::join(
+                        || {
+                            if self.key.max_noise_level.get() < 4 {
+                                self.flip_parallelized(&cmp, &keys[i], &keys[j])
+                            } else {
+                                self.unchecked_flip_parallelized(&cmp, &keys[i], &keys[j])
+                            }
+                        },
+                        || {
+                            if self.key.max_noise_level.get() < 4 {
+                                self.flip_parallelized(&cmp, &data[i], &data[j])
+                            } else {
+                                self.unchecked_flip_parallelized(&cmp, &data[i], &data[j])
+                            }
+                        },
+                    );
+
+                    (i, j, new_ki, new_kj, new_di, new_dj)
+                })
+                .collect_into_vec(&mut stage_results);
+
+            for (i, j, new_ki, new_kj, new_di, new_dj) in stage_results.drain(..) {
+                keys[i] = new_ki;
+                keys[j] = new_kj;
+                data[i] = new_di;
+                data[j] = new_dj;
+            }
+        }
+
+        data.truncate(n);
+        data
+    }
+}

--- a/tfhe/src/integer/server_key/radix_parallel/cmux.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/cmux.rs
@@ -2,6 +2,7 @@ use crate::integer::block_decomposition::{BlockDecomposer, DecomposableInto};
 use crate::integer::ciphertext::boolean_value::BooleanBlock;
 use crate::integer::ciphertext::IntegerRadixCiphertext;
 use crate::integer::{RadixCiphertext, ServerKey, SignedRadixCiphertext};
+use crate::shortint::parameters::Degree;
 use crate::shortint::Ciphertext;
 use rayon::prelude::*;
 
@@ -121,96 +122,17 @@ where
             "Inputs must have the same number of blocks"
         );
 
-        // To make use if many_lut, we require 1 bit, 1 more bit is required to pack
-        // the condition. Thus 2 bits of carry are required.
-        //
-        // Otherwise we call if_then_else twice, which is less efficient.
-        if self.carry_modulus().0 < (1 << 2) {
-            return rayon::join(
-                || self.if_then_else_parallelized(condition, b, a),
-                || self.if_then_else_parallelized(condition, a, b),
-            );
-        }
-
         let (a, b) = rayon::join(
             || self.clean_for_default_op(a),
             || self.clean_for_default_op(b),
         );
+        let (mut a, mut b) = self.unchecked_flip_parallelized(condition, &*a, &*b);
+        a.blocks_mut()
+            .par_iter_mut()
+            .chain(b.blocks_mut().par_iter_mut())
+            .for_each(|block| self.key.message_extract_assign(block));
 
-        let zero_out_if_true_fn = |packed| {
-            let condition = (packed / self.message_modulus().0) & 1;
-            let value = packed % self.message_modulus().0;
-            (1 - condition) * value
-        };
-
-        let zero_out_if_false_fn = |packed| {
-            let condition = (packed / self.message_modulus().0) & 1;
-            let value = packed % self.message_modulus().0;
-            condition * value
-        };
-
-        let lut = self
-            .key
-            .generate_many_lookup_table(&[&zero_out_if_true_fn, &zero_out_if_false_fn]);
-
-        let scaled_condition = self
-            .key
-            .unchecked_scalar_mul(&condition.0, self.message_modulus().0 as u8);
-
-        let map_condition_lut_on_blocks =
-            |blocks: &[Ciphertext]| -> (Vec<Ciphertext>, Vec<Ciphertext>) {
-                let mut left = Vec::with_capacity(blocks.len());
-                let mut right = Vec::with_capacity(blocks.len());
-                blocks
-                    .par_iter()
-                    .map(|block| {
-                        let block = self.key.unchecked_add(block, &scaled_condition);
-                        let mut resulting_blocks = self.key.apply_many_lookup_table(&block, &lut);
-
-                        let second_result = resulting_blocks.pop().unwrap();
-                        let first_result = resulting_blocks.pop().unwrap();
-
-                        (first_result, second_result)
-                    })
-                    .unzip_into_vecs(&mut left, &mut right);
-                (left, right)
-            };
-
-        let (
-            (mut a_blocks_if_cond, mut a_blocks_if_not_cond),
-            (b_blocks_if_cond, b_blocks_if_not_cond),
-        ) = rayon::join(
-            || map_condition_lut_on_blocks(a.blocks()),
-            || map_condition_lut_on_blocks(b.blocks()),
-        );
-
-        let clean_lut = self
-            .key
-            .generate_lookup_table(|x| x % self.message_modulus().0);
-
-        let inplace_add_then_clean_blocks =
-            |lhs_blocks: &mut [Ciphertext], rhs_blocks: &[Ciphertext]| {
-                lhs_blocks
-                    .par_iter_mut()
-                    .zip(rhs_blocks.par_iter())
-                    .for_each(|(lhs, rhs)| {
-                        self.key.unchecked_add_assign(lhs, rhs);
-                        self.key.apply_lookup_table_assign(lhs, &clean_lut);
-                    });
-            };
-        rayon::join(
-            || {
-                inplace_add_then_clean_blocks(&mut a_blocks_if_cond, &b_blocks_if_not_cond);
-            },
-            || {
-                inplace_add_then_clean_blocks(&mut a_blocks_if_not_cond, &b_blocks_if_cond);
-            },
-        );
-
-        (
-            T::from_blocks(a_blocks_if_cond),
-            T::from_blocks(a_blocks_if_not_cond),
-        )
+        (a, b)
     }
 }
 
@@ -912,7 +834,9 @@ impl ServerKey {
                 .iter_mut()
                 .zip(false_ct.blocks().iter())
                 .for_each(|(lhs_block, rhs_block)| {
+                    let degree = Degree::new(lhs_block.degree.get().max(rhs_block.degree.get()));
                     self.key.unchecked_add_assign(lhs_block, rhs_block);
+                    lhs_block.degree = degree;
                 });
         }
 
@@ -985,6 +909,122 @@ impl ServerKey {
                     &lut,
                 );
             });
+    }
+
+    /// Performs `if condition { (b, a) } else { (a, b) }` in fhe
+    ///
+    /// * Blocks of both `a` and `b` must have no carries and noise_level <= 2
+    /// * Outputs will have no carries but noise_level == 2
+    pub(crate) fn unchecked_flip_parallelized<T>(
+        &self,
+        condition: &BooleanBlock,
+        a: &T,
+        b: &T,
+    ) -> (T, T)
+    where
+        T: IntegerRadixCiphertext,
+    {
+        assert_eq!(
+            a.blocks().len(),
+            b.blocks().len(),
+            "Inputs must have the same number of blocks"
+        );
+
+        // To make use if many_lut, we require 1 bit, 1 more bit is required to pack
+        // the condition. Thus 2 bits of carry are required.
+        //
+        // Otherwise we call if_then_else twice, which is less efficient.
+        if self.carry_modulus().0 < (1 << 2) {
+            let unchecked_if_then_else_parallelized_no_cleanup =
+                |condition: &BooleanBlock, true_ct, false_ct| {
+                    let condition_block = &condition.0;
+                    let do_clean_message = false;
+                    self.unchecked_programmable_if_then_else_parallelized(
+                        condition_block,
+                        true_ct,
+                        false_ct,
+                        |x| x == 1,
+                        do_clean_message,
+                    )
+                };
+            return rayon::join(
+                || unchecked_if_then_else_parallelized_no_cleanup(condition, b, a),
+                || unchecked_if_then_else_parallelized_no_cleanup(condition, a, b),
+            );
+        }
+
+        // We move the block message by one bit: it is the most flexible option (at least for 2_2)
+        // as it allows the block to have noise_level <= 2 or the condition block to have
+        // noise_level <= 2.
+        //
+        // A drawback is that everyblock needs to be cloned to be shifted, as opposed to
+        // only the condition block, but it's an ok drawback
+        assert!(a.blocks().iter().chain(b.blocks().iter()).all(|block| {
+            self.key
+                .max_noise_level
+                .validate(block.noise_level() * 2 + condition.0.noise_level())
+                .is_ok()
+        }));
+
+        let zero_out_if_true_fn = |packed| {
+            let condition = packed & 1;
+            let value = packed / 2;
+            (1 - condition) * value
+        };
+
+        let zero_out_if_false_fn = |packed| {
+            let condition = packed & 1;
+            let value = packed / 2;
+            condition * value
+        };
+
+        let lut = self
+            .key
+            .generate_many_lookup_table(&[&zero_out_if_true_fn, &zero_out_if_false_fn]);
+
+        let map_condition_lut_on_blocks =
+            |blocks: &[Ciphertext]| -> (Vec<Ciphertext>, Vec<Ciphertext>) {
+                let mut left = Vec::with_capacity(blocks.len());
+                let mut right = Vec::with_capacity(blocks.len());
+                blocks
+                    .par_iter()
+                    .map(|block| {
+                        let mut block = self.key.unchecked_scalar_mul(block, 2);
+                        self.key.unchecked_add_assign(&mut block, &condition.0);
+                        let mut resulting_blocks = self.key.apply_many_lookup_table(&block, &lut);
+
+                        let second_result = resulting_blocks.pop().unwrap();
+                        let first_result = resulting_blocks.pop().unwrap();
+
+                        (first_result, second_result)
+                    })
+                    .unzip_into_vecs(&mut left, &mut right);
+                (left, right)
+            };
+
+        let (
+            (mut a_blocks_if_cond, mut a_blocks_if_not_cond),
+            (b_blocks_if_cond, b_blocks_if_not_cond),
+        ) = rayon::join(
+            || map_condition_lut_on_blocks(a.blocks()),
+            || map_condition_lut_on_blocks(b.blocks()),
+        );
+
+        for (a, b) in a_blocks_if_cond.iter_mut().zip(b_blocks_if_not_cond.iter()) {
+            self.key.unchecked_add_assign(a, b);
+            // By construction, one of the two input encrypts only zeros
+            a.degree.0 = self.message_modulus().0 - 1;
+        }
+        for (a, b) in a_blocks_if_not_cond.iter_mut().zip(b_blocks_if_cond.iter()) {
+            self.key.unchecked_add_assign(a, b);
+            // By construction, one of the two input encrypts only zeros
+            a.degree.0 = self.message_modulus().0 - 1;
+        }
+
+        (
+            T::from_blocks(a_blocks_if_cond),
+            T::from_blocks(a_blocks_if_not_cond),
+        )
     }
 
     fn scalar_flip_parallelized<T, Scalar>(

--- a/tfhe/src/integer/server_key/radix_parallel/comparison.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/comparison.rs
@@ -112,6 +112,7 @@ impl ServerKey {
     /// * inputs must have the same number of blocks
     /// * block carries of both inputs must be empty
     /// * carry modulus == message modulus
+    /// * blocks of the inputs a and b must have a noise_level such that a[i] - b[i] is possible
     fn compare<T>(&self, a: &T, b: &T, compare: ComparisonKind) -> BooleanBlock
     where
         T: IntegerRadixCiphertext,

--- a/tfhe/src/integer/server_key/radix_parallel/mod.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/mod.rs
@@ -1,6 +1,7 @@
 mod abs;
 mod add;
 mod bit_extractor;
+pub(crate) mod bitonic_shuffle;
 mod bitwise_op;
 mod block_shift;
 pub(crate) mod cmux;
@@ -47,6 +48,7 @@ use crate::integer::ciphertext::IntegerRadixCiphertext;
 use crate::integer::RadixCiphertext;
 use crate::shortint::ciphertext::{Ciphertext, NoiseLevel};
 pub(crate) use add::OutputFlag;
+pub use bitonic_shuffle::{BitonicShuffleKeySize, CollisionProbability};
 use rayon::prelude::*;
 pub use scalar_div_mod::{MiniUnsignedInteger, Reciprocable};
 pub use vector_find::MatchValues;
@@ -321,6 +323,20 @@ impl ServerKey {
             Cow::Owned(cloned)
         } else {
             Cow::Borrowed(ct)
+        }
+    }
+
+    /// Cleans the input inplace so that it is ready to be used in a default ops
+    pub(crate) fn clean_inplace_for_default_op<T>(&self, ct: &mut T)
+    where
+        T: IntegerRadixCiphertext,
+    {
+        if ct
+            .blocks()
+            .iter()
+            .any(|block| !block.carry_is_empty() || block.noise_level() != NoiseLevel::NOMINAL)
+        {
+            self.full_propagate_parallelized(ct);
         }
     }
 }

--- a/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/mod.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/mod.rs
@@ -2,6 +2,7 @@ mod modulus_switch_compression;
 pub(crate) mod test_add;
 pub(crate) mod test_aes;
 pub(crate) mod test_aes256;
+pub(crate) mod test_bitonic_shuffle;
 pub(crate) mod test_bitwise_op;
 mod test_block_rotate;
 mod test_block_shift;

--- a/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_bitonic_shuffle.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_bitonic_shuffle.rs
@@ -1,0 +1,158 @@
+use crate::integer::keycache::KEY_CACHE;
+use crate::integer::server_key::radix_parallel::bitonic_shuffle::bitonic_network;
+use crate::integer::server_key::radix_parallel::tests_cases_unsigned::FunctionExecutor;
+use crate::integer::server_key::radix_parallel::tests_unsigned::CpuFunctionExecutor;
+use crate::integer::tests::create_parameterized_test;
+use crate::integer::{IntegerKeyKind, RadixCiphertext, RadixClientKey, ServerKey};
+#[cfg(tarpaulin)]
+use crate::shortint::parameters::coverage_parameters::*;
+use crate::shortint::parameters::test_params::*;
+use crate::shortint::parameters::*;
+use rand::Rng;
+use std::sync::Arc;
+
+/// Clear reference: sorts data by keys using the same bitonic network
+/// as `ServerKey::bitonic_shuffle_with_keys`.
+fn clear_bitonic_shuffle_with_keys(data: &[u32], keys: &[u32]) -> Vec<u32> {
+    assert_eq!(data.len(), keys.len());
+    let n = data.len();
+    if n <= 1 {
+        return data.to_vec();
+    }
+
+    let padded_n = n.next_power_of_two();
+    let mut keys = keys.iter().copied().map(u64::from).collect::<Vec<_>>();
+    let mut data = data.to_vec();
+
+    // Pad with MAX keys and zero data, so padding sorts to the end and is truncated
+    for _ in 0..(padded_n - n) {
+        keys.push(u64::MAX);
+        data.push(0u32);
+    }
+
+    let network = bitonic_network(padded_n);
+    for stage in &network {
+        let swaps: Vec<_> = stage
+            .iter()
+            .map(|&(i, j, ascending)| {
+                let should_swap = if ascending {
+                    keys[i] > keys[j]
+                } else {
+                    keys[i] < keys[j]
+                };
+                (i, j, should_swap)
+            })
+            .collect();
+
+        for (i, j, should_swap) in swaps {
+            if should_swap {
+                keys.swap(i, j);
+                data.swap(i, j);
+            }
+        }
+    }
+
+    data.truncate(n);
+    data
+}
+
+#[test]
+fn bitonic_network_builds_expected_pairs_for_n8() {
+    let network = bitonic_network(8);
+
+    assert_eq!(
+        network,
+        vec![
+            vec![(0, 1, true), (2, 3, false), (4, 5, true), (6, 7, false)],
+            vec![(0, 2, true), (1, 3, true), (4, 6, false), (5, 7, false)],
+            vec![(0, 1, true), (2, 3, true), (4, 5, false), (6, 7, false)],
+            vec![(0, 4, true), (1, 5, true), (2, 6, true), (3, 7, true)],
+            vec![(0, 2, true), (1, 3, true), (4, 6, true), (5, 7, true)],
+            vec![(0, 1, true), (2, 3, true), (4, 5, true), (6, 7, true)],
+        ]
+    );
+}
+
+create_parameterized_test!(integer_bitonic_shuffle_with_keys);
+
+fn integer_bitonic_shuffle_with_keys<P>(param: P)
+where
+    P: Into<TestParameters>,
+{
+    let executor =
+        CpuFunctionExecutor::new(&ServerKey::bitonic_shuffle_with_keys::<RadixCiphertext>);
+    bitonic_shuffle_with_keys_test(param, executor);
+}
+
+pub(crate) fn bitonic_shuffle_with_keys_test<P, T>(param: P, mut executor: T)
+where
+    P: Into<TestParameters>,
+    T: for<'a> FunctionExecutor<
+        (Vec<RadixCiphertext>, Vec<RadixCiphertext>),
+        Result<Vec<RadixCiphertext>, crate::Error>,
+    >,
+{
+    let param = param.into();
+    let (cks, sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
+    let num_blocks = 32usize.div_ceil(cks.parameters().message_modulus().0.ilog2() as usize);
+    let cks = RadixClientKey::from((cks, num_blocks));
+    let sks = Arc::new(sks);
+
+    executor.setup(&cks, sks);
+
+    let mut rng = rand::thread_rng();
+
+    for _ in 0..4 {
+        let len = rng.gen_range(1..=16usize).next_power_of_two();
+        let clear_keys: Vec<u32> = (0..len).map(|_| rng.gen::<u32>()).collect();
+        let mut clear_data: Vec<u32> = (0..len).map(|_| rng.gen::<u32>()).collect();
+        println!("clear_keys: {clear_keys:?}, clear_data: {clear_data:?}");
+
+        let enc_keys = clear_keys.iter().map(|&v| cks.encrypt(v as u64)).collect();
+        let enc_data = clear_data.iter().map(|&v| cks.encrypt(v as u64)).collect();
+
+        let result = executor.execute((enc_data, enc_keys)).unwrap();
+
+        let mut decrypted: Vec<u32> = result
+            .iter()
+            .map(|ct| cks.decrypt::<u64>(ct) as u32)
+            .collect();
+
+        // Check the encrypted implementation matches the clear one
+        let expected = clear_bitonic_shuffle_with_keys(&clear_data, &clear_keys);
+        assert_eq!(decrypted, expected);
+
+        // Check that the permutation did not lose any of the data
+        decrypted.sort_unstable();
+        clear_data.sort_unstable();
+        assert_eq!(decrypted, clear_data, "permutation lost data");
+    }
+
+    {
+        let len = 17;
+        let mut clear_keys: Vec<u32> = (0..len).map(|_| rng.gen::<u32>()).collect();
+        let mut clear_data: Vec<u32> = (0..len).map(|_| rng.gen::<u32>()).collect();
+        clear_keys[3] = u32::MAX;
+        assert!(!clear_keys.len().is_power_of_two());
+        println!("clear_keys: {clear_keys:?}, clear_data: {clear_data:?}");
+
+        let enc_keys = clear_keys.iter().map(|&v| cks.encrypt(v as u64)).collect();
+        let enc_data = clear_data.iter().map(|&v| cks.encrypt(v as u64)).collect();
+
+        let result = executor.execute((enc_data, enc_keys)).unwrap();
+
+        let mut decrypted: Vec<u32> = result
+            .iter()
+            .map(|ct| cks.decrypt::<u64>(ct) as u32)
+            .collect();
+
+        // Check the encrypted implementation matches the clear one
+        let expected = clear_bitonic_shuffle_with_keys(&clear_data, &clear_keys);
+        assert_eq!(decrypted, expected);
+
+        // Check that the permutation did not lose any of the data
+        decrypted.sort_unstable();
+        clear_data.sort_unstable();
+        assert_eq!(decrypted, clear_data, "permutation lost data");
+    }
+}

--- a/tfhe/src/shortint/oprf.rs
+++ b/tfhe/src/shortint/oprf.rs
@@ -628,9 +628,38 @@ impl<C: Container<Element = c64> + Sync> GenericOprfServerKey<C> {
         random_bits_count: u64,
         target_sks: &ServerKey,
     ) -> Vec<Ciphertext> {
+        self.inner
+            .generate_pseudo_random_bits(
+                seed,
+                &[random_bits_count],
+                target_sks.message_modulus.0.ilog2() as u64,
+                target_sks,
+            )
+            .pop()
+            .unwrap()
+    }
+
+    /// Uniformly generates a batch of independent encrypted random bit-chunks
+    /// from a single seed in one call.
+    ///
+    /// For each entry `bc` in `random_bits_counts`, returns a `Vec<Ciphertext>`
+    /// of `ceil(bc / random_bits_per_block)` blocks, where `random_bits_per_block`
+    /// is the message-modulus log2. Within each chunk, every ciphertext encrypts a
+    /// value in `[0, 2^random_bits_per_block[` except for the last one, which may
+    /// hold fewer random bits if `bc` does not divide evenly.
+    ///
+    /// # Panics
+    ///
+    /// * Panics if `self` is not compatible with `target_sks`
+    pub fn generate_oblivious_pseudo_random_bits_chunks(
+        &self,
+        seed: impl OprfSeed,
+        random_bits_counts: &[u64],
+        target_sks: &ServerKey,
+    ) -> Vec<Vec<Ciphertext>> {
         self.inner.generate_pseudo_random_bits(
             seed,
-            random_bits_count,
+            random_bits_counts,
             target_sks.message_modulus.0.ilog2() as u64,
             target_sks,
         )
@@ -738,6 +767,25 @@ pub(crate) struct PrfSeededModulusSwitched {
     log_modulus: CiphertextModulusLog,
 }
 
+impl PrfSeededModulusSwitched {
+    fn zero(lwe_size: LweSize, log_modulus: CiphertextModulusLog) -> Self {
+        Self {
+            mask: vec![0usize; lwe_size.to_lwe_dimension().0],
+            body: 0,
+            log_modulus,
+        }
+    }
+
+    fn fill_mask_with_random(&mut self, rng: &mut RandomGenerator<DefaultRandomGenerator>) {
+        for mask_element in &mut self.mask {
+            *mask_element = rng.random_from_distribution_custom_mod::<u32, _>(
+                Uniform,
+                CiphertextModulus::new(1u128 << self.log_modulus.0),
+            ) as usize;
+        }
+    }
+}
+
 impl ModulusSwitchedLweCiphertext<usize> for PrfSeededModulusSwitched {
     fn log_modulus(&self) -> CiphertextModulusLog {
         self.log_modulus
@@ -819,71 +867,81 @@ impl MultiBitModulusSwitchedLweCiphertext for PrfMultiBitSeededModulusSwitched {
 // XOF-based seeded modulus switch (current implementation, uses OprfSeed)
 // ============================================================================
 
-/// Takes as input the `bit_count` to be generated (e.g. 21),
-/// the `random_bits_per_blocks` (e.g. 2) and output as many
-/// [PrfSeededModulusSwitched] as needed (ceil(bit_count/random_bits_per_blocks))
+/// Takes as input the `bit_chunks` to be generated (e.g [15, 15])
+/// the `random_bits_per_blocks` (e.g. 2).
 ///
-/// Also returns how many random bits the last block shall have.
-/// e.g 1 in the case of 21 bits over blocks of 2 bits
+/// Outputs a flat array of all [PrfSeededModulusSwitched] needed
+///
+/// Also returns the position of blocks that should be generated to contain
+/// less than `random_bits_per_block`, along with how many bits they should contain
 pub(crate) fn create_random_from_seed_modulus_switched(
     seed: impl OprfSeed,
     lwe_size: LweSize,
     polynomial_size: PolynomialSize,
-    bit_count: u64,
+    bit_chunks: &[u64],
     random_bits_per_block: u64,
-) -> (Vec<PrfSeededModulusSwitched>, u64) {
-    if bit_count == 0 || random_bits_per_block == 0 {
-        return (Vec::new(), 0);
+) -> Vec<(PrfSeededModulusSwitched, u64)> {
+    if random_bits_per_block == 0 {
+        return Vec::new();
     }
 
-    let num_blocks = bit_count.div_ceil(random_bits_per_block);
-
-    let mut last_block_bits = bit_count % random_bits_per_block;
-    if last_block_bits == 0 {
-        last_block_bits = random_bits_per_block;
-    }
-
+    // Init the hasher
     let bytes = seed.into_bytes();
     let mut hasher = sha3::Sha3_256::default();
     hasher.update(b"TFHE_PRF");
     hasher.update(bytes.as_ref());
-    if last_block_bits == random_bits_per_block {
-        // All blocks contain the same number of random bits
-        hasher.update(num_blocks.to_le_bytes());
-        hasher.update(random_bits_per_block.to_le_bytes());
-    } else {
-        let head_count = num_blocks - 1;
-        if head_count != 0 {
-            hasher.update(head_count.to_le_bytes());
-            hasher.update(random_bits_per_block.to_le_bytes());
+
+    let total_blocks: u64 = bit_chunks
+        .iter()
+        .map(|&bits| bits.div_ceil(random_bits_per_block))
+        .sum();
+    let mut seededs = Vec::with_capacity(total_blocks as usize);
+    for &bit_count in bit_chunks {
+        if bit_count == 0 {
+            continue;
         }
-        hasher.update(1u64.to_le_bytes());
-        hasher.update(last_block_bits.to_le_bytes());
+
+        let (num_full_blocks, last_block_bits) = (
+            bit_count / random_bits_per_block,
+            bit_count % random_bits_per_block,
+        );
+
+        if num_full_blocks != 0 {
+            hasher.update(num_full_blocks.to_le_bytes());
+            hasher.update(random_bits_per_block.to_le_bytes());
+
+            for _ in 0..num_full_blocks {
+                seededs.push((
+                    PrfSeededModulusSwitched::zero(
+                        lwe_size,
+                        polynomial_size.to_blind_rotation_input_modulus_log(),
+                    ),
+                    random_bits_per_block,
+                ));
+            }
+        }
+        if last_block_bits != 0 {
+            hasher.update(1u64.to_le_bytes());
+            hasher.update(last_block_bits.to_le_bytes());
+
+            seededs.push((
+                PrfSeededModulusSwitched::zero(
+                    lwe_size,
+                    polynomial_size.to_blind_rotation_input_modulus_log(),
+                ),
+                last_block_bits,
+            ));
+        }
     }
 
     let seed = hasher.finalize();
-
     let mut xof =
         RandomGenerator::<DefaultRandomGenerator>::new(XofSeed::new(seed.to_vec(), *b"PRF_INIT"));
+    for (seeded, _) in &mut seededs {
+        seeded.fill_mask_with_random(&mut xof);
+    }
 
-    let seeded = (0..num_blocks)
-        .map(|_| {
-            let mut mask = vec![0usize; lwe_size.to_lwe_dimension().0];
-            for mask_element in &mut mask {
-                *mask_element = xof.random_from_distribution_custom_mod::<u32, _>(
-                    Uniform,
-                    CiphertextModulus::new(2 * polynomial_size.0 as u128),
-                ) as usize;
-            }
-            PrfSeededModulusSwitched {
-                mask,
-                body: 0,
-                log_modulus: polynomial_size.to_blind_rotation_input_modulus_log(),
-            }
-        })
-        .collect::<Vec<_>>();
-
-    (seeded, last_block_bits)
+    seededs
 }
 
 // ============================================================================
@@ -965,28 +1023,32 @@ impl<C: Container<Element = c64> + Sync> OprfBootstrappingKey<C> {
             random_bits_count, target_sks.message_modulus.0
         );
 
-        let mut blocks = self.generate_pseudo_random_bits(
+        let mut chunks = self.generate_pseudo_random_bits(
             seed,
-            random_bits_count,
+            &[random_bits_count],
             random_bits_count, // This means we will have one block
             target_sks,
         );
+        assert_eq!(chunks.len(), 1);
+        let mut blocks = chunks.pop().unwrap();
         assert_eq!(blocks.len(), 1);
         blocks.pop().unwrap()
     }
 
-    /// Generates `bit_count` random bits split over multiple blocks.
+    /// Generates random bits split over multiple blocks, grouped per input chunk.
     ///
-    /// Each ciphertext encrypts a value in `[0, 2^random_bits_per_block[`
-    /// except for the last one which may have fewer random bits:
-    /// `bit_count=3, random_bits_per_block=2` -> first_block: 2 bits, last block: 1 bit
+    /// For each entry `bc` in `bit_chunks`, produces a `Vec<Ciphertext>` of
+    /// `ceil(bc / random_bits_per_block)` blocks. Each ciphertext encrypts a value
+    /// in `[0, 2^random_bits_per_block[` except for the last block of each chunk
+    /// which may have fewer random bits:
+    /// `bc=3, random_bits_per_block=2` -> first_block: 2 bits, last block: 1 bit.
     pub(crate) fn generate_pseudo_random_bits(
         &self,
         seed: impl OprfSeed,
-        bit_count: u64,
+        bit_chunks: &[u64],
         random_bits_per_block: u64,
         target_sks: &ServerKey,
-    ) -> Vec<Ciphertext> {
+    ) -> Vec<Vec<Ciphertext>> {
         let ks_key = match &target_sks.atomic_pattern {
             AtomicPatternServerKey::Standard(std) => {
                 self.assert_compatible_with_target_bsk(&std.bootstrapping_key);
@@ -1016,46 +1078,33 @@ impl<C: Container<Element = c64> + Sync> OprfBootstrappingKey<C> {
         let polynomial_size = self.polynomial_size();
         let in_lwe_size = self.input_lwe_dimension().to_lwe_size();
 
-        let (seeded_cts, last_block_bits) = create_random_from_seed_modulus_switched(
+        let seeded_cts = create_random_from_seed_modulus_switched(
             seed,
             in_lwe_size,
             polynomial_size,
-            bit_count,
+            bit_chunks,
             random_bits_per_block,
         );
 
         let ciphertext_modulus = target_sks.ciphertext_modulus;
+        let max_bits = seeded_cts.iter().map(|(_, b)| *b).max().unwrap_or(0);
+        let luts = (1..=max_bits)
+            .map(|bit| {
+                generate_oprf_lut(
+                    bit,
+                    bits_in_one_block,
+                    polynomial_size,
+                    self.glwe_size(),
+                    ciphertext_modulus,
+                )
+            })
+            .collect::<Vec<_>>();
 
-        let regular_lut = generate_oprf_lut(
-            random_bits_per_block,
-            bits_in_one_block,
-            polynomial_size,
-            self.glwe_size(),
-            ciphertext_modulus,
-        );
-        let last_block_lut = if last_block_bits == random_bits_per_block {
-            None
-        } else {
-            Some(generate_oprf_lut(
-                last_block_bits,
-                bits_in_one_block,
-                polynomial_size,
-                self.glwe_size(),
-                ciphertext_modulus,
-            ))
-        };
-
-        let num_blocks = seeded_cts.len();
-        seeded_cts
+        let flat: Vec<Ciphertext> = seeded_cts
             .into_par_iter()
-            .enumerate()
-            .map(|(i, seeded)| {
+            .map(|(seeded, num_bits)| {
                 let (LookupTableOwned { mut acc, degree }, post_pbs_constant) =
-                    if i == num_blocks - 1 && last_block_lut.is_some() {
-                        last_block_lut.clone().unwrap()
-                    } else {
-                        regular_lut.clone()
-                    };
+                    luts[num_bits as usize - 1].clone();
 
                 match self {
                     Self::Classic { bsk, .. } => {
@@ -1114,6 +1163,15 @@ impl<C: Container<Element = c64> + Sync> OprfBootstrappingKey<C> {
                     target_sks.carry_modulus,
                     target_sks.atomic_pattern.kind(),
                 )
+            })
+            .collect();
+
+        let mut iter = flat.into_iter();
+        bit_chunks
+            .iter()
+            .map(|&bc| {
+                let n = bc.div_ceil(random_bits_per_block) as usize;
+                iter.by_ref().take(n).collect()
             })
             .collect()
     }
@@ -1291,12 +1349,12 @@ pub(crate) mod test {
             seed,
             lwe_size,
             params.polynomial_size(),
-            params.message_modulus().0.ilog2() as u64,
+            &[params.message_modulus().0.ilog2() as u64],
             params.message_modulus().0.ilog2() as u64,
         )
-        .0
         .pop()
-        .unwrap();
+        .unwrap()
+        .0;
 
         assert!(seeded.mask.iter().all(|v| *v < input_p as usize));
 

--- a/tfhe/src/shortint/oprf.rs
+++ b/tfhe/src/shortint/oprf.rs
@@ -906,6 +906,9 @@ pub(crate) fn create_random_from_seed_modulus_switched(
             bit_count % random_bits_per_block,
         );
 
+        let num_blocks = num_full_blocks + u64::from(last_block_bits != 0);
+        hasher.update(num_blocks.to_le_bytes());
+
         if num_full_blocks != 0 {
             hasher.update(num_full_blocks.to_le_bytes());
             hasher.update(random_bits_per_block.to_le_bytes());


### PR DESCRIPTION
Bitonic shuffles allows to shuffle a vec of homomorphic integers by using a bitonic sort using random generated keys


closes https://github.com/zama-ai/tfhe-rs-internal/issues/1357

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3430)
<!-- Reviewable:end -->
