### PR TITLE
chore(ci): use cargo deny to check license dependencies

### DIFF
--- a/.cargo/deny.toml
+++ b/.cargo/deny.toml
@@ -1,0 +1,26 @@
+# cargo-deny configuration: https://embarkstudios.github.io/cargo-deny/
+
+[licenses]
+version = 2
+confidence-threshold = 1.0
+unused-allowed-license = "allow"
+allow = [
+    "0BSD",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "BSD-3-Clause-Clear",
+    "BSL-1.0",
+    "CC0-1.0",
+    "CDLA-Permissive-2.0",
+    "ISC",
+    "MIT",
+    "MPL-2.0",
+    "Unicode-3.0",
+    "Unlicense",
+    "Zlib",
+]
+
+[licenses.private]
+# Skip license enforcement on workspace members marked `publish = false`
+ignore = true

--- a/Makefile
+++ b/Makefile
@@ -203,6 +203,10 @@ install_tarpaulin:
 install_cargo_audit:
 	cargo install --locked cargo-audit
 
+.PHONY: install_cargo_deny # Install cargo-deny for license checks
+install_cargo_deny:
+	cargo install --locked cargo-deny
+
 .PHONY: install_taplo # Check Cargo.toml format
 install_taplo:
 	@./scripts/install_taplo.sh --taplo-version $(TAPLO_VERSION)
@@ -732,6 +736,10 @@ check_rust_bindings_did_not_change:
 .PHONY: audit_dependencies # Run cargo audit to check vulnerable dependencies
 audit_dependencies: install_cargo_audit
 	cargo audit
+
+.PHONY: check_licenses # Run cargo-deny on licenses
+check_licenses: install_cargo_deny
+	cargo deny check licenses
 
 .PHONY: check_floating_deps # Build & lint tfhe-rs against the latest semver-compatible deps
 check_floating_deps:
@@ -2399,6 +2407,7 @@ pcc_batch_2:
 	$(call run_recipe_with_details,clippy_test_vectors)
 	$(call run_recipe_with_details,check_test_vectors)
 	$(call run_recipe_with_details,clippy_wasm_par_mq)
+	$(call run_recipe_with_details,check_licenses)
 
 .PHONY: pcc_batch_3 # duration: 6'50''
 pcc_batch_3:

--- a/tasks/Cargo.toml
+++ b/tasks/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tasks"
 version = "0.0.0"
 edition = "2024"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/utils/tfhe-backward-compat-checker/Cargo.toml
+++ b/utils/tfhe-backward-compat-checker/Cargo.toml
@@ -3,6 +3,7 @@ name = "tfhe-backward-compat-checker"
 version = "0.1.0"
 edition = "2024"
 rust-version.workspace = true
+publish = false
 
 [dependencies]
 clap = { workspace = true }


### PR DESCRIPTION


### PR content/description
Use cargo deny to check that dependencies only use valid licenses.

The list of licenses has been taken from fhevm:
- https://github.com/zama-ai/fhevm/blob/main/coprocessor/fhevm-engine/.cargo/deny.toml,
- https://github.com/zama-ai/fhevm/blob/main/relayer/deny.toml,
- ...

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3661)
<!-- Reviewable:end -->
