### PR TITLE
feat(gpu): add kv_store

### DIFF
--- a/.github/workflows/benchmark_gpu.yml
+++ b/.github/workflows/benchmark_gpu.yml
@@ -41,6 +41,7 @@ on:
           - integer_zk_experimental
           - integer_aes
           - integer_aes256
+          - hlapi_kvstore
           - hlapi_erc7984
           - hlapi_dex
           - hlapi_noise_squash

--- a/backends/tfhe-cuda-backend/build.rs
+++ b/backends/tfhe-cuda-backend/build.rs
@@ -84,6 +84,7 @@ fn main() {
             "wrapper.h",
             "cuda/include/ciphertext.h",
             "cuda/include/integer/compression/compression.h",
+            "cuda/include/integer/kv_store/kv_store.h",
             "cuda/include/integer/integer.h",
             "cuda/include/integer/rerand.h",
             "cuda/include/aes/aes.h",

--- a/backends/tfhe-cuda-backend/cuda/CMakeLists.txt
+++ b/backends/tfhe-cuda-backend/cuda/CMakeLists.txt
@@ -24,7 +24,7 @@ if(NOT TFHE_CUDA_COMMON_CHECK_CUDA_DIR)
   set(TFHE_CUDA_COMMON_CHECK_CUDA_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../tfhe-cuda-common/cuda)
 endif()
 set(CUDAFILE ${TFHE_CUDA_COMMON_CHECK_CUDA_DIR}/check_cuda.cu)
-execute_process(COMMAND nvcc -lcuda ${CUDAFILE} -o ${OUTPUTFILE})
+execute_process(COMMAND ${CMAKE_CUDA_COMPILER} -lcuda ${CUDAFILE} -o ${OUTPUTFILE})
 execute_process(
   COMMAND ${OUTPUTFILE}
   RESULT_VARIABLE CUDA_RETURN_CODE

--- a/backends/tfhe-cuda-backend/cuda/include/integer/cmux.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer/cmux.h
@@ -128,3 +128,95 @@ template <typename Torus> struct int_cmux_buffer {
     cuda_synchronize_stream(streams.stream(0), streams.gpu_index(0));
   }
 };
+
+template <typename Torus> struct int_cmux_batch_buffer {
+  int_radix_lut<Torus> *predicate_lut;
+  int_radix_lut<Torus> *message_extract_lut;
+
+  CudaRadixCiphertextFFI *tmp_packed;
+  CudaRadixCiphertextFFI *buffer_out;
+
+  int_radix_params params;
+  bool allocate_gpu_memory;
+  bool gpu_memory_allocated;
+
+  int_cmux_batch_buffer(CudaStreams streams,
+                        std::function<Torus(Torus)> predicate_lut_f,
+                        int_radix_params params, uint32_t num_entries,
+                        uint32_t num_blocks_per_ct, bool allocate_gpu_memory,
+                        uint64_t &size_tracker) {
+    gpu_memory_allocated = allocate_gpu_memory;
+
+    this->params = params;
+    this->allocate_gpu_memory = allocate_gpu_memory;
+
+    uint32_t total_num_blocks =
+        static_cast<uint32_t>(safe_mul(static_cast<size_t>(num_entries),
+                                       static_cast<size_t>(num_blocks_per_ct)));
+
+    tmp_packed = new CudaRadixCiphertextFFI;
+    create_zero_radix_ciphertext_async<Torus>(
+        streams.stream(0), streams.gpu_index(0), tmp_packed,
+        2 * total_num_blocks, params.big_lwe_dimension, size_tracker,
+        allocate_gpu_memory);
+
+    buffer_out = new CudaRadixCiphertextFFI;
+    create_zero_radix_ciphertext_async<Torus>(
+        streams.stream(0), streams.gpu_index(0), buffer_out,
+        2 * total_num_blocks, params.big_lwe_dimension, size_tracker,
+        allocate_gpu_memory);
+
+    auto lut_f = [predicate_lut_f](Torus block, Torus condition) -> Torus {
+      return predicate_lut_f(condition) ? 0 : block;
+    };
+    auto inverted_lut_f = [predicate_lut_f](Torus block,
+                                            Torus condition) -> Torus {
+      return predicate_lut_f(condition) ? block : 0;
+    };
+    auto message_extract_lut_f = [params](Torus x) -> Torus {
+      return x % params.message_modulus;
+    };
+
+    predicate_lut =
+        new int_radix_lut<Torus>(streams, params, 2, 2 * total_num_blocks,
+                                 allocate_gpu_memory, size_tracker);
+
+    message_extract_lut =
+        new int_radix_lut<Torus>(streams, params, 1, total_num_blocks,
+                                 allocate_gpu_memory, size_tracker);
+
+    auto active_streams_pred =
+        streams.active_gpu_subset(2 * total_num_blocks, params.pbs_type);
+    auto lut_index_generator = [total_num_blocks](Torus *h_lut_indexes,
+                                                  uint32_t num_indexes) {
+      for (uint32_t index = 0; index < 2 * total_num_blocks; index++) {
+        h_lut_indexes[index] = (index < total_num_blocks) ? 0 : 1;
+      }
+    };
+
+    predicate_lut->generate_and_broadcast_bivariate_lut(
+        active_streams_pred, {0, 1}, {inverted_lut_f, lut_f},
+        lut_index_generator);
+
+    auto active_streams_msg =
+        streams.active_gpu_subset(total_num_blocks, params.pbs_type);
+
+    message_extract_lut->generate_and_broadcast_lut(
+        active_streams_msg, {0}, {message_extract_lut_f}, LUT_0_FOR_ALL_BLOCKS);
+  }
+
+  void release(CudaStreams streams) {
+    predicate_lut->release(streams);
+    delete predicate_lut;
+    message_extract_lut->release(streams);
+    delete message_extract_lut;
+
+    release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0),
+                                   tmp_packed, gpu_memory_allocated);
+    release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0),
+                                   buffer_out, gpu_memory_allocated);
+    cuda_synchronize_stream(streams.stream(0), streams.gpu_index(0));
+    delete tmp_packed;
+    delete buffer_out;
+  }
+};

--- a/backends/tfhe-cuda-backend/cuda/include/integer/cmux.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer/cmux.h
@@ -30,8 +30,51 @@ template <typename Torus> struct int_zero_out_if_buffer {
     cuda_synchronize_stream(streams.stream(0), streams.gpu_index(0));
   }
 };
+
+/// @brief GPU scratch buffer for batched zero_out_if.
+///
+/// Holds the packed intermediate ciphertext used to combine each input block
+/// with its per-entry boolean condition before a single batched PBS call.
+template <typename Torus> struct int_zero_out_if_batch_buffer {
+
+  int_radix_params params;
+
+  /// Packed bivariate input for the predicate PBS
+  CudaRadixCiphertextFFI *tmp;
+
+  bool gpu_memory_allocated;
+
+  /// @brief Allocates the packed intermediate ciphertext for batched
+  /// zero_out_if.
+  ///
+  /// @param num_entries        Number of ciphertexts in the batch
+  /// @param num_blocks_per_ct  Number of radix blocks per ciphertext
+  int_zero_out_if_batch_buffer(CudaStreams streams, int_radix_params params,
+                               uint32_t num_entries, uint32_t num_blocks_per_ct,
+                               bool allocate_gpu_memory,
+                               uint64_t &size_tracker) {
+    gpu_memory_allocated = allocate_gpu_memory;
+    this->params = params;
+    uint32_t total_num_blocks =
+        static_cast<uint32_t>(safe_mul((size_t)num_entries, num_blocks_per_ct));
+
+    tmp = new CudaRadixCiphertextFFI;
+    create_zero_radix_ciphertext_async<Torus>(
+        streams.stream(0), streams.gpu_index(0), tmp, total_num_blocks,
+        params.big_lwe_dimension, size_tracker, allocate_gpu_memory);
+  }
+  void release(CudaStreams streams) {
+    release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0), tmp,
+                                   gpu_memory_allocated);
+    delete tmp;
+    tmp = nullptr;
+    cuda_synchronize_stream(streams.stream(0), streams.gpu_index(0));
+  }
+};
+
 template <typename Torus> struct int_cmux_buffer {
   int_radix_lut<Torus> *predicate_lut;
+  /// Univariate LUT for message extraction after addition
   int_radix_lut<Torus> *message_extract_lut;
 
   CudaRadixCiphertextFFI *buffer_in;
@@ -129,17 +172,31 @@ template <typename Torus> struct int_cmux_buffer {
   }
 };
 
+/// @brief GPU scratch buffer for batched CMUX.
+///
+/// Preallocates LUTs and intermediate ciphertext buffers needed to evaluate
+/// N independent CMUX selections in a single batched PBS pass.
 template <typename Torus> struct int_cmux_batch_buffer {
+  /// Bivariate LUT that zeroes the non-selected branch
   int_radix_lut<Torus> *predicate_lut;
+  /// Univariate LUT for message extraction after addition
   int_radix_lut<Torus> *message_extract_lut;
 
+  /// Packed bivariate input (true + false regions)
   CudaRadixCiphertextFFI *tmp_packed;
+  /// PBS output for both branches before addition
   CudaRadixCiphertextFFI *buffer_out;
 
   int_radix_params params;
   bool allocate_gpu_memory;
   bool gpu_memory_allocated;
 
+  /// @brief Allocates LUTs and intermediate buffers for batched CMUX.
+  ///
+  /// @param predicate_lut_f    Predicate function used to build the CMUX
+  /// selection LUT
+  /// @param num_entries        Number of CMUX entries in the batch
+  /// @param num_blocks_per_ct  Number of radix blocks per ciphertext
   int_cmux_batch_buffer(CudaStreams streams,
                         std::function<Torus(Torus)> predicate_lut_f,
                         int_radix_params params, uint32_t num_entries,

--- a/backends/tfhe-cuda-backend/cuda/include/integer/cmux.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer/cmux.h
@@ -25,9 +25,9 @@ template <typename Torus> struct int_zero_out_if_buffer {
   void release(CudaStreams streams) {
     release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0), tmp,
                                    gpu_memory_allocated);
+    cuda_synchronize_stream(streams.stream(0), streams.gpu_index(0));
     delete tmp;
     tmp = nullptr;
-    cuda_synchronize_stream(streams.stream(0), streams.gpu_index(0));
   }
 };
 
@@ -66,9 +66,9 @@ template <typename Torus> struct int_zero_out_if_batch_buffer {
   void release(CudaStreams streams) {
     release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0), tmp,
                                    gpu_memory_allocated);
+    cuda_synchronize_stream(streams.stream(0), streams.gpu_index(0));
     delete tmp;
     tmp = nullptr;
-    cuda_synchronize_stream(streams.stream(0), streams.gpu_index(0));
   }
 };
 

--- a/backends/tfhe-cuda-backend/cuda/include/integer/integer_utilities.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer/integer_utilities.h
@@ -25,6 +25,42 @@
 /// when all blocks should use the same LUT.
 constexpr std::nullptr_t LUT_0_FOR_ALL_BLOCKS = nullptr;
 
+/// @brief Computes the survivor count after one reserve-tail-and-absorb PBS
+/// round of the kv_store one-hot sum (host_binary_tree_fold_sum).
+///
+/// Shared by scratch allocation and the host loop so the two cannot drift.
+///
+/// max_noise M = (message_modulus*carry_modulus-1)/(message_modulus-1) is the
+/// max factor of degree-1 inputs summable before a PBS. Each fold level doubles
+/// noise, so plain folding allows only L = floor(log2(M)) levels (factor
+/// 2^L<M). Reserving a tail of floor(R/M)*(M-2^L) entries at noise 1 and
+/// absorbing them one-per-survivor after the L levels lifts each survivor from
+/// 2^L to M, reaching the full factor-M reduction. The survivor count equals
+/// the front survivors after L levels (absorb does not change their count).
+/// When R<M the reservation is skipped and folding stops at one entry.
+///
+/// @param num_entries      Number of one-hot entries entering this round
+inline uint32_t kv_sum_pbs_round_survivors(uint32_t num_entries,
+                                           uint32_t message_modulus,
+                                           uint32_t carry_modulus) {
+  if (num_entries <= 1)
+    return num_entries;
+
+  uint32_t max_noise =
+      (message_modulus * carry_modulus - 1) / (message_modulus - 1);
+  uint32_t fold_levels = log2_int(max_noise);
+
+  uint32_t group_size = num_entries / max_noise;
+  uint32_t reserved_tail = group_size * (max_noise - (1u << fold_levels));
+  uint32_t remaining = num_entries - reserved_tail;
+
+  for (uint32_t level = 0; level < fold_levels && remaining > 1; level++) {
+    uint32_t half = remaining / 2;
+    remaining = remaining - half;
+  }
+  return remaining;
+}
+
 /// Generate LUT indexes with a generator, validate them, and copy to any GPU
 /// buffer.
 ///

--- a/backends/tfhe-cuda-backend/cuda/include/integer/kv_store/kv_store.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer/kv_store/kv_store.h
@@ -1,0 +1,218 @@
+#ifndef CUDA_INTEGER_KV_STORE_H
+#define CUDA_INTEGER_KV_STORE_H
+
+#include "../../pbs/pbs_enums.h"
+#include "../integer.h"
+
+extern "C" {
+
+/// @brief Allocates the scratch buffer for kv_store get.
+///
+/// @param mem_ptr            Output pointer receiving the allocated scratch
+/// buffer
+/// @param bsk_params         Bootstrap key parameters (PBS type, dimensions,
+/// decomposition)
+/// @param ksk_params         Keyswitch key parameters (dimensions,
+/// decomposition)
+/// @param num_entries        Number of stored key-value pairs
+/// @param num_key_blocks     Number of radix blocks per key
+/// @param num_value_blocks   Number of radix blocks per value
+/// @param noise_reduction_type  Noise reduction strategy for PBS
+uint64_t scratch_cuda_kv_store_get_64_async(
+    CudaStreamsFFI streams, int8_t **mem_ptr,
+    CudaLweBootstrapKeyParamsFFI bsk_params,
+    CudaLweKeyswitchKeyParamsFFI ksk_params, uint32_t num_entries,
+    uint32_t num_key_blocks, uint32_t num_value_blocks,
+    uint32_t message_modulus, uint32_t carry_modulus, bool allocate_gpu_memory,
+    PBS_MS_REDUCTION_T noise_reduction_type);
+
+/// @brief Retrieves the encrypted value for a key from an encrypted kv_store.
+///
+/// Compares the encrypted key against all stored clear keys and extracts
+/// the matching value. Does not leak which key was accessed.
+///
+/// @param lwe_array_out_result       Output ciphertext receiving the looked-up
+/// value
+/// @param lwe_array_out_boolean      Output single-block ciphertext: 1 if key
+/// found, 0 otherwise
+/// @param lwe_array_out_selectors    Output per-entry boolean selectors (one
+/// block per entry; encrypts 1 if the entry corresponds to the looked-up key)
+/// @param lwe_array_in_encrypted_key Input encrypted key to look up
+/// @param lwe_array_in_values        Input flat array of all stored encrypted
+/// values
+/// @param h_decomposed_clear_keys    Host-side clear keys decomposed into radix
+/// blocks
+/// @param mem                        Scratch buffer from
+/// scratch_cuda_kv_store_get_64_async
+/// @param ksks                       Key-switching keys (one per GPU)
+void cuda_kv_store_get_64_async(
+    CudaStreamsFFI streams, CudaRadixCiphertextFFI *lwe_array_out_result,
+    CudaRadixCiphertextFFI *lwe_array_out_boolean,
+    CudaRadixCiphertextFFI *lwe_array_out_selectors,
+    CudaRadixCiphertextFFI const *lwe_array_in_encrypted_key,
+    CudaRadixCiphertextFFI const *lwe_array_in_values,
+    const uint64_t *h_decomposed_clear_keys, int8_t *mem, void *const *bsks,
+    void *const *ksks);
+
+/// @brief Releases the scratch buffer allocated by
+/// scratch_cuda_kv_store_get_64_async.
+///
+/// @param mem_ptr_void  Pointer to the scratch buffer pointer (set to nullptr
+/// on return)
+void cleanup_cuda_kv_store_get_64(CudaStreamsFFI streams,
+                                  int8_t **mem_ptr_void);
+
+/// @brief Allocates the scratch buffer for kv_store update.
+///
+/// @param mem_ptr            Output pointer receiving the allocated scratch
+/// buffer
+/// @param bsk_params         Bootstrap key parameters (PBS type, dimensions,
+/// decomposition)
+/// @param ksk_params         Keyswitch key parameters (dimensions,
+/// decomposition)
+/// @param num_entries        Number of stored key-value pairs
+/// @param num_key_blocks     Number of radix blocks per key
+/// @param num_value_blocks   Number of radix blocks per value
+/// @param noise_reduction_type  Noise reduction strategy for PBS
+uint64_t scratch_cuda_kv_store_update_64_async(
+    CudaStreamsFFI streams, int8_t **mem_ptr,
+    CudaLweBootstrapKeyParamsFFI bsk_params,
+    CudaLweKeyswitchKeyParamsFFI ksk_params, uint32_t num_entries,
+    uint32_t num_key_blocks, uint32_t num_value_blocks,
+    uint32_t message_modulus, uint32_t carry_modulus, bool allocate_gpu_memory,
+    PBS_MS_REDUCTION_T noise_reduction_type);
+
+/// @brief Updates the encrypted value for a key in an encrypted kv_store.
+///
+/// For each entry, if the stored clear key matches the encrypted query key,
+/// the old value is replaced with lwe_in_new_value; otherwise kept unchanged.
+///
+/// @param lwe_check_out_block          Output single-block ciphertext: 1 if key
+/// found, 0 otherwise
+/// @param lwe_array_out_values         Output flat array of all stored
+/// encrypted values (updated)
+/// @param lwe_array_in_encrypted_key   Input encrypted key to match
+/// @param lwe_array_in_values          Input flat array of current stored
+/// encrypted values
+/// @param lwe_in_new_value             Input encrypted replacement value
+/// @param h_decomposed_clear_keys      Host-side clear keys decomposed into
+/// radix blocks
+/// @param mem_ptr                      Scratch buffer from
+/// scratch_cuda_kv_store_update_64_async
+/// @param ksks                         Key-switching keys (one per GPU)
+void cuda_kv_store_update_64_async(
+    CudaStreamsFFI streams, CudaRadixCiphertextFFI *lwe_check_out_block,
+    CudaRadixCiphertextFFI *lwe_array_out_values,
+    CudaRadixCiphertextFFI const *lwe_array_in_encrypted_key,
+    CudaRadixCiphertextFFI const *lwe_array_in_values,
+    CudaRadixCiphertextFFI const *lwe_in_new_value,
+    const uint64_t *h_decomposed_clear_keys, int8_t *mem_ptr, void *const *bsks,
+    void *const *ksks);
+
+/// @brief Releases the scratch buffer allocated by
+/// scratch_cuda_kv_store_update_64_async.
+///
+/// @param mem_ptr_void  Pointer to the scratch buffer pointer (set to nullptr
+/// on return)
+void cleanup_cuda_kv_store_update_64(CudaStreamsFFI streams,
+                                     int8_t **mem_ptr_void);
+
+/// @brief Allocates the scratch buffer for kv_store map.
+///
+/// @param mem_ptr            Output pointer receiving the allocated scratch
+/// buffer
+/// @param bsk_params         Bootstrap key parameters (PBS type, dimensions,
+/// decomposition)
+/// @param ksk_params         Keyswitch key parameters (dimensions,
+/// decomposition)
+/// @param num_entries        Number of stored key-value pairs
+/// @param num_value_blocks   Number of radix blocks per value
+/// @param noise_reduction_type  Noise reduction strategy for PBS
+uint64_t scratch_cuda_kv_store_map_64_async(
+    CudaStreamsFFI streams, int8_t **mem_ptr,
+    CudaLweBootstrapKeyParamsFFI bsk_params,
+    CudaLweKeyswitchKeyParamsFFI ksk_params, uint32_t num_entries,
+    uint32_t num_value_blocks, uint32_t message_modulus, uint32_t carry_modulus,
+    bool allocate_gpu_memory, PBS_MS_REDUCTION_T noise_reduction_type);
+
+/// @brief Applies a conditional update to all entries using pre-computed
+/// selectors.
+///
+/// For each entry, if the corresponding selector is 1, the old encrypted
+/// value is replaced with lwe_in_new_value; otherwise the old value is kept.
+///
+/// @param lwe_check_out_block       Output single-block ciphertext: 1 if at
+/// least one selector was true
+/// @param lwe_array_out_values      Output flat array of all stored encrypted
+/// values (updated)
+/// @param lwe_array_in_values       Input flat array of current stored
+/// encrypted values
+/// @param lwe_in_new_value          Input encrypted replacement value
+/// @param lwe_array_in_selectors    Input per-entry boolean selectors (1 =
+/// entry must be replaced, 0 = entry should be kept)
+/// @param mem_ptr                   Scratch buffer from
+/// scratch_cuda_kv_store_map_64_async
+/// @param ksks                      Key-switching keys (one per GPU)
+void cuda_kv_store_map_64_async(
+    CudaStreamsFFI streams, CudaRadixCiphertextFFI *lwe_check_out_block,
+    CudaRadixCiphertextFFI *lwe_array_out_values,
+    CudaRadixCiphertextFFI const *lwe_array_in_values,
+    CudaRadixCiphertextFFI const *lwe_in_new_value,
+    CudaRadixCiphertextFFI const *lwe_array_in_selectors, int8_t *mem_ptr,
+    void *const *bsks, void *const *ksks);
+
+/// @brief Releases the scratch buffer allocated by
+/// scratch_cuda_kv_store_map_64_async.
+///
+/// @param mem_ptr_void  Pointer to the scratch buffer pointer (set to nullptr
+/// on return)
+void cleanup_cuda_kv_store_map_64(CudaStreamsFFI streams,
+                                  int8_t **mem_ptr_void);
+
+/// @brief Allocates the scratch buffer for kv_store contains_key.
+///
+/// @param mem_ptr            Output pointer receiving the allocated scratch
+/// buffer
+/// @param bsk_params         Bootstrap key parameters (PBS type, dimensions,
+/// decomposition)
+/// @param ksk_params         Keyswitch key parameters (dimensions,
+/// decomposition)
+/// @param num_entries        Number of stored keys
+/// @param num_key_blocks     Number of radix blocks per key
+/// @param noise_reduction_type  Noise reduction strategy for PBS
+uint64_t scratch_cuda_kv_store_contains_key_64_async(
+    CudaStreamsFFI streams, int8_t **mem_ptr,
+    CudaLweBootstrapKeyParamsFFI bsk_params,
+    CudaLweKeyswitchKeyParamsFFI ksk_params, uint32_t num_entries,
+    uint32_t num_key_blocks, uint32_t message_modulus, uint32_t carry_modulus,
+    bool allocate_gpu_memory, PBS_MS_REDUCTION_T noise_reduction_type);
+
+/// @brief Checks whether a clear key exists in the encrypted kv_store.
+///
+/// Compares the encrypted key against all stored clear keys and OR-reduces
+/// the per-entry booleans into a single key-found flag.
+///
+/// @param lwe_array_out_boolean      Output single-block ciphertext: 1 if key
+/// found, 0 otherwise
+/// @param lwe_array_in_encrypted_key Input encrypted key to look up
+/// @param h_decomposed_clear_keys    Host-side clear keys decomposed into radix
+/// blocks
+/// @param mem_ptr                    Scratch buffer from
+/// scratch_cuda_kv_store_contains_key_64_async
+/// @param ksks                       Key-switching keys (one per GPU)
+void cuda_kv_store_contains_key_64_async(
+    CudaStreamsFFI streams, CudaRadixCiphertextFFI *lwe_array_out_boolean,
+    CudaRadixCiphertextFFI const *lwe_array_in_encrypted_key,
+    const uint64_t *h_decomposed_clear_keys, int8_t *mem_ptr, void *const *bsks,
+    void *const *ksks);
+
+/// @brief Releases the scratch buffer allocated by
+/// scratch_cuda_kv_store_contains_key_64_async.
+///
+/// @param mem_ptr_void  Pointer to the scratch buffer pointer (set to nullptr
+/// on return)
+void cleanup_cuda_kv_store_contains_key_64(CudaStreamsFFI streams,
+                                           int8_t **mem_ptr_void);
+}
+
+#endif // CUDA_INTEGER_KV_STORE_H

--- a/backends/tfhe-cuda-backend/cuda/include/integer/kv_store/kv_store_utilities.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer/kv_store/kv_store_utilities.h
@@ -1,0 +1,677 @@
+#ifndef CUDA_INTEGER_KV_STORE_UTILITIES_H
+#define CUDA_INTEGER_KV_STORE_UTILITIES_H
+
+#include "../comparison.h"
+#include "../vector_find.h"
+#include "integer/cmux.cuh"
+#include "integer/radix_ciphertext.cuh"
+
+/// Entry-count threshold for the equality-selector algorithm
+constexpr uint32_t KV_STORE_EQ_SELECTORS_SMALL_MAP_MAX_ENTRIES = 256;
+
+/// @brief GPU scratch buffer for the few-entries equality-selector algorithm.
+///
+/// Given one encrypted radix key and num_possible_values block-decomposed
+/// clear keys, computes one encrypted boolean per clear key via a grid PBS
+/// followed by a batched tree AND-reduction.
+///
+/// @tparam Torus  Unsigned integer type representing a ciphertext torus element
+template <typename Torus> struct int_kv_store_eq_selectors_small_map_buffer {
+  int_radix_params params;
+  bool allocate_gpu_memory;
+  /// PBS LUT stride in torus elements, derived from ciphertext modulus
+  uint32_t lut_stride;
+
+  /// Number of cleartext key candidates (entries in the map)
+  uint32_t num_possible_values;
+
+  // Grid PBS
+  /// Per-digit equality LUTs (one per message_modulus value)
+  int_radix_lut<Torus> *comparison_luts;
+  /// Grid PBS output: message_modulus x num_blocks equality indicators
+  CudaRadixCiphertextFFI tmp_many_luts_output;
+
+  /// Gathered per-candidate comparison blocks
+  CudaRadixCiphertextFFI tmp_batched_comparisons;
+  /// Device gather-index buffer for align_with_indexes
+  Torus *d_map;
+  /// Host gather-index buffer, copied to d_map before each use
+  Torus *h_map;
+
+  // Tree reduction
+  /// Accumulator for tree-level block sums (null for single-block keys)
+  CudaRadixCiphertextFFI *tree_accumulator;
+  /// PBS output at each tree level (null for single-block keys)
+  CudaRadixCiphertextFFI *tree_pbs_output;
+  /// LUTs for the is-max-value check at each tree level
+  int_radix_lut<Torus> *is_max_value_lut;
+  /// Maximum sum before a PBS round: (msg*carry - 1) / (msg - 1)
+  uint32_t max_value;
+  /// Number of chunks per entry at the first tree level
+  uint32_t max_chunks;
+
+  // Per-level precomputed LUT-index buffers for the tree reduction.
+  /// Depth of the AND-reduction tree (0 for single-block keys)
+  uint32_t num_tree_levels;
+  /// Device LUT-index arrays, one per tree level
+  Torus **d_level_lut_indexes;
+
+  /// @brief Allocates GPU buffers for the small-map equality-selector
+  /// algorithm.
+  ///
+  /// @param num_possible_values  Number of cleartext key candidates
+  /// @param num_blocks           Number of radix blocks per key
+  int_kv_store_eq_selectors_small_map_buffer(CudaStreams streams,
+                                             int_radix_params params,
+                                             uint32_t num_possible_values,
+                                             uint32_t num_blocks,
+                                             bool allocate_gpu_memory,
+                                             uint64_t &size_tracker) {
+    this->params = params;
+    this->allocate_gpu_memory = allocate_gpu_memory;
+    this->num_possible_values = num_possible_values;
+
+    uint32_t ciphertext_modulus = params.message_modulus * params.carry_modulus;
+    uint32_t box_size = params.polynomial_size / ciphertext_modulus;
+    lut_stride = (ciphertext_modulus / params.message_modulus) * box_size;
+
+    // Grid PBS LUTs: one per possible block value
+    this->comparison_luts = new int_radix_lut<Torus>(
+        streams, params, 1, num_blocks, params.message_modulus,
+        allocate_gpu_memory, size_tracker);
+
+    std::vector<std::function<Torus(Torus)>> fs;
+    fs.reserve(params.message_modulus);
+    for (uint32_t i = 0; i < params.message_modulus; i++) {
+      fs.push_back([i](Torus x) -> Torus { return (x == i); });
+    }
+
+    this->comparison_luts->generate_and_broadcast_many_lut(
+        streams.active_gpu_subset(num_blocks, params.pbs_type), {0}, {fs},
+        LUT_0_FOR_ALL_BLOCKS);
+    fs.clear();
+
+    create_zero_radix_ciphertext_async<Torus>(
+        streams.stream(0), streams.gpu_index(0), &this->tmp_many_luts_output,
+        params.message_modulus * num_blocks, params.big_lwe_dimension,
+        size_tracker, allocate_gpu_memory);
+
+    // Gather buffer: row-major layout [entry_0_blk_0, entry_0_blk_1, ...]
+    uint64_t total_blocks64 = (uint64_t)num_possible_values * num_blocks;
+    GPU_ASSERT(total_blocks64 <= UINT32_MAX,
+               "num_possible_values * num_blocks must fit in uint32_t");
+    uint32_t total_blocks = (uint32_t)total_blocks64;
+
+    create_zero_radix_ciphertext_async<Torus>(
+        streams.stream(0), streams.gpu_index(0), &this->tmp_batched_comparisons,
+        total_blocks, params.big_lwe_dimension, size_tracker,
+        allocate_gpu_memory);
+
+    this->h_map = new Torus[total_blocks];
+    this->d_map = (Torus *)cuda_malloc_with_size_tracking_async(
+        safe_mul_sizeof<Torus>(total_blocks), streams.stream(0),
+        streams.gpu_index(0), size_tracker, allocate_gpu_memory);
+
+    // Tree reduction
+    uint32_t total_modulus = params.message_modulus * params.carry_modulus;
+    this->max_value = (total_modulus - 1) / (params.message_modulus - 1);
+    this->max_chunks =
+        (num_blocks > 1) ? CEIL_DIV(num_blocks, this->max_value) : 1;
+
+    // A single-block key needs no AND-reduction: each candidate's one
+    // comparison block already is its selector. Leave the tree resources null
+    // and skip their allocation.
+    if (num_blocks == 1) {
+      this->tree_accumulator = nullptr;
+      this->tree_pbs_output = nullptr;
+      this->is_max_value_lut = nullptr;
+      this->num_tree_levels = 0;
+      this->d_level_lut_indexes = nullptr;
+    } else {
+      uint32_t acc_blocks = num_possible_values * this->max_chunks;
+      uint32_t mv = this->max_value;
+
+      this->tree_accumulator = new CudaRadixCiphertextFFI;
+      create_zero_radix_ciphertext_async<Torus>(
+          streams.stream(0), streams.gpu_index(0), this->tree_accumulator,
+          acc_blocks, params.big_lwe_dimension, size_tracker,
+          allocate_gpu_memory);
+
+      this->tree_pbs_output = new CudaRadixCiphertextFFI;
+      create_zero_radix_ciphertext_async<Torus>(
+          streams.stream(0), streams.gpu_index(0), this->tree_pbs_output,
+          acc_blocks, params.big_lwe_dimension, size_tracker,
+          allocate_gpu_memory);
+
+      std::vector<uint32_t> level_num_chunks;
+      std::vector<uint32_t> level_last_chunk_length;
+      {
+        uint32_t blocks_per_entry = num_blocks;
+        while (blocks_per_entry > 1) {
+          uint32_t num_chunks = CEIL_DIV(blocks_per_entry, mv);
+          uint32_t last_chunk_length = blocks_per_entry - (num_chunks - 1) * mv;
+          level_num_chunks.push_back(num_chunks);
+          level_last_chunk_length.push_back(last_chunk_length);
+          blocks_per_entry = num_chunks;
+        }
+      }
+      this->num_tree_levels = static_cast<uint32_t>(level_num_chunks.size());
+
+      uint32_t num_luts = 1 + this->num_tree_levels;
+      this->is_max_value_lut =
+          new int_radix_lut<Torus>(streams, params, num_luts, acc_blocks,
+                                   allocate_gpu_memory, size_tracker);
+
+      std::vector<uint32_t> lut_ids;
+      std::vector<std::function<Torus(Torus)>> lut_fns;
+      lut_ids.reserve(num_luts);
+      lut_fns.reserve(num_luts);
+      lut_ids.push_back(0);
+      lut_fns.push_back([mv](Torus x) -> Torus { return x == mv; });
+      for (uint32_t L = 0; L < this->num_tree_levels; L++) {
+        uint32_t lcl = level_last_chunk_length[L];
+        lut_ids.push_back(L + 1);
+        lut_fns.push_back([lcl](Torus x) -> Torus { return x == lcl; });
+      }
+
+      auto lut_active = streams.active_gpu_subset(acc_blocks, params.pbs_type);
+      this->is_max_value_lut->generate_and_broadcast_lut(
+          lut_active, lut_ids, lut_fns, LUT_0_FOR_ALL_BLOCKS);
+
+      // Precompute one device lut-index buffer per level. For a block at flat
+      // index idx in [0, total_chunks): the last chunk of each entry
+      // ((idx % num_chunks) == num_chunks - 1) uses this level's slot (L + 1)
+      // when last_chunk_length != max_value; every other block uses slot 0.
+      this->d_level_lut_indexes = new Torus *[this->num_tree_levels];
+      Torus *h_level_indexes = new Torus[acc_blocks];
+      for (uint32_t L = 0; L < this->num_tree_levels; L++) {
+        uint32_t num_chunks = level_num_chunks[L];
+        uint32_t total_chunks = num_possible_values * num_chunks;
+        bool special = (level_last_chunk_length[L] != mv);
+        for (uint32_t idx = 0; idx < acc_blocks; idx++) {
+          if (special && idx < total_chunks &&
+              (idx % num_chunks) == num_chunks - 1) {
+            h_level_indexes[idx] = static_cast<Torus>(L + 1);
+          } else {
+            h_level_indexes[idx] = 0;
+          }
+        }
+        this->d_level_lut_indexes[L] =
+            (Torus *)cuda_malloc_with_size_tracking_async(
+                safe_mul_sizeof<Torus>(acc_blocks), streams.stream(0),
+                streams.gpu_index(0), size_tracker, allocate_gpu_memory);
+        if (allocate_gpu_memory) {
+          cuda_memcpy_async_to_gpu(this->d_level_lut_indexes[L],
+                                   h_level_indexes,
+                                   safe_mul_sizeof<Torus>(acc_blocks),
+                                   streams.stream(0), streams.gpu_index(0));
+        }
+      }
+      cuda_synchronize_stream(streams.stream(0), streams.gpu_index(0));
+      delete[] h_level_indexes;
+    }
+  }
+
+  void release(CudaStreams streams) {
+    this->comparison_luts->release(streams);
+    delete this->comparison_luts;
+
+    release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0),
+                                   &this->tmp_many_luts_output,
+                                   this->allocate_gpu_memory);
+
+    release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0),
+                                   &this->tmp_batched_comparisons,
+                                   this->allocate_gpu_memory);
+
+    if (this->tree_accumulator != nullptr) {
+      release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0),
+                                     this->tree_accumulator,
+                                     this->allocate_gpu_memory);
+      delete this->tree_accumulator;
+      release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0),
+                                     this->tree_pbs_output,
+                                     this->allocate_gpu_memory);
+      delete this->tree_pbs_output;
+      this->is_max_value_lut->release(streams);
+      delete this->is_max_value_lut;
+      for (uint32_t L = 0; L < this->num_tree_levels; L++) {
+        cuda_drop_async(this->d_level_lut_indexes[L], streams.stream(0),
+                        streams.gpu_index(0));
+      }
+      delete[] this->d_level_lut_indexes;
+    }
+
+    cuda_drop_async(this->d_map, streams.stream(0), streams.gpu_index(0));
+    cuda_synchronize_stream(streams.stream(0), streams.gpu_index(0));
+    delete[] this->h_map;
+  }
+};
+
+/// @brief Wrapper selecting the equality-selector algorithm by entry count.
+///
+/// Holds whichever equality-selector buffer the entry count selects, so a
+/// single allocation matches the algorithm host_kv_store_compute_eq_selectors
+/// will run. Exactly one of the two pointers is non-null, decided by
+/// num_entries against KV_STORE_EQ_SELECTORS_SMALL_MAP_MAX_ENTRIES.
+///
+/// @tparam Torus  Unsigned integer type representing a ciphertext torus element
+template <typename Torus> struct int_kv_store_eq_selectors_wrapper_buffer {
+  /// True when the tree variant is selected
+  bool use_small_map;
+  /// Tree-based buffer for few entries (non-null when use_small_map)
+  int_kv_store_eq_selectors_small_map_buffer<Torus> *small_map_buffer;
+  /// Sequential-scan buffer for many entries (non-null when !use_small_map)
+  int_eq_selectors_ct_vs_clears_buffer<Torus> *vector_find_buffer;
+
+  /// @brief Allocates the appropriate equality-selector sub-buffer.
+  ///
+  /// @param num_entries    Number of stored keys in the map
+  /// @param num_key_blocks Number of radix blocks per key
+  int_kv_store_eq_selectors_wrapper_buffer(
+      CudaStreams streams, int_radix_params params, uint32_t num_entries,
+      uint32_t num_key_blocks, bool allocate_gpu_memory, uint64_t &size_tracker)
+      : small_map_buffer(nullptr), vector_find_buffer(nullptr) {
+    this->use_small_map =
+        num_entries <= KV_STORE_EQ_SELECTORS_SMALL_MAP_MAX_ENTRIES;
+    if (this->use_small_map) {
+      this->small_map_buffer =
+          new int_kv_store_eq_selectors_small_map_buffer<Torus>(
+              streams, params, num_entries, num_key_blocks, allocate_gpu_memory,
+              size_tracker);
+      this->vector_find_buffer = nullptr;
+    } else {
+      this->vector_find_buffer =
+          new int_eq_selectors_ct_vs_clears_buffer<Torus>(
+              streams, params, num_entries, num_key_blocks, allocate_gpu_memory,
+              size_tracker);
+      this->small_map_buffer = nullptr;
+    }
+  }
+
+  void release(CudaStreams streams) {
+    if (this->small_map_buffer) {
+      this->small_map_buffer->release(streams);
+      delete this->small_map_buffer;
+    }
+    if (this->vector_find_buffer) {
+      this->vector_find_buffer->release(streams);
+      delete this->vector_find_buffer;
+    }
+  }
+};
+
+/// @brief GPU scratch buffer for homomorphic kv_store get (value lookup by
+/// key).
+///
+/// Preallocates all intermediate buffers needed to look up an encrypted value
+/// by comparing an encrypted key against all stored clear keys, zero-out
+/// non-matching entries, and sum the survivors.
+///
+/// @tparam Torus  Unsigned integer type representing a ciphertext torus element
+template <typename Torus> struct int_kv_store_get_buffer {
+  int_radix_params params;
+  bool allocate_gpu_memory;
+  /// Number of stored key-value pairs
+  uint32_t num_entries;
+  /// Number of radix blocks per key
+  uint32_t num_key_blocks;
+  /// Number of radix blocks per value
+  uint32_t num_value_blocks;
+
+  /// Message modulus from radix parameters
+  Torus message_modulus;
+  /// Carry modulus from radix parameters
+  Torus carry_modulus;
+
+  /// Equality-selector sub-buffer (one boolean per entry)
+  int_kv_store_eq_selectors_wrapper_buffer<Torus> *mem_eq_selectors_buffer;
+
+  /// Batch zero-out buffer for the one-hot vector step
+  int_zero_out_if_batch_buffer<Torus> *mem_zero_out_batch_buffer;
+  /// Bivariate LUT: keep block if selector is nonzero, else zero
+  int_radix_lut<Torus> *one_hot_vector_predicate;
+  /// Scratch ciphertext for the one-hot vector
+  CudaRadixCiphertextFFI *tmp_cmux_array;
+  /// Identity LUT for carry propagation during the sum step
+  int_radix_lut<Torus> *identity_lut;
+
+  /// OR-reduction scratch producing the key-found boolean
+  int_comparison_buffer<Torus> *at_least_one_true_buffer;
+
+  /// @brief Allocates GPU buffers required for kv_store get.
+  ///
+  /// @param num_entries      Number of stored key-value pairs
+  /// @param num_key_blocks   Number of radix blocks per key
+  /// @param num_value_blocks Number of radix blocks per value
+  int_kv_store_get_buffer(CudaStreams streams, int_radix_params params,
+                          uint32_t num_entries, uint32_t num_key_blocks,
+                          uint32_t num_value_blocks, bool allocate_gpu_memory,
+                          uint64_t &size_tracker)
+      : params(params), allocate_gpu_memory(allocate_gpu_memory),
+        num_entries(num_entries), num_key_blocks(num_key_blocks),
+        num_value_blocks(num_value_blocks) {
+
+    this->message_modulus = params.message_modulus;
+    this->carry_modulus = params.carry_modulus;
+
+    uint32_t total_value_blocks =
+        static_cast<uint32_t>(safe_mul(static_cast<size_t>(num_entries),
+                                       static_cast<size_t>(num_value_blocks)));
+
+    this->mem_eq_selectors_buffer =
+        new int_kv_store_eq_selectors_wrapper_buffer<Torus>(
+            streams, params, num_entries, num_key_blocks, allocate_gpu_memory,
+            size_tracker);
+
+    this->mem_zero_out_batch_buffer = new int_zero_out_if_batch_buffer<Torus>(
+        streams, params, num_entries, num_value_blocks, allocate_gpu_memory,
+        size_tracker);
+
+    auto zero_out_predicate_lut_f = [](Torus block, Torus condition) -> Torus {
+      if (condition == 0)
+        return 0;
+      else
+        return block;
+    };
+
+    this->one_hot_vector_predicate =
+        new int_radix_lut<Torus>(streams, params, 1, total_value_blocks,
+                                 allocate_gpu_memory, size_tracker);
+
+    auto active_streams =
+        streams.active_gpu_subset(total_value_blocks, params.pbs_type);
+    this->one_hot_vector_predicate->generate_and_broadcast_bivariate_lut(
+        active_streams, {0}, {zero_out_predicate_lut_f}, LUT_0_FOR_ALL_BLOCKS);
+
+    this->tmp_cmux_array = new CudaRadixCiphertextFFI;
+    create_zero_radix_ciphertext_async<Torus>(
+        streams.stream(0), streams.gpu_index(0), this->tmp_cmux_array,
+        total_value_blocks, params.big_lwe_dimension, size_tracker,
+        allocate_gpu_memory);
+
+    uint32_t max_entries_after_pbs_round = kv_sum_pbs_round_survivors(
+        num_entries, params.message_modulus, params.carry_modulus);
+    uint32_t pbs_batch_blocks = static_cast<uint32_t>(
+        safe_mul(static_cast<size_t>(max_entries_after_pbs_round),
+                 static_cast<size_t>(num_value_blocks)));
+
+    std::function<Torus(Torus)> identity_fn = [](Torus x) -> Torus {
+      return x;
+    };
+    this->identity_lut =
+        new int_radix_lut<Torus>(streams, params, 1, pbs_batch_blocks,
+                                 allocate_gpu_memory, size_tracker);
+    this->identity_lut->generate_and_broadcast_lut(
+        streams.active_gpu_subset(pbs_batch_blocks, params.pbs_type), {0},
+        {identity_fn}, LUT_0_FOR_ALL_BLOCKS);
+
+    this->at_least_one_true_buffer = new int_comparison_buffer<Torus>(
+        streams, EQ, params, num_entries, false, allocate_gpu_memory,
+        size_tracker);
+  }
+
+  void release(CudaStreams streams) {
+    this->at_least_one_true_buffer->release(streams);
+    delete this->at_least_one_true_buffer;
+
+    release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0),
+                                   this->tmp_cmux_array,
+                                   this->allocate_gpu_memory);
+    delete this->tmp_cmux_array;
+
+    this->one_hot_vector_predicate->release(streams);
+    delete this->one_hot_vector_predicate;
+
+    this->mem_zero_out_batch_buffer->release(streams);
+    delete this->mem_zero_out_batch_buffer;
+
+    this->identity_lut->release(streams);
+    delete this->identity_lut;
+
+    this->mem_eq_selectors_buffer->release(streams);
+    delete this->mem_eq_selectors_buffer;
+
+    cuda_synchronize_stream(streams.stream(0), streams.gpu_index(0));
+  }
+};
+
+/// @brief GPU scratch buffer for homomorphic kv_store update (conditional value
+/// replacement).
+///
+/// Preallocates buffers for comparing an encrypted key against all stored
+/// clear keys and replacing the matched entry's encrypted value with a new
+/// one via batched CMUX.
+///
+/// @tparam Torus  Unsigned integer type representing a ciphertext torus element
+template <typename Torus> struct int_kv_store_update_buffer {
+  int_radix_params params;
+  bool allocate_gpu_memory;
+  bool gpu_memory_allocated;
+  /// Number of stored key-value pairs
+  uint32_t num_entries;
+  /// Number of radix blocks per key
+  uint32_t num_key_blocks;
+  /// Number of radix blocks per value
+  uint32_t num_value_blocks;
+
+  /// Message modulus from radix parameters
+  Torus message_modulus;
+  /// Carry modulus from radix parameters
+  Torus carry_modulus;
+
+  /// Batched CMUX buffer for conditional value replacement
+  int_cmux_batch_buffer<Torus> *cmux_batch_buffer;
+
+  /// Equality-selector sub-buffer (one boolean per entry)
+  int_kv_store_eq_selectors_wrapper_buffer<Torus> *mem_eq_selectors_buffer;
+
+  /// Contiguous buffer for selectors, one boolean per entry
+  CudaRadixCiphertextFFI *selectors_contiguous;
+
+  /// OR-reduction scratch producing the key-found boolean
+  int_comparison_buffer<Torus> *at_least_one_true_buffer;
+
+  /// @brief Allocates GPU buffers required for kv_store update.
+  ///
+  /// @param num_entries      Number of stored key-value pairs
+  /// @param num_key_blocks   Number of radix blocks per key
+  /// @param num_value_blocks Number of radix blocks per value
+  int_kv_store_update_buffer(CudaStreams streams, int_radix_params params,
+                             uint32_t num_entries, uint32_t num_key_blocks,
+                             uint32_t num_value_blocks,
+                             bool allocate_gpu_memory, uint64_t &size_tracker)
+      : params(params), allocate_gpu_memory(allocate_gpu_memory),
+        gpu_memory_allocated(allocate_gpu_memory), num_entries(num_entries),
+        num_key_blocks(num_key_blocks), num_value_blocks(num_value_blocks) {
+
+    this->message_modulus = params.message_modulus;
+    this->carry_modulus = params.carry_modulus;
+
+    // Equality selectors
+    this->mem_eq_selectors_buffer =
+        new int_kv_store_eq_selectors_wrapper_buffer<Torus>(
+            streams, params, num_entries, num_key_blocks, allocate_gpu_memory,
+            size_tracker);
+
+    this->selectors_contiguous = new CudaRadixCiphertextFFI;
+    create_zero_radix_ciphertext_async<Torus>(
+        streams.stream(0), streams.gpu_index(0), this->selectors_contiguous,
+        num_entries, params.big_lwe_dimension, size_tracker,
+        allocate_gpu_memory);
+
+    auto condition_is_one = [](Torus x) -> Torus { return x == 1; };
+    size_tracker += scratch_cuda_cmux_batch<Torus>(
+        streams, &this->cmux_batch_buffer, condition_is_one, num_entries,
+        num_value_blocks, params, allocate_gpu_memory);
+
+    // OR all selectors to produce a key-found boolean
+    this->at_least_one_true_buffer = new int_comparison_buffer<Torus>(
+        streams, EQ, params, num_entries, false, allocate_gpu_memory,
+        size_tracker);
+  }
+
+  void release(CudaStreams streams) {
+    this->at_least_one_true_buffer->release(streams);
+    delete this->at_least_one_true_buffer;
+
+    this->cmux_batch_buffer->release(streams);
+    delete this->cmux_batch_buffer;
+
+    release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0),
+                                   this->selectors_contiguous,
+                                   this->gpu_memory_allocated);
+    delete this->selectors_contiguous;
+
+    this->mem_eq_selectors_buffer->release(streams);
+    delete this->mem_eq_selectors_buffer;
+
+    cuda_synchronize_stream(streams.stream(0), streams.gpu_index(0));
+  }
+};
+
+/// @brief GPU scratch buffer for homomorphic kv_store map (selector-driven
+/// conditional update).
+///
+/// Preallocates buffers for the inner CMUX step shared by update and insert:
+/// given pre-computed selectors (one boolean per entry), replace matched
+/// entries' values with a new one. Does not compute equality selectors itself.
+///
+/// @tparam Torus  Unsigned integer type representing a ciphertext torus element
+template <typename Torus> struct int_kv_store_map_buffer {
+  int_radix_params params;
+  bool allocate_gpu_memory;
+  bool gpu_memory_allocated;
+  /// Number of stored key-value pairs
+  uint32_t num_entries;
+  /// Number of radix blocks per value
+  uint32_t num_value_blocks;
+
+  /// Message modulus from radix parameters
+  Torus message_modulus;
+  /// Carry modulus from radix parameters
+  Torus carry_modulus;
+
+  /// Batched CMUX buffer for conditional value replacement
+  int_cmux_batch_buffer<Torus> *cmux_batch_buffer;
+
+  /// OR-reduction scratch producing the key-found boolean
+  int_comparison_buffer<Torus> *at_least_one_true_buffer;
+
+  /// @brief Allocates GPU buffers required for kv_store map.
+  ///
+  /// @param num_entries      Number of stored key-value pairs
+  /// @param num_value_blocks Number of radix blocks per value
+  int_kv_store_map_buffer(CudaStreams streams, int_radix_params params,
+                          uint32_t num_entries, uint32_t num_value_blocks,
+                          bool allocate_gpu_memory, uint64_t &size_tracker)
+      : params(params), allocate_gpu_memory(allocate_gpu_memory),
+        gpu_memory_allocated(allocate_gpu_memory), num_entries(num_entries),
+        num_value_blocks(num_value_blocks) {
+
+    this->message_modulus = params.message_modulus;
+    this->carry_modulus = params.carry_modulus;
+
+    // Parallel CMUXes
+    auto predicate_lut_f = [](Torus x) -> Torus { return x == 1; };
+    size_tracker += scratch_cuda_cmux_batch<Torus>(
+        streams, &this->cmux_batch_buffer, predicate_lut_f, num_entries,
+        num_value_blocks, params, allocate_gpu_memory);
+
+    // OR all selectors to produce a key-found boolean
+    this->at_least_one_true_buffer = new int_comparison_buffer<Torus>(
+        streams, EQ, params, num_entries, false, allocate_gpu_memory,
+        size_tracker);
+  }
+
+  void release(CudaStreams streams) {
+    this->at_least_one_true_buffer->release(streams);
+    delete this->at_least_one_true_buffer;
+
+    this->cmux_batch_buffer->release(streams);
+    delete this->cmux_batch_buffer;
+
+    cuda_synchronize_stream(streams.stream(0), streams.gpu_index(0));
+  }
+};
+
+/// @brief GPU scratch buffer for homomorphic kv_store contains_key (key
+/// existence check).
+///
+/// Preallocates buffers for comparing an encrypted key against all stored
+/// clear keys and OR-reducing the per-entry booleans into a single
+/// key-found flag.
+///
+/// @tparam Torus  Unsigned integer type representing a ciphertext torus element
+template <typename Torus> struct int_kv_store_contains_key_buffer {
+  int_radix_params params;
+  bool allocate_gpu_memory;
+  bool gpu_memory_allocated;
+  /// Number of stored keys
+  uint32_t num_entries;
+  /// Number of radix blocks per key
+  uint32_t num_key_blocks;
+
+  /// Message modulus from radix parameters
+  Torus message_modulus;
+  /// Carry modulus from radix parameters
+  Torus carry_modulus;
+
+  /// Equality-selector sub-buffer (one boolean per entry)
+  int_kv_store_eq_selectors_wrapper_buffer<Torus> *mem_eq_selectors_buffer;
+
+  /// Contiguous buffer for selectors, one boolean per entry
+  CudaRadixCiphertextFFI *selectors_contiguous;
+
+  /// OR-reduction scratch producing the key-found boolean
+  int_comparison_buffer<Torus> *at_least_one_true_buffer;
+
+  /// @brief Allocates GPU buffers required for kv_store contains_key.
+  ///
+  /// @param num_entries    Number of stored keys
+  /// @param num_key_blocks Number of radix blocks per key
+  int_kv_store_contains_key_buffer(CudaStreams streams, int_radix_params params,
+                                   uint32_t num_entries,
+                                   uint32_t num_key_blocks,
+                                   bool allocate_gpu_memory,
+                                   uint64_t &size_tracker)
+      : params(params), allocate_gpu_memory(allocate_gpu_memory),
+        gpu_memory_allocated(allocate_gpu_memory), num_entries(num_entries),
+        num_key_blocks(num_key_blocks) {
+
+    this->message_modulus = params.message_modulus;
+    this->carry_modulus = params.carry_modulus;
+
+    this->mem_eq_selectors_buffer =
+        new int_kv_store_eq_selectors_wrapper_buffer<Torus>(
+            streams, params, num_entries, num_key_blocks, allocate_gpu_memory,
+            size_tracker);
+
+    this->selectors_contiguous = new CudaRadixCiphertextFFI;
+    create_zero_radix_ciphertext_async<Torus>(
+        streams.stream(0), streams.gpu_index(0), this->selectors_contiguous,
+        num_entries, params.big_lwe_dimension, size_tracker,
+        allocate_gpu_memory);
+
+    this->at_least_one_true_buffer = new int_comparison_buffer<Torus>(
+        streams, EQ, params, num_entries, false, allocate_gpu_memory,
+        size_tracker);
+  }
+
+  void release(CudaStreams streams) {
+    this->at_least_one_true_buffer->release(streams);
+    delete this->at_least_one_true_buffer;
+
+    release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0),
+                                   this->selectors_contiguous,
+                                   this->gpu_memory_allocated);
+    delete this->selectors_contiguous;
+
+    this->mem_eq_selectors_buffer->release(streams);
+    delete this->mem_eq_selectors_buffer;
+
+    cuda_synchronize_stream(streams.stream(0), streams.gpu_index(0));
+  }
+};
+
+#endif // CUDA_INTEGER_KV_STORE_UTILITIES_H

--- a/backends/tfhe-cuda-backend/cuda/include/integer/kv_store/kv_store_utilities.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer/kv_store/kv_store_utilities.h
@@ -129,7 +129,7 @@ template <typename Torus> struct int_kv_store_eq_selectors_small_map_buffer {
       this->d_level_lut_indexes = nullptr;
     } else {
       uint32_t acc_blocks = num_possible_values * this->max_chunks;
-      uint32_t mv = this->max_value;
+      uint32_t max_value = this->max_value;
 
       this->tree_accumulator = new CudaRadixCiphertextFFI;
       create_zero_radix_ciphertext_async<Torus>(
@@ -148,8 +148,9 @@ template <typename Torus> struct int_kv_store_eq_selectors_small_map_buffer {
       {
         uint32_t blocks_per_entry = num_blocks;
         while (blocks_per_entry > 1) {
-          uint32_t num_chunks = CEIL_DIV(blocks_per_entry, mv);
-          uint32_t last_chunk_length = blocks_per_entry - (num_chunks - 1) * mv;
+          uint32_t num_chunks = CEIL_DIV(blocks_per_entry, max_value);
+          uint32_t last_chunk_length =
+              blocks_per_entry - (num_chunks - 1) * max_value;
           level_num_chunks.push_back(num_chunks);
           level_last_chunk_length.push_back(last_chunk_length);
           blocks_per_entry = num_chunks;
@@ -167,7 +168,8 @@ template <typename Torus> struct int_kv_store_eq_selectors_small_map_buffer {
       lut_ids.reserve(num_luts);
       lut_fns.reserve(num_luts);
       lut_ids.push_back(0);
-      lut_fns.push_back([mv](Torus x) -> Torus { return x == mv; });
+      lut_fns.push_back(
+          [max_value](Torus x) -> Torus { return x == max_value; });
       for (uint32_t L = 0; L < this->num_tree_levels; L++) {
         uint32_t lcl = level_last_chunk_length[L];
         lut_ids.push_back(L + 1);
@@ -178,16 +180,15 @@ template <typename Torus> struct int_kv_store_eq_selectors_small_map_buffer {
       this->is_max_value_lut->generate_and_broadcast_lut(
           lut_active, lut_ids, lut_fns, LUT_0_FOR_ALL_BLOCKS);
 
-      // Precompute one device lut-index buffer per level. For a block at flat
-      // index idx in [0, total_chunks): the last chunk of each entry
-      // ((idx % num_chunks) == num_chunks - 1) uses this level's slot (L + 1)
-      // when last_chunk_length != max_value; every other block uses slot 0.
+      // Precompute one device LUT-index buffer per level. The last chunk of
+      // each entry uses the level-specific slot when its length differs from
+      // max_value; all other blocks use slot 0.
       this->d_level_lut_indexes = new Torus *[this->num_tree_levels];
       Torus *h_level_indexes = new Torus[acc_blocks];
       for (uint32_t L = 0; L < this->num_tree_levels; L++) {
         uint32_t num_chunks = level_num_chunks[L];
         uint32_t total_chunks = num_possible_values * num_chunks;
-        bool special = (level_last_chunk_length[L] != mv);
+        bool special = (level_last_chunk_length[L] != max_value);
         for (uint32_t idx = 0; idx < acc_blocks; idx++) {
           if (special && idx < total_chunks &&
               (idx % num_chunks) == num_chunks - 1) {
@@ -228,11 +229,9 @@ template <typename Torus> struct int_kv_store_eq_selectors_small_map_buffer {
       release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0),
                                      this->tree_accumulator,
                                      this->allocate_gpu_memory);
-      delete this->tree_accumulator;
       release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0),
                                      this->tree_pbs_output,
                                      this->allocate_gpu_memory);
-      delete this->tree_pbs_output;
       this->is_max_value_lut->release(streams);
       delete this->is_max_value_lut;
       for (uint32_t L = 0; L < this->num_tree_levels; L++) {
@@ -244,6 +243,11 @@ template <typename Torus> struct int_kv_store_eq_selectors_small_map_buffer {
 
     cuda_drop_async(this->d_map, streams.stream(0), streams.gpu_index(0));
     cuda_synchronize_stream(streams.stream(0), streams.gpu_index(0));
+
+    if (this->tree_accumulator != nullptr) {
+      delete this->tree_accumulator;
+      delete this->tree_pbs_output;
+    }
     delete[] this->h_map;
   }
 };
@@ -418,7 +422,6 @@ template <typename Torus> struct int_kv_store_get_buffer {
     release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0),
                                    this->tmp_cmux_array,
                                    this->allocate_gpu_memory);
-    delete this->tmp_cmux_array;
 
     this->one_hot_vector_predicate->release(streams);
     delete this->one_hot_vector_predicate;
@@ -433,6 +436,7 @@ template <typename Torus> struct int_kv_store_get_buffer {
     delete this->mem_eq_selectors_buffer;
 
     cuda_synchronize_stream(streams.stream(0), streams.gpu_index(0));
+    delete this->tmp_cmux_array;
   }
 };
 
@@ -521,12 +525,12 @@ template <typename Torus> struct int_kv_store_update_buffer {
     release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0),
                                    this->selectors_contiguous,
                                    this->gpu_memory_allocated);
-    delete this->selectors_contiguous;
 
     this->mem_eq_selectors_buffer->release(streams);
     delete this->mem_eq_selectors_buffer;
 
     cuda_synchronize_stream(streams.stream(0), streams.gpu_index(0));
+    delete this->selectors_contiguous;
   }
 };
 
@@ -665,12 +669,12 @@ template <typename Torus> struct int_kv_store_contains_key_buffer {
     release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0),
                                    this->selectors_contiguous,
                                    this->gpu_memory_allocated);
-    delete this->selectors_contiguous;
 
     this->mem_eq_selectors_buffer->release(streams);
     delete this->mem_eq_selectors_buffer;
 
     cuda_synchronize_stream(streams.stream(0), streams.gpu_index(0));
+    delete this->selectors_contiguous;
   }
 };
 

--- a/backends/tfhe-cuda-backend/cuda/src/CMakeLists.txt
+++ b/backends/tfhe-cuda-backend/cuda/src/CMakeLists.txt
@@ -1,6 +1,10 @@
 file(GLOB_RECURSE SOURCES "*.cu")
-add_library(tfhe_cuda_backend STATIC ${SOURCES} pbs/programmable_bootstrap_multibit_128.cuh
-                                     pbs/programmable_bootstrap_multibit_128.cu)
+file(GLOB_RECURSE HEADERS "*.cuh" "../include/*.h" "../include/*.cuh")
+
+add_library(
+  tfhe_cuda_backend STATIC
+  ${SOURCES} ${HEADERS} pbs/programmable_bootstrap_multibit_128.cuh pbs/programmable_bootstrap_multibit_128.cu
+  ../include/integer/kv_store/kv_store.h ../include/integer/kv_store/kv_store_utilities.h)
 set_target_properties(tfhe_cuda_backend PROPERTIES CUDA_SEPARABLE_COMPILATION ON CUDA_RESOLVE_DEVICE_SYMBOLS ON)
 target_link_libraries(tfhe_cuda_backend PUBLIC cudart OpenMP::OpenMP_CXX tfhe_cuda_common)
 target_include_directories(tfhe_cuda_backend PRIVATE .)

--- a/backends/tfhe-cuda-backend/cuda/src/integer/cmux.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/cmux.cuh
@@ -107,4 +107,120 @@ __host__ uint64_t scratch_cuda_cmux(CudaStreams streams,
                                         size_tracker);
   return size_tracker;
 }
+
+// Batched CMUX: for each of num_entries ciphertexts, selects lwe_array_true
+// where the condition is 1, lwe_array_false where the condition is 0.
+// Each condition in lwe_conditions is a single LWE block per entry.
+//
+// Default mode (replicate_true == false):
+//
+//  lwe_conditions   lwe_array_true     lwe_array_false
+//  (1 block each)   (B blocks/entry)   (B blocks/entry)
+//  ┌──┬──┬───┬──┐   ┌──┬──┬───┬──┐    ┌──┬──┬───┬──┐
+//  │c0│c1│...│cN│   │t0│t1│...│tN│    │f0│f1│...│fN│
+//  └──┴──┴───┴──┘   └──┴──┴───┴──┘    └──┴──┴───┴──┘
+//
+//  o0 = (c0==1) ? t0 : f0
+//  o1 = (c1==1) ? t1 : f1
+//       ...
+//  oN = (cN==1) ? tN : fN
+//
+//                    lwe_array_out
+//                    (B blocks/entry)
+//                    ┌──┬──┬───┬──┐
+//                    │o0│o1│...│oN│
+//                    └──┴──┴───┴──┘
+//
+// Replicate mode (replicate_true == true):
+// lwe_array_true is a single ciphertext of B blocks, reused for every entry.
+//
+//  lwe_conditions   lwe_array_true     lwe_array_false
+//  (1 block each)   (B blocks, shared)  (B blocks/entry)
+//  ┌──┬──┬───┬──┐   ┌──────┐            ┌──┬──┬───┬──┐
+//  │c0│c1│...│cN│   │  t   │            │f0│f1│...│fN│
+//  └──┴──┴───┴──┘   └──────┘            └──┴──┴───┴──┘
+//
+//  o0 = (c0==1) ? t : f0
+//  o1 = (c1==1) ? t : f1
+//       ...
+//  oN = (cN==1) ? t : fN
+//
+//                    lwe_array_out
+//                    (B blocks/entry)
+//                    ┌──┬──┬───┬──┐
+//                    │o0│o1│...│oN│
+//                    └──┴──┴───┴──┘
+template <typename Torus, typename KSTorus>
+__host__ void
+host_cmux_batch(CudaStreams streams, CudaRadixCiphertextFFI *lwe_array_out,
+                CudaRadixCiphertextFFI const *lwe_array_true,
+                CudaRadixCiphertextFFI const *lwe_array_false,
+                CudaRadixCiphertextFFI const *lwe_conditions,
+                int_cmux_batch_buffer<Torus> *mem_ptr, void *const *bsks,
+                KSTorus *const *ksks, uint32_t num_entries,
+                uint32_t num_blocks_per_ct, bool replicate_true = false) {
+
+  auto params = mem_ptr->params;
+  uint32_t total_num_blocks =
+      static_cast<uint32_t>(safe_mul(static_cast<size_t>(num_entries),
+                                     static_cast<size_t>(num_blocks_per_ct)));
+
+  cuda_set_device(streams.gpu_index(0));
+
+  // Step 1: pack bivariate CMUX inputs
+  // For each entry, put (true_value, condition) into the true branch and
+  // (false_value, condition) into the false branch.
+  CudaRadixCiphertextFFI packed_true, packed_false;
+  as_radix_ciphertext_slice<Torus>(&packed_true, mem_ptr->tmp_packed, 0,
+                                   total_num_blocks);
+  as_radix_ciphertext_slice<Torus>(&packed_false, mem_ptr->tmp_packed,
+                                   total_num_blocks, 2 * total_num_blocks);
+
+  host_pack_bivariate_blocks_with_per_ct_single_block<Torus>(
+      streams, &packed_true, lwe_array_true, lwe_conditions,
+      params.message_modulus, num_entries, num_blocks_per_ct, replicate_true);
+
+  host_pack_bivariate_blocks_with_per_ct_single_block<Torus>(
+      streams, &packed_false, lwe_array_false, lwe_conditions,
+      params.message_modulus, num_entries, num_blocks_per_ct);
+
+  // Step 2: evaluate CMUX predicate on both branches
+  // The LUT zeroes out the branch that does not match: true branch is zeroed
+  // where condition==0, false branch is zeroed where condition==1.
+  integer_radix_apply_univariate_lookup_table<Torus>(
+      streams, mem_ptr->buffer_out, mem_ptr->tmp_packed, bsks, ksks,
+      mem_ptr->predicate_lut, 2 * total_num_blocks);
+
+  // Step 3: combine branches
+  // Exactly one branch is non-zero per entry, so addition yields the CMUX
+  // result.
+  CudaRadixCiphertextFFI true_out, false_out;
+  as_radix_ciphertext_slice<Torus>(&true_out, mem_ptr->buffer_out, 0,
+                                   total_num_blocks);
+  as_radix_ciphertext_slice<Torus>(&false_out, mem_ptr->buffer_out,
+                                   total_num_blocks, 2 * total_num_blocks);
+
+  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), &true_out,
+                       &true_out, &false_out, total_num_blocks,
+                       params.message_modulus, params.carry_modulus);
+
+  // Step 4: message extraction
+  // Clean up noise and carry bits introduced by the addition.
+  integer_radix_apply_univariate_lookup_table<Torus>(
+      streams, lwe_array_out, &true_out, bsks, ksks,
+      mem_ptr->message_extract_lut, total_num_blocks);
+}
+
+template <typename Torus>
+__host__ uint64_t scratch_cuda_cmux_batch(
+    CudaStreams streams, int_cmux_batch_buffer<Torus> **mem_ptr,
+    std::function<Torus(Torus)> predicate_lut_f, uint32_t num_entries,
+    uint32_t num_blocks_per_ct, int_radix_params params,
+    bool allocate_gpu_memory) {
+  uint64_t size_tracker = 0;
+  *mem_ptr = new int_cmux_batch_buffer<Torus>(
+      streams, predicate_lut_f, params, num_entries, num_blocks_per_ct,
+      allocate_gpu_memory, size_tracker);
+  return size_tracker;
+}
 #endif

--- a/backends/tfhe-cuda-backend/cuda/src/integer/cmux.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/cmux.cuh
@@ -5,6 +5,10 @@
 #include "integer/cmux.h"
 #include "radix_ciphertext.cuh"
 
+// Conditionally zeros a radix ciphertext: if lwe_condition encrypts true,
+// lwe_array_out encrypts zero; otherwise lwe_array_out = lwe_array_input.
+// The condition is a single LWE block broadcast to every block of the input
+// via bivariate packing, then evaluated through the predicate LUT.
 template <typename Torus, typename KSTorus>
 __host__ void zero_out_if(CudaStreams streams,
                           CudaRadixCiphertextFFI *lwe_array_out,
@@ -39,6 +43,80 @@ __host__ void zero_out_if(CudaStreams streams,
   integer_radix_apply_univariate_lookup_table<Torus>(
       streams, lwe_array_out, tmp_lwe_array_input, bsks, ksks, predicate,
       num_radix_blocks);
+}
+
+/// @brief Applies zero_out_if to N ciphertexts in a single PBS call.
+///
+/// Each entry is zeroed when its corresponding encrypted boolean condition is
+/// true. The inputs and outputs are packed contiguously (num_entries *
+/// num_blocks_per_ct blocks).
+///
+/// @param lwe_array_out      Output radix ciphertext (num_entries *
+/// num_blocks_per_ct blocks)
+/// @param lwe_array_input    Input radix ciphertext (num_entries *
+/// num_blocks_per_ct blocks)
+/// @param lwe_conditions     Single-block encrypted boolean conditions, one per
+/// entry
+/// @param mem_ptr            Scratch buffer holding packed intermediates
+/// @param predicate          LUT that zeroes a block when the condition is true
+/// @param num_entries        Number of ciphertexts to process
+/// @param num_blocks_per_ct  Number of radix blocks per ciphertext
+template <typename Torus, typename KSTorus>
+__host__ void host_zero_out_if_batch(
+    CudaStreams streams, CudaRadixCiphertextFFI *lwe_array_out,
+    CudaRadixCiphertextFFI const *lwe_array_input,
+    CudaRadixCiphertextFFI const *lwe_conditions,
+    int_zero_out_if_batch_buffer<Torus> *mem_ptr,
+    int_radix_lut<Torus> *predicate, void *const *bsks, KSTorus *const *ksks,
+    uint32_t num_entries, uint32_t num_blocks_per_ct) {
+
+  uint32_t total_num_blocks =
+      static_cast<uint32_t>(safe_mul((size_t)num_entries, num_blocks_per_ct));
+
+  PANIC_IF_FALSE(
+      lwe_array_out->num_radix_blocks >= total_num_blocks &&
+          lwe_array_input->num_radix_blocks >= total_num_blocks,
+      "Cuda error: input or output radix ciphertexts does not have enough "
+      "blocks");
+
+  PANIC_IF_FALSE(
+      lwe_conditions->num_radix_blocks >= num_entries,
+      "Cuda error: conditions radix ciphertext does not have enough blocks");
+
+  PANIC_IF_FALSE(
+      lwe_array_out->lwe_dimension == lwe_array_input->lwe_dimension &&
+          lwe_array_input->lwe_dimension == lwe_conditions->lwe_dimension,
+      "Cuda error: input and output radix ciphertexts must have the same "
+      "lwe dimension");
+
+  cuda_set_device(streams.gpu_index(0));
+  auto params = mem_ptr->params;
+
+  auto tmp_lwe_array_input = mem_ptr->tmp;
+  host_pack_bivariate_blocks_with_per_ct_single_block<Torus>(
+      streams, tmp_lwe_array_input, lwe_array_input, lwe_conditions,
+      params.message_modulus, num_entries, num_blocks_per_ct);
+
+  integer_radix_apply_univariate_lookup_table<Torus>(
+      streams, lwe_array_out, tmp_lwe_array_input, bsks, ksks, predicate,
+      total_num_blocks);
+}
+
+/// @brief Allocates the scratch buffer for batched zero_out_if.
+///
+/// @param mem_ptr            Receives the allocated buffer pointer
+/// @param num_entries        Number of ciphertexts in the batch
+/// @param num_blocks_per_ct  Number of radix blocks per ciphertext
+template <typename Torus>
+__host__ uint64_t scratch_cuda_zero_out_if_batch(
+    CudaStreams streams, int_zero_out_if_batch_buffer<Torus> **mem_ptr,
+    uint32_t num_entries, uint32_t num_blocks_per_ct, int_radix_params params,
+    bool allocate_gpu_memory) {
+  uint64_t size_tracker = 0;
+  *mem_ptr = new int_zero_out_if_batch_buffer<Torus>(
+      streams, params, num_entries, num_blocks_per_ct, allocate_gpu_memory,
+      size_tracker);
+  return size_tracker;
 }
 
 template <typename Torus, typename KSTorus>
@@ -108,48 +186,25 @@ __host__ uint64_t scratch_cuda_cmux(CudaStreams streams,
   return size_tracker;
 }
 
-// Batched CMUX: for each of num_entries ciphertexts, selects lwe_array_true
-// where the condition is 1, lwe_array_false where the condition is 0.
-// Each condition in lwe_conditions is a single LWE block per entry.
-//
-// Default mode (replicate_true == false):
-//
-//  lwe_conditions   lwe_array_true     lwe_array_false
-//  (1 block each)   (B blocks/entry)   (B blocks/entry)
-//  ┌──┬──┬───┬──┐   ┌──┬──┬───┬──┐    ┌──┬──┬───┬──┐
-//  │c0│c1│...│cN│   │t0│t1│...│tN│    │f0│f1│...│fN│
-//  └──┴──┴───┴──┘   └──┴──┴───┴──┘    └──┴──┴───┴──┘
-//
-//  o0 = (c0==1) ? t0 : f0
-//  o1 = (c1==1) ? t1 : f1
-//       ...
-//  oN = (cN==1) ? tN : fN
-//
-//                    lwe_array_out
-//                    (B blocks/entry)
-//                    ┌──┬──┬───┬──┐
-//                    │o0│o1│...│oN│
-//                    └──┴──┴───┴──┘
-//
-// Replicate mode (replicate_true == true):
-// lwe_array_true is a single ciphertext of B blocks, reused for every entry.
-//
-//  lwe_conditions   lwe_array_true     lwe_array_false
-//  (1 block each)   (B blocks, shared)  (B blocks/entry)
-//  ┌──┬──┬───┬──┐   ┌──────┐            ┌──┬──┬───┬──┐
-//  │c0│c1│...│cN│   │  t   │            │f0│f1│...│fN│
-//  └──┴──┴───┴──┘   └──────┘            └──┴──┴───┴──┘
-//
-//  o0 = (c0==1) ? t : f0
-//  o1 = (c1==1) ? t : f1
-//       ...
-//  oN = (cN==1) ? t : fN
-//
-//                    lwe_array_out
-//                    (B blocks/entry)
-//                    ┌──┬──┬───┬──┐
-//                    │o0│o1│...│oN│
-//                    └──┴──┴───┴──┘
+/// @brief Batched CMUX: selects lwe_array_true or lwe_array_false per entry
+/// based on single-block encrypted boolean conditions.
+///
+/// In default mode each entry has its own true-branch ciphertext. In
+/// replicate mode (replicate_true == true), a single true-branch CT is
+/// broadcast to every entry.
+///
+/// @param lwe_array_out      Output radix ciphertext (num_entries *
+/// num_blocks_per_ct blocks)
+/// @param lwe_array_true     True-branch radix ciphertext(s)
+/// @param lwe_array_false    False-branch radix ciphertext(s)
+/// @param lwe_conditions     Single-block encrypted boolean conditions, one per
+/// entry
+/// @param mem_ptr            Scratch buffer holding packed intermediates and
+/// LUTs
+/// @param num_entries        Number of CMUX entries
+/// @param num_blocks_per_ct  Number of radix blocks per ciphertext
+/// @param replicate_true     When true, broadcast a single true-branch CT to
+/// all entries
 template <typename Torus, typename KSTorus>
 __host__ void
 host_cmux_batch(CudaStreams streams, CudaRadixCiphertextFFI *lwe_array_out,
@@ -169,20 +224,12 @@ host_cmux_batch(CudaStreams streams, CudaRadixCiphertextFFI *lwe_array_out,
 
   // Step 1: pack bivariate CMUX inputs
   // For each entry, put (true_value, condition) into the true branch and
-  // (false_value, condition) into the false branch.
-  CudaRadixCiphertextFFI packed_true, packed_false;
-  as_radix_ciphertext_slice<Torus>(&packed_true, mem_ptr->tmp_packed, 0,
-                                   total_num_blocks);
-  as_radix_ciphertext_slice<Torus>(&packed_false, mem_ptr->tmp_packed,
-                                   total_num_blocks, 2 * total_num_blocks);
-
-  host_pack_bivariate_blocks_with_per_ct_single_block<Torus>(
-      streams, &packed_true, lwe_array_true, lwe_conditions,
-      params.message_modulus, num_entries, num_blocks_per_ct, replicate_true);
-
-  host_pack_bivariate_blocks_with_per_ct_single_block<Torus>(
-      streams, &packed_false, lwe_array_false, lwe_conditions,
-      params.message_modulus, num_entries, num_blocks_per_ct);
+  // (false_value, condition) into the false branch. Both branches are packed
+  // into tmp_packed (true first, false second) in a single fused launch.
+  host_pack_bivariate_blocks_cmux_two_regions<Torus>(
+      streams, mem_ptr->tmp_packed, lwe_array_true, lwe_array_false,
+      lwe_conditions, params.message_modulus, num_entries, num_blocks_per_ct,
+      replicate_true);
 
   // Step 2: evaluate CMUX predicate on both branches
   // The LUT zeroes out the branch that does not match: true branch is zeroed
@@ -211,6 +258,13 @@ host_cmux_batch(CudaStreams streams, CudaRadixCiphertextFFI *lwe_array_out,
       mem_ptr->message_extract_lut, total_num_blocks);
 }
 
+/// @brief Allocates the scratch buffer for batched CMUX.
+///
+/// @param mem_ptr            Receives the allocated buffer pointer
+/// @param predicate_lut_f    Predicate function used to build the CMUX
+/// selection LUT
+/// @param num_entries        Number of CMUX entries in the batch
+/// @param num_blocks_per_ct  Number of radix blocks per ciphertext
 template <typename Torus>
 __host__ uint64_t scratch_cuda_cmux_batch(
     CudaStreams streams, int_cmux_batch_buffer<Torus> **mem_ptr,

--- a/backends/tfhe-cuda-backend/cuda/src/integer/cmux.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/cmux.cuh
@@ -222,25 +222,18 @@ host_cmux_batch(CudaStreams streams, CudaRadixCiphertextFFI *lwe_array_out,
 
   cuda_set_device(streams.gpu_index(0));
 
-  // Step 1: pack bivariate CMUX inputs
-  // For each entry, put (true_value, condition) into the true branch and
-  // (false_value, condition) into the false branch. Both branches are packed
-  // into tmp_packed (true first, false second) in a single fused launch.
+  // Step 1: pack bivariate CMUX inputs (true and false branches).
   host_pack_bivariate_blocks_cmux_two_regions<Torus>(
       streams, mem_ptr->tmp_packed, lwe_array_true, lwe_array_false,
       lwe_conditions, params.message_modulus, num_entries, num_blocks_per_ct,
       replicate_true);
 
-  // Step 2: evaluate CMUX predicate on both branches
-  // The LUT zeroes out the branch that does not match: true branch is zeroed
-  // where condition==0, false branch is zeroed where condition==1.
+  // Step 2: evaluate CMUX predicate, zeroing the non-selected branch.
   integer_radix_apply_univariate_lookup_table<Torus>(
       streams, mem_ptr->buffer_out, mem_ptr->tmp_packed, bsks, ksks,
       mem_ptr->predicate_lut, 2 * total_num_blocks);
 
-  // Step 3: combine branches
-  // Exactly one branch is non-zero per entry, so addition yields the CMUX
-  // result.
+  // Step 3: combine branches (exactly one is non-zero, so addition = select).
   CudaRadixCiphertextFFI true_out, false_out;
   as_radix_ciphertext_slice<Torus>(&true_out, mem_ptr->buffer_out, 0,
                                    total_num_blocks);
@@ -251,8 +244,7 @@ host_cmux_batch(CudaStreams streams, CudaRadixCiphertextFFI *lwe_array_out,
                        &true_out, &false_out, total_num_blocks,
                        params.message_modulus, params.carry_modulus);
 
-  // Step 4: message extraction
-  // Clean up noise and carry bits introduced by the addition.
+  // Step 4: message extraction (clean up noise/carry from the addition).
   integer_radix_apply_univariate_lookup_table<Torus>(
       streams, lwe_array_out, &true_out, bsks, ksks,
       mem_ptr->message_extract_lut, total_num_blocks);

--- a/backends/tfhe-cuda-backend/cuda/src/integer/integer.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/integer.cuh
@@ -653,6 +653,25 @@ __host__ void host_pack_bivariate_blocks_with_single_block(
   check_cuda_error(cudaGetLastError());
 }
 
+/// @brief Packs each LWE block with a per-ciphertext single-block condition
+/// for bivariate PBS evaluation.
+///
+/// For each output block, computes out = in * shift + condition, where the
+/// condition block is selected by the ciphertext index (one condition per
+/// entry). When replicate_input is true, the input is a single ciphertext
+/// reused across all entries.
+///
+/// @param lwe_array_out      Output packed LWE array
+/// @param lwe_array_in       Input LWE array (or single CT when
+/// replicate_input)
+/// @param lwe_conditions     Single-block conditions, one per entry
+/// @param lwe_dimension      LWE dimension (lwe_size = lwe_dimension + 1)
+/// @param shift              Multiplicative shift applied to the input block
+/// @param total_num_blocks   Total number of output blocks (num_entries *
+/// num_blocks_per_ct)
+/// @param num_blocks_per_ct  Number of radix blocks per ciphertext
+/// @param replicate_input    When true, reuse the first num_blocks_per_ct input
+/// blocks for every entry
 template <typename Torus>
 __global__ void device_pack_bivariate_blocks_with_per_ct_single_block(
     Torus *lwe_array_out, Torus const *lwe_array_in,
@@ -675,6 +694,130 @@ __global__ void device_pack_bivariate_blocks_with_per_ct_single_block(
   }
 }
 
+/// @brief Fused two-region bivariate packing for batched CMUX.
+///
+/// Packs both the true and false branch LWE arrays against the same
+/// conditions in a single kernel launch. The output layout is the true
+/// region (total_num_blocks blocks) followed by the false region
+/// (total_num_blocks blocks), matching two sequential calls to
+/// device_pack_bivariate_blocks_with_per_ct_single_block.
+///
+/// @param lwe_array_out      Output packed array (2 * total_num_blocks blocks)
+/// @param lwe_array_true     True-branch LWE array (or single CT when
+/// replicate_true)
+/// @param lwe_array_false    False-branch LWE array
+/// @param lwe_conditions     Single-block conditions, one per entry
+/// @param lwe_dimension      LWE dimension (lwe_size = lwe_dimension + 1)
+/// @param shift              Multiplicative shift applied to each input block
+/// @param total_num_blocks   Blocks per region (num_entries *
+/// num_blocks_per_ct)
+/// @param num_blocks_per_ct  Number of radix blocks per ciphertext
+/// @param replicate_true     When true, reuse a single true-branch CT for every
+/// entry
+template <typename Torus>
+__global__ void device_pack_bivariate_blocks_cmux_two_regions(
+    Torus *lwe_array_out, Torus const *lwe_array_true,
+    Torus const *lwe_array_false, Torus const *lwe_conditions,
+    uint32_t lwe_dimension, uint32_t shift, uint32_t total_num_blocks,
+    uint32_t num_blocks_per_ct, bool replicate_true) {
+  int tid = threadIdx.x + blockIdx.x * blockDim.x;
+  uint32_t lwe_size = lwe_dimension + 1;
+
+  if (tid < 2 * total_num_blocks * lwe_size) {
+    int global_block_id = tid / lwe_size;
+    int coeff_id = tid % lwe_size;
+
+    bool is_true_region = global_block_id < total_num_blocks;
+    int region_block_id =
+        is_true_region ? global_block_id : global_block_id - total_num_blocks;
+    int ct_idx = region_block_id / num_blocks_per_ct;
+
+    Torus const *lwe_array_in =
+        is_true_region ? lwe_array_true : lwe_array_false;
+    int in_block_id = (is_true_region && replicate_true)
+                          ? (region_block_id % num_blocks_per_ct)
+                          : region_block_id;
+
+    lwe_array_out[global_block_id * lwe_size + coeff_id] =
+        lwe_array_in[in_block_id * lwe_size + coeff_id] * shift +
+        lwe_conditions[ct_idx * lwe_size + coeff_id];
+  }
+}
+
+/// @brief Host wrapper that packs both CMUX branches into a single output
+/// buffer via device_pack_bivariate_blocks_cmux_two_regions.
+///
+/// @param lwe_array_out      Output packed radix ciphertext (2 * num_entries *
+/// num_blocks_per_ct blocks)
+/// @param lwe_array_true     True-branch radix ciphertext (or single CT when
+/// replicate_true)
+/// @param lwe_array_false    False-branch radix ciphertext
+/// @param lwe_conditions     Single-block encrypted conditions, one per entry
+/// @param shift              Multiplicative shift (typically message_modulus)
+/// @param num_entries        Number of CMUX entries to pack
+/// @param num_blocks_per_ct  Number of radix blocks per ciphertext
+/// @param replicate_true     When true, reuse a single true-branch CT for every
+/// entry
+template <typename Torus>
+__host__ void host_pack_bivariate_blocks_cmux_two_regions(
+    CudaStreams streams, CudaRadixCiphertextFFI *lwe_array_out,
+    CudaRadixCiphertextFFI const *lwe_array_true,
+    CudaRadixCiphertextFFI const *lwe_array_false,
+    CudaRadixCiphertextFFI const *lwe_conditions, uint32_t shift,
+    uint32_t num_entries, uint32_t num_blocks_per_ct, bool replicate_true) {
+
+  uint32_t total_num_blocks =
+      static_cast<uint32_t>(safe_mul(static_cast<size_t>(num_entries),
+                                     static_cast<size_t>(num_blocks_per_ct)));
+
+  PANIC_IF_FALSE(
+      lwe_array_out->num_radix_blocks >= 2 * total_num_blocks,
+      "Cuda error: output radix ciphertext does not have enough blocks");
+
+  uint32_t required_true_blocks =
+      replicate_true ? num_blocks_per_ct : total_num_blocks;
+  PANIC_IF_FALSE(
+      lwe_array_true->num_radix_blocks >= required_true_blocks,
+      "Cuda error: true-branch radix ciphertext does not have enough blocks");
+  PANIC_IF_FALSE(
+      lwe_array_false->num_radix_blocks >= total_num_blocks,
+      "Cuda error: false-branch radix ciphertext does not have enough blocks");
+  PANIC_IF_FALSE(
+      lwe_conditions->num_radix_blocks >= num_entries,
+      "Cuda error: conditions radix ciphertext does not have enough blocks");
+  PANIC_IF_FALSE(
+      lwe_array_out->lwe_dimension == lwe_array_true->lwe_dimension &&
+          lwe_array_true->lwe_dimension == lwe_array_false->lwe_dimension &&
+          lwe_array_false->lwe_dimension == lwe_conditions->lwe_dimension,
+      "Cuda error: input and output radix ciphertexts must have the same "
+      "lwe dimension");
+
+  auto lwe_dimension = lwe_array_out->lwe_dimension;
+  cuda_set_device(streams.gpu_index(0));
+  int num_blocks = 0, num_threads = 0;
+  int num_entries_kernel = 2 * total_num_blocks * (lwe_dimension + 1);
+  getNumBlocksAndThreads(num_entries_kernel, 512, num_blocks, num_threads);
+  device_pack_bivariate_blocks_cmux_two_regions<Torus>
+      <<<num_blocks, num_threads, 0, streams.stream(0)>>>(
+          (Torus *)lwe_array_out->ptr, (Torus *)lwe_array_true->ptr,
+          (Torus *)lwe_array_false->ptr, (Torus *)lwe_conditions->ptr,
+          lwe_dimension, shift, total_num_blocks, num_blocks_per_ct,
+          replicate_true);
+  check_cuda_error(cudaGetLastError());
+}
+
+/// @brief Host wrapper that packs input LWE blocks with per-ciphertext
+/// single-block conditions for bivariate PBS evaluation.
+///
+/// @param lwe_array_out      Output packed radix ciphertext
+/// @param lwe_array_in       Input radix ciphertext (or single CT when
+/// replicate_input)
+/// @param lwe_conditions     Single-block encrypted conditions, one per entry
+/// @param shift              Multiplicative shift (typically message_modulus)
+/// @param num_entries        Number of entries to pack
+/// @param num_blocks_per_ct  Number of radix blocks per ciphertext
+/// @param replicate_input    When true, reuse the first num_blocks_per_ct input
+/// blocks for every entry
 template <typename Torus>
 __host__ void host_pack_bivariate_blocks_with_per_ct_single_block(
     CudaStreams streams, CudaRadixCiphertextFFI *lwe_array_out,
@@ -691,10 +834,8 @@ __host__ void host_pack_bivariate_blocks_with_per_ct_single_block(
       lwe_array_out->num_radix_blocks >= total_num_blocks,
       "Cuda error: output radix ciphertext does not have enough blocks");
 
-  // When replicate_input is true, the kernel reuses the first num_blocks_per_ct
-  // input blocks for every entry instead of reading contiguously.
-  // Helpful in case lwe_array_in is actually a single ciphertext that needs to
-  // be packed with many conditions
+  // replicate_input: kernel reuses the first num_blocks_per_ct blocks for every
+  // entry, for packing one ciphertext against many conditions.
   uint32_t required_in_blocks =
       replicate_input ? num_blocks_per_ct : total_num_blocks;
   PANIC_IF_FALSE(
@@ -2895,6 +3036,188 @@ __host__ void host_cleartext_multiplication(
     output->degrees[i] = lwe_input->degrees[i] * cleartext_input;
     CHECK_NOISE_LEVEL(output->noise_levels[i], message_modulus, carry_modulus);
   }
+}
+
+/// @brief Pairwise in-place addition for one level of a binary tree fold.
+///
+/// Each thread adds data[idx + right_offset] onto data[idx] using a
+/// grid-stride loop, where the caller precomputes right_offset and
+/// total_elements so no per-element division is needed.
+///
+/// @param data            Flattened [entry][block][lwe_coeff] array (modified
+/// in place)
+/// @param right_offset    Offset in Torus words from left to right operand
+/// @param total_elements  Number of Torus words to process (left half only)
+template <typename Torus>
+__global__ void device_binary_tree_fold(Torus *__restrict__ data,
+                                        uint32_t right_offset,
+                                        uint32_t total_elements) {
+  uint32_t idx = threadIdx.x + blockIdx.x * blockDim.x;
+  uint32_t stride = blockDim.x * gridDim.x;
+  for (; idx < total_elements; idx += stride) {
+    data[idx] += data[idx + right_offset];
+  }
+}
+
+/// @brief Reduces num_entries one-hot radix ciphertexts into one via pairwise
+/// addition with identity PBS noise resets between rounds.
+///
+/// Uses a reserve-tail-and-absorb schedule to reach the full factor-M
+/// reduction per PBS round (M = max_degree), where plain binary folding
+/// would only achieve 2^floor(log2(M)).
+///
+/// @param output           Destination radix ciphertext (num_blocks blocks)
+/// @param input            Contiguous array of num_entries radix ciphertexts
+/// (modified in place)
+/// @param num_entries      Number of one-hot entries to reduce
+/// @param num_blocks       Number of radix blocks per entry
+/// @param identity_lut     Identity LUT used to reset noise after each round
+template <typename Torus>
+__host__ void host_binary_tree_fold_sum(
+    CudaStreams streams, CudaRadixCiphertextFFI *output,
+    CudaRadixCiphertextFFI *input, uint32_t num_entries, uint32_t num_blocks,
+    uint32_t message_modulus, uint32_t carry_modulus, void *const *bsks,
+    Torus *const *ksks, int_radix_lut<Torus> *identity_lut) {
+
+  auto stream = streams.stream(0);
+  auto gpu_index = streams.gpu_index(0);
+
+  if (num_entries == 0) {
+    set_zero_radix_ciphertext_slice_async<Torus>(stream, gpu_index, output, 0,
+                                                 num_blocks);
+    return;
+  }
+
+  cuda_set_device(gpu_index);
+
+  auto lwe_size = input->lwe_dimension + 1;
+  size_t entry_size_sz =
+      safe_mul(static_cast<size_t>(num_blocks), static_cast<size_t>(lwe_size));
+  // entry_size feeds the signed-int element count of getNumBlocksAndThreads
+  // (via total_elements), so it must fit in int.
+  bool entry_size_fits = entry_size_sz <= std::numeric_limits<int>::max();
+  PANIC_IF_FALSE(entry_size_fits,
+                 "Cuda error (binary_tree_fold_sum): entry size exceeds "
+                 "uint32_t range");
+  uint32_t entry_size = static_cast<uint32_t>(entry_size_sz);
+  auto *data = static_cast<Torus *>(input->ptr);
+
+  uint32_t max_noise =
+      (message_modulus * carry_modulus - 1) / (message_modulus - 1);
+  uint32_t fold_levels = log2_int(max_noise);
+  uint32_t extra = max_noise - (1u << fold_levels);
+
+  // Adds count entries starting at right_entry_start onto entries starting at
+  // 0.
+  auto fold = [&](uint32_t count, uint32_t right_entry_start) {
+    size_t total_elements_sz =
+        safe_mul(static_cast<size_t>(count), static_cast<size_t>(entry_size));
+    size_t right_offset_sz = safe_mul(static_cast<size_t>(right_entry_start),
+                                      static_cast<size_t>(entry_size));
+    // total_elements is the signed-int count for getNumBlocksAndThreads (must
+    // fit in int); right_offset only indexes uint32_t kernel addressing.
+    bool total_elements_fits =
+        total_elements_sz <= std::numeric_limits<int>::max();
+    bool right_offset_fits =
+        right_offset_sz <= std::numeric_limits<uint32_t>::max();
+    PANIC_IF_FALSE(total_elements_fits,
+                   "Cuda error (binary_tree_fold_sum): fold element count "
+                   "exceeds int range");
+    PANIC_IF_FALSE(right_offset_fits,
+                   "Cuda error (binary_tree_fold_sum): fold right offset "
+                   "exceeds uint32_t range");
+    uint32_t total_elements = static_cast<uint32_t>(total_elements_sz);
+    uint32_t right_offset = static_cast<uint32_t>(right_offset_sz);
+
+    // One thread per Torus word; getNumBlocksAndThreads caps the launch and the
+    // grid-stride loop covers any remainder.
+    int num_cuda_blocks = 0, num_threads = 0;
+    getNumBlocksAndThreads(total_elements, 512, num_cuda_blocks, num_threads);
+
+    device_binary_tree_fold<Torus><<<num_cuda_blocks, num_threads, 0, stream>>>(
+        data, right_offset, total_elements);
+    check_cuda_error(cudaGetLastError());
+  };
+
+  // Adds the right entry's per-block degree and noise onto the left entry and
+  // validates the resulting noise, mirroring the device-side fold.
+  auto update_metadata = [&](uint32_t left_entry, uint32_t right_entry) {
+    for (uint32_t b = 0; b < num_blocks; b++) {
+      uint32_t left_block = left_entry * num_blocks + b;
+      uint32_t right_block = right_entry * num_blocks + b;
+      input->degrees[left_block] += input->degrees[right_block];
+      input->noise_levels[left_block] += input->noise_levels[right_block];
+      CHECK_NOISE_LEVEL(input->noise_levels[left_block], message_modulus,
+                        carry_modulus);
+    }
+  };
+
+  uint32_t remaining = num_entries;
+
+  while (remaining > 1) {
+    uint32_t group_size = remaining / max_noise;
+    uint32_t reserved_tail = group_size * extra;
+    uint32_t front = remaining - reserved_tail;
+
+    uint32_t survivors = front;
+    for (uint32_t level = 0; level < fold_levels && survivors > 1; level++) {
+      uint32_t half = survivors / 2;
+      // Ceil semantics: the last entry of an odd front is left untouched at
+      // lower noise, which is strictly within budget.
+      uint32_t right_start = survivors - half;
+      for (uint32_t p = 0; p < half; p++)
+        update_metadata(p, right_start + p);
+      fold(half, right_start);
+      survivors = right_start;
+    }
+
+    // Fold each tail group onto the first group_size survivors.
+    // The guard skips the no-tail and power-of-two cases.
+    if (group_size > 0) {
+      for (uint32_t k = 0; k < extra; k++) {
+        uint32_t tail_start = front + k * group_size;
+        for (uint32_t p = 0; p < group_size; p++)
+          update_metadata(p, tail_start + p);
+        fold(group_size, tail_start);
+      }
+    }
+
+    remaining = survivors;
+
+    if (remaining > 1) {
+      uint32_t total_surviving_blocks = remaining * num_blocks;
+      CudaRadixCiphertextFFI survivors_slice;
+      as_radix_ciphertext_slice<Torus>(&survivors_slice, input, 0,
+                                       total_surviving_blocks);
+
+      integer_radix_apply_univariate_lookup_table<Torus>(
+          streams, &survivors_slice, &survivors_slice, bsks, ksks, identity_lut,
+          total_surviving_blocks);
+    }
+  }
+
+  CudaRadixCiphertextFFI final_slice;
+  as_radix_ciphertext_slice<Torus>(&final_slice, input, 0, num_blocks);
+  integer_radix_apply_univariate_lookup_table<Torus>(
+      streams, output, &final_slice, bsks, ksks, identity_lut, num_blocks);
+}
+
+/// @brief Reduces num_entries one-hot radix ciphertexts into a single sum.
+///
+/// @param output           Destination radix ciphertext
+/// @param input            Contiguous array of num_entries radix ciphertexts
+/// @param num_entries      Number of one-hot entries to reduce
+/// @param num_blocks       Number of radix blocks per entry
+/// @param identity_lut     Identity LUT for noise resets
+template <typename Torus>
+__host__ void host_binary_tree_fold_sum_dispatch(
+    CudaStreams streams, CudaRadixCiphertextFFI *output,
+    CudaRadixCiphertextFFI *input, uint32_t num_entries, uint32_t num_blocks,
+    uint32_t message_modulus, uint32_t carry_modulus, void *const *bsks,
+    Torus *const *ksks, int_radix_lut<Torus> *identity_lut) {
+  host_binary_tree_fold_sum<Torus>(streams, output, input, num_entries,
+                                   num_blocks, message_modulus, carry_modulus,
+                                   bsks, ksks, identity_lut);
 }
 
 #endif // TFHE_RS_INTERNAL_INTEGER_CUH

--- a/backends/tfhe-cuda-backend/cuda/src/integer/integer.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/integer.cuh
@@ -653,6 +653,74 @@ __host__ void host_pack_bivariate_blocks_with_single_block(
   check_cuda_error(cudaGetLastError());
 }
 
+template <typename Torus>
+__global__ void device_pack_bivariate_blocks_with_per_ct_single_block(
+    Torus *lwe_array_out, Torus const *lwe_array_in,
+    Torus const *lwe_conditions, uint32_t lwe_dimension, uint32_t shift,
+    uint32_t total_num_blocks, uint32_t num_blocks_per_ct,
+    bool replicate_input) {
+  int tid = threadIdx.x + blockIdx.x * blockDim.x;
+  uint32_t lwe_size = lwe_dimension + 1;
+
+  if (tid < total_num_blocks * lwe_size) {
+    int global_block_id = tid / lwe_size;
+    int coeff_id = tid % lwe_size;
+    int ct_idx = global_block_id / num_blocks_per_ct;
+    int in_block_id = replicate_input ? (global_block_id % num_blocks_per_ct)
+                                      : global_block_id;
+
+    lwe_array_out[global_block_id * lwe_size + coeff_id] =
+        lwe_array_in[in_block_id * lwe_size + coeff_id] * shift +
+        lwe_conditions[ct_idx * lwe_size + coeff_id];
+  }
+}
+
+template <typename Torus>
+__host__ void host_pack_bivariate_blocks_with_per_ct_single_block(
+    CudaStreams streams, CudaRadixCiphertextFFI *lwe_array_out,
+    CudaRadixCiphertextFFI const *lwe_array_in,
+    CudaRadixCiphertextFFI const *lwe_conditions, uint32_t shift,
+    uint32_t num_entries, uint32_t num_blocks_per_ct,
+    bool replicate_input = false) {
+
+  uint32_t total_num_blocks =
+      static_cast<uint32_t>(safe_mul(static_cast<size_t>(num_entries),
+                                     static_cast<size_t>(num_blocks_per_ct)));
+
+  PANIC_IF_FALSE(
+      lwe_array_out->num_radix_blocks >= total_num_blocks,
+      "Cuda error: output radix ciphertext does not have enough blocks");
+
+  // When replicate_input is true, the kernel reuses the first num_blocks_per_ct
+  // input blocks for every entry instead of reading contiguously.
+  // Helpful in case lwe_array_in is actually a single ciphertext that needs to
+  // be packed with many conditions
+  uint32_t required_in_blocks =
+      replicate_input ? num_blocks_per_ct : total_num_blocks;
+  PANIC_IF_FALSE(
+      lwe_array_in->num_radix_blocks >= required_in_blocks,
+      "Cuda error: input radix ciphertext does not have enough blocks");
+  PANIC_IF_FALSE(
+      lwe_conditions->num_radix_blocks >= num_entries,
+      "Cuda error: conditions radix ciphertext does not have enough blocks");
+  PANIC_IF_FALSE(
+      lwe_array_out->lwe_dimension == lwe_array_in->lwe_dimension &&
+          lwe_array_in->lwe_dimension == lwe_conditions->lwe_dimension,
+      "Cuda error: input and output radix ciphertexts must have the same "
+      "lwe dimension");
+
+  auto lwe_dimension = lwe_array_out->lwe_dimension;
+  cuda_set_device(streams.gpu_index(0));
+  int num_blocks = 0, num_threads = 0;
+  int num_entries_kernel = total_num_blocks * (lwe_dimension + 1);
+  getNumBlocksAndThreads(num_entries_kernel, 512, num_blocks, num_threads);
+  device_pack_bivariate_blocks_with_per_ct_single_block<Torus>
+      <<<num_blocks, num_threads, 0, streams.stream(0)>>>(
+          (Torus *)lwe_array_out->ptr, (Torus *)lwe_array_in->ptr,
+          (Torus *)lwe_conditions->ptr, lwe_dimension, shift, total_num_blocks,
+          num_blocks_per_ct, replicate_input);
+  check_cuda_error(cudaGetLastError());
+}
 /// num_radix_blocks corresponds to the number of blocks on which to apply the
 /// LUT In scalar bitops we use a number of blocks that may be lower or equal to
 /// the input and output numbers of blocks

--- a/backends/tfhe-cuda-backend/cuda/src/integer/integer.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/integer.cuh
@@ -834,8 +834,6 @@ __host__ void host_pack_bivariate_blocks_with_per_ct_single_block(
       lwe_array_out->num_radix_blocks >= total_num_blocks,
       "Cuda error: output radix ciphertext does not have enough blocks");
 
-  // replicate_input: kernel reuses the first num_blocks_per_ct blocks for every
-  // entry, for packing one ciphertext against many conditions.
   uint32_t required_in_blocks =
       replicate_input ? num_blocks_per_ct : total_num_blocks;
   PANIC_IF_FALSE(
@@ -3129,8 +3127,6 @@ __host__ void host_binary_tree_fold_sum(
     uint32_t total_elements = static_cast<uint32_t>(total_elements_sz);
     uint32_t right_offset = static_cast<uint32_t>(right_offset_sz);
 
-    // One thread per Torus word; getNumBlocksAndThreads caps the launch and the
-    // grid-stride loop covers any remainder.
     int num_cuda_blocks = 0, num_threads = 0;
     getNumBlocksAndThreads(total_elements, 512, num_cuda_blocks, num_threads);
 

--- a/backends/tfhe-cuda-backend/cuda/src/integer/kv_store/kv_store.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/kv_store/kv_store.cu
@@ -1,0 +1,255 @@
+#include "integer/kv_store/kv_store.cuh"
+
+uint64_t scratch_cuda_kv_store_get_64_async(
+    CudaStreamsFFI streams, int8_t **mem_ptr,
+    CudaLweBootstrapKeyParamsFFI bsk_params,
+    CudaLweKeyswitchKeyParamsFFI ksk_params, uint32_t num_entries,
+    uint32_t num_key_blocks, uint32_t num_value_blocks,
+    uint32_t message_modulus, uint32_t carry_modulus, bool allocate_gpu_memory,
+    PBS_MS_REDUCTION_T noise_reduction_type) {
+
+  PUSH_RANGE("scratch kv_store_get")
+
+  int_radix_params params(bsk_params, ksk_params, message_modulus,
+                          carry_modulus, noise_reduction_type);
+
+  auto size = scratch_cuda_kv_store_get<uint64_t>(
+      CudaStreams(streams), (int_kv_store_get_buffer<uint64_t> **)mem_ptr,
+      params, num_entries, num_key_blocks, num_value_blocks,
+      allocate_gpu_memory);
+
+  POP_RANGE()
+  return size;
+}
+
+void cuda_kv_store_get_64_async(
+    CudaStreamsFFI streams, CudaRadixCiphertextFFI *lwe_array_out_result,
+    CudaRadixCiphertextFFI *lwe_array_out_boolean,
+    CudaRadixCiphertextFFI *lwe_array_out_selectors,
+    CudaRadixCiphertextFFI const *lwe_array_in_encrypted_key,
+    CudaRadixCiphertextFFI const *lwe_array_in_values,
+    const uint64_t *h_decomposed_clear_keys, int8_t *mem, void *const *bsks,
+    void *const *ksks) {
+
+  PUSH_RANGE("kv_store_get")
+
+  PANIC_IF_FALSE(lwe_array_out_result != lwe_array_in_encrypted_key,
+                 "Output result and encrypted key pointers must be different "
+                 "for out-of-place operations");
+  PANIC_IF_FALSE(lwe_array_out_boolean != lwe_array_in_encrypted_key,
+                 "Output boolean and encrypted key pointers must be different "
+                 "for out-of-place operations");
+  PANIC_IF_FALSE(lwe_array_out_result != lwe_array_out_boolean,
+                 "Result and boolean output pointers must be different for "
+                 "out-of-place operations");
+
+  host_kv_store_get<uint64_t>(
+      CudaStreams(streams), lwe_array_out_result, lwe_array_out_boolean,
+      lwe_array_out_selectors, lwe_array_in_encrypted_key, lwe_array_in_values,
+      h_decomposed_clear_keys, (int_kv_store_get_buffer<uint64_t> *)mem, bsks,
+      (uint64_t *const *)ksks);
+
+  POP_RANGE()
+}
+
+void cleanup_cuda_kv_store_get_64(CudaStreamsFFI streams,
+                                  int8_t **mem_ptr_void) {
+  PUSH_RANGE("cleanup kv_store_get")
+
+  int_kv_store_get_buffer<uint64_t> *mem_ptr =
+      (int_kv_store_get_buffer<uint64_t> *)(*mem_ptr_void);
+
+  mem_ptr->release(CudaStreams(streams));
+
+  delete mem_ptr;
+  *mem_ptr_void = nullptr;
+
+  POP_RANGE()
+}
+
+uint64_t scratch_cuda_kv_store_update_64_async(
+    CudaStreamsFFI streams, int8_t **mem_ptr,
+    CudaLweBootstrapKeyParamsFFI bsk_params,
+    CudaLweKeyswitchKeyParamsFFI ksk_params, uint32_t num_entries,
+    uint32_t num_key_blocks, uint32_t num_value_blocks,
+    uint32_t message_modulus, uint32_t carry_modulus, bool allocate_gpu_memory,
+    PBS_MS_REDUCTION_T noise_reduction_type) {
+
+  PUSH_RANGE("scratch kv_store_update")
+
+  int_radix_params params(bsk_params, ksk_params, message_modulus,
+                          carry_modulus, noise_reduction_type);
+
+  auto size = scratch_cuda_kv_store_update<uint64_t>(
+      CudaStreams(streams), (int_kv_store_update_buffer<uint64_t> **)mem_ptr,
+      params, num_entries, num_key_blocks, num_value_blocks,
+      allocate_gpu_memory);
+
+  POP_RANGE()
+  return size;
+}
+
+void cuda_kv_store_update_64_async(
+    CudaStreamsFFI streams, CudaRadixCiphertextFFI *lwe_check_out_block,
+    CudaRadixCiphertextFFI *lwe_array_out_values,
+    CudaRadixCiphertextFFI const *lwe_array_in_encrypted_key,
+    CudaRadixCiphertextFFI const *lwe_array_in_values,
+    CudaRadixCiphertextFFI const *lwe_in_new_value,
+    const uint64_t *h_decomposed_clear_keys, int8_t *mem_ptr, void *const *bsks,
+    void *const *ksks) {
+
+  PUSH_RANGE("kv_store_update")
+
+  PANIC_IF_FALSE(lwe_array_out_values != lwe_array_in_values,
+                 "Output and input values pointers must be different for "
+                 "out-of-place operations");
+  PANIC_IF_FALSE(lwe_check_out_block != lwe_in_new_value,
+                 "Output and new value pointers must be different for "
+                 "out-of-place operations");
+
+  host_kv_store_update<uint64_t>(
+      CudaStreams(streams), lwe_check_out_block, lwe_array_out_values,
+      lwe_array_in_encrypted_key, lwe_array_in_values, lwe_in_new_value,
+      h_decomposed_clear_keys, (int_kv_store_update_buffer<uint64_t> *)mem_ptr,
+      bsks, (uint64_t *const *)ksks);
+
+  POP_RANGE()
+}
+
+void cleanup_cuda_kv_store_update_64(CudaStreamsFFI streams,
+                                     int8_t **mem_ptr_void) {
+  PUSH_RANGE("cleanup kv_store_update")
+
+  int_kv_store_update_buffer<uint64_t> *mem_ptr =
+      (int_kv_store_update_buffer<uint64_t> *)(*mem_ptr_void);
+
+  mem_ptr->release(CudaStreams(streams));
+
+  delete mem_ptr;
+  *mem_ptr_void = nullptr;
+
+  POP_RANGE()
+}
+
+uint64_t scratch_cuda_kv_store_map_64_async(
+    CudaStreamsFFI streams, int8_t **mem_ptr,
+    CudaLweBootstrapKeyParamsFFI bsk_params,
+    CudaLweKeyswitchKeyParamsFFI ksk_params, uint32_t num_entries,
+    uint32_t num_value_blocks, uint32_t message_modulus, uint32_t carry_modulus,
+    bool allocate_gpu_memory, PBS_MS_REDUCTION_T noise_reduction_type) {
+
+  PUSH_RANGE("scratch kv_store_map")
+
+  int_radix_params params(bsk_params, ksk_params, message_modulus,
+                          carry_modulus, noise_reduction_type);
+
+  auto size = scratch_cuda_kv_store_map<uint64_t>(
+      CudaStreams(streams), (int_kv_store_map_buffer<uint64_t> **)mem_ptr,
+      params, num_entries, num_value_blocks, allocate_gpu_memory);
+
+  POP_RANGE()
+  return size;
+}
+
+void cuda_kv_store_map_64_async(
+    CudaStreamsFFI streams, CudaRadixCiphertextFFI *lwe_check_out_block,
+    CudaRadixCiphertextFFI *lwe_array_out_values,
+    CudaRadixCiphertextFFI const *lwe_array_in_values,
+    CudaRadixCiphertextFFI const *lwe_in_new_value,
+    CudaRadixCiphertextFFI const *lwe_array_in_selectors, int8_t *mem_ptr,
+    void *const *bsks, void *const *ksks) {
+
+  PUSH_RANGE("kv_store_map")
+
+  PANIC_IF_FALSE(lwe_array_out_values != lwe_array_in_values,
+                 "Output and input values pointers must be different for "
+                 "out-of-place operations");
+
+  PANIC_IF_FALSE(lwe_check_out_block != lwe_in_new_value,
+                 "Output and new value pointers must be different for "
+                 "out-of-place operations");
+
+  PANIC_IF_FALSE(lwe_check_out_block != lwe_array_in_selectors,
+                 "Check output and selectors pointers must be different for "
+                 "out-of-place operations");
+
+  host_kv_store_map<uint64_t>(CudaStreams(streams), lwe_check_out_block,
+                              lwe_array_out_values, lwe_array_in_values,
+                              lwe_in_new_value, lwe_array_in_selectors,
+                              (int_kv_store_map_buffer<uint64_t> *)mem_ptr,
+                              bsks, (uint64_t *const *)ksks);
+
+  POP_RANGE()
+}
+
+void cleanup_cuda_kv_store_map_64(CudaStreamsFFI streams,
+                                  int8_t **mem_ptr_void) {
+  PUSH_RANGE("cleanup kv_store_map")
+
+  int_kv_store_map_buffer<uint64_t> *mem_ptr =
+      (int_kv_store_map_buffer<uint64_t> *)(*mem_ptr_void);
+
+  mem_ptr->release(CudaStreams(streams));
+
+  delete mem_ptr;
+  *mem_ptr_void = nullptr;
+
+  POP_RANGE()
+}
+
+uint64_t scratch_cuda_kv_store_contains_key_64_async(
+    CudaStreamsFFI streams, int8_t **mem_ptr,
+    CudaLweBootstrapKeyParamsFFI bsk_params,
+    CudaLweKeyswitchKeyParamsFFI ksk_params, uint32_t num_entries,
+    uint32_t num_key_blocks, uint32_t message_modulus, uint32_t carry_modulus,
+    bool allocate_gpu_memory, PBS_MS_REDUCTION_T noise_reduction_type) {
+
+  PUSH_RANGE("scratch kv_store_contains_key")
+
+  int_radix_params params(bsk_params, ksk_params, message_modulus,
+                          carry_modulus, noise_reduction_type);
+
+  auto size = scratch_cuda_kv_store_contains_key<uint64_t>(
+      CudaStreams(streams),
+      (int_kv_store_contains_key_buffer<uint64_t> **)mem_ptr, params,
+      num_entries, num_key_blocks, allocate_gpu_memory);
+
+  POP_RANGE()
+  return size;
+}
+
+void cuda_kv_store_contains_key_64_async(
+    CudaStreamsFFI streams, CudaRadixCiphertextFFI *lwe_array_out_boolean,
+    CudaRadixCiphertextFFI const *lwe_array_in_encrypted_key,
+    const uint64_t *h_decomposed_clear_keys, int8_t *mem_ptr, void *const *bsks,
+    void *const *ksks) {
+
+  PUSH_RANGE("kv_store_contains_key")
+
+  PANIC_IF_FALSE(lwe_array_out_boolean != lwe_array_in_encrypted_key,
+                 "Output boolean and encrypted key pointers must be different "
+                 "for out-of-place operations");
+
+  host_kv_store_contains_key<uint64_t>(
+      CudaStreams(streams), lwe_array_out_boolean, lwe_array_in_encrypted_key,
+      h_decomposed_clear_keys,
+      (int_kv_store_contains_key_buffer<uint64_t> *)mem_ptr, bsks,
+      (uint64_t *const *)ksks);
+
+  POP_RANGE()
+}
+
+void cleanup_cuda_kv_store_contains_key_64(CudaStreamsFFI streams,
+                                           int8_t **mem_ptr_void) {
+  PUSH_RANGE("cleanup kv_store_contains_key")
+
+  int_kv_store_contains_key_buffer<uint64_t> *mem_ptr =
+      (int_kv_store_contains_key_buffer<uint64_t> *)(*mem_ptr_void);
+
+  mem_ptr->release(CudaStreams(streams));
+
+  delete mem_ptr;
+  *mem_ptr_void = nullptr;
+
+  POP_RANGE()
+}

--- a/backends/tfhe-cuda-backend/cuda/src/integer/kv_store/kv_store.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/kv_store/kv_store.cuh
@@ -53,28 +53,50 @@ __global__ void device_accumulate_all_blocks_batched(
 
 /// @brief Host wrapper launching device_accumulate_all_blocks_batched.
 ///
-/// @param output                Output buffer receiving one accumulated block
-/// per
-///                              (entry, chunk) pair
-/// @param input                 Input LWE blocks in row-major layout
-/// @param lwe_dimension         LWE dimension (number of mask coefficients)
+/// @param output                Output ciphertext receiving one accumulated
+///                              block per (entry, chunk) pair
+/// @param input                 Input ciphertext with LWE blocks in row-major
+///                              layout (entries x blocks_per_entry)
 /// @param blocks_per_entry      Number of input LWE blocks per map entry
 /// @param max_value             Maximum chunk length (accumulation width)
 /// @param num_entries           Number of map entries being processed
 /// @param num_chunks_per_entry  Number of chunks each entry is split into
+/// @param message_modulus       Message modulus for noise-level validation
+/// @param carry_modulus         Carry modulus for noise-level validation
 template <typename Torus>
 __host__ void host_accumulate_all_blocks_batched(
-    cudaStream_t stream, uint32_t gpu_index, Torus *output, Torus const *input,
-    uint32_t lwe_dimension, uint32_t blocks_per_entry, uint32_t max_value,
-    uint32_t num_entries, uint32_t num_chunks_per_entry) {
+    cudaStream_t stream, uint32_t gpu_index, CudaRadixCiphertextFFI *output,
+    CudaRadixCiphertextFFI const *input, uint32_t blocks_per_entry,
+    uint32_t max_value, uint32_t num_entries, uint32_t num_chunks_per_entry,
+    uint32_t message_modulus, uint32_t carry_modulus) {
   cuda_set_device(gpu_index);
+  uint32_t lwe_dimension = input->lwe_dimension;
   int num_blocks_x = 0, num_threads = 0;
   getNumBlocksAndThreads(lwe_dimension + 1, 512, num_blocks_x, num_threads);
   dim3 grid(num_blocks_x, num_entries * num_chunks_per_entry);
   device_accumulate_all_blocks_batched<Torus><<<grid, num_threads, 0, stream>>>(
-      output, input, lwe_dimension, blocks_per_entry, max_value,
-      num_chunks_per_entry);
+      (Torus *)output->ptr, (Torus const *)input->ptr, lwe_dimension,
+      blocks_per_entry, max_value, num_chunks_per_entry);
   check_cuda_error(cudaGetLastError());
+
+  for (uint32_t flat = 0; flat < num_entries * num_chunks_per_entry; flat++) {
+    uint32_t entry_idx = flat / num_chunks_per_entry;
+    uint32_t chunk_idx = flat % num_chunks_per_entry;
+    uint32_t chunk_start = chunk_idx * max_value;
+    uint32_t chunk_length = std::min(max_value, blocks_per_entry - chunk_start);
+
+    uint64_t total_degree = 0;
+    uint64_t total_noise = NoiseLevel::ZERO;
+    for (uint32_t i = 0; i < chunk_length; i++) {
+      uint32_t src = entry_idx * blocks_per_entry + chunk_start + i;
+      total_degree += input->degrees[src];
+      total_noise += input->noise_levels[src];
+    }
+    output->degrees[flat] = total_degree;
+    output->noise_levels[flat] = total_noise;
+    CHECK_NOISE_LEVEL(output->noise_levels[flat], message_modulus,
+                      carry_modulus);
+  }
 }
 
 /// @brief Computes per-entry equality selectors using the small-map tree
@@ -142,17 +164,14 @@ __host__ void host_kv_store_compute_eq_selectors_small_map(
   uint32_t message_modulus = mem_ptr->params.message_modulus;
   uint32_t big_lwe_dimension = mem_ptr->params.big_lwe_dimension;
 
-  // Step 1: Grid PBS — precompute all per-block equality indicators.
-  // One batched PBS builds a message_modulus x num_blocks grid where
-  // grid[v][j] = Enc(input_block_j == v).
+  // Step 1: Grid PBS — one indicator per (block_value, block_position) pair.
   integer_radix_apply_many_univariate_lookup_table<Torus>(
       streams, &mem_ptr->tmp_many_luts_output, lwe_array_in, bsks,
       (Torus *const *)ksks, mem_ptr->comparison_luts, message_modulus,
       mem_ptr->lut_stride);
 
-  // Step 2: Gather — for each candidate i, extract its comparison blocks
-  // from the grid PBS output into a flat row-major buffer:
-  //   batched[i * num_blocks + j] = grid[decomposed[i][j]][j]
+  // Step 2: Gather — extract each candidate's comparison blocks from the
+  // grid into a flat row-major buffer.
   Torus *h_map = mem_ptr->h_map;
   uint32_t total_blocks = num_possible_values * num_blocks;
   for (uint32_t i = 0; i < num_possible_values; i++) {
@@ -183,16 +202,16 @@ __host__ void host_kv_store_compute_eq_selectors_small_map(
     return;
   }
 
-  // Step 3: Batched tree reduction — AND-reduce the per-entry comparison
-  // blocks using host_accumulate_all_blocks_batched + is_max_value PBS.
-  // The data is in row-major layout: entry_i occupies blocks
-  // [i*num_blocks .. (i+1)*num_blocks).
+  // Step 3: Batched tree reduction — AND-reduce each entry's comparison
+  // blocks into a single boolean.
   uint32_t max_value = mem_ptr->max_value;
   auto is_max_value_lut = mem_ptr->is_max_value_lut;
   auto tree_accumulator = mem_ptr->tree_accumulator;
   auto tree_pbs_output = mem_ptr->tree_pbs_output;
 
-  Torus *current_input_ptr = (Torus *)mem_ptr->tmp_batched_comparisons.ptr;
+  CudaRadixCiphertextFFI const *current_input =
+      &mem_ptr->tmp_batched_comparisons;
+  uint32_t carry_modulus = mem_ptr->params.carry_modulus;
   uint32_t blocks_per_entry = num_blocks;
   uint32_t level = 0;
 
@@ -201,20 +220,12 @@ __host__ void host_kv_store_compute_eq_selectors_small_map(
     uint32_t total_chunks = num_possible_values * num_chunks;
 
     host_accumulate_all_blocks_batched<Torus>(
-        streams.stream(0), streams.gpu_index(0), (Torus *)tree_accumulator->ptr,
-        current_input_ptr, big_lwe_dimension, blocks_per_entry, max_value,
-        num_possible_values, num_chunks);
+        streams.stream(0), streams.gpu_index(0), tree_accumulator,
+        current_input, blocks_per_entry, max_value, num_possible_values,
+        num_chunks, message_modulus, carry_modulus);
 
-    for (uint32_t flat = 0; flat < total_chunks; flat++) {
-      uint32_t chunk = flat % num_chunks;
-      uint32_t chunk_start = chunk * max_value;
-      uint32_t chunk_len = std::min(max_value, blocks_per_entry - chunk_start);
-      tree_accumulator->degrees[flat] = chunk_len;
-      tree_accumulator->noise_levels[flat] = NoiseLevel::NOMINAL;
-    }
-
-    // Switch to this level's precomputed index buffer (slots baked at scratch
-    // time): a small gpu-to-gpu copy plus broadcast, no per-level LUT regen.
+    // Use this level's precomputed LUT-index buffer instead of regenerating
+    // the LUT per level.
     auto active =
         streams.active_gpu_subset(total_chunks, mem_ptr->params.pbs_type);
     is_max_value_lut->set_lut_indexes_and_broadcast_from_gpu(
@@ -224,12 +235,12 @@ __host__ void host_kv_store_compute_eq_selectors_small_map(
         streams, tree_pbs_output, tree_accumulator, bsks, ksks,
         is_max_value_lut, total_chunks);
 
-    current_input_ptr = (Torus *)tree_pbs_output->ptr;
+    current_input = tree_pbs_output;
     blocks_per_entry = num_chunks;
     level++;
   }
 
-  CudaRadixCiphertextFFI *result_source =
+  CudaRadixCiphertextFFI const *result_source =
       (blocks_per_entry == num_blocks) ? &mem_ptr->tmp_batched_comparisons
                                        : tree_pbs_output;
   copy_radix_ciphertext_slice_async<Torus>(
@@ -318,8 +329,7 @@ host_kv_store_get(CudaStreams streams,
       bsks, ksks);
   POP_RANGE()
 
-  // Step 2: one-hot vector, zeroing every value whose selector is 0 so only the
-  // matched value (if any) survives.
+  // Step 2: zero values whose selector is 0, keeping only the matched value.
   PUSH_RANGE("get: one-hot vector")
   auto lwe_one_hot_vector = tmp_cmux_array;
   host_zero_out_if_batch(streams, lwe_one_hot_vector, lwe_array_in_values,
@@ -422,8 +432,7 @@ host_kv_store_update(CudaStreams streams,
       ksks);
   POP_RANGE()
 
-  // Step 2: batched CMUX selecting new_value where selector==1, old otherwise.
-  // The true branch (new_value) is replicated across all entries.
+  // Step 2: batched CMUX — replace value where selector==1, keep old otherwise.
   PUSH_RANGE("update: batched cmux")
   host_cmux_batch<Torus, KSTorus>(
       streams, lwe_array_out_values, lwe_in_new_value, lwe_array_in_values,
@@ -510,8 +519,7 @@ host_kv_store_map(CudaStreams streams,
 
   cuda_set_device(streams.gpu_index(0));
 
-  // Batched CMUX selecting new_value where selector==1, old otherwise. The true
-  // branch (new_value) is replicated across all entries.
+  // Batched CMUX — replace value where selector==1, keep old otherwise.
   PUSH_RANGE("map: batched cmux")
   host_cmux_batch<Torus, KSTorus>(
       streams, lwe_array_out_values, lwe_in_new_value, lwe_array_in_values,

--- a/backends/tfhe-cuda-backend/cuda/src/integer/kv_store/kv_store.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/kv_store/kv_store.cuh
@@ -1,0 +1,607 @@
+#pragma once
+
+#include "helper_profile.cuh"
+#include "integer/cmux.cuh"
+#include "integer/comparison.cuh"
+#include "integer/integer.cuh"
+#include "integer/kv_store/kv_store.h"
+#include "integer/kv_store/kv_store_utilities.h"
+#include "integer/vector_find.cuh"
+
+/// @brief Accumulates chunks of LWE blocks for multiple entries in a single
+/// kernel.
+///
+/// Each CUDA block (in the y-dimension) handles one (entry, chunk) pair,
+/// summing chunk_length adjacent LWE blocks element-wise into one output block.
+///
+/// @param output                Output buffer receiving one accumulated block
+/// per
+///                              (entry, chunk) pair
+/// @param input                 Input LWE blocks in row-major layout (entries x
+///                              blocks_per_entry)
+/// @param lwe_dimension         LWE dimension (number of mask coefficients)
+/// @param blocks_per_entry      Number of input LWE blocks per map entry
+/// @param max_value             Maximum chunk length (accumulation width)
+/// @param num_chunks_per_entry  Number of chunks each entry is split into
+template <typename Torus>
+__global__ void device_accumulate_all_blocks_batched(
+    Torus *output, Torus const *input, uint32_t lwe_dimension,
+    uint32_t blocks_per_entry, uint32_t max_value,
+    uint32_t num_chunks_per_entry) {
+  uint32_t lwe_idx = threadIdx.x + blockIdx.x * blockDim.x;
+  if (lwe_idx >= lwe_dimension + 1)
+    return;
+
+  uint32_t chunk_flat_idx = blockIdx.y;
+  uint32_t entry_idx = chunk_flat_idx / num_chunks_per_entry;
+  uint32_t chunk_idx = chunk_flat_idx % num_chunks_per_entry;
+
+  uint32_t chunk_start = chunk_idx * max_value;
+  uint32_t chunk_length = min(max_value, blocks_per_entry - chunk_start);
+
+  uint32_t stride = lwe_dimension + 1;
+  Torus const *base =
+      &input[(entry_idx * blocks_per_entry + chunk_start) * stride];
+
+  Torus sum = base[lwe_idx];
+  for (uint32_t i = 1; i < chunk_length; i++) {
+    sum += base[lwe_idx + i * stride];
+  }
+
+  output[chunk_flat_idx * stride + lwe_idx] = sum;
+}
+
+/// @brief Host wrapper launching device_accumulate_all_blocks_batched.
+///
+/// @param output                Output buffer receiving one accumulated block
+/// per
+///                              (entry, chunk) pair
+/// @param input                 Input LWE blocks in row-major layout
+/// @param lwe_dimension         LWE dimension (number of mask coefficients)
+/// @param blocks_per_entry      Number of input LWE blocks per map entry
+/// @param max_value             Maximum chunk length (accumulation width)
+/// @param num_entries           Number of map entries being processed
+/// @param num_chunks_per_entry  Number of chunks each entry is split into
+template <typename Torus>
+__host__ void host_accumulate_all_blocks_batched(
+    cudaStream_t stream, uint32_t gpu_index, Torus *output, Torus const *input,
+    uint32_t lwe_dimension, uint32_t blocks_per_entry, uint32_t max_value,
+    uint32_t num_entries, uint32_t num_chunks_per_entry) {
+  cuda_set_device(gpu_index);
+  int num_blocks_x = 0, num_threads = 0;
+  getNumBlocksAndThreads(lwe_dimension + 1, 512, num_blocks_x, num_threads);
+  dim3 grid(num_blocks_x, num_entries * num_chunks_per_entry);
+  device_accumulate_all_blocks_batched<Torus><<<grid, num_threads, 0, stream>>>(
+      output, input, lwe_dimension, blocks_per_entry, max_value,
+      num_chunks_per_entry);
+  check_cuda_error(cudaGetLastError());
+}
+
+/// @brief Computes per-entry equality selectors using the small-map tree
+/// algorithm.
+///
+/// Given one encrypted radix ciphertext (num_blocks blocks, each a digit in
+/// [0, message_modulus)) and N cleartext candidates (the clear kv_store keys),
+/// produces N encrypted booleans: selector_i = Enc(input == candidate_i).
+///
+/// Candidates live in h_decomposed_cleartexts, a flat array where candidate i
+/// occupies [i*num_blocks .. (i+1)*num_blocks). N =
+/// mem_ptr->num_possible_values.
+///
+/// A per-candidate approach costs N * num_blocks PBS. Since there are only
+/// message_modulus possible digit values (typically 2 or 4), we instead
+/// precompute all per-block comparisons in one batched PBS, then let each
+/// candidate pick the results it needs via memcpy:
+///
+/// Step 1: One batched PBS builds a message_modulus x num_blocks grid:
+///
+///                       block 0    block 1    block 2
+///                     +----------+----------+----------+
+///     LUT for v=0     | b0==0?   | b1==0?   | b2==0?   |
+///     LUT for v=1     | b0==1?   | b1==1?   | b2==1?   |
+///     LUT for v=2     | b0==2?   | b1==2?   | b2==2?   |
+///     LUT for v=3     | b0==3?   | b1==3?   | b2==3?   |
+///                     +----------+----------+----------+
+///     Flat: tmp_many_luts_output[v * num_blocks + j]
+///
+/// Step 2: For each candidate i with digits [d0, d1, ..], gather grid[dj][j]
+///   for all j into a flat N*num_blocks buffer.
+///
+/// Step 3: AND-reduce across all candidates simultaneously using a batched
+///   tree: at each level, accumulate chunks and apply one large batched PBS.
+///   This replaces per-candidate AND-trees with 2 batched PBS calls (for
+///   typical 2_2 params with 16-block keys).
+///
+/// This is the few-entries kv_store variant; see
+/// KV_STORE_EQ_SELECTORS_SMALL_MAP_MAX_ENTRIES for when it is preferred over
+/// vector_find's host_compute_eq_selectors_ct_vs_clears.
+///
+/// @param lwe_array_out_packed       Output ciphertext: N single-block boolean
+///                                   selectors packed contiguously
+/// @param lwe_array_in               Input encrypted radix key
+/// @param num_blocks                 Number of radix blocks in the input key
+/// @param h_decomposed_cleartexts    Host flat array of candidate digit values
+///                                   (N * num_blocks)
+/// @param mem_ptr                    Scratch buffer holding LUTs, gather maps,
+///                                   and tree buffers
+template <typename Torus>
+__host__ void host_kv_store_compute_eq_selectors_small_map(
+    CudaStreams streams, CudaRadixCiphertextFFI *lwe_array_out_packed,
+    CudaRadixCiphertextFFI const *lwe_array_in, uint32_t num_blocks,
+    const uint64_t *h_decomposed_cleartexts,
+    int_kv_store_eq_selectors_small_map_buffer<Torus> *mem_ptr,
+    void *const *bsks, Torus *const *ksks) {
+
+  // num_blocks == 0 would yield an all-zero selector matrix instead of the
+  // trivial all-match, so require at least one block (matching the vector_find
+  // dispatch guard so both variants agree).
+  GPU_ASSERT(num_blocks >= 1, "num_blocks must be at least 1 in "
+                              "host_kv_store_compute_eq_selectors_small_map");
+
+  uint32_t num_possible_values = mem_ptr->num_possible_values;
+  uint32_t message_modulus = mem_ptr->params.message_modulus;
+  uint32_t big_lwe_dimension = mem_ptr->params.big_lwe_dimension;
+
+  // Step 1: Grid PBS — precompute all per-block equality indicators.
+  // One batched PBS builds a message_modulus x num_blocks grid where
+  // grid[v][j] = Enc(input_block_j == v).
+  integer_radix_apply_many_univariate_lookup_table<Torus>(
+      streams, &mem_ptr->tmp_many_luts_output, lwe_array_in, bsks,
+      (Torus *const *)ksks, mem_ptr->comparison_luts, message_modulus,
+      mem_ptr->lut_stride);
+
+  // Step 2: Gather — for each candidate i, extract its comparison blocks
+  // from the grid PBS output into a flat row-major buffer:
+  //   batched[i * num_blocks + j] = grid[decomposed[i][j]][j]
+  Torus *h_map = mem_ptr->h_map;
+  uint32_t total_blocks = num_possible_values * num_blocks;
+  for (uint32_t i = 0; i < num_possible_values; i++) {
+    for (uint32_t j = 0; j < num_blocks; j++) {
+      uint64_t block_value = h_decomposed_cleartexts[i * num_blocks + j];
+      if (block_value >= message_modulus)
+        PANIC("Cuda error: block value in compute_equality_selectors exceeds "
+              "message modulus");
+      h_map[i * num_blocks + j] = (Torus)block_value * num_blocks + j;
+    }
+  }
+  cuda_memcpy_async_to_gpu(mem_ptr->d_map, h_map,
+                           safe_mul_sizeof<Torus>(total_blocks),
+                           streams.stream(0), streams.gpu_index(0));
+
+  uint32_t lwe_size = mem_ptr->tmp_batched_comparisons.lwe_dimension + 1;
+  align_with_indexes<Torus><<<total_blocks, 256, 0, streams.stream(0)>>>(
+      (Torus *)mem_ptr->tmp_batched_comparisons.ptr,
+      (Torus *)mem_ptr->tmp_many_luts_output.ptr, mem_ptr->d_map, lwe_size);
+  check_cuda_error(cudaGetLastError());
+
+  if (num_blocks == 1) {
+    // Each candidate needs exactly one comparison block; no tree reduction.
+    copy_radix_ciphertext_slice_async<Torus>(
+        streams.stream(0), streams.gpu_index(0), lwe_array_out_packed, 0,
+        num_possible_values, &mem_ptr->tmp_batched_comparisons, 0,
+        num_possible_values);
+    return;
+  }
+
+  // Step 3: Batched tree reduction — AND-reduce the per-entry comparison
+  // blocks using host_accumulate_all_blocks_batched + is_max_value PBS.
+  // The data is in row-major layout: entry_i occupies blocks
+  // [i*num_blocks .. (i+1)*num_blocks).
+  uint32_t max_value = mem_ptr->max_value;
+  auto is_max_value_lut = mem_ptr->is_max_value_lut;
+  auto tree_accumulator = mem_ptr->tree_accumulator;
+  auto tree_pbs_output = mem_ptr->tree_pbs_output;
+
+  Torus *current_input_ptr = (Torus *)mem_ptr->tmp_batched_comparisons.ptr;
+  uint32_t blocks_per_entry = num_blocks;
+  uint32_t level = 0;
+
+  while (blocks_per_entry > 1) {
+    uint32_t num_chunks = CEIL_DIV(blocks_per_entry, max_value);
+    uint32_t total_chunks = num_possible_values * num_chunks;
+
+    host_accumulate_all_blocks_batched<Torus>(
+        streams.stream(0), streams.gpu_index(0), (Torus *)tree_accumulator->ptr,
+        current_input_ptr, big_lwe_dimension, blocks_per_entry, max_value,
+        num_possible_values, num_chunks);
+
+    for (uint32_t flat = 0; flat < total_chunks; flat++) {
+      uint32_t chunk = flat % num_chunks;
+      uint32_t chunk_start = chunk * max_value;
+      uint32_t chunk_len = std::min(max_value, blocks_per_entry - chunk_start);
+      tree_accumulator->degrees[flat] = chunk_len;
+      tree_accumulator->noise_levels[flat] = NoiseLevel::NOMINAL;
+    }
+
+    // Switch to this level's precomputed index buffer (slots baked at scratch
+    // time): a small gpu-to-gpu copy plus broadcast, no per-level LUT regen.
+    auto active =
+        streams.active_gpu_subset(total_chunks, mem_ptr->params.pbs_type);
+    is_max_value_lut->set_lut_indexes_and_broadcast_from_gpu(
+        active, mem_ptr->d_level_lut_indexes[level], total_chunks);
+
+    integer_radix_apply_univariate_lookup_table<Torus>(
+        streams, tree_pbs_output, tree_accumulator, bsks, ksks,
+        is_max_value_lut, total_chunks);
+
+    current_input_ptr = (Torus *)tree_pbs_output->ptr;
+    blocks_per_entry = num_chunks;
+    level++;
+  }
+
+  CudaRadixCiphertextFFI *result_source =
+      (blocks_per_entry == num_blocks) ? &mem_ptr->tmp_batched_comparisons
+                                       : tree_pbs_output;
+  copy_radix_ciphertext_slice_async<Torus>(
+      streams.stream(0), streams.gpu_index(0), lwe_array_out_packed, 0,
+      num_possible_values, result_source, 0, num_possible_values);
+}
+
+/// @brief Dispatches equality-selector computation to the algorithm chosen at
+/// scratch time.
+///
+/// Computes one encrypted boolean per stored key (input == key_i), delegating
+/// to the small-map tree variant or the sequential-scan variant based on
+/// KV_STORE_EQ_SELECTORS_SMALL_MAP_MAX_ENTRIES.
+///
+/// @param lwe_array_out_packed       Output ciphertext: one boolean per entry
+/// @param lwe_array_in               Input encrypted radix key
+/// @param num_blocks                 Number of radix blocks in the input key
+/// @param h_decomposed_cleartexts    Host flat array of all candidate digit
+///                                   values
+/// @param mem_ptr                    Wrapper buffer selecting the active
+///                                   algorithm
+template <typename Torus>
+__host__ void host_kv_store_compute_eq_selectors(
+    CudaStreams streams, CudaRadixCiphertextFFI *lwe_array_out_packed,
+    CudaRadixCiphertextFFI const *lwe_array_in, uint32_t num_blocks,
+    const uint64_t *h_decomposed_cleartexts,
+    int_kv_store_eq_selectors_wrapper_buffer<Torus> *mem_ptr, void *const *bsks,
+    Torus *const *ksks) {
+  if (mem_ptr->use_small_map) {
+    host_kv_store_compute_eq_selectors_small_map<Torus>(
+        streams, lwe_array_out_packed, lwe_array_in, num_blocks,
+        h_decomposed_cleartexts, mem_ptr->small_map_buffer, bsks, ksks);
+  } else {
+    host_compute_eq_selectors_ct_vs_clears<Torus>(
+        streams, lwe_array_out_packed, lwe_array_in, num_blocks,
+        h_decomposed_cleartexts, mem_ptr->vector_find_buffer, bsks, ksks);
+  }
+}
+
+/// @brief Retrieves the encrypted value for a key from an encrypted kv_store.
+///
+/// Compares the encrypted key against all stored clear keys. If a match
+/// is found, the corresponding encrypted value is extracted; otherwise the
+/// result is an encryption of zero. Does not leak which key was accessed.
+///
+/// @param lwe_array_out_result       Output ciphertext receiving the looked-up
+///                                   value
+/// @param lwe_array_out_boolean      Output single-block ciphertext: 1 if key
+///                                   found, 0 otherwise
+/// @param lwe_array_out_selectors    Output per-entry boolean selectors
+/// @param lwe_array_in_encrypted_key Input encrypted key to look up
+/// @param lwe_array_in_values        Input flat array of all stored encrypted
+///                                   values
+/// @param h_decomposed_clear_keys    Host-side clear keys decomposed into radix
+///                                   blocks (num_entries * num_key_blocks)
+/// @param mem_ptr                    Scratch buffer from
+///                                   scratch_cuda_kv_store_get
+template <typename Torus>
+__host__ void
+host_kv_store_get(CudaStreams streams,
+                  CudaRadixCiphertextFFI *lwe_array_out_result,
+                  CudaRadixCiphertextFFI *lwe_array_out_boolean,
+                  CudaRadixCiphertextFFI *lwe_array_out_selectors,
+                  CudaRadixCiphertextFFI const *lwe_array_in_encrypted_key,
+                  CudaRadixCiphertextFFI const *lwe_array_in_values,
+                  const uint64_t *h_decomposed_clear_keys,
+                  int_kv_store_get_buffer<Torus> *mem_ptr, void *const *bsks,
+                  Torus *const *ksks) {
+
+  auto num_key_blocks = mem_ptr->num_key_blocks;
+  auto num_value_blocks = mem_ptr->num_value_blocks;
+  auto num_entries = mem_ptr->num_entries;
+  auto mem_zero_out_batch_buffer = mem_ptr->mem_zero_out_batch_buffer;
+  auto one_hot_vector_predicate = mem_ptr->one_hot_vector_predicate;
+  auto tmp_cmux_array = mem_ptr->tmp_cmux_array;
+  auto message_modulus = mem_ptr->message_modulus;
+  auto carry_modulus = mem_ptr->carry_modulus;
+
+  cuda_set_device(streams.gpu_index(0));
+
+  // Step 1: one encrypted boolean per stored key (input == key_i).
+  PUSH_RANGE("get: equality selectors")
+  host_kv_store_compute_eq_selectors<Torus>(
+      streams, lwe_array_out_selectors, lwe_array_in_encrypted_key,
+      num_key_blocks, h_decomposed_clear_keys, mem_ptr->mem_eq_selectors_buffer,
+      bsks, ksks);
+  POP_RANGE()
+
+  // Step 2: one-hot vector, zeroing every value whose selector is 0 so only the
+  // matched value (if any) survives.
+  PUSH_RANGE("get: one-hot vector")
+  auto lwe_one_hot_vector = tmp_cmux_array;
+  host_zero_out_if_batch(streams, lwe_one_hot_vector, lwe_array_in_values,
+                         lwe_array_out_selectors, mem_zero_out_batch_buffer,
+                         one_hot_vector_predicate, bsks, ksks, num_entries,
+                         num_value_blocks);
+  POP_RANGE()
+
+  // Step 3: Sum all elements in the vector
+  PUSH_RANGE("get: binary tree sum")
+  host_binary_tree_fold_sum_dispatch<Torus>(
+      streams, lwe_array_out_result, lwe_one_hot_vector, num_entries,
+      num_value_blocks, message_modulus, carry_modulus, bsks, ksks,
+      mem_ptr->identity_lut);
+  POP_RANGE()
+
+  PUSH_RANGE("get: OR selectors")
+  auto at_least_one_true_buffer = mem_ptr->at_least_one_true_buffer;
+  host_integer_is_at_least_one_comparisons_block_true<Torus>(
+      streams, lwe_array_out_boolean, lwe_array_out_selectors,
+      at_least_one_true_buffer, bsks, ksks, num_entries);
+  POP_RANGE()
+}
+
+/// @brief Allocates the scratch buffer for kv_store get.
+///
+/// @param mem_ptr            Output pointer receiving the allocated scratch
+///                           buffer
+/// @param num_entries        Number of stored key-value pairs
+/// @param num_key_blocks     Number of radix blocks per key
+/// @param num_value_blocks   Number of radix blocks per value
+template <typename Torus>
+uint64_t scratch_cuda_kv_store_get(
+    CudaStreams streams, int_kv_store_get_buffer<Torus> **mem_ptr,
+    int_radix_params params, uint32_t num_entries, uint32_t num_key_blocks,
+    uint32_t num_value_blocks, bool allocate_gpu_memory) {
+
+  uint64_t size_tracker = 0;
+  *mem_ptr = new int_kv_store_get_buffer<Torus>(
+      streams, params, num_entries, num_key_blocks, num_value_blocks,
+      allocate_gpu_memory, size_tracker);
+
+  return size_tracker;
+}
+
+/// @brief Updates the encrypted value for a key in an encrypted kv_store.
+///
+/// For each entry, if the stored clear key matches the query, the old
+/// encrypted value is replaced with lwe_in_new_value; otherwise kept.
+/// Does not leak which key was accessed or whether a match was found.
+///
+/// @param lwe_check_out_block          Output single-block ciphertext: 1 if key
+///                                     found, 0 otherwise
+/// @param lwe_array_out_values         Output flat array of stored encrypted
+///                                     values (updated in place)
+/// @param lwe_array_in_encrypted_key   Input encrypted key to match
+/// @param lwe_array_in_values          Input flat array of current stored
+///                                     encrypted values
+/// @param lwe_in_new_value             Input encrypted replacement value
+/// @param h_decomposed_clear_keys      Host-side clear keys decomposed into
+///                                     radix blocks
+/// @param mem_ptr                      Scratch buffer from
+///                                     scratch_cuda_kv_store_update
+template <typename Torus, typename KSTorus>
+__host__ void
+host_kv_store_update(CudaStreams streams,
+                     CudaRadixCiphertextFFI *lwe_check_out_block,
+                     CudaRadixCiphertextFFI *lwe_array_out_values,
+                     CudaRadixCiphertextFFI const *lwe_array_in_encrypted_key,
+                     CudaRadixCiphertextFFI const *lwe_array_in_values,
+                     CudaRadixCiphertextFFI const *lwe_in_new_value,
+                     const uint64_t *h_decomposed_clear_keys,
+                     int_kv_store_update_buffer<Torus> *mem_ptr,
+                     void *const *bsks, KSTorus *const *ksks) {
+
+  auto num_entries = mem_ptr->num_entries;
+  auto num_key_blocks = mem_ptr->num_key_blocks;
+  auto num_value_blocks = mem_ptr->num_value_blocks;
+  auto mem_eq_selectors_buffer = mem_ptr->mem_eq_selectors_buffer;
+  uint32_t total_value_blocks = static_cast<uint32_t>(safe_mul(
+      static_cast<size_t>(num_entries), static_cast<size_t>(num_value_blocks)));
+
+  GPU_ASSERT(
+      lwe_array_out_values->num_radix_blocks >= total_value_blocks &&
+          lwe_array_in_values->num_radix_blocks >= total_value_blocks,
+      "Cuda error: output or input values radix ciphertext does not have "
+      "enough blocks");
+
+  GPU_ASSERT(
+      lwe_in_new_value->num_radix_blocks >= num_value_blocks,
+      "Cuda error: new_value radix ciphertext does not have enough blocks");
+
+  cuda_set_device(streams.gpu_index(0));
+
+  // Step 1: one encrypted boolean per stored key (input == key_i).
+  PUSH_RANGE("update: equality selectors")
+  host_kv_store_compute_eq_selectors<Torus>(
+      streams, mem_ptr->selectors_contiguous, lwe_array_in_encrypted_key,
+      num_key_blocks, h_decomposed_clear_keys, mem_eq_selectors_buffer, bsks,
+      ksks);
+  POP_RANGE()
+
+  // Step 2: batched CMUX selecting new_value where selector==1, old otherwise.
+  // The true branch (new_value) is replicated across all entries.
+  PUSH_RANGE("update: batched cmux")
+  host_cmux_batch<Torus, KSTorus>(
+      streams, lwe_array_out_values, lwe_in_new_value, lwe_array_in_values,
+      mem_ptr->selectors_contiguous, mem_ptr->cmux_batch_buffer, bsks, ksks,
+      num_entries, num_value_blocks, true);
+  POP_RANGE()
+
+  // Step 3: OR all selectors to produce the key-found boolean
+  PUSH_RANGE("update: OR selectors")
+  host_integer_is_at_least_one_comparisons_block_true<Torus>(
+      streams, lwe_check_out_block, mem_ptr->selectors_contiguous,
+      mem_ptr->at_least_one_true_buffer, bsks, ksks, num_entries);
+  POP_RANGE()
+}
+
+/// @brief Allocates the scratch buffer for kv_store update.
+///
+/// @param mem_ptr            Output pointer receiving the allocated scratch
+///                           buffer
+/// @param num_entries        Number of stored key-value pairs
+/// @param num_key_blocks     Number of radix blocks per key
+/// @param num_value_blocks   Number of radix blocks per value
+template <typename Torus>
+uint64_t scratch_cuda_kv_store_update(
+    CudaStreams streams, int_kv_store_update_buffer<Torus> **mem_ptr,
+    int_radix_params params, uint32_t num_entries, uint32_t num_key_blocks,
+    uint32_t num_value_blocks, bool allocate_gpu_memory) {
+  uint64_t size_tracker = 0;
+  *mem_ptr = new int_kv_store_update_buffer<Torus>(
+      streams, params, num_entries, num_key_blocks, num_value_blocks,
+      allocate_gpu_memory, size_tracker);
+  return size_tracker;
+}
+
+/// @brief Applies a conditional update to all entries using pre-computed
+/// selectors.
+///
+/// For each entry, if the corresponding selector is 1, the old encrypted value
+/// is replaced with lwe_in_new_value; otherwise the old value is kept. This is
+/// the inner CMUX step shared by update and insert.
+///
+/// @param lwe_check_out_block       Output single-block ciphertext: 1 if at
+///                                  least one selector was true
+/// @param lwe_array_out_values      Output flat array of stored encrypted
+/// values
+///                                  (updated)
+/// @param lwe_array_in_values       Input flat array of current stored
+/// encrypted
+///                                  values
+/// @param lwe_in_new_value          Input encrypted replacement value
+/// @param lwe_array_in_selectors    Input per-entry boolean selectors
+///                                  (1 = replace, 0 = keep)
+/// @param mem_ptr                   Scratch buffer from
+///                                  scratch_cuda_kv_store_map
+template <typename Torus, typename KSTorus>
+__host__ void
+host_kv_store_map(CudaStreams streams,
+                  CudaRadixCiphertextFFI *lwe_check_out_block,
+                  CudaRadixCiphertextFFI *lwe_array_out_values,
+                  CudaRadixCiphertextFFI const *lwe_array_in_values,
+                  CudaRadixCiphertextFFI const *lwe_in_new_value,
+                  CudaRadixCiphertextFFI const *lwe_array_in_selectors,
+                  int_kv_store_map_buffer<Torus> *mem_ptr, void *const *bsks,
+                  KSTorus *const *ksks) {
+
+  auto num_entries = mem_ptr->num_entries;
+  auto num_value_blocks = mem_ptr->num_value_blocks;
+  uint32_t total_value_blocks = static_cast<uint32_t>(safe_mul(
+      static_cast<size_t>(num_entries), static_cast<size_t>(num_value_blocks)));
+
+  GPU_ASSERT(
+      lwe_array_out_values->num_radix_blocks >= total_value_blocks &&
+          lwe_array_in_values->num_radix_blocks >= total_value_blocks,
+      "Cuda error: output or input values radix ciphertext does not have "
+      "enough blocks");
+
+  GPU_ASSERT(
+      lwe_in_new_value->num_radix_blocks >= num_value_blocks,
+      "Cuda error: new_value radix ciphertext does not have enough blocks");
+
+  GPU_ASSERT(
+      lwe_array_in_selectors->num_radix_blocks >= num_entries,
+      "Cuda error: selectors radix ciphertext does not have enough blocks");
+
+  cuda_set_device(streams.gpu_index(0));
+
+  // Batched CMUX selecting new_value where selector==1, old otherwise. The true
+  // branch (new_value) is replicated across all entries.
+  PUSH_RANGE("map: batched cmux")
+  host_cmux_batch<Torus, KSTorus>(
+      streams, lwe_array_out_values, lwe_in_new_value, lwe_array_in_values,
+      lwe_array_in_selectors, mem_ptr->cmux_batch_buffer, bsks, ksks,
+      num_entries, num_value_blocks, true);
+  POP_RANGE()
+
+  // OR all selectors to produce the key-found boolean
+  PUSH_RANGE("map: OR selectors")
+  host_integer_is_at_least_one_comparisons_block_true<Torus>(
+      streams, lwe_check_out_block, lwe_array_in_selectors,
+      mem_ptr->at_least_one_true_buffer, bsks, ksks, num_entries);
+  POP_RANGE()
+}
+
+/// @brief Allocates the scratch buffer for kv_store map.
+///
+/// @param mem_ptr            Output pointer receiving the allocated scratch
+///                           buffer
+/// @param num_entries        Number of stored key-value pairs
+/// @param num_value_blocks   Number of radix blocks per value
+template <typename Torus>
+uint64_t
+scratch_cuda_kv_store_map(CudaStreams streams,
+                          int_kv_store_map_buffer<Torus> **mem_ptr,
+                          int_radix_params params, uint32_t num_entries,
+                          uint32_t num_value_blocks, bool allocate_gpu_memory) {
+  uint64_t size_tracker = 0;
+  *mem_ptr = new int_kv_store_map_buffer<Torus>(
+      streams, params, num_entries, num_value_blocks, allocate_gpu_memory,
+      size_tracker);
+  return size_tracker;
+}
+
+/// @brief Checks whether a clear key exists in the encrypted kv_store.
+///
+/// Compares the encrypted key against all stored clear keys and OR-reduces
+/// the per-entry booleans into a single key-found flag. Does not leak which
+/// key was queried.
+///
+/// @param lwe_array_out_boolean      Output single-block ciphertext: 1 if key
+///                                   found, 0 otherwise
+/// @param lwe_array_in_encrypted_key Input encrypted key to look up
+/// @param h_decomposed_clear_keys    Host-side clear keys decomposed into radix
+///                                   blocks
+/// @param mem_ptr                    Scratch buffer from
+///                                   scratch_cuda_kv_store_contains_key
+template <typename Torus, typename KSTorus>
+__host__ void host_kv_store_contains_key(
+    CudaStreams streams, CudaRadixCiphertextFFI *lwe_array_out_boolean,
+    CudaRadixCiphertextFFI const *lwe_array_in_encrypted_key,
+    const uint64_t *h_decomposed_clear_keys,
+    int_kv_store_contains_key_buffer<Torus> *mem_ptr, void *const *bsks,
+    KSTorus *const *ksks) {
+
+  auto num_entries = mem_ptr->num_entries;
+  auto num_key_blocks = mem_ptr->num_key_blocks;
+
+  cuda_set_device(streams.gpu_index(0));
+
+  // Step 1: one encrypted boolean per stored key (input == key_i).
+  PUSH_RANGE("contains_key: equality selectors")
+  host_kv_store_compute_eq_selectors<Torus>(
+      streams, mem_ptr->selectors_contiguous, lwe_array_in_encrypted_key,
+      num_key_blocks, h_decomposed_clear_keys, mem_ptr->mem_eq_selectors_buffer,
+      bsks, ksks);
+  POP_RANGE()
+
+  // Step 2: OR all selectors to produce the key-found boolean
+  PUSH_RANGE("contains_key: OR selectors")
+  host_integer_is_at_least_one_comparisons_block_true<Torus>(
+      streams, lwe_array_out_boolean, mem_ptr->selectors_contiguous,
+      mem_ptr->at_least_one_true_buffer, bsks, ksks, num_entries);
+  POP_RANGE()
+}
+
+/// @brief Allocates the scratch buffer for kv_store contains_key.
+///
+/// @param mem_ptr            Output pointer receiving the allocated scratch
+///                           buffer
+/// @param num_entries        Number of stored keys
+/// @param num_key_blocks     Number of radix blocks per key
+template <typename Torus>
+uint64_t scratch_cuda_kv_store_contains_key(
+    CudaStreams streams, int_kv_store_contains_key_buffer<Torus> **mem_ptr,
+    int_radix_params params, uint32_t num_entries, uint32_t num_key_blocks,
+    bool allocate_gpu_memory) {
+  uint64_t size_tracker = 0;
+  *mem_ptr = new int_kv_store_contains_key_buffer<Torus>(
+      streams, params, num_entries, num_key_blocks, allocate_gpu_memory,
+      size_tracker);
+  return size_tracker;
+}

--- a/backends/tfhe-cuda-backend/cuda/src/integer/vector_find.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/vector_find.cuh
@@ -275,19 +275,19 @@ __host__ void host_compute_eq_selectors_ct_vs_clears(
     int_eq_selectors_ct_vs_clears_buffer<Torus> *mem_ptr, void *const *bsks,
     Torus *const *ksks) {
 
+  // num_blocks == 0 would yield an all-zero selector matrix instead of the
+  // trivial all-match, so require at least one block.
+  PANIC_IF_FALSE(num_blocks >= 1, "num_blocks must be at least 1 in "
+                                  "host_compute_eq_selectors_ct_vs_clears");
+
   uint32_t num_possible_values = mem_ptr->num_possible_values;
   uint32_t message_modulus = mem_ptr->params.message_modulus;
   uint32_t carry_modulus = mem_ptr->params.carry_modulus;
   uint32_t max_degree = mem_ptr->max_degree;
 
-  // For every block in the input radix ciphertext lwe_array_in, precompute
-  // indicators of equality to all possible values of the block
-  // (0..2**(message_modulus+carry_modulus)-1).
-  // Using only num_blocks multi-variate PBS an indicator matrix is produced
-  // where columns are one-hot vectors indicating the active value in the input
-  // block.
-  // The indicator matrix can be used to assess equality for ALL the clear
-  // values to be matched
+  // With num_blocks many-LUT PBS, build an indicator matrix: per block, a
+  // one-hot column over all possible block values. This serves equality checks
+  // against every clear value at once.
   integer_radix_apply_many_univariate_lookup_table<Torus>(
       streams, &mem_ptr->tmp_many_luts_output, lwe_array_in, bsks,
       (Torus *const *)ksks, mem_ptr->comparison_luts, message_modulus,
@@ -315,10 +315,8 @@ __host__ void host_compute_eq_selectors_ct_vs_clears(
                            safe_mul_sizeof<Torus>(total_blocks),
                            streams.stream(0), streams.gpu_index(0));
 
-  // Extract the indicator booleans for each clear value to be matched and group
-  // them in a flat contiguous 2d array of LWE in order, so that each column
-  // contains the booleans corresponding to a single clear value. The 2d array
-  // is of size num_blocks (rows) x num_clear_values (cols)
+  // Gather the indicator booleans into a flat num_blocks x num_clear_values
+  // array, one clear value per column.
   uint32_t lwe_size = mem_ptr->tmp_batched_comparisons.lwe_dimension + 1;
   align_with_indexes<Torus><<<total_blocks, 256, 0, streams.stream(0)>>>(
       (Torus *)mem_ptr->tmp_batched_comparisons.ptr,
@@ -339,7 +337,6 @@ __host__ void host_compute_eq_selectors_ct_vs_clears(
       mem_ptr->luts_eq, mem_ptr->num_luts_needed, num_possible_values,
       num_blocks, max_degree, message_modulus, carry_modulus, bsks, ksks);
 
-  // Place the output booleans into the output LWE list
   copy_radix_ciphertext_slice_async<Torus>(
       streams.stream(0), streams.gpu_index(0), lwe_array_out_packed, 0,
       num_possible_values, &mem_ptr->packed_accumulator, 0,
@@ -386,10 +383,8 @@ __host__ void host_compute_eq_selectors_cts_vs_ct(
   for (uint32_t base = 0; base < num_inputs; base += chunk_size) {
     uint32_t current_chunk_size = std::min(chunk_size, num_inputs - base);
 
-    // Cache the chunk of the input radix-ciphertext list in a temporary buffer.
-    // Also duplicate the searched-for value radix-ct blocks in a manner in
-    // which the bivariate PBS can pack pairs of (inputs[i][k], value[k])
-    // for-each i in [0..num_inputs], for-each k in [0..num_blocks]
+    // Pack each (inputs[i][k], value[k]) pair so the bivariate PBS can compare
+    // every input block against the corresponding target block.
     host_pack_chunk_eq_pairs<Torus>(
         streams.stream(0), streams.gpu_index(0), &mem_ptr->packed_current_block,
         &mem_ptr->packed_value_block, mem_ptr->d_input_ptrs, inputs, value,
@@ -404,10 +399,8 @@ __host__ void host_compute_eq_selectors_cts_vs_ct(
         &mem_ptr->packed_value_block, bsks, ksks, mem_ptr->equality_lut, total,
         message_modulus);
 
-    // The indicator boolean values produced by the LUT are interpreted as a 2d
-    // array of num_blocks (rows) x num_inputs (cols). And-reduce the array to
-    // determine which inputs match the searched-for value. This produces a 1d
-    // vector of booleans
+    // AND-reduce the num_blocks x num_inputs indicator matrix into one boolean
+    // per input (whether it matches the target).
     host_and_reduce_selector_matrix<Torus>(
         streams, &mem_ptr->packed_accumulator, &mem_ptr->packed_current_block,
         mem_ptr->luts_eq, mem_ptr->num_luts_needed, current_chunk_size,
@@ -503,9 +496,66 @@ __host__ void host_create_possible_results(
       mem_ptr->d_src_idx, h_src_idx, num_possible_values, num_blocks);
 }
 
+/// @brief Allocates the scratch buffer for creating possible-result
+/// ciphertexts used in encrypted vector lookups.
+///
+/// @param mem_ptr              Receives the allocated buffer pointer
+/// @param num_blocks           Number of radix blocks per ciphertext
+/// @param num_possible_values  Number of distinct plaintext values to prepare
+template <typename Torus>
+uint64_t scratch_cuda_create_possible_results(
+    CudaStreams streams, int_possible_results_buffer<Torus> **mem_ptr,
+    int_radix_params params, uint32_t num_blocks, uint32_t num_possible_values,
+    bool allocate_gpu_memory) {
+
+  uint64_t size_tracker = 0;
+  *mem_ptr = new int_possible_results_buffer<Torus>(
+      streams, params, num_blocks, num_possible_values, allocate_gpu_memory,
+      size_tracker);
+
+  return size_tracker;
+}
+
 /**
  * @brief Fuses the sparse array of selected candidates into a single encrypted
  * result via a binary reduction tree.
+ *
+ * @details
+ * Given N encrypted radix ciphertexts forming a one-hot vector (at most one
+ * non-zero entry), sum them into a single output ciphertext. Because the
+ * vector is one-hot, the sum recovers the value of the single non-zero entry.
+ *
+ * Plain LWE addition accumulates noise in the carry bits. After chunk_size
+ * additions the carry space is exhausted, so an identity PBS is applied after
+ * each chunk to refresh the ciphertext (extract message, reset carry to zero).
+ *
+ * The algorithm has three phases:
+ *
+ * Phase 1 - Parallel chunked accumulation (one CUDA stream per partition):
+ *
+ *   stream 0: inputs[0..k)         stream 1: inputs[k..2k)        ...
+ *   +----------------------+       +----------------------+
+ *   | acc  = 0             |       | acc  = 0             |
+ *   | acc += input[0]      |       | acc += input[k]      |
+ *   | acc += input[1]      |       | acc += input[k+1]    |
+ *   | ...chunk_size adds...|       | ...chunk_size adds...|
+ *   | acc = PBS(acc) <- refresh    | acc = PBS(acc)        |
+ *   | (repeat for next chunk)      | (repeat)              |
+ *   +----------------------+       +----------------------+
+ *
+ * Phase 2 - Cross-stream merge: sum partial accumulators into stream 0's
+ *   result. num_streams must stay below the noise ceiling.
+ *
+ * Phase 3 - Message/carry extraction and interleaving:
+ *   The accumulated blocks use both message and carry space. Two parallel
+ *   PBS calls extract message bits and carry bits separately, then
+ *   interleave them into the output:
+ *
+ *     output[2i]   = message_extract(acc[i])
+ *     output[2i+1] = carry_extract(acc[i])
+ *
+ *   This unpacks each "packed" block into two standard blocks, so the
+ *   output has up to 2 * num_blocks radix blocks.
  *
  * @param lwe_array_out Output ciphertext receiving the aggregated result.
  * @param lwe_array_in_list Sparse list of candidate ciphertexts to sum.
@@ -578,8 +628,7 @@ __host__ void host_aggregate_one_hot_vector(
   CudaRadixCiphertextFFI final_agg;
   as_radix_ciphertext_slice<Torus>(&final_agg, src_buf, 0, num_blocks);
 
-  // Unpack final_agg
-  // Split them with two PBS
+  // Unpack final_agg into message/carry digits with two PBS.
   // Toy example (message_modulus = 4): final_agg = [12, 9]
   //   = [0 + 3*4, 1 + 2*4]  ->  unpacks to logical [0, 3, 1, 2].
   //

--- a/backends/tfhe-cuda-backend/cuda/src/integer/vector_find.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/vector_find.cuh
@@ -293,13 +293,8 @@ __host__ void host_compute_eq_selectors_ct_vs_clears(
       (Torus *const *)ksks, mem_ptr->comparison_luts, message_modulus,
       mem_ptr->lut_stride);
 
-  // Equality between the input radix-ciphertext and each decomposed clear value
-  // is determined by inspecting the indicator matrix cells corresponding to the
-  // decomposed clear value.
-  // E.g. for clear value = 20, the decomposed clear value with 2_2 params is
-  // [1, 1, 0]. Thus we extract the cells [indicator_matrix[0,1],
-  // indicator_matrix[1,1], indicator_matrix[2,0]]. If all these cells are 1
-  // then the input radix-ciphertext matched this clear value.
+  // For each candidate, look up the indicator cells that correspond to its
+  // decomposed block values. If all cells are 1, the input matched.
   Torus *h_map = mem_ptr->h_map;
   uint32_t total_blocks = num_possible_values * num_blocks;
   for (uint32_t j = 0; j < num_blocks; j++) {

--- a/backends/tfhe-cuda-backend/cuda/src/linearalgebra/addition.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/linearalgebra/addition.cuh
@@ -9,6 +9,7 @@
 #include "helper_multi_gpu.h"
 #include "integer/integer.h"
 #include "integer/integer_utilities.h"
+#include "polynomial/parameters.cuh"
 #include "utils/helper.cuh"
 #include <stdio.h>
 
@@ -164,10 +165,23 @@ lwe_array_2d_reduce_rows_kernel(T *dst, SrcAccessor src, uint32_t chunk_size,
   uint32_t r_end = min(r_start + chunk_size, num_rows);
 
   T *out = dst + ((size_t)g * num_columns + j) * lwe_size + lane;
-  T s = Accumulate ? *out : T(0);
-  for (uint32_t r = r_start; r < r_end; r++)
-    s += src.row(r, j)[lane];
-  *out = s;
+
+  // Unroll by 4 with independent partial sums: a serial chain serializes on
+  // global-load latency, four accumulators expose ILP on this memory-bound
+  // reduction. ulonglong2 vectorization is avoided (per-row lwe alignment not
+  // guaranteed).
+  T s0 = Accumulate ? *out : T(0);
+  T s1 = T(0), s2 = T(0), s3 = T(0);
+  uint32_t r = r_start;
+  for (; r + 4 <= r_end; r += 4) {
+    s0 += src.row(r, j)[lane];
+    s1 += src.row(r + 1, j)[lane];
+    s2 += src.row(r + 2, j)[lane];
+    s3 += src.row(r + 3, j)[lane];
+  }
+  for (; r < r_end; r++)
+    s0 += src.row(r, j)[lane];
+  *out = (s0 + s1) + (s2 + s3);
 }
 
 // Host-side (row, column) degree/noise accessor for a flat metadata array.

--- a/backends/tfhe-cuda-backend/src/bindings.rs
+++ b/backends/tfhe-cuda-backend/src/bindings.rs
@@ -2370,6 +2370,143 @@ unsafe extern "C" {
         glwe_index: u32,
     );
 }
+unsafe extern "C" {
+    #[doc = " @brief Allocates the scratch buffer for kv_store get.\n\n @param mem_ptr            Output pointer receiving the allocated scratch\n buffer\n @param bsk_params         Bootstrap key parameters (PBS type, dimensions,\n decomposition)\n @param ksk_params         Keyswitch key parameters (dimensions,\n decomposition)\n @param num_entries        Number of stored key-value pairs\n @param num_key_blocks     Number of radix blocks per key\n @param num_value_blocks   Number of radix blocks per value\n @param noise_reduction_type  Noise reduction strategy for PBS"]
+    pub fn scratch_cuda_kv_store_get_64_async(
+        streams: CudaStreamsFFI,
+        mem_ptr: *mut *mut i8,
+        bsk_params: CudaLweBootstrapKeyParamsFFI,
+        ksk_params: CudaLweKeyswitchKeyParamsFFI,
+        num_entries: u32,
+        num_key_blocks: u32,
+        num_value_blocks: u32,
+        message_modulus: u32,
+        carry_modulus: u32,
+        allocate_gpu_memory: bool,
+        noise_reduction_type: PBS_MS_REDUCTION_T,
+    ) -> u64;
+}
+unsafe extern "C" {
+    #[doc = " @brief Retrieves the encrypted value for a key from an encrypted kv_store.\n\n Compares the encrypted key against all stored clear keys and extracts\n the matching value. Does not leak which key was accessed.\n\n @param lwe_array_out_result       Output ciphertext receiving the looked-up\n value\n @param lwe_array_out_boolean      Output single-block ciphertext: 1 if key\n found, 0 otherwise\n @param lwe_array_out_selectors    Output per-entry boolean selectors (one\n block per entry; encrypts 1 if the entry corresponds to the looked-up key)\n @param lwe_array_in_encrypted_key Input encrypted key to look up\n @param lwe_array_in_values        Input flat array of all stored encrypted\n values\n @param h_decomposed_clear_keys    Host-side clear keys decomposed into radix\n blocks\n @param mem                        Scratch buffer from\n scratch_cuda_kv_store_get_64_async\n @param ksks                       Key-switching keys (one per GPU)"]
+    pub fn cuda_kv_store_get_64_async(
+        streams: CudaStreamsFFI,
+        lwe_array_out_result: *mut CudaRadixCiphertextFFI,
+        lwe_array_out_boolean: *mut CudaRadixCiphertextFFI,
+        lwe_array_out_selectors: *mut CudaRadixCiphertextFFI,
+        lwe_array_in_encrypted_key: *const CudaRadixCiphertextFFI,
+        lwe_array_in_values: *const CudaRadixCiphertextFFI,
+        h_decomposed_clear_keys: *const u64,
+        mem: *mut i8,
+        bsks: *const *mut ffi::c_void,
+        ksks: *const *mut ffi::c_void,
+    );
+}
+unsafe extern "C" {
+    #[doc = " @brief Releases the scratch buffer allocated by\n scratch_cuda_kv_store_get_64_async.\n\n @param mem_ptr_void  Pointer to the scratch buffer pointer (set to nullptr\n on return)"]
+    pub fn cleanup_cuda_kv_store_get_64(streams: CudaStreamsFFI, mem_ptr_void: *mut *mut i8);
+}
+unsafe extern "C" {
+    #[doc = " @brief Allocates the scratch buffer for kv_store update.\n\n @param mem_ptr            Output pointer receiving the allocated scratch\n buffer\n @param bsk_params         Bootstrap key parameters (PBS type, dimensions,\n decomposition)\n @param ksk_params         Keyswitch key parameters (dimensions,\n decomposition)\n @param num_entries        Number of stored key-value pairs\n @param num_key_blocks     Number of radix blocks per key\n @param num_value_blocks   Number of radix blocks per value\n @param noise_reduction_type  Noise reduction strategy for PBS"]
+    pub fn scratch_cuda_kv_store_update_64_async(
+        streams: CudaStreamsFFI,
+        mem_ptr: *mut *mut i8,
+        bsk_params: CudaLweBootstrapKeyParamsFFI,
+        ksk_params: CudaLweKeyswitchKeyParamsFFI,
+        num_entries: u32,
+        num_key_blocks: u32,
+        num_value_blocks: u32,
+        message_modulus: u32,
+        carry_modulus: u32,
+        allocate_gpu_memory: bool,
+        noise_reduction_type: PBS_MS_REDUCTION_T,
+    ) -> u64;
+}
+unsafe extern "C" {
+    #[doc = " @brief Updates the encrypted value for a key in an encrypted kv_store.\n\n For each entry, if the stored clear key matches the encrypted query key,\n the old value is replaced with lwe_in_new_value; otherwise kept unchanged.\n\n @param lwe_check_out_block          Output single-block ciphertext: 1 if key\n found, 0 otherwise\n @param lwe_array_out_values         Output flat array of all stored\n encrypted values (updated)\n @param lwe_array_in_encrypted_key   Input encrypted key to match\n @param lwe_array_in_values          Input flat array of current stored\n encrypted values\n @param lwe_in_new_value             Input encrypted replacement value\n @param h_decomposed_clear_keys      Host-side clear keys decomposed into\n radix blocks\n @param mem_ptr                      Scratch buffer from\n scratch_cuda_kv_store_update_64_async\n @param ksks                         Key-switching keys (one per GPU)"]
+    pub fn cuda_kv_store_update_64_async(
+        streams: CudaStreamsFFI,
+        lwe_check_out_block: *mut CudaRadixCiphertextFFI,
+        lwe_array_out_values: *mut CudaRadixCiphertextFFI,
+        lwe_array_in_encrypted_key: *const CudaRadixCiphertextFFI,
+        lwe_array_in_values: *const CudaRadixCiphertextFFI,
+        lwe_in_new_value: *const CudaRadixCiphertextFFI,
+        h_decomposed_clear_keys: *const u64,
+        mem_ptr: *mut i8,
+        bsks: *const *mut ffi::c_void,
+        ksks: *const *mut ffi::c_void,
+    );
+}
+unsafe extern "C" {
+    #[doc = " @brief Releases the scratch buffer allocated by\n scratch_cuda_kv_store_update_64_async.\n\n @param mem_ptr_void  Pointer to the scratch buffer pointer (set to nullptr\n on return)"]
+    pub fn cleanup_cuda_kv_store_update_64(streams: CudaStreamsFFI, mem_ptr_void: *mut *mut i8);
+}
+unsafe extern "C" {
+    #[doc = " @brief Allocates the scratch buffer for kv_store map.\n\n @param mem_ptr            Output pointer receiving the allocated scratch\n buffer\n @param bsk_params         Bootstrap key parameters (PBS type, dimensions,\n decomposition)\n @param ksk_params         Keyswitch key parameters (dimensions,\n decomposition)\n @param num_entries        Number of stored key-value pairs\n @param num_value_blocks   Number of radix blocks per value\n @param noise_reduction_type  Noise reduction strategy for PBS"]
+    pub fn scratch_cuda_kv_store_map_64_async(
+        streams: CudaStreamsFFI,
+        mem_ptr: *mut *mut i8,
+        bsk_params: CudaLweBootstrapKeyParamsFFI,
+        ksk_params: CudaLweKeyswitchKeyParamsFFI,
+        num_entries: u32,
+        num_value_blocks: u32,
+        message_modulus: u32,
+        carry_modulus: u32,
+        allocate_gpu_memory: bool,
+        noise_reduction_type: PBS_MS_REDUCTION_T,
+    ) -> u64;
+}
+unsafe extern "C" {
+    #[doc = " @brief Applies a conditional update to all entries using pre-computed\n selectors.\n\n For each entry, if the corresponding selector is 1, the old encrypted\n value is replaced with lwe_in_new_value; otherwise the old value is kept.\n\n @param lwe_check_out_block       Output single-block ciphertext: 1 if at\n least one selector was true\n @param lwe_array_out_values      Output flat array of all stored encrypted\n values (updated)\n @param lwe_array_in_values       Input flat array of current stored\n encrypted values\n @param lwe_in_new_value          Input encrypted replacement value\n @param lwe_array_in_selectors    Input per-entry boolean selectors (1 =\n entry must be replaced, 0 = entry should be kept)\n @param mem_ptr                   Scratch buffer from\n scratch_cuda_kv_store_map_64_async\n @param ksks                      Key-switching keys (one per GPU)"]
+    pub fn cuda_kv_store_map_64_async(
+        streams: CudaStreamsFFI,
+        lwe_check_out_block: *mut CudaRadixCiphertextFFI,
+        lwe_array_out_values: *mut CudaRadixCiphertextFFI,
+        lwe_array_in_values: *const CudaRadixCiphertextFFI,
+        lwe_in_new_value: *const CudaRadixCiphertextFFI,
+        lwe_array_in_selectors: *const CudaRadixCiphertextFFI,
+        mem_ptr: *mut i8,
+        bsks: *const *mut ffi::c_void,
+        ksks: *const *mut ffi::c_void,
+    );
+}
+unsafe extern "C" {
+    #[doc = " @brief Releases the scratch buffer allocated by\n scratch_cuda_kv_store_map_64_async.\n\n @param mem_ptr_void  Pointer to the scratch buffer pointer (set to nullptr\n on return)"]
+    pub fn cleanup_cuda_kv_store_map_64(streams: CudaStreamsFFI, mem_ptr_void: *mut *mut i8);
+}
+unsafe extern "C" {
+    #[doc = " @brief Allocates the scratch buffer for kv_store contains_key.\n\n @param mem_ptr            Output pointer receiving the allocated scratch\n buffer\n @param bsk_params         Bootstrap key parameters (PBS type, dimensions,\n decomposition)\n @param ksk_params         Keyswitch key parameters (dimensions,\n decomposition)\n @param num_entries        Number of stored keys\n @param num_key_blocks     Number of radix blocks per key\n @param noise_reduction_type  Noise reduction strategy for PBS"]
+    pub fn scratch_cuda_kv_store_contains_key_64_async(
+        streams: CudaStreamsFFI,
+        mem_ptr: *mut *mut i8,
+        bsk_params: CudaLweBootstrapKeyParamsFFI,
+        ksk_params: CudaLweKeyswitchKeyParamsFFI,
+        num_entries: u32,
+        num_key_blocks: u32,
+        message_modulus: u32,
+        carry_modulus: u32,
+        allocate_gpu_memory: bool,
+        noise_reduction_type: PBS_MS_REDUCTION_T,
+    ) -> u64;
+}
+unsafe extern "C" {
+    #[doc = " @brief Checks whether a clear key exists in the encrypted kv_store.\n\n Compares the encrypted key against all stored clear keys and OR-reduces\n the per-entry booleans into a single key-found flag.\n\n @param lwe_array_out_boolean      Output single-block ciphertext: 1 if key\n found, 0 otherwise\n @param lwe_array_in_encrypted_key Input encrypted key to look up\n @param h_decomposed_clear_keys    Host-side clear keys decomposed into radix\n blocks\n @param mem_ptr                    Scratch buffer from\n scratch_cuda_kv_store_contains_key_64_async\n @param ksks                       Key-switching keys (one per GPU)"]
+    pub fn cuda_kv_store_contains_key_64_async(
+        streams: CudaStreamsFFI,
+        lwe_array_out_boolean: *mut CudaRadixCiphertextFFI,
+        lwe_array_in_encrypted_key: *const CudaRadixCiphertextFFI,
+        h_decomposed_clear_keys: *const u64,
+        mem_ptr: *mut i8,
+        bsks: *const *mut ffi::c_void,
+        ksks: *const *mut ffi::c_void,
+    );
+}
+unsafe extern "C" {
+    #[doc = " @brief Releases the scratch buffer allocated by\n scratch_cuda_kv_store_contains_key_64_async.\n\n @param mem_ptr_void  Pointer to the scratch buffer pointer (set to nullptr\n on return)"]
+    pub fn cleanup_cuda_kv_store_contains_key_64(
+        streams: CudaStreamsFFI,
+        mem_ptr_void: *mut *mut i8,
+    );
+}
 pub const RERAND_MODE_RERAND_WITH_KS: RERAND_MODE = 0;
 pub const RERAND_MODE_RERAND_WITHOUT_KS: RERAND_MODE = 1;
 pub type RERAND_MODE = ffi::c_uint;

--- a/backends/tfhe-cuda-backend/wrapper.h
+++ b/backends/tfhe-cuda-backend/wrapper.h
@@ -1,6 +1,7 @@
 // These files must be added to the headers vec in the build.rs to check for file changes
 #include "cuda/include/ciphertext.h"
 #include "cuda/include/integer/compression/compression.h"
+#include "cuda/include/integer/kv_store/kv_store.h"
 #include "cuda/include/integer/integer.h"
 #include "cuda/include/integer/rerand.h"
 #include "cuda/include/aes/aes.h"

--- a/backends/tfhe-cuda-common/cuda/CMakeLists.txt
+++ b/backends/tfhe-cuda-common/cuda/CMakeLists.txt
@@ -25,7 +25,7 @@ set(CMAKE_CUDA_STANDARD_REQUIRED ON)
 # Auto-detect CUDA compute capability
 set(OUTPUTFILE ${CMAKE_CURRENT_SOURCE_DIR}/cuda_script)
 set(CUDAFILE ${CMAKE_CURRENT_SOURCE_DIR}/check_cuda.cu)
-execute_process(COMMAND nvcc -lcuda ${CUDAFILE} -o ${OUTPUTFILE})
+execute_process(COMMAND ${CMAKE_CUDA_COMPILER} -lcuda ${CUDAFILE} -o ${OUTPUTFILE})
 execute_process(
   COMMAND ${OUTPUTFILE}
   RESULT_VARIABLE CUDA_RETURN_CODE

--- a/backends/zk-cuda-backend/cuda/CMakeLists.txt
+++ b/backends/zk-cuda-backend/cuda/CMakeLists.txt
@@ -31,7 +31,7 @@ if(NOT TFHE_CUDA_COMMON_CHECK_CUDA_DIR)
   set(TFHE_CUDA_COMMON_CHECK_CUDA_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../tfhe-cuda-common/cuda)
 endif()
 set(CUDAFILE ${TFHE_CUDA_COMMON_CHECK_CUDA_DIR}/check_cuda.cu)
-execute_process(COMMAND nvcc -lcuda ${CUDAFILE} -o ${OUTPUTFILE})
+execute_process(COMMAND ${CMAKE_CUDA_COMPILER} -lcuda ${CUDAFILE} -o ${OUTPUTFILE})
 execute_process(
   COMMAND ${OUTPUTFILE}
   RESULT_VARIABLE CUDA_RETURN_CODE

--- a/scripts/check_scratch_cleanup.py
+++ b/scripts/check_scratch_cleanup.py
@@ -54,29 +54,29 @@ RUST_CALL_SITES = [
 # Bindings parsed from bindings.rs
 # Scratch functions: Two more than cleanup functions because of
 #  'scratch_cuda_programmable_bootstrap_32_async' and
-EXPECTED_SCRATCH_COUNT = 74
+EXPECTED_SCRATCH_COUNT = 78
 
 # Cuda operation functions
-EXPECTED_CUDA_COUNT = 107
+EXPECTED_CUDA_COUNT = 111
 
 # Cleanup functions
-EXPECTED_CLEANUP_COUNT = 74
+EXPECTED_CLEANUP_COUNT = 78
 
 # Check 3: Rust call-site scanning
 # Number of functions in ffi.rs files
-EXPECTED_CHECK3_RUST_FNS = 134
+EXPECTED_CHECK3_RUST_FNS = 138
 # Number of functions in ffi.rs files that
-EXPECTED_CHECK3_ASYNC_CUDA_CALLS = 98
+EXPECTED_CHECK3_ASYNC_CUDA_CALLS = 102
 
 # Number of instances of Rust calls to the scratch/cuda/cleanup in a
 # triplet sequence.
-EXPECTED_CHECK3_SCRATCH_CUDA_CLEANUP_TRIPLET_CALLS = 116
+EXPECTED_CHECK3_SCRATCH_CUDA_CLEANUP_TRIPLET_CALLS = 120
 
 # Check 5: Rust async-caller scanning
-EXPECTED_CHECK5_ASYNC_CALLERS = 127
+EXPECTED_CHECK5_ASYNC_CALLERS = 131
 
 # Check 6: Rust cleanup-caller scanning
-EXPECTED_CHECK6_CLEANUP_CALLERS = 114
+EXPECTED_CHECK6_CLEANUP_CALLERS = 118
 
 
 def check_paths_exist():

--- a/tfhe-benchmark/benches/high_level_api/kv_store.rs
+++ b/tfhe-benchmark/benches/high_level_api/kv_store.rs
@@ -1,6 +1,12 @@
 #[cfg(not(any(feature = "gpu", feature = "hpu")))]
 use benchmark::find_optimal_batch::find_optimal_batch;
 use benchmark::high_level_api::type_display::*;
+#[cfg(feature = "gpu")]
+use benchmark::params_aliases::BENCH_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+#[cfg(feature = "gpu")]
+use benchmark::params_aliases::BENCH_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+#[cfg(feature = "gpu")]
+use benchmark::utilities::{configure_gpu, get_param_type, ParamType};
 use benchmark::utilities::{write_to_json, BitSizesSet, EnvConfig, OperatorType};
 use benchmark_spec::tfhe::hlapi::kv_store::KvStoreOp;
 use benchmark_spec::{
@@ -13,10 +19,7 @@ use tfhe::core_crypto::prelude::Numeric;
 use tfhe::integer::block_decomposition::DecomposableInto;
 use tfhe::keycache::NamedParam;
 use tfhe::prelude::*;
-use tfhe::{
-    ClientKey, CompressedServerKey, FheIntegerType, FheUint128, FheUint32, FheUint64, FheUintId,
-    KVStore,
-};
+use tfhe::{ClientKey, FheIntegerType, FheUint128, FheUint32, FheUint64, FheUintId, KVStore};
 
 fn bench_kv_store<Key, FheKey, Value>(c: &mut Criterion, cks: &ClientKey, num_elements: usize)
 where
@@ -239,41 +242,49 @@ where
 fn main() {
     let env_config = EnvConfig::new();
 
-    let (cks, benched_device) = {
+    #[cfg(feature = "gpu")]
+    let cks = {
+        let params: tfhe::shortint::AtomicPatternParameters = match get_param_type() {
+            ParamType::Classical => BENCH_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128.into(),
+            _ => BENCH_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128.into(),
+        };
+        let config = tfhe::ConfigBuilder::with_custom_parameters(params).build();
+        let cks = ClientKey::generate(config);
+        configure_gpu(&cks);
+        cks
+    };
+
+    #[cfg(not(feature = "gpu"))]
+    let cks = {
         use benchmark::params_aliases::BENCH_PARAM_MESSAGE_2_CARRY_2_KS32_PBS;
-        use tfhe::{set_server_key, ConfigBuilder};
+        use tfhe::{set_server_key, CompressedServerKey, ConfigBuilder};
         let config =
             ConfigBuilder::with_custom_parameters(BENCH_PARAM_MESSAGE_2_CARRY_2_KS32_PBS).build();
         let cks = ClientKey::generate(config);
         let compressed_sks = CompressedServerKey::new(&cks);
-
         let sks = compressed_sks.decompress();
         rayon::broadcast(|_| set_server_key(sks.clone()));
         set_server_key(sks);
-        (cks, tfhe::Device::Cpu)
+        cks
     };
 
     let mut c = Criterion::default().configure_from_args();
 
     match env_config.bit_sizes_set {
         BitSizesSet::Fast => {
-            if benched_device == tfhe::Device::Cpu {
-                bench_kv_store::<u64, FheUint64, FheUint64>(&mut c, &cks, 1 << 10);
-            }
+            bench_kv_store::<u64, FheUint64, FheUint64>(&mut c, &cks, 1 << 10);
         }
         _ => {
-            if benched_device == tfhe::Device::Cpu {
-                for pow in 1..=10 {
-                    bench_kv_store::<u64, FheUint64, FheUint32>(&mut c, &cks, 1 << pow);
-                }
+            for pow in 1..=10 {
+                bench_kv_store::<u64, FheUint64, FheUint32>(&mut c, &cks, 1 << pow);
+            }
 
-                for pow in 1..=10 {
-                    bench_kv_store::<u64, FheUint64, FheUint64>(&mut c, &cks, 1 << pow);
-                }
+            for pow in 1..=10 {
+                bench_kv_store::<u64, FheUint64, FheUint64>(&mut c, &cks, 1 << pow);
+            }
 
-                for pow in 1..=10 {
-                    bench_kv_store::<u128, FheUint128, FheUint64>(&mut c, &cks, 1 << pow);
-                }
+            for pow in 1..=10 {
+                bench_kv_store::<u128, FheUint128, FheUint64>(&mut c, &cks, 1 << pow);
             }
         }
     }

--- a/tfhe/src/high_level_api/kv_store.rs
+++ b/tfhe/src/high_level_api/kv_store.rs
@@ -3,23 +3,48 @@ use tfhe_versionable::Versionize;
 
 use crate::backward_compatibility::kv_store::CompressedKVStoreVersions;
 use crate::high_level_api::global_state;
+#[cfg(feature = "gpu")]
+use crate::high_level_api::global_state::with_cuda_internal_keys;
 use crate::high_level_api::integers::FheIntegerType;
 use crate::high_level_api::keys::InternalServerKey;
-use crate::integer::block_decomposition::{Decomposable, DecomposableInto};
+use crate::integer::block_decomposition::DecomposableInto;
 use crate::integer::ciphertext::{Compressible, Expandable};
+#[cfg(feature = "gpu")]
+use crate::integer::gpu::ciphertext::CudaIntegerRadixCiphertext;
+#[cfg(feature = "gpu")]
+use crate::integer::gpu::server_key::radix::kv_store::CudaKVStore as IntegerGpuKVStore;
 use crate::integer::server_key::{
-    CompressedKVStore as CompressedIntegerKVStore, KVStore as IntegerKVStore,
+    CompressedKVStore as CompressedIntegerKVStore, KVStore as IntegerCpuKVStore,
 };
 use crate::prelude::CastInto;
 use crate::{FheBool, IntegerId, ReRandomizationMetadata, Tag};
 use std::fmt::Display;
 
-#[derive(Clone)]
 enum InnerKVStore<Key, T>
 where
     T: FheIntegerType,
 {
-    Cpu(IntegerKVStore<Key, <T::Id as IntegerId>::InnerCpu>),
+    Cpu(IntegerCpuKVStore<Key, <T::Id as IntegerId>::InnerCpu>),
+    #[cfg(feature = "gpu")]
+    Cuda(IntegerGpuKVStore<Key, <T::Id as IntegerId>::InnerGpu>),
+}
+
+impl<Key, T> Clone for InnerKVStore<Key, T>
+where
+    Key: Clone + Ord,
+    T: FheIntegerType,
+    <T::Id as IntegerId>::InnerCpu: Clone,
+{
+    fn clone(&self) -> Self {
+        match self {
+            Self::Cpu(inner) => Self::Cpu(inner.clone()),
+            #[cfg(feature = "gpu")]
+            Self::Cuda(inner) => with_cuda_internal_keys(|key| {
+                let streams = &key.streams;
+                Self::Cuda(inner.duplicate(streams))
+            }),
+        }
+    }
 }
 
 /// The KVStore is a specialized encrypted HashMap
@@ -27,7 +52,7 @@ where
 /// * Keys are clear numbers
 /// * Values are FheInt or FheUint
 ///
-/// This stores allows to insert, removed, get using clear keys.
+/// This store allows inserting, removing, and getting values using clear keys.
 /// It also allows to do some operations using encrypted keys.
 ///
 /// To serialize a KVStore it must first be compressed with [KVStore::compress]
@@ -39,7 +64,6 @@ where
 /// using the currently set server key.
 /// Even operations that do not require FHE operations will require
 /// a server key to be set in order to set the tag
-#[derive(Clone)]
 pub struct KVStore<Key, T>
 where
     T: FheIntegerType,
@@ -47,14 +71,33 @@ where
     inner: InnerKVStore<Key, T>,
 }
 
+impl<Key, T> Clone for KVStore<Key, T>
+where
+    Key: Clone + Ord,
+    T: FheIntegerType,
+    <T::Id as IntegerId>::InnerCpu: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
 impl<Key, T> KVStore<Key, T>
 where
     T: FheIntegerType,
 {
     /// Creates a new empty `KVStore`.
+    ///
+    /// Defaults to the CPU variant when no server key is set.
     pub fn new() -> Self {
         Self {
-            inner: InnerKVStore::Cpu(IntegerKVStore::new()),
+            inner: global_state::try_with_internal_keys(|server_key| match server_key {
+                #[cfg(feature = "gpu")]
+                Some(InternalServerKey::Cuda(_)) => InnerKVStore::Cuda(IntegerGpuKVStore::new()),
+                _ => InnerKVStore::Cpu(IntegerCpuKVStore::new()),
+            }),
         }
     }
 
@@ -62,6 +105,8 @@ where
     pub fn len(&self) -> usize {
         match &self.inner {
             InnerKVStore::Cpu(kvstore) => kvstore.len(),
+            #[cfg(feature = "gpu")]
+            InnerKVStore::Cuda(kvstore) => kvstore.len(),
         }
     }
 
@@ -69,6 +114,8 @@ where
     pub fn is_empty(&self) -> bool {
         match &self.inner {
             InnerKVStore::Cpu(kvstore) => kvstore.is_empty(),
+            #[cfg(feature = "gpu")]
+            InnerKVStore::Cuda(kvstore) => kvstore.is_empty(),
         }
     }
 
@@ -90,8 +137,23 @@ where
                 ))
             }
             #[cfg(feature = "gpu")]
-            (InternalServerKey::Cuda(_cuda_key), _) => {
-                panic!("GPU does not support KVStore yet")
+            (InternalServerKey::Cuda(cuda_key), InnerKVStore::Cpu(inner_store)) => {
+                let inner = inner_store.insert(key, value.into_cpu())?;
+                Some(T::from_cpu(
+                    inner,
+                    cuda_key.tag.clone(),
+                    ReRandomizationMetadata::default(),
+                ))
+            }
+            #[cfg(feature = "gpu")]
+            (InternalServerKey::Cuda(cuda_key), InnerKVStore::Cuda(inner_store)) => {
+                let streams = &cuda_key.streams;
+                let inner = inner_store.insert(key, value.into_gpu(streams))?;
+                Some(T::from_gpu(
+                    inner,
+                    cuda_key.tag.clone(),
+                    ReRandomizationMetadata::default(),
+                ))
             }
             #[cfg(feature = "hpu")]
             (InternalServerKey::Hpu(_device), _) => {
@@ -133,8 +195,33 @@ where
                 )
             }
             #[cfg(feature = "gpu")]
-            (InternalServerKey::Cuda(_cuda_key), _) => {
-                panic!("GPU does not support KVStore yet")
+            (InternalServerKey::Cuda(cuda_key), InnerKVStore::Cpu(inner_store)) => {
+                inner_store.get_mut(key).map_or_else(
+                    || None,
+                    |old_value_ref| {
+                        let old_value = std::mem::replace(old_value_ref, value.into_cpu());
+                        Some(T::from_cpu(
+                            old_value,
+                            cuda_key.tag.clone(),
+                            ReRandomizationMetadata::default(),
+                        ))
+                    },
+                )
+            }
+            #[cfg(feature = "gpu")]
+            (InternalServerKey::Cuda(cuda_key), InnerKVStore::Cuda(inner_store)) => {
+                let streams = &cuda_key.streams;
+                inner_store.get_mut(key).map_or_else(
+                    || None,
+                    |old_value_ref| {
+                        let old_value = std::mem::replace(old_value_ref, value.into_gpu(streams));
+                        Some(T::from_gpu(
+                            old_value,
+                            cuda_key.tag.clone(),
+                            ReRandomizationMetadata::default(),
+                        ))
+                    },
+                )
             }
             #[cfg(feature = "hpu")]
             (InternalServerKey::Hpu(_device), _) => {
@@ -167,8 +254,22 @@ where
                 ))
             }
             #[cfg(feature = "gpu")]
-            (InternalServerKey::Cuda(_cuda_key), _) => {
-                panic!("GPU does not support KVStore yet")
+            (InternalServerKey::Cuda(cuda_key), InnerKVStore::Cpu(inner_store)) => {
+                let inner = inner_store.remove(key)?;
+                Some(T::from_cpu(
+                    inner,
+                    cuda_key.tag.clone(),
+                    ReRandomizationMetadata::default(),
+                ))
+            }
+            #[cfg(feature = "gpu")]
+            (InternalServerKey::Cuda(cuda_key), InnerKVStore::Cuda(inner_store)) => {
+                let inner = inner_store.remove(key)?;
+                Some(T::from_gpu(
+                    inner,
+                    cuda_key.tag.clone(),
+                    ReRandomizationMetadata::default(),
+                ))
             }
             #[cfg(feature = "hpu")]
             (InternalServerKey::Hpu(_device), _) => {
@@ -187,6 +288,8 @@ where
     {
         match &self.inner {
             InnerKVStore::Cpu(kvstore) => kvstore.contains_key(key),
+            #[cfg(feature = "gpu")]
+            InnerKVStore::Cuda(kvstore) => kvstore.contains_key(key),
         }
     }
 
@@ -215,8 +318,22 @@ where
                 ))
             }
             #[cfg(feature = "gpu")]
-            (InternalServerKey::Cuda(_cuda_key), _) => {
-                panic!("GPU does not support KVStore yet")
+            (InternalServerKey::Cuda(cuda_key), InnerKVStore::Cpu(inner_store)) => {
+                let inner = inner_store.get(key)?;
+                Some(T::from_cpu(
+                    inner.clone(),
+                    cuda_key.tag.clone(),
+                    ReRandomizationMetadata::default(),
+                ))
+            }
+            #[cfg(feature = "gpu")]
+            (InternalServerKey::Cuda(cuda_key), InnerKVStore::Cuda(inner_store)) => {
+                let inner = inner_store.get(key)?;
+                Some(T::from_gpu(
+                    inner.duplicate(&cuda_key.streams),
+                    cuda_key.tag.clone(),
+                    ReRandomizationMetadata::default(),
+                ))
             }
             #[cfg(feature = "hpu")]
             (InternalServerKey::Hpu(_device), _) => {
@@ -231,6 +348,7 @@ impl<Key, T> Default for KVStore<Key, T>
 where
     T: FheIntegerType,
 {
+    /// Defaults to the CPU variant when no server key is set.
     fn default() -> Self {
         Self::new()
     }
@@ -238,7 +356,9 @@ where
 
 impl<Key, T> KVStore<Key, T>
 where
-    Key: Decomposable + CastInto<usize> + Ord,
+    // DecomposableInto<u64> (not just Decomposable): the GPU backend passes
+    // clear keys as u64 blocks through the FFI.
+    Key: DecomposableInto<u64> + CastInto<usize> + Ord,
     T: FheIntegerType,
 {
     /// Gets the value corresponding to the encrypted key.
@@ -276,8 +396,29 @@ where
                 )
             }
             #[cfg(feature = "gpu")]
-            (InternalServerKey::Cuda(_cuda_key), _) => {
-                panic!("GPU does not support KVStore yet")
+            (InternalServerKey::Cuda(_cuda_key), InnerKVStore::Cpu(_inner_store)) => {
+                panic!("CudaServerKey does not support CPU's KVStore")
+            }
+            #[cfg(feature = "gpu")]
+            (InternalServerKey::Cuda(cuda_key), InnerKVStore::Cuda(inner_store)) => {
+                let streams = &cuda_key.streams;
+                let (inner_ct, inner_bool) = cuda_key.pbs_key().kv_store_get(
+                    inner_store,
+                    &*encrypted_key.on_gpu(streams),
+                    streams,
+                );
+                (
+                    T::from_gpu(
+                        inner_ct,
+                        cuda_key.tag.clone(),
+                        ReRandomizationMetadata::default(),
+                    ),
+                    FheBool::new(
+                        inner_bool,
+                        cuda_key.tag.clone(),
+                        ReRandomizationMetadata::default(),
+                    ),
+                )
             }
             #[cfg(feature = "hpu")]
             (InternalServerKey::Hpu(_device), _) => {
@@ -313,8 +454,22 @@ where
                 )
             }
             #[cfg(feature = "gpu")]
-            (InternalServerKey::Cuda(_cuda_key), _) => {
-                panic!("GPU does not support KVStore yet")
+            (InternalServerKey::Cuda(_cuda_key), InnerKVStore::Cpu(_)) => {
+                panic!("CudaServerKey does not support CPU's KVStore")
+            }
+            #[cfg(feature = "gpu")]
+            (InternalServerKey::Cuda(cuda_key), InnerKVStore::Cuda(inner_store)) => {
+                let streams = &cuda_key.streams;
+                let inner = cuda_key.pbs_key().kv_store_contains_key(
+                    inner_store,
+                    &*encrypted_key.on_gpu(streams),
+                    streams,
+                );
+                FheBool::new(
+                    inner,
+                    cuda_key.tag.clone(),
+                    ReRandomizationMetadata::default(),
+                )
             }
             #[cfg(feature = "hpu")]
             (InternalServerKey::Hpu(_device), _) => {
@@ -341,8 +496,22 @@ where
                 )
             }
             #[cfg(feature = "gpu")]
-            (InternalServerKey::Cuda(_cuda_key), _) => {
-                panic!("GPU does not support KVStore yet")
+            (InternalServerKey::Cuda(_cuda_key), InnerKVStore::Cpu(_)) => {
+                panic!("CudaServerKey does not support CPU's KVStore")
+            }
+            #[cfg(feature = "gpu")]
+            (InternalServerKey::Cuda(cuda_key), InnerKVStore::Cuda(inner_store)) => {
+                let streams = &cuda_key.streams;
+                let inner = cuda_key.pbs_key().kv_store_contains_value(
+                    inner_store,
+                    &*encrypted_value.on_gpu(streams),
+                    streams,
+                );
+                FheBool::new(
+                    inner,
+                    cuda_key.tag.clone(),
+                    ReRandomizationMetadata::default(),
+                )
             }
             #[cfg(feature = "hpu")]
             (InternalServerKey::Hpu(_device), _) => {
@@ -372,8 +541,22 @@ where
                 )
             }
             #[cfg(feature = "gpu")]
-            (InternalServerKey::Cuda(_cuda_key), _) => {
-                panic!("GPU does not support KVStore yet")
+            (InternalServerKey::Cuda(_cuda_key), InnerKVStore::Cpu(_)) => {
+                panic!("CudaServerKey does not support CPU's KVStore")
+            }
+            #[cfg(feature = "gpu")]
+            (InternalServerKey::Cuda(cuda_key), InnerKVStore::Cuda(inner_store)) => {
+                let streams = &cuda_key.streams;
+                let inner = cuda_key.pbs_key().kv_store_contains_clear_value(
+                    inner_store,
+                    clear_value,
+                    streams,
+                );
+                FheBool::new(
+                    inner,
+                    cuda_key.tag.clone(),
+                    ReRandomizationMetadata::default(),
+                )
             }
             #[cfg(feature = "hpu")]
             (InternalServerKey::Hpu(_device), _) => {
@@ -414,8 +597,23 @@ where
                 )
             }
             #[cfg(feature = "gpu")]
-            (InternalServerKey::Cuda(_cuda_key), _) => {
-                panic!("GPU does not support KVStore yet")
+            (InternalServerKey::Cuda(_cuda_key), InnerKVStore::Cpu(_)) => {
+                panic!("CudaServerKey does not support CPU's KVStore")
+            }
+            #[cfg(feature = "gpu")]
+            (InternalServerKey::Cuda(cuda_key), InnerKVStore::Cuda(inner_store)) => {
+                let streams = &cuda_key.streams;
+                let inner = cuda_key.pbs_key().kv_store_update(
+                    inner_store,
+                    &*encrypted_key.on_gpu(streams),
+                    &*new_value.on_gpu(streams),
+                    streams,
+                );
+                FheBool::new(
+                    inner,
+                    cuda_key.tag.clone(),
+                    ReRandomizationMetadata::default(),
+                )
             }
             #[cfg(feature = "hpu")]
             (InternalServerKey::Hpu(_device), _) => {
@@ -475,8 +673,40 @@ where
                 )
             }
             #[cfg(feature = "gpu")]
-            (InternalServerKey::Cuda(_cuda_key), _) => {
-                panic!("GPU does not support KVStore yet")
+            (InternalServerKey::Cuda(_cuda_key), InnerKVStore::Cpu(_)) => {
+                panic!("CudaServerKey does not support CPU's KVStore")
+            }
+            #[cfg(feature = "gpu")]
+            (InternalServerKey::Cuda(cuda_key), InnerKVStore::Cuda(inner_store)) => {
+                let streams = &cuda_key.streams;
+                let (inner_old, inner_new, inner_bool) = cuda_key.pbs_key().kv_store_map(
+                    inner_store,
+                    &*encrypted_key.on_gpu(streams),
+                    |radix| {
+                        let wrapped =
+                            T::from_gpu(radix, Tag::default(), ReRandomizationMetadata::default());
+                        let wrapped_result = func(wrapped);
+                        wrapped_result.into_gpu(streams)
+                    },
+                    streams,
+                );
+                (
+                    T::from_gpu(
+                        inner_old,
+                        cuda_key.tag.clone(),
+                        ReRandomizationMetadata::default(),
+                    ),
+                    T::from_gpu(
+                        inner_new,
+                        cuda_key.tag.clone(),
+                        ReRandomizationMetadata::default(),
+                    ),
+                    FheBool::new(
+                        inner_bool,
+                        cuda_key.tag.clone(),
+                        ReRandomizationMetadata::default(),
+                    ),
+                )
             }
             #[cfg(feature = "hpu")]
             (InternalServerKey::Hpu(_device), _) => {
@@ -506,8 +736,21 @@ where
                 })
             }
             #[cfg(feature = "gpu")]
-            (InternalServerKey::Cuda(_cuda_key), _) => {
-                panic!("GPU does not support KVStore yet")
+            (InternalServerKey::Cuda(_), InnerKVStore::Cpu(_)) => {
+                panic!("CudaServerKey does not support CPU's KVStore compression")
+            }
+            #[cfg(feature = "gpu")]
+            (InternalServerKey::Cuda(cuda_key), InnerKVStore::Cuda(inner_store)) => {
+                let comp_key = cuda_key
+                    .key
+                    .compression_key
+                    .as_ref()
+                    .ok_or(crate::high_level_api::errors::UninitializedCompressionKey)?;
+                let streams = &cuda_key.streams;
+                let compressed_inner = inner_store.compress(comp_key, streams);
+                Ok(CompressedKVStore {
+                    inner: compressed_inner,
+                })
             }
             #[cfg(feature = "hpu")]
             (InternalServerKey::Hpu(_device), _) => {
@@ -578,7 +821,8 @@ where
     /// * A value does not have the same number of blocks as the others.
     /// * If the requested value type is not compatible with the data stored
     ///
-    /// Both these errors indicate corrupted or malformed data
+    /// An incompatible requested value type indicates the value type is wrong for the stored data;
+    /// the other errors indicate corrupted or malformed data.
     pub fn decompress(&self) -> crate::Result<KVStore<Key, Value>>
     where
         <Value::Id as IntegerId>::InnerCpu: Expandable,
@@ -608,8 +852,28 @@ where
                 })
             }
             #[cfg(feature = "gpu")]
-            Some(InternalServerKey::Cuda(_cuda_key)) => {
-                panic!("Decompressing KVStore to GPU is not implemented yet")
+            Some(InternalServerKey::Cuda(cuda_key)) => {
+                let decomp_key = cuda_key
+                    .key
+                    .decompression_key
+                    .as_ref()
+                    .ok_or(crate::high_level_api::errors::UninitializedDecompressionKey)?;
+                let streams = &cuda_key.streams;
+                let inner_kv_store = self.inner.decompress_to_cuda(decomp_key, streams)?;
+
+                let Some(actual_block_count) = inner_kv_store.blocks_per_radix() else {
+                    return Ok(KVStore::new());
+                };
+
+                let expected_block_count = Value::Id::num_blocks(cuda_key.message_modulus());
+
+                if actual_block_count.get() != expected_block_count {
+                    return Err(crate::error!("Inconsistent block count in KVStore: expected {expected_block_count} but got {actual_block_count}"));
+                }
+
+                Ok(KVStore {
+                    inner: InnerKVStore::Cuda(inner_kv_store),
+                })
             }
             #[cfg(feature = "hpu")]
             Some(InternalServerKey::Hpu(_device)) => {
@@ -903,6 +1167,18 @@ mod test {
         }
     }
 
+    // Verify that KVStore::new() and KVStore::default() do not panic when no server key
+    // is set.
+    #[test]
+    fn test_new_without_server_key_does_not_panic() {
+        let store = KVStore::<u8, FheUint32>::new();
+        assert!(store.is_empty());
+        assert_eq!(store.len(), 0);
+
+        let store_default = KVStore::<u8, FheUint32>::default();
+        assert!(store_default.is_empty());
+    }
+
     mod cpu {
         use crate::shortint::parameters::COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
         use crate::{set_server_key, ConfigBuilder};
@@ -970,6 +1246,114 @@ mod test {
             let ck = setup_default_cpu();
 
             kv_store_serialization_test_case(&ck);
+        }
+    }
+
+    #[cfg(feature = "gpu")]
+    mod gpu {
+        use crate::shortint::parameters::{
+            CompressionParameters,
+            COMP_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+            COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+            PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+            PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+        };
+        use crate::shortint::AtomicPatternParameters;
+        use crate::{set_server_key, ConfigBuilder};
+
+        use super::*;
+
+        fn gpu_parameter_sets() -> [(AtomicPatternParameters, CompressionParameters); 2] {
+            [
+                (
+                    PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128.into(),
+                    COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+                ),
+                (
+                    PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128.into(),
+                    COMP_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+                ),
+            ]
+        }
+
+        fn setup_gpu(
+            params: AtomicPatternParameters,
+            comp_params: CompressionParameters,
+        ) -> ClientKey {
+            let config = ConfigBuilder::with_custom_parameters(params)
+                .enable_compression(comp_params)
+                .build();
+
+            let client_key = ClientKey::generate(config);
+            let csks = crate::CompressedServerKey::new(&client_key);
+            let server_key = csks.decompress_to_gpu();
+
+            set_server_key(server_key);
+
+            client_key
+        }
+
+        #[test]
+        fn test_kv_store_get() {
+            for (params, comp_params) in gpu_parameter_sets() {
+                let ck = setup_gpu(params, comp_params);
+
+                kv_store_get_test_case(&ck);
+            }
+        }
+
+        #[test]
+        fn test_kv_store_update() {
+            for (params, comp_params) in gpu_parameter_sets() {
+                let ck = setup_gpu(params, comp_params);
+
+                kv_store_update_test_case(&ck);
+            }
+        }
+
+        #[test]
+        fn test_kv_store_map() {
+            for (params, comp_params) in gpu_parameter_sets() {
+                let ck = setup_gpu(params, comp_params);
+
+                kv_store_map_test_case(&ck);
+            }
+        }
+
+        #[test]
+        fn test_kv_store_contains_key() {
+            for (params, comp_params) in gpu_parameter_sets() {
+                let ck = setup_gpu(params, comp_params);
+
+                kv_store_contains_key_test_case(&ck);
+            }
+        }
+
+        #[test]
+        fn test_kv_store_contains_value() {
+            for (params, comp_params) in gpu_parameter_sets() {
+                let ck = setup_gpu(params, comp_params);
+
+                kv_store_contains_value_test_case(&ck);
+            }
+        }
+
+        #[test]
+        fn test_kv_store_contains_clear_value() {
+            for (params, comp_params) in gpu_parameter_sets() {
+                let ck = setup_gpu(params, comp_params);
+
+                kv_store_contains_clear_value_test_case(&ck);
+            }
+        }
+
+        #[test]
+        fn test_kv_store_serialization() {
+            for (params, comp_params) in gpu_parameter_sets() {
+                let ck = setup_gpu(params, comp_params);
+
+                kv_store_serialization_test_case(&ck);
+            }
         }
     }
 }

--- a/tfhe/src/integer/gpu/ciphertext/mod.rs
+++ b/tfhe/src/integer/gpu/ciphertext/mod.rs
@@ -18,7 +18,7 @@ use crate::GpuIndex;
 use crate::integer::gpu::ciphertext::info::{CudaBlockInfo, CudaRadixCiphertextInfo};
 pub use compressed_noise_squashed_ciphertext_list::*;
 
-pub trait CudaIntegerRadixCiphertext: Sized {
+pub trait CudaIntegerRadixCiphertext: Sized + Send {
     const IS_SIGNED: bool;
     fn as_ref(&self) -> &CudaRadixCiphertext;
     fn as_mut(&mut self) -> &mut CudaRadixCiphertext;

--- a/tfhe/src/integer/gpu/ffi.rs
+++ b/tfhe/src/integer/gpu/ffi.rs
@@ -7320,7 +7320,7 @@ pub(crate) unsafe fn cuda_backend_unchecked_match_value<
     // Values: decomposed Packed, 2 digits per block (base message_modulus^2)
     // Toy example (message_modulus = 4): value 156 -> base 16 -> [12, 9]
     //   (unpacked base 4 would be [0, 3, 1, 2]).
-    // host_aggregate_one_hot_vector unpacks them at the end.
+    // The backend unpacks these packed digits at the end.
     let num_output_packed_blocks = num_output_unpacked_blocks.div_ceil(2);
 
     let h_match_outputs: Vec<u64> = matches
@@ -7425,6 +7425,706 @@ pub(crate) unsafe fn cuda_backend_unchecked_match_value<
     cleanup_cuda_unchecked_match_value_64(streams.ffi(), std::ptr::addr_of_mut!(mem_ptr));
 
     update_noise_degree(lwe_array_out_result.as_mut(), &ffi_out_result_struct);
+
+    update_noise_degree(
+        &mut lwe_array_out_boolean.0.ciphertext,
+        &ffi_out_boolean_struct,
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+/// # Safety
+///
+/// - The data must not be moved or dropped while being used by the CUDA kernel.
+/// - This function assumes exclusive access to the passed data; violating this may lead to
+///   undefined behavior.
+pub(crate) unsafe fn cuda_backend_kv_store_get<
+    T: UnsignedInteger,
+    B: Numeric,
+    R: CudaIntegerRadixCiphertext,
+    Clear: DecomposableInto<u64> + CastInto<usize>,
+>(
+    streams: &CudaStreams,
+    lwe_array_out_result: &mut R,
+    lwe_array_out_boolean: &mut CudaBooleanBlock,
+    lwe_array_out_selectors: &mut CudaRadixCiphertext,
+    lwe_array_in_encrypted_key: &CudaRadixCiphertext,
+    lwe_array_in_values: &CudaRadixCiphertext,
+    clear_keys: &[Clear],
+    num_blocks_per_value: u32,
+    message_modulus: MessageModulus,
+    carry_modulus: CarryModulus,
+    bootstrapping_key: &CudaVec<B>,
+    keyswitch_key: &CudaVec<T>,
+    bsk: &impl CudaBskParams,
+    ksk_params: CudaLweKeyswitchKeyParamsFFI,
+    ms_noise_reduction_configuration: Option<&CudaModulusSwitchNoiseReductionConfiguration>,
+) {
+    let bsk_params = bsk.params_ffi();
+
+    assert_eq!(streams.gpu_indexes[0], bootstrapping_key.gpu_index(0));
+    assert_eq!(streams.gpu_indexes[0], keyswitch_key.gpu_index(0));
+    assert_eq!(
+        streams.gpu_indexes[0],
+        lwe_array_in_encrypted_key.d_blocks.0.d_vec.gpu_index(0)
+    );
+    assert_eq!(
+        streams.gpu_indexes[0],
+        lwe_array_out_result.as_ref().d_blocks.0.d_vec.gpu_index(0)
+    );
+    assert_eq!(
+        streams.gpu_indexes[0],
+        lwe_array_out_boolean
+            .0
+            .ciphertext
+            .d_blocks
+            .0
+            .d_vec
+            .gpu_index(0)
+    );
+    assert_eq!(
+        streams.gpu_indexes[0],
+        lwe_array_in_values.d_blocks.0.d_vec.gpu_index(0)
+    );
+    assert_eq!(
+        streams.gpu_indexes[0],
+        lwe_array_out_selectors.d_blocks.0.d_vec.gpu_index(0)
+    );
+
+    let num_input_blocks =
+        u32::try_from(lwe_array_in_encrypted_key.d_blocks.lwe_ciphertext_count().0).unwrap();
+    let num_bits_in_message = message_modulus.0.ilog2();
+    let num_entries = u32::try_from(clear_keys.len()).unwrap();
+
+    let h_decomposed_clear_keys: Vec<u64> = clear_keys
+        .iter()
+        .flat_map(|key| {
+            BlockDecomposer::new(*key, num_bits_in_message)
+                .take(num_input_blocks as usize)
+                .map(|block_value: Clear| block_value.cast_into())
+                .collect::<Vec<u64>>()
+        })
+        .collect();
+
+    let noise_reduction_type = resolve_ms_noise_reduction_config(ms_noise_reduction_configuration);
+
+    let mut ffi_out_result_degrees: Vec<u64> = lwe_array_out_result
+        .as_ref()
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.degree.get())
+        .collect();
+    let mut ffi_out_result_noise_levels: Vec<u64> = lwe_array_out_result
+        .as_ref()
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.noise_level.0)
+        .collect();
+    let mut ffi_out_result_struct = prepare_cuda_radix_ffi(
+        lwe_array_out_result.as_ref(),
+        &mut ffi_out_result_degrees,
+        &mut ffi_out_result_noise_levels,
+    );
+
+    let mut ffi_out_boolean_degrees: Vec<u64> =
+        vec![lwe_array_out_boolean.0.ciphertext.info.blocks[0]
+            .degree
+            .get()];
+    let mut ffi_out_boolean_noise_levels: Vec<u64> = vec![
+        lwe_array_out_boolean.0.ciphertext.info.blocks[0]
+            .noise_level
+            .0,
+    ];
+    let mut ffi_out_boolean_struct = prepare_cuda_radix_ffi(
+        &lwe_array_out_boolean.0.ciphertext,
+        &mut ffi_out_boolean_degrees,
+        &mut ffi_out_boolean_noise_levels,
+    );
+
+    let mut ffi_out_selectors_degrees: Vec<u64> = lwe_array_out_selectors
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.degree.get())
+        .collect();
+    let mut ffi_out_selectors_noise_levels: Vec<u64> = lwe_array_out_selectors
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.noise_level.0)
+        .collect();
+    let mut ffi_out_selectors_struct = prepare_cuda_radix_ffi(
+        lwe_array_out_selectors,
+        &mut ffi_out_selectors_degrees,
+        &mut ffi_out_selectors_noise_levels,
+    );
+
+    let mut ffi_in_key_degrees: Vec<u64> = lwe_array_in_encrypted_key
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.degree.get())
+        .collect();
+    let mut ffi_in_key_noise_levels: Vec<u64> = lwe_array_in_encrypted_key
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.noise_level.0)
+        .collect();
+    let ffi_in_key_struct = prepare_cuda_radix_ffi(
+        lwe_array_in_encrypted_key,
+        &mut ffi_in_key_degrees,
+        &mut ffi_in_key_noise_levels,
+    );
+
+    let mut ffi_in_values_degrees: Vec<u64> = lwe_array_in_values
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.degree.get())
+        .collect();
+    let mut ffi_in_values_noise_levels: Vec<u64> = lwe_array_in_values
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.noise_level.0)
+        .collect();
+    let ffi_in_values_struct = prepare_cuda_radix_ffi(
+        lwe_array_in_values,
+        &mut ffi_in_values_degrees,
+        &mut ffi_in_values_noise_levels,
+    );
+
+    let mut mem_ptr: *mut i8 = std::ptr::null_mut();
+
+    scratch_cuda_kv_store_get_64_async(
+        streams.ffi(),
+        std::ptr::addr_of_mut!(mem_ptr),
+        bsk_params,
+        ksk_params,
+        num_entries,
+        num_input_blocks,
+        num_blocks_per_value,
+        u32::try_from(message_modulus.0).unwrap(),
+        u32::try_from(carry_modulus.0).unwrap(),
+        true,
+        noise_reduction_type as u32,
+    );
+
+    cuda_kv_store_get_64_async(
+        streams.ffi(),
+        &raw mut ffi_out_result_struct,
+        &raw mut ffi_out_boolean_struct,
+        &raw mut ffi_out_selectors_struct,
+        &raw const ffi_in_key_struct,
+        &raw const ffi_in_values_struct,
+        h_decomposed_clear_keys.as_ptr(),
+        mem_ptr,
+        bootstrapping_key.ptr.as_ptr(),
+        keyswitch_key.ptr.as_ptr(),
+    );
+
+    cleanup_cuda_kv_store_get_64(streams.ffi(), std::ptr::addr_of_mut!(mem_ptr));
+
+    update_noise_degree(lwe_array_out_result.as_mut(), &ffi_out_result_struct);
+
+    update_noise_degree(
+        &mut lwe_array_out_boolean.0.ciphertext,
+        &ffi_out_boolean_struct,
+    );
+
+    update_noise_degree(lwe_array_out_selectors, &ffi_out_selectors_struct);
+}
+
+#[allow(clippy::too_many_arguments)]
+/// # Safety
+///
+/// - The data must not be moved or dropped while being used by the CUDA kernel.
+/// - This function assumes exclusive access to the passed data; violating this may lead to
+///   undefined behavior.
+pub(crate) unsafe fn cuda_backend_kv_store_update<
+    T: UnsignedInteger,
+    B: Numeric,
+    Clear: DecomposableInto<u64> + CastInto<usize>,
+>(
+    streams: &CudaStreams,
+    lwe_check_out_block: &mut CudaRadixCiphertext,
+    lwe_array_out_values: &mut CudaRadixCiphertext,
+    lwe_array_in_encrypted_key: &CudaRadixCiphertext,
+    lwe_array_in_values: &CudaRadixCiphertext,
+    lwe_in_new_value: &CudaRadixCiphertext,
+    clear_keys: &[Clear],
+    num_blocks_per_value: u32,
+    message_modulus: MessageModulus,
+    carry_modulus: CarryModulus,
+    bootstrapping_key: &CudaVec<B>,
+    keyswitch_key: &CudaVec<T>,
+    bsk: &impl CudaBskParams,
+    ksk_params: CudaLweKeyswitchKeyParamsFFI,
+    ms_noise_reduction_configuration: Option<&CudaModulusSwitchNoiseReductionConfiguration>,
+) {
+    let bsk_params = bsk.params_ffi();
+
+    assert_eq!(streams.gpu_indexes[0], bootstrapping_key.gpu_index(0));
+    assert_eq!(streams.gpu_indexes[0], keyswitch_key.gpu_index(0));
+    assert_eq!(
+        streams.gpu_indexes[0],
+        lwe_check_out_block.d_blocks.0.d_vec.gpu_index(0)
+    );
+    assert_eq!(
+        streams.gpu_indexes[0],
+        lwe_array_out_values.d_blocks.0.d_vec.gpu_index(0)
+    );
+    assert_eq!(
+        streams.gpu_indexes[0],
+        lwe_array_in_encrypted_key.d_blocks.0.d_vec.gpu_index(0)
+    );
+    assert_eq!(
+        streams.gpu_indexes[0],
+        lwe_array_in_values.d_blocks.0.d_vec.gpu_index(0)
+    );
+    assert_eq!(
+        streams.gpu_indexes[0],
+        lwe_in_new_value.d_blocks.0.d_vec.gpu_index(0)
+    );
+
+    let num_input_blocks =
+        u32::try_from(lwe_array_in_encrypted_key.d_blocks.lwe_ciphertext_count().0).unwrap();
+    let num_bits_in_message = message_modulus.0.ilog2();
+    let num_entries = u32::try_from(clear_keys.len()).unwrap();
+
+    let h_decomposed_clear_keys: Vec<u64> = clear_keys
+        .iter()
+        .flat_map(|key| {
+            BlockDecomposer::new(*key, num_bits_in_message)
+                .take(num_input_blocks as usize)
+                .map(|block_value: Clear| block_value.cast_into())
+                .collect::<Vec<u64>>()
+        })
+        .collect();
+
+    let noise_reduction_type = resolve_ms_noise_reduction_config(ms_noise_reduction_configuration);
+
+    let mut ffi_out_degrees: Vec<u64> = lwe_check_out_block
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.degree.get())
+        .collect();
+    let mut ffi_out_noise_levels: Vec<u64> = lwe_check_out_block
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.noise_level.0)
+        .collect();
+    let mut ffi_out_struct = prepare_cuda_radix_ffi(
+        lwe_check_out_block,
+        &mut ffi_out_degrees,
+        &mut ffi_out_noise_levels,
+    );
+
+    let mut ffi_out_values_degrees: Vec<u64> = lwe_array_out_values
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.degree.get())
+        .collect();
+    let mut ffi_out_values_noise_levels: Vec<u64> = lwe_array_out_values
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.noise_level.0)
+        .collect();
+    let mut ffi_out_values_struct = prepare_cuda_radix_ffi(
+        lwe_array_out_values,
+        &mut ffi_out_values_degrees,
+        &mut ffi_out_values_noise_levels,
+    );
+
+    let mut ffi_in_encrypted_key_degrees: Vec<u64> = lwe_array_in_encrypted_key
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.degree.get())
+        .collect();
+    let mut ffi_in_encrypted_key_noise_levels: Vec<u64> = lwe_array_in_encrypted_key
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.noise_level.0)
+        .collect();
+    let ffi_in_encrypted_key_struct = prepare_cuda_radix_ffi(
+        lwe_array_in_encrypted_key,
+        &mut ffi_in_encrypted_key_degrees,
+        &mut ffi_in_encrypted_key_noise_levels,
+    );
+
+    let mut ffi_in_values_degrees: Vec<u64> = lwe_array_in_values
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.degree.get())
+        .collect();
+    let mut ffi_in_values_noise_levels: Vec<u64> = lwe_array_in_values
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.noise_level.0)
+        .collect();
+    let ffi_in_values_struct = prepare_cuda_radix_ffi(
+        lwe_array_in_values,
+        &mut ffi_in_values_degrees,
+        &mut ffi_in_values_noise_levels,
+    );
+
+    let mut ffi_in_new_value_degrees: Vec<u64> = lwe_in_new_value
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.degree.get())
+        .collect();
+    let mut ffi_in_new_value_noise_levels: Vec<u64> = lwe_in_new_value
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.noise_level.0)
+        .collect();
+    let ffi_in_new_value_struct = prepare_cuda_radix_ffi(
+        lwe_in_new_value,
+        &mut ffi_in_new_value_degrees,
+        &mut ffi_in_new_value_noise_levels,
+    );
+
+    let mut mem_ptr: *mut i8 = std::ptr::null_mut();
+
+    scratch_cuda_kv_store_update_64_async(
+        streams.ffi(),
+        std::ptr::addr_of_mut!(mem_ptr),
+        bsk_params,
+        ksk_params,
+        num_entries,
+        num_input_blocks,
+        num_blocks_per_value,
+        u32::try_from(message_modulus.0).unwrap(),
+        u32::try_from(carry_modulus.0).unwrap(),
+        true,
+        noise_reduction_type as u32,
+    );
+
+    cuda_kv_store_update_64_async(
+        streams.ffi(),
+        &raw mut ffi_out_struct,
+        &raw mut ffi_out_values_struct,
+        &raw const ffi_in_encrypted_key_struct,
+        &raw const ffi_in_values_struct,
+        &raw const ffi_in_new_value_struct,
+        h_decomposed_clear_keys.as_ptr(),
+        mem_ptr,
+        bootstrapping_key.ptr.as_ptr(),
+        keyswitch_key.ptr.as_ptr(),
+    );
+
+    cleanup_cuda_kv_store_update_64(streams.ffi(), std::ptr::addr_of_mut!(mem_ptr));
+
+    update_noise_degree(lwe_check_out_block, &ffi_out_struct);
+    update_noise_degree(lwe_array_out_values, &ffi_out_values_struct);
+}
+
+#[allow(clippy::too_many_arguments)]
+/// # Safety
+///
+/// - The data must not be moved or dropped while being used by the CUDA kernel.
+/// - This function assumes exclusive access to the passed data; violating this may lead to
+///   undefined behavior.
+pub(crate) unsafe fn cuda_backend_kv_store_map<T: UnsignedInteger, B: Numeric>(
+    streams: &CudaStreams,
+    lwe_check_out_block: &mut CudaRadixCiphertext,
+    lwe_array_out_values: &mut CudaRadixCiphertext,
+    lwe_array_in_values: &CudaRadixCiphertext,
+    lwe_in_new_value: &CudaRadixCiphertext,
+    lwe_array_in_selectors: &CudaRadixCiphertext,
+    num_blocks_per_value: u32,
+    message_modulus: MessageModulus,
+    carry_modulus: CarryModulus,
+    bootstrapping_key: &CudaVec<B>,
+    keyswitch_key: &CudaVec<T>,
+    bsk: &impl CudaBskParams,
+    ksk_params: CudaLweKeyswitchKeyParamsFFI,
+    ms_noise_reduction_configuration: Option<&CudaModulusSwitchNoiseReductionConfiguration>,
+) {
+    let bsk_params = bsk.params_ffi();
+
+    assert_eq!(streams.gpu_indexes[0], bootstrapping_key.gpu_index(0));
+    assert_eq!(streams.gpu_indexes[0], keyswitch_key.gpu_index(0));
+    assert_eq!(
+        streams.gpu_indexes[0],
+        lwe_check_out_block.d_blocks.0.d_vec.gpu_index(0)
+    );
+    assert_eq!(
+        streams.gpu_indexes[0],
+        lwe_array_out_values.d_blocks.0.d_vec.gpu_index(0)
+    );
+    assert_eq!(
+        streams.gpu_indexes[0],
+        lwe_array_in_selectors.d_blocks.0.d_vec.gpu_index(0)
+    );
+    assert_eq!(
+        streams.gpu_indexes[0],
+        lwe_array_in_values.d_blocks.0.d_vec.gpu_index(0)
+    );
+    assert_eq!(
+        streams.gpu_indexes[0],
+        lwe_in_new_value.d_blocks.0.d_vec.gpu_index(0)
+    );
+
+    let num_entries =
+        u32::try_from(lwe_array_in_selectors.d_blocks.lwe_ciphertext_count().0).unwrap();
+
+    let noise_reduction_type = resolve_ms_noise_reduction_config(ms_noise_reduction_configuration);
+
+    let mut ffi_out_degrees: Vec<u64> = lwe_check_out_block
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.degree.get())
+        .collect();
+    let mut ffi_out_noise_levels: Vec<u64> = lwe_check_out_block
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.noise_level.0)
+        .collect();
+    let mut ffi_out_struct = prepare_cuda_radix_ffi(
+        lwe_check_out_block,
+        &mut ffi_out_degrees,
+        &mut ffi_out_noise_levels,
+    );
+
+    let mut ffi_out_values_degrees: Vec<u64> = lwe_array_out_values
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.degree.get())
+        .collect();
+    let mut ffi_out_values_noise_levels: Vec<u64> = lwe_array_out_values
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.noise_level.0)
+        .collect();
+    let mut ffi_out_values_struct = prepare_cuda_radix_ffi(
+        lwe_array_out_values,
+        &mut ffi_out_values_degrees,
+        &mut ffi_out_values_noise_levels,
+    );
+
+    let mut ffi_in_selectors_degrees: Vec<u64> = lwe_array_in_selectors
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.degree.get())
+        .collect();
+    let mut ffi_in_selectors_noise_levels: Vec<u64> = lwe_array_in_selectors
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.noise_level.0)
+        .collect();
+    let ffi_in_selectors_struct = prepare_cuda_radix_ffi(
+        lwe_array_in_selectors,
+        &mut ffi_in_selectors_degrees,
+        &mut ffi_in_selectors_noise_levels,
+    );
+
+    let mut ffi_in_values_degrees: Vec<u64> = lwe_array_in_values
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.degree.get())
+        .collect();
+    let mut ffi_in_values_noise_levels: Vec<u64> = lwe_array_in_values
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.noise_level.0)
+        .collect();
+    let ffi_in_values_struct = prepare_cuda_radix_ffi(
+        lwe_array_in_values,
+        &mut ffi_in_values_degrees,
+        &mut ffi_in_values_noise_levels,
+    );
+
+    let mut ffi_in_new_value_degrees: Vec<u64> = lwe_in_new_value
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.degree.get())
+        .collect();
+    let mut ffi_in_new_value_noise_levels: Vec<u64> = lwe_in_new_value
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.noise_level.0)
+        .collect();
+    let ffi_in_new_value_struct = prepare_cuda_radix_ffi(
+        lwe_in_new_value,
+        &mut ffi_in_new_value_degrees,
+        &mut ffi_in_new_value_noise_levels,
+    );
+
+    let mut mem_ptr: *mut i8 = std::ptr::null_mut();
+
+    scratch_cuda_kv_store_map_64_async(
+        streams.ffi(),
+        std::ptr::addr_of_mut!(mem_ptr),
+        bsk_params,
+        ksk_params,
+        num_entries,
+        num_blocks_per_value,
+        u32::try_from(message_modulus.0).unwrap(),
+        u32::try_from(carry_modulus.0).unwrap(),
+        true,
+        noise_reduction_type as u32,
+    );
+
+    cuda_kv_store_map_64_async(
+        streams.ffi(),
+        &raw mut ffi_out_struct,
+        &raw mut ffi_out_values_struct,
+        &raw const ffi_in_values_struct,
+        &raw const ffi_in_new_value_struct,
+        &raw const ffi_in_selectors_struct,
+        mem_ptr,
+        bootstrapping_key.ptr.as_ptr(),
+        keyswitch_key.ptr.as_ptr(),
+    );
+
+    cleanup_cuda_kv_store_map_64(streams.ffi(), std::ptr::addr_of_mut!(mem_ptr));
+
+    update_noise_degree(lwe_check_out_block, &ffi_out_struct);
+    update_noise_degree(lwe_array_out_values, &ffi_out_values_struct);
+}
+
+#[allow(clippy::too_many_arguments)]
+/// # Safety
+///
+/// - The data must not be moved or dropped while being used by the CUDA kernel.
+/// - This function assumes exclusive access to the passed data; violating this may lead to
+///   undefined behavior.
+pub(crate) unsafe fn cuda_backend_kv_store_contains_key<
+    T: UnsignedInteger,
+    B: Numeric,
+    Clear: DecomposableInto<u64> + CastInto<usize>,
+>(
+    streams: &CudaStreams,
+    lwe_array_out_boolean: &mut CudaBooleanBlock,
+    lwe_array_in_encrypted_key: &CudaRadixCiphertext,
+    clear_keys: &[Clear],
+    message_modulus: MessageModulus,
+    carry_modulus: CarryModulus,
+    bootstrapping_key: &CudaVec<B>,
+    keyswitch_key: &CudaVec<T>,
+    bsk: &impl CudaBskParams,
+    ksk_params: CudaLweKeyswitchKeyParamsFFI,
+    ms_noise_reduction_configuration: Option<&CudaModulusSwitchNoiseReductionConfiguration>,
+) {
+    let bsk_params = bsk.params_ffi();
+
+    assert_eq!(streams.gpu_indexes[0], bootstrapping_key.gpu_index(0));
+    assert_eq!(streams.gpu_indexes[0], keyswitch_key.gpu_index(0));
+    assert_eq!(
+        streams.gpu_indexes[0],
+        lwe_array_in_encrypted_key.d_blocks.0.d_vec.gpu_index(0)
+    );
+    assert_eq!(
+        streams.gpu_indexes[0],
+        lwe_array_out_boolean
+            .0
+            .ciphertext
+            .d_blocks
+            .0
+            .d_vec
+            .gpu_index(0)
+    );
+
+    let num_input_blocks =
+        u32::try_from(lwe_array_in_encrypted_key.d_blocks.lwe_ciphertext_count().0).unwrap();
+    let num_bits_in_message = message_modulus.0.ilog2();
+    let num_entries = u32::try_from(clear_keys.len()).unwrap();
+
+    let h_decomposed_clear_keys: Vec<u64> = clear_keys
+        .iter()
+        .flat_map(|key| {
+            BlockDecomposer::new(*key, num_bits_in_message)
+                .take(num_input_blocks as usize)
+                .map(|block_value: Clear| block_value.cast_into())
+                .collect::<Vec<u64>>()
+        })
+        .collect();
+
+    let noise_reduction_type = resolve_ms_noise_reduction_config(ms_noise_reduction_configuration);
+
+    let mut ffi_out_boolean_degrees: Vec<u64> =
+        vec![lwe_array_out_boolean.0.ciphertext.info.blocks[0]
+            .degree
+            .get()];
+    let mut ffi_out_boolean_noise_levels: Vec<u64> = vec![
+        lwe_array_out_boolean.0.ciphertext.info.blocks[0]
+            .noise_level
+            .0,
+    ];
+    let mut ffi_out_boolean_struct = prepare_cuda_radix_ffi(
+        &lwe_array_out_boolean.0.ciphertext,
+        &mut ffi_out_boolean_degrees,
+        &mut ffi_out_boolean_noise_levels,
+    );
+
+    let mut ffi_in_key_degrees: Vec<u64> = lwe_array_in_encrypted_key
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.degree.get())
+        .collect();
+    let mut ffi_in_key_noise_levels: Vec<u64> = lwe_array_in_encrypted_key
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.noise_level.0)
+        .collect();
+    let ffi_in_key_struct = prepare_cuda_radix_ffi(
+        lwe_array_in_encrypted_key,
+        &mut ffi_in_key_degrees,
+        &mut ffi_in_key_noise_levels,
+    );
+
+    let mut mem_ptr: *mut i8 = std::ptr::null_mut();
+
+    scratch_cuda_kv_store_contains_key_64_async(
+        streams.ffi(),
+        std::ptr::addr_of_mut!(mem_ptr),
+        bsk_params,
+        ksk_params,
+        num_entries,
+        num_input_blocks,
+        u32::try_from(message_modulus.0).unwrap(),
+        u32::try_from(carry_modulus.0).unwrap(),
+        true,
+        noise_reduction_type as u32,
+    );
+
+    cuda_kv_store_contains_key_64_async(
+        streams.ffi(),
+        &raw mut ffi_out_boolean_struct,
+        &raw const ffi_in_key_struct,
+        h_decomposed_clear_keys.as_ptr(),
+        mem_ptr,
+        bootstrapping_key.ptr.as_ptr(),
+        keyswitch_key.ptr.as_ptr(),
+    );
+
+    cleanup_cuda_kv_store_contains_key_64(streams.ffi(), std::ptr::addr_of_mut!(mem_ptr));
 
     update_noise_degree(
         &mut lwe_array_out_boolean.0.ciphertext,

--- a/tfhe/src/integer/gpu/server_key/mod.rs
+++ b/tfhe/src/integer/gpu/server_key/mod.rs
@@ -25,12 +25,13 @@ use crate::shortint::oprf::ExpandedOprfBootstrappingKey;
 use crate::shortint::parameters::ModulusSwitchType;
 use crate::shortint::prelude::PolynomialSize;
 use crate::shortint::{CarryModulus, CiphertextModulus, MessageModulus, PBSOrder};
+pub use radix::kv_store::CudaKVStore;
 pub use radix::{
     BitonicShuffleKeySize, CollisionProbability, CudaOprfServerKey, CudaOprfServerKeyView,
     GenericCudaOprfServerKey,
 };
 
-mod radix;
+pub(crate) mod radix;
 
 pub enum CudaBootstrappingKey<Scalar: UnsignedInteger> {
     Classic(CudaLweBootstrapKey),

--- a/tfhe/src/integer/gpu/server_key/radix/kv_store.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/kv_store.rs
@@ -307,11 +307,9 @@ impl<Key, Ct> CudaKVStore<Key, Ct> {
             let byte_offset = src_offset * std::mem::size_of::<u64>();
             let copy_size = elements_per_value * std::mem::size_of::<u64>();
 
-            // SAFETY: both pointers are valid GPU allocations on the same device,
-            // and the slice [src_offset..src_offset+elements_per_value) is within
-            // the concatenated buffer's allocation. The destination buffer owns at
-            // least `elements_per_value` elements. All copies are on the same
-            // stream, so no concurrent-access hazard.
+            // SAFETY: both pointers are valid GPU allocations on the same device.
+            // Source and destination slices are non-overlapping and in-bounds.
+            // All copies are on the same stream (no concurrent-access hazard).
             unsafe {
                 cuda_memcpy_async_gpu_to_gpu(
                     value.as_mut().d_blocks.0.d_vec.as_mut_c_ptr(0),
@@ -391,8 +389,7 @@ where
 }
 
 impl CudaServerKey {
-    // Returns the selectors ("which entry matches the encrypted key?") alongside the value so
-    // callers like `map` (a get followed by an update) reuse them instead of recomputing.
+    // Returns selectors alongside the value so callers like `map` can reuse them.
     fn kv_store_get_impl<Key, Ct>(
         &self,
         kv_store: &CudaKVStore<Key, Ct>,
@@ -454,19 +451,12 @@ impl CudaServerKey {
             panic!("Only the standard atomic pattern is supported on GPU")
         };
 
-        // num_blocks_per_value is bounded by GPU memory; it cannot exceed u32::MAX
         let num_blocks_per_value_u32 =
             u32::try_from(num_blocks_per_value).expect("num_blocks_per_value exceeds u32::MAX");
 
-        // SAFETY: result_ct, result_bool and selectors_ct are freshly allocated on
-        // the device bound to `streams` and are passed mutably for exclusive write
-        // access; the keys, concatenated values and bootstrapping/keyswitching keys
-        // are read-only and live on that same device. clear_keys has one entry per
-        // store value, matching the num_entries used to size selectors_ct, and every
-        // value holds num_blocks_per_value blocks. The kernels are enqueued on
-        // `streams`; the returned ciphertexts carry those same streams, so any
-        // downstream host access only happens after a synchronization on the
-        // ordered stream.
+        // SAFETY: all output buffers are freshly allocated on the device bound
+        // to `streams` with exclusive write access. All input buffers are
+        // read-only and live on the same device.
         unsafe {
             match &self.bootstrapping_key {
                 CudaBootstrappingKey::Classic(d_bsk) => {
@@ -540,9 +530,8 @@ impl CudaServerKey {
             panic!("Only the standard atomic pattern is supported on GPU")
         };
 
-        // SAFETY: all GPU buffers are valid allocations on the same device,
-        // the FFI function has exclusive access to result_bool and read-only
-        // access to the other buffers.
+        // SAFETY: all buffers are valid allocations on the same device.
+        // result_bool has exclusive write access; all others are read-only.
         unsafe {
             match &self.bootstrapping_key {
                 CudaBootstrappingKey::Classic(d_bsk) => {
@@ -668,17 +657,12 @@ impl CudaServerKey {
             panic!("Only the standard atomic pattern is supported on GPU")
         };
 
-        // num_blocks_per_value is bounded by GPU memory; it cannot exceed u32::MAX
         let num_blocks_per_value_u32 =
             u32::try_from(num_blocks_per_value).expect("num_blocks_per_value exceeds u32::MAX");
 
-        // SAFETY: d_check_block and d_updated_values are freshly allocated on the
-        // device bound to `streams` and passed mutably for exclusive write access;
-        // d_updated_values holds map.len() * num_blocks_per_value blocks, matching
-        // the concatenated old values. The key, new value, old values and
-        // bootstrapping/keyswitching keys are read-only and live on the same device.
-        // clear_keys has one entry per store value. All buffers outlive the call,
-        // which synchronizes the stream before returning.
+        // SAFETY: all output buffers are freshly allocated on the device bound
+        // to `streams` with exclusive write access. All input buffers are
+        // read-only and live on the same device.
         unsafe {
             match &self.bootstrapping_key {
                 CudaBootstrappingKey::Classic(d_bsk) => {
@@ -765,7 +749,7 @@ impl CudaServerKey {
 
         let concatenated_old_values = map.to_vec(streams);
 
-        // Wrap the selectors as a CudaRadixCiphertext so the FFI can consume them uniformly.
+        // The FFI expects a CudaRadixCiphertext, not a raw CudaLweCiphertextList.
         let selector_block_info = CudaBlockInfo {
             degree: Degree::new(1),
             message_modulus: self.message_modulus,
@@ -785,7 +769,6 @@ impl CudaServerKey {
             panic!("Only the standard atomic pattern is supported on GPU")
         };
 
-        // num_blocks_per_value is bounded by GPU memory; it cannot exceed u32::MAX
         let num_blocks_per_value_u32 =
             u32::try_from(num_blocks_per_value).expect("num_blocks_per_value exceeds u32::MAX");
 
@@ -796,13 +779,9 @@ impl CudaServerKey {
         let mut d_updated_values: CudaUnsignedRadixCiphertext =
             self.create_trivial_zero_radix(total_blocks, streams);
 
-        // SAFETY: d_check_block and d_updated_values are freshly allocated on the
-        // device bound to `streams` and passed mutably for exclusive write access;
-        // d_updated_values holds map.len() * num_blocks_per_value blocks, matching
-        // the concatenated old values. The old values, new value and selectors are
-        // read-only, as are the bootstrapping/keyswitching keys, and all live on the
-        // same device. selectors_ct carries num_entries blocks, one per store value.
-        // All buffers outlive the call, which synchronizes the stream before returning.
+        // SAFETY: all output buffers are freshly allocated on the device bound
+        // to `streams` with exclusive write access. All input buffers are
+        // read-only and live on the same device.
         unsafe {
             match &self.bootstrapping_key {
                 CudaBootstrappingKey::Classic(d_bsk) => {

--- a/tfhe/src/integer/gpu/server_key/radix/kv_store.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/kv_store.rs
@@ -1,0 +1,1283 @@
+use crate::core_crypto::gpu::lwe_ciphertext_list::CudaLweCiphertextList;
+use crate::core_crypto::gpu::CudaStreams;
+use crate::core_crypto::prelude::LweCiphertextCount;
+use crate::integer::block_decomposition::DecomposableInto;
+use crate::integer::ciphertext::{
+    AsShortintCiphertextSlice, DataKind, Expandable, IntegerRadixCiphertext,
+};
+use crate::integer::gpu::ciphertext::boolean_value::CudaBooleanBlock;
+use crate::integer::gpu::ciphertext::compressed_ciphertext_list::{
+    CudaCompressedCiphertextListBuilder, CudaExpandable,
+};
+use crate::integer::gpu::ciphertext::info::{CudaBlockInfo, CudaRadixCiphertextInfo};
+use crate::integer::gpu::ciphertext::{
+    CudaIntegerRadixCiphertext, CudaRadixCiphertext, CudaUnsignedRadixCiphertext,
+};
+use crate::integer::gpu::list_compression::server_keys::{
+    CudaCompressionKey, CudaDecompressionKey,
+};
+use crate::integer::gpu::server_key::{CudaBootstrappingKey, CudaDynamicKeyswitchingKey};
+use crate::integer::gpu::{
+    cuda_backend_kv_store_contains_key, cuda_backend_kv_store_get, cuda_backend_kv_store_map,
+    cuda_backend_kv_store_update, CudaServerKey,
+};
+use crate::integer::server_key::{CompressedKVStore, KVStore};
+use crate::prelude::CastInto;
+use crate::shortint::ciphertext::{Degree, NoiseLevel};
+use crate::shortint::parameters::AtomicPatternKind;
+use rayon::iter::IntoParallelRefIterator;
+use rayon::prelude::ParallelIterator;
+use std::collections::BTreeMap;
+use std::fmt::Display;
+use std::num::NonZeroUsize;
+use tfhe_cuda_backend::cuda_bind::cuda_memcpy_async_gpu_to_gpu;
+
+/// The KVStore is a specialized encrypted HashMap
+///
+/// * Keys are clear numbers
+/// * Values are CudaUnsignedRadixCiphertext or CudaSignedRadixCiphertext
+///
+/// It supports getting/modifying existing pairs of (key,value)
+/// using an encrypted key.
+///
+/// To serialize a KVStore, convert to CPU with `CudaKVStore::to_kv_store` then compress
+pub struct CudaKVStore<Key, Ct> {
+    data: BTreeMap<Key, Ct>,
+    block_count: Option<NonZeroUsize>,
+}
+
+#[allow(dead_code)]
+impl<Key, Ct> CudaKVStore<Key, Ct> {
+    pub(crate) fn from_kv_store<CpuCt>(
+        kv_store: &KVStore<Key, CpuCt>,
+        streams: &CudaStreams,
+    ) -> Self
+    where
+        Key: Clone + Ord,
+        Ct: CudaIntegerRadixCiphertext,
+        CpuCt: IntegerRadixCiphertext,
+    {
+        let mut gpu_kv_store = Self::new();
+        kv_store.iter().for_each(|(key, value)| {
+            let d_radix =
+                CudaRadixCiphertext::from_cpu_blocks(value.as_ciphertext_slice(), streams);
+            let d_value = Ct::from(d_radix);
+            gpu_kv_store.insert(key.clone(), d_value);
+        });
+        gpu_kv_store
+    }
+}
+
+impl<Key, Ct> CudaKVStore<Key, Ct> {
+    /// Creates an empty KVStore
+    pub fn new() -> Self {
+        Self {
+            data: BTreeMap::new(),
+            block_count: None,
+        }
+    }
+
+    /// Returns the value stored for the key if any
+    ///
+    /// Key is in clear, see [CudaServerKey::kv_store_get] if you wish to
+    /// query using an encrypted key
+    pub fn get(&self, key: &Key) -> Option<&Ct>
+    where
+        Key: Ord,
+    {
+        self.data.get(key)
+    }
+
+    /// Returns the value stored for the key if any
+    ///
+    /// Key is in clear, see [CudaServerKey::kv_store_get] if you wish to
+    /// query using an encrypted key
+    pub fn get_mut(&mut self, key: &Key) -> Option<&mut Ct>
+    where
+        Key: Ord,
+    {
+        self.data.get_mut(key)
+    }
+
+    /// Inserts the value for the key
+    ///
+    /// Returns the previous value stored for the key if there was any
+    ///
+    /// # Notes
+    ///
+    /// If the value does not contain blocks, nothing is inserted and None is returned
+    ///
+    /// # Panics
+    ///
+    /// Panics if the number of blocks of the value is not the same as all other
+    /// values stored
+    pub fn insert(&mut self, key: Key, value: Ct) -> Option<Ct>
+    where
+        Key: Ord,
+        Ct: CudaIntegerRadixCiphertext,
+    {
+        let n_blocks = value.as_ref().d_blocks.lwe_ciphertext_count().0;
+        if n_blocks == 0 {
+            return None;
+        }
+
+        let n = self
+            .block_count
+            .get_or_insert_with(|| NonZeroUsize::new(n_blocks).unwrap());
+
+        assert_eq!(
+            n.get(),
+            n_blocks,
+            "All ciphertexts must have the same number of blocks"
+        );
+        self.data.insert(key, value)
+    }
+
+    /// Removes a key-value pair.
+    pub fn remove(&mut self, key: &Key) -> Option<Ct>
+    where
+        Key: Ord,
+    {
+        self.data.remove(key)
+    }
+
+    /// Returns the value associated to the key given in clear
+    pub fn clear_get(&self, key: &Key) -> Option<&Ct>
+    where
+        Key: Ord,
+    {
+        self.data.get(key)
+    }
+
+    /// Returns the number of key-value pairs currently stored
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    /// Returns whether the store is empty
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+
+    pub fn contains_key(&self, key: &Key) -> bool
+    where
+        Key: Ord,
+    {
+        self.data.contains_key(key)
+    }
+
+    pub fn duplicate(&self, streams: &CudaStreams) -> Self
+    where
+        Key: Clone + Ord,
+        Ct: CudaIntegerRadixCiphertext,
+    {
+        let data = self
+            .data
+            .iter()
+            .map(|(k, v)| (k.clone(), v.duplicate(streams)))
+            .collect();
+        Self {
+            data,
+            block_count: self.block_count,
+        }
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&Key, &Ct)>
+    where
+        Key: Ord,
+        Ct: Send,
+    {
+        self.data.iter()
+    }
+
+    #[allow(dead_code)]
+    fn par_iter_keys(&self) -> impl ParallelIterator<Item = &Key>
+    where
+        Key: Send + Sync + Ord,
+        Ct: Send + Sync,
+    {
+        self.data.par_iter().map(|(k, _)| k)
+    }
+
+    pub(crate) fn blocks_per_radix(&self) -> Option<NonZeroUsize> {
+        self.block_count
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn to_kv_store<CpuCt>(
+        &self,
+        streams: &CudaStreams,
+    ) -> crate::integer::server_key::KVStore<Key, CpuCt>
+    where
+        Key: Clone + Ord,
+        Ct: CudaIntegerRadixCiphertext,
+        CpuCt: IntegerRadixCiphertext,
+    {
+        let mut kv_store = crate::integer::server_key::KVStore::new();
+        for (key, d_value) in &self.data {
+            let cpu_blocks = d_value.as_ref().to_cpu_blocks(streams);
+            kv_store.insert(key.clone(), CpuCt::from(cpu_blocks));
+        }
+        kv_store
+    }
+
+    pub fn compress<CpuCt>(
+        &self,
+        compression_key: &CudaCompressionKey,
+        streams: &CudaStreams,
+    ) -> CompressedKVStore<Key, CpuCt>
+    where
+        Key: Copy,
+        Ct: CudaIntegerRadixCiphertext,
+        CpuCt: Expandable + IntegerRadixCiphertext,
+    {
+        assert_eq!(
+            Ct::IS_SIGNED,
+            CpuCt::IS_SIGNED,
+            "GPU and CPU ciphertext signedness must match"
+        );
+
+        let mut builder = CudaCompressedCiphertextListBuilder::new();
+        let mut keys = Vec::with_capacity(self.data.len());
+        for (key, value) in &self.data {
+            let ct = value.as_ref().duplicate(streams);
+            let num_blocks = ct.d_blocks.lwe_ciphertext_count().0;
+            if let Some(n) = NonZeroUsize::new(num_blocks) {
+                keys.push(*key);
+                builder.ciphertexts.push(ct);
+                let kind = if Ct::IS_SIGNED {
+                    DataKind::Signed(n)
+                } else {
+                    DataKind::Unsigned(n)
+                };
+                builder.info.push(kind);
+            }
+        }
+        let cuda_compressed = builder.build(compression_key, streams);
+        let compressed_list = cuda_compressed.to_compressed_ciphertext_list(streams);
+        CompressedKVStore::new(keys, compressed_list)
+    }
+
+    // Concatenates all values into one contiguous device array.
+    fn to_vec(&self, streams: &CudaStreams) -> CudaRadixCiphertext
+    where
+        Key: Ord,
+        Ct: CudaIntegerRadixCiphertext + Send,
+    {
+        let d_blocks_refs: Vec<&CudaLweCiphertextList<u64>> =
+            self.iter().map(|(_, v)| &v.as_ref().d_blocks).collect();
+        let concatenated_d_blocks = CudaLweCiphertextList::from_vec_cuda_lwe_ciphertexts_list(
+            d_blocks_refs.iter().copied(),
+            streams,
+        );
+        let concatenated_info = CudaRadixCiphertextInfo {
+            blocks: self
+                .iter()
+                .flat_map(|(_, v)| v.as_ref().info.blocks.iter())
+                .copied()
+                .collect(),
+        };
+
+        CudaRadixCiphertext {
+            d_blocks: concatenated_d_blocks,
+            info: concatenated_info,
+        }
+    }
+
+    /// Scatters blocks from a concatenated `CudaRadixCiphertext` back into each value
+    /// in the BTreeMap. Entry i (in iteration order) receives blocks [i*N..(i+1)*N)
+    /// from `concatenated`, where N is `blocks_per_radix`.
+    fn update_from_concatenated(
+        &mut self,
+        concatenated: &CudaRadixCiphertext,
+        streams: &CudaStreams,
+    ) where
+        Key: Ord,
+        Ct: CudaIntegerRadixCiphertext,
+    {
+        let blocks_per_value = self
+            .block_count
+            .expect("Cannot scatter into an empty store")
+            .get();
+        let lwe_size = concatenated.d_blocks.0.lwe_dimension.to_lwe_size().0;
+        let elements_per_value = blocks_per_value * lwe_size;
+
+        for (idx, (_key, value)) in self.data.iter_mut().enumerate() {
+            let src_offset = idx * elements_per_value;
+            let byte_offset = src_offset * std::mem::size_of::<u64>();
+            let copy_size = elements_per_value * std::mem::size_of::<u64>();
+
+            // SAFETY: both pointers are valid GPU allocations on the same device,
+            // and the slice [src_offset..src_offset+elements_per_value) is within
+            // the concatenated buffer's allocation. The destination buffer owns at
+            // least `elements_per_value` elements. All copies are on the same
+            // stream, so no concurrent-access hazard.
+            unsafe {
+                cuda_memcpy_async_gpu_to_gpu(
+                    value.as_mut().d_blocks.0.d_vec.as_mut_c_ptr(0),
+                    concatenated
+                        .d_blocks
+                        .0
+                        .d_vec
+                        .as_c_ptr(0)
+                        .wrapping_byte_add(byte_offset),
+                    copy_size as u64,
+                    streams.ptr[0],
+                    streams.gpu_indexes[0].get(),
+                );
+            }
+
+            let info_start = idx * blocks_per_value;
+            let info_end = info_start + blocks_per_value;
+            value
+                .as_mut()
+                .info
+                .blocks
+                .copy_from_slice(&concatenated.info.blocks[info_start..info_end]);
+        }
+        streams.synchronize();
+    }
+}
+
+impl<Key, Ct> Default for CudaKVStore<Key, Ct> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<Key, Value> CompressedKVStore<Key, Value>
+where
+    Value: IntegerRadixCiphertext,
+{
+    /// Decompresses the stored values directly onto the GPU, mirroring the CPU-side
+    /// [`CompressedKVStore::decompress`] but producing a [`CudaKVStore`]. This is the
+    /// `CompressedKVStore -> CudaKVStore` direction; [`CudaKVStore::to_kv_store`] is the inverse.
+    pub(crate) fn decompress_to_cuda<GpuCt>(
+        &self,
+        decompression_key: &CudaDecompressionKey,
+        streams: &CudaStreams,
+    ) -> crate::Result<CudaKVStore<Key, GpuCt>>
+    where
+        Key: Copy + Display + Ord,
+        GpuCt: CudaIntegerRadixCiphertext + CudaExpandable,
+    {
+        let (keys, values, is_signed) = self.parts();
+
+        if Value::IS_SIGNED != is_signed {
+            let requested = if Value::IS_SIGNED {
+                "signed"
+            } else {
+                "unsigned"
+            };
+            let stored = if is_signed { "signed" } else { "unsigned" };
+            return Err(crate::error!(
+                "Requested value signedness does not match stored data: \
+                 requested {requested} values but stored values are {stored}"
+            ));
+        }
+
+        let cuda_compressed = values.to_cuda_compressed_ciphertext_list(streams);
+        let mut store = CudaKVStore::<Key, GpuCt>::new();
+
+        for (i, key) in keys.iter().enumerate() {
+            let value: GpuCt = cuda_compressed
+                .get(i, decompression_key, streams)?
+                .ok_or_else(|| crate::error!("Missing value for key '{key}'"))?;
+            let _ = store.insert(*key, value);
+        }
+
+        Ok(store)
+    }
+}
+
+impl CudaServerKey {
+    // Returns the selectors ("which entry matches the encrypted key?") alongside the value so
+    // callers like `map` (a get followed by an update) reuse them instead of recomputing.
+    fn kv_store_get_impl<Key, Ct>(
+        &self,
+        kv_store: &CudaKVStore<Key, Ct>,
+        encrypted_key: &Ct,
+        streams: &CudaStreams,
+    ) -> (Ct, CudaBooleanBlock, CudaLweCiphertextList<u64>)
+    where
+        Key: DecomposableInto<u64> + CastInto<usize> + Ord + Copy + Sync,
+        Ct: CudaIntegerRadixCiphertext + Send,
+    {
+        let num_blocks_per_value = if let Some(n) = kv_store.blocks_per_radix() {
+            n.get()
+        } else {
+            let num_blocks = encrypted_key.as_ref().d_blocks.lwe_ciphertext_count().0;
+            let trivial_ct: Ct = self.create_trivial_zero_radix(num_blocks, streams);
+
+            let trivial_bool_ct: Ct = self.create_trivial_zero_radix(1, streams);
+            let trivial_bool = CudaBooleanBlock::from_cuda_radix_ciphertext(
+                trivial_bool_ct.duplicate(streams).into_inner(),
+            );
+
+            let trivial_selectors = trivial_ct.as_ref().d_blocks.duplicate(streams);
+            return (trivial_ct, trivial_bool, trivial_selectors);
+        };
+
+        let num_entries = kv_store.len();
+
+        let concatenated_values = kv_store.to_vec(streams);
+        let clear_keys: Vec<Key> = kv_store.iter().map(|(k, _)| *k).collect();
+
+        let mut result_ct: Ct = self.create_trivial_zero_radix(num_blocks_per_value, streams);
+        let mut result_bool = CudaBooleanBlock(
+            self.create_trivial_zero_radix::<CudaUnsignedRadixCiphertext>(1, streams),
+        );
+
+        // Selectors are allocated here rather than in the backend because they are returned.
+        let selector_block_info = CudaBlockInfo {
+            degree: Degree::new(0),
+            message_modulus: self.message_modulus,
+            carry_modulus: self.carry_modulus,
+            atomic_pattern: AtomicPatternKind::Standard(self.pbs_order),
+            noise_level: NoiseLevel::ZERO,
+        };
+        let selectors_info = CudaRadixCiphertextInfo {
+            blocks: vec![selector_block_info; num_entries],
+        };
+        let selectors_d_blocks = CudaLweCiphertextList::new(
+            self.bootstrapping_key.output_lwe_dimension(),
+            LweCiphertextCount(num_entries),
+            encrypted_key.as_ref().d_blocks.ciphertext_modulus(),
+            streams,
+        );
+        let mut selectors_ct = CudaRadixCiphertext {
+            d_blocks: selectors_d_blocks,
+            info: selectors_info,
+        };
+
+        let CudaDynamicKeyswitchingKey::Standard(computing_ks_key) = &self.key_switching_key else {
+            panic!("Only the standard atomic pattern is supported on GPU")
+        };
+
+        // num_blocks_per_value is bounded by GPU memory; it cannot exceed u32::MAX
+        let num_blocks_per_value_u32 =
+            u32::try_from(num_blocks_per_value).expect("num_blocks_per_value exceeds u32::MAX");
+
+        // SAFETY: result_ct, result_bool and selectors_ct are freshly allocated on
+        // the device bound to `streams` and are passed mutably for exclusive write
+        // access; the keys, concatenated values and bootstrapping/keyswitching keys
+        // are read-only and live on that same device. clear_keys has one entry per
+        // store value, matching the num_entries used to size selectors_ct, and every
+        // value holds num_blocks_per_value blocks. The kernels are enqueued on
+        // `streams`; the returned ciphertexts carry those same streams, so any
+        // downstream host access only happens after a synchronization on the
+        // ordered stream.
+        unsafe {
+            match &self.bootstrapping_key {
+                CudaBootstrappingKey::Classic(d_bsk) => {
+                    cuda_backend_kv_store_get(
+                        streams,
+                        &mut result_ct,
+                        &mut result_bool,
+                        &mut selectors_ct,
+                        encrypted_key.as_ref(),
+                        &concatenated_values,
+                        &clear_keys,
+                        num_blocks_per_value_u32,
+                        self.message_modulus,
+                        self.carry_modulus,
+                        &d_bsk.d_vec,
+                        &computing_ks_key.d_vec,
+                        d_bsk,
+                        computing_ks_key.params_ffi(),
+                        d_bsk.ms_noise_reduction_configuration.as_ref(),
+                    );
+                }
+                CudaBootstrappingKey::MultiBit(d_multibit_bsk) => {
+                    cuda_backend_kv_store_get(
+                        streams,
+                        &mut result_ct,
+                        &mut result_bool,
+                        &mut selectors_ct,
+                        encrypted_key.as_ref(),
+                        &concatenated_values,
+                        &clear_keys,
+                        num_blocks_per_value_u32,
+                        self.message_modulus,
+                        self.carry_modulus,
+                        &d_multibit_bsk.d_vec,
+                        &computing_ks_key.d_vec,
+                        d_multibit_bsk,
+                        computing_ks_key.params_ffi(),
+                        None,
+                    );
+                }
+            }
+        }
+
+        (result_ct, result_bool, selectors_ct.d_blocks)
+    }
+
+    pub fn kv_store_contains_key<Key, Ct>(
+        &self,
+        map: &CudaKVStore<Key, Ct>,
+        encrypted_key: &Ct,
+        streams: &CudaStreams,
+    ) -> CudaBooleanBlock
+    where
+        Ct: CudaIntegerRadixCiphertext + Send,
+        Key: DecomposableInto<u64> + CastInto<usize> + Ord + Copy + Sync,
+    {
+        if map.is_empty() {
+            return CudaBooleanBlock::from_cuda_radix_ciphertext(
+                self.create_trivial_zero_radix::<CudaUnsignedRadixCiphertext>(1, streams)
+                    .into_inner(),
+            );
+        }
+
+        let clear_keys: Vec<Key> = map.iter().map(|(k, _)| *k).collect();
+
+        let mut result_bool = CudaBooleanBlock(
+            self.create_trivial_zero_radix::<CudaUnsignedRadixCiphertext>(1, streams),
+        );
+
+        let CudaDynamicKeyswitchingKey::Standard(computing_ks_key) = &self.key_switching_key else {
+            panic!("Only the standard atomic pattern is supported on GPU")
+        };
+
+        // SAFETY: all GPU buffers are valid allocations on the same device,
+        // the FFI function has exclusive access to result_bool and read-only
+        // access to the other buffers.
+        unsafe {
+            match &self.bootstrapping_key {
+                CudaBootstrappingKey::Classic(d_bsk) => {
+                    cuda_backend_kv_store_contains_key(
+                        streams,
+                        &mut result_bool,
+                        encrypted_key.as_ref(),
+                        &clear_keys,
+                        self.message_modulus,
+                        self.carry_modulus,
+                        &d_bsk.d_vec,
+                        &computing_ks_key.d_vec,
+                        d_bsk,
+                        computing_ks_key.params_ffi(),
+                        d_bsk.ms_noise_reduction_configuration.as_ref(),
+                    );
+                }
+                CudaBootstrappingKey::MultiBit(d_multibit_bsk) => {
+                    cuda_backend_kv_store_contains_key(
+                        streams,
+                        &mut result_bool,
+                        encrypted_key.as_ref(),
+                        &clear_keys,
+                        self.message_modulus,
+                        self.carry_modulus,
+                        &d_multibit_bsk.d_vec,
+                        &computing_ks_key.d_vec,
+                        d_multibit_bsk,
+                        computing_ks_key.params_ffi(),
+                        None,
+                    );
+                }
+            }
+        }
+
+        result_bool
+    }
+
+    pub fn kv_store_contains_value<Key, Ct>(
+        &self,
+        map: &CudaKVStore<Key, Ct>,
+        encrypted_value: &Ct,
+        streams: &CudaStreams,
+    ) -> CudaBooleanBlock
+    where
+        Ct: CudaIntegerRadixCiphertext + Send,
+        Key: Ord + Sync,
+    {
+        let values: Vec<_> = map.iter().map(|(_, v)| v.duplicate(streams)).collect();
+        self.contains(&values, encrypted_value, streams)
+    }
+
+    pub fn kv_store_contains_clear_value<Key, Ct, Clear>(
+        &self,
+        map: &CudaKVStore<Key, Ct>,
+        clear_value: Clear,
+        streams: &CudaStreams,
+    ) -> CudaBooleanBlock
+    where
+        Ct: CudaIntegerRadixCiphertext + Send,
+        Key: Ord + Sync,
+        Clear: DecomposableInto<u64>,
+    {
+        let values: Vec<_> = map.iter().map(|(_, v)| v.duplicate(streams)).collect();
+        self.contains_clear(&values, clear_value, streams)
+    }
+
+    pub fn kv_store_get<Key, Ct>(
+        &self,
+        map: &CudaKVStore<Key, Ct>,
+        encrypted_key: &Ct,
+        streams: &CudaStreams,
+    ) -> (Ct, CudaBooleanBlock)
+    where
+        Ct: CudaIntegerRadixCiphertext + Send,
+        Key: DecomposableInto<u64> + CastInto<usize> + Ord + Copy + Sync,
+    {
+        let (result, check_block, _selectors) = self.kv_store_get_impl(map, encrypted_key, streams);
+        (result, check_block)
+    }
+
+    /// Updates the value at the given key by the given value
+    ///
+    /// `map[encrypted_key] = new_value`
+    ///
+    /// This finds the value that corresponds to the given `encrypted_key`,
+    /// then updates the value stored with the `new_value`.
+    ///
+    /// Returns a boolean block that encrypts `true` if an entry for
+    /// the `encrypted_key` was found, and thus the update was done
+    pub fn kv_store_update<Key, Ct>(
+        &self,
+        map: &mut CudaKVStore<Key, Ct>,
+        encrypted_key: &Ct,
+        new_value: &Ct,
+        streams: &CudaStreams,
+    ) -> CudaBooleanBlock
+    where
+        Ct: CudaIntegerRadixCiphertext + Send,
+        Key: DecomposableInto<u64> + CastInto<usize> + Ord + Copy + Sync,
+    {
+        let num_blocks_per_value = match map.blocks_per_radix() {
+            Some(n) => n.get(),
+            None => {
+                return CudaBooleanBlock::from_cuda_radix_ciphertext(
+                    self.create_trivial_zero_radix::<CudaUnsignedRadixCiphertext>(1, streams)
+                        .into_inner(),
+                );
+            }
+        };
+
+        let concatenated_old_values = map.to_vec(streams);
+        let clear_keys: Vec<Key> = map.iter().map(|(k, _)| *k).collect();
+
+        let mut d_check_block: CudaUnsignedRadixCiphertext =
+            self.create_trivial_zero_radix(1, streams);
+
+        let total_blocks = map.len() * num_blocks_per_value;
+        let mut d_updated_values: CudaUnsignedRadixCiphertext =
+            self.create_trivial_zero_radix(total_blocks, streams);
+
+        let CudaDynamicKeyswitchingKey::Standard(computing_ks_key) = &self.key_switching_key else {
+            panic!("Only the standard atomic pattern is supported on GPU")
+        };
+
+        // num_blocks_per_value is bounded by GPU memory; it cannot exceed u32::MAX
+        let num_blocks_per_value_u32 =
+            u32::try_from(num_blocks_per_value).expect("num_blocks_per_value exceeds u32::MAX");
+
+        // SAFETY: d_check_block and d_updated_values are freshly allocated on the
+        // device bound to `streams` and passed mutably for exclusive write access;
+        // d_updated_values holds map.len() * num_blocks_per_value blocks, matching
+        // the concatenated old values. The key, new value, old values and
+        // bootstrapping/keyswitching keys are read-only and live on the same device.
+        // clear_keys has one entry per store value. All buffers outlive the call,
+        // which synchronizes the stream before returning.
+        unsafe {
+            match &self.bootstrapping_key {
+                CudaBootstrappingKey::Classic(d_bsk) => {
+                    cuda_backend_kv_store_update(
+                        streams,
+                        &mut d_check_block.ciphertext,
+                        &mut d_updated_values.ciphertext,
+                        encrypted_key.as_ref(),
+                        &concatenated_old_values,
+                        new_value.as_ref(),
+                        &clear_keys,
+                        num_blocks_per_value_u32,
+                        self.message_modulus,
+                        self.carry_modulus,
+                        &d_bsk.d_vec,
+                        &computing_ks_key.d_vec,
+                        d_bsk,
+                        computing_ks_key.params_ffi(),
+                        d_bsk.ms_noise_reduction_configuration.as_ref(),
+                    );
+                }
+                CudaBootstrappingKey::MultiBit(d_multibit_bsk) => {
+                    cuda_backend_kv_store_update(
+                        streams,
+                        &mut d_check_block.ciphertext,
+                        &mut d_updated_values.ciphertext,
+                        encrypted_key.as_ref(),
+                        &concatenated_old_values,
+                        new_value.as_ref(),
+                        &clear_keys,
+                        num_blocks_per_value_u32,
+                        self.message_modulus,
+                        self.carry_modulus,
+                        &d_multibit_bsk.d_vec,
+                        &computing_ks_key.d_vec,
+                        d_multibit_bsk,
+                        computing_ks_key.params_ffi(),
+                        None,
+                    );
+                }
+            }
+        }
+
+        map.update_from_concatenated(&d_updated_values.ciphertext, streams);
+
+        CudaBooleanBlock(d_check_block)
+    }
+
+    /// Updates the value at the given key by applying a function
+    ///
+    /// `map[encrypted_key] = func(map[encrypted_value])`
+    ///
+    /// This finds the value that corresponds to the given `encrypted_key`, then
+    /// calls `func` then updates the value stored with the one returned by the `func`.
+    ///
+    /// Returns the (old_value, new_value, check_block) where `check_block` encrypts `true` if an
+    /// entry for the `encrypted_key` was found.
+    pub fn kv_store_map<Key, Ct, F>(
+        &self,
+        map: &mut CudaKVStore<Key, Ct>,
+        encrypted_key: &Ct,
+        func: F,
+        streams: &CudaStreams,
+    ) -> (Ct, Ct, CudaBooleanBlock)
+    where
+        Ct: CudaIntegerRadixCiphertext + Send,
+        Key: DecomposableInto<u64> + CastInto<usize> + Ord + Copy + Sync,
+        F: Fn(Ct) -> Ct,
+    {
+        let (old_value, _, selectors) = self.kv_store_get_impl(map, encrypted_key, streams);
+        let old_value_copy = old_value.duplicate(streams);
+        let new_value = func(old_value);
+
+        let num_entries = map.len();
+        let num_blocks_per_value = if let Some(n) = map.blocks_per_radix() {
+            n.get()
+        } else {
+            let trivial_bool = CudaBooleanBlock::from_cuda_radix_ciphertext(
+                self.create_trivial_zero_radix::<CudaUnsignedRadixCiphertext>(1, streams)
+                    .into_inner(),
+            );
+            return (old_value_copy, new_value, trivial_bool);
+        };
+
+        let concatenated_old_values = map.to_vec(streams);
+
+        // Wrap the selectors as a CudaRadixCiphertext so the FFI can consume them uniformly.
+        let selector_block_info = CudaBlockInfo {
+            degree: Degree::new(1),
+            message_modulus: self.message_modulus,
+            carry_modulus: self.carry_modulus,
+            atomic_pattern: AtomicPatternKind::Standard(self.pbs_order),
+            noise_level: NoiseLevel::NOMINAL,
+        };
+        let selectors_info = CudaRadixCiphertextInfo {
+            blocks: vec![selector_block_info; num_entries],
+        };
+        let selectors_ct = CudaRadixCiphertext {
+            d_blocks: selectors,
+            info: selectors_info,
+        };
+
+        let CudaDynamicKeyswitchingKey::Standard(computing_ks_key) = &self.key_switching_key else {
+            panic!("Only the standard atomic pattern is supported on GPU")
+        };
+
+        // num_blocks_per_value is bounded by GPU memory; it cannot exceed u32::MAX
+        let num_blocks_per_value_u32 =
+            u32::try_from(num_blocks_per_value).expect("num_blocks_per_value exceeds u32::MAX");
+
+        let mut d_check_block: CudaUnsignedRadixCiphertext =
+            self.create_trivial_zero_radix(1, streams);
+
+        let total_blocks = map.len() * num_blocks_per_value;
+        let mut d_updated_values: CudaUnsignedRadixCiphertext =
+            self.create_trivial_zero_radix(total_blocks, streams);
+
+        // SAFETY: d_check_block and d_updated_values are freshly allocated on the
+        // device bound to `streams` and passed mutably for exclusive write access;
+        // d_updated_values holds map.len() * num_blocks_per_value blocks, matching
+        // the concatenated old values. The old values, new value and selectors are
+        // read-only, as are the bootstrapping/keyswitching keys, and all live on the
+        // same device. selectors_ct carries num_entries blocks, one per store value.
+        // All buffers outlive the call, which synchronizes the stream before returning.
+        unsafe {
+            match &self.bootstrapping_key {
+                CudaBootstrappingKey::Classic(d_bsk) => {
+                    cuda_backend_kv_store_map(
+                        streams,
+                        &mut d_check_block.ciphertext,
+                        &mut d_updated_values.ciphertext,
+                        &concatenated_old_values,
+                        new_value.as_ref(),
+                        &selectors_ct,
+                        num_blocks_per_value_u32,
+                        self.message_modulus,
+                        self.carry_modulus,
+                        &d_bsk.d_vec,
+                        &computing_ks_key.d_vec,
+                        d_bsk,
+                        computing_ks_key.params_ffi(),
+                        d_bsk.ms_noise_reduction_configuration.as_ref(),
+                    );
+                }
+                CudaBootstrappingKey::MultiBit(d_multibit_bsk) => {
+                    cuda_backend_kv_store_map(
+                        streams,
+                        &mut d_check_block.ciphertext,
+                        &mut d_updated_values.ciphertext,
+                        &concatenated_old_values,
+                        new_value.as_ref(),
+                        &selectors_ct,
+                        num_blocks_per_value_u32,
+                        self.message_modulus,
+                        self.carry_modulus,
+                        &d_multibit_bsk.d_vec,
+                        &computing_ks_key.d_vec,
+                        d_multibit_bsk,
+                        computing_ks_key.params_ffi(),
+                        None,
+                    );
+                }
+            }
+        }
+
+        map.update_from_concatenated(&d_updated_values.ciphertext, streams);
+
+        (old_value_copy, new_value, CudaBooleanBlock(d_check_block))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::Rng;
+
+    use super::*;
+    use crate::integer::gpu::ciphertext::{CudaSignedRadixCiphertext, CudaUnsignedRadixCiphertext};
+    use crate::integer::{
+        gen_keys, ClientKey, IntegerKeyKind, RadixCiphertext, SignedRadixCiphertext,
+    };
+    use crate::shortint::parameters::test_params::{
+        TEST_COMP_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+        TEST_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+    };
+    use crate::shortint::ShortintParameterSet;
+    use std::collections::BTreeMap;
+
+    use crate::core_crypto::gpu::CudaStreams;
+    use crate::integer::server_key::CompressedKVStore;
+
+    fn assert_store_unsigned_matches(
+        clear_store: &BTreeMap<u32, u64>,
+        kv_store: &CudaKVStore<u32, CudaUnsignedRadixCiphertext>,
+        cks: &ClientKey,
+    ) {
+        assert_eq!(
+            clear_store.len(),
+            kv_store.len(),
+            "Clear and Encrypted stores do no have the same number of pairs"
+        );
+
+        let streams = CudaStreams::new_multi_gpu();
+
+        for (key, value) in clear_store {
+            let d_ct = kv_store
+                .get(key)
+                .expect("Missing entry in decompressed KVStore");
+            let ct = d_ct.to_radix_ciphertext(&streams);
+
+            let decrypted: u64 = cks.decrypt_radix(&ct);
+
+            assert_eq!(
+                *value, decrypted,
+                "Invalid value stored for key '{key}', expected '{value}' got '{decrypted}'"
+            );
+        }
+    }
+
+    #[test]
+    fn test_compression_serialization_unsigned() {
+        let params =
+            TEST_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128.into();
+
+        let (cks, _) = gen_keys::<ShortintParameterSet>(params, IntegerKeyKind::Radix);
+
+        let private_compression_key = cks.new_compression_private_key(
+            TEST_COMP_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+        );
+
+        let (compression_key, decompression_key) =
+            cks.new_compression_decompression_keys(&private_compression_key);
+
+        let num_blocks = 32;
+        let num_keys = 100;
+        let streams = CudaStreams::new_multi_gpu();
+
+        let mut rng = rand::thread_rng();
+
+        let mut clear_store = BTreeMap::new();
+        let mut gpu_kv_store = CudaKVStore::new();
+        for _ in 0..num_keys {
+            let key = rng.gen::<u32>();
+            let value = rng.gen::<u64>();
+
+            let ct = cks.encrypt_radix(value, num_blocks);
+            let d_ct = CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct, &streams);
+
+            let _ = clear_store.insert(key, value);
+            gpu_kv_store.insert(key, d_ct);
+        }
+
+        assert_store_unsigned_matches(&clear_store, &gpu_kv_store, &cks);
+
+        // Validates the flow GPU -> CPU -> Compress -> Decompress -> CPU -> GPU
+        let kv_store: KVStore<u32, RadixCiphertext> = gpu_kv_store.to_kv_store(&streams);
+        let compressed = kv_store.compress(&compression_key);
+        let kv_store = compressed.decompress(&decompression_key).unwrap();
+        let gpu_kv_store = CudaKVStore::from_kv_store(&kv_store, &streams);
+
+        assert_store_unsigned_matches(&clear_store, &gpu_kv_store, &cks);
+
+        // Validates the flow GPU -> CPU -> Serialize -> Deserialize -> CPU -> GPU
+        let mut data = vec![];
+        crate::safe_serialization::safe_serialize(&compressed, &mut data, 1 << 20).unwrap();
+        let compressed: CompressedKVStore<u32, RadixCiphertext> =
+            crate::safe_serialization::safe_deserialize(data.as_slice(), 1 << 20).unwrap();
+        let kv_store = compressed.decompress(&decompression_key).unwrap();
+        let gpu_kv_store = CudaKVStore::from_kv_store(&kv_store, &streams);
+        assert_store_unsigned_matches(&clear_store, &gpu_kv_store, &cks);
+    }
+
+    fn assert_store_signed_matches(
+        clear_store: &BTreeMap<u32, i64>,
+        kv_store: &CudaKVStore<u32, CudaSignedRadixCiphertext>,
+        cks: &ClientKey,
+    ) {
+        assert_eq!(
+            clear_store.len(),
+            kv_store.len(),
+            "Clear and Encrypted stores do no have the same number of pairs"
+        );
+
+        let streams = CudaStreams::new_multi_gpu();
+
+        for (key, value) in clear_store {
+            let d_ct = kv_store
+                .get(key)
+                .expect("Missing entry in decompressed KVStore");
+            let ct = d_ct.to_signed_radix_ciphertext(&streams);
+
+            let decrypted: i64 = cks.decrypt_signed_radix(&ct);
+
+            assert_eq!(
+                *value, decrypted,
+                "Invalid value stored for key '{key}', expected '{value}' got '{decrypted}'"
+            );
+        }
+    }
+
+    #[test]
+    fn test_compression_serialization_signed() {
+        let params =
+            TEST_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128.into();
+
+        let (cks, _) = gen_keys::<ShortintParameterSet>(params, IntegerKeyKind::Radix);
+
+        let private_compression_key = cks.new_compression_private_key(
+            TEST_COMP_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+        );
+
+        let (compression_key, decompression_key) =
+            cks.new_compression_decompression_keys(&private_compression_key);
+
+        let num_blocks = 32;
+        let num_keys = 100;
+        let streams = CudaStreams::new_multi_gpu();
+
+        let mut rng = rand::thread_rng();
+
+        let mut clear_store = BTreeMap::new();
+        let mut gpu_kv_store = CudaKVStore::new();
+        for _ in 0..num_keys {
+            let key = rng.gen::<u32>();
+            let value = rng.gen::<i64>();
+
+            let ct = cks.encrypt_signed_radix(value, num_blocks);
+            let d_ct = CudaSignedRadixCiphertext::from_signed_radix_ciphertext(&ct, &streams);
+
+            let _ = clear_store.insert(key, value);
+            gpu_kv_store.insert(key, d_ct);
+        }
+
+        assert_store_signed_matches(&clear_store, &gpu_kv_store, &cks);
+
+        // Validates the flow GPU -> CPU -> Compress -> Decompress -> CPU -> GPU
+        let kv_store: KVStore<u32, SignedRadixCiphertext> = gpu_kv_store.to_kv_store(&streams);
+        let compressed = kv_store.compress(&compression_key);
+        let kv_store = compressed.decompress(&decompression_key).unwrap();
+        let gpu_kv_store = CudaKVStore::from_kv_store(&kv_store, &streams);
+
+        assert_store_signed_matches(&clear_store, &gpu_kv_store, &cks);
+
+        // Validates the flow GPU -> CPU -> Serialize -> Deserialize -> CPU -> GPU
+        let mut data = vec![];
+        crate::safe_serialization::safe_serialize(&compressed, &mut data, 1 << 20).unwrap();
+        let compressed: CompressedKVStore<u32, SignedRadixCiphertext> =
+            crate::safe_serialization::safe_deserialize(data.as_slice(), 1 << 20).unwrap();
+        let kv_store = compressed.decompress(&decompression_key).unwrap();
+        let gpu_kv_store = CudaKVStore::from_kv_store(&kv_store, &streams);
+        assert_store_signed_matches(&clear_store, &gpu_kv_store, &cks);
+    }
+
+    #[test]
+    fn test_kv_store_get() {
+        let params =
+            TEST_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128.into();
+        let (cks, _) = gen_keys::<ShortintParameterSet>(params, IntegerKeyKind::Radix);
+
+        let streams = CudaStreams::new_multi_gpu();
+        let sks = CudaServerKey::new(&cks, &streams);
+        streams.synchronize();
+
+        let num_value_blocks = 4;
+        let num_key_blocks = 4; // u8 key with message_modulus=4 => 8/2 = 4 blocks
+        let modulus = 1u64 << (2 * num_value_blocks); // 2 bits per block
+
+        let clear_entries: Vec<(u8, u64)> =
+            vec![(1, 10), (2, 42), (3, 100), (5, 200), (7, modulus - 1)];
+
+        let mut gpu_kv_store: CudaKVStore<u8, CudaUnsignedRadixCiphertext> = CudaKVStore::new();
+        for &(key, value) in &clear_entries {
+            let ct = cks.encrypt_radix(value, num_value_blocks);
+            let d_ct = CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct, &streams);
+            gpu_kv_store.insert(key, d_ct);
+        }
+
+        // Verify each stored entry is really there
+        for &(key, expected_value) in &clear_entries {
+            let encrypted_key = cks.encrypt_radix(key as u64, num_key_blocks);
+            let d_encrypted_key =
+                CudaUnsignedRadixCiphertext::from_radix_ciphertext(&encrypted_key, &streams);
+
+            let (result, found_bool) = sks.kv_store_get(&gpu_kv_store, &d_encrypted_key, &streams);
+
+            let cpu_result = result.to_radix_ciphertext(&streams);
+            let decrypted: u64 = cks.decrypt_radix(&cpu_result);
+            let found = cks.decrypt_bool(&found_bool.to_boolean_block(&streams));
+
+            assert!(found, "Key {key} should be found in the store");
+            assert_eq!(
+                decrypted, expected_value,
+                "Key {key}: expected {expected_value}, got {decrypted}"
+            );
+        }
+
+        // Verify non-stored entries are really *NOT* there
+        let missing_key = 4u8;
+        let encrypted_key = cks.encrypt_radix(missing_key as u64, num_key_blocks);
+        let d_encrypted_key =
+            CudaUnsignedRadixCiphertext::from_radix_ciphertext(&encrypted_key, &streams);
+
+        let (result, found_bool) = sks.kv_store_get(&gpu_kv_store, &d_encrypted_key, &streams);
+
+        let cpu_result = result.to_radix_ciphertext(&streams);
+        let decrypted: u64 = cks.decrypt_radix(&cpu_result);
+        let found = cks.decrypt_bool(&found_bool.to_boolean_block(&streams));
+
+        assert!(!found, "Key {missing_key} should not be found in the store");
+        assert_eq!(decrypted, 0, "Missing key should return 0");
+
+        // Checks what happens with an empty store
+        let empty_store: CudaKVStore<u8, CudaUnsignedRadixCiphertext> = CudaKVStore::new();
+        let encrypted_key = cks.encrypt_radix(1u64, num_key_blocks);
+        let d_encrypted_key =
+            CudaUnsignedRadixCiphertext::from_radix_ciphertext(&encrypted_key, &streams);
+
+        let (result, found_bool, _selectors) =
+            sks.kv_store_get_impl(&empty_store, &d_encrypted_key, &streams);
+
+        let cpu_result = result.to_radix_ciphertext(&streams);
+        let decrypted: u64 = cks.decrypt_radix(&cpu_result);
+        let found = cks.decrypt_bool(&found_bool.to_boolean_block(&streams));
+
+        assert!(!found, "Empty store should not find any key");
+        assert_eq!(decrypted, 0, "Empty store should return 0");
+    }
+
+    #[test]
+    fn test_kv_store_contains_key() {
+        let params =
+            TEST_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128.into();
+        let (cks, _) = gen_keys::<ShortintParameterSet>(params, IntegerKeyKind::Radix);
+
+        let streams = CudaStreams::new_multi_gpu();
+        let sks = CudaServerKey::new(&cks, &streams);
+        streams.synchronize();
+
+        let num_value_blocks = 4;
+        let num_key_blocks = 4;
+
+        let clear_entries: Vec<(u8, u64)> = vec![(1, 10), (2, 42), (3, 100), (5, 200)];
+
+        let mut gpu_kv_store: CudaKVStore<u8, CudaUnsignedRadixCiphertext> = CudaKVStore::new();
+        for &(key, value) in &clear_entries {
+            let ct = cks.encrypt_radix(value, num_value_blocks);
+            let d_ct = CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct, &streams);
+            gpu_kv_store.insert(key, d_ct);
+        }
+
+        // Keys that are in the store must return true
+        for &(key, _) in &clear_entries {
+            let encrypted_key = cks.encrypt_radix(key as u64, num_key_blocks);
+            let d_encrypted_key =
+                CudaUnsignedRadixCiphertext::from_radix_ciphertext(&encrypted_key, &streams);
+
+            let result_bool = sks.kv_store_contains_key(&gpu_kv_store, &d_encrypted_key, &streams);
+            let found = cks.decrypt_bool(&result_bool.to_boolean_block(&streams));
+            assert!(found, "Key {key} should be found in the store");
+        }
+
+        // A key that is not in the store must return false
+        let missing_key = 4u8;
+        let encrypted_key = cks.encrypt_radix(missing_key as u64, num_key_blocks);
+        let d_encrypted_key =
+            CudaUnsignedRadixCiphertext::from_radix_ciphertext(&encrypted_key, &streams);
+
+        let result_bool = sks.kv_store_contains_key(&gpu_kv_store, &d_encrypted_key, &streams);
+        let found = cks.decrypt_bool(&result_bool.to_boolean_block(&streams));
+        assert!(!found, "Key {missing_key} should not be found in the store");
+
+        // An empty store must always return false
+        let empty_store: CudaKVStore<u8, CudaUnsignedRadixCiphertext> = CudaKVStore::new();
+        let encrypted_key = cks.encrypt_radix(1u64, num_key_blocks);
+        let d_encrypted_key =
+            CudaUnsignedRadixCiphertext::from_radix_ciphertext(&encrypted_key, &streams);
+
+        let result_bool = sks.kv_store_contains_key(&empty_store, &d_encrypted_key, &streams);
+        let found = cks.decrypt_bool(&result_bool.to_boolean_block(&streams));
+        assert!(!found, "Empty store should not find any key");
+    }
+
+    #[test]
+    fn test_kv_store_contains_value() {
+        let params =
+            TEST_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128.into();
+        let (cks, _) = gen_keys::<ShortintParameterSet>(params, IntegerKeyKind::Radix);
+
+        let streams = CudaStreams::new_multi_gpu();
+        let sks = CudaServerKey::new(&cks, &streams);
+        streams.synchronize();
+
+        let num_value_blocks = 4;
+
+        let clear_entries: Vec<(u8, u64)> = vec![(1, 10), (2, 42), (3, 100), (5, 200)];
+
+        let mut gpu_kv_store: CudaKVStore<u8, CudaUnsignedRadixCiphertext> = CudaKVStore::new();
+        for &(key, value) in &clear_entries {
+            let ct = cks.encrypt_radix(value, num_value_blocks);
+            let d_ct = CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct, &streams);
+            gpu_kv_store.insert(key, d_ct);
+        }
+
+        // Values that are in the store must return true
+        for &(_, value) in &clear_entries {
+            let encrypted_value = cks.encrypt_radix(value, num_value_blocks);
+            let d_encrypted_value =
+                CudaUnsignedRadixCiphertext::from_radix_ciphertext(&encrypted_value, &streams);
+
+            let result_bool =
+                sks.kv_store_contains_value(&gpu_kv_store, &d_encrypted_value, &streams);
+            let found = cks.decrypt_bool(&result_bool.to_boolean_block(&streams));
+            assert!(found, "Value {value} should be found in the store");
+        }
+
+        // A value that is not in the store must return false
+        let missing_value = 99u64;
+        let encrypted_value = cks.encrypt_radix(missing_value, num_value_blocks);
+        let d_encrypted_value =
+            CudaUnsignedRadixCiphertext::from_radix_ciphertext(&encrypted_value, &streams);
+
+        let result_bool = sks.kv_store_contains_value(&gpu_kv_store, &d_encrypted_value, &streams);
+        let found = cks.decrypt_bool(&result_bool.to_boolean_block(&streams));
+        assert!(
+            !found,
+            "Value {missing_value} should not be found in the store"
+        );
+    }
+
+    #[test]
+    fn test_kv_store_contains_clear_value() {
+        let params =
+            TEST_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128.into();
+        let (cks, _) = gen_keys::<ShortintParameterSet>(params, IntegerKeyKind::Radix);
+
+        let streams = CudaStreams::new_multi_gpu();
+        let sks = CudaServerKey::new(&cks, &streams);
+        streams.synchronize();
+
+        let num_value_blocks = 4;
+
+        let clear_entries: Vec<(u8, u64)> = vec![(1, 10), (2, 42), (3, 100), (5, 200)];
+
+        let mut gpu_kv_store: CudaKVStore<u8, CudaUnsignedRadixCiphertext> = CudaKVStore::new();
+        for &(key, value) in &clear_entries {
+            let ct = cks.encrypt_radix(value, num_value_blocks);
+            let d_ct = CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct, &streams);
+            gpu_kv_store.insert(key, d_ct);
+        }
+
+        // Clear values that are in the store must return true
+        for &(_, value) in &clear_entries {
+            let result_bool = sks.kv_store_contains_clear_value(&gpu_kv_store, value, &streams);
+            let found = cks.decrypt_bool(&result_bool.to_boolean_block(&streams));
+            assert!(found, "Clear value {value} should be found in the store");
+        }
+
+        // A clear value that is not in the store must return false
+        let missing_value = 99u64;
+        let result_bool = sks.kv_store_contains_clear_value(&gpu_kv_store, missing_value, &streams);
+        let found = cks.decrypt_bool(&result_bool.to_boolean_block(&streams));
+        assert!(
+            !found,
+            "Clear value {missing_value} should not be found in the store"
+        );
+    }
+
+    #[test]
+    fn test_kv_store_map() {
+        // kv_store_map cannot use the generic test templates, hence this dedicated test.
+        let params =
+            TEST_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128.into();
+        let (cks, _) = gen_keys::<ShortintParameterSet>(params, IntegerKeyKind::Radix);
+
+        let streams = CudaStreams::new_multi_gpu();
+        let sks = CudaServerKey::new(&cks, &streams);
+        streams.synchronize();
+
+        let num_value_blocks = 4;
+        let num_key_blocks = 4; // u8 key with message_modulus=4 => 8/2 = 4 blocks
+        let modulus = 1u64 << (2 * num_value_blocks); // 2 bits per block
+
+        let clear_entries: Vec<(u8, u64)> =
+            vec![(1, 10), (2, 42), (3, 100), (5, 200), (7, modulus - 1)];
+
+        let mut gpu_kv_store: CudaKVStore<u8, CudaUnsignedRadixCiphertext> = CudaKVStore::new();
+        for &(key, value) in &clear_entries {
+            let ct = cks.encrypt_radix(value, num_value_blocks);
+            let d_ct = CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct, &streams);
+            gpu_kv_store.insert(key, d_ct);
+        }
+
+        let key: u64 = 2;
+        let s: u64 = 10;
+        let f = |ct: CudaUnsignedRadixCiphertext| sks.scalar_mul(&ct, s, &streams);
+
+        let encrypted_key = cks.encrypt_radix(key, num_key_blocks);
+        let d_encrypted_key =
+            CudaUnsignedRadixCiphertext::from_radix_ciphertext(&encrypted_key, &streams);
+
+        sks.kv_store_map(&mut gpu_kv_store, &d_encrypted_key, f, &streams);
+    }
+}

--- a/tfhe/src/integer/gpu/server_key/radix/mod.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/mod.rs
@@ -60,6 +60,7 @@ mod vector_find;
 mod aes;
 mod aes256;
 mod kreyvium;
+pub(crate) mod kv_store;
 #[cfg(test)]
 mod tests_long_run;
 #[cfg(test)]

--- a/tfhe/src/integer/gpu/server_key/radix/tests_unsigned/mod.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/tests_unsigned/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod test_comparison;
 pub(crate) mod test_div_mod;
 pub(crate) mod test_ilog2;
 pub(crate) mod test_kreyvium;
+mod test_kv_store;
 pub(crate) mod test_mul;
 pub(crate) mod test_neg;
 pub(crate) mod test_oprf;
@@ -68,7 +69,9 @@ macro_rules! create_gpu_parameterized_stringified_test{
     };
 }
 
+use crate::integer::gpu::server_key::radix::kv_store::CudaKVStore;
 use crate::integer::gpu::server_key::radix::tests_signed::GpuMultiDeviceFunctionExecutor;
+use crate::integer::server_key::KVStore;
 pub(crate) use create_gpu_parameterized_stringified_test;
 pub(crate) use create_gpu_parameterized_test;
 use tfhe_csprng::seeders::Seed;
@@ -1877,5 +1880,233 @@ where
             .iter()
             .map(|ct| ct.to_radix_ciphertext(&context.streams))
             .collect())
+    }
+}
+
+impl<'a, Key, F>
+    FunctionExecutor<
+        (&'a KVStore<Key, RadixCiphertext>, &'a RadixCiphertext),
+        (RadixCiphertext, BooleanBlock),
+    > for GpuFunctionExecutor<F>
+where
+    Key: Clone + Ord,
+    F: Fn(
+        &CudaServerKey,
+        &CudaKVStore<Key, CudaUnsignedRadixCiphertext>,
+        &CudaUnsignedRadixCiphertext,
+        &CudaStreams,
+    ) -> (CudaUnsignedRadixCiphertext, CudaBooleanBlock),
+{
+    fn setup(&mut self, cks: &RadixClientKey, sks: Arc<ServerKey>) {
+        self.setup_from_keys(cks, &sks);
+    }
+
+    fn execute(
+        &mut self,
+        input: (&'a KVStore<Key, RadixCiphertext>, &'a RadixCiphertext),
+    ) -> (RadixCiphertext, BooleanBlock) {
+        let context = self
+            .context
+            .as_ref()
+            .expect("setup was not properly called");
+
+        let d_kv_store = CudaKVStore::from_kv_store(input.0, &context.streams);
+        let d_ctxt = CudaUnsignedRadixCiphertext::from_radix_ciphertext(input.1, &context.streams);
+
+        let gpu_result = (self.func)(&context.sks, &d_kv_store, &d_ctxt, &context.streams);
+
+        let result = gpu_result.0.to_radix_ciphertext(&context.streams);
+        let boolean = gpu_result.1.to_boolean_block(&context.streams);
+
+        (result, boolean)
+    }
+}
+
+impl<'a, Key, F>
+    FunctionExecutor<
+        (
+            &'a mut KVStore<Key, RadixCiphertext>,
+            &'a RadixCiphertext,
+            &'a RadixCiphertext,
+        ),
+        BooleanBlock,
+    > for GpuFunctionExecutor<F>
+where
+    Key: Clone + Ord,
+    F: Fn(
+        &CudaServerKey,
+        &mut CudaKVStore<Key, CudaUnsignedRadixCiphertext>,
+        &CudaUnsignedRadixCiphertext,
+        &CudaUnsignedRadixCiphertext,
+        &CudaStreams,
+    ) -> CudaBooleanBlock,
+{
+    fn setup(&mut self, cks: &RadixClientKey, sks: Arc<ServerKey>) {
+        self.setup_from_keys(cks, &sks);
+    }
+
+    fn execute(
+        &mut self,
+        input: (
+            &'a mut KVStore<Key, RadixCiphertext>,
+            &'a RadixCiphertext,
+            &'a RadixCiphertext,
+        ),
+    ) -> BooleanBlock {
+        let context = self
+            .context
+            .as_ref()
+            .expect("setup was not properly called");
+
+        let mut d_kv_store = CudaKVStore::from_kv_store(input.0, &context.streams);
+        let d_ctxt_1 =
+            CudaUnsignedRadixCiphertext::from_radix_ciphertext(input.1, &context.streams);
+        let d_ctxt_2 =
+            CudaUnsignedRadixCiphertext::from_radix_ciphertext(input.2, &context.streams);
+
+        let gpu_result = (self.func)(
+            &context.sks,
+            &mut d_kv_store,
+            &d_ctxt_1,
+            &d_ctxt_2,
+            &context.streams,
+        );
+
+        *input.0 = d_kv_store.to_kv_store(&context.streams);
+
+        gpu_result.to_boolean_block(&context.streams)
+    }
+}
+
+impl<'a, Key, F>
+    FunctionExecutor<(&'a KVStore<Key, RadixCiphertext>, &'a RadixCiphertext), BooleanBlock>
+    for GpuFunctionExecutor<F>
+where
+    Key: Clone + Ord,
+    F: Fn(
+        &CudaServerKey,
+        &CudaKVStore<Key, CudaUnsignedRadixCiphertext>,
+        &CudaUnsignedRadixCiphertext,
+        &CudaStreams,
+    ) -> CudaBooleanBlock,
+{
+    fn setup(&mut self, cks: &RadixClientKey, sks: Arc<ServerKey>) {
+        self.setup_from_keys(cks, &sks);
+    }
+
+    fn execute(
+        &mut self,
+        input: (&'a KVStore<Key, RadixCiphertext>, &'a RadixCiphertext),
+    ) -> BooleanBlock {
+        let context = self
+            .context
+            .as_ref()
+            .expect("setup was not properly called");
+
+        let d_kv_store = CudaKVStore::from_kv_store(input.0, &context.streams);
+        let d_ctxt = CudaUnsignedRadixCiphertext::from_radix_ciphertext(input.1, &context.streams);
+
+        let gpu_result = (self.func)(&context.sks, &d_kv_store, &d_ctxt, &context.streams);
+
+        gpu_result.to_boolean_block(&context.streams)
+    }
+}
+
+impl<'a, Key, F> FunctionExecutor<(&'a KVStore<Key, RadixCiphertext>, u64), BooleanBlock>
+    for GpuFunctionExecutor<F>
+where
+    Key: Clone + Ord,
+    F: Fn(
+        &CudaServerKey,
+        &CudaKVStore<Key, CudaUnsignedRadixCiphertext>,
+        u64,
+        &CudaStreams,
+    ) -> CudaBooleanBlock,
+{
+    fn setup(&mut self, cks: &RadixClientKey, sks: Arc<ServerKey>) {
+        self.setup_from_keys(cks, &sks);
+    }
+
+    fn execute(&mut self, input: (&'a KVStore<Key, RadixCiphertext>, u64)) -> BooleanBlock {
+        let context = self
+            .context
+            .as_ref()
+            .expect("setup was not properly called");
+
+        let d_kv_store = CudaKVStore::from_kv_store(input.0, &context.streams);
+
+        let gpu_result = (self.func)(&context.sks, &d_kv_store, input.1, &context.streams);
+
+        gpu_result.to_boolean_block(&context.streams)
+    }
+}
+
+impl<'a, Key, F>
+    FunctionExecutor<
+        (
+            &'a mut KVStore<Key, RadixCiphertext>,
+            &'a RadixCiphertext,
+            &'a dyn Fn(RadixCiphertext) -> RadixCiphertext,
+        ),
+        (RadixCiphertext, RadixCiphertext, BooleanBlock),
+    > for GpuFunctionExecutor<F>
+where
+    Key: Clone + Ord,
+    F: Fn(
+        &CudaServerKey,
+        &mut CudaKVStore<Key, CudaUnsignedRadixCiphertext>,
+        &CudaUnsignedRadixCiphertext,
+        &dyn Fn(CudaUnsignedRadixCiphertext) -> CudaUnsignedRadixCiphertext,
+        &CudaStreams,
+    ) -> (
+        CudaUnsignedRadixCiphertext,
+        CudaUnsignedRadixCiphertext,
+        CudaBooleanBlock,
+    ),
+{
+    fn setup(&mut self, cks: &RadixClientKey, sks: Arc<ServerKey>) {
+        self.setup_from_keys(cks, &sks);
+    }
+
+    fn execute(
+        &mut self,
+        input: (
+            &'a mut KVStore<Key, RadixCiphertext>,
+            &'a RadixCiphertext,
+            &'a dyn Fn(RadixCiphertext) -> RadixCiphertext,
+        ),
+    ) -> (RadixCiphertext, RadixCiphertext, BooleanBlock) {
+        let context = self
+            .context
+            .as_ref()
+            .expect("setup was not properly called");
+
+        let mut d_kv_store = CudaKVStore::from_kv_store(input.0, &context.streams);
+        let d_ctxt = CudaUnsignedRadixCiphertext::from_radix_ciphertext(input.1, &context.streams);
+
+        // The test supplies a closure that operates on CPU ciphertexts. Bridge it to the GPU
+        // domain by converting in and out around each call so the GPU map applies the same map.
+        let cpu_func = input.2;
+        let gpu_func = |gpu_value: CudaUnsignedRadixCiphertext| -> CudaUnsignedRadixCiphertext {
+            let cpu_value = gpu_value.to_radix_ciphertext(&context.streams);
+            let cpu_result = cpu_func(cpu_value);
+            CudaUnsignedRadixCiphertext::from_radix_ciphertext(&cpu_result, &context.streams)
+        };
+
+        let gpu_result = (self.func)(
+            &context.sks,
+            &mut d_kv_store,
+            &d_ctxt,
+            &gpu_func,
+            &context.streams,
+        );
+
+        *input.0 = d_kv_store.to_kv_store(&context.streams);
+
+        let old_value = gpu_result.0.to_radix_ciphertext(&context.streams);
+        let new_value = gpu_result.1.to_radix_ciphertext(&context.streams);
+        let boolean = gpu_result.2.to_boolean_block(&context.streams);
+
+        (old_value, new_value, boolean)
     }
 }

--- a/tfhe/src/integer/gpu/server_key/radix/tests_unsigned/test_kv_store.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/tests_unsigned/test_kv_store.rs
@@ -1,0 +1,120 @@
+use crate::core_crypto::gpu::CudaStreams;
+use crate::integer::gpu::ciphertext::CudaUnsignedRadixCiphertext;
+use crate::integer::gpu::server_key::radix::kv_store::CudaKVStore;
+use crate::integer::gpu::server_key::radix::tests_unsigned::{
+    create_gpu_parameterized_test, GpuFunctionExecutor,
+};
+use crate::integer::gpu::CudaServerKey;
+use crate::integer::server_key::radix_parallel::tests_unsigned::test_kv_store::{
+    default_kv_store_contains_clear_value_test, default_kv_store_contains_test,
+    default_kv_store_contains_value_test, default_kv_store_get_update_test,
+    default_kv_store_map_test, GET_UPDATE_STORE_SIZES,
+};
+use crate::shortint::parameters::test_params::TEST_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+use crate::shortint::parameters::{TestParameters, PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128};
+
+create_gpu_parameterized_test!(integer_default_kv_store_get_update);
+create_gpu_parameterized_test!(integer_default_kv_store_contains_key);
+create_gpu_parameterized_test!(integer_default_kv_store_contains_value);
+create_gpu_parameterized_test!(integer_default_kv_store_contains_clear_value);
+create_gpu_parameterized_test!(integer_default_kv_store_map);
+create_gpu_parameterized_test!(integer_kv_store_large_map_get_update);
+create_gpu_parameterized_test!(integer_kv_store_large_map_contains_key);
+create_gpu_parameterized_test!(integer_kv_store_single_block_key_get_update);
+create_gpu_parameterized_test!(integer_kv_store_single_block_key_contains_key);
+
+fn integer_default_kv_store_get_update(params: impl Into<TestParameters>) {
+    let get_executor = GpuFunctionExecutor::new(&CudaServerKey::kv_store_get);
+    let update_executor = GpuFunctionExecutor::new(&CudaServerKey::kv_store_update);
+
+    default_kv_store_get_update_test::<u8, _, _, _>(
+        params,
+        get_executor,
+        update_executor,
+        None,
+        GET_UPDATE_STORE_SIZES,
+        usize::MAX,
+    );
+}
+
+fn integer_default_kv_store_contains_key(params: impl Into<TestParameters>) {
+    let contains_executor = GpuFunctionExecutor::new(&CudaServerKey::kv_store_contains_key);
+    default_kv_store_contains_test::<u8, _, _>(params, contains_executor, None, &[20], usize::MAX);
+}
+
+fn integer_default_kv_store_contains_value(params: impl Into<TestParameters>) {
+    let contains_value_executor = GpuFunctionExecutor::new(&CudaServerKey::kv_store_contains_value);
+    default_kv_store_contains_value_test::<u8, _, _>(params, contains_value_executor);
+}
+
+fn integer_default_kv_store_contains_clear_value(params: impl Into<TestParameters>) {
+    let contains_clear_value_executor =
+        GpuFunctionExecutor::new(&CudaServerKey::kv_store_contains_clear_value);
+    default_kv_store_contains_clear_value_test::<u8, _, _>(params, contains_clear_value_executor);
+}
+
+fn integer_default_kv_store_map(params: impl Into<TestParameters>) {
+    // `kv_store_map` is generic over the mapping closure, so it cannot be passed as a bare
+    // function item; wrap it so the executor binds a concrete `Fn`.
+    let closure =
+        |sks: &CudaServerKey,
+         store: &mut CudaKVStore<u8, CudaUnsignedRadixCiphertext>,
+         encrypted_key: &CudaUnsignedRadixCiphertext,
+         func: &dyn Fn(CudaUnsignedRadixCiphertext) -> CudaUnsignedRadixCiphertext,
+         streams: &CudaStreams| { sks.kv_store_map(store, encrypted_key, func, streams) };
+    let map_executor = GpuFunctionExecutor::new(closure);
+    default_kv_store_map_test::<u8, _, _>(params, map_executor);
+}
+
+// 300 entries exceeds the CUDA backend's small-map limit
+// (KV_STORE_EQ_SELECTORS_SMALL_MAP_MAX_ENTRIES = 256), forcing the large-map
+// equality-selector path; 20 entries stays on the small-map path for contrast. u16 keys are
+// required because a u8 key space caps the store at 256 entries. Probes are capped at 2 so
+// the 300-entry case stays fast.
+fn integer_kv_store_large_map_get_update(params: impl Into<TestParameters>) {
+    let get_executor = GpuFunctionExecutor::new(&CudaServerKey::kv_store_get);
+    let update_executor = GpuFunctionExecutor::new(&CudaServerKey::kv_store_update);
+
+    default_kv_store_get_update_test::<u16, _, _, _>(
+        params,
+        get_executor,
+        update_executor,
+        None,
+        &[20, 300],
+        2,
+    );
+}
+
+fn integer_kv_store_large_map_contains_key(params: impl Into<TestParameters>) {
+    let contains_executor = GpuFunctionExecutor::new(&CudaServerKey::kv_store_contains_key);
+    default_kv_store_contains_test::<u16, _, _>(params, contains_executor, None, &[20, 300], 2);
+}
+
+// A 1-block key is the minimal key width: the small-map equality-selector buffer skips all
+// tree-reduction allocations and uses each candidate's single comparison block directly as its
+// selector, with no AND-reduction. With message_modulus = 4 the key space is {0..3}, so a
+// 3-entry store leaves one key free for absent-key probes.
+fn integer_kv_store_single_block_key_get_update(params: impl Into<TestParameters>) {
+    let get_executor = GpuFunctionExecutor::new(&CudaServerKey::kv_store_get);
+    let update_executor = GpuFunctionExecutor::new(&CudaServerKey::kv_store_update);
+
+    default_kv_store_get_update_test::<u8, _, _, _>(
+        params,
+        get_executor,
+        update_executor,
+        Some(1),
+        &[3],
+        usize::MAX,
+    );
+}
+
+fn integer_kv_store_single_block_key_contains_key(params: impl Into<TestParameters>) {
+    let contains_executor = GpuFunctionExecutor::new(&CudaServerKey::kv_store_contains_key);
+    default_kv_store_contains_test::<u8, _, _>(
+        params,
+        contains_executor,
+        Some(1),
+        &[3],
+        usize::MAX,
+    );
+}

--- a/tfhe/src/integer/server_key/radix_parallel/kv_store.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/kv_store.rs
@@ -173,7 +173,7 @@ where
 //
 // Also, one important point is that par_iter_bridge may not keep iteration order
 // `The resulting iterator is not guaranteed to keep the order of the original iterator` (from rayon
-// docs) which is a problem for us as we need determinisn
+// docs) which is a problem for us as we need determinism
 impl ServerKey {
     /// Implementation of the get function that additionally returns the Vec of selectors
     /// so it can be reused to avoid re-computing it.
@@ -413,11 +413,20 @@ pub struct CompressedKVStore<Key, Value> {
     _v: PhantomData<Value>,
 }
 
+// The only consumer is the GPU decompression path (in `integer::gpu`); it lives in another module
+// and so cannot read the private fields directly. Hence unused, and dead in non-gpu builds.
+impl<Key, Value> CompressedKVStore<Key, Value> {
+    #[allow(dead_code)]
+    pub(crate) fn parts(&self) -> (&[Key], &CompressedCiphertextList, bool) {
+        (&self.keys, &self.values, self.is_signed)
+    }
+}
+
 impl<Key, Value> CompressedKVStore<Key, Value>
 where
     Value: Expandable + IntegerRadixCiphertext,
 {
-    fn new(keys: Vec<Key>, compressed_values: CompressedCiphertextList) -> Self {
+    pub(crate) fn new(keys: Vec<Key>, compressed_values: CompressedCiphertextList) -> Self {
         Self {
             keys,
             values: compressed_values,
@@ -433,7 +442,8 @@ where
     /// * A value (which is a radix ciphertext) does not have the same number of blocks as the
     ///   others.
     ///
-    /// Both these errors indicate corrupted or malformed data
+    /// A signedness mismatch indicates the requested value type is wrong for the stored data; the
+    /// other errors indicate corrupted or malformed data.
     pub fn decompress(
         &self,
         decompression_key: &DecompressionKey,
@@ -442,11 +452,15 @@ where
         Key: Copy + Display + Ord,
     {
         if Value::IS_SIGNED != self.is_signed {
-            let requested = if Value::IS_SIGNED { "Signed" } else { "" };
-            let stored = if self.is_signed { "Signed" } else { "" };
+            let requested = if Value::IS_SIGNED {
+                "signed"
+            } else {
+                "unsigned"
+            };
+            let stored = if self.is_signed { "signed" } else { "unsigned" };
             return Err(crate::error!(
-                "Requested value type does not have signed.\
-             Requested '{requested}RadixCiphertext' but stored '{stored}RadixCiphertext'"
+                "Requested value signedness does not match stored data: \
+                 requested {requested} values but stored values are {stored}"
             ));
         }
 

--- a/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_kv_store.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_kv_store.rs
@@ -1,3 +1,5 @@
+use crate::core_crypto::prelude::{CastFrom, UnsignedNumeric};
+use crate::integer::block_decomposition::DecomposableInto;
 use crate::integer::keycache::KEY_CACHE;
 use crate::integer::server_key::radix_parallel::tests_cases_unsigned::FunctionExecutor;
 use crate::integer::server_key::radix_parallel::tests_unsigned::{CpuFunctionExecutor, NB_CTXT};
@@ -7,6 +9,7 @@ use crate::integer::{BooleanBlock, IntegerKeyKind, RadixCiphertext, RadixClientK
 use crate::shortint::parameters::test_params::*;
 use crate::shortint::parameters::{TestParameters, *};
 use std::collections::BTreeMap;
+use std::fmt::Display;
 use std::sync::Arc;
 
 create_parameterized_test!(
@@ -105,57 +108,100 @@ create_parameterized_test!(
     }
 );
 
+type KeyType = u8;
+
 fn integer_default_kv_store_get_update(params: impl Into<TestParameters>) {
     let get_executor = CpuFunctionExecutor::new(&ServerKey::kv_store_get);
     let update_executor = CpuFunctionExecutor::new(&ServerKey::kv_store_update);
-    default_kv_store_get_update_test(params, get_executor, update_executor);
+    default_kv_store_get_update_test::<KeyType, _, _, _>(
+        params,
+        get_executor,
+        update_executor,
+        None,
+        GET_UPDATE_STORE_SIZES,
+        usize::MAX,
+    );
 }
 fn integer_default_kv_store_contains_key(params: impl Into<TestParameters>) {
     let contains_executor = CpuFunctionExecutor::new(&ServerKey::kv_store_contains_key);
-    default_kv_store_contains_test(params, contains_executor);
+    default_kv_store_contains_test::<KeyType, _, _>(
+        params,
+        contains_executor,
+        None,
+        &[20],
+        usize::MAX,
+    );
 }
 
 fn integer_default_kv_store_contains_value(params: impl Into<TestParameters>) {
     let contains_value_executor = CpuFunctionExecutor::new(&ServerKey::kv_store_contains_value);
-    default_kv_store_contains_value_test(params, contains_value_executor);
+    default_kv_store_contains_value_test::<KeyType, _, _>(params, contains_value_executor);
 }
 
 fn integer_default_kv_store_contains_clear_value(params: impl Into<TestParameters>) {
     let contains_clear_value_executor =
         CpuFunctionExecutor::new(&ServerKey::kv_store_contains_clear_value);
-    default_kv_store_contains_clear_value_test(params, contains_clear_value_executor);
+    default_kv_store_contains_clear_value_test::<KeyType, _, _>(
+        params,
+        contains_clear_value_executor,
+    );
 }
 
 fn integer_default_kv_store_map(params: impl Into<TestParameters>) {
     let closure = |sks: &ServerKey,
-                   store: &mut KVStore<u8, RadixCiphertext>,
+                   store: &mut KVStore<KeyType, RadixCiphertext>,
                    encrypted_key: &RadixCiphertext,
                    func: &dyn Fn(RadixCiphertext) -> RadixCiphertext| {
         sks.kv_store_map(store, encrypted_key, func)
     };
     let map_executor = CpuFunctionExecutor::new(closure);
-    default_kv_store_map_test(params, map_executor);
+    default_kv_store_map_test::<KeyType, _, _>(params, map_executor);
 }
 
-pub type KeyType = u8;
-
-fn get_num_block_for_key(msg_mod: MessageModulus) -> usize {
-    KeyType::BITS.div_ceil(msg_mod.0.ilog2()) as usize
+fn get_num_block_for_key<Key: UnsignedNumeric>(msg_mod: MessageModulus) -> usize {
+    Key::BITS.div_ceil(msg_mod.0.ilog2() as usize)
 }
 
-fn default_kv_store_get_update_test<P, T1, T2>(
+// Store sizes covering distinct paths in the GPU fold-sum schedule (a GPU implementation
+// detail; the CPU runs the same sizes for parity):
+//
+//   3  — below the noise budget: a fold-only schedule with no PBS round.
+//  20  — remainder is an exact multiple of the per-round budget: folds, absorbs the
+//        tail, and finishes after a second fold-only round.
+//  26  — remainder is not a multiple of the budget at any full round: takes the
+//        most general schedule, with several PBS rounds.
+pub const GET_UPDATE_STORE_SIZES: &[usize] = &[3, 20, 26];
+
+/// Number of distinct keys representable: bounded both by the encrypted key width and by the
+/// clear key type's range.
+fn key_space_modulus<Key: UnsignedNumeric>(msg_mod: MessageModulus, nb_key_blocks: usize) -> u128 {
+    assert!(Key::BITS < 128);
+    (msg_mod.0 as u128)
+        .pow(nb_key_blocks as u32)
+        .min(1u128 << Key::BITS)
+}
+
+fn random_key<Key: CastFrom<u64>>(key_modulus: u128) -> Key {
+    Key::cast_from((rand::random::<u128>() % key_modulus) as u64)
+}
+
+pub fn default_kv_store_get_update_test<Key, P, T1, T2>(
     params: P,
     mut kv_store_get: T1,
     mut kv_store_update: T2,
+    nb_key_blocks: Option<usize>,
+    store_sizes: &[usize],
+    max_probes: usize,
 ) where
+    Key: DecomposableInto<u64> + UnsignedNumeric + CastFrom<u64> + Ord + Copy + Display,
     P: Into<TestParameters>,
     T1: for<'a> FunctionExecutor<
-        (&'a KVStore<KeyType, RadixCiphertext>, &'a RadixCiphertext),
+        (&'a KVStore<Key, RadixCiphertext>, &'a RadixCiphertext),
         (RadixCiphertext, BooleanBlock),
     >,
     T2: for<'a> FunctionExecutor<
         (
-            &'a mut KVStore<KeyType, RadixCiphertext>,
+            &'a mut KVStore<Key, RadixCiphertext>,
             &'a RadixCiphertext,
             &'a RadixCiphertext,
         ),
@@ -169,7 +215,9 @@ fn default_kv_store_get_update_test<P, T1, T2>(
     sks.set_deterministic_pbs_execution(true);
     let sks = Arc::new(sks);
 
-    let nb_blocks_key = get_num_block_for_key(params.message_modulus());
+    let nb_blocks_key =
+        nb_key_blocks.unwrap_or_else(|| get_num_block_for_key::<Key>(params.message_modulus()));
+    let key_modulus = key_space_modulus::<Key>(params.message_modulus(), nb_blocks_key);
 
     // message_modulus^vec_length
     let modulus = cks.parameters().message_modulus().0.pow(NB_CTXT as u32);
@@ -179,8 +227,8 @@ fn default_kv_store_get_update_test<P, T1, T2>(
 
     // Test on an empty store
     {
-        let mut empty_map: KVStore<KeyType, RadixCiphertext> = KVStore::new();
-        let key = rand::random::<u8>();
+        let mut empty_map: KVStore<Key, RadixCiphertext> = KVStore::new();
+        let key = random_key::<Key>(key_modulus);
         let encrypted_key = cks.as_ref().encrypt_radix(key, nb_blocks_key);
 
         let (result, is_some) = kv_store_get.execute((&empty_map, &encrypted_key));
@@ -194,55 +242,59 @@ fn default_kv_store_get_update_test<P, T1, T2>(
         assert!(!cks.decrypt_bool(&is_some));
     }
 
-    let num_keys = 20usize;
-    let (mut map, mut clear_store) = create_filled_stores(num_keys, modulus, &cks);
+    for &num_keys in store_sizes {
+        let (mut map, mut clear_store) =
+            create_filled_stores::<Key>(num_keys, key_modulus, modulus, &cks);
+        let num_probes = num_keys.div_ceil(2).min(max_probes);
 
-    // Test modifying a key that does not exist
-    for _ in 0..num_keys.div_ceil(2) {
-        let key = generate_unused_key(&clear_store);
-        let encrypted_key = cks.as_ref().encrypt_radix(key, nb_blocks_key);
+        // Test a key that does not exist.
+        for _ in 0..num_probes {
+            let key = generate_unused_key(&clear_store, key_modulus);
+            let encrypted_key = cks.as_ref().encrypt_radix(key, nb_blocks_key);
 
-        let (result, is_some) = kv_store_get.execute((&mut map, &encrypted_key));
-        assert!(!cks.decrypt_bool(&is_some));
-        assert_eq!(cks.decrypt::<u64>(&result), 0);
+            let (result, is_some) = kv_store_get.execute((&map, &encrypted_key));
+            assert!(!cks.decrypt_bool(&is_some));
+            assert_eq!(cks.decrypt::<u64>(&result), 0);
 
-        let new_value = rand::random::<u64>() % modulus;
-        let encrypted_new_value: RadixCiphertext = cks.encrypt(new_value);
-        let is_some = kv_store_update.execute((&mut map, &encrypted_key, &encrypted_new_value));
-        assert!(!cks.decrypt_bool(&is_some));
+            let new_value = rand::random::<u64>() % modulus;
+            let encrypted_new_value: RadixCiphertext = cks.encrypt(new_value);
+            let is_some = kv_store_update.execute((&mut map, &encrypted_key, &encrypted_new_value));
+            assert!(!cks.decrypt_bool(&is_some));
 
-        panic_if_not_the_same(&map, &clear_store, &cks);
-    }
+            panic_if_not_the_same(&map, &clear_store, &cks);
+        }
 
-    // Test modifying a key that exists
-    for _ in 0..num_keys.div_ceil(2) {
-        let key_index = rand::random::<usize>() % num_keys;
-        let key_target = *clear_store.iter().nth(key_index).unwrap().0;
-        let encrypted_key = cks.as_ref().encrypt_radix(key_target, nb_blocks_key);
+        // Test a key that exists.
+        for _ in 0..num_probes {
+            let key_index = rand::random::<usize>() % num_keys;
+            let key_target = *clear_store.iter().nth(key_index).unwrap().0;
+            let encrypted_key = cks.as_ref().encrypt_radix(key_target, nb_blocks_key);
 
-        let expected_value = clear_store.get(&key_target).unwrap();
+            let expected_value = clear_store.get(&key_target).unwrap();
 
-        let (result, is_some) = kv_store_get.execute((&mut map, &encrypted_key));
-        assert!(cks.decrypt_bool(&is_some));
-        assert_eq!(cks.decrypt::<u64>(&result), *expected_value);
+            let (result, is_some) = kv_store_get.execute((&map, &encrypted_key));
+            assert!(cks.decrypt_bool(&is_some));
+            assert_eq!(cks.decrypt::<u64>(&result), *expected_value);
 
-        let new_value = rand::random::<u64>() % modulus;
-        let encrypted_new_value: RadixCiphertext = cks.encrypt(new_value);
-        let is_some = kv_store_update.execute((&mut map, &encrypted_key, &encrypted_new_value));
-        assert!(cks.decrypt_bool(&is_some));
+            let new_value = rand::random::<u64>() % modulus;
+            let encrypted_new_value: RadixCiphertext = cks.encrypt(new_value);
+            let is_some = kv_store_update.execute((&mut map, &encrypted_key, &encrypted_new_value));
+            assert!(cks.decrypt_bool(&is_some));
 
-        clear_store.insert(key_target, new_value);
+            clear_store.insert(key_target, new_value);
 
-        panic_if_not_properly_updated(&map, &clear_store, key_target, &cks);
+            panic_if_not_properly_updated(&map, &clear_store, key_target, &cks);
+        }
     }
 }
 
-fn default_kv_store_map_test<P, T>(params: P, mut kv_store_map: T)
+pub fn default_kv_store_map_test<Key, P, T>(params: P, mut kv_store_map: T)
 where
+    Key: DecomposableInto<u64> + UnsignedNumeric + CastFrom<u64> + Ord + Copy + Display,
     P: Into<TestParameters>,
     T: for<'a> FunctionExecutor<
         (
-            &'a mut KVStore<KeyType, RadixCiphertext>,
+            &'a mut KVStore<Key, RadixCiphertext>,
             &'a RadixCiphertext,
             &'a dyn Fn(RadixCiphertext) -> RadixCiphertext,
         ),
@@ -256,17 +308,19 @@ where
     sks.set_deterministic_pbs_execution(true);
     let sks = Arc::new(sks);
 
-    let nb_blocks_key = get_num_block_for_key(params.message_modulus());
+    let nb_blocks_key = get_num_block_for_key::<Key>(params.message_modulus());
 
     // message_modulus^vec_length
     let modulus = cks.parameters().message_modulus().0.pow(NB_CTXT as u32);
 
     kv_store_map.setup(&cks, sks);
 
+    let key_modulus = key_space_modulus::<Key>(params.message_modulus(), nb_blocks_key);
+
     // Test on an empty store
     {
-        let mut empty_map: KVStore<KeyType, RadixCiphertext> = KVStore::new();
-        let key = rand::random::<u8>();
+        let mut empty_map: KVStore<Key, RadixCiphertext> = KVStore::new();
+        let key = random_key::<Key>(key_modulus);
         let encrypted_key = cks.as_ref().encrypt_radix(key, nb_blocks_key);
         let identity: &dyn Fn(RadixCiphertext) -> RadixCiphertext = &|x| x;
         let (_, _, is_some) = kv_store_map.execute((&mut empty_map, &encrypted_key, identity));
@@ -274,7 +328,7 @@ where
     }
 
     let num_keys = 20usize;
-    let (mut map, mut clear_store) = create_filled_stores(num_keys, modulus, &cks);
+    let (mut map, mut clear_store) = create_filled_stores(num_keys, key_modulus, modulus, &cks);
 
     let clear_function = |x: u64| -> u64 { x / 3 };
     let function = Box::new(|input: RadixCiphertext| -> RadixCiphertext {
@@ -286,7 +340,7 @@ where
 
     // Test modifying a key that does not exist
     for _ in 0..num_keys.div_ceil(2) {
-        let key = generate_unused_key(&clear_store);
+        let key = generate_unused_key(&clear_store, key_modulus);
         let encrypted_key = cks.as_ref().encrypt_radix(key, nb_blocks_key);
 
         let (_, _, is_some) = kv_store_map.execute((&mut map, &encrypted_key, &function));
@@ -326,20 +380,33 @@ where
 ///
 /// # Arguments
 /// * `num_keys` - Number of key-value pairs to generate
+/// * `key_modulus` - Size of the key space keys are drawn from
 /// * `modulus` - Maximum value for the random values
 /// * `cks` - Client key for encryption
 ///
 /// # Returns
 /// A tuple containing the encrypted store and its clear counterpart
-fn create_filled_stores(
+fn create_filled_stores<Key>(
     num_keys: usize,
+    key_modulus: u128,
     modulus: u64,
     cks: &RadixClientKey,
-) -> (KVStore<KeyType, RadixCiphertext>, BTreeMap<KeyType, u64>) {
+) -> (KVStore<Key, RadixCiphertext>, BTreeMap<Key, u64>)
+where
+    Key: CastFrom<u64> + Ord + Copy,
+{
+    // The absent-key probes need at least one unused key in the key space.
+    assert!(
+        (num_keys as u128) < key_modulus,
+        "store size {num_keys} must be smaller than the key space {key_modulus}"
+    );
     let mut store = KVStore::new();
-    let mut clear_store = BTreeMap::<u8, u64>::new();
+    let mut clear_store = BTreeMap::<Key, u64>::new();
     while clear_store.len() != num_keys {
-        let (key, value) = (rand::random::<u8>(), rand::random::<u64>() % modulus);
+        let (key, value) = (
+            random_key::<Key>(key_modulus),
+            rand::random::<u64>() % modulus,
+        );
         clear_store.insert(key, value);
 
         let encrypted_value = cks.encrypt(value);
@@ -352,11 +419,13 @@ fn create_filled_stores(
 
 /// Panics if any of the key-value pairs of the encrypted store
 /// is not the same as the clear store.
-fn panic_if_not_the_same(
-    map: &KVStore<KeyType, RadixCiphertext>,
-    clear_store: &BTreeMap<KeyType, u64>,
+fn panic_if_not_the_same<Key>(
+    map: &KVStore<Key, RadixCiphertext>,
+    clear_store: &BTreeMap<Key, u64>,
     cks: &RadixClientKey,
-) {
+) where
+    Key: Ord + Copy + Display,
+{
     assert_eq!(
         map.len(),
         clear_store.len(),
@@ -374,11 +443,17 @@ fn panic_if_not_the_same(
     }
 }
 
-fn default_kv_store_contains_test<P, T1>(params: P, mut kv_store_contains_key: T1)
-where
+pub fn default_kv_store_contains_test<Key, P, T1>(
+    params: P,
+    mut kv_store_contains_key: T1,
+    nb_key_blocks: Option<usize>,
+    store_sizes: &[usize],
+    max_probes: usize,
+) where
+    Key: DecomposableInto<u64> + UnsignedNumeric + CastFrom<u64> + Ord + Copy + Display,
     P: Into<TestParameters>,
     T1: for<'a> FunctionExecutor<
-        (&'a KVStore<KeyType, RadixCiphertext>, &'a RadixCiphertext),
+        (&'a KVStore<Key, RadixCiphertext>, &'a RadixCiphertext),
         BooleanBlock,
     >,
 {
@@ -389,7 +464,9 @@ where
     sks.set_deterministic_pbs_execution(true);
     let sks = Arc::new(sks);
 
-    let nb_blocks_key = get_num_block_for_key(params.message_modulus());
+    let nb_blocks_key =
+        nb_key_blocks.unwrap_or_else(|| get_num_block_for_key::<Key>(params.message_modulus()));
+    let key_modulus = key_space_modulus::<Key>(params.message_modulus(), nb_blocks_key);
 
     // message_modulus^vec_length
     let modulus = cks.parameters().message_modulus().0.pow(NB_CTXT as u32);
@@ -398,41 +475,44 @@ where
 
     // Test on an empty store
     {
-        let empty_map: KVStore<KeyType, RadixCiphertext> = KVStore::new();
-        let key = rand::random::<u8>();
+        let empty_map: KVStore<Key, RadixCiphertext> = KVStore::new();
+        let key = random_key::<Key>(key_modulus);
         let encrypted_key = cks.as_ref().encrypt_radix(key, nb_blocks_key);
         let is_contained = kv_store_contains_key.execute((&empty_map, &encrypted_key));
         assert!(!cks.decrypt_bool(&is_contained));
     }
 
-    let num_keys = 20usize;
-    let (map, clear_store) = create_filled_stores(num_keys, modulus, &cks);
+    for &num_keys in store_sizes {
+        let (map, clear_store) = create_filled_stores::<Key>(num_keys, key_modulus, modulus, &cks);
+        let num_probes = num_keys.div_ceil(2).min(max_probes);
 
-    // Test a key that does not exist
-    for _ in 0..num_keys.div_ceil(2) {
-        let key = generate_unused_key(&clear_store);
-        let encrypted_key = cks.as_ref().encrypt_radix(key, nb_blocks_key);
+        // Test a key that does not exist
+        for _ in 0..num_probes {
+            let key = generate_unused_key(&clear_store, key_modulus);
+            let encrypted_key = cks.as_ref().encrypt_radix(key, nb_blocks_key);
 
-        let is_contained = kv_store_contains_key.execute((&map, &encrypted_key));
-        assert!(!cks.decrypt_bool(&is_contained));
-    }
+            let is_contained = kv_store_contains_key.execute((&map, &encrypted_key));
+            assert!(!cks.decrypt_bool(&is_contained));
+        }
 
-    // Test a key that exists
-    for _ in 0..num_keys.div_ceil(2) {
-        let key_index = rand::random::<usize>() % num_keys;
-        let key_target = *clear_store.iter().nth(key_index).unwrap().0;
-        let encrypted_key = cks.as_ref().encrypt_radix(key_target, nb_blocks_key);
+        // Test a key that exists
+        for _ in 0..num_probes {
+            let key_index = rand::random::<usize>() % num_keys;
+            let key_target = *clear_store.iter().nth(key_index).unwrap().0;
+            let encrypted_key = cks.as_ref().encrypt_radix(key_target, nb_blocks_key);
 
-        let is_contained = kv_store_contains_key.execute((&map, &encrypted_key));
-        assert!(cks.decrypt_bool(&is_contained));
+            let is_contained = kv_store_contains_key.execute((&map, &encrypted_key));
+            assert!(cks.decrypt_bool(&is_contained));
+        }
     }
 }
 
-fn default_kv_store_contains_value_test<P, T1>(params: P, mut kv_store_contains_value: T1)
+pub fn default_kv_store_contains_value_test<Key, P, T1>(params: P, mut kv_store_contains_value: T1)
 where
+    Key: DecomposableInto<u64> + UnsignedNumeric + CastFrom<u64> + Ord + Copy + Display,
     P: Into<TestParameters>,
     T1: for<'a> FunctionExecutor<
-        (&'a KVStore<KeyType, RadixCiphertext>, &'a RadixCiphertext),
+        (&'a KVStore<Key, RadixCiphertext>, &'a RadixCiphertext),
         BooleanBlock,
     >,
 {
@@ -443,6 +523,9 @@ where
     sks.set_deterministic_pbs_execution(true);
     let sks = Arc::new(sks);
 
+    let nb_blocks_key = get_num_block_for_key::<Key>(params.message_modulus());
+    let key_modulus = key_space_modulus::<Key>(params.message_modulus(), nb_blocks_key);
+
     // message_modulus^vec_length
     let modulus = cks.parameters().message_modulus().0.pow(NB_CTXT as u32);
 
@@ -450,14 +533,14 @@ where
 
     // Test on an empty store
     {
-        let empty_map: KVStore<KeyType, RadixCiphertext> = KVStore::new();
+        let empty_map: KVStore<Key, RadixCiphertext> = KVStore::new();
         let value: RadixCiphertext = cks.encrypt(rand::random::<u64>() % modulus);
         let is_contained = kv_store_contains_value.execute((&empty_map, &value));
         assert!(!cks.decrypt_bool(&is_contained));
     }
 
     let num_keys = 20usize;
-    let (map, clear_store) = create_filled_stores(num_keys, modulus, &cks);
+    let (map, clear_store) = create_filled_stores(num_keys, key_modulus, modulus, &cks);
 
     // Test a value that exists in the store
     for _ in 0..num_keys.div_ceil(2) {
@@ -484,12 +567,13 @@ where
     }
 }
 
-fn default_kv_store_contains_clear_value_test<P, T1>(
+pub fn default_kv_store_contains_clear_value_test<Key, P, T1>(
     params: P,
     mut kv_store_contains_clear_value: T1,
 ) where
+    Key: DecomposableInto<u64> + UnsignedNumeric + CastFrom<u64> + Ord + Copy + Display,
     P: Into<TestParameters>,
-    T1: for<'a> FunctionExecutor<(&'a KVStore<KeyType, RadixCiphertext>, u64), BooleanBlock>,
+    T1: for<'a> FunctionExecutor<(&'a KVStore<Key, RadixCiphertext>, u64), BooleanBlock>,
 {
     let params = params.into();
     let (cks, mut sks) = KEY_CACHE.get_from_params(params, IntegerKeyKind::Radix);
@@ -498,6 +582,9 @@ fn default_kv_store_contains_clear_value_test<P, T1>(
     sks.set_deterministic_pbs_execution(true);
     let sks = Arc::new(sks);
 
+    let nb_blocks_key = get_num_block_for_key::<Key>(params.message_modulus());
+    let key_modulus = key_space_modulus::<Key>(params.message_modulus(), nb_blocks_key);
+
     // message_modulus^vec_length
     let modulus = cks.parameters().message_modulus().0.pow(NB_CTXT as u32);
 
@@ -505,14 +592,14 @@ fn default_kv_store_contains_clear_value_test<P, T1>(
 
     // Test on an empty store
     {
-        let empty_map: KVStore<KeyType, RadixCiphertext> = KVStore::new();
+        let empty_map: KVStore<Key, RadixCiphertext> = KVStore::new();
         let is_contained =
             kv_store_contains_clear_value.execute((&empty_map, rand::random::<u64>() % modulus));
         assert!(!cks.decrypt_bool(&is_contained));
     }
 
     let num_keys = 20usize;
-    let (map, clear_store) = create_filled_stores(num_keys, modulus, &cks);
+    let (map, clear_store) = create_filled_stores(num_keys, key_modulus, modulus, &cks);
 
     // Test a value that exists in the store
     for _ in 0..num_keys.div_ceil(2) {
@@ -537,9 +624,12 @@ fn default_kv_store_contains_clear_value_test<P, T1>(
     }
 }
 
-fn generate_unused_key(clear_store: &BTreeMap<KeyType, u64>) -> u8 {
+fn generate_unused_key<Key>(clear_store: &BTreeMap<Key, u64>, key_modulus: u128) -> Key
+where
+    Key: CastFrom<u64> + Ord,
+{
     loop {
-        let key = rand::random::<u8>();
+        let key = random_key::<Key>(key_modulus);
         if !clear_store.contains_key(&key) {
             return key;
         }
@@ -552,12 +642,14 @@ fn generate_unused_key(clear_store: &BTreeMap<KeyType, u64>) -> u8 {
 /// To be used after updating a key.
 /// `update_key`, tells which key was last updated
 /// so that the panic message is clearer
-fn panic_if_not_properly_updated(
-    map: &KVStore<KeyType, RadixCiphertext>,
-    clear_store: &BTreeMap<KeyType, u64>,
-    updated_key: KeyType,
+fn panic_if_not_properly_updated<Key>(
+    map: &KVStore<Key, RadixCiphertext>,
+    clear_store: &BTreeMap<Key, u64>,
+    updated_key: Key,
     cks: &RadixClientKey,
-) {
+) where
+    Key: Ord + Copy + Display,
+{
     assert_eq!(
         map.len(),
         clear_store.len(),


### PR DESCRIPTION
## Benchmarks

GPU latency (ms) for `u64 / FheUint64`, sizes = number of `(key, value)` pairs,
measured on `8x NVIDIA H100 80GB HBM3` (clocks locked at 1980 MHz), latency mode,
10 samples. Speedups are computed against the CPU KVStore latency benchmark taken
on 2025-10-06 (commit `0604d237`, `AWS HPC7a`, AMD EPYC 192 cores), `KVStore<u64, FheUint64>`:

Note: the `get` rows below were re-measured on 2026-06-11 (commit `c009ef885`),
after the fold reduction was made noise-optimal (factor-5 entry reduction per PBS
round) and the equality-selectors computation was made entry-count-dispatched (see
"Equality-selectors dispatch" below). For those runs the machine's SM clocks were
capped at 1830 MHz (provider-side change), so those rows are measured at slightly
lower clocks than the other rows.

| CPU baseline (ms) | 16 | 64 | 256 | 1024 |
|---|---:|---:|---:|---:|
| `get` | 232.3 | 631.0 | 2035.1 | 7478.5 |
| `update` | 385.4 | 1158.4 | 4089.7 | 15477.0 |
| `map` | 519.7 | 1594.9 | 5587.1 | 21185.0 |

**Multi-bit** (`V1_6_PARAM_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128`):

| Operation | 16 | 64 | 256 | 1024 | Speedup range vs CPU |
|---|---:|---:|---:|---:|---|
| `get` | 21.9 | 43.9 | 128.1 | 631.8 | 10.6-15.9x |
| `update` | 28.6 | 82.1 | 357.1 | 1699.6 | 9.1-14.1x |
| `map` | 42.0 | 114.0 | 463.0 | 2243.5 | 9.4-14.0x |
| `contains_key` | 12.0 | 17.9 | 36.3 | 105.5 | GPU-only |
| `contains_value` | 23.2 | 43.8 | 145.0 | 547.4 | GPU-only |

**Classical** (`PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128`):

| Operation | 16 | 64 | 256 | 1024 | Speedup range vs CPU |
|---|---:|---:|---:|---:|---|
| `get` | 41.7 | 63.5 | 141.3 | 418.1 | 5.6-17.9x |
| `update` | 42.0 | 90.3 | 273.8 | 1063.4 | 9.2-14.9x |
| `map` | 66.2 | 135.3 | 387.1 | 1387.7 | 7.9-15.3x |
| `contains_key` | 26.5 | 32.7 | 49.4 | 108.8 | GPU-only |
| `contains_value` | 48.1 | 69.1 | 240.9 | 913.6 | GPU-only |

## GPU KVStore

This PR adds GPU acceleration for the encrypted KVStore.

### CUDA Kernels

- Add CUDA kernels for `kv_store_get`, `kv_store_update`, and `kv_store_map` operations (`backends/tfhe-cuda-backend/cuda/src/integer/kv_store/`)
- Add batched CMUX building block (`int_zero_out_if_batch_buffer`) that operates on multiple ciphertexts in a single kernel launch (`backends/tfhe-cuda-backend/cuda/include/integer/cmux.h`)
- Add a kv_store-private batch equality-selector computation dispatched by entry count (see "Equality-selectors dispatch" below).
- Add periodic identity-PBS noise cleaning to the binary-tree sum. Each pairwise fold level doubles noise because both operands carry accumulated noise; after `floor(log2(max_noise))` levels the budget would be exceeded, so a batch identity-PBS resets surviving entries to NOMINAL before continuing the reduction. A final PBS guarantees clean output.

### Equality-selectors dispatch

`kv_store` computes the `Enc(key == k_i)` selectors with one of two implementations, chosen once at scratch time by entry count (`KV_STORE_EQ_SELECTORS_SMALL_MAP_MAX_ENTRIES = 256` in `kv_store_utilities.h`):

- `<= 256` entries: `host_kv_store_compute_eq_selectors_small_map` (kv_store-private, in `kv_store.cuh`) - grid many-LUT PBS + gather + batched tree reduction; ~4N total PBS in 2 sequential levels.
- `> 256` entries: `host_compute_eq_selectors_ct_vs_clears` in `vector_find.cuh`, restored to its original sequential-accumulator implementation; ~3N total PBS in ~3 sequential rounds.

The tree variant wins on PBS critical-path depth while batches do not yet saturate the GPU; the sequential variant wins on total PBS count once they do. H100 `get` latencies (ms, `u64` keys / `FheUint64` values) measured for each implementation in isolation and for the dispatch:

| params | implementation | 16 | 64 | 256 | 1024 |
|---|---|---:|---:|---:|---:|
| classical | tree only | 44.5 | 67.8 | 151.3 | 463.1 |
| classical | sequential only | 61.7 | 86.5 | 156.5 | 420.4 |
| classical | **dispatch** | **41.7** | **63.5** | **141.3** | **418.1** |
| multi-bit | tree only | 22.8 | 45.9 | 132.6 | 668.9 |
| multi-bit | sequential only | 29.4 | 50.6 | 130.8 | 620.8 |
| multi-bit | **dispatch** | **21.9** | **43.9** | **128.1** | **631.8** |

### Side effects on existing integer operations

None remaining: the non-KVStore vector_find ops (`match_value`, `match_value_or`, `is_in_clears`, `index_in_clears`, `first_index_in_clears`, `index_of`, `index_of_clear`, `first_index_of`, `first_index_of_clear`) call `host_compute_eq_selectors_ct_vs_clears`, which this PR restores to its pre-existing implementation (with an added `num_blocks >= 1` guard). The batched tree variant is kv_store-private. A dead ct-vs-ct selector variant (`host_compute_equality_selectors` / `int_equality_selectors_buffer`, zero callers) was removed.

### Rust Integration

- Add Rust FFI bindings for the three KVStore CUDA operations (`tfhe/src/integer/gpu/ffi.rs`)
- Add `CudaKVStore` struct and `CudaServerKey` methods (`kv_store_get`, `kv_store_update`, `kv_store_map`) at the integer level (`tfhe/src/integer/gpu/server_key/radix/kv_store.rs`)
- Integrate GPU KVStore into the high-level API: `KVStore::new()` automatically selects `InnerKVStore::Cuda` when a GPU server key is active (`tfhe/src/high_level_api/kv_store.rs`)
- Handle empty `CudaKVStore` in `update` and `map` operations
- Implement GPU-native KVStore compression and decompression using `CudaCompressedCiphertextListBuilder`, with `decompress_to_cuda` for the reverse path

### Tests & Benchmarks

- Add GPU KVStore integration tests (`tfhe/src/integer/gpu/server_key/radix/tests_unsigned/test_kv_store.rs`)
- Add GPU-specific KVStore benchmarks with `hlapi::cuda` prefix (`tfhe-benchmark/benches/high_level_api/kv_store.rs`)

### Others

This PR adds comments and a couple diagrams to `backends/tfhe-cuda-backend/cuda/src/integer/vector_find.cuh`. I missed those when I was trying to understand some methods in that file, so I kept (and adjusted) the AI comments for future reference.

### binary tree sum vs `sum_ciphertexts_vec`

I executed benchmarks on 8xSXM5 to validate the improvement of using the binary-tree fold (`host_binary_tree_fold_sum`) against the usual `sum_ciphertexts_vec` accumulator. The binary-tree fold applies a PBS every `floor(log2(max_noise))` layers, which is a safe bound that could be increased after deeper research.

(These numbers are from a separate 8xSXM5 run and are kept for reference; they compare the fold against the `sum_ciphertexts_vec` accumulator, not against the generic per-level `host_binary_tree_sum`.)

### FheUint32 value

| entries | binary tree | accumulator | speedup (acc/tree) |
|--------:|------------:|------------:|-------------------:|
| 2    | 31.97 ms | 44.71 ms | 1.40x |
| 4    | 32.66 ms | 49.82 ms | 1.53x |
| 8    | 37.87 ms | 59.25 ms | 1.56x |
| 16   | 39.20 ms | 65.45 ms | 1.67x |
| 32   | 45.94 ms | 77.02 ms | 1.68x |
| 64   | 57.17 ms | 89.26 ms | 1.56x |
| 128  | 78.37 ms | 114.24 ms | 1.46x |
| 256  | 117.32 ms | 165.33 ms | 1.41x |
| 512  | 189.44 ms | 263.49 ms | 1.39x |
| 1024 | 344.72 ms | 457.59 ms | 1.33x |

### FheUint64 value

| entries | binary tree | accumulator | speedup (acc/tree) |
|--------:|------------:|------------:|-------------------:|
| 2    | 32.60 ms | 49.93 ms | 1.53x |
| 4    | 33.11 ms | 55.00 ms | 1.66x |
| 8    | 38.35 ms | 64.72 ms | 1.69x |
| 16   | 39.92 ms | 71.56 ms | 1.79x |
| 32   | 49.20 ms | 86.36 ms | 1.76x |
| 64   | 65.83 ms | 106.51 ms | 1.62x |
| 128  | 94.44 ms | 144.07 ms | 1.53x |
| 256  | 147.43 ms | 222.68 ms | 1.51x |
| 512  | 252.42 ms | 368.99 ms | 1.46x |
| 1024 | 475.19 ms | 674.86 ms | 1.42x |

### FheUint128 value

| entries | binary tree | accumulator | speedup (acc/tree) |
|--------:|------------:|------------:|-------------------:|
| 2    | 33.34 ms | 64.10 ms | 1.92x |
| 4    | 33.85 ms | 69.83 ms | 2.06x |
| 8    | 39.33 ms | 80.39 ms | 2.04x |
| 16   | 43.48 ms | 90.49 ms | 2.08x |
| 32   | 57.79 ms | 112.95 ms | 1.95x |
| 64   | 82.35 ms | 145.84 ms | 1.77x |
| 128  | 126.69 ms | 211.11 ms | 1.67x |
| 256  | 211.56 ms | 337.52 ms | 1.60x |
| 512  | 380.09 ms | 592.70 ms | 1.56x |
| 1024 | 748.59 ms | 1125.20 ms | 1.50x |


---

<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: https://github.com/zama-ai/tfhe-rs-internal/issues/1384

### PR content/description

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3540)
<!-- Reviewable:end -->
