### PR TITLE
chore: add kreyvium benches

### DIFF
--- a/make/transciphering.mk
+++ b/make/transciphering.mk
@@ -28,6 +28,24 @@ test_aes_transciphering_fast:
 		--features=shortint -p tfhe --lib \
 		"transciphering::ciphers::aes::test::aes_fhe_skip"
 
+.PHONY: test_kreyvium_transciphering # Run unit tests for the FHE Kreyvium implementation
+test_kreyvium_transciphering:
+	RUSTFLAGS="$(RUSTFLAGS)" cargo test --profile $(CARGO_PROFILE) \
+		--features=shortint -p tfhe --lib \
+		transciphering::ciphers::kreyvium
+
+.PHONY: test_kreyvium_transciphering_fast # Same as above but only the non-FHE tests (plain + seek_plain)
+test_kreyvium_transciphering_fast:
+	RUSTFLAGS="$(RUSTFLAGS)" cargo test --profile $(CARGO_PROFILE) \
+		--features=shortint -p tfhe --lib \
+		"transciphering::ciphers::kreyvium::test::kreyvium_test_plain"
+	RUSTFLAGS="$(RUSTFLAGS)" cargo test --profile $(CARGO_PROFILE) \
+		--features=shortint -p tfhe --lib \
+		"transciphering::ciphers::kreyvium::test::kreyvium_plain_encrypt_decrypt_round_trip"
+	RUSTFLAGS="$(RUSTFLAGS)" cargo test --profile $(CARGO_PROFILE) \
+		--features=shortint -p tfhe --lib \
+		"transciphering::ciphers::kreyvium::test::kreyvium_seek_plain"
+
 #
 # Benchmarks
 #
@@ -61,3 +79,23 @@ bench_aes_key_expansion_plus_1_block:
 .PHONY: bench_aes_transcipher # AES: end-to-end transcipher over 16 blocks
 bench_aes_transcipher:
 	$(MAKE) bench_aes_transciphering BENCH_FILTER=transcipher_16_blocks
+
+.PHONY: bench_kreyvium_transciphering # Run criterion benches for the CPU Kreyvium transciphering pipeline
+bench_kreyvium_transciphering:
+	RUSTFLAGS="$(RUSTFLAGS)" __TFHE_RS_BENCH_TYPE=$(BENCH_TYPE) \
+	cargo bench \
+		--bench transciphering-kreyvium \
+		--features=shortint,internal-keycache \
+		-p tfhe-benchmark -- $(BENCH_FILTER)
+
+.PHONY: bench_kreyvium_warmup # Kreyvium: 1152-step register warmup
+bench_kreyvium_warmup:
+	$(MAKE) bench_kreyvium_transciphering BENCH_FILTER=warmup
+
+.PHONY: bench_kreyvium_keystream # Kreyvium: 64-bit keystream from a warmed state
+bench_kreyvium_keystream:
+	$(MAKE) bench_kreyvium_transciphering BENCH_FILTER=keystream_64bits
+
+.PHONY: bench_kreyvium_transcipher # Kreyvium: end-to-end transcipher over 64 bits
+bench_kreyvium_transcipher:
+	$(MAKE) bench_kreyvium_transciphering BENCH_FILTER=transcipher_64bits

--- a/tfhe-benchmark/Cargo.toml
+++ b/tfhe-benchmark/Cargo.toml
@@ -173,6 +173,12 @@ harness = false
 required-features = ["shortint", "internal-keycache"]
 
 [[bench]]
+name = "transciphering-kreyvium"
+path = "benches/transciphering/kreyvium_transciphering.rs"
+harness = false
+required-features = ["shortint", "internal-keycache"]
+
+[[bench]]
 name = "integer-trivium"
 path = "benches/integer/trivium.rs"
 harness = false

--- a/tfhe-benchmark/benches/transciphering/aes_transciphering.rs
+++ b/tfhe-benchmark/benches/transciphering/aes_transciphering.rs
@@ -17,12 +17,11 @@
 //! ```
 
 use benchmark::params_aliases::BENCH_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
-use benchmark::utilities::OperatorType;
+use benchmark::utilities::bench_and_record;
 use benchmark_spec::tfhe::transciphering::aes::AesFlavor;
 use benchmark_spec::tfhe::transciphering::TranscipheringBench;
-use benchmark_spec::{BenchmarkMetric, BenchmarkSpec, TypeName};
-use criterion::measurement::WallTime;
-use criterion::{criterion_group, Bencher, BenchmarkGroup, Criterion};
+use benchmark_spec::{BenchmarkMetric, BenchmarkSpec};
+use criterion::{criterion_group, Criterion};
 use rand::{Rng, SeedableRng};
 use std::hint::black_box;
 use tfhe::keycache::NamedParam;
