### PR TITLE
chore(ci): add a check for the local versioning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1447,7 +1447,7 @@ lint_docs: lint_doc
 
 .PHONY: format_doc_latex # Format the documentation latex equations to avoid broken rendering.
 format_doc_latex:
-	RUSTFLAGS="" cargo xtask format_latex_doc
+	RUSTFLAGS="" cargo xtask format-latex-doc
 	@"$(MAKE)" --no-print-directory fmt
 	@printf "\n===============================\n\n"
 	@printf "Please manually inspect changes made by format_latex_doc, rustfmt can break equations \
@@ -1456,7 +1456,11 @@ format_doc_latex:
 
 .PHONY: check_md_docs_are_tested # Checks that the rust codeblocks in our .md files are tested
 check_md_docs_are_tested:
-	RUSTFLAGS="" cargo xtask check_tfhe_docs_are_tested
+	RUSTFLAGS="" cargo xtask check-tfhe-docs-are-tested
+
+.PHONY: check_local_workspace_version # Checks that local workspace dependency versions are consistent
+check_local_workspace_version:
+	RUSTFLAGS="" cargo xtask check-local-workspace-version
 
 .PHONY: check_intra_md_links # Checks broken internal links in Markdown docs
 check_intra_md_links: install_mlc
@@ -2339,6 +2343,7 @@ pcc_batch_1:
 	$(call run_recipe_with_details,check_typos)
 	$(call run_recipe_with_details,lint_doc)
 	$(call run_recipe_with_details,check_md_docs_are_tested)
+	$(call run_recipe_with_details,check_local_workspace_version)
 	$(call run_recipe_with_details,check_intra_md_links)
 	$(call run_recipe_with_details,check_doc_paths_use_dash)
 	$(call run_recipe_with_details,test_tfhe_lints)
@@ -2419,6 +2424,7 @@ fpcc:
 	$(call run_recipe_with_details,check_typos)
 	$(call run_recipe_with_details,lint_doc)
 	$(call run_recipe_with_details,check_md_docs_are_tested)
+	$(call run_recipe_with_details,check_local_workspace_version)
 	$(call run_recipe_with_details,check_intra_md_links)
 	$(call run_recipe_with_details,check_doc_paths_use_dash)
 	$(call run_recipe_with_details,check_main_readme_links)

--- a/apps/test-vectors/Cargo.toml
+++ b/apps/test-vectors/Cargo.toml
@@ -3,6 +3,7 @@ name = "tfhe-test-vectors"
 version = "0.2.0"
 edition = "2024"
 rust-version.workspace = true
+publish = false
 
 [dependencies]
 ciborium = "0.2"

--- a/mockups/tfhe-hpu-mockup/Cargo.toml
+++ b/mockups/tfhe-hpu-mockup/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Zama Hardware team"]
 license = "BSD-3-Clause-Clear"
 description = "Simulation model of HPU hardware."
 readme = "README.md"
+publish = false
 
 [features]
 default = []

--- a/tasks/Cargo.toml
+++ b/tasks/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
 name = "tasks"
 version = "0.0.0"
-edition = "2021"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = "=4.5.30"
+clap = { version = "=4.5.30", features = ["derive"] }
 log = "0.4"
 simplelog = "0.12"
 walkdir = "2.5.0"
 no-comment = "0.0.3"
+cargo_metadata = "0.23.1"

