### PR TITLE
chore(bench): update BenchmarkSpec type to prepare the data extractor…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -689,6 +689,11 @@ clippy_param_dedup: install_rs_check_toolchain
 	RUSTFLAGS="$(RUSTFLAGS)" cargo "$(CARGO_RS_CHECK_TOOLCHAIN)" clippy --all-targets \
 		-p param_dedup -- --no-deps -D warnings
 
+.PHONY: clippy_benchmark_spec # Run clippy lints on benchmark_spec
+clippy_benchmark_spec: install_rs_check_toolchain
+	RUSTFLAGS="$(RUSTFLAGS)" cargo "$(CARGO_RS_CHECK_TOOLCHAIN)" clippy --all-targets \
+		-p benchmark_spec -- --no-deps -D warnings
+
 .PHONY: clippy_benchmark_parser # Run clippy lints on tfhe-benchmark-parser
 clippy_benchmark_parser: install_rs_check_toolchain
 	RUSTFLAGS="$(RUSTFLAGS)" cargo "$(CARGO_RS_CHECK_TOOLCHAIN)" clippy --all-targets \
@@ -791,7 +796,8 @@ clippy_test_vectors: install_rs_check_toolchain
 clippy_all: clippy_rustdoc clippy clippy_boolean clippy_shortint clippy_integer clippy_all_targets \
 clippy_c_api clippy_js_wasm_api clippy_tasks clippy_core clippy_tfhe_csprng clippy_zk_pok clippy_zk_pok_wasm clippy_trivium \
 clippy_versionable clippy_safe_serialize clippy_tfhe_lints clippy_ws_tests clippy_bench clippy_param_dedup \
-clippy_benchmark_parser clippy_test_vectors clippy_backward_compat_data clippy_wasm_par_mq clippy_fuzz
+clippy_benchmark_spec clippy_benchmark_parser clippy_test_vectors clippy_backward_compat_data clippy_wasm_par_mq \
+clippy_fuzz
 
 .PHONY: clippy_fast # Run main clippy targets
 clippy_fast: clippy_rustdoc clippy clippy_all_targets clippy_c_api clippy_js_wasm_api clippy_tasks \
@@ -2642,6 +2648,7 @@ pcc_batch_6:
 	$(call run_recipe_with_details,clippy_versionable)
 	$(call run_recipe_with_details,clippy_safe_serialize)
 	$(call run_recipe_with_details,clippy_param_dedup)
+	$(call run_recipe_with_details,clippy_benchmark_spec)
 	$(call run_recipe_with_details,clippy_benchmark_parser)
 	$(call run_recipe_with_details,docs)
 

