### PR TITLE
chore(ci): make fuzzing start friday 5am

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -18,8 +18,8 @@ on:
         default: '86400' # 24h
         required: false
   schedule:
-    # Saturday 01:00 UTC.
-    - cron: '0 1 * * 6'
+    # Friday 05:00 UTC.
+    - cron: '0 5 * * 5'
 
 permissions: {}
 


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description
Make fuzzing job start on friday at 5am. Hopefully this will allow us to separate a "daily reaper job" (if killed at 6h30) from an "instance age" trigger (if killed after 14h)