### PR TITLE
feat(transciphering): add OPRF generation

### DIFF
--- a/tfhe/src/shortint/backward_compatibility/parameters/mod.rs
+++ b/tfhe/src/shortint/backward_compatibility/parameters/mod.rs
@@ -4,6 +4,7 @@ pub mod list_compression;
 pub mod modulus_switch_noise_reduction;
 pub mod noise_squashing;
 pub mod re_randomization;
+pub mod transciphering;
 
 use crate::core_crypto::commons::parameters::{
     DecompositionBaseLog, DecompositionLevelCount, DynamicDistribution, GlweDimension,

--- a/tfhe/src/shortint/backward_compatibility/parameters/transciphering.rs
+++ b/tfhe/src/shortint/backward_compatibility/parameters/transciphering.rs
@@ -1,0 +1,7 @@
+use super::parameters::transciphering::TranscipheringParameters;
+use tfhe_versionable::VersionsDispatch;
+
+#[derive(VersionsDispatch)]
+pub enum TranscipheringParametersVersions {
+    V0(TranscipheringParameters),
+}

--- a/tfhe/src/shortint/oprf.rs
+++ b/tfhe/src/shortint/oprf.rs
@@ -678,6 +678,32 @@ impl<C: Container<Element = c64> + Sync> GenericOprfServerKey<C> {
                 prf_re_randomization_context,
             )
     }
+
+    /// Uniformly generates a sequence of encrypted random bits from a single seed in one call.
+    ///
+    /// Returns `num_blocks` blocks, each ciphertext encrypting a value in `[0, 2[`, i.e. a single
+    /// random bit whatever the message modulus of `target_sks`.
+    ///
+    /// # Panics
+    ///
+    /// * Panics if `self` is not compatible with `target_sks`
+    pub fn generate_random_boolean_sequence(
+        &self,
+        seed: impl OprfSeed,
+        num_blocks: u64,
+        target_sks: &ServerKey,
+    ) -> Vec<Ciphertext> {
+        let max_random_bits_per_block = 1;
+        self.inner
+            .generate_pseudo_random_bits_chunks(
+                seed,
+                &[num_blocks],
+                max_random_bits_per_block, // Each ciphertext is a boolean
+                target_sks,
+            )
+            .pop()
+            .unwrap()
+    }
 }
 
 // Owned-only methods.

--- a/tfhe/src/shortint/parameters/mod.rs
+++ b/tfhe/src/shortint/parameters/mod.rs
@@ -51,6 +51,7 @@ pub mod parameters_wopbs_only;
 pub mod re_randomization;
 #[cfg(test)]
 pub mod test_params;
+pub mod transciphering;
 pub mod v0_10;
 pub mod v0_11;
 pub mod v1_0;
@@ -73,6 +74,7 @@ use super::server_key::PBSConformanceParams;
 pub use super::PBSOrder;
 use crate::shortint::ciphertext::MaxDegree;
 pub use crate::shortint::parameters::list_compression::CompressionParameters;
