### PR TITLE
fix(gpu): optimize CI to parallelize on 2x gpu

### DIFF
--- a/.github/workflows/gpu_core_h100_tests.yml
+++ b/.github/workflows/gpu_core_h100_tests.yml
@@ -20,11 +20,7 @@ env:
   EXTERNAL_CONTRIBUTION_RUNNER: "gpu_ubuntu-22.04"
 
 on:
-  # Allows you to run this workflow manually from the Actions tab as an alternative.
   workflow_dispatch:
-  pull_request:
-  schedule:
-    - cron: "0 1 * * MON-FRI"
 
 permissions:
   contents: read

--- a/.github/workflows/gpu_core_hlapi_h100_2gpu_par.yml
+++ b/.github/workflows/gpu_core_hlapi_h100_2gpu_par.yml
@@ -1,5 +1,5 @@
-# Compile and test tfhe-cuda-backend on an H100 VM on hyperstack
-name: gpu_hlapi_h100_tests
+# Run core crypto + CUDA backend tests and HLAPI tests in parallel on a 2xH100 machine
+name: gpu_core_hlapi_h100_2gpu_par
 
 env:
   CARGO_TERM_COLOR: always
@@ -15,12 +15,13 @@ env:
   IS_PULL_REQUEST: ${{ github.event_name == 'pull_request' }}
   PULL_REQUEST_MD_LINK: ""
   CHECKOUT_TOKEN: ${{ secrets.REPO_CHECKOUT_TOKEN || secrets.GITHUB_TOKEN }}
-  # Secrets will be available only to zama-ai organization members
   SECRETS_AVAILABLE: ${{ secrets.JOB_SECRET != '' }}
   EXTERNAL_CONTRIBUTION_RUNNER: "gpu_ubuntu-22.04"
 
 on:
   workflow_dispatch:
+  pull_request:
+    types: [ labeled ]
 
 permissions:
   contents: read
@@ -29,13 +30,12 @@ permissions:
 
 jobs:
   should-run:
-    name: gpu_hlapi_h100_tests/should-run
+    name: gpu_core_hlapi_h100_2gpu_par/should-run
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read  # Needed to check for file change
     outputs:
       gpu_test: ${{ env.IS_PULL_REQUEST == 'false' || steps.changed-files.outputs.gpu_any_changed }}
-      core_crypto_changed: ${{ steps.changed-files.outputs.core_crypto_any_changed }}
     steps:
       - name: Checkout tfhe-rs
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
@@ -62,18 +62,15 @@ jobs:
               - tfhe/src/high_level_api/**
               - tfhe/src/c_api/**
               - 'tfhe/docs/**/**.md'
-              - '.github/workflows/gpu_hlapi_h100_tests.yml'
+              - '.github/workflows/gpu_core_hlapi_h100_2gpu_par.yml'
               - '.github/actions/gpu_setup/action.yml'
               - ci/slab.toml
-            core_crypto:
-              - tfhe/src/core_crypto/gpu/**
 
   setup-instance:
-    name: gpu_hlapi_h100_tests/setup-instance
+    name: gpu_core_hlapi_h100_2gpu_par/setup-instance
     needs: should-run
     if: github.event_name != 'pull_request' ||
-      (github.event.action == 'labeled' && github.event.label.name == 'approved' && needs.should-run.outputs.gpu_test == 'true') ||
-      (github.event.action != 'labeled' && needs.should-run.outputs.core_crypto_changed == 'true')
+      (github.event.action == 'labeled' && github.event.label.name == 'approved' && needs.should-run.outputs.gpu_test == 'true')
     runs-on: ubuntu-latest
     outputs:
       runner-name: ${{ steps.start-remote-instance.outputs.label || steps.start-github-instance.outputs.runner_group }}
@@ -89,9 +86,8 @@ jobs:
           slab-url: ${{ secrets.SLAB_BASE_URL }}
           job-secret: ${{ secrets.JOB_SECRET }}
           backend: terraform
-          profile: scaleway-single-h100-tests
+          profile: scaleway-2-h100-sxm5-tests
 
-      # This instance will be spawned especially for pull-request from forked repository
       - name: Start GitHub instance
         id: start-github-instance
         if: env.SECRETS_AVAILABLE == 'false'
@@ -102,7 +98,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
   cuda-tests-linux:
-    name: gpu_hlapi_h100_tests/cuda-tests-linux
+    name: gpu_core_hlapi_h100_2gpu_par/cuda-tests-linux
     needs: [ should-run, setup-instance ]
     if: github.event_name != 'pull_request' ||
       (github.event_name == 'pull_request' && needs.setup-instance.result != 'skipped')
@@ -112,12 +108,11 @@ jobs:
     runs-on: ${{ needs.setup-instance.outputs.runner-name }}
     strategy:
       fail-fast: false
-      # explicit include-based build matrix, of known valid options
       matrix:
         include:
           - os: ubuntu-22.04
             cuda: "12.8 12.2"
-            gcc: 12 
+            gcc: 12
     steps:
       - name: Checkout tfhe-rs
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
@@ -136,24 +131,58 @@ jobs:
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # zizmor: ignore[stale-action-refs] this action doesn't create releases
         with:
           toolchain: stable
+
+      - name: Check GPU count
+        run: |
+          GPU_COUNT=$(nvidia-smi --query-gpu=name --format=csv,noheader | wc -l)
+          echo "Found ${GPU_COUNT} GPU(s)"
+          [ "${GPU_COUNT}" -ge 2 ] || { echo "Error: at least 2 GPUs required"; exit 1; }
+
       - name: Enable nvidia multi-process service
         run: |
           nvidia-cuda-mps-control -d
-      
-      - name: Run user docs tests
-        run: |
-          BIG_TESTS_INSTANCE=TRUE make test_user_doc_gpu
 
-      - name: Test C API
-        run: |
-          BIG_TESTS_INSTANCE=TRUE make test_c_api_gpu
+      - name: Install cargo-nextest
+        run: make install_cargo_nextest
 
-      - name: Run High Level API Tests
+      - name: Run core crypto and HLAPI tests in parallel
         run: |
-          BIG_TESTS_INSTANCE=TRUE make test_high_level_api_gpu
+          run_core() {
+            local rc=0
+            CUDA_VISIBLE_DEVICES=0 BIG_TESTS_INSTANCE=TRUE make test_core_crypto_gpu &&
+            CUDA_VISIBLE_DEVICES=0 BIG_TESTS_INSTANCE=TRUE make test_integer_compression_gpu &&
+            CUDA_VISIBLE_DEVICES=0 BIG_TESTS_INSTANCE=TRUE make test_cuda_backend || rc=$?
+            echo "${rc}" > /tmp/core.rc
+          }
+          run_hlapi() {
+            local rc=0
+            CUDA_VISIBLE_DEVICES=1 BIG_TESTS_INSTANCE=TRUE make test_user_doc_gpu &&
+            CUDA_VISIBLE_DEVICES=1 BIG_TESTS_INSTANCE=TRUE make test_c_api_gpu &&
+            CUDA_VISIBLE_DEVICES=1 BIG_TESTS_INSTANCE=TRUE make test_high_level_api_gpu || rc=$?
+            echo "${rc}" > /tmp/hlapi.rc
+          }
+          run_core 2>&1 | sed -u 's/^/[core]  /' &
+          PID0=$!
+          run_hlapi 2>&1 | sed -u 's/^/[hlapi] /' &
+          PID1=$!
+          wait "${PID0}" || true
+          wait "${PID1}" || true
+
+          STATUS=0
+          for lane in core hlapi; do
+            rc="$(cat "/tmp/${lane}.rc" 2>/dev/null || true)"
+            rc="${rc:-1}"
+            if [ "${rc}" -eq 0 ]; then
+              echo "${lane} tests passed"
+            else
+              echo "::error title=${lane} GPU tests::exited with code ${rc}, see the lines prefixed with [${lane}] above"
+              STATUS=1
+            fi
+          done
+          exit "${STATUS}"
 
   slack-notify:
-    name: gpu_hlapi_h100_tests/slack-notify
+    name: gpu_core_hlapi_h100_2gpu_par/slack-notify
     needs: [ setup-instance, cuda-tests-linux ]
     runs-on: ubuntu-latest
     if: ${{ always() && needs.cuda-tests-linux.result != 'skipped' && failure() }}
@@ -172,10 +201,10 @@ jobs:
         uses: rtCamp/action-slack-notify@33ca3be66c6f378fe1610fd1d5258632dbed5e58
         env:
           SLACK_COLOR: ${{ needs.cuda-tests-linux.result }}
-          SLACK_MESSAGE: "HL API H100 tests finished with status: ${{ needs.cuda-tests-linux.result }}. (${{ env.PULL_REQUEST_MD_LINK }}[action run](${{ env.ACTION_RUN_URL }}))"
+          SLACK_MESSAGE: "Core + HLAPI GPU H100 2-GPU parallel tests finished with status: ${{ needs.cuda-tests-linux.result }}. (${{ env.PULL_REQUEST_MD_LINK }}[action run](${{ env.ACTION_RUN_URL }}))"
 
   teardown-instance:
-    name: gpu_hlapi_h100_tests/teardown-instance
+    name: gpu_core_hlapi_h100_2gpu_par/teardown-instance
     if: ${{ always() && needs.setup-instance.result == 'success' }}
     needs: [ setup-instance, cuda-tests-linux ]
     runs-on: ubuntu-latest
@@ -196,4 +225,4 @@ jobs:
         uses: rtCamp/action-slack-notify@33ca3be66c6f378fe1610fd1d5258632dbed5e58
         env:
           SLACK_COLOR: ${{ job.status }}
-          SLACK_MESSAGE: "Instance teardown (cuda-h100-tests) finished with status: ${{ job.status }}. (${{ env.ACTION_RUN_URL }})"
+          SLACK_MESSAGE: "Instance teardown (gpu_core_hlapi_h100_2gpu_par) finished with status: ${{ job.status }}. (${{ env.ACTION_RUN_URL }})"

--- a/.github/workflows/gpu_core_hlapi_h100_2gpu_par.yml
+++ b/.github/workflows/gpu_core_hlapi_h100_2gpu_par.yml
@@ -1,5 +1,5 @@
-# Compile and test tfhe-cuda-backend on an H100 VM on hyperstack
-name: gpu_hlapi_h100_tests
+# Run core crypto + CUDA backend tests and HLAPI tests in parallel on a 2xH100 machine
+name: gpu_core_hlapi_h100_2gpu_par
 
 env:
   CARGO_TERM_COLOR: always
@@ -15,12 +15,13 @@ env:
   IS_PULL_REQUEST: ${{ github.event_name == 'pull_request' }}
   PULL_REQUEST_MD_LINK: ""
   CHECKOUT_TOKEN: ${{ secrets.REPO_CHECKOUT_TOKEN || secrets.GITHUB_TOKEN }}
-  # Secrets will be available only to zama-ai organization members
   SECRETS_AVAILABLE: ${{ secrets.JOB_SECRET != '' }}
   EXTERNAL_CONTRIBUTION_RUNNER: "gpu_ubuntu-22.04"
 
 on:
   workflow_dispatch:
+  pull_request:
+    types: [ labeled ]
 
 permissions:
   contents: read
@@ -29,7 +30,7 @@ permissions:
 
 jobs:
   should-run:
-    name: gpu_hlapi_h100_tests/should-run
+    name: gpu_core_hlapi_h100_2gpu_par/should-run
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read  # Needed to check for file change
@@ -62,18 +63,18 @@ jobs:
               - tfhe/src/high_level_api/**
               - tfhe/src/c_api/**
               - 'tfhe/docs/**/**.md'
