### PR TITLE
chore(ci): bump slab-action-runner to v1.6.2

### DIFF
--- a/.github/workflows/gpu_zk_long_run_tests.yml
+++ b/.github/workflows/gpu_zk_long_run_tests.yml
@@ -64,7 +64,7 @@ jobs:
     steps:
       - name: Start instance
         id: start-instance
-        uses: zama-ai/slab-github-runner@0a812986560d3f10dc65728b1ccb9ae4c48a8a16 # v1.5.1
+        uses: zama-ai/slab-github-runner@86c9d2378700ca356455e36ebb97b61e958ea47b # v1.6.2
         with:
           mode: start
           github-token: ${{ secrets.SLAB_ACTION_TOKEN }}
@@ -139,7 +139,7 @@ jobs:
     steps:
       - name: Stop instance
         id: stop-instance
-        uses: zama-ai/slab-github-runner@0a812986560d3f10dc65728b1ccb9ae4c48a8a16 # v1.5.1
+        uses: zama-ai/slab-github-runner@86c9d2378700ca356455e36ebb97b61e958ea47b # v1.6.2
         with:
           mode: stop
           github-token: ${{ secrets.SLAB_ACTION_TOKEN }}


### PR DESCRIPTION
This file was missed by global search and replace during the recent update.