### PR TITLE
chore(ci): fix little regression on backward sticky comment ci and generalize it

### DIFF
--- a/.github/actions/sticky_report/action.yml
+++ b/.github/actions/sticky_report/action.yml
@@ -1,0 +1,42 @@
+name: Sticky report
+description: Post or refresh a markdown report as a sticky PR comment.
+
+inputs:
+  report-path:
+    description: Markdown path
+    required: true
+  header:
+    description: Id of the report
+    required: true
+  github-token:
+    required: false
+    default: ${{ github.token }}
+
+runs:
+  using: composite
+  steps:
+    - name: Check report
+      id: report
+      shell: bash
+      env:
+        REPORT_PATH: ${{ inputs.report-path }}
+      run: |
+        if [ -s "$REPORT_PATH" ]; then
+          echo "has_report=true" >> "$GITHUB_OUTPUT"
+        elif [ -f "$REPORT_PATH" ]; then
+          echo "has_report=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "::error::$REPORT_PATH was not created something went wrong"
+          exit 1
+        fi
+
+    - name: Post/refresh report
+      if: steps.report.outputs.has_report == 'true'
+      uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0
+      with:
+        header: ${{ inputs.header }}
+        hide_and_recreate: true
+        hide_classify: OUTDATED
+        skip_unchanged: true
+        path: ${{ inputs.report-path }}
+        GITHUB_TOKEN: ${{ inputs.github-token }}

--- a/.github/workflows/backward_compatibility.yml
+++ b/.github/workflows/backward_compatibility.yml
@@ -61,41 +61,18 @@ jobs:
 
       - name: Generate diff report
         if: github.event_name == 'pull_request'
-        id: report
         run: |
           make backward_snapshot_report \
             BASE_SNAPSHOT_DIR=/tmp/snapshots/base \
             HEAD_SNAPSHOT_DIR=/tmp/snapshots/head \
             OUTPUT_FILE=report.md
 
-          if [ -s report.md ]; then
-            HASH=$(sha256sum report.md | cut -d' ' -f1)
-            printf '\n<!-- content-hash:%s -->\n' "$HASH" >> report.md
-            echo "has_report=true" >> "$GITHUB_OUTPUT"
-            echo "hash=$HASH" >> "$GITHUB_OUTPUT"
-          elif [ -f report.md ]; then
-            echo "has_report=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "::error::report.md was not created — something went wrong"
-            exit 1
-          fi
-
-      - name: Find existing comment with same content
-        if: github.event_name == 'pull_request' && steps.report.outputs.has_report == 'true'
-        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
-        id: existing
+      - name: Post report
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/sticky_report
         with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body-includes: content-hash:${{ steps.report.outputs.hash }}
-
-      - name: Post/refresh backward-compatibility report
-        if: github.event_name == 'pull_request' && steps.report.outputs.has_report == 'true' && !steps.existing.outputs.comment-id
-        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0
-        with:
+          report-path: report.md
           header: backward-compatibility-snapshot
-          hide_and_recreate: true
-          hide_classify: OUTDATED
-          path: report.md
 
       - name: Slack Notification
         if: steps.check.outcome == 'failure'


### PR DESCRIPTION
Just when I tried to take this flow for the forward compat matrices
I found out that the old flow might be broken because the find comment will try to find all comment and the issue could happen like that

hash A -> hash B -> hash A

we will not print the last A because it already exist in an hidden way so will be skip and it could lead to some issue (vary rare in theory)

So I found out that there is skip_unchanged which do the job
it's easier and clean

I also created a separate action because I will use it in another pr shortly

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3694)
<!-- Reviewable:end -->
