### PR TITLE
chore(gpu): restore 2par workflow on push

### DIFF
--- a/.github/workflows/gpu_integer_classic_tests_h100_2gpu_par.yml
+++ b/.github/workflows/gpu_integer_classic_tests_h100_2gpu_par.yml
@@ -21,7 +21,6 @@ env:
 on:
   workflow_dispatch:
   pull_request:
-    types: [ labeled ]
 
 permissions:
   contents: read


### PR DESCRIPTION
Moves the signed+unsigned integer test on 2xGPU workflow to PR push