### PR TITLE
feat: add boolean dot product

### DIFF
--- a/tfhe/src/integer/server_key/radix_parallel/dot_prod.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/dot_prod.rs
@@ -1,0 +1,116 @@
+use crate::integer::{BooleanBlock, IntegerRadixCiphertext, ServerKey};
+use crate::shortint::ciphertext::NoiseLevel;
+use rayon::prelude::*;
+use std::borrow::Cow;
+
+impl ServerKey {
+    /// Returns boolean blocks that are guaranteed clean (degree <= 1, nominal noise),
+    /// borrowing the input when it is already clean and only cloning otherwise.
+    pub(crate) fn cleaned_boolean_blocks<'a>(
+        &self,
+        boolean_blocks: &'a [BooleanBlock],
+    ) -> Cow<'a, [BooleanBlock]> {
+        let needs_cleaning =
+            |b: &BooleanBlock| b.0.noise_level() > NoiseLevel::NOMINAL || b.0.degree.get() >= 2;
+
+        if boolean_blocks.iter().any(needs_cleaning) {
+            let id_lut = self.key.generate_lookup_table(|x| u64::from(x != 0));
+            let mut cloned = boolean_blocks.to_vec();
+            cloned
+                .par_iter_mut()
+                .filter(|b| needs_cleaning(b))
+                .for_each(|b| self.key.apply_lookup_table_assign(&mut b.0, &id_lut));
+            Cow::Owned(cloned)
+        } else {
+            Cow::Borrowed(boolean_blocks)
+        }
+    }
+
+    /// Computes the dot product between encrypted booleans and encrypted values
+    ///
+    /// * `boolean_blocks` must be 'one-hot' i.e. at most 1 BooleanBlock can encrypt a `true`
+    /// * `n_blocks` number of blocks in the resulting ciphertext
+    ///
+    /// # Panic
+    ///
+    /// * Panics if `boolean_blocks` and `radixes` do not have the same lengths
+    /// * Panics if `boolean_blocks` or `radixes` is empty
+    pub fn unchecked_boolean_one_hot_dot_prod<T>(
+        &self,
+        boolean_blocks: &[BooleanBlock],
+        radixes: &[T],
+    ) -> T
+    where
+        T: IntegerRadixCiphertext,
+    {
+        assert_eq!(
+            boolean_blocks.len(),
+            radixes.len(),
+            "both operands must have the same number of elements"
+        );
+
+        assert!(!boolean_blocks.is_empty(), "operands must not be empty");
+
+        let lut = self.key.generate_lookup_table(|x| {
+            let cond = x & 1;
+            let v = x >> 1;
+
+            if cond == 1 {
+                v * self.key.message_modulus.0
+            } else {
+                0
+            }
+        });
+        let one_hot_vec_shifted = boolean_blocks
+            .par_iter()
+            .zip(radixes.par_iter())
+            .map(|(boolean, radix)| {
+                let mut result = radix.clone();
+                result.blocks_mut().par_iter_mut().for_each(|block| {
+                    self.key.unchecked_scalar_mul_assign(block, 2);
+                    self.key.unchecked_add_assign(block, &boolean.0);
+                    self.key.apply_lookup_table_assign(block, &lut);
+                });
+                result
+            })
+            .collect::<Vec<_>>();
+
+        self.aggregate_one_hot_vector_with_noise_trick(one_hot_vec_shifted)
+    }
+
+    /// Computes the dot product between encrypted booleans and encrypted values
+    ///
+    /// * `boolean_blocks` must be 'one-hot' i.e. at most 1 BooleanBlock can encrypt a `true`
+    ///
+    /// # Panic
+    ///
+    /// * Panics if `boolean_blocks` and `radixes` do not have the same lengths
+    /// * Panics if `boolean_blocks` or `radixes` is empty
+    pub fn boolean_one_hot_dot_prod<T>(&self, boolean_blocks: &[BooleanBlock], radixes: &[T]) -> T
+    where
+        T: IntegerRadixCiphertext,
+    {
+        let boolean_blocks = self.cleaned_boolean_blocks(boolean_blocks);
+
+        let radix_needs_cleaning = |r: &T| {
+            !r.block_carries_are_empty()
+                || r.blocks()
+                    .iter()
+                    .any(|b| b.noise_level() > NoiseLevel::NOMINAL)
+        };
+
+        let mut cloned_radixes;
+        let radixes = if radixes.iter().any(radix_needs_cleaning) {
+            cloned_radixes = radixes.to_vec();
+            cloned_radixes
+                .par_iter_mut()
+                .filter(|r| radix_needs_cleaning(r))
+                .for_each(|r| self.full_propagate_parallelized(r));
+            &cloned_radixes
+        } else {
+            radixes
+        };
+
+        self.unchecked_boolean_one_hot_dot_prod(&boolean_blocks, radixes)
+    }
+}

