### PR TITLE
fix windows csprng seeding when rdseed is not available

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,6 @@ Start by [forking](https://docs.github.com/en/pull-requests/collaborating-with-p
 
 {% hint style="info" %}
 - **Rust version**:  Ensure that you use a Rust version >= 1.81 to compile **TFHE-rs**.
-- **Incompatibility**: AArch64-based machines are not yet supported for Windows as it's currently missing an entropy source to be able to seed the [CSPRNGs](https://en.wikipedia.org/wiki/Cryptographically_secure_pseudorandom_number_generator) used in **TFHE-rs**.
 - **Performance**: For optimal performance, it is highly recommended to run **TFHE-rs** code in release mode with cargo's `--release` flag.
 {% endhint %}
 

--- a/README.md
+++ b/README.md
@@ -81,9 +81,6 @@ tfhe = { version = "*", features = ["boolean", "shortint", "integer"] }
 > [!Note]
 > Note: You need Rust version 1.91.1 or newer to compile TFHE-rs. You can check your version with `rustc --version`.
 
-> [!Note]
-> Note: AArch64-based machines are not supported for Windows as it's currently missing an entropy source to be able to seed the [CSPRNGs](https://en.wikipedia.org/wiki/Cryptographically_secure_pseudorandom_number_generator) used in TFHE-rs.
-
 <p align="right">
   <a href="#about" > ↑ Back to top </a>
 </p>

--- a/tfhe-csprng/README.md
+++ b/tfhe-csprng/README.md
@@ -8,7 +8,7 @@ The implementation is based on the AES blockcipher used in CTR mode, as describe
 
 Two implementations are available, an accelerated one on x86_64 CPUs with the `aes` feature and the `sse2` feature, and a pure software one that can be used on other platforms.
 
-The crate also makes two seeders available, one needing the x86_64 instruction `rdseed` and another one based on the Unix random device `/dev/random` the latter requires the user to provide a secret.
+The crate also makes seeders available: one using the x86_64 `rdseed` instruction when present, and one using OS entropy via the `getrandom` crate on Unix-like systems and on Windows (the latter takes a user-supplied secret mixed into the entropy, as documented on the type).
 
 ## Running the benchmarks
 

--- a/tfhe-csprng/benches/benchmark.rs
+++ b/tfhe-csprng/benches/benchmark.rs
@@ -13,7 +13,7 @@ use tfhe_csprng::seeders::RdseedSeeder as ActivatedSeeder;
 #[cfg(all(
     not(target_os = "macos"),
     not(all(target_arch = "x86_64", target_feature = "rdseed")),
-    target_family = "unix"
+    any(target_family = "unix", target_os = "windows")
 ))]
 use tfhe_csprng::seeders::UnixSeeder as ActivatedSeeder;
 
@@ -38,7 +38,7 @@ fn new_seeder() -> ActivatedSeeder {
     #[cfg(all(
         not(target_os = "macos"),
         not(all(target_arch = "x86_64", target_feature = "rdseed")),
-        target_family = "unix"
+        any(target_family = "unix", target_os = "windows")
     ))]
     {
         ActivatedSeeder::new(0)

--- a/tfhe-csprng/examples/generate.rs
+++ b/tfhe-csprng/examples/generate.rs
@@ -18,7 +18,7 @@ use tfhe_csprng::seeders::Seeder;
 #[cfg(all(
     not(target_os = "macos"),
     not(all(target_arch = "x86_64", target_feature = "rdseed")),
-    target_family = "unix"
+    any(target_family = "unix", target_os = "windows")
 ))]
 use tfhe_csprng::seeders::UnixSeeder as ActivatedSeeder;
 
