### PR TITLE
feat: make SystemTime Versionable

### DIFF
--- a/utils/tfhe-versionable/src/lib.rs
+++ b/utils/tfhe-versionable/src/lib.rs
@@ -271,6 +271,8 @@ impl_scalar_versionize!(char);
 impl_scalar_versionize!(NonZero<u32>);
 impl_scalar_versionize!(NonZero<usize>);
 
+impl_scalar_versionize!(std::time::SystemTime);
+
 impl<T: Versionize> Versionize for Wrapping<T> {
     type Versioned<'vers>
         = Wrapping<T::Versioned<'vers>>

--- a/utils/tfhe-versionable/tests/types.rs
+++ b/utils/tfhe-versionable/tests/types.rs
@@ -37,6 +37,7 @@ pub struct MyStruct {
     tuple: (f32, f64),
     set: HashSet<i128>,
     map: HashMap<char, bool>,
+    timestamp: std::time::SystemTime,
 }
 
 mod backward_compat {
@@ -99,6 +100,7 @@ fn test_types() {
         tuple: (std::f32::consts::PI, std::f64::consts::E),
         set: HashSet::from_iter([1, 2, 3]),
         map: HashMap::from_iter([('t', true), ('e', false), ('s', true)]),
+        timestamp: std::time::SystemTime::now(),
     };
 
     let mut ser = Vec::new();


### PR DESCRIPTION
Pretty much what it says in the title. In the KMS we currently have to cast SystemTime to u64 to work around this limitation.
