### PR TITLE
chore(gpu): rewrite GPU ZK prove/verify pipeline

### DIFF
--- a/backends/tfhe-cuda-backend/src/cuda_bind.rs
+++ b/backends/tfhe-cuda-backend/src/cuda_bind.rs
@@ -60,3 +60,56 @@ extern "C" {
     pub fn cuda_drop(ptr: *mut c_void, gpu_index: u32);
 
 } // extern "C"
+
+/// Single CUDA stream handle with automatic cleanup.
+///
+/// Wraps a `cudaStream_t` (opaque `*mut c_void`) and the GPU index it belongs to.
+/// The stream is destroyed on drop.
+pub struct CudaStream {
+    ptr: *mut c_void,
+    gpu_index: u32,
+}
+
+// SAFETY: CUDA stream handles are safe to use from any host thread for
+// submission. The CUDA runtime serializes operations enqueued on the same
+// stream regardless of which host thread submits them.
+unsafe impl Send for CudaStream {}
+unsafe impl Sync for CudaStream {}
+
+impl CudaStream {
+    pub fn new(gpu_index: u32) -> Self {
+        // SAFETY: gpu_index must refer to a valid CUDA device. The caller is
+        // responsible for ensuring the device ordinal is in range (upstream code
+        // validates via cuda_get_number_of_gpus).
+        let ptr = unsafe { cuda_create_stream(gpu_index) };
+        assert!(
+            !ptr.is_null(),
+            "cuda_create_stream returned null for gpu_index {gpu_index}"
+        );
+        Self { ptr, gpu_index }
+    }
+
+    pub fn ptr(&self) -> *mut c_void {
+        self.ptr
+    }
+
+    pub fn gpu_index(&self) -> u32 {
+        self.gpu_index
+    }
+}
+
+impl std::fmt::Debug for CudaStream {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CudaStream")
+            .field("gpu_index", &self.gpu_index)
+            .field("ptr", &self.ptr)
+            .finish()
+    }
+}
+
+impl Drop for CudaStream {
+    fn drop(&mut self) {
+        // SAFETY: self.ptr was allocated by cuda_create_stream in new().
+        unsafe { cuda_destroy_stream(self.ptr, self.gpu_index) };
+    }
+}

--- a/backends/tfhe-cuda-backend/src/lib.rs
+++ b/backends/tfhe-cuda-backend/src/lib.rs
@@ -2,3 +2,5 @@
 pub mod bindings;
 pub mod cuda_bind;
 pub mod ffi;
+
+pub use cuda_bind::CudaStream;

