### PR TITLE
chore(ci): turn persist-credentials at true for the backward compat ci

### DIFF
--- a/.github/workflows/backward_compatibility.yml
+++ b/.github/workflows/backward_compatibility.yml
@@ -12,7 +12,7 @@ env:
   SLACK_USERNAME: ${{ secrets.BOT_USERNAME }}
   SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
   SLACKIFY_MARKDOWN: true
-  CHECKOUT_TOKEN: ${{ secrets.REPO_CHECKOUT_TOKEN || secrets.GITHUB_TOKEN }}
+  CHECKOUT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 on:
   workflow_dispatch:
@@ -37,7 +37,7 @@ jobs:
       - name: Checkout tfhe-rs
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
-          persist-credentials: 'false'
+          persist-credentials: 'true'
           token: ${{ env.CHECKOUT_TOKEN }}
 
       - name: Fetch base commit


### PR DESCRIPTION
turn persist-credentials at true for the backward compat ci