### PR TITLE
HPU backend using zhc scalar ops and removing LLT/ILP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4287,7 +4287,7 @@ dependencies = [
 
 [[package]]
 name = "zhc"
-version = "0.9.0"
+version = "0.8.3"
 dependencies = [
  "zhc_builder",
  "zhc_config",
@@ -4301,7 +4301,7 @@ dependencies = [
 
 [[package]]
 name = "zhc_builder"
-version = "0.9.0"
+version = "0.8.3"
 dependencies = [
  "zhc_crypto",
  "zhc_ir",
@@ -4311,7 +4311,7 @@ dependencies = [
 
 [[package]]
 name = "zhc_config"
-version = "0.9.0"
+version = "0.8.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -4321,7 +4321,7 @@ dependencies = [
 
 [[package]]
 name = "zhc_crypto"
-version = "0.9.0"
+version = "0.8.3"
 dependencies = [
  "paste",
  "rand 0.10.1",
@@ -4330,7 +4330,7 @@ dependencies = [
 
 [[package]]
 name = "zhc_ir"
-version = "0.9.0"
+version = "0.8.3"
 dependencies = [
  "serde",
  "zhc_utils",
@@ -4339,7 +4339,7 @@ dependencies = [
 
 [[package]]
 name = "zhc_langs"
-version = "0.9.0"
+version = "0.8.3"
 dependencies = [
  "serde",
  "zhc_crypto",
@@ -4349,7 +4349,7 @@ dependencies = [
 
 [[package]]
 name = "zhc_pipeline"
-version = "0.9.0"
+version = "0.8.3"
 dependencies = [
  "bitfield-struct 0.10.1",
  "rand 0.10.1",
@@ -4365,7 +4365,7 @@ dependencies = [
 
 [[package]]
 name = "zhc_sim"
-version = "0.9.0"
+version = "0.8.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -4377,8 +4377,9 @@ dependencies = [
 
 [[package]]
 name = "zhc_utils"
-version = "0.9.0"
+version = "0.8.3"
 dependencies = [
+ "libc",
  "paste",
  "rand 0.10.1",
  "serde",
@@ -4388,7 +4389,7 @@ dependencies = [
 
 [[package]]
 name = "zhc_utils_macro"
-version = "0.9.0"
+version = "0.8.3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4287,11 +4287,10 @@ dependencies = [
 
 [[package]]
 name = "zhc"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6367989c2a0eb6a6a30c1d5631ad98b006dc191df37f5f2064804c54342afe8"
+version = "0.9.0"
 dependencies = [
  "zhc_builder",
+ "zhc_config",
  "zhc_crypto",
  "zhc_ir",
  "zhc_langs",
@@ -4302,9 +4301,7 @@ dependencies = [
 
 [[package]]
 name = "zhc_builder"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f21006bf89a5441cc9b7b44e266271f13e9ddf1129c4f52024eade2e8f66712"
+version = "0.9.0"
 dependencies = [
  "zhc_crypto",
  "zhc_ir",
@@ -4313,10 +4310,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "zhc_config"
+version = "0.9.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "toml 0.9.12+spec-1.1.0",
+ "zhc_utils",
+]
+
+[[package]]
 name = "zhc_crypto"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60bd773cede7005953fa010d41b6553d3e1f5de0d381dd927b8d9dcb95d53be6"
+version = "0.9.0"
 dependencies = [
  "paste",
  "rand 0.10.1",
@@ -4325,9 +4330,7 @@ dependencies = [
 
 [[package]]
 name = "zhc_ir"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bbb31c9690c4e9ac9c0b1cfa607c8faf28a75b1f448a46dc414120cb7ebd4a6"
+version = "0.9.0"
 dependencies = [
  "serde",
  "zhc_utils",
@@ -4336,9 +4339,7 @@ dependencies = [
 
 [[package]]
 name = "zhc_langs"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9acd110ae2e6272ccc1d8a66cdeed84b8c68f5cac875b13f3df71406b80b7a92"
+version = "0.9.0"
 dependencies = [
  "serde",
  "zhc_crypto",
@@ -4348,14 +4349,13 @@ dependencies = [
 
 [[package]]
 name = "zhc_pipeline"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db294b85c657719b080fc72b7cbec52317a7f3b9f297d2baf96deefe22cebb7"
+version = "0.9.0"
 dependencies = [
  "bitfield-struct 0.10.1",
  "rand 0.10.1",
  "serde",
  "zhc_builder",
+ "zhc_config",
  "zhc_crypto",
  "zhc_ir",
  "zhc_langs",
@@ -4365,24 +4365,22 @@ dependencies = [
 
 [[package]]
 name = "zhc_sim"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d7b27aeb112b0beb24595dcc178fc4b5120a604049f2f5decc3d79937e0a1e3"
+version = "0.9.0"
 dependencies = [
  "serde",
  "serde_json",
  "toml 0.9.12+spec-1.1.0",
+ "zhc_config",
  "zhc_langs",
  "zhc_utils",
 ]
 
 [[package]]
 name = "zhc_utils"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf2b83800a9cda8f13b34d390931449d0c7812a54db005ab90c8b017789b7c8a"
+version = "0.9.0"
 dependencies = [
  "paste",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "zhc_utils_macro",
@@ -4390,9 +4388,7 @@ dependencies = [
 
 [[package]]
 name = "zhc_utils_macro"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38d7580ede0c2f2717b7ba022e5df73fb9aeb631bfcee259590afc2cdaac313"
+version = "0.9.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/backends/tfhe-hpu-backend/Cargo.toml
+++ b/backends/tfhe-hpu-backend/Cargo.toml
@@ -14,7 +14,12 @@ keywords = ["encryption", "fhe", "cryptography", "hardware", "fpga"]
 hw-v80 = ["bincode"]
 io-dump = ["num-traits"]
 rtl_graph = ["dot2"]
-utils = ["io-dump", "clap", "clap-num", "serde_json", "bincode"]
+# In-backend DOp firmware generators (Ilp/Llt/Demo).
+# They are NOT used at runtime anymore: the DOp streams loaded in the translation table
+# are produced by ZHC (cf. `zhc::pipeline::compat::Iop::get_translation_table`).
+# Kept behind a feature for the `fw` utility binary and offline inspection/comparison.
+fw-gen = []
+utils = ["io-dump", "clap", "clap-num", "serde_json", "bincode", "fw-gen"]
 
 [dependencies]
 hw_regmap = "0.2.2"
@@ -40,7 +45,7 @@ lru = "0.16.3"
 bitfield-struct = "0.13.0"
 crossbeam = { version = "0.8.4", features = ["crossbeam-queue"] }
 rayon = { workspace = true }
-zhc = { version = "0.9.0", path = "../../../zhc/zhc" }
+zhc = { version = "0.8.3", path = "../../../zhc/zhc" }
 
 # Dependencies used for Sim feature
 ra2m_ffi = "1.0"

--- a/backends/tfhe-hpu-backend/Cargo.toml
+++ b/backends/tfhe-hpu-backend/Cargo.toml
@@ -40,7 +40,7 @@ lru = "0.16.3"
 bitfield-struct = "0.13.0"
 crossbeam = { version = "0.8.4", features = ["crossbeam-queue"] }
 rayon = { workspace = true }
-zhc = "0.8.3"
+zhc = { version = "0.9.0", path = "../../../zhc/zhc" }
 
 # Dependencies used for Sim feature
 ra2m_ffi = "1.0"

--- a/backends/tfhe-hpu-backend/src/fw/mod.rs
+++ b/backends/tfhe-hpu-backend/src/fw/mod.rs
@@ -4,7 +4,13 @@
 //! Provide two concrete implementation of those traits
 //! * DigitOperations (DOp)
 //! * IntegerOperations (IOp)
+//!
+//! WARN: The IOp -> DOp expansion implemented here is no longer used by the runtime.
+//! `HpuNode::fw_init` fills the translation table with the DOp streams produced by ZHC.
+//! The generators below are only built with the `fw-gen` feature (implied by `utils`),
+//! and are reachable through the `fw` utility binary only.
 
+#[cfg(feature = "fw-gen")]
 pub mod fw_impl;
 pub mod isc_sim;
 pub mod metavar;
@@ -12,7 +18,9 @@ pub mod program;
 pub mod rtl;
 
 use crate::asm;
+#[cfg(feature = "fw-gen")]
 use enum_dispatch::enum_dispatch;
+#[cfg(feature = "fw-gen")]
 use strum_macros::{EnumDiscriminants, EnumIter, EnumString, VariantNames};
 
 /// Parameters that reflect the targeted architecture
@@ -73,6 +81,7 @@ impl From<FwParameters> for asm::DigitParameters {
 
 /// Fw trait abstraction
 /// Use to handle Fw implementation in an abstract way
+#[cfg(feature = "fw-gen")]
 #[enum_dispatch]
 pub trait Fw {
     /// Expand a program of IOp into a program of DOp
@@ -80,6 +89,7 @@ pub trait Fw {
 }
 
 /// Gather available Fw in a enum for selection at runtime by user
+#[cfg(feature = "fw-gen")]
 #[enum_dispatch(Fw)]
 #[derive(EnumDiscriminants, VariantNames)]
 #[strum_discriminants(name(FwName))]
@@ -91,6 +101,7 @@ pub enum AvlblFw {
     Demo(fw_impl::demo::Demo),
 }
 
+#[cfg(feature = "fw-gen")]
 impl AvlblFw {
     pub fn new(kind: &FwName) -> Self {
         match kind {

--- a/backends/tfhe-hpu-backend/src/fw/program.rs
+++ b/backends/tfhe-hpu-backend/src/fw/program.rs
@@ -440,6 +440,8 @@ impl Program {
     /// Bulk reserve
     /// Evict value from cache in a bulk manner. This enable to prevent false dependency of bulk
     /// operations when cache is almost full Enforce that at least bulk_size register is `free`
+    /// NB: only used by the `fw-gen` firmware implementations
+    #[cfg_attr(not(feature = "fw-gen"), allow(dead_code))]
     pub(crate) fn reg_bulk_reserve(&self, bulk_size: usize) {
         // Iter from Lru -> MRu and take bulk_size regs
         let to_evict = self

--- a/backends/tfhe-hpu-backend/src/interface/node.rs
+++ b/backends/tfhe-hpu-backend/src/interface/node.rs
@@ -3,17 +3,13 @@ use super::*;
 use crate::asm::dop::MAX_HPU_IN_CLUSTER;
 use crate::asm::PbsLut;
 use crate::entities::*;
-use crate::fw::isc_sim::PeConfigStore;
-use crate::fw::{Fw, FwParameters};
 use crate::{asm, ffi};
 use bytemuck::{Pod, Zeroable};
 use rtl::FromRtl;
 
-use itertools::Itertools;
 use std::collections::VecDeque;
 use std::str::FromStr;
 use std::sync::{atomic, Arc, Mutex};
-use strum::VariantNames;
 use zhc::builder::CiphertextSpec;
 use zhc::config::hpu::HpuConfig;
 use zhc::pipeline::compat::Iop;
@@ -865,46 +861,16 @@ impl HpuNode {
         self.fw_mem.write_cut_at(0, 0, fw_cfg_raw_u32);
         tracing::debug!("[N{}] {fw_cfg}", self.hid);
 
-        // Create Asm architecture properties and Fw instantiation
-        let pe_cfg = PeConfigStore::from((&*self.params, config));
-        let fw_name =
-            crate::fw::FwName::from_str(&config.firmware.implementation).unwrap_or_else(|_| {
-                panic!(
-                    "Unknown firmware name {}, list of possible firmware names: {}",
-                    config.firmware.implementation,
-                    crate::fw::AvlblFw::VARIANTS.iter().join(",")
-                );
-            });
-        let fw = crate::fw::AvlblFw::new(&fw_name);
-
-        // TODO Add RTL register for the nu value
-        let mut fw_params = FwParameters {
-            register: self.params.regf_params.reg_nb,
-            isc_depth: self.params.isc_params.depth,
-            heap_size: config.board.heap_size,
-            min_iop_size: self.params.isc_params.min_iop_size,
-            min_pbs_batch_w: self
-                .params
-                .ntt_params
-                .min_pbs_nb
-                .unwrap_or(self.params.ntt_params.batch_pbs_nb),
-            pbs_batch_w: self.params.ntt_params.batch_pbs_nb,
-            total_pbs_nb: self.params.ntt_params.total_pbs_nb,
-            msg_w: self.params.pbs_params.message_width,
-            carry_w: self.params.pbs_params.carry_width,
-            nu: 5,
-            integer_w: 0,
-            use_ipip: !config.rtl.bpip_use,
-            kogge_cfg: config.firmware.kogge_cfg.expand(),
-            op_cfg: config.firmware.op_cfg.clone(),
-            cur_op_cfg: config.firmware.op_cfg.default(),
-            pe_cfg,
-            op_name: None,
-        };
+        // Asm architecture properties
+        // NB: DOp streams are entirely produced by ZHC. The in-backend Ilp/Llt firmware
+        // generators (`crate::fw::fw_impl`) are not used at runtime anymore, they are only
+        // reachable through the `fw` utility binary.
+        let msg_w = self.params.pbs_params.message_width;
+        let zhc_config = new_config(&self.params);
 
         // Check that required number of integer_w don't overflow the lookup table space
         let integer_w_max = config.firmware.integer_w.iter().max().unwrap_or(&0);
-        let blk_w_max = integer_w_max / fw_params.msg_w;
+        let blk_w_max = integer_w_max / msg_w;
         assert!(
             blk_w_max < FW_TABLE_ENTRY,
             "ERROR: requested {} fw configuration but current implementation only support {} entries",
@@ -927,32 +893,29 @@ impl HpuNode {
         tr_table_ofst += error_value.len();
 
         for integer_w in config.firmware.integer_w.iter() {
-            // Update fw parameters with concrete integer_width
             assert_eq!(
-                integer_w % fw_params.msg_w,
+                integer_w % msg_w,
                 0,
-                "ERROR: requested integer_w {integer_w} isn't compliant with MSG_W {}",
-                fw_params.msg_w
+                "ERROR: requested integer_w {integer_w} isn't compliant with MSG_W {msg_w}"
             );
-            let blk_w = integer_w / fw_params.msg_w;
-            fw_params.integer_w = *integer_w;
+            let blk_w = integer_w / msg_w;
 
-            // Generate Fw for standard operation
+            // Retrieve Fw for standard operation from ZHC
             // -> All operation with an associated alias
             let mut id_fw = asm::iop::IOP_LIST
                 .par_iter()
                 .map(|iop| {
-                    let translation_table = match iop.format().unwrap().name.as_str().parse::<Iop>()
-                    {
-                        Ok(iop) => iop.get_translation_table(
-                            &new_config(&self.params),
-                            CiphertextSpec::new(*integer_w as u16, 2, 2),
-                        ),
-                        Err(()) => {
-                            let prog = fw.expand(&fw_params, iop);
-                            prog.tr_table()
-                        }
-                    };
+                    let name = &iop.format().unwrap().name;
+                    let zhc_iop = name.as_str().parse::<Iop>().unwrap_or_else(|()| {
+                        panic!(
+                            "IOp {name} has no ZHC implementation. DOp firmwares are now only \
+                             provided by ZHC, cf. zhc::pipeline::compat::Iop"
+                        )
+                    });
+                    let translation_table = zhc_iop.get_translation_table(
+                        &zhc_config,
+                        CiphertextSpec::new(*integer_w as u16, 2, 2),
+                    );
 
                     ((iop.opcode().0 as usize, 0), translation_table)
                 })

--- a/backends/tfhe-hpu-backend/src/interface/node.rs
+++ b/backends/tfhe-hpu-backend/src/interface/node.rs
@@ -15,9 +15,9 @@ use std::str::FromStr;
 use std::sync::{atomic, Arc, Mutex};
 use strum::VariantNames;
 use zhc::builder::CiphertextSpec;
+use zhc::config::hpu::HpuConfig;
 use zhc::pipeline::compat::Iop;
-use zhc::sim::hpu::HpuConfig;
-use zhc::sim::{Cycle, MHz};
+use zhc::utils::units::{Cycle, MHz};
 
 use tracing::{debug, info, trace};
 

--- a/backends/tfhe-hpu-backend/src/interface/variable.rs
+++ b/backends/tfhe-hpu-backend/src/interface/variable.rs
@@ -210,4 +210,17 @@ impl HpuVarWrapped {
     pub fn is_boolean(&self) -> bool {
         self.mode == VarMode::Bool
     }
+
+    /// Number of radix blocks held by this variable
+    pub fn blk_width(&self) -> usize {
+        self.width
+    }
+
+    /// Width in bits of the integer held by this variable
+    ///
+    /// NB: this is `blk_width` scaled by the message width, matching the `integer_w` notion used
+    /// by the firmware configuration.
+    pub fn int_width(&self) -> usize {
+        self.width * self.params.pbs_params.message_width
+    }
 }

--- a/tfhe/docs/configuration/hpu-acceleration/run-on-hpu.md
+++ b/tfhe/docs/configuration/hpu-acceleration/run-on-hpu.md
@@ -167,3 +167,8 @@ The HPU backend includes the following operations for unsigned encrypted integer
 {% hint style="info" %}
 All operations follow the same syntax than the one described in [here](../../fhe-computation/operations/README.md).
 {% endhint %}
+
+{% hint style="info" %}
+`Add`, `Sub` and `Mul` also accept a clear operand on the left-hand side (`Int`/`Enc`), for instance
+`10u16 - encrypted_value`.
+{% endhint %}

--- a/tfhe/examples/hpu/hlapi.rs
+++ b/tfhe/examples/hpu/hlapi.rs
@@ -94,6 +94,33 @@ macro_rules! impl_hlapi_showcase {
 
             assert_eq!(dec_cmp_gte_ab, clear_cmp_gte_ab,
                  "Error with >= operation get {}, expect {}",dec_cmp_gte_ab, clear_cmp_gte_ab);
+
+            // SHIFTS_L / SHIFTS_R --------------------------------------------
+            // Shift and rotate by a *clear* amount: the amount is turned into a control word by
+            // the backend, and shifting by the operand width or more yields 0.
+            let in_a = rng.gen_range(0..$user_type::MAX);
+            let width = <$user_type>::BITS;
+            for amount in [0, 1, width / 2, width - 1, width, width + 3] {
+                let clear_shl = in_a.checked_shl(amount).unwrap_or(0);
+                let clear_shr = in_a.checked_shr(amount).unwrap_or(0);
+                let clear_rol = in_a.rotate_left(amount % width);
+                let clear_ror = in_a.rotate_right(amount % width);
+
+                let fhe_a = $fhe_type::encrypt(in_a, cks);
+                let dec_shl: $user_type = (&fhe_a << amount).decrypt(cks);
+                let dec_shr: $user_type = (&fhe_a >> amount).decrypt(cks);
+                let dec_rol: $user_type = fhe_a.clone().rotate_left(amount).decrypt(cks);
+                let dec_ror: $user_type = fhe_a.rotate_right(amount).decrypt(cks);
+
+                println!(" {} <<>> {} = fhe({}, {}, rol {}, ror {}), clear({}, {}, rol {}, ror {})",
+                    in_a, amount, dec_shl, dec_shr, dec_rol, dec_ror,
+                    clear_shl, clear_shr, clear_rol, clear_ror);
+
+                assert_eq!(dec_shl, clear_shl, "Error with << {amount}");
+                assert_eq!(dec_shr, clear_shr, "Error with >> {amount}");
+                assert_eq!(dec_rol, clear_rol, "Error with rotate_left {amount}");
+                assert_eq!(dec_ror, clear_ror, "Error with rotate_right {amount}");
+            }
         }
         };
     };

--- a/tfhe/src/high_level_api/integers/unsigned/scalar_ops.rs
+++ b/tfhe/src/high_level_api/integers/unsigned/scalar_ops.rs
@@ -2101,8 +2101,11 @@ macro_rules! define_scalar_ops {
                                 RadixCiphertext::Cuda(result)
                         }
                         #[cfg(feature = "hpu")]
-                        InternalServerKey::Hpu(_device) => {
-                            panic!("Hpu does not support this operation yet.")
+                        InternalServerKey::Hpu(device) => {
+                            let rhs = rhs.ciphertext.on_hpu(device);
+                            let lhs = u128::try_from(lhs).unwrap();
+
+                            RadixCiphertext::Hpu(lhs - HpuRadixCiphertext::clone(&rhs))
                         }
                     })
                 }

--- a/tfhe/src/high_level_api/integers/unsigned/scalar_ops.rs
+++ b/tfhe/src/high_level_api/integers/unsigned/scalar_ops.rs
@@ -1097,8 +1097,11 @@ macro_rules! define_scalar_rotate_shifts {
                             RadixCiphertext::Cuda(inner_result)
                         }
                         #[cfg(feature = "hpu")]
-                        InternalServerKey::Hpu(_device) => {
-                            panic!("Hpu does not support this operation yet.")
+                        InternalServerKey::Hpu(device) => {
+                            let lhs = lhs.ciphertext.on_hpu(device);
+                            let rhs = u128::try_from(rhs).unwrap();
+
+                            RadixCiphertext::Hpu(&*lhs << rhs)
                         }
                     })
                 }
@@ -1155,8 +1158,11 @@ macro_rules! define_scalar_rotate_shifts {
                             RadixCiphertext::Cuda(inner_result)
                         }
                         #[cfg(feature = "hpu")]
-                        InternalServerKey::Hpu(_device) => {
-                            panic!("Hpu does not support this operation yet.")
+                        InternalServerKey::Hpu(device) => {
+                            let lhs = lhs.ciphertext.on_hpu(device);
+                            let rhs = u128::try_from(rhs).unwrap();
+
+                            RadixCiphertext::Hpu(&*lhs >> rhs)
                         }
                     })
                 }
@@ -1212,8 +1218,11 @@ macro_rules! define_scalar_rotate_shifts {
                             RadixCiphertext::Cuda(inner_result)
                         }
                         #[cfg(feature = "hpu")]
-                        InternalServerKey::Hpu(_device) => {
-                            panic!("Hpu does not support this operation yet.")
+                        InternalServerKey::Hpu(device) => {
+                            let lhs = lhs.ciphertext.on_hpu(device);
+                            let rhs = u128::try_from(rhs).unwrap();
+
+                            RadixCiphertext::Hpu(lhs.rotate_left(rhs))
                         }
                     })
                 }
@@ -1269,8 +1278,11 @@ macro_rules! define_scalar_rotate_shifts {
                             RadixCiphertext::Cuda(inner_result)
                         }
                         #[cfg(feature = "hpu")]
-                        InternalServerKey::Hpu(_device) => {
-                            panic!("Hpu does not support this operation yet.")
+                        InternalServerKey::Hpu(device) => {
+                            let lhs = lhs.ciphertext.on_hpu(device);
+                            let rhs = u128::try_from(rhs).unwrap();
+
+                            RadixCiphertext::Hpu(lhs.rotate_right(rhs))
                         }
                     })
                 }
@@ -1324,8 +1336,11 @@ macro_rules! define_scalar_rotate_shifts {
                             }
                         }
                         #[cfg(feature = "hpu")]
-                        InternalServerKey::Hpu(_device) => {
-                            panic!("Hpu does not support this operation yet.")
+                        InternalServerKey::Hpu(device) => {
+                            let lhs = lhs.ciphertext.as_hpu_mut(device);
+                            let rhs = u128::try_from(rhs).unwrap();
+
+                            *lhs <<= rhs;
                         }
                     })
                 }
@@ -1356,8 +1371,11 @@ macro_rules! define_scalar_rotate_shifts {
                             }
                         }
                         #[cfg(feature = "hpu")]
-                        InternalServerKey::Hpu(_device) => {
-                            panic!("Hpu does not support this operation yet.")
+                        InternalServerKey::Hpu(device) => {
+                            let lhs = lhs.ciphertext.as_hpu_mut(device);
+                            let rhs = u128::try_from(rhs).unwrap();
+
+                            *lhs >>= rhs;
                         }
                     })
                 }
@@ -1385,8 +1403,11 @@ macro_rules! define_scalar_rotate_shifts {
                                     .scalar_rotate_left_assign(lhs.ciphertext.as_gpu_mut(streams), rhs, streams);
                         }
                         #[cfg(feature = "hpu")]
-                        InternalServerKey::Hpu(_device) => {
-                            panic!("Hpu does not support this operation yet.")
+                        InternalServerKey::Hpu(device) => {
+                            let lhs = lhs.ciphertext.as_hpu_mut(device);
+                            let rhs = u128::try_from(rhs).unwrap();
+
+                            lhs.rotate_left_assign(rhs);
                         }
                     })
                 }
@@ -1414,8 +1435,11 @@ macro_rules! define_scalar_rotate_shifts {
                                     .scalar_rotate_right_assign(lhs.ciphertext.as_gpu_mut(streams), rhs, streams);
                         }
                         #[cfg(feature = "hpu")]
-                        InternalServerKey::Hpu(_device) => {
-                            panic!("Hpu does not support this operation yet.")
+                        InternalServerKey::Hpu(device) => {
+                            let lhs = lhs.ciphertext.as_hpu_mut(device);
+                            let rhs = u128::try_from(rhs).unwrap();
+
+                            lhs.rotate_right_assign(rhs);
                         }
                     })
                 }

--- a/tfhe/src/high_level_api/integers/unsigned/tests/mod.rs
+++ b/tfhe/src/high_level_api/integers/unsigned/tests/mod.rs
@@ -349,7 +349,7 @@ fn test_case_uint32_shift(cks: &ClientKey) {
     }
 
     // clear shifts
-    if cfg!(not(feature = "hpu")) {
+    {
         let c = &a << clear_b;
         let decrypted: u32 = c.decrypt(cks);
         assert_eq!(decrypted, clear_a << clear_b);
@@ -367,8 +367,6 @@ fn test_case_uint32_shift(cks: &ClientKey) {
         c <<= clear_b;
         let decrypted: u32 = c.decrypt(cks);
         assert_eq!(decrypted, clear_a << clear_b);
-    } else {
-        println!("WARN: HPU currently not support Shift by a scalar");
     }
 }
 

--- a/tfhe/src/high_level_api/integers/unsigned/tests/mod.rs
+++ b/tfhe/src/high_level_api/integers/unsigned/tests/mod.rs
@@ -172,6 +172,21 @@ fn test_case_uint32_scalar_arith(cks: &ClientKey) {
     let c = &a * clear_b;
     let decrypted: u32 = c.decrypt(cks);
     assert_eq!(decrypted, clear_a.wrapping_mul(clear_b));
+
+    // Scalar on the left-hand side.
+    let c = clear_b - &a;
+    let decrypted: u32 = c.decrypt(cks);
+    assert_eq!(decrypted, clear_b.wrapping_sub(clear_a));
+
+    // A zero scalar is a boundary case for backends lowering `ct - cte` to an addition of the
+    // two's complement of `cte`, and for `0 - ct` which has no borrow only when `ct` is zero.
+    let c = &a - 0u32;
+    let decrypted: u32 = c.decrypt(cks);
+    assert_eq!(decrypted, clear_a);
+
+    let c = 0u32 - &a;
+    let decrypted: u32 = c.decrypt(cks);
+    assert_eq!(decrypted, clear_a.wrapping_neg());
 }
 
 fn test_case_uint32_scalar_arith_assign(cks: &ClientKey) {

--- a/tfhe/src/integer/hpu/ciphertext/mod.rs
+++ b/tfhe/src/integer/hpu/ciphertext/mod.rs
@@ -278,7 +278,65 @@ impl std::ops::Not for &HpuRadixCiphertext {
 
 map_ct_scalar!(IOP_ADDS -> "Add");
 map_scalar_ct!(IOP_ADDS -> "Add");
-map_ct_scalar!(IOP_SUBS -> "Sub");
 map_scalar_ct!(IOP_SSUB -> "Sub");
 map_ct_scalar!(IOP_MULS -> "Mul");
 map_scalar_ct!(IOP_MULS -> "Mul");
+
+/// Two's complement of `imm` over `width` bits, i.e. `!imm + 1`.
+///
+/// Lets `ct - imm` be evaluated as `ct + (-imm)` with a plain `ADDS`: the immediate is clear on
+/// the host, so the complement costs nothing and the hardware runs the exact same integer
+/// addition it would for `ADDS`.
+///
+/// Masking to `width` is required, not cosmetic: `Immediate::from_cst` derives the number of
+/// advertised digits from the *value*, so an unmasked `-1` would claim 64 digits and push a
+/// needlessly long IOp stream for, say, an 8-bit operand.
+fn neg_imm(width: usize, imm: HpuImm) -> HpuImm {
+    let mask = if width >= HpuImm::BITS as usize {
+        HpuImm::MAX
+    } else {
+        (1 << width) - 1
+    };
+    imm.wrapping_neg() & mask
+}
+
+/// `ct - imm`, lowered to `ADDS` with a negated immediate (see [`neg_imm`]).
+///
+/// Mirrors what `map_ct_scalar!(IOP_SUBS -> "Sub")` used to generate, but targets `IOP_ADDS`.
+/// `IOP_SUBS` itself is untouched and still available for direct IOp submission.
+impl std::ops::Sub<HpuImm> for HpuRadixCiphertext {
+    type Output = Self;
+
+    fn sub(self, rhs: HpuImm) -> Self::Output {
+        &self - rhs
+    }
+}
+
+impl std::ops::Sub<HpuImm> for &HpuRadixCiphertext {
+    type Output = HpuRadixCiphertext;
+
+    fn sub(self, rhs: HpuImm) -> Self::Output {
+        let opcode = IOP_ADDS.opcode();
+        let proto = &IOP_ADDS
+            .format()
+            .expect("Bind to std::ops a unspecified IOP")
+            .proto;
+
+        let rhs = neg_imm(self.0.int_width(), rhs);
+        let res = HpuCmd::exec(proto, opcode, std::slice::from_ref(&self.0), &[rhs], None);
+        HpuRadixCiphertext::new(res[0].clone())
+    }
+}
+
+impl std::ops::SubAssign<HpuImm> for HpuRadixCiphertext {
+    fn sub_assign(&mut self, rhs: HpuImm) {
+        let opcode = IOP_ADDS.opcode();
+        let proto = &IOP_ADDS
+            .format()
+            .expect("Bind to std::ops a unspecified IOP")
+            .proto;
+
+        let rhs = neg_imm(self.0.int_width(), rhs);
+        HpuCmd::exec_assign(proto, opcode, std::slice::from_ref(&self.0), &[rhs])
+    }
+}

--- a/tfhe/src/integer/hpu/ciphertext/mod.rs
+++ b/tfhe/src/integer/hpu/ciphertext/mod.rs
@@ -340,3 +340,189 @@ impl std::ops::SubAssign<HpuImm> for HpuRadixCiphertext {
         HpuCmd::exec_assign(proto, opcode, std::slice::from_ref(&self.0), &[rhs])
     }
 }
+
+/// Whether vacated positions are zero-filled rather than wrapped around.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ShiftRotKind {
+    ShiftRight,
+    ShiftLeft,
+    RotateRight,
+    RotateLeft,
+}
+
+impl ShiftRotKind {
+    fn is_shift(self) -> bool {
+        matches!(self, Self::ShiftRight | Self::ShiftLeft)
+    }
+
+    /// The IOp evaluating this operation with a clear amount.
+    fn iop(self) -> &'static hpu_asm::AsmIOpcode {
+        match self {
+            Self::ShiftRight => &IOP_SHIFTS_R,
+            Self::ShiftLeft => &IOP_SHIFTS_L,
+            Self::RotateRight => &IOP_ROTS_R,
+            Self::RotateLeft => &IOP_ROTS_L,
+        }
+    }
+}
+
+/// Encodes a clear shift/rotate amount into the control word the scalar shift/rotate IOps expect.
+///
+/// Those IOps select with plaintext multiplications, which need one *digit* per control bit, and
+/// the IOp language cannot slice a digit out of a packed immediate — so the amount is advertised
+/// bit per bit, which costs the host nothing since it holds it in the clear:
+///
+/// ```text
+///  digit i        = bit i of (amount % width)   for i < log2(width)
+///  digit log2(w)  = keep = 1 if amount < width, else 0
+/// ```
+///
+/// `keep` is what makes an overflowing *shift* return zero at no hardware cost; rotations ignore it
+/// and always set it, `amount % width` being the whole story for them.
+///
+/// This mirrors `shiftrot_ctrl_word` of the compiler that emits these IOps — one digit per control
+/// bit, *not* the `amount[stg / msg_w]` packing that the encrypted-amount datapath reads.
+///
+/// # Panics
+///
+/// Panics if `width` is not a power of two, which the control word cannot express.
+fn shiftrot_ctrl_imm(width: usize, msg_w: usize, kind: ShiftRotKind, imm: HpuImm) -> HpuImm {
+    assert!(
+        width.is_power_of_two(),
+        "Scalar shift/rotate needs a power of two width, got {width}"
+    );
+    let log_w = width.ilog2();
+    let mut ctrl = 0 as HpuImm;
+    // Only the low log2(width) bits matter, which is exactly `imm % width`.
+    for i in 0..log_w {
+        ctrl |= ((imm >> i) & 1) << (i as usize * msg_w);
+    }
+    if !kind.is_shift() || imm < width as HpuImm {
+        ctrl |= 1 << (log_w as usize * msg_w);
+    }
+    ctrl
+}
+
+/// Submits a scalar shift/rotate, encoding `imm` on the way (see [`shiftrot_ctrl_imm`]).
+fn shiftrot_scalar(ct: &HpuVarWrapped, kind: ShiftRotKind, imm: HpuImm) -> HpuVarWrapped {
+    let iop = kind.iop();
+    let proto = &iop
+        .format()
+        .expect("Bind to std::ops a unspecified IOP")
+        .proto;
+    let ctrl = shiftrot_ctrl_imm(ct.int_width(), msg_width(ct), kind, imm);
+    let res = HpuCmd::exec(proto, iop.opcode(), std::slice::from_ref(ct), &[ctrl], None);
+    res[0].clone()
+}
+
+/// In-place flavor of [`shiftrot_scalar`].
+fn shiftrot_scalar_assign(ct: &HpuVarWrapped, kind: ShiftRotKind, imm: HpuImm) {
+    let iop = kind.iop();
+    let proto = &iop
+        .format()
+        .expect("Bind to std::ops a unspecified IOP")
+        .proto;
+    let ctrl = shiftrot_ctrl_imm(ct.int_width(), msg_width(ct), kind, imm);
+    HpuCmd::exec_assign(proto, iop.opcode(), std::slice::from_ref(ct), &[ctrl])
+}
+
+/// Message width of a block, which the ciphertext only exposes indirectly.
+fn msg_width(ct: &HpuVarWrapped) -> usize {
+    ct.int_width() / ct.blk_width()
+}
+
+/// `ct >> imm` and `ct << imm`, with a clear amount: shifting by the operand width or more yields
+/// zero, as the `keep` digit of the control word nulls every block.
+impl std::ops::Shr<HpuImm> for HpuRadixCiphertext {
+    type Output = Self;
+
+    fn shr(self, rhs: HpuImm) -> Self::Output {
+        &self >> rhs
+    }
+}
+
+impl std::ops::Shr<HpuImm> for &HpuRadixCiphertext {
+    type Output = HpuRadixCiphertext;
+
+    fn shr(self, rhs: HpuImm) -> Self::Output {
+        HpuRadixCiphertext::new(shiftrot_scalar(&self.0, ShiftRotKind::ShiftRight, rhs))
+    }
+}
+
+impl std::ops::ShrAssign<HpuImm> for HpuRadixCiphertext {
+    fn shr_assign(&mut self, rhs: HpuImm) {
+        shiftrot_scalar_assign(&self.0, ShiftRotKind::ShiftRight, rhs)
+    }
+}
+
+impl std::ops::Shl<HpuImm> for HpuRadixCiphertext {
+    type Output = Self;
+
+    fn shl(self, rhs: HpuImm) -> Self::Output {
+        &self << rhs
+    }
+}
+
+impl std::ops::Shl<HpuImm> for &HpuRadixCiphertext {
+    type Output = HpuRadixCiphertext;
+
+    fn shl(self, rhs: HpuImm) -> Self::Output {
+        HpuRadixCiphertext::new(shiftrot_scalar(&self.0, ShiftRotKind::ShiftLeft, rhs))
+    }
+}
+
+impl std::ops::ShlAssign<HpuImm> for HpuRadixCiphertext {
+    fn shl_assign(&mut self, rhs: HpuImm) {
+        shiftrot_scalar_assign(&self.0, ShiftRotKind::ShiftLeft, rhs)
+    }
+}
+
+/// Rotations by a clear amount. There is no `std::ops` trait for those, hence named methods; the
+/// amount is taken modulo the operand width, so no amount is out of range.
+impl HpuRadixCiphertext {
+    pub fn rotate_right(&self, amount: HpuImm) -> Self {
+        Self::new(shiftrot_scalar(&self.0, ShiftRotKind::RotateRight, amount))
+    }
+
+    pub fn rotate_right_assign(&mut self, amount: HpuImm) {
+        shiftrot_scalar_assign(&self.0, ShiftRotKind::RotateRight, amount)
+    }
+
+    pub fn rotate_left(&self, amount: HpuImm) -> Self {
+        Self::new(shiftrot_scalar(&self.0, ShiftRotKind::RotateLeft, amount))
+    }
+
+    pub fn rotate_left_assign(&mut self, amount: HpuImm) {
+        shiftrot_scalar_assign(&self.0, ShiftRotKind::RotateLeft, amount)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// The control word is a cross-repository contract: these are the very values the compiler
+    /// emitting the scalar shift/rotate IOps asserts on its side, so any drift breaks here first.
+    #[test]
+    fn test_shiftrot_ctrl_imm() {
+        let (width, msg_w) = (64, 2);
+        let shl = |imm| shiftrot_ctrl_imm(width, msg_w, ShiftRotKind::ShiftLeft, imm);
+        let rol = |imm| shiftrot_ctrl_imm(width, msg_w, ShiftRotKind::RotateLeft, imm);
+
+        // 7 == 0b000111 -> digits [1, 1, 1, 0, 0, 0 | keep = 1]
+        assert_eq!(shl(7), 0x1015);
+        // 70 >= 64 -> keep = 0, the result is null whatever the digits say
+        assert_eq!(shl(70), 0x0014);
+        // A rotation has no overshift: 70 rotates like 70 % 64 == 6, keep stays set.
+        assert_eq!(rol(70), 0x1014);
+        assert_eq!(rol(6), shl(6));
+
+        assert_eq!(shl(0), 0x1000, "keep alone");
+        assert_eq!(shl(63), 0x1555, "every amount bit set");
+        assert_eq!(shl(64), 0x0000, "shifting everything out");
+
+        // The digit layout must not depend on the block width beyond the digit stride.
+        assert_eq!(shiftrot_ctrl_imm(8, 2, ShiftRotKind::ShiftLeft, 3), 0x45);
+        assert_eq!(shiftrot_ctrl_imm(8, 4, ShiftRotKind::ShiftLeft, 3), 0x1011);
+    }
+}

--- a/tfhe/tests/hpu.rs
+++ b/tfhe/tests/hpu.rs
@@ -135,6 +135,31 @@ mod hpu_test {
         (std::sync::Mutex::new(hpu_device), cks, key_seed)
     }
 
+    /// Encodes a clear shift/rotate amount into the control word the scalar shift/rotate IOps
+    /// expect, mirroring `shiftrot_ctrl_imm` of the integer API: one digit per amount bit, plus a
+    /// `keep` digit that nulls the result of an overshifting *shift*. Immediates of every other IOp
+    /// go through untouched.
+    fn shiftrot_ctrl_imm(iop_name: &str, width: usize, msg_w: usize, imm: u128) -> u128 {
+        let is_shift = match iop_name {
+            "SHIFTS_R" | "SHIFTS_L" => true,
+            "ROTS_R" | "ROTS_L" => false,
+            _ => return imm,
+        };
+        assert!(
+            width.is_power_of_two(),
+            "Scalar shift/rotate needs a power of two width, got {width}"
+        );
+        let log_w = width.ilog2();
+        let mut ctrl = 0_u128;
+        for i in 0..log_w {
+            ctrl |= ((imm >> i) & 1) << (i as usize * msg_w);
+        }
+        if !is_shift || imm < width as u128 {
+            ctrl |= 1 << (log_w as usize * msg_w);
+        }
+        ctrl
+    }
+
     fn hpu_check_iop_proto<T, F>(
         iop: hpu_asm::AsmIOpcode,
         proto: hpu_asm::IOpProto,
@@ -168,9 +193,14 @@ mod hpu_test {
             _ => (false, None),
         };
 
+        let iop_name = iop
+            .format()
+            .map(|format| format.name.clone())
+            .unwrap_or_default();
         let width = T::BITS;
         let max_val: u128 = T::MAX.cast_into();
-        let num_block = width / device.params().pbs_params.message_width;
+        let msg_w = device.params().pbs_params.message_width;
+        let num_block = width / msg_w;
         // NB: To support both mono-hpu IOp and multi-hpu IOp,
         // input are generated only on the first node.
         // If you want to select a specific node for test, use `HPU_SELECTED_NODE` env variable
@@ -212,10 +242,17 @@ mod hpu_test {
                     .iter()
                     .map(|v| T::cast_from(*v))
                     .collect::<Vec<_>>();
+                // The scalar shift/rotate IOps read a control word rather than the amount itself,
+                // see `shiftrot_ctrl_imm`: the behaviour closures keep working on `imms_typed`,
+                // only what is handed to the hardware is encoded.
+                let imms_hw = imms_u128
+                    .iter()
+                    .map(|v| shiftrot_ctrl_imm(&iop_name, width, msg_w, *v))
+                    .collect::<Vec<_>>();
 
                 // execute on Hpu
                 let res_hpu =
-                    HpuRadixCiphertext::exec(&proto, iop.opcode(), &srcs_enc, &imms_u128, None);
+                    HpuRadixCiphertext::exec(&proto, iop.opcode(), &srcs_enc, &imms_hw, None);
                 let res_fhe = res_hpu
                     .iter()
                     .map(|x| x.to_radix_ciphertext())
@@ -437,9 +474,9 @@ mod hpu_test {
 
     // Shift/Rotation with Scalar IOp
     hpu_testcase!("SHIFTS_R" => [u8, u16, u32, u64, u128]
-    |ct, imm| [ct[0].wrapping_shr(imm[0] as u32)] );
+    |ct, imm| [ct[0].checked_shr(imm[0] as u32).unwrap_or(0)] );
     hpu_testcase!("SHIFTS_L" => [u8, u16, u32, u64, u128]
-    |ct, imm| [ct[0].wrapping_shl(imm[0] as u32)] );
+    |ct, imm| [ct[0].checked_shl(imm[0] as u32).unwrap_or(0)] );
     hpu_testcase!("ROTS_R" => [u8, u16, u32, u64, u128]
     |ct, imm| [ct[0].rotate_right(imm[0] as u32)] );
     hpu_testcase!("ROTS_L" => [u8, u16, u32, u64, u128]
@@ -582,18 +619,16 @@ mod hpu_test {
         "ovf_ssub",
         "ovf_muls"
     ]);
-    // NB: Currently disable shift/rot with scalar.
-    // This is a known limitation, associated IOps aren't implemented
-    // #[cfg(feature = "hpu")]
-    // hpu_testbundle!("rots"::[8,16,32,64,128] => [
-    //     "rots_r",
-    //     "rots_l"
-    // ]);
-    // #[cfg(feature = "hpu")]
-    // hpu_testbundle!("shifts"::[8,16,32,64,128] => [
-    //     "shifts_r",
-    //     "shifts_l"
-    // ]);
+    #[cfg(feature = "hpu")]
+    hpu_testbundle!("rots"::[8,16,32,64,128] => [
+        "rots_r",
+        "rots_l"
+    ]);
+    #[cfg(feature = "hpu")]
+    hpu_testbundle!("shifts"::[8,16,32,64,128] => [
+        "shifts_r",
+        "shifts_l"
+    ]);
     #[cfg(feature = "hpu")]
     hpu_testbundle!("alu"::[8,16,32,64,128] => [
         "add",

--- a/tfhe/tests/hpu.rs
+++ b/tfhe/tests/hpu.rs
@@ -160,6 +160,136 @@ mod hpu_test {
         ctrl
     }
 
+    /// Right shift, with the overshift semantics the HPU implements.
+    ///
+    /// An amount at or beyond the integer width empties the result — that is what the firmware
+    /// does, via `iop_overshift_zero` for the `Ct x Ct` form and via the `keep` digit of the
+    /// control word for the scalar one. Rust's `wrapping_shr` instead reduces the amount modulo
+    /// the width, and `checked_shr` takes a `u32` so a `u128` amount has already lost everything
+    /// above bit 32 by the time it is checked; neither matches the hardware.
+    fn shift_r<T: UnsignedInteger>(value: T, amount: T) -> u128 {
+        let amount: u128 = amount.cast_into();
+        let value: u128 = value.cast_into();
+        if amount >= T::BITS as u128 {
+            0
+        } else {
+            value >> amount
+        }
+    }
+
+    /// Left shift, with the overshift semantics the HPU implements. See [`shift_r`].
+    fn shift_l<T: UnsignedInteger>(value: T, amount: T) -> u128 {
+        let amount: u128 = amount.cast_into();
+        let value: u128 = value.cast_into();
+        if amount >= T::BITS as u128 {
+            0
+        } else {
+            // Bits pushed past the integer width are dropped by the cast back to `T`.
+            value << amount
+        }
+    }
+
+    /// Right rotation.
+    ///
+    /// Unlike a shift, an amount beyond the integer width just wraps around, so this only reduces
+    /// it modulo the width — but it does so on the whole amount, where `rotate_right(amount as
+    /// u32)` would first discard everything above bit 32.
+    fn rot_r<T: UnsignedInteger>(value: T, amount: T) -> u128 {
+        let bits = T::BITS as u32;
+        let amount: u128 = amount.cast_into();
+        let amount = (amount % bits as u128) as u32;
+        let value: u128 = value.cast_into();
+        if amount == 0 {
+            value
+        } else {
+            // Whatever the left part pushes above the integer width is dropped by the cast back
+            // to `T`; the bits that must wrap around are the ones the right part carries.
+            (value >> amount) | (value << (bits - amount))
+        }
+    }
+
+    /// Left rotation. See [`rot_r`].
+    fn rot_l<T: UnsignedInteger>(value: T, amount: T) -> u128 {
+        let bits = T::BITS as u32;
+        let amount: u128 = amount.cast_into();
+        let amount = (amount % bits as u128) as u32;
+        let value: u128 = value.cast_into();
+        if amount == 0 {
+            value
+        } else {
+            (value << amount) | (value >> (bits - amount))
+        }
+    }
+
+    /// Which operand of an IOp a random value is being drawn for.
+    #[derive(Copy, Clone)]
+    enum OperandKind {
+        /// A ciphertext source.
+        Src,
+        /// A cleartext immediate.
+        Imm,
+    }
+
+    /// How a random operand should be drawn.
+    ///
+    /// Drawing uniformly over the whole width leaves some IOps all but untested. A uniform 64-bit
+    /// shift amount is at least 64 with probability `1 - 2^-58`, so every iteration of `SHIFT_R`
+    /// only ever exercised the overshift path and never a real shift. A uniform 64-bit divisor is
+    /// bigger than the dividend half the time, which makes the quotient 0 and the remainder the
+    /// dividend. These biases aim such operands at the values that actually exercise the
+    /// operation, while still drawing the degenerate ones often enough to keep them covered.
+    #[derive(Copy, Clone)]
+    enum OperandBias {
+        /// Uniform over the operand's whole range.
+        Uniform,
+        /// A shift/rotate amount: usually below the integer width, occasionally beyond it.
+        ShiftAmount,
+        /// A divisor: log-uniform, so small divisors dominate and 0 still turns up.
+        Divisor,
+    }
+
+    /// Returns the bias to use for the operand at `pos` of `iop_name`.
+    fn operand_bias(iop_name: &str, kind: OperandKind, pos: usize) -> OperandBias {
+        match (iop_name, kind, pos) {
+            // Ct x Ct: the second source holds the amount or the divisor.
+            ("SHIFT_R" | "SHIFT_L" | "ROT_R" | "ROT_L", OperandKind::Src, 1) => {
+                OperandBias::ShiftAmount
+            }
+            ("DIV" | "MOD", OperandKind::Src, 1) => OperandBias::Divisor,
+            // Ct x Imm: the amount or the divisor is the immediate.
+            ("SHIFTS_R" | "SHIFTS_L" | "ROTS_R" | "ROTS_L", OperandKind::Imm, 0) => {
+                OperandBias::ShiftAmount
+            }
+            ("DIVS" | "MODS", OperandKind::Imm, 0) => OperandBias::Divisor,
+            _ => OperandBias::Uniform,
+        }
+    }
+
+    /// Draws one random operand of `bw` bits, whose largest value is `max`, honouring `bias`.
+    fn gen_operand(rng: &mut StdRng, bias: OperandBias, bw: usize, max: u128) -> u128 {
+        match bias {
+            OperandBias::Uniform => rng.gen_range(0..=max),
+            // Seven draws out of eight land in `0..bw`, the only range where a shift keeps any of
+            // the operand's bits. The eighth overshoots on purpose, so the zeroing path stays
+            // covered — it is the one the firmware has dedicated logic for.
+            OperandBias::ShiftAmount => {
+                if rng.gen_ratio(7, 8) {
+                    rng.gen_range(0..bw as u128)
+                } else {
+                    rng.gen_range(0..=max)
+                }
+            }
+            // Draw a bit-length first, then a value of that length. Small divisors then come up
+            // far more often than a uniform draw would ever allow, quotients span many magnitudes
+            // instead of being 0 half the time, and 0 itself still turns up often enough to
+            // exercise the division-by-zero path.
+            OperandBias::Divisor => {
+                let bits = rng.gen_range(1..=bw);
+                rng.gen_range(0..=(max >> (bw - bits)))
+            }
+        }
+    }
+
     fn hpu_check_iop_proto<T, F>(
         iop: hpu_asm::AsmIOpcode,
         proto: hpu_asm::IOpProto,
@@ -213,14 +343,16 @@ mod hpu_test {
                 let (srcs_clear, srcs_enc): (Vec<_>, Vec<_>) = proto
                     .src
                     .iter()
-                    .map(|mode| {
+                    .enumerate()
+                    .map(|(pos, mode)| {
                         let (bw, block) = match mode {
                             hpu_asm::iop::VarMode::Native => (width, num_block),
                             hpu_asm::iop::VarMode::Half => (width / 2, num_block / 2),
                             hpu_asm::iop::VarMode::Bool => (1, 1),
                         };
 
-                        let clear = rng.gen_range(0_u128..=max_val >> (width - bw));
+                        let bias = operand_bias(&iop_name, OperandKind::Src, pos);
+                        let clear = gen_operand(rng, bias, bw, max_val >> (width - bw));
                         let fhe = if test_trivial {
                             sks.as_ref().unwrap().create_trivial_radix(clear, block)
                         } else {
@@ -236,7 +368,10 @@ mod hpu_test {
                     .unzip();
 
                 let imms_u128 = (0..proto.imm)
-                    .map(|_pos| rng.gen_range(0_u128..max_val))
+                    .map(|pos| {
+                        let bias = operand_bias(&iop_name, OperandKind::Imm, pos);
+                        gen_operand(rng, bias, width, max_val)
+                    })
                     .collect::<Vec<_>>();
                 let imms_typed = imms_u128
                     .iter()
@@ -474,13 +609,13 @@ mod hpu_test {
 
     // Shift/Rotation with Scalar IOp
     hpu_testcase!("SHIFTS_R" => [u8, u16, u32, u64, u128]
-    |ct, imm| [ct[0].checked_shr(imm[0] as u32).unwrap_or(0)] );
+    |ct, imm| [shift_r(ct[0], imm[0])] );
     hpu_testcase!("SHIFTS_L" => [u8, u16, u32, u64, u128]
-    |ct, imm| [ct[0].checked_shl(imm[0] as u32).unwrap_or(0)] );
+    |ct, imm| [shift_l(ct[0], imm[0])] );
     hpu_testcase!("ROTS_R" => [u8, u16, u32, u64, u128]
-    |ct, imm| [ct[0].rotate_right(imm[0] as u32)] );
+    |ct, imm| [rot_r(ct[0], imm[0])] );
     hpu_testcase!("ROTS_L" => [u8, u16, u32, u64, u128]
-    |ct, imm| [ct[0].rotate_left(imm[0] as u32)] );
+    |ct, imm| [rot_l(ct[0], imm[0])] );
 
     // Alu IOp with Ct x Ct
     hpu_testcase!("ADD" => [u8, u16, u32, u64, u128]
@@ -512,13 +647,13 @@ mod hpu_test {
 
     // Shift/Rotation IOp
     hpu_testcase!("SHIFT_R" => [u8, u16, u32, u64, u128]
-    |ct, imm| [ct[0].wrapping_shr(ct[1] as u32)] );
+    |ct, imm| [shift_r(ct[0], ct[1])] );
     hpu_testcase!("SHIFT_L" => [u8, u16, u32, u64, u128]
-    |ct, imm| [ct[0].wrapping_shl(ct[1] as u32)] );
+    |ct, imm| [shift_l(ct[0], ct[1])] );
     hpu_testcase!("ROT_R" => [u8, u16, u32, u64, u128]
-    |ct, imm| [ct[0].rotate_right(ct[1] as u32)] );
+    |ct, imm| [rot_r(ct[0], ct[1])] );
     hpu_testcase!("ROT_L" => [u8, u16, u32, u64, u128]
-    |ct, imm| [ct[0].rotate_left(ct[1] as u32)] );
+    |ct, imm| [rot_l(ct[0], ct[1])] );
 
     // Bitwise IOp
     hpu_testcase!("BW_AND" => [u8, u16, u32, u64, u128]


### PR DESCRIPTION
Linked with ZHC PR: https://github.com/zama-ai/zhc/pull/146
It is not magic but it is still faster than LLT 128b DOP fw generation.
Still 128b DOP fw scheduling is more than 90% of the total fw gen time with nearly a minute of wait added.
This PR is also modifying the way scalar shift & rot are done in HPU backend because new implementation in ZHC is using a special encoding of the scalar amount.
I have also modified the HPU tests to test more realistic values on shift/rot and div/mod.