### PR TITLE
Ts/extractor/migrate data extractor to rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,7 +133,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -144,7 +144,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -313,6 +313,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -462,6 +471,12 @@ name = "bytemuck"
 version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -808,6 +823,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
 name = "criterion"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -990,6 +1020,18 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common 0.1.7",
+ "subtle",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1009,6 +1051,12 @@ name = "dot2"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "855423f2158bcc73798b3b9a666ec4204597a72370dc91dbdb8e7f9519de8cc3"
+
+[[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "dyn-clone"
@@ -1049,6 +1097,9 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "enum-iterator"
@@ -1158,7 +1209,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
+dependencies = [
+ "parking",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1213,6 +1285,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "fs2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1262,6 +1343,17 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
 ]
 
 [[package]]
@@ -1425,7 +1517,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cfc928d8ff4ab3767a3674cf55f81186436fb6070866bb1443ffe65a640d2d6"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1475,6 +1567,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -1487,6 +1581,15 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -1514,12 +1617,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "home"
 version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1583,10 +1704,113 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "ignore"
@@ -1774,10 +1998,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libredox"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
+dependencies = [
+ "bitflags",
+ "libc",
+ "plain",
+ "redox_syscall 0.9.1",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -1811,6 +2062,16 @@ checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
 dependencies = [
  "autocfg",
  "rawpointer",
+]
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
 ]
 
 [[package]]
@@ -1860,7 +2121,7 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1923,7 +2184,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2044,6 +2305,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.5.18",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "parse-zoneinfo"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2158,6 +2448,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
 name = "plotters"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2207,6 +2503,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "031ebbce771a275a3754a853d083de4713d41dfddff247f29b11b809c8b34a2c"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -2411,6 +2716,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07507be7b4a5f9f26eeb41eeaebb1f5a7ff29dfb29739facc21d35bf8b11c21e"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "ref-cast"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2458,6 +2781,20 @@ name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "rmp"
@@ -2543,7 +2880,41 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -2599,6 +2970,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
@@ -2801,6 +3178,145 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-postgres",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+dependencies = [
+ "base64",
+ "bytes",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.15.5",
+ "hashlink",
+ "indexmap 2.14.0",
+ "log",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rustls",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "thiserror 2.0.19",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck 0.5.0",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sqlx-core",
+ "sqlx-postgres",
+ "syn 2.0.118",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags",
+ "byteorder",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "rand 0.8.6",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.19",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_assertions"
@@ -2825,6 +3341,17 @@ name = "strength_reduce"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
 
 [[package]]
 name = "strsim"
@@ -2897,6 +3424,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2916,6 +3449,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2946,7 +3490,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3170,6 +3714,20 @@ dependencies = [
  "bindgen",
  "cmake",
  "pkg-config",
+]
+
+[[package]]
+name = "tfhe-data-extractor"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "benchmark_spec",
+ "chrono",
+ "clap",
+ "serde",
+ "sqlx",
+ "tokio",
+ "toml 0.8.23",
 ]
 
 [[package]]
@@ -3402,6 +3960,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3425,6 +3993,43 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
 
 [[package]]
 name = "toml"
@@ -3537,6 +4142,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3637,10 +4243,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
@@ -3659,6 +4286,30 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -3722,6 +4373,12 @@ checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen 0.51.0",
 ]
+
+[[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -3945,6 +4602,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "whoami"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite",
+]
+
+[[package]]
 name = "wide"
 version = "0.7.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3976,7 +4661,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3992,7 +4677,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
 dependencies = [
  "windows-core 0.58.0",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4005,7 +4690,7 @@ dependencies = [
  "windows-interface 0.58.0",
  "windows-result 0.2.0",
  "windows-strings 0.1.0",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4077,7 +4762,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4096,7 +4781,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
  "windows-result 0.2.0",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4110,6 +4795,24 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -4119,19 +4822,40 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -4141,9 +4865,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4159,9 +4895,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4171,9 +4919,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4291,10 +5051,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
 name = "xdg"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fb433233f2df9344722454bc7e96465c9d03bff9d77c248f9e7523fe79585b5"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "synstructure",
+]
 
 [[package]]
 name = "zerocopy"
@@ -4317,6 +5106,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4330,6 +5140,39 @@ name = "zeroize_derive"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,8 +334,10 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 name = "benchmark_spec"
 version = "0.1.0"
 dependencies = [
+ "enum-iterator",
  "serde",
  "strum 0.28.0",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -1047,6 +1049,26 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "enum-iterator"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4549325971814bda7a44061bf3fe7e487d447cba01e4220a4b454d630d7a016"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685adfa4d6f3d765a26bc5dbc936577de9abf756c1feeb3089b01dd395034842"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "enum-ordinalize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ members = [
     "utils/wasm-par-mq",
     "utils/wasm-par-mq/examples/msm",
     "utils/wasm-par-mq/web_tests",
+    "utils/tfhe-data-extractor",
 ]
 
 exclude = [

--- a/Makefile
+++ b/Makefile
@@ -699,6 +699,11 @@ clippy_benchmark_parser: install_rs_check_toolchain
 	RUSTFLAGS="$(RUSTFLAGS)" cargo "$(CARGO_RS_CHECK_TOOLCHAIN)" clippy --all-targets \
 		-p tfhe-benchmark-parser -- --no-deps -D warnings
 
+.PHONY: clippy_data_extractor # Run clippy lints on tfhe-data-extractor
+clippy_data_extractor: install_rs_check_toolchain
+	RUSTFLAGS="$(RUSTFLAGS)" cargo "$(CARGO_RS_CHECK_TOOLCHAIN)" clippy --all-targets \
+		-p tfhe-data-extractor -- --no-deps -D warnings
+
 .PHONY: clippy_fuzz # Run clippy lints on fuzzing crates
 clippy_fuzz: install_rs_check_toolchain
 	@find utils/fuzz -name Cargo.toml -not -path '*/target/*' | while read crate; do \
@@ -797,7 +802,7 @@ clippy_test_vectors: install_rs_check_toolchain
 clippy_all: clippy_rustdoc clippy clippy_boolean clippy_shortint clippy_integer clippy_all_targets \
 clippy_c_api clippy_js_wasm_api clippy_tasks clippy_core clippy_tfhe_csprng clippy_zk_pok clippy_zk_pok_wasm clippy_trivium \
 clippy_versionable clippy_safe_serialize clippy_tfhe_lints clippy_ws_tests clippy_bench clippy_param_dedup \
-clippy_benchmark_spec clippy_benchmark_parser clippy_test_vectors clippy_backward_compat_data clippy_wasm_par_mq \
+clippy_benchmark_spec clippy_benchmark_parser clippy_data_extractor clippy_test_vectors clippy_backward_compat_data clippy_wasm_par_mq \
 clippy_fuzz
 
 .PHONY: clippy_fast # Run main clippy targets
@@ -2712,6 +2717,7 @@ pcc_batch_6:
 	$(call run_recipe_with_details,clippy_param_dedup)
 	$(call run_recipe_with_details,clippy_benchmark_spec)
 	$(call run_recipe_with_details,clippy_benchmark_parser)
+	$(call run_recipe_with_details,clippy_data_extractor)
 	$(call run_recipe_with_details,docs)
 
 .PHONY: pcc_batch_7 # duration: 7'50'' (currently PCC execution bottleneck)

--- a/utils/benchmark_spec/Cargo.toml
+++ b/utils/benchmark_spec/Cargo.toml
@@ -10,5 +10,7 @@ gpu = []
 hpu = []
 
 [dependencies]
+enum-iterator = "2"
 strum = { version = "0.28", features = ["derive"] }
 serde = { workspace = true, default-features = false, features = ["derive"] }
+thiserror = { version = "2.0.19", default-features = false }

--- a/utils/benchmark_spec/src/bench_crate.rs
+++ b/utils/benchmark_spec/src/bench_crate.rs
@@ -1,23 +1,63 @@
 use std::fmt;
-use strum::Display;
+use std::str::FromStr;
 
+use strum::{Display, EnumDiscriminants, EnumString};
+
+use crate::error::SpecParseError;
 use crate::tfhe::TfheLayer;
 use crate::traits::write_spec;
 use crate::zk::ZkLayer;
 
-#[derive(Debug, Clone, Copy, Display)]
-#[strum(serialize_all = "snake_case")]
+#[derive(Debug, Clone, Copy, EnumDiscriminants, enum_iterator::Sequence)]
+#[strum_discriminants(
+    name(BenchCrateKind),
+    derive(EnumString, Display),
+    strum(serialize_all = "snake_case")
+)]
 pub enum BenchCrate {
     Tfhe(TfheLayer),
     Zk(ZkLayer),
 }
 
-impl BenchCrate {
-    pub(crate) fn fmt_crate(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{self}")?;
+impl FromStr for BenchCrate {
+    type Err = SpecParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (head, rest) = s.split_once("::").unwrap_or((s, ""));
+        match BenchCrateKind::from_str(head)
+            .map_err(|_| SpecParseError::Unknown(format!("unknown bench crate: {head}")))?
+        {
+            BenchCrateKind::Tfhe => Ok(Self::Tfhe(rest.parse()?)),
+            BenchCrateKind::Zk => Ok(Self::Zk(rest.parse()?)),
+        }
+    }
+}
+
+impl fmt::Display for BenchCrate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Crate token ("tfhe" / "zk") from the discriminant, then the layer tree.
+        write!(f, "{}", BenchCrateKind::from(self))?;
         match self {
             BenchCrate::Tfhe(layer) => write_spec(layer, f),
             BenchCrate::Zk(layer) => write_spec(layer, f),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every possible path must survive a `Display -> FromStr -> Display`
+    /// round-trip.
+    #[test]
+    fn roundtrip_all_bench_paths() {
+        for bc in enum_iterator::all::<BenchCrate>() {
+            let s = bc.to_string();
+            let reparsed = s
+                .parse::<BenchCrate>()
+                .unwrap_or_else(|e| panic!("parse of {s:?} failed: {e:?}"));
+            assert_eq!(reparsed.to_string(), s, "round-trip mismatch for {s:?}");
         }
     }
 }

--- a/utils/benchmark_spec/src/error.rs
+++ b/utils/benchmark_spec/src/error.rs
@@ -1,0 +1,8 @@
+#[derive(Debug, thiserror::Error)]
+pub enum SpecParseError {
+    #[error("unknown token: {0}")]
+    Unknown(String),
+
+    #[error(transparent)]
+    Strum(#[from] strum::ParseError),
+}

--- a/utils/benchmark_spec/src/lib.rs
+++ b/utils/benchmark_spec/src/lib.rs
@@ -1,11 +1,16 @@
 mod backend;
 mod bench_crate;
+mod error;
+mod measured;
+mod parse;
 pub mod tfhe;
 mod traits;
 pub mod zk;
 
 pub use backend::{Backend, bench_backend_from_cfg};
-pub use bench_crate::BenchCrate;
+pub use bench_crate::{BenchCrate, BenchCrateKind};
+pub use error::SpecParseError;
+pub use measured::{MeasuredId, Statistic, measured_name};
 use serde::{Deserialize, Serialize};
 use std::fs::{File, OpenOptions};
 use std::io::Write;
@@ -160,7 +165,7 @@ pub enum BenchmarkType {
 }
 
 /// The metric being recorded by a benchmark, used in [`BenchmarkSpec`].
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum BenchmarkMetric {
     Latency,
     Throughput,
@@ -220,20 +225,49 @@ pub fn get_bench_type() -> BenchmarkType {
 /// ```text
 /// {crate}::{layer}::{bench}::{op}(::{backend})?(::{benchmark_type})?::{param}(::scalar)?(::{type})?(::{num_elements}_elements)?
 /// ```
+#[derive(Debug)]
 pub struct BenchmarkSpec {
     bench_crate: BenchCrate,
     backend: Backend,
     param_name: String,
     operand_type: OperandType,
     type_name: Option<String>,
-    bench_type: BenchmarkMetric,
+    metric: BenchmarkMetric,
     num_elements: Option<usize>,
 }
 
 impl BenchmarkSpec {
+    /// The benchmarked operation, as a path (`tfhe::hlapi::ops::add`).
+    pub fn bench_crate(&self) -> BenchCrate {
+        self.bench_crate
+    }
+
     /// The parameter set name (from `NamedParam::name()`).
     pub fn param_name(&self) -> &str {
         &self.param_name
+    }
+
+    /// What the recorded value is: a duration, a rate, a count or a byte size.
+    pub fn metric(&self) -> BenchmarkMetric {
+        self.metric
+    }
+
+    /// Whether the second operand is a plaintext (a `scalar` benchmark).
+    pub fn operand_type(&self) -> OperandType {
+        self.operand_type
+    }
+
+    /// The type tag, rendered. Still a flat string: it carries a Rust type, a
+    /// precision, a key/value pair or a keyswitch config depending on the
+    /// benchmark, so callers have to interpret it.
+    pub fn type_name(&self) -> Option<&str> {
+        self.type_name.as_deref()
+    }
+
+    /// `Some` when the id ends with an `<n>_elements` segment: batch size for a
+    /// throughput benchmark, store size for a KV-store one.
+    pub fn num_elements(&self) -> Option<usize> {
+        self.num_elements
     }
 
     pub fn new(
@@ -251,7 +285,7 @@ impl BenchmarkSpec {
             param_name: param_name.to_string(),
             operand_type,
             type_name: type_name.map(|t| t.type_name()),
-            bench_type: bench_type.into(),
+            metric: bench_type.into(),
             num_elements,
         }
     }
@@ -269,7 +303,7 @@ impl BenchmarkSpec {
             param_name: param_name.to_string(),
             operand_type,
             type_name: type_name.map(|t| t.type_name()),
-            bench_type: bench_type.into(),
+            metric: bench_type.into(),
             num_elements: None,
         }
     }
@@ -288,7 +322,7 @@ impl BenchmarkSpec {
             param_name: param_name.to_string(),
             operand_type,
             type_name: type_name.map(|t| t.type_name()),
-            bench_type: bench_type.into(),
+            metric: bench_type.into(),
             num_elements,
         }
     }
@@ -306,7 +340,7 @@ impl BenchmarkSpec {
             param_name: param_name.to_string(),
             operand_type: OperandType::CipherText,
             type_name: type_name.map(|t| t.type_name()),
-            bench_type: bench_type.into(),
+            metric: bench_type.into(),
             num_elements,
         }
     }
@@ -324,7 +358,7 @@ impl BenchmarkSpec {
             param_name: param_name.to_string(),
             operand_type: OperandType::CipherText,
             type_name: type_name.map(|t| t.type_name()),
-            bench_type: bench_type.into(),
+            metric: bench_type.into(),
             num_elements,
         }
     }
@@ -340,7 +374,7 @@ impl BenchmarkSpec {
             param_name: param_name.to_string(),
             operand_type: OperandType::CipherText,
             type_name: None,
-            bench_type: bench_type.into(),
+            metric: bench_type.into(),
             num_elements: None,
         }
     }
@@ -356,7 +390,7 @@ impl BenchmarkSpec {
             param_name: param_name.to_string(),
             operand_type: OperandType::CipherText,
             type_name: None,
-            bench_type: bench_type.into(),
+            metric: bench_type.into(),
             num_elements: None,
         }
     }
@@ -372,7 +406,7 @@ impl BenchmarkSpec {
             param_name: param_name.to_string(),
             operand_type: OperandType::CipherText,
             type_name: None,
-            bench_type: bench_type.into(),
+            metric: bench_type.into(),
             num_elements: None,
         }
     }
