### PR TITLE
HPU backend fixes 

### DIFF
--- a/.github/workflows/benchmark_documentation.yml
+++ b/.github/workflows/benchmark_documentation.yml
@@ -138,8 +138,8 @@ jobs:
       op_flavor: default
       bench_type: both
       precisions_set: documentation
-      v80_pcie_dev: 24
-      v80_serial_number: XFL12NWY3ZKG
+      hpu_number: 4
+      runner_target: v80-marais
     secrets:
       BOT_USERNAME: ${{ secrets.BOT_USERNAME }}
       SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}

--- a/.github/workflows/benchmark_hpu.yml
+++ b/.github/workflows/benchmark_hpu.yml
@@ -38,12 +38,12 @@ on:
           - latency
           - throughput
           - both
-      v80_pcie_dev:
-        description: "V80 PCIe device number"
-        default: 24
-      v80_serial_number:
-        description: "V80 serial number"
-        default: XFL12NWY3ZKG
+      hpu_number:
+        description: "number of hpu used"
+        default: 4
+      runner_target:
+        description: "machine used for bench"
+        default: v80-marais
 
 permissions: {}
 
@@ -58,8 +58,8 @@ jobs:
       op_flavor: ${{ inputs.op_flavor }}
       bench_type: ${{ inputs.bench_type }}
       precisions_set: ${{ inputs.precisions_set }}
-      v80_pcie_dev: ${{ inputs.v80_pcie_dev }}
-      v80_serial_number: ${{ inputs.v80_serial_number }}
+      hpu_number: ${{ inputs.hpu_number }}
+      runner_target: ${{ inputs.runner_target }}
     secrets:
       BOT_USERNAME: ${{ secrets.BOT_USERNAME }}
       SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}

--- a/.github/workflows/benchmark_hpu_common.yml
+++ b/.github/workflows/benchmark_hpu_common.yml
@@ -160,12 +160,11 @@ jobs:
           echo "using ${HPU_NUMBER} HPU"
           # to get available list of boards
           . /etc/profile.d/v80_pcie_dev.sh
-          sudo -n /usr/sbin/rmmod ami; echo "exit: $?"
           # to modify hpu_config.toml to use only selected number of HPU
           # will fail at start of backend if requesting more than available HPU
           ids=$(seq -s, 0 $((HPU_NUMBER - 1))) && sed -i "s/^  node_id=.*/  node_id=[$ids]/" backends/tfhe-hpu-backend/config_store/v80/hpu_config.toml
           make pull_hpu_files
-          make BIT_SIZES_SET="${PRECISIONS_SET}" BENCH_OP_FLAVOR="${OP_FLAVOR}" BENCH_TYPE="${BENCH_TYPE}" BENCH_PARAM_TYPE="${BENCH_PARAMS_TYPE}" bench_"${BENCH_COMMAND}"_hpu
+          export RUST_LOG=debug && export PATH=$PATH:/usr/local/sbin && make BIT_SIZES_SET="${PRECISIONS_SET}" BENCH_OP_FLAVOR="${OP_FLAVOR}" BENCH_TYPE="${BENCH_TYPE}" BENCH_PARAM_TYPE="${BENCH_PARAMS_TYPE}" bench_"${BENCH_COMMAND}"_hpu
         env:
           OP_FLAVOR: ${{ matrix.op_flavor }}
           BENCH_TYPE: ${{ matrix.bench_type }}

--- a/.github/workflows/benchmark_hpu_common.yml
+++ b/.github/workflows/benchmark_hpu_common.yml
@@ -16,12 +16,12 @@ on:
       precisions_set:
         type: string
         default: fast
-      v80_pcie_dev:
+      hpu_number:
         type: string
-        default: 24
-      v80_serial_number:
+        default: 4
+      runner_target:
         type: string
-        default: XFL12NWY3ZKG
+        default: v80-marais
     secrets:
       REPO_CHECKOUT_TOKEN:
         required: true
@@ -107,7 +107,7 @@ jobs:
   hpu-benchmarks:
     name: benchmark_hpu_common/hpu-benchmarks
     needs: prepare-matrix
-    runs-on: v80-marais
+    runs-on: ${{ inputs.runner_target }}
     concurrency:
       group: ${{ github.workflow }}_${{ github.ref }}
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
@@ -151,15 +151,19 @@ jobs:
 
       - name: Select HPU board
         run: |
