### PR TITLE
feat(integer): add oprf test comparing fhe output to cleartext prediction

### DIFF
--- a/tfhe/src/integer/gpu/server_key/radix/tests_signed/test_oprf.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/tests_signed/test_oprf.rs
@@ -4,6 +4,8 @@ use crate::integer::gpu::CudaOprfServerKey;
 use crate::integer::server_key::radix_parallel::tests_signed::test_oprf::{
     oprf_uniformity_bounded_test, oprf_uniformity_unbounded_test,
 };
+use crate::integer::server_key::radix_parallel::tests_unsigned::test_oprf::oprf_compare_plain_test;
+use crate::shortint::parameters::test_params::TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
 use crate::shortint::parameters::{
     TestParameters, PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
 };
@@ -14,6 +16,11 @@ create_gpu_parameterized_test!(oprf_signed_uniformity_bounded {
 
 create_gpu_parameterized_test!(oprf_signed_uniformity_unbounded {
     PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128
+});
+
+create_gpu_parameterized_test!(oprf_compare_plain_signed {
+    PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+    TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
 });
 
 fn oprf_signed_uniformity_bounded<P>(param: P)
@@ -34,4 +41,16 @@ where
         &CudaOprfServerKey::par_generate_oblivious_pseudo_random_signed_integer,
     );
     oprf_uniformity_unbounded_test(param, executor);
+}
+
+fn oprf_compare_plain_signed<P>(param: P)
+where
+    P: Into<TestParameters>,
+{
+    let executor = OpSequenceGpuMultiDeviceFunctionExecutor::new(
+        &CudaOprfServerKey::par_generate_oblivious_pseudo_random_signed_integer,
+    );
+    oprf_compare_plain_test(param, executor, |cks, img| {
+        cks.decrypt_signed::<i64>(img) as i128
+    });
 }

--- a/tfhe/src/integer/gpu/server_key/radix/tests_unsigned/test_oprf.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/tests_unsigned/test_oprf.rs
@@ -8,8 +8,8 @@ use crate::integer::gpu::server_key::radix::tests_unsigned::create_gpu_parameter
 use crate::integer::gpu::{CudaOprfServerKey, CudaServerKey};
 use crate::integer::oprf::{CompressedOprfServerKey, OprfPrivateKey};
 use crate::integer::server_key::radix_parallel::tests_unsigned::test_oprf::{
-    oprf_almost_uniformity_test, oprf_any_range_test, oprf_uniformity_test,
-    pseudo_random_integer_and_rerand_test, OprfReRandTestRunner,
+    oprf_almost_uniformity_test, oprf_any_range_test, oprf_compare_plain_test,
+    oprf_uniformity_test, pseudo_random_integer_and_rerand_test, OprfReRandTestRunner,
 };
 use crate::integer::{ClientKey, CompactPrivateKey, CompactPublicKey};
 use crate::shortint::oprf::OprfSeed;
@@ -30,6 +30,11 @@ create_gpu_parameterized_test!(oprf_almost_uniformity_unsigned {
 });
 
 create_gpu_parameterized_test!(pseudo_random_integer_and_rerand {
+    PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+    TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+});
+
+create_gpu_parameterized_test!(oprf_compare_plain_unsigned {
     PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
     TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
 });
@@ -62,6 +67,16 @@ where
         &CudaOprfServerKey::par_generate_oblivious_pseudo_random_unsigned_custom_range,
     );
     oprf_almost_uniformity_test(param, executor);
+}
+
+fn oprf_compare_plain_unsigned<P>(param: P)
+where
+    P: Into<TestParameters>,
+{
+    let executor = OpSequenceGpuMultiDeviceFunctionExecutor::new(
+        &CudaOprfServerKey::par_generate_oblivious_pseudo_random_unsigned_integer,
+    );
+    oprf_compare_plain_test(param, executor, |cks, img| cks.decrypt::<u64>(img) as i128);
 }
 
 // PRF + rerand

