### PR TITLE
Go/chore/deprecate wrong 1 1 params in v1_6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ WEB_SERVER_DIR=tfhe/web_wasm_parallel_tests
 TAPLO_VERSION=0.10.0
 TYPOS_VERSION=1.44.0
 ZIZMOR_VERSION=1.22.0
+CARGO_SEMVER_CHECKS_VERSION=0.47.0
 # This is done to avoid forgetting it, we still precise the RUSTFLAGS in the commands to be able to
 # copy paste the command in the terminal and change them if required without forgetting the flags
 export RUSTFLAGS?=-C target-cpu=native
@@ -330,7 +331,7 @@ semgrep_and_lint_gpu_code: semgrep_lint_setup_venv
 
 .PHONY: semver_check_cuda_backend # Run semver checks on tfhe-cuda-backend
 semver_check_cuda_backend:
-	cargo install cargo-semver-checks --locked
+	cargo install cargo-semver-checks@$(CARGO_SEMVER_CHECKS_VERSION) --locked
 	DOCS_RS=1 cargo semver-checks --package tfhe-cuda-backend
 
 .PHONY: fmt_gpu # Format rust and cuda code

--- a/tfhe-benchmark/src/params_aliases.rs
+++ b/tfhe-benchmark/src/params_aliases.rs
@@ -34,6 +34,7 @@ pub mod shortint_params_aliases {
     pub const BENCH_PARAM_MESSAGE_1_CARRY_1_KS_PBS_TUNIFORM_2M128: ClassicPBSParameters =
         V1_6_PARAM_MESSAGE_1_CARRY_1_KS_PBS_TUNIFORM_2M128;
     #[cfg(feature = "gpu")]
+    #[allow(deprecated)]
     pub const BENCH_PARAM_MESSAGE_1_CARRY_1_KS_PBS_TUNIFORM_2M128: ClassicPBSParameters =
         V1_6_PARAM_GPU_MESSAGE_1_CARRY_1_KS_PBS_TUNIFORM_2M128;
     pub const BENCH_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128: ClassicPBSParameters =

--- a/tfhe/Cargo.toml
+++ b/tfhe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tfhe"
-version = "1.6.3"
+version = "1.6.4"
 edition = "2021"
 readme = "../README.md"
 keywords = ["fully", "homomorphic", "encryption", "fhe", "cryptography"]

--- a/tfhe/docs/configuration/gpu-acceleration/run-on-gpu.md
+++ b/tfhe/docs/configuration/gpu-acceleration/run-on-gpu.md
@@ -74,7 +74,7 @@ To compile and execute GPU TFHE-rs programs, make sure your system has the follo
 To use the **TFHE-rs** GPU backend in your project, add the following dependency in your `Cargo.toml`.
 
 ```toml
-tfhe = { version = "~1.6.3", features = ["boolean", "shortint", "integer", "gpu"] }
+tfhe = { version = "~1.6.4", features = ["boolean", "shortint", "integer", "gpu"] }
 ```
 
 If none of the supported backends is configured in `Cargo.toml`, the CPU backend is used.

--- a/tfhe/docs/configuration/hpu-acceleration/run-on-hpu.md
+++ b/tfhe/docs/configuration/hpu-acceleration/run-on-hpu.md
@@ -17,7 +17,7 @@ This guide explains how to update your existing program to leverage HPU accelera
 To use the **TFHE-rs** HPU backend in your project, add the following dependency in your `Cargo.toml`.
 
 ```toml
-tfhe = { version = "~1.6.3", features = ["integer", "hpu-v80"] }
+tfhe = { version = "~1.6.4", features = ["integer", "hpu-v80"] }
 ```
 
 {% hint style="success" %}

--- a/tfhe/docs/fhe-computation/data-handling/data-versioning.md
+++ b/tfhe/docs/fhe-computation/data-handling/data-versioning.md
@@ -16,7 +16,7 @@ You can load serialized data with the `unversionize` function, even in newer ver
 
 [dependencies]
 # ...
-tfhe = { version = "~1.6.3", features = ["integer"] }
+tfhe = { version = "~1.6.4", features = ["integer"] }
 tfhe-versionable = "0.8.0"
 bincode = "1.3.3"
 ```

--- a/tfhe/docs/fhe-computation/data-handling/serialization.md
+++ b/tfhe/docs/fhe-computation/data-handling/serialization.md
@@ -161,7 +161,7 @@ In the following example, we use [bincode](https://crates.io/crates/bincode) for
 
 [dependencies]
 # ...
-tfhe = { version = "~1.6.3", features = ["integer"] }
+tfhe = { version = "~1.6.4", features = ["integer"] }
 bincode = "1.3.3"
 ```
 

--- a/tfhe/docs/fhe-computation/types/array.md
+++ b/tfhe/docs/fhe-computation/types/array.md
@@ -19,7 +19,7 @@ The following example shows a complete workflow of working with encrypted arrays
 # Cargo.toml
 
 [dependencies]
-tfhe = { version = "~1.6.3", features = ["integer"] }
+tfhe = { version = "~1.6.4", features = ["integer"] }
 ```
 
 ```rust

--- a/tfhe/docs/fhe-computation/types/kv-store.md
+++ b/tfhe/docs/fhe-computation/types/kv-store.md
@@ -36,7 +36,7 @@ To serialize a `KVStore`, it must first be compressed.
 # Cargo.toml
 
 [dependencies]
-tfhe = { version = "~1.6.3", features = ["integer"] }
+tfhe = { version = "~1.6.4", features = ["integer"] }
 ```
 
 ```rust

--- a/tfhe/docs/fhe-computation/types/strings.md
+++ b/tfhe/docs/fhe-computation/types/strings.md
@@ -29,7 +29,7 @@ Here is an example:
 # Cargo.toml
 
 [dependencies]
-tfhe = { version = "~1.6.3", features = ["integer", "strings"] }
+tfhe = { version = "~1.6.4", features = ["integer", "strings"] }
 ```
 
 ```rust

--- a/tfhe/docs/getting-started/installation.md
+++ b/tfhe/docs/getting-started/installation.md
@@ -7,7 +7,7 @@ This document provides instructions to set up **TFHE-rs** in your project.
 First, add **TFHE-rs** as a dependency in your `Cargo.toml`.
 
 ```toml
-tfhe = { version = "~1.6.3", features = ["boolean", "shortint", "integer"] }
+tfhe = { version = "~1.6.4", features = ["boolean", "shortint", "integer"] }
 ```
 
 {% hint style="info" %}
@@ -35,7 +35,7 @@ By default, **TFHE-rs** makes the assumption that hardware AES features are enab
 To add support for older CPU, import **TFHE-rs** with the `software-prng` feature in your `Cargo.toml`:
 
 ```toml
-tfhe = { version = "~1.6.3", features = ["boolean", "shortint", "integer", "software-prng"] }
+tfhe = { version = "~1.6.4", features = ["boolean", "shortint", "integer", "software-prng"] }
 ```
 
 ## Hardware acceleration

--- a/tfhe/docs/getting-started/quick-start.md
+++ b/tfhe/docs/getting-started/quick-start.md
@@ -59,7 +59,7 @@ edition = "2021"
 Then add the following configuration to include **TFHE-rs**:
 
 ```toml
-tfhe = { version = "~1.6.3", features = ["integer"] }
+tfhe = { version = "~1.6.4", features = ["integer"] }
 ```
 
 Your updated `Cargo.toml` file should look like this:
@@ -71,7 +71,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-tfhe = { version = "~1.6.3", features = ["integer"] }
+tfhe = { version = "~1.6.4", features = ["integer"] }
 ```
 
 If you are on a different platform please refer to the [installation documentation](installation.md) for configuration options of other supported platforms.

--- a/tfhe/docs/references/core-crypto-api/tutorial.md
+++ b/tfhe/docs/references/core-crypto-api/tutorial.md
@@ -9,7 +9,7 @@ Welcome to this tutorial about `TFHE-rs` `core_crypto` module.
 To use `TFHE-rs`, it first has to be added as a dependency in the `Cargo.toml`:
 
 ```toml
-tfhe = { version = "~1.6.3" }
+tfhe = { version = "~1.6.4" }
 ```
 
 ### Commented code to double a 2-bit message in a leveled fashion and using a PBS with the `core_crypto` module.

--- a/tfhe/docs/tutorials/ascii-fhe-string.md
+++ b/tfhe/docs/tutorials/ascii-fhe-string.md
@@ -28,7 +28,7 @@ To use the `FheUint8` type, enable the `integer` feature:
 # Cargo.toml
 
 [dependencies]
-tfhe = { version = "~1.6.3", features = ["integer"] }
+tfhe = { version = "~1.6.4", features = ["integer"] }
 ```
 
 The `MyFheString::encrypt` function performs data validation to ensure the input string contains only ASCII characters.
@@ -167,7 +167,7 @@ First, add the feature in your `Cargo.toml`
 # Cargo.toml
 
 [dependencies]
-tfhe = { version = "~1.6.3", features = ["strings"] }
+tfhe = { version = "~1.6.4", features = ["strings"] }
 ```
 
 The `FheAsciiString` type allows to simply do homomorphic case changing of encrypted strings (and much more!):

--- a/tfhe/docs/tutorials/parity-bit.md
+++ b/tfhe/docs/tutorials/parity-bit.md
@@ -17,7 +17,7 @@ This function returns a Boolean (`true` or `false`) so that the total count of `
 ```toml
 # Cargo.toml
 
-tfhe = { version = "~1.6.3", features = ["integer"] }
+tfhe = { version = "~1.6.4", features = ["integer"] }
 ```
 
 First, define the verification function.

--- a/tfhe/src/shortint/keycache.rs
+++ b/tfhe/src/shortint/keycache.rs
@@ -11,6 +11,12 @@ use crate::shortint::wopbs::WopbsKey;
 use crate::shortint::{ClientKey, KeySwitchingKey, ServerKey};
 use serde::{Deserialize, Serialize};
 
+// This parameter set is deprecated but must still be known by the key cache, shadow it locally
+// to avoid deprecation warnings in the macro expansion.
+#[allow(deprecated)]
+const V1_6_PARAM_GPU_MESSAGE_1_CARRY_1_KS_PBS_TUNIFORM_2M128: ClassicPBSParameters =
+    crate::shortint::parameters::current_params::V1_6_PARAM_GPU_MESSAGE_1_CARRY_1_KS_PBS_TUNIFORM_2M128;
+
 named_params_impl!( ShortintParameterSet =>
     V1_6_PARAM_MESSAGE_1_CARRY_0_KS_PBS_GAUSSIAN_2M128,
     V1_6_PARAM_MESSAGE_1_CARRY_1_KS_PBS_GAUSSIAN_2M128,

--- a/tfhe/src/shortint/parameters/v1_6/classic/tuniform/p_fail_2_minus_128/ks_pbs_gpu.rs
+++ b/tfhe/src/shortint/parameters/v1_6/classic/tuniform/p_fail_2_minus_128/ks_pbs_gpu.rs
@@ -5,6 +5,10 @@ use crate::shortint::parameters::{
 };
 
 /// p-fail = 2^-144.851, algorithmic cost ~ 93.2, 2-norm = 3
+#[deprecated(
+    since = "1.6.4",
+    note = "This parameter set has lower pfail than expected, upgrade to 1.8+ for a replacement"
+)]
 pub const V1_6_PARAM_GPU_MESSAGE_1_CARRY_1_KS_PBS_TUNIFORM_2M128: ClassicPBSParameters =
     ClassicPBSParameters {
         lwe_dimension: LweDimension(759),

--- a/tfhe/src/shortint/parameters/v1_6/mod.rs
+++ b/tfhe/src/shortint/parameters/v1_6/mod.rs
@@ -51,6 +51,7 @@ use crate::shortint::parameters::{
 };
 
 /// All [`ClassicPBSParameters`] in this module.
+#[allow(deprecated)]
 pub const VEC_ALL_CLASSIC_PBS_PARAMETERS: [(&ClassicPBSParameters, &str); 142] = [
     (
         &V1_6_PARAM_MESSAGE_1_CARRY_0_COMPACT_PK_KS_PBS_GAUSSIAN_2M64,


### PR DESCRIPTION
<!-- Feel free to delete the template if the PR (bumping a version e.g.) does not fit the template -->
closes: _please link all relevant issues_

### PR content/description
deprecate tuniform 1_1 params
### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