@@ -389,7 +423,7 @@ impl BenchmarkSpec {
             param_name: param_name.to_string(),
             operand_type: OperandType::CipherText,
             type_name: type_name.map(|t| t.type_name()),
-            bench_type: bench_type.into(),
+            metric: bench_type.into(),
             num_elements: None,
         }
     }
@@ -405,7 +439,7 @@ impl BenchmarkSpec {
             param_name: param_name.to_string(),
             operand_type: OperandType::CipherText,
             type_name: None,
-            bench_type: bench_type.into(),
+            metric: bench_type.into(),
             num_elements: None,
         }
     }
@@ -422,7 +456,7 @@ impl BenchmarkSpec {
             param_name: String::new(),
             operand_type: OperandType::CipherText,
             type_name: None,
-            bench_type: bench_type.into(),
+            metric: bench_type.into(),
             num_elements,
         }
     }
@@ -430,11 +464,11 @@ impl BenchmarkSpec {
 
 impl fmt::Display for BenchmarkSpec {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.bench_crate.fmt_crate(f)?;
+        write!(f, "{}", self.bench_crate)?;
         if !matches!(self.backend, Backend::Cpu) {
             write!(f, "::{}", self.backend)?;
         }
-        match self.bench_type {
+        match self.metric {
             BenchmarkMetric::Throughput => write!(f, "::throughput")?,
             BenchmarkMetric::PbsCount => write!(f, "::pbs_count")?,
             BenchmarkMetric::KeySize => write!(f, "::key_size")?,

--- a/utils/benchmark_spec/src/measured.rs
+++ b/utils/benchmark_spec/src/measured.rs
@@ -1,0 +1,145 @@
+//! The name a benchmark result is stored under:
+//!
+//! ```text
+//! {bench_id}_{statistic}(_{variant})?
+//! ```
+
+use std::fmt;
+use std::str::FromStr;
+
+use strum::{Display, EnumString};
+
+use crate::BenchmarkSpec;
+use crate::error::SpecParseError;
+
+/// Which statistic of a criterion estimate a stored value holds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Display, EnumString)]
+#[strum(serialize_all = "snake_case")]
+pub enum Statistic {
+    Mean,
+    StdDev,
+}
+
+impl Statistic {
+    fn marker(self) -> &'static str {
+        match self {
+            Self::Mean => "_mean",
+            Self::StdDev => "_std_dev",
+        }
+    }
+}
+
+/// Composes the name a result is stored under.
+///
+/// Takes the bench id as a string, not a [`BenchmarkSpec`]: results are written
+/// for every benchmark, including those whose id predates the spec grammar.
+pub fn measured_name(bench_id: &str, statistic: Statistic, variant: Option<&str>) -> String {
+    let mut name = format!("{bench_id}{}", statistic.marker());
+    if let Some(variant) = variant.filter(|v| !v.is_empty()) {
+        name.push('_');
+        name.push_str(variant);
+    }
+    name
+}
+
+/// A stored result name, parsed back into its parts.
+#[derive(Debug)]
+pub struct MeasuredId {
+    pub spec: BenchmarkSpec,
+    pub statistic: Statistic,
+    /// Run flavour: `avx512`, `regression`, or a compound string built by a
+    /// workflow. Free-form; only ever handled as a whole.
+    pub variant: Option<String>,
+}
+
+impl fmt::Display for MeasuredId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&measured_name(
+            &self.spec.to_string(),
+            self.statistic,
+            self.variant.as_deref(),
+        ))
+    }
+}
+
+impl FromStr for MeasuredId {
+    type Err = SpecParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (bench_id, statistic, rest) = split_statistic(s)
+            .ok_or_else(|| SpecParseError::Unknown(format!("no statistic in {s:?}")))?;
+
+        Ok(Self {
+            spec: bench_id.parse()?,
+            statistic,
+            variant: match rest.strip_prefix('_') {
+                Some(variant) if !variant.is_empty() => Some(variant.to_string()),
+                _ => None,
+            },
+        })
+    }
+}
+
+/// Splits a stored name around its statistic marker.
+///
+/// Uses the first marker, not the last: parameter aliases are uppercase so they
+/// cannot hold one, but a variant can (`_chrome_mean`) and belongs to the tail.
+fn split_statistic(s: &str) -> Option<(&str, Statistic, &str)> {
+    [Statistic::Mean, Statistic::StdDev]
+        .into_iter()
+        .filter_map(|statistic| s.find(statistic.marker()).map(|at| (at, statistic)))
+        .min_by_key(|(at, _)| *at)
+        .map(|(at, statistic)| (&s[..at], statistic, &s[at + statistic.marker().len()..]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip() {
+        let names = [
+            "tfhe::shortint::ops::add::PARAM_MESSAGE_2_CARRY_2_KS_PBS_mean_avx512",
+            "tfhe::shortint::ops::add::PARAM_MESSAGE_2_CARRY_2_KS_PBS_std_dev_avx512",
+            // No variant: the parser's default is an empty suffix (`cli.rs:50`).
+            "tfhe::hlapi::ops::add::PARAM_MESSAGE_2_CARRY_2::FheUint64_mean",
+            // A workflow-built compound variant stays opaque.
+            "tfhe::hlapi::ops::add::PARAM_MESSAGE_2_CARRY_2::FheUint64_mean_batch_size_4-schedule_fifo",
+        ];
+        for name in names {
+            let id: MeasuredId = name
+                .parse()
+                .unwrap_or_else(|e| panic!("parse {name:?}: {e:?}"));
+            assert_eq!(id.to_string(), name, "round-trip mismatch");
+        }
+    }
+
+    #[test]
+    fn display_matches_the_writer() {
+        let id: MeasuredId = "tfhe::shortint::ops::add::PARAM_MESSAGE_2_CARRY_2_KS_PBS_mean_avx512"
+            .parse()
+            .unwrap();
+        assert_eq!(
+            id.to_string(),
+            measured_name(&id.spec.to_string(), Statistic::Mean, Some("avx512"))
+        );
+    }
+
+    /// `marker()` is a hand-written mirror of the strum name, so that splitting
+    /// needs no allocation. This keeps the two from drifting.
+    #[test]
+    fn markers_match_the_strum_names() {
+        for statistic in [Statistic::Mean, Statistic::StdDev] {
+            assert_eq!(statistic.marker(), format!("_{statistic}"));
+        }
+    }
+
+    #[test]
+    fn a_variant_holding_a_marker_stays_in_the_tail() {
+        let id: MeasuredId = "tfhe::shortint::ops::add::PARAM_2_mean_chrome_mean"
+            .parse()
+            .unwrap();
+        assert_eq!(id.statistic, Statistic::Mean);
+        assert_eq!(id.variant.as_deref(), Some("chrome_mean"));
+    }
+}

--- a/utils/benchmark_spec/src/parse.rs
+++ b/utils/benchmark_spec/src/parse.rs
@@ -1,0 +1,160 @@
+//! Bench-id parsing: the inverse of [`BenchmarkSpec`]'s `Display`.
+
+use std::str::FromStr;
+
+use crate::error::SpecParseError;
+use crate::{Backend, BenchCrate, BenchmarkMetric, BenchmarkSpec, OperandType};
+
+/// Parses a full benchmark id back into a [`BenchmarkSpec`], following the
+/// grammar produced by its `Display`:
+///
+/// ```text
+/// {crate::layer::bench}(::{backend})?(::{metric})?::{param}(::scalar)?(::{type})?(::{n}_elements)?
+/// ```
+impl FromStr for BenchmarkSpec {
+    type Err = SpecParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // The bench path is the longest `::`-prefix that parses; everything after
+        // is the positional trailing (backend / metric / param / …).
+        let (bench_crate, trailing) = split_bench_path(s)
+            .ok_or_else(|| SpecParseError::Unknown(format!("no known bench path in {s:?}")))?;
+
+        let mut it = trailing.split("::").filter(|t| !t.is_empty()).peekable();
+
+        let backend = match it.peek().copied() {
+            Some("cuda") => {
+                it.next();
+                Backend::Cuda
+            }
+            Some("hpu") => {
+                it.next();
+                Backend::Hpu
+            }
+            _ => Backend::Cpu,
+        };
+
+        let metric = match it.peek().copied() {
+            Some("throughput") => {
+                it.next();
+                BenchmarkMetric::Throughput
+            }
+            Some("pbs_count") => {
+                it.next();
+                BenchmarkMetric::PbsCount
+            }
+            Some("key_size") => {
+                it.next();
+                BenchmarkMetric::KeySize
+            }
+            _ => BenchmarkMetric::Latency,
+        };
+
+        // `zk` benches carry no parameter set: `Display` skips the segment
+        // altogether, so there is nothing to consume here.
+        let param_name = if matches!(bench_crate, BenchCrate::Zk(_)) {
+            String::new()
+        } else {
+            it.next()
+                .ok_or_else(|| SpecParseError::Unknown(format!("missing param in {s:?}")))?
+                .to_string()
+        };
+
+        let operand_type = if it.peek().copied() == Some("scalar") {
+            it.next();
+            OperandType::PlainText
+        } else {
+            OperandType::CipherText
+        };
+
+        // Remaining tokens: the optional `<n>_elements` marker is always last;
+        // anything before it is the type name (which may itself span several
+        // `::` segments, e.g. `key_x::value_y`).
+        let rest: Vec<&str> = it.collect();
+        let (type_toks, num_elements) = match rest.last().and_then(|t| parse_elements(t)) {
+            Some(n) => (&rest[..rest.len() - 1], Some(n)),
+            None => (&rest[..], None),
+        };
+        let type_name = (!type_toks.is_empty()).then(|| type_toks.join("::"));
+
+        Ok(BenchmarkSpec {
+            bench_crate,
+            backend,
+            param_name,
+            operand_type,
+            type_name,
+            metric,
+            num_elements,
+        })
+    }
+}
+
+/// `<n>_elements` -> `n`.
+fn parse_elements(tok: &str) -> Option<usize> {
+    tok.strip_suffix("_elements")?.parse().ok()
+}
+
+/// Longest `::`-prefix of `s` that parses as a [`BenchCrate`], plus the rest.
+fn split_bench_path(s: &str) -> Option<(BenchCrate, &str)> {
+    let mut end = s.len();
+    loop {
+        let prefix = &s[..end];
+        if let Ok(bc) = prefix.parse::<BenchCrate>() {
+            return Some((bc, s[end..].trim_start_matches("::")));
+        }
+        end = prefix.rfind("::")?;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `zk` ids carry no parameter set, so the id is built from the spec rather
+    /// than spelled out.
+    #[test]
+    fn roundtrip_zk_id() {
+        use crate::zk::msm::{MsmBench, MsmFlavor};
+
+        let id = BenchmarkSpec::new_zk_msm(
+            MsmBench::G1(MsmFlavor::Bls12_446),
+            Backend::Cuda,
+            BenchmarkMetric::Latency,
+            Some(10),
+        )
+        .to_string();
+
+        let parsed: BenchmarkSpec = id.parse().unwrap_or_else(|e| panic!("parse {id:?}: {e:?}"));
+        assert_eq!(parsed.to_string(), id, "round-trip mismatch");
+    }
+
+    #[test]
+    fn roundtrip_ids() {
+        let ids = [
+            "tfhe::shortint::ops::add::PARAM_MESSAGE_2_CARRY_2_KS_PBS",
+            "tfhe::hlapi::ops::mul::cuda::PARAM_MESSAGE_2_CARRY_2::FheUint128",
+            "tfhe::hlapi::ops::add::hpu::throughput::PARAM_MESSAGE_2_CARRY_2::FheUint64",
+            "tfhe::hlapi::ops::left_shift::PARAM_MESSAGE_2_CARRY_2::scalar::FheUint64",
+            "tfhe::hlapi::erc7984::transfer::whitepaper::PARAM_MESSAGE_2_CARRY_2::10_elements",
+            "tfhe::hlapi::dex::swap_claim::no_cmux::cuda::throughput::PARAM_MESSAGE_2_CARRY_2::FheUint64::10_elements",
+            // Multi-segment type names: everything between the param and the
+            // trailing `_elements` marker belongs to the type name.
+            "tfhe::hlapi::kv_store::get::PARAM_MESSAGE_2_CARRY_2::key_FheUint32::value_FheUint64",
+            "tfhe::core_crypto::keyswitch::cuda::PARAM_MESSAGE_2_CARRY_2::64b::gemm::trivial_indices",
+        ];
+        for id in ids {
+            let spec: BenchmarkSpec = id.parse().unwrap_or_else(|e| panic!("parse {id:?}: {e:?}"));
+            assert_eq!(spec.to_string(), id, "round-trip mismatch");
+        }
+    }
+
+    #[test]
+    fn unknown_bench_path_is_rejected() {
+        // Legacy id (no crate prefix, `integer::` straight away).
+        assert!(
+            "integer::add::PARAM_MESSAGE_2_CARRY_2::64_bits"
+                .parse::<BenchmarkSpec>()
+                .is_err()
+        );
+    }
+}

--- a/utils/benchmark_spec/src/tfhe/boolean.rs
+++ b/utils/benchmark_spec/src/tfhe/boolean.rs
@@ -1,8 +1,8 @@
-use strum::Display;
+use strum::{Display, EnumString};
 
 use crate::traits::SpecLeafNode;
 
-#[derive(Debug, Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, Display, EnumString, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
 pub enum BooleanBench {
     And,

--- a/utils/benchmark_spec/src/tfhe/core_crypto/mod.rs
+++ b/utils/benchmark_spec/src/tfhe/core_crypto/mod.rs
@@ -1,8 +1,8 @@
-use strum::Display;
+use strum::{Display, EnumString};
 
 use crate::traits::SpecLeafNode;
 
-#[derive(Debug, Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, Display, EnumString, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
 pub enum CoreCryptoBench {
     // ks_bench.rs

--- a/utils/benchmark_spec/src/tfhe/hl_integer_op.rs
+++ b/utils/benchmark_spec/src/tfhe/hl_integer_op.rs
@@ -1,9 +1,9 @@
-use strum::Display;
+use strum::{Display, EnumString};
 
 use crate::traits::SpecLeafNode;
 
 /// Atomic operations shared across layers (hlapi, integer...).
-#[derive(Debug, Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, Display, EnumString, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
 pub enum HlIntegerOp {
     Add,

--- a/utils/benchmark_spec/src/tfhe/hlapi/dex.rs
+++ b/utils/benchmark_spec/src/tfhe/hlapi/dex.rs
@@ -1,10 +1,18 @@
-use strum::Display;
+use std::str::FromStr;
 
+use strum::{Display, EnumDiscriminants, EnumString};
+
+use crate::error::SpecParseError;
 use crate::traits::{SpecLeafNode, SpecNode};
 
 /// DEX (decentralized exchange) benchmark operations for the HLAPI layer.
-#[derive(Debug, Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, Display, EnumDiscriminants, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
+#[strum_discriminants(
+    name(DexKind),
+    derive(EnumString, Display),
+    strum(serialize_all = "snake_case")
+)]
 pub enum Dex {
     SwapRequest(DexFlavor),
     SwapClaim(DexFlavor),
@@ -19,7 +27,21 @@ impl SpecNode for Dex {
     }
 }
 
-#[derive(Debug, Clone, Copy, Display)]
+impl FromStr for Dex {
+    type Err = SpecParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (head, rest) = s.split_once("::").unwrap_or((s, ""));
+        match DexKind::from_str(head)
+            .map_err(|_| SpecParseError::Unknown(format!("unknown dex op: {head}")))?
+        {
+            DexKind::SwapRequest => Ok(Self::SwapRequest(rest.parse()?)),
+            DexKind::SwapClaim => Ok(Self::SwapClaim(rest.parse()?)),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Display, EnumString, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
 pub enum DexFlavor {
     Whitepaper,

--- a/utils/benchmark_spec/src/tfhe/hlapi/erc7984.rs
+++ b/utils/benchmark_spec/src/tfhe/hlapi/erc7984.rs
@@ -1,10 +1,18 @@
-use strum::Display;
+use std::str::FromStr;
 
+use strum::{Display, EnumDiscriminants, EnumString};
+
+use crate::error::SpecParseError;
 use crate::traits::{SpecLeafNode, SpecNode};
 
 /// ERC-7984 token transfer benchmark operations for the HLAPI layer.
-#[derive(Debug, Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, Display, EnumDiscriminants, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
+#[strum_discriminants(
+    name(Erc7984Kind),
+    derive(EnumString, Display),
+    strum(serialize_all = "snake_case")
+)]
 pub enum Erc7984 {
     Transfer(TransferFlavor),
 }
@@ -17,7 +25,20 @@ impl SpecNode for Erc7984 {
     }
 }
 
-#[derive(Debug, Clone, Copy, Display)]
+impl FromStr for Erc7984 {
+    type Err = SpecParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (head, rest) = s.split_once("::").unwrap_or((s, ""));
+        match Erc7984Kind::from_str(head)
+            .map_err(|_| SpecParseError::Unknown(format!("unknown erc7984 op: {head}")))?
+        {
+            Erc7984Kind::Transfer => Ok(Self::Transfer(rest.parse()?)),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Display, EnumString, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
 pub enum TransferFlavor {
     Whitepaper,

--- a/utils/benchmark_spec/src/tfhe/hlapi/kv_store.rs
+++ b/utils/benchmark_spec/src/tfhe/hlapi/kv_store.rs
@@ -1,9 +1,9 @@
-use strum::Display;
+use strum::{Display, EnumString};
 
 use crate::traits::SpecLeafNode;
 
 /// KV store benchmark operations for the HLAPI layer.
-#[derive(Debug, Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Display, EnumString, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
 pub enum KvStoreOp {
     ContainsKey,

--- a/utils/benchmark_spec/src/tfhe/hlapi/mod.rs
+++ b/utils/benchmark_spec/src/tfhe/hlapi/mod.rs
@@ -5,14 +5,17 @@ pub mod noise_squash;
 pub mod oprf;
 pub mod vector_find;
 
+use std::str::FromStr;
+
 use dex::Dex;
 use erc7984::Erc7984;
 use kv_store::KvStoreOp;
 use noise_squash::NoiseSquashingKind;
 use oprf::OprfKind;
-use strum::Display;
+use strum::{Display, EnumDiscriminants, EnumString};
 use vector_find::VectorFindOp;
 
+use crate::error::SpecParseError;
 use crate::traits::SpecNode;
 
 pub use super::hl_integer_op::HlIntegerOp;
@@ -24,8 +27,13 @@ pub use super::hl_integer_op::HlIntegerOp;
 /// 1. Add the variant here (strum handles the name)
 /// 2. Add a match arm in `child()` returning the inner op as `&dyn SpecNode` (a leaf op enum just
 ///    needs `impl SpecNode for X {}`).
-#[derive(Debug, Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, Display, EnumDiscriminants, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
+#[strum_discriminants(
+    name(HlapiBenchKind),
+    derive(EnumString, Display),
+    strum(serialize_all = "snake_case")
+)]
 pub enum HlapiBench {
     Ops(HlIntegerOp),
     Erc7984(Erc7984),
@@ -47,5 +55,24 @@ impl SpecNode for HlapiBench {
             HlapiBench::Oprf(op) => op,
             HlapiBench::VectorFind(op) => op,
         })
+    }
+}
+
+impl FromStr for HlapiBench {
+    type Err = SpecParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (head, rest) = s.split_once("::").unwrap_or((s, ""));
+        match HlapiBenchKind::from_str(head)
+            .map_err(|_| SpecParseError::Unknown(format!("Unknown layer: {head}")))?
+        {
+            HlapiBenchKind::Ops => Ok(Self::Ops(rest.parse()?)),
+            HlapiBenchKind::Erc7984 => Ok(Self::Erc7984(rest.parse()?)),
+            HlapiBenchKind::Dex => Ok(Self::Dex(rest.parse()?)),
+            HlapiBenchKind::KvStore => Ok(Self::KvStore(rest.parse()?)),
+            HlapiBenchKind::NoiseSquashing => Ok(Self::NoiseSquashing(rest.parse()?)),
+            HlapiBenchKind::Oprf => Ok(Self::Oprf(rest.parse()?)),
+            HlapiBenchKind::VectorFind => Ok(Self::VectorFind(rest.parse()?)),
+        }
     }
 }

--- a/utils/benchmark_spec/src/tfhe/hlapi/noise_squash.rs
+++ b/utils/benchmark_spec/src/tfhe/hlapi/noise_squash.rs
@@ -1,8 +1,8 @@
-use strum::Display;
+use strum::{Display, EnumString};
 
 use crate::traits::SpecLeafNode;
 
-#[derive(Debug, Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, Display, EnumString, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
 pub enum NoiseSquashingKind {
     NoiseSquash,

--- a/utils/benchmark_spec/src/tfhe/hlapi/oprf.rs
+++ b/utils/benchmark_spec/src/tfhe/hlapi/oprf.rs
@@ -1,8 +1,8 @@
-use strum::Display;
+use strum::{Display, EnumString};
 
 use crate::traits::SpecLeafNode;
 
-#[derive(Debug, Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, Display, EnumString, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
 pub enum OprfKind {
     AnyRange,

--- a/utils/benchmark_spec/src/tfhe/hlapi/vector_find.rs
+++ b/utils/benchmark_spec/src/tfhe/hlapi/vector_find.rs
@@ -1,8 +1,8 @@
-use strum::Display;
+use strum::{Display, EnumString};
 
 use crate::traits::SpecLeafNode;
 
-#[derive(Debug, Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, Display, EnumString, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
 pub enum VectorFindOp {
     Contains,

--- a/utils/benchmark_spec/src/tfhe/integer/mod.rs
+++ b/utils/benchmark_spec/src/tfhe/integer/mod.rs
@@ -1,12 +1,19 @@
 pub mod ops;
 
-use ops::IntegerOp;
-use strum::Display;
+use std::str::FromStr;
 
+use crate::error::SpecParseError;
 use crate::traits::{SpecLeafNode, SpecNode};
+use ops::IntegerOp;
+use strum::{Display, EnumDiscriminants, EnumString};
 
-#[derive(Debug, Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, Display, EnumDiscriminants, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
+#[strum_discriminants(
+    name(IntegerOpBySignKind),
+    derive(EnumString, Display),
+    strum(serialize_all = "snake_case")
+)]
 pub enum IntegerOpBySign {
     Unsigned(IntegerOp),
     Signed(IntegerOp),
@@ -21,7 +28,7 @@ impl SpecNode for IntegerOpBySign {
 }
 
 /// GLWE packing-compression operations (integer layer).
-#[derive(Debug, Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, Display, EnumString, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
 pub enum IntegerPackingOp {
     Pack,
@@ -31,7 +38,7 @@ pub enum IntegerPackingOp {
 impl SpecLeafNode for IntegerPackingOp {}
 
 /// Oblivious PRF flavors (integer layer).
-#[derive(Debug, Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, Display, EnumString, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
 pub enum IntegerOprf {
     Unsigned,
@@ -41,7 +48,7 @@ pub enum IntegerOprf {
 impl SpecLeafNode for IntegerOprf {}
 
 /// Re-randomization modes.
-#[derive(Debug, Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, Display, EnumString, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
 pub enum IntegerRerandMode {
     LegacyKeyswitch,
@@ -50,8 +57,27 @@ pub enum IntegerRerandMode {
 
 impl SpecLeafNode for IntegerRerandMode {}
 
-#[derive(Debug, Clone, Copy, Display)]
+impl FromStr for IntegerOpBySign {
+    type Err = SpecParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (head, rest) = s.split_once("::").unwrap_or((s, ""));
+        match IntegerOpBySignKind::from_str(head)
+            .map_err(|_| SpecParseError::Unknown(format!("unknown integer signedness: {head}")))?
+        {
+            IntegerOpBySignKind::Unsigned => Ok(Self::Unsigned(rest.parse()?)),
+            IntegerOpBySignKind::Signed => Ok(Self::Signed(rest.parse()?)),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Display, EnumDiscriminants, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
+#[strum_discriminants(
+    name(IntegerBenchKind),
+    derive(EnumString, Display),
+    strum(serialize_all = "snake_case")
+)]
 pub enum IntegerBench {
     Ops(IntegerOpBySign),
     PackingCompression(IntegerPackingOp),
@@ -67,5 +93,21 @@ impl SpecNode for IntegerBench {
             IntegerBench::Oprf(kind) => kind,
             IntegerBench::Rerand(mode) => mode,
         })
+    }
+}
+
+impl FromStr for IntegerBench {
+    type Err = SpecParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (head, rest) = s.split_once("::").unwrap_or((s, ""));
+        match IntegerBenchKind::from_str(head)
+            .map_err(|_| SpecParseError::Unknown(format!("unknown integer bench: {head}")))?
+        {
+            IntegerBenchKind::Ops => Ok(Self::Ops(rest.parse()?)),
+            IntegerBenchKind::PackingCompression => Ok(Self::PackingCompression(rest.parse()?)),
+            IntegerBenchKind::Oprf => Ok(Self::Oprf(rest.parse()?)),
+            IntegerBenchKind::Rerand => Ok(Self::Rerand(rest.parse()?)),
+        }
     }
 }

--- a/utils/benchmark_spec/src/tfhe/integer/ops.rs
+++ b/utils/benchmark_spec/src/tfhe/integer/ops.rs
@@ -1,8 +1,8 @@
-use strum::Display;
+use strum::{Display, EnumString};
 
 use crate::traits::SpecLeafNode;
 
-#[derive(Debug, Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Display, EnumString, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
 pub enum IntegerOp {
     Abs,

--- a/utils/benchmark_spec/src/tfhe/mod.rs
+++ b/utils/benchmark_spec/src/tfhe/mod.rs
@@ -6,8 +6,11 @@ pub mod integer;
 pub mod shortint;
 pub mod transciphering;
 
-use strum::Display;
+use std::str::FromStr;
 
+use strum::{Display, EnumDiscriminants, EnumString};
+
+use crate::error::SpecParseError;
 use crate::traits::SpecNode;
 
 pub use boolean::BooleanBench;
@@ -28,8 +31,13 @@ pub use transciphering::TranscipheringBench;
 /// 1. Add the variant here (strum handles the name)
 /// 2. Add a match arm in `child()` returning the inner type as `&dyn SpecNode` (the inner type must
 ///    implement `SpecNode`).
-#[derive(Debug, Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, Display, EnumDiscriminants, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
+#[strum_discriminants(
+    name(TfheLayerKind),
+    derive(EnumString, Display),
+    strum(serialize_all = "snake_case")
+)]
 pub enum TfheLayer {
     Boolean(BooleanBench),
     CoreCrypto(CoreCryptoBench),
@@ -49,5 +57,23 @@ impl SpecNode for TfheLayer {
             TfheLayer::Transciphering(bench) => bench,
             TfheLayer::Integer(bench) => bench,
         })
+    }
+}
+
+impl FromStr for TfheLayer {
+    type Err = SpecParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (head, rest) = s.split_once("::").unwrap_or((s, ""));
+        match TfheLayerKind::from_str(head)
+            .map_err(|_| SpecParseError::Unknown(format!("unknown tfhe layer: {head}")))?
+        {
+            TfheLayerKind::Shortint => Ok(Self::Shortint(rest.parse()?)),
+            TfheLayerKind::Hlapi => Ok(Self::Hlapi(rest.parse()?)),
+            TfheLayerKind::CoreCrypto => Ok(Self::CoreCrypto(rest.parse()?)),
+            TfheLayerKind::Boolean => Ok(Self::Boolean(rest.parse()?)),
+            TfheLayerKind::Integer => Ok(Self::Integer(rest.parse()?)),
+            TfheLayerKind::Transciphering => Ok(Self::Transciphering(rest.parse()?)),
+        }
     }
 }

--- a/utils/benchmark_spec/src/tfhe/shortint/mod.rs
+++ b/utils/benchmark_spec/src/tfhe/shortint/mod.rs
@@ -1,12 +1,15 @@
 pub mod ops;
 
-use ops::ShortintOp;
-use strum::Display;
+use std::str::FromStr;
 
+use ops::ShortintOp;
+use strum::{Display, EnumDiscriminants, EnumString};
+
+use crate::error::SpecParseError;
 use crate::traits::{SpecLeafNode, SpecNode};
 
 /// Casting operations between shortint parameter sets.
-#[derive(Debug, Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, Display, EnumString, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
 pub enum ShortintCastingOp {
     Cast,
@@ -17,7 +20,7 @@ pub enum ShortintCastingOp {
 impl SpecLeafNode for ShortintCastingOp {}
 
 /// GLWE packing-compression operations.
-#[derive(Debug, Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, Display, EnumString, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
 pub enum ShortintPackingOp {
     Pack,
@@ -30,12 +33,15 @@ pub enum ShortintPackingOp {
 
 impl SpecLeafNode for ShortintPackingOp {}
 
-/// Benchmarks of the `shortint` layer.
-///
-/// Mixed node: `Ops`/`Casting`/`PackingCompression` carry an inner leaf (a
-/// child in the spec tree), while the remaining variants are leaves themselves.
-#[derive(Debug, Clone, Copy, Display)]
+/// Benchmarks of the `shortint` layer. Mixed node: `Ops`, `Casting` and
+/// `PackingCompression` carry a child, the other variants are leaves.
+#[derive(Debug, Clone, Copy, Display, EnumDiscriminants, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
+#[strum_discriminants(
+    name(ShortintBenchKind),
+    derive(EnumString, Display),
+    strum(serialize_all = "snake_case")
+)]
 pub enum ShortintBench {
     Ops(ShortintOp),
     Casting(ShortintCastingOp),
@@ -59,6 +65,31 @@ impl SpecNode for ShortintBench {
             | ShortintBench::ProgrammableBootstrap
             | ShortintBench::UncompressKey
             | ShortintBench::DecompNoiseSquashComp => None,
+        }
+    }
+}
+
+impl FromStr for ShortintBench {
+    type Err = SpecParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (head, rest) = s.split_once("::").unwrap_or((s, ""));
+        let kind = ShortintBenchKind::from_str(head)
+            .map_err(|_| SpecParseError::Unknown(format!("unknown shortint bench: {head}")))?;
+        match kind {
+            ShortintBenchKind::Ops => Ok(Self::Ops(rest.parse()?)),
+            ShortintBenchKind::Casting => Ok(Self::Casting(rest.parse()?)),
+            ShortintBenchKind::PackingCompression => Ok(Self::PackingCompression(rest.parse()?)),
+            // Leaf variants close the bench path: what follows belongs to the
+            // trailing part of the id, not to this node.
+            _ if !rest.is_empty() => Err(SpecParseError::Unknown(format!(
+                "unexpected {rest:?} after shortint bench {head}"
+            ))),
+            ShortintBenchKind::Oprf => Ok(Self::Oprf),
+            ShortintBenchKind::CarryExtract => Ok(Self::CarryExtract),
+            ShortintBenchKind::ProgrammableBootstrap => Ok(Self::ProgrammableBootstrap),
+            ShortintBenchKind::UncompressKey => Ok(Self::UncompressKey),
+            ShortintBenchKind::DecompNoiseSquashComp => Ok(Self::DecompNoiseSquashComp),
         }
     }
 }

--- a/utils/benchmark_spec/src/tfhe/shortint/ops.rs
+++ b/utils/benchmark_spec/src/tfhe/shortint/ops.rs
@@ -1,9 +1,9 @@
-use strum::Display;
+use strum::{Display, EnumString};
 
 use crate::traits::SpecLeafNode;
 
 /// Shortint server-key operations (unary, binary and scalar variants).
-#[derive(Debug, Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, Display, EnumString, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
 pub enum ShortintOp {
     // Unary ops

--- a/utils/benchmark_spec/src/tfhe/transciphering/aes.rs
+++ b/utils/benchmark_spec/src/tfhe/transciphering/aes.rs
@@ -1,8 +1,8 @@
-use strum::Display;
+use strum::{Display, EnumString};
 
 use crate::traits::SpecLeafNode;
 
-#[derive(Debug, Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, Display, EnumString, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
 pub enum AesFlavor {
     KeyExpansion,

--- a/utils/benchmark_spec/src/tfhe/transciphering/kreyvium.rs
+++ b/utils/benchmark_spec/src/tfhe/transciphering/kreyvium.rs
@@ -1,8 +1,8 @@
-use strum::Display;
+use strum::{Display, EnumString};
 
 use crate::traits::SpecLeafNode;
 
-#[derive(Debug, Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, Display, EnumString, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
 pub enum KreyviumFlavor {
     Warmup,

--- a/utils/benchmark_spec/src/tfhe/transciphering/mod.rs
+++ b/utils/benchmark_spec/src/tfhe/transciphering/mod.rs
@@ -1,14 +1,22 @@
-use strum::Display;
+use std::str::FromStr;
+
+use strum::{Display, EnumDiscriminants, EnumString};
 
 pub mod aes;
 pub mod kreyvium;
 
+use crate::error::SpecParseError;
 use crate::traits::SpecNode;
 use aes::AesFlavor;
 use kreyvium::KreyviumFlavor;
 
-#[derive(Debug, Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, Display, EnumDiscriminants, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
+#[strum_discriminants(
+    name(TranscipheringBenchKind),
+    derive(EnumString, Display),
+    strum(serialize_all = "snake_case")
+)]
 pub enum TranscipheringBench {
     Aes(AesFlavor),
     Kreyvium(KreyviumFlavor),
@@ -20,5 +28,19 @@ impl SpecNode for TranscipheringBench {
             TranscipheringBench::Aes(op) => op,
             TranscipheringBench::Kreyvium(op) => op,
         })
+    }
+}
+
+impl FromStr for TranscipheringBench {
+    type Err = SpecParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (head, rest) = s.split_once("::").unwrap_or((s, ""));
+        match TranscipheringBenchKind::from_str(head)
+            .map_err(|_| SpecParseError::Unknown(format!("unknown transciphering bench: {head}")))?
+        {
+            TranscipheringBenchKind::Aes => Ok(Self::Aes(rest.parse()?)),
+            TranscipheringBenchKind::Kreyvium => Ok(Self::Kreyvium(rest.parse()?)),
+        }
     }
 }

--- a/utils/benchmark_spec/src/zk/mod.rs
+++ b/utils/benchmark_spec/src/zk/mod.rs
@@ -1,12 +1,20 @@
 pub mod msm;
 
-use strum::Display;
+use std::str::FromStr;
 
+use strum::{Display, EnumDiscriminants, EnumString};
+
+use crate::error::SpecParseError;
 use crate::traits::SpecNode;
 use msm::MsmBench;
 
-#[derive(Debug, Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, Display, EnumDiscriminants, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
+#[strum_discriminants(
+    name(ZkLayerKind),
+    derive(EnumString, Display),
+    strum(serialize_all = "snake_case")
+)]
 pub enum ZkLayer {
     Msm(MsmBench),
 }
