### PR TITLE
fix(gpu): fixing robustness of oprf/shuffle

### DIFF
--- a/tfhe/src/integer/gpu/ciphertext/re_randomization.rs
+++ b/tfhe/src/integer/gpu/ciphertext/re_randomization.rs
@@ -1,5 +1,7 @@
 use crate::core_crypto::gpu::lwe_compact_ciphertext_list::CudaLweCompactCiphertextList;
+use crate::core_crypto::gpu::lwe_keyswitch_key::CudaLweKeyswitchKey;
 use crate::core_crypto::gpu::CudaStreams;
+use crate::core_crypto::prelude::LweSize;
 use crate::integer::ciphertext::ReRandomizationSeed;
 use crate::integer::gpu::ciphertext::boolean_value::CudaBooleanBlock;
 use crate::integer::gpu::ciphertext::{
@@ -26,6 +28,61 @@ pub enum CudaReRandomizationKey<'key> {
     DerivedCPKWithoutKeySwitch {
         cpk: &'key CompactPublicKey,
     },
+}
+
+impl<'key> CudaReRandomizationKey<'key> {
+    /// Checks the keys can re-randomize blocks of `radix_block_lwe_size` and returns them.
+    /// The backend expands the zeros at that dimension, a mismatch reads out of bounds.
+    pub(crate) fn checked_cpk_and_rerand_ksk(
+        self,
+        radix_block_lwe_size: LweSize,
+    ) -> crate::Result<(
+        &'key CompactPublicKey,
+        Option<&'key CudaLweKeyswitchKey<u64>>,
+    )> {
+        match self {
+            Self::LegacyDedicatedCPK { cpk, ksk } => {
+                let lwe_keyswitch_key = &ksk.lwe_keyswitch_key;
+                if lwe_keyswitch_key.output_key_lwe_size() != radix_block_lwe_size {
+                    return Err(crate::error!(
+                        "Mismatched LweSize between the ciphertext being re-randomized \
+                        and the provided re-randomization keyswitch key output."
+                    ));
+                }
+                if lwe_keyswitch_key.input_key_lwe_size()
+                    != cpk.parameters().encryption_lwe_dimension.to_lwe_size()
+                {
+                    return Err(crate::error!(
+                        "Mismatched LweDimension between the provided CompactPublicKey \
+                        and the re-randomization keyswitch key input."
+                    ));
+                }
+                if ksk.destination_key.into_pbs_order() != PBSOrder::KeyswitchBootstrap {
+                    return Err(crate::error!(
+                        "Tried to re-randomize with a re-randomization keyswitch key \
+                        whose destination key uses an unsupported PBSOrder. Required \
+                        PBSOrder::KeyswitchBootstrap."
+                    ));
+                }
+                if ksk.cast_rshift != 0 {
+                    return Err(crate::error!(
+                        "Tried to re-randomize with a re-randomization keyswitch key that \
+                        has a non-zero cast_rshift, this is unsupported."
+                    ));
+                }
+                Ok((cpk, Some(lwe_keyswitch_key)))
+            }
+            Self::DerivedCPKWithoutKeySwitch { cpk } => {
+                if cpk.key.key.lwe_dimension().to_lwe_size() != radix_block_lwe_size {
+                    return Err(crate::error!(
+                        "Mismatched LweSize between the ciphertext being re-randomized \
+                        and the provided CompactPublicKey."
+                    ));
+                }
+                Ok((cpk, None))
+            }
+        }
+    }
 }
 
 impl CudaUnsignedRadixCiphertext {

--- a/tfhe/src/integer/gpu/server_key/radix/oprf.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/oprf.rs
@@ -27,7 +27,6 @@ use crate::integer::gpu::{
     cuda_backend_get_grouped_oprf_size_on_gpu, cuda_backend_grouped_oprf,
     cuda_backend_grouped_oprf_custom_range,
 };
-use crate::shortint::PBSOrder;
 
 pub struct GenericCudaOprfServerKey<K> {
     bootstrapping_key: K,
@@ -570,19 +569,15 @@ where
         let message_bits_count = target_sks.message_modulus.0.ilog2() as u64;
         let num_active_blocks = random_bits_count.div_ceil(message_bits_count);
 
-        // We need the PRF + ReRand to be applied only on the num_active_blocks and later extend
-        // with trivial 0s (so that the padding is not re-randed)
-        //
-        // The multiblocks primitive applies the rerand to all the blocks (there is no
-        // "active blocks" rerand primitive currently)
-        let mut result = target_sks.create_trivial_zero_radix(num_active_blocks as usize, streams);
+        let mut result: T =
+            target_sks.create_trivial_zero_radix(num_active_blocks as usize, streams);
 
         assert!(
             num_blocks >= num_active_blocks,
             "Cuda error: num_blocks should be greater than num_blocks_to_process"
         );
         if num_active_blocks == 0 {
-            return Ok(result);
+            return Ok(target_sks.create_trivial_zero_radix(num_blocks as usize, streams));
         }
 
         self.generate_multiblocks_oblivious_pseudo_random_and_re_randomize(
@@ -819,49 +814,8 @@ where
              computing_ks_key,
              prf_seed,
              rle_info| {
-                let radix_block_lwe_size = result.d_blocks.lwe_dimension().to_lwe_size();
-                let (compact_public_key, rerand_keyswitch_key) = match *re_randomization_key {
-                    CudaReRandomizationKey::LegacyDedicatedCPK { cpk, ksk } => {
-                        let lwe_keyswitch_key = &ksk.lwe_keyswitch_key;
-                        if lwe_keyswitch_key.output_key_lwe_size() != radix_block_lwe_size {
-                            return Err(crate::error!(
-                                "Mismatched LweSize between the ciphertext being re-randomized \
-                                and the provided re-randomization keyswitch key output."
-                            ));
-                        }
-                        if lwe_keyswitch_key.input_key_lwe_size()
-                            != cpk.parameters().encryption_lwe_dimension.to_lwe_size()
-                        {
-                            return Err(crate::error!(
-                                "Mismatched LweDimension between the provided CompactPublicKey \
-                                and the re-randomization keyswitch key input."
-                            ));
-                        }
-                        if ksk.destination_key.into_pbs_order() != PBSOrder::KeyswitchBootstrap {
-                            return Err(crate::error!(
-                                "Tried to re-randomize with a re-randomization keyswitch key \
-                                whose destination key uses an unsupported PBSOrder. Required \
-                                PBSOrder::KeyswitchBootstrap."
-                            ));
-                        }
-                        if ksk.cast_rshift != 0 {
-                            return Err(crate::error!(
-                                "Tried to re-randomize with a re-randomization keyswitch key that \
-                                has a non-zero cast_rshift, this is unsupported."
-                            ));
-                        }
-                        (cpk, Some(lwe_keyswitch_key))
-                    }
-                    CudaReRandomizationKey::DerivedCPKWithoutKeySwitch { cpk } => {
-                        if cpk.key.key.lwe_dimension().to_lwe_size() != radix_block_lwe_size {
-                            return Err(crate::error!(
-                                "Mismatched LweSize between the ciphertext being re-randomized \
-                                and the provided CompactPublicKey."
-                            ));
-                        }
-                        (cpk, None)
-                    }
-                };
+                let (compact_public_key, rerand_keyswitch_key) = re_randomization_key
+                    .checked_cpk_and_rerand_ksk(result.d_blocks.lwe_dimension().to_lwe_size())?;
 
                 let num_random_input_blocks = (shift as u64).div_ceil(message_bits_count);
                 let rerand_seed = ReRandomizationSeed::new_prf_rerand_seed(
@@ -947,6 +901,10 @@ where
             "num_blocks_output(={num_blocks_output}) is too small to hold an integer \
             up to excluded_upper_bound(={excluded_upper_bound})"
         );
+
+        if num_input_random_bits == 0 {
+            return Ok(target_sks.create_trivial_zero_radix(num_blocks_output as usize, streams));
+        }
 
         let CudaDynamicKeyswitchingKey::Standard(computing_ks_key) = &target_sks.key_switching_key
         else {

--- a/tfhe/src/integer/gpu/server_key/radix/shuffle.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/shuffle.rs
@@ -221,6 +221,10 @@ impl CudaServerKey {
             ));
         }
 
+        let (cpk, rerand_ksk) = re_randomization_key.checked_cpk_and_rerand_ksk(
+            self.bootstrapping_key.output_lwe_dimension().to_lwe_size(),
+        )?;
+
         for v in data.iter_mut() {
             let needs_propagate = v
                 .as_ref()
@@ -279,13 +283,6 @@ impl CudaServerKey {
 
         let total_key_blocks = data.len() * key_num_blocks as usize;
         let mut value_refs: Vec<_> = data.iter_mut().map(|v| v.as_mut()).collect();
-
-        let (cpk, rerand_ksk) = match re_randomization_key {
-            CudaReRandomizationKey::DerivedCPKWithoutKeySwitch { cpk } => (cpk, None),
-            CudaReRandomizationKey::LegacyDedicatedCPK { cpk, ksk } => {
-                (cpk, Some(&ksk.lwe_keyswitch_key))
-            }
-        };
 
         let encryption_of_zero = cpk
             .key

--- a/tfhe/src/integer/gpu/server_key/radix/tests_unsigned/test_bitonic_shuffle.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/tests_unsigned/test_bitonic_shuffle.rs
@@ -91,6 +91,89 @@ where
     bitonic_shuffle_with_keys_invalid_block_counts_test(param, executor);
 }
 
+/// A CPK of the wrong dimension must be rejected, the backend would read out of bounds.
+#[test]
+fn bitonic_shuffle_rerand_rejects_incompatible_cpk() {
+    use crate::core_crypto::gpu::CudaStreams;
+    use crate::core_crypto::prelude::LweDimension;
+    use crate::integer::ciphertext::PrfReRandomizationContext;
+    use crate::integer::gpu::ciphertext::re_randomization::CudaReRandomizationKey;
+    use crate::integer::gpu::CudaOprfServerKey;
+    use crate::integer::oprf::{CompressedOprfServerKey, OprfPrivateKey};
+    use crate::integer::server_key::radix_parallel::bitonic_shuffle::BitonicShuffleKeySize;
+    use crate::integer::{ClientKey, CompactPrivateKey, CompactPublicKey, RadixClientKey};
+    use crate::shortint::parameters::PARAM_PKE_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+    use tfhe_csprng::seeders::Seed;
+
+    const NUM_DATA_BLOCKS: usize = 4;
+
+    let cks = ClientKey::new(TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128);
+    let radix_cks = RadixClientKey::from((cks.clone(), NUM_DATA_BLOCKS));
+
+    let streams = CudaStreams::new_multi_gpu();
+    let sks = CudaServerKey::new(&cks, &streams);
+
+    let oprf_priv = OprfPrivateKey::new(&cks);
+    let compressed_oprf = CompressedOprfServerKey::new(&oprf_priv, &cks).unwrap();
+    let oprf_sks = CudaOprfServerKey::decompress_from_cpu(&compressed_oprf, &streams);
+
+    // Derived compact public key, re-using the compute secret key
+    let matching_privk: CompactPrivateKey<&[u64]> = (&cks).try_into().unwrap();
+    let matching_cpk = CompactPublicKey::new(&matching_privk);
+
+    let mut smaller_params = PARAM_PKE_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+    smaller_params.encryption_lwe_dimension = LweDimension(1024);
+    let mismatched_cpk = CompactPublicKey::new(&CompactPrivateKey::new(smaller_params));
+    assert_ne!(
+        mismatched_cpk.key.key.lwe_dimension(),
+        matching_cpk.key.key.lwe_dimension(),
+        "this test needs a compact public key whose dimension differs from the compute key one"
+    );
+
+    let prf_rerand_context = PrfReRandomizationContext::default();
+    let key_size = BitonicShuffleKeySize::num_bits(32);
+
+    let data = || -> Vec<CudaUnsignedRadixCiphertext> {
+        (1..=4u64)
+            .map(|v| {
+                CudaUnsignedRadixCiphertext::from_radix_ciphertext(&radix_cks.encrypt(v), &streams)
+            })
+            .collect()
+    };
+
+    let result = sks.bitonic_shuffle_and_re_randomize(
+        &oprf_sks,
+        data(),
+        key_size,
+        Seed(0x5EEDED),
+        &CudaReRandomizationKey::DerivedCPKWithoutKeySwitch {
+            cpk: &mismatched_cpk,
+        },
+        &prf_rerand_context,
+        &streams,
+    );
+    match result {
+        Ok(_) => panic!("an incompatible compact public key must be rejected"),
+        Err(err) => assert!(
+            err.to_string().contains("Mismatched LweSize"),
+            "unexpected error: {err}"
+        ),
+    }
+
+    // The matching key must still go through
+    if let Err(err) = sks.bitonic_shuffle_and_re_randomize(
+        &oprf_sks,
+        data(),
+        key_size,
+        Seed(0x5EEDED),
+        &CudaReRandomizationKey::DerivedCPKWithoutKeySwitch { cpk: &matching_cpk },
+        &prf_rerand_context,
+        &streams,
+    ) {
+        panic!("a matching compact public key must be accepted: {err}");
+    }
+}
+
 #[test]
 fn bitonic_shuffle_cpu_gpu_same_permutation() {
     use crate::core_crypto::gpu::CudaStreams;

--- a/tfhe/src/integer/gpu/server_key/radix/tests_unsigned/test_oprf.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/tests_unsigned/test_oprf.rs
@@ -9,7 +9,7 @@ use crate::integer::gpu::{CudaOprfServerKey, CudaServerKey};
 use crate::integer::oprf::{CompressedOprfServerKey, OprfPrivateKey};
 use crate::integer::server_key::radix_parallel::tests_unsigned::test_oprf::{
     oprf_almost_uniformity_test, oprf_any_range_test, oprf_uniformity_test,
-    pseudo_random_integer_and_rerand_test, OprfReRandTestRunner,
+    oprf_zero_input_bits_test, pseudo_random_integer_and_rerand_test, OprfReRandTestRunner,
 };
 use crate::integer::{ClientKey, CompactPrivateKey, CompactPublicKey};
 use crate::shortint::oprf::OprfSeed;
@@ -26,6 +26,9 @@ create_gpu_parameterized_test!(oprf_any_range_unsigned {
     PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128
 });
 create_gpu_parameterized_test!(oprf_almost_uniformity_unsigned {
+    PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128
+});
+create_gpu_parameterized_test!(oprf_zero_input_bits_unsigned {
     PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128
 });
 
@@ -52,6 +55,16 @@ where
         &CudaOprfServerKey::par_generate_oblivious_pseudo_random_unsigned_custom_range,
     );
     oprf_any_range_test(param, executor);
+}
+
+fn oprf_zero_input_bits_unsigned<P>(param: P)
+where
+    P: Into<TestParameters>,
+{
+    let executor = OpSequenceGpuMultiDeviceFunctionExecutor::new(
+        &CudaOprfServerKey::par_generate_oblivious_pseudo_random_unsigned_custom_range,
+    );
+    oprf_zero_input_bits_test(param, executor);
 }
 
 fn oprf_almost_uniformity_unsigned<P>(param: P)

--- a/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_oprf.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_oprf.rs
@@ -39,6 +39,9 @@ create_parameterized_test!(oprf_any_range_unsigned {
 create_parameterized_test!(oprf_almost_uniformity_unsigned {
     PARAM_MESSAGE_2_CARRY_2_KS_PBS_GAUSSIAN_2M128
 });
+create_parameterized_test!(oprf_zero_input_bits_unsigned {
+    PARAM_MESSAGE_2_CARRY_2_KS_PBS_GAUSSIAN_2M128
+});
 
 create_parameterized_test!(pseudo_random_integer_and_rerand {
     TEST_PARAM_MULTI_BIT_GROUP_3_MESSAGE_2_CARRY_2_KS_PBS_GAUSSIAN_2M128,
@@ -86,6 +89,28 @@ where
             )
         });
     oprf_any_range_test(param, executor);
+}
+
+fn oprf_zero_input_bits_unsigned<P>(param: P)
+where
+    P: Into<TestParameters>,
+{
+    let executor =
+        CpuOprfExecutor::new(&|oprf_key: &OprfServerKey,
+                               seed: Seed,
+                               num_input_random_bits: u64,
+                               excluded_upper_bound: u64,
+                               num_blocks_output: u64,
+                               sk: &ServerKey| {
+            oprf_key.par_generate_oblivious_pseudo_random_unsigned_custom_range(
+                seed,
+                num_input_random_bits,
+                NonZeroU64::new(excluded_upper_bound).unwrap(),
+                num_blocks_output,
+                sk,
+            )
+        });
+    oprf_zero_input_bits_test(param, executor);
 }
 
 fn oprf_almost_uniformity_unsigned<P>(param: P)
@@ -231,6 +256,25 @@ where
                 assert!(decrypted < excluded_upper_bound);
             }
         }
+    }
+}
+
+/// 0 input bits is deterministic, but the requested width must be honored.
+pub(crate) fn oprf_zero_input_bits_test<P, E>(param: P, mut executor: E)
+where
+    P: Into<TestParameters>,
+    E: OpSequenceFunctionExecutor<(Seed, u64, u64, u64), RadixCiphertext>,
+{
+    let cks = setup_oprf_test(param, &mut executor);
+
+    for (excluded_upper_bound, num_blocks_output) in [(3, 1), (3, 32), ((1 << 32) + 1, 64)] {
+        let img = executor.execute((Seed(0), 0, excluded_upper_bound, num_blocks_output as u64));
+
+        assert_eq!(img.blocks.len(), num_blocks_output);
+        assert!(img.blocks.iter().all(|ct| ct.is_trivial()));
+
+        let decrypted: u64 = cks.decrypt(&img);
+        assert_eq!(decrypted, 0);
     }
 }
 
