### PR TITLE
chore(versionable): bump to 0.8.0

### DIFF
--- a/tfhe-csprng/Cargo.toml
+++ b/tfhe-csprng/Cargo.toml
@@ -16,7 +16,7 @@ aes = "0.8.2"
 rayon = { workspace = true, optional = true }
 getrandom = { workspace = true }
 serde = "1.0.226"
-tfhe-versionable = { version = "0.7.0", path = "../utils/tfhe-versionable" }
+tfhe-versionable = { version = "0.8.0", path = "../utils/tfhe-versionable" }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 libc = "0.2.133"

--- a/tfhe-zk-pok/Cargo.toml
+++ b/tfhe-zk-pok/Cargo.toml
@@ -23,7 +23,7 @@ sha3 = "0.10.8"
 serde = { workspace = true, features = ["default", "derive"] }
 zeroize = "1.7.0"
 num-bigint = "0.4.5"
-tfhe-versionable = { version = "0.7.0", path = "../utils/tfhe-versionable" }
+tfhe-versionable = { version = "0.8.0", path = "../utils/tfhe-versionable" }
 tfhe-safe-serialize = { version = "0.1.0", path = "../utils/tfhe-safe-serialize" }
 zk-cuda-backend = { version = "0.2.0", path = "../backends/zk-cuda-backend", optional = true }
 tfhe-cuda-common = { version = "0.1.0", path = "../backends/tfhe-cuda-common", optional = true }

--- a/tfhe/Cargo.toml
+++ b/tfhe/Cargo.toml
@@ -79,7 +79,7 @@ itertools = { workspace = true }
 rand_core = { version = "0.6.4", features = ["std"] }
 strum = { version = "0.27", features = ["derive"], optional = true }
 tfhe-zk-pok = { version = "0.8.1", path = "../tfhe-zk-pok", optional = true }
-tfhe-versionable = { version = "0.7.0", path = "../utils/tfhe-versionable" }
+tfhe-versionable = { version = "0.8.0", path = "../utils/tfhe-versionable" }
 tfhe-safe-serialize = { version = "0.1.0", path = "../utils/tfhe-safe-serialize" }
 
 # wasm deps

--- a/utils/tfhe-lints/lints/Cargo.toml
+++ b/utils/tfhe-lints/lints/Cargo.toml
@@ -17,7 +17,7 @@ tfhe-lints-common = { path = "../common" }
 [dev-dependencies]
 dylint_testing = "5.0.0"
 serde = { version = "1.0", features = ["derive"] }
-tfhe-versionable = { version = "0.7.0", path = "../../tfhe-versionable" }
+tfhe-versionable = { version = "0.8.0", path = "../../tfhe-versionable" }
 
 [package.metadata.rust-analyzer]
 rustc_private = true

--- a/utils/tfhe-lints/snapshot/Cargo.toml
+++ b/utils/tfhe-lints/snapshot/Cargo.toml
@@ -20,7 +20,7 @@ sha2 = "0.10"
 [dev-dependencies]
 dylint_testing = "5.0.0"
 serde = { version = "1.0", features = ["derive"] }
-tfhe-versionable = { version = "0.7.0", path = "../../tfhe-versionable" }
+tfhe-versionable = { version = "0.8.0", path = "../../tfhe-versionable" }
 
 [package.metadata.rust-analyzer]
 rustc_private = true

--- a/utils/tfhe-safe-serialize/Cargo.toml
+++ b/utils/tfhe-safe-serialize/Cargo.toml
@@ -18,4 +18,4 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 [dependencies]
 bincode.workspace = true
 serde.workspace = true
-tfhe-versionable = { version = "0.7.0", path = "../tfhe-versionable" }
+tfhe-versionable = { version = "0.8.0", path = "../tfhe-versionable" }

--- a/utils/tfhe-versionable-derive/Cargo.toml
+++ b/utils/tfhe-versionable-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tfhe-versionable-derive"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 keywords = ["versioning", "serialization", "encoding", "proc-macro", "derive"]
 homepage = "https://zama.org/"

--- a/utils/tfhe-versionable/Cargo.toml
+++ b/utils/tfhe-versionable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tfhe-versionable"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 keywords = ["versioning", "serialization", "encoding"]
 homepage = "https://zama.org/"
@@ -26,7 +26,7 @@ toml = "0.8"
 
 [dependencies]
 serde = { workspace = true, features = ["default", "derive"] }
-tfhe-versionable-derive = { version = "0.7.0", path = "../tfhe-versionable-derive" }
+tfhe-versionable-derive = { version = "0.8.0", path = "../tfhe-versionable-derive" }
 num-complex = { workspace = true, features = ["serde"] }
 aligned-vec = { workspace = true, features = ["default", "serde"] }
 


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description
bump tfhe-versionable and derive crates to 0.8.0
