### PR TITLE
[feat] API for selective decompression of `CompressedXofKeySet`

### DIFF
--- a/tfhe-benchmark/Cargo.toml
+++ b/tfhe-benchmark/Cargo.toml
@@ -95,6 +95,12 @@ harness = false
 required-features = ["integer", "internal-keycache"]
 
 [[bench]]
+name = "hlapi-xof-keyset-decompress"
+path = "benches/high_level_api/xof_keyset_decompress.rs"
+harness = false
+required-features = ["integer", "internal-keycache"]
+
+[[bench]]
 name = "hlapi-bitonic-shuffle"
 path = "benches/high_level_api/bitonic_shuffle.rs"
 harness = false

--- a/tfhe-benchmark/benches/high_level_api/xof_keyset_decompress.rs
+++ b/tfhe-benchmark/benches/high_level_api/xof_keyset_decompress.rs
@@ -1,0 +1,137 @@
+//! Sanity-check microbench for selective decompression of a `CompressedXofKeySet`.
+//!
+//! `full` decompresses the whole key set; `all_parts_one_by_one` fetches every part through the
+//! selective API; `kms_subset` fetches only what `NoiseFloodSmall` needs. The `_parallel` variants
+//! fetch concurrently via rayon — the independent per-part walks need no coordination.
+
+use benchmark::params_aliases::{
+    BENCH_COMP_NOISE_SQUASHING_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+    BENCH_COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+    BENCH_NOISE_SQUASHING_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+    BENCH_PARAM_KEYSWITCH_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+    BENCH_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+    BENCH_PARAM_PKE_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+};
+use criterion::{criterion_group, criterion_main, Criterion};
+use std::hint::black_box;
+use tfhe::core_crypto::prelude::NormalizedHammingWeightBound;
+use tfhe::integer::ciphertext::NoiseSquashingCompressionKey;
+use tfhe::integer::compression_keys::{CompressionKey, DecompressionKey};
+use tfhe::integer::key_switching_key::KeySwitchingKeyMaterial;
+use tfhe::integer::noise_squashing::NoiseSquashingKey;
+use tfhe::integer::oprf::OprfServerKey;
+use tfhe::integer::ServerKey;
+use tfhe::xof_key_set::CompressedXofKeySet;
+use tfhe::{CompactPublicKey, ConfigBuilder, ReRandomizationKey, Tag};
+
+fn xof_keyset_decompress(c: &mut Criterion) {
+    let config =
+        ConfigBuilder::with_custom_parameters(BENCH_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128)
+            .use_dedicated_compact_public_key_parameters((
+                BENCH_PARAM_PKE_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+                BENCH_PARAM_KEYSWITCH_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+            ))
+            .enable_compression(BENCH_COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128)
+            .enable_noise_squashing(
+                BENCH_NOISE_SQUASHING_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+            )
+            .enable_noise_squashing_compression(
+                BENCH_COMP_NOISE_SQUASHING_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+            )
+            .build();
+
+    let (_client_key, key_set) = CompressedXofKeySet::generate(
+        config,
+        vec![0u8; 32],
+        128,
+        NormalizedHammingWeightBound::new(0.8).unwrap(),
+        Tag::default(),
+    )
+    .unwrap();
+    let key_set = black_box(key_set);
+
+    let mut group = c.benchmark_group("xof_keyset_decompress");
+
+    group.bench_function("full", |b| b.iter(|| key_set.decompress()));
+
+    group.bench_function("all_parts_one_by_one", |b| {
+        b.iter(|| {
+            (
+                key_set.decompress_parts::<CompactPublicKey>(),
+                key_set.decompress_parts::<ServerKey>(),
+                key_set.decompress_parts::<Option<KeySwitchingKeyMaterial>>(),
+                key_set.decompress_parts::<Option<CompressionKey>>(),
+                key_set.decompress_parts::<Option<DecompressionKey>>(),
+                key_set.decompress_parts::<Option<NoiseSquashingKey>>(),
+                key_set.decompress_parts::<Option<NoiseSquashingCompressionKey>>(),
+                key_set.decompress_parts::<Option<ReRandomizationKey>>(),
+                key_set.decompress_parts::<Option<OprfServerKey>>(),
+            )
+        })
+    });
+
+    group.bench_function("kms_subset", |b| {
+        b.iter(|| {
+            key_set.decompress_parts::<(
+                ServerKey,
+                Option<DecompressionKey>,
+                Option<NoiseSquashingKey>,
+            )>()
+        })
+    });
+
+    // The `_parallel` variants fetch their parts concurrently: each part walks the seed
+    // independently, so the tasks need no coordination.
+    group.bench_function("all_parts_parallel", |b| {
+        b.iter(|| {
+            rayon::scope(|s| {
+                s.spawn(|_| {
+                    black_box(key_set.decompress_parts::<CompactPublicKey>());
+                });
+                s.spawn(|_| {
+                    black_box(key_set.decompress_parts::<ServerKey>());
+                });
+                s.spawn(|_| {
+                    black_box(key_set.decompress_parts::<Option<KeySwitchingKeyMaterial>>());
+                });
+                s.spawn(|_| {
+                    black_box(key_set.decompress_parts::<Option<CompressionKey>>());
+                });
+                s.spawn(|_| {
+                    black_box(key_set.decompress_parts::<Option<DecompressionKey>>());
+                });
+                s.spawn(|_| {
+                    black_box(key_set.decompress_parts::<Option<NoiseSquashingKey>>());
+                });
+                s.spawn(|_| {
+                    black_box(key_set.decompress_parts::<Option<NoiseSquashingCompressionKey>>());
+                });
+                s.spawn(|_| {
+                    black_box(key_set.decompress_parts::<Option<ReRandomizationKey>>());
+                });
+                s.spawn(|_| {
+                    black_box(key_set.decompress_parts::<Option<OprfServerKey>>());
+                });
+            });
+        })
+    });
+
+    group.bench_function("kms_subset_parallel", |b| {
+        b.iter(|| {
+            rayon::join(
+                || key_set.decompress_parts::<ServerKey>(),
+                || {
+                    rayon::join(
+                        || key_set.decompress_parts::<Option<DecompressionKey>>(),
+                        || key_set.decompress_parts::<Option<NoiseSquashingKey>>(),
+                    )
+                },
+            )
+        })
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, xof_keyset_decompress);
+criterion_main!(benches);

--- a/tfhe/src/core_crypto/algorithms/test/lwe_compact_public_key_generation.rs
+++ b/tfhe/src/core_crypto/algorithms/test/lwe_compact_public_key_generation.rs
@@ -1,5 +1,6 @@
 use super::*;
-use crate::core_crypto::commons::generators::DeterministicSeeder;
+use crate::core_crypto::commons::generators::{DeterministicSeeder, MaskRandomGenerator};
+use crate::core_crypto::commons::math::random::Uniform;
 
 #[cfg(not(tarpaulin))]
 const NB_TESTS: usize = 10;
@@ -85,4 +86,58 @@ fn test_seeded_lwe_cpk_gen_equivalence_u32_native_mod() {
 #[test]
 fn test_seeded_lwe_cpk_gen_equivalence_u64_naive_mod() {
     test_seeded_lwe_cpk_gen_equivalence::<u64>(CiphertextModulus::new_native());
+}
+
+/// Verify a generator forked by `decompression_fork_config` is fully exhausted after the
+/// decompression call (its mask budget matches what decompression consumes).
+fn test_seeded_lwe_cpk_decompression_fork_config_exhaustion<Scalar: UnsignedTorus>(
+    ciphertext_modulus: CiphertextModulus<Scalar>,
+) {
+    // `SeededLweCompactPublicKey` requires a power-of-2 lwe dimension.
+    let lwe_dimension = LweDimension(1024);
+
+    let mut seeder = new_seeder();
+    let seed = seeder.as_mut().seed();
+
+    // Contents don't affect byte consumption, so a zeroed seeded key suffices.
+    let seeded_cpk = SeededLweCompactPublicKey::new(
+        Scalar::ZERO,
+        lwe_dimension,
+        seed.into(),
+        ciphertext_modulus,
+    );
+
+    let mut output_cpk = LweCompactPublicKey::new(Scalar::ZERO, lwe_dimension, ciphertext_modulus);
+
+    let mut generator =
+        MaskRandomGenerator::<DefaultRandomGenerator>::new(seeded_cpk.compression_seed());
+    let mut child = generator
+        .try_fork_from_config(seeded_cpk.decompression_fork_config(Uniform))
+        .expect("failed to fork generator")
+        .next()
+        .expect("decompression_fork_config must yield exactly one child");
+
+    decompress_seeded_lwe_compact_public_key_with_pre_seeded_generator(
+        &mut output_cpk,
+        &seeded_cpk,
+        &mut child,
+    );
+
+    assert_eq!(
+        child.remaining_bytes(),
+        Some(0),
+        "mask generator must be exhausted after compact public key decompression",
+    );
+}
+
+#[test]
+fn test_seeded_lwe_cpk_decompression_fork_config_exhaustion_u64_native_mod() {
+    test_seeded_lwe_cpk_decompression_fork_config_exhaustion::<u64>(CiphertextModulus::new_native());
+}
+
+#[test]
+fn test_seeded_lwe_cpk_decompression_fork_config_exhaustion_u64_custom_mod() {
+    test_seeded_lwe_cpk_decompression_fork_config_exhaustion::<u64>(
+        CiphertextModulus::try_new_power_of_2(63).unwrap(),
+    );
 }

--- a/tfhe/src/core_crypto/algorithms/test/lwe_packing_keyswitch_key_generation.rs
+++ b/tfhe/src/core_crypto/algorithms/test/lwe_packing_keyswitch_key_generation.rs
@@ -1,5 +1,6 @@
 use super::*;
-use crate::core_crypto::commons::generators::DeterministicSeeder;
+use crate::core_crypto::commons::generators::{DeterministicSeeder, MaskRandomGenerator};
+use crate::core_crypto::commons::math::random::Uniform;
 
 #[cfg(not(tarpaulin))]
 const NB_TESTS: usize = 10;
@@ -121,4 +122,62 @@ fn test_seeded_lwe_pksk_gen_equivalence_u32_custom_mod() {
 #[test]
 fn test_seeded_lwe_pksk_gen_equivalence_u64_custom_mod() {
     test_seeded_lwe_pksk_gen_equivalence::<u64>(CiphertextModulus::try_new_power_of_2(63).unwrap());
+}
+
+/// Verify a generator forked by `decompression_fork_config` is fully exhausted after the
+/// decompression call (its mask budget matches what decompression consumes).
+fn test_seeded_lwe_pksk_decompression_fork_config_exhaustion<Scalar: UnsignedTorus>(
+    ciphertext_modulus: CiphertextModulus<Scalar>,
+) {
+    let input_lwe_dimension = LweDimension(742);
+    let output_glwe_dimension = GlweDimension(1);
+    let output_polynomial_size = PolynomialSize(2048);
+    let decomp_base_log = DecompositionBaseLog(3);
+    let decomp_level_count = DecompositionLevelCount(5);
+
+    let mut seeder = new_seeder();
+    let seed = seeder.as_mut().seed();
+
+    // Contents don't affect byte consumption, so a zeroed seeded key suffices.
+    let seeded_pksk = SeededLwePackingKeyswitchKey::new(
+        Scalar::ZERO,
+        decomp_base_log,
+        decomp_level_count,
+        input_lwe_dimension,
+        output_glwe_dimension,
+        output_polynomial_size,
+        seed.into(),
+        ciphertext_modulus,
+    );
+
+    let mut generator =
+        MaskRandomGenerator::<DefaultRandomGenerator>::new(seeded_pksk.compression_seed());
+    let mut child = generator
+        .try_fork_from_config(seeded_pksk.decompression_fork_config(Uniform))
+        .expect("failed to fork generator")
+        .next()
+        .expect("decompression_fork_config must yield exactly one child");
+
+    let _decompressed =
+        seeded_pksk.decompress_to_lwe_packing_keyswitch_key_with_pre_seeded_generator(&mut child);
+
+    assert_eq!(
+        child.remaining_bytes(),
+        Some(0),
+        "mask generator must be exhausted after packing keyswitch key decompression",
+    );
+}
+
+#[test]
+fn test_seeded_lwe_pksk_decompression_fork_config_exhaustion_u64_native_mod() {
+    test_seeded_lwe_pksk_decompression_fork_config_exhaustion::<u64>(
+        CiphertextModulus::new_native(),
+    );
+}
+
+#[test]
+fn test_seeded_lwe_pksk_decompression_fork_config_exhaustion_u64_custom_mod() {
+    test_seeded_lwe_pksk_decompression_fork_config_exhaustion::<u64>(
+        CiphertextModulus::try_new_power_of_2(63).unwrap(),
+    );
 }

--- a/tfhe/src/core_crypto/commons/generators/encryption/mask_random_generator.rs
+++ b/tfhe/src/core_crypto/commons/generators/encryption/mask_random_generator.rs
@@ -80,6 +80,13 @@ impl MaskRandomGeneratorForkConfig {
     pub fn mask_byte_count_per_child(&self) -> EncryptionMaskByteCount {
         self.mask_byte_count_per_child
     }
+
+    pub fn byte_count(&self) -> EncryptionMaskByteCount {
+        self.children_count
+            .checked_mul(self.mask_byte_count_per_child.0)
+            .map(EncryptionMaskByteCount)
+            .expect("mask byte count overflow")
+    }
 }
 
 /// Generator dedicated to filling masks.
@@ -167,6 +174,14 @@ impl<G: ByteRandomGenerator> MaskRandomGenerator<G> {
             fork_config.children_count,
             fork_config.mask_byte_count_per_child,
         )
+    }
+
+    /// Advance the generator past `mask_bytes` worth of mask bytes, producing nothing.
+    pub fn skip(&mut self, mask_bytes: EncryptionMaskByteCount) {
+        // Forking advances the parent eagerly, so the lazy children are dropped unconsumed.
+        let _ = self
+            .try_fork(1, mask_bytes)
+            .expect("infallible: unbounded mask gen with non-zero sized child");
     }
 }
 

--- a/tfhe/src/core_crypto/entities/seeded_lwe_compact_public_key.rs
+++ b/tfhe/src/core_crypto/entities/seeded_lwe_compact_public_key.rs
@@ -5,7 +5,10 @@ use tfhe_versionable::Versionize;
 use crate::conformance::ParameterSetConformant;
 use crate::core_crypto::algorithms::decompress_seeded_lwe_compact_public_key;
 use crate::core_crypto::backward_compatibility::entities::seeded_lwe_compact_public_key::SeededLweCompactPublicKeyVersions;
-use crate::core_crypto::commons::math::random::{CompressionSeed, DefaultRandomGenerator};
+use crate::core_crypto::commons::generators::MaskRandomGeneratorForkConfig;
+use crate::core_crypto::commons::math::random::{
+    CompressionSeed, DefaultRandomGenerator, Distribution, RandomGenerable,
+};
 use crate::core_crypto::commons::parameters::*;
 use crate::core_crypto::commons::traits::*;
 use crate::core_crypto::entities::*;
@@ -164,6 +167,28 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> SeededLweCompactPu
     /// [`SeededLweCompactPublicKey`].
     pub fn as_seeded_glwe_ciphertext(&self) -> SeededGlweCiphertextView<'_, Scalar> {
         self.seeded_glwe_ciphertext.as_view()
+    }
+
+    /// Mask generator fork configuration consumed when decompressing this key.
+    pub fn decompression_fork_config<MaskDistribution>(
+        &self,
+        mask_distribution: MaskDistribution,
+    ) -> MaskRandomGeneratorForkConfig
+    where
+        MaskDistribution: Distribution,
+        Scalar: RandomGenerable<MaskDistribution, CustomModulus = Scalar>,
+    {
+        let glwe = self.as_seeded_glwe_ciphertext();
+        let mask_sample_count = glwe_ciphertext_encryption_mask_sample_count(
+            glwe.glwe_size().to_glwe_dimension(),
+            glwe.polynomial_size(),
+        );
+
+        let modulus = self
+            .ciphertext_modulus()
+            .get_custom_modulus_as_optional_scalar();
+
+        MaskRandomGeneratorForkConfig::new(1, mask_sample_count, mask_distribution, modulus)
     }
 
     /// Consume the [`SeededLweCompactPublicKey`] and decompress it into a standard

--- a/tfhe/src/core_crypto/entities/seeded_lwe_packing_keyswitch_key.rs
+++ b/tfhe/src/core_crypto/entities/seeded_lwe_packing_keyswitch_key.rs
@@ -3,8 +3,10 @@
 use crate::conformance::ParameterSetConformant;
 use crate::core_crypto::algorithms::*;
 use crate::core_crypto::backward_compatibility::entities::seeded_lwe_packing_keyswitch_key::SeededLwePackingKeyswitchKeyVersions;
-use crate::core_crypto::commons::generators::MaskRandomGenerator;
-use crate::core_crypto::commons::math::random::{CompressionSeed, DefaultRandomGenerator};
+use crate::core_crypto::commons::generators::{MaskRandomGenerator, MaskRandomGeneratorForkConfig};
+use crate::core_crypto::commons::math::random::{
+    CompressionSeed, DefaultRandomGenerator, Distribution, RandomGenerable,
+};
 use crate::core_crypto::commons::parameters::*;
 use crate::core_crypto::commons::traits::*;
 use crate::core_crypto::entities::*;
@@ -347,6 +349,31 @@ impl<Scalar: UnsignedInteger, C: Container<Element = Scalar>> SeededLwePackingKe
 
     pub fn ciphertext_modulus(&self) -> CiphertextModulus<C::Element> {
         self.ciphertext_modulus
+    }
+
+    /// Mask generator fork configuration consumed when decompressing this key.
+    pub fn decompression_fork_config<MaskDistribution>(
+        &self,
+        mask_distribution: MaskDistribution,
+    ) -> MaskRandomGeneratorForkConfig
+    where
+        MaskDistribution: Distribution,
+        Scalar: RandomGenerable<MaskDistribution, CustomModulus = Scalar>,
+    {
+        let glwe_list = self.as_seeded_glwe_ciphertext_list();
+        let per_glwe_mask_sample_count = glwe_ciphertext_encryption_mask_sample_count(
+            glwe_list.glwe_size().to_glwe_dimension(),
+            glwe_list.polynomial_size(),
+        );
+        let total_mask_sample_count = EncryptionMaskSampleCount(
+            glwe_list.glwe_ciphertext_count().0 * per_glwe_mask_sample_count.0,
+        );
+
+        let modulus = self
+            .ciphertext_modulus()
+            .get_custom_modulus_as_optional_scalar();
+
+        MaskRandomGeneratorForkConfig::new(1, total_mask_sample_count, mask_distribution, modulus)
     }
 }
 

