### PR TITLE
feat: support dedicated transciphering oprf params

### DIFF
--- a/tfhe/src/high_level_api/keys/inner.rs
+++ b/tfhe/src/high_level_api/keys/inner.rs
@@ -26,6 +26,7 @@ use crate::integer::public_key::CompactPublicKey;
 use crate::integer::CompressedCompactPublicKey;
 use crate::shortint::atomic_pattern::AtomicPatternParameters;
 use crate::shortint::key_switching_key::KeySwitchingKeyConformanceParams;
+use crate::shortint::oprf::OprfKeyConformanceParams;
 use crate::shortint::parameters::list_compression::CompressionParameters;
 use crate::shortint::parameters::{
     CompactPublicKeyEncryptionParameters, NoiseSquashingCompressionParameters,
@@ -1253,7 +1254,9 @@ impl ParameterSetConformant for IntegerServerKey {
         let oprf_is_ok = match (parameter_set.dedicated_oprf_key, oprf_key.as_ref()) {
             // We have to have a dedicated oprf key
             // Make sure it's there and that it's conformant
-            (true, Some(key)) => key.is_conformant(&parameter_set.sk_param),
+            (true, Some(key)) => key.is_conformant(&OprfKeyConformanceParams::same_as_compute(
+                parameter_set.sk_param,
+            )),
             (true, None) => false,
             // The config says to not use a dedicated oprf key but we have one
             // while it works, it is not strictly conformant
@@ -1266,9 +1269,12 @@ impl ParameterSetConformant for IntegerServerKey {
             transciphering_key.as_ref(),
         ) {
             // The key bootstraps into the compute key, so it is checked against the compute
-            // parameters.
-            (Some(TranscipheringParameters::SameAsCompute), Some(key)) => {
-                key.is_conformant(&parameter_set.sk_param)
+            // parameters, plus the oprf parameters it was generated with.
+            (Some(transciphering_params), Some(key)) => {
+                key.is_conformant(&OprfKeyConformanceParams::new(
+                    parameter_set.sk_param,
+                    transciphering_params.oprf_parameters(parameter_set.sk_param),
+                ))
             }
             (Some(_), None) => false,
             // The config says to not use transciphering but we have a key
@@ -1427,7 +1433,9 @@ impl ParameterSetConformant for IntegerCompressedServerKey {
         let oprf_is_ok = match (parameter_set.dedicated_oprf_key, oprf_key.as_ref()) {
             // We have to have a dedicated oprf key
             // Make sure it's there and that it's conformant
-            (true, Some(key)) => key.is_conformant(&parameter_set.sk_param),
+            (true, Some(key)) => key.is_conformant(&OprfKeyConformanceParams::same_as_compute(
+                parameter_set.sk_param,
+            )),
             (true, None) => false,
             // The config says to not use a dedicated oprf key but we have one
             // while it works, it is not strictly conformant
@@ -1440,9 +1448,12 @@ impl ParameterSetConformant for IntegerCompressedServerKey {
             transciphering_key.as_ref(),
         ) {
             // The key bootstraps into the compute key, so it is checked against the compute
-            // parameters.
-            (Some(TranscipheringParameters::SameAsCompute), Some(key)) => {
-                key.is_conformant(&parameter_set.sk_param)
+            // parameters, plus the oprf parameters it was generated with.
+            (Some(transciphering_params), Some(key)) => {
+                key.is_conformant(&OprfKeyConformanceParams::new(
+                    parameter_set.sk_param,
+                    transciphering_params.oprf_parameters(parameter_set.sk_param),
+                ))
             }
             (Some(_), None) => false,
             // The config says to not use transciphering but we have a key

--- a/tfhe/src/high_level_api/keys/server.rs
+++ b/tfhe/src/high_level_api/keys/server.rs
@@ -856,12 +856,14 @@ mod test {
     use crate::prelude::ParameterSetConformant;
     use crate::shortint::parameters::test_params::TEST_META_PARAM_CPU_2_2_KS_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128;
     use crate::shortint::parameters::{
-        TranscipheringParameters, COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+        OprfParameters, TranscipheringParameters,
+        COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
         NOISE_SQUASHING_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
         PARAM_KEYSWITCH_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
         PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
         PARAM_PKE_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
     };
+    use crate::shortint::prelude::LweDimension;
     use crate::shortint::ClassicPBSParameters;
     use crate::{ClientKey, CompressedServerKey, ConfigBuilder, ServerKey};
 
@@ -965,18 +967,8 @@ mod test {
 
                 modifier(&mut sk_param);
 
-                let sk_param = sk_param.into();
-
-                let conformance_params = IntegerServerKeyConformanceParams {
-                    sk_param,
-                    cpk_param: None,
-                    compression_param: None,
-                    noise_squashing_param: None,
-                    noise_squashing_compression_param: None,
-                    cpk_re_randomization_params: None,
-                    dedicated_oprf_key: true,
-                    transciphering_parameters: None,
-                };
+                let mut conformance_params = IntegerServerKeyConformanceParams::from(config);
+                conformance_params.sk_param = sk_param.into();
 
                 assert!(!sk.is_conformant(&conformance_params));
             }
@@ -995,54 +987,60 @@ mod test {
             let ck = ClientKey::generate(config);
             let sk = ServerKey::new(&ck);
 
-            let sk_param = PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128.into();
-
             cpk_params.encryption_lwe_dimension.0 += 1;
 
-            let conformance_params = IntegerServerKeyConformanceParams {
-                sk_param,
-                cpk_param: Some((cpk_params, casting_params)),
-                compression_param: None,
-                noise_squashing_param: None,
-                noise_squashing_compression_param: None,
-                cpk_re_randomization_params: None,
-                dedicated_oprf_key: true,
-                transciphering_parameters: None,
-            };
+            let mut conformance_params = IntegerServerKeyConformanceParams::from(config);
+            conformance_params.cpk_param = Some((cpk_params, casting_params));
 
             assert!(!sk.is_conformant(&conformance_params));
         }
         {
             let params = PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+            let with_transciphering = ConfigBuilder::with_custom_parameters(params)
+                .enable_transciphering(TranscipheringParameters::SameAsCompute)
+                .build();
+            let without_transciphering = ConfigBuilder::with_custom_parameters(params).build();
+
+            let with_params = IntegerServerKeyConformanceParams::from(with_transciphering);
+            let without_params = IntegerServerKeyConformanceParams::from(without_transciphering);
+
+            let ck = ClientKey::generate(with_transciphering);
+            let sk = ServerKey::new(&ck);
+
+            // Key has transciphering, parameters do not.
+            assert!(!sk.is_conformant(&without_params));
+            assert!(sk.is_conformant(&with_params));
+
+            // Parameters ask for transciphering, key does not have it.
+            let sk_without = ServerKey::new(&ClientKey::generate(without_transciphering));
+            assert!(!sk_without.is_conformant(&with_params));
+        }
+        {
+            let params = PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+            let dedicated = OprfParameters {
+                lwe_dimension: LweDimension(600),
+            };
+
             let config = ConfigBuilder::with_custom_parameters(params)
+                .enable_transciphering(TranscipheringParameters::DedicatedOprf(dedicated))
+                .build();
+            let same_as_compute_config = ConfigBuilder::with_custom_parameters(params)
                 .enable_transciphering(TranscipheringParameters::SameAsCompute)
                 .build();
 
             let ck = ClientKey::generate(config);
             let sk = ServerKey::new(&ck);
+            let compressed_sk = CompressedServerKey::new(&ck);
 
-            let sk_param = params.into();
-            let mut conformance_params = IntegerServerKeyConformanceParams {
-                sk_param,
-                cpk_param: None,
-                compression_param: None,
-                noise_squashing_param: None,
-                noise_squashing_compression_param: None,
-                cpk_re_randomization_params: None,
-                dedicated_oprf_key: true,
-                transciphering_parameters: None,
-            };
+            let dedicated_oprf_params = IntegerServerKeyConformanceParams::from(config);
+            let same_as_compute_params =
+                IntegerServerKeyConformanceParams::from(same_as_compute_config);
 
-            // Key has transciphering, parameters do not.
-            assert!(!sk.is_conformant(&conformance_params));
-            conformance_params.transciphering_parameters =
-                Some(TranscipheringParameters::SameAsCompute);
-            assert!(sk.is_conformant(&conformance_params));
+            assert!(sk.is_conformant(&dedicated_oprf_params));
+            assert!(compressed_sk.is_conformant(&dedicated_oprf_params));
 
-            // Parameters ask for transciphering, key does not have it.
-            let without = ConfigBuilder::with_custom_parameters(params).build();
-            let sk_without = ServerKey::new(&ClientKey::generate(without));
-            assert!(!sk_without.is_conformant(&conformance_params));
+            assert!(!sk.is_conformant(&same_as_compute_params));
+            assert!(!compressed_sk.is_conformant(&same_as_compute_params));
         }
     }
 
@@ -1145,18 +1143,8 @@ mod test {
 
                 modifier(&mut sk_param);
 
-                let sk_param = sk_param.into();
-
-                let conformance_params = IntegerServerKeyConformanceParams {
-                    sk_param,
-                    cpk_param: None,
-                    compression_param: None,
-                    noise_squashing_param: None,
-                    noise_squashing_compression_param: None,
-                    cpk_re_randomization_params: None,
-                    dedicated_oprf_key: true,
-                    transciphering_parameters: None,
-                };
+                let mut conformance_params = IntegerServerKeyConformanceParams::from(config);
+                conformance_params.sk_param = sk_param.into();
 
                 assert!(!sk.is_conformant(&conformance_params));
             }
@@ -1175,77 +1163,47 @@ mod test {
             let ck = ClientKey::generate(config);
             let sk = CompressedServerKey::new(&ck);
 
-            let sk_param = PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128.into();
-
             cpk_params.encryption_lwe_dimension.0 += 1;
 
-            let conformance_params = IntegerServerKeyConformanceParams {
-                sk_param,
-                cpk_param: Some((cpk_params, casting_params)),
-                compression_param: None,
-                noise_squashing_param: None,
-                noise_squashing_compression_param: None,
-                cpk_re_randomization_params: None,
-                dedicated_oprf_key: true,
-                transciphering_parameters: None,
-            };
+            let mut conformance_params = IntegerServerKeyConformanceParams::from(config);
+            conformance_params.cpk_param = Some((cpk_params, casting_params));
 
             assert!(!sk.is_conformant(&conformance_params));
         }
         {
             let params = PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
-            let config = ConfigBuilder::with_custom_parameters(params)
+            let without_dedicated_oprf = ConfigBuilder::with_custom_parameters(params)
                 .use_dedicated_oprf_key(false)
                 .build();
+            let with_dedicated_oprf = ConfigBuilder::with_custom_parameters(params).build();
 
-            let ck = ClientKey::generate(config);
+            let without_params = IntegerServerKeyConformanceParams::from(without_dedicated_oprf);
+            let with_params = IntegerServerKeyConformanceParams::from(with_dedicated_oprf);
+
+            let ck = ClientKey::generate(without_dedicated_oprf);
             let sk = CompressedServerKey::new(&ck);
 
-            let sk_param = params.into();
-            let mut conformance_params = IntegerServerKeyConformanceParams {
-                sk_param,
-                cpk_param: None,
-                compression_param: None,
-                noise_squashing_param: None,
-                noise_squashing_compression_param: None,
-                cpk_re_randomization_params: None,
-                dedicated_oprf_key: true,
-                transciphering_parameters: None,
-            };
-
-            assert!(!sk.is_conformant(&conformance_params));
-            conformance_params.dedicated_oprf_key = false;
-            assert!(sk.is_conformant(&conformance_params));
+            assert!(!sk.is_conformant(&with_params));
+            assert!(sk.is_conformant(&without_params));
         }
         {
             let params = PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
-            let config = ConfigBuilder::with_custom_parameters(params)
+            let with_transciphering = ConfigBuilder::with_custom_parameters(params)
                 .enable_transciphering(TranscipheringParameters::SameAsCompute)
                 .build();
+            let without_transciphering = ConfigBuilder::with_custom_parameters(params).build();
 
-            let ck = ClientKey::generate(config);
+            let with_params = IntegerServerKeyConformanceParams::from(with_transciphering);
+            let without_params = IntegerServerKeyConformanceParams::from(without_transciphering);
+
+            let ck = ClientKey::generate(with_transciphering);
             let sk = CompressedServerKey::new(&ck);
 
-            let sk_param = params.into();
-            let mut conformance_params = IntegerServerKeyConformanceParams {
-                sk_param,
-                cpk_param: None,
-                compression_param: None,
-                noise_squashing_param: None,
-                noise_squashing_compression_param: None,
-                cpk_re_randomization_params: None,
-                dedicated_oprf_key: true,
-                transciphering_parameters: None,
-            };
+            assert!(!sk.is_conformant(&without_params));
+            assert!(sk.is_conformant(&with_params));
 
-            assert!(!sk.is_conformant(&conformance_params));
-            conformance_params.transciphering_parameters =
-                Some(TranscipheringParameters::SameAsCompute);
-            assert!(sk.is_conformant(&conformance_params));
-
-            let without = ConfigBuilder::with_custom_parameters(params).build();
-            let sk_without = CompressedServerKey::new(&ClientKey::generate(without));
-            assert!(!sk_without.is_conformant(&conformance_params));
+            let sk_without = CompressedServerKey::new(&ClientKey::generate(without_transciphering));
+            assert!(!sk_without.is_conformant(&with_params));
         }
     }
 }

--- a/tfhe/src/high_level_api/transciphering/mod.rs
+++ b/tfhe/src/high_level_api/transciphering/mod.rs
@@ -354,6 +354,8 @@ where
 mod test {
     use tfhe_safe_serialize::{safe_deserialize, safe_serialize};
 
+    use crate::shortint::parameters::{OprfParameters, TranscipheringParameters};
+    use crate::shortint::prelude::LweDimension;
     use crate::FheUint64;
 
     const SIZE_LIMIT: u64 = 1024 * 1024 * 1024;
@@ -565,18 +567,27 @@ mod test {
     /// client, which is the direction the transciphering protocol uses.
     #[test]
     fn test_one_time_pad_using_oprf() {
+        for params in [
+            TranscipheringParameters::SameAsCompute,
+            TranscipheringParameters::DedicatedOprf(OprfParameters {
+                lwe_dimension: LweDimension(600),
+            }),
+        ] {
+            test_one_time_pad_using_oprf_impl(params)
+        }
+    }
+
+    fn test_one_time_pad_using_oprf_impl(params: TranscipheringParameters) {
         use super::{HlStreamCipher, HlTranscipherer, OneTimePadFheSecretMask, TranscipherSession};
         use crate::prelude::*;
-        use crate::shortint::parameters::TranscipheringParameters;
         use crate::transciphering::{OneTimePadPlainSecretMask, OneTimePadPlainState};
         use crate::{generate_keys, set_server_key, ConfigBuilder, Seed};
         use rand::Rng;
 
         let mut rng = rand::thread_rng();
 
-        let (client_key, server_key) = generate_keys(
-            ConfigBuilder::default().enable_transciphering(TranscipheringParameters::SameAsCompute),
-        );
+        let (client_key, server_key) =
+            generate_keys(ConfigBuilder::default().enable_transciphering(params));
         set_server_key(server_key);
 
         // Server: generate a random FHE pad.

--- a/tfhe/src/high_level_api/xof_key_set/internal.rs
+++ b/tfhe/src/high_level_api/xof_key_set/internal.rs
@@ -23,8 +23,8 @@ use crate::shortint::noise_squashing::atomic_pattern::compressed::CompressedAtom
 use crate::shortint::noise_squashing::CompressedShortint128BootstrappingKey;
 use crate::shortint::parameters::{
     CompactPublicKeyEncryptionParameters, CompressionParameters,
-    NoiseSquashingCompressionParameters, NoiseSquashingParameters, ShortintKeySwitchingParameters,
-    TranscipheringParameters,
+    NoiseSquashingCompressionParameters, NoiseSquashingParameters, OprfParameters,
+    ShortintKeySwitchingParameters, TranscipheringParameters,
 };
 use crate::shortint::server_key::{
     CompressedModulusSwitchConfiguration, CompressedModulusSwitchNoiseReductionKey,
@@ -159,16 +159,22 @@ impl crate::integer::ClientKey {
 impl OprfPrivateKey {
     fn generate_with_pre_seeded_generator<G>(
         params: AtomicPatternParameters,
+        oprf_params: OprfParameters,
         max_norm_hwt: NormalizedHammingWeightBound,
         secret_generator: &mut SecretRandomGenerator<G>,
     ) -> Self
     where
         G: ByteRandomGenerator,
     {
+        assert!(
+            params.is_compatible_with_oprf_params(oprf_params),
+            "OPRF parameters are not compatible with compute parameters"
+        );
+
         let sk = match params {
-            shortint::AtomicPatternParameters::Standard(std_params) => {
+            shortint::AtomicPatternParameters::Standard(_) => {
                 let mut lwe_secret_key =
-                    LweSecretKey::new_empty_key(0u64, std_params.lwe_dimension());
+                    LweSecretKey::new_empty_key(0u64, oprf_params.lwe_dimension);
                 generate_binary_lwe_secret_key_with_bounded_hamming_weight(
                     &mut lwe_secret_key,
                     secret_generator,
@@ -177,9 +183,9 @@ impl OprfPrivateKey {
 
                 crate::shortint::oprf::AtomicPatternOprfPrivateKey::Standard(lwe_secret_key)
             }
-            shortint::AtomicPatternParameters::KeySwitch32(ks32_params) => {
+            shortint::AtomicPatternParameters::KeySwitch32(_) => {
                 let mut lwe_secret_key =
-                    LweSecretKey::new_empty_key(0u32, ks32_params.lwe_dimension());
+                    LweSecretKey::new_empty_key(0u32, oprf_params.lwe_dimension);
                 generate_binary_lwe_secret_key_with_bounded_hamming_weight(
                     &mut lwe_secret_key,
                     secret_generator,
@@ -285,15 +291,12 @@ impl crate::transciphering::TranscipheringPrivateKey {
     where
         G: ByteRandomGenerator,
     {
-        let oprf_key = match transciphering_params {
-            TranscipheringParameters::SameAsCompute => {
-                OprfPrivateKey::generate_with_pre_seeded_generator(
-                    compute_params,
-                    max_norm_hwt,
-                    secret_generator,
-                )
-            }
-        };
+        let oprf_key = OprfPrivateKey::generate_with_pre_seeded_generator(
+            compute_params,
+            transciphering_params.oprf_parameters(compute_params),
+            max_norm_hwt,
+            secret_generator,
+        );
 
         Self::from_raw_parts(oprf_key.0, transciphering_params)
     }
@@ -343,6 +346,7 @@ impl ClientKey {
         let dedicated_oprf_private_key = config.inner.dedicated_oprf_key.then(|| {
             OprfPrivateKey::generate_with_pre_seeded_generator(
                 config.inner.block_parameters,
+                OprfParameters::same_as_compute(config.inner.block_parameters),
                 max_norm_hwt,
                 secret_generator,
             )
@@ -744,6 +748,13 @@ impl crate::shortint::oprf::CompressedOprfServerKey {
         Gen: ByteRandomGenerator + ParallelByteRandomGenerator,
     {
         use crate::shortint::oprf::CompressedOprfBootstrappingKey;
+
+        assert!(
+            client_key
+                .parameters()
+                .is_compatible_with_oprf_params(private_oprf_key.parameters()),
+            "oprf key lwe dimension is not compatible with target client key"
+        );
 
         let inner = match (&private_oprf_key.0, &client_key.atomic_pattern) {
             (

--- a/tfhe/src/integer/oprf.rs
+++ b/tfhe/src/integer/oprf.rs
@@ -9,10 +9,11 @@ use crate::named::Named;
 use crate::shortint::oprf::{
     CompressedOprfServerKey as ShortintCompressedOprfServerKey,
     ExpandedOprfServerKey as ShortintExpandedOprfServerKey,
-    GenericOprfServerKey as ShortintGenericOprfServerKey, OprfPrivateKey as ShortintOprfPrivateKey,
-    OprfServerKey as ShortintOprfServerKey,
+    GenericOprfServerKey as ShortintGenericOprfServerKey, OprfKeyConformanceParams,
+    OprfPrivateKey as ShortintOprfPrivateKey, OprfServerKey as ShortintOprfServerKey,
 };
-use crate::shortint::{AtomicPatternParameters, OprfSeed};
+use crate::shortint::parameters::OprfParameters;
+use crate::shortint::OprfSeed;
 use aligned_vec::ABox;
 use std::num::NonZeroU64;
 use tfhe_fft::c64;
@@ -29,6 +30,10 @@ pub struct OprfPrivateKey(pub(crate) ShortintOprfPrivateKey);
 impl OprfPrivateKey {
     pub fn new(ck: &ClientKey) -> Self {
         Self(ShortintOprfPrivateKey::new(&ck.key))
+    }
+
+    pub fn new_with_params(ck: &ClientKey, params: OprfParameters) -> Self {
+        Self(ShortintOprfPrivateKey::new_with_params(&ck.key, params))
     }
 
     pub fn from_raw_parts(sk: ShortintOprfPrivateKey) -> Self {
@@ -61,8 +66,8 @@ impl CompressedOprfServerKey {
         ExpandedOprfServerKey(self.0.expand())
     }
 
-    pub(crate) fn is_conformant(&self, sk_param: &AtomicPatternParameters) -> bool {
-        self.0.is_conformant(sk_param)
+    pub(crate) fn is_conformant(&self, params: &OprfKeyConformanceParams) -> bool {
+        self.0.is_conformant(params)
     }
 }
 
@@ -711,7 +716,7 @@ impl ServerKey {
 }
 
 impl ParameterSetConformant for OprfServerKey {
-    type ParameterSet = AtomicPatternParameters;
+    type ParameterSet = OprfKeyConformanceParams;
 
     fn is_conformant(&self, parameter_set: &Self::ParameterSet) -> bool {
         self.key.is_conformant(parameter_set)

--- a/tfhe/src/shortint/atomic_pattern/mod.rs
+++ b/tfhe/src/shortint/atomic_pattern/mod.rs
@@ -31,7 +31,7 @@ use super::ciphertext::{
 use super::client_key::atomic_pattern::AtomicPatternClientKey;
 use super::engine::ShortintEngine;
 use super::parameters::{
-    CiphertextConformanceParams, DynamicDistribution, KeySwitch32PBSParameters,
+    CiphertextConformanceParams, DynamicDistribution, KeySwitch32PBSParameters, OprfParameters,
 };
 use super::prelude::{DecompositionBaseLog, DecompositionLevelCount};
 use super::server_key::{
@@ -604,6 +604,14 @@ impl AtomicPatternParameters {
         self.set_deterministic_execution(true);
 
         self
+    }
+
+    /// Check if dedicated oprf parameters and compute parameters are compatible
+    pub const fn is_compatible_with_oprf_params(&self, oprf_params: OprfParameters) -> bool {
+        match self {
+            Self::Standard(parameters) => parameters.is_compatible_with_oprf_params(oprf_params),
+            Self::KeySwitch32(parameters) => parameters.is_compatible_with_oprf_params(oprf_params),
+        }
     }
 }
 

--- a/tfhe/src/shortint/backward_compatibility/parameters/mod.rs
+++ b/tfhe/src/shortint/backward_compatibility/parameters/mod.rs
@@ -15,8 +15,8 @@ use crate::shortint::parameters::meta::{
 };
 use crate::shortint::parameters::{
     Backend, CiphertextModulus32, CompressionParameters, MetaNoiseSquashingParameters,
-    ModulusSwitchNoiseReductionParams, ModulusSwitchType, ShortintParameterSetInner,
-    SupportedCompactPkeZkScheme,
+    ModulusSwitchNoiseReductionParams, ModulusSwitchType, OprfParameters,
+    ShortintParameterSetInner, SupportedCompactPkeZkScheme,
 };
 use crate::shortint::*;
 use parameters::KeySwitch32PBSParameters;
@@ -385,4 +385,9 @@ pub enum MetaParametersVersions {
 #[derive(VersionsDispatch)]
 pub enum ReRandomizationConfigurationVersions {
     V0(ReRandomizationConfiguration),
+}
+
+#[derive(VersionsDispatch)]
+pub enum OprfParametersVersions {
+    V0(OprfParameters),
 }

--- a/tfhe/src/shortint/oprf.rs
+++ b/tfhe/src/shortint/oprf.rs
@@ -3,7 +3,8 @@ use tfhe_versionable::Versionize;
 use crate::named::Named;
 
 use super::backward_compatibility::oprf::*;
-use super::client_key::atomic_pattern::AtomicPatternClientKey;
+use super::client_key::atomic_pattern::{AtomicPatternClientKey, EncryptionAtomicPattern};
+use super::parameters::OprfParameters;
 use super::server_key::LookupTableSize;
 use super::Ciphertext;
 use crate::conformance::ParameterSetConformant;
@@ -91,20 +92,37 @@ impl OprfPrivateKey {
     /// Create a new private key, this uses the same parameters as the bootstrap key used for
     /// compute
     pub fn new(target_ck: &ClientKey) -> Self {
+        let oprf_params = OprfParameters {
+            lwe_dimension: target_ck.atomic_pattern.parameters().lwe_dimension(),
+        };
+
+        Self::new_with_params(target_ck, oprf_params)
+    }
+
+    pub fn new_with_params(target_ck: &ClientKey, params: OprfParameters) -> Self {
+        assert!(
+            target_ck
+                .parameters()
+                .is_compatible_with_oprf_params(params),
+            "provided lwe dimension for oprf is not compatible with target client key"
+        );
+
+        let OprfParameters { lwe_dimension } = params;
+
         match &target_ck.atomic_pattern {
-            AtomicPatternClientKey::Standard(std) => {
+            AtomicPatternClientKey::Standard(_) => {
                 let lwe_sk = ShortintEngine::with_thread_local_mut(|engine| {
                     allocate_and_generate_new_binary_lwe_secret_key(
-                        std.parameters.lwe_dimension(),
+                        lwe_dimension,
                         &mut engine.secret_generator,
                     )
                 });
                 Self(AtomicPatternOprfPrivateKey::Standard(lwe_sk))
             }
-            AtomicPatternClientKey::KeySwitch32(ks32) => {
+            AtomicPatternClientKey::KeySwitch32(_) => {
                 let lwe_sk = ShortintEngine::with_thread_local_mut(|engine| {
                     allocate_and_generate_new_binary_lwe_secret_key(
-                        ks32.parameters.lwe_dimension(),
+                        lwe_dimension,
                         &mut engine.secret_generator,
                     )
                 });
@@ -119,6 +137,17 @@ impl OprfPrivateKey {
 
     pub fn into_raw_parts(self) -> AtomicPatternOprfPrivateKey {
         self.0
+    }
+
+    pub fn parameters(&self) -> OprfParameters {
+        let lwe_dimension = match &self.0 {
+            AtomicPatternOprfPrivateKey::Standard(lwe_secret_key) => lwe_secret_key.lwe_dimension(),
+            AtomicPatternOprfPrivateKey::KeySwitch32(lwe_secret_key) => {
+                lwe_secret_key.lwe_dimension()
+            }
+        };
+
+        OprfParameters { lwe_dimension }
     }
 }
 
@@ -181,7 +210,9 @@ impl<C: Container<Element = c64>> OprfBootstrappingKey<C> {
         &self,
         target_bsk: &ShortintBootstrappingKey<T>,
     ) {
-        assert_eq!(target_bsk.input_lwe_dimension(), self.input_lwe_dimension());
+        // If the oprf has a dedicated lwe dimension, it should be smaller than the one used
+        // for the compute bsk to guarantee output noise correctness
+        assert!(target_bsk.input_lwe_dimension() >= self.input_lwe_dimension());
         assert_eq!(
             target_bsk.output_lwe_dimension(),
             self.output_lwe_dimension()
@@ -395,6 +426,15 @@ pub struct CompressedOprfServerKey {
 
 impl CompressedOprfServerKey {
     pub fn new(sk: &OprfPrivateKey, target_ck: &ClientKey) -> crate::Result<Self> {
+        if !target_ck
+            .parameters()
+            .is_compatible_with_oprf_params(sk.parameters())
+        {
+            return Err(crate::error!(
+                "oprf key lwe dimension is not compatible with target client key"
+            ));
+        }
+
         let inner = match (&sk.0, &target_ck.atomic_pattern) {
             (
                 AtomicPatternOprfPrivateKey::KeySwitch32(sk),
@@ -438,15 +478,48 @@ impl CompressedOprfServerKey {
     }
 }
 
-impl ParameterSetConformant for CompressedOprfServerKey {
-    type ParameterSet = AtomicPatternParameters;
+#[derive(Copy, Clone)]
+pub struct OprfKeyConformanceParams {
+    pub compute_params: AtomicPatternParameters,
+    pub oprf_params: OprfParameters,
+}
 
-    fn is_conformant(&self, parameter_set: &Self::ParameterSet) -> bool {
-        let pbs_conformance_params: PBSConformanceParams = match parameter_set {
+impl OprfKeyConformanceParams {
+    pub const fn new(compute_params: AtomicPatternParameters, oprf_params: OprfParameters) -> Self {
+        Self {
+            compute_params,
+            oprf_params,
+        }
+    }
+
+    /// The parameters for an OPRF key mirroring the compute key
+    pub const fn same_as_compute(compute_params: AtomicPatternParameters) -> Self {
+        Self::new(
+            compute_params,
+            OprfParameters::same_as_compute(compute_params),
+        )
+    }
+
+    fn to_pbs_conformance_params(self) -> PBSConformanceParams {
+        let mut params: PBSConformanceParams = match &self.compute_params {
             AtomicPatternParameters::Standard(std_params) => std_params.into(),
             AtomicPatternParameters::KeySwitch32(ks32_params) => ks32_params.into(),
         };
-        self.inner.is_conformant(&pbs_conformance_params)
+
+        // Only the input dimension is specific to the OPRF key, the rest comes from the compute
+        // key.
+        params.in_lwe_dimension = self.oprf_params.lwe_dimension;
+
+        params
+    }
+}
+
+impl ParameterSetConformant for CompressedOprfServerKey {
+    type ParameterSet = OprfKeyConformanceParams;
+
+    fn is_conformant(&self, parameter_set: &Self::ParameterSet) -> bool {
+        self.inner
+            .is_conformant(&parameter_set.to_pbs_conformance_params())
     }
 }
 
@@ -709,6 +782,15 @@ impl<C: Container<Element = c64> + Sync> GenericOprfServerKey<C> {
 // Owned-only methods.
 impl OprfServerKey {
     pub fn new(sk: &OprfPrivateKey, target_ck: &ClientKey) -> crate::Result<Self> {
+        if !target_ck
+            .parameters()
+            .is_compatible_with_oprf_params(sk.parameters())
+        {
+            return Err(crate::error!(
+                "oprf key lwe dimension is not compatible with target client key"
+            ));
+        }
+
         let inner = match (&sk.0, &target_ck.atomic_pattern) {
             (
                 AtomicPatternOprfPrivateKey::KeySwitch32(sk),
@@ -743,14 +825,11 @@ impl OprfServerKey {
 }
 
 impl ParameterSetConformant for OprfServerKey {
-    type ParameterSet = AtomicPatternParameters;
+    type ParameterSet = OprfKeyConformanceParams;
 
     fn is_conformant(&self, parameter_set: &Self::ParameterSet) -> bool {
-        let pbs_conformance_params: PBSConformanceParams = match parameter_set {
-            AtomicPatternParameters::Standard(std_params) => std_params.into(),
-            AtomicPatternParameters::KeySwitch32(ks32_params) => ks32_params.into(),
-        };
-        self.inner.is_conformant(&pbs_conformance_params)
+        self.inner
+            .is_conformant(&parameter_set.to_pbs_conformance_params())
     }
 }
 

--- a/tfhe/src/shortint/parameters/classic.rs
+++ b/tfhe/src/shortint/parameters/classic.rs
@@ -14,6 +14,8 @@ use crate::shortint::parameters::{
 use serde::{Deserialize, Serialize};
 use tfhe_versionable::Versionize;
 
+use super::OprfParameters;
+
 /// A structure defining the set of cryptographic parameters for homomorphic integer circuit
 /// evaluation.
 ///
@@ -176,5 +178,12 @@ impl ClassicPBSParameters {
     /// Returns [`AtomicPatternKind::Standard`] derived from the PBS order.
     pub const fn atomic_pattern(&self) -> AtomicPatternKind {
         AtomicPatternKind::Standard(self.pbs_order())
+    }
+
+    /// Check if dedicated oprf parameters and compute parameters are compatible
+    pub const fn is_compatible_with_oprf_params(&self, oprf_params: OprfParameters) -> bool {
+        let OprfParameters { lwe_dimension } = oprf_params;
+
+        lwe_dimension.0 <= self.lwe_dimension.0
     }
 }

--- a/tfhe/src/shortint/parameters/ks32.rs
+++ b/tfhe/src/shortint/parameters/ks32.rs
@@ -16,7 +16,7 @@ use crate::shortint::parameters::ModulusSwitchType;
 
 use super::{
     AtomicPatternKind, CarryModulus, CiphertextConformanceParams, CiphertextModulus,
-    CiphertextModulus32, Degree, MaxNoiseLevel, MessageModulus, NoiseLevel,
+    CiphertextModulus32, Degree, MaxNoiseLevel, MessageModulus, NoiseLevel, OprfParameters,
 };
 
 /// A set of cryptographic parameters used with the atomic pattern
@@ -197,5 +197,12 @@ impl KeySwitch32PBSParameters {
                 self.post_keyswitch_ciphertext_modulus().try_to().unwrap()
             }
         }
+    }
+
+    /// Check if dedicated oprf parameters and compute parameters are compatible
+    pub const fn is_compatible_with_oprf_params(&self, oprf_params: OprfParameters) -> bool {
+        let OprfParameters { lwe_dimension } = oprf_params;
+
+        lwe_dimension.0 <= self.lwe_dimension.0
     }
 }

--- a/tfhe/src/shortint/parameters/meta.rs
+++ b/tfhe/src/shortint/parameters/meta.rs
@@ -126,7 +126,7 @@ impl MetaParameters {
     }
 
     pub const fn is_valid(&self) -> bool {
-        if let Some(rerand_configuration) = self.rerand_configuration {
+        let rerand_is_ok = if let Some(rerand_configuration) = self.rerand_configuration {
             match rerand_configuration {
                 ReRandomizationConfiguration::LegacyDedicatedCompactPublicKeyWithKeySwitch => {
                     let Some(params) = self.dedicated_compact_public_key_parameters else {
@@ -163,7 +163,17 @@ impl MetaParameters {
         } else {
             // No rerand config, check pke is valid and that there is no legacy rerand params
             self.dedicated_cpk_is_valid_has_no_rerand()
-        }
+        };
+
+        // need to match to be const
+        let transciphering_is_ok = match self.transciphering_parameters {
+            Some(TranscipheringParameters::DedicatedOprf(oprf_params)) => self
+                .compute_parameters
+                .is_compatible_with_oprf_params(oprf_params),
+            Some(TranscipheringParameters::SameAsCompute) | None => true,
+        };
+
+        rerand_is_ok && transciphering_is_ok
     }
 
     pub const fn validate(self) -> Self {

--- a/tfhe/src/shortint/parameters/mod.rs
+++ b/tfhe/src/shortint/parameters/mod.rs
@@ -374,6 +374,14 @@ impl PBSParameters {
             Self::MultiBitPBS(param) => param.to_compressed_modswitched_conformance_param(),
         }
     }
+
+    /// Check if dedicated oprf parameters and compute parameters are compatible
+    pub const fn is_compatible_with_oprf_params(&self, oprf_params: OprfParameters) -> bool {
+        match self {
+            Self::PBS(param) => param.is_compatible_with_oprf_params(oprf_params),
+            Self::MultiBitPBS(param) => param.is_compatible_with_oprf_params(oprf_params),
+        }
+    }
 }
 
 #[derive(Serialize, Copy, Clone, Deserialize, Debug, PartialEq, Versionize)]
@@ -685,6 +693,15 @@ impl ShortintParameterSet {
     pub const fn pbs_and_wopbs(&self) -> bool {
         self.inner.is_pbs_and_wopbs()
     }
+
+    /// Check if dedicated oprf parameters and compute parameters are compatible
+    pub const fn is_compatible_with_oprf_params(&self, oprf_params: OprfParameters) -> bool {
+        if let Some(params) = self.ap_parameters() {
+            params.is_compatible_with_oprf_params(oprf_params)
+        } else {
+            false
+        }
+    }
 }
 
 impl<P> From<P> for ShortintParameterSet
@@ -843,6 +860,26 @@ impl ModulusSwitchType {
             Self::CenteredMeanNoiseReduction => {
                 CompressedModulusSwitchConfiguration::CenteredMeanNoiseReduction
             }
+        }
+    }
+}
+
+/// Parameters of a dedicated OPRF key.
+///
+/// OPRF performance can be improved by using a smaller LWE dimension than the one used for compute,
+/// as long as lwe security is preserved. The rest of the pbs parameters are taken from the compute
+/// params.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Versionize)]
+#[versionize(OprfParametersVersions)]
+pub struct OprfParameters {
+    pub lwe_dimension: LweDimension,
+}
+
+impl OprfParameters {
+    /// The parameters of an OPRF key mirroring the compute key.
+    pub const fn same_as_compute(compute_params: AtomicPatternParameters) -> Self {
+        Self {
+            lwe_dimension: compute_params.lwe_dimension(),
         }
     }
 }

--- a/tfhe/src/shortint/parameters/multi_bit.rs
+++ b/tfhe/src/shortint/parameters/multi_bit.rs
@@ -18,6 +18,8 @@ use crate::shortint::server_key::PBSConformanceParams;
 use serde::{Deserialize, Serialize};
 use tfhe_versionable::Versionize;
 
+use super::OprfParameters;
+
 /// A structure defining the set of cryptographic parameters for homomorphic integer circuit
 /// evaluation. This structure contains information to run the so-called multi-bit PBS with improved
 /// latency provided enough threads are available on the machine performing the FHE computations
@@ -134,6 +136,14 @@ impl MultiBitPBSParameters {
             atomic_pattern,
             degree,
         }
+    }
+
+    /// Check if dedicated oprf parameters and compute parameters are compatible
+    pub const fn is_compatible_with_oprf_params(&self, oprf_params: OprfParameters) -> bool {
+        let OprfParameters { lwe_dimension } = oprf_params;
+
+        lwe_dimension.0 <= self.lwe_dimension.0
+            && lwe_dimension.0.is_multiple_of(self.grouping_factor.0)
     }
 }
 

--- a/tfhe/src/shortint/parameters/transciphering.rs
+++ b/tfhe/src/shortint/parameters/transciphering.rs
@@ -3,6 +3,8 @@ use crate::shortint::backward_compatibility::parameters::transciphering::Transci
 use serde::{Deserialize, Serialize};
 use tfhe_versionable::Versionize;
 
+use super::{AtomicPatternParameters, OprfParameters};
+
 /// Parameters of the key material used by the transciphering subsystem.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Versionize)]
 #[versionize(TranscipheringParametersVersions)]
@@ -10,6 +12,20 @@ use tfhe_versionable::Versionize;
 pub enum TranscipheringParameters {
     /// Generate the transciphering key with the parameters of the compute key.
     SameAsCompute,
+    /// Use dedicated parameters for the oprf, but stream ciphers are still evaluated with the
+    /// compute key
+    DedicatedOprf(OprfParameters),
+}
+
+impl TranscipheringParameters {
+    /// The parameters of the OPRF key these describe, resolved against the compute parameters
+    /// they are used alongside.
+    pub const fn oprf_parameters(self, compute_params: AtomicPatternParameters) -> OprfParameters {
+        match self {
+            Self::SameAsCompute => OprfParameters::same_as_compute(compute_params),
+            Self::DedicatedOprf(oprf_params) => oprf_params,
+        }
+    }
 }
 
 impl Named for TranscipheringParameters {

--- a/tfhe/src/shortint/parameters/v1_8/meta/cpu.rs
+++ b/tfhe/src/shortint/parameters/v1_8/meta/cpu.rs
@@ -10,9 +10,8 @@ use super::super::list_compression::p_fail_2_minus_128::*;
 use super::super::multi_bit::gaussian::p_fail_2_minus_128::ks_pbs::*;
 use super::super::multi_bit::tuniform::p_fail_2_minus_128::ks_pbs::*;
 use super::super::noise_squashing::p_fail_2_minus_128::*;
-use crate::shortint::parameters::{
-    Backend, MetaNoiseSquashingParameters, TranscipheringParameters,
-};
+use crate::shortint::parameters::v1_8::transciphering::V1_8_TRANSCIPHERING_PARAM_DEDICATED_OPRF;
+use crate::shortint::parameters::{Backend, MetaNoiseSquashingParameters};
 use crate::shortint::{AtomicPatternParameters, PBSParameters};
 
 pub const V1_8_META_PARAM_CPU_1_1_KS_PBS_GAUSSIAN_2M128: MetaParameters = MetaParameters {
@@ -470,7 +469,7 @@ pub const V1_8_META_PARAM_CPU_2_2_KS_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128: MetaP
         rerand_configuration: Some(
             ReRandomizationConfiguration::DerivedCompactPublicKeyWithoutKeySwitch,
         ),
-        transciphering_parameters: Some(TranscipheringParameters::SameAsCompute),
+        transciphering_parameters: Some(V1_8_TRANSCIPHERING_PARAM_DEDICATED_OPRF),
     }
     .validate();
 
@@ -496,7 +495,7 @@ pub const V1_8_META_PARAM_CPU_2_2_KS_PBS_PKE_TO_BIG_ZKV2_TUNIFORM_2M128: MetaPar
         rerand_configuration: Some(
             ReRandomizationConfiguration::DerivedCompactPublicKeyWithoutKeySwitch,
         ),
-        transciphering_parameters: Some(TranscipheringParameters::SameAsCompute),
+        transciphering_parameters: Some(V1_8_TRANSCIPHERING_PARAM_DEDICATED_OPRF),
     }
     .validate();
 
@@ -522,7 +521,7 @@ pub const V1_8_META_PARAM_CPU_2_2_KS32_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128: Met
         rerand_configuration: Some(
             ReRandomizationConfiguration::DerivedCompactPublicKeyWithoutKeySwitch,
         ),
-        transciphering_parameters: Some(TranscipheringParameters::SameAsCompute),
+        transciphering_parameters: Some(V1_8_TRANSCIPHERING_PARAM_DEDICATED_OPRF),
     }
     .validate();
 
@@ -548,7 +547,7 @@ pub const V1_8_META_PARAM_CPU_2_2_KS32_PBS_PKE_TO_BIG_ZKV2_TUNIFORM_2M128: MetaP
         rerand_configuration: Some(
             ReRandomizationConfiguration::DerivedCompactPublicKeyWithoutKeySwitch,
         ),
-        transciphering_parameters: Some(TranscipheringParameters::SameAsCompute),
+        transciphering_parameters: Some(V1_8_TRANSCIPHERING_PARAM_DEDICATED_OPRF),
     }
     .validate();
 
@@ -574,7 +573,7 @@ pub const V1_8_META_PARAM_CPU_2_2_KS_PBS_PKE_TO_SMALL_ZKV1_TUNIFORM_2M128: MetaP
         rerand_configuration: Some(
             ReRandomizationConfiguration::DerivedCompactPublicKeyWithoutKeySwitch,
         ),
-        transciphering_parameters: Some(TranscipheringParameters::SameAsCompute),
+        transciphering_parameters: Some(V1_8_TRANSCIPHERING_PARAM_DEDICATED_OPRF),
     }
     .validate();
 
@@ -600,6 +599,6 @@ pub const V1_8_META_PARAM_CPU_2_2_KS_PBS_PKE_TO_BIG_ZKV1_TUNIFORM_2M128: MetaPar
         rerand_configuration: Some(
             ReRandomizationConfiguration::DerivedCompactPublicKeyWithoutKeySwitch,
         ),
-        transciphering_parameters: Some(TranscipheringParameters::SameAsCompute),
+        transciphering_parameters: Some(V1_8_TRANSCIPHERING_PARAM_DEDICATED_OPRF),
     }
     .validate();

--- a/tfhe/src/shortint/parameters/v1_8/mod.rs
+++ b/tfhe/src/shortint/parameters/v1_8/mod.rs
@@ -10,6 +10,7 @@ pub mod list_compression;
 pub mod meta;
 pub mod multi_bit;
 pub mod noise_squashing;
+pub mod transciphering;
 pub use classic::gaussian::p_fail_2_minus_128::ks_pbs::*;
 pub use classic::gaussian::p_fail_2_minus_128::ks_pbs_gpu::*;
 pub use classic::tuniform::p_fail_2_minus_128::ks_pbs::*;

--- a/tfhe/src/shortint/parameters/v1_8/transciphering.rs
+++ b/tfhe/src/shortint/parameters/v1_8/transciphering.rs
@@ -1,0 +1,7 @@
+use crate::shortint::parameters::{OprfParameters, TranscipheringParameters};
+use crate::shortint::prelude::LweDimension;
+
+pub const V1_8_TRANSCIPHERING_PARAM_DEDICATED_OPRF: TranscipheringParameters =
+    TranscipheringParameters::DedicatedOprf(OprfParameters {
+        lwe_dimension: LweDimension(600),
+    });

--- a/tfhe/src/transciphering/keys.rs
+++ b/tfhe/src/transciphering/keys.rs
@@ -1,10 +1,11 @@
 use crate::conformance::ParameterSetConformant;
 use crate::named::Named;
 use crate::shortint::oprf::{
-    CompressedOprfServerKey, ExpandedOprfServerKey, OprfPrivateKey, OprfServerKey,
+    CompressedOprfServerKey, ExpandedOprfServerKey, OprfKeyConformanceParams, OprfPrivateKey,
+    OprfServerKey,
 };
 use crate::shortint::parameters::TranscipheringParameters;
-use crate::shortint::{AtomicPatternParameters, ClientKey};
+use crate::shortint::ClientKey;
 use crate::transciphering::backward_compatibility::{
     CompressedTranscipheringServerKeyVersions, TranscipheringPrivateKeyVersions,
     TranscipheringServerKeyVersions,
@@ -27,6 +28,9 @@ impl TranscipheringPrivateKey {
     pub fn new(ck: &ClientKey, params: TranscipheringParameters) -> Self {
         let oprf_key = match params {
             TranscipheringParameters::SameAsCompute => OprfPrivateKey::new(ck),
+            TranscipheringParameters::DedicatedOprf(oprf_params) => {
+                OprfPrivateKey::new_with_params(ck, oprf_params)
+            }
         };
 
         Self { oprf_key, params }
@@ -59,11 +63,12 @@ pub struct TranscipheringServerKey {
     oprf_key: OprfServerKey,
 }
 
-/// The key bootstraps into the compute key, so it is checked against the compute parameters.
+/// The key bootstraps into the compute key, so it is checked against the compute parameters, plus
+/// the OPRF parameters it was generated with.
 ///
 /// A key that does not match them makes the pseudo random generation it is used for panic.
 impl ParameterSetConformant for TranscipheringServerKey {
-    type ParameterSet = AtomicPatternParameters;
+    type ParameterSet = OprfKeyConformanceParams;
 
     fn is_conformant(&self, parameter_set: &Self::ParameterSet) -> bool {
         self.oprf_key.is_conformant(parameter_set)
@@ -96,7 +101,7 @@ pub struct CompressedTranscipheringServerKey {
 }
 
 impl ParameterSetConformant for CompressedTranscipheringServerKey {
-    type ParameterSet = AtomicPatternParameters;
+    type ParameterSet = OprfKeyConformanceParams;
 
     fn is_conformant(&self, parameter_set: &Self::ParameterSet) -> bool {
         self.oprf_key.is_conformant(parameter_set)
@@ -170,7 +175,29 @@ mod test {
         TEST_PARAM_MESSAGE_1_CARRY_1_KS_PBS_GAUSSIAN_2M128,
         TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
     };
+    use crate::shortint::parameters::OprfParameters;
     use crate::shortint::prelude::*;
+
+    /// Builds the transciphering keys for `transciphering_params` and checks them against every
+    /// entry of `expectations`.
+    fn check_conformance(
+        cks: &ClientKey,
+        transciphering_params: TranscipheringParameters,
+        expectations: &[(OprfKeyConformanceParams, bool)],
+    ) {
+        let private_key = TranscipheringPrivateKey::new(cks, transciphering_params);
+
+        let server_key = TranscipheringServerKey::new(&private_key, cks).unwrap();
+        let compressed = CompressedTranscipheringServerKey::new(&private_key, cks).unwrap();
+        // Decompressing must preserve conformance.
+        let expanded = compressed.expand().to_fourier();
+
+        for (conformance_params, expected) in expectations {
+            assert_eq!(server_key.is_conformant(conformance_params), *expected);
+            assert_eq!(compressed.is_conformant(conformance_params), *expected);
+            assert_eq!(expanded.is_conformant(conformance_params), *expected);
+        }
+    }
 
     #[test]
     fn transciphering_server_key_conformance() {
@@ -178,21 +205,51 @@ mod test {
         let other_params = TEST_PARAM_MESSAGE_1_CARRY_1_KS_PBS_GAUSSIAN_2M128;
 
         let (cks, _sks) = gen_keys(params);
-        let private_key =
-            TranscipheringPrivateKey::new(&cks, TranscipheringParameters::SameAsCompute);
 
-        let matching: AtomicPatternParameters = params.into();
-        let mismatched: AtomicPatternParameters = other_params.into();
+        let compute: AtomicPatternParameters = params.into();
+        let other_compute: AtomicPatternParameters = other_params.into();
 
-        let server_key = TranscipheringServerKey::new(&private_key, &cks).unwrap();
-        assert!(server_key.is_conformant(&matching));
-        assert!(!server_key.is_conformant(&mismatched));
+        check_conformance(
+            &cks,
+            TranscipheringParameters::SameAsCompute,
+            &[
+                (OprfKeyConformanceParams::same_as_compute(compute), true),
+                (
+                    OprfKeyConformanceParams::same_as_compute(other_compute),
+                    false,
+                ),
+            ],
+        );
+    }
 
-        let compressed = CompressedTranscipheringServerKey::new(&private_key, &cks).unwrap();
-        assert!(compressed.is_conformant(&matching));
-        assert!(!compressed.is_conformant(&mismatched));
+    #[test]
+    fn transciphering_server_key_conformance_dedicated_oprf() {
+        let params = TEST_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
 
-        // Decompressing must preserve conformance.
-        assert!(compressed.expand().to_fourier().is_conformant(&matching));
+        let (cks, _sks) = gen_keys(params);
+
+        let compute: AtomicPatternParameters = params.into();
+        let dedicated = OprfParameters {
+            lwe_dimension: LweDimension(600),
+        };
+
+        check_conformance(
+            &cks,
+            TranscipheringParameters::DedicatedOprf(dedicated),
+            &[
+                // A dedicated key must not pass for a key mirroring the compute parameters.
+                (OprfKeyConformanceParams::same_as_compute(compute), false),
+                (OprfKeyConformanceParams::new(compute, dedicated), true),
+            ],
+        );
+
+        check_conformance(
+            &cks,
+            TranscipheringParameters::SameAsCompute,
+            &[
+                (OprfKeyConformanceParams::same_as_compute(compute), true),
+                (OprfKeyConformanceParams::new(compute, dedicated), false),
+            ],
+        );
     }
 }

--- a/utils/tfhe-backward-compat-data/crates/generate_1_8/src/lib.rs
+++ b/utils/tfhe-backward-compat-data/crates/generate_1_8/src/lib.rs
@@ -21,6 +21,8 @@ use tfhe_backward_compat_data::generate::*;
 use tfhe_backward_compat_data::*;
 
 const TRANSCIPHERING_CLIENT_KEY_FILENAME: &str = "transciphering_client_key";
+const TRANSCIPHERING_CLIENT_KEY_DEDICATED_FILENAME: &str =
+    "transciphering_client_key_dedicated_params";
 const TRANSCIPHERING_TAG: &[u8] = &[0xC0, 0xFF, 0xEE, 0x00];
 const KREYVIUM_PLAIN_KEY: [u8; 16] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
 const KREYVIUM_IV: [u8; 16] = [16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1];
@@ -31,6 +33,11 @@ const ONE_TIME_PAD: [u8; 8] = [0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE];
 
 const HL_TRANSCIPHERING_CLIENT_KEY_TEST: HlClientKeyTest = HlClientKeyTest {
     test_filename: Cow::Borrowed(TRANSCIPHERING_CLIENT_KEY_FILENAME),
+    parameters: INSECURE_SMALL_TEST_PARAMS_MS_MEAN_COMPENSATION_LWE_DIM_64,
+};
+
+const HL_TRANSCIPHERING_DEDICATED_PARAMS_CLIENT_KEY_TEST: HlClientKeyTest = HlClientKeyTest {
+    test_filename: Cow::Borrowed(TRANSCIPHERING_CLIENT_KEY_DEDICATED_FILENAME),
     parameters: INSECURE_SMALL_TEST_PARAMS_MS_MEAN_COMPENSATION_LWE_DIM_64,
 };
 
@@ -164,6 +171,17 @@ impl TfhersVersion for V1_8 {
             );
         }
 
+        {
+            let client_key =
+                ClientKey::generate(INSECURE_TEST_TRANSCIPHERING_DEDICATED_META_PARAMS.convert());
+
+            store_versioned_test(
+                &client_key,
+                &dir,
+                &HL_TRANSCIPHERING_DEDICATED_PARAMS_CLIENT_KEY_TEST.test_filename(),
+            );
+        }
+
         vec![
             TestMetadata::HlClientKey(HL_TRANSCIPHERING_CLIENT_KEY_TEST),
             TestMetadata::HlKreyviumFheKey(HL_KREYVIUM_FHE_KEY_TEST),
@@ -172,6 +190,7 @@ impl TfhersVersion for V1_8 {
             TestMetadata::HlStreamCiphertext(HL_STREAM_CIPHERTEXT_TEST),
             TestMetadata::HlServerKey(HL_COMPRESSED_SERVER_KEY_TEST),
             TestMetadata::HlServerKey(HL_SERVER_KEY_TEST),
+            TestMetadata::HlClientKey(HL_TRANSCIPHERING_DEDICATED_PARAMS_CLIENT_KEY_TEST),
         ]
     }
 }

--- a/utils/tfhe-backward-compat-data/crates/generate_1_8/src/utils.rs
+++ b/utils/tfhe-backward-compat-data/crates/generate_1_8/src/utils.rs
@@ -460,6 +460,11 @@ impl ConvertParams<TranscipheringParameters> for TestTranscipheringParameters {
     fn convert(self) -> TranscipheringParameters {
         match self {
             Self::SameAsCompute => TranscipheringParameters::SameAsCompute,
+            Self::DedicatedOprf(lwe_dim) => {
+                TranscipheringParameters::DedicatedOprf(OprfParameters {
+                    lwe_dimension: LweDimension(lwe_dim),
+                })
+            }
         }
     }
 }

--- a/utils/tfhe-backward-compat-data/data/1_8/high_level_api/transciphering_client_key_dedicated_params.bcode
+++ b/utils/tfhe-backward-compat-data/data/1_8/high_level_api/transciphering_client_key_dedicated_params.bcode
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fca993b19b430a981d74fba9710868d48a854f7f33a8e96fc487414b89188cef
+size 18044

--- a/utils/tfhe-backward-compat-data/data/1_8/high_level_api/transciphering_client_key_dedicated_params.cbor
+++ b/utils/tfhe-backward-compat-data/data/1_8/high_level_api/transciphering_client_key_dedicated_params.cbor
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:238c93d547cf6487f97e29f6306bb82ef89a4fc27bc8fa30048f00364a4e6c0a
+size 3235

--- a/utils/tfhe-backward-compat-data/data/high_level_api.ron
+++ b/utils/tfhe-backward-compat-data/data/high_level_api.ron
@@ -1135,4 +1135,33 @@
             compressed: false,
         )),
     ),
+    (
+        tfhe_version_min: "1.8",
+        tfhe_module: "high_level_api",
+        metadata: HlClientKey((
+            test_filename: "transciphering_client_key_dedicated_params",
+            parameters: TestClassicParameterSet((
+                lwe_dimension: 64,
+                glwe_dimension: 1,
+                polynomial_size: 2048,
+                lwe_noise_distribution: TUniform(
+                    bound_log2: 45,
+                ),
+                glwe_noise_distribution: TUniform(
+                    bound_log2: 17,
+                ),
+                pbs_base_log: 23,
+                pbs_level: 1,
+                ks_base_log: 4,
+                ks_level: 4,
+                message_modulus: 4,
+                ciphertext_modulus: 18446744073709551616,
+                carry_modulus: 4,
+                max_noise_level: 5,
+                log2_p_fail: -129.15284804376165,
+                encryption_key_choice: "big",
+                modulus_switch_noise_reduction_params: CenteredMeanNoiseReduction,
+            )),
+        )),
+    ),
 ]

--- a/utils/tfhe-backward-compat-data/src/generate.rs
+++ b/utils/tfhe-backward-compat-data/src/generate.rs
@@ -416,6 +416,16 @@ pub const INSECURE_TEST_TRANSCIPHERING_META_PARAMS: TestMetaParameters = TestMet
     transciphering_parameters: Some(TestTranscipheringParameters::SameAsCompute),
 };
 
+pub const INSECURE_TEST_TRANSCIPHERING_DEDICATED_META_PARAMS: TestMetaParameters =
+    TestMetaParameters {
+        compute_parameters: INSECURE_SMALL_TEST_PARAMS_MS_MEAN_COMPENSATION_LWE_DIM_64,
+        dedicated_compact_public_key_parameters: None,
+        compression_parameters: None,
+        noise_squashing_parameters: None,
+        rerand_configuration: None,
+        transciphering_parameters: Some(TestTranscipheringParameters::DedicatedOprf(32)),
+    };
+
 pub fn save_cbor<Data: Serialize, P: AsRef<Path>>(msg: &Data, path: P) {
     let path = path.as_ref();
     if path.exists() {

--- a/utils/tfhe-backward-compat-data/src/lib.rs
+++ b/utils/tfhe-backward-compat-data/src/lib.rs
@@ -202,6 +202,7 @@ pub enum TestReRandomizationConfiguration {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub enum TestTranscipheringParameters {
     SameAsCompute,
+    DedicatedOprf(usize),
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description
Add support for dedicated params for the transciphering oprf. By lowering oprf lwe dimension, we can improve oprf performance.

Some design choices:
- I added a new variant of TranscipheringParameters. This new variant is for the case where we have a dedicated oprf but that still outputs under the general purpose compute key. In the future, I want to add another variant for the case where we also have dedicated params for the transciphering evaluation. This will be needed to support some kreyvium improvements.
- This new variant holds a new type: `OprfParameters`. This will allow to also change the params of the general purpose oprf later. Everything is ready to support this, this is just not "plugged in".
- Backward data for the new variant is added through a client key. This will only test that the parameters load, not that they are correct. In the future, I think we should store the meta params in the HlClientKeyTest, not just the pbs params. But I considered this out of scope for this pr.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zama-ai/tfhe-rs/3917)
<!-- Reviewable:end -->
