### PR TITLE
chore(ci): use new ami for benches

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -14,4 +14,6 @@ extend-ignore-identifiers-re = [
     "C9217BA0D762ACA1",
     "0x[0-9a-fA-F]+",
     "xrt_coreutil",
+    # An identifier in slab.toml
+    "067f3893108afe8cd"
 ]

--- a/ci/slab.toml
+++ b/ci/slab.toml
@@ -18,7 +18,7 @@ user = "ubuntu"
 
 [backend.aws.bench]
 region = "eu-west-1"
-image_id = "ami-0e99a601b5c4c7021"
+image_id = "ami-067f3893108afe8cd"
 instance_type = "hpc7a.96xlarge"
 user = "ubuntu"
 


### PR DESCRIPTION
disable github actions from post upgrades restarts

### PR content/description
use new ami for benches, that should prevent unwanted cancel of github action after an update