-              - '.github/workflows/gpu_hlapi_h100_tests.yml'
+              - '.github/workflows/gpu_core_hlapi_h100_2gpu_par.yml'
               - '.github/actions/gpu_setup/action.yml'
               - ci/slab.toml
             core_crypto:
               - tfhe/src/core_crypto/gpu/**
 
   setup-instance:
-    name: gpu_hlapi_h100_tests/setup-instance
+    name: gpu_core_hlapi_h100_2gpu_par/setup-instance
     needs: should-run
     if: github.event_name != 'pull_request' ||
-      (github.event.action == 'labeled' && github.event.label.name == 'approved' && needs.should-run.outputs.gpu_test == 'true') ||
-      (github.event.action != 'labeled' && needs.should-run.outputs.core_crypto_changed == 'true')
+      (github.event.action != 'labeled' && needs.should-run.outputs.core_crypto_changed == 'true') ||
+      (github.event.action == 'labeled' && github.event.label.name == 'approved' && needs.should-run.outputs.gpu_test == 'true')
     runs-on: ubuntu-latest
     outputs:
       runner-name: ${{ steps.start-remote-instance.outputs.label || steps.start-github-instance.outputs.runner_group }}
@@ -89,9 +90,8 @@ jobs:
           slab-url: ${{ secrets.SLAB_BASE_URL }}
           job-secret: ${{ secrets.JOB_SECRET }}
           backend: terraform
-          profile: scaleway-single-h100-tests
+          profile: scaleway-2-h100-sxm5-tests
 
-      # This instance will be spawned especially for pull-request from forked repository
       - name: Start GitHub instance
         id: start-github-instance
         if: env.SECRETS_AVAILABLE == 'false'
@@ -102,7 +102,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
   cuda-tests-linux:
-    name: gpu_hlapi_h100_tests/cuda-tests-linux
+    name: gpu_core_hlapi_h100_2gpu_par/cuda-tests-linux
     needs: [ should-run, setup-instance ]
     if: github.event_name != 'pull_request' ||
       (github.event_name == 'pull_request' && needs.setup-instance.result != 'skipped')
@@ -112,12 +112,11 @@ jobs:
     runs-on: ${{ needs.setup-instance.outputs.runner-name }}
     strategy:
       fail-fast: false
-      # explicit include-based build matrix, of known valid options
       matrix:
         include:
           - os: ubuntu-22.04
             cuda: "12.8 12.2"
-            gcc: 12 
+            gcc: 12
     steps:
       - name: Checkout tfhe-rs
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
@@ -136,24 +135,44 @@ jobs:
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # zizmor: ignore[stale-action-refs] this action doesn't create releases
         with:
           toolchain: stable
+
+      - name: Check GPU count
+        run: |
+          GPU_COUNT=$(nvidia-smi --query-gpu=name --format=csv,noheader | wc -l)
+          echo "Found ${GPU_COUNT} GPU(s)"
+          [ "${GPU_COUNT}" -ge 2 ] || { echo "Error: at least 2 GPUs required"; exit 1; }
+
       - name: Enable nvidia multi-process service
         run: |
           nvidia-cuda-mps-control -d
-      
-      - name: Run user docs tests
-        run: |
-          BIG_TESTS_INSTANCE=TRUE make test_user_doc_gpu
 
-      - name: Test C API
-        run: |
-          BIG_TESTS_INSTANCE=TRUE make test_c_api_gpu
+      - name: Install cargo-nextest
+        run: make install_cargo_nextest
 
-      - name: Run High Level API Tests
+      - name: Run core crypto and HLAPI tests in parallel
         run: |
-          BIG_TESTS_INSTANCE=TRUE make test_high_level_api_gpu
+          (
+            CUDA_VISIBLE_DEVICES=0 BIG_TESTS_INSTANCE=TRUE make test_core_crypto_gpu &&
+            CUDA_VISIBLE_DEVICES=0 BIG_TESTS_INSTANCE=TRUE make test_integer_compression_gpu &&
+            CUDA_VISIBLE_DEVICES=0 BIG_TESTS_INSTANCE=TRUE make test_cuda_backend
+          ) > /tmp/gpu0.log 2>&1 &
+          PID0=$!
+          (
+            CUDA_VISIBLE_DEVICES=1 BIG_TESTS_INSTANCE=TRUE make test_user_doc_gpu &&
+            CUDA_VISIBLE_DEVICES=1 BIG_TESTS_INSTANCE=TRUE make test_c_api_gpu &&
+            CUDA_VISIBLE_DEVICES=1 BIG_TESTS_INSTANCE=TRUE make test_high_level_api_gpu
+          ) > /tmp/gpu1.log 2>&1 &
+          PID1=$!
+          wait $PID0; RC0=$?
+          wait $PID1; RC1=$?
+          echo "=== GPU 0: core crypto + compression + cuda backend ==="
+          cat /tmp/gpu0.log
+          echo "=== GPU 1: user doc + C API + high level API ==="
+          cat /tmp/gpu1.log
+          [ $RC0 -eq 0 ] && [ $RC1 -eq 0 ]
 
   slack-notify:
-    name: gpu_hlapi_h100_tests/slack-notify
+    name: gpu_core_hlapi_h100_2gpu_par/slack-notify
     needs: [ setup-instance, cuda-tests-linux ]
     runs-on: ubuntu-latest
     if: ${{ always() && needs.cuda-tests-linux.result != 'skipped' && failure() }}
@@ -172,10 +191,10 @@ jobs:
         uses: rtCamp/action-slack-notify@33ca3be66c6f378fe1610fd1d5258632dbed5e58
         env:
           SLACK_COLOR: ${{ needs.cuda-tests-linux.result }}
-          SLACK_MESSAGE: "HL API H100 tests finished with status: ${{ needs.cuda-tests-linux.result }}. (${{ env.PULL_REQUEST_MD_LINK }}[action run](${{ env.ACTION_RUN_URL }}))"
+          SLACK_MESSAGE: "Core + HLAPI GPU H100 2-GPU parallel tests finished with status: ${{ needs.cuda-tests-linux.result }}. (${{ env.PULL_REQUEST_MD_LINK }}[action run](${{ env.ACTION_RUN_URL }}))"
 
   teardown-instance:
-    name: gpu_hlapi_h100_tests/teardown-instance
+    name: gpu_core_hlapi_h100_2gpu_par/teardown-instance
     if: ${{ always() && needs.setup-instance.result == 'success' }}
     needs: [ setup-instance, cuda-tests-linux ]
     runs-on: ubuntu-latest
@@ -196,4 +215,4 @@ jobs:
         uses: rtCamp/action-slack-notify@33ca3be66c6f378fe1610fd1d5258632dbed5e58
         env:
           SLACK_COLOR: ${{ job.status }}
-          SLACK_MESSAGE: "Instance teardown (cuda-h100-tests) finished with status: ${{ job.status }}. (${{ env.ACTION_RUN_URL }})"
+          SLACK_MESSAGE: "Instance teardown (gpu_core_hlapi_h100_2gpu_par) finished with status: ${{ job.status }}. (${{ env.ACTION_RUN_URL }})"

--- a/.github/workflows/gpu_integer_classic_tests_h100_2gpu_par.yml
+++ b/.github/workflows/gpu_integer_classic_tests_h100_2gpu_par.yml
@@ -1,5 +1,5 @@
-# Compile and test tfhe-cuda-backend on an H100 VM on hyperstack
-name: gpu_hlapi_h100_tests
+# Run signed and unsigned integer GPU classic tests in parallel on a 2xH100 machine
+name: gpu_integer_classic_tests_h100_2gpu_par
 
 env:
   CARGO_TERM_COLOR: always
@@ -15,12 +15,13 @@ env:
   IS_PULL_REQUEST: ${{ github.event_name == 'pull_request' }}
   PULL_REQUEST_MD_LINK: ""
   CHECKOUT_TOKEN: ${{ secrets.REPO_CHECKOUT_TOKEN || secrets.GITHUB_TOKEN }}
-  # Secrets will be available only to zama-ai organization members
   SECRETS_AVAILABLE: ${{ secrets.JOB_SECRET != '' }}
   EXTERNAL_CONTRIBUTION_RUNNER: "gpu_ubuntu-22.04"
 
 on:
   workflow_dispatch:
+  pull_request:
+    types: [ labeled ]
 
 permissions:
   contents: read
@@ -29,7 +30,7 @@ permissions:
 
 jobs:
   should-run:
-    name: gpu_hlapi_h100_tests/should-run
+    name: gpu_integer_classic_tests_h100_2gpu_par/should-run
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read  # Needed to check for file change
@@ -54,26 +55,26 @@ jobs:
               - tfhe/build.rs
               - backends/tfhe-cuda-backend/**
               - tfhe/src/core_crypto/gpu/**
-              - tfhe/src/integer/gpu/**
               - tfhe/src/integer/server_key/radix_parallel/tests_unsigned/**
               - tfhe/src/integer/server_key/radix_parallel/tests_signed/**
               - tfhe/src/integer/server_key/radix_parallel/tests_cases_unsigned.rs
+              - tfhe/src/integer/gpu/**
               - tfhe/src/shortint/parameters/**
               - tfhe/src/high_level_api/**
               - tfhe/src/c_api/**
-              - 'tfhe/docs/**/**.md'
-              - '.github/workflows/gpu_hlapi_h100_tests.yml'
+              - '.github/workflows/gpu_integer_classic_tests_h100_2gpu_par.yml'
+              - scripts/integer-tests.sh
               - '.github/actions/gpu_setup/action.yml'
               - ci/slab.toml
             core_crypto:
               - tfhe/src/core_crypto/gpu/**
 
   setup-instance:
-    name: gpu_hlapi_h100_tests/setup-instance
+    name: gpu_integer_classic_tests_h100_2gpu_par/setup-instance
     needs: should-run
     if: github.event_name != 'pull_request' ||
-      (github.event.action == 'labeled' && github.event.label.name == 'approved' && needs.should-run.outputs.gpu_test == 'true') ||
-      (github.event.action != 'labeled' && needs.should-run.outputs.core_crypto_changed == 'true')
+      (github.event.action != 'labeled' && needs.should-run.outputs.core_crypto_changed == 'true') ||
+      (github.event.action == 'labeled' && github.event.label.name == 'approved' && needs.should-run.outputs.gpu_test == 'true')
     runs-on: ubuntu-latest
     outputs:
       runner-name: ${{ steps.start-remote-instance.outputs.label || steps.start-github-instance.outputs.runner_group }}
@@ -89,9 +90,8 @@ jobs:
           slab-url: ${{ secrets.SLAB_BASE_URL }}
           job-secret: ${{ secrets.JOB_SECRET }}
           backend: terraform
-          profile: scaleway-single-h100-tests
+          profile: scaleway-2-h100-sxm5-tests
 
-      # This instance will be spawned especially for pull-request from forked repository
       - name: Start GitHub instance
         id: start-github-instance
         if: env.SECRETS_AVAILABLE == 'false'
@@ -102,7 +102,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
   cuda-tests-linux:
-    name: gpu_hlapi_h100_tests/cuda-tests-linux
+    name: gpu_integer_classic_tests_h100_2gpu_par/cuda-tests-linux
     needs: [ should-run, setup-instance ]
     if: github.event_name != 'pull_request' ||
       (github.event_name == 'pull_request' && needs.setup-instance.result != 'skipped')
@@ -112,12 +112,11 @@ jobs:
     runs-on: ${{ needs.setup-instance.outputs.runner-name }}
     strategy:
       fail-fast: false
-      # explicit include-based build matrix, of known valid options
       matrix:
         include:
           - os: ubuntu-22.04
             cuda: "12.8 12.2"
-            gcc: 12 
+            gcc: 12
     steps:
       - name: Checkout tfhe-rs
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
@@ -136,24 +135,38 @@ jobs:
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # zizmor: ignore[stale-action-refs] this action doesn't create releases
         with:
           toolchain: stable
+
+      - name: Check GPU count
+        run: |
+          GPU_COUNT=$(nvidia-smi --query-gpu=name --format=csv,noheader | wc -l)
+          echo "Found ${GPU_COUNT} GPU(s)"
+          [ "${GPU_COUNT}" -ge 2 ] || { echo "Error: at least 2 GPUs required"; exit 1; }
+
       - name: Enable nvidia multi-process service
         run: |
           nvidia-cuda-mps-control -d
-      
-      - name: Run user docs tests
-        run: |
-          BIG_TESTS_INSTANCE=TRUE make test_user_doc_gpu
 
-      - name: Test C API
-        run: |
-          BIG_TESTS_INSTANCE=TRUE make test_c_api_gpu
+      - name: Install cargo-nextest
+        run: make install_cargo_nextest
 
-      - name: Run High Level API Tests
+      - name: Run signed and unsigned integer classic tests in parallel
         run: |
-          BIG_TESTS_INSTANCE=TRUE make test_high_level_api_gpu
+          CUDA_VISIBLE_DEVICES=0 BIG_TESTS_INSTANCE=TRUE make test_signed_integer_gpu_ci \
+            > /tmp/gpu0.log 2>&1 &
+          PID0=$!
+          CUDA_VISIBLE_DEVICES=1 BIG_TESTS_INSTANCE=TRUE make test_unsigned_integer_gpu_ci \
+            > /tmp/gpu1.log 2>&1 &
+          PID1=$!
+          wait $PID0; RC0=$?
+          wait $PID1; RC1=$?
+          echo "=== GPU 0: signed integer ==="
+          cat /tmp/gpu0.log
+          echo "=== GPU 1: unsigned integer ==="
+          cat /tmp/gpu1.log
+          [ $RC0 -eq 0 ] && [ $RC1 -eq 0 ]
 
   slack-notify:
-    name: gpu_hlapi_h100_tests/slack-notify
+    name: gpu_integer_classic_tests_h100_2gpu_par/slack-notify
     needs: [ setup-instance, cuda-tests-linux ]
     runs-on: ubuntu-latest
     if: ${{ always() && needs.cuda-tests-linux.result != 'skipped' && failure() }}
@@ -172,10 +185,10 @@ jobs:
         uses: rtCamp/action-slack-notify@33ca3be66c6f378fe1610fd1d5258632dbed5e58
         env:
           SLACK_COLOR: ${{ needs.cuda-tests-linux.result }}
-          SLACK_MESSAGE: "HL API H100 tests finished with status: ${{ needs.cuda-tests-linux.result }}. (${{ env.PULL_REQUEST_MD_LINK }}[action run](${{ env.ACTION_RUN_URL }}))"
+          SLACK_MESSAGE: "Integer GPU H100 2-GPU parallel classic tests finished with status: ${{ needs.cuda-tests-linux.result }}. (${{ env.PULL_REQUEST_MD_LINK }}[action run](${{ env.ACTION_RUN_URL }}))"
 
   teardown-instance:
-    name: gpu_hlapi_h100_tests/teardown-instance
+    name: gpu_integer_classic_tests_h100_2gpu_par/teardown-instance
     if: ${{ always() && needs.setup-instance.result == 'success' }}
     needs: [ setup-instance, cuda-tests-linux ]
     runs-on: ubuntu-latest
@@ -196,4 +209,4 @@ jobs:
         uses: rtCamp/action-slack-notify@33ca3be66c6f378fe1610fd1d5258632dbed5e58
         env:
           SLACK_COLOR: ${{ job.status }}
-          SLACK_MESSAGE: "Instance teardown (cuda-h100-tests) finished with status: ${{ job.status }}. (${{ env.ACTION_RUN_URL }})"
+          SLACK_MESSAGE: "Instance teardown (gpu_integer_classic_tests_h100_2gpu_par) finished with status: ${{ job.status }}. (${{ env.ACTION_RUN_URL }})"

--- a/.github/workflows/gpu_integer_classic_tests_h100_2gpu_par.yml
+++ b/.github/workflows/gpu_integer_classic_tests_h100_2gpu_par.yml
@@ -1,5 +1,5 @@
-# Compile and test tfhe-cuda-backend on an H100 VM on hyperstack
-name: gpu_hlapi_h100_tests
+# Run signed and unsigned integer GPU classic tests in parallel on a 2xH100 machine
+name: gpu_integer_classic_tests_h100_2gpu_par
 
 env:
   CARGO_TERM_COLOR: always
@@ -15,12 +15,13 @@ env:
   IS_PULL_REQUEST: ${{ github.event_name == 'pull_request' }}
   PULL_REQUEST_MD_LINK: ""
   CHECKOUT_TOKEN: ${{ secrets.REPO_CHECKOUT_TOKEN || secrets.GITHUB_TOKEN }}
-  # Secrets will be available only to zama-ai organization members
   SECRETS_AVAILABLE: ${{ secrets.JOB_SECRET != '' }}
   EXTERNAL_CONTRIBUTION_RUNNER: "gpu_ubuntu-22.04"
 
 on:
   workflow_dispatch:
+  pull_request:
+    types: [ labeled ]
 
 permissions:
   contents: read
@@ -29,13 +30,12 @@ permissions:
 
 jobs:
   should-run:
-    name: gpu_hlapi_h100_tests/should-run
+    name: gpu_integer_classic_tests_h100_2gpu_par/should-run
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read  # Needed to check for file change
     outputs:
       gpu_test: ${{ env.IS_PULL_REQUEST == 'false' || steps.changed-files.outputs.gpu_any_changed }}
-      core_crypto_changed: ${{ steps.changed-files.outputs.core_crypto_any_changed }}
     steps:
       - name: Checkout tfhe-rs
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
@@ -54,26 +54,23 @@ jobs:
               - tfhe/build.rs
               - backends/tfhe-cuda-backend/**
               - tfhe/src/core_crypto/gpu/**
-              - tfhe/src/integer/gpu/**
               - tfhe/src/integer/server_key/radix_parallel/tests_unsigned/**
               - tfhe/src/integer/server_key/radix_parallel/tests_signed/**
               - tfhe/src/integer/server_key/radix_parallel/tests_cases_unsigned.rs
+              - tfhe/src/integer/gpu/**
               - tfhe/src/shortint/parameters/**
               - tfhe/src/high_level_api/**
               - tfhe/src/c_api/**
-              - 'tfhe/docs/**/**.md'
-              - '.github/workflows/gpu_hlapi_h100_tests.yml'
+              - '.github/workflows/gpu_integer_classic_tests_h100_2gpu_par.yml'
+              - scripts/integer-tests.sh
               - '.github/actions/gpu_setup/action.yml'
               - ci/slab.toml
