### PR TITLE
fix(gpu): fixed setup of throughput oriented pbs

### DIFF
--- a/backends/tfhe-cuda-backend/cuda/.semgrep/release-ordering.yaml
+++ b/backends/tfhe-cuda-backend/cuda/.semgrep/release-ordering.yaml
@@ -81,7 +81,13 @@ rules:
       - metavariable-regex:
           metavariable: $FUNC
           regex: "^cuda[A-Z][A-Za-z0-9]*$" # matches cudaMalloc/cudaMemcpy/... (not project helpers like cuda_set_device)
-      - pattern-not-inside: check_cuda_error(...)
+      - pattern-not: cudaGetErrorString(...) # returns a description, not a status: nothing to check
+      - pattern-not-inside: # a checker must panic on any error it is given; extend the list when adding one
+          patterns:
+            - pattern: $CHECK(...)
+            - metavariable-regex:
+                metavariable: $CHECK
+                regex: "^(check_cuda_error|check_configure_error)$"
       - pattern-not-inside: |
           $FUNC(...);
           check_cuda_error(cudaGetLastError());

--- a/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_classic.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_classic.cuh
@@ -102,38 +102,79 @@ static constexpr size_t SPECIALIZED_2_2_PARAMS_MIXPRECISION_SMEM_FIXED_BYTES =
         SPECIALIZED_2_2_PARAMS_MIXPRECISION_SMEM_AHAT_OFFSET_DOUBLES) *
     sizeof(double);
 
