### PR TITLE
chore(gpu): add benchmarking for N x sxm5 with multiple processes

### DIFF
--- a/.github/actions/resolve_gpu_hardware/action.yml
+++ b/.github/actions/resolve_gpu_hardware/action.yml
@@ -1,0 +1,28 @@
+name: Resolve GPU hardware name
+description: >
+  Rename the requested hardware profile after the GPUs nvidia-smi reports, since Slab silently falls
+  back to another machine when the requested one is unavailable. Writes the GPU list to gpu_info.txt
+  and exports HARDWARE_NAME and NUM_GROUPS (one group per GPU) to GITHUB_ENV.
+
+inputs:
+  requested-hardware-name:
+    description: Hardware name of the profile requested to Slab
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Collect GPU information
+      shell: bash
+      run: |
+        nvidia-smi --query-gpu=name --format=csv,noheader | tee gpu_info.txt
+
+    - name: Resolve GPU hardware name
+      shell: bash
+      env:
+        REQUESTED_HARDWARE_NAME: ${{ inputs.requested-hardware-name }}
+      run: |
+        python3 ci/resolve_gpu_hardware.py \
+        --requested "${REQUESTED_HARDWARE_NAME}" \
+        --gpu-info gpu_info.txt \
+        --output "${GITHUB_ENV}"

--- a/.github/workflows/benchmark_gpu.yml
+++ b/.github/workflows/benchmark_gpu.yml
@@ -30,6 +30,8 @@ on:
         default: integer
         options:
           - integer
+          - integer_multi_group
+          - signed_integer_multi_group
           - integer_compression
           - pbs
           - pbs128

--- a/.github/workflows/benchmark_gpu_common.yml
+++ b/.github/workflows/benchmark_gpu_common.yml
@@ -220,6 +220,11 @@ jobs:
         with:
           toolchain: nightly
 
+      - name: Resolve GPU hardware name
+        uses: ./.github/actions/resolve_gpu_hardware
+        with:
+          requested-hardware-name: ${{ inputs.hardware_name }}
+
       - name: Run benchmarks
         run: |
           make BIT_SIZES_SET="${PRECISIONS_SET}" BENCH_OP_FLAVOR="${OP_FLAVOR}" BENCH_TYPE="${BENCH_TYPE}" BENCH_PARAM_TYPE="${BENCH_PARAMS_TYPE}" bench_"${BENCH_COMMAND}"_gpu
@@ -231,15 +236,12 @@ jobs:
           PRECISIONS_SET: ${{ inputs.precisions_set }}
           __TFHE_RS_BENCH_ERC7984_FILTER: ${{ inputs.erc7984_filter }}
 
-      - name: Collect GPU information
-        run: nvidia-smi --query-gpu=name --format=csv,noheader | tee gpu_info.txt
-
       - name: Parse results
-        if: ${{ inputs.command != 'hlapi_erc7984_multi_group' }}
+        if: ${{ !endsWith(inputs.command, '_multi_group') }}
         run: |
           cargo run --release -p tfhe-benchmark-parser -- -i target/criterion -o "${RESULTS_FILENAME}" \
           --database tfhe_rs \
-          --hardware "${INPUTS_HARDWARE_NAME}" \
+          --hardware "${HARDWARE_NAME}" \
           --backend cuda \
           --project-version "${COMMIT_HASH}" \
           --branch "${REF_NAME}" \
@@ -249,21 +251,19 @@ jobs:
           --name-suffix avx512 \
           --bench-type "${BENCH_TYPE}"
         env:
-          INPUTS_HARDWARE_NAME: ${{ inputs.hardware_name }}
           REF_NAME: ${{ github.ref_name }}
           BENCH_TYPE: ${{ matrix.bench_type }}
 
-      - name: Parse and merge erc7984_multi_group results
-        if: ${{ inputs.command == 'hlapi_erc7984_multi_group' }}
+      - name: Parse and merge multi_group results
+        if: ${{ endsWith(inputs.command, '_multi_group') }}
         run: |