-            core_crypto:
-              - tfhe/src/core_crypto/gpu/**
 
   setup-instance:
-    name: gpu_hlapi_h100_tests/setup-instance
+    name: gpu_integer_classic_tests_h100_2gpu_par/setup-instance
     needs: should-run
     if: github.event_name != 'pull_request' ||
-      (github.event.action == 'labeled' && github.event.label.name == 'approved' && needs.should-run.outputs.gpu_test == 'true') ||
-      (github.event.action != 'labeled' && needs.should-run.outputs.core_crypto_changed == 'true')
+      (github.event.action == 'labeled' && github.event.label.name == 'approved' && needs.should-run.outputs.gpu_test == 'true')
     runs-on: ubuntu-latest
     outputs:
       runner-name: ${{ steps.start-remote-instance.outputs.label || steps.start-github-instance.outputs.runner_group }}
@@ -89,9 +86,8 @@ jobs:
           slab-url: ${{ secrets.SLAB_BASE_URL }}
           job-secret: ${{ secrets.JOB_SECRET }}
           backend: terraform
-          profile: scaleway-single-h100-tests
+          profile: scaleway-2-h100-sxm5-tests
 
-      # This instance will be spawned especially for pull-request from forked repository
       - name: Start GitHub instance
         id: start-github-instance
         if: env.SECRETS_AVAILABLE == 'false'
@@ -102,7 +98,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
   cuda-tests-linux:
-    name: gpu_hlapi_h100_tests/cuda-tests-linux
+    name: gpu_integer_classic_tests_h100_2gpu_par/cuda-tests-linux
     needs: [ should-run, setup-instance ]
     if: github.event_name != 'pull_request' ||
       (github.event_name == 'pull_request' && needs.setup-instance.result != 'skipped')
@@ -112,12 +108,11 @@ jobs:
     runs-on: ${{ needs.setup-instance.outputs.runner-name }}
     strategy:
       fail-fast: false
-      # explicit include-based build matrix, of known valid options
       matrix:
         include:
           - os: ubuntu-22.04
             cuda: "12.8 12.2"
-            gcc: 12 
+            gcc: 12
     steps:
       - name: Checkout tfhe-rs
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
@@ -136,24 +131,54 @@ jobs:
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # zizmor: ignore[stale-action-refs] this action doesn't create releases
         with:
           toolchain: stable
+
+      - name: Check GPU count
+        run: |
+          GPU_COUNT=$(nvidia-smi --query-gpu=name --format=csv,noheader | wc -l)
+          echo "Found ${GPU_COUNT} GPU(s)"
+          [ "${GPU_COUNT}" -ge 2 ] || { echo "Error: at least 2 GPUs required"; exit 1; }
+
       - name: Enable nvidia multi-process service
         run: |
           nvidia-cuda-mps-control -d
-      
-      - name: Run user docs tests
-        run: |
-          BIG_TESTS_INSTANCE=TRUE make test_user_doc_gpu
 
-      - name: Test C API
-        run: |
-          BIG_TESTS_INSTANCE=TRUE make test_c_api_gpu
+      - name: Install cargo-nextest
+        run: make install_cargo_nextest
 
-      - name: Run High Level API Tests
+      - name: Run signed and unsigned integer classic tests in parallel
         run: |
-          BIG_TESTS_INSTANCE=TRUE make test_high_level_api_gpu
+          run_signed() {
+            local rc=0
+            CUDA_VISIBLE_DEVICES=0 BIG_TESTS_INSTANCE=TRUE make test_signed_integer_gpu_ci || rc=$?
+            echo "${rc}" > /tmp/signed.rc
+          }
+          run_unsigned() {
+            local rc=0
+            CUDA_VISIBLE_DEVICES=1 BIG_TESTS_INSTANCE=TRUE make test_unsigned_integer_gpu_ci || rc=$?
+            echo "${rc}" > /tmp/unsigned.rc
+          }
+          run_signed 2>&1 | sed -u 's/^/[signed]   /' &
+          PID0=$!
+          run_unsigned 2>&1 | sed -u 's/^/[unsigned] /' &
+          PID1=$!
+          wait "${PID0}" || true
+          wait "${PID1}" || true
+
+          STATUS=0
+          for lane in signed unsigned; do
+            rc="$(cat "/tmp/${lane}.rc" 2>/dev/null || true)"
+            rc="${rc:-1}"
+            if [ "${rc}" -eq 0 ]; then
+              echo "${lane} integer tests passed"
+            else
+              echo "::error title=${lane} integer GPU tests::exited with code ${rc}, see the lines prefixed with [${lane}] above"
+              STATUS=1
+            fi
+          done
+          exit "${STATUS}"
 
   slack-notify:
-    name: gpu_hlapi_h100_tests/slack-notify
+    name: gpu_integer_classic_tests_h100_2gpu_par/slack-notify
     needs: [ setup-instance, cuda-tests-linux ]
     runs-on: ubuntu-latest
     if: ${{ always() && needs.cuda-tests-linux.result != 'skipped' && failure() }}
@@ -172,10 +197,10 @@ jobs:
         uses: rtCamp/action-slack-notify@33ca3be66c6f378fe1610fd1d5258632dbed5e58
         env:
           SLACK_COLOR: ${{ needs.cuda-tests-linux.result }}
-          SLACK_MESSAGE: "HL API H100 tests finished with status: ${{ needs.cuda-tests-linux.result }}. (${{ env.PULL_REQUEST_MD_LINK }}[action run](${{ env.ACTION_RUN_URL }}))"
+          SLACK_MESSAGE: "Integer GPU H100 2-GPU parallel classic tests finished with status: ${{ needs.cuda-tests-linux.result }}. (${{ env.PULL_REQUEST_MD_LINK }}[action run](${{ env.ACTION_RUN_URL }}))"
 
   teardown-instance:
-    name: gpu_hlapi_h100_tests/teardown-instance
+    name: gpu_integer_classic_tests_h100_2gpu_par/teardown-instance
     if: ${{ always() && needs.setup-instance.result == 'success' }}
     needs: [ setup-instance, cuda-tests-linux ]
     runs-on: ubuntu-latest
@@ -196,4 +221,4 @@ jobs:
         uses: rtCamp/action-slack-notify@33ca3be66c6f378fe1610fd1d5258632dbed5e58
         env:
           SLACK_COLOR: ${{ job.status }}
-          SLACK_MESSAGE: "Instance teardown (cuda-h100-tests) finished with status: ${{ job.status }}. (${{ env.ACTION_RUN_URL }})"
+          SLACK_MESSAGE: "Instance teardown (gpu_integer_classic_tests_h100_2gpu_par) finished with status: ${{ job.status }}. (${{ env.ACTION_RUN_URL }})"

--- a/.github/workflows/gpu_integer_multibit_tests_h100_2gpu_par.yml
+++ b/.github/workflows/gpu_integer_multibit_tests_h100_2gpu_par.yml
@@ -1,5 +1,5 @@
-# Compile and test tfhe-cuda-backend on an H100 VM on hyperstack
-name: gpu_hlapi_h100_tests
+# Run signed and unsigned integer GPU multi-bit tests in parallel on a 2xH100 machine
+name: gpu_integer_multibit_tests_h100_2gpu_par
 
 env:
   CARGO_TERM_COLOR: always
@@ -15,12 +15,13 @@ env:
   IS_PULL_REQUEST: ${{ github.event_name == 'pull_request' }}
   PULL_REQUEST_MD_LINK: ""
   CHECKOUT_TOKEN: ${{ secrets.REPO_CHECKOUT_TOKEN || secrets.GITHUB_TOKEN }}
-  # Secrets will be available only to zama-ai organization members
   SECRETS_AVAILABLE: ${{ secrets.JOB_SECRET != '' }}
   EXTERNAL_CONTRIBUTION_RUNNER: "gpu_ubuntu-22.04"
 
 on:
   workflow_dispatch:
+  pull_request:
+    types: [ labeled ]
 
 permissions:
   contents: read
@@ -29,7 +30,7 @@ permissions:
 
 jobs:
   should-run:
-    name: gpu_hlapi_h100_tests/should-run
+    name: gpu_integer_multibit_tests_h100_2gpu_par/should-run
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read  # Needed to check for file change
@@ -54,26 +55,25 @@ jobs:
               - tfhe/build.rs
               - backends/tfhe-cuda-backend/**
               - tfhe/src/core_crypto/gpu/**
-              - tfhe/src/integer/gpu/**
               - tfhe/src/integer/server_key/radix_parallel/tests_unsigned/**
               - tfhe/src/integer/server_key/radix_parallel/tests_signed/**
               - tfhe/src/integer/server_key/radix_parallel/tests_cases_unsigned.rs
+              - tfhe/src/integer/gpu/**
               - tfhe/src/shortint/parameters/**
               - tfhe/src/high_level_api/**
               - tfhe/src/c_api/**
-              - 'tfhe/docs/**/**.md'
-              - '.github/workflows/gpu_hlapi_h100_tests.yml'
+              - '.github/workflows/gpu_integer_multibit_tests_h100_2gpu_par.yml'
+              - scripts/integer-tests.sh
               - '.github/actions/gpu_setup/action.yml'
               - ci/slab.toml
             core_crypto:
               - tfhe/src/core_crypto/gpu/**
 
   setup-instance:
-    name: gpu_hlapi_h100_tests/setup-instance
+    name: gpu_integer_multibit_tests_h100_2gpu_par/setup-instance
     needs: should-run
     if: github.event_name != 'pull_request' ||
-      (github.event.action == 'labeled' && github.event.label.name == 'approved' && needs.should-run.outputs.gpu_test == 'true') ||
-      (github.event.action != 'labeled' && needs.should-run.outputs.core_crypto_changed == 'true')
+      (github.event.action == 'labeled' && github.event.label.name == 'approved' && needs.should-run.outputs.gpu_test == 'true')
     runs-on: ubuntu-latest
     outputs:
       runner-name: ${{ steps.start-remote-instance.outputs.label || steps.start-github-instance.outputs.runner_group }}
@@ -89,9 +89,8 @@ jobs:
           slab-url: ${{ secrets.SLAB_BASE_URL }}
           job-secret: ${{ secrets.JOB_SECRET }}
           backend: terraform
-          profile: scaleway-single-h100-tests
+          profile: scaleway-2-h100-sxm5-tests
 
-      # This instance will be spawned especially for pull-request from forked repository
       - name: Start GitHub instance
         id: start-github-instance
         if: env.SECRETS_AVAILABLE == 'false'
@@ -102,7 +101,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
   cuda-tests-linux:
-    name: gpu_hlapi_h100_tests/cuda-tests-linux
+    name: gpu_integer_multibit_tests_h100_2gpu_par/cuda-tests-linux
     needs: [ should-run, setup-instance ]
     if: github.event_name != 'pull_request' ||
       (github.event_name == 'pull_request' && needs.setup-instance.result != 'skipped')
@@ -112,12 +111,11 @@ jobs:
     runs-on: ${{ needs.setup-instance.outputs.runner-name }}
     strategy:
       fail-fast: false
-      # explicit include-based build matrix, of known valid options
       matrix:
         include:
           - os: ubuntu-22.04
             cuda: "12.8 12.2"
-            gcc: 12 
+            gcc: 12
     steps:
       - name: Checkout tfhe-rs
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
@@ -136,24 +134,38 @@ jobs:
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # zizmor: ignore[stale-action-refs] this action doesn't create releases
         with:
           toolchain: stable
+
+      - name: Check GPU count
+        run: |
+          GPU_COUNT=$(nvidia-smi --query-gpu=name --format=csv,noheader | wc -l)
+          echo "Found ${GPU_COUNT} GPU(s)"
+          [ "${GPU_COUNT}" -ge 2 ] || { echo "Error: at least 2 GPUs required"; exit 1; }
+
       - name: Enable nvidia multi-process service
         run: |
           nvidia-cuda-mps-control -d
-      
-      - name: Run user docs tests
-        run: |
-          BIG_TESTS_INSTANCE=TRUE make test_user_doc_gpu
 
-      - name: Test C API
-        run: |
-          BIG_TESTS_INSTANCE=TRUE make test_c_api_gpu
+      - name: Install cargo-nextest
+        run: make install_cargo_nextest
 
-      - name: Run High Level API Tests
+      - name: Run signed and unsigned integer multi-bit tests in parallel
         run: |
-          BIG_TESTS_INSTANCE=TRUE make test_high_level_api_gpu
+          CUDA_VISIBLE_DEVICES=0 BIG_TESTS_INSTANCE=TRUE make test_signed_integer_multi_bit_gpu_ci \
+            > /tmp/gpu0.log 2>&1 &
+          PID0=$!
+          CUDA_VISIBLE_DEVICES=1 BIG_TESTS_INSTANCE=TRUE make test_unsigned_integer_multi_bit_gpu_ci \
+            > /tmp/gpu1.log 2>&1 &
+          PID1=$!
+          wait $PID0; RC0=$?
+          wait $PID1; RC1=$?
+          echo "=== GPU 0: signed integer ==="
+          cat /tmp/gpu0.log
+          echo "=== GPU 1: unsigned integer ==="
+          cat /tmp/gpu1.log
+          [ $RC0 -eq 0 ] && [ $RC1 -eq 0 ]
 
   slack-notify:
-    name: gpu_hlapi_h100_tests/slack-notify
+    name: gpu_integer_multibit_tests_h100_2gpu_par/slack-notify
     needs: [ setup-instance, cuda-tests-linux ]
     runs-on: ubuntu-latest
     if: ${{ always() && needs.cuda-tests-linux.result != 'skipped' && failure() }}
@@ -172,10 +184,10 @@ jobs:
         uses: rtCamp/action-slack-notify@33ca3be66c6f378fe1610fd1d5258632dbed5e58
         env:
           SLACK_COLOR: ${{ needs.cuda-tests-linux.result }}
-          SLACK_MESSAGE: "HL API H100 tests finished with status: ${{ needs.cuda-tests-linux.result }}. (${{ env.PULL_REQUEST_MD_LINK }}[action run](${{ env.ACTION_RUN_URL }}))"
+          SLACK_MESSAGE: "Integer GPU H100 2-GPU parallel multi-bit tests finished with status: ${{ needs.cuda-tests-linux.result }}. (${{ env.PULL_REQUEST_MD_LINK }}[action run](${{ env.ACTION_RUN_URL }}))"
 
   teardown-instance:
-    name: gpu_hlapi_h100_tests/teardown-instance
+    name: gpu_integer_multibit_tests_h100_2gpu_par/teardown-instance
     if: ${{ always() && needs.setup-instance.result == 'success' }}
     needs: [ setup-instance, cuda-tests-linux ]
     runs-on: ubuntu-latest
@@ -196,4 +208,4 @@ jobs:
         uses: rtCamp/action-slack-notify@33ca3be66c6f378fe1610fd1d5258632dbed5e58
         env:
           SLACK_COLOR: ${{ job.status }}
-          SLACK_MESSAGE: "Instance teardown (cuda-h100-tests) finished with status: ${{ job.status }}. (${{ env.ACTION_RUN_URL }})"
+          SLACK_MESSAGE: "Instance teardown (gpu_integer_multibit_tests_h100_2gpu_par) finished with status: ${{ job.status }}. (${{ env.ACTION_RUN_URL }})"

--- a/.github/workflows/gpu_integer_multibit_tests_h100_2gpu_par.yml
+++ b/.github/workflows/gpu_integer_multibit_tests_h100_2gpu_par.yml
@@ -1,5 +1,5 @@
-# Compile and test tfhe-cuda-backend on an H100 VM on hyperstack
-name: gpu_hlapi_h100_tests
+# Run signed and unsigned integer GPU multi-bit tests in parallel on a 2xH100 machine
+name: gpu_integer_multibit_tests_h100_2gpu_par
 
 env:
   CARGO_TERM_COLOR: always
@@ -15,12 +15,13 @@ env:
   IS_PULL_REQUEST: ${{ github.event_name == 'pull_request' }}
   PULL_REQUEST_MD_LINK: ""
   CHECKOUT_TOKEN: ${{ secrets.REPO_CHECKOUT_TOKEN || secrets.GITHUB_TOKEN }}
-  # Secrets will be available only to zama-ai organization members
   SECRETS_AVAILABLE: ${{ secrets.JOB_SECRET != '' }}
   EXTERNAL_CONTRIBUTION_RUNNER: "gpu_ubuntu-22.04"
 
 on:
   workflow_dispatch:
+  pull_request:
+    types: [ labeled ]
 
 permissions:
   contents: read
@@ -29,13 +30,12 @@ permissions:
 
 jobs:
   should-run:
-    name: gpu_hlapi_h100_tests/should-run
+    name: gpu_integer_multibit_tests_h100_2gpu_par/should-run
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read  # Needed to check for file change
     outputs:
       gpu_test: ${{ env.IS_PULL_REQUEST == 'false' || steps.changed-files.outputs.gpu_any_changed }}
-      core_crypto_changed: ${{ steps.changed-files.outputs.core_crypto_any_changed }}
     steps:
       - name: Checkout tfhe-rs
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
@@ -54,26 +54,23 @@ jobs:
               - tfhe/build.rs
               - backends/tfhe-cuda-backend/**
               - tfhe/src/core_crypto/gpu/**
-              - tfhe/src/integer/gpu/**
               - tfhe/src/integer/server_key/radix_parallel/tests_unsigned/**
               - tfhe/src/integer/server_key/radix_parallel/tests_signed/**
               - tfhe/src/integer/server_key/radix_parallel/tests_cases_unsigned.rs
+              - tfhe/src/integer/gpu/**
               - tfhe/src/shortint/parameters/**
               - tfhe/src/high_level_api/**
               - tfhe/src/c_api/**
-              - 'tfhe/docs/**/**.md'
-              - '.github/workflows/gpu_hlapi_h100_tests.yml'
+              - '.github/workflows/gpu_integer_multibit_tests_h100_2gpu_par.yml'
+              - scripts/integer-tests.sh
               - '.github/actions/gpu_setup/action.yml'
               - ci/slab.toml