-template <typename Torus>
-uint64_t
-get_buffer_size_full_sm_programmable_bootstrap_specialized_2_2_params_throughput(
-    uint32_t lwe_dimension) {
-  // a_hat table: one uint32 per LWE coefficient, padded to 8 bytes so the
-  // address arithmetic above stays aligned for any subsequent double-typed
-  // region we might add later.
-  uint64_t ahat_bytes =
-      (static_cast<uint64_t>(lwe_dimension) * sizeof(uint32_t) + 7ull) &
-      ~static_cast<uint64_t>(7);
-  return SPECIALIZED_2_2_PARAMS_MIXPRECISION_SMEM_FIXED_BYTES + ahat_bytes;
+// Largest LWE dimension the mixprecision kernel accepts. The 2_2 parameter set
+// it is specialized for uses 918, with some margin left for parameter updates.
+// Bootstraps above it take the generic paths: the a_hat region below is sized
+// from this bound.
+static constexpr uint32_t
+    SPECIALIZED_2_2_PARAMS_MIXPRECISION_MAX_LWE_DIMENSION = 1024;
+
+// a_hat table: one uint32 per LWE coefficient, padded to 8 bytes to keep the
+// region double-aligned. Sized from the maximum dimension and not from the one
+// in use, so this kernel's dynamic shared memory is a compile-time constant:
+// the opt-in is per-function state shared by every thread of the context, so a
+// size that followed lwe_dimension let two concurrent bootstraps of different
+// parameter sets race on it. a_hat is the last region, so over-allocating it
+// moves nothing.
+static constexpr uint64_t SPECIALIZED_2_2_PARAMS_MIXPRECISION_SMEM_AHAT_BYTES =
+    (static_cast<uint64_t>(
+         SPECIALIZED_2_2_PARAMS_MIXPRECISION_MAX_LWE_DIMENSION) *
+         sizeof(uint32_t) +
+     7ull) &
+    ~static_cast<uint64_t>(7);
+
+// The one size this kernel is launched with and opts in to.
+static constexpr uint64_t SPECIALIZED_2_2_PARAMS_MIXPRECISION_SMEM_BYTES =
+    SPECIALIZED_2_2_PARAMS_MIXPRECISION_SMEM_FIXED_BYTES +
+    SPECIALIZED_2_2_PARAMS_MIXPRECISION_SMEM_AHAT_BYTES;
+
+// The launch bounds ask for 2 blocks/SM and the driver reserves 1 KiB per
+// block, so a block gets at most (228 - 2) / 2 KiB on Hopper. Measured on an
+// H100: 115712 B still gives 2 blocks/SM, 115968 B drops to 1.
+static constexpr uint64_t
+    SPECIALIZED_2_2_PARAMS_MIXPRECISION_SMEM_RESIDENCY_LIMIT_BYTES = 115712ull;
+static_assert(
+    SPECIALIZED_2_2_PARAMS_MIXPRECISION_SMEM_BYTES <=
+        SPECIALIZED_2_2_PARAMS_MIXPRECISION_SMEM_RESIDENCY_LIMIT_BYTES,
+    "the mixprecision specialized kernel would drop to 1 block/SM: "
+    "lower SPECIALIZED_2_2_PARAMS_MIXPRECISION_MAX_LWE_DIMENSION");
+
+// Reports which step of the mixprecision launch failed and with what
+// configuration. check_cuda_error cannot: every call of the launch macro
+// expands to the single line the macro is invoked from. `grid`/`block` are zero
+// when the failure happens while configuring, before a launch exists.
+__host__ inline void check_specialized_2_2_mixprecision_error(
+    cudaError_t err, const char *step, uint32_t base_log,
+    uint32_t lwe_dimension, dim3 grid, dim3 block, uint64_t smem,
+    const char *file, int line) {
+  if (err != cudaSuccess) {
+    PANIC("Cuda error (specialized 2_2 mixprecision PBS): %s failed with "
+          "\"%s\" at %s:%d\n"
+          "  base_log=%u lwe_dimension=%u grid=(%u,%u,%u) block=(%u,%u,%u)\n"
+          "  dynamic shared memory=%lu B (fixed size %lu B, max lwe "
+          "dimension %u)",
+          step, cudaGetErrorString(err), file, line, base_log, lwe_dimension,
+          grid.x, grid.y, grid.z, block.x, block.y, block.z,
+          static_cast<unsigned long>(smem),
+          static_cast<unsigned long>(
+              SPECIALIZED_2_2_PARAMS_MIXPRECISION_SMEM_BYTES),
+          SPECIALIZED_2_2_PARAMS_MIXPRECISION_MAX_LWE_DIMENSION);
+  }
 }
 
-// Residency budget for the mixprecision specialized kernel: 114 KiB/block keeps
-// 2 blocks/SM on H100 (228 KiB carveout). Promoted from the old launch guard so
-// the applicability predicate and the launch path share one value.
-static constexpr uint64_t
-    SPECIALIZED_2_2_PARAMS_MIXPRECISION_SMEM_BUDGET_BYTES = 114ull * 1024ull;
-
 // True if the FFT16x4x16 mixprecision specialized kernel is applicable for the
-// given parameters.
+// given parameters. The LWE dimension bound keeps the a_hat region large
+// enough. The launch paths and the bootstrapping key conversion both decide
+// through here, so the key layout and the kernel reading it always agree.
 template <typename Torus>
 __host__ bool specialized_2_2_use_throughput_oriented(
     uint32_t polynomial_size, uint32_t glwe_dimension, uint32_t level_count,
     uint32_t lwe_dimension, uint32_t max_shared_memory) {
-  if (polynomial_size != 2048 || glwe_dimension != 1 || level_count != 1)
-    return false;
-  uint64_t mp_smem =
-      get_buffer_size_full_sm_programmable_bootstrap_specialized_2_2_params_throughput<
-          Torus>(lwe_dimension);
-  return mp_smem <= SPECIALIZED_2_2_PARAMS_MIXPRECISION_SMEM_BUDGET_BYTES &&
-         mp_smem <= static_cast<uint64_t>(max_shared_memory);
+  return polynomial_size == 2048 && glwe_dimension == 1 && level_count == 1 &&
+         lwe_dimension <=
+             SPECIALIZED_2_2_PARAMS_MIXPRECISION_MAX_LWE_DIMENSION &&
+         SPECIALIZED_2_2_PARAMS_MIXPRECISION_SMEM_BYTES <=
+             static_cast<uint64_t>(max_shared_memory);
 }
 
 // We validate that the params and shared memory constraints for the specialized
@@ -697,6 +738,48 @@ device_programmable_bootstrap_specialized_2_2_params_throughput(
   }
 }
 
