### PR TITLE
Am/feat/prf integer hl rerand

### DIFF
--- a/tfhe/src/high_level_api/booleans/oprf.rs
+++ b/tfhe/src/high_level_api/booleans/oprf.rs
@@ -24,6 +24,8 @@ impl FheBool {
     ///
     /// set_server_key(server_key);
     ///
+    /// // DANGER: Using a deterministic seed is insecure and only done here to show API usage.
+    /// // The proper way of generating a seed depends on your application.
     /// let ct_res = FheBool::generate_oblivious_pseudo_random(Seed(0));
     ///
     /// let dec_result: bool = ct_res.decrypt(&client_key);

--- a/tfhe/src/high_level_api/booleans/oprf.rs
+++ b/tfhe/src/high_level_api/booleans/oprf.rs
@@ -1,7 +1,9 @@
 use super::{FheBool, InnerBoolean};
 use crate::high_level_api::global_state;
 use crate::high_level_api::keys::InternalServerKey;
-use crate::high_level_api::re_randomization::ReRandomizationMetadata;
+use crate::high_level_api::re_randomization::{
+    ReRandomizationHashAlgo, ReRandomizationMetadata, ReRandomizationMode,
+};
 #[cfg(feature = "gpu")]
 use crate::integer::gpu::ciphertext::boolean_value::CudaBooleanBlock;
 #[cfg(feature = "gpu")]
@@ -83,25 +85,222 @@ impl FheBool {
         });
         Self::new(ciphertext, tag, ReRandomizationMetadata::default())
     }
+
+    /// Generates an encrypted boolean taken uniformly using the given seed.
+    /// The encrypted value is oblivious to the server.
+    /// It can be useful to make server random generation deterministic.
+    ///
+    /// This variant also applies a re-randomization to the output of the PRF.
+    /// Depending on your application you may need to use this variant of the API.
+    ///
+    /// ```rust
+    /// use tfhe::prelude::*;
+    /// use tfhe::shortint::parameters::*;
+    /// use tfhe::{
+    ///     generate_keys, set_server_key, ConfigBuilder, FheBool, ReRandomizationHashAlgo,
+    ///     ReRandomizationMode,
+    /// };
+    ///
+    /// let params = PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+    /// let re_rand_params = ReRandomizationParameters::DerivedCPKWithoutKeySwitch;
+    ///
+    /// let config = ConfigBuilder::with_custom_parameters(params)
+    ///     .enable_ciphertext_re_randomization(re_rand_params)
+    ///     .build();
+    ///
+    /// let (client_key, server_key) = generate_keys(config);
+    ///
+    /// set_server_key(server_key);
+    ///
+    /// let seed = [0u8; 32].as_slice();
+    ///
+    /// let ct_res = FheBool::generate_oblivious_pseudo_random(seed);
+    ///
+    /// // DANGER: Using a deterministic seed is insecure and only done here to show API usage.
+    /// // The proper way of generating a seed depends on your application.
+    /// let ct_res_rerand = FheBool::generate_oblivious_pseudo_random_and_re_randomize(
+    ///     seed,
+    ///     ReRandomizationMode::default(),
+    ///     ReRandomizationHashAlgo::default(),
+    /// )
+    /// .unwrap();
+    ///
+    /// let dec_result: bool = ct_res.decrypt(&client_key);
+    /// let dec_result_rerand: bool = ct_res_rerand.decrypt(&client_key);
+    ///
+    /// // Re-randomization does not change the contained value
+    /// // just the values representing the ciphertext
+    /// assert_eq!(dec_result, dec_result_rerand);
+    /// ```
+    pub fn generate_oblivious_pseudo_random_and_re_randomize<
+        'a,
+        RRD: Into<ReRandomizationMode<'a>>,
+    >(
+        seed: impl OprfSeed,
+        re_randomization_mode: RRD,
+        re_randomization_hash_algo: ReRandomizationHashAlgo,
+    ) -> crate::Result<Self> {
+        let re_randomization_mode: ReRandomizationMode = re_randomization_mode.into();
+        global_state::with_internal_keys(|key| match key {
+            InternalServerKey::Cpu(key) => {
+                let sk = key.pbs_key();
+                let rerand_key =
+                    key.integer_re_randomization_key_from_mode(re_randomization_mode)?;
+
+                // 1 block with 1 bit of data is a boolean
+                let ct_wrapped = key
+                    .oprf_key()
+                    .par_generate_oblivious_pseudo_random_unsigned_integer_bounded_and_re_randomize(
+                        seed,
+                        1,
+                        1,
+                        sk,
+                        &rerand_key,
+                        re_randomization_hash_algo,
+                    )?;
+
+                let ct = ct_wrapped.blocks.into_iter().next().unwrap();
+
+                Ok((
+                    InnerBoolean::Cpu(BooleanBlock::new_unchecked(ct)),
+                    key.tag.clone(),
+                ))
+            }
+            #[cfg(feature = "gpu")]
+            InternalServerKey::Cuda(cuda_key) => {
+                let streams = &cuda_key.streams;
+                let rerand_key =
+                    cuda_key.integer_re_randomization_key_from_mode(re_randomization_mode)?;
+
+                // 1 block with 1 bit of data is a boolean
+                let d_ct: CudaUnsignedRadixCiphertext = cuda_key
+                    .oprf_key()
+                    .par_generate_oblivious_pseudo_random_unsigned_integer_bounded_and_re_randomize(
+                        seed,
+                        1,
+                        1,
+                        cuda_key.pbs_key(),
+                        &rerand_key,
+                        re_randomization_hash_algo,
+                        streams,
+                    )?;
+                Ok((
+                    InnerBoolean::Cuda(CudaBooleanBlock::from_cuda_radix_ciphertext(
+                        d_ct.ciphertext,
+                    )),
+                    cuda_key.tag.clone(),
+                ))
+            }
+            #[cfg(feature = "hpu")]
+            InternalServerKey::Hpu(_device) => {
+                panic!("Hpu does not support random bool generation")
+            }
+        })
+        .map(|(ciphertext, tag)| Self::new(ciphertext, tag, ReRandomizationMetadata::default()))
+    }
 }
 
 #[cfg(test)]
-#[cfg(feature = "gpu")]
 mod test {
+    use super::*;
     use crate::prelude::FheDecrypt;
+    use crate::shortint::parameters::ReRandomizationParameters;
 
     #[test]
     fn test_oprf_boolean() {
         let config = crate::ConfigBuilder::default()
             .use_dedicated_oprf_key(true)
+            .enable_ciphertext_re_randomization(
+                ReRandomizationParameters::DerivedCPKWithoutKeySwitch,
+            )
             .build();
-        let client_key = crate::ClientKey::generate(config);
-        let compressed_server_key = crate::CompressedServerKey::new(&client_key);
-        let gpu_key = compressed_server_key.decompress_to_gpu();
-        crate::set_server_key(gpu_key);
 
-        let rnd = crate::FheBool::generate_oblivious_pseudo_random(crate::Seed(123));
+        let rerand_mode = ReRandomizationMode::UseAvailableMode;
+
+        let client_key = crate::ClientKey::generate(config);
+        let cpu_key = crate::ServerKey::new(&client_key);
+        crate::set_server_key(cpu_key);
+
+        // Make sure seed generation is secure in production, this is a test setup
+        let seed = crate::Seed(rand::random());
+
+        let rnd = FheBool::generate_oblivious_pseudo_random(seed);
         let decrypted_result: bool = rnd.decrypt(&client_key);
-        println!("Random bool: {decrypted_result}");
+
+        for hash_algo in [
+            ReRandomizationHashAlgo::Blake3,
+            ReRandomizationHashAlgo::Shake256,
+        ] {
+            let rnd_rerand = FheBool::generate_oblivious_pseudo_random_and_re_randomize(
+                seed,
+                rerand_mode,
+                hash_algo,
+            )
+            .unwrap();
+
+            let decrypted_result_rerand: bool = rnd_rerand.decrypt(&client_key);
+
+            assert_eq!(decrypted_result, decrypted_result_rerand);
+        }
+    }
+
+    #[cfg(feature = "gpu")]
+    mod gpu {
+        use super::*;
+        #[test]
+        fn test_oprf_boolean() {
+            let config = crate::ConfigBuilder::default()
+                .use_dedicated_oprf_key(true)
+                .enable_ciphertext_re_randomization(
+                    ReRandomizationParameters::DerivedCPKWithoutKeySwitch,
+                )
+                .build();
+
+            let rerand_mode = ReRandomizationMode::UseAvailableMode;
+
+            let client_key = crate::ClientKey::generate(config);
+            let compressed_server_key = crate::CompressedServerKey::new(&client_key);
+
+            // Make sure seed generation is secure in production, this is a test setup
+            let seed = crate::Seed(rand::random());
+
+            let cpu_result = {
+                let cpu_key = compressed_server_key.decompress();
+                crate::set_server_key(cpu_key);
+
+                let rnd = FheBool::generate_oblivious_pseudo_random(seed);
+                let decrypted_result: bool = rnd.decrypt(&client_key);
+
+                decrypted_result
+            };
+            let gpu_result = {
+                let gpu_key = compressed_server_key.decompress_to_gpu();
+                crate::set_server_key(gpu_key);
+
+                let rnd = FheBool::generate_oblivious_pseudo_random(seed);
+                let decrypted_result: bool = rnd.decrypt(&client_key);
+
+                for hash_algo in [
+                    ReRandomizationHashAlgo::Blake3,
+                    ReRandomizationHashAlgo::Shake256,
+                ] {
+                    let rnd_rerand = FheBool::generate_oblivious_pseudo_random_and_re_randomize(
+                        seed,
+                        rerand_mode,
+                        hash_algo,
+                    )
+                    .unwrap();
+
+                    let decrypted_result_rerand: bool = rnd_rerand.decrypt(&client_key);
+
+                    assert_eq!(decrypted_result, decrypted_result_rerand);
+                }
+
+                decrypted_result
+            };
+
+            // Also check CPU and GPU agree
+            assert_eq!(cpu_result, gpu_result, "CPU and GPU disagree on output");
+        }
     }
 }

--- a/tfhe/src/high_level_api/booleans/oprf.rs
+++ b/tfhe/src/high_level_api/booleans/oprf.rs
@@ -2,7 +2,7 @@ use super::{FheBool, InnerBoolean};
 use crate::high_level_api::global_state;
 use crate::high_level_api::keys::InternalServerKey;
 use crate::high_level_api::re_randomization::{
-    ReRandomizationHashAlgo, ReRandomizationMetadata, ReRandomizationMode,
+    PrfReRandomizationContext, ReRandomizationMetadata, ReRandomizationMode,
 };
 #[cfg(feature = "gpu")]
 use crate::integer::gpu::ciphertext::boolean_value::CudaBooleanBlock;
