### PR TITLE
chore(gpu): add _async suffix to 12 internal PBS and scratch template functions that are asynchronous

### DIFF
--- a/backends/tfhe-cuda-backend/cuda/include/pbs/pbs_multibit_utilities.h
+++ b/backends/tfhe-cuda-backend/cuda/include/pbs/pbs_multibit_utilities.h
@@ -21,7 +21,7 @@ uint64_t scratch_cuda_tbc_multi_bit_programmable_bootstrap(
     uint32_t input_lwe_ciphertext_count, bool allocate_gpu_memory);
 
 template <typename Torus>
-void cuda_tbc_multi_bit_programmable_bootstrap_lwe_ciphertext_vector(
+void cuda_tbc_multi_bit_programmable_bootstrap_lwe_ciphertext_vector_async(
     void *stream, uint32_t gpu_index, Torus *lwe_array_out,
     Torus const *lwe_output_indexes, Torus const *lut_vector,
     Torus const *lut_vector_indexes, Torus const *lwe_array_in,
@@ -39,7 +39,7 @@ uint64_t scratch_cuda_cg_multi_bit_programmable_bootstrap(
     uint32_t input_lwe_ciphertext_count, bool allocate_gpu_memory);
 
 template <typename Torus>
-void cuda_cg_multi_bit_programmable_bootstrap_lwe_ciphertext_vector(
+void cuda_cg_multi_bit_programmable_bootstrap_lwe_ciphertext_vector_async(
     void *stream, uint32_t gpu_index, Torus *lwe_array_out,
     Torus const *lwe_output_indexes, Torus const *lut_vector,
     Torus const *lut_vector_indexes, Torus const *lwe_array_in,
@@ -56,7 +56,7 @@ uint64_t scratch_cuda_multi_bit_programmable_bootstrap(
     uint32_t input_lwe_ciphertext_count, bool allocate_gpu_memory);
 
 template <typename Torus>
-void cuda_multi_bit_programmable_bootstrap_lwe_ciphertext_vector(
+void cuda_multi_bit_programmable_bootstrap_lwe_ciphertext_vector_async(
     void *stream, uint32_t gpu_index, Torus *lwe_array_out,
     Torus const *lwe_output_indexes, Torus const *lut_vector,
     Torus const *lut_vector_indexes, Torus const *lwe_array_in,

--- a/backends/tfhe-cuda-backend/cuda/include/pbs/pbs_utilities.h
+++ b/backends/tfhe-cuda-backend/cuda/include/pbs/pbs_utilities.h
@@ -481,7 +481,7 @@ bool has_support_to_cuda_programmable_bootstrap_cg(uint32_t glwe_dimension,
                                                    uint32_t max_shared_memory);
 
 template <typename Torus>
-void cuda_programmable_bootstrap_cg_lwe_ciphertext_vector(
+void cuda_programmable_bootstrap_cg_lwe_ciphertext_vector_async(
     void *stream, uint32_t gpu_index, Torus *lwe_array_out,
     Torus const *lwe_output_indexes, Torus const *lut_vector,
     Torus const *lut_vector_indexes, Torus const *lwe_array_in,
@@ -492,7 +492,7 @@ void cuda_programmable_bootstrap_cg_lwe_ciphertext_vector(
     uint32_t lut_stride);
 
 template <typename Torus>
-void cuda_programmable_bootstrap_lwe_ciphertext_vector(
+void cuda_programmable_bootstrap_lwe_ciphertext_vector_async(
     void *stream, uint32_t gpu_index, Torus *lwe_array_out,
     Torus const *lwe_output_indexes, Torus const *lut_vector,
     Torus const *lut_vector_indexes, Torus const *lwe_array_in,
@@ -504,7 +504,7 @@ void cuda_programmable_bootstrap_lwe_ciphertext_vector(
 
 #if (CUDA_ARCH >= 900)
 template <typename Torus>
-void cuda_programmable_bootstrap_tbc_lwe_ciphertext_vector(
+void cuda_programmable_bootstrap_tbc_lwe_ciphertext_vector_async(
     void *stream, uint32_t gpu_index, Torus *lwe_array_out,
     Torus const *lwe_output_indexes, Torus const *lut_vector,
     Torus const *lut_vector_indexes, Torus const *lwe_array_in,

--- a/backends/tfhe-cuda-backend/cuda/src/integer/cmux.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/cmux.cuh
@@ -108,7 +108,7 @@ __host__ void host_zero_out_if_batch(
 /// @param num_entries        Number of ciphertexts in the batch
 /// @param num_blocks_per_ct  Number of radix blocks per ciphertext
 template <typename Torus>
-__host__ uint64_t scratch_cuda_zero_out_if_batch(
+__host__ uint64_t scratch_cuda_zero_out_if_batch_async(
     CudaStreams streams, int_zero_out_if_batch_buffer<Torus> **mem_ptr,
     uint32_t num_entries, uint32_t num_blocks_per_ct, int_radix_params params,
     bool allocate_gpu_memory) {

--- a/backends/tfhe-cuda-backend/cuda/src/integer/compression/compression.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/compression/compression.cu
@@ -14,7 +14,7 @@ uint64_t scratch_cuda_integer_compress_radix_ciphertext_64_async(
       lwe_dimension, ks_level, ks_base_log, 0, 0, 0, message_modulus,
       carry_modulus, PBS_MS_REDUCTION_T::NO_REDUCTION);
 
-  return scratch_cuda_compress_ciphertext<uint64_t>(
+  return scratch_cuda_compress_ciphertext_async<uint64_t>(
       CudaStreams(streams), (int_compression<uint64_t> **)mem_ptr,
       num_radix_blocks, compression_params, num_lwes_stored_per_glwe,
       allocate_gpu_memory);
@@ -98,7 +98,7 @@ uint64_t scratch_cuda_integer_compress_radix_ciphertext_128_async(
       lwe_dimension, ks_level, ks_base_log, 0, 0, 0, message_modulus,
       carry_modulus, PBS_MS_REDUCTION_T::NO_REDUCTION);
 
-  return scratch_cuda_compress_ciphertext<__uint128_t>(
+  return scratch_cuda_compress_ciphertext_async<__uint128_t>(
       CudaStreams(streams), (int_compression<__uint128_t> **)mem_ptr,
       num_radix_blocks, compression_params, num_lwes_stored_per_glwe,
       allocate_gpu_memory);

--- a/backends/tfhe-cuda-backend/cuda/src/integer/compression/compression.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/compression/compression.cuh
@@ -554,7 +554,7 @@ host_integer_decompress(CudaStreams streams,
 }
 
 template <typename Torus>
-__host__ uint64_t scratch_cuda_compress_ciphertext(
+__host__ uint64_t scratch_cuda_compress_ciphertext_async(
     CudaStreams streams, int_compression<Torus> **mem_ptr,
     uint32_t num_radix_blocks, int_radix_params compression_params,
     uint32_t num_lwes_stored_per_glwe, bool allocate_gpu_memory) {

--- a/backends/tfhe-cuda-backend/cuda/src/pbs/bootstrapping_key.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/pbs/bootstrapping_key.cu
@@ -383,7 +383,7 @@ bool cuda_fft16x4x16_is_supported_async(uint32_t gpu_index) {
   return err == cudaSuccess && prop.major >= 9;
 }
 
-void cuda_convert_lwe_programmable_bootstrap_key_u128(
+void cuda_convert_lwe_programmable_bootstrap_key_u128_async(
     cudaStream_t stream, uint32_t gpu_index, double *dest,
     __uint128_t const *src, uint32_t polynomial_size,
     uint32_t total_polynomials) {
@@ -415,7 +415,7 @@ void cuda_convert_lwe_programmable_bootstrap_key_128_async(
   size_t total_polynomials =
       safe_mul((size_t)input_lwe_dim, (size_t)(glwe_dim + 1),
                (size_t)(glwe_dim + 1), (size_t)level_count);
-  cuda_convert_lwe_programmable_bootstrap_key_u128(
+  cuda_convert_lwe_programmable_bootstrap_key_u128_async(
       static_cast<cudaStream_t>(stream), gpu_index, (double *)dest,
       (const __uint128_t *)src, polynomial_size, total_polynomials);
 }

--- a/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_classic.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_classic.cu
@@ -53,7 +53,7 @@ uint64_t scratch_cuda_programmable_bootstrap_tbc(
 }
 
 template <typename Torus>
-void cuda_programmable_bootstrap_tbc_lwe_ciphertext_vector(
+void cuda_programmable_bootstrap_tbc_lwe_ciphertext_vector_async(
     void *stream, uint32_t gpu_index, Torus *lwe_array_out,
     Torus const *lwe_output_indexes, Torus const *lut_vector,
     Torus const *lut_vector_indexes, Torus const *lwe_array_in,
@@ -74,7 +74,7 @@ void cuda_programmable_bootstrap_tbc_lwe_ciphertext_vector(
 }
 
 template <typename Torus>
-void cuda_programmable_bootstrap_tbc_lwe_ciphertext_vector_generic(
+void cuda_programmable_bootstrap_tbc_lwe_ciphertext_vector_generic_async(
     void *stream, uint32_t gpu_index, Torus *lwe_array_out,
     Torus const *lwe_output_indexes, Torus const *lut_vector,
     Torus const *lut_vector_indexes, Torus const *lwe_array_in,
@@ -222,7 +222,7 @@ uint64_t scratch_cuda_programmable_bootstrap_specialized_2_2_64_async(
 }
 
 template <typename Torus>
-void cuda_programmable_bootstrap_cg_lwe_ciphertext_vector(
+void cuda_programmable_bootstrap_cg_lwe_ciphertext_vector_async(
     void *stream, uint32_t gpu_index, Torus *lwe_array_out,
     Torus const *lwe_output_indexes, Torus const *lut_vector,
     Torus const *lut_vector_indexes, Torus const *lwe_array_in,
@@ -243,7 +243,7 @@ void cuda_programmable_bootstrap_cg_lwe_ciphertext_vector(
 }
 
 template <typename Torus>
-void cuda_programmable_bootstrap_lwe_ciphertext_vector(
+void cuda_programmable_bootstrap_lwe_ciphertext_vector_async(
     void *stream, uint32_t gpu_index, Torus *lwe_array_out,
     Torus const *lwe_output_indexes, Torus const *lut_vector,
     Torus const *lut_vector_indexes, Torus const *lwe_array_in,
@@ -284,7 +284,7 @@ void cuda_programmable_bootstrap_lwe_ciphertext_vector_32_async(
   switch (pbs_buf->pbs_variant) {
   case TBC:
 #if CUDA_ARCH >= 900
-    cuda_programmable_bootstrap_tbc_lwe_ciphertext_vector<uint32_t>(
+    cuda_programmable_bootstrap_tbc_lwe_ciphertext_vector_async<uint32_t>(
         stream, gpu_index, static_cast<uint32_t *>(lwe_array_out),
         static_cast<const uint32_t *>(lwe_output_indexes),
         static_cast<const uint32_t *>(lut_vector),
@@ -299,7 +299,7 @@ void cuda_programmable_bootstrap_lwe_ciphertext_vector_32_async(
     PANIC("Cuda error (PBS): TBC pbs is not supported.")
 #endif
   case CG:
-    cuda_programmable_bootstrap_cg_lwe_ciphertext_vector<uint32_t>(
+    cuda_programmable_bootstrap_cg_lwe_ciphertext_vector_async<uint32_t>(
         stream, gpu_index, static_cast<uint32_t *>(lwe_array_out),
         static_cast<const uint32_t *>(lwe_output_indexes),
         static_cast<const uint32_t *>(lut_vector),
@@ -311,7 +311,7 @@ void cuda_programmable_bootstrap_lwe_ciphertext_vector_32_async(
         num_many_lut, lut_stride);
     break;
   case DEFAULT:
-    cuda_programmable_bootstrap_lwe_ciphertext_vector<uint32_t>(
+    cuda_programmable_bootstrap_lwe_ciphertext_vector_async<uint32_t>(
         stream, gpu_index, static_cast<uint32_t *>(lwe_array_out),
         static_cast<const uint32_t *>(lwe_output_indexes),
         static_cast<const uint32_t *>(lut_vector),
@@ -406,7 +406,7 @@ void cuda_programmable_bootstrap_64_async(
   switch (pbs_buf->pbs_variant) {
   case PBS_VARIANT::TBC:
 #if (CUDA_ARCH >= 900)
-    cuda_programmable_bootstrap_tbc_lwe_ciphertext_vector<uint64_t>(
+    cuda_programmable_bootstrap_tbc_lwe_ciphertext_vector_async<uint64_t>(
         stream, gpu_index, static_cast<uint64_t *>(lwe_array_out),
         static_cast<const uint64_t *>(lwe_output_indexes),
         static_cast<const uint64_t *>(lut_vector),
@@ -421,7 +421,7 @@ void cuda_programmable_bootstrap_64_async(
     PANIC("Cuda error (PBS): TBC pbs is not supported.")
 #endif
   case PBS_VARIANT::CG:
-    cuda_programmable_bootstrap_cg_lwe_ciphertext_vector<uint64_t>(
+    cuda_programmable_bootstrap_cg_lwe_ciphertext_vector_async<uint64_t>(
         stream, gpu_index, static_cast<uint64_t *>(lwe_array_out),
         static_cast<const uint64_t *>(lwe_output_indexes),
         static_cast<const uint64_t *>(lut_vector),
@@ -433,7 +433,7 @@ void cuda_programmable_bootstrap_64_async(
         num_many_lut, lut_stride);
     break;
   case PBS_VARIANT::DEFAULT:
-    cuda_programmable_bootstrap_lwe_ciphertext_vector<uint64_t>(
+    cuda_programmable_bootstrap_lwe_ciphertext_vector_async<uint64_t>(
         stream, gpu_index, static_cast<uint64_t *>(lwe_array_out),
         static_cast<const uint64_t *>(lwe_output_indexes),
         static_cast<const uint64_t *>(lut_vector),
@@ -466,7 +466,7 @@ void cuda_programmable_bootstrap_tbc_64_generic_async(
                  "Cuda error (classical PBS): expected a TBC buffer.");
 
 #if (CUDA_ARCH >= 900)
-  cuda_programmable_bootstrap_tbc_lwe_ciphertext_vector_generic<uint64_t>(
+  cuda_programmable_bootstrap_tbc_lwe_ciphertext_vector_generic_async<uint64_t>(
       stream, gpu_index, static_cast<uint64_t *>(lwe_array_out),
       static_cast<const uint64_t *>(lwe_output_indexes),
       static_cast<const uint64_t *>(lut_vector),
@@ -596,7 +596,8 @@ template bool specialized_2_2_params_checker<uint64_t>(
     uint32_t polynomial_size, uint32_t glwe_dimension, uint32_t level_count,
     uint32_t max_shared_memory);
 
-template void cuda_programmable_bootstrap_cg_lwe_ciphertext_vector<uint64_t>(
+template void
+cuda_programmable_bootstrap_cg_lwe_ciphertext_vector_async<uint64_t>(
     void *stream, uint32_t gpu_index, uint64_t *lwe_array_out,
     uint64_t const *lwe_output_indexes, uint64_t const *lut_vector,
     uint64_t const *lut_vector_indexes, uint64_t const *lwe_array_in,
@@ -606,7 +607,7 @@ template void cuda_programmable_bootstrap_cg_lwe_ciphertext_vector<uint64_t>(
     uint32_t level_count, uint32_t num_samples, uint32_t num_many_lut,
     uint32_t lut_stride);
 
-template void cuda_programmable_bootstrap_lwe_ciphertext_vector<uint64_t>(
+template void cuda_programmable_bootstrap_lwe_ciphertext_vector_async<uint64_t>(
     void *stream, uint32_t gpu_index, uint64_t *lwe_array_out,
     uint64_t const *lwe_output_indexes, uint64_t const *lut_vector,
     uint64_t const *lut_vector_indexes, uint64_t const *lwe_array_in,
@@ -629,7 +630,8 @@ template uint64_t scratch_cuda_programmable_bootstrap<uint64_t>(
     uint32_t level_count, uint32_t input_lwe_ciphertext_count,
     bool allocate_gpu_memory, PBS_MS_REDUCTION_T noise_reduction_type);
 
-template void cuda_programmable_bootstrap_cg_lwe_ciphertext_vector<uint32_t>(
+template void
+cuda_programmable_bootstrap_cg_lwe_ciphertext_vector_async<uint32_t>(
     void *stream, uint32_t gpu_index, uint32_t *lwe_array_out,
     uint32_t const *lwe_output_indexes, uint32_t const *lut_vector,
     uint32_t const *lut_vector_indexes, uint32_t const *lwe_array_in,
@@ -639,7 +641,7 @@ template void cuda_programmable_bootstrap_cg_lwe_ciphertext_vector<uint32_t>(
     uint32_t level_count, uint32_t num_samples, uint32_t num_many_lut,
     uint32_t lut_stride);
 
-template void cuda_programmable_bootstrap_lwe_ciphertext_vector<uint32_t>(
+template void cuda_programmable_bootstrap_lwe_ciphertext_vector_async<uint32_t>(
     void *stream, uint32_t gpu_index, uint32_t *lwe_array_out,
     uint32_t const *lwe_output_indexes, uint32_t const *lut_vector,
     uint32_t const *lut_vector_indexes, uint32_t const *lwe_array_in,
@@ -670,7 +672,8 @@ template bool has_support_to_cuda_programmable_bootstrap_tbc<uint64_t>(
     uint32_t level_count, uint32_t max_shared_memory);
 
 #if CUDA_ARCH >= 900
-template void cuda_programmable_bootstrap_tbc_lwe_ciphertext_vector<uint32_t>(
+template void
+cuda_programmable_bootstrap_tbc_lwe_ciphertext_vector_async<uint32_t>(
     void *stream, uint32_t gpu_index, uint32_t *lwe_array_out,
     uint32_t const *lwe_output_indexes, uint32_t const *lut_vector,
     uint32_t const *lut_vector_indexes, uint32_t const *lwe_array_in,
@@ -679,7 +682,8 @@ template void cuda_programmable_bootstrap_tbc_lwe_ciphertext_vector<uint32_t>(
     uint32_t glwe_dimension, uint32_t polynomial_size, uint32_t base_log,
     uint32_t level_count, uint32_t num_samples, uint32_t num_many_lut,
     uint32_t lut_stride);
-template void cuda_programmable_bootstrap_tbc_lwe_ciphertext_vector<uint64_t>(
+template void
+cuda_programmable_bootstrap_tbc_lwe_ciphertext_vector_async<uint64_t>(
     void *stream, uint32_t gpu_index, uint64_t *lwe_array_out,
     uint64_t const *lwe_output_indexes, uint64_t const *lut_vector,
     uint64_t const *lut_vector_indexes, uint64_t const *lwe_array_in,

--- a/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_multibit.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_multibit.cu
@@ -37,7 +37,7 @@ bool has_support_to_cuda_programmable_bootstrap_tbc_multi_bit(
 }
 
 template <typename Torus>
-void cuda_cg_multi_bit_programmable_bootstrap_lwe_ciphertext_vector(
+void cuda_cg_multi_bit_programmable_bootstrap_lwe_ciphertext_vector_async(
     void *stream, uint32_t gpu_index, Torus *lwe_array_out,
     Torus const *lwe_output_indexes, Torus const *lut_vector,
     Torus const *lut_vector_indexes, Torus const *lwe_array_in,
@@ -58,7 +58,7 @@ void cuda_cg_multi_bit_programmable_bootstrap_lwe_ciphertext_vector(
 }
 
 template <typename Torus>
-void cuda_multi_bit_programmable_bootstrap_lwe_ciphertext_vector(
+void cuda_multi_bit_programmable_bootstrap_lwe_ciphertext_vector_async(
     void *stream, uint32_t gpu_index, Torus *lwe_array_out,
     Torus const *lwe_output_indexes, Torus const *lut_vector,
     Torus const *lut_vector_indexes, Torus const *lwe_array_in,
@@ -79,7 +79,7 @@ void cuda_multi_bit_programmable_bootstrap_lwe_ciphertext_vector(
 }
 
 template <typename Torus>
-void cuda_tbc_multi_bit_programmable_bootstrap_lwe_ciphertext_vector_generic(
+void cuda_tbc_multi_bit_programmable_bootstrap_lwe_ciphertext_vector_generic_async(
     void *stream, uint32_t gpu_index, Torus *lwe_array_out,
     Torus const *lwe_output_indexes, Torus const *lut_vector,
     Torus const *lut_vector_indexes, Torus const *lwe_array_in,
@@ -108,34 +108,36 @@ void cuda_multi_bit_programmable_bootstrap_64_async(
   switch (pbs_buf->pbs_variant) {
   case PBS_VARIANT::TBC:
 #if CUDA_ARCH >= 900
-    cuda_tbc_multi_bit_programmable_bootstrap_lwe_ciphertext_vector<uint64_t>(
-        stream, gpu_index, static_cast<uint64_t *>(lwe_array_out),
-        static_cast<const uint64_t *>(lwe_output_indexes),
-        static_cast<const uint64_t *>(lut_vector),
-        static_cast<const uint64_t *>(lut_vector_indexes),
-        static_cast<const uint64_t *>(lwe_array_in),
-        static_cast<const uint64_t *>(lwe_input_indexes),
-        static_cast<const uint64_t *>(bootstrapping_key), pbs_buf,
-        lwe_dimension, glwe_dimension, polynomial_size, grouping_factor,
-        base_log, level_count, num_samples, num_many_lut, lut_stride);
+    cuda_tbc_multi_bit_programmable_bootstrap_lwe_ciphertext_vector_async<
+        uint64_t>(stream, gpu_index, static_cast<uint64_t *>(lwe_array_out),
+                  static_cast<const uint64_t *>(lwe_output_indexes),
+                  static_cast<const uint64_t *>(lut_vector),
+                  static_cast<const uint64_t *>(lut_vector_indexes),
+                  static_cast<const uint64_t *>(lwe_array_in),
+                  static_cast<const uint64_t *>(lwe_input_indexes),
+                  static_cast<const uint64_t *>(bootstrapping_key), pbs_buf,
+                  lwe_dimension, glwe_dimension, polynomial_size,
+                  grouping_factor, base_log, level_count, num_samples,
+                  num_many_lut, lut_stride);
     break;
 #else
     PANIC("Cuda error (multi-bit PBS): TBC pbs is not supported.")
 #endif
   case PBS_VARIANT::CG:
-    cuda_cg_multi_bit_programmable_bootstrap_lwe_ciphertext_vector<uint64_t>(
-        stream, gpu_index, static_cast<uint64_t *>(lwe_array_out),
-        static_cast<const uint64_t *>(lwe_output_indexes),
-        static_cast<const uint64_t *>(lut_vector),
-        static_cast<const uint64_t *>(lut_vector_indexes),
-        static_cast<const uint64_t *>(lwe_array_in),
-        static_cast<const uint64_t *>(lwe_input_indexes),
-        static_cast<const uint64_t *>(bootstrapping_key), pbs_buf,
-        lwe_dimension, glwe_dimension, polynomial_size, grouping_factor,
-        base_log, level_count, num_samples, num_many_lut, lut_stride);
+    cuda_cg_multi_bit_programmable_bootstrap_lwe_ciphertext_vector_async<
+        uint64_t>(stream, gpu_index, static_cast<uint64_t *>(lwe_array_out),
+                  static_cast<const uint64_t *>(lwe_output_indexes),
+                  static_cast<const uint64_t *>(lut_vector),
+                  static_cast<const uint64_t *>(lut_vector_indexes),
+                  static_cast<const uint64_t *>(lwe_array_in),
+                  static_cast<const uint64_t *>(lwe_input_indexes),
+                  static_cast<const uint64_t *>(bootstrapping_key), pbs_buf,
+                  lwe_dimension, glwe_dimension, polynomial_size,
+                  grouping_factor, base_log, level_count, num_samples,
+                  num_many_lut, lut_stride);
     break;
   case PBS_VARIANT::DEFAULT:
-    cuda_multi_bit_programmable_bootstrap_lwe_ciphertext_vector<uint64_t>(
+    cuda_multi_bit_programmable_bootstrap_lwe_ciphertext_vector_async<uint64_t>(
         stream, gpu_index, static_cast<uint64_t *>(lwe_array_out),
         static_cast<const uint64_t *>(lwe_output_indexes),
         static_cast<const uint64_t *>(lut_vector),
@@ -169,7 +171,7 @@ void cuda_multi_bit_programmable_bootstrap_64_generic_async(
                  "Cuda error (multi-bit PBS): expected a TBC buffer.");
 
 #if CUDA_ARCH >= 900
-  cuda_tbc_multi_bit_programmable_bootstrap_lwe_ciphertext_vector_generic<
+  cuda_tbc_multi_bit_programmable_bootstrap_lwe_ciphertext_vector_generic_async<
       uint64_t>(stream, gpu_index, static_cast<uint64_t *>(lwe_array_out),
                 static_cast<const uint64_t *>(lwe_output_indexes),
                 static_cast<const uint64_t *>(lut_vector),
@@ -269,7 +271,7 @@ void cuda_multi_bit_programmable_bootstrap_tbc_64_generic_async(
                  "Cuda error (multi-bit PBS): expected a TBC buffer.");
 
 #if CUDA_ARCH >= 900
-  cuda_tbc_multi_bit_programmable_bootstrap_lwe_ciphertext_vector_generic<
+  cuda_tbc_multi_bit_programmable_bootstrap_lwe_ciphertext_vector_generic_async<
       uint64_t>(stream, gpu_index, static_cast<uint64_t *>(lwe_array_out),
                 static_cast<const uint64_t *>(lwe_output_indexes),
                 static_cast<const uint64_t *>(lut_vector),
@@ -609,7 +611,7 @@ template uint64_t scratch_cuda_multi_bit_programmable_bootstrap<uint64_t>(
     uint32_t input_lwe_ciphertext_count, bool allocate_gpu_memory);
 
 template void
-cuda_multi_bit_programmable_bootstrap_lwe_ciphertext_vector<uint64_t>(
+cuda_multi_bit_programmable_bootstrap_lwe_ciphertext_vector_async<uint64_t>(
     void *stream, uint32_t gpu_index, uint64_t *lwe_array_out,
     uint64_t const *lwe_output_indexes, uint64_t const *lut_vector,
     uint64_t const *lut_vector_indexes, uint64_t const *lwe_array_in,
@@ -626,7 +628,7 @@ template uint64_t scratch_cuda_cg_multi_bit_programmable_bootstrap<uint64_t>(
     uint32_t input_lwe_ciphertext_count, bool allocate_gpu_memory);
 
 template void
-cuda_cg_multi_bit_programmable_bootstrap_lwe_ciphertext_vector<uint64_t>(
+cuda_cg_multi_bit_programmable_bootstrap_lwe_ciphertext_vector_async<uint64_t>(
     void *stream, uint32_t gpu_index, uint64_t *lwe_array_out,
     uint64_t const *lwe_output_indexes, uint64_t const *lut_vector,
     uint64_t const *lut_vector_indexes, uint64_t const *lwe_array_in,
@@ -656,7 +658,7 @@ uint64_t scratch_cuda_tbc_multi_bit_programmable_bootstrap(
           allocate_gpu_memory));
 }
 template <typename Torus>
-void cuda_tbc_multi_bit_programmable_bootstrap_lwe_ciphertext_vector(
+void cuda_tbc_multi_bit_programmable_bootstrap_lwe_ciphertext_vector_async(
     void *stream, uint32_t gpu_index, Torus *lwe_array_out,
     Torus const *lwe_output_indexes, Torus const *lut_vector,
     Torus const *lut_vector_indexes, Torus const *lwe_array_in,
@@ -707,7 +709,7 @@ void cuda_tbc_multi_bit_programmable_bootstrap_lwe_ciphertext_vector(
 }
 
 template <typename Torus>
-void cuda_tbc_multi_bit_programmable_bootstrap_lwe_ciphertext_vector_generic(
+void cuda_tbc_multi_bit_programmable_bootstrap_lwe_ciphertext_vector_generic_async(
     void *stream, uint32_t gpu_index, Torus *lwe_array_out,
     Torus const *lwe_output_indexes, Torus const *lut_vector,
     Torus const *lut_vector_indexes, Torus const *lwe_array_in,
@@ -764,7 +766,7 @@ template uint64_t scratch_cuda_tbc_multi_bit_programmable_bootstrap<uint64_t>(
     uint32_t input_lwe_ciphertext_count, bool allocate_gpu_memory);
 
 template void
-cuda_tbc_multi_bit_programmable_bootstrap_lwe_ciphertext_vector<uint64_t>(
+cuda_tbc_multi_bit_programmable_bootstrap_lwe_ciphertext_vector_async<uint64_t>(
     void *stream, uint32_t gpu_index, uint64_t *lwe_array_out,
     uint64_t const *lwe_output_indexes, uint64_t const *lut_vector,
     uint64_t const *lut_vector_indexes, uint64_t const *lwe_array_in,

--- a/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_multibit_128.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_multibit_128.cu
@@ -83,7 +83,7 @@ void cuda_multi_bit_programmable_bootstrap_128_async(
 }
 
 template <typename InputTorus>
-void cuda_cg_multi_bit_programmable_bootstrap_lwe_ciphertext_vector_128(
+void cuda_cg_multi_bit_programmable_bootstrap_lwe_ciphertext_vector_128_async(
     void *stream, uint32_t gpu_index, __uint128_t *lwe_array_out,
     InputTorus const *lwe_output_indexes, __uint128_t const *lut_vector,
     InputTorus const *lwe_array_in, InputTorus const *lwe_input_indexes,
@@ -120,7 +120,7 @@ void cuda_multi_bit_programmable_bootstrap_128_async(
       reinterpret_cast<pbs_buffer_128<uint64_t, MULTI_BIT> *>(mem_ptr);
   switch (buffer->pbs_variant) {
   case PBS_VARIANT::CG:
-    cuda_cg_multi_bit_programmable_bootstrap_lwe_ciphertext_vector_128<
+    cuda_cg_multi_bit_programmable_bootstrap_lwe_ciphertext_vector_128_async<
         uint64_t>(stream, gpu_index, static_cast<__uint128_t *>(lwe_array_out),
                   static_cast<const uint64_t *>(lwe_output_indexes),
                   static_cast<const __uint128_t *>(lut_vector),

--- a/backends/tfhe-cuda-backend/cuda/tests_and_benchmarks/benchmarks/benchmark_pbs.cpp
+++ b/backends/tfhe-cuda-backend/cuda/tests_and_benchmarks/benchmarks/benchmark_pbs.cpp
@@ -181,13 +181,14 @@ BENCHMARK_DEFINE_F(MultiBitBootstrap_u64, TbcMultiBit)
   uint32_t lut_stride = 0;
   for (auto _ : st) {
     // Execute PBS
-    cuda_tbc_multi_bit_programmable_bootstrap_lwe_ciphertext_vector<uint64_t>(
-        stream, gpu_index, d_lwe_ct_out_array, d_lwe_output_indexes,
-        d_lut_pbs_identity, d_lut_pbs_indexes, d_lwe_ct_in_array,
-        d_lwe_input_indexes, d_bsk, (pbs_buffer<uint64_t, MULTI_BIT> *)buffer,
-        lwe_dimension, glwe_dimension, polynomial_size, grouping_factor,
-        pbs_base_log, pbs_level, input_lwe_ciphertext_count, num_many_lut,
-        lut_stride);
+    cuda_tbc_multi_bit_programmable_bootstrap_lwe_ciphertext_vector_async<
+        uint64_t>(stream, gpu_index, d_lwe_ct_out_array, d_lwe_output_indexes,
+                  d_lut_pbs_identity, d_lut_pbs_indexes, d_lwe_ct_in_array,
+                  d_lwe_input_indexes, d_bsk,
+                  (pbs_buffer<uint64_t, MULTI_BIT> *)buffer, lwe_dimension,
+                  glwe_dimension, polynomial_size, grouping_factor,
+                  pbs_base_log, pbs_level, input_lwe_ciphertext_count,
+                  num_many_lut, lut_stride);
     cuda_synchronize_stream(stream, gpu_index);
   }
 
@@ -212,7 +213,8 @@ BENCHMARK_DEFINE_F(MultiBitBootstrap_u64, CgMultiBit)
   uint32_t lut_stride = 0;
   for (auto _ : st) {
     // Execute PBS
-    cuda_cg_multi_bit_programmable_bootstrap_lwe_ciphertext_vector<uint64_t>(
+    cuda_cg_multi_bit_programmable_bootstrap_lwe_ciphertext_vector_async<
+        uint64_t>(
         stream, gpu_index, d_lwe_ct_out_array,
         (const uint64_t *)d_lwe_output_indexes,
         (const uint64_t *)d_lut_pbs_identity,
@@ -238,7 +240,7 @@ BENCHMARK_DEFINE_F(MultiBitBootstrap_u64, DefaultMultiBit)
   uint32_t lut_stride = 0;
   for (auto _ : st) {
     // Execute PBS
-    cuda_multi_bit_programmable_bootstrap_lwe_ciphertext_vector<uint64_t>(
+    cuda_multi_bit_programmable_bootstrap_lwe_ciphertext_vector_async<uint64_t>(
         stream, gpu_index, d_lwe_ct_out_array, d_lwe_output_indexes,
         d_lut_pbs_identity, d_lut_pbs_indexes, d_lwe_ct_in_array,
         d_lwe_input_indexes, d_bsk, (pbs_buffer<uint64_t, MULTI_BIT> *)buffer,
@@ -269,7 +271,7 @@ BENCHMARK_DEFINE_F(ClassicalBootstrap_u64, TbcPBC)
   uint32_t lut_stride = 0;
   for (auto _ : st) {
     // Execute PBS
-    cuda_programmable_bootstrap_tbc_lwe_ciphertext_vector<uint64_t>(
+    cuda_programmable_bootstrap_tbc_lwe_ciphertext_vector_async<uint64_t>(
         stream, gpu_index, (uint64_t *)d_lwe_ct_out_array,
         (uint64_t *)d_lwe_output_indexes, (uint64_t *)d_lut_pbs_identity,
         (uint64_t *)d_lut_pbs_indexes, (uint64_t *)d_lwe_ct_in_array,
@@ -301,7 +303,7 @@ BENCHMARK_DEFINE_F(ClassicalBootstrap_u64, CgPBS)
   uint32_t lut_stride = 0;
   for (auto _ : st) {
     // Execute PBS
-    cuda_programmable_bootstrap_cg_lwe_ciphertext_vector<uint64_t>(
+    cuda_programmable_bootstrap_cg_lwe_ciphertext_vector_async<uint64_t>(
         stream, gpu_index, (uint64_t *)d_lwe_ct_out_array,
         (uint64_t *)d_lwe_output_indexes, (uint64_t *)d_lut_pbs_identity,
         (uint64_t *)d_lut_pbs_indexes, (uint64_t *)d_lwe_ct_in_array,
@@ -326,7 +328,7 @@ BENCHMARK_DEFINE_F(ClassicalBootstrap_u64, DefaultPBS)
   uint32_t lut_stride = 0;
   for (auto _ : st) {
     // Execute PBS
-    cuda_programmable_bootstrap_lwe_ciphertext_vector<uint64_t>(
+    cuda_programmable_bootstrap_lwe_ciphertext_vector_async<uint64_t>(
         stream, gpu_index, (uint64_t *)d_lwe_ct_out_array,
         (uint64_t *)d_lwe_output_indexes, (uint64_t *)d_lut_pbs_identity,
         (uint64_t *)d_lut_pbs_indexes, (uint64_t *)d_lwe_ct_in_array,

--- a/backends/tfhe-cuda-backend/cuda/tests_and_benchmarks/tests/test_classical_pbs.cpp
+++ b/backends/tfhe-cuda-backend/cuda/tests_and_benchmarks/tests/test_classical_pbs.cpp
@@ -213,7 +213,7 @@ TEST_P(ClassicalProgrammableBootstrapTestPrimitives_u64, classical_cg) {
       [&](uint64_t *d_lwe_ct_in, double *d_fourier_bsk, int8_t *buffer) {
         auto *typed =
             reinterpret_cast<::pbs_buffer<uint64_t, CLASSICAL> *>(buffer);
-        cuda_programmable_bootstrap_cg_lwe_ciphertext_vector<uint64_t>(
+        cuda_programmable_bootstrap_cg_lwe_ciphertext_vector_async<uint64_t>(
             stream, gpu_index, d_lwe_ct_out_array, d_lwe_output_indexes,
             d_lut_pbs_identity, d_lut_pbs_indexes, d_lwe_ct_in,
             d_lwe_input_indexes,

--- a/backends/tfhe-cuda-backend/cuda/tests_and_benchmarks/tests/test_multibit_pbs.cpp
+++ b/backends/tfhe-cuda-backend/cuda/tests_and_benchmarks/tests/test_multibit_pbs.cpp
@@ -182,12 +182,13 @@ TEST_P(MultiBitProgrammableBootstrapTestPrimitives_u64, multi_bit_default) {
       [&](uint64_t *d_lwe_ct_in, uint64_t *d_bsk, int8_t *buffer) {
         auto *typed =
             reinterpret_cast<::pbs_buffer<uint64_t, MULTI_BIT> *>(buffer);
-        cuda_multi_bit_programmable_bootstrap_lwe_ciphertext_vector<uint64_t>(
-            stream, gpu_index, d_lwe_ct_out_array, d_lwe_output_indexes,
-            d_lut_pbs_identity, d_lut_pbs_indexes, d_lwe_ct_in,
-            d_lwe_input_indexes, d_bsk, typed, lwe_dimension, glwe_dimension,
-            polynomial_size, grouping_factor, pbs_base_log, pbs_level,
-            number_of_inputs, num_many_lut, lut_stride);
+        cuda_multi_bit_programmable_bootstrap_lwe_ciphertext_vector_async<
+            uint64_t>(stream, gpu_index, d_lwe_ct_out_array,
+                      d_lwe_output_indexes, d_lut_pbs_identity,
+                      d_lut_pbs_indexes, d_lwe_ct_in, d_lwe_input_indexes,
+                      d_bsk, typed, lwe_dimension, glwe_dimension,
+                      polynomial_size, grouping_factor, pbs_base_log, pbs_level,
+                      number_of_inputs, num_many_lut, lut_stride);
       },
       pbs_buffer);
 
@@ -212,7 +213,7 @@ TEST_P(MultiBitProgrammableBootstrapTestPrimitives_u64, multi_bit_cg) {
       [&](uint64_t *d_lwe_ct_in, uint64_t *d_bsk, int8_t *buffer) {
         auto *typed =
             reinterpret_cast<::pbs_buffer<uint64_t, MULTI_BIT> *>(buffer);
-        cuda_cg_multi_bit_programmable_bootstrap_lwe_ciphertext_vector<
+        cuda_cg_multi_bit_programmable_bootstrap_lwe_ciphertext_vector_async<
             uint64_t>(stream, gpu_index, d_lwe_ct_out_array,
                       d_lwe_output_indexes, d_lut_pbs_identity,
                       d_lut_pbs_indexes, d_lwe_ct_in, d_lwe_input_indexes,


### PR DESCRIPTION
Part of https://github.com/zama-ai/tfhe-rs-internal/issues/1482 (split 1 of 3, replaces #3896).

### PR content/description

The CUDA backend naming convention says: `_async` suffix = launches work and returns without host synchronization; no suffix = synchronizes before returning.

A transitive call-graph analysis found 12 internal C++ template functions that never reach `cuda_synchronize_stream` but were missing the `_async` suffix. This PR renames them. It is a pure rename: no behavior change.

<details><summary>10 PBS internal template functions</summary>

These are C++ templates declared in `include/pbs/pbs_utilities.h` and `include/pbs/pbs_multibit_utilities.h` (no `extern "C"` block). They are called only from `_async` FFI wrappers.

- **`cuda_programmable_bootstrap_lwe_ciphertext_vector`** => `cuda_programmable_bootstrap_lwe_ciphertext_vector_async`
- **`cuda_programmable_bootstrap_cg_lwe_ciphertext_vector`** => `cuda_programmable_bootstrap_cg_lwe_ciphertext_vector_async`
- **`cuda_programmable_bootstrap_tbc_lwe_ciphertext_vector`** => `cuda_programmable_bootstrap_tbc_lwe_ciphertext_vector_async`
- **`cuda_programmable_bootstrap_tbc_lwe_ciphertext_vector_generic`** => `cuda_programmable_bootstrap_tbc_lwe_ciphertext_vector_generic_async`
- **`cuda_multi_bit_programmable_bootstrap_lwe_ciphertext_vector`** => `cuda_multi_bit_programmable_bootstrap_lwe_ciphertext_vector_async`
- **`cuda_cg_multi_bit_programmable_bootstrap_lwe_ciphertext_vector`** => `cuda_cg_multi_bit_programmable_bootstrap_lwe_ciphertext_vector_async`
- **`cuda_tbc_multi_bit_programmable_bootstrap_lwe_ciphertext_vector`** => `cuda_tbc_multi_bit_programmable_bootstrap_lwe_ciphertext_vector_async`
- **`cuda_tbc_multi_bit_programmable_bootstrap_lwe_ciphertext_vector_generic`** => `cuda_tbc_multi_bit_programmable_bootstrap_lwe_ciphertext_vector_generic_async`
- **`cuda_cg_multi_bit_programmable_bootstrap_lwe_ciphertext_vector_128`** => `cuda_cg_multi_bit_programmable_bootstrap_lwe_ciphertext_vector_128_async`
- **`cuda_convert_lwe_programmable_bootstrap_key_u128`** => `cuda_convert_lwe_programmable_bootstrap_key_u128_async`

</details>

<details><summary>2 <code>scratch_cuda_*</code> internal template functions</summary>

- **`scratch_cuda_zero_out_if_batch`** => `scratch_cuda_zero_out_if_batch_async` (`src/integer/cmux.cuh`): the constructor only calls `create_zero_radix_ciphertext_async`, no LUT, no sync.
- **`scratch_cuda_compress_ciphertext`** => `scratch_cuda_compress_ciphertext_async` (`src/integer/compression/compression.cuh`): the constructor only calls `cuda_malloc_with_size_tracking_async` and `scratch_packing_keyswitch_lwe_list_to_glwe`, no sync.

</details>

### Check-list:

* [x] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [x] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
