### PR TITLE
Ts/extractor/migrate data extractor to rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,7 +133,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -144,7 +144,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -307,6 +307,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -455,6 +464,12 @@ name = "bytemuck"
 version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -801,6 +816,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
 name = "criterion"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -983,6 +1013,18 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common 0.1.7",
+ "subtle",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1002,6 +1044,12 @@ name = "dot2"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "855423f2158bcc73798b3b9a666ec4204597a72370dc91dbdb8e7f9519de8cc3"
+
+[[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "dyn-clone"
@@ -1042,6 +1090,9 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "enum-iterator"
@@ -1151,7 +1202,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
+dependencies = [
+ "parking",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1206,6 +1278,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "fs2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1255,6 +1336,17 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
 ]
 
 [[package]]
@@ -1418,7 +1510,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cfc928d8ff4ab3767a3674cf55f81186436fb6070866bb1443ffe65a640d2d6"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1468,6 +1560,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -1480,6 +1574,15 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -1507,12 +1610,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "home"
 version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1576,10 +1697,113 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "ignore"
@@ -1767,10 +1991,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libredox"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
+dependencies = [
+ "bitflags",
+ "libc",
+ "plain",
+ "redox_syscall 0.9.1",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -1804,6 +2055,16 @@ checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
 dependencies = [
  "autocfg",
  "rawpointer",
+]
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
 ]
 
 [[package]]
@@ -1853,7 +2114,7 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1916,7 +2177,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2037,6 +2298,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.5.18",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "parse-zoneinfo"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2151,6 +2441,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
 name = "plotters"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2200,6 +2496,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "031ebbce771a275a3754a853d083de4713d41dfddff247f29b11b809c8b34a2c"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -2404,6 +2709,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07507be7b4a5f9f26eeb41eeaebb1f5a7ff29dfb29739facc21d35bf8b11c21e"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "ref-cast"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2451,6 +2774,20 @@ name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "rmp"
@@ -2536,7 +2873,41 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -2592,6 +2963,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
@@ -2794,6 +3171,145 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-postgres",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+dependencies = [
+ "base64",
+ "bytes",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.15.5",
+ "hashlink",
+ "indexmap 2.14.0",
+ "log",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rustls",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "thiserror 2.0.19",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck 0.5.0",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sqlx-core",
+ "sqlx-postgres",
+ "syn 2.0.118",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags",
+ "byteorder",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "rand 0.8.6",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.19",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_assertions"
@@ -2818,6 +3334,17 @@ name = "strength_reduce"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
 
 [[package]]
 name = "strsim"
@@ -2890,6 +3417,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2909,6 +3442,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2939,7 +3483,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3163,6 +3707,20 @@ dependencies = [
  "bindgen",
  "cmake",
  "pkg-config",
+]
+
+[[package]]
+name = "tfhe-data-extractor"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "benchmark_spec",
+ "chrono",
+ "clap",
+ "serde",
+ "sqlx",
+ "tokio",
+ "toml 0.8.23",
 ]
 
 [[package]]
@@ -3395,6 +3953,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3418,6 +3986,43 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
 
 [[package]]
 name = "toml"
@@ -3530,6 +4135,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3630,10 +4236,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
@@ -3652,6 +4279,30 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -3715,6 +4366,12 @@ checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen 0.51.0",
 ]
+
+[[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -3938,6 +4595,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "whoami"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite",
+]
+
+[[package]]
 name = "wide"
 version = "0.7.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3969,7 +4654,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3985,7 +4670,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
 dependencies = [
  "windows-core 0.58.0",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3998,7 +4683,7 @@ dependencies = [
  "windows-interface 0.58.0",
  "windows-result 0.2.0",
  "windows-strings 0.1.0",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4070,7 +4755,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4089,7 +4774,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
  "windows-result 0.2.0",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4103,6 +4788,24 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -4112,19 +4815,40 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -4134,9 +4858,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4152,9 +4888,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4164,9 +4912,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4284,10 +5044,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
 name = "xdg"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fb433233f2df9344722454bc7e96465c9d03bff9d77c248f9e7523fe79585b5"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "synstructure",
+]
 
 [[package]]
 name = "zerocopy"
@@ -4310,6 +5099,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4323,6 +5133,39 @@ name = "zeroize_derive"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -328,8 +328,10 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 name = "benchmark_spec"
 version = "0.1.0"
 dependencies = [
+ "enum-iterator",
  "serde",
  "strum 0.28.0",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -1040,6 +1042,26 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "enum-iterator"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4549325971814bda7a44061bf3fe7e487d447cba01e4220a4b454d630d7a016"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685adfa4d6f3d765a26bc5dbc936577de9abf756c1feeb3089b01dd395034842"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "enum-ordinalize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ members = [
     "utils/wasm-par-mq",
     "utils/wasm-par-mq/examples/msm",
     "utils/wasm-par-mq/web_tests",
+    "utils/tfhe-data-extractor",
 ]
 
 exclude = [

--- a/Makefile
+++ b/Makefile
@@ -699,6 +699,11 @@ clippy_benchmark_parser: install_rs_check_toolchain
 	RUSTFLAGS="$(RUSTFLAGS)" cargo "$(CARGO_RS_CHECK_TOOLCHAIN)" clippy --all-targets \
 		-p tfhe-benchmark-parser -- --no-deps -D warnings
 
+.PHONY: clippy_data_extractor # Run clippy lints on tfhe-data-extractor
+clippy_data_extractor: install_rs_check_toolchain
+	RUSTFLAGS="$(RUSTFLAGS)" cargo "$(CARGO_RS_CHECK_TOOLCHAIN)" clippy --all-targets \
+		-p tfhe-data-extractor -- --no-deps -D warnings
+
 .PHONY: clippy_fuzz # Run clippy lints on fuzzing crates
 clippy_fuzz: install_rs_check_toolchain
 	@find utils/fuzz -name Cargo.toml -not -path '*/target/*' | while read crate; do \
@@ -797,7 +802,7 @@ clippy_test_vectors: install_rs_check_toolchain
 clippy_all: clippy_rustdoc clippy clippy_boolean clippy_shortint clippy_integer clippy_all_targets \
 clippy_c_api clippy_js_wasm_api clippy_tasks clippy_core clippy_tfhe_csprng clippy_zk_pok clippy_zk_pok_wasm clippy_trivium \
 clippy_versionable clippy_safe_serialize clippy_tfhe_lints clippy_ws_tests clippy_bench clippy_param_dedup \
-clippy_benchmark_spec clippy_benchmark_parser clippy_test_vectors clippy_backward_compat_data clippy_wasm_par_mq \
+clippy_benchmark_spec clippy_benchmark_parser clippy_data_extractor clippy_test_vectors clippy_backward_compat_data clippy_wasm_par_mq \
 clippy_fuzz
 
 .PHONY: clippy_fast # Run main clippy targets
@@ -1577,6 +1582,14 @@ test_versionable:
 test_safe_serialize:
 	RUSTFLAGS="$(RUSTFLAGS)" cargo test --profile $(CARGO_PROFILE) \
 		--all-targets -p tfhe-safe-serialize
+
+# These three own the benchmark id grammar and the tools reading it back. No
+# database needed: the extractor builds its queries at runtime, and its profile
+# test reads ci/regression.toml relative to the workspace root.
+.PHONY: test_benchmark_utils # Run tests for benchmark_spec, the bench parser and the data extractor
+test_benchmark_utils:
+	RUSTFLAGS="$(RUSTFLAGS)" cargo test --profile $(CARGO_PROFILE) \
+		--all-targets -p benchmark_spec -p tfhe-benchmark-parser -p tfhe-data-extractor
 
 # The backward compat data folder holds historical binary data but also rust code to generate and load them.
 .PHONY: gen_backward_compat_data # Re-generate backward compatibility data
@@ -2707,6 +2720,8 @@ pcc_batch_6:
 	$(call run_recipe_with_details,clippy_param_dedup)
 	$(call run_recipe_with_details,clippy_benchmark_spec)
 	$(call run_recipe_with_details,clippy_benchmark_parser)
+	$(call run_recipe_with_details,clippy_data_extractor)
+	$(call run_recipe_with_details,test_benchmark_utils)
 	$(call run_recipe_with_details,docs)
 
 .PHONY: pcc_batch_7 # duration: 7'50'' (currently PCC execution bottleneck)

--- a/tfhe-benchmark/benches/core_crypto/ks_bench.rs
+++ b/tfhe-benchmark/benches/core_crypto/ks_bench.rs
@@ -152,7 +152,7 @@ fn keyswitch<Scalar: UnsignedTorus + CastInto<usize> + Serialize>(
             &benchmark_spec,
             "ks",
             &OperatorType::Atomic,
-            bit_size,
+            bit_size as u64,
             vec![bit_size],
         );
     }
@@ -332,7 +332,7 @@ fn packing_keyswitch<Scalar, F>(
             &benchmark_spec,
             "packing_ks",
             &OperatorType::Atomic,
-            1u32,
+            1u64,
             vec![1u32],
         );
     }
@@ -505,7 +505,7 @@ mod cuda {
                         &benchmark_spec,
                         "ks",
                         &OperatorType::Atomic,
-                        bit_size,
+                        bit_size as u64,
                         vec![bit_size],
                     );
                 }
@@ -639,7 +639,7 @@ mod cuda {
                                 &benchmark_spec,
                                 "ks",
                                 &OperatorType::Atomic,
-                                bit_size,
+                                bit_size as u64,
                                 vec![bit_size],
                             );
                         }
@@ -879,7 +879,7 @@ mod cuda {
                 &benchmark_spec,
                 "packing_ks",
                 &OperatorType::Atomic,
-                bit_size,
+                bit_size as u64,
                 vec![bit_size],
             );
         }

--- a/tfhe-benchmark/benches/core_crypto/ks_pbs_bench.rs
+++ b/tfhe-benchmark/benches/core_crypto/ks_pbs_bench.rs
@@ -283,7 +283,7 @@ fn ks_pbs<Scalar: UnsignedTorus + CastInto<usize> + Serialize>(
             &benchmark_spec,
             "ks-pbs",
             &OperatorType::Atomic,
-            bit_size,
+            bit_size as u64,
             vec![bit_size],
         );
     }
@@ -530,7 +530,7 @@ fn multi_bit_ks_pbs<
             &benchmark_spec,
             "ks-pbs",
             &OperatorType::Atomic,
-            bit_size,
+            bit_size as u64,
             vec![bit_size],
         );
     }
@@ -858,7 +858,7 @@ mod cuda {
                 &benchmark_spec,
                 "ks-pbs",
                 &OperatorType::Atomic,
-                bit_size,
+                bit_size as u64,
                 vec![bit_size],
             );
         }
@@ -1165,7 +1165,7 @@ mod cuda {
                 &benchmark_spec,
                 "ks-pbs",
                 &OperatorType::Atomic,
-                bit_size,
+                bit_size as u64,
                 vec![bit_size],
             );
         }

--- a/tfhe-benchmark/benches/core_crypto/pbs128_bench.rs
+++ b/tfhe-benchmark/benches/core_crypto/pbs128_bench.rs
@@ -147,7 +147,7 @@ fn pbs_128(c: &mut Criterion) {
         &benchmark_spec,
         "pbs",
         &OperatorType::Atomic,
-        bit_size,
+        bit_size as u64,
         vec![bit_size],
     );
 }
@@ -414,7 +414,7 @@ mod cuda {
             &benchmark_spec,
             "pbs",
             &OperatorType::Atomic,
-            bit_size,
+            bit_size as u64,
             vec![bit_size],
         );
     }
@@ -665,7 +665,7 @@ mod cuda {
             &benchmark_spec,
             "pbs",
             &OperatorType::Atomic,
-            bit_size,
+            bit_size as u64,
             vec![bit_size],
         );
     }

--- a/tfhe-benchmark/benches/core_crypto/pbs_bench.rs
+++ b/tfhe-benchmark/benches/core_crypto/pbs_bench.rs
@@ -233,7 +233,7 @@ fn mem_optimized_pbs<Scalar: UnsignedTorus + CastInto<usize> + Serialize>(
             &benchmark_spec,
             "pbs",
             &OperatorType::Atomic,
-            bit_size,
+            bit_size as u64,
             vec![bit_size],
         );
     }
@@ -481,7 +481,7 @@ fn mem_optimized_batched_pbs<Scalar: UnsignedTorus + CastInto<usize> + Serialize
             &benchmark_spec,
             "pbs",
             &OperatorType::Atomic,
-            bit_size,
+            bit_size as u64,
             vec![bit_size],
         );
     }
@@ -688,7 +688,7 @@ fn multi_bit_pbs<
             &benchmark_spec,
             "pbs",
             &OperatorType::Atomic,
-            bit_size,
+            bit_size as u64,
             vec![bit_size],
         );
     }
@@ -945,7 +945,7 @@ fn mem_optimized_pbs_ntt(c: &mut Criterion) {
             &benchmark_spec,
             "pbs",
             &OperatorType::Atomic,
-            bit_size,
+            bit_size as u64,
             vec![bit_size],
         );
     }

--- a/tfhe-benchmark/benches/high_level_api/bench_common.rs
+++ b/tfhe-benchmark/benches/high_level_api/bench_common.rs
@@ -32,7 +32,7 @@ pub fn bench_fhe_type_op<FheType, Op>(
 
     let param = client_key.computation_parameters();
     let param_name = param.name();
-    let bit_size = bit_size as u32;
+    let bit_size = bit_size as u64;
 
     let inputs = op.setup_inputs(client_key, &mut rng);
 

--- a/tfhe-benchmark/benches/high_level_api/bitonic_shuffle.rs
+++ b/tfhe-benchmark/benches/high_level_api/bitonic_shuffle.rs
@@ -224,7 +224,7 @@ fn bench_shuffle_config<T>(
         params_name,
         "bitonic_shuffle",
         &OperatorType::Atomic,
-        value_bits,
+        value_bits as u64,
         vec![],
     );
 }

--- a/tfhe-benchmark/benches/high_level_api/dex.rs
+++ b/tfhe-benchmark/benches/high_level_api/dex.rs
@@ -524,7 +524,7 @@ fn bench_swap_request_throughput<FheType, F1, F2>(
             OperandType::CipherText,
             Some(type_name),
             BenchmarkMetric::Throughput,
-            Some(num_elems.try_into().unwrap()),
+            Some(num_elems),
         );
 
         group.bench_with_input(bench_spec.to_string(), &num_elems, |b, &num_elems| {
@@ -652,7 +652,7 @@ fn cuda_bench_swap_request_throughput<FheType, F1, F2>(
             OperandType::CipherText,
             Some(type_name),
             BenchmarkMetric::Throughput,
-            Some(num_elems.try_into().unwrap()),
+            Some(num_elems),
         );
         group.bench_with_input(bench_spec.to_string(), &num_elems, |b, &num_elems| {
             let from_balances_0 = (0..num_elems)
@@ -945,7 +945,7 @@ fn bench_swap_claim_throughput<FheType, F1, F2>(
             OperandType::CipherText,
             Some(type_name),
             BenchmarkMetric::Throughput,
-            Some(num_elems.try_into().unwrap()),
+            Some(num_elems),
         );
 
         group.bench_with_input(bench_spec.to_string(), &num_elems, |b, &num_elems| {
@@ -1091,7 +1091,7 @@ fn cuda_bench_swap_claim_throughput<FheType, F1, F2>(
             OperandType::CipherText,
             Some(type_name),
             BenchmarkMetric::Throughput,
-            Some(num_elems.try_into().unwrap()),
+            Some(num_elems),
         );
         group.bench_with_input(bench_spec.to_string(), &num_elems, |b, &num_elems| {
             let pending_0_in = (0..num_elems)

--- a/tfhe-benchmark/benches/high_level_api/erc7984.rs
+++ b/tfhe-benchmark/benches/high_level_api/erc7984.rs
@@ -486,7 +486,7 @@ fn bench_transfer_throughput<FheType, F>(
             OperandType::CipherText,
             Some(type_name),
             BenchmarkMetric::Throughput,
-            Some(num_elems.try_into().unwrap()),
+            Some(num_elems),
         );
         let bench_id = bench_spec.to_string();
         group.bench_with_input(&bench_id, &num_elems, |b, &num_elems| {
@@ -557,7 +557,7 @@ fn cuda_bench_transfer_throughput<FheType, F>(
         OperandType::CipherText,
         Some(type_name),
         BenchmarkMetric::Throughput,
-        Some(reported_num_elems.try_into().unwrap()),
+        Some(reported_num_elems),
     );
     group.bench_with_input(bench_spec.to_string(), &num_elems, |b, &num_elems| {
         let from_amounts = (0..num_elems)

--- a/tfhe-benchmark/benches/high_level_api/kv_store.rs
+++ b/tfhe-benchmark/benches/high_level_api/kv_store.rs
@@ -24,7 +24,7 @@ use tfhe::{
     KVStore,
 };
 
-fn bench_kv_store<Key, FheKey, Value>(c: &mut Criterion, cks: &ClientKey, num_elements: usize)
+fn bench_kv_store<Key, FheKey, Value>(c: &mut Criterion, cks: &ClientKey, num_elements: u64)
 where
     rand::distributions::Standard: Distribution<Key>,
     Key: Numeric + DecomposableInto<u64> + Ord + CastInto<usize> + TypeDisplay,
@@ -67,7 +67,7 @@ where
 
     match get_bench_type() {
         BenchmarkType::Latency => {
-            while kv_store.len() != num_elements {
+            while kv_store.len() != num_elements as usize {
                 let key = rng.gen::<Key>();
                 let value = rng.gen::<u128>();
 
@@ -118,7 +118,7 @@ where
             });
         }
         BenchmarkType::Throughput => {
-            while kv_store.len() != num_elements {
+            while kv_store.len() != num_elements as usize {
                 let key = rng.gen::<Key>();
                 let value = rng.gen::<u128>();
 
@@ -138,8 +138,8 @@ where
                     use benchmark::utilities::throughput_num_threads;
                     use tfhe::IntegerId;
                     let value_blocks = Value::Id::num_blocks(param.message_modulus());
-                    let factor =
-                        throughput_num_threads(num_elements * value_blocks, 1).max(1) as usize;
+                    let factor = throughput_num_threads(num_elements as usize * value_blocks, 1)
+                        .max(1) as usize;
 
                     let mut kv_stores = Vec::with_capacity(factor);
                     for _ in 0..factor {
@@ -231,7 +231,7 @@ where
             &bench_spec,
             display_name,
             &OperatorType::Atomic,
-            Key::BITS as u32,
+            Key::BITS as u64,
             vec![],
         );
     }

--- a/tfhe-benchmark/benches/high_level_api/vector_find.rs
+++ b/tfhe-benchmark/benches/high_level_api/vector_find.rs
@@ -15,21 +15,21 @@ fn write_metadata(
     spec: &BenchmarkSpec,
     display_name: &str,
     params: AtomicPatternParameters,
-    num_bits: usize,
+    num_bits: u64,
 ) {
     write_to_json(
         spec,
         display_name,
         &OperatorType::Atomic,
-        num_bits as u32,
-        vec![params.message_modulus().0.ilog2(); num_bits],
+        num_bits,
+        vec![params.message_modulus().0.ilog2(); num_bits as usize],
     );
 }
 
 fn bench_latency_or_throughput<F>(
     group: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
     spec: &BenchmarkSpec,
-    operand_bits: usize,
+    operand_bits: u64,
     client_key: &ClientKey,
     run_once: F,
 ) where
@@ -72,7 +72,7 @@ fn bench_latency_or_throughput<F>(
     }
 }
 
-fn bench_contains_fhe_uint64(c: &mut Criterion, client_key: &ClientKey, num_elements: usize) {
+fn bench_contains_fhe_uint64(c: &mut Criterion, client_key: &ClientKey, num_elements: u64) {
     let mut group = c.benchmark_group("vector_find");
     group.sample_size(15);
 
@@ -86,7 +86,7 @@ fn bench_contains_fhe_uint64(c: &mut Criterion, client_key: &ClientKey, num_elem
         get_bench_type(),
         Some(num_elements),
     );
-    let cts: Vec<FheUint64> = (0..num_elements as u64)
+    let cts: Vec<FheUint64> = (0..num_elements)
         .map(|i| FheUint64::encrypt(i, client_key))
         .collect();
     let value = FheUint64::encrypt(1u64, client_key);
@@ -99,7 +99,7 @@ fn bench_contains_fhe_uint64(c: &mut Criterion, client_key: &ClientKey, num_elem
     group.finish();
 }
 
-fn bench_contains_fhe_uint8(c: &mut Criterion, client_key: &ClientKey, num_elements: usize) {
+fn bench_contains_fhe_uint8(c: &mut Criterion, client_key: &ClientKey, num_elements: u64) {
     let mut group = c.benchmark_group("vector_find");
     group.sample_size(15);
 
@@ -126,7 +126,7 @@ fn bench_contains_fhe_uint8(c: &mut Criterion, client_key: &ClientKey, num_eleme
     group.finish();
 }
 
-fn bench_match_value_fhe_uint64(c: &mut Criterion, client_key: &ClientKey, num_elements: usize) {
+fn bench_match_value_fhe_uint64(c: &mut Criterion, client_key: &ClientKey, num_elements: u64) {
     let mut group = c.benchmark_group("vector_find");
     group.sample_size(15);
 
@@ -140,7 +140,7 @@ fn bench_match_value_fhe_uint64(c: &mut Criterion, client_key: &ClientKey, num_e
         get_bench_type(),
         Some(num_elements),
     );
-    let pairs: Vec<(u64, u64)> = (0..num_elements as u64).map(|i| (i, i + 1)).collect();
+    let pairs: Vec<(u64, u64)> = (0..num_elements).map(|i| (i, i + 1)).collect();
     let match_values = MatchValues::new(pairs).unwrap();
     let ct = FheUint64::encrypt(1u64, client_key);
 
@@ -152,7 +152,7 @@ fn bench_match_value_fhe_uint64(c: &mut Criterion, client_key: &ClientKey, num_e
     group.finish();
 }
 
-fn bench_match_value_fhe_uint8(c: &mut Criterion, client_key: &ClientKey, num_elements: usize) {
+fn bench_match_value_fhe_uint8(c: &mut Criterion, client_key: &ClientKey, num_elements: u64) {
     let mut group = c.benchmark_group("vector_find");
     group.sample_size(15);
 
@@ -214,7 +214,7 @@ fn main() {
     let mut c = Criterion::default().configure_from_args();
 
     let env_config = EnvConfig::new();
-    let sizes: &[usize] = match env_config.bit_sizes_set {
+    let sizes: &[u64] = match env_config.bit_sizes_set {
         BitSizesSet::Fast => &[50, 1000],
         _ => &[5, 10, 20, 30, 40, 50, 500, 1000],
     };

--- a/tfhe-benchmark/benches/integer/bench.rs
+++ b/tfhe-benchmark/benches/integer/bench.rs
@@ -151,7 +151,7 @@ fn bench_server_key_binary_function_clean_inputs<F>(
             &benchmark_spec,
             display_name,
             &OperatorType::Atomic,
-            bit_size as u32,
+            bit_size as u64,
             vec![param.message_modulus().0.ilog2(); num_block],
         );
     }
@@ -224,7 +224,7 @@ fn bench_server_key_unary_function_dirty_inputs<F>(
             &benchmark_spec,
             display_name,
             &OperatorType::Atomic,
-            bit_size as u32,
+            bit_size as u64,
             vec![param.message_modulus().0.ilog2(); num_block],
         );
     }
@@ -331,7 +331,7 @@ fn bench_server_key_unary_function_clean_inputs<F>(
             &benchmark_spec,
             display_name,
             &OperatorType::Atomic,
-            bit_size as u32,
+            bit_size as u64,
             vec![param.message_modulus().0.ilog2(); num_block],
         );
     }
@@ -460,7 +460,7 @@ fn bench_server_key_binary_scalar_function_clean_inputs<F, G>(
             &benchmark_spec,
             display_name,
             &OperatorType::Atomic,
-            bit_size as u32,
+            bit_size as u64,
             vec![param.message_modulus().0.ilog2(); num_block],
         );
     }
@@ -605,7 +605,7 @@ fn if_then_else_parallelized(c: &mut Criterion) {
             &benchmark_spec,
             display_name,
             &OperatorType::Atomic,
-            bit_size as u32,
+            bit_size as u64,
             vec![param.message_modulus().0.ilog2(); num_block],
         );
     }
@@ -719,7 +719,7 @@ fn flip_parallelized(c: &mut Criterion) {
             &benchmark_spec,
             display_name,
             &OperatorType::Atomic,
-            bit_size as u32,
+            bit_size as u64,
             vec![param.message_modulus().0.ilog2(); num_block],
         );
     }
@@ -845,7 +845,7 @@ fn ciphertexts_sum_parallelized(c: &mut Criterion) {
                 &benchmark_spec,
                 display_name,
                 &OperatorType::Atomic,
-                bit_size as u32,
+                bit_size as u64,
                 vec![param.message_modulus().0.ilog2(); num_block],
             );
         }
@@ -1374,7 +1374,7 @@ mod cuda {
                 &benchmark_spec,
                 display_name,
                 &OperatorType::Atomic,
-                bit_size as u32,
+                bit_size as u64,
                 vec![param.message_modulus().0.ilog2(); num_block],
             );
         }
@@ -1523,7 +1523,7 @@ mod cuda {
                 &benchmark_spec,
                 display_name,
                 &OperatorType::Atomic,
-                bit_size as u32,
+                bit_size as u64,
                 vec![param.message_modulus().0.ilog2(); num_block],
             );
         }
@@ -1666,7 +1666,7 @@ mod cuda {
                 &benchmark_spec,
                 display_name,
                 &OperatorType::Atomic,
-                bit_size as u32,
+                bit_size as u64,
                 vec![param.message_modulus().0.ilog2(); num_block],
             );
         }
@@ -1822,7 +1822,7 @@ mod cuda {
                 &benchmark_spec,
                 "if_then_else",
                 &OperatorType::Atomic,
-                bit_size as u32,
+                bit_size as u64,
                 vec![param.message_modulus().0.ilog2(); num_block],
             );
         }
@@ -2699,7 +2699,7 @@ mod cuda {
                     &benchmark_spec,
                     display_name,
                     &OperatorType::Atomic,
-                    bit_size as u32,
+                    bit_size as u64,
                     vec![param.message_modulus().0.ilog2(); num_blocks],
                 );
             }
@@ -2942,7 +2942,7 @@ mod hpu {
                 &benchmark_spec,
                 display_name,
                 &OperatorType::Atomic,
-                bit_size as u32,
+                bit_size as u64,
                 vec![param.message_modulus().0.ilog2(); num_block],
             );
         }
@@ -3465,7 +3465,7 @@ fn bench_server_key_cast_function<F>(
                 &benchmark_spec,
                 display_name,
                 &OperatorType::Atomic,
-                bit_size as u32,
+                bit_size as u64,
                 vec![param.message_modulus().0.ilog2(); num_blocks],
             );
         }

--- a/tfhe-benchmark/benches/integer/glwe_packing_compression.rs
+++ b/tfhe-benchmark/benches/integer/glwe_packing_compression.rs
@@ -183,7 +183,7 @@ fn cpu_glwe_packing(c: &mut Criterion) {
             comp_param.name(),
             "pack",
             &OperatorType::Atomic,
-            bit_size as u32,
+            bit_size as u64,
             vec![param.message_modulus.0.ilog2(); num_blocks],
         );
 
@@ -192,7 +192,7 @@ fn cpu_glwe_packing(c: &mut Criterion) {
             comp_param.name(),
             "unpack",
             &OperatorType::Atomic,
-            bit_size as u32,
+            bit_size as u64,
             vec![param.message_modulus.0.ilog2(); num_blocks],
         );
     }
@@ -337,7 +337,7 @@ mod cuda {
             comp_param.name(),
             "pack",
             &OperatorType::Atomic,
-            bit_size as u32,
+            bit_size as u64,
             vec![param.message_modulus().0.ilog2(); num_blocks],
         );
 
@@ -499,7 +499,7 @@ mod cuda {
             comp_param.name(),
             "unpack",
             &OperatorType::Atomic,
-            bit_size as u32,
+            bit_size as u64,
             vec![param.message_modulus().0.ilog2(); num_blocks],
         );
 

--- a/tfhe-benchmark/benches/integer/glwe_packing_compression_128b.rs
+++ b/tfhe-benchmark/benches/integer/glwe_packing_compression_128b.rs
@@ -174,7 +174,7 @@ mod cuda {
             noise_squashing_compression_parameters.name(),
             "pack",
             &OperatorType::Atomic,
-            bit_size as u32,
+            bit_size as u64,
             vec![param.message_modulus().0.ilog2(); num_blocks],
         );
 
@@ -328,7 +328,7 @@ mod cuda {
             noise_squashing_compression_parameters.name(),
             "unpack",
             &OperatorType::Atomic,
-            bit_size as u32,
+            bit_size as u64,
             vec![param.message_modulus().0.ilog2(); num_blocks],
         );
 

--- a/tfhe-benchmark/benches/integer/kreyvium.rs
+++ b/tfhe-benchmark/benches/integer/kreyvium.rs
@@ -118,7 +118,7 @@ pub mod cuda {
             param_name.clone(),
             format!("{method_label}_init"),
             &OperatorType::Atomic,
-            u32::try_from(KREYVIUM_KEY_BITS).unwrap(),
+            u64::try_from(KREYVIUM_KEY_BITS).unwrap(),
             vec![atomic_param.message_modulus().0.ilog2(); KREYVIUM_KEY_BITS],
         );
 
@@ -139,7 +139,7 @@ pub mod cuda {
                 param_name.clone(),
                 format!("{method_label}_next_{num_steps}_bits"),
                 &OperatorType::Atomic,
-                u32::try_from(KREYVIUM_KEY_BITS).unwrap(),
+                u64::try_from(KREYVIUM_KEY_BITS).unwrap(),
                 vec![atomic_param.message_modulus().0.ilog2(); KREYVIUM_KEY_BITS],
             );
 
@@ -157,7 +157,7 @@ pub mod cuda {
                 param_name.clone(),
                 format!("{method_label}_generation_{num_steps}_bits"),
                 &OperatorType::Atomic,
-                u32::try_from(KREYVIUM_KEY_BITS).unwrap(),
+                u64::try_from(KREYVIUM_KEY_BITS).unwrap(),
                 vec![atomic_param.message_modulus().0.ilog2(); KREYVIUM_KEY_BITS],
             );
         }
@@ -238,7 +238,7 @@ pub mod cuda {
             param_name.clone(),
             format!("{method_label}_throughput_init"),
             &OperatorType::Atomic,
-            u32::try_from(KREYVIUM_KEY_BITS).unwrap(),
+            u64::try_from(KREYVIUM_KEY_BITS).unwrap(),
             vec![atomic_param.message_modulus().0.ilog2(); KREYVIUM_KEY_BITS],
         );
 
@@ -259,7 +259,7 @@ pub mod cuda {
                 param_name.clone(),
                 format!("{method_label}_throughput_next_{num_steps}"),
                 &OperatorType::Atomic,
-                u32::try_from(KREYVIUM_KEY_BITS).unwrap(),
+                u64::try_from(KREYVIUM_KEY_BITS).unwrap(),
                 vec![atomic_param.message_modulus().0.ilog2(); KREYVIUM_KEY_BITS],
             );
 
@@ -276,7 +276,7 @@ pub mod cuda {
                 param_name.clone(),
                 format!("{method_label}_throughput_generate_{num_steps}"),
                 &OperatorType::Atomic,
-                u32::try_from(KREYVIUM_KEY_BITS).unwrap(),
+                u64::try_from(KREYVIUM_KEY_BITS).unwrap(),
                 vec![atomic_param.message_modulus().0.ilog2(); KREYVIUM_KEY_BITS],
             );
         }

--- a/tfhe-benchmark/benches/integer/oprf.rs
+++ b/tfhe-benchmark/benches/integer/oprf.rs
@@ -154,7 +154,7 @@ pub fn unsigned_oprf(c: &mut Criterion) {
                 spec,
                 display_name,
                 &OperatorType::Atomic,
-                bit_size as u32,
+                bit_size as u64,
                 vec![param.message_modulus().0.ilog2(); num_block],
             );
         }
@@ -324,7 +324,7 @@ pub mod cuda {
                     spec,
                     display_name,
                     &OperatorType::Atomic,
-                    bit_size as u32,
+                    bit_size as u64,
                     vec![param.message_modulus().0.ilog2(); num_block],
                 );
             }

--- a/tfhe-benchmark/benches/integer/rerand.rs
+++ b/tfhe-benchmark/benches/integer/rerand.rs
@@ -207,7 +207,7 @@ fn execute_cpu_re_randomize(c: &mut Criterion, bit_size: usize, rerand_mode: Ben
         comp_param.name(),
         "re_randomize",
         &OperatorType::Atomic,
-        bit_size as u32,
+        bit_size as u64,
         vec![param.message_modulus.0.ilog2(); num_blocks],
     );
 
@@ -492,7 +492,7 @@ mod cuda {
             comp_param.name(),
             "re_randomize",
             &OperatorType::Atomic,
-            bit_size as u32,
+            bit_size as u64,
             vec![param.message_modulus.0.ilog2(); num_blocks],
         );
 

--- a/tfhe-benchmark/benches/integer/signed_bench.rs
+++ b/tfhe-benchmark/benches/integer/signed_bench.rs
@@ -128,7 +128,7 @@ fn bench_server_key_signed_binary_function_clean_inputs<F>(
             &benchmark_spec,
             display_name,
             &OperatorType::Atomic,
-            bit_size as u32,
+            bit_size as u64,
             vec![param.message_modulus().0.ilog2(); num_block],
         );
     }
@@ -233,7 +233,7 @@ fn bench_server_key_signed_shift_function_clean_inputs<F>(
             &benchmark_spec,
             display_name,
             &OperatorType::Atomic,
-            bit_size as u32,
+            bit_size as u64,
             vec![param.message_modulus().0.ilog2(); num_block],
         );
     }
@@ -323,7 +323,7 @@ fn bench_server_key_unary_function_clean_inputs<F>(
             &benchmark_spec,
             display_name,
             &OperatorType::Atomic,
-            bit_size as u32,
+            bit_size as u64,
             vec![param.message_modulus().0.ilog2(); num_block],
         );
     }
@@ -424,7 +424,7 @@ fn signed_if_then_else_parallelized(c: &mut Criterion) {
             &benchmark_spec,
             display_name,
             &OperatorType::Atomic,
-            bit_size as u32,
+            bit_size as u64,
             vec![param.message_modulus().0.ilog2(); num_block],
         );
     }
@@ -979,7 +979,7 @@ fn bench_server_key_binary_scalar_function_clean_inputs<F, G>(
             &benchmark_spec,
             display_name,
             &OperatorType::Atomic,
-            bit_size as u32,
+            bit_size as u64,
             vec![param.message_modulus().0.ilog2(); num_block],
         );
     }
