### PR TITLE
chore(zk): rename gpu-experimental-zk to gpu-zk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -440,14 +440,14 @@ check_typos: install_typos_checker
 .PHONY: clippy_gpu # Run clippy lints on tfhe with "gpu" enabled
 clippy_gpu: install_rs_check_toolchain
 	RUSTFLAGS="$(RUSTFLAGS)" cargo "$(CARGO_RS_CHECK_TOOLCHAIN)" clippy \
-		--features=boolean,shortint,integer,internal-keycache,gpu,gpu-experimental-zk,pbs-stats,extended-types,zk-pok \
+		--features=boolean,shortint,integer,internal-keycache,gpu,gpu-zk,pbs-stats,extended-types,zk-pok \
 		--all-targets \
 		-p tfhe -- --no-deps -D warnings
 
 .PHONY: check_gpu # Run check on tfhe with "gpu" enabled
 check_gpu: install_rs_check_toolchain
 	RUSTFLAGS="$(RUSTFLAGS)" cargo "$(CARGO_RS_CHECK_TOOLCHAIN)" check \
-		--features=boolean,shortint,integer,internal-keycache,gpu,gpu-experimental-zk,pbs-stats \
+		--features=boolean,shortint,integer,internal-keycache,gpu,gpu-zk,pbs-stats \
 		--all-targets \
 		-p tfhe
 
@@ -461,7 +461,7 @@ clippy_hpu: install_rs_check_toolchain
 .PHONY: clippy_gpu_hpu # Run clippy lints on tfhe with "gpu" and "hpu" enabled
 clippy_gpu_hpu: install_rs_check_toolchain
 	RUSTFLAGS="$(RUSTFLAGS)" cargo "$(CARGO_RS_CHECK_TOOLCHAIN)" clippy \
-		--features=boolean,shortint,integer,internal-keycache,gpu,gpu-experimental-zk,hpu,pbs-stats,extended-types,zk-pok \
+		--features=boolean,shortint,integer,internal-keycache,gpu,gpu-zk,hpu,pbs-stats,extended-types,zk-pok \
 		--all-targets \
 		-p tfhe -- --no-deps -D warnings
 
@@ -558,7 +558,7 @@ clippy_rustdoc_gpu: install_rs_check_toolchain
 	fi && \
 	CARGO_TERM_QUIET=true CLIPPYFLAGS="-D warnings" RUSTDOCFLAGS="--no-run --test-builder ./scripts/clippy_driver.sh -Z unstable-options" \
 		cargo "$(CARGO_RS_CHECK_TOOLCHAIN)" test --doc \
-		--features=boolean,shortint,integer,zk-pok,pbs-stats,strings,experimental,gpu,gpu-experimental-zk \
+		--features=boolean,shortint,integer,zk-pok,pbs-stats,strings,experimental,gpu,gpu-zk \
 		-p tfhe -- --nocapture
 
 .PHONY: clippy_c_api # Run clippy lints enabling the boolean, shortint and the C API
@@ -816,7 +816,7 @@ build_c_api: install_rs_check_toolchain
 .PHONY: build_c_api_gpu # Build the C API for boolean, shortint and integer
 build_c_api_gpu: install_rs_check_toolchain
 	RUSTFLAGS="$(RUSTFLAGS)" cargo $(CARGO_RS_CHECK_TOOLCHAIN) build --profile $(CARGO_PROFILE) \
-		--features=boolean-c-api,shortint-c-api,high-level-c-api,zk-pok,extended-types,gpu,gpu-experimental-zk \
+		--features=boolean-c-api,shortint-c-api,high-level-c-api,zk-pok,extended-types,gpu,gpu-zk \
 		-p tfhe
 
 .PHONY: build_c_api_experimental_deterministic_fft # Build the C API for boolean, shortint and integer with experimental deterministic FFT
@@ -1463,7 +1463,7 @@ test_integer_zk_gpu:
 .PHONY: test_integer_zk_experimental_gpu # Run tfhe-zk-pok tests
 test_integer_zk_experimental_gpu:
 	RUSTFLAGS="$(RUSTFLAGS)" cargo test --profile $(CARGO_PROFILE) \