-          echo "V80_PCIE_DEV=${PCIE_DEV}" >> "${GITHUB_ENV}"
-          echo "V80_SERIAL_NUMBER=${SERIAL_NUMBER}" >> "${GITHUB_ENV}"
+          echo "HPU_NUMBER=${HPU_NUMBER}" >> "${GITHUB_ENV}"
         env:
-          PCIE_DEV: ${{ inputs.v80_pcie_dev }}
-          SERIAL_NUMBER: ${{ inputs.v80_serial_number }}
+          HPU_NUMBER: ${{ inputs.hpu_number }}
 
       - name: Run benchmarks
         run: |
-          echo "${V80_PCIE_DEV} ${V80_SERIAL_NUMBER}"
+          echo "using ${HPU_NUMBER} HPU"
+          # to get available list of boards
+          . /etc/profile.d/v80_pcie_dev.sh
+          sudo -n /usr/sbin/rmmod ami; echo "exit: $?"
+          # to modify hpu_config.toml to use only selected number of HPU
+          # will fail at start of backend if requesting more than available HPU
+          ids=$(seq -s, 0 $((HPU_NUMBER - 1))) && sed -i "s/^  node_id=.*/  node_id=[$ids]/" backends/tfhe-hpu-backend/config_store/v80/hpu_config.toml
           make pull_hpu_files
           make BIT_SIZES_SET="${PRECISIONS_SET}" BENCH_OP_FLAVOR="${OP_FLAVOR}" BENCH_TYPE="${BENCH_TYPE}" BENCH_PARAM_TYPE="${BENCH_PARAMS_TYPE}" bench_"${BENCH_COMMAND}"_hpu
         env:
@@ -172,7 +176,7 @@ jobs:
         run: |
           cargo run --release -p tfhe-benchmark-parser -- -i target/criterion -o "${RESULTS_FILENAME}" \
           --database tfhe_rs \
-          --hardware "hpu_x1" \
+          --hardware "hpu_x${HPU_NUMBER}" \
           --backend hpu \
           --project-version "${COMMIT_HASH}" \
           --branch "${REF_NAME}" \