@@ -1161,7 +1161,7 @@ fn signed_flip_parallelized(c: &mut Criterion) {
             &benchmark_spec,
             display_name,
             &OperatorType::Atomic,
-            bit_size as u32,
+            bit_size as u64,
             vec![param.message_modulus().0.ilog2(); num_block],
         );
     }
@@ -1527,7 +1527,7 @@ fn bench_server_key_signed_cast_function<F>(
                 &benchmark_spec,
                 display_name,
                 &OperatorType::Atomic,
-                bit_size as u32,
+                bit_size as u64,
                 vec![param.message_modulus().0.ilog2(); num_blocks],
             );
         }
@@ -1723,7 +1723,7 @@ mod cuda {
                 &benchmark_spec,
                 display_name,
                 &OperatorType::Atomic,
-                bit_size as u32,
+                bit_size as u64,
                 vec![param.message_modulus().0.ilog2(); num_block],
             );
         }
@@ -1865,7 +1865,7 @@ mod cuda {
                 &benchmark_spec,
                 display_name,
                 &OperatorType::Atomic,
-                bit_size as u32,
+                bit_size as u64,
                 vec![param.message_modulus().0.ilog2(); num_block],
             );
         }
@@ -2029,7 +2029,7 @@ mod cuda {
                 &benchmark_spec,
                 display_name,
                 &OperatorType::Atomic,
-                bit_size as u32,
+                bit_size as u64,
                 vec![param.message_modulus().0.ilog2(); num_block],
             );
         }
@@ -2210,7 +2210,7 @@ mod cuda {
                 &benchmark_spec,
                 display_name,
                 &OperatorType::Atomic,
-                bit_size as u32,
+                bit_size as u64,
                 vec![param.message_modulus().0.ilog2(); num_block],
             );
         }
@@ -2384,7 +2384,7 @@ mod cuda {
                 &benchmark_spec,
                 "if_then_else",
                 &OperatorType::Atomic,
-                bit_size as u32,
+                bit_size as u64,
                 vec![param.message_modulus().0.ilog2(); num_block],
             );
         }
@@ -3165,7 +3165,7 @@ mod cuda {
                     &benchmark_spec,
                     display_name,
                     &OperatorType::Atomic,
-                    bit_size as u32,
+                    bit_size as u64,
                     vec![param.message_modulus().0.ilog2(); num_blocks],
                 );
             }

--- a/tfhe-benchmark/benches/integer/vector_find.rs
+++ b/tfhe-benchmark/benches/integer/vector_find.rs
@@ -45,7 +45,7 @@ pub fn match_value(c: &mut Criterion) {
             param.name(),
             "match_value",
             &OperatorType::Atomic,
-            bits as u32,
+            bits as u64,
             vec![atomic_param.message_modulus().0.ilog2(); bits],
         );
     }
@@ -97,7 +97,7 @@ pub mod cuda {
                 param.name(),
                 "match_value",
                 &OperatorType::Atomic,
-                bits as u32,
+                bits as u64,
                 vec![atomic_param.message_modulus().0.ilog2(); bits],
             );
         }

--- a/tfhe-benchmark/benches/integer/zk_pke.rs
+++ b/tfhe-benchmark/benches/integer/zk_pke.rs
@@ -188,7 +188,7 @@ fn cpu_pke_zk_proof(c: &mut Criterion) {
                         param_name,
                         "pke_zk_proof",
                         &OperatorType::Atomic,
-                        shortint_params.message_modulus().0 as u32,
+                        shortint_params.message_modulus().0,
                         vec![shortint_params.message_modulus().0.ilog2(); num_block],
                     );
                 }
@@ -435,7 +435,7 @@ fn cpu_pke_zk_verify(c: &mut Criterion, results_file: &Path) {
                         param_name,
                         "pke_zk_verify",
                         &OperatorType::Atomic,
-                        shortint_params.message_modulus().0 as u32,
+                        shortint_params.message_modulus().0,
                         vec![shortint_params.message_modulus().0.ilog2(); num_block],
                     );
 
@@ -444,7 +444,7 @@ fn cpu_pke_zk_verify(c: &mut Criterion, results_file: &Path) {
                         param_name,
                         "pke_zk_verify_and_expand",
                         &OperatorType::Atomic,
-                        shortint_params.message_modulus().0 as u32,
+                        shortint_params.message_modulus().0,
                         vec![shortint_params.message_modulus().0.ilog2(); num_block],
                     );
                 }
@@ -823,7 +823,7 @@ mod cuda {
                             param_name,
                             display_name,
                             &OperatorType::Atomic,
-                            param_fhe.message_modulus().0 as u32,
+                            param_fhe.message_modulus().0,
                             vec![param_fhe.message_modulus().0.ilog2(); num_block],
                         );
                     }
@@ -957,7 +957,7 @@ mod cuda {
                             param_name,
                             "pke_zk_proof",
                             &OperatorType::Atomic,
-                            shortint_params.message_modulus().0 as u32,
+                            shortint_params.message_modulus().0,
                             vec![shortint_params.message_modulus().0.ilog2(); num_block],
                         );
                     }

--- a/tfhe-benchmark/benches/shortint/bench.rs
+++ b/tfhe-benchmark/benches/shortint/bench.rs
@@ -46,7 +46,7 @@ fn bench_server_key_unary_function<F>(
             &benchmark_spec,
             display_name,
             &OperatorType::Atomic,
-            param.message_modulus().0.ilog2(),
+            param.message_modulus().0.ilog2() as u64,
             vec![param.message_modulus().0.ilog2()],
         );
     }
@@ -91,7 +91,7 @@ fn bench_server_key_binary_function<F>(
             &benchmark_spec,
             display_name,
             &OperatorType::Atomic,
-            param.message_modulus().0.ilog2(),
+            param.message_modulus().0.ilog2() as u64,
             vec![param.message_modulus().0.ilog2()],
         );
     }
@@ -135,7 +135,7 @@ fn bench_server_key_binary_scalar_function<F>(
             &benchmark_spec,
             display_name,
             &OperatorType::Atomic,
-            param.message_modulus().0.ilog2(),
+            param.message_modulus().0.ilog2() as u64,
             vec![param.message_modulus().0.ilog2()],
         );
     }
@@ -183,7 +183,7 @@ fn bench_server_key_binary_scalar_division_function<F>(
             &benchmark_spec,
             display_name,
             &OperatorType::Atomic,
-            param.message_modulus().0.ilog2(),
+            param.message_modulus().0.ilog2() as u64,
             vec![param.message_modulus().0.ilog2()],
         );
     }
@@ -220,7 +220,7 @@ fn carry_extract_bench(c: &mut Criterion) {
             &benchmark_spec,
             "carry_extract",
             &OperatorType::Atomic,
-            param.message_modulus().0.ilog2(),
+            param.message_modulus().0.ilog2() as u64,
             vec![param.message_modulus().0.ilog2()],
         );
     }
@@ -260,7 +260,7 @@ fn programmable_bootstrapping_bench(c: &mut Criterion) {
             &benchmark_spec,
             "pbs",
             &OperatorType::Atomic,
-            param.message_modulus().0.ilog2(),
+            param.message_modulus().0.ilog2() as u64,
             vec![param.message_modulus().0.ilog2()],
         );
     }
@@ -310,7 +310,7 @@ fn server_key_from_compressed_key(c: &mut Criterion) {
             &benchmark_spec,
             "uncompress_key",
             &OperatorType::Atomic,
-            param.message_modulus().0.ilog2(),
+            param.message_modulus().0.ilog2() as u64,
             vec![param.message_modulus().0.ilog2()],
         );
     }

--- a/tfhe-benchmark/benches/shortint/oprf.rs
+++ b/tfhe-benchmark/benches/shortint/oprf.rs
@@ -35,7 +35,7 @@ fn oprf(c: &mut Criterion) {
         &benchmark_spec,
         "oprf",
         &OperatorType::Atomic,
-        param.message_modulus.0.ilog2(),
+        param.message_modulus.0.ilog2() as u64,
         vec![param.message_modulus.0.ilog2()],
     );
 }