+pub use crate::shortint::parameters::transciphering::TranscipheringParameters;
 pub use classic::ClassicPBSParameters;
 pub use compact_public_key_only::{
     CastingFunctionsOwned, CastingFunctionsView, CompactCiphertextListExpansionKind,

--- a/tfhe/src/shortint/parameters/transciphering.rs
+++ b/tfhe/src/shortint/parameters/transciphering.rs
@@ -1,0 +1,17 @@
+use crate::named::Named;
+use crate::shortint::backward_compatibility::parameters::transciphering::TranscipheringParametersVersions;
+use serde::{Deserialize, Serialize};
+use tfhe_versionable::Versionize;
+
+/// Parameters of the key material used by the transciphering subsystem.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Versionize)]
+#[versionize(TranscipheringParametersVersions)]
+#[non_exhaustive]
+pub enum TranscipheringParameters {
+    /// Generate the transciphering key with the parameters of the compute key.
+    SameAsCompute,
+}
+
+impl Named for TranscipheringParameters {
+    const NAME: &'static str = "shortint::TranscipheringParameters";
+}

--- a/tfhe/src/transciphering/backward_compatibility/mod.rs
+++ b/tfhe/src/transciphering/backward_compatibility/mod.rs
@@ -1,6 +1,10 @@
 use tfhe_versionable::VersionsDispatch;
 
-use crate::transciphering::{StreamCipherKind, StreamCiphertext};
+use crate::transciphering::{
+    AesIv, CompressedTranscipheringServerKey, KreyviumIV, OneTimePadFheSecretMask,
+    OneTimePadPlainSecretMask, SerializableAesFheKey, SerializableKreyviumFheKey, StreamCipherKind,
+    StreamCiphertext, TranscipheringPrivateKey, TranscipheringServerKey,
+};
 
 #[derive(VersionsDispatch)]
 pub enum StreamCipherKindVersions {
@@ -10,4 +14,49 @@ pub enum StreamCipherKindVersions {
 #[derive(VersionsDispatch)]
 pub enum StreamCiphertextVersions {
     V0(StreamCiphertext),
+}
+
+#[derive(VersionsDispatch)]
+pub enum SerializableKreyviumFheKeyVersions {
+    V0(SerializableKreyviumFheKey),
+}
+
+#[derive(VersionsDispatch)]
+pub enum KreyviumIVVersions {
+    V0(KreyviumIV),
+}
+
+#[derive(VersionsDispatch)]
+pub enum SerializableAesFheKeyVersions {
+    V0(SerializableAesFheKey),
+}
+
+#[derive(VersionsDispatch)]
+pub enum AesIvVersions {
+    V0(AesIv),
+}
+
+#[derive(VersionsDispatch)]
+pub enum OneTimePadFheSecretMaskVersions {
+    V0(OneTimePadFheSecretMask),
+}
+
+#[derive(VersionsDispatch)]
+pub enum OneTimePadPlainSecretMaskVersions {
+    V0(OneTimePadPlainSecretMask),
+}
+
+#[derive(VersionsDispatch)]
+pub enum TranscipheringPrivateKeyVersions {
+    V0(TranscipheringPrivateKey),
+}
+
+#[derive(VersionsDispatch)]
+pub enum TranscipheringServerKeyVersions {
+    V0(TranscipheringServerKey),
+}
+
+#[derive(VersionsDispatch)]
+pub enum CompressedTranscipheringServerKeyVersions {
+    V0(CompressedTranscipheringServerKey),
 }

--- a/tfhe/src/transciphering/ciphers/aes/mod.rs
+++ b/tfhe/src/transciphering/ciphers/aes/mod.rs
@@ -12,8 +12,14 @@ pub use fhe::AesFheState;
 pub use key::AesFheRoundKeys;
 pub use plain::AesPlainState;
 
-use crate::shortint::{Ciphertext, ClientKey};
+use crate::named::Named;
+use crate::shortint::oprf::OprfSeed;
+use crate::shortint::{Ciphertext, ClientKey, ServerKey};
+use crate::transciphering::backward_compatibility::{AesIvVersions, SerializableAesFheKeyVersions};
 use crate::transciphering::ciphers::*;
+use crate::transciphering::TranscipheringServerKey;
+use serde::{Deserialize, Serialize};
+use tfhe_versionable::Versionize;
 
 /// Big endian byte order.
 ///
@@ -73,8 +79,69 @@ impl From<[bool; 128]> for AesPlainKey {
     }
 }
 
+#[derive(Clone, Serialize, Deserialize, Versionize)]
+#[serde(into = "SerializableAesFheKey", try_from = "SerializableAesFheKey")]
+#[versionize(into = "SerializableAesFheKey", try_from = "SerializableAesFheKey")]
 pub struct AesFheKey {
     key: [Ciphertext; 128],
+}
+
+impl AesFheKey {
+    pub fn ciphertexts(&self) -> &[Ciphertext; 128] {
+        &self.key
+    }
+
+    pub fn new_random(
+        seed: impl OprfSeed,
+        transciphering_key: &TranscipheringServerKey,
+        sks: &ServerKey,
+    ) -> Self {
+        let encrypted_bits = transciphering_key
+            .oprf_key()
+            .generate_random_boolean_sequence(seed, 128, sks);
+
+        let key: [Ciphertext; 128] = encrypted_bits.try_into().expect("the vec has 128 elements");
+
+        Self { key }
+    }
+
+    /// Decrypt the key bits
+    pub fn decrypt(&self, client_key: &ClientKey) -> AesPlainKey {
+        let mut decrypted_bits = [false; 128];
+        for (ct, out) in self.key.iter().zip(decrypted_bits.iter_mut()) {
+            *out = client_key.decrypt(ct) != 0;
+        }
+        AesPlainKey::from(decrypted_bits)
+    }
+}
+
+/// Serialization form of [`AesFheKey`]. The 128 key ciphertexts are stored in a
+/// `Vec` because serde/versionize don't support arrays longer than 32; the
+/// fixed-size array is restored on deserialization.
+#[derive(Clone, Serialize, Deserialize, Versionize)]
+#[versionize(SerializableAesFheKeyVersions)]
+pub struct SerializableAesFheKey {
+    key: Vec<Ciphertext>,
+}
+
+impl From<AesFheKey> for SerializableAesFheKey {
+    fn from(value: AesFheKey) -> Self {
+        Self {
+            key: value.key.into(),
+        }
+    }
+}
+
+impl TryFrom<SerializableAesFheKey> for AesFheKey {
+    type Error = crate::Error;
+
+    fn try_from(value: SerializableAesFheKey) -> Result<Self, Self::Error> {
+        let len = value.key.len();
+        let key: [Ciphertext; 128] = value.key.try_into().map_err(|_| {
+            crate::error!("an AES key must hold exactly 128 ciphertexts, got {len}")
+        })?;
+        Ok(Self { key })
+    }
 }
 
 /// AES-128 IV / initial CTR counter, as a plain 128-bit integer.
@@ -82,7 +149,8 @@ pub struct AesFheKey {
 /// The counter is incremented directly (`iv + block_index`), the big-endian
 /// (NIST) convention only applies when bytes are involved, i.e. at the
 /// `[u8; 16]` / `[bool; 128]` construction boundaries.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Serialize, Deserialize, Versionize)]
+#[versionize(AesIvVersions)]
 pub struct AesIv(u128);
 
 impl AesIv {
@@ -109,4 +177,8 @@ impl From<[bool; 128]> for AesIv {
         pack_bits_lsb_first(&value, &mut bits);
         bits.into()
     }
+}
+
+impl Named for AesIv {
+    const NAME: &'static str = "transciphering::AesIv";
 }

--- a/tfhe/src/transciphering/ciphers/aes/test.rs
+++ b/tfhe/src/transciphering/ciphers/aes/test.rs
@@ -128,6 +128,26 @@ fn aes_plain_key_conversions_are_homogeneous() {
     }
 }
 
+/// `AesFheKey::decrypt` must be the exact inverse of `AesPlainKey::encrypt`,
+/// including the byte and bit order they agree on
+#[test]
+fn aes_fhe_key_encrypt_decrypt_round_trip() {
+    let (cks, _sks) = gen_keys(PARAM);
+
+    // An asymmetric value plus both extremes, so a reversed byte or bit order
+    // does not round-trip by accident.
+    for v in [KEY, 0u128, u128::MAX, 0x0123456789abcdeffedcba9876543210] {
+        let plain = AesPlainKey::from(v);
+        let recovered = plain.encrypt(&cks).decrypt(&cks);
+
+        assert_eq!(
+            recovered.to_csprng_key_u128(),
+            plain.to_csprng_key_u128(),
+            "AES key did not survive the encrypt/decrypt round trip for 0x{v:032x}"
+        );
+    }
+}
+
 /// Anchor the plain side to the NIST SP 800-38A AES-128 vector. The other
 /// tests use `AesPlainStream` as oracle.
 #[test]

--- a/tfhe/src/transciphering/ciphers/kreyvium/fhe.rs
+++ b/tfhe/src/transciphering/ciphers/kreyvium/fhe.rs
@@ -1,16 +1,31 @@
 //! TFHE implementation of the Kreyvium Algorithm
 
 use crate::shortint::ciphertext::NoiseLevel;
-use crate::shortint::{Ciphertext, ServerKey};
+use crate::shortint::oprf::OprfSeed;
+use crate::shortint::{Ciphertext, ClientKey, ServerKey};
+use crate::transciphering::backward_compatibility::SerializableKreyviumFheKeyVersions;
 use crate::transciphering::ciphers::shift_register::ShiftRegister;
-use crate::transciphering::{FheKeyStream, InsufficientKeystream, StreamCipherKind, Transcipherer};
+use crate::transciphering::{
+    FheKeyStream, InsufficientKeystream, StreamCipherKind, Transcipherer, TranscipheringServerKey,
+};
+use serde::{Deserialize, Serialize};
+use tfhe_versionable::Versionize;
 
 use super::{
-    collect_boxed_array, KreyviumBackwardRoundOutput, KreyviumIV, KreyviumRound,
+    collect_boxed_array, KreyviumBackwardRoundOutput, KreyviumIV, KreyviumPlainKey, KreyviumRound,
     KreyviumRoundInput, KreyviumRoundOutput, KreyviumState,
 };
 
 /// A kreyvium key encrypted in LWE, one ciphertext per bit
+#[derive(Clone, Serialize, Deserialize, Versionize)]
+#[serde(
+    into = "SerializableKreyviumFheKey",
+    try_from = "SerializableKreyviumFheKey"
+)]
+#[versionize(
+    into = "SerializableKreyviumFheKey",
+    try_from = "SerializableKreyviumFheKey"
+)]
 pub struct KreyviumFheKey {
     cts: Box<[Ciphertext; 128]>,
 }
