### PR TITLE
feat(shortint): add aes for transciphering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3002,7 +3002,7 @@ dependencies = [
 
 [[package]]
 name = "tfhe-csprng"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "aes",
  "clap",

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ CARGO_SEMVER_CHECKS_VERSION=0.47.0
 export RUSTFLAGS?=-C target-cpu=native
 
 include utils/tfhe-lints/Makefile
+include make/transciphering.mk
 
 ifeq ($(GEN_KEY_CACHE_MULTI_BIT_ONLY),TRUE)
 		MULTI_BIT_ONLY=--multi-bit-only

--- a/apps/trivium/Cargo.lock
+++ b/apps/trivium/Cargo.lock
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "tfhe-csprng"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "aes",
  "getrandom",

--- a/make/transciphering.mk
+++ b/make/transciphering.mk
@@ -1,0 +1,63 @@
+# Make rules for the FHE transciphering ciphers (tfhe/src/transciphering/ciphers/).
+#
+# Optional variables:
+#   BENCH_FILTER  Criterion regex selecting which sub-benchmarks to run
+#                 (default: run all). Examples:
+#                   make bench_aes_transciphering BENCH_FILTER=key_expansion
+#                   make bench_aes_transciphering BENCH_FILTER=keystream_16
+#                   make bench_aes_transciphering BENCH_FILTER='keystream_(1|16)'
+
+BENCH_FILTER ?=
+
+#
+# Tests
+#
+
+.PHONY: test_aes_transciphering # Run unit tests for the FHE AES-128 (CTR) implementation
+test_aes_transciphering:
+	RUSTFLAGS="$(RUSTFLAGS)" cargo test --profile $(CARGO_PROFILE) \
+		--features=shortint -p tfhe --lib \
+		transciphering::ciphers::aes
+
+.PHONY: test_aes_transciphering_fast # Same as above but only the non-FHE tests (plain helpers + skip)
+test_aes_transciphering_fast:
+	RUSTFLAGS="$(RUSTFLAGS)" cargo test --profile $(CARGO_PROFILE) \
+		--features=shortint -p tfhe --lib \
+		"transciphering::ciphers::aes::test::plain_aes"
+	RUSTFLAGS="$(RUSTFLAGS)" cargo test --profile $(CARGO_PROFILE) \
+		--features=shortint -p tfhe --lib \
+		"transciphering::ciphers::aes::test::aes_fhe_skip"
+
+#
+# Benchmarks
+#
+
+.PHONY: bench_aes_transciphering # Run criterion benches for the CPU bit-sliced AES-128 transciphering pipeline
+bench_aes_transciphering:
+	RUSTFLAGS="$(RUSTFLAGS)" __TFHE_RS_BENCH_TYPE=$(BENCH_TYPE) \
+	cargo bench \
+		--bench shortint-aes-transciphering \
+		--features=shortint,internal-keycache \
+		-p tfhe-benchmark -- $(BENCH_FILTER)
+
+# Convenience shortcuts: each sets BENCH_FILTER and recurses into the main rule.
+
+.PHONY: bench_aes_keystream_1 # AES: single CTR block (128 bits) keystream
+bench_aes_keystream_1:
+	$(MAKE) bench_aes_transciphering BENCH_FILTER=keystream_1_block
+
+.PHONY: bench_aes_keystream_16 # AES: 16 CTR blocks keystream
+bench_aes_keystream_16:
+	$(MAKE) bench_aes_transciphering BENCH_FILTER=keystream_16_blocks
+
+.PHONY: bench_aes_key_expansion # AES: one-time key schedule cost
+bench_aes_key_expansion:
+	$(MAKE) bench_aes_transciphering BENCH_FILTER=key_expansion$$
+
+.PHONY: bench_aes_key_expansion_plus_1_block # AES: cold-start (key schedule + 1 CTR block)
+bench_aes_key_expansion_plus_1_block:
+	$(MAKE) bench_aes_transciphering BENCH_FILTER=key_expansion_plus_1_block
+
+.PHONY: bench_aes_transcipher # AES: end-to-end transcipher over 16 blocks
+bench_aes_transcipher:
+	$(MAKE) bench_aes_transciphering BENCH_FILTER=transcipher_16_blocks

--- a/tfhe-benchmark/Cargo.toml
+++ b/tfhe-benchmark/Cargo.toml
@@ -166,6 +166,12 @@ harness = false
 required-features = ["integer", "internal-keycache"]
 
 [[bench]]
+name = "shortint-aes-transciphering"
+path = "benches/shortint/aes_transciphering.rs"
+harness = false
+required-features = ["shortint", "internal-keycache"]
+
+[[bench]]
 name = "integer-trivium"
 path = "benches/integer/trivium.rs"
 harness = false

--- a/tfhe-benchmark/benches/shortint/aes_transciphering.rs
+++ b/tfhe-benchmark/benches/shortint/aes_transciphering.rs
@@ -1,0 +1,192 @@
+//! CPU benchmarks for the bit-sliced shortint AES-128 transciphering pipeline
+//! (`tfhe::transciphering::ciphers::aes`).
+//!
+//! Available cases (filter with criterion's `--bench` arg or via the Makefile's
+//! `BENCH_FILTER`):
+//!   * `key_expansion`        : one-time `AesFheKey::new` cost per key.
+//!   * `keystream_1_block`    : single CTR block (128 bits) without `apply_keystream`; the unit hot
+//!     path.
+//!   * `keystream_16_blocks`  : 16 CTR blocks (cheap multi-block measurement).
+//!   * `transcipher_16_blocks` : end-to-end `transcipher` over 16 blocks (`next_keystream_bits` +
+//!     `apply_keystream_2_2`).
+//!
+//! Run with:
+//! ```sh
+//! cargo bench --features=shortint,internal-keycache \
+//!     --bench shortint-aes-transciphering
+//! ```
+
+use benchmark::params_aliases::BENCH_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+use benchmark::utilities::{write_to_json_unchecked, OperatorType};
+use criterion::measurement::WallTime;
+use criterion::{black_box, criterion_group, Bencher, BenchmarkGroup, Criterion};
+use rand::{Rng, SeedableRng};
+use tfhe::keycache::NamedParam;
+use tfhe::shortint::prelude::*;
+use tfhe::shortint::AtomicPatternParameters;
+use tfhe::transciphering::ciphers::aes::{
+    AesFheRoundKeys, AesFheState, AesPlainKey, AesPlainState,
+};
+use tfhe::transciphering::{StreamCipher, Transcipherer};
+
+const N_BLOCKS: usize = 16;
+const BLOCK_BITS: usize = 128;
+const BLOCK_BYTES: usize = 16;
+
+fn bench_and_record<F>(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    id: &str,
+    param_name: &str,
+    display_name: &str,
+    bit_size: u32,
+    decomposition_basis: Vec<u32>,
+    mut routine: F,
+) where
+    F: FnMut(&mut Bencher<'_, WallTime>),
+{
+    let recorded = std::sync::Once::new();
+    group.bench_function(id, |b| {
+        routine(b);
+        recorded.call_once(|| {
+            write_to_json_unchecked(
+                id,
+                param_name,
+                display_name,
+                &OperatorType::Atomic,
+                bit_size,
+                decomposition_basis.clone(),
+            );
+        });
+    });
+}
+
+pub fn cpu_aes_transciphering(c: &mut Criterion) {
+    let bench_name = "transciphering::cpu::aes";
+
+    let seed: u64 = rand::thread_rng().gen();
+    let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+
+    let key: u128 = rng.gen();
+    let iv: u128 = rng.gen();
+
+    let mut group = c.benchmark_group(bench_name);
+    group
+        .sample_size(10)
+        .measurement_time(std::time::Duration::from_secs(60))
+        .warm_up_time(std::time::Duration::from_secs(5));
+
+    let params = BENCH_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+    let param_name = params.name();
+    let atomic_param: AtomicPatternParameters = params.into();
+    let log2_msg = atomic_param.message_modulus().0.ilog2();
+
+    let (cks, sks) = gen_keys(params);
+    let enc_key = AesPlainKey::from(key).encrypt(&cks);
+
+    // ---- key_expansion ----
+    let id = format!("{bench_name}::{}::key_expansion", &param_name);
+    bench_and_record(
+        &mut group,
+        &id,
+        &param_name,
+        "aes_key_expansion",
+        BLOCK_BITS as u32,
+        vec![log2_msg; BLOCK_BITS],
+        |b| {
+            b.iter(|| {
+                black_box(AesFheRoundKeys::new(&sks, &enc_key));
+            })
+        },
+    );
+
+    // ---- key_expansion_plus_1_block ----
+    // Cold-start cost: fresh key schedule + one CTR block keystream per iter.
+    let id = format!("{bench_name}::{}::key_expansion_plus_1_block", &param_name);
+    bench_and_record(
+        &mut group,
+        &id,
+        &param_name,
+        "aes_key_expansion_plus_1_block",
+        BLOCK_BITS as u32,
+        vec![log2_msg; BLOCK_BITS],
+        |b| {
+            b.iter(|| {
+                let fhe_key = AesFheRoundKeys::new(&sks, &enc_key);
+                let mut stream = AesFheState::new(fhe_key, iv);
+                black_box(stream.next_keystream_bits(&sks, BLOCK_BITS));
+            })
+        },
+    );
+
+    // Single stream reused across the remaining benches via `seek(_, 0)`.
+    let fhe_key = AesFheRoundKeys::new(&sks, &enc_key);
+    let mut stream = AesFheState::new(fhe_key, iv);
+
+    // ---- keystream_1_block ----
+    let id = format!("{bench_name}::{}::keystream_1_block", &param_name);
+    bench_and_record(
+        &mut group,
+        &id,
+        &param_name,
+        "aes_keystream_1_block",
+        BLOCK_BITS as u32,
+        vec![log2_msg; BLOCK_BITS],
+        |b| {
+            b.iter(|| {
+                stream.seek(&sks, 0);
+                black_box(stream.next_keystream_bits(&sks, BLOCK_BITS));
+            })
+        },
+    );
+
+    // ---- keystream_16_blocks ----
+    let total_bits = BLOCK_BITS * N_BLOCKS;
+    let id = format!("{bench_name}::{}::keystream_16_blocks", &param_name);
+    bench_and_record(
+        &mut group,
+        &id,
+        &param_name,
+        "aes_keystream_16_blocks",
+        total_bits as u32,
+        vec![log2_msg; total_bits],
+        |b| {
+            b.iter(|| {
+                stream.seek(&sks, 0);
+                black_box(stream.next_keystream_bits(&sks, total_bits));
+            })
+        },
+    );
+
+    // ---- transcipher_16_blocks ----
+    // Pre-compute the symmetric ciphertext so the bench only times the FHE
+    // side. The clear `AesPlainStream` starts at counter 0, matching our
+    // `seek(&sks, 0)` reset below.
+    let total_bytes = BLOCK_BYTES * N_BLOCKS;
+    let message = vec![0u8; total_bytes];
+    let sym_cipher = AesPlainState::new(key, iv).encrypt(&message);
+
+    let id = format!("{bench_name}::{}::transcipher_16_blocks", &param_name);
+    bench_and_record(
+        &mut group,
+        &id,
+        &param_name,
+        "aes_transcipher_16_blocks",
+        total_bits as u32,
+        vec![log2_msg; total_bits],
+        |b| {
+            b.iter(|| {
+                stream.seek(&sks, 0);
+                black_box(stream.transcipher(&sks, &sym_cipher).unwrap());
+            })
+        },
+    );
+
+    group.finish();
+}
+
+criterion_group!(cpu_aes, cpu_aes_transciphering);
+
+fn main() {
+    cpu_aes();
+    Criterion::default().configure_from_args().final_summary();
+}

--- a/tfhe-csprng/Cargo.toml
+++ b/tfhe-csprng/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tfhe-csprng"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 license = "BSD-3-Clause-Clear"
 description = "Cryptographically Secure PRNG used in the TFHE-rs library."

--- a/tfhe-csprng/src/generators/aes_ctr/block_cipher.rs
+++ b/tfhe-csprng/src/generators/aes_ctr/block_cipher.rs
@@ -12,6 +12,17 @@ use crate::generators::aes_ctr::{AES_CALLS_PER_BATCH, BYTES_PER_AES_CALL, BYTES_
 #[derive(Clone, Copy, Debug)]
 pub struct AesKey(pub(crate) u128);
 
+impl AesKey {
+    /// Builds an [`AesKey`] from a `u128`.
+    ///
+    /// The `u128` is interpreted in native endian ordering, so that its in-memory bytes are
+    /// equivalent to a `[u8; 16]` (see the type-level documentation). Callers that load a key from
+    /// raw bytes must therefore arrange them to match the native byte order beforehand.
+    pub const fn new(key: u128) -> Self {
+        Self(key)
+    }
+}
+
 /// A trait for AES block ciphers.
 ///
 /// Note:

--- a/tfhe-csprng/src/generators/default.rs
+++ b/tfhe-csprng/src/generators/default.rs
@@ -9,11 +9,13 @@ pub type DefaultRandomGenerator = super::NeonAesRandomGenerator;
 pub type DefaultRandomGenerator = super::SoftwareRandomGenerator;
 
 #[cfg(all(target_arch = "x86_64", not(feature = "software-prng")))]
-pub type DefaultBlockCipher = super::implem::AesniBlockCipher;
+pub type AesDefaultBlockCipher = super::implem::AesniBlockCipher;
 #[cfg(all(target_arch = "aarch64", not(feature = "software-prng")))]
-pub type DefaultBlockCipher = super::implem::ArmAesBlockCipher;
+pub type AesDefaultBlockCipher = super::implem::ArmAesBlockCipher;
 #[cfg(any(
     feature = "software-prng",
     not(any(target_arch = "x86_64", target_arch = "aarch64"))
 ))]
