### PR TITLE
feat(gpu): accelerate comparisons on 2_2 params unsigned integers

### DIFF
--- a/backends/tfhe-cuda-backend/cuda/include/integer/comparison.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer/comparison.h
@@ -349,6 +349,17 @@ template <typename Torus> struct int_comparison_buffer {
   int_comparison_eq_buffer<Torus> *eq_buffer;
   int_comparison_diff_buffer<Torus> *diff_buffer;
 
+  /// @brief Borrow-propagation fast path for unsigned GT/GE/LT/LE on 2_2
+  /// params. When enabled, the comparison reuses the overflow (borrow-out) path
+  /// of the overflowing-sub borrow propagation instead of the sign-tree
+  /// reduction.
+  bool use_borrow_fast_path;
+  /// @brief Borrow-propagation memory, allocated only on the fast path.
+  int_borrow_prop_memory<Torus> *diff_borrow_mem;
+  /// @brief Final single-block LUT applying the per-op inversion:
+  ///   f(block) = ((block >> 2) & 1) ^ invert
+  int_radix_lut<Torus> *lut_borrow_flag_cmp;
+
   CudaRadixCiphertextFFI *tmp_block_comparisons;
   CudaRadixCiphertextFFI *tmp_lwe_array_out;
   CudaRadixCiphertextFFI *tmp_trivial_sign_block;
@@ -369,15 +380,34 @@ template <typename Torus> struct int_comparison_buffer {
   CudaStreams msb_streams;
   bool gpu_memory_allocated;
   Torus *preallocated_h_lut;
-
+  // The comparison buffer allows a fast path for unsigned GT/GE/LT/LE when the
+  // parameters are 2_2, by using an optimized version of the overflowing sub in
+  // the same way that is done in the cpu.
   int_comparison_buffer(CudaStreams streams, COMPARISON_TYPE op,
                         int_radix_params params, uint32_t num_radix_blocks,
                         bool is_signed, bool allocate_gpu_memory,
-                        uint64_t &size_tracker) {
+                        uint64_t &size_tracker,
+                        bool allow_borrow_fast_path = false) {
     gpu_memory_allocated = allocate_gpu_memory;
     this->params = params;
     this->op = op;
     this->is_signed = is_signed;
+    diff_borrow_mem = nullptr;
+    lut_borrow_flag_cmp = nullptr;
+    // When we are in the fast path we can avoid calculating the luts for the
+    // tree reduction.
+    use_borrow_fast_path =
+        allow_borrow_fast_path &&
+        (op == COMPARISON_TYPE::GT || op == COMPARISON_TYPE::GE ||
+         op == COMPARISON_TYPE::LT || op == COMPARISON_TYPE::LE) &&
+        !is_signed && params.message_modulus == 4 && params.carry_modulus == 4;
+    // Null the sign-tree members so release() can safely skip them.
+    diff_buffer = nullptr;
+    eq_buffer = nullptr;
+    identity_lut = nullptr;
+    is_zero_lut = nullptr;
+    tmp_lwe_array_out = nullptr;
+    tmp_packed_input = nullptr;
 
     auto active_streams =
         streams.active_gpu_subset(num_radix_blocks, params.pbs_type);
@@ -387,72 +417,78 @@ template <typename Torus> struct int_comparison_buffer {
     lsb_streams.create_on_same_gpus(active_streams);
     msb_streams.create_on_same_gpus(active_streams);
 
-    // +1 to have space for signed comparison
-    tmp_lwe_array_out = new CudaRadixCiphertextFFI;
-    create_zero_radix_ciphertext_async<Torus>(
-        streams.stream(0), streams.gpu_index(0), tmp_lwe_array_out,
-        num_radix_blocks + 1, params.big_lwe_dimension, size_tracker,
-        allocate_gpu_memory);
-
-    tmp_packed_input = new CudaRadixCiphertextFFI;
-    create_zero_radix_ciphertext_async<Torus>(
-        streams.stream(0), streams.gpu_index(0), tmp_packed_input,
-        2 * num_radix_blocks, params.big_lwe_dimension, size_tracker,
-        allocate_gpu_memory);
-
-    // Block comparisons
+    // Block comparisons buffer. Allocated for both paths: the sign-tree path
+    // stores the per-block comparison results here, the borrow-propagation fast
+    // path stores the subtraction blocks here.
     tmp_block_comparisons = new CudaRadixCiphertextFFI;
     create_zero_radix_ciphertext_async<Torus>(
         streams.stream(0), streams.gpu_index(0), tmp_block_comparisons,
         num_radix_blocks, params.big_lwe_dimension, size_tracker,
         allocate_gpu_memory);
 
-    // Cleaning LUT
-    identity_lut =
-        new int_radix_lut<Torus>(streams, params, 1, num_radix_blocks,
-                                 allocate_gpu_memory, size_tracker);
+    // We use the tree reduction old algorithm.
+    if (!use_borrow_fast_path) {
+      // +1 to have space for signed comparison
+      tmp_lwe_array_out = new CudaRadixCiphertextFFI;
+      create_zero_radix_ciphertext_async<Torus>(
+          streams.stream(0), streams.gpu_index(0), tmp_lwe_array_out,
+          num_radix_blocks + 1, params.big_lwe_dimension, size_tracker,
+          allocate_gpu_memory);
 
-    identity_lut->generate_and_broadcast_lut(
-        active_streams, {0}, {identity_lut_f}, LUT_0_FOR_ALL_BLOCKS);
+      tmp_packed_input = new CudaRadixCiphertextFFI;
+      create_zero_radix_ciphertext_async<Torus>(
+          streams.stream(0), streams.gpu_index(0), tmp_packed_input,
+          2 * num_radix_blocks, params.big_lwe_dimension, size_tracker,
+          allocate_gpu_memory);
 
-    uint32_t total_modulus = params.message_modulus * params.carry_modulus;
-    auto is_zero_f = [total_modulus](Torus x) -> Torus {
-      return (x % total_modulus) == 0;
-    };
+      // Cleaning LUT
+      identity_lut =
+          new int_radix_lut<Torus>(streams, params, 1, num_radix_blocks,
+                                   allocate_gpu_memory, size_tracker);
 
-    is_zero_lut = new int_radix_lut<Torus>(streams, params, 1, num_radix_blocks,
-                                           allocate_gpu_memory, size_tracker);
+      identity_lut->generate_and_broadcast_lut(
+          active_streams, {0}, {identity_lut_f}, LUT_0_FOR_ALL_BLOCKS);
 
-    is_zero_lut->generate_and_broadcast_lut(active_streams, {0}, {is_zero_f},
-                                            LUT_0_FOR_ALL_BLOCKS);
+      uint32_t total_modulus = params.message_modulus * params.carry_modulus;
+      auto is_zero_f = [total_modulus](Torus x) -> Torus {
+        return (x % total_modulus) == 0;
+      };
 
-    switch (op) {
-    case COMPARISON_TYPE::MAX:
-    case COMPARISON_TYPE::MIN:
-      cmux_buffer = new int_cmux_buffer<Torus>(
-          streams,
-          [op](Torus x) -> Torus {
-            if (op == COMPARISON_TYPE::MAX)
-              return (x == IS_SUPERIOR);
-            else
-              return (x == IS_INFERIOR);
-          },
-          params, num_radix_blocks, allocate_gpu_memory, size_tracker);
-    case COMPARISON_TYPE::GT:
-    case COMPARISON_TYPE::GE:
-    case COMPARISON_TYPE::LT:
-    case COMPARISON_TYPE::LE:
-      diff_buffer = new int_comparison_diff_buffer<Torus>(
-          streams, op, params, num_radix_blocks, allocate_gpu_memory,
-          size_tracker);
-    case COMPARISON_TYPE::EQ:
-    case COMPARISON_TYPE::NE:
-      eq_buffer = new int_comparison_eq_buffer<Torus>(
-          streams, op, params, num_radix_blocks, allocate_gpu_memory,
-          size_tracker);
-      break;
-    default:
-      PANIC("Unsupported comparison operation.")
+      is_zero_lut =
+          new int_radix_lut<Torus>(streams, params, 1, num_radix_blocks,
+                                   allocate_gpu_memory, size_tracker);
+
+      is_zero_lut->generate_and_broadcast_lut(active_streams, {0}, {is_zero_f},
+                                              LUT_0_FOR_ALL_BLOCKS);
+
+      switch (op) {
+      case COMPARISON_TYPE::MAX:
+      case COMPARISON_TYPE::MIN:
+        cmux_buffer = new int_cmux_buffer<Torus>(
+            streams,
+            [op](Torus x) -> Torus {
+              if (op == COMPARISON_TYPE::MAX)
+                return (x == IS_SUPERIOR);
+              else
+                return (x == IS_INFERIOR);
+            },
+            params, num_radix_blocks, allocate_gpu_memory, size_tracker);
+      case COMPARISON_TYPE::GT:
+      case COMPARISON_TYPE::GE:
+      case COMPARISON_TYPE::LT:
+      case COMPARISON_TYPE::LE:
+        diff_buffer = new int_comparison_diff_buffer<Torus>(
+            streams, op, params, num_radix_blocks, allocate_gpu_memory,
+            size_tracker);
+      case COMPARISON_TYPE::EQ:
+      case COMPARISON_TYPE::NE:
+        eq_buffer = new int_comparison_eq_buffer<Torus>(
+            streams, op, params, num_radix_blocks, allocate_gpu_memory,
+            size_tracker);
+        break;
+      default:
+        PANIC("Unsupported comparison operation.")
+      }
     }
 
     if (is_signed) {
@@ -503,43 +539,134 @@ template <typename Torus> struct int_comparison_buffer {
       signed_lut->generate_and_broadcast_bivariate_lut(
           active_streams, {0}, {signed_lut_f}, LUT_0_FOR_ALL_BLOCKS);
     }
+
+    // Allocate the borrow-propagation machinery reused by the fast path. We
+    // reuse the overflowing-sub borrow propagation and finish with a
+    // single-block LUT that extracts the borrow flag and applies the per-op
+    // boolean inversion (lut_borrow_flag_cmp below).
+    if (use_borrow_fast_path) {
+      // FLAG_NONE: host_difference_check_via_borrow does the overflow-block
+      // combination itself, so int_borrow_prop_memory's own borrow-flag LUT is
+      // never used and we avoid allocating it.
+      diff_borrow_mem = new int_borrow_prop_memory<Torus>(
+          streams, params, num_radix_blocks, (uint32_t)outputFlag::FLAG_NONE,
+          allocate_gpu_memory, size_tracker);
+
+      // GE/LE need to invert the `<` result, GT/LT do not.
+      bool invert = (op == COMPARISON_TYPE::GE || op == COMPARISON_TYPE::LE);
+      auto f_borrow_flag_cmp = [invert](Torus block) -> Torus {
+        return ((block >> 2) & 1) ^ (Torus)invert;
+      };
+
+      lut_borrow_flag_cmp = new int_radix_lut<Torus>(
+          streams, params, 1, 1, allocate_gpu_memory, size_tracker);
+      auto active_streams_one = streams.active_gpu_subset(1, params.pbs_type);
+      lut_borrow_flag_cmp->generate_and_broadcast_lut(
+          active_streams_one, {0}, {f_borrow_flag_cmp}, LUT_0_FOR_ALL_BLOCKS);
+
+      // We need to create the luts for the borrow fast path that are optimized
+      // for comparisons. This saves us half the number of pbs of the second
+      // step if we were using the generic overflow path. The cpu perform
+      // exactly this operation too.
+      if (allocate_gpu_memory) {
+        auto *mem_simu_group_carries =
+            diff_borrow_mem->prop_simu_group_carries_mem;
+        uint32_t group_size = diff_borrow_mem->group_size;
+        uint32_t n_groups = diff_borrow_mem->num_groups;
+        bool seq = mem_simu_group_carries
+                       ->use_sequential_algorithm_to_resolve_group_carries;
+
+        // Mirror second_step_lut_index_generator / h_scalar_array_cum_sum for a
+        // single cumulative-sum position (see
+        // int_prop_simu_group_carries_memory).
+        auto lut_index_for = [group_size, seq](uint32_t pos) -> Torus {
+          uint32_t group_index = pos / group_size;
+          uint32_t pos_in_group = pos % group_size;
+          if (group_index == 0)
+            return (Torus)pos_in_group;
+          else if (pos_in_group == group_size - 1)
+            return seq ? (Torus)((group_index - 1) % (group_size - 1) +
+                                 2 * group_size)
+                       : (Torus)(2 * group_size);
+          else
+            return (Torus)(pos_in_group + group_size);
+        };
+        auto corrector_for = [group_size, seq](uint32_t pos) -> Torus {
+          uint32_t group_index = pos / group_size;
+          uint32_t pos_in_group = pos % group_size;
+          if (group_index == 0 || pos_in_group != group_size - 1)
+            return (Torus)0;
+          return seq ? ((Torus)1 << ((group_index - 1) % (group_size - 1)))
+                     : (Torus)1;
+        };
+
+        std::vector<Torus> h_indexes(n_groups);
+        std::vector<Torus> h_scalar_corrector(n_groups);
+        for (uint32_t g = 0; g + 1 < n_groups; g++) {
+          uint32_t pos = (g + 1) * group_size - 1;
+          h_indexes[g] = lut_index_for(pos);
+          h_scalar_corrector[g] = corrector_for(pos);
+        }
+        uint32_t simulator_pos = num_radix_blocks - 2;
+        h_indexes[n_groups - 1] = lut_index_for(simulator_pos);
+        h_scalar_corrector[n_groups - 1] = corrector_for(simulator_pos);
+
+        auto *lut = mem_simu_group_carries->luts_array_second_step;
+        cuda_memcpy_with_size_tracking_async_to_gpu(
+            lut->get_lut_indexes(0, 0), h_indexes.data(),
+            safe_mul_sizeof<Torus>(n_groups), streams.stream(0),
+            streams.gpu_index(0), allocate_gpu_memory);
+        lut->broadcast_lut(active_streams, false);
+
+        cuda_memcpy_with_size_tracking_async_to_gpu(
+            mem_simu_group_carries->scalar_array_cum_sum,
+            h_scalar_corrector.data(), safe_mul_sizeof<Torus>(n_groups),
+            streams.stream(0), streams.gpu_index(0), allocate_gpu_memory);
+        for (uint32_t i = 0; i < n_groups; i++)
+          mem_simu_group_carries->h_scalar_array_cum_sum[i] =
+              h_scalar_corrector[i];
+      }
+    }
+
     preallocated_h_lut = (Torus *)malloc(safe_mul_sizeof<Torus>(
         params.glwe_dimension + 1, params.polynomial_size));
   }
 
   void release(CudaStreams streams) {
-    switch (op) {
-    case COMPARISON_TYPE::MAX:
-    case COMPARISON_TYPE::MIN:
-      cmux_buffer->release(streams);
-      delete (cmux_buffer);
-    case COMPARISON_TYPE::GT:
-    case COMPARISON_TYPE::GE:
-    case COMPARISON_TYPE::LT:
-    case COMPARISON_TYPE::LE:
-      diff_buffer->release(streams);
-      delete (diff_buffer);
-    case COMPARISON_TYPE::EQ:
-    case COMPARISON_TYPE::NE:
-      eq_buffer->release(streams);
-      delete (eq_buffer);
-      break;
-    default:
-      PANIC("Unsupported comparison operation.")
+    if (!use_borrow_fast_path) {
+      switch (op) {
+      case COMPARISON_TYPE::MAX:
+      case COMPARISON_TYPE::MIN:
+        cmux_buffer->release(streams);
+        delete (cmux_buffer);
+      case COMPARISON_TYPE::GT:
+      case COMPARISON_TYPE::GE:
+      case COMPARISON_TYPE::LT:
+      case COMPARISON_TYPE::LE:
+        diff_buffer->release(streams);
+        delete (diff_buffer);
+      case COMPARISON_TYPE::EQ:
+      case COMPARISON_TYPE::NE:
+        eq_buffer->release(streams);
+        delete (eq_buffer);
+        break;
+      default:
+        PANIC("Unsupported comparison operation.")
+      }
+      release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0),
+                                     tmp_lwe_array_out, gpu_memory_allocated);
+      release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0),
+                                     tmp_packed_input, gpu_memory_allocated);
+      identity_lut->release(streams);
+      delete identity_lut;
+      is_zero_lut->release(streams);
+      delete is_zero_lut;
+      delete tmp_lwe_array_out;
+      delete tmp_packed_input;
     }
     release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0),
-                                   tmp_lwe_array_out, gpu_memory_allocated);
-    release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0),
                                    tmp_block_comparisons, gpu_memory_allocated);
