### PR TITLE
chore: allow rand audit advisory

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -4,6 +4,9 @@ ignore = [
     "RUSTSEC-2024-0436",
     # Ignoring unmaintained 'bincode' crate. Getting rid of it would be too complex on the short term.
     "RUSTSEC-2025-0141",
+    # Ignoring unsoundness in 'rand' with custom logger. Rand update is currently blocked by
+    # arkworks and we do not use custom loggers.
+    "RUSTSEC-2026-0097",
 ]
 
 [output]


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description
Fix a cargo audit warning on rand 0.8, caused by an unsoundness triggered by the use of a custom logger. Upgrading rand would be too complex now because of arkworks is still depending on 0.8.
PR to update to 0.9 exists in arkworks but has not been merged yet, and looks stalled: https://github.com/arkworks-rs/std/pull/56