### PR TITLE
chore: dirty fix for zk-cuda-backend rust build

### DIFF
--- a/backends/zk-cuda-backend/cuda/CMakeLists.txt
+++ b/backends/zk-cuda-backend/cuda/CMakeLists.txt
@@ -71,11 +71,6 @@ set(CMAKE_CUDA_FLAGS_DEBUG "-g -O0 -G")
 # Additional CUDA flags (aligned with tfhe-cuda-backend)
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler -Wall -Xcompiler -Wextra --use_fast_math --expt-relaxed-constexpr")
 
-# =============================================================================
-# Path to tfhe-cuda-backend for device utilities
-# =============================================================================
-set(TFHE_CUDA_BACKEND_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../tfhe-cuda-backend/cuda)
-
 # Core source files (without device utilities) Device utilities come from tfhe-cuda-backend.
 set(FP_CORE_SOURCES src/primitives/fp.cu src/primitives/fp2.cu src/curve.cu src/msm/pippenger/msm_pippenger.cu
                     src/msm/msm.cu)
@@ -112,7 +107,7 @@ endif()
 target_link_libraries(zk_cuda_backend PUBLIC cudart)
 
 # Include both local headers and tfhe-cuda-backend headers (for device.h)
-target_include_directories(zk_cuda_backend PUBLIC include ../src/include ${TFHE_CUDA_BACKEND_DIR}/include)
+target_include_directories(zk_cuda_backend PUBLIC include ../src/include)
 
 # =============================================================================
 # Tests and Benchmarks (optional, controlled by ZK_CUDA_BACKEND_BUILD_TESTS/BENCHMARKS)
@@ -135,4 +130,3 @@ message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 message(STATUS "CUDA architectures: ${CMAKE_CUDA_ARCHITECTURES}")
 message(STATUS "C++ standard: ${CMAKE_CXX_STANDARD}")
 message(STATUS "CUDA standard: ${CMAKE_CUDA_STANDARD}")
-message(STATUS "tfhe-cuda-backend path: ${TFHE_CUDA_BACKEND_DIR}")

--- a/backends/zk-cuda-backend/cuda/include/checked_arithmetic.h
+++ b/backends/zk-cuda-backend/cuda/include/checked_arithmetic.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdio>
+
+#include "device.h"
+
+// Variadic checked multiplication of size_t values.
+// Folds left-to-right using __builtin_mul_overflow, returning true on overflow.
+// On overflow the value written to *out is unspecified.
+template <typename... Args>
+inline bool checked_mul(size_t *out, size_t first, Args... rest) {
+  size_t result = first;
+  for (size_t value : {static_cast<size_t>(rest)...}) {
+    if (__builtin_mul_overflow(result, value, &result))
+      return true;
+  }
+  *out = result;
+  return false;
+}
+
+// Variadic safe multiplication: computes the product and panics on overflow.
+template <typename... Args> inline size_t safe_mul(size_t first, Args... rest) {
+  size_t result;
+  bool overflow = checked_mul(&result, first, rest...);
+  PANIC_IF_FALSE(!overflow, "multiplication overflow wraps size_t");
+  return result;
+}
+
+// Variadic safe multiplication with an appended sizeof(T) factor.
+// Computes (args... * sizeof(T)) with overflow checking.
+template <typename T, typename... Args>
+inline size_t safe_mul_sizeof(Args... args) {
+  return safe_mul(args..., sizeof(T));
+}

