### PR TITLE
chore: fix an import gating which was tripping up rust-analyzer

### DIFF
--- a/tfhe-benchmark/src/lib.rs
+++ b/tfhe-benchmark/src/lib.rs
@@ -1,4 +1,3 @@
-#[cfg(not(any(feature = "gpu", feature = "hpu")))]
 pub mod find_optimal_batch;
 #[cfg(feature = "integer")]
 pub mod high_level_api;


### PR DESCRIPTION
- likely was ok the way it is used