-    release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0),
-                                   tmp_packed_input, gpu_memory_allocated);
-    identity_lut->release(streams);
-    delete identity_lut;
-    is_zero_lut->release(streams);
-    delete is_zero_lut;
-    delete tmp_lwe_array_out;
     delete tmp_block_comparisons;
-    delete tmp_packed_input;
 
     if (is_signed) {
       release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0),
@@ -550,6 +677,14 @@ template <typename Torus> struct int_comparison_buffer {
       signed_msb_lut->release(streams);
       delete signed_msb_lut;
       delete tmp_trivial_sign_block;
+    }
+    if (use_borrow_fast_path) {
+      diff_borrow_mem->release(streams);
+      delete diff_borrow_mem;
+      diff_borrow_mem = nullptr;
+      lut_borrow_flag_cmp->release(streams);
+      delete lut_borrow_flag_cmp;
+      lut_borrow_flag_cmp = nullptr;
     }
     cuda_synchronize_stream(streams.stream(0), streams.gpu_index(0));
     lsb_streams.release();

--- a/backends/tfhe-cuda-backend/cuda/include/integer/integer_utilities.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer/integer_utilities.h
@@ -1989,9 +1989,7 @@ template <typename Torus> struct int_prop_simu_group_carries_memory {
     // create lut objects for step 2
     uint64_t lut_indexes_size = safe_mul_sizeof<Torus>(num_radix_blocks);
     uint32_t num_carry_to_resolve = num_groups - 1;
-    uint32_t saturated_sub =
-        ((num_carry_to_resolve > 1) ? num_carry_to_resolve - 1 : 0);
-    uint32_t sequential_depth = saturated_sub / (grouping_size - 1);
+    uint32_t sequential_depth = num_carry_to_resolve / (grouping_size - 1);
     uint32_t hillis_steel_depth;
 
     if (num_carry_to_resolve == 0) {

--- a/backends/tfhe-cuda-backend/cuda/src/integer/comparison.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/comparison.cu
@@ -17,7 +17,7 @@ uint64_t scratch_cuda_integer_comparison_64_async(
   case NE:
     size_tracker += scratch_cuda_comparison_check<uint64_t>(
         CudaStreams(streams), (int_comparison_buffer<uint64_t> **)mem_ptr,
-        num_radix_blocks, params, op_type, false, allocate_gpu_memory);
+        num_radix_blocks, params, op_type, false, false, allocate_gpu_memory);
     break;
   case GT:
   case GE:
@@ -27,7 +27,8 @@ uint64_t scratch_cuda_integer_comparison_64_async(
   case MIN:
     size_tracker += scratch_cuda_comparison_check<uint64_t>(
         CudaStreams(streams), (int_comparison_buffer<uint64_t> **)mem_ptr,
-        num_radix_blocks, params, op_type, is_signed, allocate_gpu_memory);
+        num_radix_blocks, params, op_type, is_signed, true,
+        allocate_gpu_memory);
     break;
   }
   POP_RANGE()
@@ -51,7 +52,7 @@ uint64_t scratch_cuda_integer_scalar_comparison_64_async(
   case NE:
     size_tracker += scratch_cuda_comparison_check<uint64_t>(
         CudaStreams(streams), (int_comparison_buffer<uint64_t> **)mem_ptr,
-        num_radix_blocks, params, op_type, false, allocate_gpu_memory);
+        num_radix_blocks, params, op_type, false, false, allocate_gpu_memory);
     break;
   case GT:
   case GE:
@@ -61,7 +62,8 @@ uint64_t scratch_cuda_integer_scalar_comparison_64_async(
   case MIN:
     size_tracker += scratch_cuda_comparison_check<uint64_t>(
         CudaStreams(streams), (int_comparison_buffer<uint64_t> **)mem_ptr,
-        num_radix_blocks, params, op_type, is_signed, allocate_gpu_memory);
+        num_radix_blocks, params, op_type, is_signed, false,
+        allocate_gpu_memory);
     break;
   }
   POP_RANGE()
