### PR TITLE
fix(gpu): add glwe_index bounds check in GPU extract_glwe

### DIFF
--- a/tfhe/src/integer/gpu/ffi.rs
+++ b/tfhe/src/integer/gpu/ffi.rs
@@ -9463,6 +9463,12 @@ pub fn extract_glwe<T: UnsignedInteger>(
         glwe_list.data.gpu_index(0),
         "GPU error: all data should reside on the same GPU."
     );
+    assert!(
+        (glwe_index as usize) < glwe_list.glwe_ciphertext_count().0,
+        "glwe_index {glwe_index} is out of bounds for a packed GLWE list with {} ciphertexts",
+        glwe_list.glwe_ciphertext_count().0,
+    );
+
     let packed_glwe_list_ffi = prepare_cuda_packed_glwe_ct_ffi(glwe_list);
 
     unsafe {


### PR DESCRIPTION
Validate that glwe_index is within the packed GLWE ciphertext count before passing it to the CUDA FFI, preventing out-of-bounds GPU memory access.

<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: https://github.com/zama-ai/tfhe-rs-internal/issues/1421

### PR content/description

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
