### PR TITLE
fix(gpu): fixing of bugs

### DIFF
--- a/backends/tfhe-cuda-backend/cuda/include/integer/ilog2.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer/ilog2.h
@@ -204,8 +204,11 @@ template <typename Torus> struct int_ilog2_buffer {
         streams, params, input_num_blocks, Leading, Zero, allocate_gpu_memory,
         size_tracker);
 
-    uint32_t sum_input_total_blocks =
-        (input_num_blocks + 1) * counter_num_blocks;
+    // sum_input_cts is reused for the final sum of 3 ciphertexts
+    // (message_blocks_not, rotated_carry_blocks, trivial_ct_2), so it must
+    // hold at least 3 of them even for single-block inputs.
+    const uint32_t max_num_radix_in_vec = std::max(input_num_blocks + 1, 3u);
+    uint32_t sum_input_total_blocks = max_num_radix_in_vec * counter_num_blocks;
     this->sum_input_cts = new CudaRadixCiphertextFFI;
     create_zero_radix_ciphertext_async<Torus>(
         streams.stream(0), streams.gpu_index(0), this->sum_input_cts,
@@ -213,7 +216,7 @@ template <typename Torus> struct int_ilog2_buffer {
         allocate_gpu_memory);
 
     this->sum_mem = new int_sum_ciphertexts_vec_memory<Torus>(
-        streams, params, counter_num_blocks, input_num_blocks + 1, false,
+        streams, params, counter_num_blocks, max_num_radix_in_vec, false,
         allocate_gpu_memory, size_tracker);
 
     this->sum_output_not_propagated = new CudaRadixCiphertextFFI;

--- a/backends/tfhe-cuda-backend/cuda/src/integer/integer.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/integer.cuh
@@ -338,6 +338,8 @@ __global__ void radix_blocks_reverse_lwe_inplace(Torus *src,
 template <typename Torus>
 __host__ void host_radix_blocks_reverse_inplace(CudaStreams streams,
                                                 CudaRadixCiphertextFFI *src) {
+  if (src->num_radix_blocks < 2)
+    return;
   cuda_set_device(streams.gpu_index(0));
   int num_blocks = src->num_radix_blocks / 2, num_threads = 1024;
   radix_blocks_reverse_lwe_inplace<Torus>

--- a/tfhe/src/high_level_api/integers/unsigned/tests/gpu.rs
+++ b/tfhe/src/high_level_api/integers/unsigned/tests/gpu.rs
@@ -463,6 +463,18 @@ fn test_ilog2_multibit() {
 }
 
 #[test]
+fn test_ilog2_one_block_gpu() {
+    let client_key = setup_classical_gpu();
+    super::test_case_ilog2_one_block(&client_key);
+}
+
+#[test]
+fn test_ilog2_one_block_gpu_multibit() {
+    let client_key = setup_multibit_gpu();
+    super::test_case_ilog2_one_block(&client_key);
+}
+
+#[test]
 fn test_min_max() {
     let client_key = setup_classical_gpu();
     super::test_case_min_max(&client_key);

--- a/tfhe/src/high_level_api/integers/unsigned/tests/mod.rs
+++ b/tfhe/src/high_level_api/integers/unsigned/tests/mod.rs
@@ -1,6 +1,8 @@
 use crate::high_level_api::traits::BitSlice;
 use crate::integer::U256;
 use crate::prelude::*;
+#[cfg(feature = "gpu")]
+use crate::FheUint2;
 use crate::{
     ClientKey, FheBool, FheUint16, FheUint256, FheUint32, FheUint64, FheUint8, MatchValues,
 };
@@ -680,6 +682,28 @@ fn test_case_ilog2(cks: &ClientKey) {
         let is_ok = is_ok.decrypt(cks);
         assert!(!is_ok);
     }
+}
+
+// FheUint2 is a single radix block with 2_2 parameters.
+#[cfg(feature = "gpu")]
+fn test_case_ilog2_one_block(cks: &ClientKey) {
+    for clear_a in 1..=3u32 {
+        let a = FheUint2::try_encrypt(clear_a, cks).unwrap();
+
+        let ilog2: u32 = a.ilog2().decrypt(cks);
+        assert_eq!(ilog2, clear_a.ilog2());
+
+        let leading_zeros: u32 = a.leading_zeros().decrypt(cks);
+        assert_eq!(leading_zeros, clear_a.leading_zeros() - 30);
+
+        let trailing_zeros: u32 = a.trailing_zeros().decrypt(cks);
+        assert_eq!(trailing_zeros, clear_a.trailing_zeros().min(2));
+    }
+
+    let a = FheUint2::try_encrypt(0u32, cks).unwrap();
+    let (_ilog2, is_ok) = a.checked_ilog2();
+    let is_ok = is_ok.decrypt(cks);
+    assert!(!is_ok);
 }
 
 fn test_case_bitslice(cks: &ClientKey) {

--- a/tfhe/src/integer/gpu/ffi.rs
+++ b/tfhe/src/integer/gpu/ffi.rs
@@ -111,6 +111,22 @@ fn resolve_ms_noise_reduction_config(
     )
 }
 
+/// The backend dereferences every input's device pointer on
+/// `streams.gpu_indexes[0]`, so a ciphertext uploaded to another GPU would be
+/// an illegal cross-device access.
+fn assert_all_inputs_are_on_same_gpu<C: CudaIntegerRadixCiphertext>(
+    streams: &CudaStreams,
+    inputs: &[C],
+) {
+    for input in inputs {
+        assert_eq!(
+            streams.gpu_indexes[0],
+            input.as_ref().d_blocks.0.d_vec.gpu_index(0),
+            "GPU error: all data should reside on the same GPU."
+        );
+    }
+}
+
 pub(crate) fn prepare_default_scalar_divisor() -> CudaScalarDivisorFFI {
     CudaScalarDivisorFFI {
         decomposed_chosen_multiplier: std::ptr::null(),
@@ -8602,6 +8618,7 @@ pub(crate) unsafe fn cuda_backend_unchecked_contains<
     assert_eq!(streams.gpu_indexes[0], bootstrapping_key.gpu_index(0));
     assert_eq!(streams.gpu_indexes[0], keyswitch_key.gpu_index(0));
     assert_eq!(streams.gpu_indexes[0], value.d_blocks.0.d_vec.gpu_index(0));
+    assert_all_inputs_are_on_same_gpu(streams, inputs);
 
     let num_inputs = u32::try_from(inputs.len()).unwrap();
     let num_blocks = u32::try_from(value.d_blocks.lwe_ciphertext_count().0).unwrap();
@@ -8710,12 +8727,7 @@ pub(crate) unsafe fn cuda_backend_unchecked_contains_clear<
     let bsk_params = bsk.params_ffi();
     assert_eq!(streams.gpu_indexes[0], bootstrapping_key.gpu_index(0));
     assert_eq!(streams.gpu_indexes[0], keyswitch_key.gpu_index(0));
-    if !inputs.is_empty() {
-        assert_eq!(
-            streams.gpu_indexes[0],
-            inputs[0].as_ref().d_blocks.0.d_vec.gpu_index(0)
-        );
-    }
+    assert_all_inputs_are_on_same_gpu(streams, inputs);
 
     let num_inputs = u32::try_from(inputs.len()).unwrap();
     let num_blocks = u32::try_from(inputs[0].as_ref().d_blocks.lwe_ciphertext_count().0).unwrap();
@@ -9161,6 +9173,7 @@ pub(crate) unsafe fn cuda_backend_unchecked_first_index_of_clear<
     let bsk_params = bsk.params_ffi();
     assert_eq!(streams.gpu_indexes[0], bootstrapping_key.gpu_index(0));
     assert_eq!(streams.gpu_indexes[0], keyswitch_key.gpu_index(0));
+    assert_all_inputs_are_on_same_gpu(streams, inputs);
 
     let num_inputs = u32::try_from(inputs.len()).unwrap();
     let num_blocks = u32::try_from(inputs[0].as_ref().d_blocks.lwe_ciphertext_count().0).unwrap();
@@ -9291,6 +9304,7 @@ pub(crate) unsafe fn cuda_backend_unchecked_first_index_of<
     assert_eq!(streams.gpu_indexes[0], bootstrapping_key.gpu_index(0));
     assert_eq!(streams.gpu_indexes[0], keyswitch_key.gpu_index(0));
     assert_eq!(streams.gpu_indexes[0], value.d_blocks.0.d_vec.gpu_index(0));
+    assert_all_inputs_are_on_same_gpu(streams, inputs);
 
     let num_inputs = u32::try_from(inputs.len()).unwrap();
     let num_blocks = u32::try_from(value.d_blocks.lwe_ciphertext_count().0).unwrap();
@@ -9420,6 +9434,7 @@ pub(crate) unsafe fn cuda_backend_unchecked_index_of<
     assert_eq!(streams.gpu_indexes[0], bootstrapping_key.gpu_index(0));
     assert_eq!(streams.gpu_indexes[0], keyswitch_key.gpu_index(0));
     assert_eq!(streams.gpu_indexes[0], value.d_blocks.0.d_vec.gpu_index(0));
+    assert_all_inputs_are_on_same_gpu(streams, inputs);
 
     let num_inputs = u32::try_from(inputs.len()).unwrap();
     let num_blocks = u32::try_from(value.d_blocks.lwe_ciphertext_count().0).unwrap();
@@ -9549,6 +9564,7 @@ pub(crate) unsafe fn cuda_backend_unchecked_index_of_clear<
     let bsk_params = bsk.params_ffi();
     assert_eq!(streams.gpu_indexes[0], bootstrapping_key.gpu_index(0));
     assert_eq!(streams.gpu_indexes[0], keyswitch_key.gpu_index(0));
+    assert_all_inputs_are_on_same_gpu(streams, inputs);
 
     let num_inputs = u32::try_from(inputs.len()).unwrap();
     let num_blocks_in_ct =
@@ -9684,6 +9700,8 @@ pub(crate) unsafe fn cuda_backend_unchecked_all_eq_slices<
     let bsk_params = bsk.params_ffi();
     assert_eq!(streams.gpu_indexes[0], bootstrapping_key.gpu_index(0));
     assert_eq!(streams.gpu_indexes[0], keyswitch_key.gpu_index(0));
+    assert_all_inputs_are_on_same_gpu(streams, lhs);
+    assert_all_inputs_are_on_same_gpu(streams, rhs);
 
     let num_inputs = u32::try_from(lhs.len()).unwrap();
     let num_blocks = u32::try_from(lhs[0].as_ref().d_blocks.lwe_ciphertext_count().0).unwrap();
@@ -9815,6 +9833,8 @@ pub(crate) unsafe fn cuda_backend_unchecked_contains_sub_slice<
     let bsk_params = bsk.params_ffi();
     assert_eq!(streams.gpu_indexes[0], bootstrapping_key.gpu_index(0));
     assert_eq!(streams.gpu_indexes[0], keyswitch_key.gpu_index(0));
+    assert_all_inputs_are_on_same_gpu(streams, lhs);
+    assert_all_inputs_are_on_same_gpu(streams, rhs);
 
     let num_inputs_lhs = u32::try_from(lhs.len()).unwrap();
     let num_inputs_rhs = u32::try_from(rhs.len()).unwrap();

--- a/tfhe/src/integer/gpu/server_key/radix/tests_unsigned/test_vector_find.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/tests_unsigned/test_vector_find.rs
@@ -1,7 +1,10 @@
+use crate::core_crypto::gpu::vec::GpuIndex;
+use crate::core_crypto::gpu::{get_number_of_gpus, CudaStreams};
+use crate::integer::gpu::ciphertext::CudaUnsignedRadixCiphertext;
 use crate::integer::gpu::server_key::radix::tests_unsigned::{
     create_gpu_parameterized_test, GpuFunctionExecutor,
 };
-use crate::integer::gpu::CudaServerKey;
+use crate::integer::gpu::{gen_keys_gpu, CudaServerKey};
 use crate::integer::server_key::radix_parallel::tests_cases_unsigned::{
     default_contains_clear_test_case, default_contains_test_case,
     default_first_index_in_clears_test_case, default_first_index_of_clear_test_case,
@@ -218,4 +221,46 @@ where
 {
     let executor = GpuFunctionExecutor::new(&CudaServerKey::first_index_of_clear);
     default_first_index_of_clear_test_case(param, executor);
+}
+
+/// Checks that an input list mixing ciphertexts from several GPUs panics
+/// cleanly instead of causing an illegal memory access.
+#[test]
+fn test_gpu_integer_contains_rejects_mixed_gpu_inputs() {
+    if get_number_of_gpus() < 2 {
+        println!("skipping mixed-GPU input test: fewer than 2 GPUs visible");
+        return;
+    }
+
+    let streams0 = CudaStreams::new_single_gpu(GpuIndex::new(0));
+    let streams1 = CudaStreams::new_single_gpu(GpuIndex::new(1));
+    let (cks, sks) = gen_keys_gpu(PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128, &streams0);
+
+    let num_blocks = 4;
+    let d_value = CudaUnsignedRadixCiphertext::from_radix_ciphertext(
+        &cks.encrypt_radix(3u32, num_blocks),
+        &streams0,
+    );
+
+    let mut cts: Vec<CudaUnsignedRadixCiphertext> = (0..3u32)
+        .map(|m| {
+            CudaUnsignedRadixCiphertext::from_radix_ciphertext(
+                &cks.encrypt_radix(m, num_blocks),
+                &streams0,
+            )
+        })
+        .collect();
+    // This input lives on GPU 1 while the computation runs on GPU 0
+    cts.push(CudaUnsignedRadixCiphertext::from_radix_ciphertext(
+        &cks.encrypt_radix(3u32, num_blocks),
+        &streams1,
+    ));
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        sks.unchecked_contains(&cts, &d_value, &streams0)
+    }));
+    assert!(
+        result.is_err(),
+        "contains must reject an input list mixing ciphertexts from several GPUs"
+    );
 }


### PR DESCRIPTION
```
Fix 1 — one-block ilog2 (oob-write)

    ilog2(1-block ct)
        │
        ▼
    BEFORE: sum_input_cts allocated for (input_num_blocks + 1) = 2 cts
        │
        ▼
    final sum of 3 cts:        ┌──────┬──────┬──────────────┐
    (message_not, carry,       │ ct 1 │ ct 2 │ × ct 3 past  │
     trivial_2)                └──────┴──────┴── buffer ────┘
                                        out-of-bounds write

    AFTER: allocated for max(input_num_blocks + 1, 3) cts
                               ┌──────┬──────┬──────┐
                               │ ct 1 │ ct 2 │ ct 3 │  ✓
                               └──────┴──────┴──────┘

    + guard: reverse_inplace is a no-op below 2 blocks


Fix 2 — vector find with a mixed-GPU list (oob-read)

    contains([ct₀ GPU0, ct₁ GPU0, ct₂ GPU1], value, streams GPU0)
        │
        ▼
    BEFORE: Rust FFI does not check the list elements
        │
        ▼
    kernel on GPU0 reads *ct₂ (GPU1 address)  ×
    → CUDA_ERROR_ILLEGAL_ADDRESS, poisoned context, abort

    AFTER: assert_all_inputs_are_on_same_gpu
        │
        ▼
    panic! "GPU error: all data should reside on the same GPU."  ✓
    (clean rejection before any kernel launch)
```