### PR TITLE
Ts/wasm/create mini wasm sdk to lower the weight of the file

### DIFF
--- a/.github/workflows/make_release_tfhe.yml
+++ b/.github/workflows/make_release_tfhe.yml
@@ -20,6 +20,14 @@ on:
         description: "Push web compat (cross-origin) js package"
         type: boolean
         default: true
+      push_web_client_package:
+        description: "Push web client js package"
+        type: boolean
+        default: true
+      push_web_compat_client_package:
+        description: "Push web compat (cross-origin) client js package"
+        type: boolean
+        default: true
       push_node_package:
         description: "Push node js package"
         type: boolean
@@ -117,6 +125,40 @@ jobs:
 
       - name: Publish web compat (cross-origin) package
         if: ${{ inputs.push_web_compat_package }}
+        uses: JS-DevTools/npm-publish@0fd2f4369c5d6bcfcde6091a7c527d810b9b5c3f
+        with:
+          package: tfhe/pkg/package.json
+          dry-run: ${{ inputs.dry_run }}
+          tag: ${{ env.NPM_TAG }}
+          provenance: true
+
+      - name: Build web client package
+        if: ${{ inputs.push_web_client_package }}
+        run: |
+          rm -rf tfhe/pkg
+
+          make build_web_js_api_parallel_client
+          sed -i 's/"tfhe"/"tfhe-client"/g' tfhe/pkg/package.json
+
+      - name: Publish web client package
+        if: ${{ inputs.push_web_client_package }}
+        uses: JS-DevTools/npm-publish@0fd2f4369c5d6bcfcde6091a7c527d810b9b5c3f
+        with:
+          package: tfhe/pkg/package.json
+          dry-run: ${{ inputs.dry_run }}
+          tag: ${{ env.NPM_TAG }}
+          provenance: true
+
+      - name: Build web compat (cross-origin) client package
+        if: ${{ inputs.push_web_compat_client_package }}
+        run: |
+          rm -rf tfhe/pkg
+
+          make build_web_js_api_client
+          sed -i 's/"tfhe"/"tfhe-compat-client"/g' tfhe/pkg/package.json
+
+      - name: Publish web compat (cross-origin) client package
+        if: ${{ inputs.push_web_compat_client_package }}
         uses: JS-DevTools/npm-publish@0fd2f4369c5d6bcfcde6091a7c527d810b9b5c3f
         with:
           package: tfhe/pkg/package.json

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ BACKWARD_COMPAT_DATA_GEN_VERSION:=$(TFHE_VERSION)
 CORRUPTED_INPUTS_TEST=tests/corrupted_inputs_deserialization
 TEST_VECTORS_DIR=apps/test-vectors
 CURRENT_TFHE_VERSION:=$(shell grep '^version[[:space:]]*=' tfhe/Cargo.toml | cut -d '=' -f 2 | xargs)
-WASM_PACK_VERSION="0.13.1"
+WASM_PACK_VERSION="0.15.0"
 WASM_BINDGEN_VERSION:=$(shell cargo tree --target wasm32-unknown-unknown -e all --prefix none | grep "wasm-bindgen v" | head -n 1 | cut -d 'v' -f2)
 WEB_RUNNER_DIR=web-test-runner
 WEB_SERVER_DIR=tfhe/web_wasm_parallel_tests
@@ -777,39 +777,8 @@ build_c_api_experimental_deterministic_fft: install_rs_check_toolchain
 		--features=boolean-c-api,shortint-c-api,high-level-c-api,zk-pok,experimental-force_fft_algo_dif4 \
 		-p tfhe
 
-.PHONY: build_web_js_api # Build the js API targeting the web browser, in sequential or cross origin parallelism modes.
-build_web_js_api: install_wasm_pack
-	cd tfhe && \
-	RUSTFLAGS="$(WASM_RUSTFLAGS)" wasm-pack build --release --target=web \
-		-- --features=boolean-client-js-wasm-api,shortint-client-js-wasm-api,integer-client-js-wasm-api,zk-pok,extended-types,cross-origin-wasm-api && \
-	find pkg/snippets -type f -iname worker_helpers.js -exec sed -i 's|import("../../..")|import("../../../tfhe.js")|g' {} \;
-	cp utils/wasm-par-mq/js/coordinator.js tfhe/pkg/
-	jq '.files += ["snippets"]' tfhe/pkg/package.json > tmp_pkg.json && mv -f tmp_pkg.json tfhe/pkg/package.json
-
-.PHONY: build_web_js_api_parallel # Build the js API targeting the web browser with parallelism support
-# parallel wasm requires specific build options, see https://github.com/rust-lang/rust/pull/147225
-build_web_js_api_parallel: install_rs_check_toolchain install_wasm_pack install_wasm_bindgen_cli
-	cd tfhe && \
-	rustup component add rust-src --toolchain $(RS_CHECK_TOOLCHAIN) && \
-	RUSTFLAGS="$(WASM_RUSTFLAGS) -C target-feature=+atomics,+bulk-memory \
-		-Clink-arg=--shared-memory \
-		-Clink-arg=--max-memory=1073741824 \
-		-Clink-arg=--import-memory \
-		-Clink-arg=--export=__wasm_init_tls \
-		-Clink-arg=--export=__tls_size \
-		-Clink-arg=--export=__tls_align \
-		-Clink-arg=--export=__tls_base" \
-		rustup run $(RS_CHECK_TOOLCHAIN) wasm-pack build --release --target=web \
-		-- --features=boolean-client-js-wasm-api,shortint-client-js-wasm-api,integer-client-js-wasm-api,parallel-wasm-api,zk-pok,extended-types \
-		-Z build-std=panic_abort,std && \
-	find pkg/snippets -type f -iname workerHelpers.js -exec sed -i "s|const pkg = await import('..\/..\/..');|const pkg = await import('..\/..\/..\/tfhe.js');|" {} \;
-	jq '.files += ["snippets"]' tfhe/pkg/package.json > tmp_pkg.json && mv -f tmp_pkg.json tfhe/pkg/package.json
-
-.PHONY: build_node_js_api # Build the js API targeting nodejs
-build_node_js_api: install_wasm_pack
-	cd tfhe && \
-	RUSTFLAGS="$(WASM_RUSTFLAGS)" wasm-pack build --release --target=nodejs \
-		-- --features=boolean-client-js-wasm-api,shortint-client-js-wasm-api,integer-client-js-wasm-api,zk-pok,extended-types
+# wasm pkg build rules (full + client, web + node, parallel + cross-origin).
+include make/wasm.mk
 
 .PHONY: build_tfhe_csprng # Build tfhe_csprng
 build_tfhe_csprng:
@@ -1397,7 +1366,8 @@ test_zk_wasm_x86_compat_ci: check_nvm_installed
 	$(MAKE) test_zk_wasm_x86_compat
 
 .PHONY: test_zk_wasm_x86_compat # Check compatibility between wasm and x86_64 proofs
-test_zk_wasm_x86_compat: build_node_js_api
+# Uses the client pkg (lighter to compile) — compat is package-agnostic.
+test_zk_wasm_x86_compat: build_node_js_api_client
 	cd tfhe/tests/zk_wasm_x86_test && npm install
 	RUSTFLAGS="$(RUSTFLAGS)" cargo test --profile $(CARGO_PROFILE) \
 		-p tfhe --test zk_wasm_x86_test --features=integer,zk-pok