@@ -97,7 +97,7 @@ impl FheBool {
     /// use tfhe::prelude::*;
     /// use tfhe::shortint::parameters::*;
     /// use tfhe::{
-    ///     generate_keys, set_server_key, ConfigBuilder, FheBool, ReRandomizationHashAlgo,
+    ///     generate_keys, set_server_key, ConfigBuilder, FheBool, PrfReRandomizationContext,
     ///     ReRandomizationMode,
     /// };
     ///
@@ -121,7 +121,7 @@ impl FheBool {
     /// let ct_res_rerand = FheBool::generate_oblivious_pseudo_random_and_re_randomize(
     ///     seed,
     ///     ReRandomizationMode::default(),
-    ///     ReRandomizationHashAlgo::default(),
+    ///     &PrfReRandomizationContext::default(),
     /// )
     /// .unwrap();
     ///
@@ -138,7 +138,7 @@ impl FheBool {
     >(
         seed: impl OprfSeed,
         re_randomization_mode: RRD,
-        re_randomization_hash_algo: ReRandomizationHashAlgo,
+        prf_re_randomization_context: &PrfReRandomizationContext,
     ) -> crate::Result<Self> {
         let re_randomization_mode: ReRandomizationMode = re_randomization_mode.into();
         global_state::with_internal_keys(|key| match key {
@@ -156,7 +156,7 @@ impl FheBool {
                         1,
                         sk,
                         &rerand_key,
-                        re_randomization_hash_algo,
+                        prf_re_randomization_context.inner(),
                     )?;
 
                 let ct = ct_wrapped.blocks.into_iter().next().unwrap();
@@ -181,7 +181,7 @@ impl FheBool {
                         1,
                         cuda_key.pbs_key(),
                         &rerand_key,
-                        re_randomization_hash_algo,
+                        prf_re_randomization_context.inner(),
                         streams,
                     )?;
                 Ok((
@@ -203,6 +203,7 @@ impl FheBool {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::integer::ciphertext::{ReRandomizationHashAlgo, ReRandomizationSeedHasher};
     use crate::prelude::FheDecrypt;
     use crate::shortint::parameters::ReRandomizationParameters;
 
@@ -227,14 +228,23 @@ mod test {
         let rnd = FheBool::generate_oblivious_pseudo_random(seed);
         let decrypted_result: bool = rnd.decrypt(&client_key);
 
-        for hash_algo in [
+        for rerand_hash_algo in [
             ReRandomizationHashAlgo::Blake3,
             ReRandomizationHashAlgo::Shake256,
         ] {
+            let seed_hasher = ReRandomizationSeedHasher::new(
+                rerand_hash_algo,
+                crate::shortint::oprf::TFHE_PRF_RERAND_DOMAIN_SEPARATOR,
+            );
+            let prf_rerand_context = PrfReRandomizationContext::new_with_hasher(
+                crate::shortint::public_key::compact::TFHE_PKE_DOMAIN_SEPARATOR,
+                seed_hasher,
+            );
+
             let rnd_rerand = FheBool::generate_oblivious_pseudo_random_and_re_randomize(
                 seed,
                 rerand_mode,
-                hash_algo,
+                &prf_rerand_context,
             )
             .unwrap();
 
@@ -280,14 +290,23 @@ mod test {
                 let rnd = FheBool::generate_oblivious_pseudo_random(seed);
                 let decrypted_result: bool = rnd.decrypt(&client_key);
 
-                for hash_algo in [
+                for rerand_hash_algo in [
                     ReRandomizationHashAlgo::Blake3,
                     ReRandomizationHashAlgo::Shake256,
                 ] {
+                    let seed_hasher = ReRandomizationSeedHasher::new(
+                        rerand_hash_algo,
+                        crate::shortint::oprf::TFHE_PRF_RERAND_DOMAIN_SEPARATOR,
+                    );
+                    let prf_rerand_context = PrfReRandomizationContext::new_with_hasher(
+                        crate::shortint::public_key::compact::TFHE_PKE_DOMAIN_SEPARATOR,
+                        seed_hasher,
+                    );
+
                     let rnd_rerand = FheBool::generate_oblivious_pseudo_random_and_re_randomize(
                         seed,
                         rerand_mode,
-                        hash_algo,
+                        &prf_rerand_context,
                     )
                     .unwrap();
 

--- a/tfhe/src/high_level_api/integers/oprf.rs
+++ b/tfhe/src/high_level_api/integers/oprf.rs
@@ -2,7 +2,7 @@ use super::{FheIntId, FheUint, FheUintId};
 use crate::high_level_api::global_state;
 use crate::high_level_api::keys::InternalServerKey;
 use crate::high_level_api::re_randomization::{
-    ReRandomizationHashAlgo, ReRandomizationMetadata, ReRandomizationMode,
+    PrfReRandomizationContext, ReRandomizationMetadata, ReRandomizationMode,
 };
 #[cfg(feature = "gpu")]
 use crate::integer::gpu::ciphertext::{CudaSignedRadixCiphertext, CudaUnsignedRadixCiphertext};
@@ -111,7 +111,7 @@ impl<Id: FheUintId> FheUint<Id> {
     >(
         seed: impl OprfSeed,
         re_randomization_mode: RRD,
-        re_randomization_hash_algo: ReRandomizationHashAlgo,
+        prf_re_randomization_context: &PrfReRandomizationContext,
     ) -> crate::Result<Self> {
         let re_randomization_mode: ReRandomizationMode = re_randomization_mode.into();
         global_state::with_internal_keys(|key| match key {
@@ -126,7 +126,7 @@ impl<Id: FheUintId> FheUint<Id> {
                         Id::num_blocks(key.message_modulus()) as u64,
                         sk,
                         &rerand_key,
-                        re_randomization_hash_algo,
+                        prf_re_randomization_context.inner(),
                     )?;
 
                 Ok(Self::new(
@@ -147,7 +147,7 @@ impl<Id: FheUintId> FheUint<Id> {
                         Id::num_blocks(cuda_key.message_modulus()) as u64,
                         cuda_key.pbs_key(),
                         &rerand_key,
-                        re_randomization_hash_algo,
+                        prf_re_randomization_context.inner(),
                         streams,
                     )?;
 
@@ -244,7 +244,7 @@ impl<Id: FheUintId> FheUint<Id> {
         seed: impl OprfSeed,
         random_bits_count: u64,
         re_randomization_mode: RRD,
-        re_randomization_hash_algo: ReRandomizationHashAlgo,
+        prf_re_randomization_context: &PrfReRandomizationContext,
     ) -> crate::Result<Self> {
         let re_randomization_mode: ReRandomizationMode = re_randomization_mode.into();
         global_state::with_internal_keys(|key| match key {
@@ -260,7 +260,7 @@ impl<Id: FheUintId> FheUint<Id> {
                         Id::num_blocks(key.message_modulus()) as u64,
                         sk,
                         &rerand_key,
-                        re_randomization_hash_algo,
+                        prf_re_randomization_context.inner(),
                     )?;
 
                 Ok(Self::new(
@@ -282,7 +282,7 @@ impl<Id: FheUintId> FheUint<Id> {
                         Id::num_blocks(cuda_key.message_modulus()) as u64,
                         cuda_key.pbs_key(),
                         &rerand_key,
-                        re_randomization_hash_algo,
+                        prf_re_randomization_context.inner(),
                         streams,
                     )?;
 
@@ -466,7 +466,7 @@ impl<Id: FheUintId> FheUint<Id> {
         range: &RangeForRandom,
         max_distance: Option<f64>,
         re_randomization_mode: RRD,
-        re_randomization_hash_algo: ReRandomizationHashAlgo,
+        prf_re_randomization_context: &PrfReRandomizationContext,
     ) -> crate::Result<Self> {
         let excluded_upper_bound = range.excluded_upper_bound;
 
@@ -477,7 +477,7 @@ impl<Id: FheUintId> FheUint<Id> {
                 seed,
                 random_bits_count,
                 re_randomization_mode,
-                re_randomization_hash_algo,
+                prf_re_randomization_context,
             )
         } else {
             let max_distance = max_distance.unwrap_or_else(|| 2_f64.powi(-128));
@@ -512,7 +512,7 @@ impl<Id: FheUintId> FheUint<Id> {
                             num_blocks_output,
                             sk,
                             &rerand_key,
-                            re_randomization_hash_algo,
+                            prf_re_randomization_context.inner()
                         )?;
 
                     Ok(Self::new(
@@ -639,7 +639,7 @@ impl<Id: FheIntId> FheInt<Id> {
     >(
         seed: impl OprfSeed,
         re_randomization_mode: RRD,
-        re_randomization_hash_algo: ReRandomizationHashAlgo,
+        prf_re_randomization_context: &PrfReRandomizationContext,
     ) -> crate::Result<Self> {
         let re_randomization_mode: ReRandomizationMode = re_randomization_mode.into();
         global_state::with_internal_keys(|key| match key {
@@ -654,7 +654,7 @@ impl<Id: FheIntId> FheInt<Id> {
                         Id::num_blocks(key.message_modulus()) as u64,
                         sk,
                         &rerand_key,
-                        re_randomization_hash_algo,
+                        prf_re_randomization_context.inner(),
                     )?;
 
                 Ok(Self::new(
@@ -675,7 +675,7 @@ impl<Id: FheIntId> FheInt<Id> {
                         Id::num_blocks(cuda_key.message_modulus()) as u64,
                         cuda_key.pbs_key(),
                         &rerand_key,
-                        re_randomization_hash_algo,
+                        prf_re_randomization_context.inner(),
                         streams,
                     )?;
 
@@ -773,7 +773,7 @@ impl<Id: FheIntId> FheInt<Id> {
         seed: impl OprfSeed,
         random_bits_count: u64,
         re_randomization_mode: RRD,
-        re_randomization_hash_algo: ReRandomizationHashAlgo,
+        prf_re_randomization_context: &PrfReRandomizationContext,
     ) -> crate::Result<Self> {
         let re_randomization_mode: ReRandomizationMode = re_randomization_mode.into();
         global_state::with_internal_keys(|key| match key {
@@ -789,7 +789,7 @@ impl<Id: FheIntId> FheInt<Id> {
                         Id::num_blocks(key.message_modulus()) as u64,
                         sk,
                         &rerand_key,
-                        re_randomization_hash_algo,
+                        prf_re_randomization_context.inner(),
                     )?;
 
                 Ok(Self::new(
@@ -811,7 +811,7 @@ impl<Id: FheIntId> FheInt<Id> {
                         Id::num_blocks(cuda_key.message_modulus()) as u64,
                         cuda_key.pbs_key(),
                         &rerand_key,
-                        re_randomization_hash_algo,
+                        prf_re_randomization_context.inner(),
                         streams,
                     )?;
 
@@ -941,6 +941,7 @@ fn mod_pow_2(exponent: u64, modulus: u64) -> u64 {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::integer::ciphertext::{ReRandomizationHashAlgo, ReRandomizationSeedHasher};
     use crate::integer::server_key::radix_parallel::tests_unsigned::test_oprf::{
         oprf_density_function, p_value_upper_bound_oprf_almost_uniformity_from_values,
         probability_density_function_from_density,
@@ -1283,17 +1284,25 @@ mod test {
         }
 
         {
-            for rerand_algo in [
+            for rerand_hash_algo in [
                 ReRandomizationHashAlgo::Blake3,
                 ReRandomizationHashAlgo::Shake256,
             ] {
+                let seed_hasher = ReRandomizationSeedHasher::new(
+                    rerand_hash_algo,
+                    crate::shortint::oprf::TFHE_PRF_RERAND_DOMAIN_SEPARATOR,
+                );
+                let prf_rerand_context = PrfReRandomizationContext::new_with_hasher(
+                    crate::shortint::public_key::compact::TFHE_PKE_DOMAIN_SEPARATOR,
+                    seed_hasher,
+                );
                 // Do not use static seed in production
                 let ct_unsigned_bounded =
                     FheUint8::generate_oblivious_pseudo_random_bounded_and_re_randomize(
                         Seed(0),
                         0,
                         ReRandomizationMode::UseAvailableMode,
-                        rerand_algo,
+                        &prf_rerand_context,
                     )
                     .unwrap();
                 assert!(ct_unsigned_bounded.is_trivial());
@@ -1304,17 +1313,25 @@ mod test {
         }
 
         {
-            for rerand_algo in [
+            for rerand_hash_algo in [
                 ReRandomizationHashAlgo::Blake3,
                 ReRandomizationHashAlgo::Shake256,
             ] {
+                let seed_hasher = ReRandomizationSeedHasher::new(
+                    rerand_hash_algo,
+                    crate::shortint::oprf::TFHE_PRF_RERAND_DOMAIN_SEPARATOR,
+                );
+                let prf_rerand_context = PrfReRandomizationContext::new_with_hasher(
+                    crate::shortint::public_key::compact::TFHE_PKE_DOMAIN_SEPARATOR,
+                    seed_hasher,
+                );
                 // Do not use static seed in production
                 let ct_signed_bounded =
                     FheInt8::generate_oblivious_pseudo_random_bounded_and_re_randomize(
                         Seed(0),
                         0,
                         ReRandomizationMode::UseAvailableMode,
-                        rerand_algo,
+                        &prf_rerand_context,
                     )
                     .unwrap();
                 assert!(ct_signed_bounded.is_trivial());
@@ -1352,21 +1369,29 @@ mod test {
             let unsigned_decrypted_result: u8 = unsigned_rnd.decrypt(client_key);
             let signed_decrypted_result: i8 = signed_rnd.decrypt(client_key);
 
-            for hash_algo in [
+            for rerand_hash_algo in [
                 ReRandomizationHashAlgo::Blake3,
                 ReRandomizationHashAlgo::Shake256,
             ] {
+                let seed_hasher = ReRandomizationSeedHasher::new(
+                    rerand_hash_algo,
+                    crate::shortint::oprf::TFHE_PRF_RERAND_DOMAIN_SEPARATOR,
+                );
+                let prf_rerand_context = PrfReRandomizationContext::new_with_hasher(
+                    crate::shortint::public_key::compact::TFHE_PKE_DOMAIN_SEPARATOR,
+                    seed_hasher,
+                );
                 let unsigned_rnd_rerand =
                     FheUint8::generate_oblivious_pseudo_random_and_re_randomize(
                         seed,
                         rerand_mode,
-                        hash_algo,
+                        &prf_rerand_context,
                     )
                     .unwrap();
                 let signed_rnd_rerand = FheInt8::generate_oblivious_pseudo_random_and_re_randomize(
                     seed,
                     rerand_mode,
-                    hash_algo,
+                    &prf_rerand_context,
                 )
                 .unwrap();
 
@@ -1395,16 +1420,24 @@ mod test {
             let unsigned_decrypted_result: u8 = unsigned_rnd.decrypt(client_key);
             let signed_decrypted_result: i8 = signed_rnd.decrypt(client_key);
 
-            for hash_algo in [
+            for rerand_hash_algo in [
                 ReRandomizationHashAlgo::Blake3,
                 ReRandomizationHashAlgo::Shake256,
             ] {
+                let seed_hasher = ReRandomizationSeedHasher::new(
+                    rerand_hash_algo,
+                    crate::shortint::oprf::TFHE_PRF_RERAND_DOMAIN_SEPARATOR,
+                );
+                let prf_rerand_context = PrfReRandomizationContext::new_with_hasher(
+                    crate::shortint::public_key::compact::TFHE_PKE_DOMAIN_SEPARATOR,
+                    seed_hasher,
+                );
                 let unsigned_rnd_rerand =
                     FheUint8::generate_oblivious_pseudo_random_bounded_and_re_randomize(
                         seed,
                         bit_count_bounded,
                         rerand_mode,
-                        hash_algo,
+                        &prf_rerand_context,
                     )
                     .unwrap();
                 let signed_rnd_rerand =
@@ -1412,7 +1445,7 @@ mod test {
                         seed,
                         bit_count_bounded,
                         rerand_mode,
-                        hash_algo,
+                        &prf_rerand_context,
                     )
                     .unwrap();
 
@@ -1460,17 +1493,25 @@ mod test {
 
             let unsigned_decrypted_result: u8 = unsigned_rnd.decrypt(client_key);
 
-            for hash_algo in [
+            for rerand_hash_algo in [
                 ReRandomizationHashAlgo::Blake3,
                 ReRandomizationHashAlgo::Shake256,
             ] {
+                let seed_hasher = ReRandomizationSeedHasher::new(
+                    rerand_hash_algo,
+                    crate::shortint::oprf::TFHE_PRF_RERAND_DOMAIN_SEPARATOR,
+                );
+                let prf_rerand_context = PrfReRandomizationContext::new_with_hasher(
+                    crate::shortint::public_key::compact::TFHE_PKE_DOMAIN_SEPARATOR,
+                    seed_hasher,
+                );
                 let unsigned_rnd_rerand =
                     FheUint8::generate_oblivious_pseudo_random_custom_range_and_re_randomize(
                         seed,
                         &range,
                         None,
                         rerand_mode,
-                        hash_algo,
+                        &prf_rerand_context,
                     )
                     .unwrap();
 
@@ -1559,17 +1600,25 @@ mod test {
                 }
 
                 {
-                    for rerand_algo in [
+                    for rerand_hash_algo in [
                         ReRandomizationHashAlgo::Blake3,
                         ReRandomizationHashAlgo::Shake256,
                     ] {
+                        let seed_hasher = ReRandomizationSeedHasher::new(
+                            rerand_hash_algo,
+                            crate::shortint::oprf::TFHE_PRF_RERAND_DOMAIN_SEPARATOR,
+                        );
+                        let prf_rerand_context = PrfReRandomizationContext::new_with_hasher(
+                            crate::shortint::public_key::compact::TFHE_PKE_DOMAIN_SEPARATOR,
+                            seed_hasher,
+                        );
                         // Do not use static seed in production
                         let ct_unsigned_bounded =
                             FheUint8::generate_oblivious_pseudo_random_bounded_and_re_randomize(
                                 Seed(0),
                                 0,
                                 ReRandomizationMode::UseAvailableMode,
-                                rerand_algo,
+                                &prf_rerand_context,
                             )
                             .unwrap();
                         assert!(ct_unsigned_bounded.is_trivial());
@@ -1580,17 +1629,25 @@ mod test {
                 }
 
                 {
-                    for rerand_algo in [
+                    for rerand_hash_algo in [
                         ReRandomizationHashAlgo::Blake3,
                         ReRandomizationHashAlgo::Shake256,
                     ] {
+                        let seed_hasher = ReRandomizationSeedHasher::new(
+                            rerand_hash_algo,
+                            crate::shortint::oprf::TFHE_PRF_RERAND_DOMAIN_SEPARATOR,
+                        );
+                        let prf_rerand_context = PrfReRandomizationContext::new_with_hasher(
+                            crate::shortint::public_key::compact::TFHE_PKE_DOMAIN_SEPARATOR,
+                            seed_hasher,
+                        );
                         // Do not use static seed in production
                         let ct_signed_bounded =
                             FheInt8::generate_oblivious_pseudo_random_bounded_and_re_randomize(
                                 Seed(0),
                                 0,
                                 ReRandomizationMode::UseAvailableMode,
-                                rerand_algo,
+                                &prf_rerand_context,
                             )
                             .unwrap();
                         assert!(ct_signed_bounded.is_trivial());

--- a/tfhe/src/high_level_api/integers/oprf.rs
+++ b/tfhe/src/high_level_api/integers/oprf.rs
@@ -852,7 +852,7 @@ impl<Id: FheIntId> FheInt<Id> {
                 let streams = &cuda_key.streams;
                 cuda_key
                     .oprf_key()
-                    .get_par_generate_oblivious_pseudo_random_unsigned_integer_bounded_size_on_gpu(
+                    .get_par_generate_oblivious_pseudo_random_signed_integer_bounded_size_on_gpu(
                         cuda_key.pbs_key(),
                         streams,
                     )

--- a/tfhe/src/high_level_api/integers/oprf.rs
+++ b/tfhe/src/high_level_api/integers/oprf.rs
@@ -1,7 +1,9 @@
 use super::{FheIntId, FheUint, FheUintId};
 use crate::high_level_api::global_state;
 use crate::high_level_api::keys::InternalServerKey;
-use crate::high_level_api::re_randomization::ReRandomizationMetadata;
+use crate::high_level_api::re_randomization::{
+    ReRandomizationHashAlgo, ReRandomizationMetadata, ReRandomizationMode,
+};
 #[cfg(feature = "gpu")]
 use crate::integer::gpu::ciphertext::{CudaSignedRadixCiphertext, CudaUnsignedRadixCiphertext};
 use crate::shortint::{MessageModulus, OprfSeed};
@@ -67,6 +69,7 @@ impl<Id: FheUintId> FheUint<Id> {
             }
         })
     }
+
     #[cfg(feature = "gpu")]
     /// Returns the amount of memory required to execute generate_oblivious_pseudo_random
     ///
@@ -100,10 +103,74 @@ impl<Id: FheUintId> FheUint<Id> {
             }
         })
     }
+
+    /// Re-randomizing variant of [`Self::generate_oblivious_pseudo_random`].
+    pub fn generate_oblivious_pseudo_random_and_re_randomize<
+        'a,
+        RRD: Into<ReRandomizationMode<'a>>,
+    >(
+        seed: impl OprfSeed,
+        re_randomization_mode: RRD,
+        re_randomization_hash_algo: ReRandomizationHashAlgo,
+    ) -> crate::Result<Self> {
+        let re_randomization_mode: ReRandomizationMode = re_randomization_mode.into();
+        global_state::with_internal_keys(|key| match key {
+            InternalServerKey::Cpu(key) => {
+                let sk = key.pbs_key();
+                let rerand_key =
+                    key.integer_re_randomization_key_from_mode(re_randomization_mode)?;
+                let ct = key
+                    .oprf_key()
+                    .par_generate_oblivious_pseudo_random_unsigned_integer_and_re_randomize(
+                        seed,
+                        Id::num_blocks(key.message_modulus()) as u64,
+                        sk,
+                        &rerand_key,
+                        re_randomization_hash_algo,
+                    )?;
+
+                Ok(Self::new(
+                    ct,
+                    key.tag.clone(),
+                    ReRandomizationMetadata::default(),
+                ))
+            }
+            #[cfg(feature = "gpu")]
+            InternalServerKey::Cuda(cuda_key) => {
+                let streams = &cuda_key.streams;
+                let rerand_key =
+                    cuda_key.integer_re_randomization_key_from_mode(re_randomization_mode)?;
+                let d_ct: CudaUnsignedRadixCiphertext = cuda_key
+                    .oprf_key()
+                    .par_generate_oblivious_pseudo_random_unsigned_integer_and_re_randomize(
+                        seed,
+                        Id::num_blocks(cuda_key.message_modulus()) as u64,
+                        cuda_key.pbs_key(),
+                        &rerand_key,
+                        re_randomization_hash_algo,
+                        streams,
+                    )?;
+
+                Ok(Self::new(
+                    d_ct,
+                    cuda_key.tag.clone(),
+                    ReRandomizationMetadata::default(),
+                ))
+            }
+            #[cfg(feature = "hpu")]
+            InternalServerKey::Hpu(_device) => {
+                panic!("Hpu does not support this operation yet.")
+            }
+        })
+    }
+
     /// Generates an encrypted unsigned integer
     /// taken uniformly in `[0, 2^random_bits_count[` using the given seed.
     /// The encrypted value is oblivious to the server.
     /// It can be useful to make server random generation deterministic.
+    ///
+    /// WARNING: If the requested `random_bits_count` is 0, then the returned ciphertext is a
+    /// trivial encryption of 0.
     ///
     /// ```rust
     /// use tfhe::prelude::FheDecrypt;
@@ -158,6 +225,72 @@ impl<Id: FheUintId> FheUint<Id> {
                     cuda_key.tag.clone(),
                     ReRandomizationMetadata::default(),
                 )
+            }
+            #[cfg(feature = "hpu")]
+            InternalServerKey::Hpu(_device) => {
+                panic!("Hpu does not support this operation yet.")
+            }
+        })
+    }
+
+    /// Re-randomizing variant of [`Self::generate_oblivious_pseudo_random_bounded`].
+    ///
+    /// WARNING: If the requested `random_bits_count` is 0, then the returned ciphertext is a
+    /// trivial encryption of 0.
+    pub fn generate_oblivious_pseudo_random_bounded_and_re_randomize<
+        'a,
+        RRD: Into<ReRandomizationMode<'a>>,
+    >(
+        seed: impl OprfSeed,
+        random_bits_count: u64,
+        re_randomization_mode: RRD,
+        re_randomization_hash_algo: ReRandomizationHashAlgo,
+    ) -> crate::Result<Self> {
+        let re_randomization_mode: ReRandomizationMode = re_randomization_mode.into();
+        global_state::with_internal_keys(|key| match key {
+            InternalServerKey::Cpu(key) => {
+                let sk = key.pbs_key();
+                let rerand_key =
+                    key.integer_re_randomization_key_from_mode(re_randomization_mode)?;
+                let ct = key
+                    .oprf_key()
+                    .par_generate_oblivious_pseudo_random_unsigned_integer_bounded_and_re_randomize(
+                        seed,
+                        random_bits_count,
+                        Id::num_blocks(key.message_modulus()) as u64,
+                        sk,
+                        &rerand_key,
+                        re_randomization_hash_algo,
+                    )?;
+
+                Ok(Self::new(
+                    ct,
+                    key.tag.clone(),
+                    ReRandomizationMetadata::default(),
+                ))
+            }
+            #[cfg(feature = "gpu")]
+            InternalServerKey::Cuda(cuda_key) => {
+                let streams = &cuda_key.streams;
+                let rerand_key =
+                    cuda_key.integer_re_randomization_key_from_mode(re_randomization_mode)?;
+                let d_ct: CudaUnsignedRadixCiphertext = cuda_key
+                    .oprf_key()
+                    .par_generate_oblivious_pseudo_random_unsigned_integer_bounded_and_re_randomize(
+                        seed,
+                        random_bits_count,
+                        Id::num_blocks(cuda_key.message_modulus()) as u64,
+                        cuda_key.pbs_key(),
+                        &rerand_key,
+                        re_randomization_hash_algo,
+                        streams,
+                    )?;
+
+                Ok(Self::new(
+                    d_ct,
+                    cuda_key.tag.clone(),
+                    ReRandomizationMetadata::default(),
+                ))
             }
             #[cfg(feature = "hpu")]
             InternalServerKey::Hpu(_device) => {
@@ -320,6 +453,88 @@ impl<Id: FheUintId> FheUint<Id> {
             }
         })
     }
+
+    /// Re-randomizing variant of [`Self::generate_oblivious_pseudo_random_custom_range`].
+    ///
+    /// The GPU backend does not yet expose a re-randomizing custom-range PRF primitive; calling
+    /// this function with a GPU server key currently panics for the non-power-of-two case.
+    pub fn generate_oblivious_pseudo_random_custom_range_and_re_randomize<
+        'a,
+        RRD: Into<ReRandomizationMode<'a>>,
+    >(
+        seed: impl OprfSeed,
+        range: &RangeForRandom,
+        max_distance: Option<f64>,
+        re_randomization_mode: RRD,
+        re_randomization_hash_algo: ReRandomizationHashAlgo,
+    ) -> crate::Result<Self> {
+        let excluded_upper_bound = range.excluded_upper_bound;
+
+        if excluded_upper_bound.is_power_of_two() {
+            let random_bits_count = excluded_upper_bound.ilog2() as u64;
+
+            Self::generate_oblivious_pseudo_random_bounded_and_re_randomize(
+                seed,
+                random_bits_count,
+                re_randomization_mode,
+                re_randomization_hash_algo,
+            )
+        } else {
+            let max_distance = max_distance.unwrap_or_else(|| 2_f64.powi(-128));
+
+            assert!(
+                0_f64 < max_distance && max_distance < 1_f64,
+                "max_distance (={max_distance}) should be in ]0, 1["
+            );
+
+            let re_randomization_mode: ReRandomizationMode = re_randomization_mode.into();
+            global_state::with_internal_keys(|key| match key {
+                InternalServerKey::Cpu(key) => {
+                    let message_modulus = key.message_modulus();
+
+                    let num_input_random_bits = num_input_random_bits_for_max_distance(
+                        excluded_upper_bound,
+                        max_distance,
+                        message_modulus,
+                    );
+
+                    let num_blocks_output = Id::num_blocks(key.message_modulus()) as u64;
+
+                    let sk = key.pbs_key();
+                    let rerand_key =
+                        key.integer_re_randomization_key_from_mode(re_randomization_mode)?;
+                    let ct = key
+                        .oprf_key()
+                        .par_generate_oblivious_pseudo_random_unsigned_custom_range_and_re_randomize(
+                            seed,
+                            num_input_random_bits,
+                            excluded_upper_bound,
+                            num_blocks_output,
+                            sk,
+                            &rerand_key,
+                            re_randomization_hash_algo,
+                        )?;
+
+                    Ok(Self::new(
+                        ct,
+                        key.tag.clone(),
+                        ReRandomizationMetadata::default(),
+                    ))
+                }
+                #[cfg(feature = "gpu")]
+                InternalServerKey::Cuda(_cuda_key) => {
+                    panic!(
+                        "generate_oblivious_pseudo_random_custom_range_and_re_randomize is not yet \
+                        supported on GPU for non-power-of-two ranges."
+                    );
+                }
+                #[cfg(feature = "hpu")]
+                InternalServerKey::Hpu(_device) => {
+                    panic!("Hpu does not support this operation yet.")
+                }
+            })
+        }
+    }
 }
 
 impl<Id: FheIntId> FheInt<Id> {
@@ -416,10 +631,74 @@ impl<Id: FheIntId> FheInt<Id> {
             }
         })
     }
+
+    /// Re-randomizing variant of [`Self::generate_oblivious_pseudo_random`].
+    pub fn generate_oblivious_pseudo_random_and_re_randomize<
+        'a,
+        RRD: Into<ReRandomizationMode<'a>>,
+    >(
+        seed: impl OprfSeed,
+        re_randomization_mode: RRD,
+        re_randomization_hash_algo: ReRandomizationHashAlgo,
+    ) -> crate::Result<Self> {
+        let re_randomization_mode: ReRandomizationMode = re_randomization_mode.into();
+        global_state::with_internal_keys(|key| match key {
+            InternalServerKey::Cpu(key) => {
+                let sk = key.pbs_key();
+                let rerand_key =
+                    key.integer_re_randomization_key_from_mode(re_randomization_mode)?;
+                let ct = key
+                    .oprf_key()
+                    .par_generate_oblivious_pseudo_random_signed_integer_and_re_randomize(
+                        seed,
+                        Id::num_blocks(key.message_modulus()) as u64,
+                        sk,
+                        &rerand_key,
+                        re_randomization_hash_algo,
+                    )?;
+
+                Ok(Self::new(
+                    ct,
+                    key.tag.clone(),
+                    ReRandomizationMetadata::default(),
+                ))
+            }
+            #[cfg(feature = "gpu")]
+            InternalServerKey::Cuda(cuda_key) => {
+                let streams = &cuda_key.streams;
+                let rerand_key =
+                    cuda_key.integer_re_randomization_key_from_mode(re_randomization_mode)?;
+                let d_ct: CudaSignedRadixCiphertext = cuda_key
+                    .oprf_key()
+                    .par_generate_oblivious_pseudo_random_signed_integer_and_re_randomize(
+                        seed,
+                        Id::num_blocks(cuda_key.message_modulus()) as u64,
+                        cuda_key.pbs_key(),
+                        &rerand_key,
+                        re_randomization_hash_algo,
+                        streams,
+                    )?;
+
+                Ok(Self::new(
+                    d_ct,
+                    cuda_key.tag.clone(),
+                    ReRandomizationMetadata::default(),
+                ))
+            }
+            #[cfg(feature = "hpu")]
+            InternalServerKey::Hpu(_device) => {
+                panic!("Hpu does not support this operation yet.")
+            }
+        })
+    }
+
     /// Generates an encrypted signed integer
     /// taken uniformly in `[0, 2^random_bits_count[` using the given seed.
     /// The encrypted value is oblivious to the server.
     /// It can be useful to make server random generation deterministic.
+    ///
+    /// WARNING: If the requested `random_bits_count` is 0, then the returned ciphertext is a
+    /// trivial encryption of 0.
     ///
     /// ```rust
     /// use tfhe::prelude::FheDecrypt;
@@ -482,6 +761,73 @@ impl<Id: FheIntId> FheInt<Id> {
             }
         })
     }
+
+    /// Re-randomizing variant of [`Self::generate_oblivious_pseudo_random_bounded`].
+    ///
+    /// WARNING: If the requested `random_bits_count` is 0, then the returned ciphertext is a
+    /// trivial encryption of 0.
+    pub fn generate_oblivious_pseudo_random_bounded_and_re_randomize<
+        'a,
+        RRD: Into<ReRandomizationMode<'a>>,
+    >(
+        seed: impl OprfSeed,
+        random_bits_count: u64,
+        re_randomization_mode: RRD,
+        re_randomization_hash_algo: ReRandomizationHashAlgo,
+    ) -> crate::Result<Self> {
+        let re_randomization_mode: ReRandomizationMode = re_randomization_mode.into();
+        global_state::with_internal_keys(|key| match key {
+            InternalServerKey::Cpu(key) => {
+                let sk = key.pbs_key();
+                let rerand_key =
+                    key.integer_re_randomization_key_from_mode(re_randomization_mode)?;
+                let ct = key
+                    .oprf_key()
+                    .par_generate_oblivious_pseudo_random_signed_integer_bounded_and_re_randomize(
+                        seed,
+                        random_bits_count,
+                        Id::num_blocks(key.message_modulus()) as u64,
+                        sk,
+                        &rerand_key,
+                        re_randomization_hash_algo,
+                    )?;
+
+                Ok(Self::new(
+                    ct,
+                    key.tag.clone(),
+                    ReRandomizationMetadata::default(),
+                ))
+            }
+            #[cfg(feature = "gpu")]
+            InternalServerKey::Cuda(cuda_key) => {
+                let streams = &cuda_key.streams;
+                let rerand_key =
+                    cuda_key.integer_re_randomization_key_from_mode(re_randomization_mode)?;
+                let d_ct: CudaSignedRadixCiphertext = cuda_key
+                    .oprf_key()
+                    .par_generate_oblivious_pseudo_random_signed_integer_bounded_and_re_randomize(
+                        seed,
+                        random_bits_count,
+                        Id::num_blocks(cuda_key.message_modulus()) as u64,
+                        cuda_key.pbs_key(),
+                        &rerand_key,
+                        re_randomization_hash_algo,
+                        streams,
+                    )?;
+
+                Ok(Self::new(
+                    d_ct,
+                    cuda_key.tag.clone(),
+                    ReRandomizationMetadata::default(),
+                ))
+            }
+            #[cfg(feature = "hpu")]
+            InternalServerKey::Hpu(_device) => {
+                panic!("Hpu does not support this operation yet.")
+            }
+        })
+    }
+
     #[cfg(feature = "gpu")]
     /// Returns the amount of memory required to execute generate_oblivious_pseudo_random_bounded
     ///
@@ -605,8 +951,10 @@ mod test {
         TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
         TEST_PARAM_MESSAGE_2_CARRY_2_PBS_KS_GAUSSIAN_2M128,
     };
-    use crate::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS32_PBS_TUNIFORM_2M128;
-    use crate::{generate_keys, set_server_key, ConfigBuilder, FheInt8, FheUint8, Seed};
+    use crate::shortint::parameters::{
+        ReRandomizationParameters, PARAM_MESSAGE_2_CARRY_2_KS32_PBS_TUNIFORM_2M128,
+    };
+    use crate::{generate_keys, set_server_key, ClientKey, ConfigBuilder, FheInt8, FheUint8, Seed};
     use num_bigint::BigUint;
     use rand::{thread_rng, Rng};
     use rayon::iter::{IntoParallelIterator, ParallelIterator};
@@ -909,24 +1257,247 @@ mod test {
             TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
         )
         .use_dedicated_oprf_key(true)
+        .enable_ciphertext_re_randomization(ReRandomizationParameters::DerivedCPKWithoutKeySwitch)
         .build();
 
         let (client_key, server_key) = generate_keys(config);
         set_server_key(server_key);
 
-        // Do not use static seed in production
-        let ct_unsigned_bounded = FheUint8::generate_oblivious_pseudo_random_bounded(Seed(0), 0);
-        assert!(ct_unsigned_bounded.is_trivial());
-        let result_unsigned_bounded: u8 = ct_unsigned_bounded.decrypt(&client_key);
-        // PRF with 0 bits is equivalent to modulo 1 meaning only 0 is generated
-        assert_eq!(result_unsigned_bounded, 0);
+        {
+            // Do not use static seed in production
+            let ct_unsigned_bounded =
+                FheUint8::generate_oblivious_pseudo_random_bounded(Seed(0), 0);
+            assert!(ct_unsigned_bounded.is_trivial());
+            let result_unsigned_bounded: u8 = ct_unsigned_bounded.decrypt(&client_key);
+            // PRF with 0 bits is equivalent to modulo 1 meaning only 0 is generated
+            assert_eq!(result_unsigned_bounded, 0);
+        }
 
-        // Do not use static seed in production
-        let ct_signed_bounded = FheInt8::generate_oblivious_pseudo_random_bounded(Seed(0), 0);
-        assert!(ct_signed_bounded.is_trivial());
-        let result_signed_bounded: i8 = ct_signed_bounded.decrypt(&client_key);
-        // PRF with 0 bits is equivalent to modulo 1 meaning only 0 is generated
-        assert_eq!(result_signed_bounded, 0);
+        {
+            // Do not use static seed in production
+            let ct_signed_bounded = FheInt8::generate_oblivious_pseudo_random_bounded(Seed(0), 0);
+            assert!(ct_signed_bounded.is_trivial());
+            let result_signed_bounded: i8 = ct_signed_bounded.decrypt(&client_key);
+            // PRF with 0 bits is equivalent to modulo 1 meaning only 0 is generated
+            assert_eq!(result_signed_bounded, 0);
+        }
+
+        {
+            for rerand_algo in [
+                ReRandomizationHashAlgo::Blake3,
+                ReRandomizationHashAlgo::Shake256,
+            ] {
+                // Do not use static seed in production
+                let ct_unsigned_bounded =
+                    FheUint8::generate_oblivious_pseudo_random_bounded_and_re_randomize(
+                        Seed(0),
+                        0,
+                        ReRandomizationMode::UseAvailableMode,
+                        rerand_algo,
+                    )
+                    .unwrap();
+                assert!(ct_unsigned_bounded.is_trivial());
+                let result_unsigned_bounded: u8 = ct_unsigned_bounded.decrypt(&client_key);
+                // PRF with 0 bits is equivalent to modulo 1 meaning only 0 is generated
+                assert_eq!(result_unsigned_bounded, 0);
+            }
+        }
+
+        {
+            for rerand_algo in [
+                ReRandomizationHashAlgo::Blake3,
+                ReRandomizationHashAlgo::Shake256,
+            ] {
+                // Do not use static seed in production
+                let ct_signed_bounded =
+                    FheInt8::generate_oblivious_pseudo_random_bounded_and_re_randomize(
+                        Seed(0),
+                        0,
+                        ReRandomizationMode::UseAvailableMode,
+                        rerand_algo,
+                    )
+                    .unwrap();
+                assert!(ct_signed_bounded.is_trivial());
+                let result_signed_bounded: i8 = ct_signed_bounded.decrypt(&client_key);
+                // PRF with 0 bits is equivalent to modulo 1 meaning only 0 is generated
+                assert_eq!(result_signed_bounded, 0);
+            }
+        }
+    }
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    struct FullAndBoundedResults {
+        seed: Seed,
+        unsigned_full: u8,
+        signed_full: i8,
+        bit_count_bounded: u64,
+        unsigned_bounded: u8,
+        signed_bounded: i8,
+    }
+
+    fn prf_equivalence_subtests_full_and_bounded(
+        client_key: &ClientKey,
+        rerand_mode: ReRandomizationMode,
+        seed: Option<Seed>,
+        bit_count_bounded: Option<u64>,
+    ) -> FullAndBoundedResults {
+        // Make sure seed generation is secure in production, this is a test setup
+        let seed = seed.unwrap_or_else(|| crate::Seed(rand::random()));
+
+        // Full sub-case
+        let (unsigned_full, signed_full) = {
+            let unsigned_rnd = FheUint8::generate_oblivious_pseudo_random(seed);
+            let signed_rnd = FheInt8::generate_oblivious_pseudo_random(seed);
+
+            let unsigned_decrypted_result: u8 = unsigned_rnd.decrypt(client_key);
+            let signed_decrypted_result: i8 = signed_rnd.decrypt(client_key);
+
+            for hash_algo in [
+                ReRandomizationHashAlgo::Blake3,
+                ReRandomizationHashAlgo::Shake256,
+            ] {
+                let unsigned_rnd_rerand =
+                    FheUint8::generate_oblivious_pseudo_random_and_re_randomize(
+                        seed,
+                        rerand_mode,
+                        hash_algo,
+                    )
+                    .unwrap();
+                let signed_rnd_rerand = FheInt8::generate_oblivious_pseudo_random_and_re_randomize(
+                    seed,
+                    rerand_mode,
+                    hash_algo,
+                )
+                .unwrap();
+
+                let decrypted_unsigned_result_rerand: u8 = unsigned_rnd_rerand.decrypt(client_key);
+                let decrypted_signed_result_rerand: i8 = signed_rnd_rerand.decrypt(client_key);
+
+                assert_eq!(unsigned_decrypted_result, decrypted_unsigned_result_rerand);
+                assert_eq!(signed_decrypted_result, decrypted_signed_result_rerand);
+            }
+
+            (unsigned_decrypted_result, signed_decrypted_result)
+        };
+
+        // Bounded sub-case
+        let (bit_count_bounded, unsigned_bounded, signed_bounded) = {
+            // Case zero bits handled by test_oprf_bounded_zero
+            let bit_count_bounded: u64 = bit_count_bounded
+                .unwrap_or_else(|| rand::thread_rng().gen_range(1..u8::BITS).into())
+                .max(1);
+
+            let unsigned_rnd =
+                FheUint8::generate_oblivious_pseudo_random_bounded(seed, bit_count_bounded);
+            let signed_rnd =
+                FheInt8::generate_oblivious_pseudo_random_bounded(seed, bit_count_bounded);
+
+            let unsigned_decrypted_result: u8 = unsigned_rnd.decrypt(client_key);
+            let signed_decrypted_result: i8 = signed_rnd.decrypt(client_key);
+
+            for hash_algo in [
+                ReRandomizationHashAlgo::Blake3,
+                ReRandomizationHashAlgo::Shake256,
+            ] {
+                let unsigned_rnd_rerand =
+                    FheUint8::generate_oblivious_pseudo_random_bounded_and_re_randomize(
+                        seed,
+                        bit_count_bounded,
+                        rerand_mode,
+                        hash_algo,
+                    )
+                    .unwrap();
+                let signed_rnd_rerand =
+                    FheInt8::generate_oblivious_pseudo_random_bounded_and_re_randomize(
+                        seed,
+                        bit_count_bounded,
+                        rerand_mode,
+                        hash_algo,
+                    )
+                    .unwrap();
+
+                let decrypted_unsigned_result_rerand: u8 = unsigned_rnd_rerand.decrypt(client_key);
+                let decrypted_signed_result_rerand: i8 = signed_rnd_rerand.decrypt(client_key);
+
+                assert_eq!(unsigned_decrypted_result, decrypted_unsigned_result_rerand);
+                assert_eq!(signed_decrypted_result, decrypted_signed_result_rerand);
+            }
+
+            (
+                bit_count_bounded,
+                unsigned_decrypted_result,
+                signed_decrypted_result,
+            )
+        };
+
+        FullAndBoundedResults {
+            seed,
+            unsigned_full,
+            signed_full,
+            bit_count_bounded,
+            unsigned_bounded,
+            signed_bounded,
+        }
+    }
+
+    // TODO fuse in the other function once GPU is available for custom_range
+    fn prf_equivalence_subtest_custom_range(
+        client_key: &ClientKey,
+        rerand_mode: ReRandomizationMode,
+    ) {
+        // Make sure seed generation is secure in production, this is a test setup
+        let seed = crate::Seed(rand::random());
+
+        // Custom Range
+        {
+            // Case zero bits handled by test_oprf_bounded_zero
+            let inclusive_upper_bound: u64 = rand::thread_rng().gen_range(1..=u8::MAX).into();
+            let exclusive_upper_bound = NonZeroU64::new(inclusive_upper_bound + 1).unwrap();
+            let range = RangeForRandom::new_from_excluded_upper_bound(exclusive_upper_bound);
+
+            let unsigned_rnd =
+                FheUint8::generate_oblivious_pseudo_random_custom_range(seed, &range, None);
+
+            let unsigned_decrypted_result: u8 = unsigned_rnd.decrypt(client_key);
+
+            for hash_algo in [
+                ReRandomizationHashAlgo::Blake3,
+                ReRandomizationHashAlgo::Shake256,
+            ] {
+                let unsigned_rnd_rerand =
+                    FheUint8::generate_oblivious_pseudo_random_custom_range_and_re_randomize(
+                        seed,
+                        &range,
+                        None,
+                        rerand_mode,
+                        hash_algo,
+                    )
+                    .unwrap();
+
+                let decrypted_unsigned_result_rerand: u8 = unsigned_rnd_rerand.decrypt(client_key);
+
+                assert_eq!(unsigned_decrypted_result, decrypted_unsigned_result_rerand);
+            }
+        }
+    }
+
+    #[test]
+    fn test_prf_and_re_rand_equivalence() {
+        let config = ConfigBuilder::with_custom_parameters(
+            TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+        )
+        .use_dedicated_oprf_key(true)
+        .enable_ciphertext_re_randomization(ReRandomizationParameters::DerivedCPKWithoutKeySwitch)
+        .build();
+
+        let rerand_mode = ReRandomizationMode::UseAvailableMode;
+
+        let client_key = crate::ClientKey::generate(config);
+        let cpu_key = crate::ServerKey::new(&client_key);
+        crate::set_server_key(cpu_key);
+
+        let _ = prf_equivalence_subtests_full_and_bounded(&client_key, rerand_mode, None, None);
+        prf_equivalence_subtest_custom_range(&client_key, rerand_mode);
     }
 
     #[cfg(feature = "gpu")]
@@ -934,7 +1505,11 @@ mod test {
         use super::*;
         use crate::core_crypto::gpu::get_number_of_gpus;
         use crate::prelude::check_valid_cuda_malloc_assert_oom;
-        use crate::shortint::parameters::PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+        use crate::shortint::parameters::{
+            AtomicPatternParameters,
+            PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+            PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+        };
         use crate::{
             clear_gpu_thread_locals, ClientKey, CompressedServerKey, FheInt128, FheUint32,
             FheUint64, GpuIndex,
@@ -945,24 +1520,126 @@ mod test {
 
         #[test]
         fn test_oprf_bounded_zero() {
-            for setup_fn in crate::high_level_api::integers::unsigned::tests::gpu::GPU_SETUP_FN {
-                let client_key = setup_fn();
+            for params in [
+                AtomicPatternParameters::from(
+                    PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+                ),
+                AtomicPatternParameters::from(PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128),
+            ] {
+                let config = ConfigBuilder::with_custom_parameters(params)
+                    .use_dedicated_oprf_key(true)
+                    .enable_ciphertext_re_randomization(
+                        ReRandomizationParameters::DerivedCPKWithoutKeySwitch,
+                    )
+                    .build();
 
-                // Do not use static seed in production
-                let ct_unsigned_bounded =
-                    FheUint8::generate_oblivious_pseudo_random_bounded(Seed(0), 0);
-                assert!(ct_unsigned_bounded.is_trivial());
-                let result_unsigned_bounded: u8 = ct_unsigned_bounded.decrypt(&client_key);
-                // PRF with 0 bits is equivalent to modulo 1 meaning only 0 is generated
-                assert_eq!(result_unsigned_bounded, 0);
+                let client_key = ClientKey::generate(config);
+                let compressed_sk = CompressedServerKey::new(&client_key);
+                let server_key = compressed_sk.decompress_to_gpu();
+                set_server_key(server_key);
 
-                // Do not use static seed in production
-                let ct_signed_bounded =
-                    FheInt8::generate_oblivious_pseudo_random_bounded(Seed(0), 0);
-                assert!(ct_signed_bounded.is_trivial());
-                let result_signed_bounded: i8 = ct_signed_bounded.decrypt(&client_key);
-                // PRF with 0 bits is equivalent to modulo 1 meaning only 0 is generated
-                assert_eq!(result_signed_bounded, 0);
+                {
+                    // Do not use static seed in production
+                    let ct_unsigned_bounded =
+                        FheUint8::generate_oblivious_pseudo_random_bounded(Seed(0), 0);
+                    assert!(ct_unsigned_bounded.is_trivial());
+                    let result_unsigned_bounded: u8 = ct_unsigned_bounded.decrypt(&client_key);
+                    // PRF with 0 bits is equivalent to modulo 1 meaning only 0 is generated
+                    assert_eq!(result_unsigned_bounded, 0);
+                }
+
+                {
+                    // Do not use static seed in production
+                    let ct_signed_bounded =
+                        FheInt8::generate_oblivious_pseudo_random_bounded(Seed(0), 0);
+                    assert!(ct_signed_bounded.is_trivial());
+                    let result_signed_bounded: i8 = ct_signed_bounded.decrypt(&client_key);
+                    // PRF with 0 bits is equivalent to modulo 1 meaning only 0 is generated
+                    assert_eq!(result_signed_bounded, 0);
+                }
+
+                {
+                    for rerand_algo in [
+                        ReRandomizationHashAlgo::Blake3,
+                        ReRandomizationHashAlgo::Shake256,
+                    ] {
+                        // Do not use static seed in production
+                        let ct_unsigned_bounded =
+                            FheUint8::generate_oblivious_pseudo_random_bounded_and_re_randomize(
+                                Seed(0),
+                                0,
+                                ReRandomizationMode::UseAvailableMode,
+                                rerand_algo,
+                            )
+                            .unwrap();
+                        assert!(ct_unsigned_bounded.is_trivial());
+                        let result_unsigned_bounded: u8 = ct_unsigned_bounded.decrypt(&client_key);
+                        // PRF with 0 bits is equivalent to modulo 1 meaning only 0 is generated
+                        assert_eq!(result_unsigned_bounded, 0);
+                    }
+                }
+
+                {
+                    for rerand_algo in [
+                        ReRandomizationHashAlgo::Blake3,
+                        ReRandomizationHashAlgo::Shake256,
+                    ] {
+                        // Do not use static seed in production
+                        let ct_signed_bounded =
+                            FheInt8::generate_oblivious_pseudo_random_bounded_and_re_randomize(
+                                Seed(0),
+                                0,
+                                ReRandomizationMode::UseAvailableMode,
+                                rerand_algo,
+                            )
+                            .unwrap();
+                        assert!(ct_signed_bounded.is_trivial());
+                        let result_signed_bounded: i8 = ct_signed_bounded.decrypt(&client_key);
+                        // PRF with 0 bits is equivalent to modulo 1 meaning only 0 is generated
+                        assert_eq!(result_signed_bounded, 0);
+                    }
+                }
+            }
+        }
+
+        #[test]
+        fn test_prf_and_re_rand_equivalence() {
+            for params in [
+                AtomicPatternParameters::from(
+                    PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+                ),
+                AtomicPatternParameters::from(PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128),
+            ] {
+                let config = ConfigBuilder::with_custom_parameters(params)
+                    .use_dedicated_oprf_key(true)
+                    .enable_ciphertext_re_randomization(
+                        ReRandomizationParameters::DerivedCPKWithoutKeySwitch,
+                    )
+                    .build();
+
+                let client_key = ClientKey::generate(config);
+                let compressed_sk = CompressedServerKey::new(&client_key);
+                let rerand_mode = ReRandomizationMode::UseAvailableMode;
+
+                let cpu_key = compressed_sk.decompress();
+                crate::set_server_key(cpu_key);
+
+                let expected_results =
+                    prf_equivalence_subtests_full_and_bounded(&client_key, rerand_mode, None, None);
+
+                let server_key = compressed_sk.decompress_to_gpu();
+                set_server_key(server_key);
+
+                let gpu_results = prf_equivalence_subtests_full_and_bounded(
+                    &client_key,
+                    rerand_mode,
+                    Some(expected_results.seed),
+                    Some(expected_results.bit_count_bounded),
+                );
+
+                assert_eq!(expected_results, gpu_results);
+
+                // TODO add custom_range test for GPU
             }
         }
 

--- a/tfhe/src/high_level_api/integers/oprf.rs
+++ b/tfhe/src/high_level_api/integers/oprf.rs
@@ -23,6 +23,8 @@ impl<Id: FheUintId> FheUint<Id> {
     ///
     /// set_server_key(server_key);
     ///
+    /// // DANGER: Using a deterministic seed is insecure and only done here to show API usage.
+    /// // The proper way of generating a seed depends on your application.
     /// let ct_res = FheUint8::generate_oblivious_pseudo_random(Seed(0));
     ///
     /// let dec_result: u16 = ct_res.decrypt(&client_key);
@@ -114,6 +116,8 @@ impl<Id: FheUintId> FheUint<Id> {
     ///
     /// let random_bits_count = 3;
     ///
+    /// // DANGER: Using a deterministic seed is insecure and only done here to show API usage.
+    /// // The proper way of generating a seed depends on your application.
     /// let ct_res = FheUint8::generate_oblivious_pseudo_random_bounded(Seed(0), random_bits_count);
     ///
     /// let dec_result: u16 = ct_res.decrypt(&client_key);
@@ -199,6 +203,8 @@ impl<Id: FheUintId> FheUint<Id> {
     ///
     /// let range = RangeForRandom::new_from_excluded_upper_bound(excluded_upper_bound);
     ///
+    /// // DANGER: Using a deterministic seed is insecure and only done here to show API usage.
+    /// // The proper way of generating a seed depends on your application.
     /// let ct_res = FheUint8::generate_oblivious_pseudo_random_custom_range(Seed(0), &range, None);
     ///
     /// let dec_result: u16 = ct_res.decrypt(&client_key);
@@ -331,6 +337,8 @@ impl<Id: FheIntId> FheInt<Id> {
     ///
     /// set_server_key(server_key);
     ///
+    /// // DANGER: Using a deterministic seed is insecure and only done here to show API usage.
+    /// // The proper way of generating a seed depends on your application.
     /// let ct_res = FheInt8::generate_oblivious_pseudo_random(Seed(0));
     ///
     /// let dec_result: i16 = ct_res.decrypt(&client_key);
@@ -424,6 +432,8 @@ impl<Id: FheIntId> FheInt<Id> {
     ///
     /// let random_bits_count = 3;
     ///
+    /// // DANGER: Using a deterministic seed is insecure and only done here to show API usage.
+    /// // The proper way of generating a seed depends on your application.
     /// let ct_res = FheInt8::generate_oblivious_pseudo_random_bounded(Seed(0), random_bits_count);
     ///
     /// let dec_result: i16 = ct_res.decrypt(&client_key);

--- a/tfhe/src/high_level_api/integers/shuffle.rs
+++ b/tfhe/src/high_level_api/integers/shuffle.rs
@@ -2,7 +2,7 @@ use crate::high_level_api::global_state;
 use crate::high_level_api::integers::FheIntegerType;
 use crate::high_level_api::keys::InternalServerKey;
 use crate::high_level_api::re_randomization::{
-    ReRandomizationHashAlgo, ReRandomizationMetadata, ReRandomizationMode,
+    PrfReRandomizationContext, ReRandomizationMetadata, ReRandomizationMode,
 };
 use crate::integer::server_key::radix_parallel::bitonic_shuffle::BitonicShuffleKeySize;
 use crate::OprfSeed;
@@ -70,7 +70,7 @@ pub fn re_randomized_keys_bitonic_shuffle<T, S>(
     key_size: BitonicShuffleKeySize,
     seed: S,
     re_randomization_mode: ReRandomizationMode,
-    re_randomization_hash_algo: ReRandomizationHashAlgo,
+    prf_re_randomization_context: &PrfReRandomizationContext,
 ) -> Result<Vec<T>, crate::Error>
 where
     T: FheIntegerType,
@@ -87,7 +87,7 @@ where
                 key_size,
                 seed,
                 &re_randomization_key,
-                re_randomization_hash_algo,
+                prf_re_randomization_context.inner(),
             )?;
             Ok(result
                 .into_iter()
@@ -114,6 +114,7 @@ mod test {
     use crate::high_level_api::prelude::*;
     use crate::high_level_api::tests::setup_default_cpu;
     use crate::high_level_api::{set_server_key, ClientKey, ConfigBuilder, ServerKey};
+    use crate::shortint::ciphertext::{ReRandomizationHashAlgo, ReRandomizationSeedHasher};
     use crate::shortint::parameters::ReRandomizationParameters;
     #[cfg(feature = "gpu")]
     use crate::{FheInt16, FheUint32};
@@ -156,17 +157,26 @@ mod test {
         let shuffled_rerand = {
             let mut shuffled_rerand = vec![];
 
-            for algo in [
+            for rerand_hash_algo in [
                 ReRandomizationHashAlgo::Blake3,
                 ReRandomizationHashAlgo::Shake256,
             ] {
+                let seed_hasher = ReRandomizationSeedHasher::new(
+                    rerand_hash_algo,
+                    crate::shortint::oprf::TFHE_PRF_RERAND_DOMAIN_SEPARATOR,
+                );
+                let prf_rerand_context = PrfReRandomizationContext::new_with_hasher(
+                    crate::shortint::public_key::compact::TFHE_PKE_DOMAIN_SEPARATOR,
+                    seed_hasher,
+                );
+
                 shuffled_rerand.push(
                     re_randomized_keys_bitonic_shuffle(
                         encrypted.clone(),
                         key_size,
                         seed,
                         ReRandomizationMode::UseAvailableMode,
-                        algo,
+                        &prf_rerand_context,
                     )
                     .unwrap(),
                 );
@@ -230,17 +240,26 @@ mod test {
         let shuffled_rerand = {
             let mut shuffled_rerand = vec![];
 
-            for algo in [
+            for rerand_hash_algo in [
                 ReRandomizationHashAlgo::Blake3,
                 ReRandomizationHashAlgo::Shake256,
             ] {
+                let seed_hasher = ReRandomizationSeedHasher::new(
+                    rerand_hash_algo,
+                    crate::shortint::oprf::TFHE_PRF_RERAND_DOMAIN_SEPARATOR,
+                );
+                let prf_rerand_context = PrfReRandomizationContext::new_with_hasher(
+                    crate::shortint::public_key::compact::TFHE_PKE_DOMAIN_SEPARATOR,
+                    seed_hasher,
+                );
+
                 shuffled_rerand.push(
                     re_randomized_keys_bitonic_shuffle(
                         encrypted.clone(),
                         key_size,
                         seed,
                         ReRandomizationMode::UseAvailableMode,
-                        algo,
+                        &prf_rerand_context,
                     )
                     .unwrap(),
                 );

--- a/tfhe/src/high_level_api/integers/shuffle.rs
+++ b/tfhe/src/high_level_api/integers/shuffle.rs
@@ -1,7 +1,9 @@
 use crate::high_level_api::global_state;
 use crate::high_level_api::integers::FheIntegerType;
 use crate::high_level_api::keys::InternalServerKey;
-use crate::high_level_api::re_randomization::ReRandomizationMetadata;
+use crate::high_level_api::re_randomization::{
+    ReRandomizationHashAlgo, ReRandomizationMetadata, ReRandomizationMode,
+};
 use crate::integer::server_key::radix_parallel::bitonic_shuffle::BitonicShuffleKeySize;
 use crate::OprfSeed;
 
@@ -63,16 +65,58 @@ where
     })
 }
 
+pub fn re_randomized_keys_bitonic_shuffle<T, S>(
+    data: Vec<T>,
+    key_size: BitonicShuffleKeySize,
+    seed: S,
+    re_randomization_mode: ReRandomizationMode,
+    re_randomization_hash_algo: ReRandomizationHashAlgo,
+) -> Result<Vec<T>, crate::Error>
+where
+    T: FheIntegerType,
+    S: OprfSeed,
+{
+    global_state::with_internal_keys(|key| match key {
+        InternalServerKey::Cpu(cpu_key) => {
+            let re_randomization_key =
+                cpu_key.integer_re_randomization_key_from_mode(re_randomization_mode)?;
+            let inner = data.into_iter().map(|v| v.into_cpu()).collect();
+            let result = cpu_key.pbs_key().re_randomized_keys_bitonic_shuffle(
+                &cpu_key.oprf_key(),
+                inner,
+                key_size,
+                seed,
+                &re_randomization_key,
+                re_randomization_hash_algo,
+            )?;
+            Ok(result
+                .into_iter()
+                .map(|ct| T::from_cpu(ct, cpu_key.tag.clone(), ReRandomizationMetadata::default()))
+                .collect())
+        }
+        #[cfg(feature = "gpu")]
+        InternalServerKey::Cuda(_) => Err(crate::Error::new(
+            "bitonic_shuffle is not supported on Cuda".to_string(),
+        )),
+        #[cfg(feature = "hpu")]
+        InternalServerKey::Hpu(_) => Err(crate::Error::new(
+            "bitonic_shuffle is not supported on Hpu".to_string(),
+        )),
+    })
+}
+
 #[cfg(test)]
 mod test {
-    use super::{bitonic_shuffle, BitonicShuffleKeySize};
+    use super::*;
     use crate::core_crypto::prelude::new_seeder;
     #[cfg(feature = "gpu")]
     use crate::high_level_api::integers::unsigned::tests::gpu::GPU_SETUP_FN;
     use crate::high_level_api::prelude::*;
     use crate::high_level_api::tests::setup_default_cpu;
+    use crate::high_level_api::{set_server_key, ClientKey, ConfigBuilder, ServerKey};
+    use crate::shortint::parameters::ReRandomizationParameters;
     #[cfg(feature = "gpu")]
-    use crate::{ClientKey, FheInt16, FheIntegerType, FheUint32};
+    use crate::{FheInt16, FheUint32};
     use crate::{FheInt8, FheUint8};
     #[cfg(feature = "gpu")]
     use rand::distributions::Standard;
@@ -82,7 +126,21 @@ mod test {
 
     #[test]
     fn test_bitonic_shuffle_fheuint() {
-        let cks = setup_default_cpu();
+        let cks = {
+            let config = ConfigBuilder::default()
+                .use_dedicated_oprf_key(true)
+                .enable_ciphertext_re_randomization(
+                    ReRandomizationParameters::DerivedCPKWithoutKeySwitch,
+                )
+                .build();
+
+            let cks = ClientKey::generate(config);
+            let sks = ServerKey::new(&cks);
+
+            set_server_key(sks);
+
+            cks
+        };
         let mut rng = rand::thread_rng();
         let mut clear_values: Vec<u8> = (0..15).map(|_| rng.gen()).collect();
 
@@ -93,19 +151,70 @@ mod test {
 
         let seed = new_seeder().seed();
         println!("seed: {seed:?}");
-        let shuffled =
-            bitonic_shuffle(encrypted, BitonicShuffleKeySize::num_bits(32), seed).unwrap();
+        let key_size = BitonicShuffleKeySize::num_bits(32);
+        let shuffled = bitonic_shuffle(encrypted.clone(), key_size, seed).unwrap();
+        let shuffled_rerand = {
+            let mut shuffled_rerand = vec![];
 
-        let mut decrypted: Vec<u8> = shuffled.iter().map(|ct| ct.decrypt(&cks)).collect();
+            for algo in [
+                ReRandomizationHashAlgo::Blake3,
+                ReRandomizationHashAlgo::Shake256,
+            ] {
+                shuffled_rerand.push(
+                    re_randomized_keys_bitonic_shuffle(
+                        encrypted.clone(),
+                        key_size,
+                        seed,
+                        ReRandomizationMode::UseAvailableMode,
+                        algo,
+                    )
+                    .unwrap(),
+                );
+            }
+
+            shuffled_rerand
+        };
+
+        let decrypted_ref: Vec<u8> = shuffled.iter().map(|ct| ct.decrypt(&cks)).collect();
 
         clear_values.sort_unstable();
-        decrypted.sort_unstable();
-        assert_eq!(decrypted, clear_values);
+        let decrypted_sorted = {
+            let mut tmp = decrypted_ref.clone();
+            tmp.sort_unstable();
+            tmp
+        };
+
+        assert_eq!(decrypted_sorted, clear_values);
+
+        for (idx, rerand_result) in shuffled_rerand.into_iter().enumerate() {
+            let decrypted_rerand: Vec<u8> =
+                rerand_result.iter().map(|ct| ct.decrypt(&cks)).collect();
+
+            assert_eq!(
+                decrypted_ref, decrypted_rerand,
+                "failed at index {idx} of decrypted_rerand"
+            );
+        }
     }
 
     #[test]
     fn test_bitonic_shuffle_fheint() {
-        let cks = setup_default_cpu();
+        let cks = {
+            let config = ConfigBuilder::default()
+                .use_dedicated_oprf_key(true)
+                .enable_ciphertext_re_randomization(
+                    ReRandomizationParameters::DerivedCPKWithoutKeySwitch,
+                )
+                .build();
+
+            let cks = ClientKey::generate(config);
+            let sks = ServerKey::new(&cks);
+
+            set_server_key(sks);
+
+            cks
+        };
+
         let mut rng = rand::thread_rng();
         let mut clear_values: Vec<i8> = (0..15).map(|_| rng.gen()).collect();
 
@@ -116,14 +225,50 @@ mod test {
 
         let seed = new_seeder().seed();
         println!("seed: {seed:?}");
-        let shuffled =
-            bitonic_shuffle(encrypted, BitonicShuffleKeySize::num_bits(32), seed).unwrap();
+        let key_size = BitonicShuffleKeySize::num_bits(32);
+        let shuffled = bitonic_shuffle(encrypted.clone(), key_size, seed).unwrap();
+        let shuffled_rerand = {
+            let mut shuffled_rerand = vec![];
 
-        let mut decrypted: Vec<i8> = shuffled.iter().map(|ct| ct.decrypt(&cks)).collect();
+            for algo in [
+                ReRandomizationHashAlgo::Blake3,
+                ReRandomizationHashAlgo::Shake256,
+            ] {
+                shuffled_rerand.push(
+                    re_randomized_keys_bitonic_shuffle(
+                        encrypted.clone(),
+                        key_size,
+                        seed,
+                        ReRandomizationMode::UseAvailableMode,
+                        algo,
+                    )
+                    .unwrap(),
+                );
+            }
+
+            shuffled_rerand
+        };
+
+        let decrypted_ref: Vec<i8> = shuffled.iter().map(|ct| ct.decrypt(&cks)).collect();
 
         clear_values.sort_unstable();
-        decrypted.sort_unstable();
-        assert_eq!(decrypted, clear_values);
+        let decrypted_sorted = {
+            let mut tmp = decrypted_ref.clone();
+            tmp.sort_unstable();
+            tmp
+        };
+
+        assert_eq!(decrypted_sorted, clear_values);
+
+        for (idx, rerand_result) in shuffled_rerand.into_iter().enumerate() {
+            let decrypted_rerand: Vec<i8> =
+                rerand_result.iter().map(|ct| ct.decrypt(&cks)).collect();
+
+            assert_eq!(
+                decrypted_ref, decrypted_rerand,
+                "failed at index {idx} of decrypted_rerand"
+            );
+        }
     }
 
     #[test]

--- a/tfhe/src/high_level_api/mod.rs
+++ b/tfhe/src/high_level_api/mod.rs
@@ -142,8 +142,8 @@ pub use compressed_noise_squashed_ciphertext_list::{
     HlSquashedNoiseCompressible, HlSquashedNoiseExpandable,
 };
 pub use re_randomization::{
-    ReRandomizationContext, ReRandomizationHashAlgo, ReRandomizationMetadata, ReRandomizationMode,
-    ReRandomizationSeedGen, ReRandomizationSupport,
+    PrfReRandomizationContext, ReRandomizationContext, ReRandomizationHashAlgo,
+    ReRandomizationMetadata, ReRandomizationMode, ReRandomizationSeedGen, ReRandomizationSupport,
 };
 #[cfg(feature = "strings")]
 pub use strings::ascii::{EncryptableString, FheAsciiString, FheStringIsEmpty, FheStringLen};

--- a/tfhe/src/high_level_api/mod.rs
+++ b/tfhe/src/high_level_api/mod.rs
@@ -140,8 +140,8 @@ pub use compressed_noise_squashed_ciphertext_list::{
     HlSquashedNoiseCompressible, HlSquashedNoiseExpandable,
 };
 pub use re_randomization::{
-    ReRandomizationContext, ReRandomizationMetadata, ReRandomizationMode, ReRandomizationSeedGen,
-    ReRandomizationSupport,
+    ReRandomizationContext, ReRandomizationHashAlgo, ReRandomizationMetadata, ReRandomizationMode,
+    ReRandomizationSeedGen, ReRandomizationSupport,
 };
 #[cfg(feature = "strings")]
 pub use strings::ascii::{EncryptableString, FheAsciiString, FheStringIsEmpty, FheStringLen};

--- a/tfhe/src/high_level_api/mod.rs
+++ b/tfhe/src/high_level_api/mod.rs
@@ -49,7 +49,9 @@ macro_rules! export_concrete_array_types {
 
 pub use crate::core_crypto::commons::math::random::{Seed, Seeder, XofSeed};
 pub use crate::high_level_api::integers::oprf::RangeForRandom;
-pub use crate::high_level_api::integers::shuffle::bitonic_shuffle;
+pub use crate::high_level_api::integers::shuffle::{
+    bitonic_shuffle, re_randomized_keys_bitonic_shuffle,
+};
 pub use crate::integer::server_key::MatchValues;
 pub use crate::shortint::OprfSeed;
 use crate::{error, Error, Versionize};

--- a/tfhe/src/high_level_api/re_randomization.rs
+++ b/tfhe/src/high_level_api/re_randomization.rs
@@ -281,3 +281,57 @@ impl ReRandomizationMetadata {
         self.inner.clear();
     }
 }
+
+/// A context used specifically for re-randomization in PRF functions like
+/// [`crate::high_level_api::integers::FheUint::generate_oblivious_pseudo_random_and_re_randomize`].
+#[derive(Default)]
+pub struct PrfReRandomizationContext {
+    inner: crate::integer::ciphertext::PrfReRandomizationContext,
+}
+
+impl PrfReRandomizationContext {
+    /// Create a new re-randomization context with the default seed hasher (blake3).
+    ///
+    /// `rerand_seeder_domain_separator` is the domain separator that will be fed into the
+    /// seed generator.
+    /// `public_encryption_domain_separator` is the domain separator that will be used along this
+    /// seed to generate the encryptions of zero.
+    ///
+    /// (See [`XofSeed`] for more information)
+    ///
+    /// # Example
+    /// ```rust
+    /// use tfhe::PrfReRandomizationContext;
+    /// let _re_rand_context = PrfReRandomizationContext::new(
+    ///     *b"PRF_RRND",
+    ///     *b"TFHE_Enc"
+    ///  );
+    pub fn new(
+        rerand_seeder_domain_separator: [u8; XofSeed::DOMAIN_SEP_LEN],
+        public_encryption_domain_separator: [u8; XofSeed::DOMAIN_SEP_LEN],
+    ) -> Self {
+        Self {
+            inner: crate::integer::ciphertext::PrfReRandomizationContext::new(
+                rerand_seeder_domain_separator,
+                public_encryption_domain_separator,
+            ),
+        }
+    }
+
+    /// Create a new re-randomization context with the provided seed hasher.
+    pub fn new_with_hasher(
+        public_encryption_domain_separator: [u8; XofSeed::DOMAIN_SEP_LEN],
+        seed_hasher: ReRandomizationSeedHasher,
+    ) -> Self {
+        Self {
+            inner: crate::integer::ciphertext::PrfReRandomizationContext::new_with_hasher(
+                public_encryption_domain_separator,
+                seed_hasher,
+            ),
+        }
+    }
+
+    pub(crate) fn inner(&self) -> &crate::integer::ciphertext::PrfReRandomizationContext {
+        &self.inner
+    }
+}

--- a/tfhe/src/high_level_api/re_randomization.rs
+++ b/tfhe/src/high_level_api/re_randomization.rs
@@ -3,6 +3,7 @@ use crate::core_crypto::commons::math::random::XofSeed;
 use crate::high_level_api::keys::CompactPublicKey;
 pub use crate::high_level_api::keys::ReRandomizationSupport;
 use crate::high_level_api::tag::SmallVec;
+pub use crate::integer::ciphertext::ReRandomizationHashAlgo;
 use crate::integer::ciphertext::{ReRandomizationSeed, ReRandomizationSeedHasher};
 
 use tfhe_versionable::Versionize;

--- a/tfhe/src/integer/ciphertext/re_randomization.rs
+++ b/tfhe/src/integer/ciphertext/re_randomization.rs
@@ -201,3 +201,65 @@ pub(crate) fn re_randomize_ciphertext_blocks(
         seed,
     )
 }
+
+pub struct PrfReRandomizationContext {
+    inner: crate::shortint::ciphertext::ReRandomizationContext,
+}
+
+impl PrfReRandomizationContext {
+    /// Create a new re-randomization context with the default seed hasher (blake3).
+    ///
+    /// `rerand_seeder_domain_separator` is the domain separator that will be fed into the
+    /// seed generator.
+    /// `public_encryption_domain_separator` is the domain separator that will be used along this
+    /// seed to generate the encryptions of zero.
+    ///
+    /// (See [`XofSeed`] for more information)
+    ///
+    /// # Example
+    /// ```rust
+    /// use tfhe::integer::ciphertext::PrfReRandomizationContext;
+    /// let _re_rand_context = PrfReRandomizationContext::new(
+    ///     *b"PRF_RRND",
+    ///     *b"TFHE_Enc"
+    ///  );
+    pub fn new(
+        rerand_seeder_domain_separator: [u8; XofSeed::DOMAIN_SEP_LEN],
+        public_encryption_domain_separator: [u8; XofSeed::DOMAIN_SEP_LEN],
+    ) -> Self {
+        Self {
+            inner: crate::shortint::ciphertext::ReRandomizationContext::new(
+                rerand_seeder_domain_separator,
+                public_encryption_domain_separator,
+            ),
+        }
+    }
+
+    /// Create a new re-randomization context with the provided seed hasher.
+    pub fn new_with_hasher(
+        public_encryption_domain_separator: [u8; XofSeed::DOMAIN_SEP_LEN],
+        seed_hasher: ReRandomizationSeedHasher,
+    ) -> Self {
+        Self {
+            inner: crate::shortint::ciphertext::ReRandomizationContext::new_with_hasher(
+                public_encryption_domain_separator,
+                seed_hasher,
+            ),
+        }
+    }
+
+    pub(crate) fn inner(&self) -> &crate::shortint::ciphertext::ReRandomizationContext {
+        &self.inner
+    }
+}
+
+impl Default for PrfReRandomizationContext {
+    fn default() -> Self {
+        Self {
+            inner: crate::shortint::ciphertext::ReRandomizationContext::new(
+                crate::shortint::oprf::TFHE_PRF_RERAND_DOMAIN_SEPARATOR,
+                crate::shortint::public_key::compact::TFHE_PKE_DOMAIN_SEPARATOR,
+            ),
+        }
+    }
+}

--- a/tfhe/src/integer/ciphertext/re_randomization.rs
+++ b/tfhe/src/integer/ciphertext/re_randomization.rs
@@ -4,7 +4,9 @@ use crate::core_crypto::commons::math::random::XofSeed;
 use crate::integer::ciphertext::AsShortintCiphertextSlice;
 use crate::integer::key_switching_key::KeySwitchingKeyMaterialView;
 use crate::integer::CompactPublicKey;
-pub use crate::shortint::ciphertext::{ReRandomizationSeed, ReRandomizationSeedHasher};
+pub use crate::shortint::ciphertext::{
+    ReRandomizationHashAlgo, ReRandomizationSeed, ReRandomizationSeedHasher,
+};
 use crate::shortint::Ciphertext;
 use crate::Result;
 
@@ -20,6 +22,17 @@ pub enum ReRandomizationKey<'key> {
     DerivedCPKWithoutKeySwitch {
         cpk: &'key CompactPublicKey,
     },
+}
+
+impl ReRandomizationKey<'_> {
+    pub fn get_cpk_and_optional_ksk(
+        &self,
+    ) -> (&CompactPublicKey, Option<&KeySwitchingKeyMaterialView<'_>>) {
+        match self {
+            ReRandomizationKey::LegacyDedicatedCPK { cpk, ksk } => (cpk, Some(ksk)),
+            ReRandomizationKey::DerivedCPKWithoutKeySwitch { cpk } => (cpk, None),
+        }
+    }
 }
 
 /// The context that will be hashed and used to generate unique [`ReRandomizationSeed`].
@@ -179,10 +192,8 @@ pub(crate) fn re_randomize_ciphertext_blocks(
     re_randomization_key: ReRandomizationKey<'_>,
     seed: ReRandomizationSeed,
 ) -> crate::Result<()> {
-    let (compact_public_key, key_switching_key_material) = match re_randomization_key {
-        ReRandomizationKey::LegacyDedicatedCPK { cpk, ksk } => (cpk, Some(ksk)),
-        ReRandomizationKey::DerivedCPKWithoutKeySwitch { cpk } => (cpk, None),
-    };
+    let (compact_public_key, key_switching_key_material) =
+        re_randomization_key.get_cpk_and_optional_ksk();
 
     compact_public_key.key.re_randomize_ciphertexts(
         blocks,

--- a/tfhe/src/integer/gpu/ciphertext/boolean_value.rs
+++ b/tfhe/src/integer/gpu/ciphertext/boolean_value.rs
@@ -12,7 +12,7 @@ use super::CudaIntegerRadixCiphertext;
 
 /// Wrapper type used to signal that the inner value encrypts 0 or 1
 ///
-/// Since values ares encrypted, it is not possible to know whether a
+/// Since values are encrypted, it is not possible to know whether a
 /// ciphertext encrypts a boolean value (0 or 1). However, some algorithms
 /// require that the ciphertext does indeed encrypt a boolean value.
 ///

--- a/tfhe/src/integer/gpu/server_key/radix/oprf.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/oprf.rs
@@ -1,6 +1,8 @@
 use std::borrow::Borrow;
 
 use crate::core_crypto::gpu::CudaStreams;
+use crate::integer::ciphertext::{ReRandomizationHashAlgo, ReRandomizationSeed};
+use crate::integer::gpu::ciphertext::re_randomization::CudaReRandomizationKey;
 use crate::integer::gpu::ciphertext::{
     CudaIntegerRadixCiphertext, CudaRadixCiphertext, CudaSignedRadixCiphertext,
     CudaUnsignedRadixCiphertext,
@@ -10,7 +12,9 @@ use crate::integer::gpu::server_key::{
 };
 use itertools::Itertools;
 
-use crate::shortint::oprf::{create_random_from_seed_modulus_switched, raw_seeded_msed_to_lwe};
+use crate::shortint::oprf::{
+    create_random_from_seed_modulus_switched, raw_seeded_msed_to_lwe, RandomBitsRleLeBytes,
+};
 use crate::shortint::OprfSeed;
 
 use crate::core_crypto::gpu::vec::CudaVec;
@@ -130,6 +134,25 @@ where
         )
     }
 
+    pub fn par_generate_oblivious_pseudo_random_unsigned_integer_and_re_randomize(
+        &self,
+        seed: impl OprfSeed,
+        num_blocks: u64,
+        target_sks: &CudaServerKey,
+        re_randomization_key: &CudaReRandomizationKey<'_>,
+        re_randomization_hash_algo: ReRandomizationHashAlgo,
+        streams: &CudaStreams,
+    ) -> crate::Result<CudaUnsignedRadixCiphertext> {
+        self.generate_oblivious_pseudo_random_unbounded_integer_and_re_randomize(
+            seed,
+            num_blocks,
+            target_sks,
+            re_randomization_key,
+            re_randomization_hash_algo,
+            streams,
+        )
+    }
+
     /// Generates an encrypted `num_block` blocks unsigned integer
     /// taken uniformly in `[0, 2^random_bits_count[` using the given seed.
     /// The encrypted value is oblivious to the server.
@@ -200,6 +223,39 @@ where
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
+    pub fn par_generate_oblivious_pseudo_random_unsigned_integer_bounded_and_re_randomize(
+        &self,
+        seed: impl OprfSeed,
+        random_bits_count: u64,
+        num_blocks: u64,
+        target_sks: &CudaServerKey,
+        re_randomization_key: &CudaReRandomizationKey<'_>,
+        re_randomization_hash_algo: ReRandomizationHashAlgo,
+        streams: &CudaStreams,
+    ) -> crate::Result<CudaUnsignedRadixCiphertext> {
+        assert!(target_sks.message_modulus.0.is_power_of_two());
+        let message_bits_count = target_sks.message_modulus.0.ilog2() as u64;
+        let range_bits_count = message_bits_count * num_blocks;
+        assert!(range_bits_count > 0);
+
+        assert!(
+            random_bits_count <= range_bits_count,
+            "The range asked for a random value (=[0, 2^{random_bits_count}[) \
+            does not fit in the available range [0, 2^{range_bits_count}[",
+        );
+
+        self.generate_oblivious_pseudo_random_bounded_integer_and_re_randomize(
+            seed,
+            random_bits_count,
+            num_blocks,
+            target_sks,
+            re_randomization_key,
+            re_randomization_hash_algo,
+            streams,
+        )
+    }
+
     /// Generates an encrypted `num_block` blocks signed integer
     /// taken uniformly in its full range using the given seed.
     /// The encrypted value is oblivious to the server.
@@ -245,6 +301,25 @@ where
     ) -> CudaSignedRadixCiphertext {
         self.generate_oblivious_pseudo_random_unbounded_integer(
             seed, num_blocks, target_sks, streams,
+        )
+    }
+
+    pub fn par_generate_oblivious_pseudo_random_signed_integer_and_re_randomize(
+        &self,
+        seed: impl OprfSeed,
+        num_blocks: u64,
+        target_sks: &CudaServerKey,
+        re_randomization_key: &CudaReRandomizationKey<'_>,
+        re_randomization_hash_algo: ReRandomizationHashAlgo,
+        streams: &CudaStreams,
+    ) -> crate::Result<CudaSignedRadixCiphertext> {
+        self.generate_oblivious_pseudo_random_unbounded_integer_and_re_randomize(
+            seed,
+            num_blocks,
+            target_sks,
+            re_randomization_key,
+            re_randomization_hash_algo,
+            streams,
         )
     }
 
@@ -324,9 +399,45 @@ where
         )
     }
 
-    // Generic internal implementation for unbounded pseudo-random generation.
-    // It calls the core implementation with parameters for the unbounded case.
-    //
+    #[allow(clippy::too_many_arguments)]
+    pub fn par_generate_oblivious_pseudo_random_signed_integer_bounded_and_re_randomize(
+        &self,
+        seed: impl OprfSeed,
+        random_bits_count: u64,
+        num_blocks: u64,
+        target_sks: &CudaServerKey,
+        re_randomization_key: &CudaReRandomizationKey<'_>,
+        re_randomization_hash_algo: ReRandomizationHashAlgo,
+        streams: &CudaStreams,
+    ) -> crate::Result<CudaSignedRadixCiphertext> {
+        assert!(target_sks.message_modulus.0.is_power_of_two());
+        let message_bits_count = target_sks.message_modulus.0.ilog2() as u64;
+        let range_bits_count = message_bits_count * num_blocks;
+        assert!(range_bits_count > 0);
+
+        {
+            let signed_range_bits_count = range_bits_count.saturating_sub(1);
+            assert!(
+                random_bits_count <= signed_range_bits_count,
+                "The range asked for a random value (=[0, 2^{random_bits_count}[) \
+                which does not fit in the available range \
+                [-2^{signed_range_bits_count}, 2^{signed_range_bits_count}[",
+            );
+        }
+
+        self.generate_oblivious_pseudo_random_bounded_integer_and_re_randomize(
+            seed,
+            random_bits_count,
+            num_blocks,
+            target_sks,
+            re_randomization_key,
+            re_randomization_hash_algo,
+            streams,
+        )
+    }
+
+    /// Generic internal implementation for unbounded pseudo-random generation.
+    /// It calls the core implementation with parameters for the unbounded case.
     fn generate_oblivious_pseudo_random_unbounded_integer<T>(
         &self,
         seed: impl OprfSeed,
@@ -347,7 +458,7 @@ where
             return result;
         }
 
-        self.generate_multiblocks_oblivious_pseudo_random(
+        let _random_bits_rle_bytes = self.generate_multiblocks_oblivious_pseudo_random(
             result.as_mut(),
             seed,
             num_blocks,
@@ -359,9 +470,46 @@ where
         result
     }
 
-    // Generic internal implementation for bounded pseudo-random generation.
-    // It calls the core implementation with parameters for the bounded case.
-    //
+    /// Same as [`Self::generate_oblivious_pseudo_random_unbounded_integer`] with additional
+    /// re-randomization of the output.
+    fn generate_oblivious_pseudo_random_unbounded_integer_and_re_randomize<T>(
+        &self,
+        prf_seed: impl OprfSeed,
+        num_blocks: u64,
+        target_sks: &CudaServerKey,
+        re_randomization_key: &CudaReRandomizationKey<'_>,
+        re_randomization_hash_algo: ReRandomizationHashAlgo,
+        streams: &CudaStreams,
+    ) -> crate::Result<T>
+    where
+        T: CudaIntegerRadixCiphertext,
+    {
+        assert!(target_sks.message_modulus.0.is_power_of_two());
+
+        let message_bits_count = target_sks.message_modulus.0.ilog2() as u64;
+
+        let mut result = target_sks.create_trivial_zero_radix(num_blocks as usize, streams);
+
+        if num_blocks == 0 {
+            return Ok(result);
+        }
+
+        self.generate_multiblocks_oblivious_pseudo_random_and_re_randomize(
+            result.as_mut(),
+            prf_seed,
+            num_blocks,
+            num_blocks * message_bits_count,
+            target_sks,
+            re_randomization_key,
+            re_randomization_hash_algo,
+            streams,
+        )?;
+
+        Ok(result)
+    }
+
+    /// Generic internal implementation for bounded pseudo-random generation.
+    /// It calls the core implementation with parameters for the bounded case.
     fn generate_oblivious_pseudo_random_bounded_integer<T>(
         &self,
         seed: impl OprfSeed,
@@ -387,7 +535,7 @@ where
             return result;
         }
 
-        self.generate_multiblocks_oblivious_pseudo_random(
+        let _random_bits_rle_bytes = self.generate_multiblocks_oblivious_pseudo_random(
             result.as_mut(),
             seed,
             num_active_blocks,
@@ -396,6 +544,49 @@ where
             streams,
         );
         result
+    }
+
+    /// Same as [`Self::generate_oblivious_pseudo_random_bounded_integer`] with additional
+    /// re-randomization of the output.
+    #[allow(clippy::too_many_arguments)]
+    fn generate_oblivious_pseudo_random_bounded_integer_and_re_randomize<T>(
+        &self,
+        seed: impl OprfSeed,
+        random_bits_count: u64,
+        num_blocks: u64,
+        target_sks: &CudaServerKey,
+        re_randomization_key: &CudaReRandomizationKey<'_>,
+        re_randomization_hash_algo: ReRandomizationHashAlgo,
+        streams: &CudaStreams,
+    ) -> crate::Result<T>
+    where
+        T: CudaIntegerRadixCiphertext,
+    {
+        assert!(target_sks.message_modulus.0.is_power_of_two());
+        let message_bits_count = target_sks.message_modulus.0.ilog2() as u64;
+        let num_active_blocks = random_bits_count.div_ceil(message_bits_count);
+
+        let mut result = target_sks.create_trivial_zero_radix(num_blocks as usize, streams);
+
+        assert!(
+            num_blocks >= num_active_blocks,
+            "Cuda error: num_blocks should be greater than num_blocks_to_process"
+        );
+        if num_active_blocks == 0 {
+            return Ok(result);
+        }
+
+        self.generate_multiblocks_oblivious_pseudo_random_and_re_randomize(
+            result.as_mut(),
+            seed,
+            num_active_blocks,
+            random_bits_count,
+            target_sks,
+            re_randomization_key,
+            re_randomization_hash_algo,
+            streams,
+        )
+        .map(|_| result)
     }
 
     /// Core private implementation that calls the OPRF backend.
@@ -410,7 +601,7 @@ where
         total_random_bits: u64,
         target_sks: &CudaServerKey,
         streams: &CudaStreams,
-    ) {
+    ) -> RandomBitsRleLeBytes {
         let CudaDynamicKeyswitchingKey::Standard(computing_ks_key) = &target_sks.key_switching_key
         else {
             panic!("Only the standard atomic pattern is supported");
@@ -426,7 +617,7 @@ where
         let carry_bits_count = target_sks.carry_modulus.0.ilog2();
         let bits_per_block = message_bits_count + carry_bits_count + 1;
 
-        let (seeded, _rle_info) = create_random_from_seed_modulus_switched(
+        let (seeded, rle_info) = create_random_from_seed_modulus_switched(
             seed,
             in_lwe_size,
             polynomial_size,
@@ -484,6 +675,40 @@ where
                 }
             }
         }
+
+        rle_info
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn generate_multiblocks_oblivious_pseudo_random_and_re_randomize(
+        &self,
+        result: &mut CudaRadixCiphertext,
+        prf_seed: impl OprfSeed,
+        num_active_blocks: u64,
+        total_random_bits: u64,
+        target_sks: &CudaServerKey,
+        re_randomization_key: &CudaReRandomizationKey<'_>,
+        re_randomization_hash_algo: ReRandomizationHashAlgo,
+        streams: &CudaStreams,
+    ) -> crate::Result<()> {
+        let prf_seed = prf_seed.into_bytes();
+        let prf_seed = prf_seed.as_ref();
+        let prf_random_bits_rle_bytes = self.generate_multiblocks_oblivious_pseudo_random(
+            result,
+            prf_seed,
+            num_active_blocks,
+            total_random_bits,
+            target_sks,
+            streams,
+        );
+
+        let rerand_seed = ReRandomizationSeed::new_prf_rerand_seed(
+            re_randomization_hash_algo,
+            prf_seed,
+            &prf_random_bits_rle_bytes,
+        );
+
+        result.re_randomize(*re_randomization_key, rerand_seed, streams)
     }
 
     pub(crate) fn bootstrapping_key(&self) -> &CudaBootstrappingKey<u64> {
@@ -648,8 +873,7 @@ where
         result
     }
 
-    // Getter for the GPU memory usage of OPRF.
-    //
+    /// Getter for the GPU memory usage of OPRF.
     pub fn get_par_generate_oblivious_pseudo_random_unsigned_integer_size_on_gpu(
         &self,
         target_sks: &CudaServerKey,

--- a/tfhe/src/integer/gpu/server_key/radix/oprf.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/oprf.rs
@@ -524,11 +524,17 @@ where
             function instead"
         );
 
+        // Since excluded_upper_bound is not a power of two, we know the ceil log2 of the value is
+        // the ilog2 + 1, this is how many bits are needed to represent the value
+        let excluded_upper_bound_log2: u64 = excluded_upper_bound.ilog2().into();
+        let excluded_upper_bound_ceil_log2 = excluded_upper_bound_log2 + 1;
         let num_bits_output = num_blocks_output * message_bits_count;
+
         assert!(
-            (excluded_upper_bound as f64) < 2_f64.powi(num_bits_output as i32),
+            excluded_upper_bound_ceil_log2 <= num_bits_output,
             "num_blocks_output(={num_blocks_output}) is too small to hold an integer \
-            up to excluded_upper_bound(={excluded_upper_bound})"
+            up to excluded_upper_bound(={excluded_upper_bound}). Output has {num_bits_output} bits,\
+            {excluded_upper_bound} needs {excluded_upper_bound_ceil_log2} bits to be represented."
         );
 
         let CudaDynamicKeyswitchingKey::Standard(computing_ks_key) = &target_sks.key_switching_key
@@ -543,8 +549,7 @@ where
         let polynomial_size = bootstrapping_key.polynomial_size();
         let in_lwe_size = input_lwe_dimension.to_lwe_size();
 
-        let post_mul_num_bits =
-            num_input_random_bits + (excluded_upper_bound as f64).log2().ceil() as u64;
+        let post_mul_num_bits = num_input_random_bits + excluded_upper_bound_ceil_log2;
 
         let num_blocks_intermediate = post_mul_num_bits.div_ceil(message_bits_count);
 

--- a/tfhe/src/integer/gpu/server_key/radix/oprf.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/oprf.rs
@@ -109,6 +109,8 @@ where
     /// let compressed_oprf_sk = CompressedOprfServerKey::new(&oprf_pk, &cks).unwrap();
     /// let cuda_oprf_sk = CudaOprfServerKey::decompress_from_cpu(&compressed_oprf_sk, &streams);
     ///
+    /// // DANGER: Using a fixed seed is insecure and only done here to show API usage.
+    /// // The proper way of generating a seed depends on your application.
     /// let d_ct_res = cuda_oprf_sk.par_generate_oblivious_pseudo_random_unsigned_integer(Seed(0), size as u64, &sks, &streams);
     /// let ct_res = d_ct_res.to_radix_ciphertext(&streams);
     /// // Decrypt:
@@ -156,6 +158,8 @@ where
     ///
     /// let random_bits_count = 3;
     ///
+    /// // DANGER: Using a fixed seed is insecure and only done here to show API usage.
+    /// // The proper way of generating a seed depends on your application.
     /// let d_ct_res = cuda_oprf_sk.par_generate_oblivious_pseudo_random_unsigned_integer_bounded(
     ///     Seed(0),
     ///     random_bits_count,
@@ -222,6 +226,8 @@ where
     /// let compressed_oprf_sk = CompressedOprfServerKey::new(&oprf_pk, &cks).unwrap();
     /// let cuda_oprf_sk = CudaOprfServerKey::decompress_from_cpu(&compressed_oprf_sk, &streams);
     ///
+    /// // DANGER: Using a fixed seed is insecure and only done here to show API usage.
+    /// // The proper way of generating a seed depends on your application.
     /// let d_ct_res = cuda_oprf_sk.par_generate_oblivious_pseudo_random_signed_integer(Seed(0), size as u64, &sks, &streams);
     /// let ct_res = d_ct_res.to_signed_radix_ciphertext(&streams);
     ///
@@ -270,6 +276,8 @@ where
     ///
     /// let random_bits_count = 3;
     ///
+    /// // DANGER: Using a fixed seed is insecure and only done here to show API usage.
+    /// // The proper way of generating a seed depends on your application.
     /// let d_ct_res = cuda_oprf_sk.par_generate_oblivious_pseudo_random_signed_integer_bounded(
     ///     Seed(0),
     ///     random_bits_count,

--- a/tfhe/src/integer/gpu/server_key/radix/oprf.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/oprf.rs
@@ -1,7 +1,7 @@
 use std::borrow::Borrow;
 
 use crate::core_crypto::gpu::CudaStreams;
-use crate::integer::ciphertext::{ReRandomizationHashAlgo, ReRandomizationSeed};
+use crate::integer::ciphertext::{PrfReRandomizationContext, ReRandomizationSeed};
 use crate::integer::gpu::ciphertext::re_randomization::CudaReRandomizationKey;
 use crate::integer::gpu::ciphertext::{
     CudaIntegerRadixCiphertext, CudaRadixCiphertext, CudaSignedRadixCiphertext,
@@ -140,7 +140,7 @@ where
         num_blocks: u64,
         target_sks: &CudaServerKey,
         re_randomization_key: &CudaReRandomizationKey<'_>,
-        re_randomization_hash_algo: ReRandomizationHashAlgo,
+        prf_re_randomization_context: &PrfReRandomizationContext,
         streams: &CudaStreams,
     ) -> crate::Result<CudaUnsignedRadixCiphertext> {
         self.generate_oblivious_pseudo_random_unbounded_integer_and_re_randomize(
@@ -148,7 +148,7 @@ where
             num_blocks,
             target_sks,
             re_randomization_key,
-            re_randomization_hash_algo,
+            prf_re_randomization_context,
             streams,
         )
     }
@@ -231,7 +231,7 @@ where
         num_blocks: u64,
         target_sks: &CudaServerKey,
         re_randomization_key: &CudaReRandomizationKey<'_>,
-        re_randomization_hash_algo: ReRandomizationHashAlgo,
+        prf_re_randomization_context: &PrfReRandomizationContext,
         streams: &CudaStreams,
     ) -> crate::Result<CudaUnsignedRadixCiphertext> {
         assert!(target_sks.message_modulus.0.is_power_of_two());
@@ -251,7 +251,7 @@ where
             num_blocks,
             target_sks,
             re_randomization_key,
-            re_randomization_hash_algo,
+            prf_re_randomization_context,
             streams,
         )
     }
@@ -310,7 +310,7 @@ where
         num_blocks: u64,
         target_sks: &CudaServerKey,
         re_randomization_key: &CudaReRandomizationKey<'_>,
-        re_randomization_hash_algo: ReRandomizationHashAlgo,
+        prf_re_randomization_context: &PrfReRandomizationContext,
         streams: &CudaStreams,
     ) -> crate::Result<CudaSignedRadixCiphertext> {
         self.generate_oblivious_pseudo_random_unbounded_integer_and_re_randomize(
@@ -318,7 +318,7 @@ where
             num_blocks,
             target_sks,
             re_randomization_key,
-            re_randomization_hash_algo,
+            prf_re_randomization_context,
             streams,
         )
     }
@@ -407,7 +407,7 @@ where
         num_blocks: u64,
         target_sks: &CudaServerKey,
         re_randomization_key: &CudaReRandomizationKey<'_>,
-        re_randomization_hash_algo: ReRandomizationHashAlgo,
+        prf_re_randomization_context: &PrfReRandomizationContext,
         streams: &CudaStreams,
     ) -> crate::Result<CudaSignedRadixCiphertext> {
         assert!(target_sks.message_modulus.0.is_power_of_two());
@@ -431,7 +431,7 @@ where
             num_blocks,
             target_sks,
             re_randomization_key,
-            re_randomization_hash_algo,
+            prf_re_randomization_context,
             streams,
         )
     }
@@ -478,7 +478,7 @@ where
         num_blocks: u64,
         target_sks: &CudaServerKey,
         re_randomization_key: &CudaReRandomizationKey<'_>,
-        re_randomization_hash_algo: ReRandomizationHashAlgo,
+        prf_re_randomization_context: &PrfReRandomizationContext,
         streams: &CudaStreams,
     ) -> crate::Result<T>
     where
@@ -500,7 +500,7 @@ where
             num_blocks * message_bits_count,
             target_sks,
             re_randomization_key,
-            re_randomization_hash_algo,
+            prf_re_randomization_context,
             streams,
         )?;
 
@@ -555,7 +555,7 @@ where
         num_blocks: u64,
         target_sks: &CudaServerKey,
         re_randomization_key: &CudaReRandomizationKey<'_>,
-        re_randomization_hash_algo: ReRandomizationHashAlgo,
+        prf_re_randomization_context: &PrfReRandomizationContext,
         streams: &CudaStreams,
     ) -> crate::Result<T>
     where
@@ -586,7 +586,7 @@ where
             random_bits_count,
             target_sks,
             re_randomization_key,
-            re_randomization_hash_algo,
+            prf_re_randomization_context,
             streams,
         )?;
 
@@ -701,7 +701,7 @@ where
         total_random_bits: u64,
         target_sks: &CudaServerKey,
         re_randomization_key: &CudaReRandomizationKey<'_>,
-        re_randomization_hash_algo: ReRandomizationHashAlgo,
+        prf_re_randomization_context: &PrfReRandomizationContext,
         streams: &CudaStreams,
     ) -> crate::Result<()> {
         let prf_seed = prf_seed.into_bytes();
@@ -719,7 +719,7 @@ where
         );
 
         let rerand_seed = ReRandomizationSeed::new_prf_rerand_seed(
-            re_randomization_hash_algo,
+            prf_re_randomization_context.inner(),
             prf_seed,
             &prf_random_bits_rle_bytes,
         );

--- a/tfhe/src/integer/gpu/server_key/radix/oprf.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/oprf.rs
@@ -497,7 +497,6 @@ where
         self.generate_multiblocks_oblivious_pseudo_random_and_re_randomize(
             result.as_mut(),
             prf_seed,
-            num_blocks,
             num_blocks * message_bits_count,
             target_sks,
             re_randomization_key,
@@ -566,7 +565,12 @@ where
         let message_bits_count = target_sks.message_modulus.0.ilog2() as u64;
         let num_active_blocks = random_bits_count.div_ceil(message_bits_count);
 
-        let mut result = target_sks.create_trivial_zero_radix(num_blocks as usize, streams);
+        // We need the PRF + ReRand to be applied only on the num_active_blocks and later extend
+        // with trivial 0s (so that the padding is not re-randed)
+        //
+        // The multiblocks primitive applies the rerand to all the blocks (there is no
+        // "active blocks" rerand primitive currently)
+        let mut result = target_sks.create_trivial_zero_radix(num_active_blocks as usize, streams);
 
         assert!(
             num_blocks >= num_active_blocks,
@@ -579,14 +583,24 @@ where
         self.generate_multiblocks_oblivious_pseudo_random_and_re_randomize(
             result.as_mut(),
             seed,
-            num_active_blocks,
             random_bits_count,
             target_sks,
             re_randomization_key,
             re_randomization_hash_algo,
             streams,
-        )
-        .map(|_| result)
+        )?;
+
+        if num_blocks == num_active_blocks {
+            Ok(result)
+        } else {
+            // We manually cast to unsigned to be able to extend the ciphertext after PRF +
+            // ReRand without sign issues
+            let inner_radix = result.into_inner();
+            let unsigned_radix =
+                <CudaUnsignedRadixCiphertext as CudaIntegerRadixCiphertext>::from(inner_radix);
+            let result = target_sks.cast_to_unsigned(unsigned_radix, num_blocks as usize, streams);
+            Ok(T::from(result.into_inner()))
+        }
     }
 
     /// Core private implementation that calls the OPRF backend.
@@ -684,7 +698,6 @@ where
         &self,
         result: &mut CudaRadixCiphertext,
         prf_seed: impl OprfSeed,
-        num_active_blocks: u64,
         total_random_bits: u64,
         target_sks: &CudaServerKey,
         re_randomization_key: &CudaReRandomizationKey<'_>,
@@ -693,10 +706,13 @@ where
     ) -> crate::Result<()> {
         let prf_seed = prf_seed.into_bytes();
         let prf_seed = prf_seed.as_ref();
+
+        let num_blocks = result.d_blocks.lwe_ciphertext_count().0 as u64;
+
         let prf_random_bits_rle_bytes = self.generate_multiblocks_oblivious_pseudo_random(
             result,
             prf_seed,
-            num_active_blocks,
+            num_blocks,
             total_random_bits,
             target_sks,
             streams,

--- a/tfhe/src/integer/gpu/server_key/radix/tests_unsigned/test_oprf.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/tests_unsigned/test_oprf.rs
@@ -1,5 +1,7 @@
 use crate::core_crypto::gpu::CudaStreams;
-use crate::integer::ciphertext::{RadixCiphertext, ReRandomizationHashAlgo, SignedRadixCiphertext};
+use crate::integer::ciphertext::{
+    PrfReRandomizationContext, RadixCiphertext, SignedRadixCiphertext,
+};
 use crate::integer::gpu::ciphertext::re_randomization::CudaReRandomizationKey;
 use crate::integer::gpu::server_key::radix::tests_long_run::OpSequenceGpuMultiDeviceFunctionExecutor;
 use crate::integer::gpu::server_key::radix::tests_unsigned::create_gpu_parameterized_test;
@@ -129,7 +131,7 @@ impl OprfReRandTestRunner for GpuOprfReRandTestRunner {
         &mut self,
         prf_seed: impl OprfSeed,
         num_blocks: u64,
-        rerand_hash_algo: ReRandomizationHashAlgo,
+        prf_re_randomization_context: &PrfReRandomizationContext,
     ) -> (RadixCiphertext, RadixCiphertext) {
         let state = self.state();
         let rerand_key = state.rerand_key();
@@ -152,7 +154,7 @@ impl OprfReRandTestRunner for GpuOprfReRandTestRunner {
                 num_blocks,
                 &state.sks,
                 &rerand_key,
-                rerand_hash_algo,
+                prf_re_randomization_context,
                 &state.streams,
             )
             .unwrap();
@@ -168,7 +170,7 @@ impl OprfReRandTestRunner for GpuOprfReRandTestRunner {
         prf_seed: impl OprfSeed,
         random_bit_count: u64,
         num_blocks: u64,
-        rerand_hash_algo: ReRandomizationHashAlgo,
+        prf_re_randomization_context: &PrfReRandomizationContext,
     ) -> (RadixCiphertext, RadixCiphertext) {
         let state = self.state();
         let rerand_key = state.rerand_key();
@@ -193,7 +195,7 @@ impl OprfReRandTestRunner for GpuOprfReRandTestRunner {
                 num_blocks,
                 &state.sks,
                 &rerand_key,
-                rerand_hash_algo,
+                prf_re_randomization_context,
                 &state.streams,
             )
             .unwrap();
@@ -210,7 +212,7 @@ impl OprfReRandTestRunner for GpuOprfReRandTestRunner {
         _num_input_random_bits: u64,
         _excluded_upper_bound: NonZeroU64,
         _num_blocks_output: u64,
-        _rerand_hash_algo: ReRandomizationHashAlgo,
+        _prf_re_randomization_context: &PrfReRandomizationContext,
     ) -> Option<(RadixCiphertext, RadixCiphertext)> {
         // The GPU backend does not expose a re-randomizing custom-range primitive yet
         // Return None to skip the corresponding sub case
@@ -221,7 +223,7 @@ impl OprfReRandTestRunner for GpuOprfReRandTestRunner {
         &mut self,
         prf_seed: impl OprfSeed,
         num_blocks: u64,
-        rerand_hash_algo: ReRandomizationHashAlgo,
+        prf_re_randomization_context: &PrfReRandomizationContext,
     ) -> (SignedRadixCiphertext, SignedRadixCiphertext) {
         let state = self.state();
         let rerand_key = state.rerand_key();
@@ -244,7 +246,7 @@ impl OprfReRandTestRunner for GpuOprfReRandTestRunner {
                 num_blocks,
                 &state.sks,
                 &rerand_key,
-                rerand_hash_algo,
+                prf_re_randomization_context,
                 &state.streams,
             )
             .unwrap();
@@ -260,7 +262,7 @@ impl OprfReRandTestRunner for GpuOprfReRandTestRunner {
         prf_seed: impl OprfSeed,
         random_bit_count: u64,
         num_blocks: u64,
-        rerand_hash_algo: ReRandomizationHashAlgo,
+        prf_re_randomization_context: &PrfReRandomizationContext,
     ) -> (SignedRadixCiphertext, SignedRadixCiphertext) {
         let state = self.state();
         let rerand_key = state.rerand_key();
@@ -285,7 +287,7 @@ impl OprfReRandTestRunner for GpuOprfReRandTestRunner {
                 num_blocks,
                 &state.sks,
                 &rerand_key,
-                rerand_hash_algo,
+                prf_re_randomization_context,
                 &state.streams,
             )
             .unwrap();

--- a/tfhe/src/integer/gpu/server_key/radix/tests_unsigned/test_oprf.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/tests_unsigned/test_oprf.rs
@@ -1,12 +1,21 @@
+use crate::core_crypto::gpu::CudaStreams;
+use crate::integer::ciphertext::{RadixCiphertext, ReRandomizationHashAlgo, SignedRadixCiphertext};
+use crate::integer::gpu::ciphertext::re_randomization::CudaReRandomizationKey;
 use crate::integer::gpu::server_key::radix::tests_long_run::OpSequenceGpuMultiDeviceFunctionExecutor;
 use crate::integer::gpu::server_key::radix::tests_unsigned::create_gpu_parameterized_test;
-use crate::integer::gpu::CudaOprfServerKey;
+use crate::integer::gpu::{CudaOprfServerKey, CudaServerKey};
+use crate::integer::oprf::{CompressedOprfServerKey, OprfPrivateKey};
 use crate::integer::server_key::radix_parallel::tests_unsigned::test_oprf::{
     oprf_almost_uniformity_test, oprf_any_range_test, oprf_uniformity_test,
+    pseudo_random_integer_and_rerand_test, OprfReRandTestRunner,
 };
+use crate::integer::{ClientKey, CompactPrivateKey, CompactPublicKey};
+use crate::shortint::oprf::OprfSeed;
+use crate::shortint::parameters::test_params::TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
 use crate::shortint::parameters::{
     TestParameters, PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
 };
+use core::num::NonZeroU64;
 
 create_gpu_parameterized_test!(oprf_uniformity_unsigned {
     PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128
@@ -16,6 +25,11 @@ create_gpu_parameterized_test!(oprf_any_range_unsigned {
 });
 create_gpu_parameterized_test!(oprf_almost_uniformity_unsigned {
     PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128
+});
+
+create_gpu_parameterized_test!(pseudo_random_integer_and_rerand {
+    PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+    TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
 });
 
 fn oprf_uniformity_unsigned<P>(param: P)
@@ -46,4 +60,246 @@ where
         &CudaOprfServerKey::par_generate_oblivious_pseudo_random_unsigned_custom_range,
     );
     oprf_almost_uniformity_test(param, executor);
+}
+
+// PRF + rerand
+
+/// GPU implementation of [`OprfReRandTestRunner`].
+///
+/// Uses a derived compact public key (no key-switch) for re-randomization, mirroring the CPU
+/// executor. The custom-range re-randomizing primitive is not available on GPU yet, so
+/// `unsigned_custom_range` returns `None` and the generic test skips that sub-case.
+struct GpuOprfReRandTestRunner {
+    state: Option<GpuOprfReRandState>,
+}
+
+struct GpuOprfReRandState {
+    streams: CudaStreams,
+    sks: CudaServerKey,
+    oprf_sks: CudaOprfServerKey,
+    rerand_cpk: CompactPublicKey,
+}
+
+impl GpuOprfReRandState {
+    fn rerand_key(&self) -> CudaReRandomizationKey<'_> {
+        CudaReRandomizationKey::DerivedCPKWithoutKeySwitch {
+            cpk: &self.rerand_cpk,
+        }
+    }
+}
+
+impl GpuOprfReRandTestRunner {
+    fn new() -> Self {
+        Self { state: None }
+    }
+
+    fn state(&self) -> &GpuOprfReRandState {
+        self.state.as_ref().expect("setup was not properly called")
+    }
+}
+
+impl OprfReRandTestRunner for GpuOprfReRandTestRunner {
+    fn setup(&mut self, param: TestParameters) -> ClientKey {
+        let cks = ClientKey::new(param);
+
+        let streams = CudaStreams::new_multi_gpu();
+
+        let sks = CudaServerKey::new(&cks, &streams);
+
+        // Derived compact public key, re-using the compute secret key
+        // legacy rerand not covered by this test
+        let privk: CompactPrivateKey<&[u64]> = (&cks).try_into().unwrap();
+        let rerand_cpk = CompactPublicKey::new(&privk);
+
+        let oprf_pk = OprfPrivateKey::new(&cks);
+        let compressed_oprf_sk = CompressedOprfServerKey::new(&oprf_pk, &cks).unwrap();
+        let oprf_sks = CudaOprfServerKey::decompress_from_cpu(&compressed_oprf_sk, &streams);
+
+        self.state = Some(GpuOprfReRandState {
+            streams,
+            sks,
+            oprf_sks,
+            rerand_cpk,
+        });
+
+        cks
+    }
+
+    fn unsigned_full(
+        &mut self,
+        prf_seed: impl OprfSeed,
+        num_blocks: u64,
+        rerand_hash_algo: ReRandomizationHashAlgo,
+    ) -> (RadixCiphertext, RadixCiphertext) {
+        let state = self.state();
+        let rerand_key = state.rerand_key();
+
+        let prf_seed = prf_seed.into_bytes();
+        let prf_seed = prf_seed.as_ref();
+
+        let prf_not_rerand = state
+            .oprf_sks
+            .par_generate_oblivious_pseudo_random_unsigned_integer(
+                prf_seed,
+                num_blocks,
+                &state.sks,
+                &state.streams,
+            );
+        let prf_rerand = state
+            .oprf_sks
+            .par_generate_oblivious_pseudo_random_unsigned_integer_and_re_randomize(
+                prf_seed,
+                num_blocks,
+                &state.sks,
+                &rerand_key,
+                rerand_hash_algo,
+                &state.streams,
+            )
+            .unwrap();
+
+        (
+            prf_not_rerand.to_radix_ciphertext(&state.streams),
+            prf_rerand.to_radix_ciphertext(&state.streams),
+        )
+    }
+
+    fn unsigned_bounded(
+        &mut self,
+        prf_seed: impl OprfSeed,
+        random_bit_count: u64,
+        num_blocks: u64,
+        rerand_hash_algo: ReRandomizationHashAlgo,
+    ) -> (RadixCiphertext, RadixCiphertext) {
+        let state = self.state();
+        let rerand_key = state.rerand_key();
+
+        let prf_seed = prf_seed.into_bytes();
+        let prf_seed = prf_seed.as_ref();
+
+        let prf_not_rerand = state
+            .oprf_sks
+            .par_generate_oblivious_pseudo_random_unsigned_integer_bounded(
+                prf_seed,
+                random_bit_count,
+                num_blocks,
+                &state.sks,
+                &state.streams,
+            );
+        let prf_rerand = state
+            .oprf_sks
+            .par_generate_oblivious_pseudo_random_unsigned_integer_bounded_and_re_randomize(
+                prf_seed,
+                random_bit_count,
+                num_blocks,
+                &state.sks,
+                &rerand_key,
+                rerand_hash_algo,
+                &state.streams,
+            )
+            .unwrap();
+
+        (
+            prf_not_rerand.to_radix_ciphertext(&state.streams),
+            prf_rerand.to_radix_ciphertext(&state.streams),
+        )
+    }
+
+    fn unsigned_custom_range(
+        &mut self,
+        _prf_seed: impl OprfSeed,
+        _num_input_random_bits: u64,
+        _excluded_upper_bound: NonZeroU64,
+        _num_blocks_output: u64,
+        _rerand_hash_algo: ReRandomizationHashAlgo,
+    ) -> Option<(RadixCiphertext, RadixCiphertext)> {
+        // The GPU backend does not expose a re-randomizing custom-range primitive yet
+        // Return None to skip the corresponding sub case
+        None
+    }
+
+    fn signed_full(
+        &mut self,
+        prf_seed: impl OprfSeed,
+        num_blocks: u64,
+        rerand_hash_algo: ReRandomizationHashAlgo,
+    ) -> (SignedRadixCiphertext, SignedRadixCiphertext) {
+        let state = self.state();
+        let rerand_key = state.rerand_key();
+
+        let prf_seed = prf_seed.into_bytes();
+        let prf_seed = prf_seed.as_ref();
+
+        let prf_not_rerand = state
+            .oprf_sks
+            .par_generate_oblivious_pseudo_random_signed_integer(
+                prf_seed,
+                num_blocks,
+                &state.sks,
+                &state.streams,
+            );
+        let prf_rerand = state
+            .oprf_sks
+            .par_generate_oblivious_pseudo_random_signed_integer_and_re_randomize(
+                prf_seed,
+                num_blocks,
+                &state.sks,
+                &rerand_key,
+                rerand_hash_algo,
+                &state.streams,
+            )
+            .unwrap();
+
+        (
+            prf_not_rerand.to_signed_radix_ciphertext(&state.streams),
+            prf_rerand.to_signed_radix_ciphertext(&state.streams),
+        )
+    }
+
+    fn signed_bounded(
+        &mut self,
+        prf_seed: impl OprfSeed,
+        random_bit_count: u64,
+        num_blocks: u64,
+        rerand_hash_algo: ReRandomizationHashAlgo,
+    ) -> (SignedRadixCiphertext, SignedRadixCiphertext) {
+        let state = self.state();
+        let rerand_key = state.rerand_key();
+
+        let prf_seed = prf_seed.into_bytes();
+        let prf_seed = prf_seed.as_ref();
+
+        let prf_not_rerand = state
+            .oprf_sks
+            .par_generate_oblivious_pseudo_random_signed_integer_bounded(
+                prf_seed,
+                random_bit_count,
+                num_blocks,
+                &state.sks,
+                &state.streams,
+            );
+        let prf_rerand = state
+            .oprf_sks
+            .par_generate_oblivious_pseudo_random_signed_integer_bounded_and_re_randomize(
+                prf_seed,
+                random_bit_count,
+                num_blocks,
+                &state.sks,
+                &rerand_key,
+                rerand_hash_algo,
+                &state.streams,
+            )
+            .unwrap();
+
+        (
+            prf_not_rerand.to_signed_radix_ciphertext(&state.streams),
+            prf_rerand.to_signed_radix_ciphertext(&state.streams),
+        )
+    }
+}
+
+fn pseudo_random_integer_and_rerand<P>(param: P)
+where
+    P: Into<TestParameters>,
+{
+    pseudo_random_integer_and_rerand_test(param, GpuOprfReRandTestRunner::new());
 }

--- a/tfhe/src/integer/oprf.rs
+++ b/tfhe/src/integer/oprf.rs
@@ -121,6 +121,8 @@ where
     /// let oprf_pk = OprfPrivateKey::new(cks.as_ref());
     /// let oprf_sk = OprfServerKey::new(&oprf_pk, cks.as_ref()).unwrap();
     ///
+    /// // DANGER: Using a fixed seed is insecure and only done here to show API usage.
+    /// // The proper way of generating a seed depends on your application.
     /// // `seed` can be either a `Seed` or any byte-like input (`&[u8]`, `&[u8; N]`, ...).
     /// let ct_res =
     ///     oprf_sk.par_generate_oblivious_pseudo_random_unsigned_integer(Seed(0), size as u64, &sks);
@@ -160,6 +162,8 @@ where
     ///
     /// let random_bits_count = 3;
     ///
+    /// // DANGER: Using a fixed seed is insecure and only done here to show API usage.
+    /// // The proper way of generating a seed depends on your application.
     /// let ct_res = oprf_sk.par_generate_oblivious_pseudo_random_unsigned_integer_bounded(
     ///     Seed(0),
     ///     random_bits_count,
@@ -214,6 +218,8 @@ where
     /// let excluded_upper_bound = NonZeroU64::new(3).unwrap();
     /// let num_blocks_output = 8;
     ///
+    /// // DANGER: Using a fixed seed is insecure and only done here to show API usage.
+    /// // The proper way of generating a seed depends on your application.
     /// let ct_res = oprf_sk.par_generate_oblivious_pseudo_random_unsigned_custom_range(
     ///     Seed(0),
     ///     num_input_random_bits,
@@ -289,6 +295,7 @@ where
     /// use tfhe::integer::gen_keys_radix;
     /// use tfhe::integer::oprf::{OprfPrivateKey, OprfServerKey};
     /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS_GAUSSIAN_2M128;
+    /// use tfhe::Seed;
     ///
     /// let size = 4;
     ///
@@ -298,11 +305,10 @@ where
     /// let oprf_pk = OprfPrivateKey::new(cks.as_ref());
     /// let oprf_sk = OprfServerKey::new(&oprf_pk, cks.as_ref()).unwrap();
     ///
-    /// let ct_res = oprf_sk.par_generate_oblivious_pseudo_random_signed_integer(
-    ///     tfhe::Seed(0),
-    ///     size as u64,
-    ///     &sks,
-    /// );
+    /// // DANGER: Using a fixed seed is insecure and only done here to show API usage.
+    /// // The proper way of generating a seed depends on your application.
+    /// let ct_res =
+    ///     oprf_sk.par_generate_oblivious_pseudo_random_signed_integer(Seed(0), size as u64, &sks);
     ///
     /// // Decrypt:
     /// let dec_result: i64 = cks.decrypt_signed(&ct_res);
@@ -339,6 +345,8 @@ where
     /// let oprf_pk = OprfPrivateKey::new(cks.as_ref());
     /// let oprf_sk = OprfServerKey::new(&oprf_pk, cks.as_ref()).unwrap();
     ///
+    /// // DANGER: Using a fixed seed is insecure and only done here to show API usage.
+    /// // The proper way of generating a seed depends on your application.
     /// let ct_res = oprf_sk.par_generate_oblivious_pseudo_random_signed_integer_bounded(
     ///     Seed(0),
     ///     random_bits_count,

--- a/tfhe/src/integer/oprf.rs
+++ b/tfhe/src/integer/oprf.rs
@@ -646,7 +646,7 @@ where
         let excluded_upper_bound = excluded_upper_bound.get();
 
         assert!(target_sks.message_modulus().0.is_power_of_two());
-        let message_bits_count = target_sks.message_modulus().0.ilog2() as u64;
+        let message_bits_count: u64 = target_sks.message_modulus().0.ilog2().into();
 
         assert!(
             !excluded_upper_bound.is_power_of_two(),
@@ -654,15 +654,20 @@ where
             function instead"
         );
 
+        // Since excluded_upper_bound is not a power of two, we know the ceil log2 of the value is
+        // the ilog2 + 1, this is how many bits are needed to represent the value
+        let excluded_upper_bound_log2: u64 = excluded_upper_bound.ilog2().into();
+        let excluded_upper_bound_ceil_log2 = excluded_upper_bound_log2 + 1;
         let num_bits_output = num_blocks_output * message_bits_count;
+
         assert!(
-            (excluded_upper_bound as f64) < 2_f64.powi(num_bits_output as i32),
+            excluded_upper_bound_ceil_log2 <= num_bits_output,
             "num_blocks_output(={num_blocks_output}) is too small to hold an integer \
-            up to excluded_upper_bound(={excluded_upper_bound})"
+            up to excluded_upper_bound(={excluded_upper_bound}). Output has {num_bits_output} bits,\
+            {excluded_upper_bound} needs {excluded_upper_bound_ceil_log2} bits to be represented."
         );
 
-        let post_mul_num_bits =
-            num_input_random_bits + (excluded_upper_bound as f64).log2().ceil() as u64;
+        let post_mul_num_bits = num_input_random_bits + excluded_upper_bound_ceil_log2;
 
         let num_blocks = post_mul_num_bits.div_ceil(message_bits_count);
 

--- a/tfhe/src/integer/oprf.rs
+++ b/tfhe/src/integer/oprf.rs
@@ -1,7 +1,9 @@
 use super::{RadixCiphertext, ServerKey, SignedRadixCiphertext};
 use crate::conformance::ParameterSetConformant;
 use crate::core_crypto::prelude::{Container, IntoContainerOwned};
-use crate::integer::ciphertext::IntegerRadixCiphertext;
+use crate::integer::ciphertext::{
+    IntegerRadixCiphertext, ReRandomizationHashAlgo, ReRandomizationKey,
+};
 use crate::integer::ClientKey;
 use crate::named::Named;
 use crate::shortint::oprf::{
@@ -141,6 +143,23 @@ where
         self.par_generate_oblivious_pseudo_random_integer_full_impl(seed, num_blocks, target_sks)
     }
 
+    pub fn par_generate_oblivious_pseudo_random_unsigned_integer_and_re_randomize(
+        &self,
+        seed: impl OprfSeed,
+        num_blocks: u64,
+        target_sks: &ServerKey,
+        re_randomization_key: &ReRandomizationKey,
+        re_randomization_hash_algo: ReRandomizationHashAlgo,
+    ) -> crate::Result<RadixCiphertext> {
+        self.par_generate_oblivious_pseudo_random_integer_full_and_re_randomize_impl(
+            seed,
+            num_blocks,
+            target_sks,
+            re_randomization_key,
+            re_randomization_hash_algo,
+        )
+    }
+
     /// Generates an encrypted `num_block` blocks unsigned integer
     /// taken uniformly in `[0, 2^random_bits_count[` using the given seed.
     /// The encrypted value is oblivious to the server.
@@ -190,6 +209,25 @@ where
         )
     }
 
+    pub fn par_generate_oblivious_pseudo_random_unsigned_integer_bounded_and_re_randomize(
+        &self,
+        seed: impl OprfSeed,
+        random_bits_count: u64,
+        num_blocks: u64,
+        target_sks: &ServerKey,
+        re_randomization_key: &ReRandomizationKey,
+        re_randomization_hash_algo: ReRandomizationHashAlgo,
+    ) -> crate::Result<RadixCiphertext> {
+        self.par_generate_oblivious_pseudo_random_integer_bounded_and_re_randomize_impl(
+            seed,
+            random_bits_count,
+            num_blocks,
+            target_sks,
+            re_randomization_key,
+            re_randomization_hash_algo,
+        )
+    }
+
     /// Generates an encrypted `num_blocks_output` blocks unsigned integer
     /// taken almost uniformly in [0, excluded_upper_bound[ using the given seed.
     /// The encrypted value is oblivious to the server.
@@ -233,57 +271,77 @@ where
     ///
     /// assert!(dec_result < excluded_upper_bound.get());
     /// ```
-    pub fn par_generate_oblivious_pseudo_random_unsigned_custom_range(
+    pub fn par_generate_oblivious_pseudo_random_unsigned_custom_range<InputSeed>(
         &self,
-        seed: impl OprfSeed,
+        seed: InputSeed,
         num_input_random_bits: u64,
         excluded_upper_bound: NonZeroU64,
         num_blocks_output: u64,
         target_sks: &ServerKey,
-    ) -> RadixCiphertext {
-        let excluded_upper_bound = excluded_upper_bound.get();
+    ) -> RadixCiphertext
+    where
+        InputSeed: OprfSeed,
+    {
+        self.par_generate_oblivious_pseudo_random_unsigned_custom_range_impl(
+            seed,
+            num_input_random_bits,
+            excluded_upper_bound,
+            num_blocks_output,
+            target_sks,
+            |sself: &Self,
+             seed: InputSeed,
+             num_input_random_bits: u64,
+             num_blocks: u64,
+             target_sks: &ServerKey| {
+                Ok(
+                    sself.par_generate_oblivious_pseudo_random_integer_bounded_impl(
+                        seed,
+                        num_input_random_bits,
+                        num_blocks,
+                        target_sks,
+                    ),
+                )
+            },
+        )
+        .unwrap()
+        // Safe to unwrap our closure returns an Ok result
+    }
 
-        assert!(target_sks.message_modulus().0.is_power_of_two());
-        let message_bits_count = target_sks.message_modulus().0.ilog2() as u64;
-
-        assert!(
-            !excluded_upper_bound.is_power_of_two(),
-            "Use the cheaper par_generate_oblivious_pseudo_random_unsigned_integer_bounded \
-            function instead"
-        );
-
-        let num_bits_output = num_blocks_output * message_bits_count;
-        assert!(
-            (excluded_upper_bound as f64) < 2_f64.powi(num_bits_output as i32),
-            "num_blocks_output(={num_blocks_output}) is too small to hold an integer \
-            up to excluded_upper_bound(={excluded_upper_bound})"
-        );
-
-        let post_mul_num_bits =
-            num_input_random_bits + (excluded_upper_bound as f64).log2().ceil() as u64;
-
-        let num_blocks = post_mul_num_bits.div_ceil(message_bits_count);
-
-        let random_input: RadixCiphertext = self
-            .par_generate_oblivious_pseudo_random_integer_bounded_impl(
-                seed,
-                num_input_random_bits,
-                num_blocks,
-                target_sks,
-            );
-
-        let random_multiplied =
-            target_sks.scalar_mul_parallelized(&random_input, excluded_upper_bound);
-
-        let mut result =
-            target_sks.scalar_right_shift_parallelized(&random_multiplied, num_input_random_bits);
-
-        // Adjust the number of leading (MSB) trivial zeros blocks
-        result
-            .blocks
-            .resize(num_blocks_output as usize, target_sks.key.create_trivial(0));
-
-        result
+    #[allow(clippy::too_many_arguments)]
+    pub fn par_generate_oblivious_pseudo_random_unsigned_custom_range_and_re_randomize<InputSeed>(
+        &self,
+        seed: InputSeed,
+        num_input_random_bits: u64,
+        excluded_upper_bound: NonZeroU64,
+        num_blocks_output: u64,
+        target_sks: &ServerKey,
+        re_randomization_key: &ReRandomizationKey,
+        re_randomization_hash_algo: ReRandomizationHashAlgo,
+    ) -> crate::Result<RadixCiphertext>
+    where
+        InputSeed: OprfSeed,
+    {
+        self.par_generate_oblivious_pseudo_random_unsigned_custom_range_impl(
+            seed,
+            num_input_random_bits,
+            excluded_upper_bound,
+            num_blocks_output,
+            target_sks,
+            |sself: &Self,
+             seed: InputSeed,
+             num_input_random_bits: u64,
+             num_blocks: u64,
+             target_sks: &ServerKey| {
+                sself.par_generate_oblivious_pseudo_random_integer_bounded_and_re_randomize_impl(
+                    seed,
+                    num_input_random_bits,
+                    num_blocks,
+                    target_sks,
+                    re_randomization_key,
+                    re_randomization_hash_algo,
+                )
+            },
+        )
     }
 
     /// Generates an encrypted `num_block` blocks signed integer
@@ -322,6 +380,23 @@ where
         target_sks: &ServerKey,
     ) -> SignedRadixCiphertext {
         self.par_generate_oblivious_pseudo_random_integer_full_impl(seed, num_blocks, target_sks)
+    }
+
+    pub fn par_generate_oblivious_pseudo_random_signed_integer_and_re_randomize(
+        &self,
+        seed: impl OprfSeed,
+        num_blocks: u64,
+        target_sks: &ServerKey,
+        re_randomization_key: &ReRandomizationKey,
+        re_randomization_hash_algo: ReRandomizationHashAlgo,
+    ) -> crate::Result<SignedRadixCiphertext> {
+        self.par_generate_oblivious_pseudo_random_integer_full_and_re_randomize_impl(
+            seed,
+            num_blocks,
+            target_sks,
+            re_randomization_key,
+            re_randomization_hash_algo,
+        )
     }
 
     /// Generates an encrypted `num_block` blocks signed integer
@@ -374,6 +449,25 @@ where
         )
     }
 
+    pub fn par_generate_oblivious_pseudo_random_signed_integer_bounded_and_re_randomize(
+        &self,
+        seed: impl OprfSeed,
+        random_bits_count: u64,
+        num_blocks: u64,
+        target_sks: &ServerKey,
+        re_randomization_key: &ReRandomizationKey,
+        re_randomization_hash_algo: ReRandomizationHashAlgo,
+    ) -> crate::Result<SignedRadixCiphertext> {
+        self.par_generate_oblivious_pseudo_random_integer_bounded_and_re_randomize_impl(
+            seed,
+            random_bits_count,
+            num_blocks,
+            target_sks,
+            re_randomization_key,
+            re_randomization_hash_algo,
+        )
+    }
+
     fn par_generate_oblivious_pseudo_random_integer_full_impl<T: IntegerRadixCiphertext>(
         &self,
         seed: impl OprfSeed,
@@ -395,6 +489,39 @@ where
             .expect("Expected a single chunk for the radix being generated, got 0");
 
         T::from(blocks)
+    }
+
+    fn par_generate_oblivious_pseudo_random_integer_full_and_re_randomize_impl<
+        T: IntegerRadixCiphertext,
+    >(
+        &self,
+        seed: impl OprfSeed,
+        num_blocks: u64,
+        target_sks: &ServerKey,
+        re_randomization_key: &ReRandomizationKey,
+        re_randomization_hash_algo: ReRandomizationHashAlgo,
+    ) -> crate::Result<T> {
+        assert!(target_sks.message_modulus().0.is_power_of_two());
+        let message_bits_count = target_sks.message_modulus().0.ilog2() as u64;
+
+        let (compact_public_key, key_switching_key_material) =
+            re_randomization_key.get_cpk_and_optional_ksk();
+
+        let blocks = self
+            .key
+            .generate_oblivious_pseudo_random_bits_chunks_and_re_randomize(
+                seed,
+                &[num_blocks * message_bits_count],
+                &target_sks.key,
+                &compact_public_key.key,
+                key_switching_key_material.as_ref().map(|k| &k.material),
+                re_randomization_hash_algo,
+            )?
+            .into_iter()
+            .next()
+            .expect("Expected a single chunk for the radix being generated, got 0");
+
+        Ok(T::from(blocks))
     }
 
     fn par_generate_oblivious_pseudo_random_integer_bounded_impl<T: IntegerRadixCiphertext>(
@@ -440,6 +567,119 @@ where
         }
 
         T::from(blocks)
+    }
+
+    fn par_generate_oblivious_pseudo_random_integer_bounded_and_re_randomize_impl<
+        T: IntegerRadixCiphertext,
+    >(
+        &self,
+        seed: impl OprfSeed,
+        random_bits_count: u64,
+        num_blocks: u64,
+        target_sks: &ServerKey,
+        re_randomization_key: &ReRandomizationKey,
+        re_randomization_hash_algo: ReRandomizationHashAlgo,
+    ) -> crate::Result<T> {
+        assert!(target_sks.message_modulus().0.is_power_of_two());
+        let message_bits_count = target_sks.message_modulus().0.ilog2() as u64;
+        let range_bits_count = message_bits_count * num_blocks;
+        assert!(range_bits_count > 0);
+
+        if T::IS_SIGNED {
+            let signed_range_bits_count = range_bits_count.saturating_sub(1);
+            assert!(
+                random_bits_count <= signed_range_bits_count,
+                "The range asked for a random value in (=[0, 2^{random_bits_count}[) \
+                which does not fit in the available range \
+                [-2^{signed_range_bits_count}, 2^{signed_range_bits_count}[",
+            );
+        } else {
+            assert!(
+                random_bits_count <= range_bits_count,
+                "The range asked for a random value in (=[0, 2^{random_bits_count}[) \
+                which does not fit in the available range [0, 2^{range_bits_count}[",
+            );
+        }
+
+        let (compact_public_key, key_switching_key_material) =
+            re_randomization_key.get_cpk_and_optional_ksk();
+
+        let mut blocks = self
+            .key
+            .generate_oblivious_pseudo_random_bits_chunks_and_re_randomize(
+                seed,
+                &[random_bits_count],
+                &target_sks.key,
+                &compact_public_key.key,
+                key_switching_key_material.as_ref().map(|k| &k.material),
+                re_randomization_hash_algo,
+            )?
+            .into_iter()
+            .next()
+            .expect("Expected a single chunk for the radix being generated, got 0");
+
+        if blocks.len() < num_blocks as usize {
+            blocks.resize(num_blocks as usize, target_sks.key.create_trivial(0));
+        }
+
+        Ok(T::from(blocks))
+    }
+
+    fn par_generate_oblivious_pseudo_random_unsigned_custom_range_impl<InputSeed>(
+        &self,
+        seed: InputSeed,
+        num_input_random_bits: u64,
+        excluded_upper_bound: NonZeroU64,
+        num_blocks_output: u64,
+        target_sks: &ServerKey,
+        prf_callback: impl Fn(
+            &Self,      // sself
+            InputSeed,  // seed
+            u64,        // num_input_random_bits
+            u64,        // num_blocks
+            &ServerKey, // target_sks
+        ) -> crate::Result<RadixCiphertext>,
+    ) -> crate::Result<RadixCiphertext>
+    where
+        InputSeed: OprfSeed,
+    {
+        let excluded_upper_bound = excluded_upper_bound.get();
+
+        assert!(target_sks.message_modulus().0.is_power_of_two());
+        let message_bits_count = target_sks.message_modulus().0.ilog2() as u64;
+
+        assert!(
+            !excluded_upper_bound.is_power_of_two(),
+            "Use the cheaper par_generate_oblivious_pseudo_random_unsigned_integer_bounded \
+            function instead"
+        );
+
+        let num_bits_output = num_blocks_output * message_bits_count;
+        assert!(
+            (excluded_upper_bound as f64) < 2_f64.powi(num_bits_output as i32),
+            "num_blocks_output(={num_blocks_output}) is too small to hold an integer \
+            up to excluded_upper_bound(={excluded_upper_bound})"
+        );
+
+        let post_mul_num_bits =
+            num_input_random_bits + (excluded_upper_bound as f64).log2().ceil() as u64;
+
+        let num_blocks = post_mul_num_bits.div_ceil(message_bits_count);
+
+        let random_input = prf_callback(self, seed, num_input_random_bits, num_blocks, target_sks)?;
+
+        let random_multiplied =
+            target_sks.scalar_mul_parallelized(&random_input, excluded_upper_bound);
+
+        let mut result =
+            target_sks.scalar_right_shift_parallelized(&random_multiplied, num_input_random_bits);
+
+        // Adjust the number of leading (MSB) trivial zeros blocks
+        result
+            .blocks
+            .resize(num_blocks_output as usize, target_sks.key.create_trivial(0));
+
+        Ok(result)
     }
 }
 

--- a/tfhe/src/integer/oprf.rs
+++ b/tfhe/src/integer/oprf.rs
@@ -2,7 +2,7 @@ use super::{RadixCiphertext, ServerKey, SignedRadixCiphertext};
 use crate::conformance::ParameterSetConformant;
 use crate::core_crypto::prelude::{Container, IntoContainerOwned};
 use crate::integer::ciphertext::{
-    IntegerRadixCiphertext, ReRandomizationHashAlgo, ReRandomizationKey,
+    IntegerRadixCiphertext, PrfReRandomizationContext, ReRandomizationKey,
 };
 use crate::integer::ClientKey;
 use crate::named::Named;
@@ -150,14 +150,14 @@ where
         num_blocks: u64,
         target_sks: &ServerKey,
         re_randomization_key: &ReRandomizationKey,
-        re_randomization_hash_algo: ReRandomizationHashAlgo,
+        prf_re_randomization_context: &PrfReRandomizationContext,
     ) -> crate::Result<RadixCiphertext> {
         self.par_generate_oblivious_pseudo_random_integer_full_and_re_randomize_impl(
             seed,
             num_blocks,
             target_sks,
             re_randomization_key,
-            re_randomization_hash_algo,
+            prf_re_randomization_context,
         )
     }
 
@@ -217,7 +217,7 @@ where
         num_blocks: u64,
         target_sks: &ServerKey,
         re_randomization_key: &ReRandomizationKey,
-        re_randomization_hash_algo: ReRandomizationHashAlgo,
+        prf_re_randomization_context: &PrfReRandomizationContext,
     ) -> crate::Result<RadixCiphertext> {
         self.par_generate_oblivious_pseudo_random_integer_bounded_and_re_randomize_impl(
             seed,
@@ -225,7 +225,7 @@ where
             num_blocks,
             target_sks,
             re_randomization_key,
-            re_randomization_hash_algo,
+            prf_re_randomization_context,
         )
     }
 
@@ -317,7 +317,7 @@ where
         num_blocks_output: u64,
         target_sks: &ServerKey,
         re_randomization_key: &ReRandomizationKey,
-        re_randomization_hash_algo: ReRandomizationHashAlgo,
+        prf_re_randomization_context: &PrfReRandomizationContext,
     ) -> crate::Result<RadixCiphertext>
     where
         InputSeed: OprfSeed,
@@ -339,7 +339,7 @@ where
                     num_blocks,
                     target_sks,
                     re_randomization_key,
-                    re_randomization_hash_algo,
+                    prf_re_randomization_context,
                 )
             },
         )
@@ -389,14 +389,14 @@ where
         num_blocks: u64,
         target_sks: &ServerKey,
         re_randomization_key: &ReRandomizationKey,
-        re_randomization_hash_algo: ReRandomizationHashAlgo,
+        prf_re_randomization_context: &PrfReRandomizationContext,
     ) -> crate::Result<SignedRadixCiphertext> {
         self.par_generate_oblivious_pseudo_random_integer_full_and_re_randomize_impl(
             seed,
             num_blocks,
             target_sks,
             re_randomization_key,
-            re_randomization_hash_algo,
+            prf_re_randomization_context,
         )
     }
 
@@ -457,7 +457,7 @@ where
         num_blocks: u64,
         target_sks: &ServerKey,
         re_randomization_key: &ReRandomizationKey,
-        re_randomization_hash_algo: ReRandomizationHashAlgo,
+        prf_re_randomization_context: &PrfReRandomizationContext,
     ) -> crate::Result<SignedRadixCiphertext> {
         self.par_generate_oblivious_pseudo_random_integer_bounded_and_re_randomize_impl(
             seed,
@@ -465,7 +465,7 @@ where
             num_blocks,
             target_sks,
             re_randomization_key,
-            re_randomization_hash_algo,
+            prf_re_randomization_context,
         )
     }
 
@@ -500,7 +500,7 @@ where
         num_blocks: u64,
         target_sks: &ServerKey,
         re_randomization_key: &ReRandomizationKey,
-        re_randomization_hash_algo: ReRandomizationHashAlgo,
+        prf_re_randomization_context: &PrfReRandomizationContext,
     ) -> crate::Result<T> {
         assert!(target_sks.message_modulus().0.is_power_of_two());
         let message_bits_count = target_sks.message_modulus().0.ilog2() as u64;
@@ -516,7 +516,7 @@ where
                 &target_sks.key,
                 &compact_public_key.key,
                 key_switching_key_material.as_ref().map(|k| &k.material),
-                re_randomization_hash_algo,
+                prf_re_randomization_context.inner(),
             )?
             .into_iter()
             .next()
@@ -579,7 +579,7 @@ where
         num_blocks: u64,
         target_sks: &ServerKey,
         re_randomization_key: &ReRandomizationKey,
-        re_randomization_hash_algo: ReRandomizationHashAlgo,
+        prf_re_randomization_context: &PrfReRandomizationContext,
     ) -> crate::Result<T> {
         assert!(target_sks.message_modulus().0.is_power_of_two());
         let message_bits_count = target_sks.message_modulus().0.ilog2() as u64;
@@ -613,7 +613,7 @@ where
                 &target_sks.key,
                 &compact_public_key.key,
                 key_switching_key_material.as_ref().map(|k| &k.material),
-                re_randomization_hash_algo,
+                prf_re_randomization_context.inner(),
             )?
             .into_iter()
             .next()

--- a/tfhe/src/integer/oprf.rs
+++ b/tfhe/src/integer/oprf.rs
@@ -104,6 +104,7 @@ where
     pub fn into_raw_parts(self) -> ShortintGenericOprfServerKey<C> {
         self.key
     }
+
     /// Generates an encrypted `num_block` blocks unsigned integer
     /// taken uniformly in its full range using the given seed.
     /// The encrypted value is oblivious to the server.

--- a/tfhe/src/integer/server_key/radix_parallel/bitonic_shuffle.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/bitonic_shuffle.rs
@@ -3,10 +3,11 @@
 //! A bitonic sorting network for n=2^k elements has k*(k+1)/2 stages,
 //! each with n/2 comparators. It sorts any input sequence.
 use crate::core_crypto::prelude::Container;
+use crate::integer::ciphertext::{ReRandomizationHashAlgo, ReRandomizationKey};
 use crate::integer::oprf::GenericOprfServerKey;
 use crate::integer::prelude::ServerKeyDefaultCMux;
 use crate::integer::{IntegerRadixCiphertext, RadixCiphertext, ServerKey};
-use crate::shortint::MessageModulus;
+use crate::shortint::{Ciphertext, MessageModulus};
 use crate::OprfSeed;
 use rayon::prelude::*;
 use tfhe_fft::c64;
@@ -124,6 +125,55 @@ impl ServerKey {
         S: OprfSeed,
         C: Container<Element = c64> + Sync,
     {
+        self.bitonic_shuffle_impl(data, key_size, |chunks| {
+            Ok(oprf_key
+                .key
+                .generate_oblivious_pseudo_random_bits_chunks(seed, chunks, &self.key))
+        })
+    }
+
+    pub fn re_randomized_keys_bitonic_shuffle<T, S, C>(
+        &self,
+        oprf_key: &GenericOprfServerKey<C>,
+        data: Vec<T>,
+        key_size: BitonicShuffleKeySize,
+        seed: S,
+        re_randomization_key: &ReRandomizationKey,
+        re_randomization_hash_algo: ReRandomizationHashAlgo,
+    ) -> Result<Vec<T>, crate::Error>
+    where
+        T: IntegerRadixCiphertext,
+        S: OprfSeed,
+        C: Container<Element = c64> + Sync,
+    {
+        let (cpk, ksk) = re_randomization_key.get_cpk_and_optional_ksk();
+
+        self.bitonic_shuffle_impl(data, key_size, |chunks| {
+            oprf_key
+                .key
+                .generate_oblivious_pseudo_random_bits_chunks_and_re_randomize(
+                    seed,
+                    chunks,
+                    &self.key,
+                    &cpk.key,
+                    ksk.as_ref().map(|k| &k.material),
+                    re_randomization_hash_algo,
+                )
+        })
+    }
+
+    fn bitonic_shuffle_impl<T, F>(
+        &self,
+        data: Vec<T>,
+        key_size: BitonicShuffleKeySize,
+        prf_callback: F,
+    ) -> Result<Vec<T>, crate::Error>
+    where
+        T: IntegerRadixCiphertext,
+        F: FnOnce(
+            &[u64], // chunks
+        ) -> crate::Result<Vec<Vec<Ciphertext>>>,
+    {
         let key_num_blocks = key_size.num_blocks_of_keys(data.len(), self.message_modulus()) as u64;
 
         if key_num_blocks == 0 {
@@ -139,9 +189,7 @@ impl ServerKey {
         let key_num_bits = key_num_blocks * self.message_modulus().0.ilog2() as u64;
 
         let chunks = vec![key_num_bits; data.len()];
-        let block_chunks = oprf_key
-            .key
-            .generate_oblivious_pseudo_random_bits_chunks(seed, &chunks, &self.key);
+        let block_chunks = prf_callback(&chunks)?;
 
         let keys = block_chunks
             .into_iter()

--- a/tfhe/src/integer/server_key/radix_parallel/bitonic_shuffle.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/bitonic_shuffle.rs
@@ -3,7 +3,7 @@
 //! A bitonic sorting network for n=2^k elements has k*(k+1)/2 stages,
 //! each with n/2 comparators. It sorts any input sequence.
 use crate::core_crypto::prelude::Container;
-use crate::integer::ciphertext::{ReRandomizationHashAlgo, ReRandomizationKey};
+use crate::integer::ciphertext::{PrfReRandomizationContext, ReRandomizationKey};
 use crate::integer::oprf::GenericOprfServerKey;
 use crate::integer::prelude::ServerKeyDefaultCMux;
 use crate::integer::{IntegerRadixCiphertext, RadixCiphertext, ServerKey};
@@ -139,7 +139,7 @@ impl ServerKey {
         key_size: BitonicShuffleKeySize,
         seed: S,
         re_randomization_key: &ReRandomizationKey,
-        re_randomization_hash_algo: ReRandomizationHashAlgo,
+        prf_re_randomization_context: &PrfReRandomizationContext,
     ) -> Result<Vec<T>, crate::Error>
     where
         T: IntegerRadixCiphertext,
@@ -157,7 +157,7 @@ impl ServerKey {
                     &self.key,
                     &cpk.key,
                     ksk.as_ref().map(|k| &k.material),
-                    re_randomization_hash_algo,
+                    prf_re_randomization_context.inner(),
                 )
         })
     }

--- a/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_oprf.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_oprf.rs
@@ -2,13 +2,25 @@ use crate::core_crypto::commons::generators::DeterministicSeeder;
 use crate::core_crypto::commons::math::random::tests::{
     cumulate, dkw_alpha_from_epsilon, sup_diff,
 };
+use crate::integer::ciphertext::{
+    RadixCiphertext, ReRandomizationHashAlgo, ReRandomizationKey, SignedRadixCiphertext,
+};
 use crate::integer::keycache::KEY_CACHE;
 use crate::integer::oprf::{OprfPrivateKey, OprfServerKey};
 use crate::integer::server_key::radix_parallel::tests_long_run::OpSequenceFunctionExecutor;
 use crate::integer::server_key::radix_parallel::tests_unsigned::CpuOprfExecutor;
 use crate::integer::tests::create_parameterized_test;
-use crate::integer::{IntegerKeyKind, RadixCiphertext, RadixClientKey, ServerKey};
+use crate::integer::{
+    gen_keys, ClientKey, CompactPrivateKey, CompactPublicKey, IntegerKeyKind, RadixClientKey,
+    ServerKey,
+};
+use crate::shortint::parameters::test_params::{
+    TEST_PARAM_MESSAGE_2_CARRY_2_KS32_PBS_TUNIFORM_2M128,
+    TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+    TEST_PARAM_MULTI_BIT_GROUP_3_MESSAGE_2_CARRY_2_KS_PBS_GAUSSIAN_2M128,
+};
 use crate::shortint::parameters::*;
+use crate::shortint::OprfSeed;
 use crate::Tag;
 use rand::Rng;
 use statrs::distribution::ContinuousCDF;
@@ -25,6 +37,12 @@ create_parameterized_test!(oprf_any_range_unsigned {
 });
 create_parameterized_test!(oprf_almost_uniformity_unsigned {
     PARAM_MESSAGE_2_CARRY_2_KS_PBS_GAUSSIAN_2M128
+});
+
+create_parameterized_test!(pseudo_random_integer_and_rerand {
+    TEST_PARAM_MULTI_BIT_GROUP_3_MESSAGE_2_CARRY_2_KS_PBS_GAUSSIAN_2M128,
+    TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+    TEST_PARAM_MESSAGE_2_CARRY_2_KS32_PBS_TUNIFORM_2M128
 });
 
 fn oprf_uniformity_unsigned<P>(param: P)
@@ -293,4 +311,695 @@ pub(crate) fn probability_density_function_from_density(density: &[usize]) -> Ve
         .iter()
         .map(|count| *count as f64 / total_count as f64)
         .collect()
+}
+
+// PRF rerand below
+
+pub(crate) trait OprfReRandTestRunner {
+    /// Builds the compute, OPRF and re-randomization keys for `param` and returns the client key
+    /// used to decrypt the results.
+    ///
+    /// Re-randomization being tested independently too we only manage the Derived CPK case.
+    fn setup(&mut self, param: TestParameters) -> ClientKey;
+
+    /// Return the prf output once without and once with re-randomization.
+    fn unsigned_full(
+        &mut self,
+        prf_seed: impl OprfSeed,
+        num_blocks: u64,
+        rerand_hash_algo: ReRandomizationHashAlgo,
+    ) -> (RadixCiphertext, RadixCiphertext);
+
+    /// Return the prf output once without and once with re-randomization.
+    fn unsigned_bounded(
+        &mut self,
+        prf_seed: impl OprfSeed,
+        random_bit_count: u64,
+        num_blocks: u64,
+        rerand_hash_algo: ReRandomizationHashAlgo,
+    ) -> (RadixCiphertext, RadixCiphertext);
+
+    // TODO: make this function return the tuple directly once GPU supports the custom_range
+    // generation with rerand
+    /// Re-randomizing custom-range generation.
+    ///
+    /// Returns `None` on backends that do not expose a re-randomizing custom-range primitive yet
+    /// (currently the GPU backend), in which case the generic test skips this sub-test.
+    fn unsigned_custom_range(
+        &mut self,
+        prf_seed: impl OprfSeed,
+        num_input_random_bits: u64,
+        excluded_upper_bound: NonZeroU64,
+        num_blocks_output: u64,
+        rerand_hash_algo: ReRandomizationHashAlgo,
+    ) -> Option<(RadixCiphertext, RadixCiphertext)>;
+
+    /// Return the prf output once without and once with re-randomization.
+    fn signed_full(
+        &mut self,
+        prf_seed: impl OprfSeed,
+        num_blocks: u64,
+        rerand_hash_algo: ReRandomizationHashAlgo,
+    ) -> (SignedRadixCiphertext, SignedRadixCiphertext);
+
+    /// Return the prf output once without and once with re-randomization.
+    fn signed_bounded(
+        &mut self,
+        prf_seed: impl OprfSeed,
+        random_bit_count: u64,
+        num_blocks: u64,
+        rerand_hash_algo: ReRandomizationHashAlgo,
+    ) -> (SignedRadixCiphertext, SignedRadixCiphertext);
+}
+
+/// CPU implementation of [`OprfReRandTestRunner`].
+///
+/// Uses a derived compact public key (no key-switch) for re-randomization.
+pub(crate) struct CpuOprfReRandTestRunner {
+    state: Option<CpuOprfReRandState>,
+}
+
+struct CpuOprfReRandState {
+    sks: ServerKey,
+    oprf_sks: OprfServerKey,
+    rerand_cpk: CompactPublicKey,
+}
+
+impl CpuOprfReRandState {
+    fn rerand_key(&self) -> ReRandomizationKey<'_> {
+        ReRandomizationKey::DerivedCPKWithoutKeySwitch {
+            cpk: &self.rerand_cpk,
+        }
+    }
+}
+
+impl CpuOprfReRandTestRunner {
+    pub(crate) fn new() -> Self {
+        Self { state: None }
+    }
+
+    fn state(&self) -> &CpuOprfReRandState {
+        self.state.as_ref().expect("setup was not properly called")
+    }
+}
+
+impl OprfReRandTestRunner for CpuOprfReRandTestRunner {
+    fn setup(&mut self, param: TestParameters) -> ClientKey {
+        let (cks, sks) = gen_keys(param, IntegerKeyKind::Radix);
+
+        // Derived compact public key, re-using the compute secret key
+        // legacy rerand not covered by this test
+        let privk: CompactPrivateKey<&[u64]> = (&cks).try_into().unwrap();
+        let rerand_cpk = CompactPublicKey::new(&privk);
+
+        let oprf_cks = OprfPrivateKey::new(&cks);
+        let oprf_sks = OprfServerKey::new(&oprf_cks, &cks).unwrap();
+
+        self.state = Some(CpuOprfReRandState {
+            sks,
+            oprf_sks,
+            rerand_cpk,
+        });
+
+        cks
+    }
+
+    fn unsigned_full(
+        &mut self,
+        prf_seed: impl OprfSeed,
+        num_blocks: u64,
+        rerand_hash_algo: ReRandomizationHashAlgo,
+    ) -> (RadixCiphertext, RadixCiphertext) {
+        let state = self.state();
+        let rerand_key = state.rerand_key();
+
+        let prf_seed = prf_seed.into_bytes();
+        let prf_seed = prf_seed.as_ref();
+
+        let prf_not_rerand = state
+            .oprf_sks
+            .par_generate_oblivious_pseudo_random_unsigned_integer(
+                prf_seed, num_blocks, &state.sks,
+            );
+        let prf_rerand = state
+            .oprf_sks
+            .par_generate_oblivious_pseudo_random_unsigned_integer_and_re_randomize(
+                prf_seed,
+                num_blocks,
+                &state.sks,
+                &rerand_key,
+                rerand_hash_algo,
+            )
+            .unwrap();
+
+        (prf_not_rerand, prf_rerand)
+    }
+
+    fn unsigned_bounded(
+        &mut self,
+        prf_seed: impl OprfSeed,
+        random_bit_count: u64,
+        num_blocks: u64,
+        rerand_hash_algo: ReRandomizationHashAlgo,
+    ) -> (RadixCiphertext, RadixCiphertext) {
+        let state = self.state();
+        let rerand_key = state.rerand_key();
+
+        let prf_seed = prf_seed.into_bytes();
+        let prf_seed = prf_seed.as_ref();
+
+        let prf_not_rerand = state
+            .oprf_sks
+            .par_generate_oblivious_pseudo_random_unsigned_integer_bounded(
+                prf_seed,
+                random_bit_count,
+                num_blocks,
+                &state.sks,
+            );
+        let prf_rerand = state
+            .oprf_sks
+            .par_generate_oblivious_pseudo_random_unsigned_integer_bounded_and_re_randomize(
+                prf_seed,
+                random_bit_count,
+                num_blocks,
+                &state.sks,
+                &rerand_key,
+                rerand_hash_algo,
+            )
+            .unwrap();
+
+        (prf_not_rerand, prf_rerand)
+    }
+
+    fn unsigned_custom_range(
+        &mut self,
+        prf_seed: impl OprfSeed,
+        num_input_random_bits: u64,
+        excluded_upper_bound: NonZeroU64,
+        num_blocks_output: u64,
+        rerand_hash_algo: ReRandomizationHashAlgo,
+    ) -> Option<(RadixCiphertext, RadixCiphertext)> {
+        let state = self.state();
+        let rerand_key = state.rerand_key();
+
+        let prf_seed = prf_seed.into_bytes();
+        let prf_seed = prf_seed.as_ref();
+
+        let prf_not_rerand = state
+            .oprf_sks
+            .par_generate_oblivious_pseudo_random_unsigned_custom_range(
+                prf_seed,
+                num_input_random_bits,
+                excluded_upper_bound,
+                num_blocks_output,
+                &state.sks,
+            );
+        let prf_rerand = state
+            .oprf_sks
+            .par_generate_oblivious_pseudo_random_unsigned_custom_range_and_re_randomize(
+                prf_seed,
+                num_input_random_bits,
+                excluded_upper_bound,
+                num_blocks_output,
+                &state.sks,
+                &rerand_key,
+                rerand_hash_algo,
+            )
+            .unwrap();
+
+        Some((prf_not_rerand, prf_rerand))
+    }
+
+    fn signed_full(
+        &mut self,
+        prf_seed: impl OprfSeed,
+        num_blocks: u64,
+        rerand_hash_algo: ReRandomizationHashAlgo,
+    ) -> (SignedRadixCiphertext, SignedRadixCiphertext) {
+        let state = self.state();
+        let rerand_key = state.rerand_key();
+
+        let prf_seed = prf_seed.into_bytes();
+        let prf_seed = prf_seed.as_ref();
+
+        let prf_not_rerand = state
+            .oprf_sks
+            .par_generate_oblivious_pseudo_random_signed_integer(prf_seed, num_blocks, &state.sks);
+        let prf_rerand = state
+            .oprf_sks
+            .par_generate_oblivious_pseudo_random_signed_integer_and_re_randomize(
+                prf_seed,
+                num_blocks,
+                &state.sks,
+                &rerand_key,
+                rerand_hash_algo,
+            )
+            .unwrap();
+
+        (prf_not_rerand, prf_rerand)
+    }
+
+    fn signed_bounded(
+        &mut self,
+        prf_seed: impl OprfSeed,
+        random_bit_count: u64,
+        num_blocks: u64,
+        rerand_hash_algo: ReRandomizationHashAlgo,
+    ) -> (SignedRadixCiphertext, SignedRadixCiphertext) {
+        let state = self.state();
+        let rerand_key = state.rerand_key();
+
+        let prf_seed = prf_seed.into_bytes();
+        let prf_seed = prf_seed.as_ref();
+
+        let prf_not_rerand = state
+            .oprf_sks
+            .par_generate_oblivious_pseudo_random_signed_integer_bounded(
+                prf_seed,
+                random_bit_count,
+                num_blocks,
+                &state.sks,
+            );
+        let prf_rerand = state
+            .oprf_sks
+            .par_generate_oblivious_pseudo_random_signed_integer_bounded_and_re_randomize(
+                prf_seed,
+                random_bit_count,
+                num_blocks,
+                &state.sks,
+                &rerand_key,
+                rerand_hash_algo,
+            )
+            .unwrap();
+
+        (prf_not_rerand, prf_rerand)
+    }
+}
+
+#[track_caller]
+fn check_unsigned_value_and_re_rand_are_ok(
+    lhs: &RadixCiphertext,
+    rhs: &RadixCiphertext,
+    cks: &ClientKey,
+    random_block_count: usize,
+) -> u128 {
+    let lhs_blocks = &lhs.blocks;
+    let rhs_blocks = &rhs.blocks;
+
+    assert_eq!(lhs_blocks.len(), rhs_blocks.len());
+    let message_bits: u64 = cks.parameters().message_modulus().0.ilog2().into();
+    let ct_bits = lhs_blocks.len() as u64 * message_bits;
+
+    // The total number of blocks can be larger than the random bit count for bounded cases
+    for (idx, (lhs_block, rhs_block)) in lhs_blocks.iter().zip(rhs_blocks.iter()).enumerate() {
+        if idx < random_block_count {
+            assert_ne!(
+                lhs_block.ct.as_ref(),
+                rhs_block.ct.as_ref(),
+                "Error verifying block #{idx} differ in lhs and rhs"
+            );
+        } else {
+            // Upper blocks which are not random are trivial 0s;
+            assert_eq!(lhs_block.ct.as_ref(), rhs_block.ct.as_ref());
+            assert!(lhs_block.ct.as_ref().iter().all(|&x| x == 0))
+        }
+    }
+
+    assert!(
+        ct_bits <= u128::BITS as u64,
+        "ciphertext too large to decrypt properly"
+    );
+
+    let dec_lhs: u128 = cks.decrypt_radix(lhs);
+    let dec_rhs: u128 = cks.decrypt_radix(rhs);
+
+    assert_eq!(dec_lhs, dec_rhs);
+
+    dec_lhs
+}
+
+fn subtest_unsigned_integer_full<TestRunner: OprfReRandTestRunner>(
+    prf_seed: impl OprfSeed,
+    cks: &ClientKey,
+    test_runner: &mut TestRunner,
+    rerand_hash_algo: ReRandomizationHashAlgo,
+) {
+    const OUTPUT_BIT_COUNT: u64 = 16;
+
+    let prf_seed = prf_seed.into_bytes();
+    let prf_seed = prf_seed.as_ref();
+
+    let message_bits: u64 = cks.parameters().message_modulus().0.ilog2().into();
+
+    let num_blocks = OUTPUT_BIT_COUNT.div_ceil(message_bits);
+
+    let (prf_not_rerand, prf_rerand) =
+        test_runner.unsigned_full(prf_seed, num_blocks, rerand_hash_algo);
+
+    assert_eq!(prf_not_rerand.blocks.len() as u64, num_blocks);
+    assert_eq!(prf_rerand.blocks.len() as u64, num_blocks);
+
+    let decrypted = check_unsigned_value_and_re_rand_are_ok(
+        &prf_not_rerand,
+        &prf_rerand,
+        cks,
+        num_blocks as usize,
+    );
+
+    let random_value_range = 0..1 << OUTPUT_BIT_COUNT;
+    assert!(
+        random_value_range.contains(&decrypted),
+        "range: {random_value_range:?}, decrypted: {decrypted}"
+    );
+}
+
+fn subtest_unsigned_integer_bounded<TestRunner: OprfReRandTestRunner>(
+    prf_seed: impl OprfSeed,
+    cks: &ClientKey,
+    test_runner: &mut TestRunner,
+    rerand_hash_algo: ReRandomizationHashAlgo,
+) {
+    let mut rng = rand::thread_rng();
+    const OUTPUT_BIT_COUNT: u64 = 16;
+
+    let message_bits: u64 = cks.parameters().message_modulus().0.ilog2().into();
+
+    let num_blocks = OUTPUT_BIT_COUNT.div_ceil(message_bits);
+    let random_bit_count_range = 1..=OUTPUT_BIT_COUNT;
+    let random_bit_count = rng.gen_range(random_bit_count_range);
+    let random_value_range = 0..=1 << random_bit_count;
+    let random_block_count = random_bit_count.div_ceil(message_bits);
+
+    let (prf_not_rerand, prf_rerand) =
+        test_runner.unsigned_bounded(prf_seed, random_bit_count, num_blocks, rerand_hash_algo);
+
+    assert_eq!(prf_not_rerand.blocks.len() as u64, num_blocks);
+    assert_eq!(prf_rerand.blocks.len() as u64, num_blocks);
+
+    let decrypted = check_unsigned_value_and_re_rand_are_ok(
+        &prf_not_rerand,
+        &prf_rerand,
+        cks,
+        random_block_count as usize,
+    );
+
+    assert!(
+        random_value_range.contains(&decrypted),
+        "range: {random_value_range:?}, decrypted: {decrypted}"
+    );
+}
+
+fn subtest_integer_bounded_padding_stays_trivial<TestRunner: OprfReRandTestRunner>(
+    prf_seed: impl OprfSeed,
+    cks: &ClientKey,
+    test_runner: &mut TestRunner,
+    rerand_hash_algo: ReRandomizationHashAlgo,
+) {
+    let mut rng = rand::thread_rng();
+    const OUTPUT_BIT_COUNT: u64 = 16;
+
+    let prf_seed = prf_seed.into_bytes();
+    let prf_seed = prf_seed.as_ref();
+
+    let message_bits: u64 = cks.parameters().message_modulus().0.ilog2().into();
+
+    let num_blocks = OUTPUT_BIT_COUNT.div_ceil(message_bits);
+    // at most num_blocks - 1 of random to leave at least one block of trivial padding
+    let random_bit_count_range = 1..=(num_blocks - 1) * message_bits;
+    let random_bit_count = rng.gen_range(random_bit_count_range);
+    let random_block_count = random_bit_count.div_ceil(message_bits);
+
+    {
+        let (prf_not_rerand, prf_rerand) =
+            test_runner.unsigned_bounded(prf_seed, random_bit_count, num_blocks, rerand_hash_algo);
+
+        assert!(
+            prf_not_rerand.blocks[random_block_count as usize..]
+                .iter()
+                .all(|ct| ct.is_trivial()),
+            "Expected all padding blocks to be trivial 0s"
+        );
+        assert!(
+            prf_rerand.blocks[random_block_count as usize..]
+                .iter()
+                .all(|ct| ct.is_trivial()),
+            "Expected all padding blocks to be trivial 0s"
+        );
+    }
+
+    {
+        let (prf_not_rerand, prf_rerand) =
+            test_runner.signed_bounded(prf_seed, random_bit_count, num_blocks, rerand_hash_algo);
+
+        assert!(
+            prf_not_rerand.blocks[random_block_count as usize..]
+                .iter()
+                .all(|ct| ct.is_trivial()),
+            "Expected all padding blocks to be trivial 0s"
+        );
+        assert!(
+            prf_rerand.blocks[random_block_count as usize..]
+                .iter()
+                .all(|ct| ct.is_trivial()),
+            "Expected all padding blocks to be trivial 0s"
+        );
+    }
+}
+
+fn subtest_unsigned_integer_custom_range<TestRunner: OprfReRandTestRunner>(
+    prf_seed: impl OprfSeed,
+    cks: &ClientKey,
+    test_runner: &mut TestRunner,
+    rerand_hash_algo: ReRandomizationHashAlgo,
+) {
+    let mut rng = rand::thread_rng();
+    // This may cause some values to not appear, but it's fine since we don't test uniformity
+    // Do not use in production
+    const INPUT_RANDOM_BIT_COUNT: u64 = 8;
+    const OUTPUT_BIT_COUNT: u64 = 16;
+
+    let message_bits: u64 = cks.parameters().message_modulus().0.ilog2().into();
+
+    let output_num_blocks = OUTPUT_BIT_COUNT.div_ceil(message_bits);
+    let excluded_upper_bound = {
+        let mut result = NonZeroU64::new(rng.gen_range(1..=1 << OUTPUT_BIT_COUNT)).unwrap();
+
+        // Custom range does not accept power of two range, since other primitives are more
+        // efficient
+        while result.is_power_of_two() {
+            result = NonZeroU64::new(rng.gen_range(1..=1 << OUTPUT_BIT_COUNT)).unwrap();
+        }
+
+        result
+    };
+    let random_value_range = 0u128..excluded_upper_bound.get().into();
+    // range_excluded_upper_bound is not a power of 2, get how many bits are necessary to
+    // represent it via the ceil log2
+    let excluded_upper_bound_log2: u64 = excluded_upper_bound.ilog2().into();
+    let excluded_upper_bound_ceil_log2 = excluded_upper_bound_log2 + 1;
+    let random_block_count = excluded_upper_bound_ceil_log2.div_ceil(message_bits);
+
+    let Some((prf_not_rerand, prf_rerand)) = test_runner.unsigned_custom_range(
+        prf_seed,
+        INPUT_RANDOM_BIT_COUNT,
+        excluded_upper_bound,
+        output_num_blocks,
+        rerand_hash_algo,
+    ) else {
+        // Underlying executor does not have the custom_range support
+        // TODO: remove when GPU has support
+        return;
+    };
+
+    assert_eq!(prf_not_rerand.blocks.len() as u64, output_num_blocks);
+    assert_eq!(prf_rerand.blocks.len() as u64, output_num_blocks);
+
+    let decrypted = check_unsigned_value_and_re_rand_are_ok(
+        &prf_not_rerand,
+        &prf_rerand,
+        cks,
+        random_block_count as usize,
+    );
+
+    assert!(
+        random_value_range.contains(&decrypted),
+        "range: {random_value_range:?}, decrypted: {decrypted}"
+    );
+}
+
+#[track_caller]
+fn check_signed_value_and_re_rand_are_ok(
+    lhs: &SignedRadixCiphertext,
+    rhs: &SignedRadixCiphertext,
+    cks: &ClientKey,
+    random_block_count: usize,
+) -> i128 {
+    let lhs_blocks = &lhs.blocks;
+    let rhs_blocks = &rhs.blocks;
+
+    assert_eq!(lhs_blocks.len(), rhs_blocks.len());
+    let message_bits: u64 = cks.parameters().message_modulus().0.ilog2().into();
+    let ct_bits = lhs_blocks.len() as u64 * message_bits;
+
+    // The total number of blocks can be larger than the random bit count for bounded cases
+    for (idx, (lhs_block, rhs_block)) in lhs_blocks.iter().zip(rhs_blocks.iter()).enumerate() {
+        if idx < random_block_count {
+            assert_ne!(
+                lhs_block.ct.as_ref(),
+                rhs_block.ct.as_ref(),
+                "Error verifying block #{idx} differ in lhs and rhs"
+            );
+        } else {
+            // Upper blocks which are not random are trivial 0s;
+            assert_eq!(lhs_block.ct.as_ref(), rhs_block.ct.as_ref());
+            assert!(lhs_block.ct.as_ref().iter().all(|&x| x == 0))
+        }
+    }
+
+    assert!(
+        ct_bits <= i128::BITS as u64,
+        "ciphertext too large to decrypt properly"
+    );
+
+    let dec_lhs: i128 = cks.decrypt_signed_radix(lhs);
+    let dec_rhs: i128 = cks.decrypt_signed_radix(rhs);
+
+    assert_eq!(dec_lhs, dec_rhs);
+
+    dec_lhs
+}
+
+fn subtest_signed_integer_full<TestRunner: OprfReRandTestRunner>(
+    prf_seed: impl OprfSeed,
+    cks: &ClientKey,
+    test_runner: &mut TestRunner,
+    rerand_hash_algo: ReRandomizationHashAlgo,
+) {
+    const OUTPUT_BIT_COUNT: u64 = 16;
+
+    let message_bits: u64 = cks.parameters().message_modulus().0.ilog2().into();
+
+    let num_blocks = OUTPUT_BIT_COUNT.div_ceil(message_bits);
+
+    let (prf_not_rerand, prf_rerand) =
+        test_runner.signed_full(prf_seed, num_blocks, rerand_hash_algo);
+
+    assert_eq!(prf_not_rerand.blocks.len() as u64, num_blocks);
+    assert_eq!(prf_rerand.blocks.len() as u64, num_blocks);
+
+    let decrypted = check_signed_value_and_re_rand_are_ok(
+        &prf_not_rerand,
+        &prf_rerand,
+        cks,
+        num_blocks as usize,
+    );
+
+    let random_value_range = -1i128 << (OUTPUT_BIT_COUNT - 1)..1 << (OUTPUT_BIT_COUNT - 1);
+    assert!(
+        random_value_range.contains(&decrypted),
+        "range: {random_value_range:?}, decrypted: {decrypted}"
+    );
+}
+
+fn subtest_signed_integer_bounded<TestRunner: OprfReRandTestRunner>(
+    prf_seed: impl OprfSeed,
+    cks: &ClientKey,
+    test_runner: &mut TestRunner,
+    rerand_hash_algo: ReRandomizationHashAlgo,
+) {
+    let mut rng = rand::thread_rng();
+    const OUTPUT_BIT_COUNT: u64 = 16;
+
+    let message_bits: u64 = cks.parameters().message_modulus().0.ilog2().into();
+
+    let num_blocks = OUTPUT_BIT_COUNT.div_ceil(message_bits);
+    // For signed values on n_bits we need to stay < 2^(n_bits - 1)
+    // since that value is a signed negative value
+    let random_bit_count_range = 1..=(OUTPUT_BIT_COUNT - 1);
+    let random_bit_count = rng.gen_range(random_bit_count_range);
+    let random_value_range = 0..=1 << random_bit_count;
+    let random_block_count = random_bit_count.div_ceil(message_bits);
+
+    let (prf_not_rerand, prf_rerand) =
+        test_runner.signed_bounded(prf_seed, random_bit_count, num_blocks, rerand_hash_algo);
+
+    assert_eq!(prf_not_rerand.blocks.len() as u64, num_blocks);
+    assert_eq!(prf_rerand.blocks.len() as u64, num_blocks);
+
+    let decrypted = check_signed_value_and_re_rand_are_ok(
+        &prf_not_rerand,
+        &prf_rerand,
+        cks,
+        random_block_count as usize,
+    );
+
+    assert!(
+        random_value_range.contains(&decrypted),
+        "range: {random_value_range:?}, decrypted: {decrypted}"
+    );
+}
+
+/// Generic PRF + re-randomization test
+///
+/// For each supported generation primitive it generates the PRF output with and without
+/// re-randomization from the same seed and checks that:
+/// - the random blocks differ (re-randomization changed ciphertexts)
+/// - the expected trivial padding blocks are there
+/// - both decrypt to the same value within the expected range
+pub(crate) fn pseudo_random_integer_and_rerand_test<P, E>(param: P, mut test_runner: E)
+where
+    P: Into<TestParameters>,
+    E: OprfReRandTestRunner,
+{
+    let mut rng = rand::thread_rng();
+
+    let cks = test_runner.setup(param.into());
+
+    // One seed for the test, do not use this in production, re-using a seed is bad
+    let prf_seed: [u8; 256 / 8] = core::array::from_fn(|_| rng.gen());
+    println!("prf_seed={prf_seed:?}");
+    let prf_seed = prf_seed.as_slice();
+
+    for rerand_hash_algo in [
+        ReRandomizationHashAlgo::Blake3,
+        ReRandomizationHashAlgo::Shake256,
+    ] {
+        println!("rerand_hash_algo: {rerand_hash_algo:?}");
+
+        subtest_integer_bounded_padding_stays_trivial(
+            prf_seed,
+            &cks,
+            &mut test_runner,
+            rerand_hash_algo,
+        );
+
+        // A fresh seed per call: re-using a seed across re-randomization calls is unsafe in
+        // production, but each call here is self-contained (plain vs rerand from the same seed).
+        subtest_unsigned_integer_full(prf_seed, &cks, &mut test_runner, rerand_hash_algo);
+        subtest_signed_integer_full(prf_seed, &cks, &mut test_runner, rerand_hash_algo);
+
+        // Run bounded tests a little more since they have a random component
+        for _ in 0..10 {
+            subtest_unsigned_integer_bounded(prf_seed, &cks, &mut test_runner, rerand_hash_algo);
+            subtest_signed_integer_bounded(prf_seed, &cks, &mut test_runner, rerand_hash_algo);
+        }
+
+        // This test has a random component but is much heavier (and is skipped on backends that
+        // do not support the re-randomizing custom-range primitive yet, e.g. GPU).
+        for _ in 0..3 {
+            subtest_unsigned_integer_custom_range(
+                prf_seed,
+                &cks,
+                &mut test_runner,
+                rerand_hash_algo,
+            );
+        }
+    }
+}
+
+fn pseudo_random_integer_and_rerand<P>(param: P)
+where
+    P: Into<TestParameters>,
+{
+    pseudo_random_integer_and_rerand_test(param, CpuOprfReRandTestRunner::new());
 }

--- a/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_oprf.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_oprf.rs
@@ -3,7 +3,8 @@ use crate::core_crypto::commons::math::random::tests::{
     cumulate, dkw_alpha_from_epsilon, sup_diff,
 };
 use crate::integer::ciphertext::{
-    RadixCiphertext, ReRandomizationHashAlgo, ReRandomizationKey, SignedRadixCiphertext,
+    PrfReRandomizationContext, RadixCiphertext, ReRandomizationHashAlgo, ReRandomizationKey,
+    ReRandomizationSeedHasher, SignedRadixCiphertext,
 };
 use crate::integer::keycache::KEY_CACHE;
 use crate::integer::oprf::{OprfPrivateKey, OprfServerKey};
@@ -327,7 +328,7 @@ pub(crate) trait OprfReRandTestRunner {
         &mut self,
         prf_seed: impl OprfSeed,
         num_blocks: u64,
-        rerand_hash_algo: ReRandomizationHashAlgo,
+        prf_re_randomization_context: &PrfReRandomizationContext,
     ) -> (RadixCiphertext, RadixCiphertext);
 
     /// Return the prf output once without and once with re-randomization.
@@ -336,7 +337,7 @@ pub(crate) trait OprfReRandTestRunner {
         prf_seed: impl OprfSeed,
         random_bit_count: u64,
         num_blocks: u64,
-        rerand_hash_algo: ReRandomizationHashAlgo,
+        prf_re_randomization_context: &PrfReRandomizationContext,
     ) -> (RadixCiphertext, RadixCiphertext);
 
     // TODO: make this function return the tuple directly once GPU supports the custom_range
@@ -351,7 +352,7 @@ pub(crate) trait OprfReRandTestRunner {
         num_input_random_bits: u64,
         excluded_upper_bound: NonZeroU64,
         num_blocks_output: u64,
-        rerand_hash_algo: ReRandomizationHashAlgo,
+        prf_re_randomization_context: &PrfReRandomizationContext,
     ) -> Option<(RadixCiphertext, RadixCiphertext)>;
 
     /// Return the prf output once without and once with re-randomization.
@@ -359,7 +360,7 @@ pub(crate) trait OprfReRandTestRunner {
         &mut self,
         prf_seed: impl OprfSeed,
         num_blocks: u64,
-        rerand_hash_algo: ReRandomizationHashAlgo,
+        prf_re_randomization_context: &PrfReRandomizationContext,
     ) -> (SignedRadixCiphertext, SignedRadixCiphertext);
 
     /// Return the prf output once without and once with re-randomization.
@@ -368,7 +369,7 @@ pub(crate) trait OprfReRandTestRunner {
         prf_seed: impl OprfSeed,
         random_bit_count: u64,
         num_blocks: u64,
-        rerand_hash_algo: ReRandomizationHashAlgo,
+        prf_re_randomization_context: &PrfReRandomizationContext,
     ) -> (SignedRadixCiphertext, SignedRadixCiphertext);
 }
 
@@ -428,7 +429,7 @@ impl OprfReRandTestRunner for CpuOprfReRandTestRunner {
         &mut self,
         prf_seed: impl OprfSeed,
         num_blocks: u64,
-        rerand_hash_algo: ReRandomizationHashAlgo,
+        prf_re_randomization_context: &PrfReRandomizationContext,
     ) -> (RadixCiphertext, RadixCiphertext) {
         let state = self.state();
         let rerand_key = state.rerand_key();
@@ -448,7 +449,7 @@ impl OprfReRandTestRunner for CpuOprfReRandTestRunner {
                 num_blocks,
                 &state.sks,
                 &rerand_key,
-                rerand_hash_algo,
+                prf_re_randomization_context,
             )
             .unwrap();
 
@@ -460,7 +461,7 @@ impl OprfReRandTestRunner for CpuOprfReRandTestRunner {
         prf_seed: impl OprfSeed,
         random_bit_count: u64,
         num_blocks: u64,
-        rerand_hash_algo: ReRandomizationHashAlgo,
+        prf_re_randomization_context: &PrfReRandomizationContext,
     ) -> (RadixCiphertext, RadixCiphertext) {
         let state = self.state();
         let rerand_key = state.rerand_key();
@@ -484,7 +485,7 @@ impl OprfReRandTestRunner for CpuOprfReRandTestRunner {
                 num_blocks,
                 &state.sks,
                 &rerand_key,
-                rerand_hash_algo,
+                prf_re_randomization_context,
             )
             .unwrap();
 
@@ -497,7 +498,7 @@ impl OprfReRandTestRunner for CpuOprfReRandTestRunner {
         num_input_random_bits: u64,
         excluded_upper_bound: NonZeroU64,
         num_blocks_output: u64,
-        rerand_hash_algo: ReRandomizationHashAlgo,
+        prf_re_randomization_context: &PrfReRandomizationContext,
     ) -> Option<(RadixCiphertext, RadixCiphertext)> {
         let state = self.state();
         let rerand_key = state.rerand_key();
@@ -523,7 +524,7 @@ impl OprfReRandTestRunner for CpuOprfReRandTestRunner {
                 num_blocks_output,
                 &state.sks,
                 &rerand_key,
-                rerand_hash_algo,
+                prf_re_randomization_context,
             )
             .unwrap();
 
@@ -534,7 +535,7 @@ impl OprfReRandTestRunner for CpuOprfReRandTestRunner {
         &mut self,
         prf_seed: impl OprfSeed,
         num_blocks: u64,
-        rerand_hash_algo: ReRandomizationHashAlgo,
+        prf_re_randomization_context: &PrfReRandomizationContext,
     ) -> (SignedRadixCiphertext, SignedRadixCiphertext) {
         let state = self.state();
         let rerand_key = state.rerand_key();
@@ -552,7 +553,7 @@ impl OprfReRandTestRunner for CpuOprfReRandTestRunner {
                 num_blocks,
                 &state.sks,
                 &rerand_key,
-                rerand_hash_algo,
+                prf_re_randomization_context,
             )
             .unwrap();
 
@@ -564,7 +565,7 @@ impl OprfReRandTestRunner for CpuOprfReRandTestRunner {
         prf_seed: impl OprfSeed,
         random_bit_count: u64,
         num_blocks: u64,
-        rerand_hash_algo: ReRandomizationHashAlgo,
+        prf_re_randomization_context: &PrfReRandomizationContext,
     ) -> (SignedRadixCiphertext, SignedRadixCiphertext) {
         let state = self.state();
         let rerand_key = state.rerand_key();
@@ -588,7 +589,7 @@ impl OprfReRandTestRunner for CpuOprfReRandTestRunner {
                 num_blocks,
                 &state.sks,
                 &rerand_key,
-                rerand_hash_algo,
+                prf_re_randomization_context,
             )
             .unwrap();
 
@@ -642,7 +643,7 @@ fn subtest_unsigned_integer_full<TestRunner: OprfReRandTestRunner>(
     prf_seed: impl OprfSeed,
     cks: &ClientKey,
     test_runner: &mut TestRunner,
-    rerand_hash_algo: ReRandomizationHashAlgo,
+    prf_re_randomization_context: &PrfReRandomizationContext,
 ) {
     const OUTPUT_BIT_COUNT: u64 = 16;
 
@@ -654,7 +655,7 @@ fn subtest_unsigned_integer_full<TestRunner: OprfReRandTestRunner>(
     let num_blocks = OUTPUT_BIT_COUNT.div_ceil(message_bits);
 
     let (prf_not_rerand, prf_rerand) =
-        test_runner.unsigned_full(prf_seed, num_blocks, rerand_hash_algo);
+        test_runner.unsigned_full(prf_seed, num_blocks, prf_re_randomization_context);
 
     assert_eq!(prf_not_rerand.blocks.len() as u64, num_blocks);
     assert_eq!(prf_rerand.blocks.len() as u64, num_blocks);
@@ -677,7 +678,7 @@ fn subtest_unsigned_integer_bounded<TestRunner: OprfReRandTestRunner>(
     prf_seed: impl OprfSeed,
     cks: &ClientKey,
     test_runner: &mut TestRunner,
-    rerand_hash_algo: ReRandomizationHashAlgo,
+    prf_re_randomization_context: &PrfReRandomizationContext,
 ) {
     let mut rng = rand::thread_rng();
     const OUTPUT_BIT_COUNT: u64 = 16;
@@ -690,8 +691,12 @@ fn subtest_unsigned_integer_bounded<TestRunner: OprfReRandTestRunner>(
     let random_value_range = 0..=1 << random_bit_count;
     let random_block_count = random_bit_count.div_ceil(message_bits);
 
-    let (prf_not_rerand, prf_rerand) =
-        test_runner.unsigned_bounded(prf_seed, random_bit_count, num_blocks, rerand_hash_algo);
+    let (prf_not_rerand, prf_rerand) = test_runner.unsigned_bounded(
+        prf_seed,
+        random_bit_count,
+        num_blocks,
+        prf_re_randomization_context,
+    );
 
     assert_eq!(prf_not_rerand.blocks.len() as u64, num_blocks);
     assert_eq!(prf_rerand.blocks.len() as u64, num_blocks);
@@ -713,7 +718,7 @@ fn subtest_integer_bounded_padding_stays_trivial<TestRunner: OprfReRandTestRunne
     prf_seed: impl OprfSeed,
     cks: &ClientKey,
     test_runner: &mut TestRunner,
-    rerand_hash_algo: ReRandomizationHashAlgo,
+    prf_re_randomization_context: &PrfReRandomizationContext,
 ) {
     let mut rng = rand::thread_rng();
     const OUTPUT_BIT_COUNT: u64 = 16;
@@ -730,8 +735,12 @@ fn subtest_integer_bounded_padding_stays_trivial<TestRunner: OprfReRandTestRunne
     let random_block_count = random_bit_count.div_ceil(message_bits);
 
     {
-        let (prf_not_rerand, prf_rerand) =
-            test_runner.unsigned_bounded(prf_seed, random_bit_count, num_blocks, rerand_hash_algo);
+        let (prf_not_rerand, prf_rerand) = test_runner.unsigned_bounded(
+            prf_seed,
+            random_bit_count,
+            num_blocks,
+            prf_re_randomization_context,
+        );
 
         assert!(
             prf_not_rerand.blocks[random_block_count as usize..]
@@ -748,8 +757,12 @@ fn subtest_integer_bounded_padding_stays_trivial<TestRunner: OprfReRandTestRunne
     }
 
     {
-        let (prf_not_rerand, prf_rerand) =
-            test_runner.signed_bounded(prf_seed, random_bit_count, num_blocks, rerand_hash_algo);
+        let (prf_not_rerand, prf_rerand) = test_runner.signed_bounded(
+            prf_seed,
+            random_bit_count,
+            num_blocks,
+            prf_re_randomization_context,
+        );
 
         assert!(
             prf_not_rerand.blocks[random_block_count as usize..]
@@ -770,7 +783,7 @@ fn subtest_unsigned_integer_custom_range<TestRunner: OprfReRandTestRunner>(
     prf_seed: impl OprfSeed,
     cks: &ClientKey,
     test_runner: &mut TestRunner,
-    rerand_hash_algo: ReRandomizationHashAlgo,
+    prf_re_randomization_context: &PrfReRandomizationContext,
 ) {
     let mut rng = rand::thread_rng();
     // This may cause some values to not appear, but it's fine since we don't test uniformity
@@ -804,7 +817,7 @@ fn subtest_unsigned_integer_custom_range<TestRunner: OprfReRandTestRunner>(
         INPUT_RANDOM_BIT_COUNT,
         excluded_upper_bound,
         output_num_blocks,
-        rerand_hash_algo,
+        prf_re_randomization_context,
     ) else {
         // Underlying executor does not have the custom_range support
         // TODO: remove when GPU has support
@@ -873,7 +886,7 @@ fn subtest_signed_integer_full<TestRunner: OprfReRandTestRunner>(
     prf_seed: impl OprfSeed,
     cks: &ClientKey,
     test_runner: &mut TestRunner,
-    rerand_hash_algo: ReRandomizationHashAlgo,
+    prf_re_randomization_context: &PrfReRandomizationContext,
 ) {
     const OUTPUT_BIT_COUNT: u64 = 16;
 
@@ -882,7 +895,7 @@ fn subtest_signed_integer_full<TestRunner: OprfReRandTestRunner>(
     let num_blocks = OUTPUT_BIT_COUNT.div_ceil(message_bits);
 
     let (prf_not_rerand, prf_rerand) =
-        test_runner.signed_full(prf_seed, num_blocks, rerand_hash_algo);
+        test_runner.signed_full(prf_seed, num_blocks, prf_re_randomization_context);
 
     assert_eq!(prf_not_rerand.blocks.len() as u64, num_blocks);
     assert_eq!(prf_rerand.blocks.len() as u64, num_blocks);
@@ -905,7 +918,7 @@ fn subtest_signed_integer_bounded<TestRunner: OprfReRandTestRunner>(
     prf_seed: impl OprfSeed,
     cks: &ClientKey,
     test_runner: &mut TestRunner,
-    rerand_hash_algo: ReRandomizationHashAlgo,
+    prf_re_randomization_context: &PrfReRandomizationContext,
 ) {
     let mut rng = rand::thread_rng();
     const OUTPUT_BIT_COUNT: u64 = 16;
@@ -920,8 +933,12 @@ fn subtest_signed_integer_bounded<TestRunner: OprfReRandTestRunner>(
     let random_value_range = 0..=1 << random_bit_count;
     let random_block_count = random_bit_count.div_ceil(message_bits);
 
-    let (prf_not_rerand, prf_rerand) =
-        test_runner.signed_bounded(prf_seed, random_bit_count, num_blocks, rerand_hash_algo);
+    let (prf_not_rerand, prf_rerand) = test_runner.signed_bounded(
+        prf_seed,
+        random_bit_count,
+        num_blocks,
+        prf_re_randomization_context,
+    );
 
     assert_eq!(prf_not_rerand.blocks.len() as u64, num_blocks);
     assert_eq!(prf_rerand.blocks.len() as u64, num_blocks);
@@ -965,23 +982,31 @@ where
         ReRandomizationHashAlgo::Shake256,
     ] {
         println!("rerand_hash_algo: {rerand_hash_algo:?}");
+        let seed_hasher = ReRandomizationSeedHasher::new(
+            rerand_hash_algo,
+            crate::shortint::oprf::TFHE_PRF_RERAND_DOMAIN_SEPARATOR,
+        );
+        let prf_rerand_context = PrfReRandomizationContext::new_with_hasher(
+            crate::shortint::public_key::compact::TFHE_PKE_DOMAIN_SEPARATOR,
+            seed_hasher,
+        );
 
         subtest_integer_bounded_padding_stays_trivial(
             prf_seed,
             &cks,
             &mut test_runner,
-            rerand_hash_algo,
+            &prf_rerand_context,
         );
 
         // A fresh seed per call: re-using a seed across re-randomization calls is unsafe in
         // production, but each call here is self-contained (plain vs rerand from the same seed).
-        subtest_unsigned_integer_full(prf_seed, &cks, &mut test_runner, rerand_hash_algo);
-        subtest_signed_integer_full(prf_seed, &cks, &mut test_runner, rerand_hash_algo);
+        subtest_unsigned_integer_full(prf_seed, &cks, &mut test_runner, &prf_rerand_context);
+        subtest_signed_integer_full(prf_seed, &cks, &mut test_runner, &prf_rerand_context);
 
         // Run bounded tests a little more since they have a random component
         for _ in 0..10 {
-            subtest_unsigned_integer_bounded(prf_seed, &cks, &mut test_runner, rerand_hash_algo);
-            subtest_signed_integer_bounded(prf_seed, &cks, &mut test_runner, rerand_hash_algo);
+            subtest_unsigned_integer_bounded(prf_seed, &cks, &mut test_runner, &prf_rerand_context);
+            subtest_signed_integer_bounded(prf_seed, &cks, &mut test_runner, &prf_rerand_context);
         }
 
         // This test has a random component but is much heavier (and is skipped on backends that
@@ -991,7 +1016,7 @@ where
                 prf_seed,
                 &cks,
                 &mut test_runner,
-                rerand_hash_algo,
+                &prf_rerand_context,
             );
         }
     }

--- a/tfhe/src/shortint/ciphertext/re_randomization.rs
+++ b/tfhe/src/shortint/ciphertext/re_randomization.rs
@@ -27,7 +27,7 @@ use super::CompactCiphertextList;
 const RERAND_SEED_BITS: usize = 256;
 
 /// The XoF algorithm used to generate the re-randomization seed
-#[derive(Copy, Clone, Default)]
+#[derive(Copy, Clone, Default, Debug)]
 pub enum ReRandomizationHashAlgo {
     /// Used for NIST compliance
     Shake256,

--- a/tfhe/src/shortint/ciphertext/re_randomization.rs
+++ b/tfhe/src/shortint/ciphertext/re_randomization.rs
@@ -14,7 +14,6 @@ use crate::core_crypto::prelude::lwe_compact_ciphertext_list_add_assign;
 use crate::shortint::ciphertext::NoiseLevel;
 use crate::shortint::key_switching_key::KeySwitchingKeyMaterialView;
 use crate::shortint::oprf::{OprfSeed, RandomBitsRleLeBytes};
-use crate::shortint::public_key::compact::TFHE_PKE_DOMAIN_SEPARATOR;
 use crate::shortint::{Ciphertext, CompactPublicKey, PBSOrder};
 
 use rayon::prelude::*;
@@ -110,12 +109,12 @@ pub struct ReRandomizationSeed(pub(crate) XofSeed);
 
 impl ReRandomizationSeed {
     pub(crate) fn new_prf_rerand_seed(
-        hash_algo: ReRandomizationHashAlgo,
+        prf_re_randomization_context: &ReRandomizationContext,
         prf_seed: impl OprfSeed,
         random_bits_rle_bytes: &RandomBitsRleLeBytes,
     ) -> Self {
         let mut seed_gen = ReRandomizationSeedGen::new_prf_rerand_seed_gen(
-            hash_algo,
+            prf_re_randomization_context,
             prf_seed,
             random_bits_rle_bytes,
         );
@@ -129,6 +128,7 @@ impl ReRandomizationSeed {
 /// At this level, the context will directly hash any data passed to it.
 /// This means that the order in which the data will be hashed matches exactly the order in which
 /// the different `add_*` functions are called
+#[derive(Clone)]
 pub struct ReRandomizationContext {
     hash_state: ReRandomizationSeedHasher,
     public_encryption_domain_separator: [u8; XofSeed::DOMAIN_SEP_LEN],
@@ -245,16 +245,11 @@ pub struct ReRandomizationSeedGen {
 
 impl ReRandomizationSeedGen {
     pub(crate) fn new_prf_rerand_seed_gen(
-        hash_algo: ReRandomizationHashAlgo,
+        prf_re_randomization_context: &ReRandomizationContext,
         prf_seed: impl OprfSeed,
         random_bits_rle_bytes: &RandomBitsRleLeBytes,
     ) -> Self {
-        const PRF_RERAND_DOMAIN_SEPARATOR: [u8; XofSeed::DOMAIN_SEP_LEN] = *b"PRF_RRND";
-
-        let mut context = ReRandomizationContext::new_with_hasher(
-            TFHE_PKE_DOMAIN_SEPARATOR,
-            ReRandomizationSeedHasher::new(hash_algo, PRF_RERAND_DOMAIN_SEPARATOR),
-        );
+        let mut context = prf_re_randomization_context.clone();
 
         let prf_seed = prf_seed.into_bytes();
         let prf_seed = prf_seed.as_ref();

--- a/tfhe/src/shortint/ciphertext/re_randomization.rs
+++ b/tfhe/src/shortint/ciphertext/re_randomization.rs
@@ -574,17 +574,18 @@ mod test {
         let ksk_material = ksk_material.as_ref().map(|k| k.as_view());
 
         let pke_lwe_dim = pubk.parameters().encryption_lwe_dimension.0;
-
-        let msg1 = 1;
-        let msg2 = 2;
+        let message_modulus = cks.parameters().message_modulus();
 
         {
             let mut cts = Vec::with_capacity(pke_lwe_dim * 2);
+            let clears: Vec<u64> = (0..cts.capacity())
+                .map(|_| rand::random::<u64>() % message_modulus.0)
+                .collect();
 
-            for _ in 0..pke_lwe_dim {
-                let ct1 = cks.encrypt(msg1);
+            for chunk in clears.chunks_exact(2) {
+                let ct1 = cks.encrypt(chunk[0]);
                 cts.push(ct1);
-                let ct2 = cks.encrypt(msg2);
+                let ct2 = cks.encrypt(chunk[1]);
                 cts.push(ct2);
             }
 
@@ -600,16 +601,19 @@ mod test {
             pubk.re_randomize_ciphertexts(&mut cts, ksk_material.as_ref(), seeder.next_seed())
                 .unwrap();
 
-            cts.par_chunks(2).for_each(|pair| {
-                let sum = sks.add(&pair[0], &pair[1]);
-                let dec = cks.decrypt(&sum);
+            cts.par_chunks_exact(2)
+                .zip(clears.par_chunks_exact(2))
+                .for_each(|(pair, clear_pair)| {
+                    let sum = sks.add(&pair[0], &pair[1]);
+                    let dec = cks.decrypt(&sum);
 
-                assert_eq!(dec, msg1 + msg2);
-            });
+                    assert_eq!(dec, (clear_pair[0] + clear_pair[1]) % message_modulus.0);
+                });
         }
 
         {
-            let mut trivial = sks.create_trivial(3);
+            let random_clear = rand::random::<u64>() % cks.parameters().message_modulus().0;
+            let mut trivial = sks.create_trivial(random_clear);
 
             let nonce: [u8; 256 / 8] = core::array::from_fn(|_| rand::random());
             let mut re_rand_context = ReRandomizationContext::new(*b"TFHE_Rrd", *b"TFHE_Enc");
@@ -629,10 +633,12 @@ mod test {
 
             let not_trivial = trivial;
 
+            // non trivial ct should have a non zero mask
+            assert!(not_trivial.ct.get_mask().as_ref().iter().any(|&x| x != 0));
             assert!(not_trivial.noise_level() == NoiseLevel::NOMINAL);
 
             let dec = cks.decrypt(&not_trivial);
-            assert_eq!(dec, 3);
+            assert_eq!(dec, random_clear);
         }
     }
 

--- a/tfhe/src/shortint/oprf.rs
+++ b/tfhe/src/shortint/oprf.rs
@@ -11,7 +11,7 @@ use crate::core_crypto::commons::math::random::{RandomGenerator, Uniform};
 use crate::core_crypto::fft_impl::fft64::crypto::bootstrap::LweBootstrapKeyConformanceParams;
 use crate::core_crypto::prelude::*;
 use crate::shortint::atomic_pattern::{AtomicPattern, AtomicPatternServerKey};
-use crate::shortint::ciphertext::{Degree, ReRandomizationHashAlgo, ReRandomizationSeed};
+use crate::shortint::ciphertext::{Degree, ReRandomizationContext, ReRandomizationSeed};
 use crate::shortint::engine::ShortintEngine;
 use crate::shortint::key_switching_key::KeySwitchingKeyMaterialView;
 use crate::shortint::parameters::{KeySwitch32PBSParameters, NoiseLevel};
@@ -665,7 +665,7 @@ impl<C: Container<Element = c64> + Sync> GenericOprfServerKey<C> {
         target_sks: &ServerKey,
         compact_public_key: &CompactPublicKey,
         key_switching_key_material: Option<&KeySwitchingKeyMaterialView>,
-        rerand_hash_algo: ReRandomizationHashAlgo,
+        prf_re_randomization_context: &ReRandomizationContext,
     ) -> crate::Result<Vec<Vec<Ciphertext>>> {
         self.inner
             .generate_pseudo_random_bits_chunks_and_re_randomize(
@@ -675,7 +675,7 @@ impl<C: Container<Element = c64> + Sync> GenericOprfServerKey<C> {
                 target_sks,
                 compact_public_key,
                 key_switching_key_material,
-                rerand_hash_algo,
+                prf_re_randomization_context,
             )
     }
 }
@@ -900,6 +900,7 @@ impl RandomBitsRleLeBytes {
 
 pub const TFHE_PRF_DOMAIN_SEPARATOR: [u8; 8] = *b"TFHE_PRF";
 pub const TFHE_PRF_XOF_SEED_DOMAIN_SEPARATOR: [u8; XofSeed::DOMAIN_SEP_LEN] = *b"PRF_INIT";
+pub const TFHE_PRF_RERAND_DOMAIN_SEPARATOR: [u8; XofSeed::DOMAIN_SEP_LEN] = *b"PRF_RRND";
 
 /// Return the seeded inputs for each output block of the PRF, along with the Run Length Encoding
 /// (RLE) byte representation of the output random bits layout. The RLE output is e.g. used in
@@ -1281,7 +1282,7 @@ impl<C: Container<Element = c64> + Sync> OprfBootstrappingKey<C> {
         target_sks: &ServerKey,
         compact_public_key: &CompactPublicKey,
         key_switching_key_material: Option<&KeySwitchingKeyMaterialView>,
-        rerand_hash_algo: ReRandomizationHashAlgo,
+        prf_re_randomization_context: &ReRandomizationContext,
     ) -> crate::Result<Vec<Vec<Ciphertext>>> {
         let prf_seed = prf_seed.into_bytes();
         let prf_seed = prf_seed.as_ref();
@@ -1293,8 +1294,11 @@ impl<C: Container<Element = c64> + Sync> OprfBootstrappingKey<C> {
             target_sks,
         );
 
-        let rerand_seed =
-            ReRandomizationSeed::new_prf_rerand_seed(rerand_hash_algo, prf_seed, &random_bits_rle);
+        let rerand_seed = ReRandomizationSeed::new_prf_rerand_seed(
+            prf_re_randomization_context,
+            prf_seed,
+            &random_bits_rle,
+        );
 
         compact_public_key.re_randomize_ciphertexts(
             &mut flat_result,
@@ -1363,6 +1367,7 @@ pub(crate) mod test {
     use crate::core_crypto::prelude::{
         decrypt_lwe_ciphertext, new_seeder, CastInto, LweSecretKeyView,
     };
+    use crate::shortint::ciphertext::{ReRandomizationHashAlgo, ReRandomizationSeedHasher};
     use crate::shortint::oprf::create_random_from_seed_modulus_switched;
     use crate::shortint::parameters::test_params::{
         TEST_PARAM_MESSAGE_2_CARRY_2_KS32_PBS_TUNIFORM_2M128,
@@ -1797,6 +1802,15 @@ pub(crate) mod test {
                 ReRandomizationHashAlgo::Blake3,
                 ReRandomizationHashAlgo::Shake256,
             ] {
+                let seed_hasher = ReRandomizationSeedHasher::new(
+                    rerand_hash_algo,
+                    TFHE_PRF_RERAND_DOMAIN_SEPARATOR,
+                );
+                let prf_rerand_context = ReRandomizationContext::new_with_hasher(
+                    crate::shortint::public_key::compact::TFHE_PKE_DOMAIN_SEPARATOR,
+                    seed_hasher,
+                );
+
                 let prf_rerand_chunks = oprf_sks
                     .generate_oblivious_pseudo_random_bits_chunks_and_re_randomize(
                         prf_seed.as_ref(),
@@ -1804,7 +1818,7 @@ pub(crate) mod test {
                         &sks,
                         &pubk,
                         None,
-                        rerand_hash_algo,
+                        &prf_rerand_context,
                     )
                     .unwrap();
 

--- a/tfhe/src/shortint/oprf.rs
+++ b/tfhe/src/shortint/oprf.rs
@@ -1859,7 +1859,12 @@ pub(crate) mod test {
                         } = prf_rerand_ct;
                         let prf_rerand_noise_level = prf_rerand_ct.noise_level();
 
-                        assert_ne!(prf_lwe, prf_rerand_lwe);
+                        assert_ne!(prf_lwe.as_ref(), prf_rerand_lwe.as_ref());
+                        assert_eq!(prf_lwe.lwe_size(), prf_rerand_lwe.lwe_size());
+                        assert_eq!(
+                            prf_lwe.ciphertext_modulus(),
+                            prf_rerand_lwe.ciphertext_modulus()
+                        );
                         assert_eq!(prf_degree, prf_rerand_degree);
                         // Check expected max degree
                         assert_eq!(prf_degree.0, expected_max_value - 1);


### PR DESCRIPTION
First three commits + "[refacto: make reasoning about custom range for PRF easier](https://github.com/zama-ai/tfhe-rs/commit/272ca5c1a69483ef8c516b68e754d5bfa58175fe)" can be reviewed independently and contain some small fixes/updates commits (self contained)

+

PRF plug into the HL APIs except for the custom_range variant of GPU which requires GPU code
Shuffle now also has it's "reranded" variant where the PRF outputs are reranded before being fed into the bitonic_shuffle_with_keys

Also missing the size primitives for GPU

for integer used a pattern adjacent to the FunctionExecutor but more focused on the rerand APIs called a "test runner"

Normally this PR should be fairly straightforward after the shortint one

Probably missing some docs, which I can either add in this PR or in another one to avoid mixing the reviews

If the PR is too complex/needs more small PRs let me know, I'd like to get this merged for the release (and I think it's largely doable) but if something gets in the way of readability/ease of understanding I can correct that

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3649)
<!-- Reviewable:end -->
