### PR TITLE
kreyvium fixes

### DIFF
--- a/.github/workflows/aws_tfhe_fast_tests.yml
+++ b/.github/workflows/aws_tfhe_fast_tests.yml
@@ -46,6 +46,9 @@ jobs:
       shortint_test: ${{ env.IS_PULL_REQUEST == 'false' ||
         steps.changed-files.outputs.shortint_any_changed ||
         steps.changed-files.outputs.dependencies_any_changed }}
+      transciphering_test: ${{ env.IS_PULL_REQUEST == 'false' ||
+        steps.changed-files.outputs.transciphering_any_changed ||
+        steps.changed-files.outputs.dependencies_any_changed }}
       integer_test: ${{ env.IS_PULL_REQUEST == 'false' ||
         steps.changed-files.outputs.integer_any_changed ||
         steps.changed-files.outputs.dependencies_any_changed }}
@@ -97,6 +100,10 @@ jobs:
             shortint:
               - tfhe/src/core_crypto/**
               - tfhe/src/shortint/**
+            transciphering:
+              - tfhe/src/core_crypto/**
+              - tfhe/src/shortint/**
+              - tfhe/src/transciphering/**
             integer:
               - tfhe/src/core_crypto/**
               - tfhe/src/shortint/**
@@ -129,6 +136,7 @@ jobs:
           steps.changed-files.outputs.core_crypto_any_changed == 'true' ||
           steps.changed-files.outputs.boolean_any_changed == 'true' ||
           steps.changed-files.outputs.shortint_any_changed == 'true' ||
+          steps.changed-files.outputs.transciphering_any_changed == 'true' ||
           steps.changed-files.outputs.integer_any_changed == 'true' ||
           steps.changed-files.outputs.wasm_any_changed == 'true' ||
           steps.changed-files.outputs.high_level_api_any_changed == 'true' ||
@@ -248,6 +256,11 @@ jobs:
         if: needs.should-run.outputs.integer_test == 'true'
         run: |
           BIG_TESTS_INSTANCE=TRUE FAST_TESTS=TRUE make test_integer_ci
+
+      - name: Run transciphering tests
+        if: needs.should-run.outputs.transciphering_test == 'true'
+        run: |
+          make test_transciphering
 
       - name: Run high-level API tests
         if: needs.should-run.outputs.high_level_api_test == 'true'

--- a/.github/workflows/aws_tfhe_tests.yml
+++ b/.github/workflows/aws_tfhe_tests.yml
@@ -50,6 +50,9 @@ jobs:
       shortint_test: ${{ env.IS_PULL_REQUEST == 'false' ||
         steps.changed-files.outputs.shortint_any_changed ||
         steps.changed-files.outputs.dependencies_any_changed }}
+      transciphering_test: ${{ env.IS_PULL_REQUEST == 'false' ||
+        steps.changed-files.outputs.transciphering_any_changed ||
+        steps.changed-files.outputs.dependencies_any_changed }}
       strings_test: ${{ env.IS_PULL_REQUEST == 'false' ||
         steps.changed-files.outputs.strings_any_changed ||
         steps.changed-files.outputs.dependencies_any_changed }}
@@ -98,6 +101,10 @@ jobs:
             shortint:
               - tfhe/src/core_crypto/**
               - tfhe/src/shortint/**
+            transciphering:
+              - tfhe/src/core_crypto/**
+              - tfhe/src/shortint/**
+              - tfhe/src/transciphering/**
             strings:
               - tfhe/src/core_crypto/**
               - tfhe/src/shortint/**
@@ -132,6 +139,7 @@ jobs:
           steps.changed-files.outputs.core_crypto_any_changed == 'true' ||
           steps.changed-files.outputs.boolean_any_changed == 'true' ||
           steps.changed-files.outputs.shortint_any_changed == 'true' ||
+          steps.changed-files.outputs.transciphering_any_changed == 'true' ||
           steps.changed-files.outputs.strings_any_changed == 'true' ||
           steps.changed-files.outputs.high_level_api_any_changed == 'true' ||
           steps.changed-files.outputs.c_api_any_changed == 'true' ||
@@ -205,6 +213,11 @@ jobs:
         if: needs.should-run.outputs.shortint_test == 'true'
         run: |
           BIG_TESTS_INSTANCE=TRUE make test_shortint_ci
+
+      - name: Run transciphering tests
+        if: needs.should-run.outputs.transciphering_test == 'true'
+        run: |
+          make test_transciphering
 
       - name: Run strings tests
         if: needs.should-run.outputs.strings_test == 'true'

--- a/Makefile
+++ b/Makefile
@@ -1127,6 +1127,11 @@ test_shortint:
 	RUSTFLAGS="$(RUSTFLAGS)" cargo test --profile $(CARGO_PROFILE) \
 		--features=shortint,internal-keycache -p tfhe -- shortint::
 
+.PHONY: test_transciphering # Run all the tests for the transciphering module
+test_transciphering:
+	RUSTFLAGS="$(RUSTFLAGS)" cargo test --profile $(CARGO_PROFILE) \
+		--features=shortint -p tfhe -- transciphering::
+
 .PHONY: test_shortint_cov # Run the tests of the shortint module with code coverage
 test_shortint_cov: install_tarpaulin
 	RUSTFLAGS="$(RUSTFLAGS)" cargo tarpaulin --profile $(CARGO_PROFILE) \

--- a/tfhe/src/transciphering/ciphers/kreyvium/fhe.rs
+++ b/tfhe/src/transciphering/ciphers/kreyvium/fhe.rs
@@ -1,5 +1,6 @@
 //! TFHE implementation of the Kreyvium Algorithm
 
+use crate::shortint::ciphertext::NoiseLevel;
 use crate::shortint::{Ciphertext, ServerKey};
 use crate::transciphering::ciphers::shift_register::ShiftRegister;
 use crate::transciphering::{FheKeyStream, StreamCipherKind, Transcipherer};
@@ -15,20 +16,24 @@ pub struct KreyviumFheKey {
 }
 
 impl KreyviumFheKey {
-    pub fn init_state(self, iv: KreyviumIV, sk: &ServerKey) -> KreyviumFheState {
-        KreyviumFheState::new(self, iv, sk)
-    }
-}
-
-impl From<Box<[Ciphertext; 128]>> for KreyviumFheKey {
-    fn from(cts: Box<[Ciphertext; 128]>) -> Self {
+    pub(super) fn new(cts: Box<[Ciphertext; 128]>) -> Self {
+        for (i, ct) in cts.iter().enumerate() {
+            assert!(
+                ct.degree.get() <= 1,
+                "kreyvium key ciphertext {i} is not a single bit (degree {})",
+                ct.degree.get(),
+            );
+            assert!(
+                ct.noise_level() <= NoiseLevel::NOMINAL,
+                "kreyvium key ciphertext {i} exceeds nominal noise (level {:?})",
+                ct.noise_level(),
+            );
+        }
         Self { cts }
     }
-}
 
-impl From<[Ciphertext; 128]> for KreyviumFheKey {
-    fn from(cts: [Ciphertext; 128]) -> Self {
-        Self { cts: Box::new(cts) }
+    pub fn init_state(self, iv: KreyviumIV, sk: &ServerKey) -> KreyviumFheState {
+        KreyviumFheState::new(self, iv, sk)
     }
 }
 
@@ -38,8 +43,8 @@ impl KreyviumFheState {
     /// Constructor for `KreyviumFheState`: arguments are the secret key, the input vector,
     /// and a `ServerKey` reference. Outputs a state object already initialized
     /// (1152 steps have been run before returning).
-    pub fn new(key: impl Into<KreyviumFheKey>, iv: impl Into<KreyviumIV>, sk: &ServerKey) -> Self {
-        let mut key = key.into().cts;
+    pub fn new(key: KreyviumFheKey, iv: impl Into<KreyviumIV>, sk: &ServerKey) -> Self {
+        let mut key = key.cts;
         let mut iv = iv.into().expand().map(|b| b as u64);
 
         // Initialization of Kreyvium registers: a has the secret key, b the beginning of the IV,

--- a/tfhe/src/transciphering/ciphers/kreyvium/fhe.rs
+++ b/tfhe/src/transciphering/ciphers/kreyvium/fhe.rs
@@ -287,7 +287,11 @@ fn round_naive(
                     sk.add_assign(&mut new_c, &temp_b);
                     new_c
                 },
-                || sk.bitxor(&sk.unchecked_add(&temp_a, &temp_b), &temp_c),
+                || {
+                    let lhs = sk.unchecked_add(&temp_a, &temp_b);
+                    let xor_low_bit = sk.generate_lookup_table_bivariate(|x, y| (x ^ y) & 1);
+                    sk.apply_lookup_table_bivariate(&lhs, &temp_c, &xor_low_bit)
+                },
             )
         },
     );

--- a/tfhe/src/transciphering/ciphers/kreyvium/plain.rs
+++ b/tfhe/src/transciphering/ciphers/kreyvium/plain.rs
@@ -1,5 +1,6 @@
 //! Plaintext implementation of the Kreyvium Algorithm
 
+use crate::shortint::ciphertext::Degree;
 use crate::shortint::ClientKey;
 use crate::transciphering::ciphers::shift_register::ShiftRegister;
 use crate::transciphering::ciphers::{pack_bits_lsb_first, unpack_bits_lsb_first};
@@ -30,13 +31,15 @@ impl KreyviumPlainKey {
     /// Encrypt this key bit-by-bit under `client_key`, producing the FHE-side
     /// key consumed by [`KreyviumFheState`](super::KreyviumFheState).
     pub fn encrypt(&self, client_key: &ClientKey) -> KreyviumFheKey {
-        super::collect_boxed_array(
-            unpack_key_bits(&self.bits)
-                .iter()
-                .map(|&b| client_key.encrypt(b as u64)),
+        KreyviumFheKey::new(
+            super::collect_boxed_array(unpack_key_bits(&self.bits).iter().map(|&b| {
+                let mut ct = client_key.encrypt(b as u64);
+                // We know each value is a single bit, so we can set a tighter degree.
+                ct.degree = Degree::new(1);
+                ct
+            }))
+            .expect("array and iter size match"),
         )
-        .expect("array and iter size match")
-        .into()
     }
 
     pub fn init_state(self, iv: KreyviumIV) -> KreyviumPlainState {


### PR DESCRIPTION
some fixes for kreyvium/transciphering

- run transciphering tests in ci
- remove `From<[Ciphertext; 128]>` for Kreyvium
- fix a bug in `round_naive` where ciphertexts where not sanitized at the end of the round. This part is exactly similar to what round_2_2 does, and was missed when I went from "cipher state can have dirty bits that are ignored" to "cipher state should produce clean ct of at most 1 bit"

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3657)
<!-- Reviewable:end -->
