### PR TITLE
fix(hl): return an error on multiblocks bool expand

### DIFF
--- a/tfhe/src/high_level_api/utils.rs
+++ b/tfhe/src/high_level_api/utils.rs
@@ -109,7 +109,14 @@ impl Expandable for FheBool {
                 ))
             }
             DataKind::Boolean => {
-                let mut boolean_block = BooleanBlock::new_unchecked(blocks[0].clone());
+                let [block] = <[Ciphertext; 1]>::try_from(blocks).map_err(|blocks| {
+                    crate::error!(
+                        "Tried to expand a FheBool while {} blocks are stored in this slot",
+                        blocks.len(),
+                    )
+                })?;
+
+                let mut boolean_block = BooleanBlock::new_unchecked(block);
                 // We know the value is a boolean one (via the data kind)
                 boolean_block.0.degree = crate::shortint::ciphertext::Degree::new(1);
 


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description
Return an error instead of panic when calling `from_expanded_blocks` on `FheBool` and blocks count is != 1