### PR TITLE
chore(backward): use released tfhe for generate_1_6 dep

### DIFF
--- a/utils/tfhe-backward-compat-data/crates/generate_1_6/Cargo.lock
+++ b/utils/tfhe-backward-compat-data/crates/generate_1_6/Cargo.lock
@@ -781,9 +781,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -977,6 +977,7 @@ dependencies = [
 [[package]]
 name = "tfhe"
 version = "1.6.0"
+source = "git+https://github.com/zama-ai/tfhe-rs.git?tag=tfhe-rs-1.6.0#7b174b1865736e3291b5e35294acfe02946c42db"
 dependencies = [
  "aligned-vec",
  "bincode",
@@ -1015,6 +1016,7 @@ dependencies = [
 [[package]]
 name = "tfhe-csprng"
 version = "0.9.0"
+source = "git+https://github.com/zama-ai/tfhe-rs.git?tag=tfhe-rs-1.6.0#7b174b1865736e3291b5e35294acfe02946c42db"
 dependencies = [
  "aes",
  "getrandom",
@@ -1027,6 +1029,7 @@ dependencies = [
 [[package]]
 name = "tfhe-fft"
 version = "0.10.1"
+source = "git+https://github.com/zama-ai/tfhe-rs.git?tag=tfhe-rs-1.6.0#7b174b1865736e3291b5e35294acfe02946c42db"
 dependencies = [
  "aligned-vec",
  "bytemuck",
@@ -1040,6 +1043,7 @@ dependencies = [
 [[package]]
 name = "tfhe-ntt"
 version = "0.7.1"
+source = "git+https://github.com/zama-ai/tfhe-rs.git?tag=tfhe-rs-1.6.0#7b174b1865736e3291b5e35294acfe02946c42db"
 dependencies = [
  "aligned-vec",
  "bytemuck",
@@ -1049,6 +1053,7 @@ dependencies = [
 [[package]]
 name = "tfhe-safe-serialize"
 version = "0.1.0"
+source = "git+https://github.com/zama-ai/tfhe-rs.git?tag=tfhe-rs-1.6.0#7b174b1865736e3291b5e35294acfe02946c42db"
 dependencies = [
  "bincode",
  "serde",
@@ -1058,6 +1063,7 @@ dependencies = [
 [[package]]
 name = "tfhe-versionable"
 version = "0.7.0"
+source = "git+https://github.com/zama-ai/tfhe-rs.git?tag=tfhe-rs-1.6.0#7b174b1865736e3291b5e35294acfe02946c42db"
 dependencies = [
  "aligned-vec",
  "num-complex",
@@ -1068,6 +1074,7 @@ dependencies = [
 [[package]]
 name = "tfhe-versionable-derive"
 version = "0.7.0"
+source = "git+https://github.com/zama-ai/tfhe-rs.git?tag=tfhe-rs-1.6.0#7b174b1865736e3291b5e35294acfe02946c42db"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1077,6 +1084,7 @@ dependencies = [
 [[package]]
 name = "tfhe-zk-pok"
 version = "0.8.1"
+source = "git+https://github.com/zama-ai/tfhe-rs.git?tag=tfhe-rs-1.6.0#7b174b1865736e3291b5e35294acfe02946c42db"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",

--- a/utils/tfhe-backward-compat-data/crates/generate_1_6/Cargo.toml
+++ b/utils/tfhe-backward-compat-data/crates/generate_1_6/Cargo.toml
@@ -10,23 +10,13 @@ license = "BSD-3-Clause-Clear"
 clap = { version = "4.5", features = ["derive"] }
 
 # TFHE-rs
-tfhe = { features = [
+tfhe = { git = "https://github.com/zama-ai/tfhe-rs.git", tag = "tfhe-rs-1.6.0", features = [
     "boolean",
     "integer",
     "shortint",
     "zk-pok",
     "experimental-force_fft_algo_dif4",
-], path = "../../../../tfhe" }
-tfhe-versionable = { path = "../../../tfhe-versionable" }
-
-# Uncomment this and remove the lines above once the current tfhe-rs version has been released
-# tfhe = { git = "https://github.com/zama-ai/tfhe-rs.git", tag = "tfhe-rs-1.6.0", features = [
-#     "boolean",
-#     "integer",
-#     "shortint",
-#     "zk-pok",
-#     "experimental-force_fft_algo_dif4",
-# ] }
-# tfhe-versionable = { git = "https://github.com/zama-ai/tfhe-rs.git", tag = "tfhe-rs-1.6.0" }
+] }
+tfhe-versionable = { git = "https://github.com/zama-ai/tfhe-rs.git", tag = "tfhe-rs-1.6.0" }
 
 tfhe-backward-compat-data = { path = "../.." }


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description
Since tfhe 1.6 has been released, the generate_1_6 crate needs to use the released tag for the tfhe dep