### PR TITLE
fix(eeprom): supporting I2C failure

### DIFF
--- a/backends/tfhe-hpu-backend/config_store/v80_archives/psi64.hpu
+++ b/backends/tfhe-hpu-backend/config_store/v80_archives/psi64.hpu
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c9e52b1be3f0a588fcae13371a328b36794160a5ab103d8e8bf8fa5aed31a51a
-size 82563756
+oid sha256:ad1e4a6a0487a2fc6afa3eab8ae1347bd4bebf73f881daba220759c120073628
+size 82563512

--- a/backends/tfhe-hpu-backend/src/ffi/v80/ami.rs
+++ b/backends/tfhe-hpu-backend/src/ffi/v80/ami.rs
@@ -18,7 +18,7 @@ const AMI_VERSION_FILE: &str = "/sys/module/ami/version";
 const AMI_VERSION_PATTERN: &str = r"3\.1\.\d+-zama";
 
 const AMI_ID_FILE: &str = "/sys/bus/pci/drivers/ami/devices";
-const AMI_ID_PATTERN: &str = r"(?<bus>[[:xdigit:]]{2}):(?<dev>[[:xdigit:]]{2})\.(?<func>[[:xdigit:]])\s(?<devn>\d+)\s(?<hwmon>\d+)";
+const AMI_ID_PATTERN: &str = r"(?<bus>[[:xdigit:]]{2}):(?<dev>[[:xdigit:]]{2})\.(?<func>[[:xdigit:]])\s(?<devn>\d+)\s(?<hwmon>-?\d+)";
 
 fn his_version_file(pcie_id: &str) -> String {
     format!("/sys/bus/pci/devices/0000:{pcie_id}:00.0/amc_version")
@@ -40,7 +40,7 @@ pub struct AmiInfo {
     dev_id: usize,
     func_id: usize,
     devn: usize,
-    hwmon: usize,
+    hwmon: Option<usize>,
 }
 
 /// Set of discovery function
@@ -75,7 +75,18 @@ impl AmiInfo {
         let dev_id = usize::from_str_radix(&caps["dev"], 16)?;
         let func_id = usize::from_str_radix(&caps["func"], 16)?;
         let devn = caps["devn"].parse::<usize>()?;
-        let hwmon = caps["hwmon"].parse::<usize>()?;
+        let hwmon = caps["hwmon"].parse::<isize>().ok().and_then(|v| {
+            if v >= 0 {
+                Some(v as usize)
+            } else {
+                None
+            }
+        });
+        if hwmon.is_none() {
+            tracing::warn!(
+                "AMI: hwmon unavailable (EEPROM/I2C issue?), sensor data will be missing, continuing without it"
+            );
+        }
         Ok(Self {
             bus_id,
             dev_id,

--- a/setup_hpu.sh
+++ b/setup_hpu.sh
@@ -16,7 +16,7 @@ RUST_LOG="info"
 XILINX_VIVADO=${XILINX_VIVADO:-"/opt/amd/Vivado/2024.2"}
 
 # V80 bitstream refresh require insmod of ami.ko module
-AMI_PATH=${AMI_PATH:-"/opt/v80/ami/bd569ee"}
+AMI_PATH=${AMI_PATH:-"/opt/v80/ami/84d3427"}
 
 # Parse user CLI ##############################################################
 opt_short="hc:l:p:"


### PR DESCRIPTION
Adding support of hwmod "-1" so that we can continue using boards without sensors due to I2C failure + debug message