### PR TITLE
chore(test): refacto around noise check test and json output

### DIFF
--- a/tfhe/src/integer/gpu/server_key/radix/tests_noise_distribution/br_dp_ks_ms.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/tests_noise_distribution/br_dp_ks_ms.rs
@@ -26,10 +26,10 @@ use crate::shortint::server_key::tests::noise_distribution::utils::noise_simulat
     NoiseSimulationLweKeyswitchKey, NoiseSimulationModulus,
 };
 use crate::shortint::server_key::tests::noise_distribution::utils::to_json::{
-    write_empty_json_file, write_to_json_file, NoiseCheckWithNormalityCheck, TestResult,
+    TestJsonGuard, TestResult,
 };
 use crate::shortint::server_key::tests::noise_distribution::utils::{
-    mean_and_variance_check, normality_check, pfail_check, update_ap_params_for_pfail,
+    mean_and_variance_check, noise_check, normality_check, pfail_check, update_ap_params_for_pfail,
     DecryptionAndNoiseResult, NoiseSample, PfailTestMeta, PfailTestResult,
 };
 use crate::this_function_name;
@@ -41,12 +41,8 @@ use rayon::iter::{IntoParallelIterator, ParallelIterator};
 /// Test function to verify that the noise checking tools match the actual atomic patterns
 /// implemented in shortint for GPU
 fn sanity_check_encrypt_br_dp_ks_pbs_gpu(meta_params: MetaParameters, filename_suffix: &str) {
-    write_empty_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-    )
-    .unwrap();
+    let function_name = this_function_name!();
+    let guard = TestJsonGuard::new(&meta_params, filename_suffix, function_name.as_str()).unwrap();
     let atomic_params = meta_params.compute_parameters;
     let gpu_index = 0;
     let streams = CudaStreams::new_single_gpu(GpuIndex::new(gpu_index));