@@ -32,8 +47,71 @@ impl KreyviumFheKey {
         Self { cts }
     }
 
+    pub fn new_random(
+        seed: impl OprfSeed,
+        transciphering_key: &TranscipheringServerKey,
+        sks: &ServerKey,
+    ) -> Self {
+        let encrypted_bits = transciphering_key
+            .oprf_key()
+            .generate_random_boolean_sequence(seed, 128, sks);
+
+        let boxed: Box<[Ciphertext; 128]> = encrypted_bits
+            .into_boxed_slice()
+            .try_into()
+            .expect("the vec has 128 elements");
+
+        Self::new(boxed)
+    }
+
     pub fn init_state(self, iv: KreyviumIV, sk: &ServerKey) -> KreyviumFheState {
         KreyviumFheState::new(self, iv, sk)
+    }
+
+    /// Decrypt the key bits
+    pub fn decrypt(&self, client_key: &ClientKey) -> KreyviumPlainKey {
+        let mut decrypted_bits = [false; 128];
+        for (ct, out) in self.cts.iter().zip(decrypted_bits.iter_mut()) {
+            *out = client_key.decrypt(ct) != 0;
+        }
+        KreyviumPlainKey::from(decrypted_bits)
+    }
+
+    /// Borrow the underlying 128 single-bit shortint ciphertexts, MSB-first
+    /// within each byte of the packed key (see [`super::KreyviumPlainKey`]).
+    pub fn ciphertexts(&self) -> &[Ciphertext; 128] {
+        &self.cts
+    }
+}
+
+/// Serialization form of [`KreyviumFheKey`]. The 128 key ciphertexts are stored
+/// in a `Vec` because serde/versionize don't support arrays longer than 32; the
+/// fixed-size array is restored on deserialization.
+#[derive(Clone, Serialize, Deserialize, Versionize)]
+#[versionize(SerializableKreyviumFheKeyVersions)]
+pub struct SerializableKreyviumFheKey {
+    cts: Vec<Ciphertext>,
+}
+
+impl From<KreyviumFheKey> for SerializableKreyviumFheKey {
+    fn from(value: KreyviumFheKey) -> Self {
+        let cts: Box<[Ciphertext]> = value.cts;
+        Self {
+            cts: cts.into_vec(),
+        }
+    }
+}
+
+impl TryFrom<SerializableKreyviumFheKey> for KreyviumFheKey {
+    type Error = crate::Error;
+
+    fn try_from(value: SerializableKreyviumFheKey) -> Result<Self, Self::Error> {
+        let len = value.cts.len();
+        let cts: Box<[Ciphertext; 128]> =
+            value.cts.into_boxed_slice().try_into().map_err(|_| {
+                crate::error!("a kreyvium key must hold exactly 128 ciphertexts, got {len}")
+            })?;
+        Ok(Self { cts })
     }
 }
 