--- a/backends/zk-cuda-backend/NAMING_CONVENTIONS.md
+++ b/backends/zk-cuda-backend/NAMING_CONVENTIONS.md
@@ -116,6 +116,18 @@ Internal: `point_msm_g1_async`, `point_msm_g1`, `pippenger_scratch_size_g1` (gro
 - Group suffix: `affine_to_projective_g1_wrapper`, `is_on_curve_g1_wrapper`, `pippenger_scratch_size_g1_wrapper`
 - No group: `fp_to_montgomery_wrapper`, `scalar_modulus_limbs_wrapper`
 
+### Internal Implementations (`_impl` suffix)
+
+**Rule: `*_impl` suffix** for internal C++ functions whose name would otherwise collide with an `extern "C"` FFI symbol.
+
+When a header (e.g., `msm_utils.h`) defines a function with the same name as an FFI function in `c_wrapper.cu`/`api.h`, the internal function gets `_impl` appended. The FFI function then forwards to the `_impl` variant.
+
+Do **not** use C++ namespaces to avoid these collisions — neither `zk-cuda-backend` nor `tfhe-cuda-backend` uses namespaces.
+
+Examples:
+- `scratch_zk_g1_msm_impl` (internal) → `scratch_zk_g1_msm` (FFI)
+- `zk_msm_cache_acquire_impl` (internal) → `zk_msm_cache_acquire` (FFI)
+
 ### Rust API
 
 Standard Rust `snake_case`: `to_projective()`, `from_montgomery_normalized()`, `is_infinity()`, `msm()`.

--- a/backends/zk-cuda-backend/build.rs
+++ b/backends/zk-cuda-backend/build.rs
@@ -105,9 +105,11 @@ fn main() {
 
             let bindings = bindgen::Builder::default()
                 .header(header_path.to_str().unwrap())
-                // Allow only the wrapper functions (C FFI interface)
                 .allowlist_function(".*_wrapper(_async)?")
-                // Allow the core types needed for FFI
+                .allowlist_function("scratch_zk_.*")
+                .allowlist_function("cleanup_zk_.*")
+                .allowlist_function("zk_g[12]_msm.*")
+                .allowlist_function("zk_msm_cache_.*")
                 .allowlist_type("G1Point")
                 .allowlist_type("G2Point")
                 .allowlist_type("G1ProjectivePoint")
@@ -117,6 +119,8 @@ fn main() {
                 .allowlist_type("Scalar")
                 .allowlist_type("BigInt")
                 .allowlist_type("cudaStream_t")
+                .allowlist_type("zk_g[12]_msm_mem")
+                .allowlist_type("zk_cached_g[12]_points")
                 // Derive Default, PartialEq and Eq for all types so wrapper
                 // types can use derive macros instead of manual impls
                 .derive_default(true)

--- a/backends/zk-cuda-backend/cuda/include/msm.h
+++ b/backends/zk-cuda-backend/cuda/include/msm.h
@@ -117,3 +117,60 @@ void point_msm_g2(cudaStream_t stream, uint32_t gpu_index,
                   G2ProjectivePoint *h_result, const G2Point *d_points,
                   const Scalar *d_scalars, uint32_t n,
                   G2ProjectivePoint *d_scratch);
+
+// Splits the MSM into a truly async GPU launch and a CPU finalize step,
+// allowing GPU kernel execution to overlap with CPU work (e.g., pairings).
+// This is important since our MSM performs the Horner reduction on CPU for
+// performance reasons and we would like not to stall the CPU pipeline.
+//
+// Step 1: Launch (GPU-accelerated, asynchronous)
+//   - Executes Pippenger bucket method on GPU (phases 1-3):
+//     * Phase 1: Decompose scalars into windows and accumulate points into
+//     buckets
+//     * Phase 2: Sum buckets within each window (bucket reduction)
+//     * Phase 3: Combine bucket sums into window sums
+//   - Queues asynchronous D2H transfer of window sums to host memory
+//   - Returns immediately without synchronization, allowing GPU to run in
+//   parallel
+//
+// Step 2: Finalize (CPU-only, requires prior stream sync)
+//   - Performs Horner reduction on window sums (already in host memory)
+//   - Combines windows: result = w[0] + 2^c*w[1] + 2^(2c)*w[2] + ... (c =
+//   window_size)
+//   - Runs on CPU because host-side arithmetic is faster than GPU for this
+//   final step
+//
+// The split allows CPU pairing setup to overlap with GPU MSM execution.
+
+// Launches G1 Pippenger phases 1-3 and queues async D2H copy of window sums.
+// Does NOT synchronize or run the Horner combine. The caller must sync the
+// stream and then call point_msm_g1_horner_finalize() to get the result.
+void point_msm_g1_launch_async(cudaStream_t stream, uint32_t gpu_index,
+                               G1Projective *h_window_sums,
+                               const G1Affine *d_points,
+                               const Scalar *d_scalars, uint32_t n,
+                               G1Projective *d_scratch,
+                               uint32_t &out_num_windows,
+                               uint32_t &out_window_size);
+
+// Runs the CPU Horner combine on G1 window sums already in host memory.
+// The stream must have been synchronized before calling this.
+void point_msm_g1_horner_finalize(G1Projective *h_result,
+                                  const G1Projective *h_window_sums,
+                                  uint32_t num_windows, uint32_t window_size);
+
+// Launches G2 Pippenger phases 1-3 and queues async D2H copy of window sums.
+// Does NOT synchronize or run the Horner combine. The caller must sync the
+// stream and then call point_msm_g2_horner_finalize() to get the result.
+void point_msm_g2_launch_async(cudaStream_t stream, uint32_t gpu_index,
+                               G2ProjectivePoint *h_window_sums,
+                               const G2Point *d_points, const Scalar *d_scalars,
+                               uint32_t n, G2ProjectivePoint *d_scratch,
+                               uint32_t &out_num_windows,
+                               uint32_t &out_window_size);
+
+// Runs the CPU Horner combine on G2 window sums already in host memory.
+// The stream must have been synchronized before calling this.
+void point_msm_g2_horner_finalize(G2ProjectivePoint *h_result,
+                                  const G2ProjectivePoint *h_window_sums,
+                                  uint32_t num_windows, uint32_t window_size);

--- a/backends/zk-cuda-backend/cuda/include/msm_utils.h
+++ b/backends/zk-cuda-backend/cuda/include/msm_utils.h
@@ -1,0 +1,690 @@
+#pragma once
+
+#include "bls12_446_params.h"
+#include "checked_arithmetic.h"
+#include "device.h"
+#include "msm.h"
+#include <condition_variable>
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <functional>
+#include <mutex>
+
+#include "../../../tfhe-cuda-backend/cuda/src/utils/helper_profile.cuh"
+
+static void convert_g1_points_to_montgomery(cudaStream_t stream,
+                                            uint32_t gpu_index,
+                                            G1Affine *d_points, uint32_t n) {
+  point_to_montgomery_batch_async<G1Affine>(stream, gpu_index, d_points, n);
+}
+
+static void convert_g2_points_to_montgomery(cudaStream_t stream,
+                                            uint32_t gpu_index,
+                                            G2Affine *d_points, uint32_t n) {
+  point_to_montgomery_batch_async<G2Affine>(stream, gpu_index, d_points, n);
+}
+
+template <typename AffineType> struct MsmTraits;
+
+template <> struct MsmTraits<G1Affine> {
+  static constexpr uint32_t WindowSize = MSM_G1_WINDOW_SIZE;
+  using ProjectiveType = G1Projective;
+
+  static size_t scratch_size(uint32_t n, uint32_t gpu_index) {
+    return pippenger_scratch_size_g1(n, gpu_index);
+  }
+
+  static void convert_to_montgomery(cudaStream_t stream, uint32_t gpu_index,
+                                    G1Affine *d_points, uint32_t n) {
+    point_to_montgomery_batch_async<G1Affine>(stream, gpu_index, d_points, n);
+  }
+
+  static void launch_async(cudaStream_t stream, uint32_t gpu_index,
+                           ProjectiveType *h_window_sums,
+                           const G1Affine *d_points, const Scalar *d_scalars,
+                           uint32_t n, ProjectiveType *d_scratch,
+                           uint32_t &out_num_windows,
+                           uint32_t &out_window_size) {
+    point_msm_g1_launch_async(stream, gpu_index, h_window_sums, d_points,
+                              d_scalars, n, d_scratch, out_num_windows,
+                              out_window_size);
+  }
+
+  static void horner_finalize(ProjectiveType *h_result,
+                              const ProjectiveType *h_window_sums,
+                              uint32_t num_windows, uint32_t window_size) {
+    point_msm_g1_horner_finalize(h_result, h_window_sums, num_windows,
+                                 window_size);
+  }
+};
+
+template <> struct MsmTraits<G2Affine> {
+  static constexpr uint32_t WindowSize = MSM_G2_WINDOW_SIZE;
+  using ProjectiveType = G2Projective;
+
+  static size_t scratch_size(uint32_t n, uint32_t gpu_index) {
+    return pippenger_scratch_size_g2(n, gpu_index);
+  }
+
+  static void convert_to_montgomery(cudaStream_t stream, uint32_t gpu_index,
+                                    G2Affine *d_points, uint32_t n) {
+    point_to_montgomery_batch_async<G2Affine>(stream, gpu_index, d_points, n);
+  }
+
+  static void launch_async(cudaStream_t stream, uint32_t gpu_index,
+                           ProjectiveType *h_window_sums,
+                           const G2Affine *d_points, const Scalar *d_scalars,
+                           uint32_t n, ProjectiveType *d_scratch,
+                           uint32_t &out_num_windows,
+                           uint32_t &out_window_size) {
+    point_msm_g2_launch_async(stream, gpu_index, h_window_sums, d_points,
+                              d_scalars, n, d_scratch, out_num_windows,
+                              out_window_size);
+  }
+
+  static void horner_finalize(ProjectiveType *h_result,
+                              const ProjectiveType *h_window_sums,
+                              uint32_t num_windows, uint32_t window_size) {
+    point_msm_g2_horner_finalize(h_result, h_window_sums, num_windows,
+                                 window_size);
+  }
+};
+
+// Pre-allocated MSM context reused across many MSM calls. Holds device
+// buffers for points, scalars, Pippenger scratch, and a host buffer for
+// window sums (used by the launch/finalize split).
+template <typename AffineType> struct zk_msm_mem {
+  using Traits = MsmTraits<AffineType>;
+  using ProjType = typename Traits::ProjectiveType;
+
+  AffineType *d_points; // device buffer for affine points
+  Scalar *d_scalars;    // device buffer for scalars
+  ProjType *d_scratch;  // Pippenger scratch buffer
+  uint32_t capacity;    // max number of points this context can handle
+
+  // Host buffer for Pippenger window sums. Allocated once during scratch
+  // setup, filled by async D2H in launch, read by finalize.
+  ProjType *h_window_sums;  // host memory for window sums
+  uint32_t max_num_windows; // capacity of h_window_sums
+  uint32_t num_windows;     // set during launch, used by finalize
+  uint32_t window_size;     // set during launch, used by finalize
+};
+
+using zk_g1_msm_mem = zk_msm_mem<G1Affine>;
+using zk_g2_msm_mem = zk_msm_mem<G2Affine>;
+
+// Base points cached on device in Montgomery form. Set up once per CRS
+// and reused across verify MSM calls.
+template <typename AffineType> struct zk_cached_points {
+  AffineType *d_points; // device buffer, Montgomery form
+  uint32_t n;           // number of points
+  uint32_t gpu_index;   // GPU this buffer lives on
+};
+
+using zk_cached_g1_points = zk_cached_points<G1Affine>;
+using zk_cached_g2_points = zk_cached_points<G2Affine>;
+
+template <typename AffineType>
+void scratch_zk_msm(cudaStream_t stream, uint32_t gpu_index,
+                    zk_msm_mem<AffineType> **mem, uint32_t max_n,
+                    uint64_t *size_tracker, bool allocate_gpu_memory) {
+  using Traits = MsmTraits<AffineType>;
+  using ProjType = typename Traits::ProjectiveType;
+
+  PANIC_IF_FALSE(mem != nullptr, "scratch_zk_msm: mem is null");
+  PANIC_IF_FALSE(max_n > 0, "scratch_zk_msm: max_n must be positive");
+  PANIC_IF_FALSE(stream != nullptr, "scratch_zk_msm: stream is null");
+  PANIC_IF_FALSE(size_tracker != nullptr,
+                 "scratch_zk_msm: size_tracker is null");
+  PANIC_IF_FALSE(gpu_index < static_cast<uint32_t>(cuda_get_number_of_gpus()),
+                 "scratch_zk_msm: invalid gpu_index=%u (gpu_count=%d)",
+                 gpu_index, cuda_get_number_of_gpus());
+
+  *mem = new zk_msm_mem<AffineType>;
+  (*mem)->capacity = max_n;
+
+  uint64_t &tracker = *size_tracker;
+
+  size_t points_bytes = safe_mul_sizeof<AffineType>(static_cast<size_t>(max_n));
+  size_t scalars_bytes = safe_mul_sizeof<Scalar>(static_cast<size_t>(max_n));
+  size_t scratch_bytes = Traits::scratch_size(max_n, gpu_index);
+
+  (*mem)->d_points =
+      static_cast<AffineType *>(cuda_malloc_with_size_tracking_async(
+          points_bytes, stream, gpu_index, tracker, allocate_gpu_memory));
+  (*mem)->d_scalars =
+      static_cast<Scalar *>(cuda_malloc_with_size_tracking_async(
+          scalars_bytes, stream, gpu_index, tracker, allocate_gpu_memory));
+  (*mem)->d_scratch =
+      static_cast<ProjType *>(cuda_malloc_with_size_tracking_async(
+          scratch_bytes, stream, gpu_index, tracker, allocate_gpu_memory));
+
+  // Allocate host buffer for window sums (used by launch/finalize split).
+  const uint32_t max_num_windows =
+      CEIL_DIV(Scalar::NUM_BITS, Traits::WindowSize);
+  (*mem)->max_num_windows = max_num_windows;
+  (*mem)->num_windows = 0;
+  (*mem)->window_size = 0;
+
+  size_t window_sums_bytes =
+      safe_mul_sizeof<ProjType>(static_cast<size_t>(max_num_windows));
+  // TODO: benchmark cudaMallocHost (pinned memory) -- it may improve async D2H
+  // overlap
+  (*mem)->h_window_sums = static_cast<ProjType *>(malloc(window_sums_bytes));
+  PANIC_IF_FALSE((*mem)->h_window_sums != nullptr,
+                 "scratch_zk_msm: malloc failed for h_window_sums");
+}
+
+template <typename AffineType>
+void cleanup_zk_msm(cudaStream_t stream, uint32_t gpu_index,
+                    zk_msm_mem<AffineType> **mem, bool allocate_gpu_memory) {
+  PANIC_IF_FALSE(mem != nullptr && *mem != nullptr,
+                 "cleanup_zk_msm: mem is null");
+  PANIC_IF_FALSE(stream != nullptr, "cleanup_zk_msm: stream is null");
+  PANIC_IF_FALSE(gpu_index < static_cast<uint32_t>(cuda_get_number_of_gpus()),
+                 "cleanup_zk_msm: invalid gpu_index=%u (gpu_count=%d)",
+                 gpu_index, cuda_get_number_of_gpus());
+
+  cuda_drop_with_size_tracking_async((*mem)->d_points, stream, gpu_index,
+                                     allocate_gpu_memory);
+  cuda_drop_with_size_tracking_async((*mem)->d_scalars, stream, gpu_index,
+                                     allocate_gpu_memory);
+  cuda_drop_with_size_tracking_async((*mem)->d_scratch, stream, gpu_index,
+                                     allocate_gpu_memory);
+
+  if ((*mem)->h_window_sums != nullptr) {
+    free((*mem)->h_window_sums);
+  }
+
+  delete *mem;
+  *mem = nullptr;
+
+  cuda_synchronize_stream(stream, gpu_index);
+}
+
+// Reuses scratch.h_window_sums to avoid per-call malloc/free.
+template <typename AffineType>
+void zk_msm_async(cudaStream_t stream, uint32_t gpu_index,
+                  zk_msm_mem<AffineType> *mem,
+                  typename MsmTraits<AffineType>::ProjectiveType *h_result,
+                  const AffineType *h_points, const Scalar *h_scalars,
+                  uint32_t n, bool points_in_montgomery) {
+  using Traits = MsmTraits<AffineType>;
+
+  PUSH_RANGE("MSM ASYNC (SCRATCH)");
+  PANIC_IF_FALSE(mem != nullptr, "zk_msm_async: mem is null");
+  PANIC_IF_FALSE(n > 0, "zk_msm_async: n must be positive, got %u", n);
+  PANIC_IF_FALSE(n <= mem->capacity,
+                 "zk_msm_async: n=%u exceeds pre-allocated capacity=%u", n,
+                 mem->capacity);
+  PANIC_IF_FALSE(stream != nullptr, "zk_msm_async: stream is null");
+  PANIC_IF_FALSE(gpu_index < static_cast<uint32_t>(cuda_get_number_of_gpus()),
+                 "zk_msm_async: invalid gpu_index=%u (gpu_count=%d)", gpu_index,
+                 cuda_get_number_of_gpus());
+  PANIC_IF_FALSE(h_result != nullptr, "zk_msm_async: h_result is null");
+  PANIC_IF_FALSE(h_points != nullptr, "zk_msm_async: h_points is null");
+  PANIC_IF_FALSE(h_scalars != nullptr, "zk_msm_async: h_scalars is null");
+
+  size_t points_bytes = safe_mul_sizeof<AffineType>(static_cast<size_t>(n));
+  size_t scalars_bytes = safe_mul_sizeof<Scalar>(static_cast<size_t>(n));
+
+  cuda_memcpy_async_to_gpu(mem->d_points, h_points, points_bytes, stream,
+                           gpu_index);
+  cuda_memcpy_async_to_gpu(mem->d_scalars, h_scalars, scalars_bytes, stream,
+                           gpu_index);
+
+  if (!points_in_montgomery) {
+    Traits::convert_to_montgomery(stream, gpu_index, mem->d_points, n);
+    check_cuda_error(cudaGetLastError());
+  }
+
+  Traits::launch_async(stream, gpu_index, mem->h_window_sums, mem->d_points,
+                       mem->d_scalars, n, mem->d_scratch, mem->num_windows,
+                       mem->window_size);
+  cuda_synchronize_stream(stream, gpu_index);
+  Traits::horner_finalize(h_result, mem->h_window_sums, mem->num_windows,
+                          mem->window_size);
+  check_cuda_error(cudaGetLastError());
+  POP_RANGE();
+}
+
+template <typename AffineType>
+void scratch_zk_cached_points(cudaStream_t stream, uint32_t gpu_index,
+                              zk_cached_points<AffineType> **mem,
+                              const AffineType *h_points, uint32_t n,
+                              uint64_t *size_tracker,
+                              bool allocate_gpu_memory) {
+  using Traits = MsmTraits<AffineType>;
+
+  PANIC_IF_FALSE(mem != nullptr, "scratch_zk_cached_points: mem is null");
+  PANIC_IF_FALSE(h_points != nullptr,
+                 "scratch_zk_cached_points: h_points is null");
+  PANIC_IF_FALSE(n > 0, "scratch_zk_cached_points: n must be positive");
+  PANIC_IF_FALSE(stream != nullptr, "scratch_zk_cached_points: stream is null");
+  PANIC_IF_FALSE(size_tracker != nullptr,
+                 "scratch_zk_cached_points: size_tracker is null");
+  PANIC_IF_FALSE(
+      gpu_index < static_cast<uint32_t>(cuda_get_number_of_gpus()),
+      "scratch_zk_cached_points: invalid gpu_index=%u (gpu_count=%d)",
+      gpu_index, cuda_get_number_of_gpus());
+
+  *mem = new zk_cached_points<AffineType>;
+  (*mem)->n = n;
+  (*mem)->gpu_index = gpu_index;
+
+  uint64_t &tracker = *size_tracker;
+  size_t points_bytes = safe_mul_sizeof<AffineType>(static_cast<size_t>(n));
+
+  (*mem)->d_points =
+      static_cast<AffineType *>(cuda_malloc_with_size_tracking_async(
+          points_bytes, stream, gpu_index, tracker, allocate_gpu_memory));
+
+  cuda_memcpy_async_to_gpu((*mem)->d_points, h_points, points_bytes, stream,
+                           gpu_index);
+  Traits::convert_to_montgomery(stream, gpu_index, (*mem)->d_points, n);
+  check_cuda_error(cudaGetLastError());
+
+  // Sync so the cache is immediately usable by any stream.
+  cuda_synchronize_stream(stream, gpu_index);
+}
+
+template <typename AffineType>
+void cleanup_zk_cached_points(cudaStream_t stream, uint32_t gpu_index,
+                              zk_cached_points<AffineType> **mem,
+                              bool allocate_gpu_memory) {
+  PANIC_IF_FALSE(mem != nullptr && *mem != nullptr,
+                 "cleanup_zk_cached_points: mem is null");
+  PANIC_IF_FALSE(stream != nullptr, "cleanup_zk_cached_points: stream is null");
+
+  cuda_drop_with_size_tracking_async((*mem)->d_points, stream, gpu_index,
+                                     allocate_gpu_memory);
+
+  delete *mem;
+  *mem = nullptr;
+
+  cuda_synchronize_stream(stream, gpu_index);
+}
+
+template <typename AffineType>
+void zk_msm_cached_async(
+    cudaStream_t stream, uint32_t gpu_index, zk_msm_mem<AffineType> *msm_mem,
+    typename MsmTraits<AffineType>::ProjectiveType *h_result,
+    const zk_cached_points<AffineType> *cached, uint32_t point_offset,
+    const Scalar *h_scalars, uint32_t n) {
+  using Traits = MsmTraits<AffineType>;
+
+  PUSH_RANGE("MSM CACHED");
+  PANIC_IF_FALSE(msm_mem != nullptr, "zk_msm_cached_async: msm_mem is null");
+  PANIC_IF_FALSE(cached != nullptr, "zk_msm_cached_async: cached is null");
+  PANIC_IF_FALSE(n > 0, "zk_msm_cached_async: n must be positive, got %u", n);
+  PANIC_IF_FALSE(n <= msm_mem->capacity,
+                 "zk_msm_cached_async: n=%u exceeds msm_mem capacity=%u", n,
+                 msm_mem->capacity);
+  PANIC_IF_FALSE(
+      static_cast<uint64_t>(point_offset) + n <= cached->n,
+      "zk_msm_cached_async: point_offset=%u + n=%u exceeds cached points=%u",
+      point_offset, n, cached->n);
+  PANIC_IF_FALSE(stream != nullptr, "zk_msm_cached_async: stream is null");
+  PANIC_IF_FALSE(gpu_index < static_cast<uint32_t>(cuda_get_number_of_gpus()),
+                 "zk_msm_cached_async: invalid gpu_index=%u (gpu_count=%d)",
+                 gpu_index, cuda_get_number_of_gpus());
+  PANIC_IF_FALSE(
+      gpu_index == cached->gpu_index,
+      "zk_msm_cached_async: gpu_index=%u but cached points are on gpu=%u",
+      gpu_index, cached->gpu_index);
+  PANIC_IF_FALSE(h_result != nullptr, "zk_msm_cached_async: h_result is null");
+  PANIC_IF_FALSE(h_scalars != nullptr,
+                 "zk_msm_cached_async: h_scalars is null");
+
+  size_t scalars_bytes = safe_mul_sizeof<Scalar>(static_cast<size_t>(n));
+  cuda_memcpy_async_to_gpu(msm_mem->d_scalars, h_scalars, scalars_bytes, stream,
+                           gpu_index);
+
+  // Cached points are already in Montgomery form, which is what Pippenger
+  // expects. The scratch buffer from msm_mem was sized for msm_mem->capacity >=
+  // n, and pippenger_scratch_size is monotonically non-decreasing, so it is
+  // sufficient.
+  Traits::launch_async(stream, gpu_index, msm_mem->h_window_sums,
+                       cached->d_points + point_offset, msm_mem->d_scalars, n,
+                       msm_mem->d_scratch, msm_mem->num_windows,
+                       msm_mem->window_size);
+  cuda_synchronize_stream(stream, gpu_index);
+  Traits::horner_finalize(h_result, msm_mem->h_window_sums,
+                          msm_mem->num_windows, msm_mem->window_size);
+  check_cuda_error(cudaGetLastError());
+  POP_RANGE();
+}
+
+// Splits MSM into an async GPU launch and a CPU-side finalize, so the
+// caller can overlap CPU work (e.g. pairings) with GPU execution.
+
+template <typename AffineType>
+void zk_msm_cached_launch_async(cudaStream_t stream, uint32_t gpu_index,
+                                zk_msm_mem<AffineType> *msm_mem,
+                                const zk_cached_points<AffineType> *cached,
+                                uint32_t point_offset, const Scalar *h_scalars,
+                                uint32_t n) {
+  using Traits = MsmTraits<AffineType>;
+
+  PUSH_RANGE("MSM CACHED LAUNCH");
+  PANIC_IF_FALSE(msm_mem != nullptr,
+                 "zk_msm_cached_launch_async: msm_mem is null");
+  PANIC_IF_FALSE(cached != nullptr,
+                 "zk_msm_cached_launch_async: cached is null");
+  PANIC_IF_FALSE(n > 0,
+                 "zk_msm_cached_launch_async: n must be positive, got %u", n);
+  PANIC_IF_FALSE(n <= msm_mem->capacity,
+                 "zk_msm_cached_launch_async: n=%u exceeds msm_mem capacity=%u",
+                 n, msm_mem->capacity);
+  PANIC_IF_FALSE(
+      static_cast<uint64_t>(point_offset) + n <= cached->n,
+      "zk_msm_cached_launch_async: point_offset=%u + n=%u exceeds cached "
+      "points=%u",
+      point_offset, n, cached->n);
+  PANIC_IF_FALSE(stream != nullptr,
+                 "zk_msm_cached_launch_async: stream is null");
+  PANIC_IF_FALSE(
+      gpu_index < static_cast<uint32_t>(cuda_get_number_of_gpus()),
+      "zk_msm_cached_launch_async: invalid gpu_index=%u (gpu_count=%d)",
+      gpu_index, cuda_get_number_of_gpus());
+  PANIC_IF_FALSE(
+      gpu_index == cached->gpu_index,
+      "zk_msm_cached_launch_async: gpu_index=%u but cached points are on "
+      "gpu=%u",
+      gpu_index, cached->gpu_index);
+  PANIC_IF_FALSE(h_scalars != nullptr,
+                 "zk_msm_cached_launch_async: h_scalars is null");
+  PANIC_IF_FALSE(
+      msm_mem->h_window_sums != nullptr,
+      "zk_msm_cached_launch_async: h_window_sums is null (scratch not "
+      "allocated?)");
+
+  size_t scalars_bytes = safe_mul_sizeof<Scalar>(static_cast<size_t>(n));
+  cuda_memcpy_async_to_gpu(msm_mem->d_scalars, h_scalars, scalars_bytes, stream,
+                           gpu_index);
+
+  Traits::launch_async(stream, gpu_index, msm_mem->h_window_sums,
+                       cached->d_points + point_offset, msm_mem->d_scalars, n,
+                       msm_mem->d_scratch, msm_mem->num_windows,
+                       msm_mem->window_size);
+  check_cuda_error(cudaGetLastError());
+  POP_RANGE();
+}
+
+// Syncs the stream, runs CPU Horner combine on the window sums from the
+// launch phase, and writes the final result to `h_result`.
+template <typename AffineType>
+void zk_msm_finalize(cudaStream_t stream, uint32_t gpu_index,
+                     const zk_msm_mem<AffineType> *msm_mem,
+                     typename MsmTraits<AffineType>::ProjectiveType *h_result) {
+  using Traits = MsmTraits<AffineType>;
+
+  PUSH_RANGE("MSM FINALIZE");
+  PANIC_IF_FALSE(msm_mem != nullptr, "zk_msm_finalize: msm_mem is null");
+  PANIC_IF_FALSE(h_result != nullptr, "zk_msm_finalize: h_result is null");
+  PANIC_IF_FALSE(stream != nullptr, "zk_msm_finalize: stream is null");
+  PANIC_IF_FALSE(msm_mem->num_windows > 0,
+                 "zk_msm_finalize: num_windows is 0 (launch not called?)");
+  PANIC_IF_FALSE(msm_mem->h_window_sums != nullptr,
+                 "zk_msm_finalize: h_window_sums is null");
+
+  cuda_synchronize_stream(stream, gpu_index);
+
+  Traits::horner_finalize(h_result, msm_mem->h_window_sums,
+                          msm_mem->num_windows, msm_mem->window_size);
+  POP_RANGE();
+}
+
+void scratch_zk_g1_msm_impl(cudaStream_t stream, uint32_t gpu_index,
+                            zk_g1_msm_mem **mem, uint32_t max_n,
+                            uint64_t *size_tracker, bool allocate_gpu_memory) {
+  scratch_zk_msm<G1Affine>(stream, gpu_index, mem, max_n, size_tracker,
+                           allocate_gpu_memory);
+}
+
+void cleanup_zk_g1_msm_impl(cudaStream_t stream, uint32_t gpu_index,
+                            zk_g1_msm_mem **mem, bool allocate_gpu_memory) {
+  cleanup_zk_msm<G1Affine>(stream, gpu_index, mem, allocate_gpu_memory);
+}
+
+void scratch_zk_cached_g1_points_impl(cudaStream_t stream, uint32_t gpu_index,
+                                      zk_cached_g1_points **mem,
+                                      const G1Affine *h_points, uint32_t n,
+                                      uint64_t *size_tracker,
+                                      bool allocate_gpu_memory) {
+  scratch_zk_cached_points<G1Affine>(stream, gpu_index, mem, h_points, n,
+                                     size_tracker, allocate_gpu_memory);
+}
+
+void cleanup_zk_cached_g1_points_impl(cudaStream_t stream, uint32_t gpu_index,
+                                      zk_cached_g1_points **mem,
+                                      bool allocate_gpu_memory) {
+  cleanup_zk_cached_points<G1Affine>(stream, gpu_index, mem,
+                                     allocate_gpu_memory);
+}
+
+void zk_g1_msm_cached_async_impl(cudaStream_t stream, uint32_t gpu_index,
+                                 zk_g1_msm_mem *msm_mem, G1Projective *h_result,
+                                 const zk_cached_g1_points *cached,
+                                 uint32_t point_offset, const Scalar *h_scalars,
+                                 uint32_t n) {
+  zk_msm_cached_async<G1Affine>(stream, gpu_index, msm_mem, h_result, cached,
+                                point_offset, h_scalars, n);
+}
+
+void scratch_zk_g2_msm_impl(cudaStream_t stream, uint32_t gpu_index,
+                            zk_g2_msm_mem **mem, uint32_t max_n,
+                            uint64_t *size_tracker, bool allocate_gpu_memory) {
+  scratch_zk_msm<G2Affine>(stream, gpu_index, mem, max_n, size_tracker,
+                           allocate_gpu_memory);
+}
+
+void cleanup_zk_g2_msm_impl(cudaStream_t stream, uint32_t gpu_index,
+                            zk_g2_msm_mem **mem, bool allocate_gpu_memory) {
+  cleanup_zk_msm<G2Affine>(stream, gpu_index, mem, allocate_gpu_memory);
+}
+
+void scratch_zk_cached_g2_points_impl(cudaStream_t stream, uint32_t gpu_index,
+                                      zk_cached_g2_points **mem,
+                                      const G2Affine *h_points, uint32_t n,
+                                      uint64_t *size_tracker,
+                                      bool allocate_gpu_memory) {
+  scratch_zk_cached_points<G2Affine>(stream, gpu_index, mem, h_points, n,
+                                     size_tracker, allocate_gpu_memory);
+}
+
+void cleanup_zk_cached_g2_points_impl(cudaStream_t stream, uint32_t gpu_index,
+                                      zk_cached_g2_points **mem,
+                                      bool allocate_gpu_memory) {
+  cleanup_zk_cached_points<G2Affine>(stream, gpu_index, mem,
+                                     allocate_gpu_memory);
+}
+
+void zk_g2_msm_cached_async_impl(cudaStream_t stream, uint32_t gpu_index,
+                                 zk_g2_msm_mem *msm_mem, G2Projective *h_result,
+                                 const zk_cached_g2_points *cached,
+                                 uint32_t point_offset, const Scalar *h_scalars,
+                                 uint32_t n) {
+  zk_msm_cached_async<G2Affine>(stream, gpu_index, msm_mem, h_result, cached,
+                                point_offset, h_scalars, n);
+}
+
+// Populated once via zk_msm_cache_acquire(), lives until zk_msm_cache_reset()
+// or process exit. Protected by a std::mutex for the populate-or-return check.
+// Once populated, all readers access immutable data (base points in Montgomery
+// form on each GPU), so no lock is needed for reads.
+
+static constexpr uint32_t MAX_CACHE_GPUS = 16;
+
+struct ZkMsmCache {
+  zk_cached_g1_points *g1_per_gpu[MAX_CACHE_GPUS];
+  zk_cached_g2_points *g2_per_gpu[MAX_CACHE_GPUS];
+  cudaStream_t mgmt_streams[MAX_CACHE_GPUS];
+  uint32_t num_gpus;
+  // Content-hash key: (g1_hash, g1_len, g2_hash, g2_len)
+  uintptr_t key[4];
+  bool populated;
+  // Number of outstanding acquire() calls that haven't been release()d yet.
+  // Eviction is deferred until ref_count reaches 0.
+  uint32_t ref_count;
+
+  ZkMsmCache() : num_gpus(0), key{0, 0, 0, 0}, populated(false), ref_count(0) {
+    memset(g1_per_gpu, 0, sizeof(g1_per_gpu));
+    memset(g2_per_gpu, 0, sizeof(g2_per_gpu));
+    memset(mgmt_streams, 0, sizeof(mgmt_streams));
+  }
+};
+
+static std::mutex &cache_mutex() {
+  static std::mutex mtx;
+  return mtx;
+}
+
+static std::condition_variable &cache_cv() {
+  static std::condition_variable cv;
+  return cv;
+}
+
+static ZkMsmCache &global_cache() {
+  static ZkMsmCache cache;
+  return cache;
+}
+
+// Free all device resources in the cache. Caller must hold cache_mutex.
+static void cache_free_resources(ZkMsmCache &cache) {
+  if (!cache.populated)
+    return;
+
+  for (uint32_t gpu_idx = 0; gpu_idx < cache.num_gpus; gpu_idx++) {
+    cudaStream_t stream = cache.mgmt_streams[gpu_idx];
+
+    if (cache.g2_per_gpu[gpu_idx] != nullptr) {
+      cleanup_zk_cached_g2_points_impl(stream, gpu_idx,
+                                       &cache.g2_per_gpu[gpu_idx], true);
+    }
+    if (cache.g1_per_gpu[gpu_idx] != nullptr) {
+      cleanup_zk_cached_g1_points_impl(stream, gpu_idx,
+                                       &cache.g1_per_gpu[gpu_idx], true);
+    }
+
+    cuda_destroy_stream(stream, gpu_idx);
+    cache.mgmt_streams[gpu_idx] = nullptr;
+  }
+
+  cache.populated = false;
+  memset(cache.key, 0, sizeof(cache.key));
+  cache.num_gpus = 0;
+}
+
+// Acquire the cache. If the key matches, increments the reference count and
+// returns immediately (cache hit). If the key differs (or first call), waits
+// for all outstanding references to be released, evicts the old cache, and
+// populates a new one by uploading g1/g2 base points to every GPU.
+// The caller MUST call zk_msm_cache_release() when done using the pointers.
+// Returns num_gpus; caller uses get_g1/get_g2 to retrieve per-GPU pointers.
+uint32_t zk_msm_cache_acquire_impl(const G1Affine *g1_points, uint32_t n_g1,
+                                   const G2Affine *g2_points, uint32_t n_g2,
+                                   const uintptr_t key[4],
+                                   uint64_t *size_tracker) {
+  std::unique_lock<std::mutex> lock(cache_mutex());
+  ZkMsmCache &cache = global_cache();
+  // Fast path: cache hit -- same CRS, just bump ref_count
+  if (cache.populated && memcmp(cache.key, key, sizeof(cache.key)) == 0) {
+    cache.ref_count++;
+    return cache.num_gpus;
+  }
+
+  // Key mismatch: must evict and repopulate. Wait for all outstanding
+  // references to be released -- evicting while ref_count > 0 would cause
+  // use-after-free for callers still holding cached pointers.
+  cache_cv().wait(lock, [&cache] { return cache.ref_count == 0; });
+
+  // Evict old cache if populated
+  cache_free_resources(cache);
+
+  // Populate new cache across all available GPUs
+  int gpu_count = cuda_get_number_of_gpus();
+  PANIC_IF_FALSE(gpu_count > 0, "zk_msm_cache_acquire: no GPUs available");
+  PANIC_IF_FALSE(static_cast<uint32_t>(gpu_count) <= MAX_CACHE_GPUS,
+                 "zk_msm_cache_acquire: gpu_count=%d exceeds MAX_CACHE_GPUS=%u",
+                 gpu_count, MAX_CACHE_GPUS);
+
+  cache.num_gpus = static_cast<uint32_t>(gpu_count);
+  memcpy(cache.key, key, sizeof(cache.key));
+
+  for (uint32_t gpu_idx = 0; gpu_idx < cache.num_gpus; gpu_idx++) {
+    cache.mgmt_streams[gpu_idx] = cuda_create_stream(gpu_idx);
+    cudaStream_t stream = cache.mgmt_streams[gpu_idx];
+
+    if (g1_points != nullptr && n_g1 > 0) {
+      scratch_zk_cached_g1_points_impl(stream, gpu_idx,
+                                       &cache.g1_per_gpu[gpu_idx], g1_points,
+                                       n_g1, size_tracker, true);
+    }
+
+    if (g2_points != nullptr && n_g2 > 0) {
+      scratch_zk_cached_g2_points_impl(stream, gpu_idx,
+                                       &cache.g2_per_gpu[gpu_idx], g2_points,
+                                       n_g2, size_tracker, true);
+    }
+  }
+
+  cache.populated = true;
+  cache.ref_count = 1;
+  return cache.num_gpus;
+}
+
+// Release a reference to the cache. Must be called once for each
+// successful zk_msm_cache_acquire() call. When the last reference is
+// released, the cache remains populated (for potential reuse) but is
+// eligible for eviction by a future acquire with a different key.
+void zk_msm_cache_release_impl() {
+  std::lock_guard<std::mutex> lock(cache_mutex());
+  ZkMsmCache &cache = global_cache();
+  PANIC_IF_FALSE(
+      cache.ref_count > 0,
+      "zk_msm_cache_release: ref_count is already 0 (double release?)");
+  cache.ref_count--;
+  // Wake any acquire() waiting to evict the cache with a different key.
+  if (cache.ref_count == 0) {
+    cache_cv().notify_all();
+  }
+}
+
+const zk_cached_g1_points *zk_msm_cache_get_g1_impl(uint32_t gpu_index) {
+  std::lock_guard<std::mutex> lock(cache_mutex());
+  ZkMsmCache &cache = global_cache();
+  PANIC_IF_FALSE(cache.populated, "zk_msm_cache_get_g1: cache not populated");
+  PANIC_IF_FALSE(gpu_index < cache.num_gpus,
+                 "zk_msm_cache_get_g1: gpu_index=%u >= num_gpus=%u", gpu_index,
+                 cache.num_gpus);
+  return cache.g1_per_gpu[gpu_index];
+}
+
+const zk_cached_g2_points *zk_msm_cache_get_g2_impl(uint32_t gpu_index) {
+  std::lock_guard<std::mutex> lock(cache_mutex());
+  ZkMsmCache &cache = global_cache();
+  PANIC_IF_FALSE(cache.populated, "zk_msm_cache_get_g2: cache not populated");
+  PANIC_IF_FALSE(gpu_index < cache.num_gpus,
+                 "zk_msm_cache_get_g2: gpu_index=%u >= num_gpus=%u", gpu_index,
+                 cache.num_gpus);
+  return cache.g2_per_gpu[gpu_index];
+}
+
+uint32_t zk_msm_cache_num_gpus_impl() {
+  std::lock_guard<std::mutex> lock(cache_mutex());
+  ZkMsmCache &cache = global_cache();
+  PANIC_IF_FALSE(cache.populated, "zk_msm_cache_num_gpus: cache not populated");
+  return cache.num_gpus;
+}
+
+void zk_msm_cache_reset_impl() {
+  std::lock_guard<std::mutex> lock(cache_mutex());
+  ZkMsmCache &cache = global_cache();
+  PANIC_IF_FALSE(cache.ref_count == 0,
+                 "zk_msm_cache_reset: called with %u outstanding references",
+                 cache.ref_count);
+  cache_free_resources(cache);
+}

--- a/backends/zk-cuda-backend/cuda/src/msm/common.cuh
+++ b/backends/zk-cuda-backend/cuda/src/msm/common.cuh
@@ -9,11 +9,11 @@
 // Pippenger kernel: Clear buckets (works for both affine and projective points)
 template <typename PointType>
 __global__ void kernel_clear_buckets(PointType *__restrict__ buckets,
-                                     uint32_t num_buckets) {
+                                     size_t num_buckets) {
   using AffinePoint = typename SelectorChooser<PointType>::Selection;
 
-  uint32_t idx = threadIdx.x + blockIdx.x * blockDim.x;
-  if (idx < num_buckets) {
+  for (size_t idx = threadIdx.x + static_cast<size_t>(blockIdx.x) * blockDim.x;
+       idx < num_buckets; idx += static_cast<size_t>(blockDim.x) * gridDim.x) {
     AffinePoint::point_at_infinity(buckets[idx]);
   }
 }
@@ -45,7 +45,7 @@ kernel_reduce_buckets(ProjectiveType *__restrict__ final_buckets,
   // Each thread loads one block's contribution (or infinity if out of range)
   ProjectiveType my_point;
   if (threadIdx.x < num_blocks) {
-    uint32_t idx = threadIdx.x * num_buckets + bucket_idx;
+    size_t idx = static_cast<size_t>(threadIdx.x) * num_buckets + bucket_idx;
     my_point = block_buckets[idx];
   } else {
     ProjectivePoint::point_at_infinity(my_point);
@@ -53,7 +53,7 @@ kernel_reduce_buckets(ProjectiveType *__restrict__ final_buckets,
 
   // If num_blocks > blockDim.x, accumulate multiple blocks per thread
   for (uint32_t i = threadIdx.x + blockDim.x; i < num_blocks; i += blockDim.x) {
-    uint32_t idx = i * num_buckets + bucket_idx;
+    size_t idx = static_cast<size_t>(i) * num_buckets + bucket_idx;
     const ProjectiveType &contrib = block_buckets[idx];
     if (!ProjectivePoint::is_infinity(contrib)) {
       if (ProjectivePoint::is_infinity(my_point)) {

--- a/backends/zk-cuda-backend/cuda/src/msm/msm.cu
+++ b/backends/zk-cuda-backend/cuda/src/msm/msm.cu
@@ -1,56 +1,118 @@
+#include "checked_arithmetic.h"
 #include "curve.h"
 #include "device.h"
 #include "fp.h"
 #include "fp2.h"
 #include "msm.h"
+#include <cstdlib>
 #include <cstring>
 
 // Multi-Scalar Multiplication (MSM) using Pippenger algorithm for BLS12-446
+//
+// The split primitives (launch_async + horner_finalize) are the fundamental
+// building blocks. The blocking _async functions compose them with a sync
+// in between, and the fully-blocking non-_async functions add a final sync.
 
-// Forward declarations for Pippenger implementations
-void point_msm_g1_pippenger_async(cudaStream_t stream, uint32_t gpu_index,
-                                  G1Projective *h_result,
-                                  const G1Affine *d_points,
-                                  const Scalar *d_scalars, uint32_t n,
-                                  G1Projective *d_scratch);
-void point_msm_g2_pippenger_async(cudaStream_t stream, uint32_t gpu_index,
-                                  G2ProjectivePoint *h_result,
-                                  const G2Point *d_points,
-                                  const Scalar *d_scalars, uint32_t n,
-                                  G2ProjectivePoint *d_scratch);
+// Forward declarations for split launch/finalize primitives (defined in
+// msm_pippenger.cu). These are the canonical entry points into Pippenger.
+void point_msm_g1_pippenger_launch_async(
+    cudaStream_t stream, uint32_t gpu_index, G1Projective *h_window_sums,
+    const G1Affine *d_points, const Scalar *d_scalars, uint32_t n,
+    G1Projective *d_scratch, uint32_t &out_num_windows,
+    uint32_t &out_window_size);
+void point_msm_g1_horner_finalize(G1Projective *h_result,
+                                  const G1Projective *h_window_sums,
+                                  uint32_t num_windows, uint32_t window_size);
+
+void point_msm_g2_pippenger_launch_async(
+    cudaStream_t stream, uint32_t gpu_index, G2ProjectivePoint *h_window_sums,
+    const G2Point *d_points, const Scalar *d_scalars, uint32_t n,
+    G2ProjectivePoint *d_scratch, uint32_t &out_num_windows,
+    uint32_t &out_window_size);
+void point_msm_g2_horner_finalize(G2ProjectivePoint *h_result,
+                                  const G2ProjectivePoint *h_window_sums,
+                                  uint32_t num_windows, uint32_t window_size);
+
+void point_msm_g1_launch_async(cudaStream_t stream, uint32_t gpu_index,
+                               G1Projective *h_window_sums,
+                               const G1Affine *d_points,
+                               const Scalar *d_scalars, uint32_t n,
+                               G1Projective *d_scratch,
+                               uint32_t &out_num_windows,
+                               uint32_t &out_window_size) {
+  point_msm_g1_pippenger_launch_async(stream, gpu_index, h_window_sums,
+                                      d_points, d_scalars, n, d_scratch,
+                                      out_num_windows, out_window_size);
+}
+
+void point_msm_g2_launch_async(cudaStream_t stream, uint32_t gpu_index,
+                               G2ProjectivePoint *h_window_sums,
+                               const G2Point *d_points, const Scalar *d_scalars,
+                               uint32_t n, G2ProjectivePoint *d_scratch,
+                               uint32_t &out_num_windows,
+                               uint32_t &out_window_size) {
+  point_msm_g2_pippenger_launch_async(stream, gpu_index, h_window_sums,
+                                      d_points, d_scalars, n, d_scratch,
+                                      out_num_windows, out_window_size);
+}
 
 // ============================================================================
 // Public MSM API for BigInt scalars
 // ============================================================================
 
-// MSM with BigInt scalars for G1 (projective coordinates internally)
-// Result is written directly to the host pointer h_result.
 void point_msm_g1_async(cudaStream_t stream, uint32_t gpu_index,
                         G1Projective *h_result, const G1Affine *d_points,
                         const Scalar *d_scalars, uint32_t n,
                         G1Projective *d_scratch) {
-  point_msm_g1_pippenger_async(stream, gpu_index, h_result, d_points, d_scalars,
-                               n, d_scratch);
+  uint32_t num_windows = 0, window_size = 0;
+  constexpr uint32_t max_windows =
+      CEIL_DIV(Scalar::NUM_BITS, MSM_G1_WINDOW_SIZE);
+
+  // TODO: benchmark cudaMallocHost (pinned memory) — it may improve async D2H
+  // overlap
+  auto *h_window_sums = static_cast<G1Projective *>(
+      malloc(safe_mul_sizeof<G1Projective>(static_cast<size_t>(max_windows))));
+  PANIC_IF_FALSE(h_window_sums != nullptr, "point_msm_g1_async: malloc failed");
+
+  point_msm_g1_launch_async(stream, gpu_index, h_window_sums, d_points,
+                            d_scalars, n, d_scratch, num_windows, window_size);
+  cuda_synchronize_stream(stream, gpu_index);
+  point_msm_g1_horner_finalize(h_result, h_window_sums, num_windows,
+                               window_size);
+
+  free(h_window_sums);
 }
 
-// MSM with BigInt scalars for G2 (projective coordinates internally)
-// Result is written directly to the host pointer h_result.
 void point_msm_g2_async(cudaStream_t stream, uint32_t gpu_index,
                         G2ProjectivePoint *h_result, const G2Point *d_points,
                         const Scalar *d_scalars, uint32_t n,
                         G2ProjectivePoint *d_scratch) {
-  point_msm_g2_pippenger_async(stream, gpu_index, h_result, d_points, d_scalars,
-                               n, d_scratch);
+  uint32_t num_windows = 0, window_size = 0;
+  constexpr uint32_t max_windows =
+      CEIL_DIV(Scalar::NUM_BITS, MSM_G2_WINDOW_SIZE);
+
+  // TODO: benchmark cudaMallocHost (pinned memory) — it may improve async D2H
+  // overlap
+  auto *h_window_sums = static_cast<G2ProjectivePoint *>(malloc(
+      safe_mul_sizeof<G2ProjectivePoint>(static_cast<size_t>(max_windows))));
+  PANIC_IF_FALSE(h_window_sums != nullptr, "point_msm_g2_async: malloc failed");
+
+  point_msm_g2_launch_async(stream, gpu_index, h_window_sums, d_points,
+                            d_scalars, n, d_scratch, num_windows, window_size);
+  cuda_synchronize_stream(stream, gpu_index);
+  point_msm_g2_horner_finalize(h_result, h_window_sums, num_windows,
+                               window_size);
+
+  free(h_window_sums);
 }
 
+// Defensive final sync (the _async functions already sync internally).
 void point_msm_g1(cudaStream_t stream, uint32_t gpu_index,
                   G1Projective *h_result, const G1Affine *d_points,
                   const Scalar *d_scalars, uint32_t n,
                   G1Projective *d_scratch) {
   point_msm_g1_async(stream, gpu_index, h_result, d_points, d_scalars, n,
                      d_scratch);
-  // The async impl already syncs internally before the CPU-side Horner phase,
-  // so the stream is idle here. This sync is kept for defensive correctness.
   cuda_synchronize_stream(stream, gpu_index);
 }
 
@@ -60,6 +122,5 @@ void point_msm_g2(cudaStream_t stream, uint32_t gpu_index,
                   G2ProjectivePoint *d_scratch) {
   point_msm_g2_async(stream, gpu_index, h_result, d_points, d_scalars, n,
                      d_scratch);
-  // See comment in point_msm_g1 above.
   cuda_synchronize_stream(stream, gpu_index);
 }

--- a/backends/zk-cuda-backend/cuda/src/msm/pippenger/msm_pippenger.cu
+++ b/backends/zk-cuda-backend/cuda/src/msm/pippenger/msm_pippenger.cu
@@ -174,8 +174,10 @@ __global__ void kernel_accumulate_all_windows(
     return;
 
   // Output offset for this block's buckets
-  uint32_t bucket_offset =
-      (window_idx * num_blocks_per_window + block_within_window) * bucket_count;
+  size_t bucket_offset =
+      (static_cast<size_t>(window_idx) * num_blocks_per_window +
+       block_within_window) *
+      bucket_count;
   ProjectiveType *my_buckets = all_block_buckets + bucket_offset;
 
   // Shared memory layout (register-based optimization):
@@ -315,8 +317,10 @@ __global__ void kernel_reduce_all_windows(
   // Each thread sums a subset of block contributions
   for (uint32_t block = threadIdx.x; block < num_blocks_per_window;
        block += blockDim.x) {
-    uint32_t idx =
-        (window_idx * num_blocks_per_window + block) * num_buckets + bucket_idx;
+    size_t idx =
+        (static_cast<size_t>(window_idx) * num_blocks_per_window + block) *
+            num_buckets +
+        bucket_idx;
     const ProjectiveType &contrib = all_block_buckets[idx];
     if (!ProjectivePoint::is_infinity(contrib)) {
       if (ProjectivePoint::is_infinity(local_sum)) {
@@ -525,14 +529,12 @@ void point_msm_pippenger_impl_async(cudaStream_t stream, uint32_t gpu_index,
   // - all_block_buckets: [num_windows * num_blocks * bucket_count]
   // - all_final_buckets: [num_windows * bucket_count]
   // - window_sums: [num_windows]
-  // Compute element counts in size_t (64-bit) so that intermediate products
-  // of uint32_t inputs don't silently wrap at 2^32 before reaching the
-  // explicit overflow check below (which multiplies by sizeof(ProjectiveType))
-  const size_t all_block_buckets_size = static_cast<size_t>(num_windows) *
-                                        launch_params.num_blocks_per_window *
-                                        bucket_count;
-  const size_t all_final_buckets_size =
-      static_cast<size_t>(num_windows) * bucket_count;
+  const size_t all_block_buckets_size =
+      safe_mul(static_cast<size_t>(num_windows),
+               static_cast<size_t>(launch_params.num_blocks_per_window),
+               static_cast<size_t>(bucket_count));
+  const size_t all_final_buckets_size = safe_mul(
+      static_cast<size_t>(num_windows), static_cast<size_t>(bucket_count));
   const size_t total_scratch =
       all_block_buckets_size + all_final_buckets_size + num_windows;
 
@@ -542,59 +544,75 @@ void point_msm_pippenger_impl_async(cudaStream_t stream, uint32_t gpu_index,
   ProjectiveType *d_window_sums = d_all_final_buckets + all_final_buckets_size;
 
   // Clear all scratch space
-  const uint32_t clear_blocks = CEIL_DIV(total_scratch, KERNEL_THREADS_MAX);
-  PANIC_IF_FALSE(clear_blocks * KERNEL_THREADS_MAX >= total_scratch,
-                 "kernel_clear_buckets: insufficient threads (%zu) to clear "
-                 "buffer (%zu elements)",
-                 static_cast<size_t>(clear_blocks) * KERNEL_THREADS_MAX,
-                 total_scratch);
+  const size_t clear_blocks =
+      CEIL_DIV(total_scratch, static_cast<size_t>(KERNEL_THREADS_MAX));
+  PANIC_IF_FALSE(clear_blocks <= static_cast<size_t>(UINT32_MAX),
+                 "kernel_clear_buckets: clear_blocks (%zu) exceeds UINT32_MAX",
+                 clear_blocks);
   kernel_clear_buckets<ProjectiveType>
-      <<<clear_blocks, KERNEL_THREADS_MAX, 0, stream>>>(d_scratch,
-                                                        total_scratch);
+      <<<static_cast<uint32_t>(clear_blocks), KERNEL_THREADS_MAX, 0, stream>>>(
+          d_scratch, total_scratch);
   check_cuda_error(cudaGetLastError());
 
-  // Phase 1: Accumulate ALL windows in parallel (SINGLE kernel launch!)
-  const uint32_t total_accum_blocks =
-      num_windows * launch_params.num_blocks_per_window;
+  // Phase 1: Bucket accumulation
+  const size_t total_accum_blocks =
+      safe_mul(static_cast<size_t>(num_windows),
+               static_cast<size_t>(launch_params.num_blocks_per_window));
   PANIC_IF_FALSE(
-      total_accum_blocks * bucket_count <= all_block_buckets_size,
+      safe_mul(total_accum_blocks, static_cast<size_t>(bucket_count)) <=
+          all_block_buckets_size,
       "kernel_accumulate_all_windows: max write index (%zu) exceeds buffer "
       "(%zu)",
-      static_cast<size_t>(total_accum_blocks) * bucket_count,
+      safe_mul(total_accum_blocks, static_cast<size_t>(bucket_count)),
       all_block_buckets_size);
+  PANIC_IF_FALSE(total_accum_blocks <= static_cast<size_t>(UINT32_MAX),
+                 "total_accum_blocks (%zu) exceeds UINT32_MAX",
+                 total_accum_blocks);
   kernel_accumulate_all_windows<AffineType, ProjectiveType>
-      <<<total_accum_blocks, launch_params.adjusted_threads_per_block,
+      <<<static_cast<uint32_t>(total_accum_blocks),
+         launch_params.adjusted_threads_per_block,
          launch_params.accum_shared_mem, stream>>>(
           d_all_block_buckets, d_points, d_scalars, n, num_windows,
           launch_params.num_blocks_per_window, window_size, bucket_count);
   check_cuda_error(cudaGetLastError());
 
-  // Phase 2: Reduce ALL windows' buckets in parallel (SINGLE kernel launch!)
-  const uint32_t total_reduce_blocks = num_windows * bucket_count;
+  // Phase 2: Cross-block bucket reduction
+  const size_t total_reduce_blocks = safe_mul(
+      static_cast<size_t>(num_windows), static_cast<size_t>(bucket_count));
   Phase2KernelLaunchParams<ProjectiveType> reduce_params(
       launch_params.num_blocks_per_window, gpu_index);
   PANIC_IF_FALSE(
       total_reduce_blocks <= all_final_buckets_size,
-      "kernel_reduce_all_windows: blocks (%u) exceeds output buffer (%zu)",
+      "kernel_reduce_all_windows: blocks (%zu) exceeds output buffer (%zu)",
       total_reduce_blocks, all_final_buckets_size);
+  PANIC_IF_FALSE(total_reduce_blocks <= static_cast<size_t>(UINT32_MAX),
+                 "total_reduce_blocks (%zu) exceeds UINT32_MAX",
+                 total_reduce_blocks);
   kernel_reduce_all_windows<ProjectiveType>
-      <<<total_reduce_blocks, reduce_params.adjusted_threads,
-         reduce_params.shared_mem, stream>>>(
+      <<<static_cast<uint32_t>(total_reduce_blocks),
+         reduce_params.adjusted_threads, reduce_params.shared_mem, stream>>>(
           d_all_final_buckets, d_all_block_buckets, num_windows,
           launch_params.num_blocks_per_window, bucket_count);
   check_cuda_error(cudaGetLastError());
 
-  // Phase 3: Compute window sums in parallel (SINGLE kernel launch!)
+  // Phase 3: Window sum computation
   // Round up to next multiple of 32 (warp size) for efficient scheduling.
   // The kernel already has `if (tid < n)` bounds checks for the excess threads.
   const uint32_t combine_threads = ((bucket_count - 1) + 31) & ~31u;
   const size_t combine_shared_mem =
       safe_mul_sizeof<ProjectiveType>(static_cast<size_t>(combine_threads));
-  PANIC_IF_FALSE(num_windows * bucket_count <= all_final_buckets_size,
+  PANIC_IF_FALSE(safe_mul(static_cast<size_t>(num_windows),
+                          static_cast<size_t>(bucket_count)) <=
+                     all_final_buckets_size,
                  "kernel_compute_window_sums: max read index (%zu) exceeds "
                  "input buffer (%zu)",
-                 static_cast<size_t>(num_windows) * bucket_count,
+                 safe_mul(static_cast<size_t>(num_windows),
+                          static_cast<size_t>(bucket_count)),
                  all_final_buckets_size);
+  PANIC_IF_FALSE((bucket_count & (bucket_count - 1)) == 0,
+                 "kernel_compute_window_sums: bucket_count (%u) must be a "
+                 "power of 2",
+                 bucket_count);
   kernel_compute_window_sums<ProjectiveType>
       <<<num_windows, combine_threads, combine_shared_mem, stream>>>(
           d_window_sums, d_all_final_buckets, num_windows, bucket_count);
@@ -680,11 +698,12 @@ size_t pippenger_scratch_size(uint32_t n, uint32_t gpu_index) {
   Phase1KernelLaunchParams<AffineType> launch_params(n, threads_per_block,
                                                      bucket_count, gpu_index);
 
-  const size_t all_block_buckets_elems = static_cast<size_t>(num_windows) *
-                                         launch_params.num_blocks_per_window *
-                                         bucket_count;
-  const size_t all_final_buckets_elems =
-      static_cast<size_t>(num_windows) * bucket_count;
+  const size_t all_block_buckets_elems =
+      safe_mul(static_cast<size_t>(num_windows),
+               static_cast<size_t>(launch_params.num_blocks_per_window),
+               static_cast<size_t>(bucket_count));
+  const size_t all_final_buckets_elems = safe_mul(
+      static_cast<size_t>(num_windows), static_cast<size_t>(bucket_count));
   const size_t total_elems =
       all_block_buckets_elems + all_final_buckets_elems + num_windows;
 
@@ -729,4 +748,190 @@ void point_msm_g2_pippenger_async(cudaStream_t stream, uint32_t gpu_index,
   point_msm_pippenger_impl_async<G2Point, G2ProjectivePoint>(
       stream, gpu_index, h_result, d_points, d_scalars, n,
       msm_threads_per_block<G2Point>(n), window_size, bucket_count, d_scratch);
+}
+
+// For pipelining, we split the MSM into two phases:
+//   1. Launch: GPU kernels (phases 1-3) + async D2H copy of window sums
+//   2. Finalize: stream sync + CPU Horner combine
+// This allows the GPU work to overlap with CPU work (e.g., pairings)
+// between launch and finalize.
+
+// Launches Pippenger phases 1-3 and queues an async D2H copy of the window
+// sums into h_window_sums. Does NOT synchronize the stream or run the Horner
+// combine. The caller must sync the stream and call point_msm_horner_finalize()
+// to obtain the final result.
+//
+// On return, out_num_windows and out_window_size are populated so finalize
+// knows the Horner parameters without recomputing them.
+template <typename AffineType, typename ProjectiveType>
+void point_msm_pippenger_launch_async(
+    cudaStream_t stream, uint32_t gpu_index,
+    ProjectiveType *h_window_sums, // host buffer (must hold num_windows elems)
+    const AffineType *d_points, const Scalar *d_scalars, uint32_t n,
+    uint32_t threads_per_block, uint32_t window_size, uint32_t bucket_count,
+    ProjectiveType *d_scratch, uint32_t &out_num_windows,
+    uint32_t &out_window_size) {
+  using ProjectivePoint = Projective<ProjectiveType>;
+
+  PANIC_IF_FALSE(n > 0, "point_msm_pippenger_launch_async: n must be positive");
+  PANIC_IF_FALSE(h_window_sums != nullptr && d_points != nullptr &&
+                     d_scalars != nullptr && d_scratch != nullptr,
+                 "point_msm_pippenger_launch_async: null pointer argument");
+
+  cuda_set_device(gpu_index);
+
+  const uint32_t num_windows = CEIL_DIV(Scalar::NUM_BITS, window_size);
+
+  // Publish Horner parameters for finalize
+  out_num_windows = num_windows;
+  out_window_size = window_size;
+
+  Phase1KernelLaunchParams<AffineType> launch_params(n, threads_per_block,
+                                                     bucket_count, gpu_index);
+
+  // Scratch layout is identical to point_msm_pippenger_impl_async
+  const size_t all_block_buckets_size =
+      safe_mul(static_cast<size_t>(num_windows),
+               static_cast<size_t>(launch_params.num_blocks_per_window),
+               static_cast<size_t>(bucket_count));
+  const size_t all_final_buckets_size = safe_mul(
+      static_cast<size_t>(num_windows), static_cast<size_t>(bucket_count));
+  const size_t total_scratch =
+      all_block_buckets_size + all_final_buckets_size + num_windows;
+
+  ProjectiveType *d_all_block_buckets = d_scratch;
+  ProjectiveType *d_all_final_buckets = d_scratch + all_block_buckets_size;
+  ProjectiveType *d_window_sums = d_all_final_buckets + all_final_buckets_size;
+
+  // Clear scratch
+  const size_t clear_blocks =
+      CEIL_DIV(total_scratch, static_cast<size_t>(KERNEL_THREADS_MAX));
+  PANIC_IF_FALSE(clear_blocks <= static_cast<size_t>(UINT32_MAX),
+                 "kernel_clear_buckets: clear_blocks (%zu) exceeds UINT32_MAX",
+                 clear_blocks);
+  kernel_clear_buckets<ProjectiveType>
+      <<<static_cast<uint32_t>(clear_blocks), KERNEL_THREADS_MAX, 0, stream>>>(
+          d_scratch, total_scratch);
+  check_cuda_error(cudaGetLastError());
+
+  const size_t total_accum_blocks =
+      safe_mul(static_cast<size_t>(num_windows),
+               static_cast<size_t>(launch_params.num_blocks_per_window));
+  PANIC_IF_FALSE(
+      safe_mul(total_accum_blocks, static_cast<size_t>(bucket_count)) <=
+          all_block_buckets_size,
+      "kernel_accumulate_all_windows: max write index (%zu) exceeds buffer "
+      "(%zu)",
+      safe_mul(total_accum_blocks, static_cast<size_t>(bucket_count)),
+      all_block_buckets_size);
+  PANIC_IF_FALSE(total_accum_blocks <= static_cast<size_t>(UINT32_MAX),
+                 "total_accum_blocks (%zu) exceeds UINT32_MAX",
+                 total_accum_blocks);
+  kernel_accumulate_all_windows<AffineType, ProjectiveType>
+      <<<static_cast<uint32_t>(total_accum_blocks),
+         launch_params.adjusted_threads_per_block,
+         launch_params.accum_shared_mem, stream>>>(
+          d_all_block_buckets, d_points, d_scalars, n, num_windows,
+          launch_params.num_blocks_per_window, window_size, bucket_count);
+  check_cuda_error(cudaGetLastError());
+
+  const size_t total_reduce_blocks = safe_mul(
+      static_cast<size_t>(num_windows), static_cast<size_t>(bucket_count));
+  Phase2KernelLaunchParams<ProjectiveType> reduce_params(
+      launch_params.num_blocks_per_window, gpu_index);
+  PANIC_IF_FALSE(
+      total_reduce_blocks <= all_final_buckets_size,
+      "kernel_reduce_all_windows: blocks (%zu) exceeds output buffer (%zu)",
+      total_reduce_blocks, all_final_buckets_size);
+  PANIC_IF_FALSE(total_reduce_blocks <= static_cast<size_t>(UINT32_MAX),
+                 "total_reduce_blocks (%zu) exceeds UINT32_MAX",
+                 total_reduce_blocks);
+  kernel_reduce_all_windows<ProjectiveType>
+      <<<static_cast<uint32_t>(total_reduce_blocks),
+         reduce_params.adjusted_threads, reduce_params.shared_mem, stream>>>(
+          d_all_final_buckets, d_all_block_buckets, num_windows,
+          launch_params.num_blocks_per_window, bucket_count);
+  check_cuda_error(cudaGetLastError());
+
+  const uint32_t combine_threads = ((bucket_count - 1) + 31) & ~31u;
+  const size_t combine_shared_mem =
+      safe_mul_sizeof<ProjectiveType>(static_cast<size_t>(combine_threads));
+  PANIC_IF_FALSE(safe_mul(static_cast<size_t>(num_windows),
+                          static_cast<size_t>(bucket_count)) <=
+                     all_final_buckets_size,
+                 "kernel_compute_window_sums: max read index (%zu) exceeds "
+                 "input buffer (%zu)",
+                 safe_mul(static_cast<size_t>(num_windows),
+                          static_cast<size_t>(bucket_count)),
+                 all_final_buckets_size);
+  PANIC_IF_FALSE((bucket_count & (bucket_count - 1)) == 0,
+                 "kernel_compute_window_sums: bucket_count (%u) must be a "
+                 "power of 2",
+                 bucket_count);
+  kernel_compute_window_sums<ProjectiveType>
+      <<<num_windows, combine_threads, combine_shared_mem, stream>>>(
+          d_window_sums, d_all_final_buckets, num_windows, bucket_count);
+  check_cuda_error(cudaGetLastError());
+
+  // Queue async D2H copy of window sums — the stream is NOT synchronized here
+  cuda_memcpy_async_to_cpu(
+      h_window_sums, d_window_sums,
+      safe_mul_sizeof<ProjectiveType>(static_cast<size_t>(num_windows)), stream,
+      gpu_index);
+}
+
+// Runs the CPU Horner combine on window sums that were copied D2H during
+// the launch phase. The caller must have synchronized the stream before
+// calling this so that h_window_sums contains valid data.
+template <typename ProjectiveType>
+void point_msm_horner_finalize(ProjectiveType *h_result,
+                               const ProjectiveType *h_window_sums,
+                               uint32_t num_windows, uint32_t window_size) {
+  PANIC_IF_FALSE(h_result != nullptr && h_window_sums != nullptr,
+                 "point_msm_horner_finalize: null pointer argument");
+  PANIC_IF_FALSE(num_windows > 0,
+                 "point_msm_horner_finalize: num_windows must be positive");
+  horner_combine_cpu(*h_result, h_window_sums, num_windows, window_size);
+}
+
+void point_msm_g1_pippenger_launch_async(
+    cudaStream_t stream, uint32_t gpu_index, G1Projective *h_window_sums,
+    const G1Affine *d_points, const Scalar *d_scalars, uint32_t n,
+    G1Projective *d_scratch, uint32_t &out_num_windows,
+    uint32_t &out_window_size) {
+  uint32_t window_size, bucket_count;
+  get_g1_window_params(n, window_size, bucket_count);
+
+  point_msm_pippenger_launch_async<G1Affine, G1Projective>(
+      stream, gpu_index, h_window_sums, d_points, d_scalars, n,
+      msm_threads_per_block<G1Affine>(n), window_size, bucket_count, d_scratch,
+      out_num_windows, out_window_size);
+}
+
+void point_msm_g1_horner_finalize(G1Projective *h_result,
+                                  const G1Projective *h_window_sums,
+                                  uint32_t num_windows, uint32_t window_size) {
+  point_msm_horner_finalize<G1Projective>(h_result, h_window_sums, num_windows,
+                                          window_size);
+}
+
+void point_msm_g2_pippenger_launch_async(
+    cudaStream_t stream, uint32_t gpu_index, G2ProjectivePoint *h_window_sums,
+    const G2Point *d_points, const Scalar *d_scalars, uint32_t n,
+    G2ProjectivePoint *d_scratch, uint32_t &out_num_windows,
+    uint32_t &out_window_size) {
+  uint32_t window_size, bucket_count;
+  get_g2_window_params(n, window_size, bucket_count);
+
+  point_msm_pippenger_launch_async<G2Point, G2ProjectivePoint>(
+      stream, gpu_index, h_window_sums, d_points, d_scalars, n,
+      msm_threads_per_block<G2Point>(n), window_size, bucket_count, d_scratch,
+      out_num_windows, out_window_size);
+}
+
+void point_msm_g2_horner_finalize(G2ProjectivePoint *h_result,
+                                  const G2ProjectivePoint *h_window_sums,
+                                  uint32_t num_windows, uint32_t window_size) {
+  point_msm_horner_finalize<G2ProjectivePoint>(h_result, h_window_sums,
+                                               num_windows, window_size);
 }

--- a/backends/zk-cuda-backend/src/bindings.rs
+++ b/backends/zk-cuda-backend/src/bindings.rs
@@ -166,6 +166,108 @@ unsafe extern "C" {
 unsafe extern "C" {
     pub fn pippenger_scratch_size_g2_wrapper(n: u32, gpu_index: u32) -> usize;
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct zk_g1_msm_mem {
+    _unused: [u8; 0],
+}
+unsafe extern "C" {
+    pub fn scratch_zk_g1_msm(
+        stream: cudaStream_t,
+        gpu_index: u32,
+        mem: *mut *mut zk_g1_msm_mem,
+        max_n: u32,
+        size_tracker: *mut u64,
+        allocate_gpu_memory: bool,
+    );
+}
+unsafe extern "C" {
+    pub fn cleanup_zk_g1_msm(
+        stream: cudaStream_t,
+        gpu_index: u32,
+        mem: *mut *mut zk_g1_msm_mem,
+        allocate_gpu_memory: bool,
+    );
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct zk_cached_g1_points {
+    _unused: [u8; 0],
+}
+unsafe extern "C" {
+    pub fn scratch_zk_cached_g1_points(
+        stream: cudaStream_t,
+        gpu_index: u32,
+        mem: *mut *mut zk_cached_g1_points,
+        h_points: *const G1Point,
+        n: u32,
+        size_tracker: *mut u64,
+        allocate_gpu_memory: bool,
+    );
+}
+unsafe extern "C" {
+    pub fn zk_g1_msm_cached_async(
+        stream: cudaStream_t,
+        gpu_index: u32,
+        msm_mem: *mut zk_g1_msm_mem,
+        h_result: *mut G1ProjectivePoint,
+        cached: *const zk_cached_g1_points,
+        point_offset: u32,
+        h_scalars: *const Scalar,
+        n: u32,
+    );
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct zk_g2_msm_mem {
+    _unused: [u8; 0],
+}
+unsafe extern "C" {
+    pub fn scratch_zk_g2_msm(
+        stream: cudaStream_t,
+        gpu_index: u32,
+        mem: *mut *mut zk_g2_msm_mem,
+        max_n: u32,
+        size_tracker: *mut u64,
+        allocate_gpu_memory: bool,
+    );
+}
+unsafe extern "C" {
+    pub fn cleanup_zk_g2_msm(
+        stream: cudaStream_t,
+        gpu_index: u32,
+        mem: *mut *mut zk_g2_msm_mem,
+        allocate_gpu_memory: bool,
+    );
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct zk_cached_g2_points {
+    _unused: [u8; 0],
+}
+unsafe extern "C" {
+    pub fn scratch_zk_cached_g2_points(
+        stream: cudaStream_t,
+        gpu_index: u32,
+        mem: *mut *mut zk_cached_g2_points,
+        h_points: *const G2Point,
+        n: u32,
+        size_tracker: *mut u64,
+        allocate_gpu_memory: bool,
+    );
+}
+unsafe extern "C" {
+    pub fn zk_g2_msm_cached_async(
+        stream: cudaStream_t,
+        gpu_index: u32,
+        msm_mem: *mut zk_g2_msm_mem,
+        h_result: *mut G2ProjectivePoint,
+        cached: *const zk_cached_g2_points,
+        point_offset: u32,
+        h_scalars: *const Scalar,
+        n: u32,
+    );
+}
 unsafe extern "C" {
     pub fn g1_msm_managed_wrapper(
         stream: cudaStream_t,
@@ -197,12 +299,6 @@ unsafe extern "C" {
     pub fn g2_from_montgomery_wrapper(result: *mut G2Point, point: *const G2Point);
 }
 unsafe extern "C" {
-    pub fn fp_to_montgomery_wrapper(result: *mut Fp, value: *const Fp);
-}
-unsafe extern "C" {
-    pub fn fp_from_montgomery_wrapper(result: *mut Fp, value: *const Fp);
-}
-unsafe extern "C" {
     pub fn g1_projective_from_montgomery_normalized_wrapper(
         result: *mut G1ProjectivePoint,
         point: *const G1ProjectivePoint,
@@ -222,4 +318,23 @@ unsafe extern "C" {
 }
 unsafe extern "C" {
     pub fn scalar_modulus_limbs_wrapper(limbs: *mut u64);
+}
+unsafe extern "C" {
+    pub fn zk_msm_cache_acquire(
+        g1_points: *const G1Point,
+        n_g1: u32,
+        g2_points: *const G2Point,
+        n_g2: u32,
+        key: *const usize,
+        size_tracker: *mut u64,
+    ) -> u32;
+}
+unsafe extern "C" {
+    pub fn zk_msm_cache_get_g1(gpu_index: u32) -> *const zk_cached_g1_points;
+}
+unsafe extern "C" {
+    pub fn zk_msm_cache_get_g2(gpu_index: u32) -> *const zk_cached_g2_points;
+}
+unsafe extern "C" {
+    pub fn zk_msm_cache_release();
 }

--- a/backends/zk-cuda-backend/src/c_wrapper.cu
+++ b/backends/zk-cuda-backend/src/c_wrapper.cu
@@ -1,10 +1,8 @@
-// C wrapper functions for Rust FFI
-// These functions provide a C-compatible interface to the C++ functions
-
 #include "checked_arithmetic.h"
 #include "curve.h"
 #include "device.h"
 #include "msm.h"
+#include "msm_utils.h"
 #include "bls12_446_params.h"
 #include <stdint.h>
 #include <stdbool.h>
@@ -12,16 +10,6 @@
 #include <cstring>
 
 #include "../../tfhe-cuda-backend/cuda/src/utils/helper_profile.cuh"
-
-// C++ helper functions (not exported, used internally)
-// These can call template functions since they have C++ linkage
-static void convert_g1_points_to_montgomery(cudaStream_t stream, uint32_t gpu_index, G1Affine* d_points, uint32_t n) {
-    point_to_montgomery_batch_async<G1Affine>(stream, gpu_index, d_points, n);
-}
-
-static void convert_g2_points_to_montgomery(cudaStream_t stream, uint32_t gpu_index, G2Affine* d_points, uint32_t n) {
-    point_to_montgomery_batch_async<G2Affine>(stream, gpu_index, d_points, n);
-}
 
 extern "C" {
 
@@ -261,6 +249,98 @@ void g2_msm_managed_wrapper(
     POP_RANGE();
 }
 
+// Forwarding to msm_utils.h implementations.
+
+void scratch_zk_g1_msm(
+    cudaStream_t stream,
+    uint32_t gpu_index,
+    zk_g1_msm_mem** mem,
+    uint32_t max_n,
+    uint64_t* size_tracker,
+    bool allocate_gpu_memory
+) {
+    scratch_zk_g1_msm_impl(stream, gpu_index, mem, max_n, size_tracker, allocate_gpu_memory);
+}
+
+void cleanup_zk_g1_msm(
+    cudaStream_t stream,
+    uint32_t gpu_index,
+    zk_g1_msm_mem** mem,
+    bool allocate_gpu_memory
+) {
+    cleanup_zk_g1_msm_impl(stream, gpu_index, mem, allocate_gpu_memory);
+}
+
+void scratch_zk_cached_g1_points(
+    cudaStream_t stream,
+    uint32_t gpu_index,
+    zk_cached_g1_points** mem,
+    const G1Affine* h_points,
+    uint32_t n,
+    uint64_t* size_tracker,
+    bool allocate_gpu_memory
+) {
+    scratch_zk_cached_g1_points_impl(stream, gpu_index, mem, h_points, n, size_tracker, allocate_gpu_memory);
+}
+
+void zk_g1_msm_cached_async(
+    cudaStream_t stream,
+    uint32_t gpu_index,
+    zk_g1_msm_mem* msm_mem,
+    G1Projective* h_result,
+    const zk_cached_g1_points* cached,
+    uint32_t point_offset,
+    const Scalar* h_scalars,
+    uint32_t n
+) {
+    zk_g1_msm_cached_async_impl(stream, gpu_index, msm_mem, h_result, cached, point_offset, h_scalars, n);
+}
+
+void scratch_zk_g2_msm(
+    cudaStream_t stream,
+    uint32_t gpu_index,
+    zk_g2_msm_mem** mem,
+    uint32_t max_n,
+    uint64_t* size_tracker,
+    bool allocate_gpu_memory
+) {
+    scratch_zk_g2_msm_impl(stream, gpu_index, mem, max_n, size_tracker, allocate_gpu_memory);
+}
+
+void cleanup_zk_g2_msm(
+    cudaStream_t stream,
+    uint32_t gpu_index,
+    zk_g2_msm_mem** mem,
+    bool allocate_gpu_memory
+) {
+    cleanup_zk_g2_msm_impl(stream, gpu_index, mem, allocate_gpu_memory);
+}
+
+void scratch_zk_cached_g2_points(
+    cudaStream_t stream,
+    uint32_t gpu_index,
+    zk_cached_g2_points** mem,
+    const G2Affine* h_points,
+    uint32_t n,
+    uint64_t* size_tracker,
+    bool allocate_gpu_memory
+) {
+    scratch_zk_cached_g2_points_impl(stream, gpu_index, mem, h_points, n, size_tracker, allocate_gpu_memory);
+}
+
+void zk_g2_msm_cached_async(
+    cudaStream_t stream,
+    uint32_t gpu_index,
+    zk_g2_msm_mem* msm_mem,
+    G2Projective* h_result,
+    const zk_cached_g2_points* cached,
+    uint32_t point_offset,
+    const Scalar* h_scalars,
+    uint32_t n
+) {
+    zk_g2_msm_cached_async_impl(stream, gpu_index, msm_mem, h_result, cached, point_offset, h_scalars, n);
+}
+
 void g1_from_montgomery_wrapper(G1Affine* result, const G1Affine* point) {
     PANIC_IF_FALSE(result != nullptr, "g1_from_montgomery error: result is null");
     PANIC_IF_FALSE(point != nullptr, "g1_from_montgomery error: point is null");
@@ -289,22 +369,6 @@ void g2_from_montgomery_wrapper(G2Affine* result, const G2Affine* point) {
     fp_from_montgomery(result->y.c0, point->y.c0);
     fp_from_montgomery(result->y.c1, point->y.c1);
     result->infinity = false;
-}
-
-void fp_to_montgomery_wrapper(Fp* result, const Fp* value) {
-    PANIC_IF_FALSE(result != nullptr, "fp_to_montgomery error: result is null");
-    PANIC_IF_FALSE(value != nullptr, "fp_to_montgomery error: value is null");
-    PANIC_IF_FALSE(result != value,
-                   "Output and input pointers must be different for out-of-place operations");
-    fp_to_montgomery(*result, *value);
-}
-
-void fp_from_montgomery_wrapper(Fp* result, const Fp* value) {
-    PANIC_IF_FALSE(result != nullptr, "fp_from_montgomery error: result is null");
-    PANIC_IF_FALSE(value != nullptr, "fp_from_montgomery error: value is null");
-    PANIC_IF_FALSE(result != value,
-                   "Output and input pointers must be different for out-of-place operations");
-    fp_from_montgomery(*result, *value);
 }
 
 void g1_projective_from_montgomery_normalized_wrapper(G1Projective* result, const G1Projective* point) {
@@ -355,6 +419,27 @@ void scalar_modulus_limbs_wrapper(uint64_t* limbs) {
     const UNSIGNED_LIMB modulus[ZP_LIMBS] = BLS12_446_SCALAR_MODULUS_LIMBS;
     // Byte layout is identical for little-endian regardless of limb size
     std::memcpy(limbs, modulus, 5 * sizeof(uint64_t));
+}
+
+uint32_t zk_msm_cache_acquire(
+    const G1Affine* g1_points, uint32_t n_g1,
+    const G2Affine* g2_points, uint32_t n_g2,
+    const uintptr_t key[4],
+    uint64_t* size_tracker
+) {
+    return zk_msm_cache_acquire_impl(g1_points, n_g1, g2_points, n_g2, key, size_tracker);
+}
+
+const zk_cached_g1_points* zk_msm_cache_get_g1(uint32_t gpu_index) {
+    return zk_msm_cache_get_g1_impl(gpu_index);
+}
+
+const zk_cached_g2_points* zk_msm_cache_get_g2(uint32_t gpu_index) {
+    return zk_msm_cache_get_g2_impl(gpu_index);
+}
+
+void zk_msm_cache_release() {
+    zk_msm_cache_release_impl();
 }
 
 } // extern "C"

--- a/backends/zk-cuda-backend/src/include/api.h
+++ b/backends/zk-cuda-backend/src/include/api.h
@@ -127,6 +127,96 @@ void g2_msm_unmanaged_wrapper_async(
 size_t pippenger_scratch_size_g1_wrapper(uint32_t n, uint32_t gpu_index);
 size_t pippenger_scratch_size_g2_wrapper(uint32_t n, uint32_t gpu_index);
 
+struct zk_g1_msm_mem;
+
+void scratch_zk_g1_msm(
+    cudaStream_t stream,
+    uint32_t gpu_index,
+    struct zk_g1_msm_mem** mem,
+    uint32_t max_n,
+    uint64_t* size_tracker,
+    bool allocate_gpu_memory
+);
+
+void cleanup_zk_g1_msm(
+    cudaStream_t stream,
+    uint32_t gpu_index,
+    struct zk_g1_msm_mem** mem,
+    bool allocate_gpu_memory
+);
+
+// Cached G1 base points on device in Montgomery form.
+// Allocated once per CRS, reused across many MSM calls in the verify path.
+struct zk_cached_g1_points;
+
+void scratch_zk_cached_g1_points(
+    cudaStream_t stream,
+    uint32_t gpu_index,
+    struct zk_cached_g1_points** mem,
+    const G1Point* h_points,
+    uint32_t n,
+    uint64_t* size_tracker,
+    bool allocate_gpu_memory
+);
+
+// MSM variant that uses device-resident cached base points (scalars-only H2D).
+// Requires a pre-allocated zk_g1_msm_mem for scalar buffer and Pippenger scratch.
+void zk_g1_msm_cached_async(
+    cudaStream_t stream,
+    uint32_t gpu_index,
+    struct zk_g1_msm_mem* msm_mem,
+    G1ProjectivePoint* h_result,
+    const struct zk_cached_g1_points* cached,
+    uint32_t point_offset,
+    const Scalar* h_scalars,
+    uint32_t n
+);
+
+struct zk_g2_msm_mem;
+
+void scratch_zk_g2_msm(
+    cudaStream_t stream,
+    uint32_t gpu_index,
+    struct zk_g2_msm_mem** mem,
+    uint32_t max_n,
+    uint64_t* size_tracker,
+    bool allocate_gpu_memory
+);
+
+void cleanup_zk_g2_msm(
+    cudaStream_t stream,
+    uint32_t gpu_index,
+    struct zk_g2_msm_mem** mem,
+    bool allocate_gpu_memory
+);
+
+// Cached G2 base points on device in Montgomery form.
+// Allocated once per CRS, reused across many MSM calls in the verify path.
+struct zk_cached_g2_points;
+
+void scratch_zk_cached_g2_points(
+    cudaStream_t stream,
+    uint32_t gpu_index,
+    struct zk_cached_g2_points** mem,
+    const G2Point* h_points,
+    uint32_t n,
+    uint64_t* size_tracker,
+    bool allocate_gpu_memory
+);
+
+// MSM variant that uses device-resident cached base points (scalars-only H2D).
+// Requires a pre-allocated zk_g2_msm_mem for scalar buffer and Pippenger scratch.
+void zk_g2_msm_cached_async(
+    cudaStream_t stream,
+    uint32_t gpu_index,
+    struct zk_g2_msm_mem* msm_mem,
+    G2ProjectivePoint* h_result,
+    const struct zk_cached_g2_points* cached,
+    uint32_t point_offset,
+    const Scalar* h_scalars,
+    uint32_t n
+);
+
 // Managed MSM wrappers with BigInt scalars (320-bit scalars)
 // Handles memory allocation and transfers internally.
 void g1_msm_managed_wrapper(
@@ -154,9 +244,6 @@ void g2_msm_managed_wrapper(
 // Montgomery conversion helpers
 void g1_from_montgomery_wrapper(G1Point* result, const G1Point* point);
 void g2_from_montgomery_wrapper(G2Point* result, const G2Point* point);
-void fp_to_montgomery_wrapper(Fp* result, const Fp* value);
-void fp_from_montgomery_wrapper(Fp* result, const Fp* value);
-
 // Projective point from Montgomery and normalize (divides by Z to get Z=1 form)
 void g1_projective_from_montgomery_normalized_wrapper(G1ProjectivePoint* result, const G1ProjectivePoint* point);
 void g2_projective_from_montgomery_normalized_wrapper(G2ProjectivePoint* result, const G2ProjectivePoint* point);
@@ -167,6 +254,17 @@ bool is_on_curve_g2_wrapper(const G2Point* point);
 
 // Scalar modulus accessor - returns the scalar field modulus (group order)
 void scalar_modulus_limbs_wrapper(uint64_t* limbs);
+
+// Global MSM cache for CRS base points (singleton).
+// Populated once per CRS key, lives until release() or process exit.
+uint32_t zk_msm_cache_acquire(
+    const G1Point* g1_points, uint32_t n_g1,
+    const G2Point* g2_points, uint32_t n_g2,
+    const uintptr_t key[4],
+    uint64_t* size_tracker);
+const struct zk_cached_g1_points* zk_msm_cache_get_g1(uint32_t gpu_index);
+const struct zk_cached_g2_points* zk_msm_cache_get_g2(uint32_t gpu_index);
+void zk_msm_cache_release(void);
 
 #ifdef __cplusplus
 }

--- a/backends/zk-cuda-backend/src/types/g1.rs
+++ b/backends/zk-cuda-backend/src/types/g1.rs
@@ -262,12 +262,6 @@ impl G1Projective {
         let points_ffi: Vec<G1Point> = points.iter().map(|p| p.inner).collect();
         let scalars_ffi: Vec<ScalarFFI> = scalars.iter().map(|s| *s.inner()).collect();
         let mut result = G1ProjectivePoint::default();
-        // NOTE: This method uses the managed API (g1_msm_managed_wrapper) which handles
-        // memory allocation and transfers internally. For a pure-GPU verify/proof implementation
-        // where all data is already on the device and memory is managed externally, use the
-        // unmanaged API (g1_msm_unmanaged_wrapper_async) instead — it performs zero internal
-        // allocations (caller provides d_scratch via pippenger_scratch_size_g1_wrapper).
-        //
         // SAFETY:
         // - `stream` was validated as non-null above and must be a valid `cudaStream_t` obtained
         //   from `cuda_create_stream`. The raw pointer type is `*mut c_void` because CUDA streams

--- a/backends/zk-cuda-backend/src/types/g2.rs
+++ b/backends/zk-cuda-backend/src/types/g2.rs
@@ -269,12 +269,6 @@ impl G2Projective {
         let points_ffi: Vec<G2Point> = points.iter().map(|p| p.inner).collect();
         let scalars_ffi: Vec<ScalarFFI> = scalars.iter().map(|s| *s.inner()).collect();
         let mut result = G2ProjectivePoint::default();
-        // NOTE: This method uses the managed API (g2_msm_managed_wrapper) which handles
-        // memory allocation and transfers internally. For a pure-GPU verify/proof implementation
-        // where all data is already on the device and memory is managed externally, use the
-        // unmanaged API (g2_msm_unmanaged_wrapper_async) instead — it performs zero internal
-        // allocations (caller provides d_scratch via pippenger_scratch_size_g2_wrapper).
-        //
         // SAFETY:
         // - `stream` was validated as non-null above and must be a valid `cudaStream_t` obtained
         //   from `cuda_create_stream`. The raw pointer type is `*mut c_void` because CUDA streams

--- a/tfhe-benchmark/benches/integer/zk_pke.rs
+++ b/tfhe-benchmark/benches/integer/zk_pke.rs
@@ -484,6 +484,8 @@ mod cuda {
     use tfhe::integer::gpu::zk::CudaProvenCompactCiphertextList;
     use tfhe::integer::gpu::CudaServerKey;
     use tfhe::integer::CompressedServerKey;
+    #[cfg(feature = "gpu-experimental-zk")]
+    use tfhe::zk::set_gpu_affinity;
     use tfhe::GpuIndex;
 
     /// Per-GPU element count for verify+expand throughput benchmarks.
@@ -706,6 +708,10 @@ mod cuda {
                                 });
                             });
 
+                            // Drain any async GPU work left by the expand-only benchmark
+                            // before running verify_and_expand, which checks proof validity.
+                            streams.synchronize();
+
                             bench_group.bench_function(&bench_id_verify_and_expand, |b| {
                                 b.iter(|| {
                                     let _ret = gpu_ct1
@@ -774,70 +780,169 @@ mod cuda {
                                 })
                                 .collect();
 
+                            // Per-GPU rayon pools so each pool's threads have
+                            // GPU affinity pinned, ensuring select_gpu_for_msm()
+                            // routes work to the correct device.
+                            let per_gpu = elements as usize / gpu_count;
+                            let threads_per_gpu = (rayon::current_num_threads() / gpu_count).max(1);
+                            let gpu_pools: Vec<rayon::ThreadPool> = (0..gpu_count)
+                                .map(|_| {
+                                    rayon::ThreadPoolBuilder::new()
+                                        .num_threads(threads_per_gpu)
+                                        .build()
+                                        .unwrap()
+                                })
+                                .collect();
+
+                            #[cfg(feature = "gpu-experimental-zk")]
+                            for (gpu_idx, pool) in gpu_pools.iter().enumerate() {
+                                pool.broadcast(|_| {
+                                    set_gpu_affinity(Some(gpu_idx as u32));
+                                });
+                            }
+
+                            // Rebind owned values as references so that `move`
+                            // closures inside s.spawn() capture a Copy reference
+                            // instead of moving the owned value.
+                            let pk = &pk;
+                            let crs = &crs;
+                            let metadata = metadata.as_slice();
+
                             bench_group.bench_function(&bench_id_verify, |b| {
                                 b.iter(|| {
-                                    cts.par_iter().for_each(|ct1| {
-                                        ct1.verify(&crs, &pk, &metadata);
-                                    })
+                                    std::thread::scope(|s| {
+                                        for (gpu_idx, pool) in
+                                            gpu_pools.iter().enumerate().take(gpu_count)
+                                        {
+                                            let start = gpu_idx * per_gpu;
+                                            let end = start + per_gpu;
+                                            let batch = &cts[start..end];
+                                            s.spawn(move || {
+                                                pool.install(|| {
+                                                    batch.par_iter().for_each(|ct1| {
+                                                        ct1.verify(crs, pk, metadata);
+                                                    });
+                                                });
+                                            });
+                                        }
+                                    });
                                 });
                             });
 
                             bench_group.bench_function(&bench_id_expand_without_verify, |b| {
-                                    let setup_encrypted_values = || {
-                                        let gpu_cts = cts.iter().enumerate().map(|(i, ct)| {
-                                            let local_stream = &local_streams[i % local_streams.len()];
+                                let local_streams = &local_streams;
+                                let setup_encrypted_values = || {
+                                    cts.iter()
+                                        .enumerate()
+                                        .map(|(i, ct)| {
+                                            let local_stream =
+                                                &local_streams[i % local_streams.len()];
                                             CudaProvenCompactCiphertextList::from_proven_compact_ciphertext_list(
                                                 ct, local_stream,
                                             )
-                                        }).collect_vec();
+                                        })
+                                        .collect_vec()
+                                };
 
-                                        gpu_cts
-                                    };
+                                b.iter_batched(
+                                    setup_encrypted_values,
+                                    |gpu_cts| {
+                                        // Strided indexing: element i lives on GPU i%gpu_count
+                                        // (matching the round-robin stream assignment).
+                                        std::thread::scope(|s| {
+                                            for (gpu_idx, (pool, d_ksk)) in gpu_pools
+                                                .iter()
+                                                .zip(d_ksks.iter())
+                                                .enumerate()
+                                                .take(gpu_count)
+                                            {
+                                                let gpu_cts_ref = &gpu_cts;
+                                                let indices: Vec<usize> = (gpu_idx
+                                                    ..gpu_cts_ref.len())
+                                                    .step_by(gpu_count)
+                                                    .collect();
+                                                s.spawn(move || {
+                                                    pool.install(|| {
+                                                        indices.par_iter().for_each(|&i| {
+                                                            let stream_idx =
+                                                                i % local_streams.len();
+                                                            let local_stream =
+                                                                &local_streams[stream_idx];
+                                                            gpu_cts_ref[i]
+                                                                .expand_without_verification(
+                                                                    d_ksk, local_stream,
+                                                                )
+                                                                .unwrap();
+                                                        });
+                                                    });
+                                                });
+                                            }
+                                        });
+                                    },
+                                    BatchSize::PerIteration,
+                                );
+                            });
 
-                                    b.iter_batched(setup_encrypted_values,
-                                                   |gpu_cts| {
-                                                       gpu_cts.par_iter().enumerate().for_each
-                                                       (|(i, gpu_ct)| {
-                                                           let stream_idx = i % local_streams.len();
-                                                           let local_stream = &local_streams[stream_idx];
-                                                           let gpu_idx = i % gpu_count;
-                                                           let d_ksk = &d_ksks[gpu_idx];
-
-                                                           gpu_ct
-                                                               .expand_without_verification(d_ksk, local_stream)
-                                                               .unwrap();
-                                                       });
-                                                   }, BatchSize::PerIteration);
-                                });
+                            // Drain any async GPU work left by the expand-only benchmark
+                            // before running verify_and_expand, which checks proof validity.
+                            for ls in &local_streams {
+                                ls.synchronize();
+                            }
 
                             bench_group.bench_function(&bench_id_verify_and_expand, |b| {
-                                    let setup_encrypted_values = || {
-                                        let gpu_cts = cts.iter().enumerate().map(|(i, ct)| {
+                                let local_streams = &local_streams;
+                                let setup_encrypted_values = || {
+                                    cts.iter()
+                                        .enumerate()
+                                        .map(|(i, ct)| {
                                             CudaProvenCompactCiphertextList::from_proven_compact_ciphertext_list(
-                                                ct, &local_streams[i % local_streams.len()],
+                                                ct,
+                                                &local_streams[i % local_streams.len()],
                                             )
-                                        }).collect_vec();
+                                        })
+                                        .collect_vec()
+                                };
 
-                                        gpu_cts
-                                    };
-
-                                    b.iter_batched(setup_encrypted_values,
-                                                   |gpu_cts| {
-                                                       gpu_cts.par_iter().enumerate().for_each
-                                                       (|(i, gpu_ct)| {
-                                                           let stream_idx = i % local_streams.len();
-                                                           let local_stream = &local_streams[stream_idx];
-                                                           let gpu_idx = i % gpu_count;
-                                                           let d_ksk = &d_ksks[gpu_idx];
-
-                                                           gpu_ct
-                                                               .verify_and_expand(
-                                                                   &crs, &pk, &metadata, d_ksk, local_stream,
-                                                               )
-                                                               .unwrap();
-                                                       });
-                                                   }, BatchSize::PerIteration);
-                                });
+                                b.iter_batched(
+                                    setup_encrypted_values,
+                                    |gpu_cts| {
+                                        std::thread::scope(|s| {
+                                            for (gpu_idx, (pool, d_ksk)) in gpu_pools
+                                                .iter()
+                                                .zip(d_ksks.iter())
+                                                .enumerate()
+                                                .take(gpu_count)
+                                            {
+                                                let gpu_cts_ref = &gpu_cts;
+                                                let indices: Vec<usize> = (gpu_idx
+                                                    ..gpu_cts_ref.len())
+                                                    .step_by(gpu_count)
+                                                    .collect();
+                                                s.spawn(move || {
+                                                    pool.install(|| {
+                                                        indices.par_iter().for_each(|&i| {
+                                                            let stream_idx =
+                                                                i % local_streams.len();
+                                                            let local_stream =
+                                                                &local_streams[stream_idx];
+                                                            gpu_cts_ref[i]
+                                                                .verify_and_expand(
+                                                                    crs,
+                                                                    pk,
+                                                                    metadata,
+                                                                    d_ksk,
+                                                                    local_stream,
+                                                                )
+                                                                .unwrap();
+                                                        });
+                                                    });
+                                                });
+                                            }
+                                        });
+                                    },
+                                    BatchSize::PerIteration,
+                                );
+                            });
                         }
                     }
 

--- a/tfhe-zk-pok/src/gpu/mod.rs
+++ b/tfhe-zk-pok/src/gpu/mod.rs
@@ -9,15 +9,49 @@ pub mod pke_v2;
 #[cfg(test)]
 mod tests;
 
+use std::cell::Cell;
+
 use crate::curve_446::{Fq, Fq2};
 use crate::curve_api::bls12_446::{G1Affine, G2Affine, Zp, G1, G2};
 use crate::curve_api::CurveGroupOps;
 use ark_ec::CurveGroup;
 use ark_ff::{BigInt, MontFp, PrimeField};
-use tfhe_cuda_backend::cuda_bind::{
-    cuda_create_stream, cuda_destroy_stream, cuda_get_number_of_gpus,
-};
+use tfhe_cuda_backend::cuda_bind::cuda_get_number_of_gpus;
 use zk_cuda_backend::{G1Affine as CudaG1Affine, G2Affine as CudaG2Affine, Scalar as CudaScalar};
+
+thread_local! {
+    static GPU_AFFINITY: Cell<Option<u32>> = const { Cell::new(None) };
+}
+
+/// Run `f` with all GPU MSM operations pinned to `gpu_idx`.
+///
+/// While active, `select_gpu_for_msm()` returns `gpu_idx` instead of
+/// the rayon-thread-based default, and `run_in_pool` is bypassed
+/// (the caller is responsible for providing an appropriately-sized
+/// thread pool).
+pub fn with_gpu_affinity<R>(gpu_idx: u32, f: impl FnOnce() -> R) -> R {
+    struct ResetOnDrop;
+    impl Drop for ResetOnDrop {
+        fn drop(&mut self) {
+            GPU_AFFINITY.set(None);
+        }
+    }
+    GPU_AFFINITY.set(Some(gpu_idx));
+    let _guard = ResetOnDrop;
+    f()
+}
+
+/// Set GPU affinity for the current thread directly.
+///
+/// Intended for use with `rayon::ThreadPool::broadcast` to pin all pool
+/// threads to a specific GPU. Pass `None` to clear.
+pub fn set_gpu_affinity(gpu_idx: Option<u32>) {
+    GPU_AFFINITY.set(gpu_idx);
+}
+
+pub(crate) fn current_gpu_affinity() -> Option<u32> {
+    GPU_AFFINITY.get()
+}
 
 // ---------------------------------------------------------------------------
 // GPU helpers
@@ -39,16 +73,23 @@ pub(crate) fn get_num_gpus() -> u32 {
     })
 }
 
-/// Selects a GPU for MSM based on the rayon thread index, distributing work
-/// across all available GPUs. Returns `0` when only one GPU is present.
+/// Selects a GPU for MSM operations.
+///
+/// If GPU affinity is set (via `with_gpu_affinity`), returns that GPU index
+/// unconditionally. Otherwise falls back to distributing work across GPUs
+/// based on the rayon thread index. Returns `0` when only one GPU is present.
 #[inline]
 pub fn select_gpu_for_msm() -> u32 {
+    if let Some(idx) = GPU_AFFINITY.get() {
+        return idx;
+    }
     let num_gpus = get_num_gpus();
     if num_gpus <= 1 {
         return 0;
     }
     let thread_idx = rayon::current_thread_index().unwrap_or(0);
-    (thread_idx % num_gpus as usize)
+    let num_gpus_usize: usize = num_gpus.try_into().expect("GPU count fits in usize");
+    (thread_idx % num_gpus_usize)
         .try_into()
         .expect("GPU index fits in u32")
 }
@@ -205,15 +246,15 @@ pub fn g1_msm_gpu(bases: &[G1Affine], scalars: &[Zp], gpu_index: u32) -> G1 {
         gpu_index < num_gpus,
         "gpu_index {gpu_index} exceeds available GPUs ({num_gpus})",
     );
-    // SAFETY: gpu_index was validated by the assert above
-    let stream = unsafe { cuda_create_stream(gpu_index) };
+    let stream = tfhe_cuda_backend::CudaStream::new(gpu_index);
 
-    let result =
-        zk_cuda_backend::G1Projective::msm(&gpu_bases, &gpu_scalars, stream, gpu_index, false);
-
-    // SAFETY: stream was created by cuda_create_stream above with the same gpu_index and is not
-    // used after this point
-    unsafe { cuda_destroy_stream(stream, gpu_index) };
+    let result = zk_cuda_backend::G1Projective::msm(
+        &gpu_bases,
+        &gpu_scalars,
+        stream.ptr(),
+        gpu_index,
+        false,
+    );
 
     let gpu_result = result.unwrap_or_else(|e| panic!("G1 GPU MSM failed: {e}"));
 
@@ -233,7 +274,7 @@ pub fn g1_msm_gpu(bases: &[G1Affine], scalars: &[Zp], gpu_index: u32) -> G1 {
     }
 }
 
-/// GPU-accelerated multi-scalar multiplication for G2.
+/// G2 MSM on a caller-provided stream (no stream create/destroy).
 ///
 /// # Panics
 ///
@@ -241,11 +282,15 @@ pub fn g1_msm_gpu(bases: &[G1Affine], scalars: &[Zp], gpu_index: u32) -> G1 {
 /// - If `bases` and `scalars` have different lengths (checked inside the backend).
 /// - If the GPU MSM call fails.
 #[must_use]
-pub fn g2_msm_gpu(bases: &[G2Affine], scalars: &[Zp], gpu_index: u32) -> G2 {
+pub fn g2_msm_gpu_on_stream(
+    bases: &[G2Affine],
+    scalars: &[Zp],
+    stream: *mut std::ffi::c_void,
+    gpu_index: u32,
+) -> G2 {
     use crate::curve_446::g2::G2Projective;
     use ark_ec::AffineRepr;
 
-    // Convert points to zk-cuda-backend format (normal form)
     let gpu_bases: Vec<_> = bases
         .iter()
         .map(|b| {
@@ -268,15 +313,9 @@ pub fn g2_msm_gpu(bases: &[G2Affine], scalars: &[Zp], gpu_index: u32) -> G2 {
         gpu_index < num_gpus,
         "gpu_index {gpu_index} exceeds available GPUs ({num_gpus})",
     );
-    // SAFETY: gpu_index was validated by the assert above
-    let stream = unsafe { cuda_create_stream(gpu_index) };
 
     let result =
         zk_cuda_backend::G2Projective::msm(&gpu_bases, &gpu_scalars, stream, gpu_index, false);
-
-    // SAFETY: stream was created by cuda_create_stream above with the same gpu_index and is not
-    // used after this point
-    unsafe { cuda_destroy_stream(stream, gpu_index) };
 
     let gpu_result = result.unwrap_or_else(|e| panic!("G2 GPU MSM failed: {e}"));
 
@@ -288,6 +327,290 @@ pub fn g2_msm_gpu(bases: &[G2Affine], scalars: &[Zp], gpu_index: u32) -> G2 {
 
     let z_is_zero =
         z_fp2.c0.limb.iter().all(|&limb| limb == 0) && z_fp2.c1.limb.iter().all(|&limb| limb == 0);
+    if z_is_zero {
+        return G2::ZERO;
+    }
+
+    let x = fq2_from_cuda_fp2(&x_fp2);
+    let y = fq2_from_cuda_fp2(&y_fp2);
+    let z = fq2_from_cuda_fp2(&z_fp2);
+    G2 {
+        inner: G2Projective::new_unchecked(x, y, z),
+    }
+}
+
+/// G2 MSM that creates and destroys its own CUDA stream.
+#[must_use]
+pub fn g2_msm_gpu(bases: &[G2Affine], scalars: &[Zp], gpu_index: u32) -> G2 {
+    let num_gpus = get_num_gpus();
+    assert!(
+        gpu_index < num_gpus,
+        "gpu_index {gpu_index} exceeds available GPUs ({num_gpus})",
+    );
+    let stream = tfhe_cuda_backend::CudaStream::new(gpu_index);
+    g2_msm_gpu_on_stream(bases, scalars, stream.ptr(), gpu_index)
+}
+
+/// Per-GPU cached base-point handles from the C++ singleton cache.
+///
+/// The C++ `ZkMsmCache` singleton owns the device memory and manages its
+/// lifecycle. These pointers are immutable and valid as long as this struct
+/// is alive. Drop calls `zk_msm_cache_release` to decrement the C++ ref
+/// count — the cache is only eligible for eviction (by a different CRS key)
+/// once all `CachedMsmResources` instances are dropped.
+///
+/// Callers index into `cached_g1` / `cached_g2` by gpu_index to get the
+/// device pointer for a specific GPU.
+pub(crate) struct CachedMsmResources {
+    pub cached_g1: Vec<*const std::ffi::c_void>,
+    pub cached_g2: Vec<*const std::ffi::c_void>,
+    pub num_gpus: u32,
+    pub size_tracker: u64,
+}
+
+impl Drop for CachedMsmResources {
+    fn drop(&mut self) {
+        // SAFETY: zk_msm_cache_release is a simple atomic decrement inside
+        // the C++ singleton — no CUDA calls unless this is the last reference
+        // AND the cache is being evicted, which only happens inside a
+        // subsequent zk_msm_cache_acquire.
+        unsafe {
+            zk_cuda_backend::bindings::zk_msm_cache_release();
+        }
+    }
+}
+
+// SAFETY: The raw pointers point to immutable device memory (base points in
+// Montgomery form) inside the C++ singleton cache. The cache is thread-safe
+// (protected by a mutex on the C++ side) and the memory is never modified
+// after initial setup. Multiple threads can safely read these concurrently.
+unsafe impl Send for CachedMsmResources {}
+unsafe impl Sync for CachedMsmResources {}
+
+/// Acquire cached base-point pointers for the given CRS point lists.
+///
+/// Delegates to the C++ `ZkMsmCache` singleton. On cache miss (first call
+/// or CRS change), uploads both g_list and g_hat_list to **every available
+/// GPU** in Montgomery form. On cache hit, returns immediately.
+///
+/// Only immutable base points are cached. Callers are responsible for
+/// creating their own CUDA streams and MSM scratch buffers for each call.
+pub(crate) fn acquire_cached_msm_resources(
+    g_list: &[G1Affine],
+    g_hat_list: &[G2Affine],
+) -> CachedMsmResources {
+    let ffi_g1: Vec<zk_cuda_backend::bindings::G1Point> = g_list
+        .iter()
+        .map(|p| {
+            let cuda = g1_affine_to_cuda(p);
+            zk_cuda_backend::bindings::G1Point {
+                x: cuda.x(),
+                y: cuda.y(),
+                infinity: cuda.is_infinity(),
+            }
+        })
+        .collect();
+
+    let ffi_g2: Vec<zk_cuda_backend::bindings::G2Point> = g_hat_list
+        .iter()
+        .map(|p| {
+            let cuda = g2_affine_to_cuda(p);
+            zk_cuda_backend::bindings::G2Point {
+                x: cuda.x(),
+                y: cuda.y(),
+                infinity: cuda.is_infinity(),
+            }
+        })
+        .collect();
+
+    // Cache key: content-based hash of the first G1 and G2 points.
+    // We cannot use pointer identity because Rust may reuse freed addresses
+    // for new allocations, causing the cache to return stale GPU data from a
+    // previously uploaded (and now-freed) CRS.
+    let key: [usize; 4] = {
+        use std::hash::{Hash, Hasher};
+        let mut h = std::hash::DefaultHasher::new();
+        if let Some(p) = ffi_g1.first() {
+            p.x.limb.hash(&mut h);
+            p.y.limb.hash(&mut h);
+        }
+        let h1 = h.finish() as usize;
+        let mut h = std::hash::DefaultHasher::new();
+        if let Some(p) = ffi_g2.first() {
+            p.x.c0.limb.hash(&mut h);
+            p.x.c1.limb.hash(&mut h);
+        }
+        let h2 = h.finish() as usize;
+        [h1, g_list.len(), h2, g_hat_list.len()]
+    };
+
+    let n_g1: u32 = g_list.len().try_into().expect("g_list length fits in u32");
+    let n_g2: u32 = g_hat_list
+        .len()
+        .try_into()
+        .expect("g_hat_list length fits in u32");
+
+    let g1_ptr = if ffi_g1.is_empty() {
+        std::ptr::null()
+    } else {
+        ffi_g1.as_ptr()
+    };
+    let g2_ptr = if ffi_g2.is_empty() {
+        std::ptr::null()
+    } else {
+        ffi_g2.as_ptr()
+    };
+
+    // SAFETY: g1_ptr/g2_ptr are either null or valid pointers to n_g1/n_g2
+    // G1Point/G2Point structs. key is a valid 4-element array. The C++ side
+    // is internally thread-safe (mutex-protected).
+    let mut size_tracker: u64 = 0;
+    let num_gpus = unsafe {
+        zk_cuda_backend::bindings::zk_msm_cache_acquire(
+            g1_ptr,
+            n_g1,
+            g2_ptr,
+            n_g2,
+            key.as_ptr(),
+            &mut size_tracker,
+        )
+    };
+
+    let cached_g1: Vec<*const std::ffi::c_void> = (0..num_gpus)
+        .map(|i| {
+            // SAFETY: cache is populated (zk_msm_cache_acquire just returned),
+            // and i < num_gpus.
+            unsafe { zk_cuda_backend::bindings::zk_msm_cache_get_g1(i) as *const std::ffi::c_void }
+        })
+        .collect();
+    let cached_g2: Vec<*const std::ffi::c_void> = (0..num_gpus)
+        .map(|i| {
+            // SAFETY: same as above.
+            unsafe { zk_cuda_backend::bindings::zk_msm_cache_get_g2(i) as *const std::ffi::c_void }
+        })
+        .collect();
+
+    CachedMsmResources {
+        cached_g1,
+        cached_g2,
+        num_gpus,
+        size_tracker,
+    }
+}
+
+/// G1 MSM using cached device base points and pre-allocated scratch.
+/// Only scalars are transferred H2D.
+#[must_use]
+pub(crate) fn g1_msm_cached_on_stream(
+    msm_mem: *mut std::ffi::c_void,
+    cached: *const std::ffi::c_void,
+    point_offset: u32,
+    scalars: &[Zp],
+    stream: *mut std::ffi::c_void,
+    gpu_index: u32,
+) -> G1 {
+    use crate::curve_446::g1::G1Projective;
+
+    let scalars_ffi: Vec<zk_cuda_backend::bindings::Scalar> = scalars
+        .iter()
+        .map(|s| zk_cuda_backend::bindings::Scalar {
+            limb: s.inner.into_bigint().0,
+        })
+        .collect();
+    let n: u32 = scalars_ffi
+        .len()
+        .try_into()
+        .expect("GPU MSM: scalar count too large for u32");
+
+    let mut result = zk_cuda_backend::bindings::G1ProjectivePoint::default();
+    let cuda_stream = stream as zk_cuda_backend::bindings::cudaStream_t;
+
+    // SAFETY: `msm_mem` was allocated by `scratch_zk_g1_msm` for >= n points.
+    // `cached` is a valid handle from `scratch_zk_cached_g1_points`.
+    // `scalars_ffi` is a valid host array with `n` elements.
+    // The function synchronizes internally before writing to `result`.
+    unsafe {
+        zk_cuda_backend::bindings::zk_g1_msm_cached_async(
+            cuda_stream,
+            gpu_index,
+            msm_mem as *mut _,
+            &mut result,
+            cached as *const _,
+            point_offset,
+            scalars_ffi.as_ptr(),
+            n,
+        );
+    }
+
+    let gpu_result = zk_cuda_backend::G1Projective::new(result.X, result.Y, result.Z);
+    let normalized = gpu_result.from_montgomery_normalized();
+    let x_fp = normalized.X();
+    let y_fp = normalized.Y();
+    let z_fp = normalized.Z();
+
+    if z_fp.limb.iter().all(|&l| l == 0) {
+        return G1::ZERO;
+    }
+
+    let x = fq_from_cuda_fp(&x_fp);
+    let y = fq_from_cuda_fp(&y_fp);
+    let z = fq_from_cuda_fp(&z_fp);
+    G1 {
+        inner: G1Projective::new_unchecked(x, y, z),
+    }
+}
+
+/// G2 MSM using cached device base points and pre-allocated scratch.
+/// Only scalars are transferred H2D.
+#[must_use]
+pub(crate) fn g2_msm_cached_on_stream(
+    msm_mem: *mut std::ffi::c_void,
+    cached: *const std::ffi::c_void,
+    point_offset: u32,
+    scalars: &[Zp],
+    stream: *mut std::ffi::c_void,
+    gpu_index: u32,
+) -> G2 {
+    use crate::curve_446::g2::G2Projective;
+
+    let scalars_ffi: Vec<zk_cuda_backend::bindings::Scalar> = scalars
+        .iter()
+        .map(|s| zk_cuda_backend::bindings::Scalar {
+            limb: s.inner.into_bigint().0,
+        })
+        .collect();
+    let n: u32 = scalars_ffi
+        .len()
+        .try_into()
+        .expect("GPU MSM: scalar count too large for u32");
+
+    let mut result = zk_cuda_backend::bindings::G2ProjectivePoint::default();
+    let cuda_stream = stream as zk_cuda_backend::bindings::cudaStream_t;
+
+    // SAFETY: `msm_mem` was allocated by `scratch_zk_g2_msm` for >= n points.
+    // `cached` is a valid handle from `scratch_zk_cached_g2_points`.
+    // `scalars_ffi` is a valid host array with `n` elements.
+    // The function synchronizes internally before writing to `result`.
+    unsafe {
+        zk_cuda_backend::bindings::zk_g2_msm_cached_async(
+            cuda_stream,
+            gpu_index,
+            msm_mem as *mut _,
+            &mut result,
+            cached as *const _,
+            point_offset,
+            scalars_ffi.as_ptr(),
+            n,
+        );
+    }
+
+    let gpu_result = zk_cuda_backend::G2Projective::new(result.X, result.Y, result.Z);
+    let normalized = gpu_result.from_montgomery_normalized();
+    let x_fp2 = normalized.X();
+    let y_fp2 = normalized.Y();
+    let z_fp2 = normalized.Z();
+
+    let z_is_zero = z_fp2.c0.limb.iter().all(|&l| l == 0) && z_fp2.c1.limb.iter().all(|&l| l == 0);
     if z_is_zero {
         return G2::ZERO;
     }

--- a/tfhe-zk-pok/src/gpu/pke_v2.rs
+++ b/tfhe-zk-pok/src/gpu/pke_v2.rs
@@ -1,15 +1,15 @@
 //! GPU-accelerated prove/verify for PKE v2.
 //!
 //! `prove` duplicates the logic of [`crate::proofs::pke_v2::prove_impl`] but replaces every
-//! `multi_mul_scalar` call with the GPU-accelerated [`super::g1_msm_gpu`]
-//! / [`super::g2_msm_gpu`].  `verify` duplicates [`crate::proofs::pke_v2::verify_impl`]
-//! and the two pairing-check helpers (`pairing_check_two_steps`,
-//! `pairing_check_batched`) with MSM sites similarly replaced.
+//! `multi_mul_scalar` call with GPU-accelerated cached MSMs that keep the CRS
+//! base points resident on device across calls.  `verify` duplicates
+//! [`crate::proofs::pke_v2::verify_impl`] and the two pairing-check helpers
+//! (`pairing_check_two_steps`, `pairing_check_batched`) with MSM sites
+//! similarly replaced.
 
 // Follow the notation of the paper
 #![allow(non_snake_case)]
 
-use super::select_gpu_for_msm;
 use crate::curve_api::bls12_446::{Gt, Zp, G1, G2};
 use crate::curve_api::{Bls12_446, CurveGroupOps, FieldOps};
 use crate::four_squares::*;
@@ -27,6 +27,25 @@ use crate::proofs::pke_v2::{
 };
 
 use rayon::prelude::*;
+use tfhe_cuda_backend::CudaStream;
+
+/// Marks a raw pointer as `Send` so it can cross rayon scope boundaries.
+///
+/// Used exclusively for MSM scratch memory pointers (`*mut c_void`) that are
+/// allocated outside a rayon scope and handed to worker threads. Each slot is
+/// used by exactly one thread — no concurrent aliasing.
+//
+// Temporary: once the C++ MSM cache manages its own scratch buffers this
+// wrapper will no longer be needed.
+#[derive(Clone, Copy)]
+struct SendRawPtr(*mut std::ffi::c_void);
+
+// SAFETY: each SendRawPtr is used by a single rayon worker; no concurrent access.
+// Send is needed because the closures are moved into rayon threads.
+// Sync is needed because the array of SendRawPtr is borrowed (&[SendRawPtr; 3])
+// across multiple rayon::scope closures, and &T: Send requires T: Sync.
+unsafe impl Send for SendRawPtr {}
+unsafe impl Sync for SendRawPtr {}
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -35,7 +54,7 @@ use rayon::prelude::*;
 /// GPU-accelerated proof generation for PKE v2.
 ///
 /// Identical to [`crate::proofs::pke_v2::prove`] but dispatches MSM to the GPU via
-/// [`super::g1_msm_gpu`] / [`super::g2_msm_gpu`].
+/// cached device-resident CRS base points.
 pub fn prove(
     public: (&PublicParams<Bls12_446>, &PublicCommit<Bls12_446>),
     private_commit: &PrivateCommit<Bls12_446>,
@@ -43,24 +62,42 @@ pub fn prove(
     load: ComputeLoad,
     seed: &[u8],
 ) -> Proof<Bls12_446> {
-    prove_impl(
-        public,
-        private_commit,
-        metadata,
-        load,
-        seed,
-        PkeV2SupportedHashConfig::default(),
-        ProofSanityCheckMode::Panic,
-    )
+    let g_list = &*public.0.g_lists.g_list.0;
+    let g_hat_list = &*public.0.g_lists.g_hat_list.0;
+
+    // Acquire the MSM cache BEFORE entering the pool. The C++ ZkMsmCache
+    // singleton blocks on a condition variable when a different CRS key is
+    // already held (waits for ref_count == 0). If this blocking happened
+    // inside run_in_pool, it would consume a pool thread and potentially
+    // starve the rayon::scope tasks of a concurrent prove — causing a
+    // deadlock. By acquiring here, the wait happens on the caller's thread
+    // which is not part of the pool.
+    let cache = super::acquire_cached_msm_resources(g_list, g_hat_list);
+
+    // run_in_pool constrains prove_impl to a 32-thread pool. Without it, the
+    // global rayon pool (often 128+ threads on large machines) causes significant
+    // work-stealing overhead that regresses prove latency by ~40%.
+    run_in_pool(|| {
+        prove_impl(
+            public,
+            private_commit,
+            metadata,
+            load,
+            seed,
+            PkeV2SupportedHashConfig::default(),
+            ProofSanityCheckMode::Panic,
+            cache,
+        )
+    })
 }
 
 /// GPU-accelerated verification for PKE v2.
 ///
 /// Identical to [`crate::proofs::pke_v2::verify`] but dispatches MSM to the GPU via
-/// [`super::g1_msm_gpu`] / [`super::g2_msm_gpu`].
-// TODO: `run_in_pool` was introduced for the CPU path because benchmarks showed better
-// performance with fewer threads (likely due to arkworks MSM parallelization overhead).
-// This may not hold for the GPU implementation and should be revisited.
+/// cached device-resident CRS base points.
+// run_in_pool constrains verify_impl to a 32-thread pool. Without it, the
+// global rayon pool (often 128+ threads on large machines) causes significant
+// work-stealing overhead that regresses verify latency by ~30%.
 #[allow(clippy::result_unit_err)]
 pub fn verify(
     proof: &Proof<Bls12_446>,
@@ -84,8 +121,12 @@ fn prove_impl(
     seed: &[u8],
     hash_config: PkeV2SupportedHashConfig,
     sanity_check_mode: ProofSanityCheckMode,
+    cache: super::CachedMsmResources,
 ) -> Proof<Bls12_446> {
-    _ = load;
+    let timing = std::env::var("ZK_VERIFY_TIMING").is_ok();
+    let prove_start = std::time::Instant::now();
+    let mut t_phase = std::time::Instant::now();
+
     let (
         &PublicParams {
             ref g_lists,
@@ -109,6 +150,68 @@ fn prove_impl(
 
     let g_list = &*g_lists.g_list.0;
     let g_hat_list = &*g_lists.g_hat_list.0;
+
+    let cache = &cache;
+
+    // Distribute 3 MSM slots across available GPUs via round-robin.
+    // For 1 GPU: [0, 0, 0]. For 3+ GPUs: [0, 1, 2].
+    let num_gpus = cache.num_gpus;
+    let gpu_indices: [u32; 3] = [0, 1 % num_gpus, 2 % num_gpus];
+    let streams: [CudaStream; 3] = [
+        CudaStream::new(gpu_indices[0]),
+        CudaStream::new(gpu_indices[1]),
+        CudaStream::new(gpu_indices[2]),
+    ];
+
+    let g1_max_n = u32::try_from(g_list.len()).expect("g_list length fits in u32");
+    let g2_max_n = u32::try_from(g_hat_list.len()).expect("g_hat_list length fits in u32");
+
+    let mut g1_msm_raw: [*mut std::ffi::c_void; 3] = [std::ptr::null_mut(); 3];
+    let mut g2_msm_raw: [*mut std::ffi::c_void; 3] = [std::ptr::null_mut(); 3];
+    for i in 0..3 {
+        let mut tracker: u64 = 0;
+        let mut g1_typed: *mut zk_cuda_backend::bindings::zk_g1_msm_mem = std::ptr::null_mut();
+        // SAFETY: streams[i] is valid. g1_typed receives the allocation.
+        unsafe {
+            zk_cuda_backend::bindings::scratch_zk_g1_msm(
+                streams[i].ptr() as zk_cuda_backend::bindings::cudaStream_t,
+                gpu_indices[i],
+                &mut g1_typed,
+                g1_max_n,
+                &mut tracker,
+                true,
+            );
+        }
+        assert!(
+            !g1_typed.is_null(),
+            "scratch_zk_g1_msm returned null on GPU {}",
+            gpu_indices[i]
+        );
+        g1_msm_raw[i] = g1_typed as *mut std::ffi::c_void;
+        tracker = 0;
+        let mut g2_typed: *mut zk_cuda_backend::bindings::zk_g2_msm_mem = std::ptr::null_mut();
+        // SAFETY: streams[i] is valid. g2_typed receives the allocation.
+        unsafe {
+            zk_cuda_backend::bindings::scratch_zk_g2_msm(
+                streams[i].ptr() as zk_cuda_backend::bindings::cudaStream_t,
+                gpu_indices[i],
+                &mut g2_typed,
+                g2_max_n,
+                &mut tracker,
+                true,
+            );
+        }
+        assert!(
+            !g2_typed.is_null(),
+            "scratch_zk_g2_msm returned null on GPU {}",
+            gpu_indices[i]
+        );
+        g2_msm_raw[i] = g2_typed as *mut std::ffi::c_void;
+    }
+    // Wrap in SendRawPtr so the arrays can be borrowed across rayon scopes
+    // (each slot is used by exactly one thread).
+    let g1_msm_mems = g1_msm_raw.map(SendRawPtr);
+    let g2_msm_mems = g2_msm_raw.map(SendRawPtr);
 
     let PrivateCommit { r, e1, m, e2, .. } = private_commit;
 
@@ -189,36 +292,61 @@ fn prove_impl(
     let scalars_e_rev: Box<[_]> = scalars_e.iter().copied().rev().collect();
     let scalars_r: Box<[_]> = r1_zp.iter().chain(r2_zp.iter()).copied().collect();
 
+    if timing {
+        eprintln!(
+            "[ZK_PROVE_TIMING] setup+scalars: {:.1}ms",
+            t_phase.elapsed().as_secs_f64() * 1000.0
+        );
+        t_phase = std::time::Instant::now();
+    }
+
     let mut C_hat_e = None;
     let mut C_e = None;
     let mut C_r_tilde = None;
 
     rayon::scope(|s| {
         s.spawn(|_| {
-            // GPU MSM: C_hat_e commitment
+            // GPU MSM: C_hat_e commitment (G2, offset 0, n=d+k+4)
             C_hat_e = Some(
                 g_hat.mul_scalar(gamma_hat_e)
-                    + super::g2_msm_gpu(&g_hat_list[..d + k + 4], &scalars_e, select_gpu_for_msm()),
-            );
-        });
-
-        s.spawn(|_| {
-            // GPU MSM: C_e commitment
-            C_e = Some(
-                g.mul_scalar(gamma_e)
-                    + super::g1_msm_gpu(
-                        &g_list[n - (d + k + 4)..n],
-                        &scalars_e_rev,
-                        select_gpu_for_msm(),
+                    + super::g2_msm_cached_on_stream(
+                        g2_msm_mems[0].0,
+                        cache.cached_g2[gpu_indices[0] as usize],
+                        0,
+                        &scalars_e,
+                        streams[0].ptr(),
+                        gpu_indices[0],
                     ),
             );
         });
 
         s.spawn(|_| {
-            // GPU MSM: C_r_tilde commitment
+            // GPU MSM: C_e commitment (G1, offset n-(d+k+4))
+            C_e = Some(
+                g.mul_scalar(gamma_e)
+                    + super::g1_msm_cached_on_stream(
+                        g1_msm_mems[1].0,
+                        cache.cached_g1[gpu_indices[1] as usize],
+                        u32::try_from(n - (d + k + 4)).expect("point offset fits in u32"),
+                        &scalars_e_rev,
+                        streams[1].ptr(),
+                        gpu_indices[1],
+                    ),
+            );
+        });
+
+        s.spawn(|_| {
+            // GPU MSM: C_r_tilde commitment (G1, offset 0, n=d+k)
             C_r_tilde = Some(
                 g.mul_scalar(gamma_r)
-                    + super::g1_msm_gpu(&g_list[..d + k], &scalars_r, select_gpu_for_msm()),
+                    + super::g1_msm_cached_on_stream(
+                        g1_msm_mems[2].0,
+                        cache.cached_g1[gpu_indices[2] as usize],
+                        0,
+                        &scalars_r,
+                        streams[2].ptr(),
+                        gpu_indices[2],
+                    ),
             );
         });
     });
@@ -226,6 +354,14 @@ fn prove_impl(
     let C_hat_e = C_hat_e.unwrap();
     let C_e = C_e.unwrap();
     let C_r_tilde = C_r_tilde.unwrap();
+
+    if timing {
+        eprintln!(
+            "[ZK_PROVE_TIMING] initial_commitments: {:.1}ms",
+            t_phase.elapsed().as_secs_f64() * 1000.0
+        );
+        t_phase = std::time::Instant::now();
+    }
 
     let C_hat_e_bytes = C_hat_e.to_le_bytes();
     let C_e_bytes = C_e.to_le_bytes();
@@ -272,16 +408,49 @@ fn prove_impl(
         })
         .collect::<Box<[_]>>();
 
-    // GPU MSM: C_R commitment
+    // GPU MSM: C_R commitment (G1, offset 0, n=128)
     let C_R = g.mul_scalar(gamma_R)
-        + super::g1_msm_gpu(
-            &g_list[..128],
+        + super::g1_msm_cached_on_stream(
+            g1_msm_mems[0].0,
+            cache.cached_g1[gpu_indices[0] as usize],
+            0,
             &w_R.iter().copied().map(Zp::from_i64).collect::<Box<[_]>>(),
-            select_gpu_for_msm(),
+            streams[0].ptr(),
+            gpu_indices[0],
         );
 
     let C_R_bytes = C_R.to_le_bytes();
     let (phi, phi_hash) = R_hash.gen_phi(C_R_bytes.as_ref());
+
+    let mut t_sub = std::time::Instant::now();
+
+    // Precompute R^T * phi: for each column j of R, compute sum_i(phi[i] * R(i,j)).
+    // The full vector has 2*(d+k)+4 entries covering both the poly_1/C_h2/P_h2 range
+    // (first d+k+4 columns) and the poly_2/C_hat_h3/P_h3 range (next d+k columns).
+    // Each column is independent, so we parallelize across columns with rayon.
+    let r_transpose_phi: Vec<Zp> = (0..2 * (d + k) + 4)
+        .into_par_iter()
+        .map(|j| {
+            let mut acc = Zp::ZERO;
+            for (i, &phi_val) in phi.iter().enumerate() {
+                match R(i, j) {
+                    0 => {}
+                    1 => acc += phi_val,
+                    -1 => acc -= phi_val,
+                    _ => unreachable!(),
+                }
+            }
+            acc
+        })
+        .collect();
+
+    if timing {
+        eprintln!(
+            "[ZK_PROVE_TIMING]   r_transpose_phi: {:.1}ms (2*(d+k)+4={} cols)",
+            t_sub.elapsed().as_secs_f64() * 1000.0,
+            2 * (d + k) + 4,
+        );
+    }
 
     let m = m_bound;
 
@@ -295,14 +464,24 @@ fn prove_impl(
         .chain(w_R_bin.iter().copied())
         .collect::<Box<[_]>>();
 
-    let C_hat_bin = g_hat.mul_scalar(gamma_bin)
-        + g_hat_list
-            .iter()
-            .zip(&*w_bin)
-            .filter(|&(_, &w)| w)
-            .map(|(&x, _)| x)
-            .map(G2::projective)
-            .sum::<G2>();
+    // Sparse point sum: add g_hat_list[i] for each bit set in w_bin.
+    // Parallelized via chunked partial sums to use multiple cores.
+    let C_hat_bin = {
+        const CHUNK: usize = 1024;
+        let partial_sums: Vec<G2> = g_hat_list
+            .par_chunks(CHUNK)
+            .zip(w_bin.par_chunks(CHUNK))
+            .map(|(bases, flags)| {
+                bases
+                    .iter()
+                    .zip(flags)
+                    .filter(|&(_, &w)| w)
+                    .map(|(&x, _)| G2::projective(x))
+                    .sum::<G2>()
+            })
+            .collect();
+        g_hat.mul_scalar(gamma_bin) + partial_sums.into_iter().sum::<G2>()
+    };
 
     let C_hat_bin_bytes = C_hat_bin.to_le_bytes();
     let (xi, xi_hash) = phi_hash.gen_xi::<Zp>(C_hat_bin_bytes.as_ref());
@@ -319,16 +498,27 @@ fn prove_impl(
         .map(|(&y, &w)| if w { y } else { Zp::ZERO })
         .collect::<Box<[_]>>();
 
-    // GPU MSM: C_y commitment
+    // GPU MSM: C_y commitment (G1, offset n-(D+128*m))
     let C_y = g.mul_scalar(gamma_y)
-        + super::g1_msm_gpu(
-            &g_list[n - (D + 128 * m)..n],
+        + super::g1_msm_cached_on_stream(
+            g1_msm_mems[0].0,
+            cache.cached_g1[gpu_indices[0] as usize],
+            u32::try_from(n - (D + 128 * m)).expect("point offset fits in u32"),
             &scalars,
-            select_gpu_for_msm(),
+            streams[0].ptr(),
+            gpu_indices[0],
         );
 
     let C_y_bytes = C_y.to_le_bytes();
     let (t, t_hash) = y_hash.gen_t(C_y_bytes.as_ref());
+
+    if timing {
+        eprintln!(
+            "[ZK_PROVE_TIMING] hash_chain_1: {:.1}ms",
+            t_phase.elapsed().as_secs_f64() * 1000.0
+        );
+        t_phase = std::time::Instant::now();
+    }
 
     let (theta, theta_hash) = t_hash.gen_theta();
 
@@ -360,308 +550,25 @@ fn prove_impl(
     let xi_powers = precompute_xi_powers(&xi, m);
     let delta_theta_q = delta_theta * Zp::from_u128(decoded_q);
 
-    // Build all polynomial pairs in parallel
-    let mut poly_0_lhs = None;
-    let mut poly_0_rhs = None;
-    let mut poly_1_lhs = None;
-    let mut poly_1_rhs = None;
-    let mut poly_2_lhs = None;
-    let mut poly_2_rhs = None;
-    let mut poly_3_lhs = None;
-    let mut poly_3_rhs = None;
-    let mut poly_4_lhs = None;
-    let mut poly_4_rhs = None;
-    let mut poly_5_lhs = None;
-    let mut poly_5_rhs = None;
-
-    rayon::scope(|s| {
-        s.spawn(|_| {
-            let mut lhs = vec![Zp::ZERO; 1 + n];
-            let mut rhs = vec![Zp::ZERO; 1 + D + 128 * m];
-
-            lhs[0] = delta_y * gamma_y;
-            for j in 0..D + 128 * m {
-                let p = &mut lhs[n - j];
-
-                if !w_bin[j] {
-                    *p -= delta_y * y[j];
-                }
-
-                if j < D {
-                    *p += delta_theta * a_theta[j];
-                }
-                *p += delta_eq * t[j] * y[j];
-
-                if j >= D {
-                    let j_inner = j - D;
-                    let r = delta_dec * xi_powers[j_inner];
-
-                    if j_inner % m < m - 1 {
-                        *p += r;
-                    } else {
-                        *p -= r;
-                    }
-                }
-            }
-
-            rhs[0] = gamma_bin;
-            for j in 0..D + 128 * m {
-                let p = &mut rhs[j + 1];
-
-                if w_bin[j] {
-                    *p = Zp::ONE;
-                }
-            }
-
-            poly_0_lhs = Some(lhs);
-            poly_0_rhs = Some(rhs);
-        });
-
-        s.spawn(|_| {
-            let mut lhs = vec![Zp::ZERO; 1 + n];
-            let mut rhs = vec![Zp::ZERO; 1 + d + k + 4];
-
-            lhs[0] = delta_l * gamma_e;
-            for j in 0..d {
-                let p = &mut lhs[n - j];
-                *p = delta_l * e1_zp[j];
-            }
-            for j in 0..k {
-                let p = &mut lhs[n - (d + j)];
-                *p = delta_l * e2_zp[j];
-            }
-            for j in 0..4 {
-                let p = &mut lhs[n - (d + k + j)];
-                *p = delta_l * v_zp[j];
-            }
-
-            for j in 0..n {
-                let p = &mut lhs[n - j];
-                let mut acc = delta_e * omega[j];
-                if j < d + k {
-                    acc += delta_theta * theta[j];
-                }
-
-                if j < d + k + 4 {
-                    let mut acc2 = Zp::ZERO;
-                    for (i, &phi_val) in phi.iter().enumerate() {
-                        match R(i, j) {
-                            0 => {}
-                            1 => acc2 += phi_val,
-                            -1 => acc2 -= phi_val,
-                            _ => unreachable!(),
-                        }
-                    }
-                    acc += delta_r * acc2;
-                }
-                *p += acc;
-            }
-
-            rhs[0] = gamma_hat_e;
-            for j in 0..d {
-                let p = &mut rhs[1 + j];
-                *p = e1_zp[j];
-            }
-            for j in 0..k {
-                let p = &mut rhs[1 + (d + j)];
-                *p = e2_zp[j];
-            }
-            for j in 0..4 {
-                let p = &mut rhs[1 + (d + k + j)];
-                *p = v_zp[j];
-            }
-
-            poly_1_lhs = Some(lhs);
-            poly_1_rhs = Some(rhs);
-        });
-
-        s.spawn(|_| {
-            let mut lhs = vec![Zp::ZERO; 1 + d + k];
-            let mut rhs = vec![Zp::ZERO; 1 + n];
-
-            lhs[0] = gamma_r;
-            for j in 0..d {
-                let p = &mut lhs[1 + j];
-                *p = r1_zp[j];
-            }
-            for j in 0..k {
-                let p = &mut lhs[1 + (d + j)];
-                *p = r2_zp[j];
-            }
-
-            for j in 0..d + k {
-                let p = &mut rhs[n - j];
-
-                let mut acc = Zp::ZERO;
-                for (i, &phi_val) in phi.iter().enumerate() {
-                    match R(i, d + k + 4 + j) {
-                        0 => {}
-                        1 => acc += phi_val,
-                        -1 => acc -= phi_val,
-                        _ => unreachable!(),
-                    }
-                }
-                *p = delta_r * acc - delta_theta_q * theta[j];
-            }
-
-            poly_2_lhs = Some(lhs);
-            poly_2_rhs = Some(rhs);
-        });
-
-        s.spawn(|_| {
-            let mut lhs = vec![Zp::ZERO; 1 + 128];
-            let mut rhs = vec![Zp::ZERO; 1 + n];
-
-            lhs[0] = gamma_R;
-            for j in 0..128 {
-                let p = &mut lhs[1 + j];
-                *p = Zp::from_i64(w_R[j]);
-            }
-
-            for j in 0..128 {
-                let p = &mut rhs[n - j];
-                *p = delta_r * phi[j] + delta_dec * xi_powers[j * m];
-            }
-
-            poly_3_lhs = Some(lhs);
-            poly_3_rhs = Some(rhs);
-        });
-
-        s.spawn(|_| {
-            let mut lhs = vec![Zp::ZERO; 1 + n];
-            let mut rhs = vec![Zp::ZERO; 1 + d + k + 4];
-
-            lhs[0] = delta_e * gamma_e;
-            for j in 0..d {
-                let p = &mut lhs[n - j];
-                *p = delta_e * e1_zp[j];
-            }
-            for j in 0..k {
-                let p = &mut lhs[n - (d + j)];
-                *p = delta_e * e2_zp[j];
-            }
-            for j in 0..4 {
-                let p = &mut lhs[n - (d + k + j)];
-                *p = delta_e * v_zp[j];
-            }
-
-            for j in 0..d + k + 4 {
-                let p = &mut rhs[1 + j];
-                *p = omega[j];
-            }
-
-            poly_4_lhs = Some(lhs);
-            poly_4_rhs = Some(rhs);
-        });
-
-        s.spawn(|_| {
-            let mut lhs = vec![Zp::ZERO; 1 + n];
-            let mut rhs = vec![Zp::ZERO; 1 + n];
-
-            lhs[0] = delta_eq * gamma_y;
-            for j in 0..D + 128 * m {
-                let p = &mut lhs[n - j];
-
-                if w_bin[j] {
-                    *p = delta_eq * y[j];
-                }
-            }
-
-            for j in 0..n {
-                let p = &mut rhs[1 + j];
-                *p = t[j];
-            }
-
-            poly_5_lhs = Some(lhs);
-            poly_5_rhs = Some(rhs);
-        });
-    });
-
-    let poly_0_lhs = poly_0_lhs.unwrap();
-    let poly_0_rhs = poly_0_rhs.unwrap();
-    let poly_1_lhs = poly_1_lhs.unwrap();
-    let poly_1_rhs = poly_1_rhs.unwrap();
-    let poly_2_lhs = poly_2_lhs.unwrap();
-    let poly_2_rhs = poly_2_rhs.unwrap();
-    let poly_3_lhs = poly_3_lhs.unwrap();
-    let poly_3_rhs = poly_3_rhs.unwrap();
-    let poly_4_lhs = poly_4_lhs.unwrap();
-    let poly_4_rhs = poly_4_rhs.unwrap();
-    let poly_5_lhs = poly_5_lhs.unwrap();
-    let poly_5_rhs = poly_5_rhs.unwrap();
-
-    let poly = [
-        (&poly_0_lhs, &poly_0_rhs),
-        (&poly_1_lhs, &poly_1_rhs),
-        (&poly_2_lhs, &poly_2_rhs),
-        (&poly_3_lhs, &poly_3_rhs),
-        (&poly_4_lhs, &poly_4_rhs),
-        (&poly_5_lhs, &poly_5_rhs),
-    ];
-
-    let [mut poly_0, poly_1, poly_2, poly_3, poly_4, poly_5] = {
-        let tmp: Box<[Vec<Zp>; 6]> = poly
-            .into_par_iter()
-            .map(|(lhs, rhs)| Zp::poly_mul(lhs, rhs))
-            .collect::<Box<[_]>>()
-            .try_into()
-            .unwrap();
-        *tmp
-    };
-
-    let len = [
-        poly_0.len(),
-        poly_1.len(),
-        poly_2.len(),
-        poly_3.len(),
-        poly_4.len(),
-        poly_5.len(),
-    ]
-    .into_iter()
-    .max()
-    .unwrap();
-
-    poly_0.resize(len, Zp::ZERO);
-
-    {
-        let chunk_size = len.div_ceil(rayon::current_num_threads());
-
-        poly_0
-            .par_chunks_mut(chunk_size)
-            .enumerate()
-            .for_each(|(j, p0)| {
-                let offset = j * chunk_size;
-                let p1 = poly_1.get(offset..).unwrap_or(&[]);
-                let p2 = poly_2.get(offset..).unwrap_or(&[]);
-                let p3 = poly_3.get(offset..).unwrap_or(&[]);
-                let p4 = poly_4.get(offset..).unwrap_or(&[]);
-                let p5 = poly_5.get(offset..).unwrap_or(&[]);
-
-                for (j, p0) in p0.iter_mut().enumerate() {
-                    if j < p1.len() {
-                        *p0 += p1[j];
-                    }
-                    if j < p2.len() {
-                        *p0 += p2[j];
-                    }
-                    if j < p3.len() {
-                        *p0 -= p3[j];
-                    }
-                    if j < p4.len() {
-                        *p0 -= p4[j];
-                    }
-                    if j < p5.len() {
-                        *p0 -= p5[j];
-                    }
-                }
-            });
-    }
-    let mut P_pi = poly_0;
-    if P_pi.len() > n + 1 {
-        P_pi[n + 1] -= delta_theta * t_theta + delta_l * Zp::from_u128(B_squared);
+    if timing {
+        eprintln!(
+            "[ZK_PROVE_TIMING] hash_chain_2: {:.1}ms",
+            t_phase.elapsed().as_secs_f64() * 1000.0
+        );
+        t_phase = std::time::Instant::now();
     }
 
-    // Parallelize pi, C_h1, C_h2, compute_load_proof_fields, and C_hat_t computations
+    // Overlap polynomial construction (CPU-heavy) with independent commitment
+    // MSMs (GPU-heavy). 5 of the 6 commitment MSMs depend only on values
+    // already available after hash_chain_2 (delta_*, theta, omega, a_theta, y,
+    // t, xi_powers, r_transpose_phi). Only the pi MSM needs P_pi, which comes
+    // from poly construction, so pi runs at the end of the poly spawn.
+    //
+    // 6 MSMs distributed across 3 streams:
+    //   G1 side: pi (stream 0), C_h1 (stream 1), C_h2 (stream 2)
+    //   G2 side: C_hat_h3 (stream 0), C_hat_w (stream 1), C_hat_t (stream 2)
+    // G1 and G2 scratch buffers are independent, so a stream can run one G1
+    // and one G2 MSM concurrently without contention.
     let mut pi = None;
     let mut C_h1 = None;
     let mut C_h2 = None;
@@ -669,18 +576,10 @@ fn prove_impl(
     let mut C_hat_t = None;
 
     rayon::scope(|s| {
-        s.spawn(|_| {
-            // GPU MSM: pi commitment
-            pi = Some(if P_pi.is_empty() {
-                G1::ZERO
-            } else {
-                g.mul_scalar(P_pi[0])
-                    + super::g1_msm_gpu(&g_list[..P_pi.len() - 1], &P_pi[1..], select_gpu_for_msm())
-            });
-        });
+        // --- Independent MSMs: launch GPU work immediately ---
 
         s.spawn(|_| {
-            // GPU MSM: C_h1 commitment
+            // GPU MSM: C_h1 commitment (G1, stream 1, offset n-(D+128*m))
             let scalars_h1: Box<[_]> = (0..D + 128 * m)
                 .rev()
                 .map(|j| {
@@ -705,15 +604,18 @@ fn prove_impl(
                     acc
                 })
                 .collect();
-            C_h1 = Some(super::g1_msm_gpu(
-                &g_list[n - (D + 128 * m)..n],
+            C_h1 = Some(super::g1_msm_cached_on_stream(
+                g1_msm_mems[1].0,
+                cache.cached_g1[gpu_indices[1] as usize],
+                u32::try_from(n - (D + 128 * m)).expect("point offset fits in u32"),
                 &scalars_h1,
-                select_gpu_for_msm(),
+                streams[1].ptr(),
+                gpu_indices[1],
             ));
         });
 
         s.spawn(|_| {
-            // GPU MSM: C_h2 commitment
+            // GPU MSM: C_h2 commitment (G1, stream 2, offset 0, n=n)
             let scalars_h2: Box<[_]> = (0..n)
                 .rev()
                 .map(|j| {
@@ -725,28 +627,23 @@ fn prove_impl(
                     acc += delta_e * omega[j];
 
                     if j < d + k + 4 {
-                        let mut acc2 = Zp::ZERO;
-                        for (i, &phi_val) in phi.iter().enumerate() {
-                            match R(i, j) {
-                                0 => {}
-                                1 => acc2 += phi_val,
-                                -1 => acc2 -= phi_val,
-                                _ => unreachable!(),
-                            }
-                        }
-                        acc += delta_r * acc2;
+                        acc += delta_r * r_transpose_phi[j];
                     }
                     acc
                 })
                 .collect();
-            C_h2 = Some(super::g1_msm_gpu(
-                &g_list[..n],
+            C_h2 = Some(super::g1_msm_cached_on_stream(
+                g1_msm_mems[2].0,
+                cache.cached_g1[gpu_indices[2] as usize],
+                0,
                 &scalars_h2,
-                select_gpu_for_msm(),
+                streams[2].ptr(),
+                gpu_indices[2],
             ));
         });
 
         s.spawn(|_| {
+            // GPU MSMs: C_hat_h3 (G2, stream 0) + C_hat_w (G2, stream 1)
             compute_load_proof_fields = Some(match load {
                 ComputeLoad::Proof => {
                     let mut C_hat_h3 = None;
@@ -754,34 +651,30 @@ fn prove_impl(
 
                     rayon::scope(|s_inner| {
                         s_inner.spawn(|_| {
-                            // GPU MSM: C_hat_h3 commitment
-                            C_hat_h3 = Some(super::g2_msm_gpu(
-                                &g_hat_list[n - (d + k)..n],
+                            C_hat_h3 = Some(super::g2_msm_cached_on_stream(
+                                g2_msm_mems[0].0,
+                                cache.cached_g2[gpu_indices[0] as usize],
+                                u32::try_from(n - (d + k)).expect("point offset fits in u32"),
                                 &(0..d + k)
                                     .rev()
                                     .map(|j| {
-                                        let mut acc = Zp::ZERO;
-                                        for (i, &phi_val) in phi.iter().enumerate() {
-                                            match R(i, d + k + 4 + j) {
-                                                0 => {}
-                                                1 => acc += phi_val,
-                                                -1 => acc -= phi_val,
-                                                _ => unreachable!(),
-                                            }
-                                        }
-                                        delta_r * acc - delta_theta_q * theta[j]
+                                        delta_r * r_transpose_phi[d + k + 4 + j]
+                                            - delta_theta_q * theta[j]
                                     })
                                     .collect::<Box<[_]>>(),
-                                select_gpu_for_msm(),
+                                streams[0].ptr(),
+                                gpu_indices[0],
                             ));
                         });
 
                         s_inner.spawn(|_| {
-                            // GPU MSM: C_hat_w commitment
-                            C_hat_w = Some(super::g2_msm_gpu(
-                                &g_hat_list[..d + k + 4],
+                            C_hat_w = Some(super::g2_msm_cached_on_stream(
+                                g2_msm_mems[1].0,
+                                cache.cached_g2[gpu_indices[1] as usize],
+                                0,
                                 &omega[..d + k + 4],
-                                select_gpu_for_msm(),
+                                streams[1].ptr(),
+                                gpu_indices[1],
                             ));
                         });
                     });
@@ -796,8 +689,345 @@ fn prove_impl(
         });
 
         s.spawn(|_| {
-            // GPU MSM: C_hat_t commitment
-            C_hat_t = Some(super::g2_msm_gpu(g_hat_list, &t, select_gpu_for_msm()));
+            // GPU MSM: C_hat_t (G2, stream 2, offset 0, n=full g_hat_list)
+            C_hat_t = Some(super::g2_msm_cached_on_stream(
+                g2_msm_mems[2].0,
+                cache.cached_g2[gpu_indices[2] as usize],
+                0,
+                &t,
+                streams[2].ptr(),
+                gpu_indices[2],
+            ));
+        });
+
+        // --- Polynomial construction + pi MSM (depends on P_pi) ---
+
+        s.spawn(|_| {
+            if timing {
+                t_sub = std::time::Instant::now();
+            }
+
+            // Build all 6 polynomial pairs in parallel
+            let mut poly_0_lhs = None;
+            let mut poly_0_rhs = None;
+            let mut poly_1_lhs = None;
+            let mut poly_1_rhs = None;
+            let mut poly_2_lhs = None;
+            let mut poly_2_rhs = None;
+            let mut poly_3_lhs = None;
+            let mut poly_3_rhs = None;
+            let mut poly_4_lhs = None;
+            let mut poly_4_rhs = None;
+            let mut poly_5_lhs = None;
+            let mut poly_5_rhs = None;
+
+            rayon::scope(|s_poly| {
+                s_poly.spawn(|_| {
+                    let mut lhs = vec![Zp::ZERO; 1 + n];
+                    let mut rhs = vec![Zp::ZERO; 1 + D + 128 * m];
+
+                    lhs[0] = delta_y * gamma_y;
+                    for j in 0..D + 128 * m {
+                        let p = &mut lhs[n - j];
+
+                        if !w_bin[j] {
+                            *p -= delta_y * y[j];
+                        }
+
+                        if j < D {
+                            *p += delta_theta * a_theta[j];
+                        }
+                        *p += delta_eq * t[j] * y[j];
+
+                        if j >= D {
+                            let j_inner = j - D;
+                            let r = delta_dec * xi_powers[j_inner];
+
+                            if j_inner % m < m - 1 {
+                                *p += r;
+                            } else {
+                                *p -= r;
+                            }
+                        }
+                    }
+
+                    rhs[0] = gamma_bin;
+                    for j in 0..D + 128 * m {
+                        let p = &mut rhs[j + 1];
+
+                        if w_bin[j] {
+                            *p = Zp::ONE;
+                        }
+                    }
+
+                    poly_0_lhs = Some(lhs);
+                    poly_0_rhs = Some(rhs);
+                });
+
+                s_poly.spawn(|_| {
+                    let mut lhs = vec![Zp::ZERO; 1 + n];
+                    let mut rhs = vec![Zp::ZERO; 1 + d + k + 4];
+
+                    lhs[0] = delta_l * gamma_e;
+                    for j in 0..d {
+                        let p = &mut lhs[n - j];
+                        *p = delta_l * e1_zp[j];
+                    }
+                    for j in 0..k {
+                        let p = &mut lhs[n - (d + j)];
+                        *p = delta_l * e2_zp[j];
+                    }
+                    for j in 0..4 {
+                        let p = &mut lhs[n - (d + k + j)];
+                        *p = delta_l * v_zp[j];
+                    }
+
+                    for j in 0..n {
+                        let p = &mut lhs[n - j];
+                        let mut acc = delta_e * omega[j];
+                        if j < d + k {
+                            acc += delta_theta * theta[j];
+                        }
+
+                        if j < d + k + 4 {
+                            acc += delta_r * r_transpose_phi[j];
+                        }
+                        *p += acc;
+                    }
+
+                    rhs[0] = gamma_hat_e;
+                    for j in 0..d {
+                        let p = &mut rhs[1 + j];
+                        *p = e1_zp[j];
+                    }
+                    for j in 0..k {
+                        let p = &mut rhs[1 + (d + j)];
+                        *p = e2_zp[j];
+                    }
+                    for j in 0..4 {
+                        let p = &mut rhs[1 + (d + k + j)];
+                        *p = v_zp[j];
+                    }
+
+                    poly_1_lhs = Some(lhs);
+                    poly_1_rhs = Some(rhs);
+                });
+
+                s_poly.spawn(|_| {
+                    let mut lhs = vec![Zp::ZERO; 1 + d + k];
+                    let mut rhs = vec![Zp::ZERO; 1 + n];
+
+                    lhs[0] = gamma_r;
+                    for j in 0..d {
+                        let p = &mut lhs[1 + j];
+                        *p = r1_zp[j];
+                    }
+                    for j in 0..k {
+                        let p = &mut lhs[1 + (d + j)];
+                        *p = r2_zp[j];
+                    }
+
+                    for j in 0..d + k {
+                        let p = &mut rhs[n - j];
+                        *p = delta_r * r_transpose_phi[d + k + 4 + j] - delta_theta_q * theta[j];
+                    }
+
+                    poly_2_lhs = Some(lhs);
+                    poly_2_rhs = Some(rhs);
+                });
+
+                s_poly.spawn(|_| {
+                    let mut lhs = vec![Zp::ZERO; 1 + 128];
+                    let mut rhs = vec![Zp::ZERO; 1 + n];
+
+                    lhs[0] = gamma_R;
+                    for j in 0..128 {
+                        let p = &mut lhs[1 + j];
+                        *p = Zp::from_i64(w_R[j]);
+                    }
+
+                    for j in 0..128 {
+                        let p = &mut rhs[n - j];
+                        *p = delta_r * phi[j] + delta_dec * xi_powers[j * m];
+                    }
+
+                    poly_3_lhs = Some(lhs);
+                    poly_3_rhs = Some(rhs);
+                });
+
+                s_poly.spawn(|_| {
+                    let mut lhs = vec![Zp::ZERO; 1 + n];
+                    let mut rhs = vec![Zp::ZERO; 1 + d + k + 4];
+
+                    lhs[0] = delta_e * gamma_e;
+                    for j in 0..d {
+                        let p = &mut lhs[n - j];
+                        *p = delta_e * e1_zp[j];
+                    }
+                    for j in 0..k {
+                        let p = &mut lhs[n - (d + j)];
+                        *p = delta_e * e2_zp[j];
+                    }
+                    for j in 0..4 {
+                        let p = &mut lhs[n - (d + k + j)];
+                        *p = delta_e * v_zp[j];
+                    }
+
+                    for j in 0..d + k + 4 {
+                        let p = &mut rhs[1 + j];
+                        *p = omega[j];
+                    }
+
+                    poly_4_lhs = Some(lhs);
+                    poly_4_rhs = Some(rhs);
+                });
+
+                s_poly.spawn(|_| {
+                    let mut lhs = vec![Zp::ZERO; 1 + n];
+                    let mut rhs = vec![Zp::ZERO; 1 + n];
+
+                    lhs[0] = delta_eq * gamma_y;
+                    for j in 0..D + 128 * m {
+                        let p = &mut lhs[n - j];
+
+                        if w_bin[j] {
+                            *p = delta_eq * y[j];
+                        }
+                    }
+
+                    for j in 0..n {
+                        let p = &mut rhs[1 + j];
+                        *p = t[j];
+                    }
+
+                    poly_5_lhs = Some(lhs);
+                    poly_5_rhs = Some(rhs);
+                });
+            });
+
+            let poly_0_lhs = poly_0_lhs.unwrap();
+            let poly_0_rhs = poly_0_rhs.unwrap();
+            let poly_1_lhs = poly_1_lhs.unwrap();
+            let poly_1_rhs = poly_1_rhs.unwrap();
+            let poly_2_lhs = poly_2_lhs.unwrap();
+            let poly_2_rhs = poly_2_rhs.unwrap();
+            let poly_3_lhs = poly_3_lhs.unwrap();
+            let poly_3_rhs = poly_3_rhs.unwrap();
+            let poly_4_lhs = poly_4_lhs.unwrap();
+            let poly_4_rhs = poly_4_rhs.unwrap();
+            let poly_5_lhs = poly_5_lhs.unwrap();
+            let poly_5_rhs = poly_5_rhs.unwrap();
+
+            if timing {
+                eprintln!(
+                    "[ZK_PROVE_TIMING]   poly_pairs: {:.1}ms",
+                    t_sub.elapsed().as_secs_f64() * 1000.0,
+                );
+                t_sub = std::time::Instant::now();
+            }
+
+            let poly = [
+                (&poly_0_lhs, &poly_0_rhs),
+                (&poly_1_lhs, &poly_1_rhs),
+                (&poly_2_lhs, &poly_2_rhs),
+                (&poly_3_lhs, &poly_3_rhs),
+                (&poly_4_lhs, &poly_4_rhs),
+                (&poly_5_lhs, &poly_5_rhs),
+            ];
+
+            let [mut poly_0, poly_1, poly_2, poly_3, poly_4, poly_5] = {
+                let tmp: Box<[Vec<Zp>; 6]> = poly
+                    .into_par_iter()
+                    .map(|(lhs, rhs)| Zp::poly_mul(lhs, rhs))
+                    .collect::<Box<[_]>>()
+                    .try_into()
+                    .unwrap();
+                *tmp
+            };
+
+            if timing {
+                eprintln!(
+                    "[ZK_PROVE_TIMING]   poly_mul: {:.1}ms",
+                    t_sub.elapsed().as_secs_f64() * 1000.0,
+                );
+                t_sub = std::time::Instant::now();
+            }
+
+            let len = [
+                poly_0.len(),
+                poly_1.len(),
+                poly_2.len(),
+                poly_3.len(),
+                poly_4.len(),
+                poly_5.len(),
+            ]
+            .into_iter()
+            .max()
+            .unwrap();
+
+            poly_0.resize(len, Zp::ZERO);
+
+            {
+                let chunk_size = len.div_ceil(rayon::current_num_threads());
+
+                poly_0
+                    .par_chunks_mut(chunk_size)
+                    .enumerate()
+                    .for_each(|(j, p0)| {
+                        let offset = j * chunk_size;
+                        let p1 = poly_1.get(offset..).unwrap_or(&[]);
+                        let p2 = poly_2.get(offset..).unwrap_or(&[]);
+                        let p3 = poly_3.get(offset..).unwrap_or(&[]);
+                        let p4 = poly_4.get(offset..).unwrap_or(&[]);
+                        let p5 = poly_5.get(offset..).unwrap_or(&[]);
+
+                        for (j, p0) in p0.iter_mut().enumerate() {
+                            if j < p1.len() {
+                                *p0 += p1[j];
+                            }
+                            if j < p2.len() {
+                                *p0 += p2[j];
+                            }
+                            if j < p3.len() {
+                                *p0 -= p3[j];
+                            }
+                            if j < p4.len() {
+                                *p0 -= p4[j];
+                            }
+                            if j < p5.len() {
+                                *p0 -= p5[j];
+                            }
+                        }
+                    });
+            }
+
+            if timing {
+                eprintln!(
+                    "[ZK_PROVE_TIMING]   poly_accumulate: {:.1}ms",
+                    t_sub.elapsed().as_secs_f64() * 1000.0,
+                );
+            }
+
+            let mut P_pi = poly_0;
+            if P_pi.len() > n + 1 {
+                P_pi[n + 1] -= delta_theta * t_theta + delta_l * Zp::from_u128(B_squared);
+            }
+
+            // GPU MSM: pi commitment (G1, stream 0, offset 0)
+            // This is the only MSM that depends on poly construction results.
+            pi = Some(if P_pi.is_empty() {
+                G1::ZERO
+            } else {
+                g.mul_scalar(P_pi[0])
+                    + super::g1_msm_cached_on_stream(
+                        g1_msm_mems[0].0,
+                        cache.cached_g1[gpu_indices[0] as usize],
+                        0,
+                        &P_pi[1..],
+                        streams[0].ptr(),
+                        gpu_indices[0],
+                    )
+            });
         });
     });
 
@@ -813,6 +1043,14 @@ fn prove_impl(
     let C_h1_bytes = C_h1.to_le_bytes();
     let C_h2_bytes = C_h2.to_le_bytes();
     let C_hat_t_bytes = C_hat_t.to_le_bytes();
+
+    if timing {
+        eprintln!(
+            "[ZK_PROVE_TIMING] poly+msms_overlapped: {:.1}ms",
+            t_phase.elapsed().as_secs_f64() * 1000.0
+        );
+        t_phase = std::time::Instant::now();
+    }
 
     let (z, z_hash) = delta_hash.gen_z::<Zp>(
         C_h1_bytes.as_ref(),
@@ -879,16 +1117,7 @@ fn prove_impl(
                 *p += delta_e * omega[j];
 
                 if j < d + k + 4 {
-                    let mut acc = Zp::ZERO;
-                    for (i, &phi_val) in phi.iter().enumerate() {
-                        match R(i, j) {
-                            0 => {}
-                            1 => acc += phi_val,
-                            -1 => acc -= phi_val,
-                            _ => unreachable!(),
-                        }
-                    }
-                    *p += delta_r * acc;
+                    *p += delta_r * r_transpose_phi[j];
                 }
             }
             P_h2 = Some(poly);
@@ -900,17 +1129,7 @@ fn prove_impl(
                     let mut poly = vec![Zp::ZERO; 1 + n];
                     for j in 0..d + k {
                         let p = &mut poly[n - j];
-
-                        let mut acc = Zp::ZERO;
-                        for (i, &phi_val) in phi.iter().enumerate() {
-                            match R(i, d + k + 4 + j) {
-                                0 => {}
-                                1 => acc += phi_val,
-                                -1 => acc -= phi_val,
-                                _ => unreachable!(),
-                            }
-                        }
-                        *p = delta_r * acc - delta_theta_q * theta[j];
+                        *p = delta_r * r_transpose_phi[d + k + 4 + j] - delta_theta_q * theta[j];
                     }
                     poly
                 }
@@ -1031,9 +1250,49 @@ fn prove_impl(
         Q_kzg[j + 1] = Zp::ZERO;
     }
 
-    // GPU MSM: pi_kzg commitment
-    let pi_kzg =
-        g.mul_scalar(q[0]) + super::g1_msm_gpu(&g_list[..n - 1], &q[1..n], select_gpu_for_msm());
+    // GPU MSM: pi_kzg commitment (G1, offset 0, n=n-1)
+    let pi_kzg = g.mul_scalar(q[0])
+        + super::g1_msm_cached_on_stream(
+            g1_msm_mems[0].0,
+            cache.cached_g1[gpu_indices[0] as usize],
+            0,
+            &q[1..n],
+            streams[0].ptr(),
+            gpu_indices[0],
+        );
+
+    if timing {
+        eprintln!(
+            "[ZK_PROVE_TIMING] kzg_phase: {:.1}ms",
+            t_phase.elapsed().as_secs_f64() * 1000.0
+        );
+        eprintln!(
+            "[ZK_PROVE_TIMING] prove_total: {:.1}ms",
+            prove_start.elapsed().as_secs_f64() * 1000.0
+        );
+    }
+
+    // Cleanup per-call scratch buffers.
+    for i in 0..3 {
+        let mut g1_typed = g1_msm_mems[i].0 as *mut zk_cuda_backend::bindings::zk_g1_msm_mem;
+        let mut g2_typed = g2_msm_mems[i].0 as *mut zk_cuda_backend::bindings::zk_g2_msm_mem;
+        // SAFETY: g1/g2_typed were allocated by their respective scratch functions
+        // on streams[i]. All MSM work has completed.
+        unsafe {
+            zk_cuda_backend::bindings::cleanup_zk_g1_msm(
+                streams[i].ptr() as zk_cuda_backend::bindings::cudaStream_t,
+                gpu_indices[i],
+                &mut g1_typed,
+                true,
+            );
+            zk_cuda_backend::bindings::cleanup_zk_g2_msm(
+                streams[i].ptr() as zk_cuda_backend::bindings::cudaStream_t,
+                gpu_indices[i],
+                &mut g2_typed,
+                true,
+            );
+        }
+    }
 
     Proof {
         C_hat_e,
@@ -1063,6 +1322,9 @@ fn verify_impl(
     metadata: &[u8],
     pairing_mode: VerificationPairingMode,
 ) -> Result<(), ()> {
+    let timing = std::env::var("ZK_VERIFY_TIMING").is_ok();
+    let verify_start = std::time::Instant::now();
+
     let &Proof {
         C_hat_e,
         C_e,
@@ -1081,7 +1343,7 @@ fn verify_impl(
     let hash_config = hash_config.into();
 
     let &PublicParams {
-        g_lists: _,
+        ref g_lists,
         D: D_max,
         n,
         d,
@@ -1131,6 +1393,9 @@ fn verify_impl(
         return Err(());
     }
 
+    let _hash_chain_start = std::time::Instant::now();
+    let mut t_sub = std::time::Instant::now();
+
     let C_hat_e_bytes = C_hat_e.to_le_bytes();
     let C_e_bytes = C_e.to_le_bytes();
     let C_r_tilde_bytes = C_r_tilde.to_le_bytes();
@@ -1145,6 +1410,14 @@ fn verify_impl(
     );
     let R = |i: usize, j: usize| R_matrix[i + j * 128];
 
+    if timing {
+        eprintln!(
+            "[ZK_VERIFY_TIMING]   RHash::new: {:.1}ms",
+            t_sub.elapsed().as_secs_f64() * 1000.0
+        );
+        t_sub = std::time::Instant::now();
+    }
+
     let C_R_bytes = C_R.to_le_bytes();
     let (phi, phi_hash) = R_hash.gen_phi(C_R_bytes.as_ref());
 
@@ -1153,8 +1426,45 @@ fn verify_impl(
 
     let (y, y_hash) = xi_hash.gen_y::<Zp>();
 
+    if timing {
+        eprintln!(
+            "[ZK_VERIFY_TIMING]   phi+xi+y: {:.1}ms",
+            t_sub.elapsed().as_secs_f64() * 1000.0
+        );
+        t_sub = std::time::Instant::now();
+    }
+
+    // Precompute R^T * phi: for each column j of R, compute sum_i(phi[i] * R(i,j)).
+    // The full vector has 2*(d+k)+4 entries covering both the P_h2 range (first d+k+4
+    // columns) and the P_h3 / MSM-scalar range (next d+k columns). Each column is
+    // independent, so we parallelize across columns with rayon.
+    let r_transpose_phi: Vec<Zp> = (0..2 * (d + k) + 4)
+        .into_par_iter()
+        .map(|j| {
+            let mut acc = Zp::ZERO;
+            for (i, &phi_val) in phi.iter().enumerate() {
+                match R(i, j) {
+                    0 => {}
+                    1 => acc += phi_val,
+                    -1 => acc -= phi_val,
+                    _ => unreachable!(),
+                }
+            }
+            acc
+        })
+        .collect();
+
+    if timing {
+        eprintln!(
+            "[ZK_VERIFY_TIMING]   r_transpose_phi: {:.1}ms (2*(d+k)+4={} cols)",
+            t_sub.elapsed().as_secs_f64() * 1000.0,
+            2 * (d + k) + 4,
+        );
+        t_sub = std::time::Instant::now();
+    }
+
     let C_y_bytes = C_y.to_le_bytes();
-    let (t, t_hash) = y_hash.gen_t(C_y_bytes.as_ref());
+    let (t, t_hash) = y_hash.gen_t::<Zp>(C_y_bytes.as_ref());
 
     let (theta, theta_hash) = t_hash.gen_theta();
 
@@ -1165,30 +1475,60 @@ fn verify_impl(
         .map(|(x, y)| x * y)
         .sum::<Zp>();
 
+    // --- Start compute_a_theta on a dedicated rayon pool ---
+    // compute_a_theta is the single most expensive CPU operation (~18ms).
+    // It only needs theta (available now), not omega or delta. By starting
+    // it here, it overlaps with gen_omega, gen_delta, cache acquisition,
+    // MSM scratch allocation, and MSM launch.
+    let a_theta_handle = {
+        let theta = theta.clone();
+        let a = a.to_vec();
+        let b = b.to_vec();
+        // Use a small dedicated pool to avoid saturating all cores.
+        // compute_a_theta uses rayon internally (poly_mul), and the
+        // global pool (128 threads) would starve concurrent pairing threads.
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(2)
+            .build()
+            .expect("failed to build compute_a_theta thread pool");
+        std::thread::spawn(move || {
+            pool.install(|| {
+                let mut a_theta = vec![Zp::ZERO; D];
+                compute_a_theta::<Bls12_446>(
+                    &mut a_theta,
+                    &theta,
+                    &a,
+                    d,
+                    k,
+                    &b,
+                    effective_cleartext_t,
+                    delta_encoding,
+                );
+                a_theta
+            })
+        })
+    };
+
     let (omega, omega_hash) = theta_hash.gen_omega();
-
-    let (delta, delta_hash) = omega_hash.gen_delta::<Zp>();
-    let [delta_r, delta_dec, delta_eq, delta_y, delta_theta, delta_e, _delta_l] = delta;
-
-    let delta_theta_q = delta_theta * Zp::from_u128(decoded_q);
-
-    let mut a_theta = vec![Zp::ZERO; D];
-    compute_a_theta::<Bls12_446>(
-        &mut a_theta,
-        &theta,
-        a,
-        d,
-        k,
-        b,
-        effective_cleartext_t,
-        delta_encoding,
-    );
 
     let load = if compute_load_proof_fields.is_some() {
         ComputeLoad::Proof
     } else {
         ComputeLoad::Verify
     };
+
+    let (delta, delta_hash) = omega_hash.gen_delta::<Zp>();
+    let [delta_r, delta_dec, delta_eq, delta_y, delta_theta, delta_e, delta_l] = delta;
+
+    let delta_theta_q = delta_theta * Zp::from_u128(decoded_q);
+
+    if timing {
+        eprintln!(
+            "[ZK_VERIFY_TIMING]   t+theta+omega+delta: {:.1}ms",
+            t_sub.elapsed().as_secs_f64() * 1000.0
+        );
+        t_sub = std::time::Instant::now();
+    }
 
     let (C_hat_h3_bytes, C_hat_w_bytes) =
         ComputeLoadProofFields::to_le_bytes(compute_load_proof_fields);
@@ -1205,379 +1545,476 @@ fn verify_impl(
         &C_hat_w_bytes,
     );
 
-    let mut P_h1 = vec![Zp::ZERO; 1 + n];
-    let mut P_h2 = vec![Zp::ZERO; 1 + n];
-    let mut P_t = vec![Zp::ZERO; 1 + n];
-    let mut P_h3 = match load {
-        ComputeLoad::Proof => vec![Zp::ZERO; 1 + n],
-        ComputeLoad::Verify => vec![],
-    };
-    let mut P_omega = match load {
-        ComputeLoad::Proof => vec![Zp::ZERO; 1 + d + k + 4],
-        ComputeLoad::Verify => vec![],
-    };
+    // Precompute doubling powers of xi so the P_h1 loop has no sequential
+    // dependency on xi_scaled.  xi_powers[i*m + k] = 2^k * xi[i].
+    let xi_powers = precompute_xi_powers(&xi, m);
 
-    let mut xi_scaled = xi;
-    for j in 0..D + 128 * m {
-        let p = &mut P_h1[n - j];
-        if j < D {
-            *p += delta_theta * a_theta[j];
-        }
-        *p -= delta_y * y[j];
-        *p += delta_eq * t[j] * y[j];
-
-        if j >= D {
-            let j = j - D;
-            let xi = &mut xi_scaled[j / m];
-            let H_xi = *xi;
-            *xi = *xi + *xi;
-
-            let r = delta_dec * H_xi;
-
-            if j % m < m - 1 {
-                *p += r;
-            } else {
-                *p -= r;
-            }
-        }
+    if timing {
+        eprintln!(
+            "[ZK_VERIFY_TIMING]   gen_z+xi_powers: {:.1}ms",
+            t_sub.elapsed().as_secs_f64() * 1000.0
+        );
     }
-
-    for j in 0..n {
-        let p = &mut P_h2[n - j];
-
-        if j < d + k {
-            *p += delta_theta * theta[j];
-        }
-
-        *p += delta_e * omega[j];
-
-        if j < d + k + 4 {
-            let mut acc = Zp::ZERO;
-            for (i, &phi) in phi.iter().enumerate() {
-                match R(i, j) {
-                    0 => {}
-                    1 => acc += phi,
-                    -1 => acc -= phi,
-                    _ => unreachable!(),
-                }
-            }
-            *p += delta_r * acc;
-        }
-    }
-
-    P_t[1..].copy_from_slice(&t);
-
-    if !P_h3.is_empty() {
-        for j in 0..d + k {
-            let p = &mut P_h3[n - j];
-
-            let mut acc = Zp::ZERO;
-            for (i, &phi) in phi.iter().enumerate() {
-                match R(i, d + k + 4 + j) {
-                    0 => {}
-                    1 => acc += phi,
-                    -1 => acc -= phi,
-                    _ => unreachable!(),
-                }
-            }
-            *p = delta_r * acc - delta_theta_q * theta[j];
-        }
-    }
-
-    if !P_omega.is_empty() {
-        P_omega[1..].copy_from_slice(&omega[..d + k + 4]);
-    }
-
-    let mut p_h1 = Zp::ZERO;
-    let mut p_h2 = Zp::ZERO;
-    let mut p_t = Zp::ZERO;
-    let mut p_h3 = Zp::ZERO;
-    let mut p_omega = Zp::ZERO;
-
-    let mut pow = Zp::ONE;
-    for j in 0..n + 1 {
-        p_h1 += P_h1[j] * pow;
-        p_h2 += P_h2[j] * pow;
-        p_t += P_t[j] * pow;
-
-        if j < P_h3.len() {
-            p_h3 += P_h3[j] * pow;
-        }
-        if j < P_omega.len() {
-            p_omega += P_omega[j] * pow;
-        }
-
-        pow = pow * z;
-    }
-
-    let p_h3_opt = if P_h3.is_empty() { None } else { Some(p_h3) };
-    let p_omega_opt = if P_omega.is_empty() {
-        None
-    } else {
-        Some(p_omega)
-    };
-
-    let chi = z_hash.gen_chi(p_h1, p_h2, p_t, p_h3_opt, p_omega_opt);
-
-    // Compared to the reference document, chi2 and chi3 are reversed in compute load proof, that
-    // way the equation are not modified between compute load proof/verify. This is ok as long as
-    // chi2 and chi3 are reversed everywhere.
-    let chi2 = chi * chi;
-    let chi3 = chi2 * chi;
-    let chi4 = chi3 * chi;
-
-    let scalars = GeneratedScalars {
-        phi,
-        xi,
-        theta,
-        omega,
-        delta,
-        chi_powers: [chi, chi2, chi3, chi4],
-        z,
-        t_theta,
-    };
-
-    let eval_points = EvaluationPoints {
-        p_h1,
-        p_h2,
-        p_h3,
-        p_t,
-        p_omega,
-    };
 
     match pairing_mode {
-        VerificationPairingMode::TwoSteps => pairing_check_two_steps(
-            proof,
-            &public.0.g_lists,
-            n,
-            d,
-            B_squared,
-            decoded_q,
-            k,
-            R,
-            scalars,
-            eval_points,
-        ),
-        VerificationPairingMode::Batched => pairing_check_batched(
-            proof,
-            &public.0.g_lists,
-            n,
-            d,
-            B_squared,
-            decoded_q,
-            k,
-            R,
-            scalars,
-            eval_points,
-        ),
-    }
-}
+        VerificationPairingMode::TwoSteps => {
+            // Phase 1 (rayon::scope): 9 chi-independent pairings on the
+            //   verify rayon pool + polynomial evaluation on a spawned task.
+            // Phase 2 (rayon::join): 2 chi-dependent pairings.
 
-// ---------------------------------------------------------------------------
-// pairing_check_two_steps
-// ---------------------------------------------------------------------------
-
-#[allow(clippy::too_many_arguments)]
-fn pairing_check_two_steps(
-    proof: &Proof<Bls12_446>,
-    g_lists: &GroupElements<Bls12_446>,
-    n: usize,
-    d: usize,
-    B_squared: u128,
-    decoded_q: u128,
-    k: usize,
-    R: impl Fn(usize, usize) -> i8 + Sync,
-    scalars: GeneratedScalars<Bls12_446>,
-    eval_points: EvaluationPoints<Bls12_446>,
-) -> Result<(), ()> {
-    let &Proof {
-        C_hat_e,
-        C_e,
-        C_r_tilde,
-        C_R,
-        C_hat_bin,
-        C_y,
-        C_h1,
-        C_h2,
-        C_hat_t,
-        pi,
-        pi_kzg,
-        ref compute_load_proof_fields,
-        hash_config: _,
-    } = proof;
-
-    let GeneratedScalars {
-        phi,
-        xi,
-        theta,
-        omega,
-        delta,
-        chi_powers: [chi, chi2, chi3, chi4],
-        z,
-        t_theta,
-    } = scalars;
-
-    let EvaluationPoints {
-        p_h1,
-        p_h2,
-        p_h3,
-        p_t,
-        p_omega,
-    } = eval_points;
-
-    let g_list = &*g_lists.g_list.0;
-    let g_hat_list = &*g_lists.g_hat_list.0;
-
-    let [delta_r, delta_dec, delta_eq, delta_y, delta_theta, delta_e, delta_l] = delta;
-
-    let delta_theta_q = delta_theta * Zp::from_u128(decoded_q);
-
-    let pairing = Gt::pairing;
-    let g = G1::GENERATOR;
-    let g_hat = G2::GENERATOR;
-
-    let mut rhs = None;
-    let mut lhs0 = None;
-    let mut lhs1 = None;
-    let mut lhs2 = None;
-    let mut lhs3 = None;
-    let mut lhs4 = None;
-    let mut lhs5 = None;
-    let mut lhs6 = None;
-
-    let mut rhs_eq2 = None;
-    let mut lhs0_eq2 = None;
-    let mut lhs1_eq2 = None;
-
-    rayon::scope(|s| {
-        s.spawn(|_| rhs = Some(pairing(pi, g_hat)));
-        s.spawn(|_| lhs0 = Some(pairing(C_y.mul_scalar(delta_y) + C_h1, C_hat_bin)));
-        s.spawn(|_| lhs1 = Some(pairing(C_e.mul_scalar(delta_l) + C_h2, C_hat_e)));
-        s.spawn(|_| {
-            lhs2 = Some(pairing(
+            let &Proof {
+                C_hat_e,
+                C_e,
                 C_r_tilde,
-                match compute_load_proof_fields.as_ref() {
-                    Some(&ComputeLoadProofFields {
-                        C_hat_h3,
-                        C_hat_w: _,
-                    }) => C_hat_h3,
-                    // GPU MSM: C_hat_h3 on-the-fly during verify
-                    None => super::g2_msm_gpu(
-                        &g_hat_list[n - (d + k)..n],
-                        &(0..d + k)
-                            .rev()
-                            .map(|j| {
-                                let mut acc = Zp::ZERO;
-                                for (i, &phi) in phi.iter().enumerate() {
-                                    match R(i, d + k + 4 + j) {
-                                        0 => {}
-                                        1 => acc += phi,
-                                        -1 => acc -= phi,
-                                        _ => unreachable!(),
-                                    }
-                                }
-                                delta_r * acc - delta_theta_q * theta[j]
-                            })
-                            .collect::<Box<[_]>>(),
-                        select_gpu_for_msm(),
-                    ),
-                },
-            ))
-        });
-        s.spawn(|_| {
-            // GPU MSM: pairing argument for C_R
-            lhs3 = Some(pairing(
                 C_R,
-                super::g2_msm_gpu(
-                    &g_hat_list[n - 128..n],
-                    &(0..128)
-                        .rev()
-                        .map(|j| delta_r * phi[j] + delta_dec * xi[j])
-                        .collect::<Box<[_]>>(),
-                    select_gpu_for_msm(),
-                ),
-            ))
-        });
-        s.spawn(|_| {
-            lhs4 = Some(pairing(
-                C_e.mul_scalar(delta_e),
-                match compute_load_proof_fields.as_ref() {
-                    Some(&ComputeLoadProofFields {
-                        C_hat_h3: _,
-                        C_hat_w,
-                    }) => C_hat_w,
-                    // GPU MSM: C_hat_w on-the-fly during verify
-                    None => super::g2_msm_gpu(
-                        &g_hat_list[..d + k + 4],
-                        &omega[..d + k + 4],
-                        select_gpu_for_msm(),
-                    ),
-                },
-            ))
-        });
-        s.spawn(|_| lhs5 = Some(pairing(C_y.mul_scalar(delta_eq), C_hat_t)));
-        s.spawn(|_| {
-            lhs6 = Some(
-                pairing(G1::projective(g_list[0]), G2::projective(g_hat_list[n - 1]))
-                    .mul_scalar(delta_theta * t_theta + delta_l * Zp::from_u128(B_squared)),
-            )
-        });
-
-        s.spawn(|_| {
-            lhs0_eq2 = Some(pairing(
-                C_h1 + C_h2.mul_scalar(chi) - g.mul_scalar(p_h1 + chi * p_h2),
-                g_hat,
-            ));
-        });
-
-        s.spawn(|_| {
-            lhs1_eq2 = Some(pairing(
-                g,
-                {
-                    let mut C_hat = C_hat_t.mul_scalar(chi2);
-                    if let Some(ComputeLoadProofFields { C_hat_h3, C_hat_w }) =
-                        compute_load_proof_fields
-                    {
-                        C_hat += C_hat_h3.mul_scalar(chi3);
-                        C_hat += C_hat_w.mul_scalar(chi4);
-                    }
-                    C_hat
-                } - g_hat.mul_scalar(p_t * chi2 + p_h3 * chi3 + p_omega * chi4),
-            ));
-        });
-
-        s.spawn(|_| {
-            rhs_eq2 = Some(pairing(
+                C_hat_bin,
+                C_y,
+                C_h1,
+                C_h2,
+                C_hat_t,
+                pi,
                 pi_kzg,
-                G2::projective(g_hat_list[0]) - g_hat.mul_scalar(z),
-            ))
-        });
-    });
+                ref compute_load_proof_fields,
+                hash_config: _,
+            } = proof;
 
-    let rhs = rhs.unwrap();
-    let lhs0 = lhs0.unwrap();
-    let lhs1 = lhs1.unwrap();
-    let lhs2 = lhs2.unwrap();
-    let lhs3 = lhs3.unwrap();
-    let lhs4 = lhs4.unwrap();
-    let lhs5 = lhs5.unwrap();
-    let lhs6 = lhs6.unwrap();
+            let g_list = &*g_lists.g_list.0;
+            let g_hat_list = &*g_lists.g_hat_list.0;
 
-    let lhs = lhs0 + lhs1 + lhs2 - lhs3 - lhs4 - lhs5 - lhs6;
+            let pairing = Gt::pairing;
+            let g = G1::GENERATOR;
+            let g_hat = G2::GENERATOR;
 
-    if lhs != rhs {
-        return Err(());
-    }
+            let phase1_start = std::time::Instant::now();
 
-    let rhs = rhs_eq2.unwrap();
-    let lhs0 = lhs0_eq2.unwrap();
-    let lhs1 = lhs1_eq2.unwrap();
-    let lhs = lhs0 + lhs1;
+            // Phase 1: 9 pairings + poly work on the verify rayon pool.
+            let mut rhs = None;
+            let mut lhs0 = None;
+            let mut lhs1 = None;
+            let mut lhs2 = None;
+            let mut lhs3 = None;
+            let mut lhs4 = None;
+            let mut lhs5 = None;
+            let mut lhs6 = None;
+            let mut rhs_eq2 = None;
+            let mut poly_results: Option<(Zp, Zp, Zp, Zp, Zp, Zp)> = None;
 
-    if lhs != rhs {
-        Err(())
-    } else {
-        Ok(())
+            rayon::scope(|s| {
+                // --- 9 chi-independent pairings ---
+                s.spawn(|_| rhs = Some(pairing(pi, g_hat)));
+                s.spawn(|_| lhs0 = Some(pairing(C_y.mul_scalar(delta_y) + C_h1, C_hat_bin)));
+                s.spawn(|_| lhs1 = Some(pairing(C_e.mul_scalar(delta_l) + C_h2, C_hat_e)));
+                s.spawn(|_| {
+                    lhs2 = Some(pairing(
+                        C_r_tilde,
+                        match compute_load_proof_fields.as_ref() {
+                            Some(&ComputeLoadProofFields {
+                                C_hat_h3,
+                                C_hat_w: _,
+                            }) => C_hat_h3,
+                            None => super::g2_msm_gpu(
+                                &g_hat_list[n - (d + k)..n],
+                                &(0..d + k)
+                                    .rev()
+                                    .map(|j| {
+                                        delta_r * r_transpose_phi[d + k + 4 + j]
+                                            - delta_theta_q * theta[j]
+                                    })
+                                    .collect::<Box<[_]>>(),
+                                super::select_gpu_for_msm(),
+                            ),
+                        },
+                    ))
+                });
+                s.spawn(|_| {
+                    lhs3 = Some(pairing(
+                        C_R,
+                        super::g2_msm_gpu(
+                            &g_hat_list[n - 128..n],
+                            &(0..128)
+                                .rev()
+                                .map(|j| delta_r * phi[j] + delta_dec * xi[j])
+                                .collect::<Box<[_]>>(),
+                            super::select_gpu_for_msm(),
+                        ),
+                    ))
+                });
+                s.spawn(|_| {
+                    lhs4 = Some(pairing(
+                        C_e.mul_scalar(delta_e),
+                        match compute_load_proof_fields.as_ref() {
+                            Some(&ComputeLoadProofFields {
+                                C_hat_h3: _,
+                                C_hat_w,
+                            }) => C_hat_w,
+                            None => super::g2_msm_gpu(
+                                &g_hat_list[..d + k + 4],
+                                &omega[..d + k + 4],
+                                super::select_gpu_for_msm(),
+                            ),
+                        },
+                    ))
+                });
+                s.spawn(|_| lhs5 = Some(pairing(C_y.mul_scalar(delta_eq), C_hat_t)));
+                s.spawn(|_| {
+                    lhs6 = Some(
+                        pairing(G1::projective(g_list[0]), G2::projective(g_hat_list[n - 1]))
+                            .mul_scalar(delta_theta * t_theta + delta_l * Zp::from_u128(B_squared)),
+                    )
+                });
+                s.spawn(|_| {
+                    rhs_eq2 = Some(pairing(
+                        pi_kzg,
+                        G2::projective(g_hat_list[0]) - g_hat.mul_scalar(z),
+                    ))
+                });
+
+                s.spawn(|_| {
+                    let z_powers = {
+                        let mut powers = Vec::with_capacity(n + 1);
+                        let mut pow = Zp::ONE;
+                        for _ in 0..=n {
+                            powers.push(pow);
+                            pow = pow * z;
+                        }
+                        powers
+                    };
+
+                    // Fused P_h2(z) evaluation (no array allocation).
+                    let mut p_h2 = Zp::ZERO;
+                    for j in 0..n {
+                        let mut coeff = delta_e * omega[j];
+                        if j < d + k {
+                            coeff += delta_theta * theta[j];
+                        }
+                        if j < d + k + 4 {
+                            coeff += delta_r * r_transpose_phi[j];
+                        }
+                        p_h2 += coeff * z_powers[n - j];
+                    }
+
+                    // Fused P_t(z) evaluation.
+                    let mut p_t = Zp::ZERO;
+                    for j in 0..n {
+                        p_t += t[j] * z_powers[j + 1];
+                    }
+
+                    // Fused P_h3(z) evaluation (Verify mode only, else zero).
+                    let p_h3 = match load {
+                        ComputeLoad::Proof => {
+                            let mut val = Zp::ZERO;
+                            for j in 0..d + k {
+                                let coeff = delta_r * r_transpose_phi[d + k + 4 + j]
+                                    - delta_theta_q * theta[j];
+                                val += coeff * z_powers[n - j];
+                            }
+                            val
+                        }
+                        ComputeLoad::Verify => Zp::ZERO,
+                    };
+
+                    // Fused P_omega(z) evaluation (Proof mode only, else zero).
+                    let p_omega = match load {
+                        ComputeLoad::Proof => {
+                            let mut val = Zp::ZERO;
+                            for j in 0..d + k + 4 {
+                                val += omega[j] * z_powers[j + 1];
+                            }
+                            val
+                        }
+                        ComputeLoad::Verify => Zp::ZERO,
+                    };
+
+                    // Join compute_a_theta (was running in parallel).
+                    let a_theta = a_theta_handle
+                        .join()
+                        .expect("compute_a_theta thread panicked");
+
+                    // Fused P_h1(z) evaluation.
+                    let mut p_h1 = Zp::ZERO;
+                    for j in 0..D + 128 * m {
+                        let mut coeff = Zp::ZERO;
+                        if j < D {
+                            coeff += delta_theta * a_theta[j];
+                        }
+                        coeff -= delta_y * y[j];
+                        coeff += delta_eq * t[j] * y[j];
+
+                        if j >= D {
+                            let idx = j - D;
+                            let r = delta_dec * xi_powers[idx];
+                            if idx % m < m - 1 {
+                                coeff += r;
+                            } else {
+                                coeff -= r;
+                            }
+                        }
+                        p_h1 += coeff * z_powers[n - j];
+                    }
+
+                    // Generate chi (needs p_h1, p_h2, p_t and optional p_h3/p_omega).
+                    let p_h3_opt = match load {
+                        ComputeLoad::Proof => Some(p_h3),
+                        ComputeLoad::Verify => None,
+                    };
+                    let p_omega_opt = match load {
+                        ComputeLoad::Proof => Some(p_omega),
+                        ComputeLoad::Verify => None,
+                    };
+                    let chi = z_hash.gen_chi(p_h1, p_h2, p_t, p_h3_opt, p_omega_opt);
+
+                    poly_results = Some((p_h1, p_h2, p_t, p_h3, p_omega, chi));
+                });
+            });
+
+            let (p_h1, p_h2, p_t, p_h3, p_omega, chi) = poly_results.unwrap();
+
+            if timing {
+                eprintln!(
+                    "[ZK_VERIFY_TIMING] phase1 (9 pairings + poly): {:.1}ms",
+                    phase1_start.elapsed().as_secs_f64() * 1000.0,
+                );
+            }
+
+            let rhs = rhs.unwrap();
+            let lhs0 = lhs0.unwrap();
+            let lhs1 = lhs1.unwrap();
+            let lhs2 = lhs2.unwrap();
+            let lhs3 = lhs3.unwrap();
+            let lhs4 = lhs4.unwrap();
+            let lhs5 = lhs5.unwrap();
+            let lhs6 = lhs6.unwrap();
+            let rhs_eq2 = rhs_eq2.unwrap();
+
+            let chi2 = chi * chi;
+            let chi3 = chi2 * chi;
+            let chi4 = chi3 * chi;
+
+            // Phase 2: 2 chi-dependent pairings.
+            let phase2_start = std::time::Instant::now();
+
+            let (lhs0_eq2, lhs1_eq2) = rayon::join(
+                || {
+                    pairing(
+                        C_h1 + C_h2.mul_scalar(chi) - g.mul_scalar(p_h1 + chi * p_h2),
+                        g_hat,
+                    )
+                },
+                || {
+                    pairing(
+                        g,
+                        {
+                            let mut C_hat = C_hat_t.mul_scalar(chi2);
+                            if let Some(ComputeLoadProofFields { C_hat_h3, C_hat_w }) =
+                                compute_load_proof_fields
+                            {
+                                C_hat += C_hat_h3.mul_scalar(chi3);
+                                C_hat += C_hat_w.mul_scalar(chi4);
+                            }
+                            C_hat
+                        } - g_hat.mul_scalar(p_t * chi2 + p_h3 * chi3 + p_omega * chi4),
+                    )
+                },
+            );
+
+            if timing {
+                eprintln!(
+                    "[ZK_VERIFY_TIMING] phase2 (2 pairings): {:.1}ms",
+                    phase2_start.elapsed().as_secs_f64() * 1000.0,
+                );
+                eprintln!(
+                    "[ZK_VERIFY_TIMING] verify_total: {:.1}ms",
+                    verify_start.elapsed().as_secs_f64() * 1000.0,
+                );
+            }
+
+            // Check equation 1.
+            let lhs = lhs0 + lhs1 + lhs2 - lhs3 - lhs4 - lhs5 - lhs6;
+            if lhs != rhs {
+                return Err(());
+            }
+
+            // Check equation 2.
+            let lhs = lhs0_eq2 + lhs1_eq2;
+            if lhs != rhs_eq2 {
+                Err(())
+            } else {
+                Ok(())
+            }
+        }
+        VerificationPairingMode::Batched => {
+            // Join compute_a_theta.
+            let a_theta = a_theta_handle
+                .join()
+                .expect("compute_a_theta thread panicked");
+
+            let mut P_h1 = vec![Zp::ZERO; 1 + n];
+            let mut P_h2 = vec![Zp::ZERO; 1 + n];
+            let mut P_t = vec![Zp::ZERO; 1 + n];
+            let mut P_h3 = match load {
+                ComputeLoad::Proof => vec![Zp::ZERO; 1 + n],
+                ComputeLoad::Verify => vec![],
+            };
+            let mut P_omega = match load {
+                ComputeLoad::Proof => vec![Zp::ZERO; 1 + d + k + 4],
+                ComputeLoad::Verify => vec![],
+            };
+
+            rayon::join(
+                || {
+                    for j in 0..D + 128 * m {
+                        let p = &mut P_h1[n - j];
+                        if j < D {
+                            *p += delta_theta * a_theta[j];
+                        }
+                        *p -= delta_y * y[j];
+                        *p += delta_eq * t[j] * y[j];
+
+                        if j >= D {
+                            let idx = j - D;
+                            let r = delta_dec * xi_powers[idx];
+                            if idx % m < m - 1 {
+                                *p += r;
+                            } else {
+                                *p -= r;
+                            }
+                        }
+                    }
+                },
+                || {
+                    for j in 0..n {
+                        let p = &mut P_h2[n - j];
+                        if j < d + k {
+                            *p += delta_theta * theta[j];
+                        }
+                        *p += delta_e * omega[j];
+                        if j < d + k + 4 {
+                            *p += delta_r * r_transpose_phi[j];
+                        }
+                    }
+                },
+            );
+
+            P_t[1..].copy_from_slice(&t);
+
+            if !P_h3.is_empty() {
+                for j in 0..d + k {
+                    let p = &mut P_h3[n - j];
+                    *p = delta_r * r_transpose_phi[d + k + 4 + j] - delta_theta_q * theta[j];
+                }
+            }
+
+            if !P_omega.is_empty() {
+                P_omega[1..].copy_from_slice(&omega[..d + k + 4]);
+            }
+
+            // Precompute z^0..z^n for parallel evaluation.
+            let z_powers = {
+                let mut powers = Vec::with_capacity(n + 1);
+                let mut pow = Zp::ONE;
+                for _ in 0..=n {
+                    powers.push(pow);
+                    pow = pow * z;
+                }
+                powers
+            };
+
+            let (p_h1, p_h2, p_t, p_h3, p_omega) = {
+                let ((p_h1, p_h2), (p_t, (p_h3, p_omega))) = rayon::join(
+                    || {
+                        rayon::join(
+                            || P_h1.iter().zip(&z_powers).map(|(&c, &p)| c * p).sum::<Zp>(),
+                            || P_h2.iter().zip(&z_powers).map(|(&c, &p)| c * p).sum::<Zp>(),
+                        )
+                    },
+                    || {
+                        rayon::join(
+                            || P_t.iter().zip(&z_powers).map(|(&c, &p)| c * p).sum::<Zp>(),
+                            || {
+                                rayon::join(
+                                    || {
+                                        if P_h3.is_empty() {
+                                            Zp::ZERO
+                                        } else {
+                                            P_h3.iter()
+                                                .zip(&z_powers)
+                                                .map(|(&c, &p)| c * p)
+                                                .sum::<Zp>()
+                                        }
+                                    },
+                                    || {
+                                        if P_omega.is_empty() {
+                                            Zp::ZERO
+                                        } else {
+                                            P_omega
+                                                .iter()
+                                                .zip(&z_powers)
+                                                .map(|(&c, &p)| c * p)
+                                                .sum::<Zp>()
+                                        }
+                                    },
+                                )
+                            },
+                        )
+                    },
+                );
+                (p_h1, p_h2, p_t, p_h3, p_omega)
+            };
+
+            let p_h3_opt = if P_h3.is_empty() { None } else { Some(p_h3) };
+            let p_omega_opt = if P_omega.is_empty() {
+                None
+            } else {
+                Some(p_omega)
+            };
+
+            let chi = z_hash.gen_chi(p_h1, p_h2, p_t, p_h3_opt, p_omega_opt);
+
+            let chi2 = chi * chi;
+            let chi3 = chi2 * chi;
+            let chi4 = chi3 * chi;
+
+            let scalars = GeneratedScalars {
+                phi,
+                xi,
+                theta,
+                omega,
+                delta,
+                chi_powers: [chi, chi2, chi3, chi4],
+                z,
+                t_theta,
+                r_transpose_phi,
+            };
+
+            let eval_points = EvaluationPoints {
+                p_h1,
+                p_h2,
+                p_h3,
+                p_t,
+                p_omega,
+            };
+
+            let result = pairing_check_batched(
+                proof,
+                g_lists,
+                n,
+                d,
+                B_squared,
+                decoded_q,
+                k,
+                scalars,
+                eval_points,
+            );
+
+            if timing {
+                eprintln!(
+                    "[ZK_VERIFY_TIMING] verify_total: {:.1}ms",
+                    verify_start.elapsed().as_secs_f64() * 1000.0,
+                );
+            }
+
+            result
+        }
     }
 }
 
@@ -1594,7 +2031,6 @@ fn pairing_check_batched(
     B_squared: u128,
     decoded_q: u128,
     k: usize,
-    R: impl Fn(usize, usize) -> i8 + Sync,
     scalars: GeneratedScalars<Bls12_446>,
     eval_points: EvaluationPoints<Bls12_446>,
 ) -> Result<(), ()> {
@@ -1623,6 +2059,7 @@ fn pairing_check_batched(
         chi_powers: [chi, chi2, chi3, chi4],
         z,
         t_theta,
+        r_transpose_phi,
     } = scalars;
 
     let EvaluationPoints {
@@ -1684,19 +2121,10 @@ fn pairing_check_batched(
                         &(0..d + k)
                             .rev()
                             .map(|j| {
-                                let mut acc = Zp::ZERO;
-                                for (i, &phi) in phi.iter().enumerate() {
-                                    match R(i, d + k + 4 + j) {
-                                        0 => {}
-                                        1 => acc += phi,
-                                        -1 => acc -= phi,
-                                        _ => unreachable!(),
-                                    }
-                                }
-                                delta_r * acc - delta_theta_q * theta[j]
+                                delta_r * r_transpose_phi[d + k + 4 + j] - delta_theta_q * theta[j]
                             })
                             .collect::<Box<[_]>>(),
-                        select_gpu_for_msm(),
+                        super::select_gpu_for_msm(),
                     ),
                 ))
             }
@@ -1711,7 +2139,7 @@ fn pairing_check_batched(
                         .rev()
                         .map(|j| delta_r * phi[j] + delta_dec * xi[j])
                         .collect::<Box<[_]>>(),
-                    select_gpu_for_msm(),
+                    super::select_gpu_for_msm(),
                 ),
             ))
         });
@@ -1732,7 +2160,7 @@ fn pairing_check_batched(
                     super::g2_msm_gpu(
                         &g_hat_list[..d + k + 4],
                         &omega[..d + k + 4],
-                        select_gpu_for_msm(),
+                        super::select_gpu_for_msm(),
                     ),
                 ))
             }

--- a/tfhe-zk-pok/src/proofs/mod.rs
+++ b/tfhe-zk-pok/src/proofs/mod.rs
@@ -411,6 +411,14 @@ where
     OP: FnOnce() -> R + Send,
     R: Send,
 {
+    // When GPU affinity is set, the caller has partitioned work into
+    // per-GPU pools. Skip sub-pool creation to keep rayon::scope
+    // tasks on the caller's pool, preserving thread-local affinity.
+    #[cfg(feature = "gpu-experimental")]
+    if crate::gpu::current_gpu_affinity().is_some() {
+        return f();
+    }
+
     let pools = get_or_init_pools();
 
     // Select the least loaded pool

--- a/tfhe-zk-pok/src/proofs/pke_v2/mod.rs
+++ b/tfhe-zk-pok/src/proofs/pke_v2/mod.rs
@@ -2026,6 +2026,9 @@ pub(crate) struct GeneratedScalars<G: Curve> {
     pub(crate) chi_powers: [G::Zp; 4],
     pub(crate) z: G::Zp,
     pub(crate) t_theta: G::Zp,
+    /// Precomputed R^T * phi vector: entry j = sum_i(phi[i] * R(i,j)) for j in 0..2(d+k)+4.
+    /// Computed once and reused in P_h2, P_h3, and pairing-check MSM scalars.
+    pub(crate) r_transpose_phi: Vec<G::Zp>,
 }
 
 pub(crate) struct EvaluationPoints<G: Curve> {
@@ -2145,6 +2148,26 @@ pub fn verify_impl<G: Curve>(
 
     let (y, y_hash) = xi_hash.gen_y();
 
+    // Precompute R^T * phi: for each column j of R, compute sum_i(phi[i] * R(i,j)).
+    // The full vector has 2*(d+k)+4 entries covering both the P_h2 range (first d+k+4
+    // columns) and the P_h3 / MSM-scalar range (next d+k columns). Each column is
+    // independent, so we parallelize across columns with rayon.
+    let r_transpose_phi: Vec<G::Zp> = (0..2 * (d + k) + 4)
+        .into_par_iter()
+        .map(|j| {
+            let mut acc = G::Zp::ZERO;
+            for (i, &phi_val) in phi.iter().enumerate() {
+                match R(i, j) {
+                    0 => {}
+                    1 => acc += phi_val,
+                    -1 => acc -= phi_val,
+                    _ => unreachable!(),
+                }
+            }
+            acc
+        })
+        .collect();
+
     let C_y_bytes = C_y.to_le_bytes();
     let (t, t_hash) = y_hash.gen_t(C_y_bytes.as_ref());
 
@@ -2244,16 +2267,7 @@ pub fn verify_impl<G: Curve>(
         *p += delta_e * omega[j];
 
         if j < d + k + 4 {
-            let mut acc = G::Zp::ZERO;
-            for (i, &phi) in phi.iter().enumerate() {
-                match R(i, j) {
-                    0 => {}
-                    1 => acc += phi,
-                    -1 => acc -= phi,
-                    _ => unreachable!(),
-                }
-            }
-            *p += delta_r * acc;
+            *p += delta_r * r_transpose_phi[j];
         }
     }
 
@@ -2262,17 +2276,7 @@ pub fn verify_impl<G: Curve>(
     if !P_h3.is_empty() {
         for j in 0..d + k {
             let p = &mut P_h3[n - j];
-
-            let mut acc = G::Zp::ZERO;
-            for (i, &phi) in phi.iter().enumerate() {
-                match R(i, d + k + 4 + j) {
-                    0 => {}
-                    1 => acc += phi,
-                    -1 => acc -= phi,
-                    _ => unreachable!(),
-                }
-            }
-            *p = delta_r * acc - delta_theta_q * theta[j];
+            *p = delta_r * r_transpose_phi[d + k + 4 + j] - delta_theta_q * theta[j];
         }
     }
 
@@ -2327,6 +2331,7 @@ pub fn verify_impl<G: Curve>(
         chi_powers: [chi, chi2, chi3, chi4],
         z,
         t_theta,
+        r_transpose_phi,
     };
 
     let eval_points = EvaluationPoints {
@@ -2346,7 +2351,6 @@ pub fn verify_impl<G: Curve>(
             B_squared,
             decoded_q,
             k,
-            R,
             scalars,
             eval_points,
         ),
@@ -2358,7 +2362,6 @@ pub fn verify_impl<G: Curve>(
             B_squared,
             decoded_q,
             k,
-            R,
             scalars,
             eval_points,
         ),
@@ -2374,7 +2377,6 @@ fn pairing_check_two_steps<G: Curve>(
     B_squared: u128,
     decoded_q: u128,
     k: usize,
-    R: impl Fn(usize, usize) -> i8 + Sync,
     scalars: GeneratedScalars<G>,
     eval_points: EvaluationPoints<G>,
 ) -> Result<(), ()> {
@@ -2403,6 +2405,7 @@ fn pairing_check_two_steps<G: Curve>(
         chi_powers: [chi, chi2, chi3, chi4],
         z,
         t_theta,
+        r_transpose_phi,
     } = scalars;
 
     let EvaluationPoints {
@@ -2454,16 +2457,7 @@ fn pairing_check_two_steps<G: Curve>(
                         &(0..d + k)
                             .rev()
                             .map(|j| {
-                                let mut acc = G::Zp::ZERO;
-                                for (i, &phi) in phi.iter().enumerate() {
-                                    match R(i, d + k + 4 + j) {
-                                        0 => {}
-                                        1 => acc += phi,
-                                        -1 => acc -= phi,
-                                        _ => unreachable!(),
-                                    }
-                                }
-                                delta_r * acc - delta_theta_q * theta[j]
+                                delta_r * r_transpose_phi[d + k + 4 + j] - delta_theta_q * theta[j]
                             })
                             .collect::<Box<[_]>>(),
                     ),
@@ -2572,7 +2566,6 @@ fn pairing_check_batched<G: Curve>(
     B_squared: u128,
     decoded_q: u128,
     k: usize,
-    R: impl Fn(usize, usize) -> i8 + Sync,
     scalars: GeneratedScalars<G>,
     eval_points: EvaluationPoints<G>,
 ) -> Result<(), ()> {
@@ -2601,6 +2594,7 @@ fn pairing_check_batched<G: Curve>(
         chi_powers: [chi, chi2, chi3, chi4],
         z,
         t_theta,
+        r_transpose_phi,
     } = scalars;
 
     let EvaluationPoints {
@@ -2661,16 +2655,7 @@ fn pairing_check_batched<G: Curve>(
                         &(0..d + k)
                             .rev()
                             .map(|j| {
-                                let mut acc = G::Zp::ZERO;
-                                for (i, &phi) in phi.iter().enumerate() {
-                                    match R(i, d + k + 4 + j) {
-                                        0 => {}
-                                        1 => acc += phi,
-                                        -1 => acc -= phi,
-                                        _ => unreachable!(),
-                                    }
-                                }
-                                delta_r * acc - delta_theta_q * theta[j]
+                                delta_r * r_transpose_phi[d + k + 4 + j] - delta_theta_q * theta[j]
                             })
                             .collect::<Box<[_]>>(),
                     ),

--- a/tfhe/src/core_crypto/gpu/mod.rs
+++ b/tfhe/src/core_crypto/gpu/mod.rs
@@ -16,6 +16,7 @@ use std::ffi::c_void;
 use tfhe_cuda_backend::bindings::*;
 use tfhe_cuda_backend::cuda_bind::*;
 
+// TODO: refactor CudaStreams to use tfhe_cuda_backend::CudaStream internally
 pub struct CudaStreams {
     pub ptr: Vec<*mut c_void>,
     pub gpu_indexes: Vec<GpuIndex>,

--- a/tfhe/src/integer/gpu/zk/mod.rs
+++ b/tfhe/src/integer/gpu/zk/mod.rs
@@ -64,17 +64,16 @@ impl CudaProvenCompactCiphertextList {
         Err(crate::ErrorKind::InvalidZkProof.into())
     }
 
-    /// # Safety
-    ///
-    /// - [CudaStreams::synchronize] __must__ be called after this function as soon as
-    ///   synchronization is required
     pub fn expand_without_verification(
         &self,
         key: &CudaKeySwitchingKey,
         streams: &CudaStreams,
     ) -> crate::Result<CudaCompactCiphertextListExpander> {
-        self.d_flattened_compact_lists
-            .expand(key, super::ZKType::Casting, streams)
+        let result = self
+            .d_flattened_compact_lists
+            .expand(key, super::ZKType::Casting, streams)?;
+        streams.synchronize();
+        Ok(result)
     }
 
     pub fn from_proven_compact_ciphertext_list(
@@ -341,6 +340,82 @@ mod tests {
             for (idx, msg) in msgs.iter().copied().enumerate() {
                 let gpu_expanded: CudaUnsignedRadixCiphertext =
                     unverified_expander.get(idx, &streams).unwrap().unwrap();
+                let expanded = gpu_expanded.to_radix_ciphertext(&streams);
+                let decrypted = cks.decrypt_radix::<u64>(&expanded);
+                assert_eq!(msg, decrypted);
+            }
+        }
+    }
+
+    /// Exercises the `ZkComputeLoad::Verify` path where the verifier must
+    /// recompute C_hat_h3 / C_hat_w via GPU MSMs (they are not included in the
+    /// proof).
+    #[test]
+    fn test_verify_load_verify_and_expand() {
+        let ksk_params = PARAM_KEYSWITCH_TO_SMALL_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+        let pke_params = PARAM_PKE_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+        let fhe_params: PBSParameters = PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128.into();
+
+        let metadata = [b'v', b'e', b'r', b'i', b'f', b'y'];
+
+        let msg_carry_bits =
+            (pke_params.message_modulus.0 * pke_params.carry_modulus.0).ilog2() as usize;
+        let encryption_num_blocks = 64 / (pke_params.message_modulus.0.ilog2() as usize);
+
+        // Small CRS: multiple proved lists per proof, matching the original test.
+        // Large CRS: single proved list, matching the benchmark config
+        // (ProofConfig::new(2048, &[64]) with msg_bits=4).
+
+        let cks = ClientKey::new(fhe_params);
+        let compressed_server_key = CompressedServerKey::new_radix_compressed_server_key(&cks);
+        let sk = compressed_server_key.decompress();
+        let streams = CudaStreams::new_multi_gpu();
+        let gpu_sk = CudaServerKey::decompress_from_cpu(&compressed_server_key, &streams);
+
+        let compact_private_key = CompactPrivateKey::new(pke_params);
+        let ksk = KeySwitchingKey::new((&compact_private_key, None), (&cks, &sk), ksk_params);
+        let d_ksk_material = CudaKeySwitchingKeyMaterial::from_key_switching_key(&ksk, &streams);
+        let d_ksk =
+            CudaKeySwitchingKey::from_cuda_key_switching_key_material(&d_ksk_material, &gpu_sk);
+
+        let pk = CompactPublicKey::new(&compact_private_key);
+
+        // Test configurations: (crs_lwe_count, num_messages)
+        // Small CRS with 2 msgs → multiple proved lists (original test).
+        // Large CRS with 2 msgs → single proved list, many LWEs.
+        // Large CRS with 1 msg  → matches benchmark config exactly.
+        let configs: &[(usize, usize)] = &[
+            (64 / msg_carry_bits, 2),
+            (2048 / msg_carry_bits, 2),
+            (2048 / msg_carry_bits, 1),
+        ];
+
+        for &(crs_lwe_count, num_msgs) in configs {
+            let crs =
+                CompactPkeCrs::from_shortint_params(pke_params, LweCiphertextCount(crs_lwe_count))
+                    .unwrap();
+
+            let msgs: Vec<u64> = (0..num_msgs).map(|_| random::<u64>()).collect();
+
+            let proven_ct = CompactCiphertextList::builder(&pk)
+                .extend_with_num_blocks(msgs.iter().copied(), encryption_num_blocks)
+                .build_with_proof_packed(&crs, &metadata, ZkComputeLoad::Verify)
+                .unwrap();
+            let gpu_proven_ct =
+                CudaProvenCompactCiphertextList::from_proven_compact_ciphertext_list(
+                    &proven_ct, &streams,
+                );
+
+            // Verify the proof is valid before testing verify_and_expand.
+            assert!(proven_ct.verify(&crs, &pk, &metadata).is_valid());
+
+            let gpu_expander = gpu_proven_ct
+                .verify_and_expand(&crs, &pk, &metadata, &d_ksk, &streams)
+                .unwrap();
+
+            for (idx, msg) in msgs.iter().copied().enumerate() {
+                let gpu_expanded: CudaUnsignedRadixCiphertext =
+                    gpu_expander.get(idx, &streams).unwrap().unwrap();
                 let expanded = gpu_expanded.to_radix_ciphertext(&streams);
                 let decrypted = cks.decrypt_radix::<u64>(&expanded);
                 assert_eq!(msg, decrypted);

--- a/tfhe/src/zk/mod.rs
+++ b/tfhe/src/zk/mod.rs
@@ -30,6 +30,8 @@ use tfhe_zk_pok::gpu::pke_v2::{prove as prove_v2, verify as verify_v2};
 use tfhe_zk_pok::proofs::pke_v2::{prove as prove_v2, verify as verify_v2};
 
 pub use tfhe_zk_pok::curve_api::Compressible;
+#[cfg(feature = "gpu-experimental-zk")]
+pub use tfhe_zk_pok::gpu::{set_gpu_affinity, with_gpu_affinity};
 pub use tfhe_zk_pok::proofs::pke_v2::PkeV2SupportedHashConfig as ZkPkeV2SupportedHashConfig;
 pub use tfhe_zk_pok::proofs::{CompactPkeCrsConformanceParams, ComputeLoad as ZkComputeLoad};
 type Curve = tfhe_zk_pok::curve_api::Bls12_446;


### PR DESCRIPTION
The initial inspiration for this PR is that, despite scalars are always different between different MSMs, points are not since the CRS is the same as long we use the same parameter set. 

This PR:

1) strongly focus on increasing GPU computation overlap by splitting MSM in two steps, 
2) and tries to improve the throughput benchmark by making MSM execute independently per GPU. The idea is to observe the throughput on N GPUs be N times the throughput on 1. The CPU is the bottleneck in that case, but we get closer to the ideal number with these changes.

In more details,

  - Rewrite the GPU ZK prove/verify pipeline with async MSM pipelining, splitting kernel launch from result finalization to overlap compute and transfer                                      
  - Add persistent device cache (ZkMsmCache) for CRS base points across all GPUs, eliminating redundant host-to-device transfers (assumes CRS never changes within the same execution)           
  - Parallelize polynomial construction and evaluation; overlap pairing phases in verify (TwoSteps mode)                                                                                      
  - Expose new MSM split-launch/finalize APIs in zk-cuda-backend (msm_launch_*, msm_finalize_*)                               
  
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