--- a/tfhe-benchmark/benches/boolean/bench.rs
+++ b/tfhe-benchmark/benches/boolean/bench.rs
@@ -22,7 +22,7 @@ criterion_group!(
 
 criterion_main!(gates_benches);
 
-fn write_to_json_boolean(spec: BenchmarkSpec<str>, display_name: &str) {
+fn write_to_json_boolean(spec: BenchmarkSpec, display_name: &str) {
     write_to_json(&spec, display_name, &OperatorType::Atomic, 1, vec![1]);
 }
 
@@ -38,65 +38,44 @@ fn benches(c: &mut Criterion, params: BooleanParameters, parameter_name: &str) {
     let ct2 = cks.encrypt(false);
     let ct3 = cks.encrypt(true);
 
-    let spec = BenchmarkSpec::<str>::new_boolean(
-        BooleanBench::And,
-        parameter_name,
-        BenchmarkMetric::Latency,
-    );
+    let spec =
+        BenchmarkSpec::new_boolean(BooleanBench::And, parameter_name, BenchmarkMetric::Latency);
     let id = spec.to_string();
     bench_group.bench_function(&id, |b| b.iter(|| black_box(sks.and(&ct1, &ct2))));
     write_to_json_boolean(spec, "and");
 
-    let spec = BenchmarkSpec::<str>::new_boolean(
-        BooleanBench::Nand,
-        parameter_name,
-        BenchmarkMetric::Latency,
-    );
+    let spec =
+        BenchmarkSpec::new_boolean(BooleanBench::Nand, parameter_name, BenchmarkMetric::Latency);
     let id = spec.to_string();
     bench_group.bench_function(&id, |b| b.iter(|| black_box(sks.nand(&ct1, &ct2))));
     write_to_json_boolean(spec, "nand");
 
-    let spec = BenchmarkSpec::<str>::new_boolean(
-        BooleanBench::Or,
-        parameter_name,
-        BenchmarkMetric::Latency,
-    );
+    let spec =
+        BenchmarkSpec::new_boolean(BooleanBench::Or, parameter_name, BenchmarkMetric::Latency);
     let id = spec.to_string();
     bench_group.bench_function(&id, |b| b.iter(|| black_box(sks.or(&ct1, &ct2))));
     write_to_json_boolean(spec, "or");
 
-    let spec = BenchmarkSpec::<str>::new_boolean(
-        BooleanBench::Xor,
-        parameter_name,
-        BenchmarkMetric::Latency,
-    );
+    let spec =
+        BenchmarkSpec::new_boolean(BooleanBench::Xor, parameter_name, BenchmarkMetric::Latency);
     let id = spec.to_string();
     bench_group.bench_function(&id, |b| b.iter(|| black_box(sks.xor(&ct1, &ct2))));
     write_to_json_boolean(spec, "xor");
 
-    let spec = BenchmarkSpec::<str>::new_boolean(
-        BooleanBench::Xnor,
-        parameter_name,
-        BenchmarkMetric::Latency,
-    );
+    let spec =
+        BenchmarkSpec::new_boolean(BooleanBench::Xnor, parameter_name, BenchmarkMetric::Latency);
     let id = spec.to_string();
     bench_group.bench_function(&id, |b| b.iter(|| black_box(sks.xnor(&ct1, &ct2))));
     write_to_json_boolean(spec, "xnor");
 
-    let spec = BenchmarkSpec::<str>::new_boolean(
-        BooleanBench::Not,
-        parameter_name,
-        BenchmarkMetric::Latency,
-    );
+    let spec =
+        BenchmarkSpec::new_boolean(BooleanBench::Not, parameter_name, BenchmarkMetric::Latency);
     let id = spec.to_string();
     bench_group.bench_function(&id, |b| b.iter(|| black_box(sks.not(&ct1))));
     write_to_json_boolean(spec, "not");
 
-    let spec = BenchmarkSpec::<str>::new_boolean(
-        BooleanBench::Mux,
-        parameter_name,
-        BenchmarkMetric::Latency,
-    );
+    let spec =
+        BenchmarkSpec::new_boolean(BooleanBench::Mux, parameter_name, BenchmarkMetric::Latency);
     let id = spec.to_string();
     bench_group.bench_function(&id, |b| b.iter(|| black_box(sks.mux(&ct1, &ct2, &ct3))));
     write_to_json_boolean(spec, "mux");

--- a/tfhe-benchmark/benches/core_crypto/ks_bench.rs
+++ b/tfhe-benchmark/benches/core_crypto/ks_bench.rs
@@ -56,7 +56,7 @@ fn keyswitch<Scalar: UnsignedTorus + CastInto<usize> + Serialize>(
             &mut encryption_generator,
         );
 
-        let benchmark_spec = BenchmarkSpec::<str>::new_core_crypto(cc_bench, name, bench_type);
+        let benchmark_spec = BenchmarkSpec::new_core_crypto(cc_bench, name, bench_type);
         let bench_id = benchmark_spec.to_string();
 
         match bench_type {
@@ -210,7 +210,7 @@ fn packing_keyswitch<Scalar, F>(
             &mut encryption_generator,
         );
 
-        let benchmark_spec = BenchmarkSpec::<str>::new_core_crypto(cc_bench, name, bench_type);
+        let benchmark_spec = BenchmarkSpec::new_core_crypto(cc_bench, name, bench_type);
         let bench_id = benchmark_spec.to_string();
 
         match bench_type {
@@ -699,7 +699,7 @@ mod cuda {
 
             let cpu_keys: CpuKeys<_> = CpuKeysBuilder::new().packing_keyswitch_key(pksk).build();
 
-            let benchmark_spec = BenchmarkSpec::<str>::new_core_crypto(cc_bench, name, bench_type);
+            let benchmark_spec = BenchmarkSpec::new_core_crypto(cc_bench, name, bench_type);
             let bench_id = benchmark_spec.to_string();
             match bench_type {
                 BenchmarkType::Latency => {

--- a/tfhe-benchmark/benches/core_crypto/ks_pbs_bench.rs
+++ b/tfhe-benchmark/benches/core_crypto/ks_pbs_bench.rs
@@ -63,7 +63,7 @@ fn ks_pbs<Scalar: UnsignedTorus + CastInto<usize> + Serialize>(
             params.pbs_level,
         );
 
-        let benchmark_spec = BenchmarkSpec::<str>::new_core_crypto(cc_bench, name, bench_type);
+        let benchmark_spec = BenchmarkSpec::new_core_crypto(cc_bench, name, bench_type);
         let bench_id = benchmark_spec.to_string();
 
         match bench_type {
@@ -344,7 +344,7 @@ fn multi_bit_ks_pbs<
         )
         .unwrap() as usize;
 
-        let benchmark_spec = BenchmarkSpec::<str>::new_core_crypto(cc_bench, name, bench_type);
+        let benchmark_spec = BenchmarkSpec::new_core_crypto(cc_bench, name, bench_type);
         let bench_id = benchmark_spec.to_string();
 
         match bench_type {
@@ -596,7 +596,7 @@ mod cuda {
                 .bootstrap_key(bsk)
                 .build();
 
-            let benchmark_spec = BenchmarkSpec::<str>::new_core_crypto(cc_bench, name, bench_type);
+            let benchmark_spec = BenchmarkSpec::new_core_crypto(cc_bench, name, bench_type);
             let bench_id = benchmark_spec.to_string();
 
             match bench_type {
@@ -906,7 +906,7 @@ mod cuda {
                 .multi_bit_bootstrap_key(multi_bit_bsk)
                 .build();
 
-            let benchmark_spec = BenchmarkSpec::<str>::new_core_crypto(cc_bench, name, bench_type);
+            let benchmark_spec = BenchmarkSpec::new_core_crypto(cc_bench, name, bench_type);
             let bench_id = benchmark_spec.to_string();
 
             match bench_type {

--- a/tfhe-benchmark/benches/core_crypto/pbs128_bench.rs
+++ b/tfhe-benchmark/benches/core_crypto/pbs128_bench.rs
@@ -125,7 +125,7 @@ fn pbs_128(c: &mut Criterion) {
     let param_name = noise_params.name();
 
     let benchmark_spec =
-        BenchmarkSpec::<str>::new_core_crypto(cc_bench, &param_name, BenchmarkMetric::Latency);
+        BenchmarkSpec::new_core_crypto(cc_bench, &param_name, BenchmarkMetric::Latency);
     let id = benchmark_spec.to_string();
     bench_group.bench_function(&id, |b| {
         b.iter(|| {
@@ -250,8 +250,7 @@ mod cuda {
         let delta: u64 = (1 << (u64::BITS - 1)) / message_modulus;
         let plaintext = Plaintext(input_message * delta);
 
-        let benchmark_spec =
-            BenchmarkSpec::<str>::new_core_crypto(cc_bench, params_name, bench_type);
+        let benchmark_spec = BenchmarkSpec::new_core_crypto(cc_bench, params_name, bench_type);
         let bench_id = benchmark_spec.to_string();
 
         match bench_type {
@@ -481,8 +480,7 @@ mod cuda {
         let delta: u64 = (1 << (u64::BITS - 1)) / message_modulus;
         let plaintext = Plaintext(input_message * delta);
 
-        let benchmark_spec =
-            BenchmarkSpec::<str>::new_core_crypto(cc_bench, params_name, bench_type);
+        let benchmark_spec = BenchmarkSpec::new_core_crypto(cc_bench, params_name, bench_type);
         let bench_id = benchmark_spec.to_string();
 
         match bench_type {

--- a/tfhe-benchmark/benches/core_crypto/pbs_bench.rs
+++ b/tfhe-benchmark/benches/core_crypto/pbs_bench.rs
@@ -54,7 +54,7 @@ fn mem_optimized_pbs<Scalar: UnsignedTorus + CastInto<usize> + Serialize>(
             params.pbs_level,
         );
 
-        let benchmark_spec = BenchmarkSpec::<str>::new_core_crypto(cc_bench, name, bench_type);
+        let benchmark_spec = BenchmarkSpec::new_core_crypto(cc_bench, name, bench_type);
         let bench_id = benchmark_spec.to_string();
 
         match bench_type {
@@ -272,7 +272,7 @@ fn mem_optimized_batched_pbs<Scalar: UnsignedTorus + CastInto<usize> + Serialize
 
         let count = 10; // FIXME Is it a representative value (big enough?)
 
-        let benchmark_spec = BenchmarkSpec::<str>::new_core_crypto(cc_bench, name, bench_type);
+        let benchmark_spec = BenchmarkSpec::new_core_crypto(cc_bench, name, bench_type);
         let bench_id = benchmark_spec.to_string();
 
         match bench_type {
@@ -522,7 +522,7 @@ fn multi_bit_pbs<
         )
         .unwrap() as usize;
 
-        let benchmark_spec = BenchmarkSpec::<str>::new_core_crypto(cc_bench, name, bench_type);
+        let benchmark_spec = BenchmarkSpec::new_core_crypto(cc_bench, name, bench_type);
         let bench_id = benchmark_spec.to_string();
 
         match bench_type {
@@ -743,7 +743,7 @@ fn mem_optimized_pbs_ntt(c: &mut Criterion) {
 
         drop(bsk);
 
-        let benchmark_spec = BenchmarkSpec::<str>::new_core_crypto(cc_bench, &name, bench_type);
+        let benchmark_spec = BenchmarkSpec::new_core_crypto(cc_bench, &name, bench_type);
         let bench_id = benchmark_spec.to_string();
 
         match bench_type {
@@ -989,7 +989,7 @@ mod cuda {
 
             let cpu_keys: CpuKeys<_> = CpuKeysBuilder::new().bootstrap_key(bsk).build();
 
-            let benchmark_spec = BenchmarkSpec::<str>::new_core_crypto(cc_bench, name, bench_type);
+            let benchmark_spec = BenchmarkSpec::new_core_crypto(cc_bench, name, bench_type);
             let bench_id = benchmark_spec.to_string();
 
             match bench_type {
@@ -1247,7 +1247,7 @@ mod cuda {
                 .multi_bit_bootstrap_key(multi_bit_bsk)
                 .build();
 
-            let benchmark_spec = BenchmarkSpec::<str>::new_core_crypto(cc_bench, name, bench_type);
+            let benchmark_spec = BenchmarkSpec::new_core_crypto(cc_bench, name, bench_type);
             let bench_id = benchmark_spec.to_string();
 
             match bench_type {

--- a/tfhe-benchmark/benches/high_level_api/bench_common.rs
+++ b/tfhe-benchmark/benches/high_level_api/bench_common.rs
@@ -1,7 +1,9 @@
 use benchmark::high_level_api::bench_wait::*;
 use benchmark::high_level_api::benchmark_op::*;
 use benchmark::utilities::{will_this_bench_run, write_to_json, OperatorType};
-use benchmark_spec::{get_bench_type, BenchmarkSpec, BenchmarkType, HlIntegerOp, OperandType};
+use benchmark_spec::{
+    get_bench_type, BenchmarkSpec, BenchmarkType, HlIntegerOp, OperandType, TypeName,
+};
 use criterion::{Criterion, Throughput};
 use rand::prelude::*;
 use rayon::prelude::*;
@@ -17,14 +19,14 @@ pub fn bench_fhe_type_op<FheType, Op>(
     client_key: &ClientKey,
     hlapi_op: HlIntegerOp,
     operand_type: OperandType,
-    type_name: &str,
+    type_name: &dyn TypeName,
     bit_size: usize,
     op: Op,
 ) where
     Op: BenchmarkOp<FheType> + Sync,
     FheType: FheWait + Send + Sync,
 {
-    let mut bench_group = c.benchmark_group(type_name);
+    let mut bench_group = c.benchmark_group(type_name.to_string());
 
     let mut rng = thread_rng();
 
@@ -62,7 +64,7 @@ pub fn bench_fhe_type_op<FheType, Op>(
                     .collect::<Vec<_>>()
             };
 
-            let elements = if will_this_bench_run(type_name, &bench_id) {
+            let elements = if will_this_bench_run(&type_name.to_string(), &bench_id) {
                 #[cfg(any(feature = "gpu", feature = "hpu"))]
                 {
                     use benchmark::utilities::throughput_num_threads;
@@ -141,7 +143,7 @@ macro_rules! bench_type_binary_op {
                     cks,
                     $hlapi_op,
                     OperandType::CipherText,
-                    stringify!($fhe_type),
+                    &TypeDisplayer::<$fhe_type>::default(),
                     $fhe_type::num_bits(),
                     BinaryOp {
                         func: |lhs: &$fhe_type, rhs: &$fhe_right_type| lhs.$op(rhs),
@@ -172,7 +174,7 @@ macro_rules! bench_type_binary_scalar_op {
                     cks,
                     $hlapi_op,
                     OperandType::PlainText,
-                    stringify!($fhe_type),
+                    &TypeDisplayer::<$fhe_type>::default(),
                     $fhe_type::num_bits(),
                     ScalarBinaryOp {
                         func: |lhs: &$fhe_type, rhs: &$scalar_ty| lhs.$op(*rhs),
@@ -200,7 +202,7 @@ macro_rules! bench_type_unary_op {
                     cks,
                     $hlapi_op,
                     OperandType::CipherText,
-                    stringify!($fhe_type),
+                    &TypeDisplayer::<$fhe_type>::default(),
                     $fhe_type::num_bits(),
                     UnaryOp {
                         func: |lhs: &$fhe_type| lhs.$op(),
@@ -227,7 +229,7 @@ macro_rules! bench_type_ternary_op {
                     cks,
                     $hlapi_op,
                     OperandType::CipherText,
-                    stringify!($fhe_type),
+                    &TypeDisplayer::<$fhe_type>::default(),
                     $fhe_type::num_bits(),
                     TernaryOp {
                         func: |cond: &FheBool, lhs: &$fhe_type, rhs: &$fhe_type| cond.$op(lhs, rhs),
@@ -254,7 +256,7 @@ macro_rules! bench_type_array_op {
                     cks,
                     $hlapi_op,
                     OperandType::CipherText,
-                    stringify!($fhe_type),
+                    &TypeDisplayer::<$fhe_type>::default(),
                     $fhe_type::num_bits(),
                     ArrayOp {
                         func: |iter: std::slice::Iter<'_, $fhe_type>| iter.$op(),

--- a/tfhe-benchmark/benches/high_level_api/bench_signed.rs
+++ b/tfhe-benchmark/benches/high_level_api/bench_signed.rs
@@ -1,6 +1,7 @@
 use crate::bench_common::bench_fhe_type_op;
 use benchmark::high_level_api::benchmark_op::*;
 use benchmark::high_level_api::random_generator::{random_non_zero, random_not_power_of_two};
+use benchmark::high_level_api::type_display::TypeDisplayer;
 use benchmark::utilities::{BitSizesSet, EnvConfig};
 use benchmark_spec::{HlIntegerOp, OperandType};
 use criterion::Criterion;

--- a/tfhe-benchmark/benches/high_level_api/bench_unsigned.rs
+++ b/tfhe-benchmark/benches/high_level_api/bench_unsigned.rs
@@ -2,6 +2,7 @@ use crate::bench_common::bench_fhe_type_op;
 use crate::oprf::oprf_any_range2;
 use benchmark::high_level_api::benchmark_op::*;
 use benchmark::high_level_api::random_generator::{random_non_zero, random_not_power_of_two};
+use benchmark::high_level_api::type_display::TypeDisplayer;
 use benchmark::utilities::{BitSizesSet, EnvConfig};
 use benchmark_spec::{HlIntegerOp, OperandType};
 use criterion::Criterion;

--- a/tfhe-benchmark/benches/high_level_api/dex.rs
+++ b/tfhe-benchmark/benches/high_level_api/dex.rs
@@ -1,3 +1,4 @@
+use benchmark::high_level_api::type_display::TypeDisplayer;
 #[cfg(not(feature = "gpu"))]
 use benchmark::params_aliases::BENCH_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
 #[cfg(feature = "gpu")]
@@ -10,7 +11,9 @@ use benchmark::utilities::{configure_gpu, get_param_type, ParamType};
 use benchmark::utilities::{write_to_json, OperatorType};
 use benchmark_spec::tfhe::hlapi::dex::{Dex, DexFlavor};
 use benchmark_spec::tfhe::hlapi::HlapiBench;
-use benchmark_spec::{get_bench_type, BenchmarkMetric, BenchmarkSpec, BenchmarkType, OperandType};
+use benchmark_spec::{
+    get_bench_type, BenchmarkMetric, BenchmarkSpec, BenchmarkType, OperandType, TypeName,
+};
 use criterion::{Criterion, Throughput};
 use rand::prelude::*;
 use rand::thread_rng;
@@ -228,7 +231,7 @@ mod pbs_stats {
 
     pub fn print_swap_request_update_dex_balance_pbs_counts<FheType, F>(
         client_key: &ClientKey,
-        type_name: &str,
+        type_name: &dyn TypeName,
         dex_bench_spec: Dex,
         swap_request_update_dex_balance_func: F,
     ) where
@@ -271,7 +274,7 @@ mod pbs_stats {
     }
     pub fn print_swap_request_finalize_pbs_counts<FheType, F>(
         client_key: &ClientKey,
-        type_name: &str,
+        type_name: &dyn TypeName,
         dex_bench_spec: Dex,
         swap_request_finalize_func: F,
     ) where
@@ -314,7 +317,7 @@ mod pbs_stats {
     }
     pub fn print_swap_claim_prepare_pbs_counts<FheType, F>(
         client_key: &ClientKey,
-        type_name: &str,
+        type_name: &dyn TypeName,
         dex_bench_spec: Dex,
         swap_claim_prepare_func: F,
     ) where
@@ -367,7 +370,7 @@ mod pbs_stats {
     }
     pub fn print_swap_claim_update_dex_balance_pbs_counts<FheType, F>(
         client_key: &ClientKey,
-        type_name: &str,
+        type_name: &dyn TypeName,
         dex_bench_spec: Dex,
         swap_claim_update_dex_balance_func: F,
     ) where
@@ -419,7 +422,7 @@ mod pbs_stats {
 fn bench_swap_request_latency<FheType, F1, F2>(
     c: &mut Criterion,
     client_key: &ClientKey,
-    type_name: &str,
+    type_name: &dyn TypeName,
     dex_bench_spec: Dex,
     swap_request_update_dex_balance_func: F1,
     swap_request_finalize_func: F2,
@@ -434,7 +437,7 @@ fn bench_swap_request_latency<FheType, F1, F2>(
     let params = client_key.computation_parameters();
     let params_name = params.name();
 
-    let mut c = c.benchmark_group(type_name);
+    let mut c = c.benchmark_group(type_name.to_string());
 
     let bench_spec = BenchmarkSpec::new_hlapi(
         HlapiBench::Dex(dex_bench_spec),
@@ -496,7 +499,7 @@ fn bench_swap_request_latency<FheType, F1, F2>(
 fn bench_swap_request_throughput<FheType, F1, F2>(
     c: &mut Criterion,
     client_key: &ClientKey,
-    type_name: &str,
+    type_name: &dyn TypeName,
     dex_bench_spec: Dex,
     swap_request_update_dex_balance_func: F1,
     swap_request_finalize_func: F2,
@@ -510,7 +513,7 @@ fn bench_swap_request_throughput<FheType, F1, F2>(
     let params = client_key.computation_parameters();
     let params_name = params.name();
 
-    let mut group = c.benchmark_group(type_name);
+    let mut group = c.benchmark_group(type_name.to_string());
 
     for num_elems in [10, 50, 100] {
         group.throughput(Throughput::Elements(num_elems));
@@ -618,7 +621,7 @@ fn bench_swap_request_throughput<FheType, F1, F2>(
 fn cuda_bench_swap_request_throughput<FheType, F1, F2>(
     c: &mut Criterion,
     client_key: &ClientKey,
-    type_name: &str,
+    type_name: &dyn TypeName,
     dex_bench_spec: Dex,
     swap_request_update_dex_balance_func: F1,
     swap_request_finalize_func: F2,
@@ -639,7 +642,7 @@ fn cuda_bench_swap_request_throughput<FheType, F1, F2>(
     let params = client_key.computation_parameters();
     let params_name = params.name();
 
-    let mut group = c.benchmark_group(type_name);
+    let mut group = c.benchmark_group(type_name.to_string());
 
     for num_elems in [5 * num_gpus, 10 * num_gpus, 20 * num_gpus] {
         group.throughput(Throughput::Elements(num_elems));
@@ -834,7 +837,7 @@ fn cuda_bench_swap_request_throughput<FheType, F1, F2>(
 fn bench_swap_claim_latency<FheType, F1, F2>(
     c: &mut Criterion,
     client_key: &ClientKey,
-    type_name: &str,
+    type_name: &dyn TypeName,
     dex_bench_spec: Dex,
     swap_claim_prepare_func: F1,
     swap_claim_update_dex_balance_func: F2,
@@ -849,7 +852,7 @@ fn bench_swap_claim_latency<FheType, F1, F2>(
     let params = client_key.computation_parameters();
     let params_name = params.name();
 
-    let mut c = c.benchmark_group(type_name);
+    let mut c = c.benchmark_group(type_name.to_string());
 
     let bench_spec = BenchmarkSpec::new_hlapi(
         HlapiBench::Dex(dex_bench_spec),
@@ -917,7 +920,7 @@ fn bench_swap_claim_latency<FheType, F1, F2>(
 fn bench_swap_claim_throughput<FheType, F1, F2>(
     c: &mut Criterion,
     client_key: &ClientKey,
-    type_name: &str,
+    type_name: &dyn TypeName,
     dex_bench_spec: Dex,
     swap_claim_prepare_func: F1,
     swap_claim_update_dex_balance_func: F2,
@@ -931,7 +934,7 @@ fn bench_swap_claim_throughput<FheType, F1, F2>(
     let params = client_key.computation_parameters();
     let params_name = params.name();
 
-    let mut group = c.benchmark_group(type_name);
+    let mut group = c.benchmark_group(type_name.to_string());
 
     for num_elems in [2, 6, 10] {
         group.throughput(Throughput::Elements(num_elems));
@@ -1057,7 +1060,7 @@ fn bench_swap_claim_throughput<FheType, F1, F2>(
 fn cuda_bench_swap_claim_throughput<FheType, F1, F2>(
     c: &mut Criterion,
     client_key: &ClientKey,
-    type_name: &str,
+    type_name: &dyn TypeName,
     dex_bench_spec: Dex,
     swap_claim_prepare_func: F1,
     swap_claim_update_dex_balance_func: F2,
@@ -1078,7 +1081,7 @@ fn cuda_bench_swap_claim_throughput<FheType, F1, F2>(
     let params = client_key.computation_parameters();
     let params_name = params.name();
 
-    let mut group = c.benchmark_group(type_name);
+    let mut group = c.benchmark_group(type_name.to_string());
 
     for num_elems in [num_gpus, 2 * num_gpus] {
         group.throughput(Throughput::Elements(num_elems));
@@ -1296,37 +1299,37 @@ fn main() {
     {
         print_swap_request_update_dex_balance_pbs_counts(
             &cks,
-            "FheUint64",
+            &TypeDisplayer::<FheUint64>::default(),
             Dex::SwapRequest(DexFlavor::Whitepaper),
             swap_request_update_dex_balance_whitepaper::<FheUint64>,
         );
         print_swap_request_update_dex_balance_pbs_counts(
             &cks,
-            "FheUint64",
+            &TypeDisplayer::<FheUint64>::default(),
             Dex::SwapRequest(DexFlavor::NoCmux),
             swap_request_update_dex_balance_no_cmux::<FheUint64>,
         );
         print_swap_request_finalize_pbs_counts(
             &cks,
-            "FheUint64",
+            &TypeDisplayer::<FheUint64>::default(),
             Dex::SwapRequest(DexFlavor::Finalize),
             swap_request_finalize::<FheUint64>,
         );
         print_swap_claim_prepare_pbs_counts(
             &cks,
-            "FheUint64",
+            &TypeDisplayer::<FheUint64>::default(),
             Dex::SwapClaim(DexFlavor::Prepare),
             swap_claim_prepare::<FheUint64, FheUint128>,
         );
         print_swap_claim_update_dex_balance_pbs_counts(
             &cks,
-            "FheUint64",
+            &TypeDisplayer::<FheUint64>::default(),
             Dex::SwapClaim(DexFlavor::Whitepaper),
             swap_claim_update_dex_balance_whitepaper::<FheUint64>,
         );
         print_swap_claim_update_dex_balance_pbs_counts(
             &cks,
-            "FheUint64",
+            &TypeDisplayer::<FheUint64>::default(),
             Dex::SwapClaim(DexFlavor::NoCmux),
             swap_claim_update_dex_balance_no_cmux::<FheUint64>,
         );
@@ -1337,7 +1340,7 @@ fn main() {
             bench_swap_request_latency(
                 &mut c,
                 &cks,
-                "FheUint64",
+                &TypeDisplayer::<FheUint64>::default(),
                 Dex::SwapRequest(DexFlavor::Whitepaper),
                 swap_request_update_dex_balance_whitepaper::<FheUint64>,
                 swap_request_finalize::<FheUint64>,
@@ -1345,7 +1348,7 @@ fn main() {
             bench_swap_request_latency(
                 &mut c,
                 &cks,
-                "FheUint64",
+                &TypeDisplayer::<FheUint64>::default(),
                 Dex::SwapRequest(DexFlavor::NoCmux),
                 swap_request_update_dex_balance_no_cmux::<FheUint64>,
                 swap_request_finalize::<FheUint64>,
@@ -1353,7 +1356,7 @@ fn main() {
             bench_swap_claim_latency(
                 &mut c,
                 &cks,
-                "FheUint64",
+                &TypeDisplayer::<FheUint64>::default(),
                 Dex::SwapClaim(DexFlavor::Whitepaper),
                 swap_claim_prepare::<FheUint64, FheUint128>,
                 swap_claim_update_dex_balance_whitepaper::<FheUint64>,
@@ -1361,7 +1364,7 @@ fn main() {
             bench_swap_claim_latency(
                 &mut c,
                 &cks,
-                "FheUint64",
+                &TypeDisplayer::<FheUint64>::default(),
                 Dex::SwapClaim(DexFlavor::NoCmux),
                 swap_claim_prepare::<FheUint64, FheUint128>,
                 swap_claim_update_dex_balance_no_cmux::<FheUint64>,
@@ -1371,7 +1374,7 @@ fn main() {
             bench_swap_request_throughput(
                 &mut c,
                 &cks,
-                "FheUint64",
+                &TypeDisplayer::<FheUint64>::default(),
                 Dex::SwapRequest(DexFlavor::Whitepaper),
                 swap_request_update_dex_balance_whitepaper::<FheUint64>,
                 swap_request_finalize::<FheUint64>,
@@ -1379,7 +1382,7 @@ fn main() {
             bench_swap_request_throughput(
                 &mut c,
                 &cks,
-                "FheUint64",
+                &TypeDisplayer::<FheUint64>::default(),
                 Dex::SwapRequest(DexFlavor::NoCmux),
                 swap_request_update_dex_balance_no_cmux::<FheUint64>,
                 swap_request_finalize::<FheUint64>,
@@ -1387,7 +1390,7 @@ fn main() {
             bench_swap_claim_throughput(
                 &mut c,
                 &cks,
-                "FheUint64",
+                &TypeDisplayer::<FheUint64>::default(),
                 Dex::SwapClaim(DexFlavor::Whitepaper),
                 swap_claim_prepare::<FheUint64, FheUint128>,
                 swap_claim_update_dex_balance_whitepaper::<FheUint64>,
@@ -1395,7 +1398,7 @@ fn main() {
             bench_swap_claim_throughput(
                 &mut c,
                 &cks,
-                "FheUint64",
+                &TypeDisplayer::<FheUint64>::default(),
                 Dex::SwapClaim(DexFlavor::NoCmux),
                 swap_claim_prepare::<FheUint64, FheUint128>,
                 swap_claim_update_dex_balance_no_cmux::<FheUint64>,
@@ -1426,37 +1429,37 @@ fn main() {
     {
         print_swap_request_update_dex_balance_pbs_counts(
             &cks,
-            "FheUint64",
+            &TypeDisplayer::<FheUint64>::default(),
             Dex::SwapRequest(DexFlavor::Whitepaper),
             swap_request_update_dex_balance_whitepaper::<FheUint64>,
         );
         print_swap_request_update_dex_balance_pbs_counts(
             &cks,
-            "FheUint64",
+            &TypeDisplayer::<FheUint64>::default(),
             Dex::SwapRequest(DexFlavor::NoCmux),
             swap_request_update_dex_balance_no_cmux::<FheUint64>,
         );
         print_swap_request_finalize_pbs_counts(
             &cks,
-            "FheUint64",
+            &TypeDisplayer::<FheUint64>::default(),
             Dex::SwapRequest(DexFlavor::Finalize),
             swap_request_finalize::<FheUint64>,
         );
         print_swap_claim_prepare_pbs_counts(
             &cks,
-            "FheUint64",
+            &TypeDisplayer::<FheUint64>::default(),
             Dex::SwapClaim(DexFlavor::Prepare),
             swap_claim_prepare::<FheUint64, FheUint128>,
         );
         print_swap_claim_update_dex_balance_pbs_counts(
             &cks,
-            "FheUint64",
+            &TypeDisplayer::<FheUint64>::default(),
             Dex::SwapClaim(DexFlavor::Whitepaper),
             swap_claim_update_dex_balance_whitepaper::<FheUint64>,
         );
         print_swap_claim_update_dex_balance_pbs_counts(
             &cks,
-            "FheUint64",
+            &TypeDisplayer::<FheUint64>::default(),
             Dex::SwapClaim(DexFlavor::NoCmux),
             swap_claim_update_dex_balance_no_cmux::<FheUint64>,
         );
@@ -1467,7 +1470,7 @@ fn main() {
             bench_swap_request_latency(
                 &mut c,
                 &cks,
-                "FheUint64",
+                &TypeDisplayer::<FheUint64>::default(),
                 Dex::SwapRequest(DexFlavor::Whitepaper),
                 swap_request_update_dex_balance_whitepaper::<FheUint64>,
                 swap_request_finalize::<FheUint64>,
@@ -1475,7 +1478,7 @@ fn main() {
             bench_swap_request_latency(
                 &mut c,
                 &cks,
-                "FheUint64",
+                &TypeDisplayer::<FheUint64>::default(),
                 Dex::SwapRequest(DexFlavor::NoCmux),
                 swap_request_update_dex_balance_no_cmux::<FheUint64>,
                 swap_request_finalize::<FheUint64>,
@@ -1483,7 +1486,7 @@ fn main() {
             bench_swap_claim_latency(
                 &mut c,
                 &cks,
-                "FheUint64",
+                &TypeDisplayer::<FheUint64>::default(),
                 Dex::SwapClaim(DexFlavor::Whitepaper),
                 swap_claim_prepare::<FheUint64, FheUint128>,
                 swap_claim_update_dex_balance_whitepaper::<FheUint64>,
@@ -1491,7 +1494,7 @@ fn main() {
             bench_swap_claim_latency(
                 &mut c,
                 &cks,
-                "FheUint64",
+                &TypeDisplayer::<FheUint64>::default(),
                 Dex::SwapClaim(DexFlavor::NoCmux),
                 swap_claim_prepare::<FheUint64, FheUint128>,
                 swap_claim_update_dex_balance_no_cmux::<FheUint64>,
@@ -1502,7 +1505,7 @@ fn main() {
             cuda_bench_swap_request_throughput(
                 &mut c,
                 &cks,
-                "FheUint64",
+                &TypeDisplayer::<FheUint64>::default(),
                 Dex::SwapRequest(DexFlavor::Whitepaper),
                 swap_request_update_dex_balance_whitepaper::<FheUint64>,
                 swap_request_finalize::<FheUint64>,
@@ -1510,7 +1513,7 @@ fn main() {
             cuda_bench_swap_request_throughput(
                 &mut c,
                 &cks,
-                "FheUint64",
+                &TypeDisplayer::<FheUint64>::default(),
                 Dex::SwapRequest(DexFlavor::NoCmux),
                 swap_request_update_dex_balance_no_cmux::<FheUint64>,
                 swap_request_finalize::<FheUint64>,
@@ -1518,7 +1521,7 @@ fn main() {
             cuda_bench_swap_claim_throughput(
                 &mut c,
                 &cks,
-                "FheUint64",
+                &TypeDisplayer::<FheUint64>::default(),
                 Dex::SwapClaim(DexFlavor::Whitepaper),
                 swap_claim_prepare::<FheUint64, FheUint128>,
                 swap_claim_update_dex_balance_whitepaper::<FheUint64>,
@@ -1526,7 +1529,7 @@ fn main() {
             cuda_bench_swap_claim_throughput(
                 &mut c,
                 &cks,
-                "FheUint64",
+                &TypeDisplayer::<FheUint64>::default(),
                 Dex::SwapClaim(DexFlavor::NoCmux),
                 swap_claim_prepare::<FheUint64, FheUint128>,
                 swap_claim_update_dex_balance_no_cmux::<FheUint64>,

--- a/tfhe-benchmark/benches/high_level_api/erc7984.rs
+++ b/tfhe-benchmark/benches/high_level_api/erc7984.rs
@@ -1,9 +1,12 @@
+use benchmark::high_level_api::type_display::TypeDisplayer;
 #[cfg(feature = "gpu")]
 use benchmark::utilities::{configure_gpu, get_param_type, ParamType};
 use benchmark::utilities::{write_to_json, OperatorType};
 use benchmark_spec::tfhe::hlapi::erc7984::{Erc7984, TransferFlavor};
 use benchmark_spec::tfhe::hlapi::HlapiBench;
-use benchmark_spec::{get_bench_type, BenchmarkMetric, BenchmarkSpec, BenchmarkType, OperandType};
+use benchmark_spec::{
+    get_bench_type, BenchmarkMetric, BenchmarkSpec, BenchmarkType, OperandType, TypeName,
+};
 use criterion::{Criterion, Throughput};
 use rand::prelude::*;
 use rand::thread_rng;
@@ -294,7 +297,7 @@ mod pbs_stats {
 
     pub fn print_transfer_pbs_counts<FheType, F>(
         client_key: &ClientKey,
-        type_name: &str,
+        type_name: &dyn TypeName,
         erc7984_bench_spec: Erc7984,
         transfer_func: F,
     ) where
@@ -339,7 +342,7 @@ mod pbs_stats {
 fn bench_transfer_latency<FheType, F>(
     c: &mut Criterion,
     client_key: &ClientKey,
-    type_name: &str,
+    type_name: &dyn TypeName,
     erc7984_bench_spec: Erc7984,
     transfer_func: F,
 ) where
@@ -353,7 +356,7 @@ fn bench_transfer_latency<FheType, F>(
     let params = client_key.computation_parameters();
     let params_name = params.name();
 
-    let mut c = c.benchmark_group(type_name);
+    let mut c = c.benchmark_group(type_name.to_string());
 
     let bench_spec = BenchmarkSpec::new_hlapi(
         HlapiBench::Erc7984(erc7984_bench_spec),
@@ -393,7 +396,7 @@ fn bench_transfer_latency<FheType, F>(
 fn bench_transfer_latency_simd<FheType, F>(
     c: &mut Criterion,
     client_key: &ClientKey,
-    type_name: &str,
+    type_name: &dyn TypeName,
     erc7984_bench_spec: Erc7984,
     transfer_func: F,
 ) where
@@ -412,7 +415,7 @@ fn bench_transfer_latency_simd<FheType, F>(
 
     let params = client_key.computation_parameters();
     let params_name = params.name();
-    let mut c = c.benchmark_group(type_name);
+    let mut c = c.benchmark_group(type_name.to_string());
 
     let bench_spec = BenchmarkSpec::new_hlapi(
         HlapiBench::Erc7984(erc7984_bench_spec),
@@ -459,7 +462,7 @@ fn bench_transfer_latency_simd<FheType, F>(
 fn bench_transfer_throughput<FheType, F>(
     c: &mut Criterion,
     client_key: &ClientKey,
-    type_name: &str,
+    type_name: &dyn TypeName,
     erc7984_bench_spec: Erc7984,
     transfer_func: F,
 ) where
@@ -471,7 +474,7 @@ fn bench_transfer_throughput<FheType, F>(
     let params = client_key.computation_parameters();
     let params_name = params.name();
 
-    let mut group = c.benchmark_group(type_name);
+    let mut group = c.benchmark_group(type_name.to_string());
 
     for num_elems in [10, 100, 500] {
         group.throughput(Throughput::Elements(num_elems));
@@ -519,7 +522,7 @@ fn bench_transfer_throughput<FheType, F>(
 fn cuda_bench_transfer_throughput<FheType, F>(
     c: &mut Criterion,
     client_key: &ClientKey,
-    type_name: &str,
+    type_name: &dyn TypeName,
     erc7984_bench_spec: Erc7984,
     transfer_func: F,
 ) where
@@ -541,7 +544,7 @@ fn cuda_bench_transfer_throughput<FheType, F>(
     // and is a multiple of the number of streams per GPU to avoid a bigger batch on one stream
     let num_elems = 800 * num_gpus;
 
-    let mut group = c.benchmark_group(type_name);
+    let mut group = c.benchmark_group(type_name.to_string());
     group.throughput(Throughput::Elements(num_elems));
 
     let bench_spec = BenchmarkSpec::new_hlapi(
@@ -612,7 +615,7 @@ fn cuda_bench_transfer_throughput<FheType, F>(
 fn hpu_bench_transfer_throughput<FheType, F>(
     group: &mut Criterion,
     client_key: &ClientKey,
-    type_name: &str,
+    type_name: &dyn TypeName,
     erc7984_bench_spec: Erc7984,
     transfer_func: F,
 ) where
@@ -625,7 +628,7 @@ fn hpu_bench_transfer_throughput<FheType, F>(
     let params = client_key.computation_parameters();
     let params_name = params.name();
 
-    let mut group = group.benchmark_group(type_name);
+    let mut group = group.benchmark_group(type_name.to_string());
     for num_elems in [10, 100] {
         group.throughput(Throughput::Elements(num_elems));
         let bench_spec = BenchmarkSpec::new_hlapi(
@@ -680,7 +683,7 @@ fn hpu_bench_transfer_throughput<FheType, F>(
 fn hpu_bench_transfer_throughput_simd<FheType, F>(
     group: &mut Criterion,
     client_key: &ClientKey,
-    type_name: &str,
+    type_name: &dyn TypeName,
     erc7984_bench_spec: Erc7984,
     transfer_func: F,
 ) where
@@ -701,7 +704,7 @@ fn hpu_bench_transfer_throughput_simd<FheType, F>(
     let params = client_key.computation_parameters();
     let params_name = params.name();
 
-    let mut group = group.benchmark_group(type_name);
+    let mut group = group.benchmark_group(type_name.to_string());
     for num_elems in [2, 8] {
         let real_num_elems = num_elems * (hpu_simd_n as u64);
         group.throughput(Throughput::Elements(real_num_elems));
@@ -788,25 +791,25 @@ fn main() {
         use crate::pbs_stats::print_transfer_pbs_counts;
         print_transfer_pbs_counts(
             &cks,
-            "FheUint64",
+            &TypeDisplayer::<FheUint64>::default(),
             Erc7984::Transfer(TransferFlavor::Whitepaper),
             par_transfer_whitepaper::<FheUint64>,
         );
         print_transfer_pbs_counts(
             &cks,
-            "FheUint64",
+            &TypeDisplayer::<FheUint64>::default(),
             Erc7984::Transfer(TransferFlavor::NoCmux),
             par_transfer_no_cmux::<FheUint64>,
         );
         print_transfer_pbs_counts(
             &cks,
-            "FheUint64",
+            &TypeDisplayer::<FheUint64>::default(),
             Erc7984::Transfer(TransferFlavor::Overflow),
             par_transfer_overflow::<FheUint64>,
         );
         print_transfer_pbs_counts(
             &cks,
-            "FheUint64",
+            &TypeDisplayer::<FheUint64>::default(),
             Erc7984::Transfer(TransferFlavor::Safe),
             par_transfer_safe::<FheUint64>,
         );
@@ -817,28 +820,28 @@ fn main() {
             bench_transfer_latency(
                 &mut c,
                 &cks,
-                "FheUint64",
+                &TypeDisplayer::<FheUint64>::default(),
                 Erc7984::Transfer(TransferFlavor::Whitepaper),
                 par_transfer_whitepaper::<FheUint64>,
             );
             bench_transfer_latency(
                 &mut c,
                 &cks,
-                "FheUint64",
+                &TypeDisplayer::<FheUint64>::default(),
                 Erc7984::Transfer(TransferFlavor::NoCmux),
                 par_transfer_no_cmux::<FheUint64>,
             );
             bench_transfer_latency(
                 &mut c,
                 &cks,
-                "FheUint64",
+                &TypeDisplayer::<FheUint64>::default(),
                 Erc7984::Transfer(TransferFlavor::Overflow),
                 par_transfer_overflow::<FheUint64>,
             );
             bench_transfer_latency(
                 &mut c,
                 &cks,
-                "FheUint64",
+                &TypeDisplayer::<FheUint64>::default(),
                 Erc7984::Transfer(TransferFlavor::Safe),
                 par_transfer_safe::<FheUint64>,
             );
@@ -848,28 +851,28 @@ fn main() {
             bench_transfer_throughput(
                 &mut c,
                 &cks,
-                "FheUint64",
+                &TypeDisplayer::<FheUint64>::default(),
                 Erc7984::Transfer(TransferFlavor::Whitepaper),
                 par_transfer_whitepaper::<FheUint64>,
             );
             bench_transfer_throughput(
                 &mut c,
                 &cks,
-                "FheUint64",
+                &TypeDisplayer::<FheUint64>::default(),
                 Erc7984::Transfer(TransferFlavor::NoCmux),
                 par_transfer_no_cmux::<FheUint64>,
             );
             bench_transfer_throughput(
                 &mut c,
                 &cks,
-                "FheUint64",
+                &TypeDisplayer::<FheUint64>::default(),
                 Erc7984::Transfer(TransferFlavor::Overflow),
                 par_transfer_overflow::<FheUint64>,
             );
             bench_transfer_throughput(
                 &mut c,
                 &cks,
-                "FheUint64",
+                &TypeDisplayer::<FheUint64>::default(),
                 Erc7984::Transfer(TransferFlavor::Safe),
                 par_transfer_safe::<FheUint64>,
             );
@@ -904,25 +907,25 @@ fn main() {
         use crate::pbs_stats::print_transfer_pbs_counts;
         print_transfer_pbs_counts(
             &cks,
-            "FheUint64",
+            &TypeDisplayer::<FheUint64>::default(),
             Erc7984::Transfer(TransferFlavor::Whitepaper),
             par_transfer_whitepaper::<FheUint64>,
         );
         print_transfer_pbs_counts(
             &cks,
-            "FheUint64",
+            &TypeDisplayer::<FheUint64>::default(),
             Erc7984::Transfer(TransferFlavor::NoCmux),
             par_transfer_no_cmux::<FheUint64>,
         );
         print_transfer_pbs_counts(
             &cks,
-            "FheUint64",
+            &TypeDisplayer::<FheUint64>::default(),
             Erc7984::Transfer(TransferFlavor::Overflow),
             par_transfer_overflow::<FheUint64>,
         );
         print_transfer_pbs_counts(
             &cks,
-            "FheUint64",
+            &TypeDisplayer::<FheUint64>::default(),
             Erc7984::Transfer(TransferFlavor::Safe),
             par_transfer_safe::<FheUint64>,
         );
@@ -933,28 +936,28 @@ fn main() {
             bench_transfer_latency(
                 &mut c,
                 &cks,
-                "FheUint64",
+                &TypeDisplayer::<FheUint64>::default(),
                 Erc7984::Transfer(TransferFlavor::Whitepaper),
                 par_transfer_whitepaper::<FheUint64>,
             );
             bench_transfer_latency(
                 &mut c,
                 &cks,
-                "FheUint64",
+                &TypeDisplayer::<FheUint64>::default(),
                 Erc7984::Transfer(TransferFlavor::NoCmux),
                 par_transfer_no_cmux::<FheUint64>,
             );
             bench_transfer_latency(
                 &mut c,
                 &cks,
-                "FheUint64",
+                &TypeDisplayer::<FheUint64>::default(),
                 Erc7984::Transfer(TransferFlavor::Overflow),
                 par_transfer_overflow::<FheUint64>,
             );
             bench_transfer_latency(
                 &mut c,
                 &cks,
-                "FheUint64",
+                &TypeDisplayer::<FheUint64>::default(),
                 Erc7984::Transfer(TransferFlavor::Safe),
                 par_transfer_safe::<FheUint64>,
             );
@@ -964,28 +967,28 @@ fn main() {
             cuda_bench_transfer_throughput(
                 &mut c,
                 &cks,
-                "FheUint64",
+                &TypeDisplayer::<FheUint64>::default(),
                 Erc7984::Transfer(TransferFlavor::Whitepaper),
                 transfer_whitepaper::<FheUint64>,
             );
             cuda_bench_transfer_throughput(
                 &mut c,
                 &cks,
-                "FheUint64",
+                &TypeDisplayer::<FheUint64>::default(),
                 Erc7984::Transfer(TransferFlavor::NoCmux),
                 transfer_no_cmux::<FheUint64>,
             );
             cuda_bench_transfer_throughput(
                 &mut c,
                 &cks,
-                "FheUint64",
+                &TypeDisplayer::<FheUint64>::default(),
                 Erc7984::Transfer(TransferFlavor::Overflow),
                 transfer_overflow::<FheUint64>,
             );
             cuda_bench_transfer_throughput(
                 &mut c,
                 &cks,
-                "FheUint64",
+                &TypeDisplayer::<FheUint64>::default(),
                 Erc7984::Transfer(TransferFlavor::Safe),
                 transfer_safe::<FheUint64>,
             );
@@ -1024,7 +1027,7 @@ fn main() {
             bench_transfer_latency(
                 &mut c,
                 &cks,
-                "FheUint64",
+                &TypeDisplayer::<FheUint64>::default(),
                 Erc7984::Transfer(TransferFlavor::Whitepaper),
                 transfer_whitepaper::<FheUint64>,
             );
@@ -1032,7 +1035,7 @@ fn main() {
             bench_transfer_latency(
                 &mut c,
                 &cks,
-                "FheUint64",
+                &TypeDisplayer::<FheUint64>::default(),
                 Erc7984::Transfer(TransferFlavor::HpuOptim),
                 transfer_hpu::<FheUint64>,
             );
@@ -1040,7 +1043,7 @@ fn main() {
             bench_transfer_latency_simd(
                 &mut c,
                 &cks,
-                "FheUint64",
+                &TypeDisplayer::<FheUint64>::default(),
                 Erc7984::Transfer(TransferFlavor::HpuSimd),
                 transfer_hpu_simd::<FheUint64>,
             );
@@ -1050,7 +1053,7 @@ fn main() {
             hpu_bench_transfer_throughput(
                 &mut c,
                 &cks,
-                "FheUint64",
+                &TypeDisplayer::<FheUint64>::default(),
                 Erc7984::Transfer(TransferFlavor::Whitepaper),
                 transfer_whitepaper::<FheUint64>,
             );
@@ -1058,7 +1061,7 @@ fn main() {
             hpu_bench_transfer_throughput(
                 &mut c,
                 &cks,
-                "FheUint64",
+                &TypeDisplayer::<FheUint64>::default(),
                 Erc7984::Transfer(TransferFlavor::HpuOptim),
                 transfer_hpu::<FheUint64>,
             );
@@ -1066,7 +1069,7 @@ fn main() {
             hpu_bench_transfer_throughput_simd(
                 &mut c,
                 &cks,
-                "FheUint64",
+                &TypeDisplayer::<FheUint64>::default(),
                 Erc7984::Transfer(TransferFlavor::HpuSimd),
                 transfer_hpu_simd::<FheUint64>,
             );

--- a/tfhe-benchmark/benches/high_level_api/noise_squash.rs
+++ b/tfhe-benchmark/benches/high_level_api/noise_squash.rs
@@ -1,6 +1,7 @@
 #[cfg(not(feature = "hpu"))]
 use benchmark::params_aliases::BENCH_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
 
+use benchmark::high_level_api::type_display::TypeDisplayer;
 use benchmark::params_aliases::{
     BENCH_COMP_NOISE_SQUASHING_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
     BENCH_COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
@@ -18,7 +19,9 @@ use benchmark::utilities::{
     will_this_bench_run, write_to_json, BitSizesSet, EnvConfig, OperatorType,
 };
 use benchmark_spec::tfhe::hlapi::noise_squash::NoiseSquashingKind;
-use benchmark_spec::{get_bench_type, BenchmarkSpec, BenchmarkType, HlapiBench, OperandType};
+use benchmark_spec::{
+    get_bench_type, BenchmarkSpec, BenchmarkType, HlapiBench, OperandType, TypeName,
+};
 use criterion::{Criterion, Throughput};
 use rand::prelude::*;
 use rand::thread_rng;
@@ -49,7 +52,7 @@ fn bench_sns_only_fhe_type<FheType>(
         NoiseSquashingCompressionParameters,
         CompressionParameters,
     ),
-    type_name: &str,
+    type_name: &dyn TypeName,
     num_bits: usize,
 ) where
     FheType: FheEncrypt<u128, ClientKey> + Send + Sync + SquashNoise,
@@ -73,7 +76,7 @@ fn bench_sns_only_fhe_type<FheType>(
         set_server_key(decompressed_sks);
     }
 
-    let mut bench_group = c.benchmark_group(type_name);
+    let mut bench_group = c.benchmark_group(type_name.to_string());
     let noise_param_name = noise_param.name();
 
     let mut rng = thread_rng();
@@ -103,7 +106,7 @@ fn bench_sns_only_fhe_type<FheType>(
             });
         }
         BenchmarkType::Throughput => {
-            let elements = if will_this_bench_run(type_name, &bench_id) {
+            let elements = if will_this_bench_run(&type_name.to_string(), &bench_id) {
                 #[cfg(feature = "gpu")]
                 {
                     use benchmark::utilities::throughput_num_threads;
@@ -215,7 +218,7 @@ fn bench_decomp_sns_comp_fhe_type<FheType>(
         NoiseSquashingCompressionParameters,
         CompressionParameters,
     ),
-    type_name: &str,
+    type_name: &dyn TypeName,
     num_bits: usize,
 ) where
     FheType: FheEncrypt<u128, ClientKey> + Send + Sync,
@@ -243,7 +246,7 @@ fn bench_decomp_sns_comp_fhe_type<FheType>(
         set_server_key(decompressed_sks);
     }
 
-    let mut bench_group = c.benchmark_group(type_name);
+    let mut bench_group = c.benchmark_group(type_name.to_string());
     let noise_param_name = noise_param.name();
 
     let mut rng = thread_rng();
@@ -281,7 +284,7 @@ fn bench_decomp_sns_comp_fhe_type<FheType>(
             });
         }
         BenchmarkType::Throughput => {
-            let elements = if will_this_bench_run(type_name, &bench_id) {
+            let elements = if will_this_bench_run(&type_name.to_string(), &bench_id) {
                 #[cfg(feature = "gpu")]
                 {
                     use benchmark::utilities::throughput_num_threads;
@@ -416,7 +419,7 @@ macro_rules! bench_sns_only_type {
         ::paste::paste! {
             fn [<bench_sns_only_ $fhe_type:snake>](c: &mut Criterion, params: &[(PBSParameters, NoiseSquashingParameters, NoiseSquashingCompressionParameters, CompressionParameters)]) {
                 for param in params {
-                    bench_sns_only_fhe_type::<$fhe_type>(c, *param, stringify!($fhe_type), $fhe_type::num_bits());
+                    bench_sns_only_fhe_type::<$fhe_type>(c, *param, &TypeDisplayer::<$fhe_type>::default(), $fhe_type::num_bits());
                 }
             }
         }
@@ -428,7 +431,7 @@ macro_rules! bench_decomp_sns_comp_type {
         ::paste::paste! {
             fn [<bench_decomp_sns_comp_ $fhe_type:snake>](c: &mut Criterion, params: &[(PBSParameters, NoiseSquashingParameters, NoiseSquashingCompressionParameters, CompressionParameters)]) {
                 for param in params {
-                bench_decomp_sns_comp_fhe_type::<$fhe_type>(c, *param, stringify!($fhe_type), $fhe_type::num_bits());
+                bench_decomp_sns_comp_fhe_type::<$fhe_type>(c, *param, &TypeDisplayer::<$fhe_type>::default(), $fhe_type::num_bits());
     }
             }
         }

--- a/tfhe-benchmark/benches/high_level_api/oprf.rs
+++ b/tfhe-benchmark/benches/high_level_api/oprf.rs
@@ -4,12 +4,21 @@ use benchmark::params_aliases::BENCH_PARAM_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_K
 
 use benchmark::utilities::{write_to_json, OperatorType};
 use benchmark_spec::tfhe::hlapi::oprf::OprfKind;
-use benchmark_spec::{BenchmarkSpec, BenchmarkType, HlapiBench, OperandType};
+use benchmark_spec::{BenchmarkSpec, BenchmarkType, HlapiBench, OperandType, TypeName};
 use criterion::{criterion_group, Criterion};
 use std::hint::black_box;
 use std::num::NonZeroU64;
 use tfhe::keycache::NamedParam;
 use tfhe::{set_server_key, ClientKey, ConfigBuilder, FheUint64, RangeForRandom, Seed, ServerKey};
+
+/// The `type` slot for OPRF benches: the excluded upper bound of the range.
+struct OprfBound(u64);
+
+impl TypeName for OprfBound {
+    fn type_name(&self) -> String {
+        format!("bound_{}", self.0)
+    }
+}
 
 fn oprf_any_range_bench(c: &mut Criterion, cks: &ClientKey) {
     let mut bench_group = c.benchmark_group("oprf");
@@ -22,12 +31,11 @@ fn oprf_any_range_bench(c: &mut Criterion, cks: &ClientKey) {
     let param_name = param.name();
 
     for excluded_upper_bound in [3, 52] {
-        let bound_type = format!("bound_{excluded_upper_bound}",);
         let benchmark_spec = BenchmarkSpec::new_hlapi(
             hlapi_op,
             &param_name,
             OperandType::CipherText,
-            Some(bound_type.as_str()),
+            Some(&OprfBound(excluded_upper_bound)),
             BenchmarkType::Latency,
             None,
         );

--- a/tfhe-benchmark/benches/high_level_api/vector_find.rs
+++ b/tfhe-benchmark/benches/high_level_api/vector_find.rs
@@ -1,3 +1,4 @@
+use benchmark::high_level_api::type_display::TypeDisplayer;
 use benchmark::utilities::{write_to_json, BitSizesSet, EnvConfig, OperatorType};
 use benchmark_spec::tfhe::hlapi::vector_find::VectorFindOp;
 use benchmark_spec::tfhe::hlapi::HlapiBench;
@@ -11,7 +12,7 @@ use tfhe::shortint::AtomicPatternParameters;
 use tfhe::{ClientKey, ConfigBuilder, FheUint64, FheUint8, MatchValues};
 
 fn write_metadata(
-    spec: &BenchmarkSpec<str>,
+    spec: &BenchmarkSpec,
     display_name: &str,
     params: AtomicPatternParameters,
     num_bits: usize,
@@ -27,7 +28,7 @@ fn write_metadata(
 
 fn bench_latency_or_throughput<F>(
     group: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
-    spec: &BenchmarkSpec<str>,
+    spec: &BenchmarkSpec,
     operand_bits: usize,
     client_key: &ClientKey,
     run_once: F,
@@ -77,11 +78,11 @@ fn bench_contains_fhe_uint64(c: &mut Criterion, client_key: &ClientKey, num_elem
 
     let params = client_key.computation_parameters();
     let params_name = params.name();
-    let spec = BenchmarkSpec::<str>::new_hlapi(
+    let spec = BenchmarkSpec::new_hlapi(
         HlapiBench::VectorFind(VectorFindOp::Contains),
         &params_name,
         OperandType::CipherText,
-        Some("FheUint64"),
+        Some(&TypeDisplayer::<FheUint64>::default()),
         get_bench_type(),
         Some(num_elements),
     );
@@ -104,11 +105,11 @@ fn bench_contains_fhe_uint8(c: &mut Criterion, client_key: &ClientKey, num_eleme
 
     let params = client_key.computation_parameters();
     let params_name = params.name();
-    let spec = BenchmarkSpec::<str>::new_hlapi(
+    let spec = BenchmarkSpec::new_hlapi(
         HlapiBench::VectorFind(VectorFindOp::Contains),
         &params_name,
         OperandType::CipherText,
-        Some("FheUint8"),
+        Some(&TypeDisplayer::<FheUint8>::default()),
         get_bench_type(),
         Some(num_elements),
     );
@@ -131,11 +132,11 @@ fn bench_match_value_fhe_uint64(c: &mut Criterion, client_key: &ClientKey, num_e
 
     let params = client_key.computation_parameters();
     let params_name = params.name();
-    let spec = BenchmarkSpec::<str>::new_hlapi(
+    let spec = BenchmarkSpec::new_hlapi(
         HlapiBench::VectorFind(VectorFindOp::MatchValue),
         &params_name,
         OperandType::CipherText,
-        Some("FheUint64"),
+        Some(&TypeDisplayer::<FheUint64>::default()),
         get_bench_type(),
         Some(num_elements),
     );
@@ -157,11 +158,11 @@ fn bench_match_value_fhe_uint8(c: &mut Criterion, client_key: &ClientKey, num_el
 
     let params = client_key.computation_parameters();
     let params_name = params.name();
-    let spec = BenchmarkSpec::<str>::new_hlapi(
+    let spec = BenchmarkSpec::new_hlapi(
         HlapiBench::VectorFind(VectorFindOp::MatchValue),
         &params_name,
         OperandType::CipherText,
-        Some("FheUint8"),
+        Some(&TypeDisplayer::<FheUint8>::default()),
         get_bench_type(),
         Some(num_elements),
     );

--- a/tfhe-benchmark/benches/integer/bench.rs
+++ b/tfhe-benchmark/benches/integer/bench.rs
@@ -15,6 +15,7 @@ use benchmark::utilities::throughput_num_threads;
 use benchmark::utilities::{write_to_json, EnvConfig, OperatorType};
 use benchmark_spec::{
     get_bench_type, BenchmarkMetric, BenchmarkSpec, BenchmarkType, IntegerOp, IntegerOpBySign,
+    PrecisionTag,
 };
 use criterion::{criterion_group, Criterion, Throughput};
 use rand::prelude::*;
@@ -60,11 +61,11 @@ fn bench_server_key_binary_function_clean_inputs<F>(
     for (param, num_block, bit_size) in ParamsAndNumBlocksIter::default() {
         let param_name = param.name();
 
-        let bits = format!("{bit_size}_bits");
-        let benchmark_spec = BenchmarkSpec::<str>::new_integer_ops(
+        let bits = PrecisionTag::Bits(bit_size);
+        let benchmark_spec = BenchmarkSpec::new_integer_ops(
             IntegerOpBySign::Unsigned(integer_op),
             &param_name,
-            Some(bits.as_str()),
+            Some(&bits),
             get_bench_type(),
             None,
         );
@@ -180,11 +181,11 @@ fn bench_server_key_unary_function_dirty_inputs<F>(
 
         let keys = LazyCell::new(move || KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix));
 
-        let bits = format!("{bit_size}_bits");
-        let benchmark_spec = BenchmarkSpec::<str>::new_integer_ops(
+        let bits = PrecisionTag::Bits(bit_size);
+        let benchmark_spec = BenchmarkSpec::new_integer_ops(
             IntegerOpBySign::Unsigned(integer_op),
             &param_name,
-            Some(bits.as_str()),
+            Some(&bits),
             BenchmarkMetric::Latency,
             None,
         );
@@ -251,11 +252,11 @@ fn bench_server_key_unary_function_clean_inputs<F>(
     for (param, num_block, bit_size) in ParamsAndNumBlocksIter::default() {
         let param_name = param.name();
 
-        let bits = format!("{bit_size}_bits");
-        let benchmark_spec = BenchmarkSpec::<str>::new_integer_ops(
+        let bits = PrecisionTag::Bits(bit_size);
+        let benchmark_spec = BenchmarkSpec::new_integer_ops(
             IntegerOpBySign::Unsigned(integer_op),
             &param_name,
-            Some(bits.as_str()),
+            Some(&bits),
             get_bench_type(),
             None,
         );
@@ -365,13 +366,13 @@ fn bench_server_key_binary_scalar_function_clean_inputs<F, G>(
         // Preserve the historical id suffix: latency kept `_bits_scalar_{bit_size}`,
         // throughput never had it.
         let bits = match get_bench_type() {
-            BenchmarkType::Latency => format!("{bit_size}_bits_scalar_{bit_size}"),
-            BenchmarkType::Throughput => format!("{bit_size}_bits"),
+            BenchmarkType::Latency => PrecisionTag::BitsScalar(bit_size),
+            BenchmarkType::Throughput => PrecisionTag::Bits(bit_size),
         };
-        let benchmark_spec = BenchmarkSpec::<str>::new_integer_ops(
+        let benchmark_spec = BenchmarkSpec::new_integer_ops(
             IntegerOpBySign::Unsigned(integer_op),
             &param_name,
-            Some(bits.as_str()),
+            Some(&bits),
             get_bench_type(),
             None,
         );
@@ -511,11 +512,11 @@ fn if_then_else_parallelized(c: &mut Criterion) {
     for (param, num_block, bit_size) in ParamsAndNumBlocksIter::default() {
         let param_name = param.name();
 
-        let bits = format!("{bit_size}_bits");
-        let benchmark_spec = BenchmarkSpec::<str>::new_integer_ops(
+        let bits = PrecisionTag::Bits(bit_size);
+        let benchmark_spec = BenchmarkSpec::new_integer_ops(
             IntegerOpBySign::Unsigned(integer_op),
             &param_name,
-            Some(bits.as_str()),
+            Some(&bits),
             get_bench_type(),
             None,
         );
@@ -625,11 +626,11 @@ fn flip_parallelized(c: &mut Criterion) {
     for (param, num_block, bit_size) in ParamsAndNumBlocksIter::default() {
         let param_name = param.name();
 
-        let bits = format!("{bit_size}_bits");
-        let benchmark_spec = BenchmarkSpec::<str>::new_integer_ops(
+        let bits = PrecisionTag::Bits(bit_size);
+        let benchmark_spec = BenchmarkSpec::new_integer_ops(
             IntegerOpBySign::Unsigned(integer_op),
             &param_name,
-            Some(bits.as_str()),
+            Some(&bits),
             get_bench_type(),
             None,
         );
@@ -741,11 +742,11 @@ fn ciphertexts_sum_parallelized(c: &mut Criterion) {
         let max_for_bit_size = ScalarType::MAX >> (ScalarType::BITS as usize - bit_size);
 
         for len in [5, 10, 20] {
-            let bits = format!("{bit_size}_bits");
-            let benchmark_spec = BenchmarkSpec::<str>::new_integer_ops(
+            let bits = PrecisionTag::Bits(bit_size);
+            let benchmark_spec = BenchmarkSpec::new_integer_ops(
                 IntegerOpBySign::Unsigned(integer_op),
                 &param_name,
-                Some(bits.as_str()),
+                Some(&bits),
                 get_bench_type(),
                 Some(len),
             );
@@ -1283,11 +1284,11 @@ mod cuda {
         for (param, num_block, bit_size) in ParamsAndNumBlocksIter::default() {
             let param_name = param.name();
 
-            let bits = format!("{bit_size}_bits");
-            let benchmark_spec = BenchmarkSpec::<str>::new_integer_ops(
+            let bits = PrecisionTag::Bits(bit_size);
+            let benchmark_spec = BenchmarkSpec::new_integer_ops(
                 IntegerOpBySign::Unsigned(integer_op),
                 &param_name,
-                Some(bits.as_str()),
+                Some(&bits),
                 get_bench_type(),
                 None,
             );
@@ -1405,11 +1406,11 @@ mod cuda {
         for (param, num_block, bit_size) in ParamsAndNumBlocksIter::default() {
             let param_name = param.name();
 
-            let bits = format!("{bit_size}_bits");
-            let benchmark_spec = BenchmarkSpec::<str>::new_integer_ops(
+            let bits = PrecisionTag::Bits(bit_size);
+            let benchmark_spec = BenchmarkSpec::new_integer_ops(
                 IntegerOpBySign::Unsigned(integer_op),
                 &param_name,
-                Some(bits.as_str()),
+                Some(&bits),
                 get_bench_type(),
                 None,
             );
@@ -1553,11 +1554,11 @@ mod cuda {
 
             // Preserve the historical `_bits_scalar_{bit_size}` id suffix (present on
             // both latency and throughput for the GPU scalar benches).
-            let bits = format!("{bit_size}_bits_scalar_{bit_size}");
-            let benchmark_spec = BenchmarkSpec::<str>::new_integer_ops(
+            let bits = PrecisionTag::BitsScalar(bit_size);
+            let benchmark_spec = BenchmarkSpec::new_integer_ops(
                 IntegerOpBySign::Unsigned(integer_op),
                 &param_name,
-                Some(bits.as_str()),
+                Some(&bits),
                 get_bench_type(),
                 None,
             );
@@ -1684,11 +1685,11 @@ mod cuda {
 
             let param_name = param.name();
 
-            let bits = format!("{bit_size}_bits");
-            let benchmark_spec = BenchmarkSpec::<str>::new_integer_ops(
+            let bits = PrecisionTag::Bits(bit_size);
+            let benchmark_spec = BenchmarkSpec::new_integer_ops(
                 IntegerOpBySign::Unsigned(integer_op),
                 &param_name,
-                Some(bits.as_str()),
+                Some(&bits),
                 get_bench_type(),
                 None,
             );
@@ -2659,11 +2660,14 @@ mod cuda {
             for target_num_blocks in all_num_blocks.iter().copied() {
                 let target_bit_size =
                     target_num_blocks * param.message_modulus().0.ilog2() as usize;
-                let conversion = format!("{bit_size}_to_{target_bit_size}");
-                let benchmark_spec = BenchmarkSpec::<str>::new_integer_ops(
+                let conversion = PrecisionTag::Conversion {
+                    from: bit_size,
+                    to: target_bit_size,
+                };
+                let benchmark_spec = BenchmarkSpec::new_integer_ops(
                     IntegerOpBySign::Unsigned(integer_op),
                     &param_name,
-                    Some(conversion.as_str()),
+                    Some(&conversion),
                     BenchmarkMetric::Latency,
                     None,
                 );
@@ -2760,11 +2764,11 @@ mod hpu {
 
             let max_value_for_bit_size = ScalarType::MAX >> (ScalarType::BITS as usize - bit_size);
 
-            let bits = format!("{bit_size}_bits");
-            let benchmark_spec = BenchmarkSpec::<str>::new_integer_ops(
+            let bits = PrecisionTag::Bits(bit_size);
+            let benchmark_spec = BenchmarkSpec::new_integer_ops(
                 IntegerOpBySign::Unsigned(integer_op),
                 &param_name,
-                Some(bits.as_str()),
+                Some(&bits),
                 get_bench_type(),
                 None,
             );
@@ -3424,11 +3428,14 @@ fn bench_server_key_cast_function<F>(
 
         for target_num_blocks in all_num_blocks.iter().copied() {
             let target_bit_size = target_num_blocks * param.message_modulus().0.ilog2() as usize;
-            let conversion = format!("{bit_size}_to_{target_bit_size}");
-            let benchmark_spec = BenchmarkSpec::<str>::new_integer_ops(
+            let conversion = PrecisionTag::Conversion {
+                from: bit_size,
+                to: target_bit_size,
+            };
+            let benchmark_spec = BenchmarkSpec::new_integer_ops(
                 IntegerOpBySign::Unsigned(integer_op),
                 &param_name,
-                Some(conversion.as_str()),
+                Some(&conversion),
                 BenchmarkMetric::Latency,
                 None,
             );

--- a/tfhe-benchmark/benches/integer/oprf.rs
+++ b/tfhe-benchmark/benches/integer/oprf.rs
@@ -2,7 +2,9 @@ use benchmark::params::ParamsAndNumBlocksIter;
 #[cfg(any(feature = "gpu", feature = "hpu"))]
 use benchmark::utilities::throughput_num_threads;
 use benchmark::utilities::{write_to_json, OperatorType};
-use benchmark_spec::{get_bench_type, BenchmarkSpec, BenchmarkType, IntegerBench, IntegerOprf};
+use benchmark_spec::{
+    get_bench_type, BenchmarkSpec, BenchmarkType, IntegerBench, IntegerOprf, PrecisionTag,
+};
 use criterion::{Criterion, Throughput};
 use rayon::prelude::*;
 #[cfg(any(feature = "gpu", feature = "hpu"))]
@@ -26,17 +28,17 @@ pub fn unsigned_oprf(c: &mut Criterion) {
 
     for (param, num_block, bit_size) in ParamsAndNumBlocksIter::default() {
         let param_name = param.name();
-        let bits = format!("{bit_size}_bits");
+        let bits = PrecisionTag::Bits(bit_size);
         let bench_type = get_bench_type();
 
-        let oprf_spec = BenchmarkSpec::<str>::new_integer(
+        let oprf_spec = BenchmarkSpec::new_integer(
             IntegerBench::Oprf(IntegerOprf::Unsigned),
             &param_name,
             Some(&bits),
             bench_type,
             None,
         );
-        let oprf_bounded_spec = BenchmarkSpec::<str>::new_integer(
+        let oprf_bounded_spec = BenchmarkSpec::new_integer(
             IntegerBench::Oprf(IntegerOprf::UnsignedBounded),
             &param_name,
             Some(&bits),
@@ -183,17 +185,17 @@ pub mod cuda {
 
         for (param, num_block, bit_size) in ParamsAndNumBlocksIter::default() {
             let param_name = param.name();
-            let bits = format!("{bit_size}_bits");
+            let bits = PrecisionTag::Bits(bit_size);
             let bench_type = get_bench_type();
 
-            let oprf_spec = BenchmarkSpec::<str>::new_integer(
+            let oprf_spec = BenchmarkSpec::new_integer(
                 IntegerBench::Oprf(IntegerOprf::Unsigned),
                 &param_name,
                 Some(&bits),
                 bench_type,
                 None,
             );
-            let oprf_bounded_spec = BenchmarkSpec::<str>::new_integer(
+            let oprf_bounded_spec = BenchmarkSpec::new_integer(
                 IntegerBench::Oprf(IntegerOprf::UnsignedBounded),
                 &param_name,
                 Some(&bits),

--- a/tfhe-benchmark/benches/integer/signed_bench.rs
+++ b/tfhe-benchmark/benches/integer/signed_bench.rs
@@ -2,6 +2,7 @@ use benchmark::params::ParamsAndNumBlocksIter;
 use benchmark::utilities::{throughput_num_threads, write_to_json, EnvConfig, OperatorType};
 use benchmark_spec::{
     get_bench_type, BenchmarkMetric, BenchmarkSpec, BenchmarkType, IntegerOp, IntegerOpBySign,
+    PrecisionTag,
 };
 use criterion::{criterion_group, Criterion, Throughput};
 use rand::prelude::*;
@@ -42,11 +43,11 @@ fn bench_server_key_signed_binary_function_clean_inputs<F>(
     for (param, num_block, bit_size) in ParamsAndNumBlocksIter::default() {
         let param_name = param.name();
 
-        let bits = format!("{bit_size}_bits");
-        let benchmark_spec = BenchmarkSpec::<str>::new_integer_ops(
+        let bits = PrecisionTag::Bits(bit_size);
+        let benchmark_spec = BenchmarkSpec::new_integer_ops(
             IntegerOpBySign::Signed(integer_op),
             &param_name,
-            Some(bits.as_str()),
+            Some(&bits),
             get_bench_type(),
             None,
         );
@@ -154,11 +155,11 @@ fn bench_server_key_signed_shift_function_clean_inputs<F>(
     for (param, num_block, bit_size) in ParamsAndNumBlocksIter::default() {
         let param_name = param.name();
 
-        let bits = format!("{bit_size}_bits");
-        let benchmark_spec = BenchmarkSpec::<str>::new_integer_ops(
+        let bits = PrecisionTag::Bits(bit_size);
+        let benchmark_spec = BenchmarkSpec::new_integer_ops(
             IntegerOpBySign::Signed(integer_op),
             &param_name,
-            Some(bits.as_str()),
+            Some(&bits),
             get_bench_type(),
             None,
         );
@@ -260,11 +261,11 @@ fn bench_server_key_unary_function_clean_inputs<F>(
     for (param, num_block, bit_size) in ParamsAndNumBlocksIter::default() {
         let param_name = param.name();
 
-        let bits = format!("{bit_size}_bits");
-        let benchmark_spec = BenchmarkSpec::<str>::new_integer_ops(
+        let bits = PrecisionTag::Bits(bit_size);
+        let benchmark_spec = BenchmarkSpec::new_integer_ops(
             IntegerOpBySign::Signed(integer_op),
             &param_name,
-            Some(bits.as_str()),
+            Some(&bits),
             get_bench_type(),
             None,
         );
@@ -343,11 +344,11 @@ fn signed_if_then_else_parallelized(c: &mut Criterion) {
     for (param, num_block, bit_size) in ParamsAndNumBlocksIter::default() {
         let param_name = param.name();
 
-        let bits = format!("{bit_size}_bits");
-        let benchmark_spec = BenchmarkSpec::<str>::new_integer_ops(
+        let bits = PrecisionTag::Bits(bit_size);
+        let benchmark_spec = BenchmarkSpec::new_integer_ops(
             IntegerOpBySign::Signed(integer_op),
             &param_name,
-            Some(bits.as_str()),
+            Some(&bits),
             get_bench_type(),
             None,
         );
@@ -889,13 +890,13 @@ fn bench_server_key_binary_scalar_function_clean_inputs<F, G>(
         let range = range_for_signed_bit_size(bit_size);
 
         let bits = match get_bench_type() {
-            BenchmarkType::Latency => format!("{bit_size}_bits_scalar_{bit_size}"),
-            BenchmarkType::Throughput => format!("{bit_size}_bits"),
+            BenchmarkType::Latency => PrecisionTag::BitsScalar(bit_size),
+            BenchmarkType::Throughput => PrecisionTag::Bits(bit_size),
         };
-        let benchmark_spec = BenchmarkSpec::<str>::new_integer_ops(
+        let benchmark_spec = BenchmarkSpec::new_integer_ops(
             IntegerOpBySign::Signed(integer_op),
             &param_name,
-            Some(bits.as_str()),
+            Some(&bits),
             get_bench_type(),
             None,
         );
@@ -1069,11 +1070,11 @@ fn signed_flip_parallelized(c: &mut Criterion) {
     for (param, num_block, bit_size) in ParamsAndNumBlocksIter::default() {
         let param_name = param.name();
 
-        let bits = format!("{bit_size}_bits");
-        let benchmark_spec = BenchmarkSpec::<str>::new_integer_ops(
+        let bits = PrecisionTag::Bits(bit_size);
+        let benchmark_spec = BenchmarkSpec::new_integer_ops(
             IntegerOpBySign::Signed(integer_op),
             &param_name,
-            Some(bits.as_str()),
+            Some(&bits),
             get_bench_type(),
             None,
         );
@@ -1495,11 +1496,14 @@ fn bench_server_key_signed_cast_function<F>(
 
         for target_num_blocks in all_num_blocks.iter().copied() {
             let target_bit_size = target_num_blocks * param.message_modulus().0.ilog2() as usize;
-            let conversion = format!("{bit_size}_to_{target_bit_size}");
-            let benchmark_spec = BenchmarkSpec::<str>::new_integer_ops(
+            let conversion = PrecisionTag::Conversion {
+                from: bit_size,
+                to: target_bit_size,
+            };
+            let benchmark_spec = BenchmarkSpec::new_integer_ops(
                 IntegerOpBySign::Signed(integer_op),
                 &param_name,
-                Some(conversion.as_str()),
+                Some(&conversion),
                 BenchmarkMetric::Latency,
                 None,
             );
@@ -1592,11 +1596,11 @@ mod cuda {
         for (param, num_block, bit_size) in ParamsAndNumBlocksIter::default() {
             let param_name = param.name();
 
-            let bits = format!("{bit_size}_bits");
-            let benchmark_spec = BenchmarkSpec::<str>::new_integer_ops(
+            let bits = PrecisionTag::Bits(bit_size);
+            let benchmark_spec = BenchmarkSpec::new_integer_ops(
                 IntegerOpBySign::Signed(integer_op),
                 &param_name,
-                Some(bits.as_str()),
+                Some(&bits),
                 get_bench_type(),
                 None,
             );
@@ -1766,11 +1770,11 @@ mod cuda {
         for (param, num_block, bit_size) in ParamsAndNumBlocksIter::default() {
             let param_name = param.name();
 
-            let bits = format!("{bit_size}_bits");
-            let benchmark_spec = BenchmarkSpec::<str>::new_integer_ops(
+            let bits = PrecisionTag::Bits(bit_size);
+            let benchmark_spec = BenchmarkSpec::new_integer_ops(
                 IntegerOpBySign::Signed(integer_op),
                 &param_name,
-                Some(bits.as_str()),
+                Some(&bits),
                 get_bench_type(),
                 None,
             );
@@ -1912,11 +1916,11 @@ mod cuda {
 
             let max_value_for_bit_size = ScalarType::MAX >> (ScalarType::BITS as usize - bit_size);
 
-            let bits = format!("{bit_size}_bits_scalar_{bit_size}");
-            let benchmark_spec = BenchmarkSpec::<str>::new_integer_ops(
+            let bits = PrecisionTag::BitsScalar(bit_size);
+            let benchmark_spec = BenchmarkSpec::new_integer_ops(
                 IntegerOpBySign::Signed(integer_op),
                 &param_name,
-                Some(bits.as_str()),
+                Some(&bits),
                 get_bench_type(),
                 None,
             );
@@ -2076,11 +2080,11 @@ mod cuda {
         for (param, num_block, bit_size) in ParamsAndNumBlocksIter::default() {
             let param_name = param.name();
 
-            let bits = format!("{bit_size}_bits");
-            let benchmark_spec = BenchmarkSpec::<str>::new_integer_ops(
+            let bits = PrecisionTag::Bits(bit_size);
+            let benchmark_spec = BenchmarkSpec::new_integer_ops(
                 IntegerOpBySign::Signed(integer_op),
                 &param_name,
-                Some(bits.as_str()),
+                Some(&bits),
                 get_bench_type(),
                 None,
             );
@@ -2244,11 +2248,11 @@ mod cuda {
 
             let param_name = param.name();
 
-            let bits = format!("{bit_size}_bits");
-            let benchmark_spec = BenchmarkSpec::<str>::new_integer_ops(
+            let bits = PrecisionTag::Bits(bit_size);
+            let benchmark_spec = BenchmarkSpec::new_integer_ops(
                 IntegerOpBySign::Signed(integer_op),
                 &param_name,
-                Some(bits.as_str()),
+                Some(&bits),
                 get_bench_type(),
                 None,
             );
@@ -3121,11 +3125,14 @@ mod cuda {
             for target_num_blocks in all_num_blocks.iter().copied() {
                 let target_bit_size =
                     target_num_blocks * param.message_modulus().0.ilog2() as usize;
-                let conversion = format!("{bit_size}_to_{target_bit_size}");
-                let benchmark_spec = BenchmarkSpec::<str>::new_integer_ops(
+                let conversion = PrecisionTag::Conversion {
+                    from: bit_size,
+                    to: target_bit_size,
+                };
+                let benchmark_spec = BenchmarkSpec::new_integer_ops(
                     IntegerOpBySign::Signed(integer_op),
                     &param_name,
-                    Some(conversion.as_str()),
+                    Some(&conversion),
                     BenchmarkMetric::Latency,
                     None,
                 );

--- a/tfhe-benchmark/benches/shortint/bench.rs
+++ b/tfhe-benchmark/benches/shortint/bench.rs
@@ -33,11 +33,8 @@ fn bench_server_key_unary_function<F>(
 
         let mut ct = cks.encrypt(clear_text);
 
-        let benchmark_spec = BenchmarkSpec::<str>::new_shortint(
-            shortint_bench,
-            &param_name,
-            BenchmarkMetric::Latency,
-        );
+        let benchmark_spec =
+            BenchmarkSpec::new_shortint(shortint_bench, &param_name, BenchmarkMetric::Latency);
         let bench_id = benchmark_spec.to_string();
         bench_group.bench_function(&bench_id, |b| {
             b.iter(|| {
@@ -81,11 +78,8 @@ fn bench_server_key_binary_function<F>(
         let mut ct_0 = cks.encrypt(clear_0);
         let mut ct_1 = cks.encrypt(clear_1);
 
-        let benchmark_spec = BenchmarkSpec::<str>::new_shortint(
-            shortint_bench,
-            &param_name,
-            BenchmarkMetric::Latency,
-        );
+        let benchmark_spec =
+            BenchmarkSpec::new_shortint(shortint_bench, &param_name, BenchmarkMetric::Latency);
         let bench_id = benchmark_spec.to_string();
         bench_group.bench_function(&bench_id, |b| {
             b.iter(|| {
@@ -128,11 +122,8 @@ fn bench_server_key_binary_scalar_function<F>(
 
         let mut ct_0 = cks.encrypt(clear_0);
 
-        let benchmark_spec = BenchmarkSpec::<str>::new_shortint(
-            shortint_bench,
-            &param_name,
-            BenchmarkMetric::Latency,
-        );
+        let benchmark_spec =
+            BenchmarkSpec::new_shortint(shortint_bench, &param_name, BenchmarkMetric::Latency);
         let bench_id = benchmark_spec.to_string();
         bench_group.bench_function(&bench_id, |b| {
             b.iter(|| {
@@ -179,11 +170,8 @@ fn bench_server_key_binary_scalar_division_function<F>(
 
         let mut ct_0 = cks.encrypt(clear_0);
 
-        let benchmark_spec = BenchmarkSpec::<str>::new_shortint(
-            shortint_bench,
-            &param_name,
-            BenchmarkMetric::Latency,
-        );
+        let benchmark_spec =
+            BenchmarkSpec::new_shortint(shortint_bench, &param_name, BenchmarkMetric::Latency);
         let bench_id = benchmark_spec.to_string();
         bench_group.bench_function(&bench_id, |b| {
             b.iter(|| {
@@ -219,11 +207,8 @@ fn carry_extract_bench(c: &mut Criterion) {
 
         let ct_0 = cks.encrypt(clear_0);
 
-        let benchmark_spec = BenchmarkSpec::<str>::new_shortint(
-            shortint_bench,
-            &param_name,
-            BenchmarkMetric::Latency,
-        );
+        let benchmark_spec =
+            BenchmarkSpec::new_shortint(shortint_bench, &param_name, BenchmarkMetric::Latency);
         let bench_id = benchmark_spec.to_string();
         bench_group.bench_function(&bench_id, |b| {
             b.iter(|| {
@@ -261,11 +246,8 @@ fn programmable_bootstrapping_bench(c: &mut Criterion) {
 
         let ctxt = cks.encrypt(clear_0);
 
-        let benchmark_spec = BenchmarkSpec::<str>::new_shortint(
-            shortint_bench,
-            &param_name,
-            BenchmarkMetric::Latency,
-        );
+        let benchmark_spec =
+            BenchmarkSpec::new_shortint(shortint_bench, &param_name, BenchmarkMetric::Latency);
         let bench_id = benchmark_spec.to_string();
 
         bench_group.bench_function(&bench_id, |b| {
@@ -308,11 +290,8 @@ fn server_key_from_compressed_key(c: &mut Criterion) {
         let keys = KEY_CACHE.get_from_param(*param);
         let sks_compressed = CompressedServerKey::new(keys.client_key());
 
-        let benchmark_spec = BenchmarkSpec::<str>::new_shortint(
-            shortint_bench,
-            param_name,
-            BenchmarkMetric::Latency,
-        );
+        let benchmark_spec =
+            BenchmarkSpec::new_shortint(shortint_bench, param_name, BenchmarkMetric::Latency);
         let bench_id = benchmark_spec.to_string();
 
         bench_group.bench_function(&bench_id, |b| {

--- a/tfhe-benchmark/benches/shortint/casting.rs
+++ b/tfhe-benchmark/benches/shortint/casting.rs
@@ -26,11 +26,8 @@ pub fn pack_cast_64(c: &mut Criterion) {
 
     let vec_ct = vec![client_key_1.encrypt(1); 64];
 
-    let benchmark_spec = BenchmarkSpec::<str>::new_shortint(
-        shortint_bench,
-        &ks_param_name,
-        BenchmarkMetric::Latency,
-    );
+    let benchmark_spec =
+        BenchmarkSpec::new_shortint(shortint_bench, &ks_param_name, BenchmarkMetric::Latency);
     let bench_id = benchmark_spec.to_string();
     bench_group.bench_function(&bench_id, |b| {
         b.iter(|| {
@@ -81,11 +78,8 @@ pub fn pack_cast(c: &mut Criterion) {
     let ct_1 = client_key_1.encrypt(1);
     let ct_2 = client_key_1.encrypt(1);
 
-    let benchmark_spec = BenchmarkSpec::<str>::new_shortint(
-        shortint_bench,
-        &ks_param_name,
-        BenchmarkMetric::Latency,
-    );
+    let benchmark_spec =
+        BenchmarkSpec::new_shortint(shortint_bench, &ks_param_name, BenchmarkMetric::Latency);
     let bench_id = benchmark_spec.to_string();
     bench_group.bench_function(&bench_id, |b| {
         b.iter(|| {
@@ -124,11 +118,8 @@ pub fn cast(c: &mut Criterion) {
 
     let ct = client_key_1.encrypt(1);
 
-    let benchmark_spec = BenchmarkSpec::<str>::new_shortint(
-        shortint_bench,
-        &ks_param_name,
-        BenchmarkMetric::Latency,
-    );
+    let benchmark_spec =
+        BenchmarkSpec::new_shortint(shortint_bench, &ks_param_name, BenchmarkMetric::Latency);
     let bench_id = benchmark_spec.to_string();
     bench_group.bench_function(&bench_id, |b| {
         b.iter(|| {

--- a/tfhe-benchmark/benches/shortint/glwe_packing_compression.rs
+++ b/tfhe-benchmark/benches/shortint/glwe_packing_compression.rs
@@ -7,8 +7,8 @@ use std::hint::black_box;
 use tfhe::keycache::NamedParam;
 use tfhe::shortint::prelude::*;
 
-fn spec(packing_op: ShortintPackingOp, param_name: &str) -> BenchmarkSpec<'_, str> {
-    BenchmarkSpec::<str>::new_shortint(
+fn spec(packing_op: ShortintPackingOp, param_name: &str) -> BenchmarkSpec {
+    BenchmarkSpec::new_shortint(
         ShortintBench::PackingCompression(packing_op),
         param_name,
         BenchmarkMetric::Latency,

--- a/tfhe-benchmark/benches/shortint/oprf.rs
+++ b/tfhe-benchmark/benches/shortint/oprf.rs
@@ -23,7 +23,7 @@ fn oprf(c: &mut Criterion) {
     let oprf_sk = OprfServerKey::new(&oprf_pk, cks).unwrap();
 
     let benchmark_spec =
-        BenchmarkSpec::<str>::new_shortint(shortint_bench, &param_name, BenchmarkMetric::Latency);
+        BenchmarkSpec::new_shortint(shortint_bench, &param_name, BenchmarkMetric::Latency);
     let bench_id = benchmark_spec.to_string();
     bench_group.bench_function(&bench_id, |b| {
         b.iter(|| {

--- a/tfhe-benchmark/benches/transciphering/aes_transciphering.rs
+++ b/tfhe-benchmark/benches/transciphering/aes_transciphering.rs
@@ -60,7 +60,7 @@ pub fn cpu_aes_transciphering(c: &mut Criterion) {
     let enc_key = AesPlainKey::from(key).encrypt(&cks);
 
     // ---- key_expansion ----
-    let benchmark_spec = BenchmarkSpec::<str>::new_transciphering(
+    let benchmark_spec = BenchmarkSpec::new_transciphering(
         TranscipheringBench::Aes(AesFlavor::KeyExpansion),
         &param_name,
         BenchmarkMetric::Latency,
@@ -81,7 +81,7 @@ pub fn cpu_aes_transciphering(c: &mut Criterion) {
     // ---- key_expansion_plus_1_block ----
     // Cold-start cost: fresh key schedule + one CTR block keystream per iter.
 
-    let benchmark_spec = BenchmarkSpec::<str>::new_transciphering(
+    let benchmark_spec = BenchmarkSpec::new_transciphering(
         TranscipheringBench::Aes(AesFlavor::KeyExpansionPlus1Block),
         &param_name,
         BenchmarkMetric::Latency,
@@ -107,7 +107,7 @@ pub fn cpu_aes_transciphering(c: &mut Criterion) {
 
     // ---- keystream_1_block ----
 
-    let benchmark_spec = BenchmarkSpec::<str>::new_transciphering(
+    let benchmark_spec = BenchmarkSpec::new_transciphering(
         TranscipheringBench::Aes(AesFlavor::Keystream1Block),
         &param_name,
         BenchmarkMetric::Latency,
@@ -129,7 +129,7 @@ pub fn cpu_aes_transciphering(c: &mut Criterion) {
     // ---- keystream_16_blocks ----
     let total_bits = BLOCK_BITS * N_BLOCKS;
 
-    let benchmark_spec = BenchmarkSpec::<str>::new_transciphering(
+    let benchmark_spec = BenchmarkSpec::new_transciphering(
         TranscipheringBench::Aes(AesFlavor::Keystream16Blocks),
         &param_name,
         BenchmarkMetric::Latency,
@@ -156,7 +156,7 @@ pub fn cpu_aes_transciphering(c: &mut Criterion) {
     let message = vec![0u8; total_bytes];
     let sym_cipher = AesPlainState::new(key, iv).encrypt(&message).unwrap();
 
-    let benchmark_spec = BenchmarkSpec::<str>::new_transciphering(
+    let benchmark_spec = BenchmarkSpec::new_transciphering(
         TranscipheringBench::Aes(AesFlavor::Transcipher16Blocks),
         &param_name,
         BenchmarkMetric::Latency,

--- a/tfhe-benchmark/benches/transciphering/kreyvium_transciphering.rs
+++ b/tfhe-benchmark/benches/transciphering/kreyvium_transciphering.rs
@@ -60,7 +60,7 @@ pub fn cpu_kreyvium_transciphering(c: &mut Criterion) {
     let plain_key = KreyviumPlainKey::from(key_bytes);
 
     // ---- warmup ----
-    let benchmark_spec = BenchmarkSpec::<str>::new_transciphering(
+    let benchmark_spec = BenchmarkSpec::new_transciphering(
         TranscipheringBench::Kreyvium(KreyviumFlavor::Warmup),
         &param_name,
         BenchmarkMetric::Latency,
@@ -89,7 +89,7 @@ pub fn cpu_kreyvium_transciphering(c: &mut Criterion) {
     };
 
     // ---- keystream_64bits ----
-    let benchmark_spec = BenchmarkSpec::<str>::new_transciphering(
+    let benchmark_spec = BenchmarkSpec::new_transciphering(
         TranscipheringBench::Kreyvium(KreyviumFlavor::Keystream64Bits),
         &param_name,
         BenchmarkMetric::Latency,
@@ -121,7 +121,7 @@ pub fn cpu_kreyvium_transciphering(c: &mut Criterion) {
         plain_stream.encrypt(&message).unwrap()
     };
 
-    let benchmark_spec = BenchmarkSpec::<str>::new_transciphering(
+    let benchmark_spec = BenchmarkSpec::new_transciphering(
         TranscipheringBench::Kreyvium(KreyviumFlavor::Transcipher64Bits),
         &param_name,
         BenchmarkMetric::Latency,

--- a/tfhe-benchmark/benches/zk/msm.rs
+++ b/tfhe-benchmark/benches/zk/msm.rs
@@ -133,8 +133,7 @@ impl MsmBenchGroup for G2Bench {
 // =============================================================================
 
 fn bench_cpu_msm<T: MsmBenchGroup>(c: &mut Criterion) {
-    let group_name =
-        BenchmarkSpec::<str>::new_zk_msm(T::MSM_ID, Backend::Cpu, get_bench_type(), None);
+    let group_name = BenchmarkSpec::new_zk_msm(T::MSM_ID, Backend::Cpu, get_bench_type(), None);
     let mut group = c.benchmark_group(group_name.to_string());
     group.sample_size(10);
     group.measurement_time(Duration::from_secs(30));
@@ -142,7 +141,7 @@ fn bench_cpu_msm<T: MsmBenchGroup>(c: &mut Criterion) {
     for size in MSM_SIZES.iter() {
         let n = *size;
         let bench_id =
-            BenchmarkSpec::<str>::new_zk_msm(T::MSM_ID, Backend::Cpu, get_bench_type(), Some(n));
+            BenchmarkSpec::new_zk_msm(T::MSM_ID, Backend::Cpu, get_bench_type(), Some(n));
         let bench_id_string = bench_id.to_string();
 
         match get_bench_type() {
@@ -201,8 +200,7 @@ fn bench_cpu_msm<T: MsmBenchGroup>(c: &mut Criterion) {
 fn bench_gpu_msm<T: MsmBenchGroup>(c: &mut Criterion) {
     use tfhe_zk_pok::gpu::select_gpu_for_msm;
 
-    let group_name =
-        BenchmarkSpec::<str>::new_zk_msm(T::MSM_ID, Backend::Cuda, get_bench_type(), None);
+    let group_name = BenchmarkSpec::new_zk_msm(T::MSM_ID, Backend::Cuda, *get_bench_type(), None);
     let mut group = c.benchmark_group(&group_name.to_string());
     group.sample_size(10);
     group.measurement_time(Duration::from_secs(30));
@@ -213,7 +211,7 @@ fn bench_gpu_msm<T: MsmBenchGroup>(c: &mut Criterion) {
     for size in MSM_SIZES.iter() {
         let n = *size;
         let bench_id =
-            BenchmarkSpec::<str>::new_zk_msm(T::MSM_ID, Backend::Cuda, get_bench_type(), Some(n));
+            BenchmarkSpec::new_zk_msm(T::MSM_ID, Backend::Cuda, *get_bench_type(), Some(n));
         let bench_id_string = bench_id.to_string();
 
         match get_bench_type() {

--- a/tfhe-benchmark/src/high_level_api/type_display.rs
+++ b/tfhe-benchmark/src/high_level_api/type_display.rs
@@ -1,4 +1,6 @@
 use std::marker::PhantomData;
+
+use benchmark_spec::TypeName;
 use tfhe::named::Named;
 use tfhe::{FheIntegerType, FheUintId, IntegerId};
 
@@ -45,6 +47,12 @@ impl<T: TypeDisplay> Default for TypeDisplayer<T> {
 impl<T: TypeDisplay> std::fmt::Display for TypeDisplayer<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         T::fmt(f)
+    }
+}
+
+impl<T: TypeDisplay> TypeName for TypeDisplayer<T> {
+    fn type_name(&self) -> String {
+        self.to_string()
     }
 }
 

--- a/tfhe-benchmark/src/utilities.rs
+++ b/tfhe-benchmark/src/utilities.rs
@@ -1,4 +1,4 @@
-use benchmark_spec::{BenchmarkSpec, TypeName};
+use benchmark_spec::BenchmarkSpec;
 use criterion::measurement::WallTime;
 use criterion::{Bencher, BenchmarkGroup, Criterion};
 use std::env;
@@ -9,9 +9,9 @@ use tfhe::core_crypto::gpu::{get_number_of_gpus, get_number_of_sms};
 pub use tfhe_benchmark_parser::{write_to_json, write_to_json_unchecked, OperatorType};
 
 /// Run a criterion routine and record its metadata via `write_to_json`.
-pub fn bench_and_record<F, T: TypeName + ?Sized>(
+pub fn bench_and_record<F>(
     group: &mut BenchmarkGroup<'_, WallTime>,
-    benchmark_spec: &BenchmarkSpec<T>,
+    benchmark_spec: &BenchmarkSpec,
     display_name: &str,
     bit_size: u32,
     decomposition_basis: Vec<u32>,

--- a/utils/benchmark_spec/src/lib.rs
+++ b/utils/benchmark_spec/src/lib.rs
@@ -28,6 +28,12 @@ pub trait TypeName {
     fn type_name(&self) -> String;
 }
 
+impl fmt::Display for dyn TypeName + '_ {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.type_name())
+    }
+}
+
 #[derive(Debug)]
 pub struct TypedKeyValue<'a> {
     key: &'a str,
@@ -46,9 +52,23 @@ impl TypeName for TypedKeyValue<'_> {
     }
 }
 
-impl TypeName for str {
+#[derive(Debug, Clone, Copy)]
+pub enum PrecisionTag {
+    /// `{n}_bits`
+    Bits(usize),
+    /// `{n}_bits_scalar_{n}`
+    BitsScalar(usize),
+    /// `{from}_to_{to}`
+    Conversion { from: usize, to: usize },
+}
+
+impl TypeName for PrecisionTag {
     fn type_name(&self) -> String {
-        self.to_string()
+        match *self {
+            Self::Bits(n) => format!("{n}_bits"),
+            Self::BitsScalar(n) => format!("{n}_bits_scalar_{n}"),
+            Self::Conversion { from, to } => format!("{from}_to_{to}"),
+        }
     }
 }
 
@@ -200,37 +220,37 @@ pub fn get_bench_type() -> BenchmarkType {
 /// ```text
 /// {crate}::{layer}::{bench}::{op}(::{backend})?(::{benchmark_type})?::{param}(::scalar)?(::{type})?(::{num_elements}_elements)?
 /// ```
-///
-/// `param_name` is kept as `&str` because it comes from `NamedParam::name()`
-/// at runtime. `type_name` is generic over `T: TypeName` so it can be either
-/// a `&str` (from `stringify!()` in bench macros) or a structured type like
-/// [`TypedKeyValue`].
-pub struct BenchmarkSpec<'a, T: TypeName + ?Sized> {
-    pub bench_crate: BenchCrate,
-    pub backend: Backend,
-    pub param_name: &'a str,
-    pub operand_type: OperandType,
-    pub type_name: Option<&'a T>,
-    pub bench_type: BenchmarkMetric,
-    pub num_elements: Option<usize>,
+pub struct BenchmarkSpec {
+    bench_crate: BenchCrate,
+    backend: Backend,
+    param_name: String,
+    operand_type: OperandType,
+    type_name: Option<String>,
+    bench_type: BenchmarkMetric,
+    num_elements: Option<usize>,
 }
 
-impl<'a, T: TypeName + ?Sized> BenchmarkSpec<'a, T> {
+impl BenchmarkSpec {
+    /// The parameter set name (from `NamedParam::name()`).
+    pub fn param_name(&self) -> &str {
+        &self.param_name
+    }
+
     pub fn new(
         bench_crate: BenchCrate,
         backend: Backend,
-        param_name: &'a str,
+        param_name: &str,
         operand_type: OperandType,
-        type_name: Option<&'a T>,
+        type_name: Option<&dyn TypeName>,
         bench_type: impl Into<BenchmarkMetric>,
         num_elements: Option<usize>,
     ) -> Self {
         Self {
             bench_crate,
             backend,
-            param_name,
+            param_name: param_name.to_string(),
             operand_type,
-            type_name,
+            type_name: type_name.map(|t| t.type_name()),
             bench_type: bench_type.into(),
             num_elements,
         }
@@ -238,17 +258,17 @@ impl<'a, T: TypeName + ?Sized> BenchmarkSpec<'a, T> {
 
     pub fn new_hlapi_ops(
         hlapi_op: HlIntegerOp,
-        param_name: &'a str,
+        param_name: &str,
         operand_type: OperandType,
-        type_name: Option<&'a T>,
+        type_name: Option<&dyn TypeName>,
         bench_type: impl Into<BenchmarkMetric>,
     ) -> Self {
         Self {
             bench_crate: BenchCrate::Tfhe(TfheLayer::Hlapi(HlapiBench::Ops(hlapi_op))),
             backend: bench_backend_from_cfg(),
-            param_name,
+            param_name: param_name.to_string(),
             operand_type,
-            type_name,
+            type_name: type_name.map(|t| t.type_name()),
             bench_type: bench_type.into(),
             num_elements: None,
         }
@@ -256,18 +276,18 @@ impl<'a, T: TypeName + ?Sized> BenchmarkSpec<'a, T> {
 
     pub fn new_hlapi(
         hlapi_bench: HlapiBench,
-        param_name: &'a str,
+        param_name: &str,
         operand_type: OperandType,
-        type_name: Option<&'a T>,
+        type_name: Option<&dyn TypeName>,
         bench_type: impl Into<BenchmarkMetric>,
         num_elements: Option<usize>,
     ) -> Self {
         Self {
             bench_crate: BenchCrate::Tfhe(TfheLayer::Hlapi(hlapi_bench)),
             backend: bench_backend_from_cfg(),
-            param_name,
+            param_name: param_name.to_string(),
             operand_type,
-            type_name,
+            type_name: type_name.map(|t| t.type_name()),
             bench_type: bench_type.into(),
             num_elements,
         }
@@ -275,17 +295,17 @@ impl<'a, T: TypeName + ?Sized> BenchmarkSpec<'a, T> {
 
     pub fn new_integer_ops(
         ops: IntegerOpBySign,
-        param_name: &'a str,
-        type_name: Option<&'a T>,
+        param_name: &str,
+        type_name: Option<&dyn TypeName>,
         bench_type: impl Into<BenchmarkMetric>,
         num_elements: Option<usize>,
     ) -> Self {
         Self {
             bench_crate: BenchCrate::Tfhe(TfheLayer::Integer(IntegerBench::Ops(ops))),
             backend: bench_backend_from_cfg(),
-            param_name,
+            param_name: param_name.to_string(),
             operand_type: OperandType::CipherText,
-            type_name,
+            type_name: type_name.map(|t| t.type_name()),
             bench_type: bench_type.into(),
             num_elements,
         }
@@ -293,17 +313,17 @@ impl<'a, T: TypeName + ?Sized> BenchmarkSpec<'a, T> {
 
     pub fn new_integer(
         integer_bench: IntegerBench,
-        param_name: &'a str,
-        type_name: Option<&'a T>,
+        param_name: &str,
+        type_name: Option<&dyn TypeName>,
         bench_type: impl Into<BenchmarkMetric>,
         num_elements: Option<usize>,
     ) -> Self {
         Self {
             bench_crate: BenchCrate::Tfhe(TfheLayer::Integer(integer_bench)),
             backend: bench_backend_from_cfg(),
-            param_name,
+            param_name: param_name.to_string(),
             operand_type: OperandType::CipherText,
-            type_name,
+            type_name: type_name.map(|t| t.type_name()),
             bench_type: bench_type.into(),
             num_elements,
         }
@@ -311,13 +331,13 @@ impl<'a, T: TypeName + ?Sized> BenchmarkSpec<'a, T> {
 
     pub fn new_shortint(
         shortint_bench: ShortintBench,
-        param_name: &'a str,
+        param_name: &str,
         bench_type: impl Into<BenchmarkMetric>,
     ) -> Self {
         Self {
             bench_crate: BenchCrate::Tfhe(TfheLayer::Shortint(shortint_bench)),
             backend: bench_backend_from_cfg(),
-            param_name,
+            param_name: param_name.to_string(),
             operand_type: OperandType::CipherText,
             type_name: None,
             bench_type: bench_type.into(),
@@ -327,13 +347,13 @@ impl<'a, T: TypeName + ?Sized> BenchmarkSpec<'a, T> {
 
     pub fn new_boolean(
         boolean_bench: BooleanBench,
-        param_name: &'a str,
+        param_name: &str,
         bench_type: impl Into<BenchmarkMetric>,
     ) -> Self {
         Self {
             bench_crate: BenchCrate::Tfhe(TfheLayer::Boolean(boolean_bench)),
             backend: bench_backend_from_cfg(),
-            param_name,
+            param_name: param_name.to_string(),
             operand_type: OperandType::CipherText,
             type_name: None,
             bench_type: bench_type.into(),
@@ -343,13 +363,13 @@ impl<'a, T: TypeName + ?Sized> BenchmarkSpec<'a, T> {
 
     pub fn new_core_crypto(
         core_crypto_bench: CoreCryptoBench,
-        param_name: &'a str,
+        param_name: &str,
         bench_type: impl Into<BenchmarkMetric>,
     ) -> Self {
         Self {
             bench_crate: BenchCrate::Tfhe(TfheLayer::CoreCrypto(core_crypto_bench)),
             backend: bench_backend_from_cfg(),
-            param_name,
+            param_name: param_name.to_string(),
             operand_type: OperandType::CipherText,
             type_name: None,
             bench_type: bench_type.into(),
@@ -359,16 +379,16 @@ impl<'a, T: TypeName + ?Sized> BenchmarkSpec<'a, T> {
 
     pub fn new_cuda_core_crypto(
         core_crypto_bench: CoreCryptoBench,
-        param_name: &'a str,
-        type_name: Option<&'a T>,
+        param_name: &str,
+        type_name: Option<&dyn TypeName>,
         bench_type: impl Into<BenchmarkMetric>,
     ) -> Self {
         Self {
             bench_crate: BenchCrate::Tfhe(TfheLayer::CoreCrypto(core_crypto_bench)),
             backend: bench_backend_from_cfg(),
-            param_name,
+            param_name: param_name.to_string(),
             operand_type: OperandType::CipherText,
-            type_name,
+            type_name: type_name.map(|t| t.type_name()),
             bench_type: bench_type.into(),
             num_elements: None,
         }
@@ -376,13 +396,13 @@ impl<'a, T: TypeName + ?Sized> BenchmarkSpec<'a, T> {
 
     pub fn new_transciphering(
         transcipher_bench: TranscipheringBench,
-        param_name: &'a str,
+        param_name: &str,
         bench_type: impl Into<BenchmarkMetric>,
     ) -> Self {
         Self {
             bench_crate: BenchCrate::Tfhe(TfheLayer::Transciphering(transcipher_bench)),
             backend: bench_backend_from_cfg(),
-            param_name,
+            param_name: param_name.to_string(),
             operand_type: OperandType::CipherText,
             type_name: None,
             bench_type: bench_type.into(),
@@ -399,7 +419,7 @@ impl<'a, T: TypeName + ?Sized> BenchmarkSpec<'a, T> {
         Self {
             bench_crate: BenchCrate::Zk(ZkLayer::Msm(zk_bench)),
             backend,
-            param_name: "",
+            param_name: String::new(),
             operand_type: OperandType::CipherText,
             type_name: None,
             bench_type: bench_type.into(),
@@ -408,7 +428,7 @@ impl<'a, T: TypeName + ?Sized> BenchmarkSpec<'a, T> {
     }
 }
 
-impl<T: TypeName + ?Sized> fmt::Display for BenchmarkSpec<'_, T> {
+impl fmt::Display for BenchmarkSpec {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.bench_crate.fmt_crate(f)?;
         if !matches!(self.backend, Backend::Cpu) {
@@ -426,8 +446,8 @@ impl<T: TypeName + ?Sized> fmt::Display for BenchmarkSpec<'_, T> {
         if self.operand_type.is_scalar() {
             write!(f, "::scalar")?;
         }
-        if let Some(type_name) = self.type_name {
-            write!(f, "::{}", type_name.type_name())?;
+        if let Some(type_name) = &self.type_name {
+            write!(f, "::{type_name}")?;
         }
         if let Some(num_elements) = self.num_elements {
             write!(f, "::{num_elements}_elements")?;
@@ -443,13 +463,21 @@ mod tests {
 
     use super::*;
 
+    struct Ty(&'static str);
+
+    impl TypeName for Ty {
+        fn type_name(&self) -> String {
+            self.0.to_string()
+        }
+    }
+
     #[test]
     fn hlapi_cpu_latency() {
         let spec = BenchmarkSpec::new_hlapi_ops(
             HlIntegerOp::Add,
             "PARAM_MESSAGE_2_CARRY_2",
             OperandType::CipherText,
-            Some("FheUint64"),
+            Some(&Ty("FheUint64")),
             BenchmarkMetric::Latency,
         );
         assert_eq!(
@@ -465,7 +493,7 @@ mod tests {
             Backend::Cuda,
             "PARAM_MESSAGE_2_CARRY_2",
             OperandType::CipherText,
-            Some("FheUint128"),
+            Some(&Ty("FheUint128")),
             BenchmarkMetric::Latency,
             None,
         );
@@ -482,7 +510,7 @@ mod tests {
             Backend::Hpu,
             "PARAM_MESSAGE_2_CARRY_2",
             OperandType::CipherText,
-            Some("FheUint64"),
+            Some(&Ty("FheUint64")),
             BenchmarkMetric::Throughput,
             None,
         );
@@ -498,7 +526,7 @@ mod tests {
             HlIntegerOp::LeftShift,
             "PARAM_MESSAGE_2_CARRY_2",
             OperandType::PlainText,
-            Some("FheUint64"),
+            Some(&Ty("FheUint64")),
             BenchmarkMetric::Latency,
         );
         assert_eq!(
@@ -509,7 +537,7 @@ mod tests {
 
     #[test]
     fn hlapi_no_type_name() {
-        let spec = BenchmarkSpec::<str>::new_hlapi_ops(
+        let spec = BenchmarkSpec::new_hlapi_ops(
             HlIntegerOp::Neg,
             "PARAM_MESSAGE_2_CARRY_2",
             OperandType::CipherText,
@@ -524,10 +552,10 @@ mod tests {
 
     #[test]
     fn integer_ops_latency() {
-        let spec = BenchmarkSpec::<str>::new_integer_ops(
+        let spec = BenchmarkSpec::new_integer_ops(
             IntegerOpBySign::Unsigned(IntegerOp::AddParallelized),
             "PARAM_MESSAGE_2_CARRY_2",
-            Some("64_bits"),
+            Some(&Ty("64_bits")),
             BenchmarkMetric::Latency,
             None,
         );
@@ -539,10 +567,10 @@ mod tests {
 
     #[test]
     fn integer_ops_signed() {
-        let spec = BenchmarkSpec::<str>::new_integer_ops(
+        let spec = BenchmarkSpec::new_integer_ops(
             IntegerOpBySign::Signed(IntegerOp::MulParallelized),
             "PARAM_MESSAGE_2_CARRY_2",
-            Some("64_bits"),
+            Some(&Ty("64_bits")),
             BenchmarkMetric::Latency,
             None,
         );
@@ -554,10 +582,10 @@ mod tests {
 
     #[test]
     fn integer_ops_throughput_with_num_elements() {
-        let spec = BenchmarkSpec::<str>::new_integer_ops(
+        let spec = BenchmarkSpec::new_integer_ops(
             IntegerOpBySign::Unsigned(IntegerOp::SumCiphertextsParallelized),
             "PARAM_MESSAGE_2_CARRY_2",
-            Some("64_bits"),
+            Some(&Ty("64_bits")),
             BenchmarkMetric::Throughput,
             Some(5),
         );
@@ -569,10 +597,10 @@ mod tests {
 
     #[test]
     fn integer_ops_ilog2_serialization() {
-        let spec = BenchmarkSpec::<str>::new_integer_ops(
+        let spec = BenchmarkSpec::new_integer_ops(
             IntegerOpBySign::Unsigned(IntegerOp::CheckedIlog2Parallelized),
             "PARAM_MESSAGE_2_CARRY_2",
-            Some("8_bits"),
+            Some(&Ty("8_bits")),
             BenchmarkMetric::Latency,
             None,
         );
@@ -586,7 +614,7 @@ mod tests {
     fn hlapi_erc7984_with_num_elements() {
         use crate::tfhe::hlapi::erc7984::{Erc7984, TransferFlavor};
 
-        let spec = BenchmarkSpec::<str>::new_hlapi(
+        let spec = BenchmarkSpec::new_hlapi(
             HlapiBench::Erc7984(Erc7984::Transfer(TransferFlavor::Whitepaper)),
             "PARAM_MESSAGE_2_CARRY_2",
             OperandType::CipherText,
@@ -604,7 +632,7 @@ mod tests {
     fn hlapi_erc7984_without_num_elements() {
         use crate::tfhe::hlapi::erc7984::{Erc7984, TransferFlavor};
 
-        let spec = BenchmarkSpec::<str>::new_hlapi(
+        let spec = BenchmarkSpec::new_hlapi(
             HlapiBench::Erc7984(Erc7984::Transfer(TransferFlavor::NoCmux)),
             "PARAM_MESSAGE_2_CARRY_2",
             OperandType::CipherText,
@@ -622,7 +650,7 @@ mod tests {
     fn hlapi_erc7984_num_elements_with_backend() {
         use crate::tfhe::hlapi::erc7984::TransferFlavor;
 
-        let spec = BenchmarkSpec::<str>::new(
+        let spec = BenchmarkSpec::new(
             BenchCrate::Tfhe(TfheLayer::Hlapi(HlapiBench::Erc7984(Erc7984::Transfer(
                 TransferFlavor::Overflow,
             )))),
@@ -643,7 +671,7 @@ mod tests {
     fn hlapi_erc7984_num_elements_with_throughput() {
         use crate::tfhe::hlapi::erc7984::{Erc7984, TransferFlavor};
 
-        let spec = BenchmarkSpec::<str>::new_hlapi(
+        let spec = BenchmarkSpec::new_hlapi(
             HlapiBench::Erc7984(Erc7984::Transfer(TransferFlavor::Safe)),
             "PARAM_MESSAGE_2_CARRY_2",
             OperandType::CipherText,
@@ -661,7 +689,7 @@ mod tests {
     fn hlapi_erc7984_with_pbs_count() {
         use crate::tfhe::hlapi::erc7984::{Erc7984, TransferFlavor};
 
-        let spec = BenchmarkSpec::<str>::new_hlapi(
+        let spec = BenchmarkSpec::new_hlapi(
             HlapiBench::Erc7984(Erc7984::Transfer(TransferFlavor::Safe)),
             "PARAM_MESSAGE_2_CARRY_2",
             OperandType::CipherText,
@@ -683,7 +711,7 @@ mod tests {
             HlapiBench::Dex(Dex::SwapRequest(DexFlavor::Whitepaper)),
             "PARAM_MESSAGE_2_CARRY_2",
             OperandType::CipherText,
-            Some("FheUint64"),
+            Some(&Ty("FheUint64")),
             BenchmarkMetric::Latency,
             None,
         );
@@ -704,7 +732,7 @@ mod tests {
             Backend::Cuda,
             "PARAM_MESSAGE_2_CARRY_2",
             OperandType::CipherText,
-            Some("FheUint64"),
+            Some(&Ty("FheUint64")),
             BenchmarkMetric::Throughput,
             Some(10),
         );
@@ -722,7 +750,7 @@ mod tests {
             HlapiBench::Dex(Dex::SwapRequest(DexFlavor::Finalize)),
             "PARAM_MESSAGE_2_CARRY_2",
             OperandType::CipherText,
-            Some("FheUint64"),
+            Some(&Ty("FheUint64")),
             BenchmarkMetric::PbsCount,
             None,
         );

--- a/utils/tfhe-benchmark-parser/src/writer.rs
+++ b/utils/tfhe-benchmark-parser/src/writer.rs
@@ -3,13 +3,13 @@ use crate::model::record::{
     BenchmarkParametersRecord, ExecutionType, IntegerRepresentation, KeySetType,
     PolynomialMultiplication,
 };
-use benchmark_spec::{BenchmarkSpec, OperandType, TypeName};
+use benchmark_spec::{BenchmarkSpec, OperandType};
 use std::fs;
 use std::path::PathBuf;
 
 /// Writes benchmark parameters to disk in JSON format, enforcing the benchmark name spec.
-pub fn write_to_json<T: TypeName + ?Sized>(
-    benchmark_spec: &BenchmarkSpec<T>,
+pub fn write_to_json(
+    benchmark_spec: &BenchmarkSpec,
     display_name: impl Into<String>,
     operator_type: &OperatorType,
     bit_size: u32,
@@ -17,7 +17,7 @@ pub fn write_to_json<T: TypeName + ?Sized>(
 ) {
     write_to_json_unchecked(
         &benchmark_spec.to_string(),
-        benchmark_spec.param_name,
+        benchmark_spec.param_name().to_string(),
         display_name,
         operator_type,
         bit_size,


### PR DESCRIPTION
Refacto to avoid generic type in BenchmarkSpec and also no reference in the struct
Also update the issue with bits and scalar param_name with the following type

``` rust
#[derive(Debug, Clone, Copy)]
pub enum PrecisionTag {
    /// `{n}_bits`
    Bits(usize),
    /// `{n}_bits_scalar_{n}`
    BitsScalar(usize),
    /// `{from}_to_{to}`
    Conversion { from: usize, to: usize },
}

impl TypeName for PrecisionTag {
    fn type_name(&self) -> String {
        match *self {
            Self::Bits(n) => format!("{n}_bits"),
            Self::BitsScalar(n) => format!("{n}_bits_scalar_{n}"),
            Self::Conversion { from, to } => format!("{from}_to_{to}"),
        }
    }
}
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3794)
<!-- Reviewable:end -->
