### PR TITLE
chore(ci): use cuda 12.2 to release tfhe

### DIFF
--- a/.github/workflows/make_release_common_cuda.yml
+++ b/.github/workflows/make_release_common_cuda.yml
@@ -82,7 +82,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-22.04
-            cuda: "12.8 12.2"
+            cuda: "12.2"
             gcc: 9
     env:
       CUDA_PATH: /usr/local/cuda-${{ matrix.cuda }}
@@ -163,7 +163,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-22.04
-            cuda: "12.8 12.2"
+            cuda: "12.2"
             gcc: 9
     env:
       CUDA_PATH: /usr/local/cuda-${{ matrix.cuda }}


### PR DESCRIPTION
This workflow doesn't support the multi Cuda version. In addition the AWS AMI associated to the profile embbeds only Cuda 12.2.
