### PR TITLE
fix(gpu): make cuda_bind.rs stream/event bindings environment-indepent

### DIFF
--- a/backends/tfhe-cuda-common/build.rs
+++ b/backends/tfhe-cuda-common/build.rs
@@ -114,9 +114,13 @@ fn generate_cuda_bind_bindings(manifest_dir: &str, include_dir: &PathBuf) {
     if headers_modified > bindings_modified {
         let bindings = bindgen::Builder::default()
             .header(header_path.to_str().unwrap())
-            .allowlist_function("cuda_.*")
-            .blocklist_type("CUstream_st")
-            .blocklist_type("CUevent_st")
+            .allowlist_function(concat!(
+                "cuda_(create_stream_ffi|destroy_stream|synchronize_stream|",
+                "is_available|malloc|malloc_async|check_valid_malloc|",
+                "device_total_memory|memcpy_async_to_gpu|memcpy_async_gpu_to_gpu|",
+                "memcpy_gpu_to_gpu|memcpy_async_to_cpu|memset_async|",
+                "get_number_of_gpus|get_number_of_sms|synchronize_device|drop)",
+            ))
             .clang_arg("-x")
             .clang_arg("c++")
             .clang_arg("-std=c++17")

--- a/backends/tfhe-cuda-common/cuda/include/device.h
+++ b/backends/tfhe-cuda-common/cuda/include/device.h
@@ -55,37 +55,55 @@ inline void cuda_error(cudaError_t code, const char *file, int line) {
   } while (0)
 #endif
 
-uint32_t cuda_get_device();
-void cuda_set_device(uint32_t gpu_index);
-
-cudaEvent_t cuda_create_event(uint32_t gpu_index);
-
-void cuda_event_record(cudaEvent_t event, cudaStream_t stream,
-                       uint32_t gpu_index);
-void cuda_stream_wait_event(cudaStream_t stream, cudaEvent_t event,
-                            uint32_t gpu_index);
-
-void cuda_event_destroy(cudaEvent_t event, uint32_t gpu_index);
-
-cudaStream_t cuda_create_stream(uint32_t gpu_index);
-
-void cuda_destroy_stream(cudaStream_t stream, uint32_t gpu_index);
-
-void cuda_synchronize_stream(cudaStream_t stream, uint32_t gpu_index);
+void *cuda_create_stream_ffi(uint32_t gpu_index);
+void cuda_destroy_stream(void *stream, uint32_t gpu_index);
+void cuda_synchronize_stream(void *stream, uint32_t gpu_index);
 
 uint32_t cuda_is_available();
 
 void *cuda_malloc(uint64_t size, uint32_t gpu_index);
+void *cuda_malloc_async(uint64_t size, void *stream, uint32_t gpu_index);
+bool cuda_check_valid_malloc(uint64_t size, uint32_t gpu_index);
+uint64_t cuda_device_total_memory(uint32_t gpu_index);
+
+void cuda_memcpy_async_to_gpu(void *dest, const void *src, uint64_t size,
+                              void *stream, uint32_t gpu_index);
+void cuda_memcpy_async_gpu_to_gpu(void *dest, void const *src, uint64_t size,
+                                  void *stream, uint32_t gpu_index);
+void cuda_memcpy_gpu_to_gpu(void *dest, void const *src, uint64_t size,
+                            uint32_t gpu_index);
+void cuda_memcpy_async_to_cpu(void *dest, const void *src, uint64_t size,
+                              void *stream, uint32_t gpu_index);
+
+void cuda_memset_async(void *dest, uint64_t val, uint64_t size,
+                       void *stream, uint32_t gpu_index);
+
+int cuda_get_number_of_gpus();
+int cuda_get_number_of_sms();
+
+void cuda_synchronize_device(uint32_t gpu_index);
+
+void cuda_drop(void *ptr, uint32_t gpu_index);
+}
+
+inline cudaStream_t cuda_create_stream(uint32_t gpu_index) {
+  return static_cast<cudaStream_t>(cuda_create_stream_ffi(gpu_index));
+}
+
+uint32_t cuda_get_device();
+void cuda_set_device(uint32_t gpu_index);
+
+cudaEvent_t cuda_create_event(uint32_t gpu_index);
+void cuda_event_record(cudaEvent_t event, cudaStream_t stream,
+                       uint32_t gpu_index);
+void cuda_stream_wait_event(cudaStream_t stream, cudaEvent_t event,
+                            uint32_t gpu_index);
+void cuda_event_destroy(cudaEvent_t event, uint32_t gpu_index);
 
 void *cuda_malloc_with_size_tracking_async(uint64_t size, cudaStream_t stream,
                                            uint32_t gpu_index,
                                            uint64_t &size_tracker,
                                            bool allocate_gpu_memory);
-
-void *cuda_malloc_async(uint64_t size, cudaStream_t stream, uint32_t gpu_index);
-
-bool cuda_check_valid_malloc(uint64_t size, uint32_t gpu_index);
-uint64_t cuda_device_total_memory(uint32_t gpu_index);
 
 void cuda_memcpy_with_size_tracking_async_to_gpu(void *dest, const void *src,
                                                  uint64_t size,
@@ -93,44 +111,20 @@ void cuda_memcpy_with_size_tracking_async_to_gpu(void *dest, const void *src,
                                                  uint32_t gpu_index,
                                                  bool gpu_memory_allocated);
 
-void cuda_memcpy_async_to_gpu(void *dest, const void *src, uint64_t size,
-                              cudaStream_t stream, uint32_t gpu_index);
-
 void cuda_memcpy_with_size_tracking_async_gpu_to_gpu(
     void *dest, void const *src, uint64_t size, cudaStream_t stream,
     uint32_t gpu_index, bool gpu_memory_allocated);
-
-void cuda_memcpy_async_gpu_to_gpu(void *dest, void const *src, uint64_t size,
-                                  cudaStream_t stream, uint32_t gpu_index);
-
-void cuda_memcpy_gpu_to_gpu(void *dest, void const *src, uint64_t size,
-                            uint32_t gpu_index);
-
-void cuda_memcpy_async_to_cpu(void *dest, const void *src, uint64_t size,
-                              cudaStream_t stream, uint32_t gpu_index);
 
 void cuda_memset_with_size_tracking_async(void *dest, uint64_t val,
                                           uint64_t size, cudaStream_t stream,
                                           uint32_t gpu_index,
                                           bool gpu_memory_allocated);
 
-void cuda_memset_async(void *dest, uint64_t val, uint64_t size,
-                       cudaStream_t stream, uint32_t gpu_index);
-
-int cuda_get_number_of_gpus();
-
-int cuda_get_number_of_sms();
-
-void cuda_synchronize_device(uint32_t gpu_index);
-
-void cuda_drop(void *ptr, uint32_t gpu_index);
-
 void cuda_drop_with_size_tracking_async(void *ptr, cudaStream_t stream,
                                         uint32_t gpu_index,
                                         bool gpu_memory_allocated);
 
 void cuda_drop_async(void *ptr, cudaStream_t stream, uint32_t gpu_index);
-}
 
 uint32_t cuda_get_max_shared_memory(uint32_t gpu_index);
 

--- a/backends/tfhe-cuda-common/cuda/src/device.cu
+++ b/backends/tfhe-cuda-common/cuda/src/device.cu
@@ -153,7 +153,7 @@ void cuda_event_destroy(cudaEvent_t event, uint32_t gpu_index) {
 }
 
 /// Unsafe function to create a CUDA stream, must check first that GPU exists
-cudaStream_t cuda_create_stream(uint32_t gpu_index) {
+void *cuda_create_stream_ffi(uint32_t gpu_index) {
   cuda_set_device(gpu_index);
   cudaStream_t stream;
   check_cuda_error(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
@@ -161,14 +161,15 @@ cudaStream_t cuda_create_stream(uint32_t gpu_index) {
 }
 
 /// Unsafe function to destroy CUDA stream, must check first the GPU exists
-void cuda_destroy_stream(cudaStream_t stream, uint32_t gpu_index) {
+void cuda_destroy_stream(void *stream, uint32_t gpu_index) {
   cuda_set_device(gpu_index);
-  check_cuda_error(cudaStreamDestroy(stream));
+  check_cuda_error(cudaStreamDestroy(static_cast<cudaStream_t>(stream)));
 }
 
-void cuda_synchronize_stream(cudaStream_t stream, uint32_t gpu_index) {
+void cuda_synchronize_stream(void *stream, uint32_t gpu_index) {
   cuda_set_device(gpu_index);
-  check_cuda_error(cudaStreamSynchronize(stream));
+  check_cuda_error(
+      cudaStreamSynchronize(static_cast<cudaStream_t>(stream)));
 }
 
 // Determine if a CUDA device is available at runtime
@@ -218,11 +219,10 @@ void *cuda_malloc_with_size_tracking_async(uint64_t size, cudaStream_t stream,
 
 /// Allocates a size-byte array at the device memory. Tries to do it
 /// asynchronously.
-void *cuda_malloc_async(uint64_t size, cudaStream_t stream,
-                        uint32_t gpu_index) {
+void *cuda_malloc_async(uint64_t size, void *stream, uint32_t gpu_index) {
   uint64_t size_tracker = 0;
-  return cuda_malloc_with_size_tracking_async(size, stream, gpu_index,
-                                              size_tracker, true);
+  return cuda_malloc_with_size_tracking_async(
+      size, static_cast<cudaStream_t>(stream), gpu_index, size_tracker, true);
 }
 
 /// Check that allocation is valid
@@ -304,9 +304,9 @@ void cuda_memcpy_with_size_tracking_async_to_gpu(void *dest, const void *src,
 /// asynchronous data copy from the CPU to all the GPUs simultaneously (for
 /// example to copy the bootstrapping key).
 void cuda_memcpy_async_to_gpu(void *dest, const void *src, uint64_t size,
-                              cudaStream_t stream, uint32_t gpu_index) {
-  cuda_memcpy_with_size_tracking_async_to_gpu(dest, src, size, stream,
-                                              gpu_index, true);
+                              void *stream, uint32_t gpu_index) {
+  cuda_memcpy_with_size_tracking_async_to_gpu(
+      dest, src, size, static_cast<cudaStream_t>(stream), gpu_index, true);
 }
 
 /// Copy memory within a GPU asynchronously.
@@ -329,10 +329,9 @@ void cuda_memcpy_with_size_tracking_async_gpu_to_gpu(
   }
 }
 void cuda_memcpy_async_gpu_to_gpu(void *dest, void const *src, uint64_t size,
-                                  cudaStream_t stream, uint32_t gpu_index) {
-
-  cuda_memcpy_with_size_tracking_async_gpu_to_gpu(dest, src, size, stream,
-                                                  gpu_index, true);
+                                  void *stream, uint32_t gpu_index) {
+  cuda_memcpy_with_size_tracking_async_gpu_to_gpu(
+      dest, src, size, static_cast<cudaStream_t>(stream), gpu_index, true);
 }
 
 /// Copy memory within a GPU
@@ -383,10 +382,10 @@ void cuda_memset_with_size_tracking_async(void *dest, uint64_t val,
 }
 
 /// cuda_memset sets bytes, we basically only use it to initialize data to 0
-void cuda_memset_async(void *dest, uint64_t val, uint64_t size,
-                       cudaStream_t stream, uint32_t gpu_index) {
-  cuda_memset_with_size_tracking_async(dest, val, size, stream, gpu_index,
-                                       true);
+void cuda_memset_async(void *dest, uint64_t val, uint64_t size, void *stream,
+                       uint32_t gpu_index) {
+  cuda_memset_with_size_tracking_async(
+      dest, val, size, static_cast<cudaStream_t>(stream), gpu_index, true);
 }
 
 template <typename Torus>
@@ -429,15 +428,15 @@ template void cuda_set_value_async(cudaStream_t stream, uint32_t gpu_index,
 /// memory is pinned (using cudaMallocHost for the CPU allocation),
 /// so it should be avoided at all costs
 void cuda_memcpy_async_to_cpu(void *dest, const void *src, uint64_t size,
-                              cudaStream_t stream, uint32_t gpu_index) {
+                              void *stream, uint32_t gpu_index) {
   GPU_ASSERT(dest != nullptr, "Cuda error: null host ptr");
   if (size == 0)
     return;
   validate_device_ptr_and_gpu_index(src, gpu_index);
 
   cuda_set_device(gpu_index);
-  check_cuda_error(
-      cudaMemcpyAsync(dest, src, size, cudaMemcpyDeviceToHost, stream));
+  check_cuda_error(cudaMemcpyAsync(dest, src, size, cudaMemcpyDeviceToHost,
+                                   static_cast<cudaStream_t>(stream)));
 }
 
 /// Return number of GPUs available

--- a/backends/tfhe-cuda-common/src/cuda_bind.rs
+++ b/backends/tfhe-cuda-common/src/cuda_bind.rs
@@ -3,29 +3,7 @@
 use crate::ffi;
 
 unsafe extern "C" {
-    pub fn cuda_get_device() -> u32;
-}
-unsafe extern "C" {
-    pub fn cuda_set_device(gpu_index: u32);
-}
-unsafe extern "C" {
-    pub fn cuda_create_event(gpu_index: u32) -> *mut ffi::c_void;
-}
-unsafe extern "C" {
-    pub fn cuda_event_record(event: *mut ffi::c_void, stream: *mut ffi::c_void, gpu_index: u32);
-}
-unsafe extern "C" {
-    pub fn cuda_stream_wait_event(
-        stream: *mut ffi::c_void,
-        event: *mut ffi::c_void,
-        gpu_index: u32,
-    );
-}
-unsafe extern "C" {
-    pub fn cuda_event_destroy(event: *mut ffi::c_void, gpu_index: u32);
-}
-unsafe extern "C" {
-    pub fn cuda_create_stream(gpu_index: u32) -> *mut ffi::c_void;
+    pub fn cuda_create_stream_ffi(gpu_index: u32) -> *mut ffi::c_void;
 }
 unsafe extern "C" {
     pub fn cuda_destroy_stream(stream: *mut ffi::c_void, gpu_index: u32);
@@ -38,15 +16,6 @@ unsafe extern "C" {
 }
 unsafe extern "C" {
     pub fn cuda_malloc(size: u64, gpu_index: u32) -> *mut ffi::c_void;
-}
-unsafe extern "C" {
-    pub fn cuda_malloc_with_size_tracking_async(
-        size: u64,
-        stream: *mut ffi::c_void,
-        gpu_index: u32,
-        size_tracker: *mut u64,
-        allocate_gpu_memory: bool,
-    ) -> *mut ffi::c_void;
 }
 unsafe extern "C" {
     pub fn cuda_malloc_async(
@@ -62,32 +31,12 @@ unsafe extern "C" {
     pub fn cuda_device_total_memory(gpu_index: u32) -> u64;
 }
 unsafe extern "C" {
-    pub fn cuda_memcpy_with_size_tracking_async_to_gpu(
-        dest: *mut ffi::c_void,
-        src: *const ffi::c_void,
-        size: u64,
-        stream: *mut ffi::c_void,
-        gpu_index: u32,
-        gpu_memory_allocated: bool,
-    );
-}
-unsafe extern "C" {
     pub fn cuda_memcpy_async_to_gpu(
         dest: *mut ffi::c_void,
         src: *const ffi::c_void,
         size: u64,
         stream: *mut ffi::c_void,
         gpu_index: u32,
-    );
-}
-unsafe extern "C" {
-    pub fn cuda_memcpy_with_size_tracking_async_gpu_to_gpu(
-        dest: *mut ffi::c_void,
-        src: *const ffi::c_void,
-        size: u64,
-        stream: *mut ffi::c_void,
-        gpu_index: u32,
-        gpu_memory_allocated: bool,
     );
 }
 unsafe extern "C" {
@@ -117,16 +66,6 @@ unsafe extern "C" {
     );
 }
 unsafe extern "C" {
-    pub fn cuda_memset_with_size_tracking_async(
-        dest: *mut ffi::c_void,
-        val: u64,
-        size: u64,
-        stream: *mut ffi::c_void,
-        gpu_index: u32,
-        gpu_memory_allocated: bool,
-    );
-}
-unsafe extern "C" {
     pub fn cuda_memset_async(
         dest: *mut ffi::c_void,
         val: u64,
@@ -146,15 +85,4 @@ unsafe extern "C" {
 }
 unsafe extern "C" {
     pub fn cuda_drop(ptr: *mut ffi::c_void, gpu_index: u32);
-}
-unsafe extern "C" {
-    pub fn cuda_drop_with_size_tracking_async(
-        ptr: *mut ffi::c_void,
-        stream: *mut ffi::c_void,
-        gpu_index: u32,
-        gpu_memory_allocated: bool,
-    );
-}
-unsafe extern "C" {
-    pub fn cuda_drop_async(ptr: *mut ffi::c_void, stream: *mut ffi::c_void, gpu_index: u32);
 }

--- a/backends/zk-cuda-backend/src/types/g1.rs
+++ b/backends/zk-cuda-backend/src/types/g1.rs
@@ -270,9 +270,9 @@ impl G1Projective {
         //
         // SAFETY:
         // - `stream` was validated as non-null above and must be a valid `cudaStream_t` obtained
-        //   from `cuda_create_stream`. The raw pointer type is `*mut c_void` because CUDA streams
-        //   are opaque pointers. If the stream is invalid (e.g., already destroyed or corrupted),
-        //   the CUDA runtime will report an error through `cudaGetLastError()`.
+        //   from `cuda_create_stream_ffi`. The raw pointer type is `*mut c_void` because CUDA
+        //   streams are opaque pointers. If the stream is invalid (e.g., already destroyed or
+        //   corrupted), the CUDA runtime will report an error through `cudaGetLastError()`.
         // - This function borrows the stream for the duration of the call; it does not take
         //   ownership. The caller remains responsible for destroying the stream after use.
         // - `gpu_index` is passed directly to CUDA; the C++ wrapper validates it

--- a/backends/zk-cuda-backend/src/types/g2.rs
+++ b/backends/zk-cuda-backend/src/types/g2.rs
@@ -277,9 +277,9 @@ impl G2Projective {
         //
         // SAFETY:
         // - `stream` was validated as non-null above and must be a valid `cudaStream_t` obtained
-        //   from `cuda_create_stream`. The raw pointer type is `*mut c_void` because CUDA streams
-        //   are opaque pointers. If the stream is invalid (e.g., already destroyed or corrupted),
-        //   the CUDA runtime will report an error through `cudaGetLastError()`.
+        //   from `cuda_create_stream_ffi`. The raw pointer type is `*mut c_void` because CUDA
+        //   streams are opaque pointers. If the stream is invalid (e.g., already destroyed or
+        //   corrupted), the CUDA runtime will report an error through `cudaGetLastError()`.
         // - This function borrows the stream for the duration of the call; it does not take
         //   ownership. The caller remains responsible for destroying the stream after use.
         // - `gpu_index` is passed directly to CUDA; the C++ wrapper validates it

--- a/backends/zk-cuda-backend/src/types/mod.rs
+++ b/backends/zk-cuda-backend/src/types/mod.rs
@@ -193,7 +193,7 @@ mod tests {
         let gen = G1Affine::new(Fp::new(G1_GENERATOR_X), Fp::new(G1_GENERATOR_Y), false);
         let one = Scalar::from_u64(1);
 
-        let stream = unsafe { tfhe_cuda_common::cuda_bind::cuda_create_stream(0) };
+        let stream = unsafe { tfhe_cuda_common::cuda_bind::cuda_create_stream_ffi(0) };
         let result = G1Projective::msm(&[gen], &[one], stream, 0, false).unwrap();
         unsafe { tfhe_cuda_common::cuda_bind::cuda_destroy_stream(stream, 0) };
 
@@ -218,7 +218,7 @@ mod tests {
         let gen = G2Affine::new(x, y, false);
         let one = Scalar::from_u64(1);
 
-        let stream = unsafe { tfhe_cuda_common::cuda_bind::cuda_create_stream(0) };
+        let stream = unsafe { tfhe_cuda_common::cuda_bind::cuda_create_stream_ffi(0) };
         let result = G2Projective::msm(&[gen], &[one], stream, 0, false).unwrap();
         unsafe { tfhe_cuda_common::cuda_bind::cuda_destroy_stream(stream, 0) };
 

--- a/tfhe-zk-pok/src/gpu/mod.rs
+++ b/tfhe-zk-pok/src/gpu/mod.rs
@@ -15,7 +15,7 @@ use crate::curve_api::CurveGroupOps;
 use ark_ec::CurveGroup;
 use ark_ff::{BigInt, MontFp, PrimeField};
 use tfhe_cuda_common::cuda_bind::{
-    cuda_create_stream, cuda_destroy_stream, cuda_get_number_of_gpus,
+    cuda_create_stream_ffi, cuda_destroy_stream, cuda_get_number_of_gpus,
 };
 use zk_cuda_backend::{G1Affine as CudaG1Affine, G2Affine as CudaG2Affine, Scalar as CudaScalar};
 
@@ -206,12 +206,12 @@ pub fn g1_msm_gpu(bases: &[G1Affine], scalars: &[Zp], gpu_index: u32) -> G1 {
         "gpu_index {gpu_index} exceeds available GPUs ({num_gpus})",
     );
     // SAFETY: gpu_index was validated by the assert above
-    let stream = unsafe { cuda_create_stream(gpu_index) };
+    let stream = unsafe { cuda_create_stream_ffi(gpu_index) };
 
     let result =
         zk_cuda_backend::G1Projective::msm(&gpu_bases, &gpu_scalars, stream, gpu_index, false);
 
-    // SAFETY: stream was created by cuda_create_stream above with the same gpu_index and is not
+    // SAFETY: stream was created by cuda_create_stream_ffi above with the same gpu_index and is not
     // used after this point
     unsafe { cuda_destroy_stream(stream, gpu_index) };
 
@@ -269,12 +269,12 @@ pub fn g2_msm_gpu(bases: &[G2Affine], scalars: &[Zp], gpu_index: u32) -> G2 {
         "gpu_index {gpu_index} exceeds available GPUs ({num_gpus})",
     );
     // SAFETY: gpu_index was validated by the assert above
-    let stream = unsafe { cuda_create_stream(gpu_index) };
+    let stream = unsafe { cuda_create_stream_ffi(gpu_index) };
 
     let result =
         zk_cuda_backend::G2Projective::msm(&gpu_bases, &gpu_scalars, stream, gpu_index, false);
 
-    // SAFETY: stream was created by cuda_create_stream above with the same gpu_index and is not
+    // SAFETY: stream was created by cuda_create_stream_ffi above with the same gpu_index and is not
     // used after this point
     unsafe { cuda_destroy_stream(stream, gpu_index) };
 

--- a/tfhe-zk-pok/src/gpu/tests/zk_cuda_backend.rs
+++ b/tfhe-zk-pok/src/gpu/tests/zk_cuda_backend.rs
@@ -3,7 +3,7 @@
 use crate::curve_api::bls12_446::{Zp, G1, G2};
 use crate::curve_api::CurveGroupOps;
 use crate::gpu::{g1_affine_from_cuda, g1_affine_to_cuda, g2_affine_from_cuda, g2_affine_to_cuda};
-use tfhe_cuda_common::cuda_bind::{cuda_create_stream, cuda_destroy_stream};
+use tfhe_cuda_common::cuda_bind::{cuda_create_stream_ffi, cuda_destroy_stream};
 use zk_cuda_backend::conversions::{g1_affine_from_montgomery, g2_affine_from_montgomery};
 use zk_cuda_backend::{
     G1Affine as CudaG1Affine, G1Projective as CudaG1Projective, G2Affine as CudaG2Affine,
@@ -170,7 +170,7 @@ fn msm_large_n<T: MsmTestGroup>() {
         let probe_points = vec![gen_cuda];
         let probe_scalars = vec![CudaScalar::from_u64(1)];
         // SAFETY: gpu_index 0 is assumed valid on any CUDA-capable machine
-        let probe_stream = unsafe { cuda_create_stream(0) };
+        let probe_stream = unsafe { cuda_create_stream_ffi(0) };
         if T::msm(&probe_points, &probe_scalars, probe_stream, 0).is_err() {
             // SAFETY: stream was created above and is not used after this point
             unsafe { cuda_destroy_stream(probe_stream, 0) };
@@ -188,7 +188,7 @@ fn msm_large_n<T: MsmTestGroup>() {
         let scalars: Vec<CudaScalar> = (1..=n).map(CudaScalar::from_u64).collect();
 
         // SAFETY: gpu_index 0 is assumed valid on any CUDA-capable machine
-        let stream = unsafe { cuda_create_stream(0) };
+        let stream = unsafe { cuda_create_stream_ffi(0) };
         let gpu_result_proj = T::msm(&points, &scalars, stream, 0)
             .unwrap_or_else(|_| panic!("CUDA MSM failed at N={}", n));
         // SAFETY: stream was created above and is not used after this point
@@ -234,7 +234,7 @@ fn msm_zero_scalars<T: MsmTestGroup>() {
 
     let gpu_index = 0;
     // SAFETY: gpu_index 0 is assumed valid on any CUDA-capable machine
-    let stream = unsafe { cuda_create_stream(gpu_index) };
+    let stream = unsafe { cuda_create_stream_ffi(gpu_index) };
     let result_proj = T::msm(&points, &scalars, stream, gpu_index)
         .unwrap_or_else(|e| panic!("CUDA MSM failed: {e}"));
     // SAFETY: stream was created above and is not used after this point
@@ -258,7 +258,7 @@ fn msm_canceling<T: MsmTestGroup>() {
 
     let gpu_index = 0;
     // SAFETY: gpu_index 0 is assumed valid on any CUDA-capable machine
-    let stream = unsafe { cuda_create_stream(gpu_index) };
+    let stream = unsafe { cuda_create_stream_ffi(gpu_index) };
     let result_proj = T::msm(&points, &scalars, stream, gpu_index)
         .unwrap_or_else(|e| panic!("CUDA MSM failed: {e}"));
     // SAFETY: stream was created above and is not used after this point
@@ -287,7 +287,7 @@ fn msm_infinity_input<T: MsmTestGroup>() {
 
     let gpu_index = 0;
     // SAFETY: gpu_index 0 is assumed valid on any CUDA-capable machine
-    let stream = unsafe { cuda_create_stream(gpu_index) };
+    let stream = unsafe { cuda_create_stream_ffi(gpu_index) };
     let result_proj = T::msm(&points, &scalars, stream, gpu_index)
         .unwrap_or_else(|e| panic!("CUDA MSM failed: {e}"));
     // SAFETY: stream was created above and is not used after this point
@@ -394,7 +394,7 @@ fn test_g1_msm_multi_limb_scalar() {
 
     let gpu_index = 0;
     // SAFETY: gpu_index 0 is assumed valid on any CUDA-capable machine
-    let stream = unsafe { cuda_create_stream(gpu_index) };
+    let stream = unsafe { cuda_create_stream_ffi(gpu_index) };
     let gpu_result_proj = CudaG1Projective::msm(&points, &scalars, stream, gpu_index, false)
         .unwrap_or_else(|e| panic!("CUDA MSM failed: {e}"));
     // SAFETY: stream was created above and is not used after this point

--- a/tfhe/src/core_crypto/gpu/mod.rs
+++ b/tfhe/src/core_crypto/gpu/mod.rs
@@ -44,7 +44,7 @@ impl CudaStreams {
         let mut ptr_array = Vec::with_capacity(gpu_count as usize);
 
         for _ in 0..gpu_count {
-            ptr_array.push(unsafe { cuda_create_stream(0) });
+            ptr_array.push(unsafe { cuda_create_stream_ffi(0) });
             gpu_indexes.push(GpuIndex::new(0));
         }
         Self {
@@ -61,7 +61,7 @@ impl CudaStreams {
         let mut ptr_array = Vec::with_capacity(gpu_count as usize);
 
         for i in 0..gpu_count {
-            ptr_array.push(unsafe { cuda_create_stream(i) });
+            ptr_array.push(unsafe { cuda_create_stream_ffi(i) });
             gpu_indexes.push(GpuIndex::new(i));
         }
         Self {
@@ -80,7 +80,7 @@ impl CudaStreams {
         for &i in indexes {
             let index = i.get();
             assert!(index < gpu_count, "Cuda error: invalid device index");
-            ptr_array.push(unsafe { cuda_create_stream(index) });
+            ptr_array.push(unsafe { cuda_create_stream_ffi(index) });
             gpu_indexes.push(i);
         }
         Self {
@@ -92,7 +92,7 @@ impl CudaStreams {
     /// as input
     pub fn new_single_gpu(gpu_index: GpuIndex) -> Self {
         Self {
-            ptr: vec![unsafe { cuda_create_stream(gpu_index.get()) }],
+            ptr: vec![unsafe { cuda_create_stream_ffi(gpu_index.get()) }],
             gpu_indexes: vec![gpu_index],
         }
     }


### PR DESCRIPTION
## Problem

`tfhe-cuda-common/build.rs` blocklisted the `CUstream_st` / `CUevent_st` structs but kept the `cudaStream_t` / `cudaEvent_t` typedefs that reference them. On machines where the CUDA headers resolve those structs (e.g. an H100 with `/usr/local/cuda/include` populated), bindgen regenerated `cuda_bind.rs` with `pub type cudaStream_t = *mut CUstream_st;` — a reference to a blocklisted (undefined) type — failing to compile (`E0412: cannot find type CUstream_st`) and breaking every build of `tfhe-cuda-common` and everything downstream (`tfhe-cuda-backend`, `tfhe` with `gpu`).

This blocklists the typedefs as well and provides them via `raw_line` as `*mut ffi::c_void`, so the handles resolve to a stable opaque form regardless of whether the CUDA headers are on the clang include path. The generated file is now byte-identical on every machine, and the `*mut c_void` form (the universal handle cast by `CudaStreams.ptr` and `zk-cuda-backend` at their FFI boundaries) is preserved.

---


<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer

