### PR TITLE
fix(ci): wait for apt lock before installing GPU dependencies

### DIFF
--- a/.github/actions/gpu_setup/action.yml
+++ b/.github/actions/gpu_setup/action.yml
@@ -28,16 +28,10 @@ runs:
         sha256sum -c checksum
         sudo bash cmake-"${CMAKE_VERSION}"-linux-x86_64.sh --skip-license --prefix=/usr/ --exclude-subdir
 
-        # Disable unattended-upgrades to avoid lock issues
-        sudo systemctl mask --now unattended-upgrades
-        sudo systemctl stop --now unattended-upgrades
+        bash ci/wait_for_apt_lock.sh
 
-        sudo apt-get clean
-        sudo rm -rf /var/lib/apt/lists/*
-        sudo apt purge -y unattended-upgrades
-
-        sudo apt update
-        sudo apt install -y cmake-format libclang-dev
+        sudo apt-get update
+        sudo apt-get install -y cmake-format libclang-dev
       env:
         CMAKE_VERSION: 3.29.6
         CMAKE_SCRIPT_SHA: "6e4fada5cba3472ae503a11232b6580786802f0879cead2741672bf65d97488a"
@@ -47,6 +41,7 @@ runs:
       env:
         GCC_VERSION: ${{ inputs.gcc-version }}
       run: |
+        bash ci/wait_for_apt_lock.sh
         sudo apt-get install -y gcc-"${GCC_VERSION}" g++-"${GCC_VERSION}"
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-"${GCC_VERSION}" 20
         sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-"${GCC_VERSION}" 20
@@ -96,16 +91,10 @@ runs:
         sha256sum -c checksum
         sudo dpkg -i "${CUDA_KEYRING_PACKAGE}"
 
-        # Disable unattended-upgrades to avoid lock issues
-        sudo systemctl mask --now unattended-upgrades
-        sudo systemctl stop --now unattended-upgrades
+        bash ci/wait_for_apt_lock.sh
 
-        sudo apt-get clean
-        sudo rm -rf /var/lib/apt/lists/*
-        sudo apt purge -y unattended-upgrades
-
-        sudo apt update
-        sudo apt -y install cuda-toolkit-"${TOOLKIT_VERSION}"
+        sudo apt-get update
+        sudo apt-get -y install cuda-toolkit-"${TOOLKIT_VERSION}"
 
     - name: Export CUDA variables
       shell: bash
@@ -140,4 +129,4 @@ runs:
       if: ${{ inputs.requires-a-gpu == 'true' }}
       shell: bash
       run: |
-        nvidia-smi || (sudo apt install --reinstall -y nvidia-driver-580 && nvidia-smi)
+        nvidia-smi || (bash ci/wait_for_apt_lock.sh && sudo apt-get install --reinstall -y nvidia-driver-580 && nvidia-smi)

--- a/.github/workflows/benchmark_gpu_coprocessor.yml
+++ b/.github/workflows/benchmark_gpu_coprocessor.yml
@@ -123,13 +123,7 @@ jobs:
     steps:
       - name: Install git LFS
         run: |
-          # Disable unattended-upgrades to avoid lock issues
-          sudo systemctl mask --now unattended-upgrades
-          sudo systemctl stop --now unattended-upgrades
-
-          sudo apt-get clean
-          sudo rm -rf /var/lib/apt/lists/*
-          sudo apt purge -y unattended-upgrades
+          bash ci/wait_for_apt_lock.sh
 
           sudo apt-get update
           sudo apt-get install -y git-lfs protobuf-compiler

--- a/.github/workflows/gpu_build_common.yml
+++ b/.github/workflows/gpu_build_common.yml
@@ -95,7 +95,9 @@ jobs:
           requires-a-gpu: "false"
 
       - name: Install python3-venv
-        run: sudo apt-get install -y python3-venv doxygen
+        run: |
+          bash ci/wait_for_apt_lock.sh
+          sudo apt-get install -y python3-venv doxygen
 
       - name: Check doxygen on new GPU code
         run: python3 ci/check_doxygen_gpu.py

--- a/.github/workflows/gpu_code_validation_tests.yml
+++ b/.github/workflows/gpu_code_validation_tests.yml
@@ -97,15 +97,10 @@ jobs:
 
       - name: Find tools
         run: |
-          # Disable unattended-upgrades to avoid lock issues
-          sudo systemctl mask --now unattended-upgrades
-          sudo systemctl stop --now unattended-upgrades
+          bash ci/wait_for_apt_lock.sh
 
-          sudo apt-get clean
-          sudo rm -rf /var/lib/apt/lists/*
-          sudo apt purge -y unattended-upgrades
-
-          sudo apt update && sudo apt install -y valgrind
+          sudo apt-get update
+          sudo apt-get install -y valgrind
           # Find compute-sanitizer
           find /usr -executable -name "compute-sanitizer" 2>&1 | grep -v "Permission denied"
           echo "compute-sanitizer was found, checking if it's in the path..."

--- a/.github/workflows/gpu_zk_code_validation_tests.yml
+++ b/.github/workflows/gpu_zk_code_validation_tests.yml
@@ -94,15 +94,10 @@ jobs:
 
       - name: Find tools
         run: |
-          # Disable unattended-upgrades to avoid lock issues
-          sudo systemctl mask --now unattended-upgrades
-          sudo systemctl stop --now unattended-upgrades
+          bash ci/wait_for_apt_lock.sh
 
-          sudo apt-get clean
-          sudo rm -rf /var/lib/apt/lists/*
-          sudo apt purge -y unattended-upgrades
-
-          sudo apt update && sudo apt install -y valgrind
+          sudo apt-get update
+          sudo apt-get install -y valgrind
           # Find compute-sanitizer
           find /usr -executable -name "compute-sanitizer" 2>&1 | grep -v "Permission denied"
           echo "compute-sanitizer was found, checking if it's in the path..."

--- a/ci/wait_for_apt_lock.sh
+++ b/ci/wait_for_apt_lock.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Wait for any running apt/dpkg process to release locks.
+# Prevents race with boot-time unattended-upgrades on cloud instances.
+
+MAX_WAIT=120
+WAITED=0
+
+while sudo fuser /var/lib/dpkg/lock-frontend /var/lib/apt/lists/lock >/dev/null 2>&1; do
+  if [ "$WAITED" -ge "$MAX_WAIT" ]; then
+    echo "ERROR: apt lock still held after ${MAX_WAIT}s" >&2
+    exit 1
+  fi
+  echo "Waiting for apt lock to be released... (${WAITED}s elapsed)"
+  sleep 5
+  WAITED=$((WAITED + 5))
+done
+
+# Kill the automatic update timers to prevent them from re-acquiring locks
+sudo systemctl mask --now unattended-upgrades 2>/dev/null || true
+sudo systemctl stop unattended-upgrades 2>/dev/null || true
+sudo systemctl disable --now apt-daily.timer apt-daily-upgrade.timer 2>/dev/null || true


### PR DESCRIPTION
Cloud instances run unattended-upgrades at boot, which holds the dpkg lock when CI apt commands execute. The previous approach of masking the service races with the already-running process. Add a helper script that polls until the lock is released, then disables the timers.

<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