-		--features=integer,zk-pok,gpu,gpu-experimental-zk -p tfhe -- \
+		--features=integer,zk-pok,gpu,gpu-zk -p tfhe -- \
 		integer::gpu::zk::
 
 .PHONY: test_zk_cuda # Run all GPU MSM integration tests (CPU vs GPU comparison + integration test)
@@ -1897,7 +1897,7 @@ bench_msm_zk_gpu: install_rs_check_toolchain
 	RUSTFLAGS="$(RUSTFLAGS)" __TFHE_RS_BENCH_TYPE=$(BENCH_TYPE) \
 	cargo $(CARGO_RS_CHECK_TOOLCHAIN) bench \
 	--bench zk-msm \
-	--features=gpu,gpu-experimental-zk,zk-pok -p tfhe-benchmark --profile release -- zk::cuda::msm
+	--features=gpu,gpu-zk,zk-pok -p tfhe-benchmark --profile release -- zk::cuda::msm
 
 # GPU benchmarks need --profile release for correct measurements
 .PHONY: bench_integer_zk_gpu
@@ -1913,7 +1913,7 @@ bench_integer_zk_experimental_gpu: install_rs_check_toolchain
 	RUSTFLAGS="$(RUSTFLAGS)" __TFHE_RS_BENCH_TYPE=$(BENCH_TYPE) __TFHE_RS_BENCH_BIT_SIZES_SET=$(BIT_SIZES_SET) __TFHE_RS_BENCH_OP_FLAVOR=$(BENCH_OP_FLAVOR) \
 	cargo $(CARGO_RS_CHECK_TOOLCHAIN) bench \
 	--bench integer-zk-pke \
-	--features=integer,internal-keycache,gpu,gpu-experimental-zk,pbs-stats,zk-pok -p tfhe-benchmark --profile release --
+	--features=integer,internal-keycache,gpu,gpu-zk,pbs-stats,zk-pok -p tfhe-benchmark --profile release --
 
 .PHONY: bench_integer_aes_gpu # Run benchmarks for AES on GPU backend
 bench_integer_aes_gpu: install_rs_check_toolchain

--- a/Makefile
+++ b/Makefile
@@ -949,7 +949,7 @@ test_zk_pok_gpu_sanitizer: install_cargo_nextest
 	export RUSTFLAGS="-C target-cpu=x86-64" && \
 	export CARGO_PROFILE="$(CARGO_PROFILE)" && \
 	export SANITIZER_CARGO_PACKAGE=tfhe-zk-pok && \
-	export SANITIZER_CARGO_FEATURES_GPU=experimental,gpu-experimental && \
+	export SANITIZER_CARGO_FEATURES_GPU=experimental,gpu && \
 	export SANITIZER_TEST_FILTER_GPU='gpu::' && \
 	export SANITIZER_TEST_EXCLUDES_GPU='conversion_roundtrip|scalar_validation|long_run' && \
 	export SANITIZER_TEST_EXE_GLOB='tfhe_zk_pok-*' && \
@@ -960,7 +960,7 @@ test_zk_pok_gpu_valgrind: install_cargo_nextest
 	export RUSTFLAGS="-C target-cpu=x86-64" && \
 	export CARGO_PROFILE="$(CARGO_PROFILE)" && \
 	export SANITIZER_CARGO_PACKAGE=tfhe-zk-pok && \
-	export SANITIZER_CARGO_FEATURES_CPU=experimental,gpu-experimental && \
+	export SANITIZER_CARGO_FEATURES_CPU=experimental,gpu && \
 	export SANITIZER_TEST_FILTER_CPU='gpu::' && \
 	export SANITIZER_TEST_EXCLUDES_CPU='conversion_roundtrip|scalar_validation|long_run' && \
 	export SANITIZER_TEST_EXE_GLOB='tfhe_zk_pok-*' && \
@@ -1439,19 +1439,19 @@ test_zk_pok:
 .PHONY: test_zk_pok_experimental_gpu # Run tfhe-zk-pok GPU-accelerated tests
 test_zk_pok_experimental_gpu:
 	RUSTFLAGS="$(RUSTFLAGS)" cargo test --profile $(CARGO_PROFILE) \
