### PR TITLE
chore(ci): some benches for shuffle/kv_store and a new job for summary gpu 

### DIFF
--- a/.github/workflows/benchmark_gpu_common.yml
+++ b/.github/workflows/benchmark_gpu_common.yml
@@ -227,6 +227,9 @@ jobs:
           BENCH_COMMAND: ${{ matrix.command }}
           PRECISIONS_SET: ${{ inputs.precisions_set }}
 
+      - name: Collect GPU information
+        run: nvidia-smi --query-gpu=name --format=csv,noheader | tee gpu_info.txt
+
       - name: Parse results
         run: |
           cargo run --release -p tfhe-benchmark-parser -- -i target/criterion -o "${RESULTS_FILENAME}" \
@@ -263,7 +266,9 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: ${{ github.sha }}_${{ matrix.command }}_${{ matrix.op_flavor }}_${{ inputs.profile }}_${{ matrix.bench_type }}_${{ matrix.params_type }}
-          path: ${{ env.RESULTS_FILENAME }}
+          path: |
+            ${{ env.RESULTS_FILENAME }}
+            gpu_info.txt
 
       - name: Checkout Slab repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0

--- a/.github/workflows/benchmark_summary.yml
+++ b/.github/workflows/benchmark_summary.yml
@@ -115,6 +115,51 @@ jobs:
       SLAB_URL: ${{ secrets.SLAB_URL }}
       SLAB_BASE_URL: ${{ secrets.SLAB_BASE_URL }}
 