@@ -16,5 +24,18 @@ impl SpecNode for ZkLayer {
         Some(match self {
             ZkLayer::Msm(bench) => bench,
         })
+    }
+}
+
+impl FromStr for ZkLayer {
+    type Err = SpecParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (head, rest) = s.split_once("::").unwrap_or((s, ""));
+        match ZkLayerKind::from_str(head)
+            .map_err(|_| SpecParseError::Unknown(format!("unknown zk layer: {head}")))?
+        {
+            ZkLayerKind::Msm => Ok(Self::Msm(rest.parse()?)),
+        }
     }
 }

--- a/utils/benchmark_spec/src/zk/msm.rs
+++ b/utils/benchmark_spec/src/zk/msm.rs
@@ -1,9 +1,17 @@
-use strum::Display;
+use std::str::FromStr;
 
+use strum::{Display, EnumDiscriminants, EnumString};
+
+use crate::error::SpecParseError;
 use crate::traits::{SpecLeafNode, SpecNode};
 
-#[derive(Debug, Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, Display, EnumDiscriminants, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
+#[strum_discriminants(
+    name(MsmBenchKind),
+    derive(EnumString, Display),
+    strum(serialize_all = "snake_case")
+)]
 pub enum MsmBench {
     G1(MsmFlavor),
     G2(MsmFlavor),
@@ -18,6 +26,20 @@ impl SpecNode for MsmBench {
     }
 }
 