-		-p tfhe-zk-pok --features experimental,gpu-experimental -- gpu --skip long_run
+		-p tfhe-zk-pok --features experimental,gpu -- gpu --skip long_run
 
 .PHONY: test_zk_pok_experimental_long_run_gpu # Run long-run ZK GPU/CPU equivalence tests (multiple seeds)
 test_zk_pok_experimental_long_run_gpu:
 	RUSTFLAGS="$(RUSTFLAGS)" cargo test --profile $(CARGO_PROFILE) \
-		-p tfhe-zk-pok --features experimental,gpu-experimental -- \
+		-p tfhe-zk-pok --features experimental,gpu -- \
 		test_pke_v2_long_run --test-threads=1 --nocapture
 
 .PHONY: test_zk_pok_experimental_short_run_gpu
 test_zk_pok_experimental_short_run_gpu:
 	TFHE_RS_TEST_LONG_TESTS_MINIMAL=TRUE \
 	RUSTFLAGS="$(RUSTFLAGS)" cargo test --profile $(CARGO_PROFILE) \
-		-p tfhe-zk-pok --features experimental,gpu-experimental -- \
+		-p tfhe-zk-pok --features experimental,gpu -- \
 		test_pke_v2_gpu_cpu_equivalence --test-threads=1 --nocapture
 
 .PHONY: test_integer_zk_gpu # Run tfhe-zk-pok tests
@@ -2227,7 +2227,7 @@ bench_tfhe_zk_pok_gpu: install_rs_check_toolchain
 	RUSTFLAGS="$(RUSTFLAGS)" __TFHE_RS_BENCH_TYPE=$(BENCH_TYPE) \
 	cargo $(CARGO_RS_CHECK_TOOLCHAIN) bench \
 	--package tfhe-zk-pok \
-	--features=gpu-experimental --profile release
+	--features=gpu --profile release
 
 .PHONY: bench_hlapi_noise_squash # Run benchmarks for noise squash operation
 bench_hlapi_noise_squash: install_rs_check_toolchain

--- a/tfhe-benchmark/Cargo.toml
+++ b/tfhe-benchmark/Cargo.toml
@@ -43,7 +43,7 @@ shortint = ["tfhe/shortint"]
 integer = ["shortint", "tfhe/integer"]
 gpu = ["tfhe/gpu", "benchmark_spec/gpu"]
 # gpu enables tfhe-cuda-backend which provides CUDA stream management used by tfhe-zk-pok
-gpu-zk = ["gpu", "zk-pok", "tfhe/gpu-zk", "tfhe-zk-pok/gpu-experimental"]
+gpu-zk = ["gpu", "zk-pok", "tfhe/gpu-zk", "tfhe-zk-pok/gpu"]
 hpu = ["tfhe/hpu", "benchmark_spec/hpu"]
 hpu-v80 = ["tfhe/hpu-v80"]
 internal-keycache = ["tfhe/internal-keycache"]

--- a/tfhe-benchmark/Cargo.toml
+++ b/tfhe-benchmark/Cargo.toml
@@ -43,12 +43,7 @@ shortint = ["tfhe/shortint"]
 integer = ["shortint", "tfhe/integer"]
 gpu = ["tfhe/gpu", "benchmark_spec/gpu"]
 # gpu enables tfhe-cuda-backend which provides CUDA stream management used by tfhe-zk-pok
-gpu-experimental-zk = [
-    "gpu",
-    "zk-pok",
-    "tfhe/gpu-experimental-zk",
-    "tfhe-zk-pok/gpu-experimental",
-]
+gpu-zk = ["gpu", "zk-pok", "tfhe/gpu-zk", "tfhe-zk-pok/gpu-experimental"]
 hpu = ["tfhe/hpu", "benchmark_spec/hpu"]
 hpu-v80 = ["tfhe/hpu-v80"]
 internal-keycache = ["tfhe/internal-keycache"]

--- a/tfhe-benchmark/benches/zk/msm.rs
+++ b/tfhe-benchmark/benches/zk/msm.rs
@@ -5,7 +5,7 @@
 //!
 //! CPU benchmarks use the arkworks-based `G1Affine::multi_mul_scalar` /
 //! `G2Affine::multi_mul_scalar`. GPU benchmarks (gated behind the
