### PR TITLE
chore(gpu): remove os detection script (done in rust)

### DIFF
--- a/backends/tfhe-cuda-backend/build.rs
+++ b/backends/tfhe-cuda-backend/build.rs
@@ -1,5 +1,14 @@
 use std::path::PathBuf;
-use std::process::Command;
+
+fn get_linux_distribution_name() -> Option<String> {
+    let content = std::fs::read_to_string("/etc/os-release").ok()?;
+    for line in content.lines() {
+        if let Some(value) = line.strip_prefix("NAME=") {
+            return Some(value.trim_matches('"').to_string());
+        }
+    }
+    None
+}
 
 fn main() {
     if let Ok(val) = std::env::var("DOCS_RS") {
@@ -28,9 +37,7 @@ fn main() {
     println!("cargo::rerun-if-changed=src");
 
     if std::env::consts::OS == "linux" {
-        let output = Command::new("./get_os_name.sh").output().unwrap();
-        let distribution = String::from_utf8(output.stdout).unwrap();
-        if distribution != "Ubuntu\n" {
+        if get_linux_distribution_name().as_deref() != Some("Ubuntu") {
             println!(
                 "cargo:warning=This Linux distribution is not officially supported. \
                 Only Ubuntu is supported by tfhe-cuda-backend at this time. Build may fail\n"

--- a/backends/tfhe-cuda-backend/get_os_name.sh
+++ b/backends/tfhe-cuda-backend/get_os_name.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-cat /etc/os-release | grep "\<NAME\>" | sed "s/NAME=\"//g" | sed "s/\"//g"

--- a/backends/zk-cuda-backend/build.rs
+++ b/backends/zk-cuda-backend/build.rs
@@ -1,5 +1,14 @@
 use std::path::PathBuf;
-use std::process::Command;
+
+fn get_linux_distribution_name() -> Option<String> {
+    let content = std::fs::read_to_string("/etc/os-release").ok()?;
+    for line in content.lines() {
+        if let Some(value) = line.strip_prefix("NAME=") {
+            return Some(value.trim_matches('"').to_string());
+        }
+    }
+    None
+}
 
 fn main() {
     // Handle docs.rs builds (no CUDA available)
@@ -29,16 +38,10 @@ fn main() {
         println!("cargo:rustc-link-arg=-Wl,--allow-multiple-definition");
         println!("cargo:rustc-link-arg=-Wl,--no-as-needed");
 
-        // Check Linux distribution (reuse script from tfhe-cuda-backend)
         let manifest_dir = std::env::var("CARGO_MANIFEST_DIR")
             .expect("CARGO_MANIFEST_DIR must be set by cargo during build");
-        let script_path = PathBuf::from(&manifest_dir).join("./get_os_name.sh");
-        let output = Command::new(&script_path)
-            .output()
-            .expect("Failed to run get_os_name.sh — is tfhe-cuda-backend present?");
-        let distribution =
-            String::from_utf8(output.stdout).expect("get_os_name.sh output must be valid UTF-8");
-        if distribution != "Ubuntu\n" {
+
+        if get_linux_distribution_name().as_deref() != Some("Ubuntu") {
             println!(
                 "cargo:warning=This Linux distribution is not officially supported. \
                 Only Ubuntu is supported by zk-cuda-backend at this time. Build may fail\n"

--- a/backends/zk-cuda-backend/get_os_name.sh
+++ b/backends/zk-cuda-backend/get_os_name.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-cat /etc/os-release | grep "\<NAME\>" | sed "s/NAME=\"//g" | sed "s/\"//g"


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description
remove the os detection script for cuda backend, detection is done in rust