@@ -103,10 +105,23 @@ void cuda_integer_comparison_64_async(CudaStreamsFFI streams,
     if (num_radix_blocks % 2 != 0)
       PANIC("Cuda error (comparisons): the number of radix blocks has to be "
             "even.")
-    host_difference_check<uint64_t>(CudaStreams(streams), lwe_array_out,
-                                    lwe_array_1, lwe_array_2, buffer,
-                                    buffer->diff_buffer->operator_f, bsks,
-                                    (uint64_t **)(ksks), num_radix_blocks);
+    if (buffer->use_borrow_fast_path) {
+      // The borrow-propagation path computes `left < right`. Express each op as
+      // a `<` with the operands possibly swapped (the boolean inversion for
+      // GE/LE is baked into the final LUT):
+      //   LT, GE -> (a, b)   ;   GT, LE -> (b, a)
+      bool swap_operands = (buffer->op == GT || buffer->op == LE);
+      auto const *lhs = swap_operands ? lwe_array_2 : lwe_array_1;
+      auto const *rhs = swap_operands ? lwe_array_1 : lwe_array_2;
+      host_difference_check_via_borrow<uint64_t>(
+          CudaStreams(streams), lwe_array_out, lhs, rhs, buffer, bsks,
+          (uint64_t **)(ksks), num_radix_blocks);
+    } else {
+      host_difference_check<uint64_t>(CudaStreams(streams), lwe_array_out,
+                                      lwe_array_1, lwe_array_2, buffer,
+                                      buffer->diff_buffer->operator_f, bsks,
+                                      (uint64_t **)(ksks), num_radix_blocks);
+    }
     break;
   case MAX:
   case MIN:
@@ -155,7 +170,7 @@ uint64_t scratch_cuda_integer_are_all_comparisons_block_true_64_async(
 
   return scratch_cuda_comparison_check<uint64_t>(
       CudaStreams(streams), (int_comparison_buffer<uint64_t> **)mem_ptr,
-      num_radix_blocks, params, EQ, false, allocate_gpu_memory);
+      num_radix_blocks, params, EQ, false, false, allocate_gpu_memory);
 }
 
 void cuda_integer_are_all_comparisons_block_true_64_async(
@@ -195,7 +210,7 @@ uint64_t scratch_cuda_integer_is_at_least_one_comparisons_block_true_64_async(
 
   return scratch_cuda_comparison_check<uint64_t>(
       CudaStreams(streams), (int_comparison_buffer<uint64_t> **)mem_ptr,
-      num_radix_blocks, params, EQ, false, allocate_gpu_memory);
+      num_radix_blocks, params, EQ, false, false, allocate_gpu_memory);
 }
 
 void cuda_integer_is_at_least_one_comparisons_block_true_64_async(

--- a/backends/tfhe-cuda-backend/cuda/src/integer/comparison.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/comparison.cuh
@@ -642,16 +642,187 @@ __host__ void host_difference_check(
                              bsks, ksks, num_comparisons);
 }
 
