### PR TITLE
feat(zk): add GPU ZK long-run tests and CI workflow

### DIFF
--- a/.github/workflows/gpu_zk_long_run_tests.yml
+++ b/.github/workflows/gpu_zk_long_run_tests.yml
@@ -1,0 +1,155 @@
+name: gpu_zk_long_run_tests
+
+env:
+  CARGO_TERM_COLOR: always
+  ACTION_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+  RUSTFLAGS: "-C target-cpu=native"
+  RUST_BACKTRACE: "full"
+  RUST_MIN_STACK: "8388608"
+  SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
+  SLACK_ICON: https://pbs.twimg.com/profile_images/1274014582265298945/OjBKP9kn_400x400.png
+  SLACK_USERNAME: ${{ secrets.BOT_USERNAME }}
+  SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+  CHECKOUT_TOKEN: ${{ secrets.REPO_CHECKOUT_TOKEN || secrets.GITHUB_TOKEN }}
+  IS_PR: ${{ github.event_name == 'pull_request' }}
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 20 * * 1"
+  pull_request:
+
+permissions:
+  contents: read
+
+# zizmor: ignore[concurrency-limits] concurrency is managed after instance setup to ensure safe provisioning
+
+jobs:
+  should-run:
+    name: gpu_zk_long_run_tests/should-run
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read  # Needed to check for file change
+    outputs:
+      gpu_test: ${{ env.IS_PR == 'false' || steps.changed-files.outputs.gpu_any_changed }}
+    steps:
+      - name: Checkout tfhe-rs
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+          persist-credentials: 'false'
+          token: ${{ env.CHECKOUT_TOKEN }}
+
+      - name: Check for file changes
+        id: changed-files
+        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323 # v47.0.5
+        with:
+          files_yaml: |
+            gpu:
+              - backends/tfhe-cuda-backend/**
+              - backends/zk-cuda-backend/**
+              - tfhe-zk-pok/**
+              - '.github/workflows/gpu_zk_long_run_tests.yml'
+              - ci/slab.toml
+
+  setup-instance:
+    name: gpu_zk_long_run_tests/setup-instance
+    needs: [should-run]
+    if: github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'schedule' && github.repository == 'zama-ai/tfhe-rs') ||
+      needs.should-run.outputs.gpu_test == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      runner-name: ${{ steps.start-instance.outputs.label }}
+    steps:
+      - name: Start instance
+        id: start-instance
+        uses: zama-ai/slab-github-runner@0a812986560d3f10dc65728b1ccb9ae4c48a8a16 # v1.5.1
+        with:
+          mode: start
+          github-token: ${{ secrets.SLAB_ACTION_TOKEN }}
+          slab-url: ${{ secrets.SLAB_BASE_URL }}
+          job-secret: ${{ secrets.JOB_SECRET }}
+          backend: hyperstack
+          profile: gpu-test
+
+  cuda-tests:
+    name: gpu_zk_long_run_tests/cuda-tests
+    needs: [ setup-instance ]
+    concurrency:
+      group: ${{ github.workflow_ref }}_${{github.event_name}}
+      cancel-in-progress: true
+    runs-on: ${{ needs.setup-instance.outputs.runner-name }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            cuda: "12.8"
+            gcc: 11
+    timeout-minutes: 1440 # 24 hours
+    steps:
+      - name: Checkout tfhe-rs
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: 'false'
+          token: ${{ env.CHECKOUT_TOKEN }}
+
+      - name: Setup Hyperstack dependencies
+        uses: ./.github/actions/gpu_setup
+        with:
+          cuda-version: ${{ matrix.cuda }}
+          gcc-version: ${{ matrix.gcc }}
+
+      - name: Install latest stable
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # zizmor: ignore[stale-action-refs] this action doesn't create releases
+        with:
+          toolchain: stable
+
+      - name: Enable nvidia multi-process service
+        run: |
+          nvidia-cuda-mps-control -d
+
+      - name: Run tests
+        run: |
+          if [[ "${IS_PR}" == "true" ]]; then
+            make test_zk_pok_experimental_short_run_gpu
+          else
+            make test_zk_pok_experimental_long_run_gpu
+          fi
+
+  slack-notify:
+    name: gpu_zk_long_run_tests/slack-notify
+    needs: [ setup-instance, cuda-tests ]
+    runs-on: ubuntu-latest
+    if: ${{ always() && needs.cuda-tests.result != 'skipped' && failure() }}
+    continue-on-error: true
+    steps:
+      - name: Send message
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661
+        env:
+          SLACK_COLOR: ${{ needs.cuda-tests.result }}
+          SLACK_MESSAGE: "ZK GPU long run tests finished with status: ${{ needs.cuda-tests.result }}. (${{ env.ACTION_RUN_URL }})"
+
+  teardown-instance:
+    name: gpu_zk_long_run_tests/teardown-instance
+    if: ${{ always() && needs.setup-instance.result == 'success' }}
+    needs: [ setup-instance, cuda-tests ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Stop instance
+        id: stop-instance
+        uses: zama-ai/slab-github-runner@0a812986560d3f10dc65728b1ccb9ae4c48a8a16 # v1.5.1
+        with:
+          mode: stop
+          github-token: ${{ secrets.SLAB_ACTION_TOKEN }}
+          slab-url: ${{ secrets.SLAB_BASE_URL }}
+          job-secret: ${{ secrets.JOB_SECRET }}
+          label: ${{ needs.setup-instance.outputs.runner-name }}
+
+      - name: Slack Notification
+        if: ${{ failure() }}
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661
+        env:
+          SLACK_COLOR: ${{ job.status }}
+          SLACK_MESSAGE: "Instance teardown (gpu-zk-long-run-tests) finished with status: ${{ job.status }}. (${{ env.ACTION_RUN_URL }})"

--- a/Makefile
+++ b/Makefile
@@ -1298,6 +1298,19 @@ test_zk_pok_experimental_gpu:
 	RUSTFLAGS="$(RUSTFLAGS)" cargo test --profile $(CARGO_PROFILE) \
 		-p tfhe-zk-pok --features experimental,gpu-experimental -- gpu
 
+.PHONY: test_zk_pok_experimental_long_run_gpu # Run long-run ZK GPU/CPU equivalence tests (multiple seeds)
+test_zk_pok_experimental_long_run_gpu:
+	RUSTFLAGS="$(RUSTFLAGS)" cargo test --profile $(CARGO_PROFILE) \
+		-p tfhe-zk-pok --features experimental,gpu-experimental -- \
+		test_pke_v2_gpu_cpu_equivalence_long_run --test-threads=1 --nocapture
+
+.PHONY: test_zk_pok_experimental_short_run_gpu
+test_zk_pok_experimental_short_run_gpu:
+	TFHE_RS_TEST_LONG_TESTS_MINIMAL=TRUE \
+	RUSTFLAGS="$(RUSTFLAGS)" cargo test --profile $(CARGO_PROFILE) \
+		-p tfhe-zk-pok --features experimental,gpu-experimental -- \
+		test_pke_v2_gpu_cpu_equivalence_long_run --test-threads=1 --nocapture
+
 .PHONY: test_integer_zk_gpu # Run tfhe-zk-pok tests
 test_integer_zk_gpu:
 	RUSTFLAGS="$(RUSTFLAGS)" cargo test --profile $(CARGO_PROFILE) \

--- a/tfhe-zk-pok/src/gpu/tests/prove_verify_stress.rs
+++ b/tfhe-zk-pok/src/gpu/tests/prove_verify_stress.rs
@@ -11,6 +11,8 @@
 //! × 32 combinations of valid/invalid inputs (e1, e2, r, m, metadata) × 2 compute
 //! loads (Proof, Verify) × 2 pairing modes (TwoSteps, Batched).
 
+#![allow(non_snake_case)]
+
 use crate::curve_api::Bls12_446;
 use crate::gpu::pke_v2 as gpu_pke_v2;
 use crate::proofs::pke_v2::VerificationPairingMode;
@@ -21,14 +23,41 @@ use rand::{thread_rng, Rng, SeedableRng};
 
 type Curve = Bls12_446;
 
+const NB_ZK_PKE_V2_EQ_ROUNDS: usize = 20;
+const NB_ZK_PKE_V2_EQ_ROUNDS_MINIMAL: usize = 3;
+
+fn get_zk_long_run_rounds() -> usize {
+    if let Ok(val) = std::env::var("TFHE_RS_ZK_GPU_LONGRUN_ROUNDS") {
+        return val.parse::<usize>().unwrap_or_else(|e| {
+            panic!("TFHE_RS_ZK_GPU_LONGRUN_ROUNDS={val:?} is not a valid usize: {e}")
+        });
+    }
+
+    match std::env::var("TFHE_RS_TEST_LONG_TESTS_MINIMAL") {
+        Ok(val) if val.to_uppercase() == "TRUE" => NB_ZK_PKE_V2_EQ_ROUNDS_MINIMAL,
+        Ok(val) => {
+            panic!("TFHE_RS_TEST_LONG_TESTS_MINIMAL={val:?} is not valid, expected \"TRUE\"")
+        }
+        Err(_) => NB_ZK_PKE_V2_EQ_ROUNDS,
+    }
+}
+
+fn get_zk_long_run_base_seed() -> u64 {
+    if let Ok(val) = std::env::var("TFHE_RS_LONGRUN_TESTS_SEED") {
+        if let Ok(s) = val.parse::<u128>() {
+            return s as u64;
+        }
+    }
+    thread_rng().gen()
+}
+
 /// Exhaustive GPU-vs-CPU equivalence test for PKE v2.
 ///
 ///   - Uses `PKEV2_TEST_PARAMS` and `pke_v2::*` functions.
 ///   - Seed bytes are little-endian (`to_le_bytes`) per v2 convention.
 ///   - Verify takes a `VerificationPairingMode`; we test both `TwoSteps` and `Batched` and assert
 ///     they agree.
-#[test]
-fn test_pke_v2_gpu_cpu_equivalence() {
+fn run_pke_v2_gpu_cpu_equivalence_round(seed: u64) {
     let params = crate::proofs::pke_v2::tests::PKEV2_TEST_PARAMS;
     let PkeTestParameters {
         d,
@@ -39,8 +68,6 @@ fn test_pke_v2_gpu_cpu_equivalence() {
         msbs_zero_padding_bit_count,
     } = params;
 
-    let seed: u64 = thread_rng().gen();
-    println!("test_pke_v2_gpu_cpu_equivalence seed: {seed:x}");
     let rng = &mut StdRng::seed_from_u64(seed);
 
     let testcase = PkeTestcase::gen(rng, params);
@@ -145,9 +172,9 @@ fn test_pke_v2_gpu_cpu_equivalence() {
             assert_eq!(
                 bincode::serialize(&cpu_proof).unwrap(),
                 bincode::serialize(&gpu_proof).unwrap(),
-                "v2 proof mismatch: load={load}, invalid_r={use_invalid_r}, \
-                 invalid_e1={use_invalid_e1}, invalid_e2={use_invalid_e2}, \
-                 invalid_m={use_invalid_m}",
+                "v2 proof mismatch: seed={seed:#x}, load={load}, \
+                 invalid_r={use_invalid_r}, invalid_e1={use_invalid_e1}, \
+                 invalid_e2={use_invalid_e2}, invalid_m={use_invalid_m}",
             );
 
             // When invalid metadata is used at verification time (but not at
@@ -182,8 +209,8 @@ fn test_pke_v2_gpu_cpu_equivalence() {
                 assert_eq!(
                     cpu_verify_result.is_err(),
                     should_fail,
-                    "v2 CPU verify mismatch: load={load}, mode={pairing_mode:?}, \
-                     should_fail={should_fail}",
+                    "v2 CPU verify mismatch: seed={seed:#x}, load={load}, \
+                     mode={pairing_mode:?}, should_fail={should_fail}",
                 );
 
                 // --- Verify GPU proof on GPU ---
@@ -196,13 +223,14 @@ fn test_pke_v2_gpu_cpu_equivalence() {
                 assert_eq!(
                     gpu_verify_result.is_err(),
                     should_fail,
-                    "v2 GPU verify mismatch: load={load}, mode={pairing_mode:?}, \
-                     should_fail={should_fail}",
+                    "v2 GPU verify mismatch: seed={seed:#x}, load={load}, \
+                     mode={pairing_mode:?}, should_fail={should_fail}",
                 );
 
                 assert_eq!(
                     cpu_verify_result, gpu_verify_result,
-                    "v2 CPU/GPU verify disagree: load={load}, mode={pairing_mode:?}",
+                    "v2 CPU/GPU verify disagree: seed={seed:#x}, load={load}, \
+                     mode={pairing_mode:?}",
                 );
 
                 // --- Cross-direction: GPU verify of CPU-produced proof ---
@@ -218,10 +246,33 @@ fn test_pke_v2_gpu_cpu_equivalence() {
                 );
                 assert_eq!(
                     gpu_verify_cpu_proof, cpu_verify_result,
-                    "v2 GPU-verify-of-CPU-proof disagrees with CPU-verify: load={load}, \
-                     mode={pairing_mode:?}",
+                    "v2 GPU-verify-of-CPU-proof disagrees with CPU-verify: \
+                     seed={seed:#x}, load={load}, mode={pairing_mode:?}",
                 );
             }
         }
+    }
+}
+
+#[test]
+fn test_pke_v2_gpu_cpu_equivalence() {
+    let seed: u64 = get_zk_long_run_base_seed();
+    println!("test_pke_v2_gpu_cpu_equivalence seed: {seed:#x}");
+    run_pke_v2_gpu_cpu_equivalence_round(seed);
+}
+
+#[test]
+fn test_pke_v2_gpu_cpu_equivalence_long_run() {
+    let base_seed = get_zk_long_run_base_seed();
+    let rounds = get_zk_long_run_rounds();
+
+    println!("test_pke_v2_gpu_cpu_equivalence_long_run: base_seed={base_seed:#x}, rounds={rounds}");
+
+    // Derive better quality per-round seeds from the base seed.
+    let mut seed_rng = StdRng::seed_from_u64(base_seed);
+    for round in 0..rounds {
+        let round_seed: u64 = seed_rng.gen();
+        println!("  round {round}/{rounds}: seed={round_seed:#x}");
+        run_pke_v2_gpu_cpu_equivalence_round(round_seed);
     }
 }


### PR DESCRIPTION
The CPU ZK-PoK path is already exercised by long-run stress tests in CI; the GPU path was not, so any regression that only manifests after many prove/verify iterations (for example numerical drift, intermittent verification failures, or memory leaks that accumulate over time) had no automated guard. This PR brings the GPU path up to parity with the CPU long-run coverage and adds the CI plumbing to keep it running on a weekly cadence without burning GPU time on unrelated PRs.

Changes:
- New workflow `gpu_zk_long_run_tests.yml` scheduled Mondays at 20:00 UTC (`cron: 0 20 * * 1`), so failures land at the start of the week when there is time to triage.
- `should-run` job with a ZK-file-change filter so unrelated PRs don't trigger the (expensive) GPU long-run job.
- Updates to `tfhe-zk-pok/src/gpu/tests/prove_verify_stress.rs`:
  - Asserts on invalid `TFHE_RS_TEST_LONG_TESTS_MINIMAL` values rather than silently falling back, so a typo in the env var fails loudly instead of running the wrong test mode.
  - Prints the test seed in the reusable form `TFHE_RS_LONGRUN_TESTS_SEED=<decimal>`, making CI failures reproducible by simply pasting the line back into a local env.
- Adds Makefile targets so the same long-run tests can be invoked locally with the same configuration as CI.

<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: https://github.com/zama-ai/tfhe-rs-internal/issues/1372

### PR content/description

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3453)
<!-- Reviewable:end -->
