### PR TITLE
chore(ci): add dependabot config for rust

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,3 +9,24 @@ updates:
       day: "sunday"
     cooldown:
       default-days: 7
+
+  - package-ecosystem: "cargo"
+    directories:
+      - "/"
+      - "/apps/trivium"
+      - "/utils/tfhe-lints"
+    schedule:
+      # Routine version bumps monthly to limit churn. Security fixes are handled
+      # separately and immediately by Dependabot security updates.
+      interval: "monthly"
+    cooldown:
+      default-days: 7
+    allow:
+      - dependency-type: "direct"
+    groups:
+      cargo-minor-patch:
+        applies-to: version-updates
+        # Groups multiple minor or patch updates in a single pr
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Adds dependabot for rust.

/!\ This is only for non-security updates. Security updates are done through the alert mechanism (also from dependabot).

Updates to the Cargo.lock are done once every month, to reduce the noise. A 7 days cooldown is applied to reduce supply chain risks (might be modified later, especially if/when we add cargo vet).
Updates pr for minor/patch bumps are batched to reduce the review work. Major version updates get their own pr to be treated with special care.