### PR TITLE
feat(shortint): add kreyvium transcipher

### DIFF
--- a/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_kreyvium.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_kreyvium.rs
@@ -2,6 +2,8 @@ use crate::integer::keycache::KEY_CACHE;
 use crate::integer::server_key::radix_parallel::tests_cases_unsigned::FunctionExecutor;
 use crate::integer::{IntegerKeyKind, RadixCiphertext, RadixClientKey};
 use crate::shortint::parameters::TestParameters;
+use crate::transciphering::ciphers::kreyvium::KreyviumPlainState;
+use crate::transciphering::StreamCipher;
 use rand::Rng;
 use std::fmt::Write;
 use std::sync::Arc;
@@ -19,120 +21,6 @@ fn decrypt_bits(cks: &RadixClientKey, ct: &RadixCiphertext) -> Vec<u8> {
         .iter()
         .map(|block| cks.decrypt_one_block(block) as u8)
         .collect()
-}
-
-struct KreyviumRef {
-    a: Vec<u64>,
-    b: Vec<u64>,
-    c: Vec<u64>,
-    k: Vec<u64>,
-    iv: Vec<u64>,
-    cursor_a: usize,
-    cursor_b: usize,
-    cursor_c: usize,
-    cursor_k: usize,
-    cursor_iv: usize,
-}
-
-impl KreyviumRef {
-    fn new(key_bits: &[u64], iv_bits: &[u64]) -> Self {
-        let mut a = vec![0u64; 93];
-        let mut b = vec![0u64; 84];
-        let mut c = vec![0u64; 111];
-        let mut k = key_bits.to_vec();
-        let mut iv = iv_bits.to_vec();
-
-        assert_eq!(k.len(), 128);
-        assert_eq!(iv.len(), 128);
-
-        for i in 0..93 {
-            a[i] = key_bits[128 - 93 + i];
-        }
-        for i in 0..84 {
-            b[i] = iv_bits[128 - 84 + i];
-        }
-        for i in 0..44 {
-            c[111 - 44 + i] = iv_bits[i];
-        }
-        for i in 0..66 {
-            c[i + 1] = 1;
-        }
-
-        k.reverse();
-        iv.reverse();
-
-        let mut kreyvium = Self {
-            a,
-            b,
-            c,
-            k,
-            iv,
-            cursor_a: 0,
-            cursor_b: 0,
-            cursor_c: 0,
-            cursor_k: 0,
-            cursor_iv: 0,
-        };
-
-        for _ in 0..1152 {
-            kreyvium.next_bit();
-        }
-
-        kreyvium
-    }
-
-    fn next_bit(&mut self) -> u8 {
-        let idx_a = |cursor: usize, i: usize| -> usize { (93 + cursor - i - 1) % 93 };
-        let idx_b = |cursor: usize, i: usize| -> usize { (84 + cursor - i - 1) % 84 };
-        let idx_c = |cursor: usize, i: usize| -> usize { (111 + cursor - i - 1) % 111 };
-        let idx_k = |cursor: usize, i: usize| -> usize { (128 + cursor - i - 1) % 128 };
-        let idx_iv = |cursor: usize, i: usize| -> usize { (128 + cursor - i - 1) % 128 };
-
-        let k_val = self.k[idx_k(self.cursor_k, 127)];
-        let iv_val = self.iv[idx_iv(self.cursor_iv, 127)];
-
-        let a1 = self.a[idx_a(self.cursor_a, 65)];
-        let a2 = self.a[idx_a(self.cursor_a, 92)];
-        let a3 = self.a[idx_a(self.cursor_a, 91)];
-        let a4 = self.a[idx_a(self.cursor_a, 90)];
-        let a5 = self.a[idx_a(self.cursor_a, 68)];
-
-        let b1 = self.b[idx_b(self.cursor_b, 68)];
-        let b2 = self.b[idx_b(self.cursor_b, 83)];
-        let b3 = self.b[idx_b(self.cursor_b, 82)];
-        let b4 = self.b[idx_b(self.cursor_b, 81)];
-        let b5 = self.b[idx_b(self.cursor_b, 77)];
-
-        let c1 = self.c[idx_c(self.cursor_c, 65)];
-        let c2 = self.c[idx_c(self.cursor_c, 110)];
-        let c3 = self.c[idx_c(self.cursor_c, 109)];
-        let c4 = self.c[idx_c(self.cursor_c, 108)];
-        let c5 = self.c[idx_c(self.cursor_c, 86)];
-
-        let temp_a = a1 ^ a2;
-        let temp_b = b1 ^ b2;
-        let temp_c = c1 ^ c2 ^ k_val;
-
-        let new_a = (c3 & c4) ^ a5 ^ temp_c;
-        let new_b = (a3 & a4) ^ b5 ^ temp_a ^ iv_val;
-        let new_c = (b3 & b4) ^ c5 ^ temp_b;
-
-        let out = temp_a ^ temp_b ^ temp_c;
-
-        self.a[self.cursor_a] = new_a;
-        self.cursor_a = (self.cursor_a + 1) % 93;
-
-        self.b[self.cursor_b] = new_b;
-        self.cursor_b = (self.cursor_b + 1) % 84;
-
-        self.c[self.cursor_c] = new_c;
-        self.cursor_c = (self.cursor_c + 1) % 111;
-
-        self.cursor_k = (self.cursor_k + 1) % 128;
-        self.cursor_iv = (self.cursor_iv + 1) % 128;
-
-        out as u8
-    }
 }
 
 fn bits_to_hex(bits: &[u8]) -> String {
@@ -158,27 +46,6 @@ fn parse_hex_to_bits(s: &str) -> Vec<u64> {
         }
     }
     bits
-}
-
-/// Tests the Rust reference implementation of Kreyvium against a known test vector.
-/// This ensures the logic in `KreyviumRef` is correct before comparing it to FHE.
-#[test]
-fn test_kreyvium_ref_consistency() {
-    let key_hex = "0053A6F94C9FF24598EB000000000000";
-    let iv_hex = "0D74DB42A91077DE45AC000000000000";
-    let expected_out_hex = "D1F0303482061111";
-
-    let key_bits = parse_hex_to_bits(key_hex);
-    let iv_bits = parse_hex_to_bits(iv_hex);
-
-    let mut kreyvium = KreyviumRef::new(&key_bits, &iv_bits);
-    let mut output_bits = Vec::new();
-    for _ in 0..64 {
-        output_bits.push(kreyvium.next_bit());
-    }
-
-    let hex_string = bits_to_hex(&output_bits);
-    assert_eq!(hex_string, expected_out_hex);
 }
 
 /// Tests the full FHE Kreyvium implementation against a known standard test vector.
@@ -250,11 +117,15 @@ where
         let ct_key = encrypt_bits(&cks, &key_bits);
         let ct_iv = encrypt_bits(&cks, &iv_bits);
 
-        let mut ref_kreyvium = KreyviumRef::new(&key_bits, &iv_bits);
-        let mut cpu_output = Vec::with_capacity(num_steps);
-        for _ in 0..num_steps {
-            cpu_output.push(ref_kreyvium.next_bit());
-        }
+        let key_bool: [bool; 128] = std::array::from_fn(|i| key_bits[i] == 1);
+        let iv_bool: [bool; 128] = std::array::from_fn(|i| iv_bits[i] == 1);
+        let mut ref_kreyvium = KreyviumPlainState::new(key_bool, iv_bool);
+        let ref_bytes = ref_kreyvium.next_keystream_bits(num_steps);
+        let cpu_output = ref_bytes
+            .iter()
+            .flat_map(|&b| (0..8).map(move |i| (b >> i) & 1))
+            .take(num_steps)
+            .collect::<Vec<_>>();
 
         let output_radix = executor.execute((&ct_key, &ct_iv, num_steps)).unwrap();
         let fhe_output = decrypt_bits(&cks, &output_radix);
@@ -264,9 +135,8 @@ where
     }
 }
 
-// Integration test verifying the correctness of the stateful FHE Kreyvium implementation by
-// comparing consecutive keystream chunks against a cleartext CPU reference.
-//
+/// Integration test verifying the correctness of the stateful FHE Kreyvium implementation by
+/// comparing consecutive keystream chunks against a cleartext CPU reference.
 pub fn kreyvium_stateful_comparison_test<P, E>(param: P, mut executor: E)
 where
     P: Into<TestParameters>,
@@ -297,11 +167,15 @@ where
     let ct_key = encrypt_bits(&cks, &key_bits);
     let ct_iv = encrypt_bits(&cks, &iv_bits);
 
-    let mut ref_kreyvium = KreyviumRef::new(&key_bits, &iv_bits);
-    let mut cpu_output = Vec::with_capacity(total_steps);
-    for _ in 0..total_steps {
-        cpu_output.push(ref_kreyvium.next_bit());
-    }
+    let key_bool: [bool; 128] = std::array::from_fn(|i| key_bits[i] == 1);
+    let iv_bool: [bool; 128] = std::array::from_fn(|i| iv_bits[i] == 1);
+    let mut ref_kreyvium = KreyviumPlainState::new(key_bool, iv_bool);
+    let ref_bytes = ref_kreyvium.next_keystream_bits(total_steps);
+    let cpu_output = ref_bytes
+        .iter()
+        .flat_map(|&b| (0..8).map(move |i| (b >> i) & 1))
+        .take(total_steps)
+        .collect::<Vec<_>>();
 
     let output_radixes = executor.execute((&ct_key, &ct_iv, &step_chunks)).unwrap();
 

--- a/tfhe/src/lib.rs
+++ b/tfhe/src/lib.rs
@@ -100,6 +100,9 @@ pub mod integer;
 /// cbindgen:ignore
 pub mod shortint;
 
+#[cfg(feature = "shortint")]
+pub mod transciphering;
+
 #[cfg(feature = "pbs-stats")]
 pub use shortint::server_key::pbs_stats::*;
 

--- a/tfhe/src/transciphering/backward_compatibility/mod.rs
+++ b/tfhe/src/transciphering/backward_compatibility/mod.rs
@@ -1,0 +1,13 @@
+use tfhe_versionable::VersionsDispatch;
+
+use crate::transciphering::{StreamCipherKind, StreamCiphertext};
+
+#[derive(VersionsDispatch)]
+pub enum StreamCipherKindVersions {
+    V0(StreamCipherKind),
+}
+
+#[derive(VersionsDispatch)]
+pub enum StreamCiphertextVersions {
+    V0(StreamCiphertext),
+}