--- a/tfhe/src/high_level_api/keys/expanded.rs
+++ b/tfhe/src/high_level_api/keys/expanded.rs
@@ -47,15 +47,96 @@ pub struct IntegerExpandedServerKey {
     pub oprf_key: Option<ExpandedOprfServerKey>,
 }
 
+/// Convert an expanded (standard-domain) compute server key to its CPU (Fourier-domain) form.
+pub(crate) fn compute_key_to_cpu(
+    compute_key: ShortintExpandedServerKey,
+) -> crate::integer::ServerKey {
+    use crate::shortint::atomic_pattern::{
+        AtomicPatternServerKey, KS32AtomicPatternServerKey, StandardAtomicPatternServerKey,
+    };
+
+    let atomic_pattern_key = match compute_key.atomic_pattern {
+        ExpandedAtomicPatternServerKey::Standard(std_ap) => {
+            let ExpandedStandardAtomicPatternServerKey {
+                key_switching_key,
+                bootstrapping_key,
+                pbs_order,
+            } = std_ap;
+            AtomicPatternServerKey::Standard(StandardAtomicPatternServerKey {
+                key_switching_key,
+                bootstrapping_key: bootstrapping_key.into_fourier(),
+                pbs_order,
+            })
+        }
+        ExpandedAtomicPatternServerKey::KeySwitch32(ks32_ap) => {
+            let ExpandedKS32AtomicPatternServerKey {
+                key_switching_key,
+                bootstrapping_key,
+                ciphertext_modulus,
+            } = ks32_ap;
+            AtomicPatternServerKey::KeySwitch32(KS32AtomicPatternServerKey {
+                key_switching_key,
+                bootstrapping_key: bootstrapping_key.into_fourier(),
+                ciphertext_modulus,
+            })
+        }
+    };
+
+    crate::integer::ServerKey::from_raw_parts(crate::shortint::ServerKey::from_raw_parts(
+        atomic_pattern_key,
+        compute_key.message_modulus,
+        compute_key.carry_modulus,
+        compute_key.max_degree,
+        compute_key.max_noise_level,
+    ))
+}
+
+/// Convert an expanded (standard-domain) noise squashing key to its CPU (Fourier-domain) form.
+pub(crate) fn expanded_noise_squashing_key_to_cpu(
+    ns_key: ExpandedNoiseSquashingKey,
+) -> crate::integer::noise_squashing::NoiseSquashingKey {
+    use crate::shortint::noise_squashing::atomic_pattern::ks32::KS32AtomicPatternNoiseSquashingKey;
+    use crate::shortint::noise_squashing::atomic_pattern::standard::StandardAtomicPatternNoiseSquashingKey;
+    use crate::shortint::noise_squashing::atomic_pattern::AtomicPatternNoiseSquashingKey;
+
+    let (ap, msg_mod, carry_mod, ct_mod) = ns_key.into_raw_parts();
+    let ap = match ap {
+        ExpandedAtomicPatternNoiseSquashingKey::Standard(bootstrapping_key) => {
+            AtomicPatternNoiseSquashingKey::Standard(
+                StandardAtomicPatternNoiseSquashingKey::from_raw_parts(
+                    bootstrapping_key.into_fourier(),
+                ),
+            )
+        }
+        ExpandedAtomicPatternNoiseSquashingKey::KeySwitch32(bootstrapping_key) => {
+            AtomicPatternNoiseSquashingKey::KeySwitch32(
+                KS32AtomicPatternNoiseSquashingKey::from_raw_parts(
+                    bootstrapping_key.into_fourier(),
+                ),
+            )
+        }
+    };
+    crate::integer::noise_squashing::NoiseSquashingKey::from_raw_parts(
+        crate::shortint::noise_squashing::NoiseSquashingKey::from_raw_parts(
+            ap, msg_mod, carry_mod, ct_mod,
+        ),
+    )
+}
+
+/// Convert an expanded (standard-domain) decompression key to its CPU (Fourier-domain) form.
+pub(crate) fn expanded_decompression_key_to_cpu(
+    key: ExpandedDecompressionKey,
+) -> crate::integer::compression_keys::DecompressionKey {
+    let ExpandedDecompressionKey { bsk, lwe_per_glwe } = key;
+    let bsk = bsk.into_fourier();
+    crate::integer::compression_keys::DecompressionKey::from_raw_parts(
+        crate::shortint::list_compression::DecompressionKey { bsk, lwe_per_glwe },
+    )
+}
+
 impl IntegerExpandedServerKey {
     pub fn convert_to_cpu(self) -> crate::high_level_api::keys::IntegerServerKey {
         use crate::high_level_api::keys::IntegerServerKey;
-        use crate::shortint::atomic_pattern::{
-            AtomicPatternServerKey, KS32AtomicPatternServerKey, StandardAtomicPatternServerKey,
-        };
-        use crate::shortint::noise_squashing::atomic_pattern::ks32::KS32AtomicPatternNoiseSquashingKey;
-        use crate::shortint::noise_squashing::atomic_pattern::standard::StandardAtomicPatternNoiseSquashingKey;
-        use crate::shortint::noise_squashing::atomic_pattern::AtomicPatternNoiseSquashingKey;
 
         let Self {
             compute_key,
@@ -68,90 +149,15 @@ impl IntegerExpandedServerKey {
             oprf_key,
         } = self;
 
-        let atomic_pattern_key = match compute_key.atomic_pattern {
-            ExpandedAtomicPatternServerKey::Standard(std_ap) => {
-                let ExpandedStandardAtomicPatternServerKey {
-                    key_switching_key,
-                    bootstrapping_key,
-                    pbs_order,
-                } = std_ap;
-
-                let bootstrapping_key = bootstrapping_key.into_fourier();
-
-                AtomicPatternServerKey::Standard(StandardAtomicPatternServerKey {
-                    key_switching_key,
-                    bootstrapping_key,
-                    pbs_order,
-                })
-            }
-            ExpandedAtomicPatternServerKey::KeySwitch32(ks32_ap) => {
-                let ExpandedKS32AtomicPatternServerKey {
-                    key_switching_key,
-                    bootstrapping_key,
-                    ciphertext_modulus,
-                } = ks32_ap;
-
-                let bootstrapping_key = bootstrapping_key.into_fourier();
-
-                AtomicPatternServerKey::KeySwitch32(KS32AtomicPatternServerKey {
-                    key_switching_key,
-                    bootstrapping_key,
-                    ciphertext_modulus,
-                })
-            }
-        };
-
-        let key =
-            crate::integer::ServerKey::from_raw_parts(crate::shortint::ServerKey::from_raw_parts(
-                atomic_pattern_key,
-                compute_key.message_modulus,
-                compute_key.carry_modulus,
-                compute_key.max_degree,
-                compute_key.max_noise_level,
-            ));
-
-        let noise_squashing_key = noise_squashing_key.map(|ns_key| {
-            let (ap, msg_mod, carry_mod, ct_mod) = ns_key.into_raw_parts();
-            let ap = match ap {
-                ExpandedAtomicPatternNoiseSquashingKey::Standard(bootstrapping_key) => {
-                    let bootstrapping_key = bootstrapping_key.into_fourier();
-                    AtomicPatternNoiseSquashingKey::Standard(
-                        StandardAtomicPatternNoiseSquashingKey::from_raw_parts(bootstrapping_key),
-                    )
-                }
-                ExpandedAtomicPatternNoiseSquashingKey::KeySwitch32(bootstrapping_key) => {
-                    let bootstrapping_key = bootstrapping_key.into_fourier();
-                    AtomicPatternNoiseSquashingKey::KeySwitch32(
-                        KS32AtomicPatternNoiseSquashingKey::from_raw_parts(bootstrapping_key),
-                    )
-                }
-            };
-            crate::integer::noise_squashing::NoiseSquashingKey::from_raw_parts(
-                crate::shortint::noise_squashing::NoiseSquashingKey::from_raw_parts(
-                    ap, msg_mod, carry_mod, ct_mod,
-                ),
-            )
-        });
-
-        let decompression_key = decompression_key.map(|key| {
-            let ExpandedDecompressionKey { bsk, lwe_per_glwe } = key;
-            let bsk = bsk.into_fourier();
-            crate::integer::compression_keys::DecompressionKey::from_raw_parts(
-                crate::shortint::list_compression::DecompressionKey { bsk, lwe_per_glwe },
-            )
-        });
-
-        let oprf_key = oprf_key.map(|oprf_key| oprf_key.to_fourier());
-
         IntegerServerKey {
-            key,
+            key: compute_key_to_cpu(compute_key),
             cpk_key_switching_key_material,
             compression_key,
-            decompression_key,
-            noise_squashing_key,
+            decompression_key: decompression_key.map(expanded_decompression_key_to_cpu),
+            noise_squashing_key: noise_squashing_key.map(expanded_noise_squashing_key_to_cpu),
             noise_squashing_compression_key,
             cpk_re_randomization_key,
-            oprf_key,
+            oprf_key: oprf_key.map(|oprf_key| oprf_key.to_fourier()),
         }
     }
 }

--- a/tfhe/src/high_level_api/xof_key_set/internal.rs
+++ b/tfhe/src/high_level_api/xof_key_set/internal.rs
@@ -397,6 +397,13 @@ impl integer::CompressedCompactPublicKey {
         let shortint_pk = shortint::CompactPublicKey::from_raw_parts(pk, shortint_cpk.parameters);
         integer::CompactPublicKey::from_raw_parts(shortint_pk)
     }
+
+    pub(super) fn advance_generator<Gen>(&self, generator: &mut MaskRandomGenerator<Gen>)
+    where
+        Gen: ByteRandomGenerator,
+    {
+        generator.skip(self.key.key.decompression_fork_config(Uniform).byte_count());
+    }
 }
 
 impl CompressedCompactPublicKey {
@@ -426,6 +433,13 @@ impl CompressedCompactPublicKey {
     {
         let integer_pk = self.key.key.decompress_with_pre_seeded_generator(generator);
         CompactPublicKey::from_raw_parts(integer_pk, self.tag.clone())
+    }
+
+    pub(super) fn advance_generator<Gen>(&self, generator: &mut MaskRandomGenerator<Gen>)
+    where
+        Gen: ByteRandomGenerator,
+    {
+        self.key.key.advance_generator(generator);
     }
 }
 
@@ -476,33 +490,11 @@ impl crate::CompressedServerKey {
             .as_ref()
             .map(|k| k.decompress_with_pre_seeded_generator(generator));
 
-        let cpk_re_randomization_key =
-            self.integer_key
-                .cpk_re_randomization_key
-                .as_ref()
-                .map(|k| match k {
-                    CompressedReRandomizationKey::LegacyDedicatedCPK { ksk } => {
-                        let decompressed_ksk = match ksk {
-                            CompressedReRandomizationKeySwitchingKey::UseCPKEncryptionKSK => {
-                                ReRandomizationKeySwitchingKey::UseCPKEncryptionKSK
-                            }
-                            CompressedReRandomizationKeySwitchingKey::DedicatedKSK(key) => {
-                                ReRandomizationKeySwitchingKey::DedicatedKSK(
-                                    key.decompress_with_pre_seeded_generator(generator),
-                                )
-                            }
-                        };
-
-                        ReRandomizationKey::LegacyDedicatedCPK {
-                            ksk: decompressed_ksk,
-                        }
-                    }
-                    CompressedReRandomizationKey::DerivedCPKWithoutKeySwitch { cpk } => {
-                        ReRandomizationKey::DerivedCPKWithoutKeySwitch {
-                            cpk: cpk.decompress_with_pre_seeded_generator(generator),
-                        }
-                    }
-                });
+        let cpk_re_randomization_key = self
+            .integer_key
+            .cpk_re_randomization_key
+            .as_ref()
+            .map(|k| k.decompress_with_pre_seeded_generator(generator));
 
         let noise_squashing_compression_key = self
             .integer_key
@@ -587,6 +579,18 @@ impl integer::compression_keys::CompressedCompressionKey {
                 storage_log_modulus: self.key.storage_log_modulus,
             },
         }
+    }
+
+    pub(super) fn advance_generator<Gen>(&self, generator: &mut MaskRandomGenerator<Gen>)
+    where
+        Gen: ByteRandomGenerator,
+    {
+        generator.skip(
+            self.key
+                .packing_key_switching_key
+                .decompression_fork_config(Uniform)
+                .byte_count(),
+        );
     }
 }
 
