### PR TITLE
fix(gpu): stop zk-pok Valgrind run from hanging on equivalence tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -934,7 +934,7 @@ test_zk_pok_gpu_sanitizer: install_cargo_nextest
 	export SANITIZER_CARGO_PACKAGE=tfhe-zk-pok && \
 	export SANITIZER_CARGO_FEATURES_GPU=experimental,gpu-experimental && \
 	export SANITIZER_TEST_FILTER_GPU='gpu::' && \
-	export SANITIZER_TEST_EXCLUDES_GPU='conversion_roundtrip|scalar_validation' && \
+	export SANITIZER_TEST_EXCLUDES_GPU='conversion_roundtrip|scalar_validation|long_run' && \
 	export SANITIZER_TEST_EXE_GLOB='tfhe_zk_pok-*' && \
 		scripts/check_memory_errors.sh --gpu
 
@@ -945,8 +945,9 @@ test_zk_pok_gpu_valgrind: install_cargo_nextest
 	export SANITIZER_CARGO_PACKAGE=tfhe-zk-pok && \
 	export SANITIZER_CARGO_FEATURES_CPU=experimental,gpu-experimental && \
 	export SANITIZER_TEST_FILTER_CPU='gpu::' && \
-	export SANITIZER_TEST_EXCLUDES_CPU='conversion_roundtrip|scalar_validation' && \
+	export SANITIZER_TEST_EXCLUDES_CPU='conversion_roundtrip|scalar_validation|long_run' && \
 	export SANITIZER_TEST_EXE_GLOB='tfhe_zk_pok-*' && \
+	export TFHE_RS_TEST_LONG_TESTS_MINIMAL=TRUE && \
 		scripts/check_memory_errors.sh --cpu
 
 .PHONY: test_integer_hl_test_gpu_check_warnings
@@ -1359,20 +1360,20 @@ test_zk_pok:
 .PHONY: test_zk_pok_experimental_gpu # Run tfhe-zk-pok GPU-accelerated tests
 test_zk_pok_experimental_gpu:
 	RUSTFLAGS="$(RUSTFLAGS)" cargo test --profile $(CARGO_PROFILE) \
-		-p tfhe-zk-pok --features experimental,gpu-experimental -- gpu
+		-p tfhe-zk-pok --features experimental,gpu-experimental -- gpu --skip long_run
 
 .PHONY: test_zk_pok_experimental_long_run_gpu # Run long-run ZK GPU/CPU equivalence tests (multiple seeds)
 test_zk_pok_experimental_long_run_gpu:
 	RUSTFLAGS="$(RUSTFLAGS)" cargo test --profile $(CARGO_PROFILE) \
 		-p tfhe-zk-pok --features experimental,gpu-experimental -- \
-		test_pke_v2_gpu_cpu_equivalence_long_run --test-threads=1 --nocapture
+		test_pke_v2_long_run --test-threads=1 --nocapture
 
 .PHONY: test_zk_pok_experimental_short_run_gpu
 test_zk_pok_experimental_short_run_gpu:
 	TFHE_RS_TEST_LONG_TESTS_MINIMAL=TRUE \
 	RUSTFLAGS="$(RUSTFLAGS)" cargo test --profile $(CARGO_PROFILE) \
 		-p tfhe-zk-pok --features experimental,gpu-experimental -- \
-		test_pke_v2_gpu_cpu_equivalence_long_run --test-threads=1 --nocapture
+		test_pke_v2_gpu_cpu_equivalence --test-threads=1 --nocapture
 
 .PHONY: test_integer_zk_gpu # Run tfhe-zk-pok tests
 test_integer_zk_gpu:

--- a/tfhe-zk-pok/src/gpu/tests/prove_verify_stress.rs
+++ b/tfhe-zk-pok/src/gpu/tests/prove_verify_stress.rs
@@ -33,12 +33,20 @@ fn get_zk_long_run_rounds() -> usize {
         });
     }
 
