### PR TITLE
fix(bench): wrong size in wasm benchmarks

### DIFF
--- a/tfhe-benchmark/src/bin/wasm_benchmarks_parser.rs
+++ b/tfhe-benchmark/src/bin/wasm_benchmarks_parser.rs
@@ -59,7 +59,7 @@ pub fn parse_wasm_benchmarks(results_file: &Path, raw_results_file: &Path) {
         let bench_name = name_parts[0];
         let params: PBSParameters = params_from_name(name_parts[1]).into();
         println!("{name_parts:?}");
-        if bench_name.contains("_size") {
+        if full_name.contains("_size") {
             write_result(&mut file, &prefixed_full_name, *val as usize);
         } else {
             let value_in_ns = (val * 1_000_000_f32) as usize;


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description
since bench name format changed I guess, the size bench results were multiplied by 1000_000 because the "_size" marker was not found in the short name