@@ -678,6 +682,13 @@ impl integer::compression_keys::CompressedDecompressionKey {
             bsk: bsk.decompress_with_pre_seeded_generator(generator),
             lwe_per_glwe,
         }
+    }
+
+    pub(super) fn advance_generator<Gen>(&self, generator: &mut MaskRandomGenerator<Gen>)
+    where
+        Gen: ByteRandomGenerator,
+    {
+        self.key.bsk.advance_generator(generator);
     }
 }
 
@@ -882,6 +893,24 @@ impl CompressedNoiseSquashingKey {
             self.key.carry_modulus(),
             self.key.output_ciphertext_modulus(),
         )
+    }
+
+    pub(super) fn advance_generator<Gen>(&self, generator: &mut MaskRandomGenerator<Gen>)
+    where
+        Gen: ByteRandomGenerator,
+    {
+        match self.key.atomic_pattern() {
+            CompressedAtomicPatternNoiseSquashingKey::Standard(compressed_std) => {
+                compressed_std
+                    .bootstrapping_key()
+                    .advance_generator(generator);
+            }
+            CompressedAtomicPatternNoiseSquashingKey::KeySwitch32(compressed_ks32) => {
+                compressed_ks32
+                    .bootstrapping_key()
+                    .advance_generator(generator);
+            }
+        }
     }
 }
 