--- a/tfhe/src/integer/gpu/server_key/radix/tests_unsigned/test_oprf.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/tests_unsigned/test_oprf.rs
@@ -8,8 +8,9 @@ use crate::integer::gpu::server_key::radix::tests_unsigned::create_gpu_parameter
 use crate::integer::gpu::{CudaOprfServerKey, CudaServerKey};
 use crate::integer::oprf::{CompressedOprfServerKey, OprfPrivateKey};
 use crate::integer::server_key::radix_parallel::tests_unsigned::test_oprf::{
-    oprf_almost_uniformity_test, oprf_any_range_test, oprf_uniformity_test,
-    oprf_zero_input_bits_test, pseudo_random_integer_and_rerand_test, OprfReRandTestRunner,
+    oprf_almost_uniformity_test, oprf_any_range_test, oprf_compare_plain_test,
+    oprf_uniformity_test, oprf_zero_input_bits_test, pseudo_random_integer_and_rerand_test,
+    OprfReRandTestRunner,
 };
 use crate::integer::{ClientKey, CompactPrivateKey, CompactPublicKey, ServerKey};
 use crate::shortint::oprf::OprfSeed;
@@ -42,6 +43,11 @@ create_gpu_parameterized_test!(pseudo_random_integer_and_rerand {
 });
 
 create_gpu_parameterized_test!(oprf_cpu_gpu_equivalence {
+    PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+    TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+});
+
+create_gpu_parameterized_test!(oprf_compare_plain_unsigned {
     PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
     TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
 });
@@ -84,6 +90,16 @@ where
         &CudaOprfServerKey::par_generate_oblivious_pseudo_random_unsigned_custom_range,
     );
     oprf_almost_uniformity_test(param, executor);
+}
+
+fn oprf_compare_plain_unsigned<P>(param: P)
+where
+    P: Into<TestParameters>,
+{
+    let executor = OpSequenceGpuMultiDeviceFunctionExecutor::new(
+        &CudaOprfServerKey::par_generate_oblivious_pseudo_random_unsigned_integer,
+    );
+    oprf_compare_plain_test(param, executor, |cks, img| cks.decrypt::<u64>(img) as i128);
 }
 
 // PRF + rerand

--- a/tfhe/src/integer/server_key/radix_parallel/tests_signed/test_oprf.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_signed/test_oprf.rs
@@ -1,11 +1,15 @@
 use crate::integer::oprf::OprfServerKey;
 use crate::integer::server_key::radix_parallel::tests_long_run::OpSequenceFunctionExecutor;
 use crate::integer::server_key::radix_parallel::tests_unsigned::test_oprf::{
-    internal_test_uniformity, setup_oprf_test,
+    internal_test_uniformity, oprf_compare_plain_test, setup_oprf_test,
 };
 use crate::integer::server_key::radix_parallel::tests_unsigned::CpuOprfExecutor;
 use crate::integer::tests::create_parameterized_test;
 use crate::integer::{ServerKey, SignedRadixCiphertext};
+use crate::shortint::parameters::test_params::{
+    TEST_PARAM_MESSAGE_2_CARRY_2_KS32_PBS_TUNIFORM_2M128,
+    TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+};
 use crate::shortint::parameters::*;
 use tfhe_csprng::seeders::Seed;
 
