### PR TITLE
chore(c,js)!: remove non-safe serialization primitives

### DIFF
--- a/tfhe/c_api_tests/test_high_level_integers.c
+++ b/tfhe/c_api_tests/test_high_level_integers.c
@@ -382,12 +382,12 @@ int uint8_safe_serialization(const ClientKey *client_key, const ServerKey *serve
 
   uint8_t lhs_clear = 123;
 
-  ok = client_key_serialize(client_key, &cks_buffer);
+  ok = client_key_safe_serialize(client_key, &cks_buffer, max_serialization_size);
   assert(ok == 0);
 
   deser_view.pointer = cks_buffer.pointer;
   deser_view.length = cks_buffer.length;
-  ok = client_key_deserialize(deser_view, &deserialized_client_key);
+  ok = client_key_safe_deserialize(deser_view, max_serialization_size, &deserialized_client_key);
   assert(ok == 0);
 
   ok = fhe_uint8_try_encrypt_with_client_key_u8(lhs_clear, client_key, &lhs);
@@ -400,50 +400,6 @@ int uint8_safe_serialization(const ClientKey *client_key, const ServerKey *serve
   deser_view.length = value_buffer.length;
   ok = fhe_uint8_safe_deserialize_conformant(deser_view, max_serialization_size, server_key,
                                              &deserialized_lhs);
-  assert(ok == 0);
-
-  uint8_t clear;
-  ok = fhe_uint8_decrypt(deserialized_lhs, deserialized_client_key, &clear);
-  assert(ok == 0);
-
-  assert(clear == lhs_clear);
-
-  if (value_buffer.pointer != NULL) {
-    destroy_dynamic_buffer(&value_buffer);
-  }
-  fhe_uint8_destroy(lhs);
-  fhe_uint8_destroy(deserialized_lhs);
-  return ok;
-}
-
-int uint8_serialization(const ClientKey *client_key) {
-  int ok;
-  FheUint8 *lhs = NULL;
-  FheUint8 *deserialized_lhs = NULL;
-  DynamicBuffer value_buffer = {.pointer = NULL, .length = 0, .destructor = NULL};
-  DynamicBuffer cks_buffer = {.pointer = NULL, .length = 0, .destructor = NULL};
-  DynamicBufferView deser_view = {.pointer = NULL, .length = 0};
-  ClientKey *deserialized_client_key = NULL;
-
-  uint8_t lhs_clear = 123;
-
-  ok = client_key_serialize(client_key, &cks_buffer);
-  assert(ok == 0);
-
-  deser_view.pointer = cks_buffer.pointer;
-  deser_view.length = cks_buffer.length;
-  ok = client_key_deserialize(deser_view, &deserialized_client_key);
-  assert(ok == 0);
-
-  ok = fhe_uint8_try_encrypt_with_client_key_u8(lhs_clear, deserialized_client_key, &lhs);
-  assert(ok == 0);
-
-  ok = fhe_uint8_serialize(lhs, &value_buffer);
-  assert(ok == 0);
-
-  deser_view.pointer = value_buffer.pointer;
-  deser_view.length = value_buffer.length;
-  ok = fhe_uint8_deserialize(deser_view, &deserialized_lhs);
   assert(ok == 0);
 
   uint8_t clear;
@@ -605,8 +561,6 @@ int main(void) {
     ok = generate_keys(config, &client_key, &server_key);
     assert(ok == 0);
     ok = public_key_new(client_key, &public_key);
-    assert(ok == 0);
-    ok = uint8_serialization(client_key);
     assert(ok == 0);
     ok = uint8_safe_serialization(client_key, server_key);
     assert(ok == 0);

--- a/tfhe/js_on_wasm_tests/test-hlapi-signed.js
+++ b/tfhe/js_on_wasm_tests/test-hlapi-signed.js
@@ -39,6 +39,8 @@ const I256_MAX = BigInt(
 const I128_MIN = BigInt("-170141183460469231731687303715884105728");
 const I32_MIN = -2147483648;
 
+const SAFE_SERIALIZATION_SIZE_LIMIT = BigInt(10000000);
+
 // This is useful to debug test
 init_panic_hook();
 
@@ -52,18 +54,13 @@ test("hlapi_client_key_encrypt_decrypt_int8_big", (t) => {
   let decrypted = encrypted.decrypt(clientKey);
   assert.deepStrictEqual(decrypted, clear);
 
-  let serialized = encrypted.serialize();
-  let deserialized = FheInt8.deserialize(serialized);
+  let serialized = encrypted.safe_serialize(SAFE_SERIALIZATION_SIZE_LIMIT);
+  let deserialized = FheInt8.safe_deserialize(
+    serialized,
+    SAFE_SERIALIZATION_SIZE_LIMIT,
+  );
   let deserialized_decrypted = deserialized.decrypt(clientKey);
   assert.deepStrictEqual(deserialized_decrypted, clear);
-
-  let safe_serialized = encrypted.safe_serialize(BigInt(10000000));
-  let safe_deserialized = FheInt8.safe_deserialize(
-    safe_serialized,
-    BigInt(10000000),
-  );
-  let safe_deserialized_decrypted = safe_deserialized.decrypt(clientKey);
-  assert.deepStrictEqual(safe_deserialized_decrypted, clear);
 });
 
 test("hlapi_compressed_public_client_int8_big", (t) => {
@@ -76,26 +73,17 @@ test("hlapi_compressed_public_client_int8_big", (t) => {
     clear,
     clientKey,
   );
-  let compressed_serialized = compressed_encrypted.serialize();
-  let compressed_deserialized = CompressedFheInt8.deserialize(
+  let compressed_serialized = compressed_encrypted.safe_serialize(
+    SAFE_SERIALIZATION_SIZE_LIMIT,
+  );
+  let compressed_deserialized = CompressedFheInt8.safe_deserialize(
     compressed_serialized,
+    SAFE_SERIALIZATION_SIZE_LIMIT,
   );
   let decompressed = compressed_deserialized.decompress();
 
   let decrypted = decompressed.decrypt(clientKey);
   assert.deepStrictEqual(decrypted, clear);
-
-  let compressed_safe_serialized = compressed_encrypted.safe_serialize(
-    BigInt(10000000),
-  );
-  let compressed_safe_deserialized = CompressedFheInt8.safe_deserialize(
-    compressed_safe_serialized,
-    BigInt(10000000),
-  );
-  let safe_decompressed = compressed_safe_deserialized.decompress();
-
-  let safe_decrypted = safe_decompressed.decrypt(clientKey);
-  assert.deepStrictEqual(safe_decrypted, clear);
 });
 
 test("hlapi_public_key_encrypt_decrypt_int32_small", (t) => {
@@ -111,18 +99,13 @@ test("hlapi_public_key_encrypt_decrypt_int32_small", (t) => {
   let decrypted = encrypted.decrypt(clientKey);
   assert.deepStrictEqual(decrypted, I32_MIN);
 
-  let serialized = encrypted.serialize();
-  let deserialized = FheInt32.deserialize(serialized);
+  let serialized = encrypted.safe_serialize(SAFE_SERIALIZATION_SIZE_LIMIT);
+  let deserialized = FheInt32.safe_deserialize(
+    serialized,
+    SAFE_SERIALIZATION_SIZE_LIMIT,
+  );
   let deserialized_decrypted = deserialized.decrypt(clientKey);
   assert.deepStrictEqual(deserialized_decrypted, I32_MIN);
-
-  let safe_serialized = encrypted.safe_serialize(BigInt(1000000));
-  let safe_deserialized = FheInt32.safe_deserialize(
-    safe_serialized,
-    BigInt(1000000),
-  );
-  let safe_deserialized_decrypted = safe_deserialized.decrypt(clientKey);
-  assert.deepStrictEqual(safe_deserialized_decrypted, I32_MIN);
 });
 
 test("hlapi_decompress_public_key_then_encrypt_decrypt_int32_small", (t) => {
@@ -136,7 +119,7 @@ test("hlapi_decompress_public_key_then_encrypt_decrypt_int32_small", (t) => {
   let compressedPublicKey = TfheCompressedPublicKey.new(clientKey);
   var endTime = performance.now();
 
-  let data = compressedPublicKey.serialize();
+  let data = compressedPublicKey.safe_serialize(SAFE_SERIALIZATION_SIZE_LIMIT);
 
   let publicKey = compressedPublicKey.decompress();
 
@@ -144,22 +127,16 @@ test("hlapi_decompress_public_key_then_encrypt_decrypt_int32_small", (t) => {
   let encrypted = FheInt32.encrypt_with_public_key(I32_MIN, publicKey);
   var endTime = performance.now();
 
-  let ser = encrypted.serialize();
   let decrypted = encrypted.decrypt(clientKey);
   assert.deepStrictEqual(decrypted, I32_MIN);
 
-  let serialized = encrypted.serialize();
-  let deserialized = FheInt32.deserialize(serialized);
+  let serialized = encrypted.safe_serialize(SAFE_SERIALIZATION_SIZE_LIMIT);
+  let deserialized = FheInt32.safe_deserialize(
+    serialized,
+    SAFE_SERIALIZATION_SIZE_LIMIT,
+  );
   let deserialized_decrypted = deserialized.decrypt(clientKey);
   assert.deepStrictEqual(deserialized_decrypted, I32_MIN);
-
-  let safe_serialized = encrypted.safe_serialize(BigInt(10000000));
-  let safe_deserialized = FheInt32.safe_deserialize(
-    safe_serialized,
-    BigInt(10000000),
-  );
-  let safe_deserialized_decrypted = safe_deserialized.decrypt(clientKey);
-  assert.deepStrictEqual(safe_deserialized_decrypted, I32_MIN);
 });
 
 test("hlapi_client_key_encrypt_decrypt_int128_big", (t) => {
@@ -171,44 +148,30 @@ test("hlapi_client_key_encrypt_decrypt_int128_big", (t) => {
   let decrypted = encrypted.decrypt(clientKey);
   assert.deepStrictEqual(decrypted, I128_MIN);
 
-  let serialized = encrypted.serialize();
-  let deserialized = FheInt128.deserialize(serialized);
+  let serialized = encrypted.safe_serialize(SAFE_SERIALIZATION_SIZE_LIMIT);
+  let deserialized = FheInt128.safe_deserialize(
+    serialized,
+    SAFE_SERIALIZATION_SIZE_LIMIT,
+  );
   let deserialized_decrypted = deserialized.decrypt(clientKey);
   assert.deepStrictEqual(deserialized_decrypted, I128_MIN);
-
-  let safe_serialized = encrypted.safe_serialize(BigInt(10000000));
-  let safe_deserialized = FheInt128.safe_deserialize(
-    safe_serialized,
-    BigInt(10000000),
-  );
-  let safe_deserialized_decrypted = safe_deserialized.decrypt(clientKey);
-  assert.deepStrictEqual(safe_deserialized_decrypted, I128_MIN);
 
   // Compressed
   let compressed_encrypted = CompressedFheInt128.encrypt_with_client_key(
     I128_MIN,
     clientKey,
   );
-  let compressed_serialized = compressed_encrypted.serialize();
-  let compressed_deserialized = CompressedFheInt128.deserialize(
+  let compressed_serialized = compressed_encrypted.safe_serialize(
+    SAFE_SERIALIZATION_SIZE_LIMIT,
+  );
+  let compressed_deserialized = CompressedFheInt128.safe_deserialize(
     compressed_serialized,
+    SAFE_SERIALIZATION_SIZE_LIMIT,
   );
   let decompressed = compressed_deserialized.decompress();
 
   decrypted = decompressed.decrypt(clientKey);
   assert.deepStrictEqual(decrypted, I128_MIN);
-
-  let compressed_safe_serialized = compressed_encrypted.safe_serialize(
-    BigInt(10000000),
-  );
-  let compressed_safe_deserialized = CompressedFheInt128.safe_deserialize(
-    compressed_safe_serialized,
-    BigInt(10000000),
-  );
-  let safe_decompressed = compressed_safe_deserialized.decompress();
-
-  safe_decrypted = safe_decompressed.decrypt(clientKey);
-  assert.deepStrictEqual(safe_decrypted, I128_MIN);
 });
 
 test("hlapi_client_key_encrypt_decrypt_int128_small", (t) => {
@@ -223,44 +186,30 @@ test("hlapi_client_key_encrypt_decrypt_int128_small", (t) => {
   let decrypted = encrypted.decrypt(clientKey);
   assert.deepStrictEqual(decrypted, I128_MIN);
 
-  let serialized = encrypted.serialize();
-  let deserialized = FheInt128.deserialize(serialized);
+  let serialized = encrypted.safe_serialize(SAFE_SERIALIZATION_SIZE_LIMIT);
+  let deserialized = FheInt128.safe_deserialize(
+    serialized,
+    SAFE_SERIALIZATION_SIZE_LIMIT,
+  );
   let deserialized_decrypted = deserialized.decrypt(clientKey);
   assert.deepStrictEqual(deserialized_decrypted, I128_MIN);
-
-  let safe_serialized = encrypted.safe_serialize(BigInt(10000000));
-  let safe_deserialized = FheInt128.safe_deserialize(
-    safe_serialized,
-    BigInt(10000000),
-  );
-  let safe_deserialized_decrypted = safe_deserialized.decrypt(clientKey);
-  assert.deepStrictEqual(safe_deserialized_decrypted, I128_MIN);
 
   // Compressed
   let compressed_encrypted = CompressedFheInt128.encrypt_with_client_key(
     I128_MIN,
     clientKey,
   );
-  let compressed_serialized = compressed_encrypted.serialize();
-  let compressed_deserialized = CompressedFheInt128.deserialize(
+  let compressed_serialized = compressed_encrypted.safe_serialize(
+    SAFE_SERIALIZATION_SIZE_LIMIT,
+  );
+  let compressed_deserialized = CompressedFheInt128.safe_deserialize(
     compressed_serialized,
+    SAFE_SERIALIZATION_SIZE_LIMIT,
   );
   let decompressed = compressed_deserialized.decompress();
 
   decrypted = decompressed.decrypt(clientKey);
   assert.deepStrictEqual(decrypted, I128_MIN);
-
-  let compressed_safe_serialized = compressed_encrypted.safe_serialize(
-    BigInt(10000000),
-  );
-  let compressed_safe_deserialized = CompressedFheInt128.safe_deserialize(
-    compressed_safe_serialized,
-    BigInt(10000000),
-  );
-  let safe_decompressed = compressed_safe_deserialized.decompress();
-
-  safe_decrypted = safe_decompressed.decrypt(clientKey);
-  assert.deepStrictEqual(safe_decrypted, I128_MIN);
 });
 
 test("hlapi_client_key_encrypt_decrypt_int256_big", (t) => {
@@ -273,44 +222,30 @@ test("hlapi_client_key_encrypt_decrypt_int256_big", (t) => {
     let decrypted = encrypted.decrypt(clientKey);
     assert.deepStrictEqual(decrypted, value);
 
-    let serialized = encrypted.serialize();
-    let deserialized = FheInt256.deserialize(serialized);
+    let serialized = encrypted.safe_serialize(SAFE_SERIALIZATION_SIZE_LIMIT);
+    let deserialized = FheInt256.safe_deserialize(
+      serialized,
+      SAFE_SERIALIZATION_SIZE_LIMIT,
+    );
     let deserialized_decrypted = deserialized.decrypt(clientKey);
     assert.deepStrictEqual(deserialized_decrypted, value);
-
-    let safe_serialized = encrypted.safe_serialize(BigInt(10000000));
-    let safe_deserialized = FheInt256.safe_deserialize(
-      safe_serialized,
-      BigInt(10000000),
-    );
-    let safe_deserialized_decrypted = safe_deserialized.decrypt(clientKey);
-    assert.deepStrictEqual(safe_deserialized_decrypted, value);
 
     // Compressed
     let compressed_encrypted = CompressedFheInt256.encrypt_with_client_key(
       value,
       clientKey,
     );
-    let compressed_serialized = compressed_encrypted.serialize();
-    let compressed_deserialized = CompressedFheInt256.deserialize(
+    let compressed_serialized = compressed_encrypted.safe_serialize(
+      SAFE_SERIALIZATION_SIZE_LIMIT,
+    );
+    let compressed_deserialized = CompressedFheInt256.safe_deserialize(
       compressed_serialized,
+      SAFE_SERIALIZATION_SIZE_LIMIT,
     );
     let decompressed = compressed_deserialized.decompress();
 
     decrypted = decompressed.decrypt(clientKey);
     assert.deepStrictEqual(decrypted, value);
-
-    let compressed_safe_serialized = compressed_encrypted.safe_serialize(
-      BigInt(10000000),
-    );
-    let compressed_safe_deserialized = CompressedFheInt256.safe_deserialize(
-      compressed_safe_serialized,
-      BigInt(10000000),
-    );
-    let safe_decompressed = compressed_safe_deserialized.decompress();
-
-    safe_decrypted = safe_decompressed.decrypt(clientKey);
-    assert.deepStrictEqual(safe_decrypted, value);
   };
 
   round_trip_encrypt(I256_MIN);
@@ -334,44 +269,30 @@ test("hlapi_client_key_encrypt_decrypt_int256_small", (t) => {
     let decrypted = encrypted.decrypt(clientKey);
     assert.deepStrictEqual(decrypted, value);
 
-    let serialized = encrypted.serialize();
-    let deserialized = FheInt256.deserialize(serialized);
+    let serialized = encrypted.safe_serialize(SAFE_SERIALIZATION_SIZE_LIMIT);
+    let deserialized = FheInt256.safe_deserialize(
+      serialized,
+      SAFE_SERIALIZATION_SIZE_LIMIT,
+    );
     let deserialized_decrypted = deserialized.decrypt(clientKey);
     assert.deepStrictEqual(deserialized_decrypted, value);
-
-    let safe_serialized = encrypted.safe_serialize(BigInt(10000000));
-    let safe_deserialized = FheInt256.safe_deserialize(
-      safe_serialized,
-      BigInt(10000000),
-    );
-    let safe_deserialized_decrypted = safe_deserialized.decrypt(clientKey);
-    assert.deepStrictEqual(safe_deserialized_decrypted, value);
 
     // Compressed
     let compressed_encrypted = CompressedFheInt256.encrypt_with_client_key(
       value,
       clientKey,
     );
-    let compressed_serialized = compressed_encrypted.serialize();
-    let compressed_deserialized = CompressedFheInt256.deserialize(
+    let compressed_serialized = compressed_encrypted.safe_serialize(
+      SAFE_SERIALIZATION_SIZE_LIMIT,
+    );
+    let compressed_deserialized = CompressedFheInt256.safe_deserialize(
       compressed_serialized,
+      SAFE_SERIALIZATION_SIZE_LIMIT,
     );
     let decompressed = compressed_deserialized.decompress();
 
     decrypted = decompressed.decrypt(clientKey);
     assert.deepStrictEqual(decrypted, value);
-
-    let compressed_safe_serialized = compressed_encrypted.safe_serialize(
-      BigInt(10000000),
-    );
-    let compressed_safe_deserialized = CompressedFheInt256.safe_deserialize(
-      compressed_safe_serialized,
-      BigInt(10000000),
-    );
-    let safe_decompressed = compressed_safe_deserialized.decompress();
-
-    safe_decrypted = safe_decompressed.decrypt(clientKey);
-    assert.deepStrictEqual(safe_decrypted, value);
   };
 
   round_trip_encrypt(I256_MIN);
@@ -396,18 +317,13 @@ test("hlapi_decompress_public_key_then_encrypt_decrypt_int256_small", (t) => {
   let decrypted = encrypted.decrypt(clientKey);
   assert.deepStrictEqual(decrypted, I256_MIN);
 
-  let serialized = encrypted.serialize();
-  let deserialized = FheInt256.deserialize(serialized);
+  let serialized = encrypted.safe_serialize(SAFE_SERIALIZATION_SIZE_LIMIT);
+  let deserialized = FheInt256.safe_deserialize(
+    serialized,
+    SAFE_SERIALIZATION_SIZE_LIMIT,
+  );
   let deserialized_decrypted = deserialized.decrypt(clientKey);
   assert.deepStrictEqual(deserialized_decrypted, I256_MIN);
-
-  let safe_serialized = encrypted.safe_serialize(BigInt(10000000));
-  let safe_deserialized = FheInt256.safe_deserialize(
-    safe_serialized,
-    BigInt(10000000),
-  );
-  let safe_deserialized_decrypted = safe_deserialized.decrypt(clientKey);
-  assert.deepStrictEqual(safe_deserialized_decrypted, I256_MIN);
 });
 
 test("hlapi_public_key_encrypt_decrypt_int256_small", (t) => {
@@ -423,18 +339,13 @@ test("hlapi_public_key_encrypt_decrypt_int256_small", (t) => {
   let decrypted = encrypted.decrypt(clientKey);
   assert.deepStrictEqual(decrypted, I256_MIN);
 
-  let serialized = encrypted.serialize();
-  let deserialized = FheInt256.deserialize(serialized);
+  let serialized = encrypted.safe_serialize(SAFE_SERIALIZATION_SIZE_LIMIT);
+  let deserialized = FheInt256.safe_deserialize(
+    serialized,
+    SAFE_SERIALIZATION_SIZE_LIMIT,
+  );
   let deserialized_decrypted = deserialized.decrypt(clientKey);
   assert.deepStrictEqual(deserialized_decrypted, I256_MIN);
-
-  let safe_serialized = encrypted.safe_serialize(BigInt(10000000));
-  let safe_deserialized = FheInt256.safe_deserialize(
-    safe_serialized,
-    BigInt(10000000),
-  );
-  let safe_deserialized_decrypted = safe_deserialized.decrypt(clientKey);
-  assert.deepStrictEqual(safe_deserialized_decrypted, I256_MIN);
 });
 
 //////////////////////////////////////////////////////////////////////////////
@@ -454,18 +365,13 @@ function hlapi_compact_public_key_encrypt_decrypt_int32_single(config) {
   let decrypted = encrypted.decrypt(clientKey);
   assert.deepStrictEqual(decrypted, I32_MIN);
 
-  let serialized = encrypted.serialize();
-  let deserialized = FheInt32.deserialize(serialized);
+  let serialized = encrypted.safe_serialize(SAFE_SERIALIZATION_SIZE_LIMIT);
+  let deserialized = FheInt32.safe_deserialize(
+    serialized,
+    SAFE_SERIALIZATION_SIZE_LIMIT,
+  );
   let deserialized_decrypted = deserialized.decrypt(clientKey);
   assert.deepStrictEqual(deserialized_decrypted, I32_MIN);
-
-  let safe_serialized = encrypted.safe_serialize(BigInt(10000000));
-  let safe_deserialized = FheInt32.safe_deserialize(
-    safe_serialized,
-    BigInt(10000000),
-  );
-  let safe_deserialized_decrypted = safe_deserialized.decrypt(clientKey);
-  assert.deepStrictEqual(safe_deserialized_decrypted, I32_MIN);
 }
 
 test("hlapi_compact_public_key_encrypt_decrypt_int32_big_single", (t) => {
@@ -520,10 +426,10 @@ test("hlapi_compact_ciphertext_list", (t) => {
   builder.push_u2048(clear_u2048);
   let list = builder.build();
 
-  let serialized = list.safe_serialize(BigInt(10000000));
+  let serialized = list.safe_serialize(SAFE_SERIALIZATION_SIZE_LIMIT);
   let deserialized = CompactCiphertextList.safe_deserialize(
     serialized,
-    BigInt(10000000),
+    SAFE_SERIALIZATION_SIZE_LIMIT,
   );
 
   assert.deepStrictEqual(deserialized.is_empty(), false);
@@ -579,10 +485,11 @@ test("hlapi_compact_ciphertext_list_with_proof", (t) => {
 
   let crs = CompactPkeCrs.from_config(config, 2 + 32 + 1 + 256);
 
-  const compress = false; // We don't compress as it's too slow on wasm
-  let serialized_pke_crs = crs.serialize(compress);
-  let validate = false; // Also too slow on wasm
-  crs = CompactPkeCrs.deserialize(serialized_pke_crs, compress, validate);
+  let serialized_pke_crs = crs.safe_serialize(SAFE_SERIALIZATION_SIZE_LIMIT);
+  crs = CompactPkeCrs.safe_deserialize(
+    serialized_pke_crs,
+    SAFE_SERIALIZATION_SIZE_LIMIT,
+  );
 
   let clear_u2 = 3;
   let clear_i32 = -3284;
@@ -596,10 +503,10 @@ test("hlapi_compact_ciphertext_list_with_proof", (t) => {
   builder.push_u256(clear_u256);
   let list = builder.build_with_proof_packed(crs, ZkComputeLoad.Proof);
 
-  let serialized = list.safe_serialize(BigInt(10000000));
+  let serialized = list.safe_serialize(SAFE_SERIALIZATION_SIZE_LIMIT);
   let deserialized = ProvenCompactCiphertextList.safe_deserialize(
     serialized,
-    BigInt(10000000),
+    SAFE_SERIALIZATION_SIZE_LIMIT,
   );
 
   assert.deepStrictEqual(deserialized.is_empty(), false);
@@ -717,8 +624,6 @@ test("hlapi_compact_ciphertext_list_seeded", (t) => {
 });
 
 test("hlapi_compact_pk_conformance", (t) => {
-  const limit = BigInt(1 << 20);
-
   let blockParams = new ShortintParameters(
     ShortintParametersName.PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
   );
@@ -734,19 +639,23 @@ test("hlapi_compact_pk_conformance", (t) => {
   let clientKey = TfheClientKey.generate(config);
   let compressedPublicKey = TfheCompressedCompactPublicKey.new(clientKey);
 
-  let serializedCompressedPublicKey = compressedPublicKey.safe_serialize(limit);
+  let serializedCompressedPublicKey = compressedPublicKey.safe_serialize(
+    SAFE_SERIALIZATION_SIZE_LIMIT,
+  );
   let _compressedPublicKey =
     TfheCompressedCompactPublicKey.safe_deserialize_conformant(
       serializedCompressedPublicKey,
-      limit,
+      SAFE_SERIALIZATION_SIZE_LIMIT,
       publicKeyParams,
     );
 
   let publicKey = compressedPublicKey.decompress();
-  let serializedPublicKey = publicKey.safe_serialize(limit);
+  let serializedPublicKey = publicKey.safe_serialize(
+    SAFE_SERIALIZATION_SIZE_LIMIT,
+  );
   let _publicKey = TfheCompactPublicKey.safe_deserialize_conformant(
     serializedPublicKey,
-    limit,
+    SAFE_SERIALIZATION_SIZE_LIMIT,
     publicKeyParams,
   );
 
@@ -771,7 +680,7 @@ test("hlapi_compact_pk_conformance", (t) => {
     let _compressedPublicKey =
       TfheCompressedCompactPublicKey.safe_deserialize_conformant(
         serializedCompressedPublicKey,
-        limit,
+        SAFE_SERIALIZATION_SIZE_LIMIT,
         incorrectPublicKeyParams,
       );
   });
@@ -779,7 +688,7 @@ test("hlapi_compact_pk_conformance", (t) => {
   assert.throws(() => {
     let _publicKey = TfheCompactPublicKey.safe_deserialize_conformant(
       serializedPublicKey,
-      limit,
+      SAFE_SERIALIZATION_SIZE_LIMIT,
       incorrectPublicKeyParams,
     );
   });

--- a/tfhe/js_on_wasm_tests/test-hlapi-unsigned.js
+++ b/tfhe/js_on_wasm_tests/test-hlapi-unsigned.js
@@ -26,6 +26,12 @@ const U256_MAX = BigInt(
 const U128_MAX = BigInt("340282366920938463463374607431768211455");
 const U32_MAX = 4294967295;
 
+// Size limit (in bytes) used by safe (de)serialization calls on ciphertexts and other small
+// artifacts in these tests.
+const SAFE_SERIALIZATION_SIZE_LIMIT = BigInt(10000000);
+// Size limit (in bytes) used by safe (de)serialization calls on large artifacts (like server keys).
+const SAFE_LARGE_SERIALIZATION_SIZE_LIMIT = BigInt(1000000000);
+
 // This is useful to debug test
 //
 // Note that the test hlapi_panic
@@ -74,8 +80,12 @@ test("hlapi_key_gen_big", (t) => {
     assert(true);
   }
 
-  let serializedClientKey = clientKey.serialize();
-  let serializedCompressedServerKey = compressedServerKey.serialize();
+  let serializedClientKey = clientKey.safe_serialize(
+    SAFE_SERIALIZATION_SIZE_LIMIT,
+  );
+  let serializedCompressedServerKey = compressedServerKey.safe_serialize(
+    SAFE_LARGE_SERIALIZATION_SIZE_LIMIT,
+  );
 });
 
 test("hlapi_key_gen_small", (t) => {
@@ -88,9 +98,15 @@ test("hlapi_key_gen_small", (t) => {
   let compressedServerKey = TfheCompressedServerKey.new(clientKey);
   let publicKey = TfhePublicKey.new(clientKey);
 
-  let serializedClientKey = clientKey.serialize();
-  let serializedCompressedServerKey = compressedServerKey.serialize();
-  let serializedPublicKey = publicKey.serialize();
+  let serializedClientKey = clientKey.safe_serialize(
+    SAFE_SERIALIZATION_SIZE_LIMIT,
+  );
+  let serializedCompressedServerKey = compressedServerKey.safe_serialize(
+    SAFE_LARGE_SERIALIZATION_SIZE_LIMIT,
+  );
+  let serializedPublicKey = publicKey.safe_serialize(
+    SAFE_LARGE_SERIALIZATION_SIZE_LIMIT,
+  );
 });
 
 test("hlapi_client_key_encrypt_decrypt_uint8_big", (t) => {
@@ -103,18 +119,13 @@ test("hlapi_client_key_encrypt_decrypt_uint8_big", (t) => {
   let decrypted = encrypted.decrypt(clientKey);
   assert.deepStrictEqual(decrypted, clear);
 
-  let serialized = encrypted.serialize();
-  let deserialized = FheUint8.deserialize(serialized);
+  let serialized = encrypted.safe_serialize(SAFE_SERIALIZATION_SIZE_LIMIT);
+  let deserialized = FheUint8.safe_deserialize(
+    serialized,
+    SAFE_SERIALIZATION_SIZE_LIMIT,
+  );
   let deserialized_decrypted = deserialized.decrypt(clientKey);
   assert.deepStrictEqual(deserialized_decrypted, clear);
-
-  let safe_serialized = encrypted.safe_serialize(BigInt(10000000));
-  let safe_deserialized = FheUint8.safe_deserialize(
-    safe_serialized,
-    BigInt(10000000),
-  );
-  let safe_deserialized_decrypted = safe_deserialized.decrypt(clientKey);
-  assert.deepStrictEqual(safe_deserialized_decrypted, clear);
 });
 
 test("hlapi_compressed_public_client_uint8_big", (t) => {
@@ -127,26 +138,17 @@ test("hlapi_compressed_public_client_uint8_big", (t) => {
     clear,
     clientKey,
   );
-  let compressed_serialized = compressed_encrypted.serialize();
-  let compressed_deserialized = CompressedFheUint8.deserialize(
+  let compressed_serialized = compressed_encrypted.safe_serialize(
+    SAFE_SERIALIZATION_SIZE_LIMIT,
+  );
+  let compressed_deserialized = CompressedFheUint8.safe_deserialize(
     compressed_serialized,
+    SAFE_SERIALIZATION_SIZE_LIMIT,
   );
   let decompressed = compressed_deserialized.decompress();
 
   let decrypted = decompressed.decrypt(clientKey);
   assert.deepStrictEqual(decrypted, clear);
-
-  let compressed_safe_serialized = compressed_encrypted.safe_serialize(
-    BigInt(10000000),
-  );
-  let compressed_safe_deserialized = CompressedFheUint8.safe_deserialize(
-    compressed_safe_serialized,
-    BigInt(10000000),
-  );
-  let safe_decompressed = compressed_safe_deserialized.decompress();
-
-  let safe_decrypted = safe_decompressed.decrypt(clientKey);
-  assert.deepStrictEqual(safe_decrypted, clear);
 });
 
 test("hlapi_public_key_encrypt_decrypt_uint32_small", (t) => {
@@ -162,18 +164,13 @@ test("hlapi_public_key_encrypt_decrypt_uint32_small", (t) => {
   let decrypted = encrypted.decrypt(clientKey);
   assert.deepStrictEqual(decrypted, U32_MAX);
 
-  let serialized = encrypted.serialize();
-  let deserialized = FheUint32.deserialize(serialized);
+  let serialized = encrypted.safe_serialize(SAFE_SERIALIZATION_SIZE_LIMIT);
+  let deserialized = FheUint32.safe_deserialize(
+    serialized,
+    SAFE_SERIALIZATION_SIZE_LIMIT,
+  );
   let deserialized_decrypted = deserialized.decrypt(clientKey);
   assert.deepStrictEqual(deserialized_decrypted, U32_MAX);
-
-  let safe_serialized = encrypted.safe_serialize(BigInt(1000000));
-  let safe_deserialized = FheUint32.safe_deserialize(
-    safe_serialized,
-    BigInt(1000000),
-  );
-  let safe_deserialized_decrypted = safe_deserialized.decrypt(clientKey);
-  assert.deepStrictEqual(safe_deserialized_decrypted, U32_MAX);
 });
 
 test("hlapi_decompress_public_key_then_encrypt_decrypt_uint32_small", (t) => {
@@ -187,7 +184,7 @@ test("hlapi_decompress_public_key_then_encrypt_decrypt_uint32_small", (t) => {
   let compressedPublicKey = TfheCompressedPublicKey.new(clientKey);
   var endTime = performance.now();
 
-  let data = compressedPublicKey.serialize();
+  let data = compressedPublicKey.safe_serialize(SAFE_SERIALIZATION_SIZE_LIMIT);
 
   let publicKey = compressedPublicKey.decompress();
 
@@ -195,22 +192,16 @@ test("hlapi_decompress_public_key_then_encrypt_decrypt_uint32_small", (t) => {
   let encrypted = FheUint32.encrypt_with_public_key(U32_MAX, publicKey);
   var endTime = performance.now();
 
-  let ser = encrypted.serialize();
   let decrypted = encrypted.decrypt(clientKey);
   assert.deepStrictEqual(decrypted, U32_MAX);
 
-  let serialized = encrypted.serialize();
-  let deserialized = FheUint32.deserialize(serialized);
+  let serialized = encrypted.safe_serialize(SAFE_SERIALIZATION_SIZE_LIMIT);
+  let deserialized = FheUint32.safe_deserialize(
+    serialized,
+    SAFE_SERIALIZATION_SIZE_LIMIT,
+  );
   let deserialized_decrypted = deserialized.decrypt(clientKey);
   assert.deepStrictEqual(deserialized_decrypted, U32_MAX);
-
-  let safe_serialized = encrypted.safe_serialize(BigInt(10000000));
-  let safe_deserialized = FheUint32.safe_deserialize(
-    safe_serialized,
-    BigInt(10000000),
-  );
-  let safe_deserialized_decrypted = safe_deserialized.decrypt(clientKey);
-  assert.deepStrictEqual(safe_deserialized_decrypted, U32_MAX);
 });
 
 test("hlapi_client_key_encrypt_decrypt_uint128_big", (t) => {
@@ -222,44 +213,30 @@ test("hlapi_client_key_encrypt_decrypt_uint128_big", (t) => {
   let decrypted = encrypted.decrypt(clientKey);
   assert.deepStrictEqual(decrypted, U128_MAX);
 
-  let serialized = encrypted.serialize();
-  let deserialized = FheUint128.deserialize(serialized);
+  let serialized = encrypted.safe_serialize(SAFE_SERIALIZATION_SIZE_LIMIT);
+  let deserialized = FheUint128.safe_deserialize(
+    serialized,
+    SAFE_SERIALIZATION_SIZE_LIMIT,
+  );
   let deserialized_decrypted = deserialized.decrypt(clientKey);
   assert.deepStrictEqual(deserialized_decrypted, U128_MAX);
-
-  let safe_serialized = encrypted.safe_serialize(BigInt(10000000));
-  let safe_deserialized = FheUint128.safe_deserialize(
-    safe_serialized,
-    BigInt(10000000),
-  );
-  let safe_deserialized_decrypted = safe_deserialized.decrypt(clientKey);
-  assert.deepStrictEqual(safe_deserialized_decrypted, U128_MAX);
 
   // Compressed
   let compressed_encrypted = CompressedFheUint128.encrypt_with_client_key(
     U128_MAX,
     clientKey,
   );
-  let compressed_serialized = compressed_encrypted.serialize();
-  let compressed_deserialized = CompressedFheUint128.deserialize(
+  let compressed_serialized = compressed_encrypted.safe_serialize(
+    SAFE_SERIALIZATION_SIZE_LIMIT,
+  );
+  let compressed_deserialized = CompressedFheUint128.safe_deserialize(
     compressed_serialized,
+    SAFE_SERIALIZATION_SIZE_LIMIT,
   );
   let decompressed = compressed_deserialized.decompress();
 
   decrypted = decompressed.decrypt(clientKey);
   assert.deepStrictEqual(decrypted, U128_MAX);
-
-  let compressed_safe_serialized = compressed_encrypted.safe_serialize(
-    BigInt(10000000),
-  );
-  let compressed_safe_deserialized = CompressedFheUint128.safe_deserialize(
-    compressed_safe_serialized,
-    BigInt(10000000),
-  );
-  let safe_decompressed = compressed_safe_deserialized.decompress();
-
-  safe_decrypted = safe_decompressed.decrypt(clientKey);
-  assert.deepStrictEqual(safe_decrypted, U128_MAX);
 });
 
 test("hlapi_client_key_encrypt_decrypt_uint128_small", (t) => {
@@ -274,44 +251,30 @@ test("hlapi_client_key_encrypt_decrypt_uint128_small", (t) => {
   let decrypted = encrypted.decrypt(clientKey);
   assert.deepStrictEqual(decrypted, U128_MAX);
 
-  let serialized = encrypted.serialize();
-  let deserialized = FheUint128.deserialize(serialized);
+  let serialized = encrypted.safe_serialize(SAFE_SERIALIZATION_SIZE_LIMIT);
+  let deserialized = FheUint128.safe_deserialize(
+    serialized,
+    SAFE_SERIALIZATION_SIZE_LIMIT,
+  );
   let deserialized_decrypted = deserialized.decrypt(clientKey);
   assert.deepStrictEqual(deserialized_decrypted, U128_MAX);
-
-  let safe_serialized = encrypted.safe_serialize(BigInt(10000000));
-  let safe_deserialized = FheUint128.safe_deserialize(
-    safe_serialized,
-    BigInt(10000000),
-  );
-  let safe_deserialized_decrypted = safe_deserialized.decrypt(clientKey);
-  assert.deepStrictEqual(safe_deserialized_decrypted, U128_MAX);
 
   // Compressed
   let compressed_encrypted = CompressedFheUint128.encrypt_with_client_key(
     U128_MAX,
     clientKey,
   );
-  let compressed_serialized = compressed_encrypted.serialize();
-  let compressed_deserialized = CompressedFheUint128.deserialize(
+  let compressed_serialized = compressed_encrypted.safe_serialize(
+    SAFE_SERIALIZATION_SIZE_LIMIT,
+  );
+  let compressed_deserialized = CompressedFheUint128.safe_deserialize(
     compressed_serialized,
+    SAFE_SERIALIZATION_SIZE_LIMIT,
   );
   let decompressed = compressed_deserialized.decompress();
 
   decrypted = decompressed.decrypt(clientKey);
   assert.deepStrictEqual(decrypted, U128_MAX);
-
-  let compressed_safe_serialized = compressed_encrypted.safe_serialize(
-    BigInt(10000000),
-  );
-  let compressed_safe_deserialized = CompressedFheUint128.safe_deserialize(
-    compressed_safe_serialized,
-    BigInt(10000000),
-  );
-  let safe_decompressed = compressed_safe_deserialized.decompress();
-
-  safe_decrypted = safe_decompressed.decrypt(clientKey);
-  assert.deepStrictEqual(safe_decrypted, U128_MAX);
 });
 
 test("hlapi_client_key_encrypt_decrypt_uint256_big", (t) => {
@@ -323,44 +286,30 @@ test("hlapi_client_key_encrypt_decrypt_uint256_big", (t) => {
   let decrypted = encrypted.decrypt(clientKey);
   assert.deepStrictEqual(decrypted, U256_MAX);
 
-  let serialized = encrypted.serialize();
-  let deserialized = FheUint256.deserialize(serialized);
+  let serialized = encrypted.safe_serialize(SAFE_SERIALIZATION_SIZE_LIMIT);
+  let deserialized = FheUint256.safe_deserialize(
+    serialized,
+    SAFE_SERIALIZATION_SIZE_LIMIT,
+  );
   let deserialized_decrypted = deserialized.decrypt(clientKey);
   assert.deepStrictEqual(deserialized_decrypted, U256_MAX);
-
-  let safe_serialized = encrypted.safe_serialize(BigInt(10000000));
-  let safe_deserialized = FheUint256.safe_deserialize(
-    safe_serialized,
-    BigInt(10000000),
-  );
-  let safe_deserialized_decrypted = safe_deserialized.decrypt(clientKey);
-  assert.deepStrictEqual(safe_deserialized_decrypted, U256_MAX);
 
   // Compressed
   let compressed_encrypted = CompressedFheUint256.encrypt_with_client_key(
     U256_MAX,
     clientKey,
   );
-  let compressed_serialized = compressed_encrypted.serialize();
-  let compressed_deserialized = CompressedFheUint256.deserialize(
+  let compressed_serialized = compressed_encrypted.safe_serialize(
+    SAFE_SERIALIZATION_SIZE_LIMIT,
+  );
+  let compressed_deserialized = CompressedFheUint256.safe_deserialize(
     compressed_serialized,
+    SAFE_SERIALIZATION_SIZE_LIMIT,
   );
   let decompressed = compressed_deserialized.decompress();
 
   decrypted = decompressed.decrypt(clientKey);
   assert.deepStrictEqual(decrypted, U256_MAX);
-
-  let compressed_safe_serialized = compressed_encrypted.safe_serialize(
-    BigInt(10000000),
-  );
-  let compressed_safe_deserialized = CompressedFheUint256.safe_deserialize(
-    compressed_safe_serialized,
-    BigInt(10000000),
-  );
-  let safe_decompressed = compressed_safe_deserialized.decompress();
-
-  safe_decrypted = safe_decompressed.decrypt(clientKey);
-  assert.deepStrictEqual(safe_decrypted, U256_MAX);
 });
 
 test("hlapi_client_key_encrypt_decrypt_uint256_small", (t) => {
@@ -375,44 +324,30 @@ test("hlapi_client_key_encrypt_decrypt_uint256_small", (t) => {
   let decrypted = encrypted.decrypt(clientKey);
   assert.deepStrictEqual(decrypted, U256_MAX);
 
-  let serialized = encrypted.serialize();
-  let deserialized = FheUint256.deserialize(serialized);
+  let serialized = encrypted.safe_serialize(SAFE_SERIALIZATION_SIZE_LIMIT);
+  let deserialized = FheUint256.safe_deserialize(
+    serialized,
+    SAFE_SERIALIZATION_SIZE_LIMIT,
+  );
   let deserialized_decrypted = deserialized.decrypt(clientKey);
   assert.deepStrictEqual(deserialized_decrypted, U256_MAX);
-
-  let safe_serialized = encrypted.safe_serialize(BigInt(10000000));
-  let safe_deserialized = FheUint256.safe_deserialize(
-    safe_serialized,
-    BigInt(10000000),
-  );
-  let safe_deserialized_decrypted = safe_deserialized.decrypt(clientKey);
-  assert.deepStrictEqual(safe_deserialized_decrypted, U256_MAX);
 
   // Compressed
   let compressed_encrypted = CompressedFheUint256.encrypt_with_client_key(
     U256_MAX,
     clientKey,
   );
-  let compressed_serialized = compressed_encrypted.serialize();
-  let compressed_deserialized = CompressedFheUint256.deserialize(
+  let compressed_serialized = compressed_encrypted.safe_serialize(
+    SAFE_SERIALIZATION_SIZE_LIMIT,
+  );
+  let compressed_deserialized = CompressedFheUint256.safe_deserialize(
     compressed_serialized,
+    SAFE_SERIALIZATION_SIZE_LIMIT,
   );
   let decompressed = compressed_deserialized.decompress();
 
   decrypted = decompressed.decrypt(clientKey);
   assert.deepStrictEqual(decrypted, U256_MAX);
-
-  let compressed_safe_serialized = compressed_encrypted.safe_serialize(
-    BigInt(10000000),
-  );
-  let compressed_safe_deserialized = CompressedFheUint256.safe_deserialize(
-    compressed_safe_serialized,
-    BigInt(10000000),
-  );
-  let safe_decompressed = compressed_safe_deserialized.decompress();
-
-  safe_decrypted = safe_decompressed.decrypt(clientKey);
-  assert.deepStrictEqual(safe_decrypted, U256_MAX);
 });
 
 test("hlapi_decompress_public_key_then_encrypt_decrypt_uint256_small", (t) => {
@@ -429,18 +364,13 @@ test("hlapi_decompress_public_key_then_encrypt_decrypt_uint256_small", (t) => {
   let decrypted = encrypted.decrypt(clientKey);
   assert.deepStrictEqual(decrypted, U256_MAX);
 
-  let serialized = encrypted.serialize();
-  let deserialized = FheUint256.deserialize(serialized);
+  let serialized = encrypted.safe_serialize(SAFE_SERIALIZATION_SIZE_LIMIT);
+  let deserialized = FheUint256.safe_deserialize(
+    serialized,
+    SAFE_SERIALIZATION_SIZE_LIMIT,
+  );
   let deserialized_decrypted = deserialized.decrypt(clientKey);
   assert.deepStrictEqual(deserialized_decrypted, U256_MAX);
-
-  let safe_serialized = encrypted.safe_serialize(BigInt(10000000));
-  let safe_deserialized = FheUint256.safe_deserialize(
-    safe_serialized,
-    BigInt(10000000),
-  );
-  let safe_deserialized_decrypted = safe_deserialized.decrypt(clientKey);
-  assert.deepStrictEqual(safe_deserialized_decrypted, U256_MAX);
 });
 
 test("hlapi_public_key_encrypt_decrypt_uint256_small", (t) => {
@@ -456,16 +386,11 @@ test("hlapi_public_key_encrypt_decrypt_uint256_small", (t) => {
   let decrypted = encrypted.decrypt(clientKey);
   assert.deepStrictEqual(decrypted, U256_MAX);
 
-  let serialized = encrypted.serialize();
-  let deserialized = FheUint256.deserialize(serialized);
+  let serialized = encrypted.safe_serialize(SAFE_SERIALIZATION_SIZE_LIMIT);
+  let deserialized = FheUint256.safe_deserialize(
+    serialized,
+    SAFE_SERIALIZATION_SIZE_LIMIT,
+  );
   let deserialized_decrypted = deserialized.decrypt(clientKey);
   assert.deepStrictEqual(deserialized_decrypted, U256_MAX);
-
-  let safe_serialized = encrypted.safe_serialize(BigInt(10000000));
-  let safe_deserialized = FheUint256.safe_deserialize(
-    safe_serialized,
-    BigInt(10000000),
-  );
-  let safe_deserialized_decrypted = safe_deserialized.decrypt(clientKey);
-  assert.deepStrictEqual(safe_deserialized_decrypted, U256_MAX);
 });

--- a/tfhe/src/c_api/high_level_api/booleans.rs
+++ b/tfhe/src/c_api/high_level_api/booleans.rs
@@ -6,7 +6,6 @@ pub struct FheBool(pub(in crate::c_api) crate::high_level_api::FheBool);
 
 impl_destroy_on_type!(FheBool);
 impl_clone_on_type!(FheBool);
-impl_serialize_deserialize_on_type!(FheBool);
 impl_safe_serialize_on_type!(FheBool);
 impl_safe_deserialize_conformant_on_type!(FheBool, FheBoolConformanceParams);
 
@@ -44,7 +43,6 @@ pub struct CompressedFheBool(crate::high_level_api::CompressedFheBool);
 
 impl_destroy_on_type!(CompressedFheBool);
 impl_clone_on_type!(CompressedFheBool);
-impl_serialize_deserialize_on_type!(CompressedFheBool);
 impl_safe_serialize_on_type!(CompressedFheBool);
 impl_safe_deserialize_conformant_on_type!(CompressedFheBool, CompressedFheBoolConformanceParams);
 impl_try_encrypt_with_client_key_on_type!(CompressedFheBool{crate::high_level_api::CompressedFheBool}, bool);

--- a/tfhe/src/c_api/high_level_api/compact_list.rs
+++ b/tfhe/src/c_api/high_level_api/compact_list.rs
@@ -10,11 +10,13 @@ use crate::c_api::high_level_api::keys::CompactPublicKey;
 use crate::c_api::high_level_api::u128::U128;
 use crate::c_api::high_level_api::u256::U256;
 use crate::c_api::high_level_api::utils::{
-    impl_destroy_on_type, impl_serialize_deserialize_on_type, CApiIntegerType,
+    impl_destroy_on_type, impl_safe_deserialize_on_type, impl_safe_serialize_on_type,
+    CApiIntegerType,
 };
 #[cfg(feature = "zk-pok")]
 use crate::c_api::high_level_api::zk::{CompactPkeCrs, ZkComputeLoad};
 use crate::c_api::utils::{catch_panic, get_mut_checked, get_ref_checked};
+use crate::conformance::{ListSizeConstraint, ParameterSetConformant};
 use crate::prelude::CiphertextList;
 use std::ffi::c_int;
 
@@ -23,14 +25,75 @@ impl_destroy_on_type!(CompactCiphertextListBuilder);
 
 pub struct CompactCiphertextList(crate::high_level_api::CompactCiphertextList);
 impl_destroy_on_type!(CompactCiphertextList);
-impl_serialize_deserialize_on_type!(CompactCiphertextList);
+impl_safe_serialize_on_type!(CompactCiphertextList);
+impl_safe_deserialize_on_type!(CompactCiphertextList);
+
+#[no_mangle]
+pub unsafe extern "C" fn compact_ciphertext_list_safe_deserialize_conformant(
+    buffer_view: crate::c_api::buffer::DynamicBufferView,
+    serialized_size_limit: u64,
+    public_key: *const CompactPublicKey,
+    expected_num_elements: usize,
+    result: *mut *mut CompactCiphertextList,
+) -> c_int {
+    let rc = compact_ciphertext_list_safe_deserialize(buffer_view, serialized_size_limit, result);
+    if rc != 0 {
+        return rc;
+    }
+    catch_panic(|| {
+        let pk = get_ref_checked(public_key).unwrap();
+        let list = get_ref_checked(*result).unwrap();
+        let params =
+            crate::high_level_api::CompactCiphertextListConformanceParams::from_parameters_and_size_constraint(
+                pk.0.parameters(),
+                ListSizeConstraint::exact_size(expected_num_elements),
+            );
+        if !list.0.is_conformant(&params) {
+            drop(Box::from_raw(*result));
+            *result = std::ptr::null_mut();
+            panic!("CompactCiphertextList is not conformant with the provided parameters");
+        }
+    })
+}
 
 #[cfg(feature = "zk-pok")]
 pub struct ProvenCompactCiphertextList(crate::high_level_api::ProvenCompactCiphertextList);
 #[cfg(feature = "zk-pok")]
 impl_destroy_on_type!(ProvenCompactCiphertextList);
 #[cfg(feature = "zk-pok")]
-impl_serialize_deserialize_on_type!(ProvenCompactCiphertextList);
+impl_safe_serialize_on_type!(ProvenCompactCiphertextList);
+#[cfg(feature = "zk-pok")]
+impl_safe_deserialize_on_type!(ProvenCompactCiphertextList);
+
+#[cfg(feature = "zk-pok")]
+#[no_mangle]
+pub unsafe extern "C" fn proven_compact_ciphertext_list_safe_deserialize_conformant(
+    buffer_view: crate::c_api::buffer::DynamicBufferView,
+    serialized_size_limit: u64,
+    public_key: *const CompactPublicKey,
+    crs: *const CompactPkeCrs,
+    result: *mut *mut ProvenCompactCiphertextList,
+) -> c_int {
+    let rc =
+        proven_compact_ciphertext_list_safe_deserialize(buffer_view, serialized_size_limit, result);
+    if rc != 0 {
+        return rc;
+    }
+    catch_panic(|| {
+        let pk = get_ref_checked(public_key).unwrap();
+        let crs = get_ref_checked(crs).unwrap();
+        let list = get_ref_checked(*result).unwrap();
+        let params = crate::integer::ciphertext::IntegerProvenCompactCiphertextListConformanceParams::from_crs_and_parameters(
+            pk.0.parameters(),
+            &crs.0,
+        );
+        if !list.0.is_conformant(&params) {
+            drop(Box::from_raw(*result));
+            *result = std::ptr::null_mut();
+            panic!("ProvenCompactCiphertextList is not conformant with the provided parameters");
+        }
+    })
+}
 
 #[no_mangle]
 pub unsafe extern "C" fn compact_ciphertext_list_builder_new(

--- a/tfhe/src/c_api/high_level_api/compressed_ciphertext_list.rs
+++ b/tfhe/src/c_api/high_level_api/compressed_ciphertext_list.rs
@@ -5,7 +5,7 @@ use crate::c_api::high_level_api::integers::{
     FheUint160, FheUint2, FheUint256, FheUint32, FheUint4, FheUint6, FheUint64, FheUint8,
 };
 use crate::c_api::high_level_api::utils::{
-    impl_destroy_on_type, impl_serialize_deserialize_on_type,
+    impl_destroy_on_type, impl_safe_deserialize_on_type, impl_safe_serialize_on_type,
 };
 use crate::c_api::utils::{catch_panic, get_mut_checked, get_ref_checked};
 use crate::prelude::CiphertextList;
@@ -16,7 +16,8 @@ impl_destroy_on_type!(CompressedCiphertextListBuilder);
 
 pub struct CompressedCiphertextList(crate::high_level_api::CompressedCiphertextList);
 impl_destroy_on_type!(CompressedCiphertextList);
-impl_serialize_deserialize_on_type!(CompressedCiphertextList);
+impl_safe_serialize_on_type!(CompressedCiphertextList);
+impl_safe_deserialize_on_type!(CompressedCiphertextList);
 
 #[no_mangle]
 pub unsafe extern "C" fn compressed_ciphertext_list_builder_new(

--- a/tfhe/src/c_api/high_level_api/integers.rs
+++ b/tfhe/src/c_api/high_level_api/integers.rs
@@ -331,8 +331,6 @@ macro_rules! create_integer_wrapper_type {
 
         impl_try_decrypt_trivial_on_type!($name, $clear_scalar_type);
 
-        impl_serialize_deserialize_on_type!($name);
-
         impl_clone_on_type!($name);
 
         impl_safe_serialize_on_type!($name);
@@ -354,8 +352,6 @@ macro_rules! create_integer_wrapper_type {
             impl_clone_on_type!([<Compressed $name>]);
 
             impl_try_encrypt_with_client_key_on_type!([<Compressed $name>]{crate::high_level_api::[<Compressed $name>]}, $clear_scalar_type);
-
-            impl_serialize_deserialize_on_type!([<Compressed $name>]);
 
             impl_safe_serialize_on_type!([<Compressed $name>]);
 

--- a/tfhe/src/c_api/high_level_api/keys.rs
+++ b/tfhe/src/c_api/high_level_api/keys.rs
@@ -35,13 +35,6 @@ impl_destroy_on_type!(CompressedServerKey);
 #[cfg(feature = "gpu")]
 impl_destroy_on_type!(CudaServerKey);
 
-impl_serialize_deserialize_on_type!(ClientKey);
-impl_serialize_deserialize_on_type!(PublicKey);
-impl_serialize_deserialize_on_type!(CompactPublicKey);
-impl_serialize_deserialize_on_type!(CompressedCompactPublicKey);
-impl_serialize_deserialize_on_type!(ServerKey);
-impl_serialize_deserialize_on_type!(CompressedServerKey);
-
 impl_safe_serialize_on_type!(ClientKey);
 impl_safe_serialize_on_type!(PublicKey);
 impl_safe_serialize_on_type!(CompactPublicKey);

--- a/tfhe/src/c_api/high_level_api/utils.rs
+++ b/tfhe/src/c_api/high_level_api/utils.rs
@@ -225,52 +225,6 @@ macro_rules! impl_clone_on_type {
 
 pub(crate) use impl_clone_on_type;
 
-macro_rules! impl_serialize_deserialize_on_type {
-    ($wrapper_type:ty) => {
-        ::paste::paste! {
-            #[no_mangle]
-            pub unsafe extern "C" fn [<$wrapper_type:snake _serialize>](
-                sself: *const $wrapper_type,
-                result: *mut $crate::c_api::buffer::DynamicBuffer,
-            ) -> ::std::os::raw::c_int {
-                $crate::c_api::utils::catch_panic(|| {
-                    $crate::c_api::utils::check_ptr_is_non_null_and_aligned(result).unwrap();
-
-                    let wrapper = $crate::c_api::utils::get_ref_checked(sself).unwrap();
-
-                    let buffer: $crate::c_api::buffer::DynamicBuffer = bincode::serialize(&wrapper.0)
-                        .unwrap()
-                        .into();
-
-                    *result = buffer;
-                })
-            }
-
-            #[no_mangle]
-            pub unsafe extern "C" fn [<$wrapper_type:snake _deserialize>](
-                buffer_view: $crate::c_api::buffer::DynamicBufferView,
-                result: *mut *mut $wrapper_type,
-                ) -> ::std::os::raw::c_int {
-                $crate::c_api::utils::catch_panic(|| {
-                    $crate::c_api::utils::check_ptr_is_non_null_and_aligned(result).unwrap();
-
-                    // First fill the result with a null ptr so that if we fail and the return code is not
-                    // checked, then any access to the result pointer will segfault (mimics malloc on failure)
-                    *result = std::ptr::null_mut();
-
-                    let object = bincode::deserialize(buffer_view.as_slice()).unwrap();
-
-                    let heap_allocated_object = Box::new($wrapper_type(object));
-
-                    *result = Box::into_raw(heap_allocated_object);
-                })
-            }
-        }
-    };
-}
-
-pub(crate) use impl_serialize_deserialize_on_type;
-
 macro_rules! impl_safe_serialize_on_type {
     ($wrapper_type:ty) => {
         ::paste::paste! {

--- a/tfhe/src/js_on_wasm_api/js_high_level_api/integers.rs
+++ b/tfhe/src/js_on_wasm_api/js_high_level_api/integers.rs
@@ -201,20 +201,6 @@ macro_rules! create_wrapper_type_non_native_type (
             }
 
             #[wasm_bindgen]
-            pub fn serialize(&self) -> Result<Vec<u8>, JsError> {
-                catch_panic_result(|| bincode::serialize(&self.0).map_err(into_js_error))
-            }
-
-            #[wasm_bindgen]
-            pub fn deserialize(buffer: &[u8]) -> Result<$type_name, JsError> {
-                catch_panic_result(|| {
-                    bincode::deserialize(buffer)
-                        .map($type_name)
-                        .map_err(into_js_error)
-                })
-            }
-
-            #[wasm_bindgen]
             pub fn safe_serialize(&self, serialized_size_limit: u64) -> Result<Vec<u8>, JsError> {
                 let mut buffer = vec![];
                 catch_panic_result(|| crate::safe_serialization::SerializationConfig::new(serialized_size_limit)
@@ -261,20 +247,6 @@ macro_rules! create_wrapper_type_non_native_type (
             ) -> Result<$type_name, JsError> {
                 catch_panic(||{
                     $type_name(self.0.decompress())
-                })
-            }
-
-            #[wasm_bindgen]
-            pub fn serialize(&self) -> Result<Vec<u8>, JsError> {
-                catch_panic_result(|| bincode::serialize(&self.0).map_err(into_js_error))
-            }
-
-            #[wasm_bindgen]
-            pub fn deserialize(buffer: &[u8]) -> Result<$compressed_type_name, JsError> {
-                catch_panic_result(|| {
-                    bincode::deserialize(buffer)
-                        .map($compressed_type_name)
-                        .map_err(into_js_error)
                 })
             }
 
@@ -719,20 +691,6 @@ macro_rules! create_wrapper_type_that_has_native_type (
             }
 
             #[wasm_bindgen]
-            pub fn serialize(&self) -> Result<Vec<u8>, JsError> {
-                catch_panic_result(|| bincode::serialize(&self.0).map_err(into_js_error))
-            }
-
-            #[wasm_bindgen]
-            pub fn deserialize(buffer: &[u8]) -> Result<$type_name, JsError> {
-                catch_panic_result(|| {
-                    bincode::deserialize(buffer)
-                        .map($type_name)
-                        .map_err(into_js_error)
-                })
-            }
-
-            #[wasm_bindgen]
             pub fn safe_serialize(&self, serialized_size_limit: u64) -> Result<Vec<u8>, JsError> {
                 let mut buffer = vec![];
                 catch_panic_result(|| crate::safe_serialization::SerializationConfig::new(serialized_size_limit)
@@ -776,20 +734,6 @@ macro_rules! create_wrapper_type_that_has_native_type (
             ) -> Result<$type_name, JsError> {
                 catch_panic(||{
                     $type_name(self.0.decompress())
-                })
-            }
-
-            #[wasm_bindgen]
-            pub fn serialize(&self) -> Result<Vec<u8>, JsError> {
-                catch_panic_result(|| bincode::serialize(&self.0).map_err(into_js_error))
-            }
-
-            #[wasm_bindgen]
-            pub fn deserialize(buffer: &[u8]) -> Result<$compressed_type_name, JsError> {
-                catch_panic_result(|| {
-                    bincode::deserialize(buffer)
-                        .map($compressed_type_name)
-                        .map_err(into_js_error)
                 })
             }
 
@@ -1076,20 +1020,6 @@ impl CompactCiphertextList {
     }
 
     #[wasm_bindgen]
-    pub fn serialize(&self) -> Result<Vec<u8>, JsError> {
-        catch_panic_result(|| bincode::serialize(&self.0).map_err(into_js_error))
-    }
-
-    #[wasm_bindgen]
-    pub fn deserialize(buffer: &[u8]) -> Result<CompactCiphertextList, JsError> {
-        catch_panic_result(|| {
-            bincode::deserialize(buffer)
-                .map(CompactCiphertextList)
-                .map_err(into_js_error)
-        })
-    }
-
-    #[wasm_bindgen]
     pub fn safe_serialize(&self, serialized_size_limit: u64) -> Result<Vec<u8>, JsError> {
         let mut buffer = vec![];
         catch_panic_result(|| {
@@ -1173,20 +1103,6 @@ impl ProvenCompactCiphertextList {
                 .expand_without_verification()
                 .map_err(into_js_error)?;
             Ok(CompactCiphertextListExpander(inner))
-        })
-    }
-
-    #[wasm_bindgen]
-    pub fn serialize(&self) -> Result<Vec<u8>, JsError> {
-        catch_panic_result(|| bincode::serialize(&self.0).map_err(into_js_error))
-    }
-
-    #[wasm_bindgen]
-    pub fn deserialize(buffer: &[u8]) -> Result<ProvenCompactCiphertextList, JsError> {
-        catch_panic_result(|| {
-            bincode::deserialize(buffer)
-                .map(ProvenCompactCiphertextList)
-                .map_err(into_js_error)
         })
     }
 

--- a/tfhe/src/js_on_wasm_api/js_high_level_api/keys.rs
+++ b/tfhe/src/js_on_wasm_api/js_high_level_api/keys.rs
@@ -93,20 +93,6 @@ impl TfheClientKey {
     }
 
     #[wasm_bindgen]
-    pub fn serialize(&self) -> Result<Vec<u8>, JsError> {
-        catch_panic_result(|| bincode::serialize(&self.0).map_err(into_js_error))
-    }
-
-    #[wasm_bindgen]
-    pub fn deserialize(buffer: &[u8]) -> Result<TfheClientKey, JsError> {
-        catch_panic_result(|| {
-            bincode::deserialize(buffer)
-                .map(Self)
-                .map_err(into_js_error)
-        })
-    }
-
-    #[wasm_bindgen]
     pub fn safe_serialize(&self, serialized_size_limit: u64) -> Result<Vec<u8>, JsError> {
         let mut buffer = vec![];
         catch_panic_result(|| {
@@ -142,20 +128,6 @@ impl TfheCompressedServerKey {
     #[wasm_bindgen]
     pub fn new(client_key: &TfheClientKey) -> Result<TfheCompressedServerKey, JsError> {
         catch_panic(|| Self(hlapi::CompressedServerKey::new(&client_key.0)))
-    }
-
-    #[wasm_bindgen]
-    pub fn serialize(&self) -> Result<Vec<u8>, JsError> {
-        catch_panic_result(|| bincode::serialize(&self.0).map_err(into_js_error))
-    }
-
-    #[wasm_bindgen]
-    pub fn deserialize(buffer: &[u8]) -> Result<TfheCompressedServerKey, JsError> {
-        catch_panic_result(|| {
-            bincode::deserialize(buffer)
-                .map(Self)
-                .map_err(into_js_error)
-        })
     }
 
     #[wasm_bindgen]
@@ -224,20 +196,6 @@ impl TfhePublicKey {
     }
 
     #[wasm_bindgen]
-    pub fn serialize(&self) -> Result<Vec<u8>, JsError> {
-        catch_panic_result(|| bincode::serialize(&self.0).map_err(into_js_error))
-    }
-
-    #[wasm_bindgen]
-    pub fn deserialize(buffer: &[u8]) -> Result<TfhePublicKey, JsError> {
-        catch_panic_result(|| {
-            bincode::deserialize(buffer)
-                .map(Self)
-                .map_err(into_js_error)
-        })
-    }
-
-    #[wasm_bindgen]
     pub fn safe_serialize(&self, serialized_size_limit: u64) -> Result<Vec<u8>, JsError> {
         let mut buffer = vec![];
         catch_panic_result(|| {
@@ -280,20 +238,6 @@ impl TfheCompressedPublicKey {
     }
 
     #[wasm_bindgen]
-    pub fn serialize(&self) -> Result<Vec<u8>, JsError> {
-        catch_panic_result(|| bincode::serialize(&self.0).map_err(into_js_error))
-    }
-
-    #[wasm_bindgen]
-    pub fn deserialize(buffer: &[u8]) -> Result<TfheCompressedPublicKey, JsError> {
-        catch_panic_result(|| {
-            bincode::deserialize(buffer)
-                .map(Self)
-                .map_err(into_js_error)
-        })
-    }
-
-    #[wasm_bindgen]
     pub fn safe_serialize(&self, serialized_size_limit: u64) -> Result<Vec<u8>, JsError> {
         let mut buffer = vec![];
         catch_panic_result(|| {
@@ -328,20 +272,6 @@ impl TfheCompactPublicKey {
     #[wasm_bindgen]
     pub fn new(client_key: &TfheClientKey) -> Result<TfheCompactPublicKey, JsError> {
         catch_panic(|| Self(hlapi::CompactPublicKey::new(&client_key.0)))
-    }
-
-    #[wasm_bindgen]
-    pub fn serialize(&self) -> Result<Vec<u8>, JsError> {
-        catch_panic_result(|| bincode::serialize(&self.0).map_err(into_js_error))
-    }
-
-    #[wasm_bindgen]
-    pub fn deserialize(buffer: &[u8]) -> Result<TfheCompactPublicKey, JsError> {
-        catch_panic_result(|| {
-            bincode::deserialize(buffer)
-                .map(Self)
-                .map_err(into_js_error)
-        })
     }
 
     #[wasm_bindgen]
@@ -393,20 +323,6 @@ impl TfheCompressedCompactPublicKey {
     #[wasm_bindgen]
     pub fn new(client_key: &TfheClientKey) -> Result<TfheCompressedCompactPublicKey, JsError> {
         catch_panic(|| Self(hlapi::CompressedCompactPublicKey::new(&client_key.0)))
-    }
-
-    #[wasm_bindgen]
-    pub fn serialize(&self) -> Result<Vec<u8>, JsError> {
-        catch_panic_result(|| bincode::serialize(&self.0).map_err(into_js_error))
-    }
-
-    #[wasm_bindgen]
-    pub fn deserialize(buffer: &[u8]) -> Result<TfheCompressedCompactPublicKey, JsError> {
-        catch_panic_result(|| {
-            bincode::deserialize(buffer)
-                .map(Self)
-                .map_err(into_js_error)
-        })
     }
 
     #[wasm_bindgen]

--- a/tfhe/src/js_on_wasm_api/js_high_level_api/zk.rs
+++ b/tfhe/src/js_on_wasm_api/js_high_level_api/zk.rs
@@ -3,8 +3,6 @@ use wasm_bindgen::prelude::*;
 use crate::js_on_wasm_api::js_high_level_api::config::TfheConfig;
 use crate::js_on_wasm_api::js_high_level_api::{catch_panic_result, into_js_error};
 
-use crate::zk::Compressible;
-
 #[derive(Copy, Clone, Eq, PartialEq)]
 #[wasm_bindgen]
 pub enum ZkComputeLoad {
@@ -28,28 +26,6 @@ pub struct CompactPkeCrs(pub(crate) crate::core_crypto::entities::CompactPkeCrs)
 #[allow(clippy::use_self)]
 #[wasm_bindgen]
 impl CompactPkeCrs {
-    #[wasm_bindgen]
-    pub fn serialize(&self, compress: bool) -> Result<Vec<u8>, JsError> {
-        catch_panic_result(|| {
-            let data = if compress {
-                bincode::serialize(&self.0.compress())
-            } else {
-                bincode::serialize(&self.0)
-            };
-            data.map_err(into_js_error)
-        })
-    }
-
-    #[wasm_bindgen]
-    pub fn deserialize(buffer: &[u8]) -> Result<CompactPkeCrs, JsError> {
-        // If buffer is compressed it is automatically detected and uncompressed.
-        catch_panic_result(|| {
-            bincode::deserialize(buffer)
-                .map(CompactPkeCrs)
-                .map_err(into_js_error)
-        })
-    }
-
     #[wasm_bindgen]
     pub fn safe_serialize(&self, serialized_size_limit: u64) -> Result<Vec<u8>, JsError> {
         let mut buffer = vec![];
@@ -80,17 +56,6 @@ impl CompactPkeCrs {
     pub fn from_config(config: &TfheConfig, max_num_bits: usize) -> Result<CompactPkeCrs, JsError> {
         catch_panic_result(|| {
             crate::core_crypto::entities::CompactPkeCrs::from_config(config.0, max_num_bits)
-                .map(CompactPkeCrs)
-                .map_err(into_js_error)
-        })
-    }
-
-    #[wasm_bindgen]
-    pub fn deserialize_from_public_params(buffer: &[u8]) -> Result<CompactPkeCrs, JsError> {
-        // If buffer is compressed it is automatically detected and uncompressed.
-        catch_panic_result(|| {
-            bincode::deserialize(buffer)
-                .map(crate::zk::ZkCompactPkeV1PublicParams::into)
                 .map(CompactPkeCrs)
                 .map_err(into_js_error)
         })

--- a/tfhe/web_wasm_parallel_tests/package-lock.json
+++ b/tfhe/web_wasm_parallel_tests/package-lock.json
@@ -26,7 +26,6 @@
       "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -394,7 +393,6 @@
       "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/template": "^7.28.6",
         "@babel/types": "^7.28.6"
@@ -2136,6 +2134,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2162,6 +2161,7 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -2426,6 +2426,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2717,8 +2718,7 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/core-js-compat": {
       "version": "3.38.1",
@@ -3007,7 +3007,6 @@
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -3301,7 +3300,6 @@
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -4298,6 +4296,7 @@
       "integrity": "sha512-gX/dMkRQc7QOMzgTe6KsYFM7DxeIONQSui1s0n/0xht36HvrgbxtM1xBlgx596NbpHuQU8P7QpKwrZYwUX48nw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -4347,6 +4346,7 @@
       "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",


### PR DESCRIPTION
BREAKING CHANGES:
- serialize/deserialize function without the "safe" prefix have been removed from the C and JS bindings

<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: https://github.com/zama-ai/tfhe-rs-internal/issues/1419#issue-4375606344

This is technically breaking since it removes functions, but I think it's acceptable since these functions are not expected to be used.
The Serialize/Deserialize (non safe) makes sense in Rust for users that want to serialize to their own format, but in C/JS we force bincode anyways so we might as well add our "safe" wrapper.

This PR also adds some missing safe wrappers for the C API.

Note that serialize of the CompactPkeCRS in JS allowed an optional "compressed" param to compress during serialization. This is not possible with `safe_serialize`, I think it was a mistake. But fixing it would break an API that might be used, so I left it untouched.

Tests where fixed using AI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3538)
<!-- Reviewable:end -->