@@ -1134,6 +1163,19 @@ impl CompressedKS32AtomicPatternServerKey {
             ciphertext_modulus: self.bootstrapping_key().ciphertext_modulus(),
         }
     }
+
+    pub(super) fn advance_generator<Gen>(&self, mask_generator: &mut MaskRandomGenerator<Gen>)
+    where
+        Gen: ByteRandomGenerator,
+    {
+        mask_generator.skip(
+            self.key_switching_key()
+                .as_seeded_lwe_ciphertext_list()
+                .decompression_fork_config(Uniform)
+                .byte_count(),
+        );
+        self.bootstrapping_key().advance_generator(mask_generator);
+    }
 }
 
 impl KS32AtomicPatternClientKey {
@@ -1229,6 +1271,16 @@ impl CompressedAtomicPatternServerKey {
             ),
         }
     }
+
+    pub(super) fn advance_generator<Gen>(&self, mask_generator: &mut MaskRandomGenerator<Gen>)
+    where
+        Gen: ByteRandomGenerator,
+    {
+        match self {
+            Self::Standard(std_ap) => std_ap.advance_generator(mask_generator),
+            Self::KeySwitch32(ks32_ap) => ks32_ap.advance_generator(mask_generator),
+        }
+    }
 }
 
 impl<ModSwitchScalar> ShortintCompressedBootstrappingKey<ModSwitchScalar>
