### PR TITLE
chore: dirty fix for zk-cuda-backend build problem

### DIFF
--- a/backends/zk-cuda-backend/build.rs
+++ b/backends/zk-cuda-backend/build.rs
@@ -32,7 +32,7 @@ fn main() {
         // Check Linux distribution (reuse script from tfhe-cuda-backend)
         let manifest_dir = std::env::var("CARGO_MANIFEST_DIR")
             .expect("CARGO_MANIFEST_DIR must be set by cargo during build");
-        let script_path = PathBuf::from(&manifest_dir).join("../tfhe-cuda-backend/get_os_name.sh");
+        let script_path = PathBuf::from(&manifest_dir).join("./get_os_name.sh");
         let output = Command::new(&script_path)
             .output()
             .expect("Failed to run get_os_name.sh — is tfhe-cuda-backend present?");

--- a/backends/zk-cuda-backend/get_os_name.sh
+++ b/backends/zk-cuda-backend/get_os_name.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+cat /etc/os-release | grep "\<NAME\>" | sed "s/NAME=\"//g" | sed "s/\"//g"


### PR DESCRIPTION
- when compiling for real it cannot find the file which is not available