@@ -71,7 +71,7 @@ fn new_seeder() -> ActivatedSeeder {
     #[cfg(all(
         not(target_os = "macos"),
         not(all(target_arch = "x86_64", target_feature = "rdseed")),
-        target_family = "unix"
+        any(target_family = "unix", target_os = "windows")
     ))]
     {
         ActivatedSeeder::new(0)

--- a/tfhe-csprng/src/seeders/implem/mod.rs
+++ b/tfhe-csprng/src/seeders/implem/mod.rs
@@ -8,7 +8,7 @@ mod rdseed;
 #[cfg(target_arch = "x86_64")]
 pub use rdseed::RdseedSeeder;
 
-#[cfg(target_family = "unix")]
+#[cfg(any(target_family = "unix", target_os = "windows"))]
 mod unix;
-#[cfg(target_family = "unix")]
+#[cfg(any(target_family = "unix", target_os = "windows"))]
 pub use unix::UnixSeeder;

--- a/tfhe-csprng/src/seeders/implem/unix.rs
+++ b/tfhe-csprng/src/seeders/implem/unix.rs
@@ -1,9 +1,12 @@
 use crate::seeders::{Seed, Seeder};
 
-/// A seeder which uses the system entropy source on unix-like systems.
+/// A seeder which uses the OS entropy source via the [`getrandom`](https://docs.rs/getrandom)
+/// crate.
 ///
-/// If available, this will use `getrandom` or `getentropy` system call. Otherwise it will draw from
-/// `/dev/urandom` after successfully polling `/dev/random`.
+/// On Unix-like systems, this uses `getrandom` or `getentropy` when available, otherwise
+/// `/dev/urandom` (after polling `/dev/random` as implemented by `getrandom`).
+///
+/// On Windows, this uses the system APIs backed by `getrandom` (for example `BCryptGenRandom`).
 pub struct UnixSeeder {
     secret: u128,
 }
@@ -37,8 +40,7 @@ impl Seeder for UnixSeeder {
     /// but should not be blocking after.
     ///
     /// # Panics
-    /// This may panic if the `getrandom` system call is not available and no file descriptor is
-    /// available on the system.
+    /// This may panic if the platform cannot provide entropy through `getrandom`.
     fn seed(&mut self) -> Seed {
         let output = self.secret ^ get_system_entropy();
 
@@ -46,17 +48,14 @@ impl Seeder for UnixSeeder {
     }
 
     fn is_available() -> bool {
-        cfg!(target_family = "unix")
+        cfg!(any(target_family = "unix", target_os = "windows"))
     }
 }
 
 fn get_system_entropy() -> u128 {
     let mut buf = [0u8; 16];
-    // This will use the getrandom syscall if possible (from linux 3.17). This syscall is not
-    // vulnerable to fd exhaustion since it directly pulls from kernel entropy sources.
-    //
-    // This syscall will use the urandom entropy source but block at startup until it is correctly
-    // seeded. See <https://www.2uo.de/myths-about-urandom/> for a rational around random/urandom.
+    // On Linux this prefers the getrandom syscall when available. On Windows, getrandom uses the
+    // appropriate system RNG. See the getrandom crate for per-OS behavior.
     getrandom::getrandom(&mut buf).expect("Failed to read entropy from system");
     // For consistency between big and small endian, Seed exposing accidentally the endianness via
     // the pub u128 field

--- a/tfhe/src/core_crypto/seeders.rs
+++ b/tfhe/src/core_crypto/seeders.rs
@@ -9,7 +9,10 @@ pub use crate::core_crypto::commons::math::random::Seeder;
 pub use tfhe_csprng::seeders::AppleSecureEnclaveSeeder;
 #[cfg(all(target_arch = "x86_64", not(feature = "__wasm_api")))]
 pub use tfhe_csprng::seeders::RdseedSeeder;
-#[cfg(all(target_family = "unix", not(feature = "__wasm_api")))]
+#[cfg(all(
+    any(target_family = "unix", target_os = "windows"),
+    not(feature = "__wasm_api")
+))]
 pub use tfhe_csprng::seeders::UnixSeeder;
 
 #[cfg(feature = "__wasm_api")]
@@ -51,6 +54,9 @@ mod wasm_seeder {
 /// On Unix platforms, this will use `getrandom` or `getentropy` system call if available. Otherwise
 /// it will draw from `/dev/urandom` after successfully polling `/dev/random`.
 ///
+/// On Windows, a `getrandom`-backed OS entropy source is used when hardware seeding is not used (for
+/// example on AArch64 or when the `rdseed` instruction is unavailable).
+///
 /// For the wasm32 target the [`getrandom`](`https://docs.rs/getrandom/latest/getrandom/`)
 /// js random number generator is used as a source of
 /// [`cryptographically random numbers per the W3C documentation`](`https://www.w3.org/TR/WebCryptoAPI/#Crypto-method-getRandomValues`).
@@ -90,7 +96,7 @@ pub fn new_seeder() -> Box<dyn Seeder> {
             }
         }
 
-        #[cfg(target_family = "unix")]
+        #[cfg(any(target_family = "unix", target_os = "windows"))]
         {
             if seeder.is_none() && UnixSeeder::is_available() {
                 seeder = Some(Box::new(UnixSeeder::new(0)));


### PR DESCRIPTION
## what this fixes


ew_seeder() in 	fhe could panic on Windows whenever no hardware seeder was chosen: x86_64 machines without a working \
dseed\ path, and all Windows AArch64 builds, because only \RdseedSeeder\ and \UnixSeeder\ (unix-only) were considered. The library already depends on \getrandom\, which implements proper OS entropy on Windows (including AArch64).

This wires the existing \UnixSeeder\ (OS entropy via \getrandom\) for \	arget_os = "windows"\ as well, updates the csprng example/bench cfgs, and removes the outdated README/CONTRIBUTING note that said Windows AArch64 was unsupported for lack of entropy.

## testing

Could not run \cargo check\ in this environment (no Rust toolchain on PATH). Please run the usual CI / local checks.

---
made by mooncitydev

