### PR TITLE
chore: avoid cloning IntegerServerKey when destructuring a ServerKey

### DIFF
--- a/tfhe/src/high_level_api/keys/server.rs
+++ b/tfhe/src/high_level_api/keys/server.rs
@@ -98,7 +98,7 @@ impl ServerKey {
             noise_squashing_compression_key,
             cpk_re_randomization_key,
             oprf_key,
-        } = (*self.key).clone();
+        } = Arc::unwrap_or_clone(self.key);
 
         (
             key,


### PR DESCRIPTION
The `hla::ServerKey` stores an inner `IntegerServerKey` in an `Arc`. It also provides an `into_raw_parts` method. The resulting semantics are a bit sketchy. 

On the one hand there is a public API promise that `ServerKey` is cheap to clone. This assumption is widely relied upon in all kinds of public APIs and changing this would be a massive breaking change I believe. 

On the other hand, an `into_raw_parts` method that consumes `self` clearly communicates that the data is not to be used afterwards; in reality there may be any number of clones in use by any number of threads.

This PR makes `into_raw_parts` try to unwrap the `Arc` and avoid the clone **iff** the strong count is one, i.e. if there are no clones about, then `into_raw_parts` truly consumes `self`. Otherwise it clones the `IntegerServerKey` like before.

In the KMS, this change saves ~1.5Gb in allocations, per party, for user decryption tests, which is what I happened to measure. 
