### PR TITLE
harden conformance checks for compressed modswitched lists

### DIFF
--- a/tfhe/src/core_crypto/algorithms/test/modulus_switch_compression.rs
+++ b/tfhe/src/core_crypto/algorithms/test/modulus_switch_compression.rs
@@ -7,11 +7,11 @@ const NB_TESTS: usize = 10;
 #[cfg(tarpaulin)]
 const NB_TESTS: usize = 1;
 
-fn encryption_ms_decryption<Scalar: UnsignedTorus + Sync + Send + CastInto<u64> + CastFrom<u64>>(
+fn encryption_ms_decryption<
+    Scalar: UnsignedTorus + Sync + Send + CastInto<u64> + CastFrom<usize>,
+>(
     params: ClassicTestParams<Scalar>,
-) where
-    usize: CastFrom<Scalar>,
-{
+) {
     let ClassicTestParams {
         lwe_noise_distribution,
         message_modulus_log,
@@ -53,7 +53,7 @@ fn encryption_ms_decryption<Scalar: UnsignedTorus + Sync + Send + CastInto<u64> 
             let compressed = lwe.compress::<u64>();
 
             let container: Vec<Scalar> = compressed
-                .extract::<u64>()
+                .extract()
                 .container()
                 .iter()
                 .map(|i| (*i).cast_into())
@@ -77,18 +77,18 @@ fn encryption_ms_decryption<Scalar: UnsignedTorus + Sync + Send + CastInto<u64> 
 
 fn assert_ms_compression<Scalar>(ct: &LweCiphertext<Vec<Scalar>>, log_modulus: CiphertextModulusLog)
 where
-    Scalar: UnsignedTorus + CastInto<u64>,
+    Scalar: UnsignedTorus + CastInto<u64> + CastInto<usize>,
     u64: CastInto<Scalar>,
 {
     let msed_ct = lwe_ciphertext_modulus_switch::<_, u64, _>(ct.as_view(), log_modulus);
 
     let a = msed_ct.compress::<u64>();
 
-    let b = a.extract::<u64>();
+    let b = a.extract();
     let b = b.container();
 
     for (i, j) in ct.as_ref().iter().zip_eq(b.iter()) {
-        let i_ms: u64 = modulus_switch(*i, log_modulus).cast_into();
+        let i_ms: usize = modulus_switch(*i, log_modulus).cast_into();
 
         assert_eq!(i_ms, *j);
     }

--- a/tfhe/src/core_crypto/commons/parameters.rs
+++ b/tfhe/src/core_crypto/commons/parameters.rs
@@ -279,6 +279,15 @@ impl LweBskGroupingFactor {
     pub fn ggsw_per_multi_bit_element(&self) -> GgswPerLweMultiBitBskElement {
         GgswPerLweMultiBitBskElement(1 << self.0)
     }
+
+    /// The number of diffs stored per multi bit element.
+    ///
+    /// We diff starting from ggsw #1 and we skip power of 2 indexes. See
+    /// [`crate::core_crypto::entities::CompressedModulusSwitchedMultiBitLweCiphertext::compress`]
+    /// for more details.
+    pub(in crate::core_crypto) fn diffs_per_multi_bit_element(self) -> usize {
+        self.ggsw_per_multi_bit_element().0 - 1 - self.0
+    }
 }
 
 /// The number of GGSW ciphertexts required per multi_bit BSK element

--- a/tfhe/src/core_crypto/entities/compressed_modulus_switched_glwe_ciphertext.rs
+++ b/tfhe/src/core_crypto/entities/compressed_modulus_switched_glwe_ciphertext.rs
@@ -6,6 +6,8 @@ use crate::core_crypto::backward_compatibility::entities::compressed_modulus_swi
 use crate::core_crypto::fft_impl::common::modulus_switch;
 use crate::core_crypto::prelude::*;
 
+use super::packed_integers::PackedIntegersConformanceParams;
+
 /// An object to store a ciphertext using less memory
 /// The modulus of the ciphertext is decreased by rounding and the result is stored in a compact way
 /// The uncompacted result can be used as the input of a blind rotation to recover a low noise lwe
@@ -261,7 +263,7 @@ impl<Scalar: UnsignedInteger> ParameterSetConformant
 {
     type ParameterSet = GlweCiphertextConformanceParams<Scalar>;
 
-    fn is_conformant(&self, lwe_ct_parameters: &GlweCiphertextConformanceParams<Scalar>) -> bool {
+    fn is_conformant(&self, params: &GlweCiphertextConformanceParams<Scalar>) -> bool {
         let Self {
             packed_integers,
             glwe_dimension,
@@ -269,18 +271,15 @@ impl<Scalar: UnsignedInteger> ParameterSetConformant
             bodies_count,
             uncompressed_ciphertext_modulus,
         } = self;
-        let log_modulus = packed_integers.log_modulus().0;
 
-        let number_bits_to_unpack =
-            (glwe_dimension.0 * polynomial_size.0 + bodies_count.0) * log_modulus;
-
-        let len = number_bits_to_unpack.div_ceil(Scalar::BITS);
-
-        packed_integers.packed_coeffs().len() == len
-            && *glwe_dimension == lwe_ct_parameters.glwe_dim
-            && *polynomial_size == lwe_ct_parameters.polynomial_size
-            && lwe_ct_parameters.ct_modulus.is_power_of_two()
-            && *uncompressed_ciphertext_modulus == lwe_ct_parameters.ct_modulus
+        *glwe_dimension == params.glwe_dim
+            && *polynomial_size == params.polynomial_size
+            && bodies_count.0 <= polynomial_size.0
+            && *uncompressed_ciphertext_modulus == params.ct_modulus
+            && params.ct_modulus.is_power_of_two()
+            && packed_integers.is_conformant(&PackedIntegersConformanceParams::new::<Scalar>(
+                glwe_dimension.0 * polynomial_size.0 + bodies_count.0,
+            ))
     }
 }
 
@@ -412,5 +411,46 @@ mod test {
                 modulus_switch(glwe[i], CiphertextModulusLog(log_modulus))
             )
         }
+    }
+
+    #[test]
+    fn test_not_conformant() {
+        let glwe_dimension = GlweDimension(1);
+        let polynomial_size = PolynomialSize(512);
+        let log_modulus = CiphertextModulusLog(12);
+        let ciphertext_modulus = CiphertextModulus::<u64>::new_native();
+
+        // Built field by field, as a deserialized ciphertext would be, to reach states the
+        // constructor rejects
+        let ct = |log_modulus: CiphertextModulusLog, bodies_count: LweCiphertextCount| {
+            let initial_len = glwe_dimension.0 * polynomial_size.0 + bodies_count.0;
+
+            CompressedModulusSwitchedGlweCiphertext {
+                packed_integers: PackedIntegers::from_raw_parts(
+                    vec![0u64; (initial_len * log_modulus.0).div_ceil(u64::BITS as usize)],
+                    log_modulus,
+                    initial_len,
+                ),
+                glwe_dimension,
+                polynomial_size,
+                bodies_count,
+                uncompressed_ciphertext_modulus: ciphertext_modulus,
+            }
+        };
+
+        let params = GlweCiphertextConformanceParams {
+            glwe_dim: glwe_dimension,
+            polynomial_size,
+            ct_modulus: ciphertext_modulus,
+        };
+
+        assert!(ct(log_modulus, LweCiphertextCount(polynomial_size.0)).is_conformant(&params));
+
+        // `extract` pads the bodies up to the polynomial size, which underflows
+        assert!(!ct(log_modulus, LweCiphertextCount(polynomial_size.0 + 1)).is_conformant(&params));
+
+        // `extract` scales by `Scalar::BITS - log_modulus`, which overflows
+        assert!(!ct(CiphertextModulusLog(0), LweCiphertextCount(1)).is_conformant(&params));
+        assert!(!ct(CiphertextModulusLog(65), LweCiphertextCount(1)).is_conformant(&params));
     }
 }

--- a/tfhe/src/core_crypto/entities/compressed_modulus_switched_lwe_ciphertext.rs
+++ b/tfhe/src/core_crypto/entities/compressed_modulus_switched_lwe_ciphertext.rs
@@ -48,13 +48,13 @@ use crate::core_crypto::prelude::*;
 /// // Can be stored using much less space than the standard lwe ciphertexts
 /// let compressed = lwe_msed_before.compress::<u64>();
 ///
-/// let lwe_msed_after = compressed.extract::<u64>();
+/// let lwe_msed_after = compressed.extract();
 ///
 /// for (i, j) in lwe_msed_before.mask().zip_eq(lwe_msed_after.mask()) {
-///     assert_eq!(i, j);
+///     assert_eq!(i, j as u64);
 /// }
 ///
-/// assert!(lwe_msed_before.body() == lwe_msed_after.body());
+/// assert!(lwe_msed_before.body() == lwe_msed_after.body() as u64);
 /// ```
 #[derive(Clone, serde::Serialize, serde::Deserialize, Versionize)]
 #[versionize(CompressedModulusSwitchedLweCiphertextVersions)]
@@ -118,10 +118,9 @@ impl<PackingScalar: UnsignedInteger> CompressedModulusSwitchedLweCiphertext<Pack
         (packed_integers, lwe_dimension)
     }
 
-    pub fn extract<Scalar>(&self) -> StandardModulusSwitchedLweCiphertext<Scalar>
+    pub fn extract(&self) -> StandardModulusSwitchedLweCiphertext<usize>
     where
-        PackingScalar: CastInto<Scalar>,
-        Scalar: UnsignedInteger,
+        PackingScalar: CastInto<usize>,
     {
         let lwe_size = self.lwe_dimension.to_lwe_size().0;
 
@@ -225,17 +224,17 @@ mod test {
         ms_compression::<u64, u64, u64>(53, 37);
         ms_compression::<u64, u64, u64>(63, 63);
 
-        ms_compression::<u128, u128, u128>(127, 127);
+        ms_compression::<u128, u128, u128>(63, 127);
 
         ms_compression::<u32, u32, u64>(1, 100);
         ms_compression::<u32, u32, u64>(10, 64);
         ms_compression::<u32, u32, u64>(11, 700);
         ms_compression::<u32, u32, u64>(12, 751);
 
-        ms_compression::<u32, u32, u64>(1, 100);
-        ms_compression::<u32, u32, u64>(10, 64);
-        ms_compression::<u32, u32, u64>(11, 700);
-        ms_compression::<u32, u32, u64>(12, 751);
+        ms_compression::<u32, u64, u64>(1, 100);
+        ms_compression::<u32, u64, u64>(10, 64);
+        ms_compression::<u32, u64, u64>(11, 700);
+        ms_compression::<u32, u64, u64>(12, 751);
 
         ms_compression::<u64, u64, u128>(1, 100);
         ms_compression::<u64, u64, u128>(10, 64);
@@ -248,13 +247,14 @@ mod test {
 
     fn ms_compression<
         Scalar: UnsignedTorus + CastInto<SwitchedScalar>,
-        SwitchedScalar: UnsignedTorus + CastFrom<PackingScalar>,
+        SwitchedScalar: UnsignedTorus,
         PackingScalar: UnsignedTorus + CastFrom<SwitchedScalar>,
     >(
         log_modulus: usize,
         len: usize,
     ) where
         [Scalar]: Fill,
+        usize: CastFrom<PackingScalar> + CastFrom<Scalar>,
     {
         let ciphertext_modulus = CiphertextModulus::new_native();
 
@@ -270,34 +270,32 @@ mod test {
 
         let compressed = lwe_msed_before_packing.compress::<PackingScalar>();
 
-        let lwe_msed_after_packing = compressed.extract::<SwitchedScalar>();
+        let lwe_msed_after_packing = compressed.extract();
 
         let lwe = lwe.into_container();
 
         for (i, output) in lwe_msed_after_packing.container().iter().enumerate() {
-            assert!(*output < SwitchedScalar::ONE << log_modulus);
+            assert!(*output < 1 << log_modulus);
 
-            let msed: Scalar = modulus_switch(lwe[i], CiphertextModulusLog(log_modulus));
+            let msed: usize = modulus_switch(lwe[i], CiphertextModulusLog(log_modulus)).cast_into();
 
-            assert_eq!(*output, msed.cast_into());
+            assert_eq!(*output, msed);
         }
     }
 
     #[test]
     fn test_from_raw_parts() {
-        type Scalar = u64;
-
         let len = 751;
         let log_modulus = 12;
 
         let ciphertext_modulus = CiphertextModulus::new_native();
 
-        let mut lwe = LweCiphertext::new(Scalar::ZERO, LweSize(len), ciphertext_modulus);
+        let mut lwe = LweCiphertext::new(0, LweSize(len), ciphertext_modulus);
 
         // We don't care about the exact content here
         rand::thread_rng().fill(lwe.as_mut());
 
-        let msed = lwe_ciphertext_modulus_switch::<_, Scalar, _>(
+        let msed = lwe_ciphertext_modulus_switch::<_, usize, _>(
             lwe.as_view(),
             CiphertextModulusLog(log_modulus),
         );
@@ -307,7 +305,7 @@ mod test {
         let rebuilt =
             CompressedModulusSwitchedLweCiphertext::from_raw_parts(packed_integers, lwe_dimension);
 
-        let lwe_ms_ed = rebuilt.extract::<Scalar>();
+        let lwe_ms_ed = rebuilt.extract();
 
         let lwe_ms_ed = lwe_ms_ed.container();
 

--- a/tfhe/src/core_crypto/entities/compressed_modulus_switched_lwe_ciphertext.rs
+++ b/tfhe/src/core_crypto/entities/compressed_modulus_switched_lwe_ciphertext.rs
@@ -3,6 +3,7 @@ use tfhe_versionable::Versionize;
 use self::packed_integers::PackedIntegers;
 use crate::conformance::ParameterSetConformant;
 use crate::core_crypto::backward_compatibility::entities::compressed_modulus_switched_lwe_ciphertext::CompressedModulusSwitchedLweCiphertextVersions;
+use crate::core_crypto::prelude::packed_integers::PackedIntegersConformanceParams;
 use crate::core_crypto::prelude::*;
 
 /// An object to store a ciphertext using less memory
@@ -137,8 +138,15 @@ impl<PackingScalar: UnsignedInteger> CompressedModulusSwitchedLweCiphertext<Pack
 
 #[derive(Copy, Clone)]
 pub enum MsDecompressionType {
-    ClassicPbs,
-    MultiBitPbs(LweBskGroupingFactor),
+    ClassicPbs {
+        br_input_modulus_log: CiphertextModulusLog,
+        br_input_lwe_dim: LweDimension,
+    },
+    MultiBitPbs {
+        br_input_modulus_log: CiphertextModulusLog,
+        br_input_lwe_dim: LweDimension,
+        grouping_factor: LweBskGroupingFactor,
+    },
 }
 
 #[derive(Copy, Clone)]
@@ -170,20 +178,29 @@ impl<Scalar: UnsignedInteger> ParameterSetConformant
         } = compressed_ct_parameters;
 
         let LweCiphertextConformanceParams {
-            lwe_dim: params_lwe_dim,
+            // The compressed mod switched ct use the lwe dim before the br, this one is kept to
+            // build the params of the decompressed ct, in
+            // `CompressedModulusSwitchedCiphertextConformanceParams`. This could be improved,
+            // see #1513
+            lwe_dim: _,
             ct_modulus,
         } = ct_params;
 
+        let MsDecompressionType::ClassicPbs {
+            br_input_modulus_log,
+            br_input_lwe_dim,
+        } = ms_decompression_type
+        else {
+            return false;
+        };
+
         let lwe_size = lwe_dimension.to_lwe_size().0;
 
-        let number_bits_to_pack = lwe_size * packed_integers.log_modulus().0;
-
-        let len = number_bits_to_pack.div_ceil(Scalar::BITS);
-
-        packed_integers.packed_coeffs().len() == len
-            && lwe_dimension == params_lwe_dim
+        packed_integers.log_modulus() == *br_input_modulus_log
+            && lwe_dimension == br_input_lwe_dim
+            && packed_integers
+                .is_conformant(&PackedIntegersConformanceParams::new::<usize>(lwe_size))
             && ct_modulus.is_power_of_two()
-            && matches!(ms_decompression_type, MsDecompressionType::ClassicPbs)
     }
 }
 
@@ -303,5 +320,60 @@ mod test {
 
             assert_eq!(*output, msed)
         }
+    }
+
+    #[test]
+    fn test_not_conformant() {
+        let br_input_lwe_dim = LweDimension(750);
+        let encryption_lwe_dim = LweDimension(2048);
+        let br_input_modulus_log = CiphertextModulusLog(12);
+
+        let lwe_size = br_input_lwe_dim.to_lwe_size().0;
+
+        let packed_integers = PackedIntegers::from_raw_parts(
+            vec![0u64; (lwe_size * br_input_modulus_log.0).div_ceil(u64::BITS as usize)],
+            br_input_modulus_log,
+            lwe_size,
+        );
+
+        let ct = CompressedModulusSwitchedLweCiphertext::from_raw_parts(
+            packed_integers,
+            br_input_lwe_dim,
+        );
+
+        let valid_conf_params = CompressedModulusSwitchedLweCiphertextConformanceParams {
+            ct_params: LweCiphertextConformanceParams {
+                lwe_dim: br_input_lwe_dim,
+                ct_modulus: CiphertextModulus::new_native(),
+            },
+            ms_decompression_type: MsDecompressionType::ClassicPbs {
+                br_input_modulus_log,
+                br_input_lwe_dim,
+            },
+        };
+
+        assert!(ct.is_conformant(&valid_conf_params));
+
+        let mut params = valid_conf_params;
+        params.ms_decompression_type = MsDecompressionType::ClassicPbs {
+            br_input_modulus_log: CiphertextModulusLog(11),
+            br_input_lwe_dim,
+        };
+        assert!(!ct.is_conformant(&params));
+
+        let mut params = valid_conf_params;
+        params.ms_decompression_type = MsDecompressionType::ClassicPbs {
+            br_input_modulus_log,
+            br_input_lwe_dim: encryption_lwe_dim,
+        };
+        assert!(!ct.is_conformant(&params));
+
+        let mut params = valid_conf_params;
+        params.ms_decompression_type = MsDecompressionType::MultiBitPbs {
+            br_input_modulus_log,
+            br_input_lwe_dim,
+            grouping_factor: LweBskGroupingFactor(2),
+        };
+        assert!(!ct.is_conformant(&params));
     }
 }

--- a/tfhe/src/core_crypto/entities/compressed_modulus_switched_multi_bit_lwe_ciphertext.rs
+++ b/tfhe/src/core_crypto/entities/compressed_modulus_switched_multi_bit_lwe_ciphertext.rs
@@ -7,6 +7,8 @@ use entities::compressed_modulus_switched_multi_bit_lwe_ciphertext::*;
 use itertools::Itertools;
 use tfhe_versionable::Versionize;
 
+use super::packed_integers::PackedIntegersConformanceParams;
+
 /// An object to store a ciphertext using less memory
 /// The ciphertext is applied a modulus switch as done in the multi bit PBS.
 /// It is then stored in a compact way.
@@ -211,13 +213,8 @@ impl<PackingScalar: UnsignedInteger + CastFrom<usize> + CastInto<usize>>
                 equivalent_multi_bit_lwe_dimension(lwe_dimension, grouping_factor)
                     .unwrap()
                     .0;
-            let ggsw_per_multi_bit_element = grouping_factor.ggsw_per_multi_bit_element().0;
-
-            // In the diff list creation, we skip every power of two, so we have to remove them from
-            // the total count
-            let num_powers_of_2 = ggsw_per_multi_bit_element.ceil_ilog2() as usize;
             let expected_diffs_len =
-                (ggsw_per_multi_bit_element - 1 - num_powers_of_2) * multi_bit_elements;
+                grouping_factor.diffs_per_multi_bit_element() * multi_bit_elements;
             assert_eq!(
                 diffs.initial_len(),
                 expected_diffs_len,
@@ -318,12 +315,19 @@ impl<PackingScalar: UnsignedInteger + CastFrom<usize> + CastInto<usize>>
             .map(|a| modulus_switch(*a, log_modulus).cast_into())
             .collect();
 
-        let mut diffs = vec![];
+        let expected_diffs_len = (input_lwe_mask.as_ref().len() / grouping_factor.0)
+            * grouping_factor.diffs_per_multi_bit_element();
+
+        let mut diffs = Vec::with_capacity(expected_diffs_len);
 
         for lwe_mask_elements in input_lwe_mask.as_ref().chunks_exact(grouping_factor.0) {
             for ggsw_idx in 1..grouping_factor.ggsw_per_multi_bit_element().0 {
                 // We need to store the diff sums of more than one element as we store the
                 // individual modulus_switched elements
+                //
+                // the bits in ggsw_idx indicates which mask elements to select.
+                // In the case of a power of two, only one bit is set, so only one mask element will
+                // be selected, thus the diff will be zero.
                 if ggsw_idx.is_power_of_two() {
                     continue;
                 }
@@ -358,6 +362,8 @@ impl<PackingScalar: UnsignedInteger + CastFrom<usize> + CastInto<usize>>
                 diffs.push(diff);
             }
         }
+
+        assert_eq!(diffs.len(), expected_diffs_len);
 
         let packed_mask = PackedIntegers::pack::<PackingScalar>(&modulus_switched, log_modulus);
 
@@ -535,23 +541,39 @@ impl<Scalar: UnsignedInteger + CastInto<usize> + CastFrom<usize>> ParameterSetCo
         } = compressed_ct_parameters;
 
         let LweCiphertextConformanceParams {
-            lwe_dim: params_lwe_dim,
+            // The compressed mod switched ct use the lwe dim before the br, this one is kept to
+            // build the params of the decompressed ct, in
+            // `CompressedModulusSwitchedCiphertextConformanceParams`. This could be improved,
+            // see #1513
+            lwe_dim: _,
             ct_modulus,
         } = ct_params;
 
-        *body >> packed_mask.log_modulus().0 == Scalar::ZERO
-            && packed_mask.is_conformant(&lwe_dimension.0)
-            && packed_diffs
-                .as_ref()
-                .is_none_or(|packed_diffs| packed_diffs.is_conformant(&lwe_dimension.0))
-            && lwe_dimension == params_lwe_dim
+        let MsDecompressionType::MultiBitPbs {
+            br_input_modulus_log,
+            br_input_lwe_dim,
+            grouping_factor: expected_grouping_factor,
+        } = ms_decompression_type
+        else {
+            return false;
+        };
+
+        packed_mask.log_modulus() == *br_input_modulus_log
+            && lwe_dimension == br_input_lwe_dim
+            && grouping_factor.0 == expected_grouping_factor.0
+            && lwe_dimension.0.is_multiple_of(grouping_factor.0)
+            && packed_mask.is_conformant(&PackedIntegersConformanceParams::new::<usize>(
+                lwe_dimension.0,
+            ))
+            && *body >> packed_mask.log_modulus().0 == Scalar::ZERO
+            && packed_diffs.as_ref().is_none_or(|packed_diffs| {
+                packed_diffs.log_modulus().0 <= packed_mask.log_modulus().0 + 1
+                    && packed_diffs.is_conformant(&PackedIntegersConformanceParams::new::<usize>(
+                        (lwe_dimension.0 / grouping_factor.0)
+                            * grouping_factor.diffs_per_multi_bit_element(),
+                    ))
+            })
             && ct_modulus.is_power_of_two()
-            && match ms_decompression_type {
-                MsDecompressionType::ClassicPbs => false,
-                MsDecompressionType::MultiBitPbs(expected_grouping_factor) => {
-                    expected_grouping_factor.0 == grouping_factor.0
-                }
-            }
             && uncompressed_ciphertext_modulus == ct_modulus
     }
 }
@@ -601,5 +623,172 @@ mod test {
         );
 
         let _ = rebuilt.extract();
+    }
+
+    fn packed_zeros(log_modulus: CiphertextModulusLog, initial_len: usize) -> PackedIntegers<u64> {
+        PackedIntegers::from_raw_parts(
+            vec![0u64; (initial_len * log_modulus.0).div_ceil(u64::BITS as usize)],
+            log_modulus,
+            initial_len,
+        )
+    }
+
+    fn dummy_comp_ct(
+        packed_mask: PackedIntegers<u64>,
+        packed_diffs: Option<PackedIntegers<u64>>,
+        lwe_dimension: LweDimension,
+        grouping_factor: LweBskGroupingFactor,
+        body: u64,
+    ) -> CompressedModulusSwitchedMultiBitLweCiphertext<u64> {
+        CompressedModulusSwitchedMultiBitLweCiphertext {
+            body,
+            packed_mask,
+            packed_diffs,
+            lwe_dimension,
+            uncompressed_ciphertext_modulus: CiphertextModulus::new_native(),
+            grouping_factor,
+        }
+    }
+
+    #[test]
+    fn test_not_conformant() {
+        let br_input_lwe_dim = LweDimension(694);
+        let encryption_lwe_dim = LweDimension(2048);
+        let br_input_modulus_log = CiphertextModulusLog(12);
+        let grouping_factor = LweBskGroupingFactor(2);
+
+        let diffs_len = (br_input_lwe_dim.0 / grouping_factor.0)
+            * grouping_factor.diffs_per_multi_bit_element();
+
+        let valid_conf_params = CompressedModulusSwitchedLweCiphertextConformanceParams {
+            ct_params: LweCiphertextConformanceParams {
+                lwe_dim: br_input_lwe_dim,
+                ct_modulus: CiphertextModulus::new_native(),
+            },
+            ms_decompression_type: MsDecompressionType::MultiBitPbs {
+                br_input_modulus_log,
+                br_input_lwe_dim,
+                grouping_factor,
+            },
+        };
+
+        let mask = packed_zeros(br_input_modulus_log, br_input_lwe_dim.0);
+        let diffs = packed_zeros(br_input_modulus_log, diffs_len);
+
+        assert!(dummy_comp_ct(
+            mask.clone(),
+            Some(diffs.clone()),
+            br_input_lwe_dim,
+            grouping_factor,
+            0
+        )
+        .is_conformant(&valid_conf_params));
+        assert!(
+            dummy_comp_ct(mask.clone(), None, br_input_lwe_dim, grouping_factor, 0)
+                .is_conformant(&valid_conf_params)
+        );
+
+        // The mask holds one modulus switched value per mask element
+        assert!(!dummy_comp_ct(
+            packed_zeros(br_input_modulus_log, br_input_lwe_dim.0 - 1),
+            None,
+            br_input_lwe_dim,
+            grouping_factor,
+            0
+        )
+        .is_conformant(&valid_conf_params));
+
+        // A body holding bits above log_modulus is not a modulus switched value
+        assert!(!dummy_comp_ct(
+            mask.clone(),
+            None,
+            br_input_lwe_dim,
+            grouping_factor,
+            1 << br_input_modulus_log.0
+        )
+        .is_conformant(&valid_conf_params));
+
+        // `extract` indexes the diff list by a counter driven by the mask length, so a shorter
+        // list is an out of bounds read
+        assert!(!dummy_comp_ct(
+            mask.clone(),
+            Some(packed_zeros(br_input_modulus_log, diffs_len - 1)),
+            br_input_lwe_dim,
+            grouping_factor,
+            0
+        )
+        .is_conformant(&valid_conf_params));
+
+        // Diffs are stored on at most one more bit than the mask, and `extract` computes
+        // `1 << used_space_log`
+        assert!(dummy_comp_ct(
+            mask.clone(),
+            Some(packed_zeros(
+                CiphertextModulusLog(br_input_modulus_log.0 + 1),
+                diffs_len
+            )),
+            br_input_lwe_dim,
+            grouping_factor,
+            0
+        )
+        .is_conformant(&valid_conf_params));
+        assert!(!dummy_comp_ct(
+            mask.clone(),
+            Some(packed_zeros(
+                CiphertextModulusLog(br_input_modulus_log.0 + 2),
+                diffs_len
+            )),
+            br_input_lwe_dim,
+            grouping_factor,
+            0
+        )
+        .is_conformant(&valid_conf_params));
+
+        // check that GF 0 does not trigger a div by 0 in conformance
+        assert!(!dummy_comp_ct(
+            mask.clone(),
+            Some(diffs.clone()),
+            br_input_lwe_dim,
+            LweBskGroupingFactor(0),
+            0
+        )
+        .is_conformant(&valid_conf_params));
+
+        let valid_ct = dummy_comp_ct(mask, Some(diffs), br_input_lwe_dim, grouping_factor, 0);
+
+        // A log_modulus that does not match the blind rotation input modulus is silently wrong,
+        // the multi bit blind rotation has no way to notice
+        let mut params = valid_conf_params;
+        params.ms_decompression_type = MsDecompressionType::MultiBitPbs {
+            br_input_modulus_log: CiphertextModulusLog(11),
+            br_input_lwe_dim,
+            grouping_factor,
+        };
+        assert!(!valid_ct.is_conformant(&params));
+
+        let mut params = valid_conf_params;
+        params.ms_decompression_type = MsDecompressionType::MultiBitPbs {
+            br_input_modulus_log,
+            br_input_lwe_dim: encryption_lwe_dim,
+            grouping_factor,
+        };
+        assert!(!valid_ct.is_conformant(&params));
+
+        let mut params = valid_conf_params;
+        params.ms_decompression_type = MsDecompressionType::MultiBitPbs {
+            br_input_modulus_log,
+            br_input_lwe_dim,
+            grouping_factor: LweBskGroupingFactor(3),
+        };
+        assert!(!valid_ct.is_conformant(&params));
+
+        // A ciphertext compressed for a classic blind rotation cannot be decompressed by a multi
+        // bit one
+        let mut params = valid_conf_params;
+        params.ms_decompression_type = MsDecompressionType::ClassicPbs {
+            br_input_modulus_log,
+            br_input_lwe_dim,
+        };
+        assert!(!valid_ct.is_conformant(&params));
     }
 }

