### PR TITLE
chore: CompressedXofKeySet is infallible

### DIFF
--- a/tests/backward_compatibility/high_level_api.rs
+++ b/tests/backward_compatibility/high_level_api.rs
@@ -1062,9 +1062,7 @@ fn test_hl_compressed_xof_key_set_test(
         )
     })?;
 
-    let xof_key_set = compressed_xof_key_set
-        .decompress()
-        .map_err(|e| test.failure(format!("Failed to decompress the xof key set: {e}"), format))?;
+    let xof_key_set = compressed_xof_key_set.decompress();
 
     let (pk, server_key) = xof_key_set.into_raw_parts();
 

--- a/tfhe/src/high_level_api/xof_key_set/mod.rs
+++ b/tfhe/src/high_level_api/xof_key_set/mod.rs
@@ -389,7 +389,7 @@ impl CompressedXofKeySet {
     }
 
     /// Decompress the KeySet
-    pub fn decompress(&self) -> crate::Result<XofKeySet> {
+    pub fn decompress(&self) -> XofKeySet {
         let tag = self.compressed_server_key.tag.clone();
         let (mut public_key, expanded_server_key) = self.expand();
         // Server key tag is the source of truth; sync public key
@@ -400,10 +400,10 @@ impl CompressedXofKeySet {
             tag,
         };
 
-        Ok(XofKeySet {
+        XofKeySet {
             public_key,
             server_key,
-        })
+        }
     }
 
     fn expand(&self) -> (CompactPublicKey, IntegerExpandedServerKey) {

--- a/tfhe/src/high_level_api/xof_key_set/test.rs
+++ b/tfhe/src/high_level_api/xof_key_set/test.rs
@@ -244,7 +244,7 @@ fn test_xof_key_set(
 
     let cpk = match device {
         Device::Cpu => {
-            let key_set = compressed_key_set.decompress().unwrap();
+            let key_set = compressed_key_set.decompress();
             let size_limit = 1 << 33; // 8GB
             let mut data = vec![];
             crate::safe_serialization::safe_serialize(&key_set, &mut data, size_limit).unwrap();


### PR DESCRIPTION
Makes `CompressedXofKeySet::decompress` return an `XofKeySet` instead of a `Result`. This mirrors the behaviour of most other `decompress` methods in the library and is consistent with idiomatic Rust.

Fixes https://github.com/zama-ai/tfhe-rs-internal/issues/1380


