### PR TITLE
chore: make CompressedXofKeySet::decompress take a reference

### DIFF
--- a/tfhe/src/high_level_api/xof_key_set/mod.rs
+++ b/tfhe/src/high_level_api/xof_key_set/mod.rs
@@ -378,7 +378,7 @@ impl CompressedXofKeySet {
     }
 
     /// Decompress the KeySet
-    pub fn decompress(self) -> crate::Result<XofKeySet> {
+    pub fn decompress(&self) -> crate::Result<XofKeySet> {
         let tag = self.compressed_server_key.tag.clone();
         let (mut public_key, expanded_server_key) = self.expand();
         // Server key tag is the source of truth; sync public key


### PR DESCRIPTION
Noticed that the `CompressedXofKeySet::decompress` consumes `self`, forcing consumers to clone keys (e.g. in the `kms`).

At a glance it seems like most `decompress` methods in the repo take a reference and I see no reason for this particular one to be different.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3469)
<!-- Reviewable:end -->
