### PR TITLE
chore(gpu): add _async suffix to 172 internal host_* template functions that are asynchronous

### DIFF
--- a/backends/tfhe-cuda-backend/cuda/include/integer/comparison.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer/comparison.h
@@ -548,9 +548,9 @@ template <typename Torus> struct int_comparison_buffer {
     // single-block LUT that extracts the borrow flag and applies the per-op
     // boolean inversion (lut_borrow_flag_cmp below).
     if (use_borrow_fast_path) {
-      // FLAG_NONE: host_difference_check_via_borrow does the overflow-block
-      // combination itself, so int_borrow_prop_memory's own borrow-flag LUT is
-      // never used and we avoid allocating it.
+      // FLAG_NONE: host_difference_check_via_borrow_async does the
+      // overflow-block combination itself, so int_borrow_prop_memory's own
+      // borrow-flag LUT is never used and we avoid allocating it.
       diff_borrow_mem = new int_borrow_prop_memory<Torus>(
           streams, params, num_radix_blocks, (uint32_t)outputFlag::FLAG_NONE,
           allocate_gpu_memory, size_tracker);

--- a/backends/tfhe-cuda-backend/cuda/include/integer/integer_utilities.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer/integer_utilities.h
@@ -26,7 +26,7 @@
 constexpr std::nullptr_t LUT_0_FOR_ALL_BLOCKS = nullptr;
 
 /// @brief Computes the survivor count after one reserve-tail-and-absorb PBS
-/// round of the kv_store one-hot sum (host_binary_tree_fold_sum).
+/// round of the kv_store one-hot sum (host_binary_tree_fold_sum_async).
 ///
 /// Shared by scratch allocation and the host loop so the two cannot drift.
 ///

--- a/backends/tfhe-cuda-backend/cuda/include/integer/kv_store/kv_store_utilities.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer/kv_store/kv_store_utilities.h
@@ -255,9 +255,10 @@ template <typename Torus> struct int_kv_store_eq_selectors_small_map_buffer {
 /// @brief Wrapper selecting the equality-selector algorithm by entry count.
 ///
 /// Holds whichever equality-selector buffer the entry count selects, so a
-/// single allocation matches the algorithm host_kv_store_compute_eq_selectors
-/// will run. Exactly one of the two pointers is non-null, decided by
-/// num_entries against KV_STORE_EQ_SELECTORS_SMALL_MAP_MAX_ENTRIES.
+/// single allocation matches the algorithm
+/// host_kv_store_compute_eq_selectors_async will run. Exactly one of the two
+/// pointers is non-null, decided by num_entries against
+/// KV_STORE_EQ_SELECTORS_SMALL_MAP_MAX_ENTRIES.
 ///
 /// @tparam Torus  Unsigned integer type representing a ciphertext torus element
 template <typename Torus> struct int_kv_store_eq_selectors_wrapper_buffer {

--- a/backends/tfhe-cuda-backend/cuda/include/integer/shuffle_utilities.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer/shuffle_utilities.h
@@ -498,8 +498,8 @@ template <typename Torus> struct int_oprf_bitonic_shuffle_buffer {
   CudaRadixCiphertextFFI *keys_storage;
   /// @brief Per-element views into keys_storage.
   CudaRadixCiphertextFFI *keys_views;
-  /// @brief Pointer array into keys_views passed to host_bitonic_shuffle as the
-  /// key array.
+  /// @brief Pointer array into keys_views passed to host_bitonic_shuffle_async
+  /// as the key array.
   CudaRadixCiphertextFFI **keys_ptrs;
 
   bool gpu_memory_allocated;

--- a/backends/tfhe-cuda-backend/cuda/src/aes/aes.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/aes/aes.cu
@@ -39,7 +39,7 @@ void cuda_integer_aes_ctr_encrypt_64_async(
     const uint64_t *counter_bits_le_all_blocks, uint32_t num_aes_inputs,
     int8_t *mem_ptr, void *const *bsks, void *const *ksks) {
 
-  host_integer_aes_ctr_encrypt<uint64_t>(
+  host_integer_aes_ctr_encrypt_async<uint64_t>(
       CudaStreams(streams), output, iv, round_keys, counter_bits_le_all_blocks,
       num_aes_inputs, (int_aes_encrypt_buffer<uint64_t> *)mem_ptr, bsks,
       (uint64_t **)ksks);
@@ -90,7 +90,7 @@ void cuda_integer_key_expansion_64_async(CudaStreamsFFI streams,
                                          int8_t *mem_ptr, void *const *bsks,
                                          void *const *ksks) {
 
-  host_integer_key_expansion<uint64_t>(
+  host_integer_key_expansion_async<uint64_t>(
       CudaStreams(streams), expanded_keys, key,
       (int_key_expansion_buffer<uint64_t> *)mem_ptr, bsks, (uint64_t **)ksks);
 }

--- a/backends/tfhe-cuda-backend/cuda/src/aes/aes.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/aes/aes.cuh
@@ -92,9 +92,10 @@ aes_xor(CudaStreams streams, int_aes_encrypt_buffer<Torus> *mem,
         CudaRadixCiphertextFFI *out, const CudaRadixCiphertextFFI *lhs,
         const CudaRadixCiphertextFFI *rhs) {
 
-  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), out, lhs, rhs,
-                       out->num_radix_blocks, mem->params.message_modulus,
-                       mem->params.carry_modulus);
+  host_addition_async<Torus>(streams.stream(0), streams.gpu_index(0), out, lhs,
+                             rhs, out->num_radix_blocks,
+                             mem->params.message_modulus,
+                             mem->params.carry_modulus);
 }
 
 /**
@@ -128,8 +129,8 @@ aes_scalar_add_one_flush_inplace(CudaStreams streams,
                                  int_aes_encrypt_buffer<Torus> *mem,
                                  void *const *bsks, KSTorus *const *ksks) {
 
-  host_add_scalar_one_inplace<Torus>(streams, data, mem->params.message_modulus,
-                                     mem->params.carry_modulus);
+  host_add_scalar_one_inplace_async<Torus>(
+      streams, data, mem->params.message_modulus, mem->params.carry_modulus);
 
   aes_flush_inplace(streams, data, mem, bsks, ksks);
 }
@@ -360,9 +361,9 @@ __host__ void vectorized_sbox_n_bytes(CudaStreams streams,
 
 #define ADD_ONE(target)                                                        \
   do {                                                                         \
-    host_add_scalar_one_inplace<Torus>(streams, target,                        \
-                                       mem->params.message_modulus,            \
-                                       mem->params.carry_modulus);             \
+    host_add_scalar_one_inplace_async<Torus>(streams, target,                  \
+                                             mem->params.message_modulus,      \
+                                             mem->params.carry_modulus);       \
   } while (0)
 
   // Homomorphic S-Box Circuit Evaluation
@@ -1096,7 +1097,7 @@ __host__ void vectorized_aes_full_adder_inplace(
  *
  */
 template <typename Torus, typename KSTorus>
-__host__ void host_integer_aes_ctr_encrypt(
+__host__ void host_integer_aes_ctr_encrypt_async(
     CudaStreams streams, CudaRadixCiphertextFFI *output,
     CudaRadixCiphertextFFI const *iv, CudaRadixCiphertextFFI const *round_keys,
     const Torus *counter_bits_le_all_blocks, uint32_t num_aes_inputs,
@@ -1154,12 +1155,10 @@ uint64_t scratch_cuda_integer_key_expansion(
  * - If (i % 4 != 0): w_i = w_{i-4} + w_{i-1}
  */
 template <typename Torus, typename KSTorus>
-__host__ void host_integer_key_expansion(CudaStreams streams,
-                                         CudaRadixCiphertextFFI *expanded_keys,
-                                         CudaRadixCiphertextFFI const *key,
-                                         int_key_expansion_buffer<Torus> *mem,
-                                         void *const *bsks,
-                                         KSTorus *const *ksks) {
+__host__ void host_integer_key_expansion_async(
+    CudaStreams streams, CudaRadixCiphertextFFI *expanded_keys,
+    CudaRadixCiphertextFFI const *key, int_key_expansion_buffer<Torus> *mem,
+    void *const *bsks, KSTorus *const *ksks) {
 
   constexpr uint32_t BITS_PER_WORD = 32;
   constexpr uint32_t BITS_PER_BYTE = 8;
@@ -1226,9 +1225,9 @@ __host__ void host_integer_key_expansion(CudaStreams streams,
           CudaRadixCiphertextFFI first_byte_bit_slice;
           as_radix_ciphertext_slice<Torus>(&first_byte_bit_slice,
                                            &rotated_word_buffer, bit, bit + 1);
-          host_add_scalar_one_inplace<Torus>(streams, &first_byte_bit_slice,
-                                             mem->params.message_modulus,
-                                             mem->params.carry_modulus);
+          host_add_scalar_one_inplace_async<Torus>(
+              streams, &first_byte_bit_slice, mem->params.message_modulus,
+              mem->params.carry_modulus);
         }
       }
 

--- a/backends/tfhe-cuda-backend/cuda/src/aes/aes256.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/aes/aes256.cu
@@ -7,7 +7,7 @@ void cuda_integer_aes_ctr_256_encrypt_64_async(
     const uint64_t *counter_bits_le_all_blocks, uint32_t num_aes_inputs,
     int8_t *mem_ptr, void *const *bsks, void *const *ksks) {
 
-  host_integer_aes_ctr_256_encrypt<uint64_t>(
+  host_integer_aes_ctr_256_encrypt_async<uint64_t>(
       CudaStreams(streams), output, iv, round_keys, counter_bits_le_all_blocks,
       num_aes_inputs, (int_aes_encrypt_buffer<uint64_t> *)mem_ptr, bsks,
       (uint64_t **)ksks);
@@ -33,7 +33,7 @@ void cuda_integer_key_expansion_256_64_async(
     CudaRadixCiphertextFFI const *key, int8_t *mem_ptr, void *const *bsks,
     void *const *ksks) {
 
-  host_integer_key_expansion_256<uint64_t>(
+  host_integer_key_expansion_256_async<uint64_t>(
       CudaStreams(streams), expanded_keys, key,
       (int_key_expansion_256_buffer<uint64_t> *)mem_ptr, bsks,
       (uint64_t **)ksks);

--- a/backends/tfhe-cuda-backend/cuda/src/aes/aes256.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/aes/aes256.cuh
@@ -180,7 +180,7 @@ __host__ void vectorized_aes_256_encrypt_inplace(
  *
  */
 template <typename Torus>
-__host__ void host_integer_aes_ctr_256_encrypt(
+__host__ void host_integer_aes_ctr_256_encrypt_async(
     CudaStreams streams, CudaRadixCiphertextFFI *output,
     CudaRadixCiphertextFFI const *iv, CudaRadixCiphertextFFI const *round_keys,
     const Torus *counter_bits_le_all_blocks, uint32_t num_aes_inputs,
@@ -239,7 +239,7 @@ uint64_t scratch_cuda_integer_key_expansion_256(
  * - Otherwise:       w_i = w_{i-8} + w_{i-1}
  */
 template <typename Torus>
-__host__ void host_integer_key_expansion_256(
+__host__ void host_integer_key_expansion_256_async(
     CudaStreams streams, CudaRadixCiphertextFFI *expanded_keys,
     CudaRadixCiphertextFFI const *key, int_key_expansion_256_buffer<Torus> *mem,
     void *const *bsks, Torus *const *ksks) {
@@ -309,9 +309,9 @@ __host__ void host_integer_key_expansion_256(
           CudaRadixCiphertextFFI first_byte_bit_slice;
           as_radix_ciphertext_slice<Torus>(&first_byte_bit_slice,
                                            &rotated_word_buffer, bit, bit + 1);
-          host_add_scalar_one_inplace<Torus>(streams, &first_byte_bit_slice,
-                                             mem->params.message_modulus,
-                                             mem->params.carry_modulus);
+          host_add_scalar_one_inplace_async<Torus>(
+              streams, &first_byte_bit_slice, mem->params.message_modulus,
+              mem->params.carry_modulus);
         }
       }
 

--- a/backends/tfhe-cuda-backend/cuda/src/crypto/ciphertext.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/crypto/ciphertext.cu
@@ -26,7 +26,7 @@ void cuda_glwe_sample_extract_64_async(
 
   DISPATCH_POLY_SIZE(
       polynomial_size, AmortizedDegreePolicy,
-      host_sample_extract<uint64_t, Params>(
+      host_sample_extract_async<uint64_t, Params>(
           static_cast<cudaStream_t>(stream), gpu_index,
           (uint64_t *)lwe_array_out, (uint64_t const *)glwe_array_in,
           (uint32_t const *)nth_array, num_nths, num_lwes_to_extract_per_glwe,
@@ -36,7 +36,7 @@ void cuda_glwe_sample_extract_64_async(
 void cuda_modulus_switch_inplace_64_async(void *stream, uint32_t gpu_index,
                                           void *lwe_array_out, uint32_t size,
                                           uint32_t log_modulus) {
-  host_modulus_switch_inplace<uint64_t>(
+  host_modulus_switch_inplace_async<uint64_t>(
       static_cast<cudaStream_t>(stream), gpu_index,
       static_cast<uint64_t *>(lwe_array_out), size, log_modulus);
 }
@@ -46,10 +46,10 @@ void cuda_modulus_switch_64_async(void *stream, uint32_t gpu_index,
                                   uint32_t size, uint32_t log_modulus) {
   PANIC_IF_FALSE(lwe_out != lwe_in, "Output and input pointers must be "
                                     "different for out-of-place operations");
-  host_modulus_switch<uint64_t>(static_cast<cudaStream_t>(stream), gpu_index,
-                                static_cast<uint64_t *>(lwe_out),
-                                static_cast<const uint64_t *>(lwe_in), size,
-                                log_modulus);
+  host_modulus_switch_async<uint64_t>(
+      static_cast<cudaStream_t>(stream), gpu_index,
+      static_cast<uint64_t *>(lwe_out), static_cast<const uint64_t *>(lwe_in),
+      size, log_modulus);
 }
 
 void cuda_centered_modulus_switch_64_async(void *stream, uint32_t gpu_index,
@@ -58,7 +58,7 @@ void cuda_centered_modulus_switch_64_async(void *stream, uint32_t gpu_index,
                                            uint32_t log_modulus) {
   PANIC_IF_FALSE(lwe_out != lwe_in, "Output and input pointers must be "
                                     "different for out-of-place operations");
-  host_centered_modulus_switch_inplace<uint64_t>(
+  host_centered_modulus_switch_inplace_async<uint64_t>(
       static_cast<cudaStream_t>(stream), gpu_index,
       static_cast<uint64_t *>(lwe_out), static_cast<const uint64_t *>(lwe_in),
       lwe_dimension, log_modulus);
@@ -70,7 +70,7 @@ void cuda_centered_modulus_switch_cooperative_64_async(
     uint32_t block_dim_y) {
   PANIC_IF_FALSE(lwe_out != lwe_in, "Output and input pointers must be "
                                     "different for out-of-place operations");
-  host_centered_modulus_switch_cooperative<uint64_t>(
+  host_centered_modulus_switch_cooperative_async<uint64_t>(
       static_cast<cudaStream_t>(stream), gpu_index,
       static_cast<uint64_t *>(lwe_out), static_cast<const uint64_t *>(lwe_in),
       lwe_dimension, log_modulus, block_dim_x, block_dim_y);
@@ -84,7 +84,7 @@ void cuda_glwe_sample_extract_128_async(
 
   DISPATCH_POLY_SIZE(
       polynomial_size, AmortizedDegreePolicy128,
-      host_sample_extract<__uint128_t, Params>(
+      host_sample_extract_async<__uint128_t, Params>(
           static_cast<cudaStream_t>(stream), gpu_index,
           (__uint128_t *)lwe_array_out, (__uint128_t const *)glwe_array_in,
           (uint32_t const *)nth_array, num_nths, num_lwes_to_extract_per_glwe,
@@ -98,7 +98,7 @@ void cuda_modulus_switch_multi_bit_64_async(void *stream, uint32_t gpu_index,
                                             uint32_t degree,
                                             uint32_t grouping_factor) {
 
-  host_modulus_switch_multi_bit<uint64_t>(
+  host_modulus_switch_multi_bit_async<uint64_t>(
       static_cast<cudaStream_t>(stream), gpu_index,
       static_cast<uint64_t *>(lwe_array_out),
       static_cast<uint64_t *>(lwe_array_in), size, log_modulus, degree,
@@ -112,7 +112,7 @@ void cuda_modulus_switch_multi_bit_128_async(void *stream, uint32_t gpu_index,
                                              uint32_t degree,
                                              uint32_t grouping_factor) {
 
-  host_modulus_switch_multi_bit<__uint128_t>(
+  host_modulus_switch_multi_bit_async<__uint128_t>(
       static_cast<cudaStream_t>(stream), gpu_index,
       static_cast<__uint128_t *>(lwe_array_out),
       static_cast<__uint128_t *>(lwe_array_in), size, log_modulus, degree,

--- a/backends/tfhe-cuda-backend/cuda/src/crypto/ciphertext.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/crypto/ciphertext.cuh
@@ -56,13 +56,11 @@ sample_extract(Torus *lwe_array_out, Torus const *glwe_array_in,
 // num_lwes_to_extract_per_glwe LWEs will be extracted per GLWE ciphertext, thus
 // we need to have enough indexes
 template <typename Torus, class params>
-__host__ void host_sample_extract(cudaStream_t stream, uint32_t gpu_index,
-                                  Torus *lwe_array_out,
-                                  Torus const *glwe_array_in,
-                                  uint32_t const *nth_array, uint32_t num_nths,
-                                  uint32_t num_lwes_to_extract_per_glwe,
-                                  uint32_t num_lwes_stored_per_glwe,
-                                  uint32_t glwe_dimension) {
+__host__ void host_sample_extract_async(
+    cudaStream_t stream, uint32_t gpu_index, Torus *lwe_array_out,
+    Torus const *glwe_array_in, uint32_t const *nth_array, uint32_t num_nths,
+    uint32_t num_lwes_to_extract_per_glwe, uint32_t num_lwes_stored_per_glwe,
+    uint32_t glwe_dimension) {
   cuda_set_device(gpu_index);
   dim3 grid(num_nths);
   dim3 thds(params::degree / params::opt);

--- a/backends/tfhe-cuda-backend/cuda/src/crypto/keyswitch.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/crypto/keyswitch.cu
@@ -27,7 +27,7 @@ void cuda_keyswitch_gemm_64_64_async(
     uint32_t lwe_dimension_out, uint32_t base_log, uint32_t level_count,
     uint32_t num_samples, bool uses_trivial_indexes) {
 
-  host_gemm_keyswitch_lwe_ciphertext_vector<uint64_t, uint64_t>(
+  host_gemm_keyswitch_lwe_ciphertext_vector_async<uint64_t, uint64_t>(
       static_cast<cudaStream_t>(stream), gpu_index,
       static_cast<uint64_t *>(lwe_array_out),
       static_cast<const uint64_t *>(lwe_output_indexes),
@@ -48,7 +48,7 @@ void cuda_keyswitch_gemm_64_32_async(
     uint32_t lwe_dimension_out, uint32_t base_log, uint32_t level_count,
     uint32_t num_samples, bool uses_trivial_indexes) {
 
-  host_gemm_keyswitch_lwe_ciphertext_vector<uint64_t, uint32_t>(
+  host_gemm_keyswitch_lwe_ciphertext_vector_async<uint64_t, uint32_t>(
       static_cast<cudaStream_t>(stream), gpu_index,
       static_cast<uint32_t *>(lwe_array_out),
       static_cast<const uint64_t *>(lwe_output_indexes),
@@ -64,7 +64,7 @@ void cuda_keyswitch_lwe_ciphertext_vector_64_64_async(
     void const *lwe_input_indexes, void const *ksk, uint32_t lwe_dimension_in,
     uint32_t lwe_dimension_out, uint32_t base_log, uint32_t level_count,
     uint32_t num_samples) {
-  host_keyswitch_lwe_ciphertext_vector<uint64_t, uint64_t>(
+  host_keyswitch_lwe_ciphertext_vector_async<uint64_t, uint64_t>(
       static_cast<cudaStream_t>(stream), gpu_index,
       static_cast<uint64_t *>(lwe_array_out),
       static_cast<uint64_t const *>(lwe_output_indexes),
@@ -80,7 +80,7 @@ void cuda_keyswitch_lwe_ciphertext_vector_64_32_async(
     void const *lwe_input_indexes, void const *ksk, uint32_t lwe_dimension_in,
     uint32_t lwe_dimension_out, uint32_t base_log, uint32_t level_count,
     uint32_t num_samples) {
-  host_keyswitch_lwe_ciphertext_vector<uint64_t, uint32_t>(
+  host_keyswitch_lwe_ciphertext_vector_async<uint64_t, uint32_t>(
       static_cast<cudaStream_t>(stream), gpu_index,
       static_cast<uint32_t *>(lwe_array_out),
       static_cast<const uint64_t *>(lwe_output_indexes),
@@ -110,7 +110,7 @@ void cuda_packing_keyswitch_lwe_list_to_glwe_64_async(
     uint32_t output_polynomial_size, uint32_t base_log, uint32_t level_count,
     uint32_t num_lwes) {
 
-  host_packing_keyswitch_lwe_list_to_glwe<uint64_t>(
+  host_packing_keyswitch_lwe_list_to_glwe_async<uint64_t>(
       static_cast<cudaStream_t>(stream), gpu_index,
       static_cast<uint64_t *>(glwe_array_out),
       static_cast<const uint64_t *>(lwe_array_in),
@@ -158,7 +158,7 @@ void cuda_packing_keyswitch_lwe_list_to_glwe_128_async(
     uint32_t input_lwe_dimension, uint32_t output_glwe_dimension,
     uint32_t output_polynomial_size, uint32_t base_log, uint32_t level_count,
     uint32_t num_lwes) {
-  host_packing_keyswitch_lwe_list_to_glwe<__uint128_t>(
+  host_packing_keyswitch_lwe_list_to_glwe_async<__uint128_t>(
       static_cast<cudaStream_t>(stream), gpu_index,
       static_cast<__uint128_t *>(glwe_array_out),
       static_cast<const __uint128_t *>(lwe_array_in),
@@ -173,8 +173,8 @@ void cuda_closest_representable_64_async(void *stream, uint32_t gpu_index,
                                          uint32_t level_count) {
   PANIC_IF_FALSE(output != input, "Output and input pointers must be different "
                                   "for out-of-place operations");
-  host_cuda_closest_representable(static_cast<cudaStream_t>(stream), gpu_index,
-                                  static_cast<const uint64_t *>(input),
-                                  static_cast<uint64_t *>(output), base_log,
-                                  level_count);
+  host_cuda_closest_representable_async(
+      static_cast<cudaStream_t>(stream), gpu_index,
+      static_cast<const uint64_t *>(input), static_cast<uint64_t *>(output),
+      base_log, level_count);
 }

--- a/backends/tfhe-cuda-backend/cuda/src/crypto/keyswitch.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/crypto/keyswitch.cuh
@@ -66,9 +66,9 @@ __global__ void closest_representable(const T *input, T *output,
 
 template <typename T>
 __host__ void
-host_cuda_closest_representable(cudaStream_t stream, uint32_t gpu_index,
-                                const T *input, T *output, uint32_t base_log,
-                                uint32_t level_count) {
+host_cuda_closest_representable_async(cudaStream_t stream, uint32_t gpu_index,
+                                      const T *input, T *output,
+                                      uint32_t base_log, uint32_t level_count) {
   dim3 grid(1, 1, 1);
   dim3 threads(1, 1, 1);
 
@@ -297,7 +297,7 @@ keyswitch(KSTorus *lwe_array_out, const Torus *__restrict__ lwe_output_indexes,
 }
 
 template <typename Torus, typename KSTorus>
-__host__ void host_keyswitch_lwe_ciphertext_vector(
+__host__ void host_keyswitch_lwe_ciphertext_vector_async(
     cudaStream_t stream, uint32_t gpu_index, KSTorus *lwe_array_out,
     Torus const *lwe_output_indexes, Torus const *lwe_array_in,
     Torus const *lwe_input_indexes, KSTorus const *ksk,
@@ -442,7 +442,7 @@ __host__ void dispatch_gemm_keyswitch_split_k(
 
 // The GEMM keyswitch is computed as: -(-b + sum(a_i A_KSK))
 template <typename Torus, typename KSTorus>
-__host__ void host_gemm_keyswitch_lwe_ciphertext_vector(
+__host__ void host_gemm_keyswitch_lwe_ciphertext_vector_async(
     cudaStream_t stream, uint32_t gpu_index, KSTorus *lwe_array_out,
     Torus const *lwe_output_indices, Torus const *lwe_array_in,
     Torus const *lwe_input_indices, KSTorus const *ksk,
@@ -585,7 +585,7 @@ void execute_keyswitch_async(CudaStreams streams,
 
     if (supports_gemm_ks) {
       // Compute Keyswitch via fused GEMM path
-      host_gemm_keyswitch_lwe_ciphertext_vector<Torus, KSTorus>(
+      host_gemm_keyswitch_lwe_ciphertext_vector_async<Torus, KSTorus>(
           streams.stream(i), streams.gpu_index(i), current_lwe_array_out,
           current_lwe_output_indexes, current_lwe_array_in,
           current_lwe_input_indexes, ksks[i], lwe_dimension_in,
@@ -593,7 +593,7 @@ void execute_keyswitch_async(CudaStreams streams,
           uses_trivial_indices);
     } else {
       // Compute Keyswitch
-      host_keyswitch_lwe_ciphertext_vector<Torus, KSTorus>(
+      host_keyswitch_lwe_ciphertext_vector_async<Torus, KSTorus>(
           streams.stream(i), streams.gpu_index(i), current_lwe_array_out,
           current_lwe_output_indexes, current_lwe_array_in,
           current_lwe_input_indexes, ksks[i], lwe_dimension_in,
@@ -614,7 +614,7 @@ __host__ uint64_t scratch_packing_keyswitch_lwe_list_to_glwe(
   // One GLWE per input LWE for each of the two halves of the buffer: the
   // keyswitched GLWEs and the rotated ones. The fused decompose + GEMM keeps
   // the decomposition in registers, so no extra room is needed for it.
-  // Keep in sync with host_packing_keyswitch_lwe_list_to_glwe.
+  // Keep in sync with host_packing_keyswitch_lwe_list_to_glwe_async.
   uint64_t memory_unit = glwe_accumulator_size;
 
   uint64_t size_tracker = 0;

--- a/backends/tfhe-cuda-backend/cuda/src/crypto/packing_keyswitch.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/crypto/packing_keyswitch.cuh
@@ -131,7 +131,7 @@ launch_packing_gemm_1d(cudaStream_t stream, uint32_t num_lwes, uint32_t gemm_n,
 }
 
 template <typename Torus>
-__host__ void host_packing_keyswitch_lwe_list_to_glwe(
+__host__ void host_packing_keyswitch_lwe_list_to_glwe_async(
     cudaStream_t stream, uint32_t gpu_index, Torus *glwe_out,
     Torus const *lwe_array_in, Torus const *fp_ksk_array, int8_t *fp_ks_buffer,
     uint32_t lwe_dimension, uint32_t glwe_dimension, uint32_t polynomial_size,

--- a/backends/tfhe-cuda-backend/cuda/src/crypto/torus.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/crypto/torus.cuh
@@ -177,7 +177,7 @@ __global__ void modulus_switch_strided_inplace(Torus *array, uint32_t num_glwes,
 }
 
 template <typename Torus>
-__host__ void host_modulus_switch_strided_inplace(
+__host__ void host_modulus_switch_strided_inplace_async(
     cudaStream_t stream, uint32_t gpu_index, Torus *array, uint32_t num_glwes,
     uint32_t in_len, uint32_t in_stride, uint32_t log_modulus) {
   cuda_set_device(gpu_index);
@@ -197,11 +197,12 @@ __host__ void host_modulus_switch_strided_inplace(
 // This makes the strided kernel degenerate to flat sequential access:
 //   offset = glwe_index(=0) * in_stride(=0) + elem_index(=tid) = tid
 template <typename Torus>
-__host__ void host_modulus_switch_inplace(cudaStream_t stream,
-                                          uint32_t gpu_index, Torus *array,
-                                          uint32_t size, uint32_t log_modulus) {
-  host_modulus_switch_strided_inplace<Torus>(stream, gpu_index, array, 1, size,
-                                             0, log_modulus);
+__host__ void host_modulus_switch_inplace_async(cudaStream_t stream,
+                                                uint32_t gpu_index,
+                                                Torus *array, uint32_t size,
+                                                uint32_t log_modulus) {
+  host_modulus_switch_strided_inplace_async<Torus>(stream, gpu_index, array, 1,
+                                                   size, 0, log_modulus);
 }
 
 template <typename Torus>
@@ -214,9 +215,9 @@ __global__ void modulus_switch(Torus *output, const Torus *input, uint32_t size,
 }
 // Applies the modulus switch on a single LWE
 template <typename Torus>
-__host__ void host_modulus_switch(cudaStream_t stream, uint32_t gpu_index,
-                                  Torus *output, const Torus *input,
-                                  uint32_t size, uint32_t log_modulus) {
+__host__ void host_modulus_switch_async(cudaStream_t stream, uint32_t gpu_index,
+                                        Torus *output, const Torus *input,
+                                        uint32_t size, uint32_t log_modulus) {
   cuda_set_device(gpu_index);
 
   int num_threads = 0, num_blocks = 0;
@@ -379,7 +380,7 @@ __global__ void centered_modulus_switch(Torus *output, const Torus *input,
 
 // Applies the centered modulus switch on a single LWE
 template <typename Torus>
-__host__ void host_centered_modulus_switch_inplace(
+__host__ void host_centered_modulus_switch_inplace_async(
     cudaStream_t stream, uint32_t gpu_index, Torus *output, const Torus *input,
     uint32_t lwe_dimension, uint32_t log_modulus) {
   cuda_set_device(gpu_index);
@@ -435,7 +436,7 @@ __global__ void centered_modulus_switch_cooperative(Torus *output,
 // Applies the centered modulus switch on a single LWE with the cooperative body
 // correction, in a block of shape (block_dim_x, block_dim_y, 1)
 template <typename Torus>
-__host__ void host_centered_modulus_switch_cooperative(
+__host__ void host_centered_modulus_switch_cooperative_async(
     cudaStream_t stream, uint32_t gpu_index, Torus *output, const Torus *input,
     uint32_t lwe_dimension, uint32_t log_modulus, uint32_t block_dim_x,
     uint32_t block_dim_y) {
@@ -631,7 +632,7 @@ modulus_switch_multi_bit(Torus *array_out, const Torus *array_in, int size,
 // This aims to be launched only from the noise tests.
 //  That is why we support a specific set of parameters
 template <typename Torus>
-__host__ void host_modulus_switch_multi_bit(
+__host__ void host_modulus_switch_multi_bit_async(
     cudaStream_t stream, uint32_t gpu_index, Torus *array_out, Torus *array_in,
     int size, uint32_t log_modulus, uint32_t degree, uint32_t grouping_factor) {
   check_cuda_error(cudaSetDevice(gpu_index));

--- a/backends/tfhe-cuda-backend/cuda/src/fft128/fft128.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/fft128/fft128.cu
@@ -6,7 +6,7 @@ void cuda_fourier_transform_forward_as_torus_f128_async(
     void *im1, void const *standard, const uint32_t N,
     const uint32_t number_of_samples) {
   DISPATCH_POLY_SIZE(N, AmortizedDegreePolicyFFT128,
-                     host_fourier_transform_forward_as_torus_f128<Params>(
+                     host_fourier_transform_forward_as_torus_f128_async<Params>(
                          static_cast<cudaStream_t>(stream), gpu_index,
                          (double *)re0, (double *)re1, (double *)im0,
                          (double *)im1, (__uint128_t const *)standard, N,
@@ -17,10 +17,10 @@ void cuda_fourier_transform_backward_as_torus_f128_async(
     void *stream, uint32_t gpu_index, void *standard, void const *re0,
     void const *re1, void const *im0, void const *im1, const uint32_t N,
     const uint32_t number_of_samples) {
-  DISPATCH_POLY_SIZE(N, AmortizedDegreePolicyFFT128,
-                     host_fourier_transform_backward_as_torus_f128<Params>(
-                         static_cast<cudaStream_t>(stream), gpu_index,
-                         (__uint128_t *)standard, (double const *)re0,
-                         (double const *)re1, (double const *)im0,
-                         (double const *)im1, N, number_of_samples));
+  DISPATCH_POLY_SIZE(
+      N, AmortizedDegreePolicyFFT128,
+      host_fourier_transform_backward_as_torus_f128_async<Params>(
+          static_cast<cudaStream_t>(stream), gpu_index, (__uint128_t *)standard,
+          (double const *)re0, (double const *)re1, (double const *)im0,
+          (double const *)im1, N, number_of_samples));
 }

--- a/backends/tfhe-cuda-backend/cuda/src/fft128/fft128.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/fft128/fft128.cuh
@@ -727,7 +727,7 @@ __global__ void batch_NSMFFT_strided_128(double *d_in, double *d_out,
 }
 
 template <class params>
-__host__ void host_fourier_transform_forward_as_torus_f128(
+__host__ void host_fourier_transform_forward_as_torus_f128_async(
     cudaStream_t stream, uint32_t gpu_index, double *re0, double *re1,
     double *im0, double *im1, const __uint128_t *standard, const uint32_t N,
     const uint32_t number_of_samples) {
@@ -813,7 +813,7 @@ __host__ void host_fourier_transform_forward_as_torus_f128(
 }
 
 template <class params>
-__host__ void host_fourier_transform_backward_as_torus_f128(
+__host__ void host_fourier_transform_backward_as_torus_f128_async(
     cudaStream_t stream, uint32_t gpu_index, __uint128_t *standard,
     double const *re0, double const *re1, double const *im0, double const *im1,
     const uint32_t N, const uint32_t number_of_samples) {

--- a/backends/tfhe-cuda-backend/cuda/src/integer/abs.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/abs.cu
@@ -21,8 +21,8 @@ void cuda_integer_abs_inplace_64_async(CudaStreamsFFI streams,
 
   auto mem = (int_abs_buffer<uint64_t> *)mem_ptr;
 
-  host_integer_abs<uint64_t>(CudaStreams(streams), ct, bsks,
-                             (uint64_t **)(ksks), mem, is_signed);
+  host_integer_abs_async<uint64_t>(CudaStreams(streams), ct, bsks,
+                                   (uint64_t **)(ksks), mem, is_signed);
 }
 
 void cleanup_cuda_integer_abs_inplace_64(CudaStreamsFFI streams,

--- a/backends/tfhe-cuda-backend/cuda/src/integer/abs.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/abs.cuh
@@ -25,10 +25,10 @@ __host__ uint64_t scratch_cuda_integer_abs(CudaStreams streams,
 }
 
 template <typename Torus>
-__host__ void host_integer_abs(CudaStreams streams, CudaRadixCiphertextFFI *ct,
-                               void *const *bsks, uint64_t *const *ksks,
-                               int_abs_buffer<uint64_t> *mem_ptr,
-                               bool is_signed) {
+__host__ void
+host_integer_abs_async(CudaStreams streams, CudaRadixCiphertextFFI *ct,
+                       void *const *bsks, uint64_t *const *ksks,
+                       int_abs_buffer<uint64_t> *mem_ptr, bool is_signed) {
   if (!is_signed)
     return;
 
@@ -41,20 +41,22 @@ __host__ void host_integer_abs(CudaStreams streams, CudaRadixCiphertextFFI *ct,
   copy_radix_ciphertext_async<Torus>(streams.stream(0), streams.gpu_index(0),
                                      mask, ct);
 
-  host_arithmetic_scalar_shift_inplace<Torus>(
+  host_arithmetic_scalar_shift_inplace_async<Torus>(
       streams, mask, num_bits_in_ciphertext - 1,
       mem_ptr->arithmetic_scalar_shift_mem, bsks, ksks);
-  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), ct, mask, ct,
-                       ct->num_radix_blocks, mem_ptr->params.message_modulus,
-                       mem_ptr->params.carry_modulus);
+  host_addition_async<Torus>(streams.stream(0), streams.gpu_index(0), ct, mask,
+                             ct, ct->num_radix_blocks,
+                             mem_ptr->params.message_modulus,
+                             mem_ptr->params.carry_modulus);
 
   uint32_t requested_flag = outputFlag::FLAG_NONE;
   uint32_t uses_carry = 0;
-  host_propagate_single_carry<Torus>(streams, ct, nullptr, nullptr,
-                                     mem_ptr->scp_mem, bsks, ksks,
-                                     requested_flag, uses_carry);
+  host_propagate_single_carry_async<Torus>(streams, ct, nullptr, nullptr,
+                                           mem_ptr->scp_mem, bsks, ksks,
+                                           requested_flag, uses_carry);
 
-  host_bitop<Torus>(streams, ct, mask, ct, mem_ptr->bitxor_mem, bsks, ksks);
+  host_bitop_async<Torus>(streams, ct, mask, ct, mem_ptr->bitxor_mem, bsks,
+                          ksks);
 }
 
 #endif // TFHE_RS_ABS_CUH

--- a/backends/tfhe-cuda-backend/cuda/src/integer/bitwise_ops.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/bitwise_ops.cu
@@ -5,7 +5,7 @@ void cuda_boolean_bitop_inplace_64_async(
     CudaRadixCiphertextFFI const *lwe_array_2, int8_t *mem_ptr,
     void *const *bsks, void *const *ksks) {
   // In-place variant: lwe_array_inout op= lwe_array_2, no aliasing check needed
-  host_boolean_bitop<uint64_t>(
+  host_boolean_bitop_async<uint64_t>(
       CudaStreams(streams), lwe_array_inout, lwe_array_inout, lwe_array_2,
       (boolean_bitop_buffer<uint64_t> *)mem_ptr, bsks, (uint64_t **)(ksks));
 }
@@ -53,9 +53,9 @@ void cuda_boolean_bitnot_64_async(CudaStreamsFFI streams,
                                   CudaRadixCiphertextFFI *lwe_array,
                                   int8_t *mem_ptr, void *const *bsks,
                                   void *const *ksks) {
-  host_boolean_bitnot<uint64_t>(CudaStreams(streams), lwe_array,
-                                (boolean_bitnot_buffer<uint64_t> *)mem_ptr,
-                                bsks, (uint64_t **)(ksks));
+  host_boolean_bitnot_async<uint64_t>(
+      CudaStreams(streams), lwe_array,
+      (boolean_bitnot_buffer<uint64_t> *)mem_ptr, bsks, (uint64_t **)(ksks));
 }
 
 void cleanup_cuda_boolean_bitnot_64(CudaStreamsFFI streams,
@@ -102,8 +102,9 @@ void cuda_bitnot_ciphertext_64(CudaStreamsFFI streams,
                                uint32_t param_message_modulus,
                                uint32_t param_carry_modulus) {
   auto cuda_streams = CudaStreams(streams);
-  host_bitnot<uint64_t>(cuda_streams, radix_ciphertext, ct_message_modulus,
-                        param_message_modulus, param_carry_modulus);
+  host_bitnot_async<uint64_t>(cuda_streams, radix_ciphertext,
+                              ct_message_modulus, param_message_modulus,
+                              param_carry_modulus);
   cuda_synchronize_stream(cuda_streams.stream(0), cuda_streams.gpu_index(0));
 }
 
@@ -112,9 +113,9 @@ void cuda_integer_bitop_inplace_64_async(
     CudaRadixCiphertextFFI const *lwe_array_2, int8_t *mem_ptr,
     void *const *bsks, void *const *ksks) {
   // In-place variant: lwe_array_inout op= lwe_array_2, no aliasing check needed
-  host_bitop<uint64_t>(CudaStreams(streams), lwe_array_inout, lwe_array_inout,
-                       lwe_array_2, (int_bitop_buffer<uint64_t> *)mem_ptr, bsks,
-                       (uint64_t **)(ksks));
+  host_bitop_async<uint64_t>(
+      CudaStreams(streams), lwe_array_inout, lwe_array_inout, lwe_array_2,
+      (int_bitop_buffer<uint64_t> *)mem_ptr, bsks, (uint64_t **)(ksks));
 }
 
 void cleanup_cuda_integer_bitop_inplace_64(CudaStreamsFFI streams,

--- a/backends/tfhe-cuda-backend/cuda/src/integer/bitwise_ops.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/bitwise_ops.cuh
@@ -23,12 +23,13 @@ __host__ uint64_t scratch_cuda_boolean_bitop(
 }
 
 template <typename Torus, typename KSTorus>
-__host__ void host_boolean_bitop(CudaStreams streams,
-                                 CudaRadixCiphertextFFI *lwe_array_out,
-                                 CudaRadixCiphertextFFI const *lwe_array_1,
-                                 CudaRadixCiphertextFFI const *lwe_array_2,
-                                 boolean_bitop_buffer<Torus> *mem_ptr,
-                                 void *const *bsks, KSTorus *const *ksks) {
+__host__ void
+host_boolean_bitop_async(CudaStreams streams,
+                         CudaRadixCiphertextFFI *lwe_array_out,
+                         CudaRadixCiphertextFFI const *lwe_array_1,
+                         CudaRadixCiphertextFFI const *lwe_array_2,
+                         boolean_bitop_buffer<Torus> *mem_ptr,
+                         void *const *bsks, KSTorus *const *ksks) {
 
   PANIC_IF_FALSE(
       lwe_array_out->num_radix_blocks == lwe_array_1->num_radix_blocks &&
@@ -164,9 +165,9 @@ __host__ void host_boolean_bitop(CudaStreams streams,
 // updates degrees based on `ct_message_modulus`
 template <typename Torus>
 __host__ void
-host_bitnot(CudaStreams streams, CudaRadixCiphertextFFI *radix_ciphertext,
-            uint32_t ct_message_modulus, uint32_t param_message_modulus,
-            uint32_t param_carry_modulus) {
+host_bitnot_async(CudaStreams streams, CudaRadixCiphertextFFI *radix_ciphertext,
+                  uint32_t ct_message_modulus, uint32_t param_message_modulus,
+                  uint32_t param_carry_modulus) {
 
   constexpr Torus TORUS_ONE = (sizeof(Torus) == 4) ? 1U : 1ULL;
   const Torus encoded_scalar =
@@ -175,12 +176,12 @@ host_bitnot(CudaStreams streams, CudaRadixCiphertextFFI *radix_ciphertext,
                                    param_carry_modulus))) *
       (ct_message_modulus - 1);
 
-  host_negation<Torus>(streams.stream(0), streams.gpu_index(0),
-                       radix_ciphertext, radix_ciphertext,
-                       radix_ciphertext->num_radix_blocks,
-                       param_message_modulus, param_carry_modulus);
+  host_negation_async<Torus>(streams.stream(0), streams.gpu_index(0),
+                             radix_ciphertext, radix_ciphertext,
+                             radix_ciphertext->num_radix_blocks,
+                             param_message_modulus, param_carry_modulus);
 
-  host_addition_plaintext_scalar<Torus>(
+  host_addition_plaintext_scalar_async<Torus>(
       streams.stream(0), streams.gpu_index(0), radix_ciphertext,
       radix_ciphertext, encoded_scalar, (uint64_t)(ct_message_modulus - 1),
       radix_ciphertext->lwe_dimension, radix_ciphertext->num_radix_blocks,
@@ -205,10 +206,11 @@ __host__ uint64_t scratch_cuda_boolean_bitnot(
 }
 
 template <typename Torus, typename KSTorus>
-__host__ void host_boolean_bitnot(CudaStreams streams,
-                                  CudaRadixCiphertextFFI *lwe_array,
-                                  boolean_bitnot_buffer<Torus> *mem_ptr,
-                                  void *const *bsks, KSTorus *const *ksks) {
+__host__ void host_boolean_bitnot_async(CudaStreams streams,
+                                        CudaRadixCiphertextFFI *lwe_array,
+                                        boolean_bitnot_buffer<Torus> *mem_ptr,
+                                        void *const *bsks,
+                                        KSTorus *const *ksks) {
   bool carries_empty = true;
   for (size_t i = 0; i < lwe_array->num_radix_blocks; ++i) {
     if (lwe_array->degrees[i] >= mem_ptr->params.message_modulus) {
@@ -222,20 +224,21 @@ __host__ void host_boolean_bitnot(CudaStreams streams,
         lwe_array->num_radix_blocks);
   }
 
-  host_bitnot<Torus>(streams, lwe_array, 2, mem_ptr->params.message_modulus,
-                     mem_ptr->params.carry_modulus);
-  // we don't need to update degrees, because `host_bitnot` updates degrees
-  // based on ct_message_modulus and not param_message_modulus
-  // this function calls `host_bitnot` with `ct_message_modulus = 2`
+  host_bitnot_async<Torus>(streams, lwe_array, 2,
+                           mem_ptr->params.message_modulus,
+                           mem_ptr->params.carry_modulus);
+  // we don't need to update degrees, because `host_bitnot_async` updates
+  // degrees based on ct_message_modulus and not param_message_modulus this
+  // function calls `host_bitnot_async` with `ct_message_modulus = 2`
 }
 
 template <typename Torus, typename KSTorus>
-__host__ void host_bitop(CudaStreams streams,
-                         CudaRadixCiphertextFFI *lwe_array_out,
-                         CudaRadixCiphertextFFI const *lwe_array_1,
-                         CudaRadixCiphertextFFI const *lwe_array_2,
-                         int_bitop_buffer<Torus> *mem_ptr, void *const *bsks,
-                         KSTorus *const *ksks) {
+__host__ void host_bitop_async(CudaStreams streams,
+                               CudaRadixCiphertextFFI *lwe_array_out,
+                               CudaRadixCiphertextFFI const *lwe_array_1,
+                               CudaRadixCiphertextFFI const *lwe_array_2,
+                               int_bitop_buffer<Torus> *mem_ptr,
+                               void *const *bsks, KSTorus *const *ksks) {
 
   PANIC_IF_FALSE(
       lwe_array_out->num_radix_blocks == lwe_array_1->num_radix_blocks &&

--- a/backends/tfhe-cuda-backend/cuda/src/integer/cast.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/cast.cu
@@ -6,8 +6,8 @@ void extend_radix_with_trivial_zero_blocks_msb_64(
   PANIC_IF_FALSE(output != input, "Output and input pointers must be different "
                                   "for out-of-place operations");
   auto cuda_streams = CudaStreams(streams);
-  host_extend_radix_with_trivial_zero_blocks_msb<uint64_t>(output, input,
-                                                           cuda_streams);
+  host_extend_radix_with_trivial_zero_blocks_msb_async<uint64_t>(output, input,
+                                                                 cuda_streams);
   cuda_synchronize_stream(cuda_streams.stream(0), cuda_streams.gpu_index(0));
 }
 
@@ -18,7 +18,7 @@ void trim_radix_blocks_lsb_64(CudaRadixCiphertextFFI *output,
                                   "for out-of-place operations");
 
   auto cuda_streams = CudaStreams(streams);
-  host_trim_radix_blocks_lsb<uint64_t>(output, input, cuda_streams);
+  host_trim_radix_blocks_lsb_async<uint64_t>(output, input, cuda_streams);
   cuda_synchronize_stream(cuda_streams.stream(0), cuda_streams.gpu_index(0));
 }
 
@@ -29,7 +29,7 @@ void trim_radix_blocks_msb_64(CudaRadixCiphertextFFI *output,
                                   "for out-of-place operations");
 
   auto cuda_streams = CudaStreams(streams);
-  host_trim_radix_blocks_msb<uint64_t>(output, input, cuda_streams);
+  host_trim_radix_blocks_msb_async<uint64_t>(output, input, cuda_streams);
   cuda_synchronize_stream(cuda_streams.stream(0), cuda_streams.gpu_index(0));
 }
 
@@ -59,7 +59,7 @@ void cuda_cast_to_unsigned_64_async(CudaStreamsFFI streams,
   PANIC_IF_FALSE(output != input, "Output and input pointers must be different "
                                   "for out-of-place operations");
 
-  host_cast_to_unsigned<uint64_t>(
+  host_cast_to_unsigned_async<uint64_t>(
       CudaStreams(streams), output, input,
       (int_cast_to_unsigned_buffer<uint64_t> *)mem_ptr, target_num_blocks,
       input_is_signed, bsks, (uint64_t **)ksks);
@@ -99,9 +99,10 @@ void cuda_cast_to_signed_64_async(CudaStreamsFFI streams,
   PANIC_IF_FALSE(output != input, "Output and input pointers must be different "
                                   "for out-of-place operations");
 
-  host_cast_to_signed<uint64_t>(CudaStreams(streams), output, input,
-                                (int_cast_to_signed_buffer<uint64_t> *)mem,
-                                input_is_signed, bsks, (uint64_t **)ksks);
+  host_cast_to_signed_async<uint64_t>(
+      CudaStreams(streams), output, input,
+      (int_cast_to_signed_buffer<uint64_t> *)mem, input_is_signed, bsks,
+      (uint64_t **)ksks);
 }
 
 void cleanup_cuda_cast_to_signed_64(CudaStreamsFFI streams,

--- a/backends/tfhe-cuda-backend/cuda/src/integer/cast.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/cast.cuh
@@ -7,7 +7,7 @@
 #include "integer/integer_utilities.h"
 
 template <typename Torus>
-__host__ void host_extend_radix_with_trivial_zero_blocks_msb(
+__host__ void host_extend_radix_with_trivial_zero_blocks_msb_async(
     CudaRadixCiphertextFFI *output, CudaRadixCiphertextFFI const *input,
     CudaStreams streams) {
   PUSH_RANGE("extend only")
@@ -18,9 +18,10 @@ __host__ void host_extend_radix_with_trivial_zero_blocks_msb(
 }
 
 template <typename Torus>
-__host__ void host_trim_radix_blocks_lsb(CudaRadixCiphertextFFI *output,
-                                         CudaRadixCiphertextFFI const *input,
-                                         CudaStreams streams) {
+__host__ void
+host_trim_radix_blocks_lsb_async(CudaRadixCiphertextFFI *output,
+                                 CudaRadixCiphertextFFI const *input,
+                                 CudaStreams streams) {
 
   const uint32_t input_start_lwe_index =
       input->num_radix_blocks - output->num_radix_blocks;
@@ -38,9 +39,9 @@ __host__ void host_trim_radix_blocks_lsb(CudaRadixCiphertextFFI *output,
 
 template <typename Torus>
 __host__ void
-host_trim_radix_blocks_msb(CudaRadixCiphertextFFI *output_radix,
-                           const CudaRadixCiphertextFFI *input_radix,
-                           CudaStreams streams) {
+host_trim_radix_blocks_msb_async(CudaRadixCiphertextFFI *output_radix,
+                                 const CudaRadixCiphertextFFI *input_radix,
+                                 CudaStreams streams) {
 
   PANIC_IF_FALSE(input_radix->num_radix_blocks >=
                      output_radix->num_radix_blocks,
@@ -69,7 +70,7 @@ __host__ uint64_t scratch_extend_radix_with_sign_msb(
 }
 
 template <typename Torus, typename KSTorus>
-__host__ void host_extend_radix_with_sign_msb(
+__host__ void host_extend_radix_with_sign_msb_async(
     CudaStreams streams, CudaRadixCiphertextFFI *output,
     CudaRadixCiphertextFFI const *input,
     int_extend_radix_with_sign_msb_buffer<Torus> *mem_ptr,
@@ -95,8 +96,9 @@ __host__ void host_extend_radix_with_sign_msb(
       streams.stream(0), streams.gpu_index(0), mem_ptr->last_block, 0, 1, input,
       input_blocks - 1, input_blocks);
 
-  host_apply_univariate_lut(streams, mem_ptr->padding_block,
-                            mem_ptr->last_block, mem_ptr->lut, ksks, bsks);
+  host_apply_univariate_lut_async(streams, mem_ptr->padding_block,
+                                  mem_ptr->last_block, mem_ptr->lut, ksks,
+                                  bsks);
 
   for (uint32_t i = 0; i < num_additional_blocks; ++i) {
     uint32_t dst_block_idx = input_blocks + i;
@@ -125,33 +127,33 @@ uint64_t scratch_cuda_cast_to_unsigned(
 
 template <typename Torus>
 __host__ void
-host_cast_to_unsigned(CudaStreams streams, CudaRadixCiphertextFFI *output,
-                      CudaRadixCiphertextFFI *input,
-                      int_cast_to_unsigned_buffer<Torus> *mem_ptr,
-                      uint32_t target_num_blocks, bool input_is_signed,
-                      void *const *bsks, Torus *const *ksks) {
+host_cast_to_unsigned_async(CudaStreams streams, CudaRadixCiphertextFFI *output,
+                            CudaRadixCiphertextFFI *input,
+                            int_cast_to_unsigned_buffer<Torus> *mem_ptr,
+                            uint32_t target_num_blocks, bool input_is_signed,
+                            void *const *bsks, Torus *const *ksks) {
 
   uint32_t current_num_blocks = input->num_radix_blocks;
 
   if (mem_ptr->requires_full_propagate) {
-    host_full_propagate_inplace<Torus>(streams, input, mem_ptr->prop_buffer,
-                                       ksks, bsks, current_num_blocks);
+    host_full_propagate_inplace_async<Torus>(
+        streams, input, mem_ptr->prop_buffer, ksks, bsks, current_num_blocks);
   }
 
   if (target_num_blocks > current_num_blocks) {
     uint32_t num_blocks_to_add = target_num_blocks - current_num_blocks;
 
     if (input_is_signed) {
-      host_extend_radix_with_sign_msb<Torus>(
+      host_extend_radix_with_sign_msb_async<Torus>(
           streams, output, input, mem_ptr->extend_buffer, num_blocks_to_add,
           bsks, (Torus **)ksks);
     } else {
-      host_extend_radix_with_trivial_zero_blocks_msb<Torus>(output, input,
-                                                            streams);
+      host_extend_radix_with_trivial_zero_blocks_msb_async<Torus>(output, input,
+                                                                  streams);
     }
 
   } else if (target_num_blocks < current_num_blocks) {
-    host_trim_radix_blocks_msb<Torus>(output, input, streams);
+    host_trim_radix_blocks_msb_async<Torus>(output, input, streams);
 
   } else {
     copy_radix_ciphertext_slice_async<Torus>(
@@ -178,10 +180,11 @@ scratch_cuda_cast_to_signed(CudaStreams streams,
 
 template <typename Torus>
 __host__ void
-host_cast_to_signed(CudaStreams streams, CudaRadixCiphertextFFI *output,
-                    CudaRadixCiphertextFFI const *input,
-                    int_cast_to_signed_buffer<Torus> *mem_ptr,
-                    bool input_is_signed, void *const *bsks, Torus **ksks) {
+host_cast_to_signed_async(CudaStreams streams, CudaRadixCiphertextFFI *output,
+                          CudaRadixCiphertextFFI const *input,
+                          int_cast_to_signed_buffer<Torus> *mem_ptr,
+                          bool input_is_signed, void *const *bsks,
+                          Torus **ksks) {
 
   uint32_t current_num_blocks = input->num_radix_blocks;
   uint32_t target_num_blocks = mem_ptr->target_num_blocks;
@@ -189,18 +192,18 @@ host_cast_to_signed(CudaStreams streams, CudaRadixCiphertextFFI *output,
   if (input_is_signed) {
     if (target_num_blocks > current_num_blocks) {
       uint32_t num_blocks_to_add = target_num_blocks - current_num_blocks;
-      host_extend_radix_with_sign_msb<Torus>(streams, output, input,
-                                             mem_ptr->extend_buffer,
-                                             num_blocks_to_add, bsks, ksks);
+      host_extend_radix_with_sign_msb_async<Torus>(
+          streams, output, input, mem_ptr->extend_buffer, num_blocks_to_add,
+          bsks, ksks);
     } else {
-      host_trim_radix_blocks_msb<Torus>(output, input, streams);
+      host_trim_radix_blocks_msb_async<Torus>(output, input, streams);
     }
   } else {
     if (target_num_blocks > current_num_blocks) {
-      host_extend_radix_with_trivial_zero_blocks_msb<Torus>(output, input,
-                                                            streams);
+      host_extend_radix_with_trivial_zero_blocks_msb_async<Torus>(output, input,
+                                                                  streams);
     } else {
-      host_trim_radix_blocks_msb<Torus>(output, input, streams);
+      host_trim_radix_blocks_msb_async<Torus>(output, input, streams);
     }
   }
 }

--- a/backends/tfhe-cuda-backend/cuda/src/integer/cmux.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/cmux.cu
@@ -41,10 +41,10 @@ void cuda_cmux_64_async(CudaStreamsFFI streams,
       "Output and false-branch pointers must be different for out-of-place "
       "operations");
   PUSH_RANGE("cmux")
-  host_cmux<uint64_t>(CudaStreams(streams), lwe_array_out, lwe_condition,
-                      lwe_array_true, lwe_array_false,
-                      (int_cmux_buffer<uint64_t> *)mem_ptr, bsks,
-                      (uint64_t **)(ksks));
+  host_cmux_async<uint64_t>(CudaStreams(streams), lwe_array_out, lwe_condition,
+                            lwe_array_true, lwe_array_false,
+                            (int_cmux_buffer<uint64_t> *)mem_ptr, bsks,
+                            (uint64_t **)(ksks));
   POP_RANGE()
 }
 

--- a/backends/tfhe-cuda-backend/cuda/src/integer/cmux.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/cmux.cuh
@@ -35,7 +35,7 @@ __host__ void zero_out_if(CudaStreams streams,
   // We can't use integer_radix_apply_bivariate_lookup_table since the
   // second operand is not an array
   auto tmp_lwe_array_input = mem_ptr->tmp;
-  host_pack_bivariate_blocks_with_single_block<Torus>(
+  host_pack_bivariate_blocks_with_single_block_async<Torus>(
       streams, tmp_lwe_array_input, predicate->lwe_indexes_in, lwe_array_input,
       lwe_condition, predicate->lwe_indexes_in, params.message_modulus,
       num_radix_blocks);
@@ -62,7 +62,7 @@ __host__ void zero_out_if(CudaStreams streams,
 /// @param num_entries        Number of ciphertexts to process
 /// @param num_blocks_per_ct  Number of radix blocks per ciphertext
 template <typename Torus, typename KSTorus>
-__host__ void host_zero_out_if_batch(
+__host__ void host_zero_out_if_batch_async(
     CudaStreams streams, CudaRadixCiphertextFFI *lwe_array_out,
     CudaRadixCiphertextFFI const *lwe_array_input,
     CudaRadixCiphertextFFI const *lwe_conditions,
@@ -93,7 +93,7 @@ __host__ void host_zero_out_if_batch(
   auto params = mem_ptr->params;
 
   auto tmp_lwe_array_input = mem_ptr->tmp;
-  host_pack_bivariate_blocks_with_per_ct_single_block<Torus>(
+  host_pack_bivariate_blocks_with_per_ct_single_block_async<Torus>(
       streams, tmp_lwe_array_input, lwe_array_input, lwe_conditions,
       params.message_modulus, num_entries, num_blocks_per_ct);
 
@@ -120,13 +120,13 @@ __host__ uint64_t scratch_cuda_zero_out_if_batch(
 }
 
 template <typename Torus, typename KSTorus>
-__host__ void host_cmux(CudaStreams streams,
-                        CudaRadixCiphertextFFI *lwe_array_out,
-                        CudaRadixCiphertextFFI const *lwe_condition,
-                        CudaRadixCiphertextFFI const *lwe_array_true,
-                        CudaRadixCiphertextFFI const *lwe_array_false,
-                        int_cmux_buffer<Torus> *mem_ptr, void *const *bsks,
-                        KSTorus *const *ksks) {
+__host__ void host_cmux_async(CudaStreams streams,
+                              CudaRadixCiphertextFFI *lwe_array_out,
+                              CudaRadixCiphertextFFI const *lwe_condition,
+                              CudaRadixCiphertextFFI const *lwe_array_true,
+                              CudaRadixCiphertextFFI const *lwe_array_false,
+                              int_cmux_buffer<Torus> *mem_ptr,
+                              void *const *bsks, KSTorus *const *ksks) {
 
   if (lwe_array_out->num_radix_blocks != lwe_array_true->num_radix_blocks)
     PANIC("Cuda error: input and output num radix blocks must be the same")
@@ -163,9 +163,9 @@ __host__ void host_cmux(CudaStreams streams,
   as_radix_ciphertext_slice<Torus>(&mem_false, mem_ptr->buffer_out,
                                    num_radix_blocks, 2 * num_radix_blocks);
 
-  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), &mem_true,
-                       &mem_true, &mem_false, num_radix_blocks,
-                       params.message_modulus, params.carry_modulus);
+  host_addition_async<Torus>(streams.stream(0), streams.gpu_index(0), &mem_true,
+                             &mem_true, &mem_false, num_radix_blocks,
+                             params.message_modulus, params.carry_modulus);
 
   integer_radix_apply_univariate_lookup_table<Torus>(
       streams, lwe_array_out, &mem_true, bsks, ksks,
@@ -207,13 +207,14 @@ __host__ uint64_t scratch_cuda_cmux(CudaStreams streams,
 /// all entries
 template <typename Torus, typename KSTorus>
 __host__ void
-host_cmux_batch(CudaStreams streams, CudaRadixCiphertextFFI *lwe_array_out,
-                CudaRadixCiphertextFFI const *lwe_array_true,
-                CudaRadixCiphertextFFI const *lwe_array_false,
-                CudaRadixCiphertextFFI const *lwe_conditions,
-                int_cmux_batch_buffer<Torus> *mem_ptr, void *const *bsks,
-                KSTorus *const *ksks, uint32_t num_entries,
-                uint32_t num_blocks_per_ct, bool replicate_true = false) {
+host_cmux_batch_async(CudaStreams streams,
+                      CudaRadixCiphertextFFI *lwe_array_out,
+                      CudaRadixCiphertextFFI const *lwe_array_true,
+                      CudaRadixCiphertextFFI const *lwe_array_false,
+                      CudaRadixCiphertextFFI const *lwe_conditions,
+                      int_cmux_batch_buffer<Torus> *mem_ptr, void *const *bsks,
+                      KSTorus *const *ksks, uint32_t num_entries,
+                      uint32_t num_blocks_per_ct, bool replicate_true = false) {
 
   auto params = mem_ptr->params;
   uint32_t total_num_blocks =
@@ -223,7 +224,7 @@ host_cmux_batch(CudaStreams streams, CudaRadixCiphertextFFI *lwe_array_out,
   cuda_set_device(streams.gpu_index(0));
 
   // Step 1: pack bivariate CMUX inputs (true and false branches).
-  host_pack_bivariate_blocks_cmux_two_regions<Torus>(
+  host_pack_bivariate_blocks_cmux_two_regions_async<Torus>(
       streams, mem_ptr->tmp_packed, lwe_array_true, lwe_array_false,
       lwe_conditions, params.message_modulus, num_entries, num_blocks_per_ct,
       replicate_true);
@@ -240,9 +241,9 @@ host_cmux_batch(CudaStreams streams, CudaRadixCiphertextFFI *lwe_array_out,
   as_radix_ciphertext_slice<Torus>(&false_out, mem_ptr->buffer_out,
                                    total_num_blocks, 2 * total_num_blocks);
 
-  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), &true_out,
-                       &true_out, &false_out, total_num_blocks,
-                       params.message_modulus, params.carry_modulus);
+  host_addition_async<Torus>(streams.stream(0), streams.gpu_index(0), &true_out,
+                             &true_out, &false_out, total_num_blocks,
+                             params.message_modulus, params.carry_modulus);
 
   // Step 4: message extraction (clean up noise/carry from the addition).
   integer_radix_apply_univariate_lookup_table<Torus>(

--- a/backends/tfhe-cuda-backend/cuda/src/integer/comparison.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/comparison.cu
@@ -96,9 +96,9 @@ void cuda_integer_comparison_64_async(CudaStreamsFFI streams,
   switch (buffer->op) {
   case EQ:
   case NE:
-    host_equality_check<uint64_t>(CudaStreams(streams), lwe_array_out,
-                                  lwe_array_1, lwe_array_2, buffer, bsks,
-                                  (uint64_t **)(ksks), num_radix_blocks);
+    host_equality_check_async<uint64_t>(CudaStreams(streams), lwe_array_out,
+                                        lwe_array_1, lwe_array_2, buffer, bsks,
+                                        (uint64_t **)(ksks), num_radix_blocks);
     break;
   case GT:
   case GE:
@@ -115,23 +115,23 @@ void cuda_integer_comparison_64_async(CudaStreamsFFI streams,
       bool swap_operands = (buffer->op == GT || buffer->op == LE);
       auto const *lhs = swap_operands ? lwe_array_2 : lwe_array_1;
       auto const *rhs = swap_operands ? lwe_array_1 : lwe_array_2;
-      host_difference_check_via_borrow<uint64_t>(
+      host_difference_check_via_borrow_async<uint64_t>(
           CudaStreams(streams), lwe_array_out, lhs, rhs, buffer, bsks,
           (uint64_t **)(ksks), num_radix_blocks);
     } else {
-      host_difference_check<uint64_t>(CudaStreams(streams), lwe_array_out,
-                                      lwe_array_1, lwe_array_2, buffer,
-                                      buffer->diff_buffer->operator_f, bsks,
-                                      (uint64_t **)(ksks), num_radix_blocks);
+      host_difference_check_async<uint64_t>(
+          CudaStreams(streams), lwe_array_out, lwe_array_1, lwe_array_2, buffer,
+          buffer->diff_buffer->operator_f, bsks, (uint64_t **)(ksks),
+          num_radix_blocks);
     }
     break;
   case MAX:
   case MIN:
     if (num_radix_blocks % 2 != 0)
       PANIC("Cuda error (max/min): the number of radix blocks has to be even.")
-    host_maxmin<uint64_t>(CudaStreams(streams), lwe_array_out, lwe_array_1,
-                          lwe_array_2, buffer, bsks, (uint64_t **)(ksks),
-                          num_radix_blocks);
+    host_maxmin_async<uint64_t>(CudaStreams(streams), lwe_array_out,
+                                lwe_array_1, lwe_array_2, buffer, bsks,
+                                (uint64_t **)(ksks), num_radix_blocks);
     break;
   default:
     PANIC("Cuda error: integer operation not supported")
@@ -186,7 +186,7 @@ void cuda_integer_are_all_comparisons_block_true_64_async(
   int_comparison_buffer<uint64_t> *buffer =
       (int_comparison_buffer<uint64_t> *)mem_ptr;
 
-  host_integer_are_all_comparisons_block_true<uint64_t>(
+  host_integer_are_all_comparisons_block_true_async<uint64_t>(
       CudaStreams(streams), lwe_array_out, lwe_array_in, buffer, bsks,
       (uint64_t **)(ksks), num_radix_blocks);
 }
@@ -226,7 +226,7 @@ void cuda_integer_is_at_least_one_comparisons_block_true_64_async(
   int_comparison_buffer<uint64_t> *buffer =
       (int_comparison_buffer<uint64_t> *)mem_ptr;
 
-  host_integer_is_at_least_one_comparisons_block_true<uint64_t>(
+  host_integer_is_at_least_one_comparisons_block_true_async<uint64_t>(
       CudaStreams(streams), lwe_array_out, lwe_array_in, buffer, bsks,
       (uint64_t **)(ksks), num_radix_blocks);
 }

--- a/backends/tfhe-cuda-backend/cuda/src/integer/comparison.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/comparison.cuh
@@ -297,7 +297,7 @@ __host__ void is_at_least_one_comparisons_block_true(
 }
 
 template <typename Torus, typename KSTorus>
-__host__ void host_compare_blocks_with_zero(
+__host__ void host_compare_blocks_with_zero_async(
     CudaStreams streams, CudaRadixCiphertextFFI *lwe_array_out,
     CudaRadixCiphertextFFI const *lwe_array_in,
     int_comparison_buffer<Torus> *mem_ptr, void *const *bsks,
@@ -373,12 +373,12 @@ __host__ void host_compare_blocks_with_zero(
 }
 
 template <typename Torus, typename KSTorus>
-__host__ void
-host_equality_check(CudaStreams streams, CudaRadixCiphertextFFI *lwe_array_out,
-                    CudaRadixCiphertextFFI const *lwe_array_1,
-                    CudaRadixCiphertextFFI const *lwe_array_2,
-                    int_comparison_buffer<Torus> *mem_ptr, void *const *bsks,
-                    KSTorus *const *ksks, uint32_t num_radix_blocks) {
+__host__ void host_equality_check_async(
+    CudaStreams streams, CudaRadixCiphertextFFI *lwe_array_out,
+    CudaRadixCiphertextFFI const *lwe_array_1,
+    CudaRadixCiphertextFFI const *lwe_array_2,
+    int_comparison_buffer<Torus> *mem_ptr, void *const *bsks,
+    KSTorus *const *ksks, uint32_t num_radix_blocks) {
 
   if (lwe_array_out->lwe_dimension != lwe_array_1->lwe_dimension ||
       lwe_array_out->lwe_dimension != lwe_array_2->lwe_dimension)
@@ -434,9 +434,9 @@ compare_radix_blocks(CudaStreams streams, CudaRadixCiphertextFFI *lwe_array_out,
   GPU_ASSERT(
       big_lwe_dimension == lwe_array_out->lwe_dimension,
       "Cuda error: big_lwe_dimension must match ciphertexts' lwe_dimension");
-  host_subtraction<Torus>(streams.stream(0), streams.gpu_index(0),
-                          lwe_array_out, lwe_array_left, lwe_array_right,
-                          num_radix_blocks, message_modulus, carry_modulus);
+  host_subtraction_async<Torus>(
+      streams.stream(0), streams.gpu_index(0), lwe_array_out, lwe_array_left,
+      lwe_array_right, num_radix_blocks, message_modulus, carry_modulus);
 
   // Apply LUT to compare to 0
   auto is_non_zero_lut = mem_ptr->eq_buffer->is_non_zero_lut;
@@ -450,8 +450,8 @@ compare_radix_blocks(CudaStreams streams, CudaRadixCiphertextFFI *lwe_array_out,
   CudaRadixCiphertextFFI lwe_array_out_view;
   as_radix_ciphertext_slice<Torus>(&lwe_array_out_view, lwe_array_out, 0,
                                    num_radix_blocks);
-  host_add_scalar_one_inplace<Torus>(streams, &lwe_array_out_view,
-                                     message_modulus, carry_modulus);
+  host_add_scalar_one_inplace_async<Torus>(streams, &lwe_array_out_view,
+                                           message_modulus, carry_modulus);
 }
 
 // Reduces a vec containing shortint blocks that encrypts a sign
@@ -546,7 +546,7 @@ tree_sign_reduction(CudaStreams streams, CudaRadixCiphertextFFI *lwe_array_out,
 }
 
 template <typename Torus, typename KSTorus>
-__host__ void host_difference_check(
+__host__ void host_difference_check_async(
     CudaStreams streams, CudaRadixCiphertextFFI *lwe_array_out,
     CudaRadixCiphertextFFI const *lwe_array_left,
     CudaRadixCiphertextFFI const *lwe_array_right,
@@ -739,7 +739,7 @@ __host__ void host_difference_check(
 /// @param num_radix_blocks number of radix blocks in the operands
 /// @param num_groups number of block groups (the bootstrap batch width)
 template <typename Torus, typename KSTorus>
-__host__ void host_compute_reduced_pgns_and_carries_for_comparison(
+__host__ void host_compute_reduced_pgns_and_carries_for_comparison_async(
     CudaStreams streams, CudaRadixCiphertextFFI *block_states,
     int_radix_params params, int_prop_simu_group_carries_memory<Torus> *mem,
     void *const *bsks, KSTorus *const *ksks, uint32_t num_radix_blocks,
@@ -753,7 +753,7 @@ __host__ void host_compute_reduced_pgns_and_carries_for_comparison(
   auto simulators = mem->simulators;
 
   // Cumulative sum of borrow states within each group.
-  host_radix_cumulative_sum_in_groups<Torus>(
+  host_radix_cumulative_sum_in_groups_async<Torus>(
       streams.stream(0), streams.gpu_index(0), propagation_cum_sums,
       block_states, num_radix_blocks, group_size);
 
@@ -780,7 +780,7 @@ __host__ void host_compute_reduced_pgns_and_carries_for_comparison(
       mem->luts_array_second_step, num_groups);
 
   // Reduced negacyclic corrector map (installed at scratch).
-  host_scalar_addition_inplace<Torus>(
+  host_scalar_addition_inplace_async<Torus>(
       streams, grouping_pgns, mem->scalar_array_cum_sum,
       mem->h_scalar_array_cum_sum, num_groups, message_modulus, carry_modulus);
 
@@ -794,7 +794,7 @@ __host__ void host_compute_reduced_pgns_and_carries_for_comparison(
   // Group-carry resolution: reused verbatim from the full path.
   auto resolved_carries = mem->resolved_carries;
   if (mem->use_sequential_algorithm_to_resolve_group_carries) {
-    host_resolve_group_carries_sequentially(
+    host_resolve_group_carries_sequentially_async(
         streams, resolved_carries, grouping_pgns, params,
         mem->seq_group_prop_mem, bsks, ksks, num_groups);
   } else {
@@ -802,7 +802,7 @@ __host__ void host_compute_reduced_pgns_and_carries_for_comparison(
     CudaRadixCiphertextFFI shifted_resolved_carries;
     as_radix_ciphertext_slice<Torus>(&shifted_resolved_carries,
                                      resolved_carries, 1, num_groups);
-    host_compute_prefix_sum_hillis_steele<Torus>(
+    host_compute_prefix_sum_hillis_steele_async<Torus>(
         streams, &shifted_resolved_carries, grouping_pgns,
         luts_carry_propagation_sum, bsks, ksks, num_groups - 1);
   }
@@ -823,7 +823,7 @@ __host__ void host_compute_reduced_pgns_and_carries_for_comparison(
 /// LUT
 /// @param num_radix_blocks number of radix blocks in the operands
 template <typename Torus, typename KSTorus>
-__host__ void host_difference_check_via_borrow(
+__host__ void host_difference_check_via_borrow_async(
     CudaStreams streams, CudaRadixCiphertextFFI *lwe_array_out,
     CudaRadixCiphertextFFI const *lwe_array_left,
     CudaRadixCiphertextFFI const *lwe_array_right,
@@ -846,13 +846,13 @@ __host__ void host_difference_check_via_borrow(
   // matching the CPU's `unchecked_sub` so the block-state LUTs see the expected
   // encoding (block < message_modulus means the block borrows).
   auto sub_blocks = mem_ptr->tmp_block_comparisons;
-  host_unchecked_sub_with_correcting_term<Torus>(
+  host_unchecked_sub_with_correcting_term_async<Torus>(
       streams.stream(0), streams.gpu_index(0), sub_blocks, lwe_array_left,
       lwe_array_right, num_radix_blocks, message_modulus, carry_modulus);
 
   // Step 1: compute the per-block borrow states (shifted_blocks is unused
   // here).
-  host_compute_shifted_blocks_and_borrow_states<Torus>(
+  host_compute_shifted_blocks_and_borrow_states_async<Torus>(
       streams, sub_blocks, mem->shifted_blocks_borrow_state_mem, bsks, ksks,
       lut_stride, num_many_lut);
 
@@ -866,27 +866,29 @@ __host__ void host_difference_check_via_borrow(
   // version that bootstraps num_groups blocks instead of num_radix_blocks (see
   // the function header). It also writes simulators[num_radix_blocks-1], the
   // only per-block simulator the overflow combine below consumes.
-  host_compute_reduced_pgns_and_carries_for_comparison<Torus>(
+  host_compute_reduced_pgns_and_carries_for_comparison_async<Torus>(
       streams, borrow_states, params, mem->prop_simu_group_carries_mem, bsks,
       ksks, num_radix_blocks, num_groups);
 
   // Combine into the overflow (borrow-out) block, mirroring the overflow branch
-  // of host_single_borrow_propagate.
+  // of host_single_borrow_propagate_async.
   CudaRadixCiphertextFFI shifted_simulators;
   as_radix_ciphertext_slice<Torus>(&shifted_simulators,
                                    mem->prop_simu_group_carries_mem->simulators,
                                    num_radix_blocks - 1, num_radix_blocks);
-  host_addition<Torus>(streams.stream(0), streams.gpu_index(0),
-                       mem->overflow_block, mem->overflow_block,
-                       &shifted_simulators, 1, message_modulus, carry_modulus);
+  host_addition_async<Torus>(streams.stream(0), streams.gpu_index(0),
+                             mem->overflow_block, mem->overflow_block,
+                             &shifted_simulators, 1, message_modulus,
+                             carry_modulus);
 
   CudaRadixCiphertextFFI resolved_borrows;
   as_radix_ciphertext_slice<Torus>(
       &resolved_borrows, mem->prop_simu_group_carries_mem->resolved_carries,
       num_groups - 1, num_groups);
-  host_addition<Torus>(streams.stream(0), streams.gpu_index(0),
-                       mem->overflow_block, mem->overflow_block,
-                       &resolved_borrows, 1, message_modulus, carry_modulus);
+  host_addition_async<Torus>(streams.stream(0), streams.gpu_index(0),
+                             mem->overflow_block, mem->overflow_block,
+                             &resolved_borrows, 1, message_modulus,
+                             carry_modulus);
 
   // Final LUT: ((overflow_block >> 2) & 1) ^ invert, producing the boolean
   // result in a single block.
@@ -910,11 +912,11 @@ __host__ uint64_t scratch_cuda_comparison_check(
 
 template <typename Torus, typename KSTorus>
 __host__ void
-host_maxmin(CudaStreams streams, CudaRadixCiphertextFFI *lwe_array_out,
-            CudaRadixCiphertextFFI const *lwe_array_left,
-            CudaRadixCiphertextFFI const *lwe_array_right,
-            int_comparison_buffer<Torus> *mem_ptr, void *const *bsks,
-            KSTorus *const *ksks, uint32_t num_radix_blocks) {
+host_maxmin_async(CudaStreams streams, CudaRadixCiphertextFFI *lwe_array_out,
+                  CudaRadixCiphertextFFI const *lwe_array_left,
+                  CudaRadixCiphertextFFI const *lwe_array_right,
+                  int_comparison_buffer<Torus> *mem_ptr, void *const *bsks,
+                  KSTorus *const *ksks, uint32_t num_radix_blocks) {
 
   if (lwe_array_out->lwe_dimension != lwe_array_left->lwe_dimension ||
       lwe_array_out->lwe_dimension != lwe_array_right->lwe_dimension)
@@ -926,18 +928,18 @@ host_maxmin(CudaStreams streams, CudaRadixCiphertextFFI *lwe_array_out,
           "than the number of blocks to operate on")
 
   // Compute the sign
-  host_difference_check<Torus>(
+  host_difference_check_async<Torus>(
       streams, mem_ptr->tmp_lwe_array_out, lwe_array_left, lwe_array_right,
       mem_ptr, mem_ptr->identity_lut_f, bsks, ksks, num_radix_blocks);
 
   // Selector
-  host_cmux<Torus>(streams, lwe_array_out, mem_ptr->tmp_lwe_array_out,
-                   lwe_array_left, lwe_array_right, mem_ptr->cmux_buffer, bsks,
-                   ksks);
+  host_cmux_async<Torus>(streams, lwe_array_out, mem_ptr->tmp_lwe_array_out,
+                         lwe_array_left, lwe_array_right, mem_ptr->cmux_buffer,
+                         bsks, ksks);
 }
 
 template <typename Torus, typename KSTorus>
-__host__ void host_integer_are_all_comparisons_block_true(
+__host__ void host_integer_are_all_comparisons_block_true_async(
     CudaStreams streams, CudaRadixCiphertextFFI *lwe_array_out,
     CudaRadixCiphertextFFI const *lwe_array_in,
     int_comparison_buffer<Torus> *mem_ptr, void *const *bsks,
@@ -950,7 +952,7 @@ __host__ void host_integer_are_all_comparisons_block_true(
 }
 
 template <typename Torus, typename KSTorus>
-__host__ void host_integer_is_at_least_one_comparisons_block_true(
+__host__ void host_integer_is_at_least_one_comparisons_block_true_async(
     CudaStreams streams, CudaRadixCiphertextFFI *lwe_array_out,
     CudaRadixCiphertextFFI const *lwe_array_in,
     int_comparison_buffer<Torus> *mem_ptr, void *const *bsks,

--- a/backends/tfhe-cuda-backend/cuda/src/integer/compression/compression.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/compression/compression.cu
@@ -52,18 +52,18 @@ void cuda_integer_compress_radix_ciphertext_64_async(
     CudaLweCiphertextListFFI const *lwe_array_in, void *const *fp_ksk,
     int8_t *mem_ptr) {
 
-  host_integer_compress<uint64_t>(CudaStreams(streams), glwe_array_out,
-                                  lwe_array_in, (uint64_t *const *)(fp_ksk),
-                                  (int_compression<uint64_t> *)mem_ptr);
+  host_integer_compress_async<uint64_t>(
+      CudaStreams(streams), glwe_array_out, lwe_array_in,
+      (uint64_t *const *)(fp_ksk), (int_compression<uint64_t> *)mem_ptr);
 }
 void cuda_integer_decompress_radix_ciphertext_64_async(
     CudaStreamsFFI streams, CudaLweCiphertextListFFI *lwe_array_out,
     CudaPackedGlweCiphertextListFFI const *glwe_in,
     uint32_t const *indexes_array, void *const *bsks, int8_t *mem_ptr) {
 
-  host_integer_decompress<uint64_t>(CudaStreams(streams), lwe_array_out,
-                                    glwe_in, indexes_array, bsks,
-                                    (int_decompression<uint64_t> *)mem_ptr);
+  host_integer_decompress_async<uint64_t>(
+      CudaStreams(streams), lwe_array_out, glwe_in, indexes_array, bsks,
+      (int_decompression<uint64_t> *)mem_ptr);
 }
 void cleanup_cuda_integer_compress_radix_ciphertext_64(CudaStreamsFFI streams,
                                                        int8_t **mem_ptr_void) {
@@ -127,7 +127,7 @@ void cuda_integer_compress_radix_ciphertext_128_async(
     CudaLweCiphertextListFFI const *lwe_array_in, void *const *fp_ksk,
     int8_t *mem_ptr) {
 
-  host_integer_compress<__uint128_t>(
+  host_integer_compress_async<__uint128_t>(
       CudaStreams(streams), glwe_array_out, lwe_array_in,
       (__uint128_t *const *)(fp_ksk), (int_compression<__uint128_t> *)mem_ptr);
 }
@@ -136,7 +136,7 @@ void cuda_integer_decompress_radix_ciphertext_128_async(
     CudaPackedGlweCiphertextListFFI const *glwe_in,
     uint32_t const *indexes_array, int8_t *mem_ptr) {
 
-  host_integer_decompress<__uint128_t>(
+  host_integer_decompress_async<__uint128_t>(
       CudaStreams(streams), lwe_array_out, glwe_in, indexes_array, nullptr,
       (int_decompression<__uint128_t> *)mem_ptr);
 }
@@ -168,9 +168,9 @@ void cuda_integer_extract_glwe_128_async(
     uint32_t const glwe_index) {
 
   CudaStreams _streams = CudaStreams(streams);
-  host_extract<__uint128_t>(_streams.stream(0), _streams.gpu_index(0),
-                            (__uint128_t *)glwe_array_out, glwe_list,
-                            glwe_index);
+  host_extract_async<__uint128_t>(_streams.stream(0), _streams.gpu_index(0),
+                                  (__uint128_t *)glwe_array_out, glwe_list,
+                                  glwe_index);
 }
 
 void cuda_integer_extract_glwe_64_async(
@@ -179,6 +179,7 @@ void cuda_integer_extract_glwe_64_async(
     uint32_t const glwe_index) {
 
   CudaStreams _streams = CudaStreams(streams);
-  host_extract<__uint64_t>(_streams.stream(0), _streams.gpu_index(0),
-                           (__uint64_t *)glwe_array_out, glwe_list, glwe_index);
+  host_extract_async<__uint64_t>(_streams.stream(0), _streams.gpu_index(0),
+                                 (__uint64_t *)glwe_array_out, glwe_list,
+                                 glwe_index);
 }

--- a/backends/tfhe-cuda-backend/cuda/src/integer/compression/compression.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/compression/compression.cuh
@@ -105,7 +105,7 @@
  * and then sample-extracts the requested LWE from the GLWE.
  *
  * -----------------------------------------------------------------------------
- * EXTRACT OUTPUT LAYOUT (glwe_array_out in host_extract)
+ * EXTRACT OUTPUT LAYOUT (glwe_array_out in host_extract_async)
  * -----------------------------------------------------------------------------
  *
  *  +-------------------------------------------------------------------------+
@@ -173,10 +173,10 @@ __global__ void pack(Torus *array_out, Torus const *array_in,
 ///            For strided layout (packing keyswitch output), in_stride ==
 ///            (k+1)*N.
 template <typename Torus>
-__host__ void host_pack(cudaStream_t stream, uint32_t gpu_index,
-                        Torus *packed_out, Torus const *array_in,
-                        uint32_t log_modulus, uint32_t num_glwes,
-                        uint32_t in_len, uint32_t in_stride) {
+__host__ void host_pack_async(cudaStream_t stream, uint32_t gpu_index,
+                              Torus *packed_out, Torus const *array_in,
+                              uint32_t log_modulus, uint32_t num_glwes,
+                              uint32_t in_len, uint32_t in_stride) {
   if (array_in == packed_out)
     PANIC("Cuda error: Input and output must be different");
 
@@ -197,11 +197,10 @@ __host__ void host_pack(cudaStream_t stream, uint32_t gpu_index,
 }
 
 template <typename Torus>
-__host__ void
-host_integer_compress(CudaStreams streams,
-                      CudaPackedGlweCiphertextListFFI *glwe_array_out,
-                      CudaLweCiphertextListFFI const *lwe_array_in,
-                      Torus *const *fp_ksk, int_compression<Torus> *mem_ptr) {
+__host__ void host_integer_compress_async(
+    CudaStreams streams, CudaPackedGlweCiphertextListFFI *glwe_array_out,
+    CudaLweCiphertextListFFI const *lwe_array_in, Torus *const *fp_ksk,
+    int_compression<Torus> *mem_ptr) {
 
   static_assert(std::is_same_v<Torus, uint64_t> ||
                     std::is_same_v<Torus, __uint128_t>,
@@ -214,7 +213,7 @@ host_integer_compress(CudaStreams streams,
 
   if constexpr (std::is_same_v<Torus, uint64_t>) {
     lwe_pksk_input = mem_ptr->tmp_lwe;
-    host_cleartext_multiplication_unsafe_no_degrees<Torus>(
+    host_cleartext_multiplication_unsafe_no_degrees_async<Torus>(
         streams.stream(0), streams.gpu_index(0), lwe_pksk_input, lwe_array_in,
         (uint64_t)compression_params.message_modulus);
   }
@@ -258,7 +257,7 @@ host_integer_compress(CudaStreams streams,
   while (rem_lwes > 0) {
     auto chunk_size = min(rem_lwes, glwe_array_out->num_lwes_stored_per_glwe);
 
-    host_packing_keyswitch_lwe_list_to_glwe<Torus>(
+    host_packing_keyswitch_lwe_list_to_glwe_async<Torus>(
         streams.stream(0), streams.gpu_index(0), glwe_out, lwe_pksk_input,
         fp_ksk[0], fp_ks_buffer, compression_params.small_lwe_dimension,
         compression_params.glwe_dimension, compression_params.polynomial_size,
@@ -278,16 +277,16 @@ host_integer_compress(CudaStreams streams,
   // Strided modswitch: process only the meaningful elements of each GLWE,
   // skipping garbage body positions [num_lwes_stored_per_glwe,
   // polynomial_size).
-  host_modulus_switch_strided_inplace<Torus>(
+  host_modulus_switch_strided_inplace_async<Torus>(
       streams.stream(0), streams.gpu_index(0), tmp_glwe_array_out, num_glwes,
       per_glwe_in_len, glwe_out_size, glwe_array_out->storage_log_modulus);
 
   // Pack per-GLWE: read per_glwe_in_len elements from each GLWE in the
   // strided buffer (stride = glwe_out_size), pack into per-GLWE chunks.
-  host_pack<Torus>(streams.stream(0), streams.gpu_index(0),
-                   (Torus *)glwe_array_out->ptr, tmp_glwe_array_out,
-                   glwe_array_out->storage_log_modulus, num_glwes,
-                   per_glwe_in_len, glwe_out_size);
+  host_pack_async<Torus>(streams.stream(0), streams.gpu_index(0),
+                         (Torus *)glwe_array_out->ptr, tmp_glwe_array_out,
+                         glwe_array_out->storage_log_modulus, num_glwes,
+                         per_glwe_in_len, glwe_out_size);
 }
 
 template <typename Torus>
@@ -326,10 +325,9 @@ __global__ void extract(Torus *glwe_array_out, Torus const *array_in,
 /// Extracts the glwe_index-nth GLWE ciphertext
 /// This function follows the naming used in the CPU implementation
 template <typename Torus>
-__host__ void host_extract(cudaStream_t stream, uint32_t gpu_index,
-                           Torus *glwe_array_out,
-                           CudaPackedGlweCiphertextListFFI const *array_in,
-                           uint32_t glwe_index) {
+__host__ void host_extract_async(
+    cudaStream_t stream, uint32_t gpu_index, Torus *glwe_array_out,
+    CudaPackedGlweCiphertextListFFI const *array_in, uint32_t glwe_index) {
   if ((Torus *)array_in->ptr == glwe_array_out)
     PANIC("Cuda error: Input and output must be different");
 
@@ -396,12 +394,11 @@ __host__ void host_extract(cudaStream_t stream, uint32_t gpu_index,
 }
 
 template <typename Torus>
-__host__ void
-host_integer_decompress(CudaStreams streams,
-                        CudaLweCiphertextListFFI *d_lwe_array_out,
-                        CudaPackedGlweCiphertextListFFI const *d_packed_glwe_in,
-                        uint32_t const *h_indexes_array, void *const *d_bsks,
-                        int_decompression<Torus> *h_mem_ptr) {
+__host__ void host_integer_decompress_async(
+    CudaStreams streams, CudaLweCiphertextListFFI *d_lwe_array_out,
+    CudaPackedGlweCiphertextListFFI const *d_packed_glwe_in,
+    uint32_t const *h_indexes_array, void *const *d_bsks,
+    int_decompression<Torus> *h_mem_ptr) {
 
   static_assert(std::is_same_v<Torus, uint64_t> ||
                     std::is_same_v<Torus, __uint128_t>,
@@ -425,8 +422,9 @@ host_integer_decompress(CudaStreams streams,
 
   auto current_glwe_index = h_indexes_array[0] / num_lwes_stored_per_glwe;
   auto extracted_glwe = h_mem_ptr->tmp_extracted_glwe;
-  host_extract<Torus>(streams.stream(0), streams.gpu_index(0), extracted_glwe,
-                      d_packed_glwe_in, current_glwe_index);
+  host_extract_async<Torus>(streams.stream(0), streams.gpu_index(0),
+                            extracted_glwe, d_packed_glwe_in,
+                            current_glwe_index);
   glwe_vec.push_back(std::make_pair(1, extracted_glwe));
   for (int i = 1; i < num_blocks_to_decompress; i++) {
     auto glwe_index = h_indexes_array[i] / num_lwes_stored_per_glwe;
@@ -434,8 +432,8 @@ host_integer_decompress(CudaStreams streams,
       extracted_glwe += glwe_accumulator_size;
       current_glwe_index = glwe_index;
       // Extracts a new GLWE
-      host_extract<Torus>(streams.stream(0), streams.gpu_index(0),
-                          extracted_glwe, d_packed_glwe_in, glwe_index);
+      host_extract_async<Torus>(streams.stream(0), streams.gpu_index(0),
+                                extracted_glwe, d_packed_glwe_in, glwe_index);
       glwe_vec.push_back(std::make_pair(1, extracted_glwe));
     } else {
       // Updates the quantity

--- a/backends/tfhe-cuda-backend/cuda/src/integer/div_rem.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/div_rem.cuh
@@ -83,24 +83,24 @@ __host__ void host_unsigned_integer_div_rem_block_by_block_2_2(
                                      mem_ptr->d1, divisor_gpu_2);
 
   // Computes 2*d by extending and shifting on gpu[1]
-  host_extend_radix_with_trivial_zero_blocks_msb<Torus>(
+  host_extend_radix_with_trivial_zero_blocks_msb_async<Torus>(
       mem_ptr->d2, divisor_gpu_1, streams.get_ith(1));
-  host_logical_scalar_shift_inplace<Torus>(
+  host_logical_scalar_shift_inplace_async<Torus>(
       streams.get_ith(1), mem_ptr->d2, 1, mem_ptr->shift_mem, &bsks[1],
       &ksks[1], mem_ptr->d2->num_radix_blocks);
 
   // Computes 3*d = 4*d - d using block shift and subtraction on gpu[0]
-  host_extend_radix_with_trivial_zero_blocks_msb<Torus>(
+  host_extend_radix_with_trivial_zero_blocks_msb_async<Torus>(
       mem_ptr->tmp_gpu_0, divisor_gpu_0, streams.get_ith(0));
-  host_radix_blocks_rotate_right<Torus>(streams.get_ith(0), mem_ptr->d3,
-                                        mem_ptr->tmp_gpu_0, 1,
-                                        mem_ptr->tmp_gpu_0->num_radix_blocks);
+  host_radix_blocks_rotate_right_async<Torus>(
+      streams.get_ith(0), mem_ptr->d3, mem_ptr->tmp_gpu_0, 1,
+      mem_ptr->tmp_gpu_0->num_radix_blocks);
   set_zero_radix_ciphertext_slice_async<Torus>(
       streams.stream(0), streams.gpu_index(0), mem_ptr->d3, 0, 1);
-  host_sub_and_propagate_single_carry(streams.get_ith(0), mem_ptr->d3,
-                                      mem_ptr->tmp_gpu_0, nullptr, nullptr,
-                                      mem_ptr->sub_and_propagate_mem, &bsks[0],
-                                      &ksks[0], outputFlag::FLAG_NONE, 0);
+  host_sub_and_propagate_single_carry_async(
+      streams.get_ith(0), mem_ptr->d3, mem_ptr->tmp_gpu_0, nullptr, nullptr,
+      mem_ptr->sub_and_propagate_mem, &bsks[0], &ksks[0], outputFlag::FLAG_NONE,
+      0);
 
   // +-----------------+-----------------+-----------------+-----------------+
   // |     GPU[0]      |     GPU[1]      |     GPU[2]      |     GPU[3]      |
@@ -157,7 +157,7 @@ __host__ void host_unsigned_integer_div_rem_block_by_block_2_2(
       overflow_sub_mem->update_lut_indexes(
           streams.get_ith(gpu_index), first_indexes, second_indexes,
           scalar_indexes, rem->num_radix_blocks);
-      host_integer_overflowing_sub<uint64_t>(
+      host_integer_overflowing_sub_async<uint64_t>(
           streams.get_ith(gpu_index), sub_result, rem, low, sub_overflowed,
           (const CudaRadixCiphertextFFI *)nullptr, overflow_sub_mem,
           &bsks[gpu_index], &ksks[gpu_index], compute_overflow,
@@ -181,7 +181,7 @@ __host__ void host_unsigned_integer_div_rem_block_by_block_2_2(
                           streams.stream(gpu_index),
                           streams.gpu_index(gpu_index));
       } else {
-        host_compare_blocks_with_zero<Torus>(
+        host_compare_blocks_with_zero_async<Torus>(
             streams.get_ith(gpu_index), comparison_blocks, &d_msb,
             comparison_buffer, &bsks[gpu_index], &ksks[gpu_index],
             d_msb.num_radix_blocks, comparison_buffer->is_zero_lut);
@@ -194,15 +194,15 @@ __host__ void host_unsigned_integer_div_rem_block_by_block_2_2(
                        out_boolean_block->lwe_dimension,
                    "Cuda error: big_lwe_dimension must match ciphertexts' "
                    "lwe_dimension");
-        host_negation<Torus>(streams.stream(gpu_index),
-                             streams.gpu_index(gpu_index), out_boolean_block,
-                             out_boolean_block, 1, radix_params.message_modulus,
-                             radix_params.carry_modulus);
+        host_negation_async<Torus>(
+            streams.stream(gpu_index), streams.gpu_index(gpu_index),
+            out_boolean_block, out_boolean_block, 1,
+            radix_params.message_modulus, radix_params.carry_modulus);
 
         // we calculate encoding because this block works only for
         // message_modulus = 4 and carry_modulus = 4.
         const Torus encoded_scalar = 1ULL << (sizeof(Torus) * 8 - 5);
-        host_addition_plaintext_scalar<Torus>(
+        host_addition_plaintext_scalar_async<Torus>(
             streams.stream(gpu_index), streams.gpu_index(gpu_index),
             out_boolean_block, out_boolean_block, encoded_scalar, 1ULL,
             radix_params.big_lwe_dimension, 1, radix_params.message_modulus,
@@ -255,14 +255,14 @@ __host__ void host_unsigned_integer_div_rem_block_by_block_2_2(
     auto o3 = mem_ptr->sub_1_overflowed;
 
     // used as a bitor
-    host_bitop(streams.get_ith(0), o3, o3, mem_ptr->cmp_1, mem_ptr->bitor_mem_1,
-               &bsks[0], &ksks[0]);
+    host_bitop_async(streams.get_ith(0), o3, o3, mem_ptr->cmp_1,
+                     mem_ptr->bitor_mem_1, &bsks[0], &ksks[0]);
     // used as a bitor
-    host_bitop(streams.get_ith(1), o2, o2, mem_ptr->cmp_2, mem_ptr->bitor_mem_2,
-               &bsks[1], &ksks[1]);
+    host_bitop_async(streams.get_ith(1), o2, o2, mem_ptr->cmp_2,
+                     mem_ptr->bitor_mem_2, &bsks[1], &ksks[1]);
     // used as a bitor
-    host_bitop(streams.get_ith(2), o1, o1, mem_ptr->cmp_3, mem_ptr->bitor_mem_3,
-               &bsks[2], &ksks[2]);
+    host_bitop_async(streams.get_ith(2), o1, o1, mem_ptr->cmp_3,
+                     mem_ptr->bitor_mem_3, &bsks[2], &ksks[2]);
 
     // cmp_1, cmp_2, cmp_3 are not needed anymore, we can reuse them as c3,
     // c2, c1. c0 is allocated on gpu[3], we take it from mem_ptr.
@@ -297,11 +297,11 @@ __host__ void host_unsigned_integer_div_rem_block_by_block_2_2(
     GPU_ASSERT(
         radix_params.big_lwe_dimension == c3->lwe_dimension,
         "Cuda error: big_lwe_dimension must match ciphertexts' lwe_dimension");
-    host_negation<Torus>(streams.stream(0), streams.gpu_index(0), c3, c3, 1,
-                         radix_params.message_modulus,
-                         radix_params.carry_modulus);
+    host_negation_async<Torus>(streams.stream(0), streams.gpu_index(0), c3, c3,
+                               1, radix_params.message_modulus,
+                               radix_params.carry_modulus);
     const Torus encoded_scalar = 1ULL << (sizeof(Torus) * 8 - 5);
-    host_addition_plaintext_scalar<Torus>(
+    host_addition_plaintext_scalar_async<Torus>(
         streams.stream(0), streams.gpu_index(0), c3, c3, encoded_scalar, 1ULL,
         radix_params.big_lwe_dimension, 1, radix_params.message_modulus,
         radix_params.carry_modulus);
@@ -312,15 +312,15 @@ __host__ void host_unsigned_integer_div_rem_block_by_block_2_2(
     GPU_ASSERT(
         radix_params.big_lwe_dimension == c2->lwe_dimension,
         "Cuda error: big_lwe_dimension must match ciphertexts' lwe_dimension");
-    host_negation<Torus>(streams.stream(1), streams.gpu_index(1), c2, c2, 1,
-                         radix_params.message_modulus,
-                         radix_params.carry_modulus);
-    host_addition_plaintext_scalar<Torus>(
+    host_negation_async<Torus>(streams.stream(1), streams.gpu_index(1), c2, c2,
+                               1, radix_params.message_modulus,
+                               radix_params.carry_modulus);
+    host_addition_plaintext_scalar_async<Torus>(
         streams.stream(1), streams.gpu_index(1), c2, c2, encoded_scalar, 1ULL,
         radix_params.big_lwe_dimension, 1, radix_params.message_modulus,
         radix_params.carry_modulus);
-    host_addition<Torus>(streams.stream(1), streams.gpu_index(1), c2, c2,
-                         o3_gpu_1, 1, 4, 4);
+    host_addition_async<Torus>(streams.stream(1), streams.gpu_index(1), c2, c2,
+                               o3_gpu_1, 1, 4, 4);
 
     // c1 = !o1 + o2
     copy_radix_ciphertext_slice_async<Torus>(
@@ -328,15 +328,15 @@ __host__ void host_unsigned_integer_div_rem_block_by_block_2_2(
     GPU_ASSERT(
         radix_params.big_lwe_dimension == c1->lwe_dimension,
         "Cuda error: big_lwe_dimension must match ciphertexts' lwe_dimension");
-    host_negation<Torus>(streams.stream(2), streams.gpu_index(2), c1, c1, 1,
-                         radix_params.message_modulus,
-                         radix_params.carry_modulus);
-    host_addition_plaintext_scalar<Torus>(
+    host_negation_async<Torus>(streams.stream(2), streams.gpu_index(2), c1, c1,
+                               1, radix_params.message_modulus,
+                               radix_params.carry_modulus);
+    host_addition_plaintext_scalar_async<Torus>(
         streams.stream(2), streams.gpu_index(2), c1, c1, encoded_scalar, 1ULL,
         radix_params.big_lwe_dimension, 1, radix_params.message_modulus,
         radix_params.carry_modulus);
-    host_addition<Torus>(streams.stream(2), streams.gpu_index(2), c1, c1,
-                         o2_gpu_2, 1, 4, 4);
+    host_addition_async<Torus>(streams.stream(2), streams.gpu_index(2), c1, c1,
+                               o2_gpu_2, 1, 4, 4);
 
     // c0 = o1 (direct copy)
     copy_radix_ciphertext_slice_async<Torus>(streams.stream(3),
@@ -347,12 +347,12 @@ __host__ void host_unsigned_integer_div_rem_block_by_block_2_2(
                                   CudaRadixCiphertextFFI *cx,
                                   CudaRadixCiphertextFFI *rx,
                                   int_radix_lut<Torus> *lut, Torus factor) {
-      host_cleartext_multiplication<Torus>(
+      host_cleartext_multiplication_async<Torus>(
           streams.stream(gpu_index), streams.gpu_index(gpu_index), rx, rx,
           factor, radix_params.message_modulus, radix_params.carry_modulus);
-      host_add_the_same_block_to_all_blocks<Torus>(streams.stream(gpu_index),
-                                                   streams.gpu_index(gpu_index),
-                                                   rx, rx, cx, 4, 4);
+      host_add_the_same_block_to_all_blocks_async<Torus>(
+          streams.stream(gpu_index), streams.gpu_index(gpu_index), rx, rx, cx,
+          4, 4);
       integer_radix_apply_univariate_lookup_table<Torus>(
           streams.get_ith(gpu_index), rx, rx, &bsks[gpu_index],
           &ksks[gpu_index], lut, rx->num_radix_blocks);
@@ -426,20 +426,20 @@ __host__ void host_unsigned_integer_div_rem_block_by_block_2_2(
     copy_radix_ciphertext_async<Torus>(streams.stream(0), streams.gpu_index(0),
                                        q1_gpu_0, mem_ptr->q1);
 
-    host_addition<Torus>(streams.stream(0), streams.gpu_index(0), rem_gpu_0,
-                         rem_gpu_0, r3_gpu_0, rem_gpu_0->num_radix_blocks, 4,
-                         4);
-    host_addition<Torus>(streams.stream(0), streams.gpu_index(0), rem_gpu_0,
-                         rem_gpu_0, r2_gpu_0, rem_gpu_0->num_radix_blocks, 4,
-                         4);
-    host_addition<Torus>(streams.stream(0), streams.gpu_index(0), rem_gpu_0,
-                         rem_gpu_0, r1_gpu_0, rem_gpu_0->num_radix_blocks, 4,
-                         4);
+    host_addition_async<Torus>(streams.stream(0), streams.gpu_index(0),
+                               rem_gpu_0, rem_gpu_0, r3_gpu_0,
+                               rem_gpu_0->num_radix_blocks, 4, 4);
+    host_addition_async<Torus>(streams.stream(0), streams.gpu_index(0),
+                               rem_gpu_0, rem_gpu_0, r2_gpu_0,
+                               rem_gpu_0->num_radix_blocks, 4, 4);
+    host_addition_async<Torus>(streams.stream(0), streams.gpu_index(0),
+                               rem_gpu_0, rem_gpu_0, r1_gpu_0,
+                               rem_gpu_0->num_radix_blocks, 4, 4);
 
-    host_addition<Torus>(streams.stream(0), streams.gpu_index(0), q3_gpu_0,
-                         q3_gpu_0, q2_gpu_0, 1, 4, 4);
-    host_addition<Torus>(streams.stream(0), streams.gpu_index(0), q3_gpu_0,
-                         q3_gpu_0, q1_gpu_0, 1, 4, 4);
+    host_addition_async<Torus>(streams.stream(0), streams.gpu_index(0),
+                               q3_gpu_0, q3_gpu_0, q2_gpu_0, 1, 4, 4);
+    host_addition_async<Torus>(streams.stream(0), streams.gpu_index(0),
+                               q3_gpu_0, q3_gpu_0, q1_gpu_0, 1, 4, 4);
 
     streams.synchronize();
 
@@ -652,7 +652,7 @@ __host__ void host_unsigned_integer_div_rem(
           streams.stream(0), streams.gpu_index(0), mem_ptr->numerator_block_1,
           interesting_remainder1, 0);
 
-      host_logical_scalar_shift_inplace<Torus>(
+      host_logical_scalar_shift_inplace_async<Torus>(
           streams, interesting_remainder1, 1, mem_ptr->shift_mem_1, bsks, ksks,
           interesting_remainder1->num_radix_blocks);
 
@@ -662,7 +662,7 @@ __host__ void host_unsigned_integer_div_rem(
           streams.stream(0), streams.gpu_index(0), mem_ptr->tmp_radix,
           interesting_remainder1);
 
-      host_radix_blocks_rotate_left<Torus>(
+      host_radix_blocks_rotate_left_async<Torus>(
           streams, interesting_remainder1, mem_ptr->tmp_radix, 1,
           interesting_remainder1->num_radix_blocks);
 
@@ -681,7 +681,7 @@ __host__ void host_unsigned_integer_div_rem(
     }; // left_shift_interesting_remainder1
 
     auto left_shift_interesting_remainder2 = [&](CudaStreams streams) {
-      host_logical_scalar_shift_inplace<Torus>(
+      host_logical_scalar_shift_inplace_async<Torus>(
           streams, interesting_remainder2, 1, mem_ptr->shift_mem_2, bsks, ksks,
           interesting_remainder2->num_radix_blocks);
     }; // left_shift_interesting_remainder2
@@ -709,7 +709,7 @@ __host__ void host_unsigned_integer_div_rem(
     // but in that position, interesting_remainder2 always has a 0
     auto merged_interesting_remainder = interesting_remainder1;
 
-    host_addition<Torus>(
+    host_addition_async<Torus>(
         streams.stream(0), streams.gpu_index(0), merged_interesting_remainder,
         merged_interesting_remainder, interesting_remainder2,
         merged_interesting_remainder->num_radix_blocks,
@@ -752,7 +752,7 @@ __host__ void host_unsigned_integer_div_rem(
       mem_ptr->overflow_sub_mem->update_lut_indexes(
           streams, first_indexes, second_indexes, scalar_indexes,
           merged_interesting_remainder->num_radix_blocks);
-      host_integer_overflowing_sub<uint64_t>(
+      host_integer_overflowing_sub_async<uint64_t>(
           streams, new_remainder, merged_interesting_remainder,
           interesting_divisor, subtraction_overflowed,
           (const CudaRadixCiphertextFFI *)nullptr, mem_ptr->overflow_sub_mem,
@@ -772,7 +772,7 @@ __host__ void host_unsigned_integer_div_rem(
         // We could call unchecked_scalar_ne
         // But we are in the special case where scalar == 0
         // So we can skip some stuff
-        host_compare_blocks_with_zero<Torus>(
+        host_compare_blocks_with_zero_async<Torus>(
             streams, mem_ptr->tmp_1, trivial_blocks, mem_ptr->comparison_buffer,
             bsks, ksks, trivial_blocks->num_radix_blocks,
             mem_ptr->comparison_buffer->eq_buffer->is_non_zero_lut);
@@ -810,7 +810,7 @@ __host__ void host_unsigned_integer_div_rem(
     mem_ptr->sub_streams_2.synchronize();
     mem_ptr->sub_streams_3.synchronize();
 
-    host_addition<Torus>(
+    host_addition_async<Torus>(
         streams.stream(0), streams.gpu_index(0), overflow_sum,
         subtraction_overflowed, at_least_one_upper_block_is_non_zero, 1,
         radix_params.message_modulus, radix_params.carry_modulus);
@@ -854,7 +854,7 @@ __host__ void host_unsigned_integer_div_rem(
       CudaRadixCiphertextFFI quotient_block;
       as_radix_ciphertext_slice<Torus>(&quotient_block, quotient, block_of_bit,
                                        block_of_bit + 1);
-      host_addition<Torus>(
+      host_addition_async<Torus>(
           streams.stream(0), streams.gpu_index(0), &quotient_block,
           &quotient_block, mem_ptr->did_not_overflow, 1,
           radix_params.message_modulus, radix_params.carry_modulus);
@@ -896,10 +896,10 @@ __host__ void host_unsigned_integer_div_rem(
 
   // Clean the quotient and remainder
   // as even though they have no carries, they are not at nominal noise level
-  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), remainder,
-                       remainder1, remainder2, remainder1->num_radix_blocks,
-                       radix_params.message_modulus,
-                       radix_params.carry_modulus);
+  host_addition_async<Torus>(
+      streams.stream(0), streams.gpu_index(0), remainder, remainder1,
+      remainder2, remainder1->num_radix_blocks, radix_params.message_modulus,
+      radix_params.carry_modulus);
 
   streams.synchronize();
 
@@ -943,10 +943,11 @@ __host__ void host_integer_div_rem(
 
     streams.synchronize();
 
-    host_integer_abs<Torus>(int_mem_ptr->sub_streams_1, positive_numerator,
-                            bsks, ksks, int_mem_ptr->abs_mem_1, true);
-    host_integer_abs<Torus>(int_mem_ptr->sub_streams_2, positive_divisor, bsks,
-                            ksks, int_mem_ptr->abs_mem_2, true);
+    host_integer_abs_async<Torus>(int_mem_ptr->sub_streams_1,
+                                  positive_numerator, bsks, ksks,
+                                  int_mem_ptr->abs_mem_1, true);
+    host_integer_abs_async<Torus>(int_mem_ptr->sub_streams_2, positive_divisor,
+                                  bsks, ksks, int_mem_ptr->abs_mem_2, true);
 
     int_mem_ptr->sub_streams_1.synchronize();
     int_mem_ptr->sub_streams_2.synchronize();
@@ -970,34 +971,35 @@ __host__ void host_integer_div_rem(
     int_mem_ptr->sub_streams_1.synchronize();
     int_mem_ptr->sub_streams_2.synchronize();
 
-    host_negation_with_correcting_term<Torus>(
+    host_negation_with_correcting_term_async<Torus>(
         int_mem_ptr->sub_streams_1, int_mem_ptr->negated_quotient, quotient,
         radix_params.message_modulus, radix_params.carry_modulus, num_blocks);
 
     uint32_t requested_flag = outputFlag::FLAG_NONE;
     uint32_t uses_carry = 0;
-    host_propagate_single_carry<Torus>(int_mem_ptr->sub_streams_1,
-                                       int_mem_ptr->negated_quotient, nullptr,
-                                       nullptr, int_mem_ptr->scp_mem_1, bsks,
-                                       ksks, requested_flag, uses_carry);
+    host_propagate_single_carry_async<Torus>(
+        int_mem_ptr->sub_streams_1, int_mem_ptr->negated_quotient, nullptr,
+        nullptr, int_mem_ptr->scp_mem_1, bsks, ksks, requested_flag,
+        uses_carry);
 
-    host_negation_with_correcting_term<Torus>(
+    host_negation_with_correcting_term_async<Torus>(
         int_mem_ptr->sub_streams_2, int_mem_ptr->negated_remainder, remainder,
         radix_params.message_modulus, radix_params.carry_modulus, num_blocks);
 
-    host_propagate_single_carry<Torus>(int_mem_ptr->sub_streams_2,
-                                       int_mem_ptr->negated_remainder, nullptr,
-                                       nullptr, int_mem_ptr->scp_mem_2, bsks,
-                                       ksks, requested_flag, uses_carry);
+    host_propagate_single_carry_async<Torus>(
+        int_mem_ptr->sub_streams_2, int_mem_ptr->negated_remainder, nullptr,
+        nullptr, int_mem_ptr->scp_mem_2, bsks, ksks, requested_flag,
+        uses_carry);
 
-    host_cmux<Torus>(int_mem_ptr->sub_streams_1, quotient,
-                     int_mem_ptr->sign_bits_are_different,
-                     int_mem_ptr->negated_quotient, quotient,
-                     int_mem_ptr->cmux_quotient_mem, bsks, ksks);
+    host_cmux_async<Torus>(int_mem_ptr->sub_streams_1, quotient,
+                           int_mem_ptr->sign_bits_are_different,
+                           int_mem_ptr->negated_quotient, quotient,
+                           int_mem_ptr->cmux_quotient_mem, bsks, ksks);
 
-    host_cmux<Torus>(int_mem_ptr->sub_streams_2, remainder, &numerator_sign,
-                     int_mem_ptr->negated_remainder, remainder,
-                     int_mem_ptr->cmux_remainder_mem, bsks, ksks);
+    host_cmux_async<Torus>(int_mem_ptr->sub_streams_2, remainder,
+                           &numerator_sign, int_mem_ptr->negated_remainder,
+                           remainder, int_mem_ptr->cmux_remainder_mem, bsks,
+                           ksks);
 
     int_mem_ptr->sub_streams_1.synchronize();
     int_mem_ptr->sub_streams_2.synchronize();

--- a/backends/tfhe-cuda-backend/cuda/src/integer/ilog2.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/ilog2.cu
@@ -29,7 +29,7 @@ void cuda_integer_count_of_consecutive_bits_64_async(
                  "Output and input pointers must be different for out-of-place "
                  "operations");
 
-  host_integer_count_of_consecutive_bits<uint64_t, uint64_t>(
+  host_integer_count_of_consecutive_bits_async<uint64_t, uint64_t>(
       CudaStreams(streams), output_ct, input_ct,
       (int_count_of_consecutive_bits_buffer<uint64_t> *)mem_ptr, bsks,
       (uint64_t **)ksks);
@@ -78,7 +78,7 @@ void cuda_integer_ilog2_64_async(
                  "Output and input pointers must be different for out-of-place "
                  "operations");
 
-  host_integer_ilog2<uint64_t, uint64_t>(
+  host_integer_ilog2_async<uint64_t, uint64_t>(
       CudaStreams(streams), output_ct, input_ct, trivial_ct_neg_n, trivial_ct_2,
       trivial_ct_m_minus_1_block, (int_ilog2_buffer<uint64_t> *)mem_ptr, bsks,
       (uint64_t **)ksks);

--- a/backends/tfhe-cuda-backend/cuda/src/integer/ilog2.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/ilog2.cuh
@@ -7,21 +7,21 @@
 #include "multiplication.cuh"
 
 template <typename Torus, typename KSTorus>
-__host__ void host_integer_prepare_count_of_consecutive_bits(
+__host__ void host_integer_prepare_count_of_consecutive_bits_async(
     CudaStreams streams, CudaRadixCiphertextFFI *ciphertext,
     int_prepare_count_of_consecutive_bits_buffer<Torus> *mem_ptr,
     void *const *bsks, KSTorus *const *ksks) {
 
   auto tmp = mem_ptr->tmp_ct;
 
-  host_apply_univariate_lut<Torus>(streams, tmp, ciphertext,
-                                   mem_ptr->univ_lut_mem, ksks, bsks);
+  host_apply_univariate_lut_async<Torus>(streams, tmp, ciphertext,
+                                         mem_ptr->univ_lut_mem, ksks, bsks);
 
   if (mem_ptr->direction == Leading) {
-    host_radix_blocks_reverse_inplace<Torus>(streams, tmp);
+    host_radix_blocks_reverse_inplace_async<Torus>(streams, tmp);
   }
 
-  host_compute_prefix_sum_hillis_steele<uint64_t>(
+  host_compute_prefix_sum_hillis_steele_async<uint64_t>(
       streams, ciphertext, tmp, mem_ptr->biv_lut_mem, bsks, ksks,
       ciphertext->num_radix_blocks);
 }
@@ -43,7 +43,7 @@ __host__ uint64_t scratch_integer_count_of_consecutive_bits(
 }
 
 template <typename Torus, typename KSTorus>
-__host__ void host_integer_count_of_consecutive_bits(
+__host__ void host_integer_count_of_consecutive_bits_async(
     CudaStreams streams, CudaRadixCiphertextFFI *output_ct,
     CudaRadixCiphertextFFI const *input_ct,
     int_count_of_consecutive_bits_buffer<Torus> *mem_ptr, void *const *bsks,
@@ -58,7 +58,7 @@ __host__ void host_integer_count_of_consecutive_bits(
 
   // Prepare count of consecutive bits
   //
-  host_integer_prepare_count_of_consecutive_bits(
+  host_integer_prepare_count_of_consecutive_bits_async(
       streams, ct_prepared, mem_ptr->prepare_mem, bsks, ksks);
 
   // Perform addition and propagation of prepared cts
@@ -72,12 +72,13 @@ __host__ void host_integer_count_of_consecutive_bits(
         output_start_index + 1, ct_prepared, i, i + 1);
   }
 
-  host_integer_partial_sum_ciphertexts_vec<Torus>(
+  host_integer_partial_sum_ciphertexts_vec_async<Torus>(
       streams, output_ct, cts, bsks, ksks, mem_ptr->sum_mem, counter_num_blocks,
       ct_prepared->num_radix_blocks);
 
-  host_propagate_single_carry<Torus>(streams, output_ct, nullptr, nullptr,
-                                     mem_ptr->propagate_mem, bsks, ksks, 0, 0);
+  host_propagate_single_carry_async<Torus>(streams, output_ct, nullptr, nullptr,
+                                           mem_ptr->propagate_mem, bsks, ksks,
+                                           0, 0);
 }
 
 template <typename Torus>
@@ -99,21 +100,20 @@ __host__ uint64_t scratch_integer_ilog2(CudaStreams streams,
 }
 
 template <typename Torus, typename KSTorus>
-__host__ void
-host_integer_ilog2(CudaStreams streams, CudaRadixCiphertextFFI *output_ct,
-                   CudaRadixCiphertextFFI const *input_ct,
-                   CudaRadixCiphertextFFI const *trivial_ct_neg_n,
-                   CudaRadixCiphertextFFI const *trivial_ct_2,
-                   CudaRadixCiphertextFFI const *trivial_ct_m_minus_1_block,
-                   int_ilog2_buffer<Torus> *mem_ptr, void *const *bsks,
-                   KSTorus *const *ksks) {
+__host__ void host_integer_ilog2_async(
+    CudaStreams streams, CudaRadixCiphertextFFI *output_ct,
+    CudaRadixCiphertextFFI const *input_ct,
+    CudaRadixCiphertextFFI const *trivial_ct_neg_n,
+    CudaRadixCiphertextFFI const *trivial_ct_2,
+    CudaRadixCiphertextFFI const *trivial_ct_m_minus_1_block,
+    int_ilog2_buffer<Torus> *mem_ptr, void *const *bsks, KSTorus *const *ksks) {
 
   // Prepare the input ciphertext by computing the number of consecutive
   // leading zeros for each of its blocks.
   //
   copy_radix_ciphertext_async<Torus>(streams.stream(0), streams.gpu_index(0),
                                      mem_ptr->ct_in_buffer, input_ct);
-  host_integer_prepare_count_of_consecutive_bits<Torus>(
+  host_integer_prepare_count_of_consecutive_bits_async<Torus>(
       streams, mem_ptr->ct_in_buffer, mem_ptr->prepare_mem, bsks, ksks);
 
   // Build the input for the sum by taking each block's leading zero count
@@ -141,19 +141,19 @@ host_integer_ilog2(CudaStreams streams, CudaRadixCiphertextFFI *output_ct,
 
   // Perform a partial sum of all the elements without carry propagation.
   //
-  host_integer_partial_sum_ciphertexts_vec<Torus>(
+  host_integer_partial_sum_ciphertexts_vec_async<Torus>(
       streams, mem_ptr->sum_output_not_propagated, mem_ptr->sum_input_cts, bsks,
       ksks, mem_ptr->sum_mem, mem_ptr->counter_num_blocks,
       mem_ptr->input_num_blocks + 1);
 
   // Apply luts to the partial sum.
   //
-  host_apply_univariate_lut<Torus>(streams, mem_ptr->message_blocks_not,
-                                   mem_ptr->sum_output_not_propagated,
-                                   mem_ptr->lut_message_not, ksks, bsks);
-  host_apply_univariate_lut<Torus>(streams, mem_ptr->carry_blocks_not,
-                                   mem_ptr->sum_output_not_propagated,
-                                   mem_ptr->lut_carry_not, ksks, bsks);
+  host_apply_univariate_lut_async<Torus>(streams, mem_ptr->message_blocks_not,
+                                         mem_ptr->sum_output_not_propagated,
+                                         mem_ptr->lut_message_not, ksks, bsks);
+  host_apply_univariate_lut_async<Torus>(streams, mem_ptr->carry_blocks_not,
+                                         mem_ptr->sum_output_not_propagated,
+                                         mem_ptr->lut_carry_not, ksks, bsks);
 
   // Left-shift the bitwise-negated carry blocks by one position.
   //
@@ -190,13 +190,13 @@ host_integer_ilog2(CudaStreams streams, CudaRadixCiphertextFFI *output_ct,
       2 * mem_ptr->counter_num_blocks, 3 * mem_ptr->counter_num_blocks,
       trivial_ct_2, 0, mem_ptr->counter_num_blocks);
 
-  host_integer_partial_sum_ciphertexts_vec<Torus>(
+  host_integer_partial_sum_ciphertexts_vec_async<Torus>(
       streams, output_ct, mem_ptr->sum_input_cts, bsks, ksks, mem_ptr->sum_mem,
       mem_ptr->counter_num_blocks, 3);
 
-  host_full_propagate_inplace<Torus>(streams, output_ct,
-                                     mem_ptr->final_propagate_mem, ksks, bsks,
-                                     mem_ptr->counter_num_blocks);
+  host_full_propagate_inplace_async<Torus>(streams, output_ct,
+                                           mem_ptr->final_propagate_mem, ksks,
+                                           bsks, mem_ptr->counter_num_blocks);
 }
 
 #endif

--- a/backends/tfhe-cuda-backend/cuda/src/integer/integer.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/integer.cu
@@ -14,9 +14,9 @@ void cuda_add_lwe_ciphertext_vector_inplace_64(
     CudaRadixCiphertextFFI const *input_2) {
   if (lwe_array_inout->num_radix_blocks != input_2->num_radix_blocks)
     PANIC("Cuda error: input and output num radix blocks must be the same")
-  host_addition<uint64_t>(static_cast<cudaStream_t>(stream), gpu_index,
-                          lwe_array_inout, lwe_array_inout, input_2,
-                          lwe_array_inout->num_radix_blocks, 0, 0);
+  host_addition_async<uint64_t>(static_cast<cudaStream_t>(stream), gpu_index,
+                                lwe_array_inout, lwe_array_inout, input_2,
+                                lwe_array_inout->num_radix_blocks, 0, 0);
   cuda_synchronize_stream(static_cast<cudaStream_t>(stream), gpu_index);
 }
 
@@ -28,9 +28,9 @@ void cuda_full_propagation_64_inplace_async(
   int_fullprop_buffer<uint64_t> *buffer =
       (int_fullprop_buffer<uint64_t> *)mem_ptr;
 
-  host_full_propagate_inplace<uint64_t>(CudaStreams(streams), input_blocks,
-                                        buffer, (uint64_t **)(ksks), bsks,
-                                        num_blocks);
+  host_full_propagate_inplace_async<uint64_t>(
+      CudaStreams(streams), input_blocks, buffer, (uint64_t **)(ksks), bsks,
+      num_blocks);
 }
 
 uint64_t scratch_cuda_full_propagation_64_inplace_async(
@@ -106,7 +106,7 @@ void cuda_propagate_single_carry_64_inplace_async(
     int8_t *mem_ptr, void *const *bsks, void *const *ksks,
     uint32_t requested_flag, uint32_t uses_carry) {
 
-  host_propagate_single_carry<uint64_t>(
+  host_propagate_single_carry_async<uint64_t>(
       CudaStreams(streams), lwe_array, carry_out, carry_in,
       (int_sc_prop_memory<uint64_t> *)mem_ptr, bsks, (uint64_t **)(ksks),
       requested_flag, uses_carry);
@@ -118,7 +118,7 @@ void cuda_add_and_propagate_single_carry_64_inplace_async(
     const CudaRadixCiphertextFFI *carry_in, int8_t *mem_ptr, void *const *bsks,
     void *const *ksks, uint32_t requested_flag, uint32_t uses_carry) {
 
-  host_add_and_propagate_single_carry<uint64_t>(
+  host_add_and_propagate_single_carry_async<uint64_t>(
       CudaStreams(streams), lhs_array, rhs_array, carry_out, carry_in,
       (int_sc_prop_memory<uint64_t> *)mem_ptr, bsks, (uint64_t **)(ksks),
       requested_flag, uses_carry);
@@ -132,7 +132,7 @@ void cuda_integer_overflowing_sub_64_inplace_async(
     void *const *bsks, void *const *ksks, uint32_t compute_overflow,
     uint32_t uses_input_borrow) {
   PUSH_RANGE("overflow sub")
-  host_integer_overflowing_sub<uint64_t>(
+  host_integer_overflowing_sub_async<uint64_t>(
       CudaStreams(streams), lhs_array, lhs_array, rhs_array, overflow_block,
       input_borrow, (int_borrow_prop_memory<uint64_t> *)mem_ptr, bsks,
       (uint64_t **)ksks, compute_overflow, uses_input_borrow);
@@ -211,7 +211,7 @@ void cuda_apply_univariate_lut_64_async(
                  "Output and input pointers must be different for out-of-place "
                  "operations");
 
-  host_apply_univariate_lut<uint64_t>(
+  host_apply_univariate_lut_async<uint64_t>(
       CudaStreams(streams), output_radix_lwe, input_radix_lwe,
       (int_radix_lut<uint64_t> *)mem_ptr, (uint64_t **)(ksks), bsks);
 }
@@ -245,7 +245,7 @@ void cuda_apply_many_univariate_lut_64_async(
                  "Output and input pointers must be different for out-of-place "
                  "operations");
 
-  host_apply_many_univariate_lut<uint64_t>(
+  host_apply_many_univariate_lut_async<uint64_t>(
       CudaStreams(streams), output_radix_lwe, input_radix_lwe,
       (int_radix_lut<uint64_t> *)mem_ptr, (uint64_t **)(ksks), bsks, num_luts,
       lut_stride);
@@ -254,7 +254,8 @@ void cuda_apply_many_univariate_lut_64_async(
 void cuda_integer_reverse_blocks_64_inplace_async(
     CudaStreamsFFI streams, CudaRadixCiphertextFFI *lwe_array) {
 
-  host_radix_blocks_reverse_inplace<uint64_t>(CudaStreams(streams), lwe_array);
+  host_radix_blocks_reverse_inplace_async<uint64_t>(CudaStreams(streams),
+                                                    lwe_array);
 }
 
 void reverseArray(uint64_t arr[], size_t n) {

--- a/backends/tfhe-cuda-backend/cuda/src/integer/integer.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/integer.cuh
@@ -30,12 +30,13 @@
  * @param num_radix_blocks number of blocks to add
  */
 template <typename T>
-__host__ void
-host_addition(cudaStream_t stream, uint32_t gpu_index,
-              CudaRadixCiphertextFFI *output,
-              CudaRadixCiphertextFFI const *input_1,
-              CudaRadixCiphertextFFI const *input_2, uint32_t num_radix_blocks,
-              const uint32_t message_modulus, const uint32_t carry_modulus) {
+__host__ void host_addition_async(cudaStream_t stream, uint32_t gpu_index,
+                                  CudaRadixCiphertextFFI *output,
+                                  CudaRadixCiphertextFFI const *input_1,
+                                  CudaRadixCiphertextFFI const *input_2,
+                                  uint32_t num_radix_blocks,
+                                  const uint32_t message_modulus,
+                                  const uint32_t carry_modulus) {
   if (output->lwe_dimension != input_1->lwe_dimension ||
       output->lwe_dimension != input_2->lwe_dimension)
     PANIC("Cuda error: input and output num radix blocks must be the same")
@@ -73,7 +74,7 @@ host_addition(cudaStream_t stream, uint32_t gpu_index,
  * block of input_with_multiple_blocks
  */
 template <typename T>
-__host__ void host_add_the_same_block_to_all_blocks(
+__host__ void host_add_the_same_block_to_all_blocks_async(
     cudaStream_t stream, uint32_t gpu_index, CudaRadixCiphertextFFI *output,
     CudaRadixCiphertextFFI const *input_with_multiple_blocks,
     CudaRadixCiphertextFFI const *input_with_single_block,
@@ -123,7 +124,7 @@ __host__ void host_add_the_same_block_to_all_blocks(
  * @param num_radix_blocks number of blocks to subtract
  */
 template <typename T>
-__host__ void host_unchecked_sub_with_correcting_term(
+__host__ void host_unchecked_sub_with_correcting_term_async(
     cudaStream_t stream, uint32_t gpu_index, CudaRadixCiphertextFFI *output,
     CudaRadixCiphertextFFI const *input_1,
     CudaRadixCiphertextFFI const *input_2, uint32_t num_radix_blocks,
@@ -251,10 +252,11 @@ __host__ void array_rotate_left(Torus *array_out, Torus *array_in,
 // calculation is not inplace, so `dst` and `src` must not be the same
 // one block is responsible to process single lwe ciphertext
 template <typename Torus>
-__host__ void
-host_radix_blocks_rotate_right(CudaStreams streams, CudaRadixCiphertextFFI *dst,
-                               CudaRadixCiphertextFFI *src, uint32_t rotations,
-                               uint32_t num_blocks) {
+__host__ void host_radix_blocks_rotate_right_async(CudaStreams streams,
+                                                   CudaRadixCiphertextFFI *dst,
+                                                   CudaRadixCiphertextFFI *src,
+                                                   uint32_t rotations,
+                                                   uint32_t num_blocks) {
   PANIC_IF_FALSE(src != dst,
                  "Cuda error (blocks_rotate_right): the source and destination "
                  "pointers should be different");
@@ -286,10 +288,11 @@ host_radix_blocks_rotate_right(CudaStreams streams, CudaRadixCiphertextFFI *dst,
 // rotate radix ciphertext left with specific value
 // calculation is not inplace, so `dst` and `src` must not be the same
 template <typename Torus>
-__host__ void
-host_radix_blocks_rotate_left(CudaStreams streams, CudaRadixCiphertextFFI *dst,
-                              CudaRadixCiphertextFFI *src, uint32_t value,
-                              uint32_t num_blocks) {
+__host__ void host_radix_blocks_rotate_left_async(CudaStreams streams,
+                                                  CudaRadixCiphertextFFI *dst,
+                                                  CudaRadixCiphertextFFI *src,
+                                                  uint32_t value,
+                                                  uint32_t num_blocks) {
   if (src == dst) {
     PANIC("Cuda error (blocks_rotate_left): the source and destination "
           "pointers should be different");
@@ -336,8 +339,9 @@ __global__ void radix_blocks_reverse_lwe_inplace(Torus *src,
 /// This function does not update noise level/degree at this stage,
 /// it can be added later
 template <typename Torus>
-__host__ void host_radix_blocks_reverse_inplace(CudaStreams streams,
-                                                CudaRadixCiphertextFFI *src) {
+__host__ void
+host_radix_blocks_reverse_inplace_async(CudaStreams streams,
+                                        CudaRadixCiphertextFFI *src) {
   if (src->num_radix_blocks < 2)
     return;
   cuda_set_device(streams.gpu_index(0));
@@ -381,12 +385,10 @@ __global__ void device_radix_cumulative_sum_in_groups(Torus *dest, Torus *src,
 /// This function does not update noise level/degree at this stage,
 /// it can be added later
 template <typename Torus>
-__host__ void host_radix_cumulative_sum_in_groups(cudaStream_t stream,
-                                                  uint32_t gpu_index,
-                                                  CudaRadixCiphertextFFI *dest,
-                                                  CudaRadixCiphertextFFI *src,
-                                                  uint32_t num_radix_blocks,
-                                                  uint32_t group_size) {
+__host__ void host_radix_cumulative_sum_in_groups_async(
+    cudaStream_t stream, uint32_t gpu_index, CudaRadixCiphertextFFI *dest,
+    CudaRadixCiphertextFFI *src, uint32_t num_radix_blocks,
+    uint32_t group_size) {
   if (dest->lwe_dimension != src->lwe_dimension)
     PANIC("Cuda error: input and output radix ciphertexts should have the same "
           "lwe dimension")
@@ -451,7 +453,7 @@ __global__ void device_radix_split_simulators_and_grouping_pgns(
 /// This function does not update noise level/degree at this stage,
 /// it can be added later
 template <typename Torus>
-__host__ void host_radix_split_simulators_and_grouping_pgns(
+__host__ void host_radix_split_simulators_and_grouping_pgns_async(
     cudaStream_t stream, uint32_t gpu_index, CudaRadixCiphertextFFI *simulators,
     CudaRadixCiphertextFFI *grouping_pgns, CudaRadixCiphertextFFI *src,
     uint32_t num_radix_blocks, uint32_t group_size, Torus delta) {
@@ -505,12 +507,10 @@ __global__ void device_radix_sum_in_groups(Torus *dest, Torus *src1,
 /// This function does not update noise level
 /// /degree at this stage, could be added later
 template <typename Torus>
-__host__ void host_radix_sum_in_groups(cudaStream_t stream, uint32_t gpu_index,
-                                       CudaRadixCiphertextFFI *dest,
-                                       CudaRadixCiphertextFFI *src1,
-                                       CudaRadixCiphertextFFI *src2,
-                                       uint32_t num_radix_blocks,
-                                       uint32_t group_size) {
+__host__ void host_radix_sum_in_groups_async(
+    cudaStream_t stream, uint32_t gpu_index, CudaRadixCiphertextFFI *dest,
+    CudaRadixCiphertextFFI *src1, CudaRadixCiphertextFFI *src2,
+    uint32_t num_radix_blocks, uint32_t group_size) {
   if (dest->lwe_dimension != src1->lwe_dimension ||
       dest->lwe_dimension != src2->lwe_dimension)
     PANIC("Cuda error: input and output radix ciphertexts should have the same "
@@ -561,7 +561,7 @@ device_pack_bivariate_blocks(Torus *lwe_array_out, Torus const *lwe_indexes_out,
 /// This function does not update noise level/degree at this stage,
 /// it can be added later
 template <typename Torus>
-__host__ void host_pack_bivariate_blocks(
+__host__ void host_pack_bivariate_blocks_async(
     CudaStreams streams, CudaRadixCiphertextFFI *lwe_array_out,
     Torus const *lwe_indexes_out, CudaRadixCiphertextFFI const *lwe_array_1,
     CudaRadixCiphertextFFI const *lwe_array_2, Torus const *lwe_indexes_in,
@@ -627,7 +627,7 @@ __global__ void device_pack_bivariate_blocks_with_single_block(
  *  This is for the special case when one of the operands is not an array
  */
 template <typename Torus>
-__host__ void host_pack_bivariate_blocks_with_single_block(
+__host__ void host_pack_bivariate_blocks_with_single_block_async(
     CudaStreams streams, CudaRadixCiphertextFFI *lwe_array_out,
     Torus const *lwe_indexes_out, CudaRadixCiphertextFFI const *lwe_array_1,
     CudaRadixCiphertextFFI const *lwe_2, Torus const *lwe_indexes_in,
@@ -761,7 +761,7 @@ __global__ void device_pack_bivariate_blocks_cmux_two_regions(
 /// @param replicate_true     When true, reuse a single true-branch CT for every
 /// entry
 template <typename Torus>
-__host__ void host_pack_bivariate_blocks_cmux_two_regions(
+__host__ void host_pack_bivariate_blocks_cmux_two_regions_async(
     CudaStreams streams, CudaRadixCiphertextFFI *lwe_array_out,
     CudaRadixCiphertextFFI const *lwe_array_true,
     CudaRadixCiphertextFFI const *lwe_array_false,
@@ -821,7 +821,7 @@ __host__ void host_pack_bivariate_blocks_cmux_two_regions(
 /// @param replicate_input    When true, reuse the first num_blocks_per_ct input
 /// blocks for every entry
 template <typename Torus>
-__host__ void host_pack_bivariate_blocks_with_per_ct_single_block(
+__host__ void host_pack_bivariate_blocks_with_per_ct_single_block_async(
     CudaStreams streams, CudaRadixCiphertextFFI *lwe_array_out,
     CudaRadixCiphertextFFI const *lwe_array_in,
     CudaRadixCiphertextFFI const *lwe_conditions, uint32_t shift,
@@ -1158,7 +1158,7 @@ __host__ void integer_radix_apply_bivariate_lookup_table(
 
   // Left message is shifted
   auto lwe_array_pbs_in = lut->tmp_lwe_before_ks;
-  host_pack_bivariate_blocks<Torus>(
+  host_pack_bivariate_blocks_async<Torus>(
       streams, lwe_array_pbs_in, lut->lwe_trivial_indexes, lwe_array_1,
       lwe_array_2, lut->lwe_indexes_in, shift, num_radix_blocks,
       params.message_modulus, params.carry_modulus);
@@ -1688,7 +1688,7 @@ void generate_many_lut_device_accumulator(
 // depending on the group it belongs to and the internal position within the
 // block.
 template <typename Torus, typename KSTorus>
-void host_compute_shifted_blocks_and_states(
+void host_compute_shifted_blocks_and_states_async(
     CudaStreams streams, CudaRadixCiphertextFFI *lwe_array,
     int_shifted_blocks_and_states_memory<Torus> *mem, void *const *bsks,
     KSTorus *const *ksks, uint32_t lut_stride, uint32_t num_many_lut) {
@@ -1715,7 +1715,7 @@ void host_compute_shifted_blocks_and_states(
 }
 
 template <typename Torus, typename KSTorus>
-void host_resolve_group_carries_sequentially(
+void host_resolve_group_carries_sequentially_async(
     CudaStreams streams, CudaRadixCiphertextFFI *resolved_carries,
     CudaRadixCiphertextFFI *grouping_pgns, int_radix_params params,
     int_seq_group_prop_memory<Torus> *mem, void *const *bsks,
@@ -1756,7 +1756,7 @@ void host_resolve_group_carries_sequentially(
           last_resolved_pos + blocks_to_solve);
 
       // Perform one group cumulative sum
-      host_radix_cumulative_sum_in_groups<Torus>(
+      host_radix_cumulative_sum_in_groups_async<Torus>(
           streams.stream(0), streams.gpu_index(0), group_resolved_carries,
           group_resolved_carries, blocks_to_solve + 1, mem->grouping_size);
 
@@ -1783,7 +1783,7 @@ void host_resolve_group_carries_sequentially(
 }
 
 template <typename Torus, typename KSTorus>
-void host_compute_prefix_sum_hillis_steele(
+void host_compute_prefix_sum_hillis_steele_async(
     CudaStreams streams, CudaRadixCiphertextFFI *step_output,
     CudaRadixCiphertextFFI *generates_or_propagates, int_radix_lut<Torus> *luts,
     void *const *bsks, KSTorus *const *ksks, uint32_t num_radix_blocks) {
@@ -1826,7 +1826,7 @@ void host_compute_prefix_sum_hillis_steele(
 // - resolves the carries between groups, either sequentially or with hillis
 // steele
 template <typename Torus, typename KSTorus>
-void host_compute_propagation_simulators_and_group_carries(
+void host_compute_propagation_simulators_and_group_carries_async(
     CudaStreams streams, CudaRadixCiphertextFFI *block_states,
     int_radix_params params, int_prop_simu_group_carries_memory<Torus> *mem,
     void *const *bsks, KSTorus *const *ksks, uint32_t num_radix_blocks,
@@ -1840,7 +1840,7 @@ void host_compute_propagation_simulators_and_group_carries(
 
   auto propagation_cum_sums = mem->propagation_cum_sums;
   auto group_size = mem->group_size;
-  host_radix_cumulative_sum_in_groups<Torus>(
+  host_radix_cumulative_sum_in_groups_async<Torus>(
       streams.stream(0), streams.gpu_index(0), propagation_cum_sums,
       block_states, num_radix_blocks, group_size);
 
@@ -1849,7 +1849,7 @@ void host_compute_propagation_simulators_and_group_carries(
       streams, propagation_cum_sums, propagation_cum_sums, bsks, ksks,
       luts_array_second_step, num_radix_blocks);
 
-  host_scalar_addition_inplace<Torus>(
+  host_scalar_addition_inplace_async<Torus>(
       streams, propagation_cum_sums, mem->scalar_array_cum_sum,
       mem->h_scalar_array_cum_sum, num_radix_blocks, message_modulus,
       carry_modulus);
@@ -1859,14 +1859,14 @@ void host_compute_propagation_simulators_and_group_carries(
   Torus delta = (static_cast<Torus>(1) << (nbits - 1)) / modulus_sup;
   auto simulators = mem->simulators;
   auto grouping_pgns = mem->grouping_pgns;
-  host_radix_split_simulators_and_grouping_pgns<Torus>(
+  host_radix_split_simulators_and_grouping_pgns_async<Torus>(
       streams.stream(0), streams.gpu_index(0), simulators, grouping_pgns,
       propagation_cum_sums, num_radix_blocks, group_size, delta);
 
   auto resolved_carries = mem->resolved_carries;
   if (mem->use_sequential_algorithm_to_resolve_group_carries) {
     // Resolve group carries sequentially
-    host_resolve_group_carries_sequentially(
+    host_resolve_group_carries_sequentially_async(
         streams, resolved_carries, grouping_pgns, params,
         mem->seq_group_prop_mem, bsks, ksks, num_groups);
   } else {
@@ -1875,7 +1875,7 @@ void host_compute_propagation_simulators_and_group_carries(
     CudaRadixCiphertextFFI shifted_resolved_carries;
     as_radix_ciphertext_slice<Torus>(&shifted_resolved_carries,
                                      resolved_carries, 1, num_groups);
-    host_compute_prefix_sum_hillis_steele<Torus>(
+    host_compute_prefix_sum_hillis_steele_async<Torus>(
         streams, &shifted_resolved_carries, grouping_pgns,
         luts_carry_propagation_sum, bsks, ksks, num_groups - 1);
   }
@@ -1888,7 +1888,7 @@ void host_compute_propagation_simulators_and_group_carries(
 // depending on the group it belongs to and the internal position within the
 // block.
 template <typename Torus, typename KSTorus>
-void host_compute_shifted_blocks_and_borrow_states(
+void host_compute_shifted_blocks_and_borrow_states_async(
     CudaStreams streams, CudaRadixCiphertextFFI *lwe_array,
     int_shifted_blocks_and_borrow_states_memory<Torus> *mem, void *const *bsks,
     KSTorus *const *ksks, uint32_t lut_stride, uint32_t num_many_lut) {
@@ -1921,11 +1921,11 @@ void host_compute_shifted_blocks_and_borrow_states(
  * have size = 2 * (glwe_dimension * polynomial_size + 1) * sizeof(Torus)
  */
 template <typename Torus, typename KSTorus>
-void host_full_propagate_inplace(CudaStreams streams,
-                                 CudaRadixCiphertextFFI *input_blocks,
-                                 int_fullprop_buffer<Torus> *mem_ptr,
-                                 KSTorus *const *ksks, void *const *bsks,
-                                 uint32_t num_blocks) {
+void host_full_propagate_inplace_async(CudaStreams streams,
+                                       CudaRadixCiphertextFFI *input_blocks,
+                                       int_fullprop_buffer<Torus> *mem_ptr,
+                                       KSTorus *const *ksks, void *const *bsks,
+                                       uint32_t num_blocks) {
   auto params = mem_ptr->lut->params;
 
   // In the case of extracting a single LWE this parameters are dummy
@@ -1974,9 +1974,10 @@ void host_full_propagate_inplace(CudaStreams streams,
       as_radix_ciphertext_slice<Torus>(&second_input,
                                        mem_ptr->tmp_big_lwe_vector, 1, 2);
 
-      host_addition<Torus>(streams.stream(0), streams.gpu_index(0),
-                           &next_input_block, &next_input_block, &second_input,
-                           1, params.message_modulus, params.carry_modulus);
+      host_addition_async<Torus>(streams.stream(0), streams.gpu_index(0),
+                                 &next_input_block, &next_input_block,
+                                 &second_input, 1, params.message_modulus,
+                                 params.carry_modulus);
     }
   }
 }
@@ -2014,7 +2015,7 @@ __global__ void device_pack_blocks(Torus *lwe_array_out,
     }
 
     if (num_radix_blocks % 2 == 1) {
-      // We couldn't host_pack the last block, so we just copy it
+      // We couldn't host_pack_async the last block, so we just copy it
       Torus *lsb_block =
           (Torus *)lwe_array_in + (num_radix_blocks - 1) * (lwe_dimension + 1);
       Torus *last_block =
@@ -2248,11 +2249,11 @@ uint64_t scratch_cuda_apply_univariate_lut(
 }
 
 template <typename Torus, typename KSTorus>
-void host_apply_univariate_lut(CudaStreams streams,
-                               CudaRadixCiphertextFFI *radix_lwe_out,
-                               CudaRadixCiphertextFFI const *radix_lwe_in,
-                               int_radix_lut<Torus> *mem, KSTorus *const *ksks,
-                               void *const *bsks) {
+void host_apply_univariate_lut_async(CudaStreams streams,
+                                     CudaRadixCiphertextFFI *radix_lwe_out,
+                                     CudaRadixCiphertextFFI const *radix_lwe_in,
+                                     int_radix_lut<Torus> *mem,
+                                     KSTorus *const *ksks, void *const *bsks) {
 
   integer_radix_apply_univariate_lookup_table<Torus>(
       streams, radix_lwe_out, radix_lwe_in, bsks, ksks, mem,
@@ -2284,13 +2285,11 @@ uint64_t scratch_cuda_apply_many_univariate_lut(
 }
 
 template <typename Torus, typename KSTorus>
-void host_apply_many_univariate_lut(CudaStreams streams,
-                                    CudaRadixCiphertextFFI *radix_lwe_out,
-                                    CudaRadixCiphertextFFI const *radix_lwe_in,
-                                    int_radix_lut<Torus> *mem,
-                                    KSTorus *const *ksks, void *const *bsks,
-                                    uint32_t num_many_lut,
-                                    uint32_t lut_stride) {
+void host_apply_many_univariate_lut_async(
+    CudaStreams streams, CudaRadixCiphertextFFI *radix_lwe_out,
+    CudaRadixCiphertextFFI const *radix_lwe_in, int_radix_lut<Torus> *mem,
+    KSTorus *const *ksks, void *const *bsks, uint32_t num_many_lut,
+    uint32_t lut_stride) {
 
   integer_radix_apply_many_univariate_lookup_table<Torus>(
       streams, radix_lwe_out, radix_lwe_in, bsks, ksks, mem, num_many_lut,
@@ -2321,13 +2320,12 @@ uint64_t scratch_cuda_apply_bivariate_lut(
 }
 
 template <typename Torus, typename KSTorus>
-void host_apply_bivariate_lut(CudaStreams streams,
-                              CudaRadixCiphertextFFI *radix_lwe_out,
-                              CudaRadixCiphertextFFI const *radix_lwe_in_1,
-                              CudaRadixCiphertextFFI const *radix_lwe_in_2,
-                              int_radix_lut<Torus> *mem, KSTorus *const *ksks,
-                              void *const *bsks, uint32_t num_radix_blocks,
-                              uint32_t shift) {
+void host_apply_bivariate_lut_async(
+    CudaStreams streams, CudaRadixCiphertextFFI *radix_lwe_out,
+    CudaRadixCiphertextFFI const *radix_lwe_in_1,
+    CudaRadixCiphertextFFI const *radix_lwe_in_2, int_radix_lut<Torus> *mem,
+    KSTorus *const *ksks, void *const *bsks, uint32_t num_radix_blocks,
+    uint32_t shift) {
 
   integer_radix_apply_bivariate_lookup_table<Torus>(
       streams, radix_lwe_out, radix_lwe_in_1, radix_lwe_in_2, bsks, ksks, mem,
@@ -2350,13 +2348,12 @@ uint64_t scratch_cuda_propagate_single_carry_inplace(
 // This function perform the three steps of Thomas' new carry propagation
 // includes the logic to extract overflow when requested
 template <typename Torus, typename KSTorus>
-void host_propagate_single_carry(CudaStreams streams,
-                                 CudaRadixCiphertextFFI *lwe_array,
-                                 CudaRadixCiphertextFFI *carry_out,
-                                 const CudaRadixCiphertextFFI *input_carries,
-                                 int_sc_prop_memory<Torus> *mem,
-                                 void *const *bsks, KSTorus *const *ksks,
-                                 uint32_t requested_flag, uint32_t uses_carry) {
+void host_propagate_single_carry_async(
+    CudaStreams streams, CudaRadixCiphertextFFI *lwe_array,
+    CudaRadixCiphertextFFI *carry_out,
+    const CudaRadixCiphertextFFI *input_carries, int_sc_prop_memory<Torus> *mem,
+    void *const *bsks, KSTorus *const *ksks, uint32_t requested_flag,
+    uint32_t uses_carry) {
   PUSH_RANGE("propagate sc")
   auto num_radix_blocks = lwe_array->num_radix_blocks;
   auto params = mem->params;
@@ -2372,13 +2369,13 @@ void host_propagate_single_carry(CudaStreams streams,
     PANIC("Cuda error: when requesting FLAG_CARRY, carry_out must be a valid "
           "pointer")
   if (uses_carry == 1) {
-    host_addition<Torus>(streams.stream(0), streams.gpu_index(0), lwe_array,
-                         lwe_array, input_carries, 1, params.message_modulus,
-                         params.carry_modulus);
+    host_addition_async<Torus>(streams.stream(0), streams.gpu_index(0),
+                               lwe_array, lwe_array, input_carries, 1,
+                               params.message_modulus, params.carry_modulus);
   }
 
   // Step 1
-  host_compute_shifted_blocks_and_states<Torus>(
+  host_compute_shifted_blocks_and_states_async<Torus>(
       streams, lwe_array, mem->shifted_blocks_state_mem, bsks, ksks, lut_stride,
       num_many_lut);
   auto block_states = mem->shifted_blocks_state_mem->block_states;
@@ -2389,7 +2386,7 @@ void host_propagate_single_carry(CudaStreams streams,
         block_states, num_radix_blocks - 1, num_radix_blocks);
   }
   // Step 2
-  host_compute_propagation_simulators_and_group_carries<Torus>(
+  host_compute_propagation_simulators_and_group_carries_async<Torus>(
       streams, block_states, params, mem->prop_simu_group_carries_mem, bsks,
       ksks, num_radix_blocks, mem->num_groups);
 
@@ -2397,7 +2394,7 @@ void host_propagate_single_carry(CudaStreams streams,
 
   auto prepared_blocks = mem->prop_simu_group_carries_mem->prepared_blocks;
   auto shifted_blocks = mem->shifted_blocks_state_mem->shifted_blocks;
-  host_addition<Torus>(
+  host_addition_async<Torus>(
       streams.stream(0), streams.gpu_index(0), prepared_blocks, shifted_blocks,
       mem->prop_simu_group_carries_mem->simulators, num_radix_blocks,
       params.message_modulus, params.carry_modulus);
@@ -2408,12 +2405,12 @@ void host_propagate_single_carry(CudaStreams streams,
     as_radix_ciphertext_slice<Torus>(
         &shifted_simulators, mem->prop_simu_group_carries_mem->simulators,
         num_radix_blocks - 1, num_radix_blocks);
-    host_addition<Torus>(streams.stream(0), streams.gpu_index(0), &output_flag,
-                         &output_flag, &shifted_simulators, 1,
-                         params.message_modulus, params.carry_modulus);
+    host_addition_async<Torus>(streams.stream(0), streams.gpu_index(0),
+                               &output_flag, &output_flag, &shifted_simulators,
+                               1, params.message_modulus, params.carry_modulus);
   }
 
-  host_radix_sum_in_groups<Torus>(
+  host_radix_sum_in_groups_async<Torus>(
       streams.stream(0), streams.gpu_index(0), prepared_blocks, prepared_blocks,
       mem->prop_simu_group_carries_mem->resolved_carries, num_radix_blocks,
       group_size);
@@ -2423,9 +2420,10 @@ void host_propagate_single_carry(CudaStreams streams,
         &shifted_resolved_carries,
         mem->prop_simu_group_carries_mem->resolved_carries, mem->num_groups - 1,
         mem->num_groups);
-    host_addition<Torus>(streams.stream(0), streams.gpu_index(0), &output_flag,
-                         &output_flag, &shifted_resolved_carries, 1,
-                         params.message_modulus, params.carry_modulus);
+    host_addition_async<Torus>(streams.stream(0), streams.gpu_index(0),
+                               &output_flag, &output_flag,
+                               &shifted_resolved_carries, 1,
+                               params.message_modulus, params.carry_modulus);
 
     copy_radix_ciphertext_slice_async<Torus>(
         streams.stream(0), streams.gpu_index(0), prepared_blocks,
@@ -2452,7 +2450,7 @@ void host_propagate_single_carry(CudaStreams streams,
 // This function perform the three steps of Thomas' new carry propagation
 // includes the logic to extract overflow when requested
 template <typename Torus, typename KSTorus>
-void host_add_and_propagate_single_carry(
+void host_add_and_propagate_single_carry_async(
     CudaStreams streams, CudaRadixCiphertextFFI *lhs_array,
     const CudaRadixCiphertextFFI *rhs_array, CudaRadixCiphertextFFI *carry_out,
     const CudaRadixCiphertextFFI *input_carries, int_sc_prop_memory<Torus> *mem,
@@ -2499,17 +2497,17 @@ void host_add_and_propagate_single_carry(
         num_radix_blocks - 1, num_radix_blocks);
   }
 
-  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), lhs_array,
-                       lhs_array, rhs_array, num_radix_blocks,
-                       params.message_modulus, params.carry_modulus);
+  host_addition_async<Torus>(streams.stream(0), streams.gpu_index(0), lhs_array,
+                             lhs_array, rhs_array, num_radix_blocks,
+                             params.message_modulus, params.carry_modulus);
 
   if (uses_carry == 1) {
-    host_addition<Torus>(streams.stream(0), streams.gpu_index(0), lhs_array,
-                         lhs_array, input_carries, 1, params.message_modulus,
-                         params.carry_modulus);
+    host_addition_async<Torus>(streams.stream(0), streams.gpu_index(0),
+                               lhs_array, lhs_array, input_carries, 1,
+                               params.message_modulus, params.carry_modulus);
   }
   // Step 1
-  host_compute_shifted_blocks_and_states<Torus>(
+  host_compute_shifted_blocks_and_states_async<Torus>(
       streams, lhs_array, mem->shifted_blocks_state_mem, bsks, ksks, lut_stride,
       num_many_lut);
   auto block_states = mem->shifted_blocks_state_mem->block_states;
@@ -2525,7 +2523,7 @@ void host_add_and_propagate_single_carry(
   }
 
   // Step 2
-  host_compute_propagation_simulators_and_group_carries<Torus>(
+  host_compute_propagation_simulators_and_group_carries_async<Torus>(
       streams, block_states, params, mem->prop_simu_group_carries_mem, bsks,
       ksks, num_radix_blocks, mem->num_groups);
 
@@ -2533,7 +2531,7 @@ void host_add_and_propagate_single_carry(
 
   auto prepared_blocks = mem->prop_simu_group_carries_mem->prepared_blocks;
   auto shifted_blocks = mem->shifted_blocks_state_mem->shifted_blocks;
-  host_addition<Torus>(
+  host_addition_async<Torus>(
       streams.stream(0), streams.gpu_index(0), prepared_blocks, shifted_blocks,
       mem->prop_simu_group_carries_mem->simulators, num_radix_blocks,
       params.message_modulus, params.carry_modulus);
@@ -2544,14 +2542,14 @@ void host_add_and_propagate_single_carry(
     as_radix_ciphertext_slice<Torus>(
         &shifted_simulators, mem->prop_simu_group_carries_mem->simulators,
         num_radix_blocks - 1, num_radix_blocks);
-    host_addition<Torus>(streams.stream(0), streams.gpu_index(0), &output_flag,
-                         &output_flag, &shifted_simulators, 1,
-                         params.message_modulus, params.carry_modulus);
+    host_addition_async<Torus>(streams.stream(0), streams.gpu_index(0),
+                               &output_flag, &output_flag, &shifted_simulators,
+                               1, params.message_modulus, params.carry_modulus);
   }
 
   // Step 3
   //  Add carries and cleanup OutputFlag::None
-  host_radix_sum_in_groups<Torus>(
+  host_radix_sum_in_groups_async<Torus>(
       streams.stream(0), streams.gpu_index(0), prepared_blocks, prepared_blocks,
       mem->prop_simu_group_carries_mem->resolved_carries, num_radix_blocks,
       group_size);
@@ -2560,9 +2558,9 @@ void host_add_and_propagate_single_carry(
       requested_flag == outputFlag::FLAG_CARRY) {
     if (num_radix_blocks == 1 && requested_flag == outputFlag::FLAG_OVERFLOW &&
         uses_carry == 1) {
-      host_addition<Torus>(streams.stream(0), streams.gpu_index(0),
-                           &output_flag, &output_flag, input_carries, 1,
-                           params.message_modulus, params.carry_modulus);
+      host_addition_async<Torus>(streams.stream(0), streams.gpu_index(0),
+                                 &output_flag, &output_flag, input_carries, 1,
+                                 params.message_modulus, params.carry_modulus);
 
     } else {
       CudaRadixCiphertextFFI shifted_resolved_carries;
@@ -2570,10 +2568,10 @@ void host_add_and_propagate_single_carry(
           &shifted_resolved_carries,
           mem->prop_simu_group_carries_mem->resolved_carries,
           mem->num_groups - 1, mem->num_groups);
-      host_addition<Torus>(streams.stream(0), streams.gpu_index(0),
-                           &output_flag, &output_flag,
-                           &shifted_resolved_carries, 1, params.message_modulus,
-                           params.carry_modulus);
+      host_addition_async<Torus>(streams.stream(0), streams.gpu_index(0),
+                                 &output_flag, &output_flag,
+                                 &shifted_resolved_carries, 1,
+                                 params.message_modulus, params.carry_modulus);
     }
     copy_radix_ciphertext_slice_async<Torus>(
         streams.stream(0), streams.gpu_index(0), prepared_blocks,
@@ -2607,13 +2605,13 @@ void host_add_and_propagate_single_carry(
  * @param num_radix_blocks number of blocks to subtract
  */
 template <typename T>
-__host__ void host_subtraction(cudaStream_t stream, uint32_t gpu_index,
-                               CudaRadixCiphertextFFI *output,
-                               CudaRadixCiphertextFFI const *input_1,
-                               CudaRadixCiphertextFFI const *input_2,
-                               uint32_t num_radix_blocks,
-                               uint32_t message_modulus,
-                               uint32_t carry_modulus) {
+__host__ void host_subtraction_async(cudaStream_t stream, uint32_t gpu_index,
+                                     CudaRadixCiphertextFFI *output,
+                                     CudaRadixCiphertextFFI const *input_1,
+                                     CudaRadixCiphertextFFI const *input_2,
+                                     uint32_t num_radix_blocks,
+                                     uint32_t message_modulus,
+                                     uint32_t carry_modulus) {
 
   GPU_ASSERT(output->lwe_dimension == input_1->lwe_dimension &&
                  output->lwe_dimension == input_2->lwe_dimension,
@@ -2657,15 +2655,13 @@ uint64_t scratch_cuda_integer_overflowing_sub(
 // This function perform the three steps of Thomas' new borrow propagation
 // includes the logic to extract overflow when requested
 template <typename Torus, typename KSTorus>
-void host_single_borrow_propagate(CudaStreams streams,
-                                  CudaRadixCiphertextFFI *lwe_array,
-                                  CudaRadixCiphertextFFI *overflow_block,
-                                  const CudaRadixCiphertextFFI *input_borrow,
-                                  int_borrow_prop_memory<Torus> *mem,
-                                  void *const *bsks, KSTorus *const *ksks,
-                                  uint32_t num_groups,
-                                  uint32_t compute_overflow,
-                                  uint32_t uses_input_borrow) {
+void host_single_borrow_propagate_async(
+    CudaStreams streams, CudaRadixCiphertextFFI *lwe_array,
+    CudaRadixCiphertextFFI *overflow_block,
+    const CudaRadixCiphertextFFI *input_borrow,
+    int_borrow_prop_memory<Torus> *mem, void *const *bsks, KSTorus *const *ksks,
+    uint32_t num_groups, uint32_t compute_overflow,
+    uint32_t uses_input_borrow) {
   auto num_radix_blocks = lwe_array->num_radix_blocks;
   auto params = mem->params;
   auto glwe_dimension = params.glwe_dimension;
@@ -2680,12 +2676,12 @@ void host_single_borrow_propagate(CudaStreams streams,
   if (mem->num_groups < num_groups)
     PANIC("Cuda error: inconsistency in num_groups")
   if (uses_input_borrow == 1) {
-    host_unchecked_sub_with_correcting_term<Torus>(
+    host_unchecked_sub_with_correcting_term_async<Torus>(
         streams.stream(0), streams.gpu_index(0), lwe_array, lwe_array,
         input_borrow, 1, message_modulus, carry_modulus);
   }
   // Step 1
-  host_compute_shifted_blocks_and_borrow_states<Torus>(
+  host_compute_shifted_blocks_and_borrow_states_async<Torus>(
       streams, lwe_array, mem->shifted_blocks_borrow_state_mem, bsks, ksks,
       lut_stride, num_many_lut);
 
@@ -2695,7 +2691,7 @@ void host_single_borrow_propagate(CudaStreams streams,
       borrow_states, num_radix_blocks - 1, num_radix_blocks);
 
   // Step 2
-  host_compute_propagation_simulators_and_group_carries<Torus>(
+  host_compute_propagation_simulators_and_group_carries_async<Torus>(
       streams, borrow_states, params, mem->prop_simu_group_carries_mem, bsks,
       ksks, num_radix_blocks, num_groups);
 
@@ -2704,24 +2700,24 @@ void host_single_borrow_propagate(CudaStreams streams,
   GPU_ASSERT(
       big_lwe_dimension == prepared_blocks->lwe_dimension,
       "Cuda error: big_lwe_dimension must match ciphertexts' lwe_dimension");
-  host_subtraction<Torus>(streams.stream(0), streams.gpu_index(0),
-                          prepared_blocks,
-                          mem->shifted_blocks_borrow_state_mem->shifted_blocks,
-                          mem->prop_simu_group_carries_mem->simulators,
-                          num_radix_blocks, message_modulus, carry_modulus);
+  host_subtraction_async<Torus>(
+      streams.stream(0), streams.gpu_index(0), prepared_blocks,
+      mem->shifted_blocks_borrow_state_mem->shifted_blocks,
+      mem->prop_simu_group_carries_mem->simulators, num_radix_blocks,
+      message_modulus, carry_modulus);
 
-  host_add_scalar_one_inplace<Torus>(streams, prepared_blocks, message_modulus,
-                                     carry_modulus);
+  host_add_scalar_one_inplace_async<Torus>(streams, prepared_blocks,
+                                           message_modulus, carry_modulus);
 
   if (compute_overflow == outputFlag::FLAG_OVERFLOW) {
     CudaRadixCiphertextFFI shifted_simulators;
     as_radix_ciphertext_slice<Torus>(
         &shifted_simulators, mem->prop_simu_group_carries_mem->simulators,
         num_radix_blocks - 1, num_radix_blocks);
-    host_addition<Torus>(streams.stream(0), streams.gpu_index(0),
-                         mem->overflow_block, mem->overflow_block,
-                         &shifted_simulators, 1, params.message_modulus,
-                         params.carry_modulus);
+    host_addition_async<Torus>(streams.stream(0), streams.gpu_index(0),
+                               mem->overflow_block, mem->overflow_block,
+                               &shifted_simulators, 1, params.message_modulus,
+                               params.carry_modulus);
   }
   CudaRadixCiphertextFFI resolved_borrows;
   as_radix_ciphertext_slice<Torus>(
@@ -2732,10 +2728,10 @@ void host_single_borrow_propagate(CudaStreams streams,
   //  This needs to be done before because in next step we modify the resolved
   //  borrows
   if (compute_overflow == outputFlag::FLAG_OVERFLOW) {
-    host_addition<Torus>(streams.stream(0), streams.gpu_index(0),
-                         mem->overflow_block, mem->overflow_block,
-                         &resolved_borrows, 1, params.message_modulus,
-                         params.carry_modulus);
+    host_addition_async<Torus>(streams.stream(0), streams.gpu_index(0),
+                               mem->overflow_block, mem->overflow_block,
+                               &resolved_borrows, 1, params.message_modulus,
+                               params.carry_modulus);
   }
 
   mem->internal_streams.internal_streams_wait_for_main_stream_0(streams);
@@ -2754,11 +2750,11 @@ void host_single_borrow_propagate(CudaStreams streams,
   GPU_ASSERT(
       big_lwe_dimension == resolved_carries->lwe_dimension,
       "Cuda error: big_lwe_dimension must match ciphertexts' lwe_dimension");
-  host_negation<Torus>(sub_streams_2.stream(0), sub_streams_2.gpu_index(0),
-                       resolved_carries, resolved_carries, num_groups,
-                       message_modulus, carry_modulus);
+  host_negation_async<Torus>(
+      sub_streams_2.stream(0), sub_streams_2.gpu_index(0), resolved_carries,
+      resolved_carries, num_groups, message_modulus, carry_modulus);
 
-  host_radix_sum_in_groups<Torus>(
+  host_radix_sum_in_groups_async<Torus>(
       sub_streams_2.stream(0), sub_streams_2.gpu_index(0), prepared_blocks,
       prepared_blocks, resolved_carries, num_radix_blocks, mem->group_size);
 
@@ -2898,7 +2894,7 @@ integer_radix_apply_noise_squashing(CudaStreams streams,
  * @param lwe_ciphertext_count number of ciphertext blocks
  */
 template <typename T>
-__host__ void host_addition_plaintext(
+__host__ void host_addition_plaintext_async(
     cudaStream_t stream, uint32_t gpu_index, CudaRadixCiphertextFFI *output,
     CudaRadixCiphertextFFI const *lwe_input, T const *d_plaintext_input,
     uint64_t const *h_plaintext_degrees, const uint32_t lwe_dimension,
@@ -2940,7 +2936,7 @@ __host__ void host_addition_plaintext(
  * @param lwe_ciphertext_count number of ciphertext blocks
  */
 template <typename T>
-__host__ void host_addition_plaintext_scalar(
+__host__ void host_addition_plaintext_scalar_async(
     cudaStream_t stream, uint32_t gpu_index, CudaRadixCiphertextFFI *output,
     CudaRadixCiphertextFFI const *lwe_input, const T plaintext_input,
     const uint64_t plaintext_degree, const uint32_t lwe_dimension,
@@ -2980,7 +2976,7 @@ __host__ void host_addition_plaintext_scalar(
  * @param lwe_ciphertext_count number of ciphertext blocks
  */
 template <typename T>
-__host__ void host_cleartext_vec_multiplication(
+__host__ void host_cleartext_vec_multiplication_async(
     cudaStream_t stream, uint32_t gpu_index, CudaRadixCiphertextFFI *output,
     CudaRadixCiphertextFFI const *lwe_input, T const *d_cleartext_input,
     uint64_t const *h_cleartext_degrees, const uint32_t lwe_dimension,
@@ -3014,7 +3010,7 @@ __host__ void host_cleartext_vec_multiplication(
  * @param cleartext_input scalar cleartext multiplied with every block
  */
 template <typename T>
-__host__ void host_cleartext_multiplication(
+__host__ void host_cleartext_multiplication_async(
     cudaStream_t stream, uint32_t gpu_index, CudaRadixCiphertextFFI *output,
     CudaRadixCiphertextFFI const *lwe_input, T cleartext_input,
     const uint32_t message_modulus, const uint32_t carry_modulus) {
@@ -3073,7 +3069,7 @@ __global__ void device_binary_tree_fold(Torus *__restrict__ data,
 /// @param num_blocks       Number of radix blocks per entry
 /// @param identity_lut     Identity LUT used to reset noise after each round
 template <typename Torus>
-__host__ void host_binary_tree_fold_sum(
+__host__ void host_binary_tree_fold_sum_async(
     CudaStreams streams, CudaRadixCiphertextFFI *output,
     CudaRadixCiphertextFFI *input, uint32_t num_entries, uint32_t num_blocks,
     uint32_t message_modulus, uint32_t carry_modulus, void *const *bsks,
@@ -3208,14 +3204,14 @@ __host__ void host_binary_tree_fold_sum(
 /// @param num_blocks       Number of radix blocks per entry
 /// @param identity_lut     Identity LUT for noise resets
 template <typename Torus>
-__host__ void host_binary_tree_fold_sum_dispatch(
+__host__ void host_binary_tree_fold_sum_dispatch_async(
     CudaStreams streams, CudaRadixCiphertextFFI *output,
     CudaRadixCiphertextFFI *input, uint32_t num_entries, uint32_t num_blocks,
     uint32_t message_modulus, uint32_t carry_modulus, void *const *bsks,
     Torus *const *ksks, int_radix_lut<Torus> *identity_lut) {
-  host_binary_tree_fold_sum<Torus>(streams, output, input, num_entries,
-                                   num_blocks, message_modulus, carry_modulus,
-                                   bsks, ksks, identity_lut);
+  host_binary_tree_fold_sum_async<Torus>(
+      streams, output, input, num_entries, num_blocks, message_modulus,
+      carry_modulus, bsks, ksks, identity_lut);
 }
 
 #endif // TFHE_RS_INTERNAL_INTEGER_CUH

--- a/backends/tfhe-cuda-backend/cuda/src/integer/kv_store/kv_store.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/kv_store/kv_store.cu
@@ -43,7 +43,7 @@ void cuda_kv_store_get_64_async(
                  "Result and boolean output pointers must be different for "
                  "out-of-place operations");
 
-  host_kv_store_get<uint64_t>(
+  host_kv_store_get_async<uint64_t>(
       CudaStreams(streams), lwe_array_out_result, lwe_array_out_boolean,
       lwe_array_out_selectors, lwe_array_in_encrypted_key, lwe_array_in_values,
       h_decomposed_clear_keys, (int_kv_store_get_buffer<uint64_t> *)mem, bsks,
@@ -107,7 +107,7 @@ void cuda_kv_store_update_64_async(
                  "Output and new value pointers must be different for "
                  "out-of-place operations");
 
-  host_kv_store_update<uint64_t>(
+  host_kv_store_update_async<uint64_t>(
       CudaStreams(streams), lwe_check_out_block, lwe_array_out_values,
       lwe_array_in_encrypted_key, lwe_array_in_values, lwe_in_new_value,
       h_decomposed_clear_keys, (int_kv_store_update_buffer<uint64_t> *)mem_ptr,
@@ -173,11 +173,11 @@ void cuda_kv_store_map_64_async(
                  "Check output and selectors pointers must be different for "
                  "out-of-place operations");
 
-  host_kv_store_map<uint64_t>(CudaStreams(streams), lwe_check_out_block,
-                              lwe_array_out_values, lwe_array_in_values,
-                              lwe_in_new_value, lwe_array_in_selectors,
-                              (int_kv_store_map_buffer<uint64_t> *)mem_ptr,
-                              bsks, (uint64_t *const *)ksks);
+  host_kv_store_map_async<uint64_t>(
+      CudaStreams(streams), lwe_check_out_block, lwe_array_out_values,
+      lwe_array_in_values, lwe_in_new_value, lwe_array_in_selectors,
+      (int_kv_store_map_buffer<uint64_t> *)mem_ptr, bsks,
+      (uint64_t *const *)ksks);
 
   POP_RANGE()
 }
@@ -230,7 +230,7 @@ void cuda_kv_store_contains_key_64_async(
                  "Output boolean and encrypted key pointers must be different "
                  "for out-of-place operations");
 
-  host_kv_store_contains_key<uint64_t>(
+  host_kv_store_contains_key_async<uint64_t>(
       CudaStreams(streams), lwe_array_out_boolean, lwe_array_in_encrypted_key,
       h_decomposed_clear_keys,
       (int_kv_store_contains_key_buffer<uint64_t> *)mem_ptr, bsks,

--- a/backends/tfhe-cuda-backend/cuda/src/integer/kv_store/kv_store.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/kv_store/kv_store.cuh
@@ -64,7 +64,7 @@ __global__ void device_accumulate_all_blocks_batched(
 /// @param message_modulus       Message modulus for noise-level validation
 /// @param carry_modulus         Carry modulus for noise-level validation
 template <typename Torus>
-__host__ void host_accumulate_all_blocks_batched(
+__host__ void host_accumulate_all_blocks_batched_async(
     cudaStream_t stream, uint32_t gpu_index, CudaRadixCiphertextFFI *output,
     CudaRadixCiphertextFFI const *input, uint32_t blocks_per_entry,
     uint32_t max_value, uint32_t num_entries, uint32_t num_chunks_per_entry,
@@ -136,7 +136,7 @@ __host__ void host_accumulate_all_blocks_batched(
 ///
 /// This is the few-entries kv_store variant; see
 /// KV_STORE_EQ_SELECTORS_SMALL_MAP_MAX_ENTRIES for when it is preferred over
-/// vector_find's host_compute_eq_selectors_ct_vs_clears.
+/// vector_find's host_compute_eq_selectors_ct_vs_clears_async.
 ///
 /// @param lwe_array_out_packed       Output ciphertext: N single-block boolean
 ///                                   selectors packed contiguously
@@ -147,7 +147,7 @@ __host__ void host_accumulate_all_blocks_batched(
 /// @param mem_ptr                    Scratch buffer holding LUTs, gather maps,
 ///                                   and tree buffers
 template <typename Torus>
-__host__ void host_kv_store_compute_eq_selectors_small_map(
+__host__ void host_kv_store_compute_eq_selectors_small_map_async(
     CudaStreams streams, CudaRadixCiphertextFFI *lwe_array_out_packed,
     CudaRadixCiphertextFFI const *lwe_array_in, uint32_t num_blocks,
     const uint64_t *h_decomposed_cleartexts,
@@ -157,8 +157,9 @@ __host__ void host_kv_store_compute_eq_selectors_small_map(
   // num_blocks == 0 would yield an all-zero selector matrix instead of the
   // trivial all-match, so require at least one block (matching the vector_find
   // dispatch guard so both variants agree).
-  GPU_ASSERT(num_blocks >= 1, "num_blocks must be at least 1 in "
-                              "host_kv_store_compute_eq_selectors_small_map");
+  GPU_ASSERT(num_blocks >= 1,
+             "num_blocks must be at least 1 in "
+             "host_kv_store_compute_eq_selectors_small_map_async");
 
   uint32_t num_possible_values = mem_ptr->num_possible_values;
   uint32_t message_modulus = mem_ptr->params.message_modulus;
@@ -219,7 +220,7 @@ __host__ void host_kv_store_compute_eq_selectors_small_map(
     uint32_t num_chunks = CEIL_DIV(blocks_per_entry, max_value);
     uint32_t total_chunks = num_possible_values * num_chunks;
 
-    host_accumulate_all_blocks_batched<Torus>(
+    host_accumulate_all_blocks_batched_async<Torus>(
         streams.stream(0), streams.gpu_index(0), tree_accumulator,
         current_input, blocks_per_entry, max_value, num_possible_values,
         num_chunks, message_modulus, carry_modulus);
@@ -263,18 +264,18 @@ __host__ void host_kv_store_compute_eq_selectors_small_map(
 /// @param mem_ptr                    Wrapper buffer selecting the active
 ///                                   algorithm
 template <typename Torus>
-__host__ void host_kv_store_compute_eq_selectors(
+__host__ void host_kv_store_compute_eq_selectors_async(
     CudaStreams streams, CudaRadixCiphertextFFI *lwe_array_out_packed,
     CudaRadixCiphertextFFI const *lwe_array_in, uint32_t num_blocks,
     const uint64_t *h_decomposed_cleartexts,
     int_kv_store_eq_selectors_wrapper_buffer<Torus> *mem_ptr, void *const *bsks,
     Torus *const *ksks) {
   if (mem_ptr->use_small_map) {
-    host_kv_store_compute_eq_selectors_small_map<Torus>(
+    host_kv_store_compute_eq_selectors_small_map_async<Torus>(
         streams, lwe_array_out_packed, lwe_array_in, num_blocks,
         h_decomposed_cleartexts, mem_ptr->small_map_buffer, bsks, ksks);
   } else {
-    host_compute_eq_selectors_ct_vs_clears<Torus>(
+    host_compute_eq_selectors_ct_vs_clears_async<Torus>(
         streams, lwe_array_out_packed, lwe_array_in, num_blocks,
         h_decomposed_cleartexts, mem_ptr->vector_find_buffer, bsks, ksks);
   }
@@ -299,16 +300,15 @@ __host__ void host_kv_store_compute_eq_selectors(
 /// @param mem_ptr                    Scratch buffer from
 ///                                   scratch_cuda_kv_store_get
 template <typename Torus>
-__host__ void
-host_kv_store_get(CudaStreams streams,
-                  CudaRadixCiphertextFFI *lwe_array_out_result,
-                  CudaRadixCiphertextFFI *lwe_array_out_boolean,
-                  CudaRadixCiphertextFFI *lwe_array_out_selectors,
-                  CudaRadixCiphertextFFI const *lwe_array_in_encrypted_key,
-                  CudaRadixCiphertextFFI const *lwe_array_in_values,
-                  const uint64_t *h_decomposed_clear_keys,
-                  int_kv_store_get_buffer<Torus> *mem_ptr, void *const *bsks,
-                  Torus *const *ksks) {
+__host__ void host_kv_store_get_async(
+    CudaStreams streams, CudaRadixCiphertextFFI *lwe_array_out_result,
+    CudaRadixCiphertextFFI *lwe_array_out_boolean,
+    CudaRadixCiphertextFFI *lwe_array_out_selectors,
+    CudaRadixCiphertextFFI const *lwe_array_in_encrypted_key,
+    CudaRadixCiphertextFFI const *lwe_array_in_values,
+    const uint64_t *h_decomposed_clear_keys,
+    int_kv_store_get_buffer<Torus> *mem_ptr, void *const *bsks,
+    Torus *const *ksks) {
 
   auto num_key_blocks = mem_ptr->num_key_blocks;
   auto num_value_blocks = mem_ptr->num_value_blocks;
@@ -323,7 +323,7 @@ host_kv_store_get(CudaStreams streams,
 
   // Step 1: one encrypted boolean per stored key (input == key_i).
   PUSH_RANGE("get: equality selectors")
-  host_kv_store_compute_eq_selectors<Torus>(
+  host_kv_store_compute_eq_selectors_async<Torus>(
       streams, lwe_array_out_selectors, lwe_array_in_encrypted_key,
       num_key_blocks, h_decomposed_clear_keys, mem_ptr->mem_eq_selectors_buffer,
       bsks, ksks);
@@ -332,15 +332,15 @@ host_kv_store_get(CudaStreams streams,
   // Step 2: zero values whose selector is 0, keeping only the matched value.
   PUSH_RANGE("get: one-hot vector")
   auto lwe_one_hot_vector = tmp_cmux_array;
-  host_zero_out_if_batch(streams, lwe_one_hot_vector, lwe_array_in_values,
-                         lwe_array_out_selectors, mem_zero_out_batch_buffer,
-                         one_hot_vector_predicate, bsks, ksks, num_entries,
-                         num_value_blocks);
+  host_zero_out_if_batch_async(
+      streams, lwe_one_hot_vector, lwe_array_in_values, lwe_array_out_selectors,
+      mem_zero_out_batch_buffer, one_hot_vector_predicate, bsks, ksks,
+      num_entries, num_value_blocks);
   POP_RANGE()
 
   // Step 3: Sum all elements in the vector
   PUSH_RANGE("get: binary tree sum")
-  host_binary_tree_fold_sum_dispatch<Torus>(
+  host_binary_tree_fold_sum_dispatch_async<Torus>(
       streams, lwe_array_out_result, lwe_one_hot_vector, num_entries,
       num_value_blocks, message_modulus, carry_modulus, bsks, ksks,
       mem_ptr->identity_lut);
@@ -348,7 +348,7 @@ host_kv_store_get(CudaStreams streams,
 
   PUSH_RANGE("get: OR selectors")
   auto at_least_one_true_buffer = mem_ptr->at_least_one_true_buffer;
-  host_integer_is_at_least_one_comparisons_block_true<Torus>(
+  host_integer_is_at_least_one_comparisons_block_true_async<Torus>(
       streams, lwe_array_out_boolean, lwe_array_out_selectors,
       at_least_one_true_buffer, bsks, ksks, num_entries);
   POP_RANGE()
@@ -394,16 +394,15 @@ uint64_t scratch_cuda_kv_store_get(
 /// @param mem_ptr                      Scratch buffer from
 ///                                     scratch_cuda_kv_store_update
 template <typename Torus, typename KSTorus>
-__host__ void
-host_kv_store_update(CudaStreams streams,
-                     CudaRadixCiphertextFFI *lwe_check_out_block,
-                     CudaRadixCiphertextFFI *lwe_array_out_values,
-                     CudaRadixCiphertextFFI const *lwe_array_in_encrypted_key,
-                     CudaRadixCiphertextFFI const *lwe_array_in_values,
-                     CudaRadixCiphertextFFI const *lwe_in_new_value,
-                     const uint64_t *h_decomposed_clear_keys,
-                     int_kv_store_update_buffer<Torus> *mem_ptr,
-                     void *const *bsks, KSTorus *const *ksks) {
+__host__ void host_kv_store_update_async(
+    CudaStreams streams, CudaRadixCiphertextFFI *lwe_check_out_block,
+    CudaRadixCiphertextFFI *lwe_array_out_values,
+    CudaRadixCiphertextFFI const *lwe_array_in_encrypted_key,
+    CudaRadixCiphertextFFI const *lwe_array_in_values,
+    CudaRadixCiphertextFFI const *lwe_in_new_value,
+    const uint64_t *h_decomposed_clear_keys,
+    int_kv_store_update_buffer<Torus> *mem_ptr, void *const *bsks,
+    KSTorus *const *ksks) {
 
   auto num_entries = mem_ptr->num_entries;
   auto num_key_blocks = mem_ptr->num_key_blocks;
@@ -426,7 +425,7 @@ host_kv_store_update(CudaStreams streams,
 
   // Step 1: one encrypted boolean per stored key (input == key_i).
   PUSH_RANGE("update: equality selectors")
-  host_kv_store_compute_eq_selectors<Torus>(
+  host_kv_store_compute_eq_selectors_async<Torus>(
       streams, mem_ptr->selectors_contiguous, lwe_array_in_encrypted_key,
       num_key_blocks, h_decomposed_clear_keys, mem_eq_selectors_buffer, bsks,
       ksks);
@@ -434,7 +433,7 @@ host_kv_store_update(CudaStreams streams,
 
   // Step 2: batched CMUX — replace value where selector==1, keep old otherwise.
   PUSH_RANGE("update: batched cmux")
-  host_cmux_batch<Torus, KSTorus>(
+  host_cmux_batch_async<Torus, KSTorus>(
       streams, lwe_array_out_values, lwe_in_new_value, lwe_array_in_values,
       mem_ptr->selectors_contiguous, mem_ptr->cmux_batch_buffer, bsks, ksks,
       num_entries, num_value_blocks, true);
@@ -442,7 +441,7 @@ host_kv_store_update(CudaStreams streams,
 
   // Step 3: OR all selectors to produce the key-found boolean
   PUSH_RANGE("update: OR selectors")
-  host_integer_is_at_least_one_comparisons_block_true<Torus>(
+  host_integer_is_at_least_one_comparisons_block_true_async<Torus>(
       streams, lwe_check_out_block, mem_ptr->selectors_contiguous,
       mem_ptr->at_least_one_true_buffer, bsks, ksks, num_entries);
   POP_RANGE()
@@ -489,14 +488,14 @@ uint64_t scratch_cuda_kv_store_update(
 ///                                  scratch_cuda_kv_store_map
 template <typename Torus, typename KSTorus>
 __host__ void
-host_kv_store_map(CudaStreams streams,
-                  CudaRadixCiphertextFFI *lwe_check_out_block,
-                  CudaRadixCiphertextFFI *lwe_array_out_values,
-                  CudaRadixCiphertextFFI const *lwe_array_in_values,
-                  CudaRadixCiphertextFFI const *lwe_in_new_value,
-                  CudaRadixCiphertextFFI const *lwe_array_in_selectors,
-                  int_kv_store_map_buffer<Torus> *mem_ptr, void *const *bsks,
-                  KSTorus *const *ksks) {
+host_kv_store_map_async(CudaStreams streams,
+                        CudaRadixCiphertextFFI *lwe_check_out_block,
+                        CudaRadixCiphertextFFI *lwe_array_out_values,
+                        CudaRadixCiphertextFFI const *lwe_array_in_values,
+                        CudaRadixCiphertextFFI const *lwe_in_new_value,
+                        CudaRadixCiphertextFFI const *lwe_array_in_selectors,
+                        int_kv_store_map_buffer<Torus> *mem_ptr,
+                        void *const *bsks, KSTorus *const *ksks) {
 
   auto num_entries = mem_ptr->num_entries;
   auto num_value_blocks = mem_ptr->num_value_blocks;
@@ -521,7 +520,7 @@ host_kv_store_map(CudaStreams streams,
 
   // Batched CMUX — replace value where selector==1, keep old otherwise.
   PUSH_RANGE("map: batched cmux")
-  host_cmux_batch<Torus, KSTorus>(
+  host_cmux_batch_async<Torus, KSTorus>(
       streams, lwe_array_out_values, lwe_in_new_value, lwe_array_in_values,
       lwe_array_in_selectors, mem_ptr->cmux_batch_buffer, bsks, ksks,
       num_entries, num_value_blocks, true);
@@ -529,7 +528,7 @@ host_kv_store_map(CudaStreams streams,
 
   // OR all selectors to produce the key-found boolean
   PUSH_RANGE("map: OR selectors")
-  host_integer_is_at_least_one_comparisons_block_true<Torus>(
+  host_integer_is_at_least_one_comparisons_block_true_async<Torus>(
       streams, lwe_check_out_block, lwe_array_in_selectors,
       mem_ptr->at_least_one_true_buffer, bsks, ksks, num_entries);
   POP_RANGE()
@@ -568,7 +567,7 @@ scratch_cuda_kv_store_map(CudaStreams streams,
 /// @param mem_ptr                    Scratch buffer from
 ///                                   scratch_cuda_kv_store_contains_key
 template <typename Torus, typename KSTorus>
-__host__ void host_kv_store_contains_key(
+__host__ void host_kv_store_contains_key_async(
     CudaStreams streams, CudaRadixCiphertextFFI *lwe_array_out_boolean,
     CudaRadixCiphertextFFI const *lwe_array_in_encrypted_key,
     const uint64_t *h_decomposed_clear_keys,
@@ -582,7 +581,7 @@ __host__ void host_kv_store_contains_key(
 
   // Step 1: one encrypted boolean per stored key (input == key_i).
   PUSH_RANGE("contains_key: equality selectors")
-  host_kv_store_compute_eq_selectors<Torus>(
+  host_kv_store_compute_eq_selectors_async<Torus>(
       streams, mem_ptr->selectors_contiguous, lwe_array_in_encrypted_key,
       num_key_blocks, h_decomposed_clear_keys, mem_ptr->mem_eq_selectors_buffer,
       bsks, ksks);
@@ -590,7 +589,7 @@ __host__ void host_kv_store_contains_key(
 
   // Step 2: OR all selectors to produce the key-found boolean
   PUSH_RANGE("contains_key: OR selectors")
-  host_integer_is_at_least_one_comparisons_block_true<Torus>(
+  host_integer_is_at_least_one_comparisons_block_true_async<Torus>(
       streams, lwe_array_out_boolean, mem_ptr->selectors_contiguous,
       mem_ptr->at_least_one_true_buffer, bsks, ksks, num_entries);
   POP_RANGE()

--- a/backends/tfhe-cuda-backend/cuda/src/integer/multiplication.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/multiplication.cu
@@ -71,7 +71,7 @@ void cuda_integer_mult_inplace_64_async(
   // needed
   PUSH_RANGE("mul_inplace")
   DISPATCH_POLY_SIZE(polynomial_size, AmortizedDegreePolicy,
-                     host_integer_mult_radix<uint64_t, Params>(
+                     host_integer_mult_radix_async<uint64_t, Params>(
                          CudaStreams(streams), radix_lwe_inout, radix_lwe_inout,
                          is_bool_left, radix_lwe_right, is_bool_right, bsks,
                          (uint64_t **)(ksks),
@@ -140,7 +140,7 @@ void cuda_partial_sum_ciphertexts_vec_64_async(
   if (radix_lwe_vec->num_radix_blocks % radix_lwe_out->num_radix_blocks != 0)
     PANIC("Cuda error: input vector length should be a multiple of the "
           "output's number of radix blocks")
-  host_integer_partial_sum_ciphertexts_vec<uint64_t>(
+  host_integer_partial_sum_ciphertexts_vec_async<uint64_t>(
       CudaStreams(streams), radix_lwe_out, radix_lwe_vec, bsks,
       (uint64_t **)(ksks), mem, radix_lwe_out->num_radix_blocks,
       radix_lwe_vec->num_radix_blocks / radix_lwe_out->num_radix_blocks);

--- a/backends/tfhe-cuda-backend/cuda/src/integer/multiplication.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/multiplication.cuh
@@ -283,7 +283,7 @@ __host__ uint64_t scratch_cuda_integer_partial_sum_ciphertexts_vec(
 }
 
 template <typename Torus>
-__host__ void host_integer_partial_sum_ciphertexts_vec(
+__host__ void host_integer_partial_sum_ciphertexts_vec_async(
     CudaStreams streams, CudaRadixCiphertextFFI *radix_lwe_out,
     CudaRadixCiphertextFFI *terms, void *const *bsks, uint64_t *const *ksks,
     int_sum_ciphertexts_vec_memory<uint64_t> *mem_ptr,
@@ -335,10 +335,10 @@ __host__ void host_integer_partial_sum_ciphertexts_vec(
     CudaRadixCiphertextFFI terms_slice;
     as_radix_ciphertext_slice<Torus>(&terms_slice, terms, num_radix_blocks,
                                      2 * num_radix_blocks);
-    host_addition<Torus>(streams.stream(0), streams.gpu_index(0), radix_lwe_out,
-                         terms, &terms_slice, num_radix_blocks,
-                         mem_ptr->params.message_modulus,
-                         mem_ptr->params.carry_modulus);
+    host_addition_async<Torus>(
+        streams.stream(0), streams.gpu_index(0), radix_lwe_out, terms,
+        &terms_slice, num_radix_blocks, mem_ptr->params.message_modulus,
+        mem_ptr->params.carry_modulus);
     return;
   }
 
@@ -477,15 +477,15 @@ __host__ void host_integer_partial_sum_ciphertexts_vec(
     as_radix_ciphertext_slice<Torus>(&current_blocks_slice, current_blocks,
                                      num_radix_blocks, 2 * num_radix_blocks);
 
-    host_addition<Torus>(streams.stream(0), streams.gpu_index(0), radix_lwe_out,
-                         current_blocks, &current_blocks_slice,
-                         num_radix_blocks, mem_ptr->params.message_modulus,
-                         mem_ptr->params.carry_modulus);
+    host_addition_async<Torus>(
+        streams.stream(0), streams.gpu_index(0), radix_lwe_out, current_blocks,
+        &current_blocks_slice, num_radix_blocks,
+        mem_ptr->params.message_modulus, mem_ptr->params.carry_modulus);
   }
 }
 
 template <typename Torus, class params>
-__host__ void host_integer_mult_radix(
+__host__ void host_integer_mult_radix_async(
     CudaStreams streams, CudaRadixCiphertextFFI *radix_lwe_out,
     CudaRadixCiphertextFFI const *radix_lwe_left, bool const is_bool_left,
     CudaRadixCiphertextFFI const *radix_lwe_right, bool const is_bool_right,
@@ -610,16 +610,16 @@ __host__ void host_integer_mult_radix(
     size_t b_id = i % num_blocks;
     terms_degree_msb[i] = (b_id > r_id) ? message_modulus - 2 : 0;
   }
-  host_integer_partial_sum_ciphertexts_vec<Torus>(
+  host_integer_partial_sum_ciphertexts_vec_async<Torus>(
       streams, radix_lwe_out, vector_result_sb, bsks, ksks,
       mem_ptr->sum_ciphertexts_mem, num_blocks, 2 * num_blocks);
 
   auto scp_mem_ptr = mem_ptr->sc_prop_mem;
   uint32_t requested_flag = outputFlag::FLAG_NONE;
   uint32_t uses_carry = 0;
-  host_propagate_single_carry<Torus>(streams, radix_lwe_out, nullptr, nullptr,
-                                     scp_mem_ptr, bsks, ksks, requested_flag,
-                                     uses_carry);
+  host_propagate_single_carry_async<Torus>(streams, radix_lwe_out, nullptr,
+                                           nullptr, scp_mem_ptr, bsks, ksks,
+                                           requested_flag, uses_carry);
 }
 
 template <typename Torus>

--- a/backends/tfhe-cuda-backend/cuda/src/integer/negation.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/negation.cu
@@ -10,8 +10,8 @@ void cuda_negate_ciphertext_64(CudaStreamsFFI streams,
                  "operations");
 
   auto cuda_streams = CudaStreams(streams);
-  host_negation_with_correcting_term<uint64_t>(cuda_streams, lwe_array_out,
-                                               lwe_array_in, message_modulus,
-                                               carry_modulus, num_radix_blocks);
+  host_negation_with_correcting_term_async<uint64_t>(
+      cuda_streams, lwe_array_out, lwe_array_in, message_modulus, carry_modulus,
+      num_radix_blocks);
   cuda_synchronize_stream(cuda_streams.stream(0), cuda_streams.gpu_index(0));
 }

--- a/backends/tfhe-cuda-backend/cuda/src/integer/negation.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/negation.cuh
@@ -56,11 +56,12 @@ __global__ void device_negation(Torus *output, Torus const *input,
  * @param num_radix_blocks number of blocks to negate
  */
 template <typename T>
-__host__ void host_negation(cudaStream_t stream, uint32_t gpu_index,
-                            CudaRadixCiphertextFFI *output,
-                            CudaRadixCiphertextFFI const *input,
-                            uint32_t num_radix_blocks, uint32_t message_modulus,
-                            uint32_t carry_modulus) {
+__host__ void host_negation_async(cudaStream_t stream, uint32_t gpu_index,
+                                  CudaRadixCiphertextFFI *output,
+                                  CudaRadixCiphertextFFI const *input,
+                                  uint32_t num_radix_blocks,
+                                  uint32_t message_modulus,
+                                  uint32_t carry_modulus) {
 
   cuda_set_device(gpu_index);
   int lwe_size = input->lwe_dimension + 1;
@@ -98,7 +99,7 @@ __host__ void host_negation(cudaStream_t stream, uint32_t gpu_index,
  * @param num_radix_blocks number of blocks to negate
  */
 template <typename Torus>
-__host__ void host_negation_with_correcting_term(
+__host__ void host_negation_with_correcting_term_async(
     CudaStreams streams, CudaRadixCiphertextFFI *lwe_array_out,
     CudaRadixCiphertextFFI const *lwe_array_in, uint32_t message_modulus,
     uint32_t carry_modulus, uint32_t num_radix_blocks) {

--- a/backends/tfhe-cuda-backend/cuda/src/integer/oprf.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/oprf.cu
@@ -20,7 +20,7 @@ void cuda_integer_grouped_oprf_64_async(CudaStreamsFFI streams,
                                         uint32_t num_blocks_to_process,
                                         int8_t *mem, void *const *bsks) {
 
-  host_integer_grouped_oprf<uint64_t>(
+  host_integer_grouped_oprf_async<uint64_t>(
       CudaStreams(streams), radix_lwe_out, (const uint64_t *)seeded_lwe_input,
       num_blocks_to_process, (int_grouped_oprf_memory<uint64_t> *)mem, bsks);
 }

--- a/backends/tfhe-cuda-backend/cuda/src/integer/oprf.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/oprf.cuh
@@ -22,12 +22,12 @@ uint64_t scratch_cuda_integer_grouped_oprf_async(
 }
 
 template <typename Torus>
-void host_integer_grouped_oprf(CudaStreams streams,
-                               CudaRadixCiphertextFFI *radix_lwe_out,
-                               const Torus *seeded_lwe_input,
-                               uint32_t num_blocks_to_process,
-                               int_grouped_oprf_memory<Torus> *mem_ptr,
-                               void *const *bsks) {
+void host_integer_grouped_oprf_async(CudaStreams streams,
+                                     CudaRadixCiphertextFFI *radix_lwe_out,
+                                     const Torus *seeded_lwe_input,
+                                     uint32_t num_blocks_to_process,
+                                     int_grouped_oprf_memory<Torus> *mem_ptr,
+                                     void *const *bsks) {
 
   auto active_streams = streams.active_gpu_subset(num_blocks_to_process,
                                                   mem_ptr->params.pbs_type);
@@ -85,10 +85,10 @@ void host_integer_grouped_oprf(CudaStreams streams,
     radix_lwe_out->noise_levels[i] = NoiseLevel::NOMINAL;
   }
 
-  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), radix_lwe_out,
-                       radix_lwe_out, mem_ptr->plaintext_corrections,
-                       num_blocks_to_process, mem_ptr->params.message_modulus,
-                       mem_ptr->params.carry_modulus);
+  host_addition_async<Torus>(
+      streams.stream(0), streams.gpu_index(0), radix_lwe_out, radix_lwe_out,
+      mem_ptr->plaintext_corrections, num_blocks_to_process,
+      mem_ptr->params.message_modulus, mem_ptr->params.carry_modulus);
 }
 
 template <typename Torus>
@@ -138,12 +138,12 @@ void host_integer_grouped_oprf_custom_range(
       streams.stream(0), streams.gpu_index(0), computation_buffer, 0,
       num_blocks_intermediate);
 
-  host_integer_grouped_oprf<Torus>(
+  host_integer_grouped_oprf_async<Torus>(
       streams, computation_buffer, seeded_lwe_input,
       mem_ptr->num_random_input_blocks, mem_ptr->grouped_oprf_memory, bsks);
 
   if (mem_ptr->applies_rerand()) {
-    host_rerand_inplace_dispatch<Torus>(
+    host_rerand_inplace_dispatch_async<Torus>(
         streams, static_cast<Torus *>(computation_buffer->ptr),
         lwe_flattened_encryptions_of_zero_compact_array_in, rerand_ksks,
         mem_ptr->rerand_memory);
@@ -154,7 +154,7 @@ void host_integer_grouped_oprf_custom_range(
       mem_ptr->scalar_mul_buffer, compute_bsks, ksks,
       mem_ptr->params.message_modulus, num_scalars);
 
-  host_logical_scalar_shift_inplace<Torus>(
+  host_logical_scalar_shift_inplace_async<Torus>(
       streams, computation_buffer, shift, mem_ptr->logical_scalar_shift_buffer,
       compute_bsks, ksks, num_blocks_intermediate);
 

--- a/backends/tfhe-cuda-backend/cuda/src/integer/rerand.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/rerand.cu
@@ -35,7 +35,7 @@ void cuda_rerand_64_async(
   PUSH_RANGE("rerand")
   auto rerand_buffer = reinterpret_cast<int_rerand_mem<uint64_t> *>(mem_ptr);
 
-  host_rerand_inplace_dispatch<uint64_t>(
+  host_rerand_inplace_dispatch_async<uint64_t>(
       streams, static_cast<uint64_t *>(lwe_array),
       static_cast<const uint64_t *>(
           lwe_flattened_encryptions_of_zero_compact_array_in),

--- a/backends/tfhe-cuda-backend/cuda/src/integer/rerand.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/rerand.cuh
@@ -11,7 +11,7 @@
 #include "zk/zk_utilities.h"
 
 template <typename Torus, class params>
-void host_rerand_inplace(
+void host_rerand_inplace_async(
     CudaStreams const streams, Torus *lwe_array,
     const Torus *lwe_flattened_encryptions_of_zero_compact_array_in,
     Torus *const *ksk, int_rerand_mem<Torus> *mem_ptr) {
@@ -52,8 +52,9 @@ void host_rerand_inplace(
       safe_mul_sizeof<expand_job<Torus>>(compact_lwe_lists.total_num_lwes),
       streams.stream(0), streams.gpu_index(0), true);
 
-  host_lwe_expand<Torus, params>(streams.stream(0), streams.gpu_index(0),
-                                 expanded_zero_lwes, d_expand_jobs, num_lwes);
+  host_lwe_expand_async<Torus, params>(streams.stream(0), streams.gpu_index(0),
+                                       expanded_zero_lwes, d_expand_jobs,
+                                       num_lwes);
 
   auto lwes_to_be_added = expanded_zero_lwes;
   if (rerand_mode == RERAND_MODE::RERAND_WITH_KS) {
@@ -77,9 +78,9 @@ void host_rerand_inplace(
   CudaRadixCiphertextFFI ksed_zero_lwes_ffi;
   into_radix_ciphertext(&ksed_zero_lwes_ffi, lwes_to_be_added, num_lwes,
                         output_dimension);
-  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), &lwes_ffi,
-                       &lwes_ffi, &ksed_zero_lwes_ffi, num_lwes,
-                       message_modulus, carry_modulus);
+  host_addition_async<Torus>(streams.stream(0), streams.gpu_index(0), &lwes_ffi,
+                             &lwes_ffi, &ksed_zero_lwes_ffi, num_lwes,
+                             message_modulus, carry_modulus);
   release_cpu_radix_ciphertext_async(&lwes_ffi);
   release_cpu_radix_ciphertext_async(&ksed_zero_lwes_ffi);
   compact_lwe_lists.release();
@@ -94,12 +95,12 @@ void host_rerand_inplace(
 /// @param ksk                     Keyswitch key pointers (one per GPU)
 /// @param mem_ptr                 Pre-allocated re-randomization scratch buffer
 template <typename Torus>
-void host_rerand_inplace_dispatch(
+void host_rerand_inplace_dispatch_async(
     CudaStreams const streams, Torus *lwe_array,
     const Torus *lwe_flattened_encryptions_of_zero_compact_array_in,
     Torus *const *ksk, int_rerand_mem<Torus> *mem_ptr) {
   DISPATCH_POLY_SIZE(mem_ptr->params.big_lwe_dimension, AmortizedDegreePolicy,
-                     host_rerand_inplace<Torus, Params>(
+                     host_rerand_inplace_async<Torus, Params>(
                          streams, lwe_array,
                          lwe_flattened_encryptions_of_zero_compact_array_in,
                          ksk, mem_ptr));

--- a/backends/tfhe-cuda-backend/cuda/src/integer/scalar_addition.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/scalar_addition.cu
@@ -6,7 +6,7 @@ void cuda_scalar_addition_ciphertext_64_inplace(
     uint32_t message_modulus, uint32_t carry_modulus) {
 
   auto cuda_streams = CudaStreams(streams);
-  host_scalar_addition_inplace<uint64_t>(
+  host_scalar_addition_inplace_async<uint64_t>(
       cuda_streams, lwe_array, static_cast<const uint64_t *>(scalar_input),
       static_cast<const uint64_t *>(h_scalar_input), num_scalars,
       message_modulus, carry_modulus);

--- a/backends/tfhe-cuda-backend/cuda/src/integer/scalar_addition.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/scalar_addition.cuh
@@ -25,7 +25,7 @@ device_scalar_addition_inplace(Torus *lwe_array, Torus const *scalar_input,
 }
 
 template <typename Torus>
-__host__ void host_scalar_addition_inplace(
+__host__ void host_scalar_addition_inplace_async(
     CudaStreams streams, CudaRadixCiphertextFFI *lwe_array,
     Torus const *scalar_input, Torus const *h_scalar_input,
     uint32_t num_scalars, uint32_t message_modulus, uint32_t carry_modulus) {
@@ -68,10 +68,9 @@ device_add_scalar_one_inplace(Torus *lwe_array, int32_t num_blocks,
 }
 
 template <typename Torus>
-__host__ void host_add_scalar_one_inplace(CudaStreams streams,
-                                          CudaRadixCiphertextFFI *lwe_array,
-                                          uint32_t message_modulus,
-                                          uint32_t carry_modulus) {
+__host__ void host_add_scalar_one_inplace_async(
+    CudaStreams streams, CudaRadixCiphertextFFI *lwe_array,
+    uint32_t message_modulus, uint32_t carry_modulus) {
   cuda_set_device(streams.gpu_index(0));
 
   // Create a 1-dimensional grid of threads
@@ -111,7 +110,7 @@ device_scalar_subtraction_inplace(Torus *lwe_array, Torus *scalar_input,
 }
 
 template <typename Torus>
-__host__ void host_scalar_subtraction_inplace(
+__host__ void host_scalar_subtraction_inplace_async(
     CudaStreams streams, CudaRadixCiphertextFFI *lwe_array, Torus *scalar_input,
     uint32_t lwe_dimension, uint32_t input_lwe_ciphertext_count,
     uint32_t message_modulus, uint32_t carry_modulus) {

--- a/backends/tfhe-cuda-backend/cuda/src/integer/scalar_bitops.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/scalar_bitops.cu
@@ -6,7 +6,7 @@ void cuda_integer_scalar_bitop_inplace_64_async(
     uint32_t num_clear_blocks, int8_t *mem_ptr, void *const *bsks,
     void *const *ksks) {
   // In-place variant: lwe_array_inout op= scalar, no aliasing check needed
-  host_scalar_bitop<uint64_t>(
+  host_scalar_bitop_async<uint64_t>(
       CudaStreams(streams), lwe_array_inout, lwe_array_inout,
       static_cast<const uint64_t *>(clear_blocks),
       static_cast<const uint64_t *>(h_clear_blocks), num_clear_blocks,

--- a/backends/tfhe-cuda-backend/cuda/src/integer/scalar_bitops.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/scalar_bitops.cuh
@@ -4,12 +4,11 @@
 #include "integer/bitwise_ops.cuh"
 
 template <typename Torus, typename KSTorus>
-__host__ void
-host_scalar_bitop(CudaStreams streams, CudaRadixCiphertextFFI *output,
-                  CudaRadixCiphertextFFI const *input,
-                  Torus const *clear_blocks, Torus const *h_clear_blocks,
-                  uint32_t num_clear_blocks, int_bitop_buffer<Torus> *mem_ptr,
-                  void *const *bsks, KSTorus *const *ksks) {
+__host__ void host_scalar_bitop_async(
+    CudaStreams streams, CudaRadixCiphertextFFI *output,
+    CudaRadixCiphertextFFI const *input, Torus const *clear_blocks,
+    Torus const *h_clear_blocks, uint32_t num_clear_blocks,
+    int_bitop_buffer<Torus> *mem_ptr, void *const *bsks, KSTorus *const *ksks) {
 
   if (output->num_radix_blocks != input->num_radix_blocks)
     PANIC("Cuda error: input and output num radix blocks must be equal")

--- a/backends/tfhe-cuda-backend/cuda/src/integer/scalar_comparison.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/scalar_comparison.cu
@@ -48,7 +48,7 @@ void cuda_integer_scalar_comparison_64_async(
   switch (buffer->op) {
   case EQ:
   case NE:
-    host_scalar_equality_check<uint64_t>(
+    host_scalar_equality_check_async<uint64_t>(
         CudaStreams(streams), lwe_array_out, lwe_array_in,
         static_cast<const uint64_t *>(scalar_blocks), buffer, bsks,
         (uint64_t **)(ksks), num_radix_blocks, num_scalar_blocks);
@@ -60,7 +60,7 @@ void cuda_integer_scalar_comparison_64_async(
     if (num_radix_blocks % 2 != 0 && num_radix_blocks != 1)
       PANIC("Cuda error (scalar comparisons): the number of radix blocks has "
             "to be even or equal to 1.")
-    host_scalar_difference_check<uint64_t>(
+    host_scalar_difference_check_async<uint64_t>(
         CudaStreams(streams), lwe_array_out, lwe_array_in,
         static_cast<const uint64_t *>(scalar_blocks),
         static_cast<const uint64_t *>(h_scalar_blocks), buffer,
@@ -72,7 +72,7 @@ void cuda_integer_scalar_comparison_64_async(
     if (lwe_array_in->num_radix_blocks % 2 != 0)
       PANIC("Cuda error (scalar max/min): the number of radix blocks has to be "
             "even.")
-    host_scalar_maxmin<uint64_t>(
+    host_scalar_maxmin_async<uint64_t>(
         CudaStreams(streams), lwe_array_out, lwe_array_in,
         static_cast<const uint64_t *>(scalar_blocks),
         static_cast<const uint64_t *>(h_scalar_blocks), buffer, bsks,

--- a/backends/tfhe-cuda-backend/cuda/src/integer/scalar_comparison.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/scalar_comparison.cuh
@@ -62,7 +62,7 @@ __host__ void scalar_compare_radix_blocks(
                                      subtracted_blocks, lwe_array_in);
   // Subtract
   // Here we need the true lwe sub, not the one that comes from shortint.
-  host_scalar_subtraction_inplace<Torus>(
+  host_scalar_subtraction_inplace_async<Torus>(
       streams, subtracted_blocks, scalar_blocks, big_lwe_dimension,
       num_radix_blocks, message_modulus, carry_modulus);
 
@@ -78,8 +78,8 @@ __host__ void scalar_compare_radix_blocks(
   CudaRadixCiphertextFFI lwe_array_out_view;
   as_radix_ciphertext_slice<Torus>(&lwe_array_out_view, lwe_array_out, 0,
                                    num_radix_blocks);
-  host_add_scalar_one_inplace<Torus>(streams, &lwe_array_out_view,
-                                     message_modulus, carry_modulus);
+  host_add_scalar_one_inplace_async<Torus>(streams, &lwe_array_out_view,
+                                           message_modulus, carry_modulus);
 }
 
 template <typename Torus, typename KSTorus>
@@ -127,7 +127,7 @@ __host__ void integer_radix_unsigned_scalar_difference_check(
   if (num_scalar_blocks == 0) {
     // We only have to compare blocks with zero
     // means scalar is zero
-    host_compare_blocks_with_zero<Torus>(
+    host_compare_blocks_with_zero_async<Torus>(
         streams, mem_ptr->tmp_lwe_array_out, lwe_array_in, mem_ptr, bsks, ksks,
         num_radix_blocks, mem_ptr->is_zero_lut);
     are_all_comparisons_block_true<Torus>(
@@ -212,7 +212,7 @@ __host__ void integer_radix_unsigned_scalar_difference_check(
                                num_lsb_radix_blocks);
     //////////////
     // msb
-    host_compare_blocks_with_zero<Torus>(
+    host_compare_blocks_with_zero_async<Torus>(
         msb_streams, &lwe_array_msb_out, &msb, mem_ptr, bsks, ksks,
         num_msb_radix_blocks, mem_ptr->is_zero_lut);
     are_all_comparisons_block_true<Torus>(
@@ -360,7 +360,7 @@ __host__ void integer_radix_signed_scalar_difference_check(
     // We only have to compare blocks with zero
     // means scalar is zero
     auto are_all_msb_zeros = mem_ptr->tmp_lwe_array_out;
-    host_compare_blocks_with_zero<Torus>(
+    host_compare_blocks_with_zero_async<Torus>(
         streams, are_all_msb_zeros, lwe_array_in, mem_ptr, bsks, ksks,
         num_radix_blocks, mem_ptr->is_zero_lut);
     are_all_comparisons_block_true<Torus>(
@@ -475,7 +475,7 @@ __host__ void integer_radix_signed_scalar_difference_check(
     // msb
     // We remove the last block (which is the sign)
     auto are_all_msb_zeros = lwe_array_msb_out;
-    host_compare_blocks_with_zero<Torus>(
+    host_compare_blocks_with_zero_async<Torus>(
         msb_streams, &are_all_msb_zeros, &msb, mem_ptr, bsks, ksks,
         num_msb_radix_blocks, mem_ptr->is_zero_lut);
     are_all_comparisons_block_true<Torus>(
@@ -625,7 +625,7 @@ __host__ void integer_radix_signed_scalar_difference_check(
 }
 
 template <typename Torus, typename KSTorus>
-__host__ void host_scalar_difference_check(
+__host__ void host_scalar_difference_check_async(
     CudaStreams streams, CudaRadixCiphertextFFI *lwe_array_out,
     CudaRadixCiphertextFFI const *lwe_array_in, Torus const *scalar_blocks,
     Torus const *h_scalar_blocks, int_comparison_buffer<Torus> *mem_ptr,
@@ -660,13 +660,12 @@ __host__ void host_scalar_difference_check(
 }
 
 template <typename Torus, typename KSTorus>
-__host__ void
-host_scalar_maxmin(CudaStreams streams, CudaRadixCiphertextFFI *lwe_array_out,
-                   CudaRadixCiphertextFFI const *lwe_array_in,
-                   Torus const *scalar_blocks, Torus const *h_scalar_blocks,
-                   int_comparison_buffer<Torus> *mem_ptr, void *const *bsks,
-                   KSTorus *const *ksks, uint32_t num_radix_blocks,
-                   uint32_t num_scalar_blocks) {
+__host__ void host_scalar_maxmin_async(
+    CudaStreams streams, CudaRadixCiphertextFFI *lwe_array_out,
+    CudaRadixCiphertextFFI const *lwe_array_in, Torus const *scalar_blocks,
+    Torus const *h_scalar_blocks, int_comparison_buffer<Torus> *mem_ptr,
+    void *const *bsks, KSTorus *const *ksks, uint32_t num_radix_blocks,
+    uint32_t num_scalar_blocks) {
 
   if (lwe_array_out->lwe_dimension != lwe_array_in->lwe_dimension)
     PANIC("Cuda error: input and output lwe dimensions must be the same")
@@ -682,7 +681,7 @@ host_scalar_maxmin(CudaStreams streams, CudaRadixCiphertextFFI *lwe_array_out,
   // - 1 if lhs == rhs
   // - 2 if lhs > rhs
   auto sign = mem_ptr->tmp_lwe_array_out;
-  host_scalar_difference_check<Torus>(
+  host_scalar_difference_check_async<Torus>(
       streams, sign, lwe_array_in, scalar_blocks, h_scalar_blocks, mem_ptr,
       mem_ptr->identity_lut_f, bsks, ksks, num_radix_blocks, num_scalar_blocks);
 
@@ -698,13 +697,13 @@ host_scalar_maxmin(CudaStreams streams, CudaRadixCiphertextFFI *lwe_array_out,
 
   // Selector
   // CMUX for Max or Min
-  host_cmux<Torus>(streams, lwe_array_out, mem_ptr->tmp_lwe_array_out,
-                   lwe_array_left, lwe_array_right, mem_ptr->cmux_buffer, bsks,
-                   ksks);
+  host_cmux_async<Torus>(streams, lwe_array_out, mem_ptr->tmp_lwe_array_out,
+                         lwe_array_left, lwe_array_right, mem_ptr->cmux_buffer,
+                         bsks, ksks);
 }
 
 template <typename Torus, typename KSTorus>
-__host__ void host_scalar_equality_check(
+__host__ void host_scalar_equality_check_async(
     CudaStreams streams, CudaRadixCiphertextFFI *lwe_array_out,
     CudaRadixCiphertextFFI const *lwe_array_in, Torus const *scalar_blocks,
     int_comparison_buffer<Torus> *mem_ptr, void *const *bsks,
@@ -795,9 +794,9 @@ __host__ void host_scalar_equality_check(
       PANIC("Cuda error: integer operation not supported")
     }
 
-    host_compare_blocks_with_zero<Torus>(msb_streams, &msb_out, &msb_in,
-                                         mem_ptr, bsks, ksks,
-                                         num_msb_radix_blocks, msb_lut);
+    host_compare_blocks_with_zero_async<Torus>(msb_streams, &msb_out, &msb_in,
+                                               mem_ptr, bsks, ksks,
+                                               num_msb_radix_blocks, msb_lut);
     are_all_comparisons_block_true<Torus>(msb_streams, &msb_out, &msb_out,
                                           mem_ptr, bsks, ksks,
                                           msb_out.num_radix_blocks);

--- a/backends/tfhe-cuda-backend/cuda/src/integer/scalar_div.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/scalar_div.cuh
@@ -35,7 +35,7 @@ __host__ void host_integer_unsigned_scalar_div_radix(
   }
 
   if (scalar_divisor_ffi->is_divisor_pow2) {
-    host_logical_scalar_shift_inplace<Torus>(
+    host_logical_scalar_shift_inplace_async<Torus>(
         streams, numerator_ct, scalar_divisor_ffi->ilog2_divisor,
         mem_ptr->logical_scalar_shift_mem, bsks, ksks,
         numerator_ct->num_radix_blocks);
@@ -66,19 +66,19 @@ __host__ void host_integer_unsigned_scalar_div_radix(
                                 mem_ptr->scalar_mul_high_mem, ksks, bsks,
                                 scalar_divisor_ffi);
 
-    host_sub_and_propagate_single_carry<Torus>(
+    host_sub_and_propagate_single_carry_async<Torus>(
         streams, numerator_ct, numerator_copy, nullptr, nullptr,
         mem_ptr->sub_and_propagate_mem, bsks, ksks, FLAG_NONE, (uint32_t)0);
 
-    host_logical_scalar_shift_inplace<Torus>(
+    host_logical_scalar_shift_inplace_async<Torus>(
         streams, numerator_ct, (uint32_t)1, mem_ptr->logical_scalar_shift_mem,
         bsks, ksks, numerator_ct->num_radix_blocks);
 
-    host_add_and_propagate_single_carry<Torus>(
+    host_add_and_propagate_single_carry_async<Torus>(
         streams, numerator_ct, numerator_copy, nullptr, nullptr,
         mem_ptr->scp_mem, bsks, ksks, FLAG_NONE, (uint32_t)0);
 
-    host_logical_scalar_shift_inplace<Torus>(
+    host_logical_scalar_shift_inplace_async<Torus>(
         streams, numerator_ct, scalar_divisor_ffi->shift_post - (uint32_t)1,
         mem_ptr->logical_scalar_shift_mem, bsks, ksks,
         numerator_ct->num_radix_blocks);
@@ -86,7 +86,7 @@ __host__ void host_integer_unsigned_scalar_div_radix(
     return;
   }
 
-  host_logical_scalar_shift_inplace<Torus>(
+  host_logical_scalar_shift_inplace_async<Torus>(
       streams, numerator_ct, scalar_divisor_ffi->shift_pre,
       mem_ptr->logical_scalar_shift_mem, bsks, ksks,
       numerator_ct->num_radix_blocks);
@@ -95,7 +95,7 @@ __host__ void host_integer_unsigned_scalar_div_radix(
                               mem_ptr->scalar_mul_high_mem, ksks, bsks,
                               scalar_divisor_ffi);
 
-  host_logical_scalar_shift_inplace<Torus>(
+  host_logical_scalar_shift_inplace_async<Torus>(
       streams, numerator_ct, scalar_divisor_ffi->shift_post,
       mem_ptr->logical_scalar_shift_mem, bsks, ksks,
       numerator_ct->num_radix_blocks);
@@ -128,7 +128,7 @@ __host__ void host_integer_signed_scalar_div_radix(
     if (scalar_divisor_ffi->is_divisor_negative) {
       CudaRadixCiphertextFFI *tmp = mem_ptr->tmp_ffi;
 
-      host_negation_with_correcting_term<Torus>(
+      host_negation_with_correcting_term_async<Torus>(
           streams, tmp, numerator_ct, mem_ptr->params.message_modulus,
           mem_ptr->params.carry_modulus, numerator_ct->num_radix_blocks);
 
@@ -151,20 +151,20 @@ __host__ void host_integer_signed_scalar_div_radix(
     copy_radix_ciphertext_async<Torus>(streams.stream(0), streams.gpu_index(0),
                                        tmp, numerator_ct);
 
-    host_arithmetic_scalar_shift_inplace<Torus>(
+    host_arithmetic_scalar_shift_inplace_async<Torus>(
         streams, tmp, scalar_divisor_ffi->chosen_multiplier_num_bits - 1,
         mem_ptr->arithmetic_scalar_shift_mem, bsks, ksks);
 
-    host_logical_scalar_shift_inplace<Torus>(
+    host_logical_scalar_shift_inplace_async<Torus>(
         streams, tmp,
         numerator_bits - scalar_divisor_ffi->chosen_multiplier_num_bits,
         mem_ptr->logical_scalar_shift_mem, bsks, ksks, tmp->num_radix_blocks);
 
-    host_add_and_propagate_single_carry<Torus>(
+    host_add_and_propagate_single_carry_async<Torus>(
         streams, tmp, numerator_ct, nullptr, nullptr, mem_ptr->scp_mem, bsks,
         ksks, FLAG_NONE, (uint32_t)0);
 
-    host_arithmetic_scalar_shift_inplace<Torus>(
+    host_arithmetic_scalar_shift_inplace_async<Torus>(
         streams, tmp, scalar_divisor_ffi->chosen_multiplier_num_bits,
         mem_ptr->arithmetic_scalar_shift_mem, bsks, ksks);
 
@@ -176,7 +176,7 @@ __host__ void host_integer_signed_scalar_div_radix(
                                        mem_ptr->scalar_mul_high_mem, ksks,
                                        scalar_divisor_ffi, bsks);
 
-    host_arithmetic_scalar_shift_inplace<Torus>(
+    host_arithmetic_scalar_shift_inplace_async<Torus>(
         streams, tmp, scalar_divisor_ffi->shift_post,
         mem_ptr->arithmetic_scalar_shift_mem, bsks, ksks);
 
@@ -184,11 +184,11 @@ __host__ void host_integer_signed_scalar_div_radix(
     copy_radix_ciphertext_async<Torus>(streams.stream(0), streams.gpu_index(0),
                                        xsign, numerator_ct);
 
-    host_arithmetic_scalar_shift_inplace<Torus>(
+    host_arithmetic_scalar_shift_inplace_async<Torus>(
         streams, xsign, numerator_bits - 1,
         mem_ptr->arithmetic_scalar_shift_mem, bsks, ksks);
 
-    host_sub_and_propagate_single_carry<Torus>(
+    host_sub_and_propagate_single_carry_async<Torus>(
         streams, tmp, xsign, nullptr, nullptr, mem_ptr->sub_and_propagate_mem,
         bsks, ksks, FLAG_NONE, (uint32_t)0);
 
@@ -201,11 +201,11 @@ __host__ void host_integer_signed_scalar_div_radix(
                                        mem_ptr->scalar_mul_high_mem, ksks,
                                        scalar_divisor_ffi, bsks);
 
-    host_add_and_propagate_single_carry<Torus>(
+    host_add_and_propagate_single_carry_async<Torus>(
         streams, tmp, numerator_ct, nullptr, nullptr, mem_ptr->scp_mem, bsks,
         ksks, FLAG_NONE, (uint32_t)0);
 
-    host_arithmetic_scalar_shift_inplace<Torus>(
+    host_arithmetic_scalar_shift_inplace_async<Torus>(
         streams, tmp, scalar_divisor_ffi->shift_post,
         mem_ptr->arithmetic_scalar_shift_mem, bsks, ksks);
 
@@ -213,17 +213,17 @@ __host__ void host_integer_signed_scalar_div_radix(
     copy_radix_ciphertext_async<Torus>(streams.stream(0), streams.gpu_index(0),
                                        xsign, numerator_ct);
 
-    host_arithmetic_scalar_shift_inplace<Torus>(
+    host_arithmetic_scalar_shift_inplace_async<Torus>(
         streams, xsign, numerator_bits - 1,
         mem_ptr->arithmetic_scalar_shift_mem, bsks, ksks);
 
-    host_sub_and_propagate_single_carry<Torus>(
+    host_sub_and_propagate_single_carry_async<Torus>(
         streams, tmp, xsign, nullptr, nullptr, mem_ptr->sub_and_propagate_mem,
         bsks, ksks, FLAG_NONE, (uint32_t)0);
   }
 
   if (scalar_divisor_ffi->is_divisor_negative) {
-    host_negation_with_correcting_term<Torus>(
+    host_negation_with_correcting_term_async<Torus>(
         streams, numerator_ct, tmp, mem_ptr->params.message_modulus,
         mem_ptr->params.carry_modulus, numerator_ct->num_radix_blocks);
   } else {
@@ -269,9 +269,9 @@ __host__ void host_integer_unsigned_scalar_div_rem_radix(
 
     copy_radix_ciphertext_async<Torus>(streams.stream(0), streams.gpu_index(0),
                                        remainder_ct, numerator_ct);
-    host_scalar_bitop(streams, remainder_ct, remainder_ct, clear_blocks,
-                      h_clear_blocks, num_clear_blocks, mem_ptr->bitop_mem,
-                      bsks, ksks);
+    host_scalar_bitop_async(streams, remainder_ct, remainder_ct, clear_blocks,
+                            h_clear_blocks, num_clear_blocks,
+                            mem_ptr->bitop_mem, bsks, ksks);
 
   } else {
     if (!scalar_divisor_ffi->is_divisor_zero) {
@@ -291,7 +291,7 @@ __host__ void host_integer_unsigned_scalar_div_rem_radix(
       }
     }
 
-    host_sub_and_propagate_single_carry(
+    host_sub_and_propagate_single_carry_async(
         streams, numerator_ct, remainder_ct, nullptr, nullptr,
         mem_ptr->sub_and_propagate_mem, bsks, ksks, FLAG_NONE, (uint32_t)0);
 
@@ -334,19 +334,19 @@ __host__ void host_integer_signed_scalar_div_rem_radix(
                                        mem_ptr->signed_div_mem, bsks, ksks,
                                        scalar_divisor_ffi, numerator_bits);
 
-  host_propagate_single_carry<Torus>(streams, quotient_ct, nullptr, nullptr,
-                                     mem_ptr->scp_mem, bsks, ksks, FLAG_NONE,
-                                     (uint32_t)0);
+  host_propagate_single_carry_async<Torus>(streams, quotient_ct, nullptr,
+                                           nullptr, mem_ptr->scp_mem, bsks,
+                                           ksks, FLAG_NONE, (uint32_t)0);
 
   if (!scalar_divisor_ffi->is_divisor_negative &&
       scalar_divisor_ffi->is_divisor_pow2) {
     copy_radix_ciphertext_async<Torus>(streams.stream(0), streams.gpu_index(0),
                                        remainder_ct, quotient_ct);
 
-    host_logical_scalar_shift_inplace(streams, remainder_ct,
-                                      scalar_divisor_ffi->ilog2_divisor,
-                                      mem_ptr->logical_scalar_shift_mem, bsks,
-                                      ksks, remainder_ct->num_radix_blocks);
+    host_logical_scalar_shift_inplace_async(
+        streams, remainder_ct, scalar_divisor_ffi->ilog2_divisor,
+        mem_ptr->logical_scalar_shift_mem, bsks, ksks,
+        remainder_ct->num_radix_blocks);
 
   } else if (!scalar_divisor_ffi->is_divisor_zero) {
     copy_radix_ciphertext_async<Torus>(streams.stream(0), streams.gpu_index(0),
@@ -366,7 +366,7 @@ __host__ void host_integer_signed_scalar_div_rem_radix(
     }
   }
 
-  host_sub_and_propagate_single_carry(
+  host_sub_and_propagate_single_carry_async(
       streams, numerator_ct, remainder_ct, nullptr, nullptr,
       mem_ptr->sub_and_propagate_mem, bsks, ksks, FLAG_NONE, (uint32_t)0);
 

--- a/backends/tfhe-cuda-backend/cuda/src/integer/scalar_mul.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/scalar_mul.cu
@@ -42,7 +42,7 @@ void cuda_small_scalar_multiplication_integer_64_inplace_async(
     CudaStreamsFFI streams, CudaRadixCiphertextFFI *lwe_array, uint64_t scalar,
     const uint32_t message_modulus, const uint32_t carry_modulus) {
 
-  host_integer_small_scalar_mul_radix<uint64_t>(CudaStreams(streams), lwe_array,
-                                                lwe_array, scalar,
-                                                message_modulus, carry_modulus);
+  host_integer_small_scalar_mul_radix_async<uint64_t>(
+      CudaStreams(streams), lwe_array, lwe_array, scalar, message_modulus,
+      carry_modulus);
 }

--- a/backends/tfhe-cuda-backend/cuda/src/integer/scalar_mul.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/scalar_mul.cuh
@@ -69,9 +69,9 @@ __host__ void host_integer_scalar_mul_radix(
       copy_radix_ciphertext_slice_async<T>(
           streams.stream(0), streams.gpu_index(0), &shift_input, 0,
           num_radix_blocks, lwe_array, 0, num_radix_blocks);
-      host_logical_scalar_shift_inplace<T>(streams, &shift_input, shift_amount,
-                                           mem->logical_scalar_shift_buffer,
-                                           bsks, ksks, num_radix_blocks);
+      host_logical_scalar_shift_inplace_async<T>(
+          streams, &shift_input, shift_amount, mem->logical_scalar_shift_buffer,
+          bsks, ksks, num_radix_blocks);
     } else {
       // create trivial assign for value = 0
       set_zero_radix_ciphertext_slice_async<T>(
@@ -96,9 +96,9 @@ __host__ void host_integer_scalar_mul_radix(
       as_radix_ciphertext_slice<T>(&block_shift_buffer, all_shifted_buffer,
                                    j * num_radix_blocks,
                                    all_shifted_buffer->num_radix_blocks);
-      host_radix_blocks_rotate_right<T>(streams, &block_shift_buffer,
-                                        &preshifted_radix_ct, i / msg_bits,
-                                        num_radix_blocks);
+      host_radix_blocks_rotate_right_async<T>(streams, &block_shift_buffer,
+                                              &preshifted_radix_ct,
+                                              i / msg_bits, num_radix_blocks);
       // create trivial assign for value = 0
       set_zero_radix_ciphertext_slice_async<T>(
           streams.stream(0), streams.gpu_index(0), &block_shift_buffer, 0,
@@ -122,22 +122,22 @@ __host__ void host_integer_scalar_mul_radix(
                "Cuda error: j=%zu exceeds sum_ciphertexts_vec_mem "
                "max_num_radix_in_vec=%u",
                j, mem->num_ciphertext_bits);
-    host_integer_partial_sum_ciphertexts_vec<T>(
+    host_integer_partial_sum_ciphertexts_vec_async<T>(
         streams, lwe_array, all_shifted_buffer, bsks, ksks,
         mem->sum_ciphertexts_vec_mem, num_radix_blocks, j);
 
     auto scp_mem_ptr = mem->sc_prop_mem;
     uint32_t requested_flag = outputFlag::FLAG_NONE;
     uint32_t uses_carry = 0;
-    host_propagate_single_carry<T>(streams, lwe_array, nullptr, nullptr,
-                                   scp_mem_ptr, bsks, ksks, requested_flag,
-                                   uses_carry);
+    host_propagate_single_carry_async<T>(streams, lwe_array, nullptr, nullptr,
+                                         scp_mem_ptr, bsks, ksks,
+                                         requested_flag, uses_carry);
   }
 }
 
 // Small scalar_mul is used in shift/rotate
 template <typename T>
-__host__ void host_integer_small_scalar_mul_radix(
+__host__ void host_integer_small_scalar_mul_radix_async(
     CudaStreams streams, CudaRadixCiphertextFFI *output_lwe_array,
     CudaRadixCiphertextFFI *input_lwe_array, T scalar,
     const uint32_t message_modulus, const uint32_t carry_modulus) {
@@ -191,14 +191,15 @@ host_scalar_mul_high(CudaStreams streams, CudaRadixCiphertextFFI *ct,
 
   CudaRadixCiphertextFFI *tmp_ffi = mem_ptr->tmp;
 
-  host_extend_radix_with_trivial_zero_blocks_msb<Torus>(tmp_ffi, ct, streams);
+  host_extend_radix_with_trivial_zero_blocks_msb_async<Torus>(tmp_ffi, ct,
+                                                              streams);
 
   if (scalar_divisor_ffi->active_bits != (uint32_t)0 &&
       !scalar_divisor_ffi->is_abs_chosen_multiplier_one &&
       tmp_ffi->num_radix_blocks != 0) {
 
     if (scalar_divisor_ffi->is_chosen_multiplier_pow2) {
-      host_logical_scalar_shift_inplace<Torus>(
+      host_logical_scalar_shift_inplace_async<Torus>(
           streams, tmp_ffi, scalar_divisor_ffi->ilog2_chosen_multiplier,
           mem_ptr->logical_scalar_shift_mem, bsks, (uint64_t **)ksks,
           tmp_ffi->num_radix_blocks);
@@ -213,7 +214,7 @@ host_scalar_mul_high(CudaStreams streams, CudaRadixCiphertextFFI *ct,
     }
   }
 
-  host_trim_radix_blocks_lsb<Torus>(ct, tmp_ffi, streams);
+  host_trim_radix_blocks_lsb_async<Torus>(ct, tmp_ffi, streams);
 }
 
 template <typename Torus, typename KSTorus>
@@ -230,7 +231,7 @@ __host__ void host_signed_scalar_mul_high(
 
   CudaRadixCiphertextFFI *tmp_ffi = mem_ptr->tmp;
 
-  host_extend_radix_with_sign_msb<Torus>(
+  host_extend_radix_with_sign_msb_async<Torus>(
       streams, tmp_ffi, ct, mem_ptr->extend_radix_mem, ct->num_radix_blocks,
       bsks, (uint64_t **)ksks);
 
@@ -239,7 +240,7 @@ __host__ void host_signed_scalar_mul_high(
       tmp_ffi->num_radix_blocks != 0) {
 
     if (scalar_divisor_ffi->is_chosen_multiplier_pow2) {
-      host_logical_scalar_shift_inplace<Torus>(
+      host_logical_scalar_shift_inplace_async<Torus>(
           streams, tmp_ffi, scalar_divisor_ffi->ilog2_chosen_multiplier,
           mem_ptr->logical_scalar_shift_mem, bsks, (uint64_t **)ksks,
           tmp_ffi->num_radix_blocks);
@@ -252,7 +253,7 @@ __host__ void host_signed_scalar_mul_high(
     }
   }
 
-  host_trim_radix_blocks_lsb<Torus>(ct, tmp_ffi, streams);
+  host_trim_radix_blocks_lsb_async<Torus>(ct, tmp_ffi, streams);
 }
 
 #endif

--- a/backends/tfhe-cuda-backend/cuda/src/integer/scalar_rotate.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/scalar_rotate.cu
@@ -21,7 +21,7 @@ void cuda_scalar_rotate_64_inplace_async(CudaStreamsFFI streams,
                                          uint32_t n, int8_t *mem_ptr,
                                          void *const *bsks, void *const *ksks) {
 
-  host_scalar_rotate_inplace<uint64_t>(
+  host_scalar_rotate_inplace_async<uint64_t>(
       CudaStreams(streams), lwe_array, n,
       (int_logical_scalar_shift_buffer<uint64_t> *)mem_ptr, bsks,
       (uint64_t **)(ksks));

--- a/backends/tfhe-cuda-backend/cuda/src/integer/scalar_rotate.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/scalar_rotate.cuh
@@ -23,10 +23,10 @@ __host__ uint64_t scratch_cuda_scalar_rotate(
 
 template <typename Torus, typename KSTorus>
 __host__ void
-host_scalar_rotate_inplace(CudaStreams streams,
-                           CudaRadixCiphertextFFI *lwe_array, uint32_t n,
-                           int_logical_scalar_shift_buffer<Torus> *mem,
-                           void *const *bsks, KSTorus *const *ksks) {
+host_scalar_rotate_inplace_async(CudaStreams streams,
+                                 CudaRadixCiphertextFFI *lwe_array, uint32_t n,
+                                 int_logical_scalar_shift_buffer<Torus> *mem,
+                                 void *const *bsks, KSTorus *const *ksks) {
 
   auto num_blocks = lwe_array->num_radix_blocks;
   auto params = mem->params;
@@ -51,8 +51,8 @@ host_scalar_rotate_inplace(CudaStreams streams,
   // one block is responsible to process single lwe ciphertext
   if (mem->shift_type == LEFT_SHIFT) {
     // rotate right as the blocks are from LSB to MSB
-    host_radix_blocks_rotate_right<Torus>(streams, rotated_buffer, lwe_array,
-                                          rotations, num_blocks);
+    host_radix_blocks_rotate_right_async<Torus>(
+        streams, rotated_buffer, lwe_array, rotations, num_blocks);
 
     copy_radix_ciphertext_slice_async<Torus>(
         streams.stream(0), streams.gpu_index(0), lwe_array, 0, num_blocks,
@@ -64,8 +64,8 @@ host_scalar_rotate_inplace(CudaStreams streams,
 
     auto receiver_blocks = lwe_array;
     auto giver_blocks = rotated_buffer;
-    host_radix_blocks_rotate_right<Torus>(streams, giver_blocks, lwe_array, 1,
-                                          num_blocks);
+    host_radix_blocks_rotate_right_async<Torus>(streams, giver_blocks,
+                                                lwe_array, 1, num_blocks);
 
     auto lut_bivariate = mem->lut_buffers_bivariate[shift_within_block - 1];
 
@@ -75,8 +75,8 @@ host_scalar_rotate_inplace(CudaStreams streams,
 
   } else {
     // rotate left as the blocks are from LSB to MSB
-    host_radix_blocks_rotate_left<Torus>(streams, rotated_buffer, lwe_array,
-                                         rotations, num_blocks);
+    host_radix_blocks_rotate_left_async<Torus>(
+        streams, rotated_buffer, lwe_array, rotations, num_blocks);
 
     copy_radix_ciphertext_slice_async<Torus>(
         streams.stream(0), streams.gpu_index(0), lwe_array, 0, num_blocks,
@@ -88,8 +88,8 @@ host_scalar_rotate_inplace(CudaStreams streams,
 
     auto receiver_blocks = lwe_array;
     auto giver_blocks = rotated_buffer;
-    host_radix_blocks_rotate_left<Torus>(streams, giver_blocks, lwe_array, 1,
-                                         num_blocks);
+    host_radix_blocks_rotate_left_async<Torus>(streams, giver_blocks, lwe_array,
+                                               1, num_blocks);
 
     auto lut_bivariate = mem->lut_buffers_bivariate[shift_within_block - 1];
 

--- a/backends/tfhe-cuda-backend/cuda/src/integer/scalar_shifts.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/scalar_shifts.cu
@@ -24,7 +24,7 @@ void cuda_logical_scalar_shift_64_inplace_async(
     CudaStreamsFFI streams, CudaRadixCiphertextFFI *lwe_array, uint32_t shift,
     int8_t *mem_ptr, void *const *bsks, void *const *ksks) {
 
-  host_logical_scalar_shift_inplace<uint64_t>(
+  host_logical_scalar_shift_inplace_async<uint64_t>(
       CudaStreams(streams), lwe_array, shift,
       (int_logical_scalar_shift_buffer<uint64_t> *)mem_ptr, bsks,
       (uint64_t **)(ksks), lwe_array->num_radix_blocks);
@@ -57,7 +57,7 @@ void cuda_arithmetic_scalar_shift_64_inplace_async(
     CudaStreamsFFI streams, CudaRadixCiphertextFFI *lwe_array, uint32_t shift,
     int8_t *mem_ptr, void *const *bsks, void *const *ksks) {
 
-  host_arithmetic_scalar_shift_inplace<uint64_t>(
+  host_arithmetic_scalar_shift_inplace_async<uint64_t>(
       CudaStreams(streams), lwe_array, shift,
       (int_arithmetic_scalar_shift_buffer<uint64_t> *)mem_ptr, bsks,
       (uint64_t **)(ksks));

--- a/backends/tfhe-cuda-backend/cuda/src/integer/scalar_shifts.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/scalar_shifts.cuh
@@ -23,7 +23,7 @@ __host__ uint64_t scratch_cuda_logical_scalar_shift(
 }
 
 template <typename Torus, typename KSTorus>
-__host__ void host_logical_scalar_shift_inplace(
+__host__ void host_logical_scalar_shift_inplace_async(
     CudaStreams streams, CudaRadixCiphertextFFI *lwe_array, uint32_t shift,
     int_logical_scalar_shift_buffer<Torus> *mem, void *const *bsks,
     KSTorus *const *ksks, uint32_t num_blocks) {
@@ -58,8 +58,8 @@ __host__ void host_logical_scalar_shift_inplace(
 
   if (mem->shift_type == LEFT_SHIFT) {
     // rotate right as the blocks are from LSB to MSB
-    host_radix_blocks_rotate_right<Torus>(streams, &rotated_buffer, lwe_array,
-                                          rotations, num_blocks);
+    host_radix_blocks_rotate_right_async<Torus>(
+        streams, &rotated_buffer, lwe_array, rotations, num_blocks);
 
     // create trivial assign for value = 0
     set_zero_radix_ciphertext_slice_async<Torus>(
@@ -90,8 +90,8 @@ __host__ void host_logical_scalar_shift_inplace(
 
   } else {
     // right shift
-    host_radix_blocks_rotate_left<Torus>(streams, &rotated_buffer, lwe_array,
-                                         rotations, num_blocks);
+    host_radix_blocks_rotate_left_async<Torus>(
+        streams, &rotated_buffer, lwe_array, rotations, num_blocks);
 
     // rotate left as the blocks are from LSB to MSB
     // create trivial assign for value = 0
@@ -145,7 +145,7 @@ __host__ uint64_t scratch_cuda_arithmetic_scalar_shift(
  * PBS).
  */
 template <typename Torus, typename KSTorus>
-__host__ void host_arithmetic_scalar_shift_overshift(
+__host__ void host_arithmetic_scalar_shift_overshift_async(
     CudaStreams streams, CudaRadixCiphertextFFI *shifted_ct,
     int_arithmetic_scalar_shift_buffer<Torus> *mem, void *const *bsks,
     KSTorus *const *ksks, size_t num_bits_in_block) {
@@ -178,7 +178,7 @@ __host__ void host_arithmetic_scalar_shift_overshift(
 }
 
 template <typename Torus, typename KSTorus>
-__host__ void host_arithmetic_scalar_shift_inplace(
+__host__ void host_arithmetic_scalar_shift_inplace_async(
     CudaStreams streams, CudaRadixCiphertextFFI *lwe_array, uint32_t shift,
     int_arithmetic_scalar_shift_buffer<Torus> *mem, void *const *bsks,
     KSTorus *const *ksks) {
@@ -200,7 +200,7 @@ __host__ void host_arithmetic_scalar_shift_inplace(
   }
 
   if (shift >= total_num_bits) {
-    host_arithmetic_scalar_shift_overshift<Torus, KSTorus>(
+    host_arithmetic_scalar_shift_overshift_async<Torus, KSTorus>(
         streams, lwe_array, mem, bsks, ksks, num_bits_in_block);
     return;
   }
@@ -216,8 +216,8 @@ __host__ void host_arithmetic_scalar_shift_inplace(
                                    num_blocks + 2, num_blocks + 3);
 
   if (mem->shift_type == RIGHT_SHIFT) {
-    host_radix_blocks_rotate_left<Torus>(streams, mem->tmp_rotated, lwe_array,
-                                         rotations, num_blocks);
+    host_radix_blocks_rotate_left_async<Torus>(
+        streams, mem->tmp_rotated, lwe_array, rotations, num_blocks);
     copy_radix_ciphertext_slice_async<Torus>(
         streams.stream(0), streams.gpu_index(0), lwe_array, 0, num_blocks,
         mem->tmp_rotated, 0, num_blocks);

--- a/backends/tfhe-cuda-backend/cuda/src/integer/shift_and_rotate.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/shift_and_rotate.cu
@@ -20,7 +20,7 @@ void cuda_shift_and_rotate_64_inplace_async(
     CudaRadixCiphertextFFI const *lwe_shift, int8_t *mem_ptr, void *const *bsks,
     void *const *ksks) {
 
-  host_shift_and_rotate_inplace<uint64_t>(
+  host_shift_and_rotate_inplace_async<uint64_t>(
       CudaStreams(streams), lwe_array, lwe_shift,
       (int_shift_and_rotate_buffer<uint64_t> *)mem_ptr, bsks,
       (uint64_t **)(ksks));

--- a/backends/tfhe-cuda-backend/cuda/src/integer/shift_and_rotate.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/shift_and_rotate.cuh
@@ -33,12 +33,11 @@ __host__ uint64_t scratch_cuda_shift_and_rotate(
  * @param mem Scratch buffer holding the comparison memory, scalar and LUTs.
  */
 template <typename Torus, typename KSTorus>
-__host__ void
-host_compute_overshift_condition(CudaStreams streams,
-                                 CudaRadixCiphertextFFI const *lwe_shift,
-                                 CudaRadixCiphertextFFI const *last_bit,
-                                 int_shift_and_rotate_buffer<Torus> *mem,
-                                 void *const *bsks, KSTorus *const *ksks) {
+__host__ void host_compute_overshift_condition_async(
+    CudaStreams streams, CudaRadixCiphertextFFI const *lwe_shift,
+    CudaRadixCiphertextFFI const *last_bit,
+    int_shift_and_rotate_buffer<Torus> *mem, void *const *bsks,
+    KSTorus *const *ksks) {
   auto message_modulus = mem->params.message_modulus;
   auto carry_modulus = mem->params.carry_modulus;
 
@@ -65,12 +64,12 @@ host_compute_overshift_condition(CudaStreams streams,
   if (mem->is_signed && (mem->shift_type == RIGHT_SHIFT)) {
     // cond = 2 * overshift + is_neg, where is_neg is the input's sign bit
     // (`last_bit`, still the original sign bit since the loop reads a copy).
-    host_integer_small_scalar_mul_radix<Torus>(streams, mem->tmp_overshift,
-                                               mem->tmp_overshift, 2,
-                                               message_modulus, carry_modulus);
-    host_addition<Torus>(streams.stream(0), streams.gpu_index(0),
-                         mem->tmp_overshift, mem->tmp_overshift, last_bit, 1,
-                         message_modulus, carry_modulus);
+    host_integer_small_scalar_mul_radix_async<Torus>(
+        streams, mem->tmp_overshift, mem->tmp_overshift, 2, message_modulus,
+        carry_modulus);
+    host_addition_async<Torus>(streams.stream(0), streams.gpu_index(0),
+                               mem->tmp_overshift, mem->tmp_overshift, last_bit,
+                               1, message_modulus, carry_modulus);
   }
   // Move cond into the carry space (clean output).
   integer_radix_apply_univariate_lookup_table<Torus>(
@@ -88,12 +87,12 @@ host_compute_overshift_condition(CudaStreams streams,
  */
 template <typename Torus, typename KSTorus>
 __host__ void
-host_apply_overshift_cleanup(CudaStreams streams,
-                             CudaRadixCiphertextFFI *shifted_ct,
-                             int_shift_and_rotate_buffer<Torus> *mem,
-                             void *const *bsks, KSTorus *const *ksks) {
+host_apply_overshift_cleanup_async(CudaStreams streams,
+                                   CudaRadixCiphertextFFI *shifted_ct,
+                                   int_shift_and_rotate_buffer<Torus> *mem,
+                                   void *const *bsks, KSTorus *const *ksks) {
   auto num_radix_blocks = shifted_ct->num_radix_blocks;
-  host_add_the_same_block_to_all_blocks<Torus>(
+  host_add_the_same_block_to_all_blocks_async<Torus>(
       streams.stream(0), streams.gpu_index(0), shifted_ct, shifted_ct,
       mem->tmp_overshift, mem->params.message_modulus,
       mem->params.carry_modulus);
@@ -104,11 +103,11 @@ host_apply_overshift_cleanup(CudaStreams streams,
 
 template <typename Torus, typename KSTorus>
 __host__ void
-host_shift_and_rotate_inplace(CudaStreams streams,
-                              CudaRadixCiphertextFFI *lwe_array,
-                              CudaRadixCiphertextFFI const *lwe_shift,
-                              int_shift_and_rotate_buffer<Torus> *mem,
-                              void *const *bsks, KSTorus *const *ksks) {
+host_shift_and_rotate_inplace_async(CudaStreams streams,
+                                    CudaRadixCiphertextFFI *lwe_array,
+                                    CudaRadixCiphertextFFI const *lwe_shift,
+                                    int_shift_and_rotate_buffer<Torus> *mem,
+                                    void *const *bsks, KSTorus *const *ksks) {
   cuda_set_device(streams.gpu_index(0));
   // The barrel shifter packs three bits (control | previous | current) into a
   // single block for the mux LUT, so it needs the control bit at plaintext
@@ -191,7 +190,7 @@ host_shift_and_rotate_inplace(CudaStreams streams,
       // rotate right as the blocks are from LSB to MSB
       if (input_bits_b->num_radix_blocks != total_nb_bits)
         PANIC("Cuda error: incorrect number of blocks")
-      host_radix_blocks_rotate_right<Torus>(
+      host_radix_blocks_rotate_right_async<Torus>(
           streams, rotated_input, input_bits_b, rotations, total_nb_bits);
 
       set_zero_radix_ciphertext_slice_async<Torus>(
@@ -201,8 +200,8 @@ host_shift_and_rotate_inplace(CudaStreams streams,
       // rotate left as the blocks are from LSB to MSB
       if (input_bits_b->num_radix_blocks != total_nb_bits)
         PANIC("Cuda error: incorrect number of blocks")
-      host_radix_blocks_rotate_left<Torus>(streams, rotated_input, input_bits_b,
-                                           rotations, total_nb_bits);
+      host_radix_blocks_rotate_left_async<Torus>(
+          streams, rotated_input, input_bits_b, rotations, total_nb_bits);
 
       if (mem->is_signed)
         for (int i = 0; i < rotations; i++) {
@@ -219,27 +218,27 @@ host_shift_and_rotate_inplace(CudaStreams streams,
       break;
     case LEFT_ROTATE:
       // rotate right as the blocks are from LSB to MSB
-      host_radix_blocks_rotate_right<Torus>(
+      host_radix_blocks_rotate_right_async<Torus>(
           streams, rotated_input, input_bits_b, rotations, total_nb_bits);
       break;
     case RIGHT_ROTATE:
       // rotate left as the blocks are from LSB to MSB
-      host_radix_blocks_rotate_left<Torus>(streams, rotated_input, input_bits_b,
-                                           rotations, total_nb_bits);
+      host_radix_blocks_rotate_left_async<Torus>(
+          streams, rotated_input, input_bits_b, rotations, total_nb_bits);
       break;
     default:
       PANIC("Unknown operation")
     }
 
-    // host_pack bits into one block so that we have
+    // host_pack_async bits into one block so that we have
     // control_bit|b|a
-    host_pack_bivariate_blocks<Torus>(
+    host_pack_bivariate_blocks_async<Torus>(
         streams, mux_inputs, mux_lut->lwe_indexes_out, rotated_input,
         input_bits_a, mux_lut->lwe_indexes_in, 2, total_nb_bits,
         mem->params.message_modulus, mem->params.carry_modulus);
 
     // The shift bit is already properly aligned/positioned
-    host_add_the_same_block_to_all_blocks<Torus>(
+    host_add_the_same_block_to_all_blocks_async<Torus>(
         streams.stream(0), streams.gpu_index(0), mux_inputs, mux_inputs,
         &shift_bit, mem->params.message_modulus, mem->params.carry_modulus);
 
@@ -252,7 +251,7 @@ host_shift_and_rotate_inplace(CudaStreams streams,
   if (mem->handle_overshift) {
     // lwe array number of blocks is the same as the shift amount number of
     // blocks
-    host_compute_overshift_condition<Torus, KSTorus>(
+    host_compute_overshift_condition_async<Torus, KSTorus>(
         streams, lwe_shift, &last_bit, mem, bsks, ksks);
   }
 
@@ -267,9 +266,9 @@ host_shift_and_rotate_inplace(CudaStreams streams,
 
   // Bitshift and add the other bits
   for (int i = bits_per_block - 2; i >= 0; i--) {
-    host_integer_small_scalar_mul_radix<Torus>(streams, lwe_array, lwe_array, 2,
-                                               mem->params.message_modulus,
-                                               mem->params.carry_modulus);
+    host_integer_small_scalar_mul_radix_async<Torus>(
+        streams, lwe_array, lwe_array, 2, mem->params.message_modulus,
+        mem->params.carry_modulus);
     for (int j = 0; j < num_radix_blocks; j++) {
       CudaRadixCiphertextFFI block;
       CudaRadixCiphertextFFI bit_to_add;
@@ -277,9 +276,9 @@ host_shift_and_rotate_inplace(CudaStreams streams,
       as_radix_ciphertext_slice<Torus>(&bit_to_add, input_bits_a,
                                        i + j * bits_per_block,
                                        i + j * bits_per_block + 1);
-      host_addition<Torus>(streams.stream(0), streams.gpu_index(0), &block,
-                           &block, &bit_to_add, 1, mem->params.message_modulus,
-                           mem->params.carry_modulus);
+      host_addition_async<Torus>(
+          streams.stream(0), streams.gpu_index(0), &block, &block, &bit_to_add,
+          1, mem->params.message_modulus, mem->params.carry_modulus);
     }
 
     // To give back a clean ciphertext.
@@ -288,8 +287,8 @@ host_shift_and_rotate_inplace(CudaStreams streams,
     // and use the overshift cleanup LUT, which both resets the noise and
     // selects the overshift result in a single PBS (no extra PBS round).
     if (i == 0 && mem->handle_overshift) {
-      host_apply_overshift_cleanup<Torus, KSTorus>(streams, lwe_array, mem,
-                                                   bsks, ksks);
+      host_apply_overshift_cleanup_async<Torus, KSTorus>(streams, lwe_array,
+                                                         mem, bsks, ksks);
     } else {
       auto cleaning_lut = mem->cleaning_lut;
       integer_radix_apply_univariate_lookup_table<Torus>(
@@ -302,8 +301,8 @@ host_shift_and_rotate_inplace(CudaStreams streams,
   // overshift selection could not be fused into a cleaning PBS; apply it as a
   // standalone step instead.
   if (bits_per_block == 1 && mem->handle_overshift) {
-    host_apply_overshift_cleanup<Torus, KSTorus>(streams, lwe_array, mem, bsks,
-                                                 ksks);
+    host_apply_overshift_cleanup_async<Torus, KSTorus>(streams, lwe_array, mem,
+                                                       bsks, ksks);
   }
 }
 #endif

--- a/backends/tfhe-cuda-backend/cuda/src/integer/shuffle.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/shuffle.cu
@@ -41,7 +41,7 @@ void cuda_integer_bitonic_shuffle_64_async(CudaStreamsFFI streams,
                                            void *const *ksks) {
 
   PUSH_RANGE("bitonic shuffle")
-  host_bitonic_shuffle<uint64_t>(
+  host_bitonic_shuffle_async<uint64_t>(
       CudaStreams(streams), keys, values, num_values,
       (int_bitonic_shuffle_buffer<uint64_t> *)mem_ptr, bsks, (uint64_t **)ksks);
   POP_RANGE()
@@ -115,7 +115,7 @@ void cuda_integer_oprf_bitonic_shuffle_64_async(
     void *const *rerand_ksks) {
 
   PUSH_RANGE("oprf bitonic shuffle")
-  host_oprf_bitonic_shuffle<uint64_t>(
+  host_oprf_bitonic_shuffle_async<uint64_t>(
       CudaStreams(streams), values, num_values,
       static_cast<const uint64_t *>(seeded_lwe_input),
       static_cast<const uint64_t *>(

--- a/backends/tfhe-cuda-backend/cuda/src/integer/shuffle.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/shuffle.cuh
@@ -85,7 +85,7 @@ __global__ void pack_bivariate_adjacent_blocks_kernel(
  *                            body coefficient (0 = no sentinel).
  */
 template <typename Torus>
-__host__ void host_pack_bivariate_adjacent_blocks(
+__host__ void host_pack_bivariate_adjacent_blocks_async(
     cudaStream_t stream, uint32_t gpu_index,
     CudaRadixCiphertextFFI *lwe_array_out,
     CudaRadixCiphertextFFI const *lwe_array_in, uint32_t num_rows,
@@ -95,15 +95,18 @@ __host__ void host_pack_bivariate_adjacent_blocks(
   if (num_rows == 0 || n_blocks_per_row == 0)
     return;
   if (lwe_array_in->lwe_dimension != lwe_array_out->lwe_dimension)
-    PANIC("Cuda error: host_pack_bivariate_adjacent_blocks requires matching "
+    PANIC("Cuda error: host_pack_bivariate_adjacent_blocks_async requires "
+          "matching "
           "lwe_dimension on input and output")
   uint32_t out_n = (n_blocks_per_row + 1u) / 2u;
   if (lwe_array_in->num_radix_blocks < num_rows * n_blocks_per_row)
-    PANIC("Cuda error: host_pack_bivariate_adjacent_blocks input does not "
-          "have enough blocks")
+    PANIC(
+        "Cuda error: host_pack_bivariate_adjacent_blocks_async input does not "
+        "have enough blocks")
   if (lwe_array_out->num_radix_blocks < num_rows * out_n)
-    PANIC("Cuda error: host_pack_bivariate_adjacent_blocks output does not "
-          "have enough blocks")
+    PANIC(
+        "Cuda error: host_pack_bivariate_adjacent_blocks_async output does not "
+        "have enough blocks")
   uint64_t delta = ((uint64_t)1 << (sizeof(Torus) * 8 - 1)) /
                    ((uint64_t)message_modulus * carry_modulus);
   uint64_t orphan_body_sentinel = (uint64_t)orphan_clear_value * delta;
@@ -300,12 +303,12 @@ __host__ void bitonic_sort_compare_phase_batched(
   as_radix_ciphertext_slice<Torus>(&rhs_packed_view, batched_buf->tmp_packed,
                                    num_pairs * packed_blocks_per_key,
                                    2 * num_pairs * packed_blocks_per_key);
-  host_pack_bivariate_adjacent_blocks<Torus>(
+  host_pack_bivariate_adjacent_blocks_async<Torus>(
       streams.stream(0), streams.gpu_index(0), &lhs_packed_view,
       batched_buf->lhs_data, num_pairs, blocks_per_key, message_modulus,
       /*orphan_factor=*/1, /*orphan_clear_value=*/0, params.message_modulus,
       params.carry_modulus);
-  host_pack_bivariate_adjacent_blocks<Torus>(
+  host_pack_bivariate_adjacent_blocks_async<Torus>(
       streams.stream(0), streams.gpu_index(0), &rhs_packed_view,
       batched_buf->rhs_data, num_pairs, blocks_per_key, message_modulus,
       /*orphan_factor=*/1, /*orphan_clear_value=*/0, params.message_modulus,
@@ -321,10 +324,10 @@ __host__ void bitonic_sort_compare_phase_batched(
 
   // Subtract lhs - rhs block-wise in the LWE domain; result is 0 iff blocks are
   // equal. This subtraction is levelled and may overflow into the padding bit.
-  host_subtraction<Torus>(streams.stream(0), streams.gpu_index(0),
-                          batched_buf->comparisons, &lhs_packed_view,
-                          &rhs_packed_view, num_pairs * packed_blocks_per_key,
-                          params.message_modulus, params.carry_modulus);
+  host_subtraction_async<Torus>(
+      streams.stream(0), streams.gpu_index(0), batched_buf->comparisons,
+      &lhs_packed_view, &rhs_packed_view, num_pairs * packed_blocks_per_key,
+      params.message_modulus, params.carry_modulus);
 
   CudaRadixCiphertextFFI comparisons_view;
   as_radix_ciphertext_slice<Torus>(&comparisons_view, batched_buf->comparisons,
@@ -339,7 +342,7 @@ __host__ void bitonic_sort_compare_phase_batched(
   // Shift {-1=lhs_is_inferior, 0=equal, 1=lhs_is_superior} to {0, 1, 2} as
   // expected by the tree reduction and CMUX LUTs, where EQ=1 is the
   // pass-through value.
-  host_add_scalar_one_inplace<Torus>(
+  host_add_scalar_one_inplace_async<Torus>(
       streams, &comparisons_view, params.message_modulus, params.carry_modulus);
 
   // Initialize the tree reduction with the per-block verdicts.
@@ -360,7 +363,7 @@ __host__ void bitonic_sort_compare_phase_batched(
                                      num_pairs * next_remaining_packed_blocks);
     // Pack adjacent verdict pairs into one block per pair, injecting an EQ
     // sentinel into any orphan slot.
-    host_pack_bivariate_adjacent_blocks<Torus>(
+    host_pack_bivariate_adjacent_blocks_async<Torus>(
         streams.stream(0), streams.gpu_index(0), &ty_view, &tx_view, num_pairs,
         remaining_packed_blocks, message_modulus,
         /*orphan_factor=*/message_modulus, /*orphan_clear_value=*/IS_EQUAL,
@@ -386,7 +389,7 @@ __host__ void bitonic_sort_compare_phase_batched(
                                    num_pairs * 2);
   as_radix_ciphertext_slice<Torus>(&ty_final, batched_buf->tree_y, 0,
                                    num_pairs);
-  host_pack_bivariate_adjacent_blocks<Torus>(
+  host_pack_bivariate_adjacent_blocks_async<Torus>(
       streams.stream(0), streams.gpu_index(0), &ty_final, &tx_final, num_pairs,
       2, message_modulus, /*orphan_factor=*/1, /*orphan_clear_value=*/0,
       params.message_modulus, params.carry_modulus);
@@ -583,10 +586,10 @@ apply_cmux_batched(CudaStreams streams, CudaRadixCiphertextFFI **keys,
       &is_superior_half, fused_buf->batch_buffer_out, 0, blocks_per_branch);
   as_radix_ciphertext_slice<Torus>(&is_equal_half, fused_buf->batch_buffer_out,
                                    blocks_per_branch, total_bivariate);
-  host_addition<Torus>(streams.stream(0), streams.gpu_index(0),
-                       &is_superior_half, &is_superior_half, &is_equal_half,
-                       blocks_per_branch, params.message_modulus,
-                       params.carry_modulus);
+  host_addition_async<Torus>(streams.stream(0), streams.gpu_index(0),
+                             &is_superior_half, &is_superior_half,
+                             &is_equal_half, blocks_per_branch,
+                             params.message_modulus, params.carry_modulus);
 
   // Re-bootstrap via message extraction: for intermediate substeps, the next
   // substep's pair-packing amplifies noise by (1 + msg_mod) before the identity
@@ -767,10 +770,10 @@ __host__ void bitonic_shuffle_setup_padded(
  */
 template <typename Torus, typename KSTorus>
 __host__ void
-host_bitonic_shuffle(CudaStreams streams, CudaRadixCiphertextFFI **keys,
-                     CudaRadixCiphertextFFI **values, uint32_t num_values,
-                     int_bitonic_shuffle_buffer<Torus> *mem_ptr,
-                     void *const *bsks, KSTorus *const *ksks) {
+host_bitonic_shuffle_async(CudaStreams streams, CudaRadixCiphertextFFI **keys,
+                           CudaRadixCiphertextFFI **values, uint32_t num_values,
+                           int_bitonic_shuffle_buffer<Torus> *mem_ptr,
+                           void *const *bsks, KSTorus *const *ksks) {
 
   CudaRadixCiphertextFFI **eff_keys;
   CudaRadixCiphertextFFI **eff_values;
@@ -820,7 +823,7 @@ __host__ uint64_t scratch_cuda_integer_oprf_bitonic_shuffle_async(
  * GPU.
  */
 template <typename Torus, typename KSTorus>
-__host__ void host_oprf_bitonic_shuffle(
+__host__ void host_oprf_bitonic_shuffle_async(
     CudaStreams streams, CudaRadixCiphertextFFI **values, uint32_t num_values,
     const Torus *seeded_lwe_input,
     const Torus *lwe_flattened_encryptions_of_zero_compact_array_in,
@@ -829,7 +832,7 @@ __host__ void host_oprf_bitonic_shuffle(
 
   uint32_t key_num_blocks = mem_ptr->key_num_blocks;
 
-  host_integer_grouped_oprf<Torus>(
+  host_integer_grouped_oprf_async<Torus>(
       streams, mem_ptr->keys_storage, seeded_lwe_input,
       num_values * key_num_blocks, mem_ptr->oprf_memory, oprf_bsks);
 
@@ -837,13 +840,14 @@ __host__ void host_oprf_bitonic_shuffle(
     auto *rerand_mem = mem_ptr->rerand_memory;
     auto *keys_ptr = static_cast<Torus *>(mem_ptr->keys_storage->ptr);
 
-    host_rerand_inplace_dispatch<Torus>(
+    host_rerand_inplace_dispatch_async<Torus>(
         streams, keys_ptr, lwe_flattened_encryptions_of_zero_compact_array_in,
         rerand_ksks, rerand_mem);
   }
 
-  host_bitonic_shuffle<Torus>(streams, mem_ptr->keys_ptrs, values, num_values,
-                              mem_ptr->shuffle_buffer, bsks, ksks);
+  host_bitonic_shuffle_async<Torus>(streams, mem_ptr->keys_ptrs, values,
+                                    num_values, mem_ptr->shuffle_buffer, bsks,
+                                    ksks);
 }
 
 #endif

--- a/backends/tfhe-cuda-backend/cuda/src/integer/subtraction.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/subtraction.cu
@@ -20,7 +20,7 @@ void cuda_sub_and_propagate_single_carry_64_inplace_async(
     const CudaRadixCiphertextFFI *carry_in, int8_t *mem_ptr, void *const *bsks,
     void *const *ksks, uint32_t requested_flag, uint32_t uses_carry) {
   PUSH_RANGE("sub")
-  host_sub_and_propagate_single_carry<uint64_t>(
+  host_sub_and_propagate_single_carry_async<uint64_t>(
       CudaStreams(streams), lhs_array, rhs_array, carry_out, carry_in,
       (int_sub_and_propagate<uint64_t> *)mem_ptr, bsks, (uint64_t **)(ksks),
       requested_flag, uses_carry);

--- a/backends/tfhe-cuda-backend/cuda/src/integer/subtraction.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/subtraction.cuh
@@ -30,25 +30,25 @@ uint64_t scratch_cuda_sub_and_propagate_single_carry(
 }
 
 template <typename Torus, typename KSTorus>
-void host_sub_and_propagate_single_carry(
+void host_sub_and_propagate_single_carry_async(
     CudaStreams streams, CudaRadixCiphertextFFI *lhs_array,
     const CudaRadixCiphertextFFI *rhs_array, CudaRadixCiphertextFFI *carry_out,
     const CudaRadixCiphertextFFI *input_carries,
     int_sub_and_propagate<Torus> *mem, void *const *bsks, KSTorus *const *ksks,
     uint32_t requested_flag, uint32_t uses_carry) {
 
-  host_negation_with_correcting_term<Torus>(
+  host_negation_with_correcting_term_async<Torus>(
       streams, mem->neg_rhs_array, rhs_array, mem->params.message_modulus,
       mem->params.carry_modulus, mem->neg_rhs_array->num_radix_blocks);
 
-  host_add_and_propagate_single_carry<Torus>(
+  host_add_and_propagate_single_carry_async<Torus>(
       streams, lhs_array, mem->neg_rhs_array, carry_out, input_carries,
       mem->sc_prop_mem, bsks, ksks, requested_flag, uses_carry);
 }
 
 /** @brief Subtracts lwe_array_in_2 (rhs) from lwe_array_in_1 (lhs) over
  * num_radix_blocks blocks by negating rhs with a correcting term (via
- * host_negation_with_correcting_term) then adding lhs. This is a fully
+ * host_negation_with_correcting_term_async) then adding lhs. This is a fully
  * levelled subtraction and no PBS is performed.
  * @param lwe_array_out destination radix-ciphertext
  * @param lwe_array_in_1 lhs radix-ciphertext
@@ -56,7 +56,7 @@ void host_sub_and_propagate_single_carry(
  * @param num_radix_blocks number of blocks to subtract
  */
 template <typename Torus>
-__host__ void host_subtraction_with_correcting_term(
+__host__ void host_subtraction_with_correcting_term_async(
     CudaStreams streams, CudaRadixCiphertextFFI *lwe_array_out,
     CudaRadixCiphertextFFI const *lwe_array_in_1,
     CudaRadixCiphertextFFI const *lwe_array_in_2, uint32_t message_modulus,
@@ -74,12 +74,12 @@ __host__ void host_subtraction_with_correcting_term(
     PANIC("Cuda error: lwe_array_in and lwe_array_out lwe_dimension must be "
           "the same")
 
-  host_negation_with_correcting_term<Torus>(streams, lwe_array_out,
-                                            lwe_array_in_2, message_modulus,
-                                            carry_modulus, num_radix_blocks);
-  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), lwe_array_out,
-                       lwe_array_out, lwe_array_in_1, num_radix_blocks,
-                       message_modulus, carry_modulus);
+  host_negation_with_correcting_term_async<Torus>(
+      streams, lwe_array_out, lwe_array_in_2, message_modulus, carry_modulus,
+      num_radix_blocks);
+  host_addition_async<Torus>(streams.stream(0), streams.gpu_index(0),
+                             lwe_array_out, lwe_array_out, lwe_array_in_1,
+                             num_radix_blocks, message_modulus, carry_modulus);
 }
 
 template <typename Torus>
@@ -98,7 +98,7 @@ __host__ uint64_t scratch_cuda_integer_overflowing_sub(
 }
 
 template <typename Torus>
-__host__ void host_integer_overflowing_sub(
+__host__ void host_integer_overflowing_sub_async(
     CudaStreams streams, CudaRadixCiphertextFFI *output,
     CudaRadixCiphertextFFI *input_left,
     const CudaRadixCiphertextFFI *input_right,
@@ -128,11 +128,11 @@ __host__ void host_integer_overflowing_sub(
   uint32_t grouping_size = num_bits_in_block;
   uint32_t num_groups = CEIL_DIV(num_blocks, grouping_size);
 
-  host_unchecked_sub_with_correcting_term<Torus>(
+  host_unchecked_sub_with_correcting_term_async<Torus>(
       streams.stream(0), streams.gpu_index(0), output, input_left, input_right,
       num_blocks, radix_params.message_modulus, radix_params.carry_modulus);
 
-  host_single_borrow_propagate<Torus>(
+  host_single_borrow_propagate_async<Torus>(
       streams, output, overflow_block, input_borrow,
       (int_borrow_prop_memory<Torus> *)mem_ptr, bsks, (Torus **)(ksks),
       num_groups, compute_overflow, uses_input_borrow);

--- a/backends/tfhe-cuda-backend/cuda/src/integer/vector_comparison.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/vector_comparison.cu
@@ -27,7 +27,7 @@ void cuda_unchecked_all_eq_slices_64_async(
                  "Output and second input pointers must be different for "
                  "out-of-place operations");
 
-  host_unchecked_all_eq_slices<uint64_t>(
+  host_unchecked_all_eq_slices_async<uint64_t>(
       CudaStreams(streams), match_ct, lhs, rhs, num_inputs, num_blocks,
       (int_unchecked_all_eq_slices_buffer<uint64_t> *)mem, bsks,
       (uint64_t *const *)ksks);
@@ -71,7 +71,7 @@ void cuda_unchecked_contains_sub_slice_64_async(
                  "Output and second input pointers must be different for "
                  "out-of-place operations");
 
-  host_unchecked_contains_sub_slice<uint64_t>(
+  host_unchecked_contains_sub_slice_async<uint64_t>(
       CudaStreams(streams), match_ct, lhs, rhs, num_rhs, num_blocks,
       (int_unchecked_contains_sub_slice_buffer<uint64_t> *)mem, bsks,
       (uint64_t *const *)ksks);

--- a/backends/tfhe-cuda-backend/cuda/src/integer/vector_comparison.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/vector_comparison.cuh
@@ -19,7 +19,7 @@ uint64_t scratch_cuda_unchecked_all_eq_slices(
 }
 
 template <typename Torus>
-__host__ void host_unchecked_all_eq_slices(
+__host__ void host_unchecked_all_eq_slices_async(
     CudaStreams streams, CudaRadixCiphertextFFI *match_ct,
     CudaRadixCiphertextFFI const *lhs, CudaRadixCiphertextFFI const *rhs,
     uint32_t num_inputs, uint32_t num_blocks,
@@ -52,9 +52,9 @@ __host__ void host_unchecked_all_eq_slices(
     as_radix_ciphertext_slice<Torus>(&current_result_dest,
                                      mem_ptr->packed_results, i, i + 1);
 
-    host_equality_check<Torus>(current_stream, &current_result_dest, input_lhs,
-                               input_rhs, mem_ptr->eq_buffers[stream_idx], bsks,
-                               ksks, num_blocks);
+    host_equality_check_async<Torus>(
+        current_stream, &current_result_dest, input_lhs, input_rhs,
+        mem_ptr->eq_buffers[stream_idx], bsks, ksks, num_blocks);
   }
 
   // sync_to(streams)
@@ -77,7 +77,7 @@ __host__ void host_unchecked_all_eq_slices(
     }
   }
 
-  host_integer_are_all_comparisons_block_true<Torus>(
+  host_integer_are_all_comparisons_block_true_async<Torus>(
       streams, match_ct, mem_ptr->packed_results, mem_ptr->reduction_buffer,
       bsks, ksks, num_inputs);
 }
@@ -98,7 +98,7 @@ uint64_t scratch_cuda_unchecked_contains_sub_slice(
 }
 
 template <typename Torus>
-__host__ void host_unchecked_contains_sub_slice(
+__host__ void host_unchecked_contains_sub_slice_async(
     CudaStreams streams, CudaRadixCiphertextFFI *match_ct,
     CudaRadixCiphertextFFI const *lhs, CudaRadixCiphertextFFI const *rhs,
     uint32_t num_rhs, uint32_t num_blocks,
@@ -114,12 +114,12 @@ __host__ void host_unchecked_contains_sub_slice(
     as_radix_ciphertext_slice<Torus>(&current_result_dest,
                                      mem_ptr->packed_results, w, w + 1);
 
-    host_unchecked_all_eq_slices<Torus>(streams, &current_result_dest,
-                                        lhs_window, rhs, num_rhs, num_blocks,
-                                        mem_ptr->all_eq_buffer, bsks, ksks);
+    host_unchecked_all_eq_slices_async<Torus>(
+        streams, &current_result_dest, lhs_window, rhs, num_rhs, num_blocks,
+        mem_ptr->all_eq_buffer, bsks, ksks);
   }
 
-  host_integer_is_at_least_one_comparisons_block_true<Torus>(
+  host_integer_is_at_least_one_comparisons_block_true_async<Torus>(
       streams, match_ct, mem_ptr->packed_results,
       mem_ptr->final_reduction_buffer, bsks, ksks, num_windows);
 }

--- a/backends/tfhe-cuda-backend/cuda/src/integer/vector_find.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/vector_find.cu
@@ -33,7 +33,7 @@ void cuda_unchecked_match_value_64_async(
                  "Result and boolean output pointers must be different for "
                  "out-of-place operations");
 
-  host_unchecked_match_value<uint64_t>(
+  host_unchecked_match_value_async<uint64_t>(
       CudaStreams(streams), lwe_array_out_result, lwe_array_out_boolean,
       lwe_array_in_ct, h_match_inputs, h_match_outputs,
       (int_unchecked_match_buffer<uint64_t> *)mem, bsks,
@@ -79,7 +79,7 @@ void cuda_unchecked_match_value_or_64_async(
                  "Output and input pointers must be different for out-of-place "
                  "operations");
 
-  host_unchecked_match_value_or<uint64_t>(
+  host_unchecked_match_value_or_async<uint64_t>(
       CudaStreams(streams), lwe_array_out, lwe_array_in_ct, h_match_inputs,
       h_match_outputs, h_or_value,
       (int_unchecked_match_value_or_buffer<uint64_t> *)mem, bsks,
@@ -125,7 +125,7 @@ void cuda_unchecked_contains_64_async(CudaStreamsFFI streams,
                  "Output and second input pointers must be different for "
                  "out-of-place operations");
 
-  host_unchecked_contains<uint64_t>(
+  host_unchecked_contains_async<uint64_t>(
       CudaStreams(streams), output, inputs, value, num_inputs, num_blocks,
       (int_unchecked_contains_buffer<uint64_t> *)mem, bsks,
       (uint64_t *const *)ksks);
@@ -165,7 +165,7 @@ void cuda_unchecked_contains_clear_64_async(
   PANIC_IF_FALSE(output != inputs, "Output and input pointers must be "
                                    "different for out-of-place operations");
 
-  host_unchecked_contains_clear<uint64_t>(
+  host_unchecked_contains_clear_async<uint64_t>(
       CudaStreams(streams), output, inputs, h_clear_val, num_inputs, num_blocks,
       (int_unchecked_contains_clear_buffer<uint64_t> *)mem, bsks,
       (uint64_t *const *)ksks);
@@ -205,7 +205,7 @@ void cuda_unchecked_is_in_clears_64_async(
   PANIC_IF_FALSE(output != input, "Output and input pointers must be different "
                                   "for out-of-place operations");
 
-  host_unchecked_is_in_clears<uint64_t>(
+  host_unchecked_is_in_clears_async<uint64_t>(
       CudaStreams(streams), output, input, h_cleartexts, num_clears, num_blocks,
       (int_unchecked_is_in_clears_buffer<uint64_t> *)mem, bsks,
       (uint64_t *const *)ksks);
@@ -252,7 +252,7 @@ void cuda_unchecked_index_in_clears_64_async(
                  "Index and match output pointers must be different for "
                  "out-of-place operations");
 
-  host_unchecked_index_in_clears<uint64_t>(
+  host_unchecked_index_in_clears_async<uint64_t>(
       CudaStreams(streams), index_ct, match_ct, input, h_cleartexts, num_clears,
       num_blocks, num_blocks_index,
       (int_unchecked_index_in_clears_buffer<uint64_t> *)mem, bsks,
@@ -300,7 +300,7 @@ void cuda_unchecked_first_index_in_clears_64_async(
                  "Index and match output pointers must be different for "
                  "out-of-place operations");
 
-  host_unchecked_first_index_in_clears<uint64_t>(
+  host_unchecked_first_index_in_clears_async<uint64_t>(
       CudaStreams(streams), index_ct, match_ct, input, h_unique_values,
       h_unique_indices, num_unique, num_blocks, num_blocks_index,
       (int_unchecked_first_index_in_clears_buffer<uint64_t> *)mem, bsks,
@@ -348,7 +348,7 @@ void cuda_unchecked_first_index_of_clear_64_async(
                  "Index and match output pointers must be different for "
                  "out-of-place operations");
 
-  host_unchecked_first_index_of_clear<uint64_t>(
+  host_unchecked_first_index_of_clear_async<uint64_t>(
       CudaStreams(streams), index_ct, match_ct, inputs, h_clear_val, num_inputs,
       num_blocks, num_blocks_index,
       (int_unchecked_first_index_of_clear_buffer<uint64_t> *)mem, bsks,
@@ -396,7 +396,7 @@ void cuda_unchecked_first_index_of_64_async(
                  "Index and match output pointers must be different for "
                  "out-of-place operations");
 
-  host_unchecked_first_index_of<uint64_t>(
+  host_unchecked_first_index_of_async<uint64_t>(
       CudaStreams(streams), index_ct, match_ct, inputs, value, num_inputs,
       num_blocks, num_blocks_index,
       (int_unchecked_first_index_of_buffer<uint64_t> *)mem, bsks,
@@ -445,7 +445,7 @@ void cuda_unchecked_index_of_64_async(CudaStreamsFFI streams,
                  "Index and match output pointers must be different for "
                  "out-of-place operations");
 
-  host_unchecked_index_of<uint64_t>(
+  host_unchecked_index_of_async<uint64_t>(
       CudaStreams(streams), index_ct, match_ct, inputs, value, num_inputs,
       num_blocks, num_blocks_index,
       (int_unchecked_index_of_buffer<uint64_t> *)mem, bsks,
@@ -493,7 +493,7 @@ void cuda_unchecked_index_of_clear_64_async(
                  "Index and match output pointers must be different for "
                  "out-of-place operations");
 
-  host_unchecked_index_of_clear<uint64_t>(
+  host_unchecked_index_of_clear_async<uint64_t>(
       CudaStreams(streams), index_ct, match_ct, inputs, h_clear_val,
       is_scalar_obviously_bigger, num_inputs, num_blocks, num_blocks_index,
       (int_unchecked_index_of_clear_buffer<uint64_t> *)mem, bsks,

--- a/backends/tfhe-cuda-backend/cuda/src/integer/vector_find.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/vector_find.cuh
@@ -72,7 +72,7 @@ pack_chunk_eq_pairs_kernel(T *packed_current, T *packed_value,
  * -> 32 blocks).
  */
 template <typename T>
-__host__ void host_pack_chunk_eq_pairs(
+__host__ void host_pack_chunk_eq_pairs_async(
     cudaStream_t stream, uint32_t gpu_index,
     CudaRadixCiphertextFFI *packed_current,
     CudaRadixCiphertextFFI *packed_value, T *const *d_src_ptrs,
@@ -170,7 +170,7 @@ scatter_to_ptr_array_kernel(Torus *const *dst_ptr_array,
  * @param num_blocks Radix-block width of each output ciphertext.
  */
 template <typename Torus>
-__host__ void host_scatter_to_ptr_array(
+__host__ void host_scatter_to_ptr_array_async(
     cudaStream_t stream, uint32_t gpu_index,
     std::vector<CudaRadixCiphertextFFI> &dst_list, Torus *const *d_dst_ptrs,
     CudaRadixCiphertextFFI const *src, const uint32_t *d_src_offsets,
@@ -221,7 +221,7 @@ __host__ void host_scatter_to_ptr_array(
  * @param max_degree Maximum number of blocks packable into one LUT input.
  */
 template <typename Torus>
-__host__ void host_and_reduce_selector_matrix(
+__host__ void host_and_reduce_selector_matrix_async(
     CudaStreams streams, CudaRadixCiphertextFFI *accumulator,
     CudaRadixCiphertextFFI const *selectors,
     const std::vector<int_radix_lut<Torus> *> &luts_eq,
@@ -242,7 +242,7 @@ __host__ void host_and_reduce_selector_matrix(
     take = std::min(cap, num_blocks - row);
     uint32_t items_in_acc = (first ? 0u : 1u) + take;
 
-    host_lwe_flat_array_2d_accumulate_rows<Torus>(
+    host_lwe_flat_array_2d_accumulate_rows_async<Torus>(
         streams.stream(0), streams.gpu_index(0), &acc_slice, selectors, row,
         take, num_columns, message_modulus, carry_modulus);
 
@@ -268,7 +268,7 @@ __host__ void host_and_reduce_selector_matrix(
  * clear value (e.g. a u64 in 2_2 params -> 32 blocks).
  */
 template <typename Torus>
-__host__ void host_compute_eq_selectors_ct_vs_clears(
+__host__ void host_compute_eq_selectors_ct_vs_clears_async(
     CudaStreams streams, CudaRadixCiphertextFFI *lwe_array_out_packed,
     CudaRadixCiphertextFFI const *lwe_array_in, uint32_t num_blocks,
     const uint64_t *h_decomposed_cleartexts,
@@ -277,8 +277,9 @@ __host__ void host_compute_eq_selectors_ct_vs_clears(
 
   // num_blocks == 0 would yield an all-zero selector matrix instead of the
   // trivial all-match, so require at least one block.
-  PANIC_IF_FALSE(num_blocks >= 1, "num_blocks must be at least 1 in "
-                                  "host_compute_eq_selectors_ct_vs_clears");
+  PANIC_IF_FALSE(num_blocks >= 1,
+                 "num_blocks must be at least 1 in "
+                 "host_compute_eq_selectors_ct_vs_clears_async");
 
   uint32_t num_possible_values = mem_ptr->num_possible_values;
   uint32_t message_modulus = mem_ptr->params.message_modulus;
@@ -327,7 +328,7 @@ __host__ void host_compute_eq_selectors_ct_vs_clears(
 
   // And-reduce by rows the indicator 2d array. This produces a 1d vector of
   // booleans, each indicating if the input matches one of the clear values
-  host_and_reduce_selector_matrix<Torus>(
+  host_and_reduce_selector_matrix_async<Torus>(
       streams, &mem_ptr->packed_accumulator, &mem_ptr->tmp_batched_comparisons,
       mem_ptr->luts_eq, mem_ptr->num_luts_needed, num_possible_values,
       num_blocks, max_degree, message_modulus, carry_modulus, bsks, ksks);
@@ -351,7 +352,7 @@ __host__ void host_compute_eq_selectors_ct_vs_clears(
  * -> 32 blocks).
  */
 template <typename Torus>
-__host__ void host_compute_eq_selectors_cts_vs_ct(
+__host__ void host_compute_eq_selectors_cts_vs_ct_async(
     CudaStreams streams,
     std::vector<CudaRadixCiphertextFFI> &lwe_array_out_list,
     CudaRadixCiphertextFFI const *inputs, CudaRadixCiphertextFFI const *value,
@@ -380,7 +381,7 @@ __host__ void host_compute_eq_selectors_cts_vs_ct(
 
     // Pack each (inputs[i][k], value[k]) pair so the bivariate PBS can compare
     // every input block against the corresponding target block.
-    host_pack_chunk_eq_pairs<Torus>(
+    host_pack_chunk_eq_pairs_async<Torus>(
         streams.stream(0), streams.gpu_index(0), &mem_ptr->packed_current_block,
         &mem_ptr->packed_value_block, mem_ptr->d_input_ptrs, inputs, value,
         base, current_chunk_size, num_blocks);
@@ -396,7 +397,7 @@ __host__ void host_compute_eq_selectors_cts_vs_ct(
 
     // AND-reduce the num_blocks x num_inputs indicator matrix into one boolean
     // per input (whether it matches the target).
-    host_and_reduce_selector_matrix<Torus>(
+    host_and_reduce_selector_matrix_async<Torus>(
         streams, &mem_ptr->packed_accumulator, &mem_ptr->packed_current_block,
         mem_ptr->luts_eq, mem_ptr->num_luts_needed, current_chunk_size,
         num_blocks, max_degree, message_modulus, carry_modulus, bsks, ksks);
@@ -429,7 +430,7 @@ __host__ void host_compute_eq_selectors_cts_vs_ct(
  * @param num_blocks Radix-block width of each produced value.
  */
 template <typename Torus>
-__host__ void host_create_possible_results(
+__host__ void host_create_possible_results_async(
     CudaStreams streams,
     std::vector<CudaRadixCiphertextFFI> &lwe_array_out_list,
     CudaRadixCiphertextFFI const *batched_selectors,
@@ -485,7 +486,7 @@ __host__ void host_create_possible_results(
       safe_mul_sizeof<uint32_t>(num_possible_values * num_blocks),
       streams.stream(0), streams.gpu_index(0));
 
-  host_scatter_to_ptr_array<Torus>(
+  host_scatter_to_ptr_array_async<Torus>(
       streams.stream(0), streams.gpu_index(0), lwe_array_out_list,
       (Torus *const *)mem_ptr->d_dst_ptrs, &mem_ptr->tmp_many_luts_output,
       mem_ptr->d_src_idx, h_src_idx, num_possible_values, num_blocks);
@@ -559,7 +560,7 @@ uint64_t scratch_cuda_create_possible_results(
  * @param num_blocks Radix-block width of each candidate summed.
  */
 template <typename Torus>
-__host__ void host_aggregate_one_hot_vector(
+__host__ void host_aggregate_one_hot_vector_async(
     CudaStreams streams, CudaRadixCiphertextFFI *lwe_array_out,
     const std::vector<CudaRadixCiphertextFFI> &lwe_array_in_list,
     uint32_t num_input_ciphertexts, uint32_t num_blocks,
@@ -589,7 +590,7 @@ __host__ void host_aggregate_one_hot_vector(
                            safe_mul_sizeof<Torus *>(num_input_ciphertexts),
                            streams.stream(0), streams.gpu_index(0));
 
-  host_lwe_array_2d_sum_rows<Torus>(
+  host_lwe_array_2d_sum_rows_async<Torus>(
       streams.stream(0), streams.gpu_index(0), src_buf, mem_ptr->d_input_ptrs,
       lwe_array_in_list.data(), 0u, chunk_size, num_input_ciphertexts,
       num_chunks, num_blocks, message_modulus, carry_modulus);
@@ -605,7 +606,7 @@ __host__ void host_aggregate_one_hot_vector(
   while (num_pending > 1) {
     uint32_t groups = CEIL_DIV(num_pending, chunk_size);
 
-    host_lwe_flat_array_2d_sum_rows<Torus>(
+    host_lwe_flat_array_2d_sum_rows_async<Torus>(
         streams.stream(0), streams.gpu_index(0), dst_buf, src_buf, chunk_size,
         num_pending, groups, num_blocks, message_modulus, carry_modulus);
 
@@ -662,7 +663,7 @@ __host__ void host_aggregate_one_hot_vector(
  * @param h_match_outputs Host array of clear values, one per key.
  */
 template <typename Torus>
-__host__ void host_unchecked_match_value(
+__host__ void host_unchecked_match_value_async(
     CudaStreams streams, CudaRadixCiphertextFFI *lwe_array_out_result,
     CudaRadixCiphertextFFI *lwe_array_out_boolean,
     CudaRadixCiphertextFFI const *lwe_array_in_ct,
@@ -672,14 +673,14 @@ __host__ void host_unchecked_match_value(
 
   // sel_i = (key == key_i) in {0,1},
   // toy example: [10] vs [1,2,5,10,20] -> [0,0,0,1,0]
-  host_compute_eq_selectors_ct_vs_clears<Torus>(
+  host_compute_eq_selectors_ct_vs_clears_async<Torus>(
       streams, &mem_ptr->packed_selectors_ct, lwe_array_in_ct,
       mem_ptr->num_input_blocks, h_match_inputs, mem_ptr->eq_selectors_buffer,
       bsks, ksks);
 
   // result_i = sel_i * value_i: [0,0,0,1,0] * [100,15,10,9,1] -> [0,0,0,9,0]
   if (!mem_ptr->max_output_is_zero) {
-    host_create_possible_results<Torus>(
+    host_create_possible_results_async<Torus>(
         streams, mem_ptr->possible_results_list, &mem_ptr->packed_selectors_ct,
         mem_ptr->num_matches, h_match_outputs,
         mem_ptr->num_output_packed_blocks, mem_ptr->possible_results_buffer,
@@ -688,7 +689,7 @@ __host__ void host_unchecked_match_value(
 
   // all values 0 => result is 0: skip aggregation, only emit the "found" flag
   if (mem_ptr->max_output_is_zero) {
-    host_integer_is_at_least_one_comparisons_block_true<Torus>(
+    host_integer_is_at_least_one_comparisons_block_true_async<Torus>(
         streams, lwe_array_out_boolean, &mem_ptr->packed_selectors_ct,
         mem_ptr->at_least_one_true_buffer, bsks, (Torus **)ksks,
         mem_ptr->num_matches);
@@ -696,13 +697,13 @@ __host__ void host_unchecked_match_value(
   }
 
   // sum the one-hot = read out the matched value: 0+0+0+9+0 -> 9
-  host_aggregate_one_hot_vector<Torus>(
+  host_aggregate_one_hot_vector_async<Torus>(
       streams, lwe_array_out_result, mem_ptr->possible_results_list,
       mem_ptr->num_matches, mem_ptr->num_output_packed_blocks,
       mem_ptr->aggregate_buffer, bsks, ksks);
 
   // "found" flag = OR of selectors: 0 | 0 | 0 | 1 | 0 -> 1
-  host_integer_is_at_least_one_comparisons_block_true<Torus>(
+  host_integer_is_at_least_one_comparisons_block_true_async<Torus>(
       streams, lwe_array_out_boolean, &mem_ptr->packed_selectors_ct,
       mem_ptr->at_least_one_true_buffer, bsks, (Torus **)ksks,
       mem_ptr->num_matches);
@@ -742,7 +743,7 @@ uint64_t scratch_cuda_unchecked_match_value_or(
  * @brief Executes a match operation with a fallback default value.
  */
 template <typename Torus>
-__host__ void host_unchecked_match_value_or(
+__host__ void host_unchecked_match_value_or_async(
     CudaStreams streams, CudaRadixCiphertextFFI *lwe_array_out,
     CudaRadixCiphertextFFI const *lwe_array_in_ct,
     const uint64_t *h_match_inputs, const uint64_t *h_match_outputs,
@@ -750,10 +751,10 @@ __host__ void host_unchecked_match_value_or(
     int_unchecked_match_value_or_buffer<Torus> *mem_ptr, void *const *bsks,
     Torus *const *ksks) {
 
-  host_unchecked_match_value<Torus>(streams, &mem_ptr->tmp_match_result,
-                                    &mem_ptr->tmp_match_bool, lwe_array_in_ct,
-                                    h_match_inputs, h_match_outputs,
-                                    mem_ptr->match_buffer, bsks, ksks);
+  host_unchecked_match_value_async<Torus>(
+      streams, &mem_ptr->tmp_match_result, &mem_ptr->tmp_match_bool,
+      lwe_array_in_ct, h_match_inputs, h_match_outputs, mem_ptr->match_buffer,
+      bsks, ksks);
 
   cuda_memcpy_async_to_gpu(mem_ptr->d_or_value, h_or_value,
                            safe_mul_sizeof<Torus>(mem_ptr->num_final_blocks),
@@ -764,9 +765,9 @@ __host__ void host_unchecked_match_value_or(
       mem_ptr->d_or_value, h_or_value, mem_ptr->num_final_blocks,
       mem_ptr->params.message_modulus, mem_ptr->params.carry_modulus);
 
-  host_cmux<Torus>(streams, lwe_array_out, &mem_ptr->tmp_match_bool,
-                   &mem_ptr->tmp_match_result, &mem_ptr->tmp_or_value,
-                   mem_ptr->cmux_buffer, bsks, (Torus **)ksks);
+  host_cmux_async<Torus>(streams, lwe_array_out, &mem_ptr->tmp_match_bool,
+                         &mem_ptr->tmp_match_result, &mem_ptr->tmp_or_value,
+                         mem_ptr->cmux_buffer, bsks, (Torus **)ksks);
 }
 
 template <typename Torus>
@@ -795,19 +796,18 @@ scratch_cuda_unchecked_contains(CudaStreams streams,
  * params -> 32 blocks).
  */
 template <typename Torus>
-__host__ void
-host_unchecked_contains(CudaStreams streams, CudaRadixCiphertextFFI *output,
-                        CudaRadixCiphertextFFI const *inputs,
-                        CudaRadixCiphertextFFI const *value,
-                        uint32_t num_inputs, uint32_t num_blocks,
-                        int_unchecked_contains_buffer<Torus> *mem_ptr,
-                        void *const *bsks, Torus *const *ksks) {
+__host__ void host_unchecked_contains_async(
+    CudaStreams streams, CudaRadixCiphertextFFI *output,
+    CudaRadixCiphertextFFI const *inputs, CudaRadixCiphertextFFI const *value,
+    uint32_t num_inputs, uint32_t num_blocks,
+    int_unchecked_contains_buffer<Torus> *mem_ptr, void *const *bsks,
+    Torus *const *ksks) {
 
-  host_compute_eq_selectors_cts_vs_ct<Torus>(
+  host_compute_eq_selectors_cts_vs_ct_async<Torus>(
       streams, mem_ptr->unpacked_selectors, inputs, value, num_inputs,
       num_blocks, mem_ptr->eq_selectors_buf, bsks, ksks);
 
-  host_integer_is_at_least_one_comparisons_block_true<Torus>(
+  host_integer_is_at_least_one_comparisons_block_true_async<Torus>(
       streams, output, &mem_ptr->packed_selectors, mem_ptr->reduction_buffer,
       bsks, (Torus **)ksks, num_inputs);
 }
@@ -830,7 +830,7 @@ uint64_t scratch_cuda_unchecked_contains_clear(
  * @brief Checks if a clear target is present in an encrypted list.
  */
 template <typename Torus>
-__host__ void host_unchecked_contains_clear(
+__host__ void host_unchecked_contains_clear_async(
     CudaStreams streams, CudaRadixCiphertextFFI *output,
     CudaRadixCiphertextFFI const *inputs, const uint64_t *h_clear_val,
     uint32_t num_inputs, uint32_t num_blocks,
@@ -846,11 +846,11 @@ __host__ void host_unchecked_contains_clear(
       mem_ptr->d_clear_val, h_clear_val, num_blocks,
       mem_ptr->params.message_modulus, mem_ptr->params.carry_modulus);
 
-  host_compute_eq_selectors_cts_vs_ct<Torus>(
+  host_compute_eq_selectors_cts_vs_ct_async<Torus>(
       streams, mem_ptr->unpacked_selectors, inputs, &mem_ptr->tmp_clear_val,
       num_inputs, num_blocks, mem_ptr->eq_selectors_buf, bsks, ksks);
 
-  host_integer_is_at_least_one_comparisons_block_true<Torus>(
+  host_integer_is_at_least_one_comparisons_block_true_async<Torus>(
       streams, output, &mem_ptr->packed_selectors, mem_ptr->reduction_buffer,
       bsks, (Torus **)ksks, num_inputs);
 }
@@ -874,19 +874,18 @@ uint64_t scratch_cuda_unchecked_is_in_clears(
  * values.
  */
 template <typename Torus>
-__host__ void
-host_unchecked_is_in_clears(CudaStreams streams, CudaRadixCiphertextFFI *output,
-                            CudaRadixCiphertextFFI const *input,
-                            const uint64_t *h_cleartexts, uint32_t num_clears,
-                            uint32_t num_blocks,
-                            int_unchecked_is_in_clears_buffer<Torus> *mem_ptr,
-                            void *const *bsks, Torus *const *ksks) {
+__host__ void host_unchecked_is_in_clears_async(
+    CudaStreams streams, CudaRadixCiphertextFFI *output,
+    CudaRadixCiphertextFFI const *input, const uint64_t *h_cleartexts,
+    uint32_t num_clears, uint32_t num_blocks,
+    int_unchecked_is_in_clears_buffer<Torus> *mem_ptr, void *const *bsks,
+    Torus *const *ksks) {
 
-  host_compute_eq_selectors_ct_vs_clears<Torus>(
+  host_compute_eq_selectors_ct_vs_clears_async<Torus>(
       streams, &mem_ptr->packed_selectors, input, num_blocks, h_cleartexts,
       mem_ptr->eq_buffer, bsks, ksks);
 
-  host_integer_is_at_least_one_comparisons_block_true<Torus>(
+  host_integer_is_at_least_one_comparisons_block_true_async<Torus>(
       streams, output, &mem_ptr->packed_selectors, mem_ptr->reduction_buffer,
       bsks, (Torus **)ksks, num_clears);
 }
@@ -896,7 +895,7 @@ host_unchecked_is_in_clears(CudaStreams streams, CudaRadixCiphertextFFI *output,
  * encrypted scalar index.
  */
 template <typename Torus>
-__host__ void host_compute_final_index_from_selectors(
+__host__ void host_compute_final_index_from_selectors_async(
     CudaStreams streams, CudaRadixCiphertextFFI *index_ct,
     CudaRadixCiphertextFFI *match_ct,
     CudaRadixCiphertextFFI const *packed_selectors, uint32_t num_inputs,
@@ -906,16 +905,16 @@ __host__ void host_compute_final_index_from_selectors(
 
   uint32_t packed_len = (num_blocks_index + 1) / 2;
 
-  host_create_possible_results<Torus>(
+  host_create_possible_results_async<Torus>(
       streams, mem_ptr->possible_results_ct_list, packed_selectors, num_inputs,
       mem_ptr->h_indices, packed_len, mem_ptr->possible_results_buf, bsks,
       ksks);
 
-  host_aggregate_one_hot_vector<Torus>(
+  host_aggregate_one_hot_vector_async<Torus>(
       streams, index_ct, mem_ptr->possible_results_ct_list, num_inputs,
       packed_len, mem_ptr->aggregate_buf, bsks, ksks);
 
-  host_integer_is_at_least_one_comparisons_block_true<Torus>(
+  host_integer_is_at_least_one_comparisons_block_true_async<Torus>(
       streams, match_ct, packed_selectors, mem_ptr->reduction_buf, bsks,
       (Torus **)ksks, num_inputs);
 }
@@ -939,7 +938,7 @@ uint64_t scratch_cuda_unchecked_index_in_clears(
  * encrypted index.
  */
 template <typename Torus>
-__host__ void host_unchecked_index_in_clears(
+__host__ void host_unchecked_index_in_clears_async(
     CudaStreams streams, CudaRadixCiphertextFFI *index_ct,
     CudaRadixCiphertextFFI *match_ct, CudaRadixCiphertextFFI const *input,
     const uint64_t *h_cleartexts, uint32_t num_clears, uint32_t num_blocks,
@@ -947,11 +946,11 @@ __host__ void host_unchecked_index_in_clears(
     int_unchecked_index_in_clears_buffer<Torus> *mem_ptr, void *const *bsks,
     Torus *const *ksks) {
 
-  host_compute_eq_selectors_ct_vs_clears<Torus>(
+  host_compute_eq_selectors_ct_vs_clears_async<Torus>(
       streams, &mem_ptr->final_index_buf->packed_selectors, input, num_blocks,
       h_cleartexts, mem_ptr->eq_selectors_buf, bsks, ksks);
 
-  host_compute_final_index_from_selectors<Torus>(
+  host_compute_final_index_from_selectors_async<Torus>(
       streams, index_ct, match_ct, &mem_ptr->final_index_buf->packed_selectors,
       num_clears, num_blocks_index, mem_ptr->final_index_buf, bsks, ksks);
 }
@@ -976,7 +975,7 @@ uint64_t scratch_cuda_unchecked_first_index_in_clears(
  * clear values.
  */
 template <typename Torus>
-__host__ void host_unchecked_first_index_in_clears(
+__host__ void host_unchecked_first_index_in_clears_async(
     CudaStreams streams, CudaRadixCiphertextFFI *index_ct,
     CudaRadixCiphertextFFI *match_ct, CudaRadixCiphertextFFI const *input,
     const uint64_t *h_unique_values, const uint64_t *h_unique_indices,
@@ -984,22 +983,22 @@ __host__ void host_unchecked_first_index_in_clears(
     int_unchecked_first_index_in_clears_buffer<Torus> *mem_ptr,
     void *const *bsks, Torus *const *ksks) {
 
-  host_compute_eq_selectors_ct_vs_clears<Torus>(
+  host_compute_eq_selectors_ct_vs_clears_async<Torus>(
       streams, &mem_ptr->packed_selectors, input, num_blocks, h_unique_values,
       mem_ptr->eq_selectors_buf, bsks, ksks);
 
   uint32_t packed_len = (num_blocks_index + 1) / 2;
 
-  host_create_possible_results<Torus>(
+  host_create_possible_results_async<Torus>(
       streams, mem_ptr->possible_results_ct_list, &mem_ptr->packed_selectors,
       num_unique, h_unique_indices, packed_len, mem_ptr->possible_results_buf,
       bsks, ksks);
 
-  host_aggregate_one_hot_vector<Torus>(
+  host_aggregate_one_hot_vector_async<Torus>(
       streams, index_ct, mem_ptr->possible_results_ct_list, num_unique,
       packed_len, mem_ptr->aggregate_buf, bsks, ksks);
 
-  host_integer_is_at_least_one_comparisons_block_true<Torus>(
+  host_integer_is_at_least_one_comparisons_block_true_async<Torus>(
       streams, match_ct, &mem_ptr->packed_selectors, mem_ptr->reduction_buf,
       bsks, (Torus **)ksks, num_unique);
 }
@@ -1024,7 +1023,7 @@ uint64_t scratch_cuda_unchecked_first_index_of_clear(
  * list.
  */
 template <typename Torus>
-__host__ void host_unchecked_first_index_of_clear(
+__host__ void host_unchecked_first_index_of_clear_async(
     CudaStreams streams, CudaRadixCiphertextFFI *index_ct,
     CudaRadixCiphertextFFI *match_ct, CudaRadixCiphertextFFI const *inputs,
     const uint64_t *h_clear_val, uint32_t num_inputs, uint32_t num_blocks,
@@ -1041,7 +1040,7 @@ __host__ void host_unchecked_first_index_of_clear(
       mem_ptr->d_clear_val, h_clear_val, num_blocks,
       mem_ptr->params.message_modulus, mem_ptr->params.carry_modulus);
 
-  host_compute_eq_selectors_cts_vs_ct<Torus>(
+  host_compute_eq_selectors_cts_vs_ct_async<Torus>(
       streams, mem_ptr->unpacked_selectors, inputs, &mem_ptr->tmp_clear_val,
       num_inputs, num_blocks, mem_ptr->eq_selectors_buf, bsks, ksks);
 
@@ -1067,16 +1066,16 @@ __host__ void host_unchecked_first_index_of_clear(
 
   uint32_t packed_len = (num_blocks_index + 1) / 2;
 
-  host_create_possible_results<Torus>(
+  host_create_possible_results_async<Torus>(
       streams, mem_ptr->possible_results_ct_list, &mem_ptr->packed_selectors,
       num_inputs, (const uint64_t *)mem_ptr->h_indices, packed_len,
       mem_ptr->possible_results_buf, bsks, ksks);
 
-  host_aggregate_one_hot_vector<Torus>(
+  host_aggregate_one_hot_vector_async<Torus>(
       streams, index_ct, mem_ptr->possible_results_ct_list, num_inputs,
       packed_len, mem_ptr->aggregate_buf, bsks, ksks);
 
-  host_integer_is_at_least_one_comparisons_block_true<Torus>(
+  host_integer_is_at_least_one_comparisons_block_true_async<Torus>(
       streams, match_ct, &mem_ptr->packed_selectors, mem_ptr->reduction_buf,
       bsks, (Torus **)ksks, num_inputs);
 }
@@ -1100,7 +1099,7 @@ uint64_t scratch_cuda_unchecked_first_index_of(
  * encrypted list.
  */
 template <typename Torus>
-__host__ void host_unchecked_first_index_of(
+__host__ void host_unchecked_first_index_of_async(
     CudaStreams streams, CudaRadixCiphertextFFI *index_ct,
     CudaRadixCiphertextFFI *match_ct, CudaRadixCiphertextFFI const *inputs,
     CudaRadixCiphertextFFI const *value, uint32_t num_inputs,
@@ -1108,7 +1107,7 @@ __host__ void host_unchecked_first_index_of(
     int_unchecked_first_index_of_buffer<Torus> *mem_ptr, void *const *bsks,
     Torus *const *ksks) {
 
-  host_compute_eq_selectors_cts_vs_ct<Torus>(
+  host_compute_eq_selectors_cts_vs_ct_async<Torus>(
       streams, mem_ptr->unpacked_selectors, inputs, value, num_inputs,
       num_blocks, mem_ptr->eq_selectors_buf, bsks, ksks);
 
@@ -1134,16 +1133,16 @@ __host__ void host_unchecked_first_index_of(
 
   uint32_t packed_len = (num_blocks_index + 1) / 2;
 
-  host_create_possible_results<Torus>(
+  host_create_possible_results_async<Torus>(
       streams, mem_ptr->possible_results_ct_list, &mem_ptr->packed_selectors,
       num_inputs, (const uint64_t *)mem_ptr->h_indices, packed_len,
       mem_ptr->possible_results_buf, bsks, ksks);
 
-  host_aggregate_one_hot_vector<Torus>(
+  host_aggregate_one_hot_vector_async<Torus>(
       streams, index_ct, mem_ptr->possible_results_ct_list, num_inputs,
       packed_len, mem_ptr->aggregate_buf, bsks, ksks);
 
-  host_integer_is_at_least_one_comparisons_block_true<Torus>(
+  host_integer_is_at_least_one_comparisons_block_true_async<Torus>(
       streams, match_ct, &mem_ptr->packed_selectors, mem_ptr->reduction_buf,
       bsks, (Torus **)ksks, num_inputs);
 }
@@ -1167,7 +1166,7 @@ uint64_t scratch_cuda_unchecked_index_of(
  * encrypted index.
  */
 template <typename Torus>
-__host__ void host_unchecked_index_of(
+__host__ void host_unchecked_index_of_async(
     CudaStreams streams, CudaRadixCiphertextFFI *index_ct,
     CudaRadixCiphertextFFI *match_ct, CudaRadixCiphertextFFI const *inputs,
     CudaRadixCiphertextFFI const *value, uint32_t num_inputs,
@@ -1175,11 +1174,11 @@ __host__ void host_unchecked_index_of(
     int_unchecked_index_of_buffer<Torus> *mem_ptr, void *const *bsks,
     Torus *const *ksks) {
 
-  host_compute_eq_selectors_cts_vs_ct<Torus>(
+  host_compute_eq_selectors_cts_vs_ct_async<Torus>(
       streams, mem_ptr->final_index_buf->unpacked_selectors, inputs, value,
       num_inputs, num_blocks, mem_ptr->eq_selectors_buf, bsks, ksks);
 
-  host_compute_final_index_from_selectors<Torus>(
+  host_compute_final_index_from_selectors_async<Torus>(
       streams, index_ct, match_ct, &mem_ptr->final_index_buf->packed_selectors,
       num_inputs, num_blocks_index, mem_ptr->final_index_buf, bsks, ksks);
 }
@@ -1203,7 +1202,7 @@ uint64_t scratch_cuda_unchecked_index_of_clear(
  * encrypted index.
  */
 template <typename Torus>
-__host__ void host_unchecked_index_of_clear(
+__host__ void host_unchecked_index_of_clear_async(
     CudaStreams streams, CudaRadixCiphertextFFI *index_ct,
     CudaRadixCiphertextFFI *match_ct, CudaRadixCiphertextFFI const *inputs,
     const uint64_t *h_clear_val, bool is_scalar_obviously_bigger,
@@ -1228,13 +1227,13 @@ __host__ void host_unchecked_index_of_clear(
         mem_ptr->d_clear_val, h_clear_val, num_blocks,
         mem_ptr->params.message_modulus, mem_ptr->params.carry_modulus);
 
-    host_compute_eq_selectors_cts_vs_ct<Torus>(
+    host_compute_eq_selectors_cts_vs_ct_async<Torus>(
         streams, mem_ptr->final_index_buf->unpacked_selectors, inputs,
         &mem_ptr->tmp_clear_val, num_inputs, num_blocks,
         mem_ptr->eq_selectors_buf, bsks, ksks);
   }
 
-  host_compute_final_index_from_selectors<Torus>(
+  host_compute_final_index_from_selectors_async<Torus>(
       streams, index_ct, match_ct, packed_selectors, num_inputs,
       num_blocks_index, mem_ptr->final_index_buf, bsks, ksks);
 }

--- a/backends/tfhe-cuda-backend/cuda/src/kreyvium/fast_kreyvium.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/kreyvium/fast_kreyvium.cu
@@ -9,9 +9,9 @@ void cuda_fast_kreyvium_init_async(
     const CudaRadixCiphertextFFI *iv_in, uint32_t num_inputs, int8_t *mem_ptr,
     void *const *bsks, void *const *ksks) {
   auto buffer = (int_fast_kreyvium_buffer<uint64_t> *)mem_ptr;
-  host_fast_kreyvium_init<uint64_t>(CudaStreams(streams), buffer, a_reg, b_reg,
-                                    c_reg, k_reg, iv_reg, k_offset, iv_offset,
-                                    key, iv_in, bsks, (uint64_t *const *)ksks);
+  host_fast_kreyvium_init_async<uint64_t>(
+      CudaStreams(streams), buffer, a_reg, b_reg, c_reg, k_reg, iv_reg,
+      k_offset, iv_offset, key, iv_in, bsks, (uint64_t *const *)ksks);
 }
 
 void cuda_fast_kreyvium_step_async(
@@ -22,10 +22,10 @@ void cuda_fast_kreyvium_step_async(
     uint32_t num_inputs, uint32_t num_steps, int8_t *mem_ptr, void *const *bsks,
     void *const *ksks) {
   auto buffer = (int_fast_kreyvium_buffer<uint64_t> *)mem_ptr;
-  host_fast_kreyvium_step<uint64_t>(CudaStreams(streams), keystream_output,
-                                    a_reg, b_reg, c_reg, k_reg, iv_reg,
-                                    k_offset, iv_offset, num_inputs, num_steps,
-                                    buffer, bsks, (uint64_t *const *)ksks);
+  host_fast_kreyvium_step_async<uint64_t>(
+      CudaStreams(streams), keystream_output, a_reg, b_reg, c_reg, k_reg,
+      iv_reg, k_offset, iv_offset, num_inputs, num_steps, buffer, bsks,
+      (uint64_t *const *)ksks);
 }
 
 uint64_t scratch_cuda_fast_kreyvium_init_async(

--- a/backends/tfhe-cuda-backend/cuda/src/kreyvium/fast_kreyvium.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/kreyvium/fast_kreyvium.cuh
@@ -63,20 +63,20 @@ __host__ void fast_kreyvium_build_accumulator(
       streams.stream(0), streams.gpu_index(0), acc_slice, 0, num_blocks,
       xor_terms[0], 0, num_blocks);
   for (size_t i = 1; i < xor_terms.size(); i++)
-    host_addition<Torus>(streams.stream(0), streams.gpu_index(0), acc_slice,
-                         acc_slice, xor_terms[i], num_blocks,
-                         params.message_modulus, params.carry_modulus);
+    host_addition_async<Torus>(streams.stream(0), streams.gpu_index(0),
+                               acc_slice, acc_slice, xor_terms[i], num_blocks,
+                               params.message_modulus, params.carry_modulus);
 
   // acc <- 2 * acc : the parity of the XOR terms moves into the padding bit.
-  host_integer_small_scalar_mul_radix<Torus>(streams, acc_slice, acc_slice, 2,
-                                             params.message_modulus,
-                                             params.carry_modulus);
+  host_integer_small_scalar_mul_radix_async<Torus>(
+      streams, acc_slice, acc_slice, 2, params.message_modulus,
+      params.carry_modulus);
 
   // acc <- acc + AND-pair operands : their sum hits 2 (padding bit) iff both 1.
   for (size_t i = 0; i < and_terms.size(); i++)
-    host_addition<Torus>(streams.stream(0), streams.gpu_index(0), acc_slice,
-                         acc_slice, and_terms[i], num_blocks,
-                         params.message_modulus, params.carry_modulus);
+    host_addition_async<Torus>(streams.stream(0), streams.gpu_index(0),
+                               acc_slice, acc_slice, and_terms[i], num_blocks,
+                               params.message_modulus, params.carry_modulus);
 }
 
 // Core evaluation function that advances the Kreyvium state by exactly 64
@@ -226,7 +226,7 @@ __host__ void fast_kreyvium_compute_64_steps(
 // Delta = q/4), matching the loop invariant; no flush is needed afterwards.
 //
 template <typename Torus>
-__host__ void host_fast_kreyvium_init(
+__host__ void host_fast_kreyvium_init_async(
     CudaStreams streams, int_fast_kreyvium_buffer<Torus> *mem,
     CudaRadixCiphertextFFI *a_reg, CudaRadixCiphertextFFI *b_reg,
     CudaRadixCiphertextFFI *c_reg, CudaRadixCiphertextFFI *k_reg,
@@ -329,7 +329,7 @@ __host__ void host_fast_kreyvium_init(
 // existing state and updates the internal registers in place.
 //
 template <typename Torus>
-__host__ void host_fast_kreyvium_step(
+__host__ void host_fast_kreyvium_step_async(
     CudaStreams streams, CudaRadixCiphertextFFI *keystream_output,
     CudaRadixCiphertextFFI *a_reg, CudaRadixCiphertextFFI *b_reg,
     CudaRadixCiphertextFFI *c_reg, CudaRadixCiphertextFFI *k_reg,

--- a/backends/tfhe-cuda-backend/cuda/src/kreyvium/kreyvium.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/kreyvium/kreyvium.cu
@@ -9,9 +9,9 @@ void cuda_kreyvium_init_async(
     const CudaRadixCiphertextFFI *iv_in, uint32_t /*num_inputs*/,
     int8_t *mem_ptr, void *const *bsks, void *const *ksks) {
   auto buffer = (int_kreyvium_buffer<uint64_t> *)mem_ptr;
-  host_kreyvium_init<uint64_t>(CudaStreams(streams), buffer, a_reg, b_reg,
-                               c_reg, k_reg, iv_reg, k_offset, iv_offset, key,
-                               iv_in, bsks, (uint64_t *const *)ksks);
+  host_kreyvium_init_async<uint64_t>(CudaStreams(streams), buffer, a_reg, b_reg,
+                                     c_reg, k_reg, iv_reg, k_offset, iv_offset,
+                                     key, iv_in, bsks, (uint64_t *const *)ksks);
 }
 
 void cuda_kreyvium_step_async(
@@ -22,10 +22,10 @@ void cuda_kreyvium_step_async(
     uint32_t num_inputs, uint32_t num_steps, int8_t *mem_ptr, void *const *bsks,
     void *const *ksks) {
   auto buffer = (int_kreyvium_buffer<uint64_t> *)mem_ptr;
-  host_kreyvium_step<uint64_t>(CudaStreams(streams), keystream_output, a_reg,
-                               b_reg, c_reg, k_reg, iv_reg, k_offset, iv_offset,
-                               num_inputs, num_steps, buffer, bsks,
-                               (uint64_t *const *)ksks);
+  host_kreyvium_step_async<uint64_t>(CudaStreams(streams), keystream_output,
+                                     a_reg, b_reg, c_reg, k_reg, iv_reg,
+                                     k_offset, iv_offset, num_inputs, num_steps,
+                                     buffer, bsks, (uint64_t *const *)ksks);
 }
 
 uint64_t scratch_cuda_kreyvium_init_async(

--- a/backends/tfhe-cuda-backend/cuda/src/kreyvium/kreyvium.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/kreyvium/kreyvium.cuh
@@ -60,20 +60,24 @@ __host__ void kreyvium_compute_64_steps(
 
   // Compute linear feedback terms
   // temp_a <- a65 + a92
-  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), ws->temp_a,
-                       &a65, &a92, ws->temp_a->num_radix_blocks,
-                       mem->params.message_modulus, mem->params.carry_modulus);
+  host_addition_async<Torus>(
+      streams.stream(0), streams.gpu_index(0), ws->temp_a, &a65, &a92,
+      ws->temp_a->num_radix_blocks, mem->params.message_modulus,
+      mem->params.carry_modulus);
   // temp_b <- b68 + b83
-  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), ws->temp_b,
-                       &b68, &b83, ws->temp_b->num_radix_blocks,
-                       mem->params.message_modulus, mem->params.carry_modulus);
+  host_addition_async<Torus>(
+      streams.stream(0), streams.gpu_index(0), ws->temp_b, &b68, &b83,
+      ws->temp_b->num_radix_blocks, mem->params.message_modulus,
+      mem->params.carry_modulus);
   // temp_c <- c65 + c110 + k127
-  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), ws->temp_c,
-                       &c65, &c110, ws->temp_c->num_radix_blocks,
-                       mem->params.message_modulus, mem->params.carry_modulus);
-  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), ws->temp_c,
-                       ws->temp_c, &k127, ws->temp_c->num_radix_blocks,
-                       mem->params.message_modulus, mem->params.carry_modulus);
+  host_addition_async<Torus>(
+      streams.stream(0), streams.gpu_index(0), ws->temp_c, &c65, &c110,
+      ws->temp_c->num_radix_blocks, mem->params.message_modulus,
+      mem->params.carry_modulus);
+  host_addition_async<Torus>(
+      streams.stream(0), streams.gpu_index(0), ws->temp_c, ws->temp_c, &k127,
+      ws->temp_c->num_radix_blocks, mem->params.message_modulus,
+      mem->params.carry_modulus);
 
   // Flush temp_c (extract message bits and reset noise) so it can be reused
   // below
@@ -121,39 +125,48 @@ __host__ void kreyvium_compute_64_steps(
                                      (i + 1) * batch_size_blocks);
 
   // new_a <- (c109 & c108) + a68 + temp_c
-  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), &flush_new_a,
-                       &and_c109_c108, &a68, batch_size_blocks,
-                       mem->params.message_modulus, mem->params.carry_modulus);
-  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), &flush_new_a,
-                       &flush_new_a, ws->temp_c, batch_size_blocks,
-                       mem->params.message_modulus, mem->params.carry_modulus);
+  host_addition_async<Torus>(streams.stream(0), streams.gpu_index(0),
+                             &flush_new_a, &and_c109_c108, &a68,
+                             batch_size_blocks, mem->params.message_modulus,
+                             mem->params.carry_modulus);
+  host_addition_async<Torus>(streams.stream(0), streams.gpu_index(0),
+                             &flush_new_a, &flush_new_a, ws->temp_c,
+                             batch_size_blocks, mem->params.message_modulus,
+                             mem->params.carry_modulus);
 
   // new_b <- (a91 & a90) + b77 + temp_a + iv127
-  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), &flush_new_b,
-                       &and_a91_a90, &b77, batch_size_blocks,
-                       mem->params.message_modulus, mem->params.carry_modulus);
-  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), &flush_new_b,
-                       &flush_new_b, ws->temp_a, batch_size_blocks,
-                       mem->params.message_modulus, mem->params.carry_modulus);
-  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), &flush_new_b,
-                       &flush_new_b, &iv127, batch_size_blocks,
-                       mem->params.message_modulus, mem->params.carry_modulus);
+  host_addition_async<Torus>(streams.stream(0), streams.gpu_index(0),
+                             &flush_new_b, &and_a91_a90, &b77,
+                             batch_size_blocks, mem->params.message_modulus,
+                             mem->params.carry_modulus);
+  host_addition_async<Torus>(streams.stream(0), streams.gpu_index(0),
+                             &flush_new_b, &flush_new_b, ws->temp_a,
+                             batch_size_blocks, mem->params.message_modulus,
+                             mem->params.carry_modulus);
+  host_addition_async<Torus>(streams.stream(0), streams.gpu_index(0),
+                             &flush_new_b, &flush_new_b, &iv127,
+                             batch_size_blocks, mem->params.message_modulus,
+                             mem->params.carry_modulus);
 
   // new_c <- (b82 & b81) + c86 + temp_b
-  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), &flush_new_c,
-                       &and_b82_b81, &c86, batch_size_blocks,
-                       mem->params.message_modulus, mem->params.carry_modulus);
-  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), &flush_new_c,
-                       &flush_new_c, ws->temp_b, batch_size_blocks,
-                       mem->params.message_modulus, mem->params.carry_modulus);
+  host_addition_async<Torus>(streams.stream(0), streams.gpu_index(0),
+                             &flush_new_c, &and_b82_b81, &c86,
+                             batch_size_blocks, mem->params.message_modulus,
+                             mem->params.carry_modulus);
+  host_addition_async<Torus>(streams.stream(0), streams.gpu_index(0),
+                             &flush_new_c, &flush_new_c, ws->temp_b,
+                             batch_size_blocks, mem->params.message_modulus,
+                             mem->params.carry_modulus);
 
   // out <- temp_a + temp_b + temp_c
-  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), &flush_out,
-                       ws->temp_a, ws->temp_b, batch_size_blocks,
-                       mem->params.message_modulus, mem->params.carry_modulus);
-  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), &flush_out,
-                       &flush_out, ws->temp_c, batch_size_blocks,
-                       mem->params.message_modulus, mem->params.carry_modulus);
+  host_addition_async<Torus>(streams.stream(0), streams.gpu_index(0),
+                             &flush_out, ws->temp_a, ws->temp_b,
+                             batch_size_blocks, mem->params.message_modulus,
+                             mem->params.carry_modulus);
+  host_addition_async<Torus>(streams.stream(0), streams.gpu_index(0),
+                             &flush_out, &flush_out, ws->temp_c,
+                             batch_size_blocks, mem->params.message_modulus,
+                             mem->params.carry_modulus);
 
   // Flush PBS: extract message bits and reset noise on new_a, new_b, new_c, out
   integer_radix_apply_univariate_lookup_table<Torus>(
@@ -192,15 +205,14 @@ __host__ void kreyvium_compute_64_steps(
 // and executing the standard 1152-cycle warmup phase.
 //
 template <typename Torus>
-__host__ void
-host_kreyvium_init(CudaStreams streams, int_kreyvium_buffer<Torus> *mem,
-                   CudaRadixCiphertextFFI *a_reg, CudaRadixCiphertextFFI *b_reg,
-                   CudaRadixCiphertextFFI *c_reg, CudaRadixCiphertextFFI *k_reg,
-                   CudaRadixCiphertextFFI *iv_reg, uint32_t *k_offset,
-                   uint32_t *iv_offset,
-                   CudaRadixCiphertextFFI const *key_bitsliced,
-                   CudaRadixCiphertextFFI const *iv_bitsliced,
-                   void *const *bsks, uint64_t *const *ksks) {
+__host__ void host_kreyvium_init_async(
+    CudaStreams streams, int_kreyvium_buffer<Torus> *mem,
+    CudaRadixCiphertextFFI *a_reg, CudaRadixCiphertextFFI *b_reg,
+    CudaRadixCiphertextFFI *c_reg, CudaRadixCiphertextFFI *k_reg,
+    CudaRadixCiphertextFFI *iv_reg, uint32_t *k_offset, uint32_t *iv_offset,
+    CudaRadixCiphertextFFI const *key_bitsliced,
+    CudaRadixCiphertextFFI const *iv_bitsliced, void *const *bsks,
+    uint64_t *const *ksks) {
 
   uint32_t N = mem->num_inputs;
   *k_offset = 0;
@@ -272,9 +284,9 @@ host_kreyvium_init(CudaStreams streams, int_kreyvium_buffer<Torus> *mem,
   CudaRadixCiphertextFFI dest_c_ones;
   slice_reg_batch_impl<Torus>(&dest_c_ones, c_reg, KREYVIUM_C_ONES_OFFSET,
                               KREYVIUM_C_ONES_COUNT, N);
-  host_add_scalar_one_inplace<Torus>(streams, &dest_c_ones,
-                                     mem->params.message_modulus,
-                                     mem->params.carry_modulus);
+  host_add_scalar_one_inplace_async<Torus>(streams, &dest_c_ones,
+                                           mem->params.message_modulus,
+                                           mem->params.carry_modulus);
   integer_radix_apply_univariate_lookup_table<Torus>(
       streams, &dest_c_ones, &dest_c_ones, bsks, ksks, mem->luts->flush_lut,
       dest_c_ones.num_radix_blocks);
@@ -290,7 +302,7 @@ host_kreyvium_init(CudaStreams streams, int_kreyvium_buffer<Torus> *mem,
 // existing state and updates the internal registers in place.
 //
 template <typename Torus>
-__host__ void host_kreyvium_step(
+__host__ void host_kreyvium_step_async(
     CudaStreams streams, CudaRadixCiphertextFFI *keystream_output,
     CudaRadixCiphertextFFI *a_reg, CudaRadixCiphertextFFI *b_reg,
     CudaRadixCiphertextFFI *c_reg, CudaRadixCiphertextFFI *k_reg,

--- a/backends/tfhe-cuda-backend/cuda/src/linearalgebra/addition.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/linearalgebra/addition.cuh
@@ -144,9 +144,10 @@ template <typename T> struct PtrTableRowAccessor {
 // Grid: x covers num_columns*lwe_size, y = num_chunks.
 //
 // lwe_array_2d_reduce_rows_kernel
-//   ├─ host_lwe_array_2d_sum_rows              (PtrTable, Accumulate=false)
-//   ├─ host_lwe_flat_array_2d_sum_rows         (Flat,     Accumulate=false)
-//   └─ host_lwe_flat_array_2d_accumulate_rows  (Flat,     Accumulate=true)
+//   ├─ host_lwe_array_2d_sum_rows_async              (PtrTable,
+//   Accumulate=false) ├─ host_lwe_flat_array_2d_sum_rows_async         (Flat,
+//   Accumulate=false) └─ host_lwe_flat_array_2d_accumulate_rows_async  (Flat,
+//   Accumulate=true)
 template <typename T, typename SrcAccessor, bool Accumulate>
 __global__ void
 lwe_array_2d_reduce_rows_kernel(T *dst, SrcAccessor src, uint32_t chunk_size,
@@ -211,10 +212,11 @@ struct PtrTableMetaAccessor {
 // the source layout (flat vs scattered), with Accumulate the result is added
 // to the existing metadata ("+="), else it overwrites ("=").
 template <bool Accumulate, typename MetaAccessor>
-void host_reduce_rows_meta(CudaRadixCiphertextFFI *out, MetaAccessor meta,
-                           uint32_t chunk_size, uint32_t num_rows,
-                           uint32_t num_chunks, uint32_t num_columns,
-                           uint32_t message_modulus, uint32_t carry_modulus) {
+void host_reduce_rows_meta_async(CudaRadixCiphertextFFI *out, MetaAccessor meta,
+                                 uint32_t chunk_size, uint32_t num_rows,
+                                 uint32_t num_chunks, uint32_t num_columns,
+                                 uint32_t message_modulus,
+                                 uint32_t carry_modulus) {
   for (uint32_t g = 0; g < num_chunks; g++) {
     uint32_t r_start = g * chunk_size;
     uint32_t r_end = std::min(r_start + chunk_size, num_rows);
@@ -241,7 +243,7 @@ void host_reduce_rows_meta(CudaRadixCiphertextFFI *out, MetaAccessor meta,
 // Column-wise sum of rows, no carry between columns
 // NON-contiguous input: rows passed as a pointer array
 template <typename T>
-__host__ void host_lwe_array_2d_sum_rows(
+__host__ void host_lwe_array_2d_sum_rows_async(
     cudaStream_t stream, uint32_t gpu_index, CudaRadixCiphertextFFI *output,
     T *const *d_src_ptrs, CudaRadixCiphertextFFI const *inputs,
     uint32_t row_offset, uint32_t chunk_size, uint32_t num_rows,
@@ -277,15 +279,15 @@ __host__ void host_lwe_array_2d_sum_rows(
   check_cuda_error(cudaGetLastError());
 
   PtrTableMetaAccessor meta{inputs + row_offset};
-  host_reduce_rows_meta<false>(output, meta, chunk_size, num_rows - row_offset,
-                               num_chunks, num_columns, message_modulus,
-                               carry_modulus);
+  host_reduce_rows_meta_async<false>(
+      output, meta, chunk_size, num_rows - row_offset, num_chunks, num_columns,
+      message_modulus, carry_modulus);
 }
 
 // Column-wise sum of rows, no carry between columns
 // CONTIGUOUS input: one flat row-major buffer of num_rows x num_columns LWEs.
 template <typename T>
-__host__ void host_lwe_flat_array_2d_sum_rows(
+__host__ void host_lwe_flat_array_2d_sum_rows_async(
     cudaStream_t stream, uint32_t gpu_index, CudaRadixCiphertextFFI *dst,
     CudaRadixCiphertextFFI const *src, uint32_t chunk_size, uint32_t num_rows,
     uint32_t num_chunks, uint32_t num_columns, uint32_t message_modulus,
@@ -315,14 +317,15 @@ __host__ void host_lwe_flat_array_2d_sum_rows(
   check_cuda_error(cudaGetLastError());
 
   FlatMetaAccessor meta{src->degrees, src->noise_levels, num_columns};
-  host_reduce_rows_meta<false>(dst, meta, chunk_size, num_rows, num_chunks,
-                               num_columns, message_modulus, carry_modulus);
+  host_reduce_rows_meta_async<false>(dst, meta, chunk_size, num_rows,
+                                     num_chunks, num_columns, message_modulus,
+                                     carry_modulus);
 }
 
 // Column-wise accumulate of rows "+=", no carry between columns
 // CONTIGUOUS input: one flat row-major buffer of rows x num_columns LWEs.
 template <typename T>
-__host__ void host_lwe_flat_array_2d_accumulate_rows(
+__host__ void host_lwe_flat_array_2d_accumulate_rows_async(
     cudaStream_t stream, uint32_t gpu_index, CudaRadixCiphertextFFI *output,
     CudaRadixCiphertextFFI const *input, uint32_t row_offset,
     uint32_t row_count, uint32_t num_columns, const uint32_t message_modulus,
@@ -356,8 +359,9 @@ __host__ void host_lwe_flat_array_2d_accumulate_rows(
   FlatMetaAccessor meta{input->degrees + (size_t)row_offset * num_columns,
                         input->noise_levels + (size_t)row_offset * num_columns,
                         num_columns};
-  host_reduce_rows_meta<true>(output, meta, row_count, row_count, 1,
-                              num_columns, message_modulus, carry_modulus);
+  host_reduce_rows_meta_async<true>(output, meta, row_count, row_count, 1,
+                                    num_columns, message_modulus,
+                                    carry_modulus);
 }
 
 #endif // CUDA_ADD_H

--- a/backends/tfhe-cuda-backend/cuda/src/linearalgebra/multiplication.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/linearalgebra/multiplication.cu
@@ -26,7 +26,7 @@ void cuda_wrapping_polynomial_mul_one_to_many_64_async(
                  "Output and right input pointers must be different for "
                  "out-of-place operations");
 
-  host_wrapping_polynomial_mul_one_to_many<uint64_t, ulonglong4>(
+  host_wrapping_polynomial_mul_one_to_many_async<uint64_t, ulonglong4>(
       static_cast<cudaStream_t>(stream), gpu_index,
       static_cast<uint64_t *>(result), static_cast<uint64_t const *>(poly_lhs),
       circulant, static_cast<uint64_t const *>(poly_rhs), polynomial_size, 0,
@@ -44,7 +44,7 @@ void cuda_glwe_wrapping_polynomial_mul_one_to_many_64_async(
                  "Output and right input pointers must be different for "
                  "out-of-place operations");
 
-  host_glwe_wrapping_polynomial_mul_one_to_many<uint64_t, ulonglong4>(
+  host_glwe_wrapping_polynomial_mul_one_to_many_async<uint64_t, ulonglong4>(
       static_cast<cudaStream_t>(stream), gpu_index,
       static_cast<uint64_t *>(result), static_cast<uint64_t const *>(poly_lhs),
       circulant, static_cast<uint64_t const *>(poly_rhs), polynomial_size,

--- a/backends/tfhe-cuda-backend/cuda/src/linearalgebra/multiplication.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/linearalgebra/multiplication.cuh
@@ -46,7 +46,7 @@ __global__ void cleartext_multiplication(T *output, T const *lwe_input,
 }
 
 template <typename T>
-__host__ void host_cleartext_multiplication_unsafe_no_degrees(
+__host__ void host_cleartext_multiplication_unsafe_no_degrees_async(
     cudaStream_t stream, uint32_t gpu_index, T *output,
     CudaLweCiphertextListFFI const *lwe_input, T cleartext_input) {
 

--- a/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_cg_classic.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_cg_classic.cuh
@@ -242,7 +242,7 @@ __host__ uint64_t scratch_programmable_bootstrap_cg(
  * Host wrapper
  */
 template <typename Torus, class params>
-__host__ void host_programmable_bootstrap_cg(
+__host__ void host_programmable_bootstrap_cg_async(
     cudaStream_t stream, uint32_t gpu_index, Torus *lwe_array_out,
     Torus const *lwe_output_indexes, Torus const *lut_vector,
     Torus const *lut_vector_indexes, Torus const *lwe_array_in,

--- a/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_cg_multibit.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_cg_multibit.cuh
@@ -389,7 +389,7 @@ __host__ void execute_cg_external_product_loop(
 }
 
 template <typename Torus, class params>
-__host__ void host_cg_multi_bit_programmable_bootstrap(
+__host__ void host_cg_multi_bit_programmable_bootstrap_async(
     cudaStream_t stream, uint32_t gpu_index, Torus *lwe_array_out,
     Torus const *lwe_output_indexes, Torus const *lut_vector,
     Torus const *lut_vector_indexes, Torus const *lwe_array_in,
@@ -421,10 +421,11 @@ __host__ void host_cg_multi_bit_programmable_bootstrap(
   }
 }
 
-// Noise tests variant: identical to host_cg_multi_bit_programmable_bootstrap
-// but uses NOISE_TESTS keybundle mode.
+// Noise tests variant: identical to
+// host_cg_multi_bit_programmable_bootstrap_async but uses NOISE_TESTS keybundle
+// mode.
 template <typename Torus, class params>
-__host__ void host_cg_multi_bit_programmable_bootstrap_noise_tests(
+__host__ void host_cg_multi_bit_programmable_bootstrap_noise_tests_async(
     cudaStream_t stream, uint32_t gpu_index, Torus *lwe_array_out,
     Torus const *lwe_output_indexes, Torus const *lut_vector,
     Torus const *lut_vector_indexes, Torus const *lwe_array_in,

--- a/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_classic.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_classic.cu
@@ -64,7 +64,7 @@ void cuda_programmable_bootstrap_tbc_lwe_ciphertext_vector(
     uint32_t lut_stride) {
 
   DISPATCH_POLY_SIZE(polynomial_size, ClassicPBSDegreePolicy,
-                     host_programmable_bootstrap_tbc<Torus, Params>(
+                     host_programmable_bootstrap_tbc_async<Torus, Params>(
                          static_cast<cudaStream_t>(stream), gpu_index,
                          lwe_array_out, lwe_output_indexes, lut_vector,
                          lut_vector_indexes, lwe_array_in, lwe_input_indexes,
@@ -84,14 +84,14 @@ void cuda_programmable_bootstrap_tbc_lwe_ciphertext_vector_generic(
     uint32_t level_count, uint32_t num_samples, uint32_t num_many_lut,
     uint32_t lut_stride) {
 
-  DISPATCH_POLY_SIZE(polynomial_size, ClassicPBSDegreePolicy,
-                     host_programmable_bootstrap_tbc_generic<Torus, Params>(
-                         static_cast<cudaStream_t>(stream), gpu_index,
-                         lwe_array_out, lwe_output_indexes, lut_vector,
-                         lut_vector_indexes, lwe_array_in, lwe_input_indexes,
-                         bootstrapping_key, buffer, glwe_dimension,
-                         lwe_dimension, polynomial_size, base_log, level_count,
-                         num_samples, num_many_lut, lut_stride));
+  DISPATCH_POLY_SIZE(
+      polynomial_size, ClassicPBSDegreePolicy,
+      host_programmable_bootstrap_tbc_generic_async<Torus, Params>(
+          static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
+          lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
+          lwe_input_indexes, bootstrapping_key, buffer, glwe_dimension,
+          lwe_dimension, polynomial_size, base_log, level_count, num_samples,
+          num_many_lut, lut_stride));
 }
 #endif
 
@@ -233,7 +233,7 @@ void cuda_programmable_bootstrap_cg_lwe_ciphertext_vector(
     uint32_t lut_stride) {
 
   DISPATCH_POLY_SIZE(polynomial_size, AmortizedDegreePolicy,
-                     host_programmable_bootstrap_cg<Torus, Params>(
+                     host_programmable_bootstrap_cg_async<Torus, Params>(
                          static_cast<cudaStream_t>(stream), gpu_index,
                          lwe_array_out, lwe_output_indexes, lut_vector,
                          lut_vector_indexes, lwe_array_in, lwe_input_indexes,
@@ -256,7 +256,7 @@ void cuda_programmable_bootstrap_lwe_ciphertext_vector(
   // Degree<2048> is measured to outperform AmortizedDegree<2048> for non-CG
   // classic PBS.
   DISPATCH_POLY_SIZE(polynomial_size, ClassicPBSDegreePolicy,
-                     host_programmable_bootstrap<Torus, Params>(
+                     host_programmable_bootstrap_async<Torus, Params>(
                          static_cast<cudaStream_t>(stream), gpu_index,
                          lwe_array_out, lwe_output_indexes, lut_vector,
                          lut_vector_indexes, lwe_array_in, lwe_input_indexes,
@@ -516,7 +516,7 @@ void cuda_programmable_bootstrap_tbc_64_2_2_async(
                  "Cuda error (classical PBS): expected a TBC buffer.");
 
 #if (CUDA_ARCH >= 900)
-  host_programmable_bootstrap_tbc_2_2_specialized<uint64_t, Degree<2048>>(
+  host_programmable_bootstrap_tbc_2_2_specialized_async<uint64_t, Degree<2048>>(
       static_cast<cudaStream_t>(stream), gpu_index,
       static_cast<uint64_t *>(lwe_array_out),
       static_cast<const uint64_t *>(lwe_output_indexes),
@@ -563,7 +563,7 @@ void cuda_programmable_bootstrap_specialized_2_2_64_async(
   pbs_buffer<uint64_t, CLASSICAL> *buffer =
       (pbs_buffer<uint64_t, CLASSICAL> *)mem_ptr;
 
-  host_programmable_bootstrap_specialized_2_2<uint64_t, Degree<2048>>(
+  host_programmable_bootstrap_specialized_2_2_async<uint64_t, Degree<2048>>(
       static_cast<cudaStream_t>(stream), gpu_index,
       static_cast<uint64_t *>(lwe_array_out),
       static_cast<const uint64_t *>(lwe_output_indexes),

--- a/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_classic.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_classic.cuh
@@ -1254,7 +1254,7 @@ enum class ClassicalLaunchMode {
 };
 
 template <typename Torus, class params>
-__host__ void host_programmable_bootstrap_with_mode(
+__host__ void host_programmable_bootstrap_with_mode_async(
     cudaStream_t stream, uint32_t gpu_index, Torus *lwe_array_out,
     Torus const *lwe_output_indexes, Torus const *lut_vector,
     Torus const *lut_vector_indexes, Torus const *lwe_array_in,
@@ -1535,7 +1535,7 @@ __host__ void host_programmable_bootstrap_with_mode(
 }
 
 template <typename Torus, class params>
-__host__ void host_programmable_bootstrap(
+__host__ void host_programmable_bootstrap_async(
     cudaStream_t stream, uint32_t gpu_index, Torus *lwe_array_out,
     Torus const *lwe_output_indexes, Torus const *lut_vector,
     Torus const *lut_vector_indexes, Torus const *lwe_array_in,
@@ -1544,7 +1544,7 @@ __host__ void host_programmable_bootstrap(
     uint32_t lwe_dimension, uint32_t polynomial_size, uint32_t base_log,
     uint32_t level_count, uint32_t input_lwe_ciphertext_count,
     uint32_t num_many_lut, uint32_t lut_stride) {
-  host_programmable_bootstrap_with_mode<Torus, params>(
+  host_programmable_bootstrap_with_mode_async<Torus, params>(
       stream, gpu_index, lwe_array_out, lwe_output_indexes, lut_vector,
       lut_vector_indexes, lwe_array_in, lwe_input_indexes, bootstrapping_key,
       pbs_buffer, glwe_dimension, lwe_dimension, polynomial_size, base_log,
@@ -1553,7 +1553,7 @@ __host__ void host_programmable_bootstrap(
 }
 
 template <typename Torus, class params>
-__host__ void host_programmable_bootstrap_specialized_2_2(
+__host__ void host_programmable_bootstrap_specialized_2_2_async(
     cudaStream_t stream, uint32_t gpu_index, Torus *lwe_array_out,
     Torus const *lwe_output_indexes, Torus const *lut_vector,
     Torus const *lut_vector_indexes, Torus const *lwe_array_in,
@@ -1562,7 +1562,7 @@ __host__ void host_programmable_bootstrap_specialized_2_2(
     uint32_t lwe_dimension, uint32_t polynomial_size, uint32_t base_log,
     uint32_t level_count, uint32_t input_lwe_ciphertext_count,
     uint32_t num_many_lut, uint32_t lut_stride) {
-  host_programmable_bootstrap_with_mode<Torus, params>(
+  host_programmable_bootstrap_with_mode_async<Torus, params>(
       stream, gpu_index, lwe_array_out, lwe_output_indexes, lut_vector,
       lut_vector_indexes, lwe_array_in, lwe_input_indexes, bootstrapping_key,
       pbs_buffer, glwe_dimension, lwe_dimension, polynomial_size, base_log,

--- a/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_classic_128.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_classic_128.cu
@@ -60,7 +60,7 @@ void executor_cuda_programmable_bootstrap_128(
   // AmortizedDegree for 4096 avoids register exhaustion in 128-bit classic PBS
   DISPATCH_POLY_SIZE(
       polynomial_size, Multibit128DegreePolicy,
-      host_programmable_bootstrap_128<InputTorus, Params>(
+      host_programmable_bootstrap_128_async<InputTorus, Params>(
           static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
           lut_vector, lwe_array_in, bootstrapping_key, buffer, glwe_dimension,
           lwe_dimension, polynomial_size, base_log, level_count, num_samples));
@@ -78,7 +78,7 @@ void executor_cuda_programmable_bootstrap_cg_lwe_ciphertext_vector_128(
   // AmortizedDegree for 4096 avoids register exhaustion in 128-bit classic PBS
   DISPATCH_POLY_SIZE(
       polynomial_size, Multibit128DegreePolicy,
-      host_programmable_bootstrap_cg_128<InputTorus, Params>(
+      host_programmable_bootstrap_cg_128_async<InputTorus, Params>(
           static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
           lut_vector, lwe_array_in, bootstrapping_key, buffer, glwe_dimension,
           lwe_dimension, polynomial_size, base_log, level_count, num_samples));
@@ -97,7 +97,7 @@ void executor_cuda_programmable_bootstrap_tbc_lwe_ciphertext_vector_128(
 
   switch (polynomial_size) {
   case 2048:
-    host_programmable_bootstrap_tbc_128<InputTorus, Degree<2048>>(
+    host_programmable_bootstrap_tbc_128_async<InputTorus, Degree<2048>>(
         static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out, lut_vector,
         lwe_array_in, bootstrapping_key, buffer, glwe_dimension, lwe_dimension,
         polynomial_size, base_log, level_count, num_samples);

--- a/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_classic_128.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_classic_128.cuh
@@ -1162,7 +1162,7 @@ __host__ void execute_step_two_128(
  * Host wrapper to the programmable bootstrap 128
  */
 template <typename InputTorus, class params>
-__host__ void host_programmable_bootstrap_128(
+__host__ void host_programmable_bootstrap_128_async(
     cudaStream_t stream, uint32_t gpu_index, __uint128_t *lwe_array_out,
     __uint128_t const *lut_vector, InputTorus const *lwe_array_in,
     double const *bootstrapping_key,
@@ -1258,7 +1258,7 @@ __host__ void host_programmable_bootstrap_128(
 }
 
 template <typename InputTorus, class params>
-__host__ void host_programmable_bootstrap_cg_128(
+__host__ void host_programmable_bootstrap_cg_128_async(
     cudaStream_t stream, uint32_t gpu_index, __uint128_t *lwe_array_out,
     __uint128_t const *lut_vector, InputTorus const *lwe_array_in,
     double const *bootstrapping_key,
@@ -1329,7 +1329,7 @@ __host__ void host_programmable_bootstrap_cg_128(
 
 #if CUDA_ARCH >= 900
 template <typename InputTorus, class params>
-__host__ void host_programmable_bootstrap_tbc_128(
+__host__ void host_programmable_bootstrap_tbc_128_async(
     cudaStream_t stream, uint32_t gpu_index, __uint128_t *lwe_array_out,
     __uint128_t const *lut_vector, InputTorus const *lwe_array_in,
     double const *bootstrapping_key,

--- a/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_multibit.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_multibit.cu
@@ -49,7 +49,7 @@ void cuda_cg_multi_bit_programmable_bootstrap_lwe_ciphertext_vector(
 
   DISPATCH_POLY_SIZE(
       polynomial_size, AmortizedDegreePolicy,
-      host_cg_multi_bit_programmable_bootstrap<Torus, Params>(
+      host_cg_multi_bit_programmable_bootstrap_async<Torus, Params>(
           static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
           lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
           lwe_input_indexes, bootstrapping_key, pbs_buffer, glwe_dimension,
@@ -70,7 +70,7 @@ void cuda_multi_bit_programmable_bootstrap_lwe_ciphertext_vector(
 
   DISPATCH_POLY_SIZE(
       polynomial_size, AmortizedDegreePolicy,
-      host_multi_bit_programmable_bootstrap<Torus, Params>(
+      host_multi_bit_programmable_bootstrap_async<Torus, Params>(
           static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
           lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
           lwe_input_indexes, bootstrapping_key, pbs_buffer, glwe_dimension,
@@ -221,8 +221,8 @@ void cuda_multi_bit_programmable_bootstrap_tbc_64_2_2_async(
                  "Cuda error (multi-bit PBS): expected a TBC buffer.");
 
 #if CUDA_ARCH >= 900
-  host_tbc_multi_bit_programmable_bootstrap_2_2_specialized<uint64_t,
-                                                            Degree<2048>>(
+  host_tbc_multi_bit_programmable_bootstrap_2_2_specialized_async<uint64_t,
+                                                                  Degree<2048>>(
       static_cast<cudaStream_t>(stream), gpu_index,
       static_cast<uint64_t *>(lwe_array_out),
       static_cast<const uint64_t *>(lwe_output_indexes),
@@ -461,8 +461,8 @@ void cuda_multi_bit_programmable_bootstrap_noise_tests_64_async(
   case PBS_VARIANT::TBC:
 #if CUDA_ARCH >= 900
   {
-    host_tbc_multi_bit_programmable_bootstrap_noise_tests<uint64_t,
-                                                          Degree<2048>>(
+    host_tbc_multi_bit_programmable_bootstrap_noise_tests_async<uint64_t,
+                                                                Degree<2048>>(
         static_cast<cudaStream_t>(stream), gpu_index,
         static_cast<uint64_t *>(lwe_array_out),
         static_cast<const uint64_t *>(lwe_output_indexes),
@@ -478,8 +478,8 @@ void cuda_multi_bit_programmable_bootstrap_noise_tests_64_async(
     PANIC("Cuda error (multi-bit PBS): TBC pbs is not supported.")
 #endif
   case PBS_VARIANT::CG:
-    host_cg_multi_bit_programmable_bootstrap_noise_tests<uint64_t,
-                                                         Degree<2048>>(
+    host_cg_multi_bit_programmable_bootstrap_noise_tests_async<uint64_t,
+                                                               Degree<2048>>(
         static_cast<cudaStream_t>(stream), gpu_index,
         static_cast<uint64_t *>(lwe_array_out),
         static_cast<const uint64_t *>(lwe_output_indexes),
@@ -492,7 +492,8 @@ void cuda_multi_bit_programmable_bootstrap_noise_tests_64_async(
         base_log, level_count, num_samples, num_many_lut, lut_stride);
     break;
   case PBS_VARIANT::DEFAULT:
-    host_multi_bit_programmable_bootstrap_noise_tests<uint64_t, Degree<2048>>(
+    host_multi_bit_programmable_bootstrap_noise_tests_async<uint64_t,
+                                                            Degree<2048>>(
         static_cast<cudaStream_t>(stream), gpu_index,
         static_cast<uint64_t *>(lwe_array_out),
         static_cast<const uint64_t *>(lwe_output_indexes),
@@ -681,14 +682,15 @@ void cuda_tbc_multi_bit_programmable_bootstrap_lwe_ciphertext_vector(
         &num_sms, cudaDevAttrMultiProcessorCount, gpu_index));
 
     if (4 * num_sms < num_samples * level_count * (glwe_dimension + 1))
-      host_tbc_multi_bit_programmable_bootstrap<Torus, AmortizedDegree<2048>>(
+      host_tbc_multi_bit_programmable_bootstrap_async<Torus,
+                                                      AmortizedDegree<2048>>(
           static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
           lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
           lwe_input_indexes, bootstrapping_key, pbs_buffer, glwe_dimension,
           lwe_dimension, polynomial_size, grouping_factor, base_log,
           level_count, num_samples, num_many_lut, lut_stride);
     else
-      host_tbc_multi_bit_programmable_bootstrap<Torus, Degree<2048>>(
+      host_tbc_multi_bit_programmable_bootstrap_async<Torus, Degree<2048>>(
           static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
           lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
           lwe_input_indexes, bootstrapping_key, pbs_buffer, glwe_dimension,
@@ -697,7 +699,7 @@ void cuda_tbc_multi_bit_programmable_bootstrap_lwe_ciphertext_vector(
   } else {
     DISPATCH_POLY_SIZE(
         polynomial_size, AmortizedDegreePolicy,
-        host_tbc_multi_bit_programmable_bootstrap<Torus, Params>(
+        host_tbc_multi_bit_programmable_bootstrap_async<Torus, Params>(
             static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
             lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
             lwe_input_indexes, bootstrapping_key, pbs_buffer, glwe_dimension,
@@ -732,15 +734,16 @@ void cuda_tbc_multi_bit_programmable_bootstrap_lwe_ciphertext_vector_generic(
         &num_sms, cudaDevAttrMultiProcessorCount, gpu_index));
 
     if (4 * num_sms < num_samples * level_count * (glwe_dimension + 1))
-      host_tbc_multi_bit_programmable_bootstrap_generic<Torus,
-                                                        AmortizedDegree<2048>>(
+      host_tbc_multi_bit_programmable_bootstrap_generic_async<
+          Torus, AmortizedDegree<2048>>(
           static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
           lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
           lwe_input_indexes, bootstrapping_key, pbs_buffer, glwe_dimension,
           lwe_dimension, polynomial_size, grouping_factor, base_log,
           level_count, num_samples, num_many_lut, lut_stride);
     else
-      host_tbc_multi_bit_programmable_bootstrap_generic<Torus, Degree<2048>>(
+      host_tbc_multi_bit_programmable_bootstrap_generic_async<Torus,
+                                                              Degree<2048>>(
           static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
           lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
           lwe_input_indexes, bootstrapping_key, pbs_buffer, glwe_dimension,
@@ -749,7 +752,7 @@ void cuda_tbc_multi_bit_programmable_bootstrap_lwe_ciphertext_vector_generic(
   } else {
     DISPATCH_POLY_SIZE(
         polynomial_size, AmortizedDegreePolicy,
-        host_tbc_multi_bit_programmable_bootstrap_generic<Torus, Params>(
+        host_tbc_multi_bit_programmable_bootstrap_generic_async<Torus, Params>(
             static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
             lwe_output_indexes, lut_vector, lut_vector_indexes, lwe_array_in,
             lwe_input_indexes, bootstrapping_key, pbs_buffer, glwe_dimension,

--- a/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_multibit.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_multibit.cuh
@@ -1009,7 +1009,7 @@ execute_step_two(cudaStream_t stream, uint32_t gpu_index, Torus *lwe_array_out,
 }
 
 template <typename Torus, class params>
-__host__ void host_multi_bit_programmable_bootstrap(
+__host__ void host_multi_bit_programmable_bootstrap_async(
     cudaStream_t stream, uint32_t gpu_index, Torus *lwe_array_out,
     Torus const *lwe_output_indexes, Torus const *lut_vector,
     Torus const *lut_vector_indexes, Torus const *lwe_array_in,
@@ -1066,7 +1066,7 @@ __host__ void host_multi_bit_programmable_bootstrap(
 }
 
 template <typename Torus, class params>
-__host__ void host_multi_bit_programmable_bootstrap_noise_tests(
+__host__ void host_multi_bit_programmable_bootstrap_noise_tests_async(
     cudaStream_t stream, uint32_t gpu_index, Torus *lwe_array_out,
     Torus const *lwe_output_indexes, Torus const *lut_vector,
     Torus const *lut_vector_indexes, Torus const *lwe_array_in,

--- a/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_multibit_128.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_multibit_128.cu
@@ -74,7 +74,7 @@ void cuda_multi_bit_programmable_bootstrap_128_async(
   // AmortizedDegree for 4096 avoids register exhaustion in 128-bit multibit PBS
   DISPATCH_POLY_SIZE(
       polynomial_size, Multibit128DegreePolicy,
-      host_multi_bit_programmable_bootstrap_128<InputTorus, Params>(
+      host_multi_bit_programmable_bootstrap_128_async<InputTorus, Params>(
           static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
           lwe_output_indexes, lut_vector, lwe_array_in, lwe_input_indexes,
           bootstrapping_key, pbs_buffer, glwe_dimension, lwe_dimension,
@@ -96,7 +96,7 @@ void cuda_cg_multi_bit_programmable_bootstrap_lwe_ciphertext_vector_128(
   // AmortizedDegree for 4096 avoids register exhaustion in 128-bit multibit PBS
   DISPATCH_POLY_SIZE(
       polynomial_size, Multibit128DegreePolicy,
-      host_cg_multi_bit_programmable_bootstrap_128<InputTorus, Params>(
+      host_cg_multi_bit_programmable_bootstrap_128_async<InputTorus, Params>(
           static_cast<cudaStream_t>(stream), gpu_index, lwe_array_out,
           lwe_output_indexes, lut_vector, lwe_array_in, lwe_input_indexes,
           bootstrapping_key, pbs_buffer, glwe_dimension, lwe_dimension,
@@ -202,8 +202,8 @@ void cuda_multi_bit_programmable_bootstrap_noise_tests_128_async(
       reinterpret_cast<pbs_buffer_128<uint64_t, MULTI_BIT> *>(buffer);
   switch (pbs_buf->pbs_variant) {
   case PBS_VARIANT::CG:
-    host_cg_multi_bit_programmable_bootstrap_noise_tests_128<uint64_t,
-                                                             Degree<2048>>(
+    host_cg_multi_bit_programmable_bootstrap_noise_tests_128_async<
+        uint64_t, Degree<2048>>(
         static_cast<cudaStream_t>(stream), gpu_index,
         static_cast<__uint128_t *>(lwe_array_out),
         static_cast<const uint64_t *>(lwe_output_indexes),
@@ -215,8 +215,8 @@ void cuda_multi_bit_programmable_bootstrap_noise_tests_128_async(
         base_log, level_count, num_samples, num_many_lut, lut_stride);
     break;
   case PBS_VARIANT::DEFAULT:
-    host_multi_bit_programmable_bootstrap_noise_tests_128<uint64_t,
-                                                          Degree<2048>>(
+    host_multi_bit_programmable_bootstrap_noise_tests_128_async<uint64_t,
+                                                                Degree<2048>>(
         static_cast<cudaStream_t>(stream), gpu_index,
         static_cast<__uint128_t *>(lwe_array_out),
         static_cast<const uint64_t *>(lwe_output_indexes),

--- a/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_multibit_128.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_multibit_128.cuh
@@ -780,7 +780,7 @@ __host__ void execute_step_two_128(
  * Host wrapper to the multi-bit programmable bootstrap 128
  */
 template <typename InputTorus, class params>
-__host__ void host_multi_bit_programmable_bootstrap_128(
+__host__ void host_multi_bit_programmable_bootstrap_128_async(
     cudaStream_t stream, uint32_t gpu_index, __uint128_t *lwe_array_out,
     InputTorus const *lwe_output_indexes, __uint128_t const *lut_vector,
     InputTorus const *lwe_array_in, InputTorus const *lwe_input_indexes,
@@ -919,7 +919,7 @@ __host__ void execute_cg_external_product_loop_128(
 }
 
 template <typename InputTorus, class params>
-__host__ void host_cg_multi_bit_programmable_bootstrap_128(
+__host__ void host_cg_multi_bit_programmable_bootstrap_128_async(
     cudaStream_t stream, uint32_t gpu_index, __uint128_t *lwe_array_out,
     InputTorus const *lwe_output_indexes, __uint128_t const *lut_vector,
     InputTorus const *lwe_array_in, InputTorus const *lwe_input_indexes,
@@ -1273,10 +1273,10 @@ supports_cooperative_groups_on_multibit_programmable_bootstrap_128(
 }
 
 // Noise tests variant: identical to
-// host_cg_multi_bit_programmable_bootstrap_128 but uses the noise-test
+// host_cg_multi_bit_programmable_bootstrap_128_async but uses the noise-test
 // keybundle (runs_noise_test=true) instead of the standard one.
 template <typename InputTorus, class params>
-__host__ void host_cg_multi_bit_programmable_bootstrap_noise_tests_128(
+__host__ void host_cg_multi_bit_programmable_bootstrap_noise_tests_128_async(
     cudaStream_t stream, uint32_t gpu_index, __uint128_t *lwe_array_out,
     InputTorus const *lwe_output_indexes, __uint128_t const *lut_vector,
     InputTorus const *lwe_array_in, InputTorus const *lwe_input_indexes,
@@ -1307,7 +1307,7 @@ __host__ void host_cg_multi_bit_programmable_bootstrap_noise_tests_128(
 }
 
 template <typename InputTorus, class params>
-__host__ void host_multi_bit_programmable_bootstrap_noise_tests_128(
+__host__ void host_multi_bit_programmable_bootstrap_noise_tests_128_async(
     cudaStream_t stream, uint32_t gpu_index, __uint128_t *lwe_array_out,
     InputTorus const *lwe_output_indexes, __uint128_t const *lut_vector,
     InputTorus const *lwe_array_in, InputTorus const *lwe_input_indexes,

--- a/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_tbc_classic.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_tbc_classic.cuh
@@ -470,7 +470,7 @@ __host__ uint64_t scratch_programmable_bootstrap_tbc(
  * Host wrapper
  */
 template <typename Torus, class params>
-__host__ void host_programmable_bootstrap_tbc_with_mode(
+__host__ void host_programmable_bootstrap_tbc_with_mode_async(
     cudaStream_t stream, uint32_t gpu_index, Torus *lwe_array_out,
     Torus const *lwe_output_indexes, Torus const *lut_vector,
     Torus const *lut_vector_indexes, Torus const *lwe_array_in,
@@ -683,7 +683,7 @@ __host__ void host_programmable_bootstrap_tbc_with_mode(
 }
 
 template <typename Torus, class params>
-__host__ void host_programmable_bootstrap_tbc(
+__host__ void host_programmable_bootstrap_tbc_async(
     cudaStream_t stream, uint32_t gpu_index, Torus *lwe_array_out,
     Torus const *lwe_output_indexes, Torus const *lut_vector,
     Torus const *lut_vector_indexes, Torus const *lwe_array_in,
@@ -692,7 +692,7 @@ __host__ void host_programmable_bootstrap_tbc(
     uint32_t lwe_dimension, uint32_t polynomial_size, uint32_t base_log,
     uint32_t level_count, uint32_t input_lwe_ciphertext_count,
     uint32_t num_many_lut, uint32_t lut_stride) {
-  host_programmable_bootstrap_tbc_with_mode<Torus, params>(
+  host_programmable_bootstrap_tbc_with_mode_async<Torus, params>(
       stream, gpu_index, lwe_array_out, lwe_output_indexes, lut_vector,
       lut_vector_indexes, lwe_array_in, lwe_input_indexes, bootstrapping_key,
       buffer, glwe_dimension, lwe_dimension, polynomial_size, base_log,
@@ -701,7 +701,7 @@ __host__ void host_programmable_bootstrap_tbc(
 }
 
 template <typename Torus, class params>
-__host__ void host_programmable_bootstrap_tbc_generic(
+__host__ void host_programmable_bootstrap_tbc_generic_async(
     cudaStream_t stream, uint32_t gpu_index, Torus *lwe_array_out,
     Torus const *lwe_output_indexes, Torus const *lut_vector,
     Torus const *lut_vector_indexes, Torus const *lwe_array_in,
@@ -710,7 +710,7 @@ __host__ void host_programmable_bootstrap_tbc_generic(
     uint32_t lwe_dimension, uint32_t polynomial_size, uint32_t base_log,
     uint32_t level_count, uint32_t input_lwe_ciphertext_count,
     uint32_t num_many_lut, uint32_t lut_stride) {
-  host_programmable_bootstrap_tbc_with_mode<Torus, params>(
+  host_programmable_bootstrap_tbc_with_mode_async<Torus, params>(
       stream, gpu_index, lwe_array_out, lwe_output_indexes, lut_vector,
       lut_vector_indexes, lwe_array_in, lwe_input_indexes, bootstrapping_key,
       buffer, glwe_dimension, lwe_dimension, polynomial_size, base_log,
@@ -719,7 +719,7 @@ __host__ void host_programmable_bootstrap_tbc_generic(
 }
 
 template <typename Torus, class params>
-__host__ void host_programmable_bootstrap_tbc_2_2_specialized(
+__host__ void host_programmable_bootstrap_tbc_2_2_specialized_async(
     cudaStream_t stream, uint32_t gpu_index, Torus *lwe_array_out,
     Torus const *lwe_output_indexes, Torus const *lut_vector,
     Torus const *lut_vector_indexes, Torus const *lwe_array_in,
@@ -728,7 +728,7 @@ __host__ void host_programmable_bootstrap_tbc_2_2_specialized(
     uint32_t lwe_dimension, uint32_t polynomial_size, uint32_t base_log,
     uint32_t level_count, uint32_t input_lwe_ciphertext_count,
     uint32_t num_many_lut, uint32_t lut_stride) {
-  host_programmable_bootstrap_tbc_with_mode<Torus, params>(
+  host_programmable_bootstrap_tbc_with_mode_async<Torus, params>(
       stream, gpu_index, lwe_array_out, lwe_output_indexes, lut_vector,
       lut_vector_indexes, lwe_array_in, lwe_input_indexes, bootstrapping_key,
       buffer, glwe_dimension, lwe_dimension, polynomial_size, base_log,

--- a/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_tbc_multibit.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_tbc_multibit.cuh
@@ -692,7 +692,7 @@ __host__ void execute_tbc_external_product_loop(
 }
 
 template <typename Torus, class params>
-__host__ void host_tbc_multi_bit_programmable_bootstrap(
+__host__ void host_tbc_multi_bit_programmable_bootstrap_async(
     cudaStream_t stream, uint32_t gpu_index, Torus *lwe_array_out,
     Torus const *lwe_output_indexes, Torus const *lut_vector,
     Torus const *lut_vector_indexes, Torus const *lwe_array_in,
@@ -742,7 +742,7 @@ __host__ void host_tbc_multi_bit_programmable_bootstrap(
 }
 
 template <typename Torus, class params>
-__host__ void host_tbc_multi_bit_programmable_bootstrap(
+__host__ void host_tbc_multi_bit_programmable_bootstrap_async(
     cudaStream_t stream, uint32_t gpu_index, Torus *lwe_array_out,
     Torus const *lwe_output_indexes, Torus const *lut_vector,
     Torus const *lut_vector_indexes, Torus const *lwe_array_in,
@@ -751,7 +751,7 @@ __host__ void host_tbc_multi_bit_programmable_bootstrap(
     uint32_t lwe_dimension, uint32_t polynomial_size, uint32_t grouping_factor,
     uint32_t base_log, uint32_t level_count, uint32_t num_samples,
     uint32_t num_many_lut, uint32_t lut_stride) {
-  host_tbc_multi_bit_programmable_bootstrap<Torus, params>(
+  host_tbc_multi_bit_programmable_bootstrap_async<Torus, params>(
       stream, gpu_index, lwe_array_out, lwe_output_indexes, lut_vector,
       lut_vector_indexes, lwe_array_in, lwe_input_indexes, bootstrapping_key,
       buffer, glwe_dimension, lwe_dimension, polynomial_size, grouping_factor,
@@ -760,7 +760,7 @@ __host__ void host_tbc_multi_bit_programmable_bootstrap(
 }
 
 template <typename Torus, class params>
-__host__ void host_tbc_multi_bit_programmable_bootstrap_generic(
+__host__ void host_tbc_multi_bit_programmable_bootstrap_generic_async(
     cudaStream_t stream, uint32_t gpu_index, Torus *lwe_array_out,
     Torus const *lwe_output_indexes, Torus const *lut_vector,
     Torus const *lut_vector_indexes, Torus const *lwe_array_in,
@@ -769,7 +769,7 @@ __host__ void host_tbc_multi_bit_programmable_bootstrap_generic(
     uint32_t lwe_dimension, uint32_t polynomial_size, uint32_t grouping_factor,
     uint32_t base_log, uint32_t level_count, uint32_t num_samples,
     uint32_t num_many_lut, uint32_t lut_stride) {
-  host_tbc_multi_bit_programmable_bootstrap<Torus, params>(
+  host_tbc_multi_bit_programmable_bootstrap_async<Torus, params>(
       stream, gpu_index, lwe_array_out, lwe_output_indexes, lut_vector,
       lut_vector_indexes, lwe_array_in, lwe_input_indexes, bootstrapping_key,
       buffer, glwe_dimension, lwe_dimension, polynomial_size, grouping_factor,
@@ -778,7 +778,7 @@ __host__ void host_tbc_multi_bit_programmable_bootstrap_generic(
 }
 
 template <typename Torus, class params>
-__host__ void host_tbc_multi_bit_programmable_bootstrap_2_2_specialized(
+__host__ void host_tbc_multi_bit_programmable_bootstrap_2_2_specialized_async(
     cudaStream_t stream, uint32_t gpu_index, Torus *lwe_array_out,
     Torus const *lwe_output_indexes, Torus const *lut_vector,
     Torus const *lut_vector_indexes, Torus const *lwe_array_in,
@@ -787,7 +787,7 @@ __host__ void host_tbc_multi_bit_programmable_bootstrap_2_2_specialized(
     uint32_t lwe_dimension, uint32_t polynomial_size, uint32_t grouping_factor,
     uint32_t base_log, uint32_t level_count, uint32_t num_samples,
     uint32_t num_many_lut, uint32_t lut_stride) {
-  host_tbc_multi_bit_programmable_bootstrap<Torus, params>(
+  host_tbc_multi_bit_programmable_bootstrap_async<Torus, params>(
       stream, gpu_index, lwe_array_out, lwe_output_indexes, lut_vector,
       lut_vector_indexes, lwe_array_in, lwe_input_indexes, bootstrapping_key,
       buffer, glwe_dimension, lwe_dimension, polynomial_size, grouping_factor,
@@ -798,7 +798,7 @@ __host__ void host_tbc_multi_bit_programmable_bootstrap_2_2_specialized(
 // Noise tests variant: uses NOISE_TESTS keybundle mode for the keybundle step
 // while keeping the standard AUTO accumulate behaviour for the TBC loop.
 template <typename Torus, class params>
-__host__ void host_tbc_multi_bit_programmable_bootstrap_noise_tests(
+__host__ void host_tbc_multi_bit_programmable_bootstrap_noise_tests_async(
     cudaStream_t stream, uint32_t gpu_index, Torus *lwe_array_out,
     Torus const *lwe_output_indexes, Torus const *lut_vector,
     Torus const *lut_vector_indexes, Torus const *lwe_array_in,

--- a/backends/tfhe-cuda-backend/cuda/src/polynomial/dot_product.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/polynomial/dot_product.cuh
@@ -62,7 +62,7 @@ cleanup_wrapping_polynomial_mul_one_to_many(void *stream, uint32_t gpu_index,
 // from the lhs and uses matrix multiplication to
 // compute the polynomial multiplication
 template <typename Torus, typename TorusVec>
-__host__ void host_wrapping_polynomial_mul_one_to_many(
+__host__ void host_wrapping_polynomial_mul_one_to_many_async(
     cudaStream_t stream, uint32_t gpu_index, Torus *result,
     const Torus *poly_lhs, int8_t *circulant, const Torus *poly_rhs,
     uint32_t polynomial_size, uint32_t glwe_dimension, uint32_t n_rhs) {
@@ -97,13 +97,13 @@ __host__ void host_wrapping_polynomial_mul_one_to_many(
 }
 
 template <typename Torus, typename TorusVec>
-__host__ void host_glwe_wrapping_polynomial_mul_one_to_many(
+__host__ void host_glwe_wrapping_polynomial_mul_one_to_many_async(
     cudaStream_t stream, uint32_t gpu_index, Torus *result,
     const Torus *glwe_lhs, int8_t *circulant, const Torus *poly_rhs,
     uint32_t polynomial_size, uint32_t glwe_dimension, uint32_t n_rhs) {
 
   for (unsigned i = 0; i < glwe_dimension + 1; ++i) {
-    host_wrapping_polynomial_mul_one_to_many<uint64_t, ulonglong4>(
+    host_wrapping_polynomial_mul_one_to_many_async<uint64_t, ulonglong4>(
         stream, gpu_index, result + i * polynomial_size,
         glwe_lhs + i * polynomial_size, circulant, poly_rhs, polynomial_size,
         glwe_dimension, n_rhs);

--- a/backends/tfhe-cuda-backend/cuda/src/trivium/trivium.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/trivium/trivium.cu
@@ -11,8 +11,9 @@ void cuda_trivium_init_async(CudaStreamsFFI streams,
                              void *const *bsks, void *const *ksks) {
 
   auto buffer = (int_trivium_buffer<uint64_t> *)mem_ptr;
-  host_trivium_init<uint64_t>(CudaStreams(streams), buffer, a_reg, b_reg, c_reg,
-                              key, iv, bsks, (uint64_t *const *)ksks);
+  host_trivium_init_async<uint64_t>(CudaStreams(streams), buffer, a_reg, b_reg,
+                                    c_reg, key, iv, bsks,
+                                    (uint64_t *const *)ksks);
 }
 
 void cuda_trivium_step_async(
@@ -22,9 +23,9 @@ void cuda_trivium_step_async(
     int8_t *mem_ptr, void *const *bsks, void *const *ksks) {
 
   auto buffer = (int_trivium_buffer<uint64_t> *)mem_ptr;
-  host_trivium_step<uint64_t>(CudaStreams(streams), keystream_output, a_reg,
-                              b_reg, c_reg, num_steps, buffer, bsks,
-                              (uint64_t *const *)ksks);
+  host_trivium_step_async<uint64_t>(CudaStreams(streams), keystream_output,
+                                    a_reg, b_reg, c_reg, num_steps, buffer,
+                                    bsks, (uint64_t *const *)ksks);
 }
 
 uint64_t scratch_cuda_trivium_init_async(

--- a/backends/tfhe-cuda-backend/cuda/src/trivium/trivium.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/trivium/trivium.cuh
@@ -109,19 +109,22 @@ __host__ void trivium_compute_64_steps(
 
   // Compute linear feedback terms
   // t1 <- a66 + a93
-  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), ws->temp_t1,
-                       &a65_slice, &a92_slice, ws->temp_t1->num_radix_blocks,
-                       params.message_modulus, params.carry_modulus);
+  host_addition_async<Torus>(streams.stream(0), streams.gpu_index(0),
+                             ws->temp_t1, &a65_slice, &a92_slice,
+                             ws->temp_t1->num_radix_blocks,
+                             params.message_modulus, params.carry_modulus);
 
   // t2 <- b69 + b84
-  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), ws->temp_t2,
-                       &b68_slice, &b83_slice, ws->temp_t2->num_radix_blocks,
-                       params.message_modulus, params.carry_modulus);
+  host_addition_async<Torus>(streams.stream(0), streams.gpu_index(0),
+                             ws->temp_t2, &b68_slice, &b83_slice,
+                             ws->temp_t2->num_radix_blocks,
+                             params.message_modulus, params.carry_modulus);
 
   // t3 <- c66 + c111
-  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), ws->temp_t3,
-                       &c65_slice, &c110_slice, ws->temp_t3->num_radix_blocks,
-                       params.message_modulus, params.carry_modulus);
+  host_addition_async<Torus>(streams.stream(0), streams.gpu_index(0),
+                             ws->temp_t3, &c65_slice, &c110_slice,
+                             ws->temp_t3->num_radix_blocks,
+                             params.message_modulus, params.carry_modulus);
 
   // Flush t3 (extract message bits and reset noise) so it can be reused below
   integer_radix_apply_univariate_lookup_table<Torus>(
@@ -175,39 +178,42 @@ __host__ void trivium_compute_64_steps(
                                    3 * batch_size_blocks);
 
   // new_a <- t3 + a69 + and_res_a
-  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), ws->new_a,
-                       ws->temp_t3, &a68_slice, ws->new_a->num_radix_blocks,
-                       params.message_modulus, params.carry_modulus);
-  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), ws->new_a,
-                       ws->new_a, &and_res_a, ws->new_a->num_radix_blocks,
-                       params.message_modulus, params.carry_modulus);
+  host_addition_async<Torus>(streams.stream(0), streams.gpu_index(0), ws->new_a,
+                             ws->temp_t3, &a68_slice,
+                             ws->new_a->num_radix_blocks,
+                             params.message_modulus, params.carry_modulus);
+  host_addition_async<Torus>(streams.stream(0), streams.gpu_index(0), ws->new_a,
+                             ws->new_a, &and_res_a, ws->new_a->num_radix_blocks,
+                             params.message_modulus, params.carry_modulus);
 
   // new_b <- t1 + b78 + and_res_b
-  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), ws->new_b,
-                       ws->temp_t1, &b77_slice, ws->new_b->num_radix_blocks,
-                       params.message_modulus, params.carry_modulus);
-  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), ws->new_b,
-                       ws->new_b, &and_res_b, ws->new_b->num_radix_blocks,
-                       params.message_modulus, params.carry_modulus);
+  host_addition_async<Torus>(streams.stream(0), streams.gpu_index(0), ws->new_b,
+                             ws->temp_t1, &b77_slice,
+                             ws->new_b->num_radix_blocks,
+                             params.message_modulus, params.carry_modulus);
+  host_addition_async<Torus>(streams.stream(0), streams.gpu_index(0), ws->new_b,
+                             ws->new_b, &and_res_b, ws->new_b->num_radix_blocks,
+                             params.message_modulus, params.carry_modulus);
 
   // new_c <- t2 + c87 + and_res_c
-  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), ws->new_c,
-                       ws->temp_t2, &c86_slice, ws->new_c->num_radix_blocks,
-                       params.message_modulus, params.carry_modulus);
-  host_addition<Torus>(streams.stream(0), streams.gpu_index(0), ws->new_c,
-                       ws->new_c, &and_res_c, ws->new_c->num_radix_blocks,
-                       params.message_modulus, params.carry_modulus);
+  host_addition_async<Torus>(streams.stream(0), streams.gpu_index(0), ws->new_c,
+                             ws->temp_t2, &c86_slice,
+                             ws->new_c->num_radix_blocks,
+                             params.message_modulus, params.carry_modulus);
+  host_addition_async<Torus>(streams.stream(0), streams.gpu_index(0), ws->new_c,
+                             ws->new_c, &and_res_c, ws->new_c->num_radix_blocks,
+                             params.message_modulus, params.carry_modulus);
 
   if (output_dest != nullptr) {
     // z <- t1 + t2 + t3
-    host_addition<Torus>(streams.stream(0), streams.gpu_index(0), output_dest,
-                         ws->temp_t1, ws->temp_t2,
-                         output_dest->num_radix_blocks, params.message_modulus,
-                         params.carry_modulus);
-    host_addition<Torus>(streams.stream(0), streams.gpu_index(0), output_dest,
-                         output_dest, ws->temp_t3,
-                         output_dest->num_radix_blocks, params.message_modulus,
-                         params.carry_modulus);
+    host_addition_async<Torus>(streams.stream(0), streams.gpu_index(0),
+                               output_dest, ws->temp_t1, ws->temp_t2,
+                               output_dest->num_radix_blocks,
+                               params.message_modulus, params.carry_modulus);
+    host_addition_async<Torus>(streams.stream(0), streams.gpu_index(0),
+                               output_dest, output_dest, ws->temp_t3,
+                               output_dest->num_radix_blocks,
+                               params.message_modulus, params.carry_modulus);
   }
 
   // Pack new_a, new_b, new_c (and z when an output is requested) into a single
@@ -278,13 +284,12 @@ __host__ void trivium_compute_64_steps(
 // Sets up the initial state: loads Key and IV, fixes constants,
 // and runs the warm-up phase (1152 steps).
 template <typename Torus>
-__host__ void
-host_trivium_init(CudaStreams streams, int_trivium_buffer<Torus> *buffer,
-                  CudaRadixCiphertextFFI *a_reg, CudaRadixCiphertextFFI *b_reg,
-                  CudaRadixCiphertextFFI *c_reg,
-                  const CudaRadixCiphertextFFI *key_bitsliced,
-                  const CudaRadixCiphertextFFI *iv_bitsliced, void *const *bsks,
-                  uint64_t *const *ksks) {
+__host__ void host_trivium_init_async(
+    CudaStreams streams, int_trivium_buffer<Torus> *buffer,
+    CudaRadixCiphertextFFI *a_reg, CudaRadixCiphertextFFI *b_reg,
+    CudaRadixCiphertextFFI *c_reg, const CudaRadixCiphertextFFI *key_bitsliced,
+    const CudaRadixCiphertextFFI *iv_bitsliced, void *const *bsks,
+    uint64_t *const *ksks) {
 
   uint32_t N = buffer->num_inputs;
   auto ws = buffer->ws;
@@ -318,7 +323,7 @@ host_trivium_init(CudaStreams streams, int_trivium_buffer<Torus> *buffer,
   slice_reg_batch<Torus>(&dest_c_ones, c_reg, TRIVIUM_REGISTER_C_BITS - 3, 3,
                          N);
 
-  host_add_scalar_one_inplace<Torus>(
+  host_add_scalar_one_inplace_async<Torus>(
       streams, &dest_c_ones, params.message_modulus, params.carry_modulus);
   integer_radix_apply_univariate_lookup_table<Torus>(
       streams, &dest_c_ones, &dest_c_ones, bsks, ksks, buffer->luts->flush_lut,
@@ -331,12 +336,12 @@ host_trivium_init(CudaStreams streams, int_trivium_buffer<Torus> *buffer,
 }
 
 template <typename Torus>
-__host__ void
-host_trivium_step(CudaStreams streams, CudaRadixCiphertextFFI *keystream_output,
-                  CudaRadixCiphertextFFI *a_reg, CudaRadixCiphertextFFI *b_reg,
-                  CudaRadixCiphertextFFI *c_reg, uint32_t num_steps,
-                  int_trivium_buffer<Torus> *buffer, void *const *bsks,
-                  uint64_t *const *ksks) {
+__host__ void host_trivium_step_async(
+    CudaStreams streams, CudaRadixCiphertextFFI *keystream_output,
+    CudaRadixCiphertextFFI *a_reg, CudaRadixCiphertextFFI *b_reg,
+    CudaRadixCiphertextFFI *c_reg, uint32_t num_steps,
+    int_trivium_buffer<Torus> *buffer, void *const *bsks,
+    uint64_t *const *ksks) {
 
   PANIC_IF_FALSE(
       num_steps % TRIVIUM_BATCH_SIZE == 0,

--- a/backends/tfhe-cuda-backend/cuda/src/zk/expand.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/zk/expand.cuh
@@ -41,8 +41,9 @@ template <typename Torus> bool is_power_of_2(Torus value) {
 }
 
 template <typename Torus, class params>
-void host_lwe_expand(cudaStream_t stream, int gpu_index, Torus *lwe_array_out,
-                     const expand_job<Torus> *d_jobs, uint32_t num_lwes) {
+void host_lwe_expand_async(cudaStream_t stream, int gpu_index,
+                           Torus *lwe_array_out,
+                           const expand_job<Torus> *d_jobs, uint32_t num_lwes) {
   // Set the GPU device
   check_cuda_error(cudaSetDevice(gpu_index));
 

--- a/backends/tfhe-cuda-backend/cuda/src/zk/zk.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/zk/zk.cu
@@ -53,7 +53,7 @@ void cuda_expand_without_verification_64_async(
 
   DISPATCH_POLY_SIZE(
       expand_buffer->casting_params.big_lwe_dimension, AmortizedDegreePolicy,
-      host_expand_without_verification<uint64_t, Params>(
+      host_expand_without_verification_async<uint64_t, Params>(
           streams, static_cast<uint64_t *>(lwe_array_out),
           static_cast<const uint64_t *>(lwe_flattened_compact_array_in),
           expand_buffer, (uint64_t **)casting_keys, bsks,

--- a/backends/tfhe-cuda-backend/cuda/src/zk/zk.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/zk/zk.cuh
@@ -80,7 +80,7 @@
  */
 
 template <typename Torus, class params>
-__host__ void host_expand_without_verification(
+__host__ void host_expand_without_verification_async(
     CudaStreams streams, Torus *lwe_array_out,
     const Torus *lwe_flattened_compact_array_in, zk_expand_mem<Torus> *mem_ptr,
     Torus *const *casting_keys, void *const *bsks, Torus *const *compute_ksks) {
@@ -121,13 +121,15 @@ __host__ void host_expand_without_verification(
   if (mem_ptr->expand_kind == EXPAND_KIND::NO_CASTING) {
     // This path is added to mimic the CPU fallback behaviour for the no_casting
     // expand, which is needed for the noise sanity checks.
-    host_lwe_expand<Torus, params>(streams.stream(0), streams.gpu_index(0),
-                                   lwe_array_out, d_expand_jobs, num_lwes);
+    host_lwe_expand_async<Torus, params>(streams.stream(0),
+                                         streams.gpu_index(0), lwe_array_out,
+                                         d_expand_jobs, num_lwes);
 
   } else {
     // This is our default path for the expand with casting if needed.
-    host_lwe_expand<Torus, params>(streams.stream(0), streams.gpu_index(0),
-                                   expanded_lwes, d_expand_jobs, num_lwes);
+    host_lwe_expand_async<Torus, params>(streams.stream(0),
+                                         streams.gpu_index(0), expanded_lwes,
+                                         d_expand_jobs, num_lwes);
 
     auto lwe_array_input = expanded_lwes;
     auto ksks = casting_keys;


### PR DESCRIPTION
Part of https://github.com/zama-ai/tfhe-rs-internal/issues/1482 (split 3 of 3, replaces #3896).

### PR content/description

The CUDA backend naming convention says: `_async` suffix = launches work and returns without host synchronization; no suffix = synchronizes before returning.

A transitive call-graph analysis found 172 internal `host_*` template functions that never reach `cuda_synchronize_stream`, directly or transitively, but were missing the `_async` suffix. They are called by `cuda_*_async` FFI entry points. Key shared callees verified sync-free: `integer_radix_apply_univariate_lookup_table`, `integer_radix_apply_bivariate_lookup_table`, `execute_keyswitch_async`, `execute_pbs_async`.

This PR renames them and re-runs clang-format-15 on the affected call sites (the longer names change the argument alignment, which is why the diff is larger than the number of renamed lines). It is a pure rename: no behavior change.

<details><summary>172 <code>host_*</code> internal template functions</summary>

- **`host_accumulate_all_blocks_batched`** => `host_accumulate_all_blocks_batched_async`
- **`host_add_and_propagate_single_carry`** => `host_add_and_propagate_single_carry_async`
- **`host_addition`** => `host_addition_async`
- **`host_addition_plaintext`** => `host_addition_plaintext_async`
- **`host_addition_plaintext_scalar`** => `host_addition_plaintext_scalar_async`
- **`host_add_scalar_one_inplace`** => `host_add_scalar_one_inplace_async`
- **`host_add_the_same_block_to_all_blocks`** => `host_add_the_same_block_to_all_blocks_async`
- **`host_aggregate_one_hot_vector`** => `host_aggregate_one_hot_vector_async`
- **`host_and_reduce_selector_matrix`** => `host_and_reduce_selector_matrix_async`
- **`host_apply_bivariate_lut`** => `host_apply_bivariate_lut_async`
- **`host_apply_many_univariate_lut`** => `host_apply_many_univariate_lut_async`
- **`host_apply_overshift_cleanup`** => `host_apply_overshift_cleanup_async`
- **`host_apply_univariate_lut`** => `host_apply_univariate_lut_async`
- **`host_arithmetic_scalar_shift_inplace`** => `host_arithmetic_scalar_shift_inplace_async`
- **`host_arithmetic_scalar_shift_overshift`** => `host_arithmetic_scalar_shift_overshift_async`
- **`host_binary_tree_fold_sum`** => `host_binary_tree_fold_sum_async`
- **`host_binary_tree_fold_sum_dispatch`** => `host_binary_tree_fold_sum_dispatch_async`
- **`host_bitnot`** => `host_bitnot_async`
- **`host_bitonic_shuffle`** => `host_bitonic_shuffle_async`
- **`host_bitop`** => `host_bitop_async`
- **`host_boolean_bitnot`** => `host_boolean_bitnot_async`
- **`host_boolean_bitop`** => `host_boolean_bitop_async`
- **`host_cast_to_signed`** => `host_cast_to_signed_async`
- **`host_cast_to_unsigned`** => `host_cast_to_unsigned_async`
- **`host_centered_modulus_switch_cooperative`** => `host_centered_modulus_switch_cooperative_async`
- **`host_centered_modulus_switch_inplace`** => `host_centered_modulus_switch_inplace_async`
- **`host_cg_multi_bit_programmable_bootstrap`** => `host_cg_multi_bit_programmable_bootstrap_async`
- **`host_cg_multi_bit_programmable_bootstrap_128`** => `host_cg_multi_bit_programmable_bootstrap_128_async`
- **`host_cg_multi_bit_programmable_bootstrap_noise_tests`** => `host_cg_multi_bit_programmable_bootstrap_noise_tests_async`
- **`host_cg_multi_bit_programmable_bootstrap_noise_tests_128`** => `host_cg_multi_bit_programmable_bootstrap_noise_tests_128_async`
- **`host_cleartext_multiplication`** => `host_cleartext_multiplication_async`
- **`host_cleartext_multiplication_unsafe_no_degrees`** => `host_cleartext_multiplication_unsafe_no_degrees_async`
- **`host_cleartext_vec_multiplication`** => `host_cleartext_vec_multiplication_async`
- **`host_cmux`** => `host_cmux_async`
- **`host_cmux_batch`** => `host_cmux_batch_async`
- **`host_compare_blocks_with_zero`** => `host_compare_blocks_with_zero_async`
- **`host_compute_eq_selectors_cts_vs_ct`** => `host_compute_eq_selectors_cts_vs_ct_async`
- **`host_compute_eq_selectors_ct_vs_clears`** => `host_compute_eq_selectors_ct_vs_clears_async`
- **`host_compute_final_index_from_selectors`** => `host_compute_final_index_from_selectors_async`
- **`host_compute_overshift_condition`** => `host_compute_overshift_condition_async`
- **`host_compute_prefix_sum_hillis_steele`** => `host_compute_prefix_sum_hillis_steele_async`
- **`host_compute_propagation_simulators_and_group_carries`** => `host_compute_propagation_simulators_and_group_carries_async`
- **`host_compute_reduced_pgns_and_carries_for_comparison`** => `host_compute_reduced_pgns_and_carries_for_comparison_async`
- **`host_compute_shifted_blocks_and_borrow_states`** => `host_compute_shifted_blocks_and_borrow_states_async`
- **`host_compute_shifted_blocks_and_states`** => `host_compute_shifted_blocks_and_states_async`
- **`host_create_possible_results`** => `host_create_possible_results_async`
- **`host_cuda_closest_representable`** => `host_cuda_closest_representable_async`
- **`host_difference_check`** => `host_difference_check_async`
- **`host_difference_check_via_borrow`** => `host_difference_check_via_borrow_async`
- **`host_equality_check`** => `host_equality_check_async`
- **`host_expand_without_verification`** => `host_expand_without_verification_async`
- **`host_extend_radix_with_sign_msb`** => `host_extend_radix_with_sign_msb_async`
- **`host_extend_radix_with_trivial_zero_blocks_msb`** => `host_extend_radix_with_trivial_zero_blocks_msb_async`
- **`host_extract`** => `host_extract_async`
- **`host_fast_kreyvium_init`** => `host_fast_kreyvium_init_async`
- **`host_fast_kreyvium_step`** => `host_fast_kreyvium_step_async`
- **`host_fourier_transform_backward_as_torus_f128`** => `host_fourier_transform_backward_as_torus_f128_async`
- **`host_fourier_transform_forward_as_torus_f128`** => `host_fourier_transform_forward_as_torus_f128_async`
- **`host_full_propagate_inplace`** => `host_full_propagate_inplace_async`
- **`host_gemm_keyswitch_lwe_ciphertext_vector`** => `host_gemm_keyswitch_lwe_ciphertext_vector_async`
- **`host_glwe_wrapping_polynomial_mul_one_to_many`** => `host_glwe_wrapping_polynomial_mul_one_to_many_async`
- **`host_integer_abs`** => `host_integer_abs_async`
- **`host_integer_aes_ctr_256_encrypt`** => `host_integer_aes_ctr_256_encrypt_async`
- **`host_integer_aes_ctr_encrypt`** => `host_integer_aes_ctr_encrypt_async`
- **`host_integer_are_all_comparisons_block_true`** => `host_integer_are_all_comparisons_block_true_async`
- **`host_integer_compress`** => `host_integer_compress_async`
- **`host_integer_count_of_consecutive_bits`** => `host_integer_count_of_consecutive_bits_async`
- **`host_integer_decompress`** => `host_integer_decompress_async`
- **`host_integer_grouped_oprf`** => `host_integer_grouped_oprf_async`
- **`host_integer_ilog2`** => `host_integer_ilog2_async`
- **`host_integer_is_at_least_one_comparisons_block_true`** => `host_integer_is_at_least_one_comparisons_block_true_async`
- **`host_integer_key_expansion`** => `host_integer_key_expansion_async`
- **`host_integer_key_expansion_256`** => `host_integer_key_expansion_256_async`
- **`host_integer_mult_radix`** => `host_integer_mult_radix_async`
- **`host_integer_overflowing_sub`** => `host_integer_overflowing_sub_async`
- **`host_integer_partial_sum_ciphertexts_vec`** => `host_integer_partial_sum_ciphertexts_vec_async`
- **`host_integer_prepare_count_of_consecutive_bits`** => `host_integer_prepare_count_of_consecutive_bits_async`
- **`host_integer_small_scalar_mul_radix`** => `host_integer_small_scalar_mul_radix_async`
- **`host_keyswitch_lwe_ciphertext_vector`** => `host_keyswitch_lwe_ciphertext_vector_async`
- **`host_kreyvium_init`** => `host_kreyvium_init_async`
- **`host_kreyvium_step`** => `host_kreyvium_step_async`
- **`host_kv_store_compute_eq_selectors`** => `host_kv_store_compute_eq_selectors_async`
- **`host_kv_store_compute_eq_selectors_small_map`** => `host_kv_store_compute_eq_selectors_small_map_async`
- **`host_kv_store_contains_key`** => `host_kv_store_contains_key_async`
- **`host_kv_store_get`** => `host_kv_store_get_async`
- **`host_kv_store_map`** => `host_kv_store_map_async`
- **`host_kv_store_update`** => `host_kv_store_update_async`
- **`host_logical_scalar_shift_inplace`** => `host_logical_scalar_shift_inplace_async`
- **`host_lwe_array_2d_sum_rows`** => `host_lwe_array_2d_sum_rows_async`
- **`host_lwe_expand`** => `host_lwe_expand_async`
- **`host_lwe_flat_array_2d_accumulate_rows`** => `host_lwe_flat_array_2d_accumulate_rows_async`
- **`host_lwe_flat_array_2d_sum_rows`** => `host_lwe_flat_array_2d_sum_rows_async`
- **`host_maxmin`** => `host_maxmin_async`
- **`host_modulus_switch`** => `host_modulus_switch_async`
- **`host_modulus_switch_inplace`** => `host_modulus_switch_inplace_async`
- **`host_modulus_switch_multi_bit`** => `host_modulus_switch_multi_bit_async`
- **`host_modulus_switch_strided_inplace`** => `host_modulus_switch_strided_inplace_async`
- **`host_multi_bit_programmable_bootstrap`** => `host_multi_bit_programmable_bootstrap_async`
- **`host_multi_bit_programmable_bootstrap_128`** => `host_multi_bit_programmable_bootstrap_128_async`
- **`host_multi_bit_programmable_bootstrap_noise_tests`** => `host_multi_bit_programmable_bootstrap_noise_tests_async`
- **`host_multi_bit_programmable_bootstrap_noise_tests_128`** => `host_multi_bit_programmable_bootstrap_noise_tests_128_async`
- **`host_negation`** => `host_negation_async`
- **`host_negation_with_correcting_term`** => `host_negation_with_correcting_term_async`
- **`host_oprf_bitonic_shuffle`** => `host_oprf_bitonic_shuffle_async`
- **`host_pack`** => `host_pack_async`
- **`host_pack_bivariate_adjacent_blocks`** => `host_pack_bivariate_adjacent_blocks_async`
- **`host_pack_bivariate_blocks`** => `host_pack_bivariate_blocks_async`
- **`host_pack_bivariate_blocks_cmux_two_regions`** => `host_pack_bivariate_blocks_cmux_two_regions_async`
- **`host_pack_bivariate_blocks_with_per_ct_single_block`** => `host_pack_bivariate_blocks_with_per_ct_single_block_async`
- **`host_pack_bivariate_blocks_with_single_block`** => `host_pack_bivariate_blocks_with_single_block_async`
- **`host_pack_chunk_eq_pairs`** => `host_pack_chunk_eq_pairs_async`
- **`host_packing_keyswitch_lwe_list_to_glwe`** => `host_packing_keyswitch_lwe_list_to_glwe_async`
- **`host_programmable_bootstrap`** => `host_programmable_bootstrap_async`
- **`host_programmable_bootstrap_128`** => `host_programmable_bootstrap_128_async`
- **`host_programmable_bootstrap_cg`** => `host_programmable_bootstrap_cg_async`
- **`host_programmable_bootstrap_cg_128`** => `host_programmable_bootstrap_cg_128_async`
- **`host_programmable_bootstrap_specialized_2_2`** => `host_programmable_bootstrap_specialized_2_2_async`
- **`host_programmable_bootstrap_tbc`** => `host_programmable_bootstrap_tbc_async`
- **`host_programmable_bootstrap_tbc_128`** => `host_programmable_bootstrap_tbc_128_async`
- **`host_programmable_bootstrap_tbc_2_2_specialized`** => `host_programmable_bootstrap_tbc_2_2_specialized_async`
- **`host_programmable_bootstrap_tbc_generic`** => `host_programmable_bootstrap_tbc_generic_async`
- **`host_programmable_bootstrap_tbc_with_mode`** => `host_programmable_bootstrap_tbc_with_mode_async`
- **`host_programmable_bootstrap_with_mode`** => `host_programmable_bootstrap_with_mode_async`
- **`host_propagate_single_carry`** => `host_propagate_single_carry_async`
- **`host_radix_blocks_reverse_inplace`** => `host_radix_blocks_reverse_inplace_async`
- **`host_radix_blocks_rotate_left`** => `host_radix_blocks_rotate_left_async`
- **`host_radix_blocks_rotate_right`** => `host_radix_blocks_rotate_right_async`
- **`host_radix_cumulative_sum_in_groups`** => `host_radix_cumulative_sum_in_groups_async`
- **`host_radix_split_simulators_and_grouping_pgns`** => `host_radix_split_simulators_and_grouping_pgns_async`
- **`host_radix_sum_in_groups`** => `host_radix_sum_in_groups_async`
- **`host_reduce_rows_meta`** => `host_reduce_rows_meta_async`
- **`host_rerand_inplace`** => `host_rerand_inplace_async`
- **`host_rerand_inplace_dispatch`** => `host_rerand_inplace_dispatch_async`
- **`host_resolve_group_carries_sequentially`** => `host_resolve_group_carries_sequentially_async`
- **`host_sample_extract`** => `host_sample_extract_async`
- **`host_scalar_addition_inplace`** => `host_scalar_addition_inplace_async`
- **`host_scalar_bitop`** => `host_scalar_bitop_async`
- **`host_scalar_difference_check`** => `host_scalar_difference_check_async`
- **`host_scalar_equality_check`** => `host_scalar_equality_check_async`
- **`host_scalar_maxmin`** => `host_scalar_maxmin_async`
- **`host_scalar_rotate_inplace`** => `host_scalar_rotate_inplace_async`
- **`host_scalar_subtraction_inplace`** => `host_scalar_subtraction_inplace_async`
- **`host_scatter_to_ptr_array`** => `host_scatter_to_ptr_array_async`
- **`host_shift_and_rotate_inplace`** => `host_shift_and_rotate_inplace_async`
- **`host_single_borrow_propagate`** => `host_single_borrow_propagate_async`
- **`host_sub_and_propagate_single_carry`** => `host_sub_and_propagate_single_carry_async`
- **`host_subtraction`** => `host_subtraction_async`
- **`host_subtraction_with_correcting_term`** => `host_subtraction_with_correcting_term_async`
- **`host_tbc_multi_bit_programmable_bootstrap`** => `host_tbc_multi_bit_programmable_bootstrap_async`
- **`host_tbc_multi_bit_programmable_bootstrap_2_2_specialized`** => `host_tbc_multi_bit_programmable_bootstrap_2_2_specialized_async`
- **`host_tbc_multi_bit_programmable_bootstrap_generic`** => `host_tbc_multi_bit_programmable_bootstrap_generic_async`
- **`host_tbc_multi_bit_programmable_bootstrap_noise_tests`** => `host_tbc_multi_bit_programmable_bootstrap_noise_tests_async`
- **`host_trim_radix_blocks_lsb`** => `host_trim_radix_blocks_lsb_async`
- **`host_trim_radix_blocks_msb`** => `host_trim_radix_blocks_msb_async`
- **`host_trivium_init`** => `host_trivium_init_async`
- **`host_trivium_step`** => `host_trivium_step_async`
- **`host_unchecked_all_eq_slices`** => `host_unchecked_all_eq_slices_async`
- **`host_unchecked_contains`** => `host_unchecked_contains_async`
- **`host_unchecked_contains_clear`** => `host_unchecked_contains_clear_async`
- **`host_unchecked_contains_sub_slice`** => `host_unchecked_contains_sub_slice_async`
- **`host_unchecked_first_index_in_clears`** => `host_unchecked_first_index_in_clears_async`
- **`host_unchecked_first_index_of`** => `host_unchecked_first_index_of_async`
- **`host_unchecked_first_index_of_clear`** => `host_unchecked_first_index_of_clear_async`
- **`host_unchecked_index_in_clears`** => `host_unchecked_index_in_clears_async`
- **`host_unchecked_index_of`** => `host_unchecked_index_of_async`
- **`host_unchecked_index_of_clear`** => `host_unchecked_index_of_clear_async`
- **`host_unchecked_is_in_clears`** => `host_unchecked_is_in_clears_async`
- **`host_unchecked_match_value`** => `host_unchecked_match_value_async`
- **`host_unchecked_match_value_or`** => `host_unchecked_match_value_or_async`
- **`host_unchecked_sub_with_correcting_term`** => `host_unchecked_sub_with_correcting_term_async`
- **`host_wrapping_polynomial_mul_one_to_many`** => `host_wrapping_polynomial_mul_one_to_many_async`
- **`host_zero_out_if_batch`** => `host_zero_out_if_batch_async`

</details>


### Check-list:

* [x] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [x] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