--- a/tasks/src/check_local_workspace_version.rs
+++ b/tasks/src/check_local_workspace_version.rs
@@ -1,0 +1,224 @@
+use std::collections::{HashMap, HashSet};
+use std::fmt::Display;
+
+use cargo_metadata::MetadataCommand;
+use cargo_metadata::semver::{Comparator, Op, Version, VersionReq};
+
+#[derive(Debug, Clone)]
+struct WorkspaceData {
+    version: Version,
+    is_publishable: bool,
+}
+
+impl WorkspaceData {
+    fn from_package(pkg: &cargo_metadata::Package) -> Self {
+        let is_publishable = match &pkg.publish {
+            Some(publish) => !publish.is_empty(),
+            None => true,
+        };
+        WorkspaceData {
+            version: pkg.version.clone(),
+            is_publishable,
+        }
+    }
+}
+
+struct LocalWorkspaceDependencyRequirement {
+    pkg_name: String,
+    dep_name: String,
+    dep_req: VersionReq,
+    ws_version: Version,
+}
+
+impl Display for LocalWorkspaceDependencyRequirement {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{} depends on {} {} but workspace has {}",
+            self.pkg_name, self.dep_name, self.dep_req, self.ws_version
+        )
+    }
+}
+
+fn caret_req(v: &Version) -> VersionReq {
+    VersionReq {
+        comparators: vec![Comparator {
+            op: Op::Caret,
+            major: v.major,
+            minor: Some(v.minor),
+            patch: Some(v.patch),
+            pre: v.pre.clone(),
+        }],
+    }
+}
+
+#[derive(Debug, PartialEq)]
+enum DepStatus {
+    /// Version requirement matches the workspace version.
+    Ok,
+    /// Version requirement doesn't match the workspace version.
+    Outdated,
+    /// Dep uses `*` — acceptable, but the parent crate must not be publishable.
+    Star,
+}
+
+/// Check whether a local dependency requirement is acceptable.
+/// Local deps must either use `*` or pin the exact workspace version.
+fn check_dep_status(dep_req: &VersionReq, ws_version: &Version) -> DepStatus {
+    if *dep_req == VersionReq::STAR {
+        return DepStatus::Star;
+    }
+    let expected = caret_req(ws_version);
+    if *dep_req == expected {
+        DepStatus::Ok
+    } else {
+        DepStatus::Outdated
+    }
+}
+
+pub fn check_local_workspace_version() {
+    let metadata = MetadataCommand::new().exec().unwrap();
+
+    let workspace_versions: HashMap<&str, WorkspaceData> = metadata
+        .workspace_packages()
+        .iter()
+        .map(|p| (p.name.as_str(), WorkspaceData::from_package(p)))
+        .collect();
+
+    let mut publishable_with_star: HashSet<String> = HashSet::new();
+    let mut outdateds: Vec<LocalWorkspaceDependencyRequirement> = Vec::new();
+
+    for pkg in metadata.workspace_packages() {
+        let pkg_ws = workspace_versions.get(pkg.name.as_str());
+        let pkg_is_publishable = pkg_ws.is_some_and(|ws| ws.is_publishable);
+
+        for dep in &pkg.dependencies {
+            if dep.source.is_none()
+                && let Some(ws) = workspace_versions.get(dep.name.as_str())
+            {
+                match check_dep_status(&dep.req, &ws.version) {
+                    DepStatus::Ok => {}
+                    DepStatus::Outdated => {
+                        outdateds.push(LocalWorkspaceDependencyRequirement {
+                            pkg_name: pkg.name.to_string(),
+                            dep_name: dep.name.to_string(),
+                            dep_req: dep.req.clone(),
+                            ws_version: ws.version.clone(),
+                        });
+                    }
+                    DepStatus::Star if pkg_is_publishable => {
+                        publishable_with_star.insert(pkg.name.to_string());
+                    }
+                    DepStatus::Star => {}
+                }
+            }
+        }
+    }
+
+    let missing_publish_info: Vec<_> = publishable_with_star.into_iter().collect();
+
+    print_results(&missing_publish_info, &outdateds);
+}
+
+fn print_results(
+    missing_publish_info: &[String],
+    outdateds: &[LocalWorkspaceDependencyRequirement],
+) {
+    if !missing_publish_info.is_empty() {
+        eprintln!("❌ Crates missing publish information:\n");
+        eprintln!(
+            "The following crate(s) have local dependencies with `*` version requirement, \
+            but are publishable. Please either pin the dependency to the exact workspace \
+            version or add `publish = false` to the crate's manifest."
+        );
+        for missing in missing_publish_info {
+            eprintln!("\t{missing}");
+        }
+        eprintln!("\n{} issue(s) to fix.\n", missing_publish_info.len());
+    }
+
+    if outdateds.is_empty() {
+        println!("✅ All local workspace dependencies are up to date.");
+    } else {
+        eprintln!("❌ Outdated local dependencies found:\n");
+        for outdated in outdateds {
+            eprintln!("\t{outdated}");
+        }
+        eprintln!("\n{} issue(s) to fix.", outdateds.len());
+        eprintln!(
+            "Note: tfhe-rs enforces stricter rules than semver for internal workspace \
+            dependencies, the version requirement must match the workspace version exactly. \
+            A requirement like `^0.7.0` may satisfy semver for a workspace at `0.7.1`, \
+            but we still require it to be updated to `0.7.1` so all internal deps stay in sync."
+        );
+    }
+
+    if !missing_publish_info.is_empty() || !outdateds.is_empty() {
+        std::process::exit(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- check_dep_status ----
+
+    #[test]
+    fn matching_version_is_ok() {
+        let req: VersionReq = "^0.7.0".parse().unwrap();
+        assert_eq!(
+            check_dep_status(&req, &Version::new(0, 7, 0)),
+            DepStatus::Ok
+        );
+    }
+
+    #[test]
+    fn version_behind_workspace_is_outdated() {
+        let req: VersionReq = "^0.6.0".parse().unwrap();
+        assert_eq!(
+            check_dep_status(&req, &Version::new(0, 7, 0)),
+            DepStatus::Outdated
+        );
+    }
+
+    #[test]
+    fn version_ahead_of_workspace_is_outdated() {
+        let req: VersionReq = "^0.8.0".parse().unwrap();
+        assert_eq!(
+            check_dep_status(&req, &Version::new(0, 7, 0)),
+            DepStatus::Outdated
+        );
+    }
+
+    #[test]
+    fn patch_mismatch_is_outdated() {
+        let req: VersionReq = "^1.2.3".parse().unwrap();
+        assert_eq!(
+            check_dep_status(&req, &Version::new(1, 2, 4)),
+            DepStatus::Outdated
+        );
+    }
+
+    #[test]
+    fn range_requirement_is_always_outdated() {
+        let req: VersionReq = ">=1.0.0, <2.0.0".parse().unwrap();
+        assert_eq!(
+            check_dep_status(&req, &Version::new(5, 0, 0)),
+            DepStatus::Outdated
+        );
+        assert_eq!(
+            check_dep_status(&req, &Version::new(1, 5, 0)),
+            DepStatus::Outdated
+        );
+    }
+
+    #[test]
+    fn star_returns_star_status() {
+        let req = VersionReq::STAR;
+        assert_eq!(
+            check_dep_status(&req, &Version::new(1, 0, 0)),
+            DepStatus::Star
+        );
+    }
+}

--- a/tasks/src/check_tfhe_docs_are_tested.rs
+++ b/tasks/src/check_tfhe_docs_are_tested.rs
@@ -1,4 +1,4 @@
-use no_comment::{languages, IntoWithoutComments};
+use no_comment::{IntoWithoutComments, languages};
 use std::collections::HashSet;
 use std::io::{Error, ErrorKind};
 use std::path::Path;

--- a/tasks/src/format_latex_doc.rs
+++ b/tasks/src/format_latex_doc.rs
@@ -10,10 +10,10 @@ fn recurse_find_rs_files(
     for curr_entry in root_dir.read_dir().unwrap() {
         let curr_path = curr_entry.unwrap().path().canonicalize().unwrap();
         if curr_path.is_file() {
-            if let Some(extension) = curr_path.extension() {
-                if extension == "rs" {
-                    rs_files.push(curr_path);
-                }
+            if let Some(extension) = curr_path.extension()
+                && extension == "rs"
+            {
+                rs_files.push(curr_path);
             }
         } else if curr_path.is_dir() {
             if at_root {

--- a/tasks/src/main.rs
+++ b/tasks/src/main.rs
@@ -1,9 +1,10 @@
-use clap::{Arg, Command};
+use clap::{Parser, Subcommand};
 use log::LevelFilter;
 use simplelog::{ColorChoice, CombinedLogger, Config, TermLogger, TerminalMode};
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering::Relaxed;
 
+mod check_local_workspace_version;
 mod check_tfhe_docs_are_tested;
 mod format_latex_doc;
 mod utils;
@@ -15,41 +16,46 @@ mod utils;
 static DRY_RUN: AtomicBool = AtomicBool::new(false);
 
 // -------------------------------------------------------------------------------------------------
+// CLI
+// -------------------------------------------------------------------------------------------------
+
+#[derive(Parser)]
+#[command(about = "Rust scripts runner", arg_required_else_help = true)]
+struct Cli {
+    #[arg(short, long, help = "Prints debug messages")]
+    verbose: bool,
+
+    #[arg(long, help = "Do not execute the commands")]
+    dry_run: bool,
+
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Escape underscores in latex equations
+    FormatLatexDoc,
+    /// Check that doc files with rust code blocks are tested
+    CheckTfheDocsAreTested,
+    /// Check that local workspace dependency versions are consistent
+    CheckLocalWorkspaceVersion,
+}
+
+// -------------------------------------------------------------------------------------------------
 // MAIN
 // -------------------------------------------------------------------------------------------------
 
-const FORMAT_LATEX_DOC: &str = "format_latext_doc";
-const CHECK_TFHE_DOCS_ARE_TESTED: &str = "check_tfhe_docs_are_tested";
-
 fn main() -> Result<(), std::io::Error> {
-    // We parse the input args
-    let matches = Command::new("tasks")
-        .about("Rust scripts runner")
-        .arg(
-            Arg::new("verbose")
-                .short('v')
-                .long("verbose")
-                .help("Prints debug messages"),
-        )
-        .arg(
-            Arg::new("dry-run")
-                .long("dry-run")
-                .help("Do not execute the commands"),
-        )
-        .subcommand(Command::new(FORMAT_LATEX_DOC).about("Escape underscores in latex equations"))
-        .subcommand(
-            Command::new(CHECK_TFHE_DOCS_ARE_TESTED)
-                .about("Check that doc files with rust code blocks are tested"),
-        )
-        .arg_required_else_help(true)
-        .get_matches();
+    let cli = Cli::parse();
 
     // We initialize the logger with proper verbosity
-    let verb = if matches.contains_id("verbose") {
+    let verb = if cli.verbose {
         LevelFilter::Debug
     } else {
         LevelFilter::Info
     };
+
     CombinedLogger::init(vec![TermLogger::new(
         verb,
         Config::default(),
@@ -59,17 +65,18 @@ fn main() -> Result<(), std::io::Error> {
     .unwrap();
 
     // We set the dry-run mode if present
-    if matches.contains_id("dry-run") {
+    if cli.dry_run {
         DRY_RUN.store(true, Relaxed);
     }
 
-    if matches.subcommand_matches(FORMAT_LATEX_DOC).is_some() {
-        format_latex_doc::escape_underscore_in_latex_doc()?;
-    } else if matches
-        .subcommand_matches(CHECK_TFHE_DOCS_ARE_TESTED)
-        .is_some()
-    {
-        check_tfhe_docs_are_tested::check_tfhe_docs_are_tested()?;
+    match cli.command {
+        Commands::FormatLatexDoc => format_latex_doc::escape_underscore_in_latex_doc()?,
+        Commands::CheckTfheDocsAreTested => {
+            check_tfhe_docs_are_tested::check_tfhe_docs_are_tested()?
+        }
+        Commands::CheckLocalWorkspaceVersion => {
+            check_local_workspace_version::check_local_workspace_version()
+        }
     }
 
     Ok(())

--- a/tfhe/Cargo.toml
+++ b/tfhe/Cargo.toml
@@ -99,7 +99,7 @@ serde-wasm-bindgen = { workspace = true, optional = true }
 getrandom = { workspace = true, optional = true }
 bytemuck = { workspace = true }
 
-tfhe-hpu-backend = { version = "0.5", path = "../backends/tfhe-hpu-backend", optional = true }
+tfhe-hpu-backend = { version = "0.5.0", path = "../backends/tfhe-hpu-backend", optional = true }
 
 [features]
 default = ["avx512"]

--- a/utils/wasm-par-mq/examples/msm/Cargo.toml
+++ b/utils/wasm-par-mq/examples/msm/Cargo.toml
@@ -3,6 +3,7 @@ name = "wasm-par-mq-example-msm"
 version = "0.1.0"
 edition = "2024"
 rust-version.workspace = true
+publish = false
 
 [lib]
 crate-type = ["cdylib"]

--- a/utils/wasm-par-mq/web_tests/Cargo.toml
+++ b/utils/wasm-par-mq/web_tests/Cargo.toml
@@ -3,6 +3,7 @@ name = "wasm-par-mq-web-tests"
 version = "0.1.0"
 edition = "2024"
 rust-version.workspace = true
+publish = false
 
 [lib]
 crate-type = ["cdylib"]


### PR DESCRIPTION
Add the local versioning check
bump the rust version of the task crate from 2021 to 2024
also update the main.rs file of task to make it easier to read

Following the check some error came out, I also fixed it

test was generated by AI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3526)
<!-- Reviewable:end -->