+  summary-csv-gpu:
+    name: benchmark_summary/summary-csv-gpu
+    if: inputs.run-gpu-benchmarks
+    needs: [ parse-gpu-inputs, run-benchmarks-gpu ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout tfhe-rs repo
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: 'false'
+          token: ${{ secrets.REPO_CHECKOUT_TOKEN }}
+
+      - name: Download parsed benchmark results
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          path: summary-artifacts
+
+      - name: Extract GPU summary CSV
+        run: |
+          mapfile -t json_files < <(find summary-artifacts -path "*${PROFILE}*" -name 'parsed_benchmark_results_*.json')
+          if [ "${#json_files[@]}" -eq 0 ]; then
+            echo "No parsed GPU summary result files found for profile '${PROFILE}'" >&2
+            exit 1
+          fi
+          gpu_info_file="$(find summary-artifacts -path "*${PROFILE}*" -name 'gpu_info.txt' | head -n 1)"
+          if [ -z "${gpu_info_file}" ]; then
+            echo "No gpu_info.txt file found for profile '${PROFILE}'" >&2
+            exit 1
+          fi
+          inputs=()
+          for f in "${json_files[@]}"; do inputs+=(-i "$f"); done
+          python3 ci/parse_summary_benches_to_csv.py "${inputs[@]}" \
+            --gpu-info-file "${gpu_info_file}" \
+            --output-file summary_benchmarks_gpu.csv
+          echo "----- summary_benchmarks_gpu.csv -----"
+          cat summary_benchmarks_gpu.csv
+        env:
+          PROFILE: ${{ needs.parse-gpu-inputs.outputs.profile }}
+
+      - name: Upload summary CSV artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: ${{ github.sha }}_summary_benchmarks_gpu_csv
+          path: summary_benchmarks_gpu.csv
+
 # TODO add make recipe for HPU benchmarks
 #  run-benchmarks-hpu:
 #    name: benchmark_documentation/run-benchmarks-hpu

--- a/Makefile
+++ b/Makefile
@@ -2283,6 +2283,12 @@ bench_summary: install_rs_check_toolchain
 	--bench hlapi-erc7984 \
 	--features=integer,internal-keycache -p tfhe-benchmark -- '::transfer::overflow'
 
+	# ERC7984 (all transfer flavors)
+	RUSTFLAGS="$(RUSTFLAGS)" __TFHE_RS_BENCH_TYPE=$(BENCH_TYPE) __TFHE_RS_PARAM_TYPE=$(BENCH_PARAM_TYPE) \
+	cargo $(CARGO_RS_CHECK_TOOLCHAIN) bench \
+	--bench hlapi-erc7984 \
+	--features=integer,internal-keycache -p tfhe-benchmark -- '::transfer::'
+
 	# DEX
 	RUSTFLAGS="$(RUSTFLAGS)" __TFHE_RS_BENCH_TYPE=$(BENCH_TYPE) \
 	cargo $(CARGO_RS_CHECK_TOOLCHAIN) bench \
@@ -2328,6 +2334,12 @@ bench_summary_gpu: install_rs_check_toolchain
 	--bench hlapi-erc7984 \
 	--features=integer,gpu,internal-keycache -p tfhe-benchmark --profile release_lto_off -- '::transfer::overflow'
 
+	# ERC7984 (all transfer flavors)
+	RUSTFLAGS="$(RUSTFLAGS)" __TFHE_RS_BENCH_TYPE=$(BENCH_TYPE) __TFHE_RS_PARAM_TYPE=$(BENCH_PARAM_TYPE) \
+	cargo $(CARGO_RS_CHECK_TOOLCHAIN) bench \
+	--bench hlapi-erc7984 \
+	--features=integer,gpu,internal-keycache -p tfhe-benchmark --profile release_lto_off -- '::transfer::'
+
 	# DEX
 	RUSTFLAGS="$(RUSTFLAGS)" __TFHE_RS_BENCH_TYPE=$(BENCH_TYPE) __TFHE_RS_PARAM_TYPE=$(BENCH_PARAM_TYPE) \
 	cargo $(CARGO_RS_CHECK_TOOLCHAIN) bench \
@@ -2352,6 +2364,24 @@ bench_summary_gpu: install_rs_check_toolchain
 	cargo $(CARGO_RS_CHECK_TOOLCHAIN) bench \
 	--bench integer-glwe_packing_compression \
 	--features=integer,internal-keycache,gpu,pbs-stats -p tfhe-benchmark --profile release_lto_off --
+
+	# Bitonic shuffle (64b/16b, 64b/32b, 160b/16b value/key @ 16 elements)
+	RUSTFLAGS="$(RUSTFLAGS)" __TFHE_RS_PARAM_TYPE=$(BENCH_PARAM_TYPE) __TFHE_RS_BENCH_TYPE=$(BENCH_TYPE) \
+	cargo $(CARGO_RS_CHECK_TOOLCHAIN) bench \
+	--bench hlapi-bitonic-shuffle \
+	--features=integer,gpu,internal-keycache,pbs-stats -p tfhe-benchmark --profile release_lto_off -- 'hlapi::bitonic_shuffle_gpu::summary::'
+
+	# Key-Value store (summary: N=64, u64 key, u64 value)
+	RUSTFLAGS="$(RUSTFLAGS)" __TFHE_RS_PARAM_TYPE=$(BENCH_PARAM_TYPE) __TFHE_RS_BENCH_TYPE=$(BENCH_TYPE) __TFHE_RS_BENCH_BIT_SIZES_SET=FAST \
+	cargo $(CARGO_RS_CHECK_TOOLCHAIN) bench \
+	--bench hlapi-kvstore \
+	--features=integer,gpu,internal-keycache,pbs-stats -p tfhe-benchmark --profile release_lto_off -- 'kv_store::(get|update|map)::'
+
+	# Vector find (contains + match_value, FheUint64 + FheUint8, @ 50 and 1000 elements)
+	RUSTFLAGS="$(RUSTFLAGS)" __TFHE_RS_PARAM_TYPE=$(BENCH_PARAM_TYPE) __TFHE_RS_BENCH_TYPE=$(BENCH_TYPE) __TFHE_RS_BENCH_BIT_SIZES_SET=FAST \
+	cargo $(CARGO_RS_CHECK_TOOLCHAIN) bench \
+	--bench hlapi-vector-find \
+	--features=integer,gpu,internal-keycache,pbs-stats -p tfhe-benchmark --profile release_lto_off --
 
 .PHONY: bench_custom # Run benchmarks with a user-defined command
 bench_custom: install_rs_check_toolchain

--- a/ci/parse_summary_benches_to_csv.py
+++ b/ci/parse_summary_benches_to_csv.py
@@ -1,0 +1,357 @@
+import argparse
+import csv
+import json
+import math
+import re
+from pathlib import Path
+
+MILLISECONDS_IN_NANO = 1e6
+
+NOT_AVAILABLE = "N/A"
+
+# (metric, param family, CSV header) for each value column, in output order.
+COLUMNS = [
+    ("latency", "classical", "Latency classical (ms)"),
+    ("latency", "multi_bit", "Latency multi-bit (ms)"),
+    ("throughput", "classical", "Throughput classical (ops/s)"),
+    ("throughput", "multi_bit", "Throughput multi-bit (ops/s)"),
+]
+
+
+def _round_to_digits(value, max_digits):
+    if value >= 100.0:
+        rounding_digit = None
+    elif value > 0:
+        power_of_10 = math.floor(math.log10(value))
+        rounding_digit = max_digits - (power_of_10 + 1)
+    else:
+        rounding_digit = None
+    return f"{round(value, rounding_digit)}"
+
+
+def _is_ct(point):
+    return point["operand_type"] == "CipherText"
+
+
+def _unsigned64_ct(point, op_token):
+    return (
+        op_token in point["id"]
+        and point["bits"] == 64
+        and _is_ct(point)
+        and "::signed" not in point["id"]
+    )
+
+
+def _fhe_type_width(name):
+    return name.replace("FheUint", "u").replace("FheInt", "i")
+
+
+def _bitonic_shuffle_label(point):
+    pid = point["id"]
+    value_match = re.search(r"::(\d+)_bits", pid)
+    key_match = re.search(r"::key_(\d+)_bits", pid)
+    elems_match = re.search(r"::(\d+)_elements", pid)
+    value_bits = value_match.group(1) if value_match else "?"
+    key_bits = key_match.group(1) if key_match else "?"
+    elems = elems_match.group(1) if elems_match else "?"
+    return f"Bitonic Shuffle ({value_bits}b/{key_bits}b @ {elems})"
+
+
+def _kv_store_label(op_name):
+    def label(point):
+        match = re.search(
+            r"::key_([A-Za-z0-9]+)::value_([A-Za-z0-9]+)::(\d+)_elements",
+            point["id"],
+        )
+        if not match:
+            return f"KV Store - {op_name}"
+        key = _fhe_type_width(match.group(1))
+        value = _fhe_type_width(match.group(2))
+        return f"KV Store - {op_name} ({key} key / {value} value @ {match.group(3)})"
+
+    return label
+
+
+RULES = [
+    ("Add", lambda p: _unsigned64_ct(p, "::add")),
+    ("Mul", lambda p: _unsigned64_ct(p, "::mul")),
+    ("Div", lambda p: _unsigned64_ct(p, "::div_rem")),
+    ("Comparison", lambda p: _unsigned64_ct(p, "::gt")),
+    ("SNS", lambda p: "::noise_squash::" in p["id"]),
+    (
+        "SNS (decompress + squash + compress)",
+        lambda p: "decomp_noise_squash_comp" in p["id"],
+    ),
+    (
+        "Compress",
+        lambda p: "packing_compression" in p["id"]
+        and "pack_u64" in p["id"]
+        and "unpack" not in p["id"],
+    ),
+    (
+        "Decompress",
+        lambda p: "packing_compression" in p["id"] and "unpack_u64" in p["id"],
+    ),
+    ("ZKPoK Proof (server)", lambda p: "pke_zk_proof" in p["id"]),
+    (
+        "ZKPoK Proof (verification)",
+        lambda p: "pke_zk_verify_and_expand" in p["id"],
+    ),
+    *[
+        (
+            f"ERC7984 Transfer ({flavor})",
+            lambda p, f=flavor: "erc7984" in p["id"]
+            and f"::transfer::{f}::" in p["id"],
+        )
+        for flavor in ("whitepaper", "no_cmux", "overflow", "safe")
+    ],
+    (
+        "Batch Swap Intents",
+        lambda p: "swap_request" in p["id"] and "no_cmux" in p["id"],
+    ),
+    (
+        "Redistribute Swap Tokens",
+        lambda p: "swap_claim" in p["id"] and "no_cmux" in p["id"],
+    ),
+    (_bitonic_shuffle_label, lambda p: "bitonic_shuffle" in p["id"]),
+    (_kv_store_label("get"), lambda p: "kv_store::get" in p["id"]),
+    (_kv_store_label("update"), lambda p: "kv_store::update" in p["id"]),
+    (_kv_store_label("map"), lambda p: "kv_store::map" in p["id"]),
+    (
+        "Vector find - contains (u64 @ 50)",
+        lambda p: "::contains::FheUint64::50_elements" in p["id"]
+        and "kv_store" not in p["id"],
+    ),
+    (
+        "Vector find - match_value (u64 @ 50)",
+        lambda p: "::match_value::FheUint64::50_elements" in p["id"],
+    ),
+]
+
+ROW_ORDER = [label for label, _ in RULES if isinstance(label, str)]
+
+
+def classify_pbs_kind(alias):
+    alias = (alias or "").upper()
+    if "GROUP" in alias or "MULTI_BIT" in alias:
+        return "multi_bit"
+    return "classical"
+
+
+def normalize_point(raw):
+    if raw.get("class") != "evaluate":
+        return None
+
+    test = raw.get("test", "")
+    if "_std_dev" in test:
+        return None
+
+    metric = str(raw.get("type", "")).lower()
+    if metric not in ("latency", "throughput"):
+        return None
+
+    params = raw.get("params") or {}
+    alias = params.get("crypto_parameters_alias", "")
+
+    return {
+        "id": test,
+        "value": float(raw["value"]),
+        "metric": metric,
+        "bits": params.get("bit_size"),
+        "operand_type": params.get("operand_type"),
+        "pbs": classify_pbs_kind(alias),
+        "alias": alias,
+        "backend": raw.get("backend"),
+    }
+
+
+def match_row(point):
+    for label, predicate in RULES:
+        try:
+            if predicate(point):
+                return label(point) if callable(label) else label
+        except (KeyError, TypeError):
+            continue
+    return None
+
+
+def load_points(input_files):
+    points = []
+    hardware_values = []
+    for path in input_files:
+        series = json.loads(Path(path).read_text())
+        hardware = series.get("hardware")
+        if hardware and hardware not in hardware_values:
+            hardware_values.append(hardware)
+        for raw in series.get("points", []):
+            norm = normalize_point(raw)
+            if norm is not None:
+                points.append(norm)
+    return points, hardware_values
+
+
+def build_table(points):
+    table = {}
+    unmatched = []
+    collisions = []
+
+    for point in points:
+        label = match_row(point)
+        if label is None:
+            unmatched.append(point["id"])
+            continue
+
+        cell = table.setdefault(label, {})
+        key = (point["metric"], point["pbs"])
+        if key not in cell:
+            cell[key] = point["value"]
+        elif cell[key] != point["value"]:
+            collisions.append((label, point["metric"], point["pbs"], point["id"]))
+
+    return table, {"unmatched": unmatched, "collisions": collisions}
+
+
+def load_gpu_info(gpu_info_file):
+    """Read the output of `nvidia-smi --query-gpu=name --format=csv,noheader`
+    (one GPU name per line) and return (model, count), or None if empty.
+    """
+    names = [
+        line.strip()
+        for line in Path(gpu_info_file).read_text().splitlines()
+        if line.strip()
+    ]
+    if not names:
+        return None
+    models = sorted(set(names))
+    assert len(models) == 1, f"several GPU models found: {', '.join(models)}"
+    return models[0], len(names)
+
+
+def collect_param_sets(points):
+    """Raw crypto parameter alias(es) seen across all points, per PBS kind."""
+    param_sets = {}
+    for family in ("classical", "multi_bit"):
+        aliases = sorted(
+            {p["alias"] for p in points if p["alias"] and p["pbs"] == family}
+        )
+        if aliases:
+            param_sets[family] = ", ".join(aliases)
+    return param_sets
+
+
+def build_metadata_rows(hardware, gpu_info, param_sets):
+    rows = []
+    if gpu_info:
+        model, count = gpu_info
+        rows.append(["GPU model", model])
+        rows.append(["GPU count", count])
+        if hardware:
+            rows.append(["Instance", hardware])
+    elif hardware:
+        rows.append(["Hardware", hardware])
+    for family, label in [
+        ("classical", "Parameter set classical"),
+        ("multi_bit", "Parameter set multi-bit"),
+    ]:
+        if family in param_sets:
+            rows.append([label, param_sets[family]])
+    return rows
+
+
+def _natural_key(label):
+    return [
+        int(token) if token.isdigit() else token
+        for token in re.split(r"(\d+)", label)
+    ]
+
+
+def order_rows(table):
+    known = [label for label in ROW_ORDER if label in table]
+    extra = [label for label in table if label not in ROW_ORDER]
+    return known + sorted(extra, key=_natural_key)
+
+
+def write_csv(table, output_file, metadata_rows):
+    header = ["Operation"] + [column_header for _, _, column_header in COLUMNS]
+    lines = [list(row) for row in metadata_rows] + [header]
+    for label in order_rows(table):
+        cell = table[label]
+        row = [label]
+        for metric, family, _ in COLUMNS:
+            value = cell.get((metric, family))
+            if value is None:
+                row.append(NOT_AVAILABLE)
+            elif metric == "latency":
+                row.append(_round_to_digits(value / MILLISECONDS_IN_NANO, 3))
+            else:
+                row.append(_round_to_digits(value, 3))
+        lines.append(row)
+
+    with open(output_file, "w", encoding="utf-8", newline="") as out:
+        csv.writer(out).writerows(lines)
+
+
+def main(args):
+    points, hardware_values = load_points(args.input)
+    if not points:
+        print("No timing points found in the provided files; nothing written.")
+        return
+
+    table, diag = build_table(points)
+
+    if not table:
+        print("No summary operation matched the parsed points; nothing written.")
+        return
+
+    assert len(hardware_values) <= 1, (
+        "several hardware names found across input files: "
+        f"{', '.join(hardware_values)}"
+    )
+    hardware = hardware_values[0] if hardware_values else None
+    gpu_info = load_gpu_info(args.gpu_info_file) if args.gpu_info_file else None
+    param_sets = collect_param_sets(points)
+    metadata_rows = build_metadata_rows(hardware, gpu_info, param_sets)
+
+    write_csv(table, args.output_file, metadata_rows)
+
+    print(f"Wrote {len(table)} operation(s) to {args.output_file}")
+    for name, value in metadata_rows:
+        print(f"{name}: {value}")
+    if diag["collisions"]:
+        print(f"WARNING: {len(diag['collisions'])} value collision(s) (kept first):")
+        for label, metric, family, test in diag["collisions"][:10]:
+            print(f"  - {label} [{metric}/{family}]: {test}")
+    if diag["unmatched"]:
+        unique_unmatched = sorted(set(diag["unmatched"]))
+        print(f"Note: {len(unique_unmatched)} benchmark id(s) did not map to a row:")
+        for test in unique_unmatched[:15]:
+            print(f"  - {test}")
+        if len(unique_unmatched) > 15:
+            print(f"  ... and {len(unique_unmatched) - 15} more")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        "Extract a benchmark summary CSV from tfhe-benchmark-parser JSON output"
+    )
+    parser.add_argument(
+        "-i",
+        "--input",
+        action="append",
+        required=True,
+        help="A parsed_benchmark_results_*.json file. Repeat to merge several.",
+    )
+    parser.add_argument(
+        "-o",
+        "--output-file",
+        default="summary_benchmarks.csv",
+        help="Path of the output CSV file",
+    )
+    parser.add_argument(
+        "--gpu-info-file",
+        help="File holding the output of "
+        "`nvidia-smi --query-gpu=name --format=csv,noheader`, "
+        "used to report the GPU model and count",
+    )
+
+    main(parser.parse_args())

