### PR TITLE
Ns/feat/otp transciphering

### DIFF
--- a/tfhe-benchmark/benches/transciphering/aes_transciphering.rs
+++ b/tfhe-benchmark/benches/transciphering/aes_transciphering.rs
@@ -96,7 +96,7 @@ pub fn cpu_aes_transciphering(c: &mut Criterion) {
             b.iter(|| {
                 let fhe_key = AesFheRoundKeys::new(&sks, &enc_key);
                 let mut stream = AesFheState::new(fhe_key, iv);
-                black_box(stream.next_keystream_bits(&sks, BLOCK_BITS));
+                black_box(stream.next_keystream_bits(&sks, BLOCK_BITS).unwrap());
             })
         },
     );
@@ -121,7 +121,7 @@ pub fn cpu_aes_transciphering(c: &mut Criterion) {
         |b| {
             b.iter(|| {
                 stream.seek(&sks, 0);
-                black_box(stream.next_keystream_bits(&sks, BLOCK_BITS));
+                black_box(stream.next_keystream_bits(&sks, BLOCK_BITS).unwrap());
             })
         },
     );
@@ -143,7 +143,7 @@ pub fn cpu_aes_transciphering(c: &mut Criterion) {
         |b| {
             b.iter(|| {
                 stream.seek(&sks, 0);
-                black_box(stream.next_keystream_bits(&sks, total_bits));
+                black_box(stream.next_keystream_bits(&sks, total_bits).unwrap());
             })
         },
     );
