### PR TITLE
feat(gpu): add custom_range PRF + rerand

### DIFF
--- a/backends/tfhe-cuda-backend/cuda/include/integer/integer.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer/integer.h
@@ -42,6 +42,11 @@ enum Direction { Trailing = 0, Leading = 1 };
 
 enum BitValue { Zero = 0, One = 1 };
 
+enum RERAND_MODE {
+  RERAND_WITH_KS = 0,
+  RERAND_WITHOUT_KS = 1,
+};
+
 extern "C" {
 
 typedef struct {
@@ -690,6 +695,27 @@ void cuda_integer_grouped_oprf_custom_range_64_async(
 
 void cleanup_cuda_integer_grouped_oprf_custom_range_64(CudaStreamsFFI streams,
                                                        int8_t **mem_ptr_void);
+
+uint64_t scratch_cuda_integer_grouped_oprf_custom_range_with_rerand_64_async(
+    CudaStreamsFFI streams, int8_t **mem_ptr,
+    CudaLweBootstrapKeyParamsFFI bsk_params,
+    CudaLweKeyswitchKeyParamsFFI ksk_params, uint32_t num_blocks_intermediate,
+    uint32_t message_modulus, uint32_t carry_modulus, bool allocate_gpu_memory,
+    uint32_t message_bits_per_block, uint32_t num_input_random_bits,
+    uint32_t num_scalar_bits, PBS_MS_REDUCTION_T noise_reduction_type,
+    CudaLweKeyswitchKeyParamsFFI rerand_ksk_params, RERAND_MODE rerand_mode);
+
+void cuda_integer_grouped_oprf_custom_range_with_rerand_64_async(
+    CudaStreamsFFI streams, CudaRadixCiphertextFFI *radix_lwe_out,
+    uint32_t num_blocks_intermediate, const void *seeded_lwe_input,
+    const uint64_t *decomposed_scalar, const uint64_t *has_at_least_one_set,
+    uint32_t num_scalars, uint32_t shift,
+    const void *lwe_flattened_encryptions_of_zero_compact_array_in, int8_t *mem,
+    void *const *bsks, void *const *compute_bsks, void *const *ksks,
+    void *const *rerand_ksks);
+
+void cleanup_cuda_integer_grouped_oprf_custom_range_with_rerand_64(
+    CudaStreamsFFI streams, int8_t **mem_ptr_void);
 
 uint64_t scratch_cuda_integer_ilog2_64_async(
     CudaStreamsFFI streams, int8_t **mem_ptr,

--- a/backends/tfhe-cuda-backend/cuda/include/integer/rerand.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer/rerand.h
@@ -2,11 +2,6 @@
 
 #include "integer.h"
 
-enum RERAND_MODE {
-  RERAND_WITH_KS = 0,
-  RERAND_WITHOUT_KS = 1,
-};
-
 extern "C" {
 uint64_t scratch_cuda_rerand_64_async(CudaStreamsFFI streams, int8_t **mem_ptr,
                                       CudaLweKeyswitchKeyParamsFFI ksk_params,

--- a/backends/tfhe-cuda-backend/cuda/src/integer/oprf.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/oprf.cu
@@ -81,3 +81,129 @@ void cleanup_cuda_integer_grouped_oprf_custom_range_64(CudaStreamsFFI streams,
   delete mem_ptr;
   *mem_ptr_void = nullptr;
 }
+
+uint64_t scratch_cuda_integer_grouped_oprf_custom_range_with_rerand_64_async(
+    CudaStreamsFFI streams, int8_t **mem_ptr,
+    CudaLweBootstrapKeyParamsFFI bsk_params,
+    CudaLweKeyswitchKeyParamsFFI ksk_params, uint32_t num_blocks_intermediate,
+    uint32_t message_modulus, uint32_t carry_modulus, bool allocate_gpu_memory,
+    uint32_t message_bits_per_block, uint32_t num_input_random_bits,
+    uint32_t num_scalar_bits, PBS_MS_REDUCTION_T noise_reduction_type,
+    CudaLweKeyswitchKeyParamsFFI rerand_ksk_params, RERAND_MODE rerand_mode) {
+  int_radix_params params(bsk_params, ksk_params, message_modulus,
+                          carry_modulus, noise_reduction_type);
+
+  int_radix_params rerand_params(
+      PBS_TYPE::CLASSICAL, 0, 0, rerand_ksk_params.input_lwe_dimension,
+      rerand_ksk_params.output_lwe_dimension, rerand_ksk_params.level_count,
+      rerand_ksk_params.base_log, 0, 0, 0, message_modulus, carry_modulus,
+      PBS_MS_REDUCTION_T::NO_REDUCTION);
+
+  return scratch_cuda_integer_grouped_oprf_custom_range_with_rerand<uint64_t>(
+      CudaStreams(streams),
+      (int_grouped_oprf_custom_range_with_rerand_memory<uint64_t> **)mem_ptr,
+      params, rerand_params, num_blocks_intermediate, message_bits_per_block,
+      num_input_random_bits, num_scalar_bits, rerand_mode, allocate_gpu_memory);
+}
+
+void cuda_integer_grouped_oprf_custom_range_with_rerand_64_async(
+    CudaStreamsFFI streams, CudaRadixCiphertextFFI *radix_lwe_out,
+    uint32_t num_blocks_intermediate, const void *seeded_lwe_input,
+    const uint64_t *decomposed_scalar, const uint64_t *has_at_least_one_set,
+    uint32_t num_scalars, uint32_t shift,
+    const void *lwe_flattened_encryptions_of_zero_compact_array_in, int8_t *mem,
+    void *const *bsks, void *const *compute_bsks, void *const *ksks,
+    void *const *rerand_ksks) {
+
+  auto mem_ptr =
+      (int_grouped_oprf_custom_range_with_rerand_memory<uint64_t> *)mem;
+
+  switch (mem_ptr->rerand_memory->params.big_lwe_dimension) {
+  case 256:
+    host_integer_grouped_oprf_custom_range_with_rerand<uint64_t,
+                                                       AmortizedDegree<256>>(
+        CudaStreams(streams), radix_lwe_out, num_blocks_intermediate,
+        (const uint64_t *)seeded_lwe_input, decomposed_scalar,
+        has_at_least_one_set, num_scalars, shift,
+        (const uint64_t *)lwe_flattened_encryptions_of_zero_compact_array_in,
+        mem_ptr, bsks, compute_bsks, (uint64_t *const *)ksks,
+        (uint64_t *const *)rerand_ksks);
+    break;
+  case 512:
+    host_integer_grouped_oprf_custom_range_with_rerand<uint64_t,
+                                                       AmortizedDegree<512>>(
+        CudaStreams(streams), radix_lwe_out, num_blocks_intermediate,
+        (const uint64_t *)seeded_lwe_input, decomposed_scalar,
+        has_at_least_one_set, num_scalars, shift,
+        (const uint64_t *)lwe_flattened_encryptions_of_zero_compact_array_in,
+        mem_ptr, bsks, compute_bsks, (uint64_t *const *)ksks,
+        (uint64_t *const *)rerand_ksks);
+    break;
+  case 1024:
+    host_integer_grouped_oprf_custom_range_with_rerand<uint64_t,
+                                                       AmortizedDegree<1024>>(
+        CudaStreams(streams), radix_lwe_out, num_blocks_intermediate,
+        (const uint64_t *)seeded_lwe_input, decomposed_scalar,
+        has_at_least_one_set, num_scalars, shift,
+        (const uint64_t *)lwe_flattened_encryptions_of_zero_compact_array_in,
+        mem_ptr, bsks, compute_bsks, (uint64_t *const *)ksks,
+        (uint64_t *const *)rerand_ksks);
+    break;
+  case 2048:
+    host_integer_grouped_oprf_custom_range_with_rerand<uint64_t,
+                                                       AmortizedDegree<2048>>(
+        CudaStreams(streams), radix_lwe_out, num_blocks_intermediate,
+        (const uint64_t *)seeded_lwe_input, decomposed_scalar,
+        has_at_least_one_set, num_scalars, shift,
+        (const uint64_t *)lwe_flattened_encryptions_of_zero_compact_array_in,
+        mem_ptr, bsks, compute_bsks, (uint64_t *const *)ksks,
+        (uint64_t *const *)rerand_ksks);
+    break;
+  case 4096:
+    host_integer_grouped_oprf_custom_range_with_rerand<uint64_t,
+                                                       AmortizedDegree<4096>>(
+        CudaStreams(streams), radix_lwe_out, num_blocks_intermediate,
+        (const uint64_t *)seeded_lwe_input, decomposed_scalar,
+        has_at_least_one_set, num_scalars, shift,
+        (const uint64_t *)lwe_flattened_encryptions_of_zero_compact_array_in,
+        mem_ptr, bsks, compute_bsks, (uint64_t *const *)ksks,
+        (uint64_t *const *)rerand_ksks);
+    break;
+  case 8192:
+    host_integer_grouped_oprf_custom_range_with_rerand<uint64_t,
+                                                       AmortizedDegree<8192>>(
+        CudaStreams(streams), radix_lwe_out, num_blocks_intermediate,
+        (const uint64_t *)seeded_lwe_input, decomposed_scalar,
+        has_at_least_one_set, num_scalars, shift,
+        (const uint64_t *)lwe_flattened_encryptions_of_zero_compact_array_in,
+        mem_ptr, bsks, compute_bsks, (uint64_t *const *)ksks,
+        (uint64_t *const *)rerand_ksks);
+    break;
+  case 16384:
+    host_integer_grouped_oprf_custom_range_with_rerand<uint64_t,
+                                                       AmortizedDegree<16384>>(
+        CudaStreams(streams), radix_lwe_out, num_blocks_intermediate,
+        (const uint64_t *)seeded_lwe_input, decomposed_scalar,
+        has_at_least_one_set, num_scalars, shift,
+        (const uint64_t *)lwe_flattened_encryptions_of_zero_compact_array_in,
+        mem_ptr, bsks, compute_bsks, (uint64_t *const *)ksks,
+        (uint64_t *const *)rerand_ksks);
+    break;
+  default:
+    PANIC("CUDA error: compact public key dimension not supported. Supported "
+          "dimensions are powers of two in the interval [256..16384].");
+    break;
+  }
+}
+
+void cleanup_cuda_integer_grouped_oprf_custom_range_with_rerand_64(
+    CudaStreamsFFI streams, int8_t **mem_ptr_void) {
+  int_grouped_oprf_custom_range_with_rerand_memory<uint64_t> *mem_ptr =
+      (int_grouped_oprf_custom_range_with_rerand_memory<uint64_t>
+           *)(*mem_ptr_void);
+
+  mem_ptr->release(CudaStreams(streams));
+
+  delete mem_ptr;
+  *mem_ptr_void = nullptr;
+}

--- a/backends/tfhe-cuda-backend/cuda/src/integer/oprf.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/oprf.cuh
@@ -3,6 +3,7 @@
 
 #include "integer/integer.cuh"
 #include "integer/oprf.h"
+#include "integer/rerand.cuh"
 #include "integer/scalar_mul.cuh"
 #include "integer/scalar_shifts.cuh"
 
@@ -132,6 +133,125 @@ void host_integer_grouped_oprf_custom_range(
 
   host_logical_scalar_shift_inplace<Torus>(
       streams, computation_buffer, shift, mem_ptr->logical_scalar_shift_buffer,
+      compute_bsks, ksks, num_blocks_intermediate);
+
+  uint32_t num_blocks_output = radix_lwe_out->num_radix_blocks;
+  uint32_t blocks_to_copy =
+      std::min(num_blocks_output, num_blocks_intermediate);
+
+  if (blocks_to_copy > 0) {
+    copy_radix_ciphertext_slice_async<Torus>(
+        streams.stream(0), streams.gpu_index(0), radix_lwe_out, 0,
+        blocks_to_copy, computation_buffer, 0, blocks_to_copy);
+  }
+
+  if (num_blocks_output > blocks_to_copy) {
+    set_zero_radix_ciphertext_slice_async<Torus>(
+        streams.stream(0), streams.gpu_index(0), radix_lwe_out, blocks_to_copy,
+        num_blocks_output);
+  }
+}
+
+// Composes the plain custom-range OPRF scratch with a re-randomization scratch
+// sized for the freshly generated random blocks.
+template <typename Torus>
+struct int_grouped_oprf_custom_range_with_rerand_memory {
+  int_radix_params params;
+  bool allocate_gpu_memory;
+
+  int_grouped_oprf_custom_range_memory<Torus> *oprf_memory;
+  int_rerand_mem<Torus> *rerand_memory;
+
+  int_grouped_oprf_custom_range_with_rerand_memory(
+      CudaStreams streams, int_radix_params params,
+      int_radix_params rerand_params, uint32_t num_blocks_intermediate,
+      uint32_t message_bits_per_block, uint64_t num_input_random_bits,
+      uint32_t num_scalar_bits, RERAND_MODE rerand_mode,
+      bool allocate_gpu_memory, uint64_t &size_tracker) {
+    this->params = params;
+    this->allocate_gpu_memory = allocate_gpu_memory;
+
+    this->oprf_memory = new int_grouped_oprf_custom_range_memory<Torus>(
+        streams, params, num_blocks_intermediate, message_bits_per_block,
+        num_input_random_bits, num_scalar_bits, allocate_gpu_memory,
+        size_tracker);
+
+    this->rerand_memory = new int_rerand_mem<Torus>(
+        streams, rerand_params, this->oprf_memory->num_random_input_blocks,
+        rerand_mode, allocate_gpu_memory, size_tracker);
+  }
+
+  void release(CudaStreams streams) {
+    this->oprf_memory->release(streams);
+    delete this->oprf_memory;
+    this->oprf_memory = nullptr;
+
+    this->rerand_memory->release(streams);
+    delete this->rerand_memory;
+    this->rerand_memory = nullptr;
+  }
+};
+
+template <typename Torus>
+uint64_t scratch_cuda_integer_grouped_oprf_custom_range_with_rerand(
+    CudaStreams streams,
+    int_grouped_oprf_custom_range_with_rerand_memory<Torus> **mem_ptr,
+    int_radix_params params, int_radix_params rerand_params,
+    uint32_t num_blocks_intermediate, uint32_t message_bits_per_block,
+    uint64_t num_input_random_bits, uint32_t num_scalar_bits,
+    RERAND_MODE rerand_mode, bool allocate_gpu_memory) {
+  uint64_t size_tracker = 0;
+
+  *mem_ptr = new int_grouped_oprf_custom_range_with_rerand_memory<Torus>(
+      streams, params, rerand_params, num_blocks_intermediate,
+      message_bits_per_block, num_input_random_bits, num_scalar_bits,
+      rerand_mode, allocate_gpu_memory, size_tracker);
+
+  return size_tracker;
+}
+
+// Same pipeline as host_integer_grouped_oprf_custom_range, but re-randomizes
+// the freshly generated random blocks after the grouped OPRF and before the
+// range mapping, matching the CPU implementation so the result stays
+// equivalent.
+template <typename Torus, class params>
+void host_integer_grouped_oprf_custom_range_with_rerand(
+    CudaStreams streams, CudaRadixCiphertextFFI *radix_lwe_out,
+    uint32_t num_blocks_intermediate, const Torus *seeded_lwe_input,
+    const Torus *decomposed_scalar, const Torus *has_at_least_one_set,
+    uint32_t num_scalars, uint32_t shift,
+    const Torus *lwe_flattened_encryptions_of_zero_compact_array_in,
+    int_grouped_oprf_custom_range_with_rerand_memory<Torus> *mem_ptr,
+    void *const *bsks, void *const *compute_bsks, Torus *const *ksks,
+    Torus *const *rerand_ksks) {
+
+  auto oprf_mem = mem_ptr->oprf_memory;
+  CudaRadixCiphertextFFI *computation_buffer = oprf_mem->tmp_oprf_output;
+  set_zero_radix_ciphertext_slice_async<Torus>(
+      streams.stream(0), streams.gpu_index(0), computation_buffer, 0,
+      num_blocks_intermediate);
+
+  host_integer_grouped_oprf<Torus>(
+      streams, computation_buffer, seeded_lwe_input,
+      oprf_mem->num_random_input_blocks, oprf_mem->grouped_oprf_memory, bsks);
+
+  // Re-randomization requires NOMINAL input noise, which the grouped OPRF
+  // provides, and only adds an encryption of zero so the value is preserved.
+  // host_rerand_inplace does not refresh computation_buffer's noise metadata,
+  // but that is safe because the following scalar multiply bootstraps the
+  // blocks.
+  host_rerand_inplace<Torus, params>(
+      streams, (Torus *)computation_buffer->ptr,
+      lwe_flattened_encryptions_of_zero_compact_array_in, rerand_ksks,
+      mem_ptr->rerand_memory);
+
+  host_integer_scalar_mul_radix<Torus>(
+      streams, computation_buffer, decomposed_scalar, has_at_least_one_set,
+      oprf_mem->scalar_mul_buffer, compute_bsks, ksks,
+      oprf_mem->params.message_modulus, num_scalars);
+
+  host_logical_scalar_shift_inplace<Torus>(
+      streams, computation_buffer, shift, oprf_mem->logical_scalar_shift_buffer,
       compute_bsks, ksks, num_blocks_intermediate);
 
   uint32_t num_blocks_output = radix_lwe_out->num_radix_blocks;

--- a/backends/tfhe-cuda-backend/src/bindings.rs
+++ b/backends/tfhe-cuda-backend/src/bindings.rs
@@ -310,6 +310,9 @@ pub type Direction = ffi::c_uint;
 pub const BitValue_Zero: BitValue = 0;
 pub const BitValue_One: BitValue = 1;
 pub type BitValue = ffi::c_uint;
+pub const RERAND_MODE_RERAND_WITH_KS: RERAND_MODE = 0;
+pub const RERAND_MODE_RERAND_WITHOUT_KS: RERAND_MODE = 1;
+pub type RERAND_MODE = ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct CudaStreamsFFI {
@@ -1617,6 +1620,48 @@ unsafe extern "C" {
     );
 }
 unsafe extern "C" {
+    pub fn scratch_cuda_integer_grouped_oprf_custom_range_with_rerand_64_async(
+        streams: CudaStreamsFFI,
+        mem_ptr: *mut *mut i8,
+        bsk_params: CudaLweBootstrapKeyParamsFFI,
+        ksk_params: CudaLweKeyswitchKeyParamsFFI,
+        num_blocks_intermediate: u32,
+        message_modulus: u32,
+        carry_modulus: u32,
+        allocate_gpu_memory: bool,
+        message_bits_per_block: u32,
+        num_input_random_bits: u32,
+        num_scalar_bits: u32,
+        noise_reduction_type: PBS_MS_REDUCTION_T,
+        rerand_ksk_params: CudaLweKeyswitchKeyParamsFFI,
+        rerand_mode: RERAND_MODE,
+    ) -> u64;
+}
+unsafe extern "C" {
+    pub fn cuda_integer_grouped_oprf_custom_range_with_rerand_64_async(
+        streams: CudaStreamsFFI,
+        radix_lwe_out: *mut CudaRadixCiphertextFFI,
+        num_blocks_intermediate: u32,
+        seeded_lwe_input: *const ffi::c_void,
+        decomposed_scalar: *const u64,
+        has_at_least_one_set: *const u64,
+        num_scalars: u32,
+        shift: u32,
+        lwe_flattened_encryptions_of_zero_compact_array_in: *const ffi::c_void,
+        mem: *mut i8,
+        bsks: *const *mut ffi::c_void,
+        compute_bsks: *const *mut ffi::c_void,
+        ksks: *const *mut ffi::c_void,
+        rerand_ksks: *const *mut ffi::c_void,
+    );
+}
+unsafe extern "C" {
+    pub fn cleanup_cuda_integer_grouped_oprf_custom_range_with_rerand_64(
+        streams: CudaStreamsFFI,
+        mem_ptr_void: *mut *mut i8,
+    );
+}
+unsafe extern "C" {
     pub fn scratch_cuda_integer_ilog2_64_async(
         streams: CudaStreamsFFI,
         mem_ptr: *mut *mut i8,
@@ -2507,9 +2552,6 @@ unsafe extern "C" {
         mem_ptr_void: *mut *mut i8,
     );
 }
-pub const RERAND_MODE_RERAND_WITH_KS: RERAND_MODE = 0;
-pub const RERAND_MODE_RERAND_WITHOUT_KS: RERAND_MODE = 1;
-pub type RERAND_MODE = ffi::c_uint;
 unsafe extern "C" {
     pub fn scratch_cuda_rerand_64_async(
         streams: CudaStreamsFFI,

--- a/tfhe-benchmark/benches/high_level_api/oprf.rs
+++ b/tfhe-benchmark/benches/high_level_api/oprf.rs
@@ -65,7 +65,7 @@ fn oprf_any_range_bench(c: &mut Criterion, cks: &ClientKey) {
     let bench_type = get_bench_type();
 
     for excluded_upper_bound in [3, 52] {
-        let bound_type = format!("bound_{excluded_upper_bound}",);
+        let bound_type = format!("bound_{excluded_upper_bound}");
         let benchmark_spec = BenchmarkSpec::new_hlapi(
             hlapi_op,
             &param_name,
@@ -147,7 +147,7 @@ fn oprf_any_range_rerand_bench(c: &mut Criterion, cks: &ClientKey) {
     let bench_type = get_bench_type();
 
     for excluded_upper_bound in [3, 52] {
-        let bound_type = format!("bound_{excluded_upper_bound}",);
+        let bound_type = format!("bound_{excluded_upper_bound}");
         let benchmark_spec = BenchmarkSpec::new_hlapi(
             hlapi_op,
             &param_name,
@@ -173,7 +173,8 @@ fn oprf_any_range_rerand_bench(c: &mut Criterion, cks: &ClientKey) {
                                 None,
                                 ReRandomizationMode::UseAvailableMode,
                                 ReRandomizationHashAlgo::Blake3,
-                            ),
+                            )
+                            .unwrap(),
                         );
                     })
                 });

--- a/tfhe-benchmark/benches/high_level_api/oprf.rs
+++ b/tfhe-benchmark/benches/high_level_api/oprf.rs
@@ -4,11 +4,54 @@ use benchmark::params_aliases::BENCH_PARAM_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_K
 
 use benchmark::utilities::{write_to_json, OperatorType};
 use benchmark_spec::tfhe::hlapi::oprf::OprfKind;
-use benchmark_spec::{BenchmarkSpec, BenchmarkType, HlapiBench, OperandType};
-use criterion::{black_box, criterion_group, Criterion};
+use benchmark_spec::{get_bench_type, BenchmarkSpec, BenchmarkType, HlapiBench, OperandType};
+use criterion::{black_box, criterion_group, Criterion, Throughput};
+use rayon::prelude::*;
+#[cfg(any(feature = "gpu", feature = "hpu"))]
+use std::cmp::max;
 use std::num::NonZeroU64;
 use tfhe::keycache::NamedParam;
-use tfhe::{set_server_key, ClientKey, ConfigBuilder, FheUint64, RangeForRandom, Seed, ServerKey};
+use tfhe::shortint::parameters::ReRandomizationParameters;
+#[cfg(any(feature = "gpu", feature = "hpu"))]
+use tfhe::{get_pbs_count, reset_pbs_count};
+use tfhe::{
+    set_server_key, ClientKey, ConfigBuilder, FheUint64, RangeForRandom, ReRandomizationHashAlgo,
+    ReRandomizationMode, Seed, ServerKey,
+};
+
+const OPRF_OUTPUT_BIT_SIZE: u32 = 64;
+
+fn oprf_output_num_blocks(cks: &ClientKey) -> usize {
+    let param = cks.computation_parameters();
+    (OPRF_OUTPUT_BIT_SIZE as f64 / (param.message_modulus().0 as f64).log(2.0)).ceil() as usize
+}
+
+fn oprf_throughput_elements<F>(cks: &ClientKey, run_op: F) -> u64
+where
+    F: Fn(),
+{
+    let num_blocks = oprf_output_num_blocks(cks);
+
+    #[cfg(any(feature = "gpu", feature = "hpu"))]
+    {
+        use benchmark::utilities::throughput_num_threads;
+        reset_pbs_count();
+        run_op();
+        let pbs_count = max(get_pbs_count(), 1);
+        throughput_num_threads(num_blocks, pbs_count)
+    }
+    #[cfg(not(any(feature = "gpu", feature = "hpu")))]
+    {
+        use benchmark::find_optimal_batch::find_optimal_batch;
+        let setup = |_batch_size: usize| ();
+        let run = |_: &mut (), batch_size: usize| {
+            (0..batch_size).into_par_iter().for_each(|_| {
+                run_op();
+            });
+        };
+        find_optimal_batch(run, setup) as u64
+    }
+}
 
 fn oprf_any_range_bench(c: &mut Criterion, cks: &ClientKey) {
     let mut bench_group = c.benchmark_group("oprf");
@@ -19,6 +62,7 @@ fn oprf_any_range_bench(c: &mut Criterion, cks: &ClientKey) {
     let hlapi_op = HlapiBench::Oprf(OprfKind::AnyRange);
     let param = cks.computation_parameters();
     let param_name = param.name();
+    let bench_type = get_bench_type();
 
     for excluded_upper_bound in [3, 52] {
         let bound_type = format!("bound_{excluded_upper_bound}",);
@@ -27,7 +71,7 @@ fn oprf_any_range_bench(c: &mut Criterion, cks: &ClientKey) {
             &param_name,
             OperandType::CipherText,
             Some(bound_type.as_str()),
-            BenchmarkType::Latency,
+            *bench_type,
             None,
         );
         let bench_id = benchmark_spec.to_string();
@@ -36,21 +80,141 @@ fn oprf_any_range_bench(c: &mut Criterion, cks: &ClientKey) {
             NonZeroU64::new(excluded_upper_bound).unwrap(),
         );
 
-        bench_group.bench_function(&bench_id, |b| {
-            b.iter(|| {
-                _ = black_box(FheUint64::generate_oblivious_pseudo_random_custom_range(
-                    Seed(0),
-                    &range,
-                    None,
-                ));
-            })
-        });
+        match bench_type {
+            BenchmarkType::Latency => {
+                bench_group.bench_function(&bench_id, |b| {
+                    b.iter(|| {
+                        _ = black_box(FheUint64::generate_oblivious_pseudo_random_custom_range(
+                            Seed(0),
+                            &range,
+                            None,
+                        ));
+                    })
+                });
+            }
+            BenchmarkType::Throughput => {
+                let elements = oprf_throughput_elements(cks, || {
+                    _ = FheUint64::generate_oblivious_pseudo_random_custom_range(
+                        Seed(0),
+                        &range,
+                        None,
+                    );
+                });
+                bench_group.throughput(Throughput::Elements(elements));
+
+                bench_group.bench_function(&bench_id, |b| {
+                    b.iter(|| {
+                        (0..elements).into_par_iter().for_each(|_| {
+                            _ = black_box(
+                                FheUint64::generate_oblivious_pseudo_random_custom_range(
+                                    Seed(0),
+                                    &range,
+                                    None,
+                                ),
+                            );
+                        })
+                    })
+                });
+            }
+        }
 
         write_to_json(
             &benchmark_spec,
             hlapi_op.to_string(),
             &OperatorType::Atomic,
-            64,
+            OPRF_OUTPUT_BIT_SIZE,
+            vec![],
+        );
+    }
+
+    bench_group.finish()
+}
+
+/// Benchmarks the custom-range PRF fused with re-randomization of the output blocks.
+///
+/// Requires a server key configured with re-randomization support (see the `_cpu`/`_gpu` entry
+/// points). Uses the derived-CPK (no key-switch) mode, which is the configuration the GPU fused
+/// kernel exercises by default.
+fn oprf_any_range_rerand_bench(c: &mut Criterion, cks: &ClientKey) {
+    let mut bench_group = c.benchmark_group("oprf");
+    bench_group
+        .sample_size(15)
+        .measurement_time(std::time::Duration::from_secs(30));
+
+    let hlapi_op = HlapiBench::Oprf(OprfKind::AnyRangeRerand);
+    let param = cks.computation_parameters();
+    let param_name = param.name();
+    let bench_type = get_bench_type();
+
+    for excluded_upper_bound in [3, 52] {
+        let bound_type = format!("bound_{excluded_upper_bound}",);
+        let benchmark_spec = BenchmarkSpec::new_hlapi(
+            hlapi_op,
+            &param_name,
+            OperandType::CipherText,
+            Some(bound_type.as_str()),
+            *bench_type,
+            None,
+        );
+        let bench_id = benchmark_spec.to_string();
+
+        let range = RangeForRandom::new_from_excluded_upper_bound(
+            NonZeroU64::new(excluded_upper_bound).unwrap(),
+        );
+
+        match bench_type {
+            BenchmarkType::Latency => {
+                bench_group.bench_function(&bench_id, |b| {
+                    b.iter(|| {
+                        _ = black_box(
+                            FheUint64::generate_oblivious_pseudo_random_custom_range_and_re_randomize(
+                                Seed(0),
+                                &range,
+                                None,
+                                ReRandomizationMode::UseAvailableMode,
+                                ReRandomizationHashAlgo::Blake3,
+                            ),
+                        );
+                    })
+                });
+            }
+            BenchmarkType::Throughput => {
+                let elements = oprf_throughput_elements(cks, || {
+                    _ = FheUint64::generate_oblivious_pseudo_random_custom_range_and_re_randomize(
+                        Seed(0),
+                        &range,
+                        None,
+                        ReRandomizationMode::UseAvailableMode,
+                        ReRandomizationHashAlgo::Blake3,
+                    )
+                    .unwrap();
+                });
+                bench_group.throughput(Throughput::Elements(elements));
+
+                bench_group.bench_function(&bench_id, |b| {
+                    b.iter(|| {
+                        (0..elements).into_par_iter().for_each(|_| {
+                            _ = black_box(
+                                FheUint64::generate_oblivious_pseudo_random_custom_range_and_re_randomize(
+                                    Seed(0),
+                                    &range,
+                                    None,
+                                    ReRandomizationMode::UseAvailableMode,
+                                    ReRandomizationHashAlgo::Blake3,
+                                )
+                                .unwrap(),
+                            );
+                        })
+                    })
+                });
+            }
+        }
+
+        write_to_json(
+            &benchmark_spec,
+            hlapi_op.to_string(),
+            &OperatorType::Atomic,
+            OPRF_OUTPUT_BIT_SIZE,
             vec![],
         );
     }
@@ -84,8 +248,50 @@ pub fn oprf_any_range_gpu(c: &mut Criterion) {
     oprf_any_range_bench(c, &cks);
 }
 
-#[cfg(not(feature = "gpu"))]
-criterion_group!(oprf_any_range2, oprf_any_range_cpu);
+pub fn oprf_any_range_rerand_cpu(c: &mut Criterion) {
+    let param = BENCH_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+
+    let config = ConfigBuilder::with_custom_parameters(param)
+        .use_dedicated_oprf_key(true)
+        .enable_ciphertext_re_randomization(ReRandomizationParameters::DerivedCPKWithoutKeySwitch)
+        .build();
+    let cks = ClientKey::generate(config);
+    let sks = ServerKey::new(&cks);
+
+    rayon::broadcast(|_| set_server_key(sks.clone()));
+    set_server_key(sks);
+
+    oprf_any_range_rerand_bench(c, &cks);
+}
 
 #[cfg(feature = "gpu")]
-criterion_group!(oprf_any_range2, oprf_any_range_cpu, oprf_any_range_gpu);
+pub fn oprf_any_range_rerand_gpu(c: &mut Criterion) {
+    let param = BENCH_PARAM_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+
+    let config = ConfigBuilder::with_custom_parameters(param)
+        .use_dedicated_oprf_key(true)
+        .enable_ciphertext_re_randomization(ReRandomizationParameters::DerivedCPKWithoutKeySwitch)
+        .build();
+    let cks = ClientKey::generate(config);
+    let sks = tfhe::CompressedServerKey::new(&cks).decompress_to_gpu();
+
+    set_server_key(sks);
+
+    oprf_any_range_rerand_bench(c, &cks);
+}
+
+#[cfg(not(feature = "gpu"))]
+criterion_group!(
+    oprf_any_range2,
+    oprf_any_range_cpu,
+    oprf_any_range_rerand_cpu
+);
+
+#[cfg(feature = "gpu")]
+criterion_group!(
+    oprf_any_range2,
+    oprf_any_range_cpu,
+    oprf_any_range_gpu,
+    oprf_any_range_rerand_cpu,
+    oprf_any_range_rerand_gpu
+);

--- a/tfhe/src/high_level_api/booleans/oprf.rs
+++ b/tfhe/src/high_level_api/booleans/oprf.rs
@@ -24,6 +24,8 @@ impl FheBool {
     ///
     /// set_server_key(server_key);
     ///
+    /// // DANGER: Using a deterministic seed is insecure and only done here to show API usage.
+    /// // The proper way of generating a seed depends on your application.
     /// let ct_res = FheBool::generate_oblivious_pseudo_random(Seed(0));
     ///
     /// let dec_result: bool = ct_res.decrypt(&client_key);

--- a/tfhe/src/high_level_api/booleans/oprf.rs
+++ b/tfhe/src/high_level_api/booleans/oprf.rs
@@ -1,7 +1,9 @@
 use super::{FheBool, InnerBoolean};
 use crate::high_level_api::global_state;
 use crate::high_level_api::keys::InternalServerKey;
-use crate::high_level_api::re_randomization::ReRandomizationMetadata;
+use crate::high_level_api::re_randomization::{
+    ReRandomizationHashAlgo, ReRandomizationMetadata, ReRandomizationMode,
+};
 #[cfg(feature = "gpu")]
 use crate::integer::gpu::ciphertext::boolean_value::CudaBooleanBlock;
 #[cfg(feature = "gpu")]
@@ -83,25 +85,222 @@ impl FheBool {
         });
         Self::new(ciphertext, tag, ReRandomizationMetadata::default())
     }
+
+    /// Generates an encrypted boolean taken uniformly using the given seed.
+    /// The encrypted value is oblivious to the server.
+    /// It can be useful to make server random generation deterministic.
+    ///
+    /// This variant also applies a re-randomization to the output of the PRF.
+    /// Depending on your application you may need to use this variant of the API.
+    ///
+    /// ```rust
+    /// use tfhe::prelude::*;
+    /// use tfhe::shortint::parameters::*;
+    /// use tfhe::{
+    ///     generate_keys, set_server_key, ConfigBuilder, FheBool, ReRandomizationHashAlgo,
+    ///     ReRandomizationMode,
+    /// };
+    ///
+    /// let params = PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+    /// let re_rand_params = ReRandomizationParameters::DerivedCPKWithoutKeySwitch;
+    ///
+    /// let config = ConfigBuilder::with_custom_parameters(params)
+    ///     .enable_ciphertext_re_randomization(re_rand_params)
+    ///     .build();
+    ///
+    /// let (client_key, server_key) = generate_keys(config);
+    ///
+    /// set_server_key(server_key);
+    ///
+    /// let seed = [0u8; 32].as_slice();
+    ///
+    /// let ct_res = FheBool::generate_oblivious_pseudo_random(seed);
+    ///
+    /// // DANGER: Using a deterministic seed is insecure and only done here to show API usage.
+    /// // The proper way of generating a seed depends on your application.
+    /// let ct_res_rerand = FheBool::generate_oblivious_pseudo_random_and_re_randomize(
+    ///     seed,
+    ///     ReRandomizationMode::default(),
+    ///     ReRandomizationHashAlgo::default(),
+    /// )
+    /// .unwrap();
+    ///
+    /// let dec_result: bool = ct_res.decrypt(&client_key);
+    /// let dec_result_rerand: bool = ct_res_rerand.decrypt(&client_key);
+    ///
+    /// // Re-randomization does not change the contained value
+    /// // just the values representing the ciphertext
+    /// assert_eq!(dec_result, dec_result_rerand);
+    /// ```
+    pub fn generate_oblivious_pseudo_random_and_re_randomize<
+        'a,
+        RRD: Into<ReRandomizationMode<'a>>,
+    >(
+        seed: impl OprfSeed,
+        re_randomization_mode: RRD,
+        re_randomization_hash_algo: ReRandomizationHashAlgo,
+    ) -> crate::Result<Self> {
+        let re_randomization_mode: ReRandomizationMode = re_randomization_mode.into();
+        global_state::with_internal_keys(|key| match key {
+            InternalServerKey::Cpu(key) => {
+                let sk = key.pbs_key();
+                let rerand_key =
+                    key.integer_re_randomization_key_from_mode(re_randomization_mode)?;
+
+                // 1 block with 1 bit of data is a boolean
+                let ct_wrapped = key
+                    .oprf_key()
+                    .par_generate_oblivious_pseudo_random_unsigned_integer_bounded_and_re_randomize(
+                        seed,
+                        1,
+                        1,
+                        sk,
+                        &rerand_key,
+                        re_randomization_hash_algo,
+                    )?;
+
+                let ct = ct_wrapped.blocks.into_iter().next().unwrap();
+
+                Ok((
+                    InnerBoolean::Cpu(BooleanBlock::new_unchecked(ct)),
+                    key.tag.clone(),
+                ))
+            }
+            #[cfg(feature = "gpu")]
+            InternalServerKey::Cuda(cuda_key) => {
+                let streams = &cuda_key.streams;
+                let rerand_key =
+                    cuda_key.integer_re_randomization_key_from_mode(re_randomization_mode)?;
+
+                // 1 block with 1 bit of data is a boolean
+                let d_ct: CudaUnsignedRadixCiphertext = cuda_key
+                    .oprf_key()
+                    .par_generate_oblivious_pseudo_random_unsigned_integer_bounded_and_re_randomize(
+                        seed,
+                        1,
+                        1,
+                        cuda_key.pbs_key(),
+                        &rerand_key,
+                        re_randomization_hash_algo,
+                        streams,
+                    )?;
+                Ok((
+                    InnerBoolean::Cuda(CudaBooleanBlock::from_cuda_radix_ciphertext(
+                        d_ct.ciphertext,
+                    )),
+                    cuda_key.tag.clone(),
+                ))
+            }
+            #[cfg(feature = "hpu")]
+            InternalServerKey::Hpu(_device) => {
+                panic!("Hpu does not support random bool generation")
+            }
+        })
+        .map(|(ciphertext, tag)| Self::new(ciphertext, tag, ReRandomizationMetadata::default()))
+    }
 }
 
 #[cfg(test)]
-#[cfg(feature = "gpu")]
 mod test {
+    use super::*;
     use crate::prelude::FheDecrypt;
+    use crate::shortint::parameters::ReRandomizationParameters;
 
     #[test]
     fn test_oprf_boolean() {
         let config = crate::ConfigBuilder::default()
             .use_dedicated_oprf_key(true)
+            .enable_ciphertext_re_randomization(
+                ReRandomizationParameters::DerivedCPKWithoutKeySwitch,
+            )
             .build();
-        let client_key = crate::ClientKey::generate(config);
-        let compressed_server_key = crate::CompressedServerKey::new(&client_key);
-        let gpu_key = compressed_server_key.decompress_to_gpu();
-        crate::set_server_key(gpu_key);
 
-        let rnd = crate::FheBool::generate_oblivious_pseudo_random(crate::Seed(123));
+        let rerand_mode = ReRandomizationMode::UseAvailableMode;
+
+        let client_key = crate::ClientKey::generate(config);
+        let cpu_key = crate::ServerKey::new(&client_key);
+        crate::set_server_key(cpu_key);
+
+        // Make sure seed generation is secure in production, this is a test setup
+        let seed = crate::Seed(rand::random());
+
+        let rnd = FheBool::generate_oblivious_pseudo_random(seed);
         let decrypted_result: bool = rnd.decrypt(&client_key);
-        println!("Random bool: {decrypted_result}");
+
+        for hash_algo in [
+            ReRandomizationHashAlgo::Blake3,
+            ReRandomizationHashAlgo::Shake256,
+        ] {
+            let rnd_rerand = FheBool::generate_oblivious_pseudo_random_and_re_randomize(
+                seed,
+                rerand_mode,
+                hash_algo,
+            )
+            .unwrap();
+
+            let decrypted_result_rerand: bool = rnd_rerand.decrypt(&client_key);
+
+            assert_eq!(decrypted_result, decrypted_result_rerand);
+        }
+    }
+
+    #[cfg(feature = "gpu")]
+    mod gpu {
+        use super::*;
+        #[test]
+        fn test_oprf_boolean() {
+            let config = crate::ConfigBuilder::default()
+                .use_dedicated_oprf_key(true)
+                .enable_ciphertext_re_randomization(
+                    ReRandomizationParameters::DerivedCPKWithoutKeySwitch,
+                )
+                .build();
+
+            let rerand_mode = ReRandomizationMode::UseAvailableMode;
+
+            let client_key = crate::ClientKey::generate(config);
+            let compressed_server_key = crate::CompressedServerKey::new(&client_key);
+
+            // Make sure seed generation is secure in production, this is a test setup
+            let seed = crate::Seed(rand::random());
+
+            let cpu_result = {
+                let cpu_key = compressed_server_key.decompress();
+                crate::set_server_key(cpu_key);
+
+                let rnd = FheBool::generate_oblivious_pseudo_random(seed);
+                let decrypted_result: bool = rnd.decrypt(&client_key);
+
+                decrypted_result
+            };
+            let gpu_result = {
+                let gpu_key = compressed_server_key.decompress_to_gpu();
+                crate::set_server_key(gpu_key);
+
+                let rnd = FheBool::generate_oblivious_pseudo_random(seed);
+                let decrypted_result: bool = rnd.decrypt(&client_key);
+
+                for hash_algo in [
+                    ReRandomizationHashAlgo::Blake3,
+                    ReRandomizationHashAlgo::Shake256,
+                ] {
+                    let rnd_rerand = FheBool::generate_oblivious_pseudo_random_and_re_randomize(
+                        seed,
+                        rerand_mode,
+                        hash_algo,
+                    )
+                    .unwrap();
+
+                    let decrypted_result_rerand: bool = rnd_rerand.decrypt(&client_key);
+
+                    assert_eq!(decrypted_result, decrypted_result_rerand);
+                }
+
+                decrypted_result
+            };
+
+            // Also check CPU and GPU agree
+            assert_eq!(cpu_result, gpu_result, "CPU and GPU disagree on output");
+        }
     }
 }

--- a/tfhe/src/high_level_api/integers/oprf.rs
+++ b/tfhe/src/high_level_api/integers/oprf.rs
@@ -455,9 +455,6 @@ impl<Id: FheUintId> FheUint<Id> {
     }
 
     /// Re-randomizing variant of [`Self::generate_oblivious_pseudo_random_custom_range`].
-    ///
-    /// The GPU backend does not yet expose a re-randomizing custom-range PRF primitive; calling
-    /// this function with a GPU server key currently panics for the non-power-of-two case.
     pub fn generate_oblivious_pseudo_random_custom_range_and_re_randomize<
         'a,
         RRD: Into<ReRandomizationMode<'a>>,
@@ -522,11 +519,38 @@ impl<Id: FheUintId> FheUint<Id> {
                     ))
                 }
                 #[cfg(feature = "gpu")]
-                InternalServerKey::Cuda(_cuda_key) => {
-                    panic!(
-                        "generate_oblivious_pseudo_random_custom_range_and_re_randomize is not yet \
-                        supported on GPU for non-power-of-two ranges."
+                InternalServerKey::Cuda(cuda_key) => {
+                    let streams = &cuda_key.streams;
+                    let message_modulus = cuda_key.message_modulus();
+
+                    let num_input_random_bits = num_input_random_bits_for_max_distance(
+                        excluded_upper_bound,
+                        max_distance,
+                        message_modulus,
                     );
+
+                    let num_blocks_output = Id::num_blocks(message_modulus) as u64;
+
+                    let rerand_key =
+                        cuda_key.integer_re_randomization_key_from_mode(re_randomization_mode)?;
+                    let d_ct: CudaUnsignedRadixCiphertext = cuda_key
+                        .oprf_key()
+                        .par_generate_oblivious_pseudo_random_unsigned_custom_range_and_re_randomize(
+                            seed,
+                            num_input_random_bits,
+                            excluded_upper_bound.get(),
+                            num_blocks_output,
+                            cuda_key.pbs_key(),
+                            &rerand_key,
+                            re_randomization_hash_algo,
+                            streams,
+                        )?;
+
+                    Ok(Self::new(
+                        d_ct,
+                        cuda_key.tag.clone(),
+                        ReRandomizationMetadata::default(),
+                    ))
                 }
                 #[cfg(feature = "hpu")]
                 InternalServerKey::Hpu(_device) => {
@@ -1639,8 +1663,97 @@ mod test {
 
                 assert_eq!(expected_results, gpu_results);
 
-                // TODO add custom_range test for GPU
+                prf_equivalence_subtest_custom_range(&client_key, rerand_mode);
             }
+        }
+
+        /// Asserts that re-randomization leaves the custom_range value unchanged (it only adds an
+        /// encryption of zero). Iterates fixed non-power-of-two bounds so the custom_range path
+        /// (rather than the power-of-two bounded path) is always exercised, for both hash algos.
+        fn custom_range_rerand_equivalence_subtest(
+            client_key: &ClientKey,
+            rerand_mode: ReRandomizationMode<'_>,
+        ) {
+            // Make sure seed generation is secure in production, this is a test setup
+            let seed = Seed(rand::random());
+
+            for excluded_upper_bound in [3u64, 100, 255] {
+                let range = RangeForRandom::new_from_excluded_upper_bound(
+                    NonZeroU64::new(excluded_upper_bound).unwrap(),
+                );
+
+                let baseline =
+                    FheUint8::generate_oblivious_pseudo_random_custom_range(seed, &range, None);
+                let baseline_decrypted: u8 = baseline.decrypt(client_key);
+
+                for hash_algo in [
+                    ReRandomizationHashAlgo::Blake3,
+                    ReRandomizationHashAlgo::Shake256,
+                ] {
+                    let reranded =
+                        FheUint8::generate_oblivious_pseudo_random_custom_range_and_re_randomize(
+                            seed,
+                            &range,
+                            None,
+                            rerand_mode,
+                            hash_algo,
+                        )
+                        .unwrap();
+                    let reranded_decrypted: u8 = reranded.decrypt(client_key);
+
+                    assert_eq!(
+                        baseline_decrypted, reranded_decrypted,
+                        "re-randomization changed the custom_range value for \
+                        excluded_upper_bound={excluded_upper_bound}"
+                    );
+                }
+            }
+        }
+
+        // Covers the DerivedCPKWithoutKeySwitch (no keyswitch) re-randomization mode for the GPU
+        // custom_range path deterministically (the shared subtest above relies on a random bound).
+        #[test]
+        fn test_prf_custom_range_rerand_equivalence_derived_cpk_gpu() {
+            let config = ConfigBuilder::with_custom_parameters(
+                PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+            )
+            .use_dedicated_oprf_key(true)
+            .enable_ciphertext_re_randomization(
+                ReRandomizationParameters::DerivedCPKWithoutKeySwitch,
+            )
+            .build();
+
+            let client_key = ClientKey::generate(config);
+            let server_key = CompressedServerKey::new(&client_key).decompress_to_gpu();
+            set_server_key(server_key);
+
+            custom_range_rerand_equivalence_subtest(
+                &client_key,
+                ReRandomizationMode::UseAvailableMode,
+            );
+        }
+
+        // Covers the legacy dedicated CPK re-randomization mode, exercising the fused kernel's
+        // keyswitch branch that the DerivedCPKWithoutKeySwitch test does not.
+        #[test]
+        fn test_prf_custom_range_rerand_equivalence_legacy_cpk_gpu() {
+            use crate::shortint::parameters::v1_5::meta::gpu::V1_5_META_PARAM_GPU_2_2_MULTI_BIT_GROUP_4_KS_PBS_PKE_TO_BIG_ZKV2_TUNIFORM_2M128;
+
+            let client_key = ClientKey::generate(
+                V1_5_META_PARAM_GPU_2_2_MULTI_BIT_GROUP_4_KS_PBS_PKE_TO_BIG_ZKV2_TUNIFORM_2M128,
+            );
+            let compact_public_key = crate::high_level_api::CompactPublicKey::new(&client_key);
+            let server_key = client_key
+                .generate_compressed_server_key()
+                .decompress_to_gpu();
+            set_server_key(server_key);
+
+            custom_range_rerand_equivalence_subtest(
+                &client_key,
+                ReRandomizationMode::UseLegacyCPKIfNeeded {
+                    cpk: &compact_public_key,
+                },
+            );
         }
 
         #[test]

--- a/tfhe/src/high_level_api/integers/oprf.rs
+++ b/tfhe/src/high_level_api/integers/oprf.rs
@@ -852,7 +852,7 @@ impl<Id: FheIntId> FheInt<Id> {
                 let streams = &cuda_key.streams;
                 cuda_key
                     .oprf_key()
-                    .get_par_generate_oblivious_pseudo_random_unsigned_integer_bounded_size_on_gpu(
+                    .get_par_generate_oblivious_pseudo_random_signed_integer_bounded_size_on_gpu(
                         cuda_key.pbs_key(),
                         streams,
                     )

--- a/tfhe/src/high_level_api/integers/oprf.rs
+++ b/tfhe/src/high_level_api/integers/oprf.rs
@@ -1,7 +1,9 @@
 use super::{FheIntId, FheUint, FheUintId};
 use crate::high_level_api::global_state;
 use crate::high_level_api::keys::InternalServerKey;
-use crate::high_level_api::re_randomization::ReRandomizationMetadata;
+use crate::high_level_api::re_randomization::{
+    ReRandomizationHashAlgo, ReRandomizationMetadata, ReRandomizationMode,
+};
 #[cfg(feature = "gpu")]
 use crate::integer::gpu::ciphertext::{CudaSignedRadixCiphertext, CudaUnsignedRadixCiphertext};
 use crate::shortint::{MessageModulus, OprfSeed};
@@ -67,6 +69,7 @@ impl<Id: FheUintId> FheUint<Id> {
             }
         })
     }
+
     #[cfg(feature = "gpu")]
     /// Returns the amount of memory required to execute generate_oblivious_pseudo_random
     ///
@@ -100,10 +103,74 @@ impl<Id: FheUintId> FheUint<Id> {
             }
         })
     }
+
+    /// Re-randomizing variant of [`Self::generate_oblivious_pseudo_random`].
+    pub fn generate_oblivious_pseudo_random_and_re_randomize<
+        'a,
+        RRD: Into<ReRandomizationMode<'a>>,
+    >(
+        seed: impl OprfSeed,
+        re_randomization_mode: RRD,
+        re_randomization_hash_algo: ReRandomizationHashAlgo,
+    ) -> crate::Result<Self> {
+        let re_randomization_mode: ReRandomizationMode = re_randomization_mode.into();
+        global_state::with_internal_keys(|key| match key {
+            InternalServerKey::Cpu(key) => {
+                let sk = key.pbs_key();
+                let rerand_key =
+                    key.integer_re_randomization_key_from_mode(re_randomization_mode)?;
+                let ct = key
+                    .oprf_key()
+                    .par_generate_oblivious_pseudo_random_unsigned_integer_and_re_randomize(
+                        seed,
+                        Id::num_blocks(key.message_modulus()) as u64,
+                        sk,
+                        &rerand_key,
+                        re_randomization_hash_algo,
+                    )?;
+
+                Ok(Self::new(
+                    ct,
+                    key.tag.clone(),
+                    ReRandomizationMetadata::default(),
+                ))
+            }
+            #[cfg(feature = "gpu")]
+            InternalServerKey::Cuda(cuda_key) => {
+                let streams = &cuda_key.streams;
+                let rerand_key =
+                    cuda_key.integer_re_randomization_key_from_mode(re_randomization_mode)?;
+                let d_ct: CudaUnsignedRadixCiphertext = cuda_key
+                    .oprf_key()
+                    .par_generate_oblivious_pseudo_random_unsigned_integer_and_re_randomize(
+                        seed,
+                        Id::num_blocks(cuda_key.message_modulus()) as u64,
+                        cuda_key.pbs_key(),
+                        &rerand_key,
+                        re_randomization_hash_algo,
+                        streams,
+                    )?;
+
+                Ok(Self::new(
+                    d_ct,
+                    cuda_key.tag.clone(),
+                    ReRandomizationMetadata::default(),
+                ))
+            }
+            #[cfg(feature = "hpu")]
+            InternalServerKey::Hpu(_device) => {
+                panic!("Hpu does not support this operation yet.")
+            }
+        })
+    }
+
     /// Generates an encrypted unsigned integer
     /// taken uniformly in `[0, 2^random_bits_count[` using the given seed.
     /// The encrypted value is oblivious to the server.
     /// It can be useful to make server random generation deterministic.
+    ///
+    /// WARNING: If the requested `random_bits_count` is 0, then the returned ciphertext is a
+    /// trivial encryption of 0.
     ///
     /// ```rust
     /// use tfhe::prelude::FheDecrypt;
@@ -158,6 +225,72 @@ impl<Id: FheUintId> FheUint<Id> {
                     cuda_key.tag.clone(),
                     ReRandomizationMetadata::default(),
                 )
+            }
+            #[cfg(feature = "hpu")]
+            InternalServerKey::Hpu(_device) => {
+                panic!("Hpu does not support this operation yet.")
+            }
+        })
+    }
+
+    /// Re-randomizing variant of [`Self::generate_oblivious_pseudo_random_bounded`].
+    ///
+    /// WARNING: If the requested `random_bits_count` is 0, then the returned ciphertext is a
+    /// trivial encryption of 0.
+    pub fn generate_oblivious_pseudo_random_bounded_and_re_randomize<
+        'a,
+        RRD: Into<ReRandomizationMode<'a>>,
+    >(
+        seed: impl OprfSeed,
+        random_bits_count: u64,
+        re_randomization_mode: RRD,
+        re_randomization_hash_algo: ReRandomizationHashAlgo,
+    ) -> crate::Result<Self> {
+        let re_randomization_mode: ReRandomizationMode = re_randomization_mode.into();
+        global_state::with_internal_keys(|key| match key {
+            InternalServerKey::Cpu(key) => {
+                let sk = key.pbs_key();
+                let rerand_key =
+                    key.integer_re_randomization_key_from_mode(re_randomization_mode)?;
+                let ct = key
+                    .oprf_key()
+                    .par_generate_oblivious_pseudo_random_unsigned_integer_bounded_and_re_randomize(
+                        seed,
+                        random_bits_count,
+                        Id::num_blocks(key.message_modulus()) as u64,
+                        sk,
+                        &rerand_key,
+                        re_randomization_hash_algo,
+                    )?;
+
+                Ok(Self::new(
+                    ct,
+                    key.tag.clone(),
+                    ReRandomizationMetadata::default(),
+                ))
+            }
+            #[cfg(feature = "gpu")]
+            InternalServerKey::Cuda(cuda_key) => {
+                let streams = &cuda_key.streams;
+                let rerand_key =
+                    cuda_key.integer_re_randomization_key_from_mode(re_randomization_mode)?;
+                let d_ct: CudaUnsignedRadixCiphertext = cuda_key
+                    .oprf_key()
+                    .par_generate_oblivious_pseudo_random_unsigned_integer_bounded_and_re_randomize(
+                        seed,
+                        random_bits_count,
+                        Id::num_blocks(cuda_key.message_modulus()) as u64,
+                        cuda_key.pbs_key(),
+                        &rerand_key,
+                        re_randomization_hash_algo,
+                        streams,
+                    )?;
+
+                Ok(Self::new(
+                    d_ct,
+                    cuda_key.tag.clone(),
+                    ReRandomizationMetadata::default(),
+                ))
             }
             #[cfg(feature = "hpu")]
             InternalServerKey::Hpu(_device) => {
@@ -320,6 +453,88 @@ impl<Id: FheUintId> FheUint<Id> {
             }
         })
     }
+
+    /// Re-randomizing variant of [`Self::generate_oblivious_pseudo_random_custom_range`].
+    ///
+    /// The GPU backend does not yet expose a re-randomizing custom-range PRF primitive; calling
+    /// this function with a GPU server key currently panics for the non-power-of-two case.
+    pub fn generate_oblivious_pseudo_random_custom_range_and_re_randomize<
+        'a,
+        RRD: Into<ReRandomizationMode<'a>>,
+    >(
+        seed: impl OprfSeed,
+        range: &RangeForRandom,
+        max_distance: Option<f64>,
+        re_randomization_mode: RRD,
+        re_randomization_hash_algo: ReRandomizationHashAlgo,
+    ) -> crate::Result<Self> {
+        let excluded_upper_bound = range.excluded_upper_bound;
+
+        if excluded_upper_bound.is_power_of_two() {
+            let random_bits_count = excluded_upper_bound.ilog2() as u64;
+
+            Self::generate_oblivious_pseudo_random_bounded_and_re_randomize(
+                seed,
+                random_bits_count,
+                re_randomization_mode,
+                re_randomization_hash_algo,
+            )
+        } else {
+            let max_distance = max_distance.unwrap_or_else(|| 2_f64.powi(-128));
+
+            assert!(
+                0_f64 < max_distance && max_distance < 1_f64,
+                "max_distance (={max_distance}) should be in ]0, 1["
+            );
+
+            let re_randomization_mode: ReRandomizationMode = re_randomization_mode.into();
+            global_state::with_internal_keys(|key| match key {
+                InternalServerKey::Cpu(key) => {
+                    let message_modulus = key.message_modulus();
+
+                    let num_input_random_bits = num_input_random_bits_for_max_distance(
+                        excluded_upper_bound,
+                        max_distance,
+                        message_modulus,
+                    );
+
+                    let num_blocks_output = Id::num_blocks(key.message_modulus()) as u64;
+
+                    let sk = key.pbs_key();
+                    let rerand_key =
+                        key.integer_re_randomization_key_from_mode(re_randomization_mode)?;
+                    let ct = key
+                        .oprf_key()
+                        .par_generate_oblivious_pseudo_random_unsigned_custom_range_and_re_randomize(
+                            seed,
+                            num_input_random_bits,
+                            excluded_upper_bound,
+                            num_blocks_output,
+                            sk,
+                            &rerand_key,
+                            re_randomization_hash_algo,
+                        )?;
+
+                    Ok(Self::new(
+                        ct,
+                        key.tag.clone(),
+                        ReRandomizationMetadata::default(),
+                    ))
+                }
+                #[cfg(feature = "gpu")]
+                InternalServerKey::Cuda(_cuda_key) => {
+                    panic!(
+                        "generate_oblivious_pseudo_random_custom_range_and_re_randomize is not yet \
+                        supported on GPU for non-power-of-two ranges."
+                    );
+                }
+                #[cfg(feature = "hpu")]
+                InternalServerKey::Hpu(_device) => {
+                    panic!("Hpu does not support this operation yet.")
+                }
+            })
+        }
+    }
 }
 
 impl<Id: FheIntId> FheInt<Id> {
@@ -416,10 +631,74 @@ impl<Id: FheIntId> FheInt<Id> {
             }
         })
     }