-            core_crypto:
-              - tfhe/src/core_crypto/gpu/**
 
   setup-instance:
-    name: gpu_hlapi_h100_tests/setup-instance
+    name: gpu_integer_multibit_tests_h100_2gpu_par/setup-instance
     needs: should-run
     if: github.event_name != 'pull_request' ||
-      (github.event.action == 'labeled' && github.event.label.name == 'approved' && needs.should-run.outputs.gpu_test == 'true') ||
-      (github.event.action != 'labeled' && needs.should-run.outputs.core_crypto_changed == 'true')
+      (github.event.action == 'labeled' && github.event.label.name == 'approved' && needs.should-run.outputs.gpu_test == 'true')
     runs-on: ubuntu-latest
     outputs:
       runner-name: ${{ steps.start-remote-instance.outputs.label || steps.start-github-instance.outputs.runner_group }}
@@ -89,9 +86,8 @@ jobs:
           slab-url: ${{ secrets.SLAB_BASE_URL }}
           job-secret: ${{ secrets.JOB_SECRET }}
           backend: terraform
-          profile: scaleway-single-h100-tests
+          profile: scaleway-2-h100-sxm5-tests
 
-      # This instance will be spawned especially for pull-request from forked repository
       - name: Start GitHub instance
         id: start-github-instance
         if: env.SECRETS_AVAILABLE == 'false'
@@ -102,7 +98,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
   cuda-tests-linux:
-    name: gpu_hlapi_h100_tests/cuda-tests-linux
+    name: gpu_integer_multibit_tests_h100_2gpu_par/cuda-tests-linux
     needs: [ should-run, setup-instance ]
     if: github.event_name != 'pull_request' ||
       (github.event_name == 'pull_request' && needs.setup-instance.result != 'skipped')
@@ -112,12 +108,11 @@ jobs:
     runs-on: ${{ needs.setup-instance.outputs.runner-name }}
     strategy:
       fail-fast: false
-      # explicit include-based build matrix, of known valid options
       matrix:
         include:
           - os: ubuntu-22.04
             cuda: "12.8 12.2"
-            gcc: 12 
+            gcc: 12
     steps:
       - name: Checkout tfhe-rs
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
@@ -136,24 +131,54 @@ jobs:
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # zizmor: ignore[stale-action-refs] this action doesn't create releases
         with:
           toolchain: stable
+
+      - name: Check GPU count
+        run: |
+          GPU_COUNT=$(nvidia-smi --query-gpu=name --format=csv,noheader | wc -l)
+          echo "Found ${GPU_COUNT} GPU(s)"
+          [ "${GPU_COUNT}" -ge 2 ] || { echo "Error: at least 2 GPUs required"; exit 1; }
+
       - name: Enable nvidia multi-process service
         run: |
           nvidia-cuda-mps-control -d
-      
-      - name: Run user docs tests
-        run: |
-          BIG_TESTS_INSTANCE=TRUE make test_user_doc_gpu
 
-      - name: Test C API
-        run: |
-          BIG_TESTS_INSTANCE=TRUE make test_c_api_gpu
+      - name: Install cargo-nextest
+        run: make install_cargo_nextest
 
-      - name: Run High Level API Tests
+      - name: Run signed and unsigned integer multi-bit tests in parallel
         run: |
-          BIG_TESTS_INSTANCE=TRUE make test_high_level_api_gpu
+          run_signed() {
+            local rc=0
+            CUDA_VISIBLE_DEVICES=0 BIG_TESTS_INSTANCE=TRUE make test_signed_integer_multi_bit_gpu_ci || rc=$?
+            echo "${rc}" > /tmp/signed.rc
+          }
+          run_unsigned() {
+            local rc=0
+            CUDA_VISIBLE_DEVICES=1 BIG_TESTS_INSTANCE=TRUE make test_unsigned_integer_multi_bit_gpu_ci || rc=$?
+            echo "${rc}" > /tmp/unsigned.rc
+          }
+          run_signed 2>&1 | sed -u 's/^/[signed]   /' &
+          PID0=$!
+          run_unsigned 2>&1 | sed -u 's/^/[unsigned] /' &
+          PID1=$!
+          wait "${PID0}" || true
+          wait "${PID1}" || true
+
+          STATUS=0
+          for lane in signed unsigned; do
+            rc="$(cat "/tmp/${lane}.rc" 2>/dev/null || true)"
+            rc="${rc:-1}"
+            if [ "${rc}" -eq 0 ]; then
+              echo "${lane} integer tests passed"
+            else
+              echo "::error title=${lane} integer GPU tests::exited with code ${rc}, see the lines prefixed with [${lane}] above"
+              STATUS=1
+            fi
+          done
+          exit "${STATUS}"
 
   slack-notify:
-    name: gpu_hlapi_h100_tests/slack-notify
+    name: gpu_integer_multibit_tests_h100_2gpu_par/slack-notify
     needs: [ setup-instance, cuda-tests-linux ]
     runs-on: ubuntu-latest
     if: ${{ always() && needs.cuda-tests-linux.result != 'skipped' && failure() }}
@@ -172,10 +197,10 @@ jobs:
         uses: rtCamp/action-slack-notify@33ca3be66c6f378fe1610fd1d5258632dbed5e58
         env:
           SLACK_COLOR: ${{ needs.cuda-tests-linux.result }}
-          SLACK_MESSAGE: "HL API H100 tests finished with status: ${{ needs.cuda-tests-linux.result }}. (${{ env.PULL_REQUEST_MD_LINK }}[action run](${{ env.ACTION_RUN_URL }}))"
+          SLACK_MESSAGE: "Integer GPU H100 2-GPU parallel multi-bit tests finished with status: ${{ needs.cuda-tests-linux.result }}. (${{ env.PULL_REQUEST_MD_LINK }}[action run](${{ env.ACTION_RUN_URL }}))"
 
   teardown-instance:
-    name: gpu_hlapi_h100_tests/teardown-instance
+    name: gpu_integer_multibit_tests_h100_2gpu_par/teardown-instance
     if: ${{ always() && needs.setup-instance.result == 'success' }}
     needs: [ setup-instance, cuda-tests-linux ]
     runs-on: ubuntu-latest
@@ -196,4 +221,4 @@ jobs:
         uses: rtCamp/action-slack-notify@33ca3be66c6f378fe1610fd1d5258632dbed5e58
         env:
           SLACK_COLOR: ${{ job.status }}
-          SLACK_MESSAGE: "Instance teardown (cuda-h100-tests) finished with status: ${{ job.status }}. (${{ env.ACTION_RUN_URL }})"
+          SLACK_MESSAGE: "Instance teardown (gpu_integer_multibit_tests_h100_2gpu_par) finished with status: ${{ job.status }}. (${{ env.ACTION_RUN_URL }})"

--- a/.github/workflows/gpu_signed_integer_classic_tests.yml
+++ b/.github/workflows/gpu_signed_integer_classic_tests.yml
@@ -23,7 +23,6 @@ on:
   # Allows you to run this workflow manually from the Actions tab as an alternative.
   workflow_dispatch:
   pull_request:
-    types: [ labeled ]
 
 permissions:
   contents: read
@@ -71,9 +70,8 @@ jobs:
   setup-instance:
     name: gpu_signed_integer_classic_tests/setup-instance
     needs: should-run
-    if: github.event_name != 'pull_request' ||
-      (github.event.action != 'labeled' && needs.should-run.outputs.gpu_test == 'true') ||
-      (github.event.action == 'labeled' && github.event.label.name == 'approved' && needs.should-run.outputs.gpu_test == 'true')
+    if: github.event_name == 'workflow_dispatch' ||
+      needs.should-run.outputs.gpu_test == 'true'
     runs-on: ubuntu-latest
     outputs:
       runner-name: ${{ steps.start-remote-instance.outputs.label || steps.start-github-instance.outputs.runner_group }}

--- a/.github/workflows/gpu_signed_integer_h100_tests.yml
+++ b/.github/workflows/gpu_signed_integer_h100_tests.yml
@@ -20,10 +20,7 @@ env:
   EXTERNAL_CONTRIBUTION_RUNNER: "gpu_ubuntu-22.04"
 
 on:
-  # Allows you to run this workflow manually from the Actions tab as an alternative.
   workflow_dispatch:
-  pull_request:
-    types: [ labeled, opened, synchronize ]
 
 permissions:
   contents: read

--- a/.github/workflows/gpu_signed_integer_tests.yml
+++ b/.github/workflows/gpu_signed_integer_tests.yml
@@ -25,6 +25,7 @@ on:
   # Allows you to run this workflow manually from the Actions tab as an alternative.
   workflow_dispatch:
   pull_request:
+    types: [ labeled ]
 
 permissions:
   contents: read
@@ -73,9 +74,8 @@ jobs:
     name: gpu_signed_integer_tests/setup-instance
     runs-on: ubuntu-latest
     needs: should-run
-    if: (github.event_name == 'schedule' && github.repository == 'zama-ai/tfhe-rs') ||
-      github.event_name == 'workflow_dispatch' ||
-      needs.should-run.outputs.gpu_test == 'true'
+    if: github.event_name != 'pull_request' ||
+      (github.event.action == 'labeled' && github.event.label.name == 'approved' && needs.should-run.outputs.gpu_test == 'true')
     outputs:
       runner-name: ${{ steps.start-remote-instance.outputs.label || steps.start-github-instance.outputs.runner_group }}
       cloud-provider: ${{ steps.start-remote-instance.outputs.cloud-provider || steps.start-github-instance.outputs.cloud-provider }}

--- a/.github/workflows/gpu_unsigned_integer_classic_tests.yml
+++ b/.github/workflows/gpu_unsigned_integer_classic_tests.yml
@@ -23,7 +23,6 @@ on:
   # Allows you to run this workflow manually from the Actions tab as an alternative.
   workflow_dispatch:
   pull_request:
-    types: [ labeled ]
 
 permissions:
   contents: read
@@ -72,8 +71,7 @@ jobs:
     name: gpu_unsigned_integer_classic_tests/setup-instance
     needs: should-run
     if: github.event_name == 'workflow_dispatch' ||
-      (github.event.action != 'labeled' && needs.should-run.outputs.gpu_test == 'true') ||
-      (github.event.action == 'labeled' && github.event.label.name == 'approved' && needs.should-run.outputs.gpu_test == 'true')
+      needs.should-run.outputs.gpu_test == 'true'
     runs-on: ubuntu-latest
     outputs:
       runner-name: ${{ steps.start-remote-instance.outputs.label || steps.start-github-instance.outputs.runner_group }}

--- a/.github/workflows/gpu_unsigned_integer_h100_tests.yml
+++ b/.github/workflows/gpu_unsigned_integer_h100_tests.yml
@@ -20,10 +20,7 @@ env:
   EXTERNAL_CONTRIBUTION_RUNNER: "gpu_ubuntu-22.04"
 
 on:
-  # Allows you to run this workflow manually from the Actions tab as an alternative.
   workflow_dispatch:
-  pull_request:
-    types: [ labeled, opened, synchronize ]
 
 permissions:
   contents: read

--- a/.github/workflows/gpu_unsigned_integer_tests.yml
+++ b/.github/workflows/gpu_unsigned_integer_tests.yml
@@ -25,6 +25,7 @@ on:
   # Allows you to run this workflow manually from the Actions tab as an alternative.
   workflow_dispatch:
   pull_request:
+    types: [ labeled ]
 
 permissions:
   contents: read
@@ -73,9 +74,8 @@ jobs:
     name: gpu_unsigned_integer_tests/setup-instance
     runs-on: ubuntu-latest
     needs: should-run
-    if: (github.event_name == 'schedule' && github.repository == 'zama-ai/tfhe-rs') ||
-      github.event_name == 'workflow_dispatch' ||
-      needs.should-run.outputs.gpu_test == 'true'
+    if: github.event_name != 'pull_request' ||
+      (github.event.action == 'labeled' && github.event.label.name == 'approved' && needs.should-run.outputs.gpu_test == 'true')
     outputs:
       runner-name: ${{ steps.start-remote-instance.outputs.label || steps.start-github-instance.outputs.runner_group }}
       cloud-provider: ${{ steps.start-remote-instance.outputs.cloud-provider || steps.start-github-instance.outputs.cloud-provider }}

--- a/ci/gpu_workflows_table.py
+++ b/ci/gpu_workflows_table.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""Generate a CSV table of GPU test workflows with their trigger and machine info."""
+
+import csv
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+import yaml
+
+WORKFLOWS_DIR = Path(__file__).parent.parent / ".github" / "workflows"
+SLAB_TOML = Path(__file__).parent / "slab.toml"
+
+# Workflows to include (test workflows only, in display order)
+WORKFLOWS = [
+    "gpu_fast_tests",
+    "gpu_signed_integer_tests",
+    "gpu_unsigned_integer_tests",
+    "gpu_signed_integer_classic_tests",
+    "gpu_unsigned_integer_classic_tests",
+    "gpu_integer_long_run_tests",
+    "gpu_integer_multibit_tests_h100_2gpu_par",
+    "gpu_integer_classic_tests_h100_2gpu_par",
+    "gpu_core_hlapi_h100_2gpu_par",
+    "gpu_hlapi_h100_tests",
+    "gpu_core_h100_tests",
+    "gpu_h100_long_run_tests",
+    "gpu_full_multi_gpu_tests",
+    "gpu_full_h100_tests",
+    "gpu_signed_integer_h100_tests",
+    "gpu_unsigned_integer_h100_tests",
+    "gpu_code_validation_tests",
+    "gpu_memory_sanitizer",
+    "gpu_memory_sanitizer_h100",
+    "gpu_noise_level_checks",
+    "gpu_zk_tests",
+    "gpu_zk_long_run_tests",
+    "gpu_zk_code_validation_tests",
+    "gpu_zk_memory_sanitizer",
+]
+
+
+def load_slab(path: Path) -> dict:
+    """Load slab.toml and return a flat dict of profile_name -> {instance_type, fallbacks}."""
+    with open(path, "rb") as f:
+        raw = tomllib.load(f)
+
+    profiles = {}
+    for backend_name, backend_profiles in raw.get("backend", {}).items():
+        for profile_name, profile_data in backend_profiles.items():
+            instance_type = profile_data.get("instance_type") or profile_data.get("flavor_name", "?")
+            raw_fallbacks = profile_data.get("fallbacks", [])
+            profiles[profile_name] = {
+                "backend": backend_name,
+                "instance_type": instance_type,
+                "raw_fallbacks": raw_fallbacks,
+            }
+
+    # Resolve fallback instance types
+    for profile_name, pdata in profiles.items():
+        resolved = []
+        for fb in pdata["raw_fallbacks"]:
+            # fb is like "hyperstack.2-h100" or "terraform.scaleway-4-h100-sxm5"
+            fb_profile = fb.split(".", 1)[1] if "." in fb else fb
+            fb_instance = profiles.get(fb_profile, {}).get("instance_type", fb_profile)
+            resolved.append(fb_instance)
+        pdata["fallbacks"] = resolved
+
+    return profiles
+
+
+def parse_workflow(path: Path, slab: dict) -> dict:
+    """Parse a workflow YAML file and extract trigger and machine info."""
+    data = yaml.safe_load(path.read_text())
+
+    on = data.get("on") or data.get(True) or {}  # 'on' parses as True in PyYAML
+    # PyYAML parses the bare key `on:` as boolean True
+    if True in data and "on" not in data:
+        on = data[True]
+    elif "on" in data:
+        on = data["on"]
+    else:
+        on = {}
+
+    # Normalize: 'on' can be a list (e.g. [push, pull_request]) or a dict
+    if isinstance(on, list):
+        on = {k: None for k in on}
+    elif isinstance(on, str):
+        on = {on: None}
+
+    # --- Triggers ---
+    has_dispatch = "workflow_dispatch" in on
+    has_push = "push" in on
+
+    pr = on.get("pull_request")
+    has_pr = "pull_request" in on
+    if isinstance(pr, dict):
+        pr_types = pr.get("types", [])
+    else:
+        pr_types = []
+
+    pr_regular = has_pr and (not pr_types or any(t in pr_types for t in ("opened", "synchronize", "reopened")))
+    pr_labeled = has_pr and "labeled" in pr_types
+
+    # Check setup-instance condition for 'approved' label (still use text search — it's in a string expression)
+    text = path.read_text()
+    pr_approved = pr_labeled and bool(re.search(r"label\.name == 'approved'", text))
+
+    # Cron schedules
+    schedule = on.get("schedule", [])
+    crons = []
+    if isinstance(schedule, list):
+        for entry in schedule:
+            if isinstance(entry, dict) and "cron" in entry:
+                crons.append(str(entry["cron"]).strip())
+    cron = "; ".join(crons)
+
+    has_any_auto = pr_regular or pr_approved or cron or has_push
+    manual_only = has_dispatch and not has_any_auto
+
+    # --- Profile: walk jobs to find the slab-github-runner start step ---
+    profile = None
+    jobs = data.get("jobs", {})
+    for job in jobs.values():
+        steps = job.get("steps", [])
+        for step in steps:
+            uses = step.get("uses", "") or ""
+            if "slab-github-runner" not in uses:
+                continue
+            with_block = step.get("with", {}) or {}
+            if str(with_block.get("mode", "")).strip() != "start":
+                continue
+            profile = str(with_block.get("profile", "")).strip() or None
+            break
+        if profile:
+            break
+
+    # Resolve profile info from slab
+    if profile and profile in slab:
+        instance_type = slab[profile]["instance_type"]
+        fallbacks = slab[profile]["fallbacks"]
+    else:
+        instance_type = "?"
+        fallbacks = []
+
+    return {
+        "Workflow": path.stem,
+        "PR": "yes" if pr_regular else "",
+        "PR on approved": "yes" if pr_approved else "",
+        "Cron": cron,
+        "Manual only": "yes" if manual_only else "",
+        "Profile (instance)": f"{profile} ({instance_type})" if profile else "",
+        "Fallbacks": " | ".join(fallbacks),
+        "_test_targets": extract_test_targets(text),
+    }
+
+
+TEST_MARKERS = re.compile(r"cuda-tests-linux|make test_|cargo test|nextest run|nextest list")
+MAKE_TEST_RE = re.compile(r"make\s+(test_\w+)")
+
+# Known test targets — add new ones here when introduced
+TEST_TARGETS = [
+    "test_core_crypto_gpu",
+    "test_cuda_backend",
+    "test_high_level_api_gpu",
+    "test_high_level_api_gpu_fast",
+    "test_integer_compression_gpu",
+    "test_integer_long_run_gpu",
+    "test_integer_multi_bit_gpu_ci",
+    "test_integer_short_run_gpu",
+    "test_signed_integer_gpu_ci",
+    "test_signed_integer_multi_bit_gpu_ci",
+    "test_unsigned_integer_gpu_ci",
+    "test_unsigned_integer_multi_bit_gpu_ci",
+    "test_user_doc_gpu",
+    "test_c_api_gpu",
+    "test_integer_zk_experimental_gpu",
+    "test_integer_zk_gpu",
+    "test_zk_cuda_backend",
+    "test_zk_cuda_backend_memcheck",
+    "test_zk_cuda_backend_race_check",
+    "test_zk_pok_experimental_gpu",
+    "test_zk_pok_experimental_long_run_gpu",
+    "test_zk_pok_experimental_short_run_gpu",
+    "test_zk_pok_gpu_valgrind",
+    "test_high_level_api_fake_multi_gpu",
+    "test_signed_integer_fake_multi_gpu",
+    "test_cuda_backend_race_check",
+    "test_high_level_api_gpu_valgrind",
+    "test_high_level_api_gpu_sanitizer",
+]
+
+
+def is_test_workflow(path: Path) -> bool:
+    return bool(TEST_MARKERS.search(path.read_text()))
+
+
+def extract_test_targets(text: str) -> set[str]:
+    """Return whitelisted targets directly invoked via make in text."""
+    return {t for t in TEST_TARGETS if re.search(rf"make\s+{t}\b", text)}
+
+
+def find_unknown_test_targets(text: str) -> set[str]:
+    """Return make test_* invocations not in TEST_TARGETS."""
+    known = set(TEST_TARGETS)
+    return {t for t in MAKE_TEST_RE.findall(text) if t not in known}
+
+
+def main():
+    slab = load_slab(SLAB_TOML)
+    warnings: list[str] = []
+
+    # Warn about gpu_* workflows not on the whitelist
+    whitelist_set = set(WORKFLOWS)
+    for path in sorted(WORKFLOWS_DIR.glob("gpu_*.yml")):
+        name = path.stem
+        if name not in whitelist_set:
+            if is_test_workflow(path):
+                kind = "test workflow — consider adding to whitelist"
+            else:
+                kind = "non-test workflow (build/helper) — intentionally excluded"
+            warnings.append(f"WARNING: {name}.yml not in whitelist: {kind}")
+
+    # First pass: parse and collect per-workflow warnings
+    rows = []
+    for name in WORKFLOWS:
+        path = WORKFLOWS_DIR / f"{name}.yml"
+        if not path.exists():
+            warnings.append(f"WARNING: {name}.yml listed in whitelist but file not found")
+            continue
+        row = parse_workflow(path, slab)
+        text = path.read_text()
+        targets = row.pop("_test_targets")
+        for unknown in sorted(find_unknown_test_targets(text)):
+            warnings.append(f"WARNING: {name}.yml runs unknown test target '{unknown}' — add to TEST_TARGETS")
+        for col in TEST_TARGETS:
+            row[col] = "yes" if col in targets else ""
+        rows.append(row)
+
+    for w in warnings:
+        print(w, file=sys.stderr)
+
+    base_fields = ["Workflow", "PR", "PR on approved", "Cron", "Manual only", "Profile (instance)", "Fallbacks"]
+    writer = csv.DictWriter(sys.stdout, fieldnames=base_fields + TEST_TARGETS)
+    writer.writeheader()
+    for row in rows:
+        writer.writerow(row)
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/slab.toml
+++ b/ci/slab.toml
@@ -212,8 +212,6 @@ instance_type = "H100-1-80G"
 user = "ubuntu"
 fallbacks = [
     "hyperstack.single-h100",
-    "terraform.scaleway-2-h100-sxm5",
-    "terraform.scaleway-4-h100-sxm5",
 ]
 
 [backend.terraform.scaleway-4-l40]


### PR DESCRIPTION
1. Groups pairs of h100 tests: 3 new workflows to run in parallel on gpus 0 and 1 of a 2x gpu machine
- signed and unsigned integer 
  - classical
  - multi-bit
- hlapi and core

2. Moves classical tests to "PR on push" and multi-bit tests to approved
3.  One new h100 workflow: `gpu_h100_long_run_tests` -> on PR push and on CRON
4. Disables non 2x-gpu workflows: gpu_signed_integer_h100_tests and gpu_unsigned_integer_h100_tests -> replaced with the 2x gpu variant (multi-bit)

Bottom line: no cost savings but more tests