-pub type DefaultBlockCipher = super::SoftwareBlockCipher;
+pub type AesDefaultBlockCipher = super::SoftwareBlockCipher;
+
+pub type DefaultBlockCipher = AesDefaultBlockCipher;

--- a/tfhe/Cargo.toml
+++ b/tfhe/Cargo.toml
@@ -54,7 +54,7 @@ clap-num = { version = "1.1.1" }
 cbindgen = { version = "0.28", optional = true }
 
 [dependencies]
-tfhe-csprng = { version = "0.9.1", path = "../tfhe-csprng", features = [
+tfhe-csprng = { version = "0.9.2", path = "../tfhe-csprng", features = [
     "parallel",
 ] }
 serde = { workspace = true, features = ["default", "derive"] }

--- a/tfhe/src/transciphering/ciphers/aes/encrypt.rs
+++ b/tfhe/src/transciphering/ciphers/aes/encrypt.rs
@@ -1,0 +1,185 @@
+//! AES-128 round operations and the per-block encryption routine.
+
+use std::array::from_fn;
+
+use crate::shortint::server_key::LookupTable;
+use crate::shortint::{Ciphertext, ServerKey};
+use rayon::prelude::*;
+
+use super::key::AesFheRoundKeys;
+use super::sbox::sbox;
+
+/// XOR `rhs` into `lhs` element-wise.
+pub(super) fn xor_assign(sks: &ServerKey, lhs: &mut [Ciphertext], rhs: &[Ciphertext]) {
+    for (s, k) in lhs.iter_mut().zip(rhs) {
+        sks.unchecked_add_assign(s, k);
+    }
+}
+
+/// AES ShiftRows: row `r` is rotated left by `r` bytes.
+///
+/// The state is 16 bytes in column-major order, byte `(row, col)` at index
+/// `row + 4*col` (each byte spans 8 ciphertexts, so byte `b` is at bits
+/// `8*b..8*b+8`):
+///
+/// ```text
+///          col0 col1 col2 col3                col0 col1 col2 col3
+///   row0 [  0    4    8   12 ]   --ShiftRows->   0    4    8   12   (<<< 0)
+///   row1 [  1    5    9   13 ]                   5    9   13    1   (<<< 1)
+///   row2 [  2    6   10   14 ]                  10   14    2    6   (<<< 2)
+///   row3 [  3    7   11   15 ]                  15    3    7   11   (<<< 3)
+/// ```
+///
+/// Each row's left-rotation is realized by the chain of byte swaps below
+/// (rows 0 is a no-op; row 2's rotate-by-2 is two disjoint swaps).
+pub(super) fn shift_rows(state: &mut [Ciphertext; 128]) {
+    let (bytes, rest) = state.as_chunks_mut::<8>();
+    debug_assert!(rest.is_empty());
+
+    bytes.swap(1, 5);
+    bytes.swap(5, 9);
+    bytes.swap(9, 13);
+
+    bytes.swap(2, 10);
+    bytes.swap(6, 14);
+
+    bytes.swap(15, 11);
+    bytes.swap(11, 7);
+    bytes.swap(7, 3);
+}
+
+/// Multiply a GF(2^8) byte by `x` (AES `xtime`), in LSB-first layout.
+///
+/// `bits[0..7]` shift to `result[1..8]` and `result[0] = bits[7]` (the MSB
+/// becomes the new LSB, encoding the `+1` term of the reduction polynomial
+/// `0x1B`). The three remaining bits of `0x1B` are at positions 1, 3, 4 in
+/// LSB-first, so we XOR the old MSB into those positions and flush them
+/// (positions 0, 2, 5, 6, 7 stay at noise 1 from the shift alone, but the
+/// flushed three need to be ≤ 1 for the four-term MixColumns chain to fit
+/// the `2_2` `max_noise_level = 5` budget).
+fn xtime(
+    sks: &ServerKey,
+    flush_lut: &LookupTable<Vec<u64>>,
+    bits: &[Ciphertext; 8],
+) -> [Ciphertext; 8] {
+    let msb = &bits[7];
+    let mut result = [
+        msb.clone(),
+        bits[0].clone(),
+        bits[1].clone(),
+        bits[2].clone(),
+        bits[3].clone(),
+        bits[4].clone(),
+        bits[5].clone(),
+        bits[6].clone(),
+    ];
+    // The three flushes at positions 1, 3, 4 are independent, split disjoint
+    // mut refs to run them in parallel.
+    let [_, r1, _, r3, r4, _, _, _] = &mut result;
+    [r1, r3, r4].par_iter_mut().for_each(|r| {
+        sks.unchecked_add_assign(r, msb);
+        sks.apply_lookup_table_assign(r, flush_lut);
+    });
+    result
+}
+
+/// AES MixColumns on a single 32-bit column. The four `xtime` calls are run
+/// in parallel since they only depend on the input column.
+pub(super) fn mix_columns_op(
+    sks: &ServerKey,
+    flush_lut: &LookupTable<Vec<u64>>,
+    input: &[Ciphertext; 32],
+) -> [Ciphertext; 32] {
+    let (chunks, rest) = input.as_chunks::<8>();
+    debug_assert!(rest.is_empty());
+    let [c0, c1, c2, c3]: &[[Ciphertext; 8]; 4] = chunks.try_into().unwrap();
+
+    let [mut b0, mut b1, mut b2, mut b3] = [c0, c1, c2, c3]
+        .par_iter()
+        .map(|c| xtime(sks, flush_lut, c))
+        .collect::<Vec<_>>()
+        .try_into()
+        .unwrap();
+    let b0_copy = b0.clone();
+
+    // Mix matrix [2 3 1 1; 1 2 3 1; 1 1 2 3; 3 1 1 2] applied row by row.
+    xor_assign(sks, &mut b0, &b1);
+    xor_assign(sks, &mut b0, c1);
+    xor_assign(sks, &mut b0, c2);
+    xor_assign(sks, &mut b0, c3);
+
+    xor_assign(sks, &mut b1, c0);
+    xor_assign(sks, &mut b1, &b2);
+    xor_assign(sks, &mut b1, c2);
+    xor_assign(sks, &mut b1, c3);
+
+    xor_assign(sks, &mut b2, c0);
+    xor_assign(sks, &mut b2, c1);
+    xor_assign(sks, &mut b2, &b3);
+    xor_assign(sks, &mut b2, c3);
+
+    xor_assign(sks, &mut b3, c0);
+    xor_assign(sks, &mut b3, c1);
+    xor_assign(sks, &mut b3, c2);
+    xor_assign(sks, &mut b3, &b0_copy);
+
+    let mut iter = b0.into_iter().chain(b1).chain(b2).chain(b3);
+    from_fn(|_| iter.next().unwrap())
+}
+
+fn mix_columns(sks: &ServerKey, flush_lut: &LookupTable<Vec<u64>>, state: &mut [Ciphertext]) {
+    let (chunks, _) = state.as_chunks_mut::<32>();
+    chunks
+        .par_iter_mut()
+        .for_each(|col: &mut [Ciphertext; 32]| {
+            let mix_col = mix_columns_op(sks, flush_lut, col);
+            col.clone_from_slice(&mix_col);
+        });
+}
+
+fn sub_bytes(sks: &ServerKey, state: &mut [Ciphertext; 128], flush_lut: &LookupTable<Vec<u64>>) {
+    state
+        .par_chunks_mut(8)
+        .for_each(|chunk| sbox(sks, flush_lut, chunk));
+}
+
+fn flush_state(sks: &ServerKey, state: &mut [Ciphertext], flush_lut: &LookupTable<Vec<u64>>) {
+    state.par_iter_mut().for_each(|b| {
+        sks.apply_lookup_table_assign(b, flush_lut);
+    });
+}
+
+/// FHE AES-128 of a single public CTR counter block, returning its 128
+/// keystream bits at noise level 1.
+///
+/// Noise contract: every `xor_assign` with a round key is followed by a
+/// `flush_state`, so each pipeline stage (`sub_bytes`, `mix_columns`, the next
+/// `xor_assign`) sees noise-1 inputs and never exceeds `max_noise_level`.
+pub(super) fn encrypt_block(
+    sks: &ServerKey,
+    counter_value: u128,
+    key: &AesFheRoundKeys,
+) -> [Ciphertext; 128] {
+    let bytes = counter_value.to_be_bytes();
+    let mut state: [Ciphertext; 128] =
+        from_fn(|i| sks.create_trivial(((bytes[i / 8] >> (i % 8)) & 1) as u64));
+    let round_keys = key.round_keys();
+    let flush_lut = key.flush_lut();
+
+    xor_assign(sks, &mut state, &round_keys[0].key);
+    for erk in &round_keys[1..10] {
+        sub_bytes(sks, &mut state, flush_lut);
+        flush_state(sks, &mut state, flush_lut);
+        shift_rows(&mut state);
+        mix_columns(sks, flush_lut, &mut state);
+        flush_state(sks, &mut state, flush_lut);
+        xor_assign(sks, &mut state, &erk.key);
+        flush_state(sks, &mut state, flush_lut);
+    }
+    sub_bytes(sks, &mut state, flush_lut);
+    shift_rows(&mut state);
+    xor_assign(sks, &mut state, &round_keys[10].key);
+    flush_state(sks, &mut state, flush_lut);
+
+    state
+}

--- a/tfhe/src/transciphering/ciphers/aes/fhe.rs
+++ b/tfhe/src/transciphering/ciphers/aes/fhe.rs
@@ -1,0 +1,85 @@
+use crate::shortint::{Ciphertext, ServerKey};
+use crate::transciphering::ciphers::aes::AesIv;
+use crate::transciphering::{FheKeyStream, StreamCipherKind, Transcipherer};
+use rayon::prelude::*;
+
+use super::encrypt::encrypt_block;
+use super::key::AesFheRoundKeys;
+
+/// Server-side AES-128 in CTR mode, driven through the [`Transcipherer`] trait.
+pub struct AesFheState {
+    key: AesFheRoundKeys,
+    iv: AesIv,
+    counter: u64,
+}
+
+impl AesFheState {
+    pub fn new(key: AesFheRoundKeys, iv: impl Into<AesIv>) -> Self {
+        Self {
+            key,
+            iv: iv.into(),
+            counter: 0,
+        }
+    }
+
+    /// Compute `AES_k(iv + block_index)` as 128 FHE bits. The counter is public,
+    /// so it is injected via `create_trivial` (no PBS).
+    fn keystream_block(&self, sks: &ServerKey, block_index: u128) -> [Ciphertext; 128] {
+        let counter_value = self.iv.to_u128().wrapping_add(block_index);
+        encrypt_block(sks, counter_value, &self.key)
+    }
+}
+
+impl Transcipherer for AesFheState {
+    fn kind(&self) -> StreamCipherKind {
+        StreamCipherKind::Aes
+    }
+
+    fn next_keystream_bits(&mut self, sks: &ServerKey, n_bits: usize) -> FheKeyStream {
+        //  counter
+        //     │
+        //     ▼
+        //  ┌────────────────┬────────────────┬────────────────┐
+        //  │  start_block   │ start_block+1  │ start_block+2  │  ← 128 bits each
+        //  └────────────────┴────────────────┴────────────────┘
+        //   ▓▓▓▓▓░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░▓▓▓▓▓▓
+        //   └─┬─┘└────────────────  n_bits  ─────────────┘└─┬──┘
+        //  skip_head           kept & returned          tail dropped
+        //  (dropped)
+        //
+        //  Both boundary blocks are computed in full but only partially used:
+        //  a non-block-aligned call wastes the head + tail. The byte-aligned
+        //  transciphering path requests the whole message in one call to avoid
+        //  this.
+        let skip_head = (self.counter % 128) as usize;
+        let start_block = self.counter / 128;
+        let n_blocks = (skip_head + n_bits).div_ceil(128);
+
+        let blocks: Vec<[Ciphertext; 128]> = (0..n_blocks as u64)
+            .into_par_iter()
+            .map(|i| self.keystream_block(sks, (start_block + i) as u128))
+            .collect();
+
+        self.counter = self
+            .counter
+            .checked_add(n_bits as u64)
+            .expect("AesFheStream: keystream bit counter overflowed u64");
+
+        let flat: Vec<Ciphertext> = blocks
+            .into_iter()
+            .flatten()
+            .skip(skip_head)
+            .take(n_bits)
+            .collect();
+
+        FheKeyStream::from_raw_parts(flat)
+    }
+
+    fn seek(&mut self, _sks: &ServerKey, target_counter: u64) {
+        self.counter = target_counter;
+    }
+
+    fn current_counter(&self) -> u64 {
+        self.counter
+    }
+}

--- a/tfhe/src/transciphering/ciphers/aes/key.rs
+++ b/tfhe/src/transciphering/ciphers/aes/key.rs
@@ -1,0 +1,121 @@
+use std::array::from_fn;
+
+use crate::shortint::server_key::LookupTable;
+use crate::shortint::{Ciphertext, ServerKey};
+use crate::transciphering::ciphers::aes::AesFheKey;
+use rayon::prelude::*;
+
+use super::sbox::sbox;
+
+/// FHE-encrypted AES-128 round keys (11 round keys × 128 bits), plus the
+/// param-dependent `x & 1` flush LUT reused by every CTR block. The LUT depends
+/// only on the [`ServerKey`] so we generate it once at key construction.
+pub struct AesFheRoundKeys {
+    round_keys: [AesFheKey; 11],
+    flush_lut: LookupTable<Vec<u64>>,
+}
+
+impl AesFheRoundKeys {
+    /// `key_bits` is the bit-encrypted 128-bit master key in the convention of
+    /// [`super::AesPlainKey::encrypt`] (NIST byte order, LSB-first within each
+    /// byte, one clean degree-1 ciphertext per bit).
+    ///
+    /// # Panics
+    ///
+    /// AES transciphering is implemented for `MESSAGE_2_CARRY_2` parameters
+    /// only: the whole noise budget (flushes target `noise ≤ 5`, accumulators
+    /// reach degree 5 before a flush) assumes `message_modulus = carry_modulus
+    /// = 4` and `max_noise_level ≥ 5`. This panics otherwise.
+    pub fn new(sks: &ServerKey, key_bits: &AesFheKey) -> Self {
+        assert_eq!(
+            (sks.message_modulus.0, sks.carry_modulus.0),
+            (4, 4),
+            "AES transciphering is implemented for MESSAGE_2_CARRY_2 only \
+             (got message_modulus={}, carry_modulus={})",
+            sks.message_modulus.0,
+            sks.carry_modulus.0,
+        );
+        assert!(
+            sks.max_noise_level.get() >= 5,
+            "AES transciphering needs max_noise_level >= 5, got {}",
+            sks.max_noise_level.get(),
+        );
+
+        let flush_lut = sks.generate_lookup_table(|x: u64| x & 1);
+        let round_keys = key_expansion(sks, key_bits, &flush_lut);
+        Self {
+            round_keys,
+            flush_lut,
+        }
+    }
+
+    pub(super) fn round_keys(&self) -> &[AesFheKey; 11] {
+        &self.round_keys
+    }
+
+    pub(super) fn flush_lut(&self) -> &LookupTable<Vec<u64>> {
+        &self.flush_lut
+    }
+}
+
+const RCON: [u8; 10] = [0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80, 0x1B, 0x36];
+
+/// NIST FIPS 197 §5.2 KeyExpansion (AES-128 only).
+fn key_expansion(
+    sks: &ServerKey,
+    encrypted_key: &AesFheKey,
+    flush_lut: &LookupTable<Vec<u64>>,
+) -> [AesFheKey; 11] {
+    const NK: usize = 4;
+    const NR: usize = 10;
+    const NB: usize = 4;
+    const TOTAL_WORDS: usize = NB * (NR + 1);
+    const WORD_BITS: usize = 32;
+    const BYTE_BITS: usize = 8;
+
+    let mut w = Vec::with_capacity(TOTAL_WORDS * WORD_BITS);
+    w.extend(encrypted_key.key.iter().cloned());
+
+    // AES-256 would add an `else if Nk > 6 && i % Nk == 4 { temp = SubWord(temp) }`
+    // branch (unreachable here with Nk = 4).
+    for i in NK..TOTAL_WORDS {
+        // NIST line 8: temp = w[i-1].
+        let mut temp: Vec<Ciphertext> = w[(i - 1) * WORD_BITS..i * WORD_BITS].to_vec();
+
+        // NIST line 10 (when applicable): temp = SubWord(RotWord(temp)) xor Rcon[i/Nk].
+        // RotWord is folded into the read offset of the final XOR (below).
+        let rot_shift = if i % NK == 0 {
+            temp.par_chunks_mut(BYTE_BITS).for_each(|chunk| {
+                sbox(sks, flush_lut, chunk);
+            });
+
+            // Rcon is XOR'd into the byte that becomes byte 0 after RotWord.
+            for bit in 0..BYTE_BITS {
+                let rcon_bit = (RCON[i / NK - 1] >> bit) & 1;
+                if rcon_bit == 1 {
+                    sks.unchecked_scalar_add_assign(&mut temp[bit + BYTE_BITS], 1);
+                }
+            }
+
+            BYTE_BITS
+        } else {
+            0
+        };
+
+        // NIST line 14: w[i] = w[i-Nk] xor temp.
+        let w_minus_nk = &w[(i - NK) * WORD_BITS..(i - NK + 1) * WORD_BITS];
+        let mut new_word: Vec<Ciphertext> = (0..WORD_BITS)
+            .map(|bit| sks.unchecked_add(&w_minus_nk[bit], &temp[(bit + rot_shift) % WORD_BITS]))
+            .collect();
+        new_word.par_iter_mut().for_each(|b| {
+            sks.apply_lookup_table_assign(b, flush_lut);
+        });
+        w.extend(new_word);
+    }
+
+    debug_assert_eq!(w.len(), (NR + 1) * (NB * WORD_BITS));
+    let mut w_iter = w.into_iter();
+    from_fn(|_| AesFheKey {
+        key: from_fn(|_| w_iter.next().unwrap()),
+    })
+}

--- a/tfhe/src/transciphering/ciphers/aes/mod.rs
+++ b/tfhe/src/transciphering/ciphers/aes/mod.rs
@@ -1,0 +1,117 @@
+//! Bit-sliced FHE AES-128 in CTR mode for transciphering.
+
+mod encrypt;
+mod fhe;
+mod key;
+mod plain;
+mod sbox;
+#[cfg(test)]
+mod test;
+
+pub use fhe::AesFheState;
+pub use key::AesFheRoundKeys;
+pub use plain::AesPlainState;
+
+use crate::shortint::ciphertext::Degree;
+use crate::shortint::{Ciphertext, ClientKey};
+use crate::transciphering::ciphers::*;
+
+/// Big endian byte order.
+///
+/// The 16 key bytes are stored most-significant first, so for a `u128` value
+/// `bits[0]` holds the top byte. `expand()` then unpacks each byte LSB-first
+/// into the `[bool; 128]` consumed by the bit-sliced circuit:
+///
+/// ```text
+/// u128 = 0xB0 B1 B2 ... BF              (16 bytes, big endian)
+///           │  │            │
+///           ▼  ▼            ▼
+/// bits  = [ B0 B1 B2 ...    BF ]        bits[0] = MSB byte, bits[15] = LSB byte
+///
+/// within one byte, expand() goes LSB-first:
+///
+///   byte  = b7 b6 b5 b4 b3 b2 b1 b0     (binary, MSB .. LSB)
+///   bool[] = [ b0 b1 b2 b3 b4 b5 b6 b7 ]  (increasing array index)
+/// ```
+#[derive(Clone, Copy)]
+pub struct AesPlainKey([u8; 16]);
+
+impl AesPlainKey {
+    pub fn expand(self) -> [bool; 128] {
+        let mut out = [false; 128];
+        unpack_bits_lsb_first(&self.0, &mut out);
+        out
+    }
+
+    pub fn encrypt(&self, client_key: &ClientKey) -> AesFheKey {
+        AesFheKey {
+            key: self.expand().map(|b| {
+                let mut c = client_key.encrypt(b as u64);
+                c.degree = Degree::new(1);
+                c
+            }),
+        }
+    }
+
+    pub(crate) fn to_csprng_key_u128(self) -> u128 {
+        u128::from_ne_bytes(self.0)
+    }
+}
+
+impl From<u128> for AesPlainKey {
+    fn from(value: u128) -> Self {
+        value.to_be_bytes().into()
+    }
+}
+
+impl From<[u8; 16]> for AesPlainKey {
+    fn from(value: [u8; 16]) -> Self {
+        Self(value)
+    }
+}
+
+impl From<[bool; 128]> for AesPlainKey {
+    fn from(value: [bool; 128]) -> Self {
+        let mut bits = [0u8; 16];
+        pack_bits_lsb_first(&value, &mut bits);
+        bits.into()
+    }
+}
+
+pub struct AesFheKey {
+    key: [Ciphertext; 128],
+}
+
+/// AES-128 IV / initial CTR counter, as a plain 128-bit integer.
+///
+/// The counter is incremented directly (`iv + block_index`), the big-endian
+/// (NIST) convention only applies when bytes are involved, i.e. at the
+/// `[u8; 16]` / `[bool; 128]` construction boundaries.
+#[derive(Clone, Copy)]
+pub struct AesIv(u128);
+
+impl AesIv {
+    pub fn to_u128(self) -> u128 {
+        self.0
+    }
+}
+
+impl From<u128> for AesIv {
+    fn from(value: u128) -> Self {
+        Self(value)
+    }
+}
+
+impl From<[u8; 16]> for AesIv {
+    fn from(value: [u8; 16]) -> Self {
+        u128::from_be_bytes(value).into()
+    }
+}
+
+impl From<[bool; 128]> for AesIv {
+    fn from(value: [bool; 128]) -> Self {
+        let mut bits = [0u8; 16];
+        pack_bits_lsb_first(&value, &mut bits);
+        bits.into()
+    }
+}

--- a/tfhe/src/transciphering/ciphers/aes/plain.rs
+++ b/tfhe/src/transciphering/ciphers/aes/plain.rs
@@ -1,0 +1,65 @@
+use tfhe_csprng::generators::aes_ctr::{AesBlockCipher, AesKey};
+use tfhe_csprng::generators::default::AesDefaultBlockCipher;
+
+use crate::transciphering::ciphers::aes::{AesIv, AesPlainKey};
+use crate::transciphering::{StreamCipher, StreamCipherKind};
+
+/// Client-side AES-128 in CTR mode, in clear. Mirrors [`super::fhe::AesFheState`].
+pub struct AesPlainState {
+    cipher: AesDefaultBlockCipher,
+    iv: AesIv,
+    counter: u64,
+}
+
+impl AesPlainState {
+    pub fn new(key: impl Into<AesPlainKey>, iv: impl Into<AesIv>) -> Self {
+        Self {
+            cipher: AesDefaultBlockCipher::new(AesKey::new(key.into().to_csprng_key_u128())),
+            iv: iv.into(),
+            counter: 0,
+        }
+    }
+}
+
+impl StreamCipher for AesPlainState {
+    fn kind(&self) -> StreamCipherKind {
+        StreamCipherKind::Aes
+    }
+
+    fn next_keystream_bits(&mut self, n_bits: usize) -> Vec<u8> {
+        let skip_head = (self.counter % 128) as usize;
+        let start_block = self.counter / 128;
+        let n_blocks = (skip_head + n_bits).div_ceil(128);
+
+        // `generate_next` outputs 16 bytes in NIST order, LSB-first within each
+        // byte, matching the trait convention.
+        let mut keystream_bytes: Vec<u8> = Vec::with_capacity(n_blocks * 16);
+        for i in 0..n_blocks as u128 {
+            let counter_value = self.iv.to_u128().wrapping_add(start_block as u128 + i);
+            let counter_csprng = u128::from_ne_bytes(counter_value.to_be_bytes());
+            let block = self.cipher.generate_next(counter_csprng);
+            keystream_bytes.extend_from_slice(&block);
+        }
+
+        self.counter = self
+            .counter
+            .checked_add(n_bits as u64)
+            .expect("AesPlainStream: keystream bit counter overflowed u64");
+
+        let mut result = vec![0u8; n_bits.div_ceil(8)];
+        for out_idx in 0..n_bits {
+            let src_idx = skip_head + out_idx;
+            let bit = (keystream_bytes[src_idx / 8] >> (src_idx % 8)) & 1;
+            result[out_idx / 8] |= bit << (out_idx % 8);
+        }
+        result
+    }
+
+    fn seek(&mut self, target_counter: u64) {
+        self.counter = target_counter;
+    }
+
+    fn current_counter(&self) -> u64 {
+        self.counter
+    }
+}

--- a/tfhe/src/transciphering/ciphers/aes/sbox.rs
+++ b/tfhe/src/transciphering/ciphers/aes/sbox.rs
@@ -1,0 +1,471 @@
+//! AES S-box as a Boyar-Peralta boolean circuit (~32 ANDs, depth-4
+//! multiplicative, ~83 XORs). See <https://eprint.iacr.org/2011/332.pdf>.
+use crate::shortint::server_key::LookupTable;
+use crate::shortint::{Ciphertext, ServerKey};
+use rayon::join;
+use rayon::prelude::*;
+
+/// XOR two ciphertexts and flush the result back to noise 1.
+fn flush_xor(
+    sks: &ServerKey,
+    flush_lut: &LookupTable<Vec<u64>>,
+    lhs: &Ciphertext,
+    rhs: &Ciphertext,
+) -> Ciphertext {
+    sks.apply_lookup_table(&sks.unchecked_add(lhs, rhs), flush_lut)
+}
+
+fn flush_xor_batch<const N: usize>(
+    sks: &ServerKey,
+    flush_lut: &LookupTable<Vec<u64>>,
+    pairs: [(&Ciphertext, &Ciphertext); N],
+) -> [Ciphertext; N] {
+    pairs
+        .into_par_iter()
+        .map(|(l, r)| flush_xor(sks, flush_lut, l, r))
+        .collect::<Vec<_>>()
+        .try_into()
+        .expect("flush_xor_batch output length matches input")
+}
+
+/// Logical NOT on a clean bit, flushed.
+fn flush_not(sks: &ServerKey, flush_lut: &LookupTable<Vec<u64>>, bit: &Ciphertext) -> Ciphertext {
+    sks.apply_lookup_table(&sks.unchecked_scalar_add(bit, 1), flush_lut)
+}
+
+/// References to the 8 bits of the input byte in BP order (`u0` is the byte
+/// MSB = BP `U0`). [`SboxByte::from_state`] is the bridge between our LSB-first
+/// array layout and the BP MSB-first internal naming.
+#[derive(Clone, Copy)]
+struct SboxByte<'a> {
+    u0: &'a Ciphertext,
+    u1: &'a Ciphertext,
+    u2: &'a Ciphertext,
+    u3: &'a Ciphertext,
+    u4: &'a Ciphertext,
+    u5: &'a Ciphertext,
+    u6: &'a Ciphertext,
+    u7: &'a Ciphertext,
+}
+
+impl<'a> SboxByte<'a> {
+    fn from_state(state: &'a [Ciphertext]) -> Self {
+        debug_assert_eq!(state.len(), 8);
+        Self {
+            u0: &state[7],
+            u1: &state[6],
+            u2: &state[5],
+            u3: &state[4],
+            u4: &state[3],
+            u5: &state[2],
+            u6: &state[1],
+            u7: &state[0],
+        }
+    }
+}
+
+/// Outputs of the BP top linear layer: the 21 `T_i` consumed by the middle.
+///
+/// `T5`, `T7`, `T11`, `T12`, `T18`, `T21` are pure internal scratch values
+/// that are folded into other terms as they are produced, so they are never
+/// materialized as fields here (e.g. `T7 = U1 + U2` lives only as a local in
+/// [`top_sbox`] before being consumed by `T9`, `T10`, `T16`).
+struct SboxTop {
+    t1: Ciphertext,
+    t2: Ciphertext,
+    t3: Ciphertext,
+    t4: Ciphertext,
+    t6: Ciphertext,
+    t8: Ciphertext,
+    t9: Ciphertext,
+    t10: Ciphertext,
+    t13: Ciphertext,
+    t14: Ciphertext,
+    t15: Ciphertext,
+    t16: Ciphertext,
+    t17: Ciphertext,
+    t19: Ciphertext,
+    t20: Ciphertext,
+    t22: Ciphertext,
+    t23: Ciphertext,
+    t24: Ciphertext,
+    t25: Ciphertext,
+    t26: Ciphertext,
+    t27: Ciphertext,
+}
+
+/// Outputs of the BP middle non-linear layer: the 18 final ANDs `M46..M63`.
+struct SboxMiddle {
+    m46: Ciphertext,
+    m47: Ciphertext,
+    m48: Ciphertext,
+    m49: Ciphertext,
+    m50: Ciphertext,
+    m51: Ciphertext,
+    m52: Ciphertext,
+    m53: Ciphertext,
+    m54: Ciphertext,
+    m55: Ciphertext,
+    m56: Ciphertext,
+    m57: Ciphertext,
+    m58: Ciphertext,
+    m59: Ciphertext,
+    m60: Ciphertext,
+    m61: Ciphertext,
+    m62: Ciphertext,
+    m63: Ciphertext,
+}
+
+/// Final sbox outputs (`S0` is the byte MSB, `S7` the LSB).
+struct SboxBottom {
+    s0: Ciphertext,
+    s1: Ciphertext,
+    s2: Ciphertext,
+    s3: Ciphertext,
+    s4: Ciphertext,
+    s5: Ciphertext,
+    s6: Ciphertext,
+    s7: Ciphertext,
+}
+
+/// Top linear layer: produces the 21 BP `T_i` from the 8 input bits.
+///
+/// Independent flush_xor calls are grouped into `rayon::join` clusters to
+/// fan PBS calls out across cores when blocks are scarce.
+fn top_sbox(sks: &ServerKey, flush_lut: &LookupTable<Vec<u64>>, byte: SboxByte) -> SboxTop {
+    let SboxByte {
+        u0,
+        u1,
+        u2,
+        u3,
+        u4,
+        u5,
+        u6,
+        u7,
+    } = byte;
+
+    let t7 = sks.unchecked_add(u1, u2);
+
+    let [t1, t2, t3, t4, t9] = flush_xor_batch(
+        sks,
+        flush_lut,
+        [(u0, u3), (u0, u5), (u0, u6), (u3, u5), (&t7, u7)],
+    );
+
+    let [t13, t19, t20, t22] = flush_xor_batch(
+        sks,
+        flush_lut,
+        [(&t3, &t4), (&t9, u3), (&t9, u0), (&t9, u6)],
+    );
+
+    let t6_pre = sks.unchecked_add(u4, &t13);
+    let [t6, t14, t23] =
+        flush_xor_batch(sks, flush_lut, [(&t6_pre, u5), (&t6_pre, u1), (&t22, &t2)]);
+
+    let [t8, t10, t15] = flush_xor_batch(sks, flush_lut, [(&t6, u7), (&t6, &t7), (&t14, &t1)]);
+
+    let [t16, t17, t24, t27] = flush_xor_batch(
+        sks,
+        flush_lut,
+        [(&t7, &t15), (u7, &t15), (&t10, &t2), (&t10, &t15)],
+    );
+
+    let (t25, t26) = join(
+        || flush_xor(sks, flush_lut, u0, &t16),
+        || flush_xor(sks, flush_lut, &t3, &t16),
+    );
+
+    SboxTop {
+        t1,
+        t2,
+        t3,
+        t4,
+        t6,
+        t8,
+        t9,
+        t10,
+        t13,
+        t14,
+        t15,
+        t16,
+        t17,
+        t19,
+        t20,
+        t22,
+        t23,
+        t24,
+        t25,
+        t26,
+        t27,
+    }
+}
+
+/// Middle non-linear layer: 32 ANDs producing `M46..M63`.
+///
+/// `d` is the BP `D` input: for the forward direction this is the LSB of the
+/// input byte (`U7`, our `byte.u7`). The middle layer plugs it into two ANDs
+/// directly (`M4 = T19 x D` and `M48 = M39 x D`).
+///
+/// Naming: variables that equal a paper `M_i` carry the same index. The
+/// paper's `M3, M8, M16-M18, M31-M36` are not materialized (they would each
+/// cost an extra PBS), so the values computed in their place are named
+/// `aux1..aux10`. `M38` and `M40` are produced via GF(2) algebraic identities
+/// rather than the paper's literal `M32+M33` / `M35+M36` formulas.
+fn middle_sbox(
+    sks: &ServerKey,
+    flush_lut: &LookupTable<Vec<u64>>,
+    top: SboxTop,
+    d: &Ciphertext,
+) -> SboxMiddle {
+    let SboxTop {
+        t1,
+        t2,
+        t3,
+        t4,
+        t6,
+        t8,
+        t9,
+        t10,
+        t13,
+        t14,
+        t15,
+        t16,
+        t17,
+        t19,
+        t20,
+        t22,
+        t23,
+        t24,
+        t25,
+        t26,
+        t27,
+    } = top;
+
+    let and_inputs: [(&Ciphertext, &Ciphertext); 9] = [
+        (&t6, &t13),
+        (&t23, &t8),
+        (d, &t19),
+        (&t3, &t16),
+        (&t9, &t22),
+        (&t20, &t17),
+        (&t1, &t15),
+        (&t4, &t27),
+        (&t2, &t10),
+    ];
+    let [m1, m2, m4, m6, m7, m9, m11, m12, m14]: [Ciphertext; 9] = and_inputs
+        .into_par_iter()
+        .map(|(l, r)| sks.unchecked_bitand(l, r))
+        .collect::<Vec<_>>()
+        .try_into()
+        .expect("9 ANDs");
+
+    let aux1 = sks.unchecked_add(&m2, &m1);
+    let m5 = sks.unchecked_add(&m4, &m1);
+    let aux2 = sks.unchecked_add(&m7, &m6);
+    let m10 = sks.unchecked_add(&m9, &m6);
+    let m13 = sks.unchecked_add(&m12, &m11);
+    let m15 = sks.unchecked_add(&m14, &m11);
+    let aux3 = sks.unchecked_add(&aux1, &m13);
+    let aux4 = sks.unchecked_add(&m5, &m15);
+    let aux5 = sks.unchecked_add(&aux2, &m13);
+    let m19 = sks.unchecked_add(&m10, &m15);
+
+    let [m20, m21, m22, m23] = flush_xor_batch(
+        sks,
+        flush_lut,
+        [(&aux3, &t14), (&aux4, &t24), (&aux5, &t26), (&m19, &t25)],
+    );
+
+    let (m24, (m25, m27)) = join(
+        || flush_xor(sks, flush_lut, &m22, &m23),
+        || {
+            join(
+                || sks.unchecked_bitand(&m22, &m20),
+                || flush_xor(sks, flush_lut, &m20, &m21),
+            )
+        },
+    );
+
+    let (m26, m28) = join(
+        || flush_xor(sks, flush_lut, &m21, &m25),
+        || flush_xor(sks, flush_lut, &m23, &m25),
+    );
+
+    let (m29, m30) = join(
+        || sks.unchecked_bitand(&m28, &m27),
+        || sks.unchecked_bitand(&m26, &m24),
+    );
+
+    let (m37, m39) = join(
+        || flush_xor(sks, flush_lut, &m29, &m21),
+        || flush_xor(sks, flush_lut, &m30, &m23),
+    );
+
+    let aux6 = sks.unchecked_add(&m22, &m39);
+    let aux7 = flush_xor(sks, flush_lut, &m28, &m39);
+    let aux8 = sks.unchecked_bitand(&m23, &aux7);
+    let (m40, aux9) = join(
+        || flush_xor(sks, flush_lut, &aux8, &aux6),
+        || flush_xor(sks, flush_lut, &m28, &aux8),
+    );
+    let aux10 = sks.unchecked_bitand(&aux9, &m37);
+    let m38 = flush_xor(sks, flush_lut, &m27, &aux10);
+
+    let [m41, m42, m43, m44] = flush_xor_batch(
+        sks,
+        flush_lut,
+        [(&m38, &m40), (&m37, &m39), (&m37, &m38), (&m39, &m40)],
+    );
+    let m45 = flush_xor(sks, flush_lut, &m42, &m41);
+
+    let final_inputs: [(&Ciphertext, &Ciphertext); 18] = [
+        (&t6, &m44),
+        (&t8, &m40),
+        (&m39, d),
+        (&t16, &m43),
+        (&t9, &m38),
+        (&m37, &t17),
+        (&m42, &t15),
+        (&t27, &m45),
+        (&t10, &m41),
+        (&t13, &m44),
+        (&t23, &m40),
+        (&m39, &t19),
+        (&t3, &m43),
+        (&t22, &m38),
+        (&m37, &t20),
+        (&m42, &t1),
+        (&m45, &t4),
+        (&m41, &t2),
+    ];
+    let [m46, m47, m48, m49, m50, m51, m52, m53, m54, m55, m56, m57, m58, m59, m60, m61, m62, m63]: [Ciphertext; 18] =
+        final_inputs
+            .into_par_iter()
+            .map(|(l, r)| sks.unchecked_bitand(l, r))
+            .collect::<Vec<_>>()
+            .try_into()
+            .expect("18 ANDs");
+
+    SboxMiddle {
+        m46,
+        m47,
+        m48,
+        m49,
+        m50,
+        m51,
+        m52,
+        m53,
+        m54,
+        m55,
+        m56,
+        m57,
+        m58,
+        m59,
+        m60,
+        m61,
+        m62,
+        m63,
+    }
+}
+
+/// Bottom linear layer: combine the 18 `M_i` into the 8 sbox bits `S0..S7`.
+fn bottom_sbox(sks: &ServerKey, flush_lut: &LookupTable<Vec<u64>>, mid: SboxMiddle) -> SboxBottom {
+    let SboxMiddle {
+        m46,
+        m47,
+        m48,
+        m49,
+        m50,
+        m51,
+        m52,
+        m53,
+        m54,
+        m55,
+        m56,
+        m57,
+        m58,
+        m59,
+        m60,
+        m61,
+        m62,
+        m63,
+    } = mid;
+
+    let l46 = sks.unchecked_add(&m61, &m62);
+    let l47 = sks.unchecked_add(&m56, &m57);
+    let l48 = sks.unchecked_add(&m51, &m59);
+    let l49 = sks.unchecked_add(&m55, &m56);
+    let l50 = sks.unchecked_add(&m48, &m58);
+    let l51 = sks.unchecked_add(&m48, &m51);
+    let l52 = sks.unchecked_add(&m53, &m54);
+    let l53 = sks.unchecked_add(&m46, &m49);
+    let l54 = sks.unchecked_add(&m52, &m53);
+    let l55 = sks.unchecked_add(&m62, &m63);
+    let l56 = sks.unchecked_add(&m58, &l48);
+    let l58 = sks.unchecked_add(&m50, &l46);
+    let l59 = sks.unchecked_add(&m49, &l54);
+
+    let [l57, l62, l63, l64] = flush_xor_batch(
+        sks,
+        flush_lut,
+        [(&l50, &l53), (&l52, &l58), (&l49, &l58), (&m50, &l59)],
+    );
+
+    let l60 = sks.unchecked_add(&l46, &l57);
+    let l61 = sks.unchecked_add(&m60, &l57);
+
+    let ((l65, l66), l60_not) = join(
+        || {
+            join(
+                || flush_xor(sks, flush_lut, &l61, &l62),
+                || flush_xor(sks, flush_lut, &m47, &l63),
+            )
+        },
+        || flush_not(sks, flush_lut, &l60),
+    );
+
+    let s0 = sks.unchecked_add(&l59, &l63);
+
+    let mut s6 = sks.unchecked_scalar_add(&l62, 1);
+    sks.unchecked_add_assign(&mut s6, &l56);
+
+    let s7 = sks.unchecked_add(&l48, &l60_not);
+
+    let l67 = sks.unchecked_add(&l64, &l65);
+    let s3 = sks.unchecked_add(&l53, &l66);
+    let s4 = sks.unchecked_add(&l51, &l66);
+    let s5 = sks.unchecked_add(&l47, &l65);
+
+    let s3_not = sks.unchecked_scalar_add(&s3, 1);
+    let s1 = sks.unchecked_add(&l64, &s3_not);
+
+    let mut s2 = sks.unchecked_scalar_add(&l67, 1);
+    sks.unchecked_add_assign(&mut s2, &l55);
+
+    SboxBottom {
+        s0,
+        s1,
+        s2,
+        s3,
+        s4,
+        s5,
+        s6,
+        s7,
+    }
+}
+
+pub(super) fn sbox(sks: &ServerKey, flush_lut: &LookupTable<Vec<u64>>, x: &mut [Ciphertext]) {
+    let byte = SboxByte::from_state(x);
+    let top = top_sbox(sks, flush_lut, byte);
+    let mid = middle_sbox(sks, flush_lut, top, byte.u7);
+    let bot = bottom_sbox(sks, flush_lut, mid);
+
+    x[7] = bot.s0;
+    x[6] = bot.s1;
+    x[5] = bot.s2;
+    x[4] = bot.s3;
+    x[3] = bot.s4;
+    x[2] = bot.s5;
+    x[1] = bot.s6;
+    x[0] = bot.s7;
+}

--- a/tfhe/src/transciphering/ciphers/aes/test.rs
+++ b/tfhe/src/transciphering/ciphers/aes/test.rs
@@ -1,0 +1,371 @@
+use super::sbox::sbox;
+use crate::shortint::ciphertext::Degree;
+use crate::shortint::parameters::test_params::TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+use crate::shortint::prelude::*;
+use crate::transciphering::ciphers::aes::{
+    AesFheRoundKeys, AesFheState, AesIv, AesPlainKey, AesPlainState,
+};
+use crate::transciphering::{StreamCipher, Transcipherer};
+use rand::{Rng, SeedableRng};
+use rayon::prelude::*;
+
+const PARAM: ClassicPBSParameters = TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+const KEY: u128 = 0x2b7e151628aed2a6abf7158809cf4f3c;
+const IV: u128 = 0x6bc1bee22e409f96e93d7e117393172a;
+const EXPECTED: u128 = 0x3ad77bb40d7a3660a89ecaf32466ef97;
+
+// NIST SP 800-38A F.5.1 CTR-AES128 vectors (same key as `KEY`)
+const CTR_IV: u128 = 0xf0f1f2f3f4f5f6f7f8f9fafbfcfdfeff;
+const CTR_KEYSTREAM: [u128; 4] = [
+    0xec8cdf7398607cb0f2d21675ea9ea1e4,
+    0x362b7c3c6773516318a077d7fc5073ae,
+    0x6a2cc3787889374fbeb4c81b17ba6c44,
+    0xe89c399ff0f198c6d40a31db156cabfe,
+];
+
+fn decrypt_u128(cks: &ClientKey, bits: &[Ciphertext; 128]) -> u128 {
+    let mut bytes = [0u8; 16];
+    for (i, ct) in bits.iter().enumerate() {
+        let bit = (cks.decrypt(ct) & 1) as u8;
+        bytes[i / 8] |= bit << (i % 8);
+    }
+    u128::from_be_bytes(bytes)
+}
+
+fn plain_aes_ctr_keystream(key: u128, iv: u128, n_blocks: usize) -> Vec<u128> {
+    let mut stream = AesPlainState::new(key, iv);
+    let bytes = stream.next_keystream_bits(128 * n_blocks);
+    (0..n_blocks)
+        .map(|i| {
+            let block_bytes: [u8; 16] = bytes[16 * i..16 * (i + 1)]
+                .try_into()
+                .expect("16 bytes per block");
+            u128::from_be_bytes(block_bytes)
+        })
+        .collect()
+}
+
+fn decrypt_block(cks: &ClientKey, bits: &[Ciphertext]) -> u128 {
+    decrypt_u128(
+        cks,
+        bits.try_into()
+            .expect("decrypt_block expects exactly 128 ciphertexts"),
+    )
+}
+
+fn gen_random_key_iv() -> (u128, u128) {
+    let test_name = std::thread::current()
+        .name()
+        .unwrap_or("unknown")
+        .to_string();
+    let seed: u64 = rand::thread_rng().gen();
+    println!("{test_name}: gen_random_key_iv seed={seed}");
+    let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+
+    let key: u128 = rng.gen();
+    let iv: u128 = rng.gen();
+    (key, iv)
+}
+
+/// `AesIv` is a `u128` newtype using one consistent (big-endian / NIST)
+/// convention: each `from` impl is fed the big-endian representation of the
+/// same value (`v`, its `to_be_bytes()`, or those bytes unpacked LSB-first into
+/// bits), and `to_u128()` must round-trip back to `v`.
+#[test]
+fn aes_iv_from_conversions_round_trip() {
+    for v in [
+        0u128,
+        u128::MAX,
+        0x0123456789abcdeffedcba9876543210,
+        IV,
+        CTR_IV,
+    ] {
+        let from_u128 = AesIv::from(v);
+        let from_bytes = AesIv::from(v.to_be_bytes());
+        let be = v.to_be_bytes();
+        let bools: [bool; 128] = std::array::from_fn(|i| (be[i / 8] >> (i % 8)) & 1 == 1);
+        let from_bools = AesIv::from(bools);
+
+        assert_eq!(from_u128.to_u128(), v, "From<u128> round-trip failed");
+        assert_eq!(from_bytes.to_u128(), v, "From<[u8; 16]> round-trip failed");
+        assert_eq!(
+            from_bools.to_u128(),
+            v,
+            "From<[bool; 128]> round-trip failed"
+        );
+    }
+}
+
+#[test]
+fn aes_plain_key_conversions_are_homogeneous() {
+    for v in [0u128, u128::MAX, 0x0123456789abcdeffedcba9876543210, KEY] {
+        // AES/NIST byte order: bits[0] is the first (most-significant) key byte.
+        let key_bytes = v.to_be_bytes();
+
+        let from_u128 = AesPlainKey::from(v);
+        let from_bytes = AesPlainKey::from(key_bytes);
+        let be = v.to_be_bytes();
+        let bools: [bool; 128] = std::array::from_fn(|i| (be[i / 8] >> (i % 8)) & 1 == 1);
+        let from_bools = AesPlainKey::from(bools);
+
+        // (1) all three describe the same key.
+        assert_eq!(
+            from_u128.expand(),
+            from_bytes.expand(),
+            "From<u128> and From<[u8; 16]> disagree"
+        );
+        assert_eq!(
+            from_u128.expand(),
+            from_bools.expand(),
+            "From<u128> and From<[bool; 128]> disagree"
+        );
+
+        // (2) the csprng transport hands the cipher the AES key bytes unchanged.
+        assert_eq!(
+            from_u128.to_csprng_key_u128().to_ne_bytes(),
+            key_bytes,
+            "csprng key transport altered the key bytes"
+        );
+    }
+}
+
+/// Anchor the plain side to the NIST SP 800-38A AES-128 vector. The other
+/// tests use `AesPlainStream` as oracle.
+#[test]
+fn plain_aes_matches_nist_vector() {
+    let got = plain_aes_ctr_keystream(KEY, IV, 1)[0];
+    assert_eq!(
+        got, EXPECTED,
+        "\n  got      = 0x{got:032x}\n  expected = 0x{EXPECTED:032x}"
+    );
+}
+
+/// NIST CTR-AES128 known-answer test on the plain stream
+#[test]
+fn plain_aes_ctr_byte_order_nist() {
+    let got = plain_aes_ctr_keystream(KEY, CTR_IV, CTR_KEYSTREAM.len());
+    for (i, expected) in CTR_KEYSTREAM.iter().enumerate() {
+        assert_eq!(
+            got[i], *expected,
+            "block {i} differs\n  got      = 0x{:032x}\n  expected = 0x{expected:032x}",
+            got[i]
+        );
+    }
+}
+
+/// Reference AES S-box
+const REFERENCE_AES_SBOX: [u8; 256] = [
+    0x63, 0x7c, 0x77, 0x7b, 0xf2, 0x6b, 0x6f, 0xc5, 0x30, 0x01, 0x67, 0x2b, 0xfe, 0xd7, 0xab, 0x76,
+    0xca, 0x82, 0xc9, 0x7d, 0xfa, 0x59, 0x47, 0xf0, 0xad, 0xd4, 0xa2, 0xaf, 0x9c, 0xa4, 0x72, 0xc0,
+    0xb7, 0xfd, 0x93, 0x26, 0x36, 0x3f, 0xf7, 0xcc, 0x34, 0xa5, 0xe5, 0xf1, 0x71, 0xd8, 0x31, 0x15,
+    0x04, 0xc7, 0x23, 0xc3, 0x18, 0x96, 0x05, 0x9a, 0x07, 0x12, 0x80, 0xe2, 0xeb, 0x27, 0xb2, 0x75,
+    0x09, 0x83, 0x2c, 0x1a, 0x1b, 0x6e, 0x5a, 0xa0, 0x52, 0x3b, 0xd6, 0xb3, 0x29, 0xe3, 0x2f, 0x84,
+    0x53, 0xd1, 0x00, 0xed, 0x20, 0xfc, 0xb1, 0x5b, 0x6a, 0xcb, 0xbe, 0x39, 0x4a, 0x4c, 0x58, 0xcf,
+    0xd0, 0xef, 0xaa, 0xfb, 0x43, 0x4d, 0x33, 0x85, 0x45, 0xf9, 0x02, 0x7f, 0x50, 0x3c, 0x9f, 0xa8,
+    0x51, 0xa3, 0x40, 0x8f, 0x92, 0x9d, 0x38, 0xf5, 0xbc, 0xb6, 0xda, 0x21, 0x10, 0xff, 0xf3, 0xd2,
+    0xcd, 0x0c, 0x13, 0xec, 0x5f, 0x97, 0x44, 0x17, 0xc4, 0xa7, 0x7e, 0x3d, 0x64, 0x5d, 0x19, 0x73,
+    0x60, 0x81, 0x4f, 0xdc, 0x22, 0x2a, 0x90, 0x88, 0x46, 0xee, 0xb8, 0x14, 0xde, 0x5e, 0x0b, 0xdb,
+    0xe0, 0x32, 0x3a, 0x0a, 0x49, 0x06, 0x24, 0x5c, 0xc2, 0xd3, 0xac, 0x62, 0x91, 0x95, 0xe4, 0x79,
+    0xe7, 0xc8, 0x37, 0x6d, 0x8d, 0xd5, 0x4e, 0xa9, 0x6c, 0x56, 0xf4, 0xea, 0x65, 0x7a, 0xae, 0x08,
+    0xba, 0x78, 0x25, 0x2e, 0x1c, 0xa6, 0xb4, 0xc6, 0xe8, 0xdd, 0x74, 0x1f, 0x4b, 0xbd, 0x8b, 0x8a,
+    0x70, 0x3e, 0xb5, 0x66, 0x48, 0x03, 0xf6, 0x0e, 0x61, 0x35, 0x57, 0xb9, 0x86, 0xc1, 0x1d, 0x9e,
+    0xe1, 0xf8, 0x98, 0x11, 0x69, 0xd9, 0x8e, 0x94, 0x9b, 0x1e, 0x87, 0xe9, 0xce, 0x55, 0x28, 0xdf,
+    0x8c, 0xa1, 0x89, 0x0d, 0xbf, 0xe6, 0x42, 0x68, 0x41, 0x99, 0x2d, 0x0f, 0xb0, 0x54, 0xbb, 0x16,
+];
+
+#[test]
+fn fhe_sbox_exhaustive() {
+    let (cks, sks) = gen_keys(PARAM);
+    let flush_lut = sks.generate_lookup_table(|x: u64| x & 1);
+
+    let mismatches: Vec<(u8, u8, u8)> = REFERENCE_AES_SBOX
+        .into_par_iter()
+        .enumerate()
+        .filter_map(|(b, expected)| {
+            let b = b as u8;
+            let mut bits: [Ciphertext; 8] = std::array::from_fn(|j| {
+                let mut c = cks.encrypt(((b >> j) & 1) as u64);
+                c.degree = Degree::new(1);
+                c
+            });
+            sbox(&sks, &flush_lut, &mut bits);
+            let got = (0..8u8).fold(0u8, |acc, j| {
+                acc | (((cks.decrypt(&bits[j as usize]) & 1) as u8) << j)
+            });
+            (got != expected).then_some((b, got, expected))
+        })
+        .collect();
+
+    assert!(
+        mismatches.is_empty(),
+        "FHE S-box mismatches (input, got, expected): {mismatches:02x?}"
+    );
+}
+
+#[test]
+fn aes_fhe_known_answer() {
+    let (cks, sks) = gen_keys(PARAM);
+
+    let enc_key = AesPlainKey::from(KEY).encrypt(&cks);
+    let fhe_key = AesFheRoundKeys::new(&sks, &enc_key);
+    let mut stream = AesFheState::new(fhe_key, IV);
+
+    let keystream = stream.next_keystream_bits(&sks, 128);
+    let got = decrypt_block(&cks, &keystream.into_raw_parts());
+
+    assert_eq!(
+        got, EXPECTED,
+        "\n  got      = 0x{got:032x}\n  expected = 0x{EXPECTED:032x}"
+    );
+    assert_eq!(stream.current_counter(), 128);
+}
+
+/// FHE counterpart of [`plain_aes_ctr_byte_order_nist`]
+#[test]
+fn aes_fhe_ctr_byte_order_nist() {
+    let (cks, sks) = gen_keys(PARAM);
+
+    let enc_key = AesPlainKey::from(KEY).encrypt(&cks);
+    let fhe_key = AesFheRoundKeys::new(&sks, &enc_key);
+    let mut stream = AesFheState::new(fhe_key, CTR_IV);
+
+    let n_blocks = CTR_KEYSTREAM.len();
+    let keystream = stream.next_keystream_bits(&sks, 128 * n_blocks);
+    let bits = keystream.into_raw_parts();
+
+    for (i, expected) in CTR_KEYSTREAM.iter().enumerate() {
+        let got = decrypt_block(&cks, &bits[128 * i..128 * (i + 1)]);
+        assert_eq!(
+            got, *expected,
+            "block {i} differs\n  got      = 0x{got:032x}\n  expected = 0x{expected:032x}"
+        );
+    }
+    assert_eq!(stream.current_counter(), (128 * n_blocks) as u64);
+}
+
+#[test]
+fn aes_fhe_matches_plain_random() {
+    let (cks, sks) = gen_keys(PARAM);
+    let (key, iv) = gen_random_key_iv();
+    let n_blocks: usize = 2;
+
+    let plain = plain_aes_ctr_keystream(key, iv, n_blocks);
+
+    let enc_key = AesPlainKey::from(key).encrypt(&cks);
+    let fhe_key = AesFheRoundKeys::new(&sks, &enc_key);
+    let mut stream = AesFheState::new(fhe_key, iv);
+
+    let keystream = stream.next_keystream_bits(&sks, 128 * n_blocks);
+    let bits = keystream.into_raw_parts();
+
+    for (i, expected) in plain.iter().enumerate() {
+        let got = decrypt_block(&cks, &bits[128 * i..128 * (i + 1)]);
+        assert_eq!(
+            got, *expected,
+            "block {i} differs\n  got      = 0x{got:032x}\n  expected = 0x{expected:032x}"
+        );
+    }
+}
+
+#[test]
+fn aes_transcipher_round_trip() {
+    let (cks, sks) = gen_keys(PARAM);
+    let (key, iv) = gen_random_key_iv();
+
+    let message: [u8; 16] = *b"Hello world!1234";
+
+    let mut plain_stream = AesPlainState::new(key, iv);
+    let sym_cipher = plain_stream.encrypt(&message);
+
+    let enc_key = AesPlainKey::from(key).encrypt(&cks);
+    let fhe_key = AesFheRoundKeys::new(&sks, &enc_key);
+    let mut fhe_stream = AesFheState::new(fhe_key, iv);
+    let fhe_cipher = fhe_stream.transcipher(&sks, &sym_cipher).unwrap();
+
+    // `apply_keystream` in `2_2` packs two output bits per ciphertext, so 128
+    // message bits decode from 64 ciphertexts.
+    let mut recovered = [0u8; 16];
+    for (i, ct) in fhe_cipher.iter().enumerate() {
+        let val = cks.decrypt(ct) & 3;
+        let bit_lo = (val & 1) as u8;
+        let bit_hi = ((val >> 1) & 1) as u8;
+        let idx_lo = 2 * i;
+        let idx_hi = 2 * i + 1;
+        recovered[idx_lo / 8] |= bit_lo << (idx_lo % 8);
+        recovered[idx_hi / 8] |= bit_hi << (idx_hi % 8);
+    }
+
+    assert_eq!(
+        recovered, message,
+        "\n  got      = {recovered:02x?}\n  expected = {message:02x?}"
+    );
+}
+
+/// Compare `n_bits` of FHE keystream (one single-bit ciphertext per bit)
+/// against the plain reference, bit for bit (LSB-first within each byte).
+fn assert_keystream_matches(
+    cks: &ClientKey,
+    fhe_bits: &[Ciphertext],
+    plain_bytes: &[u8],
+    n_bits: usize,
+) {
+    assert_eq!(fhe_bits.len(), n_bits, "expected {n_bits} keystream bits");
+    for (i, ct) in fhe_bits.iter().enumerate() {
+        let got = (cks.decrypt(ct) & 1) as u8;
+        let expected = (plain_bytes[i / 8] >> (i % 8)) & 1;
+        assert_eq!(got, expected, "keystream bit {i} differs");
+    }
+}
+
+#[test]
+fn aes_fhe_seek() {
+    let (cks, sks) = gen_keys(PARAM);
+
+    let (key, iv) = gen_random_key_iv();
+    let enc_key = AesPlainKey::from(key).encrypt(&cks);
+    let fhe_key = AesFheRoundKeys::new(&sks, &enc_key);
+    let mut fhe_stream = AesFheState::new(fhe_key, iv);
+    let mut plain_stream = AesPlainState::new(key, iv);
+
+    // Counter bookkeeping: forward and backward seeks update the position.
+    assert_eq!(fhe_stream.current_counter(), 0);
+    fhe_stream.seek(&sks, 192);
+    assert_eq!(fhe_stream.current_counter(), 192);
+
+    // After seeking both streams to the same mid-block position, the FHE
+    // keystream must match the plain reference bit for bit. Starting at bit 64
+    // (mid block 0) and spanning 192 bits exercises the `skip_head` /
+    // multi-block path post-seek.
+    fhe_stream.seek(&sks, 64);
+    plain_stream.seek(64);
+    assert_eq!(fhe_stream.current_counter(), 64);
+
+    let n_bits = 192;
+    let fhe_bits = fhe_stream
+        .next_keystream_bits(&sks, n_bits)
+        .into_raw_parts();
+    let plain_bytes = plain_stream.next_keystream_bits(n_bits);
+    assert_keystream_matches(&cks, &fhe_bits, &plain_bytes, n_bits);
+    assert_eq!(fhe_stream.current_counter(), 64 + n_bits as u64);
+}
+
+#[test]
+fn aes_fhe_non_byte_aligned_n_bits() {
+    let (cks, sks) = gen_keys(PARAM);
+    let (key, iv) = gen_random_key_iv();
+
+    let enc_key = AesPlainKey::from(key).encrypt(&cks);
+    let fhe_key = AesFheRoundKeys::new(&sks, &enc_key);
+    let mut fhe_stream = AesFheState::new(fhe_key, iv);
+    let mut plain_stream = AesPlainState::new(key, iv);
+
+    // 100 bits is not byte-aligned: exercises the `take(n_bits)` truncation on
+    // the FHE side and the trailing partial byte on the plain side.
+    let n_bits = 100;
+    let fhe_bits = fhe_stream
+        .next_keystream_bits(&sks, n_bits)
+        .into_raw_parts();
+    let plain_bytes = plain_stream.next_keystream_bits(n_bits);
+    assert_keystream_matches(&cks, &fhe_bits, &plain_bytes, n_bits);
+    assert_eq!(fhe_stream.current_counter(), n_bits as u64);
+}

--- a/tfhe/src/transciphering/ciphers/mod.rs
+++ b/tfhe/src/transciphering/ciphers/mod.rs
@@ -1,5 +1,6 @@
 mod shift_register;
 
+pub mod aes;
 pub mod kreyvium;
 
 /// Pack `bits` into `bytes` LSB-first within each byte. `bytes` must be

--- a/tfhe/src/transciphering/mod.rs
+++ b/tfhe/src/transciphering/mod.rs
@@ -59,6 +59,7 @@ use crate::shortint::{Ciphertext, ServerKey};
 use crate::transciphering::backward_compatibility::{
     StreamCipherKindVersions, StreamCiphertextVersions,
 };
+use crate::transciphering::ciphers::aes::AesFheState;
 use crate::transciphering::ciphers::kreyvium::KreyviumFheState;
 
 /// Identifier for a concrete stream-cipher family.
@@ -72,8 +73,9 @@ use crate::transciphering::ciphers::kreyvium::KreyviumFheState;
 )]
 #[versionize(StreamCipherKindVersions)]
 pub enum StreamCipherKind {
-    Kreyvium,
     Dynamic,
+    Kreyvium,
+    Aes,
 }
 
 /// Output of [`StreamCipher::encrypt`] / [`StreamCipher::encrypt_bits`]: a
