### PR TITLE
chore(ci): use scaleway as main provider in a few workflows

### DIFF
--- a/.github/workflows/gpu_full_multi_gpu_tests.yml
+++ b/.github/workflows/gpu_full_multi_gpu_tests.yml
@@ -1,4 +1,5 @@
-# Compile and test tfhe-cuda-backend on an AWS instance
+# Compile and test tfhe-cuda-backend on a multi-GPU Scaleway instance,
+# falling back to smaller Scaleway flavors then to Hyperstack when unavailable.
 name: gpu_full_multi_gpu_tests
 
 env:
@@ -89,8 +90,8 @@ jobs:
           github-token: ${{ secrets.SLAB_ACTION_TOKEN }}
           slab-url: ${{ secrets.SLAB_BASE_URL }}
           job-secret: ${{ secrets.JOB_SECRET }}
-          backend: aws
-          profile: 4-l40
+          backend: terraform
+          profile: scaleway-4-l40-tests
 
       # This instance will be spawned especially for pull-request from forked repository
       - name: Start GitHub instance

--- a/.github/workflows/gpu_noise_level_checks.yml
+++ b/.github/workflows/gpu_noise_level_checks.yml
@@ -1,8 +1,8 @@
 # Run signed and unsigned GPU integer tests with the gpu-debug-noise-check
 # feature so that the CHECK_NOISE_LEVEL assertions in the CUDA backend are
 # active, without the multi-GPU emulation that requires a multi-GPU host.
-# Runs on a single L40 Hyperstack instance, triggered automatically on every PR
-# that touches GPU code, alongside gpu_fast_tests.
+# Runs on a single L40S Scaleway instance (Hyperstack fallback), triggered
+# automatically on every PR that touches GPU code, alongside gpu_fast_tests.
 name: gpu_noise_level_checks
 
 env:
