### PR TITLE
chore(ci): new fallbacks for GPU CI workflows

### DIFF
--- a/.github/workflows/gpu_core_h100_tests.yml
+++ b/.github/workflows/gpu_core_h100_tests.yml
@@ -90,7 +90,7 @@ jobs:
           slab-url: ${{ secrets.SLAB_BASE_URL }}
           job-secret: ${{ secrets.JOB_SECRET }}
           backend: terraform
-          profile: scaleway-2-h100-sxm5
+          profile: scaleway-2-h100-sxm5-tests
 
       # This instance will be spawned especially for pull-request from forked repository
       - name: Start GitHub instance

--- a/.github/workflows/gpu_full_h100_tests.yml
+++ b/.github/workflows/gpu_full_h100_tests.yml
@@ -37,7 +37,7 @@ jobs:
           slab-url: ${{ secrets.SLAB_BASE_URL }}
           job-secret: ${{ secrets.JOB_SECRET }}
           backend: terraform
-          profile: scaleway-2-h100-sxm5
+          profile: scaleway-2-h100-sxm5-tests
 
   cuda-tests-linux:
     name: gpu_full_h100_tests/cuda-tests-linux

--- a/.github/workflows/gpu_hlapi_h100_tests.yml
+++ b/.github/workflows/gpu_hlapi_h100_tests.yml
@@ -92,7 +92,7 @@ jobs:
           slab-url: ${{ secrets.SLAB_BASE_URL }}
           job-secret: ${{ secrets.JOB_SECRET }}
           backend: terraform
-          profile: scaleway-single-h100
+          profile: scaleway-single-h100-tests
 
       # This instance will be spawned especially for pull-request from forked repository
       - name: Start GitHub instance

--- a/.github/workflows/gpu_memory_sanitizer_h100.yml
+++ b/.github/workflows/gpu_memory_sanitizer_h100.yml
@@ -84,7 +84,7 @@ jobs:
           slab-url: ${{ secrets.SLAB_BASE_URL }}
           job-secret: ${{ secrets.JOB_SECRET }}
           backend: terraform
-          profile: scaleway-2-h100-sxm5
+          profile: scaleway-2-h100-sxm5-tests
 
       # This instance will be spawned especially for pull-request from forked repository
       - name: Start GitHub instance

--- a/.github/workflows/gpu_noise_level_checks.yml
+++ b/.github/workflows/gpu_noise_level_checks.yml
@@ -90,7 +90,7 @@ jobs:
           slab-url: ${{ secrets.SLAB_BASE_URL }}
           job-secret: ${{ secrets.JOB_SECRET }}
           backend: hyperstack
-          profile: l40
+          profile: l40-tests
 
       # This instance will be spawned especially for pull-request from forked repository
       - name: Start GitHub instance

--- a/.github/workflows/gpu_signed_integer_h100_tests.yml
+++ b/.github/workflows/gpu_signed_integer_h100_tests.yml
@@ -92,7 +92,7 @@ jobs:
           slab-url: ${{ secrets.SLAB_BASE_URL }}
           job-secret: ${{ secrets.JOB_SECRET }}
           backend: terraform
-          profile: scaleway-single-h100
+          profile: scaleway-single-h100-tests
 
       # This instance will be spawned especially for pull-request from forked repository
       - name: Start GitHub instance

--- a/.github/workflows/gpu_unsigned_integer_h100_tests.yml
+++ b/.github/workflows/gpu_unsigned_integer_h100_tests.yml
@@ -92,7 +92,7 @@ jobs:
           slab-url: ${{ secrets.SLAB_BASE_URL }}
           job-secret: ${{ secrets.JOB_SECRET }}
           backend: terraform
-          profile: scaleway-single-h100
+          profile: scaleway-single-h100-tests
 
       # This instance will be spawned especially for pull-request from forked repository
       - name: Start GitHub instance

--- a/.github/workflows/gpu_zk_code_validation_tests.yml
+++ b/.github/workflows/gpu_zk_code_validation_tests.yml
@@ -51,7 +51,7 @@ jobs:
           slab-url: ${{ secrets.SLAB_BASE_URL }}
           job-secret: ${{ secrets.JOB_SECRET }}
           backend: terraform
-          profile: scaleway-2-h100-sxm5
+          profile: scaleway-2-h100-sxm5-tests
 
       # This instance will be spawned especially for pull-request from forked repository
       - name: Start GitHub instance

--- a/.github/workflows/gpu_zk_long_run_tests.yml
+++ b/.github/workflows/gpu_zk_long_run_tests.yml
@@ -72,7 +72,7 @@ jobs:
           slab-url: ${{ secrets.SLAB_BASE_URL }}
           job-secret: ${{ secrets.JOB_SECRET }}
           backend: terraform
-          profile: scaleway-2-h100-sxm5
+          profile: scaleway-2-h100-sxm5-tests
 
   cuda-tests:
     name: gpu_zk_long_run_tests/cuda-tests

--- a/ci/slab.toml
+++ b/ci/slab.toml
@@ -64,6 +64,7 @@ region = "us-east-1"
 image_id = "ami-0250f541bc1358116"
 instance_type = "g6.24xlarge"
 user = "ubuntu"
+fallbacks = [ "hyperstack.4-l40", "terraform.scaleway-4-l40" ]
 
 [backend.aws.small-gpu]
 region = "us-east-1"
