### PR TITLE
Ns/chore/nightly floating deps

### DIFF
--- a/.github/workflows/floating_deps.yml
+++ b/.github/workflows/floating_deps.yml
@@ -1,0 +1,40 @@
+# Build and lint tfhe-rs against the latest semver-compatible dependencies.
+#
+# This job runs UNTRUSTED code: it updates dependencies to their latest semver
+# compatible version (ignoring the committed Cargo.lock), so a newly published
+# malicious dependency version could execute in build scripts / proc-macros.
+# It therefore runs on an ephemeral GitHub-hosted runner with no secrets and
+# read-only permissions.
+name: floating_deps
+
+on:
+  workflow_dispatch:
+  schedule:
+    # runs every day at 5am UTC
+    - cron: '0 5 * * *'
+
+env:
+  CARGO_TERM_COLOR: always
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  check-floating-deps:
+    name: floating_deps/check-floating-deps
+    if: github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'schedule' && github.repository == 'zama-ai/tfhe-rs')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read  # for actions/checkout
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: 'false'
+
+      - name: Build and lint against up-to-date dependencies
+        run: |
+          make check_floating_deps

--- a/.github/workflows/floating_deps_notify.yml
+++ b/.github/workflows/floating_deps_notify.yml
@@ -1,0 +1,45 @@
+# Notify on failure of the `floating_deps` workflow.
+#
+# Runs in a TRUSTED context: it is triggered by `workflow_run` once
+# `floating_deps` completes, and only posts a Slack message. It never checks out
+# the repository nor executes any dependency code, so the Slack webhook secret is
+# never exposed to the untrusted dependency-resolving job.
+name: floating_deps_notify
+
+# This workflow never runs untrusted code nor exposes secrets to it; the workflow_run
+# trigger is required to notify from a trusted context after the untrusted build runs.
+# It only reads github-controlled metadata. No output produced by the untrusted workflow
+# is ever interpreted.
+on:  # zizmor: ignore[dangerous-triggers] only reads github metadata
+  workflow_run:
+    workflows: ["floating_deps"]
+    types:
+      - completed
+
+env:
+  ACTION_RUN_URL: ${{ github.event.workflow_run.html_url }}
+  SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
+  SLACK_ICON: https://pbs.twimg.com/profile_images/1274014582265298945/OjBKP9kn_400x400.png
+  SLACK_USERNAME: ${{ secrets.BOT_USERNAME }}
+  SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+  SLACKIFY_MARKDOWN: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.id }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  notify:
+    name: floating_deps_notify/notify
+    if: github.event.workflow_run.conclusion == 'failure'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Slack Notification
+        continue-on-error: true
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661
+        env:
+          SLACK_COLOR: failure
+          SLACK_MESSAGE: "floating-deps finished with status: ${{ github.event.workflow_run.conclusion }}.
+            ([action run](${{ env.ACTION_RUN_URL }}))"

--- a/Makefile
+++ b/Makefile
@@ -616,6 +616,8 @@ clippy_backward_compat_data: install_rs_check_toolchain # the toolchain is selec
 	fi
 
 CARGO_LOCK_DIRS := $(shell git ls-files '*Cargo.lock' | xargs -n1 dirname)
+# All lock dirs except backward-compat generate_* crates (pinned to historical versions).
+FLOATING_LOCK_DIRS := $(shell git ls-files '*Cargo.lock' | grep -v 'crates/generate_' | xargs -n1 dirname)
 
 .PHONY: check_cargo_lock # Check all Cargo.lock files are up to date with their Cargo.toml
 check_cargo_lock:
@@ -682,6 +684,13 @@ check_rust_bindings_did_not_change:
 .PHONY: audit_dependencies # Run cargo audit to check vulnerable dependencies
 audit_dependencies: install_cargo_audit
 	cargo audit
+
+.PHONY: check_floating_deps # Build & lint tfhe-rs against the latest semver-compatible deps
+check_floating_deps:
+	@for dir in $(FLOATING_LOCK_DIRS); do \
+		rm -f $$dir/Cargo.lock; \
+	done
+	$(MAKE) clippy_all
 
 .PHONY: build_core # Build core_crypto without experimental features
 build_core:


### PR DESCRIPTION
Adds a nightly workflow run that removes the Cargo.lock and performs clippy checks to verify that everything build correctly.
Since according to our security model, this means running potentially untrusted deps, this workflow is running in a limited environment without access to any secret. The idea is to limit the blast radius as much as possible.

This means:
- only run inside a github instance
- runs only on public repo -> no token needed to clone
- use another workflow with `workflow_run/completed` trigger to post the result on slack.

So we have 2 workflows: one "trusted" workflow with access to the slack token but does not run any code. One "untrusted" workflow that runs untrusted deps but has no access to any token or secret.

Communication from "untrusted" to "trusted" is only done using github controlled metadata. No execution output or artefact from the workflow is ever read.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3604)
<!-- Reviewable:end -->