-//! `gpu-experimental-zk` feature) call `tfhe_zk_pok::gpu::g1_msm_gpu` /
+//! `gpu-zk` feature) call `tfhe_zk_pok::gpu::g1_msm_gpu` /
 //! `tfhe_zk_pok::gpu::g2_msm_gpu` directly, which dispatch to the
 //! zk-cuda-backend.
 //!
@@ -16,7 +16,7 @@
 //! cargo bench --package tfhe-benchmark --bench zk-msm
 //!
 //! # CPU and GPU
-//! cargo bench --package tfhe-benchmark --bench zk-msm --features gpu-experimental-zk
+//! cargo bench --package tfhe-benchmark --bench zk-msm --features gpu-zk
 //! ```
 
 use benchmark::utilities::{write_to_json_unchecked, OperatorType};
@@ -67,7 +67,7 @@ trait MsmBenchGroup {
 
     fn generate_points(rng: &mut StdRng, n: usize) -> Vec<Self::Affine>;
     fn cpu_msm(bases: &[Self::Affine], scalars: &[Zp]);
-    #[cfg(feature = "gpu-experimental-zk")]
+    #[cfg(feature = "gpu-zk")]
     fn gpu_msm(bases: &[Self::Affine], scalars: &[Zp], gpu_index: u32);
 }
 
@@ -95,7 +95,7 @@ impl MsmBenchGroup for G1Bench {
         ));
     }
 
-    #[cfg(feature = "gpu-experimental-zk")]
+    #[cfg(feature = "gpu-zk")]
     fn gpu_msm(bases: &[G1Affine], scalars: &[Zp], gpu_index: u32) {
         use tfhe_zk_pok::gpu::g1_msm_gpu;
         black_box(g1_msm_gpu(black_box(bases), black_box(scalars), gpu_index));
@@ -126,7 +126,7 @@ impl MsmBenchGroup for G2Bench {
         ));
     }
 
