### PR TITLE
Am/feat/prf rerand

### DIFF
--- a/tfhe-benchmark/benches/shortint/oprf.rs
+++ b/tfhe-benchmark/benches/shortint/oprf.rs
@@ -21,7 +21,7 @@ fn oprf(c: &mut Criterion) {
 
     bench_group.bench_function(format!("2-bits-oprf::{}", param.name()), |b| {
         b.iter(|| {
-            _ = black_box(oprf_sk.generate_oblivious_pseudo_random(Seed(0), 2, sks));
+            _ = black_box(oprf_sk.generate_oblivious_pseudo_random_bits_chunks(Seed(0), &[2], sks));
         })
     });
 }

--- a/tfhe/src/high_level_api/booleans/oprf.rs
+++ b/tfhe/src/high_level_api/booleans/oprf.rs
@@ -33,10 +33,22 @@ impl FheBool {
             InternalServerKey::Cpu(key) => {
                 let sk = &key.pbs_key().key;
 
-                let ct = key
+                let ct_wrapped = key
                     .oprf_key()
                     .key
-                    .generate_oblivious_pseudo_random(seed, 1, sk);
+                    .generate_oblivious_pseudo_random_bits_chunks(seed, &[1], sk);
+
+                // We have to do the double unwrap, we want to keep as little primitives as possible
+                // for PRF since they also need a rerandomized_variant, so we don't have a single
+                // block primitive for that
+                let ct = ct_wrapped
+                    .into_iter()
+                    .next()
+                    .expect("A single chunk was expected, got 0")
+                    .into_iter()
+                    .next()
+                    .expect("A single ciphertext was expected, got 0");
+
                 (
                     InnerBoolean::Cpu(BooleanBlock::new_unchecked(ct)),
                     key.tag.clone(),

--- a/tfhe/src/high_level_api/booleans/oprf.rs
+++ b/tfhe/src/high_level_api/booleans/oprf.rs
@@ -57,9 +57,16 @@ impl FheBool {
             #[cfg(feature = "gpu")]
             InternalServerKey::Cuda(cuda_key) => {
                 let streams = &cuda_key.streams;
+                // 1 block with 1 bit of data is a boolean
                 let d_ct: CudaUnsignedRadixCiphertext = cuda_key
                     .oprf_key()
-                    .generate_oblivious_pseudo_random(seed, 1, cuda_key.pbs_key(), streams);
+                    .par_generate_oblivious_pseudo_random_unsigned_integer_bounded(
+                        seed,
+                        1,
+                        1,
+                        cuda_key.pbs_key(),
+                        streams,
+                    );
                 (
                     InnerBoolean::Cuda(CudaBooleanBlock::from_cuda_radix_ciphertext(
                         d_ct.ciphertext,

--- a/tfhe/src/high_level_api/integers/mod.rs
+++ b/tfhe/src/high_level_api/integers/mod.rs
@@ -69,7 +69,7 @@ pub trait IntegerId: FheId + 'static {
     fn num_bits() -> usize;
 
     fn num_blocks(message_modulus: MessageModulus) -> usize {
-        Self::num_bits() / message_modulus.0.ilog2() as usize
+        Self::num_bits().div_ceil(message_modulus.0.ilog2() as usize)
     }
 }
 

--- a/tfhe/src/high_level_api/integers/oprf.rs
+++ b/tfhe/src/high_level_api/integers/oprf.rs
@@ -870,7 +870,7 @@ mod test {
     /// Test OPRF with BootstrapKeyswitch (PBS_KS) parameter order.
     ///
     /// This exercises the keyswitch-after-bootstrap code path in
-    /// `OprfBootstrappingKey::generate_pseudo_random_bits`.
+    /// [`crate::shortint::oprf::OprfBootstrappingKey::generate_pseudo_random_bits_chunks`].
     #[test]
     fn test_oprf_with_pbs_ks_params() {
         let config = ConfigBuilder::with_custom_parameters(

--- a/tfhe/src/high_level_api/integers/oprf.rs
+++ b/tfhe/src/high_level_api/integers/oprf.rs
@@ -591,9 +591,12 @@ mod test {
     };
     use crate::prelude::FheDecrypt;
     use crate::shortint::oprf::test::test_uniformity;
-    use crate::shortint::parameters::test_params::TEST_PARAM_MESSAGE_2_CARRY_2_PBS_KS_GAUSSIAN_2M128;
+    use crate::shortint::parameters::test_params::{
+        TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+        TEST_PARAM_MESSAGE_2_CARRY_2_PBS_KS_GAUSSIAN_2M128,
+    };
     use crate::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS32_PBS_TUNIFORM_2M128;
-    use crate::{generate_keys, set_server_key, ConfigBuilder, FheUint8, Seed};
+    use crate::{generate_keys, set_server_key, ConfigBuilder, FheInt8, FheUint8, Seed};
     use num_bigint::BigUint;
     use rand::{thread_rng, Rng};
     use rayon::iter::{IntoParallelIterator, ParallelIterator};
@@ -890,6 +893,32 @@ mod test {
         assert!(result_bounded < (1 << 3));
     }
 
+    #[test]
+    fn test_oprf_bounded_zero() {
+        let config = ConfigBuilder::with_custom_parameters(
+            TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+        )
+        .use_dedicated_oprf_key(true)
+        .build();
+
+        let (client_key, server_key) = generate_keys(config);
+        set_server_key(server_key);
+
+        // Do not use static seed in production
+        let ct_unsigned_bounded = FheUint8::generate_oblivious_pseudo_random_bounded(Seed(0), 0);
+        assert!(ct_unsigned_bounded.is_trivial());
+        let result_unsigned_bounded: u8 = ct_unsigned_bounded.decrypt(&client_key);
+        // PRF with 0 bits is equivalent to modulo 1 meaning only 0 is generated
+        assert_eq!(result_unsigned_bounded, 0);
+
+        // Do not use static seed in production
+        let ct_signed_bounded = FheInt8::generate_oblivious_pseudo_random_bounded(Seed(0), 0);
+        assert!(ct_signed_bounded.is_trivial());
+        let result_signed_bounded: i8 = ct_signed_bounded.decrypt(&client_key);
+        // PRF with 0 bits is equivalent to modulo 1 meaning only 0 is generated
+        assert_eq!(result_signed_bounded, 0);
+    }
+
     #[cfg(feature = "gpu")]
     mod gpu {
         use super::*;
@@ -903,6 +932,29 @@ mod test {
         use rayon::iter::IndexedParallelIterator;
         use rayon::prelude::{IntoParallelRefIterator, ParallelSlice};
         use rayon::ThreadPoolBuilder;
+
+        #[test]
+        fn test_oprf_bounded_zero() {
+            for setup_fn in crate::high_level_api::integers::unsigned::tests::gpu::GPU_SETUP_FN {
+                let client_key = setup_fn();
+
+                // Do not use static seed in production
+                let ct_unsigned_bounded =
+                    FheUint8::generate_oblivious_pseudo_random_bounded(Seed(0), 0);
+                assert!(ct_unsigned_bounded.is_trivial());
+                let result_unsigned_bounded: u8 = ct_unsigned_bounded.decrypt(&client_key);
+                // PRF with 0 bits is equivalent to modulo 1 meaning only 0 is generated
+                assert_eq!(result_unsigned_bounded, 0);
+
+                // Do not use static seed in production
+                let ct_signed_bounded =
+                    FheInt8::generate_oblivious_pseudo_random_bounded(Seed(0), 0);
+                assert!(ct_signed_bounded.is_trivial());
+                let result_signed_bounded: i8 = ct_signed_bounded.decrypt(&client_key);
+                // PRF with 0 bits is equivalent to modulo 1 meaning only 0 is generated
+                assert_eq!(result_signed_bounded, 0);
+            }
+        }
 
         #[test]
         fn test_oprf_gpu() {

--- a/tfhe/src/high_level_api/integers/signed/base.rs
+++ b/tfhe/src/high_level_api/integers/signed/base.rs
@@ -912,6 +912,27 @@ where
         self.ciphertext.on_cpu().decrypt_trivial()
     }
 
+    /// Returns true if the ciphertext is a trivial encryption
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use tfhe::prelude::*;
+    /// use tfhe::{generate_keys, set_server_key, ConfigBuilder, FheInt16};
+    ///
+    /// let (client_key, server_key) = generate_keys(ConfigBuilder::default());
+    /// set_server_key(server_key);
+    ///
+    /// let non_trivial = FheInt16::encrypt(1i16, &client_key);
+    /// assert!(!non_trivial.is_trivial());
+    ///
+    /// let trivial = FheInt16::encrypt_trivial(2i16);
+    /// assert!(trivial.is_trivial());
+    /// ```
+    pub fn is_trivial(&self) -> bool {
+        self.ciphertext.on_cpu().is_trivial()
+    }
+
     /// Reverse the bit of the signed integer
     ///
     /// # Example

--- a/tfhe/src/integer/gpu/server_key/radix/oprf.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/oprf.rs
@@ -177,12 +177,14 @@ where
         streams: &CudaStreams,
     ) -> CudaUnsignedRadixCiphertext {
         let message_bits_count = target_sks.message_modulus.0.ilog2() as u64;
-        let range_log_size = message_bits_count * num_blocks;
+        let range_bits_count = message_bits_count * num_blocks;
+        assert!(range_bits_count > 0);
 
         assert!(
-                random_bits_count <= range_log_size,
-                "The range asked for a random value (=[0, 2^{random_bits_count}[) does not fit in the available range [0, 2^{range_log_size}[",
-            );
+            random_bits_count <= range_bits_count,
+            "The range asked for a random value (=[0, 2^{random_bits_count}[) \
+            does not fit in the available range [0, 2^{range_bits_count}[",
+        );
 
         self.generate_oblivious_pseudo_random_bounded_integer(
             seed,
@@ -290,14 +292,16 @@ where
         streams: &CudaStreams,
     ) -> CudaSignedRadixCiphertext {
         let message_bits_count = target_sks.message_modulus.0.ilog2() as u64;
-        let range_log_size = message_bits_count * num_blocks;
+        let range_bits_count = message_bits_count * num_blocks;
+        assert!(range_bits_count > 0);
 
-        #[allow(clippy::int_plus_one)]
         {
+            let signed_range_bits_count = range_bits_count.saturating_sub(1);
             assert!(
-                random_bits_count + 1 <= range_log_size,
-                "The range asked for a random value (=[0, 2^{}[) does not fit in the available range [-2^{}, 2^{}[",
-                random_bits_count, range_log_size - 1, range_log_size - 1,
+                random_bits_count <= signed_range_bits_count,
+                "The range asked for a random value (=[0, 2^{random_bits_count}[) \
+                which does not fit in the available range \
+                [-2^{signed_range_bits_count}, 2^{signed_range_bits_count}[",
             );
         }
 
@@ -518,13 +522,15 @@ where
 
         assert!(
             !excluded_upper_bound.is_power_of_two(),
-            "Use the cheaper par_generate_oblivious_pseudo_random_unsigned_integer_bounded function instead"
+            "Use the cheaper par_generate_oblivious_pseudo_random_unsigned_integer_bounded \
+            function instead"
         );
 
         let num_bits_output = num_blocks_output * message_bits_count;
         assert!(
             (excluded_upper_bound as f64) < 2_f64.powi(num_bits_output as i32),
-            "num_blocks_output(={num_blocks_output}) is too small to hold an integer up to excluded_upper_bound(={excluded_upper_bound})"
+            "num_blocks_output(={num_blocks_output}) is too small to hold an integer \
+            up to excluded_upper_bound(={excluded_upper_bound})"
         );
 
         let CudaDynamicKeyswitchingKey::Standard(computing_ks_key) = &target_sks.key_switching_key

--- a/tfhe/src/integer/gpu/server_key/radix/oprf.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/oprf.rs
@@ -176,6 +176,7 @@ where
         target_sks: &CudaServerKey,
         streams: &CudaStreams,
     ) -> CudaUnsignedRadixCiphertext {
+        assert!(target_sks.message_modulus.0.is_power_of_two());
         let message_bits_count = target_sks.message_modulus.0.ilog2() as u64;
         let range_bits_count = message_bits_count * num_blocks;
         assert!(range_bits_count > 0);
@@ -291,6 +292,7 @@ where
         target_sks: &CudaServerKey,
         streams: &CudaStreams,
     ) -> CudaSignedRadixCiphertext {
+        assert!(target_sks.message_modulus.0.is_power_of_two());
         let message_bits_count = target_sks.message_modulus.0.ilog2() as u64;
         let range_bits_count = message_bits_count * num_blocks;
         assert!(range_bits_count > 0);
@@ -388,9 +390,10 @@ where
         result
     }
 
-    // Core private implementation that calls the OPRF backend.
-    // This function contains the main logic for both bounded and unbounded generation.
-    //
+    /// Core private implementation that calls the OPRF backend.
+    /// This function contains the main logic for both bounded and unbounded generation.
+    ///
+    /// Caller must ensure total_random_bits is non 0 otherwise this function will panic.
     fn generate_multiblocks_oblivious_pseudo_random(
         &self,
         result: &mut CudaRadixCiphertext,
@@ -412,14 +415,18 @@ where
         let polynomial_size = bootstrapping_key.polynomial_size();
         let in_lwe_size = input_lwe_dimension.to_lwe_size();
         let message_bits_count = target_sks.message_modulus.0.ilog2();
+        let carry_bits_count = target_sks.carry_modulus.0.ilog2();
+        let bits_per_block = message_bits_count + carry_bits_count + 1;
 
-        let seeded = create_random_from_seed_modulus_switched(
+        let (seeded, _rle_info) = create_random_from_seed_modulus_switched(
             seed,
             in_lwe_size,
             polynomial_size,
             &[total_random_bits],
-            message_bits_count as u64,
+            message_bits_count.into(),
+            bits_per_block.into(),
         );
+
         let h_seeded_lwe_list: Vec<u64> = seeded
             .into_iter()
             .flat_map(|(seeded, _bits)| {
@@ -471,6 +478,13 @@ where
         }
     }
 
+    /// # Panics
+    ///
+    /// Panics if:
+    /// - `target_sks.message_modulus` is not a power of 2
+    /// - `excluded_upper_bound` is a power of 2 use
+    ///   [`Self::par_generate_oblivious_pseudo_random_unsigned_integer_bounded`] instead
+    /// - `excluded_upper_bound.ilog2() + 1` is greater than the output bit count
     pub fn par_generate_oblivious_pseudo_random_unsigned_custom_range(
         &self,
         seed: impl OprfSeed,
@@ -484,7 +498,13 @@ where
             target_sks.message_modulus.0.is_power_of_two(),
             "Message modulus must be a power of two"
         );
-        let message_bits_count = target_sks.message_modulus.0.ilog2() as u64;
+        assert!(
+            target_sks.carry_modulus.0.is_power_of_two(),
+            "Carry modulus must be a power of two"
+        );
+        let message_bits_count: u64 = target_sks.message_modulus.0.ilog2().into();
+        let carry_bits_count: u64 = target_sks.carry_modulus.0.ilog2().into();
+        let bits_per_block = message_bits_count + carry_bits_count + 1;
 
         assert!(
             !excluded_upper_bound.is_power_of_two(),
@@ -528,12 +548,13 @@ where
             .iter_as::<u64>()
             .collect::<Vec<_>>();
 
-        let seeded = create_random_from_seed_modulus_switched(
+        let (seeded, _rle_info) = create_random_from_seed_modulus_switched(
             seed,
             in_lwe_size,
             polynomial_size,
             &[num_input_random_bits],
             message_bits_count,
+            bits_per_block,
         );
 
         let h_seeded_lwe_list: Vec<u64> = seeded

--- a/tfhe/src/integer/gpu/server_key/radix/oprf.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/oprf.rs
@@ -314,40 +314,6 @@ where
         )
     }
 
-    // Generic interface to generate a single-block oblivious pseudo-random integer.
-    // It performs checks specific to single-block capacity.
-    //
-    pub fn generate_oblivious_pseudo_random<T>(
-        &self,
-        seed: impl OprfSeed,
-        random_bits_count: u64,
-        target_sks: &CudaServerKey,
-        streams: &CudaStreams,
-    ) -> T
-    where
-        T: CudaIntegerRadixCiphertext,
-    {
-        assert!(
-            1 << random_bits_count <= target_sks.message_modulus.0,
-            "The range asked for a random value (=[0, 2^{random_bits_count}[) does not fit in the available range [0, {}[",
-            target_sks.message_modulus.0
-        );
-        let carry_bits_count = target_sks.carry_modulus.0.ilog2() as u64;
-        let message_bits_count = target_sks.message_modulus.0.ilog2() as u64;
-        assert!(
-            random_bits_count <= carry_bits_count + message_bits_count,
-            "The number of random bits asked for (={random_bits_count}) is bigger than carry_bits_count (={carry_bits_count}) + message_bits_count(={message_bits_count})",
-        );
-
-        self.generate_oblivious_pseudo_random_bounded_integer(
-            seed,
-            random_bits_count,
-            1,
-            target_sks,
-            streams,
-        )
-    }
-
     // Generic internal implementation for unbounded pseudo-random generation.
     // It calls the core implementation with parameters for the unbounded case.
     //

--- a/tfhe/src/integer/oprf.rs
+++ b/tfhe/src/integer/oprf.rs
@@ -375,11 +375,16 @@ where
         assert!(target_sks.message_modulus().0.is_power_of_two());
         let message_bits_count = target_sks.message_modulus().0.ilog2() as u64;
 
-        let blocks = self.key.generate_oblivious_pseudo_random_bits(
-            seed,
-            num_blocks * message_bits_count,
-            &target_sks.key,
-        );
+        let blocks = self
+            .key
+            .generate_oblivious_pseudo_random_bits_chunks(
+                seed,
+                &[num_blocks * message_bits_count],
+                &target_sks.key,
+            )
+            .into_iter()
+            .next()
+            .expect("Expected a single chunk for the radix being generated, got 0");
 
         T::from(blocks)
     }
@@ -412,11 +417,16 @@ where
             );
         }
 
-        let mut blocks = self.key.generate_oblivious_pseudo_random_bits(
-            seed,
-            random_bits_count,
-            &target_sks.key,
-        );
+        let mut blocks = self
+            .key
+            .generate_oblivious_pseudo_random_bits_chunks(
+                seed,
+                &[random_bits_count],
+                &target_sks.key,
+            )
+            .into_iter()
+            .next()
+            .expect("Expected a single chunk for the radix being generated, got 0");
         if blocks.len() < num_blocks as usize {
             blocks.resize(num_blocks as usize, target_sks.key.create_trivial(0));
         }

--- a/tfhe/src/integer/oprf.rs
+++ b/tfhe/src/integer/oprf.rs
@@ -241,15 +241,17 @@ where
         let message_bits_count = target_sks.message_modulus().0.ilog2() as u64;
 
         assert!(
-                !excluded_upper_bound.is_power_of_two(),
-                "Use the cheaper par_generate_oblivious_pseudo_random_unsigned_integer_bounded function instead"
-            );
+            !excluded_upper_bound.is_power_of_two(),
+            "Use the cheaper par_generate_oblivious_pseudo_random_unsigned_integer_bounded \
+            function instead"
+        );
 
         let num_bits_output = num_blocks_output * message_bits_count;
         assert!(
-                (excluded_upper_bound as f64) < 2_f64.powi(num_bits_output as i32),
-                "num_blocks_output(={num_blocks_output}) is too small to hold an integer up to excluded_upper_bound(=excluded_upper_bound)"
-            );
+            (excluded_upper_bound as f64) < 2_f64.powi(num_bits_output as i32),
+            "num_blocks_output(={num_blocks_output}) is too small to hold an integer \
+            up to excluded_upper_bound(={excluded_upper_bound})"
+        );
 
         let post_mul_num_bits =
             num_input_random_bits + (excluded_upper_bound as f64).log2().ceil() as u64;
@@ -391,22 +393,23 @@ where
     ) -> T {
         assert!(target_sks.message_modulus().0.is_power_of_two());
         let message_bits_count = target_sks.message_modulus().0.ilog2() as u64;
-        let range_log_size = message_bits_count * num_blocks;
+        let range_bits_count = message_bits_count * num_blocks;
+        assert!(range_bits_count > 0);
 
         if T::IS_SIGNED {
-            #[allow(clippy::int_plus_one)]
-            {
-                assert!(
-                        random_bits_count + 1 <= range_log_size,
-                        "The range asked for a random value (=[0, 2^{}[) does not fit in the available range [-2^{}, 2^{}[",
-                        random_bits_count, range_log_size - 1, range_log_size - 1,
-                    );
-            }
+            let signed_range_bits_count = range_bits_count.saturating_sub(1);
+            assert!(
+                random_bits_count <= signed_range_bits_count,
+                "The range asked for a random value in (=[0, 2^{random_bits_count}[) \
+                which does not fit in the available range \
+                [-2^{signed_range_bits_count}, 2^{signed_range_bits_count}[",
+            );
         } else {
             assert!(
-                    random_bits_count <= range_log_size,
-                    "The range asked for a random value (=[0, 2^{random_bits_count}[) does not fit in the available range [0, 2^{range_log_size}[",
-                );
+                random_bits_count <= range_bits_count,
+                "The range asked for a random value in (=[0, 2^{random_bits_count}[) \
+                which does not fit in the available range [0, 2^{range_bits_count}[",
+            );
         }
 
         let mut blocks = self.key.generate_oblivious_pseudo_random_bits(

--- a/tfhe/src/shortint/ciphertext/re_randomization.rs
+++ b/tfhe/src/shortint/ciphertext/re_randomization.rs
@@ -13,6 +13,8 @@ use crate::core_crypto::entities::{LweCiphertext, LweCompactCiphertextList, Plai
 use crate::core_crypto::prelude::lwe_compact_ciphertext_list_add_assign;
 use crate::shortint::ciphertext::NoiseLevel;
 use crate::shortint::key_switching_key::KeySwitchingKeyMaterialView;
+use crate::shortint::oprf::{OprfSeed, RandomBitsRleLeBytes};
+use crate::shortint::public_key::compact::TFHE_PKE_DOMAIN_SEPARATOR;
 use crate::shortint::{Ciphertext, CompactPublicKey, PBSOrder};
 
 use rayon::prelude::*;
@@ -105,6 +107,22 @@ impl From<blake3::Hasher> for ReRandomizationSeedHasher {
 ///
 /// This type cannot be cloned or copied, as a seed should only be used once.
 pub struct ReRandomizationSeed(pub(crate) XofSeed);
+
+impl ReRandomizationSeed {
+    pub(crate) fn new_prf_rerand_seed(
+        hash_algo: ReRandomizationHashAlgo,
+        prf_seed: impl OprfSeed,
+        random_bits_rle_bytes: &RandomBitsRleLeBytes,
+    ) -> Self {
+        let mut seed_gen = ReRandomizationSeedGen::new_prf_rerand_seed_gen(
+            hash_algo,
+            prf_seed,
+            random_bits_rle_bytes,
+        );
+
+        seed_gen.next_seed()
+    }
+}
 
 /// The context that will be hashed and used to generate unique [`ReRandomizationSeed`].
 ///
@@ -226,6 +244,27 @@ pub struct ReRandomizationSeedGen {
 }
 
 impl ReRandomizationSeedGen {
+    pub(crate) fn new_prf_rerand_seed_gen(
+        hash_algo: ReRandomizationHashAlgo,
+        prf_seed: impl OprfSeed,
+        random_bits_rle_bytes: &RandomBitsRleLeBytes,
+    ) -> Self {
+        const PRF_RERAND_DOMAIN_SEPARATOR: [u8; XofSeed::DOMAIN_SEP_LEN] = *b"PRF_RRND";
+
+        let mut context = ReRandomizationContext::new_with_hasher(
+            TFHE_PKE_DOMAIN_SEPARATOR,
+            ReRandomizationSeedHasher::new(hash_algo, PRF_RERAND_DOMAIN_SEPARATOR),
+        );
+
+        let prf_seed = prf_seed.into_bytes();
+        let prf_seed = prf_seed.as_ref();
+
+        context.add_bytes(prf_seed);
+        context.add_bytes(random_bits_rle_bytes.get());
+
+        context.finalize()
+    }
+
     pub fn next_seed(&mut self) -> ReRandomizationSeed {
         let current_seed_index = self.next_seed_index;
         self.next_seed_index += 1;

--- a/tfhe/src/shortint/oprf.rs
+++ b/tfhe/src/shortint/oprf.rs
@@ -608,39 +608,8 @@ impl<C: Container<Element = c64> + Sync> GenericOprfServerKey<C> {
     pub fn into_raw_parts(self) -> OprfBootstrappingKey<C> {
         self.inner
     }
-    /// Uniformly generates a random encrypted ciphertexts
-    ///
-    ///
-    /// Generates `bit_count` random bits split over multiple blocks
-    ///
-    /// Each ciphertexts encrypt a value in `[0, 2^random_bits_per_block[`
-    /// except for the last one which may have less random bits:
-    /// `bit_count=3, random_bits_per_block=2` -> first_block: 2 bits, last blocks: 1 bit
-    ///
-    ///
-    /// # Panics
-    ///
-    /// * Panics if `random_bits_per_blocks` is greater than the total number of bits in a block
-    /// * Panics if `self` is not compatible with `target_sks`
-    pub fn generate_oblivious_pseudo_random_bits(
-        &self,
-        seed: impl OprfSeed,
-        random_bits_count: u64,
-        target_sks: &ServerKey,
-    ) -> Vec<Ciphertext> {
-        self.inner
-            .generate_pseudo_random_bits(
-                seed,
-                &[random_bits_count],
-                target_sks.message_modulus.0.ilog2() as u64,
-                target_sks,
-            )
-            .pop()
-            .unwrap()
-    }
 
-    /// Uniformly generates a batch of independent encrypted random bit-chunks
-    /// from a single seed in one call.
+    /// Uniformly generates a batch of encrypted random bit-chunks from a single seed in one call.
     ///
     /// For each entry `bc` in `random_bits_counts`, returns a `Vec<Ciphertext>`
     /// of `ceil(bc / random_bits_per_block)` blocks, where `random_bits_per_block`
@@ -657,27 +626,12 @@ impl<C: Container<Element = c64> + Sync> GenericOprfServerKey<C> {
         random_bits_counts: &[u64],
         target_sks: &ServerKey,
     ) -> Vec<Vec<Ciphertext>> {
-        self.inner.generate_pseudo_random_bits(
+        self.inner.generate_pseudo_random_bits_chunks(
             seed,
             random_bits_counts,
             target_sks.message_modulus.0.ilog2() as u64,
             target_sks,
         )
-    }
-
-    /// Uniformly generates a random encrypted value in `[0, 2^random_bits_count[`
-    ///
-    /// `2^random_bits_count` must be smaller than the message modulus
-    ///
-    /// The encrypted value is oblivious to the server
-    pub fn generate_oblivious_pseudo_random(
-        &self,
-        seed: impl OprfSeed,
-        random_bits_count: u64,
-        target_sks: &ServerKey,
-    ) -> Ciphertext {
-        self.inner
-            .generate_oblivious_pseudo_random(seed, random_bits_count, target_sks)
     }
 }
 
@@ -1007,37 +961,6 @@ fn generate_oprf_lut(
 // ============================================================================
 
 impl<C: Container<Element = c64> + Sync> OprfBootstrappingKey<C> {
-    /// Uniformly generates a random encrypted value in `[0, 2^random_bits_count[`
-    /// `2^random_bits_count` must be smaller than the message modulus
-    /// The encrypted value is oblivious to the server
-    pub(crate) fn generate_oblivious_pseudo_random(
-        &self,
-        seed: impl OprfSeed,
-        random_bits_count: u64,
-        target_sks: &ServerKey,
-    ) -> Ciphertext {
-        assert!(
-            random_bits_count < 64,
-            "random_bits_count >= 64 is not supported",
-        );
-        assert!(
-            1 << random_bits_count <= target_sks.message_modulus.0,
-            "The range asked for a random value (=[0, 2^{}[) does not fit in the available range [0, {}[",
-            random_bits_count, target_sks.message_modulus.0
-        );
-
-        let mut chunks = self.generate_pseudo_random_bits(
-            seed,
-            &[random_bits_count],
-            random_bits_count, // This means we will have one block
-            target_sks,
-        );
-        assert_eq!(chunks.len(), 1);
-        let mut blocks = chunks.pop().unwrap();
-        assert_eq!(blocks.len(), 1);
-        blocks.pop().unwrap()
-    }
-
     /// Generates random bits split over multiple blocks, grouped per input chunk.
     ///
     /// For each entry `bc` in `bit_chunks`, produces a `Vec<Ciphertext>` of
@@ -1045,7 +968,7 @@ impl<C: Container<Element = c64> + Sync> OprfBootstrappingKey<C> {
     /// in `[0, 2^random_bits_per_block[` except for the last block of each chunk
     /// which may have fewer random bits:
     /// `bc=3, random_bits_per_block=2` -> first_block: 2 bits, last block: 1 bit.
-    pub(crate) fn generate_pseudo_random_bits(
+    pub(crate) fn generate_pseudo_random_bits_chunks(
         &self,
         seed: impl OprfSeed,
         bit_chunks: &[u64],
@@ -1296,7 +1219,14 @@ pub(crate) mod test {
 
         let random_bits_count = params.message_modulus().0.ilog2().into();
 
-        let img = oprf_sk.generate_oblivious_pseudo_random(seed, random_bits_count, sk);
+        let img = oprf_sk
+            .generate_oblivious_pseudo_random_bits_chunks(seed, &[random_bits_count], sk)
+            .into_iter()
+            .next()
+            .unwrap()
+            .into_iter()
+            .next()
+            .unwrap();
 
         let plain_prf_input = match &oprf_ck.0 {
             AtomicPatternOprfPrivateKey::Standard(sk) => gen_prf_input(&sk.as_view(), seed, params),
@@ -1402,13 +1332,13 @@ pub(crate) mod test {
             let random_bits_count = 2;
 
             test_uniformity(1 << random_bits_count, &|seed| {
-                let img = oprf_sk.generate_oblivious_pseudo_random(
+                let img = oprf_sk.generate_oblivious_pseudo_random_bits_chunks(
                     Seed(seed as u128),
-                    random_bits_count,
+                    &[random_bits_count],
                     &sk,
                 );
 
-                ck.decrypt_message_and_carry(&img)
+                ck.decrypt_message_and_carry(&img[0][0])
             });
         }
     }
@@ -1497,7 +1427,9 @@ pub(crate) mod test {
             let oprf_sk = OprfServerKey::new(&oprf_ck, &ck).unwrap();
 
             let random_bits_per_block = sk.message_modulus.0.ilog2() as u64;
-            let blocks = oprf_sk.generate_oblivious_pseudo_random_bits(Seed(0), 0, &sk);
+            let blocks = oprf_sk.generate_oblivious_pseudo_random_bits_chunks(Seed(0), &[0], &sk);
+            assert_eq!(blocks.len(), 1);
+            let blocks = blocks.into_iter().next().unwrap();
             assert!(blocks.is_empty());
 
             for random_bits_count in [
@@ -1514,12 +1446,14 @@ pub(crate) mod test {
 
                 for _ in 0..50 {
                     let seed_val: u128 = rand::Rng::gen(&mut rng);
-                    let blocks = oprf_sk.generate_oblivious_pseudo_random_bits(
+                    let blocks = oprf_sk.generate_oblivious_pseudo_random_bits_chunks(
                         Seed(seed_val),
-                        random_bits_count,
+                        &[random_bits_count],
                         &sk,
                     );
 
+                    assert_eq!(blocks.len(), 1);
+                    let blocks = blocks.into_iter().next().unwrap();
                     assert_eq!(blocks.len(), expected_num_blocks);
 
                     for (i, block) in blocks.iter().enumerate() {

--- a/tfhe/src/shortint/oprf.rs
+++ b/tfhe/src/shortint/oprf.rs
@@ -11,15 +11,18 @@ use crate::core_crypto::commons::math::random::{RandomGenerator, Uniform};
 use crate::core_crypto::fft_impl::fft64::crypto::bootstrap::LweBootstrapKeyConformanceParams;
 use crate::core_crypto::prelude::*;
 use crate::shortint::atomic_pattern::{AtomicPattern, AtomicPatternServerKey};
-use crate::shortint::ciphertext::Degree;
+use crate::shortint::ciphertext::{Degree, ReRandomizationHashAlgo, ReRandomizationSeed};
 use crate::shortint::engine::ShortintEngine;
+use crate::shortint::key_switching_key::KeySwitchingKeyMaterialView;
 use crate::shortint::parameters::{KeySwitch32PBSParameters, NoiseLevel};
+use crate::shortint::public_key::CompactPublicKey;
 use crate::shortint::server_key::{
     apply_multi_bit_blind_rotate, apply_standard_blind_rotate, generate_lookup_table_no_encode,
     LookupTableOwned, PBSConformanceParams, PbsTypeConformanceParams, ShortintBootstrappingKey,
 };
 use crate::shortint::{AtomicPatternParameters, ClientKey, PBSParameters, ServerKey};
 use aligned_vec::ABox;
+use core::num::NonZeroU64;
 use itertools::Itertools;
 use rayon::prelude::*;
 use sha3::digest::Digest;
@@ -611,7 +614,7 @@ impl<C: Container<Element = c64> + Sync> GenericOprfServerKey<C> {
 
     /// Uniformly generates a batch of encrypted random bit-chunks from a single seed in one call.
     ///
-    /// For each entry `bc` in `random_bits_counts`, returns a `Vec<Ciphertext>`
+    /// For each entry `bc` in `bit_chunks`, returns a `Vec<Ciphertext>`
     /// of `ceil(bc / random_bits_per_block)` blocks, where `random_bits_per_block`
     /// is the message-modulus log2. Within each chunk, every ciphertext encrypts a
     /// value in `[0, 2^random_bits_per_block[` except for the last one, which may
@@ -623,15 +626,57 @@ impl<C: Container<Element = c64> + Sync> GenericOprfServerKey<C> {
     pub fn generate_oblivious_pseudo_random_bits_chunks(
         &self,
         seed: impl OprfSeed,
-        random_bits_counts: &[u64],
+        bit_chunks: &[u64],
         target_sks: &ServerKey,
     ) -> Vec<Vec<Ciphertext>> {
         self.inner.generate_pseudo_random_bits_chunks(
             seed,
-            random_bits_counts,
+            bit_chunks,
             target_sks.message_modulus.0.ilog2() as u64,
             target_sks,
         )
+    }
+
+    /// Same as [`Self::generate_oblivious_pseudo_random_bits_chunks`], but applies re-randomization
+    /// to the encrypted outputs before returning them. The PRF output is deterministic, the input
+    /// `prf_seed` therefore needs to change for each call.
+    ///
+    /// `compact_public_key` and `key_switching_key_material` are the necessary keys for
+    /// re-randomization.
+    ///
+    /// For each entry `bc` in `bit_chunks`, returns a `Vec<Ciphertext>`
+    /// of `ceil(bc / random_bits_per_block)` blocks, where `random_bits_per_block`
+    /// is the message-modulus log2. Within each chunk, every ciphertext encrypts a
+    /// value in `[0, 2^random_bits_per_block[` except for the last one, which may
+    /// hold fewer random bits if `bc` does not divide evenly.
+    ///
+    /// # Errors
+    ///
+    /// * Returns `Err` if the supplied `compact_public_key` / `key_switching_key_material` are
+    ///   incompatible with the PRF outputs.
+    ///
+    /// # Panics
+    ///
+    /// * Panics if `self` is not compatible with `target_sks`.
+    pub fn generate_oblivious_pseudo_random_bits_chunks_and_re_randomize(
+        &self,
+        prf_seed: impl OprfSeed,
+        bit_chunks: &[u64],
+        target_sks: &ServerKey,
+        compact_public_key: &CompactPublicKey,
+        key_switching_key_material: Option<&KeySwitchingKeyMaterialView>,
+        rerand_hash_algo: ReRandomizationHashAlgo,
+    ) -> crate::Result<Vec<Vec<Ciphertext>>> {
+        self.inner
+            .generate_pseudo_random_bits_chunks_and_re_randomize(
+                prf_seed,
+                bit_chunks,
+                target_sks.message_modulus.0.ilog2() as u64,
+                target_sks,
+                compact_public_key,
+                key_switching_key_material,
+                rerand_hash_algo,
+            )
     }
 }
 
@@ -731,6 +776,12 @@ impl PrfSeededModulusSwitched {
     }
 
     fn fill_mask_with_random(&mut self, rng: &mut RandomGenerator<DefaultRandomGenerator>) {
+        // usize is the mod switched type used during BR, but we don't have a random generation for
+        // uniform usize, since the size of usize is system dependent, u32 is an ok choice as long
+        // as it can contain the represented modulus.
+        // log_modulus <= 32 so that 2^log_modulus fits in u32 (native modulus included).
+        assert!(self.log_modulus.0 <= 32);
+
         for mask_element in &mut self.mask {
             *mask_element = rng.random_from_distribution_custom_mod::<u32, _>(
                 Uniform,
@@ -817,55 +868,135 @@ impl MultiBitModulusSwitchedLweCiphertext for PrfMultiBitSeededModulusSwitched {
     }
 }
 
+/// RLE encoding of the random bits requested with prepended bits_per_block and
+/// max_random_bits_per_block, all values are represented on u64 and converted to le_bytes (free on
+/// x86 and platform independent)
+///
+/// RLE therefore contains the LE bytes representation of:
+///
+/// bits_per_block (2 + 2 + 1 padding for usual params) ||
+/// max_random_bits_per_block (2 for usual params) ||
+/// RLE(random_bits, max_random_bits_per_block) ...
+///
+/// RLE(random_bits, max_random_bits_per_block) contains
+///
+/// total_number_of_blocks ||
+/// (full_block_count || bits_per_full_block_count)? (can be skipped if full_block_count == 0)
+/// (partial_block_count || bits_in_partial_block)? partial_block_count is 1 if a block is present
+/// can be skipped if there are no partial block
+///
+/// See `test::prf_rle_encoding_ci_run_filter` for examples of encodings
+pub(crate) struct RandomBitsRleLeBytes(Vec<u8>);
+
+impl RandomBitsRleLeBytes {
+    pub(crate) fn get(&self) -> &[u8] {
+        &self.0
+    }
+}
+
 // ============================================================================
 // XOF-based seeded modulus switch (current implementation, uses OprfSeed)
 // ============================================================================
 
-/// Takes as input the `bit_chunks` to be generated (e.g [15, 15])
-/// the `random_bits_per_blocks` (e.g. 2).
+pub const TFHE_PRF_DOMAIN_SEPARATOR: [u8; 8] = *b"TFHE_PRF";
+pub const TFHE_PRF_XOF_SEED_DOMAIN_SEPARATOR: [u8; XofSeed::DOMAIN_SEP_LEN] = *b"PRF_INIT";
+
+/// Return the seeded inputs for each output block of the PRF, along with the Run Length Encoding
+/// (RLE) byte representation of the output random bits layout. The RLE output is e.g. used in
+/// [`OprfBootstrappingKey::generate_pseudo_random_bits_chunks_and_re_randomize`] to tie the
+/// re-randomization seed to the same context.
 ///
-/// Outputs a flat array of all [PrfSeededModulusSwitched] needed
+/// `bit_chunks` is the list of per-chunk random bit counts (e.g. `[15, 15]`); each chunk
+/// produces `ceil(bc / random_bits_per_block)` blocks, the last of which may be partial.
+/// `random_bits_per_block` is the per-block bit budget (e.g. `2` for a 2-bit message modulus).
 ///
-/// Also returns the position of blocks that should be generated to contain
-/// less than `random_bits_per_block`, along with how many bits they should contain
+/// Returns `(seededs, rle)` where:
+/// - `seededs` is the flat sequence of `(PrfSeededModulusSwitched, num_bits)` pairs representing
+///   the various chunks in the same order as `bit_chunks`, with `num_bits` the random bit count
+///   actually carried by a given block.
+/// - `rle` is the little-endian bytes of `random_bits_per_block` plus the per-chunk  RLE layout, it
+///   is used in the hash to generate the seed for the CSPRNG that produces the PRF input values.
+///   RLE example of `bit_chunk` == &[15, 14, 1] with a `random_bits_per_block` of 2:
+///
+///   // 15 is 8 blocks, 7 of 2 bits and 1 of 1 bit
+///   [8u64, 7, 2, 1, 1,
+///   // 14 is 7 blocks, 7 of 2 bits
+///   7, 7, 2,
+///   // 1 is 1 block, 1 of 1 bit
+///   1, 1, 1]
+///
+/// `bits_per_block` indicates how many bits are used in a block to encrypt values. For
+/// example with the usual 2_2 parameters, we have 5 bits in a block with the added padding bit.
+/// 2 bits of message + 2 bits of carry + 1 padding bit == 5
+///
+/// # Panics
+///
+/// - if `random_bits_per_block == 0`;
 pub(crate) fn create_random_from_seed_modulus_switched(
     seed: impl OprfSeed,
     lwe_size: LweSize,
     polynomial_size: PolynomialSize,
     bit_chunks: &[u64],
     random_bits_per_block: u64,
-) -> Vec<(PrfSeededModulusSwitched, u64)> {
-    if random_bits_per_block == 0 {
-        return Vec::new();
-    }
+    bits_per_block: u64,
+) -> (Vec<(PrfSeededModulusSwitched, u64)>, RandomBitsRleLeBytes) {
+    assert_ne!(
+        random_bits_per_block, 0,
+        "Got random_bits_per_block == 0, this is unsupported"
+    );
+
+    assert!(
+        bits_per_block >= random_bits_per_block,
+        "requesting more random_bits_per_block {random_bits_per_block} \
+        than available bits_per_block {bits_per_block}"
+    );
 
     // Init the hasher
-    let bytes = seed.into_bytes();
+    let seed_bytes = seed.into_bytes();
     let mut hasher = sha3::Sha3_256::default();
-    hasher.update(b"TFHE_PRF");
-    hasher.update(bytes.as_ref());
+    hasher.update(TFHE_PRF_DOMAIN_SEPARATOR);
+    hasher.update(seed_bytes.as_ref());
 
     let total_blocks: u64 = bit_chunks
         .iter()
         .map(|&bits| bits.div_ceil(random_bits_per_block))
         .sum();
     let mut seededs = Vec::with_capacity(total_blocks as usize);
-    for &bit_count in bit_chunks {
-        if bit_count == 0 {
-            continue;
-        }
 
+    // 1 u64 to encode the bits_per_block, allows to distinguish similar looking RLE that differ on
+    // how many bits can be encrypted in each block
+    //
+    // 1 u64 to encode the random_bits_per_block, allows to distinguish similar looking RLE that
+    // differ in how full each block is, the case mostly appears for incomplete blocks all
+    // containing 1s
+    //
+    // and then
+    //
+    // Max 5 u64 per bit_chunk:
+    // 1 for the total block count
+    // 1 for full block count
+    // 1 for bits per full block
+    // 1 to encode the block count "1" for the last block
+    // 1 for the number of bits in the potential last incomplete block
+    let mut bit_count_rle = Vec::with_capacity(
+        2 * core::mem::size_of::<u64>() + bit_chunks.len() * 5 * core::mem::size_of::<u64>(),
+    );
+
+    bit_count_rle.extend(bits_per_block.to_le_bytes());
+    bit_count_rle.extend(random_bits_per_block.to_le_bytes());
+
+    for &bit_count in bit_chunks {
         let (num_full_blocks, last_block_bits) = (
             bit_count / random_bits_per_block,
             bit_count % random_bits_per_block,
         );
 
         let num_blocks = num_full_blocks + u64::from(last_block_bits != 0);
-        hasher.update(num_blocks.to_le_bytes());
+        bit_count_rle.extend(num_blocks.to_le_bytes());
 
         if num_full_blocks != 0 {
-            hasher.update(num_full_blocks.to_le_bytes());
-            hasher.update(random_bits_per_block.to_le_bytes());
+            bit_count_rle.extend(num_full_blocks.to_le_bytes());
+            bit_count_rle.extend(random_bits_per_block.to_le_bytes());
 
             for _ in 0..num_full_blocks {
                 seededs.push((
@@ -877,9 +1008,10 @@ pub(crate) fn create_random_from_seed_modulus_switched(
                 ));
             }
         }
+
         if last_block_bits != 0 {
-            hasher.update(1u64.to_le_bytes());
-            hasher.update(last_block_bits.to_le_bytes());
+            bit_count_rle.extend(1u64.to_le_bytes());
+            bit_count_rle.extend(last_block_bits.to_le_bytes());
 
             seededs.push((
                 PrfSeededModulusSwitched::zero(
@@ -891,14 +1023,19 @@ pub(crate) fn create_random_from_seed_modulus_switched(
         }
     }
 
-    let seed = hasher.finalize();
-    let mut xof =
-        RandomGenerator::<DefaultRandomGenerator>::new(XofSeed::new(seed.to_vec(), *b"PRF_INIT"));
+    hasher.update(&bit_count_rle);
+
+    let xof_seed = hasher.finalize();
+    let mut xof = RandomGenerator::<DefaultRandomGenerator>::new(XofSeed::new(
+        xof_seed.to_vec(),
+        TFHE_PRF_XOF_SEED_DOMAIN_SEPARATOR,
+    ));
+
     for (seeded, _) in &mut seededs {
         seeded.fill_mask_with_random(&mut xof);
     }
 
-    seededs
+    (seededs, RandomBitsRleLeBytes(bit_count_rle))
 }
 
 // ============================================================================
@@ -929,13 +1066,13 @@ pub(crate) fn raw_seeded_msed_to_lwe<Scalar: UnsignedInteger + CastFrom<usize>>(
 // ============================================================================
 
 fn generate_oprf_lut(
-    random_bits: u64,
+    random_bits: NonZeroU64,
     full_bits_count: u64,
     polynomial_size: PolynomialSize,
     glwe_size: GlweSize,
     ciphertext_modulus: CiphertextModulus<u64>,
 ) -> (LookupTableOwned, Plaintext<u64>) {
-    let p = 1 << random_bits;
+    let p = 1 << random_bits.get();
 
     let delta = 1_u64 << (64 - full_bits_count);
 
@@ -961,20 +1098,25 @@ fn generate_oprf_lut(
 // ============================================================================
 
 impl<C: Container<Element = c64> + Sync> OprfBootstrappingKey<C> {
-    /// Generates random bits split over multiple blocks, grouped per input chunk.
+    /// Generates random bits split over multiple blocks, but without performing the explicit
+    /// grouping of chunks in [`Vec`]s. This primitive is used to be able to re-randomize
+    /// ciphertexts effectively when they are not yet grouped in chunks.
     ///
-    /// For each entry `bc` in `bit_chunks`, produces a `Vec<Ciphertext>` of
-    /// `ceil(bc / random_bits_per_block)` blocks. Each ciphertext encrypts a value
-    /// in `[0, 2^random_bits_per_block[` except for the last block of each chunk
-    /// which may have fewer random bits:
-    /// `bc=3, random_bits_per_block=2` -> first_block: 2 bits, last block: 1 bit.
-    pub(crate) fn generate_pseudo_random_bits_chunks(
+    /// For each entry `bc` in `bit_chunks`, produces a chunk of `ceil(bc /
+    /// max_random_bits_per_block)` [`Ciphertext`]s, chunks are laid out consecutively in the output
+    /// [`Vec`], it's the caller responsibility to collect chunks in dedicated [`Vec`]s as
+    /// appropriate.
+    ///
+    /// Each ciphertext encrypts a value in `[0, 2^max_random_bits_per_block[`
+    /// except for the last block of each chunk which may have fewer random bits: `bc=3,
+    /// max_random_bits_per_block=2` -> first_block: 2 bits, last block: 1 bit.
+    fn generate_pseudo_random_bits_flat(
         &self,
         seed: impl OprfSeed,
         bit_chunks: &[u64],
-        random_bits_per_block: u64,
+        max_random_bits_per_block: u64,
         target_sks: &ServerKey,
-    ) -> Vec<Vec<Ciphertext>> {
+    ) -> (Vec<Ciphertext>, RandomBitsRleLeBytes) {
         let ks_key = match &target_sks.atomic_pattern {
             AtomicPatternServerKey::Standard(std) => {
                 self.assert_compatible_with_target_bsk(&std.bootstrapping_key);
@@ -995,30 +1137,34 @@ impl<C: Container<Element = c64> + Sync> OprfBootstrappingKey<C> {
 
         let message_bits = target_sks.message_modulus.0.ilog2() as u64;
         let carry_bits = target_sks.carry_modulus.0.ilog2() as u64;
-        let bits_in_one_block = 1 + message_bits + carry_bits;
+        let block_bit_count = 1 + message_bits + carry_bits;
         assert!(
-            random_bits_per_block <= bits_in_one_block,
-            "The number of random bits asked for (={random_bits_per_block}) is bigger than full_bits_count (={bits_in_one_block})"
+            max_random_bits_per_block <= block_bit_count,
+            "The requested max_random_bits_per_block (={max_random_bits_per_block}) \
+            does not fit in a block. A maximum of {block_bit_count} bits can fit in a single block."
         );
 
         let polynomial_size = self.polynomial_size();
         let in_lwe_size = self.input_lwe_dimension().to_lwe_size();
 
-        let seeded_cts = create_random_from_seed_modulus_switched(
+        let (seeded_cts, random_bits_rle) = create_random_from_seed_modulus_switched(
             seed,
             in_lwe_size,
             polynomial_size,
             bit_chunks,
-            random_bits_per_block,
+            max_random_bits_per_block,
+            block_bit_count,
         );
 
         let ciphertext_modulus = target_sks.ciphertext_modulus;
         let max_bits = seeded_cts.iter().map(|(_, b)| *b).max().unwrap_or(0);
+        // 1..=max_bits are positive, filter_map avoids unwrapping on an infallible new call
         let luts = (1..=max_bits)
+            .filter_map(NonZeroU64::new)
             .map(|bit| {
                 generate_oprf_lut(
                     bit,
-                    bits_in_one_block,
+                    block_bit_count,
                     polynomial_size,
                     self.glwe_size(),
                     ciphertext_modulus,
@@ -1092,14 +1238,78 @@ impl<C: Container<Element = c64> + Sync> OprfBootstrappingKey<C> {
             })
             .collect();
 
+        (flat, random_bits_rle)
+    }
+
+    /// Generates random bits split over multiple blocks, grouped per input chunk.
+    ///
+    /// For each entry `bc` in `bit_chunks`, produces a `Vec<Ciphertext>` of
+    /// `ceil(bc / max_random_bits_per_block)` blocks. Each ciphertext encrypts a value in
+    /// `[0, 2^max_random_bits_per_block[` except for the last block of each chunk which may have
+    /// fewer random bits: `bc=3, max_random_bits_per_block=2` -> first_block: 2 bits, last
+    /// block: 1 bit.
+    pub(crate) fn generate_pseudo_random_bits_chunks(
+        &self,
+        seed: impl OprfSeed,
+        bit_chunks: &[u64],
+        max_random_bits_per_block: u64,
+        target_sks: &ServerKey,
+    ) -> Vec<Vec<Ciphertext>> {
+        let (flat, _rle_info) = self.generate_pseudo_random_bits_flat(
+            seed,
+            bit_chunks,
+            max_random_bits_per_block,
+            target_sks,
+        );
+
         let mut iter = flat.into_iter();
         bit_chunks
+            .iter()
+            .map(|&bc| {
+                let n = bc.div_ceil(max_random_bits_per_block) as usize;
+                iter.by_ref().take(n).collect()
+            })
+            .collect()
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn generate_pseudo_random_bits_chunks_and_re_randomize(
+        &self,
+        prf_seed: impl OprfSeed,
+        bit_chunks: &[u64],
+        random_bits_per_block: u64,
+        target_sks: &ServerKey,
+        compact_public_key: &CompactPublicKey,
+        key_switching_key_material: Option<&KeySwitchingKeyMaterialView>,
+        rerand_hash_algo: ReRandomizationHashAlgo,
+    ) -> crate::Result<Vec<Vec<Ciphertext>>> {
+        let prf_seed = prf_seed.into_bytes();
+        let prf_seed = prf_seed.as_ref();
+
+        let (mut flat_result, random_bits_rle) = self.generate_pseudo_random_bits_flat(
+            prf_seed,
+            bit_chunks,
+            random_bits_per_block,
+            target_sks,
+        );
+
+        let rerand_seed =
+            ReRandomizationSeed::new_prf_rerand_seed(rerand_hash_algo, prf_seed, &random_bits_rle);
+
+        compact_public_key.re_randomize_ciphertexts(
+            &mut flat_result,
+            key_switching_key_material,
+            rerand_seed,
+        )?;
+
+        let mut iter = flat_result.into_iter();
+        Ok(bit_chunks
             .iter()
             .map(|&bc| {
                 let n = bc.div_ceil(random_bits_per_block) as usize;
                 iter.by_ref().take(n).collect()
             })
-            .collect()
+            .collect())
     }
 }
 
@@ -1150,9 +1360,17 @@ pub(crate) mod test {
     use super::test_utils::cleartext_prf;
     use super::*;
     use crate::core_crypto::commons::math::random::Seed;
-    use crate::core_crypto::prelude::{decrypt_lwe_ciphertext, CastInto, LweSecretKeyView};
+    use crate::core_crypto::prelude::{
+        decrypt_lwe_ciphertext, new_seeder, CastInto, LweSecretKeyView,
+    };
     use crate::shortint::oprf::create_random_from_seed_modulus_switched;
-    use crate::shortint::{ClientKey, ServerKey, ShortintParameterSet};
+    use crate::shortint::parameters::test_params::{
+        TEST_PARAM_MESSAGE_2_CARRY_2_KS32_PBS_TUNIFORM_2M128,
+        TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+        TEST_PARAM_MULTI_BIT_GROUP_3_MESSAGE_2_CARRY_2_KS_PBS_GAUSSIAN_2M128,
+    };
+    use crate::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    use crate::shortint::{gen_keys, ClientKey, ServerKey, ShortintParameterSet};
     use rand::SeedableRng;
     use statrs::distribution::ContinuousCDF;
     use std::collections::HashMap;
@@ -1169,12 +1387,6 @@ pub(crate) mod test {
 
     #[test]
     fn oprf_compare_plain_ci_run_filter() {
-        use crate::shortint::gen_keys;
-        use crate::shortint::parameters::test_params::{
-            TEST_PARAM_MESSAGE_2_CARRY_2_KS32_PBS_TUNIFORM_2M128,
-            TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
-        };
-
         for params in [
             ShortintParameterSet::from(TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128),
             ShortintParameterSet::from(TEST_PARAM_MESSAGE_2_CARRY_2_KS32_PBS_TUNIFORM_2M128),
@@ -1277,21 +1489,26 @@ pub(crate) mod test {
         let log_input_p = input_p.ilog2() as usize;
 
         let ciphertext_modulus = CiphertextModulus::new_native();
+        let message_bits: u64 = params.message_modulus().0.ilog2().into();
+        let carry_bits: u64 = params.carry_modulus().0.ilog2().into();
+        let bits_per_block = message_bits + carry_bits + 1;
 
-        let seeded = create_random_from_seed_modulus_switched(
+        let (seeded_chunks, _rle_info) = create_random_from_seed_modulus_switched(
             seed,
             lwe_size,
             params.polynomial_size(),
-            &[params.message_modulus().0.ilog2() as u64],
-            params.message_modulus().0.ilog2() as u64,
-        )
-        .pop()
-        .unwrap()
-        .0;
+            &[message_bits],
+            message_bits,
+            bits_per_block,
+        );
+
+        assert_eq!(seeded_chunks.len(), 1);
+
+        let seeded = &seeded_chunks[0].0;
 
         assert!(seeded.mask.iter().all(|v| *v < input_p as usize));
 
-        let ct = raw_seeded_msed_to_lwe(&seeded, ciphertext_modulus);
+        let ct = raw_seeded_msed_to_lwe(seeded, ciphertext_modulus);
 
         CastInto::<u64>::cast_into(
             decrypt_lwe_ciphertext(sk, &ct)
@@ -1306,13 +1523,6 @@ pub(crate) mod test {
         let sample_count: usize = 100_000;
 
         let p_value_limit: f64 = 0.000_01;
-
-        use crate::shortint::gen_keys;
-        use crate::shortint::parameters::test_params::{
-            TEST_PARAM_MESSAGE_2_CARRY_2_KS32_PBS_TUNIFORM_2M128,
-            TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
-            TEST_PARAM_MULTI_BIT_GROUP_3_MESSAGE_2_CARRY_2_KS_PBS_GAUSSIAN_2M128,
-        };
 
         for params in [
             ShortintParameterSet::from(
@@ -1337,6 +1547,9 @@ pub(crate) mod test {
                     &[random_bits_count],
                     &sk,
                 );
+
+                assert_eq!(img.len(), 1);
+                assert_eq!(img[0].len(), 1);
 
                 ck.decrypt_message_and_carry(&img[0][0])
             });
@@ -1409,11 +1622,6 @@ pub(crate) mod test {
 
     #[test]
     fn oprf_test_blocks_range_bits_ci_run_filter() {
-        use crate::core_crypto::prelude::new_seeder;
-        use crate::shortint::gen_keys;
-        use crate::shortint::parameters::test_params::TEST_PARAM_MESSAGE_2_CARRY_2_KS32_PBS_TUNIFORM_2M128;
-        use crate::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
-
         let mut seeder = new_seeder();
         let rng_seed: [u8; 32] = std::array::from_fn(|_| seeder.seed().0 as u8);
         println!("oprf_test_blocks_range_bits rng_seed: {rng_seed:?}");
@@ -1427,10 +1635,6 @@ pub(crate) mod test {
             let oprf_sk = OprfServerKey::new(&oprf_ck, &ck).unwrap();
 
             let random_bits_per_block = sk.message_modulus.0.ilog2() as u64;
-            let blocks = oprf_sk.generate_oblivious_pseudo_random_bits_chunks(Seed(0), &[0], &sk);
-            assert_eq!(blocks.len(), 1);
-            let blocks = blocks.into_iter().next().unwrap();
-            assert!(blocks.is_empty());
 
             for random_bits_count in [
                 1,
@@ -1468,6 +1672,211 @@ pub(crate) mod test {
                             decrypted < (1 << block_bits),
                             "block {i}: decrypted value {decrypted} >= {}",
                             1u64 << block_bits,
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn prf_rle_encoding_ci_run_filter() {
+        let params = PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+        let lwe_size = params.lwe_dimension.to_lwe_size();
+        let polynomial_size = params.polynomial_size;
+        let bits_per_block: u64 = (params.message_modulus.0 * params.carry_modulus.0 * 2)
+            .ilog2()
+            .into();
+
+        let (a, rle_a) = create_random_from_seed_modulus_switched(
+            Seed(0),
+            lwe_size,
+            polynomial_size,
+            &[1],
+            2,
+            bits_per_block,
+        );
+        let (b, rle_b) = create_random_from_seed_modulus_switched(
+            Seed(0),
+            lwe_size,
+            polynomial_size,
+            &[1],
+            4,
+            bits_per_block,
+        );
+        let (c, rle_c) = create_random_from_seed_modulus_switched(
+            Seed(0),
+            lwe_size,
+            polynomial_size,
+            &[1],
+            2,
+            bits_per_block - 1,
+        );
+        // Different bits (2 vs. 4) should produce different RLE even when all blocks encoding are
+        // the same
+        assert_ne!(rle_a.0, rle_b.0);
+        assert_ne!(rle_a.0, rle_c.0);
+        // Check the generated bytes are indeed different too
+        assert_ne!(&a[0].0.mask, &b[0].0.mask);
+        // Check the generated bytes are indeed different too
+        assert_ne!(&a[0].0.mask, &c[0].0.mask);
+
+        for (index, (input, random_bits_per_block, expected_rle)) in [
+            (vec![1, 1], 2, vec![5u64, 2u64, 1, 1, 1, 1, 1, 1]),
+            (vec![1, 1], 4, vec![5, 4, 1, 1, 1, 1, 1, 1]),
+            (vec![15, 15], 2, vec![5, 2, 8, 7, 2, 1, 1, 8, 7, 2, 1, 1]),
+            (
+                vec![14, 1, 14, 1],
+                2,
+                vec![5, 2, 7, 7, 2, 1, 1, 1, 7, 7, 2, 1, 1, 1],
+            ),
+            (
+                vec![15, 0, 15],
+                2,
+                vec![5, 2, 8, 7, 2, 1, 1, 0, 8, 7, 2, 1, 1],
+            ),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let (_, rle) = create_random_from_seed_modulus_switched(
+                Seed(0),
+                lwe_size,
+                polynomial_size,
+                &input,
+                random_bits_per_block,
+                bits_per_block,
+            );
+
+            let expected_rle: Vec<_> = expected_rle
+                .into_iter()
+                .flat_map(|x| x.to_le_bytes())
+                .collect();
+            assert_eq!(rle.get(), &expected_rle, "Error at input #{index}");
+        }
+    }
+
+    #[test]
+    fn prf_with_re_randomization_ci_run_filter() {
+        use crate::shortint::CompactPrivateKey;
+        use rand::prelude::*;
+
+        let mut rng = rand::thread_rng();
+
+        for params in [
+            ShortintParameterSet::from(
+                TEST_PARAM_MULTI_BIT_GROUP_3_MESSAGE_2_CARRY_2_KS_PBS_GAUSSIAN_2M128,
+            ),
+            ShortintParameterSet::from(TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128),
+            ShortintParameterSet::from(TEST_PARAM_MESSAGE_2_CARRY_2_KS32_PBS_TUNIFORM_2M128),
+        ] {
+            let message_bits: u64 = params.message_modulus().0.ilog2().into();
+
+            let (cks, sks) = gen_keys(params);
+
+            // No KS rerand
+            let privk: CompactPrivateKey<&[u64]> = (&cks).try_into().unwrap();
+            let pubk = CompactPublicKey::new(&privk);
+            // PRF key
+            let oprf_cks = OprfPrivateKey::new(&cks);
+            let oprf_sks = OprfServerKey::new(&oprf_cks, &cks).unwrap();
+
+            let prf_seed: [u8; 256 / 8] = core::array::from_fn(|_| rng.gen());
+            let bit_chunks: Vec<u64> = (0..10).map(|_| rng.gen_range(0..=64)).collect();
+
+            println!("prf_seed={prf_seed:?}");
+            println!("bit_chunks={bit_chunks:?}");
+
+            let prf_not_rerand_chunks = oprf_sks.generate_oblivious_pseudo_random_bits_chunks(
+                prf_seed.as_ref(),
+                &bit_chunks,
+                &sks,
+            );
+
+            for rerand_hash_algo in [
+                ReRandomizationHashAlgo::Blake3,
+                ReRandomizationHashAlgo::Shake256,
+            ] {
+                let prf_rerand_chunks = oprf_sks
+                    .generate_oblivious_pseudo_random_bits_chunks_and_re_randomize(
+                        prf_seed.as_ref(),
+                        &bit_chunks,
+                        &sks,
+                        &pubk,
+                        None,
+                        rerand_hash_algo,
+                    )
+                    .unwrap();
+
+                assert_eq!(prf_not_rerand_chunks.len(), bit_chunks.len());
+                assert_eq!(prf_rerand_chunks.len(), bit_chunks.len());
+
+                for (requested_rand_bits, (prf, prf_rerand)) in bit_chunks
+                    .iter()
+                    .zip(prf_not_rerand_chunks.iter().zip(prf_rerand_chunks.iter()))
+                {
+                    let expected_len: usize = requested_rand_bits
+                        .div_ceil(message_bits)
+                        .try_into()
+                        .unwrap();
+                    assert_eq!(prf.len(), expected_len);
+                    assert_eq!(prf_rerand.len(), expected_len);
+
+                    for (block_idx, (prf_ct, prf_rerand_ct)) in
+                        prf.iter().zip(prf_rerand.iter()).enumerate()
+                    {
+                        let is_last_block = block_idx == expected_len - 1;
+                        let expected_max_value = if is_last_block {
+                            let last_block_is_full =
+                                requested_rand_bits.is_multiple_of(message_bits);
+                            if last_block_is_full {
+                                1 << message_bits
+                            } else {
+                                let remaining_bits = requested_rand_bits % message_bits;
+                                1 << remaining_bits
+                            }
+                        } else {
+                            1 << message_bits
+                        };
+
+                        let Ciphertext {
+                            ct: prf_lwe,
+                            degree: prf_degree,
+                            message_modulus: prf_message_modulus,
+                            carry_modulus: prf_carry_modulus,
+                            atomic_pattern: prf_atomic_pattern,
+                            .. // NoiseLevel private on purpose to avoid manual modifications
+                        } = prf_ct;
+                        let prf_noise_level = prf_ct.noise_level();
+
+                        let Ciphertext {
+                            ct: prf_rerand_lwe,
+                            degree: prf_rerand_degree,
+                            message_modulus: prf_rerand_message_modulus,
+                            carry_modulus: prf_rerand_carry_modulus,
+                            atomic_pattern: prf_rerand_atomic_pattern,
+                            .. // NoiseLevel private on purpose to avoid manual modifications
+                        } = prf_rerand_ct;
+                        let prf_rerand_noise_level = prf_rerand_ct.noise_level();
+
+                        assert_ne!(prf_lwe, prf_rerand_lwe);
+                        assert_eq!(prf_degree, prf_rerand_degree);
+                        // Check expected max degree
+                        assert_eq!(prf_degree.0, expected_max_value - 1);
+                        assert_eq!(prf_message_modulus, prf_rerand_message_modulus);
+                        assert_eq!(prf_carry_modulus, prf_rerand_carry_modulus);
+                        assert_eq!(prf_atomic_pattern, prf_rerand_atomic_pattern);
+                        assert_eq!(prf_noise_level, prf_rerand_noise_level);
+
+                        assert_eq!(prf_noise_level, NoiseLevel::NOMINAL);
+
+                        let prf_dec = cks.decrypt_message_and_carry(prf_ct);
+                        assert!(prf_dec < expected_max_value, "invalid PRF output range");
+
+                        let prf_rerand_dec = cks.decrypt_message_and_carry(prf_rerand_ct);
+                        assert_eq!(
+                            prf_dec, prf_rerand_dec,
+                            "rerand PRF differs from non-rerand PRF"
                         );
                     }
                 }

--- a/tfhe/src/shortint/public_key/compact.rs
+++ b/tfhe/src/shortint/public_key/compact.rs
@@ -36,6 +36,8 @@ pub struct CompactPrivateKey<KeyCont: Container<Element = u64>> {
     parameters: CompactPublicKeyEncryptionParameters,
 }
 
+pub const TFHE_PKE_DOMAIN_SEPARATOR: [u8; XofSeed::DOMAIN_SEP_LEN] = *b"TFHE_Enc";
+
 impl<C: Container<Element = u64>> CompactPrivateKey<C> {
     pub fn from_raw_parts(
         key: LweSecretKey<C>,
@@ -493,7 +495,7 @@ fn noise_generator_from_seed(
             seed.len()
         )));
     }
-    let xof_seed = XofSeed::new(seed.to_vec(), *b"TFHE_Enc");
+    let xof_seed = XofSeed::new(seed.to_vec(), TFHE_PKE_DOMAIN_SEPARATOR);
     Ok(NoiseRandomGenerator::new_from_seed(xof_seed))
 }
 


### PR DESCRIPTION
Preparatory PR to get a PRF + rerand primitive

First a few commits to fix/update a few small things I noticed while writing the PR.

The theme is :
- remove all the PRF APIs which are just wrappers of others at the shortint level to limit how many functions need to be written for the PRF + rerand
- only shortint CPU has a PRF + rerand API for now
- next PR will focus on integer + GPU (and likely HL) to plug everything
- the rerand seeding has been described as follows :

```
So lets get a bit more formal so we are on the same page...
You have a hash function H which outputs a matrix of size v x n, where v is the number of output bits and n is the LWE dimension of the PRF.
Let x be the input to the PRF
Let 2^{k'} be the output size of the PRF, so 0 <= k' <= 5

You should probably do

H(x || k' || v)
and not just

H(x)
```
k' is here to indicate how random bits are set in the output, it can be more complicated than "a set number of bits for all blocks" (though in practice that's the most common case we will be using for Radix)

so it was agreed to use a Run Length Encoding to describe how random bits are distributed in the output

https://en.wikipedia.org/wiki/Run-length_encoding#:~:text=Run%2Dlength%20encoding%20(RLE),than%20as%20the%20original%20run.

essentially it encodes a chunk in the following way:

chunk_block_count || repeat(block_count, bits_in_these_blocks)

so for example if we have the following random bit chunks requests [15, 14, 1] for a block that contains two bits message that we fill the encoding would be

8 || 7 || 2 || 1 || 1 ---- 7 || 7 || 2 ---- 1 || 1 || 1

8 blocks total, 7 blocks with 2 bits, 1 block with 1 bit, then 7 blocks total, 7 blocks with two bits and then 1 block total, 1 block with 1 bit

the message bit count is also hashed, since I made an LLM assisted review (only reviewing with LLM) and it pointed out that there could be a collision between the representation of the RLE if we only have partial blocks e.g.

[1, 1] -> 1 || 1 || 1 ---- 1 || 1 || 1

the representation is the same no matter the message bits

which makes me think I should also probably hash how many bits are in a block which are part of the cleartext space, so in our regular encoding 5 (1 padding bit + 2 bits of carry and 2 bits of message), so maybe hashing 1 (padding), 2 (carry) and 2 (message)

message today being hashed already

feel free to ask questions

I added a test in shortint which should ensure all properties we care about for the PRF + rerand are tested

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3580)
<!-- Reviewable:end -->
