### PR TITLE
fix(gpu): move doc bench to scaleway

### DIFF
--- a/.github/workflows/benchmark_documentation.yml
+++ b/.github/workflows/benchmark_documentation.yml
@@ -118,9 +118,10 @@ jobs:
     uses: ./.github/workflows/benchmark_gpu_common.yml
     if: inputs.run-gpu-integer-benchmarks
     with:
-      profile: multi-h100-sxm5
-      cloud_provider: hyperstack
-      hardware_name: n3-H100-SXM5x8
+      backend: terraform
+      profile: scaleway-multi-h100-sxm5
+      cloud_provider: scaleway
+      hardware_name: H100-SXM-8-80G
       command: integer_multi_bit,hlapi_erc7984
       op_flavor: fast_default
       bench_type: both
@@ -180,9 +181,10 @@ jobs:
     uses: ./.github/workflows/benchmark_gpu_common.yml
     if: inputs.run-gpu-core-crypto-benchmarks
     with:
-      profile: multi-h100-sxm5
-      cloud_provider: hyperstack
-      hardware_name: n3-H100-SXM5x8
+      backend: terraform
+      profile: scaleway-multi-h100-sxm5
+      cloud_provider: scaleway
+      hardware_name: H100-SXM-8-80G
       command: pbs, ks_pbs
       bench_type: latency
       params_type: classical_documentation + multi_bit_documentation
@@ -201,9 +203,10 @@ jobs:
     uses: ./.github/workflows/benchmark_gpu_common.yml
     if: inputs.run-gpu-zk-benchmarks
     with:
-      profile: multi-h100-sxm5
-      cloud_provider: hyperstack
-      hardware_name: n3-H100-SXM5x8
+      backend: terraform
+      profile: scaleway-multi-h100-sxm5
+      cloud_provider: scaleway
+      hardware_name: H100-SXM-8-80G
       command: integer_zk
       op_flavor: default
       bench_type: both

--- a/ci/slab.toml
+++ b/ci/slab.toml
@@ -179,7 +179,9 @@ flavor_name = "n3-L40x8"
 user = "ubuntu"
 
 [backend.terraform.scaleway-multi-h100-sxm5]
-script_path = "ci/terraform_scripts/scaleway/terraform.tf"
+# Due to a bug that can't be figured out on SXM-8 on scaleway, we need to use a dedicated script
+# for now to get the instance to register a github actions runner
+script_path = "ci/terraform_scripts/scaleway/terraform_sxm_x8.tf"
 instance_type = "H100-SXM-8-80G"
 user = "ubuntu"
 

--- a/ci/terraform_scripts/scaleway/terraform_sxm_x8.tf
+++ b/ci/terraform_scripts/scaleway/terraform_sxm_x8.tf
@@ -1,0 +1,73 @@
+# This script is an SXM-8 specific variant for Scaleway instance
+# there is a bug with our current OS image we can't figure out, this uses a base Scaleway image
+terraform {
+  required_providers {
+    scaleway = {
+      source  = "scaleway/scaleway"
+      version = "~> 2.73"
+    }
+  }
+  required_version = "~> 1.14"
+}
+
+provider "scaleway" {
+  zone = "fr-par-2"
+}
+
+# Provided via Slab server env
+variable "project_id" {
+  type        = string
+  description = "Scaleway project ID to attached to"
+}
+
+# Provided via ci/slab.toml
+variable "instance_type" {
+  type        = string
+  description = "Scaleway instance type to be used"
+}
+
+# Provided by Slab server
+variable "instance_label" {
+  type        = string
+  description = "Instance name to display in console"
+}
+
+# Provided by Slab server
+variable "user_data" {
+  type        = string
+  description = "Script that will be run at instance startup"
+}
+
+resource "scaleway_instance_ip" "github_runner" {
+  project_id = var.project_id
+}
+
+data "scaleway_instance_security_group" "github_runner" {
+  project_id = var.project_id
+  name       = "github-actions-runner"
+}
+
+resource "scaleway_instance_server" "scaleway_gpu_instance" {
+  project_id = var.project_id
+  # Current latest ubuntu GPU OS image from Scaleway (2026/07/28)
+  image      = "ubuntu_noble_gpu_os_13_nvidia"
+  type       = var.instance_type
+  name       = var.instance_label
+
+  root_volume {
+    size_in_gb = 200
+  }
+
+  ip_id = scaleway_instance_ip.github_runner.id
+
+  user_data = {
+    "cloud-init" = var.user_data
+  }
+
+  security_group_id = data.scaleway_instance_security_group.github_runner.id
+}
+
+output "instance_id" {
+  value       = scaleway_instance_server.scaleway_gpu_instance.id
+  description = "Unique ID of the Scaleway instance"
+}


### PR DESCRIPTION
- use default scaleway image for GPU CI
- update mirror to use Scaleway Ubuntu mirror for instances which are currently located in Paris

example job managing to complete on SXM-8 with setup from this PR

~~https://github.com/zama-ai/tfhe-rs/actions/runs/30362105494/job/90285535367~~

latest version of the PR run https://github.com/zama-ai/tfhe-rs/actions/runs/30374400147/job/90327900581