-    #[cfg(feature = "gpu-experimental-zk")]
+    #[cfg(feature = "gpu-zk")]
     fn gpu_msm(bases: &[G2Affine], scalars: &[Zp], gpu_index: u32) {
         use tfhe_zk_pok::gpu::g2_msm_gpu;
         black_box(g2_msm_gpu(black_box(bases), black_box(scalars), gpu_index));
@@ -205,7 +205,7 @@ fn bench_cpu_msm<T: MsmBenchGroup>(c: &mut Criterion) {
     group.finish();
 }
 
-#[cfg(feature = "gpu-experimental-zk")]
+#[cfg(feature = "gpu-zk")]
 fn bench_gpu_msm<T: MsmBenchGroup>(c: &mut Criterion) {
     use tfhe_zk_pok::gpu::select_gpu_for_msm;
 
@@ -291,23 +291,23 @@ fn bench_cpu_g2_msm(c: &mut Criterion) {
     bench_cpu_msm::<G2Bench>(c);
 }
 
-#[cfg(feature = "gpu-experimental-zk")]
+#[cfg(feature = "gpu-zk")]
 fn bench_gpu_g1_msm(c: &mut Criterion) {
     bench_gpu_msm::<G1Bench>(c);
 }
 
-#[cfg(feature = "gpu-experimental-zk")]
+#[cfg(feature = "gpu-zk")]
 fn bench_gpu_g2_msm(c: &mut Criterion) {
     bench_gpu_msm::<G2Bench>(c);
 }
 
 criterion_group!(benches_cpu, bench_cpu_g1_msm, bench_cpu_g2_msm,);
 
-#[cfg(feature = "gpu-experimental-zk")]
+#[cfg(feature = "gpu-zk")]
 criterion_group!(benches_gpu, bench_gpu_g1_msm, bench_gpu_g2_msm,);
 
-#[cfg(feature = "gpu-experimental-zk")]
+#[cfg(feature = "gpu-zk")]
 criterion_main!(benches_cpu, benches_gpu);
 
-#[cfg(not(feature = "gpu-experimental-zk"))]
+#[cfg(not(feature = "gpu-zk"))]
 criterion_main!(benches_cpu);

--- a/tfhe-zk-pok/Cargo.toml
+++ b/tfhe-zk-pok/Cargo.toml
@@ -37,7 +37,7 @@ wasm-par-mq = { version = "0.1.0", path = "../utils/wasm-par-mq", features = [
 [features]
 experimental = []
 cross-origin-wasm = ["dep:wasm-par-mq"]
-gpu-experimental = ["dep:zk-cuda-backend", "dep:tfhe-cuda-common"]
+gpu = ["dep:zk-cuda-backend", "dep:tfhe-cuda-common"]
 
 [dev-dependencies]
 serde_json = "~1.0"

--- a/tfhe-zk-pok/benches/pke_v2.rs
+++ b/tfhe-zk-pok/benches/pke_v2.rs
@@ -107,7 +107,7 @@ fn bench_pke_v2_verify(c: &mut Criterion) {
     }
 }
 
-#[cfg(feature = "gpu-experimental")]
+#[cfg(feature = "gpu")]
 mod gpu {
     use super::*;
     use tfhe_zk_pok::gpu::pke_v2 as gpu_pke_v2;
@@ -219,18 +219,18 @@ mod gpu {
 
 criterion_group!(benches_pke_v2, bench_pke_v2_verify, bench_pke_v2_prove);
 
-#[cfg(feature = "gpu-experimental")]
+#[cfg(feature = "gpu")]
 use gpu::{bench_pke_v2_prove_gpu, bench_pke_v2_verify_gpu};
 
-#[cfg(feature = "gpu-experimental")]
+#[cfg(feature = "gpu")]
 criterion_group!(
     benches_pke_v2_gpu,
     bench_pke_v2_verify_gpu,
     bench_pke_v2_prove_gpu
 );
 
-#[cfg(feature = "gpu-experimental")]
+#[cfg(feature = "gpu")]
 criterion_main!(benches_pke_v2, benches_pke_v2_gpu);
 
-#[cfg(not(feature = "gpu-experimental"))]
+#[cfg(not(feature = "gpu"))]
 criterion_main!(benches_pke_v2);

--- a/tfhe-zk-pok/src/lib.rs
+++ b/tfhe-zk-pok/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod curve_446;
 pub mod curve_api;
-#[cfg(feature = "gpu-experimental")]
+#[cfg(feature = "gpu")]
 pub mod gpu;
 pub mod proofs;
 pub mod serialization;

--- a/tfhe/Cargo.toml
+++ b/tfhe/Cargo.toml
@@ -111,7 +111,7 @@ integer = ["shortint", "dep:strum"]
 strings = ["integer"]
 internal-keycache = ["dep:fs2", "dep:sha3"]
 gpu = ["dep:tfhe-cuda-backend", "shortint"]
-gpu-experimental-zk = ["gpu", "zk-pok", "tfhe-zk-pok/gpu-experimental"]
+gpu-zk = ["gpu", "zk-pok", "tfhe-zk-pok/gpu-experimental"]
 gpu-experimental-multi-arch = [
     "gpu",
     "tfhe-cuda-backend/experimental-multi-arch",

--- a/tfhe/Cargo.toml
+++ b/tfhe/Cargo.toml
@@ -111,7 +111,7 @@ integer = ["shortint", "dep:strum"]
 strings = ["integer"]
 internal-keycache = ["dep:fs2", "dep:sha3"]
 gpu = ["dep:tfhe-cuda-backend", "shortint"]
-gpu-zk = ["gpu", "zk-pok", "tfhe-zk-pok/gpu-experimental"]
+gpu-zk = ["gpu", "zk-pok", "tfhe-zk-pok/gpu"]
 gpu-experimental-multi-arch = [
     "gpu",
     "tfhe-cuda-backend/experimental-multi-arch",

--- a/tfhe/docs/configuration/gpu-acceleration/zk-pok.md
+++ b/tfhe/docs/configuration/gpu-acceleration/zk-pok.md
@@ -21,12 +21,12 @@ For GPU-accelerated **expansion only**, build with:
 {% hint style="warning" %}
 For GPU-accelerated **proof generation** and **verification**, build with:
 ```shell
---features=gpu-experimental-zk
+--features=gpu-zk
 ```
-This feature implies `gpu` and `zk-pok`, so you do not need to specify them separately. It requires a CUDA-capable GPU. This feature is experimental and should not be used in production.
+This feature implies `gpu` and `zk-pok`, so you do not need to specify them separately. It requires a CUDA-capable GPU.
 {% endhint %}
 
-The Rust API is identical in both cases. The `gpu-experimental-zk` feature flag switches the internal dispatch for proof generation and verification from CPU to GPU at compile time, so no code changes are needed beyond the feature flag.
+The Rust API is identical in both cases. The `gpu-zk` feature flag switches the internal dispatch for proof generation and verification from CPU to GPU at compile time, so no code changes are needed beyond the feature flag.
 
 ## API elements discussed in this document
 
@@ -42,7 +42,7 @@ GPU acceleration is manifested in different ways depending on the operation.
 
 ### Proof generation and verification
 
-If the `gpu-experimental-zk` feature is active, the compute-intensive parts of proof generation and verification are offloaded to the GPU, producing proofs bitwise compatible with the CPU implementation. This is supported only for the PKE v2 scheme, which is selected by default with current parameters.
+If the `gpu-zk` feature is active, the compute-intensive parts of proof generation and verification are offloaded to the GPU, producing proofs bitwise compatible with the CPU implementation. This is supported only for the PKE v2 scheme, which is selected by default with current parameters.
 
 When multiple GPUs are available, ZK operations automatically distribute work across them.
 
@@ -117,7 +117,7 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
 ```
 
 {% hint style="info" %}
-When built with `--features=gpu-experimental-zk`, the `build_with_proof_packed` and `verify_and_expand` calls in this same code will automatically use the GPU for proof generation, verification, and ciphertext expansion. If built with `--features=gpu`, only ciphertext expansion will be accelerated by the GPU. No code changes are required.
+When built with `--features=gpu-zk`, the `build_with_proof_packed` and `verify_and_expand` calls in this same code will automatically use the GPU for proof generation, verification, and ciphertext expansion. If built with `--features=gpu`, only ciphertext expansion will be accelerated by the GPU. No code changes are required.
 {% endhint %}
 
 ## Benchmark

--- a/tfhe/src/zk/mod.rs
+++ b/tfhe/src/zk/mod.rs
@@ -24,9 +24,9 @@ use tfhe_zk_pok::proofs::pke_v2::{
     Proof as ProofV2, PublicCommit as PublicCommitV2, VerificationPairingMode,
 };
 
-#[cfg(feature = "gpu-experimental-zk")]
+#[cfg(feature = "gpu-zk")]
 use tfhe_zk_pok::gpu::pke_v2::{prove as prove_v2, verify as verify_v2};
-#[cfg(not(feature = "gpu-experimental-zk"))]
+#[cfg(not(feature = "gpu-zk"))]
 use tfhe_zk_pok::proofs::pke_v2::{prove as prove_v2, verify as verify_v2};
 
 pub use tfhe_zk_pok::curve_api::Compressible;


### PR DESCRIPTION
Renames the TFHE feature `gpu-experimental-zk` → `gpu-zk`. Behavior is unchanged:

```toml
gpu-zk = ["gpu", "zk-pok", "tfhe-zk-pok/gpu-experimental"]
```

- `gpu` alone: TFHE on GPU (including compact ciphertext expansion); ZK prove/verify stay on CPU when `zk-pok` is enabled without `gpu-zk`.
- `gpu-zk`: enables `gpu` + `zk-pok` and offloads ZK proof generation/verification to the GPU via `tfhe-zk-pok`'s existing `gpu-experimental` feature.

Makefile feature lists, `tfhe-benchmark`, ZK MSM benches, and GPU ZK docs updated to the new name. No `#[cfg(feature = "gpu")]` retargeting; `tfhe-zk-pok`'s `gpu-experimental` feature is left as-is.

**Breaking change:** replace `--features=gpu-experimental-zk` with `--features=gpu-zk`.

closes: https://github.com/zama-ai/tfhe-rs-internal/issues/1481

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [x] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3713)
<!-- Reviewable:end -->