-          # The bench runs one process per gpu, so there are as many result dirs as gpus
-          NUM_GROUPS=$(wc -l < gpu_info.txt)
+          echo "Merging results from ${NUM_GROUPS} groups"
           group_results=()
           for i in $(seq 0 $((NUM_GROUPS - 1))); do
             group_result="parsed_benchmark_results_p${i}_${GITHUB_SHA}.json"
             cargo run --release -p tfhe-benchmark-parser -- -i "tfhe-benchmark/target_p${i}/criterion" -o "${group_result}" \
             --database tfhe_rs \
-            --hardware "${INPUTS_HARDWARE_NAME}" \
+            --hardware "${HARDWARE_NAME}" \
             --backend cuda \
             --project-version "${COMMIT_HASH}" \
             --branch "${REF_NAME}" \
@@ -275,7 +275,6 @@ jobs:
           done
           python3 ./ci/merge_multi_group_results.py --bench-type "${BENCH_TYPE}" --output "${RESULTS_FILENAME}" "${group_results[@]}"
         env:
-          INPUTS_HARDWARE_NAME: ${{ inputs.hardware_name }}
           REF_NAME: ${{ github.ref_name }}
           BENCH_TYPE: ${{ matrix.bench_type }}
 

--- a/.github/workflows/benchmark_gpu_coprocessor.yml
+++ b/.github/workflows/benchmark_gpu_coprocessor.yml
@@ -117,9 +117,6 @@ jobs:
           - os: ubuntu-22.04
             cuda: "12.8 12.2"
             gcc: 12
-    env:
-      HW_NAME: "${{ needs.parse-inputs.outputs.hardware_name }}"
-
     steps:
       - name: Install git LFS
         run: |
@@ -164,6 +161,11 @@ jobs:
           cuda-version: ${{ matrix.cuda }}
           gcc-version: ${{ matrix.gcc }}
           cloud-provider: ${{ needs.parse-inputs.outputs.cloud_provider }}
+
+      - name: Resolve GPU hardware name
+        uses: ./.github/actions/resolve_gpu_hardware
+        with:
+          requested-hardware-name: ${{ needs.parse-inputs.outputs.hardware_name }}
 
       - name: Checkout tfhe-rs in fhevm coprocessor
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -295,7 +297,7 @@ jobs:
         run: |
           cargo run --release -p tfhe-benchmark-parser -- -i "${GITHUB_WORKSPACE}/fhevm/coprocessor/fhevm-engine/target/criterion" -o "${RESULTS_FILENAME}" \
           --database coprocessor \
-          --hardware "${HW_NAME}" \
+          --hardware "${HARDWARE_NAME}" \
           --backend cuda \
           --project-version "${COMMIT_HASH}" \
           --branch "${BRANCH_NAME}" \

--- a/Makefile
+++ b/Makefile
@@ -2284,60 +2284,55 @@ bench_hlapi_erc7984_gpu_classical: install_rs_check_toolchain
 	--bench hlapi-erc7984 \
 	--features=integer,gpu,internal-keycache,pbs-stats -p tfhe-benchmark --profile release_lto_off --
 
-.PHONY: bench_hlapi_erc7984_multi_group_gpu # Runs ERC7984 bench in one process per gpu and aggregates results
-bench_hlapi_erc7984_multi_group_gpu: install_rs_check_toolchain
+# Runs a bench in one process per gpu, each pinned to its own GPU and cores.
+# $(1): cargo bench target, $(2): criterion filter
+# $(3): group count to run on gpu 0 instead of one per gpu, to debug without a multi-gpu machine
+define run_multi_group_gpu_bench
 	# This next line must be kept here: the code can not remove this file without a risk of concurrency issues
 	# we don't know which process starts first and which one deletes the files - file deletion may also be not atomic)
 	rm -f /dev/shm/sem.tfhe_bench_*
 	# Single build: each group runs the same binary, criterion outputs split via CARGO_TARGET_DIR
-	NUM_GROUPS=$$(nvidia-smi --query-gpu=name --format=csv,noheader | wc -l); \
-	[ "$$NUM_GROUPS" -ge 2 ] || { echo "Error: this bench runs one process per gpu and needs at least 2 gpus, detected $$NUM_GROUPS (use bench_hlapi_erc7984_gpu on a single gpu)"; exit 1; }; \
+	NUM_GROUPS=$(if $(3),$(3),$$(nvidia-smi --query-gpu=name --format=csv,noheader | wc -l)); \
+	[ "$$NUM_GROUPS" -ge 2 ] || { echo "Error: this bench runs one process per gpu and needs at least 2 gpus, detected $$NUM_GROUPS (use the single-process gpu target instead)"; exit 1; }; \
 	CARGO_TARGET_DIR=target_p0 RUSTFLAGS="$(RUSTFLAGS)" \
 	cargo $(CARGO_RS_CHECK_TOOLCHAIN) bench \
