### PR TITLE
chore: fix sage math cache to not allow for non exact restore

### DIFF
--- a/.github/workflows/parameters_check.yml
+++ b/.github/workflows/parameters_check.yml
@@ -58,7 +58,6 @@ jobs:
         with:
           path: /tmp/sagemath_image
           key: sagemath-image-${{ env.SAGEMATH_VERSION }}
-          restore-keys: sagemath-image-
 
       - name: Load cached Docker sagemath image
         if: steps.docker-cache.outputs.cache-hit == 'true'


### PR DESCRIPTION
- otherwise one could have a case where a different version is restored since the restore key would match the start of the cache key