--- a/tfhe/src/transciphering/ciphers/kreyvium/mod.rs
+++ b/tfhe/src/transciphering/ciphers/kreyvium/mod.rs
@@ -12,7 +12,7 @@ mod test;
 
 use super::shift_register::ShiftRegister;
 
-pub use fhe::{KreyviumFheKey, KreyviumFheState};
+pub use fhe::{KreyviumFheKey, KreyviumFheState, SerializableKreyviumFheKey};
 pub use plain::{KreyviumIV, KreyviumPlainKey, KreyviumPlainState};
 use rayon::prelude::*;
 

--- a/tfhe/src/transciphering/ciphers/kreyvium/plain.rs
+++ b/tfhe/src/transciphering/ciphers/kreyvium/plain.rs
@@ -1,9 +1,13 @@
 //! Plaintext implementation of the Kreyvium Algorithm
 
+use crate::named::Named;
 use crate::shortint::ClientKey;
+use crate::transciphering::backward_compatibility::KreyviumIVVersions;
 use crate::transciphering::ciphers::shift_register::ShiftRegister;
 use crate::transciphering::ciphers::{pack_bits_lsb_first, unpack_bits_lsb_first};
 use crate::transciphering::{InsufficientKeystream, StreamCipher, StreamCipherKind};
+use serde::{Deserialize, Serialize};
+use tfhe_versionable::Versionize;
 
 use super::{
     KreyviumBackwardRoundOutput, KreyviumFheKey, KreyviumRound, KreyviumRoundInput,
@@ -16,6 +20,7 @@ fn unpack_key_bits(bytes: &[u8; 16]) -> [bool; 128] {
     out
 }
 
+#[derive(Clone, Copy)]
 pub struct KreyviumPlainKey {
     bits: [u8; 16],
 }
@@ -57,6 +62,8 @@ impl From<[bool; 128]> for KreyviumPlainKey {
     }
 }
 