@@ -154,7 +154,7 @@ pub fn cpu_aes_transciphering(c: &mut Criterion) {
     // `seek(&sks, 0)` reset below.
     let total_bytes = BLOCK_BYTES * N_BLOCKS;
     let message = vec![0u8; total_bytes];
-    let sym_cipher = AesPlainState::new(key, iv).encrypt(&message);
+    let sym_cipher = AesPlainState::new(key, iv).encrypt(&message).unwrap();
 
     let benchmark_spec = BenchmarkSpec::<str>::new_transciphering(
         TranscipheringBench::Aes(AesFlavor::Transcipher16Blocks),

--- a/tfhe-benchmark/benches/transciphering/kreyvium_transciphering.rs
+++ b/tfhe-benchmark/benches/transciphering/kreyvium_transciphering.rs
@@ -104,7 +104,7 @@ pub fn cpu_kreyvium_transciphering(c: &mut Criterion) {
             b.iter_batched(
                 || warm_state.clone(),
                 |mut stream| {
-                    black_box(stream.next_keystream_bits(&sks, KEYSTREAM_BITS));
+                    black_box(stream.next_keystream_bits(&sks, KEYSTREAM_BITS).unwrap());
                 },
                 BatchSize::SmallInput,
             )
@@ -118,7 +118,7 @@ pub fn cpu_kreyvium_transciphering(c: &mut Criterion) {
             KreyviumPlainKey::from(key_bytes),
             KreyviumIV::from(iv_bytes),
         );
-        plain_stream.encrypt(&message)
+        plain_stream.encrypt(&message).unwrap()
     };
 
     let benchmark_spec = BenchmarkSpec::<str>::new_transciphering(

--- a/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_kreyvium.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_kreyvium.rs
@@ -120,7 +120,7 @@ where
         let key_bool: [bool; 128] = std::array::from_fn(|i| key_bits[i] == 1);
         let iv_bool: [bool; 128] = std::array::from_fn(|i| iv_bits[i] == 1);
         let mut ref_kreyvium = KreyviumPlainState::new(key_bool, iv_bool);
-        let ref_bytes = ref_kreyvium.next_keystream_bits(num_steps);
+        let ref_bytes = ref_kreyvium.next_keystream_bits(num_steps).unwrap();
         let cpu_output = ref_bytes
             .iter()
             .flat_map(|&b| (0..8).map(move |i| (b >> i) & 1))
@@ -170,7 +170,7 @@ where
     let key_bool: [bool; 128] = std::array::from_fn(|i| key_bits[i] == 1);
     let iv_bool: [bool; 128] = std::array::from_fn(|i| iv_bits[i] == 1);
     let mut ref_kreyvium = KreyviumPlainState::new(key_bool, iv_bool);
-    let ref_bytes = ref_kreyvium.next_keystream_bits(total_steps);
+    let ref_bytes = ref_kreyvium.next_keystream_bits(total_steps).unwrap();
     let cpu_output = ref_bytes
         .iter()
         .flat_map(|&b| (0..8).map(move |i| (b >> i) & 1))

--- a/tfhe/src/shortint/client_key/mod.rs
+++ b/tfhe/src/shortint/client_key/mod.rs
@@ -179,6 +179,29 @@ impl<AP: EncryptionAtomicPattern> GenericClientKey<AP> {
         ShortintEngine::with_thread_local_mut(|engine| engine.encrypt(self, message))
     }
 
+    /// Encrypt a boolean message using the client key.
+    ///
+    /// The input message is converted to 1u64 if true, 0u64 otherwise.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use tfhe::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS;
+    /// use tfhe::shortint::ClientKey;
+    ///
+    /// let cks = ClientKey::new(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+    ///
+    /// for msg in [false, true] {
+    ///     let ct = cks.encrypt_bool(msg);
+    ///     assert_eq!(ct.degree.get(), 1);
+    ///     let dec = cks.decrypt(&ct);
+    ///     assert_eq!(u64::from(msg), dec);
+    /// }
+    /// ```
+    pub fn encrypt_bool(&self, message: bool) -> Ciphertext {
+        ShortintEngine::with_thread_local_mut(|engine| engine.encrypt_bool(self, message))
+    }
+
     /// Encrypt a integer message using the client key returning a compressed ciphertext.
     ///
     /// The input message is reduced to the encrypted message space modulus

--- a/tfhe/src/shortint/engine/client_side.rs
+++ b/tfhe/src/shortint/engine/client_side.rs
@@ -80,6 +80,17 @@ impl ShortintEngine {
         )
     }
 
+    pub fn encrypt_bool<AP: EncryptionAtomicPattern>(
+        &mut self,
+        client_key: &GenericClientKey<AP>,
+        message: bool,
+    ) -> Ciphertext {
+        let mut ct = self.encrypt(client_key, message.into());
+        ct.degree = Degree::new(1);
+
+        ct
+    }
+
     pub fn encrypt_compressed<AP: EncryptionAtomicPattern>(
         &mut self,
         client_key: &GenericClientKey<AP>,

--- a/tfhe/src/transciphering/ciphers/aes/fhe.rs
+++ b/tfhe/src/transciphering/ciphers/aes/fhe.rs
@@ -1,6 +1,6 @@
 use crate::shortint::{Ciphertext, ServerKey};
 use crate::transciphering::ciphers::aes::AesIv;
-use crate::transciphering::{FheKeyStream, StreamCipherKind, Transcipherer};
+use crate::transciphering::{FheKeyStream, InsufficientKeystream, StreamCipherKind, Transcipherer};
 use rayon::prelude::*;
 
 use super::encrypt::encrypt_block;
@@ -35,7 +35,11 @@ impl Transcipherer for AesFheState {
         StreamCipherKind::Aes
     }
 
-    fn next_keystream_bits(&mut self, sks: &ServerKey, n_bits: usize) -> FheKeyStream {
+    fn next_keystream_bits(
+        &mut self,
+        sks: &ServerKey,
+        n_bits: usize,
+    ) -> Result<FheKeyStream, InsufficientKeystream> {
         //  counter
         //     │
         //     ▼
@@ -51,20 +55,23 @@ impl Transcipherer for AesFheState {
         //  a non-block-aligned call wastes the head + tail. The byte-aligned
         //  transciphering path requests the whole message in one call to avoid
         //  this.
+        let end_counter = self
+            .counter
+            .checked_add(n_bits as u64)
+            .ok_or(InsufficientKeystream)?;
+
         let skip_head = (self.counter % 128) as usize;
         let start_block = self.counter / 128;
-        let n_blocks = (skip_head + n_bits).div_ceil(128);
+        let n_blocks = end_counter.div_ceil(128) - start_block;
 
-        let blocks: Vec<[Ciphertext; 128]> = (0..n_blocks as u64)
+        let blocks: Vec<[Ciphertext; 128]> = (0..n_blocks)
             .into_par_iter()
             .map(|i| self.keystream_block(sks, (start_block + i) as u128))
             .collect();
 
-        self.counter = self
-            .counter
-            .checked_add(n_bits as u64)
-            .expect("AesFheStream: keystream bit counter overflowed u64");
+        self.counter = end_counter;
 
+        // TODO: partial block could be cached to avoid generating it twice (issue #1503)
         let flat: Vec<Ciphertext> = blocks
             .into_iter()
             .flatten()
@@ -72,7 +79,7 @@ impl Transcipherer for AesFheState {
             .take(n_bits)
             .collect();
 
-        FheKeyStream::from_raw_parts(flat)
+        Ok(FheKeyStream::from_raw_parts(flat))
     }
 
     fn seek(&mut self, _sks: &ServerKey, target_counter: u64) {

--- a/tfhe/src/transciphering/ciphers/aes/mod.rs
+++ b/tfhe/src/transciphering/ciphers/aes/mod.rs
@@ -12,7 +12,6 @@ pub use fhe::AesFheState;
 pub use key::AesFheRoundKeys;
 pub use plain::AesPlainState;
 
-use crate::shortint::ciphertext::Degree;
 use crate::shortint::{Ciphertext, ClientKey};
 use crate::transciphering::ciphers::*;
 
@@ -45,11 +44,7 @@ impl AesPlainKey {
 
     pub fn encrypt(&self, client_key: &ClientKey) -> AesFheKey {
         AesFheKey {
-            key: self.expand().map(|b| {
-                let mut c = client_key.encrypt(b as u64);
-                c.degree = Degree::new(1);
-                c
-            }),
+            key: self.expand().map(|b| client_key.encrypt_bool(b)),
         }
     }
 

--- a/tfhe/src/transciphering/ciphers/aes/plain.rs
+++ b/tfhe/src/transciphering/ciphers/aes/plain.rs
@@ -2,7 +2,7 @@ use tfhe_csprng::generators::aes_ctr::{AesBlockCipher, AesKey};
 use tfhe_csprng::generators::default::AesDefaultBlockCipher;
 
 use crate::transciphering::ciphers::aes::{AesIv, AesPlainKey};
-use crate::transciphering::{StreamCipher, StreamCipherKind};
+use crate::transciphering::{InsufficientKeystream, StreamCipher, StreamCipherKind};
 
 /// Client-side AES-128 in CTR mode, in clear. Mirrors [`super::fhe::AesFheState`].
 pub struct AesPlainState {
@@ -26,14 +26,19 @@ impl StreamCipher for AesPlainState {
         StreamCipherKind::Aes
     }
 
-    fn next_keystream_bits(&mut self, n_bits: usize) -> Vec<u8> {
+    fn next_keystream_bits(&mut self, n_bits: usize) -> Result<Vec<u8>, InsufficientKeystream> {
+        let end_counter = self
+            .counter
+            .checked_add(n_bits as u64)
+            .ok_or(InsufficientKeystream)?;
+
         let skip_head = (self.counter % 128) as usize;
         let start_block = self.counter / 128;
-        let n_blocks = (skip_head + n_bits).div_ceil(128);
+        let n_blocks = end_counter.div_ceil(128) - start_block;
 
         // `generate_next` outputs 16 bytes in NIST order, LSB-first within each
         // byte, matching the trait convention.
-        let mut keystream_bytes: Vec<u8> = Vec::with_capacity(n_blocks * 16);
+        let mut keystream_bytes: Vec<u8> = Vec::with_capacity(n_blocks as usize * 16);
         for i in 0..n_blocks as u128 {
             let counter_value = self.iv.to_u128().wrapping_add(start_block as u128 + i);
             let counter_csprng = u128::from_ne_bytes(counter_value.to_be_bytes());
@@ -41,10 +46,7 @@ impl StreamCipher for AesPlainState {
             keystream_bytes.extend_from_slice(&block);
         }
 
-        self.counter = self
-            .counter
-            .checked_add(n_bits as u64)
-            .expect("AesPlainStream: keystream bit counter overflowed u64");
+        self.counter = end_counter;
 
         let mut result = vec![0u8; n_bits.div_ceil(8)];
         for out_idx in 0..n_bits {
@@ -52,7 +54,7 @@ impl StreamCipher for AesPlainState {
             let bit = (keystream_bytes[src_idx / 8] >> (src_idx % 8)) & 1;
             result[out_idx / 8] |= bit << (out_idx % 8);
         }
-        result
+        Ok(result)
     }
 
     fn seek(&mut self, target_counter: u64) {

--- a/tfhe/src/transciphering/ciphers/aes/test.rs
+++ b/tfhe/src/transciphering/ciphers/aes/test.rs
@@ -1,5 +1,4 @@
 use super::sbox::sbox;
-use crate::shortint::ciphertext::Degree;
 use crate::shortint::parameters::test_params::TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
 use crate::shortint::prelude::*;
 use crate::transciphering::ciphers::aes::{
@@ -183,11 +182,8 @@ fn fhe_sbox_exhaustive() {
         .enumerate()
         .filter_map(|(b, expected)| {
             let b = b as u8;
-            let mut bits: [Ciphertext; 8] = std::array::from_fn(|j| {
-                let mut c = cks.encrypt(((b >> j) & 1) as u64);
-                c.degree = Degree::new(1);
-                c
-            });
+            let mut bits: [Ciphertext; 8] =
+                core::array::from_fn(|j| cks.encrypt_bool(((b >> j) & 1) == 1));
             sbox(&sks, &flush_lut, &mut bits);
             let got = (0..8u8).fold(0u8, |acc, j| {
                 acc | (((cks.decrypt(&bits[j as usize]) & 1) as u8) << j)

--- a/tfhe/src/transciphering/ciphers/aes/test.rs
+++ b/tfhe/src/transciphering/ciphers/aes/test.rs
@@ -4,7 +4,7 @@ use crate::shortint::prelude::*;
 use crate::transciphering::ciphers::aes::{
     AesFheRoundKeys, AesFheState, AesIv, AesPlainKey, AesPlainState,
 };
-use crate::transciphering::{StreamCipher, Transcipherer};
+use crate::transciphering::{InsufficientKeystream, StreamCipher, Transcipherer};
 use rand::{Rng, SeedableRng};
 use rayon::prelude::*;
 
@@ -33,7 +33,7 @@ fn decrypt_u128(cks: &ClientKey, bits: &[Ciphertext; 128]) -> u128 {
 
 fn plain_aes_ctr_keystream(key: u128, iv: u128, n_blocks: usize) -> Vec<u128> {
     let mut stream = AesPlainState::new(key, iv);
-    let bytes = stream.next_keystream_bits(128 * n_blocks);
+    let bytes = stream.next_keystream_bits(128 * n_blocks).unwrap();
     (0..n_blocks)
         .map(|i| {
             let block_bytes: [u8; 16] = bytes[16 * i..16 * (i + 1)]
@@ -206,7 +206,7 @@ fn aes_fhe_known_answer() {
     let fhe_key = AesFheRoundKeys::new(&sks, &enc_key);
     let mut stream = AesFheState::new(fhe_key, IV);
 
-    let keystream = stream.next_keystream_bits(&sks, 128);
+    let keystream = stream.next_keystream_bits(&sks, 128).unwrap();
     let got = decrypt_block(&cks, &keystream.into_raw_parts());
 
     assert_eq!(
@@ -226,7 +226,7 @@ fn aes_fhe_ctr_byte_order_nist() {
     let mut stream = AesFheState::new(fhe_key, CTR_IV);
 
     let n_blocks = CTR_KEYSTREAM.len();
-    let keystream = stream.next_keystream_bits(&sks, 128 * n_blocks);
+    let keystream = stream.next_keystream_bits(&sks, 128 * n_blocks).unwrap();
     let bits = keystream.into_raw_parts();
 
     for (i, expected) in CTR_KEYSTREAM.iter().enumerate() {
@@ -251,7 +251,7 @@ fn aes_fhe_matches_plain_random() {
     let fhe_key = AesFheRoundKeys::new(&sks, &enc_key);
     let mut stream = AesFheState::new(fhe_key, iv);
 
-    let keystream = stream.next_keystream_bits(&sks, 128 * n_blocks);
+    let keystream = stream.next_keystream_bits(&sks, 128 * n_blocks).unwrap();
     let bits = keystream.into_raw_parts();
 
     for (i, expected) in plain.iter().enumerate() {
@@ -271,7 +271,7 @@ fn aes_transcipher_round_trip() {
     let message: [u8; 16] = *b"Hello world!1234";
 
     let mut plain_stream = AesPlainState::new(key, iv);
-    let sym_cipher = plain_stream.encrypt(&message);
+    let sym_cipher = plain_stream.encrypt(&message).unwrap();
 
     let enc_key = AesPlainKey::from(key).encrypt(&cks);
     let fhe_key = AesFheRoundKeys::new(&sks, &enc_key);
@@ -339,8 +339,9 @@ fn aes_fhe_seek() {
     let n_bits = 192;
     let fhe_bits = fhe_stream
         .next_keystream_bits(&sks, n_bits)
+        .unwrap()
         .into_raw_parts();
-    let plain_bytes = plain_stream.next_keystream_bits(n_bits);
+    let plain_bytes = plain_stream.next_keystream_bits(n_bits).unwrap();
     assert_keystream_matches(&cks, &fhe_bits, &plain_bytes, n_bits);
     assert_eq!(fhe_stream.current_counter(), 64 + n_bits as u64);
 }
@@ -360,8 +361,49 @@ fn aes_fhe_non_byte_aligned_n_bits() {
     let n_bits = 100;
     let fhe_bits = fhe_stream
         .next_keystream_bits(&sks, n_bits)
+        .unwrap()
         .into_raw_parts();
-    let plain_bytes = plain_stream.next_keystream_bits(n_bits);
+    let plain_bytes = plain_stream.next_keystream_bits(n_bits).unwrap();
     assert_keystream_matches(&cks, &fhe_bits, &plain_bytes, n_bits);
     assert_eq!(fhe_stream.current_counter(), n_bits as u64);
+}
+
+#[test]
+fn aes_exhaustion_at_counter_range_end() {
+    let (cks, sks) = gen_keys(PARAM);
+    let (key, iv) = gen_random_key_iv();
+
+    let enc_key = AesPlainKey::from(key).encrypt(&cks);
+    let fhe_key = AesFheRoundKeys::new(&sks, &enc_key);
+    let mut fhe_stream = AesFheState::new(fhe_key, iv);
+    let mut plain_stream = AesPlainState::new(key, iv);
+
+    // 200 bits short of the end: skip_head = 55, so 200 bits span 2 blocks.
+    let n_bits = 200;
+    let start = u64::MAX - n_bits as u64;
+    fhe_stream.seek(&sks, start);
+    plain_stream.seek(start);
+
+    // One bit too many: both sides refuse and leave the counter where it was.
+    assert!(matches!(
+        plain_stream.next_keystream_bits(n_bits + 1),
+        Err(InsufficientKeystream)
+    ));
+    assert_eq!(plain_stream.current_counter(), start);
+    assert!(matches!(
+        fhe_stream.next_keystream_bits(&sks, n_bits + 1),
+        Err(InsufficientKeystream)
+    ));
+    assert_eq!(fhe_stream.current_counter(), start);
+
+    // Exactly the bits that remain: succeeds, both impls agree bit for bit, and
+    // the counter lands on u64::MAX.
+    let fhe_bits = fhe_stream
+        .next_keystream_bits(&sks, n_bits)
+        .unwrap()
+        .into_raw_parts();
+    let plain_bytes = plain_stream.next_keystream_bits(n_bits).unwrap();
+    assert_keystream_matches(&cks, &fhe_bits, &plain_bytes, n_bits);
+    assert_eq!(fhe_stream.current_counter(), u64::MAX);
+    assert_eq!(plain_stream.current_counter(), u64::MAX);
 }

--- a/tfhe/src/transciphering/ciphers/kreyvium/fhe.rs
+++ b/tfhe/src/transciphering/ciphers/kreyvium/fhe.rs
@@ -3,7 +3,7 @@
 use crate::shortint::ciphertext::NoiseLevel;
 use crate::shortint::{Ciphertext, ServerKey};
 use crate::transciphering::ciphers::shift_register::ShiftRegister;
-use crate::transciphering::{FheKeyStream, StreamCipherKind, Transcipherer};
+use crate::transciphering::{FheKeyStream, InsufficientKeystream, StreamCipherKind, Transcipherer};
 
 use super::{
     collect_boxed_array, KreyviumBackwardRoundOutput, KreyviumIV, KreyviumRound,
@@ -96,8 +96,16 @@ impl Transcipherer for KreyviumFheState {
         StreamCipherKind::Kreyvium
     }
 
-    fn next_keystream_bits(&mut self, sks: &ServerKey, n_bits: usize) -> FheKeyStream {
-        FheKeyStream(self.next_n(sks, n_bits))
+    fn next_keystream_bits(
+        &mut self,
+        sks: &ServerKey,
+        n_bits: usize,
+    ) -> Result<FheKeyStream, InsufficientKeystream> {
+        self.current_counter()
+            .checked_add(n_bits as u64)
+            .ok_or(InsufficientKeystream)?;
+
+        Ok(FheKeyStream(self.next_n(sks, n_bits)))
     }
 
     fn seek(&mut self, sks: &ServerKey, target_counter: u64) {

--- a/tfhe/src/transciphering/ciphers/kreyvium/mod.rs
+++ b/tfhe/src/transciphering/ciphers/kreyvium/mod.rs
@@ -149,7 +149,8 @@ impl<T> KreyviumState<T> {
         self.k.n_shifts(n_rounds);
         self.iv.n_shifts(n_rounds);
 
-        // Panic explicitly if counter overflows
+        // Panic explicitly if counter overflows. Should never be reached because of the check
+        // in next_keystream_bits.
         self.counter = self.counter.checked_add(n_rounds as u64).unwrap();
     }
 

--- a/tfhe/src/transciphering/ciphers/kreyvium/mod.rs
+++ b/tfhe/src/transciphering/ciphers/kreyvium/mod.rs
@@ -1,3 +1,10 @@
+//! [Kreyvium](https://eprint.iacr.org/2023/980.pdf) is a lightweight, FHE-friendly stream cipher.
+//!
+//! Its initialization runs a heavy one-time warmup before any keystream is produced. Once warmed,
+//! drawing keystream is comparatively lightweight per bit, so Kreyvium suits workloads where a
+//! warmed state is reused to transcipher a large volume of data, amortizing the warmup across many
+//! keystream bits.
+
 mod fhe;
 mod plain;
 #[cfg(test)]

--- a/tfhe/src/transciphering/ciphers/kreyvium/plain.rs
+++ b/tfhe/src/transciphering/ciphers/kreyvium/plain.rs
@@ -1,6 +1,5 @@
 //! Plaintext implementation of the Kreyvium Algorithm
 
-use crate::shortint::ciphertext::Degree;
 use crate::shortint::ClientKey;
 use crate::transciphering::ciphers::shift_register::ShiftRegister;
 use crate::transciphering::ciphers::{pack_bits_lsb_first, unpack_bits_lsb_first};
@@ -32,12 +31,9 @@ impl KreyviumPlainKey {
     /// key consumed by [`KreyviumFheState`](super::KreyviumFheState).
     pub fn encrypt(&self, client_key: &ClientKey) -> KreyviumFheKey {
         KreyviumFheKey::new(
-            super::collect_boxed_array(unpack_key_bits(&self.bits).iter().map(|&b| {
-                let mut ct = client_key.encrypt(b as u64);
-                // We know each value is a single bit, so we can set a tighter degree.
-                ct.degree = Degree::new(1);
-                ct
-            }))
+            super::collect_boxed_array(
+                unpack_key_bits(&self.bits).map(|b| client_key.encrypt_bool(b)),
+            )
             .expect("array and iter size match"),
         )
     }

--- a/tfhe/src/transciphering/ciphers/kreyvium/plain.rs
+++ b/tfhe/src/transciphering/ciphers/kreyvium/plain.rs
@@ -3,7 +3,7 @@
 use crate::shortint::ClientKey;
 use crate::transciphering::ciphers::shift_register::ShiftRegister;
 use crate::transciphering::ciphers::{pack_bits_lsb_first, unpack_bits_lsb_first};
-use crate::transciphering::{StreamCipher, StreamCipherKind};
+use crate::transciphering::{InsufficientKeystream, StreamCipher, StreamCipherKind};
 
 use super::{
     KreyviumBackwardRoundOutput, KreyviumFheKey, KreyviumRound, KreyviumRoundInput,
@@ -131,11 +131,15 @@ impl StreamCipher for KreyviumPlainState {
         StreamCipherKind::Kreyvium
     }
 
-    fn next_keystream_bits(&mut self, n_bits: usize) -> Vec<u8> {
+    fn next_keystream_bits(&mut self, n_bits: usize) -> Result<Vec<u8>, InsufficientKeystream> {
+        self.current_counter()
+            .checked_add(n_bits as u64)
+            .ok_or(InsufficientKeystream)?;
+
         let bits = self.next_n(&(), n_bits);
         let mut result = vec![0u8; n_bits.div_ceil(8)];
         pack_bits_lsb_first(&bits, &mut result);
-        result
+        Ok(result)
     }
 
     fn seek(&mut self, target_counter: u64) {

--- a/tfhe/src/transciphering/ciphers/kreyvium/test.rs
+++ b/tfhe/src/transciphering/ciphers/kreyvium/test.rs
@@ -7,10 +7,13 @@ use crate::shortint::parameters::test_params::{
 };
 use crate::shortint::prelude::*;
 use crate::transciphering::ciphers::kreyvium::{
-    KreyviumFheState, KreyviumPlainKey, KreyviumPlainState,
+    KreyviumFheState, KreyviumPlainKey, KreyviumPlainState, KreyviumState,
 };
 use crate::transciphering::ciphers::pack_bits_lsb_first;
-use crate::transciphering::{apply_keystream, FheKeyStream, StreamCipher, Transcipherer};
+use crate::transciphering::ciphers::shift_register::ShiftRegister;
+use crate::transciphering::{
+    apply_keystream, FheKeyStream, InsufficientKeystream, StreamCipher, Transcipherer,
+};
 
 fn get_hexadecimal_string_from_bytes(bytes: &[u8]) -> String {
     let mut hexadecimal = String::new();
@@ -79,7 +82,7 @@ fn kreyvium_test_plain() {
         let iv_bytes = hex_to_bytes_16(iv);
 
         let mut kreyvium = KreyviumPlainState::new(key_bytes, iv_bytes);
-        let vec = kreyvium.next_keystream_bits(64);
+        let vec = kreyvium.next_keystream_bits(64).unwrap();
 
         let hexadecimal = get_hexadecimal_string_from_bytes(&vec);
         assert_eq!(hexadecimal, expected, "key={key} iv={iv}");
@@ -100,7 +103,7 @@ fn kreyvium_plain_encrypt_decrypt_round_trip() {
     let message: Vec<u8> = (0..37).map(|_| rng.gen()).collect();
 
     let mut enc_stream = KreyviumPlainState::new(key, iv);
-    let encrypted = enc_stream.encrypt(&message);
+    let encrypted = enc_stream.encrypt(&message).unwrap();
     assert_eq!(encrypted.bytes().len(), message.len());
 
     let mut dec_stream = KreyviumPlainState::new(key, iv);
@@ -120,7 +123,7 @@ fn kreyvium_fhe_keystream_known_answer(params: ClassicPBSParameters) {
 
     let mut kreyvium = KreyviumFheState::new(cipher_key, iv_bytes, &server_key);
 
-    let cts = kreyvium.next_keystream_bits(&server_key, 64);
+    let cts = kreyvium.next_keystream_bits(&server_key, 64).unwrap();
 
     let bytes = decrypt_keystream_to_bytes(&cts, &client_key);
 
@@ -169,13 +172,13 @@ fn kreyvium_test_round_trip() {
         // Symmetric Kreyvium encrypt: plain keystream XOR input bytes
         // (LSB-first within each byte, matching `to_le_bytes`).
         let mut sym_stream = KreyviumPlainState::new(key_bits, iv_bits);
-        let sym_cipher = sym_stream.encrypt(&input.to_le_bytes());
+        let sym_cipher = sym_stream.encrypt(&input.to_le_bytes()).unwrap();
 
         // FHE side: encrypt the same key bits, run FHE stream, transcipher.
         let cipher_key = KreyviumPlainKey::from(key_bits).encrypt(&client_key);
 
         let mut fhe_stream = KreyviumFheState::new(cipher_key, iv_bits, &server_key);
-        let keystream = fhe_stream.next_keystream_bits(&server_key, 64);
+        let keystream = fhe_stream.next_keystream_bits(&server_key, 64).unwrap();
 
         let chunks = apply_keystream(&server_key, &keystream, &sym_cipher);
 
@@ -207,9 +210,9 @@ fn kreyvium_seek_plain() {
     // Snapshot states at counters 0 and 64 from a fresh stream.
     let state_at_0 = KreyviumPlainState::new(key, iv);
     let mut state_at_64 = state_at_0.clone();
-    let head_keystream = state_at_64.next_keystream_bits(64);
+    let head_keystream = state_at_64.next_keystream_bits(64).unwrap();
     assert_eq!(state_at_64.current_counter(), 64);
-    let mid_keystream = state_at_64.clone().next_keystream_bits(64);
+    let mid_keystream = state_at_64.clone().next_keystream_bits(64).unwrap();
 
     // Forward seek
     let mut s = KreyviumPlainState::new(key, iv);
@@ -218,21 +221,21 @@ fn kreyvium_seek_plain() {
     assert_eq!(s, state_at_64, "forward-seek state mismatch");
 
     // Backward seek
-    s.next_keystream_bits(128); // counter = 192
+    s.next_keystream_bits(128).unwrap(); // counter = 192
     assert_eq!(s.current_counter(), 192);
     s.seek(64);
     assert_eq!(s.current_counter(), 64);
     assert_eq!(s, state_at_64, "backward-seek state mismatch");
 
     // Re-emit from the rewound state and check keystream matches.
-    let mid_again = s.next_keystream_bits(64);
+    let mid_again = s.next_keystream_bits(64).unwrap();
     assert_eq!(mid_again, mid_keystream);
 
     // Seek all the way back to 0
     s.seek(0);
     assert_eq!(s.current_counter(), 0);
     assert_eq!(s, state_at_0, "seek-to-0 state mismatch");
-    let head_again = s.next_keystream_bits(64);
+    let head_again = s.next_keystream_bits(64).unwrap();
     assert_eq!(head_again, head_keystream);
 }
 
@@ -252,7 +255,7 @@ fn kreyvium_seek_fhe() {
 
     // Reference plain keystream.
     let mut ref_stream = KreyviumPlainState::new(key_bits, iv_bits);
-    let ref_keystream = ref_stream.next_keystream_bits(192);
+    let ref_keystream = ref_stream.next_keystream_bits(192).unwrap();
 
     let cipher_key = KreyviumPlainKey::from(key_bits).encrypt(&client_key);
     let mut k = KreyviumFheState::new(cipher_key, iv_bits, &server_key);
@@ -262,7 +265,7 @@ fn kreyvium_seek_fhe() {
     k.seek(&server_key, 64);
     assert_eq!(k.current_counter(), 64);
 
-    let mid = k.next_keystream_bits(&server_key, 64);
+    let mid = k.next_keystream_bits(&server_key, 64).unwrap();
     assert_eq!(k.current_counter(), 128);
     assert_eq!(
         decrypt_keystream_to_bytes(&mid, &client_key),
@@ -272,10 +275,67 @@ fn kreyvium_seek_fhe() {
     // Backward seek to an earlier counter and re-emit
     k.seek(&server_key, 64);
     assert_eq!(k.current_counter(), 64);
-    let mid_again = k.next_keystream_bits(&server_key, 64);
+    let mid_again = k.next_keystream_bits(&server_key, 64).unwrap();
     assert_eq!(k.current_counter(), 128);
     assert_eq!(
         decrypt_keystream_to_bytes(&mid_again, &client_key),
         ref_keystream[8..16]
     );
+}
+
+fn filled_register<const N: usize, T: Clone>(filler: &T) -> ShiftRegister<N, T> {
+    ShiftRegister::new(Box::new(std::array::from_fn(|_| filler.clone())))
+}
+
+/// Build a stream already sitting at `counter`, with `filler` in every register
+/// slot. This avoids having to run a full warmup for a quick test
+fn state_at_counter<T: Clone>(filler: &T, counter: u64) -> KreyviumState<T> {
+    KreyviumState {
+        a: filled_register(filler),
+        b: filled_register(filler),
+        c: filled_register(filler),
+        k: filled_register(filler),
+        iv: filled_register(filler),
+        counter,
+    }
+}
+
+const EXHAUSTION_TAIL_BITS: usize = 8;
+
+#[test]
+fn kreyvium_plain_exhaustion_at_counter_range_end() {
+    let start = u64::MAX - EXHAUSTION_TAIL_BITS as u64;
+    let mut stream: KreyviumPlainState = state_at_counter(&false, start);
+
+    // One bit too many: refused before any round runs, counter untouched.
+    assert!(matches!(
+        stream.next_keystream_bits(EXHAUSTION_TAIL_BITS + 1),
+        Err(InsufficientKeystream)
+    ));
+    assert_eq!(stream.current_counter(), start);
+
+    // Exactly the bits that remain: succeeds and lands on u64::MAX.
+    assert!(stream.next_keystream_bits(EXHAUSTION_TAIL_BITS).is_ok());
+    assert_eq!(stream.current_counter(), u64::MAX);
+
+    // Fully exhausted: even a single further bit is refused.
+    assert!(matches!(
+        stream.next_keystream_bits(1),
+        Err(InsufficientKeystream)
+    ));
+    assert_eq!(stream.current_counter(), u64::MAX);
+}
+
+#[test]
+fn kreyvium_fhe_exhaustion_at_counter_range_end() {
+    let (_client_key, server_key) = gen_keys(TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128);
+
+    let start = u64::MAX - EXHAUSTION_TAIL_BITS as u64;
+    let mut stream: KreyviumFheState = state_at_counter(&server_key.create_trivial(0), start);
+
+    assert!(matches!(
+        stream.next_keystream_bits(&server_key, EXHAUSTION_TAIL_BITS + 1),
+        Err(InsufficientKeystream)
+    ));
+    assert_eq!(stream.current_counter(), start);
 }

--- a/tfhe/src/transciphering/ciphers/kreyvium/test.rs
+++ b/tfhe/src/transciphering/ciphers/kreyvium/test.rs
@@ -300,42 +300,31 @@ fn state_at_counter<T: Clone>(filler: &T, counter: u64) -> KreyviumState<T> {
     }
 }
 
-const EXHAUSTION_TAIL_BITS: usize = 8;
-
 #[test]
-fn kreyvium_plain_exhaustion_at_counter_range_end() {
-    let start = u64::MAX - EXHAUSTION_TAIL_BITS as u64;
-    let mut stream: KreyviumPlainState = state_at_counter(&false, start);
+fn kreyvium_exhaustion_at_counter_range_end() {
+    let (_client_key, server_key) = gen_keys(TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128);
+
+    let n_bits: usize = 8;
+    let start = u64::MAX - n_bits as u64;
+
+    let mut plain_stream: KreyviumPlainState = state_at_counter(&false, start);
+    let mut fhe_stream: KreyviumFheState = state_at_counter(&server_key.create_trivial(0), start);
 
     // One bit too many: refused before any round runs, counter untouched.
     assert!(matches!(
-        stream.next_keystream_bits(EXHAUSTION_TAIL_BITS + 1),
+        plain_stream.next_keystream_bits(n_bits + 1),
         Err(InsufficientKeystream)
     ));
-    assert_eq!(stream.current_counter(), start);
+    assert_eq!(plain_stream.current_counter(), start);
+    assert!(matches!(
+        fhe_stream.next_keystream_bits(&server_key, n_bits + 1),
+        Err(InsufficientKeystream)
+    ));
+    assert_eq!(fhe_stream.current_counter(), start);
 
     // Exactly the bits that remain: succeeds and lands on u64::MAX.
-    assert!(stream.next_keystream_bits(EXHAUSTION_TAIL_BITS).is_ok());
-    assert_eq!(stream.current_counter(), u64::MAX);
-
-    // Fully exhausted: even a single further bit is refused.
-    assert!(matches!(
-        stream.next_keystream_bits(1),
-        Err(InsufficientKeystream)
-    ));
-    assert_eq!(stream.current_counter(), u64::MAX);
-}
-
-#[test]
-fn kreyvium_fhe_exhaustion_at_counter_range_end() {
-    let (_client_key, server_key) = gen_keys(TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128);
-
-    let start = u64::MAX - EXHAUSTION_TAIL_BITS as u64;
-    let mut stream: KreyviumFheState = state_at_counter(&server_key.create_trivial(0), start);
-
-    assert!(matches!(
-        stream.next_keystream_bits(&server_key, EXHAUSTION_TAIL_BITS + 1),
-        Err(InsufficientKeystream)
-    ));
-    assert_eq!(stream.current_counter(), start);
+    assert!(plain_stream.next_keystream_bits(n_bits).is_ok());
+    assert_eq!(plain_stream.current_counter(), u64::MAX);
+    assert!(fhe_stream.next_keystream_bits(&server_key, n_bits).is_ok());
+    assert_eq!(fhe_stream.current_counter(), u64::MAX);
 }

--- a/tfhe/src/transciphering/ciphers/mod.rs
+++ b/tfhe/src/transciphering/ciphers/mod.rs
@@ -4,6 +4,7 @@ mod shift_register;
 
 pub mod aes;
 pub mod kreyvium;
+pub mod one_time_pad;
 
 /// Pack `bits` into `bytes` LSB-first within each byte. `bytes` must be
 /// zero-initialized and at least `bits.len().div_ceil(8)` long.
@@ -13,12 +14,15 @@ fn pack_bits_lsb_first(bits: &[bool], bytes: &mut [u8]) {
     }
 }
 
-/// Unpack `bytes` into `bits` LSB-first within each byte. `bits` must be at
-/// least `bytes.len() * 8` long.
+/// Unpack `bytes` into `bits` LSB-first within each byte. If `bits` len is <= `bytes.len() * 8`
+/// then the extra bits in the inputs bytes are ignored.
+///
+/// `bytes` len needs to be >= `bits.len().div_ceil(8)`.
 fn unpack_bits_lsb_first(bytes: &[u8], bits: &mut [bool]) {
-    for (b, &byte) in bytes.iter().enumerate() {
-        for j in 0..8 {
-            bits[8 * b + j] = ((byte >> j) & 1) == 1;
-        }
+    for (bit_idx, output) in bits.iter_mut().enumerate() {
+        let byte_idx = bit_idx / 8;
+        let idx_in_byte = bit_idx % 8;
+
+        *output = ((bytes[byte_idx] >> idx_in_byte) & 1) == 1;
     }
 }

--- a/tfhe/src/transciphering/ciphers/mod.rs
+++ b/tfhe/src/transciphering/ciphers/mod.rs
@@ -1,3 +1,5 @@
+//! Implementation of the supported stream ciphers
+
 mod shift_register;
 
 pub mod aes;

--- a/tfhe/src/transciphering/ciphers/one_time_pad/fhe.rs
+++ b/tfhe/src/transciphering/ciphers/one_time_pad/fhe.rs
@@ -1,0 +1,102 @@
+use crate::shortint::ciphertext::{Ciphertext, NoiseLevel};
+use crate::shortint::server_key::ServerKey;
+use crate::transciphering::{FheKeyStream, InsufficientKeystream, StreamCipherKind, Transcipherer};
+
+pub struct OneTimePadFheSecretMask {
+    /// Collection of encrypted random bits, from which one can pull secret bits to hide sensitive
+    /// values by XOR-ing them together.
+    secret_mask: Vec<Ciphertext>,
+}
+
+impl OneTimePadFheSecretMask {
+    /// `secret_mask` must hold exactly one [`Ciphertext`] per bit, each a clean single-bit
+    /// encryption (degree <= 1, with at most nominal noise), conformant with the [`ServerKey`]
+    /// parameters that will be used for transciphering.
+    pub fn try_new(secret_mask: Vec<Ciphertext>) -> Result<Self, &'static str> {
+        for ct in &secret_mask {
+            if ct.degree.get() > 1 {
+                return Err("Mask ciphertexts must encrypt single bits (degree <= 1).");
+            }
+            if ct.noise_level() > NoiseLevel::NOMINAL {
+                return Err("Mask ciphertexts must have at most nominal noise.");
+            }
+        }
+
+        Ok(Self { secret_mask })
+    }
+
+    /// # Panics
+    ///
+    /// Panics if `secret_mask` contains a ciphertext that is not a clean boolean encryption
+    /// (degree <= 1, noise <= NOMINAL).
+    pub fn new(secret_mask: Vec<Ciphertext>) -> Self {
+        Self::try_new(secret_mask).unwrap()
+    }
+
+    /// Single bit per [`Ciphertext`].
+    fn bit_count(&self) -> usize {
+        self.secret_mask.len()
+    }
+}
+
+pub struct OneTimePadFheState {
+    secret_mask: OneTimePadFheSecretMask,
+    /// Current keystream bit position.
+    current_counter: u64,
+}
+
+impl OneTimePadFheState {
+    pub fn new(secret_mask: OneTimePadFheSecretMask) -> Self {
+        Self {
+            secret_mask,
+            current_counter: 0,
+        }
+    }
+
+    pub fn remaining_bits(&self) -> u64 {
+        let bit_count_u64: u64 = self.secret_mask.bit_count().try_into().unwrap();
+        bit_count_u64.saturating_sub(self.current_counter)
+    }
+}
+
+impl Transcipherer for OneTimePadFheState {
+    fn kind(&self) -> StreamCipherKind {
+        StreamCipherKind::OneTimePad
+    }
+
+    fn next_keystream_bits(
+        &mut self,
+        _sks: &ServerKey,
+        n_bits: usize,
+    ) -> Result<FheKeyStream, InsufficientKeystream> {
+        if n_bits == 0 {
+            return Ok(FheKeyStream::from_raw_parts(vec![]));
+        }
+
+        let n_bits_u64: u64 = n_bits.try_into().unwrap();
+
+        let remaining_bits = self.remaining_bits();
+        if remaining_bits < n_bits_u64 {
+            return Err(InsufficientKeystream);
+        }
+
+        let start_ciphertext_idx: usize = self.current_counter.try_into().unwrap();
+        let stop_ciphertext_idx = start_ciphertext_idx + n_bits;
+
+        self.current_counter = self.current_counter.checked_add(n_bits_u64).unwrap();
+
+        Ok(FheKeyStream::from_raw_parts(
+            self.secret_mask.secret_mask[start_ciphertext_idx..stop_ciphertext_idx].to_vec(),
+        ))
+    }
+
+    fn seek(&mut self, _sks: &ServerKey, target_counter: u64) {
+        // setting a counter that is greater than the pad size will return an error at keystream
+        // generation time
+        self.current_counter = target_counter;
+    }
+
+    fn current_counter(&self) -> u64 {
+        self.current_counter
+    }
+}

--- a/tfhe/src/transciphering/ciphers/one_time_pad/mod.rs
+++ b/tfhe/src/transciphering/ciphers/one_time_pad/mod.rs
@@ -1,0 +1,15 @@
+//! One-time pad: XOR the input data with a random encrypted pad.
+//!
+//! With this transciphering method, the keystream is directly the pre-generated pad,
+//! so the only FHE operation is the XOR with the input data.
+//! The pad is finite and single-use, and must be at least as long as the data. As a
+//! result, this cipher is worthwhile when decrypting a pad as large as the data is
+//! possible and efficient enough.
+
+mod fhe;
+mod plain;
+#[cfg(test)]
+mod test;
+
+pub use fhe::{OneTimePadFheSecretMask, OneTimePadFheState};
+pub use plain::{OneTimePadPlainSecretMask, OneTimePadPlainState};

--- a/tfhe/src/transciphering/ciphers/one_time_pad/plain.rs
+++ b/tfhe/src/transciphering/ciphers/one_time_pad/plain.rs
@@ -1,0 +1,153 @@
+use crate::shortint::client_key::ClientKey;
+use crate::transciphering::ciphers::one_time_pad::fhe::OneTimePadFheSecretMask;
+use crate::transciphering::ciphers::unpack_bits_lsb_first;
+use crate::transciphering::{InsufficientKeystream, StreamCipher, StreamCipherKind};
+
+pub struct OneTimePadPlainSecretMask {
+    /// Collection of random u8, from which one can pull secret bits to hide sensitive values by
+    /// XOR-ing them together.
+    secret_mask: Vec<u8>,
+    /// How many bits in the secret mask are actually usable.
+    bit_count: usize,
+}
+
+impl OneTimePadPlainSecretMask {
+    pub fn try_new(secret_mask: Vec<u8>, bit_count: usize) -> Result<Self, &'static str> {
+        let expected_byte_count = bit_count.div_ceil(8);
+
+        if secret_mask.len() != expected_byte_count {
+            return Err("Invalid bit_count for provided secret_mask");
+        }
+
+        Ok(Self {
+            secret_mask,
+            bit_count,
+        })
+    }
+
+    /// # Panics
+    ///
+    /// Panics if `secret_mask` does not have the expected length: `bit_count.div_ceil(8)`
+    pub fn new(secret_mask: Vec<u8>, bit_count: usize) -> Self {
+        Self::try_new(secret_mask, bit_count).unwrap()
+    }
+
+    pub fn encrypt(&self, client_key: &ClientKey) -> OneTimePadFheSecretMask {
+        let mut bits = vec![false; self.bit_count];
+        unpack_bits_lsb_first(&self.secret_mask, &mut bits);
+
+        let secret_mask = bits
+            .into_iter()
+            .map(|b| client_key.encrypt_bool(b))
+            .collect();
+
+        OneTimePadFheSecretMask::new(secret_mask)
+    }
+}
+
+pub struct OneTimePadPlainState {
+    secret_mask: OneTimePadPlainSecretMask,
+    current_counter: u64,
+}
+
+impl OneTimePadPlainState {
+    pub fn new(secret_mask: OneTimePadPlainSecretMask) -> Self {
+        Self {
+            secret_mask,
+            current_counter: 0,
+        }
+    }
+
+    pub fn remaining_bits(&self) -> u64 {
+        let bit_count_u64: u64 = self.secret_mask.bit_count.try_into().unwrap();
+        bit_count_u64.saturating_sub(self.current_counter)
+    }
+}
+
+impl StreamCipher for OneTimePadPlainState {
+    fn kind(&self) -> StreamCipherKind {
+        StreamCipherKind::OneTimePad
+    }
+
+    fn next_keystream_bits(&mut self, n_bits: usize) -> Result<Vec<u8>, InsufficientKeystream> {
+        if n_bits == 0 {
+            return Ok(vec![]);
+        }
+
+        let n_bits_u64: u64 = n_bits.try_into().unwrap();
+
+        if self.remaining_bits() < n_bits_u64 {
+            return Err(InsufficientKeystream);
+        }
+
+        let start_mask_idx: usize = (self.current_counter / 8).try_into().unwrap();
+        let last_bit_idx = self.current_counter.checked_add(n_bits_u64 - 1).unwrap();
+        // Exclusive, so range is start_mask_idx..stop_mask_idx
+        let stop_mask_idx: usize = (last_bit_idx / 8 + 1).try_into().unwrap();
+
+        // We may need to look at most at mask_bytes_to_return_count + 1, e.g. if n_bits == 10 and
+        // we have 3 bytes
+        // LSB first repr
+        // [x,x,x,x,x,x,x,0][1,2,3,4,5,6,7,8][9,x,x,x,x,x,x,x]
+        // We have to return, 2 bytes
+        // [0,1,2,3,4,5,6,7][8,9,x,x,x,x,x,x]
+        let mask_bytes_to_return_count = n_bits.div_ceil(8);
+
+        let mut result = vec![0u8; mask_bytes_to_return_count];
+
+        let mask_bytes = &self.secret_mask.secret_mask[start_mask_idx..stop_mask_idx];
+
+        // Amount by which each byte will need to be shifted down/right
+        let first_bit_position_in_byte = (self.current_counter % 8) as u32;
+
+        if first_bit_position_in_byte == 0 {
+            // Happy path no cross-byte shifts
+            result.copy_from_slice(mask_bytes);
+        } else {
+            // Need some cross-byte shifts: result byte i takes the end of mask byte i,
+            // completed with the start of mask byte i + 1. Continuing the example above:
+            // result[0] == mask_bytes[0] >> 7 | mask_bytes[1] << 1
+            // result[1] == mask_bytes[1] >> 7 | mask_bytes[2] << 1
+            let shift_down = first_bit_position_in_byte;
+            let shift_up = 8 - shift_down;
+            for (result_byte, (mask, mask_next)) in result.iter_mut().zip(
+                mask_bytes
+                    .iter()
+                    .copied()
+                    .zip(mask_bytes[1..].iter().copied().chain(core::iter::once(0))),
+            ) {
+                *result_byte = (mask >> shift_down) | (mask_next << shift_up);
+            }
+        }
+
+        // Mask the last byte to return only the bits we are supposed to. Result bits are
+        // realigned to position 0 whatever the start position in the mask was, so the last
+        // of the n_bits sits at this position in the last byte:
+        let last_bit_position_in_byte = ((n_bits_u64 - 1) % 8) as u32;
+        // if the last bit is at position 0, then we need to mask out the 7 high bits
+        // u8 MSB repr
+        // base_mask = 0b1111_1111
+        // mask_to_apply = base_mask >> shift_to_apply
+        // Case 0
+        // mask_to_apply = 0b0000_0001 => shift == 7
+        // Case 7
+        // mask_to_apply = 0b1111_1111 => shift == 0
+        let shift_to_apply = 7 - last_bit_position_in_byte;
+        let last_byte_mask = u8::MAX >> shift_to_apply;
+        result[mask_bytes_to_return_count - 1] &= last_byte_mask;
+
+        self.current_counter = self.current_counter.checked_add(n_bits_u64).unwrap();
+
+        Ok(result)
+    }
+
+    fn seek(&mut self, target_counter: u64) {
+        // setting a counter that is greater than the pad size will return an error at keystream
+        // generation time
+        self.current_counter = target_counter;
+    }
+
+    fn current_counter(&self) -> u64 {
+        self.current_counter
+    }
+}

--- a/tfhe/src/transciphering/ciphers/one_time_pad/test.rs
+++ b/tfhe/src/transciphering/ciphers/one_time_pad/test.rs
@@ -1,0 +1,549 @@
+use rand::{Rng, SeedableRng};
+
+use crate::shortint::ciphertext::NoiseLevel;
+use crate::shortint::parameters::test_params::{
+    TEST_PARAM_MESSAGE_1_CARRY_1_KS_PBS_GAUSSIAN_2M128,
+    TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+    TEST_PARAM_MESSAGE_3_CARRY_3_KS_PBS_GAUSSIAN_2M128,
+};
+use crate::shortint::prelude::*;
+use crate::transciphering::ciphers::kreyvium::KreyviumPlainState;
+use crate::transciphering::ciphers::one_time_pad::fhe::{
+    OneTimePadFheSecretMask, OneTimePadFheState,
+};
+use crate::transciphering::ciphers::one_time_pad::{
+    OneTimePadPlainSecretMask, OneTimePadPlainState,
+};
+use crate::transciphering::{
+    InsufficientKeystream, StreamCipher, StreamCipherKind, TranscipherError, Transcipherer,
+};
+
+/// Reference implementation: LSB-first bit `first_bit + i` of `mask` becomes LSB-first bit
+/// `i` of the output, one bit at a time
+fn reference_keystream(mask: &[u8], first_bit: usize, n_bits: usize) -> Vec<u8> {
+    let mut out = vec![0u8; n_bits.div_ceil(8)];
+    for i in 0..n_bits {
+        let abs_idx = first_bit + i;
+        let bit = (mask[abs_idx / 8] >> (abs_idx % 8)) & 1;
+        out[i / 8] |= bit << (i % 8);
+    }
+    out
+}
+
+#[test]
+fn one_time_pad_keystream_all_offsets_and_lengths() {
+    let max_byte_count = 3usize;
+    let max_bit_count = max_byte_count * 8;
+
+    let seed: u64 = rand::thread_rng().gen();
+    println!("one_time_pad_keystream_all_offsets_and_lengths seed={seed}");
+    let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+    let mask_bytes: Vec<u8> = (0..max_byte_count).map(|_| rng.gen()).collect();
+
+    for max_bit_count in 1..=max_bit_count {
+        println!("max_bit_count={max_bit_count}");
+
+        let mut otp = OneTimePadPlainState::new(OneTimePadPlainSecretMask::new(
+            // to_vec for tests, don't do that in production
+            mask_bytes[..max_bit_count.div_ceil(8)].to_vec(),
+            max_bit_count,
+        ));
+
+        // Exhaustively check every (start offset, length) pair
+        for start in 0..max_bit_count {
+            for output_bit_count in 0..=(max_bit_count - start) {
+                println!("start={start}, output_bit_count={output_bit_count}");
+                otp.seek(start as u64);
+
+                let keystream_bits = otp.next_keystream_bits(output_bit_count).unwrap();
+
+                if !output_bit_count.is_multiple_of(8) {
+                    // Check the upper bits of the last byte are properly 0 and not leaking some
+                    // secret values
+                    let bits_in_last_byte = (output_bit_count % 8).try_into().unwrap();
+                    // e.g. we have 3 bits in the last byte
+                    // MSB repr (to be easier to think about the shift)
+                    // [x,x,x,x,x,2,1,0]
+                    // u8::MAX << 3 == 0b1111_1000
+                    // & =>
+                    // [x,x,x,x,x,0,0,0]
+                    // the upper "x" should be 0 which is what the assert checks for
+                    assert_eq!(
+                        keystream_bits.last().copied().unwrap()
+                            & (u8::MAX.checked_shl(bits_in_last_byte).unwrap()),
+                        0,
+                        "keystream_bits {keystream_bits:?}, \
+                        start {start}, output_bit_count {output_bit_count}, mask {mask_bytes:?}"
+                    );
+                }
+
+                assert_eq!(
+                    keystream_bits,
+                    reference_keystream(&mask_bytes, start, output_bit_count),
+                    "start {start}, output_bit_count {output_bit_count}, mask {mask_bytes:02X?}"
+                );
+                assert_eq!(otp.current_counter(), (start + output_bit_count) as u64);
+            }
+        }
+    }
+}
+
+#[test]
+fn one_time_pad_random_draws() {
+    let seed: u64 = rand::thread_rng().gen();
+    println!("one_time_pad_random_draws seed={seed}");
+    let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+
+    let mask_bytes: Vec<u8> = (0..32).map(|_| rng.gen()).collect();
+    // Cloning for tests, don't do that in production
+    let ref_bytes = mask_bytes.clone();
+    let bit_count = 8 * mask_bytes.len();
+
+    let mut otp = OneTimePadPlainState::new(OneTimePadPlainSecretMask::new(mask_bytes, bit_count));
+
+    let mut remaining = bit_count;
+
+    while remaining != 0 {
+        let n_bits = rng.gen_range(0..=remaining);
+
+        println!("n_bits: {n_bits}");
+
+        let start = bit_count - remaining;
+        assert_eq!(otp.current_counter(), start as u64);
+        assert_eq!(
+            otp.next_keystream_bits(n_bits).unwrap(),
+            reference_keystream(&ref_bytes, start, n_bits),
+            "start {start}, n_bits {n_bits}, mask {ref_bytes:02X?}"
+        );
+        remaining -= n_bits;
+        assert_eq!(otp.remaining_bits(), remaining as u64);
+    }
+
+    assert_eq!(otp.remaining_bits(), 0);
+    assert_eq!(otp.current_counter(), bit_count as u64);
+}
+
+#[test]
+fn one_time_pad_encrypt_decrypt() {
+    let mut rng = rand::thread_rng();
+    let mask_bytes: Vec<u8> = (0..16).map(|_| rng.gen()).collect();
+    let bit_count = 8 * mask_bytes.len();
+    let data: Vec<u8> = (0..5).map(|_| rng.gen()).collect();
+
+    let mut otp = OneTimePadPlainState::new(OneTimePadPlainSecretMask::new(mask_bytes, bit_count));
+
+    let encrypted = otp.encrypt(&data).unwrap();
+    otp.seek(encrypted.encryption_counter());
+    assert_eq!(otp.decrypt(&encrypted).unwrap(), data);
+}
+
+#[test]
+fn one_time_pad_next_bits_beyond_remaining_errors() {
+    let mut otp = OneTimePadPlainState::new(OneTimePadPlainSecretMask::new(vec![0u8; 2], 16));
+    assert!(matches!(
+        otp.next_keystream_bits(17),
+        Err(InsufficientKeystream)
+    ));
+}
+
+// ========== FHE tests below ==========
+
+/// Decrypt `fhe_bits` (one single-bit ciphertext per bit) and compare them,
+/// bit for bit, against plain keystream bytes (LSB-first within each byte).
+/// Also checks the [`Transcipherer::next_keystream_bits`] contract: each
+/// ciphertext is a clean single-bit encryption (degree <= 1, value in {0, 1})
+/// Also checks ciphertexts have strictly nominal noise, if checks are made
+/// on trivial ciphertexts update this function accordingly.
+fn assert_fhe_keystream_matches_plain(
+    cks: &ClientKey,
+    fhe_bits: &[Ciphertext],
+    plain_bytes: &[u8],
+    expected_bit_count: usize,
+    ctx: &str,
+) {
+    assert_eq!(
+        fhe_bits.len(),
+        expected_bit_count,
+        "{ctx}: expected one ciphertext per keystream bit"
+    );
+    for (i, ct) in fhe_bits.iter().enumerate() {
+        assert!(
+            ct.degree.get() <= 1,
+            "{ctx}: keystream bit {i} is not a single bit (degree {})",
+            ct.degree.get()
+        );
+        assert!(
+            ct.noise_level() == NoiseLevel::NOMINAL,
+            "{ctx}: keystream bit {i} exceeds nominal noise (level {:?})",
+            ct.noise_level()
+        );
+        let got = cks.decrypt_message_and_carry(ct);
+        assert!(
+            got <= 1,
+            "{ctx}: keystream bit {i} decrypts to non-boolean value {got}"
+        );
+        let expected = ((plain_bytes[i / 8] >> (i % 8)) & 1) as u64;
+        assert_eq!(got, expected, "{ctx}: keystream bit {i} differs");
+    }
+}
+
+/// Decode the output of [`Transcipherer::transcipher`]: each ciphertext packs
+/// up to `m = log2(message_modulus)` plaintext bits, LSB-first across the
+/// stream, the last ciphertext possibly holding fewer. Returns
+/// `n_bits.div_ceil(8)` bytes.
+fn decrypt_transciphered_bytes(
+    cks: &ClientKey,
+    cts: &[Ciphertext],
+    expected_bit_count: usize,
+) -> Vec<u8> {
+    let message_bits = cks.parameters().message_modulus().0.ilog2() as usize;
+    assert_eq!(
+        cts.len(),
+        expected_bit_count.div_ceil(message_bits),
+        "unexpected transciphered ciphertext count for {expected_bit_count} bits"
+    );
+    let mut bytes = vec![0u8; expected_bit_count.div_ceil(8)];
+
+    let plaintexts: Vec<u64> = cts.iter().map(|ct| cks.decrypt(ct)).collect();
+
+    for bit_idx in 0..expected_bit_count {
+        let plaintext_idx = bit_idx / message_bits;
+        let idx_in_plaintext = bit_idx % message_bits;
+        let out_byte_idx = bit_idx / 8;
+        let idx_in_out_byte = bit_idx % 8;
+
+        bytes[out_byte_idx] |=
+            (((plaintexts[plaintext_idx] >> idx_in_plaintext) & 1) as u8) << idx_in_out_byte;
+    }
+
+    bytes
+}
+
+/// FHE keystream == plain keystream for every (start offset, length) pair.
+///
+/// Seeks both sides before every draw, so this test isolates mask encryption/slicing from counter
+/// bookkeeping (covered separately).
+#[test]
+fn one_time_pad_fhe_keystream_matches_plain_all_offsets_and_lengths() {
+    let (cks, sks) = gen_keys(TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128);
+
+    let seed: u64 = rand::thread_rng().gen();
+    println!("one_time_pad_fhe_keystream_matches_plain_all_offsets_and_lengths seed={seed}");
+    let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+
+    let byte_count = 3usize;
+    let max_bit_count = byte_count * 8;
+    let mask_bytes: Vec<u8> = (0..byte_count).map(|_| rng.gen()).collect();
+
+    for max_bit_count in 0..=max_bit_count {
+        // to_vec for tests, don't do that in production
+        let curr_mask_bytes = mask_bytes[..max_bit_count.div_ceil(8)].to_vec();
+        let plain_mask = OneTimePadPlainSecretMask::new(curr_mask_bytes, max_bit_count);
+        let fhe_mask = plain_mask.encrypt(&cks);
+        let mut fhe_otp = OneTimePadFheState::new(fhe_mask);
+        let mut plain_otp = OneTimePadPlainState::new(plain_mask);
+
+        for start in 0..max_bit_count {
+            for output_bit_count in 0..=(max_bit_count - start) {
+                plain_otp.seek(start as u64);
+                fhe_otp.seek(&sks, start as u64);
+
+                let plain_bytes = plain_otp.next_keystream_bits(output_bit_count).unwrap();
+                let fhe_bits = fhe_otp
+                    .next_keystream_bits(&sks, output_bit_count)
+                    .unwrap()
+                    .into_raw_parts();
+
+                assert_fhe_keystream_matches_plain(
+                    &cks,
+                    &fhe_bits,
+                    &plain_bytes,
+                    output_bit_count,
+                    &format!("start={start}, output_bit_count={output_bit_count}"),
+                );
+            }
+        }
+    }
+}
+
+/// Back-to-back draws must return consecutive mask segments and advance
+/// `current_counter` / `remaining_bits` exactly like the plain side does.
+#[test]
+fn one_time_pad_fhe_sequential_draws_advance_counter() {
+    let (cks, sks) = gen_keys(TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128);
+
+    let seed: u64 = rand::thread_rng().gen();
+    println!("one_time_pad_fhe_sequential_draws_advance_counter seed={seed}");
+    let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+
+    let mask_bytes: Vec<u8> = (0..8).map(|_| rng.gen()).collect();
+    let bit_count = 8 * mask_bytes.len();
+
+    let plain_mask = OneTimePadPlainSecretMask::new(mask_bytes, bit_count);
+    let fhe_mask = plain_mask.encrypt(&cks);
+    let mut fhe_otp = OneTimePadFheState::new(fhe_mask);
+    let mut plain_otp = OneTimePadPlainState::new(plain_mask);
+
+    assert_eq!(fhe_otp.current_counter(), 0);
+    assert_eq!(fhe_otp.remaining_bits(), 64);
+
+    let first_fhe = fhe_otp
+        .next_keystream_bits(&sks, 24)
+        .unwrap()
+        .into_raw_parts();
+    let first_plain = plain_otp.next_keystream_bits(24).unwrap();
+    assert_eq!(
+        fhe_otp.current_counter(),
+        24,
+        "next_keystream_bits must advance the counter"
+    );
+    assert_eq!(fhe_otp.remaining_bits(), 40);
+    assert_fhe_keystream_matches_plain(&cks, &first_fhe, &first_plain, 24, "first draw");
+
+    // Zero-bit draw: empty keystream, counter untouched.
+    assert!(fhe_otp
+        .next_keystream_bits(&sks, 0)
+        .unwrap()
+        .into_raw_parts()
+        .is_empty());
+    assert_eq!(fhe_otp.current_counter(), 24);
+
+    let second_fhe = fhe_otp
+        .next_keystream_bits(&sks, 40)
+        .unwrap()
+        .into_raw_parts();
+    let second_plain = plain_otp.next_keystream_bits(40).unwrap();
+    assert_eq!(fhe_otp.current_counter(), 64);
+    assert_eq!(fhe_otp.remaining_bits(), 0);
+    assert_fhe_keystream_matches_plain(&cks, &second_fhe, &second_plain, 40, "second draw");
+
+    // Backward seek: the OTP re-emits the exact same pad bits.
+    fhe_otp.seek(&sks, 24);
+    assert_eq!(fhe_otp.current_counter(), 24);
+    assert_eq!(fhe_otp.remaining_bits(), 40);
+    let second_again = fhe_otp
+        .next_keystream_bits(&sks, 40)
+        .unwrap()
+        .into_raw_parts();
+    assert_fhe_keystream_matches_plain(&cks, &second_again, &second_plain, 40, "re-drawn second");
+
+    // Seeking to the exact end of the mask is allowed and leaves nothing to
+    // draw.
+    fhe_otp.seek(&sks, bit_count as u64);
+    assert_eq!(fhe_otp.remaining_bits(), 0);
+    assert!(fhe_otp
+        .next_keystream_bits(&sks, 0)
+        .unwrap()
+        .into_raw_parts()
+        .is_empty());
+}
+
+/// End-to-end: the client encrypts a sequence of messages with the plain OTP,
+/// the server transciphers them in order, the client decrypts the FHE blocks
+/// and must recover the original bits.
+///
+/// The sequence contains a byte-aligned message, an empty one and a 13-bit one
+/// so that both `apply_keystream` implementations get exercised on their
+/// partial-block branches: under 2_2 the odd trailing keystream bit, under
+/// other parameters the partial final packing chunk.
+fn one_time_pad_fhe_transcipher_round_trip_impl(params: ClassicPBSParameters) {
+    let seed: u64 = rand::thread_rng().gen();
+    println!("one_time_pad_fhe_transcipher_round_trip seed: {seed}");
+    let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+
+    let (cks, sks) = gen_keys(params);
+
+    let mask_bytes: Vec<u8> = (0..8).map(|_| rng.gen()).collect();
+    let bit_count = 8 * mask_bytes.len();
+
+    let plain_mask = OneTimePadPlainSecretMask::new(mask_bytes, bit_count);
+    let fhe_mask = plain_mask.encrypt(&cks);
+    let mut fhe_otp = OneTimePadFheState::new(fhe_mask);
+    let mut plain_otp = OneTimePadPlainState::new(plain_mask);
+
+    let msg_a: (Vec<u8>, usize) = ((0..5).map(|_| rng.gen()).collect(), 40);
+    let msg_b: (Vec<u8>, usize) = (vec![], 0);
+    let msg_c: (Vec<u8>, usize) = (rng.gen_range(0u16..(1 << 13)).to_le_bytes().to_vec(), 13);
+
+    for (i, (message, n_bits)) in [msg_a, msg_b, msg_c].into_iter().enumerate() {
+        let sym_cipher = plain_otp.encrypt_bits(&message, n_bits).unwrap();
+        let transciphered = fhe_otp
+            .transcipher(&sks, &sym_cipher)
+            .unwrap_or_else(|e| panic!("transcipher failed for message {i} (seed={seed}): {e:?}"));
+
+        let recovered = decrypt_transciphered_bytes(&cks, &transciphered, n_bits);
+
+        assert_eq!(recovered, message, "message {i} (seed={seed})");
+        assert_eq!(fhe_otp.current_counter(), plain_otp.current_counter());
+    }
+}
+
+#[test]
+fn one_time_pad_fhe_transcipher_round_trip() {
+    one_time_pad_fhe_transcipher_round_trip_impl(
+        TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+    );
+}
+
+/// Non-2_2 parameters fall back to `apply_keystream_naive`; the OTP is the
+/// cheapest cipher to round-trip that path with (the Kreyvium 1_1/3_3 tests
+/// stop at the raw keystream).
+#[test]
+fn one_time_pad_fhe_transcipher_round_trip_1_1() {
+    one_time_pad_fhe_transcipher_round_trip_impl(
+        TEST_PARAM_MESSAGE_1_CARRY_1_KS_PBS_GAUSSIAN_2M128,
+    );
+}
+
+#[test]
+fn one_time_pad_fhe_transcipher_round_trip_3_3() {
+    one_time_pad_fhe_transcipher_round_trip_impl(
+        TEST_PARAM_MESSAGE_3_CARRY_3_KS_PBS_GAUSSIAN_2M128,
+    );
+}
+
+/// `transcipher` must refuse foreign-cipher and misaligned inputs with the
+/// documented errors, leave the state untouched when refusing, and recover
+/// through `seek`.
+/// Also covers backward seek as random access to an earlier, skipped message.
+#[test]
+fn one_time_pad_fhe_transcipher_error_paths() {
+    use rand::SeedableRng;
+
+    let seed: u64 = rand::thread_rng().gen();
+    println!("one_time_pad_fhe_transcipher_error_paths seed: {seed}");
+    let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+
+    let (cks, sks) = gen_keys(TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128);
+
+    let mask_bytes: Vec<u8> = (0..8).map(|_| rng.gen()).collect();
+    let bit_count = 8 * mask_bytes.len();
+
+    let plain_mask = OneTimePadPlainSecretMask::new(mask_bytes, bit_count);
+    let fhe_mask = plain_mask.encrypt(&cks);
+    let mut fhe_otp = OneTimePadFheState::new(fhe_mask);
+    assert_eq!(fhe_otp.kind(), StreamCipherKind::OneTimePad);
+
+    let mut plain_otp = OneTimePadPlainState::new(plain_mask);
+
+    // A ciphertext from another cipher family is refused.
+    let key_bits: [bool; 128] = std::array::from_fn(|_| rng.gen());
+    let iv_bits: [bool; 128] = std::array::from_fn(|_| rng.gen());
+    let kreyvium_ct = KreyviumPlainState::new(key_bits, iv_bits)
+        .encrypt(&[0u8; 4])
+        .unwrap();
+    let err = fhe_otp
+        .transcipher(&sks, &kreyvium_ct)
+        .map(|_| ())
+        .unwrap_err();
+    assert_eq!(
+        err,
+        TranscipherError::KindMismatch {
+            session_kind: StreamCipherKind::OneTimePad,
+            ciphertext_kind: StreamCipherKind::Kreyvium,
+        }
+    );
+
+    // Client encrypts two messages; the server sees the second one first.
+    let msg_1: Vec<u8> = (0..3).map(|_| rng.gen()).collect();
+    let msg_2: Vec<u8> = (0..4).map(|_| rng.gen()).collect();
+    let ct_1 = plain_otp.encrypt(&msg_1).unwrap(); // bits 0..24
+    let ct_2 = plain_otp.encrypt(&msg_2).unwrap(); // bits 24..56
+
+    let err = fhe_otp.transcipher(&sks, &ct_2).map(|_| ()).unwrap_err();
+    assert_eq!(
+        err,
+        TranscipherError::CounterMismatch {
+            session_counter: 0,
+            ciphertext_counter: 24,
+        }
+    );
+    // The hint points at the ciphertext's absolute counter.
+    assert_eq!(
+        err.to_string(),
+        "stream ciphertext counter mismatch: session at 0, \
+        ciphertext at 24. Call `seek(24)` to align"
+    );
+    // A refused transcipher must not consume keystream.
+    assert_eq!(fhe_otp.current_counter(), 0);
+
+    // Documented recovery: seek to the ciphertext's counter and retry.
+    fhe_otp.seek(&sks, ct_2.encryption_counter());
+    let out_2 = fhe_otp.transcipher(&sks, &ct_2).unwrap();
+    assert_eq!(
+        decrypt_transciphered_bytes(&cks, &out_2, 32),
+        msg_2,
+        "seed={seed}"
+    );
+
+    // The session (56) can also be ahead of a ciphertext (0): same error, and
+    // the hint must still point at the ciphertext's counter.
+    let err = fhe_otp.transcipher(&sks, &ct_1).map(|_| ()).unwrap_err();
+    assert_eq!(
+        err,
+        TranscipherError::CounterMismatch {
+            session_counter: 56,
+            ciphertext_counter: 0,
+        }
+    );
+    assert_eq!(
+        err.to_string(),
+        "stream ciphertext counter mismatch: session at 56, \
+        ciphertext at 0. Call `seek(0)` to align"
+    );
+
+    // Backward seek gives random access to the skipped first message.
+    fhe_otp.seek(&sks, ct_1.encryption_counter());
+    let out_1 = fhe_otp.transcipher(&sks, &ct_1).unwrap();
+    assert_eq!(
+        decrypt_transciphered_bytes(&cks, &out_1, 24),
+        msg_1,
+        "seed={seed}"
+    );
+}
+
+/// Mask constructors validate their inputs: plain masks take
+/// `bit_count.div_ceil(8)` bytes; FHE mask ciphertexts must be clean
+/// single-bit encryptions.
+#[test]
+fn one_time_pad_mask_validation() {
+    let cks = ClientKey::new(TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128);
+
+    assert!(OneTimePadPlainSecretMask::try_new(vec![0u8; 2], 17).is_err());
+    assert!(OneTimePadPlainSecretMask::try_new(vec![0u8; 3], 17).is_ok());
+
+    // Cloning for tests, don't do that in production
+    let cts: Vec<Ciphertext> = (0..5).map(|_| cks.encrypt_bool(false)).collect();
+    assert!(OneTimePadFheSecretMask::try_new(cts.clone()).is_ok());
+
+    // A ciphertext that may encrypt more than a single bit is refused.
+    let mut degree_cts = cts.clone();
+    degree_cts[3] = cks.encrypt(2);
+    assert_eq!(
+        OneTimePadFheSecretMask::try_new(degree_cts).map(|_| ()),
+        Err("Mask ciphertexts must encrypt single bits (degree <= 1).")
+    );
+
+    // A ciphertext with above-nominal noise is refused.
+    let mut noisy_cts = cts;
+    noisy_cts[3].set_noise_level(NoiseLevel::NOMINAL * 2, cks.parameters().max_noise_level());
+    assert_eq!(
+        OneTimePadFheSecretMask::try_new(noisy_cts).map(|_| ()),
+        Err("Mask ciphertexts must have at most nominal noise.")
+    );
+}
+
+// The `_sks` argument is unused by the OTP (no bootstrapping happens to draw
+// keystream bits), so the error test below use the cheapest parameters to
+// generate.
+
+#[test]
+fn one_time_pad_fhe_next_bits_beyond_remaining_errors() {
+    let (cks, sks) = gen_keys(TEST_PARAM_MESSAGE_1_CARRY_1_KS_PBS_GAUSSIAN_2M128);
+    let fhe_mask = OneTimePadPlainSecretMask::new(vec![0u8; 2], 16).encrypt(&cks);
+    let mut fhe_otp = OneTimePadFheState::new(fhe_mask);
+    assert!(matches!(
+        fhe_otp.next_keystream_bits(&sks, 17),
+        Err(InsufficientKeystream)
+    ));
+}

--- a/tfhe/src/transciphering/mod.rs
+++ b/tfhe/src/transciphering/mod.rs
@@ -138,29 +138,39 @@ pub enum TranscipherError {
     /// The [`StreamCiphertext`] was produced by a cipher different from the
     /// one consuming it.
     KindMismatch {
-        expected: StreamCipherKind,
-        got: StreamCipherKind,
+        session_kind: StreamCipherKind,
+        ciphertext_kind: StreamCipherKind,
     },
     /// The consumer's current keystream counter does not match the
-    /// [`StreamCiphertext`]'s recorded counter. When the ciphertext is
-    /// ahead, the caller can call [`StreamCipher::seek`] / [`Transcipherer::seek`]
-    /// to align and retry.
-    CounterMismatch { expected: u64, got: u64 },
+    /// [`StreamCiphertext`]'s recorded counter. The caller can call
+    /// [`StreamCipher::seek`] / [`Transcipherer::seek`] with the ciphertext's
+    /// counter to align and retry.
+    CounterMismatch {
+        session_counter: u64,
+        ciphertext_counter: u64,
+    },
 }
 
 impl std::fmt::Display for TranscipherError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::KindMismatch { expected, got } => write!(
+            Self::KindMismatch {
+                session_kind,
+                ciphertext_kind,
+            } => write!(
                 f,
-                "stream ciphertext cipher kind mismatch: expected {expected:?}, got {got:?}"
+                "stream ciphertext cipher kind mismatch: session kind {session_kind:?}, \
+                ciphertext kond {ciphertext_kind:?}"
             ),
-            Self::CounterMismatch { expected, got } => {
+            Self::CounterMismatch {
+                session_counter,
+                ciphertext_counter,
+            } => {
                 write!(
                     f,
-                    "stream ciphertext counter mismatch: session at {expected}, \
-                         ciphertext at {got}. Call `seek({})` to align",
-                    got - expected,
+                    "stream ciphertext counter mismatch: session at {session_counter}, \
+                    ciphertext at {ciphertext_counter}. \
+                    Call `seek({ciphertext_counter})` to align",
                 )
             }
         }
@@ -222,14 +232,14 @@ pub trait StreamCipher {
     fn decrypt(&mut self, encrypted: &StreamCiphertext) -> Result<Vec<u8>, TranscipherError> {
         if encrypted.kind != self.kind() {
             return Err(TranscipherError::KindMismatch {
-                expected: self.kind(),
-                got: encrypted.kind,
+                session_kind: self.kind(),
+                ciphertext_kind: encrypted.kind,
             });
         }
         if encrypted.encryption_counter != self.current_counter() {
             return Err(TranscipherError::CounterMismatch {
-                expected: self.current_counter(),
-                got: encrypted.encryption_counter,
+                session_counter: self.current_counter(),
+                ciphertext_counter: encrypted.encryption_counter,
             });
         }
 
@@ -272,14 +282,14 @@ pub trait Transcipherer {
     ) -> Result<Vec<Ciphertext>, TranscipherError> {
         if input.kind != self.kind() {
             return Err(TranscipherError::KindMismatch {
-                expected: self.kind(),
-                got: input.kind,
+                session_kind: self.kind(),
+                ciphertext_kind: input.kind,
             });
         }
         if input.encryption_counter != self.current_counter() {
             return Err(TranscipherError::CounterMismatch {
-                expected: self.current_counter(),
-                got: input.encryption_counter,
+                session_counter: self.current_counter(),
+                ciphertext_counter: input.encryption_counter,
             });
         }
 

--- a/tfhe/src/transciphering/mod.rs
+++ b/tfhe/src/transciphering/mod.rs
@@ -1,6 +1,8 @@
 //! Server-side homomorphic conversion of a symmetric-cipher ciphertext into
 //! an FHE ciphertext.
 //!
+//! It is a way for a client to provide inputs to the server without having to run the FHE
+//! encryption, resulting in smaller inputs and removing the need for a zk proof of encryption.
 //! The client encrypts data with a lightweight symmetric stream cipher, using
 //! a key it generates locally, and ships an FHE encryption of that key to the
 //! server once. The server, holding only the encrypted key, applies a

--- a/tfhe/src/transciphering/mod.rs
+++ b/tfhe/src/transciphering/mod.rs
@@ -31,7 +31,7 @@
 //! let input_bytes = input.to_le_bytes();
 //!
 //! let mut sym = KreyviumPlainState::new(key_bits, iv_bits);
-//! let sym_cipher = sym.encrypt(&input_bytes);
+//! let sym_cipher = sym.encrypt(&input_bytes).unwrap();
 //!
 //! // Client → server: ship the FHE-encrypted Kreyvium key (one-time setup).
 //! let enc_key = KreyviumPlainKey::from(key_bits).encrypt(&client_key);
@@ -61,8 +61,8 @@ use crate::shortint::{Ciphertext, ServerKey};
 use crate::transciphering::backward_compatibility::{
     StreamCipherKindVersions, StreamCiphertextVersions,
 };
-use crate::transciphering::ciphers::aes::AesFheState;
-use crate::transciphering::ciphers::kreyvium::KreyviumFheState;
+use ciphers::aes::AesFheState;
+use ciphers::kreyvium::KreyviumFheState;
 
 /// Identifier for a concrete stream-cipher family.
 ///
@@ -151,6 +151,8 @@ pub enum TranscipherError {
         session_counter: u64,
         ciphertext_counter: u64,
     },
+
+    InsufficientKeystream,
 }
 
 impl std::fmt::Display for TranscipherError {
@@ -162,7 +164,7 @@ impl std::fmt::Display for TranscipherError {
             } => write!(
                 f,
                 "stream ciphertext cipher kind mismatch: session kind {session_kind:?}, \
-                ciphertext kond {ciphertext_kind:?}"
+                ciphertext kind {ciphertext_kind:?}"
             ),
             Self::CounterMismatch {
                 session_counter,
@@ -175,11 +177,34 @@ impl std::fmt::Display for TranscipherError {
                     Call `seek({ciphertext_counter})` to align",
                 )
             }
+            Self::InsufficientKeystream => InsufficientKeystream.fmt(f),
         }
     }
 }
 
 impl std::error::Error for TranscipherError {}
+
+/// Returned when a stream cipher state cannot generate enough keystream to satisfy the request.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct InsufficientKeystream;
+
+impl std::fmt::Display for InsufficientKeystream {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Cannot generate enoug keystream from the current cipher state. \
+            A new fresh state should be generated"
+        )
+    }
+}
+
+impl std::error::Error for InsufficientKeystream {}
+
+impl From<InsufficientKeystream> for TranscipherError {
+    fn from(_value: InsufficientKeystream) -> Self {
+        Self::InsufficientKeystream
+    }
+}
 
 /// Client-side: a stateful symmetric-cipher session, no FHE.
 pub trait StreamCipher {
@@ -191,7 +216,7 @@ pub trait StreamCipher {
     /// Produce the next `n_bits` of keystream and advance the internal counter.
     /// Bits are packed LSB-first into bytes; in the standard byte-aligned
     /// transciphering use case `n_bits` is a multiple of 8.
-    fn next_keystream_bits(&mut self, n_bits: usize) -> Vec<u8>;
+    fn next_keystream_bits(&mut self, n_bits: usize) -> Result<Vec<u8>, InsufficientKeystream>;
 
     /// XOR the first `n_bits` of `input` with `n_bits` keystream bits.
     ///
@@ -199,7 +224,11 @@ pub trait StreamCipher {
     /// multiple of 8, the trailing bits of the last input byte are passed
     /// through unchanged (the keystream has zero bits in that range, so the
     /// XOR is a no-op there).
-    fn encrypt_bits(&mut self, input: &[u8], n_bits: usize) -> StreamCiphertext {
+    fn encrypt_bits(
+        &mut self,
+        input: &[u8],
+        n_bits: usize,
+    ) -> Result<StreamCiphertext, InsufficientKeystream> {
         assert_eq!(
             input.len(),
             n_bits.div_ceil(8),
@@ -209,20 +238,20 @@ pub trait StreamCipher {
         );
 
         let encryption_counter = self.current_counter();
-        let mask = self.next_keystream_bits(n_bits);
+        let mask = self.next_keystream_bits(n_bits)?;
         let bytes: Vec<u8> = input.iter().zip_checked(mask).map(|(i, m)| i ^ m).collect();
 
-        StreamCiphertext {
+        Ok(StreamCiphertext {
             kind: self.kind(),
             encryption_counter,
             n_bits,
             bytes,
-        }
+        })
     }
 
     /// XOR `input` with the next `8 * input.len()` keystream bits. Advances
     /// the counter.
-    fn encrypt(&mut self, input: &[u8]) -> StreamCiphertext {
+    fn encrypt(&mut self, input: &[u8]) -> Result<StreamCiphertext, InsufficientKeystream> {
         self.encrypt_bits(input, 8 * input.len())
     }
 
@@ -245,7 +274,7 @@ pub trait StreamCipher {
             });
         }
 
-        let mask = self.next_keystream_bits(encrypted.n_bits);
+        let mask = self.next_keystream_bits(encrypted.n_bits)?;
         Ok(encrypted
             .bytes
             .iter()
@@ -273,7 +302,11 @@ pub trait Transcipherer {
     /// Produce the next `n_bits` of FHE-encrypted keystream and advance the
     /// internal counter. One `shortint::Ciphertext` per bit, each a clean
     /// single-bit ciphertext (degree 1, value in {0, 1}).
-    fn next_keystream_bits(&mut self, sks: &ServerKey, n_bits: usize) -> FheKeyStream;
+    fn next_keystream_bits(
+        &mut self,
+        sks: &ServerKey,
+        n_bits: usize,
+    ) -> Result<FheKeyStream, InsufficientKeystream>;
 
     /// Transcipher `input` against `input.n_bits()` bits of keystream from
     /// this session, advancing the internal counter.
@@ -295,7 +328,7 @@ pub trait Transcipherer {
             });
         }
 
-        let keystream = self.next_keystream_bits(sks, input.n_bits);
+        let keystream = self.next_keystream_bits(sks, input.n_bits)?;
         Ok(apply_keystream(sks, &keystream, input))
     }
 
@@ -324,7 +357,11 @@ impl Transcipherer for TranscipherSession {
         }
     }
 
-    fn next_keystream_bits(&mut self, sks: &ServerKey, n_bits: usize) -> FheKeyStream {
+    fn next_keystream_bits(
+        &mut self,
+        sks: &ServerKey,
+        n_bits: usize,
+    ) -> Result<FheKeyStream, InsufficientKeystream> {
         match self {
             Self::Dynamic(t) => t.next_keystream_bits(sks, n_bits),
             Self::Kreyvium(t) => t.next_keystream_bits(sks, n_bits),

--- a/tfhe/src/transciphering/mod.rs
+++ b/tfhe/src/transciphering/mod.rs
@@ -63,6 +63,7 @@ use crate::transciphering::backward_compatibility::{
 };
 use ciphers::aes::AesFheState;
 use ciphers::kreyvium::KreyviumFheState;
+use ciphers::one_time_pad::OneTimePadFheState;
 
 /// Identifier for a concrete stream-cipher family.
 ///
@@ -78,6 +79,7 @@ pub enum StreamCipherKind {
     Dynamic,
     Kreyvium,
     Aes,
+    OneTimePad,
 }
 
 /// Output of [`StreamCipher::encrypt`] / [`StreamCipher::encrypt_bits`]: a
@@ -346,6 +348,7 @@ pub enum TranscipherSession {
     Dynamic(Box<dyn Transcipherer + Send + Sync>),
     Kreyvium(KreyviumFheState),
     Aes(Box<AesFheState>),
+    OneTimePad(OneTimePadFheState),
 }
 
 impl Transcipherer for TranscipherSession {
@@ -354,6 +357,7 @@ impl Transcipherer for TranscipherSession {
             Self::Dynamic(t) => t.kind(),
             Self::Kreyvium(t) => t.kind(),
             Self::Aes(t) => t.kind(),
+            Self::OneTimePad(t) => t.kind(),
         }
     }
 
@@ -366,6 +370,7 @@ impl Transcipherer for TranscipherSession {
             Self::Dynamic(t) => t.next_keystream_bits(sks, n_bits),
             Self::Kreyvium(t) => t.next_keystream_bits(sks, n_bits),
             Self::Aes(t) => t.next_keystream_bits(sks, n_bits),
+            Self::OneTimePad(t) => t.next_keystream_bits(sks, n_bits),
         }
     }
 
@@ -378,6 +383,7 @@ impl Transcipherer for TranscipherSession {
             Self::Dynamic(t) => t.transcipher(sks, input),
             Self::Kreyvium(t) => t.transcipher(sks, input),
             Self::Aes(t) => t.transcipher(sks, input),
+            Self::OneTimePad(t) => t.transcipher(sks, input),
         }
     }
 
@@ -386,6 +392,7 @@ impl Transcipherer for TranscipherSession {
             Self::Dynamic(t) => t.seek(sks, target_counter),
             Self::Kreyvium(t) => t.seek(sks, target_counter),
             Self::Aes(t) => t.seek(sks, target_counter),
+            Self::OneTimePad(t) => t.seek(sks, target_counter),
         }
     }
 
@@ -394,6 +401,7 @@ impl Transcipherer for TranscipherSession {
             Self::Dynamic(t) => t.current_counter(),
             Self::Kreyvium(t) => t.current_counter(),
             Self::Aes(t) => t.current_counter(),
+            Self::OneTimePad(t) => t.current_counter(),
         }
     }
 }


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description
Adds the OTP/OneTimePad transciphering method.

Here the idea is to directly generate, using the OPRF, enough keystream to be able to directly xor the full user input. The `next_keystream_bits` operation is a no-op. This is faster than the other transciphering options, since there is nothing to run in fhe except a xor, but one requirements is that the server/protocol needs to generate and decrypt enough bits to cover the full user input.

In this pr, I also updated the Transcipherer trait to allow to return an `KeystreamExhausted` error in `next_keystream_bits`. 
That way, the OTP cipher can cleanly error if the pad is smaller than the user input. I think it can be useful for other ciphers too, for example to indicate a maximum number of bits that we can generate for a given kreyvium key/iv.

This is breaking, but on a lower api layer, and on a trait that is not yet used downstream. I think it's worth the breakage, because it avoids a potential panic on a user controlled input.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3772)
<!-- Reviewable:end -->
