### PR TITLE
chore(gpu): make scratch_cuda_* functions truly asynchronous and enforce it in check_scratch_cleanup.py

### DIFF
--- a/backends/tfhe-cuda-backend/cuda/include/integer/div_rem.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer/div_rem.h
@@ -88,6 +88,21 @@ template <typename Torus> struct unsigned_int_div_rem_2_2_memory {
   Torus **second_indexes_for_overflow_sub_gpu_2;
   Torus **scalars_for_overflow_sub_gpu_2;
 
+  /// @brief Host staging area for the first index table built by
+  /// create_indexes_for_overflow_sub.
+  ///
+  /// Iteration nb uploads its nb entries asynchronously, so each iteration
+  /// needs its own slot: the slots are packed triangularly, iteration nb
+  /// starting at offset nb * (nb - 1) / 2. Freed in release() after the
+  /// stream synchronization.
+  Torus *h_first_indexes_staging = nullptr;
+  /// @brief Host staging area for the second index table (same layout as
+  /// h_first_indexes_staging).
+  Torus *h_second_indexes_staging = nullptr;
+  /// @brief Host staging area for the scalar table (same layout as
+  /// h_first_indexes_staging).
+  Torus *h_scalars_staging = nullptr;
+
   cudaEvent_t create_indexes_done;
 
   uint32_t max_indexes_to_erase;
@@ -480,11 +495,24 @@ template <typename Torus> struct unsigned_int_div_rem_2_2_memory {
     scalars_for_overflow_sub_gpu_0 =
         (Torus **)malloc(safe_mul_sizeof<Torus *>(num_blocks));
 
-    Torus *h_lut_indexes = (Torus *)malloc(safe_mul_sizeof<Torus>(num_blocks));
-    Torus *h_scalar = (Torus *)malloc(safe_mul_sizeof<Torus>(num_blocks));
+    size_t staging_entries = (size_t)num_blocks * (num_blocks + 1) / 2;
+    h_first_indexes_staging =
+        static_cast<Torus *>(malloc(safe_mul_sizeof<Torus>(staging_entries)));
+    PANIC_IF_FALSE(h_first_indexes_staging != nullptr,
+                   "host allocation failed for h_first_indexes_staging");
+    h_second_indexes_staging =
+        static_cast<Torus *>(malloc(safe_mul_sizeof<Torus>(staging_entries)));
+    PANIC_IF_FALSE(h_second_indexes_staging != nullptr,
+                   "host allocation failed for h_second_indexes_staging");
+    h_scalars_staging =
+        static_cast<Torus *>(malloc(safe_mul_sizeof<Torus>(staging_entries)));
+    PANIC_IF_FALSE(h_scalars_staging != nullptr,
+                   "host allocation failed for h_scalars_staging");
 
     // Extra indexes for the luts in first step
     for (int nb = 1; nb <= num_blocks; nb++) {
+      size_t staging_offset = (size_t)nb * (size_t)(nb - 1) / 2;
+      Torus *h_lut_indexes = &h_first_indexes_staging[staging_offset];
       first_indexes_for_overflow_sub_gpu_0[nb - 1] =
           (Torus *)cuda_malloc_with_size_tracking_async(
               safe_mul_sizeof<Torus>(nb), streams.stream(0),
@@ -519,6 +547,9 @@ template <typename Torus> struct unsigned_int_div_rem_2_2_memory {
     uint32_t num_extra_luts = use_seq ? (group_size - 1) : 1;
     uint32_t num_luts_second_step = 2 * group_size + num_extra_luts;
     for (int nb = 1; nb <= num_blocks; nb++) {
+      size_t staging_offset = (size_t)nb * (size_t)(nb - 1) / 2;
+      Torus *h_lut_indexes = &h_second_indexes_staging[staging_offset];
+      Torus *h_scalar = &h_scalars_staging[staging_offset];
       second_indexes_for_overflow_sub_gpu_0[nb - 1] =
           (Torus *)cuda_malloc_with_size_tracking_async(
               safe_mul_sizeof<Torus>(nb), streams.stream(0),
@@ -577,9 +608,6 @@ template <typename Torus> struct unsigned_int_div_rem_2_2_memory {
           safe_mul_sizeof<Torus>(nb), streams.stream(0), streams.gpu_index(0),
           allocate_gpu_memory);
     }
-    cuda_synchronize_stream(streams.stream(0), streams.gpu_index(0));
-    free(h_lut_indexes);
-    free(h_scalar);
   };
 
   void release(CudaStreams streams) {
@@ -845,6 +873,13 @@ template <typename Torus> struct unsigned_int_div_rem_2_2_memory {
     free(second_indexes_for_overflow_sub_gpu_2);
     free(scalars_for_overflow_sub_gpu_2);
 
+    free(h_first_indexes_staging);
+    h_first_indexes_staging = nullptr;
+    free(h_second_indexes_staging);
+    h_second_indexes_staging = nullptr;
+    free(h_scalars_staging);
+    h_scalars_staging = nullptr;
+
     check_cuda_error(cudaEventDestroy(create_indexes_done));
 
     // release sub streams
@@ -899,6 +934,19 @@ template <typename Torus> struct unsigned_int_div_rem_memory {
   Torus **first_indexes_for_overflow_sub;
   Torus **second_indexes_for_overflow_sub;
   Torus **scalars_for_overflow_sub;
+  /// @brief Host staging area for the first index table built by
+  /// create_indexes_for_overflow_sub.
+  ///
+  /// Packed triangularly with iteration nb starting at offset
+  /// nb * (nb - 1) / 2. See the same members in
+  /// unsigned_int_div_rem_2_2_memory.
+  Torus *h_first_indexes_staging = nullptr;
+  /// @brief Host staging area for the second index table (same layout as
+  /// h_first_indexes_staging).
+  Torus *h_second_indexes_staging = nullptr;
+  /// @brief Host staging area for the scalar table (same layout as
+  /// h_first_indexes_staging).
+  Torus *h_scalars_staging = nullptr;
   uint32_t max_indexes_to_erase;
   bool gpu_memory_allocated;
 
@@ -1173,11 +1221,24 @@ template <typename Torus> struct unsigned_int_div_rem_memory {
     scalars_for_overflow_sub =
         (Torus **)malloc(safe_mul_sizeof<Torus *>(num_blocks));
 
-    Torus *h_lut_indexes = (Torus *)malloc(safe_mul_sizeof<Torus>(num_blocks));
-    Torus *h_scalar = (Torus *)malloc(safe_mul_sizeof<Torus>(num_blocks));
+    size_t staging_entries = (size_t)num_blocks * (num_blocks + 1) / 2;
+    h_first_indexes_staging =
+        static_cast<Torus *>(malloc(safe_mul_sizeof<Torus>(staging_entries)));
+    PANIC_IF_FALSE(h_first_indexes_staging != nullptr,
+                   "host allocation failed for h_first_indexes_staging");
+    h_second_indexes_staging =
+        static_cast<Torus *>(malloc(safe_mul_sizeof<Torus>(staging_entries)));
+    PANIC_IF_FALSE(h_second_indexes_staging != nullptr,
+                   "host allocation failed for h_second_indexes_staging");
+    h_scalars_staging =
+        static_cast<Torus *>(malloc(safe_mul_sizeof<Torus>(staging_entries)));
+    PANIC_IF_FALSE(h_scalars_staging != nullptr,
+                   "host allocation failed for h_scalars_staging");
 
     // Extra indexes for the luts in first step
     for (int nb = 1; nb <= num_blocks; nb++) {
+      size_t staging_offset = (size_t)nb * (size_t)(nb - 1) / 2;
+      Torus *h_lut_indexes = &h_first_indexes_staging[staging_offset];
       first_indexes_for_overflow_sub[nb - 1] =
           (Torus *)cuda_malloc_with_size_tracking_async(
               safe_mul_sizeof<Torus>(nb), streams.stream(0),
@@ -1211,6 +1272,9 @@ template <typename Torus> struct unsigned_int_div_rem_memory {
     uint32_t num_extra_luts = use_seq ? (group_size - 1) : 1;
     uint32_t num_luts_second_step = 2 * group_size + num_extra_luts;
     for (int nb = 1; nb <= num_blocks; nb++) {
+      size_t staging_offset = (size_t)nb * (size_t)(nb - 1) / 2;
+      Torus *h_lut_indexes = &h_second_indexes_staging[staging_offset];
+      Torus *h_scalar = &h_scalars_staging[staging_offset];
       second_indexes_for_overflow_sub[nb - 1] =
           (Torus *)cuda_malloc_with_size_tracking_async(
               safe_mul_sizeof<Torus>(nb), streams.stream(0),
@@ -1268,8 +1332,6 @@ template <typename Torus> struct unsigned_int_div_rem_memory {
           safe_mul_sizeof<Torus>(nb), streams.stream(0), streams.gpu_index(0),
           allocate_gpu_memory);
     }
-    free(h_lut_indexes);
-    free(h_scalar);
   };
 
   void release(CudaStreams streams) {
@@ -1419,6 +1481,13 @@ template <typename Torus> struct unsigned_int_div_rem_memory {
     free(first_indexes_for_overflow_sub);
     free(second_indexes_for_overflow_sub);
     free(scalars_for_overflow_sub);
+
+    free(h_first_indexes_staging);
+    h_first_indexes_staging = nullptr;
+    free(h_second_indexes_staging);
+    h_second_indexes_staging = nullptr;
+    free(h_scalars_staging);
+    h_scalars_staging = nullptr;
   }
 };
 template <typename Torus> struct int_div_rem_memory {

--- a/backends/tfhe-cuda-backend/cuda/include/integer/integer_utilities.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer/integer_utilities.h
@@ -621,8 +621,14 @@ struct int_radix_lut_custom_input_output {
     multi_gpu_alloc_array_async(active_streams, lwe_trivial_indexes_vec,
                                 num_radix_blocks, size_tracker,
                                 allocate_gpu_memory);
-    cuda_synchronize_stream(active_streams.stream(0),
-                            active_streams.gpu_index(0));
+
+    // lwe_trivial_indexes was filled from the host on stream 0 by
+    // setup_lwe_trivial_indices, while the copies below run on the worker
+    // streams, so those must wait for stream 0. On a single GPU the only copy
+    // runs on stream 0 itself and needs no ordering.
+    if (allocate_gpu_memory && active_streams.count() > 1)
+      multi_gpu_broadcast_barrier.local_streams_wait_for_stream_0(
+          active_streams);
 
     // This call will not copy if allocate_gpu_memory is false
     // thus it's safe to call it on a null source pointer
@@ -674,14 +680,17 @@ struct int_radix_lut_custom_input_output {
 
   void setup_multi_gpu(int_radix_params params, uint32_t num_radix_blocks,
                        bool allocate_gpu_memory, uint64_t &size_tracker) {
-    alloc_and_init_multi_gpu_buffers(params, num_radix_blocks,
-                                     allocate_gpu_memory, size_tracker);
-
+    // The barriers are created first because
+    // alloc_and_init_multi_gpu_buffers orders its peer copies with
+    // multi_gpu_broadcast_barrier.
     if (active_streams.count() > 1) {
       multi_gpu_gather_barrier.create_on(active_streams);
       multi_gpu_broadcast_barrier.create_on(active_streams);
       multi_gpu_scatter_barrier.create_on(active_streams);
     }
+
+    alloc_and_init_multi_gpu_buffers(params, num_radix_blocks,
+                                     allocate_gpu_memory, size_tracker);
   }
 
   int_radix_lut_custom_input_output(CudaStreams streams,
@@ -955,10 +964,10 @@ public:
     multi_gpu_broadcast_barrier.local_streams_wait_for_stream_0(
         new_active_streams);
 
-    // The LUT and its indexes reside on GPU 0
-    // these were filled by calls to generate_device_accumulator
-    // due to the previous synchronization, we're sure these buffers have
-    // finished copying to GPU 0 from CPU
+    // The LUT and its indexes reside on GPU 0, filled by calls to
+    // generate_device_accumulator on stream 0. The event barrier above was
+    // recorded on that same stream, so the worker streams below only start
+    // reading once those host to device copies have completed.
     auto src_lut = lut_vec[0];
     auto src_lut_indexes = lut_indexes_vec[0];
 
@@ -1148,6 +1157,10 @@ public:
       std::vector<OutputTorus *> cpu_prealloc_buffers = {},
       std::optional<int> factor = std::nullopt) {
     // streams should be a subset of active_streams
+    GPU_ASSERT(
+        cpu_prealloc_buffers.empty() || gpu_memory_allocated,
+        "LUT Generation with pre-allocated CPU buffer expects "
+        "gpu_memory_allocated==True ");
 
     if constexpr (!std::is_same_v<IndexGenerator, std::nullptr_t>) {
       set_lut_indexes(streams, index_generator, num_blocks);
@@ -1211,8 +1224,12 @@ public:
         active_streams.gpu_index(0), gpu_memory_allocated);
     lwe_trivial_indexes = nullptr;
 
-    cuda_synchronize_stream(active_streams.stream(0),
-                            active_streams.gpu_index(0));
+    // Nothing was ever enqueued when gpu_memory_allocated is false: this
+    // object is then only used to measure the memory it would take, so there
+    // is no in-flight copy the host frees below could race with.
+    if (gpu_memory_allocated)
+      cuda_synchronize_stream(active_streams.stream(0),
+                              active_streams.gpu_index(0));
     lut_vec.clear();
     lut_indexes_vec.clear();
     free(h_lwe_indexes_in);
@@ -1221,7 +1238,8 @@ public:
     h_lwe_indexes_out = nullptr;
 
     if (active_streams.count() > 1) {
-      active_streams.synchronize();
+      if (gpu_memory_allocated)
+        active_streams.synchronize();
       event_pool.release();
       multi_gpu_gather_barrier.release();
       multi_gpu_broadcast_barrier.release();
@@ -1379,7 +1397,9 @@ template <typename Torus> struct int_bit_extract_luts_buffer {
         active_streams, num_radix_blocks * bits_per_block, size_tracker,
         allocate_gpu_memory);
 
-    cuda_synchronize_stream(streams.stream(0), streams.gpu_index(0));
+    // set_lwe_indexes copies both arrays into the LUT's own persistent host
+    // buffers and uploads from those, so these temporaries have no in-flight
+    // reader and can be freed without synchronizing.
     free(h_lwe_indexes_in);
     free(h_lwe_indexes_out);
   }
@@ -1490,6 +1510,17 @@ template <typename Torus> struct int_sum_ciphertexts_vec_memory {
 
   // lookup table for extracting message and carry
   int_radix_lut<Torus> *luts_message_carry;
+  /// @brief Dry-run LUT used to report the memory luts_message_carry will need.
+  ///
+  /// Built with allocate_gpu_memory == false. Owns host memory only.
+  int_radix_lut<Torus> *luts_message_carry_size_probe = nullptr;
+
+  /// @brief Host staging area for device pointer tables uploaded by
+  /// setup_index_buffers.
+  ///
+  /// One contiguous slot of num_blocks_in_radix entries per table. Kept alive
+  /// until release() because the uploads are asynchronous.
+  uint32_t **h_columns_staging = nullptr;
 
   bool mem_reuse = false;
   bool allocated_luts_message_carry;
@@ -1502,10 +1533,11 @@ template <typename Torus> struct int_sum_ciphertexts_vec_memory {
 
     auto num_blocks_in_radix = this->num_blocks_in_radix;
     auto max_num_radix_in_vec = this->max_num_radix_in_vec;
+    h_columns_staging = new uint32_t *[2 * num_blocks_in_radix];
     auto setup_columns = [num_blocks_in_radix, max_num_radix_in_vec, streams](
                              uint32_t **&columns, uint32_t *&columns_data,
                              uint32_t *&columns_counter, uint64_t &size_tracker,
-                             bool gpu_memory_allocated) {
+                             bool gpu_memory_allocated, uint32_t **h_columns) {
       columns_data = (uint32_t *)cuda_malloc_with_size_tracking_async(
           safe_mul_sizeof<uint32_t>((size_t)num_blocks_in_radix,
                                     (size_t)max_num_radix_in_vec),
@@ -1517,7 +1549,6 @@ template <typename Torus> struct int_sum_ciphertexts_vec_memory {
       cuda_memset_with_size_tracking_async(
           columns_counter, 0, safe_mul_sizeof<uint32_t>(num_blocks_in_radix),
           streams.stream(0), streams.gpu_index(0), gpu_memory_allocated);
-      uint32_t **h_columns = new uint32_t *[num_blocks_in_radix];
       for (int i = 0; i < num_blocks_in_radix; ++i) {
         h_columns[i] = columns_data + i * max_num_radix_in_vec;
       }
@@ -1530,14 +1561,13 @@ template <typename Torus> struct int_sum_ciphertexts_vec_memory {
             safe_mul_sizeof<uint32_t *>(num_blocks_in_radix), streams.stream(0),
             streams.gpu_index(0));
       }
-      cuda_synchronize_stream(streams.stream(0), streams.gpu_index(0));
-      delete[] h_columns;
     };
 
     setup_columns(d_columns, d_columns_data, d_columns_counter, size_tracker,
-                  gpu_memory_allocated);
+                  gpu_memory_allocated, h_columns_staging);
     setup_columns(d_new_columns, d_new_columns_data, d_new_columns_counter,
-                  size_tracker, gpu_memory_allocated);
+                  size_tracker, gpu_memory_allocated,
+                  h_columns_staging + num_blocks_in_radix);
   }
 
   void setup_lookup_tables(CudaStreams streams, uint32_t num_radix_in_vec,
@@ -1555,24 +1585,42 @@ template <typename Torus> struct int_sum_ciphertexts_vec_memory {
     if (!mem_reuse) {
       if (total_ciphertexts > 0 ||
           reduce_degrees_for_single_carry_propagation) {
-        uint64_t size_tracker = 0;
-        allocated_luts_message_carry = true;
-        luts_message_carry = new int_radix_lut<Torus>(
-            streams, params, 2, pbs_count, true, size_tracker);
+        // This method runs once per operation, and pbs_count depends on the
+        // input degrees. An instance built for at least pbs_count blocks is
+        // reused as is, since the callers index it with the actual ciphertext
+        // count (see the assertion in
+        // host_integer_partial_sum_ciphertexts_vec_async). Only a larger
+        // request rebuilds it, and the previous instance is released first so
+        // that repeated operations do not leak it.
+        if (allocated_luts_message_carry &&
+            luts_message_carry->num_blocks < pbs_count) {
+          luts_message_carry->release(streams);
+          delete luts_message_carry;
+          luts_message_carry = nullptr;
+          allocated_luts_message_carry = false;
+        }
 
-        uint64_t message_modulus_bits =
-            (uint64_t)std::log2(params.message_modulus);
-        uint64_t carry_modulus_bits = (uint64_t)std::log2(params.carry_modulus);
-        uint64_t total_bits_per_block =
-            message_modulus_bits + carry_modulus_bits;
-        uint64_t denominator =
-            (uint64_t)std::ceil((pow(2, total_bits_per_block) - 1) /
-                                (pow(2, message_modulus_bits) - 1));
+        if (!allocated_luts_message_carry) {
+          uint64_t size_tracker = 0;
+          allocated_luts_message_carry = true;
+          luts_message_carry = new int_radix_lut<Torus>(
+              streams, params, 2, pbs_count, true, size_tracker);
 
-        uint64_t upper_bound_num_blocks =
-            max_total_blocks_in_vec * 2 / denominator;
-        luts_message_carry->allocate_lwe_vector_for_non_trivial_indexes(
-            streams, upper_bound_num_blocks, size_tracker, true);
+          uint64_t message_modulus_bits =
+              (uint64_t)std::log2(params.message_modulus);
+          uint64_t carry_modulus_bits =
+              (uint64_t)std::log2(params.carry_modulus);
+          uint64_t total_bits_per_block =
+              message_modulus_bits + carry_modulus_bits;
+          uint64_t denominator =
+              (uint64_t)std::ceil((pow(2, total_bits_per_block) - 1) /
+                                  (pow(2, message_modulus_bits) - 1));
+
+          uint64_t upper_bound_num_blocks =
+              max_total_blocks_in_vec * 2 / denominator;
+          luts_message_carry->allocate_lwe_vector_for_non_trivial_indexes(
+              streams, upper_bound_num_blocks, size_tracker, true);
+        }
       }
     }
 
@@ -1614,11 +1662,14 @@ template <typename Torus> struct int_sum_ciphertexts_vec_memory {
     uint32_t max_pbs_count = std::max(
         2 * (max_total_blocks_in_vec / chunk_size), 2 * num_blocks_in_radix);
     if (max_pbs_count > 0) {
-      int_radix_lut<Torus> *luts_message_carry_dry_run =
-          new int_radix_lut<Torus>(streams, params, 2, max_pbs_count, false,
-                                   size_tracker);
-      luts_message_carry_dry_run->release(streams);
-      delete luts_message_carry_dry_run;
+      // This probe allocates no device memory, it only reports through
+      // size_tracker what luts_message_carry will take when
+      // setup_lookup_tables builds it at operation time. It is released from
+      // release() and not here: int_radix_lut::release() waits for the
+      // asynchronous uploads of a real LUT, and calling it from a constructor
+      // would make every scratch function reaching this code synchronize.
+      luts_message_carry_size_probe = new int_radix_lut<Torus>(
+          streams, params, 2, max_pbs_count, false, size_tracker);
     }
 
     // create and allocate intermediate buffers
@@ -1706,7 +1757,14 @@ template <typename Torus> struct int_sum_ciphertexts_vec_memory {
       delete current_blocks;
       delete small_lwe_vector;
     }
+    if (luts_message_carry_size_probe != nullptr) {
+      luts_message_carry_size_probe->release(streams);
+      delete luts_message_carry_size_probe;
+      luts_message_carry_size_probe = nullptr;
+    }
     cuda_synchronize_stream(streams.stream(0), streams.gpu_index(0));
+    delete[] h_columns_staging;
+    h_columns_staging = nullptr;
   }
 };
 
@@ -1717,6 +1775,10 @@ template <typename Torus> struct int_seq_group_prop_memory {
   int_radix_lut<Torus> *lut_sequential_algorithm;
   uint32_t grouping_size;
   bool gpu_memory_allocated;
+  /// @brief Host staging area for the LUT indexes uploaded in the constructor.
+  ///
+  /// The upload is asynchronous, so the buffer is freed in release().
+  Torus *h_seq_lut_indexes = nullptr;
 
   int_seq_group_prop_memory(CudaStreams streams, int_radix_params params,
                             uint32_t group_size, uint32_t big_lwe_size_bytes,
@@ -1735,8 +1797,7 @@ template <typename Torus> struct int_seq_group_prop_memory {
                                  allocate_gpu_memory, size_tracker);
     std::vector<std::function<Torus(Torus)>> lut_funcs;
     std::vector<uint32_t> lut_indices;
-    Torus *h_seq_lut_indexes =
-        (Torus *)malloc(safe_mul_sizeof<Torus>(num_seq_luts));
+    h_seq_lut_indexes = (Torus *)malloc(safe_mul_sizeof<Torus>(num_seq_luts));
 
     for (int index = 0; index < num_seq_luts; index++) {
       auto f_lut_sequential = [index](Torus propa_cum_sum_block) {
@@ -1754,9 +1815,6 @@ template <typename Torus> struct int_seq_group_prop_memory {
     lut_sequential_algorithm->generate_and_broadcast_lut(
         active_streams, lut_indices, lut_funcs, lut_index_generator, true, {},
         h_seq_lut_indexes);
-
-    cuda_synchronize_stream(streams.stream(0), streams.gpu_index(0));
-    free(h_seq_lut_indexes);
   }
 
   void release(CudaStreams streams) {
@@ -1767,6 +1825,8 @@ template <typename Torus> struct int_seq_group_prop_memory {
     delete group_resolved_carries;
     delete lut_sequential_algorithm;
     cuda_synchronize_stream(streams.stream(0), streams.gpu_index(0));
+    free(h_seq_lut_indexes);
+    h_seq_lut_indexes = nullptr;
   };
 };
 
@@ -1985,6 +2045,11 @@ template <typename Torus> struct int_prop_simu_group_carries_memory {
 
   Torus *scalar_array_cum_sum;
   Torus *h_scalar_array_cum_sum;
+  /// @brief Host staging area for the second step LUT indexes uploaded in the
+  /// constructor.
+  ///
+  /// The upload is asynchronous, so the buffer is freed in release().
+  Torus *h_second_lut_indexes = nullptr;
 
   int_radix_lut<Torus> *luts_array_second_step;
 
@@ -2201,7 +2266,7 @@ template <typename Torus> struct int_prop_simu_group_carries_memory {
       lut_ids.push_back(lut_id);
     }
 
-    Torus *h_second_lut_indexes = (Torus *)malloc(lut_indexes_size);
+    h_second_lut_indexes = (Torus *)malloc(lut_indexes_size);
 
     luts_array_second_step->generate_and_broadcast_lut(
         active_streams, lut_ids, lut_funcs, second_step_lut_index_generator,
@@ -2218,9 +2283,6 @@ template <typename Torus> struct int_prop_simu_group_carries_memory {
           streams, params, num_groups, big_lwe_size_bytes, allocate_gpu_memory,
           size_tracker);
     }
-
-    cuda_synchronize_stream(streams.stream(0), streams.gpu_index(0));
-    free(h_second_lut_indexes);
   };
 
   // needed for the division to update the lut indexes
@@ -2271,8 +2333,13 @@ template <typename Torus> struct int_prop_simu_group_carries_memory {
     delete prepared_blocks;
     delete resolved_carries;
     delete luts_array_second_step;
-    delete[] h_scalar_array_cum_sum;
     cuda_synchronize_stream(streams.stream(0), streams.gpu_index(0));
+    // Both host buffers were uploaded asynchronously, so they are freed only
+    // after the synchronization above.
+    delete[] h_scalar_array_cum_sum;
+    h_scalar_array_cum_sum = nullptr;
+    free(h_second_lut_indexes);
+    h_second_lut_indexes = nullptr;
   };
 };
 

--- a/backends/tfhe-cuda-backend/cuda/include/integer/kv_store/kv_store_utilities.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer/kv_store/kv_store_utilities.h
@@ -55,6 +55,12 @@ template <typename Torus> struct int_kv_store_eq_selectors_small_map_buffer {
   uint32_t num_tree_levels;
   /// Device LUT-index arrays, one per tree level
   Torus **d_level_lut_indexes;
+  /// @brief Host staging area for the per-level LUT-index arrays.
+  ///
+  /// One slot of acc_blocks entries per tree level. Each level needs its own
+  /// slot because the uploads are asynchronous. Freed in release() after
+  /// synchronization.
+  Torus *h_level_lut_indexes = nullptr;
 
   /// @brief Allocates GPU buffers for the small-map equality-selector
   /// algorithm.
@@ -184,11 +190,12 @@ template <typename Torus> struct int_kv_store_eq_selectors_small_map_buffer {
       // each entry uses the level-specific slot when its length differs from
       // max_value; all other blocks use slot 0.
       this->d_level_lut_indexes = new Torus *[this->num_tree_levels];
-      Torus *h_level_indexes = new Torus[acc_blocks];
+      this->h_level_lut_indexes = new Torus[this->num_tree_levels * acc_blocks];
       for (uint32_t L = 0; L < this->num_tree_levels; L++) {
         uint32_t num_chunks = level_num_chunks[L];
         uint32_t total_chunks = num_possible_values * num_chunks;
         bool special = (level_last_chunk_length[L] != max_value);
+        Torus *h_level_indexes = &this->h_level_lut_indexes[L * acc_blocks];
         for (uint32_t idx = 0; idx < acc_blocks; idx++) {
           if (special && idx < total_chunks &&
               (idx % num_chunks) == num_chunks - 1) {
@@ -208,8 +215,6 @@ template <typename Torus> struct int_kv_store_eq_selectors_small_map_buffer {
                                    streams.stream(0), streams.gpu_index(0));
         }
       }
-      cuda_synchronize_stream(streams.stream(0), streams.gpu_index(0));
-      delete[] h_level_indexes;
     }
   }
 
@@ -247,6 +252,8 @@ template <typename Torus> struct int_kv_store_eq_selectors_small_map_buffer {
     if (this->tree_accumulator != nullptr) {
       delete this->tree_accumulator;
       delete this->tree_pbs_output;
+      delete[] this->h_level_lut_indexes;
+      this->h_level_lut_indexes = nullptr;
     }
     delete[] this->h_map;
   }

--- a/backends/tfhe-cuda-backend/cuda/include/integer/oprf.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer/oprf.h
@@ -15,6 +15,11 @@ template <typename Torus> struct int_grouped_oprf_memory {
   int_radix_lut<Torus> *luts;
   CudaRadixCiphertextFFI *plaintext_corrections;
   Torus *h_lut_indexes;
+  /// @brief Host staging area for the plaintext corrections uploaded in the
+  /// constructor.
+  ///
+  /// The upload is asynchronous, so the buffer is freed in release().
+  Torus *h_corrections = nullptr;
 
   int_grouped_oprf_memory(CudaStreams streams, int_radix_params params,
                           uint32_t num_blocks_to_process,
@@ -87,7 +92,7 @@ template <typename Torus> struct int_grouped_oprf_memory {
     // (handling both bounded and unbounded cases), which pre-computed LUT to
     // use, and the final plaintext correction to add.
     //
-    Torus *h_corrections = (Torus *)calloc(
+    this->h_corrections = (Torus *)calloc(
         1, safe_mul_sizeof<Torus>(num_blocks_to_process, lwe_size));
     this->h_lut_indexes =
         (Torus *)calloc(1, safe_mul_sizeof<Torus>(num_blocks_to_process));
@@ -151,9 +156,6 @@ template <typename Torus> struct int_grouped_oprf_memory {
     for (uint32_t i = 0; i < lut_degrees.size(); ++i) {
       *luts->get_degree(i) = lut_degrees[i];
     }
-
-    cuda_synchronize_stream(streams.stream(0), streams.gpu_index(0));
-    free(h_corrections);
   }
 
   void release(CudaStreams streams) {
@@ -170,6 +172,8 @@ template <typename Torus> struct int_grouped_oprf_memory {
     cuda_synchronize_stream(streams.stream(0), streams.gpu_index(0));
     free(this->h_lut_indexes);
     this->h_lut_indexes = nullptr;
+    free(this->h_corrections);
+    this->h_corrections = nullptr;
   }
 };
 

--- a/backends/tfhe-cuda-backend/cuda/include/integer/rerand_utilities.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer/rerand_utilities.h
@@ -20,6 +20,11 @@ template <typename Torus> struct int_rerand_mem {
 
   expand_job<Torus> *d_expand_jobs = nullptr;
   expand_job<Torus> *h_expand_jobs = nullptr;
+  /// @brief Host staging area for the trivial indexes uploaded in the
+  /// constructor on the RERAND_WITH_KS path.
+  ///
+  /// The upload is asynchronous, so the buffer is freed in release().
+  Torus *h_lwe_trivial_indexes = nullptr;
 
   int_rerand_mem(CudaStreams streams, int_radix_params params,
                  const uint32_t num_lwes, const RERAND_MODE rerand_mode,
@@ -50,7 +55,7 @@ template <typename Torus> struct int_rerand_mem {
               streams.stream(0), streams.gpu_index(0), size_tracker,
               allocate_gpu_memory));
 
-      auto h_lwe_trivial_indexes =
+      h_lwe_trivial_indexes =
           static_cast<Torus *>(malloc(safe_mul_sizeof<Torus>(num_lwes)));
       PANIC_IF_FALSE(h_lwe_trivial_indexes != nullptr,
                      "host allocation failed for h_lwe_trivial_indexes");
@@ -65,10 +70,6 @@ template <typename Torus> struct int_rerand_mem {
           lwe_trivial_indexes, h_lwe_trivial_indexes,
           safe_mul_sizeof<Torus>(num_lwes), streams.stream(0),
           streams.gpu_index(0), allocate_gpu_memory);
-      cuda_synchronize_stream(streams.stream(0), streams.gpu_index(0));
-      free(h_lwe_trivial_indexes);
-    } else {
-      cuda_synchronize_stream(streams.stream(0), streams.gpu_index(0));
     }
   }
 
@@ -96,5 +97,7 @@ template <typename Torus> struct int_rerand_mem {
     cuda_synchronize_stream(streams.stream(0), streams.gpu_index(0));
     free(h_expand_jobs);
     h_expand_jobs = nullptr;
+    free(h_lwe_trivial_indexes);
+    h_lwe_trivial_indexes = nullptr;
   }
 };

--- a/backends/tfhe-cuda-backend/cuda/include/zk/zk_utilities.h
+++ b/backends/tfhe-cuda-backend/cuda/include/zk/zk_utilities.h
@@ -116,6 +116,9 @@ template <typename Torus> struct zk_expand_mem {
   uint32_t *num_lwes_per_compact_list;
   expand_job<Torus> *d_expand_jobs;
   expand_job<Torus> *h_expand_jobs;
+  // Host staging area for the LUT indexes uploaded in the constructor. The
+  // upload is asynchronous, so the buffer is freed in release().
+  Torus *h_lut_indexes_staging = nullptr;
 
   EXPAND_KIND expand_kind;
 
@@ -277,7 +280,7 @@ template <typename Torus> struct zk_expand_mem {
           return sanitize_bool_f(carry_extract_lut_f(x));
         };
 
-        auto h_lut_indexes = static_cast<Torus *>(
+        h_lut_indexes_staging = static_cast<Torus *>(
             malloc(safe_mul_sizeof<Torus>(num_packed_msgs, num_lwes)));
 
         auto index_gen = [num_compact_lists,
@@ -304,12 +307,11 @@ template <typename Torus> struct zk_expand_mem {
             {message_extract_lut_f, carry_extract_lut_f,
              message_extract_and_sanitize_bool_lut_f,
              carry_extract_and_sanitize_bool_lut_f},
-            index_gen, true, {}, h_lut_indexes);
+            index_gen, true, {}, h_lut_indexes_staging);
         message_and_carry_extract_luts
             ->allocate_lwe_vector_for_non_trivial_indexes(
                 active_streams, 2 * num_lwes, size_tracker,
                 allocate_gpu_memory);
-        free(h_lut_indexes);
 
         // SANITY_CHECK panics on SMALL_TO_BIG, so this buffer is only needed
         // on the full casting path.
@@ -328,11 +330,12 @@ template <typename Torus> struct zk_expand_mem {
           streams.stream(0), streams.gpu_index(0), size_tracker,
           allocate_gpu_memory);
 
+      // set_lwe_indexes copies both arrays into the LUT's own persistent host
+      // buffers and uploads from those, so these temporaries have no in-flight
+      // reader and can be freed without synchronizing.
       free(h_indexes_in);
       free(h_indexes_out);
     }
-
-    cuda_synchronize_stream(streams.stream(0), streams.gpu_index(0));
   }
 
   void release(CudaStreams streams) {
@@ -358,6 +361,8 @@ template <typename Torus> struct zk_expand_mem {
     cuda_synchronize_stream(streams.stream(0), streams.gpu_index(0));
     free(num_lwes_per_compact_list);
     free(h_expand_jobs);
+    free(h_lut_indexes_staging);
+    h_lut_indexes_staging = nullptr;
   }
 };
 

--- a/backends/tfhe-cuda-backend/cuda/src/integer/integer.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/integer.cuh
@@ -1513,6 +1513,7 @@ void generate_device_accumulator_bivariate_with_factor(
   cuda_synchronize_stream(stream, gpu_index);
   free(h_lut);
 }
+
 /*
  *  generate bivariate accumulator for device pointer
  *  using preallocated host lut to avoid blocking the cpu thread

--- a/scripts/check_scratch_cleanup.py
+++ b/scripts/check_scratch_cleanup.py
@@ -16,18 +16,29 @@ Checks performed:
      their own name, call .synchronize(), or call a cleanup_ binding.
   6. Rust functions calling cleanup_ bindings must NOT have _async in
      their own name (cleanup synchronizes, so the caller is synchronous).
+  7. No scratch_cuda_* function reaches a host synchronization, directly
+     or through any function, constructor, member-initializer list or
+     method call below it, unless the entry point is listed in
+     CHECK7_SYNC_WHITELIST below.  (Implemented in check_scratch_sync.py.)
 """
 
 import os
 import re
 import subprocess
 import sys
+from collections import defaultdict
 
 import tree_sitter as ts
 import tree_sitter_rust as tsrust
 
 RUST_LANG = ts.Language(tsrust.language())
 RUST_PARSER = ts.Parser(RUST_LANG)
+
+from check_scratch_sync import (
+    SYNC_WALK_CPP_DIRS,
+    check_7_scratch_reaches_no_sync,
+    find_cpp_function_body,
+)
 
 BINDINGS_RS = "backends/tfhe-cuda-backend/src/bindings.rs"
 
@@ -78,6 +89,105 @@ EXPECTED_CHECK5_ASYNC_CALLERS = 133
 # Check 6: Rust cleanup-caller scanning
 EXPECTED_CHECK6_CLEANUP_CALLERS = 120
 
+# Check 7: transitive walk from scratch entry points to a host sync
+# Scratch entry points from bindings.rs that have a C++ definition
+EXPECTED_CHECK7_SCRATCH_ENTRY_POINTS = 80
+
+# Check 7 walks the C++ call graph downwards from each scratch_cuda_* entry
+# point and fails when the walk meets a host synchronization
+# (SYNC_SITE_NAMES in check_scratch_sync.py: cuda_synchronize_stream,
+# cudaMemcpy, cudaMalloc, ...).
+#
+# The whitelist below names the top-level scratch entry points that are known
+# to synchronize.  Their chains are still walked, but not counted as
+# violations, and an entry that does not reach a synchronization is reported
+# so it gets removed.  The whitelist deliberately holds entry points
+# and never the subfunction that synchronizes: skipping a subfunction would
+# hide the synchronization and let every scratch function above it pass as
+# asynchronous.
+#
+# Every entry below synchronizes for the same reason.  The buffer it builds
+# generates at least one LUT through the generate_device_accumulator*
+# primitives, which allocate a host buffer, upload it, synchronize, then free
+# it.  That synchronization cannot be removed yet: some host_* functions
+# regenerate a LUT into the same int_radix_lut on every call
+# (are_all_comparisons_block_true, tree_sign_reduction,
+# integer_radix_unsigned_scalar_difference_check,
+# integer_radix_signed_scalar_difference_check, reduce_signs, and
+# setup_lookup_tables called from host_integer_partial_sum_ciphertexts_vec),
+# and an asynchronous upload from a reused host buffer would race with the
+# next regeneration.  The fix, tracked in tfhe-rs-internal#1557, is to
+# generate every LUT variant in scratch and select among them in the host
+# function; each entry point leaves this list once its LUT generation no
+# longer synchronizes.
+CHECK7_SYNC_WHITELIST = frozenset({
+    "scratch_cuda_add_and_propagate_single_carry_64_inplace_async",
+    "scratch_cuda_apply_noise_squashing_async",
+    "scratch_cuda_arithmetic_scalar_shift_64_inplace_async",
+    "scratch_cuda_boolean_bitnot_64_async",
+    "scratch_cuda_boolean_bitop_inplace_64_async",
+    "scratch_cuda_cast_to_signed_64_async",
+    "scratch_cuda_cast_to_unsigned_64_async",
+    "scratch_cuda_cmux_64_async",
+    "scratch_cuda_expand_without_verification_64_async",
+    "scratch_cuda_fast_kreyvium_init_async",
+    "scratch_cuda_fast_kreyvium_step_async",
+    "scratch_cuda_full_propagation_64_inplace_async",
+    "scratch_cuda_integer_abs_inplace_64_async",
+    "scratch_cuda_integer_aes_ctr_256_encrypt_64_async",
+    "scratch_cuda_integer_aes_ctr_encrypt_64_async",
+    "scratch_cuda_integer_are_all_comparisons_block_true_64_async",
+    "scratch_cuda_integer_bitonic_shuffle_64_async",
+    "scratch_cuda_integer_bitop_inplace_64_async",
+    "scratch_cuda_integer_comparison_64_async",
+    "scratch_cuda_integer_count_of_consecutive_bits_64_async",
+    "scratch_cuda_integer_decompress_radix_ciphertext_128_async",
+    "scratch_cuda_integer_decompress_radix_ciphertext_64_async",
+    "scratch_cuda_integer_div_rem_64_async",
+    "scratch_cuda_integer_grouped_oprf_64_async",
+    "scratch_cuda_integer_grouped_oprf_custom_range_64_async",
+    "scratch_cuda_integer_ilog2_64_async",
+    "scratch_cuda_integer_is_at_least_one_comparisons_block_true_64_async",
+    "scratch_cuda_integer_key_expansion_256_64_async",
+    "scratch_cuda_integer_key_expansion_64_async",
+    "scratch_cuda_integer_mult_inplace_64_async",
+    "scratch_cuda_integer_oprf_bitonic_shuffle_64_async",
+    "scratch_cuda_integer_overflowing_sub_64_inplace_async",
+    "scratch_cuda_integer_scalar_bitop_inplace_64_async",
+    "scratch_cuda_integer_scalar_comparison_64_async",
+    "scratch_cuda_integer_scalar_mul_64_async",
+    "scratch_cuda_integer_signed_scalar_div_radix_64_async",
+    "scratch_cuda_integer_signed_scalar_div_rem_radix_64_async",
+    "scratch_cuda_integer_unsigned_scalar_div_radix_64_async",
+    "scratch_cuda_integer_unsigned_scalar_div_rem_radix_64_async",
+    "scratch_cuda_kreyvium_init_async",
+    "scratch_cuda_kreyvium_step_async",
+    "scratch_cuda_kv_store_contains_key_64_async",
+    "scratch_cuda_kv_store_get_64_async",
+    "scratch_cuda_kv_store_map_64_async",
+    "scratch_cuda_kv_store_update_64_async",
+    "scratch_cuda_logical_scalar_shift_64_inplace_async",
+    "scratch_cuda_propagate_single_carry_64_inplace_async",
+    "scratch_cuda_scalar_rotate_64_inplace_async",
+    "scratch_cuda_shift_and_rotate_64_inplace_async",
+    "scratch_cuda_sub_and_propagate_single_carry_64_inplace_async",
+    "scratch_cuda_trivium_init_async",
+    "scratch_cuda_trivium_step_async",
+    "scratch_cuda_unchecked_all_eq_slices_64_async",
+    "scratch_cuda_unchecked_contains_64_async",
+    "scratch_cuda_unchecked_contains_clear_64_async",
+    "scratch_cuda_unchecked_contains_sub_slice_64_async",
+    "scratch_cuda_unchecked_first_index_in_clears_64_async",
+    "scratch_cuda_unchecked_first_index_of_64_async",
+    "scratch_cuda_unchecked_first_index_of_clear_64_async",
+    "scratch_cuda_unchecked_index_in_clears_64_async",
+    "scratch_cuda_unchecked_index_of_64_async",
+    "scratch_cuda_unchecked_index_of_clear_64_async",
+    "scratch_cuda_unchecked_is_in_clears_64_async",
+    "scratch_cuda_unchecked_match_value_64_async",
+    "scratch_cuda_unchecked_match_value_or_64_async",
+})
+
 
 def check_paths_exist():
     """Verify that all input files and directories exist.
@@ -93,13 +203,13 @@ def check_paths_exist():
                 f"corresponding path\n"
                 f"    at the top of {os.path.basename(__file__)}."
             )
-    for d in CPP_DIRS:
+    for d in SYNC_WALK_CPP_DIRS:
         if not os.path.isdir(d):
             errors.append(
                 f"  Directory not found: {d}\n"
                 f"    If this directory was renamed or moved, update "
-                f"CPP_DIRS\n"
-                f"    at the top of {os.path.basename(__file__)}."
+                f"CPP_DIRS in {os.path.basename(__file__)} or "
+                f"SYNC_WALK_CPP_DIRS in check_scratch_sync.py."
             )
     return errors
 
@@ -507,72 +617,6 @@ def collect_cpp_files(dirs):
     return sorted(files)
 
 
-def find_cpp_function_body(func_name, content):
-    """Find a C++ function definition body in content.
-
-    Returns the body text (between { and }) if a definition is found,
-    None if only declarations/calls are found.
-    """
-    pos = 0
-    while pos < len(content):
-        idx = content.find(func_name, pos)
-        if idx == -1:
-            return None
-
-        # Verify whole-word match
-        if idx > 0 and (content[idx - 1].isalnum() or content[idx - 1] == "_"):
-            pos = idx + 1
-            continue
-        end_name = idx + len(func_name)
-        if end_name < len(content) and (
-            content[end_name].isalnum() or content[end_name] == "_"
-        ):
-            pos = idx + 1
-            continue
-
-        # Must be followed by '('
-        after = content[end_name:].lstrip()
-        if not after.startswith("("):
-            pos = idx + 1
-            continue
-
-        # Find matching ')'
-        paren_start = content.index("(", end_name)
-        paren_depth = 0
-        j = paren_start
-        while j < len(content):
-            if content[j] == "(":
-                paren_depth += 1
-            elif content[j] == ")":
-                paren_depth -= 1
-                if paren_depth == 0:
-                    break
-            j += 1
-
-        # After ')', check for '{' (definition) vs ';' (declaration/call)
-        rest = content[j + 1 : j + 100].lstrip()
-        if not rest.startswith("{"):
-            pos = j + 1
-            continue
-
-        # Extract body using brace counting
-        brace_start = content.index("{", j + 1)
-        brace_depth = 0
-        k = brace_start
-        while k < len(content):
-            if content[k] == "{":
-                brace_depth += 1
-            elif content[k] == "}":
-                brace_depth -= 1
-                if brace_depth == 0:
-                    return content[brace_start : k + 1]
-            k += 1
-
-        pos = idx + 1
-
-    return None
-
-
 def strip_comments(text):
     """Remove C/C++/Rust comments from text.
 
@@ -873,6 +917,45 @@ def main():
                 "cleanup callers", "EXPECTED_CHECK6_CLEANUP_CALLERS",
                 EXPECTED_CHECK6_CLEANUP_CALLERS, n_checked6,
             )
+        )
+
+    # Check 7
+    print(
+        "\nCheck 7: scratch functions do not reach a host "
+        "synchronization..."
+    )
+    v, n_entry7, n_reaching7, n_whitelisted7, n_defs7, sync_sites = (
+        check_7_scratch_reaches_no_sync(scratch_set, CHECK7_SYNC_WHITELIST)
+    )
+    all_violations.extend(v)
+    print(
+        f"  Walked {n_entry7} scratch entry points over "
+        f"{n_defs7} C++ definitions"
+    )
+    if n_reaching7:
+        print(
+            f"  {n_reaching7} of {n_entry7} reach a host synchronization, "
+            f"{n_whitelisted7} of them whitelisted"
+        )
+        # Only the nearest synchronization is reported as a chain per entry
+        # point, so list every reachable site: removing one uncovers the next.
+        print(f"  {len(sync_sites)} synchronization site(s) to remove:")
+        for count, sync_name, path, line in sync_sites:
+            print(f"    {count:3d} entry point(s)  {sync_name}  {path}:{line}")
+    print(f"  {'PASS' if not v else f'{len(v)} violation(s)'}")
+
+    # Validate Check 7 entry-point count
+    if n_entry7 != EXPECTED_CHECK7_SCRATCH_ENTRY_POINTS:
+        all_violations.append(
+            f"\n  *** SCRATCH ENTRY POINT COUNT CHANGED ***\n"
+            f"  Expected {EXPECTED_CHECK7_SCRATCH_ENTRY_POINTS} scratch "
+            f"entry points with a C++ definition, walked {n_entry7}.\n"
+            f"  Either a scratch binding was added or removed, or a C++\n"
+            f"  definition moved out of "
+            f"{', '.join(SYNC_WALK_CPP_DIRS)}.\n"
+            f"  If this is not a mistake, update "
+            f"EXPECTED_CHECK7_SCRATCH_ENTRY_POINTS to {n_entry7}\n"
+            f"  in {os.path.basename(__file__)}."
         )
 
     if all_violations:

--- a/scripts/check_scratch_sync.py
+++ b/scripts/check_scratch_sync.py
@@ -1,0 +1,803 @@
+"""Transitive reachability check: scratch entry points to host synchronizations.
+
+Provides two public entry points:
+
+  find_cpp_function_body(func_name, content)
+      Tree-sitter-cpp based lookup of a C++ function body by name.
+      Used by Check 4 in check_scratch_cleanup.py.
+
+  check_7_scratch_reaches_no_sync(scratch_set, sync_whitelist)
+      Walks the call graph from every scratch_cuda_* symbol in bindings.rs
+      and reports any path that reaches a host synchronization, unless the
+      entry point is named in sync_whitelist (CHECK7_SYNC_WHITELIST in
+      check_scratch_cleanup.py).  A whitelisted name that does not reach a
+      synchronization is reported too, so the whitelist cannot go stale.
+
+To disable Check 7 without touching checks 1-6, remove its call from
+check_scratch_cleanup.py.  If the tree-sitter-cpp dependency becomes
+unmaintainable, revert find_cpp_function_body to the text-based version
+in check_scratch_cleanup.py and delete this file.
+"""
+
+import os
+import re
+from collections import defaultdict, deque
+
+import tree_sitter as ts
+import tree_sitter_cpp as tscpp
+
+# ---------------------------------------------------------------------------
+# Tree-sitter C++ setup
+# ---------------------------------------------------------------------------
+
+CPP_LANG = ts.Language(tscpp.language())
+CPP_PARSER = ts.Parser(CPP_LANG)
+
+CPP_EXTENSIONS = {".cu", ".cuh", ".h", ".cpp"}
+
+# Check 7 walks the shared CUDA runtime wrappers in addition to the backend
+# directories.  Scratch paths call cuda_memcpy_with_size_tracking_async_to_gpu
+# and friends there, each of which calls cuda_set_device.
+SYNC_WALK_CPP_DIRS = [
+    "backends/tfhe-cuda-backend/cuda/src",
+    "backends/tfhe-cuda-backend/cuda/include",
+    "backends/tfhe-cuda-common/cuda/src",
+    "backends/tfhe-cuda-common/cuda/include",
+]
+
+# ---------------------------------------------------------------------------
+# CUDA attribute stripping
+#
+# tree-sitter-cpp does not understand __device__, __host__, etc.  Replacing
+# them with whitespace (same length to preserve byte offsets) lets it parse
+# the file as standard C++.
+# ---------------------------------------------------------------------------
+
+_CUDA_ATTR_RE = re.compile(
+    r"\b(?:__device__|__host__|__global__|__forceinline__|__noinline__)\b"
+    r"|__launch_bounds__\s*\([^)]*\)"
+)
+
+
+def _strip_cuda_attrs(source_bytes):
+    """Replace CUDA function attributes with equal-length spaces."""
+    text = source_bytes.decode("utf-8", errors="replace")
+    text = _CUDA_ATTR_RE.sub(lambda m: " " * len(m.group(0)), text)
+    return text.encode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Generic AST helpers
+# ---------------------------------------------------------------------------
+
+def find_all_nodes(root, node_types):
+    """Yield every descendant whose type is in node_types (including ERROR children)."""
+    stack = [root]
+    while stack:
+        node = stack.pop()
+        if node.type in node_types:
+            yield node
+        stack.extend(reversed(node.children))
+
+
+def _func_decl_name(declarator):
+    """Extract the plain function name from a function_declarator AST node.
+
+    Unwraps pointer/reference declarators, template wrappers, qualified
+    identifiers and destructor names.
+    """
+    while declarator.type in ("pointer_declarator", "reference_declarator"):
+        inner = next(
+            (c for c in declarator.children
+             if c.type in ("function_declarator", "pointer_declarator",
+                           "reference_declarator")),
+            None,
+        )
+        if inner is None:
+            return None
+        declarator = inner
+
+    if declarator.type != "function_declarator":
+        return None
+
+    for child in declarator.children:
+        if child.type in ("identifier", "field_identifier"):
+            return child.text.decode("utf-8")
+        if child.type == "destructor_name":
+            return child.text.decode("utf-8")
+        if child.type == "template_function":
+            for tc in child.children:
+                if tc.type in ("identifier", "field_identifier"):
+                    return tc.text.decode("utf-8")
+        if child.type == "qualified_identifier":
+            last_id = None
+            for qc in child.children:
+                if qc.type in ("identifier", "field_identifier",
+                                "destructor_name"):
+                    last_id = qc.text.decode("utf-8")
+            if last_id:
+                return last_id
+
+    return None
+
+
+def _enclosing_struct(node):
+    """Return the name of the nearest enclosing struct/class, or None."""
+    cur = node.parent
+    while cur:
+        if cur.type in ("struct_specifier", "class_specifier"):
+            for child in cur.children:
+                if child.type == "type_identifier":
+                    return child.text.decode("utf-8")
+                if child.type == "template_type":
+                    for tc in child.children:
+                        if tc.type == "type_identifier":
+                            return tc.text.decode("utf-8")
+        cur = cur.parent
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Public: find_cpp_function_body  (used by Check 4)
+# ---------------------------------------------------------------------------
+
+def find_cpp_function_body(func_name, content):
+    """Find a C++ function definition body using tree-sitter.
+
+    Returns the body text (between { and }) if found, None otherwise.
+    """
+    tree = CPP_PARSER.parse(_strip_cuda_attrs(content.encode("utf-8")))
+    for node in find_all_nodes(tree.root_node, {"function_definition"}):
+        declarator = node.child_by_field_name("declarator")
+        if declarator is None:
+            continue
+        if _func_decl_name(declarator) == func_name:
+            body = node.child_by_field_name("body")
+            if body:
+                return body.text.decode("utf-8")
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Check 7 constants
+# ---------------------------------------------------------------------------
+
+# Check 7 walks the call graph downwards from each scratch_cuda_* entry point
+# and compares every call it meets against two sets of function names:
+#
+#   SYNC_SITE_NAMES: what a host synchronization looks like.  Meeting one
+#     ends the walk and reports the chain that led to it.  The set is fixed,
+#     it describes the CUDA runtime.
+#
+#   SYNC_WALK_STOP_CALLS: runtime helpers the walker does not enter, because
+#     what they do is not the caller's decision (see each entry).  A
+#     SYNC_SITE_NAMES call inside them is therefore never seen.
+#
+# Any call in neither set is entered and walked further.
+#
+# Accepted exceptions are never expressed as skipped subfunctions: skipping
+# a subfunction would hide its synchronization and let every caller above
+# it pass as asynchronous.  Instead, CHECK7_SYNC_WHITELIST in
+# check_scratch_cleanup.py names the top-level scratch entry points that are
+# known to synchronize.  Their chains are still walked, but not counted as
+# violations.
+
+# Calls that block the host thread until the device catches up: the explicit
+# stream/device/event synchronizations, the CUDA runtime calls that are
+# implicitly synchronous (cudaMemcpy, cudaMemset, cudaMalloc, cudaFree and the
+# peer copy), and the backend wrappers around those runtime calls.
+SYNC_SITE_NAMES = frozenset({
+    "cuda_synchronize_stream",
+    "cuda_synchronize_device",
+    "synchronize",
+    "cudaStreamSynchronize",
+    "cudaDeviceSynchronize",
+    "cudaEventSynchronize",
+    "cudaMemcpy",
+    "cudaMemcpyPeer",
+    "cudaMemset",
+    "cudaMalloc",
+    "cudaFree",
+    "cuda_malloc",
+    "cuda_drop",
+    "cuda_memcpy_gpu_to_gpu",
+})
+
+# cuda_setup_mempool synchronizes once per process to grow the memory pool
+# (the source marks it as a deliberate exception).  Every cuda_set_device
+# reaches it.
+# cuda_malloc_with_size_tracking_async and cuda_drop_with_size_tracking_async
+# use cudaMallocAsync/cudaFreeAsync and fall back to the blocking variants
+# only on devices without memory-pool support.  This check tests what the
+# code asks for, not what a fallback device does.
+SYNC_WALK_STOP_CALLS = frozenset({
+    "cuda_setup_mempool",
+    "cuda_malloc_with_size_tracking_async",
+    "cuda_drop_with_size_tracking_async",
+})
+
+# Tokens that look like function calls but are not.
+_NON_CALL_WORDS = frozenset(
+    "if for while switch return sizeof catch else new delete do try throw "
+    "static_cast reinterpret_cast const_cast dynamic_cast decltype alignof "
+    "defined namespace template typename operator constexpr assert "
+    "static_assert GPU_ASSERT PANIC PANIC_IF_FALSE check_cuda_error "
+    "PUSH_RANGE POP_RANGE".split()
+)
+
+_NON_TYPE_WORDS = frozenset(
+    "return const struct class using template typename else auto".split()
+)
+
+
+# ---------------------------------------------------------------------------
+# C++ call-graph indexing
+# ---------------------------------------------------------------------------
+
+def _collect_cpp_files(dirs):
+    """Collect all C++ source files from the given directories."""
+    files = []
+    for d in dirs:
+        for root, _, filenames in os.walk(d):
+            for f in filenames:
+                if os.path.splitext(f)[1] in CPP_EXTENSIONS:
+                    files.append(os.path.join(root, f))
+    return sorted(files)
+
+
+def _index_definitions(cpp_files):
+    """Parse every function/method/constructor in cpp_files.
+
+    Returns:
+        definitions: list of dicts with keys name, struct, file, line, nodes
+        aliases:     dict mapping type alias names to their targets
+        bases:       dict mapping struct name to its base class names
+        fields:      dict mapping struct name to {field_name: type_name}
+        trees:       dict keeping tree-sitter trees alive for AST references
+    """
+    definitions = []
+    aliases, bases, fields = {}, defaultdict(set), defaultdict(dict)
+    trees = {}
+
+    for path in cpp_files:
+        with open(path, errors="replace") as f:
+            source_bytes = _strip_cuda_attrs(f.read().encode("utf-8"))
+        tree = CPP_PARSER.parse(source_bytes)
+        trees[path] = tree
+        root = tree.root_node
+
+        _collect_aliases(root, aliases)
+        _collect_struct_info(root, bases, fields)
+        _collect_function_defs(root, path, definitions)
+
+    return definitions, aliases, dict(bases), dict(fields), trees
+
+
+def _collect_aliases(root, aliases):
+    """Collect 'using A = B' type aliases."""
+    for node in find_all_nodes(root, {"alias_declaration"}):
+        name_node, target_node = None, None
+        for child in node.children:
+            if child.type == "type_identifier" and name_node is None:
+                name_node = child
+            elif child.type == "type_descriptor":
+                for tc in child.children:
+                    if tc.type == "type_identifier":
+                        target_node = tc
+                        break
+        if name_node and target_node:
+            aliases.setdefault(
+                name_node.text.decode("utf-8"),
+                target_node.text.decode("utf-8"),
+            )
+
+
+def _collect_struct_info(root, bases, fields):
+    """Collect base classes and pointer field types for structs/classes."""
+    for node in find_all_nodes(root, {"struct_specifier", "class_specifier"}):
+        struct_name = _struct_name(node)
+        if struct_name is None:
+            continue
+
+        for child in node.children:
+            if child.type == "base_class_clause":
+                for bc in child.children:
+                    if bc.type == "type_identifier":
+                        bases[struct_name].add(bc.text.decode("utf-8"))
+
+        body = node.child_by_field_name("body")
+        if body is None:
+            continue
+        for fdecl in body.children:
+            if fdecl.type != "field_declaration":
+                continue
+            type_name = _field_type_name(fdecl)
+            if type_name is None:
+                continue
+            for child in fdecl.children:
+                if child.type == "pointer_declarator":
+                    for pc in child.children:
+                        if pc.type == "field_identifier":
+                            fields[struct_name].setdefault(
+                                pc.text.decode("utf-8"), type_name,
+                            )
+
+
+def _struct_name(node):
+    """Extract the struct/class name from a specifier node."""
+    for child in node.children:
+        if child.type == "type_identifier":
+            return child.text.decode("utf-8")
+        if child.type == "template_type":
+            for tc in child.children:
+                if tc.type == "type_identifier":
+                    return tc.text.decode("utf-8")
+    return None
+
+
+def _field_type_name(field_decl):
+    """Extract the type name from a field_declaration, or None."""
+    for child in field_decl.children:
+        if child.type in ("type_identifier", "primitive_type",
+                          "template_type", "sized_type_specifier"):
+            name = child.text.decode("utf-8")
+            return None if name in _NON_TYPE_WORDS else name
+    return None
+
+
+def _collect_function_defs(root, path, definitions):
+    """Collect function/method/constructor definitions from root."""
+    bodies_seen = set()
+    for node in find_all_nodes(root, {"function_definition"}):
+        declarator = node.child_by_field_name("declarator")
+        if declarator is None:
+            continue
+        name = _func_decl_name(declarator)
+        if name is None or name in _NON_CALL_WORDS:
+            continue
+        body = node.child_by_field_name("body")
+        if body is None or body.start_byte in bodies_seen:
+            continue
+        bodies_seen.add(body.start_byte)
+
+        nodes = [body]
+        for child in node.children:
+            if child.type == "field_initializer_list":
+                nodes.append(child)
+                break
+
+        definitions.append({
+            "name": name,
+            "struct": _enclosing_struct(node),
+            "file": path,
+            "line": node.start_point[0] + 1,
+            "nodes": nodes,
+        })
+
+
+# ---------------------------------------------------------------------------
+# Call-site extraction from AST nodes
+# ---------------------------------------------------------------------------
+
+def _extract_call_info(func_node):
+    """Extract (receiver, operator, callee_name, line) from a call_expression's function child.
+
+    Returns None for non-call tokens (keywords, casts, macros).
+    """
+    if func_node.type == "identifier":
+        name = func_node.text.decode("utf-8")
+        if name in _NON_CALL_WORDS:
+            return None
+        return (None, None, name, func_node.start_point[0] + 1)
+
+    if func_node.type == "template_function":
+        for child in func_node.children:
+            if child.type in ("identifier", "field_identifier"):
+                name = child.text.decode("utf-8")
+                if name in _NON_CALL_WORDS:
+                    return None
+                return (None, None, name, child.start_point[0] + 1)
+            if child.type == "field_expression":
+                return _extract_field_call(child)
+        return None
+
+    if func_node.type == "field_expression":
+        return _extract_field_call(func_node)
+
+    if func_node.type == "qualified_identifier":
+        last_id = None
+        for child in func_node.children:
+            if child.type in ("identifier", "field_identifier"):
+                last_id = child
+        if last_id:
+            name = last_id.text.decode("utf-8")
+            if name in _NON_CALL_WORDS:
+                return None
+            return (None, None, name, last_id.start_point[0] + 1)
+
+    return None
+
+
+def _extract_field_call(field_expr):
+    """Extract (receiver, operator, callee_name, line) from a field_expression in a call."""
+    arg_node = field_expr.child_by_field_name("argument")
+    field_node = field_expr.child_by_field_name("field")
+    if field_node is None:
+        return None
+
+    name = field_node.text.decode("utf-8")
+    if name in _NON_CALL_WORDS:
+        return None
+
+    operator = None
+    for child in field_expr.children:
+        if child.type in (".", "->"):
+            operator = child.type
+            break
+
+    receiver = _receiver_name(arg_node)
+    return (receiver, operator, name, field_node.start_point[0] + 1)
+
+
+def _receiver_name(arg_node):
+    """Best-effort extraction of the receiver variable name."""
+    if arg_node is None:
+        return None
+    if arg_node.type == "identifier":
+        return arg_node.text.decode("utf-8")
+    if arg_node.type == "this":
+        return "this"
+    if arg_node.type == "subscript_expression":
+        for child in arg_node.children:
+            if child.type == "identifier":
+                return child.text.decode("utf-8")
+    if arg_node.type == "field_expression":
+        field = arg_node.child_by_field_name("field")
+        if field:
+            return field.text.decode("utf-8")
+    return None
+
+
+# ---------------------------------------------------------------------------
+# ScratchSyncWalker: breadth-first reachability from a definition to a sync
+# ---------------------------------------------------------------------------
+
+class ScratchSyncWalker:
+    """Walks the call graph from a C++ definition looking for host syncs."""
+
+    def __init__(self, definitions, aliases, bases, fields):
+        self.definitions = definitions
+        self.aliases = aliases
+        self.bases = bases
+        self.fields = fields
+
+        self.by_name = defaultdict(list)
+        for key, d in enumerate(definitions):
+            self.by_name[d["name"]].append(key)
+
+        self._edge_cache = {}
+
+    # -- Alias and inheritance resolution --
+
+    def _resolve_alias(self, name):
+        seen = set()
+        while name in self.aliases and name not in seen:
+            seen.add(name)
+            name = self.aliases[name]
+        return name
+
+    def _base_chain(self, struct):
+        chain, pending = set(), [struct]
+        while pending:
+            for base in sorted(self.bases.get(pending.pop(), ())):
+                resolved = self._resolve_alias(base)
+                if resolved not in chain:
+                    chain.add(resolved)
+                    pending.append(resolved)
+        return sorted(chain)
+
+    # -- Definition lookup by name --
+
+    def _methods_of(self, struct, name):
+        if not struct:
+            return []
+        for candidate in [struct] + self._base_chain(struct):
+            hits = [k for k in self.by_name.get(name, ())
+                    if self.definitions[k]["struct"] == candidate]
+            if hits:
+                return hits
+        return []
+
+    def _constructors_of(self, name):
+        resolved = self._resolve_alias(name)
+        return [k for k in self.by_name.get(resolved, ())
+                if self.definitions[k]["struct"] == resolved]
+
+    def _any_definition_of(self, name):
+        resolved = self._resolve_alias(name)
+        return self.by_name.get(resolved) or self.by_name.get(name) or []
+
+    # -- Edge computation (one definition → sync sites + callee keys) --
+
+    def _edges(self, key):
+        cached = self._edge_cache.get(key)
+        if cached is not None:
+            return cached
+
+        d = self.definitions[key]
+        calls, receiver_types = self._call_sites_of(d)
+        sync_sites, callees = [], []
+
+        for receiver, operator, name, line in calls:
+            if name in SYNC_SITE_NAMES:
+                sync_sites.append((name, d["file"], line))
+                continue
+            if name in SYNC_WALK_STOP_CALLS:
+                continue
+
+            if operator is None:
+                # Unqualified call: try constructor, then same-struct method,
+                # then any definition.
+                callees.extend(
+                    self._constructors_of(name)
+                    or self._methods_of(d["struct"], name)
+                    or self._any_definition_of(name)
+                )
+            else:
+                # Member call (. or ->): resolve the receiver type to pick
+                # the right overload (e.g. 105 definitions named "release").
+                receiver_type = self._resolve_receiver_type(
+                    d, receiver, receiver_types)
+                hits = (self._methods_of(
+                            self._resolve_alias(receiver_type), name)
+                        if receiver_type else [])
+                callees.extend(
+                    hits
+                    or self._methods_of(d["struct"], name)
+                    or self._any_definition_of(name)
+                )
+
+        sync_sites.sort(key=lambda s: (s[1], s[2], s[0]))
+        result = (sync_sites, list(dict.fromkeys(callees)))
+        self._edge_cache[key] = result
+        return result
+
+    def _resolve_receiver_type(self, d, receiver, receiver_types):
+        if receiver == "this":
+            return d["struct"]
+        if receiver is None:
+            return None
+        own_fields = self.fields.get(d["struct"], {})
+        return receiver_types.get(receiver) or own_fields.get(receiver)
+
+    def _call_sites_of(self, d):
+        """Extract all call sites and local variable types from a definition."""
+        calls, receiver_types = [], {}
+
+        for node in d["nodes"]:
+            # Regular function calls
+            for call_node in find_all_nodes(node, {"call_expression"}):
+                func = call_node.child_by_field_name("function")
+                if func is None:
+                    continue
+                info = _extract_call_info(func)
+                if info:
+                    calls.append(info)
+
+            # Member-initializer list entries (constructor: field(args))
+            for init_node in find_all_nodes(node, {"field_initializer"}):
+                for child in init_node.children:
+                    if child.type == "field_identifier":
+                        name = child.text.decode("utf-8")
+                        if name not in _NON_CALL_WORDS:
+                            calls.append((None, None, name,
+                                          child.start_point[0] + 1))
+                        break
+
+            # Calls inside ERROR nodes (e.g. DISPATCH_POLY_SIZE macro args)
+            for error_node in find_all_nodes(node, {"ERROR"}):
+                for func_decl in find_all_nodes(error_node,
+                                                {"function_declarator"}):
+                    name = _func_decl_name(func_decl)
+                    if name and name not in _NON_CALL_WORDS:
+                        calls.append((None, None, name,
+                                      func_decl.start_point[0] + 1))
+
+            # Track local variable types for receiver resolution
+            # Constructor calls through `new T<...>(...)`.  Scratch functions
+            # build their buffer this way, so without this edge the walk
+            # never enters a buffer constructor.
+            for new_node in find_all_nodes(node, {"new_expression"}):
+                type_name = self._new_type_name(new_node)
+                if type_name:
+                    calls.append((None, None, type_name,
+                                  new_node.start_point[0] + 1))
+
+            self._collect_local_types(node, receiver_types)
+
+        return calls, receiver_types
+
+    @staticmethod
+    def _new_type_name(new_node):
+        """Return the constructed type's name from a new_expression node.
+
+        Handles both `new T(...)` (type_identifier) and `new T<...>(...)`
+        (template_type wrapping a type_identifier).
+        """
+        for child in new_node.children:
+            if child.type == "type_identifier":
+                return child.text.decode("utf-8")
+            if child.type == "template_type":
+                for tc in child.children:
+                    if tc.type == "type_identifier":
+                        return tc.text.decode("utf-8")
+        return None
+
+    def _collect_local_types(self, node, receiver_types):
+        """Record variable_name → type_name for pointer declarations and new-expressions."""
+        for decl_node in find_all_nodes(node, {"declaration"}):
+            type_name = None
+            for child in decl_node.children:
+                if child.type in ("type_identifier", "template_type"):
+                    type_name = child.text.decode("utf-8")
+                    break
+            if type_name is None or type_name in _NON_TYPE_WORDS:
+                continue
+            for child in decl_node.children:
+                if child.type == "init_declarator":
+                    for ic in child.children:
+                        if ic.type == "pointer_declarator":
+                            for pc in ic.children:
+                                if pc.type == "identifier":
+                                    receiver_types.setdefault(
+                                        pc.text.decode("utf-8"), type_name)
+
+        for new_node in find_all_nodes(node, {"new_expression"}):
+            type_name = self._new_type_name(new_node)
+            if type_name is None:
+                continue
+            parent = new_node.parent
+            if parent is None:
+                continue
+            var_name = self._var_from_new(parent)
+            if var_name:
+                receiver_types.setdefault(var_name, type_name)
+
+    @staticmethod
+    def _var_from_new(parent):
+        """Extract the variable name being assigned from a new-expression's parent."""
+        if parent.type == "init_declarator":
+            for child in parent.children:
+                if child.type == "identifier":
+                    return child.text.decode("utf-8")
+                if child.type == "pointer_declarator":
+                    for pc in child.children:
+                        if pc.type == "identifier":
+                            return pc.text.decode("utf-8")
+        elif parent.type == "assignment_expression":
+            left = parent.child_by_field_name("left")
+            if left and left.type == "identifier":
+                return left.text.decode("utf-8")
+        return None
+
+    # -- Public API --
+
+    def label(self, key):
+        d = self.definitions[key]
+        if d["struct"] is None:
+            return d["name"]
+        if d["struct"] == d["name"]:
+            return f"{d['struct']}::ctor"
+        return f"{d['struct']}::{d['name']}"
+
+    def reachable_sync_chains(self, start_key):
+        """BFS for every reachable host synchronization.
+
+        Returns a dict mapping (sync_call, file, line) to the shortest
+        call chain that reaches it.
+        """
+        chains = {}
+        seen = {start_key}
+        queue = deque([(start_key, [self.label(start_key)])])
+        while queue:
+            key, chain = queue.popleft()
+            sync_sites, callees = self._edges(key)
+            for site in sync_sites:
+                chains.setdefault(site, chain)
+            for callee in callees:
+                if callee not in seen:
+                    seen.add(callee)
+                    queue.append((callee, chain + [self.label(callee)]))
+        return chains
+
+
+# ---------------------------------------------------------------------------
+# Public: check_7_scratch_reaches_no_sync
+# ---------------------------------------------------------------------------
+
+def check_7_scratch_reaches_no_sync(scratch_set, sync_whitelist):
+    """Check 7: no scratch entry point may reach a host synchronization.
+
+    Args:
+        scratch_set: set of scratch_cuda_* function names from bindings.rs
+        sync_whitelist: scratch entry points known to reach a host
+            synchronization; their chains are reported but not counted as
+            violations
+
+    Returns:
+        (violations, n_entry_points, n_reaching, n_whitelisted,
+         n_definitions, sync_sites)
+    """
+    definitions, aliases, bases, fields, trees = _index_definitions(
+        _collect_cpp_files(SYNC_WALK_CPP_DIRS)
+    )
+    walker = ScratchSyncWalker(definitions, aliases, bases, fields)
+
+    # Map each scratch name to its definition key(s).
+    entry_points = defaultdict(list)
+    for key, d in enumerate(definitions):
+        if d["struct"] is None and d["name"] in scratch_set:
+            entry_points[d["name"]].append(key)
+
+    # Missing definitions are violations.
+    violations = [
+        f"  {name}: C++ definition not found in "
+        f"{', '.join(SYNC_WALK_CPP_DIRS)}"
+        for name in sorted(scratch_set - set(entry_points))
+    ]
+
+    # Walk each entry point.  A name with multiple definitions (template
+    # helper + extern "C" wrapper) is clean only when none reaches a sync.
+    nearest = {}
+    entry_points_per_site = defaultdict(set)
+    for name, keys in entry_points.items():
+        reachable = {}
+        for key in keys:
+            for site, chain in walker.reachable_sync_chains(key).items():
+                prev = reachable.get(site)
+                if prev is None or len(chain) < len(prev):
+                    reachable[site] = chain
+        for site in reachable:
+            entry_points_per_site[site].add(name)
+        if reachable:
+            site = min(reachable,
+                       key=lambda s: (len(reachable[s]), s[1], s[2], s[0]))
+            nearest[name] = (reachable[site],) + site
+
+    sync_sites = sorted(
+        ((len(names), site[0], site[1], site[2])
+         for site, names in entry_points_per_site.items()),
+        key=lambda item: (-item[0], item[2], item[3]),
+    )
+
+    if nearest:
+        grouped = defaultdict(list)
+        for name, (chain, sync_name, path, line) in nearest.items():
+            grouped[(tuple(chain[1:]), sync_name, path, line)].append(name)
+
+        for (tail, sync_name, path, line), names in sorted(
+            grouped.items(), key=lambda item: (-len(item[1]), item[0])
+        ):
+            names.sort()
+            chain = " > ".join([names[0]] + list(tail))
+            message = f"  {chain}  [{sync_name} at {path}:{line}]"
+            if len(names) > 1:
+                shared = ", ".join(names[1:])
+                message += (
+                    f"\n    same chain from {len(names) - 1} more entry "
+                    f"point(s): {shared}"
+                )
+            if not all(n in sync_whitelist for n in names):
+                violations.append(message)
+
+    # A whitelisted name that reaches nothing is stale, whether it was fixed
+    # or never existed as an entry point.
+    for name in sorted(sync_whitelist - set(nearest)):
+        violations.append(
+            f"  {name} is in CHECK7_SYNC_WHITELIST but does not reach a "
+            f"host synchronization: remove it from the whitelist"
+        )
+
+    n_whitelisted = len(set(nearest) & sync_whitelist)
+    return (violations, len(entry_points), len(nearest), n_whitelisted,
+            len(definitions), sync_sites)

--- a/scripts/gpu-lint-requirements.txt
+++ b/scripts/gpu-lint-requirements.txt
@@ -1,3 +1,4 @@
 semgrep==1.151.0
 tree-sitter==0.25.2
+tree-sitter-cpp==0.23.4
 tree-sitter-rust==0.24.0


### PR DESCRIPTION
Part of https://github.com/zama-ai/tfhe-rs-internal/issues/1482 (split 2 of 3, replaces #3896).

### What

69 of the 80 `scratch_cuda_*_async` FFI functions reached `cuda_synchronize_stream` through their buffer constructors, at 17 synchronization sites. This PR removes 12 of them. The 5 remaining sites are inside the `generate_device_accumulator*` primitives and are kept on purpose (see below). No FFI signature changes.

A new check in `scripts/check_scratch_cleanup.py` (Check 7, implemented in `scripts/check_scratch_sync.py`) walks the C++ call graph from every `scratch_cuda_*` symbol in `bindings.rs` and fails if any of them can reach a host synchronization outside an explicit whitelist.

### Changes

- **`int_radix_lut` multi-GPU index broadcast** (68 scratch functions): host sync replaced by `multi_gpu_broadcast_barrier.local_streams_wait_for_stream_0`, guarded on `allocate_gpu_memory && count() > 1`. Single GPU needs no ordering since the copy runs on stream 0. The barriers are now created before the buffers that use them.
- **Constructor temporaries that were sync-then-freed** (`int_seq_group_prop_memory`, `int_prop_simu_group_carries_memory`, `int_sum_ciphertexts_vec_memory`, `div_rem.h`, `oprf.h`, `rerand_utilities.h`, `kv_store_utilities.h`, `zk_utilities.h`): each host staging buffer becomes a member freed in `release()` after the sync that already exists there. These buffers are written once, in the constructor, and never rewritten. Two syncs that protected nothing are deleted (`int_bit_extract_luts_buffer`, `zk_expand_mem`, `RERAND_NO_KS` branch).
- **`int_sum_ciphertexts_vec_memory` dry-run LUT**: the size probe (built with `allocate_gpu_memory == false`) is kept as a member and released in `release()`. The syncs in `int_radix_lut::release()` are guarded on `gpu_memory_allocated`, since nothing was ever enqueued for a probe.

### What is not changed: `generate_device_accumulator*`

The 6 `generate_device_accumulator*` primitives still allocate a host LUT, upload it, synchronize and free it. A first version of this PR replaced that with a per-LUT host staging slot and an asynchronous upload. That was reverted after review: some `host_*` functions regenerate a LUT into the same `int_radix_lut` on every call (`are_all_comparisons_block_true`, `tree_sign_reduction`, `integer_radix_unsigned_scalar_difference_check`, `integer_radix_signed_scalar_difference_check`, `reduce_signs`, and `setup_lookup_tables` from `host_integer_partial_sum_ciphertexts_vec`). An asynchronous upload from a reused host buffer would race with the next regeneration, and relying on `cudaMemcpyAsync` staging pageable memory internally is not acceptable.

As a result, 65 of the 80 scratch functions still synchronize once per LUT they build. The follow-up (https://github.com/zama-ai/tfhe-rs-internal/issues/1557) is to generate every LUT variant in scratch and select among them in the host function, after which the primitives can become asynchronous and the entry points leave the whitelist below.

### Bugs fixed along the way

- `zk_utilities.h` and general-path `create_indexes_for_overflow_sub` freed upload sources with no sync (now members).
- `int_prop_simu_group_carries_memory::release()` deleted `h_scalar_array_cum_sum` before its sync (moved after).
- `setup_lookup_tables` leaked a `luts_message_carry` per partial sum (now reused when large enough, rebuilt otherwise).

### Static analysis (Check 7)

- Implemented with tree-sitter-cpp in `scripts/check_scratch_sync.py`, separate from the other checks so it can be disabled by removing its call from `check_scratch_cleanup.py`. CUDA attributes (`__host__`, `__global__`, ...) are blanked before parsing.
- Follows plain calls, member calls (receiver type resolved through local declarations, struct fields and `using` aliases), member-initializer lists, calls inside macro arguments such as `DISPATCH_POLY_SIZE`, and `new T<...>(...)` constructor calls, which is how every scratch function builds its buffer.
- Scans `tfhe-cuda-common` in addition to the backend, because the memcpy wrappers there call `cuda_set_device`.
- `SYNC_SITE_NAMES` (in the sync module) says what a host synchronization looks like; meeting one is a violation. `SYNC_WALK_STOP_CALLS` (same module) holds the runtime helpers the walker does not enter: `cuda_setup_mempool` (one-time pool warm-up reached by every `cuda_set_device`) and the two allocation wrappers whose `cudaMalloc`/`cudaFree` fallback depends on device support.
- `CHECK7_SYNC_WHITELIST` in `check_scratch_cleanup.py` is passed to the check and names the top-level scratch entry points known to synchronize. It holds entry points, never the subfunction that synchronizes: skipping a subfunction would hide the synchronization and let every caller above it pass as asynchronous. Whitelisted chains are still walked, and a whitelisted name that does not reach a synchronization is reported as stale.
- It currently lists the 65 entry points whose buffers build a LUT through the `generate_device_accumulator*` primitives. With the whitelist emptied, Check 7 reports those 65 of 80, all through the five sync sites in those primitives.
- The expected number of scratch entry points (80) is pinned.

### Check-list:

* [x] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [x] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer

