### PR TITLE
feat(gpu): noise check tests on L40

### DIFF
--- a/.github/workflows/gpu_l40_noise_check_tests.yml
+++ b/.github/workflows/gpu_l40_noise_check_tests.yml
@@ -1,0 +1,200 @@
+# Run signed and unsigned GPU integer tests with the gpu-debug-noise-check
+# feature so that the CHECK_NOISE_LEVEL assertions in the CUDA backend are
+# active, without the multi-GPU emulation that requires a multi-GPU host.
+# Runs on a single L40 Hyperstack instance, triggered automatically on every PR
+# that touches GPU code, alongside gpu_fast_tests.
+name: gpu_l40_noise_check_tests
+
+env:
+  CARGO_TERM_COLOR: always
+  ACTION_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+  RUSTFLAGS: "-C target-cpu=native"
+  RUST_BACKTRACE: "full"
+  RUST_MIN_STACK: "8388608"
+  SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
+  SLACK_ICON: https://pbs.twimg.com/profile_images/1274014582265298945/OjBKP9kn_400x400.png
+  SLACK_USERNAME: ${{ secrets.BOT_USERNAME }}
+  SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+  SLACKIFY_MARKDOWN: true
+  IS_PULL_REQUEST: ${{ github.event_name == 'pull_request' }}
+  PULL_REQUEST_MD_LINK: ""
+  CHECKOUT_TOKEN: ${{ secrets.REPO_CHECKOUT_TOKEN || secrets.GITHUB_TOKEN }}
+  # Secrets will be available only to zama-ai organization members
+  SECRETS_AVAILABLE: ${{ secrets.JOB_SECRET != '' }}
+  EXTERNAL_CONTRIBUTION_RUNNER: "gpu_ubuntu-22.04"
+  GPU_FEATURE: gpu-debug-noise-check
+  FAST_TESTS: TRUE
+  NIGHTLY_TESTS: FALSE
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+permissions:
+  contents: read
+
+# zizmor: ignore[concurrency-limits] concurrency is managed after instance setup to ensure safe provisioning
+
+jobs:
+  should-run:
+    name: gpu_l40_noise_check_tests/should-run
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read  # Needed to check for file change
+    outputs:
+      gpu_test: ${{ env.IS_PULL_REQUEST == 'false' || steps.changed-files.outputs.gpu_any_changed }}
+    steps:
+      - name: Checkout tfhe-rs
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+          persist-credentials: 'false'
+          token: ${{ env.CHECKOUT_TOKEN }}
+
+      - name: Check for file changes
+        id: changed-files
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
+        with:
+          files_yaml: |
+            gpu:
+              - tfhe/Cargo.toml
+              - tfhe/build.rs
+              - backends/tfhe-cuda-backend/**
+              - tfhe/src/core_crypto/gpu/**
+              - tfhe/src/integer/gpu/**
+              - tfhe/src/integer/server_key/radix_parallel/tests_unsigned/**
+              - tfhe/src/integer/server_key/radix_parallel/tests_signed/**
+              - tfhe/src/integer/server_key/radix_parallel/tests_cases_unsigned.rs
+              - tfhe/src/shortint/parameters/**
+              - tfhe/src/c_api/**
+              - '.github/workflows/gpu_l40_noise_check_tests.yml'
+              - scripts/integer-tests.sh
+
+  setup-instance:
+    name: gpu_l40_noise_check_tests/setup-instance
+    needs: should-run
+    if: github.event_name == 'workflow_dispatch' ||
+      needs.should-run.outputs.gpu_test == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      runner-name: ${{ steps.start-remote-instance.outputs.label || steps.start-github-instance.outputs.runner_group }}
+      cloud-provider: ${{ steps.start-remote-instance.outputs.cloud-provider || steps.start-github-instance.outputs.cloud-provider }}
+    steps:
+      - name: Start remote instance
+        id: start-remote-instance
+        if: env.SECRETS_AVAILABLE == 'true'
+        uses: zama-ai/slab-github-runner@86c9d2378700ca356455e36ebb97b61e958ea47b # v1.6.2
+        with:
+          mode: start
+          github-token: ${{ secrets.SLAB_ACTION_TOKEN }}
+          slab-url: ${{ secrets.SLAB_BASE_URL }}
+          job-secret: ${{ secrets.JOB_SECRET }}
+          backend: hyperstack
+          profile: l40
+
+      # This instance will be spawned especially for pull-request from forked repository
+      - name: Start GitHub instance
+        id: start-github-instance
+        if: env.SECRETS_AVAILABLE == 'false'
+        run: |
+          {
+            echo "runner_group=${EXTERNAL_CONTRIBUTION_RUNNER}";
+            echo "cloud-provider=github";
+          } >> "$GITHUB_OUTPUT"
+
+  cuda-noise-check-tests:
+    name: gpu_l40_noise_check_tests/cuda-noise-check-tests
+    needs: [ should-run, setup-instance ]
+    if: github.event_name != 'pull_request' ||
+      (github.event_name == 'pull_request' && needs.setup-instance.result != 'skipped')
+    concurrency:
+      group: ${{ github.workflow_ref }}
+      cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+    runs-on: ${{ needs.setup-instance.outputs.runner-name }}
+    timeout-minutes: 720 # 12 hours
+    strategy:
+      fail-fast: false
+      # explicit include-based build matrix, of known valid options
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            cuda: "12.8"
+            gcc: 11
+    steps:
+      - name: Checkout tfhe-rs
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: 'false'
+          token: ${{ env.CHECKOUT_TOKEN }}
+
+      - name: Setup Hyperstack dependencies
+        uses: ./.github/actions/gpu_setup
+        with:
+          cuda-version: ${{ matrix.cuda }}
+          gcc-version: ${{ matrix.gcc }}
+          cloud-provider: ${{ needs.setup-instance.outputs.cloud-provider }}
+
+      - name: Install latest stable
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # zizmor: ignore[stale-action-refs] this action doesn't create releases
+        with:
+          toolchain: stable
+
+      - name: Enable nvidia multi-process service
+        run: |
+          nvidia-cuda-mps-control -d
+
+      - name: Build integer GPU tests (gpu-debug-noise-check)
+        run: |
+          cargo test --no-run --release --no-default-features \
+            --features=integer,internal-keycache,zk-pok,experimental,"${GPU_FEATURE}" \
+            -p tfhe
+
+      - name: Run integer GPU tests with noise checks enabled
+        run: |
+          make test_integer_gpu_ci
+
+  slack-notify:
+    name: gpu_l40_noise_check_tests/slack-notify
+    needs: [ setup-instance, cuda-noise-check-tests ]
+    runs-on: ubuntu-latest
+    if: ${{ always() && needs.cuda-noise-check-tests.result != 'skipped' && failure() }}
+    continue-on-error: true
+    steps:
+      - name: Set pull-request URL
+        if: env.SECRETS_AVAILABLE == 'true' && github.event_name == 'pull_request'
+        run: |
+          echo "PULL_REQUEST_MD_LINK=[pull-request](${PR_BASE_URL}${PR_NUMBER}), "  >> "${GITHUB_ENV}"
+        env:
+          PR_BASE_URL: ${{ vars.PR_BASE_URL }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+
+      - name: Send message
+        if: env.SECRETS_AVAILABLE == 'true'
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661
+        env:
+          SLACK_COLOR: ${{ needs.cuda-noise-check-tests.result }}
+          SLACK_MESSAGE: "GPU L40 noise check tests finished with status: ${{ needs.cuda-noise-check-tests.result }}. (${{ env.PULL_REQUEST_MD_LINK }}[action run](${{ env.ACTION_RUN_URL }}))"
+
+  teardown-instance:
+    name: gpu_l40_noise_check_tests/teardown-instance
+    if: ${{ always() && needs.setup-instance.result == 'success' }}
+    needs: [ setup-instance, cuda-noise-check-tests ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Stop remote instance
+        id: stop-instance
+        if: env.SECRETS_AVAILABLE == 'true'
+        uses: zama-ai/slab-github-runner@86c9d2378700ca356455e36ebb97b61e958ea47b # v1.6.2
+        with:
+          mode: stop
+          github-token: ${{ secrets.SLAB_ACTION_TOKEN }}
+          slab-url: ${{ secrets.SLAB_BASE_URL }}
+          job-secret: ${{ secrets.JOB_SECRET }}
+          label: ${{ needs.setup-instance.outputs.runner-name }}
+
+      - name: Slack Notification
+        if: ${{ failure() }}
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661
+        env:
+          SLACK_COLOR: ${{ job.status }}
+          SLACK_MESSAGE: "Instance teardown (gpu-l40-noise-check) finished with status: ${{ job.status }}. (${{ env.ACTION_RUN_URL }})"

--- a/backends/tfhe-cuda-backend/Cargo.toml
+++ b/backends/tfhe-cuda-backend/Cargo.toml
@@ -23,4 +23,5 @@ bindgen.workspace = true
 experimental-multi-arch = []
 profile = ["tfhe-cuda-common/profile"]
 debug = ["tfhe-cuda-common/debug"]
-debug-fake-multi-gpu = []
+debug-noise-check = []
+debug-fake-multi-gpu = ["debug-noise-check"]

--- a/backends/tfhe-cuda-backend/build.rs
+++ b/backends/tfhe-cuda-backend/build.rs
@@ -50,6 +50,9 @@ fn main() {
             cmake_config.define("CMAKE_BUILD_TYPE", "DebugOnlyCpu");
             cmake_config.define("CMAKE_VERBOSE_MAKEFILE", "ON");
             cmake_config.define("FAKE_MULTI_GPU", "ON");
+            cmake_config.define("NOISE_CHECK", "ON");
+        } else if cfg!(feature = "debug-noise-check") {
+            cmake_config.define("NOISE_CHECK", "ON");
         }
 
         // Propagated by Cargo from tfhe-cuda-common/build.rs

--- a/backends/tfhe-cuda-backend/cuda/CMakeLists.txt
+++ b/backends/tfhe-cuda-backend/cuda/CMakeLists.txt
@@ -110,6 +110,11 @@ if(${FAKE_MULTI_GPU})
   add_definitions(-DDEBUG_FAKE_MULTI_GPU)
 endif()
 
+if(${NOISE_CHECK})
+  message(STATUS "Noise-level assertions are enabled")
+  add_definitions(-DDEBUG_NOISE_CHECK)
+endif()
+
 # in production, should use -arch=sm_70 --ptxas-options=-v to see register spills -lineinfo for better debugging to use
 # nvtx when profiling -lnvToolsExt
 set(CMAKE_CUDA_FLAGS

--- a/backends/tfhe-cuda-backend/cuda/include/integer/integer_utilities.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer/integer_utilities.h
@@ -77,7 +77,8 @@ public:
   static const uint64_t UNKNOWN = std::numeric_limits<uint64_t>::max();
 };
 
-#ifdef DEBUG
+#if defined(DEBUG) || defined(DEBUG_FAKE_MULTI_GPU) ||                         \
+    defined(DEBUG_NOISE_CHECK)
 #define CHECK_NOISE_LEVEL(noise_level_expr, msg_mod, carry_mod)                \
   do {                                                                         \
     if ((msg_mod) == 2 && (carry_mod) == 2) {                                  \

--- a/scripts/integer-tests.sh
+++ b/scripts/integer-tests.sh
@@ -123,7 +123,7 @@ if [[ "${NO_BIG_PARAMS_GPU}" == TRUE ]]; then
 fi
 
 if [[ "${backend}" == "gpu" ]]; then
-    gpu_feature="gpu"
+    gpu_feature="${GPU_FEATURE:-gpu}"
 fi
 
 CURR_DIR="$(dirname "$0")"

--- a/tfhe/Cargo.toml
+++ b/tfhe/Cargo.toml
@@ -116,7 +116,11 @@ gpu-experimental-multi-arch = [
 ]
 gpu-profile = ["gpu", "tfhe-cuda-backend/profile"]
 gpu-debug = ["gpu", "tfhe-cuda-backend/debug"]
-gpu-debug-fake-multi-gpu = ["gpu", "tfhe-cuda-backend/debug-fake-multi-gpu"]
+gpu-debug-noise-check = ["gpu", "tfhe-cuda-backend/debug-noise-check"]
+gpu-debug-fake-multi-gpu = [
+    "gpu-debug-noise-check",
+    "tfhe-cuda-backend/debug-fake-multi-gpu",
+]
 zk-pok = ["dep:tfhe-zk-pok"]
 # Start Fpga Hpu features
 hpu = ["dep:tfhe-hpu-backend", "shortint", "integer"]

--- a/tfhe/src/integer/gpu/server_key/radix/tests_long_run/mod.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/tests_long_run/mod.rs
@@ -1,5 +1,7 @@
 use crate::core_crypto::commons::generators::DeterministicSeeder;
-use crate::core_crypto::gpu::{get_number_of_gpus, CudaStreams};
+#[cfg(not(feature = "gpu-debug-fake-multi-gpu"))]
+use crate::core_crypto::gpu::get_number_of_gpus;
+use crate::core_crypto::gpu::CudaStreams;
 use crate::integer::gpu::ciphertext::boolean_value::CudaBooleanBlock;
 use crate::integer::gpu::ciphertext::{CudaSignedRadixCiphertext, CudaUnsignedRadixCiphertext};
 use crate::integer::gpu::server_key::radix::tests_unsigned::GpuContext;


### PR DESCRIPTION
Noise check is done with the `gpu-debug-noise-check` feature, which enables the `CHECK_NOISE_LEVEL` assertions in the CUDA backend.

New workflow on a Hyperstack L40 instance that runs the signed and unsigned integer GPU tests with this feature. It is triggered automatically on every PR that touches GPU code (file-change filter, no label gate), alongside `gpu_fast_tests`. External (forked) PRs fall back to the GitHub-hosted `gpu_ubuntu-22.04` runner.