@@ -69,6 +69,8 @@ jobs:
               - tfhe/src/shortint/parameters/**
               - .github/workflows/gpu_noise_level_checks.yml
               - scripts/integer-tests.sh
+              - '.github/actions/gpu_setup/action.yml'
+              - ci/slab.toml
 
   setup-instance:
     name: gpu_noise_level_checks/setup-instance
@@ -89,8 +91,8 @@ jobs:
           github-token: ${{ secrets.SLAB_ACTION_TOKEN }}
           slab-url: ${{ secrets.SLAB_BASE_URL }}
           job-secret: ${{ secrets.JOB_SECRET }}
-          backend: hyperstack
-          profile: l40-tests
+          backend: terraform
+          profile: scaleway-small-gpu-noise-check
 
       # This instance will be spawned especially for pull-request from forked repository
       - name: Start GitHub instance
@@ -118,8 +120,8 @@ jobs:
       matrix:
         include:
           - os: ubuntu-22.04
-            cuda: "12.8"
-            gcc: 11
+            cuda: "12.8 12.2"
+            gcc: 12
     steps:
       - name: Checkout tfhe-rs
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -127,7 +129,7 @@ jobs:
           persist-credentials: 'false'
           token: ${{ env.CHECKOUT_TOKEN }}
 
-      - name: Setup Hyperstack dependencies
+      - name: Setup cloud GPU machine dependencies
         uses: ./.github/actions/gpu_setup
         with:
           cuda-version: ${{ matrix.cuda }}
@@ -171,7 +173,7 @@ jobs:
         uses: rtCamp/action-slack-notify@33ca3be66c6f378fe1610fd1d5258632dbed5e58
         env:
           SLACK_COLOR: ${{ needs.cuda-noise-check-tests.result }}
-          SLACK_MESSAGE: "GPU L40 noise check tests finished with status: ${{ needs.cuda-noise-check-tests.result }}. (${{ env.PULL_REQUEST_MD_LINK }}[action run](${{ env.ACTION_RUN_URL }}))"
+          SLACK_MESSAGE: "GPU noise check tests finished with status: ${{ needs.cuda-noise-check-tests.result }}. (${{ env.PULL_REQUEST_MD_LINK }}[action run](${{ env.ACTION_RUN_URL }}))"
 
   teardown-instance:
     name: gpu_noise_level_checks/teardown-instance
@@ -195,4 +197,4 @@ jobs:
         uses: rtCamp/action-slack-notify@33ca3be66c6f378fe1610fd1d5258632dbed5e58
         env:
           SLACK_COLOR: ${{ job.status }}
-          SLACK_MESSAGE: "Instance teardown (gpu-l40-noise-check) finished with status: ${{ job.status }}. (${{ env.ACTION_RUN_URL }})"
+          SLACK_MESSAGE: "Instance teardown (gpu-noise-check) finished with status: ${{ job.status }}. (${{ env.ACTION_RUN_URL }})"

--- a/.github/workflows/gpu_signed_integer_classic_tests.yml
+++ b/.github/workflows/gpu_signed_integer_classic_tests.yml
@@ -1,4 +1,5 @@
-# Signed integer GPU tests on an RTXA6000 VM on hyperstack with classical PBS
+# Signed integer GPU tests with the classical PBS, on a single-GPU Scaleway instance,
+# falling back to smaller Scaleway flavors then to Hyperstack when unavailable.
 name: gpu_signed_integer_classic_tests
 
 env:
@@ -86,8 +87,8 @@ jobs:
           github-token: ${{ secrets.SLAB_ACTION_TOKEN }}
           slab-url: ${{ secrets.SLAB_BASE_URL }}
           job-secret: ${{ secrets.JOB_SECRET }}
-          backend: hyperstack
-          profile: gpu-test
+          backend: terraform
+          profile: scaleway-small-gpu-classic-tests
 
       # This instance will be spawned especially for pull-request from forked repository
       - name: Start GitHub instance

--- a/.github/workflows/gpu_unsigned_integer_classic_tests.yml
+++ b/.github/workflows/gpu_unsigned_integer_classic_tests.yml
@@ -1,4 +1,5 @@
-# Test unsigned integers on an RTXA6000 VM on hyperstack with the classical PBS
+# Unsigned integer GPU tests with the classical PBS, on a single-GPU Scaleway instance,
+# falling back to smaller Scaleway flavors then to Hyperstack when unavailable.
 name: gpu_unsigned_integer_classic_tests
 
 env:
@@ -86,8 +87,8 @@ jobs:
           github-token: ${{ secrets.SLAB_ACTION_TOKEN }}
           slab-url: ${{ secrets.SLAB_BASE_URL }}
           job-secret: ${{ secrets.JOB_SECRET }}
-          backend: hyperstack
-          profile: gpu-test
+          backend: terraform
+          profile: scaleway-small-gpu-classic-tests
 
       # This instance will be spawned especially for pull-request from forked repository
       - name: Start GitHub instance

--- a/ci/slab.toml
+++ b/ci/slab.toml
@@ -146,13 +146,6 @@ image_name = "Ubuntu Server 22.04 LTS R570 CUDA 12.8"
 flavor_name = "n3-RTX-A6000x1"
 user = "ubuntu"
 
-[backend.hyperstack.l40-tests]
-environment_name = "canada"
-image_name = "Ubuntu Server 22.04 LTS R570 CUDA 12.8"
-flavor_name = "n3-L40x1"
-user = "ubuntu"
-fallbacks = [ "hyperstack.rtx-a6000", "terraform.scaleway-small-gpu" ]
-
 # Fallback target only.
 [backend.hyperstack.rtx-a6000]
 environment_name = "canada"
@@ -229,6 +222,32 @@ instance_type = "L40S-4-48G"
 user = "ubuntu"
 fallbacks = [ "hyperstack.4-l40", "aws.4-l40" ]
 
+[backend.terraform.scaleway-4-l40-tests]
+script_path = "ci/terraform_scripts/scaleway/terraform.tf"
+instance_type = "L40S-4-48G"
+user = "ubuntu"
+fallbacks = [
+    "terraform.scaleway-2-l40",
+    "terraform.scaleway-4-l4",
+    "terraform.scaleway-2-l4",
+    "hyperstack.4-l40",
+]
+
+[backend.terraform.scaleway-2-l40]
+script_path = "ci/terraform_scripts/scaleway/terraform.tf"
+instance_type = "L40S-2-48G"
+user = "ubuntu"
+
+[backend.terraform.scaleway-1-l4]
+script_path = "ci/terraform_scripts/scaleway/terraform.tf"
+instance_type = "L4-1-24G"
+user = "ubuntu"
+
+[backend.terraform.scaleway-4-l4]
+script_path = "ci/terraform_scripts/scaleway/terraform.tf"
+instance_type = "L4-4-24G"
+user = "ubuntu"
+
 [backend.terraform.scaleway-2-l4]
 script_path = "ci/terraform_scripts/scaleway/terraform.tf"
 instance_type = "L4-2-24G"
@@ -239,6 +258,22 @@ script_path = "ci/terraform_scripts/scaleway/terraform.tf"
 instance_type = "L40S-1-48G"
 user = "ubuntu"
 fallbacks = [ "hyperstack.gpu-test", "terraform.scaleway-2-l4" ]
+
+[backend.terraform.scaleway-small-gpu-noise-check]
+script_path = "ci/terraform_scripts/scaleway/terraform.tf"
+instance_type = "L40S-1-48G"
+user = "ubuntu"
+fallbacks = [ "hyperstack.gpu-test", "hyperstack.rtx-a6000" ]
+
+[backend.terraform.scaleway-small-gpu-classic-tests]
+script_path = "ci/terraform_scripts/scaleway/terraform.tf"
+instance_type = "L40S-1-48G"
+user = "ubuntu"
+fallbacks = [
+    "terraform.scaleway-1-l4",
+    "terraform.scaleway-2-l40",
+    "hyperstack.gpu-test",
+]
 
 [backend.terraform.scaleway-small-gpu-sanitizer]
 script_path = "ci/terraform_scripts/scaleway/terraform.tf"


### PR DESCRIPTION
```
gpu_noise_level_checks
----------------------

BEFORE (main)                               NOW
hyperstack / l40-tests                      terraform / scaleway-small-gpu-noise-check

1. HYPERSTACK  n3-L40x1       (L40 x1)      1. SCALEWAY    L40S-1-48G     (L40S x1)
2. HYPERSTACK  n3-RTX-A6000x1 (A6000 x1)    2. HYPERSTACK  n3-L40x1       (L40 x1)
3. SCALEWAY    L40S-1-48G     (L40S x1)     3. HYPERSTACK  n3-RTX-A6000x1 (A6000 x1)




gpu_full_multi_gpu_tests
------------------------

BEFORE (main)                               NOW
aws / 4-l40                                 terraform / scaleway-4-l40-tests

1. AWS         g6e.24xlarge   (L40S x4)     1. SCALEWAY    L40S-4-48G     (L40S x4)
2. HYPERSTACK  n3-L40x4       (L40 x4)      2. SCALEWAY    L40S-2-48G     (L40S x2)
3. SCALEWAY    L40S-4-48G     (L40S x4)     3. SCALEWAY    L4-4-24G       (L4 x4)
                                            4. SCALEWAY    L4-2-24G       (L4 x2)
                                            5. HYPERSTACK  n3-L40x4       (L40 x4)




gpu_signed_integer_classic_tests
gpu_unsigned_integer_classic_tests          (identical chains)
----------------------------------

BEFORE (main)                               NOW
hyperstack / gpu-test                       terraform / scaleway-small-gpu-classic-tests

1. HYPERSTACK  n3-L40x1       (L40 x1)      1. SCALEWAY    L40S-1-48G     (L40S x1)
2. SCALEWAY    L40S-1-48G     (L40S x1)     2. SCALEWAY    L4-1-24G       (L4 x1)
3. HYPERSTACK  n3-RTX-A6000x1 (A6000 x1)    3. SCALEWAY    L40S-2-48G     (L40S x2)
                                            4. HYPERSTACK  n3-L40x1       (L40 x1)
```