@@ -293,25 +295,28 @@ pub trait Transcipherer {
 }
 
 /// Owning, runtime-dispatched [`Transcipherer`]. Lets higher layers keep a
-/// single concrete type that can hold any in-tree cipher state, plus
-/// arbitrary out-of-tree implementors via [`Self::Dynamic`].
+/// single concrete type that can hold any in-tree cipher state ([`Self::Kreyvium`],
+/// [`Self::Aes`]), plus arbitrary out-of-tree implementors via [`Self::Dynamic`].
 pub enum TranscipherSession {
-    Kreyvium(KreyviumFheState),
     Dynamic(Box<dyn Transcipherer + Send + Sync>),
+    Kreyvium(KreyviumFheState),
+    Aes(Box<AesFheState>),
 }
 
 impl Transcipherer for TranscipherSession {
     fn kind(&self) -> StreamCipherKind {
         match self {
-            Self::Kreyvium(t) => t.kind(),
             Self::Dynamic(t) => t.kind(),
+            Self::Kreyvium(t) => t.kind(),
+            Self::Aes(t) => t.kind(),
         }
     }
 
     fn next_keystream_bits(&mut self, sks: &ServerKey, n_bits: usize) -> FheKeyStream {
         match self {
-            Self::Kreyvium(t) => t.next_keystream_bits(sks, n_bits),
             Self::Dynamic(t) => t.next_keystream_bits(sks, n_bits),
+            Self::Kreyvium(t) => t.next_keystream_bits(sks, n_bits),
+            Self::Aes(t) => t.next_keystream_bits(sks, n_bits),
         }
     }
 
@@ -321,22 +326,25 @@ impl Transcipherer for TranscipherSession {
         input: &StreamCiphertext,
     ) -> Result<Vec<Ciphertext>, TranscipherError> {
         match self {
-            Self::Kreyvium(t) => t.transcipher(sks, input),
             Self::Dynamic(t) => t.transcipher(sks, input),
+            Self::Kreyvium(t) => t.transcipher(sks, input),
+            Self::Aes(t) => t.transcipher(sks, input),
         }
     }
 
     fn seek(&mut self, sks: &ServerKey, target_counter: u64) {
         match self {
-            Self::Kreyvium(t) => t.seek(sks, target_counter),
             Self::Dynamic(t) => t.seek(sks, target_counter),
+            Self::Kreyvium(t) => t.seek(sks, target_counter),
+            Self::Aes(t) => t.seek(sks, target_counter),
         }
     }
 
     fn current_counter(&self) -> u64 {
         match self {
-            Self::Kreyvium(t) => t.current_counter(),
             Self::Dynamic(t) => t.current_counter(),
+            Self::Kreyvium(t) => t.current_counter(),
+            Self::Aes(t) => t.current_counter(),
         }
     }
 }


### PR DESCRIPTION
# Adding AES-128 to transcipher crate

## Core

The core algo came from this [project](https://github.com/sharkbot1/tfhe-aes-128) with a lot of refacto and performance improvment. We also moved from 1_2 to 2_2 params

A lot of function have been parallelized  and optimized a bit 
- We went from 16.5s average per block to 6.7s
- The expension key came from 13.5s to 5.6s

## CI
Adding the make subfolder for more readability around the makefile command

## AI
AI was used to make my comment better and also match correctly with tfhe-rs way of doing it
Also used to rename the sbox variable to match with [this paper](https://eprint.iacr.org/2011/332.pdf)
Also the split in 3 part of the sbox was made by AI for more readability
Some test and bench was also written with AI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3597)
<!-- Reviewable:end -->