--- a/tfhe/src/core_crypto/entities/modulus_switched_lwe_ciphertext.rs
+++ b/tfhe/src/core_crypto/entities/modulus_switched_lwe_ciphertext.rs
@@ -260,7 +260,16 @@ mod test {
             let compressed_modswitched = modswitched.compress::<u64>();
             let extracted = compressed_modswitched.extract();
 
-            let lwe_ms: LweCiphertext<Vec<_>> = extracted.into();
+            let lwe_ms_usize: LweCiphertext<Vec<usize>> = extracted.into();
+
+            let lwe_ms = LweCiphertext::from_container(
+                lwe_ms_usize
+                    .as_ref()
+                    .iter()
+                    .map(|&a| a as u64)
+                    .collect::<Vec<_>>(),
+                lwe_ms_usize.ciphertext_modulus().try_to().unwrap(),
+            );
 
             let decrypted_plaintext = decrypt_lwe_ciphertext(&key, &lwe_ms);
 

--- a/tfhe/src/core_crypto/entities/packed_integers.rs
+++ b/tfhe/src/core_crypto/entities/packed_integers.rs
@@ -4,6 +4,12 @@ use crate::conformance::ParameterSetConformant;
 use crate::core_crypto::backward_compatibility::entities::packed_integers::PackedIntegersVersions;
 use crate::core_crypto::prelude::*;
 
+/// A list of integers modulo a non-native power of two packed contiguously, stored into scalars of
+/// a greater size. Integers are stored without padding and may span over two consecutive scalars.
+///
+/// # Example
+/// Given a list of 4 integers mod 2^12: [aaa, bbb, ccc, ddd].
+/// We can pack them using only 3 u16: [baaa, ccbb, dddc]
 #[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize, Versionize)]
 #[versionize(PackedIntegersVersions)]
 pub struct PackedIntegers<Scalar: UnsignedInteger> {
@@ -36,6 +42,10 @@ impl<Scalar: UnsignedInteger> PackedIntegers<Scalar> {
         }
     }
 
+    /// Pack the input slice, assuming its values are reduced mod `2**log_modulus`.
+    ///
+    /// # Panics
+    /// Panics if `log_modulus.0 > InputScalar::BITS` or `Scalar::BITS`
     pub fn pack<InputScalar: UnsignedInteger + CastInto<Scalar>>(
         slice: &[InputScalar],
         log_modulus: CiphertextModulusLog,
@@ -46,8 +56,6 @@ impl<Scalar: UnsignedInteger> PackedIntegers<Scalar> {
         let log_modulus = log_modulus.0;
 
         let in_len = slice.len();
-
-        assert!(log_modulus <= Scalar::BITS);
 
         let number_bits_to_pack = in_len * log_modulus;
 
@@ -129,6 +137,10 @@ impl<Scalar: UnsignedInteger> PackedIntegers<Scalar> {
         }
     }
 
+    /// Unpack the list
+    ///
+    /// # Panics
+    /// Panics if `log_modulus.0` is 0, or greater than `OutputScalar::BITS` or `Scalar::BITS`
     pub fn unpack<OutputScalar>(&self) -> impl Iterator<Item = OutputScalar> + '_
     where
         Scalar: CastInto<OutputScalar>,
@@ -136,6 +148,7 @@ impl<Scalar: UnsignedInteger> PackedIntegers<Scalar> {
     {
         let log_modulus = self.log_modulus.0;
 
+        assert_ne!(log_modulus, 0);
         assert!(log_modulus <= Scalar::BITS);
         assert!(log_modulus <= OutputScalar::BITS);
 
@@ -234,56 +247,176 @@ impl<Scalar: UnsignedInteger> PackedIntegers<Scalar> {
     }
 }
 
-impl<Scalar: UnsignedInteger> ParameterSetConformant for PackedIntegers<Scalar> {
-    type ParameterSet = usize;
+#[derive(Copy, Clone, Debug)]
+pub struct PackedIntegersConformanceParams {
+    initial_len: usize,
+    output_scalar_bits: usize,
+}
 
-    fn is_conformant(&self, len: &usize) -> bool {
+impl PackedIntegersConformanceParams {
+    /// `OutputScalar` must be the scalar [`PackedIntegers::unpack`] will be called with: a
+    /// `log_modulus` wider than that scalar makes `unpack` panic.
+    pub fn new<OutputScalar: UnsignedInteger>(initial_len: usize) -> Self {
+        Self {
+            initial_len,
+            output_scalar_bits: OutputScalar::BITS,
+        }
+    }
+}
+
+impl<Scalar: UnsignedInteger> ParameterSetConformant for PackedIntegers<Scalar> {
+    type ParameterSet = PackedIntegersConformanceParams;
+
+    fn is_conformant(&self, params: &PackedIntegersConformanceParams) -> bool {
         let Self {
             packed_coeffs,
             log_modulus,
             initial_len,
         } = self;
 
-        let number_packed_bits = *len * log_modulus.0;
+        let max_log_modulus = Scalar::BITS.min(params.output_scalar_bits);
 
-        let packed_len = number_packed_bits.div_ceil(Scalar::BITS);
+        (1..=max_log_modulus).contains(&log_modulus.0)
+            && *initial_len == params.initial_len
+            && packed_coeffs.len() == (params.initial_len * log_modulus.0).div_ceil(Scalar::BITS)
+            // When the last coefficient is only partially filled, `pack` leaves the bits above
+            // `initial_len * log_modulus` to zero. `unpack` never reads them, but rejecting other
+            // values keeps the representation canonical.
+            && packed_coeffs.last().is_none_or(|last| {
+                // The length check above guarantees `used_bits` is in `1..=Scalar::BITS`
+                let last_used_bits =
+                    initial_len * log_modulus.0 - (packed_coeffs.len() - 1) * Scalar::BITS;
 
-        *len == *initial_len && packed_coeffs.len() == packed_len
+                last_used_bits == Scalar::BITS || *last >> last_used_bits == Scalar::ZERO
+            })
     }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
-    use rand::{Fill, Rng};
+    use rand::distributions::uniform::SampleUniform;
+    use rand::distributions::{Distribution, Standard};
+    use rand::Rng;
 
     #[test]
     fn pack_unpack() {
-        pack_unpack_single::<u64>(32, 700);
-        pack_unpack_single::<u64>(27, 700);
-        pack_unpack_single::<u64>(64, 700);
-        pack_unpack_single::<u128>(64, 700);
-        pack_unpack_single::<u128>(79, 700);
-        pack_unpack_single::<u128>(128, 700);
+        pack_unpack_single::<u64, u64, u64>(32, 700);
+        pack_unpack_single::<u64, u64, u64>(27, 700);
+        pack_unpack_single::<u64, u64, u64>(64, 700);
+        pack_unpack_single::<u128, u128, u128>(64, 700);
+        pack_unpack_single::<u128, u128, u128>(79, 700);
+        pack_unpack_single::<u128, u128, u128>(128, 700);
+
+        // Unpacking into a scalar narrower than the packing scalar
+        pack_unpack_single::<u32, u64, u32>(12, 700);
+        pack_unpack_single::<u32, u64, u32>(31, 700);
+        pack_unpack_single::<u32, u64, u32>(32, 700);
+        pack_unpack_single::<u64, u64, u32>(17, 700);
+        pack_unpack_single::<u64, u64, usize>(12, 700);
+        pack_unpack_single::<u32, u64, u64>(12, 700);
     }
 
-    fn pack_unpack_single<Scalar>(log_modulus: usize, len: usize)
+    fn pack_unpack_single<InputScalar, PackingScalar, OutputScalar>(log_modulus: usize, len: usize)
     where
-        [Scalar]: Fill,
-        Scalar: UnsignedInteger + CastFrom<usize>,
+        InputScalar:
+            UnsignedInteger + SampleUniform + CastInto<PackingScalar> + CastInto<OutputScalar>,
+        Standard: Distribution<InputScalar>,
+        PackingScalar: UnsignedInteger + CastInto<OutputScalar>,
+        OutputScalar: UnsignedInteger,
     {
-        let mut cont = vec![Scalar::ZERO; len];
+        assert!(
+            log_modulus
+                <= InputScalar::BITS
+                    .min(PackingScalar::BITS)
+                    .min(OutputScalar::BITS)
+        );
 
-        rand::thread_rng().fill(cont.as_mut_slice());
+        let mut cont = vec![InputScalar::ZERO; len];
 
-        for val in cont.iter_mut() {
-            *val %= log_modulus.cast_into();
+        let mut rng = rand::thread_rng();
+
+        if log_modulus == InputScalar::BITS {
+            cont.fill_with(|| rng.gen());
+        } else {
+            let modulus = InputScalar::ONE << log_modulus;
+            cont.fill_with(|| rng.gen_range(InputScalar::ZERO..modulus));
         }
 
-        let packed = PackedIntegers::<Scalar>::pack(&cont, CiphertextModulusLog(log_modulus));
+        let packed =
+            PackedIntegers::<PackingScalar>::pack(&cont, CiphertextModulusLog(log_modulus));
 
-        let unpacked: Vec<Scalar> = packed.unpack().collect();
+        assert!(packed.is_conformant(&PackedIntegersConformanceParams::new::<OutputScalar>(len)));
 
-        assert_eq!(cont, unpacked);
+        let unpacked: Vec<OutputScalar> = packed.unpack().collect();
+
+        let expected: Vec<OutputScalar> = cont.iter().copied().map(CastInto::cast_into).collect();
+
+        assert_eq!(expected, unpacked);
+    }
+
+    /// Build a list whose `packed_coeffs` length is consistent with `log_modulus` and
+    /// `initial_len`, as a deserialized list would be, without checking that `log_modulus`
+    /// itself is usable.
+    fn packed_with_log_modulus(log_modulus: usize, initial_len: usize) -> PackedIntegers<u64> {
+        let packed_len = (initial_len * log_modulus).div_ceil(u64::BITS as usize);
+
+        PackedIntegers::from_raw_parts(
+            vec![0u64; packed_len],
+            CiphertextModulusLog(log_modulus),
+            initial_len,
+        )
+    }
+
+    #[test]
+    fn test_not_conformant() {
+        let len = 700;
+
+        assert!(packed_with_log_modulus(12, len)
+            .is_conformant(&PackedIntegersConformanceParams::new::<u64>(len)));
+
+        assert!(!packed_with_log_modulus(12, len)
+            .is_conformant(&PackedIntegersConformanceParams::new::<u64>(len + 1)));
+
+        // `unpack` computes `end - 1` with `end == 0`, which underflows
+        assert!(!packed_with_log_modulus(0, len)
+            .is_conformant(&PackedIntegersConformanceParams::new::<u64>(len)));
+
+        // `unpack` shifts by `log_modulus`, which overflows `Scalar`
+        assert!(!packed_with_log_modulus(65, len)
+            .is_conformant(&PackedIntegersConformanceParams::new::<u64>(len)));
+
+        // Fits in the packing scalar, but `unpack` into a narrower scalar would panic
+        let packed = packed_with_log_modulus(40, len);
+        assert!(packed.is_conformant(&PackedIntegersConformanceParams::new::<u64>(len)));
+        assert!(!packed.is_conformant(&PackedIntegersConformanceParams::new::<u32>(len)));
+
+        // `700 * 12 = 8400` bits span 132 u64, so the last one holds 16 meaningful bits. `pack`
+        // leaves the 48 others to zero, any other value is not canonical
+        let mut packed = packed_with_log_modulus(12, len);
+        assert!(packed.is_conformant(&PackedIntegersConformanceParams::new::<u64>(len)));
+        *packed.packed_coeffs.last_mut().unwrap() |= 1 << 16;
+        assert!(!packed.is_conformant(&PackedIntegersConformanceParams::new::<u64>(len)));
+
+        // `700 * 32 = 22400` bits span exactly 350 u64, the last one has no padding bit
+        let mut packed = packed_with_log_modulus(32, len);
+        *packed.packed_coeffs.last_mut().unwrap() = u64::MAX;
+        assert!(packed.is_conformant(&PackedIntegersConformanceParams::new::<u64>(len)));
+
+        // An empty list has no last coefficient
+        assert!(packed_with_log_modulus(12, 0)
+            .is_conformant(&PackedIntegersConformanceParams::new::<u64>(0)));
+    }
+
+    #[test]
+    #[should_panic(expected = "assertion `left != right` failed")]
+    fn unpack_panics_on_zero_log_modulus() {
+        let _: Vec<u64> = packed_with_log_modulus(0, 700).unpack().collect();
+    }
+
+    #[test]
+    #[should_panic(expected = "assertion failed")]
+    fn unpack_panics_on_too_narrow_output_scalar() {
+        let _: Vec<u32> = packed_with_log_modulus(40, 700).unpack().collect();
     }
 }

--- a/tfhe/src/shortint/atomic_pattern/ks32.rs
+++ b/tfhe/src/shortint/atomic_pattern/ks32.rs
@@ -135,9 +135,18 @@ impl AtomicPattern for KS32AtomicPatternServerKey {
 
     fn ciphertext_decompression_method(&self) -> MsDecompressionType {
         match &self.bootstrapping_key {
-            ShortintBootstrappingKey::Classic { .. } => MsDecompressionType::ClassicPbs,
+            ShortintBootstrappingKey::Classic { bsk, .. } => MsDecompressionType::ClassicPbs {
+                br_input_modulus_log: bsk.polynomial_size().to_blind_rotation_input_modulus_log(),
+                br_input_lwe_dim: bsk.input_lwe_dimension(),
+            },
             ShortintBootstrappingKey::MultiBit { fourier_bsk, .. } => {
-                MsDecompressionType::MultiBitPbs(fourier_bsk.grouping_factor())
+                MsDecompressionType::MultiBitPbs {
+                    br_input_modulus_log: fourier_bsk
+                        .polynomial_size()
+                        .to_blind_rotation_input_modulus_log(),
+                    br_input_lwe_dim: fourier_bsk.input_lwe_dimension(),
+                    grouping_factor: fourier_bsk.grouping_factor(),
+                }
             }
         }
     }

--- a/tfhe/src/shortint/atomic_pattern/standard.rs
+++ b/tfhe/src/shortint/atomic_pattern/standard.rs
@@ -143,9 +143,18 @@ impl AtomicPattern for StandardAtomicPatternServerKey {
 
     fn ciphertext_decompression_method(&self) -> MsDecompressionType {
         match &self.bootstrapping_key {
-            ShortintBootstrappingKey::Classic { .. } => MsDecompressionType::ClassicPbs,
+            ShortintBootstrappingKey::Classic { bsk, .. } => MsDecompressionType::ClassicPbs {
+                br_input_modulus_log: bsk.polynomial_size().to_blind_rotation_input_modulus_log(),
+                br_input_lwe_dim: bsk.input_lwe_dimension(),
+            },
             ShortintBootstrappingKey::MultiBit { fourier_bsk, .. } => {
-                MsDecompressionType::MultiBitPbs(fourier_bsk.grouping_factor())
+                MsDecompressionType::MultiBitPbs {
+                    br_input_modulus_log: fourier_bsk
+                        .polynomial_size()
+                        .to_blind_rotation_input_modulus_log(),
+                    grouping_factor: fourier_bsk.grouping_factor(),
+                    br_input_lwe_dim: fourier_bsk.input_lwe_dimension(),
+                }
             }
         }
     }

--- a/tfhe/src/shortint/ciphertext/compressed_ciphertext_list.rs
+++ b/tfhe/src/shortint/ciphertext/compressed_ciphertext_list.rs
@@ -89,18 +89,29 @@ impl ParameterSetConformant for CompressedCiphertextList {
             lwe_per_glwe,
         } = meta;
 
-        let last_body_count = modulus_switched_glwe_ciphertext_list
+        let Some(last_body_count) = modulus_switched_glwe_ciphertext_list
             .last()
-            .unwrap()
-            .bodies_count()
-            .0;
-
+            .map(|glwe| glwe.bodies_count())
+        else {
+            return false;
+        };
         let count_is_ok = modulus_switched_glwe_ciphertext_list[..len - 1]
             .iter()
             .all(|a| a.bodies_count() == params.lwe_per_glwe)
-            && last_body_count <= params.lwe_per_glwe.0;
+            && last_body_count.0 <= params.lwe_per_glwe.0;
+
+        let Some(first_log_modulus) = modulus_switched_glwe_ciphertext_list
+            .first()
+            .map(|glwe| glwe.packed_integers().log_modulus())
+        else {
+            return false;
+        };
+        let log_modulus_is_ok = modulus_switched_glwe_ciphertext_list[1..]
+            .iter()
+            .all(|a| a.packed_integers().log_modulus() == first_log_modulus);
 
         count_is_ok
+            && log_modulus_is_ok
             && modulus_switched_glwe_ciphertext_list
                 .iter()
                 .all(|glwe| glwe.is_conformant(&params.ct_params))
@@ -148,14 +159,27 @@ impl ParameterSetConformant for CompressedSquashedNoiseCiphertextList {
             return false;
         };
 
-        let last_body_count = glwe_ciphertext_list.last().unwrap().bodies_count().0;
-
+        let Some(last_body_count) = glwe_ciphertext_list.last().map(|glwe| glwe.bodies_count())
+        else {
+            return false;
+        };
         let count_is_ok = glwe_ciphertext_list[..len - 1]
             .iter()
             .all(|a| a.bodies_count() == params.lwe_per_glwe)
-            && last_body_count <= params.lwe_per_glwe.0;
+            && last_body_count.0 <= params.lwe_per_glwe.0;
+
+        let Some(first_log_modulus) = glwe_ciphertext_list
+            .first()
+            .map(|glwe| glwe.packed_integers().log_modulus())
+        else {
+            return false;
+        };
+        let log_modulus_is_ok = glwe_ciphertext_list[1..]
+            .iter()
+            .all(|a| a.packed_integers().log_modulus() == first_log_modulus);
 
         count_is_ok
+            && log_modulus_is_ok
             && glwe_ciphertext_list
                 .iter()
                 .all(|glwe| glwe.is_conformant(&params.ct_params))

--- a/tfhe/src/shortint/parameters/classic.rs
+++ b/tfhe/src/shortint/parameters/classic.rs
@@ -154,7 +154,10 @@ impl ClassicPBSParameters {
 
         let compressed_ct_params = CompressedModulusSwitchedLweCiphertextConformanceParams {
             ct_params,
-            ms_decompression_type: MsDecompressionType::ClassicPbs,
+            ms_decompression_type: MsDecompressionType::ClassicPbs {
+                br_input_modulus_log: self.polynomial_size.to_blind_rotation_input_modulus_log(),
+                br_input_lwe_dim: self.lwe_dimension,
+            },
         };
 
         CompressedModulusSwitchedCiphertextConformanceParams {

--- a/tfhe/src/shortint/parameters/ks32.rs
+++ b/tfhe/src/shortint/parameters/ks32.rs
@@ -174,7 +174,10 @@ impl KeySwitch32PBSParameters {
 
         let compressed_ct_params = CompressedModulusSwitchedLweCiphertextConformanceParams {
             ct_params,
-            ms_decompression_type: MsDecompressionType::ClassicPbs,
+            ms_decompression_type: MsDecompressionType::ClassicPbs {
+                br_input_modulus_log: self.polynomial_size.to_blind_rotation_input_modulus_log(),
+                br_input_lwe_dim: self.lwe_dimension,
+            },
         };
 
         CompressedModulusSwitchedCiphertextConformanceParams {

--- a/tfhe/src/shortint/parameters/multi_bit.rs
+++ b/tfhe/src/shortint/parameters/multi_bit.rs
@@ -120,7 +120,11 @@ impl MultiBitPBSParameters {
 
         let compressed_ct_params = CompressedModulusSwitchedLweCiphertextConformanceParams {
             ct_params,
-            ms_decompression_type: MsDecompressionType::MultiBitPbs(self.grouping_factor),
+            ms_decompression_type: MsDecompressionType::MultiBitPbs {
+                br_input_modulus_log: self.polynomial_size.to_blind_rotation_input_modulus_log(),
+                grouping_factor: self.grouping_factor,
+                br_input_lwe_dim: self.lwe_dimension,
+            },
         };
 
         CompressedModulusSwitchedCiphertextConformanceParams {

--- a/tfhe/src/shortint/server_key/tests/modulus_switch_compression.rs
+++ b/tfhe/src/shortint/server_key/tests/modulus_switch_compression.rs
@@ -4,6 +4,7 @@ use crate::shortint::parameters::test_params::*;
 use crate::shortint::parameters::NoiseLevel;
 use crate::shortint::server_key::tests::parameterized_test::create_parameterized_test;
 use rand::Rng;
+use tfhe_safe_serialize::ParameterSetConformant;
 
 create_parameterized_test!(shortint_modulus_switch_compression);
 
@@ -55,5 +56,20 @@ where
             assert_eq!(ctxt.carry_modulus, decompressed_ct.carry_modulus);
             assert_eq!(ctxt.atomic_pattern, decompressed_ct.atomic_pattern);
         }
+    }
+
+    {
+        // Check conformance with cleanly encrypted ct
+        let ctxt = cks.encrypt(rng.gen::<u64>() % modulus);
+
+        let compressed_ct = sks.switch_modulus_and_compress(&ctxt);
+
+        assert!(compressed_ct.is_conformant(&sks.compressed_modswitched_conformance_params()));
+        assert!(compressed_ct.is_conformant(
+            &cks.parameters()
+                .ap_parameters()
+                .unwrap()
+                .to_compressed_modswitched_conformance_param()
+        ));
     }
 }


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description
improve conformance checks for compressed modswitched ct.
- `log_modulus` size was not checked relative to the packing scalar size
- the wrong lwe dimension was checked, meaning that conformance always returned false for valid ct
- a compressed ct list on gpu, decompressed from cpu, only use the log_modulus of the first glwe. Conformance for cpu list now validates that the same log_modulus is used across all GLWEs
- removed genericity in `CompressedModulusSwitchedLweCiphertext::extract`. The genericity made conformance harder to write correctly, and was never needed in practice since the output was always fed to a blind rotation which requires `usize` scalar.
- added some positive/negative tests for conformance. Check that conformance pass for valid lists and is rejected for lists that could trigger a panic.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3801)
<!-- Reviewable:end -->
