### PR TITLE
chore(zk): deprecate experimental proofs

### DIFF
--- a/tfhe-zk-pok/src/lib.rs
+++ b/tfhe-zk-pok/src/lib.rs
@@ -1,3 +1,11 @@
+#![cfg_attr(
+    test,
+    allow(
+        deprecated,
+        reason = "tests of deprecated items are expected to use them"
+    )
+)]
+
 pub mod curve_446;
 pub mod curve_api;
 #[cfg(feature = "gpu")]

--- a/tfhe-zk-pok/src/proofs/mod.rs
+++ b/tfhe-zk-pok/src/proofs/mod.rs
@@ -449,12 +449,32 @@ where
 }
 
 #[cfg(feature = "experimental")]
+#[deprecated(
+    since = "0.9.0",
+    note = "experimental proof, it will be removed in a future release. \
+            The maintained proof systems are `proofs::pke` and `proofs::pke_v2`"
+)]
 pub mod binary;
 #[cfg(feature = "experimental")]
+#[deprecated(
+    since = "0.9.0",
+    note = "experimental proof, it will be removed in a future release. \
+            The maintained proof systems are `proofs::pke` and `proofs::pke_v2`"
+)]
 pub mod index;
 #[cfg(feature = "experimental")]
+#[deprecated(
+    since = "0.9.0",
+    note = "experimental proof, it will be removed in a future release. \
+            The maintained proof systems are `proofs::pke` and `proofs::pke_v2`"
+)]
 pub mod range;
 #[cfg(feature = "experimental")]
+#[deprecated(
+    since = "0.9.0",
+    note = "experimental proof, it will be removed in a future release. \
+            The maintained proof systems are `proofs::pke` and `proofs::pke_v2`"
+)]
 pub mod rlwe;
 
 pub mod pke;


### PR DESCRIPTION
### PR content/description
Deprecate experimental zk proofs, that will be removed in a subsequent release, to reduce maintenance burden on used code.