--- a/tfhe-benchmark/Cargo.toml
+++ b/tfhe-benchmark/Cargo.toml
@@ -103,7 +103,13 @@ required-features = ["integer", "internal-keycache"]
 name = "hlapi-bitonic-shuffle"
 path = "benches/high_level_api/bitonic_shuffle.rs"
 harness = false
-required-features = ["integer", "internal-keycache"]
+required-features = ["integer", "internal-keycache", "pbs-stats"]
+
+[[bench]]
+name = "hlapi-vector-find"
+path = "benches/high_level_api/vector_find.rs"
+harness = false
+required-features = ["integer", "internal-keycache", "pbs-stats"]
 
 [[bench]]
 name = "hlapi-dex"

--- a/tfhe-benchmark/benches/high_level_api/bitonic_shuffle.rs
+++ b/tfhe-benchmark/benches/high_level_api/bitonic_shuffle.rs
@@ -1,12 +1,21 @@
+#[cfg(feature = "gpu")]
+use benchmark::params_aliases::BENCH_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
 use benchmark::params_aliases::BENCH_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
 #[cfg(feature = "gpu")]
-use benchmark::params_aliases::BENCH_PARAM_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
-use criterion::{criterion_group, Criterion};
+use benchmark::utilities::{get_param_type, ParamType};
+use benchmark::utilities::{write_to_json_unchecked, OperatorType};
+use benchmark_spec::{get_bench_type, BenchmarkType};
+use criterion::{criterion_group, Criterion, Throughput};
 use rand::prelude::*;
