### PR TITLE
chore: update shellflags in Makefile to be in POSIX compliant mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 SHELL:=$(shell /usr/bin/env which bash)
-# Enable stop on error, no undefined variables
+# Enable stop on error
 # the c flag is to run the script inline
-.SHELLFLAGS := -eu -c
+# https://www.gnu.org/software/make/manual/html_node/Choosing-the-Shell.html
+# POSIX conforming mode
+.SHELLFLAGS := -ec
 OS:=$(shell uname)
 RS_CHECK_TOOLCHAIN:=$(shell cat nightly-toolchain.txt | tr -d '\n')
 CARGO_RS_CHECK_TOOLCHAIN:=+$(RS_CHECK_TOOLCHAIN)


### PR DESCRIPTION
https://www.gnu.org/software/make/manual/html_node/Choosing-the-Shell.html

- the -u option was triggering some errors on a bench machine, reviewing the documentation systems likely do not expect a -u in default make shellflags, so let's use a default that's advertised
