### PR TITLE
fix(ci): removes 'test_zk_pok_gpu_sanitizer' from the CI workflow

### DIFF
--- a/.github/workflows/gpu_zk_memory_sanitizer.yml
+++ b/.github/workflows/gpu_zk_memory_sanitizer.yml
@@ -136,10 +136,6 @@ jobs:
         run: |
           make test_zk_cuda_backend_memcheck
 
-      - name: Run tfhe-zk-pok memcheck (Rust tests)
-        run: |
-          make test_zk_pok_gpu_sanitizer
-
   slack-notify:
     name: gpu_zk_memory_sanitizer/slack-notify
     needs: [ setup-instance, cuda-tests-linux ]


### PR DESCRIPTION
This test takes too long and is often cancelled before it finishes. The `zk-cuda-backend` memcheck is enough for what we need and it requires only a few minutes.

<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