+use rayon::prelude::*;
 use std::hint::black_box;
 use tfhe::integer::server_key::BitonicShuffleKeySize;
+use tfhe::keycache::NamedParam;
 use tfhe::prelude::*;
-use tfhe::{bitonic_shuffle, set_server_key, ClientKey, ConfigBuilder, FheUint64, Seed, ServerKey};
+use tfhe::{
+    bitonic_shuffle, set_server_key, ClientKey, ConfigBuilder, FheIntegerType, FheUint160,
+    FheUint64, Seed, ServerKey,
+};
 
 const DATA_BITS: u32 = 64;
 const SHUFFLE_KEY_NUM_BITS: u32 = 32;
@@ -48,8 +57,7 @@ fn bench_bitonic_shuffle_inner<F>(
     let mut rng = rand::thread_rng();
 
     for &num_elements in scenarios {
-        let suffix = bench_id_suffix(num_elements);
-        let bench_id = format!("{bench_name}::{suffix}");
+        let bench_id = bench_id_suffix(num_elements);
 
         group.bench_function(&bench_id, |b| {
             b.iter_batched(
@@ -114,6 +122,127 @@ fn bench_collision_probability(c: &mut Criterion, cks: &ClientKey, bench_name: &
 }
 
 // ============================================================================
+// Shuffle configs surfaced in the CI summary, all at 16 elements:
+//   - 64b values  / 16b keys
+//   - 64b values  / 32b keys
+//   - 160b values / 16b keys
+// ============================================================================
+
+fn bench_shuffle_config<T>(
+    group: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
+    cks: &ClientKey,
+    bench_name: &str,
+    value_bits: u32,
+    key_bits: u32,
+    num_elements: usize,
+) where
+    T: FheIntegerType + FheEncrypt<u128, ClientKey> + Clone + Send + Sync,
+{
+    let mut rng = rand::thread_rng();
+    let key_size = BitonicShuffleKeySize::num_bits(key_bits);
+    let params = cks.computation_parameters();
+    let params_name = params.name();
+    let stem =
+        format!("{bench_name}::{value_bits}_bits::{num_elements}_elements::key_{key_bits}_bits");
+
+    let encrypt_dataset = |rng: &mut ThreadRng| -> Vec<T> {
+        (0..num_elements)
+            .map(|_| T::encrypt(rng.gen::<u128>(), cks))
+            .collect()
+    };
+
+    let bench_id = match get_bench_type() {
+        BenchmarkType::Latency => {
+            let bench_id = format!("{stem}::{params_name}");
+            group.bench_function(&bench_id, |b| {
+                b.iter_batched(
+                    || (encrypt_dataset(&mut rng), Seed(rng.gen())),
+                    |(data, seed)| {
+                        let res =
+                            bitonic_shuffle(data, key_size, seed).expect("bitonic_shuffle failed");
+                        black_box(res);
+                    },
+                    criterion::BatchSize::SmallInput,
+                )
+            });
+            bench_id
+        }
+        BenchmarkType::Throughput => {
+            let num_ops = {
+                #[cfg(any(feature = "gpu", feature = "hpu"))]
+                {
+                    use benchmark::utilities::throughput_num_threads;
+                    let msg_bits = (cks.computation_parameters().message_modulus().0 as f64).log2();
+                    let num_block =
+                        (num_elements as f64 * value_bits as f64 / msg_bits).ceil() as usize;
+                    throughput_num_threads(num_block, 1).max(1) as usize
+                }
+                #[cfg(not(any(feature = "gpu", feature = "hpu")))]
+                {
+                    use benchmark::find_optimal_batch::find_optimal_batch;
+                    let setup = |batch_size: usize| -> Vec<(Vec<T>, Seed)> {
+                        (0..batch_size)
+                            .map(|_| (encrypt_dataset(&mut rng), Seed(rng.gen())))
+                            .collect()
+                    };
+                    let run = |inputs: &mut Vec<(Vec<T>, Seed)>, batch_size: usize| {
+                        inputs.par_iter().take(batch_size).for_each(|(data, seed)| {
+                            let res = bitonic_shuffle(data.clone(), key_size, *seed)
+                                .expect("bitonic_shuffle failed");
+                            black_box(res);
+                        });
+                    };
+                    find_optimal_batch(run, setup)
+                }
+            };
+
+            let bench_id = format!("{stem}::throughput::{params_name}");
+            group.throughput(Throughput::Elements(num_ops as u64));
+            group.bench_function(&bench_id, |b| {
+                b.iter_batched(
+                    || {
+                        (0..num_ops)
+                            .map(|_| (encrypt_dataset(&mut rng), Seed(rng.gen())))
+                            .collect::<Vec<_>>()
+                    },
+                    |inputs| {
+                        inputs.into_par_iter().for_each(|(data, seed)| {
+                            let res = bitonic_shuffle(data, key_size, seed)
+                                .expect("bitonic_shuffle failed");
+                            black_box(res);
+                        });
+                    },
+                    criterion::BatchSize::SmallInput,
+                )
+            });
+            bench_id
+        }
+    };
+
+    write_to_json_unchecked(
+        &bench_id,
+        params_name,
+        "bitonic_shuffle",
+        &OperatorType::Atomic,
+        value_bits,
+        vec![],
+    );
+}
+
+fn bench_shuffle_configs(c: &mut Criterion, cks: &ClientKey, bench_name: &str) {
+    let mut group = c.benchmark_group(bench_name);
+    group
+        .sample_size(10)
+        .measurement_time(std::time::Duration::from_secs(60));
+
+    bench_shuffle_config::<FheUint64>(&mut group, cks, bench_name, 64, 16, 16);
+    bench_shuffle_config::<FheUint64>(&mut group, cks, bench_name, 64, 32, 16);
+    bench_shuffle_config::<FheUint160>(&mut group, cks, bench_name, 160, 16, 16);
+
+    group.finish();
+}
+
+// ============================================================================
 // Unchecked bitonic_shuffle_with_keys: measured at the integer level because
 // the HL API only exposes the full `bitonic_shuffle` (key generation + shuffle).
 // ============================================================================
@@ -138,7 +267,7 @@ fn bench_unchecked_with_keys_cpu_inner(
 
     let mut rng = rand::thread_rng();
     for &num_elements in power_of_two_scenarios().iter() {
-        let bench_id = format!("{bench_name}::{DATA_BITS}_bits::{num_elements}_elements");
+        let bench_id = format!("{DATA_BITS}_bits::{num_elements}_elements");
         group.bench_function(&bench_id, |b| {
             b.iter_batched(
                 || {
@@ -188,7 +317,7 @@ fn bench_unchecked_with_keys_gpu_inner(
 
     let mut rng = rand::thread_rng();
     for &num_elements in power_of_two_scenarios().iter() {
-        let bench_id = format!("{bench_name}::{DATA_BITS}_bits::{num_elements}_elements");
+        let bench_id = format!("{DATA_BITS}_bits::{num_elements}_elements");
         group.bench_function(&bench_id, |b| {
             b.iter_batched(
                 || {
@@ -234,6 +363,7 @@ pub fn bitonic_shuffle_cpu(c: &mut Criterion) {
     bench_non_pow2(c, &cks, "hlapi::bitonic_shuffle_cpu::non_pow2");
     bench_key_size_sweep(c, &cks, "hlapi::bitonic_shuffle_cpu::key_size_sweep");
     bench_collision_probability(c, &cks, "hlapi::bitonic_shuffle_cpu::collision_probability");
+    bench_shuffle_configs(c, &cks, "hlapi::bitonic_shuffle_cpu::summary");
 
     let cpu_cks = tfhe::integer::ClientKey::new(param);
     bench_unchecked_with_keys_cpu_inner(
@@ -249,7 +379,10 @@ pub fn bitonic_shuffle_cpu(c: &mut Criterion) {
 
 #[cfg(feature = "gpu")]
 pub fn bitonic_shuffle_gpu(c: &mut Criterion) {
-    let param = BENCH_PARAM_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+    let param: tfhe::shortint::AtomicPatternParameters = match get_param_type() {
+        ParamType::Classical => BENCH_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128.into(),
+        _ => BENCH_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128.into(),
+    };
     let config = ConfigBuilder::with_custom_parameters(param).build();
     let cks = ClientKey::generate(config);
     let sks = tfhe::CompressedServerKey::new(&cks).decompress_to_gpu();
@@ -259,6 +392,7 @@ pub fn bitonic_shuffle_gpu(c: &mut Criterion) {
     bench_non_pow2(c, &cks, "hlapi::bitonic_shuffle_gpu::non_pow2");
     bench_key_size_sweep(c, &cks, "hlapi::bitonic_shuffle_gpu::key_size_sweep");
     bench_collision_probability(c, &cks, "hlapi::bitonic_shuffle_gpu::collision_probability");
+    bench_shuffle_configs(c, &cks, "hlapi::bitonic_shuffle_gpu::summary");
 
     let cpu_cks = tfhe::integer::ClientKey::new(param);
     bench_unchecked_with_keys_gpu_inner(

--- a/tfhe-benchmark/benches/high_level_api/kv_store.rs
+++ b/tfhe-benchmark/benches/high_level_api/kv_store.rs
@@ -132,16 +132,13 @@ where
             let (elements, mut kv_stores) = {
                 #[cfg(any(feature = "gpu", feature = "hpu"))]
                 {
-                    use benchmark::utilities::hlapi_throughput_num_ops;
-                    let factor = hlapi_throughput_num_ops(
-                        || {
-                            kv_store.map(&encrypted_key, |v| v);
-                        },
-                        cks,
-                    )
-                    .max(1);
+                    use benchmark::utilities::throughput_num_threads;
+                    use tfhe::IntegerId;
+                    let value_blocks = Value::Id::num_blocks(param.message_modulus());
+                    let factor =
+                        throughput_num_threads(num_elements * value_blocks, 1).max(1) as usize;
 
-                    let mut kv_stores = vec![];
+                    let mut kv_stores = Vec::with_capacity(factor);
                     for _ in 0..factor {
                         kv_stores.push(kv_store.clone());
                     }
@@ -272,7 +269,7 @@ fn main() {
 
     match env_config.bit_sizes_set {
         BitSizesSet::Fast => {
-            bench_kv_store::<u64, FheUint64, FheUint64>(&mut c, &cks, 1 << 10);
+            bench_kv_store::<u64, FheUint64, FheUint64>(&mut c, &cks, 64);
         }
         _ => {
             for pow in 1..=10 {

--- a/tfhe-benchmark/benches/high_level_api/vector_find.rs
+++ b/tfhe-benchmark/benches/high_level_api/vector_find.rs
@@ -1,57 +1,80 @@
+#[cfg(not(any(feature = "gpu", feature = "hpu")))]
+use benchmark::find_optimal_batch::find_optimal_batch;
 #[cfg(feature = "gpu")]
-use benchmark::params_aliases::BENCH_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+use benchmark::params_aliases::{
+    BENCH_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+    BENCH_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+};
 #[cfg(feature = "gpu")]
-use benchmark::utilities::{configure_gpu, write_to_json_unchecked, OperatorType};
-#[cfg(feature = "gpu")]
-use criterion::Criterion;
-#[cfg(feature = "gpu")]
+use benchmark::utilities::{configure_gpu, get_param_type, ParamType};
+use benchmark::utilities::{write_to_json_unchecked, BitSizesSet, EnvConfig, OperatorType};
+use benchmark_spec::{get_bench_type, BenchmarkType};
+use criterion::{Criterion, Throughput};
+use rayon::prelude::*;
 use std::hint::black_box;
-#[cfg(feature = "gpu")]
 use tfhe::keycache::NamedParam;
-#[cfg(feature = "gpu")]
 use tfhe::prelude::*;
 #[cfg(feature = "gpu")]
 use tfhe::shortint::AtomicPatternParameters;
-#[cfg(feature = "gpu")]
 use tfhe::{ClientKey, ConfigBuilder, FheUint64, FheUint8, MatchValues};
 
-#[cfg(feature = "gpu")]
-fn write_contains_metadata(
-    bench_id: &str,
-    params: AtomicPatternParameters,
-    params_name: &str,
-    num_bits: usize,
-) {
-    write_to_json_unchecked::<u64, _>(
-        bench_id,
-        params,
-        params_name,
-        "contains",
-        &OperatorType::Atomic,
-        num_bits as u32,
-        vec![params.message_modulus().0.ilog2(); num_bits],
-    );
+/// Registers a single operation as either a latency or a throughput benchmark,
+/// driven by __TFHE_RS_BENCH_TYPE
+fn bench_latency_or_throughput<F>(
+    group: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
+    bench_name: &str,
+    type_name: &str,
+    num_elements: usize,
+    client_key: &ClientKey,
+    operand_bits: usize,
+    run_once: F,
+) -> String
+where
+    F: Fn() + Sync,
+{
+    let params = client_key.computation_parameters();
+    let params_name = params.name();
+    match get_bench_type() {
+        BenchmarkType::Latency => {
+            let bench_id =
+                format!("{bench_name}::{type_name}::{num_elements}_elements::{params_name}");
+            group.bench_function(&bench_id, |b| b.iter(&run_once));
+            bench_id
+        }
+        BenchmarkType::Throughput => {
+            let num_ops = {
+                #[cfg(any(feature = "gpu", feature = "hpu"))]
+                {
+                    use benchmark::utilities::throughput_num_threads;
+                    let msg_bits = (params.message_modulus().0 as f64).log2();
+                    let num_block = (operand_bits as f64 / msg_bits).ceil() as usize;
+                    throughput_num_threads(num_block, 1).max(1) as usize
+                }
+                #[cfg(not(any(feature = "gpu", feature = "hpu")))]
+                {
+                    let _ = operand_bits;
+                    let setup = |_batch_size: usize| ();
+                    let run = |_: &mut (), batch_size: usize| {
+                        (0..batch_size).into_par_iter().for_each(|_| run_once());
+                    };
+                    find_optimal_batch(run, setup)
+                }
+            };
+
+            let bench_id = format!(
+                "{bench_name}::{type_name}::{num_elements}_elements::throughput::{params_name}"
+            );
+            group.throughput(Throughput::Elements(num_ops as u64));
+            group.bench_function(&bench_id, |b| {
+                b.iter(|| {
+                    (0..num_ops).into_par_iter().for_each(|_| run_once());
+                })
+            });
+            bench_id
+        }
+    }
 }
 
-#[cfg(feature = "gpu")]
-fn write_match_value_metadata(
-    bench_id: &str,
-    params: AtomicPatternParameters,
-    params_name: &str,
-    num_bits: usize,
-) {
-    write_to_json_unchecked::<u64, _>(
-        bench_id,
-        params,
-        params_name,
-        "match_value",
-        &OperatorType::Atomic,
-        num_bits as u32,
-        vec![params.message_modulus().0.ilog2(); num_bits],
-    );
-}
-
-#[cfg(feature = "gpu")]
 fn bench_contains_fhe_uint64(c: &mut Criterion, client_key: &ClientKey, num_elements: usize) {
     let bench_name = "hlapi::cuda::contains";
     let mut group = c.benchmark_group(bench_name);
@@ -59,24 +82,34 @@ fn bench_contains_fhe_uint64(c: &mut Criterion, client_key: &ClientKey, num_elem
 
     let params = client_key.computation_parameters();
     let params_name = params.name();
-    let bench_id = format!("{bench_name}::{params_name}::FheUint64_{num_elements}elements");
-
     let cts: Vec<FheUint64> = (0..num_elements as u64)
         .map(|i| FheUint64::encrypt(i, client_key))
         .collect();
     let value = FheUint64::encrypt(1u64, client_key);
 
-    group.bench_function(&bench_id, |b| {
-        b.iter(|| {
+    let bench_id = bench_latency_or_throughput(
+        &mut group,
+        bench_name,
+        "FheUint64",
+        num_elements,
+        client_key,
+        num_elements * 64,
+        || {
             black_box(FheUint64::contains(&cts, &value));
-        })
-    });
+        },
+    );
 
-    write_contains_metadata(&bench_id, params, &params_name, 64);
+    write_to_json_unchecked(
+        &bench_id,
+        params_name,
+        "contains",
+        &OperatorType::Atomic,
+        64,
+        vec![params.message_modulus().0.ilog2(); 64],
+    );
     group.finish();
 }
 
-#[cfg(feature = "gpu")]
 fn bench_contains_fhe_uint8(c: &mut Criterion, client_key: &ClientKey, num_elements: usize) {
     let bench_name = "hlapi::cuda::contains";
     let mut group = c.benchmark_group(bench_name);
@@ -84,24 +117,34 @@ fn bench_contains_fhe_uint8(c: &mut Criterion, client_key: &ClientKey, num_eleme
 
     let params = client_key.computation_parameters();
     let params_name = params.name();
-    let bench_id = format!("{bench_name}::{params_name}::FheUint8_{num_elements}elements");
-
     let cts: Vec<FheUint8> = (0..num_elements)
         .map(|i| FheUint8::encrypt((i % 256) as u8, client_key))
         .collect();
     let value = FheUint8::encrypt(1u8, client_key);
 
-    group.bench_function(&bench_id, |b| {
-        b.iter(|| {
+    let bench_id = bench_latency_or_throughput(
+        &mut group,
+        bench_name,
+        "FheUint8",
+        num_elements,
+        client_key,
+        num_elements * 8,
+        || {
             black_box(FheUint8::contains(&cts, &value));
-        })
-    });
+        },
+    );
 
-    write_contains_metadata(&bench_id, params, &params_name, 8);
+    write_to_json_unchecked(
+        &bench_id,
+        params_name,
+        "contains",
+        &OperatorType::Atomic,
+        8,
+        vec![params.message_modulus().0.ilog2(); 8],
+    );
     group.finish();
 }
 
-#[cfg(feature = "gpu")]
 fn bench_match_value_fhe_uint64(c: &mut Criterion, client_key: &ClientKey, num_elements: usize) {
     let bench_name = "hlapi::cuda::match_value";
     let mut group = c.benchmark_group(bench_name);
@@ -109,23 +152,33 @@ fn bench_match_value_fhe_uint64(c: &mut Criterion, client_key: &ClientKey, num_e
 
     let params = client_key.computation_parameters();
     let params_name = params.name();
-    let bench_id = format!("{bench_name}::{params_name}::FheUint64_{num_elements}elements");
-
     let pairs: Vec<(u64, u64)> = (0..num_elements as u64).map(|i| (i, i + 1)).collect();
     let match_values = MatchValues::new(pairs).unwrap();
     let ct = FheUint64::encrypt(1u64, client_key);
 
-    group.bench_function(&bench_id, |b| {
-        b.iter(|| {
+    let bench_id = bench_latency_or_throughput(
+        &mut group,
+        bench_name,
+        "FheUint64",
+        num_elements,
+        client_key,
+        num_elements * 64,
+        || {
             let _: (FheUint64, _) = black_box(ct.match_value(&match_values).unwrap());
-        })
-    });
+        },
+    );
 
-    write_match_value_metadata(&bench_id, params, &params_name, 64);
+    write_to_json_unchecked(
+        &bench_id,
+        params_name,
+        "match_value",
+        &OperatorType::Atomic,
+        64,
+        vec![params.message_modulus().0.ilog2(); 64],
+    );
     group.finish();
 }
 
-#[cfg(feature = "gpu")]
 fn bench_match_value_fhe_uint8(c: &mut Criterion, client_key: &ClientKey, num_elements: usize) {
     let bench_name = "hlapi::cuda::match_value";
     let mut group = c.benchmark_group(bench_name);
@@ -133,8 +186,6 @@ fn bench_match_value_fhe_uint8(c: &mut Criterion, client_key: &ClientKey, num_el
 
     let params = client_key.computation_parameters();
     let params_name = params.name();
-    let bench_id = format!("{bench_name}::{params_name}::FheUint8_{num_elements}elements");
-
     let limit = std::cmp::min(num_elements, 256);
     let pairs: Vec<(u8, u8)> = (0..limit)
         .map(|i| (i as u8, (i as u8).wrapping_add(1)))
@@ -142,48 +193,77 @@ fn bench_match_value_fhe_uint8(c: &mut Criterion, client_key: &ClientKey, num_el
     let match_values = MatchValues::new(pairs).unwrap();
     let ct = FheUint8::encrypt(1u8, client_key);
 
-    group.bench_function(&bench_id, |b| {
-        b.iter(|| {
+    let bench_id = bench_latency_or_throughput(
+        &mut group,
+        bench_name,
+        "FheUint8",
+        num_elements,
+        client_key,
+        limit * 8,
+        || {
             let _: (FheUint8, _) = black_box(ct.match_value(&match_values).unwrap());
-        })
-    });
+        },
+    );
 
-    write_match_value_metadata(&bench_id, params, &params_name, 8);
+    write_to_json_unchecked(
+        &bench_id,
+        params_name,
+        "match_value",
+        &OperatorType::Atomic,
+        8,
+        vec![params.message_modulus().0.ilog2(); 8],
+    );
     group.finish();
 }
 
-#[cfg(feature = "gpu")]
 fn main() {
-    let param: AtomicPatternParameters =
-        BENCH_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128.into();
+    let env_config = EnvConfig::new();
 
-    let config = ConfigBuilder::with_custom_parameters(param).build();
-    let client_key = ClientKey::generate(config);
+    #[cfg(feature = "gpu")]
+    let client_key = {
+        let param: AtomicPatternParameters = match get_param_type() {
+            ParamType::Classical => BENCH_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128.into(),
+            _ => BENCH_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128.into(),
+        };
+        let config = ConfigBuilder::with_custom_parameters(param).build();
+        let client_key = ClientKey::generate(config);
+        configure_gpu(&client_key);
+        client_key
+    };
 
-    configure_gpu(&client_key);
+    #[cfg(not(feature = "gpu"))]
+    let client_key = {
+        use benchmark::params_aliases::BENCH_PARAM_MESSAGE_2_CARRY_2_KS32_PBS;
+        use tfhe::{set_server_key, CompressedServerKey};
+        let config =
+            ConfigBuilder::with_custom_parameters(BENCH_PARAM_MESSAGE_2_CARRY_2_KS32_PBS).build();
+        let client_key = ClientKey::generate(config);
+        let sks = CompressedServerKey::new(&client_key).decompress();
+        rayon::broadcast(|_| set_server_key(sks.clone()));
+        set_server_key(sks);
+        client_key
+    };
 
     let mut c = Criterion::default().configure_from_args();
 
-    let sizes = [5, 10, 20, 30, 40, 50, 500, 1000];
+    let sizes: &[usize] = match env_config.bit_sizes_set {
+        BitSizesSet::Fast => &[50, 1000],
+        _ => &[5, 10, 20, 30, 40, 50, 500, 1000],
+    };
 
-    for &size in &sizes {
+    for &size in sizes {
         bench_contains_fhe_uint64(&mut c, &client_key, size);
     }
-    for &size in &sizes {
+    for &size in sizes {
         bench_match_value_fhe_uint64(&mut c, &client_key, size);
     }
 
-    for &size in &sizes {
+    for &size in sizes {
         bench_contains_fhe_uint8(&mut c, &client_key, size);
     }
-    for &size in &sizes {
+    for &size in sizes {
         bench_match_value_fhe_uint8(&mut c, &client_key, size);
     }
 
     c.final_summary();
-}
-
-#[cfg(not(feature = "gpu"))]
-fn main() {
-    println!("hlapi-vector-find bench is only available with the `gpu` feature");
 }

--- a/tfhe-benchmark/src/utilities.rs
+++ b/tfhe-benchmark/src/utilities.rs
@@ -3,8 +3,6 @@ use std::env;
 use std::sync::OnceLock;
 #[cfg(feature = "gpu")]
 use tfhe::core_crypto::gpu::{get_number_of_gpus, get_number_of_sms};
-#[cfg(feature = "integer")]
-use tfhe::prelude::*;
 
 pub use tfhe_benchmark_parser::{write_to_json, write_to_json_unchecked, OperatorType};
 
@@ -147,39 +145,6 @@ pub fn throughput_num_threads(num_block: usize, op_pbs_count: u64) -> u64 {
         ((num_threads + (num_threads * 0.2)) * block_multiplicator.min(1.0) * operation_loading)
             as u64
     }
-}
-
-// Given an `Op` this returns how many more ops should be done in parallel
-// to saturate the CPU and have a better throughput measurement
-#[cfg(all(feature = "integer", feature = "pbs-stats"))]
-pub fn hlapi_throughput_num_ops<Op>(op: Op, cks: &tfhe::ClientKey) -> usize
-where
-    Op: FnOnce(),
-{
-    tfhe::reset_pbs_count();
-    let t = std::time::Instant::now();
-    op();
-    let time_for_op = t.elapsed();
-    let pbs_count_for_op = tfhe::get_pbs_count();
-
-    let a = tfhe::FheBool::encrypt(true, cks);
-    let b = tfhe::FheBool::encrypt(true, cks);
-    let t = std::time::Instant::now();
-    let _ = a & b;
-    let time_for_single_pbs = t.elapsed();
-
-    // Round-up with nano seconds
-    let pbs_time_in_ms =
-        time_for_single_pbs.as_millis() + u128::from(time_for_single_pbs.as_nanos() != 0);
-
-    // Theoretical time if the op was just 1 layer of PBS all in parallel
-    let time_if_full_occupancy =
-        pbs_count_for_op.div_ceil(rayon::current_num_threads() as u64) as u128 * pbs_time_in_ms;
-
-    // Then find how many ops we should do to have full occupancy
-    let factor = time_for_op.as_millis().div_ceil(time_if_full_occupancy);
-
-    factor as usize
 }
 
 /// This function aims to prevent the setup function from running.


### PR DESCRIPTION
scenarios for **shuffle**:
- 16b keys, 64b values: 16 elements
- 32b keys, 64b  values: 16 elements
- 16b keys, 160b values: 16 elements

**kv_store**:
for N=64, 64-b values:
- get
- update
- map

all in _summary benchmarks_
and a job to store the result of summary gpu in a csv file

https://github.com/zama-ai/tfhe-rs/actions/runs/29827834122