### PR TITLE
chore: bump rand to 0.8.6 in data generation crate

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -4,9 +4,6 @@ ignore = [
     "RUSTSEC-2024-0436",
     # Ignoring unmaintained 'bincode' crate. Getting rid of it would be too complex on the short term.
     "RUSTSEC-2025-0141",
-    # Ignoring unsoundness in 'rand' with custom logger. Rand update is currently blocked by
-    # arkworks and we do not use custom loggers.
-    "RUSTSEC-2026-0097",
 ]
 
 [output]

--- a/utils/tfhe-backward-compat-data/crates/generate_0_10/Cargo.lock
+++ b/utils/tfhe-backward-compat-data/crates/generate_0_10/Cargo.lock
@@ -635,9 +635,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",

--- a/utils/tfhe-backward-compat-data/crates/generate_0_11/Cargo.lock
+++ b/utils/tfhe-backward-compat-data/crates/generate_0_11/Cargo.lock
@@ -710,9 +710,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",

--- a/utils/tfhe-backward-compat-data/crates/generate_0_8/Cargo.lock
+++ b/utils/tfhe-backward-compat-data/crates/generate_0_8/Cargo.lock
@@ -635,9 +635,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",

--- a/utils/tfhe-backward-compat-data/crates/generate_1_0/Cargo.lock
+++ b/utils/tfhe-backward-compat-data/crates/generate_1_0/Cargo.lock
@@ -719,9 +719,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",

--- a/utils/tfhe-backward-compat-data/crates/generate_1_1/Cargo.lock
+++ b/utils/tfhe-backward-compat-data/crates/generate_1_1/Cargo.lock
@@ -721,9 +721,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",

--- a/utils/tfhe-backward-compat-data/crates/generate_1_3/Cargo.lock
+++ b/utils/tfhe-backward-compat-data/crates/generate_1_3/Cargo.lock
@@ -721,9 +721,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",

--- a/utils/tfhe-backward-compat-data/crates/generate_1_4/Cargo.lock
+++ b/utils/tfhe-backward-compat-data/crates/generate_1_4/Cargo.lock
@@ -763,9 +763,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",

--- a/utils/tfhe-backward-compat-data/crates/generate_1_5/Cargo.lock
+++ b/utils/tfhe-backward-compat-data/crates/generate_1_5/Cargo.lock
@@ -779,9 +779,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",


### PR DESCRIPTION
- 1.6 is done in a separate PR which will use the officially published tag as source for the code, which also updates the lock

this closes the advisories about unsoundness with the log feature (which we do not use)