--- a/tfhe/src/integer/server_key/radix_parallel/kv_store.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/kv_store.rs
@@ -196,18 +196,8 @@ impl ServerKey {
 
         let (result, check_block) = rayon::join(
             || {
-                let kv_vec: Vec<(&Key, &Ct)> = map.data.iter().collect();
-                let one_hot = kv_vec
-                    .into_par_iter()
-                    .zip(selectors.par_iter())
-                    .map(|((_, v), s)| {
-                        let mut result = v.clone();
-                        self.zero_out_if_condition_is_false(&mut result, &s.0);
-                        result
-                    })
-                    .collect::<Vec<_>>();
-
-                self.aggregate_one_hot_vector(one_hot)
+                let values = map.data.values().cloned().collect::<Vec<_>>();
+                self.unchecked_boolean_one_hot_dot_prod(&selectors, &values)
             },
             || {
                 let selectors = selectors.iter().map(|s| s.0.clone()).collect::<Vec<_>>();

--- a/tfhe/src/integer/server_key/radix_parallel/mod.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/mod.rs
@@ -25,6 +25,7 @@ pub(crate) mod sub;
 mod sum;
 
 mod count_zeros_ones;
+mod dot_prod;
 pub(crate) mod ilog2;
 pub(crate) mod kv_store;
 mod reverse_bits;

--- a/tfhe/src/integer/server_key/radix_parallel/scalar_dot_prod.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/scalar_dot_prod.rs
@@ -1,6 +1,6 @@
-use crate::core_crypto::prelude::{CastInto, Numeric, OverflowingAdd};
+use crate::core_crypto::prelude::{CastInto, Numeric, OverflowingAdd, UnsignedInteger};
 use crate::integer::block_decomposition::{BlockDecomposer, DecomposableInto};
-use crate::integer::{BooleanBlock, IntegerRadixCiphertext, ServerKey};
+use crate::integer::{BooleanBlock, IntegerRadixCiphertext, RadixCiphertext, ServerKey};
 use std::ops::{AddAssign, Mul};
 
 use crate::prelude::CastFrom;
@@ -8,6 +8,123 @@ use crate::shortint::ciphertext::NoiseLevel;
 use rayon::prelude::*;
 
 impl ServerKey {
+    // Does [b * c for (b,c) in zip(boolean_blocks, clears)]
+    fn boolean_vec_scalar_mul<Clear, T>(
+        &self,
+        boolean_blocks: &[BooleanBlock],
+        clears: &[Clear],
+        n_blocks: u32,
+        inner_shift: u32,
+    ) -> Vec<T>
+    where
+        Clear: Numeric
+            + DecomposableInto<u64>
+            + CastInto<usize>
+            + CastFrom<u128>
+            + Mul<Clear, Output = Clear>
+            + AddAssign<Clear>
+            + OverflowingAdd<Clear, Output = Clear>,
+        T: IntegerRadixCiphertext,
+    {
+        // How many boolean blocks we pack together
+        let mut packing_size = 1;
+        let mut packed_noise_level = 1;
+        for _ in 1..self.message_modulus().0.ilog2() {
+            packed_noise_level = (packed_noise_level * 2) + 1;
+            if packed_noise_level > self.key.max_noise_level.get() {
+                break;
+            }
+
+            packing_size += 1;
+        }
+
+        let packed = boolean_blocks
+            .par_chunks(packing_size)
+            .map(|chunk| {
+                let mut result = chunk[0].0.clone();
+
+                for other in chunk[1..].iter() {
+                    self.key.unchecked_scalar_mul_assign(&mut result, 2);
+                    self.key.unchecked_add_assign(&mut result, &other.0);
+                }
+
+                result
+            })
+            .collect::<Vec<_>>();
+
+        let block_mask = Clear::cast_from(u128::from(self.message_modulus().0 - 1));
+
+        let many_lut_chunk =
+            ((self.message_modulus().0 * self.carry_modulus().0) / (1 << packing_size)) as usize;
+        let result = packed
+            .par_iter()
+            .zip(clears.par_chunks(packing_size))
+            .map(|(block, clear_chunk)| {
+                // For this chunk try to see, if the summed value actually needs
+                // `n_blocks` or if it could be less
+                let mut summed_clear = Clear::ZERO;
+                let mut overflowed;
+                let mut real_n_blocks = 0;
+                for c in clear_chunk.iter() {
+                    if *c < Clear::ZERO {
+                        real_n_blocks = n_blocks;
+                        break;
+                    }
+                    (summed_clear, overflowed) = summed_clear.overflowing_add(*c);
+                    if overflowed {
+                        real_n_blocks = n_blocks;
+                        break;
+                    }
+                }
+
+                if real_n_blocks == 0 {
+                    real_n_blocks = BlockDecomposer::with_early_stop_at_zero(
+                        summed_clear,
+                        self.message_modulus().0.ilog2(),
+                    )
+                    .count()
+                    .min(n_blocks as usize) as u32;
+                }
+
+                let funcs = (0..real_n_blocks)
+                    .map(|block_index| {
+                        // The LUT is going to do a part of the dot prod for the corresponding
+                        // block
+                        move |block| {
+                            let mut summed_clear = Clear::ZERO;
+                            for (i, c) in clear_chunk.iter().rev().enumerate() {
+                                let block_selector = u128::from(block >> i) & 1;
+                                summed_clear += *c * Clear::cast_from(block_selector);
+                            }
+
+                            let shift = block_index * self.message_modulus().0.ilog2();
+                            (((summed_clear >> shift) & block_mask) << inner_shift).cast_into()
+                        }
+                    })
+                    .collect::<Vec<_>>();
+
+                let mut blocks = funcs
+                    .par_chunks(many_lut_chunk)
+                    .flat_map(|chunk| {
+                        let funcs_ref = chunk
+                            .iter()
+                            .map(|f| f as &dyn Fn(u64) -> u64)
+                            .collect::<Vec<_>>();
+
+                        let lut = self.key.generate_many_lookup_table(funcs_ref.as_slice());
+                        self.key.apply_many_lookup_table(block, &lut)
+                    })
+                    .collect::<Vec<_>>();
+
+                blocks.resize_with(n_blocks as usize, || self.key.create_trivial(0));
+
+                T::from(blocks)
+            })
+            .collect::<Vec<_>>();
+
+        result
+    }
+
     /// Computes the dot product between encrypted booleans and clear values
     ///
     /// * `n_blocks` number of blocks in the resulting ciphertext
@@ -40,102 +157,9 @@ impl ServerKey {
 
         assert!(!boolean_blocks.is_empty(), "operands must not be empty");
 
-        assert!(Clear::BITS as u32 >= n_blocks * self.message_modulus().0.ilog2());
-
-        // How many boolean blocks we pack together
-        let mut packing_size = 1;
-        let mut packed_noise_level = 1;
-        for _ in 1..self.message_modulus().0.ilog2() {
-            packed_noise_level = (packed_noise_level * 2) + 1;
-            if packed_noise_level > self.key.max_noise_level.get() {
-                break;
-            }
-
-            packing_size += 1;
-        }
-
-        let packed = boolean_blocks
-            .par_chunks(packing_size)
-            .map(|chunk| {
-                let mut result = chunk[0].0.clone();
-
-                for other in chunk[1..].iter() {
-                    self.key.unchecked_scalar_mul_assign(&mut result, 2);
-                    self.key.unchecked_add_assign(&mut result, &other.0);
-                }
-
-                result
-            })
-            .collect::<Vec<_>>();
-
-        let block_mask = Clear::cast_from(u128::from(self.message_modulus().0 - 1));
-
-        let many_lut_chunk =
-            ((self.message_modulus().0 * self.carry_modulus().0) / (1 << packing_size)) as usize;
-        let to_be_summed = packed
-            .iter()
-            .zip(clears.chunks(packing_size))
-            .map(|(block, clear_chunk)| {
-                // Try to see if most significant blocks might be zero
-                // and avoid some PBS
-                let mut summed_clear = Clear::ZERO;
-                let mut overflowed;
-                let mut real_n_blocks = 0;
-                for c in clear_chunk.iter() {
-                    if *c < Clear::ZERO {
-                        real_n_blocks = n_blocks;
-                        break;
-                    }
-                    (summed_clear, overflowed) = summed_clear.overflowing_add(*c);
-                    if overflowed {
-                        real_n_blocks = n_blocks;
-                        break;
-                    }
-                }
-
-                if real_n_blocks == 0 {
-                    real_n_blocks = BlockDecomposer::with_early_stop_at_zero(
-                        summed_clear,
-                        self.message_modulus().0.ilog2(),
-                    )
-                    .count()
-                    .min(n_blocks as usize) as u32;
-                }
-
-                let funcs = (0..real_n_blocks)
-                    .map(|block_index| {
-                        // The LUT is going to do a part of the dot prod for the corresponding
-                        // block
-                        move |block| {
-                            let mut summed_clear = Clear::ZERO;
-                            for (i, c) in clear_chunk.iter().rev().enumerate() {
-                                summed_clear += *c * Clear::cast_from(u128::from(block >> i) & 1);
-                            }
-
-                            let shift = block_index * self.message_modulus().0.ilog2();
-                            ((summed_clear >> shift) & block_mask).cast_into()
-                        }
-                    })
-                    .collect::<Vec<_>>();
-
-                let mut blocks = funcs
-                    .par_chunks(many_lut_chunk)
-                    .flat_map(|chunk| {
-                        let funcs_ref = chunk
-                            .iter()
-                            .map(|f| f as &dyn Fn(u64) -> u64)
-                            .collect::<Vec<_>>();
-
-                        let lut = self.key.generate_many_lookup_table(funcs_ref.as_slice());
-                        self.key.apply_many_lookup_table(block, &lut)
-                    })
-                    .collect::<Vec<_>>();
-
-                blocks.resize_with(n_blocks as usize, || self.key.create_trivial(0));
-
-                T::from(blocks)
-            })
-            .collect::<Vec<_>>();
+        let inner_shift = 0;
+        let to_be_summed =
+            self.boolean_vec_scalar_mul(boolean_blocks, clears, n_blocks, inner_shift);
 
         self.unchecked_sum_ciphertexts_vec_parallelized(to_be_summed)
             .expect("empty input")
@@ -203,23 +227,70 @@ impl ServerKey {
             + OverflowingAdd<Clear, Output = Clear>,
         T: IntegerRadixCiphertext,
     {
-        let mut cloned;
+        let boolean_blocks = self.cleaned_boolean_blocks(boolean_blocks);
 
-        let boolean_blocks = if boolean_blocks
-            .iter()
-            .any(|b| b.0.noise_level() > NoiseLevel::NOMINAL || b.0.degree.get() >= 2)
-        {
-            let id_lut = self.key.generate_lookup_table(|x| u64::from(x != 0));
-            cloned = boolean_blocks.to_vec();
-            cloned
-                .par_iter_mut()
-                .filter(|b| b.0.noise_level() > NoiseLevel::NOMINAL || b.0.degree.get() >= 2)
-                .for_each(|b| self.key.apply_lookup_table_assign(&mut b.0, &id_lut));
-            &cloned
-        } else {
-            boolean_blocks
-        };
+        self.unchecked_boolean_scalar_dot_prod_parallelized(&boolean_blocks, clears, n_blocks)
+    }
 
-        self.unchecked_boolean_scalar_dot_prod_parallelized(boolean_blocks, clears, n_blocks)
+    /// Computes the dot product between encrypted booleans and clear values
+    ///
+    /// * `boolean_blocks` must be 'one-hot' i.e. at most 1 BooleanBlock can encrypt a `true`
+    /// * `n_blocks` number of blocks in the resulting ciphertext
+    ///
+    /// # Panic
+    ///
+    /// * Panics if `boolean_blocks` and `clears` do not have the same lengths
+    /// * Panics if `boolean_blocks` or `clears` is empty
+    /// * Panics if the output ciphertext has fewer bits than `Clear::BITS`
+    pub fn unchecked_boolean_scalar_one_hot_dot_prod_parallelized<Clear>(
+        &self,
+        boolean_blocks: &[BooleanBlock],
+        clears: &[Clear],
+        n_blocks: u32,
+    ) -> RadixCiphertext
+    where
+        Clear: UnsignedInteger + DecomposableInto<u64> + CastInto<usize>,
+    {
+        assert_eq!(
+            boolean_blocks.len(),
+            clears.len(),
+            "both operands must have the same number of elements"
+        );
+
+        assert!(!boolean_blocks.is_empty(), "operands must not be empty");
+
+        let inner_shift = self.message_modulus().0.ilog2();
+        let to_be_reduced =
+            self.boolean_vec_scalar_mul(boolean_blocks, clears, n_blocks, inner_shift);
+
+        self.aggregate_one_hot_vector_with_noise_trick(to_be_reduced)
+    }
+
+    /// Computes the dot product between encrypted booleans and clear values
+    ///
+    /// * `boolean_blocks` must be 'one-hot' i.e. at most 1 BooleanBlock can encrypt a `true`
+    /// * `n_blocks` number of blocks in the resulting ciphertext
+    ///
+    /// # Panic
+    ///
+    /// * Panics if `boolean_blocks` and `clears` do not have the same lengths
+    /// * Panics if `boolean_blocks` or `clears` is empty
+    /// * Panics if the output ciphertext has fewer bits than `Clear::BITS`
+    pub fn boolean_scalar_one_hot_dot_prod_parallelized<Clear>(
+        &self,
+        boolean_blocks: &[BooleanBlock],
+        clears: &[Clear],
+        n_blocks: u32,
+    ) -> RadixCiphertext
+    where
+        Clear: UnsignedInteger + DecomposableInto<u64> + CastInto<usize>,
+    {
+        let boolean_blocks = self.cleaned_boolean_blocks(boolean_blocks);
+
+        self.unchecked_boolean_scalar_one_hot_dot_prod_parallelized(
+            &boolean_blocks,
+            clears,
+            n_blocks,
+        )
     }
 }

--- a/tfhe/src/integer/server_key/radix_parallel/tests_signed/mod.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_signed/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod test_cmux;
 pub(crate) mod test_comparison;
 mod test_count_zeros_ones;
 pub(crate) mod test_div_rem;
+mod test_dot_prod;
 pub(crate) mod test_ilog2;
 pub(crate) mod test_mul;
 pub(crate) mod test_neg;

--- a/tfhe/src/integer/server_key/radix_parallel/tests_signed/test_dot_prod.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_signed/test_dot_prod.rs
@@ -1,0 +1,144 @@
+use crate::integer::keycache::KEY_CACHE;
+use crate::integer::server_key::radix_parallel::tests_cases_unsigned::FunctionExecutor;
+use crate::integer::server_key::radix_parallel::tests_unsigned::{
+    nb_tests_smaller_for_params, unsigned_modulus, CpuFunctionExecutor, MAX_VEC_LEN, NB_CTXT,
+};
+use crate::integer::tests::create_parameterized_test;
+use crate::integer::{
+    BooleanBlock, IntegerKeyKind, RadixClientKey, ServerKey, SignedRadixCiphertext,
+};
+use crate::shortint::ciphertext::NoiseLevel;
+use crate::shortint::parameters::TestParameters;
+use rand::{thread_rng, Rng};
+use std::sync::Arc;
+
+#[cfg(tarpaulin)]
+use crate::shortint::parameters::coverage_parameters::*;
+use crate::shortint::parameters::test_params::*;
+use crate::shortint::parameters::*;
+
+create_parameterized_test!(signed_boolean_one_hot_dot_prod);
+
+fn signed_boolean_one_hot_dot_prod(params: impl Into<TestParameters>) {
+    let executor = CpuFunctionExecutor::new(&ServerKey::boolean_one_hot_dot_prod);
+    signed_default_boolean_one_hot_dot_prod_test_case(params, executor);
+}
+
+/// Asserts that every non-trivial block of the result has empty carries and a nominal noise
+/// level, i.e. the output is clean.
+fn panic_if_signed_result_is_not_clean(ct: &SignedRadixCiphertext) {
+    for (i, block) in ct.blocks.iter().enumerate() {
+        if block.is_trivial() {
+            continue;
+        }
+        assert!(
+            block.carry_is_empty(),
+            "Block at index {i} has non-empty carries"
+        );
+        assert_eq!(
+            block.noise_level(),
+            NoiseLevel::NOMINAL,
+            "Block at index {i} has a non nominal noise level: {:?}",
+            block.noise_level()
+        );
+    }
+}
+
+pub(crate) fn signed_default_boolean_one_hot_dot_prod_test_case<P, E>(
+    params: P,
+    mut dot_prod_executor: E,
+) where
+    P: Into<TestParameters>,
+    E: for<'a> FunctionExecutor<
+        (&'a [BooleanBlock], &'a [SignedRadixCiphertext]),
+        SignedRadixCiphertext,
+    >,
+{
+    let params = params.into();
+    let nb_tests = nb_tests_smaller_for_params(params);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(params, IntegerKeyKind::Radix);
+    sks.set_deterministic_pbs_execution(true);
+
+    let sks = Arc::new(sks);
+
+    let cks = RadixClientKey::from((cks, NB_CTXT));
+    let mut rng = thread_rng();
+
+    dot_prod_executor.setup(&cks, sks.clone());
+
+    // The result has the same number of blocks as the (radix) inputs, i.e. NB_CTXT.
+    let modulus = unsigned_modulus(cks.parameters().message_modulus(), NB_CTXT as u32) as i64;
+    let half_modulus = modulus / 2;
+    if half_modulus <= 1 {
+        return;
+    }
+
+    for _ in 0..nb_tests {
+        let vector_size = rng.gen_range(1..MAX_VEC_LEN);
+
+        // 'one-hot': at most one boolean encrypts a `true`
+        let hot_index = if rng.gen_bool(0.5) {
+            Some(rng.gen_range(0..vector_size))
+        } else {
+            None
+        };
+        let clear_booleans = (0..vector_size)
+            .map(|i| hot_index == Some(i))
+            .collect::<Vec<_>>();
+        let clear_values = (0..vector_size)
+            .map(|_| rng.gen_range(-half_modulus..half_modulus))
+            .collect::<Vec<_>>();
+
+        let mut e_booleans = clear_booleans
+            .iter()
+            .map(|&b| cks.encrypt_bool(b))
+            .collect::<Vec<_>>();
+        let mut e_values = clear_values
+            .iter()
+            .map(|&v| cks.encrypt_signed(v))
+            .collect::<Vec<_>>();
+
+        // Corrupt one boolean block, preserving the logical (one-hot) value, so the
+        // default op has to clean its boolean inputs.
+        if let Some(hot) = hot_index {
+            // Replace the single `true` block with a non-clean, non-zero (possibly
+            // non-boolean) encryption. Cleaning maps it back to `true`.
+            let non_zero = rng.gen_range(1..sks.message_modulus().0);
+            e_booleans[hot] = BooleanBlock(cks.encrypt_one_block(non_zero));
+        } else {
+            // All-false: just raise the noise of some block (value stays `false`).
+            let index = rng.gen_range(0..e_booleans.len());
+            e_booleans[index].0.set_noise_level(
+                NoiseLevel::NOMINAL + NoiseLevel(1),
+                params.max_noise_level(),
+            );
+        }
+
+        // Corrupt one radix input by leaving non-empty carries (value is unchanged), so
+        // the default op has to clean its radix inputs before computing.
+        {
+            let index = rng.gen_range(0..e_values.len());
+            sks.unchecked_scalar_add_assign(&mut e_values[index], 1i64);
+            sks.unchecked_scalar_sub_assign(&mut e_values[index], 1i64);
+        }
+
+        let e_result = dot_prod_executor.execute((&e_booleans, &e_values));
+
+        let result: i64 = cks.decrypt_signed(&e_result);
+        let expected_result = hot_index.map_or(0, |i| clear_values[i]);
+
+        assert_eq!(
+            result, expected_result,
+            "Wrong result for boolean_one_hot_dot_prod:\n\
+            Inputs: {clear_booleans:?}, {clear_values:?}\n\
+            modulus: {modulus}\n\
+            Expected: {expected_result}, got {result}
+            "
+        );
+
+        panic_if_signed_result_is_not_clean(&e_result);
+
+        let e_result2 = dot_prod_executor.execute((&e_booleans, &e_values));
+        assert_eq!(e_result2, e_result, "Failed determinism check");
+    }
+}

--- a/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/mod.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod test_cmux;
 pub(crate) mod test_comparison;
 mod test_count_zeros_ones;
 pub(crate) mod test_div_mod;
+mod test_dot_prod;
 pub(crate) mod test_ilog2;
 #[cfg(feature = "gpu")]
 pub(crate) mod test_kreyvium;

--- a/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_dot_prod.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_dot_prod.rs
@@ -1,0 +1,113 @@
+use crate::integer::keycache::KEY_CACHE;
+use crate::integer::server_key::radix_parallel::tests_cases_unsigned::FunctionExecutor;
+use crate::integer::server_key::radix_parallel::tests_unsigned::{
+    nb_tests_smaller_for_params, panic_if_any_block_is_not_clean_or_trivial, unsigned_modulus,
+    CpuFunctionExecutor, MAX_VEC_LEN, NB_CTXT,
+};
+use crate::integer::tests::create_parameterized_test;
+use crate::integer::{BooleanBlock, IntegerKeyKind, RadixCiphertext, RadixClientKey, ServerKey};
+use crate::shortint::parameters::TestParameters;
+use rand::{thread_rng, Rng};
+use std::sync::Arc;
+
+#[cfg(tarpaulin)]
+use crate::shortint::parameters::coverage_parameters::*;
+use crate::shortint::parameters::test_params::*;
+use crate::shortint::parameters::*;
+
+create_parameterized_test!(boolean_one_hot_dot_prod);
+
+fn boolean_one_hot_dot_prod(params: impl Into<TestParameters>) {
+    let executor = CpuFunctionExecutor::new(&ServerKey::boolean_one_hot_dot_prod);
+    default_boolean_one_hot_dot_prod_test_case(params, executor);
+}
+
+pub(crate) fn default_boolean_one_hot_dot_prod_test_case<P, E>(params: P, mut dot_prod_executor: E)
+where
+    P: Into<TestParameters>,
+    E: for<'a> FunctionExecutor<(&'a [BooleanBlock], &'a [RadixCiphertext]), RadixCiphertext>,
+{
+    let params = params.into();
+    let nb_tests = nb_tests_smaller_for_params(params);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(params, IntegerKeyKind::Radix);
+    sks.set_deterministic_pbs_execution(true);
+
+    let sks = Arc::new(sks);
+
+    let cks = RadixClientKey::from((cks, NB_CTXT));
+    let mut rng = thread_rng();
+
+    dot_prod_executor.setup(&cks, sks.clone());
+
+    // The result has the same number of blocks as the (radix) inputs, i.e. NB_CTXT.
+    let modulus = unsigned_modulus(cks.parameters().message_modulus(), NB_CTXT as u32);
+
+    for _ in 0..nb_tests {
+        let vector_size = rng.gen_range(1..MAX_VEC_LEN);
+
+        // 'one-hot': at most one boolean encrypts a `true`
+        let hot_index = if rng.gen_bool(0.5) {
+            Some(rng.gen_range(0..vector_size))
+        } else {
+            None
+        };
+        let clear_booleans = (0..vector_size)
+            .map(|i| hot_index == Some(i))
+            .collect::<Vec<_>>();
+        let clear_values = (0..vector_size)
+            .map(|_| rng.gen_range(0..modulus))
+            .collect::<Vec<_>>();
+
+        let mut e_booleans = clear_booleans
+            .iter()
+            .map(|&b| cks.encrypt_bool(b))
+            .collect::<Vec<_>>();
+        let mut e_values = clear_values
+            .iter()
+            .map(|&v| cks.encrypt(v))
+            .collect::<Vec<_>>();
+
+        // Corrupt one boolean block, preserving the logical (one-hot) value, so the
+        // default op has to clean its boolean inputs.
+        if let Some(hot) = hot_index {
+            // Replace the single `true` block with a non-clean, non-zero (possibly
+            // non-boolean) encryption. Cleaning maps it back to `true`.
+            let non_zero = rng.gen_range(1..sks.message_modulus().0);
+            e_booleans[hot] = BooleanBlock(cks.encrypt_one_block(non_zero));
+        } else {
+            // All-false: just raise the noise of some block (value stays `false`).
+            let index = rng.gen_range(0..e_booleans.len());
+            e_booleans[index].0.set_noise_level(
+                NoiseLevel::NOMINAL + NoiseLevel(1),
+                params.max_noise_level(),
+            );
+        }
+
+        // Corrupt one radix input by leaving non-empty carries (value is unchanged), so
+        // the default op has to clean its radix inputs before computing.
+        {
+            let index = rng.gen_range(0..e_values.len());
+            sks.unchecked_scalar_add_assign(&mut e_values[index], 1u64);
+            sks.unchecked_scalar_sub_assign(&mut e_values[index], 1u64);
+        }
+
+        let e_result = dot_prod_executor.execute((&e_booleans, &e_values));
+
+        let result: u64 = cks.decrypt(&e_result);
+        let expected_result = hot_index.map_or(0, |i| clear_values[i]);
+
+        assert_eq!(
+            result, expected_result,
+            "Wrong result for boolean_one_hot_dot_prod:\n\
+            Inputs: {clear_booleans:?}, {clear_values:?}\n\
+            modulus: {modulus}\n\
+            Expected: {expected_result}, got {result}
+            "
+        );
+
+        panic_if_any_block_is_not_clean_or_trivial(&e_result, &cks);
+
+        let e_result2 = dot_prod_executor.execute((&e_booleans, &e_values));
+        assert_eq!(e_result2, e_result, "Failed determinism check");
+    }
+}

--- a/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_scalar_dot_prod.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_scalar_dot_prod.rs
@@ -19,6 +19,7 @@ use crate::shortint::parameters::*;
 create_parameterized_test!(unchecked_boolean_scalar_dot_prod);
 create_parameterized_test!(smart_boolean_scalar_dot_prod);
 create_parameterized_test!(boolean_scalar_dot_prod);
+create_parameterized_test!(boolean_scalar_one_hot_dot_prod);
 
 fn unchecked_boolean_scalar_dot_prod(params: impl Into<TestParameters>) {
     let executor =
@@ -34,6 +35,12 @@ fn smart_boolean_scalar_dot_prod(params: impl Into<TestParameters>) {
 fn boolean_scalar_dot_prod(params: impl Into<TestParameters>) {
     let executor = CpuFunctionExecutor::new(&ServerKey::boolean_scalar_dot_prod_parallelized);
     default_boolean_scalar_dot_prod_test_case(params, executor);
+}
+
+fn boolean_scalar_one_hot_dot_prod(params: impl Into<TestParameters>) {
+    let executor =
+        CpuFunctionExecutor::new(&ServerKey::boolean_scalar_one_hot_dot_prod_parallelized);
+    default_boolean_scalar_one_hot_dot_prod_test_case(params, executor);
 }
 
 fn boolean_dot_prod(bs: &[bool], cs: &[u64], modulus: u64) -> u64 {
@@ -224,6 +231,89 @@ where
             assert_eq!(
                 result, expected_result,
                 "Wrong result for boolean_scalar_dot_prod:\n\
+                Inputs: {clear_booleans:?}, {clear_values:?}, num_blocks: {num_blocks}\n\
+                modulus: {modulus}\n\
+                Expected: {expected_result}, got {result}
+                "
+            );
+
+            panic_if_any_block_is_not_clean_or_trivial(&e_result, &cks);
+
+            let e_result2 =
+                dot_prod_executor.execute((&e_booleans, &clear_values, num_blocks as u32));
+            assert_eq!(e_result2, e_result, "Failed determinism check");
+        }
+    }
+}
+
+pub(crate) fn default_boolean_scalar_one_hot_dot_prod_test_case<P, E>(
+    params: P,
+    mut dot_prod_executor: E,
+) where
+    P: Into<TestParameters>,
+    E: for<'a> FunctionExecutor<(&'a [BooleanBlock], &'a [u64], u32), RadixCiphertext>,
+{
+    let params = params.into();
+    let nb_tests = nb_tests_smaller_for_params(params);
+    let (cks, mut sks) = KEY_CACHE.get_from_params(params, IntegerKeyKind::Radix);
+    sks.set_deterministic_pbs_execution(true);
+
+    let sks = Arc::new(sks);
+
+    let cks = RadixClientKey::from((cks, NB_CTXT));
+    let mut rng = thread_rng();
+
+    dot_prod_executor.setup(&cks, sks.clone());
+
+    for num_blocks in 1..MAX_NB_CTXT {
+        let modulus = unsigned_modulus(cks.parameters().message_modulus(), num_blocks as u32);
+
+        for _ in 0..nb_tests {
+            let vector_size = rng.gen_range(1..MAX_VEC_LEN);
+
+            // 'one-hot': at most one boolean encrypts a `true`
+            let hot_index = if rng.gen_bool(0.5) {
+                Some(rng.gen_range(0..vector_size))
+            } else {
+                None
+            };
+            let clear_booleans = (0..vector_size)
+                .map(|i| hot_index == Some(i))
+                .collect::<Vec<_>>();
+            let clear_values = (0..vector_size)
+                .map(|_| rng.gen_range(0..modulus))
+                .collect::<Vec<_>>();
+
+            let mut e_booleans = clear_booleans
+                .iter()
+                .map(|&b| cks.encrypt_bool(b))
+                .collect::<Vec<_>>();
+
+            // Corrupt one block in a way that preserves the logical (one-hot) value,
+            // so the default op has to clean its inputs before computing.
+            if let Some(hot) = hot_index {
+                // Replace the single `true` block with a non-clean, non-zero (possibly
+                // non-boolean) encryption. Cleaning maps it back to `true`.
+                let non_zero = rng.gen_range(1..sks.message_modulus().0);
+                e_booleans[hot] = BooleanBlock(cks.encrypt_one_block(non_zero));
+            } else {
+                // All-false: just raise the noise of some block (value stays `false`).
+                let index = rng.gen_range(0..e_booleans.len());
+                e_booleans[index].0.set_noise_level(
+                    NoiseLevel::NOMINAL + NoiseLevel(1),
+                    params.max_noise_level(),
+                );
+            }
+
+            let e_result =
+                dot_prod_executor.execute((&e_booleans, &clear_values, num_blocks as u32));
+
+            let result: u64 = cks.decrypt(&e_result);
+            let expected_result = boolean_dot_prod(&clear_booleans, &clear_values, modulus);
+
+            assert_eq!(
+                result, expected_result,
+                "Wrong result for boolean_scalar_one_hot_dot_prod:\n\
                 Inputs: {clear_booleans:?}, {clear_values:?}, num_blocks: {num_blocks}\n\
                 modulus: {modulus}\n\
                 Expected: {expected_result}, got {result}

--- a/tfhe/src/integer/server_key/radix_parallel/vector_find.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/vector_find.rs
@@ -2,7 +2,11 @@ use crate::core_crypto::prelude::UnsignedInteger;
 use crate::integer::block_decomposition::{BlockDecomposer, Decomposable, DecomposableInto};
 use crate::integer::{BooleanBlock, IntegerRadixCiphertext, RadixCiphertext, ServerKey};
 use crate::prelude::CastInto;
-use crate::shortint::Ciphertext;
+use crate::shortint::atomic_pattern::AtomicPattern;
+use crate::shortint::server_key::{
+    generate_lookup_table_with_output_encoding, unchecked_add_assign,
+};
+use crate::shortint::{CarryModulus, Ciphertext, MaxNoiseLevel};
 use itertools::Itertools;
 use rayon::prelude::*;
 use std::collections::HashSet;
@@ -96,13 +100,6 @@ impl ServerKey {
         let num_blocks_to_represent_values =
             self.num_blocks_to_represent_unsigned_value(max_output_value);
 
-        let possible_results_to_be_aggregated = self.create_possible_results(
-            num_blocks_to_represent_values,
-            selectors
-                .into_par_iter()
-                .zip(matches.0.par_iter().map(|(_input, output)| *output)),
-        );
-
         if max_output_value == Clear::ZERO {
             // If the max output value is zero, it means 0 is the only output possible
             // and in the case where none of the input matches the ct, the returned value is 0
@@ -118,8 +115,13 @@ impl ServerKey {
         } else {
             rayon::join(
                 || {
-                    let result: RadixCiphertext =
-                        self.aggregate_and_unpack_one_hot_vector(possible_results_to_be_aggregated);
+                    let output_clears = matches.0.iter().map(|x| x.1).collect_vec();
+                    let result: RadixCiphertext = self
+                        .unchecked_boolean_scalar_one_hot_dot_prod_parallelized(
+                            &selectors,
+                            &output_clears,
+                            num_blocks_to_represent_values as u32,
+                        );
                     self.cast_to_unsigned(result, num_blocks_to_represent_values)
                 },
                 || {
@@ -472,7 +474,7 @@ impl ServerKey {
             );
         }
         let selectors = self.compute_equality_selectors(ct, clears.par_iter().copied());
-        self.compute_final_index_from_selectors(selectors)
+        self.compute_final_index_from_selectors(&selectors)
     }
 
     /// Returns the encrypted index of the encrypted `value` in the clear slice
@@ -560,19 +562,23 @@ impl ServerKey {
             ct,
             unique_clears.par_iter().copied().map(|(_, value)| value),
         );
+
         let selectors2 = selectors.iter().cloned().map(|x| x.0).collect::<Vec<_>>();
-        let num_blocks_result =
-            (clears.len().ilog2() + 1).div_ceil(self.message_modulus().0.ilog2()) as usize;
 
         rayon::join(
             || {
-                let possible_values = self.create_possible_results(
-                    num_blocks_result,
-                    selectors
-                        .into_par_iter()
-                        .zip(unique_clears.into_par_iter().map(|(index, _)| index as u64)),
-                );
-                self.aggregate_and_unpack_one_hot_vector(possible_values)
+                let indices = unique_clears
+                    .into_iter()
+                    .map(|(index, _)| index as u64)
+                    .collect::<Vec<_>>();
+                let max = indices.last().copied().unwrap();
+                let num_blocks_to_represent_values =
+                    self.num_blocks_to_represent_unsigned_value(max);
+                self.unchecked_boolean_scalar_one_hot_dot_prod_parallelized(
+                    &selectors,
+                    &indices,
+                    num_blocks_to_represent_values as u32,
+                )
             },
             || BooleanBlock::new_unchecked(self.is_at_least_one_comparisons_block_true(selectors2)),
         )
@@ -656,7 +662,7 @@ impl ServerKey {
             .map(|ct| self.eq_parallelized(ct, value))
             .collect::<Vec<_>>();
 
-        self.compute_final_index_from_selectors(selectors)
+        self.compute_final_index_from_selectors(&selectors)
     }
 
     /// Returns the encrypted index of the of encrypted `value` in the ciphertext slice
@@ -751,7 +757,7 @@ impl ServerKey {
             .map(|ct| self.scalar_eq_parallelized(ct, clear))
             .collect::<Vec<_>>();
 
-        self.compute_final_index_from_selectors(selectors)
+        self.compute_final_index_from_selectors(&selectors)
     }
 
     /// Returns the encrypted index of the of clear `value` in the ciphertext slice
@@ -833,35 +839,15 @@ impl ServerKey {
                 self.create_trivial_boolean_block(false),
             );
         }
-        let num_blocks_result =
-            (cts.len().ilog2() + 1).div_ceil(self.message_modulus().0.ilog2()) as usize;
 
         let selectors = cts
             .par_iter()
-            .map(|ct| self.scalar_eq_parallelized(ct, clear).0)
+            .map(|ct| self.scalar_eq_parallelized(ct, clear))
             .collect::<Vec<_>>();
 
         let selectors = self.only_keep_first_true(selectors);
 
-        let selectors2 = selectors
-            .iter()
-            .cloned()
-            .map(BooleanBlock::new_unchecked)
-            .collect::<Vec<_>>();
-
-        rayon::join(
-            || {
-                let possible_values = self.create_possible_results(
-                    num_blocks_result,
-                    selectors2
-                        .into_par_iter()
-                        .enumerate()
-                        .map(|(i, v)| (v, i as u64)),
-                );
-                self.aggregate_and_unpack_one_hot_vector(possible_values)
-            },
-            || BooleanBlock::new_unchecked(self.is_at_least_one_comparisons_block_true(selectors)),
-        )
+        self.compute_final_index_from_selectors(&selectors)
     }
 
     /// Returns the encrypted index of the _first_ occurrence of clear `value` in the ciphertext
@@ -941,35 +927,14 @@ impl ServerKey {
             );
         }
 
-        let num_blocks_result =
-            (cts.len().ilog2() + 1).div_ceil(self.message_modulus().0.ilog2()) as usize;
-
         let selectors = cts
             .par_iter()
-            .map(|ct| self.eq_parallelized(ct, value).0)
+            .map(|ct| self.eq_parallelized(ct, value))
             .collect::<Vec<_>>();
 
         let selectors = self.only_keep_first_true(selectors);
 
-        let selectors2 = selectors
-            .iter()
-            .cloned()
-            .map(BooleanBlock::new_unchecked)
-            .collect::<Vec<_>>();
-
-        rayon::join(
-            || {
-                let possible_values = self.create_possible_results(
-                    num_blocks_result,
-                    selectors2
-                        .into_par_iter()
-                        .enumerate()
-                        .map(|(i, v)| (v, i as u64)),
-                );
-                self.aggregate_and_unpack_one_hot_vector(possible_values)
-            },
-            || BooleanBlock::new_unchecked(self.is_at_least_one_comparisons_block_true(selectors)),
-        )
+        self.compute_final_index_from_selectors(&selectors)
     }
 
     /// Returns the encrypted index of the _first_ occurrence of encrypted `value` in the ciphertext
@@ -1040,23 +1005,20 @@ impl ServerKey {
 
     fn compute_final_index_from_selectors(
         &self,
-        selectors: Vec<BooleanBlock>,
+        selectors: &[BooleanBlock],
     ) -> (RadixCiphertext, BooleanBlock) {
-        let num_blocks_result =
-            (selectors.len().ilog2() + 1).div_ceil(self.message_modulus().0.ilog2()) as usize;
-
         let selectors2 = selectors.iter().cloned().map(|x| x.0).collect::<Vec<_>>();
 
         rayon::join(
             || {
-                let possible_values = self.create_possible_results(
-                    num_blocks_result,
-                    selectors
-                        .into_par_iter()
-                        .enumerate()
-                        .map(|(i, v)| (v, i as u64)),
-                );
-                self.aggregate_and_unpack_one_hot_vector(possible_values)
+                let indices = (0..selectors.len() as u32).collect::<Vec<_>>();
+                let num_blocks_to_represent_values =
+                    self.num_blocks_to_represent_unsigned_value(selectors.len() - 1);
+                self.unchecked_boolean_scalar_one_hot_dot_prod_parallelized(
+                    selectors,
+                    &indices,
+                    num_blocks_to_represent_values as u32,
+                )
             },
             || BooleanBlock::new_unchecked(self.is_at_least_one_comparisons_block_true(selectors2)),
         )
@@ -1131,156 +1093,54 @@ impl ServerKey {
             .collect::<Vec<_>>()
     }
 
-    /// Creates a vector of radix ciphertext from an iterator that associates encrypted boolean
-    /// values to clear values.
+    /// Aggregates the on_hot_vector into a single result
     ///
-    /// The elements of the resulting vector are zero if the corresponding BooleanBlock encrypted 0,
-    /// otherwise it encrypts the associated clear value.
+    /// the blocks inside the one hot vector must have their message
+    /// pushed onto the carry part, and the message part must be empty.
     ///
-    /// This is only really useful if only one of the boolean block is known to be non-zero.
-    ///
-    /// `num_blocks`: number of blocks (unpacked) needed to represent the biggest clear value
-    ///
-    /// - Resulting radix ciphertexts have their block packed, thus they will have ceil (numb_blocks
-    ///   / 2) elements
-    fn create_possible_results<T, Iter, Clear>(
+    /// The output will be a regular radix with the message into the message_part
+    pub(crate) fn aggregate_one_hot_vector_with_noise_trick<T>(
         &self,
-        num_blocks: usize,
-        possible_outputs: Iter,
-    ) -> Vec<T>
+        mut one_hot_vector: Vec<T>,
+    ) -> T
     where
         T: IntegerRadixCiphertext,
-        Iter: ParallelIterator<Item = (BooleanBlock, Clear)>,
-        Clear: Decomposable + CastInto<usize>,
     {
-        assert!(
-            self.carry_modulus().0 >= self.message_modulus().0,
-            "As this function packs blocks, it requires to have at least as much carry \
-                space as message space ({:?} vs {:?})",
-            self.carry_modulus(),
-            self.message_modulus()
+        let lut_size = self.key.atomic_pattern.lookup_table_size();
+
+        // As the blocks have the message/data into the carry part
+        // the is equivalent to blocks being encoded as no carry modulus
+        // and only the message modulus.
+        //
+        // This allows to do more leveled additions before cleaning the noise,
+        // and to clean the noise, we need to use a lookup table that respect
+        // the proper encoding
+        let identity_lut = generate_lookup_table_with_output_encoding(
+            lut_size,
+            self.key.ciphertext_modulus,
+            self.message_modulus(),
+            CarryModulus(1),
+            self.message_modulus(),
+            CarryModulus(1),
+            |x| x,
         );
-        // Vector of functions that returns function, that will be used to create LUTs later
-        let scalar_block_cmp_fns = (0..(self.message_modulus().0 * self.message_modulus().0))
-            .map(|packed_block_value| {
-                move |is_selected: u64| {
-                    if is_selected == 1 {
-                        packed_block_value
-                    } else {
-                        0
-                    }
-                }
-            })
-            .collect::<Vec<_>>();
 
-        // How "many LUTs" we can apply, since we are going to apply luts on boolean values
-        // (Degree(1), Modulus(2))
-        // Equivalent to (2^(msg_bits + carry_bits - 1)
-        let max_num_many_luts = (self.message_modulus().0 * self.carry_modulus().0) / 2;
-
-        let num_bits_in_message = self.message_modulus().0.ilog2();
-        possible_outputs
-            .map(|(selector, output_value)| {
-                let decomposed_value = BlockDecomposer::new(output_value, 2 * num_bits_in_message)
-                    .take(num_blocks.div_ceil(2))
-                    .collect::<Vec<_>>();
-
-                // Since there is a limit in the number of how many lut we can apply in one PBS
-                // we pre-chunk LUTs according to that amount
-                let blocks = decomposed_value
-                    .par_chunks(max_num_many_luts as usize)
-                    .flat_map(|chunk_of_packed_value| {
-                        let fns = chunk_of_packed_value
-                            .iter()
-                            .map(|packed_value| {
-                                &(scalar_block_cmp_fns[(*packed_value).cast_into()])
-                                    as &dyn Fn(u64) -> u64
-                            })
-                            .collect::<Vec<_>>();
-                        let luts = self.key.generate_many_lookup_table(fns.as_slice());
-                        self.key.apply_many_lookup_table(&selector.0, &luts)
-                    })
-                    .collect::<Vec<_>>();
-
-                T::from_blocks(blocks)
-            })
-            .collect::<Vec<_>>()
-    }
-
-    /// Aggregate/combines a vec of one-hot vector of radix ciphertexts
-    /// (i.e. at most one of the vector element is non-zero) into single ciphertext
-    /// containing the non-zero value.
-    ///
-    /// The elements in the one hot vector may have their block packed or not
-    ///
-    /// The returned result has non packed blocks
-    pub(super) fn aggregate_and_unpack_one_hot_vector<T>(&self, one_hot_vector: Vec<T>) -> T
-    where
-        T: IntegerRadixCiphertext,
-    {
-        let result = self.partial_aggregate_one_hot_vector(one_hot_vector);
-
-        let unpacked_blocks = result
-            .blocks()
-            .par_iter()
-            .flat_map(|block| -> [Ciphertext; 2] {
-                rayon::join(
-                    || self.key.message_extract(block),
-                    || self.key.carry_extract(block),
-                )
-                .into()
-            })
-            .collect::<Vec<_>>();
-
-        T::from_blocks(unpacked_blocks)
-    }
-
-    /// Aggregate/combines a vec of one-hot vector of radix ciphertexts
-    /// (i.e. at most one of the vector element is non-zero) into single ciphertext
-    /// containing the non-zero value.
-    ///
-    /// * The returned result has block still packed if the input blocks where packed.
-    pub(super) fn aggregate_one_hot_vector<T>(&self, one_hot_vector: Vec<T>) -> T
-    where
-        T: IntegerRadixCiphertext,
-    {
-        let mut result = self.partial_aggregate_one_hot_vector(one_hot_vector);
-
-        result
-            .blocks_mut()
-            .par_iter_mut()
-            .for_each(|block| self.key.message_extract_assign(block));
-
-        result
-    }
-
-    /// Aggregate/combines a vec of one-hot vector of radix ciphertexts
-    /// (i.e. at most one of the vector element is non-zero) into single ciphertext
-    /// containing the non-zero value.
-    ///
-    /// * The elements in the one hot vector may have their block packed or not
-    /// * The returned result has block still packed if the input blocks where packed.
-    ///
-    /// # Warning
-    ///
-    /// The returned value will need to be unpacked if the inputs where packed or
-    /// if they were not, noise cleaning may still need to be done.
-    fn partial_aggregate_one_hot_vector<T>(&self, mut one_hot_vector: Vec<T>) -> T
-    where
-        T: IntegerRadixCiphertext,
-    {
-        // Used to clean the noise
-        let identity_lut = self.key.generate_lookup_table(|x| x);
-
-        // Since all but one radix are zeros, the limiting factor
-        // for additions is the noise level
-        let chunk_size = self.key.max_noise_level.get() as usize;
-
+        let old_precision = self.message_modulus().0 * self.carry_modulus().0;
+        let new_precision = self.message_modulus().0;
+        let diff = old_precision / new_precision;
+        let max_noise_level = MaxNoiseLevel::new(self.key.max_noise_level.get() * diff);
+        let chunk_size = max_noise_level.get() as usize;
         let (num_init_chunks, num_init_rest) = (
             one_hot_vector.len() / chunk_size,
             one_hot_vector.len() % chunk_size,
         );
         let mut workbench = Vec::with_capacity(num_init_chunks + num_init_rest);
+
+        let radix_add_assign = |lhs: &mut T, rhs: &T| {
+            for (l, r) in lhs.blocks_mut().iter_mut().zip(rhs.blocks().iter()) {
+                unchecked_add_assign(l, r, max_noise_level);
+            }
+        };
 
         while one_hot_vector.len() > chunk_size {
             one_hot_vector
@@ -1288,7 +1148,7 @@ impl ServerKey {
                 .map(|chunk| {
                     let mut result = chunk[0].clone();
                     for r in &chunk[1..] {
-                        self.unchecked_add_assign(&mut result, r);
+                        radix_add_assign(&mut result, r);
                     }
                     result
                         .blocks_mut()
@@ -1307,20 +1167,33 @@ impl ServerKey {
         let mut result = one_hot_vector[0].clone();
         if one_hot_vector.len() > 1 {
             for r in &one_hot_vector[1..] {
-                self.unchecked_add_assign(&mut result, r);
+                radix_add_assign(&mut result, r);
             }
         }
+
+        // The final LUT needs to change the encoding to the original one
+        let encoding_change_lut = generate_lookup_table_with_output_encoding(
+            lut_size,
+            self.key.ciphertext_modulus,
+            self.message_modulus(),
+            CarryModulus(1),
+            self.message_modulus(),
+            self.carry_modulus(),
+            |x| x,
+        );
+        result.blocks_mut().par_iter_mut().for_each(|block| {
+            self.key
+                .apply_lookup_table_assign(block, &encoding_change_lut);
+        });
 
         result
     }
 
-    /// Only keeps at most one Ciphertext that encrypts 1
+    /// Only keeps at most one BooleanBlock that encrypts 1
     ///
-    /// Given a Vec of Ciphertexts where each Ciphertext encrypts 0 or 1
-    /// This function will return a Vec of Ciphertext where at most one encryption of 1 is present
-    ///
-    /// The first encryption of one is kept
-    fn only_keep_first_true(&self, mut values: Vec<Ciphertext>) -> Vec<Ciphertext> {
+    /// Given a Vec of BooleanBlocks (each encrypting 0 or 1) this function returns a Vec where at
+    /// most one encryption of 1 is present. The first encryption of 1 is kept.
+    fn only_keep_first_true(&self, mut values: Vec<BooleanBlock>) -> Vec<BooleanBlock> {
         if values.len() <= 1 {
             return values;
         }
@@ -1328,7 +1201,7 @@ impl ServerKey {
             self.message_modulus().0 < 3 || (self.carry_modulus().0 < self.message_modulus().0);
 
         if does_not_have_enough_bits {
-            let mut true_already_seen = values[0].clone();
+            let mut true_already_seen = values[0].0.clone();
             let lut =
                 self.key
                     .generate_lookup_table_bivariate(|current_block, true_already_seen| {
@@ -1340,9 +1213,12 @@ impl ServerKey {
                     });
 
             for block in &mut values[1..] {
-                let new_true_already_seen = self.key.bitor(&true_already_seen, block);
-                self.key
-                    .apply_lookup_table_bivariate_assign(block, &mut true_already_seen, &lut);
+                let new_true_already_seen = self.key.bitor(&true_already_seen, &block.0);
+                self.key.apply_lookup_table_bivariate_assign(
+                    &mut block.0,
+                    &mut true_already_seen,
+                    &lut,
+                );
                 true_already_seen = new_true_already_seen;
             }
 
@@ -1362,7 +1238,8 @@ impl ServerKey {
                 self.key
                     .unchecked_apply_lookup_table_bivariate_assign(current, previous, &lut_fn);
             };
-            let mut values = self.compute_prefix_sum_hillis_steele(values, sum_function);
+            let raw = values.into_iter().map(|b| b.0).collect();
+            let mut raw = self.compute_prefix_sum_hillis_steele(raw, sum_function);
             let lut = self.key.generate_lookup_table(|x| {
                 let x = x % self.message_modulus().0;
                 if x == ALREADY_SEEN {
@@ -1371,10 +1248,9 @@ impl ServerKey {
                     x
                 }
             });
-            values
-                .par_iter_mut()
+            raw.par_iter_mut()
                 .for_each(|block| self.key.apply_lookup_table_assign(block, &lut));
-            values
+            raw.into_iter().map(BooleanBlock::new_unchecked).collect()
         }
     }
 }

--- a/tfhe/src/shortint/server_key/mod.rs
+++ b/tfhe/src/shortint/server_key/mod.rs
@@ -24,6 +24,8 @@ pub mod expanded;
 
 pub use expanded::{ShortintExpandedBootstrappingKey, ShortintExpandedServerKey};
 
+#[cfg(feature = "integer")]
+pub(crate) use add::unchecked_add_assign;
 pub use bivariate_pbs::{
     BivariateLookupTableMutView, BivariateLookupTableOwned, BivariateLookupTableView,
 };


### PR DESCRIPTION
This adds boolean dot products, with specialized version for when the boolean vector is "one hot".
This operation already existed internally but is now more 'formalized' into a function.

Importantly this also brings an improvement to the reduction phase by moving the data in the carry bits to allow the use of message bits as extra noise buffer making it possible to do more leveled additions

closes https://github.com/zama-ai/tfhe-rs-internal/issues/1146

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3652)
<!-- Reviewable:end -->