@@ -1285,6 +1337,27 @@ where
             }
         }
     }
+
+    fn advance_generator<Gen>(&self, mask_generator: &mut MaskRandomGenerator<Gen>)
+    where
+        Gen: ByteRandomGenerator,
+    {
+        match self {
+            Self::Classic {
+                bsk,
+                modulus_switch_noise_reduction_key,
+            } => {
+                mask_generator.skip(bsk.decompression_fork_config(Uniform).byte_count());
+                modulus_switch_noise_reduction_key.advance_generator(mask_generator);
+            }
+            Self::MultiBit {
+                seeded_bsk,
+                deterministic_execution: _,
+            } => {
+                mask_generator.skip(seeded_bsk.decompression_fork_config(Uniform).byte_count());
+            }
+        }
+    }
 }
 
 impl<ModSwitchScalar> CompressedShortint128BootstrappingKey<ModSwitchScalar>
@@ -1329,6 +1402,28 @@ where
                     thread_count: *thread_count,
                     deterministic_execution: true,
                 }
+            }
+        }
+    }
+
+    fn advance_generator<Gen>(&self, mask_generator: &mut MaskRandomGenerator<Gen>)
+    where
+        Gen: ByteRandomGenerator,
+    {
+        match self {
+            Self::Classic {
+                bsk,
+                modulus_switch_noise_reduction_key,
+            } => {
+                mask_generator.skip(bsk.decompression_fork_config(Uniform).byte_count());
+                modulus_switch_noise_reduction_key.advance_generator(mask_generator);
+            }
+            Self::MultiBit {
+                bsk,
+                thread_count: _,
+                deterministic_execution: _,
+            } => {
+                mask_generator.skip(bsk.decompression_fork_config(Uniform).byte_count());
             }
         }
     }
@@ -1441,6 +1536,19 @@ impl CompressedStandardAtomicPatternServerKey {
             pbs_order: self.pbs_order(),
         }
     }
+
+    pub(super) fn advance_generator<Gen>(&self, mask_generator: &mut MaskRandomGenerator<Gen>)
+    where
+        Gen: ByteRandomGenerator,
+    {
+        mask_generator.skip(
+            self.key_switching_key()
+                .as_seeded_lwe_ciphertext_list()
+                .decompression_fork_config(Uniform)
+                .byte_count(),
+        );
+        self.bootstrapping_key().advance_generator(mask_generator);
+    }
 }
 
 impl CompressedNoiseSquashingCompressionKey {
@@ -1507,6 +1615,18 @@ impl CompressedNoiseSquashingCompressionKey {
             ),
         }
     }
+
+    pub(super) fn advance_generator<Gen>(&self, generator: &mut MaskRandomGenerator<Gen>)
+    where
+        Gen: ByteRandomGenerator,
+    {
+        generator.skip(
+            self.key
+                .packing_key_switching_key
+                .decompression_fork_config(Uniform)
+                .byte_count(),
+        );
+    }
 }
 impl CompressedKeySwitchingKeyMaterial {
     pub(super) fn decompress_with_pre_seeded_generator<Gen>(
@@ -1538,6 +1658,66 @@ impl CompressedKeySwitchingKeyMaterial {
             destination_atomic_pattern: self.material.destination_atomic_pattern,
         };
         KeySwitchingKeyMaterial::from_raw_parts(shortint_cpk_ksk)
+    }
+
+    pub(super) fn advance_generator<Gen>(&self, generator: &mut MaskRandomGenerator<Gen>)
+    where
+        Gen: ByteRandomGenerator,
+    {
+        generator.skip(
+            self.material
+                .key_switching_key
+                .as_seeded_lwe_ciphertext_list()
+                .decompression_fork_config(Uniform)
+                .byte_count(),
+        );
+    }
+}
+
+impl CompressedReRandomizationKey {
+    pub(super) fn decompress_with_pre_seeded_generator<Gen>(
+        &self,
+        generator: &mut MaskRandomGenerator<Gen>,
+    ) -> ReRandomizationKey
+    where
+        Gen: ByteRandomGenerator,
+    {
+        match self {
+            Self::LegacyDedicatedCPK { ksk } => {
+                let ksk = match ksk {
+                    CompressedReRandomizationKeySwitchingKey::UseCPKEncryptionKSK => {
+                        ReRandomizationKeySwitchingKey::UseCPKEncryptionKSK
+                    }
+                    CompressedReRandomizationKeySwitchingKey::DedicatedKSK(key) => {
+                        ReRandomizationKeySwitchingKey::DedicatedKSK(
+                            key.decompress_with_pre_seeded_generator(generator),
+                        )
+                    }
+                };
+
+                ReRandomizationKey::LegacyDedicatedCPK { ksk }
+            }
+            Self::DerivedCPKWithoutKeySwitch { cpk } => {
+                ReRandomizationKey::DerivedCPKWithoutKeySwitch {
+                    cpk: cpk.decompress_with_pre_seeded_generator(generator),
+                }
+            }
+        }
+    }
+
+    pub(super) fn advance_generator<Gen>(&self, generator: &mut MaskRandomGenerator<Gen>)
+    where
+        Gen: ByteRandomGenerator,
+    {
+        match self {
+            Self::LegacyDedicatedCPK { ksk } => match ksk {
+                CompressedReRandomizationKeySwitchingKey::UseCPKEncryptionKSK => {}
+                CompressedReRandomizationKeySwitchingKey::DedicatedKSK(key) => {
+                    key.advance_generator(generator);
+                }
+            },
+            Self::DerivedCPKWithoutKeySwitch { cpk } => cpk.advance_generator(generator),
+        }
     }
 }
 
