### PR TITLE
chore(bench): use bench spec for shortint, core crypto and remaining …

### DIFF
--- a/tfhe-benchmark/benches/core_crypto/ks_bench.rs
+++ b/tfhe-benchmark/benches/core_crypto/ks_bench.rs
@@ -4,9 +4,9 @@ use benchmark::params::{
     benchmark_compression_parameters, benchmark_parameters, multi_bit_benchmark_parameters,
 };
 use benchmark::utilities::{
-    get_param_type, write_to_json_unchecked, CryptoParametersRecord, OperatorType, ParamType,
+    get_param_type, write_to_json, CryptoParametersRecord, OperatorType, ParamType,
 };
-use benchmark_spec::{get_bench_type, BenchmarkType};
+use benchmark_spec::{get_bench_type, BenchmarkSpec, BenchmarkType, CoreCryptoBench};
 use criterion::{black_box, Criterion, Throughput};
 use itertools::Itertools;
 use rayon::prelude::*;
@@ -18,8 +18,9 @@ fn keyswitch<Scalar: UnsignedTorus + CastInto<usize> + Serialize>(
     criterion: &mut Criterion,
     parameters: &[(String, CryptoParametersRecord<Scalar>)],
 ) {
-    let bench_name = "core_crypto::keyswitch";
-    let mut bench_group = criterion.benchmark_group(bench_name);
+    let cc_bench = CoreCryptoBench::Keyswitch;
+    let bench_type = get_bench_type();
+    let mut bench_group = criterion.benchmark_group(cc_bench.to_string());
 
     // Create the PRNG
     let mut seeder = new_seeder();
@@ -54,9 +55,10 @@ fn keyswitch<Scalar: UnsignedTorus + CastInto<usize> + Serialize>(
             &mut encryption_generator,
         );
 
-        let bench_id;
+        let benchmark_spec = BenchmarkSpec::<str>::new_core_crypto(cc_bench, name, *bench_type);
+        let bench_id = benchmark_spec.to_string();
 
-        match get_bench_type() {
+        match bench_type {
             BenchmarkType::Latency => {
                 let ct = allocate_and_encrypt_new_lwe_ciphertext(
                     &big_lwe_sk,
@@ -72,7 +74,6 @@ fn keyswitch<Scalar: UnsignedTorus + CastInto<usize> + Serialize>(
                     params.ciphertext_modulus.unwrap(),
                 );
 
-                bench_id = format!("{bench_name}::{name}");
                 {
                     bench_group.bench_function(&bench_id, |b| {
                         b.iter(|| {
@@ -83,7 +84,6 @@ fn keyswitch<Scalar: UnsignedTorus + CastInto<usize> + Serialize>(
                 }
             }
             BenchmarkType::Throughput => {
-                bench_id = format!("{bench_name}::throughput::{name}");
                 let mut setup = |batch_size: usize| {
                     let input_cts = (0..batch_size)
                         .map(|_| {
@@ -146,10 +146,10 @@ fn keyswitch<Scalar: UnsignedTorus + CastInto<usize> + Serialize>(
         };
 
         let bit_size = (params.message_modulus.unwrap_or(2) as u32).ilog2();
-        write_to_json_unchecked(
-            &bench_id,
+
+        write_to_json(
+            &benchmark_spec,
             *params,
-            name,
             "ks",
             &OperatorType::Atomic,
             bit_size,
@@ -160,7 +160,7 @@ fn keyswitch<Scalar: UnsignedTorus + CastInto<usize> + Serialize>(
 
 fn packing_keyswitch<Scalar, F>(
     criterion: &mut Criterion,
-    bench_name: &str,
+    cc_bench: CoreCryptoBench,
     parameters: &[(String, CryptoParametersRecord<Scalar>)],
     ks_op: F,
 ) where
@@ -172,8 +172,8 @@ fn packing_keyswitch<Scalar, F>(
         ) + Sync
         + Send,
 {
-    let bench_name = format!("core_crypto::{bench_name}");
-    let mut bench_group = criterion.benchmark_group(&bench_name);
+    let bench_type = get_bench_type();
+    let mut bench_group = criterion.benchmark_group(cc_bench.to_string());
 
     // Create the PRNG
     let mut seeder = new_seeder();
@@ -210,9 +210,10 @@ fn packing_keyswitch<Scalar, F>(
             &mut encryption_generator,
         );
 
-        let bench_id;
+        let benchmark_spec = BenchmarkSpec::<str>::new_core_crypto(cc_bench, name, *bench_type);
+        let bench_id = benchmark_spec.to_string();
 
-        match get_bench_type() {
+        match bench_type {
             BenchmarkType::Latency => {
                 let mut input_lwe_list = LweCiphertextList::new(
                     Scalar::ZERO,
@@ -241,7 +242,6 @@ fn packing_keyswitch<Scalar, F>(
                     ciphertext_modulus,
                 );
 
-                bench_id = format!("{bench_name}::{name}");
                 {
                     bench_group.bench_function(&bench_id, |b| {
                         b.iter(|| {
@@ -252,7 +252,6 @@ fn packing_keyswitch<Scalar, F>(
                 }
             }
             BenchmarkType::Throughput => {
-                bench_id = format!("{bench_name}::throughput::{name}");
                 let mut setup = |batch_size: usize| {
                     let input_lwe_lists = (0..batch_size)
                         .map(|_| {
@@ -330,10 +329,9 @@ fn packing_keyswitch<Scalar, F>(
         };
 
         let bit_size = (params.message_modulus.unwrap_or(2) as u32).ilog2();
-        write_to_json_unchecked(
-            &bench_id,
+        write_to_json(
+            &benchmark_spec,
             *params,
-            name,
             "packing_ks",
             &OperatorType::Atomic,
             bit_size,
@@ -346,11 +344,12 @@ fn packing_keyswitch<Scalar, F>(
 mod cuda {
     use benchmark::params::{benchmark_parameters, multi_bit_benchmark_parameters};
     use benchmark::utilities::{
-        cuda_local_keys_core, cuda_local_streams_core, throughput_num_threads,
-        write_to_json_unchecked, CpuKeys, CpuKeysBuilder, CryptoParametersRecord, CudaIndexes,
-        CudaLocalKeys, OperatorType,
+        cuda_local_keys_core, cuda_local_streams_core, throughput_num_threads, write_to_json,
+        CpuKeys, CpuKeysBuilder, CryptoParametersRecord, CudaIndexes, CudaLocalKeys, OperatorType,
     };
-    use benchmark_spec::{get_bench_type, BenchmarkType};
+    use benchmark_spec::{
+        get_bench_type, BenchmarkSpec, BenchmarkType, CoreCryptoBench, CudaKeyswitchConfig,
+    };
     use criterion::{black_box, Criterion, Throughput};
     use itertools::Itertools;
     use rayon::prelude::*;
@@ -373,8 +372,9 @@ mod cuda {
         criterion: &mut Criterion,
         parameters: &[(String, CryptoParametersRecord<Scalar>)],
     ) {
-        let bench_name = "core_crypto::cuda::keyswitch";
-        let mut bench_group = criterion.benchmark_group(bench_name);
+        let cc_bench = CoreCryptoBench::Keyswitch;
+        let bench_type = get_bench_type();
+        let mut bench_group = criterion.benchmark_group(cc_bench.to_string());
 
         // Create the PRNG
         let mut seeder = new_seeder();
@@ -446,9 +446,9 @@ mod cuda {
                 .keyswitch_key(ksk_big_to_small)
                 .build();
 
-            let mut bench_id;
+            let ks_bits = KeyswitchScalar::BITS as u32;
 
-            match get_bench_type() {
+            match bench_type {
                 BenchmarkType::Latency => {
                     let streams = CudaStreams::new_multi_gpu();
                     let gpu_keys = CudaLocalKeys::from_cpu_keys(&cpu_keys, None, &streams);
@@ -473,10 +473,14 @@ mod cuda {
                     let h_indexes = [Scalar::ZERO];
                     let cuda_indexes = CudaIndexes::new(&h_indexes, &streams, 0);
 
-                    bench_id = format!(
-                        "{bench_name}::latency::{:?}b::{name}",
-                        KeyswitchScalar::BITS
+                    let ks_config = CudaKeyswitchConfig::new(ks_bits, None, None);
+                    let benchmark_spec = BenchmarkSpec::new_cuda_core_crypto(
+                        cc_bench,
+                        name,
+                        Some(&ks_config),
+                        *bench_type,
                     );
+                    let bench_id = benchmark_spec.to_string();
                     {
                         bench_group.bench_function(&bench_id, |b| {
                             b.iter(|| {
@@ -497,10 +501,9 @@ mod cuda {
                     }
 
                     let bit_size = (params.message_modulus.unwrap_or(2) as u32).ilog2();
-                    write_to_json_unchecked(
-                        &bench_id,
+                    write_to_json(
+                        &benchmark_spec,
                         *params,
-                        name,
                         "ks",
                         &OperatorType::Atomic,
                         bit_size,
@@ -513,16 +516,18 @@ mod cuda {
 
                     for uses_gemm_ks in [false, true] {
                         for uses_trivial_indices in [false, true] {
-                            let indices_str = if uses_trivial_indices {
-                                "trivial"
-                            } else {
-                                "complex"
-                            };
-                            let gemm_str = if uses_gemm_ks { "gemm" } else { "classical" };
-                            bench_id = format!(
-                                "{bench_name}::throughput::{:?}b::{gemm_str}::{indices_str}_indices::{name}",
-                                KeyswitchScalar::BITS
+                            let ks_config = CudaKeyswitchConfig::new(
+                                ks_bits,
+                                Some(uses_gemm_ks),
+                                Some(uses_trivial_indices),
                             );
+                            let benchmark_spec = BenchmarkSpec::new_cuda_core_crypto(
+                                cc_bench,
+                                name,
+                                Some(&ks_config),
+                                *bench_type,
+                            );
+                            let bench_id = benchmark_spec.to_string();
 
                             let blocks: usize = 256;
                             let elements = gpu_count * blocks;
@@ -631,10 +636,9 @@ mod cuda {
                             });
 
                             let bit_size = (params.message_modulus.unwrap_or(2) as u32).ilog2();
-                            write_to_json_unchecked(
-                                &bench_id,
+                            write_to_json(
+                                &benchmark_spec,
                                 *params,
-                                name,
                                 "ks",
                                 &OperatorType::Atomic,
                                 bit_size,
@@ -653,8 +657,9 @@ mod cuda {
         criterion: &mut Criterion,
         parameters: &[(String, CryptoParametersRecord<Scalar>)],
     ) {
-        let bench_name = "core_crypto::cuda::packing_keyswitch";
-        let mut bench_group = criterion.benchmark_group(bench_name);
+        let cc_bench = CoreCryptoBench::PackingKeyswitch;
+        let bench_type = get_bench_type();
+        let mut bench_group = criterion.benchmark_group(cc_bench.to_string());
 
         // Create the PRNG
         let mut seeder = new_seeder();
@@ -696,8 +701,9 @@ mod cuda {
 
             let cpu_keys: CpuKeys<_> = CpuKeysBuilder::new().packing_keyswitch_key(pksk).build();
 
-            let bench_id;
-            match get_bench_type() {
+            let benchmark_spec = BenchmarkSpec::<str>::new_core_crypto(cc_bench, name, *bench_type);
+            let bench_id = benchmark_spec.to_string();
+            match bench_type {
                 BenchmarkType::Latency => {
                     let streams = CudaStreams::new_multi_gpu();
 
@@ -750,7 +756,6 @@ mod cuda {
 
                     streams.synchronize();
 
-                    bench_id = format!("{bench_name}::{name}");
                     {
                         bench_group.bench_function(&bench_id, |b| {
                             b.iter(|| {
@@ -768,8 +773,6 @@ mod cuda {
                 BenchmarkType::Throughput => {
                     let gpu_keys_vec = cuda_local_keys_core(&cpu_keys, None);
                     let gpu_count = get_number_of_gpus() as usize;
-
-                    bench_id = format!("{bench_name}::throughput::{name}");
 
                     let mem_size = get_packing_keyswitch_list_64_size_on_gpu(
                         &CudaStreams::new_single_gpu(GpuIndex::new(0)),
@@ -874,10 +877,9 @@ mod cuda {
             };
 
             let bit_size = (params.message_modulus.unwrap_or(2) as u32).ilog2();
-            write_to_json_unchecked(
-                &bench_id,
+            write_to_json(
+                &benchmark_spec,
                 *params,
-                name,
                 "packing_ks",
                 &OperatorType::Atomic,
                 bit_size,
@@ -963,13 +965,13 @@ pub fn packing_ks_group() {
     .configure_from_args();
     packing_keyswitch(
         &mut criterion,
-        "packing_keyswitch",
+        CoreCryptoBench::PackingKeyswitch,
         &benchmark_compression_parameters(),
         keyswitch_lwe_ciphertext_list_and_pack_in_glwe_ciphertext,
     );
     packing_keyswitch(
         &mut criterion,
-        "par_packing_keyswitch",
+        CoreCryptoBench::ParPackingKeyswitch,
         &benchmark_compression_parameters(),
         par_keyswitch_lwe_ciphertext_list_and_pack_in_glwe_ciphertext,
     );

--- a/tfhe-benchmark/benches/core_crypto/ks_pbs_bench.rs
+++ b/tfhe-benchmark/benches/core_crypto/ks_pbs_bench.rs
@@ -3,9 +3,9 @@ use benchmark::params::{
 };
 
 use benchmark::utilities::{
-    get_param_type, write_to_json_unchecked, CryptoParametersRecord, OperatorType, ParamType,
+    get_param_type, write_to_json, CryptoParametersRecord, OperatorType, ParamType,
 };
-use benchmark_spec::{get_bench_type, BenchmarkType};
+use benchmark_spec::{get_bench_type, BenchmarkSpec, BenchmarkType, CoreCryptoBench};
 use criterion::{black_box, Criterion, Throughput};
 use rayon::prelude::*;
 use serde::Serialize;
@@ -16,8 +16,9 @@ fn ks_pbs<Scalar: UnsignedTorus + CastInto<usize> + Serialize>(
     c: &mut Criterion,
     parameters: &[(String, CryptoParametersRecord<Scalar>)],
 ) {
-    let bench_name = "core_crypto::ks_pbs";
-    let mut bench_group = c.benchmark_group(bench_name);
+    let cc_bench = CoreCryptoBench::KsPbs;
+    let bench_type = get_bench_type();
+    let mut bench_group = c.benchmark_group(cc_bench.to_string());
     bench_group
         .sample_size(10)
         .measurement_time(std::time::Duration::from_secs(30));
@@ -62,9 +63,10 @@ fn ks_pbs<Scalar: UnsignedTorus + CastInto<usize> + Serialize>(
             params.pbs_level.unwrap(),
         );
 
-        let bench_id;
+        let benchmark_spec = BenchmarkSpec::<str>::new_core_crypto(cc_bench, name, *bench_type);
+        let bench_id = benchmark_spec.to_string();
 
-        match get_bench_type() {
+        match bench_type {
             BenchmarkType::Latency => {
                 // Allocate a new LweCiphertext and encrypt our plaintext
                 let input_ks_ct: LweCiphertextOwned<Scalar> =
@@ -110,7 +112,6 @@ fn ks_pbs<Scalar: UnsignedTorus + CastInto<usize> + Serialize>(
                     .unaligned_bytes_required(),
                 );
 
-                bench_id = format!("{bench_name}::{name}");
                 {
                     bench_group.bench_function(&bench_id, |b| {
                         b.iter(|| {
@@ -133,7 +134,6 @@ fn ks_pbs<Scalar: UnsignedTorus + CastInto<usize> + Serialize>(
                 }
             }
             BenchmarkType::Throughput => {
-                bench_id = format!("{bench_name}::throughput::{name}");
                 let fft = Fft::new(fourier_bsk.polynomial_size());
                 let mut setup = |batch_size: usize| {
                     let input_ks_cts = (0..batch_size)
@@ -269,10 +269,9 @@ fn ks_pbs<Scalar: UnsignedTorus + CastInto<usize> + Serialize>(
         }
 
         let bit_size = (params.message_modulus.unwrap_or(2) as u32).ilog2();
-        write_to_json_unchecked(
-            &bench_id,
+        write_to_json(
+            &benchmark_spec,
             *params,
-            name,
             "ks-pbs",
             &OperatorType::Atomic,
             bit_size,
@@ -288,12 +287,13 @@ fn multi_bit_ks_pbs<
     parameters: &[(String, CryptoParametersRecord<Scalar>, LweBskGroupingFactor)],
     deterministic_pbs: bool,
 ) {
-    let bench_name = if deterministic_pbs {
-        "core_crypto::multi_bit_deterministic_ks_pbs"
+    let cc_bench = if deterministic_pbs {
+        CoreCryptoBench::MultiBitDeterministicKsPbs
     } else {
-        "core_crypto::multi_bit_ks_pbs"
+        CoreCryptoBench::MultiBitKsPbs
     };
-    let mut bench_group = c.benchmark_group(bench_name);
+    let bench_type = get_bench_type();
+    let mut bench_group = c.benchmark_group(cc_bench.to_string());
     bench_group
         .sample_size(10)
         .measurement_time(std::time::Duration::from_secs(30));
@@ -345,9 +345,10 @@ fn multi_bit_ks_pbs<
         )
         .unwrap() as usize;
 
-        let bench_id;
+        let benchmark_spec = BenchmarkSpec::<str>::new_core_crypto(cc_bench, name, *bench_type);
+        let bench_id = benchmark_spec.to_string();
 
-        match get_bench_type() {
+        match bench_type {
             BenchmarkType::Latency => {
                 // Allocate a new LweCiphertext and encrypt our plaintext
                 let input_ks_ct: LweCiphertextOwned<Scalar> =
@@ -378,8 +379,6 @@ fn multi_bit_ks_pbs<
                     output_lwe_secret_key.lwe_dimension().to_lwe_size(),
                     params.ciphertext_modulus.unwrap(),
                 );
-
-                bench_id = format!("{bench_name}::{name}::parallelized");
                 bench_group.bench_function(&bench_id, |b| {
                     b.iter(|| {
                         keyswitch_lwe_ciphertext(
@@ -400,7 +399,6 @@ fn multi_bit_ks_pbs<
                 });
             }
             BenchmarkType::Throughput => {
-                bench_id = format!("{bench_name}::throughput::{name}");
                 let mut setup = |batch_size: usize| {
                     let input_ks_cts = (0..batch_size)
                         .map(|_| {
@@ -505,10 +503,9 @@ fn multi_bit_ks_pbs<
         };
 
         let bit_size = params.message_modulus.unwrap().ilog2();
-        write_to_json_unchecked(
-            &bench_id,
+        write_to_json(
+            &benchmark_spec,
             *params,
-            name,
             "ks-pbs",
             &OperatorType::Atomic,
             bit_size,
@@ -521,11 +518,11 @@ fn multi_bit_ks_pbs<
 mod cuda {
     use super::{benchmark_parameters, multi_bit_benchmark_parameters_with_grouping};
     use benchmark::utilities::{
-        cuda_local_keys_core, cuda_local_streams_core, throughput_num_threads,
-        write_to_json_unchecked, CpuKeys, CpuKeysBuilder, CryptoParametersRecord, CudaIndexes,
-        CudaLocalKeys, OperatorType, GPU_MAX_SUPPORTED_POLYNOMIAL_SIZE,
+        cuda_local_keys_core, cuda_local_streams_core, throughput_num_threads, write_to_json,
+        CpuKeys, CpuKeysBuilder, CryptoParametersRecord, CudaIndexes, CudaLocalKeys, OperatorType,
+        GPU_MAX_SUPPORTED_POLYNOMIAL_SIZE,
     };
-    use benchmark_spec::{get_bench_type, BenchmarkType};
+    use benchmark_spec::{get_bench_type, BenchmarkSpec, BenchmarkType, CoreCryptoBench};
     use criterion::{black_box, Criterion, Throughput};
     use rayon::prelude::*;
     use serde::Serialize;
@@ -541,8 +538,9 @@ mod cuda {
         c: &mut Criterion,
         parameters: &[(String, CryptoParametersRecord<Scalar>)],
     ) {
-        let bench_name = "core_crypto::cuda::ks_pbs";
-        let mut bench_group = c.benchmark_group(bench_name);
+        let cc_bench = CoreCryptoBench::KsPbs;
+        let bench_type = get_bench_type();
+        let mut bench_group = c.benchmark_group(cc_bench.to_string());
         bench_group
             .sample_size(10)
             .measurement_time(std::time::Duration::from_secs(30));
@@ -599,9 +597,10 @@ mod cuda {
                 .bootstrap_key(bsk)
                 .build();
 
-            let bench_id;
+            let benchmark_spec = BenchmarkSpec::<str>::new_core_crypto(cc_bench, name, *bench_type);
+            let bench_id = benchmark_spec.to_string();
 
-            match get_bench_type() {
+            match bench_type {
                 BenchmarkType::Latency => {
                     let streams = CudaStreams::new_multi_gpu();
                     let gpu_keys = CudaLocalKeys::from_cpu_keys(&cpu_keys, None, &streams);
@@ -646,7 +645,6 @@ mod cuda {
                     let h_indexes = [Scalar::ZERO];
                     let cuda_indexes = CudaIndexes::new(&h_indexes, &streams, 0);
 
-                    bench_id = format!("{bench_name}::{name}");
                     {
                         bench_group.bench_function(&bench_id, |b| {
                             b.iter(|| {
@@ -679,7 +677,6 @@ mod cuda {
                     let gpu_keys_vec = cuda_local_keys_core(&cpu_keys, None);
                     let gpu_count = get_number_of_gpus() as usize;
 
-                    bench_id = format!("{bench_name}::throughput::{name}");
                     let blocks: usize = 1;
                     let elements = throughput_num_threads(blocks, 1);
                     let elements_per_stream = elements as usize / gpu_count;
@@ -834,10 +831,9 @@ mod cuda {
             };
 
             let bit_size = (params.message_modulus.unwrap_or(2) as u32).ilog2();
-            write_to_json_unchecked(
-                &bench_id,
+            write_to_json(
+                &benchmark_spec,
                 *params,
-                name,
                 "ks-pbs",
                 &OperatorType::Atomic,
                 bit_size,
@@ -852,8 +848,9 @@ mod cuda {
         c: &mut Criterion,
         parameters: &[(String, CryptoParametersRecord<Scalar>, LweBskGroupingFactor)],
     ) {
-        let bench_name = "core_crypto::cuda::multi_bit_ks_pbs";
-        let mut bench_group = c.benchmark_group(bench_name);
+        let cc_bench = CoreCryptoBench::MultiBitKsPbs;
+        let bench_type = get_bench_type();
+        let mut bench_group = c.benchmark_group(cc_bench.to_string());
         bench_group
             .sample_size(10)
             .measurement_time(std::time::Duration::from_secs(30));
@@ -911,9 +908,10 @@ mod cuda {
                 .multi_bit_bootstrap_key(multi_bit_bsk)
                 .build();
 
-            let bench_id;
+            let benchmark_spec = BenchmarkSpec::<str>::new_core_crypto(cc_bench, name, *bench_type);
+            let bench_id = benchmark_spec.to_string();
 
-            match get_bench_type() {
+            match bench_type {
                 BenchmarkType::Latency => {
                     let streams = CudaStreams::new_multi_gpu();
                     let gpu_keys = CudaLocalKeys::from_cpu_keys(&cpu_keys, None, &streams);
@@ -957,8 +955,6 @@ mod cuda {
 
                     let h_indexes = [Scalar::ZERO];
                     let cuda_indexes = CudaIndexes::new(&h_indexes, &streams, 0);
-
-                    bench_id = format!("{bench_name}::{name}");
                     bench_group.bench_function(&bench_id, |b| {
                         b.iter(|| {
                             cuda_keyswitch_lwe_ciphertext(
@@ -989,7 +985,6 @@ mod cuda {
                     let gpu_keys_vec = cuda_local_keys_core(&cpu_keys, None);
                     let gpu_count = get_number_of_gpus() as usize;
 
-                    bench_id = format!("{bench_name}::throughput::{name}");
                     let blocks: usize = 1;
                     let elements = throughput_num_threads(blocks, 1);
                     let elements_per_stream = elements as usize / gpu_count;
@@ -1144,10 +1139,9 @@ mod cuda {
             };
 
             let bit_size = params.message_modulus.unwrap().ilog2();
-            write_to_json_unchecked(
-                &bench_id,
+            write_to_json(
+                &benchmark_spec,
                 *params,
-                name,
                 "ks-pbs",
                 &OperatorType::Atomic,
                 bit_size,

--- a/tfhe-benchmark/benches/core_crypto/pbs128_bench.rs
+++ b/tfhe-benchmark/benches/core_crypto/pbs128_bench.rs
@@ -2,7 +2,8 @@ use benchmark::params_aliases::{
     BENCH_NOISE_SQUASHING_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
     BENCH_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
 };
-use benchmark::utilities::{write_to_json_unchecked, CryptoParametersRecord, OperatorType};
+use benchmark::utilities::{write_to_json, CryptoParametersRecord, OperatorType};
+use benchmark_spec::{BenchmarkMetric, BenchmarkSpec, CoreCryptoBench};
 use criterion::{black_box, Criterion};
 use dyn_stack::PodStack;
 use tfhe::core_crypto::fft_impl::fft128::crypto::bootstrap::bootstrap_scratch;
@@ -10,8 +11,8 @@ use tfhe::core_crypto::prelude::*;
 use tfhe::keycache::NamedParam;
 
 fn pbs_128(c: &mut Criterion) {
-    let bench_name = "core_crypto::pbs128";
-    let mut bench_group = c.benchmark_group(bench_name);
+    let cc_bench = CoreCryptoBench::Pbs128;
+    let mut bench_group = c.benchmark_group(cc_bench.to_string());
     bench_group
         .sample_size(10)
         .measurement_time(std::time::Duration::from_secs(30));
@@ -120,7 +121,11 @@ fn pbs_128(c: &mut Criterion) {
         .unaligned_bytes_required()
     ];
 
-    let id = format!("{bench_name}::{}", noise_params.name());
+    let param_name = noise_params.name();
+
+    let benchmark_spec =
+        BenchmarkSpec::<str>::new_core_crypto(cc_bench, &param_name, BenchmarkMetric::Latency);
+    let id = benchmark_spec.to_string();
     bench_group.bench_function(&id, |b| {
         b.iter(|| {
             fourier_bsk.bootstrap(
@@ -149,10 +154,9 @@ fn pbs_128(c: &mut Criterion) {
     };
 
     let bit_size = (message_modulus as u32).ilog2();
-    write_to_json_unchecked(
-        &id,
+    write_to_json(
+        &benchmark_spec,
         params_record,
-        noise_params.name(),
         "pbs",
         &OperatorType::Atomic,
         bit_size,
@@ -163,11 +167,10 @@ fn pbs_128(c: &mut Criterion) {
 #[cfg(feature = "gpu")]
 mod cuda {
     use benchmark::utilities::{
-        cuda_local_keys_core, cuda_local_streams_core, throughput_num_threads,
-        write_to_json_unchecked, CpuKeys, CpuKeysBuilder, CryptoParametersRecord, CudaIndexes,
-        CudaLocalKeys, OperatorType,
+        cuda_local_keys_core, cuda_local_streams_core, throughput_num_threads, write_to_json,
+        CpuKeys, CpuKeysBuilder, CryptoParametersRecord, CudaIndexes, CudaLocalKeys, OperatorType,
     };
-    use benchmark_spec::{get_bench_type, BenchmarkType};
+    use benchmark_spec::{get_bench_type, BenchmarkSpec, BenchmarkType, CoreCryptoBench};
     use criterion::{black_box, Criterion, Throughput};
     use rayon::prelude::*;
     use tfhe::core_crypto::gpu::glwe_ciphertext_list::CudaGlweCiphertextList;
@@ -186,8 +189,9 @@ mod cuda {
     };
 
     fn cuda_pbs_128(c: &mut Criterion) {
-        let bench_name = "core_crypto::cuda::pbs128";
-        let mut bench_group = c.benchmark_group(bench_name);
+        let cc_bench = CoreCryptoBench::Pbs128;
+        let bench_type = get_bench_type();
+        let mut bench_group = c.benchmark_group(cc_bench.to_string());
         bench_group
             .sample_size(10)
             .measurement_time(std::time::Duration::from_secs(30));
@@ -257,9 +261,11 @@ mod cuda {
         let delta: u64 = (1 << (u64::BITS - 1)) / message_modulus;
         let plaintext = Plaintext(input_message * delta);
 
-        let bench_id;
+        let benchmark_spec =
+            BenchmarkSpec::<str>::new_core_crypto(cc_bench, params_name, *bench_type);
+        let bench_id = benchmark_spec.to_string();
 
-        match get_bench_type() {
+        match bench_type {
             BenchmarkType::Latency => {
                 let gpu_keys = CudaLocalKeys::from_cpu_keys(
                     &cpu_keys,
@@ -295,7 +301,6 @@ mod cuda {
                 let mut out_pbs_ct_gpu =
                     CudaLweCiphertextList::from_lwe_ciphertext(&out_pbs_ct, &streams);
 
-                bench_id = format!("{bench_name}::{params_name}");
                 {
                     bench_group.bench_function(&bench_id, |b| {
                         b.iter(|| {
@@ -315,8 +320,6 @@ mod cuda {
                 let gpu_keys_vec =
                     cuda_local_keys_core(&cpu_keys, modulus_switch_noise_reduction_configuration);
                 let gpu_count = get_number_of_gpus() as usize;
-
-                bench_id = format!("{bench_name}::throughput::{params_name}");
                 let blocks: usize = 1;
                 let elements = throughput_num_threads(blocks, 1);
                 let elements_per_stream = elements as usize / gpu_count;
@@ -431,10 +434,9 @@ mod cuda {
         };
 
         let bit_size = (message_modulus as u32).ilog2();
-        write_to_json_unchecked(
-            &bench_id,
+        write_to_json(
+            &benchmark_spec,
             params_record,
-            params_name,
             "pbs",
             &OperatorType::Atomic,
             bit_size,
@@ -443,8 +445,9 @@ mod cuda {
     }
 
     fn cuda_multi_bit_pbs_128(c: &mut Criterion) {
-        let bench_name = "core_crypto::cuda::multi_bit_pbs128";
-        let mut bench_group = c.benchmark_group(bench_name);
+        let cc_bench = CoreCryptoBench::MultiBitPbs128;
+        let bench_type = get_bench_type();
+        let mut bench_group = c.benchmark_group(cc_bench.to_string());
         bench_group
             .sample_size(10)
             .measurement_time(std::time::Duration::from_secs(30));
@@ -502,9 +505,11 @@ mod cuda {
         let delta: u64 = (1 << (u64::BITS - 1)) / message_modulus;
         let plaintext = Plaintext(input_message * delta);
 
-        let bench_id;
+        let benchmark_spec =
+            BenchmarkSpec::<str>::new_core_crypto(cc_bench, params_name, *bench_type);
+        let bench_id = benchmark_spec.to_string();
 
-        match get_bench_type() {
+        match bench_type {
             BenchmarkType::Latency => {
                 let streams = CudaStreams::new_multi_gpu();
                 let gpu_keys = CudaLocalKeys::from_cpu_keys(&cpu_keys, None, &streams);
@@ -540,7 +545,6 @@ mod cuda {
                 let h_indexes = [0];
                 let cuda_indexes = CudaIndexes::new(&h_indexes, &streams, 0);
 
-                bench_id = format!("{bench_name}::{params_name}");
                 {
                     bench_group.bench_function(&bench_id, |b| {
                         b.iter(|| {
@@ -563,7 +567,6 @@ mod cuda {
                 let gpu_keys_vec = cuda_local_keys_core(&cpu_keys, None);
                 let gpu_count = get_number_of_gpus() as usize;
 
-                bench_id = format!("{bench_name}::throughput::{params_name}");
                 let blocks: usize = 1;
                 let elements = throughput_num_threads(blocks, 1);
                 let elements_per_stream = elements as usize / gpu_count;
@@ -696,10 +699,9 @@ mod cuda {
         };
 
         let bit_size = (message_modulus as u32).ilog2();
-        write_to_json_unchecked(
-            &bench_id,
+        write_to_json(
+            &benchmark_spec,
             params_record,
-            params_name,
             "pbs",
             &OperatorType::Atomic,
             bit_size,

--- a/tfhe-benchmark/benches/core_crypto/pbs_bench.rs
+++ b/tfhe-benchmark/benches/core_crypto/pbs_bench.rs
@@ -3,9 +3,9 @@ use benchmark::params::{
     multi_bit_benchmark_parameters_with_grouping, multi_bit_num_threads,
 };
 use benchmark::utilities::{
-    get_param_type, write_to_json_unchecked, CryptoParametersRecord, OperatorType, ParamType,
+    get_param_type, write_to_json, CryptoParametersRecord, OperatorType, ParamType,
 };
-use benchmark_spec::{get_bench_type, BenchmarkType};
+use benchmark_spec::{get_bench_type, BenchmarkSpec, BenchmarkType, CoreCryptoBench};
 use criterion::{black_box, Criterion, Throughput};
 use rayon::prelude::*;
 use serde::Serialize;
@@ -17,8 +17,9 @@ fn mem_optimized_pbs<Scalar: UnsignedTorus + CastInto<usize> + Serialize>(
     c: &mut Criterion,
     parameters: &[(String, CryptoParametersRecord<Scalar>)],
 ) {
-    let bench_name = "core_crypto::pbs_mem_optimized";
-    let mut bench_group = c.benchmark_group(bench_name);
+    let cc_bench = CoreCryptoBench::PbsMemOptimized;
+    let bench_type = get_bench_type();
+    let mut bench_group = c.benchmark_group(cc_bench.to_string());
     bench_group
         .sample_size(10)
         .measurement_time(std::time::Duration::from_secs(30));
@@ -53,9 +54,10 @@ fn mem_optimized_pbs<Scalar: UnsignedTorus + CastInto<usize> + Serialize>(
             params.pbs_level.unwrap(),
         );
 
-        let bench_id;
+        let benchmark_spec = BenchmarkSpec::<str>::new_core_crypto(cc_bench, name, *bench_type);
+        let bench_id = benchmark_spec.to_string();
 
-        match get_bench_type() {
+        match bench_type {
             BenchmarkType::Latency => {
                 // Allocate a new LweCiphertext and encrypt our plaintext
                 let lwe_ciphertext_in: LweCiphertextOwned<Scalar> =
@@ -95,8 +97,6 @@ fn mem_optimized_pbs<Scalar: UnsignedTorus + CastInto<usize> + Serialize>(
                     .unaligned_bytes_required(),
                 );
 
-                bench_id = format!("{bench_name}::{name}");
-
                 bench_group.bench_function(&bench_id, |b| {
                     b.iter(|| {
                         programmable_bootstrap_lwe_ciphertext_mem_optimized(
@@ -112,7 +112,6 @@ fn mem_optimized_pbs<Scalar: UnsignedTorus + CastInto<usize> + Serialize>(
                 });
             }
             BenchmarkType::Throughput => {
-                bench_id = format!("{bench_name}::throughput::{name}");
                 let fft = Fft::new(fourier_bsk.polynomial_size());
                 let mut setup = |batch_size: usize| {
                     let input_cts = (0..batch_size)
@@ -220,10 +219,9 @@ fn mem_optimized_pbs<Scalar: UnsignedTorus + CastInto<usize> + Serialize>(
         };
 
         let bit_size = (params.message_modulus.unwrap_or(2) as u32).ilog2();
-        write_to_json_unchecked(
-            &bench_id,
+        write_to_json(
+            &benchmark_spec,
             *params,
-            name,
             "pbs",
             &OperatorType::Atomic,
             bit_size,
@@ -236,8 +234,9 @@ fn mem_optimized_batched_pbs<Scalar: UnsignedTorus + CastInto<usize> + Serialize
     c: &mut Criterion,
     parameters: &[(String, CryptoParametersRecord<Scalar>)],
 ) {
-    let bench_name = "core_crypto::batched_pbs_mem_optimized";
-    let mut bench_group = c.benchmark_group(bench_name);
+    let cc_bench = CoreCryptoBench::BatchedPbsMemOptimized;
+    let bench_type = get_bench_type();
+    let mut bench_group = c.benchmark_group(cc_bench.to_string());
     bench_group
         .sample_size(15)
         .measurement_time(std::time::Duration::from_secs(10));
@@ -274,9 +273,10 @@ fn mem_optimized_batched_pbs<Scalar: UnsignedTorus + CastInto<usize> + Serialize
 
         let count = 10; // FIXME Is it a representative value (big enough?)
 
-        let bench_id;
+        let benchmark_spec = BenchmarkSpec::<str>::new_core_crypto(cc_bench, name, bench_type);
+        let bench_id = benchmark_spec.to_string();
 
-        match get_bench_type() {
+        match bench_type {
             BenchmarkType::Latency => {
                 // Allocate a new LweCiphertext and encrypt our plaintext
                 let mut lwe_ciphertext_in = LweCiphertextListOwned::<Scalar>::new(
@@ -325,7 +325,6 @@ fn mem_optimized_batched_pbs<Scalar: UnsignedTorus + CastInto<usize> + Serialize
             .unaligned_bytes_required(),
         );
 
-                bench_id = format!("{bench_name}::{name}");
                 bench_group.bench_function(&bench_id, |b| {
                     b.iter(|| {
                         batch_programmable_bootstrap_lwe_ciphertext_mem_optimized(
@@ -341,7 +340,6 @@ fn mem_optimized_batched_pbs<Scalar: UnsignedTorus + CastInto<usize> + Serialize
                 });
             }
             BenchmarkType::Throughput => {
-                bench_id = format!("{bench_name}::throughput::{name}");
                 let fft = Fft::new(fourier_bsk.polynomial_size());
                 let mut setup = |batch_size: usize| {
                     let input_cts = (0..batch_size)
@@ -460,10 +458,9 @@ fn mem_optimized_batched_pbs<Scalar: UnsignedTorus + CastInto<usize> + Serialize
         };
 
         let bit_size = (params.message_modulus.unwrap_or(2) as u32).ilog2();
-        write_to_json_unchecked(
-            &bench_id,
+        write_to_json(
+            &benchmark_spec,
             *params,
-            name,
             "pbs",
             &OperatorType::Atomic,
             bit_size,
@@ -479,12 +476,13 @@ fn multi_bit_pbs<
     parameters: &[(String, CryptoParametersRecord<Scalar>, LweBskGroupingFactor)],
     deterministic_pbs: bool,
 ) {
-    let bench_name = if deterministic_pbs {
-        "core_crypto::multi_bit_deterministic_pbs"
+    let cc_bench = if deterministic_pbs {
+        CoreCryptoBench::MultiBitDeterministicPbs
     } else {
-        "core_crypto::multi_bit_pbs"
+        CoreCryptoBench::MultiBitPbs
     };
-    let mut bench_group = c.benchmark_group(bench_name);
+    let bench_type = get_bench_type();
+    let mut bench_group = c.benchmark_group(cc_bench.to_string());
     bench_group
         .sample_size(10)
         .measurement_time(std::time::Duration::from_secs(30));
@@ -526,9 +524,10 @@ fn multi_bit_pbs<
         )
         .unwrap() as usize;
 
-        let bench_id;
+        let benchmark_spec = BenchmarkSpec::<str>::new_core_crypto(cc_bench, name, *bench_type);
+        let bench_id = benchmark_spec.to_string();
 
-        match get_bench_type() {
+        match bench_type {
             BenchmarkType::Latency => {
                 // Allocate a new LweCiphertext and encrypt our plaintext
                 let lwe_ciphertext_in = allocate_and_encrypt_new_lwe_ciphertext(
@@ -552,8 +551,6 @@ fn multi_bit_pbs<
                     output_lwe_secret_key.lwe_dimension().to_lwe_size(),
                     params.ciphertext_modulus.unwrap(),
                 );
-
-                bench_id = format!("{bench_name}::{name}::parallelized");
                 bench_group.bench_function(&bench_id, |b| {
                     b.iter(|| {
                         multi_bit_programmable_bootstrap_lwe_ciphertext(
@@ -569,7 +566,6 @@ fn multi_bit_pbs<
                 });
             }
             BenchmarkType::Throughput => {
-                bench_id = format!("{bench_name}::throughput::{name}");
                 let mut setup = |batch_size: usize| {
                     let input_cts = (0..batch_size)
                         .map(|_| {
@@ -656,10 +652,9 @@ fn multi_bit_pbs<
         };
 
         let bit_size = params.message_modulus.unwrap().ilog2();
-        write_to_json_unchecked(
-            &bench_id,
+        write_to_json(
+            &benchmark_spec,
             *params,
-            name,
             "pbs",
             &OperatorType::Atomic,
             bit_size,
@@ -669,8 +664,9 @@ fn multi_bit_pbs<
 }
 
 fn mem_optimized_pbs_ntt(c: &mut Criterion) {
-    let bench_name = "core_crypto::pbs_ntt";
-    let mut bench_group = c.benchmark_group(bench_name);
+    let cc_bench = CoreCryptoBench::PbsNtt;
+    let bench_type = get_bench_type();
+    let mut bench_group = c.benchmark_group(cc_bench.to_string());
     bench_group
         .sample_size(10)
         .measurement_time(std::time::Duration::from_secs(30));
@@ -754,9 +750,10 @@ fn mem_optimized_pbs_ntt(c: &mut Criterion) {
 
         drop(bsk);
 
-        let bench_id;
+        let benchmark_spec = BenchmarkSpec::<str>::new_core_crypto(cc_bench, &name, *bench_type);
+        let bench_id = benchmark_spec.to_string();
 
-        match get_bench_type() {
+        match bench_type {
             BenchmarkType::Latency => {
                 // Allocate a new LweCiphertext and encrypt our plaintext
                 let lwe_ciphertext_in: LweCiphertextOwned<u64> =
@@ -796,8 +793,6 @@ fn mem_optimized_pbs_ntt(c: &mut Criterion) {
                     .unaligned_bytes_required();
 
                 buffers.resize(stack_size);
-
-                bench_id = format!("{bench_name}::{name}");
                 bench_group.bench_function(&bench_id, |b| {
                     b.iter(|| {
                         programmable_bootstrap_ntt64_lwe_ciphertext_mem_optimized(
@@ -813,7 +808,6 @@ fn mem_optimized_pbs_ntt(c: &mut Criterion) {
                 });
             }
             BenchmarkType::Throughput => {
-                bench_id = format!("{bench_name}::throughput::{name}");
                 let ntt = Ntt64::new(params.ciphertext_modulus.unwrap(), nbsk.polynomial_size());
 
                 let mut setup = |batch_size: usize| {
@@ -920,10 +914,9 @@ fn mem_optimized_pbs_ntt(c: &mut Criterion) {
         };
 
         let bit_size = (params.message_modulus.unwrap_or(2) as u32).ilog2();
-        write_to_json_unchecked(
-            &bench_id,
+        write_to_json(
+            &benchmark_spec,
             *params,
-            name,
             "pbs",
             &OperatorType::Atomic,
             bit_size,
@@ -936,11 +929,11 @@ fn mem_optimized_pbs_ntt(c: &mut Criterion) {
 mod cuda {
     use benchmark::params::{benchmark_parameters, multi_bit_benchmark_parameters};
     use benchmark::utilities::{
-        cuda_local_keys_core, cuda_local_streams_core, throughput_num_threads,
-        write_to_json_unchecked, CpuKeys, CpuKeysBuilder, CryptoParametersRecord, CudaIndexes,
-        CudaLocalKeys, OperatorType, GPU_MAX_SUPPORTED_POLYNOMIAL_SIZE,
+        cuda_local_keys_core, cuda_local_streams_core, throughput_num_threads, write_to_json,
+        CpuKeys, CpuKeysBuilder, CryptoParametersRecord, CudaIndexes, CudaLocalKeys, OperatorType,
+        GPU_MAX_SUPPORTED_POLYNOMIAL_SIZE,
     };
-    use benchmark_spec::{get_bench_type, BenchmarkType};
+    use benchmark_spec::{get_bench_type, BenchmarkSpec, BenchmarkType, CoreCryptoBench};
     use criterion::{black_box, Criterion, Throughput};
     use rayon::prelude::*;
     use serde::Serialize;
@@ -956,8 +949,9 @@ mod cuda {
         c: &mut Criterion,
         parameters: &[(String, CryptoParametersRecord<Scalar>)],
     ) {
-        let bench_name = "core_crypto::cuda::pbs";
-        let mut bench_group = c.benchmark_group(bench_name);
+        let cc_bench = CoreCryptoBench::PbsMemOptimized;
+        let bench_type = get_bench_type();
+        let mut bench_group = c.benchmark_group(cc_bench.to_string());
         bench_group
             .sample_size(10)
             .measurement_time(std::time::Duration::from_secs(30));
@@ -1001,9 +995,10 @@ mod cuda {
 
             let cpu_keys: CpuKeys<_> = CpuKeysBuilder::new().bootstrap_key(bsk).build();
 
-            let bench_id;
+            let benchmark_spec = BenchmarkSpec::<str>::new_core_crypto(cc_bench, name, *bench_type);
+            let bench_id = benchmark_spec.to_string();
 
-            match get_bench_type() {
+            match bench_type {
                 BenchmarkType::Latency => {
                     let streams = CudaStreams::new_multi_gpu();
                     let gpu_keys = CudaLocalKeys::from_cpu_keys(&cpu_keys, None, &streams);
@@ -1040,7 +1035,6 @@ mod cuda {
                     let h_indexes = [Scalar::ZERO];
                     let cuda_indexes = CudaIndexes::new(&h_indexes, &streams, 0);
 
-                    bench_id = format!("{bench_name}::{name}");
                     {
                         bench_group.bench_function(&bench_id, |b| {
                             b.iter(|| {
@@ -1063,7 +1057,6 @@ mod cuda {
                     let gpu_keys_vec = cuda_local_keys_core(&cpu_keys, None);
                     let gpu_count = get_number_of_gpus() as usize;
 
-                    bench_id = format!("{bench_name}::throughput::{name}");
                     let blocks: usize = 1;
                     let elements = throughput_num_threads(blocks, 1);
                     let elements_per_stream = elements as usize / gpu_count;
@@ -1189,10 +1182,9 @@ mod cuda {
             };
 
             let bit_size = (params.message_modulus.unwrap_or(2) as u32).ilog2();
-            write_to_json_unchecked(
-                &bench_id,
+            write_to_json(
+                &benchmark_spec,
                 *params,
-                name,
                 "pbs",
                 &OperatorType::Atomic,
                 bit_size,
@@ -1213,8 +1205,9 @@ mod cuda {
         c: &mut Criterion,
         parameters: &[(String, CryptoParametersRecord<Scalar>, LweBskGroupingFactor)],
     ) {
-        let bench_name = "core_crypto::cuda::multi_bit_pbs";
-        let mut bench_group = c.benchmark_group(bench_name);
+        let cc_bench = CoreCryptoBench::MultiBitPbs;
+        let bench_type = get_bench_type();
+        let mut bench_group = c.benchmark_group(cc_bench.to_string());
         bench_group
             .sample_size(10)
             .measurement_time(std::time::Duration::from_secs(30));
@@ -1261,9 +1254,10 @@ mod cuda {
                 .multi_bit_bootstrap_key(multi_bit_bsk)
                 .build();
 
-            let bench_id;
+            let benchmark_spec = BenchmarkSpec::<str>::new_core_crypto(cc_bench, name, *bench_type);
+            let bench_id = benchmark_spec.to_string();
 
-            match get_bench_type() {
+            match bench_type {
                 BenchmarkType::Latency => {
                     let streams = CudaStreams::new_multi_gpu();
                     let gpu_keys = CudaLocalKeys::from_cpu_keys(&cpu_keys, None, &streams);
@@ -1300,7 +1294,6 @@ mod cuda {
                     let h_indexes = [Scalar::ZERO];
                     let cuda_indexes = CudaIndexes::new(&h_indexes, &streams, 0);
 
-                    bench_id = format!("{bench_name}::{name}");
                     bench_group.bench_function(&bench_id, |b| {
                         b.iter(|| {
                             cuda_multi_bit_programmable_bootstrap_lwe_ciphertext(
@@ -1321,7 +1314,6 @@ mod cuda {
                     let gpu_keys_vec = cuda_local_keys_core(&cpu_keys, None);
                     let gpu_count = get_number_of_gpus() as usize;
 
-                    bench_id = format!("{bench_name}::throughput::{name}");
                     let blocks: usize = 1;
                     let elements = throughput_num_threads(blocks, 1);
                     let elements_per_stream = elements as usize / gpu_count;
@@ -1447,10 +1439,9 @@ mod cuda {
             };
 
             let bit_size = params.message_modulus.unwrap().ilog2();
-            write_to_json_unchecked(
-                &bench_id,
+            write_to_json(
+                &benchmark_spec,
                 *params,
-                name,
                 "pbs",
                 &OperatorType::Atomic,
                 bit_size,

--- a/tfhe-benchmark/benches/high_level_api/bench_common.rs
+++ b/tfhe-benchmark/benches/high_level_api/bench_common.rs
@@ -114,7 +114,7 @@ pub fn bench_fhe_type_op<FheType, Op>(
         }
     }
 
-    write_to_json::<u64, _>(
+    write_to_json::<u64, _, _>(
         &benchmark_spec,
         param,
         hlapi_op.to_string(),

--- a/tfhe-benchmark/benches/high_level_api/dex.rs
+++ b/tfhe-benchmark/benches/high_level_api/dex.rs
@@ -9,7 +9,9 @@ use benchmark::params_aliases::{
 use benchmark::utilities::{configure_gpu, get_param_type, ParamType};
 use benchmark::utilities::{write_to_json, OperatorType};
 use benchmark_spec::tfhe::hlapi::dex::{Dex, DexFlavor};
-use benchmark_spec::{get_bench_type, BenchmarkMetric, BenchmarkSpec, BenchmarkType, OperandType};
+use benchmark_spec::{
+    get_bench_type, BenchmarkMetric, BenchmarkSpec, BenchmarkType, HlapiBench, OperandType,
+};
 use criterion::{Criterion, Throughput};
 use rand::prelude::*;
 use rand::thread_rng;
@@ -252,8 +254,8 @@ mod pbs_stats {
         let params = client_key.computation_parameters();
         let params_name = params.name();
 
-        let test_name = BenchmarkSpec::new_hlapi_dex(
-            dex_bench_spec,
+        let test_name = BenchmarkSpec::new_hlapi(
+            HlapiBench::Dex(dex_bench_spec),
             &params_name,
             OperandType::CipherText,
             Some(type_name),
@@ -266,7 +268,7 @@ mod pbs_stats {
 
         benchmark_test_result.write_result(&test_name.to_string(), count as usize);
 
-        write_to_json::<u64, _>(
+        write_to_json::<u64, _, _>(
             &test_name,
             params,
             "pbs-count",
@@ -302,8 +304,8 @@ mod pbs_stats {
         let params = client_key.computation_parameters();
         let params_name = params.name();
 
-        let test_name = BenchmarkSpec::new_hlapi_dex(
-            dex_bench_spec,
+        let test_name = BenchmarkSpec::new_hlapi(
+            HlapiBench::Dex(dex_bench_spec),
             &params_name,
             OperandType::CipherText,
             Some(type_name),
@@ -316,7 +318,7 @@ mod pbs_stats {
 
         benchmark_test_result.write_result(&test_name.to_string(), count as usize);
 
-        write_to_json::<u64, _>(
+        write_to_json::<u64, _, _>(
             &test_name,
             params,
             "pbs-count",
@@ -362,8 +364,8 @@ mod pbs_stats {
         let params = client_key.computation_parameters();
         let params_name = params.name();
 
-        let test_name = BenchmarkSpec::new_hlapi_dex(
-            dex_bench_spec,
+        let test_name = BenchmarkSpec::new_hlapi(
+            HlapiBench::Dex(dex_bench_spec),
             &params_name,
             OperandType::CipherText,
             Some(type_name),
@@ -376,7 +378,7 @@ mod pbs_stats {
 
         benchmark_test_result.write_result(&test_name.to_string(), count as usize);
 
-        write_to_json::<u64, _>(
+        write_to_json::<u64, _, _>(
             &test_name,
             params,
             "pbs-count",
@@ -418,8 +420,8 @@ mod pbs_stats {
         let params = client_key.computation_parameters();
         let params_name = params.name();
 
-        let test_name = BenchmarkSpec::new_hlapi_dex(
-            dex_bench_spec,
+        let test_name = BenchmarkSpec::new_hlapi(
+            HlapiBench::Dex(dex_bench_spec),
             &params_name,
             OperandType::CipherText,
             Some(type_name),
@@ -432,7 +434,7 @@ mod pbs_stats {
 
         benchmark_test_result.write_result(&test_name.to_string(), count as usize);
 
-        write_to_json::<u64, _>(
+        write_to_json::<u64, _, _>(
             &test_name,
             params,
             "pbs-count",
@@ -463,8 +465,8 @@ fn bench_swap_request_latency<FheType, F1, F2>(
 
     let mut c = c.benchmark_group(type_name);
 
-    let bench_spec = BenchmarkSpec::new_hlapi_dex(
-        dex_bench_spec,
+    let bench_spec = BenchmarkSpec::new_hlapi(
+        HlapiBench::Dex(dex_bench_spec),
         &params_name,
         OperandType::CipherText,
         Some(type_name),
@@ -510,7 +512,7 @@ fn bench_swap_request_latency<FheType, F1, F2>(
         })
     });
 
-    write_to_json::<u64, _>(
+    write_to_json::<u64, _, _>(
         &bench_spec,
         params,
         "dex-swap-request",
@@ -543,8 +545,8 @@ fn bench_swap_request_throughput<FheType, F1, F2>(
     for num_elems in [10, 50, 100] {
         group.throughput(Throughput::Elements(num_elems));
 
-        let bench_spec = BenchmarkSpec::new_hlapi_dex(
-            dex_bench_spec,
+        let bench_spec = BenchmarkSpec::new_hlapi(
+            HlapiBench::Dex(dex_bench_spec),
             &params_name,
             OperandType::CipherText,
             Some(type_name),
@@ -633,7 +635,7 @@ fn bench_swap_request_throughput<FheType, F1, F2>(
             })
         });
 
-        write_to_json::<u64, _>(
+        write_to_json::<u64, _, _>(
             &bench_spec,
             params,
             "dex-swap-request",
@@ -672,8 +674,8 @@ fn cuda_bench_swap_request_throughput<FheType, F1, F2>(
 
     for num_elems in [5 * num_gpus, 10 * num_gpus, 20 * num_gpus] {
         group.throughput(Throughput::Elements(num_elems));
-        let bench_spec = BenchmarkSpec::new_hlapi_dex(
-            dex_bench_spec,
+        let bench_spec = BenchmarkSpec::new_hlapi(
+            HlapiBench::Dex(dex_bench_spec),
             &params_name,
             OperandType::CipherText,
             Some(type_name),
@@ -850,7 +852,7 @@ fn cuda_bench_swap_request_throughput<FheType, F1, F2>(
                                 })
         });
 
-        write_to_json::<u64, _>(
+        write_to_json::<u64, _, _>(
             &bench_spec,
             params,
             "dex-swap-request",
@@ -881,8 +883,8 @@ fn bench_swap_claim_latency<FheType, F1, F2>(
 
     let mut c = c.benchmark_group(type_name);
 
-    let bench_spec = BenchmarkSpec::new_hlapi_dex(
-        dex_bench_spec,
+    let bench_spec = BenchmarkSpec::new_hlapi(
+        HlapiBench::Dex(dex_bench_spec),
         &params_name,
         OperandType::CipherText,
         Some(type_name),
@@ -934,7 +936,7 @@ fn bench_swap_claim_latency<FheType, F1, F2>(
         });
     });
 
-    write_to_json::<u64, _>(
+    write_to_json::<u64, _, _>(
         &bench_spec,
         params,
         "dex-swap-claim",
@@ -967,8 +969,8 @@ fn bench_swap_claim_throughput<FheType, F1, F2>(
     for num_elems in [2, 6, 10] {
         group.throughput(Throughput::Elements(num_elems));
 
-        let bench_spec = BenchmarkSpec::new_hlapi_dex(
-            dex_bench_spec,
+        let bench_spec = BenchmarkSpec::new_hlapi(
+            HlapiBench::Dex(dex_bench_spec),
             &params_name,
             OperandType::CipherText,
             Some(type_name),
@@ -1075,7 +1077,7 @@ fn bench_swap_claim_throughput<FheType, F1, F2>(
             });
         });
 
-        write_to_json::<u64, _>(
+        write_to_json::<u64, _, _>(
             &bench_spec,
             params,
             "dex-swap-claim",
@@ -1114,8 +1116,8 @@ fn cuda_bench_swap_claim_throughput<FheType, F1, F2>(
 
     for num_elems in [num_gpus, 2 * num_gpus] {
         group.throughput(Throughput::Elements(num_elems));
-        let bench_spec = BenchmarkSpec::new_hlapi_dex(
-            dex_bench_spec,
+        let bench_spec = BenchmarkSpec::new_hlapi(
+            HlapiBench::Dex(dex_bench_spec),
             &params_name,
             OperandType::CipherText,
             Some(type_name),
@@ -1287,7 +1289,7 @@ fn cuda_bench_swap_claim_throughput<FheType, F1, F2>(
             });
         });
 
-        write_to_json::<u64, _>(
+        write_to_json::<u64, _, _>(
             &bench_spec,
             params,
             "dex-swap-claim",

--- a/tfhe-benchmark/benches/high_level_api/erc7984.rs
+++ b/tfhe-benchmark/benches/high_level_api/erc7984.rs
@@ -2,7 +2,9 @@
 use benchmark::utilities::{configure_gpu, get_param_type, ParamType};
 use benchmark::utilities::{write_to_json, OperatorType};
 use benchmark_spec::tfhe::hlapi::erc7984::{Erc7984, TransferFlavor};
-use benchmark_spec::{get_bench_type, BenchmarkMetric, BenchmarkSpec, BenchmarkType, OperandType};
+use benchmark_spec::{
+    get_bench_type, BenchmarkMetric, BenchmarkSpec, BenchmarkType, HlapiBench, OperandType,
+};
 use criterion::{Criterion, Throughput};
 use rand::prelude::*;
 use rand::thread_rng;
@@ -317,8 +319,8 @@ mod pbs_stats {
         let params = client_key.computation_parameters();
         let params_name = params.name();
 
-        let test_name = BenchmarkSpec::new_hlapi_erc7984(
-            erc7984_bench_spec,
+        let test_name = BenchmarkSpec::new_hlapi(
+            HlapiBench::Erc7984(erc7984_bench_spec),
             &params_name,
             OperandType::CipherText,
             Some(type_name),
@@ -330,7 +332,7 @@ mod pbs_stats {
 
         benchmark_result.write_result(&test_name.to_string(), count as usize);
 
-        write_to_json::<u64, _>(
+        write_to_json::<u64, _, _>(
             &test_name,
             params,
             "pbs-count",
@@ -360,8 +362,8 @@ fn bench_transfer_latency<FheType, F>(
 
     let mut c = c.benchmark_group(type_name);
 
-    let bench_spec = BenchmarkSpec::new_hlapi_erc7984(
-        erc7984_bench_spec,
+    let bench_spec = BenchmarkSpec::new_hlapi(
+        HlapiBench::Erc7984(erc7984_bench_spec),
         &params_name,
         OperandType::CipherText,
         Some(type_name),
@@ -385,7 +387,7 @@ fn bench_transfer_latency<FheType, F>(
         })
     });
 
-    write_to_json::<u64, _>(
+    write_to_json::<u64, _, _>(
         &bench_spec,
         params,
         "erc7984-transfer",
@@ -420,8 +422,8 @@ fn bench_transfer_latency_simd<FheType, F>(
     let params_name = params.name();
     let mut c = c.benchmark_group(type_name);
 
-    let bench_spec = BenchmarkSpec::new_hlapi_erc7984(
-        erc7984_bench_spec,
+    let bench_spec = BenchmarkSpec::new_hlapi(
+        HlapiBench::Erc7984(erc7984_bench_spec),
         &params_name,
         OperandType::CipherText,
         Some(type_name),
@@ -452,7 +454,7 @@ fn bench_transfer_latency_simd<FheType, F>(
         })
     });
 
-    write_to_json::<u64, _>(
+    write_to_json::<u64, _, _>(
         &bench_spec,
         params,
         "erc7984-simd-transfer",
@@ -482,8 +484,8 @@ fn bench_transfer_throughput<FheType, F>(
 
     for num_elems in [10, 100, 500] {
         group.throughput(Throughput::Elements(num_elems));
-        let bench_spec = BenchmarkSpec::new_hlapi_erc7984(
-            erc7984_bench_spec,
+        let bench_spec = BenchmarkSpec::new_hlapi(
+            HlapiBench::Erc7984(erc7984_bench_spec),
             &params_name,
             OperandType::CipherText,
             Some(type_name),
@@ -512,7 +514,7 @@ fn bench_transfer_throughput<FheType, F>(
             })
         });
 
-        write_to_json::<u64, _>(
+        write_to_json::<u64, _, _>(
             &bench_spec,
             params,
             "erc7984-transfer",
@@ -552,8 +554,8 @@ fn cuda_bench_transfer_throughput<FheType, F>(
     let mut group = c.benchmark_group(type_name);
     group.throughput(Throughput::Elements(num_elems));
 
-    let bench_spec = BenchmarkSpec::new_hlapi_erc7984(
-        erc7984_bench_spec,
+    let bench_spec = BenchmarkSpec::new_hlapi(
+        HlapiBench::Erc7984(erc7984_bench_spec),
         &params_name,
         OperandType::CipherText,
         Some(type_name),
@@ -607,7 +609,7 @@ fn cuda_bench_transfer_throughput<FheType, F>(
         });
     });
 
-    write_to_json::<u64, _>(
+    write_to_json::<u64, _, _>(
         &bench_spec,
         params,
         "erc7984-transfer",
@@ -637,8 +639,8 @@ fn hpu_bench_transfer_throughput<FheType, F>(
     let mut group = group.benchmark_group(type_name);
     for num_elems in [10, 100] {
         group.throughput(Throughput::Elements(num_elems));
-        let bench_spec = BenchmarkSpec::new_hlapi_erc7984(
-            erc7984_bench_spec,
+        let bench_spec = BenchmarkSpec::new_hlapi(
+            HlapiBench::Erc7984(erc7984_bench_spec),
             &params_name,
             OperandType::CipherText,
             Some(type_name),
@@ -675,7 +677,7 @@ fn hpu_bench_transfer_throughput<FheType, F>(
             });
         });
 
-        write_to_json::<u64, _>(
+        write_to_json::<u64, _, _>(
             &bench_spec,
             params,
             "erc7984-transfer",
@@ -714,8 +716,8 @@ fn hpu_bench_transfer_throughput_simd<FheType, F>(
     for num_elems in [2, 8] {
         let real_num_elems = num_elems * (hpu_simd_n as u64);
         group.throughput(Throughput::Elements(real_num_elems));
-        let bench_spec = BenchmarkSpec::new_hlapi_erc7984(
-            erc7984_bench_spec,
+        let bench_spec = BenchmarkSpec::new_hlapi(
+            HlapiBench::Erc7984(erc7984_bench_spec),
             &params_name,
             OperandType::CipherText,
             Some(type_name),
@@ -764,7 +766,7 @@ fn hpu_bench_transfer_throughput_simd<FheType, F>(
             });
         });
 
-        write_to_json::<u64, _>(
+        write_to_json::<u64, _, _>(
             &bench_spec,
             params,
             "erc7984-simd-transfer",

--- a/tfhe-benchmark/benches/high_level_api/kv_store.rs
+++ b/tfhe-benchmark/benches/high_level_api/kv_store.rs
@@ -1,8 +1,11 @@
 #[cfg(not(any(feature = "gpu", feature = "hpu")))]
 use benchmark::find_optimal_batch::find_optimal_batch;
 use benchmark::high_level_api::type_display::*;
-use benchmark::utilities::{write_to_json_unchecked, BitSizesSet, EnvConfig, OperatorType};
-use benchmark_spec::{get_bench_type, BenchmarkType};
+use benchmark::utilities::{write_to_json, BitSizesSet, EnvConfig, OperatorType};
+use benchmark_spec::tfhe::hlapi::kv_store::KvStoreOp;
+use benchmark_spec::{
+    get_bench_type, BenchmarkSpec, BenchmarkType, HlapiBench, OperandType, TypedKeyValue,
+};
 use criterion::{Criterion, Throughput};
 use rand::prelude::*;
 use rayon::prelude::*;
@@ -31,21 +34,30 @@ where
     let mut kv_store = KVStore::new();
     let mut rng = rand::thread_rng();
 
-    let format_id_bench = |op_name: &str| -> String {
-        format!(
-            "hlapi::kv_store::{op_name}::{}::key_{}_value_{}_elements_{num_elements}",
-            param.name(),
-            TypeDisplayer::<Key>::default(),
-            TypeDisplayer::<Value>::default(),
+    let key_name = TypeDisplayer::<Key>::default().to_string();
+    let value_name = TypeDisplayer::<Value>::default().to_string();
+    let tkv = TypedKeyValue::new(&key_name, &value_name);
+
+    let param_name = param.name();
+    let bench_type = get_bench_type();
+
+    let generate_bench_spec = |op: KvStoreOp| {
+        BenchmarkSpec::new_hlapi(
+            HlapiBench::KvStore(op),
+            &param_name,
+            OperandType::CipherText,
+            Some(&tkv),
+            *bench_type,
+            Some(num_elements),
         )
     };
 
-    let bench_id_contains_key;
-    let bench_id_contains_value;
-    let bench_id_contains_clear_value;
-    let bench_id_get;
-    let bench_id_update;
-    let bench_id_map;
+    let bench_spec_contains_key = generate_bench_spec(KvStoreOp::ContainsKey);
+    let bench_spec_contains_value = generate_bench_spec(KvStoreOp::ContainsValue);
+    let bench_spec_contains_clear_value = generate_bench_spec(KvStoreOp::ContainsClearValue);
+    let bench_spec_get = generate_bench_spec(KvStoreOp::Get);
+    let bench_spec_update = generate_bench_spec(KvStoreOp::Update);
+    let bench_spec_map = generate_bench_spec(KvStoreOp::Map);
 
     match get_bench_type() {
         BenchmarkType::Latency => {
@@ -63,43 +75,37 @@ where
             let value = rng.gen::<u128>();
             let value_to_add = Value::encrypt(value, cks);
 
-            bench_id_contains_key = format_id_bench("contains_key");
-            bench_group.bench_function(&bench_id_contains_key, |b| {
+            bench_group.bench_function(bench_spec_contains_key.to_string(), |b| {
                 b.iter(|| {
                     let _ = kv_store.contains_key(&encrypted_key);
                 })
             });
 
-            bench_id_contains_value = format_id_bench("contains_value");
-            bench_group.bench_function(&bench_id_contains_value, |b| {
+            bench_group.bench_function(bench_spec_contains_value.to_string(), |b| {
                 b.iter(|| {
                     let _ = kv_store.contains_value(&value_to_add);
                 })
             });
 
-            bench_id_contains_clear_value = format_id_bench("contains_clear_value");
-            bench_group.bench_function(&bench_id_contains_clear_value, |b| {
+            bench_group.bench_function(bench_spec_contains_clear_value.to_string(), |b| {
                 b.iter(|| {
                     let _ = kv_store.contains_clear_value(value);
                 })
             });
 
-            bench_id_get = format_id_bench("get");
-            bench_group.bench_function(&bench_id_get, |b| {
+            bench_group.bench_function(bench_spec_get.to_string(), |b| {
                 b.iter(|| {
                     let _ = kv_store.get(&encrypted_key);
                 })
             });
 
-            bench_id_update = format_id_bench("update");
-            bench_group.bench_function(&bench_id_update, |b| {
+            bench_group.bench_function(bench_spec_update.to_string(), |b| {
                 b.iter(|| {
                     let _ = kv_store.update(&encrypted_key, &value_to_add);
                 })
             });
 
-            bench_id_map = format_id_bench("map");
-            bench_group.bench_function(&bench_id_map, |b| {
+            bench_group.bench_function(bench_spec_map.to_string(), |b| {
                 b.iter(|| {
                     kv_store.map(&encrypted_key, |v| v);
                 })
@@ -160,8 +166,7 @@ where
 
             bench_group.throughput(Throughput::Elements(elements));
 
-            bench_id_contains_key = format_id_bench("contains_key::throughput");
-            bench_group.bench_function(&bench_id_contains_key, |b| {
+            bench_group.bench_function(bench_spec_contains_key.to_string(), |b| {
                 b.iter(|| {
                     kv_stores.par_iter().for_each(|kv_store| {
                         kv_store.contains_key(&encrypted_key);
@@ -169,8 +174,7 @@ where
                 })
             });
 
-            bench_id_contains_value = format_id_bench("contains_value::throughput");
-            bench_group.bench_function(&bench_id_contains_value, |b| {
+            bench_group.bench_function(bench_spec_contains_value.to_string(), |b| {
                 b.iter(|| {
                     kv_stores.par_iter().for_each(|kv_store| {
                         kv_store.contains_value(&value_to_add);
@@ -178,8 +182,7 @@ where
                 })
             });
 
-            bench_id_contains_clear_value = format_id_bench("contains_clear_value::throughput");
-            bench_group.bench_function(&bench_id_contains_clear_value, |b| {
+            bench_group.bench_function(bench_spec_contains_clear_value.to_string(), |b| {
                 b.iter(|| {
                     kv_stores.par_iter().for_each(|kv_store| {
                         kv_store.contains_clear_value(value);
@@ -187,8 +190,7 @@ where
                 })
             });
 
-            bench_id_get = format_id_bench("get::throughput");
-            bench_group.bench_function(&bench_id_get, |b| {
+            bench_group.bench_function(bench_spec_get.to_string(), |b| {
                 b.iter(|| {
                     kv_stores.par_iter_mut().for_each(|kv_store| {
                         kv_store.get(&encrypted_key);
@@ -196,8 +198,7 @@ where
                 })
             });
 
-            bench_id_update = format_id_bench("update::throughput");
-            bench_group.bench_function(&bench_id_update, |b| {
+            bench_group.bench_function(bench_spec_update.to_string(), |b| {
                 b.iter(|| {
                     kv_stores.par_iter_mut().for_each(|kv_store| {
                         kv_store.update(&encrypted_key, &value_to_add);
@@ -205,8 +206,7 @@ where
                 })
             });
 
-            bench_id_map = format_id_bench("map::throughput");
-            bench_group.bench_function(&bench_id_map, |b| {
+            bench_group.bench_function(bench_spec_map.to_string(), |b| {
                 b.iter(|| {
                     kv_stores.par_iter_mut().for_each(|kv_store| {
                         kv_store.map(&encrypted_key, |v| v);
@@ -216,18 +216,17 @@ where
         }
     }
 
-    for (bench_id, display_name) in [
-        (bench_id_contains_key, "contains_key"),
-        (bench_id_contains_value, "contains_value"),
-        (bench_id_contains_clear_value, "contains_clear_value"),
-        (bench_id_get, "get"),
-        (bench_id_update, "update"),
-        (bench_id_map, "map"),
+    for (bench_spec, display_name) in [
+        (bench_spec_contains_key, "contains_key"),
+        (bench_spec_contains_value, "contains_value"),
+        (bench_spec_contains_clear_value, "contains_clear_value"),
+        (bench_spec_get, "get"),
+        (bench_spec_update, "update"),
+        (bench_spec_map, "map"),
     ] {
-        write_to_json_unchecked::<u64, _>(
-            &bench_id,
+        write_to_json::<u64, _, _>(
+            &bench_spec,
             param,
-            param.name(),
             display_name,
             &OperatorType::Atomic,
             Key::BITS as u32,

--- a/tfhe-benchmark/benches/high_level_api/noise_squash.rs
+++ b/tfhe-benchmark/benches/high_level_api/noise_squash.rs
@@ -15,9 +15,10 @@ use benchmark::params_aliases::{
 #[cfg(feature = "gpu")]
 use benchmark::utilities::configure_gpu;
 use benchmark::utilities::{
-    will_this_bench_run, write_to_json_unchecked, BitSizesSet, EnvConfig, OperatorType,
+    will_this_bench_run, write_to_json, BitSizesSet, EnvConfig, OperatorType,
 };
-use benchmark_spec::{get_bench_type, BenchmarkType};
+use benchmark_spec::tfhe::hlapi::noise_squash::NoiseSquashingKind;
+use benchmark_spec::{get_bench_type, BenchmarkSpec, BenchmarkType, HlapiBench, OperandType};
 use criterion::{Criterion, Throughput};
 use rand::prelude::*;
 use rand::thread_rng;
@@ -73,36 +74,35 @@ fn bench_sns_only_fhe_type<FheType>(
     }
 
     let mut bench_group = c.benchmark_group(type_name);
-    let bench_id_prefix = if cfg!(feature = "gpu") {
-        "hlapi::cuda".to_string()
-    } else {
-        "hlapi".to_string()
-    };
     let noise_param_name = noise_param.name();
-    let bench_id_suffix = format!("noise_squash::{noise_param_name}::{type_name}");
 
     let mut rng = thread_rng();
 
-    let bench_id;
+    let bench_type = get_bench_type();
+    let bench_spec = BenchmarkSpec::new_hlapi(
+        HlapiBench::NoiseSquashing(NoiseSquashingKind::NoiseSquash),
+        &noise_param_name,
+        OperandType::CipherText,
+        Some(type_name),
+        *bench_type,
+        None,
+    );
+    let bench_id = bench_spec.to_string();
 
-    match get_bench_type() {
+    match bench_type {
         BenchmarkType::Latency => {
-            bench_id = format!("{bench_id_prefix}::{bench_id_suffix}");
-
             #[cfg(feature = "gpu")]
             configure_gpu(&client_key);
 
             let input = FheType::encrypt(rng.gen(), &client_key);
 
-            bench_group.bench_function(&bench_id, |b| {
+            bench_group.bench_function(bench_id.as_str(), |b| {
                 b.iter(|| {
                     let _ = input.squash_noise();
                 })
             });
         }
         BenchmarkType::Throughput => {
-            bench_id = format!("{bench_id_prefix}::throughput::{bench_id_suffix}");
-
             let elements = if will_this_bench_run(type_name, &bench_id) {
                 #[cfg(feature = "gpu")]
                 {
@@ -153,7 +153,7 @@ fn bench_sns_only_fhe_type<FheType>(
                     })
                     .collect::<Vec<_>>();
 
-                bench_group.bench_function(&bench_id, |b| {
+                bench_group.bench_function(bench_id.as_str(), |b| {
                     let encrypt_values = || {
                         (0..elements)
                             .map(|_| FheType::encrypt(rng.gen(), &client_key))
@@ -178,7 +178,7 @@ fn bench_sns_only_fhe_type<FheType>(
             {
                 bench_group.throughput(Throughput::Elements(elements));
                 println!("elements: {elements}");
-                bench_group.bench_function(&bench_id, |b| {
+                bench_group.bench_function(bench_id.as_str(), |b| {
                     let encrypt_values = || {
                         (0..elements)
                             .map(|_| FheType::encrypt(rng.gen(), &client_key))
@@ -200,10 +200,9 @@ fn bench_sns_only_fhe_type<FheType>(
     }
     let params = client_key.computation_parameters();
 
-    write_to_json_unchecked::<u64, _>(
-        &bench_id,
+    write_to_json::<u64, _, _>(
+        &bench_spec,
         params,
-        params.name(),
         "noise_squash",
         &OperatorType::Atomic,
         64,
@@ -248,22 +247,23 @@ fn bench_decomp_sns_comp_fhe_type<FheType>(
     }
 
     let mut bench_group = c.benchmark_group(type_name);
-    let bench_id_prefix = if cfg!(feature = "gpu") {
-        "hlapi::cuda".to_string()
-    } else {
-        "hlapi".to_string()
-    };
     let noise_param_name = noise_param.name();
-    let bench_id_suffix = format!("decomp_noise_squash_comp::{noise_param_name}::{type_name}");
 
     let mut rng = thread_rng();
 
-    let bench_id;
+    let bench_type = get_bench_type();
+    let bench_spec = BenchmarkSpec::new_hlapi(
+        HlapiBench::NoiseSquashing(NoiseSquashingKind::DecompNoiseSquashComp),
+        &noise_param_name,
+        OperandType::CipherText,
+        Some(type_name),
+        *bench_type,
+        None,
+    );
+    let bench_id = bench_spec.to_string();
 
-    match get_bench_type() {
+    match bench_type {
         BenchmarkType::Latency => {
-            bench_id = format!("{bench_id_prefix}::{bench_id_suffix}");
-
             #[cfg(feature = "gpu")]
             configure_gpu(&client_key);
 
@@ -273,7 +273,7 @@ fn bench_decomp_sns_comp_fhe_type<FheType>(
             builder.push(input);
             let compressed = builder.build().unwrap();
 
-            bench_group.bench_function(&bench_id, |b| {
+            bench_group.bench_function(bench_id.as_str(), |b| {
                 b.iter(|| {
                     let decompressed = compressed.get::<FheType>(0).unwrap().unwrap();
                     let squashed = decompressed.squash_noise().unwrap();
@@ -284,8 +284,6 @@ fn bench_decomp_sns_comp_fhe_type<FheType>(
             });
         }
         BenchmarkType::Throughput => {
-            bench_id = format!("{bench_id_prefix}::throughput::{bench_id_suffix}");
-
             let elements = if will_this_bench_run(type_name, &bench_id) {
                 #[cfg(feature = "gpu")]
                 {
@@ -340,7 +338,7 @@ fn bench_decomp_sns_comp_fhe_type<FheType>(
                     })
                     .collect::<Vec<_>>();
 
-                bench_group.bench_function(&bench_id, |b| {
+                bench_group.bench_function(bench_id.as_str(), |b| {
                     let compressed_values = || {
                         (0..elements)
                             .map(|_| {
@@ -377,7 +375,7 @@ fn bench_decomp_sns_comp_fhe_type<FheType>(
             #[cfg(all(not(feature = "hpu"), not(feature = "gpu")))]
             {
                 bench_group.throughput(Throughput::Elements(elements));
-                bench_group.bench_function(&bench_id, |b| {
+                bench_group.bench_function(bench_id.as_str(), |b| {
                     let compressed_values = || {
                         (0..elements)
                             .map(|_| {
@@ -409,10 +407,9 @@ fn bench_decomp_sns_comp_fhe_type<FheType>(
     }
     let params = client_key.computation_parameters();
 
-    write_to_json_unchecked::<u64, _>(
-        &bench_id,
+    write_to_json::<u64, _, _>(
+        &bench_spec,
         params,
-        params.name(),
         "decomp_noise_squash_comp",
         &OperatorType::Atomic,
         64,

--- a/tfhe-benchmark/benches/shortint/bench.rs
+++ b/tfhe-benchmark/benches/shortint/bench.rs
@@ -2,7 +2,8 @@ use benchmark::params::{
     raw_benchmark_parameters, SHORTINT_BENCH_PARAMS_GAUSSIAN, SHORTINT_BENCH_PARAMS_TUNIFORM,
     SHORTINT_MULTI_BIT_BENCH_PARAMS,
 };
-use benchmark::utilities::{write_to_json_unchecked, OperatorType};
+use benchmark::utilities::{write_to_json, OperatorType};
+use benchmark_spec::{BenchmarkMetric, BenchmarkSpec, ShortintBench};
 use criterion::{criterion_group, Criterion};
 use rand::Rng;
 use std::env;
@@ -13,13 +14,13 @@ use tfhe::shortint::{Ciphertext, CompressedServerKey, ServerKey};
 
 fn bench_server_key_unary_function<F>(
     c: &mut Criterion,
-    bench_name: &str,
+    shortint_bench: ShortintBench,
     display_name: &str,
     unary_op: F,
 ) where
     F: Fn(&ServerKey, &mut Ciphertext),
 {
-    let mut bench_group = c.benchmark_group(bench_name);
+    let mut bench_group = c.benchmark_group(shortint_bench.to_string());
 
     for param in raw_benchmark_parameters().iter() {
         let keys = KEY_CACHE.get_from_param(*param);
@@ -33,17 +34,22 @@ fn bench_server_key_unary_function<F>(
 
         let mut ct = cks.encrypt(clear_text);
 
-        let bench_id = format!("{bench_name}::{}", param.name());
+        let param_name = param.name();
+        let benchmark_spec = BenchmarkSpec::<str>::new_shortint(
+            shortint_bench,
+            &param_name,
+            BenchmarkMetric::Latency,
+        );
+        let bench_id = benchmark_spec.to_string();
         bench_group.bench_function(&bench_id, |b| {
             b.iter(|| {
                 unary_op(sks, &mut ct);
             })
         });
 
-        write_to_json_unchecked::<u64, _>(
-            &bench_id,
+        write_to_json::<u64, _, _>(
+            &benchmark_spec,
             *param,
-            param.name(),
             display_name,
             &OperatorType::Atomic,
             param.message_modulus().0.ilog2(),
@@ -56,13 +62,13 @@ fn bench_server_key_unary_function<F>(
 
 fn bench_server_key_binary_function<F>(
     c: &mut Criterion,
-    bench_name: &str,
+    shortint_bench: ShortintBench,
     display_name: &str,
     binary_op: F,
 ) where
     F: Fn(&ServerKey, &mut Ciphertext, &mut Ciphertext),
 {
-    let mut bench_group = c.benchmark_group(bench_name);
+    let mut bench_group = c.benchmark_group(shortint_bench.to_string());
 
     for param in raw_benchmark_parameters().iter() {
         let keys = KEY_CACHE.get_from_param(*param);
@@ -78,17 +84,22 @@ fn bench_server_key_binary_function<F>(
         let mut ct_0 = cks.encrypt(clear_0);
         let mut ct_1 = cks.encrypt(clear_1);
 
-        let bench_id = format!("{bench_name}::{}", param.name());
+        let param_name = param.name();
+        let benchmark_spec = BenchmarkSpec::<str>::new_shortint(
+            shortint_bench,
+            &param_name,
+            BenchmarkMetric::Latency,
+        );
+        let bench_id = benchmark_spec.to_string();
         bench_group.bench_function(&bench_id, |b| {
             b.iter(|| {
                 binary_op(sks, &mut ct_0, &mut ct_1);
             })
         });
 
-        write_to_json_unchecked::<u64, _>(
-            &bench_id,
+        write_to_json::<u64, _, _>(
+            &benchmark_spec,
             *param,
-            param.name(),
             display_name,
             &OperatorType::Atomic,
             param.message_modulus().0.ilog2(),
@@ -101,13 +112,13 @@ fn bench_server_key_binary_function<F>(
 
 fn bench_server_key_binary_scalar_function<F>(
     c: &mut Criterion,
-    bench_name: &str,
+    shortint_bench: ShortintBench,
     display_name: &str,
     binary_op: F,
 ) where
     F: Fn(&ServerKey, &mut Ciphertext, u8),
 {
-    let mut bench_group = c.benchmark_group(bench_name);
+    let mut bench_group = c.benchmark_group(shortint_bench.to_string());
 
     for param in raw_benchmark_parameters().iter() {
         let keys = KEY_CACHE.get_from_param(*param);
@@ -122,17 +133,22 @@ fn bench_server_key_binary_scalar_function<F>(
 
         let mut ct_0 = cks.encrypt(clear_0);
 
-        let bench_id = format!("{bench_name}::{}", param.name());
+        let param_name = param.name();
+        let benchmark_spec = BenchmarkSpec::<str>::new_shortint(
+            shortint_bench,
+            &param_name,
+            BenchmarkMetric::Latency,
+        );
+        let bench_id = benchmark_spec.to_string();
         bench_group.bench_function(&bench_id, |b| {
             b.iter(|| {
                 binary_op(sks, &mut ct_0, clear_1 as u8);
             })
         });
 
-        write_to_json_unchecked::<u64, _>(
-            &bench_id,
+        write_to_json::<u64, _, _>(
+            &benchmark_spec,
             *param,
-            param.name(),
             display_name,
             &OperatorType::Atomic,
             param.message_modulus().0.ilog2(),
@@ -145,13 +161,13 @@ fn bench_server_key_binary_scalar_function<F>(
 
 fn bench_server_key_binary_scalar_division_function<F>(
     c: &mut Criterion,
-    bench_name: &str,
+    shortint_bench: ShortintBench,
     display_name: &str,
     binary_op: F,
 ) where
     F: Fn(&ServerKey, &mut Ciphertext, u8),
 {
-    let mut bench_group = c.benchmark_group(bench_name);
+    let mut bench_group = c.benchmark_group(shortint_bench.to_string());
 
     for param in raw_benchmark_parameters().iter() {
         let keys = KEY_CACHE.get_from_param(*param);
@@ -170,17 +186,22 @@ fn bench_server_key_binary_scalar_division_function<F>(
 
         let mut ct_0 = cks.encrypt(clear_0);
 
-        let bench_id = format!("{bench_name}::{}", param.name());
+        let param_name = param.name();
+        let benchmark_spec = BenchmarkSpec::<str>::new_shortint(
+            shortint_bench,
+            &param_name,
+            BenchmarkMetric::Latency,
+        );
+        let bench_id = benchmark_spec.to_string();
         bench_group.bench_function(&bench_id, |b| {
             b.iter(|| {
                 binary_op(sks, &mut ct_0, clear_1 as u8);
             })
         });
 
-        write_to_json_unchecked::<u64, _>(
-            &bench_id,
+        write_to_json::<u64, _, _>(
+            &benchmark_spec,
             *param,
-            param.name(),
             display_name,
             &OperatorType::Atomic,
             param.message_modulus().0.ilog2(),
@@ -192,7 +213,8 @@ fn bench_server_key_binary_scalar_division_function<F>(
 }
 
 fn carry_extract_bench(c: &mut Criterion) {
-    let mut bench_group = c.benchmark_group("carry_extract");
+    let shortint_bench = ShortintBench::CarryExtract;
+    let mut bench_group = c.benchmark_group(shortint_bench.to_string());
 
     for param in raw_benchmark_parameters().iter() {
         let keys = KEY_CACHE.get_from_param(*param);
@@ -206,17 +228,22 @@ fn carry_extract_bench(c: &mut Criterion) {
 
         let ct_0 = cks.encrypt(clear_0);
 
-        let bench_id = format!("shortint::carry_extract::{}", param.name());
+        let param_name = param.name();
+        let benchmark_spec = BenchmarkSpec::<str>::new_shortint(
+            shortint_bench,
+            &param_name,
+            BenchmarkMetric::Latency,
+        );
+        let bench_id = benchmark_spec.to_string();
         bench_group.bench_function(&bench_id, |b| {
             b.iter(|| {
                 let _ = sks.carry_extract(&ct_0);
             })
         });
 
-        write_to_json_unchecked::<u64, _>(
-            &bench_id,
+        write_to_json::<u64, _, _>(
+            &benchmark_spec,
             *param,
-            param.name(),
             "carry_extract",
             &OperatorType::Atomic,
             param.message_modulus().0.ilog2(),
@@ -228,7 +255,8 @@ fn carry_extract_bench(c: &mut Criterion) {
 }
 
 fn programmable_bootstrapping_bench(c: &mut Criterion) {
-    let mut bench_group = c.benchmark_group("programmable_bootstrap");
+    let shortint_bench = ShortintBench::ProgrammableBootstrap;
+    let mut bench_group = c.benchmark_group(shortint_bench.to_string());
 
     for param in raw_benchmark_parameters().iter() {
         let keys = KEY_CACHE.get_from_param(*param);
@@ -244,7 +272,13 @@ fn programmable_bootstrapping_bench(c: &mut Criterion) {
 
         let ctxt = cks.encrypt(clear_0);
 
-        let bench_id = format!("shortint::programmable_bootstrap::{}", param.name());
+        let param_name = param.name();
+        let benchmark_spec = BenchmarkSpec::<str>::new_shortint(
+            shortint_bench,
+            &param_name,
+            BenchmarkMetric::Latency,
+        );
+        let bench_id = benchmark_spec.to_string();
 
         bench_group.bench_function(&bench_id, |b| {
             b.iter(|| {
@@ -252,10 +286,9 @@ fn programmable_bootstrapping_bench(c: &mut Criterion) {
             })
         });
 
-        write_to_json_unchecked::<u64, _>(
-            &bench_id,
+        write_to_json::<u64, _, _>(
+            &benchmark_spec,
             *param,
-            param.name(),
             "pbs",
             &OperatorType::Atomic,
             param.message_modulus().0.ilog2(),
@@ -267,7 +300,8 @@ fn programmable_bootstrapping_bench(c: &mut Criterion) {
 }
 
 fn server_key_from_compressed_key(c: &mut Criterion) {
-    let mut bench_group = c.benchmark_group("uncompress_key");
+    let shortint_bench = ShortintBench::UncompressKey;
+    let mut bench_group = c.benchmark_group(shortint_bench.to_string());
     bench_group
         .sample_size(10)
         .measurement_time(std::time::Duration::from_secs(60));
@@ -287,7 +321,13 @@ fn server_key_from_compressed_key(c: &mut Criterion) {
         let keys = KEY_CACHE.get_from_param(*param);
         let sks_compressed = CompressedServerKey::new(keys.client_key());
 
-        let bench_id = format!("shortint::uncompress_key::{}", param.name());
+        let param_name = param.name();
+        let benchmark_spec = BenchmarkSpec::<str>::new_shortint(
+            shortint_bench,
+            &param_name,
+            BenchmarkMetric::Latency,
+        );
+        let bench_id = benchmark_spec.to_string();
 
         bench_group.bench_function(&bench_id, |b| {
             let clone_compressed_key = || sks_compressed.clone();
@@ -301,10 +341,9 @@ fn server_key_from_compressed_key(c: &mut Criterion) {
             )
         });
 
-        write_to_json_unchecked::<u64, _>(
-            &bench_id,
+        write_to_json::<u64, _, _>(
+            &benchmark_spec,
             *param,
-            param.name(),
             "uncompress_key",
             &OperatorType::Atomic,
             param.message_modulus().0.ilog2(),
@@ -316,11 +355,11 @@ fn server_key_from_compressed_key(c: &mut Criterion) {
 }
 
 macro_rules! define_server_key_unary_bench_fn (
-    (method_name:$server_key_method:ident, display_name:$name:ident) => {
+    (method_name:$server_key_method:ident, display_name:$name:ident, shortint_bench:$bench:expr) => {
         fn $server_key_method(c: &mut Criterion) {
             bench_server_key_unary_function(
                 c,
-                concat!("shortint::", stringify!($server_key_method)),
+                $bench,
                 stringify!($name),
                 |server_key, lhs| {
                     let _ = server_key.$server_key_method(lhs);},
@@ -330,11 +369,11 @@ macro_rules! define_server_key_unary_bench_fn (
 );
 
 macro_rules! define_server_key_bench_fn (
-    (method_name:$server_key_method:ident, display_name:$name:ident) => {
+    (method_name:$server_key_method:ident, display_name:$name:ident, shortint_bench:$bench:expr) => {
         fn $server_key_method(c: &mut Criterion) {
             bench_server_key_binary_function(
                 c,
-                concat!("shortint::", stringify!($server_key_method)),
+                $bench,
                 stringify!($name),
                 |server_key, lhs, rhs| {
                     let _ = server_key.$server_key_method(lhs, rhs);},
@@ -344,11 +383,11 @@ macro_rules! define_server_key_bench_fn (
 );
 
 macro_rules! define_server_key_scalar_bench_fn (
-    (method_name:$server_key_method:ident, display_name:$name:ident) => {
+    (method_name:$server_key_method:ident, display_name:$name:ident, shortint_bench:$bench:expr) => {
         fn $server_key_method(c: &mut Criterion) {
             bench_server_key_binary_scalar_function(
                 c,
-                concat!("shortint::", stringify!($server_key_method)),
+                $bench,
                 stringify!($name),
                 |server_key, lhs, rhs| {
                     let _ = server_key.$server_key_method(lhs, rhs);},
@@ -358,11 +397,11 @@ macro_rules! define_server_key_scalar_bench_fn (
 );
 
 macro_rules! define_server_key_scalar_div_bench_fn (
-    (method_name:$server_key_method:ident, display_name:$name:ident) => {
+    (method_name:$server_key_method:ident, display_name:$name:ident, shortint_bench:$bench:expr) => {
         fn $server_key_method(c: &mut Criterion) {
             bench_server_key_binary_scalar_division_function(
                 c,
-                concat!("shortint::", stringify!($server_key_method)),
+                $bench,
                 stringify!($name),
                 |server_key, lhs, rhs| {
                     let _ = server_key.$server_key_method(lhs, rhs);},
@@ -385,202 +424,251 @@ macro_rules! define_custom_bench_fn (
 
 define_server_key_unary_bench_fn!(
     method_name: unchecked_neg,
-    display_name: negation
+    display_name: negation,
+    shortint_bench: ShortintBench::UncheckedNeg
 );
 define_server_key_bench_fn!(
     method_name: unchecked_add,
-    display_name: add
+    display_name: add,
+    shortint_bench: ShortintBench::UncheckedAdd
 );
 define_server_key_bench_fn!(
     method_name: unchecked_sub,
-    display_name: sub
+    display_name: sub,
+    shortint_bench: ShortintBench::UncheckedSub
 );
 define_server_key_bench_fn!(
     method_name: unchecked_mul_lsb,
-    display_name: mul
+    display_name: mul,
+    shortint_bench: ShortintBench::UncheckedMulLsb
 );
 define_server_key_bench_fn!(
     method_name: unchecked_mul_msb,
-    display_name: mul
+    display_name: mul,
+    shortint_bench: ShortintBench::UncheckedMulMsb
 );
 define_server_key_bench_fn!(
     method_name: unchecked_div,
-    display_name: div
+    display_name: div,
+    shortint_bench: ShortintBench::UncheckedDiv
 );
 define_server_key_bench_fn!(
     method_name: smart_bitand,
-    display_name: bitand
+    display_name: bitand,
+    shortint_bench: ShortintBench::SmartBitand
 );
 define_server_key_bench_fn!(
     method_name: smart_bitor,
-    display_name: bitor
+    display_name: bitor,
+    shortint_bench: ShortintBench::SmartBitor
 );
 define_server_key_bench_fn!(
     method_name: smart_bitxor,
-    display_name: bitxor
+    display_name: bitxor,
+    shortint_bench: ShortintBench::SmartBitxor
 );
 define_server_key_bench_fn!(
     method_name: smart_add,
-    display_name: add
+    display_name: add,
+    shortint_bench: ShortintBench::SmartAdd
 );
 define_server_key_bench_fn!(
     method_name: smart_sub,
-    display_name: sub
+    display_name: sub,
+    shortint_bench: ShortintBench::SmartSub
 );
 define_server_key_bench_fn!(
     method_name: smart_mul_lsb,
-    display_name: mul
+    display_name: mul,
+    shortint_bench: ShortintBench::SmartMulLsb
 );
 define_server_key_bench_fn!(
     method_name: bitand,
-    display_name: bitand
+    display_name: bitand,
+    shortint_bench: ShortintBench::Bitand
 );
 define_server_key_bench_fn!(
     method_name: bitor,
-    display_name: bitor
+    display_name: bitor,
+    shortint_bench: ShortintBench::Bitor
 );
 define_server_key_bench_fn!(
     method_name: bitxor,
-    display_name: bitxor
+    display_name: bitxor,
+    shortint_bench: ShortintBench::Bitxor
 );
 define_server_key_bench_fn!(
     method_name: add,
-    display_name: add
+    display_name: add,
+    shortint_bench: ShortintBench::Add
 );
 define_server_key_bench_fn!(
     method_name: sub,
-    display_name: sub
+    display_name: sub,
+    shortint_bench: ShortintBench::Sub
 );
 define_server_key_bench_fn!(
     method_name: mul,
-    display_name: mul
+    display_name: mul,
+    shortint_bench: ShortintBench::Mul
 );
 define_server_key_bench_fn!(
     method_name: div,
-    display_name: div
+    display_name: div,
+    shortint_bench: ShortintBench::Div
 );
 define_server_key_bench_fn!(
     method_name: greater,
-    display_name: greater_than
+    display_name: greater_than,
+    shortint_bench: ShortintBench::Greater
 );
 define_server_key_bench_fn!(
     method_name: greater_or_equal,
-    display_name: greater_or_equal
+    display_name: greater_or_equal,
+    shortint_bench: ShortintBench::GreaterOrEqual
 );
 define_server_key_bench_fn!(
     method_name: less,
-    display_name: less_than
+    display_name: less_than,
+    shortint_bench: ShortintBench::Less
 );
 define_server_key_bench_fn!(
     method_name: less_or_equal,
-    display_name: less_or_equal
+    display_name: less_or_equal,
+    shortint_bench: ShortintBench::LessOrEqual
 );
 define_server_key_bench_fn!(
     method_name: equal,
-    display_name: equal
+    display_name: equal,
+    shortint_bench: ShortintBench::Equal
 );
 define_server_key_bench_fn!(
     method_name: not_equal,
-    display_name: not_equal
+    display_name: not_equal,
+    shortint_bench: ShortintBench::NotEqual
 );
 define_server_key_unary_bench_fn!(
     method_name: neg,
-    display_name: negation
+    display_name: negation,
+    shortint_bench: ShortintBench::Neg
 );
 define_server_key_bench_fn!(
     method_name: unchecked_greater,
-    display_name: greater_than
+    display_name: greater_than,
+    shortint_bench: ShortintBench::UncheckedGreater
 );
 define_server_key_bench_fn!(
     method_name: unchecked_less,
-    display_name: less_than
+    display_name: less_than,
+    shortint_bench: ShortintBench::UncheckedLess
 );
 define_server_key_bench_fn!(
     method_name: unchecked_equal,
-    display_name: equal
+    display_name: equal,
+    shortint_bench: ShortintBench::UncheckedEqual
 );
 
 define_server_key_scalar_bench_fn!(
     method_name: unchecked_scalar_add,
-    display_name: add
+    display_name: add,
+    shortint_bench: ShortintBench::UncheckedScalarAdd
 );
 define_server_key_scalar_bench_fn!(
     method_name: unchecked_scalar_sub,
-    display_name: sub
+    display_name: sub,
+    shortint_bench: ShortintBench::UncheckedScalarSub
 );
 define_server_key_scalar_bench_fn!(
     method_name: unchecked_scalar_mul,
-    display_name: mul
+    display_name: mul,
+    shortint_bench: ShortintBench::UncheckedScalarMul
 );
 define_server_key_scalar_bench_fn!(
     method_name: unchecked_scalar_left_shift,
-    display_name: left_shift
+    display_name: left_shift,
+    shortint_bench: ShortintBench::UncheckedScalarLeftShift
 );
 define_server_key_scalar_bench_fn!(
     method_name: unchecked_scalar_right_shift,
-    display_name: right_shift
+    display_name: right_shift,
+    shortint_bench: ShortintBench::UncheckedScalarRightShift
 );
 
 define_server_key_scalar_div_bench_fn!(
     method_name: unchecked_scalar_div,
-    display_name: div
+    display_name: div,
+    shortint_bench: ShortintBench::UncheckedScalarDiv
 );
 define_server_key_scalar_div_bench_fn!(
     method_name: unchecked_scalar_mod,
-    display_name: modulo
+    display_name: modulo,
+    shortint_bench: ShortintBench::UncheckedScalarMod
 );
 define_server_key_scalar_bench_fn!(
     method_name: scalar_add,
-    display_name: add
+    display_name: add,
+    shortint_bench: ShortintBench::ScalarAdd
 );
 define_server_key_scalar_bench_fn!(
     method_name: scalar_sub,
-    display_name: sub
+    display_name: sub,
+    shortint_bench: ShortintBench::ScalarSub
 );
 define_server_key_scalar_bench_fn!(
     method_name: scalar_mul,
-    display_name: mul
+    display_name: mul,
+    shortint_bench: ShortintBench::ScalarMul
 );
 define_server_key_scalar_bench_fn!(
     method_name: scalar_left_shift,
-    display_name: left_shift
+    display_name: left_shift,
+    shortint_bench: ShortintBench::ScalarLeftShift
 );
 define_server_key_scalar_bench_fn!(
     method_name: scalar_right_shift,
-    display_name: right_shift
+    display_name: right_shift,
+    shortint_bench: ShortintBench::ScalarRightShift
 );
 
 define_server_key_scalar_div_bench_fn!(
     method_name: scalar_div,
-    display_name: div
+    display_name: div,
+    shortint_bench: ShortintBench::ScalarDiv
 );
 define_server_key_scalar_div_bench_fn!(
     method_name: scalar_mod,
-    display_name: modulo
+    display_name: modulo,
+    shortint_bench: ShortintBench::ScalarMod
 );
 define_server_key_scalar_bench_fn!(
     method_name: scalar_greater,
-    display_name: greater_than
+    display_name: greater_than,
+    shortint_bench: ShortintBench::ScalarGreater
 );
 define_server_key_scalar_bench_fn!(
     method_name: scalar_greater_or_equal,
-    display_name: greater_or_equal
+    display_name: greater_or_equal,
+    shortint_bench: ShortintBench::ScalarGreaterOrEqual
 );
 define_server_key_scalar_bench_fn!(
     method_name: scalar_less,
-    display_name: less_than
+    display_name: less_than,
+    shortint_bench: ShortintBench::ScalarLess
 );
 define_server_key_scalar_bench_fn!(
     method_name: scalar_less_or_equal,
-    display_name: less_or_equal
+    display_name: less_or_equal,
+    shortint_bench: ShortintBench::ScalarLessOrEqual
 );
 define_server_key_scalar_div_bench_fn!(
     method_name: scalar_equal,
-    display_name: equal
+    display_name: equal,
+    shortint_bench: ShortintBench::ScalarEqual
 );
 define_server_key_scalar_div_bench_fn!(
     method_name: scalar_not_equal,
-    display_name: not_equal
+    display_name: not_equal,
+    shortint_bench: ShortintBench::ScalarNotEqual
 );
 
 define_custom_bench_fn!(function_name: carry_extract);

--- a/tfhe-benchmark/benches/shortint/casting.rs
+++ b/tfhe-benchmark/benches/shortint/casting.rs
@@ -1,13 +1,14 @@
 use benchmark::params_aliases::*;
-use benchmark::utilities::{write_to_json_unchecked, OperatorType};
+use benchmark::utilities::{write_to_json, OperatorType};
+use benchmark_spec::{BenchmarkMetric, BenchmarkSpec, ShortintBench};
 use criterion::Criterion;
 use rayon::prelude::*;
 use tfhe::keycache::NamedParam;
 use tfhe::shortint::prelude::*;
 
 pub fn pack_cast_64(c: &mut Criterion) {
-    let bench_name = "shortint::pack_cast_64";
-    let mut bench_group = c.benchmark_group(bench_name);
+    let shortint_bench = ShortintBench::PackCast64;
+    let mut bench_group = c.benchmark_group(shortint_bench.to_string());
 
     let (client_key_1, server_key_1): (ClientKey, ServerKey) =
         gen_keys(BENCH_PARAM_MESSAGE_1_CARRY_1_KS_PBS_GAUSSIAN_2M128);
@@ -25,7 +26,12 @@ pub fn pack_cast_64(c: &mut Criterion) {
 
     let vec_ct = vec![client_key_1.encrypt(1); 64];
 
-    let bench_id = format!("{bench_name}_{ks_param_name}");
+    let benchmark_spec = BenchmarkSpec::<str>::new_shortint(
+        shortint_bench,
+        &ks_param_name,
+        BenchmarkMetric::Latency,
+    );
+    let bench_id = benchmark_spec.to_string();
     bench_group.bench_function(&bench_id, |b| {
         b.iter(|| {
             let _ = (0..32)
@@ -45,10 +51,9 @@ pub fn pack_cast_64(c: &mut Criterion) {
         });
     });
 
-    write_to_json_unchecked::<u64, _>(
-        &bench_id,
+    write_to_json::<u64, _, _>(
+        &benchmark_spec,
         ks_param,
-        ks_param_name,
         "pack_cast_64",
         &OperatorType::Atomic,
         0,
@@ -57,8 +62,8 @@ pub fn pack_cast_64(c: &mut Criterion) {
 }
 
 pub fn pack_cast(c: &mut Criterion) {
-    let bench_name = "shortint::pack_cast";
-    let mut bench_group = c.benchmark_group(bench_name);
+    let shortint_bench = ShortintBench::PackCast;
+    let mut bench_group = c.benchmark_group(shortint_bench.to_string());
 
     let (client_key_1, server_key_1): (ClientKey, ServerKey) =
         gen_keys(BENCH_PARAM_MESSAGE_1_CARRY_1_KS_PBS_GAUSSIAN_2M128);
@@ -66,7 +71,7 @@ pub fn pack_cast(c: &mut Criterion) {
         gen_keys(BENCH_PARAM_MESSAGE_2_CARRY_2_KS_PBS_GAUSSIAN_2M128);
 
     let ks_param = BENCH_PARAM_KEYSWITCH_1_1_KS_PBS_TO_2_2_KS_PBS_GAUSSIAN_2M128;
-    let ks_param_name = "BENCH_PARAM_KEYSWITCH_1_1_KS_PBS_TO_2_2_KS_PBS_GAUSSIAN_2M128";
+    let ks_param_name = ks_param.name();
 
     let ksk = KeySwitchingKey::new(
         (&client_key_1, Some(&server_key_1)),
@@ -77,7 +82,12 @@ pub fn pack_cast(c: &mut Criterion) {
     let ct_1 = client_key_1.encrypt(1);
     let ct_2 = client_key_1.encrypt(1);
 
-    let bench_id = format!("{bench_name}_{ks_param_name}");
+    let benchmark_spec = BenchmarkSpec::<str>::new_shortint(
+        shortint_bench,
+        &ks_param_name,
+        BenchmarkMetric::Latency,
+    );
+    let bench_id = benchmark_spec.to_string();
     bench_group.bench_function(&bench_id, |b| {
         b.iter(|| {
             let _ = ksk.cast(
@@ -86,10 +96,9 @@ pub fn pack_cast(c: &mut Criterion) {
         });
     });
 
-    write_to_json_unchecked::<u64, _>(
-        &bench_id,
+    write_to_json::<u64, _, _>(
+        &benchmark_spec,
         ks_param,
-        ks_param_name,
         "pack_cast",
         &OperatorType::Atomic,
         0,
@@ -98,8 +107,8 @@ pub fn pack_cast(c: &mut Criterion) {
 }
 
 pub fn cast(c: &mut Criterion) {
-    let bench_name = "shortint::cast";
-    let mut bench_group = c.benchmark_group(bench_name);
+    let shortint_bench = ShortintBench::Cast;
+    let mut bench_group = c.benchmark_group(shortint_bench.to_string());
 
     let (client_key_1, server_key_1): (ClientKey, ServerKey) =
         gen_keys(BENCH_PARAM_MESSAGE_1_CARRY_1_KS_PBS_GAUSSIAN_2M128);
@@ -107,7 +116,7 @@ pub fn cast(c: &mut Criterion) {
         gen_keys(BENCH_PARAM_MESSAGE_2_CARRY_2_KS_PBS_GAUSSIAN_2M128);
 
     let ks_param = BENCH_PARAM_KEYSWITCH_1_1_KS_PBS_TO_2_2_KS_PBS_GAUSSIAN_2M128;
-    let ks_param_name = "BENCH_PARAM_KEYSWITCH_1_1_KS_PBS_TO_2_2_KS_PBS_GAUSSIAN_2M128";
+    let ks_param_name = ks_param.name();
 
     let ksk = KeySwitchingKey::new(
         (&client_key_1, Some(&server_key_1)),
@@ -117,17 +126,21 @@ pub fn cast(c: &mut Criterion) {
 
     let ct = client_key_1.encrypt(1);
 
-    let bench_id = format!("{bench_name}_{ks_param_name}");
+    let benchmark_spec = BenchmarkSpec::<str>::new_shortint(
+        shortint_bench,
+        &ks_param_name,
+        BenchmarkMetric::Latency,
+    );
+    let bench_id = benchmark_spec.to_string();
     bench_group.bench_function(&bench_id, |b| {
         b.iter(|| {
             let _ = ksk.cast(&ct);
         });
     });
 
-    write_to_json_unchecked::<u64, _>(
-        &bench_id,
+    write_to_json::<u64, _, _>(
+        &benchmark_spec,
         ks_param,
-        ks_param_name,
         "cast",
         &OperatorType::Atomic,
         0,

--- a/tfhe-benchmark/src/utilities.rs
+++ b/tfhe-benchmark/src/utilities.rs
@@ -1,4 +1,4 @@
-use benchmark_spec::{BenchmarkSpec, OperandType};
+use benchmark_spec::{BenchmarkSpec, OperandType, TypeName};
 use criterion::Criterion;
 use serde::Serialize;
 use std::path::PathBuf;
@@ -291,8 +291,9 @@ struct BenchmarkParametersRecord<Scalar: UnsignedInteger> {
 pub fn write_to_json<
     Scalar: UnsignedInteger + Serialize,
     T: Into<CryptoParametersRecord<Scalar>>,
+    U: TypeName + ?Sized,
 >(
-    benchmark_spec: &BenchmarkSpec,
+    benchmark_spec: &BenchmarkSpec<U>,
     params: T,
     display_name: impl Into<String>,
     operator_type: &OperatorType,

--- a/utils/benchmark_spec/src/backend.rs
+++ b/utils/benchmark_spec/src/backend.rs
@@ -1,6 +1,6 @@
 use strum::Display;
 
-#[derive(Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, Display)]
 #[strum(serialize_all = "snake_case")]
 pub enum Backend {
     Cpu,

--- a/utils/benchmark_spec/src/bench_crate.rs
+++ b/utils/benchmark_spec/src/bench_crate.rs
@@ -4,7 +4,7 @@ use strum::Display;
 use crate::tfhe::TfheLayer;
 use crate::traits::SpecFmt;
 
-#[derive(Display)]
+#[derive(Debug, Clone, Copy, Display)]
 #[strum(serialize_all = "snake_case")]
 pub enum BenchCrate {
     Tfhe(TfheLayer),

--- a/utils/benchmark_spec/src/lib.rs
+++ b/utils/benchmark_spec/src/lib.rs
@@ -11,10 +11,69 @@ use std::io::Write;
 use std::path::Path;
 use std::{env, fmt};
 pub use tfhe::hlapi::HlapiBench;
-pub use tfhe::{HlIntegerOp, TfheLayer};
+pub use tfhe::{CoreCryptoBench, HlIntegerOp, ShortintBench, TfheLayer};
 
-use crate::tfhe::hlapi::dex::Dex;
-use crate::tfhe::hlapi::erc7984::Erc7984;
+pub trait TypeName {
+    fn type_name(&self) -> String;
+}
+
+#[derive(Debug)]
+pub struct TypedKeyValue<'a> {
+    key: &'a str,
+    value: &'a str,
+}
+
+impl<'a> TypedKeyValue<'a> {
+    pub fn new(key: &'a str, value: &'a str) -> Self {
+        Self { key, value }
+    }
+}
+
+impl TypeName for TypedKeyValue<'_> {
+    fn type_name(&self) -> String {
+        format!("key_{}::value_{}", self.key, self.value)
+    }
+}
+
+impl TypeName for str {
+    fn type_name(&self) -> String {
+        self.to_string()
+    }
+}
+
+#[derive(Debug)]
+pub struct CudaKeyswitchConfig {
+    pub bits: u32,
+    pub uses_gemm: Option<bool>,
+    pub trivial_indices: Option<bool>,
+}
+
+impl CudaKeyswitchConfig {
+    pub fn new(bits: u32, uses_gemm: Option<bool>, trivial_indices: Option<bool>) -> Self {
+        Self {
+            bits,
+            uses_gemm,
+            trivial_indices,
+        }
+    }
+}
+
+impl TypeName for CudaKeyswitchConfig {
+    fn type_name(&self) -> String {
+        let mut name = format!("{}b", self.bits);
+        if let Some(uses_gemm) = self.uses_gemm {
+            name.push_str(if uses_gemm { "::gemm" } else { "::classical" });
+        }
+        if let Some(trivial) = self.trivial_indices {
+            name.push_str(if trivial {
+                "::trivial_indices"
+            } else {
+                "::complex_indices"
+            });
+        }
+        name
+    }
+}
 
 pub struct CsvResultWriter {
     file: File,
@@ -47,7 +106,7 @@ impl CsvResultWriter {
     }
 }
 
-#[derive(Serialize, Clone, Copy)]
+#[derive(Debug, Serialize, Clone, Copy)]
 pub enum OperandType {
     CipherText,
     PlainText,
@@ -63,14 +122,14 @@ impl OperandType {
 ///
 /// Only `Latency` and `Throughput` can come from the environment; `PbsCount`
 /// is hard-coded at specific call sites.
-#[derive(Clone, Copy, Serialize)]
+#[derive(Debug, Clone, Copy, Serialize)]
 pub enum BenchmarkType {
     Latency,
     Throughput,
 }
 
 /// The metric being recorded by a benchmark, used in [`BenchmarkSpec`].
-#[derive(Clone, Copy, Serialize)]
+#[derive(Debug, Clone, Copy, Serialize)]
 pub enum BenchmarkMetric {
     Latency,
     Throughput,
@@ -113,26 +172,27 @@ pub fn get_bench_type() -> &'static BenchmarkType {
 /// {crate}::{layer}::{bench}::{op}(::{backend})?(::{benchmark_type})?::{param}(::scalar)?(::{type})?(::{num_elements}_elements)?
 /// ```
 ///
-/// `param_name` and `type_name` are kept as `&str` because their values
-/// are generated dynamically: `type_name` comes from `stringify!()` in
-/// bench macros, and `param_name` comes from `NamedParam::name()` at runtime.
-pub struct BenchmarkSpec<'a> {
+/// `param_name` is kept as `&str` because it comes from `NamedParam::name()`
+/// at runtime. `type_name` is generic over `T: TypeName` so it can be either
+/// a `&str` (from `stringify!()` in bench macros) or a structured type like
+/// [`TypedKeyValue`].
+pub struct BenchmarkSpec<'a, T: TypeName + ?Sized> {
     pub bench_crate: BenchCrate,
     pub backend: Backend,
     pub param_name: &'a str,
     pub operand_type: OperandType,
-    pub type_name: Option<&'a str>,
+    pub type_name: Option<&'a T>,
     pub bench_type: BenchmarkMetric,
     pub num_elements: Option<usize>,
 }
 
-impl<'a> BenchmarkSpec<'a> {
+impl<'a, T: TypeName + ?Sized> BenchmarkSpec<'a, T> {
     pub fn new(
         bench_crate: BenchCrate,
         backend: Backend,
         param_name: &'a str,
         operand_type: OperandType,
-        type_name: Option<&'a str>,
+        type_name: Option<&'a T>,
         bench_type: impl Into<BenchmarkMetric>,
         num_elements: Option<usize>,
     ) -> Self {
@@ -151,7 +211,7 @@ impl<'a> BenchmarkSpec<'a> {
         hlapi_op: HlIntegerOp,
         param_name: &'a str,
         operand_type: OperandType,
-        type_name: Option<&'a str>,
+        type_name: Option<&'a T>,
         bench_type: impl Into<BenchmarkMetric>,
     ) -> Self {
         Self {
@@ -165,16 +225,16 @@ impl<'a> BenchmarkSpec<'a> {
         }
     }
 
-    pub fn new_hlapi_erc7984(
-        hlapi_erc7984_op: Erc7984,
+    pub fn new_hlapi(
+        hlapi_bench: HlapiBench,
         param_name: &'a str,
         operand_type: OperandType,
-        type_name: Option<&'a str>,
+        type_name: Option<&'a T>,
         bench_type: impl Into<BenchmarkMetric>,
         num_elements: Option<usize>,
     ) -> Self {
         Self {
-            bench_crate: BenchCrate::Tfhe(TfheLayer::Hlapi(HlapiBench::Erc7984(hlapi_erc7984_op))),
+            bench_crate: BenchCrate::Tfhe(TfheLayer::Hlapi(hlapi_bench)),
             backend: bench_backend_from_cfg(),
             param_name,
             operand_type,
@@ -183,27 +243,58 @@ impl<'a> BenchmarkSpec<'a> {
             num_elements,
         }
     }
-    pub fn new_hlapi_dex(
-        hlapi_dex: Dex,
+
+    pub fn new_shortint(
+        shortint_bench: ShortintBench,
         param_name: &'a str,
-        operand_type: OperandType,
-        type_name: Option<&'a str>,
         bench_type: impl Into<BenchmarkMetric>,
-        num_elements: Option<usize>,
     ) -> Self {
         Self {
-            bench_crate: BenchCrate::Tfhe(TfheLayer::Hlapi(HlapiBench::Dex(hlapi_dex))),
+            bench_crate: BenchCrate::Tfhe(TfheLayer::Shortint(shortint_bench)),
             backend: bench_backend_from_cfg(),
             param_name,
-            operand_type,
+            operand_type: OperandType::CipherText,
+            type_name: None,
+            bench_type: bench_type.into(),
+            num_elements: None,
+        }
+    }
+
+    pub fn new_core_crypto(
+        core_crypto_bench: CoreCryptoBench,
+        param_name: &'a str,
+        bench_type: impl Into<BenchmarkMetric>,
+    ) -> Self {
+        Self {
+            bench_crate: BenchCrate::Tfhe(TfheLayer::CoreCrypto(core_crypto_bench)),
+            backend: bench_backend_from_cfg(),
+            param_name,
+            operand_type: OperandType::CipherText,
+            type_name: None,
+            bench_type: bench_type.into(),
+            num_elements: None,
+        }
+    }
+
+    pub fn new_cuda_core_crypto(
+        core_crypto_bench: CoreCryptoBench,
+        param_name: &'a str,
+        type_name: Option<&'a T>,
+        bench_type: impl Into<BenchmarkMetric>,
+    ) -> Self {
+        Self {
+            bench_crate: BenchCrate::Tfhe(TfheLayer::CoreCrypto(core_crypto_bench)),
+            backend: bench_backend_from_cfg(),
+            param_name,
+            operand_type: OperandType::CipherText,
             type_name,
             bench_type: bench_type.into(),
-            num_elements,
+            num_elements: None,
         }
     }
 }
 
-impl fmt::Display for BenchmarkSpec<'_> {
+impl<T: TypeName + ?Sized> fmt::Display for BenchmarkSpec<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.bench_crate.fmt_crate(f)?;
         if !matches!(self.backend, Backend::Cpu) {
@@ -219,7 +310,7 @@ impl fmt::Display for BenchmarkSpec<'_> {
             write!(f, "::scalar")?;
         }
         if let Some(type_name) = self.type_name {
-            write!(f, "::{type_name}")?;
+            write!(f, "::{}", type_name.type_name())?;
         }
         if let Some(num_elements) = self.num_elements {
             write!(f, "::{num_elements}_elements")?;
@@ -230,6 +321,9 @@ impl fmt::Display for BenchmarkSpec<'_> {
 
 #[cfg(test)]
 mod tests {
+    use crate::tfhe::hlapi::dex::Dex;
+    use crate::tfhe::hlapi::erc7984::Erc7984;
+
     use super::*;
 
     #[test]
@@ -298,7 +392,7 @@ mod tests {
 
     #[test]
     fn hlapi_no_type_name() {
-        let spec = BenchmarkSpec::new_hlapi_ops(
+        let spec = BenchmarkSpec::<str>::new_hlapi_ops(
             HlIntegerOp::Neg,
             "PARAM_MESSAGE_2_CARRY_2",
             OperandType::CipherText,
@@ -313,10 +407,10 @@ mod tests {
 
     #[test]
     fn hlapi_erc7984_with_num_elements() {
-        use crate::tfhe::hlapi::erc7984::TransferFlavor;
+        use crate::tfhe::hlapi::erc7984::{Erc7984, TransferFlavor};
 
-        let spec = BenchmarkSpec::new_hlapi_erc7984(
-            Erc7984::Transfer(TransferFlavor::Whitepaper),
+        let spec = BenchmarkSpec::<str>::new_hlapi(
+            HlapiBench::Erc7984(Erc7984::Transfer(TransferFlavor::Whitepaper)),
             "PARAM_MESSAGE_2_CARRY_2",
             OperandType::CipherText,
             None,
@@ -331,10 +425,10 @@ mod tests {
 
     #[test]
     fn hlapi_erc7984_without_num_elements() {
-        use crate::tfhe::hlapi::erc7984::TransferFlavor;
+        use crate::tfhe::hlapi::erc7984::{Erc7984, TransferFlavor};
 
-        let spec = BenchmarkSpec::new_hlapi_erc7984(
-            Erc7984::Transfer(TransferFlavor::NoCmux),
+        let spec = BenchmarkSpec::<str>::new_hlapi(
+            HlapiBench::Erc7984(Erc7984::Transfer(TransferFlavor::NoCmux)),
             "PARAM_MESSAGE_2_CARRY_2",
             OperandType::CipherText,
             None,
@@ -351,7 +445,7 @@ mod tests {
     fn hlapi_erc7984_num_elements_with_backend() {
         use crate::tfhe::hlapi::erc7984::TransferFlavor;
 
-        let spec = BenchmarkSpec::new(
+        let spec = BenchmarkSpec::<str>::new(
             BenchCrate::Tfhe(TfheLayer::Hlapi(HlapiBench::Erc7984(Erc7984::Transfer(
                 TransferFlavor::Overflow,
             )))),
@@ -370,10 +464,10 @@ mod tests {
 
     #[test]
     fn hlapi_erc7984_num_elements_with_throughput() {
-        use crate::tfhe::hlapi::erc7984::TransferFlavor;
+        use crate::tfhe::hlapi::erc7984::{Erc7984, TransferFlavor};
 
-        let spec = BenchmarkSpec::new_hlapi_erc7984(
-            Erc7984::Transfer(TransferFlavor::Safe),
+        let spec = BenchmarkSpec::<str>::new_hlapi(
+            HlapiBench::Erc7984(Erc7984::Transfer(TransferFlavor::Safe)),
             "PARAM_MESSAGE_2_CARRY_2",
             OperandType::CipherText,
             None,
@@ -388,10 +482,10 @@ mod tests {
 
     #[test]
     fn hlapi_erc7984_with_pbs_count() {
-        use crate::tfhe::hlapi::erc7984::TransferFlavor;
+        use crate::tfhe::hlapi::erc7984::{Erc7984, TransferFlavor};
 
-        let spec = BenchmarkSpec::new_hlapi_erc7984(
-            Erc7984::Transfer(TransferFlavor::Safe),
+        let spec = BenchmarkSpec::<str>::new_hlapi(
+            HlapiBench::Erc7984(Erc7984::Transfer(TransferFlavor::Safe)),
             "PARAM_MESSAGE_2_CARRY_2",
             OperandType::CipherText,
             None,
@@ -406,10 +500,10 @@ mod tests {
 
     #[test]
     fn hlapi_dex_swap_request_latency() {
-        use crate::tfhe::hlapi::dex::DexFlavor;
+        use crate::tfhe::hlapi::dex::{Dex, DexFlavor};
 
-        let spec = BenchmarkSpec::new_hlapi_dex(
-            Dex::SwapRequest(DexFlavor::Whitepaper),
+        let spec = BenchmarkSpec::new_hlapi(
+            HlapiBench::Dex(Dex::SwapRequest(DexFlavor::Whitepaper)),
             "PARAM_MESSAGE_2_CARRY_2",
             OperandType::CipherText,
             Some("FheUint64"),
@@ -445,10 +539,10 @@ mod tests {
 
     #[test]
     fn hlapi_dex_with_pbs_count() {
-        use crate::tfhe::hlapi::dex::DexFlavor;
+        use crate::tfhe::hlapi::dex::{Dex, DexFlavor};
 
-        let spec = BenchmarkSpec::new_hlapi_dex(
-            Dex::SwapRequest(DexFlavor::Finalize),
+        let spec = BenchmarkSpec::new_hlapi(
+            HlapiBench::Dex(Dex::SwapRequest(DexFlavor::Finalize)),
             "PARAM_MESSAGE_2_CARRY_2",
             OperandType::CipherText,
             Some("FheUint64"),

--- a/utils/benchmark_spec/src/tfhe/core_crypto/mod.rs
+++ b/utils/benchmark_spec/src/tfhe/core_crypto/mod.rs
@@ -1,0 +1,40 @@
+use std::fmt;
+use strum::Display;
+
+use crate::traits::SpecFmt;
+
+#[derive(Debug, Clone, Copy, Display)]
+#[strum(serialize_all = "snake_case")]
+pub enum CoreCryptoBench {
+    // ks_bench.rs
+    Keyswitch,
+    PackingKeyswitch,
+    ParPackingKeyswitch,
+    // pbs_bench.rs
+    PbsMemOptimized,
+    BatchedPbsMemOptimized,
+    MultiBitPbs,
+    MultiBitDeterministicPbs,
+    PbsNtt,
+    // ks_pbs_bench.rs
+    KsPbs,
+    MultiBitKsPbs,
+    MultiBitDeterministicKsPbs,
+    // pbs128_bench.rs
+    Pbs128,
+    MultiBitPbs128,
+}
+
+impl CoreCryptoBench {
+    fn op(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // All variants are leaf benchmarks — no inner op to format.
+        Ok(())
+    }
+}
+
+impl SpecFmt for CoreCryptoBench {
+    fn fmt_spec(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "::{}", self)?;
+        self.op(f)
+    }
+}

--- a/utils/benchmark_spec/src/tfhe/hl_integer_op.rs
+++ b/utils/benchmark_spec/src/tfhe/hl_integer_op.rs
@@ -1,7 +1,7 @@
 use strum::Display;
 
 /// Atomic operations shared across layers (hlapi, integer...).
-#[derive(Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, Display)]
 #[strum(serialize_all = "snake_case")]
 pub enum HlIntegerOp {
     Add,

--- a/utils/benchmark_spec/src/tfhe/hlapi/dex.rs
+++ b/utils/benchmark_spec/src/tfhe/hlapi/dex.rs
@@ -5,7 +5,7 @@ use strum::Display;
 use crate::traits::SpecFmt;
 
 /// DEX (decentralized exchange) benchmark operations for the HLAPI layer.
-#[derive(Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, Display)]
 #[strum(serialize_all = "snake_case")]
 pub enum Dex {
     SwapRequest(DexFlavor),
@@ -27,7 +27,7 @@ impl SpecFmt for Dex {
     }
 }
 
-#[derive(Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, Display)]
 #[strum(serialize_all = "snake_case")]
 pub enum DexFlavor {
     Whitepaper,

--- a/utils/benchmark_spec/src/tfhe/hlapi/erc7984.rs
+++ b/utils/benchmark_spec/src/tfhe/hlapi/erc7984.rs
@@ -5,7 +5,7 @@ use strum::Display;
 use crate::traits::SpecFmt;
 
 /// ERC-7984 token transfer benchmark operations for the HLAPI layer.
-#[derive(Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, Display)]
 #[strum(serialize_all = "snake_case")]
 pub enum Erc7984 {
     Transfer(TransferFlavor),
@@ -25,7 +25,7 @@ impl SpecFmt for Erc7984 {
     }
 }
 
-#[derive(Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, Display)]
 #[strum(serialize_all = "snake_case")]
 pub enum TransferFlavor {
     Whitepaper,

--- a/utils/benchmark_spec/src/tfhe/hlapi/kv_store.rs
+++ b/utils/benchmark_spec/src/tfhe/hlapi/kv_store.rs
@@ -1,0 +1,13 @@
+use strum::Display;
+
+/// KV store benchmark operations for the HLAPI layer.
+#[derive(Debug, Clone, Copy, Display)]
+#[strum(serialize_all = "snake_case")]
+pub enum KvStoreOp {
+    ContainsKey,
+    ContainsValue,
+    ContainsClearValue,
+    Get,
+    Update,
+    Map,
+}

--- a/utils/benchmark_spec/src/tfhe/hlapi/mod.rs
+++ b/utils/benchmark_spec/src/tfhe/hlapi/mod.rs
@@ -1,8 +1,12 @@
 pub mod dex;
 pub mod erc7984;
+pub mod kv_store;
+pub mod noise_squash;
 
 use dex::Dex;
 use erc7984::Erc7984;
+use kv_store::KvStoreOp;
+use noise_squash::NoiseSquashingKind;
 use std::fmt;
 use strum::Display;
 
@@ -18,12 +22,14 @@ pub use super::hl_integer_op::HlIntegerOp;
 /// 2. Add a match arm in `op()` to return the inner op
 ///
 /// `SpecFmt` is already implemented generically — no change needed there.
-#[derive(Display)]
+#[derive(Debug, Clone, Copy, Display)]
 #[strum(serialize_all = "snake_case")]
 pub enum HlapiBench {
     Ops(HlIntegerOp),
     Erc7984(Erc7984),
     Dex(Dex),
+    KvStore(KvStoreOp),
+    NoiseSquashing(NoiseSquashingKind),
 }
 
 impl HlapiBench {
@@ -32,6 +38,8 @@ impl HlapiBench {
             HlapiBench::Ops(op) => write!(f, "::{op}"),
             HlapiBench::Erc7984(op) => op.fmt_spec(f),
             HlapiBench::Dex(op) => op.fmt_spec(f),
+            HlapiBench::KvStore(op) => write!(f, "::{op}"),
+            HlapiBench::NoiseSquashing(op) => write!(f, "::{op}"),
         }
     }
 }

--- a/utils/benchmark_spec/src/tfhe/hlapi/noise_squash.rs
+++ b/utils/benchmark_spec/src/tfhe/hlapi/noise_squash.rs
@@ -1,0 +1,8 @@
+use strum::Display;
+
+#[derive(Debug, Clone, Copy, Display)]
+#[strum(serialize_all = "snake_case")]
+pub enum NoiseSquashingKind {
+    NoiseSquash,
+    DecompNoiseSquashComp,
+}

--- a/utils/benchmark_spec/src/tfhe/mod.rs
+++ b/utils/benchmark_spec/src/tfhe/mod.rs
@@ -1,13 +1,17 @@
+pub mod core_crypto;
 pub mod hl_integer_op;
 pub mod hlapi;
+pub mod shortint;
 
 use std::fmt;
 use strum::Display;
 
 use crate::traits::SpecFmt;
 
+pub use core_crypto::CoreCryptoBench;
 pub use hl_integer_op::HlIntegerOp;
 pub use hlapi::HlapiBench;
+pub use shortint::ShortintBench;
 
 /// Layers of the `tfhe` crate.
 ///
@@ -16,16 +20,20 @@ pub use hlapi::HlapiBench;
 /// 2. Add a match arm in `bench()` — the inner type must implement `SpecFmt`
 ///
 /// `SpecFmt` is already implemented generically — no change needed there.
-#[derive(Display)]
+#[derive(Debug, Clone, Copy, Display)]
 #[strum(serialize_all = "snake_case")]
 pub enum TfheLayer {
+    CoreCrypto(CoreCryptoBench),
     Hlapi(HlapiBench),
+    Shortint(ShortintBench),
 }
 
 impl TfheLayer {
     fn bench(&self) -> &dyn SpecFmt {
         match self {
+            TfheLayer::CoreCrypto(bench) => bench,
             TfheLayer::Hlapi(bench) => bench,
+            TfheLayer::Shortint(bench) => bench,
         }
     }
 }

--- a/utils/benchmark_spec/src/tfhe/shortint/mod.rs
+++ b/utils/benchmark_spec/src/tfhe/shortint/mod.rs
@@ -1,0 +1,84 @@
+use std::fmt;
+use strum::Display;
+
+use crate::traits::SpecFmt;
+
+#[derive(Debug, Clone, Copy, Display)]
+#[strum(serialize_all = "snake_case")]
+pub enum ShortintBench {
+    // Unary ops
+    UncheckedNeg,
+    Neg,
+    // Binary ops
+    UncheckedAdd,
+    UncheckedSub,
+    UncheckedMulLsb,
+    UncheckedMulMsb,
+    UncheckedDiv,
+    SmartBitand,
+    SmartBitor,
+    SmartBitxor,
+    SmartAdd,
+    SmartSub,
+    SmartMulLsb,
+    Bitand,
+    Bitor,
+    Bitxor,
+    Add,
+    Sub,
+    Mul,
+    Div,
+    Greater,
+    GreaterOrEqual,
+    Less,
+    LessOrEqual,
+    Equal,
+    NotEqual,
+    UncheckedGreater,
+    UncheckedLess,
+    UncheckedEqual,
+    // Scalar ops
+    UncheckedScalarAdd,
+    UncheckedScalarSub,
+    UncheckedScalarMul,
+    UncheckedScalarLeftShift,
+    UncheckedScalarRightShift,
+    UncheckedScalarDiv,
+    UncheckedScalarMod,
+    ScalarAdd,
+    ScalarSub,
+    ScalarMul,
+    ScalarLeftShift,
+    ScalarRightShift,
+    ScalarDiv,
+    ScalarMod,
+    ScalarGreater,
+    ScalarGreaterOrEqual,
+    ScalarLess,
+    ScalarLessOrEqual,
+    ScalarEqual,
+    ScalarNotEqual,
+    // Special ops
+    CarryExtract,
+    ProgrammableBootstrap,
+    UncompressKey,
+    DecompNoiseSquashComp,
+    // Casting ops
+    Cast,
+    PackCast,
+    PackCast64,
+}
+
+impl ShortintBench {
+    fn op(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // All variants are leaf benchmarks — no inner op to format.
+        Ok(())
+    }
+}
+
+impl SpecFmt for ShortintBench {
+    fn fmt_spec(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "::{}", self)?;
+        self.op(f)
+    }
+}


### PR DESCRIPTION
Update of the bench spec to use TypeName which enforce the type_name field and enforce some strong typing
This lead to a general update with one extra generic type for write to json

Spec was applied to last files in hlapi
and now in shortint and core crypto

AI was used to help for some copy/paste stuff like new generic args or update from unchecked to checked write to json function
Also a prompt was used to ask an update of the doc comment / comment 

I highly recommend to focus first on the benchmark_spec files first before looking into the code change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3523)
<!-- Reviewable:end -->
