### PR TITLE
fix(gpu): add racecheck on selected kernels, optimize CI

### DIFF
--- a/.github/workflows/gpu_code_validation_tests.yml
+++ b/.github/workflows/gpu_code_validation_tests.yml
@@ -117,10 +117,6 @@ jobs:
         run: |
           make test_high_level_api_gpu_valgrind
 
-      - name: Run CUDA backend racecheck tests
-        run: |
-          make test_cuda_backend_race_check
-
   slack-notify:
     name: gpu_code_validation_tests/slack-notify
     needs: [ setup-instance, cuda-tests-linux ]

--- a/.github/workflows/gpu_core_h100_tests.yml
+++ b/.github/workflows/gpu_core_h100_tests.yml
@@ -141,6 +141,7 @@ jobs:
           BIG_TESTS_INSTANCE=TRUE make test_core_crypto_gpu
           BIG_TESTS_INSTANCE=TRUE make test_integer_compression_gpu
           BIG_TESTS_INSTANCE=TRUE make test_cuda_backend
+          BIG_TESTS_INSTANCE=TRUE PROTOCOL_STRESS_TRANSACTIONS=1500 make test_protocol_stress_gpu
 
   slack-notify:
     name: gpu_core_h100_tests/slack-notify

--- a/.github/workflows/gpu_core_hlapi_h100_2gpu_par.yml
+++ b/.github/workflows/gpu_core_hlapi_h100_2gpu_par.yml
@@ -70,7 +70,8 @@ jobs:
     name: gpu_core_hlapi_h100_2gpu_par/setup-instance
     needs: should-run
     if: github.event_name != 'pull_request' ||
-      (github.event.action == 'labeled' && github.event.label.name == 'approved' && needs.should-run.outputs.gpu_test == 'true')
+      (github.event.action == 'labeled' && (github.event.label.name == 'gpu_int_core_hl' ||
+      (github.event.label.name == 'approved' && needs.should-run.outputs.gpu_test == 'true')))
     runs-on: ubuntu-latest
     outputs:
       runner-name: ${{ steps.start-remote-instance.outputs.label || steps.start-github-instance.outputs.runner_group }}

--- a/.github/workflows/gpu_full_h100_tests.yml
+++ b/.github/workflows/gpu_full_h100_tests.yml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Run protocol workflow stress test
         run: |
-          make test_protocol_stress_gpu
+          make test_protocol_long_run_gpu
 
   slack-notify:
     name: gpu_full_h100_tests/slack-notify

--- a/.github/workflows/gpu_integer_classic_tests_h100_2gpu_par.yml
+++ b/.github/workflows/gpu_integer_classic_tests_h100_2gpu_par.yml
@@ -21,6 +21,7 @@ env:
 on:
   workflow_dispatch:
   pull_request:
+    types: [ labeled ]
 
 permissions:
   contents: read
@@ -69,7 +70,8 @@ jobs:
     name: gpu_integer_classic_tests_h100_2gpu_par/setup-instance
     needs: should-run
     if: github.event_name != 'pull_request' ||
-      (github.event.action == 'labeled' && github.event.label.name == 'approved' && needs.should-run.outputs.gpu_test == 'true')
+      (github.event.action == 'labeled' && (github.event.label.name == 'gpu_int_classic' ||
+      (github.event.label.name == 'approved' && needs.should-run.outputs.gpu_test == 'true')))
     runs-on: ubuntu-latest
     outputs:
       runner-name: ${{ steps.start-remote-instance.outputs.label || steps.start-github-instance.outputs.runner_group }}

--- a/.github/workflows/gpu_integer_multibit_tests_h100_2gpu_par.yml
+++ b/.github/workflows/gpu_integer_multibit_tests_h100_2gpu_par.yml
@@ -70,7 +70,8 @@ jobs:
     name: gpu_integer_multibit_tests_h100_2gpu_par/setup-instance
     needs: should-run
     if: github.event_name != 'pull_request' ||
-      (github.event.action == 'labeled' && github.event.label.name == 'approved' && needs.should-run.outputs.gpu_test == 'true')
+      (github.event.action == 'labeled' && (github.event.label.name == 'gpu_int_mb' ||
+      (github.event.label.name == 'approved' && needs.should-run.outputs.gpu_test == 'true')))
     runs-on: ubuntu-latest
     outputs:
       runner-name: ${{ steps.start-remote-instance.outputs.label || steps.start-github-instance.outputs.runner_group }}

--- a/.github/workflows/gpu_memory_sanitizer.yml
+++ b/.github/workflows/gpu_memory_sanitizer.yml
@@ -20,9 +20,6 @@ env:
   EXTERNAL_CONTRIBUTION_RUNNER: "gpu_ubuntu-22.04"
 
 on:
-  # Allows you to run this workflow manually from the Actions tab as an alternative.
-  pull_request:
-    types: [ labeled ]
   workflow_dispatch:
 
 permissions:
@@ -128,13 +125,18 @@ jobs:
           gcc-version: ${{ matrix.gcc }}
           cloud-provider: ${{ needs.setup-instance.outputs.cloud-provider }}
 
-      - name: Find tools
+      - name: Ensure compute-sanitizer 12.8 is installed
         run: |
-          # Find compute-sanitizer
-          find /usr -executable -name "compute-sanitizer" 2>&1 | grep -v "Permission denied"
-          echo "compute-sanitizer was found, checking if it's in the path..."
-          # Check that compute sanitizer is in the path
+          if command -v compute-sanitizer > /dev/null 2>&1 \
+              && compute-sanitizer --version 2>&1 | grep -q "2025"; then
+            echo "compute-sanitizer 12.8 already installed"
+          else
+            echo "Installing compute-sanitizer 12.8 via apt..."
+            sudo apt-get install -y cuda-sanitizer-12-8
+            echo "/usr/local/cuda-12.8/bin" >> "${GITHUB_PATH}"
+          fi
           which compute-sanitizer
+          compute-sanitizer --version
 
       - name: Install latest stable
         uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # zizmor: ignore[stale-action-refs] this action doesn't create releases
@@ -143,7 +145,7 @@ jobs:
 
       - name: Run memory sanitizer
         run: |
-          make test_high_level_api_gpu_sanitizer
+          make test_high_level_api_gpu_memcheck
 
   slack-notify:
     name: gpu_memory_sanitizer/slack-notify

--- a/.github/workflows/gpu_memory_sanitizer_h100.yml
+++ b/.github/workflows/gpu_memory_sanitizer_h100.yml
@@ -21,8 +21,6 @@ env:
 
 on:
   # Allows you to run this workflow manually from the Actions tab as an alternative.
-  pull_request:
-    types: [ labeled ]
   workflow_dispatch:
 
 permissions:
@@ -128,13 +126,18 @@ jobs:
           gcc-version: ${{ matrix.gcc }}
           cloud-provider: ${{ needs.setup-instance.outputs.cloud-provider }}
 
-      - name: Find tools
+      - name: Ensure compute-sanitizer 12.8 is installed
         run: |
-          # Find compute-sanitizer
-          find /usr -executable -name "compute-sanitizer" 2>&1 | grep -v "Permission denied"
-          echo "compute-sanitizer was found, checking if it's in the path..."
-          # Check that compute sanitizer is in the path
+          if command -v compute-sanitizer > /dev/null 2>&1 \
+              && compute-sanitizer --version 2>&1 | grep -q "2025"; then
+            echo "compute-sanitizer 12.8 already installed"
+          else
+            echo "Installing compute-sanitizer 12.8 via apt..."
+            sudo apt-get install -y cuda-sanitizer-12-8
+            echo "/usr/local/cuda-12.8/bin" >> "${GITHUB_PATH}"
+          fi
           which compute-sanitizer
+          compute-sanitizer --version
 
       - name: Install latest stable
         uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # zizmor: ignore[stale-action-refs] this action doesn't create releases
@@ -143,7 +146,7 @@ jobs:
 
       - name: Run memory sanitizer
         run: |
-          make test_high_level_api_gpu_sanitizer
+          make test_high_level_api_gpu_memcheck
 
   slack-notify:
     name: gpu_memory_sanitizer/slack-notify

--- a/.github/workflows/gpu_memory_sanitizer_h100_2gpu_par.yml
+++ b/.github/workflows/gpu_memory_sanitizer_h100_2gpu_par.yml
@@ -1,5 +1,5 @@
-# Compile and test tfhe-cuda-backend unsigned integer on an AWS instance
-name: gpu_unsigned_integer_tests
+# Run compute-sanitizer memcheck and racecheck in parallel on a 2xH100 machine
+name: gpu_memory_sanitizer_h100_2gpu_par
 
 env:
   CARGO_TERM_COLOR: always
@@ -12,19 +12,16 @@ env:
   SLACK_USERNAME: ${{ secrets.BOT_USERNAME }}
   SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
   SLACKIFY_MARKDOWN: true
-  FAST_TESTS: TRUE
-  NIGHTLY_TESTS: FALSE
   IS_PULL_REQUEST: ${{ github.event_name == 'pull_request' }}
   PULL_REQUEST_MD_LINK: ""
   CHECKOUT_TOKEN: ${{ secrets.REPO_CHECKOUT_TOKEN || secrets.GITHUB_TOKEN }}
-  # Secrets will be available only to zama-ai organization members
   SECRETS_AVAILABLE: ${{ secrets.JOB_SECRET != '' }}
   EXTERNAL_CONTRIBUTION_RUNNER: "gpu_ubuntu-22.04"
 
 on:
-  # Allows you to run this workflow manually from the Actions tab as an alternative.
   workflow_dispatch:
   pull_request:
+    types: [ labeled ]
 
 permissions:
   contents: read
@@ -33,7 +30,7 @@ permissions:
 
 jobs:
   should-run:
-    name: gpu_unsigned_integer_tests/should-run
+    name: gpu_memory_sanitizer_h100_2gpu_par/should-run
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read  # Needed to check for file change
@@ -53,28 +50,24 @@ jobs:
         with:
           files_yaml: |
             gpu:
