### PR TITLE
feat(gpu): add DISPATCH_POLY_SIZE macro to replace manual switch dispatches

### DIFF
--- a/backends/tfhe-cuda-backend/cuda/src/crypto/ciphertext.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/crypto/ciphertext.cu
@@ -1,4 +1,5 @@
 #include "ciphertext.cuh"
+#include "polynomial/dispatch.cuh"
 #include "polynomial/parameters.cuh"
 
 void cuda_convert_lwe_ciphertext_vector_to_gpu_64_async(
@@ -23,53 +24,13 @@ void cuda_glwe_sample_extract_64_async(
     uint32_t num_lwes_to_extract_per_glwe, uint32_t num_lwes_stored_per_glwe,
     uint32_t glwe_dimension, uint32_t polynomial_size) {
 
-  switch (polynomial_size) {
-  case 256:
-    host_sample_extract<uint64_t, AmortizedDegree<256>>(
-        static_cast<cudaStream_t>(stream), gpu_index, (uint64_t *)lwe_array_out,
-        (uint64_t const *)glwe_array_in, (uint32_t const *)nth_array, num_nths,
-        num_lwes_to_extract_per_glwe, num_lwes_stored_per_glwe, glwe_dimension);
-    break;
-  case 512:
-    host_sample_extract<uint64_t, AmortizedDegree<512>>(
-        static_cast<cudaStream_t>(stream), gpu_index, (uint64_t *)lwe_array_out,
-        (uint64_t const *)glwe_array_in, (uint32_t const *)nth_array, num_nths,
-        num_lwes_to_extract_per_glwe, num_lwes_stored_per_glwe, glwe_dimension);
-    break;
-  case 1024:
-    host_sample_extract<uint64_t, AmortizedDegree<1024>>(
-        static_cast<cudaStream_t>(stream), gpu_index, (uint64_t *)lwe_array_out,
-        (uint64_t const *)glwe_array_in, (uint32_t const *)nth_array, num_nths,
-        num_lwes_to_extract_per_glwe, num_lwes_stored_per_glwe, glwe_dimension);
-    break;
-  case 2048:
-    host_sample_extract<uint64_t, AmortizedDegree<2048>>(
-        static_cast<cudaStream_t>(stream), gpu_index, (uint64_t *)lwe_array_out,
-        (uint64_t const *)glwe_array_in, (uint32_t const *)nth_array, num_nths,
-        num_lwes_to_extract_per_glwe, num_lwes_stored_per_glwe, glwe_dimension);
-    break;
-  case 4096:
-    host_sample_extract<uint64_t, AmortizedDegree<4096>>(
-        static_cast<cudaStream_t>(stream), gpu_index, (uint64_t *)lwe_array_out,
-        (uint64_t const *)glwe_array_in, (uint32_t const *)nth_array, num_nths,
-        num_lwes_to_extract_per_glwe, num_lwes_stored_per_glwe, glwe_dimension);
-    break;
-  case 8192:
-    host_sample_extract<uint64_t, AmortizedDegree<8192>>(
-        static_cast<cudaStream_t>(stream), gpu_index, (uint64_t *)lwe_array_out,
-        (uint64_t const *)glwe_array_in, (uint32_t const *)nth_array, num_nths,
-        num_lwes_to_extract_per_glwe, num_lwes_stored_per_glwe, glwe_dimension);
-    break;
-  case 16384:
-    host_sample_extract<uint64_t, AmortizedDegree<16384>>(
-        static_cast<cudaStream_t>(stream), gpu_index, (uint64_t *)lwe_array_out,
-        (uint64_t const *)glwe_array_in, (uint32_t const *)nth_array, num_nths,
-        num_lwes_to_extract_per_glwe, num_lwes_stored_per_glwe, glwe_dimension);
-    break;
-  default:
-    PANIC("Cuda error: unsupported polynomial size. Supported "
-          "N's are powers of two in the interval [256..16384].")
-  }
+  DISPATCH_POLY_SIZE(
+      polynomial_size, AmortizedDegreePolicy,
+      host_sample_extract<uint64_t, Params>(
+          static_cast<cudaStream_t>(stream), gpu_index,
+          (uint64_t *)lwe_array_out, (uint64_t const *)glwe_array_in,
+          (uint32_t const *)nth_array, num_nths, num_lwes_to_extract_per_glwe,
+          num_lwes_stored_per_glwe, glwe_dimension));
 }
 
 void cuda_modulus_switch_inplace_64_async(void *stream, uint32_t gpu_index,
@@ -121,46 +82,13 @@ void cuda_glwe_sample_extract_128_async(
     uint32_t num_lwes_to_extract_per_glwe, uint32_t num_lwes_stored_per_glwe,
     uint32_t glwe_dimension, uint32_t polynomial_size) {
 
-  switch (polynomial_size) {
-  case 256:
-    host_sample_extract<__uint128_t, AmortizedDegree<256>>(
-        static_cast<cudaStream_t>(stream), gpu_index,
-        (__uint128_t *)lwe_array_out, (__uint128_t const *)glwe_array_in,
-        (uint32_t const *)nth_array, num_nths, num_lwes_to_extract_per_glwe,
-        num_lwes_stored_per_glwe, glwe_dimension);
-    break;
-  case 512:
-    host_sample_extract<__uint128_t, AmortizedDegree<512>>(
-        static_cast<cudaStream_t>(stream), gpu_index,
-        (__uint128_t *)lwe_array_out, (__uint128_t const *)glwe_array_in,
-        (uint32_t const *)nth_array, num_nths, num_lwes_to_extract_per_glwe,
-        num_lwes_stored_per_glwe, glwe_dimension);
-    break;
-  case 1024:
-    host_sample_extract<__uint128_t, AmortizedDegree<1024>>(
-        static_cast<cudaStream_t>(stream), gpu_index,
-        (__uint128_t *)lwe_array_out, (__uint128_t const *)glwe_array_in,
-        (uint32_t const *)nth_array, num_nths, num_lwes_to_extract_per_glwe,
-        num_lwes_stored_per_glwe, glwe_dimension);
-    break;
-  case 2048:
-    host_sample_extract<__uint128_t, AmortizedDegree<2048>>(
-        static_cast<cudaStream_t>(stream), gpu_index,
-        (__uint128_t *)lwe_array_out, (__uint128_t const *)glwe_array_in,
-        (uint32_t const *)nth_array, num_nths, num_lwes_to_extract_per_glwe,
-        num_lwes_stored_per_glwe, glwe_dimension);
-    break;
-  case 4096:
-    host_sample_extract<__uint128_t, AmortizedDegree<4096>>(
-        static_cast<cudaStream_t>(stream), gpu_index,
-        (__uint128_t *)lwe_array_out, (__uint128_t const *)glwe_array_in,
-        (uint32_t const *)nth_array, num_nths, num_lwes_to_extract_per_glwe,
-        num_lwes_stored_per_glwe, glwe_dimension);
-    break;
-  default:
-    PANIC("Cuda error: unsupported polynomial size. Supported "
-          "N's are powers of two in the interval [256..4096].")
-  }
+  DISPATCH_POLY_SIZE(
+      polynomial_size, AmortizedDegreePolicy128,
+      host_sample_extract<__uint128_t, Params>(
+          static_cast<cudaStream_t>(stream), gpu_index,
+          (__uint128_t *)lwe_array_out, (__uint128_t const *)glwe_array_in,
+          (uint32_t const *)nth_array, num_nths, num_lwes_to_extract_per_glwe,
+          num_lwes_stored_per_glwe, glwe_dimension));
 }
 
 void cuda_modulus_switch_multi_bit_64_async(void *stream, uint32_t gpu_index,

--- a/backends/tfhe-cuda-backend/cuda/src/fft128/fft128.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/fft128/fft128.cu
@@ -1,163 +1,38 @@
 #include "fft128.cuh"
+#include "polynomial/dispatch.cuh"
 
 void cuda_fourier_transform_forward_as_integer_f128_async(
     void *stream, uint32_t gpu_index, void *re0, void *re1, void *im0,
     void *im1, void const *standard, const uint32_t N,
     const uint32_t number_of_samples) {
-  switch (N) {
-  case 64:
-    host_fourier_transform_forward_as_integer_f128<AmortizedDegree<64>>(
-        static_cast<cudaStream_t>(stream), gpu_index, (double *)re0,
-        (double *)re1, (double *)im0, (double *)im1,
-        (__uint128_t const *)standard, N, number_of_samples);
-    break;
-  case 128:
-    host_fourier_transform_forward_as_integer_f128<AmortizedDegree<128>>(
-        static_cast<cudaStream_t>(stream), gpu_index, (double *)re0,
-        (double *)re1, (double *)im0, (double *)im1,
-        (__uint128_t const *)standard, N, number_of_samples);
-    break;
-  case 256:
-    host_fourier_transform_forward_as_integer_f128<AmortizedDegree<256>>(
-        static_cast<cudaStream_t>(stream), gpu_index, (double *)re0,
-        (double *)re1, (double *)im0, (double *)im1,
-        (__uint128_t const *)standard, N, number_of_samples);
-    break;
-  case 512:
-    host_fourier_transform_forward_as_integer_f128<AmortizedDegree<512>>(
-        static_cast<cudaStream_t>(stream), gpu_index, (double *)re0,
-        (double *)re1, (double *)im0, (double *)im1,
-        (__uint128_t const *)standard, N, number_of_samples);
-    break;
-  case 1024:
-    host_fourier_transform_forward_as_integer_f128<AmortizedDegree<1024>>(
-        static_cast<cudaStream_t>(stream), gpu_index, (double *)re0,
-        (double *)re1, (double *)im0, (double *)im1,
-        (__uint128_t const *)standard, N, number_of_samples);
-    break;
-  case 2048:
-    host_fourier_transform_forward_as_integer_f128<AmortizedDegree<2048>>(
-        static_cast<cudaStream_t>(stream), gpu_index, (double *)re0,
-        (double *)re1, (double *)im0, (double *)im1,
-        (__uint128_t const *)standard, N, number_of_samples);
-    break;
-  case 4096:
-    host_fourier_transform_forward_as_integer_f128<AmortizedDegree<4096>>(
-        static_cast<cudaStream_t>(stream), gpu_index, (double *)re0,
-        (double *)re1, (double *)im0, (double *)im1,
-        (__uint128_t const *)standard, N, number_of_samples);
-    break;
-  default:
-    PANIC("Cuda error (f128 fft): unsupported polynomial size. Supported "
-          "N's are powers of two"
-          " in the interval [64..4096].")
-  }
+  DISPATCH_POLY_SIZE(N, AmortizedDegreePolicyFFT128,
+                     host_fourier_transform_forward_as_integer_f128<Params>(
+                         static_cast<cudaStream_t>(stream), gpu_index,
+                         (double *)re0, (double *)re1, (double *)im0,
+                         (double *)im1, (__uint128_t const *)standard, N,
+                         number_of_samples));
 }
 
 void cuda_fourier_transform_forward_as_torus_f128_async(
     void *stream, uint32_t gpu_index, void *re0, void *re1, void *im0,
     void *im1, void const *standard, const uint32_t N,
     const uint32_t number_of_samples) {
-  switch (N) {
-  case 64:
-    host_fourier_transform_forward_as_torus_f128<AmortizedDegree<64>>(
-        static_cast<cudaStream_t>(stream), gpu_index, (double *)re0,
-        (double *)re1, (double *)im0, (double *)im1,
-        (__uint128_t const *)standard, N, number_of_samples);
-    break;
-  case 128:
-    host_fourier_transform_forward_as_torus_f128<AmortizedDegree<128>>(
-        static_cast<cudaStream_t>(stream), gpu_index, (double *)re0,
-        (double *)re1, (double *)im0, (double *)im1,
-        (__uint128_t const *)standard, N, number_of_samples);
-    break;
-  case 256:
-    host_fourier_transform_forward_as_torus_f128<AmortizedDegree<256>>(
-        static_cast<cudaStream_t>(stream), gpu_index, (double *)re0,
-        (double *)re1, (double *)im0, (double *)im1,
-        (__uint128_t const *)standard, N, number_of_samples);
-    break;
-  case 512:
-    host_fourier_transform_forward_as_torus_f128<AmortizedDegree<512>>(
-        static_cast<cudaStream_t>(stream), gpu_index, (double *)re0,
-        (double *)re1, (double *)im0, (double *)im1,
-        (__uint128_t const *)standard, N, number_of_samples);
-    break;
-  case 1024:
-    host_fourier_transform_forward_as_torus_f128<AmortizedDegree<1024>>(
-        static_cast<cudaStream_t>(stream), gpu_index, (double *)re0,
-        (double *)re1, (double *)im0, (double *)im1,
-        (__uint128_t const *)standard, N, number_of_samples);
-    break;
-  case 2048:
-    host_fourier_transform_forward_as_torus_f128<AmortizedDegree<2048>>(
-        static_cast<cudaStream_t>(stream), gpu_index, (double *)re0,
-        (double *)re1, (double *)im0, (double *)im1,
-        (__uint128_t const *)standard, N, number_of_samples);
-    break;
-  case 4096:
-    host_fourier_transform_forward_as_torus_f128<AmortizedDegree<4096>>(
-        static_cast<cudaStream_t>(stream), gpu_index, (double *)re0,
-        (double *)re1, (double *)im0, (double *)im1,
-        (__uint128_t const *)standard, N, number_of_samples);
-    break;
-  default:
-    PANIC("Cuda error (f128 fft): unsupported polynomial size. Supported "
-          "N's are powers of two"
-          " in the interval [64..4096].")
-  }
+  DISPATCH_POLY_SIZE(N, AmortizedDegreePolicyFFT128,
+                     host_fourier_transform_forward_as_torus_f128<Params>(
+                         static_cast<cudaStream_t>(stream), gpu_index,
+                         (double *)re0, (double *)re1, (double *)im0,
+                         (double *)im1, (__uint128_t const *)standard, N,
+                         number_of_samples));
 }
 
 void cuda_fourier_transform_backward_as_torus_f128_async(
     void *stream, uint32_t gpu_index, void *standard, void const *re0,
     void const *re1, void const *im0, void const *im1, const uint32_t N,
     const uint32_t number_of_samples) {
-  switch (N) {
-  case 64:
-    host_fourier_transform_backward_as_torus_f128<AmortizedDegree<64>>(
-        static_cast<cudaStream_t>(stream), gpu_index, (__uint128_t *)standard,
-        (double const *)re0, (double const *)re1, (double const *)im0,
-        (double const *)im1, N, number_of_samples);
-    break;
-  case 128:
-    host_fourier_transform_backward_as_torus_f128<AmortizedDegree<128>>(
-        static_cast<cudaStream_t>(stream), gpu_index, (__uint128_t *)standard,
-        (double const *)re0, (double const *)re1, (double const *)im0,
-        (double const *)im1, N, number_of_samples);
-    break;
-  case 256:
-    host_fourier_transform_backward_as_torus_f128<AmortizedDegree<256>>(
-        static_cast<cudaStream_t>(stream), gpu_index, (__uint128_t *)standard,
-        (double const *)re0, (double const *)re1, (double const *)im0,
-        (double const *)im1, N, number_of_samples);
-    break;
-  case 512:
-    host_fourier_transform_backward_as_torus_f128<AmortizedDegree<512>>(
-        static_cast<cudaStream_t>(stream), gpu_index, (__uint128_t *)standard,
-        (double const *)re0, (double const *)re1, (double const *)im0,
-        (double const *)im1, N, number_of_samples);
-    break;
-  case 1024:
-    host_fourier_transform_backward_as_torus_f128<AmortizedDegree<1024>>(
-        static_cast<cudaStream_t>(stream), gpu_index, (__uint128_t *)standard,
-        (double const *)re0, (double const *)re1, (double const *)im0,
-        (double const *)im1, N, number_of_samples);
-    break;
-  case 2048:
-    host_fourier_transform_backward_as_torus_f128<AmortizedDegree<2048>>(
-        static_cast<cudaStream_t>(stream), gpu_index, (__uint128_t *)standard,
-        (double const *)re0, (double const *)re1, (double const *)im0,
-        (double const *)im1, N, number_of_samples);
-    break;
-  case 4096:
-    host_fourier_transform_backward_as_torus_f128<AmortizedDegree<4096>>(
-        static_cast<cudaStream_t>(stream), gpu_index, (__uint128_t *)standard,
-        (double const *)re0, (double const *)re1, (double const *)im0,
-        (double const *)im1, N, number_of_samples);
-    break;
-  default:
-    PANIC("Cuda error (f128 ifft): unsupported polynomial size. Supported "
-          "N's are powers of two"
-          " in the interval [64..4096].")
-  }
+  DISPATCH_POLY_SIZE(N, AmortizedDegreePolicyFFT128,
+                     host_fourier_transform_backward_as_torus_f128<Params>(
+                         static_cast<cudaStream_t>(stream), gpu_index,
+                         (__uint128_t *)standard, (double const *)re0,
+                         (double const *)re1, (double const *)im0,
+                         (double const *)im1, N, number_of_samples));
 }

--- a/backends/tfhe-cuda-backend/cuda/src/integer/multiplication.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/multiplication.cu
@@ -1,4 +1,5 @@
 #include "integer/multiplication.cuh"
+#include "polynomial/dispatch.cuh"
 
 /*
  * when adding chunk_size times terms together, there might be some blocks
@@ -69,53 +70,12 @@ void cuda_integer_mult_inplace_64_async(
   // In-place variant: radix_lwe_inout *= radix_lwe_right, no aliasing check
   // needed
   PUSH_RANGE("mul_inplace")
-  switch (polynomial_size) {
-  case 256:
-    host_integer_mult_radix<uint64_t, AmortizedDegree<256>>(
-        CudaStreams(streams), radix_lwe_inout, radix_lwe_inout, is_bool_left,
-        radix_lwe_right, is_bool_right, bsks, (uint64_t **)(ksks),
-        (int_mul_memory<uint64_t> *)mem_ptr, num_blocks);
-    break;
-  case 512:
-    host_integer_mult_radix<uint64_t, AmortizedDegree<512>>(
-        CudaStreams(streams), radix_lwe_inout, radix_lwe_inout, is_bool_left,
-        radix_lwe_right, is_bool_right, bsks, (uint64_t **)(ksks),
-        (int_mul_memory<uint64_t> *)mem_ptr, num_blocks);
-    break;
-  case 1024:
-    host_integer_mult_radix<uint64_t, AmortizedDegree<1024>>(
-        CudaStreams(streams), radix_lwe_inout, radix_lwe_inout, is_bool_left,
-        radix_lwe_right, is_bool_right, bsks, (uint64_t **)(ksks),
-        (int_mul_memory<uint64_t> *)mem_ptr, num_blocks);
-    break;
-  case 2048:
-    host_integer_mult_radix<uint64_t, AmortizedDegree<2048>>(
-        CudaStreams(streams), radix_lwe_inout, radix_lwe_inout, is_bool_left,
-        radix_lwe_right, is_bool_right, bsks, (uint64_t **)(ksks),
-        (int_mul_memory<uint64_t> *)mem_ptr, num_blocks);
-    break;
-  case 4096:
-    host_integer_mult_radix<uint64_t, AmortizedDegree<4096>>(
-        CudaStreams(streams), radix_lwe_inout, radix_lwe_inout, is_bool_left,
-        radix_lwe_right, is_bool_right, bsks, (uint64_t **)(ksks),
-        (int_mul_memory<uint64_t> *)mem_ptr, num_blocks);
-    break;
-  case 8192:
-    host_integer_mult_radix<uint64_t, AmortizedDegree<8192>>(
-        CudaStreams(streams), radix_lwe_inout, radix_lwe_inout, is_bool_left,
-        radix_lwe_right, is_bool_right, bsks, (uint64_t **)(ksks),
-        (int_mul_memory<uint64_t> *)mem_ptr, num_blocks);
-    break;
-  case 16384:
-    host_integer_mult_radix<uint64_t, AmortizedDegree<16384>>(
-        CudaStreams(streams), radix_lwe_inout, radix_lwe_inout, is_bool_left,
-        radix_lwe_right, is_bool_right, bsks, (uint64_t **)(ksks),
-        (int_mul_memory<uint64_t> *)mem_ptr, num_blocks);
-    break;
-  default:
-    PANIC("Cuda error (integer multiplication): unsupported polynomial size. "
-          "Supported N's are powers of two in the interval [256..16384].")
-  }
+  DISPATCH_POLY_SIZE(polynomial_size, AmortizedDegreePolicy,
+                     host_integer_mult_radix<uint64_t, Params>(
+                         CudaStreams(streams), radix_lwe_inout, radix_lwe_inout,
+                         is_bool_left, radix_lwe_right, is_bool_right, bsks,
+                         (uint64_t **)(ksks),
+                         (int_mul_memory<uint64_t> *)mem_ptr, num_blocks));
   POP_RANGE()
 }
 
@@ -129,22 +89,15 @@ uint64_t scratch_cuda_integer_mult_inplace_64_async(
   int_radix_params params(bsk_params, ksk_params, message_modulus,
                           carry_modulus, noise_reduction_type);
 
-  switch (polynomial_size) {
-  case 256:
-  case 512:
-  case 1024:
-  case 2048:
-  case 4096:
-  case 8192:
-  case 16384:
-    return scratch_cuda_integer_mult_radix_ciphertext<uint64_t>(
-        CudaStreams(streams), (int_mul_memory<uint64_t> **)mem_ptr,
-        is_boolean_left, is_boolean_right, num_radix_blocks, params,
-        allocate_gpu_memory);
-  default:
+  if (polynomial_size < 256 || polynomial_size > 16384 ||
+      (polynomial_size & (polynomial_size - 1)) != 0)
     PANIC("Cuda error (integer multiplication): unsupported polynomial size. "
           "Supported N's are powers of two in the interval [256..16384].")
-  }
+
+  return scratch_cuda_integer_mult_radix_ciphertext<uint64_t>(
+      CudaStreams(streams), (int_mul_memory<uint64_t> **)mem_ptr,
+      is_boolean_left, is_boolean_right, num_radix_blocks, params,
+      allocate_gpu_memory);
 }
 
 void cleanup_cuda_integer_mult_inplace_64(CudaStreamsFFI streams,

--- a/backends/tfhe-cuda-backend/cuda/src/integer/rerand.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/rerand.cuh
@@ -6,6 +6,7 @@
 #include "integer/radix_ciphertext.h"
 #include "integer/rerand.h"
 #include "integer/rerand_utilities.h"
+#include "polynomial/dispatch.cuh"
 #include "utils/helper.cuh"
 #include "zk/zk_utilities.h"
 
@@ -97,47 +98,11 @@ void host_rerand_inplace_dispatch(
     CudaStreams const streams, Torus *lwe_array,
     const Torus *lwe_flattened_encryptions_of_zero_compact_array_in,
     Torus *const *ksk, int_rerand_mem<Torus> *mem_ptr) {
-  switch (mem_ptr->params.big_lwe_dimension) {
-  case 256:
-    host_rerand_inplace<Torus, AmortizedDegree<256>>(
-        streams, lwe_array, lwe_flattened_encryptions_of_zero_compact_array_in,
-        ksk, mem_ptr);
-    break;
-  case 512:
-    host_rerand_inplace<Torus, AmortizedDegree<512>>(
-        streams, lwe_array, lwe_flattened_encryptions_of_zero_compact_array_in,
-        ksk, mem_ptr);
-    break;
-  case 1024:
-    host_rerand_inplace<Torus, AmortizedDegree<1024>>(
-        streams, lwe_array, lwe_flattened_encryptions_of_zero_compact_array_in,
-        ksk, mem_ptr);
-    break;
-  case 2048:
-    host_rerand_inplace<Torus, AmortizedDegree<2048>>(
-        streams, lwe_array, lwe_flattened_encryptions_of_zero_compact_array_in,
-        ksk, mem_ptr);
-    break;
-  case 4096:
-    host_rerand_inplace<Torus, AmortizedDegree<4096>>(
-        streams, lwe_array, lwe_flattened_encryptions_of_zero_compact_array_in,
-        ksk, mem_ptr);
-    break;
-  case 8192:
-    host_rerand_inplace<Torus, AmortizedDegree<8192>>(
-        streams, lwe_array, lwe_flattened_encryptions_of_zero_compact_array_in,
-        ksk, mem_ptr);
-    break;
-  case 16384:
-    host_rerand_inplace<Torus, AmortizedDegree<16384>>(
-        streams, lwe_array, lwe_flattened_encryptions_of_zero_compact_array_in,
-        ksk, mem_ptr);
-    break;
-  default:
-    PANIC("CUDA error: lwe_dimension not supported. Supported dimensions are "
-          "powers of two in the interval [256..16384].");
-    break;
-  }
+  DISPATCH_POLY_SIZE(mem_ptr->params.big_lwe_dimension, AmortizedDegreePolicy,
+                     host_rerand_inplace<Torus, Params>(
+                         streams, lwe_array,
+                         lwe_flattened_encryptions_of_zero_compact_array_in,
+                         ksk, mem_ptr));
 }
 
 template <typename Torus>

--- a/backends/tfhe-cuda-backend/cuda/src/pbs/bootstrapping_key.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/pbs/bootstrapping_key.cu
@@ -1,5 +1,6 @@
 #include "bootstrapping_key.cuh"
 #include "checked_arithmetic.h"
+#include "polynomial/dispatch.cuh"
 #include "programmable_bootstrap_classic.cuh"
 
 void cuda_convert_lwe_programmable_bootstrap_key_32_async(
@@ -191,158 +192,26 @@ void cuda_fourier_polynomial_mul_async(void *stream, uint32_t gpu_index,
   auto max_shared_memory = cuda_get_max_shared_memory(gpu_index);
 
   double2 *buf;
-  switch (polynomial_size) {
-  case 256:
-    if (shared_memory_size <= max_shared_memory) {
-      buf = (double2 *)cuda_malloc_async(0, s, gpu_index);
-      check_cuda_error(cudaFuncSetAttribute(
-          batch_polynomial_mul<FFTDegree<AmortizedDegree<256>, ForwardFFT>,
-                               FULLSM>,
-          cudaFuncAttributeMaxDynamicSharedMemorySize, shared_memory_size));
-      check_cuda_error(cudaFuncSetCacheConfig(
-          batch_polynomial_mul<FFTDegree<AmortizedDegree<256>, ForwardFFT>,
-                               FULLSM>,
-          cudaFuncCachePreferShared));
-      batch_polynomial_mul<FFTDegree<AmortizedDegree<256>, ForwardFFT>, FULLSM>
-          <<<gridSize, blockSize, shared_memory_size, s>>>(in1, in2, out, buf);
-    } else {
-      buf = (double2 *)cuda_malloc_async(
-          safe_mul(shared_memory_size, (size_t)total_polynomials), s,
-          gpu_index);
-      batch_polynomial_mul<FFTDegree<AmortizedDegree<256>, ForwardFFT>, NOSM>
-          <<<gridSize, blockSize, 0, s>>>(in1, in2, out, buf);
-    }
-    break;
-  case 512:
-    if (shared_memory_size <= max_shared_memory) {
-      buf = (double2 *)cuda_malloc_async(0, s, gpu_index);
-      check_cuda_error(cudaFuncSetAttribute(
-          batch_polynomial_mul<FFTDegree<AmortizedDegree<521>, ForwardFFT>,
-                               FULLSM>,
-          cudaFuncAttributeMaxDynamicSharedMemorySize, shared_memory_size));
-      check_cuda_error(cudaFuncSetCacheConfig(
-          batch_polynomial_mul<FFTDegree<AmortizedDegree<512>, ForwardFFT>,
-                               FULLSM>,
-          cudaFuncCachePreferShared));
-      batch_polynomial_mul<FFTDegree<AmortizedDegree<512>, ForwardFFT>, FULLSM>
-          <<<gridSize, blockSize, shared_memory_size, s>>>(in1, in2, out, buf);
-    } else {
-      buf = (double2 *)cuda_malloc_async(
-          safe_mul(shared_memory_size, (size_t)total_polynomials), s,
-          gpu_index);
-      batch_polynomial_mul<FFTDegree<AmortizedDegree<512>, ForwardFFT>, NOSM>
-          <<<gridSize, blockSize, 0, s>>>(in1, in2, out, buf);
-    }
-    break;
-  case 1024:
-    if (shared_memory_size <= max_shared_memory) {
-      buf = (double2 *)cuda_malloc_async(0, s, gpu_index);
-      check_cuda_error(cudaFuncSetAttribute(
-          batch_polynomial_mul<FFTDegree<AmortizedDegree<1024>, ForwardFFT>,
-                               FULLSM>,
-          cudaFuncAttributeMaxDynamicSharedMemorySize, shared_memory_size));
-      check_cuda_error(cudaFuncSetCacheConfig(
-          batch_polynomial_mul<FFTDegree<AmortizedDegree<1024>, ForwardFFT>,
-                               FULLSM>,
-          cudaFuncCachePreferShared));
-      batch_polynomial_mul<FFTDegree<AmortizedDegree<1024>, ForwardFFT>, FULLSM>
-          <<<gridSize, blockSize, shared_memory_size, s>>>(in1, in2, out, buf);
-    } else {
-      buf = (double2 *)cuda_malloc_async(
-          safe_mul(shared_memory_size, (size_t)total_polynomials), s,
-          gpu_index);
-      batch_polynomial_mul<FFTDegree<AmortizedDegree<1024>, ForwardFFT>, NOSM>
-          <<<gridSize, blockSize, 0, s>>>(in1, in2, out, buf);
-    }
-    break;
-  case 2048:
-    if (shared_memory_size <= max_shared_memory) {
-      buf = (double2 *)cuda_malloc_async(0, s, gpu_index);
-      check_cuda_error(cudaFuncSetAttribute(
-          batch_polynomial_mul<FFTDegree<AmortizedDegree<2048>, ForwardFFT>,
-                               FULLSM>,
-          cudaFuncAttributeMaxDynamicSharedMemorySize, shared_memory_size));
-      check_cuda_error(cudaFuncSetCacheConfig(
-          batch_polynomial_mul<FFTDegree<AmortizedDegree<2048>, ForwardFFT>,
-                               FULLSM>,
-          cudaFuncCachePreferShared));
-      batch_polynomial_mul<FFTDegree<AmortizedDegree<2048>, ForwardFFT>, FULLSM>
-          <<<gridSize, blockSize, shared_memory_size, s>>>(in1, in2, out, buf);
-    } else {
-      buf = (double2 *)cuda_malloc_async(
-          safe_mul(shared_memory_size, (size_t)total_polynomials), s,
-          gpu_index);
-      batch_polynomial_mul<FFTDegree<AmortizedDegree<2048>, ForwardFFT>, NOSM>
-          <<<gridSize, blockSize, 0, s>>>(in1, in2, out, buf);
-    }
-    break;
-  case 4096:
-    if (shared_memory_size <= max_shared_memory) {
-      buf = (double2 *)cuda_malloc_async(0, s, gpu_index);
-      check_cuda_error(cudaFuncSetAttribute(
-          batch_polynomial_mul<FFTDegree<AmortizedDegree<4096>, ForwardFFT>,
-                               FULLSM>,
-          cudaFuncAttributeMaxDynamicSharedMemorySize, shared_memory_size));
-      check_cuda_error(cudaFuncSetCacheConfig(
-          batch_polynomial_mul<FFTDegree<AmortizedDegree<4096>, ForwardFFT>,
-                               FULLSM>,
-          cudaFuncCachePreferShared));
-      batch_polynomial_mul<FFTDegree<AmortizedDegree<4096>, ForwardFFT>, FULLSM>
-          <<<gridSize, blockSize, shared_memory_size, s>>>(in1, in2, out, buf);
-    } else {
-      buf = (double2 *)cuda_malloc_async(
-          safe_mul(shared_memory_size, (size_t)total_polynomials), s,
-          gpu_index);
-      batch_polynomial_mul<FFTDegree<AmortizedDegree<4096>, ForwardFFT>, NOSM>
-          <<<gridSize, blockSize, 0, s>>>(in1, in2, out, buf);
-    }
-    break;
-  case 8192:
-    if (shared_memory_size <= max_shared_memory) {
-      buf = (double2 *)cuda_malloc_async(0, s, gpu_index);
-      check_cuda_error(cudaFuncSetAttribute(
-          batch_polynomial_mul<FFTDegree<AmortizedDegree<8192>, ForwardFFT>,
-                               FULLSM>,
-          cudaFuncAttributeMaxDynamicSharedMemorySize, shared_memory_size));
-      check_cuda_error(cudaFuncSetCacheConfig(
-          batch_polynomial_mul<FFTDegree<AmortizedDegree<8192>, ForwardFFT>,
-                               FULLSM>,
-          cudaFuncCachePreferShared));
-      batch_polynomial_mul<FFTDegree<AmortizedDegree<8192>, ForwardFFT>, FULLSM>
-          <<<gridSize, blockSize, shared_memory_size, s>>>(in1, in2, out, buf);
-    } else {
-      buf = (double2 *)cuda_malloc_async(
-          safe_mul(shared_memory_size, (size_t)total_polynomials), s,
-          gpu_index);
-      batch_polynomial_mul<FFTDegree<AmortizedDegree<8192>, ForwardFFT>, NOSM>
-          <<<gridSize, blockSize, 0, s>>>(in1, in2, out, buf);
-    }
-    break;
-  case 16384:
-    if (shared_memory_size <= max_shared_memory) {
-      buf = (double2 *)cuda_malloc_async(0, s, gpu_index);
-      check_cuda_error(cudaFuncSetAttribute(
-          batch_polynomial_mul<FFTDegree<AmortizedDegree<16384>, ForwardFFT>,
-                               FULLSM>,
-          cudaFuncAttributeMaxDynamicSharedMemorySize, shared_memory_size));
-      check_cuda_error(cudaFuncSetCacheConfig(
-          batch_polynomial_mul<FFTDegree<AmortizedDegree<16384>, ForwardFFT>,
-                               FULLSM>,
-          cudaFuncCachePreferShared));
-      batch_polynomial_mul<FFTDegree<AmortizedDegree<16384>, ForwardFFT>,
-                           FULLSM>
-          <<<gridSize, blockSize, shared_memory_size, s>>>(in1, in2, out, buf);
-    } else {
-      buf = (double2 *)cuda_malloc_async(
-          safe_mul(shared_memory_size, (size_t)total_polynomials), s,
-          gpu_index);
-      batch_polynomial_mul<FFTDegree<AmortizedDegree<16384>, ForwardFFT>, NOSM>
-          <<<gridSize, blockSize, 0, s>>>(in1, in2, out, buf);
-    }
-    break;
-  default:
-    break;
-  }
+  DISPATCH_POLY_SIZE(
+      polynomial_size, AmortizedDegreePolicy,
+      if (shared_memory_size <= max_shared_memory) {
+        buf = (double2 *)cuda_malloc_async(0, s, gpu_index);
+        check_cuda_error(cudaFuncSetAttribute(
+            batch_polynomial_mul<FFTDegree<Params, ForwardFFT>, FULLSM>,
+            cudaFuncAttributeMaxDynamicSharedMemorySize, shared_memory_size));
+        check_cuda_error(cudaFuncSetCacheConfig(
+            batch_polynomial_mul<FFTDegree<Params, ForwardFFT>, FULLSM>,
+            cudaFuncCachePreferShared));
+        batch_polynomial_mul<FFTDegree<Params, ForwardFFT>, FULLSM>
+            <<<gridSize, blockSize, shared_memory_size, s>>>(in1, in2, out,
+                                                             buf);
+      } else {
+        buf = (double2 *)cuda_malloc_async(
+            safe_mul(shared_memory_size, (size_t)total_polynomials), s,
+            gpu_index);
+        batch_polynomial_mul<FFTDegree<Params, ForwardFFT>, NOSM>
+            <<<gridSize, blockSize, 0, s>>>(in1, in2, out, buf);
+      });
   check_cuda_error(cudaGetLastError());
 
   cuda_drop_async(buf, s, gpu_index);
@@ -489,31 +358,10 @@ void cuda_convert_lwe_programmable_bootstrap_key_u128(
 
   cuda_memcpy_async_to_gpu(d_standard, src, buffer_size, stream, gpu_index);
 
-  switch (polynomial_size) {
-  case 256:
-    convert_u128_to_f128_and_forward_fft_128<AmortizedDegree<256>>(
-        stream, gpu_index, dest, d_standard, total_polynomials);
-    break;
-  case 512:
-    convert_u128_to_f128_and_forward_fft_128<AmortizedDegree<512>>(
-        stream, gpu_index, dest, d_standard, total_polynomials);
-    break;
-  case 1024:
-    convert_u128_to_f128_and_forward_fft_128<AmortizedDegree<1024>>(
-        stream, gpu_index, dest, d_standard, total_polynomials);
-    break;
-  case 2048:
-    convert_u128_to_f128_and_forward_fft_128<AmortizedDegree<2048>>(
-        stream, gpu_index, dest, d_standard, total_polynomials);
-    break;
-  case 4096:
-    convert_u128_to_f128_and_forward_fft_128<AmortizedDegree<4096>>(
-        stream, gpu_index, dest, d_standard, total_polynomials);
-    break;
-  default:
-    PANIC("Cuda error (convert BSK): unsupported polynomial size. Supported "
-          "N's are powers of two in the interval [256..4096].")
-  }
+  DISPATCH_POLY_SIZE(
+      polynomial_size, AmortizedDegreePolicy128,
+      convert_u128_to_f128_and_forward_fft_128<Params>(
+          stream, gpu_index, dest, d_standard, total_polynomials));
 
   cuda_drop_async(d_standard, stream, gpu_index);
 }

--- a/backends/tfhe-cuda-backend/cuda/src/pbs/bootstrapping_key.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/pbs/bootstrapping_key.cuh
@@ -8,6 +8,7 @@
 
 #include "pbs/programmable_bootstrap.h"
 #include "pbs/programmable_bootstrap_multibit.h"
+#include "polynomial/dispatch.cuh"
 #include "polynomial/parameters.cuh"
 #include <atomic>
 #include <cstdint>
@@ -165,184 +166,66 @@ void cuda_convert_lwe_programmable_bootstrap_key(
   auto max_shared_memory = cuda_get_max_shared_memory(gpu_index);
 
   double2 *buffer = (double2 *)cuda_malloc_async(0, stream, gpu_index);
-  switch (polynomial_size) {
-  case 256:
-    if (shared_memory_size <= max_shared_memory) {
+  if (polynomial_size == 2048 && use_specialized_fft_2_2 &&
+      shared_memory_size <= max_shared_memory) {
+    // Specialized 2048 FFT paths for noise-squashing 2_2 parameters
+    if (use_throughput_oriented) {
+      // Throughput oriented path: FFT16x4x16 forward, writes bsk in
+      // bit-reversed frequency order to match the new accumulate kernel.
+      // AccumulatorDegree<2048> -> opt=32 -> 64 threads/block.
+      blockSize = polynomial_size / AccumulatorDegree<2048>::opt;
+      size_t throughput_smem = BATCH_FFT16X4X16_BSK_SMEM_BYTES;
       check_cuda_error(cudaFuncSetAttribute(
-          batch_NSMFFT<FFTDegree<AmortizedDegree<256>, ForwardFFT>, FULLSM>,
-          cudaFuncAttributeMaxDynamicSharedMemorySize, shared_memory_size));
-      check_cuda_error(cudaFuncSetCacheConfig(
-          batch_NSMFFT<FFTDegree<AmortizedDegree<256>, ForwardFFT>, FULLSM>,
-          cudaFuncCachePreferShared));
-      batch_NSMFFT<FFTDegree<AmortizedDegree<256>, ForwardFFT>, FULLSM>
-          <<<gridSize, blockSize, shared_memory_size, stream>>>(d_bsk, dest,
-                                                                buffer);
-    } else {
-      buffer = (double2 *)cuda_malloc_async(
-          safe_mul((size_t)shared_memory_size, (size_t)total_polynomials),
-          stream, gpu_index);
-      batch_NSMFFT<FFTDegree<AmortizedDegree<256>, ForwardFFT>, NOSM>
-          <<<gridSize, blockSize, 0, stream>>>(d_bsk, dest, buffer);
-    }
-    break;
-  case 512:
-    if (shared_memory_size <= max_shared_memory) {
-      check_cuda_error(cudaFuncSetAttribute(
-          batch_NSMFFT<FFTDegree<AmortizedDegree<512>, ForwardFFT>, FULLSM>,
-          cudaFuncAttributeMaxDynamicSharedMemorySize, shared_memory_size));
-      check_cuda_error(cudaFuncSetCacheConfig(
-          batch_NSMFFT<FFTDegree<AmortizedDegree<512>, ForwardFFT>, FULLSM>,
-          cudaFuncCachePreferShared));
-      batch_NSMFFT<FFTDegree<AmortizedDegree<512>, ForwardFFT>, FULLSM>
-          <<<gridSize, blockSize, shared_memory_size, stream>>>(d_bsk, dest,
-                                                                buffer);
-    } else {
-      buffer = (double2 *)cuda_malloc_async(
-          safe_mul((size_t)shared_memory_size, (size_t)total_polynomials),
-          stream, gpu_index);
-      batch_NSMFFT<FFTDegree<AmortizedDegree<512>, ForwardFFT>, NOSM>
-          <<<gridSize, blockSize, 0, stream>>>(d_bsk, dest, buffer);
-    }
-    break;
-  case 1024:
-    if (shared_memory_size <= max_shared_memory) {
-      check_cuda_error(cudaFuncSetAttribute(
-          batch_NSMFFT<FFTDegree<AmortizedDegree<1024>, ForwardFFT>, FULLSM>,
-          cudaFuncAttributeMaxDynamicSharedMemorySize, shared_memory_size));
-      check_cuda_error(cudaFuncSetCacheConfig(
-          batch_NSMFFT<FFTDegree<AmortizedDegree<1024>, ForwardFFT>, FULLSM>,
-          cudaFuncCachePreferShared));
-      batch_NSMFFT<FFTDegree<AmortizedDegree<1024>, ForwardFFT>, FULLSM>
-          <<<gridSize, blockSize, shared_memory_size, stream>>>(d_bsk, dest,
-                                                                buffer);
-    } else {
-      buffer = (double2 *)cuda_malloc_async(
-          safe_mul((size_t)shared_memory_size, (size_t)total_polynomials),
-          stream, gpu_index);
-      batch_NSMFFT<FFTDegree<AmortizedDegree<1024>, ForwardFFT>, NOSM>
-          <<<gridSize, blockSize, 0, stream>>>(d_bsk, dest, buffer);
-    }
-    break;
-  case 2048:
-    if (shared_memory_size <= max_shared_memory) {
-      if (use_specialized_fft_2_2) {
-        if (use_throughput_oriented) {
-          // Throughput oriented path: FFT16x4x16 forward, writes bsk in
-          // bit-reversed frequency order to match the new accumulate kernel.
-          // AccumulatorDegree<2048> → opt=32 → 64 threads/block.
-          blockSize = polynomial_size / AccumulatorDegree<2048>::opt;
-          size_t throughput_smem = BATCH_FFT16X4X16_BSK_SMEM_BYTES;
-          check_cuda_error(cudaFuncSetAttribute(
-              batch_FFT16x4x16_classical_specialized<
-                  FFTDegree<AccumulatorDegree<2048>, ForwardFFT>>,
-              cudaFuncAttributeMaxDynamicSharedMemorySize,
-              static_cast<int>(throughput_smem)));
-          check_cuda_error(cudaFuncSetCacheConfig(
-              batch_FFT16x4x16_classical_specialized<
-                  FFTDegree<AccumulatorDegree<2048>, ForwardFFT>>,
-              cudaFuncCachePreferShared));
           batch_FFT16x4x16_classical_specialized<
-              FFTDegree<AccumulatorDegree<2048>, ForwardFFT>>
-              <<<gridSize, blockSize, throughput_smem, stream>>>(d_bsk, dest);
-        } else {
-          // Specialized natural-order layout consumed by the old
-          // device_programmable_bootstrap_specialized_2_2_params kernel (used
-          // when the throughput path is unavailable, e.g. GPUs without enough
-          // shared memory for the FFT16x4x16 kernel).
-          blockSize = polynomial_size / choose_opt(polynomial_size);
-          check_cuda_error(
-              cudaFuncSetAttribute(batch_NSMFFT_classical_specialized<
-                                       FFTDegree<Degree<2048>, ForwardFFT>>,
-                                   cudaFuncAttributeMaxDynamicSharedMemorySize,
-                                   2 * shared_memory_size));
-          check_cuda_error(
-              cudaFuncSetCacheConfig(batch_NSMFFT_classical_specialized<
-                                         FFTDegree<Degree<2048>, ForwardFFT>>,
-                                     cudaFuncCachePreferShared));
+              FFTDegree<AccumulatorDegree<2048>, ForwardFFT>>,
+          cudaFuncAttributeMaxDynamicSharedMemorySize,
+          static_cast<int>(throughput_smem)));
+      check_cuda_error(cudaFuncSetCacheConfig(
+          batch_FFT16x4x16_classical_specialized<
+              FFTDegree<AccumulatorDegree<2048>, ForwardFFT>>,
+          cudaFuncCachePreferShared));
+      batch_FFT16x4x16_classical_specialized<
+          FFTDegree<AccumulatorDegree<2048>, ForwardFFT>>
+          <<<gridSize, blockSize, throughput_smem, stream>>>(d_bsk, dest);
+    } else {
+      // Specialized natural-order layout consumed by the old
+      // device_programmable_bootstrap_specialized_2_2_params kernel (used
+      // when the throughput path is unavailable, e.g. GPUs without enough
+      // shared memory for the FFT16x4x16 kernel).
+      blockSize = polynomial_size / choose_opt(polynomial_size);
+      check_cuda_error(cudaFuncSetAttribute(
           batch_NSMFFT_classical_specialized<
-              FFTDegree<Degree<2048>, ForwardFFT>>
-              <<<gridSize, blockSize, 2 * shared_memory_size, stream>>>(d_bsk,
-                                                                        dest);
-        }
-      } else {
-        check_cuda_error(cudaFuncSetAttribute(
-            batch_NSMFFT<FFTDegree<AmortizedDegree<2048>, ForwardFFT>, FULLSM>,
-            cudaFuncAttributeMaxDynamicSharedMemorySize, shared_memory_size));
-        check_cuda_error(cudaFuncSetCacheConfig(
-            batch_NSMFFT<FFTDegree<AmortizedDegree<2048>, ForwardFFT>, FULLSM>,
-            cudaFuncCachePreferShared));
-        batch_NSMFFT<FFTDegree<AmortizedDegree<2048>, ForwardFFT>, FULLSM>
-            <<<gridSize, blockSize, shared_memory_size, stream>>>(d_bsk, dest,
-                                                                  buffer);
-      }
-    } else {
-      buffer = (double2 *)cuda_malloc_async(
-          safe_mul((size_t)shared_memory_size, (size_t)total_polynomials),
-          stream, gpu_index);
-      batch_NSMFFT<FFTDegree<AmortizedDegree<2048>, ForwardFFT>, NOSM>
-          <<<gridSize, blockSize, 0, stream>>>(d_bsk, dest, buffer);
+              FFTDegree<Degree<2048>, ForwardFFT>>,
+          cudaFuncAttributeMaxDynamicSharedMemorySize, 2 * shared_memory_size));
+      check_cuda_error(
+          cudaFuncSetCacheConfig(batch_NSMFFT_classical_specialized<
+                                     FFTDegree<Degree<2048>, ForwardFFT>>,
+                                 cudaFuncCachePreferShared));
+      batch_NSMFFT_classical_specialized<FFTDegree<Degree<2048>, ForwardFFT>>
+          <<<gridSize, blockSize, 2 * shared_memory_size, stream>>>(d_bsk,
+                                                                    dest);
     }
-    break;
-  case 4096:
-    if (shared_memory_size <= max_shared_memory) {
-      check_cuda_error(cudaFuncSetAttribute(
-          batch_NSMFFT<FFTDegree<AmortizedDegree<4096>, ForwardFFT>, FULLSM>,
-          cudaFuncAttributeMaxDynamicSharedMemorySize, shared_memory_size));
-      check_cuda_error(cudaFuncSetCacheConfig(
-          batch_NSMFFT<FFTDegree<AmortizedDegree<4096>, ForwardFFT>, FULLSM>,
-          cudaFuncCachePreferShared));
-      batch_NSMFFT<FFTDegree<AmortizedDegree<4096>, ForwardFFT>, FULLSM>
-          <<<gridSize, blockSize, shared_memory_size, stream>>>(d_bsk, dest,
-                                                                buffer);
-    } else {
-      buffer = (double2 *)cuda_malloc_async(
-          safe_mul((size_t)shared_memory_size, (size_t)total_polynomials),
-          stream, gpu_index);
-      batch_NSMFFT<FFTDegree<AmortizedDegree<4096>, ForwardFFT>, NOSM>
-          <<<gridSize, blockSize, 0, stream>>>(d_bsk, dest, buffer);
-    }
-    break;
-  case 8192:
-    if (shared_memory_size <= max_shared_memory) {
-      check_cuda_error(cudaFuncSetAttribute(
-          batch_NSMFFT<FFTDegree<AmortizedDegree<8192>, ForwardFFT>, FULLSM>,
-          cudaFuncAttributeMaxDynamicSharedMemorySize, shared_memory_size));
-      check_cuda_error(cudaFuncSetCacheConfig(
-          batch_NSMFFT<FFTDegree<AmortizedDegree<8192>, ForwardFFT>, FULLSM>,
-          cudaFuncCachePreferShared));
-      batch_NSMFFT<FFTDegree<AmortizedDegree<8192>, ForwardFFT>, FULLSM>
-          <<<gridSize, blockSize, shared_memory_size, stream>>>(d_bsk, dest,
-                                                                buffer);
-    } else {
-      buffer = (double2 *)cuda_malloc_async(
-          safe_mul((size_t)shared_memory_size, (size_t)total_polynomials),
-          stream, gpu_index);
-      batch_NSMFFT<FFTDegree<AmortizedDegree<8192>, ForwardFFT>, NOSM>
-          <<<gridSize, blockSize, 0, stream>>>(d_bsk, dest, buffer);
-    }
-    break;
-  case 16384:
-    if (shared_memory_size <= max_shared_memory) {
-      check_cuda_error(cudaFuncSetAttribute(
-          batch_NSMFFT<FFTDegree<AmortizedDegree<16384>, ForwardFFT>, FULLSM>,
-          cudaFuncAttributeMaxDynamicSharedMemorySize, shared_memory_size));
-      check_cuda_error(cudaFuncSetCacheConfig(
-          batch_NSMFFT<FFTDegree<AmortizedDegree<16384>, ForwardFFT>, FULLSM>,
-          cudaFuncCachePreferShared));
-      batch_NSMFFT<FFTDegree<AmortizedDegree<16384>, ForwardFFT>, FULLSM>
-          <<<gridSize, blockSize, shared_memory_size, stream>>>(d_bsk, dest,
-                                                                buffer);
-    } else {
-      buffer = (double2 *)cuda_malloc_async(
-          safe_mul((size_t)shared_memory_size, (size_t)total_polynomials),
-          stream, gpu_index);
-      batch_NSMFFT<FFTDegree<AmortizedDegree<16384>, ForwardFFT>, NOSM>
-          <<<gridSize, blockSize, 0, stream>>>(d_bsk, dest, buffer);
-    }
-    break;
-  default:
-    PANIC("Cuda error (convert KSK): unsupported polynomial size. Supported "
-          "N's are powers of two in the interval [256..16384].")
+  } else {
+    // Generic FULLSM/NOSM path for all polynomial sizes
+    DISPATCH_POLY_SIZE(
+        polynomial_size, AmortizedDegreePolicy,
+        if (shared_memory_size <= max_shared_memory) {
+          check_cuda_error(cudaFuncSetAttribute(
+              batch_NSMFFT<FFTDegree<Params, ForwardFFT>, FULLSM>,
+              cudaFuncAttributeMaxDynamicSharedMemorySize, shared_memory_size));
+          check_cuda_error(cudaFuncSetCacheConfig(
+              batch_NSMFFT<FFTDegree<Params, ForwardFFT>, FULLSM>,
+              cudaFuncCachePreferShared));
+          batch_NSMFFT<FFTDegree<Params, ForwardFFT>, FULLSM>
+              <<<gridSize, blockSize, shared_memory_size, stream>>>(d_bsk, dest,
+                                                                    buffer);
+        } else {
+          buffer = (double2 *)cuda_malloc_async(
+              safe_mul((size_t)shared_memory_size, (size_t)total_polynomials),
+              stream, gpu_index);
+          batch_NSMFFT<FFTDegree<Params, ForwardFFT>, NOSM>
+              <<<gridSize, blockSize, 0, stream>>>(d_bsk, dest, buffer);
+        });
   }
   check_cuda_error(cudaGetLastError());
 

--- a/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_cg_classic.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_cg_classic.cuh
@@ -14,6 +14,7 @@
 #include "fft/twiddles.cuh"
 #include "pbs/pbs_utilities.h"
 #include "pbs/programmable_bootstrap.h"
+#include "polynomial/dispatch.cuh"
 #include "polynomial/parameters.cuh"
 #include "polynomial/polynomial_math.cuh"
 #include "programmable_bootstrap.cuh"
@@ -391,40 +392,10 @@ __host__ bool supports_cooperative_groups_on_programmable_bootstrap(
     return false;
   }
 
-  switch (polynomial_size) {
-  case 256:
-    return verify_cuda_programmable_bootstrap_cg_grid_size<
-        Torus, AmortizedDegree<256>>(glwe_dimension, level_count, num_samples,
-                                     max_shared_memory);
-  case 512:
-    return verify_cuda_programmable_bootstrap_cg_grid_size<
-        Torus, AmortizedDegree<512>>(glwe_dimension, level_count, num_samples,
-                                     max_shared_memory);
-  case 1024:
-    return verify_cuda_programmable_bootstrap_cg_grid_size<
-        Torus, AmortizedDegree<1024>>(glwe_dimension, level_count, num_samples,
-                                      max_shared_memory);
-  case 2048:
-    return verify_cuda_programmable_bootstrap_cg_grid_size<
-        Torus, AmortizedDegree<2048>>(glwe_dimension, level_count, num_samples,
-                                      max_shared_memory);
-  case 4096:
-    return verify_cuda_programmable_bootstrap_cg_grid_size<
-        Torus, AmortizedDegree<4096>>(glwe_dimension, level_count, num_samples,
-                                      max_shared_memory);
-  case 8192:
-    return verify_cuda_programmable_bootstrap_cg_grid_size<
-        Torus, AmortizedDegree<8192>>(glwe_dimension, level_count, num_samples,
-                                      max_shared_memory);
-  case 16384:
-    return verify_cuda_programmable_bootstrap_cg_grid_size<
-        Torus, AmortizedDegree<16384>>(glwe_dimension, level_count, num_samples,
-                                       max_shared_memory);
-  default:
-    PANIC("Cuda error (classical PBS): unsupported polynomial size. "
-          "Supported N's are powers of two"
-          " in the interval [256..16384].")
-  }
+  DISPATCH_POLY_SIZE(
+      polynomial_size, AmortizedDegreePolicy,
+      return verify_cuda_programmable_bootstrap_cg_grid_size<Torus, Params>(
+          glwe_dimension, level_count, num_samples, max_shared_memory));
 }
 
 #endif // CG_PBS_H

--- a/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_cg_multibit.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_cg_multibit.cuh
@@ -10,6 +10,7 @@
 #include "fft/twiddles.cuh"
 #include "pbs/pbs_multibit_utilities.h"
 #include "pbs/programmable_bootstrap.h"
+#include "polynomial/dispatch.cuh"
 #include "polynomial/functions.cuh"
 #include "polynomial/parameters.cuh"
 #include "polynomial/polynomial_math.cuh"
@@ -528,39 +529,10 @@ template <typename Torus>
 __host__ bool supports_cooperative_groups_on_multibit_programmable_bootstrap(
     int glwe_dimension, int polynomial_size, int level_count, int num_samples,
     uint32_t max_shared_memory) {
-  switch (polynomial_size) {
-  case 256:
-    return verify_cuda_programmable_bootstrap_cg_multi_bit_grid_size<
-        Torus, AmortizedDegree<256>>(glwe_dimension, level_count, num_samples,
-                                     max_shared_memory);
-  case 512:
-    return verify_cuda_programmable_bootstrap_cg_multi_bit_grid_size<
-        Torus, AmortizedDegree<512>>(glwe_dimension, level_count, num_samples,
-                                     max_shared_memory);
-  case 1024:
-    return verify_cuda_programmable_bootstrap_cg_multi_bit_grid_size<
-        Torus, AmortizedDegree<1024>>(glwe_dimension, level_count, num_samples,
-                                      max_shared_memory);
-  case 2048:
-    return verify_cuda_programmable_bootstrap_cg_multi_bit_grid_size<
-        Torus, AmortizedDegree<2048>>(glwe_dimension, level_count, num_samples,
-                                      max_shared_memory);
-  case 4096:
-    return verify_cuda_programmable_bootstrap_cg_multi_bit_grid_size<
-        Torus, AmortizedDegree<4096>>(glwe_dimension, level_count, num_samples,
-                                      max_shared_memory);
-  case 8192:
-    return verify_cuda_programmable_bootstrap_cg_multi_bit_grid_size<
-        Torus, AmortizedDegree<8192>>(glwe_dimension, level_count, num_samples,
-                                      max_shared_memory);
-  case 16384:
-    return verify_cuda_programmable_bootstrap_cg_multi_bit_grid_size<
-        Torus, AmortizedDegree<16384>>(glwe_dimension, level_count, num_samples,
-                                       max_shared_memory);
-  default:
-    PANIC("Cuda error (multi-bit PBS): unsupported polynomial size. Supported "
-          "N's are powers of two"
-          " in the interval [256..16384].")
-  }
+  DISPATCH_POLY_SIZE(
+      polynomial_size, AmortizedDegreePolicy,
+      return verify_cuda_programmable_bootstrap_cg_multi_bit_grid_size<Torus,
+                                                                       Params>(
+          glwe_dimension, level_count, num_samples, max_shared_memory));
 }
 #endif // FASTMULTIBIT_PBS_H

--- a/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_classic.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_classic.cu
@@ -3,6 +3,7 @@
 #if (CUDA_ARCH >= 900)
 #include "programmable_bootstrap_tbc_classic.cuh"
 #endif
+#include "polynomial/dispatch.cuh"
 
 #include <cstdio>
 
@@ -24,46 +25,11 @@ bool has_support_to_cuda_programmable_bootstrap_tbc(
 #if CUDA_ARCH >= 900
   if ((glwe_dimension + 1) * level_count > 8)
     return false;
-  switch (polynomial_size) {
-  case 256:
-    return supports_thread_block_clusters_on_classic_programmable_bootstrap<
-        Torus, AmortizedDegree<256>>(num_samples, glwe_dimension,
-                                     polynomial_size, level_count,
-                                     max_shared_memory);
-  case 512:
-    return supports_thread_block_clusters_on_classic_programmable_bootstrap<
-        Torus, AmortizedDegree<512>>(num_samples, glwe_dimension,
-                                     polynomial_size, level_count,
-                                     max_shared_memory);
-  case 1024:
-    return supports_thread_block_clusters_on_classic_programmable_bootstrap<
-        Torus, AmortizedDegree<1024>>(num_samples, glwe_dimension,
-                                      polynomial_size, level_count,
-                                      max_shared_memory);
-  case 2048:
-    return supports_thread_block_clusters_on_classic_programmable_bootstrap<
-        Torus, Degree<2048>>(num_samples, glwe_dimension, polynomial_size,
-                             level_count, max_shared_memory);
-  case 4096:
-    return supports_thread_block_clusters_on_classic_programmable_bootstrap<
-        Torus, AmortizedDegree<4096>>(num_samples, glwe_dimension,
-                                      polynomial_size, level_count,
-                                      max_shared_memory);
-  case 8192:
-    return supports_thread_block_clusters_on_classic_programmable_bootstrap<
-        Torus, AmortizedDegree<8192>>(num_samples, glwe_dimension,
-                                      polynomial_size, level_count,
-                                      max_shared_memory);
-  case 16384:
-    return supports_thread_block_clusters_on_classic_programmable_bootstrap<
-        Torus, AmortizedDegree<16384>>(num_samples, glwe_dimension,
-                                       polynomial_size, level_count,
-                                       max_shared_memory);
-  default:
-    PANIC("Cuda error (classical PBS): unsupported polynomial size. Supported "
-          "N's are powers of two"
-          " in the interval [256..16384].")
-  }
+  DISPATCH_POLY_SIZE(
+      polynomial_size, ClassicPBSDegreePolicy,
+      return supports_thread_block_clusters_on_classic_programmable_bootstrap<
+          Torus, Params>(num_samples, glwe_dimension, polynomial_size,
+                         level_count, max_shared_memory));
 #else
   return false;
 #endif
@@ -77,47 +43,13 @@ uint64_t scratch_cuda_programmable_bootstrap_tbc(
     uint32_t level_count, uint32_t input_lwe_ciphertext_count,
     bool allocate_gpu_memory, PBS_MS_REDUCTION_T noise_reduction_type) {
 
-  switch (polynomial_size) {
-  case 256:
-    return scratch_programmable_bootstrap_tbc<Torus, AmortizedDegree<256>>(
-        static_cast<cudaStream_t>(stream), gpu_index, pbs_buffer, lwe_dimension,
-        glwe_dimension, polynomial_size, level_count,
-        input_lwe_ciphertext_count, allocate_gpu_memory, noise_reduction_type);
-  case 512:
-    return scratch_programmable_bootstrap_tbc<Torus, AmortizedDegree<512>>(
-        static_cast<cudaStream_t>(stream), gpu_index, pbs_buffer, lwe_dimension,
-        glwe_dimension, polynomial_size, level_count,
-        input_lwe_ciphertext_count, allocate_gpu_memory, noise_reduction_type);
-  case 1024:
-    return scratch_programmable_bootstrap_tbc<Torus, AmortizedDegree<1024>>(
-        static_cast<cudaStream_t>(stream), gpu_index, pbs_buffer, lwe_dimension,
-        glwe_dimension, polynomial_size, level_count,
-        input_lwe_ciphertext_count, allocate_gpu_memory, noise_reduction_type);
-  case 2048:
-    return scratch_programmable_bootstrap_tbc<Torus, Degree<2048>>(
-        static_cast<cudaStream_t>(stream), gpu_index, pbs_buffer, lwe_dimension,
-        glwe_dimension, polynomial_size, level_count,
-        input_lwe_ciphertext_count, allocate_gpu_memory, noise_reduction_type);
-  case 4096:
-    return scratch_programmable_bootstrap_tbc<Torus, AmortizedDegree<4096>>(
-        static_cast<cudaStream_t>(stream), gpu_index, pbs_buffer, lwe_dimension,
-        glwe_dimension, polynomial_size, level_count,
-        input_lwe_ciphertext_count, allocate_gpu_memory, noise_reduction_type);
-  case 8192:
-    return scratch_programmable_bootstrap_tbc<Torus, AmortizedDegree<8192>>(
-        static_cast<cudaStream_t>(stream), gpu_index, pbs_buffer, lwe_dimension,
-        glwe_dimension, polynomial_size, level_count,
-        input_lwe_ciphertext_count, allocate_gpu_memory, noise_reduction_type);
-  case 16384:
-    return scratch_programmable_bootstrap_tbc<Torus, AmortizedDegree<16384>>(
-        static_cast<cudaStream_t>(stream), gpu_index, pbs_buffer, lwe_dimension,
-        glwe_dimension, polynomial_size, level_count,
-        input_lwe_ciphertext_count, allocate_gpu_memory, noise_reduction_type);
-  default:
-    PANIC("Cuda error (classical PBS): unsupported polynomial size. "
-          "Supported N's are powers of two"
-          " in the interval [256..16384].")
-  }
+  DISPATCH_POLY_SIZE(polynomial_size, ClassicPBSDegreePolicy,
+                     return scratch_programmable_bootstrap_tbc<Torus, Params>(
+                         static_cast<cudaStream_t>(stream), gpu_index,
+                         pbs_buffer, lwe_dimension, glwe_dimension,
+                         polynomial_size, level_count,
+                         input_lwe_ciphertext_count, allocate_gpu_memory,
+                         noise_reduction_type));
 }
 
 template <typename Torus>
@@ -131,68 +63,14 @@ void cuda_programmable_bootstrap_tbc_lwe_ciphertext_vector(
     uint32_t level_count, uint32_t num_samples, uint32_t num_many_lut,
     uint32_t lut_stride) {
 
-  switch (polynomial_size) {
-  case 256:
-    host_programmable_bootstrap_tbc<Torus, AmortizedDegree<256>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, base_log, level_count, num_samples,
-        num_many_lut, lut_stride);
-    break;
-  case 512:
-    host_programmable_bootstrap_tbc<Torus, AmortizedDegree<512>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, base_log, level_count, num_samples,
-        num_many_lut, lut_stride);
-    break;
-  case 1024:
-    host_programmable_bootstrap_tbc<Torus, AmortizedDegree<1024>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, base_log, level_count, num_samples,
-        num_many_lut, lut_stride);
-    break;
-  case 2048:
-    host_programmable_bootstrap_tbc<Torus, Degree<2048>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, base_log, level_count, num_samples,
-        num_many_lut, lut_stride);
-    break;
-  case 4096:
-    host_programmable_bootstrap_tbc<Torus, AmortizedDegree<4096>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, base_log, level_count, num_samples,
-        num_many_lut, lut_stride);
-    break;
-  case 8192:
-    host_programmable_bootstrap_tbc<Torus, AmortizedDegree<8192>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, base_log, level_count, num_samples,
-        num_many_lut, lut_stride);
-    break;
-  case 16384:
-    host_programmable_bootstrap_tbc<Torus, AmortizedDegree<16384>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, base_log, level_count, num_samples,
-        num_many_lut, lut_stride);
-    break;
-  default:
-    PANIC("Cuda error (classical PBS): unsupported polynomial size. "
-          "Supported N's are powers of two"
-          " in the interval [256..16384].")
-  }
+  DISPATCH_POLY_SIZE(polynomial_size, ClassicPBSDegreePolicy,
+                     host_programmable_bootstrap_tbc<Torus, Params>(
+                         static_cast<cudaStream_t>(stream), gpu_index,
+                         lwe_array_out, lwe_output_indexes, lut_vector,
+                         lut_vector_indexes, lwe_array_in, lwe_input_indexes,
+                         bootstrapping_key, buffer, glwe_dimension,
+                         lwe_dimension, polynomial_size, base_log, level_count,
+                         num_samples, num_many_lut, lut_stride));
 }
 
 template <typename Torus>
@@ -206,68 +84,14 @@ void cuda_programmable_bootstrap_tbc_lwe_ciphertext_vector_generic(
     uint32_t level_count, uint32_t num_samples, uint32_t num_many_lut,
     uint32_t lut_stride) {
 
-  switch (polynomial_size) {
-  case 256:
-    host_programmable_bootstrap_tbc_generic<Torus, AmortizedDegree<256>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, base_log, level_count, num_samples,
-        num_many_lut, lut_stride);
-    break;
-  case 512:
-    host_programmable_bootstrap_tbc_generic<Torus, AmortizedDegree<512>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, base_log, level_count, num_samples,
-        num_many_lut, lut_stride);
-    break;
-  case 1024:
-    host_programmable_bootstrap_tbc_generic<Torus, AmortizedDegree<1024>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, base_log, level_count, num_samples,
-        num_many_lut, lut_stride);
-    break;
-  case 2048:
-    host_programmable_bootstrap_tbc_generic<Torus, Degree<2048>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, base_log, level_count, num_samples,
-        num_many_lut, lut_stride);
-    break;
-  case 4096:
-    host_programmable_bootstrap_tbc_generic<Torus, AmortizedDegree<4096>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, base_log, level_count, num_samples,
-        num_many_lut, lut_stride);
-    break;
-  case 8192:
-    host_programmable_bootstrap_tbc_generic<Torus, AmortizedDegree<8192>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, base_log, level_count, num_samples,
-        num_many_lut, lut_stride);
-    break;
-  case 16384:
-    host_programmable_bootstrap_tbc_generic<Torus, AmortizedDegree<16384>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, base_log, level_count, num_samples,
-        num_many_lut, lut_stride);
-    break;
-  default:
-    PANIC("Cuda error (classical PBS): unsupported polynomial size. "
-          "Supported N's are powers of two"
-          " in the interval [256..16384].")
-  }
+  DISPATCH_POLY_SIZE(polynomial_size, ClassicPBSDegreePolicy,
+                     host_programmable_bootstrap_tbc_generic<Torus, Params>(
+                         static_cast<cudaStream_t>(stream), gpu_index,
+                         lwe_array_out, lwe_output_indexes, lut_vector,
+                         lut_vector_indexes, lwe_array_in, lwe_input_indexes,
+                         bootstrapping_key, buffer, glwe_dimension,
+                         lwe_dimension, polynomial_size, base_log, level_count,
+                         num_samples, num_many_lut, lut_stride));
 }
 #endif
 
@@ -278,47 +102,13 @@ uint64_t scratch_cuda_programmable_bootstrap_cg(
     uint32_t level_count, uint32_t input_lwe_ciphertext_count,
     bool allocate_gpu_memory, PBS_MS_REDUCTION_T noise_reduction_type) {
 
-  switch (polynomial_size) {
-  case 256:
-    return scratch_programmable_bootstrap_cg<Torus, AmortizedDegree<256>>(
-        static_cast<cudaStream_t>(stream), gpu_index, pbs_buffer, lwe_dimension,
-        glwe_dimension, polynomial_size, level_count,
-        input_lwe_ciphertext_count, allocate_gpu_memory, noise_reduction_type);
-  case 512:
-    return scratch_programmable_bootstrap_cg<Torus, AmortizedDegree<512>>(
-        static_cast<cudaStream_t>(stream), gpu_index, pbs_buffer, lwe_dimension,
-        glwe_dimension, polynomial_size, level_count,
-        input_lwe_ciphertext_count, allocate_gpu_memory, noise_reduction_type);
-  case 1024:
-    return scratch_programmable_bootstrap_cg<Torus, AmortizedDegree<1024>>(
-        static_cast<cudaStream_t>(stream), gpu_index, pbs_buffer, lwe_dimension,
-        glwe_dimension, polynomial_size, level_count,
-        input_lwe_ciphertext_count, allocate_gpu_memory, noise_reduction_type);
-  case 2048:
-    return scratch_programmable_bootstrap_cg<Torus, AmortizedDegree<2048>>(
-        static_cast<cudaStream_t>(stream), gpu_index, pbs_buffer, lwe_dimension,
-        glwe_dimension, polynomial_size, level_count,
-        input_lwe_ciphertext_count, allocate_gpu_memory, noise_reduction_type);
-  case 4096:
-    return scratch_programmable_bootstrap_cg<Torus, AmortizedDegree<4096>>(
-        static_cast<cudaStream_t>(stream), gpu_index, pbs_buffer, lwe_dimension,
-        glwe_dimension, polynomial_size, level_count,
-        input_lwe_ciphertext_count, allocate_gpu_memory, noise_reduction_type);
-  case 8192:
-    return scratch_programmable_bootstrap_cg<Torus, AmortizedDegree<8192>>(
-        static_cast<cudaStream_t>(stream), gpu_index, pbs_buffer, lwe_dimension,
-        glwe_dimension, polynomial_size, level_count,
-        input_lwe_ciphertext_count, allocate_gpu_memory, noise_reduction_type);
-  case 16384:
-    return scratch_programmable_bootstrap_cg<Torus, AmortizedDegree<16384>>(
-        static_cast<cudaStream_t>(stream), gpu_index, pbs_buffer, lwe_dimension,
-        glwe_dimension, polynomial_size, level_count,
-        input_lwe_ciphertext_count, allocate_gpu_memory, noise_reduction_type);
-  default:
-    PANIC("Cuda error (classical PBS): unsupported polynomial size. "
-          "Supported N's are powers of two"
-          " in the interval [256..16384].")
-  }
+  DISPATCH_POLY_SIZE(polynomial_size, AmortizedDegreePolicy,
+                     return scratch_programmable_bootstrap_cg<Torus, Params>(
+                         static_cast<cudaStream_t>(stream), gpu_index,
+                         pbs_buffer, lwe_dimension, glwe_dimension,
+                         polynomial_size, level_count,
+                         input_lwe_ciphertext_count, allocate_gpu_memory,
+                         noise_reduction_type));
 }
 
 template <typename Torus>
@@ -328,49 +118,14 @@ uint64_t scratch_cuda_programmable_bootstrap(
     uint32_t level_count, uint32_t input_lwe_ciphertext_count,
     bool allocate_gpu_memory, PBS_MS_REDUCTION_T noise_reduction_type) {
 
-  switch (polynomial_size) {
-  case 256:
-    return scratch_programmable_bootstrap<Torus, AmortizedDegree<256>>(
-        static_cast<cudaStream_t>(stream), gpu_index, buffer, lwe_dimension,
-        glwe_dimension, polynomial_size, level_count,
-        input_lwe_ciphertext_count, allocate_gpu_memory, noise_reduction_type);
-  case 512:
-    return scratch_programmable_bootstrap<Torus, AmortizedDegree<512>>(
-        static_cast<cudaStream_t>(stream), gpu_index, buffer, lwe_dimension,
-        glwe_dimension, polynomial_size, level_count,
-        input_lwe_ciphertext_count, allocate_gpu_memory, noise_reduction_type);
-  case 1024:
-    return scratch_programmable_bootstrap<Torus, AmortizedDegree<1024>>(
-        static_cast<cudaStream_t>(stream), gpu_index, buffer, lwe_dimension,
-        glwe_dimension, polynomial_size, level_count,
-        input_lwe_ciphertext_count, allocate_gpu_memory, noise_reduction_type);
-  case 2048:
-    // For polynomial size 2048, we know Degree is better than AmortizedDegree,
-    //  other sizes require further evaluation.
-    return scratch_programmable_bootstrap<Torus, Degree<2048>>(
-        static_cast<cudaStream_t>(stream), gpu_index, buffer, lwe_dimension,
-        glwe_dimension, polynomial_size, level_count,
-        input_lwe_ciphertext_count, allocate_gpu_memory, noise_reduction_type);
-  case 4096:
-    return scratch_programmable_bootstrap<Torus, AmortizedDegree<4096>>(
-        static_cast<cudaStream_t>(stream), gpu_index, buffer, lwe_dimension,
-        glwe_dimension, polynomial_size, level_count,
-        input_lwe_ciphertext_count, allocate_gpu_memory, noise_reduction_type);
-  case 8192:
-    return scratch_programmable_bootstrap<Torus, AmortizedDegree<8192>>(
-        static_cast<cudaStream_t>(stream), gpu_index, buffer, lwe_dimension,
-        glwe_dimension, polynomial_size, level_count,
-        input_lwe_ciphertext_count, allocate_gpu_memory, noise_reduction_type);
-  case 16384:
-    return scratch_programmable_bootstrap<Torus, AmortizedDegree<16384>>(
-        static_cast<cudaStream_t>(stream), gpu_index, buffer, lwe_dimension,
-        glwe_dimension, polynomial_size, level_count,
-        input_lwe_ciphertext_count, allocate_gpu_memory, noise_reduction_type);
-  default:
-    PANIC("Cuda error (classical PBS): unsupported polynomial size. "
-          "Supported N's are powers of two"
-          " in the interval [256..16384].")
-  }
+  // Degree<2048> is measured to outperform AmortizedDegree<2048> for non-CG
+  // classic PBS.
+  DISPATCH_POLY_SIZE(polynomial_size, ClassicPBSDegreePolicy,
+                     return scratch_programmable_bootstrap<Torus, Params>(
+                         static_cast<cudaStream_t>(stream), gpu_index, buffer,
+                         lwe_dimension, glwe_dimension, polynomial_size,
+                         level_count, input_lwe_ciphertext_count,
+                         allocate_gpu_memory, noise_reduction_type));
 }
 
 /*
@@ -477,68 +232,14 @@ void cuda_programmable_bootstrap_cg_lwe_ciphertext_vector(
     uint32_t level_count, uint32_t num_samples, uint32_t num_many_lut,
     uint32_t lut_stride) {
 
-  switch (polynomial_size) {
-  case 256:
-    host_programmable_bootstrap_cg<Torus, AmortizedDegree<256>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, base_log, level_count, num_samples,
-        num_many_lut, lut_stride);
-    break;
-  case 512:
-    host_programmable_bootstrap_cg<Torus, AmortizedDegree<512>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, base_log, level_count, num_samples,
-        num_many_lut, lut_stride);
-    break;
-  case 1024:
-    host_programmable_bootstrap_cg<Torus, AmortizedDegree<1024>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, base_log, level_count, num_samples,
-        num_many_lut, lut_stride);
-    break;
-  case 2048:
-    host_programmable_bootstrap_cg<Torus, AmortizedDegree<2048>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, base_log, level_count, num_samples,
-        num_many_lut, lut_stride);
-    break;
-  case 4096:
-    host_programmable_bootstrap_cg<Torus, AmortizedDegree<4096>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, base_log, level_count, num_samples,
-        num_many_lut, lut_stride);
-    break;
-  case 8192:
-    host_programmable_bootstrap_cg<Torus, AmortizedDegree<8192>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, base_log, level_count, num_samples,
-        num_many_lut, lut_stride);
-    break;
-  case 16384:
-    host_programmable_bootstrap_cg<Torus, AmortizedDegree<16384>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, base_log, level_count, num_samples,
-        num_many_lut, lut_stride);
-    break;
-  default:
-    PANIC("Cuda error (classical PBS): unsupported polynomial size. "
-          "Supported N's are powers of two"
-          " in the interval [256..16384].")
-  }
+  DISPATCH_POLY_SIZE(polynomial_size, AmortizedDegreePolicy,
+                     host_programmable_bootstrap_cg<Torus, Params>(
+                         static_cast<cudaStream_t>(stream), gpu_index,
+                         lwe_array_out, lwe_output_indexes, lut_vector,
+                         lut_vector_indexes, lwe_array_in, lwe_input_indexes,
+                         bootstrapping_key, buffer, glwe_dimension,
+                         lwe_dimension, polynomial_size, base_log, level_count,
+                         num_samples, num_many_lut, lut_stride));
 }
 
 template <typename Torus>
@@ -552,70 +253,16 @@ void cuda_programmable_bootstrap_lwe_ciphertext_vector(
     uint32_t level_count, uint32_t num_samples, uint32_t num_many_lut,
     uint32_t lut_stride) {
 
-  switch (polynomial_size) {
-  case 256:
-    host_programmable_bootstrap<Torus, AmortizedDegree<256>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, base_log, level_count, num_samples,
-        num_many_lut, lut_stride);
-    break;
-  case 512:
-    host_programmable_bootstrap<Torus, AmortizedDegree<512>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, base_log, level_count, num_samples,
-        num_many_lut, lut_stride);
-    break;
-  case 1024:
-    host_programmable_bootstrap<Torus, AmortizedDegree<1024>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, base_log, level_count, num_samples,
-        num_many_lut, lut_stride);
-    break;
-  case 2048:
-    // For polynomial size 2048, we know Degree is better than AmortizedDegree,
-    //  other sizes require further evaluation.
-    host_programmable_bootstrap<Torus, Degree<2048>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, base_log, level_count, num_samples,
-        num_many_lut, lut_stride);
-    break;
-  case 4096:
-    host_programmable_bootstrap<Torus, AmortizedDegree<4096>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, base_log, level_count, num_samples,
-        num_many_lut, lut_stride);
-    break;
-  case 8192:
-    host_programmable_bootstrap<Torus, AmortizedDegree<8192>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, base_log, level_count, num_samples,
-        num_many_lut, lut_stride);
-    break;
-  case 16384:
-    host_programmable_bootstrap<Torus, AmortizedDegree<16384>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, base_log, level_count, num_samples,
-        num_many_lut, lut_stride);
-    break;
-  default:
-    PANIC("Cuda error (classical PBS): unsupported polynomial size. "
-          "Supported N's are powers of two"
-          " in the interval [256..16384].")
-  }
+  // Degree<2048> is measured to outperform AmortizedDegree<2048> for non-CG
+  // classic PBS.
+  DISPATCH_POLY_SIZE(polynomial_size, ClassicPBSDegreePolicy,
+                     host_programmable_bootstrap<Torus, Params>(
+                         static_cast<cudaStream_t>(stream), gpu_index,
+                         lwe_array_out, lwe_output_indexes, lut_vector,
+                         lut_vector_indexes, lwe_array_in, lwe_input_indexes,
+                         bootstrapping_key, buffer, glwe_dimension,
+                         lwe_dimension, polynomial_size, base_log, level_count,
+                         num_samples, num_many_lut, lut_stride));
 }
 
 /* Perform bootstrapping on a batch of input u32 LWE ciphertexts.

--- a/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_classic_128.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_classic_128.cu
@@ -1,3 +1,4 @@
+#include "polynomial/dispatch.cuh"
 #include "programmable_bootstrap_classic_128.cuh"
 
 bool has_support_to_cuda_programmable_bootstrap_128_cg(
@@ -56,43 +57,13 @@ void executor_cuda_programmable_bootstrap_128(
     uint32_t lwe_dimension, uint32_t glwe_dimension, uint32_t polynomial_size,
     uint32_t base_log, uint32_t level_count, uint32_t num_samples) {
 
-  switch (polynomial_size) {
-  case 256:
-    host_programmable_bootstrap_128<InputTorus, Degree<256>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out, lut_vector,
-        lwe_array_in, bootstrapping_key, buffer, glwe_dimension, lwe_dimension,
-        polynomial_size, base_log, level_count, num_samples);
-    break;
-  case 512:
-    host_programmable_bootstrap_128<InputTorus, Degree<512>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out, lut_vector,
-        lwe_array_in, bootstrapping_key, buffer, glwe_dimension, lwe_dimension,
-        polynomial_size, base_log, level_count, num_samples);
-    break;
-  case 1024:
-    host_programmable_bootstrap_128<InputTorus, Degree<1024>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out, lut_vector,
-        lwe_array_in, bootstrapping_key, buffer, glwe_dimension, lwe_dimension,
-        polynomial_size, base_log, level_count, num_samples);
-    break;
-  case 2048:
-    host_programmable_bootstrap_128<InputTorus, Degree<2048>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out, lut_vector,
-        lwe_array_in, bootstrapping_key, buffer, glwe_dimension, lwe_dimension,
-        polynomial_size, base_log, level_count, num_samples);
-    break;
-  case 4096:
-    // We use AmortizedDegree for 4096 to avoid register exhaustion
-    host_programmable_bootstrap_128<InputTorus, AmortizedDegree<4096>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out, lut_vector,
-        lwe_array_in, bootstrapping_key, buffer, glwe_dimension, lwe_dimension,
-        polynomial_size, base_log, level_count, num_samples);
-    break;
-  default:
-    PANIC("Cuda error (classical PBS128): unsupported polynomial size. "
-          "Supported N's are powers of two"
-          " in the interval [256..4096].")
-  }
+  // AmortizedDegree for 4096 avoids register exhaustion in 128-bit classic PBS
+  DISPATCH_POLY_SIZE(
+      polynomial_size, Multibit128DegreePolicy,
+      host_programmable_bootstrap_128<InputTorus, Params>(
+          static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
+          lut_vector, lwe_array_in, bootstrapping_key, buffer, glwe_dimension,
+          lwe_dimension, polynomial_size, base_log, level_count, num_samples));
 }
 
 template <typename InputTorus>
@@ -104,43 +75,13 @@ void executor_cuda_programmable_bootstrap_cg_lwe_ciphertext_vector_128(
     uint32_t lwe_dimension, uint32_t glwe_dimension, uint32_t polynomial_size,
     uint32_t base_log, uint32_t level_count, uint32_t num_samples) {
 
-  switch (polynomial_size) {
-  case 256:
-    host_programmable_bootstrap_cg_128<InputTorus, Degree<256>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out, lut_vector,
-        lwe_array_in, bootstrapping_key, buffer, glwe_dimension, lwe_dimension,
-        polynomial_size, base_log, level_count, num_samples);
-    break;
-  case 512:
-    host_programmable_bootstrap_cg_128<InputTorus, Degree<512>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out, lut_vector,
-        lwe_array_in, bootstrapping_key, buffer, glwe_dimension, lwe_dimension,
-        polynomial_size, base_log, level_count, num_samples);
-    break;
-  case 1024:
-    host_programmable_bootstrap_cg_128<InputTorus, Degree<1024>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out, lut_vector,
-        lwe_array_in, bootstrapping_key, buffer, glwe_dimension, lwe_dimension,
-        polynomial_size, base_log, level_count, num_samples);
-    break;
-  case 2048:
-    host_programmable_bootstrap_cg_128<InputTorus, Degree<2048>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out, lut_vector,
-        lwe_array_in, bootstrapping_key, buffer, glwe_dimension, lwe_dimension,
-        polynomial_size, base_log, level_count, num_samples);
-    break;
-  case 4096:
-    // We use AmortizedDegree for 4096 to avoid register exhaustion
-    host_programmable_bootstrap_cg_128<InputTorus, AmortizedDegree<4096>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out, lut_vector,
-        lwe_array_in, bootstrapping_key, buffer, glwe_dimension, lwe_dimension,
-        polynomial_size, base_log, level_count, num_samples);
-    break;
-  default:
-    PANIC("Cuda error (classical PBS128): unsupported polynomial size. "
-          "Supported N's are powers of two"
-          " in the interval [256..4096].")
-  }
+  // AmortizedDegree for 4096 avoids register exhaustion in 128-bit classic PBS
+  DISPATCH_POLY_SIZE(
+      polynomial_size, Multibit128DegreePolicy,
+      host_programmable_bootstrap_cg_128<InputTorus, Params>(
+          static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
+          lut_vector, lwe_array_in, bootstrapping_key, buffer, glwe_dimension,
+          lwe_dimension, polynomial_size, base_log, level_count, num_samples));
 }
 
 #if CUDA_ARCH >= 900
@@ -215,7 +156,7 @@ void host_programmable_bootstrap_lwe_ciphertext_vector_128(
  * - `v_stream` is a void pointer to the CUDA stream used in the kernel launch
  * - `gpu_index` is the index of the GPU to be used in the kernel launch
  * - `lwe_array_out`: output batch of `num_samples` bootstrapped ciphertexts
- *   c = (a0, .., a(n−1), b), where n is the LWE dimension
+ *   c = (a0, .., a(n-1), b), where n is the LWE dimension
  * - `lut_vector`: must contain exactly one LUT (of size `polynomial_size`) that
  *   will be applied uniformly to every input ciphertext
  * - `lwe_array_in`: input batch of `num_samples` LWE ciphertexts, each
@@ -249,9 +190,9 @@ void host_programmable_bootstrap_lwe_ciphertext_vector_128(
  *   - `num_samples * level_count * (glwe_dimension + 1)` blocks of threads are
  *     launched, where each thread handles one or more polynomial coefficients
  * at each stage (for a given decomposition level), either for the LUT mask or
- * its body: • Perform the blind rotation • Round the result • Decompose the
- * current level • Switch to the FFT domain • Multiply with the bootstrapping
- * key • Come back to the coefficient representation
+ * its body: * Perform the blind rotation * Round the result * Decompose the
+ * current level * Switch to the FFT domain * Multiply with the bootstrapping
+ * key * Come back to the coefficient representation
  *   - Between stages, some synchronizations happen at block level and between
  * blocks (using cooperative groups).
  *   - If the device has sufficient shared memory, temporary arrays for

--- a/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_classic_128.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_classic_128.cuh
@@ -13,6 +13,7 @@
 #include "pbs/bootstrapping_key.cuh"
 #include "pbs/pbs_utilities.h"
 #include "pbs/programmable_bootstrap.h"
+#include "polynomial/dispatch.cuh"
 #include "polynomial/parameters.cuh"
 #include "polynomial/polynomial_math.cuh"
 #include "programmable_bootstrap.cuh"
@@ -1051,93 +1052,21 @@ uint64_t scratch_cuda_programmable_bootstrap_128_vector(
              has_support_to_cuda_programmable_bootstrap_128_cg(
                  glwe_dimension, polynomial_size, level_count,
                  input_lwe_ciphertext_count, max_shared_memory)) {
-    switch (polynomial_size) {
-    case 256:
-      return scratch_programmable_bootstrap_cg_128<InputTorus, Degree<256>>(
-          static_cast<cudaStream_t>(stream), gpu_index, buffer, lwe_dimension,
-          glwe_dimension, polynomial_size, level_count,
-          input_lwe_ciphertext_count, allocate_gpu_memory,
-          noise_reduction_type);
-      break;
-    case 512:
-      return scratch_programmable_bootstrap_cg_128<InputTorus, Degree<512>>(
-          static_cast<cudaStream_t>(stream), gpu_index, buffer, lwe_dimension,
-          glwe_dimension, polynomial_size, level_count,
-          input_lwe_ciphertext_count, allocate_gpu_memory,
-          noise_reduction_type);
-      break;
-    case 1024:
-      return scratch_programmable_bootstrap_cg_128<InputTorus, Degree<1024>>(
-          static_cast<cudaStream_t>(stream), gpu_index, buffer, lwe_dimension,
-          glwe_dimension, polynomial_size, level_count,
-          input_lwe_ciphertext_count, allocate_gpu_memory,
-          noise_reduction_type);
-      break;
-    case 2048:
-      return scratch_programmable_bootstrap_cg_128<InputTorus, Degree<2048>>(
-          static_cast<cudaStream_t>(stream), gpu_index, buffer, lwe_dimension,
-          glwe_dimension, polynomial_size, level_count,
-          input_lwe_ciphertext_count, allocate_gpu_memory,
-          noise_reduction_type);
-      break;
-    case 4096:
-      // We use AmortizedDegree for 4096 to avoid register exhaustion
-      return scratch_programmable_bootstrap_cg_128<InputTorus,
-                                                   AmortizedDegree<4096>>(
-          static_cast<cudaStream_t>(stream), gpu_index, buffer, lwe_dimension,
-          glwe_dimension, polynomial_size, level_count,
-          input_lwe_ciphertext_count, allocate_gpu_memory,
-          noise_reduction_type);
-      break;
-    default:
-      PANIC("Cuda error (classical PBS128): unsupported polynomial size. "
-            "Supported N's are powers of two"
-            " in the interval [256..4096].")
-    }
+    DISPATCH_POLY_SIZE(
+        polynomial_size, Multibit128DegreePolicy,
+        return scratch_programmable_bootstrap_cg_128<InputTorus, Params>(
+            static_cast<cudaStream_t>(stream), gpu_index, buffer, lwe_dimension,
+            glwe_dimension, polynomial_size, level_count,
+            input_lwe_ciphertext_count, allocate_gpu_memory,
+            noise_reduction_type));
   } else {
-    switch (polynomial_size) {
-    case 256:
-      return scratch_programmable_bootstrap_128<InputTorus, Degree<256>>(
-          static_cast<cudaStream_t>(stream), gpu_index, buffer, lwe_dimension,
-          glwe_dimension, polynomial_size, level_count,
-          input_lwe_ciphertext_count, allocate_gpu_memory,
-          noise_reduction_type);
-      break;
-    case 512:
-      return scratch_programmable_bootstrap_128<InputTorus, Degree<512>>(
-          static_cast<cudaStream_t>(stream), gpu_index, buffer, lwe_dimension,
-          glwe_dimension, polynomial_size, level_count,
-          input_lwe_ciphertext_count, allocate_gpu_memory,
-          noise_reduction_type);
-      break;
-    case 1024:
-      return scratch_programmable_bootstrap_128<InputTorus, Degree<1024>>(
-          static_cast<cudaStream_t>(stream), gpu_index, buffer, lwe_dimension,
-          glwe_dimension, polynomial_size, level_count,
-          input_lwe_ciphertext_count, allocate_gpu_memory,
-          noise_reduction_type);
-      break;
-    case 2048:
-      return scratch_programmable_bootstrap_128<InputTorus, Degree<2048>>(
-          static_cast<cudaStream_t>(stream), gpu_index, buffer, lwe_dimension,
-          glwe_dimension, polynomial_size, level_count,
-          input_lwe_ciphertext_count, allocate_gpu_memory,
-          noise_reduction_type);
-      break;
-    case 4096:
-      // We use AmortizedDegree for 4096 to avoid register exhaustion
-      return scratch_programmable_bootstrap_128<InputTorus,
-                                                AmortizedDegree<4096>>(
-          static_cast<cudaStream_t>(stream), gpu_index, buffer, lwe_dimension,
-          glwe_dimension, polynomial_size, level_count,
-          input_lwe_ciphertext_count, allocate_gpu_memory,
-          noise_reduction_type);
-      break;
-    default:
-      PANIC("Cuda error (classical PBS): unsupported polynomial size. "
-            "Supported N's are powers of two"
-            " in the interval [256..4096].")
-    }
+    DISPATCH_POLY_SIZE(
+        polynomial_size, Multibit128DegreePolicy,
+        return scratch_programmable_bootstrap_128<InputTorus, Params>(
+            static_cast<cudaStream_t>(stream), gpu_index, buffer, lwe_dimension,
+            glwe_dimension, polynomial_size, level_count,
+            input_lwe_ciphertext_count, allocate_gpu_memory,
+            noise_reduction_type));
   }
 }
 
@@ -1570,28 +1499,10 @@ __host__ bool verify_cuda_programmable_bootstrap_128_cg_grid_size(
 __host__ bool supports_cooperative_groups_on_programmable_bootstrap_128(
     int glwe_dimension, int polynomial_size, int level_count, int num_samples,
     uint32_t max_shared_memory) {
-  switch (polynomial_size) {
-  case 256:
-    return verify_cuda_programmable_bootstrap_128_cg_grid_size<Degree<256>>(
-        glwe_dimension, level_count, num_samples, max_shared_memory);
-  case 512:
-    return verify_cuda_programmable_bootstrap_128_cg_grid_size<Degree<512>>(
-        glwe_dimension, level_count, num_samples, max_shared_memory);
-  case 1024:
-    return verify_cuda_programmable_bootstrap_128_cg_grid_size<Degree<1024>>(
-        glwe_dimension, level_count, num_samples, max_shared_memory);
-  case 2048:
-    return verify_cuda_programmable_bootstrap_128_cg_grid_size<Degree<2048>>(
-        glwe_dimension, level_count, num_samples, max_shared_memory);
-  case 4096:
-    // We use AmortizedDegree for 4096 to avoid register exhaustion
-    return verify_cuda_programmable_bootstrap_128_cg_grid_size<
-        AmortizedDegree<4096>>(glwe_dimension, level_count, num_samples,
-                               max_shared_memory);
-  default:
-    PANIC("Cuda error (classical PBS128): unsupported polynomial size. "
-          "Supported N's are powers of two"
-          " in the interval [256..4096].")
-  }
+  // AmortizedDegree for 4096 avoids register exhaustion in 128-bit classic PBS
+  DISPATCH_POLY_SIZE(
+      polynomial_size, Multibit128DegreePolicy,
+      return verify_cuda_programmable_bootstrap_128_cg_grid_size<Params>(
+          glwe_dimension, level_count, num_samples, max_shared_memory));
 }
 #endif // TFHE_RS_BACKENDS_TFHE_CUDA_BACKEND_CUDA_SRC_PBS_PROGRAMMABLE_BOOTSTRAP_CLASSIC_128_CUH_

--- a/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_multibit.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_multibit.cu
@@ -1,6 +1,7 @@
 #include "../polynomial/parameters.cuh"
 #include "checked_arithmetic.h"
 #include "pbs/programmable_bootstrap_multibit.h"
+#include "polynomial/dispatch.cuh"
 #include "programmable_bootstrap_cg_multibit.cuh"
 #include "programmable_bootstrap_multibit.cuh"
 #include <type_traits>
@@ -25,47 +26,11 @@ bool has_support_to_cuda_programmable_bootstrap_tbc_multi_bit(
   if ((glwe_dimension + 1) * level_count > 8)
     return false;
 
-  switch (polynomial_size) {
-  case 256:
-    return supports_thread_block_clusters_on_multibit_programmable_bootstrap<
-        Torus, AmortizedDegree<256>>(num_samples, glwe_dimension,
-                                     polynomial_size, level_count,
-                                     max_shared_memory);
-  case 512:
-    return supports_thread_block_clusters_on_multibit_programmable_bootstrap<
-        Torus, AmortizedDegree<512>>(num_samples, glwe_dimension,
-                                     polynomial_size, level_count,
-                                     max_shared_memory);
-  case 1024:
-    return supports_thread_block_clusters_on_multibit_programmable_bootstrap<
-        Torus, AmortizedDegree<1024>>(num_samples, glwe_dimension,
-                                      polynomial_size, level_count,
-                                      max_shared_memory);
-  case 2048:
-    return supports_thread_block_clusters_on_multibit_programmable_bootstrap<
-        Torus, AmortizedDegree<2048>>(num_samples, glwe_dimension,
-                                      polynomial_size, level_count,
-                                      max_shared_memory);
-  case 4096:
-    return supports_thread_block_clusters_on_multibit_programmable_bootstrap<
-        Torus, AmortizedDegree<4096>>(num_samples, glwe_dimension,
-                                      polynomial_size, level_count,
-                                      max_shared_memory);
-  case 8192:
-    return supports_thread_block_clusters_on_multibit_programmable_bootstrap<
-        Torus, AmortizedDegree<8192>>(num_samples, glwe_dimension,
-                                      polynomial_size, level_count,
-                                      max_shared_memory);
-  case 16384:
-    return supports_thread_block_clusters_on_multibit_programmable_bootstrap<
-        Torus, AmortizedDegree<16384>>(num_samples, glwe_dimension,
-                                       polynomial_size, level_count,
-                                       max_shared_memory);
-  default:
-    PANIC("Cuda error (multi-bit PBS): unsupported polynomial size. Supported "
-          "N's are powers of two"
-          " in the interval [256..16384].")
-  }
+  DISPATCH_POLY_SIZE(
+      polynomial_size, AmortizedDegreePolicy,
+      return supports_thread_block_clusters_on_multibit_programmable_bootstrap<
+          Torus, Params>(num_samples, glwe_dimension, polynomial_size,
+                         level_count, max_shared_memory));
 #else
   return false;
 #endif
@@ -82,68 +47,14 @@ void cuda_cg_multi_bit_programmable_bootstrap_lwe_ciphertext_vector(
     uint32_t base_log, uint32_t level_count, uint32_t num_samples,
     uint32_t num_many_lut, uint32_t lut_stride) {
 
-  switch (polynomial_size) {
-  case 256:
-    host_cg_multi_bit_programmable_bootstrap<Torus, AmortizedDegree<256>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, pbs_buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, grouping_factor, base_log, level_count,
-        num_samples, num_many_lut, lut_stride);
-    break;
-  case 512:
-    host_cg_multi_bit_programmable_bootstrap<Torus, AmortizedDegree<512>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, pbs_buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, grouping_factor, base_log, level_count,
-        num_samples, num_many_lut, lut_stride);
-    break;
-  case 1024:
-    host_cg_multi_bit_programmable_bootstrap<Torus, AmortizedDegree<1024>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, pbs_buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, grouping_factor, base_log, level_count,
-        num_samples, num_many_lut, lut_stride);
-    break;
-  case 2048:
-    host_cg_multi_bit_programmable_bootstrap<Torus, AmortizedDegree<2048>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, pbs_buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, grouping_factor, base_log, level_count,
-        num_samples, num_many_lut, lut_stride);
-    break;
-  case 4096:
-    host_cg_multi_bit_programmable_bootstrap<Torus, AmortizedDegree<4096>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, pbs_buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, grouping_factor, base_log, level_count,
-        num_samples, num_many_lut, lut_stride);
-    break;
-  case 8192:
-    host_cg_multi_bit_programmable_bootstrap<Torus, AmortizedDegree<8192>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, pbs_buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, grouping_factor, base_log, level_count,
-        num_samples, num_many_lut, lut_stride);
-    break;
-  case 16384:
-    host_cg_multi_bit_programmable_bootstrap<Torus, AmortizedDegree<16384>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, pbs_buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, grouping_factor, base_log, level_count,
-        num_samples, num_many_lut, lut_stride);
-    break;
-  default:
-    PANIC("Cuda error (multi-bit PBS): unsupported polynomial size. Supported "
-          "N's are powers of two"
-          " in the interval [256..16384].")
-  }
+  DISPATCH_POLY_SIZE(
+      polynomial_size, AmortizedDegreePolicy,
+      host_cg_multi_bit_programmable_bootstrap<Torus, Params>(
+          static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
+          lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
+          lwe_input_indexes, bootstrapping_key, pbs_buffer, glwe_dimension,
+          lwe_dimension, polynomial_size, grouping_factor, base_log,
+          level_count, num_samples, num_many_lut, lut_stride));
 }
 
 template <typename Torus>
@@ -157,68 +68,14 @@ void cuda_multi_bit_programmable_bootstrap_lwe_ciphertext_vector(
     uint32_t base_log, uint32_t level_count, uint32_t num_samples,
     uint32_t num_many_lut, uint32_t lut_stride) {
 
-  switch (polynomial_size) {
-  case 256:
-    host_multi_bit_programmable_bootstrap<Torus, AmortizedDegree<256>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, pbs_buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, grouping_factor, base_log, level_count,
-        num_samples, num_many_lut, lut_stride);
-    break;
-  case 512:
-    host_multi_bit_programmable_bootstrap<Torus, AmortizedDegree<512>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, pbs_buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, grouping_factor, base_log, level_count,
-        num_samples, num_many_lut, lut_stride);
-    break;
-  case 1024:
-    host_multi_bit_programmable_bootstrap<Torus, AmortizedDegree<1024>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, pbs_buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, grouping_factor, base_log, level_count,
-        num_samples, num_many_lut, lut_stride);
-    break;
-  case 2048:
-    host_multi_bit_programmable_bootstrap<Torus, AmortizedDegree<2048>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, pbs_buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, grouping_factor, base_log, level_count,
-        num_samples, num_many_lut, lut_stride);
-    break;
-  case 4096:
-    host_multi_bit_programmable_bootstrap<Torus, AmortizedDegree<4096>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, pbs_buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, grouping_factor, base_log, level_count,
-        num_samples, num_many_lut, lut_stride);
-    break;
-  case 8192:
-    host_multi_bit_programmable_bootstrap<Torus, AmortizedDegree<8192>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, pbs_buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, grouping_factor, base_log, level_count,
-        num_samples, num_many_lut, lut_stride);
-    break;
-  case 16384:
-    host_multi_bit_programmable_bootstrap<Torus, AmortizedDegree<16384>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, pbs_buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, grouping_factor, base_log, level_count,
-        num_samples, num_many_lut, lut_stride);
-    break;
-  default:
-    PANIC("Cuda error (multi-bit PBS): unsupported polynomial size. Supported "
-          "N's are powers of two"
-          " in the interval [256..16384].")
-  }
+  DISPATCH_POLY_SIZE(
+      polynomial_size, AmortizedDegreePolicy,
+      host_multi_bit_programmable_bootstrap<Torus, Params>(
+          static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
+          lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
+          lwe_input_indexes, bootstrapping_key, pbs_buffer, glwe_dimension,
+          lwe_dimension, polynomial_size, grouping_factor, base_log,
+          level_count, num_samples, num_many_lut, lut_stride));
 }
 
 template <typename Torus>
@@ -450,54 +307,12 @@ uint64_t scratch_cuda_cg_multi_bit_programmable_bootstrap(
     uint32_t glwe_dimension, uint32_t polynomial_size, uint32_t level_count,
     uint32_t input_lwe_ciphertext_count, bool allocate_gpu_memory) {
 
-  switch (polynomial_size) {
-  case 256:
-    return scratch_cg_multi_bit_programmable_bootstrap<Torus,
-                                                       AmortizedDegree<256>>(
-        static_cast<cudaStream_t>(stream), gpu_index, buffer, glwe_dimension,
-        polynomial_size, level_count, input_lwe_ciphertext_count,
-        allocate_gpu_memory);
-  case 512:
-    return scratch_cg_multi_bit_programmable_bootstrap<Torus,
-                                                       AmortizedDegree<512>>(
-        static_cast<cudaStream_t>(stream), gpu_index, buffer, glwe_dimension,
-        polynomial_size, level_count, input_lwe_ciphertext_count,
-        allocate_gpu_memory);
-  case 1024:
-    return scratch_cg_multi_bit_programmable_bootstrap<Torus,
-                                                       AmortizedDegree<1024>>(
-        static_cast<cudaStream_t>(stream), gpu_index, buffer, glwe_dimension,
-        polynomial_size, level_count, input_lwe_ciphertext_count,
-        allocate_gpu_memory);
-  case 2048:
-    return scratch_cg_multi_bit_programmable_bootstrap<Torus,
-                                                       AmortizedDegree<2048>>(
-        static_cast<cudaStream_t>(stream), gpu_index, buffer, glwe_dimension,
-        polynomial_size, level_count, input_lwe_ciphertext_count,
-        allocate_gpu_memory);
-  case 4096:
-    return scratch_cg_multi_bit_programmable_bootstrap<Torus,
-                                                       AmortizedDegree<4096>>(
-        static_cast<cudaStream_t>(stream), gpu_index, buffer, glwe_dimension,
-        polynomial_size, level_count, input_lwe_ciphertext_count,
-        allocate_gpu_memory);
-  case 8192:
-    return scratch_cg_multi_bit_programmable_bootstrap<Torus,
-                                                       AmortizedDegree<8192>>(
-        static_cast<cudaStream_t>(stream), gpu_index, buffer, glwe_dimension,
-        polynomial_size, level_count, input_lwe_ciphertext_count,
-        allocate_gpu_memory);
-  case 16384:
-    return scratch_cg_multi_bit_programmable_bootstrap<Torus,
-                                                       AmortizedDegree<16384>>(
-        static_cast<cudaStream_t>(stream), gpu_index, buffer, glwe_dimension,
-        polynomial_size, level_count, input_lwe_ciphertext_count,
-        allocate_gpu_memory);
-  default:
-    PANIC("Cuda error (multi-bit PBS): unsupported polynomial size. Supported "
-          "N's are powers of two"
-          " in the interval [256..16384].")
-  }
+  DISPATCH_POLY_SIZE(
+      polynomial_size, AmortizedDegreePolicy,
+      return scratch_cg_multi_bit_programmable_bootstrap<Torus, Params>(
+          static_cast<cudaStream_t>(stream), gpu_index, buffer, glwe_dimension,
+          polynomial_size, level_count, input_lwe_ciphertext_count,
+          allocate_gpu_memory));
 }
 
 template <typename Torus>
@@ -506,54 +321,12 @@ uint64_t scratch_cuda_multi_bit_programmable_bootstrap(
     uint32_t glwe_dimension, uint32_t polynomial_size, uint32_t level_count,
     uint32_t input_lwe_ciphertext_count, bool allocate_gpu_memory) {
 
-  switch (polynomial_size) {
-  case 256:
-    return scratch_multi_bit_programmable_bootstrap<Torus,
-                                                    AmortizedDegree<256>>(
-        static_cast<cudaStream_t>(stream), gpu_index, buffer, glwe_dimension,
-        polynomial_size, level_count, input_lwe_ciphertext_count,
-        allocate_gpu_memory);
-  case 512:
-    return scratch_multi_bit_programmable_bootstrap<Torus,
-                                                    AmortizedDegree<512>>(
-        static_cast<cudaStream_t>(stream), gpu_index, buffer, glwe_dimension,
-        polynomial_size, level_count, input_lwe_ciphertext_count,
-        allocate_gpu_memory);
-  case 1024:
-    return scratch_multi_bit_programmable_bootstrap<Torus,
-                                                    AmortizedDegree<1024>>(
-        static_cast<cudaStream_t>(stream), gpu_index, buffer, glwe_dimension,
-        polynomial_size, level_count, input_lwe_ciphertext_count,
-        allocate_gpu_memory);
-  case 2048:
-    return scratch_multi_bit_programmable_bootstrap<Torus,
-                                                    AmortizedDegree<2048>>(
-        static_cast<cudaStream_t>(stream), gpu_index, buffer, glwe_dimension,
-        polynomial_size, level_count, input_lwe_ciphertext_count,
-        allocate_gpu_memory);
-  case 4096:
-    return scratch_multi_bit_programmable_bootstrap<Torus,
-                                                    AmortizedDegree<4096>>(
-        static_cast<cudaStream_t>(stream), gpu_index, buffer, glwe_dimension,
-        polynomial_size, level_count, input_lwe_ciphertext_count,
-        allocate_gpu_memory);
-  case 8192:
-    return scratch_multi_bit_programmable_bootstrap<Torus,
-                                                    AmortizedDegree<8192>>(
-        static_cast<cudaStream_t>(stream), gpu_index, buffer, glwe_dimension,
-        polynomial_size, level_count, input_lwe_ciphertext_count,
-        allocate_gpu_memory);
-  case 16384:
-    return scratch_multi_bit_programmable_bootstrap<Torus,
-                                                    AmortizedDegree<16384>>(
-        static_cast<cudaStream_t>(stream), gpu_index, buffer, glwe_dimension,
-        polynomial_size, level_count, input_lwe_ciphertext_count,
-        allocate_gpu_memory);
-  default:
-    PANIC("Cuda error (multi-bit PBS): unsupported polynomial size. Supported "
-          "N's are powers of two"
-          " in the interval [256..16384].")
-  }
+  DISPATCH_POLY_SIZE(
+      polynomial_size, AmortizedDegreePolicy,
+      return scratch_multi_bit_programmable_bootstrap<Torus, Params>(
+          static_cast<cudaStream_t>(stream), gpu_index, buffer, glwe_dimension,
+          polynomial_size, level_count, input_lwe_ciphertext_count,
+          allocate_gpu_memory));
 }
 
 uint64_t scratch_cuda_multi_bit_programmable_bootstrap_64_async(
@@ -875,54 +648,12 @@ uint64_t scratch_cuda_tbc_multi_bit_programmable_bootstrap(
     uint32_t glwe_dimension, uint32_t polynomial_size, uint32_t level_count,
     uint32_t input_lwe_ciphertext_count, bool allocate_gpu_memory) {
 
-  switch (polynomial_size) {
-  case 256:
-    return scratch_tbc_multi_bit_programmable_bootstrap<Torus,
-                                                        AmortizedDegree<256>>(
-        static_cast<cudaStream_t>(stream), gpu_index, buffer, glwe_dimension,
-        polynomial_size, level_count, input_lwe_ciphertext_count,
-        allocate_gpu_memory);
-  case 512:
-    return scratch_tbc_multi_bit_programmable_bootstrap<Torus,
-                                                        AmortizedDegree<512>>(
-        static_cast<cudaStream_t>(stream), gpu_index, buffer, glwe_dimension,
-        polynomial_size, level_count, input_lwe_ciphertext_count,
-        allocate_gpu_memory);
-  case 1024:
-    return scratch_tbc_multi_bit_programmable_bootstrap<Torus,
-                                                        AmortizedDegree<1024>>(
-        static_cast<cudaStream_t>(stream), gpu_index, buffer, glwe_dimension,
-        polynomial_size, level_count, input_lwe_ciphertext_count,
-        allocate_gpu_memory);
-  case 2048:
-    return scratch_tbc_multi_bit_programmable_bootstrap<Torus,
-                                                        AmortizedDegree<2048>>(
-        static_cast<cudaStream_t>(stream), gpu_index, buffer, glwe_dimension,
-        polynomial_size, level_count, input_lwe_ciphertext_count,
-        allocate_gpu_memory);
-  case 4096:
-    return scratch_tbc_multi_bit_programmable_bootstrap<Torus,
-                                                        AmortizedDegree<4096>>(
-        static_cast<cudaStream_t>(stream), gpu_index, buffer, glwe_dimension,
-        polynomial_size, level_count, input_lwe_ciphertext_count,
-        allocate_gpu_memory);
-  case 8192:
-    return scratch_tbc_multi_bit_programmable_bootstrap<Torus,
-                                                        AmortizedDegree<8192>>(
-        static_cast<cudaStream_t>(stream), gpu_index, buffer, glwe_dimension,
-        polynomial_size, level_count, input_lwe_ciphertext_count,
-        allocate_gpu_memory);
-  case 16384:
-    return scratch_tbc_multi_bit_programmable_bootstrap<Torus,
-                                                        AmortizedDegree<16384>>(
-        static_cast<cudaStream_t>(stream), gpu_index, buffer, glwe_dimension,
-        polynomial_size, level_count, input_lwe_ciphertext_count,
-        allocate_gpu_memory);
-  default:
-    PANIC("Cuda error (multi-bit PBS): unsupported polynomial size. Supported "
-          "N's are powers of two"
-          " in the interval [256..16384].")
-  }
+  DISPATCH_POLY_SIZE(
+      polynomial_size, AmortizedDegreePolicy,
+      return scratch_tbc_multi_bit_programmable_bootstrap<Torus, Params>(
+          static_cast<cudaStream_t>(stream), gpu_index, buffer, glwe_dimension,
+          polynomial_size, level_count, input_lwe_ciphertext_count,
+          allocate_gpu_memory));
 }
 template <typename Torus>
 void cuda_tbc_multi_bit_programmable_bootstrap_lwe_ciphertext_vector(
@@ -941,32 +672,10 @@ void cuda_tbc_multi_bit_programmable_bootstrap_lwe_ciphertext_vector(
   if (base_log > 32)
     PANIC("Cuda error (multi-bit PBS): base log should be <= 32")
 
-  switch (polynomial_size) {
-  case 256:
-    host_tbc_multi_bit_programmable_bootstrap<uint64_t, AmortizedDegree<256>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, pbs_buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, grouping_factor, base_log, level_count,
-        num_samples, num_many_lut, lut_stride);
-    break;
-  case 512:
-    host_tbc_multi_bit_programmable_bootstrap<Torus, AmortizedDegree<512>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, pbs_buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, grouping_factor, base_log, level_count,
-        num_samples, num_many_lut, lut_stride);
-    break;
-  case 1024:
-    host_tbc_multi_bit_programmable_bootstrap<Torus, AmortizedDegree<1024>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, pbs_buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, grouping_factor, base_log, level_count,
-        num_samples, num_many_lut, lut_stride);
-    break;
-  case 2048: {
+  if (polynomial_size == 2048) {
+    // Runtime SM-count heuristic: use Degree<2048> (more registers per thread)
+    // when there are enough SMs to avoid underoccupancy, otherwise fall back to
+    // AmortizedDegree<2048>.
     int num_sms = 0;
     check_cuda_error(cudaDeviceGetAttribute(
         &num_sms, cudaDevAttrMultiProcessorCount, gpu_index));
@@ -985,37 +694,15 @@ void cuda_tbc_multi_bit_programmable_bootstrap_lwe_ciphertext_vector(
           lwe_input_indexes, bootstrapping_key, pbs_buffer, glwe_dimension,
           lwe_dimension, polynomial_size, grouping_factor, base_log,
           level_count, num_samples, num_many_lut, lut_stride);
-
-    break;
-  }
-  case 4096:
-    host_tbc_multi_bit_programmable_bootstrap<Torus, AmortizedDegree<4096>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, pbs_buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, grouping_factor, base_log, level_count,
-        num_samples, num_many_lut, lut_stride);
-    break;
-  case 8192:
-    host_tbc_multi_bit_programmable_bootstrap<Torus, AmortizedDegree<8192>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, pbs_buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, grouping_factor, base_log, level_count,
-        num_samples, num_many_lut, lut_stride);
-    break;
-  case 16384:
-    host_tbc_multi_bit_programmable_bootstrap<Torus, AmortizedDegree<16384>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, pbs_buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, grouping_factor, base_log, level_count,
-        num_samples, num_many_lut, lut_stride);
-    break;
-  default:
-    PANIC("Cuda error (multi-bit PBS): unsupported polynomial size. Supported "
-          "N's are powers of two"
-          " in the interval [256..16384].")
+  } else {
+    DISPATCH_POLY_SIZE(
+        polynomial_size, AmortizedDegreePolicy,
+        host_tbc_multi_bit_programmable_bootstrap<Torus, Params>(
+            static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
+            lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
+            lwe_input_indexes, bootstrapping_key, pbs_buffer, glwe_dimension,
+            lwe_dimension, polynomial_size, grouping_factor, base_log,
+            level_count, num_samples, num_many_lut, lut_stride));
   }
 }
 
@@ -1036,35 +723,10 @@ void cuda_tbc_multi_bit_programmable_bootstrap_lwe_ciphertext_vector_generic(
   if (base_log > 32)
     PANIC("Cuda error (multi-bit PBS): base log should be <= 32")
 
-  switch (polynomial_size) {
-  case 256:
-    host_tbc_multi_bit_programmable_bootstrap_generic<uint64_t,
-                                                      AmortizedDegree<256>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, pbs_buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, grouping_factor, base_log, level_count,
-        num_samples, num_many_lut, lut_stride);
-    break;
-  case 512:
-    host_tbc_multi_bit_programmable_bootstrap_generic<Torus,
-                                                      AmortizedDegree<512>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, pbs_buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, grouping_factor, base_log, level_count,
-        num_samples, num_many_lut, lut_stride);
-    break;
-  case 1024:
-    host_tbc_multi_bit_programmable_bootstrap_generic<Torus,
-                                                      AmortizedDegree<1024>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, pbs_buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, grouping_factor, base_log, level_count,
-        num_samples, num_many_lut, lut_stride);
-    break;
-  case 2048: {
+  if (polynomial_size == 2048) {
+    // Runtime SM-count heuristic: use Degree<2048> (more registers per thread)
+    // when there are enough SMs to avoid underoccupancy, otherwise fall back to
+    // AmortizedDegree<2048>.
     int num_sms = 0;
     check_cuda_error(cudaDeviceGetAttribute(
         &num_sms, cudaDevAttrMultiProcessorCount, gpu_index));
@@ -1084,40 +746,15 @@ void cuda_tbc_multi_bit_programmable_bootstrap_lwe_ciphertext_vector_generic(
           lwe_input_indexes, bootstrapping_key, pbs_buffer, glwe_dimension,
           lwe_dimension, polynomial_size, grouping_factor, base_log,
           level_count, num_samples, num_many_lut, lut_stride);
-
-    break;
-  }
-  case 4096:
-    host_tbc_multi_bit_programmable_bootstrap_generic<Torus,
-                                                      AmortizedDegree<4096>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, pbs_buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, grouping_factor, base_log, level_count,
-        num_samples, num_many_lut, lut_stride);
-    break;
-  case 8192:
-    host_tbc_multi_bit_programmable_bootstrap_generic<Torus,
-                                                      AmortizedDegree<8192>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, pbs_buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, grouping_factor, base_log, level_count,
-        num_samples, num_many_lut, lut_stride);
-    break;
-  case 16384:
-    host_tbc_multi_bit_programmable_bootstrap_generic<Torus,
-                                                      AmortizedDegree<16384>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
-        lwe_input_indexes, bootstrapping_key, pbs_buffer, glwe_dimension,
-        lwe_dimension, polynomial_size, grouping_factor, base_log, level_count,
-        num_samples, num_many_lut, lut_stride);
-    break;
-  default:
-    PANIC("Cuda error (multi-bit PBS): unsupported polynomial size. Supported "
-          "N's are powers of two"
-          " in the interval [256..16384].")
+  } else {
+    DISPATCH_POLY_SIZE(
+        polynomial_size, AmortizedDegreePolicy,
+        host_tbc_multi_bit_programmable_bootstrap_generic<Torus, Params>(
+            static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
+            lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
+            lwe_input_indexes, bootstrapping_key, pbs_buffer, glwe_dimension,
+            lwe_dimension, polynomial_size, grouping_factor, base_log,
+            level_count, num_samples, num_many_lut, lut_stride));
   }
 }
 

--- a/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_multibit_128.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_multibit_128.cu
@@ -1,3 +1,4 @@
+#include "polynomial/dispatch.cuh"
 #include "programmable_bootstrap_cg_multibit.cuh"
 #include "programmable_bootstrap_multibit_128.cuh"
 
@@ -8,43 +9,13 @@ uint64_t scratch_cuda_multi_bit_programmable_bootstrap_128_async(
     uint32_t polynomial_size, uint32_t level_count,
     uint32_t input_lwe_ciphertext_count, bool allocate_gpu_memory) {
 
-  switch (polynomial_size) {
-  case 256:
-    return scratch_multi_bit_programmable_bootstrap_128<InputTorus,
-                                                        Degree<256>>(
-        static_cast<cudaStream_t>(stream), gpu_index, buffer, glwe_dimension,
-        polynomial_size, level_count, input_lwe_ciphertext_count,
-        allocate_gpu_memory);
-  case 512:
-    return scratch_multi_bit_programmable_bootstrap_128<InputTorus,
-                                                        Degree<512>>(
-        static_cast<cudaStream_t>(stream), gpu_index, buffer, glwe_dimension,
-        polynomial_size, level_count, input_lwe_ciphertext_count,
-        allocate_gpu_memory);
-  case 1024:
-    return scratch_multi_bit_programmable_bootstrap_128<InputTorus,
-                                                        Degree<1024>>(
-        static_cast<cudaStream_t>(stream), gpu_index, buffer, glwe_dimension,
-        polynomial_size, level_count, input_lwe_ciphertext_count,
-        allocate_gpu_memory);
-  case 2048:
-    return scratch_multi_bit_programmable_bootstrap_128<InputTorus,
-                                                        Degree<2048>>(
-        static_cast<cudaStream_t>(stream), gpu_index, buffer, glwe_dimension,
-        polynomial_size, level_count, input_lwe_ciphertext_count,
-        allocate_gpu_memory);
-  case 4096:
-    // We use AmortizedDegree for 4096 to avoid register exhaustion
-    return scratch_multi_bit_programmable_bootstrap_128<InputTorus,
-                                                        AmortizedDegree<4096>>(
-        static_cast<cudaStream_t>(stream), gpu_index, buffer, glwe_dimension,
-        polynomial_size, level_count, input_lwe_ciphertext_count,
-        allocate_gpu_memory);
-  default:
-    PANIC("Cuda error (multi-bit PBS): unsupported polynomial size. Supported "
-          "N's are powers of two"
-          " in the interval [256..4096].")
-  }
+  // AmortizedDegree for 4096 avoids register exhaustion in 128-bit multibit PBS
+  DISPATCH_POLY_SIZE(
+      polynomial_size, Multibit128DegreePolicy,
+      return scratch_multi_bit_programmable_bootstrap_128<InputTorus, Params>(
+          static_cast<cudaStream_t>(stream), gpu_index, buffer, glwe_dimension,
+          polynomial_size, level_count, input_lwe_ciphertext_count,
+          allocate_gpu_memory));
 }
 
 template <typename InputTorus>
@@ -54,43 +25,14 @@ uint64_t scratch_cuda_cg_multi_bit_programmable_bootstrap_128(
     uint32_t polynomial_size, uint32_t level_count,
     uint32_t input_lwe_ciphertext_count, bool allocate_gpu_memory) {
 
-  switch (polynomial_size) {
-  case 256:
-    return scratch_cg_multi_bit_programmable_bootstrap_128<InputTorus,
-                                                           Degree<256>>(
-        static_cast<cudaStream_t>(stream), gpu_index, buffer, glwe_dimension,
-        polynomial_size, level_count, input_lwe_ciphertext_count,
-        allocate_gpu_memory);
-  case 512:
-    return scratch_cg_multi_bit_programmable_bootstrap_128<InputTorus,
-                                                           Degree<512>>(
-        static_cast<cudaStream_t>(stream), gpu_index, buffer, glwe_dimension,
-        polynomial_size, level_count, input_lwe_ciphertext_count,
-        allocate_gpu_memory);
-  case 1024:
-    return scratch_cg_multi_bit_programmable_bootstrap_128<InputTorus,
-                                                           Degree<1024>>(
-        static_cast<cudaStream_t>(stream), gpu_index, buffer, glwe_dimension,
-        polynomial_size, level_count, input_lwe_ciphertext_count,
-        allocate_gpu_memory);
-  case 2048:
-    return scratch_cg_multi_bit_programmable_bootstrap_128<InputTorus,
-                                                           Degree<2048>>(
-        static_cast<cudaStream_t>(stream), gpu_index, buffer, glwe_dimension,
-        polynomial_size, level_count, input_lwe_ciphertext_count,
-        allocate_gpu_memory);
-  case 4096:
-    // We use AmortizedDegree for 4096 to avoid register exhaustion
-    return scratch_cg_multi_bit_programmable_bootstrap_128<
-        InputTorus, AmortizedDegree<4096>>(
-        static_cast<cudaStream_t>(stream), gpu_index, buffer, glwe_dimension,
-        polynomial_size, level_count, input_lwe_ciphertext_count,
-        allocate_gpu_memory);
-  default:
-    PANIC("Cuda error (multi-bit PBS): unsupported polynomial size. Supported "
-          "N's are powers of two"
-          " in the interval [256..4096].")
-  }
+  // AmortizedDegree for 4096 avoids register exhaustion in 128-bit multibit PBS
+  DISPATCH_POLY_SIZE(
+      polynomial_size, Multibit128DegreePolicy,
+      return scratch_cg_multi_bit_programmable_bootstrap_128<InputTorus,
+                                                             Params>(
+          static_cast<cudaStream_t>(stream), gpu_index, buffer, glwe_dimension,
+          polynomial_size, level_count, input_lwe_ciphertext_count,
+          allocate_gpu_memory));
 }
 
 uint64_t scratch_cuda_multi_bit_programmable_bootstrap_128_async(
@@ -129,54 +71,15 @@ void cuda_multi_bit_programmable_bootstrap_128_async(
     uint32_t base_log, uint32_t level_count, uint32_t num_samples,
     uint32_t num_many_lut, uint32_t lut_stride) {
 
-  switch (polynomial_size) {
-  case 256:
-    host_multi_bit_programmable_bootstrap_128<InputTorus, Degree<256>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lwe_array_in, lwe_input_indexes,
-        bootstrapping_key, pbs_buffer, glwe_dimension, lwe_dimension,
-        polynomial_size, grouping_factor, base_log, level_count, num_samples,
-        num_many_lut, lut_stride);
-    break;
-  case 512:
-    host_multi_bit_programmable_bootstrap_128<InputTorus, Degree<512>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lwe_array_in, lwe_input_indexes,
-        bootstrapping_key, pbs_buffer, glwe_dimension, lwe_dimension,
-        polynomial_size, grouping_factor, base_log, level_count, num_samples,
-        num_many_lut, lut_stride);
-    break;
-  case 1024:
-    host_multi_bit_programmable_bootstrap_128<InputTorus, Degree<1024>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lwe_array_in, lwe_input_indexes,
-        bootstrapping_key, pbs_buffer, glwe_dimension, lwe_dimension,
-        polynomial_size, grouping_factor, base_log, level_count, num_samples,
-        num_many_lut, lut_stride);
-    break;
-  case 2048:
-    host_multi_bit_programmable_bootstrap_128<InputTorus, Degree<2048>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lwe_array_in, lwe_input_indexes,
-        bootstrapping_key, pbs_buffer, glwe_dimension, lwe_dimension,
-        polynomial_size, grouping_factor, base_log, level_count, num_samples,
-        num_many_lut, lut_stride);
-    break;
-  case 4096:
-    // We use AmortizedDegree for 4096 to avoid register exhaustion
-    host_multi_bit_programmable_bootstrap_128<InputTorus,
-                                              AmortizedDegree<4096>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lwe_array_in, lwe_input_indexes,
-        bootstrapping_key, pbs_buffer, glwe_dimension, lwe_dimension,
-        polynomial_size, grouping_factor, base_log, level_count, num_samples,
-        num_many_lut, lut_stride);
-    break;
-  default:
-    PANIC("Cuda error (multi-bit PBS): unsupported polynomial size. Supported "
-          "N's are powers of two"
-          " in the interval [256..4096].")
-  }
+  // AmortizedDegree for 4096 avoids register exhaustion in 128-bit multibit PBS
+  DISPATCH_POLY_SIZE(
+      polynomial_size, Multibit128DegreePolicy,
+      host_multi_bit_programmable_bootstrap_128<InputTorus, Params>(
+          static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
+          lwe_output_indexes, lut_vector, lwe_array_in, lwe_input_indexes,
+          bootstrapping_key, pbs_buffer, glwe_dimension, lwe_dimension,
+          polynomial_size, grouping_factor, base_log, level_count, num_samples,
+          num_many_lut, lut_stride));
 }
 
 template <typename InputTorus>
@@ -190,54 +93,15 @@ void cuda_cg_multi_bit_programmable_bootstrap_lwe_ciphertext_vector_128(
     uint32_t base_log, uint32_t level_count, uint32_t num_samples,
     uint32_t num_many_lut, uint32_t lut_stride) {
 
-  switch (polynomial_size) {
-  case 256:
-    host_cg_multi_bit_programmable_bootstrap_128<InputTorus, Degree<256>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lwe_array_in, lwe_input_indexes,
-        bootstrapping_key, pbs_buffer, glwe_dimension, lwe_dimension,
-        polynomial_size, grouping_factor, base_log, level_count, num_samples,
-        num_many_lut, lut_stride);
-    break;
-  case 512:
-    host_cg_multi_bit_programmable_bootstrap_128<InputTorus, Degree<512>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lwe_array_in, lwe_input_indexes,
-        bootstrapping_key, pbs_buffer, glwe_dimension, lwe_dimension,
-        polynomial_size, grouping_factor, base_log, level_count, num_samples,
-        num_many_lut, lut_stride);
-    break;
-  case 1024:
-    host_cg_multi_bit_programmable_bootstrap_128<InputTorus, Degree<1024>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lwe_array_in, lwe_input_indexes,
-        bootstrapping_key, pbs_buffer, glwe_dimension, lwe_dimension,
-        polynomial_size, grouping_factor, base_log, level_count, num_samples,
-        num_many_lut, lut_stride);
-    break;
-  case 2048:
-    host_cg_multi_bit_programmable_bootstrap_128<InputTorus, Degree<2048>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lwe_array_in, lwe_input_indexes,
-        bootstrapping_key, pbs_buffer, glwe_dimension, lwe_dimension,
-        polynomial_size, grouping_factor, base_log, level_count, num_samples,
-        num_many_lut, lut_stride);
-    break;
-  case 4096:
-    // We use AmortizedDegree for 4096 to avoid register exhaustion
-    host_cg_multi_bit_programmable_bootstrap_128<InputTorus,
-                                                 AmortizedDegree<4096>>(
-        static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
-        lwe_output_indexes, lut_vector, lwe_array_in, lwe_input_indexes,
-        bootstrapping_key, pbs_buffer, glwe_dimension, lwe_dimension,
-        polynomial_size, grouping_factor, base_log, level_count, num_samples,
-        num_many_lut, lut_stride);
-    break;
-  default:
-    PANIC("Cuda error (multi-bit PBS): unsupported polynomial size. Supported "
-          "N's are powers of two"
-          " in the interval [256..4096].")
-  }
+  // AmortizedDegree for 4096 avoids register exhaustion in 128-bit multibit PBS
+  DISPATCH_POLY_SIZE(
+      polynomial_size, Multibit128DegreePolicy,
+      host_cg_multi_bit_programmable_bootstrap_128<InputTorus, Params>(
+          static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
+          lwe_output_indexes, lut_vector, lwe_array_in, lwe_input_indexes,
+          bootstrapping_key, pbs_buffer, glwe_dimension, lwe_dimension,
+          polynomial_size, grouping_factor, base_log, level_count, num_samples,
+          num_many_lut, lut_stride));
 }
 
 void cuda_multi_bit_programmable_bootstrap_128_async(

--- a/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_multibit_128.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_multibit_128.cuh
@@ -8,6 +8,7 @@
 
 #include "fft128/fft128.cuh"
 #include "pbs/pbs_multibit_utilities.h"
+#include "polynomial/dispatch.cuh"
 #include "programmable_bootstrap_multibit.cuh"
 #include "utils/helper.cuh"
 
@@ -1263,34 +1264,12 @@ __host__ bool
 supports_cooperative_groups_on_multibit_programmable_bootstrap_128(
     int glwe_dimension, int polynomial_size, int level_count, int num_samples,
     uint32_t max_shared_memory) {
-  switch (polynomial_size) {
-  case 256:
-    return verify_cuda_programmable_bootstrap_cg_multi_bit_grid_size_128<
-        Torus, Degree<256>>(glwe_dimension, level_count, num_samples,
-                            max_shared_memory);
-  case 512:
-    return verify_cuda_programmable_bootstrap_cg_multi_bit_grid_size_128<
-        Torus, Degree<512>>(glwe_dimension, level_count, num_samples,
-                            max_shared_memory);
-  case 1024:
-    return verify_cuda_programmable_bootstrap_cg_multi_bit_grid_size_128<
-        Torus, Degree<1024>>(glwe_dimension, level_count, num_samples,
-                             max_shared_memory);
-  case 2048:
-    return verify_cuda_programmable_bootstrap_cg_multi_bit_grid_size_128<
-        Torus, Degree<2048>>(glwe_dimension, level_count, num_samples,
-                             max_shared_memory);
-  case 4096:
-    // We use AmortizedDegree for 4096 to avoid register exhaustion
-    return verify_cuda_programmable_bootstrap_cg_multi_bit_grid_size_128<
-        Torus, AmortizedDegree<4096>>(glwe_dimension, level_count, num_samples,
-                                      max_shared_memory);
-  default:
-    PANIC(
-        "Cuda error (multi-bit PBS128): unsupported polynomial size. Supported "
-        "N's are powers of two"
-        " in the interval [256..4096].")
-  }
+  // AmortizedDegree for 4096 avoids register exhaustion in 128-bit multibit PBS
+  DISPATCH_POLY_SIZE(
+      polynomial_size, Multibit128DegreePolicy,
+      return verify_cuda_programmable_bootstrap_cg_multi_bit_grid_size_128<
+          Torus, Params>(glwe_dimension, level_count, num_samples,
+                         max_shared_memory));
 }
 
 // Noise tests variant: identical to

--- a/backends/tfhe-cuda-backend/cuda/src/polynomial/dispatch.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/polynomial/dispatch.cuh
@@ -1,0 +1,86 @@
+#ifndef CUDA_POLYNOMIAL_DISPATCH_CUH
+#define CUDA_POLYNOMIAL_DISPATCH_CUH
+
+#include "parameters.cuh"
+#include <type_traits>
+
+// Degree policies map a polynomial size N to the appropriate Degree or
+// AmortizedDegree type. `supported` controls which sizes are valid;
+// unsupported sizes PANIC at runtime and are not instantiated at compile time
+// (via if constexpr).
+
+// Standard policy: AmortizedDegree for sizes 256-16384
+// (64-bit PBS CG, integer ops, FFT, keyswitch, sample extract)
+template <uint32_t N> struct AmortizedDegreePolicy {
+  static constexpr bool supported = (N >= 256 && N <= 16384);
+  using type = AmortizedDegree<N>;
+};
+
+// FFT128 policy: AmortizedDegree for sizes 64-4096
+template <uint32_t N> struct AmortizedDegreePolicyFFT128 {
+  static constexpr bool supported = (N >= 64 && N <= 4096);
+  using type = AmortizedDegree<N>;
+};
+
+// 128-bit policy: AmortizedDegree for sizes 256-4096
+// (128-bit sample extract, BSK 128 conversion)
+template <uint32_t N> struct AmortizedDegreePolicy128 {
+  static constexpr bool supported = (N >= 256 && N <= 4096);
+  using type = AmortizedDegree<N>;
+};
+
+// Classic PBS policy: Degree<2048> for N=2048 (measured to outperform
+// AmortizedDegree there), AmortizedDegree for all other sizes 256-16384.
+// Used by non-CG classic PBS and TBC classic PBS.
+template <uint32_t N> struct ClassicPBSDegreePolicy {
+  static constexpr bool supported = (N >= 256 && N <= 16384);
+  using type = std::conditional_t<(N == 2048), Degree<N>, AmortizedDegree<N>>;
+};
+
+// Multibit 128-bit PBS policy: Degree for sizes 256-2048, AmortizedDegree
+// for 4096 (avoids register exhaustion at that size).
+template <uint32_t N> struct Multibit128DegreePolicy {
+  static constexpr bool supported = (N >= 256 && N <= 4096);
+  using type = std::conditional_t<(N <= 2048), Degree<N>, AmortizedDegree<N>>;
+};
+
+// Dispatch helper: expands a single case arm, injecting a `Params` type alias.
+// The body uses `Params` as a template argument. Unsupported sizes PANIC.
+#define DISPATCH_POLY_SIZE_CASE(N, Policy, ...)                                \
+  case N:                                                                      \
+    if constexpr (Policy<N>::supported) {                                      \
+      using Params = typename Policy<N>::type;                                 \
+      __VA_ARGS__;                                                             \
+    } else {                                                                   \
+      PANIC("Unsupported polynomial size: %u", static_cast<unsigned>(N));      \
+    }                                                                          \
+    break;
+
+// Dispatches a runtime polynomial size to the correct compile-time Degree
+// or AmortizedDegree instantiation.
+//
+// Usage:
+//   DISPATCH_POLY_SIZE(polynomial_size, AmortizedDegreePolicy,
+//       host_some_function<Torus, Params>(stream, gpu_index, ...));
+//
+//   DISPATCH_POLY_SIZE(polynomial_size, Multibit128DegreePolicy,
+//       return scratch_function<InputTorus, Params>(stream, ...));
+#define DISPATCH_POLY_SIZE(poly_size, Policy, ...)                             \
+  do {                                                                         \
+    switch (poly_size) {                                                       \
+      DISPATCH_POLY_SIZE_CASE(64, Policy, __VA_ARGS__)                         \
+      DISPATCH_POLY_SIZE_CASE(128, Policy, __VA_ARGS__)                        \
+      DISPATCH_POLY_SIZE_CASE(256, Policy, __VA_ARGS__)                        \
+      DISPATCH_POLY_SIZE_CASE(512, Policy, __VA_ARGS__)                        \
+      DISPATCH_POLY_SIZE_CASE(1024, Policy, __VA_ARGS__)                       \
+      DISPATCH_POLY_SIZE_CASE(2048, Policy, __VA_ARGS__)                       \
+      DISPATCH_POLY_SIZE_CASE(4096, Policy, __VA_ARGS__)                       \
+      DISPATCH_POLY_SIZE_CASE(8192, Policy, __VA_ARGS__)                       \
+      DISPATCH_POLY_SIZE_CASE(16384, Policy, __VA_ARGS__)                      \
+    default:                                                                   \
+      PANIC("Unsupported polynomial size: %u",                                 \
+            static_cast<unsigned>(poly_size));                                 \
+    }                                                                          \
+  } while (0)
+
+#endif // CUDA_POLYNOMIAL_DISPATCH_CUH

--- a/backends/tfhe-cuda-backend/cuda/src/zk/zk.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/zk/zk.cu
@@ -1,3 +1,4 @@
+#include "polynomial/dispatch.cuh"
 #include "zk.cuh"
 
 uint64_t scratch_cuda_expand_without_verification_64_async(
@@ -50,62 +51,13 @@ void cuda_expand_without_verification_64_async(
 
   auto expand_buffer = reinterpret_cast<zk_expand_mem<uint64_t> *>(mem_ptr);
 
-  switch (expand_buffer->casting_params.big_lwe_dimension) {
-  case 256:
-    host_expand_without_verification<uint64_t, AmortizedDegree<256>>(
-        streams, static_cast<uint64_t *>(lwe_array_out),
-        static_cast<const uint64_t *>(lwe_flattened_compact_array_in),
-        expand_buffer, (uint64_t **)casting_keys, bsks,
-        (uint64_t **)(computing_ksks));
-    break;
-  case 512:
-    host_expand_without_verification<uint64_t, AmortizedDegree<512>>(
-        streams, static_cast<uint64_t *>(lwe_array_out),
-        static_cast<const uint64_t *>(lwe_flattened_compact_array_in),
-        expand_buffer, (uint64_t **)casting_keys, bsks,
-        (uint64_t **)(computing_ksks));
-    break;
-  case 1024:
-    host_expand_without_verification<uint64_t, AmortizedDegree<1024>>(
-        streams, static_cast<uint64_t *>(lwe_array_out),
-        static_cast<const uint64_t *>(lwe_flattened_compact_array_in),
-        expand_buffer, (uint64_t **)casting_keys, bsks,
-        (uint64_t **)(computing_ksks));
-    break;
-  case 2048:
-    host_expand_without_verification<uint64_t, AmortizedDegree<2048>>(
-        streams, static_cast<uint64_t *>(lwe_array_out),
-        static_cast<const uint64_t *>(lwe_flattened_compact_array_in),
-        expand_buffer, (uint64_t **)casting_keys, bsks,
-        (uint64_t **)(computing_ksks));
-    break;
-  case 4096:
-    host_expand_without_verification<uint64_t, AmortizedDegree<4096>>(
-        streams, static_cast<uint64_t *>(lwe_array_out),
-        static_cast<const uint64_t *>(lwe_flattened_compact_array_in),
-        expand_buffer, (uint64_t **)casting_keys, bsks,
-        (uint64_t **)(computing_ksks));
-    break;
-  case 8192:
-    host_expand_without_verification<uint64_t, AmortizedDegree<8192>>(
-        streams, static_cast<uint64_t *>(lwe_array_out),
-        static_cast<const uint64_t *>(lwe_flattened_compact_array_in),
-        expand_buffer, (uint64_t **)casting_keys, bsks,
-        (uint64_t **)(computing_ksks));
-    break;
-  case 16384:
-    host_expand_without_verification<uint64_t, AmortizedDegree<16384>>(
-        streams, static_cast<uint64_t *>(lwe_array_out),
-        static_cast<const uint64_t *>(lwe_flattened_compact_array_in),
-        expand_buffer, (uint64_t **)casting_keys, bsks,
-        (uint64_t **)(computing_ksks));
-    break;
-  default:
-    PANIC("CUDA error: lwe_dimension not supported."
-          "Supported n's are powers of two"
-          " in the interval [256..16384].");
-    break;
-  }
+  DISPATCH_POLY_SIZE(
+      expand_buffer->casting_params.big_lwe_dimension, AmortizedDegreePolicy,
+      host_expand_without_verification<uint64_t, Params>(
+          streams, static_cast<uint64_t *>(lwe_array_out),
+          static_cast<const uint64_t *>(lwe_flattened_compact_array_in),
+          expand_buffer, (uint64_t **)casting_keys, bsks,
+          (uint64_t **)(computing_ksks)));
 }
 
 void cleanup_cuda_expand_without_verification_64(CudaStreamsFFI streams,


### PR DESCRIPTION
This PR introduces macros to avoid the long and error prone switch cases we use when `Params` based on `AmortizedDegree` or `Degree` are needed.

<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
