### PR TITLE
feat(gpu): add custom_range PRF + rerand

### DIFF
--- a/backends/tfhe-cuda-backend/cuda/include/integer/integer.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer/integer.h
@@ -42,6 +42,11 @@ enum Direction { Trailing = 0, Leading = 1 };
 
 enum BitValue { Zero = 0, One = 1 };
 
+enum RERAND_MODE {
+  RERAND_WITH_KS = 0,
+  RERAND_WITHOUT_KS = 1,
+};
+
 extern "C" {
 
 typedef struct {
@@ -679,14 +684,18 @@ uint64_t scratch_cuda_integer_grouped_oprf_custom_range_64_async(
     CudaLweKeyswitchKeyParamsFFI ksk_params, uint32_t num_blocks_intermediate,
     uint32_t message_modulus, uint32_t carry_modulus, bool allocate_gpu_memory,
     uint32_t message_bits_per_block, uint32_t num_input_random_bits,
-    uint32_t num_scalar_bits, PBS_MS_REDUCTION_T noise_reduction_type);
+    uint32_t num_scalar_bits, PBS_MS_REDUCTION_T noise_reduction_type,
+    bool apply_rerand, CudaLweKeyswitchKeyParamsFFI rerand_ksk_params,
+    RERAND_MODE rerand_mode);
 
 void cuda_integer_grouped_oprf_custom_range_64_async(
     CudaStreamsFFI streams, CudaRadixCiphertextFFI *radix_lwe_out,
     uint32_t num_blocks_intermediate, const void *seeded_lwe_input,
     const uint64_t *decomposed_scalar, const uint64_t *has_at_least_one_set,
-    uint32_t num_scalars, uint32_t shift, int8_t *mem, void *const *bsks,
-    void *const *compute_bsks, void *const *ksks);
+    uint32_t num_scalars, uint32_t shift,
+    const void *lwe_flattened_encryptions_of_zero_compact_array_in, int8_t *mem,
+    void *const *bsks, void *const *compute_bsks, void *const *ksks,
+    void *const *rerand_ksks);
 
 void cleanup_cuda_integer_grouped_oprf_custom_range_64(CudaStreamsFFI streams,
                                                        int8_t **mem_ptr_void);

--- a/backends/tfhe-cuda-backend/cuda/include/integer/integer.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer/integer.h
@@ -1013,12 +1013,15 @@ uint64_t scratch_cuda_integer_oprf_bitonic_shuffle_64_async(
     CudaLweKeyswitchKeyParamsFFI ksk_params, uint32_t key_num_radix_blocks,
     uint32_t data_num_radix_blocks, uint32_t num_values,
     uint32_t message_modulus, uint32_t carry_modulus, bool allocate_gpu_memory,
-    PBS_MS_REDUCTION_T noise_reduction_type);
+    PBS_MS_REDUCTION_T noise_reduction_type, bool apply_rerand,
+    CudaLweKeyswitchKeyParamsFFI rerand_ksk_params, RERAND_MODE rerand_mode);
 
 void cuda_integer_oprf_bitonic_shuffle_64_async(
     CudaStreamsFFI streams, CudaRadixCiphertextFFI **values,
     uint32_t num_values, const void *seeded_lwe_input, int8_t *mem_ptr,
-    void *const *oprf_bsks, void *const *bsks, void *const *ksks);
+    void *const *oprf_bsks, void *const *bsks, void *const *ksks,
+    const void *lwe_flattened_encryptions_of_zero_compact_array_in,
+    void *const *rerand_ksks);
 
 void cleanup_cuda_integer_oprf_bitonic_shuffle_64(CudaStreamsFFI streams,
                                                   int8_t **mem_ptr_void);

