### PR TITLE
chore(ci): check that Cargo.lock of generate_ crates is up to date

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -587,6 +587,17 @@ clippy_backward_compat_data: install_rs_check_toolchain # the toolchain is selec
 		echo "Cannot run clippy for backward compat crate on non x86 platform for now."; \
 	fi
 
+.PHONY: check_backward_compat_locks_did_not_change # Check backward compat Cargo.lock files are up to date
+check_backward_compat_locks_did_not_change: install_rs_check_toolchain
+	@for crate in `ls -1 $(BACKWARD_COMPAT_DATA_DIR)/crates/ | grep generate_`; do \
+		echo "checking Cargo.lock for $$crate"; \
+		cargo "$(CARGO_RS_CHECK_TOOLCHAIN)" -Z unstable-options \
+			-C $(BACKWARD_COMPAT_DATA_DIR)/crates/$$crate metadata --locked --format-version 1 > /dev/null || \
+		( echo "Cargo.lock for $$crate is out of date. Update it with:" && \
+		  echo "  cd $(BACKWARD_COMPAT_DATA_DIR)/crates/$$crate && cargo metadata --format-version 1 > /dev/null" && \
+		  echo "then commit the updated Cargo.lock." && exit 1 ); \
+	done
+
 .PHONY: clippy_test_vectors # Run clippy lints on the test vectors app
 clippy_test_vectors: install_rs_check_toolchain
 	cd apps/test-vectors; RUSTFLAGS="$(RUSTFLAGS)" cargo "$(CARGO_RS_CHECK_TOOLCHAIN)" clippy --all-targets \
@@ -2265,6 +2276,7 @@ pcc_batch_5:
 	$(call run_recipe_with_details,clippy_tfhe_lints)
 	$(call run_recipe_with_details,check_compile_tests)
 	$(call run_recipe_with_details,clippy_backward_compat_data)
+	$(call run_recipe_with_details,check_backward_compat_locks_did_not_change)
 
 .PHONY: pcc_batch_6  # duration: 6'32''
 pcc_batch_6:

--- a/utils/tfhe-backward-compat-data/crates/generate_1_6/Cargo.lock
+++ b/utils/tfhe-backward-compat-data/crates/generate_1_6/Cargo.lock
@@ -994,6 +994,7 @@ dependencies = [
  "tfhe-csprng",
  "tfhe-fft",
  "tfhe-ntt",
+ "tfhe-safe-serialize",
  "tfhe-versionable",
  "tfhe-zk-pok",
 ]
@@ -1046,6 +1047,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tfhe-safe-serialize"
+version = "0.1.0"
+dependencies = [
+ "bincode",
+ "serde",
+ "tfhe-versionable",
+]
+
+[[package]]
 name = "tfhe-versionable"
 version = "0.7.0"
 dependencies = [
@@ -1073,11 +1083,13 @@ dependencies = [
  "ark-ff",
  "ark-poly",
  "getrandom",
+ "itertools 0.14.0",
  "num-bigint",
  "rand",
  "rayon",
  "serde",
  "sha3",
+ "tfhe-safe-serialize",
  "tfhe-versionable",
  "zeroize",
 ]


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description
Adds a check in ci that the Cargo.lock of the generate_XXX (backward data generation) crates are stable. The Cargo.lock of the generate crate for the current version can be "broken" if we add a dependency to the `tfhe` crate.

Basically we just do a git diff on the lock files after the clippy clippy_backward_compat_data and check that nothing changed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3479)
<!-- Reviewable:end -->
