### PR TITLE
chore(ci): fix pcc matrix results handling

### DIFF
--- a/.github/workflows/cargo_build.yml
+++ b/.github/workflows/cargo_build.yml
@@ -141,22 +141,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check all builds success
-        if: needs.parallel-pcc-cpu.outputs.builds-result == 'success' &&
-          needs.pcc-hpu.outputs.builds-result == 'success' &&
-          needs.build-tfhe-full.outputs.builds-result == 'success' &&
-          needs.build.outputs.builds-result == 'success' &&
-          needs.build-layers.outputs.builds-result == 'success' &&
-          needs.build-c-api.outputs.builds-result == 'success'
+        if: needs.parallel-pcc-cpu.result == 'success' &&
+          needs.pcc-hpu.result == 'success' &&
+          needs.build-tfhe-full.result == 'success' &&
+          needs.build.result == 'success' &&
+          needs.build-layers.result == 'success' &&
+          needs.build-c-api.result == 'success'
         run: |
           echo "All tfhe-rs build checks passed"
 
       - name: Check builds failure
-        if: needs.parallel-pcc-cpu.outputs.builds-result != 'success' ||
-          needs.pcc-hpu.outputs.builds-result != 'success' ||
-          needs.build-tfhe-full.outputs.builds-result != 'success' ||
-          needs.build.outputs.builds-result != 'success' ||
-          needs.build-layers.outputs.builds-result != 'success' ||
-          needs.build-c-api.outputs.builds-result != 'success'
+        if: needs.parallel-pcc-cpu.result != 'success' ||
+          needs.pcc-hpu.result != 'success' ||
+          needs.build-tfhe-full.result != 'success' ||
+          needs.build.result != 'success' ||
+          needs.build-layers.result != 'success' ||
+          needs.build-c-api.result != 'success'
         run: |
           echo "Some tfhe-rs build checks failed"
           exit 1

--- a/.github/workflows/cargo_build_common.yml
+++ b/.github/workflows/cargo_build_common.yml
@@ -23,10 +23,6 @@ on:
       extra-runners-to-use: # Additional runners to run builds command against
         type: string # Use comma separated values to generate an array
         default: ""
-    outputs:
-      builds-result:
-        description: "Result of builds job"
-        value: ${{ jobs.builds.outputs.result }}
     secrets:
       REPO_CHECKOUT_TOKEN:
         required: true
@@ -109,8 +105,6 @@ jobs:
       matrix:
         runner: ${{ fromJSON(needs.prepare-matrix.outputs.runners) }}
       fail-fast: false
-    outputs:
-      result: ${{ steps.set_builds_result.outputs.result }}
     steps:
       - name: Checkout tfhe-rs repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -227,9 +221,3 @@ jobs:
 
       # The wasm build check is a bit annoying to set-up here and is done during the tests in
       # aws_tfhe_tests.yml
-
-      - name: Set result output
-        id: set_builds_result
-        if: ${{ always() }}
-        run: | # zizmor: ignore[template-injection] this context variable is safe
-          echo "result=${{ job.status }}" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
The usage of 'builds-result' workflow output came from the need to treat instance teardown failures as infra issue not a CI one. Thus if the build was green but the teardown failed, the dev could see the CI pipeline as green.

However this design had a issue. When multiple jobs were running in parallel via the 'runners' matrix, the 'builds-result' output would be set by the job that finished last. So if a quicker job had failed, the 'failure' status would be overwritten by the one that finished successfully a bit later.
    
Since teardown is not an issue anymore, thanks to the usage of runson service, we can rely on the regular job result instead of using workflow outputs as a medium.