@@ -1669,6 +1849,17 @@ where
             ms_input_variance: self.ms_input_variance,
         }
     }
+
+    pub(crate) fn advance_generator<Gen>(&self, generator: &mut MaskRandomGenerator<Gen>)
+    where
+        Gen: ByteRandomGenerator,
+    {
+        generator.skip(
+            self.modulus_switch_zeros
+                .decompression_fork_config(Uniform)
+                .byte_count(),
+        );
+    }
 }
 
 impl<Scalar> CompressedModulusSwitchConfiguration<Scalar>
@@ -1731,6 +1922,16 @@ where
                     key.decompress_with_pre_seeded_generator(generator),
                 )
             }
+        }
+    }
+
+    pub(crate) fn advance_generator<Gen>(&self, generator: &mut MaskRandomGenerator<Gen>)
+    where
+        Gen: ByteRandomGenerator,
+    {
+        match self {
+            Self::Standard | Self::CenteredMeanNoiseReduction => {}
+            Self::DriftTechniqueNoiseReduction(key) => key.advance_generator(generator),
         }
     }
 }

--- a/tfhe/src/high_level_api/xof_key_set/mod.rs
+++ b/tfhe/src/high_level_api/xof_key_set/mod.rs
@@ -1,6 +1,9 @@
 mod internal;
+mod parts;
 #[cfg(test)]
 mod test;
