### PR TITLE
fix(gpu): compare CUDA crate versions against same major.minor family on crates.io

### DIFF
--- a/scripts/check_cuda_version_bump.sh
+++ b/scripts/check_cuda_version_bump.sh
@@ -2,78 +2,60 @@
 
 set -euo pipefail
 
-# Each entry: tag_prefix:crate_dir:cargo_toml
+if [[ -z "${GITHUB_BASE_REF:-}" ]]; then
+    echo "ERROR: this script must run inside a pull_request workflow (GITHUB_BASE_REF is not set)."
+    exit 1
+fi
+
+# Each entry: crate_name:crate_dir:cargo_toml
 CRATES=(
     "tfhe-cuda-common:backends/tfhe-cuda-common:backends/tfhe-cuda-common/Cargo.toml"
     "tfhe-cuda-backend:backends/tfhe-cuda-backend:backends/tfhe-cuda-backend/Cargo.toml"
     "zk-cuda-backend:backends/zk-cuda-backend:backends/zk-cuda-backend/Cargo.toml"
 )
 
-# In pull_request CI, actions/checkout produces a merge commit whose first
-# parent is the base branch. Compare against that so we only flag changes
-# introduced by the PR, not pre-existing unreleased changes on main.
-if [[ -n "${GITHUB_BASE_REF:-}" ]]; then
-    base_ref="HEAD^1"
-    echo "PR context: comparing against base branch (${GITHUB_BASE_REF})"
-else
-    base_ref=""
-    echo "Non-PR context: comparing against latest release tags"
-fi
+CRATES_IO_API="https://crates.io/api/v1/crates"
+USER_AGENT="tfhe-rs-ci (https://github.com/zama-ai/tfhe-rs)"
+
+# actions/checkout produces a merge commit whose first parent is the base
+# branch. Compare against that so we only flag changes introduced by the PR.
+base_ref="HEAD^1"
+echo "Comparing PR changes against base branch (${GITHUB_BASE_REF})"
 
 failed=0
 
 for crate_info in "${CRATES[@]}"; do
-    IFS=':' read -r tag_prefix crate_dir cargo_toml <<< "$crate_info"
+    IFS=':' read -r crate_name crate_dir cargo_toml <<< "$crate_info"
+
+    if git diff --quiet "$base_ref" HEAD -- "$crate_dir"; then
+        echo "[OK] ${crate_name}: no changes in this PR"
+        continue
+    fi
 
     current_version=$(cargo metadata --format-version 1 --no-deps --manifest-path Cargo.toml \
-        | jq -r "first(.packages[] | select(.name == \"${tag_prefix}\")) | .version")
+        | jq -r "first(.packages[] | select(.name == \"${crate_name}\")) | .version")
 
-    if [[ -n "$base_ref" ]]; then
-        # PR context: check only changes introduced by this PR
-        if git diff --quiet "$base_ref" HEAD -- "$crate_dir"; then
-            echo "[OK] ${tag_prefix}: no changes in this PR"
-            continue
-        fi
+    family_prefix="${current_version%.*}"
 
-        base_version=$(git show "${base_ref}:${cargo_toml}" 2>/dev/null \
-            | grep '^version' | head -1 | sed 's/.*"\(.*\)".*/\1/' || echo "")
+    published_family_max=$(curl -s -H "User-Agent: ${USER_AGENT}" \
+        "${CRATES_IO_API}/${crate_name}/versions" \
+        | jq -r --arg prefix "${family_prefix}." \
+            '[.versions[] | select(.yanked == false) | .num | select(startswith($prefix))] | .[]' \
+        | sort -V | tail -1)
 
-        if [[ "$current_version" == "${base_version}" ]]; then
-            echo "[FAIL] ${tag_prefix}: files changed in this PR but version is still ${current_version}"
-            echo "       Please bump the version in ${cargo_toml}"
-            echo "       Changed files:"
-            git diff "$base_ref" HEAD -- "$crate_dir" | sed 's/^/         /'
-            failed=1
-        else
-            echo "[OK] ${tag_prefix}: version bumped from ${base_version} to ${current_version}"
-        fi
+    if [[ -z "$published_family_max" ]]; then
+        echo "[OK] ${crate_name}: version ${current_version} has no published versions in the ${family_prefix}.x family"
+        continue
+    fi
+
+    if [[ "$current_version" == "$published_family_max" ]]; then
+        echo "[FAIL] ${crate_name}: has changes but version ${current_version} matches latest published in ${family_prefix}.x family"
+        echo "       Please bump the version in ${cargo_toml}"
+        echo "       Changed files:"
+        git diff "$base_ref" HEAD -- "$crate_dir" --stat | sed 's/^/         /'
+        failed=1
     else
-        # Non-PR context: compare against latest release tag
-        latest_tag=$(git tag --list "${tag_prefix}-*" --sort=-v:refname \
-            | grep -vE -- '-(alpha|beta|rc)\.' \
-            | head -1)
-
-        if [[ -z "$latest_tag" ]]; then
-            echo "[SKIP] ${tag_prefix}: no release tag found, skipping"
-            continue
-        fi
-
-        tag_version="${latest_tag#"${tag_prefix}-"}"
-
-        if git diff --quiet "$latest_tag" HEAD -- "$crate_dir"; then
-            echo "[OK] ${tag_prefix}: no changes since ${latest_tag}"
-            continue
-        fi
-
-        if [[ "$current_version" == "$tag_version" ]]; then
-            echo "[FAIL] ${tag_prefix}: files changed since ${latest_tag} but version is still ${current_version}"
-            echo "       Please bump the version in ${cargo_toml}"
-            echo "       Changed files:"
-            git diff "$latest_tag" HEAD -- "$crate_dir" | sed 's/^/         /'
-            failed=1
-        else
-            echo "[OK] ${tag_prefix}: version bumped from ${tag_version} to ${current_version}"
-        fi
+        echo "[OK] ${crate_name}: version ${current_version} is ahead of published ${published_family_max} (${family_prefix}.x family)"
     fi
 done
 


### PR DESCRIPTION
- Query all published versions from crates.io instead of just the global latest (`max_stable_version`)
- Filter to the same `major.minor` family as the local `Cargo.toml` version, then compare against the highest patch in that family
- This makes the check work on older release branches (e.g., `release/1.6.x` where the global latest is `1.8.0` but the relevant comparison is `1.6.5`)
- Remove the non-PR mode (this script only runs as a PR workflow)

### Examples

Assume the latest published version is `1.8.0` and `1.6.5` also exists on crates.io:

| Local version | Family | Highest in family | Result |
|---|---|---|---|
| `1.8.0` | `1.8.x` | `1.8.0` | FAIL (needs bump) |
| `1.8.1` | `1.8.x` | `1.8.0` | OK (ahead of published) |
| `1.6.5` | `1.6.x` | `1.6.5` | FAIL (needs bump) |
| `1.6.6` | `1.6.x` | `1.6.5` | OK (ahead of published) |
| `1.9.0` | `1.9.x` | (none) | OK (new minor, nothing published yet) |

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3894)
<!-- Reviewable:end -->