+
+    /// Re-randomizing variant of [`Self::generate_oblivious_pseudo_random`].
+    pub fn generate_oblivious_pseudo_random_and_re_randomize<
+        'a,
+        RRD: Into<ReRandomizationMode<'a>>,
+    >(
+        seed: impl OprfSeed,
+        re_randomization_mode: RRD,
+        re_randomization_hash_algo: ReRandomizationHashAlgo,
+    ) -> crate::Result<Self> {
+        let re_randomization_mode: ReRandomizationMode = re_randomization_mode.into();
+        global_state::with_internal_keys(|key| match key {
+            InternalServerKey::Cpu(key) => {
+                let sk = key.pbs_key();
+                let rerand_key =
+                    key.integer_re_randomization_key_from_mode(re_randomization_mode)?;
+                let ct = key
+                    .oprf_key()
+                    .par_generate_oblivious_pseudo_random_signed_integer_and_re_randomize(
+                        seed,
+                        Id::num_blocks(key.message_modulus()) as u64,
+                        sk,
+                        &rerand_key,
+                        re_randomization_hash_algo,
+                    )?;
+
+                Ok(Self::new(
+                    ct,
+                    key.tag.clone(),
+                    ReRandomizationMetadata::default(),
+                ))
+            }
+            #[cfg(feature = "gpu")]
+            InternalServerKey::Cuda(cuda_key) => {
+                let streams = &cuda_key.streams;
+                let rerand_key =
+                    cuda_key.integer_re_randomization_key_from_mode(re_randomization_mode)?;
+                let d_ct: CudaSignedRadixCiphertext = cuda_key
+                    .oprf_key()
+                    .par_generate_oblivious_pseudo_random_signed_integer_and_re_randomize(
+                        seed,
+                        Id::num_blocks(cuda_key.message_modulus()) as u64,
+                        cuda_key.pbs_key(),
+                        &rerand_key,
+                        re_randomization_hash_algo,
+                        streams,
+                    )?;
+
+                Ok(Self::new(
+                    d_ct,
+                    cuda_key.tag.clone(),
+                    ReRandomizationMetadata::default(),
+                ))
+            }
+            #[cfg(feature = "hpu")]
+            InternalServerKey::Hpu(_device) => {
+                panic!("Hpu does not support this operation yet.")
+            }
+        })
+    }
+
     /// Generates an encrypted signed integer
     /// taken uniformly in `[0, 2^random_bits_count[` using the given seed.
     /// The encrypted value is oblivious to the server.
     /// It can be useful to make server random generation deterministic.