+
+pub use parts::XofParts;
 
 use crate::backward_compatibility::xof_key_set::{
     CompressedXofKeySetVersions, XofSeedStartVersions,

--- a/tfhe/src/high_level_api/xof_key_set/parts.rs
+++ b/tfhe/src/high_level_api/xof_key_set/parts.rs
@@ -1,0 +1,461 @@
+//! Selective decompression: fetch individual parts of a [`CompressedXofKeySet`] without
+//! materializing the whole server key.
+//!
+//! Each call rebuilds a fresh mask generator from the seed and fast-forwards (skips) past every
+//! component preceding the requested one, so calls are independent and order-free.
+
+use super::CompressedXofKeySet;
+use crate::core_crypto::commons::generators::MaskRandomGenerator;
+use crate::core_crypto::prelude::DefaultRandomGenerator;
+use crate::high_level_api::keys::expanded::{
+    compute_key_to_cpu, expanded_decompression_key_to_cpu, expanded_noise_squashing_key_to_cpu,
+    ShortintExpandedServerKey,
+};
+use crate::high_level_api::keys::ReRandomizationKey;
+use crate::integer::ciphertext::NoiseSquashingCompressionKey;
+use crate::integer::compression_keys::{CompressionKey, DecompressionKey};
+use crate::integer::key_switching_key::KeySwitchingKeyMaterial;
+use crate::integer::noise_squashing::NoiseSquashingKey;
+use crate::integer::oprf::OprfServerKey;
+use crate::prelude::Tagged;
+use crate::{integer, CompactPublicKey};
+
+/// Position of a component in the XOF mask stream (its generation/decompression order).
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum Slot {
+    PublicKey,
+    Compression,
+    Decompression,
+    Compute,
+    NoiseSquashing,
+    CpkKsk,
+    ReRand,
+    NsCompression,
+    Oprf,
+}
+
+mod sealed {
+    pub trait Sealed {}
+}
+use self::sealed::Sealed;
+
+/// A selection of parts that can be decompressed from a [`CompressedXofKeySet`] via
+/// [`CompressedXofKeySet::decompress_parts`].
+///
+/// The trait is sealed. Implemented for `CompactPublicKey`, the compute `integer::ServerKey`,
+/// `Option<K>` of each optional part, and tuples of these.
+pub trait XofParts: Sized + Sealed {
+    #[doc(hidden)]
+    fn decompress_parts(keyset: &CompressedXofKeySet) -> Self;
+}
+
+impl CompressedXofKeySet {
+    /// Decompress only the requested part(s).
+    ///
+    /// `K` selects what is returned: an always-present part (the public key or the compute server
+    /// key), an `Option` of any optional key, or a tuple of up to four of these.
+    pub fn decompress_parts<K: XofParts>(&self) -> K {
+        K::decompress_parts(self)
+    }
+
+    /// A fresh mask generator seeded from the key set, fast-forwarded to `target`'s position by
+    /// skipping every present component before it.
+    fn generator_at(&self, target: Slot) -> MaskRandomGenerator<DefaultRandomGenerator> {
+        #[allow(clippy::enum_glob_use)]
+        use Slot::*;
+
+        let mut gen = MaskRandomGenerator::new(self.seed.clone());
+        let icsk = &self.compressed_server_key.integer_key;
+
+        // Skip each present component, in stream order, until we reach `target`.
+        for slot in [
+            PublicKey,
+            Compression,
+            Decompression,
+            Compute,
+            NoiseSquashing,
+            CpkKsk,
+            ReRand,
+            NsCompression,
+            Oprf,
+        ] {
+            if slot >= target {
+                break;
+            }
+            match slot {
+                PublicKey => self.compressed_public_key.advance_generator(&mut gen),
+                Compression => {
+                    if let Some(k) = icsk.compression_key.as_ref() {
+                        k.advance_generator(&mut gen);
+                    }
+                }
+                Decompression => {
+                    if let Some(k) = icsk.decompression_key.as_ref() {
+                        k.advance_generator(&mut gen);
+                    }
+                }
+                Compute => icsk
+                    .key
+                    .key
+                    .compressed_ap_server_key
+                    .advance_generator(&mut gen),
+                NoiseSquashing => {
+                    if let Some(k) = icsk.noise_squashing_key.as_ref() {
+                        k.advance_generator(&mut gen);
+                    }
+                }
+                CpkKsk => {
+                    if let Some(k) = icsk.cpk_key_switching_key_material.as_ref() {
+                        k.advance_generator(&mut gen);
+                    }
+                }
+                ReRand => {
+                    if let Some(k) = icsk.cpk_re_randomization_key.as_ref() {
+                        k.advance_generator(&mut gen);
+                    }
+                }
+                NsCompression => {
+                    if let Some(k) = icsk.noise_squashing_compression_key.as_ref() {
+                        k.advance_generator(&mut gen);
+                    }
+                }
+                Oprf => break,
+            }
+        }
+
+        gen
+    }
+}
+
+impl Sealed for CompactPublicKey {}
+impl XofParts for CompactPublicKey {
+    fn decompress_parts(keyset: &CompressedXofKeySet) -> Self {
+        let mut gen = keyset.generator_at(Slot::PublicKey);
+
+        let mut public_key = keyset
+            .compressed_public_key
+            .decompress_with_pre_seeded_generator(&mut gen);
+        // Server key tag is the source of truth.
+        public_key
+            .tag_mut()
+            .set_data(keyset.compressed_server_key.tag.data());
+        public_key
+    }
+}
+
+impl Sealed for integer::ServerKey {}
+impl XofParts for integer::ServerKey {
+    fn decompress_parts(keyset: &CompressedXofKeySet) -> Self {
+        let mut gen = keyset.generator_at(Slot::Compute);
+        let shortint_csk = &keyset.compressed_server_key.integer_key.key.key;
+
+        let compute_key = ShortintExpandedServerKey {
+            atomic_pattern: shortint_csk
+                .compressed_ap_server_key
+                .decompress_with_pre_seeded_generator(&mut gen),
+            message_modulus: shortint_csk.message_modulus,
+            carry_modulus: shortint_csk.carry_modulus,
+            max_degree: shortint_csk.max_degree,
+            max_noise_level: shortint_csk.max_noise_level,
+            ciphertext_modulus: shortint_csk.ciphertext_modulus(),
+        };
+        compute_key_to_cpu(compute_key)
+    }
+}
+
+impl Sealed for CompressionKey {}
+impl XofParts for Option<CompressionKey> {
+    fn decompress_parts(keyset: &CompressedXofKeySet) -> Self {
+        let compressed = keyset
+            .compressed_server_key
+            .integer_key
+            .compression_key
+            .as_ref()?;
+        let mut gen = keyset.generator_at(Slot::Compression);
+        Some(compressed.decompress_with_pre_seeded_generator(&mut gen))
+    }
+}
+
+impl Sealed for DecompressionKey {}
+impl XofParts for Option<DecompressionKey> {
+    fn decompress_parts(keyset: &CompressedXofKeySet) -> Self {
+        let compressed = keyset
+            .compressed_server_key
+            .integer_key
+            .decompression_key
+            .as_ref()?;
+        let mut gen = keyset.generator_at(Slot::Decompression);
+        Some(expanded_decompression_key_to_cpu(
+            compressed.decompress_with_pre_seeded_generator(&mut gen),
+        ))
+    }
+}
+
+impl Sealed for NoiseSquashingKey {}
+impl XofParts for Option<NoiseSquashingKey> {
+    fn decompress_parts(keyset: &CompressedXofKeySet) -> Self {
+        let compressed = keyset
+            .compressed_server_key
+            .integer_key
+            .noise_squashing_key
+            .as_ref()?;
+        let mut gen = keyset.generator_at(Slot::NoiseSquashing);
+        Some(expanded_noise_squashing_key_to_cpu(
+            compressed.decompress_with_pre_seeded_generator(&mut gen),
+        ))
+    }
+}
+
+impl Sealed for KeySwitchingKeyMaterial {}
+impl XofParts for Option<KeySwitchingKeyMaterial> {
+    fn decompress_parts(keyset: &CompressedXofKeySet) -> Self {
+        let compressed = keyset
+            .compressed_server_key
+            .integer_key
+            .cpk_key_switching_key_material
+            .as_ref()?;
+        let mut gen = keyset.generator_at(Slot::CpkKsk);
+        Some(compressed.decompress_with_pre_seeded_generator(&mut gen))
+    }
+}
+
+impl Sealed for NoiseSquashingCompressionKey {}
+impl XofParts for Option<NoiseSquashingCompressionKey> {
+    fn decompress_parts(keyset: &CompressedXofKeySet) -> Self {
+        let compressed = keyset
+            .compressed_server_key
+            .integer_key
+            .noise_squashing_compression_key
+            .as_ref()?;
+        let mut gen = keyset.generator_at(Slot::NsCompression);
+        Some(compressed.decompress_with_pre_seeded_generator(&mut gen))
+    }
+}
+
+impl Sealed for ReRandomizationKey {}
+impl XofParts for Option<ReRandomizationKey> {
+    fn decompress_parts(keyset: &CompressedXofKeySet) -> Self {
+        let compressed = keyset
+            .compressed_server_key
+            .integer_key
+            .cpk_re_randomization_key
+            .as_ref()?;
+        let mut gen = keyset.generator_at(Slot::ReRand);
+        Some(compressed.decompress_with_pre_seeded_generator(&mut gen))
+    }
+}
+
+impl Sealed for OprfServerKey {}
+impl XofParts for Option<OprfServerKey> {
+    fn decompress_parts(keyset: &CompressedXofKeySet) -> Self {
+        let compressed = keyset.compressed_server_key.integer_key.oprf_key.as_ref()?;
+        let mut gen = keyset.generator_at(Slot::Oprf);
+        Some(
+            compressed
+                .decompress_with_pre_seeded_generator(&mut gen)
+                .to_fourier(),
+        )
+    }
+}
+
+impl<K: Sealed> Sealed for Option<K> {}
+
+impl<A: Sealed, B: Sealed> Sealed for (A, B) {}
+impl<A: XofParts, B: XofParts> XofParts for (A, B) {
+    fn decompress_parts(keyset: &CompressedXofKeySet) -> Self {
+        (A::decompress_parts(keyset), B::decompress_parts(keyset))
+    }
+}
+
+impl<A: Sealed, B: Sealed, C: Sealed> Sealed for (A, B, C) {}
+impl<A: XofParts, B: XofParts, C: XofParts> XofParts for (A, B, C) {
+    fn decompress_parts(keyset: &CompressedXofKeySet) -> Self {
+        (
+            A::decompress_parts(keyset),
+            B::decompress_parts(keyset),
+            C::decompress_parts(keyset),
+        )
+    }
+}
+
+impl<A: Sealed, B: Sealed, C: Sealed, D: Sealed> Sealed for (A, B, C, D) {}
+impl<A: XofParts, B: XofParts, C: XofParts, D: XofParts> XofParts for (A, B, C, D) {
+    fn decompress_parts(keyset: &CompressedXofKeySet) -> Self {
+        (
+            A::decompress_parts(keyset),
+            B::decompress_parts(keyset),
+            C::decompress_parts(keyset),
+            D::decompress_parts(keyset),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core_crypto::prelude::NormalizedHammingWeightBound;
+    use crate::shortint::parameters::test_params::TEST_META_PARAM_CPU_2_2_KS_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128;
+    use crate::shortint::parameters::{
+        PARAM_KEYSWITCH_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+        PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+        PARAM_PKE_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+    };
+    use crate::{integer, ConfigBuilder, Tag};
+
+    fn generate_keyset(config: crate::Config) -> CompressedXofKeySet {
+        CompressedXofKeySet::generate(
+            config,
+            vec![9u8; 32],
+            128,
+            NormalizedHammingWeightBound::new(0.8).unwrap(),
+            Tag::default(),
+        )
+        .unwrap()
+        .1
+    }
+
+    /// A key set carrying every optional part.
+    fn full_keyset() -> CompressedXofKeySet {
+        generate_keyset(TEST_META_PARAM_CPU_2_2_KS_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128.into())
+    }
+
+    /// A minimal valid key set: a dedicated compact public key (required for an XOF key set) but no
+    /// compression, noise squashing, etc., so most optional parts are absent.
+    fn minimal_keyset() -> CompressedXofKeySet {
+        let config =
+            ConfigBuilder::with_custom_parameters(PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128)
+                .use_dedicated_compact_public_key_parameters((
+                    PARAM_PKE_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+                    PARAM_KEYSWITCH_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+                ))
+                .build();
+        generate_keyset(config)
+    }
+
+    fn ser<T: serde::Serialize>(value: &T) -> Vec<u8> {
+        bincode::serialize(value).unwrap()
+    }
+
+    /// Every single-part fetch must byte-match the corresponding piece of a full
+    /// `decompress().into_raw_parts()`: bare for the always-present parts, `Option` for the rest
+    /// (matching the `Option` from `into_raw_parts`, present or absent).
+    fn assert_single_parts_match(ks: &CompressedXofKeySet) {
+        let (public_key, server_key) = ks.decompress().into_raw_parts();
+        let (
+            isk,
+            cpk_ksk,
+            compression,
+            decompression,
+            noise_squashing,
+            ns_compression,
+            re_rand,
+            oprf,
+            _tag,
+        ) = server_key.into_raw_parts();
+
+        assert_eq!(
+            ser(&ks.decompress_parts::<CompactPublicKey>()),
+            ser(&public_key)
+        );
+        assert_eq!(ser(&ks.decompress_parts::<integer::ServerKey>()), ser(&isk));
+        assert_eq!(
+            ser(&ks.decompress_parts::<Option<KeySwitchingKeyMaterial>>()),
+            ser(&cpk_ksk),
+        );
+        assert_eq!(
+            ser(&ks.decompress_parts::<Option<CompressionKey>>()),
+            ser(&compression),
+        );
+        assert_eq!(
+            ser(&ks.decompress_parts::<Option<DecompressionKey>>()),
+            ser(&decompression),
+        );
+        assert_eq!(
+            ser(&ks.decompress_parts::<Option<NoiseSquashingKey>>()),
+            ser(&noise_squashing),
+        );
+        assert_eq!(
+            ser(&ks.decompress_parts::<Option<NoiseSquashingCompressionKey>>()),
+            ser(&ns_compression),
+        );
+        assert_eq!(
+            ser(&ks.decompress_parts::<Option<ReRandomizationKey>>()),
+            ser(&re_rand),
+        );
+        assert_eq!(
+            ser(&ks.decompress_parts::<Option<OprfServerKey>>()),
+            ser(&oprf),
+        );
+    }
+
+    #[test]
+    fn single_parts_match_full_decompress() {
+        assert_single_parts_match(&full_keyset());
+    }
+
+    /// On a key set missing optional parts, those parts come back as `None` (present ones still
+    /// match). Exercises the `None` path and fast-forwarding past absent components.
+    #[test]
+    fn single_parts_match_minimal_keyset() {
+        let ks = minimal_keyset();
+        assert!(!ks.has_compression_key());
+        assert!(!ks.has_noise_squashing_key());
+        assert!(ks.decompress_parts::<Option<CompressionKey>>().is_none());
+        assert!(ks.decompress_parts::<Option<NoiseSquashingKey>>().is_none());
+        assert_single_parts_match(&ks);
+    }
+
+    // Tuples fetch each element independently; verify the KMS `NoiseFloodSmall` triple and a
+    // four-tuple against a full decompression.
+    #[test]
+    fn tuple_parts_match_full_decompress() {
+        let ks = full_keyset();
+
+        let (_pk, server_key) = ks.decompress().into_raw_parts();
+        let (
+            isk,
+            _cpk_ksk,
+            _compression,
+            decompression,
+            noise_squashing,
+            _ns_comp,
+            _rerand,
+            oprf,
+            _tag,
+        ) = server_key.into_raw_parts();
+
+        let (t_isk, t_decompk, t_snsk): (
+            crate::integer::ServerKey,
+            Option<DecompressionKey>,
+            Option<NoiseSquashingKey>,
+        ) = ks.decompress_parts();
+        assert_eq!(ser(&t_isk), ser(&isk));
+        assert_eq!(ser(&t_decompk), ser(&decompression));
+        assert_eq!(ser(&t_snsk), ser(&noise_squashing));
+
+        let (q_isk, q_decompk, q_snsk, q_oprf): (
+            crate::integer::ServerKey,
+            Option<DecompressionKey>,
+            Option<NoiseSquashingKey>,
+            Option<OprfServerKey>,
+        ) = ks.decompress_parts();
+        assert_eq!(ser(&q_isk), ser(&isk));
+        assert_eq!(ser(&q_decompk), ser(&decompression));
+        assert_eq!(ser(&q_snsk), ser(&noise_squashing));
+        assert_eq!(ser(&q_oprf), ser(&oprf));
+    }
+
+    /// The same part requested twice in one tuple yields two equal copies: each element walks the
+    /// stream independently from the seed, so they don't interfere.
+    #[test]
+    fn repeated_part_in_tuple() {
+        let ks = full_keyset();
+
+        let (a, b): (Option<DecompressionKey>, Option<DecompressionKey>) = ks.decompress_parts();
+        assert!(a.is_some());
+        assert_eq!(ser(&a), ser(&b));
+
+        let (isk_a, isk_b): (integer::ServerKey, integer::ServerKey) = ks.decompress_parts();
+        assert_eq!(ser(&isk_a), ser(&isk_b));
+    }
+}


### PR DESCRIPTION
Currently users of `CompressedXofKeySet` calling `decompress()` must pay the cost of decompressing all nine key parts even though just a subset of keys are actually used.

This is a code sample from a test on the KMS `main` branch:

```rust
            let (pk, server_key) = compressed_keyset.decompress().unwrap().into_raw_parts();
            let (_, _, _, _, _, _, _, oprf_key, _) = server_key.clone().into_raw_parts();
```

After this PR which introduces a `decompress_parts()` API, the above code would look like this:

```rust
            let (pk, oprf_key): (
                tfhe::CompactPublicKey,
                Option<tfhe::integer::oprf::OprfServerKey>,
            ) = compressed_keyset.decompress_parts();
```

The space/time savings in the KMS are fairly substantive, here shown as measured with the `hotpath` profiler using default (production) parameters on a subset of tests that are representative of user/public decryption:

| flow | metric | original | current | delta |
|---|---|---:|---:|---:|
| user decrypt NoiseFlood | runtime | `12.07s` | `6.88s` | `-5.19s` / `-43%` |
| user decrypt NoiseFlood | Hotpath alloc | `13.9 GB` | `8.9 GB` | `-5.0 GB` / `-36%` |
| user decrypt NoiseFlood | sampled RSS | `15.4 GB` | `12.1 GB` | `-3.3 GB` / `-21%` |
| public decrypt NoiseFlood | runtime | `12.13s` | `9.84s` | `-2.29s` / `-19%` |
| public decrypt NoiseFlood | Hotpath alloc | `13.9 GB` | `10.8 GB` | `-3.1 GB` / `-22%` |
| public decrypt NoiseFlood | sampled RSS | `15.4 GB` | `13.5 GB` | `-1.9 GB` / `-12%` |

The PR contains a benchmark that is mostly there to prove that the overhead of selective decompression is low. One benchmark measures a full `decompress()` call and another shows that decompressing each component one by one has less than 10% overhead. For use cases that only select a subset of keys the overhead is definitely worth it.

As a hint of possible follow-up work, the benchmarks also include a couple of `rayon` variants, showing how this PR provides the machinery necessary for decompressing keys in parallel.

Results on my laptop:

| variant | time | × full |
|---|---:|---:|
| `full` (`decompress()`) | 1.97 s | 1.00× |
| `all_parts_one_by_one` | 2.02 s | 1.03× |
| `all_parts_parallel` | 1.10 s | 0.56× |
| `kms_subset` | 1.41 s | 0.72× |
| `kms_subset_parallel` | 0.94 s | 0.48× |

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3638)
<!-- Reviewable:end -->