+/// @brief Computes the group carries the unsigned comparison needs,
+/// bootstrapping only `num_groups` blocks instead of all `num_radix_blocks`.
+///
+/// Unlike the full overflowing-sub, a comparison only consumes the group
+/// carries and the last simulator, so we gather just those `num_groups`
+/// cumulative-sum blocks, bootstrap them in a single batch, and reuse the
+/// existing group-carry resolvers. This matches the CPU implementation.
+///
+/// @param block_states each block has a previously computed state (borrow,
+/// carry, etc.)
+/// @param mem borrow-propagation memory (cumulative sums, group PGNs,
+/// simulators, resolved carries)
+/// @param num_radix_blocks number of radix blocks in the operands
+/// @param num_groups number of block groups (the bootstrap batch width)
+template <typename Torus, typename KSTorus>
+__host__ void host_compute_reduced_pgns_and_carries_for_comparison(
+    CudaStreams streams, CudaRadixCiphertextFFI *block_states,
+    int_radix_params params, int_prop_simu_group_carries_memory<Torus> *mem,
+    void *const *bsks, KSTorus *const *ksks, uint32_t num_radix_blocks,
+    uint32_t num_groups) {
+
+  auto message_modulus = params.message_modulus;
+  auto carry_modulus = params.carry_modulus;
+  auto group_size = mem->group_size;
+  auto propagation_cum_sums = mem->propagation_cum_sums;
+  auto grouping_pgns = mem->grouping_pgns;
+  auto simulators = mem->simulators;
+
+  // Cumulative sum of borrow states within each group.
+  host_radix_cumulative_sum_in_groups<Torus>(
+      streams.stream(0), streams.gpu_index(0), propagation_cum_sums,
+      block_states, num_radix_blocks, group_size);
+
+  // Gather the G cumulative-sum blocks the comparison actually needs into
+  // grouping_pgns: slots [0, num_groups-1) are the group totals (last block of
+  // each propagating group); the final slot is the source of the last
+  // simulator (block num_radix_blocks-2). The gather order must match the
+  // reduced LUT-index / corrector maps installed at scratch time.
+  for (uint32_t g = 0; g + 1 < num_groups; g++) {
+    uint32_t src = (g + 1) * group_size - 1;
+    copy_radix_ciphertext_slice_async<Torus>(
+        streams.stream(0), streams.gpu_index(0), grouping_pgns, g, g + 1,
+        propagation_cum_sums, src, src + 1);
+  }
+  copy_radix_ciphertext_slice_async<Torus>(
+      streams.stream(0), streams.gpu_index(0), grouping_pgns, num_groups - 1,
+      num_groups, propagation_cum_sums, num_radix_blocks - 2,
+      num_radix_blocks - 1);
+
+  // Single G-block bootstrap. The reduced LUT-index map (installed at scratch)
+  // selects, per slot, the same LUT the full path applies at that position.
+  integer_radix_apply_univariate_lookup_table<Torus>(
+      streams, grouping_pgns, grouping_pgns, bsks, ksks,
+      mem->luts_array_second_step, num_groups);
+
+  // Reduced negacyclic corrector map (installed at scratch).
+  host_scalar_addition_inplace<Torus>(
+      streams, grouping_pgns, mem->scalar_array_cum_sum,
+      mem->h_scalar_array_cum_sum, num_groups, message_modulus, carry_modulus);
+
+  // Move the last simulator into simulators[n-1] for the overflow combine;
+  // grouping_pgns[0 .. num_groups-2] stay in place for the resolvers (which
+  // never read the final slot).
+  copy_radix_ciphertext_slice_async<Torus>(
+      streams.stream(0), streams.gpu_index(0), simulators, num_radix_blocks - 1,
+      num_radix_blocks, grouping_pgns, num_groups - 1, num_groups);
+
+  // Group-carry resolution: reused verbatim from the full path.
+  auto resolved_carries = mem->resolved_carries;
+  if (mem->use_sequential_algorithm_to_resolve_group_carries) {
+    host_resolve_group_carries_sequentially(
+        streams, resolved_carries, grouping_pgns, params,
+        mem->seq_group_prop_mem, bsks, ksks, num_groups);
+  } else {
+    auto luts_carry_propagation_sum = mem->hs_group_prop_mem->lut_hillis_steele;
+    CudaRadixCiphertextFFI shifted_resolved_carries;
+    as_radix_ciphertext_slice<Torus>(&shifted_resolved_carries,
+                                     resolved_carries, 1, num_groups);
+    host_compute_prefix_sum_hillis_steele<Torus>(
+        streams, &shifted_resolved_carries, grouping_pgns,
+        luts_carry_propagation_sum, bsks, ksks, num_groups - 1);
+  }
+}
+
+/// @brief Unsigned GT/GE/LT/LE via borrow propagation: `a < b` iff `a - b`
+/// borrows out of the most significant block.
+///
+/// Reuses the borrow-propagation steps of the overflowing-sub and finishes with
+/// a single-block LUT (`lut_borrow_flag_cmp`) that extracts the borrow-out and
+/// applies the per-op inversion. The caller orders the operands so this always
+/// computes `left < right`.
+///
+/// @param lwe_array_out single boolean result block
+/// @param lwe_array_left left operand (ordered so the op is `left < right`)
+/// @param lwe_array_right right operand
+/// @param mem_ptr comparison buffer with the borrow fast-path memory and flag
+/// LUT
+/// @param num_radix_blocks number of radix blocks in the operands
+template <typename Torus, typename KSTorus>
+__host__ void host_difference_check_via_borrow(
+    CudaStreams streams, CudaRadixCiphertextFFI *lwe_array_out,
+    CudaRadixCiphertextFFI const *lwe_array_left,
+    CudaRadixCiphertextFFI const *lwe_array_right,
+    int_comparison_buffer<Torus> *mem_ptr, void *const *bsks,
+    KSTorus *const *ksks, uint32_t num_radix_blocks) {
+
+  if (lwe_array_out->lwe_dimension != lwe_array_left->lwe_dimension ||
+      lwe_array_out->lwe_dimension != lwe_array_right->lwe_dimension)
+    PANIC("Cuda error: input lwe dimensions must be the same")
+
+  auto mem = mem_ptr->diff_borrow_mem;
+  auto params = mem_ptr->params;
+  auto message_modulus = params.message_modulus;
+  auto carry_modulus = params.carry_modulus;
+  auto lut_stride = mem->lut_stride;
+  auto num_many_lut = mem->num_many_lut;
+  auto num_groups = mem->num_groups;
+
+  // Step 0: per-block subtraction with the message_modulus - 1 correcting term,
+  // matching the CPU's `unchecked_sub` so the block-state LUTs see the expected
+  // encoding (block < message_modulus means the block borrows).
+  auto sub_blocks = mem_ptr->tmp_block_comparisons;
+  host_unchecked_sub_with_correcting_term<Torus>(
+      streams.stream(0), streams.gpu_index(0), sub_blocks, lwe_array_left,
+      lwe_array_right, num_radix_blocks, message_modulus, carry_modulus);
+
+  // Step 1: compute the per-block borrow states (shifted_blocks is unused
+  // here).
+  host_compute_shifted_blocks_and_borrow_states<Torus>(
+      streams, sub_blocks, mem->shifted_blocks_borrow_state_mem, bsks, ksks,
+      lut_stride, num_many_lut);
+
+  auto borrow_states = mem->shifted_blocks_borrow_state_mem->borrow_states;
+  // Save the borrow state of the last block to combine into the overflow block.
+  copy_radix_ciphertext_slice_async<Torus>(
+      streams.stream(0), streams.gpu_index(0), mem->overflow_block, 0, 1,
+      borrow_states, num_radix_blocks - 1, num_radix_blocks);
+
+  // Step 2: group PGNs + group-carry resolution. Comparison-only reduced
+  // version that bootstraps num_groups blocks instead of num_radix_blocks (see
+  // the function header). It also writes simulators[num_radix_blocks-1], the
+  // only per-block simulator the overflow combine below consumes.
+  host_compute_reduced_pgns_and_carries_for_comparison<Torus>(
+      streams, borrow_states, params, mem->prop_simu_group_carries_mem, bsks,
+      ksks, num_radix_blocks, num_groups);
+
+  // Combine into the overflow (borrow-out) block, mirroring the overflow branch
+  // of host_single_borrow_propagate.
+  CudaRadixCiphertextFFI shifted_simulators;
+  as_radix_ciphertext_slice<Torus>(&shifted_simulators,
+                                   mem->prop_simu_group_carries_mem->simulators,
+                                   num_radix_blocks - 1, num_radix_blocks);
+  host_addition<Torus>(streams.stream(0), streams.gpu_index(0),
+                       mem->overflow_block, mem->overflow_block,
+                       &shifted_simulators, 1, message_modulus, carry_modulus);
+
+  CudaRadixCiphertextFFI resolved_borrows;
+  as_radix_ciphertext_slice<Torus>(
+      &resolved_borrows, mem->prop_simu_group_carries_mem->resolved_carries,
+      num_groups - 1, num_groups);
+  host_addition<Torus>(streams.stream(0), streams.gpu_index(0),
+                       mem->overflow_block, mem->overflow_block,
+                       &resolved_borrows, 1, message_modulus, carry_modulus);
+
+  // Final LUT: ((overflow_block >> 2) & 1) ^ invert, producing the boolean
+  // result in a single block.
+  integer_radix_apply_univariate_lookup_table<Torus>(
+      streams, lwe_array_out, mem->overflow_block, bsks, ksks,
+      mem_ptr->lut_borrow_flag_cmp, 1);
+}
+
 template <typename Torus>
 __host__ uint64_t scratch_cuda_comparison_check(
     CudaStreams streams, int_comparison_buffer<Torus> **mem_ptr,
     uint32_t num_radix_blocks, int_radix_params params, COMPARISON_TYPE op,
-    bool is_signed, bool allocate_gpu_memory) {
+    bool is_signed, bool allow_borrow_fast_path, bool allocate_gpu_memory) {
 
   uint64_t size_tracker = 0;
   *mem_ptr = new int_comparison_buffer<Torus>(
       streams, op, params, num_radix_blocks, is_signed, allocate_gpu_memory,
-      size_tracker);
+      size_tracker, allow_borrow_fast_path);
   return size_tracker;
 }
 


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description
The idea is reuse overflowing sub logic as on rust side to perform some of the comparisons, the limit is 2_2 params since carry prop is optimized for it. It reduces the batches of pbs from 6->5, provides about 18% of latency improvement on the comparisons.

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