+impl FromStr for MsmBench {
+    type Err = SpecParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (head, rest) = s.split_once("::").unwrap_or((s, ""));
+        match MsmBenchKind::from_str(head)
+            .map_err(|_| SpecParseError::Unknown(format!("unknown msm bench: {head}")))?
+        {
+            MsmBenchKind::G1 => Ok(Self::G1(rest.parse()?)),
+            MsmBenchKind::G2 => Ok(Self::G2(rest.parse()?)),
+        }
+    }
+}
+
 impl MsmBench {
     pub fn display_name(&self) -> String {
         match self {
@@ -27,7 +49,7 @@ impl MsmBench {
     }
 }
 
-#[derive(Debug, Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, Display, EnumString, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
 pub enum MsmFlavor {
     Bls12_446,

--- a/utils/tfhe-benchmark-parser/src/parse/criterion_parser.rs
+++ b/utils/tfhe-benchmark-parser/src/parse/criterion_parser.rs
@@ -1,7 +1,7 @@
 use super::ParseOutcome;
 use super::parameters::get_parameters;
 use anyhow::{Context, Result};
-use benchmark_spec::{Backend, BenchmarkMetric};
+use benchmark_spec::{Backend, BenchmarkMetric, Statistic, measured_name};
 use serde::de::DeserializeOwned;
 use serde_json::Number;
 use std::fs;
@@ -148,8 +148,8 @@ fn process_leaf(
     };
 
     for (raw_value, stat) in [
-        (mean_value, "mean"),
-        (estimates.std_dev.point_estimate, "std_dev"),
+        (mean_value, Statistic::Mean),
+        (estimates.std_dev.point_estimate, Statistic::StdDev),
     ] {
         let Some(number) = Number::from_f64(raw_value) else {
             failures.push(ParsingFailure {
@@ -160,7 +160,7 @@ fn process_leaf(
         };
         points.push(Point {
             value: number,
-            test: join_test_name_parts(&[&test_name, stat, name_suffix]),
+            test: measured_name(&test_name, stat, Some(name_suffix)),
             name: display_name.clone(),
             class: PointClass::Evaluate,
             point_type: bench_type,
@@ -186,13 +186,4 @@ fn read_json<T: DeserializeOwned>(directory: &Path, filename: &str) -> Result<T>
     let parsed =
         serde_json::from_str(&content).with_context(|| format!("parsing {}", path.display()))?;
     Ok(parsed)
-}
-
-fn join_test_name_parts(parts: &[&str]) -> String {
-    parts
-        .iter()
-        .filter(|s| !s.is_empty())
-        .copied()
-        .collect::<Vec<_>>()
-        .join("_")
 }

--- a/utils/tfhe-data-extractor/.gitignore
+++ b/utils/tfhe-data-extractor/.gitignore
@@ -1,0 +1,1 @@
+config.toml

--- a/utils/tfhe-data-extractor/Cargo.toml
+++ b/utils/tfhe-data-extractor/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "tfhe-data-extractor"
+version = "0.1.0"
+edition = "2024"
+rust-version.workspace = true
+publish = false
+
+[dependencies]
+clap = { workspace = true }
+benchmark_spec = { path = "../benchmark_spec" }
+sqlx = { version = "0.8.6", default-features = false, features = [
+    "runtime-tokio",
+    "tls-rustls",
+    "postgres",
+    "macros",
+] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+serde = { version = "1", features = ["derive"] }
+toml = "0.8"
+anyhow = "1"
+chrono = { version = "0.4", default-features = false, features = ["std"] }

--- a/utils/tfhe-data-extractor/config.example.toml
+++ b/utils/tfhe-data-extractor/config.example.toml
@@ -1,0 +1,14 @@
+# Copy this file to `config.toml` and fill in the credentials, then pass it with
+# `--config-file config.toml`.
+#
+# Environment variables OVERRIDE any value below (matching the Python tool):
+#   DATA_EXTRACTOR_DATABASE_HOST
+#   DATA_EXTRACTOR_DATABASE_USER
+#   DATA_EXTRACTOR_DATABASE_PASSWORD
+#
+# The database name comes from the `--database` CLI flag (default: tfhe_rs).
+
+[database]
+host = ""
+user = ""
+password = ""

--- a/utils/tfhe-data-extractor/src/db.rs
+++ b/utils/tfhe-data-extractor/src/db.rs
@@ -1,0 +1,288 @@
+//! PostgreSQL access layer (read-only) for the data extractor.
+//!
+//! Credentials come from a TOML config file (`--config-file`) and/or the
+//! environment variables `DATA_EXTRACTOR_DATABASE_{HOST,USER,PASSWORD}`, the
+//! latter taking precedence.
+
+use std::path::Path;
+
+use benchmark_spec::BenchmarkMetric;
+use sqlx::postgres::{PgConnectOptions, PgPool, PgPoolOptions, PgSslMode};
+use sqlx::{Postgres, QueryBuilder};
+
+/// Database credentials. Every field is optional so the file and the
+/// environment can each provide a subset.
+#[derive(Debug, Default, serde::Deserialize)]
+#[serde(default)]
+pub struct DbConfig {
+    pub host: Option<String>,
+    pub user: Option<String>,
+    pub password: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct ConfigFile {
+    database: DbConfig,
+}
+
+impl DbConfig {
+    /// Loads credentials from the optional TOML file, then overrides any value
+    /// present in the environment, which wins.
+    pub fn load(path: Option<&Path>) -> anyhow::Result<Self> {
+        let mut cfg = match path {
+            Some(p) => {
+                let raw = std::fs::read_to_string(p)
+                    .map_err(|e| anyhow::anyhow!("cannot read config file {}: {e}", p.display()))?;
+                toml::from_str::<ConfigFile>(&raw)?.database
+            }
+            None => DbConfig::default(),
+        };
+
+        if let Ok(v) = std::env::var("DATA_EXTRACTOR_DATABASE_HOST") {
+            cfg.host = Some(v);
+        }
+        if let Ok(v) = std::env::var("DATA_EXTRACTOR_DATABASE_USER") {
+            cfg.user = Some(v);
+        }
+        if let Ok(v) = std::env::var("DATA_EXTRACTOR_DATABASE_PASSWORD") {
+            cfg.password = Some(v);
+        }
+
+        Ok(cfg)
+    }
+
+    fn connect_options(&self, dbname: &str) -> anyhow::Result<PgConnectOptions> {
+        let host = self
+            .host
+            .as_deref()
+            .ok_or_else(|| anyhow::anyhow!("missing database host"))?;
+        let user = self
+            .user
+            .as_deref()
+            .ok_or_else(|| anyhow::anyhow!("missing database user"))?;
+        let password = self
+            .password
+            .as_deref()
+            .ok_or_else(|| anyhow::anyhow!("missing database password"))?;
+
+        Ok(PgConnectOptions::new()
+            .host(host)
+            .username(user)
+            .password(password)
+            .database(dbname)
+            // RDS enforces TLS; `Require` encrypts without CA verification.
+            .ssl_mode(PgSslMode::Require))
+    }
+
+    /// Opens a connection pool to the given database.
+    pub async fn connect(&self, dbname: &str) -> anyhow::Result<PgPool> {
+        let pool = PgPoolOptions::new()
+            .max_connections(4)
+            .connect_with(self.connect_options(dbname)?)
+            .await?;
+        Ok(pool)
+    }
+}
+
+/// One benchmark result, as stored. `name` holds the whole rendered id, so
+/// every structured part of a result has to be parsed back out of it:
+///
+/// ```text
+/// name     = "<bench path>::<param set>::<type>_mean_avx512"
+/// bit_size = 64
+/// value    = 2310000.0     // nanoseconds, for a latency bench
+/// ```
+#[derive(Debug, sqlx::FromRow)]
+pub struct BenchRow {
+    pub name: String,
+    pub bit_size: i64,
+    pub value: f64,
+}
+
+/// Escapes the `LIKE` metacharacters. Bench ids and parameter aliases are full
+/// of `_`, which `LIKE` would otherwise read as "any single character", making
+/// the pattern match more than was asked for.
+///
+/// ```text
+/// add_parallelized  ->  add\_parallelized
+/// ```
+pub fn like_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        if matches!(c, '_' | '%' | '\\') {
+            out.push('\\');
+        }
+        out.push(c);
+    }
+    out
+}
+
+/// PBS-kind filter, applied as a pattern on the parameter-set alias.
+pub enum PbsKind {
+    Classical,
+    MultiBit,
+    Any,
+}
+
+/// Dynamic filters for the benchmark fetch query.
+pub struct FetchQuery<'a> {
+    pub hardware: &'a str,
+    pub backend: &'a str,
+    pub branch: &'a str,
+    /// SQL `LIKE` patterns for the id; a row matching any of them is kept.
+    /// Either one broad layer pattern, or one exact prefix per bench path when
+    /// a regression profile drives the selection.
+    pub like_patterns: &'a [String],
+    /// Drop the `unchecked_` variants by name. Only needed for the broad
+    /// pattern: a profile already spells out the operations it wants.
+    pub exclude_non_default: bool,
+    /// `None` = no metric filter (both latency and throughput).
+    pub metric: Option<BenchmarkMetric>,
+    pub pbs_kind: PbsKind,
+    /// `LIKE` pattern on the parameter set alias, already wrapped in `%`.
+    /// Matched as a substring, which matters: aliases carry a version prefix
+    /// (`V1_6_PARAM_…`).
+    pub param_pattern: Option<&'a str>,
+    /// If set, pin to that exact commit; otherwise use the date window.
+    pub project_version: Option<&'a str>,
+    pub bench_date: Option<&'a str>,
+    pub time_span_days: i32,
+}
+
+/// Tiny `WHERE` builder over `sqlx::QueryBuilder`.
+///
+/// [`BASE_QUERY`] ends with `WHERE true`, so every condition is a plain `AND`
+/// and no method has to know whether it is the first one. Which one that would
+/// be is not knowable anyway: most filters here are optional. It also keeps the
+/// query valid when none of them applies.
+///
+/// ```sql
+/// WHERE true AND h.name = $1 AND bk.name = $2 AND test.name LIKE ANY($3)
+/// WHERE true                                    -- no filter active
+/// ```
+///
+/// Column names are always hardcoded constants (safe to inline); only values go
+/// through `push_bind`.
+struct Filters<'a>(QueryBuilder<'a, Postgres>);
+
+impl<'a> Filters<'a> {
+    fn new(base: &str) -> Self {
+        Filters(QueryBuilder::new(base))
+    }
+
+    fn eq<T>(&mut self, col: &str, val: T) -> &mut Self
+    where
+        T: 'a + sqlx::Encode<'a, Postgres> + sqlx::Type<Postgres> + Send,
+    {
+        self.0.push(" AND ").push(col).push(" = ").push_bind(val);
+        self
+    }
+
+    /// `col LIKE ANY($n)`: one round-trip whatever the number of patterns.
+    fn like_any(&mut self, col: &str, patterns: &'a [String]) -> &mut Self {
+        self.0
+            .push(" AND ")
+            .push(col)
+            .push(" LIKE ANY(")
+            .push_bind(patterns)
+            .push(")");
+        self
+    }
+
+    /// Adds `col = val` only when `val` is `Some`.
+    fn opt<T>(&mut self, col: &str, val: Option<T>) -> &mut Self
+    where
+        T: 'a + sqlx::Encode<'a, Postgres> + sqlx::Type<Postgres> + Send,
+    {
+        if let Some(v) = val {
+            self.eq(col, v);
+        }
+        self
+    }
+
+    /// Appends a raw `AND <sql>`. Constant SQL only, never user input.
+    fn raw(&mut self, sql: &str) -> &mut Self {
+        self.0.push(" AND ").push(sql);
+        self
+    }
+}
+
+const BASE_QUERY: &str = "\
+    SELECT DISTINCT ON (test.name) \
+        test.name AS name, p.bit_size AS bit_size, m.value AS value \
+    FROM benchmark.metrics AS m \
+    LEFT JOIN benchmark.hardware        AS h  ON m.hardware_id        = h.id \
+    LEFT JOIN benchmark.backend         AS bk ON m.backend_id         = bk.id \
+    LEFT JOIN benchmark.branch          AS b  ON m.branch_id          = b.id \
+    LEFT JOIN benchmark.test            AS test ON m.test_id          = test.id \
+    LEFT JOIN benchmark.parameters      AS p  ON m.parameters_id      = p.id \
+    LEFT JOIN benchmark.project_version AS pv ON m.project_version_id = pv.id \
+    WHERE true";
+
+/// Latest value per `test.name` matching the filters.
+pub async fn fetch_bench_rows(pool: &PgPool, q: &FetchQuery<'_>) -> anyhow::Result<Vec<BenchRow>> {
+    let mut f = Filters::new(BASE_QUERY);
+    f.eq("h.name", q.hardware)
+        .eq("bk.name", q.backend)
+        .eq("b.name", q.branch)
+        .like_any("test.name", q.like_patterns)
+        .opt("pv.name", q.project_version);
+
+    if let Some(pattern) = q.param_pattern {
+        f.0.push(" AND p.crypto_parameters_alias LIKE ")
+            .push_bind(pattern);
+    }
+
+    if q.exclude_non_default {
+        // Default operations only. `smart_` was dropped from the benches in
+        // a20ee6325; kept here for the historical rows.
+        f.raw("test.name NOT SIMILAR TO '%(smart|unchecked)_%'");
+    }
+
+    match q.metric {
+        Some(BenchmarkMetric::Latency) => {
+            f.raw("test.name NOT LIKE '%::throughput::%'");
+        }
+        Some(BenchmarkMetric::Throughput) => {
+            f.raw("test.name LIKE '%::throughput::%'");
+        }
+        _ => {}
+    }
+
+    match q.pbs_kind {
+        PbsKind::Classical => {
+            f.raw("p.crypto_parameters_alias NOT SIMILAR TO '%_MULTI_BIT_%'");
+        }
+        PbsKind::MultiBit => {
+            f.raw("p.crypto_parameters_alias SIMILAR TO '%_MULTI_BIT_%'");
+        }
+        PbsKind::Any => {}
+    }
+
+    // Date window only when no exact commit was pinned. Anchored on the
+    // requested date, which also closes the window, or on `now()`, in which case
+    // there is nothing to close: no row can be inserted in the future.
+    if q.project_version.is_none() {
+        match q.bench_date {
+            Some(date) => {
+                f.0.push(" AND m.insert_time <= ")
+                    .push_bind(date)
+                    .push("::timestamp AND m.insert_time >= ")
+                    .push_bind(date)
+                    .push("::timestamp - make_interval(days => ")
+                    .push_bind(q.time_span_days)
+                    .push(")");
+            }
+            None => {
+                f.0.push(" AND m.insert_time >= now() - make_interval(days => ")
+                    .push_bind(q.time_span_days)
+                    .push(")");
+            }
+        }
+    }
+
+    f.0.push(" ORDER BY test.name, m.insert_time DESC");
+
+    let rows = f.0.build_query_as::<BenchRow>().fetch_all(pool).await?;
+    Ok(rows)
+}

--- a/utils/tfhe-data-extractor/src/format/erc7984.rs
+++ b/utils/tfhe-data-extractor/src/format/erc7984.rs
@@ -1,0 +1,68 @@
+//! The `transfer implementation × metric` table of the ERC7984 benchmarks.
+
+use benchmark_spec::tfhe::hlapi::erc7984::{Erc7984, TransferFlavor};
+use benchmark_spec::{BenchCrate, BenchmarkMetric, HlapiBench, TfheLayer};
+
+use super::{Cells, GridSpec, Table, build_grid, parse_rows, readable_value};
+use crate::db::BenchRow;
+
+const ROW_HEADER: &str = "Transfer implementation";
+
+/// Column headers, spelled as published.
+const COLUMNS: &[(&str, BenchmarkMetric)] = &[
+    ("Latency", BenchmarkMetric::Latency),
+    ("Throughput", BenchmarkMetric::Throughput),
+];
+
+/// Rows in publication order. HPU publishes a different set (`hpu_optim`,
+/// `hpu_simd`) that is not covered here.
+const ROWS: &[TransferFlavor] = &[
+    TransferFlavor::Whitepaper,
+    TransferFlavor::NoCmux,
+    TransferFlavor::Overflow,
+];
+
+/// Builds the ERC7984 transfer table.
+///
+/// A flavour with no result at all is still printed, as two `N/A` cells: the
+/// table exists to compare the three against each other, so a missing one is
+/// the finding.
+pub fn table(rows: &[BenchRow]) -> Table {
+    let mut cells: Cells<(TransferFlavor, BenchmarkMetric)> = Cells::new();
+    let (parsed, unparsed) = parse_rows(rows);
+
+    for (id, row) in parsed {
+        let BenchCrate::Tfhe(TfheLayer::Hlapi(HlapiBench::Erc7984(Erc7984::Transfer(flavor)))) =
+            id.spec.bench_crate()
+        else {
+            continue;
+        };
+        // Only benchmarked on 64-bit ciphertexts, so flavour and metric are
+        // the whole key.
+        cells.insert(
+            (flavor, id.spec.metric()),
+            readable_value(id.spec.metric(), row.value),
+            || format!("{flavor}::{:?}", id.spec.metric()),
+        );
+    }
+
+    let (grid, empty_rows) = build_grid(
+        GridSpec {
+            row_header: ROW_HEADER,
+            rows: ROWS
+                .iter()
+                .map(|flavor| (flavor.to_string(), *flavor))
+                .collect(),
+            columns: COLUMNS,
+            drop_empty_rows: false,
+        },
+        |flavor, metric| cells.get(&(*flavor, *metric)).cloned(),
+    );
+
+    Table {
+        grid,
+        unparsed,
+        empty_rows,
+        conflicts: cells.conflicts(),
+    }
+}

--- a/utils/tfhe-data-extractor/src/format/integer.rs
+++ b/utils/tfhe-data-extractor/src/format/integer.rs
@@ -1,0 +1,129 @@
+//! The `operation × ciphertext size` table of the integer layer.
+
+use benchmark_spec::{
+    BenchCrate, IntegerBench, IntegerOp, IntegerOpBySign, OperandType, TfheLayer,
+};
+
+use super::{Cells, GridSpec, Table, build_grid, parse_rows, readable_value};
+use crate::db::BenchRow;
+
+const ROW_HEADER: &str = r"Operation \ Size";
+
+/// Published precisions. FheUint2, FheUint4 and FheUint256 are benchmarked but
+/// not shown.
+const COLUMNS: &[(&str, i64)] = &[
+    ("FheUint8", 8),
+    ("FheUint16", 16),
+    ("FheUint32", 32),
+    ("FheUint64", 64),
+    ("FheUint128", 128),
+];
+
+/// Rows in publication order, each a label and the operation it is measured
+/// from. A label may name several operations while only one is benchmarked.
+const CIPHERTEXT_ROWS: &[(&str, IntegerOp)] = &[
+    ("Negation (-)", IntegerOp::NegParallelized),
+    ("Add / Sub (+,-)", IntegerOp::AddParallelized),
+    ("Mul (x)", IntegerOp::MulParallelized),
+    ("Equal / Not Equal (eq, ne)", IntegerOp::EqParallelized),
+    ("Comparisons (ge, gt, le, lt)", IntegerOp::GtParallelized),
+    ("Max / Min (max, min)", IntegerOp::MaxParallelized),
+    (
+        "Bitwise operations (&, |, ^)",
+        IntegerOp::BitandParallelized,
+    ),
+    ("Div / Rem  (/, %)", IntegerOp::DivRemParallelized),
+    (
+        "Left / Right Shifts (<<, >>)",
+        IntegerOp::LeftShiftParallelized,
+    ),
+    (
+        "Left / Right Rotations (left_rotate, right_rotate)",
+        IntegerOp::RotateLeftParallelized,
+    ),
+    (
+        "Leading / Trailing zeros/ones",
+        IntegerOp::LeadingZerosParallelized,
+    ),
+    ("Log2", IntegerOp::Ilog2Parallelized),
+    ("Select", IntegerOp::IfThenElseParallelized),
+];
+
+/// Same, for `scalar` operations: no negation, and `Div / Rem` split in two.
+const SCALAR_ROWS: &[(&str, IntegerOp)] = &[
+    ("Add / Sub (+,-)", IntegerOp::AddParallelized),
+    ("Mul (x)", IntegerOp::MulParallelized),
+    ("Equal / Not Equal (eq, ne)", IntegerOp::EqParallelized),
+    ("Comparisons (ge, gt, le, lt)", IntegerOp::GtParallelized),
+    ("Max / Min (max, min)", IntegerOp::MaxParallelized),
+    (
+        "Bitwise operations (&, |, ^)",
+        IntegerOp::BitandParallelized,
+    ),
+    ("Div  (/)", IntegerOp::DivParallelized),
+    ("Rem  (%)", IntegerOp::RemParallelized),
+    (
+        "Left / Right Shifts (<<, >>)",
+        IntegerOp::LeftShiftParallelized,
+    ),
+    (
+        "Left / Right Rotations (left_rotate, right_rotate)",
+        IntegerOp::RotateLeftParallelized,
+    ),
+    (
+        "Leading / Trailing zeros/ones",
+        IntegerOp::LeadingZerosParallelized,
+    ),
+    ("Log2", IntegerOp::Ilog2Parallelized),
+    ("Select", IntegerOp::IfThenElseParallelized),
+];
+
+/// Builds the integer table for one operand type.
+pub fn table(rows: &[BenchRow], operand: OperandType) -> Table {
+    let table_rows = match operand {
+        OperandType::CipherText => CIPHERTEXT_ROWS,
+        OperandType::PlainText => SCALAR_ROWS,
+    };
+
+    let mut cells: Cells<(IntegerOp, i64)> = Cells::new();
+    let (parsed, unparsed) = parse_rows(rows);
+
+    for (id, row) in parsed {
+        if id.spec.operand_type().is_scalar() != operand.is_scalar() {
+            continue;
+        }
+        // Unsigned operations only.
+        let BenchCrate::Tfhe(TfheLayer::Integer(IntegerBench::Ops(IntegerOpBySign::Unsigned(op)))) =
+            id.spec.bench_crate()
+        else {
+            continue;
+        };
+        cells.insert(
+            (op, row.bit_size),
+            readable_value(id.spec.metric(), row.value),
+            || format!("{op}::{} bits", row.bit_size),
+        );
+    }
+
+    let (grid, empty_rows) = build_grid(
+        GridSpec {
+            row_header: ROW_HEADER,
+            rows: table_rows
+                .iter()
+                .map(|(label, op)| (label.to_string(), *op))
+                .collect(),
+            columns: COLUMNS,
+            // An operation with no result at all is left out: the row list is a
+            // catalogue, and benchmarking a subset of it is routine.
+            drop_empty_rows: true,
+        },
+        |op, size| cells.get(&(*op, *size)).cloned(),
+    );
+
+    Table {
+        grid,
+        unparsed,
+        empty_rows,
+        conflicts: cells.conflicts(),
+    }
+}

--- a/utils/tfhe-data-extractor/src/format/kv_store.rs
+++ b/utils/tfhe-data-extractor/src/format/kv_store.rs
@@ -1,0 +1,110 @@
+//! One `store size × value precision` table per KV-store operation.
+//!
+//! The store size is `num_elements` and the value type sits in `type_name` as
+//! `key_<K>::value_<V>`.
+
+use benchmark_spec::tfhe::hlapi::kv_store::KvStoreOp;
+use benchmark_spec::{BenchCrate, HlapiBench, TfheLayer};
+
+use super::{Cells, GridSpec, Table, build_grid, parse_rows, readable_value};
+use crate::db::BenchRow;
+
+const ROW_HEADER: &str = r"Store size \ Value";
+
+const COLUMNS: &[(&str, u32)] = &[
+    ("FheUint8", 8),
+    ("FheUint16", 16),
+    ("FheUint32", 32),
+    ("FheUint64", 64),
+    ("FheUint128", 128),
+];
+
+const ROWS: &[usize] = &[2, 4, 8, 16, 32, 64, 128, 256, 512, 1024];
+
+/// Operations published, in order. The spec knows three more (`contains_*`)
+/// that the documentation does not show.
+const OPERATIONS: &[KvStoreOp] = &[KvStoreOp::Get, KvStoreOp::Update, KvStoreOp::Map];
+
+/// Builds one table per operation, suffixed with the operation name.
+pub fn tables(rows: &[BenchRow]) -> Vec<(String, Table)> {
+    let mut cells: Cells<(KvStoreOp, usize, u32)> = Cells::new();
+    let (parsed, unparsed) = parse_rows(rows);
+
+    for (id, row) in parsed {
+        let BenchCrate::Tfhe(TfheLayer::Hlapi(HlapiBench::KvStore(op))) = id.spec.bench_crate()
+        else {
+            continue;
+        };
+        let (Some(store_size), Some(value_bits)) = (
+            id.spec.num_elements(),
+            id.spec.type_name().and_then(value_precision),
+        ) else {
+            continue;
+        };
+
+        cells.insert(
+            (op, store_size, value_bits),
+            readable_value(id.spec.metric(), row.value),
+            || format!("{op}::{store_size} elements::FheUint{value_bits}"),
+        );
+    }
+
+    let conflicts = cells.conflicts();
+
+    OPERATIONS
+        .iter()
+        .enumerate()
+        .map(|(index, op)| {
+            let (grid, empty) = build_grid(
+                GridSpec {
+                    row_header: ROW_HEADER,
+                    rows: ROWS.iter().map(|size| (size.to_string(), *size)).collect(),
+                    columns: COLUMNS,
+                    drop_empty_rows: false,
+                },
+                |size, bits| cells.get(&(*op, *size, *bits)).cloned(),
+            );
+
+            let table = Table {
+                grid,
+                // One parse pass feeds every operation; only report it once.
+                unparsed: if index == 0 { unparsed } else { 0 },
+                // Qualified with the operation, since three tables share a report.
+                empty_rows: empty
+                    .into_iter()
+                    .map(|size| format!("{op}::{size}"))
+                    .collect(),
+                conflicts: if index == 0 {
+                    conflicts.clone()
+                } else {
+                    Vec::new()
+                },
+            };
+
+            (format!("-{op}"), table)
+        })
+        .collect()
+}
+
+/// Pulls the value precision out of a `key_<K>::value_<V>` type tag. Anchored
+/// on the `value_` marker so a differently spelled key type cannot shift it.
+fn value_precision(type_name: &str) -> Option<u32> {
+    type_name
+        .split("::")
+        .find_map(|part| part.strip_prefix("value_"))
+        .and_then(|ty| ty.strip_prefix("FheUint"))
+        .and_then(|bits| bits.parse().ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn value_precision_is_anchored() {
+        assert_eq!(value_precision("key_FheUint32::value_FheUint64"), Some(64));
+        // A key type that happens to look like a value must not be picked up.
+        assert_eq!(value_precision("key_FheUint8"), None);
+        assert_eq!(value_precision("FheUint64"), None);
+    }
+}

--- a/utils/tfhe-data-extractor/src/format/mod.rs
+++ b/utils/tfhe-data-extractor/src/format/mod.rs
@@ -1,0 +1,211 @@
+//! The published benchmark tables, one module per table.
+//!
+//! This module holds what all of them need: the [`Table`] result, cell
+//! collection, id parsing and value formatting.
+
+pub mod erc7984;
+pub mod integer;
+pub mod kv_store;
+pub mod render;
+
+use std::collections::{BTreeSet, HashMap};
+use std::hash::Hash;
+
+use benchmark_spec::{BenchmarkMetric, MeasuredId};
+
+use crate::db::BenchRow;
+
+/// A table as data, before serialization. Cell values are already formatted;
+/// only the layout is left to the renderer.
+///
+/// ```text
+/// | Operation \ Size | FheUint8 | FheUint16 |   <- row_header, then columns
+/// | Add / Sub (+,-)  | 2.31 ms  | N/A       |   <- one Row { label, cells }
+/// ```
+pub struct Grid {
+    /// Header of the first column, the one holding row labels.
+    pub row_header: String,
+    /// Remaining column headers, in order.
+    pub columns: Vec<String>,
+    pub rows: Vec<Row>,
+}
+
+pub struct Row {
+    pub label: String,
+    /// One entry per column, `None` when that column was not measured.
+    pub cells: Vec<Option<String>>,
+}
+
+/// A built table plus what it could not account for.
+pub struct Table {
+    pub grid: Grid,
+    /// Ids that did not parse against the current spec: legacy grammar.
+    pub unparsed: usize,
+    /// Rows with no result at any column. Whether they are printed as `N/A` or
+    /// left out is up to each table.
+    pub empty_rows: Vec<String>,
+    /// Cells several benchmarks competed for with different values, meaning the
+    /// selection is under-specified.
+    pub conflicts: Vec<String>,
+}
+
+impl Table {
+    /// Reports on stderr what the table could not account for.
+    pub fn report(&self) {
+        if self.unparsed > 0 {
+            eprintln!(
+                "warning: {} ids skipped, not in the current spec grammar",
+                self.unparsed
+            );
+        }
+        if !self.empty_rows.is_empty() {
+            eprintln!(
+                "warning: {} rows without any result: {}",
+                self.empty_rows.len(),
+                self.empty_rows.join(", "),
+            );
+        }
+        if !self.conflicts.is_empty() {
+            eprintln!(
+                "warning: {} cell(s) matched by several benchmarks, first kept. \
+                 Narrow the selection with --param:",
+                self.conflicts.len(),
+            );
+            for conflict in &self.conflicts {
+                eprintln!("  {conflict}");
+            }
+        }
+    }
+}
+
+/// One value per cell of a table.
+///
+/// A second, different value for the same cell means the query did not narrow
+/// down to a single benchmark. The first wins, which is deterministic since
+/// rows arrive ordered by `test.name`, and the clash is recorded.
+struct Cells<K> {
+    values: HashMap<K, String>,
+    conflicts: BTreeSet<String>,
+}
+
+impl<K: Eq + Hash> Cells<K> {
+    fn new() -> Self {
+        Self {
+            values: HashMap::new(),
+            conflicts: BTreeSet::new(),
+        }
+    }
+
+    /// `label` is only evaluated on a clash.
+    fn insert(&mut self, key: K, value: String, label: impl FnOnce() -> String) {
+        match self.values.get(&key) {
+            Some(kept) if *kept != value => {
+                self.conflicts
+                    .insert(format!("{} ({kept} / {value})", label()));
+            }
+            Some(_) => {}
+            None => {
+                self.values.insert(key, value);
+            }
+        }
+    }
+
+    fn get(&self, key: &K) -> Option<&String> {
+        self.values.get(key)
+    }
+
+    fn conflicts(&self) -> Vec<String> {
+        self.conflicts.iter().cloned().collect()
+    }
+}
+
+/// A table's layout, declared the same way by every table.
+struct GridSpec<'a, R, C> {
+    /// Header of the first column, the one holding row labels.
+    row_header: &'a str,
+    /// Row label and the key it is looked up by, in publication order.
+    rows: Vec<(String, R)>,
+    /// Column header and the key it is looked up by, in publication order.
+    columns: &'a [(&'a str, C)],
+    /// Leave out a row with no result at any column, instead of filling it
+    /// with `N/A`.
+    drop_empty_rows: bool,
+}
+
+/// Fills a layout from `lookup`, returning the grid and the labels of the rows
+/// that had no result at any column.
+fn build_grid<R, C>(
+    spec: GridSpec<'_, R, C>,
+    lookup: impl Fn(&R, &C) -> Option<String>,
+) -> (Grid, Vec<String>) {
+    let mut grid_rows = Vec::with_capacity(spec.rows.len());
+    let mut empty_rows = Vec::new();
+
+    for (label, row_key) in spec.rows {
+        let cells: Vec<Option<String>> = spec
+            .columns
+            .iter()
+            .map(|(_, col_key)| lookup(&row_key, col_key))
+            .collect();
+
+        if cells.iter().all(Option::is_none) {
+            empty_rows.push(label.clone());
+            if spec.drop_empty_rows {
+                continue;
+            }
+        }
+
+        grid_rows.push(Row { label, cells });
+    }
+
+    let grid = Grid {
+        row_header: spec.row_header.to_string(),
+        columns: spec
+            .columns
+            .iter()
+            .map(|(name, _)| name.to_string())
+            .collect(),
+        rows: grid_rows,
+    };
+
+    (grid, empty_rows)
+}
+
+/// Parses each stored name against the spec, returning the rows that parsed and
+/// how many did not.
+fn parse_rows(rows: &[BenchRow]) -> (Vec<(MeasuredId, &BenchRow)>, usize) {
+    let mut parsed = Vec::with_capacity(rows.len());
+    let mut unparsed = 0;
+
+    for row in rows {
+        match row.name.parse::<MeasuredId>() {
+            Ok(id) => parsed.push((id, row)),
+            Err(_) => unparsed += 1,
+        }
+    }
+
+    (parsed, unparsed)
+}
+
+/// Human-readable latency from a nanosecond figure.
+fn readable_latency(ns: f64) -> String {
+    if ns < 1e3 {
+        format!("{ns:.0} ns")
+    } else if ns < 1e6 {
+        format!("{:.2} us", ns / 1e3)
+    } else if ns < 1e9 {
+        format!("{:.2} ms", ns / 1e6)
+    } else {
+        format!("{:.2} s", ns / 1e9)
+    }
+}
+
+/// Renders a value with the unit implied by its metric.
+fn readable_value(metric: BenchmarkMetric, value: f64) -> String {
+    match metric {
+        BenchmarkMetric::Latency => readable_latency(value),
+        BenchmarkMetric::Throughput => format!("{value:.2} elem/s"),
+        // Counts and byte sizes are not durations.
+        BenchmarkMetric::PbsCount | BenchmarkMetric::KeySize => format!("{value:.0}"),
+    }
+}

--- a/utils/tfhe-data-extractor/src/format/render/csv.rs
+++ b/utils/tfhe-data-extractor/src/format/render/csv.rs
@@ -1,0 +1,37 @@
+//! RFC 4180 CSV. Quoting is not optional here: row labels contain commas
+//! (`Comparisons (ge, gt, le, lt)`).
+
+use super::MISSING;
+use crate::format::Grid;
+
+pub fn table(grid: &Grid) -> String {
+    let mut out = String::new();
+    write_record(
+        &mut out,
+        std::iter::once(grid.row_header.as_str()).chain(grid.columns.iter().map(String::as_str)),
+    );
+    for row in &grid.rows {
+        write_record(
+            &mut out,
+            std::iter::once(row.label.as_str())
+                .chain(row.cells.iter().map(|c| c.as_deref().unwrap_or(MISSING))),
+        );
+    }
+    out
+}
+
+fn write_record<'a>(out: &mut String, fields: impl Iterator<Item = &'a str>) {
+    for (index, field) in fields.enumerate() {
+        if index > 0 {
+            out.push(',');
+        }
+        if field.contains([',', '"', '\n']) {
+            out.push('"');
+            out.push_str(&field.replace('"', "\"\""));
+            out.push('"');
+        } else {
+            out.push_str(field);
+        }
+    }
+    out.push('\n');
+}

--- a/utils/tfhe-data-extractor/src/format/render/markdown.rs
+++ b/utils/tfhe-data-extractor/src/format/render/markdown.rs
@@ -1,0 +1,32 @@
+//! GitHub-flavoured markdown table.
+
+use super::MISSING;
+use crate::format::Grid;
+
+pub fn table(grid: &Grid) -> String {
+    let mut out = format!("| {} |", escape(&grid.row_header));
+    let mut separator = String::from("\n|---|");
+    for column in &grid.columns {
+        out.push_str(&format!(" {} |", escape(column)));
+        separator.push_str("---|");
+    }
+    out.push_str(&separator);
+    out.push('\n');
+
+    for row in &grid.rows {
+        out.push_str(&format!("| {} |", escape(&row.label)));
+        for cell in &row.cells {
+            out.push_str(&format!(
+                " {} |",
+                escape(cell.as_deref().unwrap_or(MISSING))
+            ));
+        }
+        out.push('\n');
+    }
+    out
+}
+
+/// A `|` would end the cell.
+fn escape(s: &str) -> String {
+    s.replace('|', "\\|")
+}

--- a/utils/tfhe-data-extractor/src/format/render/mod.rs
+++ b/utils/tfhe-data-extractor/src/format/render/mod.rs
@@ -1,0 +1,49 @@
+//! Serializers for a `Grid`, one module per output format. Each owns its own
+//! escaping.
+
+pub mod csv;
+pub mod markdown;
+pub mod svg;
+
+/// Cell shown when a column was not measured for a row that has data.
+const MISSING: &str = "N/A";
+
+#[cfg(test)]
+mod tests {
+    use crate::format::{Grid, Row};
+
+    fn grid() -> Grid {
+        Grid {
+            row_header: r"Operation \ Size".to_string(),
+            columns: vec!["FheUint8".to_string()],
+            rows: vec![Row {
+                label: "Comparisons (ge, gt)".to_string(),
+                cells: vec![None],
+            }],
+        }
+    }
+
+    #[test]
+    fn csv_quotes_labels_containing_commas() {
+        assert_eq!(
+            super::csv::table(&grid()),
+            "Operation \\ Size,FheUint8\n\"Comparisons (ge, gt)\",N/A\n"
+        );
+    }
+
+    #[test]
+    fn markdown_fills_missing_cells() {
+        assert!(super::markdown::table(&grid()).ends_with("| Comparisons (ge, gt) | N/A |\n"));
+    }
+
+    /// The pipe lives unescaped in the grid; each format escapes its own way.
+    #[test]
+    fn each_format_escapes_its_own_pipe() {
+        let mut g = grid();
+        g.rows[0].label = "Bitwise (&, |, ^)".to_string();
+
+        assert!(super::markdown::table(&g).contains(r"Bitwise (&, \|, ^)"));
+        assert!(super::csv::table(&g).contains("\"Bitwise (&, |, ^)\""));
+        assert!(super::svg::table(&g).contains("Bitwise (&#38;, &#124;, ^)"));
+    }
+}

--- a/utils/tfhe-data-extractor/src/format/render/svg.rs
+++ b/utils/tfhe-data-extractor/src/format/render/svg.rs
@@ -1,0 +1,166 @@
+//! SVG table, as published in the documentation: fixed geometry, a black header
+//! row, a yellow first column and a grey body, separated by white rules.
+
+use super::MISSING;
+use crate::format::Grid;
+
+const BLACK: &str = "black";
+const WHITE: &str = "white";
+const LIGHT_GREY: &str = "#f3f3f3";
+const YELLOW: &str = "#fbbc04";
+/// Arial first, for the metrics the fixed geometry below was sized against.
+/// Liberation Sans, the usual Linux substitute, is metric-compatible.
+const FONT_FAMILY: &str = "Arial, Helvetica, sans-serif";
+const FONT_SIZE: u32 = 14;
+const BORDER_WIDTH: u32 = 2;
+/// Left inset of the row labels and of the row header.
+const LABEL_INSET: f64 = 6.0;
+
+/// Dimensions of the published tables. The label column is sized to hold the
+/// longest row label at [`FONT_SIZE`], with little to spare.
+const OVERALL_WIDTH: f64 = 720.0;
+const ROW_HEIGHT: f64 = 40.0;
+const LABEL_COL_WIDTH: f64 = 300.0;
+
+pub fn table(grid: &Grid) -> String {
+    let col_count = grid.columns.len().max(1) as f64;
+    let col_width = (OVERALL_WIDTH - LABEL_COL_WIDTH) / col_count;
+    let height = (1 + grid.rows.len()) as f64 * ROW_HEIGHT;
+
+    // The accessible name of the image. The row header is the closest thing to a
+    // caption a `Grid` carries.
+    let mut elements = vec![format!("  <title>{}</title>", escape(&grid.row_header))];
+
+    // Header row: black band, then the column labels.
+    elements.push(rect(0.0, 0.0, OVERALL_WIDTH, ROW_HEIGHT, BLACK));
+    elements.push(text(
+        LABEL_INSET,
+        ROW_HEIGHT / 2.0,
+        &grid.row_header,
+        "start",
+        WHITE,
+        true,
+    ));
+    for (index, column) in grid.columns.iter().enumerate() {
+        let centre = LABEL_COL_WIDTH + index as f64 * col_width + col_width / 2.0;
+        // Rust type headers are split over two lines so the size stands out;
+        // anything else is a single centred label.
+        match column.strip_prefix("FheUint") {
+            Some(size) => {
+                elements.push(text(
+                    centre,
+                    ROW_HEIGHT / 3.0,
+                    "FheUint",
+                    "middle",
+                    WHITE,
+                    true,
+                ));
+                elements.push(text(
+                    centre,
+                    2.0 * ROW_HEIGHT / 3.0 + 3.0,
+                    size,
+                    "middle",
+                    WHITE,
+                    true,
+                ));
+            }
+            None => elements.push(text(
+                centre,
+                ROW_HEIGHT / 2.0,
+                column,
+                "middle",
+                WHITE,
+                true,
+            )),
+        }
+    }
+
+    // Body background: labels on yellow, values on grey.
+    elements.push(rect(
+        0.0,
+        ROW_HEIGHT,
+        LABEL_COL_WIDTH,
+        height - ROW_HEIGHT,
+        YELLOW,
+    ));
+    elements.push(rect(
+        LABEL_COL_WIDTH,
+        ROW_HEIGHT,
+        OVERALL_WIDTH - LABEL_COL_WIDTH,
+        height - ROW_HEIGHT,
+        LIGHT_GREY,
+    ));
+
+    for (index, row) in grid.rows.iter().enumerate() {
+        let baseline = (index + 1) as f64 * ROW_HEIGHT + ROW_HEIGHT / 2.0;
+        elements.push(text(
+            LABEL_INSET,
+            baseline,
+            &row.label,
+            "start",
+            BLACK,
+            false,
+        ));
+        for (column, cell) in row.cells.iter().enumerate() {
+            let centre = LABEL_COL_WIDTH + column as f64 * col_width + col_width / 2.0;
+            let value = cell.as_deref().unwrap_or(MISSING);
+            elements.push(text(centre, baseline, value, "middle", BLACK, false));
+        }
+    }
+
+    // One rule per row boundary, the bottom edge included.
+    //
+    // The four outer rules sit half a stroke inside the box, otherwise the
+    // viewBox clips them to half their width while the inner ones keep theirs.
+    let inset = f64::from(BORDER_WIDTH) / 2.0;
+    for index in 0..=grid.rows.len() + 1 {
+        let y = (index as f64 * ROW_HEIGHT).clamp(inset, height - inset);
+        elements.push(line(0.0, y, OVERALL_WIDTH, y));
+    }
+    elements.push(line(inset, 0.0, inset, height));
+    for index in 0..=grid.columns.len() {
+        let x = (LABEL_COL_WIDTH + index as f64 * col_width).clamp(inset, OVERALL_WIDTH - inset);
+        elements.push(line(x, 0.0, x, height));
+    }
+
+    // A percentage width with the content height keeps the table at 1:1 and
+    // centred in its container, which is how the published tables read. Below
+    // `OVERALL_WIDTH` of available width it shrinks and leaves vertical padding,
+    // the trade-off that comes with the centring.
+    format!(
+        "<svg xmlns=\"http://www.w3.org/2000/svg\" role=\"img\" \
+         width=\"100%\" height=\"{height}\" \
+         viewBox=\"0 0 {OVERALL_WIDTH} {height}\" \
+         preserveAspectRatio=\"xMidYMid meet\">\n{}\n</svg>\n",
+        elements.join("\n")
+    )
+}
+
+fn rect(x: f64, y: f64, width: f64, height: f64, fill: &str) -> String {
+    format!("  <rect x=\"{x}\" y=\"{y}\" width=\"{width}\" height=\"{height}\" fill=\"{fill}\"/>")
+}
+
+fn line(x1: f64, y1: f64, x2: f64, y2: f64) -> String {
+    format!(
+        "  <line x1=\"{x1}\" y1=\"{y1}\" x2=\"{x2}\" y2=\"{y2}\" \
+         stroke=\"{WHITE}\" stroke-width=\"{BORDER_WIDTH}\"/>"
+    )
+}
+
+fn text(x: f64, y: f64, content: &str, anchor: &str, fill: &str, bold: bool) -> String {
+    let weight = if bold { "bold" } else { "normal" };
+    format!(
+        "  <text x=\"{x}\" y=\"{y}\" dominant-baseline=\"middle\" text-anchor=\"{anchor}\" \
+         font-family=\"{FONT_FAMILY}\" font-size=\"{FONT_SIZE}\" fill=\"{fill}\" \
+         font-weight=\"{weight}\">{}</text>",
+        escape(content)
+    )
+}
+
+/// `&` first, or it would escape the ampersands of the other entities.
+fn escape(s: &str) -> String {
+    s.replace('&', "&#38;")
+        .replace('<', "&#60;")
+        .replace('>', "&#62;")
+        .replace('|', "&#124;")
+}

--- a/utils/tfhe-data-extractor/src/main.rs
+++ b/utils/tfhe-data-extractor/src/main.rs
@@ -1,0 +1,478 @@
+//! Extracts benchmark results from the Zama PostgreSQL instance and writes the
+//! filtered tables as CSV, Markdown or SVG.
+//!
+//! Connection settings come from a configuration file, from these environment
+//! variables, or from both:
+//!  * DATA_EXTRACTOR_DATABASE_HOST
+//!  * DATA_EXTRACTOR_DATABASE_USER
+//!  * DATA_EXTRACTOR_DATABASE_PASSWORD
+//!
+//! Environment variables take precedence over the configuration file.
+
+use std::path::PathBuf;
+
+use benchmark_spec::tfhe::TfheLayerKind;
+use benchmark_spec::{BenchCrateKind, OperandType};
+use chrono::NaiveDateTime;
+use clap::{ArgGroup, Parser, ValueEnum};
+
+mod db;
+mod format;
+mod profile;
+
+/// Layer of the tfhe-rs library to filter against.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
+pub enum Layer {
+    #[value(name = "hlapi")]
+    HlApi,
+    Integer,
+    Shortint,
+    #[value(name = "core_crypto")]
+    CoreCrypto,
+    Wasm,
+}
+
+/// Kind of parameter set used for the Programmable Bootstrapping operation.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
+pub enum PbsKind {
+    Classical,
+    #[value(name = "multi_bit")]
+    MultiBit,
+    /// Special variant used when the user doesn't care about the PBS kind.
+    Any,
+}
+
+/// Type of benchmark to filter against.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
+pub enum BenchType {
+    Latency,
+    Throughput,
+    Both,
+}
+
+/// Subset of benchmarks to filter against, dedicated formatting will be applied.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
+pub enum BenchSubset {
+    All,
+    Erc7984,
+    Zk,
+    #[value(name = "kv_store")]
+    KvStore,
+}
+
+impl BenchType {
+    /// Maps the CLI filter onto the spec metric. `None` means no metric filter
+    /// (i.e. both latency and throughput).
+    fn as_metric(self) -> Option<benchmark_spec::BenchmarkMetric> {
+        match self {
+            BenchType::Latency => Some(benchmark_spec::BenchmarkMetric::Latency),
+            BenchType::Throughput => Some(benchmark_spec::BenchmarkMetric::Throughput),
+            BenchType::Both => None,
+        }
+    }
+}
+
+/// Parses the `--backend` argument straight into the spec's `Backend` type.
+fn parse_backend(s: &str) -> Result<benchmark_spec::Backend, String> {
+    s.parse()
+}
+
+/// The timestamp format `--bench-date` accepts and the query sends back out.
+const BENCH_DATE_FORMAT: &str = "%Y-%m-%dT%H:%M:%S";
+
+/// Rejects a malformed `--bench-date` here rather than leaving it to PostgreSQL
+/// once the connection is open.
+fn parse_bench_date(s: &str) -> Result<NaiveDateTime, String> {
+    NaiveDateTime::parse_from_str(s, BENCH_DATE_FORMAT)
+        .map_err(|e| format!("expected an ISO 8601 YYYY-MM-DDThh:mm:ss timestamp: {e}"))
+}
+
+// Several fields are parsed but not consumed yet.
+#[allow(dead_code)]
+#[derive(Parser, Debug)]
+#[command(
+    about = "Extract benchmarks results from Zama PostgreSQL instance, filtered and formatted as CSV.",
+    // `-V` is taken by --project-version, so free clap's automatic version flag.
+    disable_version_flag = true,
+    // `-w/--hardware` and `--hardware-comp` are mutually exclusive.
+    group(ArgGroup::new("hardware_selection").args(["hardware", "hardware_comp"])),
+    // The four `--generate-*` options are mutually exclusive. The CSV has no
+    // flag: it is emitted alongside whichever of these is picked.
+    group(ArgGroup::new("generation").args([
+        "generate_markdown",
+        "generate_svg",
+        "generate_svg_from_file",
+        "generate_regression_json",
+    ])),
+)]
+struct Args {
+    /// File storing parsed results (with no extension).
+    output_file: String,
+
+    /// Location of configuration file containing credentials to connect to
+    /// PostgreSQL instance.
+    #[arg(short = 'c', long = "config-file")]
+    config_file: Option<PathBuf>,
+
+    /// Last insertion date to look for in the database, formatted as ISO 8601
+    /// timestamp YYYY-MM-DDThh:mm:ss. Defaults to now when omitted.
+    #[arg(long = "bench-date", value_parser = parse_bench_date)]
+    bench_date: Option<NaiveDateTime>,
+
+    /// Name of the database used to store results.
+    #[arg(short, long, default_value = "tfhe_rs")]
+    database: String,
+
+    /// Hardware reference used to perform benchmark.
+    #[arg(short = 'w', long, default_value = "hpc8a.96xlarge")]
+    hardware: String,
+
+    /// Comma separated values of hardware to compare. The first value would be
+    /// chosen as baseline.
+    #[arg(long = "hardware-comp")]
+    hardware_comp: Option<String>,
+
+    /// Commit hash reference.
+    #[arg(short = 'V', long = "project-version")]
+    project_version: Option<String>,
+
+    /// Git branch name on which benchmark was performed.
+    #[arg(short, long, default_value = "main")]
+    branch: String,
+
+    /// Git base branch name on which benchmark history can be fetched.
+    #[arg(long = "base-branch", default_value = "main")]
+    base_branch: String,
+
+    /// Backend on which benchmarks have run.
+    #[arg(long, default_value = "cpu", value_parser = parse_backend)]
+    backend: benchmark_spec::Backend,
+
+    /// Produce a comparison between backends on 64 bits ciphertext/ciphertext
+    /// integer operations.
+    #[arg(long = "backends-comparison")]
+    backends_comparison: bool,
+
+    /// Layer of the tfhe-rs library to filter against.
+    #[arg(long = "tfhe-rs-layer", value_enum, default_value_t = Layer::Integer)]
+    layer: Layer,
+
+    /// Kind of PBS to look for.
+    #[arg(long = "pbs-kind", value_enum, default_value_t = PbsKind::Classical)]
+    pbs_kind: PbsKind,
+
+    /// Grouping factor used in multi-bit parameters set.
+    #[arg(long = "grouping-factor", value_parser = clap::value_parser!(u8).range(2..=4))]
+    grouping_factor: Option<u8>,
+
+    /// Numbers of days prior of `bench_date` we search for results in the
+    /// database.
+    #[arg(long = "time-span-days", default_value_t = 30, value_parser = clap::value_parser!(i64).range(1..))]
+    time_span_days: i64,
+
+    /// Type of benchmark to filter against.
+    #[arg(long = "bench-type", value_enum, default_value_t = BenchType::Latency)]
+    bench_type: BenchType,
+
+    /// Subset of benchmarks to filter against, dedicated formatting will be
+    /// applied.
+    #[arg(long = "bench-subset", value_enum, default_value_t = BenchSubset::All)]
+    bench_subset: BenchSubset,
+
+    /// Suffix to match the test names.
+    #[arg(long = "name-suffix", default_value = "_mean_avx512")]
+    name_suffix: String,
+
+    /// Path to file containing regression profiles formatted as TOML.
+    #[arg(long = "regression-profiles")]
+    regression_profiles: Option<PathBuf>,
+
+    /// Regression profile to select from the regression profiles file to filter
+    /// out database results.
+    #[arg(long = "regression-selected-profile")]
+    regression_selected_profile: Option<String>,
+
+    /// Generate Markdown array.
+    #[arg(long = "generate-markdown")]
+    generate_markdown: bool,
+
+    /// Generate SVG table formatted like ones in tfhe-rs documentation.
+    #[arg(long = "generate-svg")]
+    generate_svg: bool,
+
+    /// Generate SVG table formatted like ones in tfhe-rs documentation from a
+    /// Markdown table.
+    #[arg(long = "generate-svg-from-markdown")]
+    generate_svg_from_file: Option<String>,
+
+    /// Generate JSON file with regression data with all the results from base
+    /// branch and the latest results of the development branch.
+    #[arg(long = "generate-regression-json")]
+    generate_regression_json: bool,
+
+    /// Restrict the report to one parameter set, matched as a substring of the
+    /// alias. Overrides the profile's `parameters_filter`.
+    #[arg(long = "param")]
+    param: Option<String>,
+
+    /// Print the id patterns the selection expands to, then exit without
+    /// touching the database.
+    #[arg(long = "dry-run")]
+    dry_run: bool,
+}
+
+/// Maps the CLI layer onto the spec's own layer token, so the id prefix used in
+/// the SQL `LIKE` pattern always follows the spec grammar.
+fn layer_kind(layer: Layer) -> anyhow::Result<TfheLayerKind> {
+    Ok(match layer {
+        Layer::HlApi => TfheLayerKind::Hlapi,
+        Layer::Integer => TfheLayerKind::Integer,
+        Layer::Shortint => TfheLayerKind::Shortint,
+        Layer::CoreCrypto => TfheLayerKind::CoreCrypto,
+        // Wasm benches never migrated to the spec grammar: their ids carry no
+        // crate prefix, so there is nothing the parser could match.
+        Layer::Wasm => anyhow::bail!("the `wasm` layer is not part of the benchmark spec"),
+    })
+}
+
+/// How a built table is serialized.
+#[derive(Copy, Clone, Debug)]
+enum OutputFormat {
+    Markdown,
+    Csv,
+    Svg,
+    RegressionJson,
+}
+
+impl OutputFormat {
+    /// Every artefact a run produces: at most one from the exclusive
+    /// `generation` group, plus the CSV, which is always emitted alongside it.
+    /// No flag at all writes nothing.
+    fn from_args(args: &Args) -> Vec<Self> {
+        let mut outputs = Vec::new();
+        if args.generate_markdown {
+            outputs.push(Self::Markdown);
+        } else if args.generate_svg {
+            outputs.push(Self::Svg);
+        } else if args.generate_regression_json {
+            outputs.push(Self::RegressionJson);
+        }
+        if !outputs.is_empty() {
+            outputs.push(Self::Csv);
+        }
+        outputs
+    }
+
+    fn extension(self) -> &'static str {
+        match self {
+            Self::Markdown => "md",
+            Self::Csv => "csv",
+            Self::Svg => "svg",
+            Self::RegressionJson => "json",
+        }
+    }
+
+    fn render(self, grid: &format::Grid) -> anyhow::Result<String> {
+        Ok(match self {
+            Self::Markdown => format::render::markdown::table(grid),
+            Self::Csv => format::render::csv::table(grid),
+            Self::Svg => format::render::svg::table(grid),
+            // Two branches compared over a longer window.
+            Self::RegressionJson => {
+                anyhow::bail!("output format {self:?} is not implemented yet")
+            }
+        })
+    }
+}
+
+/// Which benchmarks the report is about, as SQL-ready patterns.
+struct Selection {
+    /// One exact prefix per bench path (profile), or one broad layer pattern.
+    like_patterns: Vec<String>,
+    /// `LIKE` pattern pinning the parameter set, if any.
+    param_pattern: Option<String>,
+    /// Drop the `unchecked_` variants by name. Only needed for the broad
+    /// pattern: a profile already spells out the operations it wants.
+    exclude_non_default: bool,
+}
+
+impl Selection {
+    /// A regression profile gives an explicit allow-list of bench paths;
+    /// without one, fall back to a broad per-layer pattern. Both are anchored on
+    /// the crate prefix, so legacy ids are excluded.
+    fn from_args(args: &Args) -> anyhow::Result<Self> {
+        let (like_patterns, param_filter, exclude_non_default) = match (
+            args.regression_profiles.as_deref(),
+            args.regression_selected_profile.as_deref(),
+        ) {
+            (Some(path), Some(name)) => {
+                let profiles = profile::Profiles::load(path)?;
+                let selected = profiles.get(args.backend, name)?;
+                let resolved = selected.resolve();
+                if !resolved.unresolved.is_empty() {
+                    eprintln!(
+                        "warning: {} profile entries not in the spec: {}",
+                        resolved.unresolved.len(),
+                        resolved.unresolved.join(", "),
+                    );
+                }
+                (
+                    resolved.like_patterns(&args.name_suffix),
+                    // `--param` wins over the profile's own filter.
+                    args.param
+                        .clone()
+                        .or_else(|| selected.parameters_filter.clone()),
+                    false,
+                )
+            }
+            (Some(_), None) | (None, Some(_)) => {
+                anyhow::bail!("--regression-profiles and --regression-selected-profile go together")
+            }
+            (None, None) => (
+                vec![format!(
+                    "{}::{}::%{}",
+                    BenchCrateKind::Tfhe,
+                    db::like_escape(&layer_kind(args.layer)?.to_string()),
+                    db::like_escape(&args.name_suffix),
+                )],
+                args.param.clone(),
+                true,
+            ),
+        };
+
+        Ok(Self {
+            like_patterns,
+            param_pattern: param_filter
+                .as_deref()
+                .map(|p| format!("%{}%", db::like_escape(p))),
+            exclude_non_default,
+        })
+    }
+
+    /// Human-readable lines, shared by `--dry-run` and the no-result report.
+    fn describe(&self) -> Vec<String> {
+        let mut lines = Vec::new();
+        if let Some(pattern) = &self.param_pattern {
+            lines.push(format!("parameter set: {pattern}"));
+        }
+        lines.push(format!("{} id pattern(s):", self.like_patterns.len()));
+        lines.extend(self.like_patterns.iter().map(|p| format!("  {p}")));
+        lines
+    }
+}
+
+/// Lists every filter the query applied, so that a run without a single result
+/// says why rather than just how many.
+fn report_no_rows(args: &Args, backend: &str, selection: &Selection) {
+    eprintln!("no result matched. Filters applied:");
+    eprintln!("  hardware: {}", args.hardware);
+    eprintln!("  backend:  {backend}");
+    eprintln!("  branch:   {}", args.branch);
+    eprintln!("  metric:   {:?}", args.bench_type);
+    eprintln!("  pbs kind: {:?}", args.pbs_kind);
+    match args.project_version.as_deref() {
+        Some(version) => eprintln!("  version:  {version}"),
+        None => eprintln!(
+            "  window:   {} days back from {}",
+            args.time_span_days,
+            args.bench_date.map_or_else(
+                || "now".to_string(),
+                |date| date.format(BENCH_DATE_FORMAT).to_string()
+            ),
+        ),
+    }
+    for line in selection.describe() {
+        eprintln!("  {line}");
+    }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+    let selection = Selection::from_args(&args)?;
+
+    if args.dry_run {
+        for line in selection.describe() {
+            println!("{line}");
+        }
+        return Ok(());
+    }
+
+    let db_config = db::DbConfig::load(args.config_file.as_deref())?;
+    let pool = db_config.connect(&args.database).await?;
+    let backend = args.backend.to_string();
+    // Sent as text: the `insert_time` column may be `timestamp` or `timestamptz`,
+    // and a SQL cast copes with either, where a typed bind would have to pick one.
+    let bench_date = args
+        .bench_date
+        .map(|date| date.format(BENCH_DATE_FORMAT).to_string());
+
+    let query = db::FetchQuery {
+        hardware: &args.hardware,
+        backend: &backend,
+        branch: &args.branch,
+        like_patterns: &selection.like_patterns,
+        exclude_non_default: selection.exclude_non_default,
+        param_pattern: selection.param_pattern.as_deref(),
+        metric: args.bench_type.as_metric(),
+        pbs_kind: match args.pbs_kind {
+            PbsKind::Classical => db::PbsKind::Classical,
+            PbsKind::MultiBit => db::PbsKind::MultiBit,
+            PbsKind::Any => db::PbsKind::Any,
+        },
+        project_version: args.project_version.as_deref(),
+        bench_date: bench_date.as_deref(),
+        time_span_days: args.time_span_days as i32,
+    };
+
+    let rows = db::fetch_bench_rows(&pool, &query).await?;
+
+    if rows.is_empty() {
+        report_no_rows(&args, &backend, &selection);
+    }
+
+    let outputs = OutputFormat::from_args(&args);
+    if !outputs.is_empty() {
+        // Files are named after the operand type for every layer but
+        // core_crypto; integer publishes both.
+        let tables: Vec<(String, format::Table)> = match (args.layer, args.bench_subset) {
+            (Layer::Integer, BenchSubset::All) => vec![
+                (
+                    "-ciphertext".to_string(),
+                    format::integer::table(&rows, OperandType::CipherText),
+                ),
+                (
+                    "-plaintext".to_string(),
+                    format::integer::table(&rows, OperandType::PlainText),
+                ),
+            ],
+            (Layer::HlApi, BenchSubset::Erc7984) => {
+                vec![("-ciphertext".to_string(), format::erc7984::table(&rows))]
+            }
+            // One table per operation, all ciphertext.
+            (Layer::HlApi, BenchSubset::KvStore) => format::kv_store::tables(&rows)
+                .into_iter()
+                .map(|(suffix, table)| (format!("-ciphertext{suffix}"), table))
+                .collect(),
+            (layer, subset) => {
+                anyhow::bail!("no table implemented for layer {layer:?} / subset {subset:?}")
+            }
+        };
+        println!("{} rows fetched", rows.len());
+        for (suffix, table) in &tables {
+            for output in &outputs {
+                let path = format!("{}{suffix}.{}", args.output_file, output.extension());
+                std::fs::write(&path, output.render(&table.grid)?)?;
+                println!("  wrote {path}");
+            }
+            table.report();
+        }
+    } else {
+        println!("fetched {} rows (layer: {:?})", rows.len(), args.layer);
+        for row in rows.iter().take(10) {
+            println!("{row:?}");
+        }
+    }
+
+    Ok(())
+}

