### PR TITLE
fix(gpu): fix f128 FFT buffer leak and sizing, remove unused as_integer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3126,7 +3126,7 @@ dependencies = [
 
 [[package]]
 name = "tfhe-cuda-backend"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "bindgen",
  "cmake",

--- a/backends/tfhe-cuda-backend/Cargo.toml
+++ b/backends/tfhe-cuda-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tfhe-cuda-backend"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 authors = ["Zama team"]
 license = "BSD-3-Clause-Clear"

--- a/backends/tfhe-cuda-backend/cuda/include/fft/fft128.h
+++ b/backends/tfhe-cuda-backend/cuda/include/fft/fft128.h
@@ -5,11 +5,6 @@ void cuda_fourier_transform_forward_as_torus_f128_async(
     void *im1, void const *standard, uint32_t const N,
     const uint32_t number_of_samples);
 
-void cuda_fourier_transform_forward_as_integer_f128_async(
-    void *stream, uint32_t gpu_index, void *re0, void *re1, void *im0,
-    void *im1, void const *standard, uint32_t const N,
-    const uint32_t number_of_samples);
-
 void cuda_fourier_transform_backward_as_torus_f128_async(
     void *stream, uint32_t gpu_index, void *standard, void const *re0,
     void const *re1, void const *im0, void const *im1, uint32_t const N,

--- a/backends/tfhe-cuda-backend/cuda/src/fft128/fft128.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/fft128/fft128.cu
@@ -1,59 +1,5 @@
 #include "fft128.cuh"
 
-void cuda_fourier_transform_forward_as_integer_f128_async(
-    void *stream, uint32_t gpu_index, void *re0, void *re1, void *im0,
-    void *im1, void const *standard, const uint32_t N,
-    const uint32_t number_of_samples) {
-  switch (N) {
-  case 64:
-    host_fourier_transform_forward_as_integer_f128<AmortizedDegree<64>>(
-        static_cast<cudaStream_t>(stream), gpu_index, (double *)re0,
-        (double *)re1, (double *)im0, (double *)im1,
-        (__uint128_t const *)standard, N, number_of_samples);
-    break;
-  case 128:
-    host_fourier_transform_forward_as_integer_f128<AmortizedDegree<128>>(
-        static_cast<cudaStream_t>(stream), gpu_index, (double *)re0,
-        (double *)re1, (double *)im0, (double *)im1,
-        (__uint128_t const *)standard, N, number_of_samples);
-    break;
-  case 256:
-    host_fourier_transform_forward_as_integer_f128<AmortizedDegree<256>>(
-        static_cast<cudaStream_t>(stream), gpu_index, (double *)re0,
-        (double *)re1, (double *)im0, (double *)im1,
-        (__uint128_t const *)standard, N, number_of_samples);
-    break;
-  case 512:
-    host_fourier_transform_forward_as_integer_f128<AmortizedDegree<512>>(
-        static_cast<cudaStream_t>(stream), gpu_index, (double *)re0,
-        (double *)re1, (double *)im0, (double *)im1,
-        (__uint128_t const *)standard, N, number_of_samples);
-    break;
-  case 1024:
-    host_fourier_transform_forward_as_integer_f128<AmortizedDegree<1024>>(
-        static_cast<cudaStream_t>(stream), gpu_index, (double *)re0,
-        (double *)re1, (double *)im0, (double *)im1,
-        (__uint128_t const *)standard, N, number_of_samples);
-    break;
-  case 2048:
-    host_fourier_transform_forward_as_integer_f128<AmortizedDegree<2048>>(
-        static_cast<cudaStream_t>(stream), gpu_index, (double *)re0,
-        (double *)re1, (double *)im0, (double *)im1,
-        (__uint128_t const *)standard, N, number_of_samples);
-    break;
-  case 4096:
-    host_fourier_transform_forward_as_integer_f128<AmortizedDegree<4096>>(
-        static_cast<cudaStream_t>(stream), gpu_index, (double *)re0,
-        (double *)re1, (double *)im0, (double *)im1,
-        (__uint128_t const *)standard, N, number_of_samples);
-    break;
-  default:
-    PANIC("Cuda error (f128 fft): unsupported polynomial size. Supported "
-          "N's are powers of two"
-          " in the interval [64..4096].")
-  }
-}
-
 void cuda_fourier_transform_forward_as_torus_f128_async(
     void *stream, uint32_t gpu_index, void *re0, void *re1, void *im0,
     void *im1, void const *standard, const uint32_t N,

--- a/backends/tfhe-cuda-backend/cuda/src/fft128/fft128.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/fft128/fft128.cuh
@@ -487,27 +487,6 @@ negacyclic_backward_fft_f128_tbc(double *dt_re_hi, double *dt_re_lo,
 
 // params is expected to be full degree not half degree
 template <class params>
-__device__ void convert_u128_to_f128_as_integer(
-    double *out_re_hi, double *out_re_lo, double *out_im_hi, double *out_im_lo,
-    const __uint128_t *in_re, const __uint128_t *in_im) {
-
-  Index tid = threadIdx.x;
-  // #pragma unroll
-  for (Index i = 0; i < params::opt / 2; i++) {
-    auto out_re = u128_to_signed_to_f128(in_re[tid]);
-    auto out_im = u128_to_signed_to_f128(in_im[tid]);
-
-    out_re_hi[tid] = out_re.hi;
-    out_re_lo[tid] = out_re.lo;
-    out_im_hi[tid] = out_im.hi;
-    out_im_lo[tid] = out_im.lo;
-
-    tid += params::degree / params::opt;
-  }
-}
-
-// params is expected to be full degree not half degree
-template <class params>
 __device__ void convert_u128_to_f128_as_torus(
     double *out_re_hi, double *out_re_lo, double *out_im_hi, double *out_im_lo,
     const __uint128_t *in_re, const __uint128_t *in_im) {
@@ -570,22 +549,6 @@ convert_f128_to_u128_as_torus(__uint128_t *out_re, __uint128_t *out_im,
 
     tid += params::degree / params::opt;
   }
-}
-
-// params is expected to be full degree not half degree
-template <class params>
-__global__ void
-batch_convert_u128_to_f128_as_integer(double *out_re_hi, double *out_re_lo,
-                                      double *out_im_hi, double *out_im_lo,
-                                      const __uint128_t *in) {
-
-  convert_u128_to_f128_as_integer<params>(
-      &out_re_hi[blockIdx.x * params::degree / 2],
-      &out_re_lo[blockIdx.x * params::degree / 2],
-      &out_im_hi[blockIdx.x * params::degree / 2],
-      &out_im_lo[blockIdx.x * params::degree / 2],
-      &in[blockIdx.x * params::degree],
-      &in[blockIdx.x * params::degree + params::degree / 2]);
 }
 
 // params is expected to be full degree not half degree
@@ -764,118 +727,49 @@ __global__ void batch_NSMFFT_strided_128(double *d_in, double *d_out,
 }
 
 template <class params>
-__host__ void host_fourier_transform_forward_as_integer_f128(
-    cudaStream_t stream, uint32_t gpu_index, double *re0, double *re1,
-    double *im0, double *im1, const __uint128_t *standard, const uint32_t N,
-    const uint32_t number_of_samples) {
-
-  // allocate device buffers
-  double *d_re0 = (double *)cuda_malloc_async(safe_mul_sizeof<double>(N / 2),
-                                              stream, gpu_index);
-  double *d_re1 = (double *)cuda_malloc_async(safe_mul_sizeof<double>(N / 2),
-                                              stream, gpu_index);
-  double *d_im0 = (double *)cuda_malloc_async(safe_mul_sizeof<double>(N / 2),
-                                              stream, gpu_index);
-  double *d_im1 = (double *)cuda_malloc_async(safe_mul_sizeof<double>(N / 2),
-                                              stream, gpu_index);
-  __uint128_t *d_standard = (__uint128_t *)cuda_malloc_async(
-      safe_mul_sizeof<__uint128_t>(N), stream, gpu_index);
-
-  // copy input into device
-  cuda_memcpy_async_to_gpu(d_standard, standard,
-                           safe_mul_sizeof<__uint128_t>(N), stream, gpu_index);
-
-  // setup launch parameters
-  size_t required_shared_memory_size =
-      safe_mul_sizeof<double>((size_t)(N / 2), (size_t)4);
-  int grid_size = number_of_samples;
-  int block_size = params::degree / params::opt;
-  bool full_sm =
-      (required_shared_memory_size <= cuda_get_max_shared_memory(gpu_index));
-  size_t buffer_size =
-      full_sm ? 0
-              : safe_mul((size_t)number_of_samples, (size_t)(N / 2), (size_t)4);
-  size_t shared_memory_size = full_sm ? required_shared_memory_size : 0;
-  double *buffer = (double *)cuda_malloc_async(buffer_size, stream, gpu_index);
-
-  // configure shared memory for batch fft kernel
-  if (full_sm) {
-    check_cuda_error(cudaFuncSetAttribute(
-        batch_NSMFFT_128<FFTDegree<params, ForwardFFT>, FULLSM>,
-        cudaFuncAttributeMaxDynamicSharedMemorySize, shared_memory_size));
-    check_cuda_error(cudaFuncSetCacheConfig(
-        batch_NSMFFT_128<FFTDegree<params, ForwardFFT>, FULLSM>,
-        cudaFuncCachePreferShared));
-  }
-
-  // convert u128 into 4 x double
-  batch_convert_u128_to_f128_as_integer<params>
-      <<<grid_size, block_size, 0, stream>>>(d_re0, d_re1, d_im0, d_im1,
-                                             d_standard);
-  check_cuda_error(cudaGetLastError());
-
-  // call negacyclic 128 bit forward fft.
-  if (full_sm) {
-    batch_NSMFFT_128<FFTDegree<params, ForwardFFT>, FULLSM>
-        <<<grid_size, block_size, shared_memory_size, stream>>>(
-            d_re0, d_re1, d_im0, d_im1, d_re0, d_re1, d_im0, d_im1, buffer);
-  } else {
-    batch_NSMFFT_128<FFTDegree<params, ForwardFFT>, NOSM>
-        <<<grid_size, block_size, shared_memory_size, stream>>>(
-            d_re0, d_re1, d_im0, d_im1, d_re0, d_re1, d_im0, d_im1, buffer);
-  }
-  check_cuda_error(cudaGetLastError());
-
-  cuda_memcpy_async_to_cpu(re0, d_re0, safe_mul_sizeof<double>(N / 2), stream,
-                           gpu_index);
-  cuda_memcpy_async_to_cpu(re1, d_re1, safe_mul_sizeof<double>(N / 2), stream,
-                           gpu_index);
-  cuda_memcpy_async_to_cpu(im0, d_im0, safe_mul_sizeof<double>(N / 2), stream,
-                           gpu_index);
-  cuda_memcpy_async_to_cpu(im1, d_im1, safe_mul_sizeof<double>(N / 2), stream,
-                           gpu_index);
-
-  cuda_drop_async(d_standard, stream, gpu_index);
-  cuda_drop_async(d_re0, stream, gpu_index);
-  cuda_drop_async(d_re1, stream, gpu_index);
-  cuda_drop_async(d_im0, stream, gpu_index);
-  cuda_drop_async(d_im1, stream, gpu_index);
-}
-
-template <class params>
 __host__ void host_fourier_transform_forward_as_torus_f128(
     cudaStream_t stream, uint32_t gpu_index, double *re0, double *re1,
     double *im0, double *im1, const __uint128_t *standard, const uint32_t N,
     const uint32_t number_of_samples) {
 
-  // allocate device buffers
-  double *d_re0 = (double *)cuda_malloc_async(safe_mul_sizeof<double>(N / 2),
-                                              stream, gpu_index);
-  double *d_re1 = (double *)cuda_malloc_async(safe_mul_sizeof<double>(N / 2),
-                                              stream, gpu_index);
-  double *d_im0 = (double *)cuda_malloc_async(safe_mul_sizeof<double>(N / 2),
-                                              stream, gpu_index);
-  double *d_im1 = (double *)cuda_malloc_async(safe_mul_sizeof<double>(N / 2),
-                                              stream, gpu_index);
-  __uint128_t *d_standard = (__uint128_t *)cuda_malloc_async(
-      safe_mul_sizeof<__uint128_t>(N), stream, gpu_index);
+  // allocate device buffers; each kernel block processes its own sample, so
+  // every buffer is sized for the whole batch
+  size_t re_im_size = safe_mul_sizeof<double>(
+      static_cast<size_t>(number_of_samples), static_cast<size_t>(N / 2));
+  size_t standard_size = safe_mul_sizeof<__uint128_t>(
+      static_cast<size_t>(number_of_samples), static_cast<size_t>(N));
+  double *d_re0 =
+      static_cast<double *>(cuda_malloc_async(re_im_size, stream, gpu_index));
+  double *d_re1 =
+      static_cast<double *>(cuda_malloc_async(re_im_size, stream, gpu_index));
+  double *d_im0 =
+      static_cast<double *>(cuda_malloc_async(re_im_size, stream, gpu_index));
+  double *d_im1 =
+      static_cast<double *>(cuda_malloc_async(re_im_size, stream, gpu_index));
+  __uint128_t *d_standard = static_cast<__uint128_t *>(
+      cuda_malloc_async(standard_size, stream, gpu_index));
 
   // copy input into device
-  cuda_memcpy_async_to_gpu(d_standard, standard,
-                           safe_mul_sizeof<__uint128_t>(N), stream, gpu_index);
+  cuda_memcpy_async_to_gpu(d_standard, standard, standard_size, stream,
+                           gpu_index);
 
   // setup launch parameters
-  size_t required_shared_memory_size =
-      safe_mul_sizeof<double>((size_t)(N / 2), (size_t)4);
+  size_t required_shared_memory_size = safe_mul_sizeof<double>(
+      static_cast<size_t>(N / 2), static_cast<size_t>(4));
   int grid_size = number_of_samples;
   int block_size = params::degree / params::opt;
   bool full_sm =
       (required_shared_memory_size <= cuda_get_max_shared_memory(gpu_index));
-  size_t buffer_size =
-      full_sm ? 0
-              : safe_mul((size_t)number_of_samples, (size_t)(N / 2), (size_t)4);
   size_t shared_memory_size = full_sm ? required_shared_memory_size : 0;
-  double *buffer = (double *)cuda_malloc_async(buffer_size, stream, gpu_index);
+  // global scratch is only needed by the NOSM kernel variant, when the FFT
+  // working set does not fit in shared memory; each block uses one
+  // shared-memory-sized slice of it
+  double *buffer = full_sm
+                       ? nullptr
+                       : static_cast<double *>(cuda_malloc_async(
+                             safe_mul(static_cast<size_t>(number_of_samples),
+                                      required_shared_memory_size),
+                             stream, gpu_index));
 
   // configure shared memory for batch fft kernel
   if (full_sm) {
@@ -891,6 +785,7 @@ __host__ void host_fourier_transform_forward_as_torus_f128(
   batch_convert_u128_to_f128_as_torus<params>
       <<<grid_size, block_size, 0, stream>>>(d_re0, d_re1, d_im0, d_im1,
                                              d_standard);
+  check_cuda_error(cudaGetLastError());
 
   // call negacyclic 128 bit forward fft.
   if (full_sm) {
@@ -902,21 +797,19 @@ __host__ void host_fourier_transform_forward_as_torus_f128(
         <<<grid_size, block_size, shared_memory_size, stream>>>(
             d_re0, d_re1, d_im0, d_im1, d_re0, d_re1, d_im0, d_im1, buffer);
   }
+  check_cuda_error(cudaGetLastError());
 
-  cuda_memcpy_async_to_cpu(re0, d_re0, safe_mul_sizeof<double>(N / 2), stream,
-                           gpu_index);
-  cuda_memcpy_async_to_cpu(re1, d_re1, safe_mul_sizeof<double>(N / 2), stream,
-                           gpu_index);
-  cuda_memcpy_async_to_cpu(im0, d_im0, safe_mul_sizeof<double>(N / 2), stream,
-                           gpu_index);
-  cuda_memcpy_async_to_cpu(im1, d_im1, safe_mul_sizeof<double>(N / 2), stream,
-                           gpu_index);
+  cuda_memcpy_async_to_cpu(re0, d_re0, re_im_size, stream, gpu_index);
+  cuda_memcpy_async_to_cpu(re1, d_re1, re_im_size, stream, gpu_index);
+  cuda_memcpy_async_to_cpu(im0, d_im0, re_im_size, stream, gpu_index);
+  cuda_memcpy_async_to_cpu(im1, d_im1, re_im_size, stream, gpu_index);
 
   cuda_drop_async(d_standard, stream, gpu_index);
   cuda_drop_async(d_re0, stream, gpu_index);
   cuda_drop_async(d_re1, stream, gpu_index);
   cuda_drop_async(d_im0, stream, gpu_index);
   cuda_drop_async(d_im1, stream, gpu_index);
+  cuda_drop_async(buffer, stream, gpu_index);
 }
 
 template <class params>
@@ -925,40 +818,46 @@ __host__ void host_fourier_transform_backward_as_torus_f128(
     double const *re0, double const *re1, double const *im0, double const *im1,
     const uint32_t N, const uint32_t number_of_samples) {
 
-  // allocate device buffers
-  double *d_re0 = (double *)cuda_malloc_async(safe_mul_sizeof<double>(N / 2),
-                                              stream, gpu_index);
-  double *d_re1 = (double *)cuda_malloc_async(safe_mul_sizeof<double>(N / 2),
-                                              stream, gpu_index);
-  double *d_im0 = (double *)cuda_malloc_async(safe_mul_sizeof<double>(N / 2),
-                                              stream, gpu_index);
-  double *d_im1 = (double *)cuda_malloc_async(safe_mul_sizeof<double>(N / 2),
-                                              stream, gpu_index);
-  __uint128_t *d_standard = (__uint128_t *)cuda_malloc_async(
-      safe_mul_sizeof<__uint128_t>(N), stream, gpu_index);
+  // allocate device buffers; each kernel block processes its own sample, so
+  // every buffer is sized for the whole batch
+  size_t re_im_size = safe_mul_sizeof<double>(
+      static_cast<size_t>(number_of_samples), static_cast<size_t>(N / 2));
+  size_t standard_size = safe_mul_sizeof<__uint128_t>(
+      static_cast<size_t>(number_of_samples), static_cast<size_t>(N));
+  double *d_re0 =
+      static_cast<double *>(cuda_malloc_async(re_im_size, stream, gpu_index));
+  double *d_re1 =
+      static_cast<double *>(cuda_malloc_async(re_im_size, stream, gpu_index));
+  double *d_im0 =
+      static_cast<double *>(cuda_malloc_async(re_im_size, stream, gpu_index));
+  double *d_im1 =
+      static_cast<double *>(cuda_malloc_async(re_im_size, stream, gpu_index));
+  __uint128_t *d_standard = static_cast<__uint128_t *>(
+      cuda_malloc_async(standard_size, stream, gpu_index));
 
-  //  // copy input into device
-  cuda_memcpy_async_to_gpu(d_re0, re0, safe_mul_sizeof<double>(N / 2), stream,
-                           gpu_index);
-  cuda_memcpy_async_to_gpu(d_re1, re1, safe_mul_sizeof<double>(N / 2), stream,
-                           gpu_index);
-  cuda_memcpy_async_to_gpu(d_im0, im0, safe_mul_sizeof<double>(N / 2), stream,
-                           gpu_index);
-  cuda_memcpy_async_to_gpu(d_im1, im1, safe_mul_sizeof<double>(N / 2), stream,
-                           gpu_index);
+  // copy input into device
+  cuda_memcpy_async_to_gpu(d_re0, re0, re_im_size, stream, gpu_index);
+  cuda_memcpy_async_to_gpu(d_re1, re1, re_im_size, stream, gpu_index);
+  cuda_memcpy_async_to_gpu(d_im0, im0, re_im_size, stream, gpu_index);
+  cuda_memcpy_async_to_gpu(d_im1, im1, re_im_size, stream, gpu_index);
 
   // setup launch parameters
-  size_t required_shared_memory_size =
-      safe_mul_sizeof<double>((size_t)(N / 2), (size_t)4);
+  size_t required_shared_memory_size = safe_mul_sizeof<double>(
+      static_cast<size_t>(N / 2), static_cast<size_t>(4));
   int grid_size = number_of_samples;
   int block_size = params::degree / params::opt;
   bool full_sm =
       (required_shared_memory_size <= cuda_get_max_shared_memory(gpu_index));
-  size_t buffer_size =
-      full_sm ? 0
-              : safe_mul((size_t)number_of_samples, (size_t)(N / 2), (size_t)4);
   size_t shared_memory_size = full_sm ? required_shared_memory_size : 0;
-  double *buffer = (double *)cuda_malloc_async(buffer_size, stream, gpu_index);
+  // global scratch is only needed by the NOSM kernel variant, when the FFT
+  // working set does not fit in shared memory; each block uses one
+  // shared-memory-sized slice of it
+  double *buffer = full_sm
+                       ? nullptr
+                       : static_cast<double *>(cuda_malloc_async(
+                             safe_mul(static_cast<size_t>(number_of_samples),
+                                      required_shared_memory_size),
+                             stream, gpu_index));
 
   // configure shared memory for batch fft kernel
   if (full_sm) {
@@ -976,18 +875,21 @@ __host__ void host_fourier_transform_backward_as_torus_f128(
         <<<grid_size, block_size, shared_memory_size, stream>>>(
             d_re0, d_re1, d_im0, d_im1, d_re0, d_re1, d_im0, d_im1, buffer);
   }
+  check_cuda_error(cudaGetLastError());
 
   batch_convert_f128_to_u128_as_torus<params>
       <<<grid_size, block_size, 0, stream>>>(d_standard, d_re0, d_re1, d_im0,
                                              d_im1);
+  check_cuda_error(cudaGetLastError());
 
-  cuda_memcpy_async_to_cpu(standard, d_standard,
-                           safe_mul_sizeof<__uint128_t>(N), stream, gpu_index);
+  cuda_memcpy_async_to_cpu(standard, d_standard, standard_size, stream,
+                           gpu_index);
   cuda_drop_async(d_standard, stream, gpu_index);
   cuda_drop_async(d_re0, stream, gpu_index);
   cuda_drop_async(d_re1, stream, gpu_index);
   cuda_drop_async(d_im0, stream, gpu_index);
   cuda_drop_async(d_im1, stream, gpu_index);
+  cuda_drop_async(buffer, stream, gpu_index);
 }
 
 #undef NEG_TWID

--- a/backends/tfhe-cuda-backend/cuda/src/pbs/bootstrapping_key.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/pbs/bootstrapping_key.cuh
@@ -164,7 +164,9 @@ void cuda_convert_lwe_programmable_bootstrap_key(
 
   auto max_shared_memory = cuda_get_max_shared_memory(gpu_index);
 
-  double2 *buffer = (double2 *)cuda_malloc_async(0, stream, gpu_index);
+  // global scratch is only allocated on the NOSM paths below; cuda_drop_async
+  // accepts the nullptr left by the FULLSM paths
+  double2 *buffer = nullptr;
   switch (polynomial_size) {
   case 256:
     if (shared_memory_size <= max_shared_memory) {
@@ -358,18 +360,22 @@ void convert_u128_to_f128_and_forward_fft_128(cudaStream_t stream,
                                               uint32_t number_of_samples) {
 
   cuda_set_device(gpu_index);
-  size_t required_shared_memory_size =
-      safe_mul_sizeof<double>((size_t)(params::degree / 2), (size_t)4);
+  size_t required_shared_memory_size = safe_mul_sizeof<double>(
+      static_cast<size_t>(params::degree / 2), static_cast<size_t>(4));
   int grid_size = number_of_samples;
   int block_size = params::degree / params::opt;
   bool full_sm =
       (required_shared_memory_size <= cuda_get_max_shared_memory(gpu_index));
-  size_t buffer_size = full_sm
-                           ? 0
-                           : safe_mul((size_t)number_of_samples,
-                                      (size_t)(params::degree / 2), (size_t)4);
   size_t shared_memory_size = full_sm ? required_shared_memory_size : 0;
-  double *buffer = (double *)cuda_malloc_async(buffer_size, stream, gpu_index);
+  // global scratch is only needed by the NOSM kernel variant, when the FFT
+  // working set does not fit in shared memory; each block uses one
+  // shared-memory-sized slice of it
+  double *buffer = full_sm
+                       ? nullptr
+                       : static_cast<double *>(cuda_malloc_async(
+                             safe_mul(static_cast<size_t>(number_of_samples),
+                                      required_shared_memory_size),
+                             stream, gpu_index));
 
   // configure shared memory for batch fft kernel
   if (full_sm) {

--- a/backends/tfhe-cuda-backend/src/bindings.rs
+++ b/backends/tfhe-cuda-backend/src/bindings.rs
@@ -2979,19 +2979,6 @@ unsafe extern "C" {
     );
 }
 unsafe extern "C" {
-    pub fn cuda_fourier_transform_forward_as_integer_f128_async(
-        stream: *mut ffi::c_void,
-        gpu_index: u32,
-        re0: *mut ffi::c_void,
-        re1: *mut ffi::c_void,
-        im0: *mut ffi::c_void,
-        im1: *mut ffi::c_void,
-        standard: *const ffi::c_void,
-        N: u32,
-        number_of_samples: u32,
-    );
-}
-unsafe extern "C" {
     pub fn cuda_fourier_transform_backward_as_torus_f128_async(
         stream: *mut ffi::c_void,
         gpu_index: u32,

--- a/backends/tfhe-cuda-common/cuda/src/device.cu
+++ b/backends/tfhe-cuda-common/cuda/src/device.cu
@@ -467,6 +467,10 @@ void cuda_drop_with_size_tracking_async(void *ptr, cudaStream_t stream,
 
   if (!gpu_memory_allocated)
     return;
+  // unlike cudaFree, cudaFreeAsync is not documented to accept a null
+  // pointer, so make dropping never-allocated scratch an explicit no-op
+  if (ptr == nullptr)
+    return;
   cuda_set_device(gpu_index);
 #ifndef CUDART_VERSION
 #error CUDART_VERSION Undefined!

--- a/scripts/check_scratch_cleanup.py
+++ b/scripts/check_scratch_cleanup.py
@@ -57,23 +57,23 @@ RUST_CALL_SITES = [
 EXPECTED_SCRATCH_COUNT = 80
 
 # Cuda operation functions
-EXPECTED_CUDA_COUNT = 119
+EXPECTED_CUDA_COUNT = 118
 
 # Cleanup functions
 EXPECTED_CLEANUP_COUNT = 80
 
 # Check 3: Rust call-site scanning
 # Number of functions in ffi.rs files
-EXPECTED_CHECK3_RUST_FNS = 141
+EXPECTED_CHECK3_RUST_FNS = 140
 # Number of functions in ffi.rs files that
-EXPECTED_CHECK3_ASYNC_CUDA_CALLS = 105
+EXPECTED_CHECK3_ASYNC_CUDA_CALLS = 104
 
 # Number of instances of Rust calls to the scratch/cuda/cleanup in a
 # triplet sequence.
 EXPECTED_CHECK3_SCRATCH_CUDA_CLEANUP_TRIPLET_CALLS = 122
 
 # Check 5: Rust async-caller scanning
-EXPECTED_CHECK5_ASYNC_CALLERS = 134
+EXPECTED_CHECK5_ASYNC_CALLERS = 133
 
 # Check 6: Rust cleanup-caller scanning
 EXPECTED_CHECK6_CLEANUP_CALLERS = 120

--- a/tfhe/Cargo.toml
+++ b/tfhe/Cargo.toml
@@ -68,7 +68,7 @@ tfhe-fft = { version = "0.10.1", path = "../tfhe-fft", features = [
 ] }
 tfhe-ntt = { version = "0.7.1", path = "../tfhe-ntt" }
 pulp = { workspace = true, features = ["default"] }
-tfhe-cuda-backend = { version = "0.15.0", path = "../backends/tfhe-cuda-backend", optional = true }
+tfhe-cuda-backend = { version = "0.16.0", path = "../backends/tfhe-cuda-backend", optional = true }
 aligned-vec = { workspace = true, features = ["default", "serde"] }
 dyn-stack = { workspace = true, features = ["default"] }
 paste = { workspace = true }

--- a/tfhe/src/core_crypto/gpu/ffi.rs
+++ b/tfhe/src/core_crypto/gpu/ffi.rs
@@ -958,37 +958,6 @@ pub fn cuda_modulus_switch_multi_bit_ciphertext_u128<T: UnsignedInteger>(
     streams.synchronize();
 }
 
-/// forward fourier transform for complex f128 as integer
-///
-/// # Safety
-///
-/// [CudaStreams::synchronize] __must__ be called as soon as synchronization is
-/// required
-#[allow(clippy::too_many_arguments)]
-pub unsafe fn fourier_transform_forward_as_integer_f128_async<T: UnsignedInteger>(
-    streams: &CudaStreams,
-    re0: &mut [f64],
-    re1: &mut [f64],
-    im0: &mut [f64],
-    im1: &mut [f64],
-    standard: &[T],
-    fft_size: u32,
-    number_of_samples: u32,
-) {
-    assert_eq!(TypeId::of::<T>(), TypeId::of::<u128>());
-    cuda_fourier_transform_forward_as_integer_f128_async(
-        streams.ptr[0],
-        streams.gpu_indexes[0].get(),
-        re0.as_mut_ptr().cast::<c_void>(),
-        re1.as_mut_ptr().cast::<c_void>(),
-        im0.as_mut_ptr().cast::<c_void>(),
-        im1.as_mut_ptr().cast::<c_void>(),
-        standard.as_ptr().cast::<c_void>(),
-        fft_size,
-        number_of_samples,
-    );
-}
-
 /// forward fourier transform for complex f128 as torus
 ///
 /// # Safety


### PR DESCRIPTION
> **Warning:** removing the unused `as_integer` f128 FFT entry point is a breaking change to the public `tfhe-cuda-backend` API. This requires bumping the crate version from `0.15.0` to `0.16.0` (a minor bump, since `tfhe-cuda-backend` is pre-1.0 and breaking changes bump the second component). `Cargo.lock` and the `tfhe-cuda-backend` dependency in `tfhe/Cargo.toml` are updated accordingly. `scripts/check_scratch_cleanup.py`'s expected binding counts are also updated to match the removed bindings.

This PR fixes memory management issues in the f128 FFT host functions and in the 128-bit BSK conversion, found while investigating a memory leak in `host_fourier_transform_forward_as_torus_f128`. Following the review discussion, the unused `as_integer` f128 FFT entry point is removed instead of being fixed.

### Removed the unused `as_integer` f128 FFT path
`cuda_fourier_transform_forward_as_integer_f128_async` had the same leak and the same undersized scratch allocation as the `as_torus` variants, but it has no caller and no test: it was only exposed to `core_crypto` through the `fourier_transform_forward_as_integer_f128_async` wrapper, which nothing calls. It is deleted rather than fixed, along with everything it was the only user of: the `extern "C"` entry point and its declaration in `fft128.h`, `host_fourier_transform_forward_as_integer_f128`, the `convert_u128_to_f128_as_integer` and `batch_convert_u128_to_f128_as_integer` kernels, the generated Rust binding, and the `core_crypto` wrapper.

### Memory leak in the f128 FFT host functions
`host_fourier_transform_forward_as_torus_f128` and `host_fourier_transform_backward_as_torus_f128` allocated a global scratch `buffer` for the FFT kernel but never freed it. The cleanup block only released `d_standard` and `d_re0/d_re1/d_im0/d_im1`.

### Scratch buffer allocated in elements instead of bytes
The same `buffer` was sized with `safe_mul(number_of_samples, N/2, 4)`, but `cuda_malloc_async` takes bytes, so the allocation was 8x too small (missing the `sizeof(double)` factor). Any call taking the no-shared-memory (NOSM) kernel path wrote out of bounds. The same defect existed in `convert_u128_to_f128_and_forward_fft_128` (`bootstrapping_key.cuh`), which is used by the 128-bit BSK conversion.

### Device buffers not sized for batched calls
The two `as_torus` FFT host functions launch `number_of_samples` kernel blocks, each indexing its own sample slice, but all device buffers and host/device copies were sized for a single sample. Calls with `number_of_samples > 1` wrote out of bounds. Buffers and copies are now sized for the whole batch. (The only callers, the GPU FFT tests, pass 1, so this was latent.)

### Smaller cleanups
- The global scratch is now allocated only on the NOSM path instead of issuing a 0-byte allocation on the shared-memory path; `cuda_convert_lwe_programmable_bootstrap_key` also initializes its scratch pointer to `nullptr` instead of a 0-byte allocation whose pointer was overwritten (and leaked) by the NOSM branches.
- `cuda_drop_with_size_tracking_async` is now an explicit no-op for null pointers, since `cudaFreeAsync` (unlike `cudaFree`) is not documented to accept them.
- Added missing `check_cuda_error(cudaGetLastError())` after kernel launches in the two `as_torus` FFT variants, and replaced C-style casts with `static_cast` in the touched code.

<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