--- a/tfhe/src/transciphering/ciphers/kreyvium/fhe.rs
+++ b/tfhe/src/transciphering/ciphers/kreyvium/fhe.rs
@@ -1,0 +1,428 @@
+//! TFHE implementation of the Kreyvium Algorithm
+
+use crate::shortint::{Ciphertext, ServerKey};
+use crate::transciphering::ciphers::shift_register::ShiftRegister;
+use crate::transciphering::{FheKeyStream, StreamCipherKind, Transcipherer};
+
+use super::{
+    collect_boxed_array, KreyviumBackwardRoundOutput, KreyviumIV, KreyviumRound,
+    KreyviumRoundInput, KreyviumRoundOutput, KreyviumState,
+};
+
+/// A kreyvium key encrypted in LWE, one ciphertext per bit
+pub struct KreyviumFheKey {
+    cts: Box<[Ciphertext; 128]>,
+}
+
+impl KreyviumFheKey {
+    pub fn init_state(self, iv: KreyviumIV, sk: &ServerKey) -> KreyviumFheState {
+        KreyviumFheState::new(self, iv, sk)
+    }
+}
+
+impl From<Box<[Ciphertext; 128]>> for KreyviumFheKey {
+    fn from(cts: Box<[Ciphertext; 128]>) -> Self {
+        Self { cts }
+    }
+}
+
+impl From<[Ciphertext; 128]> for KreyviumFheKey {
+    fn from(cts: [Ciphertext; 128]) -> Self {
+        Self { cts: Box::new(cts) }
+    }
+}
+
+pub type KreyviumFheState = KreyviumState<Ciphertext>;
+
+impl KreyviumFheState {
+    /// Constructor for `KreyviumFheState`: arguments are the secret key, the input vector,
+    /// and a `ServerKey` reference. Outputs a state object already initialized
+    /// (1152 steps have been run before returning).
+    pub fn new(key: impl Into<KreyviumFheKey>, iv: impl Into<KreyviumIV>, sk: &ServerKey) -> Self {
+        let mut key = key.into().cts;
+        let mut iv = iv.into().expand().map(|b| b as u64);
+
+        // Initialization of Kreyvium registers: a has the secret key, b the beginning of the IV,
+        // c the end of the iv and padding 1s.
+        let mut a_register: Box<[Ciphertext; 93]> =
+            collect_boxed_array((0..93).map(|_| sk.create_trivial(0)))
+                .expect("array and iter size match");
+        let mut b_register: Box<[Ciphertext; 84]> =
+            collect_boxed_array((0..84).map(|_| sk.create_trivial(0)))
+                .expect("array and iter size match");
+        let mut c_register: Box<[Ciphertext; 111]> =
+            collect_boxed_array((0..111).map(|_| sk.create_trivial(0)))
+                .expect("array and iter size match");
+
+        for i in 0..93 {
+            a_register[i].clone_from(&key[128 - 93 + i]);
+        }
+        for i in 0..84 {
+            b_register[i] = sk.create_trivial(iv[128 - 84 + i]);
+        }
+        for i in 0..44 {
+            c_register[111 - 44 + i] = sk.create_trivial(iv[i]);
+        }
+        for i in 0..66 {
+            c_register[i + 1] = sk.create_trivial(1);
+        }
+
+        key.reverse();
+        iv.reverse();
+        let iv: Box<[Ciphertext; 128]> =
+            collect_boxed_array(iv.iter().map(|&x| sk.create_trivial(x)))
+                .expect("array and iter size match");
+
+        let mut state = Self {
+            a: ShiftRegister::new(a_register),
+            b: ShiftRegister::new(b_register),
+            c: ShiftRegister::new(c_register),
+            k: ShiftRegister::new(key),
+            iv: ShiftRegister::new(iv),
+            counter: 0,
+        };
+        state.warmup(sk);
+        state
+    }
+}
+
+impl Transcipherer for KreyviumFheState {
+    fn kind(&self) -> StreamCipherKind {
+        StreamCipherKind::Kreyvium
+    }
+
+    fn next_keystream_bits(&mut self, sks: &ServerKey, n_bits: usize) -> FheKeyStream {
+        FheKeyStream(self.next_n(sks, n_bits))
+    }
+
+    fn seek(&mut self, sks: &ServerKey, target_counter: u64) {
+        self.seek_to(sks, target_counter)
+    }
+
+    fn current_counter(&self) -> u64 {
+        self.counter
+    }
+}
+
+type KreyviumFheRoundInput<'a> = KreyviumRoundInput<'a, Ciphertext>;
+
+impl KreyviumRound for KreyviumFheRoundInput<'_> {
+    type AuxData = ServerKey;
+    type Bit = Ciphertext;
+
+    /// Kreyvium round. Output keystream bit is a clean single-bit ciphertext
+    /// (degree 1, value in {0, 1}).
+    fn round(self, sk: &Self::AuxData) -> KreyviumRoundOutput<Self::Bit> {
+        if sk.message_modulus.0 == 4 && sk.carry_modulus.0 == 4 {
+            round_2_2(&self, sk)
+        } else {
+            round_naive(&self, sk)
+        }
+    }
+
+    fn backward_round(self, sk: &Self::AuxData) -> KreyviumBackwardRoundOutput<Self::Bit> {
+        if sk.message_modulus.0 == 4 && sk.carry_modulus.0 == 4 {
+            backward_round_2_2(&self, sk)
+        } else {
+            backward_round_naive(&self, sk)
+        }
+    }
+}
+
+/// Kreyvium round optimized for MESSAGE_2_CARRY_2.
+fn round_2_2(input: &KreyviumFheRoundInput<'_>, sk: &ServerKey) -> KreyviumRoundOutput<Ciphertext> {
+    // Peak noise of the algo is 4 (new_b).
+    // Regarding degree: `unchecked_bitand` in the next round is a bivariate PBS and requires
+    // carry-empty operands, so register updates end with `message_extract`.
+    // We don't need anything stricter (e.g. masking to a single bit): the
+    // cipher reads only the low bit of each cell, so the high message bit is
+    // free to hold whatever `message_extract` leaves there.
+    assert!(
+        sk.max_noise_level.get() >= 4,
+        "round_2_2 needs max_noise_level >= 4, got {}",
+        sk.max_noise_level.get(),
+    );
+
+    let KreyviumRoundInput {
+        a: (a1, a2, a3, a4, a5),
+        b: (b1, b2, b3, b4, b5),
+        c: (c1, c2, c3, c4, c5),
+        k,
+        iv,
+    } = input;
+
+    for (l, r) in [(a3, a4), (b3, b4), (c3, c4)] {
+        sk.is_functional_bivariate_pbs_possible(l.noise_degree(), r.noise_degree(), None)
+            .expect("bivariate bitand precondition violated for kreyvium round_2_2");
+    }
+
+    let temp_a = sk.unchecked_add(a1, a2);
+    let temp_b = sk.unchecked_add(b1, b2);
+    let mut temp_c = sk.unchecked_add(c1, c2);
+    sk.unchecked_add_assign(&mut temp_c, k);
+
+    let ((a, b), (c, output)) = rayon::join(
+        || {
+            rayon::join(
+                || {
+                    let mut new_a = sk.unchecked_bitand(c3, c4);
+                    sk.unchecked_add_assign(&mut new_a, a5);
+                    sk.unchecked_add_assign(&mut new_a, &temp_c);
+                    sk.message_extract_assign(&mut new_a);
+                    new_a
+                },
+                || {
+                    let mut new_b = sk.unchecked_bitand(a3, a4);
+                    sk.unchecked_add_assign(&mut new_b, b5);
+                    sk.unchecked_add_assign(&mut new_b, &temp_a);
+                    sk.unchecked_add_assign(&mut new_b, iv);
+                    sk.message_extract_assign(&mut new_b);
+                    new_b
+                },
+            )
+        },
+        || {
+            rayon::join(
+                || {
+                    let mut new_c = sk.unchecked_bitand(b3, b4);
+                    sk.unchecked_add_assign(&mut new_c, c5);
+                    sk.unchecked_add_assign(&mut new_c, &temp_b);
+                    sk.message_extract_assign(&mut new_c);
+                    new_c
+                },
+                || {
+                    let lhs = sk.unchecked_add(&temp_a, &temp_b);
+                    let xor_low_bit = sk.generate_lookup_table_bivariate(|x, y| (x ^ y) & 1);
+                    sk.apply_lookup_table_bivariate(&lhs, &temp_c, &xor_low_bit)
+                },
+            )
+        },
+    );
+    KreyviumRoundOutput { output, a, b, c }
+}
+
+/// Param-agnostic fallback round, assuming tight params
+/// (e.g. 1_1: `max_noise_level = 3`, `MSG_MOD*CARRY_MOD = 4`)
+/// Costs 3 extra PBS per round versus `round_2_2`.
+fn round_naive(
+    input: &KreyviumFheRoundInput<'_>,
+    sk: &ServerKey,
+) -> KreyviumRoundOutput<Ciphertext> {
+    // Peak noise of the algo is 3 (temp_c and new_b).
+    // Regarding degree: `unchecked_bitand` in the next round is a bivariate PBS and requires
+    // carry-empty operands, so register updates end with `message_extract`.
+    // We don't need anything stricter (e.g. masking to a single bit): the
+    // cipher reads only the low bit of each cell, so the high message bit is
+    // free to hold whatever `message_extract` leaves there.
+    assert!(
+        sk.max_noise_level.get() >= 3,
+        "round_naive needs max_noise_level >= 3, got {}",
+        sk.max_noise_level.get(),
+    );
+
+    let KreyviumRoundInput {
+        a: (a1, a2, a3, a4, a5),
+        b: (b1, b2, b3, b4, b5),
+        c: (c1, c2, c3, c4, c5),
+        k,
+        iv,
+    } = input;
+
+    for (l, r) in [(a3, a4), (b3, b4), (c3, c4)] {
+        sk.is_functional_bivariate_pbs_possible(l.noise_degree(), r.noise_degree(), None)
+            .expect("bivariate bitand precondition violated for kreyvium round_naive");
+    }
+
+    let (temp_a, (temp_b, temp_c)) = rayon::join(
+        || {
+            let mut t = sk.unchecked_add(a1, a2);
+            sk.message_extract_assign(&mut t);
+            t
+        },
+        || {
+            rayon::join(
+                || {
+                    let mut t = sk.unchecked_add(b1, b2);
+                    sk.message_extract_assign(&mut t);
+                    t
+                },
+                || {
+                    let mut t = sk.unchecked_add(c1, c2);
+                    sk.unchecked_add_assign(&mut t, k);
+                    sk.message_extract_assign(&mut t);
+                    t
+                },
+            )
+        },
+    );
+
+    let ((a, b), (c, output)) = rayon::join(
+        || {
+            rayon::join(
+                || {
+                    let mut new_a = sk.unchecked_bitand(c3, c4);
+                    sk.unchecked_add_assign(&mut new_a, a5);
+                    sk.add_assign(&mut new_a, &temp_c);
+                    new_a
+                },
+                || {
+                    let mut new_b = sk.unchecked_bitand(a3, a4);
+                    sk.unchecked_add_assign(&mut new_b, b5);
+                    sk.unchecked_add_assign(&mut new_b, &temp_a);
+                    sk.add_assign(&mut new_b, iv);
+                    new_b
+                },
+            )
+        },
+        || {
+            rayon::join(
+                || {
+                    let mut new_c = sk.unchecked_bitand(b3, b4);
+                    sk.unchecked_add_assign(&mut new_c, c5);
+                    sk.add_assign(&mut new_c, &temp_b);
+                    new_c
+                },
+                || sk.bitxor(&sk.unchecked_add(&temp_a, &temp_b), &temp_c),
+            )
+        },
+    );
+    KreyviumRoundOutput { output, a, b, c }
+}
+
+/// Backward Kreyvium round optimized for MESSAGE_2_CARRY_2.
+fn backward_round_2_2(
+    input: &KreyviumFheRoundInput<'_>,
+    sk: &ServerKey,
+) -> KreyviumBackwardRoundOutput<Ciphertext> {
+    assert!(
+        sk.max_noise_level.get() >= 4,
+        "backward_round_2_2 needs max_noise_level >= 4, got {}",
+        sk.max_noise_level.get(),
+    );
+
+    let KreyviumRoundInput {
+        a: (new_a, a1, a3, a4, a5),
+        b: (new_b, b1, b3, b4, b5),
+        c: (new_c, c1, c3, c4, c5),
+        k,
+        iv,
+    } = input;
+
+    for (l, r) in [(a3, a4), (b3, b4), (c3, c4)] {
+        sk.is_functional_bivariate_pbs_possible(l.noise_degree(), r.noise_degree(), None)
+            .expect("bivariate bitand precondition violated for kreyvium backward_round_2_2");
+    }
+
+    let (a, (b, c)) = rayon::join(
+        || {
+            // new_b = a1 ^ a2 ^ (a3 & a4) ^ iv ^ b5
+            // so
+            // a2 = (a3 & a4) ^ new_b ^ a1 ^ b5 ^ iv
+            let mut a2 = sk.unchecked_bitand(a3, a4);
+            sk.unchecked_add_assign(&mut a2, new_b);
+            sk.unchecked_add_assign(&mut a2, a1);
+            sk.unchecked_add_assign(&mut a2, b5);
+            sk.unchecked_add_assign(&mut a2, iv);
+            sk.message_extract_assign(&mut a2);
+            a2
+        },
+        || {
+            rayon::join(
+                || {
+                    // new_c = b1 ^ b2 ^ (b3 & b4) ^ c5
+                    // so
+                    // b2 = (b3 & b4) ^ new_c ^ b1 ^ c5
+                    let mut b2 = sk.unchecked_bitand(b3, b4);
+                    sk.unchecked_add_assign(&mut b2, new_c);
+                    sk.unchecked_add_assign(&mut b2, b1);
+                    sk.unchecked_add_assign(&mut b2, c5);
+                    sk.message_extract_assign(&mut b2);
+                    b2
+                },
+                || {
+                    // new_a = c1 ^ c2 ^ (c3 & c3) ^ a5 ^ k
+                    // so
+                    // c2 = (c3 & c4) ^ new_a ^ c1 ^ a5 ^ k
+                    let mut c2 = sk.unchecked_bitand(c3, c4);
+                    sk.unchecked_add_assign(&mut c2, new_a);
+                    sk.unchecked_add_assign(&mut c2, c1);
+                    sk.unchecked_add_assign(&mut c2, a5);
+                    sk.unchecked_add_assign(&mut c2, k);
+                    sk.message_extract_assign(&mut c2);
+                    c2
+                },
+            )
+        },
+    );
+
+    KreyviumBackwardRoundOutput { a, b, c }
+}
+
+/// Param-agnostic fallback backward round, mirroring [`round_naive`]
+fn backward_round_naive(
+    input: &KreyviumFheRoundInput<'_>,
+    sk: &ServerKey,
+) -> KreyviumBackwardRoundOutput<Ciphertext> {
+    assert!(
+        sk.max_noise_level.get() >= 3,
+        "backward_round_naive needs max_noise_level >= 3, got {}",
+        sk.max_noise_level.get(),
+    );
+
+    let KreyviumRoundInput {
+        a: (new_a, a1, a3, a4, a5),
+        b: (new_b, b1, b3, b4, b5),
+        c: (new_c, c1, c3, c4, c5),
+        k,
+        iv,
+    } = input;
+
+    for (l, r) in [(a3, a4), (b3, b4), (c3, c4)] {
+        sk.is_functional_bivariate_pbs_possible(l.noise_degree(), r.noise_degree(), None)
+            .expect("bivariate bitand precondition violated for kreyvium backward_round_naive");
+    }
+
+    let (a, (b, c)) = rayon::join(
+        || {
+            // new_b = a1 ^ a2 ^ (a3 & a4) ^ iv ^ b5
+            // so
+            // a2 = (a3 & a4) ^ new_b ^ a1 ^ b5 ^ iv
+            let mut a2 = sk.unchecked_bitand(a3, a4);
+            sk.unchecked_add_assign(&mut a2, new_b);
+            sk.unchecked_add_assign(&mut a2, a1);
+            sk.add_assign(&mut a2, b5);
+            sk.add_assign(&mut a2, iv);
+            sk.message_extract_assign(&mut a2);
+            a2
+        },
+        || {
+            rayon::join(
+                || {
+                    // new_c = b1 ^ b2 ^ (b3 & b4) ^ c5
+                    // so
+                    // b2 = (b3 & b4) ^ new_c ^ b1 ^ c5
+                    let mut b2 = sk.unchecked_bitand(b3, b4);
+                    sk.unchecked_add_assign(&mut b2, new_c);
+                    sk.unchecked_add_assign(&mut b2, b1);
+                    sk.add_assign(&mut b2, c5);
+                    sk.message_extract_assign(&mut b2);
+                    b2
+                },
+                || {
+                    // new_a = c1 ^ c2 ^ (c3 & c4) ^ a5 ^ k
+                    // so
+                    // c2 = (c3 & c4) ^ new_a ^ c1 ^ a5 ^ k
+                    let mut c2 = sk.unchecked_bitand(c3, c4);
+                    sk.unchecked_add_assign(&mut c2, new_a);
+                    sk.unchecked_add_assign(&mut c2, c1);
+                    sk.add_assign(&mut c2, a5);
+                    sk.add_assign(&mut c2, k);
+                    sk.message_extract_assign(&mut c2);
+                    c2
+                },
+            )
+        },
+    );
+
+    KreyviumBackwardRoundOutput { a, b, c }
+}

