### PR TITLE
  feat!: change 'overshift' behavior

### DIFF
--- a/tfhe/src/high_level_api/integers/signed/ops.rs
+++ b/tfhe/src/high_level_api/integers/signed/ops.rs
@@ -1894,6 +1894,11 @@ where
 {
     /// Performs the `<<=` operation on [FheInt]
     ///
+    /// # Overshift
+    ///
+    /// If the shift amount is greater than or equal to the number of bits of the type,
+    /// the result is `0`.
+    ///
     /// # Example
     ///
     /// ```rust
@@ -1950,6 +1955,12 @@ where
     Id2: FheUintId,
 {
     /// Performs the `>>=` operation on [FheInt]
+    ///
+    /// # Overshift
+    ///
+    /// If the shift amount is greater than or equal to the number of bits of the type,
+    /// the result is `0` for non-negative inputs, and `-1` for negative inputs
+    /// (sign-extension).
     ///
     /// # Example
     ///

--- a/tfhe/src/high_level_api/integers/signed/scalar_ops.rs
+++ b/tfhe/src/high_level_api/integers/signed/scalar_ops.rs
@@ -680,6 +680,7 @@ macro_rules! define_scalar_rotate_shifts {
     ) => {
 
         generic_integer_impl_scalar_operation!(
+            op_doc: "# Overshift\n\nIf the shift amount is greater than or equal to the number of bits of the type, the result is `0`.",
             rust_trait: Shl(shl),
             implem: {
                 |lhs: &FheInt<_>, rhs| {
@@ -736,6 +737,7 @@ macro_rules! define_scalar_rotate_shifts {
         );
 
         generic_integer_impl_scalar_operation!(
+            op_doc: "# Overshift\n\nIf the shift amount is greater than or equal to the number of bits of the type, the result is `0` for non-negative inputs, and `-1` for negative inputs (sign-extension).",
             rust_trait: Shr(shr),
             implem: {
                 |lhs: &FheInt<_>, rhs| {
@@ -904,6 +906,7 @@ macro_rules! define_scalar_rotate_shifts {
         );
 
         generic_integer_impl_scalar_operation_assign!(
+            op_doc: "# Overshift\n\nIf the shift amount is greater than or equal to the number of bits of the type, the result is `0`.",
             rust_trait: ShlAssign(shl_assign),
             implem: {
                 |lhs: &mut FheInt<_>, rhs| {
@@ -933,6 +936,7 @@ macro_rules! define_scalar_rotate_shifts {
         );
 
         generic_integer_impl_scalar_operation_assign!(
+            op_doc: "# Overshift\n\nIf the shift amount is greater than or equal to the number of bits of the type, the result is `0` for non-negative inputs, and `-1` for negative inputs (sign-extension).",
             rust_trait: ShrAssign(shr_assign),
             implem: {
                 |lhs: &mut FheInt<_>, rhs| {

--- a/tfhe/src/high_level_api/integers/unsigned/ops.rs
+++ b/tfhe/src/high_level_api/integers/unsigned/ops.rs
@@ -2258,6 +2258,11 @@ where
 {
     /// Performs the `<<=` operation on [FheUint]
     ///
+    /// # Overshift
+    ///
+    /// If the shift amount is greater than or equal to the number of bits of the type,
+    /// the result is `0`.
+    ///
     /// # Example
     ///
     /// ```rust
@@ -2332,6 +2337,11 @@ where
     Id2: FheUintId,
 {
     /// Performs the `>>=` operation on [FheUint]
+    ///
+    /// # Overshift
+    ///
+    /// If the shift amount is greater than or equal to the number of bits of the type,
+    /// the result is `0`.
     ///
     /// # Example
     ///

--- a/tfhe/src/high_level_api/integers/unsigned/scalar_ops.rs
+++ b/tfhe/src/high_level_api/integers/unsigned/scalar_ops.rs
@@ -794,8 +794,12 @@ macro_rules! generic_integer_impl_scalar_div_rem {
     };
 }
 // Ciphertext/Scalar ops
+//
+// `op_doc` is a single string literal rather than `$(#[$op_doc:meta])*`:
+// to avoid problems of levels of repetition.
 macro_rules! generic_integer_impl_scalar_operation {
     (
+        op_doc: $op_doc:literal,
         rust_trait: $rust_trait_name:ident($rust_trait_method:ident),
         implem: {
             // A closure that must return a RadixCiphertext
@@ -810,6 +814,42 @@ macro_rules! generic_integer_impl_scalar_operation {
     ) => {
         $( // First repeating pattern
             $( // Second repeating pattern
+                impl $rust_trait_name<$scalar_type> for $concrete_type
+                {
+                    type Output = $concrete_type;
+
+                    #[doc = $op_doc]
+                    fn $rust_trait_method(self, rhs: $scalar_type) -> Self::Output {
+                        <&Self as $rust_trait_name<$scalar_type>>::$rust_trait_method(&self, rhs)
+                    }
+                }
+
+                impl $rust_trait_name<$scalar_type> for &$concrete_type
+                {
+                    type Output = $concrete_type;
+
+                    #[doc = $op_doc]
+                    fn $rust_trait_method(self, rhs: $scalar_type) -> Self::Output {
+                        let inner_result = $closure(self, rhs);
+                        let tag = global_state::tag_of_internal_server_key().unwrap_display();
+                        <$concrete_type>::new(inner_result, tag, ReRandomizationMetadata::default())
+                    }
+                }
+            )* // Closing second repeating pattern
+        )* // Closing first repeating pattern
+    };
+    (
+        rust_trait: $rust_trait_name:ident($rust_trait_method:ident),
+        implem: {
+            $closure:expr
+        },
+        fhe_and_scalar_type: $(
+            ($concrete_type:ty, $($scalar_type:ty),* $(,)?)
+        ),*
+        $(,)?
+    ) => {
+        $(
+            $(
                 impl $rust_trait_name<$scalar_type> for $concrete_type
                 {
                     type Output = $concrete_type;
@@ -829,8 +869,8 @@ macro_rules! generic_integer_impl_scalar_operation {
                         <$concrete_type>::new(inner_result, tag, ReRandomizationMetadata::default())
                     }
                 }
-            )* // Closing second repeating pattern
-        )* // Closing first repeating pattern
+            )*
+        )*
     };
 }
 
@@ -974,12 +1014,36 @@ pub(in crate::high_level_api::integers) use generic_integer_impl_get_scalar_left
 // Scalar assign ops
 macro_rules! generic_integer_impl_scalar_operation_assign {
     (
+        op_doc: $op_doc:literal,
         rust_trait: $rust_trait_name:ident($rust_trait_method:ident),
         implem: {
             $closure:expr
         },
         // A 'list' of tuple, where the first element is the concrete Fhe type
         // e.g (FheUint8 and the rest is scalar types (u8, u16, etc)
+        fhe_and_scalar_type: $(
+            ($concrete_type:ty, $($(#[$doc:meta])* $scalar_type:ty),* $(,)?)
+        ),*
+        $(,)?
+    ) => {
+        $(
+            $(
+                impl $rust_trait_name<$scalar_type> for $concrete_type
+                {
+                    #[doc = $op_doc]
+                    $(#[$doc])*
+                    fn $rust_trait_method(&mut self, rhs: $scalar_type) {
+                        $closure(self, rhs);
+                    }
+                }
+            )*
+        )*
+    };
+    (
+        rust_trait: $rust_trait_name:ident($rust_trait_method:ident),
+        implem: {
+            $closure:expr
+        },
         fhe_and_scalar_type: $(
             ($concrete_type:ty, $($(#[$doc:meta])* $scalar_type:ty),* $(,)?)
         ),*
@@ -1010,6 +1074,7 @@ macro_rules! define_scalar_rotate_shifts {
     ) => {
 
         generic_integer_impl_scalar_operation!(
+            op_doc: "# Overshift\n\nIf the shift amount is greater than or equal to the number of bits of the type, the result is `0`.",
             rust_trait: Shl(shl),
             implem: {
                 |lhs: &FheUint<_>, rhs| {
@@ -1067,6 +1132,7 @@ macro_rules! define_scalar_rotate_shifts {
         );
 
         generic_integer_impl_scalar_operation!(
+            op_doc: "# Overshift\n\nIf the shift amount is greater than or equal to the number of bits of the type, the result is `0`.",
             rust_trait: Shr(shr),
             implem: {
                 |lhs: &FheUint<_>, rhs| {
@@ -1238,6 +1304,7 @@ macro_rules! define_scalar_rotate_shifts {
         );
 
         generic_integer_impl_scalar_operation_assign!(
+            op_doc: "# Overshift\n\nIf the shift amount is greater than or equal to the number of bits of the type, the result is `0`.",
             rust_trait: ShlAssign(shl_assign),
             implem: {
                 |lhs: &mut FheUint<_>, rhs| {
@@ -1269,6 +1336,7 @@ macro_rules! define_scalar_rotate_shifts {
         );
 
         generic_integer_impl_scalar_operation_assign!(
+            op_doc: "# Overshift\n\nIf the shift amount is greater than or equal to the number of bits of the type, the result is `0`.",
             rust_trait: ShrAssign(shr_assign),
             implem: {
                 |lhs: &mut FheUint<_>, rhs| {

--- a/tfhe/src/integer/gpu/server_key/radix/tests_signed/test_scalar_shift.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/tests_signed/test_scalar_shift.rs
@@ -19,7 +19,7 @@ where
     P: Into<TestParameters>,
 {
     let executor = GpuFunctionExecutor::new(&CudaServerKey::unchecked_scalar_left_shift);
-    signed_unchecked_scalar_left_shift_test(param, executor);
+    signed_unchecked_scalar_left_shift_test(param, executor, false);
 }
 
 fn integer_signed_scalar_left_shift<P>(param: P)
@@ -27,7 +27,7 @@ where
     P: Into<TestParameters>,
 {
     let executor = GpuFunctionExecutor::new(&CudaServerKey::scalar_left_shift);
-    signed_default_scalar_left_shift_test(param, executor);
+    signed_default_scalar_left_shift_test(param, executor, false);
 }
 
 fn integer_signed_unchecked_scalar_right_shift<P>(param: P)
@@ -35,7 +35,7 @@ where
     P: Into<TestParameters>,
 {
     let executor = GpuFunctionExecutor::new(&CudaServerKey::unchecked_scalar_right_shift);
-    signed_unchecked_scalar_right_shift_test(param, executor);
+    signed_unchecked_scalar_right_shift_test(param, executor, false);
 }
 
 fn integer_signed_scalar_right_shift<P>(param: P)
@@ -43,5 +43,5 @@ where
     P: Into<TestParameters>,
 {
     let executor = GpuFunctionExecutor::new(&CudaServerKey::scalar_right_shift);
-    signed_default_scalar_right_shift_test(param, executor);
+    signed_default_scalar_right_shift_test(param, executor, false);
 }

--- a/tfhe/src/integer/gpu/server_key/radix/tests_signed/test_shift.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/tests_signed/test_shift.rs
@@ -19,7 +19,7 @@ where
     P: Into<TestParameters> + Copy,
 {
     let executor = GpuFunctionExecutor::new(&CudaServerKey::unchecked_right_shift);
-    signed_unchecked_right_shift_test(param, executor);
+    signed_unchecked_right_shift_test(param, executor, false);
 }
 
 fn integer_signed_right_shift<P>(param: P)
@@ -27,7 +27,7 @@ where
     P: Into<TestParameters> + Copy,
 {
     let executor = GpuFunctionExecutor::new(&CudaServerKey::right_shift);
-    signed_default_right_shift_test(param, executor);
+    signed_default_right_shift_test(param, executor, false);
 }
 
 fn integer_signed_unchecked_left_shift<P>(param: P)
@@ -35,7 +35,7 @@ where
     P: Into<TestParameters> + Copy,
 {
     let executor = GpuFunctionExecutor::new(&CudaServerKey::unchecked_left_shift);
-    signed_unchecked_left_shift_test(param, executor);
+    signed_unchecked_left_shift_test(param, executor, false);
 }
 
 fn integer_signed_left_shift<P>(param: P)
@@ -43,5 +43,5 @@ where
     P: Into<TestParameters> + Copy,
 {
     let executor = GpuFunctionExecutor::new(&CudaServerKey::left_shift);
-    signed_default_left_shift_test(param, executor);
+    signed_default_left_shift_test(param, executor, false);
 }

--- a/tfhe/src/integer/gpu/server_key/radix/tests_unsigned/test_scalar_shift.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/tests_unsigned/test_scalar_shift.rs
@@ -19,7 +19,7 @@ where
     P: Into<TestParameters> + Copy,
 {
     let executor = GpuFunctionExecutor::new(&CudaServerKey::unchecked_scalar_right_shift);
-    unchecked_scalar_right_shift_test(param, executor);
+    unchecked_scalar_right_shift_test(param, executor, false);
 }
 
 fn integer_scalar_right_shift<P>(param: P)
@@ -27,7 +27,7 @@ where
     P: Into<TestParameters> + Copy,
 {
     let executor = GpuFunctionExecutor::new(&CudaServerKey::scalar_right_shift);
-    default_scalar_right_shift_test(param, executor);
+    default_scalar_right_shift_test(param, executor, false);
 }
 
 fn integer_unchecked_scalar_left_shift<P>(param: P)
@@ -35,7 +35,7 @@ where
     P: Into<TestParameters> + Copy,
 {
     let executor = GpuFunctionExecutor::new(&CudaServerKey::unchecked_scalar_left_shift);
-    unchecked_scalar_left_shift_test(param, executor);
+    unchecked_scalar_left_shift_test(param, executor, false);
 }
 
 fn integer_scalar_left_shift<P>(param: P)
@@ -43,5 +43,5 @@ where
     P: Into<TestParameters> + Copy,
 {
     let executor = GpuFunctionExecutor::new(&CudaServerKey::scalar_left_shift);
-    default_scalar_left_shift_test(param, executor);
+    default_scalar_left_shift_test(param, executor, false);
 }

--- a/tfhe/src/integer/gpu/server_key/radix/tests_unsigned/test_shift.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/tests_unsigned/test_shift.rs
@@ -19,7 +19,7 @@ where
     P: Into<TestParameters> + Copy,
 {
     let executor = GpuFunctionExecutor::new(&CudaServerKey::unchecked_right_shift);
-    unchecked_right_shift_test(param, executor);
+    unchecked_right_shift_test(param, executor, false);
 }
 
 fn integer_right_shift<P>(param: P)
@@ -27,7 +27,7 @@ where
     P: Into<TestParameters> + Copy,
 {
     let executor = GpuFunctionExecutor::new(&CudaServerKey::right_shift);
-    default_right_shift_test(param, executor);
+    default_right_shift_test(param, executor, false);
 }
 
 fn integer_unchecked_left_shift<P>(param: P)
@@ -35,7 +35,7 @@ where
     P: Into<TestParameters> + Copy,
 {
     let executor = GpuFunctionExecutor::new(&CudaServerKey::unchecked_left_shift);
-    unchecked_left_shift_test(param, executor);
+    unchecked_left_shift_test(param, executor, false);
 }
 
 fn integer_left_shift<P>(param: P)
@@ -43,5 +43,5 @@ where
     P: Into<TestParameters> + Copy,
 {
     let executor = GpuFunctionExecutor::new(&CudaServerKey::left_shift);
-    default_left_shift_test(param, executor);
+    default_left_shift_test(param, executor, false);
 }

--- a/tfhe/src/integer/server_key/radix/shift.rs
+++ b/tfhe/src/integer/server_key/radix/shift.rs
@@ -127,9 +127,14 @@ impl ServerKey {
         let num_bits_in_block = self.key.message_modulus.0.ilog2() as u64;
         let total_num_bits = num_bits_in_block * ct.blocks.len() as u64;
 
-        let shift = shift % T::cast_from(total_num_bits);
         let shift = u64::cast_from(shift);
         if shift == 0 {
+            return;
+        }
+
+        if shift >= total_num_bits {
+            // This function takes unsigned radix only, so no sign to handle
+            self.create_trivial_zero_assign_radix(ct);
             return;
         }
 
@@ -284,7 +289,11 @@ impl ServerKey {
 
         let num_bits_in_block = self.key.message_modulus.0.ilog2() as u64;
         let total_num_bits = num_bits_in_block * ct.blocks.len() as u64;
-        let shift = shift % total_num_bits;
+        if shift >= total_num_bits {
+            // Overshift on a left shift pushes every bit out: the result is 0.
+            self.create_trivial_zero_assign_radix(ct);
+            return;
+        }
 
         let rotations = ((shift / num_bits_in_block) as usize).min(ct.blocks.len());
         let shift_within_block = shift % num_bits_in_block;

--- a/tfhe/src/integer/server_key/radix/tests.rs
+++ b/tfhe/src/integer/server_key/radix/tests.rs
@@ -546,7 +546,7 @@ where
     P: Into<TestParameters>,
 {
     let executor = CpuFunctionExecutor::new(&ServerKey::unchecked_scalar_left_shift);
-    unchecked_scalar_left_shift_test(param, executor);
+    unchecked_scalar_left_shift_test(param, executor, true);
 }
 
 fn integer_unchecked_scalar_right_shift<P>(param: P)
@@ -554,7 +554,7 @@ where
     P: Into<TestParameters>,
 {
     let executor = CpuFunctionExecutor::new(&ServerKey::unchecked_scalar_right_shift);
-    unchecked_scalar_right_shift_test(param, executor);
+    unchecked_scalar_right_shift_test(param, executor, true);
 }
 
 fn integer_unchecked_neg<P>(param: P)

--- a/tfhe/src/integer/server_key/radix_parallel/block_shift.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/block_shift.rs
@@ -50,6 +50,10 @@ impl ServerKey {
     ///     e.g: d_range = 2.. => the first bit of the shift_bits_extractor is
     ///     actually the bit at index 2
     /// operation: The operation to perform
+    ///
+    /// The values returned is not fully clean:
+    /// - blocks have no carries
+    /// - blocks have noise_level = 2
     pub(super) fn block_barrel_shifter_impl<T>(
         &self,
         ct: &T,
@@ -235,11 +239,6 @@ impl ServerKey {
             }
         }
 
-        // Reset noise due to last add
-        current_blocks
-            .par_iter_mut()
-            .for_each(|block| self.key.message_extract_assign(block));
-
         T::from_blocks(current_blocks)
     }
 
@@ -277,12 +276,17 @@ impl ServerKey {
             message_bits_per_block as usize,
         );
         shift_bit_extractor.prepare_n_bits(max_num_bits_that_tell_shift as usize);
-        self.block_barrel_shifter_impl(
+        let mut dirty_result = self.block_barrel_shifter_impl(
             ct,
             &mut shift_bit_extractor,
             0..max_num_bits_that_tell_shift as usize,
             operation,
-        )
+        );
+        dirty_result
+            .blocks_mut()
+            .par_iter_mut()
+            .for_each(|block| self.key.message_extract_assign(block));
+        dirty_result
     }
 
     pub fn unchecked_block_rotate_right<T>(&self, ct: &T, amount: &RadixCiphertext) -> T

--- a/tfhe/src/integer/server_key/radix_parallel/cmux.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/cmux.rs
@@ -894,20 +894,28 @@ impl ServerKey {
             return;
         }
 
-        let lut =
-            self.key.generate_lookup_table_bivariate(
-                |block, condition| if predicate(condition) { 0 } else { block },
-            );
+        // Shifting by the condition's current modulus allows to be more flexible
+        // regarding noise levels when the condition is a a boolean
+        let condition_mod = condition_block.degree.get() + 1;
+        let lut = self.key.generate_lookup_table(|block| {
+            let condition = block % condition_mod;
+            let x = block / condition_mod;
+
+            if predicate(condition) {
+                0
+            } else {
+                x
+            }
+        });
 
         ct.blocks_mut()
             .par_iter_mut()
             .filter(|block| block.degree.get() != 0)
             .for_each(|block| {
-                self.key.unchecked_apply_lookup_table_bivariate_assign(
-                    block,
-                    condition_block,
-                    &lut,
-                );
+                self.key
+                    .unchecked_scalar_mul_assign(block, condition_mod as u8);
+                self.key.unchecked_add_assign(block, condition_block);
+                self.key.apply_lookup_table_assign(block, &lut);
             });
     }
 

--- a/tfhe/src/integer/server_key/radix_parallel/scalar_shift.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/scalar_shift.rs
@@ -118,6 +118,28 @@ impl ServerKey {
         result
     }
 
+    /// Produces a "sign block" from `sign_source`: a block whose message is all-ones
+    /// (`message_modulus - 1`) if the sign bit (the MSB of the message) of `sign_source` is set,
+    /// and `0` otherwise. This costs one PBS.
+    ///
+    /// Note: this is only meaningful for blocks holding at least 2 bits of message; for
+    /// 1-bit-message blocks the block itself already is the sign, so callers should clone it
+    /// instead.
+    fn arithmetic_shift_sign_block(
+        &self,
+        sign_source: &crate::shortint::Ciphertext,
+    ) -> crate::shortint::Ciphertext {
+        let message_modulus = self.key.message_modulus.0;
+        let num_bits_in_block = message_modulus.ilog2() as u64;
+        let lut = self.key.generate_lookup_table(|x| {
+            let x = x % message_modulus;
+            let x_sign_bit = (x >> (num_bits_in_block - 1)) & 1;
+            // a message full of 1s if the sign bit is set, else 0
+            (message_modulus - 1) * x_sign_bit
+        });
+        self.key.apply_lookup_table(sign_source, &lut)
+    }
+
     pub fn unchecked_scalar_right_shift_arithmetic_assign_parallelized<T, Scalar>(
         &self,
         ct: &mut T,
@@ -140,8 +162,24 @@ impl ServerKey {
         let num_bits_in_block = self.key.message_modulus.0.ilog2() as u64;
         let total_num_bits = num_bits_in_block * ct.blocks().len() as u64;
 
-        let shift = u64::cast_from(shift) % total_num_bits;
+        let shift = u64::cast_from(shift);
         if shift == 0 {
+            return;
+        }
+
+        if shift >= total_num_bits {
+            // Overshift: an arithmetic right shift saturates to the sign, so every block becomes
+            // the sign block (all-ones if the input is negative, else 0).
+            let num_blocks = ct.blocks().len();
+            let sign_block = if num_bits_in_block == 1 {
+                // a 1-bit-message block already is its own sign bit
+                ct.blocks()[num_blocks - 1].clone()
+            } else {
+                self.arithmetic_shift_sign_block(&ct.blocks()[num_blocks - 1])
+            };
+            for block in ct.blocks_mut() {
+                block.clone_from(&sign_block);
+            }
             return;
         }
 
@@ -191,20 +229,9 @@ impl ServerKey {
             });
             let last_block = &ct.blocks()[num_blocks - rotations - 1];
 
-            let pad_block_creator_lut = self.key.generate_lookup_table(|x| {
-                let x = x % message_modulus;
-                let x_sign_bit = (x >> (num_bits_in_block - 1)) & 1;
-                // padding is a message full of 1 if sign bit is one
-                // else padding is a zero message
-                (message_modulus - 1) * x_sign_bit
-            });
-
             rayon::join(
                 || self.key.apply_lookup_table(last_block, &last_block_lut),
-                || {
-                    self.key
-                        .apply_lookup_table(last_block, &pad_block_creator_lut)
-                },
+                || self.arithmetic_shift_sign_block(last_block),
             )
         };
 
@@ -257,8 +284,15 @@ impl ServerKey {
         let num_bits_in_block = self.key.message_modulus.0.ilog2() as u64;
         let total_num_bits = num_bits_in_block * ct.blocks().len() as u64;
 
-        let shift = u64::cast_from(shift) % total_num_bits;
+        let shift = u64::cast_from(shift);
         if shift == 0 {
+            return;
+        }
+
+        if shift >= total_num_bits {
+            // Overshift: a logical right shift pushes every bit out,
+            // so the result is 0.
+            self.create_trivial_zero_assign_radix(ct);
             return;
         }
 
@@ -392,6 +426,12 @@ impl ServerKey {
     /// let dec: u64 = cks.decrypt(&ct_res);
     /// assert_eq!(msg >> shift, dec);
     /// ```
+    ///
+    /// # Overshift
+    ///
+    /// If the shift amount is greater than or equal to the number of bits of the type,
+    /// the result is `0` for unsigned or non-negative signed inputs, and `-1` (all bits
+    /// set) for negative signed inputs (sign-extension).
     pub fn scalar_right_shift_parallelized<T, Scalar>(&self, ct: &T, shift: Scalar) -> T
     where
         T: IntegerRadixCiphertext,
@@ -437,6 +477,12 @@ impl ServerKey {
     /// let dec: u64 = cks.decrypt(&ct);
     /// assert_eq!(msg >> shift, dec);
     /// ```
+    ///
+    /// # Overshift
+    ///
+    /// If the shift amount is greater than or equal to the number of bits of the type,
+    /// the result is `0` for unsigned or non-negative signed inputs, and `-1` (all bits
+    /// set) for negative signed inputs (sign-extension).
     pub fn scalar_right_shift_assign_parallelized<T, Scalar>(&self, ct: &mut T, shift: Scalar)
     where
         T: IntegerRadixCiphertext,
@@ -559,8 +605,15 @@ impl ServerKey {
         let num_bits_in_block = self.key.message_modulus.0.ilog2() as u64;
         let total_num_bits = num_bits_in_block * ct.blocks().len() as u64;
 
-        let shift = u64::cast_from(shift) % total_num_bits;
+        let shift = u64::cast_from(shift);
         if shift == 0 {
+            return;
+        }
+
+        if shift >= total_num_bits {
+            // Overshift: a left shift pushes every bit out,
+            // so the result is 0.
+            self.create_trivial_zero_assign_radix(ct);
             return;
         }
 
@@ -666,6 +719,11 @@ impl ServerKey {
     /// let dec: u64 = cks.decrypt(&ct_res);
     /// assert_eq!(msg << shift, dec);
     /// ```
+    ///
+    /// # Overshift
+    ///
+    /// If the shift amount is greater than or equal to the number of bits of the type,
+    /// the result is `0`.
     pub fn scalar_left_shift_parallelized<T, Scalar>(&self, ct_left: &T, shift: Scalar) -> T
     where
         T: IntegerRadixCiphertext,
@@ -711,6 +769,11 @@ impl ServerKey {
     /// let dec: u64 = cks.decrypt(&ct);
     /// assert_eq!(msg << shift, dec);
     /// ```
+    ///
+    /// # Overshift
+    ///
+    /// If the shift amount is greater than or equal to the number of bits of the type,
+    /// the result is `0`.
     pub fn scalar_left_shift_assign_parallelized<T, Scalar>(&self, ct: &mut T, shift: Scalar)
     where
         T: IntegerRadixCiphertext,

--- a/tfhe/src/integer/server_key/radix_parallel/shift.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/shift.rs
@@ -1,6 +1,7 @@
 use crate::integer::ciphertext::{IntegerRadixCiphertext, RadixCiphertext};
 use crate::integer::server_key::radix_parallel::bit_extractor::BitExtractor;
-use crate::integer::ServerKey;
+use crate::integer::{BooleanBlock, ServerKey};
+use crate::shortint::Ciphertext;
 use rayon::prelude::*;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -81,6 +82,13 @@ impl ServerKey {
         self.unchecked_right_shift_parallelized(ct, shift)
     }
 
+    /// Computes homomorphically a right shift by an encrypted amount, in place.
+    ///
+    /// # Overshift
+    ///
+    /// If the shift amount is greater than or equal to the number of bits of the type,
+    /// the result is `0` for unsigned or non-negative signed inputs, and `-1` (all bits
+    /// set) for negative signed inputs (sign-extension).
     pub fn right_shift_assign_parallelized<T>(&self, ct: &mut T, shift: &RadixCiphertext)
     where
         T: IntegerRadixCiphertext,
@@ -126,6 +134,12 @@ impl ServerKey {
     /// This means that when using only "default" operations, a given operation (like add for
     /// example) has always the same performance characteristics from one call to another and
     /// guarantees correctness by pre-emptively clearing carries of output ciphertexts.
+    ///
+    /// # Overshift
+    ///
+    /// If the shift amount is greater than or equal to the number of bits of the type,
+    /// the result is `0` for unsigned or non-negative signed inputs, and `-1` (all bits
+    /// set) for negative signed inputs (sign-extension).
     ///
     /// # Example
     ///
@@ -229,6 +243,12 @@ impl ServerKey {
         self.unchecked_left_shift_parallelized(ct, shift)
     }
 
+    /// Computes homomorphically a left shift by an encrypted amount, in place.
+    ///
+    /// # Overshift
+    ///
+    /// If the shift amount is greater than or equal to the number of bits of the type,
+    /// the result is `0`.
     pub fn left_shift_assign_parallelized<T>(&self, ct: &mut T, shift: &RadixCiphertext)
     where
         T: IntegerRadixCiphertext,
@@ -274,6 +294,11 @@ impl ServerKey {
     /// This means that when using only "default" operations, a given operation (like add for
     /// example) has always the same performance characteristics from one call to another and
     /// guarantees correctness by pre-emptively clearing carries of output ciphertexts.
+    ///
+    /// # Overshift
+    ///
+    /// If the shift amount is greater than or equal to the number of bits of the type,
+    /// the result is `0`.
     ///
     /// # Example
     ///
@@ -334,33 +359,251 @@ impl ServerKey {
         }
 
         if message_bits_per_block == 1 {
-            let mut shift_bit_extractor = BitExtractor::with_final_offset(
-                &amount.blocks,
-                self,
-                message_bits_per_block as usize,
-                message_bits_per_block as usize,
-            );
-
-            // If blocks encrypt one bit, then shifting bits is just shifting blocks
-            let result = self.block_barrel_shifter_impl(
-                ct,
-                &mut shift_bit_extractor,
-                0..max_num_bits_that_tell_shift as usize,
-                // Our blocks are stored in little endian order
-                operation.invert_direction(),
-            );
-
-            *ct = result;
-        } else if message_bits_per_block.is_power_of_two() {
-            let result = self.barrel_shift_bits_pow2_block_modulus(
+            *ct = self.barrel_shift_bits_1_bit(
                 ct,
                 amount,
                 operation,
                 max_num_bits_that_tell_shift as usize,
             );
-            *ct = result;
+        } else if message_bits_per_block.is_power_of_two() {
+            *ct = self.barrel_shift_bits_pow2_block_modulus(
+                ct,
+                amount,
+                operation,
+                max_num_bits_that_tell_shift as usize,
+            );
         } else {
             self.bit_barrel_shifter(ct, amount, operation);
+        }
+    }
+
+    /// Computes the overshift predicate `amount >= num_bits` cheaply.
+    ///
+    /// The `amount` is expected to be already split into `low_amount` (the low blocks, which can
+    /// hold a valid shift) and `high_blocks` (the remaining, more significant blocks).
+    ///
+    /// Because `num_bits <= message_modulus^low_amount.len()`, the shift
+    /// overshifts iff any high block is non-zero, or the low part is `>= num_bits`:
+    ///
+    ///   `(low_amount >= num_bits) | (high_blocks != 0)`
+    fn overshift_predicate(
+        &self,
+        low_amount: &RadixCiphertext,
+        high_blocks: &[Ciphertext],
+        num_bits: u64,
+    ) -> Ciphertext {
+        // When the amount fits entirely in the low blocks there is no high part to OR in, so the
+        // predicate is just the comparison (avoids a wasted `is_zero` + `bitor` PBS).
+        if high_blocks.is_empty() {
+            return self.scalar_ge_parallelized(low_amount, num_bits).0;
+        }
+        let (low_is_ge, high_is_non_zero) = rayon::join(
+            || self.scalar_ge_parallelized(low_amount, num_bits),
+            || {
+                let mut b = BooleanBlock::new_unchecked(self.are_all_blocks_zero(high_blocks));
+                self.boolean_bitnot_assign(&mut b);
+                b
+            },
+        );
+        self.key.unchecked_bitor(&low_is_ge.0, &high_is_non_zero.0)
+    }
+
+    /// Builds the `cond` ciphertext used to finalize an arithmetic (signed) right shift.
+    ///
+    /// It packs two booleans into the carry bits of a block:
+    /// - bit 1: `amount >= num_bits` (the shift overshifts), via [`Self::overshift_predicate`]
+    /// - bit 0: `ct < 0` (the input is negative)
+    ///
+    /// so that, once added to a shifted block, [`Self::apply_arithmetic_right_shift_overshift`]
+    /// can read them back as `block / message_modulus`.
+    ///
+    /// This is meant to be computed in parallel with the shift itself (it only depends on
+    /// `ct` and `amount`).
+    ///
+    /// This only works when blocks hold at least 2 bits of message, otherwise the packed
+    /// `cond` does not fit in the block's carry space.
+    fn arithmetic_right_shift_overshift_cond<T>(
+        &self,
+        ct: &T,
+        low_amount: &RadixCiphertext,
+        high_blocks: &[Ciphertext],
+        num_bits: u64,
+    ) -> Ciphertext
+    where
+        T: IntegerRadixCiphertext,
+    {
+        let (mut overshifted, is_neg) = rayon::join(
+            || self.overshift_predicate(low_amount, high_blocks, num_bits),
+            || self.scalar_lt_parallelized(ct, 0),
+        );
+        self.key.unchecked_scalar_mul_assign(&mut overshifted, 2);
+        self.key.unchecked_add_assign(&mut overshifted, &is_neg.0);
+        let lut = self
+            .key
+            .generate_lookup_table(|x| x * self.message_modulus().0);
+        self.key.apply_lookup_table_assign(&mut overshifted, &lut);
+        overshifted
+    }
+
+    /// Finalizes an arithmetic (signed) right shift given the `cond` ciphertext built by
+    /// [`Self::arithmetic_right_shift_overshift_cond`].
+    ///
+    /// For each (possibly noisy) block of `output`, it returns:
+    /// - `-1` (all bits set, i.e. `message_modulus - 1`) if the shift overshifted a negative input,
+    /// - `0` if the shift overshifted a positive input,
+    /// - the shifted block value otherwise.
+    ///
+    /// The blocks of `output` come out clean (the cleanup PBS also resets their noise).
+    fn apply_arithmetic_right_shift_overshift<T>(&self, output: &mut T, cond: &Ciphertext)
+    where
+        T: IntegerRadixCiphertext,
+    {
+        let cleanup_lut = self.key.generate_lookup_table(|block| {
+            let cond = block / self.message_modulus().0;
+            let value = block % self.message_modulus().0;
+
+            match cond {
+                // overshift AND negative input => -1 (all bits set)
+                3 => self.message_modulus().0 - 1,
+                // overshift but positive input => 0
+                2 => 0,
+                // in range => keep the shifted value
+                _ => value,
+            }
+        });
+        output.blocks_mut().par_iter_mut().for_each(|block| {
+            self.key.unchecked_add_assign(block, cond);
+            self.key.apply_lookup_table_assign(block, &cleanup_lut);
+        });
+    }
+
+    fn barrel_shift_bits_1_bit<T>(
+        &self,
+        ct: &T,
+        amount: &RadixCiphertext,
+        operation: BarrelShifterOperation,
+        max_num_bits_that_tell_shift: usize,
+    ) -> T
+    where
+        T: IntegerRadixCiphertext,
+    {
+        let message_bits_per_block = 1;
+        let num_bits = ct.blocks().len() * message_bits_per_block;
+
+        let mut shift_bit_extractor = BitExtractor::with_final_offset(
+            &amount.blocks,
+            self,
+            message_bits_per_block,
+            message_bits_per_block,
+        );
+
+        match operation {
+            BarrelShifterOperation::RightShift if T::IS_SIGNED => {
+                let mut is_ge = None;
+                let mut is_neg = None;
+                let mut dirty_shift = None;
+                rayon::scope(|s| {
+                    s.spawn(|_| {
+                        is_ge = Some(self.scalar_ge_parallelized(amount, num_bits as u32));
+                    });
+
+                    s.spawn(|_| {
+                        // This is a simple sign check (1 PBS)
+                        is_neg = Some(self.scalar_lt_parallelized(ct, 0));
+                    });
+
+                    s.spawn(|_| {
+                        dirty_shift = Some(self.block_barrel_shifter_impl(
+                            ct,
+                            &mut shift_bit_extractor,
+                            0..max_num_bits_that_tell_shift,
+                            // Our blocks are stored in little endian order
+                            operation.invert_direction(),
+                        ));
+                    });
+                });
+
+                let is_ge = is_ge.unwrap();
+                let is_neg = is_neg.unwrap();
+                let mut dirty_shift = dirty_shift.unwrap();
+
+                let (_, should_return_minus_one) = rayon::join(
+                    || {
+                        dirty_shift
+                            .blocks_mut()
+                            .par_iter_mut()
+                            .for_each(|block| self.key.message_extract_assign(block));
+                    },
+                    || self.key.unchecked_bitand(&is_ge.0, &is_neg.0),
+                );
+
+                self.zero_out_if(&mut dirty_shift, &is_ge.0, |x| x == 1);
+
+                // if the shift amount was greater than the number of bits, and the input was
+                // negative, then return -1 (which is all bits set to 1)
+                let lut =
+                    self.key.generate_lookup_table_bivariate(
+                        |block, cond| {
+                            if cond == 1 {
+                                1
+                            } else {
+                                block
+                            }
+                        },
+                    );
+                dirty_shift.blocks_mut().par_iter_mut().for_each(|block| {
+                    self.key.unchecked_apply_lookup_table_bivariate_assign(
+                        block,
+                        &should_return_minus_one,
+                        &lut,
+                    )
+                });
+
+                dirty_shift
+            }
+            BarrelShifterOperation::LeftShift | BarrelShifterOperation::RightShift => {
+                let (overshifted, mut dirty_shift) = rayon::join(
+                    || self.scalar_ge_parallelized(amount, num_bits as u32),
+                    || {
+                        self.block_barrel_shifter_impl(
+                            ct,
+                            &mut shift_bit_extractor,
+                            0..max_num_bits_that_tell_shift,
+                            // Our blocks are stored in little endian order
+                            operation.invert_direction(),
+                        )
+                    },
+                );
+                // We need to clean noise before being able to call zero out if
+                // as the noise budget won't allow it
+                dirty_shift
+                    .blocks_mut()
+                    .par_iter_mut()
+                    .for_each(|block| self.key.message_extract_assign(block));
+
+                self.zero_out_if(&mut dirty_shift, &overshifted.0, |overshifted| {
+                    overshifted == 1
+                });
+
+                dirty_shift
+            }
+            BarrelShifterOperation::RightRotate | BarrelShifterOperation::LeftRotate => {
+                let mut dirty_output = self.block_barrel_shifter_impl(
+                    ct,
+                    &mut shift_bit_extractor,
+                    0..max_num_bits_that_tell_shift,
+                    // Our blocks are stored in little endian order
+                    operation.invert_direction(),
+                );
+
+                // Reset noise
+                dirty_output
+                    .blocks_mut()
+                    .par_iter_mut()
+                    .for_each(|block| self.key.message_extract_assign(block));
+
+                dirty_output
+            }
         }
     }
 
@@ -371,7 +614,8 @@ impl ServerKey {
     /// # Note
     ///
     /// This only works for parameters where blocks encrypts a number of bits
-    /// of message that is a power of 2 (e.g. 1 bit, 2 bit, 4 bits, but not 3 bits)
+    /// of message that is a power of 2, and have more than 1 bit (e.g. 2 bit, 4 bits, but not 1, 3
+    /// bits)
     pub(super) fn barrel_shift_bits_pow2_block_modulus<T>(
         &self,
         ct: &T,
@@ -390,6 +634,12 @@ impl ServerKey {
         let carry_bits_per_block = self.key.carry_modulus.0.ilog2() as u64;
         assert!(carry_bits_per_block >= message_bits_per_block);
         assert!(message_bits_per_block.is_power_of_two());
+
+        let split = max_num_bits_that_tell_shift
+            .div_ceil(message_bits_per_block as usize)
+            .min(amount.blocks.len());
+        let (low_blocks, high_blocks) = amount.blocks.split_at(split);
+        let low_amount = RadixCiphertext::from(low_blocks.to_vec());
 
         if ct.blocks().len() == 1 {
             let lut = self
@@ -428,43 +678,78 @@ impl ServerKey {
                     }
                 });
 
-            let block = self.key.unchecked_apply_lookup_table_bivariate(
-                &ct.blocks()[0],
-                &amount.blocks[0],
-                &lut,
-            );
+            // The bivariate LUT only looks at the within-block shift (it wraps the amount mod
+            // `message_bits_per_block`), so we still have to handle overshifts: a single block
+            // holds `num_bits == message_bits_per_block` bits, so any `amount >=
+            // message_bits_per_block` is an overshift. Rotations wrap and need no
+            // fixup.
+            // The within-block shift is a single PBS; compute it in parallel with the (independent)
+            // overshift predicate so the predicate, not the shift, is the critical path.
+            let do_shift = || {
+                T::from_blocks(vec![self.key.unchecked_apply_lookup_table_bivariate(
+                    &ct.blocks()[0],
+                    &amount.blocks[0],
+                    &lut,
+                )])
+            };
 
-            return T::from_blocks(vec![block]);
+            return match operation {
+                BarrelShifterOperation::RightShift if T::IS_SIGNED => {
+                    let (mut result, cond) = rayon::join(do_shift, || {
+                        self.arithmetic_right_shift_overshift_cond(
+                            ct,
+                            &low_amount,
+                            high_blocks,
+                            message_bits_per_block,
+                        )
+                    });
+                    self.apply_arithmetic_right_shift_overshift(&mut result, &cond);
+                    result
+                }
+                BarrelShifterOperation::LeftShift | BarrelShifterOperation::RightShift => {
+                    let (mut result, overshifted) = rayon::join(do_shift, || {
+                        self.overshift_predicate(&low_amount, high_blocks, message_bits_per_block)
+                    });
+                    self.zero_out_if(&mut result, &overshifted, |overshifted| overshifted == 1);
+                    result
+                }
+                BarrelShifterOperation::LeftRotate | BarrelShifterOperation::RightRotate => {
+                    do_shift()
+                }
+            };
         }
 
-        let message_for_block =
-            self.key
-                .generate_lookup_table_bivariate(|input, first_shift_block| {
-                    let shift_within_block = first_shift_block % message_bits_per_block;
-                    let shift_to_next_block = (first_shift_block / message_bits_per_block) % 2;
+        let call_barrel_shifter_impl = || {
+            let message_for_block =
+                self.key
+                    .generate_lookup_table_bivariate(|input, first_shift_block| {
+                        let shift_within_block = first_shift_block % message_bits_per_block;
+                        let shift_to_next_block = (first_shift_block / message_bits_per_block) % 2;
 
-                    let b = match operation {
-                        BarrelShifterOperation::LeftShift | BarrelShifterOperation::LeftRotate => {
-                            (input << shift_within_block) % self.message_modulus().0
+                        let b = match operation {
+                            BarrelShifterOperation::LeftShift
+                            | BarrelShifterOperation::LeftRotate => {
+                                (input << shift_within_block) % self.message_modulus().0
+                            }
+                            BarrelShifterOperation::RightShift
+                            | BarrelShifterOperation::RightRotate => {
+                                (input >> shift_within_block) % self.message_modulus().0
+                            }
+                        };
+
+                        if shift_to_next_block == 1 {
+                            0
+                        } else {
+                            b
                         }
-                        BarrelShifterOperation::RightShift
-                        | BarrelShifterOperation::RightRotate => {
-                            (input >> shift_within_block) % self.message_modulus().0
-                        }
-                    };
+                    });
 
-                    if shift_to_next_block == 1 {
-                        0
-                    } else {
-                        b
-                    }
-                });
-
-        // When doing right shift of a signed ciphertext, we do an arithmetic shift
-        // Thus, we need some special luts to be used on the last block
-        // (which has the sign bit)
-        let message_for_block_right_shift_signed =
-            if T::IS_SIGNED && operation == BarrelShifterOperation::RightShift {
+            // When doing right shift of a signed ciphertext, we do an arithmetic shift
+            // Thus, we need some special luts to be used on the last block
+            // (which has the sign bit)
+            let message_for_block_right_shift_signed = if T::IS_SIGNED
+                && operation == BarrelShifterOperation::RightShift
+            {
                 let lut = self
                     .key
                     .generate_lookup_table_bivariate(|input, first_shift_block| {
@@ -488,152 +773,125 @@ impl ServerKey {
                 None
             };
 
-        // Extracts bits and put them in the bit index 2 (=> bit number 3)
-        // so that it is already aligned to the correct position of the cmux input,
-        // and we reduce noise growth
-        let mut shift_bit_extractor = BitExtractor::with_final_offset(
-            &amount.blocks,
-            self,
-            message_bits_per_block as usize,
-            message_bits_per_block as usize,
-        );
+            // Extracts bits and put them in the bit index 2 (=> bit number 3)
+            // so that it is already aligned to the correct position of the cmux input,
+            // and we reduce noise growth
+            let mut shift_bit_extractor = BitExtractor::with_final_offset(
+                &low_amount.blocks,
+                self,
+                message_bits_per_block as usize,
+                message_bits_per_block as usize,
+            );
 
-        let message_for_next_block =
-            self.key
-                .generate_lookup_table_bivariate(|previous, first_shift_block| {
-                    let shift_within_block = first_shift_block % message_bits_per_block;
-                    let shift_to_next_block = (first_shift_block / message_bits_per_block) % 2;
+            let message_for_next_block =
+                self.key
+                    .generate_lookup_table_bivariate(|previous, first_shift_block| {
+                        let shift_within_block = first_shift_block % message_bits_per_block;
+                        let shift_to_next_block = (first_shift_block / message_bits_per_block) % 2;
 
-                    if shift_to_next_block == 1 {
-                        // We get the message part of the previous block
-                        match operation {
-                            BarrelShifterOperation::LeftShift
-                            | BarrelShifterOperation::LeftRotate => {
-                                (previous << shift_within_block) % self.message_modulus().0
+                        if shift_to_next_block == 1 {
+                            // We get the message part of the previous block
+                            match operation {
+                                BarrelShifterOperation::LeftShift
+                                | BarrelShifterOperation::LeftRotate => {
+                                    (previous << shift_within_block) % self.message_modulus().0
+                                }
+                                BarrelShifterOperation::RightShift
+                                | BarrelShifterOperation::RightRotate => {
+                                    (previous >> shift_within_block) % self.message_modulus().0
+                                }
                             }
-                            BarrelShifterOperation::RightShift
-                            | BarrelShifterOperation::RightRotate => {
-                                (previous >> shift_within_block) % self.message_modulus().0
+                        } else {
+                            // We get the carry part of the previous block
+                            match operation {
+                                BarrelShifterOperation::LeftShift
+                                | BarrelShifterOperation::LeftRotate => {
+                                    previous >> (message_bits_per_block - shift_within_block)
+                                }
+                                BarrelShifterOperation::RightShift
+                                | BarrelShifterOperation::RightRotate => {
+                                    (previous << (message_bits_per_block - shift_within_block))
+                                        % self.message_modulus().0
+                                }
                             }
                         }
-                    } else {
-                        // We get the carry part of the previous block
-                        match operation {
-                            BarrelShifterOperation::LeftShift
-                            | BarrelShifterOperation::LeftRotate => {
-                                previous >> (message_bits_per_block - shift_within_block)
+                    });
+
+            let message_for_next_next_block =
+                self.key
+                    .generate_lookup_table_bivariate(|previous_previous, first_shift_block| {
+                        let shift_within_block = first_shift_block % message_bits_per_block;
+                        let shift_to_next_block = (first_shift_block / message_bits_per_block) % 2;
+
+                        if shift_to_next_block == 1 {
+                            // We get the carry part of the previous block
+                            match operation {
+                                BarrelShifterOperation::LeftShift
+                                | BarrelShifterOperation::LeftRotate => {
+                                    previous_previous
+                                        >> (message_bits_per_block - shift_within_block)
+                                }
+                                BarrelShifterOperation::RightShift
+                                | BarrelShifterOperation::RightRotate => {
+                                    (previous_previous
+                                        << (message_bits_per_block - shift_within_block))
+                                        % self.message_modulus().0
+                                }
                             }
-                            BarrelShifterOperation::RightShift
-                            | BarrelShifterOperation::RightRotate => {
+                        } else {
+                            // Nothing reaches that block
+                            0
+                        }
+                    });
+
+            let message_for_next_block_right_shift_signed = if T::IS_SIGNED
+                && operation == BarrelShifterOperation::RightShift
+            {
+                let lut =
+                    self.key
+                        .generate_lookup_table_bivariate(|previous, first_shift_block| {
+                            let shift_within_block = first_shift_block % message_bits_per_block;
+                            let shift_to_next_block =
+                                (first_shift_block / message_bits_per_block) % 2;
+
+                            let sign_bit_pos = message_bits_per_block - 1;
+                            let sign_bit = (previous >> sign_bit_pos) & 1;
+                            let padding_block = (self.message_modulus().0 - 1) * sign_bit;
+
+                            if shift_to_next_block == 1 {
+                                // Pad with sign bits to 'simulate' an arithmetic shift
+                                let previous = (padding_block << message_bits_per_block) | previous;
+                                // We get the message part of the previous block
+                                (previous >> shift_within_block) % self.message_modulus().0
+                            } else {
+                                // We get the carry part of the previous block
                                 (previous << (message_bits_per_block - shift_within_block))
                                     % self.message_modulus().0
                             }
-                        }
-                    }
-                });
+                        });
+                Some(lut)
+            } else {
+                None
+            };
 
-        let message_for_next_next_block =
-            self.key
-                .generate_lookup_table_bivariate(|previous_previous, first_shift_block| {
-                    let shift_within_block = first_shift_block % message_bits_per_block;
-                    let shift_to_next_block = (first_shift_block / message_bits_per_block) % 2;
+            let mut messages = ct.blocks().to_vec();
+            let mut messages_for_next_blocks = ct.blocks().to_vec();
+            let mut messages_for_next_next_blocks = ct.blocks().to_vec();
+            let first_block = &low_amount.blocks[0];
+            let num_blocks = ct.blocks().len();
 
-                    if shift_to_next_block == 1 {
-                        // We get the carry part of the previous block
-                        match operation {
-                            BarrelShifterOperation::LeftShift
-                            | BarrelShifterOperation::LeftRotate => {
-                                previous_previous >> (message_bits_per_block - shift_within_block)
-                            }
-                            BarrelShifterOperation::RightShift
-                            | BarrelShifterOperation::RightRotate => {
-                                (previous_previous << (message_bits_per_block - shift_within_block))
-                                    % self.message_modulus().0
-                            }
-                        }
-                    } else {
-                        // Nothing reaches that block
-                        0
-                    }
-                });
-
-        let message_for_next_block_right_shift_signed = if T::IS_SIGNED
-            && operation == BarrelShifterOperation::RightShift
-        {
-            let lut = self
-                .key
-                .generate_lookup_table_bivariate(|previous, first_shift_block| {
-                    let shift_within_block = first_shift_block % message_bits_per_block;
-                    let shift_to_next_block = (first_shift_block / message_bits_per_block) % 2;
-
-                    let sign_bit_pos = message_bits_per_block - 1;
-                    let sign_bit = (previous >> sign_bit_pos) & 1;
-                    let padding_block = (self.message_modulus().0 - 1) * sign_bit;
-
-                    if shift_to_next_block == 1 {
-                        // Pad with sign bits to 'simulate' an arithmetic shift
-                        let previous = (padding_block << message_bits_per_block) | previous;
-                        // We get the message part of the previous block
-                        (previous >> shift_within_block) % self.message_modulus().0
-                    } else {
-                        // We get the carry part of the previous block
-                        (previous << (message_bits_per_block - shift_within_block))
-                            % self.message_modulus().0
-                    }
-                });
-            Some(lut)
-        } else {
-            None
-        };
-
-        let mut messages = ct.blocks().to_vec();
-        let mut messages_for_next_blocks = ct.blocks().to_vec();
-        let mut messages_for_next_next_blocks = ct.blocks().to_vec();
-        let first_block = &amount.blocks[0];
-        let num_blocks = ct.blocks().len();
-        rayon::scope(|s| {
-            s.spawn(|_| {
-                messages.par_iter_mut().enumerate().for_each(|(i, block)| {
-                    let lut = if T::IS_SIGNED
-                        && operation == BarrelShifterOperation::RightShift
-                        && i == num_blocks - 1
-                    {
-                        message_for_block_right_shift_signed.as_ref().unwrap()
-                    } else {
-                        &message_for_block
-                    };
-                    self.key
-                        .unchecked_apply_lookup_table_bivariate_assign(block, first_block, lut);
-                });
-            });
-
-            s.spawn(|_| {
-                let range = match operation {
-                    BarrelShifterOperation::RightShift => {
-                        messages_for_next_blocks[0] = self.key.create_trivial(0);
-                        1..num_blocks
-                    }
-                    BarrelShifterOperation::LeftShift => {
-                        messages_for_next_blocks[num_blocks - 1] = self.key.create_trivial(0);
-                        0..num_blocks - 1
-                    }
-                    BarrelShifterOperation::LeftRotate | BarrelShifterOperation::RightRotate => {
-                        0..num_blocks
-                    }
-                };
-
-                let range_len = range.len();
-                messages_for_next_blocks[range]
-                    .par_iter_mut()
-                    .enumerate()
-                    .for_each(|(i, block)| {
+            let remaining_shift_rounds = max_num_bits_that_tell_shift
+                .saturating_sub((message_bits_per_block.ilog2() + 1) as usize);
+            rayon::scope(|s| {
+                s.spawn(|_| {
+                    messages.par_iter_mut().enumerate().for_each(|(i, block)| {
                         let lut = if T::IS_SIGNED
                             && operation == BarrelShifterOperation::RightShift
-                            && i == range_len - 1
+                            && i == num_blocks - 1
                         {
-                            message_for_next_block_right_shift_signed.as_ref().unwrap()
+                            message_for_block_right_shift_signed.as_ref().unwrap()
                         } else {
-                            &message_for_next_block
+                            &message_for_block
                         };
                         self.key.unchecked_apply_lookup_table_bivariate_assign(
                             block,
@@ -641,91 +899,181 @@ impl ServerKey {
                             lut,
                         );
                     });
-            });
+                });
 
-            s.spawn(|_| {
-                let range = match operation {
-                    BarrelShifterOperation::RightShift => {
-                        messages_for_next_next_blocks[0] = self.key.create_trivial(0);
-                        messages_for_next_next_blocks[1] = self.key.create_trivial(0);
-                        2..num_blocks
+                s.spawn(|_| {
+                    let range = match operation {
+                        BarrelShifterOperation::RightShift => {
+                            messages_for_next_blocks[0] = self.key.create_trivial(0);
+                            1..num_blocks
+                        }
+                        BarrelShifterOperation::LeftShift => {
+                            messages_for_next_blocks[num_blocks - 1] = self.key.create_trivial(0);
+                            0..num_blocks - 1
+                        }
+                        BarrelShifterOperation::LeftRotate
+                        | BarrelShifterOperation::RightRotate => 0..num_blocks,
+                    };
+
+                    let range_len = range.len();
+                    messages_for_next_blocks[range]
+                        .par_iter_mut()
+                        .enumerate()
+                        .for_each(|(i, block)| {
+                            let lut = if T::IS_SIGNED
+                                && operation == BarrelShifterOperation::RightShift
+                                && i == range_len - 1
+                            {
+                                message_for_next_block_right_shift_signed.as_ref().unwrap()
+                            } else {
+                                &message_for_next_block
+                            };
+                            self.key.unchecked_apply_lookup_table_bivariate_assign(
+                                block,
+                                first_block,
+                                lut,
+                            );
+                        });
+                });
+
+                s.spawn(|_| {
+                    let range = match operation {
+                        BarrelShifterOperation::RightShift => {
+                            messages_for_next_next_blocks[0] = self.key.create_trivial(0);
+                            messages_for_next_next_blocks[1] = self.key.create_trivial(0);
+                            2..num_blocks
+                        }
+                        BarrelShifterOperation::LeftShift => {
+                            messages_for_next_next_blocks[num_blocks - 1] =
+                                self.key.create_trivial(0);
+                            messages_for_next_next_blocks[num_blocks - 2] =
+                                self.key.create_trivial(0);
+                            0..num_blocks - 2
+                        }
+                        BarrelShifterOperation::LeftRotate
+                        | BarrelShifterOperation::RightRotate => 0..num_blocks,
+                    };
+                    messages_for_next_next_blocks[range]
+                        .par_iter_mut()
+                        .for_each(|block| {
+                            self.key.unchecked_apply_lookup_table_bivariate_assign(
+                                block,
+                                first_block,
+                                &message_for_next_next_block,
+                            );
+                        });
+                });
+
+                s.spawn(|_| {
+                    if remaining_shift_rounds == 0 {
+                        // The within-block round already covers the whole shift; nothing left to
+                        // extract from the amount.
+                        return;
                     }
-                    BarrelShifterOperation::LeftShift => {
-                        messages_for_next_next_blocks[num_blocks - 1] = self.key.create_trivial(0);
-                        messages_for_next_next_blocks[num_blocks - 2] = self.key.create_trivial(0);
-                        0..num_blocks - 2
-                    }
-                    BarrelShifterOperation::LeftRotate | BarrelShifterOperation::RightRotate => {
-                        0..num_blocks
-                    }
-                };
-                messages_for_next_next_blocks[range]
-                    .par_iter_mut()
-                    .for_each(|block| {
-                        self.key.unchecked_apply_lookup_table_bivariate_assign(
-                            block,
-                            first_block,
-                            &message_for_next_next_block,
+                    let num_bit_that_tells_shift_within_blocks = message_bits_per_block.ilog2();
+                    let num_bits_already_done = num_bit_that_tells_shift_within_blocks + 1;
+                    if u64::from(num_bits_already_done) == message_bits_per_block {
+                        shift_bit_extractor.set_source_blocks(&low_amount.blocks[1..]);
+                        shift_bit_extractor.prepare_next_batch();
+                    } else {
+                        shift_bit_extractor.prepare_next_batch();
+                        assert!(
+                            shift_bit_extractor.current_buffer_len()
+                                > num_bits_already_done as usize
                         );
-                    });
-            });
-
-            s.spawn(|_| {
-                let num_bit_that_tells_shift_within_blocks = message_bits_per_block.ilog2();
-                let num_bits_already_done = num_bit_that_tells_shift_within_blocks + 1;
-                if u64::from(num_bits_already_done) == message_bits_per_block {
-                    shift_bit_extractor.set_source_blocks(&amount.blocks[1..]);
-                    shift_bit_extractor.prepare_next_batch();
-                } else {
-                    shift_bit_extractor.prepare_next_batch();
-                    assert!(
-                        shift_bit_extractor.current_buffer_len() > num_bits_already_done as usize
-                    );
-                    // Now remove bits that where used for the 'shift within blocks'
-                    for _ in 0..num_bits_already_done {
-                        let _ = shift_bit_extractor.next().unwrap();
+                        // Now remove bits that where used for the 'shift within blocks'
+                        for _ in 0..num_bits_already_done {
+                            let _ = shift_bit_extractor.next().unwrap();
+                        }
                     }
-                }
+                });
             });
-        });
 
-        // 0 should never be possible
-        assert!(shift_bit_extractor.current_buffer_len() >= 1);
+            // When there are rounds left, the extractor must hold at least one bit for them.
+            assert!(remaining_shift_rounds == 0 || shift_bit_extractor.current_buffer_len() >= 1);
 
+            match operation {
+                BarrelShifterOperation::LeftShift | BarrelShifterOperation::LeftRotate => {
+                    messages_for_next_blocks.rotate_right(1);
+                    messages_for_next_next_blocks.rotate_right(2);
+                }
+                BarrelShifterOperation::RightShift | BarrelShifterOperation::RightRotate => {
+                    messages_for_next_blocks.rotate_left(1);
+                    messages_for_next_next_blocks.rotate_left(2);
+                }
+            }
+
+            for (m0, (m1, m2)) in messages.iter_mut().zip(
+                messages_for_next_blocks
+                    .iter()
+                    .zip(messages_for_next_next_blocks.iter()),
+            ) {
+                self.key.unchecked_add_assign(m0, m1);
+                self.key.unchecked_add_assign(m0, m2);
+            }
+
+            let radix = T::from_blocks(messages);
+
+            let num_bit_that_tells_shift_within_blocks = message_bits_per_block.ilog2();
+            let num_bits_already_done = num_bit_that_tells_shift_within_blocks + 1;
+            self.block_barrel_shifter_impl(
+                &radix,
+                &mut shift_bit_extractor,
+                // We already did the first block rotation so we start at 1
+                // And do + 1 as the range is exclusive
+                1..max_num_bits_that_tell_shift - num_bits_already_done as usize + 1,
+                // blocks are in little endian order which is the opposite
+                // of how bits are textually represented
+                operation.invert_direction(),
+            )
+        };
+
+        let num_blocks = ct.blocks().len();
         match operation {
-            BarrelShifterOperation::LeftShift | BarrelShifterOperation::LeftRotate => {
-                messages_for_next_blocks.rotate_right(1);
-                messages_for_next_next_blocks.rotate_right(2);
+            BarrelShifterOperation::RightShift if T::IS_SIGNED => {
+                let (mut dirty_output, cond) = rayon::join(call_barrel_shifter_impl, || {
+                    self.arithmetic_right_shift_overshift_cond(
+                        ct,
+                        &low_amount,
+                        high_blocks,
+                        num_blocks as u64 * message_bits_per_block,
+                    )
+                });
+
+                self.apply_arithmetic_right_shift_overshift(&mut dirty_output, &cond);
+
+                dirty_output
             }
-            BarrelShifterOperation::RightShift | BarrelShifterOperation::RightRotate => {
-                messages_for_next_blocks.rotate_left(1);
-                messages_for_next_next_blocks.rotate_left(2);
+            BarrelShifterOperation::LeftShift | BarrelShifterOperation::RightShift => {
+                let (overshifted, mut dirty_shift) = rayon::join(
+                    || {
+                        self.overshift_predicate(
+                            &low_amount,
+                            high_blocks,
+                            num_blocks as u64 * message_bits_per_block,
+                        )
+                    },
+                    call_barrel_shifter_impl,
+                );
+
+                self.zero_out_if(&mut dirty_shift, &overshifted, |overshifted| {
+                    overshifted == 1
+                });
+
+                dirty_shift
+            }
+            BarrelShifterOperation::RightRotate | BarrelShifterOperation::LeftRotate => {
+                let mut dirty_output = call_barrel_shifter_impl();
+
+                // Reset noise
+                dirty_output
+                    .blocks_mut()
+                    .par_iter_mut()
+                    .for_each(|block| self.key.message_extract_assign(block));
+
+                dirty_output
             }
         }
-
-        for (m0, (m1, m2)) in messages.iter_mut().zip(
-            messages_for_next_blocks
-                .iter()
-                .zip(messages_for_next_next_blocks.iter()),
-        ) {
-            self.key.unchecked_add_assign(m0, m1);
-            self.key.unchecked_add_assign(m0, m2);
-        }
-
-        let radix = T::from_blocks(messages);
-
-        let num_bit_that_tells_shift_within_blocks = message_bits_per_block.ilog2();
-        let num_bits_already_done = num_bit_that_tells_shift_within_blocks + 1;
-        self.block_barrel_shifter_impl(
-            &radix,
-            &mut shift_bit_extractor,
-            // We already did the first block rotation so we start at 1
-            // And do + 1 as the range is exclusive
-            1..max_num_bits_that_tell_shift - num_bits_already_done as usize + 1,
-            // blocks are in little endian order which is the opposite
-            // of how bits are textually represented
-            operation.invert_direction(),
-        )
     }
 
     /// This implements a "barrel shifter".
@@ -749,7 +1097,7 @@ impl ServerKey {
     /// thus, any bit that are higher than log2(16) will be removed
     ///
     /// `ct` will be assigned the result, and it will be in a fresh state
-    pub(super) fn bit_barrel_shifter<T>(
+    fn unchecked_bit_barrel_shifter<T>(
         &self,
         ct: &mut T,
         shift: &RadixCiphertext,
@@ -910,5 +1258,67 @@ impl ServerKey {
                 self.key.message_extract_assign(&mut last[0]);
                 std::mem::swap(block, &mut last[0]);
             });
+    }
+
+    fn bit_barrel_shifter<T>(
+        &self,
+        ct: &mut T,
+        amount: &RadixCiphertext,
+        operation: BarrelShifterOperation,
+    ) where
+        T: IntegerRadixCiphertext,
+    {
+        let num_blocks = ct.blocks().len();
+        let message_bits_per_block = self.key.message_modulus.0.ilog2() as u64;
+        let num_bits = num_blocks as u64 * message_bits_per_block;
+
+        let mut max_num_bits_that_tell_shift = num_bits.ilog2();
+        if !num_bits.is_power_of_two() {
+            max_num_bits_that_tell_shift += 1;
+        }
+        let split = (max_num_bits_that_tell_shift as usize)
+            .div_ceil(message_bits_per_block as usize)
+            .min(amount.blocks.len());
+        let (low_blocks, high_blocks) = amount.blocks.split_at(split);
+        let low_amount = RadixCiphertext::from(low_blocks.to_vec());
+
+        match operation {
+            BarrelShifterOperation::RightShift if T::IS_SIGNED => {
+                let ct_cloned = ct.clone();
+
+                let (_, cond) = rayon::join(
+                    || {
+                        self.unchecked_bit_barrel_shifter(ct, amount, operation);
+                    },
+                    || {
+                        // `ct` is being shifted in place by the other closure, so the sign check
+                        // reads from a clone.
+                        self.arithmetic_right_shift_overshift_cond(
+                            &ct_cloned,
+                            &low_amount,
+                            high_blocks,
+                            num_bits,
+                        )
+                    },
+                );
+
+                self.apply_arithmetic_right_shift_overshift(ct, &cond);
+            }
+            BarrelShifterOperation::LeftShift | BarrelShifterOperation::RightShift => {
+                let (overshifted, _) = rayon::join(
+                    || self.overshift_predicate(&low_amount, high_blocks, num_bits),
+                    || {
+                        self.unchecked_bit_barrel_shifter(ct, amount, operation);
+                    },
+                );
+
+                self.zero_out_if(ct, &overshifted, |overshifted| overshifted == 1);
+            }
+            BarrelShifterOperation::RightRotate | BarrelShifterOperation::LeftRotate => {
+                // `unchecked_bit_barrel_shifter` already returns clean blocks, and a rotation
+                // needs no overshift handling, so there is nothing left to do.
+                self.unchecked_bit_barrel_shifter(ct, amount, operation);
+            }
+        }
     }
 }

--- a/tfhe/src/integer/server_key/radix_parallel/tests_cases_unsigned.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_cases_unsigned.rs
@@ -325,8 +325,11 @@ where
     }
 }
 
-pub(crate) fn unchecked_scalar_left_shift_test<P, T>(param: P, mut executor: T)
-where
+pub(crate) fn unchecked_scalar_left_shift_test<P, T>(
+    param: P,
+    mut executor: T,
+    test_overshift: bool,
+) where
     P: Into<TestParameters>,
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, u64), RadixCiphertext>,
 {
@@ -364,15 +367,15 @@ where
         }
 
         // case when scalar >= nb_bits
-        {
+        if test_overshift {
+            // An overshift pushes every bit out, so a left shift returns 0.
             let scalar = scalar.saturating_add(nb_bits);
             let encrypted_result = executor.execute((&ct, scalar as u64));
             let decrypted_result: u64 = cks.decrypt(&encrypted_result);
-            let expected = (clear << u64::from(scalar % nb_bits)) % modulus;
             assert_eq!(
-                expected, decrypted_result,
+                0, decrypted_result,
                 "Invalid left shift result for {clear} << {scalar}: \
-                expected {expected}, got {decrypted_result}"
+                expected 0, got {decrypted_result}"
             );
         }
     }
@@ -393,8 +396,11 @@ where
     }
 }
 
-pub(crate) fn unchecked_scalar_right_shift_test<P, T>(param: P, mut executor: T)
-where
+pub(crate) fn unchecked_scalar_right_shift_test<P, T>(
+    param: P,
+    mut executor: T,
+    test_overshift: bool,
+) where
     P: Into<TestParameters>,
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, u64), RadixCiphertext>,
 {
@@ -433,16 +439,16 @@ where
         }
 
         // case when scalar >= nb_bits
-        {
+        if test_overshift {
+            // An overshift pushes every bit out, so an unsigned right shift returns 0.
             let scalar = scalar.saturating_add(nb_bits);
             let encrypted_result = executor.execute((&ct, scalar as u64));
             assert!(encrypted_result.block_carries_are_empty());
             let decrypted_result: u64 = cks.decrypt(&encrypted_result);
-            let expected = clear >> u64::from(scalar % nb_bits);
             assert_eq!(
-                expected, decrypted_result,
+                0, decrypted_result,
                 "Invalid right shift result for {clear} >> {scalar}: \
-                expected {expected}, got {decrypted_result}"
+                expected 0, got {decrypted_result}"
             );
         }
     }
@@ -2106,7 +2112,7 @@ where
     }
 }
 
-pub(crate) fn default_scalar_left_shift_test<P, T>(param: P, mut executor: T)
+pub(crate) fn default_scalar_left_shift_test<P, T>(param: P, mut executor: T, test_overshift: bool)
 where
     P: Into<TestParameters>,
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, u64), RadixCiphertext>,
@@ -2144,14 +2150,15 @@ where
         }
 
         // case when scalar >= nb_bits
-        {
+        if test_overshift {
+            // An overshift pushes every bit out, so a left shift returns 0.
             let scalar = scalar.saturating_add(nb_bits);
             let ct_res = executor.execute((&ct, scalar as u64));
             let tmp = executor.execute((&ct, scalar as u64));
             assert!(ct_res.block_carries_are_empty());
             assert_eq!(ct_res, tmp);
             let dec_res: u64 = cks.decrypt(&ct_res);
-            assert_eq!(clear.wrapping_shl(scalar % nb_bits) % modulus, dec_res);
+            assert_eq!(0, dec_res);
         }
     }
 
@@ -2166,7 +2173,7 @@ where
     }
 }
 
-pub(crate) fn default_scalar_right_shift_test<P, T>(param: P, mut executor: T)
+pub(crate) fn default_scalar_right_shift_test<P, T>(param: P, mut executor: T, test_overshift: bool)
 where
     P: Into<TestParameters>,
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, u64), RadixCiphertext>,
@@ -2205,14 +2212,15 @@ where
         }
 
         // case when scalar >= nb_bits
-        {
+        if test_overshift {
+            // An overshift pushes every bit out, so an unsigned right shift returns 0.
             let scalar = scalar.saturating_add(nb_bits);
             let ct_res = executor.execute((&ct, scalar as u64));
             let tmp = executor.execute((&ct, scalar as u64));
             assert!(ct_res.block_carries_are_empty());
             assert_eq!(ct_res, tmp);
             let dec_res: u64 = cks.decrypt(&ct_res);
-            assert_eq!(clear.wrapping_shr(scalar % nb_bits) % modulus, dec_res);
+            assert_eq!(0, dec_res);
         }
     }
 

--- a/tfhe/src/integer/server_key/radix_parallel/tests_signed/test_scalar_shift.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_signed/test_scalar_shift.rs
@@ -26,7 +26,7 @@ where
     P: Into<TestParameters>,
 {
     let executor = CpuFunctionExecutor::new(&ServerKey::unchecked_scalar_left_shift_parallelized);
-    signed_unchecked_scalar_left_shift_test(param, executor);
+    signed_unchecked_scalar_left_shift_test(param, executor, true);
 }
 
 fn integer_signed_default_scalar_left_shift<P>(param: P)
@@ -34,7 +34,7 @@ where
     P: Into<TestParameters>,
 {
     let executor = CpuFunctionExecutor::new(&ServerKey::scalar_left_shift_parallelized);
-    signed_default_scalar_left_shift_test(param, executor);
+    signed_default_scalar_left_shift_test(param, executor, true);
 }
 
 fn integer_signed_unchecked_scalar_right_shift<P>(param: P)
@@ -42,7 +42,7 @@ where
     P: Into<TestParameters>,
 {
     let executor = CpuFunctionExecutor::new(&ServerKey::unchecked_scalar_right_shift_parallelized);
-    signed_unchecked_scalar_right_shift_test(param, executor);
+    signed_unchecked_scalar_right_shift_test(param, executor, true);
 }
 
 fn integer_signed_default_scalar_right_shift<P>(param: P)
@@ -50,10 +50,13 @@ where
     P: Into<TestParameters>,
 {
     let executor = CpuFunctionExecutor::new(&ServerKey::scalar_right_shift_parallelized);
-    signed_default_scalar_right_shift_test(param, executor);
+    signed_default_scalar_right_shift_test(param, executor, true);
 }
-pub(crate) fn signed_unchecked_scalar_left_shift_test<P, T>(param: P, mut executor: T)
-where
+pub(crate) fn signed_unchecked_scalar_left_shift_test<P, T>(
+    param: P,
+    mut executor: T,
+    test_overshift: bool,
+) where
     P: Into<TestParameters>,
     T: for<'a> FunctionExecutor<(&'a SignedRadixCiphertext, i64), SignedRadixCiphertext>,
 {
@@ -88,18 +91,21 @@ where
         }
 
         // case when shift >= nb_bits
-        {
+        if test_overshift {
+            // An overshift pushes every bit out, so a left shift returns 0.
             let clear_shift = clear_shift.saturating_add(nb_bits);
             let ct_res = executor.execute((&ct, clear_shift as i64));
             let dec_res: i64 = cks.decrypt_signed(&ct_res);
-            let expected = signed_left_shift_under_modulus(clear, clear_shift % nb_bits, modulus);
-            assert_eq!(expected, dec_res);
+            assert_eq!(0, dec_res);
         }
     }
 }
 
-pub(crate) fn signed_unchecked_scalar_right_shift_test<P, T>(param: P, mut executor: T)
-where
+pub(crate) fn signed_unchecked_scalar_right_shift_test<P, T>(
+    param: P,
+    mut executor: T,
+    test_overshift: bool,
+) where
     P: Into<TestParameters>,
     T: for<'a> FunctionExecutor<(&'a SignedRadixCiphertext, i64), SignedRadixCiphertext>,
 {
@@ -134,18 +140,22 @@ where
         }
 
         // case when shift >= nb_bits
-        {
+        if test_overshift {
+            // An overshift saturates an arithmetic right shift to the sign: -1 if negative, else 0.
             let clear_shift = clear_shift.saturating_add(nb_bits);
             let ct_res = executor.execute((&ct, clear_shift as i64));
             let dec_res: i64 = cks.decrypt_signed(&ct_res);
-            let expected = signed_right_shift_under_modulus(clear, clear_shift % nb_bits, modulus);
+            let expected = if clear < 0 { -1i64 } else { 0i64 };
             assert_eq!(expected, dec_res);
         }
     }
 }
 
-pub(crate) fn signed_default_scalar_left_shift_test<P, T>(param: P, mut executor: T)
-where
+pub(crate) fn signed_default_scalar_left_shift_test<P, T>(
+    param: P,
+    mut executor: T,
+    test_overshift: bool,
+) where
     P: Into<TestParameters>,
     T: for<'a> FunctionExecutor<(&'a SignedRadixCiphertext, i64), SignedRadixCiphertext>,
 {
@@ -192,13 +202,12 @@ where
         }
 
         // case when shift >= nb_bits
-        {
+        if test_overshift {
+            // An overshift pushes every bit out, so a left shift returns 0.
             let clear_shift = rng.gen_range(nb_bits..=u32::MAX);
             let ct_res = executor.execute((&ct, clear_shift as i64));
             let dec_res: i64 = cks.decrypt_signed(&ct_res);
-            // We mimic wrapping_shl manually as we use a bigger type
-            // than the nb_bits we actually simulate in this test
-            let clear_res = signed_left_shift_under_modulus(clear, clear_shift % nb_bits, modulus);
+            let clear_res = 0i64;
             assert_eq!(
                 clear_res, dec_res,
                 "Invalid left shift result, for '{clear} << {clear_shift}', \
@@ -211,8 +220,11 @@ where
     }
 }
 
-pub(crate) fn signed_default_scalar_right_shift_test<P, T>(param: P, mut executor: T)
-where
+pub(crate) fn signed_default_scalar_right_shift_test<P, T>(
+    param: P,
+    mut executor: T,
+    test_overshift: bool,
+) where
     P: Into<TestParameters>,
     T: for<'a> FunctionExecutor<(&'a SignedRadixCiphertext, i64), SignedRadixCiphertext>,
 {
@@ -259,13 +271,12 @@ where
         }
 
         // case when shift >= nb_bits
-        {
+        if test_overshift {
+            // An overshift saturates an arithmetic right shift to the sign: -1 if negative, else 0.
             let clear_shift = rng.gen_range(nb_bits..=u32::MAX);
             let ct_res = executor.execute((&ct, clear_shift as i64));
             let dec_res: i64 = cks.decrypt_signed(&ct_res);
-            // We mimic wrapping_shl manually as we use a bigger type
-            // than the nb_bits we actually simulate in this test
-            let clear_res = signed_right_shift_under_modulus(clear, clear_shift % nb_bits, modulus);
+            let clear_res = if clear < 0 { -1i64 } else { 0i64 };
             assert_eq!(
                 clear_res, dec_res,
                 "Invalid right shift result, for '{clear} >> {clear_shift}', \

--- a/tfhe/src/integer/server_key/radix_parallel/tests_signed/test_shift.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_signed/test_shift.rs
@@ -24,7 +24,7 @@ create_parameterized_test!(integer_signed_unchecked_right_shift);
 create_parameterized_test!(integer_signed_left_shift);
 create_parameterized_test!(integer_signed_right_shift);
 
-pub(crate) fn signed_default_left_shift_test<P, T>(param: P, mut executor: T)
+pub(crate) fn signed_default_left_shift_test<P, T>(param: P, mut executor: T, test_overshift: bool)
 where
     P: Into<TestParameters>,
     T: for<'a> FunctionExecutor<
@@ -82,7 +82,9 @@ where
         }
 
         // case when shift >= nb_bits
-        {
+        // TODO: remove the `test_overshift` parameter (and this branch's gating) once the
+        // GPU backend implements the new overshift-returns-zero behavior.
+        if test_overshift {
             // Here we create a encrypted shift value >= nb_bits
             // in a way that the shift ciphertext is seen as having non empty carries
             let mut clear_shift = rng.gen::<u32>() % nb_bits;
@@ -94,15 +96,8 @@ where
 
             let ct_res = executor.execute((&ct, &shift));
             let dec_res: i64 = cks.decrypt_signed(&ct_res);
-            // When nb_bits is not a power of two
-            // then the behaviour is not the same
-            let mut nb_bits = modulus.ilog2();
-            if !nb_bits.is_power_of_two() {
-                nb_bits = nb_bits.next_power_of_two();
-            }
-            // We mimic wrapping_shl manually as we use a bigger type
-            // than the nb_bits we actually simulate in this test
-            let clear_res = signed_left_shift_under_modulus(clear, clear_shift % nb_bits, modulus);
+            // A shift >= nb_bits is an overshift; a left shift must return 0
+            let clear_res = 0i64;
             assert_eq!(
                 clear_res, dec_res,
                 "Invalid left shift result, for '{clear} << {clear_shift}', \
@@ -115,7 +110,7 @@ where
     }
 }
 
-pub(crate) fn signed_default_right_shift_test<P, T>(param: P, mut executor: T)
+pub(crate) fn signed_default_right_shift_test<P, T>(param: P, mut executor: T, test_overshift: bool)
 where
     P: Into<TestParameters>,
     T: for<'a> FunctionExecutor<
@@ -173,7 +168,9 @@ where
         }
 
         // case when shift >= nb_bits
-        {
+        // TODO: remove the `test_overshift` parameter (and this branch's gating) once the
+        // GPU backend implements the new overshift-returns-zero behavior.
+        if test_overshift {
             // Here we create a encrypted shift value >= nb_bits
             // in a way that the shift ciphertext is seen as having non empty carries
             let mut clear_shift = rng.gen::<u32>() % nb_bits;
@@ -185,15 +182,9 @@ where
 
             let ct_res = executor.execute((&ct, &shift));
             let dec_res: i64 = cks.decrypt_signed(&ct_res);
-            // When nb_bits is not a power of two
-            // then the behaviour is not the same
-            let mut nb_bits = modulus.ilog2();
-            if !nb_bits.is_power_of_two() {
-                nb_bits = nb_bits.next_power_of_two();
-            }
-            // We mimic wrapping_shl manually as we use a bigger type
-            // than the nb_bits we actually simulate in this test
-            let clear_res = signed_right_shift_under_modulus(clear, clear_shift % nb_bits, modulus);
+            // A shift >= nb_bits is an overshift; an arithmetic right shift
+            // saturates to the sign bit: -1 if negative, 0 otherwise
+            let clear_res = if clear < 0 { -1i64 } else { 0i64 };
             assert_eq!(
                 clear_res, dec_res,
                 "Invalid right shift result, for '{clear} >> {clear_shift}', \
@@ -206,8 +197,11 @@ where
     }
 }
 
-pub(crate) fn signed_unchecked_left_shift_test<P, T>(param: P, mut executor: T)
-where
+pub(crate) fn signed_unchecked_left_shift_test<P, T>(
+    param: P,
+    mut executor: T,
+    test_overshift: bool,
+) where
     P: Into<TestParameters>,
     T: for<'a> FunctionExecutor<
         (&'a SignedRadixCiphertext, &'a RadixCiphertext),
@@ -248,28 +242,26 @@ where
         }
 
         // case when shift >= nb_bits
-        {
-            let clear_shift = clear_shift.saturating_add(nb_bits);
+        // TODO: remove the `test_overshift` parameter (and this branch's gating) once the
+        // GPU backend implements the new overshift-returns-zero behavior.
+        if test_overshift {
+            // The shift amount lies in [nb_bits, modulus), so it encrypts without
+            // wrapping and is a genuine overshift: a left shift must return 0.
+            let clear_shift = rng.gen_range(nb_bits..modulus as u32);
             let shift = cks.encrypt(clear_shift as u64);
 
             let ct_res = executor.execute((&ct, &shift));
             let dec_res: i64 = cks.decrypt_signed(&ct_res);
-            // When nb_bits is not a power of two
-            // then the behaviour is not the same
-            let mut nb_bits = modulus.ilog2();
-            if !nb_bits.is_power_of_two() {
-                nb_bits = nb_bits.next_power_of_two();
-            }
-            // We mimic wrapping_shl manually as we use a bigger type
-            // than the nb_bits we actually simulate in this test
-            let clear_res = signed_left_shift_under_modulus(clear, clear_shift % nb_bits, modulus);
-            assert_eq!(clear_res, dec_res);
+            assert_eq!(0, dec_res);
         }
     }
 }
 
-pub(crate) fn signed_unchecked_right_shift_test<P, T>(param: P, mut executor: T)
-where
+pub(crate) fn signed_unchecked_right_shift_test<P, T>(
+    param: P,
+    mut executor: T,
+    test_overshift: bool,
+) where
     P: Into<TestParameters>,
     T: for<'a> FunctionExecutor<
         (&'a SignedRadixCiphertext, &'a RadixCiphertext),
@@ -309,21 +301,17 @@ where
         }
 
         // case when shift >= nb_bits
-        {
-            let clear_shift = clear_shift.saturating_add(nb_bits);
+        // TODO: remove the `test_overshift` parameter (and this branch's gating) once the
+        // GPU backend implements the new overshift-returns-zero behavior.
+        if test_overshift {
+            // The shift amount lies in [nb_bits, modulus), so it encrypts without
+            // wrapping and is a genuine overshift: an arithmetic right shift
+            // saturates to the sign bit (-1 if negative, 0 otherwise).
+            let clear_shift = rng.gen_range(nb_bits..modulus as u32);
             let shift = cks.encrypt(clear_shift as u64);
             let ct_res = executor.execute((&ct, &shift));
             let dec_res: i64 = cks.decrypt_signed(&ct_res);
-
-            // When nb_bits is not a power of two
-            // then the behaviour is not the same
-            let mut nb_bits = modulus.ilog2();
-            if !nb_bits.is_power_of_two() {
-                nb_bits = nb_bits.next_power_of_two();
-            }
-            // We mimic wrapping_shr manually as we use a bigger type
-            // than the nb_bits we actually simulate in this test
-            let clear_res = signed_right_shift_under_modulus(clear, clear_shift % nb_bits, modulus);
+            let clear_res = if clear < 0 { -1i64 } else { 0i64 };
             assert_eq!(clear_res, dec_res);
         }
     }
@@ -334,7 +322,7 @@ where
     P: Into<TestParameters> + Copy,
 {
     let executor = CpuFunctionExecutor::new(&ServerKey::unchecked_right_shift_parallelized);
-    signed_unchecked_right_shift_test(param, executor);
+    signed_unchecked_right_shift_test(param, executor, true);
 }
 
 fn integer_signed_right_shift<P>(param: P)
@@ -342,7 +330,7 @@ where
     P: Into<TestParameters> + Copy,
 {
     let executor = CpuFunctionExecutor::new(&ServerKey::right_shift_parallelized);
-    signed_default_right_shift_test(param, executor);
+    signed_default_right_shift_test(param, executor, true);
 }
 
 fn integer_signed_unchecked_left_shift<P>(param: P)
@@ -350,7 +338,7 @@ where
     P: Into<TestParameters> + Copy,
 {
     let executor = CpuFunctionExecutor::new(&ServerKey::unchecked_left_shift_parallelized);
-    signed_unchecked_left_shift_test(param, executor);
+    signed_unchecked_left_shift_test(param, executor, true);
 }
 
 fn integer_signed_left_shift<P>(param: P)
@@ -358,5 +346,5 @@ where
     P: Into<TestParameters> + Copy,
 {
     let executor = CpuFunctionExecutor::new(&ServerKey::left_shift_parallelized);
-    signed_default_left_shift_test(param, executor);
+    signed_default_left_shift_test(param, executor, true);
 }

--- a/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_scalar_shift.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_scalar_shift.rs
@@ -20,7 +20,7 @@ where
     P: Into<TestParameters>,
 {
     let executor = CpuFunctionExecutor::new(&ServerKey::scalar_left_shift_parallelized);
-    default_scalar_left_shift_test(param, executor);
+    default_scalar_left_shift_test(param, executor, true);
 }
 
 fn integer_unchecked_scalar_left_shift<P>(param: P)
@@ -28,7 +28,7 @@ where
     P: Into<TestParameters>,
 {
     let executor = CpuFunctionExecutor::new(&ServerKey::unchecked_scalar_left_shift_parallelized);
-    unchecked_scalar_left_shift_test(param, executor);
+    unchecked_scalar_left_shift_test(param, executor, true);
 }
 
 fn integer_default_scalar_right_shift<P>(param: P)
@@ -36,7 +36,7 @@ where
     P: Into<TestParameters>,
 {
     let executor = CpuFunctionExecutor::new(&ServerKey::scalar_right_shift_parallelized);
-    default_scalar_right_shift_test(param, executor);
+    default_scalar_right_shift_test(param, executor, true);
 }
 
 fn integer_unchecked_scalar_right_shift<P>(param: P)
@@ -44,5 +44,5 @@ where
     P: Into<TestParameters>,
 {
     let executor = CpuFunctionExecutor::new(&ServerKey::unchecked_scalar_right_shift_parallelized);
-    unchecked_scalar_right_shift_test(param, executor);
+    unchecked_scalar_right_shift_test(param, executor, true);
 }

--- a/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_shift.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_shift.rs
@@ -22,7 +22,7 @@ where
     P: Into<TestParameters>,
 {
     let executor = CpuFunctionExecutor::new(&ServerKey::unchecked_left_shift_parallelized);
-    unchecked_left_shift_test(param, executor);
+    unchecked_left_shift_test(param, executor, true);
 }
 
 fn integer_unchecked_right_shift<P>(param: P)
@@ -30,7 +30,7 @@ where
     P: Into<TestParameters>,
 {
     let executor = CpuFunctionExecutor::new(&ServerKey::unchecked_right_shift_parallelized);
-    unchecked_right_shift_test(param, executor);
+    unchecked_right_shift_test(param, executor, true);
 }
 
 fn integer_right_shift<P>(param: P)
@@ -38,7 +38,7 @@ where
     P: Into<TestParameters> + Copy,
 {
     let executor = CpuFunctionExecutor::new(&ServerKey::right_shift_parallelized);
-    default_right_shift_test(param, executor);
+    default_right_shift_test(param, executor, true);
 }
 
 fn integer_left_shift<P>(param: P)
@@ -46,10 +46,10 @@ where
     P: Into<TestParameters> + Copy,
 {
     let executor = CpuFunctionExecutor::new(&ServerKey::left_shift_parallelized);
-    default_left_shift_test(param, executor);
+    default_left_shift_test(param, executor, true);
 }
 
-pub(crate) fn unchecked_left_shift_test<P, T>(param: P, mut executor: T)
+pub(crate) fn unchecked_left_shift_test<P, T>(param: P, mut executor: T, test_overshift: bool)
 where
     P: Into<TestParameters>,
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, &'a RadixCiphertext), RadixCiphertext>,
@@ -86,29 +86,22 @@ where
         }
 
         // case when shift >= nb_bits
-        {
-            let clear_shift = clear_shift.saturating_add(nb_bits);
+        // TODO: remove the `test_overshift` parameter (and this branch's gating) once the
+        // GPU backend implements the new overshift-returns-zero behavior.
+        if test_overshift {
+            // The shift amount lies in [nb_bits, modulus), so it encrypts without
+            // wrapping and is a genuine overshift: the result must be 0.
+            let clear_shift = rng.gen_range(nb_bits..modulus as u32);
             let shift = cks.encrypt(clear_shift as u64);
 
             let encrypted_result = executor.execute((&ct, &shift));
             let decrypted_result: u64 = cks.decrypt(&encrypted_result);
-            // When nb_bits is not a power of two
-            // then the behaviour is not the same
-            let mut nb_bits = modulus.ilog2();
-            if !nb_bits.is_power_of_two() {
-                nb_bits = nb_bits.next_power_of_two();
-            }
-            // We mimic wrapping_shl manually as we use a bigger type
-            // than the nb_bits we actually simulate in this test
-            assert_eq!(
-                (clear << (clear_shift % nb_bits)) % modulus,
-                decrypted_result
-            );
+            assert_eq!(0, decrypted_result);
         }
     }
 }
 
-pub(crate) fn unchecked_right_shift_test<P, T>(param: P, mut executor: T)
+pub(crate) fn unchecked_right_shift_test<P, T>(param: P, mut executor: T, test_overshift: bool)
 where
     P: Into<TestParameters>,
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, &'a RadixCiphertext), RadixCiphertext>,
@@ -144,29 +137,21 @@ where
         }
 
         // case when shift >= nb_bits
-        {
-            let clear_shift = clear_shift.saturating_add(nb_bits);
+        // TODO: remove the `test_overshift` parameter (and this branch's gating) once the
+        // GPU backend implements the new overshift-returns-zero behavior.
+        if test_overshift {
+            // The shift amount lies in [nb_bits, modulus), so it encrypts without
+            // wrapping and is a genuine overshift: the result must be 0.
+            let clear_shift = rng.gen_range(nb_bits..modulus as u32);
             let shift = cks.encrypt(clear_shift as u64);
             let encrypted_result = executor.execute((&ct, &shift));
             let decrypted_result: u64 = cks.decrypt(&encrypted_result);
-
-            // When nb_bits is not a power of two
-            // then the behaviour is not the same
-            let mut nb_bits = modulus.ilog2();
-            if !nb_bits.is_power_of_two() {
-                nb_bits = nb_bits.next_power_of_two();
-            }
-            // We mimic wrapping_shr manually as we use a bigger type
-            // than the nb_bits we actually simulate in this test
-            assert_eq!(
-                (clear >> (clear_shift % nb_bits)) % modulus,
-                decrypted_result
-            );
+            assert_eq!(0, decrypted_result);
         }
     }
 }
 
-pub(crate) fn default_left_shift_test<P, T>(param: P, mut executor: T)
+pub(crate) fn default_left_shift_test<P, T>(param: P, mut executor: T, test_overshift: bool)
 where
     P: Into<TestParameters>,
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, &'a RadixCiphertext), RadixCiphertext>,
@@ -217,7 +202,9 @@ where
             }
 
             // case when shift >= nb_bits
-            {
+            // TODO: remove the `test_overshift` parameter (and this branch's gating) once the
+            // GPU backend implements the new overshift-returns-zero behavior.
+            if test_overshift {
                 let clear_shift = rng.gen_range(nb_bits..modulus as u32);
                 let shift = cks.encrypt_radix(clear_shift as u64, num_blocks);
 
@@ -230,24 +217,14 @@ where
                     "Expected all blocks to have at most NOMINAL noise level"
                 );
                 let decrypted_result: u64 = cks.decrypt_radix(&encrypted_result);
-                // When nb_bits is not a power of two
-                // then the behaviour is not the same
-                let mut nb_bits = modulus.ilog2();
-                if !nb_bits.is_power_of_two() {
-                    nb_bits = nb_bits.next_power_of_two();
-                }
-                // We mimic wrapping_shl manually as we use a bigger type
-                // than the nb_bits we actually simulate in this test
-                assert_eq!(
-                    (clear << (clear_shift % nb_bits)) % modulus,
-                    decrypted_result
-                );
+                // A shift >= nb_bits is an overshift and must return 0
+                assert_eq!(0, decrypted_result);
             }
         }
     }
 }
 
-pub(crate) fn default_right_shift_test<P, T>(param: P, mut executor: T)
+pub(crate) fn default_right_shift_test<P, T>(param: P, mut executor: T, test_overshift: bool)
 where
     P: Into<TestParameters>,
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, &'a RadixCiphertext), RadixCiphertext>,
@@ -292,7 +269,9 @@ where
             }
 
             // case when shift >= nb_bits
-            {
+            // TODO: remove the `test_overshift` parameter (and this branch's gating) once the
+            // GPU backend implements the new overshift-returns-zero behavior.
+            if test_overshift {
                 let clear_shift = rng.gen_range(nb_bits..modulus as u32);
                 let shift = cks.encrypt_radix(clear_shift as u64, num_blocks);
                 let encrypted_result = executor.execute((&ct, &shift));
@@ -304,19 +283,8 @@ where
                     "Expected all blocks to have at most NOMINAL noise level"
                 );
                 let decrypted_result: u64 = cks.decrypt_radix(&encrypted_result);
-
-                // When nb_bits is not a power of two
-                // then the behaviour is not the same
-                let mut nb_bits = modulus.ilog2();
-                if !nb_bits.is_power_of_two() {
-                    nb_bits = nb_bits.next_power_of_two();
-                }
-                // We mimic wrapping_shr manually as we use a bigger type
-                // than the nb_bits we actually simulate in this test
-                assert_eq!(
-                    (clear >> (clear_shift % nb_bits)) % modulus,
-                    decrypted_result
-                );
+                // A shift >= nb_bits is an overshift and must return 0
+                assert_eq!(0, decrypted_result, "Invalid result for {clear} << {clear_shift}, expected 0, got {decrypted_result}");
             }
         }
     }


### PR DESCRIPTION
Previously a in a shift, left or right of a
FheUintX << y, FheUintX >> y (and for FheInt too)

A modulo by trunctaion was applied to `y`.
This worked well when X was a power of 2,
as the trunctaion meant we did a real `y % X` modulo, wrapping y to values < X
However, when X was not a power of two then the modulo was `y % (1 << ceil(log2(X)))` which meant y could still hold values >= X

This made the behavior inconsistent between the two cases, and we relied on the user to know about it and handle it.

This commit changes that behavior to now make 'overshift', i.e shifts where y >= X return 0, (or -1 for right shift of negative
                values).
This cost one additional scalar comparison, done in parallel of the shift, and a conditional zeroing which, depending on the algorithm and parameters is absorbed or not.

BREAKIN_CHANGES: not an api break, but behavior break, however, the new
        behavior is likely more intuive for users

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3617)
<!-- Reviewable:end -->
