### PR TITLE
chore(ci): add formatter for kvstore benchmarks

### DIFF
--- a/.github/workflows/benchmark_documentation.yml
+++ b/.github/workflows/benchmark_documentation.yml
@@ -88,6 +88,25 @@ jobs:
       SLAB_URL: ${{ secrets.SLAB_URL }}
       SLAB_BASE_URL: ${{ secrets.SLAB_BASE_URL }}
 
+  run-benchmarks-cpu-kvstore:
+    name: benchmark_documentation/run-benchmarks-cpu-kvstore
+    uses: ./.github/workflows/benchmark_cpu_common.yml
+    if: inputs.run-cpu-benchmarks
+    with:
+      command: hlapi_kvstore
+      op_flavor: default
+      bench_type: latency
+      precisions_set: all
+    secrets:
+      BOT_USERNAME: ${{ secrets.BOT_USERNAME }}
+      SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+      REPO_CHECKOUT_TOKEN: ${{ secrets.REPO_CHECKOUT_TOKEN }}
+      JOB_SECRET: ${{ secrets.JOB_SECRET }}
+      SLAB_ACTION_TOKEN: ${{ secrets.SLAB_ACTION_TOKEN }}
+      SLAB_URL: ${{ secrets.SLAB_URL }}
+      SLAB_BASE_URL: ${{ secrets.SLAB_BASE_URL }}
+
   run-benchmarks-gpu-integer:
     name: benchmark_documentation/run-benchmarks-gpu-integer
     uses: ./.github/workflows/benchmark_gpu_common.yml
@@ -197,6 +216,7 @@ jobs:
     needs: [
       run-benchmarks-cpu-integer, run-benchmarks-gpu-integer, run-benchmarks-hpu-integer,
       run-benchmarks-cpu-zk-server, run-benchmarks-cpu-zk-client,
+      run-benchmarks-cpu-kvstore,
       run-benchmarks-cpu-core-crypto, run-benchmarks-gpu-core-crypto,
       run-benchmarks-gpu-zk-server
     ]

--- a/.github/workflows/generate_svgs.yml
+++ b/.github/workflows/generate_svgs.yml
@@ -307,6 +307,28 @@ jobs:
       DATA_EXTRACTOR_DATABASE_PASSWORD: ${{ secrets.DATA_EXTRACTOR_DATABASE_PASSWORD }}
 
   # -----------------------------------------------------------
+  # KVStore benchmarks tables
+  # -----------------------------------------------------------
+
+  cpu-kvstore-latency-table:
+    name: generate_documentation_svgs/cpu-kvstore-latency-table
+    uses: ./.github/workflows/generate_svg_common.yml
+    if: inputs.generate-cpu-svgs
+    with:
+      backend: cpu
+      hardware_name: hpc7a.96xlarge
+      layer: hlapi
+      bench_subset: kv_store
+      pbs_kind: classical
+      bench_type: latency
+      time_span_days: ${{ inputs.time_span_days }}
+      output_filename: cpu-hlapi-kvstore-benchmark-latency
+    secrets:
+      DATA_EXTRACTOR_DATABASE_USER: ${{ secrets.DATA_EXTRACTOR_DATABASE_USER }}
+      DATA_EXTRACTOR_DATABASE_HOST: ${{ secrets.DATA_EXTRACTOR_DATABASE_HOST }}
+      DATA_EXTRACTOR_DATABASE_PASSWORD: ${{ secrets.DATA_EXTRACTOR_DATABASE_PASSWORD }}
+
+  # -----------------------------------------------------------
   # PBS benchmarks tables
   # -----------------------------------------------------------
 

--- a/ci/data_extractor/src/benchmark_specs.py
+++ b/ci/data_extractor/src/benchmark_specs.py
@@ -304,6 +304,7 @@ class BenchSubset(enum.StrEnum):
     All = "all"
     Erc7984 = "erc7984"
     Zk = "zk"
+    KVStore = "kv_store"
 
     @staticmethod
     def from_str(bench_subset):
@@ -314,6 +315,8 @@ class BenchSubset(enum.StrEnum):
                 return BenchSubset.Erc7984
             case "zk":
                 return BenchSubset.Zk
+            case "kv_store":
+                return BenchSubset.KVStore
             case _:
                 raise ValueError(f"BenchSubset '{bench_subset}' not supported")
 

