### PR TITLE
chore: align expected shift value with new behavior

### DIFF
--- a/tfhe/src/integer/server_key/radix_parallel/tests_long_run/test_random_op_sequence.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_long_run/test_random_op_sequence.rs
@@ -131,10 +131,12 @@ where
     let clear_mul = |x: u64, y: u64| x.wrapping_mul(y);
     // Warning this rotate definition only works with 64-bit ciphertexts
     let clear_rotate_left = |x: u64, y: u64| x.rotate_left(y as u32);
-    let clear_left_shift = |x, y| x << y;
+    // Warning this shift definition only works with 64-bit ciphertexts
+    let clear_left_shift = |x, y| if y >= u64::BITS as u64 { 0 } else { x << y };
     // Warning this rotate definition only works with 64-bit ciphertexts
     let clear_rotate_right = |x: u64, y: u64| x.rotate_right(y as u32);
-    let clear_right_shift = |x, y| x >> y;
+    // Warning this shift definition only works with 64-bit ciphertexts
+    let clear_right_shift = |x, y| if y >= u64::BITS as u64 { 0 } else { x >> y };
     let clear_max = |x: u64, y: u64| max(x, y);
     let clear_min = |x: u64, y: u64| min(x, y);
 

--- a/tfhe/src/integer/server_key/radix_parallel/tests_long_run/test_signed_random_op_sequence.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_long_run/test_signed_random_op_sequence.rs
@@ -152,10 +152,22 @@ where
         OpSequenceCpuFunctionExecutor::new(&ServerKey::right_shift_parallelized);
     // Warning this rotate definition only works with 64-bit ciphertexts
     let clear_rotate_left = |x: i64, y: u64| x.rotate_left(y as u32);
-    let clear_left_shift = |x: i64, y: u64| x << y;
+    // Warning this shift definition only works with 64-bit ciphertexts
+    let clear_left_shift = |x, y| if y >= (u64::BITS as u64) { 0 } else { x << y };
     // Warning this rotate definition only works with 64-bit ciphertexts
     let clear_rotate_right = |x: i64, y: u64| x.rotate_right(y as u32);
-    let clear_right_shift = |x: i64, y: u64| x >> y;
+    // Warning this shift definition only works with 64-bit ciphertexts
+    let clear_right_shift = |x: i64, y: u64| {
+        if y >= u64::BITS as u64 {
+            if x < 0 {
+                -1
+            } else {
+                0
+            }
+        } else {
+            x >> y
+        }
+    };
     #[allow(clippy::type_complexity)]
     let mut rotate_shift_ops: Vec<(
         SignedShiftRotateExecutor,


### PR DESCRIPTION
in 53d1737787f9eb7064495e3d6c6216814529214c the shifts functions were changed to return 0 (or -1) on 'overshift', the long run tests were not updated.

