### PR TITLE
fix(shortint): explicit panic for iter encryption with mod 0

### DIFF
--- a/tfhe/src/shortint/public_key/compact.rs
+++ b/tfhe/src/shortint/public_key/compact.rs
@@ -155,6 +155,8 @@ fn to_plaintext_iterator(
 
     let full_modulus = message_modulus * carry_modulus;
 
+    assert!(encryption_modulus != 0, "Encryption modulus cannot be zero");
+
     assert!(
         encryption_modulus <= full_modulus,
         "Encryption modulus cannot exceed the plaintext modulus"
@@ -326,7 +328,8 @@ impl CompactPublicKey {
     ///
     /// # Panic
     ///
-    /// - This will panic is encryption modulus is greater that message_modulus * carry_modulus
+    /// - This will panic if encryption modulus is zero, or greater than message_modulus *
+    ///   carry_modulus
     pub fn encrypt_iter_with_modulus(
         &self,
         messages: impl Iterator<Item = u64>,


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: https://github.com/zama-ai/tfhe-rs/issues/3847

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3857)
<!-- Reviewable:end -->
