### PR TITLE
chore(ci): add terraform script to use scaleway as provider

### DIFF
--- a/ci/slab.toml
+++ b/ci/slab.toml
@@ -112,3 +112,8 @@ environment_name = "canada"
 image_name = "Ubuntu Server 22.04 LTS R570 CUDA 12.8"
 flavor_name = "n3-L40x8"
 user = "ubuntu"
+
+[backend.terraform.scaleway-multi-h100-sxm5]
+script_path = "ci/terraform_scripts/scaleway/multi-h100-sxm5/terraform.tf"
+instance_type = "H100-SXM-8-80G"
+user = "ubuntu"

--- a/ci/terraform_scripts/scaleway/multi-h100-sxm5/terraform.tf
+++ b/ci/terraform_scripts/scaleway/multi-h100-sxm5/terraform.tf
@@ -1,0 +1,71 @@
+terraform {
+  required_providers {
+    scaleway = {
+      source  = "scaleway/scaleway"
+      version = "~> 2.73"
+    }
+  }
+  required_version = "~> 1.14"
+}
+
+provider "scaleway" {
+  zone = "fr-par-2"
+}
+
+# Provided via Slab server env
+variable "project_id" {
+  type        = string
+  description = "Scaleway project ID to attached to"
+}
+
+# Provided via ci/slab.toml
+variable "instance_type" {
+  type        = string
+  description = "Scaleway instance type to be used"
+}
+
+# Provided by Slab server
+variable "instance_label" {
+  type        = string
+  description = "Instance name to display in console"
+}
+
+# Provided by Slab server
+variable "user_data" {
+  type        = string
+  description = "Script that will be run at instance startup"
+}
+
+resource "scaleway_instance_ip" "github_runner" {
+  project_id = var.project_id
+}
+
+resource "scaleway_instance_security_group" "github_runner" {
+  project_id              = var.project_id
+  inbound_default_policy  = "drop"
+  outbound_default_policy = "accept"
+}
+
+data "scaleway_instance_image" "gpu_benchmark_image" {
+  name = "tfhe-rs-ubuntu-noble-cuda"
+}
+
+resource "scaleway_instance_server" "multi_h100_sxm5" {
+  project_id = var.project_id
+  image      = data.scaleway_instance_image.gpu_benchmark_image.id
+  type       = var.instance_type
+  name       = var.instance_label
+
+  ip_id = scaleway_instance_ip.github_runner.id
+
+  user_data = {
+    "cloud-init" = var.user_data
+  }
+
+  security_group_id = scaleway_instance_security_group.github_runner.id
+}
+
+output "instance_id" {
+  value       = scaleway_instance_server.multi_h100_sxm5.id
+  description = "Unique ID of the Scaleway instance"
+}


### PR DESCRIPTION
This will allow CI user to spawn a H100x8-SXM5 on Scaleway cloud provider using Terraform integrated in Zama continuous integration bot.

This PR simply adds the Terraform script, a second PR will be open to make it usable in the workflows.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3499)
<!-- Reviewable:end -->