+#[derive(Clone, Copy, Serialize, Deserialize, Versionize)]
+#[versionize(KreyviumIVVersions)]
 pub struct KreyviumIV {
     bits: [u8; 16],
 }
@@ -200,4 +207,8 @@ impl KreyviumRound for KreyviumPlainRoundInput<'_> {
 
         KreyviumBackwardRoundOutput { a, b, c }
     }
+}
+
+impl Named for KreyviumIV {
+    const NAME: &'static str = "transciphering::KreyviumIV";
 }

--- a/tfhe/src/transciphering/ciphers/one_time_pad/fhe.rs
+++ b/tfhe/src/transciphering/ciphers/one_time_pad/fhe.rs
@@ -1,7 +1,19 @@
-use crate::shortint::ciphertext::{Ciphertext, NoiseLevel};
-use crate::shortint::server_key::ServerKey;
-use crate::transciphering::{FheKeyStream, InsufficientKeystream, StreamCipherKind, Transcipherer};
+use serde::{Deserialize, Serialize};
+use tfhe_versionable::Versionize;
 
+use crate::shortint::ciphertext::{Ciphertext, NoiseLevel};
+use crate::shortint::client_key::ClientKey;
+use crate::shortint::oprf::OprfSeed;
+use crate::shortint::server_key::ServerKey;
+use crate::transciphering::backward_compatibility::OneTimePadFheSecretMaskVersions;
+use crate::transciphering::ciphers::one_time_pad::plain::OneTimePadPlainSecretMask;
+use crate::transciphering::ciphers::pack_bits_lsb_first;
+use crate::transciphering::{
+    FheKeyStream, InsufficientKeystream, StreamCipherKind, Transcipherer, TranscipheringServerKey,
+};
+
+#[derive(Clone, Serialize, Deserialize, Versionize)]
+#[versionize(OneTimePadFheSecretMaskVersions)]
 pub struct OneTimePadFheSecretMask {
     /// Collection of encrypted random bits, from which one can pull secret bits to hide sensitive
     /// values by XOR-ing them together.
@@ -33,9 +45,45 @@ impl OneTimePadFheSecretMask {
         Self::try_new(secret_mask).unwrap()
     }
 
+    pub fn new_random(
+        seed: impl OprfSeed,
+        transciphering_key: &TranscipheringServerKey,
+        sks: &ServerKey,
+        n_bits: u64,
+    ) -> Self {
+        let encrypted_bits = transciphering_key
+            .oprf_key()
+            .generate_random_boolean_sequence(seed, n_bits, sks);
+
+        Self::new(encrypted_bits)
+    }
+
     /// Single bit per [`Ciphertext`].
     fn bit_count(&self) -> usize {
         self.secret_mask.len()
+    }
+
+    /// Borrow the pad bits, one single-bit shortint ciphertext per bit.
+    pub fn ciphertexts(&self) -> &[Ciphertext] {
+        &self.secret_mask
+    }
+
+    /// Decrypt the pad bits. Inverse of [`OneTimePadPlainSecretMask::encrypt`],
+    /// so the recovered mask drives a [`OneTimePadPlainState`] that stays in
+    /// step with the [`OneTimePadFheState`] built from `self`.
+    ///
+    /// [`OneTimePadPlainState`]: super::OneTimePadPlainState
+    pub fn decrypt(&self, client_key: &ClientKey) -> OneTimePadPlainSecretMask {
+        let bits: Vec<bool> = self
+            .secret_mask
+            .iter()
+            .map(|ct| client_key.decrypt(ct) != 0)
+            .collect();
+
+        let mut bytes = vec![0u8; bits.len().div_ceil(8)];
+        pack_bits_lsb_first(&bits, &mut bytes);
+
+        OneTimePadPlainSecretMask::new(bytes, bits.len())
     }
 }
 