--- a/tfhe-benchmark/benches/transciphering/aes_transciphering.rs
+++ b/tfhe-benchmark/benches/transciphering/aes_transciphering.rs
@@ -69,7 +69,7 @@ pub fn cpu_aes_transciphering(c: &mut Criterion) {
         &mut group,
         &benchmark_spec,
         "aes_key_expansion",
-        BLOCK_BITS as u32,
+        BLOCK_BITS as u64,
         vec![log2_msg; BLOCK_BITS],
         |b| {
             b.iter(|| {
@@ -90,7 +90,7 @@ pub fn cpu_aes_transciphering(c: &mut Criterion) {
         &mut group,
         &benchmark_spec,
         "aes_key_expansion_plus_1_block",
-        BLOCK_BITS as u32,
+        BLOCK_BITS as u64,
         vec![log2_msg; BLOCK_BITS],
         |b| {
             b.iter(|| {
@@ -116,7 +116,7 @@ pub fn cpu_aes_transciphering(c: &mut Criterion) {
         &mut group,
         &benchmark_spec,
         "aes_keystream_1_block",
-        BLOCK_BITS as u32,
+        BLOCK_BITS as u64,
         vec![log2_msg; BLOCK_BITS],
         |b| {
             b.iter(|| {
@@ -138,7 +138,7 @@ pub fn cpu_aes_transciphering(c: &mut Criterion) {
         &mut group,
         &benchmark_spec,
         "aes_keystream_16_blocks",
-        total_bits as u32,
+        total_bits as u64,
         vec![log2_msg; total_bits],
         |b| {
             b.iter(|| {
@@ -165,7 +165,7 @@ pub fn cpu_aes_transciphering(c: &mut Criterion) {
         &mut group,
         &benchmark_spec,
         "aes_transcipher_16_blocks",
-        total_bits as u32,
+        total_bits as u64,
         vec![log2_msg; total_bits],
         |b| {
             b.iter(|| {

--- a/tfhe-benchmark/benches/transciphering/kreyvium_transciphering.rs
+++ b/tfhe-benchmark/benches/transciphering/kreyvium_transciphering.rs
@@ -69,7 +69,7 @@ pub fn cpu_kreyvium_transciphering(c: &mut Criterion) {
         &mut group,
         &benchmark_spec,
         "kreyvium_warmup",
-        KEY_BITS as u32,
+        KEY_BITS as u64,
         vec![log2_msg; KEY_BITS],
         |b| {
             b.iter_batched(
@@ -98,7 +98,7 @@ pub fn cpu_kreyvium_transciphering(c: &mut Criterion) {
         &mut group,
         &benchmark_spec,
         &format!("kreyvium_keystream_{KEYSTREAM_BITS}bits"),
-        KEYSTREAM_BITS as u32,
+        KEYSTREAM_BITS as u64,
         vec![log2_msg; KEYSTREAM_BITS],
         |b| {
             b.iter_batched(
@@ -130,7 +130,7 @@ pub fn cpu_kreyvium_transciphering(c: &mut Criterion) {
         &mut group,
         &benchmark_spec,
         &format!("kreyvium_transcipher_{KEYSTREAM_BITS}bits"),
-        KEYSTREAM_BITS as u32,
+        KEYSTREAM_BITS as u64,
         vec![log2_msg; KEYSTREAM_BITS],
         |b| {
             b.iter_batched(

--- a/tfhe-benchmark/benches/zk/msm.rs
+++ b/tfhe-benchmark/benches/zk/msm.rs
@@ -32,11 +32,11 @@ use std::time::Duration;
 use tfhe_zk_pok::curve_api::bls12_446::{G1Affine, G2Affine, Zp, G1, G2};
 use tfhe_zk_pok::curve_api::CurveGroupOps;
 
-const MSM_SIZES: &[usize] = &[100, 1000, 2048, 4096, 10000];
+const MSM_SIZES: &[u32] = &[100, 1000, 2048, 4096, 10000];
 
 /// Compute the number of parallel elements for MSM throughput benchmarks.
 /// Uses aggressive values to maximize throughput testing while keeping setup time reasonable.
-fn msm_throughput_elements(input_size: usize) -> u64 {
+fn msm_throughput_elements(input_size: u32) -> u64 {
     match input_size {
         n if n <= 1000 => 64,
         n if n <= 4096 => 32,
@@ -44,7 +44,7 @@ fn msm_throughput_elements(input_size: usize) -> u64 {
     }
 }
 
-fn generate_scalars(rng: &mut StdRng, n: usize) -> Vec<Zp> {
+fn generate_scalars(rng: &mut StdRng, n: u32) -> Vec<Zp> {
     (0..n).map(|_| Zp::rand(rng)).collect()
 }
 
@@ -62,7 +62,7 @@ trait MsmBenchGroup {
 
     const MSM_ID: MsmBench;
 
-    fn generate_points(rng: &mut StdRng, n: usize) -> Vec<Self::Affine>;
+    fn generate_points(rng: &mut StdRng, n: u32) -> Vec<Self::Affine>;
     fn cpu_msm(bases: &[Self::Affine], scalars: &[Zp]);
     #[cfg(feature = "gpu-zk")]
     fn gpu_msm(bases: &[Self::Affine], scalars: &[Zp], gpu_index: u32);
@@ -75,7 +75,7 @@ impl MsmBenchGroup for G1Bench {
 
     const MSM_ID: MsmBench = MsmBench::G1(MsmFlavor::Bls12_446);
 
-    fn generate_points(rng: &mut StdRng, n: usize) -> Vec<G1Affine> {
+    fn generate_points(rng: &mut StdRng, n: u32) -> Vec<G1Affine> {
         (0..n)
             .map(|_| {
                 let point = G1::GENERATOR.mul_scalar(Zp::rand(rng));
@@ -105,7 +105,7 @@ impl MsmBenchGroup for G2Bench {
 
     const MSM_ID: MsmBench = MsmBench::G2(MsmFlavor::Bls12_446);
 
-    fn generate_points(rng: &mut StdRng, n: usize) -> Vec<G2Affine> {
+    fn generate_points(rng: &mut StdRng, n: u32) -> Vec<G2Affine> {
         (0..n)
             .map(|_| {
                 let point = G2::GENERATOR.mul_scalar(Zp::rand(rng));
@@ -139,9 +139,9 @@ fn bench_cpu_msm<T: MsmBenchGroup>(c: &mut Criterion) {
     group.measurement_time(Duration::from_secs(30));
 
     for size in MSM_SIZES.iter() {
-        let n = *size;
+        let n: u32 = *size;
         let bench_id =
-            BenchmarkSpec::new_zk_msm(T::MSM_ID, Backend::Cpu, get_bench_type(), Some(n));
+            BenchmarkSpec::new_zk_msm(T::MSM_ID, Backend::Cpu, get_bench_type(), Some(n as u64));
         let bench_id_string = bench_id.to_string();
 
         match get_bench_type() {

--- a/tfhe-benchmark/src/utilities.rs
+++ b/tfhe-benchmark/src/utilities.rs
@@ -13,7 +13,7 @@ pub fn bench_and_record<F>(
     group: &mut BenchmarkGroup<'_, WallTime>,
     benchmark_spec: &BenchmarkSpec,
     display_name: &str,
-    bit_size: u32,
+    bit_size: u64,
     decomposition_basis: Vec<u32>,
     mut routine: F,
 ) where

--- a/utils/benchmark_spec/Cargo.toml
+++ b/utils/benchmark_spec/Cargo.toml
@@ -10,5 +10,7 @@ gpu = []
 hpu = []
 
 [dependencies]
+enum-iterator = "2"
 strum = { version = "0.28", features = ["derive"] }
 serde = { workspace = true, default-features = false, features = ["derive"] }
+thiserror = { version = "2.0.19", default-features = false }

--- a/utils/benchmark_spec/src/backend.rs
+++ b/utils/benchmark_spec/src/backend.rs
@@ -1,9 +1,19 @@
-use std::str::FromStr;
-
 use serde::{Deserialize, Serialize};
-use strum::Display;
+use strum::{Display, EnumString, IntoStaticStr};
 
-#[derive(Debug, Clone, Copy, Display, Deserialize, Serialize)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    Display,
+    Deserialize,
+    EnumString,
+    Serialize,
+    PartialEq,
+    Eq,
+    Hash,
+    IntoStaticStr,
+)]
 #[strum(serialize_all = "snake_case")]
 #[serde(rename_all = "snake_case")]
 pub enum Backend {
@@ -19,17 +29,5 @@ pub fn bench_backend_from_cfg() -> Backend {
         Backend::Hpu
     } else {
         Backend::Cpu
-    }
-}
-
-impl FromStr for Backend {
-    type Err = String;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().as_str() {
-            "cpu" => Ok(Self::Cpu),
-            "cuda" => Ok(Self::Cuda),
-            "hpu" => Ok(Self::Hpu),
-            _ => Err(format!("unknown benchmark metric: {s}")),
-        }
     }
 }

--- a/utils/benchmark_spec/src/bench_crate.rs
+++ b/utils/benchmark_spec/src/bench_crate.rs
@@ -1,23 +1,63 @@
 use std::fmt;
-use strum::Display;
+use std::str::FromStr;
 
+use strum::{Display, EnumDiscriminants, EnumString};
+
+use crate::error::SpecParseError;
 use crate::tfhe::TfheLayer;
 use crate::traits::write_spec;
 use crate::zk::ZkLayer;
 
-#[derive(Debug, Clone, Copy, Display)]
-#[strum(serialize_all = "snake_case")]
+#[derive(Debug, Clone, Copy, EnumDiscriminants, enum_iterator::Sequence)]
+#[strum_discriminants(
+    name(BenchCrateKind),
+    derive(EnumString, Display),
+    strum(serialize_all = "snake_case")
+)]
 pub enum BenchCrate {
     Tfhe(TfheLayer),
     Zk(ZkLayer),
 }
 
-impl BenchCrate {
-    pub(crate) fn fmt_crate(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{self}")?;
+impl FromStr for BenchCrate {
+    type Err = SpecParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (head, rest) = s.split_once("::").unwrap_or((s, ""));
+        match BenchCrateKind::from_str(head)
+            .map_err(|_| SpecParseError::Unknown(format!("unknown bench crate: {head}")))?
+        {
+            BenchCrateKind::Tfhe => Ok(Self::Tfhe(rest.parse()?)),
+            BenchCrateKind::Zk => Ok(Self::Zk(rest.parse()?)),
+        }
+    }
+}
+
+impl fmt::Display for BenchCrate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Crate token ("tfhe" / "zk") from the discriminant, then the layer tree.
+        write!(f, "{}", BenchCrateKind::from(self))?;
         match self {
             BenchCrate::Tfhe(layer) => write_spec(layer, f),
             BenchCrate::Zk(layer) => write_spec(layer, f),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every possible path must survive a `Display -> FromStr -> Display`
+    /// round-trip.
+    #[test]
+    fn roundtrip_all_bench_paths() {
+        for bc in enum_iterator::all::<BenchCrate>() {
+            let s = bc.to_string();
+            let reparsed = s
+                .parse::<BenchCrate>()
+                .unwrap_or_else(|e| panic!("parse of {s:?} failed: {e:?}"));
+            assert_eq!(reparsed.to_string(), s, "round-trip mismatch for {s:?}");
         }
     }
 }

--- a/utils/benchmark_spec/src/bench_path.rs
+++ b/utils/benchmark_spec/src/bench_path.rs
@@ -10,36 +10,36 @@ use crate::zk::ZkLayer;
 
 #[derive(Debug, Clone, Copy, EnumDiscriminants, enum_iterator::Sequence)]
 #[strum_discriminants(
-    name(BenchCrateKind),
+    name(BenchPathKind),
     derive(EnumString, Display),
     strum(serialize_all = "snake_case")
 )]
-pub enum BenchCrate {
+pub enum BenchPath {
     Tfhe(TfheLayer),
     Zk(ZkLayer),
 }
 
-impl FromStr for BenchCrate {
+impl FromStr for BenchPath {
     type Err = SpecParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let (head, rest) = s.split_once("::").unwrap_or((s, ""));
-        match BenchCrateKind::from_str(head)
+        match BenchPathKind::from_str(head)
             .map_err(|_| SpecParseError::Unknown(format!("unknown bench crate: {head}")))?
         {
-            BenchCrateKind::Tfhe => Ok(Self::Tfhe(rest.parse()?)),
-            BenchCrateKind::Zk => Ok(Self::Zk(rest.parse()?)),
+            BenchPathKind::Tfhe => Ok(Self::Tfhe(rest.parse()?)),
+            BenchPathKind::Zk => Ok(Self::Zk(rest.parse()?)),
         }
     }
 }
 
-impl fmt::Display for BenchCrate {
+impl fmt::Display for BenchPath {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // Crate token ("tfhe" / "zk") from the discriminant, then the layer tree.
-        write!(f, "{}", BenchCrateKind::from(self))?;
+        write!(f, "{}", BenchPathKind::from(self))?;
         match self {
-            BenchCrate::Tfhe(layer) => write_spec(layer, f),
-            BenchCrate::Zk(layer) => write_spec(layer, f),
+            BenchPath::Tfhe(layer) => write_spec(layer, f),
+            BenchPath::Zk(layer) => write_spec(layer, f),
         }
     }
 }
@@ -52,10 +52,10 @@ mod tests {
     /// round-trip.
     #[test]
     fn roundtrip_all_bench_paths() {
-        for bc in enum_iterator::all::<BenchCrate>() {
+        for bc in enum_iterator::all::<BenchPath>() {
             let s = bc.to_string();
             let reparsed = s
-                .parse::<BenchCrate>()
+                .parse::<BenchPath>()
                 .unwrap_or_else(|e| panic!("parse of {s:?} failed: {e:?}"));
             assert_eq!(reparsed.to_string(), s, "round-trip mismatch for {s:?}");
         }

--- a/utils/benchmark_spec/src/error.rs
+++ b/utils/benchmark_spec/src/error.rs
@@ -1,0 +1,8 @@
+#[derive(Debug, thiserror::Error)]
+pub enum SpecParseError {
+    #[error("unknown token: {0}")]
+    Unknown(String),
+
+    #[error(transparent)]
+    Strum(#[from] strum::ParseError),
+}

--- a/utils/benchmark_spec/src/lib.rs
+++ b/utils/benchmark_spec/src/lib.rs
@@ -1,14 +1,16 @@
 mod backend;
-mod bench_crate;
+mod bench_path;
 mod error;
 mod measured;
 mod parse;
+mod segment;
 pub mod tfhe;
 mod traits;
 pub mod zk;
 
+use crate::segment::OptionalSegment;
 pub use backend::{Backend, bench_backend_from_cfg};
-pub use bench_crate::{BenchCrate, BenchCrateKind};
+pub use bench_path::{BenchPath, BenchPathKind};
 pub use error::SpecParseError;
 pub use measured::{MeasuredId, Statistic, measured_name};
 use serde::{Deserialize, Serialize};
@@ -18,6 +20,7 @@ use std::path::Path;
 use std::str::FromStr;
 use std::sync::OnceLock;
 use std::{env, fmt};
+use strum::{EnumString, IntoStaticStr};
 pub use tfhe::hlapi::HlapiBench;
 pub use tfhe::{
     BooleanBench, CoreCryptoBench, HlIntegerOp, IntegerBench, IntegerOp, IntegerOpBySign,
@@ -142,9 +145,11 @@ impl CsvResultWriter {
     }
 }
 
-#[derive(Debug, Serialize, Clone, Copy)]
+#[derive(Debug, Serialize, Clone, Copy, IntoStaticStr, EnumString, PartialEq, Eq, Hash)]
+#[strum(serialize_all = "snake_case")]
 pub enum OperandType {
     CipherText,
+    #[strum(serialize = "scalar")]
     PlainText,
 }
 
@@ -165,7 +170,10 @@ pub enum BenchmarkType {
 }
 
 /// The metric being recorded by a benchmark, used in [`BenchmarkSpec`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, IntoStaticStr, EnumString,
+)]
+#[strum(serialize_all = "snake_case")]
 pub enum BenchmarkMetric {
     Latency,
     Throughput,
@@ -178,19 +186,6 @@ impl From<BenchmarkType> for BenchmarkMetric {
         match ct {
             BenchmarkType::Latency => BenchmarkMetric::Latency,
             BenchmarkType::Throughput => BenchmarkMetric::Throughput,
-        }
-    }
-}
-
-impl FromStr for BenchmarkMetric {
-    type Err = String;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().as_str() {
-            "latency" => Ok(Self::Latency),
-            "throughput" => Ok(Self::Throughput),
-            "pbscount" => Ok(Self::PbsCount),
-            "keysize" => Ok(Self::KeySize),
-            _ => Err(format!("unknown benchmark metric: {s}")),
         }
     }
 }
@@ -227,19 +222,19 @@ pub fn get_bench_type() -> BenchmarkType {
 /// ```
 #[derive(Debug)]
 pub struct BenchmarkSpec {
-    bench_crate: BenchCrate,
+    bench_path: BenchPath,
     backend: Backend,
     param_name: String,
     operand_type: OperandType,
     type_name: Option<String>,
     metric: BenchmarkMetric,
-    num_elements: Option<usize>,
+    num_elements: Option<u64>,
 }
 
 impl BenchmarkSpec {
     /// The benchmarked operation, as a path (`tfhe::hlapi::ops::add`).
-    pub fn bench_crate(&self) -> BenchCrate {
-        self.bench_crate
+    pub fn bench_path(&self) -> BenchPath {
+        self.bench_path
     }
 
     /// The parameter set name (from `NamedParam::name()`).
@@ -266,21 +261,21 @@ impl BenchmarkSpec {
 
     /// `Some` when the id ends with an `<n>_elements` segment: batch size for a
     /// throughput benchmark, store size for a KV-store one.
-    pub fn num_elements(&self) -> Option<usize> {
+    pub fn num_elements(&self) -> Option<u64> {
         self.num_elements
     }
 
     pub fn new(
-        bench_crate: BenchCrate,
+        bench_path: BenchPath,
         backend: Backend,
         param_name: &str,
         operand_type: OperandType,
         type_name: Option<&dyn TypeName>,
         bench_type: impl Into<BenchmarkMetric>,
-        num_elements: Option<usize>,
+        num_elements: Option<u64>,
     ) -> Self {
         Self {
-            bench_crate,
+            bench_path,
             backend,
             param_name: param_name.to_string(),
             operand_type,
@@ -298,7 +293,7 @@ impl BenchmarkSpec {
         bench_type: impl Into<BenchmarkMetric>,
     ) -> Self {
         Self {
-            bench_crate: BenchCrate::Tfhe(TfheLayer::Hlapi(HlapiBench::Ops(hlapi_op))),
+            bench_path: BenchPath::Tfhe(TfheLayer::Hlapi(HlapiBench::Ops(hlapi_op))),
             backend: bench_backend_from_cfg(),
             param_name: param_name.to_string(),
             operand_type,
@@ -314,10 +309,10 @@ impl BenchmarkSpec {
         operand_type: OperandType,
         type_name: Option<&dyn TypeName>,
         bench_type: impl Into<BenchmarkMetric>,
-        num_elements: Option<usize>,
+        num_elements: Option<u64>,
     ) -> Self {
         Self {
-            bench_crate: BenchCrate::Tfhe(TfheLayer::Hlapi(hlapi_bench)),
+            bench_path: BenchPath::Tfhe(TfheLayer::Hlapi(hlapi_bench)),
             backend: bench_backend_from_cfg(),
             param_name: param_name.to_string(),
             operand_type,
@@ -332,10 +327,10 @@ impl BenchmarkSpec {
         param_name: &str,
         type_name: Option<&dyn TypeName>,
         bench_type: impl Into<BenchmarkMetric>,
-        num_elements: Option<usize>,
+        num_elements: Option<u64>,
     ) -> Self {
         Self {
-            bench_crate: BenchCrate::Tfhe(TfheLayer::Integer(IntegerBench::Ops(ops))),
+            bench_path: BenchPath::Tfhe(TfheLayer::Integer(IntegerBench::Ops(ops))),
             backend: bench_backend_from_cfg(),
             param_name: param_name.to_string(),
             operand_type: OperandType::CipherText,
@@ -350,10 +345,10 @@ impl BenchmarkSpec {
         param_name: &str,
         type_name: Option<&dyn TypeName>,
         bench_type: impl Into<BenchmarkMetric>,
-        num_elements: Option<usize>,
+        num_elements: Option<u64>,
     ) -> Self {
         Self {
-            bench_crate: BenchCrate::Tfhe(TfheLayer::Integer(integer_bench)),
+            bench_path: BenchPath::Tfhe(TfheLayer::Integer(integer_bench)),
             backend: bench_backend_from_cfg(),
             param_name: param_name.to_string(),
             operand_type: OperandType::CipherText,
@@ -369,7 +364,7 @@ impl BenchmarkSpec {
         bench_type: impl Into<BenchmarkMetric>,
     ) -> Self {
         Self {
-            bench_crate: BenchCrate::Tfhe(TfheLayer::Shortint(shortint_bench)),
+            bench_path: BenchPath::Tfhe(TfheLayer::Shortint(shortint_bench)),
             backend: bench_backend_from_cfg(),
             param_name: param_name.to_string(),
             operand_type: OperandType::CipherText,
@@ -385,7 +380,7 @@ impl BenchmarkSpec {
         bench_type: impl Into<BenchmarkMetric>,
     ) -> Self {
         Self {
-            bench_crate: BenchCrate::Tfhe(TfheLayer::Boolean(boolean_bench)),
+            bench_path: BenchPath::Tfhe(TfheLayer::Boolean(boolean_bench)),
             backend: bench_backend_from_cfg(),
             param_name: param_name.to_string(),
             operand_type: OperandType::CipherText,
@@ -401,7 +396,7 @@ impl BenchmarkSpec {
         bench_type: impl Into<BenchmarkMetric>,
     ) -> Self {
         Self {
-            bench_crate: BenchCrate::Tfhe(TfheLayer::CoreCrypto(core_crypto_bench)),
+            bench_path: BenchPath::Tfhe(TfheLayer::CoreCrypto(core_crypto_bench)),
             backend: bench_backend_from_cfg(),
             param_name: param_name.to_string(),
             operand_type: OperandType::CipherText,
@@ -418,7 +413,7 @@ impl BenchmarkSpec {
         bench_type: impl Into<BenchmarkMetric>,
     ) -> Self {
         Self {
-            bench_crate: BenchCrate::Tfhe(TfheLayer::CoreCrypto(core_crypto_bench)),
+            bench_path: BenchPath::Tfhe(TfheLayer::CoreCrypto(core_crypto_bench)),
             backend: bench_backend_from_cfg(),
             param_name: param_name.to_string(),
             operand_type: OperandType::CipherText,
@@ -434,7 +429,7 @@ impl BenchmarkSpec {
         bench_type: impl Into<BenchmarkMetric>,
     ) -> Self {
         Self {
-            bench_crate: BenchCrate::Tfhe(TfheLayer::Transciphering(transcipher_bench)),
+            bench_path: BenchPath::Tfhe(TfheLayer::Transciphering(transcipher_bench)),
             backend: bench_backend_from_cfg(),
             param_name: param_name.to_string(),
             operand_type: OperandType::CipherText,
@@ -448,10 +443,10 @@ impl BenchmarkSpec {
         zk_bench: MsmBench,
         backend: Backend,
         bench_type: impl Into<BenchmarkMetric>,
-        num_elements: Option<usize>,
+        num_elements: Option<u64>,
     ) -> Self {
         Self {
-            bench_crate: BenchCrate::Zk(ZkLayer::Msm(zk_bench)),
+            bench_path: BenchPath::Zk(ZkLayer::Msm(zk_bench)),
             backend,
             param_name: String::new(),
             operand_type: OperandType::CipherText,
@@ -464,21 +459,18 @@ impl BenchmarkSpec {
 
 impl fmt::Display for BenchmarkSpec {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.bench_crate)?;
-        if !matches!(self.backend, Backend::Cpu) {
-            write!(f, "::{}", self.backend)?;
+        write!(f, "{}", self.bench_path)?;
+        if let Some(segment) = self.backend.segment() {
+            write!(f, "::{segment}")?;
         }
-        match self.metric {
-            BenchmarkMetric::Throughput => write!(f, "::throughput")?,
-            BenchmarkMetric::PbsCount => write!(f, "::pbs_count")?,
-            BenchmarkMetric::KeySize => write!(f, "::key_size")?,
-            BenchmarkMetric::Latency => {}
+        if let Some(segment) = self.metric.segment() {
+            write!(f, "::{segment}")?;
         }
         if !self.param_name.is_empty() {
             write!(f, "::{}", self.param_name)?;
         }
-        if self.operand_type.is_scalar() {
-            write!(f, "::scalar")?;
+        if let Some(segment) = self.operand_type.segment() {
+            write!(f, "::{segment}")?;
         }
         if let Some(type_name) = &self.type_name {
             write!(f, "::{type_name}")?;
@@ -523,7 +515,7 @@ mod tests {
     #[test]
     fn hlapi_cuda_latency() {
         let spec = BenchmarkSpec::new(
-            BenchCrate::Tfhe(TfheLayer::Hlapi(HlapiBench::Ops(HlIntegerOp::Mul))),
+            BenchPath::Tfhe(TfheLayer::Hlapi(HlapiBench::Ops(HlIntegerOp::Mul))),
             Backend::Cuda,
             "PARAM_MESSAGE_2_CARRY_2",
             OperandType::CipherText,
@@ -540,7 +532,7 @@ mod tests {
     #[test]
     fn hlapi_hpu_throughput() {
         let spec = BenchmarkSpec::new(
-            BenchCrate::Tfhe(TfheLayer::Hlapi(HlapiBench::Ops(HlIntegerOp::Add))),
+            BenchPath::Tfhe(TfheLayer::Hlapi(HlapiBench::Ops(HlIntegerOp::Add))),
             Backend::Hpu,
             "PARAM_MESSAGE_2_CARRY_2",
             OperandType::CipherText,
@@ -685,7 +677,7 @@ mod tests {
         use crate::tfhe::hlapi::erc7984::TransferFlavor;
 
         let spec = BenchmarkSpec::new(
-            BenchCrate::Tfhe(TfheLayer::Hlapi(HlapiBench::Erc7984(Erc7984::Transfer(
+            BenchPath::Tfhe(TfheLayer::Hlapi(HlapiBench::Erc7984(Erc7984::Transfer(
                 TransferFlavor::Overflow,
             )))),
             Backend::Cuda,
@@ -760,7 +752,7 @@ mod tests {
         use crate::tfhe::hlapi::dex::DexFlavor;
 
         let spec = BenchmarkSpec::new(
-            BenchCrate::Tfhe(TfheLayer::Hlapi(HlapiBench::Dex(Dex::SwapClaim(
+            BenchPath::Tfhe(TfheLayer::Hlapi(HlapiBench::Dex(Dex::SwapClaim(
                 DexFlavor::NoCmux,
             )))),
             Backend::Cuda,

--- a/utils/benchmark_spec/src/lib.rs
+++ b/utils/benchmark_spec/src/lib.rs
@@ -1,11 +1,16 @@
 mod backend;
 mod bench_crate;
+mod error;
+mod measured;
+mod parse;
 pub mod tfhe;
 mod traits;
 pub mod zk;
 
 pub use backend::{Backend, bench_backend_from_cfg};
-pub use bench_crate::BenchCrate;
+pub use bench_crate::{BenchCrate, BenchCrateKind};
+pub use error::SpecParseError;
+pub use measured::{MeasuredId, Statistic, measured_name};
 use serde::{Deserialize, Serialize};
 use std::fs::{File, OpenOptions};
 use std::io::Write;
@@ -160,7 +165,7 @@ pub enum BenchmarkType {
 }
 
 /// The metric being recorded by a benchmark, used in [`BenchmarkSpec`].
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum BenchmarkMetric {
     Latency,
     Throughput,
@@ -220,20 +225,49 @@ pub fn get_bench_type() -> BenchmarkType {
 /// ```text
 /// {crate}::{layer}::{bench}::{op}(::{backend})?(::{benchmark_type})?::{param}(::scalar)?(::{type})?(::{num_elements}_elements)?
 /// ```
+#[derive(Debug)]
 pub struct BenchmarkSpec {
     bench_crate: BenchCrate,
     backend: Backend,
     param_name: String,
     operand_type: OperandType,
     type_name: Option<String>,
-    bench_type: BenchmarkMetric,
+    metric: BenchmarkMetric,
     num_elements: Option<usize>,
 }
 
 impl BenchmarkSpec {
+    /// The benchmarked operation, as a path (`tfhe::hlapi::ops::add`).
+    pub fn bench_crate(&self) -> BenchCrate {
+        self.bench_crate
+    }
+
     /// The parameter set name (from `NamedParam::name()`).
     pub fn param_name(&self) -> &str {
         &self.param_name
+    }
+
+    /// What the recorded value is: a duration, a rate, a count or a byte size.
+    pub fn metric(&self) -> BenchmarkMetric {
+        self.metric
+    }
+
+    /// Whether the second operand is a plaintext (a `scalar` benchmark).
+    pub fn operand_type(&self) -> OperandType {
+        self.operand_type
+    }
+
+    /// The type tag, rendered. Still a flat string: it carries a Rust type, a
+    /// precision, a key/value pair or a keyswitch config depending on the
+    /// benchmark, so callers have to interpret it.
+    pub fn type_name(&self) -> Option<&str> {
+        self.type_name.as_deref()
+    }
+
+    /// `Some` when the id ends with an `<n>_elements` segment: batch size for a
+    /// throughput benchmark, store size for a KV-store one.
+    pub fn num_elements(&self) -> Option<usize> {
+        self.num_elements
     }
 
     pub fn new(
@@ -251,7 +285,7 @@ impl BenchmarkSpec {
             param_name: param_name.to_string(),
             operand_type,
             type_name: type_name.map(|t| t.type_name()),
-            bench_type: bench_type.into(),
+            metric: bench_type.into(),
             num_elements,
         }
     }
@@ -269,7 +303,7 @@ impl BenchmarkSpec {
             param_name: param_name.to_string(),
             operand_type,
             type_name: type_name.map(|t| t.type_name()),
-            bench_type: bench_type.into(),
+            metric: bench_type.into(),
             num_elements: None,
         }
     }
@@ -288,7 +322,7 @@ impl BenchmarkSpec {
             param_name: param_name.to_string(),
             operand_type,
             type_name: type_name.map(|t| t.type_name()),
-            bench_type: bench_type.into(),
+            metric: bench_type.into(),
             num_elements,
         }
     }
@@ -306,7 +340,7 @@ impl BenchmarkSpec {
             param_name: param_name.to_string(),
             operand_type: OperandType::CipherText,
             type_name: type_name.map(|t| t.type_name()),
-            bench_type: bench_type.into(),
+            metric: bench_type.into(),
             num_elements,
         }
     }
@@ -324,7 +358,7 @@ impl BenchmarkSpec {
             param_name: param_name.to_string(),
             operand_type: OperandType::CipherText,
             type_name: type_name.map(|t| t.type_name()),
-            bench_type: bench_type.into(),
+            metric: bench_type.into(),
             num_elements,
         }
     }
@@ -340,7 +374,7 @@ impl BenchmarkSpec {
             param_name: param_name.to_string(),
             operand_type: OperandType::CipherText,
             type_name: None,
-            bench_type: bench_type.into(),
+            metric: bench_type.into(),
             num_elements: None,
         }
     }
@@ -356,7 +390,7 @@ impl BenchmarkSpec {
             param_name: param_name.to_string(),
             operand_type: OperandType::CipherText,
             type_name: None,
-            bench_type: bench_type.into(),
+            metric: bench_type.into(),
             num_elements: None,
         }
     }
@@ -372,7 +406,7 @@ impl BenchmarkSpec {
             param_name: param_name.to_string(),
             operand_type: OperandType::CipherText,
             type_name: None,
-            bench_type: bench_type.into(),
+            metric: bench_type.into(),
             num_elements: None,
         }
     }
@@ -389,7 +423,7 @@ impl BenchmarkSpec {
             param_name: param_name.to_string(),
             operand_type: OperandType::CipherText,
             type_name: type_name.map(|t| t.type_name()),
-            bench_type: bench_type.into(),
+            metric: bench_type.into(),
             num_elements: None,
         }
     }
@@ -405,7 +439,7 @@ impl BenchmarkSpec {
             param_name: param_name.to_string(),
             operand_type: OperandType::CipherText,
             type_name: None,
-            bench_type: bench_type.into(),
+            metric: bench_type.into(),
             num_elements: None,
         }
     }
@@ -422,7 +456,7 @@ impl BenchmarkSpec {
             param_name: String::new(),
             operand_type: OperandType::CipherText,
             type_name: None,
-            bench_type: bench_type.into(),
+            metric: bench_type.into(),
             num_elements,
         }
     }
@@ -430,11 +464,11 @@ impl BenchmarkSpec {
 
 impl fmt::Display for BenchmarkSpec {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.bench_crate.fmt_crate(f)?;
+        write!(f, "{}", self.bench_crate)?;
         if !matches!(self.backend, Backend::Cpu) {
             write!(f, "::{}", self.backend)?;
         }
-        match self.bench_type {
+        match self.metric {
             BenchmarkMetric::Throughput => write!(f, "::throughput")?,
             BenchmarkMetric::PbsCount => write!(f, "::pbs_count")?,
             BenchmarkMetric::KeySize => write!(f, "::key_size")?,

--- a/utils/benchmark_spec/src/measured.rs
+++ b/utils/benchmark_spec/src/measured.rs
@@ -72,10 +72,13 @@ impl FromStr for MeasuredId {
         Ok(Self {
             spec: bench_id.parse()?,
             statistic,
-            variant: match rest.strip_prefix('_') {
-                Some(variant) if !variant.is_empty() => Some(variant.to_string()),
-                _ => None,
-            },
+            variant: rest.strip_prefix('_').and_then(|variant| {
+                if variant.is_empty() {
+                    None
+                } else {
+                    Some(variant.to_string())
+                }
+            }),
         })
     }
 }
@@ -101,7 +104,8 @@ mod tests {
         let names = [
             "tfhe::shortint::ops::add::PARAM_MESSAGE_2_CARRY_2_KS_PBS_mean_avx512",
             "tfhe::shortint::ops::add::PARAM_MESSAGE_2_CARRY_2_KS_PBS_std_dev_avx512",
-            // No variant: the parser's default is an empty suffix (`cli.rs:50`).
+            // No variant: the parser's default is an empty suffix
+            // (`utils/tfhe-benchmark-parser/src/cli.rs:50`).
             "tfhe::hlapi::ops::add::PARAM_MESSAGE_2_CARRY_2::FheUint64_mean",
             // A workflow-built compound variant stays opaque.
             "tfhe::hlapi::ops::add::PARAM_MESSAGE_2_CARRY_2::FheUint64_mean_batch_size_4-schedule_fifo",
@@ -112,17 +116,6 @@ mod tests {
                 .unwrap_or_else(|e| panic!("parse {name:?}: {e:?}"));
             assert_eq!(id.to_string(), name, "round-trip mismatch");
         }
-    }
-
-    #[test]
-    fn display_matches_the_writer() {
-        let id: MeasuredId = "tfhe::shortint::ops::add::PARAM_MESSAGE_2_CARRY_2_KS_PBS_mean_avx512"
-            .parse()
-            .unwrap();
-        assert_eq!(
-            id.to_string(),
-            measured_name(&id.spec.to_string(), Statistic::Mean, Some("avx512"))
-        );
     }
 
     /// `marker()` is a hand-written mirror of the strum name, so that splitting

--- a/utils/benchmark_spec/src/measured.rs
+++ b/utils/benchmark_spec/src/measured.rs
@@ -1,0 +1,145 @@
+//! Composes and parses the name of a stored benchmark result:
+//!
+//! ```text
+//! {bench_id}_{statistic}(_{variant})?
+//! ```
+
+use std::fmt;
+use std::str::FromStr;
+
+use strum::{Display, EnumString};
+
+use crate::BenchmarkSpec;
+use crate::error::SpecParseError;
+
+/// Which statistic of a criterion estimate a stored value holds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Display, EnumString)]
+#[strum(serialize_all = "snake_case")]
+pub enum Statistic {
+    Mean,
+    StdDev,
+}
+
+impl Statistic {
+    fn marker(self) -> &'static str {
+        match self {
+            Self::Mean => "_mean",
+            Self::StdDev => "_std_dev",
+        }
+    }
+}
+
+/// Composes the name of a stored result.
+///
+/// Takes the bench id as a string, not a [`BenchmarkSpec`]: results are written
+/// for every benchmark, including those whose id predates the spec grammar.
+pub fn measured_name(bench_id: &str, statistic: Statistic, variant: Option<&str>) -> String {
+    let mut name = format!("{bench_id}{}", statistic.marker());
+    if let Some(variant) = variant.filter(|v| !v.is_empty()) {
+        name.push('_');
+        name.push_str(variant);
+    }
+    name
+}
+
+/// A stored result name, parsed back into its parts.
+#[derive(Debug)]
+pub struct MeasuredId {
+    pub spec: BenchmarkSpec,
+    pub statistic: Statistic,
+    /// Run flavour: `avx512`, `regression`, or a compound string built by a
+    /// workflow. Free-form; only ever handled as a whole.
+    pub variant: Option<String>,
+}
+
+impl fmt::Display for MeasuredId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&measured_name(
+            &self.spec.to_string(),
+            self.statistic,
+            self.variant.as_deref(),
+        ))
+    }
+}
+
+impl FromStr for MeasuredId {
+    type Err = SpecParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (bench_id, statistic, rest) = split_statistic(s)
+            .ok_or_else(|| SpecParseError::Unknown(format!("no statistic in {s:?}")))?;
+
+        Ok(Self {
+            spec: bench_id.parse()?,
+            statistic,
+            variant: match rest.strip_prefix('_') {
+                Some(variant) if !variant.is_empty() => Some(variant.to_string()),
+                _ => None,
+            },
+        })
+    }
+}
+
+/// Splits a stored name around its statistic marker.
+///
+/// Uses the first marker, not the last: parameter aliases are uppercase so they
+/// cannot hold one, but a variant can (`_chrome_mean`) and belongs to the tail.
+fn split_statistic(s: &str) -> Option<(&str, Statistic, &str)> {
+    [Statistic::Mean, Statistic::StdDev]
+        .into_iter()
+        .filter_map(|statistic| s.find(statistic.marker()).map(|at| (at, statistic)))
+        .min_by_key(|(at, _)| *at)
+        .map(|(at, statistic)| (&s[..at], statistic, &s[at + statistic.marker().len()..]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip() {
+        let names = [
+            "tfhe::shortint::ops::add::PARAM_MESSAGE_2_CARRY_2_KS_PBS_mean_avx512",
+            "tfhe::shortint::ops::add::PARAM_MESSAGE_2_CARRY_2_KS_PBS_std_dev_avx512",
+            // No variant: the parser's default is an empty suffix (`cli.rs:50`).
+            "tfhe::hlapi::ops::add::PARAM_MESSAGE_2_CARRY_2::FheUint64_mean",
+            // A workflow-built compound variant stays opaque.
+            "tfhe::hlapi::ops::add::PARAM_MESSAGE_2_CARRY_2::FheUint64_mean_batch_size_4-schedule_fifo",
+        ];
+        for name in names {
+            let id: MeasuredId = name
+                .parse()
+                .unwrap_or_else(|e| panic!("parse {name:?}: {e:?}"));
+            assert_eq!(id.to_string(), name, "round-trip mismatch");
+        }
+    }
+
+    #[test]
+    fn display_matches_the_writer() {
+        let id: MeasuredId = "tfhe::shortint::ops::add::PARAM_MESSAGE_2_CARRY_2_KS_PBS_mean_avx512"
+            .parse()
+            .unwrap();
+        assert_eq!(
+            id.to_string(),
+            measured_name(&id.spec.to_string(), Statistic::Mean, Some("avx512"))
+        );
+    }
+
+    /// `marker()` is a hand-written mirror of the strum name, so that splitting
+    /// needs no allocation. This keeps the two from drifting.
+    #[test]
+    fn markers_match_the_strum_names() {
+        for statistic in [Statistic::Mean, Statistic::StdDev] {
+            assert_eq!(statistic.marker(), format!("_{statistic}"));
+        }
+    }
+
+    #[test]
+    fn a_variant_holding_a_marker_stays_in_the_tail() {
+        let id: MeasuredId = "tfhe::shortint::ops::add::PARAM_2_mean_chrome_mean"
+            .parse()
+            .unwrap();
+        assert_eq!(id.statistic, Statistic::Mean);
+        assert_eq!(id.variant.as_deref(), Some("chrome_mean"));
+    }
+}

--- a/utils/benchmark_spec/src/parse.rs
+++ b/utils/benchmark_spec/src/parse.rs
@@ -3,7 +3,8 @@
 use std::str::FromStr;
 
 use crate::error::SpecParseError;
-use crate::{Backend, BenchCrate, BenchmarkMetric, BenchmarkSpec, OperandType};
+use crate::segment::next_segment;
+use crate::{Backend, BenchPath, BenchmarkMetric, BenchmarkSpec, OperandType};
 
 /// Parses a full benchmark id back into a [`BenchmarkSpec`], following the
 /// grammar produced by its `Display`:
@@ -17,42 +18,27 @@ impl FromStr for BenchmarkSpec {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         // The bench path is the longest `::`-prefix that parses; everything after
         // is the positional trailing (backend / metric / param / …).
-        let (bench_crate, trailing) = split_bench_path(s)
+        let (bench_path, trailing) = split_bench_path(s)
             .ok_or_else(|| SpecParseError::Unknown(format!("no known bench path in {s:?}")))?;
 
-        let mut it = trailing.split("::").filter(|t| !t.is_empty()).peekable();
-
-        let backend = match it.peek().copied() {
-            Some("cuda") => {
-                it.next();
-                Backend::Cuda
-            }
-            Some("hpu") => {
-                it.next();
-                Backend::Hpu
-            }
-            _ => Backend::Cpu,
+        let tokens: Vec<&str> = if trailing.is_empty() {
+            Vec::new()
+        } else {
+            trailing.split("::").collect()
         };
+        if tokens.iter().any(|t| t.is_empty()) {
+            return Err(SpecParseError::Unknown(format!("empty segment in {s:?}")));
+        }
 
-        let metric = match it.peek().copied() {
-            Some("throughput") => {
-                it.next();
-                BenchmarkMetric::Throughput
-            }
-            Some("pbs_count") => {
-                it.next();
-                BenchmarkMetric::PbsCount
-            }
-            Some("key_size") => {
-                it.next();
-                BenchmarkMetric::KeySize
-            }
-            _ => BenchmarkMetric::Latency,
-        };
+        let mut it = tokens.into_iter().peekable();
+
+        let backend = next_segment(&mut it).unwrap_or(Backend::Cpu);
+
+        let metric = next_segment(&mut it).unwrap_or(BenchmarkMetric::Latency);
 
         // `zk` benches carry no parameter set: `Display` skips the segment
         // altogether, so there is nothing to consume here.
-        let param_name = if matches!(bench_crate, BenchCrate::Zk(_)) {
+        let param_name = if matches!(bench_path, BenchPath::Zk(_)) {
             String::new()
         } else {
             it.next()
@@ -60,12 +46,7 @@ impl FromStr for BenchmarkSpec {
                 .to_string()
         };
 
-        let operand_type = if it.peek().copied() == Some("scalar") {
-            it.next();
-            OperandType::PlainText
-        } else {
-            OperandType::CipherText
-        };
+        let operand_type = next_segment(&mut it).unwrap_or(OperandType::CipherText);
 
         // Remaining tokens: the optional `<n>_elements` marker is always last;
         // anything before it is the type name (which may itself span several
@@ -78,7 +59,7 @@ impl FromStr for BenchmarkSpec {
         let type_name = (!type_toks.is_empty()).then(|| type_toks.join("::"));
 
         Ok(BenchmarkSpec {
-            bench_crate,
+            bench_path,
             backend,
             param_name,
             operand_type,
@@ -90,17 +71,17 @@ impl FromStr for BenchmarkSpec {
 }
 
 /// `<n>_elements` -> `n`.
-fn parse_elements(tok: &str) -> Option<usize> {
+fn parse_elements(tok: &str) -> Option<u64> {
     tok.strip_suffix("_elements")?.parse().ok()
 }
 
-/// Longest `::`-prefix of `s` that parses as a [`BenchCrate`], plus the rest.
-fn split_bench_path(s: &str) -> Option<(BenchCrate, &str)> {
+/// Longest `::`-prefix of `s` that parses as a [`BenchPath`], plus the rest.
+fn split_bench_path(s: &str) -> Option<(BenchPath, &str)> {
     let mut end = s.len();
     loop {
         let prefix = &s[..end];
-        if let Ok(bc) = prefix.parse::<BenchCrate>() {
-            return Some((bc, s[end..].trim_start_matches("::")));
+        if let Ok(bc) = prefix.parse::<BenchPath>() {
+            return Some((bc, s[end..].strip_prefix("::").unwrap_or("")));
         }
         end = prefix.rfind("::")?;
     }
@@ -141,11 +122,136 @@ mod tests {
             // trailing `_elements` marker belongs to the type name.
             "tfhe::hlapi::kv_store::get::PARAM_MESSAGE_2_CARRY_2::key_FheUint32::value_FheUint64",
             "tfhe::core_crypto::keyswitch::cuda::PARAM_MESSAGE_2_CARRY_2::64b::gemm::trivial_indices",
+            "tfhe::shortint::oprf::PARAM_MESSAGE_2_CARRY_2_KS_PBS",
         ];
         for id in ids {
             let spec: BenchmarkSpec = id.parse().unwrap_or_else(|e| panic!("parse {id:?}: {e:?}"));
             assert_eq!(spec.to_string(), id, "round-trip mismatch");
         }
+    }
+
+    /// A round-trip on the string cannot see a segment landing in the wrong
+    /// field: `Display` re-emits it at the same position, so the id comes back
+    /// byte-identical while the spec holds the wrong values. These cases pin
+    /// every field instead.
+    ///
+    /// Mismatches are collected rather than asserted one at a time, so a single
+    /// run reports every field that is off.
+    #[test]
+    fn parses_every_field() {
+        struct Case {
+            id: &'static str,
+            backend: Backend,
+            operand_type: OperandType,
+            metric: BenchmarkMetric,
+            param_name: &'static str,
+            type_name: Option<&'static str>,
+            num_elements: Option<usize>,
+        }
+
+        let cases = [
+            Case {
+                id: "tfhe::shortint::ops::add::PARAM_MESSAGE_2_CARRY_2_KS_PBS",
+                backend: Backend::Cpu,
+                operand_type: OperandType::CipherText,
+                metric: BenchmarkMetric::Latency,
+                param_name: "PARAM_MESSAGE_2_CARRY_2_KS_PBS",
+                type_name: None,
+                num_elements: None,
+            },
+            // `scalar` comes after the param, not before the metric.
+            Case {
+                id: "tfhe::hlapi::ops::left_shift::PARAM_MESSAGE_2_CARRY_2::scalar::FheUint64",
+                backend: Backend::Cpu,
+                operand_type: OperandType::PlainText,
+                metric: BenchmarkMetric::Latency,
+                param_name: "PARAM_MESSAGE_2_CARRY_2",
+                type_name: Some("FheUint64"),
+                num_elements: None,
+            },
+            // Every optional segment at once, `scalar` included.
+            Case {
+                id: "tfhe::hlapi::ops::left_shift::hpu::throughput::PARAM_MESSAGE_2_CARRY_2::scalar::FheUint64::10_elements",
+                backend: Backend::Hpu,
+                operand_type: OperandType::PlainText,
+                metric: BenchmarkMetric::Throughput,
+                param_name: "PARAM_MESSAGE_2_CARRY_2",
+                type_name: Some("FheUint64"),
+                num_elements: Some(10),
+            },
+            // Metric segments are spelled the way `Display` writes them:
+            // snake_case, underscore included.
+            Case {
+                id: "tfhe::hlapi::erc7984::transfer::safe::pbs_count::PARAM_MESSAGE_2_CARRY_2",
+                backend: Backend::Cpu,
+                operand_type: OperandType::CipherText,
+                metric: BenchmarkMetric::PbsCount,
+                param_name: "PARAM_MESSAGE_2_CARRY_2",
+                type_name: None,
+                num_elements: None,
+            },
+            // Synthetic pairing: the metric is orthogonal to the bench path, so
+            // any path exercises the segment.
+            Case {
+                id: "tfhe::shortint::ops::add::key_size::PARAM_MESSAGE_2_CARRY_2_KS_PBS",
+                backend: Backend::Cpu,
+                operand_type: OperandType::CipherText,
+                metric: BenchmarkMetric::KeySize,
+                param_name: "PARAM_MESSAGE_2_CARRY_2_KS_PBS",
+                type_name: None,
+                num_elements: None,
+            },
+        ];
+
+        let mut failures = Vec::new();
+        for case in cases {
+            let spec: BenchmarkSpec = match case.id.parse() {
+                Ok(spec) => spec,
+                Err(e) => {
+                    failures.push(format!("{}\n    does not parse: {e:?}", case.id));
+                    continue;
+                }
+            };
+            let mut check = |field: &str, got: String, want: String| {
+                if got != want {
+                    failures.push(format!(
+                        "{}\n    {field}: got {got}, expected {want}",
+                        case.id
+                    ));
+                }
+            };
+            check(
+                "backend",
+                format!("{:?}", spec.backend),
+                format!("{:?}", case.backend),
+            );
+            check(
+                "operand_type",
+                format!("{:?}", spec.operand_type()),
+                format!("{:?}", case.operand_type),
+            );
+            check(
+                "metric",
+                format!("{:?}", spec.metric()),
+                format!("{:?}", case.metric),
+            );
+            check(
+                "param_name",
+                format!("{:?}", spec.param_name()),
+                format!("{:?}", case.param_name),
+            );
+            check(
+                "type_name",
+                format!("{:?}", spec.type_name()),
+                format!("{:?}", case.type_name),
+            );
+            check(
+                "num_elements",
+                format!("{:?}", spec.num_elements()),
+                format!("{:?}", case.num_elements),
+            );
+        }
+        assert!(failures.is_empty(), "\n{}", failures.join("\n"));
     }
 
     #[test]
@@ -156,5 +262,45 @@ mod tests {
                 .parse::<BenchmarkSpec>()
                 .is_err()
         );
+    }
+
+    /// Ids no `Display` could ever have produced. Each one trips a different
+    /// guard, so a regression in any single one of them surfaces here.
+    #[test]
+    fn malformed_ids_are_rejected() {
+        let ids = [
+            // Nothing in there resolves to a bench path.
+            "",
+            "tfhe",
+            "zk",
+            "tfhe::shortint",
+            "tfhe::not_a_layer::add::PARAM_MESSAGE_2_CARRY_2",
+            "tfhe::shortint::ops::not_an_op::PARAM_MESSAGE_2_CARRY_2",
+            "zk::not_a_layer::G1_bls12_446",
+            // Tokens are snake_case, and matched exactly.
+            "TFHE::shortint::ops::add::PARAM_MESSAGE_2_CARRY_2",
+            "tfhe::Shortint::ops::add::PARAM_MESSAGE_2_CARRY_2",
+            // `::` is the only separator, and it never doubles up.
+            "::tfhe::shortint::ops::add::PARAM_MESSAGE_2_CARRY_2",
+            "tfhe::shortint::ops::add::PARAM_MESSAGE_2_CARRY_2::",
+            "tfhe::shortint::ops::add::::PARAM_MESSAGE_2_CARRY_2",
+            "tfhe::shortint::ops::add::PARAM_MESSAGE_2_CARRY_2::::FheUint64",
+            "tfhe:shortint:ops:add:PARAM_MESSAGE_2_CARRY_2",
+            "tfhe/shortint/ops/add/PARAM_MESSAGE_2_CARRY_2",
+            // Surrounding whitespace is not trimmed anywhere.
+            " tfhe::shortint::ops::add::PARAM_MESSAGE_2_CARRY_2",
+            "tfhe::shortint::ops::add ::PARAM_MESSAGE_2_CARRY_2",
+            // A bench path on its own is not an id: the parameter set is
+            // mandatory for everything but `zk`, and the id stops too early.
+            "tfhe::shortint::ops::add",
+            "tfhe::hlapi::ops::mul::cuda",
+            "tfhe::hlapi::ops::add::hpu::throughput",
+        ];
+        for id in ids {
+            assert!(
+                id.parse::<BenchmarkSpec>().is_err(),
+                "{id:?} parsed but should not have"
+            );
+        }
     }
 }

--- a/utils/benchmark_spec/src/parse.rs
+++ b/utils/benchmark_spec/src/parse.rs
@@ -1,0 +1,160 @@
+//! Bench-id parsing: the inverse of [`BenchmarkSpec`]'s `Display`.
+
+use std::str::FromStr;
+
+use crate::error::SpecParseError;
+use crate::{Backend, BenchCrate, BenchmarkMetric, BenchmarkSpec, OperandType};
+
+/// Parses a full benchmark id back into a [`BenchmarkSpec`], following the
+/// grammar produced by its `Display`:
+///
+/// ```text
+/// {crate::layer::bench}(::{backend})?(::{metric})?::{param}(::scalar)?(::{type})?(::{n}_elements)?
+/// ```
+impl FromStr for BenchmarkSpec {
+    type Err = SpecParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // The bench path is the longest `::`-prefix that parses; everything after
+        // is the positional trailing (backend / metric / param / …).
+        let (bench_crate, trailing) = split_bench_path(s)
+            .ok_or_else(|| SpecParseError::Unknown(format!("no known bench path in {s:?}")))?;
+
+        let mut it = trailing.split("::").filter(|t| !t.is_empty()).peekable();
+
+        let backend = match it.peek().copied() {
+            Some("cuda") => {
+                it.next();
+                Backend::Cuda
+            }
+            Some("hpu") => {
+                it.next();
+                Backend::Hpu
+            }
+            _ => Backend::Cpu,
+        };
+
+        let metric = match it.peek().copied() {
+            Some("throughput") => {
+                it.next();
+                BenchmarkMetric::Throughput
+            }
+            Some("pbs_count") => {
+                it.next();
+                BenchmarkMetric::PbsCount
+            }
+            Some("key_size") => {
+                it.next();
+                BenchmarkMetric::KeySize
+            }
+            _ => BenchmarkMetric::Latency,
+        };
+
+        // `zk` benches carry no parameter set: `Display` skips the segment
+        // altogether, so there is nothing to consume here.
+        let param_name = if matches!(bench_crate, BenchCrate::Zk(_)) {
+            String::new()
+        } else {
+            it.next()
+                .ok_or_else(|| SpecParseError::Unknown(format!("missing param in {s:?}")))?
+                .to_string()
+        };
+
+        let operand_type = if it.peek().copied() == Some("scalar") {
+            it.next();
+            OperandType::PlainText
+        } else {
+            OperandType::CipherText
+        };
+
+        // Remaining tokens: the optional `<n>_elements` marker is always last;
+        // anything before it is the type name (which may itself span several
+        // `::` segments, e.g. `key_x::value_y`).
+        let rest: Vec<&str> = it.collect();
+        let (type_toks, num_elements) = match rest.last().and_then(|t| parse_elements(t)) {
+            Some(n) => (&rest[..rest.len() - 1], Some(n)),
+            None => (&rest[..], None),
+        };
+        let type_name = (!type_toks.is_empty()).then(|| type_toks.join("::"));
+
+        Ok(BenchmarkSpec {
+            bench_crate,
+            backend,
+            param_name,
+            operand_type,
+            type_name,
+            metric,
+            num_elements,
+        })
+    }
+}
+
+/// `<n>_elements` -> `n`.
+fn parse_elements(tok: &str) -> Option<usize> {
+    tok.strip_suffix("_elements")?.parse().ok()
+}
+
+/// Longest `::`-prefix of `s` that parses as a [`BenchCrate`], plus the rest.
+fn split_bench_path(s: &str) -> Option<(BenchCrate, &str)> {
+    let mut end = s.len();
+    loop {
+        let prefix = &s[..end];
+        if let Ok(bc) = prefix.parse::<BenchCrate>() {
+            return Some((bc, s[end..].trim_start_matches("::")));
+        }
+        end = prefix.rfind("::")?;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `zk` ids carry no parameter set, so the id is built from the spec rather
+    /// than spelled out.
+    #[test]
+    fn roundtrip_zk_id() {
+        use crate::zk::msm::{MsmBench, MsmFlavor};
+
+        let id = BenchmarkSpec::new_zk_msm(
+            MsmBench::G1(MsmFlavor::Bls12_446),
+            Backend::Cuda,
+            BenchmarkMetric::Latency,
+            Some(10),
+        )
+        .to_string();
+
+        let parsed: BenchmarkSpec = id.parse().unwrap_or_else(|e| panic!("parse {id:?}: {e:?}"));
+        assert_eq!(parsed.to_string(), id, "round-trip mismatch");
+    }
+
+    #[test]
+    fn roundtrip_ids() {
+        let ids = [
+            "tfhe::shortint::ops::add::PARAM_MESSAGE_2_CARRY_2_KS_PBS",
+            "tfhe::hlapi::ops::mul::cuda::PARAM_MESSAGE_2_CARRY_2::FheUint128",
+            "tfhe::hlapi::ops::add::hpu::throughput::PARAM_MESSAGE_2_CARRY_2::FheUint64",
+            "tfhe::hlapi::ops::left_shift::PARAM_MESSAGE_2_CARRY_2::scalar::FheUint64",
+            "tfhe::hlapi::erc7984::transfer::whitepaper::PARAM_MESSAGE_2_CARRY_2::10_elements",
+            "tfhe::hlapi::dex::swap_claim::no_cmux::cuda::throughput::PARAM_MESSAGE_2_CARRY_2::FheUint64::10_elements",
+            // Multi-segment type names: everything between the param and the
+            // trailing `_elements` marker belongs to the type name.
+            "tfhe::hlapi::kv_store::get::PARAM_MESSAGE_2_CARRY_2::key_FheUint32::value_FheUint64",
+            "tfhe::core_crypto::keyswitch::cuda::PARAM_MESSAGE_2_CARRY_2::64b::gemm::trivial_indices",
+        ];
+        for id in ids {
+            let spec: BenchmarkSpec = id.parse().unwrap_or_else(|e| panic!("parse {id:?}: {e:?}"));
+            assert_eq!(spec.to_string(), id, "round-trip mismatch");
+        }
+    }
+
+    #[test]
+    fn unknown_bench_path_is_rejected() {
+        // Legacy id (no crate prefix, `integer::` straight away).
+        assert!(
+            "integer::add::PARAM_MESSAGE_2_CARRY_2::64_bits"
+                .parse::<BenchmarkSpec>()
+                .is_err()
+        );
+    }
+}

--- a/utils/benchmark_spec/src/segment.rs
+++ b/utils/benchmark_spec/src/segment.rs
@@ -1,0 +1,95 @@
+use std::iter::Peekable;
+use std::str::FromStr;
+
+use crate::{Backend, BenchmarkMetric, OperandType};
+
+pub(crate) trait OptionalSegment:
+    Sized + FromStr + PartialEq + Into<&'static str> + Copy
+{
+    const OMITTED_VARIANT: Self;
+
+    fn segment(&self) -> Option<&'static str> {
+        (*self != Self::OMITTED_VARIANT).then(|| (*self).into())
+    }
+
+    fn from_segment(s: &str) -> Option<Self> {
+        s.parse().ok().filter(|v| v != &Self::OMITTED_VARIANT)
+    }
+}
+
+pub(crate) fn next_segment<'a, T: OptionalSegment>(
+    it: &mut Peekable<impl Iterator<Item = &'a str>>,
+) -> Option<T> {
+    let value = T::from_segment(it.peek()?)?;
+    it.next();
+    Some(value)
+}
+
+impl OptionalSegment for Backend {
+    const OMITTED_VARIANT: Self = Backend::Cpu;
+}
+
+impl OptionalSegment for OperandType {
+    const OMITTED_VARIANT: Self = OperandType::CipherText;
+}
+
+impl OptionalSegment for BenchmarkMetric {
+    const OMITTED_VARIANT: Self = BenchmarkMetric::Latency;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pins the vocabulary to literal strings.
+    ///
+    /// `segment_roundtrip` cannot do this on its own: both directions read the
+    /// same `#[strum]` attribute, so dropping `serialize_all` renames every
+    /// segment while keeping the round-trip perfect.
+    #[test]
+    fn segments_are_spelled_as_the_grammar_writes_them() {
+        assert_eq!(Backend::Cpu.segment(), None);
+        assert_eq!(Backend::Cuda.segment(), Some("cuda"));
+        assert_eq!(Backend::Hpu.segment(), Some("hpu"));
+
+        assert_eq!(BenchmarkMetric::Latency.segment(), None);
+        assert_eq!(BenchmarkMetric::Throughput.segment(), Some("throughput"));
+        assert_eq!(BenchmarkMetric::PbsCount.segment(), Some("pbs_count"));
+        assert_eq!(BenchmarkMetric::KeySize.segment(), Some("key_size"));
+
+        assert_eq!(OperandType::CipherText.segment(), None);
+        assert_eq!(OperandType::PlainText.segment(), Some("scalar"));
+    }
+
+    /// The omitted variant must not parse as a segment. `Display` never writes
+    /// it, so accepting it would give the same spec two spellings.
+    #[test]
+    fn omitted_variants_are_not_segments() {
+        assert_eq!(Backend::from_segment("cpu"), None);
+        assert_eq!(BenchmarkMetric::from_segment("latency"), None);
+        assert_eq!(OperandType::from_segment("cipher_text"), None);
+    }
+
+    #[test]
+    fn segment_roundtrip() {
+        fn check<T>(variants: &[T])
+        where
+            T: OptionalSegment + Copy + PartialEq + std::fmt::Debug,
+        {
+            for &variant in variants {
+                if let Some(segment) = variant.segment() {
+                    assert_eq!(T::from_segment(segment), Some(variant), "{segment:?}");
+                }
+            }
+        }
+
+        check(&[Backend::Cpu, Backend::Cuda, Backend::Hpu]);
+        check(&[
+            BenchmarkMetric::Latency,
+            BenchmarkMetric::Throughput,
+            BenchmarkMetric::PbsCount,
+            BenchmarkMetric::KeySize,
+        ]);
+        check(&[OperandType::CipherText, OperandType::PlainText]);
+    }
+}

--- a/utils/benchmark_spec/src/tfhe/boolean.rs
+++ b/utils/benchmark_spec/src/tfhe/boolean.rs
@@ -1,8 +1,8 @@
-use strum::Display;
+use strum::{Display, EnumString};
 
 use crate::traits::SpecLeafNode;
 
-#[derive(Debug, Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, Display, EnumString, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
 pub enum BooleanBench {
     And,

--- a/utils/benchmark_spec/src/tfhe/core_crypto/mod.rs
+++ b/utils/benchmark_spec/src/tfhe/core_crypto/mod.rs
@@ -1,8 +1,8 @@
-use strum::Display;
+use strum::{Display, EnumString};
 
 use crate::traits::SpecLeafNode;
 
-#[derive(Debug, Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, Display, EnumString, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
 pub enum CoreCryptoBench {
     // ks_bench.rs

--- a/utils/benchmark_spec/src/tfhe/hl_integer_op.rs
+++ b/utils/benchmark_spec/src/tfhe/hl_integer_op.rs
@@ -1,9 +1,9 @@
-use strum::Display;
+use strum::{Display, EnumString};
 
 use crate::traits::SpecLeafNode;
 
 /// Atomic operations shared across layers (hlapi, integer...).
-#[derive(Debug, Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, Display, EnumString, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
 pub enum HlIntegerOp {
     Add,

--- a/utils/benchmark_spec/src/tfhe/hlapi/dex.rs
+++ b/utils/benchmark_spec/src/tfhe/hlapi/dex.rs
@@ -1,10 +1,18 @@
-use strum::Display;
+use std::str::FromStr;
 
+use strum::{Display, EnumDiscriminants, EnumString};
+
+use crate::error::SpecParseError;
 use crate::traits::{SpecLeafNode, SpecNode};
 
 /// DEX (decentralized exchange) benchmark operations for the HLAPI layer.
-#[derive(Debug, Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, Display, EnumDiscriminants, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
+#[strum_discriminants(
+    name(DexKind),
+    derive(EnumString, Display),
+    strum(serialize_all = "snake_case")
+)]
 pub enum Dex {
     SwapRequest(DexFlavor),
     SwapClaim(DexFlavor),
@@ -19,7 +27,21 @@ impl SpecNode for Dex {
     }
 }
 
-#[derive(Debug, Clone, Copy, Display)]
+impl FromStr for Dex {
+    type Err = SpecParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (head, rest) = s.split_once("::").unwrap_or((s, ""));
+        match DexKind::from_str(head)
+            .map_err(|_| SpecParseError::Unknown(format!("unknown dex op: {head}")))?
+        {
+            DexKind::SwapRequest => Ok(Self::SwapRequest(rest.parse()?)),
+            DexKind::SwapClaim => Ok(Self::SwapClaim(rest.parse()?)),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Display, EnumString, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
 pub enum DexFlavor {
     Whitepaper,

--- a/utils/benchmark_spec/src/tfhe/hlapi/erc7984.rs
+++ b/utils/benchmark_spec/src/tfhe/hlapi/erc7984.rs
@@ -1,10 +1,18 @@
-use strum::Display;
+use std::str::FromStr;
 
+use strum::{Display, EnumDiscriminants, EnumString};
+
+use crate::error::SpecParseError;
 use crate::traits::{SpecLeafNode, SpecNode};
 
 /// ERC-7984 token transfer benchmark operations for the HLAPI layer.
-#[derive(Debug, Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, Display, EnumDiscriminants, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
+#[strum_discriminants(
+    name(Erc7984Kind),
+    derive(EnumString, Display),
+    strum(serialize_all = "snake_case")
+)]
 pub enum Erc7984 {
     Transfer(TransferFlavor),
 }
@@ -17,7 +25,20 @@ impl SpecNode for Erc7984 {
     }
 }
 
-#[derive(Debug, Clone, Copy, Display)]
+impl FromStr for Erc7984 {
+    type Err = SpecParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (head, rest) = s.split_once("::").unwrap_or((s, ""));
+        match Erc7984Kind::from_str(head)
+            .map_err(|_| SpecParseError::Unknown(format!("unknown erc7984 op: {head}")))?
+        {
+            Erc7984Kind::Transfer => Ok(Self::Transfer(rest.parse()?)),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Display, EnumString, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
 pub enum TransferFlavor {
     Whitepaper,

--- a/utils/benchmark_spec/src/tfhe/hlapi/kv_store.rs
+++ b/utils/benchmark_spec/src/tfhe/hlapi/kv_store.rs
@@ -1,9 +1,9 @@
-use strum::Display;
+use strum::{Display, EnumString};
 
 use crate::traits::SpecLeafNode;
 
 /// KV store benchmark operations for the HLAPI layer.
-#[derive(Debug, Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Display, EnumString, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
 pub enum KvStoreOp {
     ContainsKey,

--- a/utils/benchmark_spec/src/tfhe/hlapi/mod.rs
+++ b/utils/benchmark_spec/src/tfhe/hlapi/mod.rs
@@ -5,14 +5,17 @@ pub mod noise_squash;
 pub mod oprf;
 pub mod vector_find;
 
+use std::str::FromStr;
+
 use dex::Dex;
 use erc7984::Erc7984;
 use kv_store::KvStoreOp;
 use noise_squash::NoiseSquashingKind;
 use oprf::OprfKind;
-use strum::Display;
+use strum::{Display, EnumDiscriminants, EnumString};
 use vector_find::VectorFindOp;
 
+use crate::error::SpecParseError;
 use crate::traits::SpecNode;
 
 pub use super::hl_integer_op::HlIntegerOp;
@@ -24,8 +27,13 @@ pub use super::hl_integer_op::HlIntegerOp;
 /// 1. Add the variant here (strum handles the name)
 /// 2. Add a match arm in `child()` returning the inner op as `&dyn SpecNode` (a leaf op enum just
 ///    needs `impl SpecNode for X {}`).
-#[derive(Debug, Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, Display, EnumDiscriminants, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
+#[strum_discriminants(
+    name(HlapiBenchKind),
+    derive(EnumString, Display),
+    strum(serialize_all = "snake_case")
+)]
 pub enum HlapiBench {
     Ops(HlIntegerOp),
     Erc7984(Erc7984),
@@ -47,5 +55,24 @@ impl SpecNode for HlapiBench {
             HlapiBench::Oprf(op) => op,
             HlapiBench::VectorFind(op) => op,
         })
+    }
+}
+
+impl FromStr for HlapiBench {
+    type Err = SpecParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (head, rest) = s.split_once("::").unwrap_or((s, ""));
+        match HlapiBenchKind::from_str(head)
+            .map_err(|_| SpecParseError::Unknown(format!("Unknown layer: {head}")))?
+        {
+            HlapiBenchKind::Ops => Ok(Self::Ops(rest.parse()?)),
+            HlapiBenchKind::Erc7984 => Ok(Self::Erc7984(rest.parse()?)),
+            HlapiBenchKind::Dex => Ok(Self::Dex(rest.parse()?)),
+            HlapiBenchKind::KvStore => Ok(Self::KvStore(rest.parse()?)),
+            HlapiBenchKind::NoiseSquashing => Ok(Self::NoiseSquashing(rest.parse()?)),
+            HlapiBenchKind::Oprf => Ok(Self::Oprf(rest.parse()?)),
+            HlapiBenchKind::VectorFind => Ok(Self::VectorFind(rest.parse()?)),
+        }
     }
 }

--- a/utils/benchmark_spec/src/tfhe/hlapi/noise_squash.rs
+++ b/utils/benchmark_spec/src/tfhe/hlapi/noise_squash.rs
@@ -1,8 +1,8 @@
-use strum::Display;
+use strum::{Display, EnumString};
 
 use crate::traits::SpecLeafNode;
 
-#[derive(Debug, Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, Display, EnumString, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
 pub enum NoiseSquashingKind {
     NoiseSquash,

--- a/utils/benchmark_spec/src/tfhe/hlapi/oprf.rs
+++ b/utils/benchmark_spec/src/tfhe/hlapi/oprf.rs
@@ -1,8 +1,8 @@
-use strum::Display;
+use strum::{Display, EnumString};
 
 use crate::traits::SpecLeafNode;
 
-#[derive(Debug, Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, Display, EnumString, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
 pub enum OprfKind {
     AnyRange,

--- a/utils/benchmark_spec/src/tfhe/hlapi/vector_find.rs
+++ b/utils/benchmark_spec/src/tfhe/hlapi/vector_find.rs
@@ -1,8 +1,8 @@
-use strum::Display;
+use strum::{Display, EnumString};
 
 use crate::traits::SpecLeafNode;
 
-#[derive(Debug, Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, Display, EnumString, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
 pub enum VectorFindOp {
     Contains,

--- a/utils/benchmark_spec/src/tfhe/integer/mod.rs
+++ b/utils/benchmark_spec/src/tfhe/integer/mod.rs
@@ -1,12 +1,19 @@
 pub mod ops;
 
-use ops::IntegerOp;
-use strum::Display;
+use std::str::FromStr;
 
+use crate::error::SpecParseError;
 use crate::traits::{SpecLeafNode, SpecNode};
+use ops::IntegerOp;
+use strum::{Display, EnumDiscriminants, EnumString};
 
-#[derive(Debug, Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, Display, EnumDiscriminants, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
+#[strum_discriminants(
+    name(IntegerOpBySignKind),
+    derive(EnumString, Display),
+    strum(serialize_all = "snake_case")
+)]
 pub enum IntegerOpBySign {
     Unsigned(IntegerOp),
     Signed(IntegerOp),
@@ -21,7 +28,7 @@ impl SpecNode for IntegerOpBySign {
 }
 
 /// GLWE packing-compression operations (integer layer).
-#[derive(Debug, Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, Display, EnumString, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
 pub enum IntegerPackingOp {
     Pack,
@@ -31,7 +38,7 @@ pub enum IntegerPackingOp {
 impl SpecLeafNode for IntegerPackingOp {}
 
 /// Oblivious PRF flavors (integer layer).
-#[derive(Debug, Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, Display, EnumString, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
 pub enum IntegerOprf {
     Unsigned,
@@ -41,7 +48,7 @@ pub enum IntegerOprf {
 impl SpecLeafNode for IntegerOprf {}
 
 /// Re-randomization modes.
-#[derive(Debug, Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, Display, EnumString, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
 pub enum IntegerRerandMode {
     LegacyKeyswitch,
@@ -50,8 +57,27 @@ pub enum IntegerRerandMode {
 
 impl SpecLeafNode for IntegerRerandMode {}
 
-#[derive(Debug, Clone, Copy, Display)]
+impl FromStr for IntegerOpBySign {
+    type Err = SpecParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (head, rest) = s.split_once("::").unwrap_or((s, ""));
+        match IntegerOpBySignKind::from_str(head)
+            .map_err(|_| SpecParseError::Unknown(format!("unknown integer signedness: {head}")))?
+        {
+            IntegerOpBySignKind::Unsigned => Ok(Self::Unsigned(rest.parse()?)),
+            IntegerOpBySignKind::Signed => Ok(Self::Signed(rest.parse()?)),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Display, EnumDiscriminants, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
+#[strum_discriminants(
+    name(IntegerBenchKind),
+    derive(EnumString, Display),
+    strum(serialize_all = "snake_case")
+)]
 pub enum IntegerBench {
     Ops(IntegerOpBySign),
     PackingCompression(IntegerPackingOp),
@@ -67,5 +93,21 @@ impl SpecNode for IntegerBench {
             IntegerBench::Oprf(kind) => kind,
             IntegerBench::Rerand(mode) => mode,
         })
+    }
+}
+
+impl FromStr for IntegerBench {
+    type Err = SpecParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (head, rest) = s.split_once("::").unwrap_or((s, ""));
+        match IntegerBenchKind::from_str(head)
+            .map_err(|_| SpecParseError::Unknown(format!("unknown integer bench: {head}")))?
+        {
+            IntegerBenchKind::Ops => Ok(Self::Ops(rest.parse()?)),
+            IntegerBenchKind::PackingCompression => Ok(Self::PackingCompression(rest.parse()?)),
+            IntegerBenchKind::Oprf => Ok(Self::Oprf(rest.parse()?)),
+            IntegerBenchKind::Rerand => Ok(Self::Rerand(rest.parse()?)),
+        }
     }
 }

--- a/utils/benchmark_spec/src/tfhe/integer/ops.rs
+++ b/utils/benchmark_spec/src/tfhe/integer/ops.rs
@@ -1,8 +1,8 @@
-use strum::Display;
+use strum::{Display, EnumString};
 
 use crate::traits::SpecLeafNode;
 
-#[derive(Debug, Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Display, EnumString, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
 pub enum IntegerOp {
     Abs,

--- a/utils/benchmark_spec/src/tfhe/mod.rs
+++ b/utils/benchmark_spec/src/tfhe/mod.rs
@@ -6,8 +6,11 @@ pub mod integer;
 pub mod shortint;
 pub mod transciphering;
 
-use strum::Display;
+use std::str::FromStr;
 
+use strum::{Display, EnumDiscriminants, EnumString};
+
+use crate::error::SpecParseError;
 use crate::traits::SpecNode;
 
 pub use boolean::BooleanBench;
@@ -28,8 +31,13 @@ pub use transciphering::TranscipheringBench;
 /// 1. Add the variant here (strum handles the name)
 /// 2. Add a match arm in `child()` returning the inner type as `&dyn SpecNode` (the inner type must
 ///    implement `SpecNode`).
-#[derive(Debug, Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, Display, EnumDiscriminants, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
+#[strum_discriminants(
+    name(TfheLayerKind),
+    derive(EnumString, Display),
+    strum(serialize_all = "snake_case")
+)]
 pub enum TfheLayer {
     Boolean(BooleanBench),
     CoreCrypto(CoreCryptoBench),
@@ -49,5 +57,23 @@ impl SpecNode for TfheLayer {
             TfheLayer::Transciphering(bench) => bench,
             TfheLayer::Integer(bench) => bench,
         })
+    }
+}
+
+impl FromStr for TfheLayer {
+    type Err = SpecParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (head, rest) = s.split_once("::").unwrap_or((s, ""));
+        match TfheLayerKind::from_str(head)
+            .map_err(|_| SpecParseError::Unknown(format!("unknown tfhe layer: {head}")))?
+        {
+            TfheLayerKind::Shortint => Ok(Self::Shortint(rest.parse()?)),
+            TfheLayerKind::Hlapi => Ok(Self::Hlapi(rest.parse()?)),
+            TfheLayerKind::CoreCrypto => Ok(Self::CoreCrypto(rest.parse()?)),
+            TfheLayerKind::Boolean => Ok(Self::Boolean(rest.parse()?)),
+            TfheLayerKind::Integer => Ok(Self::Integer(rest.parse()?)),
+            TfheLayerKind::Transciphering => Ok(Self::Transciphering(rest.parse()?)),
+        }
     }
 }

--- a/utils/benchmark_spec/src/tfhe/shortint/mod.rs
+++ b/utils/benchmark_spec/src/tfhe/shortint/mod.rs
@@ -1,12 +1,15 @@
 pub mod ops;
 
-use ops::ShortintOp;
-use strum::Display;
+use std::str::FromStr;
 
+use ops::ShortintOp;
+use strum::{Display, EnumDiscriminants, EnumString};
+
+use crate::error::SpecParseError;
 use crate::traits::{SpecLeafNode, SpecNode};
 
 /// Casting operations between shortint parameter sets.
-#[derive(Debug, Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, Display, EnumString, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
 pub enum ShortintCastingOp {
     Cast,
@@ -17,7 +20,7 @@ pub enum ShortintCastingOp {
 impl SpecLeafNode for ShortintCastingOp {}
 
 /// GLWE packing-compression operations.
-#[derive(Debug, Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, Display, EnumString, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
 pub enum ShortintPackingOp {
     Pack,
@@ -30,12 +33,15 @@ pub enum ShortintPackingOp {
 
 impl SpecLeafNode for ShortintPackingOp {}
 
-/// Benchmarks of the `shortint` layer.
-///
-/// Mixed node: `Ops`/`Casting`/`PackingCompression` carry an inner leaf (a
-/// child in the spec tree), while the remaining variants are leaves themselves.
-#[derive(Debug, Clone, Copy, Display)]
+/// Benchmarks of the `shortint` layer. Mixed node: `Ops`, `Casting` and
+/// `PackingCompression` carry a child, the other variants are leaves.
+#[derive(Debug, Clone, Copy, Display, EnumDiscriminants, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
+#[strum_discriminants(
+    name(ShortintBenchKind),
+    derive(EnumString, Display),
+    strum(serialize_all = "snake_case")
+)]
 pub enum ShortintBench {
     Ops(ShortintOp),
     Casting(ShortintCastingOp),
@@ -59,6 +65,31 @@ impl SpecNode for ShortintBench {
             | ShortintBench::ProgrammableBootstrap
             | ShortintBench::UncompressKey
             | ShortintBench::DecompNoiseSquashComp => None,
+        }
+    }
+}
+
+impl FromStr for ShortintBench {
+    type Err = SpecParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (head, rest) = s.split_once("::").unwrap_or((s, ""));
+        let kind = ShortintBenchKind::from_str(head)
+            .map_err(|_| SpecParseError::Unknown(format!("unknown shortint bench: {head}")))?;
+        match kind {
+            ShortintBenchKind::Ops => Ok(Self::Ops(rest.parse()?)),
+            ShortintBenchKind::Casting => Ok(Self::Casting(rest.parse()?)),
+            ShortintBenchKind::PackingCompression => Ok(Self::PackingCompression(rest.parse()?)),
+            // Leaf variants close the bench path: what follows belongs to the
+            // trailing part of the id, not to this node.
+            _ if !rest.is_empty() => Err(SpecParseError::Unknown(format!(
+                "unexpected {rest:?} after shortint bench {head}"
+            ))),
+            ShortintBenchKind::Oprf => Ok(Self::Oprf),
+            ShortintBenchKind::CarryExtract => Ok(Self::CarryExtract),
+            ShortintBenchKind::ProgrammableBootstrap => Ok(Self::ProgrammableBootstrap),
+            ShortintBenchKind::UncompressKey => Ok(Self::UncompressKey),
+            ShortintBenchKind::DecompNoiseSquashComp => Ok(Self::DecompNoiseSquashComp),
         }
     }
 }

--- a/utils/benchmark_spec/src/tfhe/shortint/ops.rs
+++ b/utils/benchmark_spec/src/tfhe/shortint/ops.rs
@@ -1,9 +1,9 @@
-use strum::Display;
+use strum::{Display, EnumString};
 
 use crate::traits::SpecLeafNode;
 
 /// Shortint server-key operations (unary, binary and scalar variants).
-#[derive(Debug, Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, Display, EnumString, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
 pub enum ShortintOp {
     // Unary ops

--- a/utils/benchmark_spec/src/tfhe/transciphering/aes.rs
+++ b/utils/benchmark_spec/src/tfhe/transciphering/aes.rs
@@ -1,8 +1,8 @@
-use strum::Display;
+use strum::{Display, EnumString};
 
 use crate::traits::SpecLeafNode;
 
-#[derive(Debug, Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, Display, EnumString, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
 pub enum AesFlavor {
     KeyExpansion,

--- a/utils/benchmark_spec/src/tfhe/transciphering/kreyvium.rs
+++ b/utils/benchmark_spec/src/tfhe/transciphering/kreyvium.rs
@@ -1,8 +1,8 @@
-use strum::Display;
+use strum::{Display, EnumString};
 
 use crate::traits::SpecLeafNode;
 
-#[derive(Debug, Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, Display, EnumString, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
 pub enum KreyviumFlavor {
     Warmup,

--- a/utils/benchmark_spec/src/tfhe/transciphering/mod.rs
+++ b/utils/benchmark_spec/src/tfhe/transciphering/mod.rs
@@ -1,14 +1,22 @@
-use strum::Display;
+use std::str::FromStr;
+
+use strum::{Display, EnumDiscriminants, EnumString};
 
 pub mod aes;
 pub mod kreyvium;
 
+use crate::error::SpecParseError;
 use crate::traits::SpecNode;
 use aes::AesFlavor;
 use kreyvium::KreyviumFlavor;
 
-#[derive(Debug, Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, Display, EnumDiscriminants, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
+#[strum_discriminants(
+    name(TranscipheringBenchKind),
+    derive(EnumString, Display),
+    strum(serialize_all = "snake_case")
+)]
 pub enum TranscipheringBench {
     Aes(AesFlavor),
     Kreyvium(KreyviumFlavor),
@@ -20,5 +28,19 @@ impl SpecNode for TranscipheringBench {
             TranscipheringBench::Aes(op) => op,
             TranscipheringBench::Kreyvium(op) => op,
         })
+    }
+}
+
+impl FromStr for TranscipheringBench {
+    type Err = SpecParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (head, rest) = s.split_once("::").unwrap_or((s, ""));
+        match TranscipheringBenchKind::from_str(head)
+            .map_err(|_| SpecParseError::Unknown(format!("unknown transciphering bench: {head}")))?
+        {
+            TranscipheringBenchKind::Aes => Ok(Self::Aes(rest.parse()?)),
+            TranscipheringBenchKind::Kreyvium => Ok(Self::Kreyvium(rest.parse()?)),
+        }
     }
 }

--- a/utils/benchmark_spec/src/zk/mod.rs
+++ b/utils/benchmark_spec/src/zk/mod.rs
@@ -1,12 +1,20 @@
 pub mod msm;
 
-use strum::Display;
+use std::str::FromStr;
 
+use strum::{Display, EnumDiscriminants, EnumString};
+
+use crate::error::SpecParseError;
 use crate::traits::SpecNode;
 use msm::MsmBench;
 
-#[derive(Debug, Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, Display, EnumDiscriminants, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
+#[strum_discriminants(
+    name(ZkLayerKind),
+    derive(EnumString, Display),
+    strum(serialize_all = "snake_case")
+)]
 pub enum ZkLayer {
     Msm(MsmBench),
 }
@@ -16,5 +24,18 @@ impl SpecNode for ZkLayer {
         Some(match self {
             ZkLayer::Msm(bench) => bench,
         })
+    }
+}
+
+impl FromStr for ZkLayer {
+    type Err = SpecParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (head, rest) = s.split_once("::").unwrap_or((s, ""));
+        match ZkLayerKind::from_str(head)
+            .map_err(|_| SpecParseError::Unknown(format!("unknown zk layer: {head}")))?
+        {
+            ZkLayerKind::Msm => Ok(Self::Msm(rest.parse()?)),
+        }
     }
 }

--- a/utils/benchmark_spec/src/zk/msm.rs
+++ b/utils/benchmark_spec/src/zk/msm.rs
@@ -1,9 +1,17 @@
-use strum::Display;
+use std::str::FromStr;
 
+use strum::{Display, EnumDiscriminants, EnumString};
+
+use crate::error::SpecParseError;
 use crate::traits::{SpecLeafNode, SpecNode};
 
-#[derive(Debug, Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, Display, EnumDiscriminants, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
+#[strum_discriminants(
+    name(MsmBenchKind),
+    derive(EnumString, Display),
+    strum(serialize_all = "snake_case")
+)]
 pub enum MsmBench {
     G1(MsmFlavor),
     G2(MsmFlavor),
@@ -18,6 +26,20 @@ impl SpecNode for MsmBench {
     }
 }
 
+impl FromStr for MsmBench {
+    type Err = SpecParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (head, rest) = s.split_once("::").unwrap_or((s, ""));
+        match MsmBenchKind::from_str(head)
+            .map_err(|_| SpecParseError::Unknown(format!("unknown msm bench: {head}")))?
+        {
+            MsmBenchKind::G1 => Ok(Self::G1(rest.parse()?)),
+            MsmBenchKind::G2 => Ok(Self::G2(rest.parse()?)),
+        }
+    }
+}
+
 impl MsmBench {
     pub fn display_name(&self) -> String {
         match self {
@@ -27,7 +49,7 @@ impl MsmBench {
     }
 }
 
-#[derive(Debug, Clone, Copy, Display)]
+#[derive(Debug, Clone, Copy, Display, EnumString, enum_iterator::Sequence)]
 #[strum(serialize_all = "snake_case")]
 pub enum MsmFlavor {
     Bls12_446,

--- a/utils/tfhe-benchmark-parser/src/cli.rs
+++ b/utils/tfhe-benchmark-parser/src/cli.rs
@@ -1,7 +1,6 @@
 use benchmark_spec::{Backend, BenchmarkMetric};
 use clap::Parser;
 use std::path::PathBuf;
-use std::str::FromStr;
 
 #[derive(Parser, Debug)]
 #[command(
@@ -82,7 +81,9 @@ pub struct Cli {
 }
 
 fn parse_cli_bench_metric(s: &str) -> Result<BenchmarkMetric, String> {
-    let m = BenchmarkMetric::from_str(s)?;
+    let m: BenchmarkMetric = s
+        .parse()
+        .map_err(|_| format!("unknown benchmark type: {s}"))?;
     match m {
         BenchmarkMetric::Latency | BenchmarkMetric::Throughput => Ok(m),
         _ => Err(format!("--bench-type does not support {m:?}")),
@@ -90,5 +91,5 @@ fn parse_cli_bench_metric(s: &str) -> Result<BenchmarkMetric, String> {
 }
 
 fn parse_cli_backend(s: &str) -> Result<Backend, String> {
-    Backend::from_str(s)
+    s.parse().map_err(|_| format!("unknown backend: {s}"))
 }

--- a/utils/tfhe-benchmark-parser/src/model/record.rs
+++ b/utils/tfhe-benchmark-parser/src/model/record.rs
@@ -36,7 +36,7 @@ pub enum OperatorType {
 pub(crate) struct BenchmarkParametersRecord {
     pub display_name: String,
     pub crypto_parameters_alias: String,
-    pub bit_size: u32,
+    pub bit_size: u64,
     pub polynomial_multiplication: PolynomialMultiplication,
     pub integer_representation: IntegerRepresentation,
     pub decomposition_basis: Vec<u32>,

--- a/utils/tfhe-benchmark-parser/src/parse/criterion_parser.rs
+++ b/utils/tfhe-benchmark-parser/src/parse/criterion_parser.rs
@@ -1,7 +1,7 @@
 use super::ParseOutcome;
 use super::parameters::get_parameters;
 use anyhow::{Context, Result};
-use benchmark_spec::{Backend, BenchmarkMetric};
+use benchmark_spec::{Backend, BenchmarkMetric, Statistic, measured_name};
 use serde::de::DeserializeOwned;
 use serde_json::Number;
 use std::fs;
@@ -148,8 +148,8 @@ fn process_leaf(
     };
 
     for (raw_value, stat) in [
-        (mean_value, "mean"),
-        (estimates.std_dev.point_estimate, "std_dev"),
+        (mean_value, Statistic::Mean),
+        (estimates.std_dev.point_estimate, Statistic::StdDev),
     ] {
         let Some(number) = Number::from_f64(raw_value) else {
             failures.push(ParsingFailure {
@@ -160,7 +160,7 @@ fn process_leaf(
         };
         points.push(Point {
             value: number,
-            test: join_test_name_parts(&[&test_name, stat, name_suffix]),
+            test: measured_name(&test_name, stat, Some(name_suffix)),
             name: display_name.clone(),
             class: PointClass::Evaluate,
             point_type: bench_type,
@@ -186,13 +186,4 @@ fn read_json<T: DeserializeOwned>(directory: &Path, filename: &str) -> Result<T>
     let parsed =
         serde_json::from_str(&content).with_context(|| format!("parsing {}", path.display()))?;
     Ok(parsed)
-}
-
-fn join_test_name_parts(parts: &[&str]) -> String {
-    parts
-        .iter()
-        .filter(|s| !s.is_empty())
-        .copied()
-        .collect::<Vec<_>>()
-        .join("_")
 }

--- a/utils/tfhe-benchmark-parser/src/writer.rs
+++ b/utils/tfhe-benchmark-parser/src/writer.rs
@@ -12,7 +12,7 @@ pub fn write_to_json(
     benchmark_spec: &BenchmarkSpec,
     display_name: impl Into<String>,
     operator_type: &OperatorType,
-    bit_size: u32,
+    bit_size: u64,
     decomposition_basis: Vec<u32>,
 ) {
     write_to_json_unchecked(
@@ -32,7 +32,7 @@ pub fn write_to_json_unchecked(
     params_alias: impl Into<String>,
     display_name: impl Into<String>,
     operator_type: &OperatorType,
-    bit_size: u32,
+    bit_size: u64,
     decomposition_basis: Vec<u32>,
 ) {
     let execution_type = match bench_id.contains("parallelized") {

--- a/utils/tfhe-data-extractor/.gitignore
+++ b/utils/tfhe-data-extractor/.gitignore
@@ -1,0 +1,1 @@
+config.toml

--- a/utils/tfhe-data-extractor/Cargo.toml
+++ b/utils/tfhe-data-extractor/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "tfhe-data-extractor"
+version = "0.1.0"
+edition = "2024"
+rust-version.workspace = true
+publish = false
+
+[dependencies]
+clap = { workspace = true }
+benchmark_spec = { path = "../benchmark_spec" }
+sqlx = { version = "0.8.6", default-features = false, features = [
+    "runtime-tokio",
+    "tls-rustls",
+    "postgres",
+    "macros",
+] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+serde = { workspace = true, features = ["derive"] }
+toml = "0.8"
+anyhow = "1"
+chrono = { version = "0.4", default-features = false, features = ["std"] }

--- a/utils/tfhe-data-extractor/README.md
+++ b/utils/tfhe-data-extractor/README.md
@@ -1,0 +1,89 @@
+# tfhe-data-extractor
+
+Reads benchmark results back out of the Zama PostgreSQL instance and renders
+them as CSV, Markdown or SVG tables. It is the tool behind the performance
+tables published in the documentation and behind the regression reports.
+
+`--help` lists every flag. This file covers how to get access, how to run the
+tool once, and how it works internally.
+
+## Access
+
+There is no local database to set up. The tool always reads the remote Zama
+PostgreSQL instance, so a run from your laptop and a run from CI look at the
+same data. The only statement it ever issues is a `SELECT`, so a local run
+cannot alter anything.
+
+Three environment variables carry the credentials:
+
+```shell
+export DATA_EXTRACTOR_DATABASE_HOST=...
+export DATA_EXTRACTOR_DATABASE_USER=...
+export DATA_EXTRACTOR_DATABASE_PASSWORD=...
+```
+
+They are enough on their own, and this is how CI passes its secrets. The same
+three values can also live in a TOML file given with `--config-file`: copy
+`config.example.toml` to `config.toml` and fill it in. When both are present,
+the environment wins.
+
+The database name is part of neither: it is the `--database` flag, defaulting to
+`tfhe_rs`.
+
+If you do not have those credentials, ask TFHE-rs team. Note that `--dry-run` needs none of them: it prints the
+SQL `LIKE` patterns a selection resolves to and exits without opening a
+connection, which is the cheapest way to check a command line, with or without
+access.
+
+## Usage
+
+Integer tables for the last 30 days, as SVG plus the CSV that comes with it:
+
+```shell
+cargo run -p tfhe-data-extractor -- bench-results \
+  --generate-svg \
+  --tfhe-rs-layer integer \
+  --hardware hpc8a.96xlarge \
+  --branch main
+```
+
+The first argument is a path prefix with no extension, so this writes
+`bench-results-ciphertext.svg`, `bench-results-plaintext.svg` and the two
+matching `.csv` files.
+
+The `--generate-*` flags are mutually exclusive and the CSV is written alongside
+whichever one is picked, so there is no `--generate-csv`. With none of them,
+nothing is written and the first ten rows are printed instead.
+
+Which tables get built depends on the layer and the subset:
+
+| Layer     | Subset     | Tables                                               |
+| --------- | ---------- | ---------------------------------------------------- |
+| `integer` | `all`      | `-ciphertext` and `-plaintext`                       |
+| `hlapi`   | `erc7984`  | `-ciphertext`                                        |
+| `hlapi`   | `kv_store` | `-ciphertext<op>`, one per key/value store operation |
+
+### Regression profiles
+
+Profiles come from `ci/regression.toml`, selected with `--regression-profiles`
+plus `--regression-selected-profile` (the two go together). Their entries are
+spec path fragments, not bare operation names: under `target.hlapi-dex`,
+`swap_request::whitepaper` is a valid entry and `swap_request` alone is not.
+`cargo test -p tfhe-data-extractor` checks that every default profile still
+resolves against the spec.
+
+## How it works
+
+The database stores one row per benchmark, and the whole structured identity of
+a result (layer, operation, parameter set, precision, metric) lives inside its
+`name` column as a rendered id. A run is therefore four steps:
+
+1. **Build patterns.** The selection becomes SQL `LIKE` patterns over those ids,
+   either one broad pattern for the whole `--tfhe-rs-layer`, or one exact
+   pattern per bench path when a regression profile drives the selection.
+2. **Query.** One read-only query, narrowed further by hardware, backend,
+   branch, metric, PBS kind and either a commit or a date window.
+3. **Parse.** Every id is parsed back into its parts with `benchmark_spec`.
+   Rows whose id does not follow the spec grammar are counted and reported on
+   stderr rather than dropped in silence.
+4. **Render.** The parsed rows are laid out into a table, then serialized.

--- a/utils/tfhe-data-extractor/config.example.toml
+++ b/utils/tfhe-data-extractor/config.example.toml
@@ -1,0 +1,14 @@
+# Copy this file to `config.toml` and fill in the credentials, then pass it with
+# `--config-file config.toml`.
+#
+# Environment variables OVERRIDE any value below:
+#   DATA_EXTRACTOR_DATABASE_HOST
+#   DATA_EXTRACTOR_DATABASE_USER
+#   DATA_EXTRACTOR_DATABASE_PASSWORD
+#
+# The database name comes from the `--database` CLI flag (default: tfhe_rs).
+
+[database]
+host = ""
+user = ""
+password = ""

--- a/utils/tfhe-data-extractor/src/db.rs
+++ b/utils/tfhe-data-extractor/src/db.rs
@@ -1,0 +1,283 @@
+//! PostgreSQL access layer (read-only) for the data extractor.
+//!
+//! Credentials come from a TOML config file (`--config-file`) and/or the
+//! environment variables `DATA_EXTRACTOR_DATABASE_{HOST,USER,PASSWORD}`, the
+//! latter taking precedence.
+
+use std::path::Path;
+
+use benchmark_spec::BenchmarkMetric;
+use sqlx::postgres::{PgConnectOptions, PgPool, PgPoolOptions, PgSslMode};
+use sqlx::{Postgres, QueryBuilder};
+
+/// Database credentials. Every field is optional so the file and the
+/// environment can each provide a subset.
+#[derive(Debug, Default, serde::Deserialize)]
+#[serde(default)]
+pub struct DbConfig {
+    pub host: Option<String>,
+    pub user: Option<String>,
+    pub password: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct ConfigFile {
+    database: DbConfig,
+}
+
+impl DbConfig {
+    /// Loads credentials from the optional TOML file, then overrides any value
+    /// present in the environment, which wins.
+    pub fn load(path: Option<&Path>) -> anyhow::Result<Self> {
+        let mut cfg = match path {
+            Some(p) => {
+                let raw = std::fs::read_to_string(p)
+                    .map_err(|e| anyhow::anyhow!("cannot read config file {}: {e}", p.display()))?;
+                toml::from_str::<ConfigFile>(&raw)?.database
+            }
+            None => DbConfig::default(),
+        };
+
+        if let Ok(v) = std::env::var("DATA_EXTRACTOR_DATABASE_HOST") {
+            cfg.host = Some(v);
+        }
+        if let Ok(v) = std::env::var("DATA_EXTRACTOR_DATABASE_USER") {
+            cfg.user = Some(v);
+        }
+        if let Ok(v) = std::env::var("DATA_EXTRACTOR_DATABASE_PASSWORD") {
+            cfg.password = Some(v);
+        }
+
+        Ok(cfg)
+    }
+
+    fn connect_options(&self, dbname: &str) -> anyhow::Result<PgConnectOptions> {
+        let host = self
+            .host
+            .as_deref()
+            .ok_or_else(|| anyhow::anyhow!("missing database host"))?;
+        let user = self
+            .user
+            .as_deref()
+            .ok_or_else(|| anyhow::anyhow!("missing database user"))?;
+        let password = self
+            .password
+            .as_deref()
+            .ok_or_else(|| anyhow::anyhow!("missing database password"))?;
+
+        Ok(PgConnectOptions::new()
+            .host(host)
+            .username(user)
+            .password(password)
+            .database(dbname)
+            // RDS enforces TLS; `Require` encrypts without CA verification.
+            .ssl_mode(PgSslMode::Require))
+    }
+
+    /// Opens a connection pool to the given database.
+    pub async fn connect(&self, dbname: &str) -> anyhow::Result<PgPool> {
+        let pool = PgPoolOptions::new()
+            .max_connections(4)
+            .connect_with(self.connect_options(dbname)?)
+            .await?;
+        Ok(pool)
+    }
+}
+
+/// One benchmark result, as stored. `name` holds the whole rendered id, so
+/// every structured part of a result has to be parsed back out of it:
+///
+/// ```text
+/// name     = "<bench path>::<param set>::<type>_mean_avx512"
+/// bit_size = 64
+/// value    = 2310000.0     // nanoseconds, for a latency bench
+/// ```
+#[derive(Debug, sqlx::FromRow)]
+pub struct BenchRow {
+    pub name: String,
+    pub bit_size: i64,
+    pub value: f64,
+}
+
+/// Escapes the `LIKE` metacharacters. Bench ids and parameter aliases are full
+/// of `_`, which `LIKE` would otherwise read as "any single character", making
+/// the pattern match more than was asked for.
+///
+/// ```text
+/// add_parallelized  ->  add\_parallelized
+/// ```
+pub fn like_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        if matches!(c, '_' | '%' | '\\') {
+            out.push('\\');
+        }
+        out.push(c);
+    }
+    out
+}
+
+/// PBS-kind filter, applied as a pattern on the parameter-set alias.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, clap::ValueEnum)]
+pub enum PbsKind {
+    Classical,
+    #[value(name = "multi_bit")]
+    MultiBit,
+    /// Special variant used when the user doesn't care about the PBS kind.
+    Any,
+}
+
+/// Dynamic filters for the benchmark fetch query.
+pub struct FetchQuery<'a> {
+    pub hardware: &'a str,
+    pub backend: &'a str,
+    pub branch: &'a str,
+    /// SQL `LIKE` patterns for the id; a row matching any of them is kept.
+    /// Either one broad layer pattern, or one exact prefix per bench path when
+    /// a regression profile drives the selection.
+    pub like_patterns: &'a [String],
+    /// Drop the `unchecked_` variants by name. Only needed for the broad
+    /// pattern: a profile already spells out the operations it wants.
+    pub exclude_non_default: bool,
+    /// `None` = no metric filter (both latency and throughput).
+    pub metric: Option<BenchmarkMetric>,
+    pub pbs_kind: PbsKind,
+    /// `LIKE` pattern on the parameter set alias, already wrapped in `%`.
+    /// Matched as a substring, which matters: aliases carry a version prefix
+    /// (`V1_6_PARAM_…`).
+    pub param_pattern: Option<&'a str>,
+    /// If set, pin to that exact commit; otherwise use the date window.
+    pub project_version: Option<&'a str>,
+    pub bench_date: Option<&'a str>,
+    pub time_span_days: i32,
+}
+
+/// Tiny `WHERE` builder over `sqlx::QueryBuilder`.
+///
+/// [`BASE_QUERY`] ends with `WHERE true`, so every condition is a plain `AND`
+/// and no method has to know whether it is the first one. Which one that would
+/// be is not knowable anyway: most filters here are optional. It also keeps the
+/// query valid when none of them applies.
+///
+/// ```sql
+/// WHERE true AND h.name = $1 AND bk.name = $2 AND test.name LIKE ANY($3)
+/// WHERE true                                    -- no filter active
+/// ```
+///
+/// Column names are always hardcoded constants (safe to inline); only values go
+/// through `push_bind`.
+struct Filters<'a>(QueryBuilder<'a, Postgres>);
+
+impl<'a> Filters<'a> {
+    fn new(base: &str) -> Self {
+        Filters(QueryBuilder::new(base))
+    }
+
+    fn eq<T>(&mut self, col: &str, val: T) -> &mut Self
+    where
+        T: 'a + sqlx::Encode<'a, Postgres> + sqlx::Type<Postgres> + Send,
+    {
+        self.0.push(" AND ").push(col).push(" = ").push_bind(val);
+        self
+    }
+
+    /// `col LIKE ANY($n)`: one round-trip whatever the number of patterns.
+    fn like_any(&mut self, col: &str, patterns: &'a [String]) -> &mut Self {
+        self.0
+            .push(" AND ")
+            .push(col)
+            .push(" LIKE ANY(")
+            .push_bind(patterns)
+            .push(")");
+        self
+    }
+
+    /// Appends a raw `AND <sql>`. Constant SQL only, never user input.
+    fn raw(&mut self, sql: &str) -> &mut Self {
+        self.0.push(" AND ").push(sql);
+        self
+    }
+}
+
+const BASE_QUERY: &str = "\
+    SELECT DISTINCT ON (test.name) \
+        test.name AS name, p.bit_size AS bit_size, m.value AS value \
+    FROM benchmark.metrics AS m \
+    LEFT JOIN benchmark.hardware        AS h  ON m.hardware_id        = h.id \
+    LEFT JOIN benchmark.backend         AS bk ON m.backend_id         = bk.id \
+    LEFT JOIN benchmark.branch          AS b  ON m.branch_id          = b.id \
+    LEFT JOIN benchmark.test            AS test ON m.test_id          = test.id \
+    LEFT JOIN benchmark.parameters      AS p  ON m.parameters_id      = p.id \
+    LEFT JOIN benchmark.project_version AS pv ON m.project_version_id = pv.id \
+    WHERE true";
+
+/// Latest value per `test.name` matching the filters.
+pub async fn fetch_bench_rows(pool: &PgPool, q: &FetchQuery<'_>) -> anyhow::Result<Vec<BenchRow>> {
+    let mut f = Filters::new(BASE_QUERY);
+    f.eq("h.name", q.hardware)
+        .eq("bk.name", q.backend)
+        .eq("b.name", q.branch)
+        .like_any("test.name", q.like_patterns);
+
+    if let Some(version) = q.project_version {
+        f.eq("pv.name", version);
+    }
+
+    if let Some(pattern) = q.param_pattern {
+        f.0.push(" AND p.crypto_parameters_alias LIKE ")
+            .push_bind(pattern);
+    }
+
+    if q.exclude_non_default {
+        // Default operations only. `smart_` was dropped from the benches in
+        // a20ee6325; kept here for the historical rows.
+        f.raw("test.name NOT SIMILAR TO '%(smart|unchecked)_%'");
+    }
+
+    match q.metric {
+        Some(BenchmarkMetric::Latency) => {
+            f.raw("test.name NOT LIKE '%::throughput::%'");
+        }
+        Some(BenchmarkMetric::Throughput) => {
+            f.raw("test.name LIKE '%::throughput::%'");
+        }
+        _ => {}
+    }
+
+    match q.pbs_kind {
+        PbsKind::Classical => {
+            f.raw("p.crypto_parameters_alias NOT SIMILAR TO '%_MULTI_BIT_%'");
+        }
+        PbsKind::MultiBit => {
+            f.raw("p.crypto_parameters_alias SIMILAR TO '%_MULTI_BIT_%'");
+        }
+        PbsKind::Any => {}
+    }
+
+    // Date window only when no exact commit was pinned. Anchored on the
+    // requested date, which also closes the window, or on `now()`, in which case
+    // there is nothing to close: no row can be inserted in the future.
+    if q.project_version.is_none() {
+        match q.bench_date {
+            Some(date) => {
+                f.0.push(" AND m.insert_time <= ")
+                    .push_bind(date)
+                    .push("::timestamp AND m.insert_time >= ")
+                    .push_bind(date)
+                    .push("::timestamp - make_interval(days => ")
+                    .push_bind(q.time_span_days)
+                    .push(")");
+            }
+            None => {
+                f.0.push(" AND m.insert_time >= now() - make_interval(days => ")
+                    .push_bind(q.time_span_days)
+                    .push(")");
+            }
+        }
+    }
+
+    f.0.push(" ORDER BY test.name, m.insert_time DESC");
+
+    let rows = f.0.build_query_as::<BenchRow>().fetch_all(pool).await?;
+    Ok(rows)
+}

--- a/utils/tfhe-data-extractor/src/format/erc7984.rs
+++ b/utils/tfhe-data-extractor/src/format/erc7984.rs
@@ -1,0 +1,71 @@
+//! The `transfer implementation × metric` table of the ERC7984 benchmarks.
+
+use benchmark_spec::tfhe::hlapi::erc7984::{Erc7984, TransferFlavor};
+use benchmark_spec::{BenchPath, BenchmarkMetric, HlapiBench, TfheLayer};
+
+use super::{Cells, GridSpec, Measured, Table, build_grid, readable_value};
+
+const ROW_HEADER: &str = "Transfer implementation";
+
+/// Column headers, spelled as published.
+const COLUMNS: &[(&str, BenchmarkMetric)] = &[
+    ("Latency", BenchmarkMetric::Latency),
+    ("Throughput", BenchmarkMetric::Throughput),
+];
+
+/// Rows in publication order. HPU publishes a different set (`hpu_optim`,
+/// `hpu_simd`) that is not covered here.
+const ROWS: &[TransferFlavor] = &[
+    TransferFlavor::Whitepaper,
+    TransferFlavor::NoCmux,
+    TransferFlavor::Overflow,
+    TransferFlavor::Safe,
+];
+
+/// Builds the ERC7984 transfer table.
+///
+/// A flavour with no result at all is still printed, as two `N/A` cells: the
+/// table exists to compare the three against each other, so a missing one is
+/// the finding.
+pub fn table(measured: &[Measured]) -> Table {
+    let mut cells: Cells<(TransferFlavor, BenchmarkMetric)> = Cells::new();
+
+    for m in measured {
+        let BenchPath::Tfhe(TfheLayer::Hlapi(HlapiBench::Erc7984(Erc7984::Transfer(flavor)))) =
+            m.spec.bench_path()
+        else {
+            continue;
+        };
+        // Only benchmarked on 64-bit ciphertexts, so flavour and metric are
+        // the whole key.
+        cells.insert(
+            (flavor, m.spec.metric()),
+            readable_value(m.spec.metric(), m.value),
+        );
+    }
+
+    let (grid, empty_rows) = build_grid(
+        GridSpec {
+            row_header: ROW_HEADER,
+            rows: ROWS
+                .iter()
+                .map(|flavor| (flavor.to_string(), *flavor))
+                .collect(),
+            columns: COLUMNS,
+            drop_empty_rows: false,
+        },
+        |flavor, metric| cells.get(&(*flavor, *metric)).cloned(),
+    );
+
+    Table {
+        grid,
+        empty_rows,
+        conflicts: cells
+            .conflicts()
+            .map(|c| {
+                let (flavor, metric) = c.key;
+                format!("{flavor}::{metric:?} ({} / {})", c.kept, c.dropped)
+            })
+            .collect(),
+    }
+}

--- a/utils/tfhe-data-extractor/src/format/integer.rs
+++ b/utils/tfhe-data-extractor/src/format/integer.rs
@@ -1,0 +1,125 @@
+//! The `operation × ciphertext size` table of the integer layer.
+
+use benchmark_spec::{BenchPath, IntegerBench, IntegerOp, IntegerOpBySign, OperandType, TfheLayer};
+
+use super::{Cells, GridSpec, Measured, Table, build_grid, readable_value};
+
+const ROW_HEADER: &str = r"Operation \ Size";
+
+/// Published precisions. FheUint2, FheUint4 and FheUint256 are benchmarked but
+/// not shown.
+const COLUMNS: &[(&str, i64)] = &[
+    ("FheUint8", 8),
+    ("FheUint16", 16),
+    ("FheUint32", 32),
+    ("FheUint64", 64),
+    ("FheUint128", 128),
+];
+
+/// Rows in publication order, each a label and the operation it is measured
+/// from. A label may name several operations while only one is benchmarked.
+const CIPHERTEXT_ROWS: &[(&str, IntegerOp)] = &[
+    ("Negation (-)", IntegerOp::NegParallelized),
+    ("Add / Sub (+,-)", IntegerOp::AddParallelized),
+    ("Mul (x)", IntegerOp::MulParallelized),
+    ("Equal / Not Equal (eq, ne)", IntegerOp::EqParallelized),
+    ("Comparisons (ge, gt, le, lt)", IntegerOp::GtParallelized),
+    ("Max / Min (max, min)", IntegerOp::MaxParallelized),
+    (
+        "Bitwise operations (&, |, ^)",
+        IntegerOp::BitandParallelized,
+    ),
+    ("Div / Rem  (/, %)", IntegerOp::DivRemParallelized),
+    (
+        "Left / Right Shifts (<<, >>)",
+        IntegerOp::LeftShiftParallelized,
+    ),
+    (
+        "Left / Right Rotations (left_rotate, right_rotate)",
+        IntegerOp::RotateLeftParallelized,
+    ),
+    (
+        "Leading / Trailing zeros/ones",
+        IntegerOp::LeadingZerosParallelized,
+    ),
+    ("Log2", IntegerOp::Ilog2Parallelized),
+    ("Select", IntegerOp::IfThenElseParallelized),
+];
+
+/// Same, for `scalar` operations, with `Div / Rem` split in two.
+///
+/// Negation, leading and trailing zeros/ones, and log2 are missing because they
+/// are unary: there is no scalar form to measure. `Select` is missing for a
+/// different reason, being available on scalars but not benchmarked, so its row
+/// belongs here again the day it is.
+const SCALAR_ROWS: &[(&str, IntegerOp)] = &[
+    ("Add / Sub (+,-)", IntegerOp::AddParallelized),
+    ("Mul (x)", IntegerOp::MulParallelized),
+    ("Equal / Not Equal (eq, ne)", IntegerOp::EqParallelized),
+    ("Comparisons (ge, gt, le, lt)", IntegerOp::GtParallelized),
+    ("Max / Min (max, min)", IntegerOp::MaxParallelized),
+    (
+        "Bitwise operations (&, |, ^)",
+        IntegerOp::BitandParallelized,
+    ),
+    ("Div  (/)", IntegerOp::DivParallelized),
+    ("Rem  (%)", IntegerOp::RemParallelized),
+    (
+        "Left / Right Shifts (<<, >>)",
+        IntegerOp::LeftShiftParallelized,
+    ),
+    (
+        "Left / Right Rotations (left_rotate, right_rotate)",
+        IntegerOp::RotateLeftParallelized,
+    ),
+];
+
+/// Builds the integer table for one operand type.
+pub fn table(measured: &[Measured], operand: OperandType) -> Table {
+    let table_rows = match operand {
+        OperandType::CipherText => CIPHERTEXT_ROWS,
+        OperandType::PlainText => SCALAR_ROWS,
+    };
+
+    let mut cells: Cells<(IntegerOp, i64)> = Cells::new();
+
+    for m in measured {
+        if m.spec.operand_type().is_scalar() != operand.is_scalar() {
+            continue;
+        }
+        // Unsigned operations only.
+        let BenchPath::Tfhe(TfheLayer::Integer(IntegerBench::Ops(IntegerOpBySign::Unsigned(op)))) =
+            m.spec.bench_path()
+        else {
+            continue;
+        };
+        cells.insert((op, m.bit_size), readable_value(m.spec.metric(), m.value));
+    }
+
+    let (grid, empty_rows) = build_grid(
+        GridSpec {
+            row_header: ROW_HEADER,
+            rows: table_rows
+                .iter()
+                .map(|(label, op)| (label.to_string(), *op))
+                .collect(),
+            columns: COLUMNS,
+            // An operation with no result at all is left out: the row list is a
+            // catalogue, and benchmarking a subset of it is routine.
+            drop_empty_rows: true,
+        },
+        |op, size| cells.get(&(*op, *size)).cloned(),
+    );
+
+    Table {
+        grid,
+        empty_rows,
+        conflicts: cells
+            .conflicts()
+            .map(|c| {
+                let (op, bits) = c.key;
+                format!("{op}::{bits} bits ({} / {})", c.kept, c.dropped)
+            })
+            .collect(),
+    }
+}

--- a/utils/tfhe-data-extractor/src/format/kv_store.rs
+++ b/utils/tfhe-data-extractor/src/format/kv_store.rs
@@ -1,0 +1,107 @@
+//! One `store size × value precision` table per KV-store operation.
+//!
+//! The store size is `num_elements` and the value type sits in `type_name` as
+//! `key_<K>::value_<V>`.
+
+use benchmark_spec::tfhe::hlapi::kv_store::KvStoreOp;
+use benchmark_spec::{BenchPath, HlapiBench, TfheLayer};
+
+use super::{Cells, GridSpec, Measured, Table, build_grid, readable_value};
+
+const ROW_HEADER: &str = r"Store size \ Value";
+
+const COLUMNS: &[(&str, u32)] = &[
+    ("FheUint8", 8),
+    ("FheUint16", 16),
+    ("FheUint32", 32),
+    ("FheUint64", 64),
+    ("FheUint128", 128),
+];
+
+const ROWS: &[u64] = &[2, 4, 8, 16, 32, 64, 128, 256, 512, 1024];
+
+/// Operations published, in order. The spec knows three more (`contains_*`)
+/// that the documentation does not show.
+const OPERATIONS: &[KvStoreOp] = &[KvStoreOp::Get, KvStoreOp::Update, KvStoreOp::Map];
+
+/// Builds one table per operation, suffixed with the operation name.
+pub fn tables(measured: &[Measured]) -> Vec<(String, Table)> {
+    OPERATIONS
+        .iter()
+        .map(|op| {
+            let mut cells: Cells<(u64, u32)> = Cells::new();
+
+            for m in measured {
+                let BenchPath::Tfhe(TfheLayer::Hlapi(HlapiBench::KvStore(row_op))) =
+                    m.spec.bench_path()
+                else {
+                    continue;
+                };
+                if row_op != *op {
+                    continue;
+                }
+                let (Some(store_size), Some(value_bits)) = (
+                    m.spec.num_elements(),
+                    m.spec.type_name().and_then(value_precision),
+                ) else {
+                    continue;
+                };
+
+                cells.insert(
+                    (store_size, value_bits),
+                    readable_value(m.spec.metric(), m.value),
+                );
+            }
+
+            let (grid, empty_rows) = build_grid(
+                GridSpec {
+                    row_header: ROW_HEADER,
+                    rows: ROWS.iter().map(|size| (size.to_string(), *size)).collect(),
+                    columns: COLUMNS,
+                    drop_empty_rows: false,
+                },
+                |size, bits| cells.get(&(*size, *bits)).cloned(),
+            );
+
+            let table = Table {
+                grid,
+                empty_rows,
+                conflicts: cells
+                    .conflicts()
+                    .map(|c| {
+                        let (size, bits) = c.key;
+                        format!(
+                            "{size} elements::FheUint{bits} ({} / {})",
+                            c.kept, c.dropped
+                        )
+                    })
+                    .collect(),
+            };
+
+            (format!("-{op}"), table)
+        })
+        .collect()
+}
+
+/// Pulls the value precision out of a `key_<K>::value_<V>` type tag. Anchored
+/// on the `value_` marker so a differently spelled key type cannot shift it.
+fn value_precision(type_name: &str) -> Option<u32> {
+    type_name
+        .split("::")
+        .find_map(|part| part.strip_prefix("value_"))
+        .and_then(|ty| ty.strip_prefix("FheUint"))
+        .and_then(|bits| bits.parse().ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn value_precision_is_anchored() {
+        assert_eq!(value_precision("key_FheUint32::value_FheUint64"), Some(64));
+        // A key type that happens to look like a value must not be picked up.
+        assert_eq!(value_precision("key_FheUint8"), None);
+        assert_eq!(value_precision("FheUint64"), None);
+    }
+}

--- a/utils/tfhe-data-extractor/src/format/mod.rs
+++ b/utils/tfhe-data-extractor/src/format/mod.rs
@@ -1,0 +1,230 @@
+//! The published benchmark tables, one module per table.
+//!
+//! This module holds what all of them need: the [`Table`] result, cell
+//! collection, id parsing and value formatting.
+
+pub mod erc7984;
+pub mod integer;
+pub mod kv_store;
+pub mod render;
+
+use std::collections::HashMap;
+use std::hash::Hash;
+
+use benchmark_spec::{BenchmarkMetric, BenchmarkSpec, MeasuredId};
+
+use crate::db::BenchRow;
+
+/// A stored result the spec recognised, reduced to what the tables read.
+///
+/// The statistic and the run variant are left behind: the query pins them
+/// through `--name-suffix`, so every row carries the same ones.
+pub struct Measured {
+    pub spec: BenchmarkSpec,
+    pub bit_size: i64,
+    pub value: f64,
+}
+
+/// A table as data, before serialization. Cell values are already formatted;
+/// only the layout is left to the renderer.
+///
+/// ```text
+/// | Operation \ Size | FheUint8 | FheUint16 |   <- row_header, then columns
+/// | Add / Sub (+,-)  | 2.31 ms  | N/A       |   <- one Row { label, cells }
+/// ```
+pub struct Grid {
+    /// Header of the first column, the one holding row labels.
+    pub row_header: String,
+    /// Remaining column headers, in order.
+    pub columns: Vec<String>,
+    pub rows: Vec<Row>,
+}
+
+pub struct Row {
+    pub label: String,
+    /// One entry per column, `None` when that column was not measured.
+    pub cells: Vec<Option<String>>,
+}
+
+/// A built table plus what it could not account for.
+pub struct Table {
+    pub grid: Grid,
+    /// Rows with no result at any column. Whether they are printed as `N/A` or
+    /// left out is up to each table.
+    pub empty_rows: Vec<String>,
+    /// Cells several benchmarks competed for with different values, meaning the
+    /// selection is under-specified. Already formatted by the table they belong
+    /// to, which is the only one that knows how to name its own cells.
+    pub conflicts: Vec<String>,
+}
+
+impl Table {
+    /// Reports on stderr what the table could not account for.
+    pub fn report(&self) {
+        if !self.empty_rows.is_empty() {
+            eprintln!(
+                "warning: {} rows without any result: {}",
+                self.empty_rows.len(),
+                self.empty_rows.join(", "),
+            );
+        }
+        if !self.conflicts.is_empty() {
+            eprintln!(
+                "warning: {} cell(s) matched by several benchmarks, first kept. \
+                 Narrow the selection with --param:",
+                self.conflicts.len(),
+            );
+            for conflict in &self.conflicts {
+                eprintln!("  {conflict}");
+            }
+        }
+    }
+}
+
+/// One value per cell of a table.
+///
+/// A second, different value for the same cell means the query did not narrow
+/// down to a single benchmark. The first wins, which is deterministic since
+/// rows arrive ordered by `test.name`, and the clash is recorded.
+struct Cells<K> {
+    values: HashMap<K, String>,
+    conflicts: Vec<Conflict<K>>,
+}
+
+/// A contested cell: its key, the value kept and the one dropped.
+///
+/// The key is kept rather than formatted on the spot, so that a table sharing a
+/// [`Cells`] with its siblings can pick out the clashes that are its own, and
+/// name them the way it names its cells.
+struct Conflict<K> {
+    key: K,
+    kept: String,
+    dropped: String,
+}
+
+impl<K: Eq + Hash> Cells<K> {
+    fn new() -> Self {
+        Self {
+            values: HashMap::new(),
+            conflicts: Vec::new(),
+        }
+    }
+
+    fn insert(&mut self, key: K, value: String) {
+        match self.values.get(&key) {
+            Some(kept) if *kept != value => self.conflicts.push(Conflict {
+                key,
+                kept: kept.clone(),
+                dropped: value,
+            }),
+            Some(_) => {}
+            None => {
+                self.values.insert(key, value);
+            }
+        }
+    }
+
+    fn get(&self, key: &K) -> Option<&String> {
+        self.values.get(key)
+    }
+
+    /// Contested cells in the order they turned up, which follows `test.name`.
+    fn conflicts(&self) -> impl Iterator<Item = &Conflict<K>> {
+        self.conflicts.iter()
+    }
+}
+
+/// A table's layout, declared the same way by every table.
+struct GridSpec<'a, R, C> {
+    /// Header of the first column, the one holding row labels.
+    row_header: &'a str,
+    /// Row label and the key it is looked up by, in publication order.
+    rows: Vec<(String, R)>,
+    /// Column header and the key it is looked up by, in publication order.
+    columns: &'a [(&'a str, C)],
+    /// Leave out a row with no result at any column, instead of filling it
+    /// with `N/A`.
+    drop_empty_rows: bool,
+}
+
+/// Fills a layout from `lookup`, returning the grid and the labels of the rows
+/// that had no result at any column.
+fn build_grid<R, C>(
+    spec: GridSpec<'_, R, C>,
+    lookup: impl Fn(&R, &C) -> Option<String>,
+) -> (Grid, Vec<String>) {
+    let mut grid_rows = Vec::with_capacity(spec.rows.len());
+    let mut empty_rows = Vec::new();
+
+    for (label, row_key) in spec.rows {
+        let cells: Vec<Option<String>> = spec
+            .columns
+            .iter()
+            .map(|(_, col_key)| lookup(&row_key, col_key))
+            .collect();
+
+        if cells.iter().all(Option::is_none) {
+            empty_rows.push(label.clone());
+            if spec.drop_empty_rows {
+                continue;
+            }
+        }
+
+        grid_rows.push(Row { label, cells });
+    }
+
+    let grid = Grid {
+        row_header: spec.row_header.to_string(),
+        columns: spec
+            .columns
+            .iter()
+            .map(|(name, _)| name.to_string())
+            .collect(),
+        rows: grid_rows,
+    };
+
+    (grid, empty_rows)
+}
+
+/// Parses each stored name against the spec, returning the rows that parsed and
+/// how many did not.
+pub fn parse_rows(rows: &[BenchRow]) -> (Vec<Measured>, usize) {
+    let mut parsed = Vec::with_capacity(rows.len());
+    let mut unparsed = 0;
+
+    for row in rows {
+        match row.name.parse::<MeasuredId>() {
+            Ok(id) => parsed.push(Measured {
+                spec: id.spec,
+                bit_size: row.bit_size,
+                value: row.value,
+            }),
+            Err(_) => unparsed += 1,
+        }
+    }
+
+    (parsed, unparsed)
+}
+
+/// Human-readable latency from a nanosecond figure.
+fn readable_latency(ns: f64) -> String {
+    if ns < 1e3 {
+        format!("{ns:.0} ns")
+    } else if ns < 1e6 {
+        format!("{:.2} us", ns / 1e3)
+    } else if ns < 1e9 {
+        format!("{:.2} ms", ns / 1e6)
+    } else {
+        format!("{:.2} s", ns / 1e9)
+    }
+}
+
+/// Renders a value with the unit implied by its metric.
+fn readable_value(metric: BenchmarkMetric, value: f64) -> String {
+    match metric {
+        BenchmarkMetric::Latency => readable_latency(value),
+        BenchmarkMetric::Throughput => format!("{value:.2} elem/s"),
+        // Counts and byte sizes are not durations.
+        BenchmarkMetric::PbsCount | BenchmarkMetric::KeySize => format!("{value:.0}"),
+    }
+}

--- a/utils/tfhe-data-extractor/src/format/render/csv.rs
+++ b/utils/tfhe-data-extractor/src/format/render/csv.rs
@@ -1,0 +1,37 @@
+//! RFC 4180 CSV. Quoting is not optional here: row labels contain commas
+//! (`Comparisons (ge, gt, le, lt)`).
+
+use super::MISSING;
+use crate::format::Grid;
+
+pub fn table(grid: &Grid) -> String {
+    let mut out = String::new();
+    write_record(
+        &mut out,
+        std::iter::once(grid.row_header.as_str()).chain(grid.columns.iter().map(String::as_str)),
+    );
+    for row in &grid.rows {
+        write_record(
+            &mut out,
+            std::iter::once(row.label.as_str())
+                .chain(row.cells.iter().map(|c| c.as_deref().unwrap_or(MISSING))),
+        );
+    }
+    out
+}
+
+fn write_record<'a>(out: &mut String, fields: impl Iterator<Item = &'a str>) {
+    for (index, field) in fields.enumerate() {
+        if index > 0 {
+            out.push(',');
+        }
+        if field.contains([',', '"', '\n']) {
+            out.push('"');
+            out.push_str(&field.replace('"', "\"\""));
+            out.push('"');
+        } else {
+            out.push_str(field);
+        }
+    }
+    out.push('\n');
+}

--- a/utils/tfhe-data-extractor/src/format/render/markdown.rs
+++ b/utils/tfhe-data-extractor/src/format/render/markdown.rs
@@ -1,0 +1,32 @@
+//! GitHub-flavoured markdown table.
+
+use super::MISSING;
+use crate::format::Grid;
+
+pub fn table(grid: &Grid) -> String {
+    let mut out = format!("| {} |", escape(&grid.row_header));
+    let mut separator = String::from("\n|---|");
+    for column in &grid.columns {
+        out.push_str(&format!(" {} |", escape(column)));
+        separator.push_str("---|");
+    }
+    out.push_str(&separator);
+    out.push('\n');
+
+    for row in &grid.rows {
+        out.push_str(&format!("| {} |", escape(&row.label)));
+        for cell in &row.cells {
+            out.push_str(&format!(
+                " {} |",
+                escape(cell.as_deref().unwrap_or(MISSING))
+            ));
+        }
+        out.push('\n');
+    }
+    out
+}
+
+/// A `|` would end the cell.
+fn escape(s: &str) -> String {
+    s.replace('|', "\\|")
+}

--- a/utils/tfhe-data-extractor/src/format/render/mod.rs
+++ b/utils/tfhe-data-extractor/src/format/render/mod.rs
@@ -1,0 +1,49 @@
+//! Serializers for a `Grid`, one module per output format. Each owns its own
+//! escaping.
+
+pub mod csv;
+pub mod markdown;
+pub mod svg;
+
+/// Cell shown when a column was not measured for a row that has data.
+const MISSING: &str = "N/A";
+
+#[cfg(test)]
+mod tests {
+    use crate::format::{Grid, Row};
+
+    fn grid() -> Grid {
+        Grid {
+            row_header: r"Operation \ Size".to_string(),
+            columns: vec!["FheUint8".to_string()],
+            rows: vec![Row {
+                label: "Comparisons (ge, gt)".to_string(),
+                cells: vec![None],
+            }],
+        }
+    }
+
+    #[test]
+    fn csv_quotes_labels_containing_commas() {
+        assert_eq!(
+            super::csv::table(&grid()),
+            "Operation \\ Size,FheUint8\n\"Comparisons (ge, gt)\",N/A\n"
+        );
+    }
+
+    #[test]
+    fn markdown_fills_missing_cells() {
+        assert!(super::markdown::table(&grid()).ends_with("| Comparisons (ge, gt) | N/A |\n"));
+    }
+
+    /// The pipe lives unescaped in the grid; each format escapes its own way.
+    #[test]
+    fn each_format_escapes_its_own_pipe() {
+        let mut g = grid();
+        g.rows[0].label = "Bitwise (&, |, ^)".to_string();
+
+        assert!(super::markdown::table(&g).contains(r"Bitwise (&, \|, ^)"));
+        assert!(super::csv::table(&g).contains("\"Bitwise (&, |, ^)\""));
+        assert!(super::svg::table(&g).contains("Bitwise (&#38;, &#124;, ^)"));
+    }
+}

--- a/utils/tfhe-data-extractor/src/format/render/svg.rs
+++ b/utils/tfhe-data-extractor/src/format/render/svg.rs
@@ -1,0 +1,164 @@
+//! SVG table, as published in the documentation: fixed geometry, a black header
+//! row, a yellow first column and a grey body, separated by white rules.
+
+use super::MISSING;
+use crate::format::Grid;
+
+const BLACK: &str = "black";
+const WHITE: &str = "white";
+const LIGHT_GREY: &str = "#f3f3f3";
+const YELLOW: &str = "#fbbc04";
+const FONT_FAMILY: &str = "Arial, Helvetica, sans-serif";
+const FONT_SIZE: u32 = 14;
+const BORDER_WIDTH: u32 = 2;
+/// Left inset of the row labels and of the row header.
+const LABEL_INSET: f64 = 6.0;
+
+/// Dimensions of the published tables. The label column is sized to hold the
+/// longest row label at [`FONT_SIZE`], with little to spare.
+const OVERALL_WIDTH: f64 = 720.0;
+const ROW_HEIGHT: f64 = 40.0;
+const LABEL_COL_WIDTH: f64 = 300.0;
+
+pub fn table(grid: &Grid) -> String {
+    let col_count = grid.columns.len().max(1) as f64;
+    let col_width = (OVERALL_WIDTH - LABEL_COL_WIDTH) / col_count;
+    let height = (1 + grid.rows.len()) as f64 * ROW_HEIGHT;
+
+    // The accessible name of the image. The row header is the closest thing to a
+    // caption a `Grid` carries.
+    let mut elements = vec![format!("  <title>{}</title>", escape(&grid.row_header))];
+
+    // Header row: black band, then the column labels.
+    elements.push(rect(0.0, 0.0, OVERALL_WIDTH, ROW_HEIGHT, BLACK));
+    elements.push(text(
+        LABEL_INSET,
+        ROW_HEIGHT / 2.0,
+        &grid.row_header,
+        "start",
+        WHITE,
+        true,
+    ));
+    for (index, column) in grid.columns.iter().enumerate() {
+        let centre = LABEL_COL_WIDTH + index as f64 * col_width + col_width / 2.0;
+        // Rust type headers are split over two lines so the size stands out;
+        // anything else is a single centred label.
+        match column.strip_prefix("FheUint") {
+            Some(size) => {
+                elements.push(text(
+                    centre,
+                    ROW_HEIGHT / 3.0,
+                    "FheUint",
+                    "middle",
+                    WHITE,
+                    true,
+                ));
+                elements.push(text(
+                    centre,
+                    2.0 * ROW_HEIGHT / 3.0 + 3.0,
+                    size,
+                    "middle",
+                    WHITE,
+                    true,
+                ));
+            }
+            None => elements.push(text(
+                centre,
+                ROW_HEIGHT / 2.0,
+                column,
+                "middle",
+                WHITE,
+                true,
+            )),
+        }
+    }
+
+    // Body background: labels on yellow, values on grey.
+    elements.push(rect(
+        0.0,
+        ROW_HEIGHT,
+        LABEL_COL_WIDTH,
+        height - ROW_HEIGHT,
+        YELLOW,
+    ));
+    elements.push(rect(
+        LABEL_COL_WIDTH,
+        ROW_HEIGHT,
+        OVERALL_WIDTH - LABEL_COL_WIDTH,
+        height - ROW_HEIGHT,
+        LIGHT_GREY,
+    ));
+
+    for (index, row) in grid.rows.iter().enumerate() {
+        let baseline = (index + 1) as f64 * ROW_HEIGHT + ROW_HEIGHT / 2.0;
+        elements.push(text(
+            LABEL_INSET,
+            baseline,
+            &row.label,
+            "start",
+            BLACK,
+            false,
+        ));
+        for (column, cell) in row.cells.iter().enumerate() {
+            let centre = LABEL_COL_WIDTH + column as f64 * col_width + col_width / 2.0;
+            let value = cell.as_deref().unwrap_or(MISSING);
+            elements.push(text(centre, baseline, value, "middle", BLACK, false));
+        }
+    }
+
+    // One rule per row boundary, the bottom edge included.
+    //
+    // The four outer rules sit half a stroke inside the box, otherwise the
+    // viewBox clips them to half their width while the inner ones keep theirs.
+    let inset = f64::from(BORDER_WIDTH) / 2.0;
+    for index in 0..=grid.rows.len() + 1 {
+        let y = (index as f64 * ROW_HEIGHT).clamp(inset, height - inset);
+        elements.push(line(0.0, y, OVERALL_WIDTH, y));
+    }
+    elements.push(line(inset, 0.0, inset, height));
+    for index in 0..=grid.columns.len() {
+        let x = (LABEL_COL_WIDTH + index as f64 * col_width).clamp(inset, OVERALL_WIDTH - inset);
+        elements.push(line(x, 0.0, x, height));
+    }
+
+    // A percentage width with the content height keeps the table at 1:1 and
+    // centred in its container, which is how the published tables read. Below
+    // `OVERALL_WIDTH` of available width it shrinks and leaves vertical padding,
+    // the trade-off that comes with the centring.
+    format!(
+        "<svg xmlns=\"http://www.w3.org/2000/svg\" role=\"img\" \
+         width=\"100%\" height=\"{height}\" \
+         viewBox=\"0 0 {OVERALL_WIDTH} {height}\" \
+         preserveAspectRatio=\"xMidYMid meet\">\n{}\n</svg>\n",
+        elements.join("\n")
+    )
+}
+
+fn rect(x: f64, y: f64, width: f64, height: f64, fill: &str) -> String {
+    format!("  <rect x=\"{x}\" y=\"{y}\" width=\"{width}\" height=\"{height}\" fill=\"{fill}\"/>")
+}
+
+fn line(x1: f64, y1: f64, x2: f64, y2: f64) -> String {
+    format!(
+        "  <line x1=\"{x1}\" y1=\"{y1}\" x2=\"{x2}\" y2=\"{y2}\" \
+         stroke=\"{WHITE}\" stroke-width=\"{BORDER_WIDTH}\"/>"
+    )
+}
+
+fn text(x: f64, y: f64, content: &str, anchor: &str, fill: &str, bold: bool) -> String {
+    let weight = if bold { "bold" } else { "normal" };
+    format!(
+        "  <text x=\"{x}\" y=\"{y}\" dominant-baseline=\"middle\" text-anchor=\"{anchor}\" \
+         font-family=\"{FONT_FAMILY}\" font-size=\"{FONT_SIZE}\" fill=\"{fill}\" \
+         font-weight=\"{weight}\">{}</text>",
+        escape(content)
+    )
+}
+
+/// `&` first, or it would escape the ampersands of the other entities.
+fn escape(s: &str) -> String {
+    s.replace('&', "&#38;")
+        .replace('<', "&#60;")
+        .replace('>', "&#62;")
+        .replace('|', "&#124;")
+}

--- a/utils/tfhe-data-extractor/src/main.rs
+++ b/utils/tfhe-data-extractor/src/main.rs
@@ -1,0 +1,514 @@
+//! Extracts benchmark results from the Zama PostgreSQL instance and writes the
+//! filtered tables as CSV, Markdown or SVG.
+//!
+//! Connection settings come from a configuration file, from these environment
+//! variables, or from both:
+//!  * DATA_EXTRACTOR_DATABASE_HOST
+//!  * DATA_EXTRACTOR_DATABASE_USER
+//!  * DATA_EXTRACTOR_DATABASE_PASSWORD
+//!
+//! Environment variables take precedence over the configuration file.
+
+use std::path::PathBuf;
+
+use benchmark_spec::tfhe::TfheLayerKind;
+use benchmark_spec::{BenchPathKind, OperandType};
+use chrono::NaiveDateTime;
+use clap::{ArgGroup, Parser, ValueEnum};
+
+mod db;
+mod format;
+mod profile;
+
+use db::PbsKind;
+
+/// Layer of the tfhe-rs library to filter against.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
+pub enum Layer {
+    #[value(name = "hlapi")]
+    HlApi,
+    Integer,
+    Shortint,
+    #[value(name = "core_crypto")]
+    CoreCrypto,
+    Wasm,
+}
+
+impl Layer {
+    /// Maps the CLI layer onto the spec's own layer token, so the id prefix used in
+    /// the SQL `LIKE` pattern always follows the spec grammar.
+    fn layer_kind(&self) -> anyhow::Result<TfheLayerKind> {
+        Ok(match self {
+            Layer::HlApi => TfheLayerKind::Hlapi,
+            Layer::Integer => TfheLayerKind::Integer,
+            Layer::Shortint => TfheLayerKind::Shortint,
+            Layer::CoreCrypto => TfheLayerKind::CoreCrypto,
+            // Wasm benches never migrated to the spec grammar: their ids carry no
+            // crate prefix, so there is nothing the parser could match.
+            Layer::Wasm => anyhow::bail!("the `wasm` layer is not part of the benchmark spec"),
+        })
+    }
+}
+
+/// Type of benchmark to filter against.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
+pub enum BenchType {
+    Latency,
+    Throughput,
+    Both,
+}
+
+/// Subset of benchmarks to filter against, dedicated formatting will be applied.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
+pub enum BenchSubset {
+    All,
+    Erc7984,
+    Zk,
+    #[value(name = "kv_store")]
+    KvStore,
+}
+
+impl BenchType {
+    /// Maps the CLI filter onto the spec metric. `None` means no metric filter
+    /// (i.e. both latency and throughput).
+    fn as_metric(self) -> Option<benchmark_spec::BenchmarkMetric> {
+        match self {
+            BenchType::Latency => Some(benchmark_spec::BenchmarkMetric::Latency),
+            BenchType::Throughput => Some(benchmark_spec::BenchmarkMetric::Throughput),
+            BenchType::Both => None,
+        }
+    }
+}
+
+/// Parses the `--backend` argument straight into the spec's `Backend` type.
+fn parse_backend(s: &str) -> Result<benchmark_spec::Backend, String> {
+    s.parse().map_err(|e| format!("invalid backend: {e}"))
+}
+
+/// The timestamp format `--bench-date` accepts and the query sends back out.
+const BENCH_DATE_FORMAT: &str = "%Y-%m-%dT%H:%M:%S";
+
+/// Rejects a malformed `--bench-date` here rather than leaving it to PostgreSQL
+/// once the connection is open.
+fn parse_bench_date(s: &str) -> Result<NaiveDateTime, String> {
+    NaiveDateTime::parse_from_str(s, BENCH_DATE_FORMAT)
+        .map_err(|e| format!("expected an ISO 8601 YYYY-MM-DDThh:mm:ss timestamp: {e}"))
+}
+
+/// What no single flag description can say: where the credentials come from,
+/// what a run writes, and how a selection is built. Shown by `--help` only, so
+/// `-h` stays a flag list.
+const AFTER_LONG_HELP: &str = r#"CREDENTIALS:
+  --config-file takes a TOML file holding [database] host, user and password;
+  see config.example.toml next to this crate. The environment variables
+  DATA_EXTRACTOR_DATABASE_HOST, _USER and _PASSWORD override any value that
+  file holds, and are enough on their own.
+
+OUTPUTS:
+  The --generate-* flags are mutually exclusive, and the CSV comes out
+  alongside whichever one is picked: there is no --generate-csv. Files are
+  named `<output-file><suffix>.<ext>`, the suffix being the operand type.
+
+  With no --generate-* flag, nothing is written: the row count and the first
+  ten rows are printed instead, which is the quickest way to eyeball a filter.
+
+SELECTION:
+  Without a profile, the report is one broad pattern for the whole layer, minus
+  the `unchecked_` variants.
+
+  --regression-profiles and --regression-selected-profile go together and, when
+  given, pin the report to exactly the bench paths that profile lists. Profile
+  entries are spec path fragments rather than bare operation names, for example
+  `target.hlapi-dex = ["swap_request::whitepaper"]`.
+
+  --dry-run prints the id patterns the selection expands to and exits, without
+  reading the config file or opening a connection.
+
+EXAMPLES:
+  Check what a profile selects, no database needed:
+    tfhe-data-extractor out --dry-run \
+      --regression-profiles ci/regression.toml \
+      --regression-selected-profile default
+
+  SVG and CSV for the integer tables of the last 30 days:
+    tfhe-data-extractor bench-results --config-file config.toml \
+      --generate-svg --tfhe-rs-layer integer --hardware hpc8a.96xlarge
+"#;
+
+// Several fields are parsed but not consumed yet.
+#[allow(dead_code)]
+#[derive(Parser, Debug)]
+#[command(
+    about = "Extract benchmarks results from Zama PostgreSQL instance, filtered and formatted as CSV.",
+    after_long_help = AFTER_LONG_HELP,
+    // `-V` is taken by --project-version, so free clap's automatic version flag.
+    disable_version_flag = true,
+    // `-w/--hardware` and `--hardware-comp` are mutually exclusive.
+    group(ArgGroup::new("hardware_selection").args(["hardware", "hardware_comp"])),
+    // The four `--generate-*` options are mutually exclusive. The CSV has no
+    // flag: it is emitted alongside whichever of these is picked.
+    group(ArgGroup::new("generation").args([
+        "generate_markdown",
+        "generate_svg",
+        "generate_svg_from_file",
+        "generate_regression_json",
+    ])),
+)]
+struct Args {
+    /// File storing parsed results (with no extension).
+    output_file: String,
+
+    /// Location of configuration file containing credentials to connect to
+    /// PostgreSQL instance.
+    #[arg(short = 'c', long = "config-file")]
+    config_file: Option<PathBuf>,
+
+    /// Last insertion date to look for in the database, formatted as ISO 8601
+    /// timestamp YYYY-MM-DDThh:mm:ss. Defaults to now when omitted.
+    #[arg(long = "bench-date", value_parser = parse_bench_date)]
+    bench_date: Option<NaiveDateTime>,
+
+    /// Name of the database used to store results.
+    #[arg(short, long, default_value = "tfhe_rs")]
+    database: String,
+
+    /// Hardware reference used to perform benchmark.
+    #[arg(short = 'w', long)]
+    hardware: String,
+
+    /// Comma separated values of hardware to compare. The first value would be
+    /// chosen as baseline.
+    #[arg(long = "hardware-comp")]
+    hardware_comp: Option<String>,
+
+    /// Commit hash reference.
+    #[arg(short = 'V', long = "project-version")]
+    project_version: Option<String>,
+
+    /// Git branch name on which benchmark was performed.
+    #[arg(short, long, default_value = "main")]
+    branch: String,
+
+    /// Git base branch name on which benchmark history can be fetched.
+    #[arg(long = "base-branch", default_value = "main")]
+    base_branch: String,
+
+    /// Backend on which benchmarks have run.
+    #[arg(long, default_value = "cpu", value_parser = parse_backend)]
+    backend: benchmark_spec::Backend,
+
+    /// Produce a comparison between backends on 64 bits ciphertext/ciphertext
+    /// integer operations.
+    #[arg(long = "backends-comparison")]
+    backends_comparison: bool,
+
+    /// Layer of the tfhe-rs library to filter against.
+    #[arg(long = "tfhe-rs-layer", value_enum, default_value_t = Layer::Integer)]
+    layer: Layer,
+
+    /// Kind of PBS to look for.
+    #[arg(long = "pbs-kind", value_enum, default_value_t = PbsKind::Classical)]
+    pbs_kind: PbsKind,
+
+    /// Grouping factor used in multi-bit parameters set.
+    #[arg(long = "grouping-factor", value_parser = clap::value_parser!(u8).range(2..=4))]
+    grouping_factor: Option<u8>,
+
+    /// Numbers of days prior of `bench_date` we search for results in the
+    /// database.
+    #[arg(long = "time-span-days", default_value_t = 30, value_parser = clap::value_parser!(i64).range(1..))]
+    time_span_days: i64,
+
+    /// Type of benchmark to filter against.
+    #[arg(long = "bench-type", value_enum, default_value_t = BenchType::Latency)]
+    bench_type: BenchType,
+
+    /// Subset of benchmarks to filter against, dedicated formatting will be
+    /// applied.
+    #[arg(long = "bench-subset", value_enum, default_value_t = BenchSubset::All)]
+    bench_subset: BenchSubset,
+
+    /// Suffix to match the test names.
+    #[arg(long = "name-suffix", default_value = "_mean_avx512")]
+    name_suffix: String,
+
+    /// Path to file containing regression profiles formatted as TOML.
+    #[arg(long = "regression-profiles")]
+    regression_profiles: Option<PathBuf>,
+
+    /// Regression profile to select from the regression profiles file to filter
+    /// out database results.
+    #[arg(long = "regression-selected-profile")]
+    regression_selected_profile: Option<String>,
+
+    /// Generate Markdown array.
+    #[arg(long = "generate-markdown")]
+    generate_markdown: bool,
+
+    /// Generate SVG table formatted like ones in tfhe-rs documentation.
+    #[arg(long = "generate-svg")]
+    generate_svg: bool,
+
+    /// Generate SVG table formatted like ones in tfhe-rs documentation from a
+    /// Markdown table.
+    #[arg(long = "generate-svg-from-markdown")]
+    generate_svg_from_file: Option<String>,
+
+    /// Generate JSON file with regression data with all the results from base
+    /// branch and the latest results of the development branch.
+    #[arg(long = "generate-regression-json")]
+    generate_regression_json: bool,
+
+    /// Restrict the report to one parameter set, matched as a substring of the
+    /// alias. Overrides the profile's `parameters_filter`.
+    #[arg(long = "param")]
+    param: Option<String>,
+
+    /// Print the id patterns the selection expands to, then exit without
+    /// touching the database.
+    #[arg(long = "dry-run")]
+    dry_run: bool,
+}
+
+/// How a built table is serialized.
+#[derive(Copy, Clone, Debug)]
+enum OutputFormat {
+    Markdown,
+    Csv,
+    Svg,
+    RegressionJson,
+}
+
+impl OutputFormat {
+    /// Every artefact a run produces: at most one from the exclusive
+    /// `generation` group, plus the CSV, which is always emitted alongside it.
+    /// No flag at all writes nothing.
+    fn from_args(args: &Args) -> Vec<Self> {
+        let mut outputs = Vec::new();
+        if args.generate_markdown {
+            outputs.push(Self::Markdown);
+        } else if args.generate_svg {
+            outputs.push(Self::Svg);
+        } else if args.generate_regression_json {
+            outputs.push(Self::RegressionJson);
+        }
+        if !outputs.is_empty() {
+            outputs.push(Self::Csv);
+        }
+        outputs
+    }
+
+    fn extension(self) -> &'static str {
+        match self {
+            Self::Markdown => "md",
+            Self::Csv => "csv",
+            Self::Svg => "svg",
+            Self::RegressionJson => "json",
+        }
+    }
+
+    fn render(self, grid: &format::Grid) -> anyhow::Result<String> {
+        Ok(match self {
+            Self::Markdown => format::render::markdown::table(grid),
+            Self::Csv => format::render::csv::table(grid),
+            Self::Svg => format::render::svg::table(grid),
+            // Two branches compared over a longer window.
+            Self::RegressionJson => {
+                anyhow::bail!("output format {self:?} is not implemented yet")
+            }
+        })
+    }
+}
+
+/// Which benchmarks the report is about, as SQL-ready patterns.
+struct Selection {
+    /// One exact prefix per bench path (profile), or one broad layer pattern.
+    like_patterns: Vec<String>,
+    /// `LIKE` pattern pinning the parameter set, if any.
+    param_pattern: Option<String>,
+    /// Drop the `unchecked_` variants by name. Only needed for the broad
+    /// pattern: a profile already spells out the operations it wants.
+    exclude_non_default: bool,
+}
+
+impl Selection {
+    /// A regression profile gives an explicit allow-list of bench paths;
+    /// without one, fall back to a broad per-layer pattern. Both are anchored on
+    /// the crate prefix, so legacy ids are excluded.
+    fn from_args(args: &Args) -> anyhow::Result<Self> {
+        let (like_patterns, param_filter, exclude_non_default) = match (
+            args.regression_profiles.as_deref(),
+            args.regression_selected_profile.as_deref(),
+        ) {
+            (Some(path), Some(name)) => {
+                let profiles = profile::Profiles::load(path)?;
+                let selected = profiles.get(args.backend, name)?;
+                let resolved = selected.resolve();
+                if !resolved.unresolved.is_empty() {
+                    eprintln!(
+                        "warning: {} profile entries not in the spec: {}",
+                        resolved.unresolved.len(),
+                        resolved.unresolved.join(", "),
+                    );
+                }
+                (
+                    resolved.like_patterns(&args.name_suffix),
+                    // `--param` wins over the profile's own filter.
+                    args.param
+                        .clone()
+                        .or_else(|| selected.parameters_filter.clone()),
+                    false,
+                )
+            }
+            (Some(_), None) | (None, Some(_)) => {
+                anyhow::bail!("--regression-profiles and --regression-selected-profile go together")
+            }
+            (None, None) => (
+                vec![format!(
+                    "{}::{}::%{}",
+                    BenchPathKind::Tfhe,
+                    db::like_escape(&args.layer.layer_kind()?.to_string()),
+                    db::like_escape(&args.name_suffix),
+                )],
+                args.param.clone(),
+                true,
+            ),
+        };
+
+        Ok(Self {
+            like_patterns,
+            param_pattern: param_filter
+                .as_deref()
+                .map(|p| format!("%{}%", db::like_escape(p))),
+            exclude_non_default,
+        })
+    }
+
+    /// Human-readable lines, shared by `--dry-run` and the no-result report.
+    fn describe(&self) -> Vec<String> {
+        let mut lines = Vec::new();
+        if let Some(pattern) = &self.param_pattern {
+            lines.push(format!("parameter set: {pattern}"));
+        }
+        lines.push(format!("{} id pattern(s):", self.like_patterns.len()));
+        lines.extend(self.like_patterns.iter().map(|p| format!("  {p}")));
+        lines
+    }
+}
+
+/// Lists every filter the query applied, so that a run without a single result
+/// says why rather than just how many.
+fn report_no_rows(args: &Args, backend: &str, selection: &Selection) {
+    eprintln!("no result matched. Filters applied:");
+    eprintln!("  hardware: {}", args.hardware);
+    eprintln!("  backend:  {backend}");
+    eprintln!("  branch:   {}", args.branch);
+    eprintln!("  metric:   {:?}", args.bench_type);
+    eprintln!("  pbs kind: {:?}", args.pbs_kind);
+    match args.project_version.as_deref() {
+        Some(version) => eprintln!("  version:  {version}"),
+        None => eprintln!(
+            "  window:   {} days back from {}",
+            args.time_span_days,
+            args.bench_date.map_or_else(
+                || "now".to_string(),
+                |date| date.format(BENCH_DATE_FORMAT).to_string()
+            ),
+        ),
+    }
+    for line in selection.describe() {
+        eprintln!("  {line}");
+    }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+    let selection = Selection::from_args(&args)?;
+
+    if args.dry_run {
+        for line in selection.describe() {
+            println!("{line}");
+        }
+        return Ok(());
+    }
+
+    let db_config = db::DbConfig::load(args.config_file.as_deref())?;
+    let pool = db_config.connect(&args.database).await?;
+    let backend = args.backend.to_string();
+    // Sent as text: the `insert_time` column may be `timestamp` or `timestamptz`,
+    // and a SQL cast copes with either, where a typed bind would have to pick one.
+    let bench_date = args
+        .bench_date
+        .map(|date| date.format(BENCH_DATE_FORMAT).to_string());
+
+    let query = db::FetchQuery {
+        hardware: &args.hardware,
+        backend: &backend,
+        branch: &args.branch,
+        like_patterns: &selection.like_patterns,
+        exclude_non_default: selection.exclude_non_default,
+        param_pattern: selection.param_pattern.as_deref(),
+        metric: args.bench_type.as_metric(),
+        pbs_kind: args.pbs_kind,
+        project_version: args.project_version.as_deref(),
+        bench_date: bench_date.as_deref(),
+        time_span_days: args.time_span_days as i32,
+    };
+
+    let rows = db::fetch_bench_rows(&pool, &query).await?;
+
+    if rows.is_empty() {
+        report_no_rows(&args, &backend, &selection);
+    }
+
+    let outputs = OutputFormat::from_args(&args);
+    if !outputs.is_empty() {
+        let (measured, unparsed) = format::parse_rows(&rows);
+        if unparsed > 0 {
+            eprintln!("warning: {unparsed} ids skipped, not in the current spec grammar");
+        }
+
+        // Files are named after the operand type for every layer but
+        // core_crypto; integer publishes both.
+        let tables: Vec<(String, format::Table)> = match (args.layer, args.bench_subset) {
+            (Layer::Integer, BenchSubset::All) => vec![
+                (
+                    "-ciphertext".to_string(),
+                    format::integer::table(&measured, OperandType::CipherText),
+                ),
+                (
+                    "-plaintext".to_string(),
+                    format::integer::table(&measured, OperandType::PlainText),
+                ),
+            ],
+            (Layer::HlApi, BenchSubset::Erc7984) => {
+                vec![("-ciphertext".to_string(), format::erc7984::table(&measured))]
+            }
+            // One table per operation, all ciphertext.
+            (Layer::HlApi, BenchSubset::KvStore) => format::kv_store::tables(&measured)
+                .into_iter()
+                .map(|(suffix, table)| (format!("-ciphertext{suffix}"), table))
+                .collect(),
+            (layer, subset) => {
+                anyhow::bail!("no table implemented for layer {layer:?} / subset {subset:?}")
+            }
+        };
+        println!("{} rows fetched", rows.len());
+        for (suffix, table) in &tables {
+            for output in &outputs {
+                let path = format!("{}{suffix}.{}", args.output_file, output.extension());
+                std::fs::write(&path, output.render(&table.grid)?)?;
+                println!("  wrote {path}");
+            }
+            table.report();
+        }
+    } else {
+        println!("fetched {} rows (layer: {:?})", rows.len(), args.layer);
+        for row in rows.iter().take(10) {
+            println!("{row:?}");
+        }
+    }
+
+    Ok(())
+}

--- a/utils/tfhe-data-extractor/src/profile.rs
+++ b/utils/tfhe-data-extractor/src/profile.rs
@@ -1,0 +1,202 @@
+//! Regression profiles (`ci/regression.toml`): the list of benchmarks a report
+//! is made of, per backend.
+//!
+//! Operations are listed under benchmark targets (the `[[bench]]` names of
+//! `tfhe-benchmark/Cargo.toml`), not under spec layers. Each target maps onto
+//! spec path prefixes, and an entry appended to a prefix must parse as a full
+//! [`BenchPath`] path.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use benchmark_spec::{Backend, BenchPath};
+use serde::Deserialize;
+
+use crate::db::like_escape;
+
+/// One `[<backend>.<profile>]` section. `env` and `slab` drive benchmark
+/// execution, not extraction, and are deliberately not deserialized.
+#[derive(Debug, Deserialize)]
+pub struct Profile {
+    /// `target.<name> = [<entry>, …]`, where an entry is a spec path fragment
+    /// and not just an operation name:
+    ///
+    /// ```toml
+    /// target.shortint = ["bitand"]
+    /// target.hlapi-dex = ["swap_request::whitepaper"]
+    /// ```
+    #[serde(default)]
+    pub target: HashMap<String, Vec<String>>,
+    /// Parameter set name to restrict the report to, applied as a SQL filter.
+    pub parameters_filter: Option<String>,
+}
+
+/// Every profile in the file, indexed by backend section, then by profile name.
+///
+/// ```toml
+/// [cpu.default]
+/// target.shortint = ["bitand"]
+/// ```
+///
+/// becomes
+///
+/// ```text
+/// {"cpu": {"default": Profile { target: {"shortint": ["bitand"]} }}}
+/// ```
+#[derive(Debug, Deserialize)]
+#[serde(transparent)]
+pub struct Profiles(HashMap<String, HashMap<String, Profile>>);
+
+impl Profiles {
+    /// Reads and parses the profiles file.
+    pub fn load(path: &Path) -> anyhow::Result<Self> {
+        let raw = std::fs::read_to_string(path)
+            .map_err(|e| anyhow::anyhow!("cannot read profiles file {}: {e}", path.display()))?;
+        Ok(toml::from_str(&raw)?)
+    }
+
+    /// Looks up `[<backend>.<name>]`.
+    pub fn get(&self, backend: Backend, name: &str) -> anyhow::Result<&Profile> {
+        let section = profile_section(backend);
+        self.0
+            .get(section)
+            .and_then(|profiles| profiles.get(name))
+            .ok_or_else(|| anyhow::anyhow!("no profile [{section}.{name}] in profiles file"))
+    }
+}
+
+/// Sections are named after the hardware family, not the spec backend: the
+/// Cuda backend lives under `[gpu.*]`.
+fn profile_section(backend: Backend) -> &'static str {
+    match backend {
+        Backend::Cpu => "cpu",
+        Backend::Cuda => "gpu",
+        Backend::Hpu => "hpu",
+    }
+}
+
+/// Spec path prefixes a profile target expands to.
+///
+/// ```text
+/// target.integer = ["add_parallelized"]
+///   -> tfhe::integer::ops::unsigned::add_parallelized
+///   -> tfhe::integer::ops::signed::add_parallelized
+/// ```
+///
+/// `integer` is the only target yielding two prefixes; conversely
+/// `core_crypto-ks` and `core_crypto-pbs` share one.
+fn target_prefixes(target: &str) -> Option<&'static [&'static str]> {
+    Some(match target {
+        "integer" => &["tfhe::integer::ops::unsigned", "tfhe::integer::ops::signed"],
+        "shortint" => &["tfhe::shortint::ops"],
+        "hlapi-dex" => &["tfhe::hlapi::dex"],
+        "hlapi-erc7984" => &["tfhe::hlapi::erc7984"],
+        "core_crypto-ks" | "core_crypto-pbs" => &["tfhe::core_crypto"],
+        _ => return None,
+    })
+}
+
+/// Outcome of resolving a profile against the spec.
+#[derive(Debug, Default)]
+pub struct Resolved {
+    /// Bench paths the report covers.
+    pub paths: Vec<BenchPath>,
+    /// `target.entry` pairs that match no spec path: a not-yet-migrated bench,
+    /// or a typo. Reported, never silently dropped.
+    pub unresolved: Vec<String>,
+}
+
+impl Profile {
+    /// Turns every `target.<name> = [ops]` entry into spec bench paths.
+    pub fn resolve(&self) -> Resolved {
+        let mut out = Resolved::default();
+
+        // HashMap order is arbitrary; sort so warnings are stable.
+        let mut targets: Vec<_> = self.target.iter().collect();
+        targets.sort_by_key(|(name, _)| *name);
+
+        for (target, entries) in targets {
+            let Some(prefixes) = target_prefixes(target) else {
+                out.unresolved.push(format!("{target} (unknown target)"));
+                continue;
+            };
+
+            for entry in entries {
+                let matched: Vec<BenchPath> = prefixes
+                    .iter()
+                    .filter_map(|prefix| format!("{prefix}::{entry}").parse().ok())
+                    .collect();
+
+                if matched.is_empty() {
+                    out.unresolved.push(format!("{target}.{entry}"));
+                } else {
+                    out.paths.extend(matched);
+                }
+            }
+        }
+
+        out
+    }
+}
+
+impl Resolved {
+    /// SQL `LIKE` patterns matching every id under these bench paths.
+    ///
+    /// `LIKE` matches the whole string, so neither end needs a `%`: both are
+    /// anchored, and the single `%` is the hole left for the backend, the
+    /// metric, the parameter set and the type.
+    ///
+    /// ```text
+    /// tfhe::integer::ops::unsigned::add_parallelized::%\_mean\_avx512
+    /// └──────────── bench path, exact ─────────────┘  ↑└── suffix ──┘
+    /// ```
+    pub fn like_patterns(&self, suffix: &str) -> Vec<String> {
+        self.paths
+            .iter()
+            .map(|path| {
+                format!(
+                    "{}::%{}",
+                    like_escape(&path.to_string()),
+                    like_escape(suffix)
+                )
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PROFILES: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../../ci/regression.toml");
+
+    /// A failure here lists the benches still outside the spec.
+    #[test]
+    fn regression_profiles_resolve() {
+        let profiles = Profiles::load(Path::new(PROFILES)).unwrap();
+
+        for (backend, name) in [(Backend::Cpu, "default"), (Backend::Cuda, "default")] {
+            let resolved = profiles.get(backend, name).unwrap().resolve();
+            assert!(
+                resolved.unresolved.is_empty(),
+                "[{}.{name}] does not resolve: {:?}",
+                profile_section(backend),
+                resolved.unresolved,
+            );
+            assert!(!resolved.paths.is_empty());
+        }
+    }
+
+    #[test]
+    fn like_patterns_are_escaped_and_anchored() {
+        let profiles = Profiles::load(Path::new(PROFILES)).unwrap();
+        let resolved = profiles.get(Backend::Cpu, "default").unwrap().resolve();
+        let patterns = resolved.like_patterns("_mean_avx512");
+
+        assert!(
+            patterns
+                .iter()
+                .any(|p| p == r"tfhe::integer::ops::unsigned::add\_parallelized::%\_mean\_avx512")
+        );
+    }
+}


### PR DESCRIPTION
Ports `ci/data_extractor` to Rust as `utils/tfhe-data-extractor`, plus the `benchmark_spec` work it needs.

`benchmark_spec` gains `FromStr` down the whole bench tree, so an id parses back through the grammar it renders with, and now owns the stored result name `{bench_id}_{statistic}(_{variant})?` that `tfhe-benchmark-parser` composes. What lands in the results database is unchanged.

The extractor resolves a regression profile to bench paths, turns them into anchored SQL `LIKE` patterns, and renders the integer, ERC7984 and KV-store tables as Markdown, CSV or SVG. Regression JSON, backends comparison, the wasm layer and the shortint and core_crypto tables are not ported and fail explicitly, so the Python tool stays for now.

AI was used along the way to keep the python context and correct the code written

Here is an example of the rust version

<img width="720" height="560" alt="out_rs-ciphertext" src="https://github.com/user-attachments/assets/89c096b9-5656-4d12-a7cc-529b5f47054d" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3816)
<!-- Reviewable:end -->