--- a/backends/zk-cuda-backend/cuda/include/device.h
+++ b/backends/zk-cuda-backend/cuda/include/device.h
@@ -1,0 +1,145 @@
+#ifndef DEVICE_H
+#define DEVICE_H
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cuda_runtime.h>
+
+extern "C" {
+
+#define check_cuda_error(ans)                                                  \
+  { cuda_error((ans), __FILE__, __LINE__); }
+inline void cuda_error(cudaError_t code, const char *file, int line) {
+  if (code != cudaSuccess) {
+    std::fprintf(stderr, "Cuda error: %s %s %d\n", cudaGetErrorString(code),
+                 file, line);
+    std::abort();
+  }
+}
+
+// The PANIC macro should be used to validate user-inputs to GPU functions
+// it will execute in all targets, including production settings
+// e.g., cudaMemCopy to the device should check that the destination pointer is
+// a device pointer
+#define PANIC(format, ...)                                                     \
+  {                                                                            \
+    std::fprintf(stderr, "%s::%d::%s: panic.\n" format "\n", __FILE__,         \
+                 __LINE__, __func__, ##__VA_ARGS__);                           \
+    std::abort();                                                              \
+  }
+
+// This is a generic assertion checking macro with user defined printf-style
+// message
+#define PANIC_IF_FALSE(cond, format, ...)                                      \
+  do {                                                                         \
+    if (!(cond)) {                                                             \
+      PANIC(format "\n\n %s\n", ##__VA_ARGS__, #cond);                         \
+    }                                                                          \
+  } while (0)
+
+#ifndef GPU_ASSERTS_DISABLE
+// The GPU assert should be used to validate assumptions in algorithms,
+// for example, checking that two user-provided quantities have a certain
+// relationship or that the size of the buffer  provided to a function is
+// sufficient when it is filled with some algorithm that depends on
+// user-provided inputs e.g., OPRF corrections buffer should not have a size
+// higher than the number of blocks in the datatype that is generated
+#define GPU_ASSERT(cond, format, ...)                                          \
+  PANIC_IF_FALSE(cond, format, ##__VA_ARGS__)
+#else
+#define GPU_ASSERT(cond)                                                       \
+  do {                                                                         \
+  } while (0)
+#endif
+
+uint32_t cuda_get_device();
+void cuda_set_device(uint32_t gpu_index);
+
+cudaEvent_t cuda_create_event(uint32_t gpu_index);
+
+void cuda_event_record(cudaEvent_t event, cudaStream_t stream,
+                       uint32_t gpu_index);
+void cuda_stream_wait_event(cudaStream_t stream, cudaEvent_t event,
+                            uint32_t gpu_index);
+
+void cuda_event_destroy(cudaEvent_t event, uint32_t gpu_index);
+
+cudaStream_t cuda_create_stream(uint32_t gpu_index);
+
+void cuda_destroy_stream(cudaStream_t stream, uint32_t gpu_index);
+
+void cuda_synchronize_stream(cudaStream_t stream, uint32_t gpu_index);
+
+uint32_t cuda_is_available();
+
+void *cuda_malloc(uint64_t size, uint32_t gpu_index);
+
+void *cuda_malloc_with_size_tracking_async(uint64_t size, cudaStream_t stream,
+                                           uint32_t gpu_index,
+                                           uint64_t &size_tracker,
+                                           bool allocate_gpu_memory);
+
+void *cuda_malloc_async(uint64_t size, cudaStream_t stream, uint32_t gpu_index);
+
+bool cuda_check_valid_malloc(uint64_t size, uint32_t gpu_index);
+uint64_t cuda_device_total_memory(uint32_t gpu_index);
+
+void cuda_memcpy_with_size_tracking_async_to_gpu(void *dest, const void *src,
+                                                 uint64_t size,
+                                                 cudaStream_t stream,
+                                                 uint32_t gpu_index,
+                                                 bool gpu_memory_allocated);
+
+void cuda_memcpy_async_to_gpu(void *dest, const void *src, uint64_t size,
+                              cudaStream_t stream, uint32_t gpu_index);
+
+void cuda_memcpy_with_size_tracking_async_gpu_to_gpu(
+    void *dest, void const *src, uint64_t size, cudaStream_t stream,
+    uint32_t gpu_index, bool gpu_memory_allocated);
+
+void cuda_memcpy_async_gpu_to_gpu(void *dest, void const *src, uint64_t size,
+                                  cudaStream_t stream, uint32_t gpu_index);
+
+void cuda_memcpy_gpu_to_gpu(void *dest, void const *src, uint64_t size,
+                            uint32_t gpu_index);
+
+void cuda_memcpy_async_to_cpu(void *dest, const void *src, uint64_t size,
+                              cudaStream_t stream, uint32_t gpu_index);
+
+void cuda_memset_with_size_tracking_async(void *dest, uint64_t val,
+                                          uint64_t size, cudaStream_t stream,
+                                          uint32_t gpu_index,
+                                          bool gpu_memory_allocated);
+
+void cuda_memset_async(void *dest, uint64_t val, uint64_t size,
+                       cudaStream_t stream, uint32_t gpu_index);
+
+int cuda_get_number_of_gpus();
+
+int cuda_get_number_of_sms();
+
+void cuda_synchronize_device(uint32_t gpu_index);
+
+void cuda_drop(void *ptr, uint32_t gpu_index);
+
+void cuda_drop_with_size_tracking_async(void *ptr, cudaStream_t stream,
+                                        uint32_t gpu_index,
+                                        bool gpu_memory_allocated);
+
+void cuda_drop_async(void *ptr, cudaStream_t stream, uint32_t gpu_index);
+}
+
+uint32_t cuda_get_max_shared_memory(uint32_t gpu_index);
+
+uint32_t cuda_get_max_shared_memory_per_block(uint32_t gpu_index);
+
+bool cuda_check_support_cooperative_groups();
+
+bool cuda_check_support_thread_block_clusters();
+
+template <typename Torus>
+void cuda_set_value_async(cudaStream_t stream, uint32_t gpu_index,
+                          Torus *d_array, Torus value, Torus n);
+
+#endif

--- a/backends/zk-cuda-backend/cuda/include/helper_profile.cuh
+++ b/backends/zk-cuda-backend/cuda/include/helper_profile.cuh
@@ -1,0 +1,16 @@
+#ifndef HELPER_PROFILE
+#define HELPER_PROFILE
+
+#ifdef USE_NVTOOLS
+#include <nvtx3/nvToolsExt.h>
+#endif
+
+void cuda_nvtx_label_with_color(const char *name);
+void cuda_nvtx_pop();
+
+#define PUSH_RANGE(name)                                                       \
+  { cuda_nvtx_label_with_color(name); }
+#define POP_RANGE()                                                            \
+  { cuda_nvtx_pop(); }
+
+#endif

--- a/backends/zk-cuda-backend/cuda/src/helper_profile.cu
+++ b/backends/zk-cuda-backend/cuda/src/helper_profile.cu
@@ -1,0 +1,43 @@
+#include "helper_profile.cuh"
+#include <stdint.h>
+
+uint32_t adler32(const unsigned char *data) {
+  const uint32_t MOD_ADLER = 65521;
+  uint32_t a = 1, b = 0;
+  size_t index;
+  for (index = 0; data[index] != 0; ++index) {
+    a = (a + data[index] * 2) % MOD_ADLER;
+    b = (b + a) % MOD_ADLER;
+  }
+  return (b << 16) | a;
+}
+
+void cuda_nvtx_label_with_color(const char *name) {
+#ifdef USE_NVTOOLS
+  int color_id = adler32((const unsigned char *)name);
+  int r, g, b;
+  r = color_id & 0x000000ff;
+  g = (color_id & 0x000ff000) >> 12;
+  b = (color_id & 0x0ff00000) >> 20;
+  if (r < 64 & g < 64 & b < 64) {
+    r = r * 3;
+    g = g * 3 + 64;
+    b = b * 4;
+  }
+
+  color_id = 0xff000000 | (r << 16) | (g << 8) | (b);
+  nvtxEventAttributes_t eventAttrib = {0};
+  eventAttrib.version = NVTX_VERSION;
+  eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+  eventAttrib.colorType = NVTX_COLOR_ARGB;
+  eventAttrib.color = color_id;
+  eventAttrib.messageType = NVTX_MESSAGE_TYPE_ASCII;
+  eventAttrib.message.ascii = name;
+  nvtxRangePushEx(&eventAttrib);
+#endif
+}
+void cuda_nvtx_pop() {
+#ifdef USE_NVTOOLS
+  nvtxRangePop();
+#endif
+}

--- a/backends/zk-cuda-backend/src/c_wrapper.cu
+++ b/backends/zk-cuda-backend/src/c_wrapper.cu
@@ -11,7 +11,7 @@
 #include <stddef.h>
 #include <cstring>
 
-#include "../../tfhe-cuda-backend/cuda/src/utils/helper_profile.cuh"
+#include "helper_profile.cuh"
 
 // C++ helper functions (not exported, used internally)
 // These can call template functions since they have C++ linkage


### PR DESCRIPTION
quick and dirty fix of compilation fo zk-cuda-backend

the backend depends on headers that does not belong to it, making the compilation fail when trying to compile using the crates.io dependency

this PR fixes it temporarily, but this needs to be adressed long term


https://github.com/zama-ai/tfhe-rs-internal/issues/1386