### PR TITLE
chore(gpu): require documentation on all new GPU HL code

### DIFF
--- a/.github/workflows/gpu_pcc.yml
+++ b/.github/workflows/gpu_pcc.yml
@@ -89,7 +89,12 @@ jobs:
           requires-a-gpu: "false"
 
       - name: Install python3-venv
-        run: sudo apt-get install -y python3-venv
+        run: sudo apt-get install -y python3-venv doxygen
+
+      - name: Check doxygen on new GPU code
+        run: python3 ci/check_doxygen_gpu.py
+        env:
+          GITHUB_BASE_REF: ${{ github.base_ref }}
 
       - name: Install latest stable
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # zizmor: ignore[stale-action-refs] this action doesn't create releases

--- a/ci/check_doxygen_gpu.py
+++ b/ci/check_doxygen_gpu.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""
+Verify that newly added code in GPU source files has doxygen documentation.
+
+Each new struct, member, and function must have a comment block with @brief and
+@param (or @tparam) covering every parameter.
+
+Scoped to:
+  backends/tfhe-cuda-backend/cuda/include/integer/   (*.h)
+  backends/tfhe-cuda-backend/cuda/src/integer/       (*.cuh, *.cu)
+"""
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+SCOPED_DIRS = [
+    "backends/tfhe-cuda-backend/cuda/include/integer",
+    "backends/tfhe-cuda-backend/cuda/src/integer",
+]
+EXTENSIONS = {".h", ".cuh", ".cu"}
+
+# Function parameters that don't require @param documentation.
+# Each entry is a (type_substring, param_name) pair.
+SKIP_PARAMS = {
+    ("CudaStreams", "streams"),
+    ("int_radix_params", "params"),
+    ("bool", "allocate_gpu_memory"),
+    ("uint64_t", "size_tracker"),
+    ("void", "bsks"),
+    ("KSTorus", "ksks"),
+    ("cudaStream_t", "stream"),
+    ("uint32_t", "gpu_index"),
+}
+
+# Struct/class members that don't require inline documentation.
+# Each entry is a (type_substring, member_name) pair.
+SKIP_MEMBERS = {
+    ("int_radix_params", "params"),
+    ("bool", "gpu_memory_allocated"),
+}
+
+# Template parameters that don't require @tparam documentation.
+SKIP_TPARAMS = {"Torus", "KSTorus"}
+
+
+def run(cmd, **kwargs):
+    return subprocess.run(cmd, capture_output=True, text=True, check=True, **kwargs)
+
+
+def repo_root():
+    return Path(run(["git", "rev-parse", "--show-toplevel"]).stdout.strip())
+
+
+def changed_files(root):
+    out = run(["git", "diff", "FETCH_HEAD", "--name-only"], cwd=root)
+    return [root / p for p in out.stdout.strip().splitlines() if p]
+
+
+def added_line_numbers(root, filepath):
+    """Return the set of line numbers (1-based) that were added in filepath."""
+    rel = filepath.relative_to(root)
+    out = run(["git", "diff", "FETCH_HEAD", "--", str(rel)], cwd=root)
+    added = set()
+    current = 0
+    for line in out.stdout.splitlines():
+        m = re.match(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@", line)
+        if m:
+            current = int(m.group(1))
+            continue
+        if line.startswith("+++"):
+            continue
+        if line.startswith("+"):
+            added.add(current)
+            current += 1
+        elif not line.startswith("-"):
+            current += 1
+    return added
+
+
+def run_doxygen_xml(root, files):
+    """Run doxygen with EXTRACT_ALL=YES and XML output. Returns the output directory."""
+    output_dir = tempfile.mkdtemp()
+    input_paths = " \\\n    ".join(str(f) for f in files)
+    doxyfile = f"""\
+PROJECT_NAME      = tfhe-cuda-backend
+INPUT             = {input_paths}
+RECURSIVE         = NO
+EXTENSION_MAPPING = cu=C++ cuh=C++
+PREDEFINED        = __host__= __device__= __global__= __shared__= __constant__= __forceinline__=
+GENERATE_HTML     = NO
+GENERATE_LATEX    = NO
+GENERATE_XML      = YES
+EXTRACT_ALL       = YES
+QUIET             = YES
+WARNINGS          = NO
+OUTPUT_DIRECTORY  = {output_dir}
+"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".cfg", delete=False) as f:
+        f.write(doxyfile)
+        cfg = f.name
+    try:
+        subprocess.run(["doxygen", cfg], capture_output=True, text=True, cwd=root)
+    finally:
+        os.unlink(cfg)
+    return output_dir
+
+
+def is_empty(elem):
+    return elem is None or not "".join(elem.itertext()).strip()
+
+
+def skip_param(type_str, name):
+    return any(t in type_str and name == n for t, n in SKIP_PARAMS)
+
+
+def skip_member(type_str, name):
+    return any(t in type_str and name == n for t, n in SKIP_MEMBERS)
+
+
+def check_entity(name, kind, memberdef, param_elems):
+    """Return list of documentation issues for a function/struct member."""
+    issues = []
+
+    if is_empty(memberdef.find("briefdescription")):
+        issues.append("missing @brief")
+        return issues  # no point checking params without a brief
+
+    # Collect declared parameter names, excluding well-known boilerplate params
+    declared = [
+        p.findtext("declname", "").strip()
+        for p in param_elems
+        if p.findtext("declname", "").strip()
+        and not skip_param("".join(p.itertext()).strip(), p.findtext("declname", "").strip())
+    ]
+
+    # Collect documented @param names
+    documented_params = set()
+    for paramlist in memberdef.iter("parameterlist"):
+        if paramlist.get("kind") == "param":
+            for item in paramlist.findall("parameteritem"):
+                for nl in item.findall("parameternamelist"):
+                    for pname in nl.findall("parametername"):
+                        if pname.text:
+                            documented_params.add(pname.text.strip())
+
+    missing_params = [p for p in declared if p not in documented_params]
+    if missing_params:
+        issues.append(f"missing @param for: {', '.join(missing_params)}")
+
+    # Check @tparam for template parameters, excluding skipped ones
+    tpl = memberdef.find("templateparamlist")
+    if tpl is not None:
+        declared_tparams = []
+        for tp in tpl.findall("param"):
+            # type is e.g. "typename Torus" or "class KSTorus"
+            tname = tp.findtext("type", "").replace("typename", "").replace("class", "").strip()
+            if tname and tname not in SKIP_TPARAMS:
+                declared_tparams.append(tname)
+
+        documented_tparams = set()
+        for paramlist in memberdef.iter("parameterlist"):
+            if paramlist.get("kind") == "templateparam":
+                for item in paramlist.findall("parameteritem"):
+                    for nl in item.findall("parameternamelist"):
+                        for pname in nl.findall("parametername"):
+                            if pname.text:
+                                documented_tparams.add(pname.text.strip())
+
+        missing_tparams = [t for t in declared_tparams if t not in documented_tparams]
+        if missing_tparams:
+            issues.append(f"missing @tparam for: {', '.join(missing_tparams)}")
+
+    return issues
+
+
+def resolve(path_str, root):
+    p = Path(path_str)
+    return p if p.is_absolute() else (root / p).resolve()
+
+
+def parse_xml_issues(xml_dir, added, root):
+    failures = []
+
+    for xml_path in sorted(Path(xml_dir).glob("xml/*.xml")):
+        if xml_path.name == "index.xml":
+            continue
+        try:
+            tree = ET.parse(xml_path)
+        except ET.ParseError:
+            continue
+        doc_root = tree.getroot()
+
+        # Structs and classes
+        for compound in doc_root.iter("compounddef"):
+            if compound.get("kind") not in ("struct", "class"):
+                continue
+            loc = compound.find("location")
+            if loc is None:
+                continue
+            fpath = resolve(loc.get("file", ""), root)
+            line = int(loc.get("line", 0))
+            if fpath not in added or line not in added[fpath]:
+                continue
+            cname = compound.findtext("compoundname", "")
+            if is_empty(compound.find("briefdescription")):
+                failures.append((fpath, line, f"struct/class '{cname}': missing @brief"))
+                continue
+            tpl = compound.find("templateparamlist")
+            if tpl is not None:
+                declared_tparams = []
+                for tp in tpl.findall("param"):
+                    tname = tp.findtext("type", "").replace("typename", "").replace("class", "").strip()
+                    if tname and tname not in SKIP_TPARAMS:
+                        declared_tparams.append(tname)
+                documented_tparams = set()
+                for paramlist in compound.iter("parameterlist"):
+                    if paramlist.get("kind") == "templateparam":
+                        for item in paramlist.findall("parameteritem"):
+                            for nl in item.findall("parameternamelist"):
+                                for pname in nl.findall("parametername"):
+                                    if pname.text:
+                                        documented_tparams.add(pname.text.strip())
+                missing = [t for t in declared_tparams if t not in documented_tparams]
+                if missing:
+                    failures.append((fpath, line, f"struct/class '{cname}': missing @tparam for: {', '.join(missing)}"))
+
+        # Functions and member variables
+        for memberdef in doc_root.iter("memberdef"):
+            kind = memberdef.get("kind")
+            if kind not in ("function", "variable"):
+                continue
+            loc = memberdef.find("location")
+            if loc is None:
+                continue
+            fpath = resolve(loc.get("file", ""), root)
+            line = int(loc.get("line", 0))
+            if fpath not in added or line not in added[fpath]:
+                continue
+            name = memberdef.findtext("name", "")
+            if kind == "function":
+                issues = check_entity(name, kind, memberdef, memberdef.findall("param"))
+                for issue in issues:
+                    failures.append((fpath, line, f"function '{name}': {issue}"))
+            else:
+                type_str = "".join(memberdef.find("type").itertext()).strip() if memberdef.find("type") is not None else ""
+                if not skip_member(type_str, name) and is_empty(memberdef.find("briefdescription")):
+                    failures.append((fpath, line, f"member '{name}': missing documentation"))
+
+
+    return failures
+
+
+def main():
+    base_ref = os.environ.get("GITHUB_BASE_REF", "main")
+    root = repo_root()
+
+    subprocess.run(
+        ["git", "fetch", "origin", base_ref, "--depth=1"],
+        cwd=root, capture_output=True
+    )
+
+    all_changed = changed_files(root)
+    relevant = [
+        f for f in all_changed
+        if f.suffix in EXTENSIONS
+        and any(str(f).startswith(str(root / d)) for d in SCOPED_DIRS)
+    ]
+
+    if not relevant:
+        print("No GPU files changed — skipping doxygen check.")
+        return 0
+
+    print(f"Running doxygen check on {len(relevant)} file(s):")
+    for f in relevant:
+        print(f"  {f.relative_to(root)}")
+
+    added = {f: added_line_numbers(root, f) for f in relevant}
+
+    xml_dir = run_doxygen_xml(root, relevant)
+    try:
+        failures = parse_xml_issues(xml_dir, added, root)
+    finally:
+        shutil.rmtree(xml_dir, ignore_errors=True)
+
+    if failures:
+        print("\nMissing doxygen documentation on newly added code:")
+        for fpath, line, msg in failures:
+            try:
+                rel = fpath.relative_to(root)
+            except ValueError:
+                rel = fpath
+            print(f"  {rel}:{line}: {msg}")
+        print(
+            "\nNew structs, members, and functions must have a doxygen block with"
+            " @brief, @tparam for template parameters, and @param for each argument."
+        )
+        return 1
+
+    print("OK: all newly added GPU code is documented.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Require documentation for all new or modified GPU HL code in the integer subdir. Does not require documentation for older code. 



Sample output:

```
Running doxygen check on 2 file(s):
  backends/tfhe-cuda-backend/cuda/include/integer/scalar_mul.h
  backends/tfhe-cuda-backend/cuda/src/integer/comparison.cuh

Missing doxygen documentation on newly added code:
  backends/tfhe-cuda-backend/cuda/src/integer/comparison.cuh:690: function 'host_maxmin2': missing @brief
  backends/tfhe-cuda-backend/cuda/include/integer/scalar_mul.h:18: member 'new_member': missing documentation
  backends/tfhe-cuda-backend/cuda/include/integer/scalar_mul.h:6: struct/class 'int_scalar_mul_buffer2': missing @brief

New structs, members, and functions must have a doxygen block with @brief, @tparam for template parameters, and @param for each argument.

```

What needs to be documented:
 - structs
 - struct members and member functions
 - functions, function parameters and template parameters

Examples (AI generated):

```
/// @brief GPU scratch buffer for homomorphic scalar multiplication.                                                                                   
  ///             
  /// Preallocates all intermediate ciphertext buffers needed to multiply a
  /// radix ciphertext by a plaintext scalar via a shift-and-sum strategy.
  /// Memory is owned by this object and must be released explicitly via release().
  ///
  /// @tparam Torus  Unsigned integer type representing a ciphertext torus element
  template <typename Torus> struct int_scalar_mul_buffer {
    int_radix_params params;                                         ///< Radix decomposition parameters (moduli, LWE dimension, etc.)
    int_logical_scalar_shift_buffer<Torus> *logical_scalar_shift_buffer; ///< Shift buffer for the left-shift stage
    int_sum_ciphertexts_vec_memory<Torus>  *sum_ciphertexts_vec_mem;     ///< Accumulator memory for the final ciphertext summation
    CudaRadixCiphertextFFI *preshifted_buffer;  ///< One shifted copy per message bit (shifts 0..msg_bits); used to derive larger shifts via block
  rotation
    CudaRadixCiphertextFFI *all_shifted_buffer; ///< Full set of shifted ciphertexts covering 0..num_ciphertext_bits
    int_sc_prop_memory<Torus> *sc_prop_mem;     ///< Carry-propagation scratch memory for the summation step
    bool anticipated_buffers_drop; ///< When true, intermediate buffers are freed as soon as they are no longer needed to reduce peak GPU memory
    bool gpu_memory_allocated;     ///< Tracks whether this object owns its GPU allocations and must free them on release()
    uint32_t num_ciphertext_bits;  ///< Total ciphertext bits: msg_bits * num_scalar_bits

    /// @brief Allocates and initialises all GPU buffers required for scalar multiplication.
    ///
    /// @param streams                CUDA streams used for asynchronous allocations and kernel launches
    /// @param params                 Radix decomposition parameters shared across all sub-buffers
    /// @param num_radix_blocks       Number of radix blocks in the input ciphertext
    /// @param num_scalar_bits        Bit-width of the plaintext scalar
    /// @param allocate_gpu_memory    When true, GPU memory is allocated; when false only sizes are tracked (dry-run mode)
    /// @param anticipated_buffer_drop  When true, peak memory is reduced by reusing buffers as soon as they are done
    /// @param size_tracker           Accumulated GPU memory size in bytes; updated in-place by each sub-buffer constructor
    int_scalar_mul_buffer(CudaStreams streams, int_radix_params params, ...);
```