--- a/make/wasm.mk
+++ b/make/wasm.mk
@@ -1,0 +1,84 @@
+WEB_CLIENT_OUT_DIR ?= pkg
+
+.PHONY: build_web_js_api # Build the js API targeting the web browser, in sequential or cross origin parallelism modes.
+build_web_js_api: install_wasm_pack
+	cd tfhe && \
+	RUSTFLAGS="$(WASM_RUSTFLAGS)" wasm-pack build --release --target=web \
+		-- --features=boolean-client-js-wasm-api,shortint-client-js-wasm-api,integer-client-js-wasm-api,zk-pok,extended-types,cross-origin-wasm-api && \
+	find pkg/snippets -type f -iname worker_helpers.js -exec sed -i 's|import("../../..")|import("../../../tfhe.js")|g' {} \;
+	cp utils/wasm-par-mq/js/coordinator.js tfhe/pkg/
+	jq '.files += ["snippets"]' tfhe/pkg/package.json > tmp_pkg.json && mv -f tmp_pkg.json tfhe/pkg/package.json
+
+.PHONY: build_web_js_api_parallel # Build the js API targeting the web browser with parallelism support
+# parallel wasm requires specific build options, see https://github.com/rust-lang/rust/pull/147225
+build_web_js_api_parallel: install_rs_check_toolchain install_wasm_pack install_wasm_bindgen_cli
+	cd tfhe && \
+	rustup component add rust-src --toolchain $(RS_CHECK_TOOLCHAIN) && \
+	RUSTFLAGS="$(WASM_RUSTFLAGS) -C target-feature=+atomics,+bulk-memory \
+		-Clink-arg=--shared-memory \
+		-Clink-arg=--max-memory=1073741824 \
+		-Clink-arg=--import-memory \
+		-Clink-arg=--export=__wasm_init_tls \
+		-Clink-arg=--export=__tls_size \
+		-Clink-arg=--export=__tls_align \
+		-Clink-arg=--export=__tls_base" \
+		rustup run $(RS_CHECK_TOOLCHAIN) wasm-pack build --release --target=web \
+		-- --features=boolean-client-js-wasm-api,shortint-client-js-wasm-api,integer-client-js-wasm-api,parallel-wasm-api,zk-pok,extended-types \
+		-Z build-std=panic_abort,std && \
+	find pkg/snippets -type f -iname workerHelpers.js -exec sed -i "s|const pkg = await import('..\/..\/..');|const pkg = await import('..\/..\/..\/tfhe.js');|" {} \;
+	jq '.files += ["snippets"]' tfhe/pkg/package.json > tmp_pkg.json && mv -f tmp_pkg.json tfhe/pkg/package.json
+
+.PHONY: build_node_js_api # Build the js API targeting nodejs
+build_node_js_api: install_wasm_pack
+	cd tfhe && \
+	RUSTFLAGS="$(WASM_RUSTFLAGS)" wasm-pack build --release --target=nodejs \
+		-- --features=boolean-client-js-wasm-api,shortint-client-js-wasm-api,integer-client-js-wasm-api,zk-pok,extended-types
+
+.PHONY: build_node_js_api_client # Build the client js API targeting nodejs (compact encryption + ZK proofs only)
+build_node_js_api_client: install_wasm_pack
+	cd tfhe && \
+	RUSTFLAGS="$(WASM_RUSTFLAGS)" wasm-pack build --release --target=nodejs \
+		-- --no-default-features \
+		--features=__wasm_api,zk-pok,integer,extended-types
+
+.PHONY: build_web_js_api_client # Build the client js API (compact encryption + ZK proofs only), in sequential or cross origin parallelism modes.
+build_web_js_api_client: install_wasm_pack
+	cd tfhe && \
+	RUSTFLAGS="$(WASM_RUSTFLAGS)" wasm-pack build --release --target=web \
+		--out-dir $(WEB_CLIENT_OUT_DIR) \
+		-- --no-default-features \
+		--features=__wasm_api,zk-pok,integer,extended-types,cross-origin-wasm-api && \
+	find $(WEB_CLIENT_OUT_DIR)/snippets -type f -iname worker_helpers.js -exec sed -i 's|import("../../..")|import("../../../tfhe.js")|g' {} \;
+	cp utils/wasm-par-mq/js/coordinator.js tfhe/$(WEB_CLIENT_OUT_DIR)/
+	jq '.files += ["snippets"]' tfhe/$(WEB_CLIENT_OUT_DIR)/package.json > tmp_pkg.json && mv -f tmp_pkg.json tfhe/$(WEB_CLIENT_OUT_DIR)/package.json
+
+.PHONY: build_web_js_api_parallel_client # Build the client js API with parallelism support
+# parallel wasm requires specific build options, see https://github.com/rust-lang/rust/pull/147225
+build_web_js_api_parallel_client: install_rs_check_toolchain install_wasm_pack install_wasm_bindgen_cli
+	cd tfhe && \
+	rustup component add rust-src --toolchain $(RS_CHECK_TOOLCHAIN) && \
+	RUSTFLAGS="$(WASM_RUSTFLAGS) -C target-feature=+atomics,+bulk-memory \
+		-Clink-arg=--shared-memory \
+		-Clink-arg=--max-memory=1073741824 \
+		-Clink-arg=--import-memory \
+		-Clink-arg=--export=__wasm_init_tls \
+		-Clink-arg=--export=__tls_size \
+		-Clink-arg=--export=__tls_align \
+		-Clink-arg=--export=__tls_base" \
+		rustup run $(RS_CHECK_TOOLCHAIN) wasm-pack build --release --target=web \
+		--out-dir $(WEB_CLIENT_OUT_DIR) \
+		-- --no-default-features \
+		--features=__wasm_api,zk-pok,integer,extended-types,parallel-wasm-api \
+		-Z build-std=panic_abort,std && \
+	find $(WEB_CLIENT_OUT_DIR)/snippets -type f -iname workerHelpers.js -exec sed -i "s|const pkg = await import('..\/..\/..');|const pkg = await import('..\/..\/..\/tfhe.js');|" {} \;
+	jq '.files += ["snippets"]' tfhe/$(WEB_CLIENT_OUT_DIR)/package.json > tmp_pkg.json && mv -f tmp_pkg.json tfhe/$(WEB_CLIENT_OUT_DIR)/package.json
+
+.PHONY: build_web_js_api_parallel_pair # Build full + client parallel pkgs (pkg/ + pkg-client/)
+build_web_js_api_parallel_pair:
+	$(MAKE) build_web_js_api_parallel
+	$(MAKE) build_web_js_api_parallel_client WEB_CLIENT_OUT_DIR=pkg-client
+
+.PHONY: build_web_js_api_compat_pair # Build full + client cross-origin (compat) pkgs (pkg/ + pkg-client/)
+build_web_js_api_compat_pair:
+	$(MAKE) build_web_js_api
+	$(MAKE) build_web_js_api_client WEB_CLIENT_OUT_DIR=pkg-client

--- a/tfhe/Cargo.toml
+++ b/tfhe/Cargo.toml
@@ -262,3 +262,11 @@ unexpected_cfgs = { level = "warn", check-cfg = [
     # This is a bug/unwanted behavior from wasm_bindgen macro, for now warn instead of erroring
     'cfg(wasm_bindgen_unstable_test_coverage)',
 ] }
+
+# wasm-opt args for wasm-pack release builds.
+# -Oz: optimize aggressively for size (wasm-pack default is -O).
+# --enable-simd: required because pulp (via tfhe-fft / tfhe-ntt) emits SIMD.
+# --enable-threads: required for the parallel build's +atomics target feature.
+# --enable-bulk-memory: required because modern rustc emits memory.copy/fill.
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ["-Oz", "--enable-simd", "--enable-threads", "--enable-bulk-memory"]

--- a/tfhe/src/js_on_wasm_api/client/config.rs
+++ b/tfhe/src/js_on_wasm_api/client/config.rs
@@ -1,0 +1,63 @@
+use crate::high_level_api as hlapi;
+use crate::js_on_wasm_api::{catch_panic, catch_panic_result, into_js_error};
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub struct TfheConfig(pub(crate) hlapi::Config);
+
+#[wasm_bindgen]
+impl TfheConfig {
+    #[wasm_bindgen]
+    pub fn default() -> Self {
+        Self(hlapi::ConfigBuilder::default().build())
+    }
+}
+
+#[wasm_bindgen]
+pub struct TfheClientKey(pub(crate) hlapi::ClientKey);
+
+#[wasm_bindgen]
+impl TfheClientKey {
+    #[wasm_bindgen]
+    pub fn generate(config: &TfheConfig) -> Result<Self, JsError> {
+        catch_panic(|| Self(hlapi::ClientKey::generate(config.0)))
+    }
+
+    #[wasm_bindgen]
+    pub fn generate_with_seed(config: &TfheConfig, seed: JsValue) -> Result<Self, JsError> {
+        catch_panic_result(|| {
+            let seed =
+                u128::try_from(seed).map_err(|_| JsError::new("Value does not fit in a u128"))?;
+            let key = hlapi::ClientKey::generate_with_seed(config.0, crate::Seed(seed));
+            Ok(Self(key))
+        })
+    }
+
+    #[wasm_bindgen]
+    pub fn safe_serialize(&self, serialized_size_limit: u64) -> Result<Vec<u8>, JsError> {
+        let mut buffer = vec![];
+        catch_panic_result(|| {
+            crate::safe_serialization::SerializationConfig::new(serialized_size_limit)
+                .serialize_into(&self.0, &mut buffer)
+                .map_err(into_js_error)
+        })?;
+
+        Ok(buffer)
+    }
+
+    #[wasm_bindgen]
+    pub fn safe_deserialize(buffer: &[u8], serialized_size_limit: u64) -> Result<Self, JsError> {
+        catch_panic_result(|| {
+            crate::safe_serialization::DeserializationConfig::new(serialized_size_limit)
+                .disable_conformance()
+                .deserialize_from(buffer)
+                .map(Self)
+                .map_err(into_js_error)
+        })
+    }
+}
+
+#[wasm_bindgen]
+pub fn init_panic_hook() {
+    console_error_panic_hook::set_once();
+}

