### PR TITLE
chore: bump chacha20 after version is yanked

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -562,9 +562,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",


### PR DESCRIPTION
- https://github.com/RustCrypto/stream-ciphers/pull/583 (yank)
- https://github.com/RustCrypto/stream-ciphers/pull/580 (UB SSE2 backend)
- https://github.com/RustCrypto/utils/pull/1513 (MIRI stuff enabled)

following a cargo audit fail since the current locked version was yanked