+    ///
+    /// WARNING: If the requested `random_bits_count` is 0, then the returned ciphertext is a
+    /// trivial encryption of 0.
     ///
     /// ```rust
     /// use tfhe::prelude::FheDecrypt;
@@ -482,6 +761,73 @@ impl<Id: FheIntId> FheInt<Id> {
             }
         })
     }
+
+    /// Re-randomizing variant of [`Self::generate_oblivious_pseudo_random_bounded`].
+    ///
+    /// WARNING: If the requested `random_bits_count` is 0, then the returned ciphertext is a
+    /// trivial encryption of 0.
+    pub fn generate_oblivious_pseudo_random_bounded_and_re_randomize<
+        'a,
+        RRD: Into<ReRandomizationMode<'a>>,
+    >(
+        seed: impl OprfSeed,
+        random_bits_count: u64,
+        re_randomization_mode: RRD,
+        re_randomization_hash_algo: ReRandomizationHashAlgo,
+    ) -> crate::Result<Self> {
+        let re_randomization_mode: ReRandomizationMode = re_randomization_mode.into();
+        global_state::with_internal_keys(|key| match key {
+            InternalServerKey::Cpu(key) => {
+                let sk = key.pbs_key();
+                let rerand_key =
+                    key.integer_re_randomization_key_from_mode(re_randomization_mode)?;
+                let ct = key
+                    .oprf_key()
+                    .par_generate_oblivious_pseudo_random_signed_integer_bounded_and_re_randomize(
+                        seed,
+                        random_bits_count,
+                        Id::num_blocks(key.message_modulus()) as u64,
+                        sk,
+                        &rerand_key,
+                        re_randomization_hash_algo,
+                    )?;
+
+                Ok(Self::new(
+                    ct,
+                    key.tag.clone(),
+                    ReRandomizationMetadata::default(),
+                ))
+            }
+            #[cfg(feature = "gpu")]
+            InternalServerKey::Cuda(cuda_key) => {
+                let streams = &cuda_key.streams;
+                let rerand_key =
+                    cuda_key.integer_re_randomization_key_from_mode(re_randomization_mode)?;
+                let d_ct: CudaSignedRadixCiphertext = cuda_key
+                    .oprf_key()
+                    .par_generate_oblivious_pseudo_random_signed_integer_bounded_and_re_randomize(
+                        seed,
+                        random_bits_count,
+                        Id::num_blocks(cuda_key.message_modulus()) as u64,
+                        cuda_key.pbs_key(),
+                        &rerand_key,
+                        re_randomization_hash_algo,
+                        streams,
+                    )?;
+
+                Ok(Self::new(
+                    d_ct,
+                    cuda_key.tag.clone(),
+                    ReRandomizationMetadata::default(),
+                ))
+            }
+            #[cfg(feature = "hpu")]
+            InternalServerKey::Hpu(_device) => {
+                panic!("Hpu does not support this operation yet.")
+            }
+        })
+    }
+
     #[cfg(feature = "gpu")]
     /// Returns the amount of memory required to execute generate_oblivious_pseudo_random_bounded
     ///
@@ -605,8 +951,10 @@ mod test {
         TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
         TEST_PARAM_MESSAGE_2_CARRY_2_PBS_KS_GAUSSIAN_2M128,
     };
-    use crate::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS32_PBS_TUNIFORM_2M128;
-    use crate::{generate_keys, set_server_key, ConfigBuilder, FheInt8, FheUint8, Seed};
+    use crate::shortint::parameters::{
+        ReRandomizationParameters, PARAM_MESSAGE_2_CARRY_2_KS32_PBS_TUNIFORM_2M128,
+    };
+    use crate::{generate_keys, set_server_key, ClientKey, ConfigBuilder, FheInt8, FheUint8, Seed};
     use num_bigint::BigUint;
     use rand::{thread_rng, Rng};
     use rayon::iter::{IntoParallelIterator, ParallelIterator};
@@ -909,24 +1257,247 @@ mod test {
             TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
         )
         .use_dedicated_oprf_key(true)
+        .enable_ciphertext_re_randomization(ReRandomizationParameters::DerivedCPKWithoutKeySwitch)
         .build();
 
         let (client_key, server_key) = generate_keys(config);
         set_server_key(server_key);
 
-        // Do not use static seed in production
-        let ct_unsigned_bounded = FheUint8::generate_oblivious_pseudo_random_bounded(Seed(0), 0);
-        assert!(ct_unsigned_bounded.is_trivial());
-        let result_unsigned_bounded: u8 = ct_unsigned_bounded.decrypt(&client_key);
-        // PRF with 0 bits is equivalent to modulo 1 meaning only 0 is generated
-        assert_eq!(result_unsigned_bounded, 0);
+        {
+            // Do not use static seed in production
+            let ct_unsigned_bounded =
+                FheUint8::generate_oblivious_pseudo_random_bounded(Seed(0), 0);
+            assert!(ct_unsigned_bounded.is_trivial());
+            let result_unsigned_bounded: u8 = ct_unsigned_bounded.decrypt(&client_key);
+            // PRF with 0 bits is equivalent to modulo 1 meaning only 0 is generated
+            assert_eq!(result_unsigned_bounded, 0);
+        }
 
-        // Do not use static seed in production
-        let ct_signed_bounded = FheInt8::generate_oblivious_pseudo_random_bounded(Seed(0), 0);
-        assert!(ct_signed_bounded.is_trivial());
-        let result_signed_bounded: i8 = ct_signed_bounded.decrypt(&client_key);
-        // PRF with 0 bits is equivalent to modulo 1 meaning only 0 is generated
-        assert_eq!(result_signed_bounded, 0);
+        {
+            // Do not use static seed in production
+            let ct_signed_bounded = FheInt8::generate_oblivious_pseudo_random_bounded(Seed(0), 0);
+            assert!(ct_signed_bounded.is_trivial());
+            let result_signed_bounded: i8 = ct_signed_bounded.decrypt(&client_key);
+            // PRF with 0 bits is equivalent to modulo 1 meaning only 0 is generated
+            assert_eq!(result_signed_bounded, 0);
+        }
+
+        {
+            for rerand_algo in [
+                ReRandomizationHashAlgo::Blake3,
+                ReRandomizationHashAlgo::Shake256,
+            ] {
+                // Do not use static seed in production
+                let ct_unsigned_bounded =
+                    FheUint8::generate_oblivious_pseudo_random_bounded_and_re_randomize(
+                        Seed(0),
+                        0,
+                        ReRandomizationMode::UseAvailableMode,
+                        rerand_algo,
+                    )
+                    .unwrap();
+                assert!(ct_unsigned_bounded.is_trivial());
+                let result_unsigned_bounded: u8 = ct_unsigned_bounded.decrypt(&client_key);
+                // PRF with 0 bits is equivalent to modulo 1 meaning only 0 is generated
+                assert_eq!(result_unsigned_bounded, 0);
+            }
+        }
+
+        {
+            for rerand_algo in [
+                ReRandomizationHashAlgo::Blake3,
+                ReRandomizationHashAlgo::Shake256,
+            ] {
+                // Do not use static seed in production
+                let ct_signed_bounded =
+                    FheInt8::generate_oblivious_pseudo_random_bounded_and_re_randomize(
+                        Seed(0),
+                        0,
+                        ReRandomizationMode::UseAvailableMode,
+                        rerand_algo,
+                    )
+                    .unwrap();
+                assert!(ct_signed_bounded.is_trivial());
+                let result_signed_bounded: i8 = ct_signed_bounded.decrypt(&client_key);
+                // PRF with 0 bits is equivalent to modulo 1 meaning only 0 is generated
+                assert_eq!(result_signed_bounded, 0);
+            }
+        }
+    }
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    struct FullAndBoundedResults {
+        seed: Seed,
+        unsigned_full: u8,
+        signed_full: i8,
+        bit_count_bounded: u64,
+        unsigned_bounded: u8,
+        signed_bounded: i8,
+    }
+
+    fn prf_equivalence_subtests_full_and_bounded(
+        client_key: &ClientKey,
+        rerand_mode: ReRandomizationMode,
+        seed: Option<Seed>,
+        bit_count_bounded: Option<u64>,
+    ) -> FullAndBoundedResults {
+        // Make sure seed generation is secure in production, this is a test setup
+        let seed = seed.unwrap_or_else(|| crate::Seed(rand::random()));
+
+        // Full sub-case
+        let (unsigned_full, signed_full) = {
+            let unsigned_rnd = FheUint8::generate_oblivious_pseudo_random(seed);
+            let signed_rnd = FheInt8::generate_oblivious_pseudo_random(seed);
+
+            let unsigned_decrypted_result: u8 = unsigned_rnd.decrypt(client_key);
+            let signed_decrypted_result: i8 = signed_rnd.decrypt(client_key);
+
+            for hash_algo in [
+                ReRandomizationHashAlgo::Blake3,
+                ReRandomizationHashAlgo::Shake256,
+            ] {
+                let unsigned_rnd_rerand =
+                    FheUint8::generate_oblivious_pseudo_random_and_re_randomize(
+                        seed,
+                        rerand_mode,
+                        hash_algo,
+                    )
+                    .unwrap();
+                let signed_rnd_rerand = FheInt8::generate_oblivious_pseudo_random_and_re_randomize(
+                    seed,
+                    rerand_mode,
+                    hash_algo,
+                )
+                .unwrap();
+
+                let decrypted_unsigned_result_rerand: u8 = unsigned_rnd_rerand.decrypt(client_key);
+                let decrypted_signed_result_rerand: i8 = signed_rnd_rerand.decrypt(client_key);
+
+                assert_eq!(unsigned_decrypted_result, decrypted_unsigned_result_rerand);
+                assert_eq!(signed_decrypted_result, decrypted_signed_result_rerand);
+            }
+
+            (unsigned_decrypted_result, signed_decrypted_result)
+        };
+
+        // Bounded sub-case
+        let (bit_count_bounded, unsigned_bounded, signed_bounded) = {
+            // Case zero bits handled by test_oprf_bounded_zero
+            let bit_count_bounded: u64 = bit_count_bounded
+                .unwrap_or_else(|| rand::thread_rng().gen_range(1..u8::BITS).into())
+                .max(1);
+
+            let unsigned_rnd =
+                FheUint8::generate_oblivious_pseudo_random_bounded(seed, bit_count_bounded);
+            let signed_rnd =
+                FheInt8::generate_oblivious_pseudo_random_bounded(seed, bit_count_bounded);
+
+            let unsigned_decrypted_result: u8 = unsigned_rnd.decrypt(client_key);
+            let signed_decrypted_result: i8 = signed_rnd.decrypt(client_key);
+
+            for hash_algo in [
+                ReRandomizationHashAlgo::Blake3,
+                ReRandomizationHashAlgo::Shake256,
+            ] {
+                let unsigned_rnd_rerand =
+                    FheUint8::generate_oblivious_pseudo_random_bounded_and_re_randomize(
+                        seed,
+                        bit_count_bounded,
+                        rerand_mode,
+                        hash_algo,
+                    )
+                    .unwrap();
+                let signed_rnd_rerand =
+                    FheInt8::generate_oblivious_pseudo_random_bounded_and_re_randomize(
+                        seed,
+                        bit_count_bounded,
+                        rerand_mode,
+                        hash_algo,
+                    )
+                    .unwrap();
+
+                let decrypted_unsigned_result_rerand: u8 = unsigned_rnd_rerand.decrypt(client_key);
+                let decrypted_signed_result_rerand: i8 = signed_rnd_rerand.decrypt(client_key);
+
+                assert_eq!(unsigned_decrypted_result, decrypted_unsigned_result_rerand);
+                assert_eq!(signed_decrypted_result, decrypted_signed_result_rerand);
+            }
+
+            (
+                bit_count_bounded,
+                unsigned_decrypted_result,
+                signed_decrypted_result,
+            )
+        };
+
+        FullAndBoundedResults {
+            seed,
+            unsigned_full,
+            signed_full,
+            bit_count_bounded,
+            unsigned_bounded,
+            signed_bounded,
+        }
+    }
+
+    // TODO fuse in the other function once GPU is available for custom_range
+    fn prf_equivalence_subtest_custom_range(
+        client_key: &ClientKey,
+        rerand_mode: ReRandomizationMode,
+    ) {
+        // Make sure seed generation is secure in production, this is a test setup
+        let seed = crate::Seed(rand::random());
+
+        // Custom Range
+        {
+            // Case zero bits handled by test_oprf_bounded_zero
+            let inclusive_upper_bound: u64 = rand::thread_rng().gen_range(1..=u8::MAX).into();
+            let exclusive_upper_bound = NonZeroU64::new(inclusive_upper_bound + 1).unwrap();
+            let range = RangeForRandom::new_from_excluded_upper_bound(exclusive_upper_bound);
+
+            let unsigned_rnd =
+                FheUint8::generate_oblivious_pseudo_random_custom_range(seed, &range, None);
+
+            let unsigned_decrypted_result: u8 = unsigned_rnd.decrypt(client_key);
+
+            for hash_algo in [
+                ReRandomizationHashAlgo::Blake3,
+                ReRandomizationHashAlgo::Shake256,
+            ] {
+                let unsigned_rnd_rerand =
+                    FheUint8::generate_oblivious_pseudo_random_custom_range_and_re_randomize(
+                        seed,
+                        &range,
+                        None,
+                        rerand_mode,
+                        hash_algo,
+                    )
+                    .unwrap();
+
+                let decrypted_unsigned_result_rerand: u8 = unsigned_rnd_rerand.decrypt(client_key);
+
+                assert_eq!(unsigned_decrypted_result, decrypted_unsigned_result_rerand);
+            }
+        }
+    }
+
+    #[test]
+    fn test_prf_and_re_rand_equivalence() {
+        let config = ConfigBuilder::with_custom_parameters(
+            TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+        )
+        .use_dedicated_oprf_key(true)
+        .enable_ciphertext_re_randomization(ReRandomizationParameters::DerivedCPKWithoutKeySwitch)
+        .build();
+
+        let rerand_mode = ReRandomizationMode::UseAvailableMode;
+
+        let client_key = crate::ClientKey::generate(config);
+        let cpu_key = crate::ServerKey::new(&client_key);
+        crate::set_server_key(cpu_key);
+
+        let _ = prf_equivalence_subtests_full_and_bounded(&client_key, rerand_mode, None, None);
+        prf_equivalence_subtest_custom_range(&client_key, rerand_mode);
     }
 
     #[cfg(feature = "gpu")]