--- a/utils/tfhe-data-extractor/src/profile.rs
+++ b/utils/tfhe-data-extractor/src/profile.rs
@@ -1,0 +1,202 @@
+//! Regression profiles (`ci/regression.toml`): the list of benchmarks a report
+//! is made of, per backend.
+//!
+//! Operations are listed under benchmark targets (the `[[bench]]` names of
+//! `tfhe-benchmark/Cargo.toml`), not under spec layers. Each target maps onto
+//! spec path prefixes, and an entry appended to a prefix must parse as a full
+//! [`BenchCrate`] path.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use benchmark_spec::{Backend, BenchCrate};
+use serde::Deserialize;
+
+use crate::db::like_escape;
+
+/// One `[<backend>.<profile>]` section. `env` and `slab` drive benchmark
+/// execution, not extraction, and are deliberately not deserialized.
+#[derive(Debug, Deserialize)]
+pub struct Profile {
+    /// `target.<name> = [<entry>, …]`, where an entry is a spec path fragment
+    /// and not just an operation name:
+    ///
+    /// ```toml
+    /// target.shortint = ["bitand"]
+    /// target.hlapi-dex = ["swap_request::whitepaper"]
+    /// ```
+    #[serde(default)]
+    pub target: HashMap<String, Vec<String>>,
+    /// Parameter set name to restrict the report to, applied as a SQL filter.
+    pub parameters_filter: Option<String>,
+}
+
+/// Every profile in the file, indexed by backend section, then by profile name.
+///
+/// ```toml
+/// [cpu.default]
+/// target.shortint = ["bitand"]
+/// ```
+///
+/// becomes
+///
+/// ```text
+/// {"cpu": {"default": Profile { target: {"shortint": ["bitand"]} }}}
+/// ```
+#[derive(Debug, Deserialize)]
+#[serde(transparent)]
+pub struct Profiles(HashMap<String, HashMap<String, Profile>>);
+
+impl Profiles {
+    /// Reads and parses the profiles file.
+    pub fn load(path: &Path) -> anyhow::Result<Self> {
+        let raw = std::fs::read_to_string(path)
+            .map_err(|e| anyhow::anyhow!("cannot read profiles file {}: {e}", path.display()))?;
+        Ok(toml::from_str(&raw)?)
+    }
+
+    /// Looks up `[<backend>.<name>]`.
+    pub fn get(&self, backend: Backend, name: &str) -> anyhow::Result<&Profile> {
+        let section = profile_section(backend);
+        self.0
+            .get(section)
+            .and_then(|profiles| profiles.get(name))
+            .ok_or_else(|| anyhow::anyhow!("no profile [{section}.{name}] in profiles file"))
+    }
+}
+
+/// Sections are named after the hardware family, not the spec backend: the
+/// Cuda backend lives under `[gpu.*]`.
+fn profile_section(backend: Backend) -> &'static str {
+    match backend {
+        Backend::Cpu => "cpu",
+        Backend::Cuda => "gpu",
+        Backend::Hpu => "hpu",
+    }
+}
+
+/// Spec path prefixes a profile target expands to.
+///
+/// ```text
+/// target.integer = ["add_parallelized"]
+///   -> tfhe::integer::ops::unsigned::add_parallelized
+///   -> tfhe::integer::ops::signed::add_parallelized
+/// ```
+///
+/// `integer` is the only target yielding two prefixes; conversely
+/// `core_crypto-ks` and `core_crypto-pbs` share one.
+fn target_prefixes(target: &str) -> Option<&'static [&'static str]> {
+    Some(match target {
+        "integer" => &["tfhe::integer::ops::unsigned", "tfhe::integer::ops::signed"],
+        "shortint" => &["tfhe::shortint::ops"],
+        "hlapi-dex" => &["tfhe::hlapi::dex"],
+        "hlapi-erc7984" => &["tfhe::hlapi::erc7984"],
+        "core_crypto-ks" | "core_crypto-pbs" => &["tfhe::core_crypto"],
+        _ => return None,
+    })
+}
+
+/// Outcome of resolving a profile against the spec.
+#[derive(Debug, Default)]
+pub struct Resolved {
+    /// Bench paths the report covers.
+    pub paths: Vec<BenchCrate>,
+    /// `target.entry` pairs that match no spec path: a not-yet-migrated bench,
+    /// or a typo. Reported, never silently dropped.
+    pub unresolved: Vec<String>,
+}
+
+impl Profile {
+    /// Turns every `target.<name> = [ops]` entry into spec bench paths.
+    pub fn resolve(&self) -> Resolved {
+        let mut out = Resolved::default();
+
+        // HashMap order is arbitrary; sort so warnings are stable.
+        let mut targets: Vec<_> = self.target.iter().collect();
+        targets.sort_by_key(|(name, _)| *name);
+
+        for (target, entries) in targets {
+            let Some(prefixes) = target_prefixes(target) else {
+                out.unresolved.push(format!("{target} (unknown target)"));
+                continue;
+            };
+
+            for entry in entries {
+                let matched: Vec<BenchCrate> = prefixes
+                    .iter()
+                    .filter_map(|prefix| format!("{prefix}::{entry}").parse().ok())
+                    .collect();
+
+                if matched.is_empty() {
+                    out.unresolved.push(format!("{target}.{entry}"));
+                } else {
+                    out.paths.extend(matched);
+                }
+            }
+        }
+
+        out
+    }
+}
+
+impl Resolved {
+    /// SQL `LIKE` patterns matching every id under these bench paths.
+    ///
+    /// `LIKE` matches the whole string, so neither end needs a `%`: both are
+    /// anchored, and the single `%` is the hole left for the backend, the
+    /// metric, the parameter set and the type.
+    ///
+    /// ```text
+    /// tfhe::integer::ops::unsigned::add_parallelized::%\_mean\_avx512
+    /// └──────────── bench path, exact ─────────────┘  ↑└── suffix ──┘
+    /// ```
+    pub fn like_patterns(&self, suffix: &str) -> Vec<String> {
+        self.paths
+            .iter()
+            .map(|path| {
+                format!(
+                    "{}::%{}",
+                    like_escape(&path.to_string()),
+                    like_escape(suffix)
+                )
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PROFILES: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../../ci/regression.toml");
+
+    /// A failure here lists the benches still outside the spec.
+    #[test]
+    fn regression_profiles_resolve() {
+        let profiles = Profiles::load(Path::new(PROFILES)).unwrap();
+
+        for (backend, name) in [(Backend::Cpu, "default"), (Backend::Cuda, "default")] {
+            let resolved = profiles.get(backend, name).unwrap().resolve();
+            assert!(
+                resolved.unresolved.is_empty(),
+                "[{}.{name}] does not resolve: {:?}",
+                profile_section(backend),
+                resolved.unresolved,
+            );
+            assert!(!resolved.paths.is_empty());
+        }
+    }
+
+    #[test]
+    fn like_patterns_are_escaped_and_anchored() {
+        let profiles = Profiles::load(Path::new(PROFILES)).unwrap();
+        let resolved = profiles.get(Backend::Cpu, "default").unwrap().resolve();
+        let patterns = resolved.like_patterns("_mean_avx512");
+
+        assert!(
+            patterns
+                .iter()
+                .any(|p| p == r"tfhe::integer::ops::unsigned::add\_parallelized::%\_mean\_avx512")
+        );
+    }
+}


### PR DESCRIPTION
Ports `ci/data_extractor` to Rust as `utils/tfhe-data-extractor`, plus the `benchmark_spec` work it needs.

`benchmark_spec` gains `FromStr` down the whole bench tree, so an id parses back through the grammar it renders with, and now owns the stored result name `{bench_id}_{statistic}(_{variant})?` that `tfhe-benchmark-parser` composes. What lands in the results database is unchanged.

The extractor resolves a regression profile to bench paths, turns them into anchored SQL `LIKE` patterns, and renders the integer, ERC7984 and KV-store tables as Markdown, CSV or SVG. Regression JSON, backends comparison, the wasm layer and the shortint and core_crypto tables are not ported and fail explicitly, so the Python tool stays for now.

AI was used along the way to keep the python context and correct the code written

Here is an example of the rust version

<img width="720" height="560" alt="out_rs-ciphertext" src="https://github.com/user-attachments/assets/89c096b9-5656-4d12-a7cc-529b5f47054d" />