--- a/tfhe/src/transciphering/ciphers/kreyvium/mod.rs
+++ b/tfhe/src/transciphering/ciphers/kreyvium/mod.rs
@@ -1,0 +1,320 @@
+mod fhe;
+mod plain;
+#[cfg(test)]
+mod test;
+
+use super::shift_register::ShiftRegister;
+
+pub use fhe::{KreyviumFheKey, KreyviumFheState};
+pub use plain::{KreyviumIV, KreyviumPlainKey, KreyviumPlainState};
+use rayon::prelude::*;
+
+/// Collect an iterator of `T` into a heap-allocated `Box<[T; N]>`, avoiding
+/// any intermediate `[T; N]` on the stack.
+///
+/// Returns an error if the iterator does not yield exactly `N` items.
+fn collect_boxed_array<T: std::fmt::Debug, const N: usize>(
+    iter: impl IntoIterator<Item = T>,
+) -> Result<Box<[T; N]>, ()> {
+    iter.into_iter()
+        .collect::<Vec<_>>()
+        .into_boxed_slice()
+        .try_into()
+        .map_err(|_| ())
+}
+
+/// Internal state of the kreyvium cipher
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct KreyviumState<T> {
+    a: ShiftRegister<93, T>,
+    b: ShiftRegister<84, T>,
+    c: ShiftRegister<111, T>,
+    k: ShiftRegister<128, T>,
+    iv: ShiftRegister<128, T>,
+    counter: u64,
+}
+
+impl<T> KreyviumState<T> {
+    /// Recover the inputs of the n-th round in the future from the state.
+    /// Since the values in the registers are simply shifted between rounds, we can recover
+    /// the inputs to the n-th round in the future by shifting the reading offsets by n, as long as
+    /// we do not read outside of the register.
+    ///
+    /// # Panics
+    /// Panics if n > 65.
+    fn round_input(&self, n: usize) -> KreyviumRoundInput<'_, T> {
+        assert!(n <= 65);
+
+        // Offsets are taken from the formula in the kreyvium paper
+        let (k, iv) = (&self.k[127 - n], &self.iv[127 - n]);
+
+        let a = (
+            &self.a[65 - n], // a1
+            &self.a[92 - n], // a2
+            &self.a[91 - n], // a3
+            &self.a[90 - n], // a4
+            &self.a[68 - n], // a5
+        );
+
+        let b = (
+            &self.b[68 - n], // b1
+            &self.b[83 - n], // b2
+            &self.b[82 - n], // b3
+            &self.b[81 - n], // b4
+            &self.b[77 - n], // b5
+        );
+
+        let c = (
+            &self.c[65 - n],  // c1
+            &self.c[110 - n], // c2
+            &self.c[109 - n], // c3
+            &self.c[108 - n], // c4
+            &self.c[86 - n],  // c5
+        );
+
+        KreyviumRoundInput { a, b, c, k, iv }
+    }
+
+    /// Inputs to one backward round, read from the current state `S_{t+1}` the values needed to
+    /// reconstruct S_t.
+    fn backward_round_input(&self) -> KreyviumRoundInput<'_, T> {
+        // From the forward round input above, we see that (a2, b2, c2) are the values that need to
+        // be recovered, since they are at the edge of each of register and are pushed out after the
+        // round.
+        // Looking at the round formula:
+        // - new_a is built from (c1, c2, c3, c4, a5, k)
+        // - new_b is built from (a1, a2, a3, a4, b5, iv)
+        // - new_c is built from (b1, b2, b3, b4, c5)
+        //
+        // Thus, we can recover:
+        // - c2 from (new_a, c1, c3, c4, a5, k)
+        // - a2 from (new_b, a1, a3, a4, b5, iv)
+        // - b2 from (new_c, b1, b3, b4, c5)
+        //
+        // Since we want the inputs for one step in the past, we need to add 1 to each offset to
+        // read the correct value in the register.
+        // new_a, new_b and new_c are the values pushed by the round at the beginning of the
+        // register.
+        // k and iv are circular registers of size 128, so the value at index 127 in S_t is equal
+        // to the value at index 0 in S_{t+1}
+
+        let (k, iv) = (&self.k[0], &self.iv[0]);
+
+        let a = (
+            &self.a[0],  // new_a
+            &self.a[66], // a1 (was a[65]_t)
+            &self.a[92], // a3 (was a[91]_t)
+            &self.a[91], // a4 (was a[90]_t)
+            &self.a[69], // a5 (was a[68]_t)
+        );
+
+        let b = (
+            &self.b[0],  // new_b
+            &self.b[69], // b1 (was b[68]_t)
+            &self.b[83], // b3 (was b[82]_t)
+            &self.b[82], // b4 (was b[81]_t)
+            &self.b[78], // b5 (was b[77]_t)
+        );
+
+        let c = (
+            &self.c[0],   // new_c
+            &self.c[66],  // c1 (was c[65]_t)
+            &self.c[110], // c3 (was c[109]_t)
+            &self.c[109], // c4 (was c[108]_t)
+            &self.c[87],  // c5 (was c[86]_t)
+        );
+
+        KreyviumRoundInput { a, b, c, k, iv }
+    }
+
+    /// Update the content of the registers with the values computed in the round.
+    ///
+    /// # Panics
+    /// panics if counter overflows
+    fn update(&mut self, values: impl ExactSizeIterator<Item = [T; 3]>) {
+        let n_rounds = values.len();
+
+        for [a, b, c] in values {
+            self.a.push(a);
+            self.b.push(b);
+            self.c.push(c);
+        }
+        self.k.n_shifts(n_rounds);
+        self.iv.n_shifts(n_rounds);
+
+        // Panic explicitly if counter overflows
+        self.counter = self.counter.checked_add(n_rounds as u64).unwrap();
+    }
+
+    /// Inverse of [`update`](Self::update): roll the registers back by `n_rounds` using the
+    /// recovered `(a, b, c)` bits in the order they were destroyed (most recent first).
+    ///
+    /// # Panics
+    /// panics if counter underflows
+    fn rewind(&mut self, values: impl ExactSizeIterator<Item = [T; 3]>) {
+        let n_rounds = values.len();
+
+        for [a, b, c] in values {
+            self.a.push_back(a);
+            self.b.push_back(b);
+            self.c.push_back(c);
+        }
+        self.k.n_unshifts(n_rounds);
+        self.iv.n_unshifts(n_rounds);
+
+        self.counter = self.counter.checked_sub(n_rounds as u64).unwrap();
+    }
+}
+
+#[allow(
+    private_bounds,
+    reason = "All methods in this impl block are private, so the private bounds won't be visible on user side"
+)]
+impl<T, A> KreyviumState<T>
+where
+    for<'a> KreyviumRoundInput<'a, T>: KreyviumRound<Bit = T, AuxData = A>,
+{
+    fn next(&mut self, aux: &A) -> T {
+        let round_input = self.round_input(0);
+        let KreyviumRoundOutput { output, a, b, c } = round_input.round(aux);
+
+        self.update(std::iter::once([a, b, c]));
+
+        output
+    }
+
+    /// One sequential backward round: recover the destroyed bits from the current
+    /// post-round state and roll the registers back by one.
+    fn prev(&mut self, aux: &A) {
+        let backward_input = self.backward_round_input();
+        let KreyviumBackwardRoundOutput { a, b, c } = backward_input.backward_round(aux);
+
+        self.rewind(std::iter::once([a, b, c]));
+    }
+}
+
+#[allow(
+    private_bounds,
+    reason = "All methods in this impl block are private, so the private bounds won't be visible on user side"
+)]
+impl<T, A> KreyviumState<T>
+where
+    for<'a> KreyviumRoundInput<'a, T>: KreyviumRound<Bit = T, AuxData = A>,
+    T: Send + Sync,
+    A: Sync,
+{
+    fn next_64(&mut self, aux: &A) -> Vec<T> {
+        let values = (0..64).into_par_iter().map(|x| {
+            let round_input = self.round_input(x);
+            let KreyviumRoundOutput { output, a, b, c } = round_input.round(aux);
+            (output, [a, b, c])
+        });
+
+        let (res, updates): (Vec<_>, Vec<_>) = values.unzip();
+        self.update(updates.into_iter());
+
+        res
+    }
+
+    fn next_n(&mut self, aux: &A, n_bits: usize) -> Vec<T> {
+        let mut result = Vec::with_capacity(n_bits);
+
+        for _ in 0..n_bits / 64 {
+            result.extend(self.next_64(aux));
+        }
+        for _ in 0..n_bits % 64 {
+            result.push(self.next(aux));
+        }
+
+        result
+    }
+
+    /// Advance the registers by `n_bits` forward rounds without accumulating the
+    /// keystream. Same parallelism as [`next_n`](Self::next_n).
+    fn skip_n(&mut self, aux: &A, n_bits: usize) {
+        for _ in 0..n_bits / 64 {
+            let _ = self.next_64(aux);
+        }
+        for _ in 0..n_bits % 64 {
+            self.next(aux);
+        }
+    }
+
+    fn prev_n(&mut self, aux: &A, n_bits: usize) {
+        // Currently, it is not possible to parallelize the backward rounds, since the inputs for
+        // state n-2 need state n-1 to be fully recovered.
+        // It could be solved by increasing the state size, by storing more values in the registers.
+        for _ in 0..n_bits {
+            self.prev(aux);
+        }
+    }
+
+    /// Set the keystream position to `target`. Equivalent to a forward
+    /// [`skip_n`](Self::skip_n) of `target - counter` bits when `target >= counter`, or to
+    /// `counter - target` sequential [`prev`](Self::prev) calls when `target < counter`.
+    fn seek_to(&mut self, aux: &A, target: u64) {
+        match target.cmp(&self.counter) {
+            std::cmp::Ordering::Greater => {
+                let n = (target - self.counter) as usize;
+                self.skip_n(aux, n);
+            }
+            std::cmp::Ordering::Less => {
+                let n = (self.counter - target) as usize;
+                self.prev_n(aux, n);
+            }
+            std::cmp::Ordering::Equal => {}
+        }
+    }
+
+    /// The specification of Kreyvium includes running 1152 (= 18*64) unused steps to mix up the
+    /// registers, before starting the proper stream
+    fn warmup(&mut self, aux: &A) {
+        for _ in 0..18 {
+            self.next_64(aux);
+        }
+
+        // Spec specifies that counter is 0 after the warmup, but running rounds will advance it
+        self.counter = 0;
+    }
+}
+
+/// Five registers + key + iv passed to one Kreyvium round.
+///
+/// `[backward_]round_input` populate the tuple in the appropriate order; impls destructure
+/// in matching order.
+struct KreyviumRoundInput<'a, T> {
+    a: (&'a T, &'a T, &'a T, &'a T, &'a T),
+    b: (&'a T, &'a T, &'a T, &'a T, &'a T),
+    c: (&'a T, &'a T, &'a T, &'a T, &'a T),
+    k: &'a T,
+    iv: &'a T,
+}
+
+struct KreyviumRoundOutput<T> {
+    output: T,
+    a: T,
+    b: T,
+    c: T,
+}
+
+/// The three destroyed bits (`a2`, `b2`, `c2`) recovered by one backward round.
+struct KreyviumBackwardRoundOutput<T> {
+    a: T,
+    b: T,
+    c: T,
+}
+
+/// Internal only trait used to factorize kreyvium implementation in plaintext and FHE
+trait KreyviumRound {
+    type AuxData;
+    type Bit;
+
+    /// Arithmetic part of one forward Kreyvium round. `self` is read as
+    /// `(a1, a2, a3, a4, a5)` etc.
+    fn round(self, aux: &Self::AuxData) -> KreyviumRoundOutput<Self::Bit>;
+
+    /// Arithmetic part of one backward Kreyvium round: recover `(a2, b2, c2)` of `S_t`
+    /// from the post-round state `S_{t+1}`. `self` is read as `(new_a, a1, a3, a4, a5)`
+    /// etc. (see [`KreyviumRoundInput`] doc).
+    fn backward_round(self, aux: &Self::AuxData) -> KreyviumBackwardRoundOutput<Self::Bit>;
+}

--- a/tfhe/src/transciphering/ciphers/kreyvium/plain.rs
+++ b/tfhe/src/transciphering/ciphers/kreyvium/plain.rs
@@ -1,0 +1,200 @@
+//! Plaintext implementation of the Kreyvium Algorithm
+
+use crate::shortint::ClientKey;
+use crate::transciphering::ciphers::shift_register::ShiftRegister;
+use crate::transciphering::ciphers::{pack_bits_lsb_first, unpack_bits_lsb_first};
+use crate::transciphering::{StreamCipher, StreamCipherKind};
+
+use super::{
+    KreyviumBackwardRoundOutput, KreyviumFheKey, KreyviumRound, KreyviumRoundInput,
+    KreyviumRoundOutput, KreyviumState,
+};
+
+fn unpack_key_bits(bytes: &[u8; 16]) -> [bool; 128] {
+    let mut out = [false; 128];
+    unpack_bits_lsb_first(bytes, &mut out);
+    out
+}
+
+pub struct KreyviumPlainKey {
+    bits: [u8; 16],
+}
+
+impl KreyviumPlainKey {
+    /// Expand the packed 128-bit key into one bit per byte (LSB-first within
+    /// each input byte), suitable for loading into the K shift register.
+    pub(super) fn expand(self) -> [bool; 128] {
+        unpack_key_bits(&self.bits)
+    }
+
+    /// Encrypt this key bit-by-bit under `client_key`, producing the FHE-side
+    /// key consumed by [`KreyviumFheState`](super::KreyviumFheState).
+    pub fn encrypt(&self, client_key: &ClientKey) -> KreyviumFheKey {
+        super::collect_boxed_array(
+            unpack_key_bits(&self.bits)
+                .iter()
+                .map(|&b| client_key.encrypt(b as u64)),
+        )
+        .expect("array and iter size match")
+        .into()
+    }
+
+    pub fn init_state(self, iv: KreyviumIV) -> KreyviumPlainState {
+        KreyviumPlainState::new(self, iv)
+    }
+}
+
+impl From<[u8; 16]> for KreyviumPlainKey {
+    fn from(value: [u8; 16]) -> Self {
+        Self { bits: value }
+    }
+}
+
+impl From<[bool; 128]> for KreyviumPlainKey {
+    fn from(value: [bool; 128]) -> Self {
+        let mut bits = [0u8; 16];
+        pack_bits_lsb_first(&value, &mut bits);
+        Self { bits }
+    }
+}
+
+pub struct KreyviumIV {
+    bits: [u8; 16],
+}
+
+impl KreyviumIV {
+    /// Expand the packed 128-bit IV into one bit per byte (LSB-first within
+    /// each input byte), suitable for loading into the IV shift register.
+    pub(super) fn expand(self) -> [bool; 128] {
+        unpack_key_bits(&self.bits)
+    }
+}
+
+impl From<[u8; 16]> for KreyviumIV {
+    fn from(value: [u8; 16]) -> Self {
+        Self { bits: value }
+    }
+}
+
+impl From<[bool; 128]> for KreyviumIV {
+    fn from(value: [bool; 128]) -> Self {
+        let mut bits = [0u8; 16];
+        pack_bits_lsb_first(&value, &mut bits);
+        Self { bits }
+    }
+}
+
+pub type KreyviumPlainState = KreyviumState<bool>;
+
+impl KreyviumPlainState {
+    /// Constructor for `KreyviumPlainState`: arguments are the secret key and the input vector.
+    /// Outputs a state already initialized (1152 steps have been run before returning)
+    pub fn new(key: impl Into<KreyviumPlainKey>, iv: impl Into<KreyviumIV>) -> Self {
+        let mut key = key.into().expand();
+        let mut iv = iv.into().expand();
+
+        // Initialization of Kreyvium registers: a has the secret key, b the beginning of the IV,
+        // c the end of the iv and padding 1s.
+        let mut a_register = [false; 93];
+        let mut b_register = [false; 84];
+        let mut c_register = [false; 111];
+
+        for i in 0..93 {
+            a_register[i] = key[128 - 93 + i];
+        }
+        for i in 0..84 {
+            b_register[i] = iv[128 - 84 + i];
+        }
+        for i in 0..44 {
+            c_register[111 - 44 + i] = iv[i];
+        }
+        for i in 0..66 {
+            c_register[i + 1] = true;
+        }
+
+        key.reverse();
+        iv.reverse();
+        let mut state = Self {
+            a: ShiftRegister::new(Box::new(a_register)),
+            b: ShiftRegister::new(Box::new(b_register)),
+            c: ShiftRegister::new(Box::new(c_register)),
+            k: ShiftRegister::new(Box::new(key)),
+            iv: ShiftRegister::new(Box::new(iv)),
+            counter: 0,
+        };
+        state.warmup(&());
+        state
+    }
+}
+
+impl StreamCipher for KreyviumPlainState {
+    fn kind(&self) -> StreamCipherKind {
+        StreamCipherKind::Kreyvium
+    }
+
+    fn next_keystream_bits(&mut self, n_bits: usize) -> Vec<u8> {
+        let bits = self.next_n(&(), n_bits);
+        let mut result = vec![0u8; n_bits.div_ceil(8)];
+        pack_bits_lsb_first(&bits, &mut result);
+        result
+    }
+
+    fn seek(&mut self, target_counter: u64) {
+        self.seek_to(&(), target_counter)
+    }
+
+    fn current_counter(&self) -> u64 {
+        self.counter
+    }
+}
+
+type KreyviumPlainRoundInput<'a> = KreyviumRoundInput<'a, bool>;
+
+impl KreyviumRound for KreyviumPlainRoundInput<'_> {
+    type AuxData = ();
+
+    type Bit = bool;
+
+    fn round(self, _aux: &Self::AuxData) -> KreyviumRoundOutput<Self::Bit> {
+        let Self {
+            a: (a1, a2, a3, a4, a5),
+            b: (b1, b2, b3, b4, b5),
+            c: (c1, c2, c3, c4, c5),
+            k,
+            iv,
+        } = self;
+
+        let temp_a = a1 ^ a2;
+        let temp_b = b1 ^ b2;
+
+        let temp_c = (c1 ^ c2) ^ k;
+
+        let a_and = (a3 & a4) ^ iv;
+        let b_and = b3 & b4;
+        let c_and = c3 & c4;
+
+        let output = (temp_a ^ temp_b) ^ temp_c;
+        let a = temp_c ^ (c_and ^ a5);
+        let b = temp_a ^ (a_and ^ b5);
+        let c = temp_b ^ (b_and ^ c5);
+
+        KreyviumRoundOutput { output, a, b, c }
+    }
+
+    fn backward_round(self, _aux: &Self::AuxData) -> KreyviumBackwardRoundOutput<Self::Bit> {
+        let Self {
+            a: (new_a, a1, a3, a4, a5),
+            b: (new_b, b1, b3, b4, b5),
+            c: (new_c, c1, c3, c4, c5),
+            k,
+            iv,
+        } = self;
+
+        // Recover the bits destroyed at the forward step (see backward derivation in mod.rs):
+        let a = new_b ^ a1 ^ (a3 & a4) ^ iv ^ b5;
+        let b = new_c ^ b1 ^ (b3 & b4) ^ c5;
+        let c = new_a ^ c1 ^ (c3 & c4) ^ a5 ^ k;
+
+        KreyviumBackwardRoundOutput { a, b, c }
+    }
+}

--- a/tfhe/src/transciphering/ciphers/kreyvium/test.rs
+++ b/tfhe/src/transciphering/ciphers/kreyvium/test.rs
@@ -1,0 +1,281 @@
+use std::fmt::Write;
+
+use crate::shortint::parameters::test_params::{
+    TEST_PARAM_MESSAGE_1_CARRY_1_KS_PBS_GAUSSIAN_2M128,
+    TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+    TEST_PARAM_MESSAGE_3_CARRY_3_KS_PBS_GAUSSIAN_2M128,
+};
+use crate::shortint::prelude::*;
+use crate::transciphering::ciphers::kreyvium::{
+    KreyviumFheState, KreyviumPlainKey, KreyviumPlainState,
+};
+use crate::transciphering::ciphers::pack_bits_lsb_first;
+use crate::transciphering::{apply_keystream, FheKeyStream, StreamCipher, Transcipherer};
+
+fn get_hexadecimal_string_from_bytes(bytes: &[u8]) -> String {
+    let mut hexadecimal = String::new();
+    for test in bytes {
+        write!(hexadecimal, "{test:02X?}").expect("writing to a String is infallible");
+    }
+    hexadecimal
+}
+
+fn hex_to_bytes_16(hex: &str) -> [u8; 16] {
+    let mut bytes = [0u8; 16];
+    for i in (0..hex.len()).step_by(2) {
+        bytes[i >> 1] = u8::from_str_radix(&hex[i..i + 2], 16).unwrap();
+    }
+    bytes
+}
+
+fn decrypt_keystream_to_bytes(fhe: &FheKeyStream, client_key: &ClientKey) -> Vec<u8> {
+    let bits: Vec<bool> = fhe.iter().map(|ct| client_key.decrypt(ct) != 0).collect();
+    let mut bytes = vec![0u8; bits.len().div_ceil(8)];
+    pack_bits_lsb_first(&bits, &mut bytes);
+    bytes
+}
+
+struct KreyviumTestVector {
+    key: &'static str,
+    iv: &'static str,
+    expected: &'static str,
+}
+
+const KREYVIUM_TV_ZERO: KreyviumTestVector = KreyviumTestVector {
+    key: "00000000000000000000000000000000",
+    iv: "00000000000000000000000000000000",
+    expected: "26DCF1F4BC0F1922",
+};
+
+const KREYVIUM_TV_KEY_BIT: KreyviumTestVector = KreyviumTestVector {
+    key: "01000000000000000000000000000000",
+    iv: "00000000000000000000000000000000",
+    expected: "4FD421D4DA3D2C8A",
+};
+
+const KREYVIUM_TV_IV_BIT: KreyviumTestVector = KreyviumTestVector {
+    key: "00000000000000000000000000000000",
+    iv: "01000000000000000000000000000000",
+    expected: "C9217BA0D762ACA1",
+};
+
+const KREYVIUM_TV_STANDARD: KreyviumTestVector = KreyviumTestVector {
+    key: "0053A6F94C9FF24598EB000000000000",
+    iv: "0D74DB42A91077DE45AC000000000000",
+    expected: "D1F0303482061111",
+};
+
+#[test]
+fn kreyvium_test_plain() {
+    let cases = [
+        KREYVIUM_TV_ZERO,
+        KREYVIUM_TV_KEY_BIT,
+        KREYVIUM_TV_IV_BIT,
+        KREYVIUM_TV_STANDARD,
+    ];
+
+    for KreyviumTestVector { key, iv, expected } in cases {
+        let key_bytes = hex_to_bytes_16(key);
+        let iv_bytes = hex_to_bytes_16(iv);
+
+        let mut kreyvium = KreyviumPlainState::new(key_bytes, iv_bytes);
+        let vec = kreyvium.next_keystream_bits(64);
+
+        let hexadecimal = get_hexadecimal_string_from_bytes(&vec);
+        assert_eq!(hexadecimal, expected, "key={key} iv={iv}");
+    }
+}
+
+#[test]
+fn kreyvium_plain_encrypt_decrypt_round_trip() {
+    use rand::{Rng, SeedableRng};
+
+    let seed: u64 = rand::thread_rng().gen();
+    println!("kreyvium_encrypt_decrypt_round_trip seed: {seed}");
+    let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+
+    let key: [bool; 128] = std::array::from_fn(|_| rng.gen());
+    let iv: [bool; 128] = std::array::from_fn(|_| rng.gen());
+
+    let message: Vec<u8> = (0..37).map(|_| rng.gen()).collect();
+
+    let mut enc_stream = KreyviumPlainState::new(key, iv);
+    let encrypted = enc_stream.encrypt(&message);
+    assert_eq!(encrypted.bytes().len(), message.len());
+
+    let mut dec_stream = KreyviumPlainState::new(key, iv);
+    let decrypted = dec_stream.decrypt(&encrypted).unwrap();
+
+    assert_eq!(decrypted, message);
+}
+
+fn kreyvium_fhe_keystream_known_answer(params: ClassicPBSParameters) {
+    let (client_key, server_key) = gen_keys(params);
+
+    let KreyviumTestVector { key, iv, expected } = KREYVIUM_TV_STANDARD;
+    let key_bytes = hex_to_bytes_16(key);
+    let iv_bytes = hex_to_bytes_16(iv);
+
+    let cipher_key = KreyviumPlainKey::from(key_bytes).encrypt(&client_key);
+
+    let mut kreyvium = KreyviumFheState::new(cipher_key, iv_bytes, &server_key);
+
+    let cts = kreyvium.next_keystream_bits(&server_key, 64);
+
+    let bytes = decrypt_keystream_to_bytes(&cts, &client_key);
+
+    let hexadecimal = get_hexadecimal_string_from_bytes(&bytes);
+    assert_eq!(expected, hexadecimal);
+}
+
+#[test]
+fn kreyvium_test_fhe() {
+    kreyvium_fhe_keystream_known_answer(TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128);
+}
+
+/// Tests the `round_naive` fallback path under params where the
+/// optimized 2_2 round would overshoot the noise budget.
+#[test]
+fn kreyvium_test_fhe_1_1() {
+    kreyvium_fhe_keystream_known_answer(TEST_PARAM_MESSAGE_1_CARRY_1_KS_PBS_GAUSSIAN_2M128);
+}
+
+#[test]
+fn kreyvium_test_fhe_3_3() {
+    kreyvium_fhe_keystream_known_answer(TEST_PARAM_MESSAGE_3_CARRY_3_KS_PBS_GAUSSIAN_2M128);
+}
+
+/// End-to-end round trip: random Kreyvium key + IV, random 64-bit input,
+/// symmetric Kreyvium encrypt, FHE keystream, transcipher,
+/// decrypt, expect the recovered u64 to match the original input.
+#[test]
+fn kreyvium_test_round_trip() {
+    use rand::{Rng, SeedableRng};
+
+    let seed: u64 = rand::thread_rng().gen();
+    println!("kreyvium_test_round_trip seed: {seed}");
+    let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+
+    let (client_key, server_key) = gen_keys(TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128);
+
+    const N_ITER: usize = 2;
+    for iter in 0..N_ITER {
+        // Random Kreyvium key and IV (already in unpacked-bit form), plus a
+        // random 64-bit input.
+        let key_bits: [bool; 128] = std::array::from_fn(|_| rng.gen());
+        let iv_bits: [bool; 128] = std::array::from_fn(|_| rng.gen());
+        let input: u64 = rng.gen();
+
+        // Symmetric Kreyvium encrypt: plain keystream XOR input bytes
+        // (LSB-first within each byte, matching `to_le_bytes`).
+        let mut sym_stream = KreyviumPlainState::new(key_bits, iv_bits);
+        let sym_cipher = sym_stream.encrypt(&input.to_le_bytes());
+
+        // FHE side: encrypt the same key bits, run FHE stream, transcipher.
+        let cipher_key = KreyviumPlainKey::from(key_bits).encrypt(&client_key);
+
+        let mut fhe_stream = KreyviumFheState::new(cipher_key, iv_bits, &server_key);
+        let keystream = fhe_stream.next_keystream_bits(&server_key, 64);
+
+        let chunks = apply_keystream(&server_key, &keystream, &sym_cipher);
+
+        // Decrypt each clean 2-bit chunk back into bits 2i and 2i+1 of u64.
+        let result: u64 = chunks
+            .iter()
+            .enumerate()
+            .map(|(i, chunk)| (client_key.decrypt(chunk) & 0b11) << (2 * i))
+            .sum();
+
+        assert_eq!(
+            result, input,
+            "round-trip mismatch (seed={seed}, iter={iter})"
+        );
+    }
+}
+
+#[test]
+fn kreyvium_seek_plain() {
+    use rand::{Rng, SeedableRng};
+
+    let seed: u64 = rand::thread_rng().gen();
+    println!("kreyvium_seek_plain seed: {seed}");
+    let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+
+    let key: [bool; 128] = std::array::from_fn(|_| rng.gen());
+    let iv: [bool; 128] = std::array::from_fn(|_| rng.gen());
+
+    // Snapshot states at counters 0 and 64 from a fresh stream.
+    let state_at_0 = KreyviumPlainState::new(key, iv);
+    let mut state_at_64 = state_at_0.clone();
+    let head_keystream = state_at_64.next_keystream_bits(64);
+    assert_eq!(state_at_64.current_counter(), 64);
+    let mid_keystream = state_at_64.clone().next_keystream_bits(64);
+
+    // Forward seek
+    let mut s = KreyviumPlainState::new(key, iv);
+    s.seek(64);
+    assert_eq!(s.current_counter(), 64);
+    assert_eq!(s, state_at_64, "forward-seek state mismatch");
+
+    // Backward seek
+    s.next_keystream_bits(128); // counter = 192
+    assert_eq!(s.current_counter(), 192);
+    s.seek(64);
+    assert_eq!(s.current_counter(), 64);
+    assert_eq!(s, state_at_64, "backward-seek state mismatch");
+
+    // Re-emit from the rewound state and check keystream matches.
+    let mid_again = s.next_keystream_bits(64);
+    assert_eq!(mid_again, mid_keystream);
+
+    // Seek all the way back to 0
+    s.seek(0);
+    assert_eq!(s.current_counter(), 0);
+    assert_eq!(s, state_at_0, "seek-to-0 state mismatch");
+    let head_again = s.next_keystream_bits(64);
+    assert_eq!(head_again, head_keystream);
+}
+
+/// FHE side: `seek` matches the plain stream both forward and backward.
+#[test]
+fn kreyvium_seek_fhe() {
+    use rand::{Rng, SeedableRng};
+
+    let seed: u64 = rand::thread_rng().gen();
+    println!("kreyvium_seek_fhe seed: {seed}");
+    let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+
+    let (client_key, server_key) = gen_keys(TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128);
+
+    let key_bits: [bool; 128] = std::array::from_fn(|_| rng.gen());
+    let iv_bits: [bool; 128] = std::array::from_fn(|_| rng.gen());
+
+    // Reference plain keystream.
+    let mut ref_stream = KreyviumPlainState::new(key_bits, iv_bits);
+    let ref_keystream = ref_stream.next_keystream_bits(192);
+
+    let cipher_key = KreyviumPlainKey::from(key_bits).encrypt(&client_key);
+    let mut k = KreyviumFheState::new(cipher_key, iv_bits, &server_key);
+    assert_eq!(k.current_counter(), 0);
+
+    // Forward seek
+    k.seek(&server_key, 64);
+    assert_eq!(k.current_counter(), 64);
+
+    let mid = k.next_keystream_bits(&server_key, 64);
+    assert_eq!(k.current_counter(), 128);
+    assert_eq!(
+        decrypt_keystream_to_bytes(&mid, &client_key),
+        ref_keystream[8..16]
+    );
+
+    // Backward seek to an earlier counter and re-emit
+    k.seek(&server_key, 64);
+    assert_eq!(k.current_counter(), 64);
+    let mid_again = k.next_keystream_bits(&server_key, 64);
+    assert_eq!(k.current_counter(), 128);
+    assert_eq!(
+        decrypt_keystream_to_bytes(&mid_again, &client_key),
+        ref_keystream[8..16]
+    );
+}

--- a/tfhe/src/transciphering/ciphers/mod.rs
+++ b/tfhe/src/transciphering/ciphers/mod.rs
@@ -1,0 +1,21 @@
+mod shift_register;
+
+pub mod kreyvium;
+
+/// Pack `bits` into `bytes` LSB-first within each byte. `bytes` must be
+/// zero-initialized and at least `bits.len().div_ceil(8)` long.
+fn pack_bits_lsb_first(bits: &[bool], bytes: &mut [u8]) {
+    for (i, &bit) in bits.iter().enumerate() {
+        bytes[i / 8] |= (bit as u8) << (i % 8);
+    }
+}
+
+/// Unpack `bytes` into `bits` LSB-first within each byte. `bits` must be at
+/// least `bytes.len() * 8` long.
+fn unpack_bits_lsb_first(bytes: &[u8], bits: &mut [bool]) {
+    for (b, &byte) in bytes.iter().enumerate() {
+        for j in 0..8 {
+            bits[8 * b + j] = ((byte >> j) & 1) == 1;
+        }
+    }
+}

--- a/tfhe/src/transciphering/ciphers/shift_register.rs
+++ b/tfhe/src/transciphering/ciphers/shift_register.rs
@@ -1,0 +1,165 @@
+//! Fixed-size cyclic shift register used by Trivium/Kreyvium.
+
+use core::ops::{Index, IndexMut};
+
+/// Fixed-capacity cyclic shift register.
+///
+/// Indexed by age: `reg[0]` is the most recently pushed value, `reg[N-1]`
+/// the oldest still present.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ShiftRegister<const N: usize, T> {
+    arr: Box<[T; N]>,
+    cursor: usize,
+}
+
+impl<const N: usize, T> ShiftRegister<N, T> {
+    /// `arr[0]` is treated as the oldest initial value, `arr[N-1]` as the newest.
+    pub(crate) fn new(arr: Box<[T; N]>) -> Self {
+        Self { arr, cursor: 0 }
+    }
+
+    /// Push a new element, overwriting the oldest. After push, the new value is at index 0.
+    pub(crate) fn push(&mut self, val: T) {
+        self.arr[self.cursor] = val;
+        self.shift();
+    }
+
+    /// Inverse of [`push`](Self::push): rewind the cursor by one and overwrite the
+    /// newly-revealed oldest slot with `val`. After the call, what was at index 0
+    /// is gone and `val` sits at index `N-1`.
+    pub(crate) fn push_back(&mut self, val: T) {
+        self.cursor = (self.cursor + N - 1) % N;
+        self.arr[self.cursor] = val;
+    }
+
+    /// Rotate the buffer by one: what was oldest becomes newest. No data is copied
+    /// and no value is dropped.
+    pub(crate) fn shift(&mut self) {
+        self.n_shifts(1);
+    }
+
+    /// Rotate by `n` positions in O(1) (cursor-only). Equivalent to calling
+    /// shift `n` times.
+    pub(crate) fn n_shifts(&mut self, n: usize) {
+        self.cursor += n;
+        self.cursor %= N;
+    }
+
+    /// Inverse of [`n_shifts`](Self::n_shifts): rotate the cursor backward by `n`.
+    pub(crate) fn n_unshifts(&mut self, n: usize) {
+        let n_mod = n % N;
+        self.cursor = (self.cursor + N - n_mod) % N;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn inner(&self) -> &[T; N] {
+        &self.arr
+    }
+}
+
+/// Indexed by age: `reg[0]` is the newest element, `reg[N-1]` the oldest.
+/// Panics if `i >= N`.
+impl<const N: usize, T> Index<usize> for ShiftRegister<N, T> {
+    type Output = T;
+
+    fn index(&self, i: usize) -> &T {
+        assert!(i < N, "Index {i} too high for size {N}");
+        &self.arr[(N + self.cursor - i - 1) % N]
+    }
+}
+
+/// Indexed by age: `reg[0]` is the newest element, `reg[N-1]` the oldest.
+/// Panics if `i >= N`.
+impl<const N: usize, T> IndexMut<usize> for ShiftRegister<N, T> {
+    fn index_mut(&mut self, i: usize) -> &mut T {
+        assert!(i < N, "Index {i} too high for size {N}");
+        &mut self.arr[(N + self.cursor - i - 1) % N]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ShiftRegister;
+
+    #[test]
+    fn test_shift_register() {
+        let a = [1, 2, 3, 4, 5, 6];
+
+        let mut shift_register = ShiftRegister::new(Box::new(a));
+        for i in 7..11 {
+            shift_register.push(i);
+        }
+        assert_eq!(*shift_register.inner(), [7, 8, 9, 10, 5, 6]);
+
+        for i in 11..15 {
+            shift_register.push(i);
+        }
+        assert_eq!(*shift_register.inner(), [13, 14, 9, 10, 11, 12]);
+
+        assert_eq!(shift_register[0], 14);
+        assert_eq!(shift_register[1], 13);
+        assert_eq!(shift_register[2], 12);
+        assert_eq!(shift_register[3], 11);
+        assert_eq!(shift_register[4], 10);
+        assert_eq!(shift_register[5], 9);
+    }
+
+    #[test]
+    fn test_shift_register_indexmut() {
+        let a = [1, 2, 3, 4, 5, 6];
+
+        let mut shift_register = ShiftRegister::new(Box::new(a));
+        for i in 7..11 {
+            shift_register.push(i);
+        }
+        assert_eq!(*shift_register.inner(), [7, 8, 9, 10, 5, 6]);
+
+        for i in 11..15 {
+            shift_register.push(i);
+        }
+        assert_eq!(*shift_register.inner(), [13, 14, 9, 10, 11, 12]);
+
+        shift_register[1] = 100;
+
+        assert_eq!(shift_register[0], 14);
+        assert_eq!(shift_register[1], 100);
+        assert_eq!(shift_register[2], 12);
+        assert_eq!(shift_register[3], 11);
+        assert_eq!(shift_register[4], 10);
+        assert_eq!(shift_register[5], 9);
+    }
+
+    #[test]
+    #[should_panic(expected = "Index 6 too high for size 6")]
+    fn test_shift_register_index_fail() {
+        let a = [1, 2, 3, 4, 5, 6];
+
+        let shift_register = ShiftRegister::new(Box::new(a));
+        let _ = shift_register[6];
+    }
+
+    #[test]
+    fn test_push_back_is_inverse_of_push() {
+        let mut reg = ShiftRegister::new(Box::new([1, 2, 3, 4, 5, 6]));
+        let before: Vec<_> = (0..6).map(|i| reg[i]).collect();
+
+        reg.push(99);
+        assert_eq!(reg[0], 99);
+        reg.push_back(before[5]);
+
+        let after: Vec<_> = (0..6).map(|i| reg[i]).collect();
+        assert_eq!(before, after, "push_back should undo the prior push");
+    }
+
+    #[test]
+    fn test_n_unshifts_is_inverse_of_n_shifts() {
+        let mut reg = ShiftRegister::new(Box::new([1, 2, 3, 4, 5, 6]));
+        let before: Vec<_> = (0..6).map(|i| reg[i]).collect();
+
+        reg.n_shifts(4);
+        reg.n_unshifts(4);
+
+        let after: Vec<_> = (0..6).map(|i| reg[i]).collect();
+        assert_eq!(before, after);
+    }
+}

--- a/tfhe/src/transciphering/mod.rs
+++ b/tfhe/src/transciphering/mod.rs
@@ -1,0 +1,530 @@
+//! Server-side homomorphic conversion of a symmetric-cipher ciphertext into
+//! an FHE ciphertext.
+//!
+//! The client encrypts data with a lightweight symmetric stream cipher, using
+//! a key it generates locally, and ships an FHE encryption of that key to the
+//! server once. The server, holding only the encrypted key, applies a
+//! transcipher round that turns each symmetric ciphertext into an FHE
+//! ciphertext of the same plaintext.
+//!
+//! End-to-end example using Kreyvium:
+//!
+//! ```
+//! use rand::Rng;
+//! use tfhe::shortint::prelude::*;
+//! use tfhe::shortint::parameters::current_params::V1_6_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+//! use tfhe::transciphering::{StreamCipher, Transcipherer};
+//! use tfhe::transciphering::ciphers::kreyvium::{
+//!     KreyviumFheState, KreyviumPlainKey, KreyviumPlainState,
+//! };
+//!
+//! let (client_key, server_key) =
+//!     gen_keys(V1_6_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128);
+//!
+//! // Client: pick a symmetric key + IV and encrypt a u64 with plain Kreyvium.
+//! let mut rng = rand::thread_rng();
+//! let key_bits: [bool; 128] = std::array::from_fn(|_| rng.gen());
+//! let iv_bits: [bool; 128] = std::array::from_fn(|_| rng.gen());
+//! let input: u64 = 0xDEADBEEFCAFEBABE;
+//! let input_bytes = input.to_le_bytes();
+//!
+//! let mut sym = KreyviumPlainState::new(key_bits, iv_bits);
+//! let sym_cipher = sym.encrypt(&input_bytes);
+//!
+//! // Client → server: ship the FHE-encrypted Kreyvium key (one-time setup).
+//! let enc_key = KreyviumPlainKey::from(key_bits).encrypt(&client_key);
+//!
+//! // Server: warm up the FHE-side Kreyvium stream and transcipher.
+//! let mut fhe_stream = KreyviumFheState::new(enc_key, iv_bits, &server_key);
+//! let blocks = fhe_stream.transcipher(&server_key, &sym_cipher).unwrap();
+//!
+//! // Client: decrypt to recover `input`.
+//! let recovered: u64 = blocks
+//!     .iter()
+//!     .enumerate()
+//!     .map(|(i, b)| client_key.decrypt(b) << (2 * i))
+//!     .sum();
+//! assert_eq!(recovered, input);
+//! ```
+
+pub mod backward_compatibility;
+pub mod ciphers;
+
+use rayon::prelude::*;
+use tfhe_versionable::Versionize;
+
+use crate::conformance::ParameterSetConformant;
+use crate::core_crypto::commons::utils::ZipChecked;
+use crate::shortint::{Ciphertext, ServerKey};
+use crate::transciphering::backward_compatibility::{
+    StreamCipherKindVersions, StreamCiphertextVersions,
+};
+use crate::transciphering::ciphers::kreyvium::KreyviumFheState;
+
+/// Identifier for a concrete stream-cipher family.
+///
+/// Carried by [`StreamCiphertext`] so a [`Transcipherer`] can refuse inputs
+/// that were not produced by the matching [`StreamCipher`].
+///
+/// The [`Self::Dynamic`] variant can be used for out-of-tree experimental ciphers
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize, Versionize,
+)]
+#[versionize(StreamCipherKindVersions)]
+pub enum StreamCipherKind {
+    Kreyvium,
+    Dynamic,
+}
+
+/// Output of [`StreamCipher::encrypt`] / [`StreamCipher::encrypt_bits`]: a
+/// stream-cipher ciphertext that the client ships to the server for
+/// transciphering.
+///
+/// This is a "ciphertext" from the stream-cipher perspective; from the FHE
+/// perspective these bytes are plaintext (they are in the clear until
+/// `transcipher` lifts them under FHE).
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, Versionize)]
+#[versionize(StreamCiphertextVersions)]
+pub struct StreamCiphertext {
+    kind: StreamCipherKind,
+    /// Keystream bit position at which this ciphertext was encrypted.
+    encryption_counter: u64,
+    n_bits: usize,
+    bytes: Vec<u8>,
+}
+
+impl StreamCiphertext {
+    pub fn kind(&self) -> StreamCipherKind {
+        self.kind
+    }
+
+    pub fn encryption_counter(&self) -> u64 {
+        self.encryption_counter
+    }
+
+    pub fn n_bits(&self) -> usize {
+        self.n_bits
+    }
+
+    pub fn bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+}
+
+/// Parameters used to check [`StreamCiphertext`] conformance: the expected
+/// cipher family and bit length.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct StreamCiphertextConformanceParams {
+    pub kind: StreamCipherKind,
+    pub n_bits: usize,
+}
+
+impl ParameterSetConformant for StreamCiphertext {
+    type ParameterSet = StreamCiphertextConformanceParams;
+
+    fn is_conformant(&self, params: &Self::ParameterSet) -> bool {
+        self.kind == params.kind
+            && self.n_bits == params.n_bits
+            && self.bytes.len() == self.n_bits.div_ceil(8)
+    }
+}
+
+/// Errors raised by [`StreamCipher`] / [`Transcipherer`] operations that
+/// consume a [`StreamCiphertext`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TranscipherError {
+    /// The [`StreamCiphertext`] was produced by a cipher different from the
+    /// one consuming it.
+    KindMismatch {
+        expected: StreamCipherKind,
+        got: StreamCipherKind,
+    },
+    /// The consumer's current keystream counter does not match the
+    /// [`StreamCiphertext`]'s recorded counter. When the ciphertext is
+    /// ahead, the caller can call [`StreamCipher::seek`] / [`Transcipherer::seek`]
+    /// to align and retry.
+    CounterMismatch { expected: u64, got: u64 },
+}
+
+impl std::fmt::Display for TranscipherError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::KindMismatch { expected, got } => write!(
+                f,
+                "stream ciphertext cipher kind mismatch: expected {expected:?}, got {got:?}"
+            ),
+            Self::CounterMismatch { expected, got } => {
+                write!(
+                    f,
+                    "stream ciphertext counter mismatch: session at {expected}, \
+                         ciphertext at {got}. Call `seek({})` to align",
+                    got - expected,
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for TranscipherError {}
+
+/// Client-side: a stateful symmetric-cipher session, no FHE.
+pub trait StreamCipher {
+    /// Cipher family this session belongs to. Embedded into every
+    /// [`StreamCiphertext`] produced by [`Self::encrypt`] /
+    /// [`Self::encrypt_bits`].
+    fn kind(&self) -> StreamCipherKind;
+
+    /// Produce the next `n_bits` of keystream and advance the internal counter.
+    /// Bits are packed LSB-first into bytes; in the standard byte-aligned
+    /// transciphering use case `n_bits` is a multiple of 8.
+    fn next_keystream_bits(&mut self, n_bits: usize) -> Vec<u8>;
+
+    /// XOR the first `n_bits` of `input` with `n_bits` keystream bits.
+    ///
+    /// `input.len()` must equal `n_bits.div_ceil(8)`. When `n_bits` is not a
+    /// multiple of 8, the trailing bits of the last input byte are passed
+    /// through unchanged (the keystream has zero bits in that range, so the
+    /// XOR is a no-op there).
+    fn encrypt_bits(&mut self, input: &[u8], n_bits: usize) -> StreamCiphertext {
+        assert_eq!(
+            input.len(),
+            n_bits.div_ceil(8),
+            "input must have exactly ceil(n_bits / 8) = {} bytes (got {})",
+            n_bits.div_ceil(8),
+            input.len()
+        );
+
+        let encryption_counter = self.current_counter();
+        let mask = self.next_keystream_bits(n_bits);
+        let bytes: Vec<u8> = input.iter().zip_checked(mask).map(|(i, m)| i ^ m).collect();
+
+        StreamCiphertext {
+            kind: self.kind(),
+            encryption_counter,
+            n_bits,
+            bytes,
+        }
+    }
+
+    /// XOR `input` with the next `8 * input.len()` keystream bits. Advances
+    /// the counter.
+    fn encrypt(&mut self, input: &[u8]) -> StreamCiphertext {
+        self.encrypt_bits(input, 8 * input.len())
+    }
+
+    /// Stream-cipher decryption: XOR `encrypted` with a fresh chunk of
+    /// keystream. Returns `encrypted.n_bits().div_ceil(8)` bytes.
+    ///
+    /// Errors with [`TranscipherError::KindMismatch`] when `encrypted` was
+    /// produced by a different cipher family.
+    fn decrypt(&mut self, encrypted: &StreamCiphertext) -> Result<Vec<u8>, TranscipherError> {
+        if encrypted.kind != self.kind() {
+            return Err(TranscipherError::KindMismatch {
+                expected: self.kind(),
+                got: encrypted.kind,
+            });
+        }
+        if encrypted.encryption_counter != self.current_counter() {
+            return Err(TranscipherError::CounterMismatch {
+                expected: self.current_counter(),
+                got: encrypted.encryption_counter,
+            });
+        }
+
+        let mask = self.next_keystream_bits(encrypted.n_bits);
+        Ok(encrypted
+            .bytes
+            .iter()
+            .zip_checked(mask)
+            .map(|(i, m)| i ^ m)
+            .collect())
+    }
+
+    /// Set the keystream bit position to `target_counter`. The new position can be
+    /// anywhere in `[0, u64::MAX]`; backward-seek is supported and may be more expensive
+    /// than forward depending on the cipher.
+    fn seek(&mut self, target_counter: u64);
+
+    /// Current keystream bit position.
+    fn current_counter(&self) -> u64;
+}
+
+/// Server-side: a stateful FHE-side session that mirrors a StreamCipher.
+/// Same shape as `StreamCipher`, FHE-evaluated.
+pub trait Transcipherer {
+    /// Cipher family this session belongs to. Must match the
+    /// [`StreamCiphertext::kind`] of any input passed to [`Self::transcipher`].
+    fn kind(&self) -> StreamCipherKind;
+
+    /// Produce the next `n_bits` of FHE-encrypted keystream and advance the
+    /// internal counter. One `shortint::Ciphertext` per bit, each a clean
+    /// single-bit ciphertext (degree 1, value in {0, 1}).
+    fn next_keystream_bits(&mut self, sks: &ServerKey, n_bits: usize) -> FheKeyStream;
+
+    /// Transcipher `input` against `input.n_bits()` bits of keystream from
+    /// this session, advancing the internal counter.
+    fn transcipher(
+        &mut self,
+        sks: &ServerKey,
+        input: &StreamCiphertext,
+    ) -> Result<Vec<Ciphertext>, TranscipherError> {
+        if input.kind != self.kind() {
+            return Err(TranscipherError::KindMismatch {
+                expected: self.kind(),
+                got: input.kind,
+            });
+        }
+        if input.encryption_counter != self.current_counter() {
+            return Err(TranscipherError::CounterMismatch {
+                expected: self.current_counter(),
+                got: input.encryption_counter,
+            });
+        }
+
+        let keystream = self.next_keystream_bits(sks, input.n_bits);
+        Ok(apply_keystream(sks, &keystream, input))
+    }
+
+    /// Set the keystream bit position to `target_counter`. Backward-seek is supported
+    /// and may be more expensive than forward (see cipher-specific docs).
+    fn seek(&mut self, sks: &ServerKey, target_counter: u64);
+
+    fn current_counter(&self) -> u64;
+}
+
+/// Owning, runtime-dispatched [`Transcipherer`]. Lets higher layers keep a
+/// single concrete type that can hold any in-tree cipher state, plus
+/// arbitrary out-of-tree implementors via [`Self::Dynamic`].
+pub enum TranscipherSession {
+    Kreyvium(KreyviumFheState),
+    Dynamic(Box<dyn Transcipherer + Send + Sync>),
+}
+
+impl Transcipherer for TranscipherSession {
+    fn kind(&self) -> StreamCipherKind {
+        match self {
+            Self::Kreyvium(t) => t.kind(),
+            Self::Dynamic(t) => t.kind(),
+        }
+    }
+
+    fn next_keystream_bits(&mut self, sks: &ServerKey, n_bits: usize) -> FheKeyStream {
+        match self {
+            Self::Kreyvium(t) => t.next_keystream_bits(sks, n_bits),
+            Self::Dynamic(t) => t.next_keystream_bits(sks, n_bits),
+        }
+    }
+
+    fn transcipher(
+        &mut self,
+        sks: &ServerKey,
+        input: &StreamCiphertext,
+    ) -> Result<Vec<Ciphertext>, TranscipherError> {
+        match self {
+            Self::Kreyvium(t) => t.transcipher(sks, input),
+            Self::Dynamic(t) => t.transcipher(sks, input),
+        }
+    }
+
+    fn seek(&mut self, sks: &ServerKey, target_counter: u64) {
+        match self {
+            Self::Kreyvium(t) => t.seek(sks, target_counter),
+            Self::Dynamic(t) => t.seek(sks, target_counter),
+        }
+    }
+
+    fn current_counter(&self) -> u64 {
+        match self {
+            Self::Kreyvium(t) => t.current_counter(),
+            Self::Dynamic(t) => t.current_counter(),
+        }
+    }
+}
+
+/// An FHE encrypted keystream that can be xored with an input encrypted with a [`StreamCipher`].
+pub struct FheKeyStream(Vec<Ciphertext>);
+
+impl FheKeyStream {
+    pub fn from_raw_parts(bits: Vec<Ciphertext>) -> Self {
+        Self(bits)
+    }
+
+    pub fn into_raw_parts(self) -> Vec<Ciphertext> {
+        self.0
+    }
+
+    pub fn iter(&self) -> std::slice::Iter<'_, Ciphertext> {
+        self.0.iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a FheKeyStream {
+    type Item = &'a Ciphertext;
+    type IntoIter = std::slice::Iter<'a, Ciphertext>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+/// LSB-first bit `i` of `bytes` (i.e. `bytes[i / 8] >> (i % 8) & 1`).
+fn bit_at(bytes: &[u8], i: usize) -> u8 {
+    (bytes[i / 8] >> (i % 8)) & 1
+}
+
+/// Xor an FHE keystream with a clear [`StreamCiphertext`].
+///
+/// Validates that `input` was produced by a cipher in the same family as the
+/// `keystream` (which the caller asserts implicitly by pairing them). The
+/// number of keystream bits consumed is `input.n_bits()`.
+pub fn apply_keystream(
+    sks: &ServerKey,
+    keystream: &FheKeyStream,
+    input: &StreamCiphertext,
+) -> Vec<Ciphertext> {
+    assert_eq!(
+        keystream.0.len(),
+        input.n_bits,
+        "keystream length ({}) must equal input.n_bits ({})",
+        keystream.0.len(),
+        input.n_bits,
+    );
+    if sks.message_modulus.0 == 4 && sks.carry_modulus.0 == 4 {
+        apply_keystream_2_2(sks, &keystream.0, &input.bytes)
+    } else {
+        apply_keystream_naive(sks, &keystream.0, &input.bytes)
+    }
+}
+
+/// Xor an FHE keystream with a clear symmetric ciphertext under
+/// MESSAGE_2_CARRY_2.
+///
+/// `keystream` is what [`Transcipherer::next_keystream_bits`] returns: one
+/// clean single-bit `Ciphertext` per bit. `input_stream` is the clear
+/// symmetric-cipher output from the user.
+///
+/// Cost: one 0.5 PBS per bit.
+/// Xoring and packing a pair of 2 bits of keystream + 2 bits of input is done in a
+/// single PBS.
+///
+/// `input_stream.len()` must equal `keystream.len().div_ceil(8)`: the
+/// minimum number of bytes that contain `keystream.len()` bits. When
+/// `keystream.len()` is not a multiple of 8, the trailing bits of the last
+/// input byte are ignored.
+fn apply_keystream_2_2(
+    sks: &ServerKey,
+    keystream: &[Ciphertext],
+    input_stream: &[u8],
+) -> Vec<Ciphertext> {
+    assert_eq!(
+        input_stream.len(),
+        keystream.len().div_ceil(8),
+        "input must have exactly ceil(keystream_len / 8) = {} bytes (got {})",
+        keystream.len().div_ceil(8),
+        input_stream.len()
+    );
+
+    // For each possible 2-bit clear input value `i` (i_hi | i_lo), build a LUT
+    // that performs keystream xor and packing in a single pbs
+    let luts: [_; 4] = std::array::from_fn(|i| {
+        let i_lo = (i & 1) as u64;
+        let i_hi = ((i >> 1) & 1) as u64;
+        sks.generate_lookup_table_bivariate(move |k0, k1| {
+            ((k0 & 1) ^ i_lo) | (((k1 & 1) ^ i_hi) << 1)
+        })
+    });
+
+    let pairs = keystream.par_chunks_exact(2);
+    // 0 or 1 trailing keystream ct when `keystream.len()` is odd.
+    let trailing = pairs.remainder();
+
+    // Pair `i` consumes input bits 2i and 2i+1 (LSB-first across bytes), and
+    // produces one 2-bit XOR'd ciphertext via a single bivariate PBS.
+    // Example:
+    // keystream (2 lwe 2_2 encoded): 0000a 0000b
+    // user input bits (plaintext)  :     x     y
+    // output (1 lwe 2_2 encoded)   : 000(b^y)(a^x)
+    let pairs_iter = pairs.enumerate().map(|(i, keystream)| {
+        let lo_idx = 2 * i;
+        let hi_idx = 2 * i + 1;
+        let i_lo = bit_at(input_stream, lo_idx);
+        let i_hi = bit_at(input_stream, hi_idx);
+        let s = (i_lo | (i_hi << 1)) as usize;
+        sks.unchecked_apply_lookup_table_bivariate(&keystream[0], &keystream[1], &luts[s])
+    });
+
+    // Odd keystream length: one PBS for the trailing bit
+    let trailing_iter = trailing.par_iter().map(|last_keystream| {
+        let last_idx = keystream.len() - 1;
+        let s = bit_at(input_stream, last_idx) as u64;
+        let trailing_lut = sks.generate_lookup_table(move |t| (t & 1) ^ s);
+        let mut last = last_keystream.clone();
+        sks.apply_lookup_table_assign(&mut last, &trailing_lut);
+        last
+    });
+
+    pairs_iter.chain(trailing_iter).collect()
+}
+
+/// Generic param-agnostic transcipher, usable as a fallback for any
+/// param set.
+///
+/// Cost: two PBS per output bit.
+/// One for the xor, followed by a per-block linear combination that packs `m`
+/// bits into one output ciphertext, followed by a second PBS to restore the noise.
+///
+/// `input_stream.len()` must equal `keystream.len().div_ceil(8)`: i.e. the
+/// minimum number of bytes that contain `keystream.len()` bits. When
+/// `keystream.len()` is not a multiple of 8, the trailing bits of the last
+/// input byte are ignored.
+fn apply_keystream_naive(
+    sks: &ServerKey,
+    keystream: &[Ciphertext],
+    input_stream: &[u8],
+) -> Vec<Ciphertext> {
+    assert_eq!(
+        input_stream.len(),
+        keystream.len().div_ceil(8),
+        "input must have exactly ceil(keystream_len / 8) = {} bytes (got {})",
+        keystream.len().div_ceil(8),
+        input_stream.len()
+    );
+
+    let m = sks.message_modulus.0.ilog2() as usize;
+
+    // Per-bit XOR LUT, indexed by the clear sym bit
+    let luts: [_; 2] =
+        std::array::from_fn(|i| sks.generate_lookup_table(move |t| (t & 1) ^ (i as u64)));
+
+    // One PBS per output bit, in parallel: cleans the keystream low bit and
+    // XORs the clear input bit (LSB-first across bytes). Each result is a 1-bit
+    // ciphertext.
+    let cleaned: Vec<Ciphertext> = keystream
+        .par_iter()
+        .enumerate()
+        .map(|(i, k)| {
+            let s = bit_at(input_stream, i) as usize;
+            let mut c = k.clone();
+            sks.apply_lookup_table_assign(&mut c, &luts[s]);
+            c
+        })
+        .collect();
+
+    // Pack up to m cleaned bits per output ciphertext via linear combination,
+    // in parallel. The final chunk may be partial when `keystream.len()` is
+    // not a multiple of `m`. Then a final pbs is done to restore the noise
+    // to a nominal level when the linear combination grew it.
+    cleaned
+        .par_chunks(m)
+        .map(|chunk| {
+            let mut out = chunk[0].clone();
+            for (j, c) in chunk.iter().enumerate().skip(1) {
+                let shifted = sks.unchecked_scalar_mul(c, 1u8 << j);
+                sks.unchecked_add_assign(&mut out, &shifted);
+            }
+            if chunk.len() >= 2 {
+                sks.message_extract_assign(&mut out);
+            }
+            out
+        })
+        .collect()
+}


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description
This PR adds a new `transciphering` module, that sits above shortint and is home to the (cpu) impl of transciphering algorithms, as well as the "plaintext" symmetric encryption. This adds 2 traits, "Transcipherer" and "StreamCipher", that can be used to implement any stream cipher algorithm, both in plaintext and fhe. These traits are dyn compatible, allowing to mimic the "AtomicPattern" type, to be able to have dynamic dispatch in an enum but at the same time allow an easy implementation of a new algo outside of the lib for research purposes.

Transciphering works by:
- initiate a "plain" stream cipher with a key and iv
- initiate the same cipher in fhe with the fhe encrypted key and trivial iv
- generate stream from the plain cipher, xor it with the input
- generate encrypted stream from the fhe cipher, fhe-xor with the kreyvium encrypted input converted to trivial ct.

Since plain (client) and fhe (server) streams must be kept in sync, there is a "skip" function that allows to advance the counter without keeping the stream. Since going back in the stream is considered insecure, it is not permitted. In case of a desync, the stream (client or server) that is behind must skip enough bits to match the other one.

It also integrates kreyvium from `app` into this module as the first transciphering algo, with a few differences:
  - Types are organized a bit differently, with common parent types generics and monomorphized types that are specializing the implementations for Fhe or Plain. This allows to factorize parts of the algo that are in common (moslty shift register rotations), and specialize the parts that need dedicated implementations (arithmetic ops on the values).
  - everything is optimized for 2_2 params (with slower generics fallbacks), with only the lower bits of the messages that are used. This is slower than the 1_1 to 2_2 implementation in apps but does not require a keyswitch. If we want to later use a 1_1 to 2_2, we can always optimize the algo for 1_1 and then add a keyswitch outside of the `trans_cipher` method.
  - the transciphering part in apps is done by encrypting the input in FHE on top of the kreyvium encryption, then calling a FHE xor. Instead, I used the "plain" kreyvium input directly to build 4 LUTs (one per possible input pair of bits) and do the xor directly here.


### Benches
pure kreyvium is a bit slower in the new impl due to 2_2 params. Full transciphering (after warmup) is actually faster than the code in apps because of the input in lut optim.

```rust
┌──────────────────────┬───────────┬───────────┬───────────┐
│                      │ 1_1 (app) │ 2_2 (new) │ 2_2 / 1_1 │
├──────────────────────┼───────────┼───────────┼───────────┤
│ generate 64 bits     │ 109.8 ms  │ 138.3 ms  │ 1.26×     │
├──────────────────────┼───────────┼───────────┼───────────┤
│ transencrypt 64 bits │ 178.2 ms  │ 161.9 ms  │ 0.91×     │
├──────────────────────┼───────────┼───────────┼───────────┤
│ warmup               │ 2.15 s    │ 2.46 s    │ 1.14×     │
└──────────────────────┴───────────┴───────────┴───────────┘
```

### Next steps
Following pr will come up with: 
- a light integer + hl wrapping, allowing to directly produce FHE types from a kreyvium encrypted input, and dispatch between CPU/GPU implementations.
- benches and tests at the integer or hl level
- a new implementation of Kreyvium for 2_2, making a better use of the allowed space
- a rework of the app targeted to end user, that will directly use the high level api. Trivium will be re-implemented using the dyn trait to show the extensibility.

### Review
To review, you can start by looking at the doc comment in `tfhe/src/transciphering/mod.rs`, that explains how this API works (remember that this is only the shortint level api yet).
Functions to review carefully:
- `round_naive` and `round_2_2` in `tfhe/src/transciphering/ciphers/kreyvium/fhe.rs`,
- `trans_cipher_naive` and `trans_cipher_2_2`  in `tfhe/src/transciphering/mod.rs` 

They are the most critical part of this implementation. Tests ran without error with the noise_asserts.

AI has been used to generate tests and docs

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3556)
<!-- Reviewable:end -->
