### PR TITLE
chore: fix m1 workflow for nvm install

### DIFF
--- a/.github/workflows/m1_tests.yml
+++ b/.github/workflows/m1_tests.yml
@@ -41,6 +41,10 @@ jobs:
     timeout-minutes: 720
 
     steps:
+      - name: Override NVM_DIR for proper node detection on this runner
+        run: |
+          echo "NVM_DIR=${HOME}/.nvm" >> "${GITHUB_ENV}"
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: "false"


### PR DESCRIPTION
- use ~/.nvm since its the location nvm is installed in for the M1 workflow
- most CI workflows use nvm from the repo root in .nvm
- M1 was already using previous location and is not making use of GH caching, so revert to previous location