### PR TITLE
fix(shortint): explicit panic if carry_modulus is 0

### DIFF
--- a/tfhe/src/integer/server_key/mod.rs
+++ b/tfhe/src/integer/server_key/mod.rs
@@ -51,11 +51,15 @@ impl MaxDegree {
     /// [`RadixCiphertext`](`crate::integer::RadixCiphertext`) (which includes adding the extracted
     /// carry from one shortint block to the next block), this formula provisions space to add a
     /// carry.
+    ///
+    /// # Panics
+    ///
+    /// Panics if either modulus is 0.
     pub(crate) fn integer_radix_server_key(
         message_modulus: MessageModulus,
         carry_modulus: CarryModulus,
     ) -> Self {
-        let full_max_degree = message_modulus.0 * carry_modulus.0 - 1;
+        let full_max_degree = Self::from_msg_carry_modulus(message_modulus, carry_modulus).get();
 
         let carry_max_degree = carry_modulus.0 - 1;
 
@@ -68,13 +72,15 @@ impl MaxDegree {
     /// Compute the [`MaxDegree`] for an integer server key (compressed or uncompressed).
     /// This is tailored for [`CrtCiphertext`](`crate::integer::CrtCiphertext`) and not compatible
     /// for use with [`RadixCiphertext`](`crate::integer::RadixCiphertext`).
+    ///
+    /// # Panics
+    ///
+    /// Panics if either modulus is 0.
     fn integer_crt_server_key(
         message_modulus: MessageModulus,
         carry_modulus: CarryModulus,
     ) -> Self {
-        let full_max_degree = message_modulus.0 * carry_modulus.0 - 1;
-
-        Self::new(full_max_degree)
+        Self::from_msg_carry_modulus(message_modulus, carry_modulus)
     }
 }
 

--- a/tfhe/src/shortint/ciphertext/common.rs
+++ b/tfhe/src/shortint/ciphertext/common.rs
@@ -39,7 +39,7 @@ impl MaxNoiseLevel {
     /// # Panics
     ///
     /// Panics if `msg_modulus` is smaller than 2, as a message space holding less than 2 values is
-    /// degenerate and the norm2 limit is not defined for it.
+    /// degenerate and the norm2 limit is not defined for it, or if `carry_modulus` is 0.
     // This function is valid for current parameters as they guarantee the p-error for a norm2 noise
     // limit equal to the norm2 limit which guarantees a clean padding bit
     //
@@ -52,6 +52,10 @@ impl MaxNoiseLevel {
         assert!(
             msg_modulus.0 >= 2,
             "MessageModulus must be at least 2 to derive a MaxNoiseLevel"
+        );
+        assert!(
+            carry_modulus.0 != 0,
+            "CarryModulus must be non zero to derive a MaxNoiseLevel"
         );
         let level = (carry_modulus.0 * msg_modulus.0 - 1) / (msg_modulus.0 - 1);
         Self(level)
@@ -304,9 +308,21 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "CarryModulus must be non zero")]
+    fn test_max_noise_level_from_zero_carry_modulus_ci_run_filter() {
+        let _ = MaxNoiseLevel::from_msg_carry_modulus(MessageModulus(2), CarryModulus(0));
+    }
+
+    #[test]
     #[should_panic(expected = "must both be non zero")]
     fn test_max_degree_from_zero_msg_modulus_ci_run_filter() {
         let _ = MaxDegree::from_msg_carry_modulus(MessageModulus(0), CarryModulus(2));
+    }
+
+    #[test]
+    #[should_panic(expected = "must both be non zero")]
+    fn test_max_degree_from_zero_carry_modulus_ci_run_filter() {
+        let _ = MaxDegree::from_msg_carry_modulus(MessageModulus(2), CarryModulus(0));
     }
 
     #[test]

--- a/tfhe/src/shortint/ciphertext/compact_list.rs
+++ b/tfhe/src/shortint/ciphertext/compact_list.rs
@@ -202,10 +202,19 @@ impl ParameterSetConformant for ExpandedCiphertextList {
             carry_modulus: params_carry_modulus,
         } = parameter_set;
 
+        if params_message_modulus.0 == 0 {
+            return false;
+        }
+
+        if is_packed && params_carry_modulus.0 < params_message_modulus.0 {
+            // parameters do not support packing
+            return false;
+        }
+
         let expected_degree = if is_packed {
-            Degree::new(message_modulus.0 * message_modulus.0 - 1)
+            Degree::new(params_message_modulus.0 * params_message_modulus.0 - 1)
         } else {
-            Degree::new(message_modulus.0 - 1)
+            Degree::new(params_message_modulus.0 - 1)
         };
 
         ct_list.is_conformant(ct_list_params)


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: https://github.com/zama-ai/tfhe-rs/issues/3831

### PR content/description
3 things:
- add explicit panic when computing max noise level for CarryModulus(0), which is better than a silent underflow
- use `MaxDegree::from_msg_carry_modulus` when possible instead of recomputing it, to have the explicit panic from https://github.com/zama-ai/tfhe-rs/pull/3827
- use message and carry moduli from parameters in conformance checks if possible

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3839)
<!-- Reviewable:end -->
