### PR TITLE
chore: bump tfhe-hpu-backend after erc7984 update

### DIFF
--- a/backends/tfhe-hpu-backend/Cargo.toml
+++ b/backends/tfhe-hpu-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tfhe-hpu-backend"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "BSD-3-Clause-Clear"
 description = "HPU implementation on FPGA of TFHE-rs primitives."

--- a/tfhe/Cargo.toml
+++ b/tfhe/Cargo.toml
@@ -99,7 +99,7 @@ serde-wasm-bindgen = { workspace = true, optional = true }
 getrandom = { workspace = true, optional = true }
 bytemuck = { workspace = true }
 
-tfhe-hpu-backend = { version = "0.4", path = "../backends/tfhe-hpu-backend", optional = true }
+tfhe-hpu-backend = { version = "0.5", path = "../backends/tfhe-hpu-backend", optional = true }
 
 [features]
 default = ["avx512"]


### PR DESCRIPTION
there was the erc7984 update which most likely is breaking, so bumping out of caution to not be stuck during release