### PR TITLE
fix(gpu): g6e.24xlarge is a 4xL40, g6.24xlarge was a 4xL4

### DIFF
--- a/ci/slab.toml
+++ b/ci/slab.toml
@@ -62,7 +62,7 @@ user = "ubuntu"
 [backend.aws.4-l40]
 region = "us-east-1"
 image_id = "ami-0250f541bc1358116"
-instance_type = "g6.24xlarge"
+instance_type = "g6e.24xlarge"
 user = "ubuntu"
 fallbacks = [ "hyperstack.4-l40", "terraform.scaleway-4-l40" ]
 


### PR DESCRIPTION
small fix for **gpu_integer_long_run_tests/cuda-tests (ubuntu-22.04, 12.8 12.2, 12)**