### PR TITLE
chore(zk-gpu): run zk-cuda-backend under valgrind and compute-sanitizer

### DIFF
--- a/.github/workflows/gpu_zk_code_validation_tests.yml
+++ b/.github/workflows/gpu_zk_code_validation_tests.yml
@@ -1,0 +1,165 @@
+# Compile and test zk-cuda-backend under compute-sanitizer racecheck and valgrind
+name: gpu_zk_code_validation_tests
+
+env:
+  CARGO_TERM_COLOR: always
+  ACTION_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+  RUSTFLAGS: "-C target-cpu=native"
+  RUST_BACKTRACE: "full"
+  RUST_MIN_STACK: "8388608"
+  SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
+  SLACK_ICON: https://pbs.twimg.com/profile_images/1274014582265298945/OjBKP9kn_400x400.png
+  SLACK_USERNAME: ${{ secrets.BOT_USERNAME }}
+  SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+  SLACKIFY_MARKDOWN: true
+  IS_PULL_REQUEST: ${{ github.event_name == 'pull_request' }}
+  PULL_REQUEST_MD_LINK: ""
+  CHECKOUT_TOKEN: ${{ secrets.REPO_CHECKOUT_TOKEN || secrets.GITHUB_TOKEN }}
+  # Secrets will be available only to zama-ai organization members
+  SECRETS_AVAILABLE: ${{ secrets.JOB_SECRET != '' }}
+  EXTERNAL_CONTRIBUTION_RUNNER: "gpu_ubuntu-22.04"
+
+on:
+  # Allows you to run this workflow manually from the Actions tab as an alternative.
+  workflow_dispatch:
+  schedule:
+    # every friday noon
+    - cron: "0 12 * * 5"
+
+permissions:
+  contents: read
+
+# zizmor: ignore[concurrency-limits] concurrency is managed after instance setup to ensure safe provisioning
+
+jobs:
+  setup-instance:
+    name: gpu_zk_code_validation_tests/setup-instance
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'schedule' && github.repository == 'zama-ai/tfhe-rs')
+    outputs:
+      runner-name: ${{ steps.start-remote-instance.outputs.label || steps.start-github-instance.outputs.runner_group }}
+    steps:
+      - name: Start remote instance
+        id: start-remote-instance
+        if: env.SECRETS_AVAILABLE == 'true'
+        uses: zama-ai/slab-github-runner@5aee5d157f4a0201e5eaefc9cc648e5f9f5472a5 # v1.6.0
+        with:
+          mode: start
+          github-token: ${{ secrets.SLAB_ACTION_TOKEN }}
+          slab-url: ${{ secrets.SLAB_BASE_URL }}
+          job-secret: ${{ secrets.JOB_SECRET }}
+          backend: hyperstack
+          profile: single-h100
+
+      # This instance will be spawned especially for pull-request from forked repository
+      - name: Start GitHub instance
+        id: start-github-instance
+        if: env.SECRETS_AVAILABLE == 'false'
+        run: |
+          echo "runner_group=${EXTERNAL_CONTRIBUTION_RUNNER}" >> "$GITHUB_OUTPUT"
+
+  cuda-tests-linux:
+    name: gpu_zk_code_validation_tests/cuda-tests-linux
+    needs: [ setup-instance ]
+    if: github.event_name != 'pull_request' ||
+      (github.event_name == 'pull_request' && needs.setup-instance.result != 'skipped')
+    concurrency:
+      group: ${{ github.workflow_ref }}
+      cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+    runs-on: ${{ needs.setup-instance.outputs.runner-name }}
+    timeout-minutes: 14400
+    strategy:
+      fail-fast: false
+      # explicit include-based build matrix, of known valid options
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            cuda: "12.8"
+            gcc: 11
+    steps:
+      - name: Checkout tfhe-rs
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: 'false'
+          token: ${{ env.CHECKOUT_TOKEN }}
+
+      - name: Setup Hyperstack dependencies
+        uses: ./.github/actions/gpu_setup
+        with:
+          cuda-version: ${{ matrix.cuda }}
+          gcc-version: ${{ matrix.gcc }}
+          github-instance: ${{ env.SECRETS_AVAILABLE == 'false' }}
+
+      - name: Find tools
+        run: |
+          # Disable unattended-upgrades to avoid lock issues
+          sudo systemctl mask --now unattended-upgrades
+          sudo systemctl stop --now unattended-upgrades
+
+          sudo apt-get clean
+          sudo rm -rf /var/lib/apt/lists/*
+          sudo apt purge -y unattended-upgrades
+
+          sudo apt update && sudo apt install -y valgrind
+          find /usr -executable -name "compute-sanitizer"
+          which valgrind
+
+      - name: Install latest stable
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # zizmor: ignore[stale-action-refs] this action doesn't create releases
+        with:
+          toolchain: stable
+
+      - name: Run ZK CUDA backend racecheck tests
+        run: |
+          make test_zk_cuda_backend_race_check
+
+      - name: Run tfhe-zk-pok valgrind tests
+        run: |
+          make test_zk_pok_gpu_valgrind
+
+  slack-notify:
+    name: gpu_zk_code_validation_tests/slack-notify
+    needs: [ setup-instance, cuda-tests-linux ]
+    runs-on: ubuntu-latest
+    if: ${{ always() && needs.cuda-tests-linux.result != 'skipped' && failure() }}
+    continue-on-error: true
+    steps:
+      - name: Set pull-request URL
+        if: env.SECRETS_AVAILABLE == 'true' && github.event_name == 'pull_request'
+        run: |
+          echo "PULL_REQUEST_MD_LINK=[pull-request](${PR_BASE_URL}${PR_NUMBER}), "  >> "${GITHUB_ENV}"
+        env:
+          PR_BASE_URL: ${{ vars.PR_BASE_URL }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+
+      - name: Send message
+        if: env.SECRETS_AVAILABLE == 'true'
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661
+        env:
+          SLACK_COLOR: ${{ needs.cuda-tests-linux.result }}
+          SLACK_MESSAGE: "ZK GPU Memory Checks tests finished with status: ${{ needs.cuda-tests-linux.result }}. (${{ env.PULL_REQUEST_MD_LINK }}[action run](${{ env.ACTION_RUN_URL }}))"
+
+  teardown-instance:
+    name: gpu_zk_code_validation_tests/teardown-instance
+    if: ${{ always() && needs.setup-instance.result == 'success' }}
+    needs: [ setup-instance, cuda-tests-linux ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Stop remote instance
+        id: stop-instance
+        if: env.SECRETS_AVAILABLE == 'true'
+        uses: zama-ai/slab-github-runner@5aee5d157f4a0201e5eaefc9cc648e5f9f5472a5 # v1.6.0
+        with:
+          mode: stop
+          github-token: ${{ secrets.SLAB_ACTION_TOKEN }}
+          slab-url: ${{ secrets.SLAB_BASE_URL }}
+          job-secret: ${{ secrets.JOB_SECRET }}
+          label: ${{ needs.setup-instance.outputs.runner-name }}
+
+      - name: Slack Notification
+        if: ${{ failure() }}
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661
+        env:
+          SLACK_COLOR: ${{ job.status }}
+          SLACK_MESSAGE: "Instance teardown (gpu-zk-code-validation-tests) finished with status: ${{ job.status }}. (${{ env.ACTION_RUN_URL }})"

--- a/.github/workflows/gpu_zk_memory_sanitizer.yml
+++ b/.github/workflows/gpu_zk_memory_sanitizer.yml
@@ -1,0 +1,187 @@
+# Compile and test zk-cuda-backend under compute-sanitizer memcheck
+name: gpu_zk_memory_sanitizer
+
+env:
+  CARGO_TERM_COLOR: always
+  ACTION_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+  RUSTFLAGS: "-C target-cpu=native"
+  RUST_BACKTRACE: "full"
+  RUST_MIN_STACK: "8388608"
+  SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
+  SLACK_ICON: https://pbs.twimg.com/profile_images/1274014582265298945/OjBKP9kn_400x400.png
+  SLACK_USERNAME: ${{ secrets.BOT_USERNAME }}
+  SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+  SLACKIFY_MARKDOWN: true
+  IS_PULL_REQUEST: ${{ github.event_name == 'pull_request' }}
+  PULL_REQUEST_MD_LINK: ""
+  CHECKOUT_TOKEN: ${{ secrets.REPO_CHECKOUT_TOKEN || secrets.GITHUB_TOKEN }}
+  # Secrets will be available only to zama-ai organization members
+  SECRETS_AVAILABLE: ${{ secrets.JOB_SECRET != '' }}
+  EXTERNAL_CONTRIBUTION_RUNNER: "gpu_ubuntu-22.04"
+
+on:
+  # Allows you to run this workflow manually from the Actions tab as an alternative.
+  pull_request:
+    types: [ labeled ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# zizmor: ignore[concurrency-limits] concurrency is managed after instance setup to ensure safe provisioning
+
+jobs:
+  should-run:
+    name: gpu_zk_memory_sanitizer/should-run
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read  # Needed to check for file change
+    outputs:
+      gpu_test: ${{ env.IS_PULL_REQUEST == 'false' || steps.changed-files.outputs.gpu_any_changed }}
+    steps:
+      - name: Checkout tfhe-rs
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+          persist-credentials: 'false'
+          token: ${{ env.CHECKOUT_TOKEN }}
+
+      - name: Check for file changes
+        id: changed-files
+        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323 # v47.0.5
+        with:
+          files_yaml: |
+            gpu:
+              - Cargo.toml
+              - tfhe/Cargo.toml
+              - tfhe/build.rs
+              - backends/tfhe-cuda-backend/**
+              - backends/zk-cuda-backend/**
+              - tfhe-zk-pok/**
+              - tfhe/src/zk/**
+              - tfhe/src/shortint/parameters/**
+              - '.github/workflows/gpu_zk_memory_sanitizer.yml'
+              - ci/slab.toml
+
+  setup-instance:
+    name: gpu_zk_memory_sanitizer/setup-instance
+    needs: should-run
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' ||
+      (github.event.action == 'labeled' && github.event.label.name == 'approved' && needs.should-run.outputs.gpu_test == 'true')
+    outputs:
+      runner-name: ${{ steps.start-remote-instance.outputs.label || steps.start-github-instance.outputs.runner_group }}
+    steps:
+      - name: Start remote instance
+        id: start-remote-instance
+        if: env.SECRETS_AVAILABLE == 'true'
+        uses: zama-ai/slab-github-runner@5aee5d157f4a0201e5eaefc9cc648e5f9f5472a5 # v1.6.0
+        with:
+          mode: start
+          github-token: ${{ secrets.SLAB_ACTION_TOKEN }}
+          slab-url: ${{ secrets.SLAB_BASE_URL }}
+          job-secret: ${{ secrets.JOB_SECRET }}
+          backend: hyperstack
+          profile: gpu-test
+
+      # This instance will be spawned especially for pull-request from forked repository
+      - name: Start GitHub instance
+        id: start-github-instance
+        if: env.SECRETS_AVAILABLE == 'false'
+        run: |
+          echo "runner_group=${EXTERNAL_CONTRIBUTION_RUNNER}" >> "$GITHUB_OUTPUT"
+
+  cuda-tests-linux:
+    name: gpu_zk_memory_sanitizer/cuda-tests-linux
+    needs: [ setup-instance ]
+    if: github.event_name != 'pull_request' ||
+      (github.event_name == 'pull_request' && needs.setup-instance.result != 'skipped')
+    concurrency:
+      group: ${{ github.workflow_ref }}
+      cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+    runs-on: ${{ needs.setup-instance.outputs.runner-name }}
+    timeout-minutes: 240
+    strategy:
+      fail-fast: false
+      # explicit include-based build matrix, of known valid options
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            cuda: "12.8"
+            gcc: 11
+    steps:
+      - name: Checkout tfhe-rs
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: 'false'
+          token: ${{ env.CHECKOUT_TOKEN }}
+
+      - name: Setup Hyperstack dependencies
+        uses: ./.github/actions/gpu_setup
+        with:
+          cuda-version: ${{ matrix.cuda }}
+          gcc-version: ${{ matrix.gcc }}
+          github-instance: ${{ env.SECRETS_AVAILABLE == 'false' }}
+
+      - name: Find tools
+        run: |
+          find /usr -executable -name "compute-sanitizer"
+
+      - name: Install latest stable
+        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # zizmor: ignore[stale-action-refs] this action doesn't create releases
+        with:
+          toolchain: stable
+
+      - name: Run zk-cuda-backend memcheck (gtest binaries)
+        run: |
+          make test_zk_cuda_backend_memcheck
+
+      - name: Run tfhe-zk-pok memcheck (Rust tests)
+        run: |
+          make test_zk_pok_gpu_sanitizer
+
+  slack-notify:
+    name: gpu_zk_memory_sanitizer/slack-notify
+    needs: [ setup-instance, cuda-tests-linux ]
+    runs-on: ubuntu-latest
+    if: ${{ always() && needs.cuda-tests-linux.result != 'skipped' && failure() }}
+    continue-on-error: true
+    steps:
+      - name: Set pull-request URL
+        if: env.SECRETS_AVAILABLE == 'true' && github.event_name == 'pull_request'
+        run: |
+          echo "PULL_REQUEST_MD_LINK=[pull-request](${PR_BASE_URL}${PR_NUMBER}), "  >> "${GITHUB_ENV}"
+        env:
+          PR_BASE_URL: ${{ vars.PR_BASE_URL }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+
+      - name: Send message
+        if: env.SECRETS_AVAILABLE == 'true'
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661
+        env:
+          SLACK_COLOR: ${{ needs.cuda-tests-linux.result }}
+          SLACK_MESSAGE: "ZK GPU Memory Checks tests finished with status: ${{ needs.cuda-tests-linux.result }}. (${{ env.PULL_REQUEST_MD_LINK }}[action run](${{ env.ACTION_RUN_URL }}))"
+
+  teardown-instance:
+    name: gpu_zk_memory_sanitizer/teardown-instance
+    if: ${{ always() && needs.setup-instance.result == 'success' }}
+    needs: [ setup-instance, cuda-tests-linux ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Stop remote instance
+        id: stop-instance
+        if: env.SECRETS_AVAILABLE == 'true'
+        uses: zama-ai/slab-github-runner@5aee5d157f4a0201e5eaefc9cc648e5f9f5472a5 # v1.6.0
+        with:
+          mode: stop
+          github-token: ${{ secrets.SLAB_ACTION_TOKEN }}
+          slab-url: ${{ secrets.SLAB_BASE_URL }}
+          job-secret: ${{ secrets.JOB_SECRET }}
+          label: ${{ needs.setup-instance.outputs.runner-name }}
+
+      - name: Slack Notification
+        if: ${{ failure() }}
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661
+        env:
+          SLACK_COLOR: ${{ job.status }}
+          SLACK_MESSAGE: "Instance teardown (gpu-zk-memory-sanitizer) finished with status: ${{ job.status }}. (${{ env.ACTION_RUN_URL }})"

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ dieharder_run.log
 # Cuda local build
 backends/tfhe-cuda-backend/cuda/cmake-build-debug/
 backends/tfhe-cuda-backend/cuda/build/
+backends/zk-cuda-backend/cuda/cmake-build-debug/
+backends/zk-cuda-backend/cuda/build/
 
 # WASM tests
 tfhe/web_wasm_parallel_tests/server.PID

--- a/Makefile
+++ b/Makefile
@@ -805,6 +805,29 @@ test_zk_cuda_backend:
 	cd "$(ZKCUDARS_SRC)" && \
 		cargo test --release
 
+.PHONY: test_zk_cuda_backend_race_check # Build and run ZK CUDA backend tests with Compute Sanitizer racecheck
+test_zk_cuda_backend_race_check:
+	mkdir -p "$(ZKCUDA_BUILD)" && \
+		cd "$(ZKCUDA_BUILD)" && \
+		cmake .. -DCMAKE_BUILD_TYPE=Release -DZK_CUDA_BACKEND_BUILD_TESTS=ON && \
+		"$(MAKE)" -j "$(CPU_COUNT)" test_fp test_fp2 test_msm test_point_ops && \
+		for t in test_fp test_fp2 test_msm test_point_ops; do \
+			compute-sanitizer --tool racecheck --target-processes all \
+				./tests_and_benchmarks/tests/$$t || exit 1; \
+		done
+
+.PHONY: test_zk_cuda_backend_memcheck # Build and run ZK CUDA backend tests with Compute Sanitizer memcheck
+test_zk_cuda_backend_memcheck:
+	mkdir -p "$(ZKCUDA_BUILD)" && \
+		cd "$(ZKCUDA_BUILD)" && \
+		cmake .. -DCMAKE_BUILD_TYPE=Release -DZK_CUDA_BACKEND_BUILD_TESTS=ON && \
+		"$(MAKE)" -j "$(CPU_COUNT)" test_fp test_fp2 test_msm test_point_ops && \
+		for t in test_fp test_fp2 test_msm test_point_ops; do \
+			compute-sanitizer --tool memcheck --leak-check=full \
+				--error-exitcode=1 --target-processes=all \
+				./tests_and_benchmarks/tests/$$t || exit 1; \
+		done
+
 
 .PHONY: test_gpu # Run the tests of the core_crypto module including experimental on the gpu backend
 test_gpu: test_core_crypto_gpu test_integer_gpu test_cuda_backend test_zk_cuda_backend
@@ -840,6 +863,28 @@ test_high_level_api_gpu_valgrind: install_cargo_nextest
 test_high_level_api_gpu_sanitizer: install_cargo_nextest
 	export RUSTFLAGS="-C target-cpu=x86-64" && \
 	export CARGO_PROFILE="$(CARGO_PROFILE)" &&	scripts/check_memory_errors.sh --gpu
+
+.PHONY: test_zk_pok_gpu_sanitizer # Run compute-sanitizer memcheck on Rust zk-pok GPU tests
+test_zk_pok_gpu_sanitizer: install_cargo_nextest
+	export RUSTFLAGS="-C target-cpu=x86-64" && \
+	export CARGO_PROFILE="$(CARGO_PROFILE)" && \
+	export SANITIZER_CARGO_PACKAGE=tfhe-zk-pok && \
+	export SANITIZER_CARGO_FEATURES_GPU=experimental,gpu-experimental && \
+	export SANITIZER_TEST_FILTER_GPU='gpu::' && \
+	export SANITIZER_TEST_EXCLUDES_GPU='conversion_roundtrip|scalar_validation' && \
+	export SANITIZER_TEST_EXE_GLOB='tfhe_zk_pok-*' && \
+		scripts/check_memory_errors.sh --gpu
+
+.PHONY: test_zk_pok_gpu_valgrind # Run valgrind on Rust zk-pok GPU tests (CPU-side leaks)
+test_zk_pok_gpu_valgrind: install_cargo_nextest
+	export RUSTFLAGS="-C target-cpu=x86-64" && \
+	export CARGO_PROFILE="$(CARGO_PROFILE)" && \
+	export SANITIZER_CARGO_PACKAGE=tfhe-zk-pok && \
+	export SANITIZER_CARGO_FEATURES_CPU=experimental,gpu-experimental && \
+	export SANITIZER_TEST_FILTER_CPU='gpu::' && \
+	export SANITIZER_TEST_EXCLUDES_CPU='conversion_roundtrip|scalar_validation' && \
+	export SANITIZER_TEST_EXE_GLOB='tfhe_zk_pok-*' && \
+		scripts/check_memory_errors.sh --cpu
 
 .PHONY: test_integer_hl_test_gpu_check_warnings
 test_integer_hl_test_gpu_check_warnings:

--- a/scripts/check_memory_errors.sh
+++ b/scripts/check_memory_errors.sh
@@ -28,26 +28,39 @@ if [[ "${RUN_VALGRIND}" == "0" && "${RUN_COMPUTE_SANITIZER}" == "0" ]]; then
   exit 1
 fi
 
+# Parameters (overridable via env vars) — defaults preserve the historical
+# tfhe-cuda-backend invocation.
+SANITIZER_CARGO_PACKAGE="${SANITIZER_CARGO_PACKAGE:-tfhe}"
+SANITIZER_CARGO_FEATURES_CPU="${SANITIZER_CARGO_FEATURES_CPU:-integer,internal-keycache,gpu-debug,zk-pok}"
+SANITIZER_CARGO_FEATURES_GPU="${SANITIZER_CARGO_FEATURES_GPU:-integer,internal-keycache,gpu,zk-pok}"
+SANITIZER_TEST_FILTER_CPU="${SANITIZER_TEST_FILTER_CPU:-high_level_api::.*gpu.*}"
+SANITIZER_TEST_EXCLUDES_CPU="${SANITIZER_TEST_EXCLUDES_CPU:-test_uniformity|array|flip}"
+SANITIZER_TEST_FILTER_GPU="${SANITIZER_TEST_FILTER_GPU:-high_level_api::.*gpu.*|core_crypto::.*gpu.*}"
+SANITIZER_TEST_EXCLUDES_GPU="${SANITIZER_TEST_EXCLUDES_GPU:-array|modulus_switch|3_3|noise_distribution|flip|test_uniformity}"
+SANITIZER_TEST_EXE_GLOB="${SANITIZER_TEST_EXE_GLOB:-tfhe-*}"
+
 # Array to collect error messages for final summary
 ERROR_MESSAGES=()
 
-# List the tests into a temporary file
-RUSTFLAGS="$RUSTFLAGS" cargo nextest list --cargo-profile "${CARGO_PROFILE}" \
-          --features=integer,internal-keycache,gpu-debug,zk-pok -p tfhe &> /tmp/test_list.txt
-
 if [[ "${RUN_VALGRIND}" == "1" ]]; then
-  # The tests are filtered using grep (to keep only HL) GPU tests.
-  # Since, when output is directed to a file, nextest outputs a list of `<executable name> <test name>` the `grep -o '[^ ]\+$'` filter
-  # will keep only the test name and the `tfhe` executable is assumed. To sanitize tests from another
-  # executable changes might be needed
-  TESTS_TO_RUN=$(sed -e $'s/\x1b\[[0-9;]*m//g' < /tmp/test_list.txt | grep -E 'high_level_api::.*gpu.*' | grep -v 'test_uniformity' | grep -v 'array' | grep -v 'flip' | grep -o '[^ ]\+$')
+  # List the tests into a temporary file using the CPU feature set
+  RUSTFLAGS="$RUSTFLAGS" cargo nextest list --cargo-profile "${CARGO_PROFILE}" \
+            --features="${SANITIZER_CARGO_FEATURES_CPU}" -p "${SANITIZER_CARGO_PACKAGE}" &> /tmp/test_list.txt
+
+  # The tests are filtered using grep. Since, when output is directed to a file, nextest
+  # outputs a list of `<executable name> <test name>` the `grep -o '[^ ]\+$'` filter will
+  # keep only the test name. The executable glob is controlled by SANITIZER_TEST_EXE_GLOB.
+  TESTS_TO_RUN=$(sed -e $'s/\x1b\[[0-9;]*m//g' < /tmp/test_list.txt \
+      | grep -E "${SANITIZER_TEST_FILTER_CPU}" \
+      | grep -vE "${SANITIZER_TEST_EXCLUDES_CPU}" \
+      | grep -o '[^ ]\+$')
 
   # Build the tests but don't run them
   RUSTFLAGS="$RUSTFLAGS" cargo test --no-run --profile "${CARGO_PROFILE}" \
-    --features=integer,internal-keycache,gpu-debug,zk-pok -p tfhe
+    --features="${SANITIZER_CARGO_FEATURES_CPU}" -p "${SANITIZER_CARGO_PACKAGE}"
 
   # Find the test executable -> last one to have been modified
-  EXECUTABLE=target/release/deps/$(find target/release/deps/ -type f -executable -name "tfhe-*" -printf "%T@ %f\n" |sort -nr|sed 's/^.* //; q;')
+  EXECUTABLE=target/release/deps/$(find target/release/deps/ -type f -executable -name "${SANITIZER_TEST_EXE_GLOB}" -printf "%T@ %f\n" |sort -nr|sed 's/^.* //; q;')
 
   RESULT=0
   while read -r t; do
@@ -77,17 +90,20 @@ if [[ "${RUN_VALGRIND}" == "1" ]]; then
 fi
 
 if [[ "${RUN_COMPUTE_SANITIZER}" == "1" ]]; then
-  # The tests are filtered using grep (to keep only HL / corecrypto) GPU tests.
-  # Since, when output is directed to a file, nextest outputs a list of `<executable name> <test name>` the `grep -o '[^ ]\+$'` filter
-  # will keep only the test name and the `tfhe` executable is assumed. To sanitize tests from another
-  # executable changes might be needed
-  TESTS_TO_RUN=$(sed -e $'s/\x1b\[[0-9;]*m//g' < /tmp/test_list.txt | grep -E 'high_level_api::.*gpu.*|core_crypto::.*gpu.*' | grep -v 'array' | grep -v 'modulus_switch' | grep -v '3_3' | grep -v 'noise_distribution' | grep -v 'flip' | grep -v 'test_uniformity' | grep -o '[^ ]\+$')
+  # List the tests into a temporary file using the GPU feature set
+  RUSTFLAGS="$RUSTFLAGS" cargo nextest list --cargo-profile "${CARGO_PROFILE}" \
+            --features="${SANITIZER_CARGO_FEATURES_GPU}" -p "${SANITIZER_CARGO_PACKAGE}" &> /tmp/test_list.txt
+
+  TESTS_TO_RUN=$(sed -e $'s/\x1b\[[0-9;]*m//g' < /tmp/test_list.txt \
+      | grep -E "${SANITIZER_TEST_FILTER_GPU}" \
+      | grep -vE "${SANITIZER_TEST_EXCLUDES_GPU}" \
+      | grep -o '[^ ]\+$')
   # Build the tests but don't run them
   RUSTFLAGS="$RUSTFLAGS" cargo test --no-run --profile "${CARGO_PROFILE}" \
-    --features=integer,internal-keycache,gpu,zk-pok -p tfhe
+    --features="${SANITIZER_CARGO_FEATURES_GPU}" -p "${SANITIZER_CARGO_PACKAGE}"
 
   # Find the test executable -> last one to have been modified
-  EXECUTABLE=target/release/deps/$(find target/release/deps/ -type f -executable -name "tfhe-*" -printf "%T@ %f\n" |sort -nr|sed 's/^.* //; q;')
+  EXECUTABLE=target/release/deps/$(find target/release/deps/ -type f -executable -name "${SANITIZER_TEST_EXE_GLOB}" -printf "%T@ %f\n" |sort -nr|sed 's/^.* //; q;')
 
   RESULT=0
   while read -r t; do


### PR DESCRIPTION
`tfhe-cuda-backend` already runs under `compute-sanitizer` and Valgrind in CI, so memory-safety and race-condition regressions there are caught quickly. `zk-cuda-backend` had no equivalent coverage, which means a wild pointer or a kernel race in the ZK GPU path could land on `main` and only surface much later (e.g. on long-run tests or in user code). This PR closes that gap by mirroring the existing `tfhe-cuda-backend` sanitizer setup for `zk-cuda-backend`.

Changes:
- Parameterize `scripts/check_memory_errors.sh` via `SANITIZER_*` env vars so a single script can drive both backends. Defaults preserve the existing `tfhe-cuda-backend` invocation, so nothing changes for that backend.
- Add Makefile targets: `test_zk_cuda_backend_race_check`, `test_zk_cuda_backend_memcheck`, `test_zk_pok_gpu_sanitizer`, `test_zk_pok_gpu_valgrind`.
- Add two CI workflows:
  - `gpu_zk_memory_sanitizer.yml` — PR-label triggered `compute-sanitizer memcheck` run.
  - `gpu_zk_code_validation_tests.yml` — Friday cron running `racecheck` + Valgrind.
- Exclude CPU-only `zk-pok` tests (`conversion_roundtrip`, `scalar_validation`) from sanitizer / Valgrind runs since they don't touch GPU code and would only slow the job down.

<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: https://github.com/zama-ai/tfhe-rs-internal/issues/1309

### PR content/description

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3502)
<!-- Reviewable:end -->