-	--bench hlapi-erc7984 \
+	--bench $(1) \
 	--features=integer,gpu,internal-keycache,pbs-stats -p tfhe-benchmark --profile release_lto_off --no-run || exit 1; \
 	BENCH_BIN=$$(CARGO_TARGET_DIR=target_p0 RUSTFLAGS="$(RUSTFLAGS)" \
 	cargo $(CARGO_RS_CHECK_TOOLCHAIN) bench \
-	--bench hlapi-erc7984 \
+	--bench $(1) \
 	--features=integer,gpu,internal-keycache,pbs-stats -p tfhe-benchmark --profile release_lto_off --no-run --message-format=json 2>/dev/null \
-	| grep -o '"executable":"[^"]*hlapi_erc7984[^"]*"' | cut -d'"' -f4); \
+	| grep -o '"executable":"[^"]*$(subst -,_,$(1))[^"]*"' | cut -d'"' -f4); \
 	[ -x "$$BENCH_BIN" ] || { echo "Error: bench executable not found"; exit 1; }; \
-	BENCH_FILTER=$${__TFHE_RS_BENCH_ERC7984_FILTER:-}; \
-	if [ -z "$$BENCH_FILTER" ]; then \
-		BENCH_FILTER='::transfer::(whitepaper|no_cmux)'; \
-		case "$(BENCH_PARAM_TYPE)" in multi_bit*) BENCH_FILTER='::transfer::overflow';; esac; \
-	fi; \
+	BENCH_FILTER="$(2)"; \
 	CORES_PER_GROUP=$$(( $$(nproc) / NUM_GROUPS )); \
 	trap "echo 'User interrupted the benchmark, stopping all workers!'; rm -f /dev/shm/sem.tfhe_bench_*; kill 0" INT TERM; \
 	for i in $$(seq 0 $$((NUM_GROUPS - 1))); do \
 		CORE_LIST="$$((i * CORES_PER_GROUP))-$$(((i + 1) * CORES_PER_GROUP - 1))"; \
