### PR TITLE
chore(docs): add GPU ZK-PoK benchmarks section

### DIFF
--- a/tfhe/docs/getting-started/benchmarks/zk-proof-benchmarks.md
+++ b/tfhe/docs/getting-started/benchmarks/zk-proof-benchmarks.md
@@ -2,7 +2,7 @@
 
 This document details the performance benchmarks of [zero-knowledge proofs](../../fhe-computation/advanced-features/zk-pok.md) for [compact public key encryption](../../fhe-computation/advanced-features/public-key.md) using **TFHE-rs**.
 
-## Server-side computation
+## CPU server-side computation
 
 {% hint style="info" %}
 Benchmarks were launched on an `AWS hpc7a.96xlarge` instance equipped with two 96-core `AMD EPYC 9R14 CPU @ 2.60GHz` and 740GB of RAM.
@@ -25,6 +25,24 @@ Proving and verification are done with tfhe-rs native executable on a powerful s
 ### Slow proof / fast verify throughput
 
 ![](../../.gitbook/assets/cpu-zk-benchmark-slow-proof-fast-verify-throughput.svg)
+
+## GPU server-side computation
+
+{% hint style="info" %}
+Benchmarks were launched on an `AWS p5.48xlarge` instance equipped with `NVIDIA H100` GPUs.
+{% endhint %}
+
+Proving and verification are done with tfhe-rs built with `--features=gpu-experimental-zk`. For details on GPU ZK acceleration, see [GPU ZK-PoKs](../../configuration/gpu-acceleration/zk-pok.md).
+
+<!-- TODO: We must set the script to generated these SVGs -->
+
+### Fast proof / slow verify latency
+
+### Fast proof / slow verify throughput
+
+### Slow proof / fast verify latency
+
+### Slow proof / fast verify throughput
 
 ## Client-side computation
 

--- a/tfhe/docs/getting-started/benchmarks/zk-proof-benchmarks.md
+++ b/tfhe/docs/getting-started/benchmarks/zk-proof-benchmarks.md
@@ -29,7 +29,7 @@ Proving and verification are done with tfhe-rs native executable on a powerful s
 ## GPU server-side computation
 
 {% hint style="info" %}
-Benchmarks were launched on an `AWS p5.48xlarge` instance equipped with `NVIDIA H100` GPUs.
+Benchmarks were launched on a machine equipped with `8x NVIDIA H100 SXM5` GPUs.
 {% endhint %}
 
 Proving and verification are done with tfhe-rs built with `--features=gpu-experimental-zk`. For details on GPU ZK acceleration, see [GPU ZK-PoKs](../../configuration/gpu-acceleration/zk-pok.md).


### PR DESCRIPTION
The public benchmarks page currently only documents CPU ZK-PoK numbers, even though GPU ZK-PoK is supported (behind `--features=gpu-experimental-zk`) and is the configuration that matters for users running on accelerators. Without a parallel GPU section, anyone evaluating tfhe-rs for GPU deployment has to either dig through internal benchmark reports or re-run the suite themselves. This PR scaffolds the GPU section so once the SXM5 benchmark run completes the SVGs can be dropped in without any further docs surgery.

Changes:
- Rename the existing top-level section to **"CPU server-side computation"** for symmetry with the new GPU section.
- Add **"GPU server-side computation"** section noting the hardware (`AWS p5.48xlarge` with `NVIDIA H100`) and the `--features=gpu-experimental-zk` build flag, with a link to the GPU ZK-PoK configuration page.
- Stub the four benchmark subsections (fast-proof/slow-verify latency+throughput, slow-proof/fast-verify latency+throughput) ready to receive SVGs.
- `TODO` left in the file to set up a script that generates these SVGs from CI output, so the next refresh isn't a manual chore.

This change needs the CI to run benchmarks on SXM5s before merging.

<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
