### PR TITLE
feat(gpu): update over shift behavior

### DIFF
--- a/backends/tfhe-cuda-backend/cuda/include/integer/shift_and_rotate.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer/shift_and_rotate.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "integer/comparison.h"
 #include "integer_utilities.h"
 
 template <typename Torus> struct int_shift_and_rotate_buffer {
@@ -17,6 +18,39 @@ template <typename Torus> struct int_shift_and_rotate_buffer {
   int_bit_extract_luts_buffer<Torus> *bit_extract_luts_with_offset_2;
   int_radix_lut<Torus> *mux_lut;
   int_radix_lut<Torus> *cleaning_lut;
+
+  // Overshift handling: shifting by >= the integer's bit width yields 0, or the
+  // sign (0 / -1) for an arithmetic right shift.
+
+  /// @brief true for shifts (left/right), false for rotations.
+  bool handle_overshift;
+  /// @brief Scratch for the comparison "shift amount >= total_nb_bits".
+  int_comparison_buffer<Torus> *overshift_compare_mem;
+  /// @brief One-block ct reused by the fixup: first the boolean predicate,
+  /// then the per-block condition packed into the carry.
+  CudaRadixCiphertextFFI *tmp_overshift;
+  /// @brief Zero-padded copy of the shift amount, used when the block count is
+  /// odd (the comparison needs an even count, or one). Null when not padding.
+  CudaRadixCiphertextFFI *tmp_padded_shift;
+  /// @brief Number of blocks the comparison runs on: the input block count
+  /// rounded up to even (or 1).
+  uint32_t overshift_compare_num_blocks;
+  /// @brief Constant the shift amount is compared against: total_nb_bits split
+  /// into blocks, on the host.
+  Torus *h_overshift_scalar_blocks;
+  /// @brief Device copy of the scalar blocks.
+  Torus *d_overshift_scalar_blocks;
+  /// @brief Number of digits in the total_nb_bits decomposition.
+  uint32_t num_overshift_scalar_blocks;
+  /// @brief Moves the small condition into a block's carry
+  /// (x -> (x % message_modulus) * message_modulus) so it can be added per
+  /// block.
+  int_radix_lut<Torus> *overshift_pack_lut;
+  /// @brief Per-block finalizer: reads the packed condition and keeps the
+  /// shifted value or replaces it with 0 / the sign, refreshing noise in the
+  /// same PBS.
+
+  int_radix_lut<Torus> *overshift_cleanup_lut;
 
   Torus offset;
   bool gpu_memory_allocated;
@@ -127,6 +161,122 @@ template <typename Torus> struct int_shift_and_rotate_buffer {
         streams.active_gpu_subset(num_radix_blocks, params.pbs_type);
     cleaning_lut->generate_and_broadcast_lut(
         active_gpu_count_cleaning, {0}, {cleaning_lut_f}, LUT_0_FOR_ALL_BLOCKS);
+
+    // ---- Overshift handling (shifts only, not rotations) ----
+    setup_handle_overshift(streams, num_radix_blocks, total_nb_bits,
+                           allocate_gpu_memory, size_tracker);
+  }
+
+  /// @brief Allocates and initializes the buffers and LUTs used to fix up the
+  /// result when the shift amount is >= the integer's bit width (overshift).
+  /// Only shifts (not rotations) need this; for rotations it just resets the
+  /// members to their null/zero defaults.
+  /// @param num_radix_blocks Number of radix blocks of the value being shifted.
+  /// @param total_nb_bits Bit width of the value, i.e. the overshift threshold.
+  void setup_handle_overshift(CudaStreams streams, uint32_t num_radix_blocks,
+                              uint32_t total_nb_bits, bool allocate_gpu_memory,
+                              uint64_t &size_tracker) {
+    handle_overshift = (shift_type == LEFT_SHIFT || shift_type == RIGHT_SHIFT);
+    overshift_compare_mem = nullptr;
+    tmp_overshift = nullptr;
+    tmp_padded_shift = nullptr;
+    overshift_compare_num_blocks = 0;
+    d_overshift_scalar_blocks = nullptr;
+    h_overshift_scalar_blocks = nullptr;
+    num_overshift_scalar_blocks = 0;
+    overshift_pack_lut = nullptr;
+    overshift_cleanup_lut = nullptr;
+
+    if (handle_overshift) {
+      auto message_modulus = params.message_modulus;
+
+      // The unsigned scalar comparison requires an even number of blocks (or
+      // exactly 1), so pad the comparison block count when needed.
+      overshift_compare_num_blocks = num_radix_blocks;
+      if (num_radix_blocks > 1 && (num_radix_blocks % 2 != 0))
+        overshift_compare_num_blocks = num_radix_blocks + 1;
+
+      overshift_compare_mem = new int_comparison_buffer<Torus>(
+          streams, COMPARISON_TYPE::GE, params, overshift_compare_num_blocks,
+          /*is_signed=*/false, allocate_gpu_memory, size_tracker);
+
+      tmp_overshift = new CudaRadixCiphertextFFI;
+      create_zero_radix_ciphertext_async<Torus>(
+          streams.stream(0), streams.gpu_index(0), tmp_overshift, 1,
+          params.big_lwe_dimension, size_tracker, allocate_gpu_memory);
+
+      if (overshift_compare_num_blocks != num_radix_blocks) {
+        tmp_padded_shift = new CudaRadixCiphertextFFI;
+        create_zero_radix_ciphertext_async<Torus>(
+            streams.stream(0), streams.gpu_index(0), tmp_padded_shift,
+            overshift_compare_num_blocks, params.big_lwe_dimension,
+            size_tracker, allocate_gpu_memory);
+      }
+
+      // Decompose total_nb_bits into base-message_modulus digits
+      // (little-endian)
+      std::vector<Torus> digits;
+      {
+        uint32_t v = total_nb_bits;
+        while (v > 0) {
+          digits.push_back((Torus)(v % message_modulus));
+          v /= message_modulus;
+        }
+        if (digits.empty())
+          digits.push_back((Torus)0);
+      }
+      num_overshift_scalar_blocks = (uint32_t)digits.size();
+      h_overshift_scalar_blocks =
+          (Torus *)malloc(num_overshift_scalar_blocks * sizeof(Torus));
+      for (uint32_t i = 0; i < num_overshift_scalar_blocks; i++)
+        h_overshift_scalar_blocks[i] = digits[i];
+      d_overshift_scalar_blocks = (Torus *)cuda_malloc_with_size_tracking_async(
+          num_overshift_scalar_blocks * sizeof(Torus), streams.stream(0),
+          streams.gpu_index(0), size_tracker, allocate_gpu_memory);
+      cuda_memcpy_with_size_tracking_async_to_gpu(
+          d_overshift_scalar_blocks, h_overshift_scalar_blocks,
+          num_overshift_scalar_blocks * sizeof(Torus), streams.stream(0),
+          streams.gpu_index(0), allocate_gpu_memory);
+
+      bool arithmetic = is_signed && (shift_type == RIGHT_SHIFT);
+
+      // Pack LUT: moves the small condition value into the carry space, clean.
+      overshift_pack_lut = new int_radix_lut<Torus>(
+          streams, params, 1, 1, allocate_gpu_memory, size_tracker);
+      auto pack_f = [message_modulus](Torus x) -> Torus {
+        return (x % message_modulus) * message_modulus;
+      };
+      auto active_streams_pack = streams.active_gpu_subset(1, params.pbs_type);
+      overshift_pack_lut->generate_and_broadcast_lut(
+          active_streams_pack, {0}, {pack_f}, LUT_0_FOR_ALL_BLOCKS);
+
+      // Cleanup LUT: applied per result block, reads `cond` from the carry.
+      overshift_cleanup_lut =
+          new int_radix_lut<Torus>(streams, params, 1, num_radix_blocks,
+                                   allocate_gpu_memory, size_tracker);
+      std::function<Torus(Torus)> cleanup_f;
+      if (arithmetic) {
+        cleanup_f = [message_modulus](Torus x) -> Torus {
+          Torus c = x / message_modulus; // c == (overshift << 1) | is_neg
+          Torus v = x % message_modulus;
+          if (c == 3)
+            return message_modulus - 1; // overshift & negative -> -1
+          if (c == 2)
+            return (Torus)0; // overshift & positive -> 0
+          return v;          // in range -> shifted value
+        };
+      } else {
+        cleanup_f = [message_modulus](Torus x) -> Torus {
+          Torus c = x / message_modulus; // c == overshift
+          Torus v = x % message_modulus;
+          return (c >= 1) ? (Torus)0 : v;
+        };
+      }
+      auto active_streams_cleanup =
+          streams.active_gpu_subset(num_radix_blocks, params.pbs_type);
+      overshift_cleanup_lut->generate_and_broadcast_lut(
+          active_streams_cleanup, {0}, {cleanup_f}, LUT_0_FOR_ALL_BLOCKS);
+    }
   }
 
   void release(CudaStreams streams) {
@@ -147,6 +297,8 @@ template <typename Torus> struct int_shift_and_rotate_buffer {
     bit_extract_luts_with_offset_2->release(streams);
     mux_lut->release(streams);
     cleaning_lut->release(streams);
+    if (handle_overshift)
+      release_handle_overshift(streams);
 
     delete tmp_bits;
     delete tmp_shift_bits;
@@ -159,5 +311,40 @@ template <typename Torus> struct int_shift_and_rotate_buffer {
     delete mux_lut;
     delete cleaning_lut;
     cuda_synchronize_stream(streams.stream(0), streams.gpu_index(0));
+  }
+
+  /// @brief Releases the buffers and LUTs allocated by
+  /// setup_handle_overshift. A no-op when overshift handling is disabled
+  /// (rotations), since all members are then null.
+  void release_handle_overshift(CudaStreams streams) {
+
+    if (overshift_compare_mem) {
+      overshift_compare_mem->release(streams);
+      delete overshift_compare_mem;
+    }
+    if (tmp_overshift) {
+      release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0),
+                                     tmp_overshift, gpu_memory_allocated);
+      delete tmp_overshift;
+    }
+    if (tmp_padded_shift) {
+      release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0),
+                                     tmp_padded_shift, gpu_memory_allocated);
+      delete tmp_padded_shift;
+    }
+    if (overshift_pack_lut) {
+      overshift_pack_lut->release(streams);
+      delete overshift_pack_lut;
+    }
+    if (overshift_cleanup_lut) {
+      overshift_cleanup_lut->release(streams);
+      delete overshift_cleanup_lut;
+    }
+    if (d_overshift_scalar_blocks)
+      cuda_drop_with_size_tracking_async(
+          d_overshift_scalar_blocks, streams.stream(0), streams.gpu_index(0),
+          gpu_memory_allocated);
+    if (h_overshift_scalar_blocks)
+      free(h_overshift_scalar_blocks);
   }
 };