+// Applies the kernel's fixed attributes, reporting a failure the same way the
+// launch path does. They do not change between calls, so this could be done
+// once per device instead of once per launch; see
+// docs/gpu_kernel_configuration.md.
+template <typename Torus, class params, uint32_t base_log>
+__host__ void
+configure_specialized_2_2_mixprecision_kernel(uint32_t lwe_dimension,
+                                              const char *file, int line) {
+  // Last line of defence for the bound the selection predicate
+  // (specialized_2_2_use_throughput_oriented) already enforces: the a_hat
+  // region is sized from MAX_LWE_DIMENSION, so a larger dimension reaching
+  // here would have the kernel write past it instead of falling back.
+  PANIC_IF_FALSE(
+      lwe_dimension <= SPECIALIZED_2_2_PARAMS_MIXPRECISION_MAX_LWE_DIMENSION,
+      "Cuda error (specialized 2_2 mixprecision PBS): lwe_dimension=%u "
+      "exceeds SPECIALIZED_2_2_PARAMS_MIXPRECISION_MAX_LWE_DIMENSION=%u; this "
+      "launch path must not be selected for it",
+      lwe_dimension, SPECIALIZED_2_2_PARAMS_MIXPRECISION_MAX_LWE_DIMENSION);
+
+  auto kernel = device_programmable_bootstrap_specialized_2_2_params_throughput<
+      Torus, params, base_log>;
+  auto check_configure_error = [&](cudaError_t err, const char *step) {
+    check_specialized_2_2_mixprecision_error(
+        err, step, base_log, lwe_dimension, dim3(0, 0, 0), dim3(0, 0, 0),
+        SPECIALIZED_2_2_PARAMS_MIXPRECISION_SMEM_BYTES, file, line);
+  };
+
+  check_configure_error(
+      cudaFuncSetAttribute(
+          kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
+          static_cast<int>(SPECIALIZED_2_2_PARAMS_MIXPRECISION_SMEM_BYTES)),
+      "cudaFuncSetAttribute(MaxDynamicSharedMemorySize)");
+  check_configure_error(
+      cudaFuncSetAttribute(kernel,
+                           cudaFuncAttributePreferredSharedMemoryCarveout,
+                           cudaSharedmemCarveoutMaxShared),
+      "cudaFuncSetAttribute(PreferredSharedMemoryCarveout)");
+  check_configure_error(
+      cudaFuncSetCacheConfig(kernel, cudaFuncCachePreferShared),
+      "cudaFuncSetCacheConfig");
+}
+
 template <typename Torus, class params, sharedMemDegree SMD, bool first_iter>
 __global__ void __launch_bounds__(params::degree / params::opt)
     device_programmable_bootstrap_step_one(
@@ -1223,35 +1306,30 @@ __host__ void host_programmable_bootstrap_with_mode(
       int mp_thds = polynomial_size / mp_params::opt; // 64
       dim3 mp_grid(input_lwe_ciphertext_count, 1, level_count);
       dim3 mp_block(mp_thds, glwe_dimension + 1, 1); // (64, 2, 1) = 128 threads
-      uint64_t mp_smem =
-          get_buffer_size_full_sm_programmable_bootstrap_specialized_2_2_params_throughput<
-              Torus>(lwe_dimension);
+      uint64_t mp_smem = SPECIALIZED_2_2_PARAMS_MIXPRECISION_SMEM_BYTES;
 
-      // smem is already bounded to the 114 KiB / 2-block-per-SM budget by the
-      // specialized_2_2_use_throughput_oriented predicate above.
+// Names the step that failed, since every call below expands to the line the
+// macro is invoked from.
+#define CHECK_SPECIALIZED_2_2_MIXPRECISION(call, step, BL)                     \
+  check_specialized_2_2_mixprecision_error((call), (step), (BL),               \
+                                           lwe_dimension, mp_grid, mp_block,   \
+                                           mp_smem, __FILE__, __LINE__)
 
+// The launched size and the opt-in are both the compile-time SMEM_BYTES, never
+// a per-call value: see the a_hat comment above.
 #define LAUNCH_SPECIALIZED_2_2_MIXPRECISION(BL)                                \
   do {                                                                         \
-    check_cuda_error(cudaFuncSetAttribute(                                     \
-        device_programmable_bootstrap_specialized_2_2_params_throughput<       \
-            Torus, mp_params, BL>,                                             \
-        cudaFuncAttributeMaxDynamicSharedMemorySize, mp_smem));                \
-    check_cuda_error(cudaFuncSetAttribute(                                     \
-        device_programmable_bootstrap_specialized_2_2_params_throughput<       \
-            Torus, mp_params, BL>,                                             \
-        cudaFuncAttributePreferredSharedMemoryCarveout,                        \
-        cudaSharedmemCarveoutMaxShared));                                      \
-    check_cuda_error(cudaFuncSetCacheConfig(                                   \
-        device_programmable_bootstrap_specialized_2_2_params_throughput<       \
-            Torus, mp_params, BL>,                                             \
-        cudaFuncCachePreferShared));                                           \
-    check_cuda_error(cudaGetLastError());                                      \
+    configure_specialized_2_2_mixprecision_kernel<Torus, mp_params, BL>(       \
+        lwe_dimension, __FILE__, __LINE__);                                    \
+    CHECK_SPECIALIZED_2_2_MIXPRECISION(                                        \
+        cudaGetLastError(), "a CUDA call issued before this launch", BL);      \
     device_programmable_bootstrap_specialized_2_2_params_throughput<           \
         Torus, mp_params, BL><<<mp_grid, mp_block, mp_smem, stream>>>(         \
         lwe_array_out, lwe_output_indexes, lut_vector, lut_vector_indexes,     \
         lwe_array_in, lwe_input_indexes, bootstrapping_key, lwe_dimension,     \
         num_many_lut, lut_stride, noise_reduction_type);                       \
-    check_cuda_error(cudaGetLastError());                                      \
+    CHECK_SPECIALIZED_2_2_MIXPRECISION(cudaGetLastError(),                     \
+                                       "the kernel launch", BL);               \
   } while (0)
 
       switch (base_log) {
@@ -1274,11 +1352,9 @@ __host__ void host_programmable_bootstrap_with_mode(
         PANIC("Unsupported base_log value for specialized 2_2_params "
               "mixprecision kernel");
       }
-      // NOTE: LAUNCH_SPECIALIZED_2_2_MIXPRECISION is intentionally left defined
-      // (not #undef-ed): the TBC entry point in
+      // Both macros are intentionally left defined: the TBC entry point in
       // programmable_bootstrap_tbc_classic.cuh includes this header and reuses
-      // it. It expects a `mp_grid` (and mp_block/mp_smem/mp_params/...) in
-      // scope.
+      // them. They expect mp_grid / mp_block / mp_smem / mp_params in scope.
       return;
     }
 

--- a/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_tbc_classic.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_tbc_classic.cuh
@@ -578,14 +578,11 @@ __host__ void host_programmable_bootstrap_tbc_with_mode(
         int mp_thds = polynomial_size / mp_params::opt; // 64
         dim3 mp_grid(input_lwe_ciphertext_count, 1, level_count);
         dim3 mp_block(mp_thds, glwe_dimension + 1, 1); // (64, 2, 1)
-        uint64_t mp_smem =
-            get_buffer_size_full_sm_programmable_bootstrap_specialized_2_2_params_throughput<
-                Torus>(lwe_dimension);
+        uint64_t mp_smem = SPECIALIZED_2_2_PARAMS_MIXPRECISION_SMEM_BYTES;
 
-        // Reuses LAUNCH_SPECIALIZED_2_2_MIXPRECISION defined in
-        // programmable_bootstrap_classic.cuh (included above). It expects
-        // mp_grid / mp_block / mp_smem / mp_params and the kernel arguments in
-        // scope, which are all declared just above.
+        // Reuses LAUNCH_SPECIALIZED_2_2_MIXPRECISION from
+        // programmable_bootstrap_classic.cuh, which expects mp_grid / mp_block
+        // / mp_smem / mp_params and the kernel arguments in scope.
         switch (base_log) {
         case 21:
           LAUNCH_SPECIALIZED_2_2_MIXPRECISION(21);

--- a/backends/tfhe-cuda-backend/cuda/tests_and_benchmarks/tests/test_concurrent_pbs.cpp
+++ b/backends/tfhe-cuda-backend/cuda/tests_and_benchmarks/tests/test_concurrent_pbs.cpp
@@ -1,0 +1,186 @@
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <memory>
+#include <pbs/pbs_utilities.h>
+#include <pbs/programmable_bootstrap_testing.h>
+#include <setup_and_teardown.h>
+#include <thread>
+#include <utils.h>
+#include <vector>
+
+#include "checked_arithmetic.h"
+
+// The mixprecision 2_2 kernel used to size its shared memory from the LWE
+// dimension, which is not one of its template arguments. Since the opt-in is
+// per-function state shared by the whole context, two concurrent bootstraps of
+// different dimensions raced on it and the larger launch died with "invalid
+// argument".
+//
+// The race is for the few microseconds between the opt-in and the launch, on
+// the host, which is what dictates the shape of this test: several threads per
+// dimension, bootstraps issued back to back and a single readback at the end.
+// Reading the result after every bootstrap instead never reproduced it, since
+// that parks each thread on the GPU for the whole kernel.
+
+// Both dimensions must select the same kernel instantiation, so they only
+// differ in n. They are the two 2_2-shaped parameter sets the PBS tests already
+// use.
+constexpr int CONCURRENT_LWE_DIMENSIONS[] = {759, 918};
+constexpr int CONCURRENT_GLWE_DIMENSION = 1;
+constexpr int CONCURRENT_POLYNOMIAL_SIZE = 2048;
+constexpr int CONCURRENT_PBS_LEVEL = 1;
+constexpr int CONCURRENT_PBS_BASE_LOG = 23;
+constexpr int CONCURRENT_MESSAGE_MODULUS = 4;
+constexpr int CONCURRENT_CARRY_MODULUS = 4;
+constexpr int CONCURRENT_THREADS_PER_DIMENSION = 4;
+constexpr int CONCURRENT_ITERATIONS = 2000;
+
+namespace {
+
+// Keys, lut and input for one LWE dimension, shared read-only by the threads
+// running it.
+struct ConcurrentPbsKeys {
+  cudaStream_t stream;
+  uint32_t gpu_index = 0;
+  int lwe_dimension;
+  uint64_t *lwe_sk_in_array = nullptr;
+  uint64_t *lwe_sk_out_array = nullptr;
+  uint64_t *plaintexts = nullptr;
+  double *d_fourier_bsk_array = nullptr;
+  uint64_t *d_lut_pbs_identity = nullptr;
+  uint64_t *d_lut_pbs_indexes = nullptr;
+  uint64_t *d_lwe_ct_in_array = nullptr;
+  uint64_t *d_lwe_ct_out_array = nullptr;
+  uint64_t *d_lwe_input_indexes = nullptr;
+  uint64_t *d_lwe_output_indexes = nullptr;
+  int payload_modulus = 0;
+  uint64_t delta = 0;
+
+  explicit ConcurrentPbsKeys(int n) : lwe_dimension(n) {
+    stream = cuda_create_stream(gpu_index);
+    Seed seed;
+    init_seed(&seed);
+    programmable_bootstrap_classical_setup(
+        stream, gpu_index, &seed, &lwe_sk_in_array, &lwe_sk_out_array,
+        &d_fourier_bsk_array, &plaintexts, &d_lut_pbs_identity,
+        &d_lut_pbs_indexes, &d_lwe_ct_in_array, &d_lwe_input_indexes,
+        &d_lwe_ct_out_array, &d_lwe_output_indexes, lwe_dimension,
+        CONCURRENT_GLWE_DIMENSION, CONCURRENT_POLYNOMIAL_SIZE,
+        new_t_uniform(45), new_t_uniform(17), CONCURRENT_PBS_BASE_LOG,
+        CONCURRENT_PBS_LEVEL, CONCURRENT_MESSAGE_MODULUS,
+        CONCURRENT_CARRY_MODULUS, &payload_modulus, &delta, 1, 1, 1);
+
+    // The specialized kernel reads the bsk in its own layout.
+    cuda_drop_async(d_fourier_bsk_array, stream, gpu_index);
+    Seed bsk_seed;
+    init_seed(&bsk_seed);
+    generate_lwe_programmable_bootstrap_keys_specialized_2_2(
+        stream, gpu_index, &d_fourier_bsk_array, lwe_sk_in_array,
+        lwe_sk_out_array, lwe_dimension, CONCURRENT_GLWE_DIMENSION,
+        CONCURRENT_POLYNOMIAL_SIZE, CONCURRENT_PBS_LEVEL,
+        CONCURRENT_PBS_BASE_LOG, &bsk_seed, new_t_uniform(17), 1);
+    cuda_synchronize_stream(stream, gpu_index);
+  }
+
+  ~ConcurrentPbsKeys() {
+    programmable_bootstrap_classical_teardown(
+        stream, gpu_index, lwe_sk_in_array, lwe_sk_out_array,
+        d_fourier_bsk_array, plaintexts, d_lut_pbs_identity, d_lut_pbs_indexes,
+        d_lwe_ct_in_array, d_lwe_input_indexes, d_lwe_ct_out_array,
+        d_lwe_output_indexes);
+  }
+};
+
+// One thread's own stream, scratch buffer and output ciphertext.
+struct ConcurrentPbsWorker {
+  cudaStream_t stream;
+  uint32_t gpu_index = 0;
+  int8_t *pbs_buffer = nullptr;
+  uint64_t *d_lwe_ct_out = nullptr;
+  size_t out_size;
+
+  explicit ConcurrentPbsWorker(const ConcurrentPbsKeys &keys) {
+    stream = cuda_create_stream(gpu_index);
+    out_size =
+        safe_mul_sizeof<uint64_t>(safe_mul((size_t)CONCURRENT_GLWE_DIMENSION,
+                                           (size_t)CONCURRENT_POLYNOMIAL_SIZE) +
+                                  1);
+    d_lwe_ct_out = (uint64_t *)cuda_malloc_async(out_size, stream, gpu_index);
+    scratch_cuda_programmable_bootstrap_specialized_2_2_64_async(
+        stream, gpu_index, &pbs_buffer, keys.lwe_dimension,
+        CONCURRENT_GLWE_DIMENSION, CONCURRENT_POLYNOMIAL_SIZE,
+        CONCURRENT_PBS_LEVEL, 1, true, PBS_MS_REDUCTION_T::NO_REDUCTION);
+    cuda_synchronize_stream(stream, gpu_index);
+  }
+
+  // Issues one bootstrap and returns, without reading the result back.
+  void launch(const ConcurrentPbsKeys &keys) {
+    cuda_programmable_bootstrap_specialized_2_2_64_async(
+        stream, gpu_index, (void *)d_lwe_ct_out,
+        (void *)keys.d_lwe_output_indexes, (void *)keys.d_lut_pbs_identity,
+        (void *)keys.d_lut_pbs_indexes, (void *)keys.d_lwe_ct_in_array,
+        (void *)keys.d_lwe_input_indexes, (void *)keys.d_fourier_bsk_array,
+        pbs_buffer, keys.lwe_dimension, CONCURRENT_GLWE_DIMENSION,
+        CONCURRENT_POLYNOMIAL_SIZE, CONCURRENT_PBS_BASE_LOG,
+        CONCURRENT_PBS_LEVEL, 1, 1, 0);
+  }
+
+  // Checks the last result decrypts to the expected message.
+  void check(const ConcurrentPbsKeys &keys) {
+    std::vector<uint64_t> host(
+        CONCURRENT_GLWE_DIMENSION * CONCURRENT_POLYNOMIAL_SIZE + 1);
+    cuda_memcpy_async_to_cpu(host.data(), d_lwe_ct_out, out_size, stream,
+                             gpu_index);
+    cuda_synchronize_stream(stream, gpu_index);
+
+    uint64_t decrypted = 0;
+    core_crypto_lwe_decrypt(&decrypted, host.data(), keys.lwe_sk_out_array,
+                            CONCURRENT_GLWE_DIMENSION *
+                                CONCURRENT_POLYNOMIAL_SIZE);
+    uint64_t rounding = (decrypted & (keys.delta >> 1)) << 1;
+    ASSERT_EQ((decrypted + rounding) / keys.delta,
+              keys.plaintexts[0] / keys.delta);
+  }
+
+  ~ConcurrentPbsWorker() {
+    cleanup_cuda_programmable_bootstrap_64(stream, gpu_index, &pbs_buffer);
+    cuda_drop_async(d_lwe_ct_out, stream, gpu_index);
+    cuda_synchronize_stream(stream, gpu_index);
+    cuda_destroy_stream(stream, gpu_index);
+  }
+};
+
+} // namespace
+
+TEST(ConcurrentSpecialized2_2ProgrammableBootstrap, DistinctLweDimensions) {
+  uint32_t gpu_index = 0;
+  if (!specialized_2_2_params_checker<uint64_t>(
+          CONCURRENT_POLYNOMIAL_SIZE, CONCURRENT_GLWE_DIMENSION,
+          CONCURRENT_PBS_LEVEL, cuda_get_max_shared_memory(gpu_index))) {
+    GTEST_SKIP() << "Specialized 2_2 classical PBS is not supported here.";
+  }
+
+  std::vector<std::unique_ptr<ConcurrentPbsKeys>> keys;
+  for (int n : CONCURRENT_LWE_DIMENSIONS)
+    keys.push_back(std::make_unique<ConcurrentPbsKeys>(n));
+
+  std::vector<std::unique_ptr<ConcurrentPbsWorker>> workers;
+  std::vector<size_t> worker_keys;
+  for (size_t k = 0; k < keys.size(); k++)
+    for (int t = 0; t < CONCURRENT_THREADS_PER_DIMENSION; t++) {
+      workers.push_back(std::make_unique<ConcurrentPbsWorker>(*keys[k]));
+      worker_keys.push_back(k);
+    }
+
+  std::vector<std::thread> threads;
+  for (size_t w = 0; w < workers.size(); w++)
+    threads.emplace_back([&, w] {
+      for (int i = 0; i < CONCURRENT_ITERATIONS; i++)
+        workers[w]->launch(*keys[worker_keys[w]]);
+    });
+  for (auto &t : threads)
+    t.join();
+
+  for (size_t w = 0; w < workers.size(); w++)
+    workers[w]->check(*keys[worker_keys[w]]);
+}


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description
Fixes issue when running multiple streams with different params each (like in the tests). In that case they were trying to setup different shared memory sizes based on the lwe_dimension.  This fix setups the shared memory only once and always up to a max of lwe_dimension =1024, that leaves margin for increasing params if need in future and covers all current potential calls to the throughput oriented pbs. 

Actually it was a problem when combining decompression params with regular pbs params too.
### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