@@ -170,15 +166,9 @@ fn sanity_check_encrypt_br_dp_ks_pbs_gpu(meta_params: MetaParameters, filename_s
         .iter()
         .all(|(lhs, rhs)| lhs.as_view() == rhs.as_view());
 
-    write_to_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-        res_cond,
-        None,
-        TestResult::Empty {},
-    )
-    .unwrap();
+    guard
+        .write_results(res_cond, None, TestResult::Empty {})
+        .unwrap();
 
     // We check each step to preserve failure details and print the invalid case if one occurs
     for (after_pbs_ct, shortint_res_ct) in results.iter() {
@@ -372,12 +362,8 @@ fn encrypt_br_dp_ks_any_ms_pfail_helper_gpu(
 }
 
 fn noise_check_encrypt_br_dp_ks_ms_noise(meta_params: MetaParameters, filename_suffix: &str) {
-    write_empty_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-    )
-    .unwrap();
+    let function_name = this_function_name!();
+    let guard = TestJsonGuard::new(&meta_params, filename_suffix, function_name.as_str()).unwrap();
     let params: AtomicPatternParameters = meta_params.compute_parameters;
 
     let noise_simulation_ksk =
@@ -506,39 +492,21 @@ fn noise_check_encrypt_br_dp_ks_ms_noise(meta_params: MetaParameters, filename_s
     }
     let before_ms_normality = normality_check(&noise_samples_before_ms, "before ms", 0.01);
 
-    let (after_ms_is_ok, bounded_variance_measurement, bounded_mean_measurement) =
-        mean_and_variance_check(
-            &noise_samples_after_ms,
-            "after_ms",
-            expected_average_after_ms,
-            after_ms_sim.variance(),
-            params.lwe_noise_distribution(),
-            after_ms_sim.lwe_dimension(),
-            after_ms_sim.modulus().as_f64(),
-        );
+    let mean_variance_result = mean_and_variance_check(
+        &noise_samples_after_ms,
+        "after_ms",
+        expected_average_after_ms,
+        after_ms_sim.variance(),
+        params.lwe_noise_distribution(),
+        after_ms_sim.lwe_dimension(),
+        after_ms_sim.modulus().as_f64(),
+    );
 
-    let before_ms_normality_valid = before_ms_normality.null_hypothesis_is_valid;
-
-    let sanity_check_valid = before_ms_normality_valid && after_ms_is_ok;
-
-    let noise_check =
-        TestResult::NoiseCheckWithNormalityCheck(Box::new(NoiseCheckWithNormalityCheck::new(
-            bounded_variance_measurement,
-            bounded_mean_measurement,
-            before_ms_normality_valid,
-        )));
-
-    write_to_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-        sanity_check_valid,
-        None,
-        noise_check,
-    )
-    .unwrap();
-
-    assert!(sanity_check_valid);
+    noise_check(
+        &guard,
+        mean_variance_result,
+        Some(before_ms_normality.null_hypothesis_is_valid),
+    );
 }
 
 create_gpu_parameterized_stringified_test!(noise_check_encrypt_br_dp_ks_ms_noise {
@@ -548,12 +516,8 @@ create_gpu_parameterized_stringified_test!(noise_check_encrypt_br_dp_ks_ms_noise
 });
 
 fn noise_check_encrypt_br_dp_ks_ms_pfail_gpu(meta_params: MetaParameters, filename_suffix: &str) {
-    write_empty_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-    )
-    .unwrap();
+    let function_name = this_function_name!();
+    let guard = TestJsonGuard::new(&meta_params, filename_suffix, function_name.as_str()).unwrap();
     let (pfail_test_meta, params) = {
         let mut ap_params: AtomicPatternParameters = meta_params.compute_parameters;
 
@@ -631,13 +595,7 @@ fn noise_check_encrypt_br_dp_ks_ms_pfail_gpu(meta_params: MetaParameters, filena
         .sum();
     let test_result = PfailTestResult { measured_fails };
 
-    pfail_check(
-        &pfail_test_meta,
-        test_result,
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-    );
+    pfail_check(&pfail_test_meta, test_result, &guard);
 }
 
 create_gpu_parameterized_stringified_test!(noise_check_encrypt_br_dp_ks_ms_pfail_gpu {

--- a/tfhe/src/integer/gpu/server_key/radix/tests_noise_distribution/br_dp_packingks_ms.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/tests_noise_distribution/br_dp_packingks_ms.rs
@@ -24,12 +24,12 @@ use crate::shortint::server_key::tests::noise_distribution::utils::noise_simulat
     NoiseSimulationLwePackingKeyswitchKey, NoiseSimulationModulus,
 };
 use crate::shortint::server_key::tests::noise_distribution::utils::to_json::{
-    write_empty_json_file, write_to_json_file, NoiseCheckWithNormalityCheck, TestResult,
+    TestJsonGuard, TestResult,
 };
 use crate::shortint::server_key::tests::noise_distribution::utils::{
-    expected_pfail_for_precision, mean_and_variance_check, normality_check, pfail_check,
-    precision_with_padding, update_ap_params_msg_and_carry_moduli, DecryptionAndNoiseResult,
-    NoiseSample, PfailAndPrecision, PfailTestMeta, PfailTestResult,
+    expected_pfail_for_precision, mean_and_variance_check, noise_check, normality_check,
+    pfail_check, precision_with_padding, update_ap_params_msg_and_carry_moduli,
+    DecryptionAndNoiseResult, NoiseSample, PfailAndPrecision, PfailTestMeta, PfailTestResult,
 };
 use crate::shortint::server_key::tests::noise_distribution::{
     should_run_short_pfail_tests_debug, should_use_single_key_debug,
@@ -43,12 +43,8 @@ use rayon::iter::{IntoParallelIterator, ParallelIterator};
 pub const SAMPLES_PER_MSG_PACKING_KS_NOISE: usize = 1000;
 
 fn sanity_check_encrypt_br_dp_packing_ks_ms(meta_params: MetaParameters, filename_suffix: &str) {
-    write_empty_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-    )
-    .unwrap();
+    let function_name = this_function_name!();
+    let guard = TestJsonGuard::new(&meta_params, filename_suffix, function_name.as_str()).unwrap();
     let (params, comp_params) = (
         meta_params.compute_parameters,
         meta_params.compression_parameters.unwrap(),
@@ -151,15 +147,13 @@ fn sanity_check_encrypt_br_dp_packing_ks_ms(meta_params: MetaParameters, filenam
     // Bodies that were not filled are discarded
     after_ms.get_mut_body().as_mut()[lwe_per_glwe.0..].fill(0);
 
-    write_to_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-        after_ms.as_view() == extracted_glwe.as_view(),
-        None,
-        TestResult::Empty {},
-    )
-    .unwrap();
+    guard
+        .write_results(
+            after_ms.as_view() == extracted_glwe.as_view(),
+            None,
+            TestResult::Empty {},
+        )
+        .unwrap();
 
     assert_eq!(after_ms.as_view(), extracted_glwe.as_view());
 }
@@ -419,12 +413,8 @@ fn noise_check_encrypt_br_dp_packing_ks_ms_noise_gpu(
     meta_params: MetaParameters,
     filename_suffix: &str,
 ) {
-    write_empty_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-    )
-    .unwrap();
+    let function_name = this_function_name!();
+    let guard = TestJsonGuard::new(&meta_params, filename_suffix, function_name.as_str()).unwrap();
     let (params, comp_params) = (
         meta_params.compute_parameters,
         meta_params.compression_parameters.unwrap(),
@@ -590,41 +580,23 @@ fn noise_check_encrypt_br_dp_packing_ks_ms_noise_gpu(
     let before_ms_normality =
         normality_check(&noise_samples_before_ms_flattened, "before ms", 0.01);
 
-    let (after_ms_is_ok, bounded_variance_measurement, bounded_mean_measurement) =
-        mean_and_variance_check(
-            &noise_samples_after_ms_flattened,
-            "after_ms",
-            0.0,
-            after_ms_sim.variance_per_occupied_slot(),
-            comp_params.packing_ks_key_noise_distribution(),
-            after_ms_sim
-                .glwe_dimension()
-                .to_equivalent_lwe_dimension(after_ms_sim.polynomial_size()),
-            after_ms_sim.modulus().as_f64(),
-        );
+    let mean_variance_result = mean_and_variance_check(
+        &noise_samples_after_ms_flattened,
+        "after_ms",
+        0.0,
+        after_ms_sim.variance_per_occupied_slot(),
+        comp_params.packing_ks_key_noise_distribution(),
+        after_ms_sim
+            .glwe_dimension()
+            .to_equivalent_lwe_dimension(after_ms_sim.polynomial_size()),
+        after_ms_sim.modulus().as_f64(),
+    );
 
-    let before_ms_normality_valid = before_ms_normality.null_hypothesis_is_valid;
-
-    let sanity_check_valid = before_ms_normality_valid && after_ms_is_ok;
-
-    let noise_check =
-        TestResult::NoiseCheckWithNormalityCheck(Box::new(NoiseCheckWithNormalityCheck::new(
-            bounded_variance_measurement,
-            bounded_mean_measurement,
-            before_ms_normality_valid,
-        )));
-
-    write_to_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-        sanity_check_valid,
-        None,
-        noise_check,
-    )
-    .unwrap();
-
-    assert!(sanity_check_valid);
+    noise_check(
+        &guard,
+        mean_variance_result,
+        Some(before_ms_normality.null_hypothesis_is_valid),
+    );
 }
 create_gpu_parameterized_stringified_test!(noise_check_encrypt_br_dp_packing_ks_ms_noise_gpu {
     TEST_META_PARAM_CPU_2_2_KS_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128,
@@ -635,12 +607,8 @@ fn noise_check_encrypt_br_dp_packing_ks_ms_pfail_gpu(
     meta_params: MetaParameters,
     filename_suffix: &str,
 ) {
-    write_empty_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-    )
-    .unwrap();
+    let function_name = this_function_name!();
+    let guard = TestJsonGuard::new(&meta_params, filename_suffix, function_name.as_str()).unwrap();
     let (pfail_test_meta, params, comp_params) = {
         let (mut params, comp_params) = (
             meta_params.compute_parameters,
@@ -813,13 +781,7 @@ fn noise_check_encrypt_br_dp_packing_ks_ms_pfail_gpu(
 
     let test_result = PfailTestResult { measured_fails };
 
-    pfail_check(
-        &pfail_test_meta,
-        test_result,
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-    );
+    pfail_check(&pfail_test_meta, test_result, &guard);
 }
 
 create_gpu_parameterized_stringified_test!(noise_check_encrypt_br_dp_packing_ks_ms_pfail_gpu {

--- a/tfhe/src/integer/gpu/server_key/radix/tests_noise_distribution/br_rerand_dp_ks_ms.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/tests_noise_distribution/br_rerand_dp_ks_ms.rs
@@ -34,8 +34,9 @@ use crate::shortint::parameters::{
     ShortintCompactCiphertextListCastingMode
 };
 use crate::shortint::server_key::tests::noise_distribution::utils::{
-    mean_and_variance_check, normality_check, pfail_check, update_ap_params_for_pfail,
-    DecryptionAndNoiseResult, NoiseSample, PfailTestMeta, PfailTestResult,
+    mean_and_variance_check, noise_check, normality_check, pfail_check,
+    update_ap_params_for_pfail, DecryptionAndNoiseResult, NoiseSample, PfailTestMeta,
+    PfailTestResult,
 };
 use crate::shortint::server_key::tests::noise_distribution::{
     should_run_short_pfail_tests_debug, should_use_single_key_debug,
@@ -70,7 +71,7 @@ use crate::core_crypto::prelude::LweCiphertext;
 use crate::integer::gpu::server_key::radix::{CudaRadixCiphertext, CudaRadixCiphertextInfo};
 use crate::integer::ClientKey;
 use crate::shortint::server_key::tests::noise_distribution::utils::to_json::{
-    write_empty_json_file, write_to_json_file, NoiseCheckWithNormalityCheck, TestResult,
+    TestJsonGuard, TestResult,
 };
 
 use crate::this_function_name;
@@ -498,12 +499,8 @@ fn noise_check_encrypt_br_rerand_dp_ks_ms_noise_gpu(
     meta_params: MetaParameters,
     filename_suffix: &str,
 ) {
-    write_empty_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-    )
-    .unwrap();
+    let function_name = this_function_name!();
+    let guard = TestJsonGuard::new(&meta_params, filename_suffix, function_name.as_str()).unwrap();
     let (params, re_rand_parameters, compression_params) = {
         let compute_params = meta_params.compute_parameters;
         (
@@ -747,38 +744,21 @@ fn noise_check_encrypt_br_rerand_dp_ks_ms_noise_gpu(
 
     let before_ms_normality = normality_check(&noise_samples_before_ms, "before ms", 0.01);
 
-    let (after_ms_is_ok, bounded_variance_measurement, bounded_mean_measurement) =
-        mean_and_variance_check(
-            &noise_samples_after_ms,
-            "after_ms",
-            expected_average_after_ms,
-            after_ms_sim.variance(),
-            params.lwe_noise_distribution(),
-            after_ms_sim.lwe_dimension(),
-            after_ms_sim.modulus().as_f64(),
-        );
-    let before_ms_normality_valid = before_ms_normality.null_hypothesis_is_valid;
+    let mean_variance_result = mean_and_variance_check(
+        &noise_samples_after_ms,
+        "after_ms",
+        expected_average_after_ms,
+        after_ms_sim.variance(),
+        params.lwe_noise_distribution(),
+        after_ms_sim.lwe_dimension(),
+        after_ms_sim.modulus().as_f64(),
+    );
 
-    let noise_check_valid = before_ms_normality_valid && after_ms_is_ok;
-
-    let noise_check =
-        TestResult::NoiseCheckWithNormalityCheck(Box::new(NoiseCheckWithNormalityCheck::new(
-            bounded_variance_measurement,
-            bounded_mean_measurement,
-            before_ms_normality_valid,
-        )));
-
-    write_to_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-        noise_check_valid,
-        None,
-        noise_check,
-    )
-    .unwrap();
-
-    assert!(noise_check_valid);
+    noise_check(
+        &guard,
+        mean_variance_result,
+        Some(before_ms_normality.null_hypothesis_is_valid),
+    );
 }
 
 create_gpu_parameterized_stringified_test!(noise_check_encrypt_br_rerand_dp_ks_ms_noise_gpu {
@@ -791,12 +771,8 @@ fn noise_check_encrypt_br_rerand_dp_ks_ms_pfail_gpu(
     meta_params: MetaParameters,
     filename_suffix: &str,
 ) {
-    write_empty_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-    )
-    .unwrap();
+    let function_name = this_function_name!();
+    let guard = TestJsonGuard::new(&meta_params, filename_suffix, function_name.as_str()).unwrap();
     let (params, re_rand_parameters, compression_params) = {
         let compute_params = meta_params.compute_parameters;
         (
@@ -934,13 +910,7 @@ fn noise_check_encrypt_br_rerand_dp_ks_ms_pfail_gpu(
 
     let test_result = PfailTestResult { measured_fails };
 
-    pfail_check(
-        &pfail_test_meta,
-        test_result,
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-    );
+    pfail_check(&pfail_test_meta, test_result, &guard);
 }
 
 create_gpu_parameterized_stringified_test!(noise_check_encrypt_br_rerand_dp_ks_ms_pfail_gpu {
@@ -953,12 +923,8 @@ fn sanity_check_encrypt_br_rerand_dp_ks_ms_pbs_gpu(
     meta_params: MetaParameters,
     filename_suffix: &str,
 ) {
-    write_empty_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-    )
-    .unwrap();
+    let function_name = this_function_name!();
+    let guard = TestJsonGuard::new(&meta_params, filename_suffix, function_name.as_str()).unwrap();
     let (compute_params, re_rand_parameters, compression_params) = {
         let compute_params = meta_params
             .compute_parameters
@@ -1252,15 +1218,9 @@ fn sanity_check_encrypt_br_rerand_dp_ks_ms_pbs_gpu(
         .iter()
         .all(|(lhs, rhs)| lhs.as_view() == rhs.as_view());
 
-    write_to_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-        res_cond,
-        None,
-        TestResult::Empty {},
-    )
-    .unwrap();
+    guard
+        .write_results(res_cond, None, TestResult::Empty {})
+        .unwrap();
     // We check each step to preserve failure details and print the invalid case if one occurs
     for (after_pbs_ct, shortint_res_ct) in results.iter() {
         assert_eq!(after_pbs_ct.as_view(), shortint_res_ct.as_view());

--- a/tfhe/src/integer/gpu/server_key/radix/tests_noise_distribution/cpk_ks_ms.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/tests_noise_distribution/cpk_ks_ms.rs
@@ -16,13 +16,14 @@ use crate::shortint::server_key::tests::noise_distribution::utils::noise_simulat
     NoiseSimulationModulusSwitchConfig,
 };
 use crate::shortint::server_key::tests::noise_distribution::utils::to_json::{
-    write_empty_json_file, write_to_json_file, NoiseCheckWithNormalityCheck, TestResult,
+    TestJsonGuard, TestResult,
 };
 use crate::this_function_name;
 use crate::integer::gpu::server_key::radix::LweCiphertextList;
 use crate::shortint::server_key::tests::noise_distribution::utils::{
-    mean_and_variance_check, normality_check, pfail_check, update_ap_params_for_pfail,
-    DecryptionAndNoiseResult, NoiseSample, PfailTestMeta, PfailTestResult,
+    mean_and_variance_check, noise_check, normality_check, pfail_check,
+    update_ap_params_for_pfail, DecryptionAndNoiseResult, NoiseSample, PfailTestMeta,
+    PfailTestResult,
 };
 use crate::shortint::server_key::tests::noise_distribution::{
     should_run_short_pfail_tests_debug, should_use_single_key_debug,
@@ -272,12 +273,8 @@ fn cpk_ks_any_ms_pfail_helper_gpu(
 }
 
 fn noise_check_encrypt_cpk_ks_ms_noise_gpu(meta_params: MetaParameters, filename_suffix: &str) {
-    write_empty_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-    )
-    .unwrap();
+    let function_name = this_function_name!();
+    let guard = TestJsonGuard::new(&meta_params, filename_suffix, function_name.as_str()).unwrap();
     let (params, cpk_params, ksk_ds_params) = {
         let compute_params = meta_params.compute_parameters;
         let dedicated_cpk_params = meta_params.dedicated_compact_public_key_parameters.unwrap();
@@ -422,39 +419,21 @@ fn noise_check_encrypt_cpk_ks_ms_noise_gpu(meta_params: MetaParameters, filename
 
     let before_ms_normality = normality_check(&noise_samples_before_ms, "before ms", 0.01);
 
-    let (after_ms_is_ok, bounded_variance_measurement, bounded_mean_measurement) =
-        mean_and_variance_check(
-            &noise_samples_after_ms,
-            "after_ms",
-            expected_average_after_ms,
-            after_ms_sim.variance(),
-            params.lwe_noise_distribution(),
-            after_ms_sim.lwe_dimension(),
-            after_ms_sim.modulus().as_f64(),
-        );
+    let mean_variance_result = mean_and_variance_check(
+        &noise_samples_after_ms,
+        "after_ms",
+        expected_average_after_ms,
+        after_ms_sim.variance(),
+        params.lwe_noise_distribution(),
+        after_ms_sim.lwe_dimension(),
+        after_ms_sim.modulus().as_f64(),
+    );
 
-    let before_ms_normality_valid = before_ms_normality.null_hypothesis_is_valid;
-
-    let sanity_check_valid = before_ms_normality_valid && after_ms_is_ok;
-
-    let noise_check =
-        TestResult::NoiseCheckWithNormalityCheck(Box::new(NoiseCheckWithNormalityCheck::new(
-            bounded_variance_measurement,
-            bounded_mean_measurement,
-            before_ms_normality_valid,
-        )));
-
-    write_to_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-        sanity_check_valid,
-        None,
-        noise_check,
-    )
-    .unwrap();
-
-    assert!(sanity_check_valid);
+    noise_check(
+        &guard,
+        mean_variance_result,
+        Some(before_ms_normality.null_hypothesis_is_valid),
+    );
 }
 
 create_gpu_parameterized_stringified_test!(noise_check_encrypt_cpk_ks_ms_noise_gpu {
@@ -463,12 +442,8 @@ create_gpu_parameterized_stringified_test!(noise_check_encrypt_cpk_ks_ms_noise_g
 });
 
 fn noise_check_encrypt_cpk_ks_ms_pfail_gpu(meta_params: MetaParameters, filename_suffix: &str) {
-    write_empty_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-    )
-    .unwrap();
+    let function_name = this_function_name!();
+    let guard = TestJsonGuard::new(&meta_params, filename_suffix, function_name.as_str()).unwrap();
     let (params, cpk_params, ksk_ds_params) = {
         let compute_params = meta_params.compute_parameters;
         let dedicated_cpk_params = meta_params.dedicated_compact_public_key_parameters.unwrap();
@@ -573,13 +548,7 @@ fn noise_check_encrypt_cpk_ks_ms_pfail_gpu(meta_params: MetaParameters, filename
 
     let test_result = PfailTestResult { measured_fails };
 
-    pfail_check(
-        &pfail_test_meta,
-        test_result,
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-    );
+    pfail_check(&pfail_test_meta, test_result, &guard);
 }
 
 create_gpu_parameterized_stringified_test!(noise_check_encrypt_cpk_ks_ms_pfail_gpu {
@@ -588,12 +557,8 @@ create_gpu_parameterized_stringified_test!(noise_check_encrypt_cpk_ks_ms_pfail_g
 });
 
 fn sanity_check_encrypt_cpk_ks_ms_pbs_gpu(meta_params: MetaParameters, filename_suffix: &str) {
-    write_empty_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-    )
-    .unwrap();
+    let function_name = this_function_name!();
+    let guard = TestJsonGuard::new(&meta_params, filename_suffix, function_name.as_str()).unwrap();
     let (params, cpk_params, ksk_ds_params) = {
         let compute_params = meta_params.compute_parameters;
         let dedicated_cpk_params = meta_params.dedicated_compact_public_key_parameters.unwrap();
@@ -734,15 +699,9 @@ fn sanity_check_encrypt_cpk_ks_ms_pbs_gpu(meta_params: MetaParameters, filename_
 
     let res_cond = results.iter().all(|(lhs, rhs)| lhs == rhs);
 
-    write_to_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-        res_cond,
-        None,
-        TestResult::Empty {},
-    )
-    .unwrap();
+    guard
+        .write_results(res_cond, None, TestResult::Empty {})
+        .unwrap();
 
     // We check each step to preserve failure details and print the invalid case if one occurs
     for (pbs_result_list, shortint_res) in results.iter() {

--- a/tfhe/src/integer/gpu/server_key/radix/tests_noise_distribution/dp_ks_ms.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/tests_noise_distribution/dp_ks_ms.rs
@@ -25,10 +25,10 @@ use crate::shortint::server_key::tests::noise_distribution::utils::noise_simulat
     DynLwe, NoiseSimulationLwe, NoiseSimulationLweKeyswitchKey, NoiseSimulationModulusSwitchConfig,
 };
 use crate::shortint::server_key::tests::noise_distribution::utils::to_json::{
-    write_empty_json_file, write_to_json_file, NoiseCheckWithNormalityCheck, TestResult,
+    TestJsonGuard, TestResult,
 };
 use crate::shortint::server_key::tests::noise_distribution::utils::{
-    mean_and_variance_check, normality_check, pfail_check, update_ap_params_for_pfail,
+    mean_and_variance_check, noise_check, normality_check, pfail_check, update_ap_params_for_pfail,
     DecryptionAndNoiseResult, NoiseSample, PfailTestMeta, PfailTestResult,
 };
 use crate::shortint::server_key::tests::noise_distribution::{
@@ -42,12 +42,8 @@ use rayon::prelude::*;
 /// Test function to verify that the noise checking tools match the actual atomic patterns
 /// implemented in shortint
 fn sanity_check_encrypt_dp_ks_pbs_gpu(meta_params: MetaParameters, filename_suffix: &str) {
-    write_empty_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-    )
-    .unwrap();
+    let function_name = this_function_name!();
+    let guard = TestJsonGuard::new(&meta_params, filename_suffix, function_name.as_str()).unwrap();
     let block_params = meta_params.compute_parameters;
     let gpu_index = 0;
     let streams = CudaStreams::new_single_gpu(GpuIndex::new(gpu_index));
@@ -168,15 +164,9 @@ fn sanity_check_encrypt_dp_ks_pbs_gpu(meta_params: MetaParameters, filename_suff
         .iter()
         .all(|(lhs, rhs)| lhs.as_view() == rhs.as_view());
 
-    write_to_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-        res_cond,
-        None,
-        TestResult::Empty {},
-    )
-    .unwrap();
+    guard
+        .write_results(res_cond, None, TestResult::Empty {})
+        .unwrap();
 
     // We check each step to preserve failure details and print the invalid case if one occurs
     for (after_pbs_ct, shortint_res_ct) in results.iter() {
@@ -353,12 +343,8 @@ fn encrypt_dp_ks_any_ms_pfail_helper_gpu(
 
 /// GPU version of the noise checking test
 fn noise_check_encrypt_dp_ks_ms_noise_gpu(meta_params: MetaParameters, filename_suffix: &str) {
-    write_empty_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-    )
-    .unwrap();
+    let function_name = this_function_name!();
+    let guard = TestJsonGuard::new(&meta_params, filename_suffix, function_name.as_str()).unwrap();
     let params = meta_params.compute_parameters;
     let noise_simulation_ksk =
         NoiseSimulationLweKeyswitchKey::new_from_atomic_pattern_parameters(params);
@@ -462,39 +448,21 @@ fn noise_check_encrypt_dp_ks_ms_noise_gpu(meta_params: MetaParameters, filename_
 
     let before_ms_normality = normality_check(&noise_samples_before_ms, "before ms", 0.01);
 
-    let (after_ms_is_ok, bounded_variance_measurement, bounded_mean_measurement) =
-        mean_and_variance_check(
-            &noise_samples_after_ms,
-            "after_ms",
-            expected_average_after_ms,
-            after_ms_sim.variance(),
-            params.lwe_noise_distribution(),
-            after_ms_sim.lwe_dimension(),
-            after_ms_sim.modulus().as_f64(),
-        );
+    let mean_variance_result = mean_and_variance_check(
+        &noise_samples_after_ms,
+        "after_ms",
+        expected_average_after_ms,
+        after_ms_sim.variance(),
+        params.lwe_noise_distribution(),
+        after_ms_sim.lwe_dimension(),
+        after_ms_sim.modulus().as_f64(),
+    );
 
-    let before_ms_normality_valid = before_ms_normality.null_hypothesis_is_valid;
-
-    let sanity_check_valid = before_ms_normality_valid && after_ms_is_ok;
-
-    let noise_check =
-        TestResult::NoiseCheckWithNormalityCheck(Box::new(NoiseCheckWithNormalityCheck::new(
-            bounded_variance_measurement,
-            bounded_mean_measurement,
-            before_ms_normality_valid,
-        )));
-
-    write_to_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-        sanity_check_valid,
-        None,
-        noise_check,
-    )
-    .unwrap();
-
-    assert!(sanity_check_valid);
+    noise_check(
+        &guard,
+        mean_variance_result,
+        Some(before_ms_normality.null_hypothesis_is_valid),
+    );
 }
 
 create_gpu_parameterized_stringified_test!(noise_check_encrypt_dp_ks_ms_noise_gpu {
@@ -504,12 +472,8 @@ create_gpu_parameterized_stringified_test!(noise_check_encrypt_dp_ks_ms_noise_gp
 });
 
 fn noise_check_encrypt_dp_ks_ms_pfail_gpu(meta_params: MetaParameters, filename_suffix: &str) {
-    write_empty_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-    )
-    .unwrap();
+    let function_name = this_function_name!();
+    let guard = TestJsonGuard::new(&meta_params, filename_suffix, function_name.as_str()).unwrap();
     let mut ap_params = meta_params.compute_parameters;
     let (pfail_test_meta, params) = {
         let original_message_modulus = ap_params.message_modulus();
@@ -586,13 +550,7 @@ fn noise_check_encrypt_dp_ks_ms_pfail_gpu(meta_params: MetaParameters, filename_
         .sum();
     let test_result = PfailTestResult { measured_fails };
 
-    pfail_check(
-        &pfail_test_meta,
-        test_result,
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-    );
+    pfail_check(&pfail_test_meta, test_result, &guard);
 }
 
 create_gpu_parameterized_stringified_test!(noise_check_encrypt_dp_ks_ms_pfail_gpu {

--- a/tfhe/src/integer/gpu/server_key/radix/tests_noise_distribution/dp_ks_pbs_128_packingks.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/tests_noise_distribution/dp_ks_pbs_128_packingks.rs
@@ -33,10 +33,10 @@ use crate::shortint::server_key::tests::noise_distribution::utils::noise_simulat
     NoiseSimulationLwe, NoiseSimulationLweKeyswitchKey, NoiseSimulationModulusSwitchConfig,
 };
 use crate::shortint::server_key::tests::noise_distribution::utils::to_json::{
-    write_empty_json_file, write_to_json_file, NoiseCheckWithoutNormalityCheck, TestResult,
+    TestJsonGuard, TestResult,
 };
 use crate::shortint::server_key::tests::noise_distribution::utils::{
-    mean_and_variance_check, DecryptionAndNoiseResult, NoiseSample,
+    mean_and_variance_check, noise_check, DecryptionAndNoiseResult, NoiseSample,
 };
 use crate::shortint::{PaddingBit, ShortintEncoding, ShortintParameterSet};
 use crate::{this_function_name, GpuIndex};
@@ -48,12 +48,8 @@ fn sanity_check_encrypt_dp_ks_standard_pbs128_packing_ks_gpu(
     meta_params: MetaParameters,
     filename_suffix: &str,
 ) {
-    write_empty_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-    )
-    .unwrap();
+    let function_name = this_function_name!();
+    let guard = TestJsonGuard::new(&meta_params, filename_suffix, function_name.as_str()).unwrap();
     let (atomic_params, noise_squashing_params, noise_squashing_compression_params) = {
         let meta_noise_squashing_params = meta_params.noise_squashing_parameters.unwrap();
         (
@@ -197,15 +193,13 @@ fn sanity_check_encrypt_dp_ks_standard_pbs128_packing_ks_gpu(
     // Bodies that were not filled are discarded
     after_packing.get_mut_body().as_mut()[lwe_per_glwe.0..].fill(0);
 
-    write_to_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-        after_packing.as_view() == extracted_glwe.as_view(),
-        None,
-        TestResult::Empty {},
-    )
-    .unwrap();
+    guard
+        .write_results(
+            after_packing.as_view() == extracted_glwe.as_view(),
+            None,
+            TestResult::Empty {},
+        )
+        .unwrap();
 
     assert_eq!(after_packing.as_view(), extracted_glwe.as_view());
 }
@@ -216,12 +210,8 @@ fn sanity_check_encrypt_dp_ks_standard_pbs128_gpu(
     meta_params: MetaParameters,
     filename_suffix: &str,
 ) {
-    write_empty_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-    )
-    .unwrap();
+    let function_name = this_function_name!();
+    let guard = TestJsonGuard::new(&meta_params, filename_suffix, function_name.as_str()).unwrap();
     let (params, noise_squashing_params) = {
         let meta_noise_squashing_params = meta_params.noise_squashing_parameters.unwrap();
         (
@@ -375,15 +365,13 @@ fn sanity_check_encrypt_dp_ks_standard_pbs128_gpu(
         })
         .collect();
 
-    write_to_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-        vector_pattern_cpu == vector_non_pattern_cpu,
-        None,
-        TestResult::Empty {},
-    )
-    .unwrap();
+    guard
+        .write_results(
+            vector_pattern_cpu == vector_non_pattern_cpu,
+            None,
+            TestResult::Empty {},
+        )
+        .unwrap();
 
     // Compare that all the results are equivalent
     assert_eq!(vector_pattern_cpu, vector_non_pattern_cpu);
@@ -742,12 +730,8 @@ fn noise_check_encrypt_dp_ks_standard_pbs128_packing_ks_noise_gpu(
     meta_params: MetaParameters,
     filename_suffix: &str,
 ) {
-    write_empty_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-    )
-    .unwrap();
+    let function_name = this_function_name!();
+    let guard = TestJsonGuard::new(&meta_params, filename_suffix, function_name.as_str()).unwrap();
     let (atomic_params, noise_squashing_params, noise_squashing_compression_params) = {
         let meta_noise_squashing_params = meta_params.noise_squashing_parameters.unwrap();
         (
@@ -911,35 +895,17 @@ fn noise_check_encrypt_dp_ks_standard_pbs128_packing_ks_noise_gpu(
         .map(|x| x.value)
         .collect();
 
-    let (after_packing_is_ok, bounded_variance_measurement, bounded_mean_measurement) =
-        mean_and_variance_check(
-            &noise_samples_after_packing_flattened,
-            "after_packing",
-            0.0,
-            after_packing_sim.variance(),
-            noise_squashing_compression_params.packing_ks_key_noise_distribution,
-            after_packing_sim.lwe_dimension(),
-            after_packing_sim.modulus().as_f64(),
-        );
+    let mean_variance_result = mean_and_variance_check(
+        &noise_samples_after_packing_flattened,
+        "after_packing",
+        0.0,
+        after_packing_sim.variance(),
+        noise_squashing_compression_params.packing_ks_key_noise_distribution,
+        after_packing_sim.lwe_dimension(),
+        after_packing_sim.modulus().as_f64(),
+    );
 
-    let noise_check = TestResult::NoiseCheckWithoutNormalityCheck(Box::new(
-        NoiseCheckWithoutNormalityCheck::new(
-            bounded_variance_measurement,
-            bounded_mean_measurement,
-        ),
-    ));
-
-    write_to_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-        after_packing_is_ok,
-        None,
-        noise_check,
-    )
-    .unwrap();
-
-    assert!(after_packing_is_ok);
+    noise_check(&guard, mean_variance_result, None);
 }
 
 create_gpu_parameterized_stringified_test!(

--- a/tfhe/src/shortint/server_key/tests/noise_distribution/br_dp_ks_ms.rs
+++ b/tfhe/src/shortint/server_key/tests/noise_distribution/br_dp_ks_ms.rs
@@ -3,10 +3,10 @@ use super::utils::noise_simulation::{
     NoiseSimulationGenericBootstrapKey, NoiseSimulationGlwe, NoiseSimulationLwe,
     NoiseSimulationLweKeyswitchKey, NoiseSimulationModulusSwitchConfig,
 };
-use super::utils::to_json::{write_to_json_file, TestResult};
+use super::utils::to_json::TestResult;
 use super::utils::traits::*;
 use super::utils::{
-    mean_and_variance_check, normality_check, pfail_check, update_ap_params_for_pfail,
+    mean_and_variance_check, noise_check, normality_check, pfail_check, update_ap_params_for_pfail,
     DecryptionAndNoiseResult, NoiseSample, PfailTestMeta, PfailTestResult,
 };
 use super::{should_run_short_pfail_tests_debug, should_use_single_key_debug};
@@ -26,7 +26,7 @@ use crate::shortint::parameters::{AtomicPatternParameters, CarryModulus, MetaPar
 use crate::shortint::server_key::tests::noise_distribution::utils::noise_simulation::{
     DynLwe, NoiseSimulationModulus,
 };
-use crate::shortint::server_key::tests::noise_distribution::utils::to_json::write_empty_json_file;
+use crate::shortint::server_key::tests::noise_distribution::utils::to_json::TestJsonGuard;
 use crate::shortint::server_key::tests::parameterized_test::create_parameterized_stringified_test;
 use crate::shortint::server_key::ServerKey;
 use crate::shortint::Ciphertext;
@@ -117,12 +117,8 @@ where
 /// Test function to verify that the noise checking tools match the actual atomic patterns
 /// implemented in shortint
 fn sanity_check_encrypt_br_dp_ks_pbs(meta_params: MetaParameters, filename_suffix: &str) {
-    write_empty_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-    )
-    .unwrap();
+    let function_name = this_function_name!();
+    let guard = TestJsonGuard::new(&meta_params, filename_suffix, function_name.as_str()).unwrap();
 
     let params = meta_params
         .compute_parameters
@@ -186,15 +182,9 @@ fn sanity_check_encrypt_br_dp_ks_pbs(meta_params: MetaParameters, filename_suffi
         .iter()
         .all(|(lhs, rhs)| lhs.as_lwe_64() == rhs.ct.as_view());
 
-    write_to_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-        all_results_match,
-        None,
-        TestResult::Empty {},
-    )
-    .unwrap();
+    guard
+        .write_results(all_results_match, None, TestResult::Empty {})
+        .unwrap();
 
     // We check each step to preserve failure details and print the invalid case if one occurs
     for (pbs_result, shortint_res) in results.iter() {
@@ -337,12 +327,8 @@ fn encrypt_br_dp_ks_any_ms_pfail_helper(
 }
 
 fn noise_check_encrypt_br_dp_ks_ms_noise(meta_params: MetaParameters, filename_suffix: &str) {
-    write_empty_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-    )
-    .unwrap();
+    let function_name = this_function_name!();
+    let guard = TestJsonGuard::new(&meta_params, filename_suffix, function_name.as_str()).unwrap();
     let params = meta_params
         .compute_parameters
         .with_deterministic_execution();
@@ -439,40 +425,21 @@ fn noise_check_encrypt_br_dp_ks_ms_noise(meta_params: MetaParameters, filename_s
 
     let before_ms_normality = normality_check(&noise_samples_before_ms, "before ms", 0.01);
 
-    let (after_ms_is_ok, bounded_variance_measurement, bounded_mean_measurement) =
-        mean_and_variance_check(
-            &noise_samples_after_ms,
-            "after_ms",
-            expected_average_after_ms,
-            after_ms_sim.variance(),
-            params.lwe_noise_distribution(),
-            after_ms_sim.lwe_dimension(),
-            after_ms_sim.modulus().as_f64(),
-        );
+    let mean_variance_result = mean_and_variance_check(
+        &noise_samples_after_ms,
+        "after_ms",
+        expected_average_after_ms,
+        after_ms_sim.variance(),
+        params.lwe_noise_distribution(),
+        after_ms_sim.lwe_dimension(),
+        after_ms_sim.modulus().as_f64(),
+    );
 
-    let before_ms_normality_valid = before_ms_normality.null_hypothesis_is_valid;
-
-    let noise_check_valid = before_ms_normality_valid && after_ms_is_ok;
-
-    let noise_check = TestResult::NoiseCheckWithNormalityCheck(Box::new(
-        super::utils::to_json::NoiseCheckWithNormalityCheck::new(
-            bounded_variance_measurement,
-            bounded_mean_measurement,
-            before_ms_normality_valid,
-        ),
-    ));
-
-    write_to_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-        noise_check_valid,
-        None,
-        noise_check,
-    )
-    .unwrap();
-
-    assert!(noise_check_valid);
+    noise_check(
+        &guard,
+        mean_variance_result,
+        Some(before_ms_normality.null_hypothesis_is_valid),
+    );
 }
 
 create_parameterized_stringified_test!(noise_check_encrypt_br_dp_ks_ms_noise {
@@ -483,12 +450,8 @@ create_parameterized_stringified_test!(noise_check_encrypt_br_dp_ks_ms_noise {
 });
 
 fn noise_check_encrypt_br_dp_ks_ms_pfail(meta_params: MetaParameters, filename_suffix: &str) {
-    write_empty_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-    )
-    .unwrap();
+    let function_name = this_function_name!();
+    let guard = TestJsonGuard::new(&meta_params, filename_suffix, function_name.as_str()).unwrap();
     let (pfail_test_meta, params) = {
         let mut ap_params = meta_params
             .compute_parameters
@@ -547,13 +510,7 @@ fn noise_check_encrypt_br_dp_ks_ms_pfail(meta_params: MetaParameters, filename_s
 
     let test_result = PfailTestResult { measured_fails };
 
-    pfail_check(
-        &pfail_test_meta,
-        test_result,
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-    );
+    pfail_check(&pfail_test_meta, test_result, &guard);
 }
 
 create_parameterized_stringified_test!(noise_check_encrypt_br_dp_ks_ms_pfail {

--- a/tfhe/src/shortint/server_key/tests/noise_distribution/br_dp_packingks_ms.rs
+++ b/tfhe/src/shortint/server_key/tests/noise_distribution/br_dp_packingks_ms.rs
@@ -1,10 +1,10 @@
 use super::utils::noise_simulation::*;
-use super::utils::to_json::{write_to_json_file, TestResult};
+use super::utils::to_json::TestResult;
 use super::utils::traits::*;
 use super::utils::{
-    expected_pfail_for_precision, mean_and_variance_check, normality_check, pfail_check,
-    precision_with_padding, update_ap_params_msg_and_carry_moduli, DecryptionAndNoiseResult,
-    NoiseSample, PfailAndPrecision, PfailTestMeta, PfailTestResult,
+    expected_pfail_for_precision, mean_and_variance_check, noise_check, normality_check,
+    pfail_check, precision_with_padding, update_ap_params_msg_and_carry_moduli,
+    DecryptionAndNoiseResult, NoiseSample, PfailAndPrecision, PfailTestMeta, PfailTestResult,
 };
 use super::{should_run_short_pfail_tests_debug, should_use_single_key_debug};
 use crate::shortint::atomic_pattern::AtomicPattern;
@@ -21,7 +21,7 @@ use crate::shortint::parameters::{
     AtomicPatternParameters, CarryModulus, CiphertextModulusLog, CompressionParameters,
     MessageModulus, MetaParameters, Variance,
 };
-use crate::shortint::server_key::tests::noise_distribution::utils::to_json::write_empty_json_file;
+use crate::shortint::server_key::tests::noise_distribution::utils::to_json::TestJsonGuard;
 use crate::shortint::server_key::tests::parameterized_test::create_parameterized_stringified_test;
 use crate::shortint::server_key::ServerKey;
 use crate::shortint::{PaddingBit, ShortintEncoding};
@@ -99,12 +99,8 @@ where
 }
 
 fn sanity_check_encrypt_br_dp_packing_ks_ms(meta_params: MetaParameters, filename_suffix: &str) {
-    write_empty_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-    )
-    .unwrap();
+    let function_name = this_function_name!();
+    let guard = TestJsonGuard::new(&meta_params, filename_suffix, function_name.as_str()).unwrap();
     let (params, comp_params) = (
         meta_params
             .compute_parameters
@@ -167,15 +163,9 @@ fn sanity_check_encrypt_br_dp_packing_ks_ms(meta_params: MetaParameters, filenam
 
     let sanity_check_valid = after_ms.as_view() == extracted.as_view();
 
-    write_to_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-        sanity_check_valid,
-        None,
-        TestResult::Empty {},
-    )
-    .unwrap();
+    guard
+        .write_results(sanity_check_valid, None, TestResult::Empty {})
+        .unwrap();
 
     assert_eq!(after_ms.as_view(), extracted.as_view());
 }
@@ -401,12 +391,8 @@ fn noise_check_encrypt_br_dp_packing_ks_ms_noise(
     meta_params: MetaParameters,
     filename_suffix: &str,
 ) {
-    write_empty_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-    )
-    .unwrap();
+    let function_name = this_function_name!();
+    let guard = TestJsonGuard::new(&meta_params, filename_suffix, function_name.as_str()).unwrap();
     let (params, comp_params) = (
         meta_params
             .compute_parameters
@@ -521,42 +507,23 @@ fn noise_check_encrypt_br_dp_packing_ks_ms_noise(
 
     let before_ms_normality = normality_check(&noise_samples_before_ms, "before ms", 0.01);
 
-    let (after_ms_is_ok, bounded_variance_measurement, bounded_mean_measurement) =
-        mean_and_variance_check(
-            &noise_samples_after_ms,
-            "after_ms",
-            0.0,
-            after_ms_sim.variance_per_occupied_slot(),
-            comp_params.packing_ks_key_noise_distribution(),
-            after_ms_sim
-                .glwe_dimension()
-                .to_equivalent_lwe_dimension(after_ms_sim.polynomial_size()),
-            after_ms_sim.modulus().as_f64(),
-        );
+    let mean_variance_result = mean_and_variance_check(
+        &noise_samples_after_ms,
+        "after_ms",
+        0.0,
+        after_ms_sim.variance_per_occupied_slot(),
+        comp_params.packing_ks_key_noise_distribution(),
+        after_ms_sim
+            .glwe_dimension()
+            .to_equivalent_lwe_dimension(after_ms_sim.polynomial_size()),
+        after_ms_sim.modulus().as_f64(),
+    );
 
-    let before_ms_normality_valid = before_ms_normality.null_hypothesis_is_valid;
-
-    let noise_check_valid = before_ms_normality_valid && after_ms_is_ok;
-
-    let noise_check = TestResult::NoiseCheckWithNormalityCheck(Box::new(
-        super::utils::to_json::NoiseCheckWithNormalityCheck::new(
-            bounded_variance_measurement,
-            bounded_mean_measurement,
-            before_ms_normality_valid,
-        ),
-    ));
-
-    write_to_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-        noise_check_valid,
-        None,
-        noise_check,
-    )
-    .unwrap();
-
-    assert!(noise_check_valid);
+    noise_check(
+        &guard,
+        mean_variance_result,
+        Some(before_ms_normality.null_hypothesis_is_valid),
+    );
 }
 create_parameterized_stringified_test!(noise_check_encrypt_br_dp_packing_ks_ms_noise {
     TEST_META_PARAM_CPU_2_2_KS_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128,
@@ -568,12 +535,8 @@ fn noise_check_encrypt_br_dp_packing_ks_ms_pfail(
     meta_params: MetaParameters,
     filename_suffix: &str,
 ) {
-    write_empty_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-    )
-    .unwrap();
+    let function_name = this_function_name!();
+    let guard = TestJsonGuard::new(&meta_params, filename_suffix, function_name.as_str()).unwrap();
     let (pfail_test_meta, params, comp_params) = {
         let (mut params, comp_params) = (
             meta_params
@@ -732,13 +695,7 @@ fn noise_check_encrypt_br_dp_packing_ks_ms_pfail(
 
     let test_result = PfailTestResult { measured_fails };
 
-    pfail_check(
-        &pfail_test_meta,
-        test_result,
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-    );
+    pfail_check(&pfail_test_meta, test_result, &guard);
 }
 
 create_parameterized_stringified_test!(noise_check_encrypt_br_dp_packing_ks_ms_pfail {

--- a/tfhe/src/shortint/server_key/tests/noise_distribution/br_rerand_dp_ks_ms.rs
+++ b/tfhe/src/shortint/server_key/tests/noise_distribution/br_rerand_dp_ks_ms.rs
@@ -3,10 +3,10 @@ use super::utils::noise_simulation::{
     DynLwe, DynLweSecretKeyView, NoiseSimulationGenericBootstrapKey, NoiseSimulationGlwe,
     NoiseSimulationLwe, NoiseSimulationLweKeyswitchKey, NoiseSimulationModulusSwitchConfig,
 };
-use super::utils::to_json::{write_to_json_file, TestResult};
+use super::utils::to_json::TestResult;
 use super::utils::traits::*;
 use super::utils::{
-    mean_and_variance_check, normality_check, pfail_check, update_ap_params_for_pfail,
+    mean_and_variance_check, noise_check, normality_check, pfail_check, update_ap_params_for_pfail,
     DecryptionAndNoiseResult, NoiseSample, PfailTestMeta, PfailTestResult,
 };
 use super::{should_run_short_pfail_tests_debug, should_use_single_key_debug};
@@ -42,7 +42,7 @@ use crate::shortint::parameters::{
 };
 use crate::shortint::public_key::compact::{CompactPrivateKey, CompactPublicKey};
 use crate::shortint::server_key::tests::noise_distribution::utils::noise_simulation::NoiseSimulationModulus;
-use crate::shortint::server_key::tests::noise_distribution::utils::to_json::write_empty_json_file;
+use crate::shortint::server_key::tests::noise_distribution::utils::to_json::TestJsonGuard;
 use crate::shortint::server_key::tests::parameterized_test::create_parameterized_stringified_test;
 use crate::shortint::server_key::ServerKey;
 use crate::shortint::{Ciphertext, PaddingBit};
@@ -527,12 +527,8 @@ fn noise_check_encrypt_br_rerand_dp_ks_ms_noise(
     meta_params: MetaParameters,
     filename_suffix: &str,
 ) {
-    write_empty_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-    )
-    .unwrap();
+    let function_name = this_function_name!();
+    let guard = TestJsonGuard::new(&meta_params, filename_suffix, function_name.as_str()).unwrap();
     let (compute_params, re_rand_parameters, compression_params) = {
         let compute_params = meta_params
             .compute_parameters
@@ -751,40 +747,21 @@ fn noise_check_encrypt_br_rerand_dp_ks_ms_noise(
 
     let before_ms_normality = normality_check(&noise_samples_before_ms, "before ms", 0.01);
 
-    let (after_ms_is_ok, bounded_variance_measurement, bounded_mean_measurement) =
-        mean_and_variance_check(
-            &noise_samples_after_ms,
-            "after_ms",
-            expected_average_after_ms,
-            after_ms_sim.variance(),
-            compute_params.lwe_noise_distribution(),
-            after_ms_sim.lwe_dimension(),
-            after_ms_sim.modulus().as_f64(),
-        );
+    let mean_variance_result = mean_and_variance_check(
+        &noise_samples_after_ms,
+        "after_ms",
+        expected_average_after_ms,
+        after_ms_sim.variance(),
+        compute_params.lwe_noise_distribution(),
+        after_ms_sim.lwe_dimension(),
+        after_ms_sim.modulus().as_f64(),
+    );
 
-    let before_ms_normality_valid = before_ms_normality.null_hypothesis_is_valid;
-
-    let noise_check_valid = before_ms_normality_valid && after_ms_is_ok;
-
-    let noise_check = TestResult::NoiseCheckWithNormalityCheck(Box::new(
-        super::utils::to_json::NoiseCheckWithNormalityCheck::new(
-            bounded_variance_measurement,
-            bounded_mean_measurement,
-            before_ms_normality_valid,
-        ),
-    ));
-
-    write_to_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-        noise_check_valid,
-        None,
-        noise_check,
-    )
-    .unwrap();
-
-    assert!(noise_check_valid);
+    noise_check(
+        &guard,
+        mean_variance_result,
+        Some(before_ms_normality.null_hypothesis_is_valid),
+    );
 }
 
 create_parameterized_stringified_test!(noise_check_encrypt_br_rerand_dp_ks_ms_noise {
@@ -798,12 +775,8 @@ fn noise_check_encrypt_br_rerand_dp_ks_ms_pfail(
     meta_params: MetaParameters,
     filename_suffix: &str,
 ) {
-    write_empty_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-    )
-    .unwrap();
+    let function_name = this_function_name!();
+    let guard = TestJsonGuard::new(&meta_params, filename_suffix, function_name.as_str()).unwrap();
     let (compute_params, re_rand_parameters, compression_params) = {
         let compute_params = meta_params
             .compute_parameters
@@ -919,13 +892,7 @@ fn noise_check_encrypt_br_rerand_dp_ks_ms_pfail(
 
     let test_result = PfailTestResult { measured_fails };
 
-    pfail_check(
-        &pfail_test_meta,
-        test_result,
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-    );
+    pfail_check(&pfail_test_meta, test_result, &guard);
 }
 
 create_parameterized_stringified_test!(noise_check_encrypt_br_rerand_dp_ks_ms_pfail {
@@ -936,12 +903,8 @@ create_parameterized_stringified_test!(noise_check_encrypt_br_rerand_dp_ks_ms_pf
 });
 
 fn sanity_check_encrypt_br_rerand_dp_ks_ms_pbs(meta_params: MetaParameters, filename_suffix: &str) {
-    write_empty_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-    )
-    .unwrap();
+    let function_name = this_function_name!();
+    let guard = TestJsonGuard::new(&meta_params, filename_suffix, function_name.as_str()).unwrap();
     let (compute_params, re_rand_parameters, compression_params) = {
         let compute_params = meta_params
             .compute_parameters
@@ -1122,15 +1085,9 @@ fn sanity_check_encrypt_br_rerand_dp_ks_ms_pbs(meta_params: MetaParameters, file
         .iter()
         .all(|(lhs, rhs)| lhs.as_lwe_64() == rhs.ct.as_view());
 
-    write_to_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-        all_result_match,
-        None,
-        TestResult::Empty {},
-    )
-    .unwrap();
+    guard
+        .write_results(all_result_match, None, TestResult::Empty {})
+        .unwrap();
 
     // We check each step to preserve failure details and print the invalid case if one occurs
     for (pbs_result, shortint_res) in results.iter() {

--- a/tfhe/src/shortint/server_key/tests/noise_distribution/cpk_ks_ms.rs
+++ b/tfhe/src/shortint/server_key/tests/noise_distribution/cpk_ks_ms.rs
@@ -2,10 +2,10 @@ use super::dp_ks_ms::any_ms;
 use super::utils::noise_simulation::{
     DynLwe, NoiseSimulationLwe, NoiseSimulationLweKeyswitchKey, NoiseSimulationModulusSwitchConfig,
 };
-use super::utils::to_json::{write_to_json_file, TestResult};
+use super::utils::to_json::TestResult;
 use super::utils::traits::*;
 use super::utils::{
-    mean_and_variance_check, normality_check, pfail_check, update_ap_params_for_pfail,
+    mean_and_variance_check, noise_check, normality_check, pfail_check, update_ap_params_for_pfail,
     DecryptionAndNoiseResult, NoiseSample, PfailTestMeta, PfailTestResult,
 };
 use super::{should_run_short_pfail_tests_debug, should_use_single_key_debug};
@@ -24,7 +24,7 @@ use crate::shortint::parameters::{
     ShortintKeySwitchingParameters,
 };
 use crate::shortint::public_key::compact::{CompactPrivateKey, CompactPublicKey};
-use crate::shortint::server_key::tests::noise_distribution::utils::to_json::write_empty_json_file;
+use crate::shortint::server_key::tests::noise_distribution::utils::to_json::TestJsonGuard;
 use crate::shortint::server_key::tests::parameterized_test::create_parameterized_stringified_test;
 use crate::shortint::server_key::ServerKey;
 use crate::shortint::Ciphertext;
@@ -249,12 +249,8 @@ fn cpk_ks_any_ms_pfail_helper(
 }
 
 fn noise_check_encrypt_cpk_ks_ms_noise(meta_params: MetaParameters, filename_suffix: &str) {
-    write_empty_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-    )
-    .unwrap();
+    let function_name = this_function_name!();
+    let guard = TestJsonGuard::new(&meta_params, filename_suffix, function_name.as_str()).unwrap();
     let (params, cpk_params, ksk_ds_params) = {
         let compute_params = meta_params
             .compute_parameters
@@ -368,40 +364,21 @@ fn noise_check_encrypt_cpk_ks_ms_noise(meta_params: MetaParameters, filename_suf
 
     let before_ms_normality = normality_check(&noise_samples_before_ms, "before ms", 0.01);
 
-    let (after_ms_is_ok, bounded_variance_measurement, bounded_mean_measurement) =
-        mean_and_variance_check(
-            &noise_samples_after_ms,
-            "after_ms",
-            expected_average_after_ms,
-            after_ms_sim.variance(),
-            params.lwe_noise_distribution(),
-            after_ms_sim.lwe_dimension(),
-            after_ms_sim.modulus().as_f64(),
-        );
+    let mean_variance_result = mean_and_variance_check(
+        &noise_samples_after_ms,
+        "after_ms",
+        expected_average_after_ms,
+        after_ms_sim.variance(),
+        params.lwe_noise_distribution(),
+        after_ms_sim.lwe_dimension(),
+        after_ms_sim.modulus().as_f64(),
+    );
 
-    let before_ms_normality_valid = before_ms_normality.null_hypothesis_is_valid;
-
-    let noise_check_valid = before_ms_normality_valid && after_ms_is_ok;
-
-    let noise_check = TestResult::NoiseCheckWithNormalityCheck(Box::new(
-        super::utils::to_json::NoiseCheckWithNormalityCheck::new(
-            bounded_variance_measurement,
-            bounded_mean_measurement,
-            before_ms_normality_valid,
-        ),
-    ));
-
-    write_to_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-        noise_check_valid,
-        None,
-        noise_check,
-    )
-    .unwrap();
-
-    assert!(noise_check_valid);
+    noise_check(
+        &guard,
+        mean_variance_result,
+        Some(before_ms_normality.null_hypothesis_is_valid),
+    );
 }
 
 create_parameterized_stringified_test!(noise_check_encrypt_cpk_ks_ms_noise {
@@ -411,12 +388,8 @@ create_parameterized_stringified_test!(noise_check_encrypt_cpk_ks_ms_noise {
 });
 
 fn noise_check_encrypt_cpk_ks_ms_pfail(meta_params: MetaParameters, filename_suffix: &str) {
-    write_empty_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-    )
-    .unwrap();
+    let function_name = this_function_name!();
+    let guard = TestJsonGuard::new(&meta_params, filename_suffix, function_name.as_str()).unwrap();
     let (params, cpk_params, ksk_ds_params) = {
         let compute_params = meta_params
             .compute_parameters
@@ -503,13 +476,7 @@ fn noise_check_encrypt_cpk_ks_ms_pfail(meta_params: MetaParameters, filename_suf
 
     let test_result = PfailTestResult { measured_fails };
 
-    pfail_check(
-        &pfail_test_meta,
-        test_result,
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-    );
+    pfail_check(&pfail_test_meta, test_result, &guard);
 }
 
 create_parameterized_stringified_test!(noise_check_encrypt_cpk_ks_ms_pfail {
@@ -519,12 +486,8 @@ create_parameterized_stringified_test!(noise_check_encrypt_cpk_ks_ms_pfail {
 });
 
 fn sanity_check_encrypt_cpk_ks_ms_pbs(meta_params: MetaParameters, filename_suffix: &str) {
-    write_empty_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-    )
-    .unwrap();
+    let function_name = this_function_name!();
+    let guard = TestJsonGuard::new(&meta_params, filename_suffix, function_name.as_str()).unwrap();
     let (params, cpk_params, ksk_ds_params, orig_cast_mode) = {
         let compute_params = meta_params
             .compute_parameters
@@ -617,15 +580,9 @@ fn sanity_check_encrypt_cpk_ks_ms_pbs(meta_params: MetaParameters, filename_suff
         .iter()
         .all(|(lhs, rhs)| lhs.as_lwe_64() == rhs.ct.as_view());
 
-    write_to_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-        all_result_match,
-        None,
-        TestResult::Empty {},
-    )
-    .unwrap();
+    guard
+        .write_results(all_result_match, None, TestResult::Empty {})
+        .unwrap();
 
     // We check each step to preserve failure details and print the invalid case if one occurs
     for (pbs_result, shortint_res) in results.iter() {

--- a/tfhe/src/shortint/server_key/tests/noise_distribution/dp_ks_ms.rs
+++ b/tfhe/src/shortint/server_key/tests/noise_distribution/dp_ks_ms.rs
@@ -1,8 +1,8 @@
 use super::utils::noise_simulation::*;
-use super::utils::to_json::{write_to_json_file, TestResult};
+use super::utils::to_json::TestResult;
 use super::utils::traits::*;
 use super::utils::{
-    mean_and_variance_check, normality_check, pfail_check, update_ap_params_for_pfail,
+    mean_and_variance_check, noise_check, normality_check, pfail_check, update_ap_params_for_pfail,
     DecryptionAndNoiseResult, NoiseSample, PfailTestMeta, PfailTestResult,
 };
 use super::{should_run_short_pfail_tests_debug, should_use_single_key_debug};
@@ -16,7 +16,7 @@ use crate::shortint::parameters::test_params::{
     TEST_META_PARAM_GPU_2_2_MULTI_BIT_GROUP_4_KS_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128,
 };
 use crate::shortint::parameters::{AtomicPatternParameters, CarryModulus, MetaParameters};
-use crate::shortint::server_key::tests::noise_distribution::utils::to_json::write_empty_json_file;
+use crate::shortint::server_key::tests::noise_distribution::utils::to_json::TestJsonGuard;
 use crate::shortint::server_key::tests::parameterized_test::create_parameterized_stringified_test;
 use crate::shortint::server_key::ServerKey;
 use crate::shortint::Ciphertext;
@@ -170,12 +170,8 @@ where
 /// Test function to verify that the noise checking tools match the actual atomic patterns
 /// implemented in shortint
 fn sanity_check_encrypt_dp_ks_pbs(meta_params: MetaParameters, filename_suffix: &str) {
-    write_empty_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-    )
-    .unwrap();
+    let function_name = this_function_name!();
+    let guard = TestJsonGuard::new(&meta_params, filename_suffix, function_name.as_str()).unwrap();
     let params = meta_params
         .compute_parameters
         .with_deterministic_execution();
@@ -219,15 +215,9 @@ fn sanity_check_encrypt_dp_ks_pbs(meta_params: MetaParameters, filename_suffix: 
         .iter()
         .all(|(lhs, rhs)| lhs.as_lwe_64() == rhs.ct.as_view());
 
-    write_to_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-        all_result_match,
-        None,
-        TestResult::Empty {},
-    )
-    .unwrap();
+    guard
+        .write_results(all_result_match, None, TestResult::Empty {})
+        .unwrap();
 
     // We check each step to preserve failure details and print the invalid case if one occurs
     for (pbs_result, shortint_res) in results.iter() {
@@ -358,12 +348,8 @@ fn encrypt_dp_ks_any_ms_pfail_helper(
 }
 
 fn noise_check_encrypt_dp_ks_ms_noise(meta_params: MetaParameters, filename_suffix: &str) {
-    write_empty_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-    )
-    .unwrap();
+    let function_name = this_function_name!();
+    let guard = TestJsonGuard::new(&meta_params, filename_suffix, function_name.as_str()).unwrap();
     let params = meta_params
         .compute_parameters
         .with_deterministic_execution();
@@ -441,40 +427,21 @@ fn noise_check_encrypt_dp_ks_ms_noise(meta_params: MetaParameters, filename_suff
 
     let before_ms_normality = normality_check(&noise_samples_before_ms, "before ms", 0.01);
 
-    let (after_ms_is_ok, bounded_variance_measurement, bounded_mean_measurement) =
-        mean_and_variance_check(
-            &noise_samples_after_ms,
-            "after_ms",
-            expected_average_after_ms,
-            after_ms_sim.variance(),
-            params.lwe_noise_distribution(),
-            after_ms_sim.lwe_dimension(),
-            after_ms_sim.modulus().as_f64(),
-        );
+    let mean_variance_result = mean_and_variance_check(
+        &noise_samples_after_ms,
+        "after_ms",
+        expected_average_after_ms,
+        after_ms_sim.variance(),
+        params.lwe_noise_distribution(),
+        after_ms_sim.lwe_dimension(),
+        after_ms_sim.modulus().as_f64(),
+    );
 
-    let before_ms_normality_valid = before_ms_normality.null_hypothesis_is_valid;
-
-    let noise_check_valid = before_ms_normality_valid && after_ms_is_ok;
-
-    let noise_check = TestResult::NoiseCheckWithNormalityCheck(Box::new(
-        super::utils::to_json::NoiseCheckWithNormalityCheck::new(
-            bounded_variance_measurement,
-            bounded_mean_measurement,
-            before_ms_normality_valid,
-        ),
-    ));
-
-    write_to_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-        noise_check_valid,
-        None,
-        noise_check,
-    )
-    .unwrap();
-
-    assert!(noise_check_valid);
+    noise_check(
+        &guard,
+        mean_variance_result,
+        Some(before_ms_normality.null_hypothesis_is_valid),
+    );
 }
 
 create_parameterized_stringified_test!(noise_check_encrypt_dp_ks_ms_noise {
@@ -485,12 +452,8 @@ create_parameterized_stringified_test!(noise_check_encrypt_dp_ks_ms_noise {
 });
 
 fn noise_check_encrypt_dp_ks_ms_pfail(meta_params: MetaParameters, filename_suffix: &str) {
-    write_empty_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-    )
-    .unwrap();
+    let function_name = this_function_name!();
+    let guard = TestJsonGuard::new(&meta_params, filename_suffix, function_name.as_str()).unwrap();
     let (pfail_test_meta, params) = {
         let mut ap_params = meta_params
             .compute_parameters
@@ -549,13 +512,7 @@ fn noise_check_encrypt_dp_ks_ms_pfail(meta_params: MetaParameters, filename_suff
 
     let test_result = PfailTestResult { measured_fails };
 
-    pfail_check(
-        &pfail_test_meta,
-        test_result,
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-    );
+    pfail_check(&pfail_test_meta, test_result, &guard);
 }
 
 create_parameterized_stringified_test!(noise_check_encrypt_dp_ks_ms_pfail {

--- a/tfhe/src/shortint/server_key/tests/noise_distribution/dp_ks_pbs128_packingks.rs
+++ b/tfhe/src/shortint/server_key/tests/noise_distribution/dp_ks_pbs128_packingks.rs
@@ -1,9 +1,9 @@
 use super::dp_ks_ms::any_ms;
 use super::should_use_single_key_debug;
 use super::utils::noise_simulation::*;
-use super::utils::to_json::{write_to_json_file, TestResult};
+use super::utils::to_json::TestResult;
 use super::utils::traits::*;
-use super::utils::{mean_and_variance_check, DecryptionAndNoiseResult, NoiseSample};
+use super::utils::{mean_and_variance_check, noise_check, DecryptionAndNoiseResult, NoiseSample};
 use crate::core_crypto::algorithms::lwe_programmable_bootstrapping::generate_programmable_bootstrap_glwe_lut;
 use crate::core_crypto::commons::dispersion::Variance;
 use crate::core_crypto::commons::parameters::CiphertextModulusLog;
@@ -23,7 +23,7 @@ use crate::shortint::parameters::test_params::{
 use crate::shortint::parameters::{
     AtomicPatternParameters, MetaParameters, NoiseSquashingCompressionParameters,
 };
-use crate::shortint::server_key::tests::noise_distribution::utils::to_json::write_empty_json_file;
+use crate::shortint::server_key::tests::noise_distribution::utils::to_json::TestJsonGuard;
 use crate::shortint::server_key::tests::parameterized_test::create_parameterized_stringified_test;
 use crate::shortint::server_key::ServerKey;
 use crate::this_function_name;
@@ -247,12 +247,8 @@ fn sanity_check_encrypt_dp_ks_standard_pbs128_packing_ks(
     meta_params: MetaParameters,
     filename_suffix: &str,
 ) {
-    write_empty_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-    )
-    .unwrap();
+    let function_name = this_function_name!();
+    let guard = TestJsonGuard::new(&meta_params, filename_suffix, function_name.as_str()).unwrap();
 
     let (params, noise_squashing_params, noise_squashing_compression_params) = {
         let meta_noise_squashing_params = meta_params.noise_squashing_parameters.unwrap();
@@ -346,15 +342,9 @@ fn sanity_check_encrypt_dp_ks_standard_pbs128_packing_ks(
 
     let sanity_check_valid = after_packing.as_view() == extracted.as_view();
 
-    write_to_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-        sanity_check_valid,
-        None,
-        TestResult::Empty {},
-    )
-    .unwrap();
+    guard
+        .write_results(sanity_check_valid, None, TestResult::Empty {})
+        .unwrap();
 
     assert_eq!(after_packing.as_view(), extracted.as_view());
 }
@@ -624,12 +614,8 @@ fn noise_check_encrypt_dp_ks_standard_pbs128_packing_ks_noise(
     meta_params: MetaParameters,
     filename_suffix: &str,
 ) {
-    write_empty_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-    )
-    .unwrap();
+    let function_name = this_function_name!();
+    let guard = TestJsonGuard::new(&meta_params, filename_suffix, function_name.as_str()).unwrap();
     let (params, noise_squashing_params, noise_squashing_compression_params) = {
         let meta_noise_squashing_params = meta_params.noise_squashing_parameters.unwrap();
         (
@@ -765,35 +751,17 @@ fn noise_check_encrypt_dp_ks_standard_pbs128_packing_ks_noise(
         );
     }
 
-    let (after_packing_is_ok, bounded_variance_measurement, bounded_mean_measurement) =
-        mean_and_variance_check(
-            &noise_samples_after_packing,
-            "after_packing",
-            0.0,
-            after_packing_sim.variance(),
-            noise_squashing_compression_params.packing_ks_key_noise_distribution,
-            after_packing_sim.lwe_dimension(),
-            after_packing_sim.modulus().as_f64(),
-        );
+    let mean_variance_result = mean_and_variance_check(
+        &noise_samples_after_packing,
+        "after_packing",
+        0.0,
+        after_packing_sim.variance(),
+        noise_squashing_compression_params.packing_ks_key_noise_distribution,
+        after_packing_sim.lwe_dimension(),
+        after_packing_sim.modulus().as_f64(),
+    );
 
-    let noise_check = TestResult::NoiseCheckWithoutNormalityCheck(Box::new(
-        super::utils::to_json::NoiseCheckWithoutNormalityCheck::new(
-            bounded_variance_measurement,
-            bounded_mean_measurement,
-        ),
-    ));
-
-    write_to_json_file(
-        &meta_params,
-        filename_suffix,
-        this_function_name!().as_str(),
-        after_packing_is_ok,
-        None,
-        noise_check,
-    )
-    .unwrap();
-
-    assert!(after_packing_is_ok);
+    noise_check(&guard, mean_variance_result, None);
 }
 
 create_parameterized_stringified_test!(

--- a/tfhe/src/shortint/server_key/tests/noise_distribution/utils/mod.rs
+++ b/tfhe/src/shortint/server_key/tests/noise_distribution/utils/mod.rs
@@ -35,15 +35,16 @@ use crate::core_crypto::entities::lwe_secret_key::LweSecretKey;
 use crate::core_crypto::entities::{Cleartext, Plaintext, PlaintextList};
 use crate::shortint::encoding::ShortintEncoding;
 use crate::shortint::parameters::{
-    AtomicPatternParameters, CarryModulus, MessageModulus, MetaParameters, PBSParameters,
+    AtomicPatternParameters, CarryModulus, MessageModulus, PBSParameters,
 };
 use crate::shortint::server_key::tests::noise_distribution::utils::noise_simulation::{
     DynLwe, DynLweSecretKeyView, DynModSwitchedLwe, DynStandardMultiBitModulusSwitchedCt,
 };
 use crate::shortint::server_key::tests::noise_distribution::utils::to_json::{
-    write_to_json_file, BoundedLog2Measurement, BoundedMeasurement, ConfidenceInterval,
-    ConfidenceIntervalWithLog2, Measurement, NoBounds, PfailMetadata, PfailTestResultJson,
-    StringConfidenceInterval, StringConfidenceIntervalWithLog2, ValueWithLog2,
+    BoundedLog2Measurement, BoundedMeasurement, ConfidenceInterval, ConfidenceIntervalWithLog2,
+    Measurement, NoBounds, NoiseCheckWithNormalityCheck, NoiseCheckWithoutNormalityCheck,
+    PfailMetadata, PfailTestResultJson, StringConfidenceInterval, StringConfidenceIntervalWithLog2,
+    TestJsonGuard, TestResult, ValueWithLog2,
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -340,6 +341,33 @@ impl PfailTestMeta {
     }
 }
 
+pub fn noise_check(
+    guard: &TestJsonGuard,
+    mean_variance_result: (bool, BoundedMeasurement, BoundedMeasurement),
+    normality_valid: Option<bool>,
+) {
+    let (mv_ok, bounded_variance, bounded_mean) = mean_variance_result;
+
+    let (valid, test_result) =
+        match normality_valid {
+            Some(norm_ok) => (
+                mv_ok && norm_ok,
+                TestResult::NoiseCheckWithNormalityCheck(Box::new(
+                    NoiseCheckWithNormalityCheck::new(bounded_variance, bounded_mean, norm_ok),
+                )),
+            ),
+            None => (
+                mv_ok,
+                TestResult::NoiseCheckWithoutNormalityCheck(Box::new(
+                    NoiseCheckWithoutNormalityCheck::new(bounded_variance, bounded_mean),
+                )),
+            ),
+        };
+
+    guard.write_results(valid, None, test_result).unwrap();
+    assert!(valid);
+}
+
 #[derive(Clone, Copy)]
 pub struct PfailTestResult {
     pub measured_fails: f64,
@@ -348,9 +376,7 @@ pub struct PfailTestResult {
 pub fn pfail_check(
     pfail_test_meta: &PfailTestMeta,
     pfail_test_result: PfailTestResult,
-    param_name: &MetaParameters,
-    test_name: &str,
-    test_module_path: &str,
+    guard: &TestJsonGuard,
 ) {
     let measured_fails = pfail_test_result.measured_fails;
     let total_runs_for_expected_fails = pfail_test_meta.total_runs_for_expected_fails;
@@ -418,21 +444,19 @@ pub fn pfail_check(
                       pass: bool,
                       pfail_serialized: BoundedMeasurement,
                       pfail_original_serialized: BoundedLog2Measurement| {
-        write_to_json_file(
-            param_name,
-            test_name,
-            test_module_path,
-            pass,
-            warning,
-            PfailTestResultJson::new(
-                pfail_meta_serialized.clone(),
-                fails_serialized.clone(),
-                pfail_serialized,
-                pfail_original_serialized,
+        guard
+            .write_results(
+                pass,
+                warning,
+                PfailTestResultJson::new(
+                    pfail_meta_serialized.clone(),
+                    fails_serialized.clone(),
+                    pfail_serialized,
+                    pfail_original_serialized,
+                )
+                .into_test_result(),
             )
-            .into_test_result(),
-        )
-        .unwrap();
+            .unwrap();
     };
 
     if measured_fails > 0.0 {

--- a/tfhe/src/shortint/server_key/tests/noise_distribution/utils/to_json.rs
+++ b/tfhe/src/shortint/server_key/tests/noise_distribution/utils/to_json.rs
@@ -325,39 +325,69 @@ macro_rules! this_function_name {
     }};
 }
 
-pub fn write_empty_json_file(
-    meta_param: &MetaParameters,
-    test_name: &str,
-    test_module_path: &str,
-) -> Result<(), Box<dyn std::error::Error>> {
-    write_to_json_file(
-        meta_param,
-        test_name,
-        test_module_path,
-        false,
-        None,
-        TestResult::Empty {},
-    )
+pub struct TestJsonGuard<'a> {
+    meta_param: &'a MetaParameters,
+    test_name: &'a str,
+    test_module_path: &'a str,
 }
 
-pub fn write_to_json_file(
-    meta_param: &MetaParameters,
-    test_name: &str,
-    test_module_path: &str,
-    pass: bool,
-    warning: Option<String>,
-    results: TestResult,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let test_id = format!("{test_module_path}::{test_name}").to_lowercase();
-    let short_name = test_module_path
-        .rsplit_once("::")
-        .map_or(test_module_path, |(_, p)| p);
-    let output_data = TestJsonOutput::new(&test_id, short_name, pass, warning, meta_param, results);
-    let serialized_output = serde_json::to_string_pretty(&output_data)?;
-    let mut path = PathBuf::new();
-    path.push("tests_results");
-    fs::create_dir_all(&path)?;
-    path.push(format!("{test_id}.json"));
-    fs::write(&path, serialized_output)?;
-    Ok(())
+impl<'a> TestJsonGuard<'a> {
+    pub fn new(
+        meta_param: &'a MetaParameters,
+        test_name: &'a str,
+        test_module_path: &'a str,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        Self::write_json_file(
+            meta_param,
+            test_name,
+            test_module_path,
+            false,
+            None,
+            TestResult::Empty {},
+        )?;
+        Ok(TestJsonGuard {
+            meta_param,
+            test_name,
+            test_module_path,
+        })
+    }
+
+    pub fn write_results(
+        &self,
+        pass: bool,
+        warning: Option<String>,
+        results: TestResult,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        Self::write_json_file(
+            self.meta_param,
+            self.test_name,
+            self.test_module_path,
+            pass,
+            warning,
+            results,
+        )
+    }
+
+    fn write_json_file(
+        meta_param: &MetaParameters,
+        test_name: &str,
+        test_module_path: &str,
+        pass: bool,
+        warning: Option<String>,
+        results: TestResult,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let test_id = format!("{test_module_path}::{test_name}").to_lowercase();
+        let short_name = test_module_path
+            .rsplit_once("::")
+            .map_or(test_module_path, |(_, p)| p);
+        let output_data =
+            TestJsonOutput::new(&test_id, short_name, pass, warning, meta_param, results);
+        let serialized_output = serde_json::to_string_pretty(&output_data)?;
+        let mut path = PathBuf::new();
+        path.push("tests_results");
+        fs::create_dir_all(&path)?;
+        path.push(format!("{test_id}.json"));
+        fs::write(&path, serialized_output)?;
+        Ok(())
+    }
 }


### PR DESCRIPTION
simplification around noise check test and json generation

creation of a struct to manage tmp empty json file and after the test the generation of the final one

also creation of a general noise_check function to handle mean_and_variance_check + normality check in one place with the json output

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3457)
<!-- Reviewable:end -->