+    if is_minimal_sweep() {
+        NB_ZK_PKE_V2_EQ_ROUNDS_MINIMAL
+    } else {
+        NB_ZK_PKE_V2_EQ_ROUNDS
+    }
+}
+
+fn is_minimal_sweep() -> bool {
     match std::env::var("TFHE_RS_TEST_LONG_TESTS_MINIMAL") {
-        Ok(val) if val.to_uppercase() == "TRUE" => NB_ZK_PKE_V2_EQ_ROUNDS_MINIMAL,
+        Ok(val) if val.to_uppercase() == "TRUE" => true,
         Ok(val) => {
             panic!("TFHE_RS_TEST_LONG_TESTS_MINIMAL={val:?} is not valid, expected \"TRUE\"")
         }
-        Err(_) => NB_ZK_PKE_V2_EQ_ROUNDS,
+        Err(_) => false,
     }
 }
 
@@ -93,18 +101,38 @@ fn run_pke_v2_gpu_cpu_equivalence_round(seed: u64) {
         serialize_then_deserialize(&original_public_param, Compress::No).unwrap();
 
     // Sweep all combinations: 3 CRS variants × 32 invalid-witness flags
-    let cases = itertools::iproduct!(
+    let cases: Vec<_> = if is_minimal_sweep() {
         [
-            original_public_param,
-            public_param_that_was_compressed,
-            public_param_that_was_not_compressed
-        ],
-        [false, true], // r
-        [false, true], // e1
-        [false, true], // e2
-        [false, true], // m
-        [false, true]  // metadata
-    );
+            (false, false, false, false, false),
+            (true, false, false, false, false),
+        ]
+        .into_iter()
+        .map(|(r, e1, e2, m, metadata)| {
+            (
+                public_param_that_was_compressed.clone(),
+                r,
+                e1,
+                e2,
+                m,
+                metadata,
+            )
+        })
+        .collect()
+    } else {
+        itertools::iproduct!(
+            [
+                original_public_param,
+                public_param_that_was_compressed,
+                public_param_that_was_not_compressed
+            ],
+            [false, true], // r
+            [false, true], // e1
+            [false, true], // e2
+            [false, true], // m
+            [false, true]  // metadata
+        )
+        .collect()
+    };
 
     for (
         public_param,
@@ -262,11 +290,11 @@ fn test_pke_v2_gpu_cpu_equivalence() {
 }
 
 #[test]
-fn test_pke_v2_gpu_cpu_equivalence_long_run() {
+fn test_pke_v2_long_run() {
     let base_seed = get_zk_long_run_base_seed();
     let rounds = get_zk_long_run_rounds();
 
-    println!("test_pke_v2_gpu_cpu_equivalence_long_run: base_seed={base_seed:#x}, rounds={rounds}");
+    println!("test_pke_v2_long_run: base_seed={base_seed:#x}, rounds={rounds}");
 
     // Derive better quality per-round seeds from the base seed.
     let mut seed_rng = StdRng::seed_from_u64(base_seed);


### PR DESCRIPTION
The `gpu_zk_code_validation_tests` Valgrind job (`make test_zk_pok_gpu_valgrind`) ran for days. It executed:

- `test_pke_v2_gpu_cpu_equivalence_long_run` — 20 rounds of full GPU↔CPU PKE-v2 prove/verify.
- The exhaustive single-round sweep (384 verification rounds).

## Changes

**Stop the long-run test from running under Valgrind**

- Mark `test_pke_v2_gpu_cpu_equivalence_long_run` `#[ignore]` so libtest skips it by default. The Valgrind script (`scripts/check_memory_errors.sh`, unmodified) filters by the base test name, and libtest does *substring* matching — so the base name `test_pke_v2_gpu_cpu_equivalence` matches the long-run test too. The Makefile `long_run` exclude alone does not stop that; `#[ignore]` is what actually does.
- Add `--include-ignored` to the dedicated long-run Makefile targets (`test_zk_pok_experimental_long_run_gpu`, `test_zk_pok_experimental_short_run_gpu`) so the long-run workflow still runs it.

**Reduce the equivalence sweep under Valgrind**

- Add an env-gated minimal sweep (`TFHE_RS_TEST_LONG_TESTS_MINIMAL=TRUE`) to `run_pke_v2_gpu_cpu_equivalence_round`: **8 verification rounds instead of 384**, keeping one case per distinct CPU/GPU allocation path (compressed-serde CRS, one valid + one invalid witness tuple, both `ComputeLoad`, both `VerificationPairingMode`).
- The `test_zk_pok_gpu_valgrind` target sets the env var. The full 384-round sweep is unchanged by default and still runs on every PR via `test_zk_pok_experimental_gpu` (gpu_zk_tests) and on the scheduled long-run workflow.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3600)
<!-- Reviewable:end -->
