### PR TITLE
fix(hl): handle panics in with_server_key_as_context

### DIFF
--- a/tfhe/src/high_level_api/global_state.rs
+++ b/tfhe/src/high_level_api/global_state.rs
@@ -80,10 +80,18 @@ pub fn with_server_key_as_context<T, F>(keys: ServerKey, f: F) -> T
 where
     F: FnOnce() -> T,
 {
-    set_server_key(keys);
-    let result = f();
-    unset_server_key();
-    result
+    // If there is an existing key, save it to be restored later
+    let previous_key = replace_server_key(Some(keys));
+
+    struct ServerKeyGuard(Option<InternalServerKey>);
+    impl Drop for ServerKeyGuard {
+        fn drop(&mut self) {
+            let _ = replace_server_key(self.0.take());
+        }
+    }
+
+    let _guard = ServerKeyGuard(previous_key);
+    f()
 }
 
 /// Convenience function that allows to write functions that needs to access the internal keys


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: https://github.com/zama-ai/tfhe-rs-internal/issues/1420#issue-4375610741

### PR content/description
Handle panic in `with_server_key_as_context` by using a drop guard to restore the state. Also handle the case where a key was previously set.