### PR TITLE
chore(bench): use the bench spec for erc7984 and dex in hlapi

### DIFF
--- a/tfhe-benchmark/Cargo.toml
+++ b/tfhe-benchmark/Cargo.toml
@@ -40,7 +40,7 @@ default = ["avx512"]
 boolean = ["tfhe/boolean"]
 shortint = ["tfhe/shortint"]
 integer = ["shortint", "tfhe/integer"]
-gpu = ["tfhe/gpu"]
+gpu = ["tfhe/gpu", "benchmark_spec/gpu"]
 # gpu enables tfhe-cuda-backend which provides CUDA stream management used by tfhe-zk-pok
 gpu-experimental-zk = [
     "gpu",
@@ -48,7 +48,7 @@ gpu-experimental-zk = [
     "tfhe/gpu-experimental-zk",
     "tfhe-zk-pok/gpu-experimental",
 ]
-hpu = ["tfhe/hpu"]
+hpu = ["tfhe/hpu", "benchmark_spec/hpu"]
 hpu-v80 = ["tfhe/hpu-v80"]
 internal-keycache = ["tfhe/internal-keycache"]
 avx512 = ["tfhe/avx512"]

--- a/tfhe-benchmark/benches/high_level_api/bench_common.rs
+++ b/tfhe-benchmark/benches/high_level_api/bench_common.rs
@@ -1,8 +1,6 @@
 use benchmark::high_level_api::bench_wait::*;
 use benchmark::high_level_api::benchmark_op::*;
-use benchmark::utilities::{
-    bench_backend_from_cfg, will_this_bench_run, write_to_json, OperatorType,
-};
+use benchmark::utilities::{will_this_bench_run, write_to_json, OperatorType};
 use benchmark_spec::{get_bench_type, BenchmarkSpec, BenchmarkType, HlIntegerOp, OperandType};
 use criterion::{black_box, Criterion, Throughput};
 use rand::prelude::*;
@@ -36,13 +34,12 @@ pub fn bench_fhe_type_op<FheType, Op>(
     let inputs = op.setup_inputs(client_key, &mut rng);
 
     let bench_type = get_bench_type();
-    let benchmark_spec = BenchmarkSpec::new_hlapi(
+    let benchmark_spec = BenchmarkSpec::new_hlapi_ops(
         hlapi_op,
         &param_name,
-        &operand_type,
+        operand_type,
         Some(type_name),
-        bench_type,
-        bench_backend_from_cfg(),
+        *bench_type,
     );
     let bench_id = benchmark_spec.to_string();
 

--- a/tfhe-benchmark/benches/high_level_api/dex.rs
+++ b/tfhe-benchmark/benches/high_level_api/dex.rs
@@ -7,10 +7,10 @@ use benchmark::params_aliases::{
 };
 #[cfg(feature = "gpu")]
 use benchmark::utilities::{configure_gpu, get_param_type, ParamType};
-use benchmark::utilities::{write_to_json_unchecked, OperatorType};
-use benchmark_spec::{get_bench_type, BenchmarkType};
-use criterion::measurement::WallTime;
-use criterion::{BenchmarkGroup, Criterion, Throughput};
+use benchmark::utilities::{write_to_json, OperatorType};
+use benchmark_spec::tfhe::hlapi::dex::{Dex, DexFlavor};
+use benchmark_spec::{get_bench_type, BenchmarkMetric, BenchmarkSpec, BenchmarkType, OperandType};
+use criterion::{Criterion, Throughput};
 use rand::prelude::*;
 use rand::thread_rng;
 use rayon::prelude::*;
@@ -220,21 +220,15 @@ where
 
 #[cfg(feature = "pbs-stats")]
 mod pbs_stats {
-    use super::*;
-    use std::fs::{File, OpenOptions};
-    use std::io::Write;
-    use std::path::Path;
 
-    fn write_result(file: &mut File, name: &str, value: usize) {
-        let line = format!("{name},{value}\n");
-        let error_message = format!("cannot write {name} result into file");
-        file.write_all(line.as_bytes()).expect(&error_message);
-    }
+    use benchmark_spec::CsvResultWriter;
+
+    use super::*;
 
     pub fn print_swap_request_update_dex_balance_pbs_counts<FheType, F>(
         client_key: &ClientKey,
         type_name: &str,
-        fn_name: &str,
+        dex_bench_spec: Dex,
         swap_request_update_dex_balance_func: F,
     ) where
         FheType: FheEncrypt<u64, ClientKey>,
@@ -258,29 +252,23 @@ mod pbs_stats {
         let params = client_key.computation_parameters();
         let params_name = params.name();
 
-        let test_name = if cfg!(feature = "gpu") {
-            format!("hlapi::cuda::dex::pbs_count::swap_request_update_dex_balance::{fn_name}::{params_name}::{type_name}")
-        } else {
-            format!(
-                "hlapi::dex::pbs_count::swap_request_update_dex_balance::{fn_name}::{params_name}::{type_name}"
-            )
-        };
+        let test_name = BenchmarkSpec::new_hlapi_dex(
+            dex_bench_spec,
+            &params_name,
+            OperandType::CipherText,
+            Some(type_name),
+            BenchmarkMetric::PbsCount,
+            None,
+        );
 
-        let results_file = Path::new("dex_swap_request_update_dex_balance_pbs_count.csv");
-        if !results_file.exists() {
-            File::create(results_file).expect("create results file failed");
-        }
-        let mut file = OpenOptions::new()
-            .append(true)
-            .open(results_file)
-            .expect("cannot open results file");
+        let mut benchmark_test_result =
+            CsvResultWriter::new("dex_swap_request_update_dex_balance_pbs_count.csv");
 
-        write_result(&mut file, &test_name, count as usize);
+        benchmark_test_result.write_result(&test_name.to_string(), count as usize);
 
-        write_to_json_unchecked::<u64, _>(
+        write_to_json::<u64, _>(
             &test_name,
             params,
-            params_name,
             "pbs-count",
             &OperatorType::Atomic,
             0,
@@ -290,6 +278,7 @@ mod pbs_stats {
     pub fn print_swap_request_finalize_pbs_counts<FheType, F>(
         client_key: &ClientKey,
         type_name: &str,
+        dex_bench_spec: Dex,
         swap_request_finalize_func: F,
     ) where
         FheType: FheEncrypt<u64, ClientKey>,
@@ -313,29 +302,23 @@ mod pbs_stats {
         let params = client_key.computation_parameters();
         let params_name = params.name();
 
-        let test_name = if cfg!(feature = "gpu") {
-            format!(
-                "hlapi::cuda::dex::pbs_count::swap_request_finalize::{params_name}::{type_name}"
-            )
-        } else {
-            format!("hlapi::dex::pbs_count::swap_request_finalize::{params_name}::{type_name}")
-        };
+        let test_name = BenchmarkSpec::new_hlapi_dex(
+            dex_bench_spec,
+            &params_name,
+            OperandType::CipherText,
+            Some(type_name),
+            BenchmarkMetric::PbsCount,
+            None,
+        );
 
-        let results_file = Path::new("dex_swap_request_finalize_pbs_count.csv");
-        if !results_file.exists() {
-            File::create(results_file).expect("create results file failed");
-        }
-        let mut file = OpenOptions::new()
-            .append(true)
-            .open(results_file)
-            .expect("cannot open results file");
+        let mut benchmark_test_result =
+            CsvResultWriter::new("dex_swap_request_finalize_pbs_count.csv");
 
-        write_result(&mut file, &test_name, count as usize);
+        benchmark_test_result.write_result(&test_name.to_string(), count as usize);
 
-        write_to_json_unchecked::<u64, _>(
+        write_to_json::<u64, _>(
             &test_name,
             params,
-            params_name,
             "pbs-count",
             &OperatorType::Atomic,
             0,
@@ -345,6 +328,7 @@ mod pbs_stats {
     pub fn print_swap_claim_prepare_pbs_counts<FheType, F>(
         client_key: &ClientKey,
         type_name: &str,
+        dex_bench_spec: Dex,
         swap_claim_prepare_func: F,
     ) where
         FheType: FheEncrypt<u64, ClientKey>,
@@ -378,27 +362,23 @@ mod pbs_stats {
         let params = client_key.computation_parameters();
         let params_name = params.name();
 
-        let test_name = if cfg!(feature = "gpu") {
-            format!("hlapi::cuda::pbs_count::dex::swap_claim_prepare::{params_name}::{type_name}")
-        } else {
-            format!("hlapi::dex::pbs_count::swap_claim_prepare::{params_name}::{type_name}")
-        };
+        let test_name = BenchmarkSpec::new_hlapi_dex(
+            dex_bench_spec,
+            &params_name,
+            OperandType::CipherText,
+            Some(type_name),
+            BenchmarkMetric::PbsCount,
+            None,
+        );
 
-        let results_file = Path::new("dex_swap_claim_prepare_pbs_count.csv");
-        if !results_file.exists() {
-            File::create(results_file).expect("create results file failed");
-        }
-        let mut file = OpenOptions::new()
-            .append(true)
-            .open(results_file)
-            .expect("cannot open results file");
+        let mut benchmark_test_result =
+            CsvResultWriter::new("dex_swap_claim_prepare_pbs_count.csv");
 
-        write_result(&mut file, &test_name, count as usize);
+        benchmark_test_result.write_result(&test_name.to_string(), count as usize);
 
-        write_to_json_unchecked::<u64, _>(
+        write_to_json::<u64, _>(
             &test_name,
             params,
-            params_name,
             "pbs-count",
             &OperatorType::Atomic,
             0,
@@ -408,7 +388,7 @@ mod pbs_stats {
     pub fn print_swap_claim_update_dex_balance_pbs_counts<FheType, F>(
         client_key: &ClientKey,
         type_name: &str,
-        fn_name: &str,
+        dex_bench_spec: Dex,
         swap_claim_update_dex_balance_func: F,
     ) where
         FheType: FheEncrypt<u64, ClientKey>,
@@ -438,27 +418,23 @@ mod pbs_stats {
         let params = client_key.computation_parameters();
         let params_name = params.name();
 
-        let test_name = if cfg!(feature = "gpu") {
-            format!("hlapi::cuda::pbs_count::dex::swap_claim_update_dex_balance::{fn_name}::{params_name}::{type_name}")
-        } else {
-            format!("hlapi::dex::pbs_count::swap_claim_update_dex_balance::{fn_name}::{params_name}::{type_name}")
-        };
+        let test_name = BenchmarkSpec::new_hlapi_dex(
+            dex_bench_spec,
+            &params_name,
+            OperandType::CipherText,
+            Some(type_name),
+            BenchmarkMetric::PbsCount,
+            None,
+        );
 
-        let results_file = Path::new("dex_swap_claim_update_dex_balance_pbs_count.csv");
-        if !results_file.exists() {
-            File::create(results_file).expect("create results file failed");
-        }
-        let mut file = OpenOptions::new()
-            .append(true)
-            .open(results_file)
-            .expect("cannot open results file");
+        let mut benchmark_test_result =
+            CsvResultWriter::new("dex_swap_claim_update_dex_balance_pbs_count.csv");
 
-        write_result(&mut file, &test_name, count as usize);
+        benchmark_test_result.write_result(&test_name.to_string(), count as usize);
 
-        write_to_json_unchecked::<u64, _>(
+        write_to_json::<u64, _>(
             &test_name,
             params,
-            params_name,
             "pbs-count",
             &OperatorType::Atomic,
             0,
@@ -468,11 +444,10 @@ mod pbs_stats {
 }
 
 fn bench_swap_request_latency<FheType, F1, F2>(
-    c: &mut BenchmarkGroup<'_, WallTime>,
+    c: &mut Criterion,
     client_key: &ClientKey,
-    bench_name: &str,
     type_name: &str,
-    fn_name: &str,
+    dex_bench_spec: Dex,
     swap_request_update_dex_balance_func: F1,
     swap_request_finalize_func: F2,
 ) where
@@ -486,8 +461,18 @@ fn bench_swap_request_latency<FheType, F1, F2>(
     let params = client_key.computation_parameters();
     let params_name = params.name();
 
-    let bench_id = format!("{bench_name}::{fn_name}::{type_name}");
-    c.bench_function(&bench_id, |b| {
+    let mut c = c.benchmark_group(type_name);
+
+    let bench_spec = BenchmarkSpec::new_hlapi_dex(
+        dex_bench_spec,
+        &params_name,
+        OperandType::CipherText,
+        Some(type_name),
+        BenchmarkMetric::Latency,
+        None,
+    );
+
+    c.bench_function(bench_spec.to_string(), |b| {
         let mut rng = thread_rng();
 
         let from_balance_0 = FheType::encrypt(rng.gen::<u64>(), client_key);
@@ -525,10 +510,9 @@ fn bench_swap_request_latency<FheType, F1, F2>(
         })
     });
 
-    write_to_json_unchecked::<u64, _>(
-        &bench_id,
+    write_to_json::<u64, _>(
+        &bench_spec,
         params,
-        params_name,
         "dex-swap-request",
         &OperatorType::Atomic,
         64,
@@ -538,11 +522,10 @@ fn bench_swap_request_latency<FheType, F1, F2>(
 
 #[cfg(not(feature = "gpu"))]
 fn bench_swap_request_throughput<FheType, F1, F2>(
-    group: &mut BenchmarkGroup<'_, WallTime>,
+    c: &mut Criterion,
     client_key: &ClientKey,
-    bench_name: &str,
     type_name: &str,
-    fn_name: &str,
+    dex_bench_spec: Dex,
     swap_request_update_dex_balance_func: F1,
     swap_request_finalize_func: F2,
 ) where
@@ -555,12 +538,21 @@ fn bench_swap_request_throughput<FheType, F1, F2>(
     let params = client_key.computation_parameters();
     let params_name = params.name();
 
+    let mut group = c.benchmark_group(type_name);
+
     for num_elems in [10, 50, 100] {
         group.throughput(Throughput::Elements(num_elems));
-        let bench_id = format!(
-            "{bench_name}::throughput::{fn_name}::{params_name}::{type_name}::{num_elems}_elems"
+
+        let bench_spec = BenchmarkSpec::new_hlapi_dex(
+            dex_bench_spec,
+            &params_name,
+            OperandType::CipherText,
+            Some(type_name),
+            BenchmarkMetric::Throughput,
+            Some(num_elems.try_into().unwrap()),
         );
-        group.bench_with_input(&bench_id, &num_elems, |b, &num_elems| {
+
+        group.bench_with_input(bench_spec.to_string(), &num_elems, |b, &num_elems| {
             let from_balances_0 = (0..num_elems)
                 .map(|_| FheType::encrypt(rng.gen::<u64>(), client_key))
                 .collect::<Vec<_>>();
@@ -641,10 +633,9 @@ fn bench_swap_request_throughput<FheType, F1, F2>(
             })
         });
 
-        write_to_json_unchecked::<u64, _>(
-            &bench_id,
+        write_to_json::<u64, _>(
+            &bench_spec,
             params,
-            &params_name,
             "dex-swap-request",
             &OperatorType::Atomic,
             64,
@@ -654,11 +645,10 @@ fn bench_swap_request_throughput<FheType, F1, F2>(
 }
 #[cfg(feature = "gpu")]
 fn cuda_bench_swap_request_throughput<FheType, F1, F2>(
-    group: &mut BenchmarkGroup<'_, WallTime>,
+    c: &mut Criterion,
     client_key: &ClientKey,
-    bench_name: &str,
     type_name: &str,
-    fn_name: &str,
+    dex_bench_spec: Dex,
     swap_request_update_dex_balance_func: F1,
     swap_request_finalize_func: F2,
 ) where
@@ -678,12 +668,19 @@ fn cuda_bench_swap_request_throughput<FheType, F1, F2>(
     let params = client_key.computation_parameters();
     let params_name = params.name();
 
+    let mut group = c.benchmark_group(type_name);
+
     for num_elems in [5 * num_gpus, 10 * num_gpus, 20 * num_gpus] {
         group.throughput(Throughput::Elements(num_elems));
-        let bench_id = format!(
-            "{bench_name}::throughput::{fn_name}::{params_name}::{type_name}::{num_elems}_elems"
+        let bench_spec = BenchmarkSpec::new_hlapi_dex(
+            dex_bench_spec,
+            &params_name,
+            OperandType::CipherText,
+            Some(type_name),
+            BenchmarkMetric::Throughput,
+            Some(num_elems.try_into().unwrap()),
         );
-        group.bench_with_input(&bench_id, &num_elems, |b, &num_elems| {
+        group.bench_with_input(bench_spec.to_string(), &num_elems, |b, &num_elems| {
             let from_balances_0 = (0..num_elems)
                 .map(|_| FheType::encrypt(rng.gen::<u64>(), client_key))
                 .collect::<Vec<_>>();
@@ -853,10 +850,9 @@ fn cuda_bench_swap_request_throughput<FheType, F1, F2>(
                                 })
         });
 
-        write_to_json_unchecked::<u64, _>(
-            &bench_id,
+        write_to_json::<u64, _>(
+            &bench_spec,
             params,
-            &params_name,
             "dex-swap-request",
             &OperatorType::Atomic,
             64,
@@ -866,11 +862,10 @@ fn cuda_bench_swap_request_throughput<FheType, F1, F2>(
 }
 
 fn bench_swap_claim_latency<FheType, F1, F2>(
-    c: &mut BenchmarkGroup<'_, WallTime>,
+    c: &mut Criterion,
     client_key: &ClientKey,
-    bench_name: &str,
     type_name: &str,
-    fn_name: &str,
+    dex_bench_spec: Dex,
     swap_claim_prepare_func: F1,
     swap_claim_update_dex_balance_func: F2,
 ) where
@@ -884,8 +879,18 @@ fn bench_swap_claim_latency<FheType, F1, F2>(
     let params = client_key.computation_parameters();
     let params_name = params.name();
 
-    let bench_id = format!("{bench_name}::{fn_name}::{params_name}::{type_name}");
-    c.bench_function(&bench_id, |b| {
+    let mut c = c.benchmark_group(type_name);
+
+    let bench_spec = BenchmarkSpec::new_hlapi_dex(
+        dex_bench_spec,
+        &params_name,
+        OperandType::CipherText,
+        Some(type_name),
+        BenchmarkMetric::Latency,
+        None,
+    );
+
+    c.bench_function(bench_spec.to_string(), |b| {
         let mut rng = thread_rng();
 
         let pending_0_in = FheType::encrypt(rng.gen::<u64>(), client_key);
@@ -929,10 +934,9 @@ fn bench_swap_claim_latency<FheType, F1, F2>(
         });
     });
 
-    write_to_json_unchecked::<u64, _>(
-        &bench_id,
+    write_to_json::<u64, _>(
+        &bench_spec,
         params,
-        &params_name,
         "dex-swap-claim",
         &OperatorType::Atomic,
         64,
@@ -942,11 +946,10 @@ fn bench_swap_claim_latency<FheType, F1, F2>(
 
 #[cfg(not(feature = "gpu"))]
 fn bench_swap_claim_throughput<FheType, F1, F2>(
-    group: &mut BenchmarkGroup<'_, WallTime>,
+    c: &mut Criterion,
     client_key: &ClientKey,
-    bench_name: &str,
     type_name: &str,
-    fn_name: &str,
+    dex_bench_spec: Dex,
     swap_claim_prepare_func: F1,
     swap_claim_update_dex_balance_func: F2,
 ) where
@@ -959,12 +962,21 @@ fn bench_swap_claim_throughput<FheType, F1, F2>(
     let params = client_key.computation_parameters();
     let params_name = params.name();
 
+    let mut group = c.benchmark_group(type_name);
+
     for num_elems in [2, 6, 10] {
         group.throughput(Throughput::Elements(num_elems));
-        let bench_id = format!(
-            "{bench_name}::throughput::{fn_name}::{params_name}::{type_name}::{num_elems}_elems"
+
+        let bench_spec = BenchmarkSpec::new_hlapi_dex(
+            dex_bench_spec,
+            &params_name,
+            OperandType::CipherText,
+            Some(type_name),
+            BenchmarkMetric::Throughput,
+            Some(num_elems.try_into().unwrap()),
         );
-        group.bench_with_input(&bench_id, &num_elems, |b, &num_elems| {
+
+        group.bench_with_input(bench_spec.to_string(), &num_elems, |b, &num_elems| {
             let pending_0_in = (0..num_elems)
                 .map(|_| FheType::encrypt(rng.gen::<u64>(), client_key))
                 .collect::<Vec<_>>();
@@ -1063,10 +1075,9 @@ fn bench_swap_claim_throughput<FheType, F1, F2>(
             });
         });
 
-        write_to_json_unchecked::<u64, _>(
-            &bench_id,
+        write_to_json::<u64, _>(
+            &bench_spec,
             params,
-            &params_name,
             "dex-swap-claim",
             &OperatorType::Atomic,
             64,
@@ -1076,11 +1087,10 @@ fn bench_swap_claim_throughput<FheType, F1, F2>(
 }
 #[cfg(feature = "gpu")]
 fn cuda_bench_swap_claim_throughput<FheType, F1, F2>(
-    group: &mut BenchmarkGroup<'_, WallTime>,
+    c: &mut Criterion,
     client_key: &ClientKey,
-    bench_name: &str,
     type_name: &str,
-    fn_name: &str,
+    dex_bench_spec: Dex,
     swap_claim_prepare_func: F1,
     swap_claim_update_dex_balance_func: F2,
 ) where
@@ -1100,12 +1110,19 @@ fn cuda_bench_swap_claim_throughput<FheType, F1, F2>(
     let params = client_key.computation_parameters();
     let params_name = params.name();
 
+    let mut group = c.benchmark_group(type_name);
+
     for num_elems in [num_gpus, 2 * num_gpus] {
         group.throughput(Throughput::Elements(num_elems));
-        let bench_id = format!(
-            "{bench_name}::throughput::{fn_name}::{params_name}::{type_name}::{num_elems}_elems"
+        let bench_spec = BenchmarkSpec::new_hlapi_dex(
+            dex_bench_spec,
+            &params_name,
+            OperandType::CipherText,
+            Some(type_name),
+            BenchmarkMetric::Throughput,
+            Some(num_elems.try_into().unwrap()),
         );
-        group.bench_with_input(&bench_id, &num_elems, |b, &num_elems| {
+        group.bench_with_input(bench_spec.to_string(), &num_elems, |b, &num_elems| {
             let pending_0_in = (0..num_elems)
                 .map(|_| FheType::encrypt(rng.gen::<u64>(), client_key))
                 .collect::<Vec<_>>();
@@ -1270,10 +1287,9 @@ fn cuda_bench_swap_claim_throughput<FheType, F1, F2>(
             });
         });
 
-        write_to_json_unchecked::<u64, _>(
-            &bench_id,
+        write_to_json::<u64, _>(
+            &bench_spec,
             params,
-            &params_name,
             "dex-swap-claim",
             &OperatorType::Atomic,
             64,
@@ -1306,8 +1322,6 @@ fn main() {
 
     let mut c = Criterion::default().sample_size(10).configure_from_args();
 
-    let bench_name = "hlapi::dex";
-
     // FheUint64 PBS counts
     // We don't run multiple times since every input is encrypted
     // PBS count is always the same
@@ -1316,120 +1330,109 @@ fn main() {
         print_swap_request_update_dex_balance_pbs_counts(
             &cks,
             "FheUint64",
-            "whitepaper",
+            Dex::SwapRequest(DexFlavor::Whitepaper),
             swap_request_update_dex_balance_whitepaper::<FheUint64>,
         );
         print_swap_request_update_dex_balance_pbs_counts(
             &cks,
             "FheUint64",
-            "no_cmux",
+            Dex::SwapRequest(DexFlavor::NoCmux),
             swap_request_update_dex_balance_no_cmux::<FheUint64>,
         );
         print_swap_request_finalize_pbs_counts(
             &cks,
             "FheUint64",
+            Dex::SwapRequest(DexFlavor::Finalize),
             swap_request_finalize::<FheUint64>,
         );
         print_swap_claim_prepare_pbs_counts(
             &cks,
             "FheUint64",
+            Dex::SwapClaim(DexFlavor::Prepare),
             swap_claim_prepare::<FheUint64, FheUint128>,
         );
         print_swap_claim_update_dex_balance_pbs_counts(
             &cks,
             "FheUint64",
-            "whitepaper",
+            Dex::SwapClaim(DexFlavor::Whitepaper),
             swap_claim_update_dex_balance_whitepaper::<FheUint64>,
         );
         print_swap_claim_update_dex_balance_pbs_counts(
             &cks,
             "FheUint64",
-            "no_cmux",
+            Dex::SwapClaim(DexFlavor::NoCmux),
             swap_claim_update_dex_balance_no_cmux::<FheUint64>,
         );
     }
 
     match get_bench_type() {
         BenchmarkType::Latency => {
-            let mut group = c.benchmark_group(bench_name);
             bench_swap_request_latency(
-                &mut group,
+                &mut c,
                 &cks,
-                bench_name,
                 "FheUint64",
-                "swap_request::whitepaper",
+                Dex::SwapRequest(DexFlavor::Whitepaper),
                 swap_request_update_dex_balance_whitepaper::<FheUint64>,
                 swap_request_finalize::<FheUint64>,
             );
             bench_swap_request_latency(
-                &mut group,
+                &mut c,
                 &cks,
-                bench_name,
                 "FheUint64",
-                "swap_request::no_cmux",
+                Dex::SwapRequest(DexFlavor::NoCmux),
                 swap_request_update_dex_balance_no_cmux::<FheUint64>,
                 swap_request_finalize::<FheUint64>,
             );
             bench_swap_claim_latency(
-                &mut group,
+                &mut c,
                 &cks,
-                bench_name,
                 "FheUint64",
-                "swap_claim::whitepaper",
+                Dex::SwapClaim(DexFlavor::Whitepaper),
                 swap_claim_prepare::<FheUint64, FheUint128>,
                 swap_claim_update_dex_balance_whitepaper::<FheUint64>,
             );
             bench_swap_claim_latency(
-                &mut group,
+                &mut c,
                 &cks,
-                bench_name,
                 "FheUint64",
-                "swap_claim::no_cmux",
+                Dex::SwapClaim(DexFlavor::NoCmux),
                 swap_claim_prepare::<FheUint64, FheUint128>,
                 swap_claim_update_dex_balance_no_cmux::<FheUint64>,
             );
-
-            group.finish();
         }
         BenchmarkType::Throughput => {
-            let mut group = c.benchmark_group(bench_name);
             bench_swap_request_throughput(
-                &mut group,
+                &mut c,
                 &cks,
-                bench_name,
                 "FheUint64",
-                "swap_request::whitepaper",
+                Dex::SwapRequest(DexFlavor::Whitepaper),
                 swap_request_update_dex_balance_whitepaper::<FheUint64>,
                 swap_request_finalize::<FheUint64>,
             );
             bench_swap_request_throughput(
-                &mut group,
+                &mut c,
                 &cks,
-                bench_name,
                 "FheUint64",
-                "swap_request::no_cmux",
+                Dex::SwapRequest(DexFlavor::NoCmux),
                 swap_request_update_dex_balance_no_cmux::<FheUint64>,
                 swap_request_finalize::<FheUint64>,
             );
             bench_swap_claim_throughput(
-                &mut group,
+                &mut c,
                 &cks,
-                bench_name,
                 "FheUint64",
-                "swap_claim::whitepaper",
+                Dex::SwapClaim(DexFlavor::Whitepaper),
                 swap_claim_prepare::<FheUint64, FheUint128>,
                 swap_claim_update_dex_balance_whitepaper::<FheUint64>,
             );
             bench_swap_claim_throughput(
-                &mut group,
+                &mut c,
                 &cks,
-                bench_name,
                 "FheUint64",
-                "swap_claim::no_cmux",
+                Dex::SwapClaim(DexFlavor::NoCmux),
                 swap_claim_prepare::<FheUint64, FheUint128>,
                 swap_claim_update_dex_balance_no_cmux::<FheUint64>,
             );
-            group.finish();
         }
     };
 
@@ -1449,8 +1452,6 @@ fn main() {
 
     let mut c = Criterion::default().sample_size(10).configure_from_args();
 
-    let bench_name = "hlapi::cuda::dex";
-
     // FheUint64 PBS counts
     // We don't run multiple times since every input is encrypted
     // PBS count is always the same
@@ -1459,121 +1460,110 @@ fn main() {
         print_swap_request_update_dex_balance_pbs_counts(
             &cks,
             "FheUint64",
-            "whitepaper",
+            Dex::SwapRequest(DexFlavor::Whitepaper),
             swap_request_update_dex_balance_whitepaper::<FheUint64>,
         );
         print_swap_request_update_dex_balance_pbs_counts(
             &cks,
             "FheUint64",
-            "no_cmux",
+            Dex::SwapRequest(DexFlavor::NoCmux),
             swap_request_update_dex_balance_no_cmux::<FheUint64>,
         );
         print_swap_request_finalize_pbs_counts(
             &cks,
             "FheUint64",
+            Dex::SwapRequest(DexFlavor::Finalize),
             swap_request_finalize::<FheUint64>,
         );
         print_swap_claim_prepare_pbs_counts(
             &cks,
             "FheUint64",
+            Dex::SwapClaim(DexFlavor::Prepare),
             swap_claim_prepare::<FheUint64, FheUint128>,
         );
         print_swap_claim_update_dex_balance_pbs_counts(
             &cks,
             "FheUint64",
-            "whitepaper",
+            Dex::SwapClaim(DexFlavor::Whitepaper),
             swap_claim_update_dex_balance_whitepaper::<FheUint64>,
         );
         print_swap_claim_update_dex_balance_pbs_counts(
             &cks,
             "FheUint64",
-            "no_cmux",
+            Dex::SwapClaim(DexFlavor::NoCmux),
             swap_claim_update_dex_balance_no_cmux::<FheUint64>,
         );
     }
 
     match get_bench_type() {
         BenchmarkType::Latency => {
-            let mut group = c.benchmark_group(bench_name);
             bench_swap_request_latency(
-                &mut group,
+                &mut c,
                 &cks,
-                bench_name,
                 "FheUint64",
-                "swap_request::whitepaper",
+                Dex::SwapRequest(DexFlavor::Whitepaper),
                 swap_request_update_dex_balance_whitepaper::<FheUint64>,
                 swap_request_finalize::<FheUint64>,
             );
             bench_swap_request_latency(
-                &mut group,
+                &mut c,
                 &cks,
-                bench_name,
                 "FheUint64",
-                "swap_request::no_cmux",
+                Dex::SwapRequest(DexFlavor::NoCmux),
                 swap_request_update_dex_balance_no_cmux::<FheUint64>,
                 swap_request_finalize::<FheUint64>,
             );
             bench_swap_claim_latency(
-                &mut group,
+                &mut c,
                 &cks,
-                bench_name,
                 "FheUint64",
-                "swap_claim::whitepaper",
+                Dex::SwapClaim(DexFlavor::Whitepaper),
                 swap_claim_prepare::<FheUint64, FheUint128>,
                 swap_claim_update_dex_balance_whitepaper::<FheUint64>,
             );
             bench_swap_claim_latency(
-                &mut group,
+                &mut c,
                 &cks,
-                bench_name,
                 "FheUint64",
-                "swap_claim::no_cmux",
+                Dex::SwapClaim(DexFlavor::NoCmux),
                 swap_claim_prepare::<FheUint64, FheUint128>,
                 swap_claim_update_dex_balance_no_cmux::<FheUint64>,
             );
-
-            group.finish();
         }
 
         BenchmarkType::Throughput => {
-            let mut group = c.benchmark_group(bench_name);
             cuda_bench_swap_request_throughput(
-                &mut group,
+                &mut c,
                 &cks,
-                bench_name,
                 "FheUint64",
-                "swap_request::whitepaper",
+                Dex::SwapRequest(DexFlavor::Whitepaper),
                 swap_request_update_dex_balance_whitepaper::<FheUint64>,
                 swap_request_finalize::<FheUint64>,
             );
             cuda_bench_swap_request_throughput(
-                &mut group,
+                &mut c,
                 &cks,
-                bench_name,
                 "FheUint64",
-                "swap_request::no_cmux",
+                Dex::SwapRequest(DexFlavor::NoCmux),
                 swap_request_update_dex_balance_no_cmux::<FheUint64>,
                 swap_request_finalize::<FheUint64>,
             );
             cuda_bench_swap_claim_throughput(
-                &mut group,
+                &mut c,
                 &cks,
-                bench_name,
                 "FheUint64",
-                "swap_claim::whitepaper",
+                Dex::SwapClaim(DexFlavor::Whitepaper),
                 swap_claim_prepare::<FheUint64, FheUint128>,
                 swap_claim_update_dex_balance_whitepaper::<FheUint64>,
             );
             cuda_bench_swap_claim_throughput(
-                &mut group,
+                &mut c,
                 &cks,
-                bench_name,
                 "FheUint64",
-                "swap_claim::no_cmux",
+                Dex::SwapClaim(DexFlavor::NoCmux),
                 swap_claim_prepare::<FheUint64, FheUint128>,
                 swap_claim_update_dex_balance_no_cmux::<FheUint64>,
             );
-            group.finish();
         }
     };
 

--- a/tfhe-benchmark/benches/high_level_api/erc7984.rs
+++ b/tfhe-benchmark/benches/high_level_api/erc7984.rs
@@ -1,9 +1,9 @@
 #[cfg(feature = "gpu")]
 use benchmark::utilities::{configure_gpu, get_param_type, ParamType};
-use benchmark::utilities::{write_to_json_unchecked, OperatorType};
-use benchmark_spec::{get_bench_type, BenchmarkType};
-use criterion::measurement::WallTime;
-use criterion::{BenchmarkGroup, Criterion, Throughput};
+use benchmark::utilities::{write_to_json, OperatorType};
+use benchmark_spec::tfhe::hlapi::erc7984::{Erc7984, TransferFlavor};
+use benchmark_spec::{get_bench_type, BenchmarkMetric, BenchmarkSpec, BenchmarkType, OperandType};
+use criterion::{Criterion, Throughput};
 use rand::prelude::*;
 use rand::thread_rng;
 #[cfg(not(feature = "hpu"))]
@@ -286,21 +286,14 @@ where
 
 #[cfg(all(feature = "pbs-stats", not(feature = "hpu")))]
 mod pbs_stats {
-    use super::*;
-    use std::fs::{File, OpenOptions};
-    use std::io::Write;
-    use std::path::Path;
+    use benchmark_spec::CsvResultWriter;
 
-    fn write_result(file: &mut File, name: &str, value: usize) {
-        let line = format!("{name},{value}\n");
-        let error_message = format!("cannot write {name} result into file");
-        file.write_all(line.as_bytes()).expect(&error_message);
-    }
+    use super::*;
 
     pub fn print_transfer_pbs_counts<FheType, F>(
         client_key: &ClientKey,
         type_name: &str,
-        fn_name: &str,
+        erc7984_bench_spec: Erc7984,
         transfer_func: F,
     ) where
         FheType: FheEncrypt<u64, ClientKey>,
@@ -319,32 +312,27 @@ mod pbs_stats {
         let (_, _) = transfer_func(&from_amount, &to_amount, &amount);
         let count = tfhe::get_pbs_count();
 
-        println!("ERC7984 transfer/{fn_name}::{type_name}: {count} PBS");
+        println!("ERC7984 transfer/{erc7984_bench_spec}::{type_name}: {count} PBS");
 
         let params = client_key.computation_parameters();
         let params_name = params.name();
 
-        let test_name = if cfg!(feature = "gpu") {
-            format!("hlapi::cuda::erc7984::pbs_count::{fn_name}::{params_name}::{type_name}")
-        } else {
-            format!("hlapi::erc7984::pbs_count::{fn_name}::{params_name}::{type_name}")
-        };
+        let test_name = BenchmarkSpec::new_hlapi_erc7984(
+            erc7984_bench_spec,
+            &params_name,
+            OperandType::CipherText,
+            Some(type_name),
+            BenchmarkMetric::PbsCount,
+            None,
+        );
 
-        let results_file = Path::new("erc7984_pbs_count.csv");
-        if !results_file.exists() {
-            File::create(results_file).expect("create results file failed");
-        }
-        let mut file = OpenOptions::new()
-            .append(true)
-            .open(results_file)
-            .expect("cannot open results file");
+        let mut benchmark_result = CsvResultWriter::new("erc7984_pbs_count.csv");
 
-        write_result(&mut file, &test_name, count as usize);
+        benchmark_result.write_result(&test_name.to_string(), count as usize);
 
-        write_to_json_unchecked::<u64, _>(
+        write_to_json::<u64, _>(
             &test_name,
             params,
-            params_name,
             "pbs-count",
             &OperatorType::Atomic,
             0,
@@ -354,11 +342,10 @@ mod pbs_stats {
 }
 
 fn bench_transfer_latency<FheType, F>(
-    c: &mut BenchmarkGroup<'_, WallTime>,
+    c: &mut Criterion,
     client_key: &ClientKey,
-    bench_name: &str,
     type_name: &str,
-    fn_name: &str,
+    erc7984_bench_spec: Erc7984,
     transfer_func: F,
 ) where
     FheType: FheEncrypt<u64, ClientKey>,
@@ -371,7 +358,17 @@ fn bench_transfer_latency<FheType, F>(
     let params = client_key.computation_parameters();
     let params_name = params.name();
 
-    let bench_id = format!("{bench_name}::{fn_name}::{params_name}::{type_name}");
+    let mut c = c.benchmark_group(type_name);
+
+    let bench_spec = BenchmarkSpec::new_hlapi_erc7984(
+        erc7984_bench_spec,
+        &params_name,
+        OperandType::CipherText,
+        Some(type_name),
+        BenchmarkMetric::Latency,
+        None,
+    );
+    let bench_id = bench_spec.to_string();
     c.bench_function(&bench_id, |b| {
         let mut rng = thread_rng();
 
@@ -388,10 +385,9 @@ fn bench_transfer_latency<FheType, F>(
         })
     });
 
-    write_to_json_unchecked::<u64, _>(
-        &bench_id,
+    write_to_json::<u64, _>(
+        &bench_spec,
         params,
-        params_name,
         "erc7984-transfer",
         &OperatorType::Atomic,
         64,
@@ -401,11 +397,10 @@ fn bench_transfer_latency<FheType, F>(
 
 #[cfg(feature = "hpu")]
 fn bench_transfer_latency_simd<FheType, F>(
-    c: &mut BenchmarkGroup<'_, WallTime>,
+    c: &mut Criterion,
     client_key: &ClientKey,
-    bench_name: &str,
     type_name: &str,
-    fn_name: &str,
+    erc7984_bench_spec: Erc7984,
     transfer_func: F,
 ) where
     FheType: FheEncrypt<u64, ClientKey>,
@@ -423,9 +418,17 @@ fn bench_transfer_latency_simd<FheType, F>(
 
     let params = client_key.computation_parameters();
     let params_name = params.name();
+    let mut c = c.benchmark_group(type_name);
 
-    let bench_id = format!("{bench_name}::{fn_name}::{params_name}::{type_name}");
-    c.bench_function(&bench_id, |b| {
+    let bench_spec = BenchmarkSpec::new_hlapi_erc7984(
+        erc7984_bench_spec,
+        &params_name,
+        OperandType::CipherText,
+        Some(type_name),
+        BenchmarkMetric::Throughput,
+        None,
+    );
+    c.bench_function(bench_spec.to_string(), |b| {
         let mut rng = thread_rng();
 
         let mut from_amounts: Vec<FheType> = vec![];
@@ -449,10 +452,9 @@ fn bench_transfer_latency_simd<FheType, F>(
         })
     });
 
-    write_to_json_unchecked::<u64, _>(
-        &bench_id,
+    write_to_json::<u64, _>(
+        &bench_spec,
         params,
-        params_name,
         "erc7984-simd-transfer",
         &OperatorType::Atomic,
         64,
@@ -462,11 +464,10 @@ fn bench_transfer_latency_simd<FheType, F>(
 
 #[cfg(not(any(feature = "gpu", feature = "hpu")))]
 fn bench_transfer_throughput<FheType, F>(
-    group: &mut BenchmarkGroup<'_, WallTime>,
+    c: &mut Criterion,
     client_key: &ClientKey,
-    bench_name: &str,
     type_name: &str,
-    fn_name: &str,
+    erc7984_bench_spec: Erc7984,
     transfer_func: F,
 ) where
     FheType: FheEncrypt<u64, ClientKey> + Send + Sync,
@@ -477,11 +478,19 @@ fn bench_transfer_throughput<FheType, F>(
     let params = client_key.computation_parameters();
     let params_name = params.name();
 
+    let mut group = c.benchmark_group(type_name);
+
     for num_elems in [10, 100, 500] {
         group.throughput(Throughput::Elements(num_elems));
-        let bench_id = format!(
-            "{bench_name}::throughput::{fn_name}::{params_name}::{type_name}::{num_elems}_elems"
+        let bench_spec = BenchmarkSpec::new_hlapi_erc7984(
+            erc7984_bench_spec,
+            &params_name,
+            OperandType::CipherText,
+            Some(type_name),
+            BenchmarkMetric::Throughput,
+            Some(num_elems.try_into().unwrap()),
         );
+        let bench_id = bench_spec.to_string();
         group.bench_with_input(&bench_id, &num_elems, |b, &num_elems| {
             let from_amounts = (0..num_elems)
                 .map(|_| FheType::encrypt(rng.gen::<u64>(), client_key))
@@ -503,10 +512,9 @@ fn bench_transfer_throughput<FheType, F>(
             })
         });
 
-        write_to_json_unchecked::<u64, _>(
-            &bench_id,
+        write_to_json::<u64, _>(
+            &bench_spec,
             params,
-            &params_name,
             "erc7984-transfer",
             &OperatorType::Atomic,
             64,
@@ -517,11 +525,10 @@ fn bench_transfer_throughput<FheType, F>(
 
 #[cfg(feature = "gpu")]
 fn cuda_bench_transfer_throughput<FheType, F>(
-    group: &mut BenchmarkGroup<'_, WallTime>,
+    c: &mut Criterion,
     client_key: &ClientKey,
-    bench_name: &str,
     type_name: &str,
-    fn_name: &str,
+    erc7984_bench_spec: Erc7984,
     transfer_func: F,
 ) where
     FheType: FheEncrypt<u64, ClientKey> + Send + Sync,
@@ -542,11 +549,18 @@ fn cuda_bench_transfer_throughput<FheType, F>(
     // and is a multiple of the number of streams per GPU to avoid a bigger batch on one stream
     let num_elems = 300 * num_gpus;
 
+    let mut group = c.benchmark_group(type_name);
     group.throughput(Throughput::Elements(num_elems));
-    let bench_id = format!(
-        "{bench_name}::throughput::{fn_name}::{params_name}::{type_name}::{num_elems}_elems"
+
+    let bench_spec = BenchmarkSpec::new_hlapi_erc7984(
+        erc7984_bench_spec,
+        &params_name,
+        OperandType::CipherText,
+        Some(type_name),
+        BenchmarkMetric::Throughput,
+        Some(num_elems.try_into().unwrap()),
     );
-    group.bench_with_input(&bench_id, &num_elems, |b, &num_elems| {
+    group.bench_with_input(bench_spec.to_string(), &num_elems, |b, &num_elems| {
         let from_amounts = (0..num_elems)
             .map(|_| FheType::encrypt(rng.gen::<u64>(), client_key))
             .collect::<Vec<_>>();
@@ -593,10 +607,9 @@ fn cuda_bench_transfer_throughput<FheType, F>(
         });
     });
 
-    write_to_json_unchecked::<u64, _>(
-        &bench_id,
+    write_to_json::<u64, _>(
+        &bench_spec,
         params,
-        &params_name,
         "erc7984-transfer",
         &OperatorType::Atomic,
         64,
@@ -606,11 +619,10 @@ fn cuda_bench_transfer_throughput<FheType, F>(
 
 #[cfg(feature = "hpu")]
 fn hpu_bench_transfer_throughput<FheType, F>(
-    group: &mut BenchmarkGroup<'_, WallTime>,
+    group: &mut Criterion,
     client_key: &ClientKey,
-    bench_name: &str,
     type_name: &str,
-    fn_name: &str,
+    erc7984_bench_spec: Erc7984,
     transfer_func: F,
 ) where
     FheType: FheEncrypt<u64, ClientKey> + Send + Sync,
@@ -622,12 +634,18 @@ fn hpu_bench_transfer_throughput<FheType, F>(
     let params = client_key.computation_parameters();
     let params_name = params.name();
 
+    let mut group = group.benchmark_group(type_name);
     for num_elems in [10, 100] {
         group.throughput(Throughput::Elements(num_elems));
-        let bench_id = format!(
-            "{bench_name}::throughput::{fn_name}::{params_name}::{type_name}::{num_elems}_elems"
+        let bench_spec = BenchmarkSpec::new_hlapi_erc7984(
+            erc7984_bench_spec,
+            &params_name,
+            OperandType::CipherText,
+            Some(type_name),
+            BenchmarkMetric::Throughput,
+            Some(num_elems.try_into().unwrap()),
         );
-        group.bench_with_input(&bench_id, &num_elems, |b, &num_elems| {
+        group.bench_with_input(bench_spec.to_string(), &num_elems, |b, &num_elems| {
             let from_amounts = (0..num_elems)
                 .map(|_| FheType::encrypt(rng.gen::<u64>(), client_key))
                 .collect::<Vec<_>>();
@@ -657,10 +675,9 @@ fn hpu_bench_transfer_throughput<FheType, F>(
             });
         });
 
-        write_to_json_unchecked::<u64, _>(
-            &bench_id,
+        write_to_json::<u64, _>(
+            &bench_spec,
             params,
-            &params_name,
             "erc7984-transfer",
             &OperatorType::Atomic,
             64,
@@ -671,11 +688,10 @@ fn hpu_bench_transfer_throughput<FheType, F>(
 
 #[cfg(feature = "hpu")]
 fn hpu_bench_transfer_throughput_simd<FheType, F>(
-    group: &mut BenchmarkGroup<'_, WallTime>,
+    group: &mut Criterion,
     client_key: &ClientKey,
-    bench_name: &str,
     type_name: &str,
-    fn_name: &str,
+    erc7984_bench_spec: Erc7984,
     transfer_func: F,
 ) where
     FheType: FheEncrypt<u64, ClientKey> + Send + Sync,
@@ -698,9 +714,15 @@ fn hpu_bench_transfer_throughput_simd<FheType, F>(
     for num_elems in [2, 8] {
         let real_num_elems = num_elems * (hpu_simd_n as u64);
         group.throughput(Throughput::Elements(real_num_elems));
-        let bench_id =
-            format!("{bench_name}::throughput::{fn_name}::{params_name}::{type_name}::{real_num_elems}_elems");
-        group.bench_with_input(&bench_id, &num_elems, |b, &num_elems| {
+        let bench_spec = BenchmarkSpec::new_hlapi_erc7984(
+            erc7984_bench_spec,
+            &params_name,
+            OperandType::CipherText,
+            Some(type_name),
+            BenchmarkMetric::Throughput,
+            Some(real_num_elems.try_into().unwrap()),
+        );
+        group.bench_with_input(bench_spec.to_string(), &num_elems, |b, &num_elems| {
             let from_amounts = (0..num_elems)
                 .map(|_| {
                     (0..hpu_simd_n)
@@ -742,11 +764,10 @@ fn hpu_bench_transfer_throughput_simd<FheType, F>(
             });
         });
 
-        write_to_json_unchecked::<u64, _>(
-            &bench_id,
+        write_to_json::<u64, _>(
+            &bench_spec,
             params,
-            &params_name,
-            "erc7984-simd-ransfer",
+            "erc7984-simd-transfer",
             &OperatorType::Atomic,
             64,
             vec![],
@@ -769,8 +790,6 @@ fn main() {
 
     let mut c = Criterion::default().sample_size(10).configure_from_args();
 
-    let bench_name = "hlapi::erc7984";
-
     // FheUint64 PBS counts
     // We don't run multiple times since every input is encrypted
     // PBS count is always the same
@@ -780,99 +799,90 @@ fn main() {
         print_transfer_pbs_counts(
             &cks,
             "FheUint64",
-            "transfer::whitepaper",
+            Erc7984::Transfer(TransferFlavor::Whitepaper),
             par_transfer_whitepaper::<FheUint64>,
         );
         print_transfer_pbs_counts(
             &cks,
             "FheUint64",
-            "no_cmux",
+            Erc7984::Transfer(TransferFlavor::NoCmux),
             par_transfer_no_cmux::<FheUint64>,
         );
         print_transfer_pbs_counts(
             &cks,
             "FheUint64",
-            "transfer::overflow",
+            Erc7984::Transfer(TransferFlavor::Overflow),
             par_transfer_overflow::<FheUint64>,
         );
-        print_transfer_pbs_counts(&cks, "FheUint64", "safe", par_transfer_safe::<FheUint64>);
+        print_transfer_pbs_counts(
+            &cks,
+            "FheUint64",
+            Erc7984::Transfer(TransferFlavor::Safe),
+            par_transfer_safe::<FheUint64>,
+        );
     }
 
     match get_bench_type() {
         BenchmarkType::Latency => {
-            let mut group = c.benchmark_group(bench_name);
             bench_transfer_latency(
-                &mut group,
+                &mut c,
                 &cks,
-                bench_name,
                 "FheUint64",
-                "transfer::whitepaper",
+                Erc7984::Transfer(TransferFlavor::Whitepaper),
                 par_transfer_whitepaper::<FheUint64>,
             );
             bench_transfer_latency(
-                &mut group,
+                &mut c,
                 &cks,
-                bench_name,
                 "FheUint64",
-                "transfer::no_cmux",
+                Erc7984::Transfer(TransferFlavor::NoCmux),
                 par_transfer_no_cmux::<FheUint64>,
             );
             bench_transfer_latency(
-                &mut group,
+                &mut c,
                 &cks,
-                bench_name,
                 "FheUint64",
-                "transfer::overflow",
+                Erc7984::Transfer(TransferFlavor::Overflow),
                 par_transfer_overflow::<FheUint64>,
             );
             bench_transfer_latency(
-                &mut group,
+                &mut c,
                 &cks,
-                bench_name,
                 "FheUint64",
-                "transfer::safe",
+                Erc7984::Transfer(TransferFlavor::Safe),
                 par_transfer_safe::<FheUint64>,
             );
-
-            group.finish();
         }
 
         BenchmarkType::Throughput => {
-            let mut group = c.benchmark_group(bench_name);
             bench_transfer_throughput(
-                &mut group,
+                &mut c,
                 &cks,
-                bench_name,
                 "FheUint64",
-                "transfer::whitepaper",
+                Erc7984::Transfer(TransferFlavor::Whitepaper),
                 par_transfer_whitepaper::<FheUint64>,
             );
             bench_transfer_throughput(
-                &mut group,
+                &mut c,
                 &cks,
-                bench_name,
                 "FheUint64",
-                "transfer::no_cmux",
+                Erc7984::Transfer(TransferFlavor::NoCmux),
                 par_transfer_no_cmux::<FheUint64>,
             );
             bench_transfer_throughput(
-                &mut group,
+                &mut c,
                 &cks,
-                bench_name,
                 "FheUint64",
-                "transfer::overflow",
+                Erc7984::Transfer(TransferFlavor::Overflow),
                 par_transfer_overflow::<FheUint64>,
             );
             bench_transfer_throughput(
-                &mut group,
+                &mut c,
                 &cks,
-                bench_name,
                 "FheUint64",
-                "transfer::safe",
+                Erc7984::Transfer(TransferFlavor::Safe),
                 par_transfer_safe::<FheUint64>,
             );
-
-            group.finish();
         }
     };
 
@@ -896,8 +906,6 @@ fn main() {
 
     let mut c = Criterion::default().sample_size(10).configure_from_args();
 
-    let bench_name = "hlapi::cuda::erc7984";
-
     // FheUint64 PBS counts
     // We don't run multiple times since every input is encrypted
     // PBS count is always the same
@@ -907,98 +915,90 @@ fn main() {
         print_transfer_pbs_counts(
             &cks,
             "FheUint64",
-            "transfer::whitepaper",
+            Erc7984::Transfer(TransferFlavor::Whitepaper),
             par_transfer_whitepaper::<FheUint64>,
         );
         print_transfer_pbs_counts(
             &cks,
             "FheUint64",
-            "no_cmux",
+            Erc7984::Transfer(TransferFlavor::NoCmux),
             par_transfer_no_cmux::<FheUint64>,
         );
         print_transfer_pbs_counts(
             &cks,
             "FheUint64",
-            "transfer::overflow",
+            Erc7984::Transfer(TransferFlavor::Overflow),
             par_transfer_overflow::<FheUint64>,
         );
-        print_transfer_pbs_counts(&cks, "FheUint64", "safe", par_transfer_safe::<FheUint64>);
+        print_transfer_pbs_counts(
+            &cks,
+            "FheUint64",
+            Erc7984::Transfer(TransferFlavor::Safe),
+            par_transfer_safe::<FheUint64>,
+        );
     }
 
     match get_bench_type() {
         BenchmarkType::Latency => {
-            let mut group = c.benchmark_group(bench_name);
             bench_transfer_latency(
-                &mut group,
+                &mut c,
                 &cks,
-                bench_name,
                 "FheUint64",
-                "transfer::whitepaper",
+                Erc7984::Transfer(TransferFlavor::Whitepaper),
                 par_transfer_whitepaper::<FheUint64>,
             );
             bench_transfer_latency(
-                &mut group,
+                &mut c,
                 &cks,
-                bench_name,
                 "FheUint64",
-                "transfer::no_cmux",
+                Erc7984::Transfer(TransferFlavor::NoCmux),
                 par_transfer_no_cmux::<FheUint64>,
             );
             bench_transfer_latency(
-                &mut group,
+                &mut c,
                 &cks,
-                bench_name,
                 "FheUint64",
-                "transfer::overflow",
+                Erc7984::Transfer(TransferFlavor::Overflow),
                 par_transfer_overflow::<FheUint64>,
             );
             bench_transfer_latency(
-                &mut group,
+                &mut c,
                 &cks,
-                bench_name,
                 "FheUint64",
-                "transfer::safe",
+                Erc7984::Transfer(TransferFlavor::Safe),
                 par_transfer_safe::<FheUint64>,
             );
-
-            group.finish();
         }
 
         BenchmarkType::Throughput => {
-            let mut group = c.benchmark_group(bench_name);
             cuda_bench_transfer_throughput(
-                &mut group,
+                &mut c,
                 &cks,
-                bench_name,
                 "FheUint64",
-                "transfer::whitepaper",
+                Erc7984::Transfer(TransferFlavor::Whitepaper),
                 transfer_whitepaper::<FheUint64>,
             );
             cuda_bench_transfer_throughput(
-                &mut group,
+                &mut c,
                 &cks,
-                bench_name,
                 "FheUint64",
-                "transfer::no_cmux",
+                Erc7984::Transfer(TransferFlavor::NoCmux),
                 transfer_no_cmux::<FheUint64>,
             );
             cuda_bench_transfer_throughput(
-                &mut group,
+                &mut c,
                 &cks,
-                bench_name,
                 "FheUint64",
-                "transfer::overflow",
+                Erc7984::Transfer(TransferFlavor::Overflow),
                 transfer_overflow::<FheUint64>,
             );
             cuda_bench_transfer_throughput(
-                &mut group,
+                &mut c,
                 &cks,
-                bench_name,
                 "FheUint64",
-                "transfer::safe",
+                Erc7984::Transfer(TransferFlavor::Safe),
                 transfer_safe::<FheUint64>,
             );
-            group.finish();
         }
     };
 
@@ -1027,69 +1027,57 @@ fn main() {
 
     let mut c = Criterion::default().sample_size(10).configure_from_args();
 
-    let bench_name = "hlapi::hpu::erc7984";
-
     match get_bench_type() {
         BenchmarkType::Latency => {
-            let mut group = c.benchmark_group(bench_name);
             bench_transfer_latency(
-                &mut group,
+                &mut c,
                 &cks,
-                bench_name,
                 "FheUint64",
-                "transfer::whitepaper",
+                Erc7984::Transfer(TransferFlavor::Whitepaper),
                 transfer_whitepaper::<FheUint64>,
             );
             // Erc7984 optimized instruction only available on Hpu
             bench_transfer_latency(
-                &mut group,
+                &mut c,
                 &cks,
-                bench_name,
                 "FheUint64",
-                "transfer::hpu_optim",
+                Erc7984::Transfer(TransferFlavor::HpuOptim),
                 transfer_hpu::<FheUint64>,
             );
             // Erc7984 SIMD instruction only available on Hpu
             bench_transfer_latency_simd(
-                &mut group,
+                &mut c,
                 &cks,
-                bench_name,
                 "FheUint64",
-                "transfer::hpu_simd",
+                Erc7984::Transfer(TransferFlavor::HpuSimd),
                 transfer_hpu_simd::<FheUint64>,
             );
-            group.finish();
         }
 
         BenchmarkType::Throughput => {
-            let mut group = c.benchmark_group(bench_name);
             hpu_bench_transfer_throughput(
-                &mut group,
+                &mut c,
                 &cks,
-                bench_name,
                 "FheUint64",
-                "transfer::whitepaper",
+                Erc7984::Transfer(TransferFlavor::Whitepaper),
                 transfer_whitepaper::<FheUint64>,
             );
             // Erc7984 optimized instruction only available on Hpu
             hpu_bench_transfer_throughput(
-                &mut group,
+                &mut c,
                 &cks,
-                bench_name,
                 "FheUint64",
-                "transfer::hpu_optim",
+                Erc7984::Transfer(TransferFlavor::HpuOptim),
                 transfer_hpu::<FheUint64>,
             );
             // Erc7984 SIMD instruction only available on Hpu
             hpu_bench_transfer_throughput_simd(
-                &mut group,
+                &mut c,
                 &cks,
-                bench_name,
                 "FheUint64",
-                "transfer::hpu_simd",
+                Erc7984::Transfer(TransferFlavor::HpuSimd),
                 transfer_hpu_simd::<FheUint64>,
             );
-            group.finish();
         }
     };
 

--- a/tfhe-benchmark/benches/integer/zk_pke.rs
+++ b/tfhe-benchmark/benches/integer/zk_pke.rs
@@ -1,12 +1,10 @@
 use benchmark::params_aliases::*;
 use benchmark::utilities::{throughput_num_threads, write_to_json_unchecked, OperatorType};
-use benchmark_spec::{get_bench_type, BenchmarkType};
+use benchmark_spec::{get_bench_type, BenchmarkType, CsvResultWriter};
 use criterion::{criterion_group, Criterion, Throughput};
 use rand::prelude::*;
 use rayon::prelude::*;
 use std::env;
-use std::fs::{File, OpenOptions};
-use std::io::Write;
 use std::path::Path;
 use tfhe::core_crypto::prelude::LweCiphertextCount;
 use tfhe::integer::key_switching_key::KeySwitchingKey;
@@ -59,12 +57,6 @@ fn compute_load_config() -> Vec<ZkComputeLoad> {
     };
 
     conf
-}
-
-fn write_result(file: &mut File, name: &str, value: usize) {
-    let line = format!("{name},{value}\n");
-    let error_message = format!("cannot write {name} result into file");
-    file.write_all(line.as_bytes()).expect(&error_message);
 }
 
 fn zk_throughput_num_elements() -> u64 {
@@ -217,11 +209,7 @@ fn cpu_pke_zk_verify(c: &mut Criterion, results_file: &Path) {
         .sample_size(15)
         .measurement_time(std::time::Duration::from_secs(60));
 
-    File::create(results_file).expect("create results file failed");
-    let mut file = OpenOptions::new()
-        .append(true)
-        .open(results_file)
-        .expect("cannot open results file");
+    let mut benchmark_test_result = CsvResultWriter::from_path(results_file);
 
     for (param_pke, param_casting, param_fhe) in [(
         BENCH_PARAM_PKE_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
@@ -271,7 +259,8 @@ fn cpu_pke_zk_verify(c: &mut Criterion, results_file: &Path) {
                 let test_name =
                     format!("zk::crs_sizes::{param_name}::{bits}_bits_packed_ZK{zk_vers:?}");
 
-                write_result(&mut file, &test_name, crs_data.len());
+                benchmark_test_result.write_result(&test_name, crs_data.len());
+
                 write_to_json_unchecked::<u64, _>(
                     &test_name,
                     shortint_params,
@@ -321,11 +310,9 @@ fn cpu_pke_zk_verify(c: &mut Criterion, results_file: &Path) {
                             "zk::proven_list_size::{param_name}::{bits}_bits_packed_{crs_size}_bits_crs_{zk_load}_ZK{zk_vers:?}"
                         );
 
-                            write_result(
-                                &mut file,
-                                &test_name,
-                                proven_ciphertext_list_serialized.len(),
-                            );
+                            benchmark_test_result
+                                .write_result(&test_name, proven_ciphertext_list_serialized.len());
+
                             write_to_json_unchecked::<u64, _>(
                                 &test_name,
                                 shortint_params,
@@ -342,7 +329,8 @@ fn cpu_pke_zk_verify(c: &mut Criterion, results_file: &Path) {
                             let test_name =
                             format!("zk::proof_sizes::{param_name}::{bits}_bits_packed_{crs_size}_bits_crs_{zk_load}_ZK{zk_vers:?}");
 
-                            write_result(&mut file, &test_name, proof_size);
+                            benchmark_test_result.write_result(&test_name, proof_size);
+
                             write_to_json_unchecked::<u64, _>(
                                 &test_name,
                                 shortint_params,
@@ -522,11 +510,7 @@ mod cuda {
             .sample_size(15)
             .measurement_time(std::time::Duration::from_secs(60));
 
-        File::create(results_file).expect("create results file failed");
-        let mut file = OpenOptions::new()
-            .append(true)
-            .open(results_file)
-            .expect("cannot open results file");
+        let mut benchmark_test_result = CsvResultWriter::from_path(results_file);
 
         let (param_pke, param_ksk, param_fhe): (
             CompactPublicKeyEncryptionParameters,
@@ -590,7 +574,7 @@ mod cuda {
                 let test_name =
                     format!("zk::crs_sizes::{param_name}::{bits}_bits_packed_ZK{zk_vers:?}");
 
-                write_result(&mut file, &test_name, crs_data.len());
+                benchmark_test_result.write_result(&test_name, crs_data.len());
                 write_to_json_unchecked::<u64, _>(
                     &test_name,
                     param_fhe,
@@ -660,11 +644,8 @@ mod cuda {
                                     "zk::proven_list_size::{param_name}::{bits}_bits_packed_{crs_size}_bits_crs_{zk_load}_ZK{zk_vers:?}"
                                 );
 
-                            write_result(
-                                &mut file,
-                                &test_name,
-                                proven_ciphertext_list_serialized.len(),
-                            );
+                            benchmark_test_result
+                                .write_result(&test_name, proven_ciphertext_list_serialized.len());
                             write_to_json_unchecked::<u64, _>(
                                 &test_name,
                                 param_fhe,
@@ -681,7 +662,7 @@ mod cuda {
                             let test_name =
                                     format!("zk::proof_sizes::{param_name}::{bits}_bits_packed_{crs_size}_bits_crs_{zk_load}_ZK{zk_vers:?}");
 
-                            write_result(&mut file, &test_name, proof_size);
+                            benchmark_test_result.write_result(&test_name, proof_size);
                             write_to_json_unchecked::<u64, _>(
                                 &test_name,
                                 param_fhe,

--- a/tfhe-benchmark/src/bin/boolean_key_sizes.rs
+++ b/tfhe-benchmark/src/bin/boolean_key_sizes.rs
@@ -1,26 +1,16 @@
 use benchmark::utilities::{write_to_json_unchecked, OperatorType};
-use std::fs::{File, OpenOptions};
-use std::io::Write;
+use benchmark_spec::CsvResultWriter;
 use std::path::Path;
 use tfhe::boolean::parameters::{DEFAULT_PARAMETERS, PARAMETERS_ERROR_PROB_2_POW_MINUS_165};
 use tfhe::boolean::{client_key, server_key};
-
-fn write_result(file: &mut File, name: &str, value: usize) {
-    let line = format!("{name},{value}\n");
-    let error_message = format!("cannot write {name} result into file");
-    file.write_all(line.as_bytes()).expect(&error_message);
-}
 
 fn client_server_key_sizes(results_file: &Path) {
     let boolean_params_vec = [
         (DEFAULT_PARAMETERS, "DEFAULT_PARAMETERS"),
         (PARAMETERS_ERROR_PROB_2_POW_MINUS_165, "TFHE_LIB_PARAMETERS"),
     ];
-    File::create(results_file).expect("create results file failed");
-    let mut file = OpenOptions::new()
-        .append(true)
-        .open(results_file)
-        .expect("cannot open results file");
+
+    let mut benchmark_test_result = CsvResultWriter::from_path(results_file);
 
     let operator = OperatorType::Atomic;
 
@@ -38,7 +28,7 @@ fn client_server_key_sizes(results_file: &Path) {
         let ksk_size = sks.key_switching_key_size_bytes();
         let test_name = format!("boolean_key_sizes_{params_name}_ksk");
 
-        write_result(&mut file, &test_name, ksk_size);
+        benchmark_test_result.write_result(&test_name, ksk_size);
         write_to_json_unchecked::<u32, _>(
             &test_name,
             *params,
@@ -58,7 +48,7 @@ fn client_server_key_sizes(results_file: &Path) {
         let bsk_size = sks.bootstrapping_key_size_bytes();
         let test_name = format!("boolean_key_sizes_{params_name}_bsk");
 
-        write_result(&mut file, &test_name, bsk_size);
+        benchmark_test_result.write_result(&test_name, bsk_size);
         write_to_json_unchecked::<u32, _>(
             &test_name,
             *params,

--- a/tfhe-benchmark/src/bin/hlapi_ct_sizes.rs
+++ b/tfhe-benchmark/src/bin/hlapi_ct_sizes.rs
@@ -1,9 +1,8 @@
 use benchmark::params::{get_classical_tuniform_groups, get_multi_bit_tuniform_groups};
 use benchmark::params_aliases::*;
 use benchmark::utilities::{write_to_json_unchecked, OperatorType};
+use benchmark_spec::CsvResultWriter;
 use rand::Rng;
-use std::fs::{File, OpenOptions};
-use std::io::Write;
 use std::path::Path;
 use tfhe::integer::U256;
 use tfhe::keycache::NamedParam;
@@ -15,22 +14,10 @@ use tfhe::{
     CompressedSquashedNoiseCiphertextList, ConfigBuilder, FheUint64,
 };
 
-fn write_result(file: &mut File, name: &str, value: usize) {
-    let line = format!("{name},{value}\n");
-    let error_message = format!("cannot write {name} result into file");
-    file.write_all(line.as_bytes()).expect(&error_message);
-}
-
 pub fn ct_sizes(results_file: &Path) {
     let mut rng = rand::thread_rng();
 
-    File::create(results_file).expect("create results file failed");
-    let mut file = OpenOptions::new()
-        .create(true)
-        .truncate(true)
-        .write(true)
-        .open(results_file)
-        .expect("cannot open results file");
+    let mut benchmark_test_result = CsvResultWriter::from_path(results_file);
 
     let operator = OperatorType::Atomic;
 
@@ -87,7 +74,7 @@ pub fn ct_sizes(results_file: &Path) {
         let params_record = param_fhe;
 
         let mut write_and_record_result = |res: usize, test_name: &str, display_name: &str| {
-            write_result(&mut file, test_name, res);
+            benchmark_test_result.write_result(test_name, res);
             write_to_json_unchecked::<u64, _>(
                 test_name,
                 params_record,
@@ -174,13 +161,7 @@ pub fn cpk_and_cctl_sizes(results_file: &Path) {
 
     let mut rng = rand::thread_rng();
 
-    File::create(results_file).expect("create results file failed");
-    let mut file = OpenOptions::new()
-        .create(true)
-        .truncate(true)
-        .write(true)
-        .open(results_file)
-        .expect("cannot open results file");
+    let mut benchmark_test_result = CsvResultWriter::from_path(results_file);
 
     let operator = OperatorType::Atomic;
 
@@ -205,7 +186,7 @@ pub fn cpk_and_cctl_sizes(results_file: &Path) {
         let cpk_size = bincode::serialize(&public_key).unwrap().len();
 
         println!("PK size: {cpk_size} bytes");
-        write_result(&mut file, &test_name, cpk_size);
+        benchmark_test_result.write_result(&test_name, cpk_size);
         write_to_json_unchecked::<u64, _>(
             &test_name,
             params,
@@ -227,7 +208,7 @@ pub fn cpk_and_cctl_sizes(results_file: &Path) {
 
         println!("Compact CT list for {NB_CTXT} CTs: {cctl_size} bytes");
 
-        write_result(&mut file, &test_name, cctl_size);
+        benchmark_test_result.write_result(&test_name, cctl_size);
         write_to_json_unchecked::<u64, _>(
             &test_name,
             params,
@@ -273,7 +254,7 @@ pub fn cpk_and_cctl_sizes(results_file: &Path) {
 
         println!("Compact CT list for {NB_CTXT} CTs: {cctl_size} bytes");
 
-        write_result(&mut file, &test_name, cctl_size);
+        benchmark_test_result.write_result(&test_name, cctl_size);
         write_to_json_unchecked::<u64, _>(
             &test_name,
             params,

--- a/tfhe-benchmark/src/bin/shortint_key_sizes.rs
+++ b/tfhe-benchmark/src/bin/shortint_key_sizes.rs
@@ -1,8 +1,7 @@
 use benchmark::params::get_classical_tuniform_groups;
 use benchmark::params_aliases::*;
 use benchmark::utilities::{write_to_json_unchecked, CryptoParametersRecord, OperatorType};
-use std::fs::{File, OpenOptions};
-use std::io::Write;
+use benchmark_spec::CsvResultWriter;
 use std::path::Path;
 use tfhe::keycache::NamedParam;
 use tfhe::shortint::atomic_pattern::compressed::CompressedAtomicPatternServerKey;
@@ -17,12 +16,6 @@ use tfhe::shortint::{
     ClientKey, CompactPrivateKey, CompressedCompactPublicKey, CompressedKeySwitchingKey,
     CompressedServerKey, PBSParameters, ServerKey,
 };
-
-fn write_result(file: &mut File, name: &str, value: usize) {
-    let line = format!("{name},{value}\n");
-    let error_message = format!("cannot write {name} result into file");
-    file.write_all(line.as_bytes()).expect(&error_message);
-}
 
 fn client_server_key_sizes(results_file: &Path) {
     let shortint_params_vec: Vec<PBSParameters> = vec![
@@ -59,11 +52,8 @@ fn client_server_key_sizes(results_file: &Path) {
         BENCH_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_3_CARRY_3_KS_PBS_TUNIFORM_2M128.into(),
         BENCH_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_4_CARRY_4_KS_PBS_TUNIFORM_2M128.into(),
     ];
-    File::create(results_file).expect("create results file failed");
-    let mut file = OpenOptions::new()
-        .append(true)
-        .open(results_file)
-        .expect("cannot open results file");
+
+    let mut benchmark_test_result = CsvResultWriter::from_path(results_file);
 
     let operator = OperatorType::Atomic;
 
@@ -83,7 +73,8 @@ fn client_server_key_sizes(results_file: &Path) {
         let ksk_size = sks.key_switching_key_size_bytes();
         let test_name = format!("shortint_key_sizes_{}_ksk", params.name());
 
-        write_result(&mut file, &test_name, ksk_size);
+        benchmark_test_result.write_result(&test_name, ksk_size);
+
         write_to_json_unchecked::<u64, _>(
             &test_name,
             params,
@@ -103,7 +94,8 @@ fn client_server_key_sizes(results_file: &Path) {
         let bsk_size = sks.bootstrapping_key_size_bytes();
         let test_name = format!("shortint_key_sizes_{}_bsk", params.name());
 
-        write_result(&mut file, &test_name, bsk_size);
+        benchmark_test_result.write_result(&test_name, bsk_size);
+
         write_to_json_unchecked::<u64, _>(
             &test_name,
             params,
@@ -124,7 +116,8 @@ fn client_server_key_sizes(results_file: &Path) {
         let bsk_compressed_size = sks_compressed.bootstrapping_key_size_bytes();
         let test_name = format!("shortint_key_sizes_{}_bsk_compressed", params.name());
 
-        write_result(&mut file, &test_name, bsk_compressed_size);
+        benchmark_test_result.write_result(&test_name, bsk_compressed_size);
+
         write_to_json_unchecked::<u64, _>(
             &test_name,
             params,
@@ -152,12 +145,12 @@ fn measure_serialized_size<T: serde::Serialize, P: Into<CryptoParametersRecord<u
     param_name: &str,
     test_name_suffix: &str,
     display_name: &str,
-    file: &mut File,
+    file: &mut CsvResultWriter,
 ) {
     let serialized = bincode::serialize(to_serialize).unwrap();
     let size = serialized.len();
     let test_name = format!("shortint_key_sizes_{param_name}_{test_name_suffix}");
-    write_result(file, &test_name, size);
+    file.write_result(&test_name, size);
     write_to_json_unchecked::<u64, _>(
         &test_name,
         param.clone(),
@@ -172,11 +165,7 @@ fn measure_serialized_size<T: serde::Serialize, P: Into<CryptoParametersRecord<u
 }
 
 fn tuniform_key_set_sizes(results_file: &Path) {
-    File::create(results_file).expect("create results file failed");
-    let mut file = OpenOptions::new()
-        .append(true)
-        .open(results_file)
-        .expect("cannot open results file");
+    let mut benchmark_test_result = CsvResultWriter::from_path(results_file);
 
     println!("Measuring shortint key sizes:");
 
@@ -200,7 +189,7 @@ fn tuniform_key_set_sizes(results_file: &Path) {
                     &param_fhe_name,
                     "ksk",
                     "KSK",
-                    &mut file,
+                    &mut benchmark_test_result,
                 );
                 measure_serialized_size(
                     &ap.bootstrapping_key,
@@ -208,7 +197,7 @@ fn tuniform_key_set_sizes(results_file: &Path) {
                     &param_fhe_name,
                     "bsk",
                     "BSK",
-                    &mut file,
+                    &mut benchmark_test_result,
                 );
             }
             AtomicPatternServerKey::KeySwitch32(ap) => {
@@ -218,7 +207,7 @@ fn tuniform_key_set_sizes(results_file: &Path) {
                     &param_fhe_name,
                     "ksk",
                     "KSK",
-                    &mut file,
+                    &mut benchmark_test_result,
                 );
                 measure_serialized_size(
                     &ap.bootstrapping_key,
@@ -226,7 +215,7 @@ fn tuniform_key_set_sizes(results_file: &Path) {
                     &param_fhe_name,
                     "bsk",
                     "BSK",
-                    &mut file,
+                    &mut benchmark_test_result,
                 );
             }
             AtomicPatternServerKey::Dynamic(_) => panic!("Dynamic atomic pattern not supported"),
@@ -240,7 +229,7 @@ fn tuniform_key_set_sizes(results_file: &Path) {
                     &param_fhe_name,
                     "ksk_compressed",
                     "KSK",
-                    &mut file,
+                    &mut benchmark_test_result,
                 );
                 measure_serialized_size(
                     &comp_ap.bootstrapping_key(),
@@ -248,7 +237,7 @@ fn tuniform_key_set_sizes(results_file: &Path) {
                     &param_fhe_name,
                     "bsk_compressed",
                     "BSK",
-                    &mut file,
+                    &mut benchmark_test_result,
                 );
             }
             CompressedAtomicPatternServerKey::KeySwitch32(comp_ap) => {
@@ -258,7 +247,7 @@ fn tuniform_key_set_sizes(results_file: &Path) {
                     &param_fhe_name,
                     "ksk_compressed",
                     "KSK",
-                    &mut file,
+                    &mut benchmark_test_result,
                 );
                 measure_serialized_size(
                     &comp_ap.bootstrapping_key(),
@@ -266,7 +255,7 @@ fn tuniform_key_set_sizes(results_file: &Path) {
                     &param_fhe_name,
                     "bsk_compressed",
                     "BSK",
-                    &mut file,
+                    &mut benchmark_test_result,
                 );
             }
         }
@@ -278,14 +267,21 @@ fn tuniform_key_set_sizes(results_file: &Path) {
             let compressed_pk = CompressedCompactPublicKey::new(&compact_private_key);
             let pk = compressed_pk.decompress();
 
-            measure_serialized_size(&pk, pke_param, &param_pke_name, "cpk", "CPK", &mut file);
+            measure_serialized_size(
+                &pk,
+                pke_param,
+                &param_pke_name,
+                "cpk",
+                "CPK",
+                &mut benchmark_test_result,
+            );
             measure_serialized_size(
                 &compressed_pk,
                 pke_param,
                 &param_pke_name,
                 "cpk_compressed",
                 "CPK",
-                &mut file,
+                &mut benchmark_test_result,
             );
 
             let casting_param = dedicated_pke_params.ksk_params;
@@ -303,7 +299,7 @@ fn tuniform_key_set_sizes(results_file: &Path) {
                 &param_casting_name,
                 "casting_key",
                 "CastKey",
-                &mut file,
+                &mut benchmark_test_result,
             );
             measure_serialized_size(
                 &compressed_casting_key.into_raw_parts().0,
@@ -311,7 +307,7 @@ fn tuniform_key_set_sizes(results_file: &Path) {
                 &param_casting_name,
                 "casting_key_compressed",
                 "CastKey",
-                &mut file,
+                &mut benchmark_test_result,
             );
         }
 
@@ -329,7 +325,7 @@ fn tuniform_key_set_sizes(results_file: &Path) {
                 &param_compression_name,
                 "compression_key",
                 "CompressionKey",
-                &mut file,
+                &mut benchmark_test_result,
             );
             measure_serialized_size(
                 &decompression_key,
@@ -337,7 +333,7 @@ fn tuniform_key_set_sizes(results_file: &Path) {
                 &param_compression_name,
                 "decompression_key",
                 "CompressionKey",
-                &mut file,
+                &mut benchmark_test_result,
             );
 
             let (compressed_compression_key, compressed_decompression_key) =
@@ -349,7 +345,7 @@ fn tuniform_key_set_sizes(results_file: &Path) {
                 &param_compression_name,
                 "compressed_compression_key",
                 "CompressedCompressionKey",
-                &mut file,
+                &mut benchmark_test_result,
             );
             measure_serialized_size(
                 &compressed_decompression_key,
@@ -357,7 +353,7 @@ fn tuniform_key_set_sizes(results_file: &Path) {
                 &param_compression_name,
                 "compressed_decompression_key",
                 "CompressedCompressionKey",
-                &mut file,
+                &mut benchmark_test_result,
             );
         }
 
@@ -373,7 +369,7 @@ fn tuniform_key_set_sizes(results_file: &Path) {
                 &noise_squashing_param.name(),
                 "noise_squashing_key",
                 "NoiseSquashingKey",
-                &mut file,
+                &mut benchmark_test_result,
             );
             if let Some(noise_squashing_comp_param) =
                 meta_noise_squashing_param.compression_parameters
@@ -392,7 +388,7 @@ fn tuniform_key_set_sizes(results_file: &Path) {
                     &noise_squashing_comp_param.name(),
                     "noise_squashing_compression_key",
                     "NoiseSquashingCompressionKey",
-                    &mut file,
+                    &mut benchmark_test_result,
                 );
             }
         }

--- a/tfhe-benchmark/src/bin/wasm_benchmarks_parser.rs
+++ b/tfhe-benchmark/src/bin/wasm_benchmarks_parser.rs
@@ -1,9 +1,8 @@
 use benchmark::utilities::{write_to_json_unchecked, OperatorType};
+use benchmark_spec::CsvResultWriter;
 use clap::Parser;
 use std::collections::HashMap;
 use std::fs;
-use std::fs::{File, OpenOptions};
-use std::io::Write;
 use std::path::Path;
 use tfhe::keycache::NamedParam;
 use tfhe::shortint::keycache::get_shortint_parameter_set_from_name;
@@ -29,18 +28,8 @@ fn params_from_name(name: &str) -> ClassicPBSParameters {
     }
 }
 
-fn write_result(file: &mut File, name: &str, value: usize) {
-    let line = format!("{name},{value}\n");
-    let error_message = format!("cannot write {name} result into file");
-    file.write_all(line.as_bytes()).expect(&error_message);
-}
-
 pub fn parse_wasm_benchmarks(results_file: &Path, raw_results_file: &Path) {
-    File::create(results_file).expect("create results file failed");
-    let mut file = OpenOptions::new()
-        .append(true)
-        .open(results_file)
-        .expect("cannot open parsed results file");
+    let mut benchmark_test_result = CsvResultWriter::from_path(results_file);
 
     let operator = OperatorType::Atomic;
 
@@ -60,10 +49,10 @@ pub fn parse_wasm_benchmarks(results_file: &Path, raw_results_file: &Path) {
         let params: PBSParameters = params_from_name(name_parts[1]).into();
         println!("{name_parts:?}");
         if full_name.contains("_size") {
-            write_result(&mut file, &prefixed_full_name, *val as usize);
+            benchmark_test_result.write_result(&prefixed_full_name, *val as usize);
         } else {
             let value_in_ns = (val * 1_000_000_f32) as usize;
-            write_result(&mut file, &prefixed_full_name, value_in_ns);
+            benchmark_test_result.write_result(&prefixed_full_name, value_in_ns);
         }
 
         write_to_json_unchecked::<u64, _>(

--- a/tfhe-benchmark/src/utilities.rs
+++ b/tfhe-benchmark/src/utilities.rs
@@ -1,4 +1,4 @@
-use benchmark_spec::{Backend, BenchmarkSpec, OperandType};
+use benchmark_spec::{BenchmarkSpec, OperandType};
 use criterion::Criterion;
 use serde::Serialize;
 use std::path::PathBuf;
@@ -9,16 +9,6 @@ use tfhe::core_crypto::gpu::{get_number_of_gpus, get_number_of_sms};
 use tfhe::core_crypto::prelude::*;
 #[cfg(feature = "integer")]
 use tfhe::prelude::*;
-
-pub fn bench_backend_from_cfg() -> Backend {
-    if cfg!(feature = "gpu") {
-        Backend::Cuda
-    } else if cfg!(feature = "hpu") {
-        Backend::Hpu
-    } else {
-        Backend::Cpu
-    }
-}
 
 #[cfg(feature = "boolean")]
 pub mod boolean_utils {

--- a/utils/benchmark_spec/Cargo.toml
+++ b/utils/benchmark_spec/Cargo.toml
@@ -5,6 +5,10 @@ edition = "2024"
 rust-version.workspace = true
 publish = false
 
+[features]
+gpu = []
+hpu = []
+
 [dependencies]
 strum = { version = "0.28", features = ["derive"] }
 serde = { workspace = true, default-features = false, features = ["derive"] }

--- a/utils/benchmark_spec/src/backend.rs
+++ b/utils/benchmark_spec/src/backend.rs
@@ -7,3 +7,13 @@ pub enum Backend {
     Cuda,
     Hpu,
 }
+
+pub fn bench_backend_from_cfg() -> Backend {
+    if cfg!(feature = "gpu") {
+        Backend::Cuda
+    } else if cfg!(feature = "hpu") {
+        Backend::Hpu
+    } else {
+        Backend::Cpu
+    }
+}

--- a/utils/benchmark_spec/src/lib.rs
+++ b/utils/benchmark_spec/src/lib.rs
@@ -3,14 +3,51 @@ mod bench_crate;
 pub mod tfhe;
 mod traits;
 
-pub use backend::Backend;
+pub use backend::{Backend, bench_backend_from_cfg};
 pub use bench_crate::BenchCrate;
 use serde::Serialize;
+use std::fs::{File, OpenOptions};
+use std::io::Write;
+use std::path::Path;
 use std::{env, fmt};
 pub use tfhe::hlapi::HlapiBench;
 pub use tfhe::{HlIntegerOp, TfheLayer};
 
-#[derive(Serialize)]
+use crate::tfhe::hlapi::dex::Dex;
+use crate::tfhe::hlapi::erc7984::Erc7984;
+
+pub struct CsvResultWriter {
+    file: File,
+}
+
+impl CsvResultWriter {
+    pub fn new(file_name: &str) -> Self {
+        let file_path = Path::new(file_name);
+        Self::from_path(file_path)
+    }
+
+    pub fn from_path(path: &Path) -> Self {
+        if !path.exists() {
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent).expect("cannot create parent dirs");
+            }
+            File::create(path).expect("cannot create result file");
+        }
+        let file = OpenOptions::new()
+            .append(true)
+            .open(path)
+            .expect("cannot open result file");
+        Self { file }
+    }
+
+    pub fn write_result(&mut self, name: &str, value: usize) {
+        let line = format!("{name},{value}\n");
+        let error_message = format!("cannot write {name} result into file");
+        self.file.write_all(line.as_bytes()).expect(&error_message);
+    }
+}
+
+#[derive(Serialize, Clone, Copy)]
 pub enum OperandType {
     CipherText,
     PlainText,
@@ -22,14 +59,36 @@ impl OperandType {
     }
 }
 
-#[derive(Serialize)]
+/// Benchmark type driven by the `__TFHE_RS_BENCH_TYPE` environment variable.
+///
+/// Only `Latency` and `Throughput` can come from the environment; `PbsCount`
+/// is hard-coded at specific call sites.
+#[derive(Clone, Copy, Serialize)]
 pub enum BenchmarkType {
     Latency,
     Throughput,
 }
 
+/// The metric being recorded by a benchmark, used in [`BenchmarkSpec`].
+#[derive(Clone, Copy, Serialize)]
+pub enum BenchmarkMetric {
+    Latency,
+    Throughput,
+    PbsCount,
+}
+
+impl From<BenchmarkType> for BenchmarkMetric {
+    fn from(ct: BenchmarkType) -> Self {
+        match ct {
+            BenchmarkType::Latency => BenchmarkMetric::Latency,
+            BenchmarkType::Throughput => BenchmarkMetric::Throughput,
+        }
+    }
+}
+
 impl BenchmarkType {
-    pub fn from_env() -> Result<Self, String> {
+    /// Retrieves the benchmark type from the environment variable `__TFHE_RS_BENCH_TYPE`.
+    fn from_env() -> Result<Self, String> {
         let raw_value = env::var("__TFHE_RS_BENCH_TYPE").unwrap_or("latency".to_string());
         match raw_value.to_lowercase().as_str() {
             "latency" => Ok(BenchmarkType::Latency),
@@ -39,6 +98,9 @@ impl BenchmarkType {
     }
 }
 
+/// Retrieves the benchmark type from the environment variable `__TFHE_RS_BENCH_TYPE`.
+///
+/// Returns only `Latency` or `Throughput` — never `PbsCount`.
 pub fn get_bench_type() -> &'static BenchmarkType {
     use std::sync::OnceLock;
     static BENCH_TYPE: OnceLock<BenchmarkType> = OnceLock::new();
@@ -48,7 +110,7 @@ pub fn get_bench_type() -> &'static BenchmarkType {
 /// Enforces the naming convention for benchmark IDs.
 ///
 /// ```text
-/// {crate}::{layer}::{bench}::{op}(::{backend})?(::throughput)?::{param}(::scalar)?(::{type})?
+/// {crate}::{layer}::{bench}::{op}(::{backend})?(::{benchmark_type})?::{param}(::scalar)?(::{type})?(::{num_elements}_elements)?
 /// ```
 ///
 /// `param_name` and `type_name` are kept as `&str` because their values
@@ -58,9 +120,10 @@ pub struct BenchmarkSpec<'a> {
     pub bench_crate: BenchCrate,
     pub backend: Backend,
     pub param_name: &'a str,
-    pub operand_type: &'a OperandType,
+    pub operand_type: OperandType,
     pub type_name: Option<&'a str>,
-    pub bench_type: &'a BenchmarkType,
+    pub bench_type: BenchmarkMetric,
+    pub num_elements: Option<usize>,
 }
 
 impl<'a> BenchmarkSpec<'a> {
@@ -68,9 +131,10 @@ impl<'a> BenchmarkSpec<'a> {
         bench_crate: BenchCrate,
         backend: Backend,
         param_name: &'a str,
-        operand_type: &'a OperandType,
+        operand_type: OperandType,
         type_name: Option<&'a str>,
-        bench_type: &'a BenchmarkType,
+        bench_type: impl Into<BenchmarkMetric>,
+        num_elements: Option<usize>,
     ) -> Self {
         Self {
             bench_crate,
@@ -78,25 +142,63 @@ impl<'a> BenchmarkSpec<'a> {
             param_name,
             operand_type,
             type_name,
-            bench_type,
+            bench_type: bench_type.into(),
+            num_elements,
         }
     }
 
-    pub fn new_hlapi(
+    pub fn new_hlapi_ops(
         hlapi_op: HlIntegerOp,
         param_name: &'a str,
-        operand_type: &'a OperandType,
+        operand_type: OperandType,
         type_name: Option<&'a str>,
-        bench_type: &'a BenchmarkType,
-        backend: Backend,
+        bench_type: impl Into<BenchmarkMetric>,
     ) -> Self {
         Self {
             bench_crate: BenchCrate::Tfhe(TfheLayer::Hlapi(HlapiBench::Ops(hlapi_op))),
-            backend,
+            backend: bench_backend_from_cfg(),
             param_name,
             operand_type,
             type_name,
-            bench_type,
+            bench_type: bench_type.into(),
+            num_elements: None,
+        }
+    }
+
+    pub fn new_hlapi_erc7984(
+        hlapi_erc7984_op: Erc7984,
+        param_name: &'a str,
+        operand_type: OperandType,
+        type_name: Option<&'a str>,
+        bench_type: impl Into<BenchmarkMetric>,
+        num_elements: Option<usize>,
+    ) -> Self {
+        Self {
+            bench_crate: BenchCrate::Tfhe(TfheLayer::Hlapi(HlapiBench::Erc7984(hlapi_erc7984_op))),
+            backend: bench_backend_from_cfg(),
+            param_name,
+            operand_type,
+            type_name,
+            bench_type: bench_type.into(),
+            num_elements,
+        }
+    }
+    pub fn new_hlapi_dex(
+        hlapi_dex: Dex,
+        param_name: &'a str,
+        operand_type: OperandType,
+        type_name: Option<&'a str>,
+        bench_type: impl Into<BenchmarkMetric>,
+        num_elements: Option<usize>,
+    ) -> Self {
+        Self {
+            bench_crate: BenchCrate::Tfhe(TfheLayer::Hlapi(HlapiBench::Dex(hlapi_dex))),
+            backend: bench_backend_from_cfg(),
+            param_name,
+            operand_type,
+            type_name,
+            bench_type: bench_type.into(),
+            num_elements,
         }
     }
 }
@@ -107,8 +209,10 @@ impl fmt::Display for BenchmarkSpec<'_> {
         if !matches!(self.backend, Backend::Cpu) {
             write!(f, "::{}", self.backend)?;
         }
-        if matches!(self.bench_type, BenchmarkType::Throughput) {
-            write!(f, "::throughput")?;
+        match self.bench_type {
+            BenchmarkMetric::Throughput => write!(f, "::throughput")?,
+            BenchmarkMetric::PbsCount => write!(f, "::pbs_count")?,
+            BenchmarkMetric::Latency => {}
         }
         write!(f, "::{}", self.param_name)?;
         if self.operand_type.is_scalar() {
@@ -116,6 +220,9 @@ impl fmt::Display for BenchmarkSpec<'_> {
         }
         if let Some(type_name) = self.type_name {
             write!(f, "::{type_name}")?;
+        }
+        if let Some(num_elements) = self.num_elements {
+            write!(f, "::{num_elements}_elements")?;
         }
         Ok(())
     }
@@ -127,13 +234,12 @@ mod tests {
 
     #[test]
     fn hlapi_cpu_latency() {
-        let spec = BenchmarkSpec::new(
-            BenchCrate::Tfhe(TfheLayer::Hlapi(HlapiBench::Ops(HlIntegerOp::Add))),
-            Backend::Cpu,
+        let spec = BenchmarkSpec::new_hlapi_ops(
+            HlIntegerOp::Add,
             "PARAM_MESSAGE_2_CARRY_2",
-            &OperandType::CipherText,
+            OperandType::CipherText,
             Some("FheUint64"),
-            &BenchmarkType::Latency,
+            BenchmarkMetric::Latency,
         );
         assert_eq!(
             spec.to_string(),
@@ -147,9 +253,10 @@ mod tests {
             BenchCrate::Tfhe(TfheLayer::Hlapi(HlapiBench::Ops(HlIntegerOp::Mul))),
             Backend::Cuda,
             "PARAM_MESSAGE_2_CARRY_2",
-            &OperandType::CipherText,
+            OperandType::CipherText,
             Some("FheUint128"),
-            &BenchmarkType::Latency,
+            BenchmarkMetric::Latency,
+            None,
         );
         assert_eq!(
             spec.to_string(),
@@ -163,9 +270,10 @@ mod tests {
             BenchCrate::Tfhe(TfheLayer::Hlapi(HlapiBench::Ops(HlIntegerOp::Add))),
             Backend::Hpu,
             "PARAM_MESSAGE_2_CARRY_2",
-            &OperandType::CipherText,
+            OperandType::CipherText,
             Some("FheUint64"),
-            &BenchmarkType::Throughput,
+            BenchmarkMetric::Throughput,
+            None,
         );
         assert_eq!(
             spec.to_string(),
@@ -175,13 +283,12 @@ mod tests {
 
     #[test]
     fn hlapi_scalar() {
-        let spec = BenchmarkSpec::new(
-            BenchCrate::Tfhe(TfheLayer::Hlapi(HlapiBench::Ops(HlIntegerOp::LeftShift))),
-            Backend::Cpu,
+        let spec = BenchmarkSpec::new_hlapi_ops(
+            HlIntegerOp::LeftShift,
             "PARAM_MESSAGE_2_CARRY_2",
-            &OperandType::PlainText,
+            OperandType::PlainText,
             Some("FheUint64"),
-            &BenchmarkType::Latency,
+            BenchmarkMetric::Latency,
         );
         assert_eq!(
             spec.to_string(),
@@ -191,17 +298,166 @@ mod tests {
 
     #[test]
     fn hlapi_no_type_name() {
-        let spec = BenchmarkSpec::new(
-            BenchCrate::Tfhe(TfheLayer::Hlapi(HlapiBench::Ops(HlIntegerOp::Neg))),
-            Backend::Cpu,
+        let spec = BenchmarkSpec::new_hlapi_ops(
+            HlIntegerOp::Neg,
             "PARAM_MESSAGE_2_CARRY_2",
-            &OperandType::CipherText,
+            OperandType::CipherText,
             None,
-            &BenchmarkType::Latency,
+            BenchmarkMetric::Latency,
         );
         assert_eq!(
             spec.to_string(),
             "tfhe::hlapi::ops::neg::PARAM_MESSAGE_2_CARRY_2"
+        );
+    }
+
+    #[test]
+    fn hlapi_erc7984_with_num_elements() {
+        use crate::tfhe::hlapi::erc7984::TransferFlavor;
+
+        let spec = BenchmarkSpec::new_hlapi_erc7984(
+            Erc7984::Transfer(TransferFlavor::Whitepaper),
+            "PARAM_MESSAGE_2_CARRY_2",
+            OperandType::CipherText,
+            None,
+            BenchmarkMetric::Latency,
+            Some(10),
+        );
+        assert_eq!(
+            spec.to_string(),
+            "tfhe::hlapi::erc7984::transfer::whitepaper::PARAM_MESSAGE_2_CARRY_2::10_elements"
+        );
+    }
+
+    #[test]
+    fn hlapi_erc7984_without_num_elements() {
+        use crate::tfhe::hlapi::erc7984::TransferFlavor;
+
+        let spec = BenchmarkSpec::new_hlapi_erc7984(
+            Erc7984::Transfer(TransferFlavor::NoCmux),
+            "PARAM_MESSAGE_2_CARRY_2",
+            OperandType::CipherText,
+            None,
+            BenchmarkMetric::Latency,
+            None,
+        );
+        assert_eq!(
+            spec.to_string(),
+            "tfhe::hlapi::erc7984::transfer::no_cmux::PARAM_MESSAGE_2_CARRY_2"
+        );
+    }
+
+    #[test]
+    fn hlapi_erc7984_num_elements_with_backend() {
+        use crate::tfhe::hlapi::erc7984::TransferFlavor;
+
+        let spec = BenchmarkSpec::new(
+            BenchCrate::Tfhe(TfheLayer::Hlapi(HlapiBench::Erc7984(Erc7984::Transfer(
+                TransferFlavor::Overflow,
+            )))),
+            Backend::Cuda,
+            "PARAM_MESSAGE_2_CARRY_2",
+            OperandType::CipherText,
+            None,
+            BenchmarkMetric::Latency,
+            Some(5),
+        );
+        assert_eq!(
+            spec.to_string(),
+            "tfhe::hlapi::erc7984::transfer::overflow::cuda::PARAM_MESSAGE_2_CARRY_2::5_elements"
+        );
+    }
+
+    #[test]
+    fn hlapi_erc7984_num_elements_with_throughput() {
+        use crate::tfhe::hlapi::erc7984::TransferFlavor;
+
+        let spec = BenchmarkSpec::new_hlapi_erc7984(
+            Erc7984::Transfer(TransferFlavor::Safe),
+            "PARAM_MESSAGE_2_CARRY_2",
+            OperandType::CipherText,
+            None,
+            BenchmarkMetric::Throughput,
+            Some(20),
+        );
+        assert_eq!(
+            spec.to_string(),
+            "tfhe::hlapi::erc7984::transfer::safe::throughput::PARAM_MESSAGE_2_CARRY_2::20_elements"
+        );
+    }
+
+    #[test]
+    fn hlapi_erc7984_with_pbs_count() {
+        use crate::tfhe::hlapi::erc7984::TransferFlavor;
+
+        let spec = BenchmarkSpec::new_hlapi_erc7984(
+            Erc7984::Transfer(TransferFlavor::Safe),
+            "PARAM_MESSAGE_2_CARRY_2",
+            OperandType::CipherText,
+            None,
+            BenchmarkMetric::PbsCount,
+            None,
+        );
+        assert_eq!(
+            spec.to_string(),
+            "tfhe::hlapi::erc7984::transfer::safe::pbs_count::PARAM_MESSAGE_2_CARRY_2"
+        );
+    }
+
+    #[test]
+    fn hlapi_dex_swap_request_latency() {
+        use crate::tfhe::hlapi::dex::DexFlavor;
+
+        let spec = BenchmarkSpec::new_hlapi_dex(
+            Dex::SwapRequest(DexFlavor::Whitepaper),
+            "PARAM_MESSAGE_2_CARRY_2",
+            OperandType::CipherText,
+            Some("FheUint64"),
+            BenchmarkMetric::Latency,
+            None,
+        );
+        assert_eq!(
+            spec.to_string(),
+            "tfhe::hlapi::dex::swap_request::whitepaper::PARAM_MESSAGE_2_CARRY_2::FheUint64"
+        );
+    }
+
+    #[test]
+    fn hlapi_dex_swap_claim_throughput_with_elements() {
+        use crate::tfhe::hlapi::dex::DexFlavor;
+
+        let spec = BenchmarkSpec::new(
+            BenchCrate::Tfhe(TfheLayer::Hlapi(HlapiBench::Dex(Dex::SwapClaim(
+                DexFlavor::NoCmux,
+            )))),
+            Backend::Cuda,
+            "PARAM_MESSAGE_2_CARRY_2",
+            OperandType::CipherText,
+            Some("FheUint64"),
+            BenchmarkMetric::Throughput,
+            Some(10),
+        );
+        assert_eq!(
+            spec.to_string(),
+            "tfhe::hlapi::dex::swap_claim::no_cmux::cuda::throughput::PARAM_MESSAGE_2_CARRY_2::FheUint64::10_elements"
+        );
+    }
+
+    #[test]
+    fn hlapi_dex_with_pbs_count() {
+        use crate::tfhe::hlapi::dex::DexFlavor;
+
+        let spec = BenchmarkSpec::new_hlapi_dex(
+            Dex::SwapRequest(DexFlavor::Finalize),
+            "PARAM_MESSAGE_2_CARRY_2",
+            OperandType::CipherText,
+            Some("FheUint64"),
+            BenchmarkMetric::PbsCount,
+            None,
+        );
+        assert_eq!(
+            spec.to_string(),
+            "tfhe::hlapi::dex::swap_request::finalize::pbs_count::PARAM_MESSAGE_2_CARRY_2::FheUint64"
         );
     }
 }

--- a/utils/benchmark_spec/src/tfhe/hlapi/dex.rs
+++ b/utils/benchmark_spec/src/tfhe/hlapi/dex.rs
@@ -1,0 +1,37 @@
+use core::fmt;
+
+use strum::Display;
+
+use crate::traits::SpecFmt;
+
+/// DEX (decentralized exchange) benchmark operations for the HLAPI layer.
+#[derive(Clone, Copy, Display)]
+#[strum(serialize_all = "snake_case")]
+pub enum Dex {
+    SwapRequest(DexFlavor),
+    SwapClaim(DexFlavor),
+}
+
+impl Dex {
+    fn op(&self) -> &dyn fmt::Display {
+        match self {
+            Dex::SwapRequest(op) => op,
+            Dex::SwapClaim(op) => op,
+        }
+    }
+}
+
+impl SpecFmt for Dex {
+    fn fmt_spec(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "::{}::{}", self, self.op())
+    }
+}
+
+#[derive(Clone, Copy, Display)]
+#[strum(serialize_all = "snake_case")]
+pub enum DexFlavor {
+    Whitepaper,
+    NoCmux,
+    Prepare,
+    Finalize,
+}

--- a/utils/benchmark_spec/src/tfhe/hlapi/erc7984.rs
+++ b/utils/benchmark_spec/src/tfhe/hlapi/erc7984.rs
@@ -1,0 +1,37 @@
+use core::fmt;
+
+use strum::Display;
+
+use crate::traits::SpecFmt;
+
+/// ERC-7984 token transfer benchmark operations for the HLAPI layer.
+#[derive(Clone, Copy, Display)]
+#[strum(serialize_all = "snake_case")]
+pub enum Erc7984 {
+    Transfer(TransferFlavor),
+}
+
+impl Erc7984 {
+    fn op(&self) -> &dyn fmt::Display {
+        match self {
+            Erc7984::Transfer(op) => op,
+        }
+    }
+}
+
+impl SpecFmt for Erc7984 {
+    fn fmt_spec(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "::{}::{}", self, self.op())
+    }
+}
+
+#[derive(Clone, Copy, Display)]
+#[strum(serialize_all = "snake_case")]
+pub enum TransferFlavor {
+    Whitepaper,
+    NoCmux,
+    Overflow,
+    Safe,
+    HpuOptim,
+    HpuSimd,
+}

--- a/utils/benchmark_spec/src/tfhe/hlapi/mod.rs
+++ b/utils/benchmark_spec/src/tfhe/hlapi/mod.rs
@@ -1,3 +1,8 @@
+pub mod dex;
+pub mod erc7984;
+
+use dex::Dex;
+use erc7984::Erc7984;
 use std::fmt;
 use strum::Display;
 
@@ -17,18 +22,23 @@ pub use super::hl_integer_op::HlIntegerOp;
 #[strum(serialize_all = "snake_case")]
 pub enum HlapiBench {
     Ops(HlIntegerOp),
+    Erc7984(Erc7984),
+    Dex(Dex),
 }
 
 impl HlapiBench {
-    fn op(&self) -> &dyn fmt::Display {
+    fn op(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            HlapiBench::Ops(op) => op,
+            HlapiBench::Ops(op) => write!(f, "::{op}"),
+            HlapiBench::Erc7984(op) => op.fmt_spec(f),
+            HlapiBench::Dex(op) => op.fmt_spec(f),
         }
     }
 }
 
 impl SpecFmt for HlapiBench {
     fn fmt_spec(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "::{}::{}", self, self.op())
+        write!(f, "::{}", self)?;
+        self.op(f)
     }
 }


### PR DESCRIPTION
pr to use the bench specification on for dex and erc7984

there is also a refacto to have two different type for benchmark type
one dedicated to the pattern matchin to know which bench we will execute and one for the bench spec this allow us to add pbs count which is specific erc7984 and dex bench

also we added the num element field in bench id so it could be useful in another pr to add it for all the throughput

Unit tests was made by AI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3454)
<!-- Reviewable:end -->