@@ -718,6 +762,38 @@ fn subtest_unsigned_integer_bounded<TestRunner: OprfReRandTestRunner>(
     );
 }
 
+/// 0 random bits must still yield the requested block count.
+fn subtest_integer_bounded_zero_random_bits<TestRunner: OprfReRandTestRunner>(
+    prf_seed: impl OprfSeed,
+    cks: &ClientKey,
+    test_runner: &mut TestRunner,
+    prf_re_randomization_context: &PrfReRandomizationContext,
+) {
+    const OUTPUT_BIT_COUNT: u64 = 16;
+
+    let prf_seed = prf_seed.into_bytes();
+    let prf_seed = prf_seed.as_ref();
+
+    let message_bits: u64 = cks.parameters().message_modulus().0.ilog2().into();
+    let num_blocks = OUTPUT_BIT_COUNT.div_ceil(message_bits);
+
+    let (prf_not_rerand, prf_rerand) =
+        test_runner.unsigned_bounded(prf_seed, 0, num_blocks, prf_re_randomization_context);
+
+    assert_eq!(prf_not_rerand.blocks.len() as u64, num_blocks);
+    assert_eq!(prf_rerand.blocks.len() as u64, num_blocks);
+    let decrypted = check_unsigned_value_and_re_rand_are_ok(&prf_not_rerand, &prf_rerand, cks, 0);
+    assert_eq!(decrypted, 0);
+
+    let (prf_not_rerand, prf_rerand) =
+        test_runner.signed_bounded(prf_seed, 0, num_blocks, prf_re_randomization_context);
+
+    assert_eq!(prf_not_rerand.blocks.len() as u64, num_blocks);
+    assert_eq!(prf_rerand.blocks.len() as u64, num_blocks);
+    let decrypted = check_signed_value_and_re_rand_are_ok(&prf_not_rerand, &prf_rerand, cks, 0);
+    assert_eq!(decrypted, 0);
+}
+
 fn subtest_integer_bounded_padding_stays_trivial<TestRunner: OprfReRandTestRunner>(
     prf_seed: impl OprfSeed,
     cks: &ClientKey,
@@ -996,6 +1072,13 @@ where
         );
 
         subtest_integer_bounded_padding_stays_trivial(
+            prf_seed,
+            &cks,
+            &mut test_runner,
+            &prf_rerand_context,
+        );
+
+        subtest_integer_bounded_zero_random_bits(
             prf_seed,
             &cks,
             &mut test_runner,


### PR DESCRIPTION
```
[Fix 1] bounded OPRF + rerand, 0 random bits (width loss, GPU only)

bounded_and_re_randomize(random_bits=0, num_blocks=8)
↓
num_active_blocks = ceil(0 / msg_bits) = 0
↓
BEFORE : The early return skips the `extend-to-num_blocks` step.
         [ ] × 0 blocks -> requested width lost.
AFTER  : The early return properly allocates `num_blocks`.
         [ 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 ] ✓

* CPU and the non-rerand GPU path already honored num_blocks.

───────────────────────────────────────────────────────────────────────

[Fix 2] fused shuffle + rerand, unchecked CPK (OOB-read)

bitonic_shuffle_and_re_randomize(data, cpk_dim=1024, target_dim=2048)
↓
BEFORE : The fused path validates no key. The backend expands to 2048.
         [── cpk buffer (1024) ──|── × past end (OOB) ──]
         -> 324 invalid global reads (compute-sanitizer).
AFTER  : checked_cpk_and_rerand_ksk(bsk_output_lwe_size)
         ↓
         Err "Mismatched LweSize..." ✓ (stopped before allocation/launch)

───────────────────────────────────────────────────────────────────────

[Fix 3] custom range, 0 input bits (GPU crash, CPU OK)

custom_range(input_bits=0, bound, out_blocks)
↓
num_random_input_blocks = ceil(0 / msg_bits) = 0
│
├─ GPU BEFORE : PBS launched with 0 samples (grid dim 0).
│               -> SIGABRT (classic) / SIGFPE (multibit).
└─ CPU BEFORE : PRF(0) -> trivial 0s, deterministic (reference behavior).
↓
AFTER : GPU short-circuits after validity asserts, before any seeded input.
        create_trivial_zero_radix(out_blocks) ✓ (no kernel launch).
        [ 0 | 0 ] -> same width and value as the CPU.
```