@@ -76,6 +77,7 @@ environment_name = "canada"
 image_name = "Ubuntu Server 22.04 LTS R570 CUDA 12.8"
 flavor_name = "n3-L40x1"
 user = "ubuntu"
+fallbacks = [ "terraform.scaleway-small-gpu", "hyperstack.rtx-a6000" ]
 
 [backend.hyperstack.single-h100]
 environment_name = "canada"
@@ -137,6 +139,20 @@ image_name = "Ubuntu Server 22.04 LTS R570 CUDA 12.8"
 flavor_name = "n3-RTX-A6000x1"
 user = "ubuntu"
 
+[backend.hyperstack.l40-tests]
+environment_name = "canada"
+image_name = "Ubuntu Server 22.04 LTS R570 CUDA 12.8"
+flavor_name = "n3-L40x1"
+user = "ubuntu"
+fallbacks = [ "hyperstack.rtx-a6000", "terraform.scaleway-small-gpu" ]
+
+# Fallback target only.
+[backend.hyperstack.rtx-a6000]
+environment_name = "canada"
+image_name = "Ubuntu Server 22.04 LTS R570 CUDA 12.8"
+flavor_name = "n3-RTX-A6000x1"
+user = "ubuntu"
+
 [backend.hyperstack.4-l40]
 environment_name = "canada"
 image_name = "Ubuntu Server 22.04 LTS R570 CUDA 12.8"
@@ -170,6 +186,16 @@ script_path = "ci/terraform_scripts/scaleway/terraform.tf"
 instance_type = "H100-SXM-2-80G"
 user = "ubuntu"
 
+[backend.terraform.scaleway-2-h100-sxm5-tests]
+script_path = "ci/terraform_scripts/scaleway/terraform.tf"
+instance_type = "H100-SXM-2-80G"
+user = "ubuntu"
+fallbacks = [
+    "hyperstack.2-h100",
+    "terraform.scaleway-4-h100-sxm5",
+    "hyperstack.4-h100",
+]
+
 [backend.terraform.scaleway-single-h100]
 script_path = "ci/terraform_scripts/scaleway/terraform.tf"
 instance_type = "H100-1-80G"
@@ -179,6 +205,16 @@ user = "ubuntu"
 script_path = "ci/terraform_scripts/scaleway/terraform.tf"
 instance_type = "H100-SXM-2-80G"
 user = "ubuntu"
+
+[backend.terraform.scaleway-single-h100-tests]
+script_path = "ci/terraform_scripts/scaleway/terraform.tf"
+instance_type = "H100-1-80G"
+user = "ubuntu"
+fallbacks = [
+    "hyperstack.single-h100",
+    "terraform.scaleway-2-h100-sxm5",
+    "terraform.scaleway-4-h100-sxm5",
+]
 
 [backend.terraform.scaleway-4-l40]
 script_path = "ci/terraform_scripts/scaleway/terraform.tf"
@@ -194,8 +230,4 @@ user = "ubuntu"
 script_path = "ci/terraform_scripts/scaleway/terraform.tf"
 instance_type = "L40S-1-48G"
 user = "ubuntu"
-
-[backend.terraform.scaleway-small-gpu_fallback]
-script_path = "ci/terraform_scripts/scaleway/terraform.tf"
-instance_type = "L4-2-24G"
-user = "ubuntu"
+fallbacks = [ "hyperstack.gpu-test", "terraform.scaleway-2-l4" ]


### PR DESCRIPTION
```
──▶ explicit   ··▶ implicit   * renamed start (same hw)   (=X) re-encodes the old implicit

gpu_core_h100_tests · gpu_full_h100_tests · gpu_memory_sanitizer_h100
gpu_zk_code_validation_tests · gpu_zk_long_run_tests
    before  scw.2-h100-sxm5
    after   scw.2-h100-sxm5-tests* ──▶ hyp.2-h100 ──▶ scw.4-h100-sxm5 ──▶ hyp.4-h100

gpu_hlapi_h100_tests · gpu_signed_integer_h100_tests · gpu_unsigned_integer_h100_tests
    before  scw.single-h100 ··▶ SXM-2
    after   scw.single-h100-tests* ──▶ hyp.single-h100 ──▶ scw.2-h100-sxm5 (=SXM-2) ──▶ scw.4-h100-sxm5

gpu_noise_level_checks
    before  hyp.l40 ··▶ A6000
    after   hyp.l40-tests* ──▶ hyp.rtx-a6000 (=A6000) ──▶ scw.small-gpu

gpu_fast_tests · gpu_code_validation_tests · gpu_memory_sanitizer
gpu_signed_integer_tests · gpu_unsigned_integer_tests · gpu_zk_tests
    before  scw.small-gpu ··▶ 2×L4
    after   scw.small-gpu ──▶ hyp.gpu-test ──▶ scw.2-l4 (=2×L4)

gpu_signed_integer_classic_tests · gpu_unsigned_integer_classic_tests · gpu_zk_memory_sanitizer
    before  hyp.gpu-test
    after   hyp.gpu-test ──▶ scw.small-gpu ──▶ hyp.rtx-a6000

gpu_full_multi_gpu_tests · gpu_integer_long_run_tests
    before  aws.4-l40
    after   aws.4-l40 ──▶ hyp.4-l40 ──▶ scw.4-l40
```

NB: The original profiles are also used by benchmark workflows, which must always run on the exact hardware they advertise, so we duplicated them as _-tests_ profiles carrying the fallback chains. Tests can tolerate landing on different hardware, benchmarks can't.