+              - Cargo.toml
               - tfhe/Cargo.toml
               - tfhe/build.rs
               - backends/tfhe-cuda-backend/**
               - tfhe/src/core_crypto/gpu/**
-              - tfhe/src/integer/server_key/radix_parallel/tests_unsigned/**
-              - tfhe/src/integer/server_key/radix_parallel/tests_signed/**
-              - tfhe/src/integer/server_key/radix_parallel/tests_cases_unsigned.rs
               - tfhe/src/integer/gpu/**
               - tfhe/src/shortint/parameters/**
               - tfhe/src/high_level_api/**
-              - tfhe/src/c_api/**
-              - '.github/workflows/gpu_unsigned_integer_tests.yml'
-              - scripts/integer-tests.sh
+              - '.github/workflows/gpu_memory_sanitizer_h100_2gpu_par.yml'
               - '.github/actions/gpu_setup/action.yml'
               - ci/slab.toml
 
   setup-instance:
-    name: gpu_unsigned_integer_tests/setup-instance
-    runs-on: ubuntu-latest
+    name: gpu_memory_sanitizer_h100_2gpu_par/setup-instance
     needs: should-run
+    runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' ||
-      needs.should-run.outputs.gpu_test == 'true'
+      (github.event.action == 'labeled' && github.event.label.name == 'approved' && needs.should-run.outputs.gpu_test == 'true')
     outputs:
       runner-name: ${{ steps.start-remote-instance.outputs.label || steps.start-github-instance.outputs.runner_group }}
       cloud-provider: ${{ steps.start-remote-instance.outputs.cloud-provider || steps.start-github-instance.outputs.cloud-provider }}
@@ -89,9 +82,8 @@ jobs:
           slab-url: ${{ secrets.SLAB_BASE_URL }}
           job-secret: ${{ secrets.JOB_SECRET }}
           backend: terraform
-          profile: scaleway-small-gpu
+          profile: scaleway-2-h100-sxm5-tests
 
-      # This instance will be spawned especially for pull-request from forked repository
       - name: Start GitHub instance
         id: start-github-instance
         if: env.SECRETS_AVAILABLE == 'false'
@@ -101,18 +93,18 @@ jobs:
             echo "cloud-provider=github";
           } >> "$GITHUB_OUTPUT"
 
-  cuda-unsigned-integer-tests:
-    name: gpu_unsigned_integer_tests/cuda-unsigned-integer-tests
+  cuda-tests-linux:
+    name: gpu_memory_sanitizer_h100_2gpu_par/cuda-tests-linux
     needs: [ should-run, setup-instance ]
     if: github.event_name != 'pull_request' ||
       (github.event_name == 'pull_request' && needs.setup-instance.result != 'skipped')
     concurrency:
       group: ${{ github.workflow_ref }}
-      cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+      cancel-in-progress: false
     runs-on: ${{ needs.setup-instance.outputs.runner-name }}
+    timeout-minutes: 600
     strategy:
       fail-fast: false
-      # explicit include-based build matrix, of known valid options
       matrix:
         include:
           - os: ubuntu-22.04
@@ -132,30 +124,74 @@ jobs:
           gcc-version: ${{ matrix.gcc }}
           cloud-provider: ${{ needs.setup-instance.outputs.cloud-provider }}
 
+      - name: Ensure compute-sanitizer 12.8 is installed
+        run: |
+          if command -v compute-sanitizer > /dev/null 2>&1 \
+              && compute-sanitizer --version 2>&1 | grep -q "2025"; then
+            echo "compute-sanitizer 12.8 already installed"
+          else
+            echo "Installing compute-sanitizer 12.8 via apt..."
+            sudo apt-get install -y cuda-sanitizer-12-8
+            echo "/usr/local/cuda-12.8/bin" >> "${GITHUB_PATH}"
+          fi
+          which compute-sanitizer
+          compute-sanitizer --version
+
       - name: Install latest stable
         uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # zizmor: ignore[stale-action-refs] this action doesn't create releases
         with:
           toolchain: stable
+
+      - name: Check GPU count
+        run: |
+          GPU_COUNT=$(nvidia-smi --query-gpu=name --format=csv,noheader | wc -l)
+          echo "Found ${GPU_COUNT} GPU(s)"
+          [ "${GPU_COUNT}" -ge 2 ] || { echo "Error: at least 2 GPUs required"; exit 1; }
+
       - name: Enable nvidia multi-process service
         run: |
           nvidia-cuda-mps-control -d
-      - name: Should run nightly tests
-        if: github.event_name == 'schedule'
-        run: |
-          {
-            echo "FAST_TESTS=FALSE";
-            echo "NIGHTLY_TESTS=TRUE";
-          } >> "${GITHUB_ENV}"
 
-      - name: Run unsigned integer multi-bit tests
+      - name: Install cargo-nextest
+        run: make install_cargo_nextest
+
+      - name: Run memcheck and racecheck in parallel
         run: |
-          make test_unsigned_integer_multi_bit_gpu_ci
+          run_memcheck() {
+            local rc=0
+            CUDA_VISIBLE_DEVICES=0 make test_high_level_api_gpu_memcheck || rc=$?
+            echo "${rc}" > /tmp/memcheck.rc
+          }
+          run_racecheck() {
+            local rc=0
+            CUDA_VISIBLE_DEVICES=1 make test_gpu_racecheck || rc=$?
+            echo "${rc}" > /tmp/racecheck.rc
+          }
+          run_memcheck 2>&1 | sed -u 's/^/[memcheck]  /' &
+          PID0=$!
+          run_racecheck 2>&1 | sed -u 's/^/[racecheck] /' &
+          PID1=$!
+          wait "${PID0}" || true
+          wait "${PID1}" || true
+
+          STATUS=0
+          for lane in memcheck racecheck; do
+            rc="$(cat "/tmp/${lane}.rc" 2>/dev/null || true)"
+            rc="${rc:-1}"
+            if [ "${rc}" -eq 0 ]; then
+              echo "${lane} passed"
+            else
+              echo "::error title=${lane}::exited with code ${rc}, see the lines prefixed with [${lane}] above"
+              STATUS=1
+            fi
+          done
+          exit "${STATUS}"
 
   slack-notify:
-    name: gpu_unsigned_integer_tests/slack-notify
-    needs: [ setup-instance, cuda-unsigned-integer-tests ]
+    name: gpu_memory_sanitizer_h100_2gpu_par/slack-notify
+    needs: [ setup-instance, cuda-tests-linux ]
     runs-on: ubuntu-latest
-    if: ${{ always() && needs.cuda-unsigned-integer-tests.result != 'skipped' && failure() }}
+    if: ${{ always() && needs.cuda-tests-linux.result != 'skipped' && failure() }}
     continue-on-error: true
     steps:
       - name: Set pull-request URL
@@ -170,16 +206,16 @@ jobs:
         if: env.SECRETS_AVAILABLE == 'true'
         uses: rtCamp/action-slack-notify@33ca3be66c6f378fe1610fd1d5258632dbed5e58
         env:
-          SLACK_COLOR: ${{ needs.cuda-unsigned-integer-tests.result }}
-          SLACK_MESSAGE: "Unsigned integer GPU tests finished with status: ${{ needs.cuda-unsigned-integer-tests.result }}. (${{ env.PULL_REQUEST_MD_LINK }}[action run](${{ env.ACTION_RUN_URL }}))"
+          SLACK_COLOR: ${{ needs.cuda-tests-linux.result }}
+          SLACK_MESSAGE: "GPU Memory Sanitizer (memcheck + racecheck parallel) finished with status: ${{ needs.cuda-tests-linux.result }}. (${{ env.PULL_REQUEST_MD_LINK }}[action run](${{ env.ACTION_RUN_URL }}))"
 
   teardown-instance:
-    name: gpu_unsigned_integer_tests/teardown-instance
+    name: gpu_memory_sanitizer_h100_2gpu_par/teardown-instance
     if: ${{ always() && needs.setup-instance.result == 'success' }}
-    needs: [ setup-instance, cuda-unsigned-integer-tests ]
+    needs: [ setup-instance, cuda-tests-linux ]
     runs-on: ubuntu-latest
     steps:
-      - name: Stop instance
+      - name: Stop remote instance
         id: stop-instance
         if: env.SECRETS_AVAILABLE == 'true'
         uses: zama-ai/slab-github-runner@d4a5bb6e2a4b8aa19a10f596d7f142006a7e2c21 # v1.6.3
@@ -195,4 +231,4 @@ jobs:
         uses: rtCamp/action-slack-notify@33ca3be66c6f378fe1610fd1d5258632dbed5e58
         env:
           SLACK_COLOR: ${{ job.status }}
-          SLACK_MESSAGE: "Instance teardown (cuda-unsigned-integer-tests) finished with status: ${{ job.status }}. (${{ env.ACTION_RUN_URL }})"
+          SLACK_MESSAGE: "Instance teardown (gpu_memory_sanitizer_h100_2gpu_par) finished with status: ${{ job.status }}. (${{ env.ACTION_RUN_URL }})"

--- a/.github/workflows/gpu_signed_integer_classic_tests.yml
+++ b/.github/workflows/gpu_signed_integer_classic_tests.yml
@@ -23,7 +23,6 @@ env:
 on:
   # Allows you to run this workflow manually from the Actions tab as an alternative.
   workflow_dispatch:
-  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/gpu_signed_integer_tests.yml
+++ b/.github/workflows/gpu_signed_integer_tests.yml
@@ -25,7 +25,6 @@ on:
   # Allows you to run this workflow manually from the Actions tab as an alternative.
   workflow_dispatch:
   pull_request:
-    types: [ labeled ]
 
 permissions:
   contents: read
@@ -75,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: should-run
     if: github.event_name != 'pull_request' ||
-      (github.event.action == 'labeled' && github.event.label.name == 'approved' && needs.should-run.outputs.gpu_test == 'true')
+      needs.should-run.outputs.gpu_test == 'true'
     outputs:
       runner-name: ${{ steps.start-remote-instance.outputs.label || steps.start-github-instance.outputs.runner_group }}
       cloud-provider: ${{ steps.start-remote-instance.outputs.cloud-provider || steps.start-github-instance.outputs.cloud-provider }}

--- a/.github/workflows/gpu_unsigned_integer_classic_tests.yml
+++ b/.github/workflows/gpu_unsigned_integer_classic_tests.yml
@@ -23,7 +23,6 @@ env:
 on:
   # Allows you to run this workflow manually from the Actions tab as an alternative.
   workflow_dispatch:
-  pull_request:
 
 permissions:
   contents: read

--- a/Makefile
+++ b/Makefile
@@ -961,15 +961,6 @@ test_cuda_backend:
 		"$(MAKE)" -j "$(CPU_COUNT)" && \
 		"$(MAKE)" test
 
-.PHONY: test_cuda_backend_race_check # Build and run selected CUDA backend tests with Compute Sanitizer racecheck
-test_cuda_backend_race_check:
-	mkdir -p "$(TFHECUDA_BUILD)" && \
-		cd "$(TFHECUDA_BUILD)" && \
-		cmake .. -DCMAKE_BUILD_TYPE=Release -DTFHE_CUDA_BACKEND_BUILD_TESTS=ON && \
-		"$(MAKE)" -j "$(CPU_COUNT)" test_tfhe_cuda_backend && \
-		compute-sanitizer --tool racecheck --target-processes all ./tests_and_benchmarks/tests/test_tfhe_cuda_backend \
-			--gtest_filter="*ClassicalProgrammableBootstrap*:*MultiBitProgrammableBootstrap*"
-
 .PHONY: test_zk_cuda_backend # Run the internal tests of the CUDA ZK backend
 test_zk_cuda_backend:
 	mkdir -p "$(ZKCUDA_BUILD)" && \
@@ -1034,10 +1025,21 @@ test_high_level_api_gpu_valgrind: install_cargo_nextest
 	export RUSTFLAGS="-C target-cpu=x86-64" && \
 	export CARGO_PROFILE="$(CARGO_PROFILE)" &&	scripts/check_memory_errors.sh --cpu
 
-.PHONY: test_high_level_api_gpu_sanitizer # Run the tests of the integer module with Debug flags for CUDA
-test_high_level_api_gpu_sanitizer: install_cargo_nextest
+.PHONY: test_high_level_api_gpu_memcheck # Run compute-sanitizer memcheck on high-level API GPU tests
+test_high_level_api_gpu_memcheck: install_cargo_nextest
 	export RUSTFLAGS="-C target-cpu=x86-64" && \
-	export CARGO_PROFILE="$(CARGO_PROFILE)" &&	scripts/check_memory_errors.sh --gpu
+	export CARGO_PROFILE="$(CARGO_PROFILE)" && scripts/check_memory_errors.sh --memcheck
+
+.PHONY: test_gpu_racecheck # Run compute-sanitizer racecheck on GPU tests (Rust u128 PBS + CUDA backend GTest PBS/KS)
+test_gpu_racecheck: install_cargo_nextest
+	mkdir -p "$(TFHECUDA_BUILD)" && \
+		cd "$(TFHECUDA_BUILD)" && \
+		cmake .. -DCMAKE_BUILD_TYPE=Release -DTFHE_CUDA_BACKEND_BUILD_TESTS=ON && \
+		"$(MAKE)" -j "$(CPU_COUNT)" test_tfhe_cuda_backend
+	export RUSTFLAGS="-C target-cpu=x86-64" && \
+	export CARGO_PROFILE="$(CARGO_PROFILE)" && \
+	SANITIZER_GTEST_EXE="$(CURDIR)/$(TFHECUDA_BUILD)/tests_and_benchmarks/tests/test_tfhe_cuda_backend" \
+		scripts/check_memory_errors.sh --racecheck
 
 .PHONY: test_zk_pok_gpu_sanitizer # Run compute-sanitizer memcheck on Rust zk-pok GPU tests
 test_zk_pok_gpu_sanitizer: install_cargo_nextest

--- a/backends/tfhe-cuda-backend/cuda/include/pbs/programmable_bootstrap.h
+++ b/backends/tfhe-cuda-backend/cuda/include/pbs/programmable_bootstrap.h
@@ -39,9 +39,9 @@ void cuda_backward_fft16x4x16_async(void *stream, uint32_t gpu_index,
                                     uint32_t total_polynomials);
 
 // Returns true iff the given GPU can run the FFT16x4x16 core, i.e. it has
-// compute capability 9.x (Hopper) or newer, whose named-barrier / mbarrier
-// primitives the core relies on. Lets callers (e.g. tests) gate the specialized
-// path at runtime instead of failing on older architectures.
+// compute capability 9.x (Hopper) or newer, the only architectures the core
+// is validated on. Lets callers (e.g. tests) gate the specialized path at
+// runtime instead of failing on older architectures.
 bool cuda_fft16x4x16_is_supported_async(uint32_t gpu_index);
 
 void cuda_convert_lwe_programmable_bootstrap_key_32_async(

--- a/backends/tfhe-cuda-backend/cuda/src/fft/bnsmfft.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/fft/bnsmfft.cuh
@@ -606,7 +606,6 @@ __global__ void batch_NSMFFT_classical_specialized(double2 *d_input,
 //   [0 .. TW_SMEM_DOUBLES-1]                   tw_1024 twiddle table (1920)
 //   [FFT16x4x16_DUAL_COMPACT_TW_OFFSET .. +101] compact_twiddles (102)
 //   [FFT16x4x16_DUAL_XPOSE0_OFFSET .. +2207]   xpose scratch (2208)
-//   [KB_BARRIER_OFFSET]                         mbarrier (1 storage double)
 //   [KB_TWIST_OFFSET .. +1025]                  negacyclic twist half-table
 template <class params>
 __global__ void batch_FFT16x4x16_classical_specialized(double2 *d_input,
@@ -618,12 +617,6 @@ __global__ void batch_FFT16x4x16_classical_specialized(double2 *d_input,
   const double *compact_twiddles = smem + FFT16x4x16_DUAL_COMPACT_TW_OFFSET;
   double *smem_xpose = smem + FFT16x4x16_DUAL_XPOSE0_OFFSET;
   double2 *smem_twist = reinterpret_cast<double2 *>(smem + KB_TWIST_OFFSET);
-  FFT16x4x16MBarrierStorage *barrier =
-      reinterpret_cast<FFT16x4x16MBarrierStorage *>(smem + KB_BARRIER_OFFSET);
-
-  // 64 threads / 32 lanes = 2 warps participate in each per-FFT barrier.
-  if (threadIdx.x == 0)
-    fft16x4x16_mbarrier_init_raw(barrier, 2u);
 
   // Load FFT twiddle table cooperatively (64 threads × 15 iters = 960 d2's).
   double2 *tw_shared_w = reinterpret_cast<double2 *>(smem);
@@ -668,9 +661,8 @@ __global__ void batch_FFT16x4x16_classical_specialized(double2 *d_input,
   }
 
   // Standard 1024-point FFT; output is in bit-reversed register order.
-  FFT16x4x16_fwd_core_mbarrier_explicit(a, tw_shared, smem_xpose,
-                                        compact_twiddles, barrier);
-  fft16x4x16_mbarrier_sync(barrier);
+  FFT16x4x16_fwd_core_named_barrier(a, tw_shared, smem_xpose, compact_twiddles);
+  sync_coupled_warps();
 
   // Persist a[j] at physical index tid + j*64 — see layout comment at the top.
   //
@@ -686,7 +678,7 @@ __global__ void batch_FFT16x4x16_classical_specialized(double2 *d_input,
 
 // Shared-memory footprint of batch_FFT16x4x16_classical_specialized.
 //   KB_TWIST_OFFSET doubles + 513 double2 entries
-//   = 4232 * 8 + 513 * 16 = 33856 + 8208 = 42064 bytes  (≈41 KB)
+//   = 4230 * 8 + 513 * 16 = 33840 + 8208 = 42048 bytes  (≈41 KB)
 static constexpr size_t BATCH_FFT16X4X16_BSK_SMEM_BYTES =
     static_cast<size_t>(KB_TWIST_OFFSET) * sizeof(double) +
     513 * sizeof(double2);
@@ -771,7 +763,7 @@ __global__ void batch_polynomial_mul(double2 *d_input1, double2 *d_input2,
 // PBS (FFT16x4x16_fwd/inv_optimized_for_pbs). Hardcoded to N = 2048
 // (N/2 = 1024 = 16×64) and to a single 64-thread FFT group per block.
 //
-// REQUIRES sm_90 (H100): the optimized cores rely on named-barrier / mbarrier
+// REQUIRES sm_90 (H100): the optimized cores rely on named-barrier
 // primitives only available there.
 //
 // Data flow (mirrors the production PBS exactly):
@@ -893,7 +885,7 @@ batch_polynomial_mul_fft16x4x16(const double2 *__restrict__ d_input1,
 // specialized 2_2_params PBS). Hardcoded to N = 2048 (N/2 = 1024 = 16×64), one
 // 64-thread FFT group per block.
 //
-// REQUIRES sm_90 (H100): the optimized core relies on named-barrier / mbarrier
+// REQUIRES sm_90 (H100): the optimized core relies on named-barrier
 // primitives only available there.
 //
 // Output layout: the spectrum is written in NATURAL frequency order. The
@@ -983,7 +975,7 @@ __global__ void batch_forward_fft16x4x16(const double2 *__restrict__ d_input,
 // by the specialized 2_2_params PBS). Hardcoded to N = 2048 (N/2 = 1024 =
 // 16×64), one 64-thread FFT group per block.
 //
-// REQUIRES sm_90 (H100): the optimized core relies on named-barrier / mbarrier
+// REQUIRES sm_90 (H100): the optimized core relies on named-barrier
 // primitives only available there.
 //
 // This is the clean inverse of batch_forward_fft16x4x16 and uses the SAME

--- a/backends/tfhe-cuda-backend/cuda/src/fft/fft16x4x16.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/fft/fft16x4x16.cuh
@@ -382,8 +382,9 @@ static inline __device__ void mul_itwiddles_4x4_regs(double2 *a, double2 w1,
 //
 //  Dual-FFT variant (128-thread block, threadIdx.y=0/1 selects FFT group):
 //    Shared twiddle table (row 0) + compact_twiddles (1 copy, shared by both
-//    groups) Each group gets its own xpose scratch area and mbarrier storage.
-//    A startup mbarrier gates the twiddle-load phase.
+//    groups) Each group gets its own xpose scratch area; cross-warp syncs use
+//    named barriers, so no per-group barrier storage is reserved in smem.
+//    A __syncthreads() gates the twiddle-load phase.
 // ============================================================================
 static constexpr int TW_SMEM_DOUBLES =
     2 * 15 * 64; // 1920 doubles = 15360 bytes
@@ -400,44 +401,25 @@ static constexpr int TWIST_HALF_SMEM_OFFSET =
 // (N/2 + 1) for the 1024-point (16×4×16) FFT, i.e. 1024/2 + 1 = 513.
 static constexpr int FFT16x4x16_TWIST_HALF_TABLE_SIZE = 513;
 
-struct alignas(8) FFT16x4x16MBarrierStorage {
-  unsigned long long barrier;
-};
-
-static_assert(sizeof(FFT16x4x16MBarrierStorage) % sizeof(double) == 0,
-              "FFT16x4x16MBarrierStorage must stay double-aligned");
-
-static constexpr int FFT16x4x16_MBARRIER_STORAGE_DOUBLES =
-    sizeof(FFT16x4x16MBarrierStorage) / sizeof(double);
-
 // Dual smem offsets: one shared twiddle table then two independent xpose areas
-// + two per-group PONG xpose areas (ping-pong for fwd FFT barrier elimination)
-// + two per-group mbarriers + one startup mbarrier.
+// + two per-group PONG xpose areas (ping-pong for fwd FFT barrier elimination).
 //
-// PONG insertion is between XPOSE1 and BARRIER0 so KB_* (single-FFT keybundle
-// layout, built from XPOSE0 only) is unaffected.
+// Cross-warp synchronisation uses named barriers (see sync_coupled_warps),
+// which are hardware CTA barriers and need no shared-memory storage.
 static constexpr int FFT16x4x16_DUAL_COMPACT_TW_OFFSET = TW_SMEM_DOUBLES;
 static constexpr int FFT16x4x16_DUAL_XPOSE0_OFFSET =
     FFT16x4x16_DUAL_COMPACT_TW_OFFSET + COMPACT_TW_SMEM_DOUBLES;
 static constexpr int FFT16x4x16_DUAL_XPOSE1_OFFSET =
     FFT16x4x16_DUAL_XPOSE0_OFFSET + XPOSE_SMEM_DOUBLES;
 // PONG xpose buffers for ping-pong fwd FFT (1 per y-group, same size as ping).
-// Used to eliminate the explicit mbarrier between mul_twiddles_4x4_regs and
-// permute_4x4 and the post-FFT mbarrier before smem_comm publish.
+// Used to eliminate the explicit sync between mul_twiddles_4x4_regs and
+// permute_4x4 and the post-FFT sync before smem_comm publish.
 static constexpr int FFT16x4x16_DUAL_XPOSE0_PONG_OFFSET =
     FFT16x4x16_DUAL_XPOSE1_OFFSET + XPOSE_SMEM_DOUBLES;
 static constexpr int FFT16x4x16_DUAL_XPOSE1_PONG_OFFSET =
     FFT16x4x16_DUAL_XPOSE0_PONG_OFFSET + XPOSE_SMEM_DOUBLES;
-static constexpr int FFT16x4x16_DUAL_BARRIER0_OFFSET =
-    FFT16x4x16_DUAL_XPOSE1_PONG_OFFSET + XPOSE_SMEM_DOUBLES;
-static constexpr int FFT16x4x16_DUAL_BARRIER1_OFFSET =
-    FFT16x4x16_DUAL_BARRIER0_OFFSET + FFT16x4x16_MBARRIER_STORAGE_DOUBLES;
-static constexpr int FFT16x4x16_DUAL_STARTUP_BARRIER_OFFSET =
-    FFT16x4x16_DUAL_BARRIER1_OFFSET + FFT16x4x16_MBARRIER_STORAGE_DOUBLES;
-// Padding double so the negacyclic twist table (double2) is 16-byte aligned.
 static constexpr int FFT16x4x16_DUAL_TWIST_OFFSET =
-    FFT16x4x16_DUAL_STARTUP_BARRIER_OFFSET +
-    FFT16x4x16_MBARRIER_STORAGE_DOUBLES + 1;
+    FFT16x4x16_DUAL_XPOSE1_PONG_OFFSET + XPOSE_SMEM_DOUBLES;
 static_assert((FFT16x4x16_DUAL_TWIST_OFFSET * sizeof(double)) %
                       sizeof(double2) ==
                   0,
@@ -452,27 +434,9 @@ static_assert(FFT16x4x16_DUAL_SMEM_BYTES <= 114u * 1024u,
               "dual FFT16x4x16 smem layout exceeds the per-block budget");
 
 // ============================================================================
-//  mbarrier helpers — SM90+ uses hardware mbarrier for intra-warp-group sync;
-//  older architectures fall back to __syncthreads().
+//  Cross-warp synchronisation — a partial (named) barrier over the 64 threads
+//  of one FFT y-group, so the sibling y-group is never stalled.
 // ============================================================================
-// expected_count must equal the number of warps that sync on this barrier:
-// fft16x4x16_mbarrier_sync arrives once per warp (lane 0 only).
-static __device__ __forceinline__ void
-fft16x4x16_mbarrier_init_raw(FFT16x4x16MBarrierStorage *storage,
-                             unsigned expected_count) {
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
-  asm volatile(
-      "mbarrier.init.shared.b64 [%0], %1;"
-      :
-      : "r"(static_cast<unsigned>(__cvta_generic_to_shared(&storage->barrier))),
-        "r"(expected_count)
-      : "memory");
-#else
-  (void)storage;
-  (void)expected_count;
-#endif
-}
-
 static __device__ __forceinline__ void
 fft16x4x16_named_barrier_sync(unsigned barrier_id, unsigned thread_count) {
 #if defined(__CUDA_ARCH__)
@@ -483,9 +447,11 @@ fft16x4x16_named_barrier_sync(unsigned barrier_id, unsigned thread_count) {
 #endif
 }
 
-// Partial named-barrier sync over one 64-thread FFT y-group (2 warps). Drop-in
-// replacement for the mbarrier arrive/test_wait spin used by the production
-// ping-pong cores. y-group g (= threadIdx.y) uses named barrier id (g+1):
+// Partial named-barrier sync over one 64-thread FFT y-group (2 warps).
+// Named barriers are hardware CTA barriers: the participant count is an
+// operand of every bar.sync and the barrier self-resets, so unlike an mbarrier
+// there is nothing to allocate in shared memory and nothing to initialise.
+// y-group g (= threadIdx.y) uses named barrier id (g+1):
 // groups use ids 1 and 2 — id 0 is reserved for __syncthreads() (== bar.sync
 // 0). 64 = 2 warps; bar.sync carries the CTA-scope shared-memory fence the
 // transpose store -> sibling-warp-load relies on.
@@ -493,107 +459,14 @@ static __device__ __forceinline__ void sync_coupled_warps() {
   fft16x4x16_named_barrier_sync(threadIdx.y + 1u, 64u);
 }
 
-// Barrier synchronization between two warps of the same 64-thread FFT group.
-// On SM90+ uses the mbarrier arrive/wait protocol to avoid full __syncthreads()
-// (which would stall all 128 threads in the block).
-static __device__ __forceinline__ void
-fft16x4x16_mbarrier_sync(FFT16x4x16MBarrierStorage *storage) {
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
-  constexpr unsigned warp_mask = 0xffffffffu;
-  const int lane = threadIdx.x & 31;
-  const unsigned barrier_addr =
-      static_cast<unsigned>(__cvta_generic_to_shared(&storage->barrier));
-
-  __syncwarp(warp_mask);
-
-  unsigned long long token = 0;
-  if (lane == 0) {
-    asm volatile("mbarrier.arrive.release.cta.shared::cta.b64 %0, [%1];"
-                 : "=l"(token)
-                 : "r"(barrier_addr)
-                 : "memory");
-  }
-
-  int ready = 0;
-  do {
-    if (lane == 0) {
-      asm volatile(
-          "{\n\t"
-          ".reg .pred p;\n\t"
-          "mbarrier.test_wait.acquire.cta.shared::cta.b64 p, [%1], %2;\n\t"
-          "selp.b32 %0, 1, 0, p;\n\t"
-          "}"
-          : "=r"(ready)
-          : "r"(barrier_addr), "l"(token)
-          : "memory");
-    }
-    ready = __shfl_sync(warp_mask, ready, 0);
-  } while (!ready);
-
-  __syncwarp(warp_mask);
-#else
-  (void)storage;
-  __syncthreads();
-#endif
-}
-
 // ============================================================================
 //  Transpose helpers (shared-memory shuffles between FFT stages)
 //
-//  permute_16x64_mbarrier: 16×64 matrix transpose after the first FFT16 pass.
-//    Store pitch 65, stride 4 → smem[lo4*65 + hi4 + i*4]; read indirect.
-//  permute_4x4_mbarrier: 4×4 block transpose after the FFT4x4 pass.
-//    Store pitch 69; read stride 1.
-//  Both variants use fft16x4x16_mbarrier_sync (per-group) instead of
-//  __syncthreads.
+//  permute_16x64_optimized: 16×64 matrix transpose after the first FFT16 pass.
+//  permute_4x4_optimized:   4×4 block transpose after the FFT4x4 pass.
+//  Both hand data between the two warps of a y-group and therefore close with
+//  sync_coupled_warps() rather than __syncthreads().
 // ============================================================================
-static inline __device__ void
-permute_16x64_mbarrier(double2 *a, double *smem,
-                       FFT16x4x16MBarrierStorage *barrier) {
-  double *smem_re = smem, *smem_im = smem + 69 * 16;
-  int lo4 = threadIdx.x & 15;
-  int hi4 = threadIdx.x >> 4;
-  int sb = lo4 * 65 + hi4;
-  int lb = lo4 * 65 + (hi4 << 2);
-
-#pragma unroll
-  for (int i = 0; i < 16; i++) {
-    int ri = ((i & 1) << 3) | ((i & 2) << 1) | ((i & 4) >> 1) | ((i & 8) >> 3);
-    smem_re[sb + (i << 2)] = a[ri].x;
-    smem_im[sb + (i << 2)] = a[ri].y;
-  }
-  fft16x4x16_mbarrier_sync(barrier);
-#pragma unroll
-  for (int i = 0; i < 16; i++) {
-    int li = lb + (i >> 2) * 16 + (i & 3);
-    a[i].x = smem_re[li];
-    a[i].y = smem_im[li];
-  }
-}
-
-static inline __device__ void
-permute_4x4_mbarrier(double2 *a, double *smem,
-                     FFT16x4x16MBarrierStorage *barrier) {
-  double *smem_re = smem, *smem_im = smem + 69 * 16;
-  int lo2 = threadIdx.x & 3;
-  int mi2 = (threadIdx.x >> 2) & 3;
-  int hi2 = threadIdx.x >> 4;
-  int sb = hi2 * 17 + (mi2 << 2) + lo2;
-  int lb = mi2 * 276 + hi2 * 69 + lo2 * 17;
-
-#pragma unroll
-  for (int i = 0; i < 16; i++) {
-    int ri = (i & 12) | ((i & 1) << 1) | ((i & 2) >> 1);
-    smem_re[sb + i * 69] = a[ri].x;
-    smem_im[sb + i * 69] = a[ri].y;
-  }
-  fft16x4x16_mbarrier_sync(barrier);
-#pragma unroll
-  for (int i = 0; i < 16; i++) {
-    a[i].x = smem_re[lb + i];
-    a[i].y = smem_im[lb + i];
-  }
-}
 // Performs the data permutation using specialized barriers
 static inline __device__ void permute_16x64_optimized(double2 *a,
                                                       double *smem) {
@@ -620,8 +493,7 @@ static inline __device__ void permute_16x64_optimized(double2 *a,
 // Permutation for the 4xfft-4 using specialized barriers.
 //
 // Transposes the 4x4 blocks between the FFT4x4 and the final FFT16 pass, in
-// smem, using the same double2 grid as its mbarrier twin
-// (permute_4x4_mbarrier).
+// smem, using a double2 grid.
 //
 // The 64-lane group id splits into three radix-4 digits:
 //   tid = hi2*16 + mi2*4 + lo2   (lo2,mi2,hi2 each in 0..3)
@@ -657,7 +529,7 @@ static inline __device__ void permute_4x4_optimized(double2 *a, double *smem) {
 
 // ============================================================================
 //  FFT16x4x16 core — operates on 16 registers per thread; smem pointers must
-//  be the per-group xpose area and barrier, not the full smem base.
+//  be the per-group xpose area, not the full smem base.
 //
 //  Forward: FFT16 → inter-stage twiddles → 16x64 transpose → FFT4x4 →
 //           compact twiddles → sync → 4x4 transpose → FFT16.
@@ -666,17 +538,22 @@ static inline __device__ void permute_4x4_optimized(double2 *a, double *smem) {
 //  NOTE: output registers are in bit-reversed order d_rev<16>(j).  Callers
 //  that do not reorder on output get results in "scrambled" order.
 // ============================================================================
-static __device__ void FFT16x4x16_fwd_core_mbarrier_explicit(
-    double2 *a, const double2 *tw, double *smem_xpose,
-    const double *compact_twiddles, FFT16x4x16MBarrierStorage *barrier) {
+// Single-buffer forward core: the full stage sequence over one xpose scratch,
+// with every cross-warp handoff going through sync_coupled_warps() (bar.sync
+// over the 64-thread group). Used by the keybundle FFT, which runs one FFT per
+// block and has no second buffer to ping-pong against.
+static __device__ void
+FFT16x4x16_fwd_core_named_barrier(double2 *a, const double2 *tw,
+                                  double *smem_xpose,
+                                  const double *compact_twiddles) {
   int tid = threadIdx.x;
   FFT16(a);
   mul_twiddles_16(a, tid, tw);
-  permute_16x64_mbarrier(a, smem_xpose, barrier);
+  permute_16x64_optimized(a, smem_xpose);
   FFT4x4(a);
   mul_twiddles_4x4(a, compact_twiddles);
-  fft16x4x16_mbarrier_sync(barrier);
-  permute_4x4_mbarrier(a, smem_xpose, barrier);
+  sync_coupled_warps();
+  permute_4x4_optimized(a, smem_xpose);
   FFT16(a);
 }
 
@@ -709,7 +586,7 @@ apply_negacyclic_pre_twist_16x64_stage_fused(double2 *a,
 // unchanged and the inverse path keeps its smem_twist-based untwist with no
 // modification. Ping-pong is preserved: PING (smem_xpose_ping) holds the
 // permute_16x64 transpose, PONG (smem_xpose_pong) the permute_4x4 transpose,
-// and the mid-FFT explicit mbarrier stays dropped (permute_4x4 writes PONG → no
+// and the mid-FFT explicit sync stays dropped (permute_4x4 writes PONG → no
 // WAR on PING).
 static __device__ void FFT16x4x16_fwd_optimized_for_pbs(
     double2 *a, const double2 *tw, const double2 *smem_twist,
@@ -724,7 +601,7 @@ static __device__ void FFT16x4x16_fwd_optimized_for_pbs(
       a, smem_xpose_ping); // STS→PING, LDS←PING (named bar.sync)
   FFT4x4(a);
   mul_twiddles_4x4_regs(a, compact_w1, compact_w2, compact_w3);
-  // [explicit mbarrier dropped — permute_4x4 below writes to PONG, no WAR on
+  // [explicit sync dropped — permute_4x4 below writes to PONG, no WAR on
   // PING]
   permute_4x4_optimized(a,
                         smem_xpose_pong); // STS→PONG, LDS←PONG (named bar.sync)
@@ -769,8 +646,8 @@ apply_negacyclic_post_twist_16x64_stage_fused(double2 *a,
 // bit-reversed time-domain registers at the end, replacing the kernel's
 // separate twist_lookup loop. Mathematically identical, still reads smem_twist;
 // ping-pong (PING for permute_16x64, PONG for permute_4x4) and the dropped
-// mid-FFT mbarrier unchanged. The post-twist is register-only besides the
-// read-only smem_twist loads, so the dropped post-IFFT mbarrier reasoning still
+// mid-FFT sync unchanged. The post-twist is register-only besides the
+// read-only smem_twist loads, so the dropped post-IFFT sync reasoning still
 // holds.
 static __device__ void FFT16x4x16_inv_optimized_for_pbs(
     double2 *a, const double2 *tw, const double2 *smem_twist,
@@ -784,7 +661,7 @@ static __device__ void FFT16x4x16_inv_optimized_for_pbs(
       a, smem_xpose_ping); // STS→PING, LDS←PING (named bar.sync)
   IFFT4x4(a);
   mul_itwiddles_4x4_regs(a, compact_w1, compact_w2, compact_w3);
-  // [explicit mbarrier dropped — permute_4x4 below writes to PONG, no WAR on
+  // [explicit sync dropped — permute_4x4 below writes to PONG, no WAR on
   // PING]
   permute_4x4_optimized(a,
                         smem_xpose_pong); // STS→PONG, LDS←PONG (named bar.sync)
@@ -796,8 +673,8 @@ static __device__ void FFT16x4x16_inv_optimized_for_pbs(
 //  Dual-block twiddle loader (128-thread block: threadIdx.y=0/1 selects group)
 //
 //  Loads tw_1024[15][64] and compact_twiddles into the shared region that
-//  both FFT groups (y=0 and y=1) share.  Callers must synchronize (via the
-//  startup mbarrier) before calling the core functions.
+//  both FFT groups (y=0 and y=1) share.  Callers must synchronize (with
+//  __syncthreads()) before calling the core functions.
 // ============================================================================
 static __device__ __forceinline__ void
 fft16x4x16_load_shared_twiddles_128t(double *smem) {
@@ -836,10 +713,8 @@ static inline __device__ double2 twist_lookup(const double2 *smem_twist,
   return make_double2(-t.y, -t.x);
 }
 
-// Total shared memory before the barriers
-static constexpr int KB_BARRIER_OFFSET =
-    FFT16x4x16_DUAL_XPOSE0_OFFSET + XPOSE_SMEM_DOUBLES; // 4230
-
 // Total shared memory before the twisting layer
 static constexpr int KB_TWIST_OFFSET =
-    KB_BARRIER_OFFSET + FFT16x4x16_MBARRIER_STORAGE_DOUBLES + 1; // 4232
+    FFT16x4x16_DUAL_XPOSE0_OFFSET + XPOSE_SMEM_DOUBLES; // 4230
+static_assert((KB_TWIST_OFFSET * sizeof(double)) % sizeof(double2) == 0,
+              "keybundle twist table must be 16-byte aligned");

--- a/backends/tfhe-cuda-backend/cuda/src/pbs/bootstrapping_key.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/pbs/bootstrapping_key.cu
@@ -378,8 +378,8 @@ void cuda_backward_fft16x4x16_async(void *stream, uint32_t gpu_index,
 bool cuda_fft16x4x16_is_supported_async(uint32_t gpu_index) {
   cudaDeviceProp prop{};
   cudaError_t err = cudaGetDeviceProperties(&prop, gpu_index);
-  // sm_90 (Hopper) or newer: the FFT16x4x16 core needs the named-barrier /
-  // mbarrier primitives introduced with compute capability 9.x.
+  // sm_90 (Hopper) or newer: the FFT16x4x16 core is only validated on
+  // compute capability 9.x and above.
   return err == cudaSuccess && prop.major >= 9;
 }
 

--- a/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_classic.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/pbs/programmable_bootstrap_classic.cuh
@@ -54,8 +54,7 @@ uint64_t get_buffer_size_full_sm_programmable_bootstrap_specialized_2_2_params(
 //   [FFT16x4x16_DUAL_COMPACT_TW_OFFSET ..]          compact_twiddles (102)
 //   [FFT16x4x16_DUAL_XPOSE0_OFFSET ..]              xpose0 / comm0 / final_acc0
 //   [FFT16x4x16_DUAL_XPOSE1_OFFSET ..]              xpose1 / comm1 / final_acc1
-//   [FFT16x4x16_DUAL_BARRIER0_OFFSET ..]            barrier0 / barrier1 /
-//   startup [FFT16x4x16_DUAL_TWIST_OFFSET ..]               twist half-table
+//   [FFT16x4x16_DUAL_TWIST_OFFSET ..]               twist half-table
 //   (1026) [SMEM_ACC_OFFSET_DOUBLES ..]                    Torus (uint64)
 //   running acc
 //                                                    storage (2 × 2048 u64 →
@@ -67,7 +66,7 @@ uint64_t get_buffer_size_full_sm_programmable_bootstrap_specialized_2_2_params(
 //      (other_fft_ptr in the GGSW helper);
 //   3. final uint64 accumulator on the last loop iteration, read by
 //      sample_extract_mask / sample_extract_body.
-// All three uses are sequenced by __syncthreads / mbarrier syncs in the
+// All three uses are sequenced by __syncthreads / sync_coupled_warps in the
 // kernel; they never overlap in time.
 // ─────────────────────────────────────────────────────────────────────────────
 static constexpr int
@@ -409,7 +408,7 @@ device_programmable_bootstrap_specialized_2_2_params_throughput(
   const double *compact_twiddles = smem + FFT16x4x16_DUAL_COMPACT_TW_OFFSET;
   double *smem_xpose = smem + (fft_id == 0 ? FFT16x4x16_DUAL_XPOSE0_OFFSET
                                            : FFT16x4x16_DUAL_XPOSE1_OFFSET);
-  // PONG buffer for the fwd-FFT ping-pong path (eliminates 2 mbarrier_syncs per
+  // PONG buffer for the fwd-FFT ping-pong path (eliminates 2 group syncs per
   // fwd call). PING is `smem_xpose` above; PONG is the symmetric extra slot.
   double *smem_xpose_pong =
       smem + (fft_id == 0 ? FFT16x4x16_DUAL_XPOSE0_PONG_OFFSET
@@ -468,7 +467,7 @@ device_programmable_bootstrap_specialized_2_2_params_throughput(
   // Cooperative twiddle / compact_twiddles load (128-thread loader).
   fft16x4x16_load_shared_twiddles_128t(smem);
   // Block-wide startup sync (all 4 warps). Per-group FFT syncs use named ids
-  // 1/2 (see sync_coupled_warps), so no mbarrier init is needed.
+  // 1/2 (see sync_coupled_warps), which need no initialization.
   __syncthreads();
 
   // Preload the 3 compact 4×4 twiddles into per-thread registers (one-time

--- a/backends/tfhe-cuda-backend/cuda/tests_and_benchmarks/include/utils.h
+++ b/backends/tfhe-cuda-backend/cuda/tests_and_benchmarks/include/utils.h
@@ -2,8 +2,16 @@
 #define UTILS_H
 
 #include "tfhe.h"
+#include <algorithm>
+#include <cstdlib>
+#include <cstring>
 #include <device.h>
 #include <functional>
+
+inline bool is_sanitizer_run() {
+  const char *v = std::getenv("TFHE_RS_COMPUTE_SANITIZER");
+  return v != nullptr && std::strcmp(v, "1") == 0;
+}
 
 typedef struct Seed {
   uint64_t lo;

--- a/backends/tfhe-cuda-backend/cuda/tests_and_benchmarks/tests/test_classical_pbs.cpp
+++ b/backends/tfhe-cuda-backend/cuda/tests_and_benchmarks/tests/test_classical_pbs.cpp
@@ -63,6 +63,8 @@ protected:
       int8_t *pbs_buffer) {
     int bsk_size = (glwe_dimension + 1) * (glwe_dimension + 1) * pbs_level *
                    polynomial_size * (lwe_dimension + 1);
+    const int eff_inputs =
+        is_sanitizer_run() ? std::min(number_of_inputs, 2) : number_of_inputs;
 
     for (int r = 0; r < repetitions; r++) {
       double *d_fourier_bsk = d_fourier_bsk_array + (ptrdiff_t)(bsk_size * r);
@@ -78,11 +80,11 @@ protected:
 
         cuda_memcpy_async_to_cpu(lwe_ct_out_array, d_lwe_ct_out_array,
                                  (glwe_dimension * polynomial_size + 1) *
-                                     number_of_inputs * sizeof(uint64_t),
+                                     eff_inputs * sizeof(uint64_t),
                                  stream, gpu_index);
         cuda_synchronize_stream(stream, gpu_index);
 
-        for (int j = 0; j < number_of_inputs; j++) {
+        for (int j = 0; j < eff_inputs; j++) {
           uint64_t *result =
               lwe_ct_out_array +
               (ptrdiff_t)(j * (glwe_dimension * polynomial_size + 1));

--- a/backends/tfhe-cuda-backend/cuda/tests_and_benchmarks/tests/test_keyswitch.cpp
+++ b/backends/tfhe-cuda-backend/cuda/tests_and_benchmarks/tests/test_keyswitch.cpp
@@ -1,6 +1,7 @@
 #include "checked_arithmetic.h"
 #include "device.h"
 #include "helper_multi_gpu.h"
+#include <algorithm>
 #include <cmath>
 #include <cstdint>
 #include <gtest/gtest.h>
@@ -84,14 +85,18 @@ public:
 };
 
 TEST_P(KeyswitchTestPrimitives_u64, keyswitch) {
+  const uint eff_reps = is_sanitizer_run() ? 1u : REPETITIONS;
+  const uint eff_samples = is_sanitizer_run() ? 1u : SAMPLES;
+  const int eff_inputs =
+      is_sanitizer_run() ? std::min(number_of_inputs, 2) : number_of_inputs;
   uint64_t *lwe_out_ct = (uint64_t *)malloc(safe_mul_sizeof<uint64_t>(
-      (size_t)(output_lwe_dimension + 1), (size_t)number_of_inputs));
-  for (uint r = 0; r < REPETITIONS; r++) {
+      (size_t)(output_lwe_dimension + 1), (size_t)eff_inputs));
+  for (uint r = 0; r < eff_reps; r++) {
     uint64_t *lwe_out_sk =
         lwe_sk_out_array + (ptrdiff_t)(r * output_lwe_dimension);
     int ksk_size = ksk_level * (output_lwe_dimension + 1) * input_lwe_dimension;
     uint64_t *d_ksk = d_ksk_array + (ptrdiff_t)(ksk_size * r);
-    for (uint s = 0; s < SAMPLES; s++) {
+    for (uint s = 0; s < eff_samples; s++) {
       uint64_t *d_lwe_ct_in =
           d_lwe_ct_in_array +
           (ptrdiff_t)((r * SAMPLES * number_of_inputs + s * number_of_inputs) *
@@ -101,16 +106,15 @@ TEST_P(KeyswitchTestPrimitives_u64, keyswitch) {
           stream, gpu_index, (void *)d_lwe_ct_out_array,
           (void *)lwe_output_indexes, (void *)d_lwe_ct_in,
           (void *)lwe_input_indexes, (void *)d_ksk, input_lwe_dimension,
-          output_lwe_dimension, ksk_base_log, ksk_level, number_of_inputs,
-          false);
+          output_lwe_dimension, ksk_base_log, ksk_level, eff_inputs, false);
 
       // Copy result back
       cuda_memcpy_async_to_cpu(
           lwe_out_ct, d_lwe_ct_out_array,
-          safe_mul_sizeof<uint64_t>((size_t)number_of_inputs,
+          safe_mul_sizeof<uint64_t>((size_t)eff_inputs,
                                     (size_t)(output_lwe_dimension + 1)),
           stream, gpu_index);
-      for (int i = 0; i < number_of_inputs; i++) {
+      for (int i = 0; i < eff_inputs; i++) {
         uint64_t plaintext = plaintexts[r * SAMPLES * number_of_inputs +
                                         s * number_of_inputs + i];
         uint64_t decrypted = 0;

--- a/backends/tfhe-cuda-backend/cuda/tests_and_benchmarks/tests/test_multibit_pbs.cpp
+++ b/backends/tfhe-cuda-backend/cuda/tests_and_benchmarks/tests/test_multibit_pbs.cpp
@@ -67,6 +67,8 @@ protected:
     int bsk_size = (lwe_dimension / grouping_factor) * pbs_level *
                    (glwe_dimension + 1) * (glwe_dimension + 1) *
                    polynomial_size * (1 << grouping_factor);
+    const int eff_inputs =
+        is_sanitizer_run() ? std::min(number_of_inputs, 2) : number_of_inputs;
 
     for (int r = 0; r < repetitions; r++) {
       uint64_t *d_bsk = d_bsk_array + (ptrdiff_t)(bsk_size * r);
@@ -82,11 +84,11 @@ protected:
 
         cuda_memcpy_async_to_cpu(lwe_ct_out_array, d_lwe_ct_out_array,
                                  (glwe_dimension * polynomial_size + 1) *
-                                     number_of_inputs * sizeof(uint64_t),
+                                     eff_inputs * sizeof(uint64_t),
                                  stream, gpu_index);
         cuda_synchronize_stream(stream, gpu_index);
 
-        for (int j = 0; j < number_of_inputs; j++) {
+        for (int j = 0; j < eff_inputs; j++) {
           uint64_t *result =
               lwe_ct_out_array +
               (ptrdiff_t)(j * (glwe_dimension * polynomial_size + 1));

--- a/ci/gpu_workflows_table.py
+++ b/ci/gpu_workflows_table.py
@@ -33,11 +33,13 @@ WORKFLOWS = [
     "gpu_code_validation_tests",
     "gpu_memory_sanitizer",
     "gpu_memory_sanitizer_h100",
+    "gpu_memory_sanitizer_h100_2gpu_par",
     "gpu_noise_level_checks",
     "gpu_zk_tests",
     "gpu_zk_long_run_tests",
     "gpu_zk_code_validation_tests",
     "gpu_zk_memory_sanitizer",
+    "gpu_protocol_stress_h100_tests",
 ]
 
 
@@ -150,8 +152,7 @@ def parse_workflow(path: Path, slab: dict) -> dict:
         "PR on approved": "yes" if pr_approved else "",
         "Cron": cron,
         "Manual only": "yes" if manual_only else "",
-        "Profile (instance)": f"{profile} ({instance_type})" if profile else "",
-        "Fallbacks": " | ".join(fallbacks),
+        "Profile (instance)": instance_type if profile else "",
         "_test_targets": extract_test_targets(text),
     }
 
@@ -173,6 +174,12 @@ TEST_TARGETS = [
     "test_signed_integer_multi_bit_gpu_ci",
     "test_unsigned_integer_gpu_ci",
     "test_unsigned_integer_multi_bit_gpu_ci",
+    "test_protocol_stress_gpu",
+    "test_protocol_long_run_gpu",
+    "test_high_level_api_gpu_valgrind",
+    "test_high_level_api_gpu_sanitizer",
+    "test_high_level_api_gpu_memcheck",
+    "test_gpu_racecheck",
     "test_user_doc_gpu",
     "test_c_api_gpu",
     "test_integer_zk_experimental_gpu",
@@ -186,9 +193,6 @@ TEST_TARGETS = [
     "test_zk_pok_gpu_valgrind",
     "test_high_level_api_fake_multi_gpu",
     "test_signed_integer_fake_multi_gpu",
-    "test_cuda_backend_race_check",
-    "test_high_level_api_gpu_valgrind",
-    "test_high_level_api_gpu_sanitizer",
 ]
 
 
@@ -241,7 +245,19 @@ def main():
     for w in warnings:
         print(w, file=sys.stderr)
 
-    base_fields = ["Workflow", "PR", "PR on approved", "Cron", "Manual only", "Profile (instance)", "Fallbacks"]
+    def sort_key(row):
+        name = row["Workflow"]
+        if row["PR"] == "yes":
+            return (0, name)
+        if row["PR on approved"] == "yes":
+            return (1, name)
+        if row["Manual only"] == "yes":
+            return (3, name)
+        return (2, name)
+
+    rows.sort(key=sort_key)
+
+    base_fields = ["Workflow", "PR", "PR on approved", "Manual only", "Cron", "Profile (instance)"]
     writer = csv.DictWriter(sys.stdout, fieldnames=base_fields + TEST_TARGETS)
     writer.writeheader()
     for row in rows:

--- a/scripts/check_memory_errors.sh
+++ b/scripts/check_memory_errors.sh
@@ -3,7 +3,8 @@ set -x
 set -euo pipefail
 
 RUN_VALGRIND=0
-RUN_COMPUTE_SANITIZER=0
+RUN_MEMCHECK=0
+RUN_RACECHECK=0
 
 while [ -n "${1:-}" ]; do
    case "$1" in
@@ -12,7 +13,16 @@ while [ -n "${1:-}" ]; do
             ;;
 
         "--gpu" )
-            RUN_COMPUTE_SANITIZER=1
+            RUN_MEMCHECK=1
+            RUN_RACECHECK=1
+            ;;
+
+        "--memcheck" )
+            RUN_MEMCHECK=1
+            ;;
+
+        "--racecheck" )
+            RUN_RACECHECK=1
             ;;
 
         *)
@@ -23,31 +33,39 @@ while [ -n "${1:-}" ]; do
    shift
 done
 
-if [[ "${RUN_VALGRIND}" == "0" && "${RUN_COMPUTE_SANITIZER}" == "0" ]]; then
-  echo "Usage: check_memory_errors.sh [--gpu] [--cpu]"
+if [[ "${RUN_VALGRIND}" == "0" && "${RUN_MEMCHECK}" == "0" && "${RUN_RACECHECK}" == "0" ]]; then
+  echo "Usage: check_memory_errors.sh [--gpu] [--memcheck] [--racecheck] [--cpu]"
   exit 1
 fi
 
-# Parameters (overridable via env vars) — defaults preserve the historical
-# tfhe-cuda-backend invocation.
+# Parameters (overridable via env vars)
 SANITIZER_CARGO_PACKAGE="${SANITIZER_CARGO_PACKAGE:-tfhe}"
-SANITIZER_CARGO_FEATURES_CPU="${SANITIZER_CARGO_FEATURES_CPU:-integer,internal-keycache,gpu-debug,zk-pok}"
+SANITIZER_CARGO_FEATURES_GPU_DEBUG="${SANITIZER_CARGO_FEATURES_GPU_DEBUG:-integer,internal-keycache,gpu-debug-fake-multi-gpu,zk-pok}"
 SANITIZER_CARGO_FEATURES_GPU="${SANITIZER_CARGO_FEATURES_GPU:-integer,internal-keycache,gpu,zk-pok}"
 SANITIZER_TEST_FILTER_CPU="${SANITIZER_TEST_FILTER_CPU:-high_level_api::.*gpu.*}"
 SANITIZER_TEST_EXCLUDES_CPU="${SANITIZER_TEST_EXCLUDES_CPU:-test_uniformity|array|flip|long_run}"
 SANITIZER_TEST_FILTER_GPU="${SANITIZER_TEST_FILTER_GPU:-high_level_api::.*gpu.*|core_crypto::.*gpu.*}"
 SANITIZER_TEST_EXCLUDES_GPU="${SANITIZER_TEST_EXCLUDES_GPU:-array|modulus_switch|3_3|noise_distribution|flip|test_uniformity|long_run}"
+# Racecheck runs only the two u128 PBS tests — they use is_sanitizer_run() to limit to 2 iterations
+SANITIZER_TEST_FILTER_GPU_RACECHECK="${SANITIZER_TEST_FILTER_GPU_RACECHECK:-test_bootstrap_u128_with_squashing|test_multibit_bootstrap_u128_with_squashing|test_compressed_ct_list_gpu_many_sizes}"
+SANITIZER_TEST_EXCLUDES_GPU_RACECHECK="${SANITIZER_TEST_EXCLUDES_GPU_RACECHECK:-}"
 SANITIZER_TEST_EXE_GLOB="${SANITIZER_TEST_EXE_GLOB:-tfhe-*}"
 SANITIZER_TEST_TIMEOUT="${SANITIZER_TEST_TIMEOUT:-1800}"
 SANITIZER_LAUNCH_TIMEOUT="${SANITIZER_LAUNCH_TIMEOUT:-600}"
+# GTest binary built from tfhe-cuda-backend; if unset, the GTest section is skipped
+SANITIZER_GTEST_EXE="${SANITIZER_GTEST_EXE:-}"
+# classical PBS + multi-bit PBS + keyswitch; concurrent PBS excluded (too many iterations)
+SANITIZER_GTEST_FILTER="${SANITIZER_GTEST_FILTER:-ClassicalProgrammableBootstrapInstantiation*:MultiBitProgrammableBootstrapInstantiation*:KeyswitchInstantiation*}"
 
 # Array to collect error messages for final summary
 ERROR_MESSAGES=()
+RESULT=0
 
 if [[ "${RUN_VALGRIND}" == "1" ]]; then
-  # List the tests into a temporary file using the CPU feature set
+  # List the tests into a temporary file using the GPU debug feature set
+  # CPU code is compiled in debug but kernels are in release
   RUSTFLAGS="$RUSTFLAGS" cargo nextest list --cargo-profile "${CARGO_PROFILE}" \
-            --features="${SANITIZER_CARGO_FEATURES_CPU}" -p "${SANITIZER_CARGO_PACKAGE}" &> /tmp/test_list.txt
+            --features="${SANITIZER_CARGO_FEATURES_GPU_DEBUG}" -p "${SANITIZER_CARGO_PACKAGE}" &> /tmp/test_list.txt
 
   # The tests are filtered using grep. Since, when output is directed to a file, nextest
   # outputs a list of `<executable name> <test name>` the `grep -o '[^ ]\+$'` filter will
@@ -59,15 +77,17 @@ if [[ "${RUN_VALGRIND}" == "1" ]]; then
 
   # Build the tests but don't run them
   RUSTFLAGS="$RUSTFLAGS" cargo test --no-run --profile "${CARGO_PROFILE}" \
-    --features="${SANITIZER_CARGO_FEATURES_CPU}" -p "${SANITIZER_CARGO_PACKAGE}"
+    --features="${SANITIZER_CARGO_FEATURES_GPU_DEBUG}" -p "${SANITIZER_CARGO_PACKAGE}"
 
   # Find the test executable -> last one to have been modified
   EXECUTABLE=target/release/deps/$(find target/release/deps/ -type f -executable -name "${SANITIZER_TEST_EXE_GLOB}" -printf "%T@ %f\n" |sort -nr|sed 's/^.* //; q;')
 
-  RESULT=0
+  TOTAL=$(grep -cE '\S' <<< "$TESTS_TO_RUN" || true)
+  IDX=0
   while read -r t; do
         [ -z "$t" ] && continue
-        echo "Running valgrind on: $t"
+        IDX=$((IDX + 1))
+        echo "Running valgrind on [${IDX}/${TOTAL}] $(date '+%Y-%m-%d %H:%M:%S'): $t"
 
         VALGRIND_EXIT=0
         valgrind --leak-check=full \
@@ -91,16 +111,25 @@ if [[ "${RUN_VALGRIND}" == "1" ]]; then
   done <<< "$TESTS_TO_RUN"
 fi
 
-if [[ "${RUN_COMPUTE_SANITIZER}" == "1" ]]; then
+run_compute_sanitizer_tool() {
+  local CS_TOOL="$1"
   export TFHE_RS_COMPUTE_SANITIZER=1
+
+  # Select the right filter: racecheck uses a narrower set (only u128 PBS tests)
+  local TEST_FILTER="${SANITIZER_TEST_FILTER_GPU}"
+  local TEST_EXCLUDES="${SANITIZER_TEST_EXCLUDES_GPU}"
+  if [[ "${CS_TOOL}" == "racecheck" ]]; then
+    TEST_FILTER="${SANITIZER_TEST_FILTER_GPU_RACECHECK}"
+    TEST_EXCLUDES="${SANITIZER_TEST_EXCLUDES_GPU_RACECHECK}"
+  fi
 
   # List the tests into a temporary file using the GPU feature set
   RUSTFLAGS="$RUSTFLAGS" cargo nextest list --cargo-profile "${CARGO_PROFILE}" \
             --features="${SANITIZER_CARGO_FEATURES_GPU}" -p "${SANITIZER_CARGO_PACKAGE}" &> /tmp/test_list.txt
 
   TESTS_TO_RUN=$(sed -e $'s/\x1b\[[0-9;]*m//g' < /tmp/test_list.txt \
-      | grep -E "${SANITIZER_TEST_FILTER_GPU}" \
-      | grep -vE "${SANITIZER_TEST_EXCLUDES_GPU}" \
+      | grep -E "${TEST_FILTER}" \
+      | { if [[ -n "${TEST_EXCLUDES}" ]]; then grep -vE "${TEST_EXCLUDES}"; else cat; fi; } \
       | grep -o '[^ ]\+$')
   # Build the tests but don't run them
   RUSTFLAGS="$RUSTFLAGS" cargo test --no-run --profile "${CARGO_PROFILE}" \
@@ -109,30 +138,87 @@ if [[ "${RUN_COMPUTE_SANITIZER}" == "1" ]]; then
   # Find the test executable -> last one to have been modified
   EXECUTABLE=target/release/deps/$(find target/release/deps/ -type f -executable -name "${SANITIZER_TEST_EXE_GLOB}" -printf "%T@ %f\n" |sort -nr|sed 's/^.* //; q;')
 
-  RESULT=0
+  TOTAL=$(grep -cE '\S' <<< "$TESTS_TO_RUN" || true)
+  echo "========================================"
+  echo "compute-sanitizer --tool ${CS_TOOL} (${TOTAL} tests)"
+  echo "========================================"
+  IDX=0
   while read -r t; do
         [ -z "$t" ] && continue
-        echo "Running compute-sanitizer on: $t"
+        IDX=$((IDX + 1))
+        echo "Running compute-sanitizer (${CS_TOOL}) on [${IDX}/${TOTAL}] $(date '+%Y-%m-%d %H:%M:%S'): $t"
         CS_EXIT=0
-        WEDGED=0
+
+        # memcheck supports --leak-check; racecheck does not
+        CS_EXTRA_ARGS=""
+        if [[ "${CS_TOOL}" == "memcheck" ]]; then
+          CS_EXTRA_ARGS="--leak-check=full"
+        fi
+
+        # shellcheck disable=SC2086
         timeout -k 30 "${SANITIZER_TEST_TIMEOUT}" \
-            compute-sanitizer --tool memcheck --leak-check=full \
+            compute-sanitizer --tool "${CS_TOOL}" ${CS_EXTRA_ARGS} \
             --error-exitcode=1 --launch-timeout "${SANITIZER_LAUNCH_TIMEOUT}" \
             --target-processes=all \
             "$EXECUTABLE" --exact "$t" > /tmp/sanitizer_output.log 2>&1 || CS_EXIT=$?
         cat /tmp/sanitizer_output.log
-        if [[ $CS_EXIT -eq 124 || $CS_EXIT -eq 137 ]] \
-            || grep -q "No attachable process found" /tmp/sanitizer_output.log; then
-            WEDGED=1
-        fi
-        if [[ $WEDGED -ne 0 ]]; then
-            ERROR_MESSAGES+=("Compute-sanitizer timed out or lost attach on test: $t")
-            RESULT=1
-        elif [[ $CS_EXIT -ne 0 ]]; then
-            ERROR_MESSAGES+=("Compute-sanitizer detected error for test: $t")
+        if [[ $CS_EXIT -ne 0 ]]; then
+            ERROR_MESSAGES+=("Compute-sanitizer (${CS_TOOL}) detected error for test: $t")
             RESULT=1
         fi
     done <<< "$TESTS_TO_RUN"
+}
+
+run_compute_sanitizer_gtest() {
+  local CS_TOOL="$1"
+  export TFHE_RS_COMPUTE_SANITIZER=1
+
+  if [[ -z "${SANITIZER_GTEST_EXE}" ]]; then
+    echo "[gtest] SANITIZER_GTEST_EXE not set — skipping GTest ${CS_TOOL} run"
+    return
+  fi
+  if [[ ! -x "${SANITIZER_GTEST_EXE}" ]]; then
+    echo "[gtest] ${SANITIZER_GTEST_EXE} is not executable — skipping GTest ${CS_TOOL} run"
+    return
+  fi
+
+  # List individual GTest cases so we can run each under its own sanitizer invocation
+  # (prevents a failing test from hiding subsequent ones)
+  GTEST_TESTS=$(TFHE_RS_COMPUTE_SANITIZER=1 "${SANITIZER_GTEST_EXE}" \
+      --gtest_list_tests --gtest_filter="${SANITIZER_GTEST_FILTER}" 2>/dev/null \
+      | awk '/^[^ \t]/ {suite=$1} /^[[:space:]]/ {print suite $1}')
+
+  TOTAL=$(grep -cE '\S' <<< "$GTEST_TESTS" || true)
+  echo "========================================"
+  echo "compute-sanitizer --tool ${CS_TOOL} GTest (${TOTAL} cases)"
+  echo "========================================"
+  IDX=0
+  while read -r t; do
+    [ -z "$t" ] && continue
+    IDX=$((IDX + 1))
+    echo "Running compute-sanitizer (${CS_TOOL}) on GTest [${IDX}/${TOTAL}] $(date '+%Y-%m-%d %H:%M:%S'): $t"
+    CS_EXIT=0
+
+    timeout -k 30 "${SANITIZER_TEST_TIMEOUT}" \
+        compute-sanitizer --tool "${CS_TOOL}" \
+        --error-exitcode=1 --launch-timeout "${SANITIZER_LAUNCH_TIMEOUT}" \
+        --target-processes=all \
+        "${SANITIZER_GTEST_EXE}" "--gtest_filter=${t}" > /tmp/sanitizer_output.log 2>&1 || CS_EXIT=$?
+    cat /tmp/sanitizer_output.log
+    if [[ $CS_EXIT -ne 0 ]]; then
+      ERROR_MESSAGES+=("Compute-sanitizer (${CS_TOOL}) detected error in GTest: $t")
+      RESULT=1
+    fi
+  done <<< "$GTEST_TESTS"
+}
+
+if [[ "${RUN_MEMCHECK}" == "1" ]]; then
+  run_compute_sanitizer_tool memcheck
+fi
+
+if [[ "${RUN_RACECHECK}" == "1" ]]; then
+  run_compute_sanitizer_tool racecheck
+  run_compute_sanitizer_gtest racecheck
 fi
 
 # Print summary of errors if any were encountered

--- a/tfhe/src/core_crypto/gpu/algorithms/test/lwe_multi_bit_programmable_bootstrapping_128.rs
+++ b/tfhe/src/core_crypto/gpu/algorithms/test/lwe_multi_bit_programmable_bootstrapping_128.rs
@@ -36,8 +36,13 @@ fn execute_multibit_bootstrap_u128(
 
     let delta = encoding_with_padding / msg_modulus.0 as u128;
     let delta_64 = encoding_with_padding_64 / msg_modulus.0 as u64;
-    const NB_TESTS: usize = 10;
-    for number_of_messages in [1_usize, 2_usize, 100_usize] {
+    let nb_tests = if is_sanitizer_run() { 2 } else { 10 };
+    let messages_counts: &[usize] = if is_sanitizer_run() {
+        &[1]
+    } else {
+        &[1, 2, 100]
+    };
+    for &number_of_messages in messages_counts {
         let mut msg = msg_modulus.0 as u64;
 
         let accumulator = generate_programmable_bootstrap_glwe_lut(
@@ -105,7 +110,7 @@ fn execute_multibit_bootstrap_u128(
 
         while msg != 0 {
             msg -= 1;
-            for _ in 0..NB_TESTS {
+            for _ in 0..nb_tests {
                 let input_plaintext_list =
                     PlaintextList::from_container(vec![msg * delta_64; number_of_messages]);
 

--- a/tfhe/src/core_crypto/gpu/algorithms/test/lwe_programmable_bootstrapping_128.rs
+++ b/tfhe/src/core_crypto/gpu/algorithms/test/lwe_programmable_bootstrapping_128.rs
@@ -1,4 +1,4 @@
-use super::assert_gpu_determinism;
+use super::{assert_gpu_determinism, is_sanitizer_run};
 pub(crate) use crate::core_crypto::algorithms::test::gen_keys_or_get_from_cache_if_enabled;
 use crate::shortint::parameters::{
     DynamicDistribution, NOISE_SQUASHING_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
@@ -188,25 +188,27 @@ pub fn execute_bootstrap_u128(
 
     let pbs_ct = d_out_pbs_ct.into_lwe_ciphertext(&stream);
 
-    // Determinism check
-    let mut d_out_pbs_ct_bis = CudaLweCiphertextList::new(
-        output_lwe_dimension,
-        LweCiphertextCount(1),
-        ciphertext_modulus,
-        &stream,
-    );
-    cuda_programmable_bootstrap_128_lwe_ciphertext(
-        &d_lwe_ciphertext_in,
-        &mut d_out_pbs_ct_bis,
-        &d_accumulator,
-        &d_bsk,
-        &stream,
-    );
-    assert_gpu_determinism(
-        pbs_ct.as_ref(),
-        d_out_pbs_ct_bis.into_lwe_ciphertext(&stream).as_ref(),
-        "cuda_programmable_bootstrap_128_lwe_ciphertext",
-    );
+    // Determinism check (skipped under sanitizer to keep the test to a single kernel call)
+    if !is_sanitizer_run() {
+        let mut d_out_pbs_ct_bis = CudaLweCiphertextList::new(
+            output_lwe_dimension,
+            LweCiphertextCount(1),
+            ciphertext_modulus,
+            &stream,
+        );
+        cuda_programmable_bootstrap_128_lwe_ciphertext(
+            &d_lwe_ciphertext_in,
+            &mut d_out_pbs_ct_bis,
+            &d_accumulator,
+            &d_bsk,
+            &stream,
+        );
+        assert_gpu_determinism(
+            pbs_ct.as_ref(),
+            d_out_pbs_ct_bis.into_lwe_ciphertext(&stream).as_ref(),
+            "cuda_programmable_bootstrap_128_lwe_ciphertext",
+        );
+    }
 
     // Decrypt the PBS result
     let pbs_plaintext: Plaintext<u128> = decrypt_lwe_ciphertext(&big_lwe_sk, &pbs_ct);

--- a/tfhe/src/core_crypto/gpu/algorithms/test/mod.rs
+++ b/tfhe/src/core_crypto/gpu/algorithms/test/mod.rs
@@ -78,6 +78,10 @@ pub(crate) fn should_check_determinism(message_modulus_log: MessageModulusLog) -
     message_modulus_log == MessageModulusLog(4)
 }
 
+pub(crate) fn is_sanitizer_run() -> bool {
+    std::env::var("TFHE_RS_COMPUTE_SANITIZER").is_ok_and(|v| v == "1")
+}
+
 /// Counterpart of [`MULTI_BIT_2_2_2_PARAMS`] and [`MULTI_BIT_2_2_3_PARAMS`] for a grouping factor
 /// of 4, which only the GPU backend implements: the parameters actually used with it.
 pub const MULTI_BIT_2_2_4_PARAMS: MultiBitTestParams<u64> =

--- a/tfhe/src/high_level_api/compressed_ciphertext_list.rs
+++ b/tfhe/src/high_level_api/compressed_ciphertext_list.rs
@@ -1148,13 +1148,18 @@ mod tests {
     #[cfg(feature = "gpu")]
     #[test]
     fn test_compressed_ct_list_gpu_many_sizes() {
-        use rand::{thread_rng, Rng};
+        let is_sanitizer_run = std::env::var("TFHE_RS_COMPUTE_SANITIZER").is_ok_and(|v| v == "1");
 
-        let mut rng = thread_rng();
-        let mut sizes: Vec<usize> = (0..10).map(|_| rng.gen_range(1..=512)).collect();
-
-        // Add some fixed sizes.
-        sizes.extend([32, 64, 128, 256]);
+        let sizes: Vec<usize> = if is_sanitizer_run {
+            vec![1, 2]
+        } else {
+            use rand::{thread_rng, Rng};
+            let mut rng = thread_rng();
+            let mut s: Vec<usize> = (0..10).map(|_| rng.gen_range(1..=512)).collect();
+            // Add some fixed sizes.
+            s.extend([32, 64, 128, 256]);
+            s
+        };
         // Printed so a CI failure can be reproduced.
         println!("compressed list sizes under test: {sizes:?}");
 


### PR DESCRIPTION
- fix racecheck false alarm in `batch_FFT16x4x16_classical_specialized` (@guillermo-oyarzun)
- move valgrind to use GPU release kernels and CPU debug
- combine memcheck & racecheck workflows on 2xH100 in parallel
- full stress test in gpu full tests manually run
- add stress test to disabled 1xh100 core tests
- add racecheck in addition to memcheck on tests that run selected kernels:

```
batch_NSMFFT (FULLSM)                                                                                                                                
  batch_NSMFFT (NOSM)                                                                                                                                  
  batch_NSMFFT_classical_specialized                                                                                                                   
  batch_FFT16x4x16_classical_specialized
  
  device_programmable_bootstrap_step_one                                                                                                               
  device_programmable_bootstrap_step_two
  device_programmable_bootstrap_cg
  device_programmable_bootstrap_tbc
  device_programmable_bootstrap_tbc_2_2_params
  device_programmable_bootstrap_specialized_2_2_params
  device_programmable_bootstrap_step_one_128
  device_programmable_bootstrap_step_one_128_regs
  device_programmable_bootstrap_step_two_128
  device_programmable_bootstrap_cg_128
  device_programmable_bootstrap_tbc_128
  
  device_multi_bit_programmable_bootstrap_keybundle
  device_multi_bit_programmable_bootstrap_keybundle_2_2_params
  device_multi_bit_programmable_bootstrap_accumulate_step_one
  device_multi_bit_programmable_bootstrap_accumulate_step_two
  device_multi_bit_programmable_bootstrap_cg_accumulate
  device_multi_bit_programmable_bootstrap_tbc_accumulate
  device_multi_bit_programmable_bootstrap_tbc_accumulate_2_2_params
  device_multi_bit_programmable_bootstrap_keybundle_128
  device_multi_bit_programmable_bootstrap_accumulate_step_one_128
  device_multi_bit_programmable_bootstrap_accumulate_step_two_128
  device_multi_bit_programmable_bootstrap_cg_accumulate_128

  keyswitch_zero_output_with_output_indices
  keyswitch_gemm_copy_negated_message_with_indices
  tgemm_all_levels_split_k
  keyswitch_negate_with_output_indices
  cleartext_multiplication
  tgemm_all_levels
  polynomial_accumulate_monic_monomial_mul_many_neg_and_add_C
  accumulate_glwes
  modulus_switch_strided_inplace
  pack
  extract
  sample_extract
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3909)
<!-- Reviewable:end -->