--- a/backends/tfhe-cuda-backend/cuda/src/integer/scalar_shifts.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/scalar_shifts.cuh
@@ -35,11 +35,19 @@ __host__ void host_logical_scalar_shift_inplace(
 
   size_t num_bits_in_block = (size_t)log2_int(message_modulus);
   size_t total_num_bits = num_bits_in_block * num_blocks;
-  shift = shift % total_num_bits;
 
   if (shift == 0) {
     return;
   }
+
+  // Overshift: a logical shift (used for unsigned shifts, left or right, and
+  // for the signed left shift) pushes every bit out, so the result is 0.
+  if (shift >= total_num_bits) {
+    set_zero_radix_ciphertext_slice_async<Torus>(
+        streams.stream(0), streams.gpu_index(0), lwe_array, 0, num_blocks);
+    return;
+  }
+
   size_t rotations = std::min(shift / num_bits_in_block, (size_t)num_blocks);
   size_t shift_within_block = shift % num_bits_in_block;
 
@@ -126,6 +134,49 @@ __host__ uint64_t scratch_cuda_arithmetic_scalar_shift(
   return size_tracker;
 }
 
+/**
+ * @brief Overshift fixup for an arithmetic right shift: when the shift amount
+ * is >= the bit width, the result saturates to the sign, so every block becomes
+ * the "sign block" (message_modulus - 1 if the input is negative, else 0).
+ * @param shifted_ct Ciphertext shifted in place; overwritten with the sign.
+ * @param mem Scratch buffer holding the padding-block LUT and tmp_rotated.
+ * @param num_blocks Number of radix blocks in shifted_ct.
+ * @param num_bits_in_block Message bits per block (1 skips the sign-extract
+ * PBS).
+ */
+template <typename Torus, typename KSTorus>
+__host__ void host_arithmetic_scalar_shift_overshift(
+    CudaStreams streams, CudaRadixCiphertextFFI *shifted_ct,
+    int_arithmetic_scalar_shift_buffer<Torus> *mem, void *const *bsks,
+    KSTorus *const *ksks, size_t num_bits_in_block) {
+  auto num_blocks = shifted_ct->num_radix_blocks;
+  CudaRadixCiphertextFFI sign_block;
+  as_radix_ciphertext_slice<Torus>(&sign_block, mem->tmp_rotated,
+                                   num_blocks + 1, num_blocks + 2);
+  CudaRadixCiphertextFFI last_block;
+  as_radix_ciphertext_slice<Torus>(&last_block, shifted_ct, num_blocks - 1,
+                                   num_blocks);
+
+  if (num_bits_in_block == 1) {
+    // A 1-bit-message block already is its own sign bit, so no PBS is needed.
+    copy_radix_ciphertext_slice_async<Torus>(
+        streams.stream(0), streams.gpu_index(0), &sign_block, 0, 1, shifted_ct,
+        num_blocks - 1, num_blocks);
+  } else {
+    // The last univariate LUT is the "padding block" LUT, producing
+    // (message_modulus - 1) * sign_bit from the (sign-holding) last block.
+    auto padding_block_lut = mem->lut_buffers_univariate[num_bits_in_block - 1];
+    integer_radix_apply_univariate_lookup_table<Torus>(
+        streams, &sign_block, &last_block, bsks, ksks, padding_block_lut, 1);
+  }
+
+  for (uint i = 0; i < num_blocks; i++) {
+    copy_radix_ciphertext_slice_async<Torus>(streams.stream(0),
+                                             streams.gpu_index(0), shifted_ct,
+                                             i, i + 1, &sign_block, 0, 1);
+  }
+}
+
 template <typename Torus, typename KSTorus>
 __host__ void host_arithmetic_scalar_shift_inplace(
     CudaStreams streams, CudaRadixCiphertextFFI *lwe_array, uint32_t shift,
@@ -138,11 +189,22 @@ __host__ void host_arithmetic_scalar_shift_inplace(
 
   size_t num_bits_in_block = (size_t)log2_int(message_modulus);
   size_t total_num_bits = num_bits_in_block * num_blocks;
-  shift = shift % total_num_bits;
 
   if (shift == 0) {
     return;
   }
+
+  if (mem->shift_type != RIGHT_SHIFT) {
+    PANIC("Cuda error (scalar shift): left scalar shift is never of the "
+          "arithmetic type")
+  }
+
+  if (shift >= total_num_bits) {
+    host_arithmetic_scalar_shift_overshift<Torus, KSTorus>(
+        streams, lwe_array, mem, bsks, ksks, num_bits_in_block);
+    return;
+  }
+
   size_t rotations = std::min(shift / num_bits_in_block, (size_t)num_blocks);
   size_t shift_within_block = shift % num_bits_in_block;
 

--- a/backends/tfhe-cuda-backend/cuda/src/integer/shift_and_rotate.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/shift_and_rotate.cuh
@@ -5,6 +5,7 @@
 #include "device.h"
 #include "integer.cuh"
 #include "integer/integer_utilities.h"
+#include "integer/scalar_comparison.cuh"
 #include "integer/shift_and_rotate.h"
 #include "pbs/programmable_bootstrap_classic.cuh"
 #include "pbs/programmable_bootstrap_multibit.cuh"
@@ -22,6 +23,85 @@ __host__ uint64_t scratch_cuda_shift_and_rotate(
   return size_tracker;
 }
 
+/**
+ * @brief Computes the overshift condition (shift_amount >= total_nb_bits) and
+ * packs it into the carry of mem->tmp_overshift, so it can later be fused into
+ * the final cleaning PBS of the reassembly at no extra per-block PBS cost. For
+ * an arithmetic right shift the condition also encodes the input's sign.
+ * @param lwe_shift Encrypted shift amount to compare against the bit width.
+ * @param last_bit Input's original sign bit, used for the arithmetic case.
+ * @param mem Scratch buffer holding the comparison memory, scalar and LUTs.
+ */
+template <typename Torus, typename KSTorus>
+__host__ void
+host_compute_overshift_condition(CudaStreams streams,
+                                 CudaRadixCiphertextFFI const *lwe_shift,
+                                 CudaRadixCiphertextFFI const *last_bit,
+                                 int_shift_and_rotate_buffer<Torus> *mem,
+                                 void *const *bsks, KSTorus *const *ksks) {
+  auto message_modulus = mem->params.message_modulus;
+  auto carry_modulus = mem->params.carry_modulus;
+
+  auto num_radix_blocks = lwe_shift->num_radix_blocks;
+  CudaRadixCiphertextFFI const *compare_in;
+  if (mem->tmp_padded_shift != nullptr) {
+    // Pad the shift amount to an even number of blocks (high block is 0).
+    set_zero_radix_ciphertext_slice_async<Torus>(
+        streams.stream(0), streams.gpu_index(0), mem->tmp_padded_shift, 0,
+        mem->tmp_padded_shift->num_radix_blocks);
+    copy_radix_ciphertext_slice_async<Torus>(
+        streams.stream(0), streams.gpu_index(0), mem->tmp_padded_shift, 0,
+        num_radix_blocks, lwe_shift, 0, num_radix_blocks);
+    compare_in = mem->tmp_padded_shift;
+  } else {
+    compare_in = lwe_shift;
+  }
+  integer_radix_unsigned_scalar_difference_check<Torus>(
+      streams, mem->tmp_overshift, compare_in, mem->d_overshift_scalar_blocks,
+      mem->h_overshift_scalar_blocks, mem->overshift_compare_mem,
+      mem->overshift_compare_mem->diff_buffer->operator_f, bsks, ksks,
+      mem->overshift_compare_num_blocks, mem->num_overshift_scalar_blocks);
+
+  if (mem->is_signed && (mem->shift_type == RIGHT_SHIFT)) {
+    // cond = 2 * overshift + is_neg, where is_neg is the input's sign bit
+    // (`last_bit`, still the original sign bit since the loop reads a copy).
+    host_integer_small_scalar_mul_radix<Torus>(streams, mem->tmp_overshift,
+                                               mem->tmp_overshift, 2,
+                                               message_modulus, carry_modulus);
+    host_addition<Torus>(streams.stream(0), streams.gpu_index(0),
+                         mem->tmp_overshift, mem->tmp_overshift, last_bit, 1,
+                         message_modulus, carry_modulus);
+  }
+  // Move cond into the carry space (clean output).
+  integer_radix_apply_univariate_lookup_table<Torus>(
+      streams, mem->tmp_overshift, mem->tmp_overshift, bsks, ksks,
+      mem->overshift_pack_lut, 1);
+}
+
+/**
+ * @brief Applies the overshift selection: adds the packed condition from
+ * mem->tmp_overshift to every block and runs the overshift cleanup LUT, which
+ * both refreshes the noise and selects the overshift result (0 / the sign) in a
+ * single PBS.
+ * @param shifted_ct Shift result, updated in place with the selection.
+ * @param mem Scratch buffer holding tmp_overshift and the cleanup LUT.
+ */
+template <typename Torus, typename KSTorus>
+__host__ void
+host_apply_overshift_cleanup(CudaStreams streams,
+                             CudaRadixCiphertextFFI *shifted_ct,
+                             int_shift_and_rotate_buffer<Torus> *mem,
+                             void *const *bsks, KSTorus *const *ksks) {
+  auto num_radix_blocks = shifted_ct->num_radix_blocks;
+  host_add_the_same_block_to_all_blocks<Torus>(
+      streams.stream(0), streams.gpu_index(0), shifted_ct, shifted_ct,
+      mem->tmp_overshift, mem->params.message_modulus,
+      mem->params.carry_modulus);
+  integer_radix_apply_univariate_lookup_table<Torus>(
+      streams, shifted_ct, shifted_ct, bsks, ksks, mem->overshift_cleanup_lut,
+      num_radix_blocks);
+}
+
 template <typename Torus, typename KSTorus>
 __host__ void
 host_shift_and_rotate_inplace(CudaStreams streams,
@@ -30,7 +110,13 @@ host_shift_and_rotate_inplace(CudaStreams streams,
                               int_shift_and_rotate_buffer<Torus> *mem,
                               void *const *bsks, KSTorus *const *ksks) {
   cuda_set_device(streams.gpu_index(0));
-
+  // The barrel shifter packs three bits (control | previous | current) into a
+  // single block for the mux LUT, so it needs the control bit at plaintext
+  // position 2 (value 4). This only fits when a block holds at least 3 bits.
+  if (mem->params.message_modulus * mem->params.carry_modulus < 8)
+    PANIC("Cuda error: shift/rotate by an encrypted amount requires "
+          "message_modulus * carry_modulus >= 8 (1_1 parameters are not "
+          "supported)")
   if (lwe_array->num_radix_blocks != lwe_shift->num_radix_blocks)
     PANIC("Cuda error: lwe_shift and lwe_array num radix blocks must be "
           "the same")
@@ -163,6 +249,13 @@ host_shift_and_rotate_inplace(CudaStreams streams,
         streams, input_bits_a, mux_inputs, bsks, ksks, mux_lut, total_nb_bits);
   }
 
+  if (mem->handle_overshift) {
+    // lwe array number of blocks is the same as the shift amount number of
+    // blocks
+    host_compute_overshift_condition<Torus, KSTorus>(
+        streams, lwe_shift, &last_bit, mem, bsks, ksks);
+  }
+
   // Initializes the output
   // Copy the last bit for each radix block
   for (int i = 0; i < num_radix_blocks; i++) {
@@ -189,11 +282,28 @@ host_shift_and_rotate_inplace(CudaStreams streams,
                            mem->params.carry_modulus);
     }
 
-    // To give back a clean ciphertext
-    auto cleaning_lut = mem->cleaning_lut;
-    integer_radix_apply_univariate_lookup_table<Torus>(
-        streams, lwe_array, lwe_array, bsks, ksks, cleaning_lut,
-        num_radix_blocks);
+    // To give back a clean ciphertext.
+    // For a shift (not a rotation), the final cleaning PBS also applies the
+    // overshift selection: we add `cond` (packed in the carry) to every block
+    // and use the overshift cleanup LUT, which both resets the noise and
+    // selects the overshift result in a single PBS (no extra PBS round).
+    if (i == 0 && mem->handle_overshift) {
+      host_apply_overshift_cleanup<Torus, KSTorus>(streams, lwe_array, mem,
+                                                   bsks, ksks);
+    } else {
+      auto cleaning_lut = mem->cleaning_lut;
+      integer_radix_apply_univariate_lookup_table<Torus>(
+          streams, lwe_array, lwe_array, bsks, ksks, cleaning_lut,
+          num_radix_blocks);
+    }
+  }
+
+  // 1-bit-message blocks: the reassembly loop above does not run, so the
+  // overshift selection could not be fused into a cleaning PBS; apply it as a
+  // standalone step instead.
+  if (bits_per_block == 1 && mem->handle_overshift) {
+    host_apply_overshift_cleanup<Torus, KSTorus>(streams, lwe_array, mem, bsks,
+                                                 ksks);
   }
 }
 #endif

--- a/tfhe/src/integer/gpu/server_key/radix/scalar_shift.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/scalar_shift.rs
@@ -56,8 +56,7 @@ impl CudaServerKey {
         streams: &CudaStreams,
     ) -> T
     where
-        Scalar: CastFrom<u32>,
-        u32: CastFrom<Scalar>,
+        u64: CastFrom<Scalar>,
         T: CudaIntegerRadixCiphertext,
     {
         let mut result = ct.duplicate(streams);
@@ -71,11 +70,14 @@ impl CudaServerKey {
         shift: Scalar,
         streams: &CudaStreams,
     ) where
-        Scalar: CastFrom<u32>,
-        u32: CastFrom<Scalar>,
+        u64: CastFrom<Scalar>,
         T: CudaIntegerRadixCiphertext,
     {
         let lwe_ciphertext_count = ct.as_ref().d_blocks.lwe_ciphertext_count();
+        // Clamp to the bit count so a large amount overshifts instead of wrapping after the u32
+        // cast (matches the CPU backend).
+        let total_num_bits = lwe_ciphertext_count.0 as u64 * self.message_modulus.0.ilog2() as u64;
+        let shift = u64::cast_from(shift).min(total_num_bits) as u32;
         let CudaDynamicKeyswitchingKey::Standard(computing_ks_key) = &self.key_switching_key else {
             panic!("Only the standard atomic pattern is supported on GPU")
         };
@@ -98,7 +100,7 @@ impl CudaServerKey {
                     cuda_backend_unchecked_scalar_left_shift_assign(
                         streams,
                         ct.as_mut(),
-                        u32::cast_from(shift),
+                        shift,
                         &d_bsk.d_vec,
                         &computing_ks_key.d_vec,
                         self.message_modulus,
@@ -125,7 +127,7 @@ impl CudaServerKey {
                     cuda_backend_unchecked_scalar_left_shift_assign(
                         streams,
                         ct.as_mut(),
-                        u32::cast_from(shift),
+                        shift,
                         &d_multibit_bsk.d_vec,
                         &computing_ks_key.d_vec,
                         self.message_modulus,
@@ -183,8 +185,7 @@ impl CudaServerKey {
         streams: &CudaStreams,
     ) -> T
     where
-        Scalar: CastFrom<u32>,
-        u32: CastFrom<Scalar>,
+        u64: CastFrom<Scalar>,
         T: CudaIntegerRadixCiphertext,
     {
         let mut result = ct.duplicate(streams);
@@ -198,11 +199,14 @@ impl CudaServerKey {
         shift: Scalar,
         streams: &CudaStreams,
     ) where
-        Scalar: CastFrom<u32>,
-        u32: CastFrom<Scalar>,
+        u64: CastFrom<Scalar>,
         T: CudaIntegerRadixCiphertext,
     {
         let lwe_ciphertext_count = ct.as_ref().d_blocks.lwe_ciphertext_count();
+        // Clamp to the bit count so a large amount overshifts instead of wrapping after the u32
+        // cast (matches the CPU backend).
+        let total_num_bits = lwe_ciphertext_count.0 as u64 * self.message_modulus.0.ilog2() as u64;
+        let shift = u64::cast_from(shift).min(total_num_bits) as u32;
         let CudaDynamicKeyswitchingKey::Standard(computing_ks_key) = &self.key_switching_key else {
             panic!("Only the standard atomic pattern is supported on GPU")
         };
@@ -226,7 +230,7 @@ impl CudaServerKey {
                         cuda_backend_unchecked_scalar_arithmetic_right_shift_assign(
                             streams,
                             ct.as_mut(),
-                            u32::cast_from(shift),
+                            shift,
                             &d_bsk.d_vec,
                             &computing_ks_key.d_vec,
                             self.message_modulus,
@@ -252,7 +256,7 @@ impl CudaServerKey {
                         cuda_backend_unchecked_scalar_arithmetic_right_shift_assign(
                             streams,
                             ct.as_mut(),
-                            u32::cast_from(shift),
+                            shift,
                             &d_multibit_bsk.d_vec,
                             &computing_ks_key.d_vec,
                             self.message_modulus,
@@ -281,7 +285,7 @@ impl CudaServerKey {
                         cuda_backend_unchecked_scalar_logical_right_shift_assign(
                             streams,
                             ct.as_mut(),
-                            u32::cast_from(shift),
+                            shift,
                             &d_bsk.d_vec,
                             &computing_ks_key.d_vec,
                             self.message_modulus,
@@ -308,7 +312,7 @@ impl CudaServerKey {
                         cuda_backend_unchecked_scalar_logical_right_shift_assign(
                             streams,
                             ct.as_mut(),
-                            u32::cast_from(shift),
+                            shift,
                             &d_multibit_bsk.d_vec,
                             &computing_ks_key.d_vec,
                             self.message_modulus,
@@ -330,8 +334,7 @@ impl CudaServerKey {
         shift: Scalar,
         streams: &CudaStreams,
     ) where
-        Scalar: CastFrom<u32>,
-        u32: CastFrom<Scalar>,
+        u64: CastFrom<Scalar>,
         T: CudaIntegerRadixCiphertext,
     {
         if !ct.block_carries_are_empty() {
@@ -379,8 +382,7 @@ impl CudaServerKey {
     /// ```
     pub fn scalar_right_shift<Scalar, T>(&self, ct: &T, shift: Scalar, streams: &CudaStreams) -> T
     where
-        Scalar: CastFrom<u32>,
-        u32: CastFrom<Scalar>,
+        u64: CastFrom<Scalar>,
         T: CudaIntegerRadixCiphertext,
     {
         let mut result = ct.duplicate(streams);
@@ -426,8 +428,7 @@ impl CudaServerKey {
     /// ```
     pub fn scalar_left_shift<Scalar, T>(&self, ct: &T, shift: Scalar, streams: &CudaStreams) -> T
     where
-        Scalar: CastFrom<u32>,
-        u32: CastFrom<Scalar>,
+        u64: CastFrom<Scalar>,
         T: CudaIntegerRadixCiphertext,
     {
         let mut result = ct.duplicate(streams);
@@ -441,8 +442,7 @@ impl CudaServerKey {
         shift: Scalar,
         streams: &CudaStreams,
     ) where
-        Scalar: CastFrom<u32>,
-        u32: CastFrom<Scalar>,
+        u64: CastFrom<Scalar>,
         T: CudaIntegerRadixCiphertext,
     {
         if !ct.block_carries_are_empty() {

--- a/tfhe/src/integer/gpu/server_key/radix/tests_long_run/test_random_op_sequence.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/tests_long_run/test_random_op_sequence.rs
@@ -192,11 +192,15 @@ mod clear_functions {
     // Warning this rotate definition only works with 64-bit ciphertexts
     pub(crate) const clear_rotate_left: fn(u64, u64) -> u64 =
         |x: u64, y: u64| x.rotate_left(y as u32);
-    pub(crate) const clear_left_shift: fn(u64, u64) -> u64 = |x, y| x.wrapping_shl(y as u32);
+    // An overshift (amount >= number of bits) pushes every bit out, so a
+    // logical shift returns 0.
+    pub(crate) const clear_left_shift: fn(u64, u64) -> u64 =
+        |x, y| if y >= 64 { 0 } else { x << y };
     // Warning this rotate definition only works with 64-bit ciphertexts
     pub(crate) const clear_rotate_right: fn(u64, u64) -> u64 =
         |x: u64, y: u64| x.rotate_right(y as u32);
-    pub(crate) const clear_right_shift: fn(u64, u64) -> u64 = |x, y| x.wrapping_shr(y as u32);
+    pub(crate) const clear_right_shift: fn(u64, u64) -> u64 =
+        |x, y| if y >= 64 { 0 } else { x >> y };
     pub(crate) const clear_max: fn(u64, u64) -> u64 = |x: u64, y: u64| std::cmp::max(x, y);
     pub(crate) const clear_min: fn(u64, u64) -> u64 = |x: u64, y: u64| std::cmp::min(x, y);
     pub(crate) const clear_neg: fn(u64) -> u64 = |x: u64| x.wrapping_neg();

--- a/tfhe/src/integer/gpu/server_key/radix/tests_long_run/test_signed_random_op_sequence.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/tests_long_run/test_signed_random_op_sequence.rs
@@ -253,10 +253,23 @@ where
         OpSequenceGpuMultiDeviceFunctionExecutor::new(&CudaServerKey::right_shift);
     // Warning this rotate definition only works with 64-bit ciphertexts
     let clear_rotate_left = |x: i64, y: u64| x.rotate_left(y as u32);
-    let clear_left_shift = |x: i64, y: u64| x << y;
+    // An overshift (amount >= number of bits) returns 0 for a left shift.
+    let clear_left_shift = |x: i64, y: u64| if y >= 64 { 0 } else { x << y };
     // Warning this rotate definition only works with 64-bit ciphertexts
     let clear_rotate_right = |x: i64, y: u64| x.rotate_right(y as u32);
-    let clear_right_shift = |x: i64, y: u64| x >> y;
+    // An arithmetic right shift saturates to the sign on overshift: -1 if the
+    // input is negative, else 0.
+    let clear_right_shift = |x: i64, y: u64| {
+        if y >= 64 {
+            if x < 0 {
+                -1
+            } else {
+                0
+            }
+        } else {
+            x >> y
+        }
+    };
     #[allow(clippy::type_complexity)]
     let mut shift_rotate_ops: Vec<(
         SignedShiftRotateExecutor,

--- a/tfhe/src/integer/gpu/server_key/radix/tests_signed/test_scalar_shift.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/tests_signed/test_scalar_shift.rs
@@ -19,7 +19,7 @@ where
     P: Into<TestParameters>,
 {
     let executor = GpuFunctionExecutor::new(&CudaServerKey::unchecked_scalar_left_shift);
-    signed_unchecked_scalar_left_shift_test(param, executor, false);
+    signed_unchecked_scalar_left_shift_test(param, executor);
 }
 
 fn integer_signed_scalar_left_shift<P>(param: P)
@@ -27,7 +27,7 @@ where
     P: Into<TestParameters>,
 {
     let executor = GpuFunctionExecutor::new(&CudaServerKey::scalar_left_shift);
-    signed_default_scalar_left_shift_test(param, executor, false);
+    signed_default_scalar_left_shift_test(param, executor);
 }
 
 fn integer_signed_unchecked_scalar_right_shift<P>(param: P)
@@ -35,7 +35,7 @@ where
     P: Into<TestParameters>,
 {
     let executor = GpuFunctionExecutor::new(&CudaServerKey::unchecked_scalar_right_shift);
-    signed_unchecked_scalar_right_shift_test(param, executor, false);
+    signed_unchecked_scalar_right_shift_test(param, executor);
 }
 
 fn integer_signed_scalar_right_shift<P>(param: P)
@@ -43,5 +43,5 @@ where
     P: Into<TestParameters>,
 {
     let executor = GpuFunctionExecutor::new(&CudaServerKey::scalar_right_shift);
-    signed_default_scalar_right_shift_test(param, executor, false);
+    signed_default_scalar_right_shift_test(param, executor);
 }

--- a/tfhe/src/integer/gpu/server_key/radix/tests_signed/test_shift.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/tests_signed/test_shift.rs
@@ -19,7 +19,7 @@ where
     P: Into<TestParameters> + Copy,
 {
     let executor = GpuFunctionExecutor::new(&CudaServerKey::unchecked_right_shift);
-    signed_unchecked_right_shift_test(param, executor, false);
+    signed_unchecked_right_shift_test(param, executor);
 }
 
 fn integer_signed_right_shift<P>(param: P)
@@ -27,7 +27,7 @@ where
     P: Into<TestParameters> + Copy,
 {
     let executor = GpuFunctionExecutor::new(&CudaServerKey::right_shift);
-    signed_default_right_shift_test(param, executor, false);
+    signed_default_right_shift_test(param, executor);
 }
 
 fn integer_signed_unchecked_left_shift<P>(param: P)
@@ -35,7 +35,7 @@ where
     P: Into<TestParameters> + Copy,
 {
     let executor = GpuFunctionExecutor::new(&CudaServerKey::unchecked_left_shift);
-    signed_unchecked_left_shift_test(param, executor, false);
+    signed_unchecked_left_shift_test(param, executor);
 }
 
 fn integer_signed_left_shift<P>(param: P)
@@ -43,5 +43,5 @@ where
     P: Into<TestParameters> + Copy,
 {
     let executor = GpuFunctionExecutor::new(&CudaServerKey::left_shift);
-    signed_default_left_shift_test(param, executor, false);
+    signed_default_left_shift_test(param, executor);
 }

--- a/tfhe/src/integer/gpu/server_key/radix/tests_unsigned/test_scalar_shift.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/tests_unsigned/test_scalar_shift.rs
@@ -19,7 +19,7 @@ where
     P: Into<TestParameters> + Copy,
 {
     let executor = GpuFunctionExecutor::new(&CudaServerKey::unchecked_scalar_right_shift);
-    unchecked_scalar_right_shift_test(param, executor, false);
+    unchecked_scalar_right_shift_test(param, executor);
 }
 
 fn integer_scalar_right_shift<P>(param: P)
@@ -27,7 +27,7 @@ where
     P: Into<TestParameters> + Copy,
 {
     let executor = GpuFunctionExecutor::new(&CudaServerKey::scalar_right_shift);
-    default_scalar_right_shift_test(param, executor, false);
+    default_scalar_right_shift_test(param, executor);
 }
 
 fn integer_unchecked_scalar_left_shift<P>(param: P)
@@ -35,7 +35,7 @@ where
     P: Into<TestParameters> + Copy,
 {
     let executor = GpuFunctionExecutor::new(&CudaServerKey::unchecked_scalar_left_shift);
-    unchecked_scalar_left_shift_test(param, executor, false);
+    unchecked_scalar_left_shift_test(param, executor);
 }
 
 fn integer_scalar_left_shift<P>(param: P)
@@ -43,5 +43,5 @@ where
     P: Into<TestParameters> + Copy,
 {
     let executor = GpuFunctionExecutor::new(&CudaServerKey::scalar_left_shift);
-    default_scalar_left_shift_test(param, executor, false);
+    default_scalar_left_shift_test(param, executor);
 }

--- a/tfhe/src/integer/gpu/server_key/radix/tests_unsigned/test_shift.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/tests_unsigned/test_shift.rs
@@ -19,7 +19,7 @@ where
     P: Into<TestParameters> + Copy,
 {
     let executor = GpuFunctionExecutor::new(&CudaServerKey::unchecked_right_shift);
-    unchecked_right_shift_test(param, executor, false);
+    unchecked_right_shift_test(param, executor);
 }
 
 fn integer_right_shift<P>(param: P)
@@ -27,7 +27,7 @@ where
     P: Into<TestParameters> + Copy,
 {
     let executor = GpuFunctionExecutor::new(&CudaServerKey::right_shift);
-    default_right_shift_test(param, executor, false);
+    default_right_shift_test(param, executor);
 }
 
 fn integer_unchecked_left_shift<P>(param: P)
@@ -35,7 +35,7 @@ where
     P: Into<TestParameters> + Copy,
 {
     let executor = GpuFunctionExecutor::new(&CudaServerKey::unchecked_left_shift);
-    unchecked_left_shift_test(param, executor, false);
+    unchecked_left_shift_test(param, executor);
 }
 
 fn integer_left_shift<P>(param: P)
@@ -43,5 +43,5 @@ where
     P: Into<TestParameters> + Copy,
 {
     let executor = GpuFunctionExecutor::new(&CudaServerKey::left_shift);
-    default_left_shift_test(param, executor, false);
+    default_left_shift_test(param, executor);
 }

--- a/tfhe/src/integer/server_key/radix/tests.rs
+++ b/tfhe/src/integer/server_key/radix/tests.rs
@@ -546,7 +546,7 @@ where
     P: Into<TestParameters>,
 {
     let executor = CpuFunctionExecutor::new(&ServerKey::unchecked_scalar_left_shift);
-    unchecked_scalar_left_shift_test(param, executor, true);
+    unchecked_scalar_left_shift_test(param, executor);
 }
 
 fn integer_unchecked_scalar_right_shift<P>(param: P)
@@ -554,7 +554,7 @@ where
     P: Into<TestParameters>,
 {
     let executor = CpuFunctionExecutor::new(&ServerKey::unchecked_scalar_right_shift);
-    unchecked_scalar_right_shift_test(param, executor, true);
+    unchecked_scalar_right_shift_test(param, executor);
 }
 
 fn integer_unchecked_neg<P>(param: P)

--- a/tfhe/src/integer/server_key/radix_parallel/tests_cases_unsigned.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_cases_unsigned.rs
@@ -325,11 +325,8 @@ where
     }
 }
 
-pub(crate) fn unchecked_scalar_left_shift_test<P, T>(
-    param: P,
-    mut executor: T,
-    test_overshift: bool,
-) where
+pub(crate) fn unchecked_scalar_left_shift_test<P, T>(param: P, mut executor: T)
+where
     P: Into<TestParameters>,
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, u64), RadixCiphertext>,
 {
@@ -367,7 +364,7 @@ pub(crate) fn unchecked_scalar_left_shift_test<P, T>(
         }
 
         // case when scalar >= nb_bits
-        if test_overshift {
+        {
             // An overshift pushes every bit out, so a left shift returns 0.
             let scalar = scalar.saturating_add(nb_bits);
             let encrypted_result = executor.execute((&ct, scalar as u64));
@@ -396,11 +393,8 @@ pub(crate) fn unchecked_scalar_left_shift_test<P, T>(
     }
 }
 
-pub(crate) fn unchecked_scalar_right_shift_test<P, T>(
-    param: P,
-    mut executor: T,
-    test_overshift: bool,
-) where
+pub(crate) fn unchecked_scalar_right_shift_test<P, T>(param: P, mut executor: T)
+where
     P: Into<TestParameters>,
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, u64), RadixCiphertext>,
 {
@@ -439,7 +433,7 @@ pub(crate) fn unchecked_scalar_right_shift_test<P, T>(
         }
 
         // case when scalar >= nb_bits
-        if test_overshift {
+        {
             // An overshift pushes every bit out, so an unsigned right shift returns 0.
             let scalar = scalar.saturating_add(nb_bits);
             let encrypted_result = executor.execute((&ct, scalar as u64));
@@ -2112,7 +2106,7 @@ where
     }
 }
 
-pub(crate) fn default_scalar_left_shift_test<P, T>(param: P, mut executor: T, test_overshift: bool)
+pub(crate) fn default_scalar_left_shift_test<P, T>(param: P, mut executor: T)
 where
     P: Into<TestParameters>,
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, u64), RadixCiphertext>,
@@ -2150,7 +2144,7 @@ where
         }
 
         // case when scalar >= nb_bits
-        if test_overshift {
+        {
             // An overshift pushes every bit out, so a left shift returns 0.
             let scalar = scalar.saturating_add(nb_bits);
             let ct_res = executor.execute((&ct, scalar as u64));
@@ -2173,7 +2167,7 @@ where
     }
 }
 
-pub(crate) fn default_scalar_right_shift_test<P, T>(param: P, mut executor: T, test_overshift: bool)
+pub(crate) fn default_scalar_right_shift_test<P, T>(param: P, mut executor: T)
 where
     P: Into<TestParameters>,
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, u64), RadixCiphertext>,
@@ -2212,7 +2206,7 @@ where
         }
 
         // case when scalar >= nb_bits
-        if test_overshift {
+        {
             // An overshift pushes every bit out, so an unsigned right shift returns 0.
             let scalar = scalar.saturating_add(nb_bits);
             let ct_res = executor.execute((&ct, scalar as u64));

--- a/tfhe/src/integer/server_key/radix_parallel/tests_long_run/test_random_op_sequence.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_long_run/test_random_op_sequence.rs
@@ -131,10 +131,12 @@ where
     let clear_mul = |x: u64, y: u64| x.wrapping_mul(y);
     // Warning this rotate definition only works with 64-bit ciphertexts
     let clear_rotate_left = |x: u64, y: u64| x.rotate_left(y as u32);
-    let clear_left_shift = |x, y| x << y;
+    // An overshift (amount >= number of bits) pushes every bit out, so a
+    // logical shift returns 0.
+    let clear_left_shift = |x: u64, y: u64| if y >= 64 { 0 } else { x << y };
     // Warning this rotate definition only works with 64-bit ciphertexts
     let clear_rotate_right = |x: u64, y: u64| x.rotate_right(y as u32);
-    let clear_right_shift = |x, y| x >> y;
+    let clear_right_shift = |x: u64, y: u64| if y >= 64 { 0 } else { x >> y };
     let clear_max = |x: u64, y: u64| max(x, y);
     let clear_min = |x: u64, y: u64| min(x, y);
 

--- a/tfhe/src/integer/server_key/radix_parallel/tests_long_run/test_signed_random_op_sequence.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_long_run/test_signed_random_op_sequence.rs
@@ -152,10 +152,23 @@ where
         OpSequenceCpuFunctionExecutor::new(&ServerKey::right_shift_parallelized);
     // Warning this rotate definition only works with 64-bit ciphertexts
     let clear_rotate_left = |x: i64, y: u64| x.rotate_left(y as u32);
-    let clear_left_shift = |x: i64, y: u64| x << y;
+    // An overshift (amount >= number of bits) returns 0 for a left shift.
+    let clear_left_shift = |x: i64, y: u64| if y >= 64 { 0 } else { x << y };
     // Warning this rotate definition only works with 64-bit ciphertexts
     let clear_rotate_right = |x: i64, y: u64| x.rotate_right(y as u32);
-    let clear_right_shift = |x: i64, y: u64| x >> y;
+    // An arithmetic right shift saturates to the sign on overshift: -1 if the
+    // input is negative, else 0.
+    let clear_right_shift = |x: i64, y: u64| {
+        if y >= 64 {
+            if x < 0 {
+                -1
+            } else {
+                0
+            }
+        } else {
+            x >> y
+        }
+    };
     #[allow(clippy::type_complexity)]
     let mut rotate_shift_ops: Vec<(
         SignedShiftRotateExecutor,

--- a/tfhe/src/integer/server_key/radix_parallel/tests_signed/test_scalar_shift.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_signed/test_scalar_shift.rs
@@ -26,7 +26,7 @@ where
     P: Into<TestParameters>,
 {
     let executor = CpuFunctionExecutor::new(&ServerKey::unchecked_scalar_left_shift_parallelized);
-    signed_unchecked_scalar_left_shift_test(param, executor, true);
+    signed_unchecked_scalar_left_shift_test(param, executor);
 }
 
 fn integer_signed_default_scalar_left_shift<P>(param: P)
@@ -34,7 +34,7 @@ where
     P: Into<TestParameters>,
 {
     let executor = CpuFunctionExecutor::new(&ServerKey::scalar_left_shift_parallelized);
-    signed_default_scalar_left_shift_test(param, executor, true);
+    signed_default_scalar_left_shift_test(param, executor);
 }
 
 fn integer_signed_unchecked_scalar_right_shift<P>(param: P)
@@ -42,7 +42,7 @@ where
     P: Into<TestParameters>,
 {
     let executor = CpuFunctionExecutor::new(&ServerKey::unchecked_scalar_right_shift_parallelized);
-    signed_unchecked_scalar_right_shift_test(param, executor, true);
+    signed_unchecked_scalar_right_shift_test(param, executor);
 }
 
 fn integer_signed_default_scalar_right_shift<P>(param: P)
@@ -50,13 +50,10 @@ where
     P: Into<TestParameters>,
 {
     let executor = CpuFunctionExecutor::new(&ServerKey::scalar_right_shift_parallelized);
-    signed_default_scalar_right_shift_test(param, executor, true);
+    signed_default_scalar_right_shift_test(param, executor);
 }
-pub(crate) fn signed_unchecked_scalar_left_shift_test<P, T>(
-    param: P,
-    mut executor: T,
-    test_overshift: bool,
-) where
+pub(crate) fn signed_unchecked_scalar_left_shift_test<P, T>(param: P, mut executor: T)
+where
     P: Into<TestParameters>,
     T: for<'a> FunctionExecutor<(&'a SignedRadixCiphertext, i64), SignedRadixCiphertext>,
 {
@@ -91,7 +88,7 @@ pub(crate) fn signed_unchecked_scalar_left_shift_test<P, T>(
         }
 
         // case when shift >= nb_bits
-        if test_overshift {
+        {
             // An overshift pushes every bit out, so a left shift returns 0.
             let clear_shift = clear_shift.saturating_add(nb_bits);
             let ct_res = executor.execute((&ct, clear_shift as i64));
@@ -101,11 +98,8 @@ pub(crate) fn signed_unchecked_scalar_left_shift_test<P, T>(
     }
 }
 
-pub(crate) fn signed_unchecked_scalar_right_shift_test<P, T>(
-    param: P,
-    mut executor: T,
-    test_overshift: bool,
-) where
+pub(crate) fn signed_unchecked_scalar_right_shift_test<P, T>(param: P, mut executor: T)
+where
     P: Into<TestParameters>,
     T: for<'a> FunctionExecutor<(&'a SignedRadixCiphertext, i64), SignedRadixCiphertext>,
 {
@@ -140,7 +134,7 @@ pub(crate) fn signed_unchecked_scalar_right_shift_test<P, T>(
         }
 
         // case when shift >= nb_bits
-        if test_overshift {
+        {
             // An overshift saturates an arithmetic right shift to the sign: -1 if negative, else 0.
             let clear_shift = clear_shift.saturating_add(nb_bits);
             let ct_res = executor.execute((&ct, clear_shift as i64));
@@ -151,11 +145,8 @@ pub(crate) fn signed_unchecked_scalar_right_shift_test<P, T>(
     }
 }
 
-pub(crate) fn signed_default_scalar_left_shift_test<P, T>(
-    param: P,
-    mut executor: T,
-    test_overshift: bool,
-) where
+pub(crate) fn signed_default_scalar_left_shift_test<P, T>(param: P, mut executor: T)
+where
     P: Into<TestParameters>,
     T: for<'a> FunctionExecutor<(&'a SignedRadixCiphertext, i64), SignedRadixCiphertext>,
 {
@@ -202,7 +193,7 @@ pub(crate) fn signed_default_scalar_left_shift_test<P, T>(
         }
 
         // case when shift >= nb_bits
-        if test_overshift {
+        {
             // An overshift pushes every bit out, so a left shift returns 0.
             let clear_shift = rng.gen_range(nb_bits..=u32::MAX);
             let ct_res = executor.execute((&ct, clear_shift as i64));
@@ -220,11 +211,8 @@ pub(crate) fn signed_default_scalar_left_shift_test<P, T>(
     }
 }
 
-pub(crate) fn signed_default_scalar_right_shift_test<P, T>(
-    param: P,
-    mut executor: T,
-    test_overshift: bool,
-) where
+pub(crate) fn signed_default_scalar_right_shift_test<P, T>(param: P, mut executor: T)
+where
     P: Into<TestParameters>,
     T: for<'a> FunctionExecutor<(&'a SignedRadixCiphertext, i64), SignedRadixCiphertext>,
 {
@@ -271,7 +259,7 @@ pub(crate) fn signed_default_scalar_right_shift_test<P, T>(
         }
 
         // case when shift >= nb_bits
-        if test_overshift {
+        {
             // An overshift saturates an arithmetic right shift to the sign: -1 if negative, else 0.
             let clear_shift = rng.gen_range(nb_bits..=u32::MAX);
             let ct_res = executor.execute((&ct, clear_shift as i64));

--- a/tfhe/src/integer/server_key/radix_parallel/tests_signed/test_shift.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_signed/test_shift.rs
@@ -25,7 +25,7 @@ create_parameterized_test!(integer_signed_unchecked_right_shift);
 create_parameterized_test!(integer_signed_left_shift);
 create_parameterized_test!(integer_signed_right_shift);
 
-pub(crate) fn signed_default_left_shift_test<P, T>(param: P, mut executor: T, test_overshift: bool)
+pub(crate) fn signed_default_left_shift_test<P, T>(param: P, mut executor: T)
 where
     P: Into<TestParameters>,
     T: for<'a> FunctionExecutor<
@@ -84,9 +84,7 @@ where
         }
 
         // case when shift >= nb_bits
-        // TODO: remove the `test_overshift` parameter (and this branch's gating) once the
-        // GPU backend implements the new overshift-returns-zero behavior.
-        if test_overshift {
+        {
             // Here we create a encrypted shift value >= nb_bits
             // in a way that the shift ciphertext is seen as having non empty carries
             let mut clear_shift = rng.gen::<u32>() % nb_bits;
@@ -113,7 +111,7 @@ where
     }
 }
 
-pub(crate) fn signed_default_right_shift_test<P, T>(param: P, mut executor: T, test_overshift: bool)
+pub(crate) fn signed_default_right_shift_test<P, T>(param: P, mut executor: T)
 where
     P: Into<TestParameters>,
     T: for<'a> FunctionExecutor<
@@ -172,9 +170,7 @@ where
         }
 
         // case when shift >= nb_bits
-        // TODO: remove the `test_overshift` parameter (and this branch's gating) once the
-        // GPU backend implements the new overshift-returns-zero behavior.
-        if test_overshift {
+        {
             // Here we create a encrypted shift value >= nb_bits
             // in a way that the shift ciphertext is seen as having non empty carries
             let mut clear_shift = rng.gen::<u32>() % nb_bits;
@@ -202,11 +198,8 @@ where
     }
 }
 
-pub(crate) fn signed_unchecked_left_shift_test<P, T>(
-    param: P,
-    mut executor: T,
-    test_overshift: bool,
-) where
+pub(crate) fn signed_unchecked_left_shift_test<P, T>(param: P, mut executor: T)
+where
     P: Into<TestParameters>,
     T: for<'a> FunctionExecutor<
         (&'a SignedRadixCiphertext, &'a RadixCiphertext),
@@ -247,9 +240,7 @@ pub(crate) fn signed_unchecked_left_shift_test<P, T>(
         }
 
         // case when shift >= nb_bits
-        // TODO: remove the `test_overshift` parameter (and this branch's gating) once the
-        // GPU backend implements the new overshift-returns-zero behavior.
-        if test_overshift {
+        {
             // The shift amount lies in [nb_bits, modulus), so it encrypts without
             // wrapping and is a genuine overshift: a left shift must return 0.
             let clear_shift = rng.gen_range(nb_bits..modulus as u32);
@@ -262,11 +253,8 @@ pub(crate) fn signed_unchecked_left_shift_test<P, T>(
     }
 }
 
-pub(crate) fn signed_unchecked_right_shift_test<P, T>(
-    param: P,
-    mut executor: T,
-    test_overshift: bool,
-) where
+pub(crate) fn signed_unchecked_right_shift_test<P, T>(param: P, mut executor: T)
+where
     P: Into<TestParameters>,
     T: for<'a> FunctionExecutor<
         (&'a SignedRadixCiphertext, &'a RadixCiphertext),
@@ -307,9 +295,7 @@ pub(crate) fn signed_unchecked_right_shift_test<P, T>(
         }
 
         // case when shift >= nb_bits
-        // TODO: remove the `test_overshift` parameter (and this branch's gating) once the
-        // GPU backend implements the new overshift-returns-zero behavior.
-        if test_overshift {
+        {
             // The shift amount lies in [nb_bits, modulus), so it encrypts without
             // wrapping and is a genuine overshift: an arithmetic right shift
             // saturates to the sign bit (-1 if negative, 0 otherwise).
@@ -328,7 +314,7 @@ where
     P: Into<TestParameters> + Copy,
 {
     let executor = CpuFunctionExecutor::new(&ServerKey::unchecked_right_shift_parallelized);
-    signed_unchecked_right_shift_test(param, executor, true);
+    signed_unchecked_right_shift_test(param, executor);
 }
 
 fn integer_signed_right_shift<P>(param: P)
@@ -336,7 +322,7 @@ where
     P: Into<TestParameters> + Copy,
 {
     let executor = CpuFunctionExecutor::new(&ServerKey::right_shift_parallelized);
-    signed_default_right_shift_test(param, executor, true);
+    signed_default_right_shift_test(param, executor);
 }
 
 fn integer_signed_unchecked_left_shift<P>(param: P)
@@ -344,7 +330,7 @@ where
     P: Into<TestParameters> + Copy,
 {
     let executor = CpuFunctionExecutor::new(&ServerKey::unchecked_left_shift_parallelized);
-    signed_unchecked_left_shift_test(param, executor, true);
+    signed_unchecked_left_shift_test(param, executor);
 }
 
 fn integer_signed_left_shift<P>(param: P)
@@ -352,5 +338,5 @@ where
     P: Into<TestParameters> + Copy,
 {
     let executor = CpuFunctionExecutor::new(&ServerKey::left_shift_parallelized);
-    signed_default_left_shift_test(param, executor, true);
+    signed_default_left_shift_test(param, executor);
 }

--- a/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_scalar_shift.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_scalar_shift.rs
@@ -20,7 +20,7 @@ where
     P: Into<TestParameters>,
 {
     let executor = CpuFunctionExecutor::new(&ServerKey::scalar_left_shift_parallelized);
-    default_scalar_left_shift_test(param, executor, true);
+    default_scalar_left_shift_test(param, executor);
 }
 
 fn integer_unchecked_scalar_left_shift<P>(param: P)
@@ -28,7 +28,7 @@ where
     P: Into<TestParameters>,
 {
     let executor = CpuFunctionExecutor::new(&ServerKey::unchecked_scalar_left_shift_parallelized);
-    unchecked_scalar_left_shift_test(param, executor, true);
+    unchecked_scalar_left_shift_test(param, executor);
 }
 
 fn integer_default_scalar_right_shift<P>(param: P)
@@ -36,7 +36,7 @@ where
     P: Into<TestParameters>,
 {
     let executor = CpuFunctionExecutor::new(&ServerKey::scalar_right_shift_parallelized);
-    default_scalar_right_shift_test(param, executor, true);
+    default_scalar_right_shift_test(param, executor);
 }
 
 fn integer_unchecked_scalar_right_shift<P>(param: P)
@@ -44,5 +44,5 @@ where
     P: Into<TestParameters>,
 {
     let executor = CpuFunctionExecutor::new(&ServerKey::unchecked_scalar_right_shift_parallelized);
-    unchecked_scalar_right_shift_test(param, executor, true);
+    unchecked_scalar_right_shift_test(param, executor);
 }

--- a/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_shift.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_shift.rs
@@ -23,7 +23,7 @@ where
     P: Into<TestParameters>,
 {
     let executor = CpuFunctionExecutor::new(&ServerKey::unchecked_left_shift_parallelized);
-    unchecked_left_shift_test(param, executor, true);
+    unchecked_left_shift_test(param, executor);
 }
 
 fn integer_unchecked_right_shift<P>(param: P)
@@ -31,7 +31,7 @@ where
     P: Into<TestParameters>,
 {
     let executor = CpuFunctionExecutor::new(&ServerKey::unchecked_right_shift_parallelized);
-    unchecked_right_shift_test(param, executor, true);
+    unchecked_right_shift_test(param, executor);
 }
 
 fn integer_right_shift<P>(param: P)
@@ -39,7 +39,7 @@ where
     P: Into<TestParameters> + Copy,
 {
     let executor = CpuFunctionExecutor::new(&ServerKey::right_shift_parallelized);
-    default_right_shift_test(param, executor, true);
+    default_right_shift_test(param, executor);
 }
 
 fn integer_left_shift<P>(param: P)
@@ -47,10 +47,10 @@ where
     P: Into<TestParameters> + Copy,
 {
     let executor = CpuFunctionExecutor::new(&ServerKey::left_shift_parallelized);
-    default_left_shift_test(param, executor, true);
+    default_left_shift_test(param, executor);
 }
 
-pub(crate) fn unchecked_left_shift_test<P, T>(param: P, mut executor: T, test_overshift: bool)
+pub(crate) fn unchecked_left_shift_test<P, T>(param: P, mut executor: T)
 where
     P: Into<TestParameters>,
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, &'a RadixCiphertext), RadixCiphertext>,
@@ -87,9 +87,7 @@ where
         }
 
         // case when shift >= nb_bits
-        // TODO: remove the `test_overshift` parameter (and this branch's gating) once the
-        // GPU backend implements the new overshift-returns-zero behavior.
-        if test_overshift {
+        {
             // The shift amount lies in [nb_bits, modulus), so it encrypts without
             // wrapping and is a genuine overshift: the result must be 0.
             let clear_shift = rng.gen_range(nb_bits..modulus as u32);
@@ -102,7 +100,7 @@ where
     }
 }
 
-pub(crate) fn unchecked_right_shift_test<P, T>(param: P, mut executor: T, test_overshift: bool)
+pub(crate) fn unchecked_right_shift_test<P, T>(param: P, mut executor: T)
 where
     P: Into<TestParameters>,
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, &'a RadixCiphertext), RadixCiphertext>,
@@ -138,9 +136,7 @@ where
         }
 
         // case when shift >= nb_bits
-        // TODO: remove the `test_overshift` parameter (and this branch's gating) once the
-        // GPU backend implements the new overshift-returns-zero behavior.
-        if test_overshift {
+        {
             // The shift amount lies in [nb_bits, modulus), so it encrypts without
             // wrapping and is a genuine overshift: the result must be 0.
             let clear_shift = rng.gen_range(nb_bits..modulus as u32);
@@ -152,7 +148,7 @@ where
     }
 }
 
-pub(crate) fn default_left_shift_test<P, T>(param: P, mut executor: T, test_overshift: bool)
+pub(crate) fn default_left_shift_test<P, T>(param: P, mut executor: T)
 where
     P: Into<TestParameters>,
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, &'a RadixCiphertext), RadixCiphertext>,
@@ -197,9 +193,7 @@ where
             }
 
             // case when shift >= nb_bits
-            // TODO: remove the `test_overshift` parameter (and this branch's gating) once the
-            // GPU backend implements the new overshift-returns-zero behavior.
-            if test_overshift {
+            {
                 let clear_shift = rng.gen_range(nb_bits..modulus as u32);
                 let shift = cks.encrypt_radix(clear_shift as u64, num_blocks);
 
@@ -213,7 +207,7 @@ where
     }
 }
 
-pub(crate) fn default_right_shift_test<P, T>(param: P, mut executor: T, test_overshift: bool)
+pub(crate) fn default_right_shift_test<P, T>(param: P, mut executor: T)
 where
     P: Into<TestParameters>,
     T: for<'a> FunctionExecutor<(&'a RadixCiphertext, &'a RadixCiphertext), RadixCiphertext>,
@@ -252,9 +246,7 @@ where
             }
 
             // case when shift >= nb_bits
-            // TODO: remove the `test_overshift` parameter (and this branch's gating) once the
-            // GPU backend implements the new overshift-returns-zero behavior.
-            if test_overshift {
+            {
                 let clear_shift = rng.gen_range(nb_bits..modulus as u32);
                 let shift = cks.encrypt_radix(clear_shift as u64, num_blocks);
                 let encrypted_result = executor.execute((&ct, &shift));


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: https://github.com/zama-ai/tfhe-rs-internal/issues/1454

This PR implements the cpu updated version of the shift when overflowing implemented in [PR](https://github.com/zama-ai/tfhe-rs/pull/3617)


> Previously a in a shift, left or right of a
> FheUintX << y, FheUintX >> y (and for FheInt too)
> 
> A modulo by trunctaion was applied to y.
> This worked well when X was a power of 2,
> as the trunctaion meant we did a real y % X modulo, wrapping y to values < X
> However, when X was not a power of two then the modulo was y % (1 << ceil(log2(X))) which meant y could still hold values >= X
> 
> This made the behavior inconsistent between the two cases, and we relied on the user to know about it and handle it.
> 
> This commit changes that behavior to now make 'overshift', i.e shifts where y >= X return 0, (or -1 for right shift of negative
> values).
> This cost one additional scalar comparison, done in parallel of the shift, and a conditional zeroing which, depending on the algorithm and parameters is absorbed or not.
> 

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