--- a/backends/tfhe-hpu-backend/README.md
+++ b/backends/tfhe-hpu-backend/README.md
@@ -147,7 +147,8 @@ Following code snippet shows how to instantiate and configure a `HpuDevice`:
 ```rust
     // Following code snippets used the HighLevelApi abstraction
     // Instantiate HpuDevice --------------------------------------------------
-    let hpu_device = HpuDevice::from_config(&args.config.expand());
+    let hpu_device = HpuDevice::from_config(&config_path.expand(), false)
+        .expect("Hpu device init failed");
 
     // Generate keys ----------------------------------------------------------
     let config = Config::from_hpu_device(&hpu_device);

--- a/backends/tfhe-hpu-backend/config_store/v80_archives/psi64.hpu
+++ b/backends/tfhe-hpu-backend/config_store/v80_archives/psi64.hpu
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1085d5a50908c9364327d3135b4357360f95c5b0bf6f5a72a6acfe84340b841e
-size 82511764
+oid sha256:c9e52b1be3f0a588fcae13371a328b36794160a5ab103d8e8bf8fa5aed31a51a
+size 82563756

--- a/backends/tfhe-hpu-backend/scripts/v80-pcie-perms.sh
+++ b/backends/tfhe-hpu-backend/scripts/v80-pcie-perms.sh
@@ -3,15 +3,15 @@
 GROUP=hw;
 # Enable Pcie rescan
 if [ -e /sys/bus/pci/rescan ]; then
-  sudo /usr/bin/chgrp $GROUP /sys/bus/pci/rescan && sudo /usr/bin/chmod g+w /sys/bus/pci/rescan
+  sudo --stdin -l /usr/bin/chgrp $GROUP /sys/bus/pci/rescan && sudo --stdin -l /usr/bin/chmod g+w /sys/bus/pci/rescan
 fi
 # Search V80 pcie boards PF0
 for dev in $(lspci -nn -d 10ee:50b4 | awk '{print $1}'); do
-  sudo /usr/bin/chgrp -R $GROUP /sys/bus/pci/devices/0000\:$dev/
-  sudo /usr/bin/chmod -R g=u    /sys/bus/pci/devices/0000\:$dev/
+  sudo --stdin -l /usr/bin/chgrp -R $GROUP /sys/bus/pci/devices/0000\:$dev/
+  sudo --stdin -l /usr/bin/chmod -R g=u    /sys/bus/pci/devices/0000\:$dev/
 done
 # Search V80 pcie boards PF1
 for dev in $(lspci -nn -d 10ee:50b5 | awk '{print $1}'); do
-  sudo /usr/bin/chgrp -R $GROUP /sys/bus/pci/devices/0000\:$dev/
-  sudo /usr/bin/chmod -R g=u    /sys/bus/pci/devices/0000\:$dev/
+  sudo --stdin -l /usr/bin/chgrp -R $GROUP /sys/bus/pci/devices/0000\:$dev/
+  sudo --stdin -l /usr/bin/chmod -R g=u    /sys/bus/pci/devices/0000\:$dev/
 done

--- a/backends/tfhe-hpu-backend/scripts/v80-pcie-perms.sh
+++ b/backends/tfhe-hpu-backend/scripts/v80-pcie-perms.sh
@@ -3,15 +3,15 @@
 GROUP=hw;
 # Enable Pcie rescan
 if [ -e /sys/bus/pci/rescan ]; then
-  sudo --stdin -l /usr/bin/chgrp $GROUP /sys/bus/pci/rescan && sudo --stdin -l /usr/bin/chmod g+w /sys/bus/pci/rescan
+  sudo --stdin /usr/bin/chgrp $GROUP /sys/bus/pci/rescan && sudo --stdin /usr/bin/chmod g+w /sys/bus/pci/rescan
 fi
 # Search V80 pcie boards PF0
 for dev in $(lspci -nn -d 10ee:50b4 | awk '{print $1}'); do
-  sudo --stdin -l /usr/bin/chgrp -R $GROUP /sys/bus/pci/devices/0000\:$dev/
-  sudo --stdin -l /usr/bin/chmod -R g=u    /sys/bus/pci/devices/0000\:$dev/
+  sudo --stdin /usr/bin/chgrp -R $GROUP /sys/bus/pci/devices/0000\:$dev/
+  sudo --stdin /usr/bin/chmod -R g=u    /sys/bus/pci/devices/0000\:$dev/
 done
 # Search V80 pcie boards PF1
 for dev in $(lspci -nn -d 10ee:50b5 | awk '{print $1}'); do
-  sudo --stdin -l /usr/bin/chgrp -R $GROUP /sys/bus/pci/devices/0000\:$dev/
-  sudo --stdin -l /usr/bin/chmod -R g=u    /sys/bus/pci/devices/0000\:$dev/
+  sudo --stdin /usr/bin/chgrp -R $GROUP /sys/bus/pci/devices/0000\:$dev/
+  sudo --stdin /usr/bin/chmod -R g=u    /sys/bus/pci/devices/0000\:$dev/
 done

--- a/backends/tfhe-hpu-backend/scripts/v80-pcie-perms.sh
+++ b/backends/tfhe-hpu-backend/scripts/v80-pcie-perms.sh
@@ -3,15 +3,15 @@
 GROUP=hw;
 # Enable Pcie rescan
 if [ -e /sys/bus/pci/rescan ]; then
-  sudo --stdin /usr/bin/chgrp $GROUP /sys/bus/pci/rescan && sudo --stdin /usr/bin/chmod g+w /sys/bus/pci/rescan
+  sudo --non-interactive /usr/bin/chgrp $GROUP /sys/bus/pci/rescan && sudo --non-interactive /usr/bin/chmod g+w /sys/bus/pci/rescan
 fi
 # Search V80 pcie boards PF0
 for dev in $(lspci -nn -d 10ee:50b4 | awk '{print $1}'); do
-  sudo --stdin /usr/bin/chgrp -R $GROUP /sys/bus/pci/devices/0000\:$dev/
-  sudo --stdin /usr/bin/chmod -R g=u    /sys/bus/pci/devices/0000\:$dev/
+  sudo --non-interactive /usr/bin/chgrp -R $GROUP /sys/bus/pci/devices/0000\:$dev/
+  sudo --non-interactive /usr/bin/chmod -R g=u    /sys/bus/pci/devices/0000\:$dev/
 done
 # Search V80 pcie boards PF1
 for dev in $(lspci -nn -d 10ee:50b5 | awk '{print $1}'); do
-  sudo --stdin /usr/bin/chgrp -R $GROUP /sys/bus/pci/devices/0000\:$dev/
-  sudo --stdin /usr/bin/chmod -R g=u    /sys/bus/pci/devices/0000\:$dev/
+  sudo --non-interactive /usr/bin/chgrp -R $GROUP /sys/bus/pci/devices/0000\:$dev/
+  sudo --non-interactive /usr/bin/chmod -R g=u    /sys/bus/pci/devices/0000\:$dev/
 done

--- a/backends/tfhe-hpu-backend/src/ffi/v80/ami.rs
+++ b/backends/tfhe-hpu-backend/src/ffi/v80/ami.rs
@@ -119,7 +119,7 @@ impl AmiDriver {
             .open(&ami_proc_path)
             .unwrap();
 
-        let addr = unsafe {
+        let iop_ack_addr = unsafe {
             mmap(
                 None,
                 NonZero::new(AMI_ACK_PTR_LEN).unwrap(),
@@ -130,7 +130,7 @@ impl AmiDriver {
             )?
         };
 
-        let iop_ack_atomic_ptr: NonNull<AtomicU32> = addr.cast();
+        let iop_ack_atomic_ptr: NonNull<AtomicU32> = iop_ack_addr.cast();
 
         // Try to use direct register access if available
         let bar_reg_ptr = Self::map_bar_reg(&ami_dev).ok();
@@ -163,14 +163,6 @@ impl AmiDriver {
 
         let bar_addr: NonNull<u8> = map_addr.cast();
         Ok(bar_addr)
-    }
-
-    pub fn munmap_cnt(&self) -> Result<(), Box<dyn Error>> {
-        let cnt_addr = self.iop_ack_atomic_ptr.cast();
-        unsafe {
-            munmap(cnt_addr, AMI_ACK_PTR_LEN)?;
-        }
-        Ok(())
     }
 
     /// Read currently loaded UUID in BAR
@@ -448,6 +440,22 @@ impl AmiDriver {
     // read shared atomic counter of iop acknowledge
     pub fn iop_ackq_rd(&self) -> u32 {
         unsafe { self.iop_ack_atomic_ptr.as_ref().swap(0, Ordering::SeqCst) }
+    }
+}
+
+impl Drop for AmiDriver {
+    fn drop(&mut self) {
+        let iop_ack_addr = self.iop_ack_atomic_ptr.cast();
+        unsafe {
+            munmap(iop_ack_addr, AMI_ACK_PTR_LEN).expect("Unable to unmap iop_ack_ptr");
+        }
+
+        if let Some(bar_ptr) = self.bar_reg_ptr {
+            let bar_addr = bar_ptr.cast();
+            unsafe {
+                munmap(bar_addr, AMI_BAR_LEN).expect("Unable to unmap bar_reg_ptr");
+            }
+        }
     }
 }
 

--- a/backends/tfhe-hpu-backend/src/ffi/v80/mod.rs
+++ b/backends/tfhe-hpu-backend/src/ffi/v80/mod.rs
@@ -77,7 +77,7 @@ impl HpuHw {
             // Reload Ami driver
             tracing::info!("Load ami kernel module [{ami_path}]");
             Command::new("sudo")
-                .arg("--stdin")
+                .arg("--non-interactive")
                 .arg("/usr/sbin/insmod")
                 .arg(ami_path)
                 .status()
@@ -180,7 +180,7 @@ impl HpuHw {
         // If either we fail to unload ami or qdma we must raise an error
         tracing::info!("Unload drivers ami/qdma_pf");
         let _ = Command::new("sudo")
-            .arg("--stdin")
+            .arg("--non-interactive")
             .arg("/usr/sbin/rmmod")
             .arg("--syslog") // Output to syslog instead of stderr
             .arg("ami")
@@ -190,7 +190,7 @@ impl HpuHw {
             "Failed to unload ami driver: module still loaded"
         );
         let _ = Command::new("sudo")
-            .arg("--stdin")
+            .arg("--non-interactive")
             .arg("/usr/sbin/rmmod")
             .arg("--syslog") // Output to syslog instead of stderr
             .arg("qdma_pf")

--- a/backends/tfhe-hpu-backend/src/ffi/v80/mod.rs
+++ b/backends/tfhe-hpu-backend/src/ffi/v80/mod.rs
@@ -102,7 +102,6 @@ impl HpuHw {
                 // Check state and version
                 match AmiDriver::new(&board.pcie_id, &hpu_pdi.metadata.amc.his_version, None) {
                     Ok(ami) => {
-                        ami.munmap_cnt().unwrap();
                         if hpu_pdi.metadata.bitstream.uuid.to_lowercase()
                             == ami.uuid().to_lowercase()
                         {

--- a/backends/tfhe-hpu-backend/src/ffi/v80/mod.rs
+++ b/backends/tfhe-hpu-backend/src/ffi/v80/mod.rs
@@ -418,14 +418,6 @@ impl HpuHw {
             }
         }
 
-        if let Err(e) = OpenOptions::new()
-            .write(true)
-            .open(format!("/sys/bus/pci/devices/0000:{dev}:00.1/qdma/qmax"))
-            .and_then(|mut f| f.write_all(b"100\n"))
-        {
-            tracing::debug!("Dma: Failed to configure qmax ({e}). Must have been already done after the last rescan");
-        }
-
         // Create user queues ----------------------------------------------
         let h2c_path = format!("/dev/qdma{dev}001-MM-1");
         let c2h_path = format!("/dev/qdma{dev}001-MM-2");

--- a/backends/tfhe-hpu-backend/src/ffi/v80/mod.rs
+++ b/backends/tfhe-hpu-backend/src/ffi/v80/mod.rs
@@ -77,7 +77,6 @@ impl HpuHw {
             // Reload Ami driver
             tracing::info!("Load ami kernel module [{ami_path}]");
             Command::new("sudo")
-                .arg("-l")
                 .arg("--stdin")
                 .arg("/usr/sbin/insmod")
                 .arg(ami_path)
@@ -182,7 +181,6 @@ impl HpuHw {
         // If either we fail to unload ami or qdma we must raise an error
         tracing::info!("Unload drivers ami/qdma_pf");
         let _ = Command::new("sudo")
-            .arg("-l")
             .arg("--stdin")
             .arg("/usr/sbin/rmmod")
             .arg("--syslog") // Output to syslog instead of stderr
@@ -193,7 +191,6 @@ impl HpuHw {
             "Failed to unload ami driver: module still loaded"
         );
         let _ = Command::new("sudo")
-            .arg("-l")
             .arg("--stdin")
             .arg("/usr/sbin/rmmod")
             .arg("--syslog") // Output to syslog instead of stderr
@@ -402,14 +399,25 @@ impl HpuHw {
     /// Thus dma_queues must be recreated for each node when any of the cluster node is reloaded -_-
     pub fn cfg_dma_queues(dev: &str) {
         // Configure maximum Dma queues
-        //OpenOptions::new()
-        //    .write(true)
-        //    .open(format!(
-        //        "/sys/bus/pci/devices/0000:{dev}:00.1/qdma/qmax"
-        //    ))
-        //    .expect("Unable to open qdma qmax cmd file")
-        //    .write_all(b"100\n")
-        //.unwrap_or_else(|_| tracing::debug!("Dma: Failed to configure qmax. Must have been already done after the last rescan"));
+        let qmax_path = format!("/sys/bus/pci/devices/0000:{dev}:00.1/qdma/qmax");
+
+        match std::fs::read_to_string(&qmax_path) {
+            Ok(current) if current.trim() == "100" => {
+                tracing::debug!("Dma: qmax already set to 100, skipping");
+            }
+            Ok(_) => {
+                if let Err(e) = OpenOptions::new()
+                    .write(true)
+                    .open(&qmax_path)
+                    .and_then(|mut f| f.write_all(b"100\n"))
+                {
+                    tracing::debug!("Dma: Failed to configure qmax ({e}). Must have been already done after the last rescan");
+                }
+            }
+            Err(e) => {
+                tracing::debug!("Dma: Failed to read qmax ({e}), skipping configuration");
+            }
+        }
 
         if let Err(e) = OpenOptions::new()
             .write(true)

--- a/backends/tfhe-hpu-backend/src/ffi/v80/mod.rs
+++ b/backends/tfhe-hpu-backend/src/ffi/v80/mod.rs
@@ -77,6 +77,8 @@ impl HpuHw {
             // Reload Ami driver
             tracing::info!("Load ami kernel module [{ami_path}]");
             Command::new("sudo")
+                .arg("-l")
+                .arg("--stdin")
                 .arg("/usr/sbin/insmod")
                 .arg(ami_path)
                 .status()
@@ -180,6 +182,8 @@ impl HpuHw {
         // If either we fail to unload ami or qdma we must raise an error
         tracing::info!("Unload drivers ami/qdma_pf");
         let _ = Command::new("sudo")
+            .arg("-l")
+            .arg("--stdin")
             .arg("/usr/sbin/rmmod")
             .arg("--syslog") // Output to syslog instead of stderr
             .arg("ami")
@@ -189,6 +193,8 @@ impl HpuHw {
             "Failed to unload ami driver: module still loaded"
         );
         let _ = Command::new("sudo")
+            .arg("-l")
+            .arg("--stdin")
             .arg("/usr/sbin/rmmod")
             .arg("--syslog") // Output to syslog instead of stderr
             .arg("qdma_pf")
@@ -396,14 +402,22 @@ impl HpuHw {
     /// Thus dma_queues must be recreated for each node when any of the cluster node is reloaded -_-
     pub fn cfg_dma_queues(dev: &str) {
         // Configure maximum Dma queues
-        OpenOptions::new()
+        //OpenOptions::new()
+        //    .write(true)
+        //    .open(format!(
+        //        "/sys/bus/pci/devices/0000:{dev}:00.1/qdma/qmax"
+        //    ))
+        //    .expect("Unable to open qdma qmax cmd file")
+        //    .write_all(b"100\n")
+        //.unwrap_or_else(|_| tracing::debug!("Dma: Failed to configure qmax. Must have been already done after the last rescan"));
+
+        if let Err(e) = OpenOptions::new()
             .write(true)
-            .open(format!(
-                "/sys/bus/pci/devices/0000:{dev}:00.1/qdma/qmax"
-            ))
-            .expect("Unable to open qdma qmax cmd file")
-            .write_all(b"100\n")
-        .unwrap_or_else(|_| tracing::debug!("Dma: Failed to configure qmax. Must have been already done after the last rescan"));
+            .open(format!("/sys/bus/pci/devices/0000:{dev}:00.1/qdma/qmax"))
+            .and_then(|mut f| f.write_all(b"100\n"))
+        {
+            tracing::debug!("Dma: Failed to configure qmax ({e}). Must have been already done after the last rescan");
+        }
 
         // Create user queues ----------------------------------------------
         let h2c_path = format!("/dev/qdma{dev}001-MM-1");

--- a/tfhe-benchmark/benches/high_level_api/bench_signed.rs
+++ b/tfhe-benchmark/benches/high_level_api/bench_signed.rs
@@ -50,7 +50,8 @@ fn main() {
         let config_path = ShellString::new(
             "${HPU_BACKEND_DIR}/config_store/${HPU_CONFIG}/hpu_config.toml".to_string(),
         );
-        let hpu_device = HpuDevice::from_config(&config_path.expand());
+        let hpu_device =
+            HpuDevice::from_config(&config_path.expand(), false).expect("Hpu device init failed");
 
         let config = Config::from_hpu_device(&hpu_device);
         let cks = ClientKey::generate(config);

--- a/tfhe-benchmark/benches/high_level_api/bench_unsigned.rs
+++ b/tfhe-benchmark/benches/high_level_api/bench_unsigned.rs
@@ -57,7 +57,8 @@ fn main() {
         let config_path = ShellString::new(
             "${HPU_BACKEND_DIR}/config_store/${HPU_CONFIG}/hpu_config.toml".to_string(),
         );
-        let hpu_device = HpuDevice::from_config(&config_path.expand());
+        let hpu_device =
+            HpuDevice::from_config(&config_path.expand(), false).expect("Hpu device init failed");
 
         let config = Config::from_hpu_device(&hpu_device);
         let cks = ClientKey::generate(config);


### PR DESCRIPTION
Summary

- Fix mmap ptr lifetime — replaced explicit munmap call with a Drop trait implementation, ensuring correct memory cleanup via Rust's drop glue
- Fix HpuDevice init — updated missed function calls left behind from a prior HPU backend refactor
- Fix DMA queue write guard — now reads and validates the max queue value before attempting to write it, preventing out-of-bounds writes
- Fix DMA queue PATH — added missing PATH entry required to update DMA queues

Chores

- Updated psi64.hpu with latest bitstream and firmware from main
- Extended the HPU bench GitHub workflow to run on a broader set of HPU targets