### PR TITLE
chore(ci): fixing memory sanitizer gpu workflow

### DIFF
--- a/tfhe/src/high_level_api/compressed_noise_squashed_ciphertext_list.rs
+++ b/tfhe/src/high_level_api/compressed_noise_squashed_ciphertext_list.rs
@@ -626,6 +626,8 @@ impl CompressedSquashedNoiseCiphertextListBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "gpu")]
+    use crate::high_level_api::tests::is_sanitizer_run;
     use crate::prelude::*;
     use crate::safe_serialization::{safe_deserialize, safe_serialize};
     use crate::shortint::parameters::current_params::*;
@@ -754,6 +756,10 @@ mod tests {
     #[test]
     #[cfg(feature = "gpu")]
     fn test_gpu_compressed_squashed_noise_ciphertext_list_multibit() {
+        if is_sanitizer_run() {
+            return;
+        }
+
         let params = V1_7_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
         let noise_squashing_params =
             V1_7_NOISE_SQUASHING_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;

--- a/tfhe/src/high_level_api/integers/shuffle.rs
+++ b/tfhe/src/high_level_api/integers/shuffle.rs
@@ -144,9 +144,7 @@ mod test {
     use std::fmt::Debug;
 
     #[cfg(feature = "gpu")]
-    fn is_sanitizer_run() -> bool {
-        std::env::var("TFHE_RS_COMPUTE_SANITIZER").is_ok_and(|v| v == "1")
-    }
+    use crate::high_level_api::tests::is_sanitizer_run;
 
     #[test]
     fn test_bitonic_shuffle_fheuint() {

--- a/tfhe/src/high_level_api/tests/mod.rs
+++ b/tfhe/src/high_level_api/tests/mod.rs
@@ -37,6 +37,11 @@ pub(crate) fn setup_default_cpu() -> ClientKey {
     setup_cpu(Option::<ClassicPBSParameters>::None)
 }
 
+#[cfg(feature = "gpu")]
+pub(crate) fn is_sanitizer_run() -> bool {
+    std::env::var("TFHE_RS_COMPUTE_SANITIZER").is_ok_and(|v| v == "1")
+}
+
 fn assert_that_public_key_encryption_is_decrypted_by_client_key<FheType, ClearType>(
     clear: ClearType,
     pks: &PublicKey,

--- a/tfhe/src/high_level_api/tests/noise_squashing.rs
+++ b/tfhe/src/high_level_api/tests/noise_squashing.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "gpu")]
+use super::is_sanitizer_run;
 use crate::high_level_api::prelude::*;
 use crate::high_level_api::{
     generate_keys, ConfigBuilder, FheBool, FheInt10, FheInt8, FheUint256, FheUint32,
@@ -81,10 +83,14 @@ fn test_noise_squashing() {
 #[cfg(feature = "gpu")]
 #[test]
 fn test_gpu_noise_squashing() {
-    let noise_squashing_params = [
-        NOISE_SQUASHING_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
-        NOISE_SQUASHING_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
-    ];
+    let noise_squashing_params = if is_sanitizer_run() {
+        vec![NOISE_SQUASHING_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128]
+    } else {
+        vec![
+            NOISE_SQUASHING_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+            NOISE_SQUASHING_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+        ]
+    };
 
     for noise_squashing_param in noise_squashing_params {
         let config = ConfigBuilder::with_custom_parameters(
@@ -97,15 +103,16 @@ fn test_gpu_noise_squashing() {
 
         let mut rng = thread_rng();
 
-        // Non native type for clear
-        let clear: U256 = rng.gen();
-        let enc = FheUint256::encrypt(clear, &cks);
-        let bitand = &enc & &enc;
+        if !is_sanitizer_run() {
+            let clear: U256 = rng.gen();
+            let enc = FheUint256::encrypt(clear, &cks);
+            let bitand = &enc & &enc;
 
-        let squashed = bitand.squash_noise().unwrap();
+            let squashed = bitand.squash_noise().unwrap();
 
-        let recovered: U256 = squashed.decrypt(&cks);
-        assert_eq!(clear, recovered);
+            let recovered: U256 = squashed.decrypt(&cks);
+            assert_eq!(clear, recovered);
+        }
 
         // Native unsigned
         let clear: u32 = rng.gen();


### PR DESCRIPTION
* Share `is_sanitizer_run()` as a helper function in `high_level_api::tests`
* Limit `test_gpu_noise_squashing` under the sanitizer to run with a single parameter set (excluding the FheUint256 case)
* Skip the compressed-list multibit variant when running under the sanitizer