--- a/backends/tfhe-cuda-backend/cuda/include/integer/integer.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer/integer.h
@@ -666,8 +666,7 @@ uint64_t scratch_cuda_integer_grouped_oprf_64_async(
     CudaLweBootstrapKeyParamsFFI bsk_params,
     CudaLweKeyswitchKeyParamsFFI ksk_params, uint32_t num_blocks_to_process,
     uint32_t message_modulus, uint32_t carry_modulus, bool allocate_gpu_memory,
-    uint32_t message_bits_per_block, uint32_t total_random_bits,
-    PBS_MS_REDUCTION_T noise_reduction_type);
+    uint32_t total_random_bits, PBS_MS_REDUCTION_T noise_reduction_type);
 
 void cuda_integer_grouped_oprf_64_async(CudaStreamsFFI streams,
                                         CudaRadixCiphertextFFI *radix_lwe_out,
@@ -683,10 +682,9 @@ uint64_t scratch_cuda_integer_grouped_oprf_custom_range_64_async(
     CudaLweBootstrapKeyParamsFFI bsk_params,
     CudaLweKeyswitchKeyParamsFFI ksk_params, uint32_t num_blocks_intermediate,
     uint32_t message_modulus, uint32_t carry_modulus, bool allocate_gpu_memory,
-    uint32_t message_bits_per_block, uint32_t num_input_random_bits,
-    uint32_t num_scalar_bits, PBS_MS_REDUCTION_T noise_reduction_type,
-    bool apply_rerand, CudaLweKeyswitchKeyParamsFFI rerand_ksk_params,
-    RERAND_MODE rerand_mode);
+    uint32_t num_input_random_bits, uint32_t num_scalar_bits,
+    PBS_MS_REDUCTION_T noise_reduction_type, bool apply_rerand,
+    CudaLweKeyswitchKeyParamsFFI rerand_ksk_params, RERAND_MODE rerand_mode);
 
 void cuda_integer_grouped_oprf_custom_range_64_async(
     CudaStreamsFFI streams, CudaRadixCiphertextFFI *radix_lwe_out,

--- a/backends/tfhe-cuda-backend/cuda/include/integer/oprf.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer/oprf.h
@@ -3,6 +3,10 @@
 
 template <typename Torus> struct int_scalar_mul_buffer;
 template <typename Torus> struct int_logical_scalar_shift_buffer;
+/// @brief Scratch buffer for re-randomizing LWE ciphertext blocks (defined in
+/// rerand.h).
+/// @tparam Torus Unsigned integer type representing a ciphertext torus element.
+template <typename Torus> struct int_rerand_mem;
 
 template <typename Torus> struct int_grouped_oprf_memory {
   int_radix_params params;
@@ -181,7 +185,22 @@ template <typename Torus> struct int_grouped_oprf_custom_range_memory {
   int_logical_scalar_shift_buffer<Torus> *logical_scalar_shift_buffer;
   CudaRadixCiphertextFFI *tmp_oprf_output;
   uint32_t num_random_input_blocks;
+  /// @brief Optional scratch for re-randomizing the fresh random blocks
+  /// (nullptr when re-randomization is not requested).
+  int_rerand_mem<Torus> *rerand_memory;
 
+  /// @brief Returns whether this scratch buffer was allocated with
+  /// re-randomization support.
+  bool applies_rerand() const { return rerand_memory != nullptr; }
+
+  /// @brief Allocates the scratch buffer without re-randomization support.
+  ///
+  /// @param num_blocks_intermediate  Number of radix blocks for scalar-multiply
+  /// and shift
+  /// @param message_bits_per_block   Number of message bits per radix block
+  /// @param num_input_random_bits    Random bits to generate before range
+  /// mapping
+  /// @param num_scalar_bits          Bit-width of the scalar multiplier
   int_grouped_oprf_custom_range_memory(
       CudaStreams streams, int_radix_params params,
       uint32_t num_blocks_intermediate, uint32_t message_bits_per_block,
@@ -189,6 +208,7 @@ template <typename Torus> struct int_grouped_oprf_custom_range_memory {
       bool allocate_gpu_memory, uint64_t &size_tracker) {
     this->params = params;
     this->allocate_gpu_memory = allocate_gpu_memory;
+    this->rerand_memory = nullptr;
 
     this->num_random_input_blocks =
         CEIL_DIV(num_input_random_bits, message_bits_per_block);
@@ -213,6 +233,33 @@ template <typename Torus> struct int_grouped_oprf_custom_range_memory {
         allocate_gpu_memory);
   }
 
+  /// @brief Allocates the scratch buffer with re-randomization support.
+  ///
+  /// @param rerand_params            Radix parameters for the re-randomization
+  /// keyswitch stage
+  /// @param num_blocks_intermediate  Number of radix blocks for scalar-multiply
+  /// and shift
+  /// @param message_bits_per_block   Number of message bits per radix block
+  /// @param num_input_random_bits    Random bits to generate before range
+  /// mapping
+  /// @param num_scalar_bits          Bit-width of the scalar multiplier
+  /// @param rerand_mode              Re-randomization mode (with or without
+  /// keyswitch)
+  int_grouped_oprf_custom_range_memory(
+      CudaStreams streams, int_radix_params params,
+      int_radix_params rerand_params, uint32_t num_blocks_intermediate,
+      uint32_t message_bits_per_block, uint64_t num_input_random_bits,
+      uint32_t num_scalar_bits, RERAND_MODE rerand_mode,
+      bool allocate_gpu_memory, uint64_t &size_tracker)
+      : int_grouped_oprf_custom_range_memory(
+            streams, params, num_blocks_intermediate, message_bits_per_block,
+            num_input_random_bits, num_scalar_bits, allocate_gpu_memory,
+            size_tracker) {
+    this->rerand_memory = new int_rerand_mem<Torus>(
+        streams, rerand_params, this->num_random_input_blocks, rerand_mode,
+        allocate_gpu_memory, size_tracker);
+  }
+
   void release(CudaStreams streams) {
     this->scalar_mul_buffer->release(streams);
     delete this->scalar_mul_buffer;
@@ -231,6 +278,12 @@ template <typename Torus> struct int_grouped_oprf_custom_range_memory {
                                    this->allocate_gpu_memory);
     delete this->tmp_oprf_output;
     this->tmp_oprf_output = nullptr;
+
+    if (this->applies_rerand()) {
+      this->rerand_memory->release(streams);
+      delete this->rerand_memory;
+      this->rerand_memory = nullptr;
+    }
 
     cuda_synchronize_stream(streams.stream(0), streams.gpu_index(0));
   }

--- a/backends/tfhe-cuda-backend/cuda/include/integer/oprf.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer/oprf.h
@@ -16,12 +16,13 @@ template <typename Torus> struct int_grouped_oprf_memory {
   CudaRadixCiphertextFFI *plaintext_corrections;
   Torus *h_lut_indexes;
 
-  // with message_bits_per_block == ilog2(msg_modulus) from crypto params
   int_grouped_oprf_memory(CudaStreams streams, int_radix_params params,
                           uint32_t num_blocks_to_process,
-                          uint32_t message_bits_per_block,
                           uint64_t total_random_bits, bool allocate_gpu_memory,
                           uint64_t &size_tracker) {
+
+    uint32_t message_bits_per_block =
+        (uint32_t)std::log2(params.message_modulus);
 
     uint32_t calculated_active_blocks =
         total_random_bits == 0
@@ -45,12 +46,8 @@ template <typename Torus> struct int_grouped_oprf_memory {
         num_blocks_to_process, params.big_lwe_dimension, size_tracker,
         allocate_gpu_memory);
 
-    uint64_t message_modulus_log2 = (uint64_t)std::log2(params.message_modulus);
-    if (message_modulus_log2 != message_bits_per_block) {
-      PANIC("message_modulus_log2 should be equal to message_bits_per_block");
-    }
     uint64_t carry_modulus_log2 = (uint64_t)std::log2(params.carry_modulus);
-    uint64_t full_bits_count = 1 + carry_modulus_log2 + message_modulus_log2;
+    uint64_t full_bits_count = 1 + carry_modulus_log2 + message_bits_per_block;
     uint64_t delta = 1ULL << (64 - full_bits_count);
     size_t lwe_size = params.big_lwe_dimension + 1;
 
@@ -197,24 +194,26 @@ template <typename Torus> struct int_grouped_oprf_custom_range_memory {
   ///
   /// @param num_blocks_intermediate  Number of radix blocks for scalar-multiply
   /// and shift
-  /// @param message_bits_per_block   Number of message bits per radix block
   /// @param num_input_random_bits    Random bits to generate before range
   /// mapping
   /// @param num_scalar_bits          Bit-width of the scalar multiplier
   int_grouped_oprf_custom_range_memory(
       CudaStreams streams, int_radix_params params,
-      uint32_t num_blocks_intermediate, uint32_t message_bits_per_block,
-      uint64_t num_input_random_bits, uint32_t num_scalar_bits,
-      bool allocate_gpu_memory, uint64_t &size_tracker) {
+      uint32_t num_blocks_intermediate, uint64_t num_input_random_bits,
+      uint32_t num_scalar_bits, bool allocate_gpu_memory,
+      uint64_t &size_tracker) {
     this->params = params;
     this->allocate_gpu_memory = allocate_gpu_memory;
     this->rerand_memory = nullptr;
+
+    uint32_t message_bits_per_block =
+        (uint32_t)std::log2(params.message_modulus);
 
     this->num_random_input_blocks =
         CEIL_DIV(num_input_random_bits, message_bits_per_block);
 
     this->grouped_oprf_memory = new int_grouped_oprf_memory<Torus>(
-        streams, params, this->num_random_input_blocks, message_bits_per_block,
+        streams, params, this->num_random_input_blocks,
         num_input_random_bits, allocate_gpu_memory, size_tracker);
 
     this->scalar_mul_buffer = new int_scalar_mul_buffer<Torus>(
@@ -239,7 +238,6 @@ template <typename Torus> struct int_grouped_oprf_custom_range_memory {
   /// keyswitch stage
   /// @param num_blocks_intermediate  Number of radix blocks for scalar-multiply
   /// and shift
-  /// @param message_bits_per_block   Number of message bits per radix block
   /// @param num_input_random_bits    Random bits to generate before range
   /// mapping
   /// @param num_scalar_bits          Bit-width of the scalar multiplier
@@ -248,11 +246,11 @@ template <typename Torus> struct int_grouped_oprf_custom_range_memory {
   int_grouped_oprf_custom_range_memory(
       CudaStreams streams, int_radix_params params,
       int_radix_params rerand_params, uint32_t num_blocks_intermediate,
-      uint32_t message_bits_per_block, uint64_t num_input_random_bits,
-      uint32_t num_scalar_bits, RERAND_MODE rerand_mode,
-      bool allocate_gpu_memory, uint64_t &size_tracker)
+      uint64_t num_input_random_bits, uint32_t num_scalar_bits,
+      RERAND_MODE rerand_mode, bool allocate_gpu_memory,
+      uint64_t &size_tracker)
       : int_grouped_oprf_custom_range_memory(
-            streams, params, num_blocks_intermediate, message_bits_per_block,
+            streams, params, num_blocks_intermediate,
             num_input_random_bits, num_scalar_bits, allocate_gpu_memory,
             size_tracker) {
     this->rerand_memory = new int_rerand_mem<Torus>(

--- a/backends/tfhe-cuda-backend/cuda/include/integer/oprf.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer/oprf.h
@@ -197,11 +197,13 @@ template <typename Torus> struct int_grouped_oprf_custom_range_memory {
   /// @param num_input_random_bits    Random bits to generate before range
   /// mapping
   /// @param num_scalar_bits          Bit-width of the scalar multiplier
-  int_grouped_oprf_custom_range_memory(
-      CudaStreams streams, int_radix_params params,
-      uint32_t num_blocks_intermediate, uint64_t num_input_random_bits,
-      uint32_t num_scalar_bits, bool allocate_gpu_memory,
-      uint64_t &size_tracker) {
+  int_grouped_oprf_custom_range_memory(CudaStreams streams,
+                                       int_radix_params params,
+                                       uint32_t num_blocks_intermediate,
+                                       uint64_t num_input_random_bits,
+                                       uint32_t num_scalar_bits,
+                                       bool allocate_gpu_memory,
+                                       uint64_t &size_tracker) {
     this->params = params;
     this->allocate_gpu_memory = allocate_gpu_memory;
     this->rerand_memory = nullptr;
@@ -213,8 +215,8 @@ template <typename Torus> struct int_grouped_oprf_custom_range_memory {
         CEIL_DIV(num_input_random_bits, message_bits_per_block);
 
     this->grouped_oprf_memory = new int_grouped_oprf_memory<Torus>(
-        streams, params, this->num_random_input_blocks,
-        num_input_random_bits, allocate_gpu_memory, size_tracker);
+        streams, params, this->num_random_input_blocks, num_input_random_bits,
+        allocate_gpu_memory, size_tracker);
 
     this->scalar_mul_buffer = new int_scalar_mul_buffer<Torus>(
         streams, params, num_blocks_intermediate, num_scalar_bits,
@@ -247,12 +249,10 @@ template <typename Torus> struct int_grouped_oprf_custom_range_memory {
       CudaStreams streams, int_radix_params params,
       int_radix_params rerand_params, uint32_t num_blocks_intermediate,
       uint64_t num_input_random_bits, uint32_t num_scalar_bits,
-      RERAND_MODE rerand_mode, bool allocate_gpu_memory,
-      uint64_t &size_tracker)
+      RERAND_MODE rerand_mode, bool allocate_gpu_memory, uint64_t &size_tracker)
       : int_grouped_oprf_custom_range_memory(
-            streams, params, num_blocks_intermediate,
-            num_input_random_bits, num_scalar_bits, allocate_gpu_memory,
-            size_tracker) {
+            streams, params, num_blocks_intermediate, num_input_random_bits,
+            num_scalar_bits, allocate_gpu_memory, size_tracker) {
     this->rerand_memory = new int_rerand_mem<Torus>(
         streams, rerand_params, this->num_random_input_blocks, rerand_mode,
         allocate_gpu_memory, size_tracker);

--- a/backends/tfhe-cuda-backend/cuda/include/integer/rerand.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer/rerand.h
@@ -2,11 +2,6 @@
 
 #include "integer.h"
 
-enum RERAND_MODE {
-  RERAND_WITH_KS = 0,
-  RERAND_WITHOUT_KS = 1,
-};
-
 extern "C" {
 uint64_t scratch_cuda_rerand_64_async(CudaStreamsFFI streams, int8_t **mem_ptr,
                                       CudaLweKeyswitchKeyParamsFFI ksk_params,

--- a/backends/tfhe-cuda-backend/cuda/include/integer/shuffle_utilities.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer/shuffle_utilities.h
@@ -524,8 +524,8 @@ template <typename Torus> struct int_oprf_bitonic_shuffle_buffer {
         (uint64_t)total_oprf_blocks * message_bits_per_block;
 
     this->oprf_memory = new int_grouped_oprf_memory<Torus>(
-        streams, params, total_oprf_blocks,
-        total_random_bits, allocate_gpu_memory, size_tracker);
+        streams, params, total_oprf_blocks, total_random_bits,
+        allocate_gpu_memory, size_tracker);
 
     this->shuffle_buffer = new int_bitonic_shuffle_buffer<Torus>(
         streams, params, key_num_blocks, data_num_blocks, num_values,

--- a/backends/tfhe-cuda-backend/cuda/include/integer/shuffle_utilities.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer/shuffle_utilities.h
@@ -4,6 +4,9 @@
 #include "integer_utilities.h"
 #include "oprf.h"
 
+/// @brief Forward declaration of the re-randomization scratch buffer.
+template <typename Torus> struct int_rerand_mem;
+
 /**
  * @brief Scratch buffer for batched encrypted key comparisons. Holds
  * contiguous lhs/rhs key blocks for all pairs, intermediate packing and
@@ -480,11 +483,15 @@ template <typename Torus> struct int_oprf_bitonic_shuffle_buffer {
   int_radix_params params;
   /// @brief Number of radix blocks per OPRF-generated key.
   uint32_t key_num_blocks;
+  /// @brief Number of data elements to shuffle.
+  uint32_t num_values;
 
   /// @brief OPRF scratch memory used to produce the random sorting keys.
   int_grouped_oprf_memory<Torus> *oprf_memory;
   /// @brief Underlying bitonic shuffle buffer that sorts data by the OPRF keys.
   int_bitonic_shuffle_buffer<Torus> *shuffle_buffer;
+  /// @brief Optional re-randomization scratch for sort keys.
+  int_rerand_mem<Torus> *rerand_memory;
 
   /// @brief Flat storage for all num_values OPRF-generated keys: num_values *
   /// key_num_blocks blocks.
@@ -497,6 +504,9 @@ template <typename Torus> struct int_oprf_bitonic_shuffle_buffer {
 
   bool gpu_memory_allocated;
 
+  /// @brief Returns true when re-randomization of sort keys is enabled.
+  bool applies_rerand() const { return rerand_memory != nullptr; }
+
   int_oprf_bitonic_shuffle_buffer(CudaStreams streams, int_radix_params params,
                                   uint32_t key_num_blocks,
                                   uint32_t data_num_blocks, uint32_t num_values,
@@ -505,6 +515,8 @@ template <typename Torus> struct int_oprf_bitonic_shuffle_buffer {
     this->params = params;
     this->gpu_memory_allocated = allocate_gpu_memory;
     this->key_num_blocks = key_num_blocks;
+    this->num_values = num_values;
+    this->rerand_memory = nullptr;
 
     uint64_t message_bits_per_block = log2_int(params.message_modulus);
     uint32_t total_oprf_blocks = num_values * key_num_blocks;
@@ -535,7 +547,31 @@ template <typename Torus> struct int_oprf_bitonic_shuffle_buffer {
     }
   }
 
+  /// @brief Overloaded constructor that also allocates re-randomization scratch
+  ///        for the OPRF-generated sort keys.
+  ///
+  /// @param rerand_params      Radix params for the re-randomization key.
+  /// @param rerand_mode        Re-randomization mode (with or without KS).
+  int_oprf_bitonic_shuffle_buffer(CudaStreams streams, int_radix_params params,
+                                  int_radix_params rerand_params,
+                                  uint32_t key_num_blocks,
+                                  uint32_t data_num_blocks, uint32_t num_values,
+                                  RERAND_MODE rerand_mode,
+                                  bool allocate_gpu_memory,
+                                  uint64_t &size_tracker)
+      : int_oprf_bitonic_shuffle_buffer(streams, params, key_num_blocks,
+                                        data_num_blocks, num_values,
+                                        allocate_gpu_memory, size_tracker) {
+    this->rerand_memory = new int_rerand_mem<Torus>(
+        streams, rerand_params, num_values * key_num_blocks, rerand_mode,
+        allocate_gpu_memory, size_tracker);
+  }
+
   void release(CudaStreams streams) {
+    if (this->applies_rerand()) {
+      rerand_memory->release(streams);
+      delete rerand_memory;
+    }
     oprf_memory->release(streams);
     delete oprf_memory;
     shuffle_buffer->release(streams);

--- a/backends/tfhe-cuda-backend/cuda/include/integer/shuffle_utilities.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer/shuffle_utilities.h
@@ -512,7 +512,7 @@ template <typename Torus> struct int_oprf_bitonic_shuffle_buffer {
         (uint64_t)total_oprf_blocks * message_bits_per_block;
 
     this->oprf_memory = new int_grouped_oprf_memory<Torus>(
-        streams, params, total_oprf_blocks, (uint32_t)message_bits_per_block,
+        streams, params, total_oprf_blocks,
         total_random_bits, allocate_gpu_memory, size_tracker);
 
     this->shuffle_buffer = new int_bitonic_shuffle_buffer<Torus>(

--- a/backends/tfhe-cuda-backend/cuda/src/integer/oprf.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/oprf.cu
@@ -77,19 +77,22 @@ uint64_t scratch_cuda_integer_grouped_oprf_custom_range_64_async(
         rerand_ksk_params.base_log, 0, 0, 0, message_modulus, carry_modulus,
         PBS_MS_REDUCTION_T::NO_REDUCTION);
 
-    size_tracker = scratch_cuda_integer_grouped_oprf_custom_range_async<uint64_t>(
-        CudaStreams(streams),
-        reinterpret_cast<int_grouped_oprf_custom_range_memory<uint64_t> **>(
-            mem_ptr),
-        params, rerand_params, num_blocks_intermediate, num_input_random_bits,
-        num_scalar_bits, rerand_mode, allocate_gpu_memory);
+    size_tracker =
+        scratch_cuda_integer_grouped_oprf_custom_range_async<uint64_t>(
+            CudaStreams(streams),
+            reinterpret_cast<int_grouped_oprf_custom_range_memory<uint64_t> **>(
+                mem_ptr),
+            params, rerand_params, num_blocks_intermediate,
+            num_input_random_bits, num_scalar_bits, rerand_mode,
+            allocate_gpu_memory);
   } else {
-    size_tracker = scratch_cuda_integer_grouped_oprf_custom_range_async<uint64_t>(
-        CudaStreams(streams),
-        reinterpret_cast<int_grouped_oprf_custom_range_memory<uint64_t> **>(
-            mem_ptr),
-        params, num_blocks_intermediate, num_input_random_bits, num_scalar_bits,
-        allocate_gpu_memory);
+    size_tracker =
+        scratch_cuda_integer_grouped_oprf_custom_range_async<uint64_t>(
+            CudaStreams(streams),
+            reinterpret_cast<int_grouped_oprf_custom_range_memory<uint64_t> **>(
+                mem_ptr),
+            params, num_blocks_intermediate, num_input_random_bits,
+            num_scalar_bits, allocate_gpu_memory);
   }
 
   return size_tracker;

--- a/backends/tfhe-cuda-backend/cuda/src/integer/oprf.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/oprf.cu
@@ -5,15 +5,13 @@ uint64_t scratch_cuda_integer_grouped_oprf_64_async(
     CudaLweBootstrapKeyParamsFFI bsk_params,
     CudaLweKeyswitchKeyParamsFFI ksk_params, uint32_t num_blocks_to_process,
     uint32_t message_modulus, uint32_t carry_modulus, bool allocate_gpu_memory,
-    uint32_t message_bits_per_block, uint32_t total_random_bits,
-    PBS_MS_REDUCTION_T noise_reduction_type) {
+    uint32_t total_random_bits, PBS_MS_REDUCTION_T noise_reduction_type) {
   int_radix_params params(bsk_params, ksk_params, message_modulus,
                           carry_modulus, noise_reduction_type);
 
-  return scratch_cuda_integer_grouped_oprf<uint64_t>(
+  return scratch_cuda_integer_grouped_oprf_async<uint64_t>(
       CudaStreams(streams), (int_grouped_oprf_memory<uint64_t> **)mem_ptr,
-      params, num_blocks_to_process, message_bits_per_block, total_random_bits,
-      allocate_gpu_memory);
+      params, num_blocks_to_process, total_random_bits, allocate_gpu_memory);
 }
 
 void cuda_integer_grouped_oprf_64_async(CudaStreamsFFI streams,
@@ -47,7 +45,6 @@ void cleanup_cuda_integer_grouped_oprf_64(CudaStreamsFFI streams,
 /// @param ksk_params Keyswitch key parameters for the OPRF.
 /// @param num_blocks_intermediate Computed on the Rust side; scratch and
 /// execute must pass the same value.
-/// @param message_bits_per_block Number of message bits carried by each block.
 /// @param num_input_random_bits Number of random bits generated before range
 /// mapping.
 /// @param num_scalar_bits Bit-width of the scalar the intermediate value is
@@ -65,10 +62,9 @@ uint64_t scratch_cuda_integer_grouped_oprf_custom_range_64_async(
     CudaLweBootstrapKeyParamsFFI bsk_params,
     CudaLweKeyswitchKeyParamsFFI ksk_params, uint32_t num_blocks_intermediate,
     uint32_t message_modulus, uint32_t carry_modulus, bool allocate_gpu_memory,
-    uint32_t message_bits_per_block, uint32_t num_input_random_bits,
-    uint32_t num_scalar_bits, PBS_MS_REDUCTION_T noise_reduction_type,
-    bool apply_rerand, CudaLweKeyswitchKeyParamsFFI rerand_ksk_params,
-    RERAND_MODE rerand_mode) {
+    uint32_t num_input_random_bits, uint32_t num_scalar_bits,
+    PBS_MS_REDUCTION_T noise_reduction_type, bool apply_rerand,
+    CudaLweKeyswitchKeyParamsFFI rerand_ksk_params, RERAND_MODE rerand_mode) {
   int_radix_params params(bsk_params, ksk_params, message_modulus,
                           carry_modulus, noise_reduction_type);
 
@@ -81,20 +77,19 @@ uint64_t scratch_cuda_integer_grouped_oprf_custom_range_64_async(
         rerand_ksk_params.base_log, 0, 0, 0, message_modulus, carry_modulus,
         PBS_MS_REDUCTION_T::NO_REDUCTION);
 
-    *reinterpret_cast<int_grouped_oprf_custom_range_memory<uint64_t> **>(
-        mem_ptr) =
-        new int_grouped_oprf_custom_range_memory<uint64_t>(
-            CudaStreams(streams), params, rerand_params,
-            num_blocks_intermediate, message_bits_per_block,
-            num_input_random_bits, num_scalar_bits, rerand_mode,
-            allocate_gpu_memory, size_tracker);
-  } else {
-    size_tracker = scratch_cuda_integer_grouped_oprf_custom_range<uint64_t>(
+    size_tracker = scratch_cuda_integer_grouped_oprf_custom_range_async<uint64_t>(
         CudaStreams(streams),
         reinterpret_cast<int_grouped_oprf_custom_range_memory<uint64_t> **>(
             mem_ptr),
-        params, num_blocks_intermediate, message_bits_per_block,
-        num_input_random_bits, num_scalar_bits, allocate_gpu_memory);
+        params, rerand_params, num_blocks_intermediate, num_input_random_bits,
+        num_scalar_bits, rerand_mode, allocate_gpu_memory);
+  } else {
+    size_tracker = scratch_cuda_integer_grouped_oprf_custom_range_async<uint64_t>(
+        CudaStreams(streams),
+        reinterpret_cast<int_grouped_oprf_custom_range_memory<uint64_t> **>(
+            mem_ptr),
+        params, num_blocks_intermediate, num_input_random_bits, num_scalar_bits,
+        allocate_gpu_memory);
   }
 
   return size_tracker;

--- a/backends/tfhe-cuda-backend/cuda/src/integer/oprf.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/oprf.cu
@@ -39,45 +39,117 @@ void cleanup_cuda_integer_grouped_oprf_64(CudaStreamsFFI streams,
   *mem_ptr_void = nullptr;
 }
 
+/// @brief FFI entry point allocating the scratch buffer for the 64-bit
+/// custom-range grouped OPRF.
+///
+/// @param mem_ptr Receives the newly allocated scratch buffer.
+/// @param bsk_params Bootstrapping key parameters for the OPRF.
+/// @param ksk_params Keyswitch key parameters for the OPRF.
+/// @param num_blocks_intermediate Computed on the Rust side; scratch and
+/// execute must pass the same value.
+/// @param message_bits_per_block Number of message bits carried by each block.
+/// @param num_input_random_bits Number of random bits generated before range
+/// mapping.
+/// @param num_scalar_bits Bit-width of the scalar the intermediate value is
+/// multiplied by.
+/// @param noise_reduction_type Modulus-switch noise reduction strategy.
+/// @param apply_rerand When true, allocate the re-randomization scratch; when
+/// false, allocate only the plain custom-range scratch and ignore the rerand
+/// parameters.
+/// @param rerand_ksk_params Keyswitch key parameters for the re-randomization
+/// stage (only read when apply_rerand is true).
+/// @param rerand_mode Re-randomization mode selecting whether a keyswitch is
+/// applied (only read when apply_rerand is true).
 uint64_t scratch_cuda_integer_grouped_oprf_custom_range_64_async(
     CudaStreamsFFI streams, int8_t **mem_ptr,
     CudaLweBootstrapKeyParamsFFI bsk_params,
     CudaLweKeyswitchKeyParamsFFI ksk_params, uint32_t num_blocks_intermediate,
     uint32_t message_modulus, uint32_t carry_modulus, bool allocate_gpu_memory,
     uint32_t message_bits_per_block, uint32_t num_input_random_bits,
-    uint32_t num_scalar_bits, PBS_MS_REDUCTION_T noise_reduction_type) {
+    uint32_t num_scalar_bits, PBS_MS_REDUCTION_T noise_reduction_type,
+    bool apply_rerand, CudaLweKeyswitchKeyParamsFFI rerand_ksk_params,
+    RERAND_MODE rerand_mode) {
   int_radix_params params(bsk_params, ksk_params, message_modulus,
                           carry_modulus, noise_reduction_type);
 
-  return scratch_cuda_integer_grouped_oprf_custom_range<uint64_t>(
-      CudaStreams(streams),
-      (int_grouped_oprf_custom_range_memory<uint64_t> **)mem_ptr, params,
-      num_blocks_intermediate, message_bits_per_block, num_input_random_bits,
-      num_scalar_bits, allocate_gpu_memory);
+  uint64_t size_tracker = 0;
+
+  if (apply_rerand) {
+    int_radix_params rerand_params(
+        PBS_TYPE::CLASSICAL, 0, 0, rerand_ksk_params.input_lwe_dimension,
+        rerand_ksk_params.output_lwe_dimension, rerand_ksk_params.level_count,
+        rerand_ksk_params.base_log, 0, 0, 0, message_modulus, carry_modulus,
+        PBS_MS_REDUCTION_T::NO_REDUCTION);
+
+    *reinterpret_cast<int_grouped_oprf_custom_range_memory<uint64_t> **>(
+        mem_ptr) =
+        new int_grouped_oprf_custom_range_memory<uint64_t>(
+            CudaStreams(streams), params, rerand_params,
+            num_blocks_intermediate, message_bits_per_block,
+            num_input_random_bits, num_scalar_bits, rerand_mode,
+            allocate_gpu_memory, size_tracker);
+  } else {
+    size_tracker = scratch_cuda_integer_grouped_oprf_custom_range<uint64_t>(
+        CudaStreams(streams),
+        reinterpret_cast<int_grouped_oprf_custom_range_memory<uint64_t> **>(
+            mem_ptr),
+        params, num_blocks_intermediate, message_bits_per_block,
+        num_input_random_bits, num_scalar_bits, allocate_gpu_memory);
+  }
+
+  return size_tracker;
 }
 
+/// @brief FFI entry point running the 64-bit custom-range grouped OPRF.
+///
+/// @param radix_lwe_out Output radix ciphertext holding the range-mapped
+/// result.
+/// @param num_blocks_intermediate Must match the value passed at scratch
+/// allocation.
+/// @param seeded_lwe_input Seeded LWE ciphertext used as the OPRF input.
+/// @param decomposed_scalar Blockwise decomposition of the scalar multiplier.
+/// @param has_at_least_one_set Per-scalar flag marking non-zero scalar blocks.
+/// @param num_scalars Number of scalar blocks in decomposed_scalar.
+/// @param shift Right-shift amount applied after the scalar multiply.
+/// @param lwe_flattened_encryptions_of_zero_compact_array_in Compact array of
+/// encryptions of zero consumed by the re-randomization stage (only read when
+/// rerand was enabled at scratch time).
+/// @param mem Pre-allocated scratch buffer for this operation.
+/// @param compute_bsks Array of bootstrapping key pointers for the
+/// scalar-multiply and shift stages.
+/// @param rerand_ksks Array of keyswitch key pointers for the re-randomization
+/// stage (only read when rerand was enabled at scratch time).
 void cuda_integer_grouped_oprf_custom_range_64_async(
     CudaStreamsFFI streams, CudaRadixCiphertextFFI *radix_lwe_out,
     uint32_t num_blocks_intermediate, const void *seeded_lwe_input,
     const uint64_t *decomposed_scalar, const uint64_t *has_at_least_one_set,
-    uint32_t num_scalars, uint32_t shift, int8_t *mem, void *const *bsks,
-    void *const *compute_bsks, void *const *ksks) {
+    uint32_t num_scalars, uint32_t shift,
+    const void *lwe_flattened_encryptions_of_zero_compact_array_in, int8_t *mem,
+    void *const *bsks, void *const *compute_bsks, void *const *ksks,
+    void *const *rerand_ksks) {
 
   host_integer_grouped_oprf_custom_range<uint64_t>(
       CudaStreams(streams), radix_lwe_out, num_blocks_intermediate,
-      (const uint64_t *)seeded_lwe_input, decomposed_scalar,
+      static_cast<const uint64_t *>(seeded_lwe_input), decomposed_scalar,
       has_at_least_one_set, num_scalars, shift,
-      (int_grouped_oprf_custom_range_memory<uint64_t> *)mem, bsks, compute_bsks,
-      (uint64_t *const *)ksks);
+      static_cast<const uint64_t *>(
+          lwe_flattened_encryptions_of_zero_compact_array_in),
+      reinterpret_cast<int_grouped_oprf_custom_range_memory<uint64_t> *>(mem),
+      bsks, compute_bsks, reinterpret_cast<uint64_t *const *>(ksks),
+      reinterpret_cast<uint64_t *const *>(rerand_ksks));
 }
 
+/// @brief FFI entry point releasing the custom-range grouped OPRF scratch
+/// buffer.
+///
+/// @param mem_ptr_void Address of the scratch buffer pointer, set to nullptr
+/// after release.
 void cleanup_cuda_integer_grouped_oprf_custom_range_64(CudaStreamsFFI streams,
                                                        int8_t **mem_ptr_void) {
-  int_grouped_oprf_custom_range_memory<uint64_t> *mem_ptr =
-      (int_grouped_oprf_custom_range_memory<uint64_t> *)(*mem_ptr_void);
-
+  auto *mem_ptr =
+      reinterpret_cast<int_grouped_oprf_custom_range_memory<uint64_t> *>(
+          *mem_ptr_void);
   mem_ptr->release(CudaStreams(streams));
-
   delete mem_ptr;
   *mem_ptr_void = nullptr;
 }

--- a/backends/tfhe-cuda-backend/cuda/src/integer/oprf.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/oprf.cuh
@@ -3,6 +3,7 @@
 
 #include "integer/integer.cuh"
 #include "integer/oprf.h"
+#include "integer/rerand.cuh"
 #include "integer/scalar_mul.cuh"
 #include "integer/scalar_shifts.cuh"
 
@@ -113,8 +114,9 @@ void host_integer_grouped_oprf_custom_range(
     uint32_t num_blocks_intermediate, const Torus *seeded_lwe_input,
     const Torus *decomposed_scalar, const Torus *has_at_least_one_set,
     uint32_t num_scalars, uint32_t shift,
+    const Torus *lwe_flattened_encryptions_of_zero_compact_array_in,
     int_grouped_oprf_custom_range_memory<Torus> *mem_ptr, void *const *bsks,
-    void *const *compute_bsks, Torus *const *ksks) {
+    void *const *compute_bsks, Torus *const *ksks, Torus *const *rerand_ksks) {
 
   CudaRadixCiphertextFFI *computation_buffer = mem_ptr->tmp_oprf_output;
   set_zero_radix_ciphertext_slice_async<Torus>(
@@ -124,6 +126,43 @@ void host_integer_grouped_oprf_custom_range(
   host_integer_grouped_oprf<Torus>(
       streams, computation_buffer, seeded_lwe_input,
       mem_ptr->num_random_input_blocks, mem_ptr->grouped_oprf_memory, bsks);
+
+  if (mem_ptr->applies_rerand()) {
+    auto rerand = [&](auto degree_tag) {
+      host_rerand_inplace<Torus, decltype(degree_tag)>(
+          streams, static_cast<Torus *>(computation_buffer->ptr),
+          lwe_flattened_encryptions_of_zero_compact_array_in, rerand_ksks,
+          mem_ptr->rerand_memory);
+    };
+
+    switch (mem_ptr->rerand_memory->params.polynomial_size) {
+    case 256:
+      rerand(AmortizedDegree<256>{});
+      break;
+    case 512:
+      rerand(AmortizedDegree<512>{});
+      break;
+    case 1024:
+      rerand(AmortizedDegree<1024>{});
+      break;
+    case 2048:
+      rerand(AmortizedDegree<2048>{});
+      break;
+    case 4096:
+      rerand(AmortizedDegree<4096>{});
+      break;
+    case 8192:
+      rerand(AmortizedDegree<8192>{});
+      break;
+    case 16384:
+      rerand(AmortizedDegree<16384>{});
+      break;
+    default:
+      PANIC("CUDA error: compact public key dimension not supported. Supported "
+            "dimensions are powers of two in the interval [256..16384].");
+      break;
+    }
+  }
 
   host_integer_scalar_mul_radix<Torus>(
       streams, computation_buffer, decomposed_scalar, has_at_least_one_set,

--- a/backends/tfhe-cuda-backend/cuda/src/integer/oprf.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/oprf.cuh
@@ -15,8 +15,8 @@ uint64_t scratch_cuda_integer_grouped_oprf_async(
   uint64_t size_tracker = 0;
 
   *mem_ptr = new int_grouped_oprf_memory<Torus>(
-      streams, params, num_blocks_to_process,
-      total_random_bits, allocate_gpu_memory, size_tracker);
+      streams, params, num_blocks_to_process, total_random_bits,
+      allocate_gpu_memory, size_tracker);
 
   return size_tracker;
 }
@@ -100,9 +100,8 @@ uint64_t scratch_cuda_integer_grouped_oprf_custom_range_async(
   uint64_t size_tracker = 0;
 
   *mem_ptr = new int_grouped_oprf_custom_range_memory<Torus>(
-      streams, params, num_blocks_intermediate,
-      num_input_random_bits, num_scalar_bits, allocate_gpu_memory,
-      size_tracker);
+      streams, params, num_blocks_intermediate, num_input_random_bits,
+      num_scalar_bits, allocate_gpu_memory, size_tracker);
 
   return size_tracker;
 }

--- a/backends/tfhe-cuda-backend/cuda/src/integer/oprf.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/oprf.cuh
@@ -8,15 +8,14 @@
 #include "integer/scalar_shifts.cuh"
 
 template <typename Torus>
-uint64_t scratch_cuda_integer_grouped_oprf(
+uint64_t scratch_cuda_integer_grouped_oprf_async(
     CudaStreams streams, int_grouped_oprf_memory<Torus> **mem_ptr,
     int_radix_params params, uint32_t num_blocks_to_process,
-    uint32_t message_bits_per_block, uint64_t total_random_bits,
-    bool allocate_gpu_memory) {
+    uint64_t total_random_bits, bool allocate_gpu_memory) {
   uint64_t size_tracker = 0;
 
   *mem_ptr = new int_grouped_oprf_memory<Torus>(
-      streams, params, num_blocks_to_process, message_bits_per_block,
+      streams, params, num_blocks_to_process,
       total_random_bits, allocate_gpu_memory, size_tracker);
 
   return size_tracker;
@@ -93,16 +92,33 @@ void host_integer_grouped_oprf(CudaStreams streams,
 }
 
 template <typename Torus>
-uint64_t scratch_cuda_integer_grouped_oprf_custom_range(
+uint64_t scratch_cuda_integer_grouped_oprf_custom_range_async(
     CudaStreams streams, int_grouped_oprf_custom_range_memory<Torus> **mem_ptr,
     int_radix_params params, uint32_t num_blocks_intermediate,
-    uint32_t message_bits_per_block, uint64_t num_input_random_bits,
-    uint32_t num_scalar_bits, bool allocate_gpu_memory) {
+    uint64_t num_input_random_bits, uint32_t num_scalar_bits,
+    bool allocate_gpu_memory) {
   uint64_t size_tracker = 0;
 
   *mem_ptr = new int_grouped_oprf_custom_range_memory<Torus>(
-      streams, params, num_blocks_intermediate, message_bits_per_block,
+      streams, params, num_blocks_intermediate,
       num_input_random_bits, num_scalar_bits, allocate_gpu_memory,
+      size_tracker);
+
+  return size_tracker;
+}
+
+template <typename Torus>
+uint64_t scratch_cuda_integer_grouped_oprf_custom_range_async(
+    CudaStreams streams, int_grouped_oprf_custom_range_memory<Torus> **mem_ptr,
+    int_radix_params params, int_radix_params rerand_params,
+    uint32_t num_blocks_intermediate, uint64_t num_input_random_bits,
+    uint32_t num_scalar_bits, RERAND_MODE rerand_mode,
+    bool allocate_gpu_memory) {
+  uint64_t size_tracker = 0;
+
+  *mem_ptr = new int_grouped_oprf_custom_range_memory<Torus>(
+      streams, params, rerand_params, num_blocks_intermediate,
+      num_input_random_bits, num_scalar_bits, rerand_mode, allocate_gpu_memory,
       size_tracker);
 
   return size_tracker;
@@ -128,40 +144,10 @@ void host_integer_grouped_oprf_custom_range(
       mem_ptr->num_random_input_blocks, mem_ptr->grouped_oprf_memory, bsks);
 
   if (mem_ptr->applies_rerand()) {
-    auto rerand = [&](auto degree_tag) {
-      host_rerand_inplace<Torus, decltype(degree_tag)>(
-          streams, static_cast<Torus *>(computation_buffer->ptr),
-          lwe_flattened_encryptions_of_zero_compact_array_in, rerand_ksks,
-          mem_ptr->rerand_memory);
-    };
-
-    switch (mem_ptr->rerand_memory->params.big_lwe_dimension) {
-    case 256:
-      rerand(AmortizedDegree<256>{});
-      break;
-    case 512:
-      rerand(AmortizedDegree<512>{});
-      break;
-    case 1024:
-      rerand(AmortizedDegree<1024>{});
-      break;
-    case 2048:
-      rerand(AmortizedDegree<2048>{});
-      break;
-    case 4096:
-      rerand(AmortizedDegree<4096>{});
-      break;
-    case 8192:
-      rerand(AmortizedDegree<8192>{});
-      break;
-    case 16384:
-      rerand(AmortizedDegree<16384>{});
-      break;
-    default:
-      PANIC("CUDA error: compact public key dimension not supported. Supported "
-            "dimensions are powers of two in the interval [256..16384].");
-      break;
-    }
+    host_rerand_inplace_dispatch<Torus>(
+        streams, static_cast<Torus *>(computation_buffer->ptr),
+        lwe_flattened_encryptions_of_zero_compact_array_in, rerand_ksks,
+        mem_ptr->rerand_memory);
   }
 
   host_integer_scalar_mul_radix<Torus>(

--- a/backends/tfhe-cuda-backend/cuda/src/integer/oprf.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/oprf.cuh
@@ -135,7 +135,7 @@ void host_integer_grouped_oprf_custom_range(
           mem_ptr->rerand_memory);
     };
 
-    switch (mem_ptr->rerand_memory->params.polynomial_size) {
+    switch (mem_ptr->rerand_memory->params.big_lwe_dimension) {
     case 256:
       rerand(AmortizedDegree<256>{});
       break;

--- a/backends/tfhe-cuda-backend/cuda/src/integer/rerand.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/rerand.cu
@@ -35,7 +35,7 @@ void cuda_rerand_64_async(
   PUSH_RANGE("rerand")
   auto rerand_buffer = reinterpret_cast<int_rerand_mem<uint64_t> *>(mem_ptr);
 
-  switch (rerand_buffer->params.polynomial_size) {
+  switch (rerand_buffer->params.big_lwe_dimension) {
   case 256:
     host_rerand_inplace<uint64_t, AmortizedDegree<256>>(
         streams, static_cast<uint64_t *>(lwe_array),

--- a/backends/tfhe-cuda-backend/cuda/src/integer/rerand.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/rerand.cu
@@ -35,62 +35,11 @@ void cuda_rerand_64_async(
   PUSH_RANGE("rerand")
   auto rerand_buffer = reinterpret_cast<int_rerand_mem<uint64_t> *>(mem_ptr);
 
-  switch (rerand_buffer->params.big_lwe_dimension) {
-  case 256:
-    host_rerand_inplace<uint64_t, AmortizedDegree<256>>(
-        streams, static_cast<uint64_t *>(lwe_array),
-        static_cast<const uint64_t *>(
-            lwe_flattened_encryptions_of_zero_compact_array_in),
-        reinterpret_cast<uint64_t *const *>(ksk), rerand_buffer);
-    break;
-  case 512:
-    host_rerand_inplace<uint64_t, AmortizedDegree<512>>(
-        streams, static_cast<uint64_t *>(lwe_array),
-        static_cast<const uint64_t *>(
-            lwe_flattened_encryptions_of_zero_compact_array_in),
-        reinterpret_cast<uint64_t *const *>(ksk), rerand_buffer);
-    break;
-  case 1024:
-    host_rerand_inplace<uint64_t, AmortizedDegree<1024>>(
-        streams, static_cast<uint64_t *>(lwe_array),
-        static_cast<const uint64_t *>(
-            lwe_flattened_encryptions_of_zero_compact_array_in),
-        reinterpret_cast<uint64_t *const *>(ksk), rerand_buffer);
-    break;
-  case 2048:
-    host_rerand_inplace<uint64_t, AmortizedDegree<2048>>(
-        streams, static_cast<uint64_t *>(lwe_array),
-        static_cast<const uint64_t *>(
-            lwe_flattened_encryptions_of_zero_compact_array_in),
-        reinterpret_cast<uint64_t *const *>(ksk), rerand_buffer);
-    break;
-  case 4096:
-    host_rerand_inplace<uint64_t, AmortizedDegree<4096>>(
-        streams, static_cast<uint64_t *>(lwe_array),
-        static_cast<const uint64_t *>(
-            lwe_flattened_encryptions_of_zero_compact_array_in),
-        reinterpret_cast<uint64_t *const *>(ksk), rerand_buffer);
-    break;
-  case 8192:
-    host_rerand_inplace<uint64_t, AmortizedDegree<8192>>(
-        streams, static_cast<uint64_t *>(lwe_array),
-        static_cast<const uint64_t *>(
-            lwe_flattened_encryptions_of_zero_compact_array_in),
-        reinterpret_cast<uint64_t *const *>(ksk), rerand_buffer);
-    break;
-  case 16384:
-    host_rerand_inplace<uint64_t, AmortizedDegree<16384>>(
-        streams, static_cast<uint64_t *>(lwe_array),
-        static_cast<const uint64_t *>(
-            lwe_flattened_encryptions_of_zero_compact_array_in),
-        reinterpret_cast<uint64_t *const *>(ksk), rerand_buffer);
-    break;
-  default:
-    PANIC("CUDA error: lwe_dimension not supported."
-          "Supported n's are powers of two"
-          " in the interval [256..16384].");
-    break;
-  }
+  host_rerand_inplace_dispatch<uint64_t>(
+      streams, static_cast<uint64_t *>(lwe_array),
+      static_cast<const uint64_t *>(
+          lwe_flattened_encryptions_of_zero_compact_array_in),
+      reinterpret_cast<uint64_t *const *>(ksk), rerand_buffer);
   POP_RANGE()
 }
 

--- a/backends/tfhe-cuda-backend/cuda/src/integer/rerand.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/rerand.cu
@@ -35,7 +35,7 @@ void cuda_rerand_64_async(
   PUSH_RANGE("rerand")
   auto rerand_buffer = reinterpret_cast<int_rerand_mem<uint64_t> *>(mem_ptr);
 
-  switch (rerand_buffer->params.big_lwe_dimension) {
+  switch (rerand_buffer->params.polynomial_size) {
   case 256:
     host_rerand_inplace<uint64_t, AmortizedDegree<256>>(
         streams, static_cast<uint64_t *>(lwe_array),

--- a/backends/tfhe-cuda-backend/cuda/src/integer/rerand.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/rerand.cuh
@@ -85,6 +85,54 @@ void host_rerand_inplace(
 }
 
 template <typename Torus>
+void host_rerand_inplace_dispatch(
+    CudaStreams const streams, Torus *lwe_array,
+    const Torus *lwe_flattened_encryptions_of_zero_compact_array_in,
+    Torus *const *ksk, int_rerand_mem<Torus> *mem_ptr) {
+  switch (mem_ptr->params.big_lwe_dimension) {
+  case 256:
+    host_rerand_inplace<Torus, AmortizedDegree<256>>(
+        streams, lwe_array,
+        lwe_flattened_encryptions_of_zero_compact_array_in, ksk, mem_ptr);
+    break;
+  case 512:
+    host_rerand_inplace<Torus, AmortizedDegree<512>>(
+        streams, lwe_array,
+        lwe_flattened_encryptions_of_zero_compact_array_in, ksk, mem_ptr);
+    break;
+  case 1024:
+    host_rerand_inplace<Torus, AmortizedDegree<1024>>(
+        streams, lwe_array,
+        lwe_flattened_encryptions_of_zero_compact_array_in, ksk, mem_ptr);
+    break;
+  case 2048:
+    host_rerand_inplace<Torus, AmortizedDegree<2048>>(
+        streams, lwe_array,
+        lwe_flattened_encryptions_of_zero_compact_array_in, ksk, mem_ptr);
+    break;
+  case 4096:
+    host_rerand_inplace<Torus, AmortizedDegree<4096>>(
+        streams, lwe_array,
+        lwe_flattened_encryptions_of_zero_compact_array_in, ksk, mem_ptr);
+    break;
+  case 8192:
+    host_rerand_inplace<Torus, AmortizedDegree<8192>>(
+        streams, lwe_array,
+        lwe_flattened_encryptions_of_zero_compact_array_in, ksk, mem_ptr);
+    break;
+  case 16384:
+    host_rerand_inplace<Torus, AmortizedDegree<16384>>(
+        streams, lwe_array,
+        lwe_flattened_encryptions_of_zero_compact_array_in, ksk, mem_ptr);
+    break;
+  default:
+    PANIC("CUDA error: lwe_dimension not supported. Supported dimensions are "
+          "powers of two in the interval [256..16384].");
+    break;
+  }
+}
+
+template <typename Torus>
 __host__ uint64_t scratch_cuda_rerand(CudaStreams streams,
                                       int_rerand_mem<Torus> **mem_ptr,
                                       uint32_t num_lwes,

--- a/backends/tfhe-cuda-backend/cuda/src/integer/rerand.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/rerand.cuh
@@ -84,6 +84,14 @@ void host_rerand_inplace(
   compact_lwe_lists.release();
 }
 
+/// @brief Dispatches re-randomization over the supported polynomial sizes.
+///
+/// @param lwe_array                LWE ciphertext array to re-randomize in
+/// place
+/// @param lwe_flattened_encryptions_of_zero_compact_array_in  Flattened compact
+///        encryptions of zero used as noise source
+/// @param ksk                     Keyswitch key pointers (one per GPU)
+/// @param mem_ptr                 Pre-allocated re-randomization scratch buffer
 template <typename Torus>
 void host_rerand_inplace_dispatch(
     CudaStreams const streams, Torus *lwe_array,
@@ -92,38 +100,38 @@ void host_rerand_inplace_dispatch(
   switch (mem_ptr->params.big_lwe_dimension) {
   case 256:
     host_rerand_inplace<Torus, AmortizedDegree<256>>(
-        streams, lwe_array,
-        lwe_flattened_encryptions_of_zero_compact_array_in, ksk, mem_ptr);
+        streams, lwe_array, lwe_flattened_encryptions_of_zero_compact_array_in,
+        ksk, mem_ptr);
     break;
   case 512:
     host_rerand_inplace<Torus, AmortizedDegree<512>>(
-        streams, lwe_array,
-        lwe_flattened_encryptions_of_zero_compact_array_in, ksk, mem_ptr);
+        streams, lwe_array, lwe_flattened_encryptions_of_zero_compact_array_in,
+        ksk, mem_ptr);
     break;
   case 1024:
     host_rerand_inplace<Torus, AmortizedDegree<1024>>(
-        streams, lwe_array,
-        lwe_flattened_encryptions_of_zero_compact_array_in, ksk, mem_ptr);
+        streams, lwe_array, lwe_flattened_encryptions_of_zero_compact_array_in,
+        ksk, mem_ptr);
     break;
   case 2048:
     host_rerand_inplace<Torus, AmortizedDegree<2048>>(
-        streams, lwe_array,
-        lwe_flattened_encryptions_of_zero_compact_array_in, ksk, mem_ptr);
+        streams, lwe_array, lwe_flattened_encryptions_of_zero_compact_array_in,
+        ksk, mem_ptr);
     break;
   case 4096:
     host_rerand_inplace<Torus, AmortizedDegree<4096>>(
-        streams, lwe_array,
-        lwe_flattened_encryptions_of_zero_compact_array_in, ksk, mem_ptr);
+        streams, lwe_array, lwe_flattened_encryptions_of_zero_compact_array_in,
+        ksk, mem_ptr);
     break;
   case 8192:
     host_rerand_inplace<Torus, AmortizedDegree<8192>>(
-        streams, lwe_array,
-        lwe_flattened_encryptions_of_zero_compact_array_in, ksk, mem_ptr);
+        streams, lwe_array, lwe_flattened_encryptions_of_zero_compact_array_in,
+        ksk, mem_ptr);
     break;
   case 16384:
     host_rerand_inplace<Torus, AmortizedDegree<16384>>(
-        streams, lwe_array,
-        lwe_flattened_encryptions_of_zero_compact_array_in, ksk, mem_ptr);
+        streams, lwe_array, lwe_flattened_encryptions_of_zero_compact_array_in,
+        ksk, mem_ptr);
     break;
   default:
     PANIC("CUDA error: lwe_dimension not supported. Supported dimensions are "

--- a/backends/tfhe-cuda-backend/cuda/src/integer/shuffle.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/shuffle.cu
@@ -62,17 +62,24 @@ uint64_t scratch_cuda_integer_oprf_bitonic_shuffle_64_async(
     CudaLweKeyswitchKeyParamsFFI ksk_params, uint32_t key_num_radix_blocks,
     uint32_t data_num_radix_blocks, uint32_t num_values,
     uint32_t message_modulus, uint32_t carry_modulus, bool allocate_gpu_memory,
-    PBS_MS_REDUCTION_T noise_reduction_type) {
+    PBS_MS_REDUCTION_T noise_reduction_type, bool apply_rerand,
+    CudaLweKeyswitchKeyParamsFFI rerand_ksk_params, RERAND_MODE rerand_mode) {
 
   PUSH_RANGE("scratch oprf bitonic shuffle")
   int_radix_params params(bsk_params, ksk_params, message_modulus,
                           carry_modulus, noise_reduction_type);
 
+  int_radix_params rerand_params(
+      PBS_TYPE::CLASSICAL, 0, 0, rerand_ksk_params.input_lwe_dimension,
+      rerand_ksk_params.output_lwe_dimension, rerand_ksk_params.level_count,
+      rerand_ksk_params.base_log, 0, 0, 0, message_modulus, carry_modulus,
+      PBS_MS_REDUCTION_T::NO_REDUCTION);
+
   uint64_t ret = scratch_cuda_integer_oprf_bitonic_shuffle_async<uint64_t>(
       CudaStreams(streams),
       (int_oprf_bitonic_shuffle_buffer<uint64_t> **)mem_ptr,
       key_num_radix_blocks, data_num_radix_blocks, num_values, params,
-      allocate_gpu_memory);
+      apply_rerand, rerand_params, rerand_mode, allocate_gpu_memory);
   POP_RANGE()
   return ret;
 }
@@ -93,14 +100,19 @@ uint64_t scratch_cuda_integer_oprf_bitonic_shuffle_64_async(
 void cuda_integer_oprf_bitonic_shuffle_64_async(
     CudaStreamsFFI streams, CudaRadixCiphertextFFI **values,
     uint32_t num_values, const void *seeded_lwe_input, int8_t *mem_ptr,
-    void *const *oprf_bsks, void *const *bsks, void *const *ksks) {
+    void *const *oprf_bsks, void *const *bsks, void *const *ksks,
+    const void *lwe_flattened_encryptions_of_zero_compact_array_in,
+    void *const *rerand_ksks) {
 
   PUSH_RANGE("oprf bitonic shuffle")
   host_oprf_bitonic_shuffle<uint64_t>(
       CudaStreams(streams), values, num_values,
       static_cast<const uint64_t *>(seeded_lwe_input),
-      (int_oprf_bitonic_shuffle_buffer<uint64_t> *)mem_ptr, oprf_bsks, bsks,
-      (uint64_t **)ksks);
+      static_cast<const uint64_t *>(
+          lwe_flattened_encryptions_of_zero_compact_array_in),
+      reinterpret_cast<uint64_t *const *>(rerand_ksks),
+      reinterpret_cast<int_oprf_bitonic_shuffle_buffer<uint64_t> *>(mem_ptr),
+      oprf_bsks, bsks, reinterpret_cast<uint64_t *const *>(ksks));
   POP_RANGE()
 }
 

--- a/backends/tfhe-cuda-backend/cuda/src/integer/shuffle.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/shuffle.cu
@@ -12,7 +12,7 @@ uint64_t scratch_cuda_integer_bitonic_shuffle_64_async(
   int_radix_params params(bsk_params, ksk_params, message_modulus,
                           carry_modulus, noise_reduction_type);
 
-  uint64_t ret = scratch_cuda_integer_bitonic_shuffle<uint64_t>(
+  uint64_t ret = scratch_cuda_integer_bitonic_shuffle_async<uint64_t>(
       CudaStreams(streams), (int_bitonic_shuffle_buffer<uint64_t> **)mem_ptr,
       key_num_radix_blocks, data_num_radix_blocks, num_values, params,
       allocate_gpu_memory);
@@ -68,7 +68,7 @@ uint64_t scratch_cuda_integer_oprf_bitonic_shuffle_64_async(
   int_radix_params params(bsk_params, ksk_params, message_modulus,
                           carry_modulus, noise_reduction_type);
 
-  uint64_t ret = scratch_cuda_integer_oprf_bitonic_shuffle<uint64_t>(
+  uint64_t ret = scratch_cuda_integer_oprf_bitonic_shuffle_async<uint64_t>(
       CudaStreams(streams),
       (int_oprf_bitonic_shuffle_buffer<uint64_t> **)mem_ptr,
       key_num_radix_blocks, data_num_radix_blocks, num_values, params,

--- a/backends/tfhe-cuda-backend/cuda/src/integer/shuffle.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/shuffle.cuh
@@ -2,6 +2,7 @@
 #define TFHE_RS_SHUFFLE_CUH
 
 #include "integer/oprf.cuh"
+#include "integer/rerand.cuh"
 #include "integer/shuffle_utilities.h"
 #include "radix_ciphertext.cuh"
 
@@ -787,12 +788,19 @@ template <typename Torus>
 __host__ uint64_t scratch_cuda_integer_oprf_bitonic_shuffle_async(
     CudaStreams streams, int_oprf_bitonic_shuffle_buffer<Torus> **mem_ptr,
     uint32_t key_num_blocks, uint32_t data_num_blocks, uint32_t num_values,
-    int_radix_params params, bool allocate_gpu_memory) {
+    int_radix_params params, bool apply_rerand, int_radix_params rerand_params,
+    RERAND_MODE rerand_mode, bool allocate_gpu_memory) {
 
   uint64_t size_tracker = 0;
-  *mem_ptr = new int_oprf_bitonic_shuffle_buffer<Torus>(
-      streams, params, key_num_blocks, data_num_blocks, num_values,
-      allocate_gpu_memory, size_tracker);
+  if (apply_rerand) {
+    *mem_ptr = new int_oprf_bitonic_shuffle_buffer<Torus>(
+        streams, params, rerand_params, key_num_blocks, data_num_blocks,
+        num_values, rerand_mode, allocate_gpu_memory, size_tracker);
+  } else {
+    *mem_ptr = new int_oprf_bitonic_shuffle_buffer<Torus>(
+        streams, params, key_num_blocks, data_num_blocks, num_values,
+        allocate_gpu_memory, size_tracker);
+  }
   return size_tracker;
 }
 
@@ -804,22 +812,35 @@ __host__ uint64_t scratch_cuda_integer_oprf_bitonic_shuffle_async(
  * radix-ciphertexts.
  * @param num_values       Number of values to shuffle.
  * @param seeded_lwe_input Seeded LWE ciphertext used as OPRF input.
+ * @param lwe_flattened_encryptions_of_zero_compact_array_in Flattened compact
+ * array of encryptions of zero used for re-randomization.
+ * @param rerand_ksks      Array of re-randomization keyswitch key pointers, one
+ * per GPU.
  * @param oprf_bsks        Array of OPRF bootstrapping key pointers, one per
  * GPU.
  */
 template <typename Torus, typename KSTorus>
-__host__ void
-host_oprf_bitonic_shuffle(CudaStreams streams, CudaRadixCiphertextFFI **values,
-                          uint32_t num_values, const Torus *seeded_lwe_input,
-                          int_oprf_bitonic_shuffle_buffer<Torus> *mem_ptr,
-                          void *const *oprf_bsks, void *const *bsks,
-                          KSTorus *const *ksks) {
+__host__ void host_oprf_bitonic_shuffle(
+    CudaStreams streams, CudaRadixCiphertextFFI **values, uint32_t num_values,
+    const Torus *seeded_lwe_input,
+    const Torus *lwe_flattened_encryptions_of_zero_compact_array_in,
+    Torus *const *rerand_ksks, int_oprf_bitonic_shuffle_buffer<Torus> *mem_ptr,
+    void *const *oprf_bsks, void *const *bsks, KSTorus *const *ksks) {
 
   uint32_t key_num_blocks = mem_ptr->key_num_blocks;
 
   host_integer_grouped_oprf<Torus>(
       streams, mem_ptr->keys_storage, seeded_lwe_input,
       num_values * key_num_blocks, mem_ptr->oprf_memory, oprf_bsks);
+
+  if (mem_ptr->applies_rerand()) {
+    auto *rerand_mem = mem_ptr->rerand_memory;
+    auto *keys_ptr = static_cast<Torus *>(mem_ptr->keys_storage->ptr);
+
+    host_rerand_inplace_dispatch<Torus>(
+        streams, keys_ptr, lwe_flattened_encryptions_of_zero_compact_array_in,
+        rerand_ksks, rerand_mem);
+  }
 
   host_bitonic_shuffle<Torus>(streams, mem_ptr->keys_ptrs, values, num_values,
                               mem_ptr->shuffle_buffer, bsks, ksks);

--- a/backends/tfhe-cuda-backend/cuda/src/integer/shuffle.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/shuffle.cuh
@@ -631,7 +631,7 @@ apply_cmux_batched(CudaStreams streams, CudaRadixCiphertextFFI **keys,
 }
 
 template <typename Torus>
-__host__ uint64_t scratch_cuda_integer_bitonic_shuffle(
+__host__ uint64_t scratch_cuda_integer_bitonic_shuffle_async(
     CudaStreams streams, int_bitonic_shuffle_buffer<Torus> **mem_ptr,
     uint32_t key_num_radix_blocks, uint32_t data_num_radix_blocks,
     uint32_t num_values, int_radix_params params, bool allocate_gpu_memory) {
@@ -784,7 +784,7 @@ host_bitonic_shuffle(CudaStreams streams, CudaRadixCiphertextFFI **keys,
 }
 
 template <typename Torus>
-__host__ uint64_t scratch_cuda_integer_oprf_bitonic_shuffle(
+__host__ uint64_t scratch_cuda_integer_oprf_bitonic_shuffle_async(
     CudaStreams streams, int_oprf_bitonic_shuffle_buffer<Torus> **mem_ptr,
     uint32_t key_num_blocks, uint32_t data_num_blocks, uint32_t num_values,
     int_radix_params params, bool allocate_gpu_memory) {

--- a/backends/tfhe-cuda-backend/src/bindings.rs
+++ b/backends/tfhe-cuda-backend/src/bindings.rs
@@ -310,6 +310,9 @@ pub type Direction = ffi::c_uint;
 pub const BitValue_Zero: BitValue = 0;
 pub const BitValue_One: BitValue = 1;
 pub type BitValue = ffi::c_uint;
+pub const RERAND_MODE_RERAND_WITH_KS: RERAND_MODE = 0;
+pub const RERAND_MODE_RERAND_WITHOUT_KS: RERAND_MODE = 1;
+pub type RERAND_MODE = ffi::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct CudaStreamsFFI {
@@ -1592,6 +1595,9 @@ unsafe extern "C" {
         num_input_random_bits: u32,
         num_scalar_bits: u32,
         noise_reduction_type: PBS_MS_REDUCTION_T,
+        apply_rerand: bool,
+        rerand_ksk_params: CudaLweKeyswitchKeyParamsFFI,
+        rerand_mode: RERAND_MODE,
     ) -> u64;
 }
 unsafe extern "C" {
@@ -1604,10 +1610,12 @@ unsafe extern "C" {
         has_at_least_one_set: *const u64,
         num_scalars: u32,
         shift: u32,
+        lwe_flattened_encryptions_of_zero_compact_array_in: *const ffi::c_void,
         mem: *mut i8,
         bsks: *const *mut ffi::c_void,
         compute_bsks: *const *mut ffi::c_void,
         ksks: *const *mut ffi::c_void,
+        rerand_ksks: *const *mut ffi::c_void,
     );
 }
 unsafe extern "C" {
@@ -2507,9 +2515,6 @@ unsafe extern "C" {
         mem_ptr_void: *mut *mut i8,
     );
 }
-pub const RERAND_MODE_RERAND_WITH_KS: RERAND_MODE = 0;
-pub const RERAND_MODE_RERAND_WITHOUT_KS: RERAND_MODE = 1;
-pub type RERAND_MODE = ffi::c_uint;
 unsafe extern "C" {
     pub fn scratch_cuda_rerand_64_async(
         streams: CudaStreamsFFI,

--- a/backends/tfhe-cuda-backend/src/bindings.rs
+++ b/backends/tfhe-cuda-backend/src/bindings.rs
@@ -1560,7 +1560,6 @@ unsafe extern "C" {
         message_modulus: u32,
         carry_modulus: u32,
         allocate_gpu_memory: bool,
-        message_bits_per_block: u32,
         total_random_bits: u32,
         noise_reduction_type: PBS_MS_REDUCTION_T,
     ) -> u64;
@@ -1591,7 +1590,6 @@ unsafe extern "C" {
         message_modulus: u32,
         carry_modulus: u32,
         allocate_gpu_memory: bool,
-        message_bits_per_block: u32,
         num_input_random_bits: u32,
         num_scalar_bits: u32,
         noise_reduction_type: PBS_MS_REDUCTION_T,

--- a/backends/tfhe-cuda-backend/src/bindings.rs
+++ b/backends/tfhe-cuda-backend/src/bindings.rs
@@ -2216,6 +2216,9 @@ unsafe extern "C" {
         carry_modulus: u32,
         allocate_gpu_memory: bool,
         noise_reduction_type: PBS_MS_REDUCTION_T,
+        apply_rerand: bool,
+        rerand_ksk_params: CudaLweKeyswitchKeyParamsFFI,
+        rerand_mode: RERAND_MODE,
     ) -> u64;
 }
 unsafe extern "C" {
@@ -2228,6 +2231,8 @@ unsafe extern "C" {
         oprf_bsks: *const *mut ffi::c_void,
         bsks: *const *mut ffi::c_void,
         ksks: *const *mut ffi::c_void,
+        lwe_flattened_encryptions_of_zero_compact_array_in: *const ffi::c_void,
+        rerand_ksks: *const *mut ffi::c_void,
     );
 }
 unsafe extern "C" {

--- a/scripts/check_memory_errors.sh
+++ b/scripts/check_memory_errors.sh
@@ -90,6 +90,8 @@ if [[ "${RUN_VALGRIND}" == "1" ]]; then
 fi
 
 if [[ "${RUN_COMPUTE_SANITIZER}" == "1" ]]; then
+  export TFHE_RS_COMPUTE_SANITIZER=1
+
   # List the tests into a temporary file using the GPU feature set
   RUSTFLAGS="$RUSTFLAGS" cargo nextest list --cargo-profile "${CARGO_PROFILE}" \
             --features="${SANITIZER_CARGO_FEATURES_GPU}" -p "${SANITIZER_CARGO_PACKAGE}" &> /tmp/test_list.txt

--- a/tfhe/src/high_level_api/integers/oprf.rs
+++ b/tfhe/src/high_level_api/integers/oprf.rs
@@ -404,7 +404,7 @@ impl<Id: FheUintId> FheUint<Id> {
                         .par_generate_oblivious_pseudo_random_unsigned_custom_range(
                             seed,
                             num_input_random_bits,
-                            excluded_upper_bound.get(),
+                            excluded_upper_bound,
                             num_blocks_output,
                             cuda_key.pbs_key(),
                             &cuda_key.streams,
@@ -455,9 +455,6 @@ impl<Id: FheUintId> FheUint<Id> {
     }
 
     /// Re-randomizing variant of [`Self::generate_oblivious_pseudo_random_custom_range`].
-    ///
-    /// The GPU backend does not yet expose a re-randomizing custom-range PRF primitive; calling
-    /// this function with a GPU server key currently panics for the non-power-of-two case.
     pub fn generate_oblivious_pseudo_random_custom_range_and_re_randomize<
         'a,
         RRD: Into<ReRandomizationMode<'a>>,
@@ -522,11 +519,38 @@ impl<Id: FheUintId> FheUint<Id> {
                     ))
                 }
                 #[cfg(feature = "gpu")]
-                InternalServerKey::Cuda(_cuda_key) => {
-                    panic!(
-                        "generate_oblivious_pseudo_random_custom_range_and_re_randomize is not yet \
-                        supported on GPU for non-power-of-two ranges."
+                InternalServerKey::Cuda(cuda_key) => {
+                    let streams = &cuda_key.streams;
+                    let message_modulus = cuda_key.message_modulus();
+
+                    let num_input_random_bits = num_input_random_bits_for_max_distance(
+                        excluded_upper_bound,
+                        max_distance,
+                        message_modulus,
                     );
+
+                    let num_blocks_output = Id::num_blocks(cuda_key.message_modulus()) as u64;
+
+                    let rerand_key =
+                        cuda_key.integer_re_randomization_key_from_mode(re_randomization_mode)?;
+                    let d_ct = cuda_key
+                        .oprf_key()
+                        .par_generate_oblivious_pseudo_random_unsigned_custom_range_and_re_randomize(
+                            seed,
+                            num_input_random_bits,
+                            excluded_upper_bound,
+                            num_blocks_output,
+                            cuda_key.pbs_key(),
+                            &rerand_key,
+                            prf_re_randomization_context.inner(),
+                            streams,
+                        )?;
+
+                    Ok(Self::new(
+                        d_ct,
+                        cuda_key.tag.clone(),
+                        ReRandomizationMetadata::default(),
+                    ))
                 }
                 #[cfg(feature = "hpu")]
                 InternalServerKey::Hpu(_device) => {
@@ -1473,7 +1497,6 @@ mod test {
         }
     }
 
-    // TODO fuse in the other function once GPU is available for custom_range
     fn prf_equivalence_subtest_custom_range(
         client_key: &ClientKey,
         rerand_mode: ReRandomizationMode,
@@ -1696,7 +1719,7 @@ mod test {
 
                 assert_eq!(expected_results, gpu_results);
 
-                // TODO add custom_range test for GPU
+                prf_equivalence_subtest_custom_range(&client_key, rerand_mode);
             }
         }
 

--- a/tfhe/src/high_level_api/integers/shuffle.rs
+++ b/tfhe/src/high_level_api/integers/shuffle.rs
@@ -95,9 +95,25 @@ where
                 .collect())
         }
         #[cfg(feature = "gpu")]
-        InternalServerKey::Cuda(_) => Err(crate::Error::new(
-            "bitonic_shuffle is not supported on Cuda".to_string(),
-        )),
+        InternalServerKey::Cuda(cuda_key) => {
+            let re_randomization_key =
+                cuda_key.integer_re_randomization_key_from_mode(re_randomization_mode)?;
+            let streams = &cuda_key.streams;
+            let inner = data.into_iter().map(|v| v.into_gpu(streams)).collect();
+            let result = cuda_key.pbs_key().bitonic_shuffle_and_re_randomize(
+                &cuda_key.oprf_key(),
+                inner,
+                key_size,
+                seed,
+                &re_randomization_key,
+                prf_re_randomization_context.inner(),
+                streams,
+            )?;
+            Ok(result
+                .into_iter()
+                .map(|ct| T::from_gpu(ct, cuda_key.tag.clone(), ReRandomizationMetadata::default()))
+                .collect())
+        }
         #[cfg(feature = "hpu")]
         InternalServerKey::Hpu(_) => Err(crate::Error::new(
             "bitonic_shuffle is not supported on Hpu".to_string(),
@@ -116,6 +132,8 @@ mod test {
     use crate::high_level_api::{set_server_key, ClientKey, ConfigBuilder, ServerKey};
     use crate::shortint::ciphertext::{ReRandomizationHashAlgo, ReRandomizationSeedHasher};
     use crate::shortint::parameters::ReRandomizationParameters;
+    #[cfg(feature = "gpu")]
+    use crate::CompressedServerKey;
     #[cfg(feature = "gpu")]
     use crate::{FheInt16, FheUint32};
     use crate::{FheInt8, FheUint8};
@@ -559,6 +577,81 @@ mod test {
             clear_values.sort_unstable();
             decrypted.sort_unstable();
             assert_eq!(decrypted, clear_values);
+        }
+    }
+
+    #[cfg(feature = "gpu")]
+    #[test]
+    fn test_bitonic_shuffle_rerand_fheuint_gpu() {
+        let cks = {
+            let config = ConfigBuilder::default()
+                .use_dedicated_oprf_key(true)
+                .enable_ciphertext_re_randomization(
+                    ReRandomizationParameters::DerivedCPKWithoutKeySwitch,
+                )
+                .build();
+            let cks = ClientKey::generate(config);
+            let compressed_sks = CompressedServerKey::new(&cks);
+            let sks = compressed_sks.decompress_to_gpu();
+            set_server_key(sks);
+            cks
+        };
+        let mut rng = rand::thread_rng();
+        let mut clear_values: Vec<u8> = (0..15).map(|_| rng.gen()).collect();
+
+        let encrypted: Vec<FheUint8> = clear_values
+            .iter()
+            .map(|&v| FheUint8::try_encrypt(v, &cks).unwrap())
+            .collect();
+
+        let seed = new_seeder().seed();
+        println!("seed: {seed:?}");
+        let key_size = BitonicShuffleKeySize::num_bits(32);
+        let shuffled = bitonic_shuffle(encrypted.clone(), key_size, seed).unwrap();
+        let shuffled_rerand = {
+            let mut shuffled_rerand = vec![];
+            for rerand_hash_algo in [
+                ReRandomizationHashAlgo::Blake3,
+                ReRandomizationHashAlgo::Shake256,
+            ] {
+                let seed_hasher = ReRandomizationSeedHasher::new(
+                    rerand_hash_algo,
+                    crate::shortint::oprf::TFHE_PRF_RERAND_DOMAIN_SEPARATOR,
+                );
+                let prf_rerand_context = PrfReRandomizationContext::new_with_hasher(
+                    crate::shortint::public_key::compact::TFHE_PKE_DOMAIN_SEPARATOR,
+                    seed_hasher,
+                );
+                shuffled_rerand.push(
+                    re_randomized_keys_bitonic_shuffle(
+                        encrypted.clone(),
+                        key_size,
+                        seed,
+                        ReRandomizationMode::UseAvailableMode,
+                        &prf_rerand_context,
+                    )
+                    .unwrap(),
+                );
+            }
+            shuffled_rerand
+        };
+
+        let decrypted_ref: Vec<u8> = shuffled.iter().map(|ct| ct.decrypt(&cks)).collect();
+        clear_values.sort_unstable();
+        let decrypted_sorted = {
+            let mut tmp = decrypted_ref.clone();
+            tmp.sort_unstable();
+            tmp
+        };
+        assert_eq!(decrypted_sorted, clear_values);
+
+        for (idx, rerand_result) in shuffled_rerand.into_iter().enumerate() {
+            let decrypted_rerand: Vec<u8> =
+                rerand_result.iter().map(|ct| ct.decrypt(&cks)).collect();
+            assert_eq!(
+                decrypted_ref, decrypted_rerand,
+                "failed at index {idx} of decrypted_rerand"
+            );
         }
     }
 }

--- a/tfhe/src/high_level_api/integers/shuffle.rs
+++ b/tfhe/src/high_level_api/integers/shuffle.rs
@@ -125,6 +125,11 @@ mod test {
     #[cfg(feature = "gpu")]
     use std::fmt::Debug;
 
+    #[cfg(feature = "gpu")]
+    fn is_sanitizer_run() -> bool {
+        std::env::var("TFHE_RS_COMPUTE_SANITIZER").is_ok_and(|v| v == "1")
+    }
+
     #[test]
     fn test_bitonic_shuffle_fheuint() {
         let cks = {
@@ -380,8 +385,11 @@ mod test {
 
         let mut rng = rand::thread_rng();
 
-        // List of number of items sort
-        let ns: &[usize] = &[2, 5, 9, 11, 3, 6, 7, 10];
+        let ns: &[usize] = if is_sanitizer_run() {
+            &[2, 5, 11]
+        } else {
+            &[2, 5, 9, 11, 3, 6, 7, 10]
+        };
 
         // Pre-generate clear data: three categories of key patterns.
         let cases: Vec<(Vec<u32>, Vec<CT>)> = ns
@@ -471,8 +479,10 @@ mod test {
     #[test]
     fn test_bitonic_sort_order_cpu_vs_gpu() {
         common_test_bitonic_sort_order_cpu_vs_gpu::<i16, FheInt16>();
-        common_test_bitonic_sort_order_cpu_vs_gpu::<i8, FheInt8>();
-        common_test_bitonic_sort_order_cpu_vs_gpu::<u32, FheUint32>();
+        if !is_sanitizer_run() {
+            common_test_bitonic_sort_order_cpu_vs_gpu::<i8, FheInt8>();
+            common_test_bitonic_sort_order_cpu_vs_gpu::<u32, FheUint32>();
+        }
     }
 
     #[cfg(feature = "gpu")]
@@ -520,9 +530,11 @@ mod test {
     #[cfg(feature = "gpu")]
     #[test]
     fn test_bitonic_shuffle_unique_seed_gpu() {
-        common_test_bitonic_shuffle_seed_unique_gpu::<i16, FheInt16>();
-        common_test_bitonic_shuffle_seed_unique_gpu::<i8, FheInt8>();
         common_test_bitonic_shuffle_seed_unique_gpu::<u32, FheUint32>();
+        if !is_sanitizer_run() {
+            common_test_bitonic_shuffle_seed_unique_gpu::<i16, FheInt16>();
+            common_test_bitonic_shuffle_seed_unique_gpu::<i8, FheInt8>();
+        }
     }
 
     #[cfg(feature = "gpu")]

--- a/tfhe/src/integer/gpu/ffi.rs
+++ b/tfhe/src/integer/gpu/ffi.rs
@@ -10738,6 +10738,9 @@ pub(crate) unsafe fn cuda_backend_oprf_bitonic_shuffle<T: UnsignedInteger, B: Nu
     key_num_blocks: u32,
     data_num_blocks: u32,
     ms_noise_reduction_configuration: Option<&CudaModulusSwitchNoiseReductionConfiguration>,
+    apply_rerand: bool,
+    zero_lwes: Option<&CudaLweCompactCiphertextList<u64>>,
+    rerand_keyswitch_key: Option<&CudaLweKeyswitchKey<u64>>,
 ) {
     let num_values = values.len();
     assert!(
@@ -10770,6 +10773,44 @@ pub(crate) unsafe fn cuda_backend_oprf_bitonic_shuffle<T: UnsignedInteger, B: Nu
     let bsk_params = bsk.params_ffi();
     let noise_reduction_type = resolve_ms_noise_reduction_config(ms_noise_reduction_configuration);
 
+    let (rerand_ksk_params, rerand_mode, zero_lwes_ptr) = if apply_rerand {
+        let zero_lwes = zero_lwes.expect("apply_rerand requires zero_lwes to be Some");
+        assert_eq!(streams.gpu_indexes[0], zero_lwes.0.d_vec.gpu_index(0));
+        let (rerand_ksk_params, rerand_mode) = rerand_keyswitch_key.map_or(
+            (
+                CudaLweKeyswitchKeyParamsFFI {
+                    input_lwe_dimension: bsk_params.big_lwe_dimension,
+                    output_lwe_dimension: 0,
+                    level_count: 0,
+                    base_log: 0,
+                },
+                RerandMode::WithoutKs,
+            ),
+            |ksk| {
+                assert_eq!(streams.gpu_indexes[0], ksk.d_vec.gpu_index(0));
+                (ksk.params_ffi(), RerandMode::WithKs)
+            },
+        );
+        (
+            rerand_ksk_params,
+            rerand_mode,
+            zero_lwes.0.d_vec.as_c_ptr(0),
+        )
+    } else {
+        (
+            CudaLweKeyswitchKeyParamsFFI {
+                input_lwe_dimension: 0,
+                output_lwe_dimension: 0,
+                base_log: 0,
+                level_count: 0,
+            },
+            RerandMode::WithoutKs,
+            std::ptr::null(),
+        )
+    };
+    let rerand_ksks_ptr =
+        rerand_keyswitch_key.map_or(std::ptr::null(), |ksk| ksk.d_vec.ptr.as_ptr());
+
     let mut data_degrees: Vec<Vec<u64>> = values
         .iter()
         .map(|v| v.info.blocks.iter().map(|b| b.degree.0).collect())
@@ -10800,6 +10841,9 @@ pub(crate) unsafe fn cuda_backend_oprf_bitonic_shuffle<T: UnsignedInteger, B: Nu
         u32::try_from(carry_modulus.0).unwrap(),
         true,
         noise_reduction_type as u32,
+        apply_rerand,
+        rerand_ksk_params,
+        rerand_mode as u32,
     );
 
     cuda_integer_oprf_bitonic_shuffle_64_async(
@@ -10811,6 +10855,8 @@ pub(crate) unsafe fn cuda_backend_oprf_bitonic_shuffle<T: UnsignedInteger, B: Nu
         oprf_bootstrapping_key.ptr.as_ptr(),
         bootstrapping_key.ptr.as_ptr(),
         keyswitch_key.ptr.as_ptr(),
+        zero_lwes_ptr,
+        rerand_ksks_ptr,
     );
 
     cleanup_cuda_integer_oprf_bitonic_shuffle_64(streams.ffi(), std::ptr::addr_of_mut!(mem_ptr));

--- a/tfhe/src/integer/gpu/ffi.rs
+++ b/tfhe/src/integer/gpu/ffi.rs
@@ -2684,11 +2684,24 @@ pub(crate) unsafe fn cuda_backend_grouped_oprf<B: Numeric>(
 }
 
 #[allow(clippy::too_many_arguments)]
+/// Custom-range grouped OPRF backend call, optionally re-randomizing the fresh random blocks.
+///
+/// When `apply_rerand` is `false`, this performs the plain custom-range grouped OPRF. When
+/// `apply_rerand` is `true`, `zero_lwes` must be `Some` and carries the encryptions of zero added
+/// to re-randomize the random blocks before the range mapping, and `rerand_keyswitch_key` selects
+/// the keyswitching mode.
+///
 /// # Safety
 ///
 /// - The data must not be moved or dropped while being used by the CUDA kernel.
 /// - This function assumes exclusive access to the passed data; violating this may lead to
 ///   undefined behavior.
+/// - When `apply_rerand` is `true`, `zero_lwes` must be `Some`.
+/// - In `WithoutKs` mode, when `rerand_keyswitch_key` is `None`, the `rerand_ksks` pointer passed
+///   to the backend is null and is never dereferenced because the encryptions of zero are added
+///   directly. In `rerand_ksk_params`, only `input_lwe_dimension` is read in that mode: it sizes
+///   the expanded encryptions of zero and selects the expansion kernel. `output_lwe_dimension`,
+///   `base_log` and `level_count` are unused.
 pub(crate) unsafe fn cuda_backend_grouped_oprf_custom_range<
     T: UnsignedInteger,
     B: Numeric,
@@ -2709,8 +2722,10 @@ pub(crate) unsafe fn cuda_backend_grouped_oprf_custom_range<
     message_modulus: MessageModulus,
     carry_modulus: CarryModulus,
     message_bits_per_block: u32,
-    _total_random_bits: u32,
     ms_noise_reduction_configuration: Option<&CudaModulusSwitchNoiseReductionConfiguration>,
+    apply_rerand: bool,
+    zero_lwes: Option<&CudaLweCompactCiphertextList<u64>>,
+    rerand_keyswitch_key: Option<&CudaLweKeyswitchKey<u64>>,
 ) {
     let bsk_params = bsk.params_ffi();
     assert_eq!(
@@ -2746,6 +2761,45 @@ pub(crate) unsafe fn cuda_backend_grouped_oprf_custom_range<
     let mut cuda_ffi_radix_lwe_out =
         prepare_cuda_radix_ffi(radix_lwe_out, &mut out_degrees, &mut out_noise_levels);
 
+    let (rerand_ksk_params, rerand_mode, zero_lwes_ptr) = if apply_rerand {
+        let zero_lwes = zero_lwes.expect("apply_rerand requires zero_lwes to be Some");
+        assert_eq!(streams.gpu_indexes[0], zero_lwes.0.d_vec.gpu_index(0));
+        let (rerand_ksk_params, rerand_mode) = if let Some(ksk) = rerand_keyswitch_key {
+            assert_eq!(streams.gpu_indexes[0], ksk.d_vec.gpu_index(0));
+            (ksk.params_ffi(), RerandMode::WithKs)
+        } else {
+            let radix_lwe_dimension =
+                u32::try_from(radix_lwe_out.d_blocks.lwe_dimension().0).unwrap();
+            (
+                CudaLweKeyswitchKeyParamsFFI {
+                    input_lwe_dimension: radix_lwe_dimension,
+                    output_lwe_dimension: radix_lwe_dimension,
+                    base_log: 0,
+                    level_count: 0,
+                },
+                RerandMode::WithoutKs,
+            )
+        };
+        (
+            rerand_ksk_params,
+            rerand_mode,
+            zero_lwes.0.d_vec.as_c_ptr(0),
+        )
+    } else {
+        (
+            CudaLweKeyswitchKeyParamsFFI {
+                input_lwe_dimension: 0,
+                output_lwe_dimension: 0,
+                base_log: 0,
+                level_count: 0,
+            },
+            RerandMode::WithoutKs,
+            std::ptr::null(),
+        )
+    };
+    let rerand_ksks_ptr =
+        rerand_keyswitch_key.map_or(std::ptr::null(), |ksk| ksk.d_vec.ptr.as_ptr());
+
     scratch_cuda_integer_grouped_oprf_custom_range_64_async(
         streams.ffi(),
         std::ptr::addr_of_mut!(mem_ptr),
@@ -2759,6 +2813,9 @@ pub(crate) unsafe fn cuda_backend_grouped_oprf_custom_range<
         shift,
         num_scalars,
         noise_reduction_type as u32,
+        apply_rerand,
+        rerand_ksk_params,
+        rerand_mode as u32,
     );
 
     cuda_integer_grouped_oprf_custom_range_64_async(
@@ -2770,10 +2827,12 @@ pub(crate) unsafe fn cuda_backend_grouped_oprf_custom_range<
         has_at_least_one_set.as_ptr().cast::<u64>(),
         num_scalars,
         shift,
+        zero_lwes_ptr,
         mem_ptr,
         bootstrapping_key.ptr.as_ptr(),
         compute_bootstrapping_key.ptr.as_ptr(),
         key_switching_key.ptr.as_ptr(),
+        rerand_ksks_ptr,
     );
 
     cleanup_cuda_integer_grouped_oprf_custom_range_64(

--- a/tfhe/src/integer/gpu/ffi.rs
+++ b/tfhe/src/integer/gpu/ffi.rs
@@ -2624,7 +2624,6 @@ pub(crate) unsafe fn cuda_backend_grouped_oprf<B: Numeric>(
     ksk_params: CudaLweKeyswitchKeyParamsFFI,
     message_modulus: MessageModulus,
     carry_modulus: CarryModulus,
-    message_bits_per_block: u32,
     total_random_bits: u32,
     ms_noise_reduction_configuration: Option<&CudaModulusSwitchNoiseReductionConfiguration>,
 ) {
@@ -2664,7 +2663,6 @@ pub(crate) unsafe fn cuda_backend_grouped_oprf<B: Numeric>(
         u32::try_from(message_modulus.0).unwrap(),
         u32::try_from(carry_modulus.0).unwrap(),
         true,
-        message_bits_per_block,
         total_random_bits,
         noise_reduction_type as u32,
     );
@@ -2721,7 +2719,6 @@ pub(crate) unsafe fn cuda_backend_grouped_oprf_custom_range<
     ksk_params: CudaLweKeyswitchKeyParamsFFI,
     message_modulus: MessageModulus,
     carry_modulus: CarryModulus,
-    message_bits_per_block: u32,
     ms_noise_reduction_configuration: Option<&CudaModulusSwitchNoiseReductionConfiguration>,
     apply_rerand: bool,
     zero_lwes: Option<&CudaLweCompactCiphertextList<u64>>,
@@ -2809,7 +2806,6 @@ pub(crate) unsafe fn cuda_backend_grouped_oprf_custom_range<
         u32::try_from(message_modulus.0).unwrap(),
         u32::try_from(carry_modulus.0).unwrap(),
         true,
-        message_bits_per_block,
         shift,
         num_scalars,
         noise_reduction_type as u32,
@@ -2851,7 +2847,6 @@ pub(crate) fn cuda_backend_get_grouped_oprf_size_on_gpu(
     ksk_params: CudaLweKeyswitchKeyParamsFFI,
     message_modulus: MessageModulus,
     carry_modulus: CarryModulus,
-    message_bits_per_block: u32,
     total_random_bits: u32,
     ms_noise_reduction_configuration: Option<&CudaModulusSwitchNoiseReductionConfiguration>,
 ) -> u64 {
@@ -2870,7 +2865,6 @@ pub(crate) fn cuda_backend_get_grouped_oprf_size_on_gpu(
             u32::try_from(message_modulus.0).unwrap(),
             u32::try_from(carry_modulus.0).unwrap(),
             false,
-            message_bits_per_block,
             total_random_bits,
             noise_reduction_type as u32,
         )

--- a/tfhe/src/integer/gpu/server_key/radix/oprf.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/oprf.rs
@@ -671,7 +671,6 @@ where
                         computing_ks_key.params_ffi(),
                         target_sks.message_modulus,
                         target_sks.carry_modulus,
-                        message_bits_count,
                         total_random_bits as u32,
                         d_bsk.ms_noise_reduction_configuration.as_ref(),
                     );
@@ -687,7 +686,6 @@ where
                         computing_ks_key.params_ffi(),
                         target_sks.message_modulus,
                         target_sks.carry_modulus,
-                        message_bits_count,
                         total_random_bits as u32,
                         None,
                     );
@@ -1041,7 +1039,6 @@ where
         zero_lwes: Option<&CudaLweCompactCiphertextList<u64>>,
         rerand_keyswitch_key: Option<&CudaLweKeyswitchKey<u64>>,
     ) {
-        let message_bits_count = target_sks.message_modulus.0.ilog2();
         match (
             self.bootstrapping_key.borrow(),
             &target_sks.bootstrapping_key,
@@ -1065,7 +1062,6 @@ where
                     computing_ks_key.params_ffi(),
                     target_sks.message_modulus,
                     target_sks.carry_modulus,
-                    message_bits_count,
                     d_bsk.ms_noise_reduction_configuration.as_ref(),
                     apply_rerand,
                     zero_lwes,
@@ -1091,7 +1087,6 @@ where
                     computing_ks_key.params_ffi(),
                     target_sks.message_modulus,
                     target_sks.carry_modulus,
-                    message_bits_count,
                     None,
                     apply_rerand,
                     zero_lwes,
@@ -1125,7 +1120,6 @@ where
                 target_sks.message_modulus,
                 target_sks.carry_modulus,
                 message_bits,
-                message_bits,
                 d_bsk.ms_noise_reduction_configuration.as_ref(),
             ),
             CudaBootstrappingKey::MultiBit(d_bsk) => cuda_backend_get_grouped_oprf_size_on_gpu(
@@ -1135,7 +1129,6 @@ where
                 computing_ks_key.params_ffi(),
                 target_sks.message_modulus,
                 target_sks.carry_modulus,
-                message_bits,
                 message_bits,
                 None,
             ),

--- a/tfhe/src/integer/gpu/server_key/radix/oprf.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/oprf.rs
@@ -1,4 +1,5 @@
 use std::borrow::Borrow;
+use std::num::NonZeroU64;
 
 use crate::core_crypto::gpu::CudaStreams;
 use crate::integer::ciphertext::{PrfReRandomizationContext, ReRandomizationSeed};
@@ -17,12 +18,16 @@ use crate::shortint::oprf::{
 };
 use crate::shortint::OprfSeed;
 
+use crate::core_crypto::gpu::lwe_compact_ciphertext_list::CudaLweCompactCiphertextList;
+use crate::core_crypto::gpu::lwe_keyswitch_key::CudaLweKeyswitchKey;
 use crate::core_crypto::gpu::vec::CudaVec;
+use crate::core_crypto::prelude::LweCiphertextCount;
 use crate::integer::block_decomposition::BlockDecomposer;
 use crate::integer::gpu::{
     cuda_backend_get_grouped_oprf_size_on_gpu, cuda_backend_grouped_oprf,
     cuda_backend_grouped_oprf_custom_range,
 };
+use crate::shortint::PBSOrder;
 
 pub struct GenericCudaOprfServerKey<K> {
     bootstrapping_key: K,
@@ -742,11 +747,183 @@ where
         &self,
         seed: impl OprfSeed,
         num_input_random_bits: u64,
-        excluded_upper_bound: u64,
+        excluded_upper_bound: NonZeroU64,
         num_blocks_output: u64,
         target_sks: &CudaServerKey,
         streams: &CudaStreams,
     ) -> CudaUnsignedRadixCiphertext {
+        self.par_generate_oblivious_pseudo_random_unsigned_custom_range_impl(
+            seed,
+            num_input_random_bits,
+            excluded_upper_bound,
+            num_blocks_output,
+            target_sks,
+            streams,
+            |result,
+             num_blocks_intermediate,
+             d_seeded_lwe_input,
+             decomposed_scalar,
+             has_at_least_one_set,
+             shift,
+             computing_ks_key,
+             _prf_seed,
+             _rle_info| {
+                // SAFETY: all device buffers referenced below outlive the backend call, and this
+                // closure holds exclusive access to `result`.
+                unsafe {
+                    self.dispatch_custom_range_oprf(
+                        streams,
+                        result,
+                        num_blocks_intermediate,
+                        d_seeded_lwe_input,
+                        decomposed_scalar,
+                        has_at_least_one_set,
+                        shift,
+                        computing_ks_key,
+                        target_sks,
+                        false,
+                        None,
+                        None,
+                    );
+                }
+                Ok(())
+            },
+        )
+        .unwrap()
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn par_generate_oblivious_pseudo_random_unsigned_custom_range_and_re_randomize(
+        &self,
+        seed: impl OprfSeed,
+        num_input_random_bits: u64,
+        excluded_upper_bound: NonZeroU64,
+        num_blocks_output: u64,
+        target_sks: &CudaServerKey,
+        re_randomization_key: &CudaReRandomizationKey<'_>,
+        prf_re_randomization_context: &PrfReRandomizationContext,
+        streams: &CudaStreams,
+    ) -> crate::Result<CudaUnsignedRadixCiphertext> {
+        let message_bits_count: u64 = target_sks.message_modulus.0.ilog2().into();
+        self.par_generate_oblivious_pseudo_random_unsigned_custom_range_impl(
+            seed,
+            num_input_random_bits,
+            excluded_upper_bound,
+            num_blocks_output,
+            target_sks,
+            streams,
+            |result,
+             num_blocks_intermediate,
+             d_seeded_lwe_input,
+             decomposed_scalar,
+             has_at_least_one_set,
+             shift,
+             computing_ks_key,
+             prf_seed,
+             rle_info| {
+                let radix_block_lwe_size = result.d_blocks.lwe_dimension().to_lwe_size();
+                let (compact_public_key, rerand_keyswitch_key) = match *re_randomization_key {
+                    CudaReRandomizationKey::LegacyDedicatedCPK { cpk, ksk } => {
+                        let lwe_keyswitch_key = &ksk.lwe_keyswitch_key;
+                        if lwe_keyswitch_key.output_key_lwe_size() != radix_block_lwe_size {
+                            return Err(crate::error!(
+                                "Mismatched LweSize between the ciphertext being re-randomized \
+                                and the provided re-randomization keyswitch key output."
+                            ));
+                        }
+                        if lwe_keyswitch_key.input_key_lwe_size()
+                            != cpk.parameters().encryption_lwe_dimension.to_lwe_size()
+                        {
+                            return Err(crate::error!(
+                                "Mismatched LweDimension between the provided CompactPublicKey \
+                                and the re-randomization keyswitch key input."
+                            ));
+                        }
+                        if ksk.destination_key.into_pbs_order() != PBSOrder::KeyswitchBootstrap {
+                            return Err(crate::error!(
+                                "Tried to re-randomize with a re-randomization keyswitch key \
+                                whose destination key uses an unsupported PBSOrder. Required \
+                                PBSOrder::KeyswitchBootstrap."
+                            ));
+                        }
+                        if ksk.cast_rshift != 0 {
+                            return Err(crate::error!(
+                                "Tried to re-randomize with a re-randomization keyswitch key that \
+                                has a non-zero cast_rshift, this is unsupported."
+                            ));
+                        }
+                        (cpk, Some(lwe_keyswitch_key))
+                    }
+                    CudaReRandomizationKey::DerivedCPKWithoutKeySwitch { cpk } => {
+                        if cpk.key.key.lwe_dimension().to_lwe_size() != radix_block_lwe_size {
+                            return Err(crate::error!(
+                                "Mismatched LweSize between the ciphertext being re-randomized \
+                                and the provided CompactPublicKey."
+                            ));
+                        }
+                        (cpk, None)
+                    }
+                };
+
+                let num_random_input_blocks = (shift as u64).div_ceil(message_bits_count);
+                let rerand_seed = ReRandomizationSeed::new_prf_rerand_seed(
+                    prf_re_randomization_context.inner(),
+                    prf_seed,
+                    rle_info,
+                );
+                let encryption_of_zero = compact_public_key.key.prepare_cpk_zero_for_rerand(
+                    rerand_seed,
+                    LweCiphertextCount(num_random_input_blocks as usize),
+                );
+                let d_zero_lwes = CudaLweCompactCiphertextList::from_lwe_compact_ciphertext_list(
+                    &encryption_of_zero,
+                    streams,
+                );
+
+                // SAFETY: all device buffers referenced below outlive the backend call, and this
+                // closure holds exclusive access to `result`.
+                unsafe {
+                    self.dispatch_custom_range_oprf(
+                        streams,
+                        result,
+                        num_blocks_intermediate,
+                        d_seeded_lwe_input,
+                        decomposed_scalar,
+                        has_at_least_one_set,
+                        shift,
+                        computing_ks_key,
+                        target_sks,
+                        true,
+                        Some(&d_zero_lwes),
+                        rerand_keyswitch_key,
+                    );
+                }
+                Ok(())
+            },
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn par_generate_oblivious_pseudo_random_unsigned_custom_range_impl(
+        &self,
+        seed: impl OprfSeed,
+        num_input_random_bits: u64,
+        excluded_upper_bound: NonZeroU64,
+        num_blocks_output: u64,
+        target_sks: &CudaServerKey,
+        streams: &CudaStreams,
+        prf_dispatch: impl FnOnce(
+            &mut CudaRadixCiphertext,
+            u32,
+            &CudaVec<u64>,
+            &[u64],
+            &[u64],
+            u32,
+            &CudaLweKeyswitchKey<u64>,
+            &[u8],
+            &RandomBitsRleLeBytes,
+        ) -> crate::Result<()>,
+    ) -> crate::Result<CudaUnsignedRadixCiphertext> {
         assert!(
             target_sks.message_modulus.0.is_power_of_two(),
             "Message modulus must be a power of two"
@@ -765,17 +942,12 @@ where
             function instead"
         );
 
-        // Since excluded_upper_bound is not a power of two, we know the ceil log2 of the value is
-        // the ilog2 + 1, this is how many bits are needed to represent the value
-        let excluded_upper_bound_log2: u64 = excluded_upper_bound.ilog2().into();
-        let excluded_upper_bound_ceil_log2 = excluded_upper_bound_log2 + 1;
         let num_bits_output = num_blocks_output * message_bits_count;
-
+        let excluded_upper_bound_ceil_log2 = u64::BITS - excluded_upper_bound.leading_zeros();
         assert!(
-            excluded_upper_bound_ceil_log2 <= num_bits_output,
+            u64::from(excluded_upper_bound_ceil_log2) <= num_bits_output,
             "num_blocks_output(={num_blocks_output}) is too small to hold an integer \
-            up to excluded_upper_bound(={excluded_upper_bound}). Output has {num_bits_output} bits,\
-            {excluded_upper_bound} needs {excluded_upper_bound_ceil_log2} bits to be represented."
+            up to excluded_upper_bound(={excluded_upper_bound})"
         );
 
         let CudaDynamicKeyswitchingKey::Standard(computing_ks_key) = &target_sks.key_switching_key
@@ -790,24 +962,27 @@ where
         let polynomial_size = bootstrapping_key.polynomial_size();
         let in_lwe_size = input_lwe_dimension.to_lwe_size();
 
-        let post_mul_num_bits = num_input_random_bits + excluded_upper_bound_ceil_log2;
-
+        let post_mul_num_bits = num_input_random_bits + u64::from(excluded_upper_bound.ilog2()) + 1;
         let num_blocks_intermediate = post_mul_num_bits.div_ceil(message_bits_count);
 
         let decomposer =
-            BlockDecomposer::with_early_stop_at_zero(excluded_upper_bound, 1).iter_as::<u8>();
+            BlockDecomposer::with_early_stop_at_zero(excluded_upper_bound.get(), 1).iter_as::<u8>();
         let mut has_at_least_one_set = vec![0u64; message_bits_count as usize];
         for (i, bit) in decomposer.collect_vec().iter().copied().enumerate() {
             if bit == 1 {
                 has_at_least_one_set[i % message_bits_count as usize] = 1;
             }
         }
-        let decomposed_scalar = BlockDecomposer::with_early_stop_at_zero(excluded_upper_bound, 1)
-            .iter_as::<u64>()
-            .collect::<Vec<_>>();
+        let decomposed_scalar =
+            BlockDecomposer::with_early_stop_at_zero(excluded_upper_bound.get(), 1)
+                .iter_as::<u64>()
+                .collect::<Vec<_>>();
 
-        let (seeded, _rle_info) = create_random_from_seed_modulus_switched(
-            seed,
+        let seed_bytes = seed.into_bytes();
+        let prf_seed: &[u8] = seed_bytes.as_ref();
+
+        let (seeded, rle_info) = create_random_from_seed_modulus_switched(
+            prf_seed,
             in_lwe_size,
             polynomial_size,
             &[num_input_random_bits],
@@ -830,63 +1005,103 @@ where
         let mut result: CudaUnsignedRadixCiphertext =
             target_sks.create_trivial_zero_radix(num_blocks_output as usize, streams);
 
-        unsafe {
-            match (bootstrapping_key, &target_sks.bootstrapping_key) {
-                (
-                    CudaBootstrappingKey::Classic(d_bsk),
-                    CudaBootstrappingKey::Classic(compute_d_bsk),
-                ) => {
-                    cuda_backend_grouped_oprf_custom_range(
-                        streams,
-                        result.as_mut(),
-                        num_blocks_intermediate as u32,
-                        &d_seeded_lwe_input,
-                        decomposed_scalar.as_slice(),
-                        has_at_least_one_set.as_slice(),
-                        num_input_random_bits as u32,
-                        &d_bsk.d_vec,
-                        &compute_d_bsk.d_vec,
-                        &computing_ks_key.d_vec,
-                        d_bsk,
-                        computing_ks_key.params_ffi(),
-                        target_sks.message_modulus,
-                        target_sks.carry_modulus,
-                        message_bits_count as u32,
-                        post_mul_num_bits as u32,
-                        d_bsk.ms_noise_reduction_configuration.as_ref(),
-                    );
-                }
-                (
-                    CudaBootstrappingKey::MultiBit(d_bsk),
-                    CudaBootstrappingKey::MultiBit(compute_d_bsk),
-                ) => {
-                    cuda_backend_grouped_oprf_custom_range(
-                        streams,
-                        result.as_mut(),
-                        num_blocks_intermediate as u32,
-                        &d_seeded_lwe_input,
-                        decomposed_scalar.as_slice(),
-                        has_at_least_one_set.as_slice(),
-                        num_input_random_bits as u32,
-                        &d_bsk.d_vec,
-                        &compute_d_bsk.d_vec,
-                        &computing_ks_key.d_vec,
-                        d_bsk,
-                        computing_ks_key.params_ffi(),
-                        target_sks.message_modulus,
-                        target_sks.carry_modulus,
-                        message_bits_count as u32,
-                        post_mul_num_bits as u32,
-                        None,
-                    );
-                }
-                (_, _) => {
-                    panic!("OPRF and compute bootstrapping keys must have matching types");
-                }
+        prf_dispatch(
+            result.as_mut(),
+            num_blocks_intermediate as u32,
+            &d_seeded_lwe_input,
+            decomposed_scalar.as_slice(),
+            has_at_least_one_set.as_slice(),
+            num_input_random_bits as u32,
+            computing_ks_key,
+            prf_seed,
+            &rle_info,
+        )?;
+
+        Ok(result)
+    }
+
+    /// # Safety
+    ///
+    /// All device buffers referenced by `self`, `target_sks`, `computing_ks_key`, the input
+    /// arguments, and `zero_lwes`/`rerand_keyswitch_key` must remain alive and unmodified for the
+    /// duration of the backend call.
+    #[allow(clippy::too_many_arguments)]
+    unsafe fn dispatch_custom_range_oprf(
+        &self,
+        streams: &CudaStreams,
+        result: &mut CudaRadixCiphertext,
+        num_blocks_intermediate: u32,
+        d_seeded_lwe_input: &CudaVec<u64>,
+        decomposed_scalar: &[u64],
+        has_at_least_one_set: &[u64],
+        num_input_random_bits: u32,
+        computing_ks_key: &CudaLweKeyswitchKey<u64>,
+        target_sks: &CudaServerKey,
+        apply_rerand: bool,
+        zero_lwes: Option<&CudaLweCompactCiphertextList<u64>>,
+        rerand_keyswitch_key: Option<&CudaLweKeyswitchKey<u64>>,
+    ) {
+        let message_bits_count = target_sks.message_modulus.0.ilog2();
+        match (
+            self.bootstrapping_key.borrow(),
+            &target_sks.bootstrapping_key,
+        ) {
+            (
+                CudaBootstrappingKey::Classic(d_bsk),
+                CudaBootstrappingKey::Classic(compute_d_bsk),
+            ) => {
+                cuda_backend_grouped_oprf_custom_range(
+                    streams,
+                    result,
+                    num_blocks_intermediate,
+                    d_seeded_lwe_input,
+                    decomposed_scalar,
+                    has_at_least_one_set,
+                    num_input_random_bits,
+                    &d_bsk.d_vec,
+                    &compute_d_bsk.d_vec,
+                    &computing_ks_key.d_vec,
+                    d_bsk,
+                    computing_ks_key.params_ffi(),
+                    target_sks.message_modulus,
+                    target_sks.carry_modulus,
+                    message_bits_count,
+                    d_bsk.ms_noise_reduction_configuration.as_ref(),
+                    apply_rerand,
+                    zero_lwes,
+                    rerand_keyswitch_key,
+                );
+            }
+            (
+                CudaBootstrappingKey::MultiBit(d_bsk),
+                CudaBootstrappingKey::MultiBit(compute_d_bsk),
+            ) => {
+                cuda_backend_grouped_oprf_custom_range(
+                    streams,
+                    result,
+                    num_blocks_intermediate,
+                    d_seeded_lwe_input,
+                    decomposed_scalar,
+                    has_at_least_one_set,
+                    num_input_random_bits,
+                    &d_bsk.d_vec,
+                    &compute_d_bsk.d_vec,
+                    &computing_ks_key.d_vec,
+                    d_bsk,
+                    computing_ks_key.params_ffi(),
+                    target_sks.message_modulus,
+                    target_sks.carry_modulus,
+                    message_bits_count,
+                    None,
+                    apply_rerand,
+                    zero_lwes,
+                    rerand_keyswitch_key,
+                );
+            }
+            (_, _) => {
+                panic!("OPRF and compute bootstrapping keys must have matching types");
             }
         }
-
-        result
     }
 
     /// Getter for the GPU memory usage of OPRF.

--- a/tfhe/src/integer/gpu/server_key/radix/shuffle.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/shuffle.rs
@@ -1,5 +1,9 @@
+use crate::core_crypto::gpu::lwe_compact_ciphertext_list::CudaLweCompactCiphertextList;
 use crate::core_crypto::gpu::vec::CudaVec;
 use crate::core_crypto::gpu::CudaStreams;
+use crate::core_crypto::prelude::LweCiphertextCount;
+use crate::integer::ciphertext::{PrfReRandomizationContext, ReRandomizationSeed};
+use crate::integer::gpu::ciphertext::re_randomization::CudaReRandomizationKey;
 use crate::integer::gpu::ciphertext::{CudaIntegerRadixCiphertext, CudaUnsignedRadixCiphertext};
 use crate::integer::gpu::server_key::radix::oprf::GenericCudaOprfServerKey;
 use crate::integer::gpu::server_key::{CudaBootstrappingKey, CudaDynamicKeyswitchingKey};
@@ -137,6 +141,9 @@ impl CudaServerKey {
                         key_num_blocks as u32,
                         data_num_blocks as u32,
                         d_bsk.ms_noise_reduction_configuration.as_ref(),
+                        false,
+                        None,
+                        None,
                     );
                 }
                 (
@@ -157,6 +164,183 @@ impl CudaServerKey {
                         key_num_blocks as u32,
                         data_num_blocks as u32,
                         None,
+                        false,
+                        None,
+                        None,
+                    );
+                }
+                _ => panic!("OPRF key and compute key must use the same kind of bootstrapping key"),
+            }
+        }
+
+        Ok(data)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn bitonic_shuffle_and_re_randomize<T, S, K>(
+        &self,
+        oprf_key: &GenericCudaOprfServerKey<K>,
+        mut data: Vec<T>,
+        key_size: BitonicShuffleKeySize,
+        seed: S,
+        re_randomization_key: &CudaReRandomizationKey<'_>,
+        prf_re_randomization_context: &PrfReRandomizationContext,
+        streams: &CudaStreams,
+    ) -> Result<Vec<T>, crate::Error>
+    where
+        T: CudaIntegerRadixCiphertext,
+        S: OprfSeed,
+        K: Borrow<CudaBootstrappingKey<u64>>,
+    {
+        if self.message_modulus.0 != 4 || self.carry_modulus.0 != 4 {
+            return Err(crate::Error::new(
+                "bitonic_shuffle on GPU currently only supports MESSAGE_2_CARRY_2 parameters"
+                    .to_string(),
+            ));
+        }
+
+        let key_num_blocks = key_size.num_blocks_of_keys(data.len(), self.message_modulus) as u64;
+
+        if key_num_blocks == 0 {
+            return Err(crate::Error::new(
+                "key_num_blocks must be at least 1".to_string(),
+            ));
+        }
+
+        if data.len() <= 1 {
+            return Ok(data);
+        }
+
+        let data_num_blocks = data[0].as_ref().d_blocks.lwe_ciphertext_count().0;
+        if data[1..]
+            .iter()
+            .any(|d| d.as_ref().d_blocks.lwe_ciphertext_count().0 != data_num_blocks)
+        {
+            return Err(crate::Error::new(
+                "all data elements must have the same number of blocks".to_string(),
+            ));
+        }
+
+        for v in data.iter_mut() {
+            let needs_propagate = v
+                .as_ref()
+                .info
+                .blocks
+                .iter()
+                .any(|b| !b.carry_is_empty() || b.noise_level != NoiseLevel::NOMINAL);
+            if needs_propagate {
+                self.full_propagate_assign(v, streams);
+            }
+        }
+
+        let CudaDynamicKeyswitchingKey::Standard(computing_ks_key) = &self.key_switching_key else {
+            panic!("Only the standard atomic pattern is supported on GPU")
+        };
+
+        let oprf_bsk = oprf_key.bootstrapping_key();
+        oprf_key.assert_compatible_with_target_bsk(&self.bootstrapping_key);
+
+        let input_lwe_dimension = self.bootstrapping_key.input_lwe_dimension();
+        let polynomial_size = self.bootstrapping_key.polynomial_size();
+        let in_lwe_size = input_lwe_dimension.to_lwe_size();
+        let message_bits_count = self.message_modulus.0.ilog2() as u64;
+        let bits_per_block = message_bits_count + self.carry_modulus.0.ilog2() as u64 + 1;
+        let key_num_bits = key_num_blocks * message_bits_count;
+
+        let seed_bytes = seed.into_bytes();
+        let chunks = vec![key_num_bits; data.len()];
+        let (seeded, rle_info) = create_random_from_seed_modulus_switched(
+            seed_bytes.as_ref(),
+            in_lwe_size,
+            polynomial_size,
+            &chunks,
+            message_bits_count,
+            bits_per_block,
+        );
+        let h_seeded_lwe_list: Vec<u64> = seeded
+            .into_iter()
+            .flat_map(|(seeded, _bits)| {
+                raw_seeded_msed_to_lwe(&seeded, self.ciphertext_modulus).into_container()
+            })
+            .collect();
+
+        let mut d_seeded_lwe_input =
+            unsafe { CudaVec::<u64>::new_async(h_seeded_lwe_list.len(), streams, 0) };
+        unsafe {
+            d_seeded_lwe_input.copy_from_cpu_async(&h_seeded_lwe_list, streams, 0);
+        }
+        streams.synchronize();
+
+        let rerand_seed = ReRandomizationSeed::new_prf_rerand_seed(
+            prf_re_randomization_context.inner(),
+            seed_bytes.as_ref(),
+            &rle_info,
+        );
+
+        let total_key_blocks = data.len() * key_num_blocks as usize;
+        let mut value_refs: Vec<_> = data.iter_mut().map(|v| v.as_mut()).collect();
+
+        let (cpk, rerand_ksk) = match re_randomization_key {
+            CudaReRandomizationKey::DerivedCPKWithoutKeySwitch { cpk } => (cpk, None),
+            CudaReRandomizationKey::LegacyDedicatedCPK { cpk, ksk } => {
+                (cpk, Some(&ksk.lwe_keyswitch_key))
+            }
+        };
+
+        let encryption_of_zero = cpk
+            .key
+            .prepare_cpk_zero_for_rerand(rerand_seed, LweCiphertextCount(total_key_blocks));
+        let d_zero_lwes = CudaLweCompactCiphertextList::from_lwe_compact_ciphertext_list(
+            &encryption_of_zero,
+            streams,
+        );
+
+        unsafe {
+            match (&self.bootstrapping_key, oprf_bsk) {
+                (
+                    CudaBootstrappingKey::Classic(d_bsk),
+                    CudaBootstrappingKey::Classic(oprf_d_bsk),
+                ) => {
+                    cuda_backend_oprf_bitonic_shuffle(
+                        streams,
+                        &mut value_refs,
+                        &d_seeded_lwe_input,
+                        &oprf_d_bsk.d_vec,
+                        &d_bsk.d_vec,
+                        &computing_ks_key.d_vec,
+                        self.message_modulus,
+                        self.carry_modulus,
+                        d_bsk,
+                        computing_ks_key.params_ffi(),
+                        key_num_blocks as u32,
+                        data_num_blocks as u32,
+                        d_bsk.ms_noise_reduction_configuration.as_ref(),
+                        true,
+                        Some(&d_zero_lwes),
+                        rerand_ksk,
+                    );
+                }
+                (
+                    CudaBootstrappingKey::MultiBit(d_multibit_bsk),
+                    CudaBootstrappingKey::MultiBit(oprf_d_multibit_bsk),
+                ) => {
+                    cuda_backend_oprf_bitonic_shuffle(
+                        streams,
+                        &mut value_refs,
+                        &d_seeded_lwe_input,
+                        &oprf_d_multibit_bsk.d_vec,
+                        &d_multibit_bsk.d_vec,
+                        &computing_ks_key.d_vec,
+                        self.message_modulus,
+                        self.carry_modulus,
+                        d_multibit_bsk,
+                        computing_ks_key.params_ffi(),
+                        key_num_blocks as u32,
+                        data_num_blocks as u32,
+                        None,
+                        true,
+                        Some(&d_zero_lwes),
+                        rerand_ksk,
                     );
                 }
                 _ => panic!("OPRF key and compute key must use the same kind of bootstrapping key"),

--- a/tfhe/src/integer/gpu/server_key/radix/tests_long_run/mod.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/tests_long_run/mod.rs
@@ -8,6 +8,7 @@ use crate::integer::server_key::radix_parallel::tests_long_run::OpSequenceFuncti
 use crate::integer::{BooleanBlock, RadixCiphertext, RadixClientKey, SignedRadixCiphertext, U256};
 use crate::{CompressedServerKey, CudaGpuChoice, CustomMultiGpuIndexes, GpuIndex, MatchValues};
 use std::cell::RefCell;
+use std::num::NonZeroU64;
 use std::sync::Arc;
 use tfhe_csprng::generators::DefaultRandomGenerator;
 use tfhe_csprng::seeders::{Seed, Seeder};
@@ -1692,7 +1693,7 @@ where
         &CudaOprfServerKey,
         Seed,
         u64,
-        u64,
+        NonZeroU64,
         u64,
         &CudaServerKey,
         &CudaStreams,
@@ -1714,11 +1715,13 @@ where
             .expect("setup was not properly called");
         let oprf_key = context.oprf_key.as_ref().expect("OPRF key not set");
 
+        let excluded_upper_bound =
+            NonZeroU64::new(input.2).expect("excluded_upper_bound must be non-zero");
         let gpu_result = (self.func)(
             oprf_key,
             input.0,
             input.1,
-            input.2,
+            excluded_upper_bound,
             input.3,
             &context.sks,
             &context.streams,

--- a/tfhe/src/integer/gpu/server_key/radix/tests_unsigned/test_oprf.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/tests_unsigned/test_oprf.rs
@@ -66,11 +66,6 @@ where
 
 // PRF + rerand
 
-/// GPU implementation of [`OprfReRandTestRunner`].
-///
-/// Uses a derived compact public key (no key-switch) for re-randomization, mirroring the CPU
-/// executor. The custom-range re-randomizing primitive is not available on GPU yet, so
-/// `unsigned_custom_range` returns `None` and the generic test skips that sub-case.
 struct GpuOprfReRandTestRunner {
     state: Option<GpuOprfReRandState>,
 }
@@ -208,15 +203,46 @@ impl OprfReRandTestRunner for GpuOprfReRandTestRunner {
 
     fn unsigned_custom_range(
         &mut self,
-        _prf_seed: impl OprfSeed,
-        _num_input_random_bits: u64,
-        _excluded_upper_bound: NonZeroU64,
-        _num_blocks_output: u64,
-        _prf_re_randomization_context: &PrfReRandomizationContext,
+        prf_seed: impl OprfSeed,
+        num_input_random_bits: u64,
+        excluded_upper_bound: NonZeroU64,
+        num_blocks_output: u64,
+        prf_re_randomization_context: &PrfReRandomizationContext,
     ) -> Option<(RadixCiphertext, RadixCiphertext)> {
-        // The GPU backend does not expose a re-randomizing custom-range primitive yet
-        // Return None to skip the corresponding sub case
-        None
+        let state = self.state();
+        let rerand_key = state.rerand_key();
+
+        let prf_seed = prf_seed.into_bytes();
+        let prf_seed = prf_seed.as_ref();
+
+        let prf_not_rerand = state
+            .oprf_sks
+            .par_generate_oblivious_pseudo_random_unsigned_custom_range(
+                prf_seed,
+                num_input_random_bits,
+                excluded_upper_bound,
+                num_blocks_output,
+                &state.sks,
+                &state.streams,
+            );
+        let prf_rerand = state
+            .oprf_sks
+            .par_generate_oblivious_pseudo_random_unsigned_custom_range_and_re_randomize(
+                prf_seed,
+                num_input_random_bits,
+                excluded_upper_bound,
+                num_blocks_output,
+                &state.sks,
+                &rerand_key,
+                prf_re_randomization_context,
+                &state.streams,
+            )
+            .unwrap();
+
+        Some((
+            prf_not_rerand.to_radix_ciphertext(&state.streams),
+            prf_rerand.to_radix_ciphertext(&state.streams),
+        ))
     }
 
     fn signed_full(

--- a/tfhe/src/integer/gpu/server_key/radix/tests_unsigned/test_oprf.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/tests_unsigned/test_oprf.rs
@@ -66,6 +66,10 @@ where
 
 // PRF + rerand
 
+/// GPU implementation of [`OprfReRandTestRunner`].
+///
+/// Uses a derived compact public key (no key-switch) for re-randomization, mirroring the CPU
+/// executor.
 struct GpuOprfReRandTestRunner {
     state: Option<GpuOprfReRandState>,
 }


### PR DESCRIPTION
Adds fused **custom-range OPRF + ciphertext re-randomization** on GPU, with CPU/GPU HLAPI and integer-layer plumbing. 

**Motivation**

- **GPU fused kernel** (`oprf.cu`/`oprf.cuh`): run grouped custom-range OPRF and rerand in one pass. Rerand is optional via `apply_rerand`; scratch memory is combined (`int_grouped_oprf_custom_range_with_rerand_memory`).
- **Integer + HLAPI layers**: expose the fused path through existing OPRF dispatch, matching the no-key-switch rerand mode (`DerivedCPKWithoutKeySwitch`) the GPU kernel uses by default.
- **Tests**: equivalence tests that PRF+rerand decrypts like plain PRF but changes ciphertext bytes; covers derived-CPK and legacy-CPK rerand modes on CPU and GPU.
- **Benchmarks** (`oprf.rs`): add `AnyRangeRerand` benches (CPU/GPU) to measure the fused API; upgrade existing OPRF benches to support latency/throughput via `get_bench_type()`.

closes: https://github.com/zama-ai/tfhe-rs-internal/issues/1447

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer