### PR TITLE
feat(csprng): aes 256

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3116,7 +3116,7 @@ dependencies = [
 
 [[package]]
 name = "tfhe-csprng"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "aes",
  "clap",

--- a/apps/trivium/Cargo.lock
+++ b/apps/trivium/Cargo.lock
@@ -828,7 +828,7 @@ dependencies = [
 
 [[package]]
 name = "tfhe-csprng"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "aes",
  "getrandom",

--- a/tfhe-csprng/Cargo.toml
+++ b/tfhe-csprng/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tfhe-csprng"
-version = "0.9.2"
+version = "0.10.0"
 edition = "2021"
 license = "BSD-3-Clause-Clear"
 description = "Cryptographically Secure PRNG used in the TFHE-rs library."

--- a/tfhe-csprng/src/generators/aes_ctr/block_cipher.rs
+++ b/tfhe-csprng/src/generators/aes_ctr/block_cipher.rs
@@ -1,24 +1,33 @@
 use crate::generators::aes_ctr::{AES_CALLS_PER_BATCH, BYTES_PER_AES_CALL, BYTES_PER_BATCH};
 
-/// Represents a key used in the AES block cipher.
+/// Represents a key used in the AES 128 block cipher.
 ///
 /// The u128 endianness should be ignored by implementations and the u128 should be seen as a simple
 /// [u8; 16].
 ///
 /// Therefore, except when loading the key from a [`Seed`](`crate::seeders::Seed`), whose bytes
 /// needs to be loaded with [u128::from_le] (to keep consistency of the loaded bytes across systems
-/// endianness), the rest of the code should use the [`AesKey`] with native endian ordering such
+/// endianness), the rest of the code should use the [`Aes128Key`] with native endian ordering such
 /// that the internal u128 is equivalent to [u8; 16].
 #[derive(Clone, Copy, Debug)]
-pub struct AesKey(pub(crate) u128);
+pub struct Aes128Key(pub(crate) u128);
 
-impl AesKey {
-    /// Builds an [`AesKey`] from a `u128`.
+impl Aes128Key {
+    /// Builds an [`Aes128Key`] from a `u128`.
     ///
     /// The `u128` is interpreted in native endian ordering, so that its in-memory bytes are
     /// equivalent to a `[u8; 16]` (see the type-level documentation). Callers that load a key from
     /// raw bytes must therefore arrange them to match the native byte order beforehand.
     pub const fn new(key: u128) -> Self {
+        Self(key)
+    }
+}
+
+/// Key for AES 256 Block cipher
+pub struct Aes256Key(pub(crate) [u8; 32]);
+
+impl Aes256Key {
+    pub const fn new(key: [u8; 32]) -> Self {
         Self(key)
     }
 }
@@ -31,10 +40,261 @@ impl AesKey {
 /// The block cipher is used in a batched manner (to reduce amortized cost on special hardware).
 /// For this reason we only expose a `generate_batch` method.
 pub trait AesBlockCipher: Clone + Send + Sync {
+    type Key;
+
     /// Instantiate a new generator from a secret key.
-    fn new(key: AesKey) -> Self;
+    fn new(key: Self::Key) -> Self;
     /// Generates the batch corresponding to the given index.
     fn generate_batch(&mut self, data: [u128; AES_CALLS_PER_BATCH]) -> [u8; BYTES_PER_BATCH];
     /// Generate next bytes
     fn generate_next(&mut self, data: u128) -> [u8; BYTES_PER_AES_CALL];
+}
+
+pub trait Aes128BlockCipher: AesBlockCipher<Key = Aes128Key> {}
+impl<T> Aes128BlockCipher for T where T: AesBlockCipher<Key = Aes128Key> {}
+pub trait Aes256BlockCipher: AesBlockCipher<Key = Aes256Key> {}
+impl<T> Aes256BlockCipher for T where T: AesBlockCipher<Key = Aes256Key> {}
+
+/// Known answer tests shared by every block cipher backend.
+#[cfg(test)]
+#[allow(unused)] // to please clippy when tests are not activated
+pub mod block_cipher_generic_test {
+    use super::*;
+    use crate::generators::aes_ctr::{AES_128_NUM_ROUND_KEYS, AES_256_NUM_ROUND_KEYS};
+
+    // Test vector for aes128, from appendix C.1 of the FIPS publication 197
+    pub const KEY_128: u128 = u128::from_be(0x000102030405060708090a0b0c0d0e0f);
+    pub const KEY_SCHEDULE_128: [u128; AES_128_NUM_ROUND_KEYS] = [
+        u128::from_be(0x000102030405060708090a0b0c0d0e0f),
+        u128::from_be(0xd6aa74fdd2af72fadaa678f1d6ab76fe),
+        u128::from_be(0xb692cf0b643dbdf1be9bc5006830b3fe),
+        u128::from_be(0xb6ff744ed2c2c9bf6c590cbf0469bf41),
+        u128::from_be(0x47f7f7bc95353e03f96c32bcfd058dfd),
+        u128::from_be(0x3caaa3e8a99f9deb50f3af57adf622aa),
+        u128::from_be(0x5e390f7df7a69296a7553dc10aa31f6b),
+        u128::from_be(0x14f9701ae35fe28c440adf4d4ea9c026),
+        u128::from_be(0x47438735a41c65b9e016baf4aebf7ad2),
+        u128::from_be(0x549932d1f08557681093ed9cbe2c974e),
+        u128::from_be(0x13111d7fe3944a17f307a78b4d2b30c5),
+    ];
+    /// Plaintext of both the C.1 (aes128) and C.3 (aes256) vectors.
+    pub const PLAINTEXT: u128 = u128::from_be(0x00112233445566778899aabbccddeeff);
+    pub const CIPHERTEXT_128: u128 = u128::from_be(0x69c4e0d86a7b0430d8cdb78070b4c55a);
+
+    // Test vector for aes256, from appendix C.3 of the FIPS publication 197
+    pub const KEY_256: [u8; 32] = [
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e,
+        0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d,
+        0x1e, 0x1f,
+    ];
+    pub const KEY_SCHEDULE_256: [u128; AES_256_NUM_ROUND_KEYS] = [
+        u128::from_be(0x000102030405060708090a0b0c0d0e0f),
+        u128::from_be(0x101112131415161718191a1b1c1d1e1f),
+        u128::from_be(0xa573c29fa176c498a97fce93a572c09c),
+        u128::from_be(0x1651a8cd0244beda1a5da4c10640bade),
+        u128::from_be(0xae87dff00ff11b68a68ed5fb03fc1567),
+        u128::from_be(0x6de1f1486fa54f9275f8eb5373b8518d),
+        u128::from_be(0xc656827fc9a799176f294cec6cd5598b),
+        u128::from_be(0x3de23a75524775e727bf9eb45407cf39),
+        u128::from_be(0x0bdc905fc27b0948ad5245a4c1871c2f),
+        u128::from_be(0x45f5a66017b2d387300d4d33640a820a),
+        u128::from_be(0x7ccff71cbeb4fe5413e6bbf0d261a7df),
+        u128::from_be(0xf01afafee7a82979d7a5644ab3afe640),
+        u128::from_be(0x2541fe719bf500258813bbd55a721c0a),
+        u128::from_be(0x4e5a6699a9f24fe07e572baacdf8cdea),
+        u128::from_be(0x24fc79ccbf0979e9371ac23c6d68de36),
+    ];
+    pub const CIPHERTEXT_256: u128 = u128::from_be(0x8ea2b7ca516745bfeafc49904b496089);
+
+    // ECB-AES256 test vectors from appendix F.1.5 of NIST SP 800-38A. Uses a different (less
+    // structured) key than the FIPS C.3 vector above, and four distinct plaintext blocks.
+    pub const NIST_KEY_256: [u8; 32] = [
+        0x60, 0x3d, 0xeb, 0x10, 0x15, 0xca, 0x71, 0xbe, 0x2b, 0x73, 0xae, 0xf0, 0x85, 0x7d, 0x77,
+        0x81, 0x1f, 0x35, 0x2c, 0x07, 0x3b, 0x61, 0x08, 0xd7, 0x2d, 0x98, 0x10, 0xa3, 0x09, 0x14,
+        0xdf, 0xf4,
+    ];
+    pub const NIST_BLOCKS_256: [(u128, u128); 4] = [
+        (
+            u128::from_be(0x6bc1bee22e409f96e93d7e117393172a),
+            u128::from_be(0xf3eed1bdb5d2a03c064b5a7e3db181f8),
+        ),
+        (
+            u128::from_be(0xae2d8a571e03ac9c9eb76fac45af8e51),
+            u128::from_be(0x591ccb10d410ed26dc5ba74a31362870),
+        ),
+        (
+            u128::from_be(0x30c81c46a35ce411e5fbc1191a0a52ef),
+            u128::from_be(0xb6ed21b99ca6f4f9f153e7b1beafed1d),
+        ),
+        (
+            u128::from_be(0xf69f2445df4f9b17ad2b417be66c3710),
+            u128::from_be(0x23304b7a39f9f3ff067d8d8f9e24ecc7),
+        ),
+    ];
+
+    /// Eight pairwise-distinct blocks, so that a lane mix-up in the batched path cannot hide behind
+    /// every lane holding the same value.
+    pub const DISTINCT_MESSAGES: [u128; AES_CALLS_PER_BATCH] = [
+        u128::from_be(0x6bc1bee22e409f96e93d7e117393172a),
+        u128::from_be(0xae2d8a571e03ac9c9eb76fac45af8e51),
+        u128::from_be(0x30c81c46a35ce411e5fbc1191a0a52ef),
+        u128::from_be(0xf69f2445df4f9b17ad2b417be66c3710),
+        u128::from_be(0x00112233445566778899aabbccddeeff),
+        u128::from_be(0x000102030405060708090a0b0c0d0e0f),
+        u128::from_be(0xffffffffffffffffffffffffffffffff),
+        u128::from_be(0x00000000000000000000000000000001),
+    ];
+
+    /// Splits a batch output into its [`AES_CALLS_PER_BATCH`] blocks.
+    fn batch_blocks(batch: [u8; BYTES_PER_BATCH]) -> [u128; AES_CALLS_PER_BATCH] {
+        core::array::from_fn(|i| {
+            let block: [u8; BYTES_PER_AES_CALL] = batch
+                [i * BYTES_PER_AES_CALL..(i + 1) * BYTES_PER_AES_CALL]
+                .try_into()
+                .expect("infallible");
+            u128::from_ne_bytes(block)
+        })
+    }
+
+    /// Feeds every block of `messages` through `generate_next`.
+    fn encrypt_each<C: AesBlockCipher>(
+        cipher: &mut C,
+        messages: [u128; AES_CALLS_PER_BATCH],
+    ) -> [u128; AES_CALLS_PER_BATCH] {
+        messages.map(|m| u128::from_ne_bytes(cipher.generate_next(m)))
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Key schedules. Round keys are a backend native vector type, so the caller passes a closure
+    // that expands the key and normalizes the result to `u128`.
+    // ---------------------------------------------------------------------------------------
+
+    /// Checks the aes128 round keys against the FIPS 197 appendix A.1 schedule.
+    pub fn test_key_schedule_128(expand: impl FnOnce(Aes128Key) -> [u128; AES_128_NUM_ROUND_KEYS]) {
+        let actual = expand(Aes128Key::new(KEY_128));
+        assert_eq!(actual, KEY_SCHEDULE_128);
+    }
+
+    /// Checks the aes256 round keys against the FIPS 197 appendix A.3 schedule.
+    ///
+    /// Pinning all 15 round keys also rules out the 256 path silently falling back to an aes128
+    /// schedule, since the two disagree from round key 1 onwards.
+    pub fn test_key_schedule_256(expand: impl FnOnce(Aes256Key) -> [u128; AES_256_NUM_ROUND_KEYS]) {
+        let actual = expand(Aes256Key::new(KEY_256));
+        assert_eq!(actual, KEY_SCHEDULE_256);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Encryption. These go through the `AesBlockCipher` trait, which means they also cover
+    // whatever wrappers a backend puts between the trait methods and its inner routines.
+    // ---------------------------------------------------------------------------------------
+
+    /// FIPS 197 appendix C.1, single block through `generate_next`.
+    pub fn test_fips197_c1_single_block<C: Aes128BlockCipher>() {
+        let mut cipher = C::new(Aes128Key::new(KEY_128));
+        assert_eq!(
+            u128::from_ne_bytes(cipher.generate_next(PLAINTEXT)),
+            CIPHERTEXT_128
+        );
+    }
+
+    /// FIPS 197 appendix C.1, the same block in all lanes of `generate_batch`.
+    pub fn test_fips197_c1_batch<C: Aes128BlockCipher>() {
+        let mut cipher = C::new(Aes128Key::new(KEY_128));
+        let blocks = batch_blocks(cipher.generate_batch([PLAINTEXT; AES_CALLS_PER_BATCH]));
+        for (i, block) in blocks.iter().enumerate() {
+            assert_eq!(*block, CIPHERTEXT_128, "lane {i}");
+        }
+    }
+
+    /// FIPS 197 appendix C.3, single block through `generate_next`.
+    pub fn test_fips197_c3_single_block<C: Aes256BlockCipher>() {
+        let mut cipher = C::new(Aes256Key::new(KEY_256));
+        assert_eq!(
+            u128::from_ne_bytes(cipher.generate_next(PLAINTEXT)),
+            CIPHERTEXT_256
+        );
+    }
+
+    /// FIPS 197 appendix C.3, the same block in all lanes of `generate_batch`.
+    pub fn test_fips197_c3_batch<C: Aes256BlockCipher>() {
+        let mut cipher = C::new(Aes256Key::new(KEY_256));
+        let blocks = batch_blocks(cipher.generate_batch([PLAINTEXT; AES_CALLS_PER_BATCH]));
+        for (i, block) in blocks.iter().enumerate() {
+            assert_eq!(*block, CIPHERTEXT_256, "lane {i}");
+        }
+    }
+
+    /// NIST SP 800-38A ECB-AES256, four distinct blocks through `generate_next`.
+    ///
+    /// Uses a less structured key than the FIPS vector, so a byte ordering mistake in the key
+    /// handling that the regular `00..1f` key happens to survive still shows up here.
+    pub fn test_nist_ecb_aes256_single_blocks<C: Aes256BlockCipher>() {
+        let mut cipher = C::new(Aes256Key::new(NIST_KEY_256));
+        for (plaintext, expected) in NIST_BLOCKS_256 {
+            assert_eq!(
+                u128::from_ne_bytes(cipher.generate_next(plaintext)),
+                expected
+            );
+        }
+    }
+
+    /// NIST SP 800-38A ECB-AES256 through `generate_batch`, the four blocks laid out twice so that
+    /// neighbouring lanes always differ.
+    pub fn test_nist_ecb_aes256_batch<C: Aes256BlockCipher>() {
+        let mut cipher = C::new(Aes256Key::new(NIST_KEY_256));
+        let data: [u128; AES_CALLS_PER_BATCH] =
+            core::array::from_fn(|i| NIST_BLOCKS_256[i % NIST_BLOCKS_256.len()].0);
+
+        let blocks = batch_blocks(cipher.generate_batch(data));
+
+        for (i, block) in blocks.iter().enumerate() {
+            assert_eq!(
+                *block,
+                NIST_BLOCKS_256[i % NIST_BLOCKS_256.len()].1,
+                "lane {i}"
+            );
+        }
+    }
+
+    /// `generate_batch` must agree with `generate_next` lane by lane on eight *different* blocks.
+    ///
+    /// The known answer vectors above cannot catch a lane mix-up on their own: where every lane
+    /// holds the same value, any permutation of the lanes still passes.
+    pub fn test_batch_matches_single_aes256<C: Aes256BlockCipher>() {
+        let mut batched = C::new(Aes256Key::new(NIST_KEY_256));
+        let mut single = C::new(Aes256Key::new(NIST_KEY_256));
+
+        let from_batch = batch_blocks(batched.generate_batch(DISTINCT_MESSAGES));
+        let from_single = encrypt_each(&mut single, DISTINCT_MESSAGES);
+
+        for i in 0..AES_CALLS_PER_BATCH {
+            assert_eq!(
+                from_batch[i], from_single[i],
+                "lane {i} of generate_batch disagrees with generate_next"
+            );
+        }
+    }
+
+    /// The aes256 cipher must not silently behave like the aes128 one.
+    ///
+    /// Both are keyed with the same leading 16 bytes, so an implementation that ignored the second
+    /// half of the 256 bit key, or that ran 10 rounds instead of 14, would agree here.
+    pub fn test_aes128_and_aes256_differ<C128, C256>()
+    where
+        C128: Aes128BlockCipher,
+        C256: Aes256BlockCipher,
+    {
+        let leading_16_bytes: [u8; BYTES_PER_AES_CALL] = KEY_256[..BYTES_PER_AES_CALL]
+            .try_into()
+            .expect("infallible");
+
+        let mut cipher_128 = C128::new(Aes128Key::new(u128::from_ne_bytes(leading_16_bytes)));
+        let mut cipher_256 = C256::new(Aes256Key::new(KEY_256));
+
+        assert_ne!(
+            cipher_128.generate_next(PLAINTEXT),
+            cipher_256.generate_next(PLAINTEXT)
+        );
+    }
 }

--- a/tfhe-csprng/src/generators/aes_ctr/generic.rs
+++ b/tfhe-csprng/src/generators/aes_ctr/generic.rs
@@ -1,10 +1,12 @@
 use std::ops::Bound;
 
-use crate::generators::aes_ctr::block_cipher::{AesBlockCipher, AesKey};
+use crate::generators::aes_ctr::block_cipher::{Aes128Key, AesBlockCipher};
 use crate::generators::aes_ctr::index::TableIndex;
 use crate::generators::aes_ctr::states::{BufferPointer, ShiftAction, State};
 use crate::generators::aes_ctr::{AesIndex, BYTES_PER_BATCH};
-use crate::generators::{widening_mul, ByteCount, BytesPerChild, ChildrenCount, ForkError};
+use crate::generators::{
+    widening_mul, AnyAesKey, ByteCount, BytesPerChild, ChildrenCount, ForkError,
+};
 
 // Usually, to work with iterators and parallel iterators, we would use opaque types such as
 // `impl Iterator<..>`. Unfortunately, it is not yet possible to return existential types in
@@ -49,7 +51,7 @@ impl<BlockCipher: AesBlockCipher> AesCtrGenerator<BlockCipher> {
     /// - `Bound::Included(x)` — bytes up to and including `x`
     /// - `Bound::Unbounded` — all bytes up to and including `TableIndex::LAST`
     pub(crate) fn new(
-        key: AesKey,
+        key: BlockCipher::Key,
         start_index: TableIndex,
         end: Bound<TableIndex>,
         offset: AesIndex,
@@ -80,17 +82,26 @@ impl<BlockCipher: AesBlockCipher> AesCtrGenerator<BlockCipher> {
         }
     }
 
-    pub(crate) fn from_params(params: impl Into<super::AesCtrParams>) -> Self {
+    pub(crate) fn from_params(params: impl Into<super::AesCtrParams>) -> Self
+    where
+        BlockCipher: AesBlockCipher<Key = crate::generators::AnyAesKey>,
+    {
         use crate::seeders::SeedKind;
         let params = params.into();
         let (key, offset) = match &params.seed {
-            // AesKey has an unspoken requirement to have bytes in an order independent of
+            // Aes128Key has an unspoken requirement to have bytes in an order independent of
             // platform endianness, problem is the Seed(u128) has an endianness, meaning
             // 1u128 == [1, 0, ..., 0] for little endian
             // but
             // 1u128 == [0, ..., 0, 1] for big endian
-            SeedKind::Ctr(s) => (AesKey(u128::from_le(s.0)), AesIndex(0)),
-            SeedKind::Xof(xof) => super::xof_init(xof.clone()),
+            SeedKind::Ctr(s) => (
+                AnyAesKey::Aes128(Aes128Key(u128::from_le(s.0))),
+                AesIndex(0),
+            ),
+            SeedKind::Xof(xof) => {
+                let (key, index) = super::xof_init_128(xof.clone());
+                (AnyAesKey::Aes128(key), index)
+            }
         };
         Self::new(key, params.first_index, Bound::Unbounded, offset)
     }
@@ -221,8 +232,8 @@ pub mod aes_ctr_generic_test {
         std::iter::repeat_with(|| BytesPerChild(thread_rng().gen::<u64>() % 2048 + 1))
     }
 
-    pub fn any_key() -> impl Iterator<Item = AesKey> {
-        std::iter::repeat_with(|| AesKey(thread_rng().gen()))
+    pub fn any_key() -> impl Iterator<Item = Aes128Key> {
+        std::iter::repeat_with(|| Aes128Key(thread_rng().gen()))
     }
 
     /// Output a valid fork:
@@ -250,7 +261,7 @@ pub mod aes_ctr_generic_test {
     /// Check the property:
     ///     On a valid fork, the table index of the first child is the same as the table index of
     ///     the parent before the fork.
-    pub fn prop_fork_first_state_table_index<G: AesBlockCipher>() {
+    pub fn prop_fork_first_state_table_index<G: AesBlockCipher<Key = Aes128Key>>() {
         for _ in 0..REPEATS {
             let (t, nc, nb, i) = any_valid_fork().next().unwrap();
             let k = any_key().next().unwrap();
@@ -274,7 +285,7 @@ pub mod aes_ctr_generic_test {
     /// Check the property:
     ///     On a valid fork, the table index of the first byte outputted by the parent after the
     ///     fork, is the bound of the last child of the fork.
-    pub fn prop_fork_last_bound_table_index<G: AesBlockCipher>() {
+    pub fn prop_fork_last_bound_table_index<G: AesBlockCipher<Key = Aes128Key>>() {
         for _ in 0..REPEATS {
             let (t, nc, nb, i) = any_valid_fork().next().unwrap();
             let k = any_key().next().unwrap();
@@ -299,7 +310,7 @@ pub mod aes_ctr_generic_test {
 
     /// Check the property:
     ///     On a valid fork, the bound of the parent does not change.
-    pub fn prop_fork_parent_bound_table_index<G: AesBlockCipher>() {
+    pub fn prop_fork_parent_bound_table_index<G: AesBlockCipher<Key = Aes128Key>>() {
         for _ in 0..REPEATS {
             let (t, nc, nb, i) = any_valid_fork().next().unwrap();
             let k = any_key().next().unwrap();
@@ -323,7 +334,7 @@ pub mod aes_ctr_generic_test {
     /// Check the property:
     ///     On a valid fork, the parent table index is increased of the number of children
     ///     multiplied by the number of bytes per child.
-    pub fn prop_fork_parent_state_table_index<G: AesBlockCipher>() {
+    pub fn prop_fork_parent_state_table_index<G: AesBlockCipher<Key = Aes128Key>>() {
         for _ in 0..REPEATS {
             let (t, nc, nb, i) = any_valid_fork().next().unwrap();
             let k = any_key().next().unwrap();
@@ -347,7 +358,7 @@ pub mod aes_ctr_generic_test {
     /// Check the property:
     ///     On a valid fork, the bytes outputted by the children in the fork order form the same
     ///     sequence the parent would have had yielded no fork had happened.
-    pub fn prop_fork<G: AesBlockCipher>() {
+    pub fn prop_fork<G: AesBlockCipher<Key = Aes128Key>>() {
         for _ in 0..1000 {
             let (t, nc, nb, i) = any_valid_fork().next().unwrap();
             let offset = AesIndex(rand::random());
@@ -378,7 +389,7 @@ pub mod aes_ctr_generic_test {
     /// Check the property:
     ///     On a valid fork, all children got a number of remaining bytes equals to the number of
     ///     bytes per child given as fork input.
-    pub fn prop_fork_children_remaining_bytes<G: AesBlockCipher>() {
+    pub fn prop_fork_children_remaining_bytes<G: AesBlockCipher<Key = Aes128Key>>() {
         for _ in 0..REPEATS {
             let (t, nc, nb, i) = any_valid_fork().next().unwrap();
             let k = any_key().next().unwrap();
@@ -402,7 +413,7 @@ pub mod aes_ctr_generic_test {
     /// Check the property:
     ///     On a valid fork, the number of remaining bybtes of the parent is reduced by the number
     ///     of children multiplied by the number of bytes per child.
-    pub fn prop_fork_parent_remaining_bytes<G: AesBlockCipher>() {
+    pub fn prop_fork_parent_remaining_bytes<G: AesBlockCipher<Key = Aes128Key>>() {
         for _ in 0..REPEATS {
             let (t, nc, nb, i) = any_valid_fork().next().unwrap();
             let k = any_key().next().unwrap();
@@ -463,8 +474,8 @@ pub mod aes_ctr_generic_test {
 
     // Builds an AesCtrGenerator and a Ctr128LE using parameters
     // such that they should produce same outputs
-    pub(crate) fn make_ctr_pair<G: AesBlockCipher>(
-        key: AesKey,
+    pub(crate) fn make_ctr_pair<G: AesBlockCipher<Key = Aes128Key>>(
+        key: Aes128Key,
         aes_idx: u128,
         byte_idx: usize,
         offset: u128,
@@ -484,11 +495,11 @@ pub mod aes_ctr_generic_test {
     /// Check that our AesCtrGenerator produces the same keystream as `Ctr128LE<Aes128>` from
     /// the RustCrypto `ctr` crate. CTR mode XORs plaintext with AES keystream, so encrypting
     /// zeros gives the raw keystream for comparison.
-    pub fn test_conformance_with_ctr_crate<G: AesBlockCipher>() {
+    pub fn test_conformance_with_ctr_crate<G: AesBlockCipher<Key = Aes128Key>>() {
         let mut rng = thread_rng();
 
         for _ in 0..1_000 {
-            let key = AesKey(rng.gen());
+            let key = Aes128Key(rng.gen());
             let aes_idx: u128 = rng.gen();
             let offset: u128 = rng.gen();
 
@@ -507,7 +518,7 @@ pub mod aes_ctr_generic_test {
     /// Check that our AesCtrGenerator produces the same keystream as `Ctr128LE<Aes128>` from
     /// the RustCrypto `ctr` crate. CTR mode XORs plaintext with AES keystream, so encrypting
     /// zeros gives the raw keystream for comparison.
-    pub fn test_forking_conformance_with_ctr_crate<G: AesBlockCipher>() {
+    pub fn test_forking_conformance_with_ctr_crate<G: AesBlockCipher<Key = Aes128Key>>() {
         let mut rng = thread_rng();
 
         fn random_tuple_less_or_equal_than(rng: &mut ThreadRng, x: u64) -> (u64, u64) {
@@ -529,7 +540,7 @@ pub mod aes_ctr_generic_test {
         }
 
         for _ in 0..1_000 {
-            let key = AesKey(rng.gen());
+            let key = Aes128Key(rng.gen());
             let aes_idx: u128 = rng.gen_range(0..u128::MAX);
             let offset: u128 = rng.gen();
 
@@ -572,7 +583,7 @@ pub mod aes_ctr_generic_test {
     ///     On a valid fork, the bytes outputted by the children in fork order, followed by the
     ///     remaining parent bytes, form the same sequence the parent would have yielded had no
     ///     fork happened.
-    pub fn prop_fork_with_parent_continuation<G: AesBlockCipher>() {
+    pub fn prop_fork_with_parent_continuation<G: AesBlockCipher<Key = Aes128Key>>() {
         for _ in 0..10_000 {
             let (t, nc, nb, num_extra_bytes) = any_valid_fork().next().unwrap();
             let k = any_key().next().unwrap();
@@ -626,7 +637,7 @@ pub mod aes_ctr_generic_test {
         }
     }
 
-    pub fn prop_different_offset_means_different_output<G: AesBlockCipher>() {
+    pub fn prop_different_offset_means_different_output<G: AesBlockCipher<Key = Aes128Key>>() {
         for _ in 0..10_000 {
             let (t, nc, nb, num_extra_bytes) = any_valid_fork().next().unwrap();
             let k = any_key().next().unwrap();

--- a/tfhe-csprng/src/generators/aes_ctr/mod.rs
+++ b/tfhe-csprng/src/generators/aes_ctr/mod.rs
@@ -200,6 +200,16 @@ pub const AES_CALLS_PER_BATCH: usize = 8;
 pub const BYTES_PER_AES_CALL: usize = 128 / 8;
 pub const BYTES_PER_BATCH: usize = BYTES_PER_AES_CALL * AES_CALLS_PER_BATCH;
 
+/// The number of rounds and round keys of the AES variants.
+///
+/// A round key is consumed by the initial AddRoundKey step on top of one per round, hence the
+/// `+ 1`.
+pub(crate) const AES_128_NUM_ROUNDS: usize = 10;
+pub(crate) const AES_128_NUM_ROUND_KEYS: usize = AES_128_NUM_ROUNDS + 1;
+
+pub(crate) const AES_256_NUM_ROUNDS: usize = 14;
+pub(crate) const AES_256_NUM_ROUND_KEYS: usize = AES_256_NUM_ROUNDS + 1;
+
 #[derive(
     Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize, tfhe_versionable::Versionize,
 )]
@@ -255,9 +265,9 @@ use crate::seeders::{Seed, SeedKind, XofSeed};
 #[cfg(feature = "parallel")]
 pub use parallel::*;
 
-pub(crate) fn xof_init(seed: XofSeed) -> (AesKey, AesIndex) {
-    let init_key = AesKey(0);
-    let mut aes = crate::generators::default::DefaultBlockCipher::new(init_key);
+pub(crate) fn xof_init_128(seed: XofSeed) -> (Aes128Key, AesIndex) {
+    let init_key = Aes128Key(0);
+    let mut aes = crate::generators::default::DefaultAes128BlockCipher::new(init_key);
 
     let blocks = seed
         .iter_u128_blocks()
@@ -271,7 +281,7 @@ pub(crate) fn xof_init(seed: XofSeed) -> (AesKey, AesIndex) {
     }
 
     let init = AesIndex(prev_c.to_le());
-    let key = AesKey(c);
+    let key = Aes128Key(c);
 
     (key, init)
 }

--- a/tfhe-csprng/src/generators/aes_ctr/parallel.rs
+++ b/tfhe-csprng/src/generators/aes_ctr/parallel.rs
@@ -92,7 +92,7 @@ pub mod aes_ctr_parallel_generic_tests {
         any_key, any_valid_fork, assert_generator_matches_cipher, make_ctr_pair,
     };
     use crate::generators::aes_ctr::index::AesIndex;
-    use crate::generators::aes_ctr::{AesKey, BYTES_PER_AES_CALL};
+    use crate::generators::aes_ctr::{Aes128BlockCipher, Aes128Key, BYTES_PER_AES_CALL};
     use rand::prelude::*;
     use rand::rngs::ThreadRng;
     use rand::thread_rng;
@@ -103,7 +103,7 @@ pub mod aes_ctr_parallel_generic_tests {
     /// Check the property:
     ///     On a valid fork, the table index of the first child is the same as the table index of
     ///     the parent before the fork.
-    pub fn prop_fork_first_state_table_index<G: AesBlockCipher>() {
+    pub fn prop_fork_first_state_table_index<G: Aes128BlockCipher>() {
         for _ in 0..REPEATS {
             let (t, nc, nb, i) = any_valid_fork().next().unwrap();
             let k = any_key().next().unwrap();
@@ -131,7 +131,7 @@ pub mod aes_ctr_parallel_generic_tests {
     /// Check the property:
     ///     On a valid fork, the table index of the first byte outputted by the parent after the
     ///     fork, is the bound of the last child of the fork.
-    pub fn prop_fork_last_bound_table_index<G: AesBlockCipher>() {
+    pub fn prop_fork_last_bound_table_index<G: Aes128BlockCipher>() {
         for _ in 0..REPEATS {
             let (t, nc, nb, i) = any_valid_fork().next().unwrap();
             let k = any_key().next().unwrap();
@@ -160,7 +160,7 @@ pub mod aes_ctr_parallel_generic_tests {
 
     /// Check the property:
     ///     On a valid fork, the bound of the parent does not change.
-    pub fn prop_fork_parent_bound_table_index<G: AesBlockCipher>() {
+    pub fn prop_fork_parent_bound_table_index<G: Aes128BlockCipher>() {
         for _ in 0..REPEATS {
             let (t, nc, nb, i) = any_valid_fork().next().unwrap();
             let k = any_key().next().unwrap();
@@ -188,7 +188,7 @@ pub mod aes_ctr_parallel_generic_tests {
     /// Check the property:
     ///     On a valid fork, the parent table index is increased of the number of children
     ///     multiplied by the number of bytes per child.
-    pub fn prop_fork_parent_state_table_index<G: AesBlockCipher>() {
+    pub fn prop_fork_parent_state_table_index<G: Aes128BlockCipher>() {
         for _ in 0..REPEATS {
             let (t, nc, nb, i) = any_valid_fork().next().unwrap();
             let k = any_key().next().unwrap();
@@ -216,7 +216,7 @@ pub mod aes_ctr_parallel_generic_tests {
     /// Check the property:
     ///     On a valid fork, the bytes outputted by the children in the fork order form the same
     ///     sequence the parent would have had outputted no fork had happened.
-    pub fn prop_fork<G: AesBlockCipher>() {
+    pub fn prop_fork<G: Aes128BlockCipher>() {
         for _ in 0..1000 {
             let (t, nc, nb, i) = any_valid_fork().next().unwrap();
             let k = any_key().next().unwrap();
@@ -247,7 +247,7 @@ pub mod aes_ctr_parallel_generic_tests {
     /// Check the property:
     ///     On a valid fork, all children got a number of remaining bytes equals to the number of
     ///     bytes per child given as fork input.
-    pub fn prop_fork_children_remaining_bytes<G: AesBlockCipher>() {
+    pub fn prop_fork_children_remaining_bytes<G: Aes128BlockCipher>() {
         for _ in 0..REPEATS {
             let (t, nc, nb, i) = any_valid_fork().next().unwrap();
             let k = any_key().next().unwrap();
@@ -272,7 +272,7 @@ pub mod aes_ctr_parallel_generic_tests {
     ///     On a valid fork, the bytes consumed before the fork, the bytes outputted by the
     ///     children (collected into a Vec and iterated sequentially), and the bytes consumed
     ///     after the fork from the parent, all match the expected non-forked sequence.
-    pub fn prop_fork_with_parent_continuation<G: AesBlockCipher>() {
+    pub fn prop_fork_with_parent_continuation<G: Aes128BlockCipher>() {
         for _ in 0..10_000 {
             let (t, nc, nb, num_extra_bytes) = any_valid_fork().next().unwrap();
             let k = any_key().next().unwrap();
@@ -321,7 +321,7 @@ pub mod aes_ctr_parallel_generic_tests {
     /// Check the property:
     ///     On a valid fork, the number of remaining bytes of the parent is reduced by the
     ///     number of children multiplied by the number of bytes per child.
-    pub fn prop_fork_parent_remaining_bytes<G: AesBlockCipher>() {
+    pub fn prop_fork_parent_remaining_bytes<G: Aes128BlockCipher>() {
         for _ in 0..REPEATS {
             let (t, nc, nb, i) = any_valid_fork().next().unwrap();
             let k = any_key().next().unwrap();
@@ -347,7 +347,7 @@ pub mod aes_ctr_parallel_generic_tests {
     /// Check that our AesCtrGenerator produces the same keystream as `Ctr128LE<Aes128>` from
     /// the RustCrypto `ctr` crate. CTR mode XORs plaintext with AES keystream, so encrypting
     /// zeros gives the raw keystream for comparison.
-    pub fn test_forking_conformance_with_ctr_crate<G: AesBlockCipher>() {
+    pub fn test_forking_conformance_with_ctr_crate<G: Aes128BlockCipher>() {
         let mut rng = thread_rng();
 
         fn random_tuple_that_equals(rng: &mut ThreadRng, x: u64) -> (u64, u64) {
@@ -361,7 +361,7 @@ pub mod aes_ctr_parallel_generic_tests {
         }
 
         for _ in 0..1_000 {
-            let key = AesKey(rng.gen());
+            let key = Aes128Key(rng.gen());
             let aes_idx: u128 = rng.gen_range(0..u128::MAX);
             let offset: u128 = rng.gen();
 

--- a/tfhe-csprng/src/generators/default.rs
+++ b/tfhe-csprng/src/generators/default.rs
@@ -1,3 +1,5 @@
+use crate::generators::{AesBackend, AnyAesBlockCipher};
+
 #[cfg(all(target_arch = "x86_64", not(feature = "software-prng")))]
 pub type DefaultRandomGenerator = super::AesniRandomGenerator;
 #[cfg(all(target_arch = "aarch64", not(feature = "software-prng")))]
@@ -8,14 +10,20 @@ pub type DefaultRandomGenerator = super::NeonAesRandomGenerator;
 ))]
 pub type DefaultRandomGenerator = super::SoftwareRandomGenerator;
 
+/// The [`AesBackend`] selected for this target and feature set.
 #[cfg(all(target_arch = "x86_64", not(feature = "software-prng")))]
-pub type AesDefaultBlockCipher = super::implem::AesniBlockCipher;
+pub type DefaultAesBackend = super::Aesni;
 #[cfg(all(target_arch = "aarch64", not(feature = "software-prng")))]
-pub type AesDefaultBlockCipher = super::implem::ArmAesBlockCipher;
+pub type DefaultAesBackend = super::Arm;
 #[cfg(any(
     feature = "software-prng",
     not(any(target_arch = "x86_64", target_arch = "aarch64"))
 ))]
-pub type AesDefaultBlockCipher = super::SoftwareBlockCipher;
+pub type DefaultAesBackend = super::Software;
 
-pub type DefaultBlockCipher = AesDefaultBlockCipher;
+/// The Aes-128 block cipher of the [`DefaultAesBackend`].
+pub type DefaultAes128BlockCipher = <DefaultAesBackend as AesBackend>::Aes128BlockCipher;
+/// The Aes-256 block cipher of the [`DefaultAesBackend`].
+pub type DefaultAes256BlockCipher = <DefaultAesBackend as AesBackend>::Aes256BlockCipher;
+/// The block cipher of the [`DefaultAesBackend`], with the Aes variant chosen at runtime.
+pub type DefaultAesBlockCipher = AnyAesBlockCipher<DefaultAesBackend>;

--- a/tfhe-csprng/src/generators/implem/aarch64/block_cipher.rs
+++ b/tfhe-csprng/src/generators/implem/aarch64/block_cipher.rs
@@ -1,5 +1,6 @@
 use crate::generators::aes_ctr::{
-    AesBlockCipher, AesKey, AES_CALLS_PER_BATCH, BYTES_PER_AES_CALL, BYTES_PER_BATCH,
+    Aes128Key, Aes256Key, AesBlockCipher, AES_128_NUM_ROUND_KEYS, AES_256_NUM_ROUND_KEYS,
+    AES_CALLS_PER_BATCH, BYTES_PER_AES_CALL, BYTES_PER_BATCH,
 };
 use core::arch::aarch64::{
     uint8x16_t, vaeseq_u8, vaesmcq_u8, vdupq_n_u32, vdupq_n_u8, veorq_u8, vgetq_lane_u32,
@@ -8,56 +9,114 @@ use core::arch::aarch64::{
 use std::arch::is_aarch64_feature_detected;
 use std::mem::transmute;
 
-const RCONS: [u32; 10] = [0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80, 0x1B, 0x36];
-const NUM_WORDS_IN_KEY: usize = 4;
-const NUM_ROUNDS: usize = 10;
-const NUM_ROUND_KEYS: usize = NUM_ROUNDS + 1;
+#[derive(Copy, Clone)]
+pub struct Arm;
 
-/// An aes block cipher implementation which uses `neon` and `aes` instructions.
-#[derive(Clone)]
-pub struct ArmAesBlockCipher {
-    round_keys: [uint8x16_t; NUM_ROUND_KEYS],
+impl crate::generators::AesBackend for Arm {
+    type Aes128BlockCipher = ArmAes128BlockCipher;
+
+    type Aes256BlockCipher = ArmAes256BlockCipher;
 }
 
-impl AesBlockCipher for ArmAesBlockCipher {
-    fn new(key: AesKey) -> ArmAesBlockCipher {
+trait ArmKey: Sized {
+    type Array;
+
+    fn generate_round_keys(self) -> Self::Array {
         let aes_detected = is_aarch64_feature_detected!("aes");
         let neon_detected = is_aarch64_feature_detected!("neon");
 
         if !(aes_detected && neon_detected) {
             panic!(
-                "The ArmAesBlockCipher requires both aes and neon aarch64 CPU features.\n\
+                "The arm64 based block cipher requires both aes and neon aarch64 CPU features.\n\
                 aes feature available: {aes_detected}\nneon feature available: {neon_detected}\n\
                 Please consider enabling the SoftwareRandomGenerator with the `software-prng` feature",
             )
         }
 
-        let round_keys = unsafe { generate_round_keys(key) };
-        ArmAesBlockCipher { round_keys }
+        // SAFETY: we checked for aes and sse2 availability
+        unsafe { self.unchecked_generate_round_keys() }
+    }
+
+    unsafe fn unchecked_generate_round_keys(self) -> Self::Array;
+}
+
+impl ArmKey for Aes128Key {
+    type Array = [uint8x16_t; AES_128_NUM_ROUND_KEYS];
+
+    unsafe fn unchecked_generate_round_keys(self) -> Self::Array {
+        aes_key_schedule(self.0.to_ne_bytes())
+    }
+}
+
+impl ArmKey for Aes256Key {
+    type Array = [uint8x16_t; AES_256_NUM_ROUND_KEYS];
+
+    unsafe fn unchecked_generate_round_keys(self) -> Self::Array {
+        aes_key_schedule(self.0)
+    }
+}
+
+/// An aes block cipher implementation which uses `neon` and `aes` instructions.
+///
+/// Not re-exported: only the [`ArmAes128BlockCipher`] and [`ArmAes256BlockCipher`] so that
+/// users cannot potentially use this type with a bad `N`.
+#[derive(Clone)]
+pub struct ArmAesBlockCipher<const N: usize> {
+    round_keys: [uint8x16_t; N],
+}
+
+/// The aarch64 Aes-128 block cipher.
+pub type ArmAes128BlockCipher = ArmAesBlockCipher<AES_128_NUM_ROUND_KEYS>;
+
+/// The aarch64 Aes-256 block cipher.
+pub type ArmAes256BlockCipher = ArmAesBlockCipher<AES_256_NUM_ROUND_KEYS>;
+
+// Shared by both `AesBlockCipher` impls below, which otherwise differ only in their `Key`.
+impl<const N: usize> ArmAesBlockCipher<N> {
+    fn encrypt_batch(&self, data: [u128; AES_CALLS_PER_BATCH]) -> [u8; BYTES_PER_BATCH] {
+        // SAFETY: we checked for aes and neon availability in `Self::new`
+        unsafe { generate_batch(data, &self.round_keys) }
+    }
+
+    fn encrypt_next(&self, data: u128) -> [u8; BYTES_PER_AES_CALL] {
+        // SAFETY: we checked for aes and neon availability in `Self::new`
+        unsafe { generate_next(data, &self.round_keys) }
+    }
+}
+
+impl AesBlockCipher for ArmAes128BlockCipher {
+    type Key = Aes128Key;
+
+    fn new(key: Self::Key) -> Self {
+        Self {
+            round_keys: key.generate_round_keys(),
+        }
     }
 
     fn generate_batch(&mut self, data: [u128; AES_CALLS_PER_BATCH]) -> [u8; BYTES_PER_BATCH] {
-        #[target_feature(enable = "aes,neon")]
-        unsafe fn implementation(
-            this: &ArmAesBlockCipher,
-            data: [u128; AES_CALLS_PER_BATCH],
-        ) -> [u8; BYTES_PER_BATCH] {
-            let mut output = [0u8; BYTES_PER_BATCH];
-            // We want 128 bytes of output, the ctr gives 128 bit message (16 bytes)
-            for (input, out) in data.iter().copied().zip(output.as_chunks_mut::<16>().0) {
-                // Safe because we prevent the user from creating the Generator
-                // on non-supported hardware
-                let encrypted = encrypt(input, &this.round_keys);
-                out.copy_from_slice(&encrypted.to_ne_bytes());
-            }
-            output
-        }
-        // SAFETY: we checked for aes and neon availability in `Self::new`
-        unsafe { implementation(self, data) }
+        self.encrypt_batch(data)
     }
 
     fn generate_next(&mut self, data: u128) -> [u8; BYTES_PER_AES_CALL] {
-        unsafe { encrypt(data, &self.round_keys) }.to_ne_bytes()
+        self.encrypt_next(data)
+    }
+}
+
+impl AesBlockCipher for ArmAes256BlockCipher {
+    type Key = Aes256Key;
+
+    fn new(key: Self::Key) -> Self {
+        Self {
+            round_keys: key.generate_round_keys(),
+        }
+    }
+
+    fn generate_batch(&mut self, data: [u128; AES_CALLS_PER_BATCH]) -> [u8; BYTES_PER_BATCH] {
+        self.encrypt_batch(data)
+    }
+
+    fn generate_next(&mut self, data: u128) -> [u8; BYTES_PER_AES_CALL] {
+        self.encrypt_next(data)
     }
 }
 
@@ -92,31 +151,88 @@ fn u128_to_uint8x16_t(input: u128) -> uint8x16_t {
 }
 
 #[target_feature(enable = "aes,neon")]
-unsafe fn generate_round_keys(key: AesKey) -> [uint8x16_t; NUM_ROUND_KEYS] {
-    let mut round_keys: [uint8x16_t; NUM_ROUND_KEYS] = std::mem::zeroed();
-    round_keys[0] = u128_to_uint8x16_t(key.0);
+unsafe fn aes_key_schedule<const S: usize, const R: usize>(
+    aes_key_bytes: [u8; S],
+) -> [uint8x16_t; R] {
+    const {
+        assert!(
+            (S == 16 && R == AES_128_NUM_ROUND_KEYS) || (S == 32 && R == AES_256_NUM_ROUND_KEYS),
+            "AES key length and round key count must match"
+        )
+    };
+    const RCONS: [u32; 10] = [0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80, 0x1B, 0x36];
 
+    // 'words' are 32 bit, since we have bytes: 32/8=4
+    let num_words_in_key = S / 4;
+    // Whatever the key size, a round key is always 128 bits, that is 4 words
+    const NUM_WORDS_IN_ROUND_KEY: usize = 4;
+
+    let mut round_keys: [uint8x16_t; R] = std::mem::zeroed();
     let words = std::slice::from_raw_parts_mut(
         round_keys.as_mut_ptr() as *mut u32,
-        NUM_ROUND_KEYS * NUM_WORDS_IN_KEY,
+        R * NUM_WORDS_IN_ROUND_KEY,
     );
 
-    debug_assert_eq!(words.len(), 44);
-
+    for i in 0..num_words_in_key {
+        let bytes = [
+            aes_key_bytes[i * 4],
+            aes_key_bytes[(i * 4) + 1],
+            aes_key_bytes[(i * 4) + 2],
+            aes_key_bytes[(i * 4) + 3],
+        ];
+        words[i] = u32::from_ne_bytes(bytes)
+    }
     // Skip the words of the first key, its already done
-    for i in NUM_WORDS_IN_KEY..words.len() {
-        if (i % NUM_WORDS_IN_KEY) == 0 {
-            words[i] = words[i - NUM_WORDS_IN_KEY]
+    for i in num_words_in_key..words.len() {
+        if (i % num_words_in_key) == 0 {
+            words[i] = words[i - num_words_in_key]
                 ^ sub_word(words[i - 1]).rotate_right(8)
-                ^ RCONS[(i / NUM_WORDS_IN_KEY) - 1];
+                ^ RCONS[(i / num_words_in_key) - 1];
+        } else if num_words_in_key > 6 && (i % num_words_in_key) == 4 {
+            words[i] = words[i - num_words_in_key] ^ sub_word(words[i - 1]);
         } else {
-            words[i] = words[i - NUM_WORDS_IN_KEY] ^ words[i - 1];
+            words[i] = words[i - num_words_in_key] ^ words[i - 1];
         }
-        // Note: there is also a special thing to do when
-        // i mod SElf::NUM_WORDS_IN_KEY == 4 but it cannot happen on 128 bits keys
     }
 
     round_keys
+}
+
+/// Encrypts a batch of  128-bit message
+///
+/// # SAFETY
+///
+/// You must make sure the CPU's arch is`aarch64` and has
+/// `neon` and `aes` features.
+#[target_feature(enable = "aes,neon")]
+unsafe fn generate_batch<const N: usize>(
+    messages: [u128; AES_CALLS_PER_BATCH],
+    round_keys: &[uint8x16_t; N],
+) -> [u8; BYTES_PER_BATCH] {
+    let mut output = [0u8; BYTES_PER_BATCH];
+    // We want 128 bytes of output, the ctr gives 128 bit message (16 bytes)
+    for (message, out) in messages.iter().copied().zip(output.as_chunks_mut::<16>().0) {
+        let encrypted = encrypt(message, round_keys);
+        out.copy_from_slice(&encrypted.to_ne_bytes());
+    }
+    output
+}
+
+/// Encrypts a single 128-bit message
+///
+/// We have this, so that we call the encrypt function in a context where target_features are
+/// enabled
+///
+/// # SAFETY
+///
+/// You must make sure the CPU's arch is`aarch64` and has
+/// `neon` and `aes` features.
+#[target_feature(enable = "aes,neon")]
+unsafe fn generate_next<const N: usize>(
+    message: u128,
+    round_keys: &[uint8x16_t; N],
+) -> [u8; BYTES_PER_AES_CALL] {
+    encrypt(message, round_keys).to_ne_bytes()
 }
 
 /// Encrypts a 128-bit message
@@ -126,22 +242,22 @@ unsafe fn generate_round_keys(key: AesKey) -> [uint8x16_t; NUM_ROUND_KEYS] {
 /// You must make sure the CPU's arch is`aarch64` and has
 /// `neon` and `aes` features.
 #[inline(always)]
-unsafe fn encrypt(message: u128, keys: &[uint8x16_t; NUM_ROUND_KEYS]) -> u128 {
+unsafe fn encrypt<const N: usize>(message: u128, keys: &[uint8x16_t; N]) -> u128 {
     // Notes:
     // According the [ARM Manual](https://developer.arm.com/documentation/ddi0487/gb/):
     // `vaeseq_u8` is the following AES operations:
     //      1. AddRoundKey (XOR)
-    //      2. ShiftRows
-    //      3. SubBytes
+    //      2. SubBytes
+    //      3. ShiftRows
     // `vaesmcq_u8` is MixColumns
     let mut data: uint8x16_t = u128_to_uint8x16_t(message);
 
-    for &key in keys.iter().take(NUM_ROUNDS - 1) {
+    for &key in keys.iter().take(N - 2) {
         data = vaesmcq_u8(vaeseq_u8(data, key));
     }
 
-    data = vaeseq_u8(data, keys[NUM_ROUNDS - 1]);
-    data = veorq_u8(data, keys[NUM_ROUND_KEYS - 1]);
+    data = vaeseq_u8(data, keys[N - 2]);
+    data = veorq_u8(data, keys[N - 1]);
 
     uint8x16_t_to_u128(data)
 }
@@ -149,42 +265,62 @@ unsafe fn encrypt(message: u128, keys: &[uint8x16_t; NUM_ROUND_KEYS]) -> u128 {
 #[cfg(test)]
 mod test {
     use super::*;
-
-    // Test vector for aes128, from the FIPS publication 197
-    const CIPHER_KEY: u128 = u128::from_be(0x000102030405060708090a0b0c0d0e0f);
-    const KEY_SCHEDULE: [u128; 11] = [
-        u128::from_be(0x000102030405060708090a0b0c0d0e0f),
-        u128::from_be(0xd6aa74fdd2af72fadaa678f1d6ab76fe),
-        u128::from_be(0xb692cf0b643dbdf1be9bc5006830b3fe),
-        u128::from_be(0xb6ff744ed2c2c9bf6c590cbf0469bf41),
-        u128::from_be(0x47f7f7bc95353e03f96c32bcfd058dfd),
-        u128::from_be(0x3caaa3e8a99f9deb50f3af57adf622aa),
-        u128::from_be(0x5e390f7df7a69296a7553dc10aa31f6b),
-        u128::from_be(0x14f9701ae35fe28c440adf4d4ea9c026),
-        u128::from_be(0x47438735a41c65b9e016baf4aebf7ad2),
-        u128::from_be(0x549932d1f08557681093ed9cbe2c974e),
-        u128::from_be(0x13111d7fe3944a17f307a78b4d2b30c5),
-    ];
-    const PLAINTEXT: u128 = u128::from_be(0x00112233445566778899aabbccddeeff);
-    const CIPHERTEXT: u128 = u128::from_be(0x69c4e0d86a7b0430d8cdb78070b4c55a);
+    use crate::generators::aes_ctr::block_cipher_generic_test;
 
     #[test]
     fn test_generate_key_schedule() {
-        // Checks that the round keys are correctly generated from the sample key from FIPS
-        let key = AesKey(CIPHER_KEY);
-        let keys = unsafe { generate_round_keys(key) };
-        for (expected, actual) in KEY_SCHEDULE.iter().zip(keys.iter()) {
-            assert_eq!(*expected, uint8x16_t_to_u128(*actual));
-        }
+        block_cipher_generic_test::test_key_schedule_128(|key| {
+            key.generate_round_keys().map(uint8x16_t_to_u128)
+        });
     }
 
     #[test]
-    fn test_encrypt_message() {
-        // Checks that encrypting many plaintext at the same time gives the correct output.
-        let message = PLAINTEXT;
-        let key = AesKey(CIPHER_KEY);
-        let keys = unsafe { generate_round_keys(key) };
-        let ciphertext = unsafe { encrypt(message, &keys) };
-        assert_eq!(CIPHERTEXT, ciphertext);
+    fn test_generate_key_schedule_256() {
+        block_cipher_generic_test::test_key_schedule_256(|key| {
+            key.generate_round_keys().map(uint8x16_t_to_u128)
+        });
+    }
+
+    #[test]
+    fn test_encrypt_one_message() {
+        block_cipher_generic_test::test_fips197_c1_single_block::<ArmAes128BlockCipher>();
+    }
+
+    #[test]
+    fn test_encrypt_many_messages() {
+        block_cipher_generic_test::test_fips197_c1_batch::<ArmAes128BlockCipher>();
+    }
+
+    #[test]
+    fn test_encrypt_one_message_256() {
+        block_cipher_generic_test::test_fips197_c3_single_block::<ArmAes256BlockCipher>();
+    }
+
+    #[test]
+    fn test_encrypt_many_messages_256() {
+        block_cipher_generic_test::test_fips197_c3_batch::<ArmAes256BlockCipher>();
+    }
+
+    #[test]
+    fn test_nist_vectors_256() {
+        block_cipher_generic_test::test_nist_ecb_aes256_single_blocks::<ArmAes256BlockCipher>();
+    }
+
+    #[test]
+    fn test_nist_vectors_256_batch() {
+        block_cipher_generic_test::test_nist_ecb_aes256_batch::<ArmAes256BlockCipher>();
+    }
+
+    #[test]
+    fn test_encrypt_many_matches_encrypt_one_256() {
+        block_cipher_generic_test::test_batch_matches_single_aes256::<ArmAes256BlockCipher>();
+    }
+
+    #[test]
+    fn test_aes128_and_aes256_differ() {
+        block_cipher_generic_test::test_aes128_and_aes256_differ::<
+            ArmAes128BlockCipher,
+            ArmAes256BlockCipher,
+        >();
     }
 }

--- a/tfhe-csprng/src/generators/implem/aarch64/generator.rs
+++ b/tfhe-csprng/src/generators/implem/aarch64/generator.rs
@@ -1,14 +1,15 @@
 use crate::generators::aes_ctr::{AesCtrGenerator, AesCtrParams, ChildrenIterator, TableIndex};
-use crate::generators::implem::aarch64::block_cipher::ArmAesBlockCipher;
-use crate::generators::{ByteCount, BytesPerChild, ChildrenCount, ForkError, RandomGenerator};
+use crate::generators::{
+    AnyAesBlockCipher, Arm, ByteCount, BytesPerChild, ChildrenCount, ForkError, RandomGenerator,
+};
 
 /// A random number generator using the arm `neon` instructions.
-pub struct NeonAesRandomGenerator(pub(super) AesCtrGenerator<ArmAesBlockCipher>);
+pub struct NeonAesRandomGenerator(pub(super) AesCtrGenerator<AnyAesBlockCipher<Arm>>);
 
 /// The children iterator used by [`NeonAesRandomGenerator`].
 ///
 /// Outputs children generators one by one.
-pub struct ArmAesChildrenIterator(ChildrenIterator<ArmAesBlockCipher>);
+pub struct ArmAesChildrenIterator(ChildrenIterator<AnyAesBlockCipher<Arm>>);
 
 impl Iterator for ArmAesChildrenIterator {
     type Item = NeonAesRandomGenerator;
@@ -52,52 +53,53 @@ impl Iterator for NeonAesRandomGenerator {
 #[cfg(test)]
 mod test {
     use crate::generators::aes_ctr::aes_ctr_generic_test;
-    use crate::generators::implem::aarch64::block_cipher::ArmAesBlockCipher;
+    use crate::generators::implem::aarch64::block_cipher::ArmAes128BlockCipher;
     use crate::generators::{generator_generic_test, NeonAesRandomGenerator};
 
     #[test]
     fn prop_fork_first_state_table_index() {
-        aes_ctr_generic_test::prop_fork_first_state_table_index::<ArmAesBlockCipher>();
+        aes_ctr_generic_test::prop_fork_first_state_table_index::<ArmAes128BlockCipher>();
     }
 
     #[test]
     fn prop_fork_last_bound_table_index() {
-        aes_ctr_generic_test::prop_fork_last_bound_table_index::<ArmAesBlockCipher>();
+        aes_ctr_generic_test::prop_fork_last_bound_table_index::<ArmAes128BlockCipher>();
     }
 
     #[test]
     fn prop_fork_parent_bound_table_index() {
-        aes_ctr_generic_test::prop_fork_parent_bound_table_index::<ArmAesBlockCipher>();
+        aes_ctr_generic_test::prop_fork_parent_bound_table_index::<ArmAes128BlockCipher>();
     }
 
     #[test]
     fn prop_fork_parent_state_table_index() {
-        aes_ctr_generic_test::prop_fork_parent_state_table_index::<ArmAesBlockCipher>();
+        aes_ctr_generic_test::prop_fork_parent_state_table_index::<ArmAes128BlockCipher>();
     }
 
     #[test]
     fn prop_fork() {
-        aes_ctr_generic_test::prop_fork::<ArmAesBlockCipher>();
+        aes_ctr_generic_test::prop_fork::<ArmAes128BlockCipher>();
     }
 
     #[test]
     fn prop_fork_with_parent_continuation() {
-        aes_ctr_generic_test::prop_fork_with_parent_continuation::<ArmAesBlockCipher>();
+        aes_ctr_generic_test::prop_fork_with_parent_continuation::<ArmAes128BlockCipher>();
     }
 
     #[test]
     fn prop_fork_children_remaining_bytes() {
-        aes_ctr_generic_test::prop_fork_children_remaining_bytes::<ArmAesBlockCipher>();
+        aes_ctr_generic_test::prop_fork_children_remaining_bytes::<ArmAes128BlockCipher>();
     }
 
     #[test]
     fn prop_fork_parent_remaining_bytes() {
-        aes_ctr_generic_test::prop_fork_parent_remaining_bytes::<ArmAesBlockCipher>();
+        aes_ctr_generic_test::prop_fork_parent_remaining_bytes::<ArmAes128BlockCipher>();
     }
 
     #[test]
     fn prop_different_offset_means_different_output() {
-        aes_ctr_generic_test::prop_different_offset_means_different_output::<ArmAesBlockCipher>();
+        aes_ctr_generic_test::prop_different_offset_means_different_output::<ArmAes128BlockCipher>(
+        );
     }
 
     #[test]
@@ -107,12 +109,12 @@ mod test {
 
     #[test]
     fn test_conformance_with_ctr_crate() {
-        aes_ctr_generic_test::test_conformance_with_ctr_crate::<ArmAesBlockCipher>();
+        aes_ctr_generic_test::test_conformance_with_ctr_crate::<ArmAes128BlockCipher>();
     }
 
     #[test]
     fn test_forking_conformance_with_ctr_crate() {
-        aes_ctr_generic_test::test_forking_conformance_with_ctr_crate::<ArmAesBlockCipher>();
+        aes_ctr_generic_test::test_forking_conformance_with_ctr_crate::<ArmAes128BlockCipher>();
     }
 
     #[test]

--- a/tfhe-csprng/src/generators/implem/aarch64/mod.rs
+++ b/tfhe-csprng/src/generators/implem/aarch64/mod.rs
@@ -6,7 +6,7 @@
 //! [intel aesni white paper 323641-001 revision 3.0](https://www.intel.com/content/dam/doc/white-paper/advanced-encryption-standard-new-instructions-set-paper.pdf).
 
 mod block_cipher;
-pub use block_cipher::ArmAesBlockCipher;
+pub use block_cipher::{Arm, ArmAes128BlockCipher, ArmAes256BlockCipher};
 
 mod generator;
 pub use generator::*;

--- a/tfhe-csprng/src/generators/implem/aarch64/parallel.rs
+++ b/tfhe-csprng/src/generators/implem/aarch64/parallel.rs
@@ -1,7 +1,8 @@
 use super::*;
 use crate::generators::aes_ctr::{AesCtrGenerator, ParallelChildrenIterator};
-use crate::generators::implem::aarch64::block_cipher::ArmAesBlockCipher;
-use crate::generators::{BytesPerChild, ChildrenCount, ForkError, ParallelRandomGenerator};
+use crate::generators::{
+    AnyAesBlockCipher, BytesPerChild, ChildrenCount, ForkError, ParallelRandomGenerator,
+};
 use rayon::iter::plumbing::{Consumer, ProducerCallback, UnindexedConsumer};
 use rayon::prelude::*;
 
@@ -11,8 +12,8 @@ use rayon::prelude::*;
 #[allow(clippy::type_complexity)]
 pub struct ParallelArmAesChildrenIterator(
     rayon::iter::Map<
-        ParallelChildrenIterator<ArmAesBlockCipher>,
-        fn(AesCtrGenerator<ArmAesBlockCipher>) -> NeonAesRandomGenerator,
+        ParallelChildrenIterator<AnyAesBlockCipher<Arm>>,
+        fn(AesCtrGenerator<AnyAesBlockCipher<Arm>>) -> NeonAesRandomGenerator,
     >,
 );
 
@@ -55,51 +56,56 @@ impl ParallelRandomGenerator for NeonAesRandomGenerator {
 #[cfg(test)]
 mod test {
     use crate::generators::aes_ctr::aes_ctr_parallel_generic_tests;
-    use crate::generators::implem::aarch64::block_cipher::ArmAesBlockCipher;
+    use crate::generators::implem::aarch64::block_cipher::ArmAes128BlockCipher;
 
     #[test]
     fn prop_fork_first_state_table_index() {
-        aes_ctr_parallel_generic_tests::prop_fork_first_state_table_index::<ArmAesBlockCipher>();
+        aes_ctr_parallel_generic_tests::prop_fork_first_state_table_index::<ArmAes128BlockCipher>();
     }
 
     #[test]
     fn prop_fork_last_bound_table_index() {
-        aes_ctr_parallel_generic_tests::prop_fork_last_bound_table_index::<ArmAesBlockCipher>();
+        aes_ctr_parallel_generic_tests::prop_fork_last_bound_table_index::<ArmAes128BlockCipher>();
     }
 
     #[test]
     fn prop_fork_parent_bound_table_index() {
-        aes_ctr_parallel_generic_tests::prop_fork_parent_bound_table_index::<ArmAesBlockCipher>();
+        aes_ctr_parallel_generic_tests::prop_fork_parent_bound_table_index::<ArmAes128BlockCipher>(
+        );
     }
 
     #[test]
     fn prop_fork_parent_state_table_index() {
-        aes_ctr_parallel_generic_tests::prop_fork_parent_state_table_index::<ArmAesBlockCipher>();
+        aes_ctr_parallel_generic_tests::prop_fork_parent_state_table_index::<ArmAes128BlockCipher>(
+        );
     }
 
     #[test]
     fn prop_fork_ttt() {
-        aes_ctr_parallel_generic_tests::prop_fork::<ArmAesBlockCipher>();
+        aes_ctr_parallel_generic_tests::prop_fork::<ArmAes128BlockCipher>();
     }
 
     #[test]
     fn prop_fork_children_remaining_bytes() {
-        aes_ctr_parallel_generic_tests::prop_fork_children_remaining_bytes::<ArmAesBlockCipher>();
+        aes_ctr_parallel_generic_tests::prop_fork_children_remaining_bytes::<ArmAes128BlockCipher>(
+        );
     }
 
     #[test]
     fn prop_fork_parent_remaining_bytes() {
-        aes_ctr_parallel_generic_tests::prop_fork_parent_remaining_bytes::<ArmAesBlockCipher>();
+        aes_ctr_parallel_generic_tests::prop_fork_parent_remaining_bytes::<ArmAes128BlockCipher>();
     }
 
     #[test]
     fn prop_fork_with_parent_continuation() {
-        aes_ctr_parallel_generic_tests::prop_fork_with_parent_continuation::<ArmAesBlockCipher>();
+        aes_ctr_parallel_generic_tests::prop_fork_with_parent_continuation::<ArmAes128BlockCipher>(
+        );
     }
 
     #[test]
     fn test_forking_conformance_with_ctr_crate() {
-        aes_ctr_parallel_generic_tests::test_forking_conformance_with_ctr_crate::<ArmAesBlockCipher>(
-        );
+        aes_ctr_parallel_generic_tests::test_forking_conformance_with_ctr_crate::<
+            ArmAes128BlockCipher,
+        >();
     }
 }

--- a/tfhe-csprng/src/generators/implem/aesni/block_cipher.rs
+++ b/tfhe-csprng/src/generators/implem/aesni/block_cipher.rs
@@ -1,5 +1,6 @@
 use crate::generators::aes_ctr::{
-    AesBlockCipher, AesKey, AES_CALLS_PER_BATCH, BYTES_PER_AES_CALL, BYTES_PER_BATCH,
+    Aes128Key, Aes256Key, AesBlockCipher, AES_128_NUM_ROUND_KEYS, AES_256_NUM_ROUND_KEYS,
+    AES_CALLS_PER_BATCH, BYTES_PER_AES_CALL, BYTES_PER_BATCH,
 };
 use std::arch::x86_64::{
     __m128i, _mm_aesenc_si128, _mm_aesenclast_si128, _mm_aeskeygenassist_si128, _mm_shuffle_epi32,
@@ -7,84 +8,178 @@ use std::arch::x86_64::{
 };
 use std::mem::transmute;
 
-/// An aes block cipher implementation which uses `aesni` instructions.
-#[derive(Clone)]
-pub struct AesniBlockCipher {
-    // The set of round keys used for the aes encryption
-    round_keys: [__m128i; 11],
+#[derive(Copy, Clone)]
+pub struct Aesni;
+
+impl crate::generators::AesBackend for Aesni {
+    type Aes128BlockCipher = Aesni128BlockCipher;
+
+    type Aes256BlockCipher = Aesni256BlockCipher;
 }
 
-impl AesBlockCipher for AesniBlockCipher {
-    fn new(key: AesKey) -> AesniBlockCipher {
+trait AesniKey: Sized {
+    type Array;
+
+    fn generate_round_keys(self) -> Self::Array {
         let aes_detected = is_x86_feature_detected!("aes");
         let sse2_detected = is_x86_feature_detected!("sse2");
 
         if !(aes_detected && sse2_detected) {
             panic!(
-                "The AesniBlockCipher requires both aes and sse2 x86 CPU features.\n\
+                "The aesni based block ciphers requires both aes and sse2 x86 CPU features.\n\
                 aes feature available: {aes_detected}\nsse2 feature available: {sse2_detected}\n\
                 Please consider enabling the SoftwareRandomGenerator with the `software-prng` feature",
             )
         }
 
         // SAFETY: we checked for aes and sse2 availability
-        let round_keys = unsafe { generate_round_keys(key) };
-        AesniBlockCipher { round_keys }
+        unsafe { self.unchecked_generate_round_keys() }
+    }
+
+    unsafe fn unchecked_generate_round_keys(self) -> Self::Array;
+}
+
+impl AesniKey for Aes128Key {
+    type Array = [__m128i; AES_128_NUM_ROUND_KEYS];
+
+    unsafe fn unchecked_generate_round_keys(self) -> Self::Array {
+        generate_round_keys_128(self)
+    }
+}
+
+impl AesniKey for Aes256Key {
+    type Array = [__m128i; AES_256_NUM_ROUND_KEYS];
+
+    unsafe fn unchecked_generate_round_keys(self) -> Self::Array {
+        generate_round_keys_256(self)
+    }
+}
+
+/// An aes block cipher implementation which uses `aesni` instructions.
+///
+/// Not re-exported: only the [`Aesni128BlockCipher`] and [`Aesni256BlockCipher`] so that
+/// users cannot potentially use this type with a bad `N`.
+#[derive(Clone)]
+pub struct AesniBlockCipher<const N: usize> {
+    // The set of round keys used for the aes encryption
+    round_keys: [__m128i; N],
+}
+
+/// The aesni Aes-128 block cipher.
+pub type Aesni128BlockCipher = AesniBlockCipher<AES_128_NUM_ROUND_KEYS>;
+
+/// The aesni Aes-256 block cipher.
+pub type Aesni256BlockCipher = AesniBlockCipher<AES_256_NUM_ROUND_KEYS>;
+
+// Shared by both `AesBlockCipher` impls below, which otherwise differ only in their `Key`.
+impl<const N: usize> AesniBlockCipher<N> {
+    fn encrypt_batch(&self, data: [u128; AES_CALLS_PER_BATCH]) -> [u8; BYTES_PER_BATCH] {
+        // SAFETY: we checked for aes and sse2 availability in `Self::new`
+        unsafe { generate_batch_implementation(&self.round_keys, data) }
+    }
+
+    fn encrypt_next(&self, data: u128) -> [u8; BYTES_PER_AES_CALL] {
+        // SAFETY: we checked for aes and sse2 availability in `Self::new`
+        unsafe { generate_next_implementation(&self.round_keys, data) }
+    }
+}
+
+impl AesBlockCipher for Aesni128BlockCipher {
+    type Key = Aes128Key;
+
+    fn new(key: Self::Key) -> Self {
+        Self {
+            round_keys: key.generate_round_keys(),
+        }
     }
 
     fn generate_batch(&mut self, data: [u128; AES_CALLS_PER_BATCH]) -> [u8; BYTES_PER_BATCH] {
-        #[target_feature(enable = "sse2,aes")]
-        unsafe fn implementation(
-            this: &AesniBlockCipher,
-            data: [u128; AES_CALLS_PER_BATCH],
-        ) -> [u8; BYTES_PER_BATCH] {
-            si128arr_to_u8arr(aes_encrypt_many(
-                u128_to_si128(data[0]),
-                u128_to_si128(data[1]),
-                u128_to_si128(data[2]),
-                u128_to_si128(data[3]),
-                u128_to_si128(data[4]),
-                u128_to_si128(data[5]),
-                u128_to_si128(data[6]),
-                u128_to_si128(data[7]),
-                &this.round_keys,
-            ))
-        }
-        // SAFETY: we checked for aes and sse2 availability in `Self::new`
-        unsafe { implementation(self, data) }
+        self.encrypt_batch(data)
     }
 
     fn generate_next(&mut self, data: u128) -> [u8; BYTES_PER_AES_CALL] {
-        unsafe { transmute(aes_encrypt_one(u128_to_si128(data), &self.round_keys)) }
+        self.encrypt_next(data)
+    }
+}
+
+impl AesBlockCipher for Aesni256BlockCipher {
+    type Key = Aes256Key;
+
+    fn new(key: Self::Key) -> Self {
+        Self {
+            round_keys: key.generate_round_keys(),
+        }
+    }
+
+    fn generate_batch(&mut self, data: [u128; AES_CALLS_PER_BATCH]) -> [u8; BYTES_PER_BATCH] {
+        self.encrypt_batch(data)
+    }
+
+    fn generate_next(&mut self, data: u128) -> [u8; BYTES_PER_AES_CALL] {
+        self.encrypt_next(data)
     }
 }
 
 #[target_feature(enable = "sse2,aes")]
-unsafe fn generate_round_keys(key: AesKey) -> [__m128i; 11] {
+unsafe fn generate_round_keys_128(key: Aes128Key) -> [__m128i; AES_128_NUM_ROUND_KEYS] {
     let key = u128_to_si128(key.0);
-    let mut keys: [__m128i; 11] = [u128_to_si128(0); 11];
+    let mut keys: [__m128i; AES_128_NUM_ROUND_KEYS] = [u128_to_si128(0); AES_128_NUM_ROUND_KEYS];
     aes_128_key_expansion(key, &mut keys);
     keys
 }
 
+#[target_feature(enable = "sse2,aes")]
+unsafe fn generate_batch_implementation<const N: usize>(
+    round_keys: &[__m128i; N],
+    data: [u128; AES_CALLS_PER_BATCH],
+) -> [u8; BYTES_PER_BATCH] {
+    si128arr_to_u8arr(aes_encrypt_many(
+        u128_to_si128(data[0]),
+        u128_to_si128(data[1]),
+        u128_to_si128(data[2]),
+        u128_to_si128(data[3]),
+        u128_to_si128(data[4]),
+        u128_to_si128(data[5]),
+        u128_to_si128(data[6]),
+        u128_to_si128(data[7]),
+        round_keys,
+    ))
+}
+
+// Like `generate_batch_implementation`, this exists so that the aes intrinsics are expanded in a
+// context where the `aes` feature is enabled. Calling `aes_encrypt_one` straight from the trait
+// method instead leaves the round loop rolled, with an out-of-line call per round, on any build
+// that does not enable `aes` crate-wide (e.g. without `-C target-cpu=native`).
+#[target_feature(enable = "sse2,aes")]
+unsafe fn generate_next_implementation<const N: usize>(
+    round_keys: &[__m128i; N],
+    data: u128,
+) -> [u8; BYTES_PER_AES_CALL] {
+    transmute(aes_encrypt_one(u128_to_si128(data), round_keys))
+}
+
 #[inline(always)]
-fn aes_encrypt_one(message: __m128i, keys: &[__m128i; 11]) -> __m128i {
-    unsafe {
-        let mut tmp_1 = _mm_xor_si128(message, keys[0]);
+unsafe fn aes_encrypt_one<const N: usize>(message: __m128i, keys: &[__m128i; N]) -> __m128i {
+    const {
+        assert!(
+            N == AES_128_NUM_ROUND_KEYS || N == AES_256_NUM_ROUND_KEYS,
+            "invalid AES round key count"
+        )
+    };
+    let mut tmp_1 = _mm_xor_si128(message, keys[0]);
 
-        for key in keys.iter().take(10).skip(1) {
-            tmp_1 = _mm_aesenc_si128(tmp_1, *key);
-        }
-
-        _mm_aesenclast_si128(tmp_1, keys[10])
+    for key in keys.iter().take(N - 1).skip(1) {
+        tmp_1 = _mm_aesenc_si128(tmp_1, *key);
     }
+
+    _mm_aesenclast_si128(tmp_1, keys[N - 1])
 }
 
 // Uses aes to encrypt many values at once. This allows a substantial speedup (around 30%)
 // compared to the naive approach.
 #[allow(clippy::too_many_arguments)]
 #[inline(always)]
-fn aes_encrypt_many(
+unsafe fn aes_encrypt_many<const N: usize>(
     message_1: __m128i,
     message_2: __m128i,
     message_3: __m128i,
@@ -93,64 +188,70 @@ fn aes_encrypt_many(
     message_6: __m128i,
     message_7: __m128i,
     message_8: __m128i,
-    keys: &[__m128i; 11],
+    keys: &[__m128i; N],
 ) -> [__m128i; 8] {
-    unsafe {
-        let mut tmp_1 = _mm_xor_si128(message_1, keys[0]);
-        let mut tmp_2 = _mm_xor_si128(message_2, keys[0]);
-        let mut tmp_3 = _mm_xor_si128(message_3, keys[0]);
-        let mut tmp_4 = _mm_xor_si128(message_4, keys[0]);
-        let mut tmp_5 = _mm_xor_si128(message_5, keys[0]);
-        let mut tmp_6 = _mm_xor_si128(message_6, keys[0]);
-        let mut tmp_7 = _mm_xor_si128(message_7, keys[0]);
-        let mut tmp_8 = _mm_xor_si128(message_8, keys[0]);
+    const {
+        assert!(
+            N == AES_128_NUM_ROUND_KEYS || N == AES_256_NUM_ROUND_KEYS,
+            "invalid AES round key count"
+        )
+    };
+    let mut tmp_1 = _mm_xor_si128(message_1, keys[0]);
+    let mut tmp_2 = _mm_xor_si128(message_2, keys[0]);
+    let mut tmp_3 = _mm_xor_si128(message_3, keys[0]);
+    let mut tmp_4 = _mm_xor_si128(message_4, keys[0]);
+    let mut tmp_5 = _mm_xor_si128(message_5, keys[0]);
+    let mut tmp_6 = _mm_xor_si128(message_6, keys[0]);
+    let mut tmp_7 = _mm_xor_si128(message_7, keys[0]);
+    let mut tmp_8 = _mm_xor_si128(message_8, keys[0]);
 
-        for key in keys.iter().take(10).skip(1) {
-            tmp_1 = _mm_aesenc_si128(tmp_1, *key);
-            tmp_2 = _mm_aesenc_si128(tmp_2, *key);
-            tmp_3 = _mm_aesenc_si128(tmp_3, *key);
-            tmp_4 = _mm_aesenc_si128(tmp_4, *key);
-            tmp_5 = _mm_aesenc_si128(tmp_5, *key);
-            tmp_6 = _mm_aesenc_si128(tmp_6, *key);
-            tmp_7 = _mm_aesenc_si128(tmp_7, *key);
-            tmp_8 = _mm_aesenc_si128(tmp_8, *key);
-        }
-
-        tmp_1 = _mm_aesenclast_si128(tmp_1, keys[10]);
-        tmp_2 = _mm_aesenclast_si128(tmp_2, keys[10]);
-        tmp_3 = _mm_aesenclast_si128(tmp_3, keys[10]);
-        tmp_4 = _mm_aesenclast_si128(tmp_4, keys[10]);
-        tmp_5 = _mm_aesenclast_si128(tmp_5, keys[10]);
-        tmp_6 = _mm_aesenclast_si128(tmp_6, keys[10]);
-        tmp_7 = _mm_aesenclast_si128(tmp_7, keys[10]);
-        tmp_8 = _mm_aesenclast_si128(tmp_8, keys[10]);
-
-        [tmp_1, tmp_2, tmp_3, tmp_4, tmp_5, tmp_6, tmp_7, tmp_8]
+    for key in keys.iter().take(N - 1).skip(1) {
+        tmp_1 = _mm_aesenc_si128(tmp_1, *key);
+        tmp_2 = _mm_aesenc_si128(tmp_2, *key);
+        tmp_3 = _mm_aesenc_si128(tmp_3, *key);
+        tmp_4 = _mm_aesenc_si128(tmp_4, *key);
+        tmp_5 = _mm_aesenc_si128(tmp_5, *key);
+        tmp_6 = _mm_aesenc_si128(tmp_6, *key);
+        tmp_7 = _mm_aesenc_si128(tmp_7, *key);
+        tmp_8 = _mm_aesenc_si128(tmp_8, *key);
     }
+
+    tmp_1 = _mm_aesenclast_si128(tmp_1, keys[N - 1]);
+    tmp_2 = _mm_aesenclast_si128(tmp_2, keys[N - 1]);
+    tmp_3 = _mm_aesenclast_si128(tmp_3, keys[N - 1]);
+    tmp_4 = _mm_aesenclast_si128(tmp_4, keys[N - 1]);
+    tmp_5 = _mm_aesenclast_si128(tmp_5, keys[N - 1]);
+    tmp_6 = _mm_aesenclast_si128(tmp_6, keys[N - 1]);
+    tmp_7 = _mm_aesenclast_si128(tmp_7, keys[N - 1]);
+    tmp_8 = _mm_aesenclast_si128(tmp_8, keys[N - 1]);
+
+    [tmp_1, tmp_2, tmp_3, tmp_4, tmp_5, tmp_6, tmp_7, tmp_8]
 }
 
-fn aes_128_assist(temp1: __m128i, temp2: __m128i) -> __m128i {
-    let mut temp3: __m128i;
+#[inline(always)]
+unsafe fn aes_key_fold(mut temp1: __m128i, temp2: __m128i) -> __m128i {
+    let mut temp3 = _mm_slli_si128(temp1, 0x4);
+    temp1 = _mm_xor_si128(temp1, temp3);
+    temp3 = _mm_slli_si128(temp3, 0x4);
+    temp1 = _mm_xor_si128(temp1, temp3);
+    temp3 = _mm_slli_si128(temp3, 0x4);
+    temp1 = _mm_xor_si128(temp1, temp3);
+    _mm_xor_si128(temp1, temp2)
+}
+
+unsafe fn aes_128_assist(temp1: __m128i, temp2: __m128i) -> __m128i {
     let mut temp2 = temp2;
     let mut temp1 = temp1;
-    unsafe {
-        temp2 = _mm_shuffle_epi32(temp2, 0xff);
-        temp3 = _mm_slli_si128(temp1, 0x4);
-        temp1 = _mm_xor_si128(temp1, temp3);
-        temp3 = _mm_slli_si128(temp3, 0x4);
-        temp1 = _mm_xor_si128(temp1, temp3);
-        temp3 = _mm_slli_si128(temp3, 0x4);
-        temp1 = _mm_xor_si128(temp1, temp3);
-        temp1 = _mm_xor_si128(temp1, temp2);
-    }
+    temp2 = _mm_shuffle_epi32(temp2, 0xff);
+    temp1 = aes_key_fold(temp1, temp2);
     temp1
 }
 
 #[inline(always)]
-fn aes_128_key_expansion(key: __m128i, keys: &mut [__m128i; 11]) {
+unsafe fn aes_128_key_expansion(key: __m128i, keys: &mut [__m128i; AES_128_NUM_ROUND_KEYS]) {
     let (mut temp1, mut temp2): (__m128i, __m128i);
     temp1 = key;
-    unsafe {
+    {
         _mm_store_si128(keys.as_mut_ptr(), temp1);
         temp2 = _mm_aeskeygenassist_si128(temp1, 0x01);
         temp1 = aes_128_assist(temp1, temp2);
@@ -185,12 +286,81 @@ fn aes_128_key_expansion(key: __m128i, keys: &mut [__m128i; 11]) {
     }
 }
 
+unsafe fn aes_256_assist_1(temp1: __m128i, temp2: __m128i) -> __m128i {
+    aes_128_assist(temp1, temp2)
+}
+
+unsafe fn aes_256_assist_2(temp1: __m128i, temp3: __m128i) -> __m128i {
+    let temp4 = _mm_aeskeygenassist_si128(temp1, 0x0);
+    let temp2 = _mm_shuffle_epi32(temp4, 0xaa);
+    aes_key_fold(temp3, temp2)
+}
+
+#[target_feature(enable = "sse2,aes")]
+unsafe fn generate_round_keys_256(key: Aes256Key) -> [__m128i; AES_256_NUM_ROUND_KEYS] {
+    let mut keys: [__m128i; AES_256_NUM_ROUND_KEYS] = [u128_to_si128(0); AES_256_NUM_ROUND_KEYS];
+
+    let first_half: [u8; 16] = key.0[..16].try_into().expect("infallible");
+    let second_half: [u8; 16] = key.0[16..].try_into().expect("infallible");
+
+    let mut temp1: __m128i = transmute(first_half);
+    let mut temp2: __m128i;
+    let mut temp3: __m128i = transmute(second_half);
+
+    keys[0] = temp1;
+    keys[1] = temp3;
+
+    temp2 = _mm_aeskeygenassist_si128(temp3, 0x01);
+    temp1 = aes_256_assist_1(temp1, temp2);
+    keys[2] = temp1;
+    temp3 = aes_256_assist_2(temp1, temp3);
+    keys[3] = temp3;
+
+    temp2 = _mm_aeskeygenassist_si128(temp3, 0x02);
+    temp1 = aes_256_assist_1(temp1, temp2);
+    keys[4] = temp1;
+    temp3 = aes_256_assist_2(temp1, temp3);
+    keys[5] = temp3;
+
+    temp2 = _mm_aeskeygenassist_si128(temp3, 0x04);
+    temp1 = aes_256_assist_1(temp1, temp2);
+    keys[6] = temp1;
+    temp3 = aes_256_assist_2(temp1, temp3);
+    keys[7] = temp3;
+
+    temp2 = _mm_aeskeygenassist_si128(temp3, 0x08);
+    temp1 = aes_256_assist_1(temp1, temp2);
+    keys[8] = temp1;
+    temp3 = aes_256_assist_2(temp1, temp3);
+    keys[9] = temp3;
+
+    temp2 = _mm_aeskeygenassist_si128(temp3, 0x10);
+    temp1 = aes_256_assist_1(temp1, temp2);
+    keys[10] = temp1;
+    temp3 = aes_256_assist_2(temp1, temp3);
+    keys[11] = temp3;
+
+    temp2 = _mm_aeskeygenassist_si128(temp3, 0x20);
+    temp1 = aes_256_assist_1(temp1, temp2);
+    keys[12] = temp1;
+    temp3 = aes_256_assist_2(temp1, temp3);
+    keys[13] = temp3;
+
+    // The last round only needs `aes_256_assist_1`: the schedule is 60 words (15 round keys), so
+    // it stops on the `i % 8 == 0` branch. A trailing `aes_256_assist_2` would compute a 16th key.
+    temp2 = _mm_aeskeygenassist_si128(temp3, 0x40);
+    temp1 = aes_256_assist_1(temp1, temp2);
+    keys[14] = temp1;
+
+    keys
+}
+
 #[inline(always)]
 fn u128_to_si128(input: u128) -> __m128i {
     unsafe { transmute(input) }
 }
 
-#[allow(unused)] // to please clippy when tests are not activated
+#[cfg(test)]
 fn si128_to_u128(input: __m128i) -> u128 {
     unsafe { transmute(input) }
 }
@@ -203,58 +373,65 @@ fn si128arr_to_u8arr(input: [__m128i; 8]) -> [u8; BYTES_PER_BATCH] {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::generators::aes_ctr::block_cipher_generic_test;
 
-    // Test vector for aes128, from the FIPS publication 197
-    const CIPHER_KEY: u128 = u128::from_be(0x000102030405060708090a0b0c0d0e0f);
-    const KEY_SCHEDULE: [u128; 11] = [
-        u128::from_be(0x000102030405060708090a0b0c0d0e0f),
-        u128::from_be(0xd6aa74fdd2af72fadaa678f1d6ab76fe),
-        u128::from_be(0xb692cf0b643dbdf1be9bc5006830b3fe),
-        u128::from_be(0xb6ff744ed2c2c9bf6c590cbf0469bf41),
-        u128::from_be(0x47f7f7bc95353e03f96c32bcfd058dfd),
-        u128::from_be(0x3caaa3e8a99f9deb50f3af57adf622aa),
-        u128::from_be(0x5e390f7df7a69296a7553dc10aa31f6b),
-        u128::from_be(0x14f9701ae35fe28c440adf4d4ea9c026),
-        u128::from_be(0x47438735a41c65b9e016baf4aebf7ad2),
-        u128::from_be(0x549932d1f08557681093ed9cbe2c974e),
-        u128::from_be(0x13111d7fe3944a17f307a78b4d2b30c5),
-    ];
-    const PLAINTEXT: u128 = u128::from_be(0x00112233445566778899aabbccddeeff);
-    const CIPHERTEXT: u128 = u128::from_be(0x69c4e0d86a7b0430d8cdb78070b4c55a);
+    // SAFETY (both closures): the aesni module is only compiled in on x86_64, and the round key
+    // generation is otherwise guarded by the cpu feature check in `AesniKey::generate_round_keys`.
 
     #[test]
     fn test_generate_key_schedule() {
-        // Checks that the round keys are correctly generated from the sample key from FIPS
-        let key = u128_to_si128(CIPHER_KEY);
-        let mut keys: [__m128i; 11] = [u128_to_si128(0); 11];
-        aes_128_key_expansion(key, &mut keys);
-        for (expected, actual) in KEY_SCHEDULE.iter().zip(keys.iter()) {
-            assert_eq!(*expected, si128_to_u128(*actual));
-        }
+        block_cipher_generic_test::test_key_schedule_128(|key| {
+            unsafe { generate_round_keys_128(key) }.map(si128_to_u128)
+        });
     }
 
     #[test]
-    fn test_encrypt_many_messages() {
-        // Checks that encrypting many plaintext at the same time gives the correct output.
-        let message = u128_to_si128(PLAINTEXT);
-        let key = u128_to_si128(CIPHER_KEY);
-        let mut keys: [__m128i; 11] = [u128_to_si128(0); 11];
-        aes_128_key_expansion(key, &mut keys);
-        let ciphertexts = aes_encrypt_many(
-            message, message, message, message, message, message, message, message, &keys,
-        );
-        for ct in &ciphertexts {
-            assert_eq!(CIPHERTEXT, si128_to_u128(*ct));
-        }
+    fn test_generate_key_schedule_256() {
+        block_cipher_generic_test::test_key_schedule_256(|key| {
+            unsafe { generate_round_keys_256(key) }.map(si128_to_u128)
+        });
     }
 
     #[test]
     fn test_encrypt_one_message() {
-        let message = u128_to_si128(PLAINTEXT);
-        let key = u128_to_si128(CIPHER_KEY);
-        let mut keys: [__m128i; 11] = [u128_to_si128(0); 11];
-        aes_128_key_expansion(key, &mut keys);
-        let ciphertext = aes_encrypt_one(message, &keys);
-        assert_eq!(CIPHERTEXT, si128_to_u128(ciphertext));
+        block_cipher_generic_test::test_fips197_c1_single_block::<Aesni128BlockCipher>();
+    }
+
+    #[test]
+    fn test_encrypt_many_messages() {
+        block_cipher_generic_test::test_fips197_c1_batch::<Aesni128BlockCipher>();
+    }
+
+    #[test]
+    fn test_encrypt_one_message_256() {
+        block_cipher_generic_test::test_fips197_c3_single_block::<Aesni256BlockCipher>();
+    }
+
+    #[test]
+    fn test_encrypt_many_messages_256() {
+        block_cipher_generic_test::test_fips197_c3_batch::<Aesni256BlockCipher>();
+    }
+
+    #[test]
+    fn test_nist_vectors_256() {
+        block_cipher_generic_test::test_nist_ecb_aes256_single_blocks::<Aesni256BlockCipher>();
+    }
+
+    #[test]
+    fn test_nist_vectors_256_batch() {
+        block_cipher_generic_test::test_nist_ecb_aes256_batch::<Aesni256BlockCipher>();
+    }
+
+    #[test]
+    fn test_encrypt_many_matches_encrypt_one_256() {
+        block_cipher_generic_test::test_batch_matches_single_aes256::<Aesni256BlockCipher>();
+    }
+
+    #[test]
+    fn test_aes128_and_aes256_differ() {
+        block_cipher_generic_test::test_aes128_and_aes256_differ::<
+            Aesni128BlockCipher,
+            Aesni256BlockCipher,
+        >();
     }
 }

--- a/tfhe-csprng/src/generators/implem/aesni/generator.rs
+++ b/tfhe-csprng/src/generators/implem/aesni/generator.rs
@@ -1,14 +1,15 @@
 use crate::generators::aes_ctr::{AesCtrGenerator, AesCtrParams, ChildrenIterator, TableIndex};
-use crate::generators::implem::aesni::block_cipher::AesniBlockCipher;
-use crate::generators::{ByteCount, BytesPerChild, ChildrenCount, ForkError, RandomGenerator};
+use crate::generators::{
+    Aesni, AnyAesBlockCipher, ByteCount, BytesPerChild, ChildrenCount, ForkError, RandomGenerator,
+};
 
 /// A random number generator using the `aesni` instructions.
-pub struct AesniRandomGenerator(pub(super) AesCtrGenerator<AesniBlockCipher>);
+pub struct AesniRandomGenerator(pub(super) AesCtrGenerator<AnyAesBlockCipher<Aesni>>);
 
 /// The children iterator used by [`AesniRandomGenerator`].
 ///
 /// Outputs children generators one by one.
-pub struct AesniChildrenIterator(ChildrenIterator<AesniBlockCipher>);
+pub struct AesniChildrenIterator(ChildrenIterator<AnyAesBlockCipher<Aesni>>);
 
 impl Iterator for AesniChildrenIterator {
     type Item = AesniRandomGenerator;
@@ -52,52 +53,52 @@ impl Iterator for AesniRandomGenerator {
 #[cfg(test)]
 mod test {
     use crate::generators::aes_ctr::aes_ctr_generic_test;
-    use crate::generators::implem::aesni::block_cipher::AesniBlockCipher;
+    use crate::generators::implem::aesni::block_cipher::Aesni128BlockCipher;
     use crate::generators::{generator_generic_test, AesniRandomGenerator};
 
     #[test]
     fn prop_fork_first_state_table_index() {
-        aes_ctr_generic_test::prop_fork_first_state_table_index::<AesniBlockCipher>();
+        aes_ctr_generic_test::prop_fork_first_state_table_index::<Aesni128BlockCipher>();
     }
 
     #[test]
     fn prop_fork_last_bound_table_index() {
-        aes_ctr_generic_test::prop_fork_last_bound_table_index::<AesniBlockCipher>();
+        aes_ctr_generic_test::prop_fork_last_bound_table_index::<Aesni128BlockCipher>();
     }
 
     #[test]
     fn prop_fork_parent_bound_table_index() {
-        aes_ctr_generic_test::prop_fork_parent_bound_table_index::<AesniBlockCipher>();
+        aes_ctr_generic_test::prop_fork_parent_bound_table_index::<Aesni128BlockCipher>();
     }
 
     #[test]
     fn prop_fork_parent_state_table_index() {
-        aes_ctr_generic_test::prop_fork_parent_state_table_index::<AesniBlockCipher>();
+        aes_ctr_generic_test::prop_fork_parent_state_table_index::<Aesni128BlockCipher>();
     }
 
     #[test]
     fn prop_fork() {
-        aes_ctr_generic_test::prop_fork::<AesniBlockCipher>();
+        aes_ctr_generic_test::prop_fork::<Aesni128BlockCipher>();
     }
 
     #[test]
     fn prop_fork_with_parent_continuation() {
-        aes_ctr_generic_test::prop_fork_with_parent_continuation::<AesniBlockCipher>();
+        aes_ctr_generic_test::prop_fork_with_parent_continuation::<Aesni128BlockCipher>();
     }
 
     #[test]
     fn prop_fork_children_remaining_bytes() {
-        aes_ctr_generic_test::prop_fork_children_remaining_bytes::<AesniBlockCipher>();
+        aes_ctr_generic_test::prop_fork_children_remaining_bytes::<Aesni128BlockCipher>();
     }
 
     #[test]
     fn prop_fork_parent_remaining_bytes() {
-        aes_ctr_generic_test::prop_fork_parent_remaining_bytes::<AesniBlockCipher>();
+        aes_ctr_generic_test::prop_fork_parent_remaining_bytes::<Aesni128BlockCipher>();
     }
 
     #[test]
     fn prop_different_offset_means_different_output() {
-        aes_ctr_generic_test::prop_different_offset_means_different_output::<AesniBlockCipher>();
+        aes_ctr_generic_test::prop_different_offset_means_different_output::<Aesni128BlockCipher>();
     }
 
     #[test]
@@ -107,12 +108,12 @@ mod test {
 
     #[test]
     fn test_conformance_with_ctr_crate() {
-        aes_ctr_generic_test::test_conformance_with_ctr_crate::<AesniBlockCipher>();
+        aes_ctr_generic_test::test_conformance_with_ctr_crate::<Aesni128BlockCipher>();
     }
 
     #[test]
     fn test_forking_conformance_with_ctr_crate() {
-        aes_ctr_generic_test::test_forking_conformance_with_ctr_crate::<AesniBlockCipher>();
+        aes_ctr_generic_test::test_forking_conformance_with_ctr_crate::<Aesni128BlockCipher>();
     }
 
     #[test]

--- a/tfhe-csprng/src/generators/implem/aesni/mod.rs
+++ b/tfhe-csprng/src/generators/implem/aesni/mod.rs
@@ -5,7 +5,7 @@
 //! [intel aesni white paper 323641-001 revision 3.0](https://www.intel.com/content/dam/doc/white-paper/advanced-encryption-standard-new-instructions-set-paper.pdf).
 
 mod block_cipher;
-pub use block_cipher::AesniBlockCipher;
+pub use block_cipher::{Aesni, Aesni128BlockCipher, Aesni256BlockCipher};
 
 mod generator;
 pub use generator::*;

--- a/tfhe-csprng/src/generators/implem/aesni/parallel.rs
+++ b/tfhe-csprng/src/generators/implem/aesni/parallel.rs
@@ -1,7 +1,8 @@
 use super::*;
 use crate::generators::aes_ctr::{AesCtrGenerator, ParallelChildrenIterator};
-use crate::generators::implem::aesni::block_cipher::AesniBlockCipher;
-use crate::generators::{BytesPerChild, ChildrenCount, ForkError, ParallelRandomGenerator};
+use crate::generators::{
+    AnyAesBlockCipher, BytesPerChild, ChildrenCount, ForkError, ParallelRandomGenerator,
+};
 use rayon::iter::plumbing::{Consumer, ProducerCallback, UnindexedConsumer};
 use rayon::prelude::*;
 
@@ -11,8 +12,8 @@ use rayon::prelude::*;
 #[allow(clippy::type_complexity)]
 pub struct ParallelAesniChildrenIterator(
     rayon::iter::Map<
-        ParallelChildrenIterator<AesniBlockCipher>,
-        fn(AesCtrGenerator<AesniBlockCipher>) -> AesniRandomGenerator,
+        ParallelChildrenIterator<AnyAesBlockCipher<Aesni>>,
+        fn(AesCtrGenerator<AnyAesBlockCipher<Aesni>>) -> AesniRandomGenerator,
     >,
 );
 
@@ -55,51 +56,52 @@ impl ParallelRandomGenerator for AesniRandomGenerator {
 #[cfg(test)]
 mod test {
     use crate::generators::aes_ctr::aes_ctr_parallel_generic_tests;
-    use crate::generators::implem::aesni::block_cipher::AesniBlockCipher;
+    use crate::generators::implem::aesni::block_cipher::Aesni128BlockCipher;
 
     #[test]
     fn prop_fork_first_state_table_index() {
-        aes_ctr_parallel_generic_tests::prop_fork_first_state_table_index::<AesniBlockCipher>();
+        aes_ctr_parallel_generic_tests::prop_fork_first_state_table_index::<Aesni128BlockCipher>();
     }
 
     #[test]
     fn prop_fork_last_bound_table_index() {
-        aes_ctr_parallel_generic_tests::prop_fork_last_bound_table_index::<AesniBlockCipher>();
+        aes_ctr_parallel_generic_tests::prop_fork_last_bound_table_index::<Aesni128BlockCipher>();
     }
 
     #[test]
     fn prop_fork_parent_bound_table_index() {
-        aes_ctr_parallel_generic_tests::prop_fork_parent_bound_table_index::<AesniBlockCipher>();
+        aes_ctr_parallel_generic_tests::prop_fork_parent_bound_table_index::<Aesni128BlockCipher>();
     }
 
     #[test]
     fn prop_fork_parent_state_table_index() {
-        aes_ctr_parallel_generic_tests::prop_fork_parent_state_table_index::<AesniBlockCipher>();
+        aes_ctr_parallel_generic_tests::prop_fork_parent_state_table_index::<Aesni128BlockCipher>();
     }
 
     #[test]
     fn prop_fork_ttt() {
-        aes_ctr_parallel_generic_tests::prop_fork::<AesniBlockCipher>();
+        aes_ctr_parallel_generic_tests::prop_fork::<Aesni128BlockCipher>();
     }
 
     #[test]
     fn prop_fork_children_remaining_bytes() {
-        aes_ctr_parallel_generic_tests::prop_fork_children_remaining_bytes::<AesniBlockCipher>();
+        aes_ctr_parallel_generic_tests::prop_fork_children_remaining_bytes::<Aesni128BlockCipher>();
     }
 
     #[test]
     fn prop_fork_parent_remaining_bytes() {
-        aes_ctr_parallel_generic_tests::prop_fork_parent_remaining_bytes::<AesniBlockCipher>();
+        aes_ctr_parallel_generic_tests::prop_fork_parent_remaining_bytes::<Aesni128BlockCipher>();
     }
 
     #[test]
     fn prop_fork_with_parent_continuation() {
-        aes_ctr_parallel_generic_tests::prop_fork_with_parent_continuation::<AesniBlockCipher>();
+        aes_ctr_parallel_generic_tests::prop_fork_with_parent_continuation::<Aesni128BlockCipher>();
     }
 
     #[test]
     fn test_forking_conformance_with_ctr_crate() {
-        aes_ctr_parallel_generic_tests::test_forking_conformance_with_ctr_crate::<AesniBlockCipher>(
-        );
+        aes_ctr_parallel_generic_tests::test_forking_conformance_with_ctr_crate::<
+            Aesni128BlockCipher,
+        >();
     }
 }

--- a/tfhe-csprng/src/generators/implem/dynamic.rs
+++ b/tfhe-csprng/src/generators/implem/dynamic.rs
@@ -1,0 +1,81 @@
+//! A module with generic wrapper to handle at runtime either AES-128  or AES-256
+use crate::generators::aes_ctr::{
+    Aes128BlockCipher, Aes128Key, Aes256BlockCipher, Aes256Key, AesBlockCipher,
+    AES_CALLS_PER_BATCH, BYTES_PER_AES_CALL,
+};
+
+/// An AES backend of the crate shall implement the needed variants of AES
+pub trait AesBackend {
+    type Aes128BlockCipher: Aes128BlockCipher;
+    type Aes256BlockCipher: Aes256BlockCipher;
+}
+
+pub enum AnyAesKey {
+    Aes128(Aes128Key),
+    Aes256(Aes256Key),
+}
+
+impl From<Aes128Key> for AnyAesKey {
+    fn from(key: Aes128Key) -> Self {
+        Self::Aes128(key)
+    }
+}
+
+impl From<Aes256Key> for AnyAesKey {
+    fn from(key: Aes256Key) -> Self {
+        Self::Aes256(key)
+    }
+}
+
+pub enum AnyAesBlockCipher<B>
+where
+    B: AesBackend,
+{
+    Aes128(B::Aes128BlockCipher),
+    Aes256(B::Aes256BlockCipher),
+}
+
+// Written by hand rather than derived: `#[derive(Clone)]` would emit a `B: Clone` bound, but `B` is
+// only a marker and never stored. The variants get `Clone` from the `AesBlockCipher` supertrait.
+impl<B> Clone for AnyAesBlockCipher<B>
+where
+    B: AesBackend,
+{
+    fn clone(&self) -> Self {
+        match self {
+            Self::Aes128(aes) => Self::Aes128(aes.clone()),
+            Self::Aes256(aes) => Self::Aes256(aes.clone()),
+        }
+    }
+}
+
+impl<B> AesBlockCipher for AnyAesBlockCipher<B>
+where
+    B: AesBackend,
+{
+    type Key = AnyAesKey;
+
+    fn new(key: Self::Key) -> Self {
+        match key {
+            AnyAesKey::Aes128(key) => Self::Aes128(B::Aes128BlockCipher::new(key)),
+            AnyAesKey::Aes256(key) => Self::Aes256(B::Aes256BlockCipher::new(key)),
+        }
+    }
+
+    fn generate_batch(
+        &mut self,
+        data: [u128; AES_CALLS_PER_BATCH],
+    ) -> [u8; crate::generators::aes_ctr::BYTES_PER_BATCH] {
+        match self {
+            Self::Aes128(aes) => aes.generate_batch(data),
+            Self::Aes256(aes) => aes.generate_batch(data),
+        }
+    }
+
+    fn generate_next(&mut self, data: u128) -> [u8; BYTES_PER_AES_CALL] {
+        match self {
+            Self::Aes128(aes) => aes.generate_next(data),
+            Self::Aes256(aes) => aes.generate_next(data),
+        }
+    }
+}

--- a/tfhe-csprng/src/generators/implem/mod.rs
+++ b/tfhe-csprng/src/generators/implem/mod.rs
@@ -10,3 +10,6 @@ pub use aarch64::*;
 
 mod soft;
 pub use soft::*;
+
+pub mod dynamic;
+pub use dynamic::*;

--- a/tfhe-csprng/src/generators/implem/soft/block_cipher.rs
+++ b/tfhe-csprng/src/generators/implem/soft/block_cipher.rs
@@ -1,21 +1,33 @@
 use crate::generators::aes_ctr::{
-    AesBlockCipher, AesKey, AES_CALLS_PER_BATCH, BYTES_PER_AES_CALL, BYTES_PER_BATCH,
+    Aes128Key, Aes256Key, AesBlockCipher, AES_CALLS_PER_BATCH, BYTES_PER_AES_CALL, BYTES_PER_BATCH,
 };
+use aes::cipher::consts::U16;
 use aes::cipher::{BlockCipherEncrypt, KeyInit};
-use aes::{Aes128, Block};
+use aes::{Aes128, Aes256, Block};
+
+#[derive(Copy, Clone)]
+pub struct Software;
+
+impl crate::generators::implem::AesBackend for Software {
+    type Aes128BlockCipher = SoftwareAes128BlockCipher;
+
+    type Aes256BlockCipher = SoftwareAes256BlockCipher;
+}
 
 #[derive(Clone)]
-pub struct SoftwareBlockCipher {
+pub struct SoftwareAes128BlockCipher {
     // Aes structure
     aes: Aes128,
 }
 
-impl AesBlockCipher for SoftwareBlockCipher {
-    fn new(key: AesKey) -> SoftwareBlockCipher {
+impl AesBlockCipher for SoftwareAes128BlockCipher {
+    type Key = Aes128Key;
+
+    fn new(key: Self::Key) -> SoftwareAes128BlockCipher {
         let key: [u8; BYTES_PER_AES_CALL] = key.0.to_ne_bytes();
         let key = Block::from(key);
         let aes = Aes128::new(&key);
-        SoftwareBlockCipher { aes }
+        SoftwareAes128BlockCipher { aes }
     }
 
     fn generate_batch(&mut self, data: [u128; AES_CALLS_PER_BATCH]) -> [u8; BYTES_PER_BATCH] {
@@ -29,7 +41,35 @@ impl AesBlockCipher for SoftwareBlockCipher {
     }
 }
 
-fn aes_encrypt_one(message: u128, cipher: &Aes128) -> [u8; BYTES_PER_AES_CALL] {
+#[derive(Clone)]
+pub struct SoftwareAes256BlockCipher {
+    // Aes structure
+    aes: Aes256,
+}
+
+impl AesBlockCipher for SoftwareAes256BlockCipher {
+    type Key = Aes256Key;
+
+    fn new(key: Self::Key) -> Self {
+        let aes = Aes256::new(&key.0.into());
+        SoftwareAes256BlockCipher { aes }
+    }
+
+    fn generate_batch(&mut self, data: [u128; AES_CALLS_PER_BATCH]) -> [u8; BYTES_PER_BATCH] {
+        aes_encrypt_many(
+            data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7], &self.aes,
+        )
+    }
+
+    fn generate_next(&mut self, data: u128) -> [u8; BYTES_PER_AES_CALL] {
+        aes_encrypt_one(data, &self.aes)
+    }
+}
+
+fn aes_encrypt_one<G>(message: u128, cipher: &G) -> [u8; BYTES_PER_AES_CALL]
+where
+    G: BlockCipherEncrypt<BlockSize = U16>,
+{
     let mut b1 = Block::from(message.to_ne_bytes());
 
     cipher.encrypt_block(&mut b1);
@@ -40,7 +80,7 @@ fn aes_encrypt_one(message: u128, cipher: &Aes128) -> [u8; BYTES_PER_AES_CALL] {
 // Uses aes to encrypt many values at once. This allows a substantial speedup (around 30%)
 // compared to the naive approach.
 #[allow(clippy::too_many_arguments)]
-fn aes_encrypt_many(
+fn aes_encrypt_many<G>(
     message_1: u128,
     message_2: u128,
     message_3: u128,
@@ -49,8 +89,11 @@ fn aes_encrypt_many(
     message_6: u128,
     message_7: u128,
     message_8: u128,
-    cipher: &Aes128,
-) -> [u8; BYTES_PER_BATCH] {
+    cipher: &G,
+) -> [u8; BYTES_PER_BATCH]
+where
+    G: BlockCipherEncrypt<BlockSize = U16>,
+{
     let mut b1 = Block::from(message_1.to_ne_bytes());
     let mut b2 = Block::from(message_2.to_ne_bytes());
     let mut b3 = Block::from(message_3.to_ne_bytes());
@@ -86,39 +129,49 @@ fn aes_encrypt_many(
 #[cfg(test)]
 mod test {
     use super::*;
-
-    // Test vector for aes128, from the FIPS publication 197
-    const CIPHER_KEY: u128 = u128::from_be(0x000102030405060708090a0b0c0d0e0f);
-    const PLAINTEXT: u128 = u128::from_be(0x00112233445566778899aabbccddeeff);
-    const CIPHERTEXT: u128 = u128::from_be(0x69c4e0d86a7b0430d8cdb78070b4c55a);
-
-    #[test]
-    fn test_encrypt_many_messages() {
-        // Checks that encrypting many plaintext at the same time gives the correct output.
-        let key: [u8; BYTES_PER_AES_CALL] = CIPHER_KEY.to_ne_bytes();
-        let aes = Aes128::new(&Block::from(key));
-        let ciphertexts = aes_encrypt_many(
-            PLAINTEXT, PLAINTEXT, PLAINTEXT, PLAINTEXT, PLAINTEXT, PLAINTEXT, PLAINTEXT, PLAINTEXT,
-            &aes,
-        );
-        let ciphertexts: [u8; BYTES_PER_BATCH] = ciphertexts[..].try_into().unwrap();
-        for i in 0..8 {
-            assert_eq!(
-                u128::from_ne_bytes(
-                    ciphertexts[BYTES_PER_AES_CALL * i..BYTES_PER_AES_CALL * (i + 1)]
-                        .try_into()
-                        .unwrap()
-                ),
-                CIPHERTEXT
-            );
-        }
-    }
+    use crate::generators::aes_ctr::block_cipher_generic_test;
 
     #[test]
     fn test_encrypt_one_message() {
-        let key: [u8; BYTES_PER_AES_CALL] = CIPHER_KEY.to_ne_bytes();
-        let aes = Aes128::new(&Block::from(key));
-        let ciphertext = aes_encrypt_one(PLAINTEXT, &aes);
-        assert_eq!(u128::from_ne_bytes(ciphertext), CIPHERTEXT);
+        block_cipher_generic_test::test_fips197_c1_single_block::<SoftwareAes128BlockCipher>();
+    }
+
+    #[test]
+    fn test_encrypt_many_messages() {
+        block_cipher_generic_test::test_fips197_c1_batch::<SoftwareAes128BlockCipher>();
+    }
+
+    #[test]
+    fn test_encrypt_one_message_256() {
+        block_cipher_generic_test::test_fips197_c3_single_block::<SoftwareAes256BlockCipher>();
+    }
+
+    #[test]
+    fn test_encrypt_many_messages_256() {
+        block_cipher_generic_test::test_fips197_c3_batch::<SoftwareAes256BlockCipher>();
+    }
+
+    #[test]
+    fn test_nist_vectors_256() {
+        block_cipher_generic_test::test_nist_ecb_aes256_single_blocks::<SoftwareAes256BlockCipher>(
+        );
+    }
+
+    #[test]
+    fn test_nist_vectors_256_batch() {
+        block_cipher_generic_test::test_nist_ecb_aes256_batch::<SoftwareAes256BlockCipher>();
+    }
+
+    #[test]
+    fn test_encrypt_many_matches_encrypt_one_256() {
+        block_cipher_generic_test::test_batch_matches_single_aes256::<SoftwareAes256BlockCipher>();
+    }
+
+    #[test]
+    fn test_aes128_and_aes256_differ() {
+        block_cipher_generic_test::test_aes128_and_aes256_differ::<
+            SoftwareAes128BlockCipher,
+            SoftwareAes256BlockCipher,
+        >();
     }
 }

--- a/tfhe-csprng/src/generators/implem/soft/generator.rs
+++ b/tfhe-csprng/src/generators/implem/soft/generator.rs
@@ -1,14 +1,16 @@
 use crate::generators::aes_ctr::{AesCtrGenerator, AesCtrParams, ChildrenIterator, TableIndex};
-use crate::generators::implem::soft::block_cipher::SoftwareBlockCipher;
-use crate::generators::{ByteCount, BytesPerChild, ChildrenCount, ForkError, RandomGenerator};
+use crate::generators::{
+    AnyAesBlockCipher, ByteCount, BytesPerChild, ChildrenCount, ForkError, RandomGenerator,
+    Software,
+};
 
 /// A random number generator using a software implementation.
-pub struct SoftwareRandomGenerator(pub(super) AesCtrGenerator<SoftwareBlockCipher>);
+pub struct SoftwareRandomGenerator(pub(super) AesCtrGenerator<AnyAesBlockCipher<Software>>);
 
 /// The children iterator used by [`SoftwareRandomGenerator`].
 ///
 /// Outputs children generators one by one.
-pub struct SoftwareChildrenIterator(ChildrenIterator<SoftwareBlockCipher>);
+pub struct SoftwareChildrenIterator(ChildrenIterator<AnyAesBlockCipher<Software>>);
 
 impl Iterator for SoftwareChildrenIterator {
     type Item = SoftwareRandomGenerator;
@@ -53,59 +55,62 @@ impl Iterator for SoftwareRandomGenerator {
 mod test {
     use super::*;
     use crate::generators::aes_ctr::aes_ctr_generic_test;
-    use crate::generators::generator_generic_test;
+    use crate::generators::{generator_generic_test, SoftwareAes128BlockCipher};
 
     // We use powerpc64 as the target to test behavior on big-endian
     // However, we run these tests using an emulator. Thus, these get really slow
     // so we skip them
     #[cfg(not(target_arch = "powerpc64"))]
     mod fork_tests {
+        use crate::generators::SoftwareAes128BlockCipher;
+
         use super::*;
 
         #[test]
         fn prop_fork_first_state_table_index() {
-            aes_ctr_generic_test::prop_fork_first_state_table_index::<SoftwareBlockCipher>();
+            aes_ctr_generic_test::prop_fork_first_state_table_index::<SoftwareAes128BlockCipher>();
         }
 
         #[test]
         fn prop_fork_last_bound_table_index() {
-            aes_ctr_generic_test::prop_fork_last_bound_table_index::<SoftwareBlockCipher>();
+            aes_ctr_generic_test::prop_fork_last_bound_table_index::<SoftwareAes128BlockCipher>();
         }
 
         #[test]
         fn prop_fork_parent_bound_table_index() {
-            aes_ctr_generic_test::prop_fork_parent_bound_table_index::<SoftwareBlockCipher>();
+            aes_ctr_generic_test::prop_fork_parent_bound_table_index::<SoftwareAes128BlockCipher>();
         }
 
         #[test]
         fn prop_fork_parent_state_table_index() {
-            aes_ctr_generic_test::prop_fork_parent_state_table_index::<SoftwareBlockCipher>();
+            aes_ctr_generic_test::prop_fork_parent_state_table_index::<SoftwareAes128BlockCipher>();
         }
 
         #[test]
         fn prop_fork() {
-            aes_ctr_generic_test::prop_fork::<SoftwareBlockCipher>();
+            aes_ctr_generic_test::prop_fork::<SoftwareAes128BlockCipher>();
         }
 
         #[test]
         fn prop_fork_with_parent_continuation() {
-            aes_ctr_generic_test::prop_fork_with_parent_continuation::<SoftwareBlockCipher>();
+            aes_ctr_generic_test::prop_fork_with_parent_continuation::<SoftwareAes128BlockCipher>();
         }
 
         #[test]
         fn prop_fork_children_remaining_bytes() {
-            aes_ctr_generic_test::prop_fork_children_remaining_bytes::<SoftwareBlockCipher>();
+            aes_ctr_generic_test::prop_fork_children_remaining_bytes::<SoftwareAes128BlockCipher>();
         }
 
         #[test]
         fn prop_fork_parent_remaining_bytes() {
-            aes_ctr_generic_test::prop_fork_parent_remaining_bytes::<SoftwareBlockCipher>();
+            aes_ctr_generic_test::prop_fork_parent_remaining_bytes::<SoftwareAes128BlockCipher>();
         }
 
         #[test]
         fn prop_different_offset_means_different_output() {
-            aes_ctr_generic_test::prop_different_offset_means_different_output::<SoftwareBlockCipher>(
-            );
+            aes_ctr_generic_test::prop_different_offset_means_different_output::<
+                SoftwareAes128BlockCipher,
+            >();
         }
 
         #[test]
@@ -121,12 +126,13 @@ mod test {
 
     #[test]
     fn test_conformance_with_ctr_crate() {
-        aes_ctr_generic_test::test_conformance_with_ctr_crate::<SoftwareBlockCipher>();
+        aes_ctr_generic_test::test_conformance_with_ctr_crate::<SoftwareAes128BlockCipher>();
     }
 
     #[test]
     fn test_forking_conformance_with_ctr_crate() {
-        aes_ctr_generic_test::test_forking_conformance_with_ctr_crate::<SoftwareBlockCipher>();
+        aes_ctr_generic_test::test_forking_conformance_with_ctr_crate::<SoftwareAes128BlockCipher>(
+        );
     }
 
     #[test]

--- a/tfhe-csprng/src/generators/implem/soft/mod.rs
+++ b/tfhe-csprng/src/generators/implem/soft/mod.rs
@@ -1,7 +1,7 @@
 //! A module using a software fallback implementation of random number generator.
 
 mod block_cipher;
-pub use block_cipher::SoftwareBlockCipher;
+pub use block_cipher::{Software, SoftwareAes128BlockCipher, SoftwareAes256BlockCipher};
 
 mod generator;
 pub use generator::*;

--- a/tfhe-csprng/src/generators/implem/soft/parallel.rs
+++ b/tfhe-csprng/src/generators/implem/soft/parallel.rs
@@ -1,7 +1,8 @@
 use super::*;
 use crate::generators::aes_ctr::{AesCtrGenerator, ParallelChildrenIterator};
-use crate::generators::implem::soft::block_cipher::SoftwareBlockCipher;
-use crate::generators::{BytesPerChild, ChildrenCount, ForkError, ParallelRandomGenerator};
+use crate::generators::{
+    AnyAesBlockCipher, BytesPerChild, ChildrenCount, ForkError, ParallelRandomGenerator,
+};
 use rayon::iter::plumbing::{Consumer, ProducerCallback, UnindexedConsumer};
 use rayon::prelude::*;
 
@@ -11,8 +12,8 @@ use rayon::prelude::*;
 #[allow(clippy::type_complexity)]
 pub struct ParallelSoftwareChildrenIterator(
     rayon::iter::Map<
-        ParallelChildrenIterator<SoftwareBlockCipher>,
-        fn(AesCtrGenerator<SoftwareBlockCipher>) -> SoftwareRandomGenerator,
+        ParallelChildrenIterator<AnyAesBlockCipher<Software>>,
+        fn(AesCtrGenerator<AnyAesBlockCipher<Software>>) -> SoftwareRandomGenerator,
     >,
 );
 
@@ -59,48 +60,60 @@ mod test {
 
     #[test]
     fn prop_fork_first_state_table_index() {
-        aes_ctr_parallel_generic_tests::prop_fork_first_state_table_index::<SoftwareBlockCipher>();
+        aes_ctr_parallel_generic_tests::prop_fork_first_state_table_index::<
+            SoftwareAes128BlockCipher,
+        >();
     }
 
     #[test]
     fn prop_fork_last_bound_table_index() {
-        aes_ctr_parallel_generic_tests::prop_fork_last_bound_table_index::<SoftwareBlockCipher>();
+        aes_ctr_parallel_generic_tests::prop_fork_last_bound_table_index::<SoftwareAes128BlockCipher>(
+        );
     }
 
     #[test]
     fn prop_fork_parent_bound_table_index() {
-        aes_ctr_parallel_generic_tests::prop_fork_parent_bound_table_index::<SoftwareBlockCipher>();
+        aes_ctr_parallel_generic_tests::prop_fork_parent_bound_table_index::<
+            SoftwareAes128BlockCipher,
+        >();
     }
 
     #[test]
     fn prop_fork_parent_state_table_index() {
-        aes_ctr_parallel_generic_tests::prop_fork_parent_state_table_index::<SoftwareBlockCipher>();
+        aes_ctr_parallel_generic_tests::prop_fork_parent_state_table_index::<
+            SoftwareAes128BlockCipher,
+        >();
     }
 
     #[test]
     fn prop_fork() {
-        aes_ctr_parallel_generic_tests::prop_fork::<SoftwareBlockCipher>();
+        aes_ctr_parallel_generic_tests::prop_fork::<SoftwareAes128BlockCipher>();
     }
 
     #[test]
     fn prop_fork_children_remaining_bytes() {
-        aes_ctr_parallel_generic_tests::prop_fork_children_remaining_bytes::<SoftwareBlockCipher>();
+        aes_ctr_parallel_generic_tests::prop_fork_children_remaining_bytes::<
+            SoftwareAes128BlockCipher,
+        >();
     }
 
     #[test]
     fn prop_fork_parent_remaining_bytes() {
-        aes_ctr_parallel_generic_tests::prop_fork_parent_remaining_bytes::<SoftwareBlockCipher>();
+        aes_ctr_parallel_generic_tests::prop_fork_parent_remaining_bytes::<SoftwareAes128BlockCipher>(
+        );
     }
 
     #[test]
     fn prop_fork_with_parent_continuation() {
-        aes_ctr_parallel_generic_tests::prop_fork_with_parent_continuation::<SoftwareBlockCipher>();
+        aes_ctr_parallel_generic_tests::prop_fork_with_parent_continuation::<
+            SoftwareAes128BlockCipher,
+        >();
     }
 
     #[test]
     fn test_forking_conformance_with_ctr_crate() {
         aes_ctr_parallel_generic_tests::test_forking_conformance_with_ctr_crate::<
-            SoftwareBlockCipher,
+            SoftwareAes128BlockCipher,
         >();
     }
 }

--- a/tfhe/Cargo.toml
+++ b/tfhe/Cargo.toml
@@ -56,7 +56,7 @@ clap-num = { version = "1.1.1" }
 cbindgen = { version = "0.28", optional = true }
 
 [dependencies]
-tfhe-csprng = { version = "0.9.2", path = "../tfhe-csprng", features = [
+tfhe-csprng = { version = "0.10.0", path = "../tfhe-csprng", features = [
     "parallel",
 ] }
 serde = { workspace = true, features = ["default", "derive"] }

--- a/tfhe/src/transciphering/ciphers/aes/plain.rs
+++ b/tfhe/src/transciphering/ciphers/aes/plain.rs
@@ -1,12 +1,12 @@
-use tfhe_csprng::generators::aes_ctr::{AesBlockCipher, AesKey};
-use tfhe_csprng::generators::default::AesDefaultBlockCipher;
+use tfhe_csprng::generators::aes_ctr::{Aes128Key, AesBlockCipher};
+use tfhe_csprng::generators::default::DefaultAes128BlockCipher;
 
 use crate::transciphering::ciphers::aes::{AesIv, AesPlainKey};
 use crate::transciphering::{InsufficientKeystream, StreamCipher, StreamCipherKind};
 
 /// Client-side AES-128 in CTR mode, in clear. Mirrors [`super::fhe::AesFheState`].
 pub struct AesPlainState {
-    cipher: AesDefaultBlockCipher,
+    cipher: DefaultAes128BlockCipher,
     iv: AesIv,
     counter: u64,
 }
@@ -14,7 +14,7 @@ pub struct AesPlainState {
 impl AesPlainState {
     pub fn new(key: impl Into<AesPlainKey>, iv: impl Into<AesIv>) -> Self {
         Self {
-            cipher: AesDefaultBlockCipher::new(AesKey::new(key.into().to_csprng_key_u128())),
+            cipher: DefaultAes128BlockCipher::new(Aes128Key::new(key.into().to_csprng_key_u128())),
             iv: iv.into(),
             counter: 0,
         }

--- a/utils/tfhe-forward-compat-matrices/compat_nightly/Cargo.lock
+++ b/utils/tfhe-forward-compat-matrices/compat_nightly/Cargo.lock
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "tfhe-csprng"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "aes",
  "getrandom",


### PR DESCRIPTION
This adds AES-256 to the 3 backends
This also add a wrapper enum to allow at runtime to select between Aes128/Aes256

As a consequence, the DefaultRandomGeneator exported is the one that can accomodate AES-128/256. Meaning in tfhe-rs's ShortintEngine the price of dispatch is paid even though the enven will only use AES 128, but changing that requires deeper changes in tfhe-csprng (on the RandomGenerator trait)

BREAKIN CHANGES:
  * AesKey renamed to Aes128Key
  * Block ciphers that were specialized for Aes128 now include '128' in their name

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3820)
<!-- Reviewable:end -->