@@ -32,36 +31,10 @@ use tfhe::transciphering::ciphers::aes::{
     AesFheRoundKeys, AesFheState, AesPlainKey, AesPlainState,
 };
 use tfhe::transciphering::{StreamCipher, Transcipherer};
-use tfhe_benchmark_parser::write_to_json;
 
 const N_BLOCKS: usize = 16;
 const BLOCK_BITS: usize = 128;
 const BLOCK_BYTES: usize = 16;
-
-fn bench_and_record<F, T: TypeName + ?Sized>(
-    group: &mut BenchmarkGroup<'_, WallTime>,
-    benchmark_spec: &BenchmarkSpec<T>,
-    display_name: &str,
-    bit_size: u32,
-    decomposition_basis: Vec<u32>,
-    mut routine: F,
-) where
-    F: FnMut(&mut Bencher<'_, WallTime>),
-{
-    let recorded = std::sync::Once::new();
-    group.bench_function(benchmark_spec.to_string(), |b| {
-        routine(b);
-        recorded.call_once(|| {
-            write_to_json(
-                benchmark_spec,
-                display_name,
-                &OperatorType::Atomic,
-                bit_size,
-                decomposition_basis.clone(),
-            );
-        });
-    });
-}
 
 pub fn cpu_aes_transciphering(c: &mut Criterion) {
     let bench_name = "transciphering::cpu::aes";

--- a/tfhe-benchmark/benches/transciphering/kreyvium_transciphering.rs
+++ b/tfhe-benchmark/benches/transciphering/kreyvium_transciphering.rs
@@ -1,0 +1,154 @@
+//! CPU benchmarks for the shortint Kreyvium transciphering pipeline
+//! (`tfhe::transciphering::ciphers::kreyvium`).
+//!
+//! Available cases (filter with criterion's `--bench` arg or via the Makefile's
+//! `BENCH_FILTER`):
+//!   * `warmup`             : the 1152 (= 18*64) mixing rounds run by `KreyviumFheState::new`
+//!     before any keystream is produced.
+//!   * `keystream_64bits`   : 64 keystream bits from an already-warmed state. 64 is Kreyvium's
+//!     parallel round-batch size (`next_64`).
+//!   * `transcipher_64bits` : end-to-end `transcipher` over 64 bits (`next_keystream_bits` +
+//!     `apply_keystream_2_2`).
+//!
+//! Run with:
+//! ```sh
+//! cargo bench --features=shortint,internal-keycache \
+//!     --bench transciphering-kreyvium
+//! ```
+
+use benchmark::params_aliases::BENCH_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+use benchmark::utilities::bench_and_record;
+use benchmark_spec::tfhe::transciphering::kreyvium::KreyviumFlavor;
+use benchmark_spec::tfhe::transciphering::TranscipheringBench;
+use benchmark_spec::{BenchmarkMetric, BenchmarkSpec};
+use criterion::{criterion_group, BatchSize, Criterion};
+use rand::{Rng, SeedableRng};
+use std::hint::black_box;
+use tfhe::keycache::NamedParam;
+use tfhe::shortint::prelude::*;
+use tfhe::shortint::AtomicPatternParameters;
+use tfhe::transciphering::ciphers::kreyvium::{
+    KreyviumFheState, KreyviumIV, KreyviumPlainKey, KreyviumPlainState,
+};
+use tfhe::transciphering::{StreamCipher, Transcipherer};
+
+const KEY_BITS: usize = 128;
+const KEYSTREAM_BITS: usize = 64;
+const KEYSTREAM_BYTES: usize = KEYSTREAM_BITS / 8;
+
+pub fn cpu_kreyvium_transciphering(c: &mut Criterion) {
+    let bench_name = "transciphering::cpu::kreyvium";
+
+    let seed: u64 = rand::thread_rng().gen();
+    let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+
+    let key_bytes: [u8; 16] = rng.gen();
+    let iv_bytes: [u8; 16] = rng.gen();
+
+    let mut group = c.benchmark_group(bench_name);
+    group
+        .sample_size(10)
+        .measurement_time(std::time::Duration::from_secs(60))
+        .warm_up_time(std::time::Duration::from_secs(5));
+
+    let params = BENCH_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+    let param_name = params.name();
+    let atomic_param: AtomicPatternParameters = params.into();
+    let log2_msg = atomic_param.message_modulus().0.ilog2();
+
+    let (cks, sks) = gen_keys(params);
+    let plain_key = KreyviumPlainKey::from(key_bytes);
+
+    // ---- warmup ----
+    let benchmark_spec = BenchmarkSpec::<str>::new_transciphering(
+        TranscipheringBench::Kreyvium(KreyviumFlavor::Warmup),
+        &param_name,
+        BenchmarkMetric::Latency,
+    );
+    bench_and_record(
+        &mut group,
+        &benchmark_spec,
+        "kreyvium_warmup",
+        KEY_BITS as u32,
+        vec![log2_msg; KEY_BITS],
+        |b| {
+            b.iter_batched(
+                || KreyviumPlainKey::from(key_bytes).encrypt(&cks),
+                |fhe_key| {
+                    black_box(KreyviumFheState::new(fhe_key, iv_bytes, &sks));
+                },
+                BatchSize::SmallInput,
+            )
+        },
+    );
+
+    // Pre-warmed state cloned per iter for the remaining benches.
+    let warm_state = {
+        let fhe_key = plain_key.encrypt(&cks);
+        KreyviumFheState::new(fhe_key, iv_bytes, &sks)
+    };
+
+    // ---- keystream_64bits ----
+    let benchmark_spec = BenchmarkSpec::<str>::new_transciphering(
+        TranscipheringBench::Kreyvium(KreyviumFlavor::Keystream64Bits),
+        &param_name,
+        BenchmarkMetric::Latency,
+    );
+    bench_and_record(
+        &mut group,
+        &benchmark_spec,
+        &format!("kreyvium_keystream_{KEYSTREAM_BITS}bits"),
+        KEYSTREAM_BITS as u32,
+        vec![log2_msg; KEYSTREAM_BITS],
+        |b| {
+            b.iter_batched(
+                || warm_state.clone(),
+                |mut stream| {
+                    black_box(stream.next_keystream_bits(&sks, KEYSTREAM_BITS));
+                },
+                BatchSize::SmallInput,
+            )
+        },
+    );
+
+    // ---- transcipher_64bits ----
+    let message = vec![0u8; KEYSTREAM_BYTES];
+    let sym_cipher = {
+        let mut plain_stream = KreyviumPlainState::new(
+            KreyviumPlainKey::from(key_bytes),
+            KreyviumIV::from(iv_bytes),
+        );
+        plain_stream.encrypt(&message)
+    };
+
+    let benchmark_spec = BenchmarkSpec::<str>::new_transciphering(
+        TranscipheringBench::Kreyvium(KreyviumFlavor::Transcipher64Bits),
+        &param_name,
+        BenchmarkMetric::Latency,
+    );
+    bench_and_record(
+        &mut group,
+        &benchmark_spec,
+        &format!("kreyvium_transcipher_{KEYSTREAM_BITS}bits"),
+        KEYSTREAM_BITS as u32,
+        vec![log2_msg; KEYSTREAM_BITS],
+        |b| {
+            b.iter_batched(
+                || warm_state.clone(),
+                |mut stream| {
+                    black_box(stream.transcipher(&sks, &sym_cipher).unwrap());
+                },
+                BatchSize::SmallInput,
+            )
+        },
+    );
+
+    group.finish();
+}
+
+criterion_group!(cpu_kreyvium, cpu_kreyvium_transciphering);
+
+fn main() {
+    cpu_kreyvium();
+    Criterion::default().configure_from_args().final_summary();
+}

--- a/tfhe-benchmark/src/utilities.rs
+++ b/tfhe-benchmark/src/utilities.rs
@@ -147,12 +147,19 @@ pub fn throughput_num_threads(num_block: usize, op_pbs_count: u64) -> u64 {
     }
 }
 
+/// Like [`will_this_bench_id_run`], but takes a group and id hierarchy
+pub fn will_this_bench_run(bench_group: &str, bench_id: &str) -> bool {
+    // Criterion matches the filter against the full `group/function` id, which is
+    // exactly what a top-level bench of `"{bench_group}/{bench_id}"` reproduces.
+    will_this_bench_id_run(&format!("{bench_group}/{bench_id}"))
+}
+
 /// This function aims to prevent the setup function from running.
 /// `Gag` is used here to suppress the temporary output noise from Criterion.
 /// We use a minimal Criterion configuration to retrieve information about the current filter setup.
 /// The function returns a boolean indicating whether the current `bench_id` should be executed or
 /// not.
-pub fn will_this_bench_run(bench_group: &str, bench_id: &str) -> bool {
+pub fn will_this_bench_id_run(bench_id: &str) -> bool {
     let mut c = Criterion::default()
         .configure_from_args()
         .sample_size(10)
@@ -165,12 +172,13 @@ pub fn will_this_bench_run(bench_group: &str, bench_id: &str) -> bool {
         use gag::Gag;
         let _print_gag = Gag::stdout().unwrap();
         let _err_gag = Gag::stderr().unwrap();
-        c.benchmark_group(bench_group)
-            .bench_function(bench_id, |b| {
-                b.iter(|| {
-                    will_run = true;
-                });
+        // Top-level `bench_function` registers with no function part, so the
+        // filter is matched against `bench_id` verbatim.
+        c.bench_function(bench_id, |b| {
+            b.iter(|| {
+                will_run = true;
             });
+        });
     }
     will_run
 }

--- a/tfhe-benchmark/src/utilities.rs
+++ b/tfhe-benchmark/src/utilities.rs
@@ -1,10 +1,43 @@
-use criterion::Criterion;
+use benchmark_spec::{BenchmarkSpec, TypeName};
+use criterion::measurement::WallTime;
+use criterion::{Bencher, BenchmarkGroup, Criterion};
 use std::env;
 use std::sync::OnceLock;
 #[cfg(feature = "gpu")]
 use tfhe::core_crypto::gpu::{get_number_of_gpus, get_number_of_sms};
 
 pub use tfhe_benchmark_parser::{write_to_json, write_to_json_unchecked, OperatorType};
+
+/// Run a criterion routine and record its metadata via `write_to_json`.
+pub fn bench_and_record<F, T: TypeName + ?Sized>(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    benchmark_spec: &BenchmarkSpec<T>,
+    display_name: &str,
+    bit_size: u32,
+    decomposition_basis: Vec<u32>,
+    mut routine: F,
+) where
+    F: FnMut(&mut Bencher<'_, WallTime>),
+{
+    let id = benchmark_spec.to_string();
+    // Criterion truncates the id in its own output; print the full name here.
+    if will_this_bench_id_run(&id) {
+        println!("{id}");
+    }
+    let recorded = std::sync::Once::new();
+    group.bench_function(&id, |b| {
+        routine(b);
+        recorded.call_once(|| {
+            write_to_json(
+                benchmark_spec,
+                display_name,
+                &OperatorType::Atomic,
+                bit_size,
+                decomposition_basis.clone(),
+            );
+        });
+    });
+}
 
 const FAST_BENCH_BIT_SIZES: [usize; 1] = [64];
 #[cfg(not(feature = "gpu"))]
@@ -172,8 +205,6 @@ pub fn will_this_bench_id_run(bench_id: &str) -> bool {
         use gag::Gag;
         let _print_gag = Gag::stdout().unwrap();
         let _err_gag = Gag::stderr().unwrap();
-        // Top-level `bench_function` registers with no function part, so the
-        // filter is matched against `bench_id` verbatim.
         c.bench_function(bench_id, |b| {
             b.iter(|| {
                 will_run = true;

--- a/utils/benchmark_spec/src/tfhe/transciphering/kreyvium.rs
+++ b/utils/benchmark_spec/src/tfhe/transciphering/kreyvium.rs
@@ -1,0 +1,15 @@
+use strum::Display;
+
+use crate::traits::SpecLeafNode;
+
+#[derive(Debug, Clone, Copy, Display)]
+#[strum(serialize_all = "snake_case")]
+pub enum KreyviumFlavor {
+    Warmup,
+    #[strum(serialize = "keystream_64bits")]
+    Keystream64Bits,
+    #[strum(serialize = "transcipher_64bits")]
+    Transcipher64Bits,
+}
+
+impl SpecLeafNode for KreyviumFlavor {}

--- a/utils/benchmark_spec/src/tfhe/transciphering/mod.rs
+++ b/utils/benchmark_spec/src/tfhe/transciphering/mod.rs
@@ -1,20 +1,24 @@
 use strum::Display;
 
 pub mod aes;
+pub mod kreyvium;
 
 use crate::traits::SpecNode;
 use aes::AesFlavor;
+use kreyvium::KreyviumFlavor;
 
 #[derive(Debug, Clone, Copy, Display)]
 #[strum(serialize_all = "snake_case")]
 pub enum TranscipheringBench {
     Aes(AesFlavor),
+    Kreyvium(KreyviumFlavor),
 }
 
 impl SpecNode for TranscipheringBench {
     fn child(&self) -> Option<&dyn SpecNode> {
         Some(match self {
             TranscipheringBench::Aes(op) => op,
+            TranscipheringBench::Kreyvium(op) => op,
         })
     }
 }


### PR DESCRIPTION
### PR content/description
Add transciphering benches for kreyvium, following what's done for aes

I also added some bench id print as a workaround for criterion cutting bench names. Don't hesitate to tell me if this pattern is wrong.

Also, this pr includes a small "unused import" warning fix

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3688)
<!-- Reviewable:end -->