--- a/tfhe/src/transciphering/ciphers/one_time_pad/plain.rs
+++ b/tfhe/src/transciphering/ciphers/one_time_pad/plain.rs
@@ -1,8 +1,15 @@
+use serde::{Deserialize, Serialize};
+use tfhe_versionable::Versionize;
+
+use crate::named::Named;
 use crate::shortint::client_key::ClientKey;
+use crate::transciphering::backward_compatibility::OneTimePadPlainSecretMaskVersions;
 use crate::transciphering::ciphers::one_time_pad::fhe::OneTimePadFheSecretMask;
 use crate::transciphering::ciphers::unpack_bits_lsb_first;
 use crate::transciphering::{InsufficientKeystream, StreamCipher, StreamCipherKind};
 
+#[derive(Clone, Serialize, Deserialize, Versionize)]
+#[versionize(OneTimePadPlainSecretMaskVersions)]
 pub struct OneTimePadPlainSecretMask {
     /// Collection of random u8, from which one can pull secret bits to hide sensitive values by
     /// XOR-ing them together.
@@ -43,6 +50,10 @@ impl OneTimePadPlainSecretMask {
 
         OneTimePadFheSecretMask::new(secret_mask)
     }
+}
+
+impl Named for OneTimePadPlainSecretMask {
+    const NAME: &'static str = "transciphering::OneTimePadPlainSecretMask";
 }
 
 pub struct OneTimePadPlainState {

--- a/tfhe/src/transciphering/keys.rs
+++ b/tfhe/src/transciphering/keys.rs
@@ -1,0 +1,150 @@
+use crate::conformance::ParameterSetConformant;
+use crate::shortint::oprf::{
+    CompressedOprfServerKey, ExpandedOprfServerKey, OprfPrivateKey, OprfServerKey,
+};
+use crate::shortint::parameters::TranscipheringParameters;
+use crate::shortint::{AtomicPatternParameters, ClientKey};
+use crate::transciphering::backward_compatibility::{
+    CompressedTranscipheringServerKeyVersions, TranscipheringPrivateKeyVersions,
+    TranscipheringServerKeyVersions,
+};
+use serde::{Deserialize, Serialize};
+use tfhe_versionable::Versionize;
+
+/// Secret key material of the transciphering subsystem.
+///
+/// Its OPRF key is sampled independently of the general purpose one, so that the key material
+/// handed to a client (symmetric keys, one time pads) does not derive from a key used elsewhere.
+#[derive(Clone, Debug, Serialize, Deserialize, Versionize)]
+#[versionize(TranscipheringPrivateKeyVersions)]
+pub struct TranscipheringPrivateKey {
+    oprf_key: OprfPrivateKey,
+    params: TranscipheringParameters,
+}
+
+impl TranscipheringPrivateKey {
+    pub fn new(ck: &ClientKey, params: TranscipheringParameters) -> Self {
+        let oprf_key = match params {
+            TranscipheringParameters::SameAsCompute => OprfPrivateKey::new(ck),
+        };
+
+        Self { oprf_key, params }
+    }
+
+    pub fn oprf_key(&self) -> &OprfPrivateKey {
+        &self.oprf_key
+    }
+
+    pub fn params(&self) -> TranscipheringParameters {
+        self.params
+    }
+
+    pub fn from_raw_parts(oprf_key: OprfPrivateKey, params: TranscipheringParameters) -> Self {
+        Self { oprf_key, params }
+    }
+
+    pub fn into_raw_parts(self) -> (OprfPrivateKey, TranscipheringParameters) {
+        (self.oprf_key, self.params)
+    }
+}
+
+/// Key material of the transciphering subsystem.
+///
+/// Taking this rather than a plain [`OprfServerKey`] is what keeps the ciphers from drawing their
+/// key material from the general purpose OPRF key or, through it, from the compute key.
+#[derive(Clone, Serialize, Deserialize, Versionize)]
+#[versionize(TranscipheringServerKeyVersions)]
+pub struct TranscipheringServerKey {
+    oprf_key: OprfServerKey,
+}
+
+/// The key bootstraps into the compute key, so it is checked against the compute parameters.
+///
+/// A key that does not match them makes the pseudo random generation it is used for panic.
+impl ParameterSetConformant for TranscipheringServerKey {
+    type ParameterSet = AtomicPatternParameters;
+
+    fn is_conformant(&self, parameter_set: &Self::ParameterSet) -> bool {
+        self.oprf_key.is_conformant(parameter_set)
+    }
+}
+
+impl TranscipheringServerKey {
+    pub fn new(sk: &TranscipheringPrivateKey, target_ck: &ClientKey) -> crate::Result<Self> {
+        OprfServerKey::new(sk.oprf_key(), target_ck).map(|oprf_key| Self { oprf_key })
+    }
+
+    pub fn oprf_key(&self) -> &OprfServerKey {
+        &self.oprf_key
+    }
+
+    pub fn from_raw_parts(oprf_key: OprfServerKey) -> Self {
+        Self { oprf_key }
+    }
+
+    pub fn into_raw_parts(self) -> OprfServerKey {
+        self.oprf_key
+    }
+}
+
+/// Seeded form of [`TranscipheringServerKey`], which is what gets stored and transmitted.
+#[derive(Clone, Serialize, Deserialize, Versionize)]
+#[versionize(CompressedTranscipheringServerKeyVersions)]
+pub struct CompressedTranscipheringServerKey {
+    oprf_key: CompressedOprfServerKey,
+}
+
+impl ParameterSetConformant for CompressedTranscipheringServerKey {
+    type ParameterSet = AtomicPatternParameters;
+
+    fn is_conformant(&self, parameter_set: &Self::ParameterSet) -> bool {
+        self.oprf_key.is_conformant(parameter_set)
+    }
+}
+
+impl CompressedTranscipheringServerKey {
+    pub fn new(sk: &TranscipheringPrivateKey, target_ck: &ClientKey) -> crate::Result<Self> {
+        CompressedOprfServerKey::new(sk.oprf_key(), target_ck).map(|oprf_key| Self { oprf_key })
+    }
+
+    pub fn expand(&self) -> ExpandedTranscipheringServerKey {
+        ExpandedTranscipheringServerKey {
+            oprf_key: self.oprf_key.expand(),
+        }
+    }
+
+    pub fn oprf_key(&self) -> &CompressedOprfServerKey {
+        &self.oprf_key
+    }
+
+    pub fn from_raw_parts(oprf_key: CompressedOprfServerKey) -> Self {
+        Self { oprf_key }
+    }
+
+    pub fn into_raw_parts(self) -> CompressedOprfServerKey {
+        self.oprf_key
+    }
+}
+
+/// [`CompressedTranscipheringServerKey`] expanded to the standard domain, before the Fourier
+/// conversion done by [`Self::to_fourier`].
+#[derive(PartialEq, Eq)]
+pub struct ExpandedTranscipheringServerKey {
+    oprf_key: ExpandedOprfServerKey,
+}
+
+impl ExpandedTranscipheringServerKey {
+    pub fn to_fourier(&self) -> TranscipheringServerKey {
+        TranscipheringServerKey {
+            oprf_key: self.oprf_key.to_fourier(),
+        }
+    }
+
+    pub fn from_raw_parts(oprf_key: ExpandedOprfServerKey) -> Self {
+        Self { oprf_key }
+    }
+
+    pub fn into_raw_parts(self) -> ExpandedOprfServerKey {
+        self.oprf_key
+    }
+}

--- a/tfhe/src/transciphering/mod.rs
+++ b/tfhe/src/transciphering/mod.rs
@@ -15,9 +15,8 @@
 //! use rand::Rng;
 //! use tfhe::shortint::prelude::*;
 //! use tfhe::shortint::parameters::current_params::V1_7_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
-//! use tfhe::transciphering::{StreamCipher, Transcipherer};
-//! use tfhe::transciphering::ciphers::kreyvium::{
-//!     KreyviumFheState, KreyviumPlainKey, KreyviumPlainState,
+//! use tfhe::transciphering::{
+//!     KreyviumFheState, KreyviumPlainKey, KreyviumPlainState, StreamCipher, Transcipherer,
 //! };
 //!
 //! let (client_key, server_key) =
@@ -51,6 +50,24 @@
 
 pub mod backward_compatibility;
 pub mod ciphers;
+mod keys;
+
+pub use keys::{
+    CompressedTranscipheringServerKey, ExpandedTranscipheringServerKey, TranscipheringPrivateKey,
+    TranscipheringServerKey,
+};
+
+pub use ciphers::aes::{
+    AesFheKey, AesFheRoundKeys, AesFheState, AesIv, AesPlainKey, AesPlainState,
+    SerializableAesFheKey,
+};
+pub use ciphers::kreyvium::{
+    KreyviumFheKey, KreyviumFheState, KreyviumIV, KreyviumPlainKey, KreyviumPlainState,
+    SerializableKreyviumFheKey,
+};
+pub use ciphers::one_time_pad::{
+    OneTimePadFheSecretMask, OneTimePadFheState, OneTimePadPlainSecretMask, OneTimePadPlainState,
+};
 
 use rayon::prelude::*;
 use tfhe_versionable::Versionize;
@@ -61,9 +78,6 @@ use crate::shortint::{Ciphertext, ServerKey};
 use crate::transciphering::backward_compatibility::{
     StreamCipherKindVersions, StreamCiphertextVersions,
 };
-use ciphers::aes::AesFheState;
-use ciphers::kreyvium::KreyviumFheState;
-use ciphers::one_time_pad::OneTimePadFheState;
 
 /// Identifier for a concrete stream-cipher family.
 ///
@@ -317,18 +331,7 @@ pub trait Transcipherer {
         sks: &ServerKey,
         input: &StreamCiphertext,
     ) -> Result<Vec<Ciphertext>, TranscipherError> {
-        if input.kind != self.kind() {
-            return Err(TranscipherError::KindMismatch {
-                session_kind: self.kind(),
-                ciphertext_kind: input.kind,
-            });
-        }
-        if input.encryption_counter != self.current_counter() {
-            return Err(TranscipherError::CounterMismatch {
-                session_counter: self.current_counter(),
-                ciphertext_counter: input.encryption_counter,
-            });
-        }
+        check_transcipher_input(self, input)?;
 
         let keystream = self.next_keystream_bits(sks, input.n_bits)?;
         Ok(apply_keystream(sks, &keystream, input))
@@ -434,6 +437,26 @@ impl<'a> IntoIterator for &'a FheKeyStream {
 /// LSB-first bit `i` of `bytes` (i.e. `bytes[i / 8] >> (i % 8) & 1`).
 fn bit_at(bytes: &[u8], i: usize) -> u8 {
     (bytes[i / 8] >> (i % 8)) & 1
+}
+
+fn check_transcipher_input<T: Transcipherer + ?Sized>(
+    transcipherer: &T,
+    input: &StreamCiphertext,
+) -> Result<(), TranscipherError> {
+    if input.kind != transcipherer.kind() {
+        return Err(TranscipherError::KindMismatch {
+            session_kind: transcipherer.kind(),
+            ciphertext_kind: input.kind,
+        });
+    }
+    if input.encryption_counter != transcipherer.current_counter() {
+        return Err(TranscipherError::CounterMismatch {
+            session_counter: transcipherer.current_counter(),
+            ciphertext_counter: input.encryption_counter,
+        });
+    }
+
+    Ok(())
 }
 
 /// Xor an FHE keystream with a clear [`StreamCiphertext`].


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description
small fixes made to the transciphering layer needed for the integer and hl api:
- orpf generation with dedicated/newtype keys
- serialization
- decrypt method on the fhe encrypted key

I created a dedicated TranscipheringParameters enum. For the moment there is only one variant: `SameAsCompute`. This means that the transciphering key will be created using the compute parameters. This prepares the APIs to future optimizations where we might have dedicated parameters for the transciphering.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3835)
<!-- Reviewable:end -->