--- a/ci/data_extractor/src/data_extractor.py
+++ b/ci/data_extractor/src/data_extractor.py
@@ -137,7 +137,7 @@ parser.add_argument(
 parser.add_argument(
     "--bench-subset",
     dest="bench_subset",
-    choices=["all", "erc7984", "zk"],
+    choices=["all", "erc7984", "zk", "kv_store"],
     default="all",
     help="Subset of benchmarks to filter against, dedicated formatting will be applied",
 )
@@ -292,6 +292,8 @@ def get_formatter(layer: Layer, bench_subset: BenchSubset):
                 return formatters.wasm.ZKFormatter
             else:
                 return formatters.integer.ZKFormatter
+        case BenchSubset.KVStore:
+            return formatters.hlapi.KVStoreFormatter
 
     match layer:
         case Layer.Integer:
@@ -442,7 +444,7 @@ def get_operands_types(layer: Layer, bench_subset: BenchSubset = None):
         return ciphertext_only
     elif bench_subset:
         match bench_subset:
-            case BenchSubset.Zk | BenchSubset.Erc7984:
+            case BenchSubset.Zk | BenchSubset.Erc7984 | BenchSubset.KVStore:
                 return ciphertext_only
             case BenchSubset.All:
                 return ciphertext_and_plaintext

--- a/ci/data_extractor/src/formatters/hlapi/hlapi.py
+++ b/ci/data_extractor/src/formatters/hlapi/hlapi.py
@@ -1,6 +1,7 @@
 import collections
+from collections.abc import Callable
 
-from benchmark_specs import Backend, BenchDetails, BenchType
+from benchmark_specs import Backend, BenchDetails, BenchType, RustType
 from formatters.common import BenchArray, GenericFormatter
 
 import utils
@@ -87,3 +88,85 @@ class Erc7984Formatter(HlApiFormatter):
         return [
             BenchArray(result_lines, self.layer),
         ]
+
+
+OPERATIONS_DISPLAYS = [
+    "get",
+    "update",
+    "map",
+]
+
+DEFAULT_STORE_SIZE = (
+    2,
+    4,
+    8,
+    16,
+    32,
+    64,
+    128,
+    256,
+    512,
+    1024,
+)
+
+DEFAULT_KVSTORE_VALUE_SIZE = lambda: {
+    8: "N/A",
+    16: "N/A",
+    32: "N/A",
+    64: "N/A",
+    128: "N/A",
+}
+
+
+STORE_SIZE_COLUMN_HEADER = "Store size \\ Value"
+
+
+class KVStoreFormatter(HlApiFormatter):
+    """
+    Formatter for Key-Value store benchmarks.
+    """
+
+    @staticmethod
+    def _format_data(data: dict[BenchDetails : list[int]], conversion_func):
+        results_dict = {}
+
+        for op in OPERATIONS_DISPLAYS:
+            results_dict[op] = {
+                size: DEFAULT_KVSTORE_VALUE_SIZE() for size in DEFAULT_STORE_SIZE
+            }
+
+        for details, timings in data.items():
+            test_name = details.operation_name.lstrip("kv_store::")
+            # This is a hack to get the array size and the precision of the value.
+            # It would be fixed once the data extractor would be rewritten in Rust
+            # thanks to the benchmark specs.
+            case_variation = details.rust_type.split("_")
+            array_size = int(case_variation[-1])
+            value_size = int(case_variation[-3].lstrip("FheUint"))
+            value = conversion_func(timings[-1])
+            results_dict[test_name][array_size][value_size] = value
+
+        return results_dict
+
+    def _generate_arrays(self, data, *args, **kwargs):
+        first_column_header = STORE_SIZE_COLUMN_HEADER
+
+        arrays = []
+
+        for op_name in data.keys():
+            result_lines = []
+            for array_size, values in data[op_name].items():
+                line = {first_column_header: str(array_size)}
+                line.update(
+                    {
+                        RustType.from_int(bench_type).name: v
+                        for bench_type, v in values.items()
+                    }
+                )
+                result_lines.append(line)
+
+            bench_array = BenchArray(result_lines, self.layer)
+            bench_array.metadata = {"operation": op_name}
+            arrays.append(bench_array)
+
+        return arrays


### PR DESCRIPTION
Also add automatic benchmlark run and SVG generation in documentation benchmarks workflow.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3568)
<!-- Reviewable:end -->