@@ -934,7 +1505,11 @@ mod test {
         use super::*;
         use crate::core_crypto::gpu::get_number_of_gpus;
         use crate::prelude::check_valid_cuda_malloc_assert_oom;
-        use crate::shortint::parameters::PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+        use crate::shortint::parameters::{
+            AtomicPatternParameters,
+            PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+            PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+        };
         use crate::{
             clear_gpu_thread_locals, ClientKey, CompressedServerKey, FheInt128, FheUint32,
             FheUint64, GpuIndex,
@@ -945,24 +1520,126 @@ mod test {
 
         #[test]
         fn test_oprf_bounded_zero() {
-            for setup_fn in crate::high_level_api::integers::unsigned::tests::gpu::GPU_SETUP_FN {
-                let client_key = setup_fn();
+            for params in [
+                AtomicPatternParameters::from(
+                    PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+                ),
+                AtomicPatternParameters::from(PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128),
+            ] {
+                let config = ConfigBuilder::with_custom_parameters(params)
+                    .use_dedicated_oprf_key(true)
+                    .enable_ciphertext_re_randomization(
+                        ReRandomizationParameters::DerivedCPKWithoutKeySwitch,
+                    )
+                    .build();
 
-                // Do not use static seed in production
-                let ct_unsigned_bounded =
-                    FheUint8::generate_oblivious_pseudo_random_bounded(Seed(0), 0);
-                assert!(ct_unsigned_bounded.is_trivial());
-                let result_unsigned_bounded: u8 = ct_unsigned_bounded.decrypt(&client_key);
-                // PRF with 0 bits is equivalent to modulo 1 meaning only 0 is generated
-                assert_eq!(result_unsigned_bounded, 0);
+                let client_key = ClientKey::generate(config);
+                let compressed_sk = CompressedServerKey::new(&client_key);
+                let server_key = compressed_sk.decompress_to_gpu();
+                set_server_key(server_key);
 
-                // Do not use static seed in production
-                let ct_signed_bounded =
-                    FheInt8::generate_oblivious_pseudo_random_bounded(Seed(0), 0);
-                assert!(ct_signed_bounded.is_trivial());
-                let result_signed_bounded: i8 = ct_signed_bounded.decrypt(&client_key);
-                // PRF with 0 bits is equivalent to modulo 1 meaning only 0 is generated
-                assert_eq!(result_signed_bounded, 0);
+                {
+                    // Do not use static seed in production
+                    let ct_unsigned_bounded =
+                        FheUint8::generate_oblivious_pseudo_random_bounded(Seed(0), 0);
+                    assert!(ct_unsigned_bounded.is_trivial());
+                    let result_unsigned_bounded: u8 = ct_unsigned_bounded.decrypt(&client_key);
+                    // PRF with 0 bits is equivalent to modulo 1 meaning only 0 is generated
+                    assert_eq!(result_unsigned_bounded, 0);
+                }
+
+                {
+                    // Do not use static seed in production
+                    let ct_signed_bounded =
+                        FheInt8::generate_oblivious_pseudo_random_bounded(Seed(0), 0);
+                    assert!(ct_signed_bounded.is_trivial());
+                    let result_signed_bounded: i8 = ct_signed_bounded.decrypt(&client_key);
+                    // PRF with 0 bits is equivalent to modulo 1 meaning only 0 is generated
+                    assert_eq!(result_signed_bounded, 0);
+                }
+
+                {
+                    for rerand_algo in [
+                        ReRandomizationHashAlgo::Blake3,
+                        ReRandomizationHashAlgo::Shake256,
+                    ] {
+                        // Do not use static seed in production
+                        let ct_unsigned_bounded =
+                            FheUint8::generate_oblivious_pseudo_random_bounded_and_re_randomize(
+                                Seed(0),
+                                0,
+                                ReRandomizationMode::UseAvailableMode,
+                                rerand_algo,
+                            )
+                            .unwrap();
+                        assert!(ct_unsigned_bounded.is_trivial());
+                        let result_unsigned_bounded: u8 = ct_unsigned_bounded.decrypt(&client_key);
+                        // PRF with 0 bits is equivalent to modulo 1 meaning only 0 is generated
+                        assert_eq!(result_unsigned_bounded, 0);
+                    }
+                }
+
+                {
+                    for rerand_algo in [
+                        ReRandomizationHashAlgo::Blake3,
+                        ReRandomizationHashAlgo::Shake256,
+                    ] {
+                        // Do not use static seed in production
+                        let ct_signed_bounded =
+                            FheInt8::generate_oblivious_pseudo_random_bounded_and_re_randomize(
+                                Seed(0),
+                                0,
+                                ReRandomizationMode::UseAvailableMode,
+                                rerand_algo,
+                            )
+                            .unwrap();
+                        assert!(ct_signed_bounded.is_trivial());
+                        let result_signed_bounded: i8 = ct_signed_bounded.decrypt(&client_key);
+                        // PRF with 0 bits is equivalent to modulo 1 meaning only 0 is generated
+                        assert_eq!(result_signed_bounded, 0);
+                    }
+                }
+            }
+        }
+
+        #[test]
+        fn test_prf_and_re_rand_equivalence() {
+            for params in [
+                AtomicPatternParameters::from(
+                    PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+                ),
+                AtomicPatternParameters::from(PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128),
+            ] {
+                let config = ConfigBuilder::with_custom_parameters(params)
+                    .use_dedicated_oprf_key(true)
+                    .enable_ciphertext_re_randomization(
+                        ReRandomizationParameters::DerivedCPKWithoutKeySwitch,
+                    )
+                    .build();
+
+                let client_key = ClientKey::generate(config);
+                let compressed_sk = CompressedServerKey::new(&client_key);
+                let rerand_mode = ReRandomizationMode::UseAvailableMode;
+
+                let cpu_key = compressed_sk.decompress();
+                crate::set_server_key(cpu_key);
+
+                let expected_results =
+                    prf_equivalence_subtests_full_and_bounded(&client_key, rerand_mode, None, None);
+
+                let server_key = compressed_sk.decompress_to_gpu();
+                set_server_key(server_key);
+
+                let gpu_results = prf_equivalence_subtests_full_and_bounded(
+                    &client_key,
+                    rerand_mode,
+                    Some(expected_results.seed),
+                    Some(expected_results.bit_count_bounded),
+                );
+
+                assert_eq!(expected_results, gpu_results);
+
+                // TODO add custom_range test for GPU
             }
         }
 

--- a/tfhe/src/high_level_api/integers/oprf.rs
+++ b/tfhe/src/high_level_api/integers/oprf.rs
@@ -23,6 +23,8 @@ impl<Id: FheUintId> FheUint<Id> {
     ///
     /// set_server_key(server_key);
     ///
+    /// // DANGER: Using a deterministic seed is insecure and only done here to show API usage.
+    /// // The proper way of generating a seed depends on your application.
     /// let ct_res = FheUint8::generate_oblivious_pseudo_random(Seed(0));
     ///
     /// let dec_result: u16 = ct_res.decrypt(&client_key);
@@ -114,6 +116,8 @@ impl<Id: FheUintId> FheUint<Id> {
     ///
     /// let random_bits_count = 3;
     ///
+    /// // DANGER: Using a deterministic seed is insecure and only done here to show API usage.
+    /// // The proper way of generating a seed depends on your application.
     /// let ct_res = FheUint8::generate_oblivious_pseudo_random_bounded(Seed(0), random_bits_count);
     ///
     /// let dec_result: u16 = ct_res.decrypt(&client_key);
@@ -199,6 +203,8 @@ impl<Id: FheUintId> FheUint<Id> {
     ///
     /// let range = RangeForRandom::new_from_excluded_upper_bound(excluded_upper_bound);
     ///
+    /// // DANGER: Using a deterministic seed is insecure and only done here to show API usage.
+    /// // The proper way of generating a seed depends on your application.
     /// let ct_res = FheUint8::generate_oblivious_pseudo_random_custom_range(Seed(0), &range, None);
     ///
     /// let dec_result: u16 = ct_res.decrypt(&client_key);
@@ -331,6 +337,8 @@ impl<Id: FheIntId> FheInt<Id> {
     ///
     /// set_server_key(server_key);
     ///
+    /// // DANGER: Using a deterministic seed is insecure and only done here to show API usage.
+    /// // The proper way of generating a seed depends on your application.
     /// let ct_res = FheInt8::generate_oblivious_pseudo_random(Seed(0));
     ///
     /// let dec_result: i16 = ct_res.decrypt(&client_key);
@@ -424,6 +432,8 @@ impl<Id: FheIntId> FheInt<Id> {
     ///
     /// let random_bits_count = 3;
     ///
+    /// // DANGER: Using a deterministic seed is insecure and only done here to show API usage.
+    /// // The proper way of generating a seed depends on your application.
     /// let ct_res = FheInt8::generate_oblivious_pseudo_random_bounded(Seed(0), random_bits_count);
     ///
     /// let dec_result: i16 = ct_res.decrypt(&client_key);

--- a/tfhe/src/high_level_api/integers/shuffle.rs
+++ b/tfhe/src/high_level_api/integers/shuffle.rs
@@ -1,7 +1,9 @@
 use crate::high_level_api::global_state;
 use crate::high_level_api::integers::FheIntegerType;
 use crate::high_level_api::keys::InternalServerKey;
-use crate::high_level_api::re_randomization::ReRandomizationMetadata;
+use crate::high_level_api::re_randomization::{
+    ReRandomizationHashAlgo, ReRandomizationMetadata, ReRandomizationMode,
+};
 use crate::integer::server_key::radix_parallel::bitonic_shuffle::BitonicShuffleKeySize;
 use crate::OprfSeed;
 
@@ -63,16 +65,58 @@ where
     })
 }
 
+pub fn re_randomized_keys_bitonic_shuffle<T, S>(
+    data: Vec<T>,
+    key_size: BitonicShuffleKeySize,
+    seed: S,
+    re_randomization_mode: ReRandomizationMode,
+    re_randomization_hash_algo: ReRandomizationHashAlgo,
+) -> Result<Vec<T>, crate::Error>
+where
+    T: FheIntegerType,
+    S: OprfSeed,
+{
+    global_state::with_internal_keys(|key| match key {
+        InternalServerKey::Cpu(cpu_key) => {
+            let re_randomization_key =
+                cpu_key.integer_re_randomization_key_from_mode(re_randomization_mode)?;
+            let inner = data.into_iter().map(|v| v.into_cpu()).collect();
+            let result = cpu_key.pbs_key().re_randomized_keys_bitonic_shuffle(
+                &cpu_key.oprf_key(),
+                inner,
+                key_size,
+                seed,
+                &re_randomization_key,
+                re_randomization_hash_algo,
+            )?;
+            Ok(result
+                .into_iter()
+                .map(|ct| T::from_cpu(ct, cpu_key.tag.clone(), ReRandomizationMetadata::default()))
+                .collect())
+        }
+        #[cfg(feature = "gpu")]
+        InternalServerKey::Cuda(_) => Err(crate::Error::new(
+            "bitonic_shuffle is not supported on Cuda".to_string(),
+        )),
+        #[cfg(feature = "hpu")]
+        InternalServerKey::Hpu(_) => Err(crate::Error::new(
+            "bitonic_shuffle is not supported on Hpu".to_string(),
+        )),
+    })
+}
+
 #[cfg(test)]
 mod test {
-    use super::{bitonic_shuffle, BitonicShuffleKeySize};
+    use super::*;
     use crate::core_crypto::prelude::new_seeder;
     #[cfg(feature = "gpu")]
     use crate::high_level_api::integers::unsigned::tests::gpu::GPU_SETUP_FN;
     use crate::high_level_api::prelude::*;
     use crate::high_level_api::tests::setup_default_cpu;
+    use crate::high_level_api::{set_server_key, ClientKey, ConfigBuilder, ServerKey};
+    use crate::shortint::parameters::ReRandomizationParameters;
     #[cfg(feature = "gpu")]
-    use crate::{ClientKey, FheInt16, FheIntegerType, FheUint32};
+    use crate::{FheInt16, FheUint32};
     use crate::{FheInt8, FheUint8};
     #[cfg(feature = "gpu")]
     use rand::distributions::Standard;
@@ -82,7 +126,21 @@ mod test {
 
     #[test]
     fn test_bitonic_shuffle_fheuint() {
-        let cks = setup_default_cpu();
+        let cks = {
+            let config = ConfigBuilder::default()
+                .use_dedicated_oprf_key(true)
+                .enable_ciphertext_re_randomization(
+                    ReRandomizationParameters::DerivedCPKWithoutKeySwitch,
+                )
+                .build();
+
+            let cks = ClientKey::generate(config);
+            let sks = ServerKey::new(&cks);
+
+            set_server_key(sks);
+
+            cks
+        };
         let mut rng = rand::thread_rng();
         let mut clear_values: Vec<u8> = (0..15).map(|_| rng.gen()).collect();
 
@@ -93,19 +151,70 @@ mod test {
 
         let seed = new_seeder().seed();
         println!("seed: {seed:?}");
-        let shuffled =
-            bitonic_shuffle(encrypted, BitonicShuffleKeySize::num_bits(32), seed).unwrap();
+        let key_size = BitonicShuffleKeySize::num_bits(32);
+        let shuffled = bitonic_shuffle(encrypted.clone(), key_size, seed).unwrap();
+        let shuffled_rerand = {
+            let mut shuffled_rerand = vec![];
 
-        let mut decrypted: Vec<u8> = shuffled.iter().map(|ct| ct.decrypt(&cks)).collect();
+            for algo in [
+                ReRandomizationHashAlgo::Blake3,
+                ReRandomizationHashAlgo::Shake256,
+            ] {
+                shuffled_rerand.push(
+                    re_randomized_keys_bitonic_shuffle(
+                        encrypted.clone(),
+                        key_size,
+                        seed,
+                        ReRandomizationMode::UseAvailableMode,
+                        algo,
+                    )
+                    .unwrap(),
+                );
+            }
+
+            shuffled_rerand
+        };
+
+        let decrypted_ref: Vec<u8> = shuffled.iter().map(|ct| ct.decrypt(&cks)).collect();
 
         clear_values.sort_unstable();
-        decrypted.sort_unstable();
-        assert_eq!(decrypted, clear_values);
+        let decrypted_sorted = {
+            let mut tmp = decrypted_ref.clone();
+            tmp.sort_unstable();
+            tmp
+        };
+
+        assert_eq!(decrypted_sorted, clear_values);
+
+        for (idx, rerand_result) in shuffled_rerand.into_iter().enumerate() {
+            let decrypted_rerand: Vec<u8> =
+                rerand_result.iter().map(|ct| ct.decrypt(&cks)).collect();
+
+            assert_eq!(
+                decrypted_ref, decrypted_rerand,
+                "failed at index {idx} of decrypted_rerand"
+            );
+        }
     }
 
     #[test]
     fn test_bitonic_shuffle_fheint() {
-        let cks = setup_default_cpu();
+        let cks = {
+            let config = ConfigBuilder::default()
+                .use_dedicated_oprf_key(true)
+                .enable_ciphertext_re_randomization(
+                    ReRandomizationParameters::DerivedCPKWithoutKeySwitch,
+                )
+                .build();
+
+            let cks = ClientKey::generate(config);
+            let sks = ServerKey::new(&cks);
+
+            set_server_key(sks);
+
+            cks
+        };
+
         let mut rng = rand::thread_rng();
         let mut clear_values: Vec<i8> = (0..15).map(|_| rng.gen()).collect();
 
@@ -116,14 +225,50 @@ mod test {
 
         let seed = new_seeder().seed();
         println!("seed: {seed:?}");
-        let shuffled =
-            bitonic_shuffle(encrypted, BitonicShuffleKeySize::num_bits(32), seed).unwrap();
+        let key_size = BitonicShuffleKeySize::num_bits(32);
+        let shuffled = bitonic_shuffle(encrypted.clone(), key_size, seed).unwrap();
+        let shuffled_rerand = {
+            let mut shuffled_rerand = vec![];
 
-        let mut decrypted: Vec<i8> = shuffled.iter().map(|ct| ct.decrypt(&cks)).collect();
+            for algo in [
+                ReRandomizationHashAlgo::Blake3,
+                ReRandomizationHashAlgo::Shake256,
+            ] {
+                shuffled_rerand.push(
+                    re_randomized_keys_bitonic_shuffle(
+                        encrypted.clone(),
+                        key_size,
+                        seed,
+                        ReRandomizationMode::UseAvailableMode,
+                        algo,
+                    )
+                    .unwrap(),
+                );
+            }
+
+            shuffled_rerand
+        };
+
+        let decrypted_ref: Vec<i8> = shuffled.iter().map(|ct| ct.decrypt(&cks)).collect();
 
         clear_values.sort_unstable();
-        decrypted.sort_unstable();
-        assert_eq!(decrypted, clear_values);
+        let decrypted_sorted = {
+            let mut tmp = decrypted_ref.clone();
+            tmp.sort_unstable();
+            tmp
+        };
+
+        assert_eq!(decrypted_sorted, clear_values);
+
+        for (idx, rerand_result) in shuffled_rerand.into_iter().enumerate() {
+            let decrypted_rerand: Vec<i8> =
+                rerand_result.iter().map(|ct| ct.decrypt(&cks)).collect();
+
+            assert_eq!(
+                decrypted_ref, decrypted_rerand,
+                "failed at index {idx} of decrypted_rerand"
+            );
+        }
     }
 
     #[test]

--- a/tfhe/src/high_level_api/mod.rs
+++ b/tfhe/src/high_level_api/mod.rs
@@ -140,8 +140,8 @@ pub use compressed_noise_squashed_ciphertext_list::{
     HlSquashedNoiseCompressible, HlSquashedNoiseExpandable,
 };
 pub use re_randomization::{
-    ReRandomizationContext, ReRandomizationMetadata, ReRandomizationMode, ReRandomizationSeedGen,
-    ReRandomizationSupport,
+    ReRandomizationContext, ReRandomizationHashAlgo, ReRandomizationMetadata, ReRandomizationMode,
+    ReRandomizationSeedGen, ReRandomizationSupport,
 };
 #[cfg(feature = "strings")]
 pub use strings::ascii::{EncryptableString, FheAsciiString, FheStringIsEmpty, FheStringLen};

--- a/tfhe/src/high_level_api/mod.rs
+++ b/tfhe/src/high_level_api/mod.rs
@@ -49,7 +49,9 @@ macro_rules! export_concrete_array_types {
 
 pub use crate::core_crypto::commons::math::random::{Seed, Seeder, XofSeed};
 pub use crate::high_level_api::integers::oprf::RangeForRandom;
-pub use crate::high_level_api::integers::shuffle::bitonic_shuffle;
+pub use crate::high_level_api::integers::shuffle::{
+    bitonic_shuffle, re_randomized_keys_bitonic_shuffle,
+};
 pub use crate::integer::server_key::MatchValues;
 pub use crate::shortint::OprfSeed;
 use crate::{error, Error, Versionize};

--- a/tfhe/src/high_level_api/re_randomization.rs
+++ b/tfhe/src/high_level_api/re_randomization.rs
@@ -3,6 +3,7 @@ use crate::core_crypto::commons::math::random::XofSeed;
 use crate::high_level_api::keys::CompactPublicKey;
 pub use crate::high_level_api::keys::ReRandomizationSupport;
 use crate::high_level_api::tag::SmallVec;
+pub use crate::integer::ciphertext::ReRandomizationHashAlgo;
 use crate::integer::ciphertext::{ReRandomizationSeed, ReRandomizationSeedHasher};
 
 use tfhe_versionable::Versionize;

--- a/tfhe/src/integer/ciphertext/re_randomization.rs
+++ b/tfhe/src/integer/ciphertext/re_randomization.rs
@@ -4,7 +4,9 @@ use crate::core_crypto::commons::math::random::XofSeed;
 use crate::integer::ciphertext::AsShortintCiphertextSlice;
 use crate::integer::key_switching_key::KeySwitchingKeyMaterialView;
 use crate::integer::CompactPublicKey;
-pub use crate::shortint::ciphertext::{ReRandomizationSeed, ReRandomizationSeedHasher};
+pub use crate::shortint::ciphertext::{
+    ReRandomizationHashAlgo, ReRandomizationSeed, ReRandomizationSeedHasher,
+};
 use crate::shortint::Ciphertext;
 use crate::Result;
 
@@ -20,6 +22,17 @@ pub enum ReRandomizationKey<'key> {
     DerivedCPKWithoutKeySwitch {
         cpk: &'key CompactPublicKey,
     },
+}
+
+impl ReRandomizationKey<'_> {
+    pub fn get_cpk_and_optional_ksk(
+        &self,
+    ) -> (&CompactPublicKey, Option<&KeySwitchingKeyMaterialView<'_>>) {
+        match self {
+            ReRandomizationKey::LegacyDedicatedCPK { cpk, ksk } => (cpk, Some(ksk)),
+            ReRandomizationKey::DerivedCPKWithoutKeySwitch { cpk } => (cpk, None),
+        }
+    }
 }
 
 /// The context that will be hashed and used to generate unique [`ReRandomizationSeed`].
@@ -179,10 +192,8 @@ pub(crate) fn re_randomize_ciphertext_blocks(
     re_randomization_key: ReRandomizationKey<'_>,
     seed: ReRandomizationSeed,
 ) -> crate::Result<()> {
-    let (compact_public_key, key_switching_key_material) = match re_randomization_key {
-        ReRandomizationKey::LegacyDedicatedCPK { cpk, ksk } => (cpk, Some(ksk)),
-        ReRandomizationKey::DerivedCPKWithoutKeySwitch { cpk } => (cpk, None),
-    };
+    let (compact_public_key, key_switching_key_material) =
+        re_randomization_key.get_cpk_and_optional_ksk();
 
     compact_public_key.key.re_randomize_ciphertexts(
         blocks,

--- a/tfhe/src/integer/gpu/ciphertext/boolean_value.rs
+++ b/tfhe/src/integer/gpu/ciphertext/boolean_value.rs
@@ -12,7 +12,7 @@ use super::CudaIntegerRadixCiphertext;
 
 /// Wrapper type used to signal that the inner value encrypts 0 or 1
 ///
-/// Since values ares encrypted, it is not possible to know whether a
+/// Since values are encrypted, it is not possible to know whether a
 /// ciphertext encrypts a boolean value (0 or 1). However, some algorithms
 /// require that the ciphertext does indeed encrypt a boolean value.
 ///

--- a/tfhe/src/integer/gpu/ffi.rs
+++ b/tfhe/src/integer/gpu/ffi.rs
@@ -2785,6 +2785,145 @@ pub(crate) unsafe fn cuda_backend_grouped_oprf_custom_range<
 }
 
 #[allow(clippy::too_many_arguments)]
+/// # Safety
+///
+/// - The data must not be moved or dropped while being used by the CUDA kernel.
+/// - This function assumes exclusive access to the passed data; violating this may lead to
+///   undefined behavior.
+/// - In `WithoutKs` mode, when `rerand_keyswitch_key` is `None`, the `rerand_ksks` pointer passed
+///   to the backend is null and is never dereferenced because the encryptions of zero are added
+///   directly. In `rerand_ksk_params`, only `input_lwe_dimension` is read in that mode: it sizes
+///   the expanded encryptions of zero and selects the expansion kernel. `output_lwe_dimension`,
+///   `base_log` and `level_count` are unused.
+pub(crate) unsafe fn cuda_backend_grouped_oprf_custom_range_with_rerand<
+    T: UnsignedInteger,
+    B: Numeric,
+    KST: Numeric,
+>(
+    streams: &CudaStreams,
+    radix_lwe_out: &mut CudaRadixCiphertext,
+    num_blocks_intermediate: u32,
+    seeded_lwe_input: &CudaVec<u64>,
+    decomposed_scalar: &[T],
+    has_at_least_one_set: &[T],
+    shift: u32,
+    bootstrapping_key: &CudaVec<B>,
+    compute_bootstrapping_key: &CudaVec<B>,
+    key_switching_key: &CudaVec<KST>,
+    bsk: &impl CudaBskParams,
+    ksk_params: CudaLweKeyswitchKeyParamsFFI,
+    message_modulus: MessageModulus,
+    carry_modulus: CarryModulus,
+    message_bits_per_block: u32,
+    ms_noise_reduction_configuration: Option<&CudaModulusSwitchNoiseReductionConfiguration>,
+    zero_lwes: &CudaLweCompactCiphertextList<u64>,
+    rerand_keyswitch_key: Option<&CudaLweKeyswitchKey<u64>>,
+) {
+    let bsk_params = bsk.params_ffi();
+    assert_eq!(
+        streams.gpu_indexes[0],
+        radix_lwe_out.d_blocks.0.d_vec.gpu_index(0),
+    );
+    assert_eq!(streams.gpu_indexes[0], seeded_lwe_input.gpu_index(0));
+    assert_eq!(streams.gpu_indexes[0], bootstrapping_key.gpu_index(0));
+    assert_eq!(
+        streams.gpu_indexes[0],
+        compute_bootstrapping_key.gpu_index(0)
+    );
+    assert_eq!(streams.gpu_indexes[0], key_switching_key.gpu_index(0));
+    assert_eq!(streams.gpu_indexes[0], zero_lwes.0.d_vec.gpu_index(0));
+
+    let noise_reduction_type = resolve_ms_noise_reduction_config(ms_noise_reduction_configuration);
+
+    let num_scalars = u32::try_from(decomposed_scalar.len()).unwrap();
+
+    // Same rerand keyswitch parameter layout as `cuda_backend_rerand_assign` and
+    // `cuda_backend_rerand_without_keyswitch_assign`.
+    let (rerand_ksk_params, rerand_mode) = match rerand_keyswitch_key {
+        Some(ksk) => {
+            assert_eq!(streams.gpu_indexes[0], ksk.d_vec.gpu_index(0));
+            (ksk.params_ffi(), RerandMode::WithKs)
+        }
+        None => {
+            // Without keyswitch, encryptions of zero already live at the radix block dimension.
+            // Only input_lwe_dimension is read; the other fields are unused.
+            let radix_lwe_dimension =
+                u32::try_from(radix_lwe_out.d_blocks.lwe_dimension().0).unwrap();
+            (
+                CudaLweKeyswitchKeyParamsFFI {
+                    input_lwe_dimension: radix_lwe_dimension,
+                    output_lwe_dimension: radix_lwe_dimension,
+                    base_log: 0,
+                    level_count: 0,
+                },
+                RerandMode::WithoutKs,
+            )
+        }
+    };
+    let rerand_ksks_ptr = rerand_keyswitch_key
+        .map(|ksk| ksk.d_vec.ptr.as_ptr())
+        .unwrap_or(std::ptr::null());
+
+    let mut mem_ptr: *mut i8 = std::ptr::null_mut();
+
+    let mut out_degrees = radix_lwe_out
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.degree.get())
+        .collect();
+    let mut out_noise_levels = radix_lwe_out
+        .info
+        .blocks
+        .iter()
+        .map(|b| b.noise_level.0)
+        .collect();
+    let mut cuda_ffi_radix_lwe_out =
+        prepare_cuda_radix_ffi(radix_lwe_out, &mut out_degrees, &mut out_noise_levels);
+
+    scratch_cuda_integer_grouped_oprf_custom_range_with_rerand_64_async(
+        streams.ffi(),
+        std::ptr::addr_of_mut!(mem_ptr),
+        bsk_params,
+        ksk_params,
+        num_blocks_intermediate,
+        u32::try_from(message_modulus.0).unwrap(),
+        u32::try_from(carry_modulus.0).unwrap(),
+        true,
+        message_bits_per_block,
+        shift,
+        num_scalars,
+        noise_reduction_type as u32,
+        rerand_ksk_params,
+        rerand_mode as u32,
+    );
+
+    cuda_integer_grouped_oprf_custom_range_with_rerand_64_async(
+        streams.ffi(),
+        &raw mut cuda_ffi_radix_lwe_out,
+        num_blocks_intermediate,
+        seeded_lwe_input.as_c_ptr(0),
+        decomposed_scalar.as_ptr().cast::<u64>(),
+        has_at_least_one_set.as_ptr().cast::<u64>(),
+        num_scalars,
+        shift,
+        zero_lwes.0.d_vec.as_c_ptr(0),
+        mem_ptr,
+        bootstrapping_key.ptr.as_ptr(),
+        compute_bootstrapping_key.ptr.as_ptr(),
+        key_switching_key.ptr.as_ptr(),
+        rerand_ksks_ptr,
+    );
+
+    cleanup_cuda_integer_grouped_oprf_custom_range_with_rerand_64(
+        streams.ffi(),
+        std::ptr::addr_of_mut!(mem_ptr),
+    );
+
+    update_noise_degree(radix_lwe_out, &cuda_ffi_radix_lwe_out);
+}
+
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn cuda_backend_get_grouped_oprf_size_on_gpu(
     streams: &CudaStreams,
     num_blocks_to_process: u32,

--- a/tfhe/src/integer/gpu/server_key/radix/oprf.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/oprf.rs
@@ -1,6 +1,8 @@
 use std::borrow::Borrow;
 
 use crate::core_crypto::gpu::CudaStreams;
+use crate::integer::ciphertext::{ReRandomizationHashAlgo, ReRandomizationSeed};
+use crate::integer::gpu::ciphertext::re_randomization::CudaReRandomizationKey;
 use crate::integer::gpu::ciphertext::{
     CudaIntegerRadixCiphertext, CudaRadixCiphertext, CudaSignedRadixCiphertext,
     CudaUnsignedRadixCiphertext,
@@ -10,7 +12,9 @@ use crate::integer::gpu::server_key::{
 };
 use itertools::Itertools;
 
-use crate::shortint::oprf::{create_random_from_seed_modulus_switched, raw_seeded_msed_to_lwe};
+use crate::shortint::oprf::{
+    create_random_from_seed_modulus_switched, raw_seeded_msed_to_lwe, RandomBitsRleLeBytes,
+};
 use crate::shortint::OprfSeed;
 
 use crate::core_crypto::gpu::vec::CudaVec;
@@ -130,6 +134,25 @@ where
         )
     }
 
+    pub fn par_generate_oblivious_pseudo_random_unsigned_integer_and_re_randomize(
+        &self,
+        seed: impl OprfSeed,
+        num_blocks: u64,
+        target_sks: &CudaServerKey,
+        re_randomization_key: &CudaReRandomizationKey<'_>,
+        re_randomization_hash_algo: ReRandomizationHashAlgo,
+        streams: &CudaStreams,
+    ) -> crate::Result<CudaUnsignedRadixCiphertext> {
+        self.generate_oblivious_pseudo_random_unbounded_integer_and_re_randomize(
+            seed,
+            num_blocks,
+            target_sks,
+            re_randomization_key,
+            re_randomization_hash_algo,
+            streams,
+        )
+    }
+
     /// Generates an encrypted `num_block` blocks unsigned integer
     /// taken uniformly in `[0, 2^random_bits_count[` using the given seed.
     /// The encrypted value is oblivious to the server.
@@ -200,6 +223,39 @@ where
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
+    pub fn par_generate_oblivious_pseudo_random_unsigned_integer_bounded_and_re_randomize(
+        &self,
+        seed: impl OprfSeed,
+        random_bits_count: u64,
+        num_blocks: u64,
+        target_sks: &CudaServerKey,
+        re_randomization_key: &CudaReRandomizationKey<'_>,
+        re_randomization_hash_algo: ReRandomizationHashAlgo,
+        streams: &CudaStreams,
+    ) -> crate::Result<CudaUnsignedRadixCiphertext> {
+        assert!(target_sks.message_modulus.0.is_power_of_two());
+        let message_bits_count = target_sks.message_modulus.0.ilog2() as u64;
+        let range_bits_count = message_bits_count * num_blocks;
+        assert!(range_bits_count > 0);
+
+        assert!(
+            random_bits_count <= range_bits_count,
+            "The range asked for a random value (=[0, 2^{random_bits_count}[) \
+            does not fit in the available range [0, 2^{range_bits_count}[",
+        );
+
+        self.generate_oblivious_pseudo_random_bounded_integer_and_re_randomize(
+            seed,
+            random_bits_count,
+            num_blocks,
+            target_sks,
+            re_randomization_key,
+            re_randomization_hash_algo,
+            streams,
+        )
+    }
+
     /// Generates an encrypted `num_block` blocks signed integer
     /// taken uniformly in its full range using the given seed.
     /// The encrypted value is oblivious to the server.
@@ -245,6 +301,25 @@ where
     ) -> CudaSignedRadixCiphertext {
         self.generate_oblivious_pseudo_random_unbounded_integer(
             seed, num_blocks, target_sks, streams,
+        )
+    }
+
+    pub fn par_generate_oblivious_pseudo_random_signed_integer_and_re_randomize(
+        &self,
+        seed: impl OprfSeed,
+        num_blocks: u64,
+        target_sks: &CudaServerKey,
+        re_randomization_key: &CudaReRandomizationKey<'_>,
+        re_randomization_hash_algo: ReRandomizationHashAlgo,
+        streams: &CudaStreams,
+    ) -> crate::Result<CudaSignedRadixCiphertext> {
+        self.generate_oblivious_pseudo_random_unbounded_integer_and_re_randomize(
+            seed,
+            num_blocks,
+            target_sks,
+            re_randomization_key,
+            re_randomization_hash_algo,
+            streams,
         )
     }
 
@@ -324,9 +399,45 @@ where
         )
     }
 
-    // Generic internal implementation for unbounded pseudo-random generation.
-    // It calls the core implementation with parameters for the unbounded case.
-    //
+    #[allow(clippy::too_many_arguments)]
+    pub fn par_generate_oblivious_pseudo_random_signed_integer_bounded_and_re_randomize(
+        &self,
+        seed: impl OprfSeed,
+        random_bits_count: u64,
+        num_blocks: u64,
+        target_sks: &CudaServerKey,
+        re_randomization_key: &CudaReRandomizationKey<'_>,
+        re_randomization_hash_algo: ReRandomizationHashAlgo,
+        streams: &CudaStreams,
+    ) -> crate::Result<CudaSignedRadixCiphertext> {
+        assert!(target_sks.message_modulus.0.is_power_of_two());
+        let message_bits_count = target_sks.message_modulus.0.ilog2() as u64;
+        let range_bits_count = message_bits_count * num_blocks;
+        assert!(range_bits_count > 0);
+
+        {
+            let signed_range_bits_count = range_bits_count.saturating_sub(1);
+            assert!(
+                random_bits_count <= signed_range_bits_count,
+                "The range asked for a random value (=[0, 2^{random_bits_count}[) \
+                which does not fit in the available range \
+                [-2^{signed_range_bits_count}, 2^{signed_range_bits_count}[",
+            );
+        }
+
+        self.generate_oblivious_pseudo_random_bounded_integer_and_re_randomize(
+            seed,
+            random_bits_count,
+            num_blocks,
+            target_sks,
+            re_randomization_key,
+            re_randomization_hash_algo,
+            streams,
+        )
+    }
+
+    /// Generic internal implementation for unbounded pseudo-random generation.
+    /// It calls the core implementation with parameters for the unbounded case.
     fn generate_oblivious_pseudo_random_unbounded_integer<T>(
         &self,
         seed: impl OprfSeed,
@@ -347,7 +458,7 @@ where
             return result;
         }
 
-        self.generate_multiblocks_oblivious_pseudo_random(
+        let _random_bits_rle_bytes = self.generate_multiblocks_oblivious_pseudo_random(
             result.as_mut(),
             seed,
             num_blocks,
@@ -359,9 +470,46 @@ where
         result
     }
 
-    // Generic internal implementation for bounded pseudo-random generation.
-    // It calls the core implementation with parameters for the bounded case.
-    //
+    /// Same as [`Self::generate_oblivious_pseudo_random_unbounded_integer`] with additional
+    /// re-randomization of the output.
+    fn generate_oblivious_pseudo_random_unbounded_integer_and_re_randomize<T>(
+        &self,
+        prf_seed: impl OprfSeed,
+        num_blocks: u64,
+        target_sks: &CudaServerKey,
+        re_randomization_key: &CudaReRandomizationKey<'_>,
+        re_randomization_hash_algo: ReRandomizationHashAlgo,
+        streams: &CudaStreams,
+    ) -> crate::Result<T>
+    where
+        T: CudaIntegerRadixCiphertext,
+    {
+        assert!(target_sks.message_modulus.0.is_power_of_two());
+
+        let message_bits_count = target_sks.message_modulus.0.ilog2() as u64;
+
+        let mut result = target_sks.create_trivial_zero_radix(num_blocks as usize, streams);
+
+        if num_blocks == 0 {
+            return Ok(result);
+        }
+
+        self.generate_multiblocks_oblivious_pseudo_random_and_re_randomize(
+            result.as_mut(),
+            prf_seed,
+            num_blocks,
+            num_blocks * message_bits_count,
+            target_sks,
+            re_randomization_key,
+            re_randomization_hash_algo,
+            streams,
+        )?;
+
+        Ok(result)
+    }
+
+    /// Generic internal implementation for bounded pseudo-random generation.
+    /// It calls the core implementation with parameters for the bounded case.
     fn generate_oblivious_pseudo_random_bounded_integer<T>(
         &self,
         seed: impl OprfSeed,
@@ -387,7 +535,7 @@ where
             return result;
         }
 
-        self.generate_multiblocks_oblivious_pseudo_random(
+        let _random_bits_rle_bytes = self.generate_multiblocks_oblivious_pseudo_random(
             result.as_mut(),
             seed,
             num_active_blocks,
@@ -396,6 +544,49 @@ where
             streams,
         );
         result
+    }
+
+    /// Same as [`Self::generate_oblivious_pseudo_random_bounded_integer`] with additional
+    /// re-randomization of the output.
+    #[allow(clippy::too_many_arguments)]
+    fn generate_oblivious_pseudo_random_bounded_integer_and_re_randomize<T>(
+        &self,
+        seed: impl OprfSeed,
+        random_bits_count: u64,
+        num_blocks: u64,
+        target_sks: &CudaServerKey,
+        re_randomization_key: &CudaReRandomizationKey<'_>,
+        re_randomization_hash_algo: ReRandomizationHashAlgo,
+        streams: &CudaStreams,
+    ) -> crate::Result<T>
+    where
+        T: CudaIntegerRadixCiphertext,
+    {
+        assert!(target_sks.message_modulus.0.is_power_of_two());
+        let message_bits_count = target_sks.message_modulus.0.ilog2() as u64;
+        let num_active_blocks = random_bits_count.div_ceil(message_bits_count);
+
+        let mut result = target_sks.create_trivial_zero_radix(num_blocks as usize, streams);
+
+        assert!(
+            num_blocks >= num_active_blocks,
+            "Cuda error: num_blocks should be greater than num_blocks_to_process"
+        );
+        if num_active_blocks == 0 {
+            return Ok(result);
+        }
+
+        self.generate_multiblocks_oblivious_pseudo_random_and_re_randomize(
+            result.as_mut(),
+            seed,
+            num_active_blocks,
+            random_bits_count,
+            target_sks,
+            re_randomization_key,
+            re_randomization_hash_algo,
+            streams,
+        )
+        .map(|_| result)
     }
 
     /// Core private implementation that calls the OPRF backend.
@@ -410,7 +601,7 @@ where
         total_random_bits: u64,
         target_sks: &CudaServerKey,
         streams: &CudaStreams,
-    ) {
+    ) -> RandomBitsRleLeBytes {
         let CudaDynamicKeyswitchingKey::Standard(computing_ks_key) = &target_sks.key_switching_key
         else {
             panic!("Only the standard atomic pattern is supported");
@@ -426,7 +617,7 @@ where
         let carry_bits_count = target_sks.carry_modulus.0.ilog2();
         let bits_per_block = message_bits_count + carry_bits_count + 1;
 
-        let (seeded, _rle_info) = create_random_from_seed_modulus_switched(
+        let (seeded, rle_info) = create_random_from_seed_modulus_switched(
             seed,
             in_lwe_size,
             polynomial_size,
@@ -484,6 +675,40 @@ where
                 }
             }
         }
+
+        rle_info
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn generate_multiblocks_oblivious_pseudo_random_and_re_randomize(
+        &self,
+        result: &mut CudaRadixCiphertext,
+        prf_seed: impl OprfSeed,
+        num_active_blocks: u64,
+        total_random_bits: u64,
+        target_sks: &CudaServerKey,
+        re_randomization_key: &CudaReRandomizationKey<'_>,
+        re_randomization_hash_algo: ReRandomizationHashAlgo,
+        streams: &CudaStreams,
+    ) -> crate::Result<()> {
+        let prf_seed = prf_seed.into_bytes();
+        let prf_seed = prf_seed.as_ref();
+        let prf_random_bits_rle_bytes = self.generate_multiblocks_oblivious_pseudo_random(
+            result,
+            prf_seed,
+            num_active_blocks,
+            total_random_bits,
+            target_sks,
+            streams,
+        );
+
+        let rerand_seed = ReRandomizationSeed::new_prf_rerand_seed(
+            re_randomization_hash_algo,
+            prf_seed,
+            &prf_random_bits_rle_bytes,
+        );
+
+        result.re_randomize(*re_randomization_key, rerand_seed, streams)
     }
 
     pub(crate) fn bootstrapping_key(&self) -> &CudaBootstrappingKey<u64> {
@@ -648,8 +873,7 @@ where
         result
     }
 
-    // Getter for the GPU memory usage of OPRF.
-    //
+    /// Getter for the GPU memory usage of OPRF.
     pub fn get_par_generate_oblivious_pseudo_random_unsigned_integer_size_on_gpu(
         &self,
         target_sks: &CudaServerKey,

--- a/tfhe/src/integer/gpu/server_key/radix/oprf.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/oprf.rs
@@ -524,11 +524,17 @@ where
             function instead"
         );
 
+        // Since excluded_upper_bound is not a power of two, we know the ceil log2 of the value is
+        // the ilog2 + 1, this is how many bits are needed to represent the value
+        let excluded_upper_bound_log2: u64 = excluded_upper_bound.ilog2().into();
+        let excluded_upper_bound_ceil_log2 = excluded_upper_bound_log2 + 1;
         let num_bits_output = num_blocks_output * message_bits_count;
+
         assert!(
-            (excluded_upper_bound as f64) < 2_f64.powi(num_bits_output as i32),
+            excluded_upper_bound_ceil_log2 <= num_bits_output,
             "num_blocks_output(={num_blocks_output}) is too small to hold an integer \
-            up to excluded_upper_bound(={excluded_upper_bound})"
+            up to excluded_upper_bound(={excluded_upper_bound}). Output has {num_bits_output} bits,\
+            {excluded_upper_bound} needs {excluded_upper_bound_ceil_log2} bits to be represented."
         );
 
         let CudaDynamicKeyswitchingKey::Standard(computing_ks_key) = &target_sks.key_switching_key
@@ -543,8 +549,7 @@ where
         let polynomial_size = bootstrapping_key.polynomial_size();
         let in_lwe_size = input_lwe_dimension.to_lwe_size();
 
-        let post_mul_num_bits =
-            num_input_random_bits + (excluded_upper_bound as f64).log2().ceil() as u64;
+        let post_mul_num_bits = num_input_random_bits + excluded_upper_bound_ceil_log2;
 
         let num_blocks_intermediate = post_mul_num_bits.div_ceil(message_bits_count);
 

--- a/tfhe/src/integer/gpu/server_key/radix/oprf.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/oprf.rs
@@ -109,6 +109,8 @@ where
     /// let compressed_oprf_sk = CompressedOprfServerKey::new(&oprf_pk, &cks).unwrap();
     /// let cuda_oprf_sk = CudaOprfServerKey::decompress_from_cpu(&compressed_oprf_sk, &streams);
     ///
+    /// // DANGER: Using a fixed seed is insecure and only done here to show API usage.
+    /// // The proper way of generating a seed depends on your application.
     /// let d_ct_res = cuda_oprf_sk.par_generate_oblivious_pseudo_random_unsigned_integer(Seed(0), size as u64, &sks, &streams);
     /// let ct_res = d_ct_res.to_radix_ciphertext(&streams);
     /// // Decrypt:
@@ -156,6 +158,8 @@ where
     ///
     /// let random_bits_count = 3;
     ///
+    /// // DANGER: Using a fixed seed is insecure and only done here to show API usage.
+    /// // The proper way of generating a seed depends on your application.
     /// let d_ct_res = cuda_oprf_sk.par_generate_oblivious_pseudo_random_unsigned_integer_bounded(
     ///     Seed(0),
     ///     random_bits_count,
@@ -222,6 +226,8 @@ where
     /// let compressed_oprf_sk = CompressedOprfServerKey::new(&oprf_pk, &cks).unwrap();
     /// let cuda_oprf_sk = CudaOprfServerKey::decompress_from_cpu(&compressed_oprf_sk, &streams);
     ///
+    /// // DANGER: Using a fixed seed is insecure and only done here to show API usage.
+    /// // The proper way of generating a seed depends on your application.
     /// let d_ct_res = cuda_oprf_sk.par_generate_oblivious_pseudo_random_signed_integer(Seed(0), size as u64, &sks, &streams);
     /// let ct_res = d_ct_res.to_signed_radix_ciphertext(&streams);
     ///
@@ -270,6 +276,8 @@ where
     ///
     /// let random_bits_count = 3;
     ///
+    /// // DANGER: Using a fixed seed is insecure and only done here to show API usage.
+    /// // The proper way of generating a seed depends on your application.
     /// let d_ct_res = cuda_oprf_sk.par_generate_oblivious_pseudo_random_signed_integer_bounded(
     ///     Seed(0),
     ///     random_bits_count,

--- a/tfhe/src/integer/gpu/server_key/radix/oprf.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/oprf.rs
@@ -15,13 +15,15 @@ use itertools::Itertools;
 use crate::shortint::oprf::{
     create_random_from_seed_modulus_switched, raw_seeded_msed_to_lwe, RandomBitsRleLeBytes,
 };
-use crate::shortint::OprfSeed;
+use crate::shortint::{OprfSeed, PBSOrder};
 
+use crate::core_crypto::gpu::lwe_compact_ciphertext_list::CudaLweCompactCiphertextList;
 use crate::core_crypto::gpu::vec::CudaVec;
+use crate::core_crypto::prelude::LweCiphertextCount;
 use crate::integer::block_decomposition::BlockDecomposer;
 use crate::integer::gpu::{
     cuda_backend_get_grouped_oprf_size_on_gpu, cuda_backend_grouped_oprf,
-    cuda_backend_grouped_oprf_custom_range,
+    cuda_backend_grouped_oprf_custom_range, cuda_backend_grouped_oprf_custom_range_with_rerand,
 };
 
 pub struct GenericCudaOprfServerKey<K> {
@@ -887,6 +889,246 @@ where
         }
 
         result
+    }
+
+    /// Re-randomizing variant of
+    /// [`Self::par_generate_oblivious_pseudo_random_unsigned_custom_range`].
+    ///
+    /// The random blocks are re-randomized after the grouped OPRF and before the range mapping,
+    /// matching the CPU implementation. Re-randomization only adds an encryption of zero, so the
+    /// decrypted value is identical to the non-re-randomizing variant for the same seed.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `re_randomization_key` is incompatible with the target server key, with
+    /// the same checks as `CudaRadixCiphertext::re_randomize`.
+    ///
+    /// # Panics
+    ///
+    /// Panics under the same conditions as
+    /// [`Self::par_generate_oblivious_pseudo_random_unsigned_custom_range`].
+    #[allow(clippy::too_many_arguments)]
+    pub fn par_generate_oblivious_pseudo_random_unsigned_custom_range_and_re_randomize(
+        &self,
+        seed: impl OprfSeed,
+        num_input_random_bits: u64,
+        excluded_upper_bound: u64,
+        num_blocks_output: u64,
+        target_sks: &CudaServerKey,
+        re_randomization_key: &CudaReRandomizationKey<'_>,
+        re_randomization_hash_algo: ReRandomizationHashAlgo,
+        streams: &CudaStreams,
+    ) -> crate::Result<CudaUnsignedRadixCiphertext> {
+        assert!(
+            target_sks.message_modulus.0.is_power_of_two(),
+            "Message modulus must be a power of two"
+        );
+        assert!(
+            target_sks.carry_modulus.0.is_power_of_two(),
+            "Carry modulus must be a power of two"
+        );
+        let message_bits_count: u64 = target_sks.message_modulus.0.ilog2().into();
+        let carry_bits_count: u64 = target_sks.carry_modulus.0.ilog2().into();
+        let bits_per_block = message_bits_count + carry_bits_count + 1;
+
+        assert!(
+            !excluded_upper_bound.is_power_of_two(),
+            "Use the cheaper \
+            par_generate_oblivious_pseudo_random_unsigned_integer_bounded_and_re_randomize \
+            function instead"
+        );
+
+        // Since excluded_upper_bound is not a power of two, we know the ceil log2 of the value is
+        // the ilog2 + 1, this is how many bits are needed to represent the value
+        let excluded_upper_bound_log2: u64 = excluded_upper_bound.ilog2().into();
+        let excluded_upper_bound_ceil_log2 = excluded_upper_bound_log2 + 1;
+        let num_bits_output = num_blocks_output * message_bits_count;
+
+        assert!(
+            excluded_upper_bound_ceil_log2 <= num_bits_output,
+            "num_blocks_output(={num_blocks_output}) is too small to hold an integer \
+            up to excluded_upper_bound(={excluded_upper_bound}). Output has {num_bits_output} bits,\
+            {excluded_upper_bound} needs {excluded_upper_bound_ceil_log2} bits to be represented."
+        );
+
+        let CudaDynamicKeyswitchingKey::Standard(computing_ks_key) = &target_sks.key_switching_key
+        else {
+            panic!("Only the standard atomic pattern is supported");
+        };
+
+        self.assert_compatible_with_target_bsk(&target_sks.bootstrapping_key);
+
+        let bootstrapping_key = self.bootstrapping_key.borrow();
+        let input_lwe_dimension = bootstrapping_key.input_lwe_dimension();
+        let polynomial_size = bootstrapping_key.polynomial_size();
+        let in_lwe_size = input_lwe_dimension.to_lwe_size();
+
+        let post_mul_num_bits = num_input_random_bits + excluded_upper_bound_ceil_log2;
+
+        let num_blocks_intermediate = post_mul_num_bits.div_ceil(message_bits_count);
+
+        let decomposer =
+            BlockDecomposer::with_early_stop_at_zero(excluded_upper_bound, 1).iter_as::<u8>();
+        let mut has_at_least_one_set = vec![0u64; message_bits_count as usize];
+        for (i, bit) in decomposer.collect_vec().iter().copied().enumerate() {
+            if bit == 1 {
+                has_at_least_one_set[i % message_bits_count as usize] = 1;
+            }
+        }
+        let decomposed_scalar = BlockDecomposer::with_early_stop_at_zero(excluded_upper_bound, 1)
+            .iter_as::<u64>()
+            .collect::<Vec<_>>();
+
+        let seed_bytes = seed.into_bytes();
+        let prf_seed: &[u8] = seed_bytes.as_ref();
+
+        let (seeded, rle_info) = create_random_from_seed_modulus_switched(
+            prf_seed,
+            in_lwe_size,
+            polynomial_size,
+            &[num_input_random_bits],
+            message_bits_count,
+            bits_per_block,
+        );
+
+        let h_seeded_lwe_list: Vec<u64> = seeded
+            .into_iter()
+            .flat_map(|(seeded, _bits)| {
+                raw_seeded_msed_to_lwe(&seeded, target_sks.ciphertext_modulus).into_container()
+            })
+            .collect();
+
+        let mut d_seeded_lwe_input =
+            unsafe { CudaVec::<u64>::new_async(h_seeded_lwe_list.len(), streams, 0) };
+        unsafe { d_seeded_lwe_input.copy_from_cpu_async(&h_seeded_lwe_list, streams, 0) };
+        streams.synchronize();
+
+        let mut result: CudaUnsignedRadixCiphertext =
+            target_sks.create_trivial_zero_radix(num_blocks_output as usize, streams);
+
+        // The fused kernel re-randomizes the radix blocks directly instead of going through
+        // `CudaRadixCiphertext::re_randomize`, so replicate that function's key-compatibility
+        // checks here.
+        let radix_block_lwe_size = result.as_ref().d_blocks.lwe_dimension().to_lwe_size();
+        let (compact_public_key, rerand_keyswitch_key) = match *re_randomization_key {
+            CudaReRandomizationKey::LegacyDedicatedCPK { cpk, ksk } => {
+                let lwe_keyswitch_key = &ksk.lwe_keyswitch_key;
+                if lwe_keyswitch_key.output_key_lwe_size() != radix_block_lwe_size {
+                    return Err(crate::error!(
+                        "Mismatched LweSize between the ciphertext being re-randomized and the \
+                        provided re-randomization keyswitch key output."
+                    ));
+                }
+                if lwe_keyswitch_key.input_key_lwe_size()
+                    != cpk.parameters().encryption_lwe_dimension.to_lwe_size()
+                {
+                    return Err(crate::error!(
+                        "Mismatched LweDimension between the provided CompactPublicKey and the \
+                        re-randomization keyswitch key input."
+                    ));
+                }
+                if ksk.destination_key.into_pbs_order() != PBSOrder::KeyswitchBootstrap {
+                    return Err(crate::error!(
+                        "Tried to re-randomize with a re-randomization keyswitch key whose \
+                        destination key uses an unsupported PBSOrder. Required \
+                        PBSOrder::KeyswitchBootstrap."
+                    ));
+                }
+                if ksk.cast_rshift != 0 {
+                    return Err(crate::error!(
+                        "Tried to re-randomize with a re-randomization keyswitch key that has a \
+                        non-zero cast_rshift, this is unsupported."
+                    ));
+                }
+                (cpk, Some(lwe_keyswitch_key))
+            }
+            CudaReRandomizationKey::DerivedCPKWithoutKeySwitch { cpk } => {
+                if cpk.key.key.lwe_dimension().to_lwe_size() != radix_block_lwe_size {
+                    return Err(crate::error!(
+                        "Mismatched LweSize between the ciphertext being re-randomized and the \
+                        provided CompactPublicKey."
+                    ));
+                }
+                (cpk, None)
+            }
+        };
+
+        // Only the active random blocks are re-randomized (matching CPU); the high intermediate
+        // blocks are trivial-zero headroom for the multiply.
+        let num_random_input_blocks = num_input_random_bits.div_ceil(message_bits_count);
+        let rerand_seed = ReRandomizationSeed::new_prf_rerand_seed(
+            re_randomization_hash_algo,
+            prf_seed,
+            &rle_info,
+        );
+        let encryption_of_zero = compact_public_key.key.prepare_cpk_zero_for_rerand(
+            rerand_seed,
+            LweCiphertextCount(num_random_input_blocks as usize),
+        );
+        let d_zero_lwes = CudaLweCompactCiphertextList::from_lwe_compact_ciphertext_list(
+            &encryption_of_zero,
+            streams,
+        );
+
+        unsafe {
+            match (bootstrapping_key, &target_sks.bootstrapping_key) {
+                (
+                    CudaBootstrappingKey::Classic(d_bsk),
+                    CudaBootstrappingKey::Classic(compute_d_bsk),
+                ) => {
+                    cuda_backend_grouped_oprf_custom_range_with_rerand(
+                        streams,
+                        result.as_mut(),
+                        num_blocks_intermediate as u32,
+                        &d_seeded_lwe_input,
+                        decomposed_scalar.as_slice(),
+                        has_at_least_one_set.as_slice(),
+                        num_input_random_bits as u32,
+                        &d_bsk.d_vec,
+                        &compute_d_bsk.d_vec,
+                        &computing_ks_key.d_vec,
+                        d_bsk,
+                        computing_ks_key.params_ffi(),
+                        target_sks.message_modulus,
+                        target_sks.carry_modulus,
+                        message_bits_count as u32,
+                        d_bsk.ms_noise_reduction_configuration.as_ref(),
+                        &d_zero_lwes,
+                        rerand_keyswitch_key,
+                    );
+                }
+                (
+                    CudaBootstrappingKey::MultiBit(d_bsk),
+                    CudaBootstrappingKey::MultiBit(compute_d_bsk),
+                ) => {
+                    cuda_backend_grouped_oprf_custom_range_with_rerand(
+                        streams,
+                        result.as_mut(),
+                        num_blocks_intermediate as u32,
+                        &d_seeded_lwe_input,
+                        decomposed_scalar.as_slice(),
+                        has_at_least_one_set.as_slice(),
+                        num_input_random_bits as u32,
+                        &d_bsk.d_vec,
+                        &compute_d_bsk.d_vec,
+                        &computing_ks_key.d_vec,
+                        d_bsk,
+                        computing_ks_key.params_ffi(),
+                        target_sks.message_modulus,
+                        target_sks.carry_modulus,
+                        message_bits_count as u32,
+                        None,
+                        &d_zero_lwes,
+                        rerand_keyswitch_key,
+                    );
+                }
+                (_, _) => {
+                    panic!("OPRF and compute bootstrapping keys must have matching types");
+                }
+            }
+        }
+
+        Ok(result)
     }
 
     /// Getter for the GPU memory usage of OPRF.

--- a/tfhe/src/integer/gpu/server_key/radix/oprf.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/oprf.rs
@@ -497,7 +497,6 @@ where
         self.generate_multiblocks_oblivious_pseudo_random_and_re_randomize(
             result.as_mut(),
             prf_seed,
-            num_blocks,
             num_blocks * message_bits_count,
             target_sks,
             re_randomization_key,
@@ -566,7 +565,12 @@ where
         let message_bits_count = target_sks.message_modulus.0.ilog2() as u64;
         let num_active_blocks = random_bits_count.div_ceil(message_bits_count);
 
-        let mut result = target_sks.create_trivial_zero_radix(num_blocks as usize, streams);
+        // We need the PRF + ReRand to be applied only on the num_active_blocks and later extend
+        // with trivial 0s (so that the padding is not re-randed)
+        //
+        // The multiblocks primitive applies the rerand to all the blocks (there is no
+        // "active blocks" rerand primitive currently)
+        let mut result = target_sks.create_trivial_zero_radix(num_active_blocks as usize, streams);
 
         assert!(
             num_blocks >= num_active_blocks,
@@ -579,14 +583,24 @@ where
         self.generate_multiblocks_oblivious_pseudo_random_and_re_randomize(
             result.as_mut(),
             seed,
-            num_active_blocks,
             random_bits_count,
             target_sks,
             re_randomization_key,
             re_randomization_hash_algo,
             streams,
-        )
-        .map(|_| result)
+        )?;
+
+        if num_blocks == num_active_blocks {
+            Ok(result)
+        } else {
+            // We manually cast to unsigned to be able to extend the ciphertext after PRF +
+            // ReRand without sign issues
+            let inner_radix = result.into_inner();
+            let unsigned_radix =
+                <CudaUnsignedRadixCiphertext as CudaIntegerRadixCiphertext>::from(inner_radix);
+            let result = target_sks.cast_to_unsigned(unsigned_radix, num_blocks as usize, streams);
+            Ok(T::from(result.into_inner()))
+        }
     }
 
     /// Core private implementation that calls the OPRF backend.
@@ -684,7 +698,6 @@ where
         &self,
         result: &mut CudaRadixCiphertext,
         prf_seed: impl OprfSeed,
-        num_active_blocks: u64,
         total_random_bits: u64,
         target_sks: &CudaServerKey,
         re_randomization_key: &CudaReRandomizationKey<'_>,
@@ -693,10 +706,13 @@ where
     ) -> crate::Result<()> {
         let prf_seed = prf_seed.into_bytes();
         let prf_seed = prf_seed.as_ref();
+
+        let num_blocks = result.d_blocks.lwe_ciphertext_count().0 as u64;
+
         let prf_random_bits_rle_bytes = self.generate_multiblocks_oblivious_pseudo_random(
             result,
             prf_seed,
-            num_active_blocks,
+            num_blocks,
             total_random_bits,
             target_sks,
             streams,

--- a/tfhe/src/integer/gpu/server_key/radix/oprf.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/oprf.rs
@@ -17,9 +17,12 @@ use crate::shortint::oprf::{
 };
 use crate::shortint::{OprfSeed, PBSOrder};
 
+use crate::core_crypto::gpu::entities::lwe_bootstrap_key::CudaModulusSwitchNoiseReductionConfiguration;
+use crate::core_crypto::gpu::entities::lwe_keyswitch_key::CudaLweKeyswitchKey;
 use crate::core_crypto::gpu::lwe_compact_ciphertext_list::CudaLweCompactCiphertextList;
 use crate::core_crypto::gpu::vec::CudaVec;
-use crate::core_crypto::prelude::LweCiphertextCount;
+use crate::core_crypto::prelude::{LweCiphertextCount, LweSize};
+use crate::integer::CompactPublicKey;
 use crate::integer::block_decomposition::BlockDecomposer;
 use crate::integer::gpu::{
     cuda_backend_get_grouped_oprf_size_on_gpu, cuda_backend_grouped_oprf,
@@ -32,6 +35,17 @@ pub struct GenericCudaOprfServerKey<K> {
 
 pub type CudaOprfServerKey = GenericCudaOprfServerKey<CudaBootstrappingKey<u64>>;
 pub type CudaOprfServerKeyView<'a> = GenericCudaOprfServerKey<&'a CudaBootstrappingKey<u64>>;
+
+struct CustomRangeOprfPreparedInputs {
+    num_blocks_intermediate: u32,
+    message_bits_count: u32,
+    post_mul_num_bits: u64,
+    decomposed_scalar: Vec<u64>,
+    has_at_least_one_set: Vec<u64>,
+    d_seeded_lwe_input: CudaVec<u64>,
+    rle_info: RandomBitsRleLeBytes,
+    prf_seed: Box<[u8]>,
+}
 
 impl CudaOprfServerKey {
     pub fn as_view(&self) -> CudaOprfServerKeyView<'_> {
@@ -749,102 +763,48 @@ where
         target_sks: &CudaServerKey,
         streams: &CudaStreams,
     ) -> CudaUnsignedRadixCiphertext {
-        assert!(
-            target_sks.message_modulus.0.is_power_of_two(),
-            "Message modulus must be a power of two"
-        );
-        assert!(
-            target_sks.carry_modulus.0.is_power_of_two(),
-            "Carry modulus must be a power of two"
-        );
-        let message_bits_count: u64 = target_sks.message_modulus.0.ilog2().into();
-        let carry_bits_count: u64 = target_sks.carry_modulus.0.ilog2().into();
-        let bits_per_block = message_bits_count + carry_bits_count + 1;
-
-        assert!(
-            !excluded_upper_bound.is_power_of_two(),
-            "Use the cheaper par_generate_oblivious_pseudo_random_unsigned_integer_bounded \
-            function instead"
+        let prepared = self.prepare_custom_range_oprf_inputs(
+            seed,
+            num_input_random_bits,
+            excluded_upper_bound,
+            num_blocks_output,
+            target_sks,
+            streams,
         );
 
-        // Since excluded_upper_bound is not a power of two, we know the ceil log2 of the value is
-        // the ilog2 + 1, this is how many bits are needed to represent the value
-        let excluded_upper_bound_log2: u64 = excluded_upper_bound.ilog2().into();
-        let excluded_upper_bound_ceil_log2 = excluded_upper_bound_log2 + 1;
-        let num_bits_output = num_blocks_output * message_bits_count;
+        let mut result: CudaUnsignedRadixCiphertext =
+            target_sks.create_trivial_zero_radix(num_blocks_output as usize, streams);
 
-        assert!(
-            excluded_upper_bound_ceil_log2 <= num_bits_output,
-            "num_blocks_output(={num_blocks_output}) is too small to hold an integer \
-            up to excluded_upper_bound(={excluded_upper_bound}). Output has {num_bits_output} bits,\
-            {excluded_upper_bound} needs {excluded_upper_bound_ceil_log2} bits to be represented."
-        );
-
+        let bootstrapping_key = self.bootstrapping_key.borrow();
         let CudaDynamicKeyswitchingKey::Standard(computing_ks_key) = &target_sks.key_switching_key
         else {
             panic!("Only the standard atomic pattern is supported");
         };
 
-        self.assert_compatible_with_target_bsk(&target_sks.bootstrapping_key);
-
-        let bootstrapping_key = self.bootstrapping_key.borrow();
-        let input_lwe_dimension = bootstrapping_key.input_lwe_dimension();
-        let polynomial_size = bootstrapping_key.polynomial_size();
-        let in_lwe_size = input_lwe_dimension.to_lwe_size();
-
-        let post_mul_num_bits = num_input_random_bits + excluded_upper_bound_ceil_log2;
-
-        let num_blocks_intermediate = post_mul_num_bits.div_ceil(message_bits_count);
-
-        let decomposer =
-            BlockDecomposer::with_early_stop_at_zero(excluded_upper_bound, 1).iter_as::<u8>();
-        let mut has_at_least_one_set = vec![0u64; message_bits_count as usize];
-        for (i, bit) in decomposer.collect_vec().iter().copied().enumerate() {
-            if bit == 1 {
-                has_at_least_one_set[i % message_bits_count as usize] = 1;
-            }
-        }
-        let decomposed_scalar = BlockDecomposer::with_early_stop_at_zero(excluded_upper_bound, 1)
-            .iter_as::<u64>()
-            .collect::<Vec<_>>();
-
-        let (seeded, _rle_info) = create_random_from_seed_modulus_switched(
-            seed,
-            in_lwe_size,
-            polynomial_size,
-            &[num_input_random_bits],
-            message_bits_count,
-            bits_per_block,
-        );
-
-        let h_seeded_lwe_list: Vec<u64> = seeded
-            .into_iter()
-            .flat_map(|(seeded, _bits)| {
-                raw_seeded_msed_to_lwe(&seeded, target_sks.ciphertext_modulus).into_container()
-            })
-            .collect();
-
-        let mut d_seeded_lwe_input =
-            unsafe { CudaVec::<u64>::new_async(h_seeded_lwe_list.len(), streams, 0) };
-        unsafe { d_seeded_lwe_input.copy_from_cpu_async(&h_seeded_lwe_list, streams, 0) };
-        streams.synchronize();
-
-        let mut result: CudaUnsignedRadixCiphertext =
-            target_sks.create_trivial_zero_radix(num_blocks_output as usize, streams);
-
         unsafe {
-            match (bootstrapping_key, &target_sks.bootstrapping_key) {
-                (
-                    CudaBootstrappingKey::Classic(d_bsk),
-                    CudaBootstrappingKey::Classic(compute_d_bsk),
-                ) => {
+            Self::invoke_custom_range_oprf_backend(
+                bootstrapping_key,
+                &target_sks.bootstrapping_key,
+                computing_ks_key,
+                target_sks,
+                streams,
+                result.as_mut(),
+                &prepared,
+                |streams,
+                 result,
+                 prepared,
+                 d_bsk,
+                 compute_d_bsk,
+                 computing_ks_key,
+                 ms_noise_reduction_configuration,
+                 target_sks| {
                     cuda_backend_grouped_oprf_custom_range(
                         streams,
-                        result.as_mut(),
-                        num_blocks_intermediate as u32,
-                        &d_seeded_lwe_input,
-                        decomposed_scalar.as_slice(),
-                        has_at_least_one_set.as_slice(),
+                        result,
+                        prepared.num_blocks_intermediate,
+                        &prepared.d_seeded_lwe_input,
+                        prepared.decomposed_scalar.as_slice(),
+                        prepared.has_at_least_one_set.as_slice(),
                         num_input_random_bits as u32,
                         &d_bsk.d_vec,
                         &compute_d_bsk.d_vec,
@@ -853,39 +813,12 @@ where
                         computing_ks_key.params_ffi(),
                         target_sks.message_modulus,
                         target_sks.carry_modulus,
-                        message_bits_count as u32,
-                        post_mul_num_bits as u32,
-                        d_bsk.ms_noise_reduction_configuration.as_ref(),
+                        prepared.message_bits_count,
+                        prepared.post_mul_num_bits as u32,
+                        ms_noise_reduction_configuration,
                     );
-                }
-                (
-                    CudaBootstrappingKey::MultiBit(d_bsk),
-                    CudaBootstrappingKey::MultiBit(compute_d_bsk),
-                ) => {
-                    cuda_backend_grouped_oprf_custom_range(
-                        streams,
-                        result.as_mut(),
-                        num_blocks_intermediate as u32,
-                        &d_seeded_lwe_input,
-                        decomposed_scalar.as_slice(),
-                        has_at_least_one_set.as_slice(),
-                        num_input_random_bits as u32,
-                        &d_bsk.d_vec,
-                        &compute_d_bsk.d_vec,
-                        &computing_ks_key.d_vec,
-                        d_bsk,
-                        computing_ks_key.params_ffi(),
-                        target_sks.message_modulus,
-                        target_sks.carry_modulus,
-                        message_bits_count as u32,
-                        post_mul_num_bits as u32,
-                        None,
-                    );
-                }
-                (_, _) => {
-                    panic!("OPRF and compute bootstrapping keys must have matching types");
-                }
-            }
+                },
+            );
         }
 
         result
@@ -920,6 +853,110 @@ where
         streams: &CudaStreams,
     ) -> crate::Result<CudaUnsignedRadixCiphertext> {
         assert!(
+            !excluded_upper_bound.is_power_of_two(),
+            "Use the cheaper \
+            par_generate_oblivious_pseudo_random_unsigned_integer_bounded_and_re_randomize \
+            function instead"
+        );
+
+        let prepared = self.prepare_custom_range_oprf_inputs(
+            seed,
+            num_input_random_bits,
+            excluded_upper_bound,
+            num_blocks_output,
+            target_sks,
+            streams,
+        );
+
+        let mut result: CudaUnsignedRadixCiphertext =
+            target_sks.create_trivial_zero_radix(num_blocks_output as usize, streams);
+
+        // The fused kernel re-randomizes the radix blocks directly instead of going through
+        // `CudaRadixCiphertext::re_randomize`, so replicate that function's key-compatibility
+        // checks here.
+        let radix_block_lwe_size = result.as_ref().d_blocks.lwe_dimension().to_lwe_size();
+        let (compact_public_key, rerand_keyswitch_key) =
+            Self::resolve_custom_range_rerand_key(re_randomization_key, radix_block_lwe_size)?;
+
+        // Only the active random blocks are re-randomized (matching CPU); the high intermediate
+        // blocks are trivial-zero headroom for the multiply.
+        let num_random_input_blocks = num_input_random_bits.div_ceil(u64::from(
+            prepared.message_bits_count,
+        ));
+        let rerand_seed = ReRandomizationSeed::new_prf_rerand_seed(
+            re_randomization_hash_algo,
+            prepared.prf_seed.as_ref(),
+            &prepared.rle_info,
+        );
+        let encryption_of_zero = compact_public_key.key.prepare_cpk_zero_for_rerand(
+            rerand_seed,
+            LweCiphertextCount(num_random_input_blocks as usize),
+        );
+        let d_zero_lwes = CudaLweCompactCiphertextList::from_lwe_compact_ciphertext_list(
+            &encryption_of_zero,
+            streams,
+        );
+
+        let bootstrapping_key = self.bootstrapping_key.borrow();
+        let CudaDynamicKeyswitchingKey::Standard(computing_ks_key) = &target_sks.key_switching_key
+        else {
+            panic!("Only the standard atomic pattern is supported");
+        };
+
+        unsafe {
+            Self::invoke_custom_range_oprf_backend(
+                bootstrapping_key,
+                &target_sks.bootstrapping_key,
+                computing_ks_key,
+                target_sks,
+                streams,
+                result.as_mut(),
+                &prepared,
+                |streams,
+                 result,
+                 prepared,
+                 d_bsk,
+                 compute_d_bsk,
+                 computing_ks_key,
+                 ms_noise_reduction_configuration,
+                 target_sks| {
+                    cuda_backend_grouped_oprf_custom_range_with_rerand(
+                        streams,
+                        result,
+                        prepared.num_blocks_intermediate,
+                        &prepared.d_seeded_lwe_input,
+                        prepared.decomposed_scalar.as_slice(),
+                        prepared.has_at_least_one_set.as_slice(),
+                        num_input_random_bits as u32,
+                        &d_bsk.d_vec,
+                        &compute_d_bsk.d_vec,
+                        &computing_ks_key.d_vec,
+                        d_bsk,
+                        computing_ks_key.params_ffi(),
+                        target_sks.message_modulus,
+                        target_sks.carry_modulus,
+                        prepared.message_bits_count,
+                        ms_noise_reduction_configuration,
+                        &d_zero_lwes,
+                        rerand_keyswitch_key,
+                    );
+                },
+            );
+        }
+
+        Ok(result)
+    }
+
+    fn prepare_custom_range_oprf_inputs(
+        &self,
+        seed: impl OprfSeed,
+        num_input_random_bits: u64,
+        excluded_upper_bound: u64,
+        num_blocks_output: u64,
+        target_sks: &CudaServerKey,
+        streams: &CudaStreams,
+    ) -> CustomRangeOprfPreparedInputs {
+        assert!(
             target_sks.message_modulus.0.is_power_of_two(),
             "Message modulus must be a power of two"
         );
@@ -933,8 +970,7 @@ where
 
         assert!(
             !excluded_upper_bound.is_power_of_two(),
-            "Use the cheaper \
-            par_generate_oblivious_pseudo_random_unsigned_integer_bounded_and_re_randomize \
+            "Use the cheaper par_generate_oblivious_pseudo_random_unsigned_integer_bounded \
             function instead"
         );
 
@@ -951,11 +987,6 @@ where
             {excluded_upper_bound} needs {excluded_upper_bound_ceil_log2} bits to be represented."
         );
 
-        let CudaDynamicKeyswitchingKey::Standard(computing_ks_key) = &target_sks.key_switching_key
-        else {
-            panic!("Only the standard atomic pattern is supported");
-        };
-
         self.assert_compatible_with_target_bsk(&target_sks.bootstrapping_key);
 
         let bootstrapping_key = self.bootstrapping_key.borrow();
@@ -964,7 +995,6 @@ where
         let in_lwe_size = input_lwe_dimension.to_lwe_size();
 
         let post_mul_num_bits = num_input_random_bits + excluded_upper_bound_ceil_log2;
-
         let num_blocks_intermediate = post_mul_num_bits.div_ceil(message_bits_count);
 
         let decomposer =
@@ -979,11 +1009,10 @@ where
             .iter_as::<u64>()
             .collect::<Vec<_>>();
 
-        let seed_bytes = seed.into_bytes();
-        let prf_seed: &[u8] = seed_bytes.as_ref();
-
+        let prf_seed = seed.into_bytes();
+        let prf_seed = prf_seed.as_ref().to_vec();
         let (seeded, rle_info) = create_random_from_seed_modulus_switched(
-            prf_seed,
+            prf_seed.as_slice(),
             in_lwe_size,
             polynomial_size,
             &[num_input_random_bits],
@@ -1003,14 +1032,26 @@ where
         unsafe { d_seeded_lwe_input.copy_from_cpu_async(&h_seeded_lwe_list, streams, 0) };
         streams.synchronize();
 
-        let mut result: CudaUnsignedRadixCiphertext =
-            target_sks.create_trivial_zero_radix(num_blocks_output as usize, streams);
+        CustomRangeOprfPreparedInputs {
+            num_blocks_intermediate: num_blocks_intermediate as u32,
+            message_bits_count: message_bits_count as u32,
+            post_mul_num_bits,
+            decomposed_scalar,
+            has_at_least_one_set,
+            d_seeded_lwe_input,
+            rle_info,
+            prf_seed: prf_seed.into_boxed_slice(),
+        }
+    }
 
-        // The fused kernel re-randomizes the radix blocks directly instead of going through
-        // `CudaRadixCiphertext::re_randomize`, so replicate that function's key-compatibility
-        // checks here.
-        let radix_block_lwe_size = result.as_ref().d_blocks.lwe_dimension().to_lwe_size();
-        let (compact_public_key, rerand_keyswitch_key) = match *re_randomization_key {
+    fn resolve_custom_range_rerand_key<'key>(
+        re_randomization_key: &CudaReRandomizationKey<'key>,
+        radix_block_lwe_size: LweSize,
+    ) -> crate::Result<(
+        &'key CompactPublicKey,
+        Option<&'key CudaLweKeyswitchKey<u64>>,
+    )> {
+        match *re_randomization_key {
             CudaReRandomizationKey::LegacyDedicatedCPK { cpk, ksk } => {
                 let lwe_keyswitch_key = &ksk.lwe_keyswitch_key;
                 if lwe_keyswitch_key.output_key_lwe_size() != radix_block_lwe_size {
@@ -1040,7 +1081,7 @@ where
                         non-zero cast_rshift, this is unsupported."
                     ));
                 }
-                (cpk, Some(lwe_keyswitch_key))
+                Ok((cpk, Some(lwe_keyswitch_key)))
             }
             CudaReRandomizationKey::DerivedCPKWithoutKeySwitch { cpk } => {
                 if cpk.key.key.lwe_dimension().to_lwe_size() != radix_block_lwe_size {
@@ -1049,86 +1090,62 @@ where
                         provided CompactPublicKey."
                     ));
                 }
-                (cpk, None)
-            }
-        };
-
-        // Only the active random blocks are re-randomized (matching CPU); the high intermediate
-        // blocks are trivial-zero headroom for the multiply.
-        let num_random_input_blocks = num_input_random_bits.div_ceil(message_bits_count);
-        let rerand_seed = ReRandomizationSeed::new_prf_rerand_seed(
-            re_randomization_hash_algo,
-            prf_seed,
-            &rle_info,
-        );
-        let encryption_of_zero = compact_public_key.key.prepare_cpk_zero_for_rerand(
-            rerand_seed,
-            LweCiphertextCount(num_random_input_blocks as usize),
-        );
-        let d_zero_lwes = CudaLweCompactCiphertextList::from_lwe_compact_ciphertext_list(
-            &encryption_of_zero,
-            streams,
-        );
-
-        unsafe {
-            match (bootstrapping_key, &target_sks.bootstrapping_key) {
-                (
-                    CudaBootstrappingKey::Classic(d_bsk),
-                    CudaBootstrappingKey::Classic(compute_d_bsk),
-                ) => {
-                    cuda_backend_grouped_oprf_custom_range_with_rerand(
-                        streams,
-                        result.as_mut(),
-                        num_blocks_intermediate as u32,
-                        &d_seeded_lwe_input,
-                        decomposed_scalar.as_slice(),
-                        has_at_least_one_set.as_slice(),
-                        num_input_random_bits as u32,
-                        &d_bsk.d_vec,
-                        &compute_d_bsk.d_vec,
-                        &computing_ks_key.d_vec,
-                        d_bsk,
-                        computing_ks_key.params_ffi(),
-                        target_sks.message_modulus,
-                        target_sks.carry_modulus,
-                        message_bits_count as u32,
-                        d_bsk.ms_noise_reduction_configuration.as_ref(),
-                        &d_zero_lwes,
-                        rerand_keyswitch_key,
-                    );
-                }
-                (
-                    CudaBootstrappingKey::MultiBit(d_bsk),
-                    CudaBootstrappingKey::MultiBit(compute_d_bsk),
-                ) => {
-                    cuda_backend_grouped_oprf_custom_range_with_rerand(
-                        streams,
-                        result.as_mut(),
-                        num_blocks_intermediate as u32,
-                        &d_seeded_lwe_input,
-                        decomposed_scalar.as_slice(),
-                        has_at_least_one_set.as_slice(),
-                        num_input_random_bits as u32,
-                        &d_bsk.d_vec,
-                        &compute_d_bsk.d_vec,
-                        &computing_ks_key.d_vec,
-                        d_bsk,
-                        computing_ks_key.params_ffi(),
-                        target_sks.message_modulus,
-                        target_sks.carry_modulus,
-                        message_bits_count as u32,
-                        None,
-                        &d_zero_lwes,
-                        rerand_keyswitch_key,
-                    );
-                }
-                (_, _) => {
-                    panic!("OPRF and compute bootstrapping keys must have matching types");
-                }
+                Ok((cpk, None))
             }
         }
+    }
 
-        Ok(result)
+    #[allow(clippy::too_many_arguments)]
+    unsafe fn invoke_custom_range_oprf_backend(
+        bootstrapping_key: &CudaBootstrappingKey<u64>,
+        target_bsk: &CudaBootstrappingKey<u64>,
+        computing_ks_key: &CudaLweKeyswitchKey<u64>,
+        target_sks: &CudaServerKey,
+        streams: &CudaStreams,
+        result: &mut CudaRadixCiphertext,
+        prepared: &CustomRangeOprfPreparedInputs,
+        invoke: impl FnOnce(
+            &CudaStreams,
+            &mut CudaRadixCiphertext,
+            &CustomRangeOprfPreparedInputs,
+            &CudaBootstrappingKey<u64>,
+            &CudaBootstrappingKey<u64>,
+            &CudaLweKeyswitchKey<u64>,
+            Option<&CudaModulusSwitchNoiseReductionConfiguration>,
+            &CudaServerKey,
+        ),
+    ) {
+        match (bootstrapping_key, target_bsk) {
+            (
+                CudaBootstrappingKey::Classic(d_bsk),
+                CudaBootstrappingKey::Classic(compute_d_bsk),
+            ) => invoke(
+                streams,
+                result,
+                prepared,
+                d_bsk,
+                compute_d_bsk,
+                computing_ks_key,
+                d_bsk.ms_noise_reduction_configuration.as_ref(),
+                target_sks,
+            ),
+            (
+                CudaBootstrappingKey::MultiBit(d_bsk),
+                CudaBootstrappingKey::MultiBit(compute_d_bsk),
+            ) => invoke(
+                streams,
+                result,
+                prepared,
+                d_bsk,
+                compute_d_bsk,
+                computing_ks_key,
+                None,
+                target_sks,
+            ),
+            (_, _) => {
+                panic!("OPRF and compute bootstrapping keys must have matching types");
+            }
+        }
     }
 
     /// Getter for the GPU memory usage of OPRF.

--- a/tfhe/src/integer/gpu/server_key/radix/tests_unsigned/test_oprf.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/tests_unsigned/test_oprf.rs
@@ -67,8 +67,7 @@ where
 /// GPU implementation of [`OprfReRandTestRunner`].
 ///
 /// Uses a derived compact public key (no key-switch) for re-randomization, mirroring the CPU
-/// executor. The custom-range re-randomizing primitive is not available on GPU yet, so
-/// `unsigned_custom_range` returns `None` and the generic test skips that sub-case.
+/// executor.
 struct GpuOprfReRandTestRunner {
     state: Option<GpuOprfReRandState>,
 }
@@ -206,15 +205,46 @@ impl OprfReRandTestRunner for GpuOprfReRandTestRunner {
 
     fn unsigned_custom_range(
         &mut self,
-        _prf_seed: impl OprfSeed,
-        _num_input_random_bits: u64,
-        _excluded_upper_bound: NonZeroU64,
-        _num_blocks_output: u64,
-        _rerand_hash_algo: ReRandomizationHashAlgo,
-    ) -> Option<(RadixCiphertext, RadixCiphertext)> {
-        // The GPU backend does not expose a re-randomizing custom-range primitive yet
-        // Return None to skip the corresponding sub case
-        None
+        prf_seed: impl OprfSeed,
+        num_input_random_bits: u64,
+        excluded_upper_bound: NonZeroU64,
+        num_blocks_output: u64,
+        rerand_hash_algo: ReRandomizationHashAlgo,
+    ) -> (RadixCiphertext, RadixCiphertext) {
+        let state = self.state();
+        let rerand_key = state.rerand_key();
+
+        let prf_seed = prf_seed.into_bytes();
+        let prf_seed = prf_seed.as_ref();
+
+        let prf_not_rerand = state
+            .oprf_sks
+            .par_generate_oblivious_pseudo_random_unsigned_custom_range(
+                prf_seed,
+                num_input_random_bits,
+                excluded_upper_bound.get(),
+                num_blocks_output,
+                &state.sks,
+                &state.streams,
+            );
+        let prf_rerand = state
+            .oprf_sks
+            .par_generate_oblivious_pseudo_random_unsigned_custom_range_and_re_randomize(
+                prf_seed,
+                num_input_random_bits,
+                excluded_upper_bound.get(),
+                num_blocks_output,
+                &state.sks,
+                &rerand_key,
+                rerand_hash_algo,
+                &state.streams,
+            )
+            .unwrap();
+
+        (
+            prf_not_rerand.to_radix_ciphertext(&state.streams),
+            prf_rerand.to_radix_ciphertext(&state.streams),
+        )
     }
 
     fn signed_full(

--- a/tfhe/src/integer/gpu/server_key/radix/tests_unsigned/test_oprf.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/tests_unsigned/test_oprf.rs
@@ -1,12 +1,21 @@
+use crate::core_crypto::gpu::CudaStreams;
+use crate::integer::ciphertext::{RadixCiphertext, ReRandomizationHashAlgo, SignedRadixCiphertext};
+use crate::integer::gpu::ciphertext::re_randomization::CudaReRandomizationKey;
 use crate::integer::gpu::server_key::radix::tests_long_run::OpSequenceGpuMultiDeviceFunctionExecutor;
 use crate::integer::gpu::server_key::radix::tests_unsigned::create_gpu_parameterized_test;
-use crate::integer::gpu::CudaOprfServerKey;
+use crate::integer::gpu::{CudaOprfServerKey, CudaServerKey};
+use crate::integer::oprf::{CompressedOprfServerKey, OprfPrivateKey};
 use crate::integer::server_key::radix_parallel::tests_unsigned::test_oprf::{
     oprf_almost_uniformity_test, oprf_any_range_test, oprf_uniformity_test,
+    pseudo_random_integer_and_rerand_test, OprfReRandTestRunner,
 };
+use crate::integer::{ClientKey, CompactPrivateKey, CompactPublicKey};
+use crate::shortint::oprf::OprfSeed;
+use crate::shortint::parameters::test_params::TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
 use crate::shortint::parameters::{
     TestParameters, PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
 };
+use core::num::NonZeroU64;
 
 create_gpu_parameterized_test!(oprf_uniformity_unsigned {
     PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128
@@ -16,6 +25,11 @@ create_gpu_parameterized_test!(oprf_any_range_unsigned {
 });
 create_gpu_parameterized_test!(oprf_almost_uniformity_unsigned {
     PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128
+});
+
+create_gpu_parameterized_test!(pseudo_random_integer_and_rerand {
+    PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+    TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
 });
 
 fn oprf_uniformity_unsigned<P>(param: P)
@@ -46,4 +60,246 @@ where
         &CudaOprfServerKey::par_generate_oblivious_pseudo_random_unsigned_custom_range,
     );
     oprf_almost_uniformity_test(param, executor);
+}
+
+// PRF + rerand
+
+/// GPU implementation of [`OprfReRandTestRunner`].
+///
+/// Uses a derived compact public key (no key-switch) for re-randomization, mirroring the CPU
+/// executor. The custom-range re-randomizing primitive is not available on GPU yet, so
+/// `unsigned_custom_range` returns `None` and the generic test skips that sub-case.
+struct GpuOprfReRandTestRunner {
+    state: Option<GpuOprfReRandState>,
+}
+
+struct GpuOprfReRandState {
+    streams: CudaStreams,
+    sks: CudaServerKey,
+    oprf_sks: CudaOprfServerKey,
+    rerand_cpk: CompactPublicKey,
+}
+
+impl GpuOprfReRandState {
+    fn rerand_key(&self) -> CudaReRandomizationKey<'_> {
+        CudaReRandomizationKey::DerivedCPKWithoutKeySwitch {
+            cpk: &self.rerand_cpk,
+        }
+    }
+}
+
+impl GpuOprfReRandTestRunner {
+    fn new() -> Self {
+        Self { state: None }
+    }
+
+    fn state(&self) -> &GpuOprfReRandState {
+        self.state.as_ref().expect("setup was not properly called")
+    }
+}
+
+impl OprfReRandTestRunner for GpuOprfReRandTestRunner {
+    fn setup(&mut self, param: TestParameters) -> ClientKey {
+        let cks = ClientKey::new(param);
+
+        let streams = CudaStreams::new_multi_gpu();
+
+        let sks = CudaServerKey::new(&cks, &streams);
+
+        // Derived compact public key, re-using the compute secret key
+        // legacy rerand not covered by this test
+        let privk: CompactPrivateKey<&[u64]> = (&cks).try_into().unwrap();
+        let rerand_cpk = CompactPublicKey::new(&privk);
+
+        let oprf_pk = OprfPrivateKey::new(&cks);
+        let compressed_oprf_sk = CompressedOprfServerKey::new(&oprf_pk, &cks).unwrap();
+        let oprf_sks = CudaOprfServerKey::decompress_from_cpu(&compressed_oprf_sk, &streams);
+
+        self.state = Some(GpuOprfReRandState {
+            streams,
+            sks,
+            oprf_sks,
+            rerand_cpk,
+        });
+
+        cks
+    }
+
+    fn unsigned_full(
+        &mut self,
+        prf_seed: impl OprfSeed,
+        num_blocks: u64,
+        rerand_hash_algo: ReRandomizationHashAlgo,
+    ) -> (RadixCiphertext, RadixCiphertext) {
+        let state = self.state();
+        let rerand_key = state.rerand_key();
+
+        let prf_seed = prf_seed.into_bytes();
+        let prf_seed = prf_seed.as_ref();
+
+        let prf_not_rerand = state
+            .oprf_sks
+            .par_generate_oblivious_pseudo_random_unsigned_integer(
+                prf_seed,
+                num_blocks,
+                &state.sks,
+                &state.streams,
+            );
+        let prf_rerand = state
+            .oprf_sks
+            .par_generate_oblivious_pseudo_random_unsigned_integer_and_re_randomize(
+                prf_seed,
+                num_blocks,
+                &state.sks,
+                &rerand_key,
+                rerand_hash_algo,
+                &state.streams,
+            )
+            .unwrap();
+
+        (
+            prf_not_rerand.to_radix_ciphertext(&state.streams),
+            prf_rerand.to_radix_ciphertext(&state.streams),
+        )
+    }
+
+    fn unsigned_bounded(
+        &mut self,
+        prf_seed: impl OprfSeed,
+        random_bit_count: u64,
+        num_blocks: u64,
+        rerand_hash_algo: ReRandomizationHashAlgo,
+    ) -> (RadixCiphertext, RadixCiphertext) {
+        let state = self.state();
+        let rerand_key = state.rerand_key();
+
+        let prf_seed = prf_seed.into_bytes();
+        let prf_seed = prf_seed.as_ref();
+
+        let prf_not_rerand = state
+            .oprf_sks
+            .par_generate_oblivious_pseudo_random_unsigned_integer_bounded(
+                prf_seed,
+                random_bit_count,
+                num_blocks,
+                &state.sks,
+                &state.streams,
+            );
+        let prf_rerand = state
+            .oprf_sks
+            .par_generate_oblivious_pseudo_random_unsigned_integer_bounded_and_re_randomize(
+                prf_seed,
+                random_bit_count,
+                num_blocks,
+                &state.sks,
+                &rerand_key,
+                rerand_hash_algo,
+                &state.streams,
+            )
+            .unwrap();
+
+        (
+            prf_not_rerand.to_radix_ciphertext(&state.streams),
+            prf_rerand.to_radix_ciphertext(&state.streams),
+        )
+    }
+
+    fn unsigned_custom_range(
+        &mut self,
+        _prf_seed: impl OprfSeed,
+        _num_input_random_bits: u64,
+        _excluded_upper_bound: NonZeroU64,
+        _num_blocks_output: u64,
+        _rerand_hash_algo: ReRandomizationHashAlgo,
+    ) -> Option<(RadixCiphertext, RadixCiphertext)> {
+        // The GPU backend does not expose a re-randomizing custom-range primitive yet
+        // Return None to skip the corresponding sub case
+        None
+    }
+
+    fn signed_full(
+        &mut self,
+        prf_seed: impl OprfSeed,
+        num_blocks: u64,
+        rerand_hash_algo: ReRandomizationHashAlgo,
+    ) -> (SignedRadixCiphertext, SignedRadixCiphertext) {
+        let state = self.state();
+        let rerand_key = state.rerand_key();
+
+        let prf_seed = prf_seed.into_bytes();
+        let prf_seed = prf_seed.as_ref();
+
+        let prf_not_rerand = state
+            .oprf_sks
+            .par_generate_oblivious_pseudo_random_signed_integer(
+                prf_seed,
+                num_blocks,
+                &state.sks,
+                &state.streams,
+            );
+        let prf_rerand = state
+            .oprf_sks
+            .par_generate_oblivious_pseudo_random_signed_integer_and_re_randomize(
+                prf_seed,
+                num_blocks,
+                &state.sks,
+                &rerand_key,
+                rerand_hash_algo,
+                &state.streams,
+            )
+            .unwrap();
+
+        (
+            prf_not_rerand.to_signed_radix_ciphertext(&state.streams),
+            prf_rerand.to_signed_radix_ciphertext(&state.streams),
+        )
+    }
+
+    fn signed_bounded(
+        &mut self,
+        prf_seed: impl OprfSeed,
+        random_bit_count: u64,
+        num_blocks: u64,
+        rerand_hash_algo: ReRandomizationHashAlgo,
+    ) -> (SignedRadixCiphertext, SignedRadixCiphertext) {
+        let state = self.state();
+        let rerand_key = state.rerand_key();
+
+        let prf_seed = prf_seed.into_bytes();
+        let prf_seed = prf_seed.as_ref();
+
+        let prf_not_rerand = state
+            .oprf_sks
+            .par_generate_oblivious_pseudo_random_signed_integer_bounded(
+                prf_seed,
+                random_bit_count,
+                num_blocks,
+                &state.sks,
+                &state.streams,
+            );
+        let prf_rerand = state
+            .oprf_sks
+            .par_generate_oblivious_pseudo_random_signed_integer_bounded_and_re_randomize(
+                prf_seed,
+                random_bit_count,
+                num_blocks,
+                &state.sks,
+                &rerand_key,
+                rerand_hash_algo,
+                &state.streams,
+            )
+            .unwrap();
+
+        (
+            prf_not_rerand.to_signed_radix_ciphertext(&state.streams),
+            prf_rerand.to_signed_radix_ciphertext(&state.streams),
+        )
+    }
+}
+
+fn pseudo_random_integer_and_rerand<P>(param: P)
+where
+    P: Into<TestParameters>,
+{
+    pseudo_random_integer_and_rerand_test(param, GpuOprfReRandTestRunner::new());
 }

--- a/tfhe/src/integer/oprf.rs
+++ b/tfhe/src/integer/oprf.rs
@@ -121,6 +121,8 @@ where
     /// let oprf_pk = OprfPrivateKey::new(cks.as_ref());
     /// let oprf_sk = OprfServerKey::new(&oprf_pk, cks.as_ref()).unwrap();
     ///
+    /// // DANGER: Using a fixed seed is insecure and only done here to show API usage.
+    /// // The proper way of generating a seed depends on your application.
     /// // `seed` can be either a `Seed` or any byte-like input (`&[u8]`, `&[u8; N]`, ...).
     /// let ct_res =
     ///     oprf_sk.par_generate_oblivious_pseudo_random_unsigned_integer(Seed(0), size as u64, &sks);
@@ -160,6 +162,8 @@ where
     ///
     /// let random_bits_count = 3;
     ///
+    /// // DANGER: Using a fixed seed is insecure and only done here to show API usage.
+    /// // The proper way of generating a seed depends on your application.
     /// let ct_res = oprf_sk.par_generate_oblivious_pseudo_random_unsigned_integer_bounded(
     ///     Seed(0),
     ///     random_bits_count,
@@ -214,6 +218,8 @@ where
     /// let excluded_upper_bound = NonZeroU64::new(3).unwrap();
     /// let num_blocks_output = 8;
     ///
+    /// // DANGER: Using a fixed seed is insecure and only done here to show API usage.
+    /// // The proper way of generating a seed depends on your application.
     /// let ct_res = oprf_sk.par_generate_oblivious_pseudo_random_unsigned_custom_range(
     ///     Seed(0),
     ///     num_input_random_bits,
@@ -289,6 +295,7 @@ where
     /// use tfhe::integer::gen_keys_radix;
     /// use tfhe::integer::oprf::{OprfPrivateKey, OprfServerKey};
     /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS_GAUSSIAN_2M128;
+    /// use tfhe::Seed;
     ///
     /// let size = 4;
     ///
@@ -298,11 +305,10 @@ where
     /// let oprf_pk = OprfPrivateKey::new(cks.as_ref());
     /// let oprf_sk = OprfServerKey::new(&oprf_pk, cks.as_ref()).unwrap();
     ///
-    /// let ct_res = oprf_sk.par_generate_oblivious_pseudo_random_signed_integer(
-    ///     tfhe::Seed(0),
-    ///     size as u64,
-    ///     &sks,
-    /// );
+    /// // DANGER: Using a fixed seed is insecure and only done here to show API usage.
+    /// // The proper way of generating a seed depends on your application.
+    /// let ct_res =
+    ///     oprf_sk.par_generate_oblivious_pseudo_random_signed_integer(Seed(0), size as u64, &sks);
     ///
     /// // Decrypt:
     /// let dec_result: i64 = cks.decrypt_signed(&ct_res);
@@ -339,6 +345,8 @@ where
     /// let oprf_pk = OprfPrivateKey::new(cks.as_ref());
     /// let oprf_sk = OprfServerKey::new(&oprf_pk, cks.as_ref()).unwrap();
     ///
+    /// // DANGER: Using a fixed seed is insecure and only done here to show API usage.
+    /// // The proper way of generating a seed depends on your application.
     /// let ct_res = oprf_sk.par_generate_oblivious_pseudo_random_signed_integer_bounded(
     ///     Seed(0),
     ///     random_bits_count,

--- a/tfhe/src/integer/oprf.rs
+++ b/tfhe/src/integer/oprf.rs
@@ -646,7 +646,7 @@ where
         let excluded_upper_bound = excluded_upper_bound.get();
 
         assert!(target_sks.message_modulus().0.is_power_of_two());
-        let message_bits_count = target_sks.message_modulus().0.ilog2() as u64;
+        let message_bits_count: u64 = target_sks.message_modulus().0.ilog2().into();
 
         assert!(
             !excluded_upper_bound.is_power_of_two(),
@@ -654,15 +654,20 @@ where
             function instead"
         );
 
+        // Since excluded_upper_bound is not a power of two, we know the ceil log2 of the value is
+        // the ilog2 + 1, this is how many bits are needed to represent the value
+        let excluded_upper_bound_log2: u64 = excluded_upper_bound.ilog2().into();
+        let excluded_upper_bound_ceil_log2 = excluded_upper_bound_log2 + 1;
         let num_bits_output = num_blocks_output * message_bits_count;
+
         assert!(
-            (excluded_upper_bound as f64) < 2_f64.powi(num_bits_output as i32),
+            excluded_upper_bound_ceil_log2 <= num_bits_output,
             "num_blocks_output(={num_blocks_output}) is too small to hold an integer \
-            up to excluded_upper_bound(={excluded_upper_bound})"
+            up to excluded_upper_bound(={excluded_upper_bound}). Output has {num_bits_output} bits,\
+            {excluded_upper_bound} needs {excluded_upper_bound_ceil_log2} bits to be represented."
         );
 
-        let post_mul_num_bits =
-            num_input_random_bits + (excluded_upper_bound as f64).log2().ceil() as u64;
+        let post_mul_num_bits = num_input_random_bits + excluded_upper_bound_ceil_log2;
 
         let num_blocks = post_mul_num_bits.div_ceil(message_bits_count);
 

--- a/tfhe/src/integer/oprf.rs
+++ b/tfhe/src/integer/oprf.rs
@@ -1,7 +1,9 @@
 use super::{RadixCiphertext, ServerKey, SignedRadixCiphertext};
 use crate::conformance::ParameterSetConformant;
 use crate::core_crypto::prelude::{Container, IntoContainerOwned};
-use crate::integer::ciphertext::IntegerRadixCiphertext;
+use crate::integer::ciphertext::{
+    IntegerRadixCiphertext, ReRandomizationHashAlgo, ReRandomizationKey,
+};
 use crate::integer::ClientKey;
 use crate::named::Named;
 use crate::shortint::oprf::{
@@ -141,6 +143,23 @@ where
         self.par_generate_oblivious_pseudo_random_integer_full_impl(seed, num_blocks, target_sks)
     }
 
+    pub fn par_generate_oblivious_pseudo_random_unsigned_integer_and_re_randomize(
+        &self,
+        seed: impl OprfSeed,
+        num_blocks: u64,
+        target_sks: &ServerKey,
+        re_randomization_key: &ReRandomizationKey,
+        re_randomization_hash_algo: ReRandomizationHashAlgo,
+    ) -> crate::Result<RadixCiphertext> {
+        self.par_generate_oblivious_pseudo_random_integer_full_and_re_randomize_impl(
+            seed,
+            num_blocks,
+            target_sks,
+            re_randomization_key,
+            re_randomization_hash_algo,
+        )
+    }
+
     /// Generates an encrypted `num_block` blocks unsigned integer
     /// taken uniformly in `[0, 2^random_bits_count[` using the given seed.
     /// The encrypted value is oblivious to the server.
@@ -190,6 +209,25 @@ where
         )
     }
 
+    pub fn par_generate_oblivious_pseudo_random_unsigned_integer_bounded_and_re_randomize(
+        &self,
+        seed: impl OprfSeed,
+        random_bits_count: u64,
+        num_blocks: u64,
+        target_sks: &ServerKey,
+        re_randomization_key: &ReRandomizationKey,
+        re_randomization_hash_algo: ReRandomizationHashAlgo,
+    ) -> crate::Result<RadixCiphertext> {
+        self.par_generate_oblivious_pseudo_random_integer_bounded_and_re_randomize_impl(
+            seed,
+            random_bits_count,
+            num_blocks,
+            target_sks,
+            re_randomization_key,
+            re_randomization_hash_algo,
+        )
+    }
+
     /// Generates an encrypted `num_blocks_output` blocks unsigned integer
     /// taken almost uniformly in [0, excluded_upper_bound[ using the given seed.
     /// The encrypted value is oblivious to the server.
@@ -233,57 +271,77 @@ where
     ///
     /// assert!(dec_result < excluded_upper_bound.get());
     /// ```
-    pub fn par_generate_oblivious_pseudo_random_unsigned_custom_range(
+    pub fn par_generate_oblivious_pseudo_random_unsigned_custom_range<InputSeed>(
         &self,
-        seed: impl OprfSeed,
+        seed: InputSeed,
         num_input_random_bits: u64,
         excluded_upper_bound: NonZeroU64,
         num_blocks_output: u64,
         target_sks: &ServerKey,
-    ) -> RadixCiphertext {
-        let excluded_upper_bound = excluded_upper_bound.get();
+    ) -> RadixCiphertext
+    where
+        InputSeed: OprfSeed,
+    {
+        self.par_generate_oblivious_pseudo_random_unsigned_custom_range_impl(
+            seed,
+            num_input_random_bits,
+            excluded_upper_bound,
+            num_blocks_output,
+            target_sks,
+            |sself: &Self,
+             seed: InputSeed,
+             num_input_random_bits: u64,
+             num_blocks: u64,
+             target_sks: &ServerKey| {
+                Ok(
+                    sself.par_generate_oblivious_pseudo_random_integer_bounded_impl(
+                        seed,
+                        num_input_random_bits,
+                        num_blocks,
+                        target_sks,
+                    ),
+                )
+            },
+        )
+        .unwrap()
+        // Safe to unwrap our closure returns an Ok result
+    }
 
-        assert!(target_sks.message_modulus().0.is_power_of_two());
-        let message_bits_count = target_sks.message_modulus().0.ilog2() as u64;
-
-        assert!(
-            !excluded_upper_bound.is_power_of_two(),
-            "Use the cheaper par_generate_oblivious_pseudo_random_unsigned_integer_bounded \
-            function instead"
-        );
-
-        let num_bits_output = num_blocks_output * message_bits_count;
-        assert!(
-            (excluded_upper_bound as f64) < 2_f64.powi(num_bits_output as i32),
-            "num_blocks_output(={num_blocks_output}) is too small to hold an integer \
-            up to excluded_upper_bound(={excluded_upper_bound})"
-        );
-
-        let post_mul_num_bits =
-            num_input_random_bits + (excluded_upper_bound as f64).log2().ceil() as u64;
-
-        let num_blocks = post_mul_num_bits.div_ceil(message_bits_count);
-
-        let random_input: RadixCiphertext = self
-            .par_generate_oblivious_pseudo_random_integer_bounded_impl(
-                seed,
-                num_input_random_bits,
-                num_blocks,
-                target_sks,
-            );
-
-        let random_multiplied =
-            target_sks.scalar_mul_parallelized(&random_input, excluded_upper_bound);
-
-        let mut result =
-            target_sks.scalar_right_shift_parallelized(&random_multiplied, num_input_random_bits);
-
-        // Adjust the number of leading (MSB) trivial zeros blocks
-        result
-            .blocks
-            .resize(num_blocks_output as usize, target_sks.key.create_trivial(0));
-
-        result
+    #[allow(clippy::too_many_arguments)]
+    pub fn par_generate_oblivious_pseudo_random_unsigned_custom_range_and_re_randomize<InputSeed>(
+        &self,
+        seed: InputSeed,
+        num_input_random_bits: u64,
+        excluded_upper_bound: NonZeroU64,
+        num_blocks_output: u64,
+        target_sks: &ServerKey,
+        re_randomization_key: &ReRandomizationKey,
+        re_randomization_hash_algo: ReRandomizationHashAlgo,
+    ) -> crate::Result<RadixCiphertext>
+    where
+        InputSeed: OprfSeed,
+    {
+        self.par_generate_oblivious_pseudo_random_unsigned_custom_range_impl(
+            seed,
+            num_input_random_bits,
+            excluded_upper_bound,
+            num_blocks_output,
+            target_sks,
+            |sself: &Self,
+             seed: InputSeed,
+             num_input_random_bits: u64,
+             num_blocks: u64,
+             target_sks: &ServerKey| {
+                sself.par_generate_oblivious_pseudo_random_integer_bounded_and_re_randomize_impl(
+                    seed,
+                    num_input_random_bits,
+                    num_blocks,
+                    target_sks,
+                    re_randomization_key,
+                    re_randomization_hash_algo,
+                )
+            },
+        )
     }
 
     /// Generates an encrypted `num_block` blocks signed integer
@@ -322,6 +380,23 @@ where
         target_sks: &ServerKey,
     ) -> SignedRadixCiphertext {
         self.par_generate_oblivious_pseudo_random_integer_full_impl(seed, num_blocks, target_sks)
+    }
+
+    pub fn par_generate_oblivious_pseudo_random_signed_integer_and_re_randomize(
+        &self,
+        seed: impl OprfSeed,
+        num_blocks: u64,
+        target_sks: &ServerKey,
+        re_randomization_key: &ReRandomizationKey,
+        re_randomization_hash_algo: ReRandomizationHashAlgo,
+    ) -> crate::Result<SignedRadixCiphertext> {
+        self.par_generate_oblivious_pseudo_random_integer_full_and_re_randomize_impl(
+            seed,
+            num_blocks,
+            target_sks,
+            re_randomization_key,
+            re_randomization_hash_algo,
+        )
     }
 
     /// Generates an encrypted `num_block` blocks signed integer
@@ -374,6 +449,25 @@ where
         )
     }
 
+    pub fn par_generate_oblivious_pseudo_random_signed_integer_bounded_and_re_randomize(
+        &self,
+        seed: impl OprfSeed,
+        random_bits_count: u64,
+        num_blocks: u64,
+        target_sks: &ServerKey,
+        re_randomization_key: &ReRandomizationKey,
+        re_randomization_hash_algo: ReRandomizationHashAlgo,
+    ) -> crate::Result<SignedRadixCiphertext> {
+        self.par_generate_oblivious_pseudo_random_integer_bounded_and_re_randomize_impl(
+            seed,
+            random_bits_count,
+            num_blocks,
+            target_sks,
+            re_randomization_key,
+            re_randomization_hash_algo,
+        )
+    }
+
     fn par_generate_oblivious_pseudo_random_integer_full_impl<T: IntegerRadixCiphertext>(
         &self,
         seed: impl OprfSeed,
@@ -395,6 +489,39 @@ where
             .expect("Expected a single chunk for the radix being generated, got 0");
 
         T::from(blocks)
+    }
+
+    fn par_generate_oblivious_pseudo_random_integer_full_and_re_randomize_impl<
+        T: IntegerRadixCiphertext,
+    >(
+        &self,
+        seed: impl OprfSeed,
+        num_blocks: u64,
+        target_sks: &ServerKey,
+        re_randomization_key: &ReRandomizationKey,
+        re_randomization_hash_algo: ReRandomizationHashAlgo,
+    ) -> crate::Result<T> {
+        assert!(target_sks.message_modulus().0.is_power_of_two());
+        let message_bits_count = target_sks.message_modulus().0.ilog2() as u64;
+
+        let (compact_public_key, key_switching_key_material) =
+            re_randomization_key.get_cpk_and_optional_ksk();
+
+        let blocks = self
+            .key
+            .generate_oblivious_pseudo_random_bits_chunks_and_re_randomize(
+                seed,
+                &[num_blocks * message_bits_count],
+                &target_sks.key,
+                &compact_public_key.key,
+                key_switching_key_material.as_ref().map(|k| &k.material),
+                re_randomization_hash_algo,
+            )?
+            .into_iter()
+            .next()
+            .expect("Expected a single chunk for the radix being generated, got 0");
+
+        Ok(T::from(blocks))
     }
 
     fn par_generate_oblivious_pseudo_random_integer_bounded_impl<T: IntegerRadixCiphertext>(
@@ -440,6 +567,119 @@ where
         }
 
         T::from(blocks)
+    }
+
+    fn par_generate_oblivious_pseudo_random_integer_bounded_and_re_randomize_impl<
+        T: IntegerRadixCiphertext,
+    >(
+        &self,
+        seed: impl OprfSeed,
+        random_bits_count: u64,
+        num_blocks: u64,
+        target_sks: &ServerKey,
+        re_randomization_key: &ReRandomizationKey,
+        re_randomization_hash_algo: ReRandomizationHashAlgo,
+    ) -> crate::Result<T> {
+        assert!(target_sks.message_modulus().0.is_power_of_two());
+        let message_bits_count = target_sks.message_modulus().0.ilog2() as u64;
+        let range_bits_count = message_bits_count * num_blocks;
+        assert!(range_bits_count > 0);
+
+        if T::IS_SIGNED {
+            let signed_range_bits_count = range_bits_count.saturating_sub(1);
+            assert!(
+                random_bits_count <= signed_range_bits_count,
+                "The range asked for a random value in (=[0, 2^{random_bits_count}[) \
+                which does not fit in the available range \
+                [-2^{signed_range_bits_count}, 2^{signed_range_bits_count}[",
+            );
+        } else {
+            assert!(
+                random_bits_count <= range_bits_count,
+                "The range asked for a random value in (=[0, 2^{random_bits_count}[) \
+                which does not fit in the available range [0, 2^{range_bits_count}[",
+            );
+        }
+
+        let (compact_public_key, key_switching_key_material) =
+            re_randomization_key.get_cpk_and_optional_ksk();
+
+        let mut blocks = self
+            .key
+            .generate_oblivious_pseudo_random_bits_chunks_and_re_randomize(
+                seed,
+                &[random_bits_count],
+                &target_sks.key,
+                &compact_public_key.key,
+                key_switching_key_material.as_ref().map(|k| &k.material),
+                re_randomization_hash_algo,
+            )?
+            .into_iter()
+            .next()
+            .expect("Expected a single chunk for the radix being generated, got 0");
+
+        if blocks.len() < num_blocks as usize {
+            blocks.resize(num_blocks as usize, target_sks.key.create_trivial(0));
+        }
+
+        Ok(T::from(blocks))
+    }
+
+    fn par_generate_oblivious_pseudo_random_unsigned_custom_range_impl<InputSeed>(
+        &self,
+        seed: InputSeed,
+        num_input_random_bits: u64,
+        excluded_upper_bound: NonZeroU64,
+        num_blocks_output: u64,
+        target_sks: &ServerKey,
+        prf_callback: impl Fn(
+            &Self,      // sself
+            InputSeed,  // seed
+            u64,        // num_input_random_bits
+            u64,        // num_blocks
+            &ServerKey, // target_sks
+        ) -> crate::Result<RadixCiphertext>,
+    ) -> crate::Result<RadixCiphertext>
+    where
+        InputSeed: OprfSeed,
+    {
+        let excluded_upper_bound = excluded_upper_bound.get();
+
+        assert!(target_sks.message_modulus().0.is_power_of_two());
+        let message_bits_count = target_sks.message_modulus().0.ilog2() as u64;
+
+        assert!(
+            !excluded_upper_bound.is_power_of_two(),
+            "Use the cheaper par_generate_oblivious_pseudo_random_unsigned_integer_bounded \
+            function instead"
+        );
+
+        let num_bits_output = num_blocks_output * message_bits_count;
+        assert!(
+            (excluded_upper_bound as f64) < 2_f64.powi(num_bits_output as i32),
+            "num_blocks_output(={num_blocks_output}) is too small to hold an integer \
+            up to excluded_upper_bound(={excluded_upper_bound})"
+        );
+
+        let post_mul_num_bits =
+            num_input_random_bits + (excluded_upper_bound as f64).log2().ceil() as u64;
+
+        let num_blocks = post_mul_num_bits.div_ceil(message_bits_count);
+
+        let random_input = prf_callback(self, seed, num_input_random_bits, num_blocks, target_sks)?;
+
+        let random_multiplied =
+            target_sks.scalar_mul_parallelized(&random_input, excluded_upper_bound);
+
+        let mut result =
+            target_sks.scalar_right_shift_parallelized(&random_multiplied, num_input_random_bits);
+
+        // Adjust the number of leading (MSB) trivial zeros blocks
+        result
+            .blocks
+            .resize(num_blocks_output as usize, target_sks.key.create_trivial(0));
+
+        Ok(result)
     }
 }
 

--- a/tfhe/src/integer/oprf.rs
+++ b/tfhe/src/integer/oprf.rs
@@ -104,6 +104,7 @@ where
     pub fn into_raw_parts(self) -> ShortintGenericOprfServerKey<C> {
         self.key
     }
+
     /// Generates an encrypted `num_block` blocks unsigned integer
     /// taken uniformly in its full range using the given seed.
     /// The encrypted value is oblivious to the server.

--- a/tfhe/src/integer/server_key/radix_parallel/bitonic_shuffle.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/bitonic_shuffle.rs
@@ -3,10 +3,11 @@
 //! A bitonic sorting network for n=2^k elements has k*(k+1)/2 stages,
 //! each with n/2 comparators. It sorts any input sequence.
 use crate::core_crypto::prelude::Container;
+use crate::integer::ciphertext::{ReRandomizationHashAlgo, ReRandomizationKey};
 use crate::integer::oprf::GenericOprfServerKey;
 use crate::integer::prelude::ServerKeyDefaultCMux;
 use crate::integer::{IntegerRadixCiphertext, RadixCiphertext, ServerKey};
-use crate::shortint::MessageModulus;
+use crate::shortint::{Ciphertext, MessageModulus};
 use crate::OprfSeed;
 use rayon::prelude::*;
 use tfhe_fft::c64;
@@ -124,6 +125,55 @@ impl ServerKey {
         S: OprfSeed,
         C: Container<Element = c64> + Sync,
     {
+        self.bitonic_shuffle_impl(data, key_size, |chunks| {
+            Ok(oprf_key
+                .key
+                .generate_oblivious_pseudo_random_bits_chunks(seed, chunks, &self.key))
+        })
+    }
+
+    pub fn re_randomized_keys_bitonic_shuffle<T, S, C>(
+        &self,
+        oprf_key: &GenericOprfServerKey<C>,
+        data: Vec<T>,
+        key_size: BitonicShuffleKeySize,
+        seed: S,
+        re_randomization_key: &ReRandomizationKey,
+        re_randomization_hash_algo: ReRandomizationHashAlgo,
+    ) -> Result<Vec<T>, crate::Error>
+    where
+        T: IntegerRadixCiphertext,
+        S: OprfSeed,
+        C: Container<Element = c64> + Sync,
+    {
+        let (cpk, ksk) = re_randomization_key.get_cpk_and_optional_ksk();
+
+        self.bitonic_shuffle_impl(data, key_size, |chunks| {
+            oprf_key
+                .key
+                .generate_oblivious_pseudo_random_bits_chunks_and_re_randomize(
+                    seed,
+                    chunks,
+                    &self.key,
+                    &cpk.key,
+                    ksk.as_ref().map(|k| &k.material),
+                    re_randomization_hash_algo,
+                )
+        })
+    }
+
+    fn bitonic_shuffle_impl<T, F>(
+        &self,
+        data: Vec<T>,
+        key_size: BitonicShuffleKeySize,
+        prf_callback: F,
+    ) -> Result<Vec<T>, crate::Error>
+    where
+        T: IntegerRadixCiphertext,
+        F: FnOnce(
+            &[u64], // chunks
+        ) -> crate::Result<Vec<Vec<Ciphertext>>>,
+    {
         let key_num_blocks = key_size.num_blocks_of_keys(data.len(), self.message_modulus()) as u64;
 
         if key_num_blocks == 0 {
@@ -139,9 +189,7 @@ impl ServerKey {
         let key_num_bits = key_num_blocks * self.message_modulus().0.ilog2() as u64;
 
         let chunks = vec![key_num_bits; data.len()];
-        let block_chunks = oprf_key
-            .key
-            .generate_oblivious_pseudo_random_bits_chunks(seed, &chunks, &self.key);
+        let block_chunks = prf_callback(&chunks)?;
 
         let keys = block_chunks
             .into_iter()

--- a/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_oprf.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_oprf.rs
@@ -339,12 +339,7 @@ pub(crate) trait OprfReRandTestRunner {
         rerand_hash_algo: ReRandomizationHashAlgo,
     ) -> (RadixCiphertext, RadixCiphertext);
 
-    // TODO: make this function return the tuple directly once GPU supports the custom_range
-    // generation with rerand
-    /// Re-randomizing custom-range generation.
-    ///
-    /// Returns `None` on backends that do not expose a re-randomizing custom-range primitive yet
-    /// (currently the GPU backend), in which case the generic test skips this sub-test.
+    /// Return the prf output once without and once with re-randomization.
     fn unsigned_custom_range(
         &mut self,
         prf_seed: impl OprfSeed,
@@ -352,7 +347,7 @@ pub(crate) trait OprfReRandTestRunner {
         excluded_upper_bound: NonZeroU64,
         num_blocks_output: u64,
         rerand_hash_algo: ReRandomizationHashAlgo,
-    ) -> Option<(RadixCiphertext, RadixCiphertext)>;
+    ) -> (RadixCiphertext, RadixCiphertext);
 
     /// Return the prf output once without and once with re-randomization.
     fn signed_full(
@@ -498,7 +493,7 @@ impl OprfReRandTestRunner for CpuOprfReRandTestRunner {
         excluded_upper_bound: NonZeroU64,
         num_blocks_output: u64,
         rerand_hash_algo: ReRandomizationHashAlgo,
-    ) -> Option<(RadixCiphertext, RadixCiphertext)> {
+    ) -> (RadixCiphertext, RadixCiphertext) {
         let state = self.state();
         let rerand_key = state.rerand_key();
 
@@ -527,7 +522,7 @@ impl OprfReRandTestRunner for CpuOprfReRandTestRunner {
             )
             .unwrap();
 
-        Some((prf_not_rerand, prf_rerand))
+        (prf_not_rerand, prf_rerand)
     }
 
     fn signed_full(
@@ -799,17 +794,13 @@ fn subtest_unsigned_integer_custom_range<TestRunner: OprfReRandTestRunner>(
     let excluded_upper_bound_ceil_log2 = excluded_upper_bound_log2 + 1;
     let random_block_count = excluded_upper_bound_ceil_log2.div_ceil(message_bits);
 
-    let Some((prf_not_rerand, prf_rerand)) = test_runner.unsigned_custom_range(
+    let (prf_not_rerand, prf_rerand) = test_runner.unsigned_custom_range(
         prf_seed,
         INPUT_RANDOM_BIT_COUNT,
         excluded_upper_bound,
         output_num_blocks,
         rerand_hash_algo,
-    ) else {
-        // Underlying executor does not have the custom_range support
-        // TODO: remove when GPU has support
-        return;
-    };
+    );
 
     assert_eq!(prf_not_rerand.blocks.len() as u64, output_num_blocks);
     assert_eq!(prf_rerand.blocks.len() as u64, output_num_blocks);

--- a/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_oprf.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_oprf.rs
@@ -2,13 +2,25 @@ use crate::core_crypto::commons::generators::DeterministicSeeder;
 use crate::core_crypto::commons::math::random::tests::{
     cumulate, dkw_alpha_from_epsilon, sup_diff,
 };
+use crate::integer::ciphertext::{
+    RadixCiphertext, ReRandomizationHashAlgo, ReRandomizationKey, SignedRadixCiphertext,
+};
 use crate::integer::keycache::KEY_CACHE;
 use crate::integer::oprf::{OprfPrivateKey, OprfServerKey};
 use crate::integer::server_key::radix_parallel::tests_long_run::OpSequenceFunctionExecutor;
 use crate::integer::server_key::radix_parallel::tests_unsigned::CpuOprfExecutor;
 use crate::integer::tests::create_parameterized_test;
-use crate::integer::{IntegerKeyKind, RadixCiphertext, RadixClientKey, ServerKey};
+use crate::integer::{
+    gen_keys, ClientKey, CompactPrivateKey, CompactPublicKey, IntegerKeyKind, RadixClientKey,
+    ServerKey,
+};
+use crate::shortint::parameters::test_params::{
+    TEST_PARAM_MESSAGE_2_CARRY_2_KS32_PBS_TUNIFORM_2M128,
+    TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+    TEST_PARAM_MULTI_BIT_GROUP_3_MESSAGE_2_CARRY_2_KS_PBS_GAUSSIAN_2M128,
+};
 use crate::shortint::parameters::*;
+use crate::shortint::OprfSeed;
 use crate::Tag;
 use rand::Rng;
 use statrs::distribution::ContinuousCDF;
@@ -25,6 +37,12 @@ create_parameterized_test!(oprf_any_range_unsigned {
 });
 create_parameterized_test!(oprf_almost_uniformity_unsigned {
     PARAM_MESSAGE_2_CARRY_2_KS_PBS_GAUSSIAN_2M128
+});
+
+create_parameterized_test!(pseudo_random_integer_and_rerand {
+    TEST_PARAM_MULTI_BIT_GROUP_3_MESSAGE_2_CARRY_2_KS_PBS_GAUSSIAN_2M128,
+    TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+    TEST_PARAM_MESSAGE_2_CARRY_2_KS32_PBS_TUNIFORM_2M128
 });
 
 fn oprf_uniformity_unsigned<P>(param: P)
@@ -293,4 +311,695 @@ pub(crate) fn probability_density_function_from_density(density: &[usize]) -> Ve
         .iter()
         .map(|count| *count as f64 / total_count as f64)
         .collect()
+}
+
+// PRF rerand below
+
+pub(crate) trait OprfReRandTestRunner {
+    /// Builds the compute, OPRF and re-randomization keys for `param` and returns the client key
+    /// used to decrypt the results.
+    ///
+    /// Re-randomization being tested independently too we only manage the Derived CPK case.
+    fn setup(&mut self, param: TestParameters) -> ClientKey;
+
+    /// Return the prf output once without and once with re-randomization.
+    fn unsigned_full(
+        &mut self,
+        prf_seed: impl OprfSeed,
+        num_blocks: u64,
+        rerand_hash_algo: ReRandomizationHashAlgo,
+    ) -> (RadixCiphertext, RadixCiphertext);
+
+    /// Return the prf output once without and once with re-randomization.
+    fn unsigned_bounded(
+        &mut self,
+        prf_seed: impl OprfSeed,
+        random_bit_count: u64,
+        num_blocks: u64,
+        rerand_hash_algo: ReRandomizationHashAlgo,
+    ) -> (RadixCiphertext, RadixCiphertext);
+
+    // TODO: make this function return the tuple directly once GPU supports the custom_range
+    // generation with rerand
+    /// Re-randomizing custom-range generation.
+    ///
+    /// Returns `None` on backends that do not expose a re-randomizing custom-range primitive yet
+    /// (currently the GPU backend), in which case the generic test skips this sub-test.
+    fn unsigned_custom_range(
+        &mut self,
+        prf_seed: impl OprfSeed,
+        num_input_random_bits: u64,
+        excluded_upper_bound: NonZeroU64,
+        num_blocks_output: u64,
+        rerand_hash_algo: ReRandomizationHashAlgo,
+    ) -> Option<(RadixCiphertext, RadixCiphertext)>;
+
+    /// Return the prf output once without and once with re-randomization.
+    fn signed_full(
+        &mut self,
+        prf_seed: impl OprfSeed,
+        num_blocks: u64,
+        rerand_hash_algo: ReRandomizationHashAlgo,
+    ) -> (SignedRadixCiphertext, SignedRadixCiphertext);
+
+    /// Return the prf output once without and once with re-randomization.
+    fn signed_bounded(
+        &mut self,
+        prf_seed: impl OprfSeed,
+        random_bit_count: u64,
+        num_blocks: u64,
+        rerand_hash_algo: ReRandomizationHashAlgo,
+    ) -> (SignedRadixCiphertext, SignedRadixCiphertext);
+}
+
+/// CPU implementation of [`OprfReRandTestRunner`].
+///
+/// Uses a derived compact public key (no key-switch) for re-randomization.
+pub(crate) struct CpuOprfReRandTestRunner {
+    state: Option<CpuOprfReRandState>,
+}
+
+struct CpuOprfReRandState {
+    sks: ServerKey,
+    oprf_sks: OprfServerKey,
+    rerand_cpk: CompactPublicKey,
+}
+
+impl CpuOprfReRandState {
+    fn rerand_key(&self) -> ReRandomizationKey<'_> {
+        ReRandomizationKey::DerivedCPKWithoutKeySwitch {
+            cpk: &self.rerand_cpk,
+        }
+    }
+}
+
+impl CpuOprfReRandTestRunner {
+    pub(crate) fn new() -> Self {
+        Self { state: None }
+    }
+
+    fn state(&self) -> &CpuOprfReRandState {
+        self.state.as_ref().expect("setup was not properly called")
+    }
+}
+
+impl OprfReRandTestRunner for CpuOprfReRandTestRunner {
+    fn setup(&mut self, param: TestParameters) -> ClientKey {
+        let (cks, sks) = gen_keys(param, IntegerKeyKind::Radix);
+
+        // Derived compact public key, re-using the compute secret key
+        // legacy rerand not covered by this test
+        let privk: CompactPrivateKey<&[u64]> = (&cks).try_into().unwrap();
+        let rerand_cpk = CompactPublicKey::new(&privk);
+
+        let oprf_cks = OprfPrivateKey::new(&cks);
+        let oprf_sks = OprfServerKey::new(&oprf_cks, &cks).unwrap();
+
+        self.state = Some(CpuOprfReRandState {
+            sks,
+            oprf_sks,
+            rerand_cpk,
+        });
+
+        cks
+    }
+
+    fn unsigned_full(
+        &mut self,
+        prf_seed: impl OprfSeed,
+        num_blocks: u64,
+        rerand_hash_algo: ReRandomizationHashAlgo,
+    ) -> (RadixCiphertext, RadixCiphertext) {
+        let state = self.state();
+        let rerand_key = state.rerand_key();
+
+        let prf_seed = prf_seed.into_bytes();
+        let prf_seed = prf_seed.as_ref();
+
+        let prf_not_rerand = state
+            .oprf_sks
+            .par_generate_oblivious_pseudo_random_unsigned_integer(
+                prf_seed, num_blocks, &state.sks,
+            );
+        let prf_rerand = state
+            .oprf_sks
+            .par_generate_oblivious_pseudo_random_unsigned_integer_and_re_randomize(
+                prf_seed,
+                num_blocks,
+                &state.sks,
+                &rerand_key,
+                rerand_hash_algo,
+            )
+            .unwrap();
+
+        (prf_not_rerand, prf_rerand)
+    }
+
+    fn unsigned_bounded(
+        &mut self,
+        prf_seed: impl OprfSeed,
+        random_bit_count: u64,
+        num_blocks: u64,
+        rerand_hash_algo: ReRandomizationHashAlgo,
+    ) -> (RadixCiphertext, RadixCiphertext) {
+        let state = self.state();
+        let rerand_key = state.rerand_key();
+
+        let prf_seed = prf_seed.into_bytes();
+        let prf_seed = prf_seed.as_ref();
+
+        let prf_not_rerand = state
+            .oprf_sks
+            .par_generate_oblivious_pseudo_random_unsigned_integer_bounded(
+                prf_seed,
+                random_bit_count,
+                num_blocks,
+                &state.sks,
+            );
+        let prf_rerand = state
+            .oprf_sks
+            .par_generate_oblivious_pseudo_random_unsigned_integer_bounded_and_re_randomize(
+                prf_seed,
+                random_bit_count,
+                num_blocks,
+                &state.sks,
+                &rerand_key,
+                rerand_hash_algo,
+            )
+            .unwrap();
+
+        (prf_not_rerand, prf_rerand)
+    }
+
+    fn unsigned_custom_range(
+        &mut self,
+        prf_seed: impl OprfSeed,
+        num_input_random_bits: u64,
+        excluded_upper_bound: NonZeroU64,
+        num_blocks_output: u64,
+        rerand_hash_algo: ReRandomizationHashAlgo,
+    ) -> Option<(RadixCiphertext, RadixCiphertext)> {
+        let state = self.state();
+        let rerand_key = state.rerand_key();
+
+        let prf_seed = prf_seed.into_bytes();
+        let prf_seed = prf_seed.as_ref();
+
+        let prf_not_rerand = state
+            .oprf_sks
+            .par_generate_oblivious_pseudo_random_unsigned_custom_range(
+                prf_seed,
+                num_input_random_bits,
+                excluded_upper_bound,
+                num_blocks_output,
+                &state.sks,
+            );
+        let prf_rerand = state
+            .oprf_sks
+            .par_generate_oblivious_pseudo_random_unsigned_custom_range_and_re_randomize(
+                prf_seed,
+                num_input_random_bits,
+                excluded_upper_bound,
+                num_blocks_output,
+                &state.sks,
+                &rerand_key,
+                rerand_hash_algo,
+            )
+            .unwrap();
+
+        Some((prf_not_rerand, prf_rerand))
+    }
+
+    fn signed_full(
+        &mut self,
+        prf_seed: impl OprfSeed,
+        num_blocks: u64,
+        rerand_hash_algo: ReRandomizationHashAlgo,
+    ) -> (SignedRadixCiphertext, SignedRadixCiphertext) {
+        let state = self.state();
+        let rerand_key = state.rerand_key();
+
+        let prf_seed = prf_seed.into_bytes();
+        let prf_seed = prf_seed.as_ref();
+
+        let prf_not_rerand = state
+            .oprf_sks
+            .par_generate_oblivious_pseudo_random_signed_integer(prf_seed, num_blocks, &state.sks);
+        let prf_rerand = state
+            .oprf_sks
+            .par_generate_oblivious_pseudo_random_signed_integer_and_re_randomize(
+                prf_seed,
+                num_blocks,
+                &state.sks,
+                &rerand_key,
+                rerand_hash_algo,
+            )
+            .unwrap();
+
+        (prf_not_rerand, prf_rerand)
+    }
+
+    fn signed_bounded(
+        &mut self,
+        prf_seed: impl OprfSeed,
+        random_bit_count: u64,
+        num_blocks: u64,
+        rerand_hash_algo: ReRandomizationHashAlgo,
+    ) -> (SignedRadixCiphertext, SignedRadixCiphertext) {
+        let state = self.state();
+        let rerand_key = state.rerand_key();
+
+        let prf_seed = prf_seed.into_bytes();
+        let prf_seed = prf_seed.as_ref();
+
+        let prf_not_rerand = state
+            .oprf_sks
+            .par_generate_oblivious_pseudo_random_signed_integer_bounded(
+                prf_seed,
+                random_bit_count,
+                num_blocks,
+                &state.sks,
+            );
+        let prf_rerand = state
+            .oprf_sks
+            .par_generate_oblivious_pseudo_random_signed_integer_bounded_and_re_randomize(
+                prf_seed,
+                random_bit_count,
+                num_blocks,
+                &state.sks,
+                &rerand_key,
+                rerand_hash_algo,
+            )
+            .unwrap();
+
+        (prf_not_rerand, prf_rerand)
+    }
+}
+
+#[track_caller]
+fn check_unsigned_value_and_re_rand_are_ok(
+    lhs: &RadixCiphertext,
+    rhs: &RadixCiphertext,
+    cks: &ClientKey,
+    random_block_count: usize,
+) -> u128 {
+    let lhs_blocks = &lhs.blocks;
+    let rhs_blocks = &rhs.blocks;
+
+    assert_eq!(lhs_blocks.len(), rhs_blocks.len());
+    let message_bits: u64 = cks.parameters().message_modulus().0.ilog2().into();
+    let ct_bits = lhs_blocks.len() as u64 * message_bits;
+
+    // The total number of blocks can be larger than the random bit count for bounded cases
+    for (idx, (lhs_block, rhs_block)) in lhs_blocks.iter().zip(rhs_blocks.iter()).enumerate() {
+        if idx < random_block_count {
+            assert_ne!(
+                lhs_block.ct.as_ref(),
+                rhs_block.ct.as_ref(),
+                "Error verifying block #{idx} differ in lhs and rhs"
+            );
+        } else {
+            // Upper blocks which are not random are trivial 0s;
+            assert_eq!(lhs_block.ct.as_ref(), rhs_block.ct.as_ref());
+            assert!(lhs_block.ct.as_ref().iter().all(|&x| x == 0))
+        }
+    }
+
+    assert!(
+        ct_bits <= u128::BITS as u64,
+        "ciphertext too large to decrypt properly"
+    );
+
+    let dec_lhs: u128 = cks.decrypt_radix(lhs);
+    let dec_rhs: u128 = cks.decrypt_radix(rhs);
+
+    assert_eq!(dec_lhs, dec_rhs);
+
+    dec_lhs
+}
+
+fn subtest_unsigned_integer_full<TestRunner: OprfReRandTestRunner>(
+    prf_seed: impl OprfSeed,
+    cks: &ClientKey,
+    test_runner: &mut TestRunner,
+    rerand_hash_algo: ReRandomizationHashAlgo,
+) {
+    const OUTPUT_BIT_COUNT: u64 = 16;
+
+    let prf_seed = prf_seed.into_bytes();
+    let prf_seed = prf_seed.as_ref();
+
+    let message_bits: u64 = cks.parameters().message_modulus().0.ilog2().into();
+
+    let num_blocks = OUTPUT_BIT_COUNT.div_ceil(message_bits);
+
+    let (prf_not_rerand, prf_rerand) =
+        test_runner.unsigned_full(prf_seed, num_blocks, rerand_hash_algo);
+
+    assert_eq!(prf_not_rerand.blocks.len() as u64, num_blocks);
+    assert_eq!(prf_rerand.blocks.len() as u64, num_blocks);
+
+    let decrypted = check_unsigned_value_and_re_rand_are_ok(
+        &prf_not_rerand,
+        &prf_rerand,
+        cks,
+        num_blocks as usize,
+    );
+
+    let random_value_range = 0..1 << OUTPUT_BIT_COUNT;
+    assert!(
+        random_value_range.contains(&decrypted),
+        "range: {random_value_range:?}, decrypted: {decrypted}"
+    );
+}
+
+fn subtest_unsigned_integer_bounded<TestRunner: OprfReRandTestRunner>(
+    prf_seed: impl OprfSeed,
+    cks: &ClientKey,
+    test_runner: &mut TestRunner,
+    rerand_hash_algo: ReRandomizationHashAlgo,
+) {
+    let mut rng = rand::thread_rng();
+    const OUTPUT_BIT_COUNT: u64 = 16;
+
+    let message_bits: u64 = cks.parameters().message_modulus().0.ilog2().into();
+
+    let num_blocks = OUTPUT_BIT_COUNT.div_ceil(message_bits);
+    let random_bit_count_range = 1..=OUTPUT_BIT_COUNT;
+    let random_bit_count = rng.gen_range(random_bit_count_range);
+    let random_value_range = 0..=1 << random_bit_count;
+    let random_block_count = random_bit_count.div_ceil(message_bits);
+
+    let (prf_not_rerand, prf_rerand) =
+        test_runner.unsigned_bounded(prf_seed, random_bit_count, num_blocks, rerand_hash_algo);
+
+    assert_eq!(prf_not_rerand.blocks.len() as u64, num_blocks);
+    assert_eq!(prf_rerand.blocks.len() as u64, num_blocks);
+
+    let decrypted = check_unsigned_value_and_re_rand_are_ok(
+        &prf_not_rerand,
+        &prf_rerand,
+        cks,
+        random_block_count as usize,
+    );
+
+    assert!(
+        random_value_range.contains(&decrypted),
+        "range: {random_value_range:?}, decrypted: {decrypted}"
+    );
+}
+
+fn subtest_integer_bounded_padding_stays_trivial<TestRunner: OprfReRandTestRunner>(
+    prf_seed: impl OprfSeed,
+    cks: &ClientKey,
+    test_runner: &mut TestRunner,
+    rerand_hash_algo: ReRandomizationHashAlgo,
+) {
+    let mut rng = rand::thread_rng();
+    const OUTPUT_BIT_COUNT: u64 = 16;
+
+    let prf_seed = prf_seed.into_bytes();
+    let prf_seed = prf_seed.as_ref();
+
+    let message_bits: u64 = cks.parameters().message_modulus().0.ilog2().into();
+
+    let num_blocks = OUTPUT_BIT_COUNT.div_ceil(message_bits);
+    // at most num_blocks - 1 of random to leave at least one block of trivial padding
+    let random_bit_count_range = 1..=(num_blocks - 1) * message_bits;
+    let random_bit_count = rng.gen_range(random_bit_count_range);
+    let random_block_count = random_bit_count.div_ceil(message_bits);
+
+    {
+        let (prf_not_rerand, prf_rerand) =
+            test_runner.unsigned_bounded(prf_seed, random_bit_count, num_blocks, rerand_hash_algo);
+
+        assert!(
+            prf_not_rerand.blocks[random_block_count as usize..]
+                .iter()
+                .all(|ct| ct.is_trivial()),
+            "Expected all padding blocks to be trivial 0s"
+        );
+        assert!(
+            prf_rerand.blocks[random_block_count as usize..]
+                .iter()
+                .all(|ct| ct.is_trivial()),
+            "Expected all padding blocks to be trivial 0s"
+        );
+    }
+
+    {
+        let (prf_not_rerand, prf_rerand) =
+            test_runner.signed_bounded(prf_seed, random_bit_count, num_blocks, rerand_hash_algo);
+
+        assert!(
+            prf_not_rerand.blocks[random_block_count as usize..]
+                .iter()
+                .all(|ct| ct.is_trivial()),
+            "Expected all padding blocks to be trivial 0s"
+        );
+        assert!(
+            prf_rerand.blocks[random_block_count as usize..]
+                .iter()
+                .all(|ct| ct.is_trivial()),
+            "Expected all padding blocks to be trivial 0s"
+        );
+    }
+}
+
+fn subtest_unsigned_integer_custom_range<TestRunner: OprfReRandTestRunner>(
+    prf_seed: impl OprfSeed,
+    cks: &ClientKey,
+    test_runner: &mut TestRunner,
+    rerand_hash_algo: ReRandomizationHashAlgo,
+) {
+    let mut rng = rand::thread_rng();
+    // This may cause some values to not appear, but it's fine since we don't test uniformity
+    // Do not use in production
+    const INPUT_RANDOM_BIT_COUNT: u64 = 8;
+    const OUTPUT_BIT_COUNT: u64 = 16;
+
+    let message_bits: u64 = cks.parameters().message_modulus().0.ilog2().into();
+
+    let output_num_blocks = OUTPUT_BIT_COUNT.div_ceil(message_bits);
+    let excluded_upper_bound = {
+        let mut result = NonZeroU64::new(rng.gen_range(1..=1 << OUTPUT_BIT_COUNT)).unwrap();
+
+        // Custom range does not accept power of two range, since other primitives are more
+        // efficient
+        while result.is_power_of_two() {
+            result = NonZeroU64::new(rng.gen_range(1..=1 << OUTPUT_BIT_COUNT)).unwrap();
+        }
+
+        result
+    };
+    let random_value_range = 0u128..excluded_upper_bound.get().into();
+    // range_excluded_upper_bound is not a power of 2, get how many bits are necessary to
+    // represent it via the ceil log2
+    let excluded_upper_bound_log2: u64 = excluded_upper_bound.ilog2().into();
+    let excluded_upper_bound_ceil_log2 = excluded_upper_bound_log2 + 1;
+    let random_block_count = excluded_upper_bound_ceil_log2.div_ceil(message_bits);
+
+    let Some((prf_not_rerand, prf_rerand)) = test_runner.unsigned_custom_range(
+        prf_seed,
+        INPUT_RANDOM_BIT_COUNT,
+        excluded_upper_bound,
+        output_num_blocks,
+        rerand_hash_algo,
+    ) else {
+        // Underlying executor does not have the custom_range support
+        // TODO: remove when GPU has support
+        return;
+    };
+
+    assert_eq!(prf_not_rerand.blocks.len() as u64, output_num_blocks);
+    assert_eq!(prf_rerand.blocks.len() as u64, output_num_blocks);
+
+    let decrypted = check_unsigned_value_and_re_rand_are_ok(
+        &prf_not_rerand,
+        &prf_rerand,
+        cks,
+        random_block_count as usize,
+    );
+
+    assert!(
+        random_value_range.contains(&decrypted),
+        "range: {random_value_range:?}, decrypted: {decrypted}"
+    );
+}
+
+#[track_caller]
+fn check_signed_value_and_re_rand_are_ok(
+    lhs: &SignedRadixCiphertext,
+    rhs: &SignedRadixCiphertext,
+    cks: &ClientKey,
+    random_block_count: usize,
+) -> i128 {
+    let lhs_blocks = &lhs.blocks;
+    let rhs_blocks = &rhs.blocks;
+
+    assert_eq!(lhs_blocks.len(), rhs_blocks.len());
+    let message_bits: u64 = cks.parameters().message_modulus().0.ilog2().into();
+    let ct_bits = lhs_blocks.len() as u64 * message_bits;
+
+    // The total number of blocks can be larger than the random bit count for bounded cases
+    for (idx, (lhs_block, rhs_block)) in lhs_blocks.iter().zip(rhs_blocks.iter()).enumerate() {
+        if idx < random_block_count {
+            assert_ne!(
+                lhs_block.ct.as_ref(),
+                rhs_block.ct.as_ref(),
+                "Error verifying block #{idx} differ in lhs and rhs"
+            );
+        } else {
+            // Upper blocks which are not random are trivial 0s;
+            assert_eq!(lhs_block.ct.as_ref(), rhs_block.ct.as_ref());
+            assert!(lhs_block.ct.as_ref().iter().all(|&x| x == 0))
+        }
+    }
+
+    assert!(
+        ct_bits <= i128::BITS as u64,
+        "ciphertext too large to decrypt properly"
+    );
+
+    let dec_lhs: i128 = cks.decrypt_signed_radix(lhs);
+    let dec_rhs: i128 = cks.decrypt_signed_radix(rhs);
+
+    assert_eq!(dec_lhs, dec_rhs);
+
+    dec_lhs
+}
+
+fn subtest_signed_integer_full<TestRunner: OprfReRandTestRunner>(
+    prf_seed: impl OprfSeed,
+    cks: &ClientKey,
+    test_runner: &mut TestRunner,
+    rerand_hash_algo: ReRandomizationHashAlgo,
+) {
+    const OUTPUT_BIT_COUNT: u64 = 16;
+
+    let message_bits: u64 = cks.parameters().message_modulus().0.ilog2().into();
+
+    let num_blocks = OUTPUT_BIT_COUNT.div_ceil(message_bits);
+
+    let (prf_not_rerand, prf_rerand) =
+        test_runner.signed_full(prf_seed, num_blocks, rerand_hash_algo);
+
+    assert_eq!(prf_not_rerand.blocks.len() as u64, num_blocks);
+    assert_eq!(prf_rerand.blocks.len() as u64, num_blocks);
+
+    let decrypted = check_signed_value_and_re_rand_are_ok(
+        &prf_not_rerand,
+        &prf_rerand,
+        cks,
+        num_blocks as usize,
+    );
+
+    let random_value_range = -1i128 << (OUTPUT_BIT_COUNT - 1)..1 << (OUTPUT_BIT_COUNT - 1);
+    assert!(
+        random_value_range.contains(&decrypted),
+        "range: {random_value_range:?}, decrypted: {decrypted}"
+    );
+}
+
+fn subtest_signed_integer_bounded<TestRunner: OprfReRandTestRunner>(
+    prf_seed: impl OprfSeed,
+    cks: &ClientKey,
+    test_runner: &mut TestRunner,
+    rerand_hash_algo: ReRandomizationHashAlgo,
+) {
+    let mut rng = rand::thread_rng();
+    const OUTPUT_BIT_COUNT: u64 = 16;
+
+    let message_bits: u64 = cks.parameters().message_modulus().0.ilog2().into();
+
+    let num_blocks = OUTPUT_BIT_COUNT.div_ceil(message_bits);
+    // For signed values on n_bits we need to stay < 2^(n_bits - 1)
+    // since that value is a signed negative value
+    let random_bit_count_range = 1..=(OUTPUT_BIT_COUNT - 1);
+    let random_bit_count = rng.gen_range(random_bit_count_range);
+    let random_value_range = 0..=1 << random_bit_count;
+    let random_block_count = random_bit_count.div_ceil(message_bits);
+
+    let (prf_not_rerand, prf_rerand) =
+        test_runner.signed_bounded(prf_seed, random_bit_count, num_blocks, rerand_hash_algo);
+
+    assert_eq!(prf_not_rerand.blocks.len() as u64, num_blocks);
+    assert_eq!(prf_rerand.blocks.len() as u64, num_blocks);
+
+    let decrypted = check_signed_value_and_re_rand_are_ok(
+        &prf_not_rerand,
+        &prf_rerand,
+        cks,
+        random_block_count as usize,
+    );
+
+    assert!(
+        random_value_range.contains(&decrypted),
+        "range: {random_value_range:?}, decrypted: {decrypted}"
+    );
+}
+
+/// Generic PRF + re-randomization test
+///
+/// For each supported generation primitive it generates the PRF output with and without
+/// re-randomization from the same seed and checks that:
+/// - the random blocks differ (re-randomization changed ciphertexts)
+/// - the expected trivial padding blocks are there
+/// - both decrypt to the same value within the expected range
+pub(crate) fn pseudo_random_integer_and_rerand_test<P, E>(param: P, mut test_runner: E)
+where
+    P: Into<TestParameters>,
+    E: OprfReRandTestRunner,
+{
+    let mut rng = rand::thread_rng();
+
+    let cks = test_runner.setup(param.into());
+
+    // One seed for the test, do not use this in production, re-using a seed is bad
+    let prf_seed: [u8; 256 / 8] = core::array::from_fn(|_| rng.gen());
+    println!("prf_seed={prf_seed:?}");
+    let prf_seed = prf_seed.as_slice();
+
+    for rerand_hash_algo in [
+        ReRandomizationHashAlgo::Blake3,
+        ReRandomizationHashAlgo::Shake256,
+    ] {
+        println!("rerand_hash_algo: {rerand_hash_algo:?}");
+
+        subtest_integer_bounded_padding_stays_trivial(
+            prf_seed,
+            &cks,
+            &mut test_runner,
+            rerand_hash_algo,
+        );
+
+        // A fresh seed per call: re-using a seed across re-randomization calls is unsafe in
+        // production, but each call here is self-contained (plain vs rerand from the same seed).
+        subtest_unsigned_integer_full(prf_seed, &cks, &mut test_runner, rerand_hash_algo);
+        subtest_signed_integer_full(prf_seed, &cks, &mut test_runner, rerand_hash_algo);
+
+        // Run bounded tests a little more since they have a random component
+        for _ in 0..10 {
+            subtest_unsigned_integer_bounded(prf_seed, &cks, &mut test_runner, rerand_hash_algo);
+            subtest_signed_integer_bounded(prf_seed, &cks, &mut test_runner, rerand_hash_algo);
+        }
+
+        // This test has a random component but is much heavier (and is skipped on backends that
+        // do not support the re-randomizing custom-range primitive yet, e.g. GPU).
+        for _ in 0..3 {
+            subtest_unsigned_integer_custom_range(
+                prf_seed,
+                &cks,
+                &mut test_runner,
+                rerand_hash_algo,
+            );
+        }
+    }
+}
+
+fn pseudo_random_integer_and_rerand<P>(param: P)
+where
+    P: Into<TestParameters>,
+{
+    pseudo_random_integer_and_rerand_test(param, CpuOprfReRandTestRunner::new());
 }

--- a/tfhe/src/shortint/ciphertext/re_randomization.rs
+++ b/tfhe/src/shortint/ciphertext/re_randomization.rs
@@ -27,7 +27,7 @@ use super::CompactCiphertextList;
 const RERAND_SEED_BITS: usize = 256;
 
 /// The XoF algorithm used to generate the re-randomization seed
-#[derive(Copy, Clone, Default)]
+#[derive(Copy, Clone, Default, Debug)]
 pub enum ReRandomizationHashAlgo {
     /// Used for NIST compliance
     Shake256,

--- a/tfhe/src/shortint/ciphertext/re_randomization.rs
+++ b/tfhe/src/shortint/ciphertext/re_randomization.rs
@@ -574,17 +574,18 @@ mod test {
         let ksk_material = ksk_material.as_ref().map(|k| k.as_view());
 
         let pke_lwe_dim = pubk.parameters().encryption_lwe_dimension.0;
-
-        let msg1 = 1;
-        let msg2 = 2;
+        let message_modulus = cks.parameters().message_modulus();
 
         {
             let mut cts = Vec::with_capacity(pke_lwe_dim * 2);
+            let clears: Vec<u64> = (0..cts.capacity())
+                .map(|_| rand::random::<u64>() % message_modulus.0)
+                .collect();
 
-            for _ in 0..pke_lwe_dim {
-                let ct1 = cks.encrypt(msg1);
+            for chunk in clears.chunks_exact(2) {
+                let ct1 = cks.encrypt(chunk[0]);
                 cts.push(ct1);
-                let ct2 = cks.encrypt(msg2);
+                let ct2 = cks.encrypt(chunk[1]);
                 cts.push(ct2);
             }
 
@@ -600,16 +601,19 @@ mod test {
             pubk.re_randomize_ciphertexts(&mut cts, ksk_material.as_ref(), seeder.next_seed())
                 .unwrap();
 
-            cts.par_chunks(2).for_each(|pair| {
-                let sum = sks.add(&pair[0], &pair[1]);
-                let dec = cks.decrypt(&sum);
+            cts.par_chunks_exact(2)
+                .zip(clears.par_chunks_exact(2))
+                .for_each(|(pair, clear_pair)| {
+                    let sum = sks.add(&pair[0], &pair[1]);
+                    let dec = cks.decrypt(&sum);
 
-                assert_eq!(dec, msg1 + msg2);
-            });
+                    assert_eq!(dec, (clear_pair[0] + clear_pair[1]) % message_modulus.0);
+                });
         }
 
         {
-            let mut trivial = sks.create_trivial(3);
+            let random_clear = rand::random::<u64>() % cks.parameters().message_modulus().0;
+            let mut trivial = sks.create_trivial(random_clear);
 
             let nonce: [u8; 256 / 8] = core::array::from_fn(|_| rand::random());
             let mut re_rand_context = ReRandomizationContext::new(*b"TFHE_Rrd", *b"TFHE_Enc");
@@ -629,10 +633,12 @@ mod test {
 
             let not_trivial = trivial;
 
+            // non trivial ct should have a non zero mask
+            assert!(not_trivial.ct.get_mask().as_ref().iter().any(|&x| x != 0));
             assert!(not_trivial.noise_level() == NoiseLevel::NOMINAL);
 
             let dec = cks.decrypt(&not_trivial);
-            assert_eq!(dec, 3);
+            assert_eq!(dec, random_clear);
         }
     }
 

--- a/tfhe/src/shortint/oprf.rs
+++ b/tfhe/src/shortint/oprf.rs
@@ -1859,7 +1859,12 @@ pub(crate) mod test {
                         } = prf_rerand_ct;
                         let prf_rerand_noise_level = prf_rerand_ct.noise_level();
 
-                        assert_ne!(prf_lwe, prf_rerand_lwe);
+                        assert_ne!(prf_lwe.as_ref(), prf_rerand_lwe.as_ref());
+                        assert_eq!(prf_lwe.lwe_size(), prf_rerand_lwe.lwe_size());
+                        assert_eq!(
+                            prf_lwe.ciphertext_modulus(),
+                            prf_rerand_lwe.ciphertext_modulus()
+                        );
                         assert_eq!(prf_degree, prf_rerand_degree);
                         // Check expected max degree
                         assert_eq!(prf_degree.0, expected_max_value - 1);

--- a/utils/benchmark_spec/src/tfhe/hlapi/oprf.rs
+++ b/utils/benchmark_spec/src/tfhe/hlapi/oprf.rs
@@ -4,4 +4,6 @@ use strum::Display;
 #[strum(serialize_all = "snake_case")]
 pub enum OprfKind {
     AnyRange,
+    /// Custom-range generation fused with re-randomization of the output.
+    AnyRangeRerand,
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a fused GPU kernel for custom-range OPRF followed by re-randomization, matching the existing CPU pipeline (grouped OPRF → rerand → scalar multiply → shift).

Also includes a quality pass on the GPU orchestration and benchmarks:

- Extract shared custom-range input preparation and backend dispatch helpers in `oprf.rs` to remove duplication between plain and re-randomizing paths.
- Benchmark latency rerand case now unwraps errors consistently with the throughput path.
- Minor benchmark cleanup (`format!` trailing commas).

## Testing

- `cargo check -p tfhe --features integer,internal-keycache` (passes)
- GPU build/tests not run in this environment (missing C++/CUDA toolchain)

## Review notes

Automated bugbot and security review found no blocking issues in the branch diff. Key compatibility checks for rerand mirror `CudaRadixCiphertext::re_randomize`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3a18acb8-3667-4458-8750-ca9dc0f04486"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a18acb8-3667-4458-8750-ca9dc0f04486"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

