### PR TITLE
Am/chore/misc

### DIFF
--- a/tfhe/src/core_crypto/fft_impl/fft64/math/fft/mod.rs
+++ b/tfhe/src/core_crypto/fft_impl/fft64/math/fft/mod.rs
@@ -108,14 +108,14 @@ fn plans() -> &'static PlanMap {
 }
 
 pub fn setup_custom_fft_plan(plan: Plan) {
-    let base_n = FourierPolynomialSize(plan.fft_size());
-    let n = base_n.to_standard_polynomial_size();
+    let fft_size = FourierPolynomialSize(plan.fft_size());
+    let std_poly_size = fft_size.to_standard_polynomial_size();
 
-    let plan = Arc::new((Twisties::new(base_n.0), plan));
+    let plan = Arc::new((Twisties::new(fft_size.0), plan));
 
     let global_plans = plans();
 
-    global_plans.set(n, plan);
+    global_plans.set(std_poly_size, plan);
 }
 
 /// Return the input slice, cast to the same type.

--- a/tfhe/src/shortint/encoding.rs
+++ b/tfhe/src/shortint/encoding.rs
@@ -56,7 +56,7 @@ impl<Scalar: UnsignedInteger + CastFrom<u64>> ShortintEncoding<Scalar> {
 }
 
 impl<Scalar: UnsignedInteger + CastFrom<u64>> ShortintEncoding<Scalar> {
-    /// Return the cleatext space including the space for the [`Self::padding_bit`] if it is set to
+    /// Return the cleartext space including the space for the [`Self::padding_bit`] if it is set to
     /// [`PaddingBit::Yes`].
     pub(crate) fn full_cleartext_space(&self) -> Scalar {
         let cleartext_modulus = self.cleartext_space_without_padding();
@@ -69,7 +69,7 @@ impl<Scalar: UnsignedInteger + CastFrom<u64>> ShortintEncoding<Scalar> {
             }
     }
 
-    /// Return the cleatext space defined by the [`Self::message_modulus`] and
+    /// Return the cleartext space defined by the [`Self::message_modulus`] and
     /// [`Self::carry_modulus`], not taking the value of the [`Self::padding_bit`] into account.
     pub(crate) fn cleartext_space_without_padding(&self) -> Scalar {
         (self.message_modulus.0 * self.carry_modulus.0).cast_into()

--- a/tfhe/src/shortint/oprf.rs
+++ b/tfhe/src/shortint/oprf.rs
@@ -1130,7 +1130,7 @@ pub mod test_utils {
     /// to 0 to keep the carry free.
     /// output_modulus: the output cleartext space, continuing the above example, it must contain
     /// the padding bit, so for 4 bits of cleartext this is actually 2^(1 + 4)==32
-    pub fn cleatext_prf(
+    pub fn cleartext_prf(
         input_cleartext: u64,
         random_bits_count: u64,
         output_modulus: u64,
@@ -1163,7 +1163,7 @@ pub mod test_utils {
 
 #[cfg(test)]
 pub(crate) mod test {
-    use super::test_utils::cleatext_prf;
+    use super::test_utils::cleartext_prf;
     use super::*;
     use crate::core_crypto::commons::math::random::Seed;
     use crate::core_crypto::prelude::{decrypt_lwe_ciphertext, CastInto, LweSecretKeyView};
@@ -1244,7 +1244,7 @@ pub(crate) mod test {
 
         // includes padding bit
         let output_modulus = 2 * params.message_modulus().0 * params.carry_modulus().0;
-        let expected_output = cleatext_prf(
+        let expected_output = cleartext_prf(
             plain_prf_input,
             random_bits_count,
             output_modulus,


### PR DESCRIPTION
First commit is to make it less confusing to reason about the custom fft code which was mixing the notion of base_n used in tfhe-fft to select the base fft algorithm size, which has nothing to do with how we store the plan in that case

Second commit is an unfortunate typo reported by KMS when they used the newly available cleartext_prf for testing purposes