@@ -15,6 +19,11 @@ create_parameterized_test!(oprf_signed_uniformity_bounded {
 
 create_parameterized_test!(oprf_signed_uniformity_unbounded {
     PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128
+});
+
+create_parameterized_test!(oprf_compare_plain_signed {
+    TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+    TEST_PARAM_MESSAGE_2_CARRY_2_KS32_PBS_TUNIFORM_2M128
 });
 
 fn oprf_signed_uniformity_bounded<P>(param: P)
@@ -51,12 +60,28 @@ where
     oprf_uniformity_unbounded_test(param, executor);
 }
 
+fn oprf_compare_plain_signed<P>(param: P)
+where
+    P: Into<TestParameters>,
+{
+    let executor =
+        CpuOprfExecutor::new(&|oprf_key: &OprfServerKey,
+                               seed: Seed,
+                               num_blocks: u64,
+                               sk: &ServerKey| {
+            oprf_key.par_generate_oblivious_pseudo_random_signed_integer(seed, num_blocks, sk)
+        });
+    oprf_compare_plain_test(param, executor, |cks, img| {
+        cks.decrypt_signed::<i64>(img) as i128
+    });
+}
+
 pub fn oprf_uniformity_bounded_test<P, E>(param: P, mut executor: E)
 where
     P: Into<TestParameters>,
     E: OpSequenceFunctionExecutor<(Seed, u64, u64), SignedRadixCiphertext>,
 {
-    let cks = setup_oprf_test(param, &mut executor);
+    let (cks, _oprf_priv_key) = setup_oprf_test(param, &mut executor);
 
     let sample_count: usize = 10_000;
     let p_value_limit: f64 = 0.000_01;
@@ -78,7 +103,7 @@ where
     P: Into<TestParameters>,
     E: OpSequenceFunctionExecutor<(Seed, u64), SignedRadixCiphertext>,
 {
-    let cks = setup_oprf_test(param, &mut executor);
+    let (cks, _oprf_priv_key) = setup_oprf_test(param, &mut executor);
 
     let sample_count: usize = 10_000;
     let p_value_limit: f64 = 0.000_01;

--- a/tfhe/src/integer/server_key/radix_parallel/tests_signed/test_oprf.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_signed/test_oprf.rs
@@ -1,11 +1,15 @@
 use crate::integer::oprf::OprfServerKey;
 use crate::integer::server_key::radix_parallel::tests_long_run::OpSequenceFunctionExecutor;
 use crate::integer::server_key::radix_parallel::tests_unsigned::test_oprf::{
-    internal_test_uniformity, setup_oprf_test,
+    internal_test_uniformity, oprf_compare_plain_test, setup_oprf_test,
 };
 use crate::integer::server_key::radix_parallel::tests_unsigned::CpuOprfExecutor;
 use crate::integer::tests::create_parameterized_test;
 use crate::integer::{ServerKey, SignedRadixCiphertext};
+use crate::shortint::parameters::test_params::{
+    TEST_PARAM_MESSAGE_2_CARRY_2_KS32_PBS_TUNIFORM_2M128,
+    TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+};
 use crate::shortint::parameters::*;
 use tfhe_csprng::seeders::Seed;
 
@@ -15,6 +19,11 @@ create_parameterized_test!(oprf_signed_uniformity_bounded {
 
 create_parameterized_test!(oprf_signed_uniformity_unbounded {
     PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128
+});
+
+create_parameterized_test!(oprf_compare_plain_signed {
+    TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+    TEST_PARAM_MESSAGE_2_CARRY_2_KS32_PBS_TUNIFORM_2M128
 });
 
 fn oprf_signed_uniformity_bounded<P>(param: P)
@@ -51,12 +60,28 @@ where
     oprf_uniformity_unbounded_test(param, executor);
 }
 
+fn oprf_compare_plain_signed<P>(param: P)
+where
+    P: Into<TestParameters>,
+{
+    let executor =
+        CpuOprfExecutor::new(&|oprf_key: &OprfServerKey,
+                               seed: Seed,
+                               num_blocks: u64,
+                               sk: &ServerKey| {
+            oprf_key.par_generate_oblivious_pseudo_random_signed_integer(seed, num_blocks, sk)
+        });
+    oprf_compare_plain_test(param, executor, |cks, img| {
+        cks.decrypt_signed::<i64>(img) as i128
+    });
+}
+
 pub fn oprf_uniformity_bounded_test<P, E>(param: P, mut executor: E)
 where
     P: Into<TestParameters>,
     E: for<'a> OpSequenceFunctionExecutor<(Seed, u64, u64), SignedRadixCiphertext>,
 {
-    let cks = setup_oprf_test(param, &mut executor);
+    let (cks, _oprf_priv_key) = setup_oprf_test(param, &mut executor);
 
     let sample_count: usize = 10_000;
     let p_value_limit: f64 = 0.000_01;
@@ -78,7 +103,7 @@ where
     P: Into<TestParameters>,
     E: for<'a> OpSequenceFunctionExecutor<(Seed, u64), SignedRadixCiphertext>,
 {
-    let cks = setup_oprf_test(param, &mut executor);
+    let (cks, _oprf_priv_key) = setup_oprf_test(param, &mut executor);
 
     let sample_count: usize = 10_000;
     let p_value_limit: f64 = 0.000_01;

--- a/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_oprf.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_oprf.rs
@@ -3,8 +3,8 @@ use crate::core_crypto::commons::math::random::tests::{
     cumulate, dkw_alpha_from_epsilon, sup_diff,
 };
 use crate::integer::ciphertext::{
-    PrfReRandomizationContext, RadixCiphertext, ReRandomizationHashAlgo, ReRandomizationKey,
-    ReRandomizationSeedHasher, SignedRadixCiphertext,
+    IntegerRadixCiphertext, PrfReRandomizationContext, RadixCiphertext, ReRandomizationHashAlgo,
+    ReRandomizationKey, ReRandomizationSeedHasher, SignedRadixCiphertext,
 };
 use crate::integer::keycache::KEY_CACHE;
 use crate::integer::oprf::{OprfPrivateKey, OprfServerKey};
@@ -15,6 +15,8 @@ use crate::integer::{
     gen_keys, ClientKey, CompactPrivateKey, CompactPublicKey, IntegerKeyKind, RadixClientKey,
     ServerKey,
 };
+use crate::shortint::oprf::test::gen_prf_inputs;
+use crate::shortint::oprf::test_utils::cleartext_prf;
 use crate::shortint::parameters::test_params::{
     TEST_PARAM_MESSAGE_2_CARRY_2_KS32_PBS_TUNIFORM_2M128,
     TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
@@ -42,6 +44,11 @@ create_parameterized_test!(oprf_almost_uniformity_unsigned {
 
 create_parameterized_test!(pseudo_random_integer_and_rerand {
     TEST_PARAM_MULTI_BIT_GROUP_3_MESSAGE_2_CARRY_2_KS_PBS_GAUSSIAN_2M128,
+    TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+    TEST_PARAM_MESSAGE_2_CARRY_2_KS32_PBS_TUNIFORM_2M128
+});
+
+create_parameterized_test!(oprf_compare_plain_unsigned {
     TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
     TEST_PARAM_MESSAGE_2_CARRY_2_KS32_PBS_TUNIFORM_2M128
 });
@@ -110,6 +117,20 @@ where
     oprf_almost_uniformity_test(param, executor);
 }
 
+fn oprf_compare_plain_unsigned<P>(param: P)
+where
+    P: Into<TestParameters>,
+{
+    let executor =
+        CpuOprfExecutor::new(&|oprf_key: &OprfServerKey,
+                               seed: Seed,
+                               num_blocks: u64,
+                               sk: &ServerKey| {
+            oprf_key.par_generate_oblivious_pseudo_random_unsigned_integer(seed, num_blocks, sk)
+        });
+    oprf_compare_plain_test(param, executor, |cks, img| cks.decrypt::<u64>(img) as i128);
+}
+
 pub(crate) fn square(a: f64) -> f64 {
     a * a
 }
@@ -154,7 +175,7 @@ pub(crate) fn internal_test_uniformity<F>(
 pub(crate) fn setup_oprf_test<I, O, E>(
     param: impl Into<TestParameters>,
     executor: &mut E,
-) -> RadixClientKey
+) -> (RadixClientKey, OprfPrivateKey)
 where
     E: OpSequenceFunctionExecutor<I, O>,
 {
@@ -173,13 +194,13 @@ where
         None,
         None,
         None,
-        Some(oprf_priv_key),
+        Some(oprf_priv_key.clone()),
         Tag::default(),
     );
     let comp_sks = crate::CompressedServerKey::new(&temp_cks);
     let cks = RadixClientKey::from((cks, 1));
     executor.setup(&cks, &comp_sks, &mut deterministic_seeder);
-    cks
+    (cks, oprf_priv_key)
 }
 
 pub(crate) fn oprf_uniformity_test<P, E>(param: P, mut executor: E)
@@ -187,7 +208,7 @@ where
     P: Into<TestParameters>,
     E: for<'a> OpSequenceFunctionExecutor<(Seed, u64, u64), RadixCiphertext>,
 {
-    let cks = setup_oprf_test(param, &mut executor);
+    let (cks, _oprf_priv_key) = setup_oprf_test(param, &mut executor);
 
     let sample_count: usize = 10_000;
     let p_value_limit: f64 = 0.000_01;
@@ -207,7 +228,7 @@ where
     P: Into<TestParameters>,
     E: for<'a> OpSequenceFunctionExecutor<(Seed, u64, u64, u64), RadixCiphertext>,
 {
-    let cks = setup_oprf_test(param, &mut executor);
+    let (cks, _oprf_priv_key) = setup_oprf_test(param, &mut executor);
 
     let num_loops = 100;
 
@@ -239,7 +260,7 @@ where
     P: Into<TestParameters>,
     E: for<'a> OpSequenceFunctionExecutor<(Seed, u64, u64, u64), RadixCiphertext>,
 {
-    let cks = setup_oprf_test(param, &mut executor);
+    let (cks, _oprf_priv_key) = setup_oprf_test(param, &mut executor);
 
     let sample_count: usize = 10_000;
     let p_value_limit: f64 = 0.001;
@@ -266,6 +287,69 @@ where
     );
 
     assert!(p_value_limit < p_value_upper_bound);
+}
+
+/// Predicts the full-precision PRF output from the seed in the clear and checks it against
+/// the decrypted FHE result, block by block.
+///
+/// The prediction re-derives the seeded modulus-switched PRF inputs from the seed, decrypts them
+/// under the OPRF private key, and applies the clear LUT model ([`cleartext_prf`]).
+pub(crate) fn oprf_compare_plain_test<P, E, T>(
+    param: P,
+    mut executor: E,
+    // Lets the caller pick the decryption matching `T` (`decrypt` vs `decrypt_signed`).
+    decrypt_whole: impl Fn(&RadixClientKey, &T) -> i128,
+) where
+    P: Into<TestParameters>,
+    T: IntegerRadixCiphertext,
+    E: for<'a> OpSequenceFunctionExecutor<(Seed, u64), T>,
+{
+    let (cks, oprf_priv_key) = setup_oprf_test(param, &mut executor);
+    let shortint_oprf_ck = oprf_priv_key.into_raw_parts();
+    let params: ShortintParameterSet = cks.parameters().into();
+    let message_bits: u64 = params.message_modulus().0.ilog2().into();
+    // includes padding bit (same as shortint oprf_compare_plain_from_seed)
+    let output_modulus = 2 * params.message_modulus().0 * params.carry_modulus().0;
+    let polynomial_size = params.polynomial_size().0 as u64;
+    let num_blocks: u64 = 4;
+    let total_bits = num_blocks * message_bits;
+
+    for s in 0..100u128 {
+        let seed = Seed(s);
+        let img: T = executor.execute((seed, num_blocks));
+        assert_eq!(img.blocks().len() as u64, num_blocks);
+
+        let plain_prf_inputs = gen_prf_inputs(&shortint_oprf_ck, seed, params, &[total_bits]);
+        assert_eq!(plain_prf_inputs.len(), img.blocks().len());
+
+        let mut expected_value = 0u64;
+        for (i, (block, (plain_input, block_bits))) in
+            img.blocks().iter().zip(plain_prf_inputs).enumerate()
+        {
+            let expected_block =
+                cleartext_prf(plain_input, block_bits, output_modulus, polynomial_size);
+            let decrypted_block = cks.as_ref().key.decrypt_message_and_carry(block);
+            assert!(
+                decrypted_block < (1 << block_bits),
+                "seed {s}: block {i} out of range: got {decrypted_block}, block_bits {block_bits}"
+            );
+            assert_eq!(
+                decrypted_block, expected_block,
+                "seed {s}: block {i}: got {decrypted_block}, expected {expected_block}"
+            );
+            expected_value |= expected_block << (i as u64 * message_bits);
+        }
+
+        // For signed outputs the assembled bits are interpreted as two's complement over
+        // `total_bits`, so a set top bit means a negative value.
+        let expected_whole = if T::IS_SIGNED && expected_value & (1u64 << (total_bits - 1)) != 0 {
+            expected_value as i128 - (1i128 << total_bits)
+        } else {
+            expected_value as i128
+        };
+        let decrypted = decrypt_whole(&cks, &img);
+        assert_eq!(decrypted, expected_whole, "seed {s}");
+    }
 }
 
 pub(crate) fn p_value_upper_bound_oprf_almost_uniformity_from_values(

--- a/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_oprf.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_oprf.rs
@@ -3,8 +3,8 @@ use crate::core_crypto::commons::math::random::tests::{
     cumulate, dkw_alpha_from_epsilon, sup_diff,
 };
 use crate::integer::ciphertext::{
-    PrfReRandomizationContext, RadixCiphertext, ReRandomizationHashAlgo, ReRandomizationKey,
-    ReRandomizationSeedHasher, SignedRadixCiphertext,
+    IntegerRadixCiphertext, PrfReRandomizationContext, RadixCiphertext, ReRandomizationHashAlgo,
+    ReRandomizationKey, ReRandomizationSeedHasher, SignedRadixCiphertext,
 };
 use crate::integer::keycache::KEY_CACHE;
 use crate::integer::oprf::{OprfPrivateKey, OprfServerKey};
@@ -16,6 +16,8 @@ use crate::integer::{
     ServerKey,
 };
 use crate::shortint::engine::ShortintEngine;
+use crate::shortint::oprf::test::gen_prf_inputs;
+use crate::shortint::oprf::test_utils::cleartext_prf;
 use crate::shortint::parameters::test_params::{
     TEST_PARAM_MESSAGE_2_CARRY_2_KS32_PBS_TUNIFORM_2M128,
     TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
@@ -46,6 +48,11 @@ create_parameterized_test!(oprf_zero_input_bits_unsigned {
 
 create_parameterized_test!(pseudo_random_integer_and_rerand {
     TEST_PARAM_MULTI_BIT_GROUP_3_MESSAGE_2_CARRY_2_KS_PBS_GAUSSIAN_2M128,
+    TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+    TEST_PARAM_MESSAGE_2_CARRY_2_KS32_PBS_TUNIFORM_2M128
+});
+
+create_parameterized_test!(oprf_compare_plain_unsigned {
     TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
     TEST_PARAM_MESSAGE_2_CARRY_2_KS32_PBS_TUNIFORM_2M128
 });
@@ -136,6 +143,20 @@ where
     oprf_almost_uniformity_test(param, executor);
 }
 
+fn oprf_compare_plain_unsigned<P>(param: P)
+where
+    P: Into<TestParameters>,
+{
+    let executor =
+        CpuOprfExecutor::new(&|oprf_key: &OprfServerKey,
+                               seed: Seed,
+                               num_blocks: u64,
+                               sk: &ServerKey| {
+            oprf_key.par_generate_oblivious_pseudo_random_unsigned_integer(seed, num_blocks, sk)
+        });
+    oprf_compare_plain_test(param, executor, |cks, img| cks.decrypt::<u64>(img) as i128);
+}
+
 pub(crate) fn square(a: f64) -> f64 {
     a * a
 }
@@ -180,7 +201,7 @@ pub(crate) fn internal_test_uniformity<F>(
 pub(crate) fn setup_oprf_test<I, O, E>(
     param: impl Into<TestParameters>,
     executor: &mut E,
-) -> RadixClientKey
+) -> (RadixClientKey, OprfPrivateKey)
 where
     E: OpSequenceFunctionExecutor<I, O>,
 {
@@ -207,13 +228,13 @@ where
         None,
         None,
         None,
-        Some(oprf_priv_key),
+        Some(oprf_priv_key.clone()),
         Tag::default(),
     );
     let comp_sks = crate::CompressedServerKey::new(&temp_cks);
     let cks = RadixClientKey::from((cks, 1));
     executor.setup(&cks, &comp_sks, &mut deterministic_seeder);
-    cks
+    (cks, oprf_priv_key)
 }
 
 pub(crate) fn oprf_uniformity_test<P, E>(param: P, mut executor: E)
@@ -221,7 +242,7 @@ where
     P: Into<TestParameters>,
     E: OpSequenceFunctionExecutor<(Seed, u64, u64), RadixCiphertext>,
 {
-    let cks = setup_oprf_test(param, &mut executor);
+    let (cks, _oprf_priv_key) = setup_oprf_test(param, &mut executor);
 
     let sample_count: usize = 10_000;
     let p_value_limit: f64 = 0.000_01;
@@ -241,7 +262,7 @@ where
     P: Into<TestParameters>,
     E: OpSequenceFunctionExecutor<(Seed, u64, u64, u64), RadixCiphertext>,
 {
-    let cks = setup_oprf_test(param, &mut executor);
+    let (cks, _oprf_priv_key) = setup_oprf_test(param, &mut executor);
 
     let num_loops = 100;
 
@@ -274,7 +295,7 @@ where
     P: Into<TestParameters>,
     E: OpSequenceFunctionExecutor<(Seed, u64, u64, u64), RadixCiphertext>,
 {
-    let cks = setup_oprf_test(param, &mut executor);
+    let (cks, _oprf_priv_key) = setup_oprf_test(param, &mut executor);
 
     for (excluded_upper_bound, num_blocks_output) in [(3, 1), (3, 32), ((1 << 32) + 1, 64)] {
         let img = executor.execute((Seed(0), 0, excluded_upper_bound, num_blocks_output as u64));
@@ -292,7 +313,7 @@ where
     P: Into<TestParameters>,
     E: OpSequenceFunctionExecutor<(Seed, u64, u64, u64), RadixCiphertext>,
 {
-    let cks = setup_oprf_test(param, &mut executor);
+    let (cks, _oprf_priv_key) = setup_oprf_test(param, &mut executor);
 
     let sample_count: usize = 10_000;
     let p_value_limit: f64 = 0.001;
@@ -319,6 +340,69 @@ where
     );
 
     assert!(p_value_limit < p_value_upper_bound);
+}
+
+/// Predicts the full-precision PRF output from the seed in the clear and checks it against
+/// the decrypted FHE result, block by block.
+///
+/// The prediction re-derives the seeded modulus-switched PRF inputs from the seed, decrypts them
+/// under the OPRF private key, and applies the clear LUT model ([`cleartext_prf`]).
+pub(crate) fn oprf_compare_plain_test<P, E, T>(
+    param: P,
+    mut executor: E,
+    // Lets the caller pick the decryption matching `T` (`decrypt` vs `decrypt_signed`).
+    decrypt_whole: impl Fn(&RadixClientKey, &T) -> i128,
+) where
+    P: Into<TestParameters>,
+    T: IntegerRadixCiphertext,
+    E: OpSequenceFunctionExecutor<(Seed, u64), T>,
+{
+    let (cks, oprf_priv_key) = setup_oprf_test(param, &mut executor);
+    let shortint_oprf_ck = oprf_priv_key.into_raw_parts();
+    let params: ShortintParameterSet = cks.parameters().into();
+    let message_bits: u64 = params.message_modulus().0.ilog2().into();
+    // includes padding bit (same as shortint oprf_compare_plain_from_seed)
+    let output_modulus = 2 * params.message_modulus().0 * params.carry_modulus().0;
+    let polynomial_size = params.polynomial_size().0 as u64;
+    let num_blocks: u64 = 4;
+    let total_bits = num_blocks * message_bits;
+
+    for s in 0..100u128 {
+        let seed = Seed(s);
+        let img: T = executor.execute((seed, num_blocks));
+        assert_eq!(img.blocks().len() as u64, num_blocks);
+
+        let plain_prf_inputs = gen_prf_inputs(&shortint_oprf_ck, seed, params, &[total_bits]);
+        assert_eq!(plain_prf_inputs.len(), img.blocks().len());
+
+        let mut expected_value = 0u64;
+        for (i, (block, (plain_input, block_bits))) in
+            img.blocks().iter().zip(plain_prf_inputs).enumerate()
+        {
+            let expected_block =
+                cleartext_prf(plain_input, block_bits, output_modulus, polynomial_size);
+            let decrypted_block = cks.as_ref().key.decrypt_message_and_carry(block);
+            assert!(
+                decrypted_block < (1 << block_bits),
+                "seed {s}: block {i} out of range: got {decrypted_block}, block_bits {block_bits}"
+            );
+            assert_eq!(
+                decrypted_block, expected_block,
+                "seed {s}: block {i}: got {decrypted_block}, expected {expected_block}"
+            );
+            expected_value |= expected_block << (i as u64 * message_bits);
+        }
+
+        // For signed outputs the assembled bits are interpreted as two's complement over
+        // `total_bits`, so a set top bit means a negative value.
+        let expected_whole = if T::IS_SIGNED && expected_value & (1u64 << (total_bits - 1)) != 0 {
+            expected_value as i128 - (1i128 << total_bits)
+        } else {
+            expected_value as i128
+        };
+        let decrypted = decrypt_whole(&cks, &img);
+        assert_eq!(decrypted, expected_whole, "seed {s}");
+    }
 }
 
 pub(crate) fn p_value_upper_bound_oprf_almost_uniformity_from_values(

--- a/tfhe/src/shortint/oprf.rs
+++ b/tfhe/src/shortint/oprf.rs
@@ -1445,12 +1445,11 @@ pub(crate) mod test {
             .next()
             .unwrap();
 
-        let plain_prf_input = match &oprf_ck.0 {
-            AtomicPatternOprfPrivateKey::Standard(sk) => gen_prf_input(&sk.as_view(), seed, params),
-            AtomicPatternOprfPrivateKey::KeySwitch32(sk) => {
-                gen_prf_input(&sk.as_view(), seed, params)
-            }
-        };
+        let plain_prf_input = gen_prf_inputs(oprf_ck, seed, params, &[random_bits_count])
+            .into_iter()
+            .next()
+            .unwrap()
+            .0;
 
         // includes padding bit
         let output_modulus = 2 * params.message_modulus().0 * params.carry_modulus().0;
@@ -1480,12 +1479,30 @@ pub(crate) mod test {
         }
     }
 
-    /// Returns the value used as input of the pbs for the prf with the provided seed
-    fn gen_prf_input<Scalar>(
+    /// Returns the `(plain_prf_input, random_bits_in_block)` pairs feeding the pbs of the prf for
+    /// the provided seed, one per output block, matching the layout requested by `bit_chunks`.
+    pub(crate) fn gen_prf_inputs(
+        oprf_ck: &OprfPrivateKey,
+        seed: Seed,
+        params: ShortintParameterSet,
+        bit_chunks: &[u64],
+    ) -> Vec<(u64, u64)> {
+        match &oprf_ck.0 {
+            AtomicPatternOprfPrivateKey::Standard(sk) => {
+                gen_prf_inputs_impl(&sk.as_view(), seed, params, bit_chunks)
+            }
+            AtomicPatternOprfPrivateKey::KeySwitch32(sk) => {
+                gen_prf_inputs_impl(&sk.as_view(), seed, params, bit_chunks)
+            }
+        }
+    }
+
+    fn gen_prf_inputs_impl<Scalar>(
         sk: &LweSecretKeyView<Scalar>,
         seed: Seed,
         params: ShortintParameterSet,
-    ) -> u64
+        bit_chunks: &[u64],
+    ) -> Vec<(u64, u64)>
     where
         Scalar: UnsignedInteger + CastFrom<usize> + CastInto<u64> + CastInto<usize>,
     {
@@ -1502,25 +1519,27 @@ pub(crate) mod test {
             seed,
             lwe_size,
             params.polynomial_size(),
-            &[message_bits],
+            bit_chunks,
             message_bits,
             bits_per_block,
         );
 
-        assert_eq!(seeded_chunks.len(), 1);
+        seeded_chunks
+            .iter()
+            .map(|(seeded, block_bits)| {
+                assert!(seeded.mask.iter().all(|v| *v < input_p as usize));
 
-        let seeded = &seeded_chunks[0].0;
+                let ct = raw_seeded_msed_to_lwe(seeded, ciphertext_modulus);
 
-        assert!(seeded.mask.iter().all(|v| *v < input_p as usize));
-
-        let ct = raw_seeded_msed_to_lwe(seeded, ciphertext_modulus);
-
-        CastInto::<u64>::cast_into(
-            decrypt_lwe_ciphertext(sk, &ct)
-                .0
-                .wrapping_add(Scalar::ONE << (Scalar::BITS - log_input_p - 1))
-                >> (Scalar::BITS - log_input_p),
-        )
+                let plain_input = CastInto::<u64>::cast_into(
+                    decrypt_lwe_ciphertext(sk, &ct)
+                        .0
+                        .wrapping_add(Scalar::ONE << (Scalar::BITS - log_input_p - 1))
+                        >> (Scalar::BITS - log_input_p),
+                );
+                (plain_input, *block_bits)
+            })
+            .collect()
     }
 
     #[test]


### PR DESCRIPTION


<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: https://github.com/zama-ai/tfhe-rs-internal/issues/1483

### PR content/description

The GPU integer OPRF tests only checked statistical uniformity; none compared the FHE output
against a cleartext prediction. The shortint layer already does this in
`oprf_compare_plain_from_seed` (`tfhe/src/shortint/oprf.rs`). This PR brings the equivalent
exact-value check to the integer level, covering both the CPU and GPU backends.

- **New integer test `oprf_compare_plain_test`** (`radix_parallel/tests_unsigned/test_oprf.rs`):
  for each seed it re-derives the seeded PRF inputs, decrypts them under the OPRF private key,
  applies the clear LUT model (`cleartext_prf`), and asserts the prediction matches the decrypted
  FHE result block by block, as well as the full-precision decrypted integer. The prediction
  requests the exact same RLE chunk layout the implementation uses (`num_blocks * message_bits`
  bits in one chunk), since a different layout hashes to a different XOF seed.
- **Registered on both backends**: `create_parameterized_test!` for CPU
  (`MESSAGE_2_CARRY_2_KS_PBS` and `KS32_PBS`) and `create_gpu_parameterized_test!` for GPU
  (multi-bit and classic PBS params).
- **`setup_oprf_test` now returns the `OprfPrivateKey`** alongside the client key, so the test can
  decrypt the PRF inputs. All existing callers updated (signed and unsigned uniformity/range tests).
- **Generalized shortint `gen_prf_input` → `gen_prf_inputs`** (`pub(crate)`): it now returns one
  `(plain_prf_input, random_bits_in_block)` pair per output block for an arbitrary chunk layout,
  instead of a single-block value. The existing shortint test reuses it, and the new integer test
  imports it, avoiding duplication of the input-derivation logic.

### Check-list:

* [x] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [x] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3721)
<!-- Reviewable:end -->