--- a/tfhe/src/js_on_wasm_api/client/integers.rs
+++ b/tfhe/src/js_on_wasm_api/client/integers.rs
@@ -1,0 +1,646 @@
+use crate::integer::bigint::{
+    StaticSignedBigInt, StaticUnsignedBigInt, I1024, I2048, I512, U1024, U2048, U512,
+};
+use crate::integer::{I256, U256};
+use crate::js_on_wasm_api::{catch_panic, catch_panic_result, into_js_error};
+use js_sys::BigInt;
+use wasm_bindgen::prelude::*;
+
+use super::TfheCompactPublicKey;
+#[cfg(feature = "zk-pok")]
+use super::{CompactPkeCrs, ZkComputeLoad};
+
+impl<const N: usize> From<StaticUnsignedBigInt<N>> for JsValue {
+    fn from(value: StaticUnsignedBigInt<N>) -> Self {
+        if N == 0 {
+            return Self::from(0);
+        }
+
+        let shift = BigInt::from(64u64);
+        let mut js_value = BigInt::from(0);
+
+        for v in value.0.iter().copied().rev() {
+            js_value = js_value << &shift;
+            js_value = js_value | BigInt::from(v);
+        }
+
+        js_value.into()
+    }
+}
+
+impl<const N: usize> TryFrom<JsValue> for StaticUnsignedBigInt<N> {
+    type Error = JsError;
+
+    fn try_from(js_value: JsValue) -> Result<Self, Self::Error> {
+        let mut js_bigint = BigInt::new(&js_value).map_err(|err| {
+            JsError::new(&format!("Failed to convert the value: {}", err.to_string()))
+        })?;
+        let mask = BigInt::from(u64::MAX);
+        let shift = BigInt::from(u64::BITS);
+
+        let mut data = [0u64; N];
+        for word in data.iter_mut() {
+            // Since we masked the low value it will fit in u64
+            *word = (&js_bigint & &mask).try_into().unwrap();
+            js_bigint = js_bigint >> &shift;
+        }
+
+        if js_bigint == 0 {
+            Ok(Self(data))
+        } else {
+            Err(JsError::new(&format!(
+                "Value is out of range for U{}",
+                N * u64::BITS as usize
+            )))
+        }
+    }
+}
+
+impl<const N: usize> TryFrom<JsValue> for StaticSignedBigInt<N> {
+    type Error = JsError;
+
+    fn try_from(mut js_value: JsValue) -> Result<Self, Self::Error> {
+        let was_neg = if js_value.lt(&JsValue::from(0)) {
+            js_value = -js_value;
+            true
+        } else {
+            false
+        };
+
+        let mut js_bigint = BigInt::new(&js_value).map_err(|err| {
+            JsError::new(&format!("Failed to convert the value: {}", err.to_string()))
+        })?;
+        let mask = BigInt::from(u64::MAX);
+        let shift = BigInt::from(u64::BITS);
+
+        let mut data = [0u64; N];
+        for word in data.iter_mut() {
+            // Since we masked the low value it will fit in u64
+            *word = (&js_bigint & &mask).try_into().unwrap();
+            js_bigint = js_bigint >> &shift;
+        }
+
+        if js_bigint == 0 {
+            let rs_value = Self(data);
+            Ok(if was_neg { -rs_value } else { rs_value })
+        } else {
+            Err(JsError::new(&format!(
+                "Value is out of range for U{}",
+                N * u64::BITS as usize
+            )))
+        }
+    }
+}
+
+impl<const N: usize> From<StaticSignedBigInt<N>> for JsValue {
+    fn from(mut value: StaticSignedBigInt<N>) -> Self {
+        if N == 0 {
+            return Self::from(0);
+        }
+
+        let was_neg = if value < StaticSignedBigInt::ZERO {
+            value = -value;
+            true
+        } else {
+            false
+        };
+
+        let shift = BigInt::from(64u64);
+        let mut js_value = BigInt::from(0);
+
+        for v in value.0.iter().copied().rev() {
+            js_value = js_value << &shift;
+            js_value = js_value | BigInt::from(v);
+        }
+
+        if was_neg {
+            -Self::from(js_value)
+        } else {
+            Self::from(js_value)
+        }
+    }
+}
+
+#[wasm_bindgen]
+pub enum FheTypes {
+    Bool = 0,
+
+    Uint4 = 1,
+    Uint8 = 2,
+    Uint16 = 3,
+    Uint32 = 4,
+    Uint64 = 5,
+    Uint128 = 6,
+    Uint160 = 7,
+    Uint256 = 8,
+    Uint512 = 9,
+    Uint1024 = 10,
+    Uint2048 = 11,
+    Uint2 = 12,
+    Uint6 = 13,
+    Uint10 = 14,
+    Uint12 = 15,
+    Uint14 = 16,
+
+    Int2 = 17,
+    Int4 = 18,
+    Int6 = 19,
+    Int8 = 20,
+    Int10 = 21,
+    Int12 = 22,
+    Int14 = 23,
+    Int16 = 24,
+    Int32 = 25,
+    Int64 = 26,
+    Int128 = 27,
+    Int160 = 28,
+    Int256 = 29,
+    AsciiString = 30,
+
+    Int512 = 31,
+    Int1024 = 32,
+    Int2048 = 33,
+
+    Uint24 = 34,
+    Uint40 = 35,
+    Uint48 = 36,
+    Uint56 = 37,
+    Uint72 = 38,
+    Uint80 = 39,
+    Uint88 = 40,
+    Uint96 = 41,
+    Uint104 = 42,
+    Uint112 = 43,
+    Uint120 = 44,
+    Uint136 = 45,
+    Uint144 = 46,
+    Uint152 = 47,
+    Uint168 = 48,
+    Uint176 = 49,
+    Uint184 = 50,
+    Uint192 = 51,
+    Uint200 = 52,
+    Uint208 = 53,
+    Uint216 = 54,
+    Uint224 = 55,
+    Uint232 = 56,
+    Uint240 = 57,
+    Uint248 = 58,
+
+    Int24 = 59,
+    Int40 = 60,
+    Int48 = 61,
+    Int56 = 62,
+    Int72 = 63,
+    Int80 = 64,
+    Int88 = 65,
+    Int96 = 66,
+    Int104 = 67,
+    Int112 = 68,
+    Int120 = 69,
+    Int136 = 70,
+    Int144 = 71,
+    Int152 = 72,
+    Int168 = 73,
+    Int176 = 74,
+    Int184 = 75,
+    Int192 = 76,
+    Int200 = 77,
+    Int208 = 78,
+    Int216 = 79,
+    Int224 = 80,
+    Int232 = 81,
+    Int240 = 82,
+    Int248 = 83,
+}
+
+impl From<crate::FheTypes> for FheTypes {
+    fn from(value: crate::FheTypes) -> Self {
+        match value {
+            crate::FheTypes::Bool => Self::Bool,
+            crate::FheTypes::Uint2 => Self::Uint2,
+            crate::FheTypes::Uint4 => Self::Uint4,
+            crate::FheTypes::Uint6 => Self::Uint6,
+            crate::FheTypes::Uint8 => Self::Uint8,
+            crate::FheTypes::Uint10 => Self::Uint10,
+            crate::FheTypes::Uint12 => Self::Uint12,
+            crate::FheTypes::Uint14 => Self::Uint14,
+            crate::FheTypes::Uint16 => Self::Uint16,
+            crate::FheTypes::Uint24 => Self::Uint24,
+            crate::FheTypes::Uint32 => Self::Uint32,
+            crate::FheTypes::Uint40 => Self::Uint40,
+            crate::FheTypes::Uint48 => Self::Uint48,
+            crate::FheTypes::Uint56 => Self::Uint56,
+            crate::FheTypes::Uint64 => Self::Uint64,
+            crate::FheTypes::Uint72 => Self::Uint72,
+            crate::FheTypes::Uint80 => Self::Uint80,
+            crate::FheTypes::Uint88 => Self::Uint88,
+            crate::FheTypes::Uint96 => Self::Uint96,
+            crate::FheTypes::Uint104 => Self::Uint104,
+            crate::FheTypes::Uint112 => Self::Uint112,
+            crate::FheTypes::Uint120 => Self::Uint120,
+            crate::FheTypes::Uint128 => Self::Uint128,
+            crate::FheTypes::Uint136 => Self::Uint136,
+            crate::FheTypes::Uint144 => Self::Uint144,
+            crate::FheTypes::Uint152 => Self::Uint152,
+            crate::FheTypes::Uint160 => Self::Uint160,
+            crate::FheTypes::Uint168 => Self::Uint168,
+            crate::FheTypes::Uint176 => Self::Uint176,
+            crate::FheTypes::Uint184 => Self::Uint184,
+            crate::FheTypes::Uint192 => Self::Uint192,
+            crate::FheTypes::Uint200 => Self::Uint200,
+            crate::FheTypes::Uint208 => Self::Uint208,
+            crate::FheTypes::Uint216 => Self::Uint216,
+            crate::FheTypes::Uint224 => Self::Uint224,
+            crate::FheTypes::Uint232 => Self::Uint232,
+            crate::FheTypes::Uint240 => Self::Uint240,
+            crate::FheTypes::Uint248 => Self::Uint248,
+            crate::FheTypes::Uint256 => Self::Uint256,
+            crate::FheTypes::Uint512 => Self::Uint512,
+            crate::FheTypes::Uint1024 => Self::Uint1024,
+            crate::FheTypes::Uint2048 => Self::Uint2048,
+            crate::FheTypes::Int2 => Self::Int2,
+            crate::FheTypes::Int4 => Self::Int4,
+            crate::FheTypes::Int6 => Self::Int6,
+            crate::FheTypes::Int8 => Self::Int8,
+            crate::FheTypes::Int10 => Self::Int10,
+            crate::FheTypes::Int12 => Self::Int12,
+            crate::FheTypes::Int14 => Self::Int14,
+            crate::FheTypes::Int16 => Self::Int16,
+            crate::FheTypes::Int24 => Self::Int24,
+            crate::FheTypes::Int32 => Self::Int32,
+            crate::FheTypes::Int40 => Self::Int40,
+            crate::FheTypes::Int48 => Self::Int48,
+            crate::FheTypes::Int56 => Self::Int56,
+            crate::FheTypes::Int64 => Self::Int64,
+            crate::FheTypes::Int72 => Self::Int72,
+            crate::FheTypes::Int80 => Self::Int80,
+            crate::FheTypes::Int88 => Self::Int88,
+            crate::FheTypes::Int96 => Self::Int96,
+            crate::FheTypes::Int104 => Self::Int104,
+            crate::FheTypes::Int112 => Self::Int112,
+            crate::FheTypes::Int120 => Self::Int120,
+            crate::FheTypes::Int128 => Self::Int128,
+            crate::FheTypes::Int136 => Self::Int136,
+            crate::FheTypes::Int144 => Self::Int144,
+            crate::FheTypes::Int152 => Self::Int152,
+            crate::FheTypes::Int160 => Self::Int160,
+            crate::FheTypes::Int168 => Self::Int168,
+            crate::FheTypes::Int176 => Self::Int176,
+            crate::FheTypes::Int184 => Self::Int184,
+            crate::FheTypes::Int192 => Self::Int192,
+            crate::FheTypes::Int200 => Self::Int200,
+            crate::FheTypes::Int208 => Self::Int208,
+            crate::FheTypes::Int216 => Self::Int216,
+            crate::FheTypes::Int224 => Self::Int224,
+            crate::FheTypes::Int232 => Self::Int232,
+            crate::FheTypes::Int240 => Self::Int240,
+            crate::FheTypes::Int248 => Self::Int248,
+            crate::FheTypes::Int256 => Self::Int256,
+            crate::FheTypes::Int512 => Self::Int512,
+            crate::FheTypes::Int1024 => Self::Int1024,
+            crate::FheTypes::Int2048 => Self::Int2048,
+            crate::FheTypes::AsciiString => Self::AsciiString,
+        }
+    }
+}
+
+#[wasm_bindgen]
+pub struct CompactCiphertextListExpander(
+    pub(crate) crate::high_level_api::CompactCiphertextListExpander,
+);
+
+#[wasm_bindgen]
+pub struct CompactCiphertextList(pub(crate) crate::high_level_api::CompactCiphertextList);
+
+#[wasm_bindgen]
+impl CompactCiphertextList {
+    #[wasm_bindgen]
+    pub fn builder(
+        public_key: &TfheCompactPublicKey,
+    ) -> Result<CompactCiphertextListBuilder, JsError> {
+        catch_panic(|| {
+            let inner = crate::high_level_api::CompactCiphertextList::builder(&public_key.0);
+            CompactCiphertextListBuilder(inner)
+        })
+    }
+
+    #[wasm_bindgen]
+    pub fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+#[cfg(feature = "zk-pok")]
+#[wasm_bindgen]
+pub struct ProvenCompactCiphertextList(
+    pub(crate) crate::high_level_api::ProvenCompactCiphertextList,
+);
+
+#[cfg(feature = "zk-pok")]
+#[wasm_bindgen]
+impl ProvenCompactCiphertextList {
+    #[wasm_bindgen]
+    pub fn builder(
+        public_key: &TfheCompactPublicKey,
+    ) -> Result<CompactCiphertextListBuilder, JsError> {
+        catch_panic(|| {
+            let inner = crate::high_level_api::ProvenCompactCiphertextList::builder(&public_key.0);
+            CompactCiphertextListBuilder(inner)
+        })
+    }
+
+    #[wasm_bindgen]
+    pub fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+
+    #[wasm_bindgen]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    #[wasm_bindgen]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    #[wasm_bindgen]
+    pub fn get_kind_of(&self, index: usize) -> Option<FheTypes> {
+        self.0.get_kind_of(index).map(Into::into)
+    }
+
+    #[wasm_bindgen]
+    pub fn safe_serialize(&self, serialized_size_limit: u64) -> Result<Vec<u8>, JsError> {
+        let mut buffer = vec![];
+        catch_panic_result(|| {
+            crate::safe_serialization::SerializationConfig::new(serialized_size_limit)
+                .serialize_into(&self.0, &mut buffer)
+                .map_err(into_js_error)
+        })?;
+
+        Ok(buffer)
+    }
+
+    #[wasm_bindgen]
+    pub fn safe_deserialize(buffer: &[u8], serialized_size_limit: u64) -> Result<Self, JsError> {
+        catch_panic_result(|| {
+            crate::safe_serialization::DeserializationConfig::new(serialized_size_limit)
+                .disable_conformance()
+                .deserialize_from(buffer)
+                .map(ProvenCompactCiphertextList)
+                .map_err(into_js_error)
+        })
+    }
+}
+
+#[wasm_bindgen]
+pub struct CompactCiphertextListBuilder(
+    pub(crate) crate::high_level_api::CompactCiphertextListBuilder,
+);
+
+/// Helper macro to define push methods for the builder
+///
+/// The js_type must be a type that is "native" between rust and wasm_bindgen
+macro_rules! define_builder_push_method {
+    (
+        unsigned: {
+            $($num_bits:literal <= $js_type:ty),*
+            $(,)?
+        }
+    ) => {
+        ::paste::paste!{
+            #[wasm_bindgen]
+            impl CompactCiphertextListBuilder {
+                $(
+                    #[wasm_bindgen]
+                    pub fn [<push_u $num_bits>] (&mut self, value: $js_type) -> Result<(), JsError> {
+                        catch_panic(|| {
+                            self.0.push_with_num_bits(value, $num_bits).unwrap();
+                        })
+                    }
+                )*
+            }
+        }
+    };
+    (
+        signed: {
+            $($num_bits:literal <= $js_type:ty),*
+            $(,)?
+        }
+    ) => {
+        ::paste::paste!{
+            #[wasm_bindgen]
+            impl CompactCiphertextListBuilder {
+                $(
+                    #[wasm_bindgen]
+                    pub fn [<push_i $num_bits>] (&mut self, value: $js_type) -> Result<(), JsError> {
+                        catch_panic(|| {
+                            self.0.push_with_num_bits(value, $num_bits).unwrap();
+                        })
+                    }
+                )*
+            }
+        }
+    };
+}
+
+define_builder_push_method!(unsigned: {
+    2 <= u8,
+    4 <= u8,
+    6 <= u8,
+    8 <= u8,
+    10 <= u16,
+    12 <= u16,
+    14 <= u16,
+    16 <= u16,
+    32 <= u32,
+    64 <= u64,
+});
+
+define_builder_push_method!(signed: {
+    2 <= i8,
+    4 <= i8,
+    6 <= i8,
+    8 <= i8,
+    10 <= i16,
+    12 <= i16,
+    14 <= i16,
+    16 <= i16,
+    32 <= i32,
+    64 <= i64,
+});
+
+#[wasm_bindgen]
+impl CompactCiphertextListBuilder {
+    #[wasm_bindgen]
+    pub fn push_u128(&mut self, value: JsValue) -> Result<(), JsError> {
+        catch_panic_result(|| {
+            let value = u128::try_from(value).map_err(into_js_error)?;
+            self.0.push(value);
+            Ok(())
+        })
+    }
+
+    #[wasm_bindgen]
+    pub fn push_u160(&mut self, value: JsValue) -> Result<(), JsError> {
+        catch_panic_result(|| {
+            let value = U256::try_from(value)?;
+            self.0.push_with_num_bits(value, 160)?;
+            Ok(())
+        })
+    }
+
+    #[wasm_bindgen]
+    pub fn push_u256(&mut self, value: JsValue) -> Result<(), JsError> {
+        catch_panic_result(|| {
+            let value = U256::try_from(value)?;
+            self.0.push(value);
+            Ok(())
+        })
+    }
+
+    #[wasm_bindgen]
+    pub fn push_u512(&mut self, value: JsValue) -> Result<(), JsError> {
+        catch_panic_result(|| {
+            let value = U512::try_from(value)?;
+            self.0.push(value);
+            Ok(())
+        })
+    }
+
+    #[wasm_bindgen]
+    pub fn push_u1024(&mut self, value: JsValue) -> Result<(), JsError> {
+        catch_panic_result(|| {
+            let value = U1024::try_from(value)?;
+            self.0.push(value);
+            Ok(())
+        })
+    }
+
+    #[wasm_bindgen]
+    pub fn push_u2048(&mut self, value: JsValue) -> Result<(), JsError> {
+        catch_panic_result(|| {
+            let value = U2048::try_from(value)?;
+            self.0.push(value);
+            Ok(())
+        })
+    }
+
+    #[wasm_bindgen]
+    pub fn push_i128(&mut self, value: JsValue) -> Result<(), JsError> {
+        catch_panic_result(|| {
+            let value = i128::try_from(value).map_err(into_js_error)?;
+            self.0.push(value);
+            Ok(())
+        })
+    }
+
+    #[wasm_bindgen]
+    pub fn push_i160(&mut self, value: JsValue) -> Result<(), JsError> {
+        catch_panic_result(|| {
+            let value = I256::try_from(value)?;
+            self.0.push_with_num_bits(value, 160)?;
+            Ok(())
+        })
+    }
+
+    #[wasm_bindgen]
+    pub fn push_i256(&mut self, value: JsValue) -> Result<(), JsError> {
+        catch_panic_result(|| {
+            let value = I256::try_from(value)?;
+            self.0.push(value);
+            Ok(())
+        })
+    }
+
+    #[wasm_bindgen]
+    pub fn push_i512(&mut self, value: JsValue) -> Result<(), JsError> {
+        catch_panic_result(|| {
+            let value = I512::try_from(value)?;
+            self.0.push(value);
+            Ok(())
+        })
+    }
+
+    #[wasm_bindgen]
+    pub fn push_i1024(&mut self, value: JsValue) -> Result<(), JsError> {
+        catch_panic_result(|| {
+            let value = I1024::try_from(value)?;
+            self.0.push(value);
+            Ok(())
+        })
+    }
+
+    #[wasm_bindgen]
+    pub fn push_i2048(&mut self, value: JsValue) -> Result<(), JsError> {
+        catch_panic_result(|| {
+            let value = I2048::try_from(value)?;
+            self.0.push(value);
+            Ok(())
+        })
+    }
+
+    #[wasm_bindgen]
+    pub fn push_boolean(&mut self, value: bool) -> Result<(), JsError> {
+        catch_panic(|| {
+            self.0.push(value);
+        })
+    }
+
+    #[wasm_bindgen]
+    pub fn build(&self) -> Result<CompactCiphertextList, JsError> {
+        catch_panic(|| {
+            let inner = self.0.build();
+            CompactCiphertextList(inner)
+        })
+    }
+
+    #[wasm_bindgen]
+    pub fn build_packed(&self) -> Result<CompactCiphertextList, JsError> {
+        catch_panic(|| {
+            let inner = self.0.build_packed();
+            CompactCiphertextList(inner)
+        })
+    }
+
+    #[wasm_bindgen]
+    pub fn build_packed_seeded(&self, seed: &[u8]) -> Result<CompactCiphertextList, JsError> {
+        catch_panic_result(|| {
+            let inner = self.0.build_packed_seeded(seed).map_err(into_js_error)?;
+            Ok(CompactCiphertextList(inner))
+        })
+    }
+
+    #[cfg(feature = "zk-pok")]
+    #[wasm_bindgen]
+    pub fn build_with_proof_packed(
+        &self,
+        crs: &CompactPkeCrs,
+        metadata: &[u8],
+        compute_load: ZkComputeLoad,
+    ) -> Result<ProvenCompactCiphertextList, JsError> {
+        catch_panic_result(|| {
+            self.0
+                .build_with_proof_packed(&crs.0, metadata, compute_load.into())
+                .map_err(into_js_error)
+                .map(ProvenCompactCiphertextList)
+        })
+    }
+
+    #[cfg(feature = "zk-pok")]
+    pub fn build_with_proof_packed_seeded(
+        &self,
+        crs: &CompactPkeCrs,
+        metadata: &[u8],
+        compute_load: ZkComputeLoad,
+        seed: &[u8],
+    ) -> Result<ProvenCompactCiphertextList, JsError> {
+        catch_panic_result(|| {
+            self.0
+                .build_with_proof_packed_seeded(&crs.0, metadata, compute_load.into(), seed)
+                .map_err(into_js_error)
+                .map(ProvenCompactCiphertextList)
+        })
+    }
+}

--- a/tfhe/src/js_on_wasm_api/client/keys.rs
+++ b/tfhe/src/js_on_wasm_api/client/keys.rs
@@ -1,0 +1,53 @@
+use super::TfheClientKey;
+use crate::high_level_api as hlapi;
+use crate::js_on_wasm_api::{catch_panic, catch_panic_result, into_js_error};
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub struct TfheCompactPublicKey(pub(crate) hlapi::CompactPublicKey);
+
+#[wasm_bindgen]
+impl TfheCompactPublicKey {
+    #[wasm_bindgen]
+    pub fn new(client_key: &TfheClientKey) -> Result<Self, JsError> {
+        catch_panic(|| Self(hlapi::CompactPublicKey::new(&client_key.0)))
+    }
+
+    #[wasm_bindgen]
+    pub fn safe_serialize(&self, serialized_size_limit: u64) -> Result<Vec<u8>, JsError> {
+        let mut buffer = vec![];
+        catch_panic_result(|| {
+            crate::safe_serialization::SerializationConfig::new(serialized_size_limit)
+                .serialize_into(&self.0, &mut buffer)
+                .map_err(into_js_error)
+        })?;
+
+        Ok(buffer)
+    }
+
+    #[wasm_bindgen]
+    pub fn safe_deserialize(buffer: &[u8], serialized_size_limit: u64) -> Result<Self, JsError> {
+        catch_panic_result(|| {
+            crate::safe_serialization::DeserializationConfig::new(serialized_size_limit)
+                .disable_conformance()
+                .deserialize_from(buffer)
+                .map(Self)
+                .map_err(into_js_error)
+        })
+    }
+
+    #[cfg(feature = "shortint-client-js-wasm-api")]
+    #[wasm_bindgen]
+    pub fn safe_deserialize_conformant(
+        buffer: &[u8],
+        serialized_size_limit: u64,
+        conformance_params: &crate::js_on_wasm_api::shortint::ShortintCompactPublicKeyEncryptionParameters,
+    ) -> Result<Self, JsError> {
+        catch_panic_result(|| {
+            crate::safe_serialization::DeserializationConfig::new(serialized_size_limit)
+                .deserialize_from(buffer, &conformance_params.compact_pke_params)
+                .map(Self)
+                .map_err(into_js_error)
+        })
+    }
+}

--- a/tfhe/src/js_on_wasm_api/client/mod.rs
+++ b/tfhe/src/js_on_wasm_api/client/mod.rs
@@ -1,0 +1,12 @@
+mod config;
+mod integers;
+mod keys;
+#[cfg(feature = "zk-pok")]
+mod zk;
+
+pub(crate) use config::*;
+#[cfg(feature = "integer-client-js-wasm-api")]
+pub(crate) use integers::*;
+pub(crate) use keys::*;
+#[cfg(feature = "zk-pok")]
+pub(crate) use zk::*;

--- a/tfhe/src/js_on_wasm_api/client/zk.rs
+++ b/tfhe/src/js_on_wasm_api/client/zk.rs
@@ -1,7 +1,6 @@
+use super::TfheConfig;
+use crate::js_on_wasm_api::{catch_panic_result, into_js_error};
 use wasm_bindgen::prelude::*;
-
-use crate::js_on_wasm_api::js_high_level_api::config::TfheConfig;
-use crate::js_on_wasm_api::js_high_level_api::{catch_panic_result, into_js_error};
 
 #[derive(Copy, Clone, Eq, PartialEq)]
 #[wasm_bindgen]
@@ -22,8 +21,6 @@ impl From<ZkComputeLoad> for crate::zk::ZkComputeLoad {
 #[wasm_bindgen]
 pub struct CompactPkeCrs(pub(crate) crate::core_crypto::entities::CompactPkeCrs);
 
-// "wasm bindgen is fragile and prefers the actual type vs. Self"
-#[allow(clippy::use_self)]
 #[wasm_bindgen]
 impl CompactPkeCrs {
     #[wasm_bindgen]
@@ -39,10 +36,7 @@ impl CompactPkeCrs {
     }
 
     #[wasm_bindgen]
-    pub fn safe_deserialize(
-        buffer: &[u8],
-        serialized_size_limit: u64,
-    ) -> Result<CompactPkeCrs, JsError> {
+    pub fn safe_deserialize(buffer: &[u8], serialized_size_limit: u64) -> Result<Self, JsError> {
         catch_panic_result(|| {
             crate::safe_serialization::DeserializationConfig::new(serialized_size_limit)
                 .disable_conformance()
@@ -53,7 +47,7 @@ impl CompactPkeCrs {
     }
 
     #[wasm_bindgen]
-    pub fn from_config(config: &TfheConfig, max_num_bits: usize) -> Result<CompactPkeCrs, JsError> {
+    pub fn from_config(config: &TfheConfig, max_num_bits: usize) -> Result<Self, JsError> {
         catch_panic_result(|| {
             crate::core_crypto::entities::CompactPkeCrs::from_config(config.0, max_num_bits)
                 .map(CompactPkeCrs)
@@ -65,7 +59,7 @@ impl CompactPkeCrs {
     pub fn safe_deserialize_from_public_params(
         buffer: &[u8],
         serialized_size_limit: u64,
-    ) -> Result<CompactPkeCrs, JsError> {
+    ) -> Result<Self, JsError> {
         catch_panic_result(|| {
             crate::safe_serialization::DeserializationConfig::new(serialized_size_limit)
                 .disable_conformance()

--- a/tfhe/src/js_on_wasm_api/js_high_level_api/config.rs
+++ b/tfhe/src/js_on_wasm_api/js_high_level_api/config.rs
@@ -1,26 +1,21 @@
-use crate::high_level_api as hlapi;
+use crate::js_on_wasm_api::client::TfheConfig;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
-pub struct TfheConfig(pub(crate) hlapi::Config);
-
-#[wasm_bindgen]
-pub struct TfheConfigBuilder(pub(crate) hlapi::ConfigBuilder);
+pub struct TfheConfigBuilder(pub(crate) crate::high_level_api::ConfigBuilder);
 
 #[wasm_bindgen]
 impl TfheConfigBuilder {
     #[wasm_bindgen]
     pub fn default() -> Self {
-        Self(hlapi::ConfigBuilder::default())
+        Self(crate::high_level_api::ConfigBuilder::default())
     }
 
     #[wasm_bindgen]
     pub fn with_custom_parameters(
         block_parameters: &crate::js_on_wasm_api::shortint::ShortintParameters,
     ) -> Self {
-        Self(hlapi::ConfigBuilder::with_custom_parameters(
-            block_parameters.0,
-        ))
+        Self(crate::high_level_api::ConfigBuilder::with_custom_parameters(block_parameters.0))
     }
 
     #[wasm_bindgen]

--- a/tfhe/src/js_on_wasm_api/js_high_level_api/integers.rs
+++ b/tfhe/src/js_on_wasm_api/js_high_level_api/integers.rs
@@ -1,129 +1,42 @@
 #![allow(clippy::use_self)]
 use crate::high_level_api::prelude::*;
-use crate::integer::bigint::{
-    StaticSignedBigInt, StaticUnsignedBigInt, I1024, I2048, I512, U1024, U2048, U512,
-};
+use crate::integer::bigint::{I1024, I2048, I512, U1024, U2048, U512};
 use crate::integer::{I256, U256};
-use crate::js_on_wasm_api::js_high_level_api::keys::TfheCompactPublicKey;
-#[cfg(feature = "zk-pok")]
-use crate::js_on_wasm_api::js_high_level_api::zk::{CompactPkeCrs, ZkComputeLoad};
-use crate::js_on_wasm_api::js_high_level_api::{catch_panic, catch_panic_result, into_js_error};
-use js_sys::BigInt;
+use crate::js_on_wasm_api::client::*;
+use crate::js_on_wasm_api::{catch_panic, catch_panic_result, into_js_error};
 use wasm_bindgen::prelude::*;
 
 #[cfg(all(feature = "zk-pok", feature = "cross-origin-wasm-api"))]
 use wasm_par_mq::{execute_async, register_fn, sync_fn};
 
-const U128_MAX_AS_STR: &str = "340282366920938463463374607431768211455";
-
-impl<const N: usize> From<StaticUnsignedBigInt<N>> for JsValue {
-    fn from(value: StaticUnsignedBigInt<N>) -> Self {
-        if N == 0 {
-            return Self::from(0);
-        }
-
-        let shift = BigInt::from(64u64);
-        let mut js_value = BigInt::from(0);
-
-        for v in value.0.iter().copied().rev() {
-            js_value = js_value << &shift;
-            js_value = js_value | BigInt::from(v);
-        }
-
-        js_value.into()
+#[cfg(feature = "zk-pok")]
+#[wasm_bindgen]
+impl ProvenCompactCiphertextList {
+    #[wasm_bindgen]
+    pub fn verify_and_expand(
+        &self,
+        crs: &CompactPkeCrs,
+        public_key: &TfheCompactPublicKey,
+        metadata: &[u8],
+    ) -> Result<CompactCiphertextListExpander, JsError> {
+        catch_panic_result(|| {
+            let inner = self
+                .0
+                .verify_and_expand(&crs.0, &public_key.0, metadata)
+                .map_err(into_js_error)?;
+            Ok(CompactCiphertextListExpander(inner))
+        })
     }
-}
 
-impl<const N: usize> TryFrom<JsValue> for StaticUnsignedBigInt<N> {
-    type Error = JsError;
-
-    fn try_from(js_value: JsValue) -> Result<Self, Self::Error> {
-        let mut js_bigint = BigInt::new(&js_value).map_err(|err| {
-            JsError::new(&format!("Failed to convert the value: {}", err.to_string()))
-        })?;
-        let mask = BigInt::from(u64::MAX);
-        let shift = BigInt::from(u64::BITS);
-
-        let mut data = [0u64; N];
-        for word in data.iter_mut() {
-            // Since we masked the low value it will fit in u64
-            *word = (&js_bigint & &mask).try_into().unwrap();
-            js_bigint = js_bigint >> &shift;
-        }
-
-        if js_bigint == 0 {
-            Ok(Self(data))
-        } else {
-            Err(JsError::new(&format!(
-                "Value is out of range for U{}",
-                N * u64::BITS as usize
-            )))
-        }
-    }
-}
-
-impl<const N: usize> TryFrom<JsValue> for StaticSignedBigInt<N> {
-    type Error = JsError;
-
-    fn try_from(mut js_value: JsValue) -> Result<Self, Self::Error> {
-        let was_neg = if js_value.lt(&JsValue::from(0)) {
-            js_value = -js_value;
-            true
-        } else {
-            false
-        };
-
-        let mut js_bigint = BigInt::new(&js_value).map_err(|err| {
-            JsError::new(&format!("Failed to convert the value: {}", err.to_string()))
-        })?;
-        let mask = BigInt::from(u64::MAX);
-        let shift = BigInt::from(u64::BITS);
-
-        let mut data = [0u64; N];
-        for word in data.iter_mut() {
-            // Since we masked the low value it will fit in u64
-            *word = (&js_bigint & &mask).try_into().unwrap();
-            js_bigint = js_bigint >> &shift;
-        }
-
-        if js_bigint == 0 {
-            let rs_value = Self(data);
-            Ok(if was_neg { -rs_value } else { rs_value })
-        } else {
-            Err(JsError::new(&format!(
-                "Value is out of range for U{}",
-                N * u64::BITS as usize
-            )))
-        }
-    }
-}
-
-impl<const N: usize> From<StaticSignedBigInt<N>> for JsValue {
-    fn from(mut value: StaticSignedBigInt<N>) -> Self {
-        if N == 0 {
-            return Self::from(0);
-        }
-
-        let was_neg = if value < StaticSignedBigInt::ZERO {
-            value = -value;
-            true
-        } else {
-            false
-        };
-
-        let shift = BigInt::from(64u64);
-        let mut js_value = BigInt::from(0);
-
-        for v in value.0.iter().copied().rev() {
-            js_value = js_value << &shift;
-            js_value = js_value | BigInt::from(v);
-        }
-
-        if was_neg {
-            -Self::from(js_value)
-        } else {
-            Self::from(js_value)
-        }
+    #[wasm_bindgen]
+    pub fn expand_without_verification(&self) -> Result<CompactCiphertextListExpander, JsError> {
+        catch_panic_result(|| {
+            let inner = self
+                .0
+                .expand_without_verification()
+                .map_err(into_js_error)?;
+            Ok(CompactCiphertextListExpander(inner))
+        })
     }
 }
 
@@ -148,7 +61,7 @@ macro_rules! create_wrapper_type_non_native_type (
             #[wasm_bindgen]
             pub fn encrypt_with_client_key(
                 value: JsValue,
-                client_key: &crate::js_on_wasm_api::js_high_level_api::keys::TfheClientKey,
+                client_key: &crate::js_on_wasm_api::client::TfheClientKey,
             ) -> Result<$type_name, JsError> {
                 catch_panic_result(|| {
                     let value = <$rust_type>::try_from(value)
@@ -190,7 +103,7 @@ macro_rules! create_wrapper_type_non_native_type (
             #[wasm_bindgen]
             pub fn decrypt(
                 &self,
-                client_key: &crate::js_on_wasm_api::js_high_level_api::keys::TfheClientKey,
+                client_key: &crate::js_on_wasm_api::client::TfheClientKey,
             ) -> Result<JsValue, JsError> {
                 catch_panic_result(|| {
                     let value: $rust_type = self.0.decrypt(&client_key.0);
@@ -230,7 +143,7 @@ macro_rules! create_wrapper_type_non_native_type (
             #[wasm_bindgen]
             pub fn encrypt_with_client_key(
                 value: JsValue,
-                client_key: &crate::js_on_wasm_api::js_high_level_api::keys::TfheClientKey,
+                client_key: &crate::js_on_wasm_api::client::TfheClientKey,
             ) -> Result<$compressed_type_name, JsError> {
                 catch_panic_result(|| {
                     let value = <$rust_type>::try_from(value)
@@ -649,7 +562,7 @@ macro_rules! create_wrapper_type_that_has_native_type (
             #[wasm_bindgen]
             pub fn encrypt_with_client_key(
                 value: $native_type,
-                client_key: &crate::js_on_wasm_api::js_high_level_api::keys::TfheClientKey,
+                client_key: &crate::js_on_wasm_api::client::TfheClientKey,
             ) -> Result<$type_name, JsError> {
                 catch_panic_result(|| {
                     crate::high_level_api::$type_name::try_encrypt(value, &client_key.0)
@@ -685,7 +598,7 @@ macro_rules! create_wrapper_type_that_has_native_type (
             #[wasm_bindgen]
             pub fn decrypt(
                 &self,
-                client_key: &crate::js_on_wasm_api::js_high_level_api::keys::TfheClientKey,
+                client_key: &crate::js_on_wasm_api::client::TfheClientKey,
             ) -> Result<$native_type, JsError> {
                 catch_panic(|| self.0.decrypt(&client_key.0))
             }
@@ -719,7 +632,7 @@ macro_rules! create_wrapper_type_that_has_native_type (
             #[wasm_bindgen]
             pub fn encrypt_with_client_key(
                 value: $native_type,
-                client_key: &crate::js_on_wasm_api::js_high_level_api::keys::TfheClientKey,
+                client_key: &crate::js_on_wasm_api::client::TfheClientKey,
             ) -> Result<$compressed_type_name, JsError> {
                 catch_panic_result(|| {
                     crate::high_level_api::$compressed_type_name::try_encrypt(value, &client_key.0)
@@ -965,35 +878,7 @@ create_wrapper_type_that_has_native_type!(
 );
 
 #[wasm_bindgen]
-pub struct CompactCiphertextListBuilder(crate::high_level_api::CompactCiphertextListBuilder);
-
-#[wasm_bindgen]
-pub struct CompactCiphertextListExpander(crate::high_level_api::CompactCiphertextListExpander);
-
-#[wasm_bindgen]
-pub struct CompactCiphertextList(crate::high_level_api::CompactCiphertextList);
-
-#[cfg(feature = "zk-pok")]
-#[wasm_bindgen]
-pub struct ProvenCompactCiphertextList(crate::high_level_api::ProvenCompactCiphertextList);
-
-#[wasm_bindgen]
 impl CompactCiphertextList {
-    #[wasm_bindgen]
-    pub fn eq(&self, other: &CompactCiphertextList) -> bool {
-        self.0 == other.0
-    }
-
-    #[wasm_bindgen]
-    pub fn builder(
-        public_key: &TfheCompactPublicKey,
-    ) -> Result<CompactCiphertextListBuilder, JsError> {
-        catch_panic(|| {
-            let inner = crate::high_level_api::CompactCiphertextList::builder(&public_key.0);
-            CompactCiphertextListBuilder(inner)
-        })
-    }
-
     #[wasm_bindgen]
     pub fn len(&self) -> usize {
         self.0.len()
@@ -1046,96 +931,10 @@ impl CompactCiphertextList {
     }
 }
 
-#[cfg(feature = "zk-pok")]
-#[wasm_bindgen]
-impl ProvenCompactCiphertextList {
-    #[wasm_bindgen]
-    pub fn builder(
-        public_key: &TfheCompactPublicKey,
-    ) -> Result<CompactCiphertextListBuilder, JsError> {
-        catch_panic(|| {
-            let inner = crate::high_level_api::ProvenCompactCiphertextList::builder(&public_key.0);
-            CompactCiphertextListBuilder(inner)
-        })
-    }
-
-    #[wasm_bindgen]
-    pub fn eq(&self, other: &ProvenCompactCiphertextList) -> bool {
-        self.0 == other.0
-    }
-
-    #[wasm_bindgen]
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    #[wasm_bindgen]
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
-    #[wasm_bindgen]
-    pub fn get_kind_of(&self, index: usize) -> Option<FheTypes> {
-        self.0.get_kind_of(index).map(Into::into)
-    }
-
-    #[wasm_bindgen]
-    pub fn verify_and_expand(
-        &self,
-        crs: &CompactPkeCrs,
-        public_key: &TfheCompactPublicKey,
-        metadata: &[u8],
-    ) -> Result<CompactCiphertextListExpander, JsError> {
-        catch_panic_result(|| {
-            let inner = self
-                .0
-                .verify_and_expand(&crs.0, &public_key.0, metadata)
-                .map_err(into_js_error)?;
-            Ok(CompactCiphertextListExpander(inner))
-        })
-    }
-
-    #[wasm_bindgen]
-    pub fn expand_without_verification(&self) -> Result<CompactCiphertextListExpander, JsError> {
-        catch_panic_result(|| {
-            let inner = self
-                .0
-                .expand_without_verification()
-                .map_err(into_js_error)?;
-            Ok(CompactCiphertextListExpander(inner))
-        })
-    }
-
-    #[wasm_bindgen]
-    pub fn safe_serialize(&self, serialized_size_limit: u64) -> Result<Vec<u8>, JsError> {
-        let mut buffer = vec![];
-        catch_panic_result(|| {
-            crate::safe_serialization::SerializationConfig::new(serialized_size_limit)
-                .serialize_into(&self.0, &mut buffer)
-                .map_err(into_js_error)
-        })?;
-
-        Ok(buffer)
-    }
-
-    #[wasm_bindgen]
-    pub fn safe_deserialize(
-        buffer: &[u8],
-        serialized_size_limit: u64,
-    ) -> Result<ProvenCompactCiphertextList, JsError> {
-        catch_panic_result(|| {
-            crate::safe_serialization::DeserializationConfig::new(serialized_size_limit)
-                .disable_conformance()
-                .deserialize_from(buffer)
-                .map(ProvenCompactCiphertextList)
-                .map_err(into_js_error)
-        })
-    }
-}
-
 /// Helper macro to define push methods for the builder
 ///
 /// The js_type must be a type that is "native" between rust and wasm_bindgen
+#[cfg(feature = "extended-types")]
 macro_rules! define_builder_push_method {
     (
         unsigned: {
@@ -1187,19 +986,6 @@ define_builder_push_method!(unsigned: {
     56 <= u64,
 });
 
-define_builder_push_method!(unsigned: {
-    2 <= u8,
-    4 <= u8,
-    6 <= u8,
-    8 <= u8,
-    10 <= u16,
-    12 <= u16,
-    14 <= u16,
-    16 <= u16,
-    32 <= u32,
-    64 <= u64,
-});
-
 #[cfg(feature = "extended-types")]
 define_builder_push_method!(signed: {
     24 <= i32,
@@ -1208,192 +994,8 @@ define_builder_push_method!(signed: {
     56 <= i64,
 });
 
-define_builder_push_method!(signed: {
-    2 <= i8,
-    4 <= i8,
-    6 <= i8,
-    8 <= i8,
-    10 <= i16,
-    12 <= i16,
-    14 <= i16,
-    16 <= i16,
-    32 <= i32,
-    64 <= i64,
-});
-
 #[wasm_bindgen]
 impl CompactCiphertextListBuilder {
-    #[wasm_bindgen]
-    pub fn push_u128(&mut self, value: JsValue) -> Result<(), JsError> {
-        catch_panic_result(|| {
-            let value = u128::try_from(value).map_err(into_js_error)?;
-            self.0.push(value);
-            Ok(())
-        })
-    }
-
-    #[wasm_bindgen]
-    pub fn push_u160(&mut self, value: JsValue) -> Result<(), JsError> {
-        catch_panic_result(|| {
-            let value = U256::try_from(value)?;
-            self.0.push_with_num_bits(value, 160)?;
-            Ok(())
-        })
-    }
-
-    #[wasm_bindgen]
-    pub fn push_u256(&mut self, value: JsValue) -> Result<(), JsError> {
-        catch_panic_result(|| {
-            let value = U256::try_from(value)?;
-            self.0.push(value);
-            Ok(())
-        })
-    }
-
-    #[wasm_bindgen]
-    pub fn push_u512(&mut self, value: JsValue) -> Result<(), JsError> {
-        catch_panic_result(|| {
-            let value = U512::try_from(value)?;
-            self.0.push(value);
-            Ok(())
-        })
-    }
-
-    #[wasm_bindgen]
-    pub fn push_u1024(&mut self, value: JsValue) -> Result<(), JsError> {
-        catch_panic_result(|| {
-            let value = U1024::try_from(value)?;
-            self.0.push(value);
-            Ok(())
-        })
-    }
-
-    #[wasm_bindgen]
-    pub fn push_u2048(&mut self, value: JsValue) -> Result<(), JsError> {
-        catch_panic_result(|| {
-            let value = U2048::try_from(value)?;
-            self.0.push(value);
-            Ok(())
-        })
-    }
-
-    #[wasm_bindgen]
-    pub fn push_i128(&mut self, value: JsValue) -> Result<(), JsError> {
-        catch_panic_result(|| {
-            let value = i128::try_from(value).map_err(into_js_error)?;
-            self.0.push(value);
-            Ok(())
-        })
-    }
-
-    #[wasm_bindgen]
-    pub fn push_i160(&mut self, value: JsValue) -> Result<(), JsError> {
-        catch_panic_result(|| {
-            let value = I256::try_from(value)?;
-            self.0.push_with_num_bits(value, 160)?;
-            Ok(())
-        })
-    }
-
-    #[wasm_bindgen]
-    pub fn push_i256(&mut self, value: JsValue) -> Result<(), JsError> {
-        catch_panic_result(|| {
-            let value = I256::try_from(value)?;
-            self.0.push(value);
-            Ok(())
-        })
-    }
-
-    #[wasm_bindgen]
-    pub fn push_i512(&mut self, value: JsValue) -> Result<(), JsError> {
-        catch_panic_result(|| {
-            let value = I512::try_from(value)?;
-            self.0.push(value);
-            Ok(())
-        })
-    }
-
-    #[wasm_bindgen]
-    pub fn push_i1024(&mut self, value: JsValue) -> Result<(), JsError> {
-        catch_panic_result(|| {
-            let value = I1024::try_from(value)?;
-            self.0.push(value);
-            Ok(())
-        })
-    }
-
-    #[wasm_bindgen]
-    pub fn push_i2048(&mut self, value: JsValue) -> Result<(), JsError> {
-        catch_panic_result(|| {
-            let value = I2048::try_from(value)?;
-            self.0.push(value);
-            Ok(())
-        })
-    }
-
-    #[wasm_bindgen]
-    pub fn push_boolean(&mut self, value: bool) -> Result<(), JsError> {
-        catch_panic(|| {
-            self.0.push(value);
-        })
-    }
-
-    #[wasm_bindgen]
-    pub fn build(&self) -> Result<CompactCiphertextList, JsError> {
-        catch_panic(|| {
-            let inner = self.0.build();
-            CompactCiphertextList(inner)
-        })
-    }
-
-    #[wasm_bindgen]
-    pub fn build_packed(&self) -> Result<CompactCiphertextList, JsError> {
-        catch_panic(|| {
-            let inner = self.0.build_packed();
-            CompactCiphertextList(inner)
-        })
-    }
-
-    #[wasm_bindgen]
-    pub fn build_packed_seeded(&self, seed: &[u8]) -> Result<CompactCiphertextList, JsError> {
-        catch_panic_result(|| {
-            let inner = self.0.build_packed_seeded(seed).map_err(into_js_error)?;
-            Ok(CompactCiphertextList(inner))
-        })
-    }
-
-    #[cfg(feature = "zk-pok")]
-    #[wasm_bindgen]
-    pub fn build_with_proof_packed(
-        &self,
-        crs: &CompactPkeCrs,
-        metadata: &[u8],
-        compute_load: ZkComputeLoad,
-    ) -> Result<ProvenCompactCiphertextList, JsError> {
-        catch_panic_result(|| {
-            self.0
-                .build_with_proof_packed(&crs.0, metadata, compute_load.into())
-                .map_err(into_js_error)
-                .map(ProvenCompactCiphertextList)
-        })
-    }
-
-    #[cfg(feature = "zk-pok")]
-    pub fn build_with_proof_packed_seeded(
-        &self,
-        crs: &CompactPkeCrs,
-        metadata: &[u8],
-        compute_load: ZkComputeLoad,
-        seed: &[u8],
-    ) -> Result<ProvenCompactCiphertextList, JsError> {
-        catch_panic_result(|| {
-            self.0
-                .build_with_proof_packed_seeded(&crs.0, metadata, compute_load.into(), seed)
-                .map_err(into_js_error)
-                .map(ProvenCompactCiphertextList)
-        })
-    }
-
     /// This function is like build_with_proof_packed, but can be called in cross origin
     /// from the main thread
     #[cfg(all(feature = "zk-pok", feature = "cross-origin-wasm-api"))]
@@ -1985,189 +1587,5 @@ impl CompactCiphertextListExpander {
     #[wasm_bindgen]
     pub fn get_kind_of(&self, index: usize) -> Option<FheTypes> {
         self.0.get_kind_of(index).map(Into::into)
-    }
-}
-
-#[wasm_bindgen]
-pub enum FheTypes {
-    Bool = 0,
-
-    Uint4 = 1,
-    Uint8 = 2,
-    Uint16 = 3,
-    Uint32 = 4,
-    Uint64 = 5,
-    Uint128 = 6,
-    Uint160 = 7,
-    Uint256 = 8,
-    Uint512 = 9,
-    Uint1024 = 10,
-    Uint2048 = 11,
-    Uint2 = 12,
-    Uint6 = 13,
-    Uint10 = 14,
-    Uint12 = 15,
-    Uint14 = 16,
-
-    Int2 = 17,
-    Int4 = 18,
-    Int6 = 19,
-    Int8 = 20,
-    Int10 = 21,
-    Int12 = 22,
-    Int14 = 23,
-    Int16 = 24,
-    Int32 = 25,
-    Int64 = 26,
-    Int128 = 27,
-    Int160 = 28,
-    Int256 = 29,
-    AsciiString = 30,
-
-    Int512 = 31,
-    Int1024 = 32,
-    Int2048 = 33,
-
-    Uint24 = 34,
-    Uint40 = 35,
-    Uint48 = 36,
-    Uint56 = 37,
-    Uint72 = 38,
-    Uint80 = 39,
-    Uint88 = 40,
-    Uint96 = 41,
-    Uint104 = 42,
-    Uint112 = 43,
-    Uint120 = 44,
-    Uint136 = 45,
-    Uint144 = 46,
-    Uint152 = 47,
-    Uint168 = 48,
-    Uint176 = 49,
-    Uint184 = 50,
-    Uint192 = 51,
-    Uint200 = 52,
-    Uint208 = 53,
-    Uint216 = 54,
-    Uint224 = 55,
-    Uint232 = 56,
-    Uint240 = 57,
-    Uint248 = 58,
-
-    Int24 = 59,
-    Int40 = 60,
-    Int48 = 61,
-    Int56 = 62,
-    Int72 = 63,
-    Int80 = 64,
-    Int88 = 65,
-    Int96 = 66,
-    Int104 = 67,
-    Int112 = 68,
-    Int120 = 69,
-    Int136 = 70,
-    Int144 = 71,
-    Int152 = 72,
-    Int168 = 73,
-    Int176 = 74,
-    Int184 = 75,
-    Int192 = 76,
-    Int200 = 77,
-    Int208 = 78,
-    Int216 = 79,
-    Int224 = 80,
-    Int232 = 81,
-    Int240 = 82,
-    Int248 = 83,
-}
-
-impl From<crate::FheTypes> for FheTypes {
-    fn from(value: crate::FheTypes) -> Self {
-        match value {
-            crate::FheTypes::Bool => Self::Bool,
-            crate::FheTypes::Uint2 => Self::Uint2,
-            crate::FheTypes::Uint4 => Self::Uint4,
-            crate::FheTypes::Uint6 => Self::Uint6,
-            crate::FheTypes::Uint8 => Self::Uint8,
-            crate::FheTypes::Uint10 => Self::Uint10,
-            crate::FheTypes::Uint12 => Self::Uint12,
-            crate::FheTypes::Uint14 => Self::Uint14,
-            crate::FheTypes::Uint16 => Self::Uint16,
-            crate::FheTypes::Uint24 => Self::Uint24,
-            crate::FheTypes::Uint32 => Self::Uint32,
-            crate::FheTypes::Uint40 => Self::Uint40,
-            crate::FheTypes::Uint48 => Self::Uint48,
-            crate::FheTypes::Uint56 => Self::Uint56,
-            crate::FheTypes::Uint64 => Self::Uint64,
-            crate::FheTypes::Uint72 => Self::Uint72,
-            crate::FheTypes::Uint80 => Self::Uint80,
-            crate::FheTypes::Uint88 => Self::Uint88,
-            crate::FheTypes::Uint96 => Self::Uint96,
-            crate::FheTypes::Uint104 => Self::Uint104,
-            crate::FheTypes::Uint112 => Self::Uint112,
-            crate::FheTypes::Uint120 => Self::Uint120,
-            crate::FheTypes::Uint128 => Self::Uint128,
-            crate::FheTypes::Uint136 => Self::Uint136,
-            crate::FheTypes::Uint144 => Self::Uint144,
-            crate::FheTypes::Uint152 => Self::Uint152,
-            crate::FheTypes::Uint160 => Self::Uint160,
-            crate::FheTypes::Uint168 => Self::Uint168,
-            crate::FheTypes::Uint176 => Self::Uint176,
-            crate::FheTypes::Uint184 => Self::Uint184,
-            crate::FheTypes::Uint192 => Self::Uint192,
-            crate::FheTypes::Uint200 => Self::Uint200,
-            crate::FheTypes::Uint208 => Self::Uint208,
-            crate::FheTypes::Uint216 => Self::Uint216,
-            crate::FheTypes::Uint224 => Self::Uint224,
-            crate::FheTypes::Uint232 => Self::Uint232,
-            crate::FheTypes::Uint240 => Self::Uint240,
-            crate::FheTypes::Uint248 => Self::Uint248,
-            crate::FheTypes::Uint256 => Self::Uint256,
-            crate::FheTypes::Uint512 => Self::Uint512,
-            crate::FheTypes::Uint1024 => Self::Uint1024,
-            crate::FheTypes::Uint2048 => Self::Uint2048,
-            crate::FheTypes::Int2 => Self::Int2,
-            crate::FheTypes::Int4 => Self::Int4,
-            crate::FheTypes::Int6 => Self::Int6,
-            crate::FheTypes::Int8 => Self::Int8,
-            crate::FheTypes::Int10 => Self::Int10,
-            crate::FheTypes::Int12 => Self::Int12,
-            crate::FheTypes::Int14 => Self::Int14,
-            crate::FheTypes::Int16 => Self::Int16,
-            crate::FheTypes::Int24 => Self::Int24,
-            crate::FheTypes::Int32 => Self::Int32,
-            crate::FheTypes::Int40 => Self::Int40,
-            crate::FheTypes::Int48 => Self::Int48,
-            crate::FheTypes::Int56 => Self::Int56,
-            crate::FheTypes::Int64 => Self::Int64,
-            crate::FheTypes::Int72 => Self::Int72,
-            crate::FheTypes::Int80 => Self::Int80,
-            crate::FheTypes::Int88 => Self::Int88,
-            crate::FheTypes::Int96 => Self::Int96,
-            crate::FheTypes::Int104 => Self::Int104,
-            crate::FheTypes::Int112 => Self::Int112,
-            crate::FheTypes::Int120 => Self::Int120,
-            crate::FheTypes::Int128 => Self::Int128,
-            crate::FheTypes::Int136 => Self::Int136,
-            crate::FheTypes::Int144 => Self::Int144,
-            crate::FheTypes::Int152 => Self::Int152,
-            crate::FheTypes::Int160 => Self::Int160,
-            crate::FheTypes::Int168 => Self::Int168,
-            crate::FheTypes::Int176 => Self::Int176,
-            crate::FheTypes::Int184 => Self::Int184,
-            crate::FheTypes::Int192 => Self::Int192,
-            crate::FheTypes::Int200 => Self::Int200,
-            crate::FheTypes::Int208 => Self::Int208,
-            crate::FheTypes::Int216 => Self::Int216,
-            crate::FheTypes::Int224 => Self::Int224,
-            crate::FheTypes::Int232 => Self::Int232,
-            crate::FheTypes::Int240 => Self::Int240,
-            crate::FheTypes::Int248 => Self::Int248,
-            crate::FheTypes::Int256 => Self::Int256,
-            crate::FheTypes::Int512 => Self::Int512,
-            crate::FheTypes::Int1024 => Self::Int1024,
-            crate::FheTypes::Int2048 => Self::Int2048,
-            crate::FheTypes::AsciiString => Self::AsciiString,
-        }
     }
 }

--- a/tfhe/src/js_on_wasm_api/js_high_level_api/keys.rs
+++ b/tfhe/src/js_on_wasm_api/js_high_level_api/keys.rs
@@ -1,13 +1,8 @@
 use crate::high_level_api as hlapi;
-use crate::js_on_wasm_api::js_high_level_api::config::TfheConfig;
-use crate::js_on_wasm_api::js_high_level_api::{catch_panic, catch_panic_result, into_js_error};
+use crate::js_on_wasm_api::client::{TfheClientKey, TfheCompactPublicKey};
 use crate::js_on_wasm_api::shortint::ShortintCompactPublicKeyEncryptionParameters;
+use crate::js_on_wasm_api::{catch_panic, catch_panic_result, into_js_error};
 use wasm_bindgen::prelude::*;
-
-#[wasm_bindgen]
-pub fn init_panic_hook() {
-    console_error_panic_hook::set_once();
-}
 
 /// Initialize a cross-origin worker pool for parallel computation.
 ///
@@ -67,56 +62,6 @@ pub async fn init_cross_origin_worker_pool_from_worker(
     wasm_par_mq::init_pool_sync_from_worker(num_workers)
         .await
         .map_err(|e| JsValue::from_str(&e))
-}
-
-#[wasm_bindgen]
-pub struct TfheClientKey(pub(crate) hlapi::ClientKey);
-
-#[wasm_bindgen]
-impl TfheClientKey {
-    #[wasm_bindgen]
-    pub fn generate(config: &TfheConfig) -> Result<TfheClientKey, JsError> {
-        catch_panic(|| Self(hlapi::ClientKey::generate(config.0)))
-    }
-
-    #[wasm_bindgen]
-    pub fn generate_with_seed(
-        config: &TfheConfig,
-        seed: JsValue,
-    ) -> Result<TfheClientKey, JsError> {
-        catch_panic_result(|| {
-            let seed =
-                u128::try_from(seed).map_err(|_| JsError::new("Value does not fit in a u128"))?;
-            let key = hlapi::ClientKey::generate_with_seed(config.0, crate::Seed(seed));
-            Ok(Self(key))
-        })
-    }
-
-    #[wasm_bindgen]
-    pub fn safe_serialize(&self, serialized_size_limit: u64) -> Result<Vec<u8>, JsError> {
-        let mut buffer = vec![];
-        catch_panic_result(|| {
-            crate::safe_serialization::SerializationConfig::new(serialized_size_limit)
-                .serialize_into(&self.0, &mut buffer)
-                .map_err(into_js_error)
-        })?;
-
-        Ok(buffer)
-    }
-
-    #[wasm_bindgen]
-    pub fn safe_deserialize(
-        buffer: &[u8],
-        serialized_size_limit: u64,
-    ) -> Result<TfheClientKey, JsError> {
-        catch_panic_result(|| {
-            crate::safe_serialization::DeserializationConfig::new(serialized_size_limit)
-                .disable_conformance()
-                .deserialize_from(buffer)
-                .map(Self)
-                .map_err(into_js_error)
-        })
-    }
 }
 
 // Wasm cannot generate a normal server key, only a compressed one
@@ -258,57 +203,6 @@ impl TfheCompressedPublicKey {
             crate::safe_serialization::DeserializationConfig::new(serialized_size_limit)
                 .disable_conformance()
                 .deserialize_from(buffer)
-                .map(Self)
-                .map_err(into_js_error)
-        })
-    }
-}
-
-#[wasm_bindgen]
-pub struct TfheCompactPublicKey(pub(crate) hlapi::CompactPublicKey);
-
-#[wasm_bindgen]
-impl TfheCompactPublicKey {
-    #[wasm_bindgen]
-    pub fn new(client_key: &TfheClientKey) -> Result<TfheCompactPublicKey, JsError> {
-        catch_panic(|| Self(hlapi::CompactPublicKey::new(&client_key.0)))
-    }
-
-    #[wasm_bindgen]
-    pub fn safe_serialize(&self, serialized_size_limit: u64) -> Result<Vec<u8>, JsError> {
-        let mut buffer = vec![];
-        catch_panic_result(|| {
-            crate::safe_serialization::SerializationConfig::new(serialized_size_limit)
-                .serialize_into(&self.0, &mut buffer)
-                .map_err(into_js_error)
-        })?;
-
-        Ok(buffer)
-    }
-
-    #[wasm_bindgen]
-    pub fn safe_deserialize(
-        buffer: &[u8],
-        serialized_size_limit: u64,
-    ) -> Result<TfheCompactPublicKey, JsError> {
-        catch_panic_result(|| {
-            crate::safe_serialization::DeserializationConfig::new(serialized_size_limit)
-                .disable_conformance()
-                .deserialize_from(buffer)
-                .map(Self)
-                .map_err(into_js_error)
-        })
-    }
-
-    #[wasm_bindgen]
-    pub fn safe_deserialize_conformant(
-        buffer: &[u8],
-        serialized_size_limit: u64,
-        conformance_params: &ShortintCompactPublicKeyEncryptionParameters,
-    ) -> Result<TfheCompactPublicKey, JsError> {
-        catch_panic_result(|| {
-            crate::safe_serialization::DeserializationConfig::new(serialized_size_limit)
-                .deserialize_from(buffer, &conformance_params.compact_pke_params)
                 .map(Self)
                 .map_err(into_js_error)
         })

--- a/tfhe/src/js_on_wasm_api/js_high_level_api/mod.rs
+++ b/tfhe/src/js_on_wasm_api/js_high_level_api/mod.rs
@@ -3,29 +3,10 @@ use wasm_bindgen::prelude::*;
 pub(crate) mod config;
 
 pub(crate) mod integers;
+
 // using Self does not work well with #[wasm_bindgen] macro
 #[allow(clippy::use_self)]
 pub(crate) mod keys;
-#[cfg(feature = "zk-pok")]
-mod zk;
-
-use super::into_js_error;
-
-pub(crate) fn catch_panic_result<F, R>(closure: F) -> Result<R, JsError>
-where
-    F: FnOnce() -> Result<R, JsError>,
-{
-    std::panic::catch_unwind(std::panic::AssertUnwindSafe(closure))
-        .unwrap_or_else(|_| Err(JsError::new("Operation Failed")))
-}
-
-pub(crate) fn catch_panic<F, R>(closure: F) -> Result<R, JsError>
-where
-    F: FnOnce() -> R,
-{
-    std::panic::catch_unwind(std::panic::AssertUnwindSafe(closure))
-        .map_or_else(|_| Err(JsError::new("Operation Failed")), |ret| Ok(ret))
-}
 
 #[wasm_bindgen]
 #[allow(non_camel_case_types)]

--- a/tfhe/src/js_on_wasm_api/mod.rs
+++ b/tfhe/src/js_on_wasm_api/mod.rs
@@ -1,3 +1,5 @@
+pub(crate) mod client;
+
 #[cfg(feature = "shortint-client-js-wasm-api")]
 mod shortint;
 
@@ -15,4 +17,22 @@ mod js_high_level_api;
 
 pub(crate) fn into_js_error<E: std::fmt::Debug>(e: E) -> wasm_bindgen::JsError {
     wasm_bindgen::JsError::new(format!("{e:?}").as_str())
+}
+
+pub(crate) fn catch_panic_result<F, R>(closure: F) -> Result<R, wasm_bindgen::JsError>
+where
+    F: FnOnce() -> Result<R, wasm_bindgen::JsError>,
+{
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(closure))
+        .unwrap_or_else(|_| Err(wasm_bindgen::JsError::new("Operation Failed")))
+}
+
+pub(crate) fn catch_panic<F, R>(closure: F) -> Result<R, wasm_bindgen::JsError>
+where
+    F: FnOnce() -> R,
+{
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(closure)).map_or_else(
+        |_| Err(wasm_bindgen::JsError::new("Operation Failed")),
+        |ret| Ok(ret),
+    )
 }


### PR DESCRIPTION
# Creation of the client wasm package
this is following this [issue](https://github.com/zama-ai/tfhe-rs-internal/issues/1394)

## Client package

I create a dedicated folder client in js_high_level_api lived
if you activate few feature you will only support what's inside it which is what we want

Also in the makefile/cargo.toml some optimization has been made to reduce the size a little bit more (only Oz in fine)

some extra function have been added from my perspective for example I found it weird to have TfheClientKey needed for TfheCompactPublicKey and not bring all the creation or parsing process for TfheClientKey
This is something open to the discussion of course (not sure it make the package heavier a lot)

we went from 4237274 bytes to 1348195 bytes which is a reduction of almost 70%

## tooling

I also moved the makefile part inside a file under make/... to make it more readable for everyone

I also used it has a reviewer to correct my code before going in PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3557)
<!-- Reviewable:end -->
