### PR TITLE
chore(gpu): add semver_check_zk_cuda_backend

### DIFF
--- a/.github/workflows/gpu_pcc.yml
+++ b/.github/workflows/gpu_pcc.yml
@@ -147,6 +147,10 @@ jobs:
         run: |
           make semver_check_cuda_backend
 
+      - name: Run semver checks on zk-cuda-backend
+        run: |
+          make semver_check_zk_cuda_backend
+
       - name: Check build with hpu enabled
         run: |
           make clippy_gpu_hpu

--- a/Makefile
+++ b/Makefile
@@ -320,6 +320,11 @@ semver_check_cuda_backend:
 	cargo install cargo-semver-checks --locked
 	DOCS_RS=1 cargo semver-checks --package tfhe-cuda-backend
 
+.PHONY: semver_check_zk_cuda_backend # Run semver checks on zk-cuda-backend
+semver_check_zk_cuda_backend:
+	cargo install cargo-semver-checks --locked
+	DOCS_RS=1 cargo semver-checks --package zk-cuda-backend
+
 .PHONY: fmt_gpu # Format rust and cuda code
 fmt_gpu: install_rs_check_toolchain
 	cargo "$(CARGO_RS_CHECK_TOOLCHAIN)" fmt

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ WEB_SERVER_DIR=tfhe/web_wasm_parallel_tests
 TAPLO_VERSION=0.10.0
 TYPOS_VERSION=1.44.0
 ZIZMOR_VERSION=1.22.0
+CARGO_SEMVER_CHECKS_VERSION=0.47.0
 # This is done to avoid forgetting it, we still precise the RUSTFLAGS in the commands to be able to
 # copy paste the command in the terminal and change them if required without forgetting the flags
 export RUSTFLAGS?=-C target-cpu=native
@@ -317,12 +318,12 @@ semgrep_and_lint_gpu_code: semgrep_lint_setup_venv
 
 .PHONY: semver_check_cuda_backend # Run semver checks on tfhe-cuda-backend
 semver_check_cuda_backend:
-	cargo install cargo-semver-checks --locked
+	cargo install cargo-semver-checks@$(CARGO_SEMVER_CHECKS_VERSION) --locked
 	DOCS_RS=1 cargo semver-checks --package tfhe-cuda-backend
 
 .PHONY: semver_check_zk_cuda_backend # Run semver checks on zk-cuda-backend
 semver_check_zk_cuda_backend:
-	cargo install cargo-semver-checks --locked
+	cargo install cargo-semver-checks@$(CARGO_SEMVER_CHECKS_VERSION) --locked
 	DOCS_RS=1 cargo semver-checks --package zk-cuda-backend
 
 .PHONY: fmt_gpu # Format rust and cuda code


### PR DESCRIPTION
### PR content/description

Add `cargo semver-checks` enforcement for `zk-cuda-backend`, mirroring the existing `tfhe-cuda-backend` pattern:

- New Makefile target `semver_check_zk_cuda_backend`
- New CI step in `gpu_pcc.yml` running the check on every PR

<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: https://github.com/zama-ai/tfhe-rs-internal/issues/1407

### Check-list:

* [x] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [x] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer