### PR TITLE
fix(gpu): scalar comparison bug due to pointer aliasing on two streams

### DIFF
--- a/backends/tfhe-cuda-backend/cuda/include/integer/integer_utilities.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer/integer_utilities.h
@@ -2204,6 +2204,10 @@ template <typename Torus> struct int_prop_simu_group_carries_memory {
   // needed for the division to update the lut indexes
   void update_lut_indexes(CudaStreams streams, Torus *new_lut_indexes,
                           Torus *new_scalars, uint32_t new_num_blocks) {
+    GPU_ASSERT(new_num_blocks <= propagation_cum_sums->num_radix_blocks,
+               "Cuda error: update_lut_indexes new_num_blocks=%u exceeds "
+               "h_scalar_array_cum_sum/scalar_array_cum_sum allocation=%u",
+               new_num_blocks, propagation_cum_sums->num_radix_blocks);
     auto new_active_streams = streams.active_gpu_subset(
         new_num_blocks, luts_array_second_step->params.pbs_type);
     luts_array_second_step->set_lut_indexes_and_broadcast_from_gpu(

--- a/backends/tfhe-cuda-backend/cuda/include/integer/scalar_mul.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer/scalar_mul.h
@@ -39,6 +39,12 @@ template <typename Torus> struct int_scalar_mul_buffer {
         streams.stream(0), streams.gpu_index(0), all_shifted_buffer,
         num_ciphertext_bits * num_radix_blocks, params.big_lwe_dimension,
         size_tracker, allocate_gpu_memory);
+    GPU_ASSERT(all_shifted_buffer->num_radix_blocks ==
+                   num_ciphertext_bits * num_radix_blocks,
+               "Cuda error: all_shifted_buffer->num_radix_blocks=%u != "
+               "num_ciphertext_bits=%u * num_radix_blocks=%u",
+               all_shifted_buffer->num_radix_blocks, num_ciphertext_bits,
+               num_radix_blocks);
 
     if (num_ciphertext_bits * num_radix_blocks >= num_radix_blocks + 2)
       logical_scalar_shift_buffer = new int_logical_scalar_shift_buffer<Torus>(

--- a/backends/tfhe-cuda-backend/cuda/src/aes/aes.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/aes/aes.cuh
@@ -722,15 +722,13 @@ __host__ void vectorized_mix_columns(CudaStreams streams,
     CudaRadixCiphertextFFI *col_copy_buffer =
         mem->round_workspaces->mix_columns_col_copy_buffer;
     for (uint32_t i = 0; i < BITS_PER_COLUMN; ++i) {
-      CudaRadixCiphertextFFI dest_slice, src_slice;
+      CudaRadixCiphertextFFI dest_slice;
       as_radix_ciphertext_slice<Torus>(&dest_slice, col_copy_buffer,
                                        i * num_aes_inputs,
                                        (i + 1) * num_aes_inputs);
-      as_radix_ciphertext_slice<Torus>(
-          &src_slice, s_bits, (col * BITS_PER_COLUMN + i) * num_aes_inputs,
-          (col * BITS_PER_COLUMN + i + 1) * num_aes_inputs);
-      copy_radix_ciphertext_async<Torus>(
-          streams.stream(0), streams.gpu_index(0), &dest_slice, &src_slice);
+      copy_radix_ciphertext_async<Torus>(streams.stream(0),
+                                         streams.gpu_index(0), &dest_slice,
+                                         &s_bits[col * BITS_PER_COLUMN + i]);
     }
 
     CudaRadixCiphertextFFI b_orig[BYTES_PER_COLUMN][BITS_PER_BYTE];

--- a/backends/tfhe-cuda-backend/cuda/src/integer/comparison.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/comparison.cuh
@@ -447,8 +447,11 @@ compare_radix_blocks(CudaStreams streams, CudaRadixCiphertextFFI *lwe_array_out,
   // Add one
   // Here Lhs can have the following values: (-1) % (message modulus * carry
   // modulus), 0, 1 So the output values after the addition will be: 0, 1, 2
-  host_add_scalar_one_inplace<Torus>(streams, lwe_array_out, message_modulus,
-                                     carry_modulus);
+  CudaRadixCiphertextFFI lwe_array_out_view;
+  as_radix_ciphertext_slice<Torus>(&lwe_array_out_view, lwe_array_out, 0,
+                                   num_radix_blocks);
+  host_add_scalar_one_inplace<Torus>(streams, &lwe_array_out_view,
+                                     message_modulus, carry_modulus);
 }
 
 // Reduces a vec containing shortint blocks that encrypts a sign

--- a/backends/tfhe-cuda-backend/cuda/src/integer/radix_ciphertext.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/radix_ciphertext.cuh
@@ -70,6 +70,8 @@ void as_radix_ciphertext_slice(CudaRadixCiphertextFFI *output_radix,
           "range")
   if (start_input_lwe_index > end_input_lwe_index)
     PANIC("Cuda error: slice range should be positive")
+  GPU_ASSERT(end_input_lwe_index <= input_radix->num_radix_blocks,
+             "Cuda error: slice end index exceeds num_radix_blocks");
 
   auto lwe_size = input_radix->lwe_dimension + 1;
   output_radix->num_radix_blocks = end_input_lwe_index - start_input_lwe_index;
@@ -117,6 +119,10 @@ void copy_radix_ciphertext_slice_async(
   if (input_start_lwe_index > input_radix->num_radix_blocks)
     PANIC("Cuda error: input start index should be smaller than the number "
           "of blocks")
+  GPU_ASSERT(output_end_lwe_index <= output_radix->num_radix_blocks,
+             "Cuda error: output end index exceeds num_radix_blocks");
+  GPU_ASSERT(input_end_lwe_index <= input_radix->num_radix_blocks,
+             "Cuda error: input end index exceeds num_radix_blocks");
 
   auto lwe_size = input_radix->lwe_dimension + 1;
   Torus *out_ptr = (Torus *)output_radix->ptr;
@@ -154,11 +160,12 @@ void set_zero_radix_ciphertext_slice_async(cudaStream_t const stream,
                                            CudaRadixCiphertextFFI *radix,
                                            const uint32_t start_lwe_index,
                                            const uint32_t end_lwe_index) {
-  if (radix->num_radix_blocks < end_lwe_index - start_lwe_index)
-    PANIC("Cuda error: input radix should have more blocks than the specified "
-          "range")
   if (start_lwe_index > end_lwe_index)
     PANIC("Cuda error: slice range should be positive")
+  GPU_ASSERT(end_lwe_index <= radix->num_radix_blocks,
+             "Cuda error: set_zero end_lwe_index exceeds num_radix_blocks");
+  GPU_ASSERT(start_lwe_index <= radix->num_radix_blocks,
+             "Cuda error: set_zero start_lwe_index exceeds num_radix_blocks");
 
   auto lwe_size = radix->lwe_dimension + 1;
   auto num_blocks_to_set = end_lwe_index - start_lwe_index;
@@ -243,6 +250,16 @@ template <typename Torus>
 void pop_radix_ciphertext_block_async(cudaStream_t stream, uint32_t gpu_index,
                                       CudaRadixCiphertextFFI *block,
                                       CudaRadixCiphertextFFI *radix_in) {
+  GPU_ASSERT(radix_in->num_radix_blocks != 0,
+             "Cuda error: cannot pop a block from an empty radix ciphertext");
+  GPU_ASSERT(block->max_num_radix_blocks >= 1,
+             "Cuda error: pop destination block has max_num_radix_blocks < 1");
+  GPU_ASSERT(block->lwe_dimension == radix_in->lwe_dimension,
+             "Cuda error: pop source and destination lwe_dimension mismatch");
+  GPU_ASSERT(
+      radix_in->num_radix_blocks <= radix_in->max_num_radix_blocks,
+      "Cuda error: pop source num_radix_blocks exceeds max_num_radix_blocks");
+  block->num_radix_blocks = 1;
   copy_radix_ciphertext_slice_async<Torus>(
       stream, gpu_index, block, 0, 1, radix_in, radix_in->num_radix_blocks - 1,
       radix_in->num_radix_blocks);
@@ -273,6 +290,12 @@ void push_block_to_radix_ciphertext_async(cudaStream_t stream,
                                           uint32_t gpu_index,
                                           CudaRadixCiphertextFFI *block,
                                           CudaRadixCiphertextFFI *radix_out) {
+  GPU_ASSERT(block->num_radix_blocks >= 1,
+             "Cuda error: push source block has num_radix_blocks < 1");
+  GPU_ASSERT(block->lwe_dimension == radix_out->lwe_dimension,
+             "Cuda error: push source and destination lwe_dimension mismatch");
+  GPU_ASSERT(radix_out->num_radix_blocks + 1 <= radix_out->max_num_radix_blocks,
+             "Cuda error: push would exceed radix_out max_num_radix_blocks");
   reset_radix_ciphertext_blocks(radix_out, radix_out->num_radix_blocks + 1);
   copy_radix_ciphertext_slice_async<Torus>(
       stream, gpu_index, radix_out, radix_out->num_radix_blocks - 1,

--- a/backends/tfhe-cuda-backend/cuda/src/integer/scalar_comparison.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/scalar_comparison.cuh
@@ -72,14 +72,14 @@ __host__ void scalar_compare_radix_blocks(
       streams, lwe_array_out, subtracted_blocks, bsks, ksks, sign_lut,
       num_radix_blocks);
 
-  // FIXME: without this sync signed scalar eq tests fail, I don't understand
-  // the reason
-  cuda_synchronize_stream(streams.stream(0), streams.gpu_index(0));
   // Add one
   // Here Lhs can have the following values: (-1) % (message modulus * carry
   // modulus), 0, 1 So the output values after the addition will be: 0, 1, 2
-  host_add_scalar_one_inplace<Torus>(streams, lwe_array_out, message_modulus,
-                                     carry_modulus);
+  CudaRadixCiphertextFFI lwe_array_out_view;
+  as_radix_ciphertext_slice<Torus>(&lwe_array_out_view, lwe_array_out, 0,
+                                   num_radix_blocks);
+  host_add_scalar_one_inplace<Torus>(streams, &lwe_array_out_view,
+                                     message_modulus, carry_modulus);
 }
 
 template <typename Torus, typename KSTorus>
@@ -147,7 +147,8 @@ __host__ void integer_radix_unsigned_scalar_difference_check(
         true, {mem_ptr->diff_buffer->tree_buffer->preallocated_h_lut});
 
     integer_radix_apply_univariate_lookup_table<Torus>(
-        streams, lwe_array_out, mem_ptr->tmp_lwe_array_out, bsks, ksks, lut, 1);
+        active_streams, lwe_array_out, mem_ptr->tmp_lwe_array_out, bsks, ksks,
+        lut, 1);
 
   } else if (num_scalar_blocks < num_radix_blocks) {
     // We have to handle both part of the work described above
@@ -181,11 +182,11 @@ __host__ void integer_radix_unsigned_scalar_difference_check(
     as_radix_ciphertext_slice<Torus>(&rhs, lhs, num_radix_blocks / 2,
                                      lhs->num_radix_blocks);
 
-    pack_blocks<Torus>(lsb_streams.stream(0), streams.gpu_index(0), lhs,
+    pack_blocks<Torus>(lsb_streams.stream(0), lsb_streams.gpu_index(0), lhs,
                        lwe_array_in, num_lsb_radix_blocks, message_modulus,
                        message_modulus, carry_modulus);
-    scalar_pack_blocks<Torus>(lsb_streams.stream(0), streams.gpu_index(0), &rhs,
-                              scalar_blocks, num_scalar_blocks,
+    scalar_pack_blocks<Torus>(lsb_streams.stream(0), lsb_streams.gpu_index(0),
+                              &rhs, scalar_blocks, num_scalar_blocks,
                               message_modulus);
 
     // From this point we have half number of blocks
@@ -637,6 +638,12 @@ __host__ void host_scalar_difference_check(
   if (lwe_array_in->num_radix_blocks < num_radix_blocks)
     PANIC("Cuda error: input num radix blocks should not be lower "
           "than the number of blocks to operate on")
+  GPU_ASSERT(lwe_array_out->num_radix_blocks >= 1,
+             "Cuda error: output must have at least one radix block");
+  GPU_ASSERT(num_radix_blocks >= 1,
+             "Cuda error: num_radix_blocks must be at least 1");
+  GPU_ASSERT(num_scalar_blocks <= num_radix_blocks,
+             "Cuda error: num_scalar_blocks must not exceed num_radix_blocks");
 
   if (mem_ptr->is_signed) {
     // is signed and scalar is positive

--- a/backends/tfhe-cuda-backend/cuda/src/integer/scalar_div.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/scalar_div.cuh
@@ -49,7 +49,6 @@ __host__ void host_integer_unsigned_scalar_div_radix(
   }
 
   if (scalar_divisor_ffi->is_chosen_multiplier_geq_two_pow_numerator) {
-
     if (scalar_divisor_ffi->shift_pre != (uint64_t)0) {
       PANIC("shift_pre should be == 0");
     }
@@ -282,6 +281,9 @@ __host__ void host_integer_unsigned_scalar_div_rem_radix(
       if (!scalar_divisor_ffi->is_abs_divisor_one &&
           remainder_ct->num_radix_blocks != 0) {
 
+        GPU_ASSERT(mem_ptr->scalar_mul_mem != nullptr,
+                   "Cuda error: scalar_mul_mem is null for non-trivial "
+                   "unsigned divisor multiplication");
         host_integer_scalar_mul_radix<Torus>(
             streams, remainder_ct, decomposed_divisor,
             divisor_has_at_least_one_set, mem_ptr->scalar_mul_mem, bsks, ksks,
@@ -354,6 +356,9 @@ __host__ void host_integer_signed_scalar_div_rem_radix(
                           !scalar_divisor_ffi->is_divisor_negative;
 
     if (!is_divisor_one && remainder_ct->num_radix_blocks != 0) {
+      GPU_ASSERT(mem_ptr->scalar_mul_mem != nullptr,
+                 "Cuda error: scalar_mul_mem is null for non-trivial "
+                 "signed divisor multiplication");
       host_integer_scalar_mul_radix<Torus>(
           streams, remainder_ct, decomposed_divisor,
           divisor_has_at_least_one_set, mem_ptr->scalar_mul_mem, bsks, ksks,

--- a/backends/tfhe-cuda-backend/cuda/src/integer/scalar_mul.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/scalar_mul.cuh
@@ -82,6 +82,11 @@ __host__ void host_integer_scalar_mul_radix(
   size_t j = 0;
   for (size_t i = 0; i < std::min(num_scalars, num_ciphertext_bits); i++) {
     if (decomposed_scalar[i] == 1) {
+      GPU_ASSERT(
+          (j + 1) * num_radix_blocks <= all_shifted_buffer->num_radix_blocks,
+          "Cuda error: all_shifted_buffer overflow: slot %zu needs %zu blocks, "
+          "capacity is %u",
+          j, (j + 1) * num_radix_blocks, all_shifted_buffer->num_radix_blocks);
       // Perform a block shift
       CudaRadixCiphertextFFI preshifted_radix_ct;
       as_radix_ciphertext_slice<T>(&preshifted_radix_ct, preshifted_buffer,
@@ -113,6 +118,10 @@ __host__ void host_integer_scalar_mul_radix(
                                              streams.gpu_index(0), lwe_array, 0,
                                              num_radix_blocks);
   } else {
+    GPU_ASSERT(j <= mem->num_ciphertext_bits,
+               "Cuda error: j=%zu exceeds sum_ciphertexts_vec_mem "
+               "max_num_radix_in_vec=%u",
+               j, mem->num_ciphertext_bits);
     host_integer_partial_sum_ciphertexts_vec<T>(
         streams, lwe_array, all_shifted_buffer, bsks, ksks,
         mem->sum_ciphertexts_vec_mem, num_radix_blocks, j);


### PR DESCRIPTION
Fixes a synchronization bug in scalar div:

Two streams are launched, but they work on aliased buffers (overlap of some blocks in a radix ciphertext). The fix is to ensure is no overlapping (aliasing). The common blocks were aliased by mistake.

Also adds many sanity checks. 