### PR TITLE
fix(gpu): add reproducibility in oprf uniformity test

### DIFF
--- a/tfhe/src/integer/gpu/server_key/radix/tests_signed/test_oprf.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/tests_signed/test_oprf.rs
@@ -11,11 +11,13 @@ use crate::shortint::parameters::{
 };
 
 create_gpu_parameterized_test!(oprf_signed_uniformity_bounded {
-    PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128
+    PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+    TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128
 });
 
 create_gpu_parameterized_test!(oprf_signed_uniformity_unbounded {
-    PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128
+    PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+    TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128
 });
 
 create_gpu_parameterized_test!(oprf_compare_plain_signed {

--- a/tfhe/src/integer/gpu/server_key/radix/tests_unsigned/test_oprf.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/tests_unsigned/test_oprf.rs
@@ -34,7 +34,8 @@ create_gpu_parameterized_test!(oprf_almost_uniformity_unsigned {
     TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128
 });
 create_gpu_parameterized_test!(oprf_zero_input_bits_unsigned {
-    PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128
+    PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+    TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128
 });
 
 create_gpu_parameterized_test!(pseudo_random_integer_and_rerand {

--- a/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_oprf.rs
+++ b/tfhe/src/integer/server_key/radix_parallel/tests_unsigned/test_oprf.rs
@@ -6,7 +6,6 @@ use crate::integer::ciphertext::{
     IntegerRadixCiphertext, PrfReRandomizationContext, RadixCiphertext, ReRandomizationHashAlgo,
     ReRandomizationKey, ReRandomizationSeedHasher, SignedRadixCiphertext,
 };
-use crate::integer::keycache::KEY_CACHE;
 use crate::integer::oprf::{OprfPrivateKey, OprfServerKey};
 use crate::integer::server_key::radix_parallel::tests_long_run::OpSequenceFunctionExecutor;
 use crate::integer::server_key::radix_parallel::tests_unsigned::CpuOprfExecutor;
@@ -204,21 +203,33 @@ pub(crate) fn setup_oprf_test<I, O, E>(
 where
     E: OpSequenceFunctionExecutor<I, O>,
 {
-    let (cks, mut sks) = KEY_CACHE.get_from_params(param, IntegerKeyKind::Radix);
-    sks.set_deterministic_pbs_execution(true);
-
-    let mut rng = rand::thread_rng();
-    let seed: u128 = rng.gen();
+    // TFHE_OPRF_TEST_SEED forces the seed, to replay a failing run: it is the only source of
+    // randomness of this test, so it is enough to reproduce a failure bit for bit.
+    let seed: u128 = std::env::var("TFHE_OPRF_TEST_SEED").ok().map_or_else(
+        || rand::thread_rng().gen(),
+        |forced| {
+            forced
+                .trim()
+                .parse()
+                .expect("TFHE_OPRF_TEST_SEED must be a u128 written in base 10")
+        },
+    );
     println!("seed: {seed:?}");
+    println!("set TFHE_OPRF_TEST_SEED={seed} to replay this run");
     let mut deterministic_seeder = DeterministicSeeder::<DefaultRandomGenerator>::new(Seed(seed));
 
-    // Install a deterministic ShortintEngine on this thread so that OPRF private key
-    // generation and CompressedServerKey::new below are reproducible across runs.
+    // Install a deterministic ShortintEngine on this thread before generating any key, so that
+    // every key used by the test (client key, OPRF private key and the server keys below) is
+    // derived from the printed seed and the test is fully reproducible from it.
+    //
+    // This is also why the client key is generated here instead of being taken from KEY_CACHE:
+    // cached keys are machine dependent, so they would not be part of the reproducible state.
     let shortint_engine = ShortintEngine::new_from_seeder(&mut deterministic_seeder);
     ShortintEngine::with_thread_local_mut(|local_engine| {
         let _ = std::mem::replace(local_engine, shortint_engine);
     });
 
+    let cks = ClientKey::new(param.into());
     let oprf_priv_key = OprfPrivateKey::new(&cks);
     let temp_cks = crate::ClientKey::from_raw_parts(
         cks.clone(),


### PR DESCRIPTION
- Improves the oprf test debug print to include the distribution
- Allows the user to specify the oprf seed using an env variable

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3840)
<!-- Reviewable:end -->