-		echo "Starting benchmark group $$i with CUDA_VISIBLE_DEVICES=$$i on cores $$CORE_LIST"; \
-		(cd tfhe-benchmark && CUDA_VISIBLE_DEVICES=$$i CUDA_DEVICE_MAX_CONNECTIONS=32 CARGO_TARGET_DIR=target_p$$i RAYON_NUM_THREADS=$$CORES_PER_GROUP __TFHE_RS_BENCH_TYPE=$(BENCH_TYPE) __TFHE_RS_PARAM_TYPE=$(BENCH_PARAM_TYPE) __TFHE_RS_BENCH_GPU_PROCESS_COUNT=$$NUM_GROUPS \
+		GPU_ID=$(if $(3),0,$$i); \
+		echo "Starting benchmark group $$i with CUDA_VISIBLE_DEVICES=$$GPU_ID on cores $$CORE_LIST"; \
+		(cd tfhe-benchmark && CUDA_VISIBLE_DEVICES=$$GPU_ID CUDA_DEVICE_MAX_CONNECTIONS=32 CARGO_TARGET_DIR=target_p$$i RAYON_NUM_THREADS=$$CORES_PER_GROUP __TFHE_RS_BENCH_TYPE=$(BENCH_TYPE) __TFHE_RS_PARAM_TYPE=$(BENCH_PARAM_TYPE) __TFHE_RS_BENCH_OP_FLAVOR=$(BENCH_OP_FLAVOR) __TFHE_RS_BENCH_BIT_SIZES_SET=$(BIT_SIZES_SET) __TFHE_RS_BENCH_GPU_PROCESS_COUNT=$$NUM_GROUPS \
 		taskset -c $$CORE_LIST "$$BENCH_BIN" --bench "$$BENCH_FILTER") & \
 	done; \
 	wait
+endef
+
+.PHONY: bench_hlapi_erc7984_multi_group_gpu # Runs ERC7984 bench in one process per gpu and aggregates results
+bench_hlapi_erc7984_multi_group_gpu: install_rs_check_toolchain
+	$(call run_multi_group_gpu_bench,hlapi-erc7984,$${__TFHE_RS_BENCH_ERC7984_FILTER:-$(if $(findstring multi_bit,$(BENCH_PARAM_TYPE)),::transfer::overflow,::transfer::(whitepaper|no_cmux))})
+
+.PHONY: bench_integer_multi_group_gpu # Runs integer benchmarks in one process per gpu and aggregates results
+bench_integer_multi_group_gpu: install_rs_check_toolchain
+	$(call run_multi_group_gpu_bench,integer,)
+
+.PHONY: bench_signed_integer_multi_group_gpu # Runs signed integer benchmarks in one process per gpu and aggregates results
+bench_signed_integer_multi_group_gpu: install_rs_check_toolchain
+	$(call run_multi_group_gpu_bench,integer-signed,)
 
 .PHONY: bench_hlapi_erc7984_multi_group_fake_multi_gpu # Runs ERC7984 bench in two processes in parallel on a single GPU (use to debug bench_hlapi_erc7984_multi_group_gpu)
+bench_hlapi_erc7984_multi_group_fake_multi_gpu: BENCH_TYPE=throughput
 bench_hlapi_erc7984_multi_group_fake_multi_gpu: install_rs_check_toolchain
-	# This next line must be kept here: the code can not remove this file without a risk of concurrency issues
-	# we don't know which process starts first and which one deletes the files - file deletion may also be not atomic)
-	rm -f /dev/shm/sem.tfhe_bench_*
-	CARGO_TARGET_DIR=target_p0 RUSTFLAGS="$(RUSTFLAGS)" \
-	cargo $(CARGO_RS_CHECK_TOOLCHAIN) bench \
-	--bench hlapi-erc7984 \
-	--features=integer,gpu,internal-keycache,pbs-stats -p tfhe-benchmark --profile release_lto_off --no-run || exit 1; \
-	BENCH_BIN=$$(CARGO_TARGET_DIR=target_p0 RUSTFLAGS="$(RUSTFLAGS)" \
-	cargo $(CARGO_RS_CHECK_TOOLCHAIN) bench \
-	--bench hlapi-erc7984 \
-	--features=integer,gpu,internal-keycache,pbs-stats -p tfhe-benchmark --profile release_lto_off --no-run --message-format=json 2>/dev/null \
-	| grep -o '"executable":"[^"]*hlapi_erc7984[^"]*"' | cut -d'"' -f4); \
-	[ -x "$$BENCH_BIN" ] || { echo "Error: bench executable not found"; exit 1; }; \
-	trap "echo 'User interrupted the benchmark, stopping all workers!'; rm -f /dev/shm/sem.tfhe_bench_*; kill 0" INT TERM; \
-	for i in 0 1; do \
-		(cd tfhe-benchmark && CARGO_TARGET_DIR=target_p$$i __TFHE_RS_BENCH_TYPE=throughput __TFHE_RS_PARAM_TYPE=$(BENCH_PARAM_TYPE) __TFHE_RS_BENCH_GPU_PROCESS_COUNT=2 \
-		"$$BENCH_BIN" --bench '::transfer::overflow') & \
-	done; \
-	wait
+	$(call run_multi_group_gpu_bench,hlapi-erc7984,::transfer::overflow,2)
 
 .PHONY: bench_hlapi_dex # Run benchmarks for DEX operations
 bench_hlapi_dex: install_rs_check_toolchain

--- a/ci/gpu_hardware.json
+++ b/ci/gpu_hardware.json
@@ -1,0 +1,30 @@
+{
+  "aws": {
+    "p5.4xlarge": { "count": 1, "model": "H100 80GB HBM3" },
+    "g6e.24xlarge": { "count": 4, "model": "L40S" },
+    "g6.2xlarge": { "count": 1, "model": "NVIDIA L4" }
+  },
+  "hyperstack": {
+    "n3-L40x1": { "count": 1, "model": "NVIDIA L40" },
+    "n3-L40x4": { "count": 4, "model": "NVIDIA L40" },
+    "n3-L40x8": { "count": 8, "model": "NVIDIA L40" },
+    "n3-RTX-A6000x1": { "count": 1, "model": "RTX A6000" },
+    "n3-RTX-A4000x4": { "count": 4, "model": "RTX A4000" },
+    "n3-H100x1": { "count": 1, "model": "H100 PCIe" },
+    "n3-H100x2": { "count": 2, "model": "H100 PCIe" },
+    "n3-H100x4": { "count": 4, "model": "H100 PCIe" },
+    "n3-H100x8": { "count": 8, "model": "H100 PCIe" },
+    "n3-H100x8-NVLink": { "count": 8 },
+    "n3-H100-SXM5x8": { "count": 8, "model": "H100 80GB HBM3" },
+    "n3-A100x8-NVLink": { "count": 8, "model": "A100" }
+  },
+  "scaleway": {
+    "H100-SXM-8-80G": { "count": 8, "model": "H100 80GB HBM3" },
+    "H100-SXM-4-80G": { "count": 4, "model": "H100 80GB HBM3" },
+    "H100-SXM-2-80G": { "count": 2, "model": "H100 80GB HBM3" },
+    "H100-1-80G": { "count": 1, "model": "H100 PCIe" },
+    "L40S-4-48G": { "count": 4, "model": "L40S" },
+    "L40S-1-48G": { "count": 1, "model": "L40S" },
+    "L4-2-24G": { "count": 2, "model": "NVIDIA L4" }
+  }
+}

--- a/ci/merge_multi_group_results.py
+++ b/ci/merge_multi_group_results.py
@@ -5,7 +5,7 @@ import argparse
 import json
 import sys
 
-ACCEPTED_TEST_PREFIX = "tfhe::hlapi::erc7984::transfer"
+ACCEPTED_TEST_PREFIX = "tfhe::"
 
 
 # Looks at the Slab JSON benchmark results and aggregates the "value" field.
@@ -51,8 +51,14 @@ def merge_multi_group_results(input_files, output_file, bench_type):
         for test in accumulated:
             accumulated[test]["value"] /= counts[test]
 
+    num_groups = len(input_files)
     for test, point in accumulated.items():
-        print(f"merged {bench_type} over {counts[test]} groups: {test} = {point['value']:.1f}")
+        if counts[test] != num_groups:
+            print(
+                f"Warning: test '{test}' was only found in {counts[test]}/{num_groups} groups",
+                file=sys.stderr,
+            )
+        print(f"{test} = {point['value']:.1f}")
 
     result = dict(metadata)
     result["points"] = list(accumulated.values())

--- a/ci/resolve_gpu_hardware.py
+++ b/ci/resolve_gpu_hardware.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+# Slab silently starts a fallback profile when the requested one is unavailable, so the requested
+# hardware name may describe a machine we never got. Rename it after the GPUs nvidia-smi reports.
+import argparse
+import json
+import pathlib
+import sys
+
+TABLE_PATH = pathlib.Path(__file__).with_name("gpu_hardware.json")
+
+
+def load_hardware():
+    """
+    Read gpu_hardware.json: GPU count and model keyed by instance_type (aws, terraform) or
+    flavor_name (hyperstack), grouped by provider.
+
+    :return: flattened table as {hardware name: (GPU count, model)}
+    """
+    return {
+        name: (spec["count"], spec.get("model", ""))
+        for profiles in json.loads(TABLE_PATH.read_text()).values()
+        for name, spec in profiles.items()
+    }
+
+
+def warn(message):
+    print(f"Warning: {message}", file=sys.stderr)
+
+
+def resolve(requested, gpu_names, hardware):
+    models = sorted(set(gpu_names))
+    observed = f"{len(gpu_names)} x {', '.join(models) or 'no GPU'}"
+    print(f"Detected {observed}", flush=True)
+
+    if requested not in hardware:
+        sys.exit(f"Error: unknown hardware '{requested}', add it to {TABLE_PATH.name}.")
+
+    def matches(name):
+        count, model = hardware[name]
+        return count == len(gpu_names) and all(model in observed_model for observed_model in models)
+
+    if matches(requested):
+        return requested
+
+    candidates = [name for name in hardware if matches(name)]
+    if len(candidates) == 1:
+        warn(f"requested {requested}, got a {candidates[0]}: Slab fell back.")
+        return candidates[0]
+
+    if hardware[requested][0] == len(gpu_names):
+        warn(f"requested {requested}, got {observed}: keeping {requested}.")
+        return requested
+
+    raise SystemExit(
+        f"Error: no hardware in {TABLE_PATH.name} has {observed} (requested {requested})."
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Resolve the hardware name describing the machine a benchmark runs on."
+    )
+    parser.add_argument("--requested", required=True, help="hardware name of the requested profile")
+    parser.add_argument("--gpu-info", required=True, help="file with one GPU name per line")
+    parser.add_argument(
+        "--output", required=True, help="file to append HARDWARE_NAME and NUM_GROUPS to"
+    )
+    args = parser.parse_args()
+
+    with open(args.gpu_info) as f:
+        gpu_names = [line.strip() for line in f if line.strip()]
+
+    resolved = resolve(args.requested, gpu_names, load_hardware())
+
+    print(f"Sending results under hardware name: {resolved}", flush=True)
+    with open(args.output, "a") as f:
+        f.write(f"HARDWARE_NAME={resolved}\nNUM_GROUPS={len(gpu_names)}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/tfhe-benchmark/benches/high_level_api/erc7984.rs
+++ b/tfhe-benchmark/benches/high_level_api/erc7984.rs
@@ -1,8 +1,8 @@
 use benchmark::high_level_api::type_display::TypeDisplayer;
-#[cfg(all(feature = "gpu", target_os = "linux"))]
-use benchmark::utilities::bench_sync_barrier;
 #[cfg(feature = "gpu")]
-use benchmark::utilities::{configure_gpu, get_bench_gpu_instances, get_param_type, ParamType};
+use benchmark::utilities::{
+    configure_gpu, get_bench_gpu_instances, get_param_type, sync_bench_gpu_processes, ParamType,
+};
 use benchmark::utilities::{write_to_json, OperatorType};
 use benchmark_spec::tfhe::hlapi::erc7984::{Erc7984, TransferFlavor};
 use benchmark_spec::tfhe::hlapi::HlapiBench;
@@ -573,10 +573,7 @@ fn cuda_bench_transfer_throughput<FheType, F>(
         let num_streams_per_gpu = 16; // Hard coded stream value for FheUint64
         let chunk_size = (num_elems / num_gpus) as usize;
 
-        #[cfg(target_os = "linux")]
-        if let Some(n) = get_bench_gpu_instances() {
-            bench_sync_barrier(n);
-        }
+        sync_bench_gpu_processes();
 
         b.iter(|| {
             from_amounts

--- a/tfhe-benchmark/benches/integer/bench.rs
+++ b/tfhe-benchmark/benches/integer/bench.rs
@@ -1257,6 +1257,7 @@ define_server_key_bench_default_fn!(
 mod cuda {
     use super::*;
     use benchmark::utilities::cuda_integer_utils::{cuda_local_keys, cuda_local_streams};
+    use benchmark::utilities::sync_bench_gpu_processes;
     use criterion::criterion_group;
     use std::cmp::max;
     use tfhe::core_crypto::gpu::{get_number_of_gpus, CudaStreams};
@@ -1335,6 +1336,7 @@ mod cuda {
                         .measurement_time(std::time::Duration::from_secs(30));
                     let elements = throughput_num_threads(num_block, pbs_count);
                     bench_group.throughput(Throughput::Elements(elements));
+                    sync_bench_gpu_processes();
                     bench_group.bench_function(&bench_id, |b| {
                         let setup_encrypted_values = || {
                             let local_streams = cuda_local_streams(num_block, elements as usize);
@@ -1466,6 +1468,7 @@ mod cuda {
                         .measurement_time(std::time::Duration::from_secs(30));
                     let elements = throughput_num_threads(num_block, pbs_count);
                     bench_group.throughput(Throughput::Elements(elements));
+                    sync_bench_gpu_processes();
                     bench_group.bench_function(&bench_id, |b| {
                         let setup_encrypted_values = || {
                             let local_streams = cuda_local_streams(num_block, elements as usize);
@@ -1615,6 +1618,7 @@ mod cuda {
                         .measurement_time(std::time::Duration::from_secs(30));
                     let elements = throughput_num_threads(num_block, pbs_count);
                     bench_group.throughput(Throughput::Elements(elements));
+                    sync_bench_gpu_processes();
                     bench_group.bench_function(&bench_id, |b| {
                         let setup_encrypted_values = || {
                             let local_streams = cuda_local_streams(num_block, elements as usize);
@@ -1752,6 +1756,7 @@ mod cuda {
                         .measurement_time(std::time::Duration::from_secs(30));
                     let elements = throughput_num_threads(num_block, pbs_count);
                     bench_group.throughput(Throughput::Elements(elements));
+                    sync_bench_gpu_processes();
                     bench_group.bench_function(&bench_id, |b| {
                         let setup_encrypted_values = || {
                             let local_streams = cuda_local_streams(num_block, elements as usize);

--- a/tfhe-benchmark/benches/integer/signed_bench.rs
+++ b/tfhe-benchmark/benches/integer/signed_bench.rs
@@ -1562,6 +1562,7 @@ mod cuda {
     use super::*;
     use benchmark::params::ParamsAndNumBlocksIter;
     use benchmark::utilities::cuda_integer_utils::{cuda_local_keys, cuda_local_streams};
+    use benchmark::utilities::sync_bench_gpu_processes;
     use criterion::criterion_group;
     use rayon::iter::IntoParallelRefIterator;
     use std::cmp::max;
@@ -1661,6 +1662,7 @@ mod cuda {
 
                     let elements = throughput_num_threads(num_block, pbs_count);
                     bench_group.throughput(Throughput::Elements(elements));
+                    sync_bench_gpu_processes();
                     bench_group.bench_function(&bench_id, |b| {
                         let setup_encrypted_values = || {
                             let local_streams = cuda_local_streams(num_block, elements as usize);
@@ -1822,6 +1824,7 @@ mod cuda {
 
                     let elements = throughput_num_threads(num_block, pbs_count);
                     bench_group.throughput(Throughput::Elements(elements));
+                    sync_bench_gpu_processes();
                     bench_group.bench_function(&bench_id, |b| {
                         let setup_encrypted_values = || {
                             let local_streams = cuda_local_streams(num_block, elements as usize);
@@ -1975,6 +1978,7 @@ mod cuda {
 
                     let elements = throughput_num_threads(num_block, pbs_count);
                     bench_group.throughput(Throughput::Elements(elements));
+                    sync_bench_gpu_processes();
                     bench_group.bench_function(&bench_id, |b| {
                         let setup_encrypted_values = || {
                             let local_streams = cuda_local_streams(num_block, elements as usize);
@@ -2145,6 +2149,7 @@ mod cuda {
 
                     let elements = throughput_num_threads(num_block, pbs_count);
                     bench_group.throughput(Throughput::Elements(elements));
+                    sync_bench_gpu_processes();
                     bench_group.bench_function(&bench_id, |b| {
                         let setup_encrypted_values = || {
                             let local_streams = cuda_local_streams(num_block, elements as usize);
@@ -2312,6 +2317,7 @@ mod cuda {
 
                     let elements = throughput_num_threads(num_block, pbs_count);
                     bench_group.throughput(Throughput::Elements(elements));
+                    sync_bench_gpu_processes();
                     bench_group.bench_function(&bench_id, |b| {
                         let setup_encrypted_values = || {
                             let local_streams = cuda_local_streams(num_block, elements as usize);

--- a/tfhe-benchmark/src/utilities.rs
+++ b/tfhe-benchmark/src/utilities.rs
@@ -145,10 +145,18 @@ pub fn get_bench_gpu_instances() -> Option<usize> {
     })
 }
 
+/// Waits for the other processes when benchmarking one process per GPU.
+pub fn sync_bench_gpu_processes() {
+    #[cfg(target_os = "linux")]
+    if let Some(num_instances) = get_bench_gpu_instances() {
+        bench_sync_barrier(num_instances);
+    }
+}
+
 /// Multi-process barrier that ensures num_instances processes
 /// start at the same time
 #[cfg(target_os = "linux")]
-pub fn bench_sync_barrier(num_instances: usize) {
+fn bench_sync_barrier(num_instances: usize) {
     use std::ffi::CString;
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
 


### PR DESCRIPTION
extension of multigroups benchmarks
notice the user in the logs if there is a fallback to another machine
one process per GPU, so 8 GPU -> 8 processes