### PR TITLE
chore(wasm-par-mq): bump to 0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3826,7 +3826,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-par-mq"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "futures",
  "inventory",

--- a/tfhe-zk-pok/Cargo.toml
+++ b/tfhe-zk-pok/Cargo.toml
@@ -30,7 +30,7 @@ tfhe-cuda-common = { version = "0.1.0", path = "../backends/tfhe-cuda-common", o
 itertools.workspace = true
 [target.'cfg(target_family = "wasm")'.dependencies]
 getrandom = { workspace = true, features = ["js"] }
-wasm-par-mq = { version = "0.1.0", path = "../utils/wasm-par-mq", features = [
+wasm-par-mq = { version = "0.1.1", path = "../utils/wasm-par-mq", features = [
     "sync-api",
 ], optional = true }
 

--- a/tfhe/Cargo.toml
+++ b/tfhe/Cargo.toml
@@ -92,7 +92,7 @@ wasm-bindgen-rayon = { version = "1.3.0", optional = true }
 js-sys = { workspace = true, optional = true }
 wasm-bindgen-futures = { workspace = true, optional = true }
 
-wasm-par-mq = { version = "0.1.0", path = "../utils/wasm-par-mq", features = [
+wasm-par-mq = { version = "0.1.1", path = "../utils/wasm-par-mq", features = [
     "sync-api",
 ], optional = true }
 

--- a/utils/wasm-par-mq/Cargo.toml
+++ b/utils/wasm-par-mq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-par-mq"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 keywords = ["wasm", "parallel", "web-workers"]
 homepage = "https://zama.ai/"


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description

### Check-list:
bump wasm-par-mq to 0.1.1.

This might not strictly be required, but done to be safe. Only change is the dep to serde-json moved to workspace dep