### PR TITLE
fix(gpu): semgrep step not failing on error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -312,7 +312,7 @@ semgrep_and_lint_gpu_code: semgrep_lint_setup_venv
 	find "$(TFHECUDA_SRC)" -name '*.h' -o -name '*.cuh' -o -name '*.cu' \
 		| grep -v '/cmake-build-debug/' \
 		| grep -v '/build/' \
-		| xargs venv/bin/semgrep --config "$(TFHECUDA_SRC)/.semgrep/release-ordering.yaml" --scan-unknown-extensions
+		| xargs venv/bin/semgrep --error --config "$(TFHECUDA_SRC)/.semgrep/release-ordering.yaml" --scan-unknown-extensions
 	venv/bin/python3 "scripts/check_scratch_cleanup.py"
 
 .PHONY: semver_check_cuda_backend # Run semver checks on tfhe-cuda-backend

--- a/backends/tfhe-cuda-backend/cuda/src/crypto/torus.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/crypto/torus.cuh
@@ -489,7 +489,7 @@ template <typename Torus>
 __host__ void host_modulus_switch_multi_bit(
     cudaStream_t stream, uint32_t gpu_index, Torus *array_out, Torus *array_in,
     int size, uint32_t log_modulus, uint32_t degree, uint32_t grouping_factor) {
-  cudaSetDevice(gpu_index);
+  check_cuda_error(cudaSetDevice(gpu_index));
   int multibit_size = size / grouping_factor;
   int num_threads = 0, num_blocks = 0;
   getNumBlocksAndThreads(multibit_size, 1024, num_blocks, num_threads);

--- a/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_multibit_128.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_multibit_128.cu
@@ -308,6 +308,7 @@ void cleanup_cuda_multi_bit_programmable_bootstrap_noise_tests_128(
     void *stream, uint32_t gpu_index, int8_t **pbs_buffer) {
   cleanup_cuda_multi_bit_programmable_bootstrap_128(stream, gpu_index,
                                                     pbs_buffer);
+  cuda_synchronize_stream(static_cast<cudaStream_t>(stream), gpu_index);
 }
 
 // Noise tests variant of the 128-bit multi-bit PBS, restricted to


### PR DESCRIPTION
Semgrep wasn't making the CI fail when an error was detected. This PR fixes that

Errors that need fixing:

```

                                                        
    backends/tfhe-cuda-backend/cuda/src/crypto/torus.cuh
    ❯❱ backends.tfhe-cuda-backend.cuda..semgrep.tfhe-cuda-unwrapped-cuda-runtime-call
          CUDA runtime API call is not wrapped in `check_cuda_error(...)`.
                                                                          
          492┆ cudaSetDevice(gpu_index);
                                                                                  
    backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_multibit_128.cu
   ❯❯❱ backends.tfhe-cuda-backend.cuda..semgrep.cleanup-missing-release-or-synchronize
          cleanup_ function does not call release() or cuda_synchronize_stream(). All non-async cleanup_
          functions must either call release() on a memory structure or synchronize the CUDA stream.    
                                                                                                        
          307┆ void cleanup_cuda_multi_bit_programmable_bootstrap_noise_tests_128(
          308┆     void *stream, uint32_t gpu_index, int8_t **pbs_buffer) {
          309┆   cleanup_cuda_multi_bit_programmable_bootstrap_128(stream, gpu_index,
          310┆                                                     pbs_buffer);
          311┆ }
```