### PR TITLE
chore(gpu): add missing hlapi_kvstore to the makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2249,6 +2249,13 @@ bench_hlapi_kvstore: install_rs_check_toolchain
 	--bench hlapi-kvstore \
 	--features=integer,internal-keycache,pbs-stats -p tfhe-benchmark --
 
+.PHONY: bench_hlapi_kvstore_gpu # Run benchmarks for Key-Value Store operations on GPU
+bench_hlapi_kvstore_gpu: install_rs_check_toolchain
+	RUSTFLAGS="$(RUSTFLAGS)" __TFHE_RS_BENCH_TYPE=$(BENCH_TYPE) __TFHE_RS_BENCH_BIT_SIZES_SET=$(BIT_SIZES_SET) __TFHE_RS_PARAM_TYPE=$(BENCH_PARAM_TYPE) \
+	cargo $(CARGO_RS_CHECK_TOOLCHAIN) bench \
+	--bench hlapi-kvstore \
+	--features=integer,gpu,internal-keycache,pbs-stats -p tfhe-benchmark --profile release_lto_off --
+
 .PHONY: bench_summary # Run summary benchmarks
 bench_summary: install_rs_check_toolchain
 	# Arithmetic operations: addition, multiplication, division, comparison


### PR DESCRIPTION
The target to run the kvstore benchmarks on the GPU was missing. This PR adds it.

<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
