### PR TITLE
feat(gpu): add custom size lhs rhs mul and mul_add

### DIFF
--- a/backends/tfhe-cuda-backend/cuda/include/integer/integer.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer/integer.h
@@ -446,6 +446,35 @@ void cuda_partial_sum_ciphertexts_vec_64_async(
 void cleanup_cuda_partial_sum_ciphertexts_vec_64(CudaStreamsFFI streams,
                                                  int8_t **mem_ptr_void);
 
+// Fixed-point fused multiply-add with an asymmetric right operand.
+// `mode` is 0 for the fixed-point shape (accumulator = lhs + rhs + rescaling,
+// low columns below the precision threshold skipped) and 1 for the low half of
+// a square product with caller-supplied extra terms. In both cases the result
+// has as many blocks as the left operand.
+uint64_t scratch_cuda_mul_add_fixed_point_64_async(
+    CudaStreamsFFI streams, int8_t **mem_ptr, uint32_t mode,
+    uint32_t lhs_blocks, uint32_t rhs_blocks, uint32_t rescaling,
+    uint32_t precision, uint32_t max_extra_terms, uint32_t message_modulus,
+    uint32_t carry_modulus, CudaLweBootstrapKeyParamsFFI bsk_params,
+    CudaLweKeyswitchKeyParamsFFI ksk_params, bool allocate_gpu_memory,
+    PBS_MS_REDUCTION_T noise_reduction_type);
+
+void cuda_mul_add_fixed_point_with_rescaling_64_async(
+    CudaStreamsFFI streams, CudaRadixCiphertextFFI *result,
+    CudaRadixCiphertextFFI const *lhs, CudaRadixCiphertextFFI const *rhs,
+    CudaRadixCiphertextFFI const *added, int8_t *mem_ptr, void *const *bsks,
+    void *const *ksks);
+
+void cuda_mul_low_partial_sum_64_async(
+    CudaStreamsFFI streams, CudaRadixCiphertextFFI *result,
+    CudaRadixCiphertextFFI const *lhs, CudaRadixCiphertextFFI const *rhs,
+    CudaRadixCiphertextFFI const *extra_terms, uint32_t num_extra_terms,
+    bool propagate_carries, int8_t *mem_ptr, void *const *bsks,
+    void *const *ksks);
+
+void cleanup_cuda_mul_add_fixed_point_64(CudaStreamsFFI streams,
+                                         int8_t **mem_ptr_void);
+
 uint64_t scratch_cuda_integer_scalar_mul_64_async(
     CudaStreamsFFI streams, int8_t **mem_ptr,
     CudaLweBootstrapKeyParamsFFI bsk_params,

--- a/backends/tfhe-cuda-backend/cuda/include/integer/multiplication.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer/multiplication.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "cmux.h"
 #include "integer_utilities.h"
+#include <cstring>
 
 template <typename Torus> struct int_mul_memory {
   CudaRadixCiphertextFFI *vector_result_sb;
@@ -149,6 +150,396 @@ template <typename Torus> struct int_mul_memory {
     delete luts_array;
     delete sum_ciphertexts_mem;
     delete sc_prop_mem;
+    cuda_synchronize_stream(streams.stream(0), streams.gpu_index(0));
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Fixed-point fused multiply-add with an asymmetric right operand
+// ---------------------------------------------------------------------------
+//
+// Computes, over a radix of base beta = message_modulus:
+//
+//     result[L] = trunc_beta^s( lhs[L] * rhs[R] + added[L] * beta^s )
+//
+// where s = R + |rescaling| is the number of low blocks dropped from the
+// product, so that the output has exactly as many blocks as `lhs`. This is the
+// primitive the Goldschmidt divider needs: the left operand carries the running
+// numerator/denominator (L blocks) and the right one the short iteration factor
+// (R << L blocks).
+//
+// Two shapes are supported, selected at scratch time:
+//
+//   MUL_ADD_MODE_FIXED_POINT
+//     accumulator W  = L + R + |rescaling|
+//     dropped blocks s = R + |rescaling|
+//     skip k         = the largest column count whose worst-case weight stays
+//                      below 2^precision, i.e. below one output ulp. Those
+//                      columns are never bootstrapped.
+//
+//   MUL_ADD_MODE_MUL_LOW
+//     accumulator W  = L = R = n, skip = 0, s = 0
+//     i.e. the low half of a square product, plus caller-supplied extra terms.
+//     Used for the remainder r = n - q*d, where the extra terms are bitnot(n)
+//     and a trivial 1.
+//
+// The (lhs block, rhs block) pairs that survive both the skip threshold and the
+// accumulator width are enumerated once on the host at scratch time - the set
+// only depends on the shape, never on the data - and turned into gather/scatter
+// index maps. Only those pairs are bootstrapped, which is what keeps this at
+// the CPU implementation's block-multiplication count.
+//
+// The surviving pairs form a trapezoid rather than the square matrix a naive
+// port would bootstrap: columns below `skip` weigh less than one output ulp,
+// and columns at or above `accumulator` fall off the top. For L = 34, R = 5, k
+// = 3 (the seed step), with a = lhs block index and column = a + r:
+//
+//     column   0  1  2 | 3  4  5 ...            36 37 38 | (>= W: dropped)
+//              -  -  - | x  x  x                 x  x  x
+//     r = 0    .  .  . | *  *  *  ...            *  *  .
+//     r = 1       .  . | *  *  *  ...            *  *  *
+//     r = 2          . | *  *  *  ...            *  *  *
+//     r = 3            | *  *  *  ...            *  *  *
+//     r = 4            | *  *  *  ...            *  *  *
+//              \_____ skipped: total weight < 1 output ulp
+//
+// Each surviving '*' becomes one bivariate bootstrap, producing a message half
+// at `column` and a carry half at `column + 1`. Those land in a dense term
+// vector of (2R + 1) rows by `window = accumulator - skip` blocks, which the
+// column sum consumes directly - row r holds the message halves of rhs block r,
+// row R + r its carry halves, and the last row the `added` operand, shifted so
+// its LSB sits at the output's LSB:
+//
+//     terms row  0    [ . . lsb products of r=0 . . ]
+//                ...
+//     terms row  R-1  [ . . lsb products of r=R-1 . ]
+//     terms row  R    [ . . msb products of r=0 . . ]
+//                ...
+//     terms row 2R-1  [ . . msb products of r=R-1 . ]
+//     terms row 2R    [ 0 ... 0 | added ........... ]
+//                       |<- s-k ->|
+//
+// The retained output is the top L blocks of that window, i.e. blocks
+// [s - k, s - k + L) of the summed accumulator.
+#define MUL_ADD_MODE_FIXED_POINT 0u
+#define MUL_ADD_MODE_MUL_LOW 1u
+
+// Worst-case weight of the low `columns` columns of a schoolbook product whose
+// right operand has `rhs_length` blocks, in units of the product's LSB.
+// Saturating 128-bit arithmetic: a 64-bit target (2^precision with precision up
+// to 66 in this algorithm) does not fit in uint64_t.
+inline __uint128_t mul_add_sat_mul(__uint128_t a, __uint128_t b) {
+  const __uint128_t max = ~(__uint128_t)0;
+  if (a == 0 || b == 0)
+    return 0;
+  if (a > max / b)
+    return max;
+  return a * b;
+}
+
+inline __uint128_t mul_add_sat_pow(__uint128_t base, uint32_t exp) {
+  __uint128_t result = 1;
+  for (uint32_t i = 0; i < exp; i++)
+    result = mul_add_sat_mul(result, base);
+  return result;
+}
+
+// c * beta^(c+1) - (c+1) * beta^c + 1, the bound when every dropped column is
+// still growing (columns <= rhs_length).
+inline __uint128_t mul_add_triangular_max(uint32_t columns,
+                                          uint32_t block_size) {
+  __uint128_t term1 =
+      mul_add_sat_mul(columns, mul_add_sat_pow(block_size, columns + 1));
+  __uint128_t term2 =
+      mul_add_sat_mul(columns + 1, mul_add_sat_pow(block_size, columns));
+  if (term1 < term2)
+    return 1;
+  return term1 - term2 + 1;
+}
+
+// Same bound once the columns saturate at rhs_length entries.
+inline __uint128_t mul_add_general_max(uint32_t columns, uint32_t block_size,
+                                       uint32_t rhs_length) {
+  if (columns <= rhs_length)
+    return mul_add_triangular_max(columns, block_size);
+  __uint128_t triangular = mul_add_triangular_max(rhs_length, block_size);
+  __uint128_t rectangular = mul_add_sat_mul(
+      mul_add_sat_mul(
+          mul_add_sat_mul(rhs_length, mul_add_sat_pow(block_size, rhs_length)),
+          mul_add_sat_pow(block_size, columns - rhs_length) - 1),
+      block_size - 1);
+  const __uint128_t max = ~(__uint128_t)0;
+  if (triangular > max - rectangular)
+    return max;
+  return triangular + rectangular;
+}
+
+// Largest number of low columns that can be dropped while keeping the discarded
+// weight strictly below 2^precision.
+inline uint32_t mul_add_find_max_columns(uint32_t block_size,
+                                         uint32_t rhs_length,
+                                         uint32_t precision) {
+  if (rhs_length == 0)
+    return 0;
+  __uint128_t target = (__uint128_t)1 << precision;
+  for (uint32_t columns = 0; columns <= 4096; columns++) {
+    if (mul_add_general_max(columns, block_size, rhs_length) >= target)
+      return columns == 0 ? 0 : columns - 1;
+  }
+  PANIC("Cuda error (mul_add_fixed_point): could not determine the number of "
+        "columns to skip")
+  return 0;
+}
+
+template <typename Torus> struct int_mul_add_fixed_point_memory {
+  int_radix_params params;
+  bool gpu_memory_allocated;
+
+  uint32_t mode;
+  uint32_t lhs_blocks;  // L, also the output width
+  uint32_t rhs_blocks;  // R
+  uint32_t rescaling;   // |rescaling|, the extra low blocks dropped
+  uint32_t precision;   // bits of the output ulp, drives `skip`
+  uint32_t skip;        // k, low columns never computed
+  uint32_t accumulator; // W
+  uint32_t window;      // W - k, the only part of the accumulator we build
+  uint32_t out_shift;   // s = R + |rescaling|
+  uint32_t max_extra_terms;
+  uint32_t num_terms; // 2R + (added slot) + extra terms
+  uint32_t num_lsb_pairs;
+  uint32_t num_pairs; // lsb + msb, i.e. the bootstrap count of one call
+
+  // Compact per-pair operands. `pair_products` holds the rhs blocks on entry
+  // and the bootstrapped block products on exit (the bivariate LUT is applied
+  // in place, as in host_integer_mult_radix).
+  CudaRadixCiphertextFFI *pair_lhs;
+  CudaRadixCiphertextFFI *pair_products;
+  // num_terms * window, consumed directly by the column sum (no copy).
+  CudaRadixCiphertextFFI *terms;
+  CudaRadixCiphertextFFI *small_lwe_vector;
+  CudaRadixCiphertextFFI *sum_result;
+
+  uint32_t *d_pair_lhs_idx;
+  uint32_t *d_pair_rhs_idx;
+  uint32_t *d_pair_dst_idx;
+  uint32_t *h_pair_lhs_idx;
+  uint32_t *h_pair_rhs_idx;
+  // Degrees and noise levels of the product slots of `terms`, laid out exactly
+  // as the term vector: copied in wholesale on every call, then the added/extra
+  // slots are overwritten from the actual inputs.
+  uint64_t *h_product_degrees;
+  uint64_t *h_product_noise_levels;
+
+  int_radix_lut<Torus> *luts_array; // {lsb, msb} block multiplication
+  int_radix_lut<Torus> *sum_luts;   // {message, carry} for the column sum
+  int_sum_ciphertexts_vec_memory<Torus> *sum_mem;
+  int_sc_prop_memory<Torus> *sc_prop_mem;
+
+  int_mul_add_fixed_point_memory(CudaStreams streams, int_radix_params params,
+                                 uint32_t mode, uint32_t lhs_blocks,
+                                 uint32_t rhs_blocks, uint32_t rescaling,
+                                 uint32_t precision, uint32_t max_extra_terms,
+                                 bool allocate_gpu_memory,
+                                 uint64_t &size_tracker) {
+    this->params = params;
+    this->gpu_memory_allocated = allocate_gpu_memory;
+    this->mode = mode;
+    this->lhs_blocks = lhs_blocks;
+    this->rhs_blocks = rhs_blocks;
+    this->rescaling = rescaling;
+    this->precision = precision;
+    this->max_extra_terms = max_extra_terms;
+
+    PANIC_IF_FALSE(lhs_blocks > 0 && rhs_blocks > 0,
+                   "Cuda error (mul_add_fixed_point): both operands must have "
+                   "at least one block");
+
+    auto message_modulus = params.message_modulus;
+
+    if (mode == MUL_ADD_MODE_MUL_LOW) {
+      PANIC_IF_FALSE(lhs_blocks == rhs_blocks,
+                     "Cuda error (mul_add_fixed_point): the mul-low shape "
+                     "expects two operands of the same width");
+      this->skip = 0;
+      this->accumulator = lhs_blocks;
+      this->out_shift = 0;
+      this->num_terms = 2 * rhs_blocks + max_extra_terms;
+    } else {
+      this->skip =
+          mul_add_find_max_columns(message_modulus, rhs_blocks, precision);
+      this->accumulator = lhs_blocks + rhs_blocks + rescaling;
+      this->out_shift = rhs_blocks + rescaling;
+      this->num_terms = 2 * rhs_blocks + 1 + max_extra_terms;
+      PANIC_IF_FALSE(this->skip <= this->out_shift,
+                     "Cuda error (mul_add_fixed_point): the truncation "
+                     "threshold reaches into the retained output blocks");
+    }
+    this->window = this->accumulator - this->skip;
+
+    // Enumerate the surviving (lhs block, rhs block) pairs: lsb halves first so
+    // a single lut_indexes run switches to the msb LUT, mirroring
+    // host_integer_mult_radix.
+    uint32_t max_pairs = 2 * lhs_blocks * rhs_blocks;
+    h_pair_lhs_idx = new uint32_t[max_pairs];
+    h_pair_rhs_idx = new uint32_t[max_pairs];
+    uint32_t *h_pair_dst_idx = new uint32_t[max_pairs];
+    h_product_degrees = new uint64_t[(size_t)num_terms * window];
+    h_product_noise_levels = new uint64_t[(size_t)num_terms * window];
+    std::memset(h_product_degrees, 0,
+                safe_mul_sizeof<uint64_t>((size_t)num_terms * window));
+
+    uint32_t idx = 0;
+    for (uint32_t r = 0; r < rhs_blocks; r++) {
+      for (uint32_t a = 0; a < lhs_blocks; a++) {
+        uint32_t column = a + r;
+        if (column < skip || column >= accumulator)
+          continue;
+        h_pair_lhs_idx[idx] = a;
+        h_pair_rhs_idx[idx] = r;
+        h_pair_dst_idx[idx] = r * window + (column - skip);
+        h_product_degrees[h_pair_dst_idx[idx]] = message_modulus - 1;
+        idx++;
+      }
+    }
+    num_lsb_pairs = idx;
+    for (uint32_t r = 0; r < rhs_blocks; r++) {
+      for (uint32_t a = 0; a < lhs_blocks; a++) {
+        uint32_t column = a + r + 1;
+        if (a + r < skip || column >= accumulator)
+          continue;
+        h_pair_lhs_idx[idx] = a;
+        h_pair_rhs_idx[idx] = r;
+        h_pair_dst_idx[idx] = (rhs_blocks + r) * window + (column - skip);
+        h_product_degrees[h_pair_dst_idx[idx]] = message_modulus - 2;
+        idx++;
+      }
+    }
+    num_pairs = idx;
+    // Every block that carries a product comes straight out of a bootstrap.
+    for (size_t i = 0; i < (size_t)num_terms * window; i++)
+      h_product_noise_levels[i] = h_product_degrees[i] ? 1 : 0;
+    PANIC_IF_FALSE(num_pairs > 0,
+                   "Cuda error (mul_add_fixed_point): the shape leaves no "
+                   "block product to compute");
+
+    d_pair_lhs_idx = (uint32_t *)cuda_malloc_with_size_tracking_async(
+        safe_mul_sizeof<uint32_t>(num_pairs), streams.stream(0),
+        streams.gpu_index(0), size_tracker, allocate_gpu_memory);
+    d_pair_rhs_idx = (uint32_t *)cuda_malloc_with_size_tracking_async(
+        safe_mul_sizeof<uint32_t>(num_pairs), streams.stream(0),
+        streams.gpu_index(0), size_tracker, allocate_gpu_memory);
+    d_pair_dst_idx = (uint32_t *)cuda_malloc_with_size_tracking_async(
+        safe_mul_sizeof<uint32_t>(num_pairs), streams.stream(0),
+        streams.gpu_index(0), size_tracker, allocate_gpu_memory);
+    if (allocate_gpu_memory) {
+      cuda_memcpy_async_to_gpu(d_pair_lhs_idx, h_pair_lhs_idx,
+                               safe_mul_sizeof<uint32_t>(num_pairs),
+                               streams.stream(0), streams.gpu_index(0));
+      cuda_memcpy_async_to_gpu(d_pair_rhs_idx, h_pair_rhs_idx,
+                               safe_mul_sizeof<uint32_t>(num_pairs),
+                               streams.stream(0), streams.gpu_index(0));
+      cuda_memcpy_async_to_gpu(d_pair_dst_idx, h_pair_dst_idx,
+                               safe_mul_sizeof<uint32_t>(num_pairs),
+                               streams.stream(0), streams.gpu_index(0));
+      cuda_synchronize_stream(streams.stream(0), streams.gpu_index(0));
+    }
+    delete[] h_pair_dst_idx;
+
+    pair_lhs = new CudaRadixCiphertextFFI;
+    create_zero_radix_ciphertext_async<Torus>(
+        streams.stream(0), streams.gpu_index(0), pair_lhs, num_pairs,
+        params.big_lwe_dimension, size_tracker, allocate_gpu_memory);
+    pair_products = new CudaRadixCiphertextFFI;
+    create_zero_radix_ciphertext_async<Torus>(
+        streams.stream(0), streams.gpu_index(0), pair_products, num_pairs,
+        params.big_lwe_dimension, size_tracker, allocate_gpu_memory);
+    terms = new CudaRadixCiphertextFFI;
+    create_zero_radix_ciphertext_async<Torus>(
+        streams.stream(0), streams.gpu_index(0), terms, num_terms * window,
+        params.big_lwe_dimension, size_tracker, allocate_gpu_memory);
+    small_lwe_vector = new CudaRadixCiphertextFFI;
+    create_zero_radix_ciphertext_async<Torus>(
+        streams.stream(0), streams.gpu_index(0), small_lwe_vector,
+        num_terms * window, params.small_lwe_dimension, size_tracker,
+        allocate_gpu_memory);
+    sum_result = new CudaRadixCiphertextFFI;
+    create_zero_radix_ciphertext_async<Torus>(
+        streams.stream(0), streams.gpu_index(0), sum_result, window,
+        params.big_lwe_dimension, size_tracker, allocate_gpu_memory);
+
+    // {lsb, msb} block multiplication, one index run per half.
+    luts_array = new int_radix_lut<Torus>(streams, params, 2, num_pairs,
+                                          allocate_gpu_memory, size_tracker);
+    auto lut_f_lsb = [message_modulus](Torus x, Torus y) -> Torus {
+      return (x * y) % message_modulus;
+    };
+    auto lut_f_msb = [message_modulus](Torus x, Torus y) -> Torus {
+      return (x * y) / message_modulus;
+    };
+    auto num_lsb = num_lsb_pairs;
+    auto lut_index_generator = [num_lsb](Torus *h_lut_indexes,
+                                         uint32_t num_indexes) {
+      for (uint32_t i = 0; i < num_indexes; i++)
+        h_lut_indexes[i] = (i < num_lsb) ? 0 : 1;
+    };
+    auto active_streams = streams.active_gpu_subset(num_pairs, params.pbs_type);
+    luts_array->generate_and_broadcast_bivariate_lut(
+        active_streams, {0, 1}, {lut_f_lsb, lut_f_msb}, lut_index_generator);
+
+    // The column sum needs its own {message, carry} LUT: sharing `luts_array`
+    // the way int_mul_memory does would overwrite the block-multiplication
+    // accumulators, which is only safe when the buffer is scratched per call.
+    uint32_t chunk_size = params.max_degree();
+    uint32_t max_pbs_count =
+        std::max(2 * ((num_terms * window) / chunk_size), 2 * window);
+    sum_luts = new int_radix_lut<Torus>(streams, params, 2, max_pbs_count,
+                                        allocate_gpu_memory, size_tracker);
+    sum_mem = new int_sum_ciphertexts_vec_memory<Torus>(
+        streams, params, window, num_terms, terms, small_lwe_vector, sum_luts,
+        true, allocate_gpu_memory, size_tracker);
+    sc_prop_mem = new int_sc_prop_memory<Torus>(
+        streams, params, window, outputFlag::FLAG_NONE, allocate_gpu_memory,
+        size_tracker);
+  }
+
+  void release(CudaStreams streams) {
+    release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0),
+                                   pair_lhs, gpu_memory_allocated);
+    release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0),
+                                   pair_products, gpu_memory_allocated);
+    release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0),
+                                   terms, gpu_memory_allocated);
+    release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0),
+                                   small_lwe_vector, gpu_memory_allocated);
+    release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0),
+                                   sum_result, gpu_memory_allocated);
+    cuda_drop_with_size_tracking_async(d_pair_lhs_idx, streams.stream(0),
+                                       streams.gpu_index(0),
+                                       gpu_memory_allocated);
+    cuda_drop_with_size_tracking_async(d_pair_rhs_idx, streams.stream(0),
+                                       streams.gpu_index(0),
+                                       gpu_memory_allocated);
+    cuda_drop_with_size_tracking_async(d_pair_dst_idx, streams.stream(0),
+                                       streams.gpu_index(0),
+                                       gpu_memory_allocated);
+    luts_array->release(streams);
+    sum_mem->release(streams);
+    sum_luts->release(streams);
+    sc_prop_mem->release(streams);
+
+    delete pair_lhs;
+    delete pair_products;
+    delete terms;
+    delete small_lwe_vector;
+    delete sum_result;
+    delete luts_array;
+    delete sum_mem;
+    delete sum_luts;
+    delete sc_prop_mem;
+    delete[] h_pair_lhs_idx;
+    delete[] h_pair_rhs_idx;
+    delete[] h_product_degrees;
+    delete[] h_product_noise_levels;
     cuda_synchronize_stream(streams.stream(0), streams.gpu_index(0));
   }
 };

--- a/backends/tfhe-cuda-backend/cuda/include/integer/shift_and_rotate.h
+++ b/backends/tfhe-cuda-backend/cuda/include/integer/shift_and_rotate.h
@@ -7,6 +7,13 @@ template <typename Torus> struct int_shift_and_rotate_buffer {
   SHIFT_OR_ROTATE_TYPE shift_type;
   bool is_signed;
 
+  /// @brief Selects the algorithm. When true the block-level barrel shifter
+  /// (host_block_shift_and_rotate_inplace) runs, otherwise the bit-level one
+  /// (host_shift_and_rotate_inplace). Only the buffers of the selected path
+  /// are allocated; the other path's pointers stay null.
+  bool use_block_path;
+
+  // ---- bit-level path ----
   CudaRadixCiphertextFFI *tmp_bits;
   CudaRadixCiphertextFFI *tmp_shift_bits;
   CudaRadixCiphertextFFI *tmp_rotated;
@@ -18,6 +25,48 @@ template <typename Torus> struct int_shift_and_rotate_buffer {
   int_bit_extract_luts_buffer<Torus> *bit_extract_luts_with_offset_2;
   int_radix_lut<Torus> *mux_lut;
   int_radix_lut<Torus> *cleaning_lut;
+
+  // ---- block-level path ----
+  // Working array holding the result being built, plus the two "donor" arrays
+  // of the fused first round (what each block hands to the block one and two
+  // positions away).
+  CudaRadixCiphertextFFI *blk_messages;
+  CudaRadixCiphertextFFI *blk_next;
+  CudaRadixCiphertextFFI *blk_next_next;
+  /// @brief Destination of the block rotations, which are not in-place.
+  CudaRadixCiphertextFFI *blk_rotate_tmp;
+  /// @brief Holds (input block) * message_modulus + (amount block 0) for the
+  /// three bivariate LUTs of the first round.
+  CudaRadixCiphertextFFI *blk_pack_tmp;
+  /// @brief Many-LUT output of a barrel round: messages in [0, num_blocks),
+  /// carries in [num_blocks, 2 * num_blocks).
+  CudaRadixCiphertextFFI *blk_many_out;
+  /// @brief Shift-amount bits 2.. , one per remaining barrel round, already
+  /// aligned on the control-bit position.
+  CudaRadixCiphertextFFI *blk_shift_bits;
+  /// @brief Sign bit of the original input (arithmetic right shift only).
+  CudaRadixCiphertextFFI *blk_sign;
+  /// @brief Sign-extension block used to fill the slots that wrap around
+  /// during an arithmetic right shift, recomputed every round.
+  CudaRadixCiphertextFFI *blk_padding;
+  CudaRadixCiphertextFFI *blk_padding_in;
+  /// @brief Copy of the top block after the first round; the sign bit read to
+  /// build blk_padding, kept because blk_messages is overwritten each round.
+  CudaRadixCiphertextFFI *blk_saved_top;
+
+  int_radix_lut<Torus> *blk_msg_lut;
+  int_radix_lut<Torus> *blk_next_lut;
+  int_radix_lut<Torus> *blk_next_next_lut;
+  int_radix_lut<Torus> *blk_round_lut;
+  int_radix_lut<Torus> *blk_sign_lut;
+  int_radix_lut<Torus> *blk_padding_lut;
+  /// @brief Number of barrel rounds left after the fused first round.
+  uint32_t blk_num_rounds;
+  /// @brief Number of amount blocks, starting at block 1, the rounds' shift
+  /// bits are extracted from.
+  uint32_t blk_num_amount_blocks;
+  /// @brief Distance between the two sub-LUTs packed in blk_round_lut.
+  uint32_t blk_lut_stride;
 
   // Overshift handling: shifting by >= the integer's bit width yields 0, or the
   // sign (0 / -1) for an arithmetic right shift.
@@ -80,6 +129,53 @@ template <typename Torus> struct int_shift_and_rotate_buffer {
 
     offset = (shift_type == LEFT_SHIFT ? 0 : total_nb_bits);
 
+    // The block-level barrel shifter costs roughly half the PBS of the
+    // bit-level one, but it requires blocks holding a power-of-two number of
+    // message bits and a noise budget of three additions before a PBS. Only
+    // 2_2 is enabled for now; every other parameter set keeps the bit-level
+    // path. A single block is excluded because the fused first round needs a
+    // neighbour to hand its overflow to.
+    use_block_path = (params.message_modulus == 4 &&
+                      params.carry_modulus == 4 && num_radix_blocks > 1);
+
+    cleaning_lut =
+        new int_radix_lut<Torus>(streams, params, 1, num_radix_blocks,
+                                 allocate_gpu_memory, size_tracker);
+
+    auto cleaning_lut_f = [params](Torus x) -> Torus {
+      return x % params.message_modulus;
+    };
+    auto active_gpu_count_cleaning =
+        streams.active_gpu_subset(num_radix_blocks, params.pbs_type);
+    cleaning_lut->generate_and_broadcast_lut(
+        active_gpu_count_cleaning, {0}, {cleaning_lut_f}, LUT_0_FOR_ALL_BLOCKS);
+
+    if (use_block_path) {
+      setup_bit_path_null();
+      setup_block_path(streams, num_radix_blocks, bits_per_block,
+                       max_num_bits_that_tell_shift, allocate_gpu_memory,
+                       size_tracker);
+    } else {
+      setup_block_path_null();
+      setup_bit_path(streams, num_radix_blocks, bits_per_block,
+                     max_num_bits_that_tell_shift, allocate_gpu_memory,
+                     size_tracker);
+    }
+
+    // ---- Overshift handling (shifts only, not rotations) ----
+    setup_handle_overshift(streams, num_radix_blocks, total_nb_bits,
+                           allocate_gpu_memory, size_tracker);
+  }
+
+  /// @brief Allocates the buffers and LUTs of the bit-level barrel shifter,
+  /// which explodes both operands into one-bit ciphertexts and runs a cmux per
+  /// bit and per round.
+  void setup_bit_path(CudaStreams streams, uint32_t num_radix_blocks,
+                      uint32_t bits_per_block,
+                      uint32_t max_num_bits_that_tell_shift,
+                      bool allocate_gpu_memory, uint64_t &size_tracker) {
+    auto params = this->params;
+
     bit_extract_luts = new int_bit_extract_luts_buffer<Torus>(
         streams, params, bits_per_block, num_radix_blocks, allocate_gpu_memory,
         size_tracker);
@@ -90,9 +186,6 @@ template <typename Torus> struct int_shift_and_rotate_buffer {
     mux_lut = new int_radix_lut<Torus>(streams, params, 1,
                                        bits_per_block * num_radix_blocks,
                                        allocate_gpu_memory, size_tracker);
-    cleaning_lut =
-        new int_radix_lut<Torus>(streams, params, 1, num_radix_blocks,
-                                 allocate_gpu_memory, size_tracker);
 
     tmp_bits = new CudaRadixCiphertextFFI;
     create_zero_radix_ciphertext_async<Torus>(
@@ -152,19 +245,254 @@ template <typename Torus> struct int_shift_and_rotate_buffer {
 
     mux_lut->generate_and_broadcast_lut(active_gpu_count_mux, {0}, {mux_lut_f},
                                         LUT_0_FOR_ALL_BLOCKS);
+  }
 
-    auto cleaning_lut_f = [params](Torus x) -> Torus {
-      return x % params.message_modulus;
+  void setup_bit_path_null() {
+    tmp_bits = nullptr;
+    tmp_shift_bits = nullptr;
+    tmp_rotated = nullptr;
+    tmp_input_bits_a = nullptr;
+    tmp_input_bits_b = nullptr;
+    tmp_mux_inputs = nullptr;
+    bit_extract_luts = nullptr;
+    bit_extract_luts_with_offset_2 = nullptr;
+    mux_lut = nullptr;
+  }
+
+  void setup_block_path_null() {
+    blk_messages = nullptr;
+    blk_next = nullptr;
+    blk_next_next = nullptr;
+    blk_rotate_tmp = nullptr;
+    blk_pack_tmp = nullptr;
+    blk_many_out = nullptr;
+    blk_shift_bits = nullptr;
+    blk_sign = nullptr;
+    blk_padding = nullptr;
+    blk_padding_in = nullptr;
+    blk_saved_top = nullptr;
+    blk_msg_lut = nullptr;
+    blk_next_lut = nullptr;
+    blk_next_next_lut = nullptr;
+    blk_round_lut = nullptr;
+    blk_sign_lut = nullptr;
+    blk_padding_lut = nullptr;
+    blk_num_rounds = 0;
+    blk_num_amount_blocks = 0;
+    blk_lut_stride = 0;
+  }
+
+  /// @brief Allocates the buffers and LUTs of the block-level barrel shifter.
+  ///
+  /// The shift amount is split as `amount = 2 * t + s + 4 * rest`, where `s`
+  /// is the shift inside a block and `t` a shift by one block; both live in
+  /// amount block 0 and are consumed by the fused first round. `rest` drives
+  /// the remaining `blk_num_rounds` rounds, each shifting by `1 << d` blocks.
+  void setup_block_path(CudaStreams streams, uint32_t num_radix_blocks,
+                        uint32_t bits_per_block,
+                        uint32_t max_num_bits_that_tell_shift,
+                        bool allocate_gpu_memory, uint64_t &size_tracker) {
+    auto params = this->params;
+    auto message_modulus = params.message_modulus;
+    bool is_left = (shift_type == LEFT_SHIFT || shift_type == LEFT_ROTATE);
+    // Only a right shift of a signed value is arithmetic: it pads with the
+    // sign bit instead of zeros.
+    bool arithmetic = is_signed && (shift_type == RIGHT_SHIFT);
+
+    // Amount block 0 carries the first log2(bits_per_block) + 1 shift bits,
+    // consumed by the fused first round.
+    uint32_t bits_done_by_first_round = std::log2(bits_per_block) + 1;
+    blk_num_rounds =
+        (max_num_bits_that_tell_shift > bits_done_by_first_round)
+            ? max_num_bits_that_tell_shift - bits_done_by_first_round
+            : 0;
+    // Rounds read their bit from amount blocks 1.. , as the bits of block 0
+    // are already spent.
+    blk_num_amount_blocks =
+        std::max(1u, (blk_num_rounds + bits_per_block - 1) / bits_per_block);
+    GPU_ASSERT(blk_num_amount_blocks <= num_radix_blocks - 1,
+               "Cuda error: not enough shift amount blocks for the block "
+               "barrel shifter");
+
+    uint32_t block_modulus = message_modulus * params.carry_modulus;
+    uint32_t box_size = params.polynomial_size / block_modulus;
+    blk_lut_stride = (block_modulus / 2) * box_size;
+
+    auto alloc = [&](CudaRadixCiphertextFFI **ct, uint32_t n) {
+      *ct = new CudaRadixCiphertextFFI;
+      create_zero_radix_ciphertext_async<Torus>(
+          streams.stream(0), streams.gpu_index(0), *ct, n,
+          params.big_lwe_dimension, size_tracker, allocate_gpu_memory);
+    };
+    alloc(&blk_messages, num_radix_blocks);
+    alloc(&blk_next, num_radix_blocks);
+    alloc(&blk_next_next, num_radix_blocks);
+    alloc(&blk_rotate_tmp, num_radix_blocks);
+    alloc(&blk_pack_tmp, num_radix_blocks);
+    alloc(&blk_many_out, 2 * num_radix_blocks);
+    alloc(&blk_shift_bits, std::max(1u, blk_num_rounds));
+
+    // Shift bits are extracted onto plaintext position bits_per_block, which
+    // is where the round LUT expects the control bit.
+    bit_extract_luts_with_offset_2 = new int_bit_extract_luts_buffer<Torus>(
+        streams, params, bits_per_block, bits_per_block, blk_num_amount_blocks,
+        allocate_gpu_memory, size_tracker);
+
+    // ---- first round: three bivariate LUTs over (block, amount block 0) ----
+    // The packed input is x = block * message_modulus + a0.
+    auto split_amount = [message_modulus, bits_per_block](Torus x, Torus &s,
+                                                          Torus &t) {
+      Torus a0 = x % message_modulus;
+      s = a0 % bits_per_block;
+      t = (a0 / bits_per_block) % 2;
     };
 
-    auto active_gpu_count_cleaning =
-        streams.active_gpu_subset(num_radix_blocks, params.pbs_type);
-    cleaning_lut->generate_and_broadcast_lut(
-        active_gpu_count_cleaning, {0}, {cleaning_lut_f}, LUT_0_FOR_ALL_BLOCKS);
+    // What a block keeps of its own value.
+    auto f_msg = [=](Torus x) -> Torus {
+      Torus s, t;
+      split_amount(x, s, t);
+      Torus blk = x / message_modulus;
+      if (t == 1)
+        return 0; // the whole block moved to a neighbour
+      return is_left ? ((blk << s) % message_modulus) : (blk >> s);
+    };
+    // Same, for the block holding the sign: the value is first extended with
+    // sign bits so that shifting in from above brings in the sign.
+    auto f_msg_signed = [=](Torus x) -> Torus {
+      Torus s, t;
+      split_amount(x, s, t);
+      Torus blk = x / message_modulus;
+      Torus sign = (blk >> (bits_per_block - 1)) & 1;
+      Torus pad = (message_modulus - 1) * sign;
+      if (t == 1)
+        return pad;
+      return (((pad << bits_per_block) | blk) >> s) % message_modulus;
+    };
+    // What a block hands to the block one position away: its message part when
+    // the amount also moves a whole block, its overflowing part otherwise.
+    auto f_next = [=](Torus x) -> Torus {
+      Torus s, t;
+      split_amount(x, s, t);
+      Torus prev = x / message_modulus;
+      if (t == 1)
+        return is_left ? ((prev << s) % message_modulus) : (prev >> s);
+      return is_left ? (prev >> (bits_per_block - s))
+                     : ((prev << (bits_per_block - s)) % message_modulus);
+    };
+    auto f_next_signed = [=](Torus x) -> Torus {
+      Torus s, t;
+      split_amount(x, s, t);
+      Torus prev = x / message_modulus;
+      Torus sign = (prev >> (bits_per_block - 1)) & 1;
+      Torus pad = (message_modulus - 1) * sign;
+      if (t == 1)
+        return (((pad << bits_per_block) | prev) >> s) % message_modulus;
+      return (prev << (bits_per_block - s)) % message_modulus;
+    };
+    // What a block hands two positions away: only its overflowing part, and
+    // only when the amount also moves a whole block.
+    auto f_next_next = [=](Torus x) -> Torus {
+      Torus s, t;
+      split_amount(x, s, t);
+      Torus pp = x / message_modulus;
+      if (t == 0)
+        return 0;
+      return is_left ? (pp >> (bits_per_block - s))
+                     : ((pp << (bits_per_block - s)) % message_modulus);
+    };
 
-    // ---- Overshift handling (shifts only, not rotations) ----
-    setup_handle_overshift(streams, num_radix_blocks, total_nb_bits,
-                           allocate_gpu_memory, size_tracker);
+    // For an arithmetic right shift the top block needs the sign-extended
+    // variants; every other block uses LUT 0.
+    auto last_block_uses_lut_1 = [num_radix_blocks](Torus *h_lut_indexes,
+                                                    uint32_t) {
+      for (uint32_t i = 0; i < num_radix_blocks; i++)
+        h_lut_indexes[i] = (i == num_radix_blocks - 1) ? 1 : 0;
+    };
+    auto active_streams =
+        streams.active_gpu_subset(num_radix_blocks, params.pbs_type);
+
+    uint32_t num_first_round_luts = arithmetic ? 2 : 1;
+    blk_msg_lut = new int_radix_lut<Torus>(
+        streams, params, num_first_round_luts, num_radix_blocks,
+        allocate_gpu_memory, size_tracker);
+    blk_next_lut = new int_radix_lut<Torus>(
+        streams, params, num_first_round_luts, num_radix_blocks,
+        allocate_gpu_memory, size_tracker);
+    blk_next_next_lut =
+        new int_radix_lut<Torus>(streams, params, 1, num_radix_blocks,
+                                 allocate_gpu_memory, size_tracker);
+
+    if (arithmetic) {
+      blk_msg_lut->generate_and_broadcast_lut(
+          active_streams, {0, 1}, {f_msg, f_msg_signed}, last_block_uses_lut_1);
+      blk_next_lut->generate_and_broadcast_lut(active_streams, {0, 1},
+                                               {f_next, f_next_signed},
+                                               last_block_uses_lut_1);
+    } else {
+      blk_msg_lut->generate_and_broadcast_lut(active_streams, {0}, {f_msg},
+                                              LUT_0_FOR_ALL_BLOCKS);
+      blk_next_lut->generate_and_broadcast_lut(active_streams, {0}, {f_next},
+                                               LUT_0_FOR_ALL_BLOCKS);
+    }
+    blk_next_next_lut->generate_and_broadcast_lut(
+        active_streams, {0}, {f_next_next}, LUT_0_FOR_ALL_BLOCKS);
+
+    // ---- barrel rounds: one many-LUT splitting message and carry ----
+    // Input is (block + shift_bit << bits_per_block): when the round's shift
+    // bit is set the whole block moves, otherwise it stays.
+    auto f_round_message = [=](Torus x) -> Torus {
+      Torus control = (x >> bits_per_block) % 2;
+      return control == 1 ? 0 : (x % message_modulus);
+    };
+    auto f_round_carry = [=](Torus x) -> Torus {
+      Torus control = (x >> bits_per_block) % 2;
+      return control == 1 ? (x % message_modulus) : 0;
+    };
+    blk_round_lut =
+        new int_radix_lut<Torus>(streams, params, 1, num_radix_blocks, 2,
+                                 allocate_gpu_memory, size_tracker);
+    blk_round_lut->generate_and_broadcast_many_lut(
+        active_streams, {0}, {{f_round_message, f_round_carry}},
+        LUT_0_FOR_ALL_BLOCKS);
+
+    // ---- arithmetic right shift extras ----
+    if (arithmetic) {
+      alloc(&blk_sign, 1);
+      alloc(&blk_padding, 1);
+      alloc(&blk_padding_in, 1);
+      alloc(&blk_saved_top, 1);
+
+      auto active_streams_single =
+          streams.active_gpu_subset(1, params.pbs_type);
+      // Sign bit of the input, consumed by the overshift condition.
+      auto f_sign = [bits_per_block](Torus x) -> Torus {
+        return (x >> (bits_per_block - 1)) & 1;
+      };
+      blk_sign_lut = new int_radix_lut<Torus>(
+          streams, params, 1, 1, allocate_gpu_memory, size_tracker);
+      blk_sign_lut->generate_and_broadcast_lut(active_streams_single, {0},
+                                               {f_sign}, LUT_0_FOR_ALL_BLOCKS);
+
+      // Block of sign bits that fills the slots wrapping around during a
+      // round; zero when this round does not shift.
+      auto f_padding = [=](Torus x) -> Torus {
+        Torus control = (x >> bits_per_block) % 2;
+        Torus last = x % message_modulus;
+        Torus sign = (last >> (bits_per_block - 1)) & 1;
+        return control == 1 ? (message_modulus - 1) * sign : 0;
+      };
+      blk_padding_lut = new int_radix_lut<Torus>(
+          streams, params, 1, 1, allocate_gpu_memory, size_tracker);
+      blk_padding_lut->generate_and_broadcast_lut(
+          active_streams_single, {0}, {f_padding}, LUT_0_FOR_ALL_BLOCKS);
+    } else {
+      blk_sign = nullptr;
+      blk_padding = nullptr;
+      blk_padding_in = nullptr;
+      blk_saved_top = nullptr;
+      blk_sign_lut = nullptr;
+      blk_padding_lut = nullptr;
+    }
   }
 
   /// @brief Allocates and initializes the buffers and LUTs used to fix up the
@@ -280,36 +608,59 @@ template <typename Torus> struct int_shift_and_rotate_buffer {
   }
 
   void release(CudaStreams streams) {
-    release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0),
-                                   tmp_bits, gpu_memory_allocated);
-    release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0),
-                                   tmp_shift_bits, gpu_memory_allocated);
-    release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0),
-                                   tmp_rotated, gpu_memory_allocated);
-    release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0),
-                                   tmp_input_bits_a, gpu_memory_allocated);
-    release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0),
-                                   tmp_input_bits_b, gpu_memory_allocated);
-    release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0),
-                                   tmp_mux_inputs, gpu_memory_allocated);
+    auto drop_ct = [&](CudaRadixCiphertextFFI *ct) {
+      if (ct == nullptr)
+        return;
+      release_radix_ciphertext_async(streams.stream(0), streams.gpu_index(0),
+                                     ct, gpu_memory_allocated);
+      delete ct;
+    };
+    auto drop_lut = [&](int_radix_lut<Torus> *lut) {
+      if (lut == nullptr)
+        return;
+      lut->release(streams);
+      delete lut;
+    };
 
-    bit_extract_luts->release(streams);
-    bit_extract_luts_with_offset_2->release(streams);
-    mux_lut->release(streams);
-    cleaning_lut->release(streams);
+    drop_ct(tmp_bits);
+    drop_ct(tmp_shift_bits);
+    drop_ct(tmp_rotated);
+    drop_ct(tmp_input_bits_a);
+    drop_ct(tmp_input_bits_b);
+    drop_ct(tmp_mux_inputs);
+
+    drop_ct(blk_messages);
+    drop_ct(blk_next);
+    drop_ct(blk_next_next);
+    drop_ct(blk_rotate_tmp);
+    drop_ct(blk_pack_tmp);
+    drop_ct(blk_many_out);
+    drop_ct(blk_shift_bits);
+    drop_ct(blk_sign);
+    drop_ct(blk_padding);
+    drop_ct(blk_padding_in);
+    drop_ct(blk_saved_top);
+
+    if (bit_extract_luts != nullptr) {
+      bit_extract_luts->release(streams);
+      delete bit_extract_luts;
+    }
+    if (bit_extract_luts_with_offset_2 != nullptr) {
+      bit_extract_luts_with_offset_2->release(streams);
+      delete bit_extract_luts_with_offset_2;
+    }
+    drop_lut(mux_lut);
+    drop_lut(blk_msg_lut);
+    drop_lut(blk_next_lut);
+    drop_lut(blk_next_next_lut);
+    drop_lut(blk_round_lut);
+    drop_lut(blk_sign_lut);
+    drop_lut(blk_padding_lut);
+    drop_lut(cleaning_lut);
+
     if (handle_overshift)
       release_handle_overshift(streams);
 
-    delete tmp_bits;
-    delete tmp_shift_bits;
-    delete tmp_rotated;
-    delete tmp_input_bits_a;
-    delete tmp_input_bits_b;
-    delete tmp_mux_inputs;
-    delete bit_extract_luts;
-    delete bit_extract_luts_with_offset_2;
-    delete mux_lut;
-    delete cleaning_lut;
     cuda_synchronize_stream(streams.stream(0), streams.gpu_index(0));
   }
 

--- a/backends/tfhe-cuda-backend/cuda/src/integer/multiplication.cu
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/multiplication.cu
@@ -202,3 +202,60 @@ void cleanup_cuda_partial_sum_ciphertexts_vec_64(CudaStreamsFFI streams,
   delete mem_ptr;
   *mem_ptr_void = nullptr;
 }
+
+uint64_t scratch_cuda_mul_add_fixed_point_64_async(
+    CudaStreamsFFI streams, int8_t **mem_ptr, uint32_t mode,
+    uint32_t lhs_blocks, uint32_t rhs_blocks, uint32_t rescaling,
+    uint32_t precision, uint32_t max_extra_terms, uint32_t message_modulus,
+    uint32_t carry_modulus, CudaLweBootstrapKeyParamsFFI bsk_params,
+    CudaLweKeyswitchKeyParamsFFI ksk_params, bool allocate_gpu_memory,
+    PBS_MS_REDUCTION_T noise_reduction_type) {
+  int_radix_params params(bsk_params, ksk_params, message_modulus,
+                          carry_modulus, noise_reduction_type);
+  return scratch_cuda_mul_add_fixed_point<uint64_t>(
+      CudaStreams(streams),
+      (int_mul_add_fixed_point_memory<uint64_t> **)mem_ptr, mode, lhs_blocks,
+      rhs_blocks, rescaling, precision, max_extra_terms, params,
+      allocate_gpu_memory);
+}
+
+void cuda_mul_add_fixed_point_with_rescaling_64_async(
+    CudaStreamsFFI streams, CudaRadixCiphertextFFI *result,
+    CudaRadixCiphertextFFI const *lhs, CudaRadixCiphertextFFI const *rhs,
+    CudaRadixCiphertextFFI const *added, int8_t *mem_ptr, void *const *bsks,
+    void *const *ksks) {
+  PANIC_IF_FALSE(result != lhs && result != added,
+                 "Output and input pointers must be different for "
+                 "out-of-place operations");
+  host_mul_add_fixed_point_with_rescaling<uint64_t>(
+      CudaStreams(streams), result, lhs, rhs, added,
+      (int_mul_add_fixed_point_memory<uint64_t> *)mem_ptr, bsks,
+      (uint64_t **)(ksks));
+}
+
+void cuda_mul_low_partial_sum_64_async(
+    CudaStreamsFFI streams, CudaRadixCiphertextFFI *result,
+    CudaRadixCiphertextFFI const *lhs, CudaRadixCiphertextFFI const *rhs,
+    CudaRadixCiphertextFFI const *extra_terms, uint32_t num_extra_terms,
+    bool propagate_carries, int8_t *mem_ptr, void *const *bsks,
+    void *const *ksks) {
+  PANIC_IF_FALSE(result != lhs && result != rhs,
+                 "Output and input pointers must be different for "
+                 "out-of-place operations");
+  host_mul_low_partial_sum<uint64_t>(
+      CudaStreams(streams), result, lhs, rhs, extra_terms, num_extra_terms,
+      propagate_carries, (int_mul_add_fixed_point_memory<uint64_t> *)mem_ptr,
+      bsks, (uint64_t **)(ksks));
+}
+
+void cleanup_cuda_mul_add_fixed_point_64(CudaStreamsFFI streams,
+                                         int8_t **mem_ptr_void) {
+  PUSH_RANGE("cleanup mul_add_fixed_point")
+  int_mul_add_fixed_point_memory<uint64_t> *mem_ptr =
+      (int_mul_add_fixed_point_memory<uint64_t> *)(*mem_ptr_void);
+
+  mem_ptr->release(CudaStreams(streams));
+  delete mem_ptr;
+  *mem_ptr_void = nullptr;
+  POP_RANGE()
+}

--- a/backends/tfhe-cuda-backend/cuda/src/integer/multiplication.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/multiplication.cuh
@@ -637,4 +637,222 @@ __host__ uint64_t scratch_cuda_integer_mult_radix_ciphertext(
   return size_tracker;
 }
 
+// ---------------------------------------------------------------------------
+// Fixed-point fused multiply-add with an asymmetric right operand
+// ---------------------------------------------------------------------------
+
+// Packs the surviving (lhs block, rhs block) pairs into two compact arrays so a
+// single bivariate bootstrap covers the whole block-product matrix. The index
+// maps come from int_mul_add_fixed_point_memory and depend only on the shape.
+template <typename Torus>
+__global__ void mul_add_gather_pairs(Torus *__restrict__ lhs_out,
+                                     Torus *__restrict__ rhs_out,
+                                     const Torus *__restrict__ lhs,
+                                     const Torus *__restrict__ rhs,
+                                     const uint32_t *__restrict__ lhs_idx,
+                                     const uint32_t *__restrict__ rhs_idx,
+                                     uint32_t block_size) {
+  const size_t pair_id = blockIdx.x;
+  const Torus *src_lhs = &lhs[(size_t)lhs_idx[pair_id] * block_size];
+  const Torus *src_rhs = &rhs[(size_t)rhs_idx[pair_id] * block_size];
+  Torus *dst_lhs = &lhs_out[pair_id * block_size];
+  Torus *dst_rhs = &rhs_out[pair_id * block_size];
+
+  for (uint32_t tid = threadIdx.x; tid < block_size; tid += blockDim.x) {
+    dst_lhs[tid] = src_lhs[tid];
+    dst_rhs[tid] = src_rhs[tid];
+  }
+}
+
+// Places each bootstrapped block product at its shifted position in the dense
+// term vector the column sum consumes. Blocks nobody writes keep whatever they
+// held: the sum reads a block only when its degree is non-zero, and empty
+// columns are emitted as zero by calculate_final_chunk_into_radix.
+template <typename Torus>
+__global__ void mul_add_scatter_products(Torus *__restrict__ terms,
+                                         const Torus *__restrict__ products,
+                                         const uint32_t *__restrict__ dst_idx,
+                                         uint32_t block_size) {
+  const size_t pair_id = blockIdx.x;
+  const Torus *src = &products[pair_id * block_size];
+  Torus *dst = &terms[(size_t)dst_idx[pair_id] * block_size];
+
+  for (uint32_t tid = threadIdx.x; tid < block_size; tid += blockDim.x)
+    dst[tid] = src[tid];
+}
+
+// result[L] = trunc( lhs[L] * rhs[R] + added[L] * beta^s + sum(extra_terms) )
+//
+// See int_mul_add_fixed_point_memory for the two supported shapes. `added` and
+// `extra_terms` may be null; `extra_terms` is a radix list of
+// num_extra_terms * L blocks. With propagate_carries the result comes back with
+// clean carries, otherwise it is the raw column sum - which is what the
+// Goldschmidt remainder step wants, since it inverts message and carry itself.
+template <typename Torus>
+__host__ void host_mul_add_fixed_point_core(
+    CudaStreams streams, CudaRadixCiphertextFFI *result,
+    CudaRadixCiphertextFFI const *lhs, CudaRadixCiphertextFFI const *rhs,
+    CudaRadixCiphertextFFI const *added,
+    CudaRadixCiphertextFFI const *extra_terms, uint32_t num_extra_terms,
+    bool propagate_carries, int_mul_add_fixed_point_memory<Torus> *mem,
+    void *const *bsks, uint64_t *const *ksks) {
+  PUSH_RANGE("mul_add_fixed_point")
+
+  auto stream = streams.stream(0);
+  auto gpu_index = streams.gpu_index(0);
+  auto message_modulus = mem->params.message_modulus;
+  uint32_t L = mem->lhs_blocks;
+  uint32_t R = mem->rhs_blocks;
+  uint32_t window = mem->window;
+
+  PANIC_IF_FALSE(lhs->num_radix_blocks >= L,
+                 "Cuda error (mul_add_fixed_point): left operand is narrower "
+                 "than the shape this buffer was scratched for");
+  PANIC_IF_FALSE(rhs->num_radix_blocks >= R,
+                 "Cuda error (mul_add_fixed_point): right operand is narrower "
+                 "than the shape this buffer was scratched for");
+  PANIC_IF_FALSE(result->num_radix_blocks >= L,
+                 "Cuda error (mul_add_fixed_point): output is narrower than "
+                 "the left operand");
+  PANIC_IF_FALSE(num_extra_terms <= mem->max_extra_terms,
+                 "Cuda error (mul_add_fixed_point): more extra terms than the "
+                 "buffer was scratched for");
+  PANIC_IF_FALSE(num_extra_terms == 0 || extra_terms != nullptr,
+                 "Cuda error (mul_add_fixed_point): extra term count is "
+                 "non-zero but no extra terms were given");
+  if (mem->mode == MUL_ADD_MODE_MUL_LOW)
+    PANIC_IF_FALSE(added == nullptr,
+                   "Cuda error (mul_add_fixed_point): the mul-low shape takes "
+                   "its addends through extra_terms");
+
+  // Both operands feed one bivariate LUT, so their degrees have to fit the
+  // packing lhs_degree + message_modulus * rhs_degree.
+  for (uint32_t a = 0; a < L; a++)
+    PANIC_IF_FALSE(lhs->degrees[a] < message_modulus,
+                   "Cuda error (mul_add_fixed_point): left operand carries a "
+                   "block with a non-empty carry");
+  for (uint32_t r = 0; r < R; r++)
+    PANIC_IF_FALSE(rhs->degrees[r] < message_modulus,
+                   "Cuda error (mul_add_fixed_point): right operand carries a "
+                   "block with a non-empty carry");
+
+  // ---- block products: gather, one bootstrap per surviving pair, scatter ----
+  uint32_t block_size = mem->params.big_lwe_dimension + 1;
+  cuda_set_device(gpu_index);
+  mul_add_gather_pairs<Torus><<<mem->num_pairs, 256, 0, stream>>>(
+      (Torus *)mem->pair_lhs->ptr, (Torus *)mem->pair_products->ptr,
+      (Torus const *)lhs->ptr, (Torus const *)rhs->ptr, mem->d_pair_lhs_idx,
+      mem->d_pair_rhs_idx, block_size);
+  check_cuda_error(cudaGetLastError());
+
+  for (uint32_t j = 0; j < mem->num_pairs; j++) {
+    mem->pair_lhs->degrees[j] = lhs->degrees[mem->h_pair_lhs_idx[j]];
+    mem->pair_lhs->noise_levels[j] = lhs->noise_levels[mem->h_pair_lhs_idx[j]];
+    mem->pair_products->degrees[j] = rhs->degrees[mem->h_pair_rhs_idx[j]];
+    mem->pair_products->noise_levels[j] =
+        rhs->noise_levels[mem->h_pair_rhs_idx[j]];
+  }
+
+  integer_radix_apply_bivariate_lookup_table<Torus>(
+      streams, mem->pair_products, mem->pair_products, mem->pair_lhs, bsks,
+      ksks, mem->luts_array, mem->num_pairs, message_modulus);
+
+  cuda_set_device(gpu_index);
+  mul_add_scatter_products<Torus><<<mem->num_pairs, 256, 0, stream>>>(
+      (Torus *)mem->terms->ptr, (Torus const *)mem->pair_products->ptr,
+      mem->d_pair_dst_idx, block_size);
+  check_cuda_error(cudaGetLastError());
+
+  size_t term_blocks = (size_t)mem->num_terms * window;
+  std::memcpy(mem->terms->degrees, mem->h_product_degrees,
+              safe_mul_sizeof<uint64_t>(term_blocks));
+  std::memcpy(mem->terms->noise_levels, mem->h_product_noise_levels,
+              safe_mul_sizeof<uint64_t>(term_blocks));
+
+  // ---- the accumulator term and any caller-supplied terms ----
+  uint32_t extra_base = 2 * R;
+  if (mem->mode == MUL_ADD_MODE_FIXED_POINT) {
+    uint32_t added_slot = 2 * R * window + (mem->out_shift - mem->skip);
+    extra_base = 2 * R + 1;
+    if (added != nullptr) {
+      PANIC_IF_FALSE(added->num_radix_blocks >= L,
+                     "Cuda error (mul_add_fixed_point): accumulator operand is "
+                     "narrower than the left operand");
+      copy_radix_ciphertext_slice_async<Torus>(stream, gpu_index, mem->terms,
+                                               added_slot, added_slot + L,
+                                               added, 0, L);
+    }
+  }
+  for (uint32_t e = 0; e < num_extra_terms; e++) {
+    uint32_t slot = (extra_base + e) * window;
+    copy_radix_ciphertext_slice_async<Torus>(stream, gpu_index, mem->terms,
+                                             slot, slot + L, extra_terms, e * L,
+                                             (e + 1) * L);
+  }
+
+  // ---- column sum, then optionally finish the carries ----
+  host_integer_partial_sum_ciphertexts_vec<Torus>(
+      streams, mem->sum_result, mem->terms, bsks, ksks, mem->sum_mem, window,
+      mem->num_terms);
+
+  if (propagate_carries) {
+    host_propagate_single_carry<Torus>(streams, mem->sum_result, nullptr,
+                                       nullptr, mem->sc_prop_mem, bsks, ksks,
+                                       outputFlag::FLAG_NONE, 0);
+  }
+
+  uint32_t out_start = mem->out_shift - mem->skip;
+  copy_radix_ciphertext_slice_async<Torus>(stream, gpu_index, result, 0, L,
+                                           mem->sum_result, out_start,
+                                           out_start + L);
+  POP_RANGE()
+}
+
+// result[L] = trunc_beta^(R+|rescaling|)( lhs[L] * rhs[R] ) + added[L]
+template <typename Torus>
+__host__ void host_mul_add_fixed_point_with_rescaling(
+    CudaStreams streams, CudaRadixCiphertextFFI *result,
+    CudaRadixCiphertextFFI const *lhs, CudaRadixCiphertextFFI const *rhs,
+    CudaRadixCiphertextFFI const *added,
+    int_mul_add_fixed_point_memory<Torus> *mem, void *const *bsks,
+    uint64_t *const *ksks) {
+  PANIC_IF_FALSE(mem->mode == MUL_ADD_MODE_FIXED_POINT,
+                 "Cuda error (mul_add_fixed_point): buffer was scratched for "
+                 "the mul-low shape");
+  host_mul_add_fixed_point_core<Torus>(streams, result, lhs, rhs, added,
+                                       nullptr, 0, true, mem, bsks, ksks);
+}
+
+// Low half of lhs[n] * rhs[n], plus num_extra_terms addends of n blocks each.
+// Leaves the carries alone unless propagate_carries is set.
+template <typename Torus>
+__host__ void host_mul_low_partial_sum(
+    CudaStreams streams, CudaRadixCiphertextFFI *result,
+    CudaRadixCiphertextFFI const *lhs, CudaRadixCiphertextFFI const *rhs,
+    CudaRadixCiphertextFFI const *extra_terms, uint32_t num_extra_terms,
+    bool propagate_carries, int_mul_add_fixed_point_memory<Torus> *mem,
+    void *const *bsks, uint64_t *const *ksks) {
+  PANIC_IF_FALSE(mem->mode == MUL_ADD_MODE_MUL_LOW,
+                 "Cuda error (mul_add_fixed_point): buffer was scratched for "
+                 "the fixed-point shape");
+  host_mul_add_fixed_point_core<Torus>(streams, result, lhs, rhs, nullptr,
+                                       extra_terms, num_extra_terms,
+                                       propagate_carries, mem, bsks, ksks);
+}
+
+template <typename Torus>
+__host__ uint64_t scratch_cuda_mul_add_fixed_point(
+    CudaStreams streams, int_mul_add_fixed_point_memory<Torus> **mem_ptr,
+    uint32_t mode, uint32_t lhs_blocks, uint32_t rhs_blocks, uint32_t rescaling,
+    uint32_t precision, uint32_t max_extra_terms, int_radix_params params,
+    bool allocate_gpu_memory) {
+  PUSH_RANGE("scratch mul_add_fixed_point")
+  uint64_t size_tracker = 0;
+  *mem_ptr = new int_mul_add_fixed_point_memory<Torus>(
+      streams, params, mode, lhs_blocks, rhs_blocks, rescaling, precision,
+      max_extra_terms, allocate_gpu_memory, size_tracker);
+  POP_RANGE()
+  return size_tracker;
+}
+
 #endif

--- a/backends/tfhe-cuda-backend/cuda/src/integer/shift_and_rotate.cuh
+++ b/backends/tfhe-cuda-backend/cuda/src/integer/shift_and_rotate.cuh
@@ -83,23 +83,251 @@ host_compute_overshift_condition(CudaStreams streams,
  * mem->tmp_overshift to every block and runs the overshift cleanup LUT, which
  * both refreshes the noise and selects the overshift result (0 / the sign) in a
  * single PBS.
- * @param shifted_ct Shift result, updated in place with the selection.
+ * @param output Destination of the selection; may alias shifted_ct.
+ * @param shifted_ct Shift result, updated in place by the condition addition.
  * @param mem Scratch buffer holding tmp_overshift and the cleanup LUT.
  */
 template <typename Torus, typename KSTorus>
-__host__ void
-host_apply_overshift_cleanup(CudaStreams streams,
-                             CudaRadixCiphertextFFI *shifted_ct,
-                             int_shift_and_rotate_buffer<Torus> *mem,
-                             void *const *bsks, KSTorus *const *ksks) {
-  auto num_radix_blocks = shifted_ct->num_radix_blocks;
+__host__ void host_apply_overshift_cleanup(
+    CudaStreams streams, CudaRadixCiphertextFFI *output,
+    CudaRadixCiphertextFFI *shifted_ct, int_shift_and_rotate_buffer<Torus> *mem,
+    void *const *bsks, KSTorus *const *ksks) {
+  auto num_radix_blocks = output->num_radix_blocks;
   host_add_the_same_block_to_all_blocks<Torus>(
       streams.stream(0), streams.gpu_index(0), shifted_ct, shifted_ct,
       mem->tmp_overshift, mem->params.message_modulus,
       mem->params.carry_modulus);
   integer_radix_apply_univariate_lookup_table<Torus>(
-      streams, shifted_ct, shifted_ct, bsks, ksks, mem->overshift_cleanup_lut,
+      streams, output, shifted_ct, bsks, ksks, mem->overshift_cleanup_lut,
       num_radix_blocks);
+}
+
+/**
+ * @brief Block-level barrel shifter: shift/rotate by an encrypted amount
+ * without ever splitting the ciphertext into one-bit ciphertexts.
+ *
+ * Writing the amount as `2*t + s + 4*rest` (for 2 message bits per block), the
+ * first round consumes `s` (the shift inside a block) and `t` (a shift by one
+ * block) at once with three bivariate LUTs, and the remaining rounds form a
+ * barrel shifter over blocks, each shifting by `1 << d` blocks.
+ *
+ * First round, for a left shift. Three bivariate LUTs read every block
+ * together with amount block 0, producing what each block keeps and what it
+ * hands over; the donor arrays are then rotated into place and summed. Only
+ * one of the three terms is non-zero for a given block, which is what keeps
+ * the sum inside the message space.
+ *
+ *      input       b0        b1        b2        b3
+ *                  |         |         |         |
+ *      msg        m0        m1        m2        m3         stays in place
+ *      next       n0 -.     n1 -.     n2 -.     n3 -x      +1 block
+ *      next_next  p0 --.    p1 --.    p2 -x     p3 -x      +2 blocks
+ *                      |         |         |         |
+ *      result     m0   m1+n0   m2+n1+p0  m3+n2+p1
+ *                      (n3, p2, p3 wrapped: dropped for a shift,
+ *                       kept for a rotation)
+ *
+ * Then, for d = 1 .. num_rounds, one many-LUT per block splits it into
+ * (message kept, carry handed `1 << d` blocks away), selected by that round's
+ * shift bit.
+ *
+ * This costs about half the PBS of host_shift_and_rotate_inplace; see
+ * int_shift_and_rotate_buffer::use_block_path for when it is selected.
+ *
+ * @param lwe_array Value to shift, overwritten with the result.
+ * @param lwe_shift Encrypted shift amount, same block count as lwe_array.
+ */
+template <typename Torus, typename KSTorus>
+__host__ void
+host_block_shift_and_rotate_inplace(CudaStreams streams,
+                                    CudaRadixCiphertextFFI *lwe_array,
+                                    CudaRadixCiphertextFFI const *lwe_shift,
+                                    int_shift_and_rotate_buffer<Torus> *mem,
+                                    void *const *bsks, KSTorus *const *ksks) {
+  cuda_set_device(streams.gpu_index(0));
+  auto params = mem->params;
+  auto message_modulus = params.message_modulus;
+  auto carry_modulus = params.carry_modulus;
+  auto stream = streams.stream(0);
+  auto gpu_index = streams.gpu_index(0);
+  uint32_t bits_per_block = log2_int(message_modulus);
+  auto num_blocks = lwe_array->num_radix_blocks;
+
+  if (lwe_array->num_radix_blocks != lwe_shift->num_radix_blocks)
+    PANIC("Cuda error: lwe_shift and lwe_array num radix blocks must be "
+          "the same")
+  if (lwe_array->lwe_dimension != lwe_shift->lwe_dimension)
+    PANIC("Cuda error: lwe_shift and lwe_array lwe_dimension must be "
+          "the same")
+
+  bool is_left =
+      (mem->shift_type == LEFT_SHIFT || mem->shift_type == LEFT_ROTATE);
+  bool is_rotate =
+      (mem->shift_type == LEFT_ROTATE || mem->shift_type == RIGHT_ROTATE);
+  // Only a right shift of a signed value pads with the sign instead of zeros.
+  bool arithmetic = mem->is_signed && (mem->shift_type == RIGHT_SHIFT);
+
+  // The input's sign bit feeds the overshift condition, so read it before
+  // lwe_array is overwritten.
+  if (arithmetic) {
+    CudaRadixCiphertextFFI top_block;
+    as_radix_ciphertext_slice<Torus>(&top_block, lwe_array, num_blocks - 1,
+                                     num_blocks);
+    integer_radix_apply_univariate_lookup_table<Torus>(
+        streams, mem->blk_sign, &top_block, bsks, ksks, mem->blk_sign_lut, 1);
+  }
+
+  // ---- first round ----
+  // The three LUTs share the same bivariate input, so pack it once.
+  CudaRadixCiphertextFFI amount_block_0;
+  as_radix_ciphertext_slice<Torus>(&amount_block_0, lwe_shift, 0, 1);
+
+  auto packed = mem->blk_pack_tmp;
+  host_pack_bivariate_blocks_with_single_block<Torus>(
+      streams, packed, mem->blk_msg_lut->lwe_indexes_in, lwe_array,
+      &amount_block_0, mem->blk_msg_lut->lwe_indexes_in, message_modulus,
+      num_blocks);
+  for (uint32_t i = 0; i < num_blocks; i++) {
+    packed->degrees[i] =
+        lwe_array->degrees[i] * message_modulus + amount_block_0.degrees[0];
+    packed->noise_levels[i] = lwe_array->noise_levels[i] * message_modulus +
+                              amount_block_0.noise_levels[0];
+    CHECK_NOISE_LEVEL(packed->noise_levels[i], message_modulus, carry_modulus);
+  }
+
+  integer_radix_apply_univariate_lookup_table<Torus>(
+      streams, mem->blk_messages, packed, bsks, ksks, mem->blk_msg_lut,
+      num_blocks);
+  integer_radix_apply_univariate_lookup_table<Torus>(
+      streams, mem->blk_next, packed, bsks, ksks, mem->blk_next_lut,
+      num_blocks);
+  integer_radix_apply_univariate_lookup_table<Torus>(
+      streams, mem->blk_next_next, packed, bsks, ksks, mem->blk_next_next_lut,
+      num_blocks);
+
+  // Moves a donor array `rotations` blocks along and accumulates it into the
+  // result. Blocks are little endian, so a left shift of the value moves
+  // blocks towards higher indexes. The slots that wrap around are dropped for
+  // a shift; the sign extension of an arithmetic right shift is already baked
+  // into the LUTs of this round.
+  auto accumulate_donor = [&](CudaRadixCiphertextFFI *donor,
+                              uint32_t rotations) {
+    if (is_left)
+      host_radix_blocks_rotate_right<Torus>(streams, mem->blk_rotate_tmp, donor,
+                                            rotations, num_blocks);
+    else
+      host_radix_blocks_rotate_left<Torus>(streams, mem->blk_rotate_tmp, donor,
+                                           rotations, num_blocks);
+    if (!is_rotate) {
+      uint32_t start = is_left ? 0 : num_blocks - rotations;
+      uint32_t end = is_left ? rotations : num_blocks;
+      set_zero_radix_ciphertext_slice_async<Torus>(
+          stream, gpu_index, mem->blk_rotate_tmp, start, end);
+    }
+    host_addition<Torus>(stream, gpu_index, mem->blk_messages,
+                         mem->blk_messages, mem->blk_rotate_tmp, num_blocks,
+                         message_modulus, carry_modulus);
+  };
+  accumulate_donor(mem->blk_next, 1);
+  accumulate_donor(mem->blk_next_next, 2);
+  // At most one of the three contributions is non-zero for a given block, so
+  // the sum still fits in the message space.
+  for (uint32_t i = 0; i < num_blocks; i++)
+    mem->blk_messages->degrees[i] = message_modulus - 1;
+
+  // ---- remaining barrel rounds ----
+  if (mem->blk_num_rounds > 0) {
+    if (arithmetic) {
+      // The sign stays in the top block's MSB through every round, so this
+      // copy is a valid sign source for all of them.
+      copy_radix_ciphertext_slice_async<Torus>(
+          stream, gpu_index, mem->blk_saved_top, 0, 1, mem->blk_messages,
+          num_blocks - 1, num_blocks);
+    }
+
+    // Bits 0..1 of the amount were spent by the first round, so the rounds
+    // read theirs from amount block 1 onwards.
+    CudaRadixCiphertextFFI amount_high;
+    as_radix_ciphertext_slice<Torus>(&amount_high, lwe_shift, 1,
+                                     1 + mem->blk_num_amount_blocks);
+    extract_n_bits<Torus>(streams, mem->blk_shift_bits, &amount_high, bsks,
+                          ksks, mem->blk_num_rounds, mem->blk_num_amount_blocks,
+                          mem->bit_extract_luts_with_offset_2);
+  }
+
+  for (uint32_t d = 1; d <= mem->blk_num_rounds; d++) {
+    CudaRadixCiphertextFFI shift_bit;
+    as_radix_ciphertext_slice<Torus>(&shift_bit, mem->blk_shift_bits, d - 1, d);
+
+    if (arithmetic) {
+      // Sign-extension block for this round: the sign repeated, or 0 when this
+      // round does not shift.
+      host_addition<Torus>(stream, gpu_index, mem->blk_padding_in,
+                           mem->blk_saved_top, &shift_bit, 1, message_modulus,
+                           carry_modulus);
+      integer_radix_apply_univariate_lookup_table<Torus>(
+          streams, mem->blk_padding, mem->blk_padding_in, bsks, ksks,
+          mem->blk_padding_lut, 1);
+    }
+
+    // The shift bit sits on the control position, so a single many-LUT splits
+    // every block into "what it keeps" and "what it hands over".
+    host_add_the_same_block_to_all_blocks<Torus>(
+        stream, gpu_index, mem->blk_messages, mem->blk_messages, &shift_bit,
+        message_modulus, carry_modulus);
+    integer_radix_apply_many_univariate_lookup_table<Torus>(
+        streams, mem->blk_many_out, mem->blk_messages, bsks, ksks,
+        mem->blk_round_lut, 2, mem->blk_lut_stride);
+
+    copy_radix_ciphertext_slice_async<Torus>(stream, gpu_index,
+                                             mem->blk_messages, 0, num_blocks,
+                                             mem->blk_many_out, 0, num_blocks);
+    CudaRadixCiphertextFFI carries;
+    as_radix_ciphertext_slice<Torus>(&carries, mem->blk_many_out, num_blocks,
+                                     2 * num_blocks);
+
+    uint32_t rotations = 1u << d;
+    if (is_left)
+      host_radix_blocks_rotate_right<Torus>(streams, mem->blk_rotate_tmp,
+                                            &carries, rotations, num_blocks);
+    else
+      host_radix_blocks_rotate_left<Torus>(streams, mem->blk_rotate_tmp,
+                                           &carries, rotations, num_blocks);
+
+    if (!is_rotate) {
+      uint32_t start = is_left ? 0 : num_blocks - rotations;
+      uint32_t end = is_left ? rotations : num_blocks;
+      if (arithmetic) {
+        for (uint32_t i = start; i < end; i++)
+          copy_radix_ciphertext_slice_async<Torus>(
+              stream, gpu_index, mem->blk_rotate_tmp, i, i + 1,
+              mem->blk_padding, 0, 1);
+      } else {
+        set_zero_radix_ciphertext_slice_async<Torus>(
+            stream, gpu_index, mem->blk_rotate_tmp, start, end);
+      }
+    }
+
+    host_addition<Torus>(stream, gpu_index, mem->blk_messages,
+                         mem->blk_messages, mem->blk_rotate_tmp, num_blocks,
+                         message_modulus, carry_modulus);
+    for (uint32_t i = 0; i < num_blocks; i++)
+      mem->blk_messages->degrees[i] = message_modulus - 1;
+  }
+
+  // ---- finalize ----
+  // The result still carries the accumulated noise, so a cleaning PBS is due
+  // anyway; for a shift it also applies the overshift selection for free.
+  if (is_rotate) {
+    integer_radix_apply_univariate_lookup_table<Torus>(
+        streams, lwe_array, mem->blk_messages, bsks, ksks, mem->cleaning_lut,
+        num_blocks);
+  } else {
+    host_compute_overshift_condition<Torus, KSTorus>(
+        streams, lwe_shift, mem->blk_sign, mem, bsks, ksks);
+    host_apply_overshift_cleanup<Torus, KSTorus>(
+        streams, lwe_array, mem->blk_messages, mem, bsks, ksks);
+  }
 }
 
 template <typename Torus, typename KSTorus>
@@ -109,6 +337,11 @@ host_shift_and_rotate_inplace(CudaStreams streams,
                               CudaRadixCiphertextFFI const *lwe_shift,
                               int_shift_and_rotate_buffer<Torus> *mem,
                               void *const *bsks, KSTorus *const *ksks) {
+  if (mem->use_block_path) {
+    host_block_shift_and_rotate_inplace<Torus, KSTorus>(
+        streams, lwe_array, lwe_shift, mem, bsks, ksks);
+    return;
+  }
   cuda_set_device(streams.gpu_index(0));
   // The barrel shifter packs three bits (control | previous | current) into a
   // single block for the mux LUT, so it needs the control bit at plaintext
@@ -288,8 +521,8 @@ host_shift_and_rotate_inplace(CudaStreams streams,
     // and use the overshift cleanup LUT, which both resets the noise and
     // selects the overshift result in a single PBS (no extra PBS round).
     if (i == 0 && mem->handle_overshift) {
-      host_apply_overshift_cleanup<Torus, KSTorus>(streams, lwe_array, mem,
-                                                   bsks, ksks);
+      host_apply_overshift_cleanup<Torus, KSTorus>(streams, lwe_array,
+                                                   lwe_array, mem, bsks, ksks);
     } else {
       auto cleaning_lut = mem->cleaning_lut;
       integer_radix_apply_univariate_lookup_table<Torus>(
@@ -302,8 +535,8 @@ host_shift_and_rotate_inplace(CudaStreams streams,
   // overshift selection could not be fused into a cleaning PBS; apply it as a
   // standalone step instead.
   if (bits_per_block == 1 && mem->handle_overshift) {
-    host_apply_overshift_cleanup<Torus, KSTorus>(streams, lwe_array, mem, bsks,
-                                                 ksks);
+    host_apply_overshift_cleanup<Torus, KSTorus>(streams, lwe_array, lwe_array,
+                                                 mem, bsks, ksks);
   }
 }
 #endif

--- a/backends/tfhe-cuda-backend/src/bindings.rs
+++ b/backends/tfhe-cuda-backend/src/bindings.rs
@@ -1158,6 +1158,53 @@ unsafe extern "C" {
     );
 }
 unsafe extern "C" {
+    pub fn scratch_cuda_mul_add_fixed_point_64_async(
+        streams: CudaStreamsFFI,
+        mem_ptr: *mut *mut i8,
+        mode: u32,
+        lhs_blocks: u32,
+        rhs_blocks: u32,
+        rescaling: u32,
+        precision: u32,
+        max_extra_terms: u32,
+        message_modulus: u32,
+        carry_modulus: u32,
+        bsk_params: CudaLweBootstrapKeyParamsFFI,
+        ksk_params: CudaLweKeyswitchKeyParamsFFI,
+        allocate_gpu_memory: bool,
+        noise_reduction_type: PBS_MS_REDUCTION_T,
+    ) -> u64;
+}
+unsafe extern "C" {
+    pub fn cuda_mul_add_fixed_point_with_rescaling_64_async(
+        streams: CudaStreamsFFI,
+        result: *mut CudaRadixCiphertextFFI,
+        lhs: *const CudaRadixCiphertextFFI,
+        rhs: *const CudaRadixCiphertextFFI,
+        added: *const CudaRadixCiphertextFFI,
+        mem_ptr: *mut i8,
+        bsks: *const *mut ffi::c_void,
+        ksks: *const *mut ffi::c_void,
+    );
+}
+unsafe extern "C" {
+    pub fn cuda_mul_low_partial_sum_64_async(
+        streams: CudaStreamsFFI,
+        result: *mut CudaRadixCiphertextFFI,
+        lhs: *const CudaRadixCiphertextFFI,
+        rhs: *const CudaRadixCiphertextFFI,
+        extra_terms: *const CudaRadixCiphertextFFI,
+        num_extra_terms: u32,
+        propagate_carries: bool,
+        mem_ptr: *mut i8,
+        bsks: *const *mut ffi::c_void,
+        ksks: *const *mut ffi::c_void,
+    );
+}
+unsafe extern "C" {
+    pub fn cleanup_cuda_mul_add_fixed_point_64(streams: CudaStreamsFFI, mem_ptr_void: *mut *mut i8);
+}
+unsafe extern "C" {
     pub fn scratch_cuda_integer_scalar_mul_64_async(
         streams: CudaStreamsFFI,
         mem_ptr: *mut *mut i8,

--- a/tfhe-benchmark/benches/integer/bench.rs
+++ b/tfhe-benchmark/benches/integer/bench.rs
@@ -3,6 +3,8 @@
 mod aes;
 mod aes256;
 mod kreyvium;
+#[cfg(feature = "gpu")]
+mod mul_add_fixed_point;
 mod oprf;
 mod trivium;
 mod vector_find;
@@ -2578,6 +2580,8 @@ mod cuda {
         cuda_ilog2,
         oprf::cuda::cuda_unsigned_oprf,
         vector_find::cuda::cuda_match_value,
+        mul_add_fixed_point::cuda::cuda_mul_add_fixed_point,
+        mul_add_fixed_point::cuda::cuda_mul_low_partial_sum,
     );
 
     criterion_group!(
@@ -3506,6 +3510,13 @@ criterion_group!(oprf, oprf::unsigned_oprf);
 criterion_group!(vector_find, vector_find::match_value);
 
 #[cfg(feature = "gpu")]
+criterion_group!(
+    cuda_mul_add_fixed_point_ops,
+    mul_add_fixed_point::cuda::cuda_mul_add_fixed_point,
+    mul_add_fixed_point::cuda::cuda_mul_low_partial_sum,
+);
+
+#[cfg(feature = "gpu")]
 fn go_through_gpu_bench_groups(val: &str) {
     match val.to_lowercase().as_str() {
         "default" => {
@@ -3519,6 +3530,9 @@ fn go_through_gpu_bench_groups(val: &str) {
         "unchecked" => {
             unchecked_cuda_ops();
             unchecked_scalar_cuda_ops()
+        }
+        "mul_add_fixed_point" => {
+            cuda_mul_add_fixed_point_ops();
         }
         _ => panic!("unknown benchmark operations flavor"),
     };

--- a/tfhe-benchmark/benches/integer/mul_add_fixed_point.rs
+++ b/tfhe-benchmark/benches/integer/mul_add_fixed_point.rs
@@ -8,7 +8,10 @@
 
 #[cfg(feature = "gpu")]
 pub mod cuda {
-    use benchmark::params_aliases::BENCH_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+    use benchmark::params_aliases::{
+        BENCH_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+        BENCH_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+    };
     use benchmark::utilities::{write_to_json_unchecked, OperatorType};
     use criterion::Criterion;
     use std::hint::black_box;
@@ -21,6 +24,21 @@ pub mod cuda {
     use tfhe::shortint::AtomicPatternParameters;
 
     const BITS_PER_BLOCK: u32 = 2;
+
+    /// Both PBS flavours, so a shape can be compared across them. The bench id
+    /// carries the parameter name, so the cases stay distinguishable.
+    fn param_sets() -> Vec<(AtomicPatternParameters, String)> {
+        vec![
+            (
+                BENCH_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128.into(),
+                BENCH_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128.name(),
+            ),
+            (
+                BENCH_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128.into(),
+                BENCH_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128.name(),
+            ),
+        ]
+    }
 
     /// (label, lhs blocks, rhs blocks, rescaling, precision bits) - the four
     /// multiply-adds of a 64-bit Goldschmidt division.
@@ -38,52 +56,52 @@ pub mod cuda {
         let mut group = c.benchmark_group(bench_name);
         group.sample_size(15);
 
-        let param = BENCH_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
-        let atomic_param: AtomicPatternParameters = param.into();
-        let param_name = param.name();
-
         let streams = CudaStreams::new_multi_gpu();
-        let (cpu_cks, _) = KEY_CACHE.get_from_params(atomic_param, IntegerKeyKind::Radix);
-        let sks = CudaServerKey::new(&cpu_cks, &streams);
 
-        for (label, lhs_blocks, rhs_blocks, rescaling, precision) in fixed_point_shapes() {
-            let bench_id =
-                format!("{bench_name}::{param_name}::{label}_{lhs_blocks}x{rhs_blocks}blocks");
+        for (atomic_param, param_name) in param_sets() {
+            let (cpu_cks, _) = KEY_CACHE.get_from_params(atomic_param, IntegerKeyKind::Radix);
+            let sks = CudaServerKey::new(&cpu_cks, &streams);
 
-            // A left operand just under beta^L / 2 and a full-width right one:
-            // the worst case for the number of surviving block products, and the
-            // regime the divider actually runs in.
-            let clear_lhs: u128 = (1u128 << (lhs_blocks as u32 * BITS_PER_BLOCK - 1)) - 1;
-            let clear_rhs: u128 = (1u128 << (rhs_blocks as u32 * BITS_PER_BLOCK)) - 1;
+            for (label, lhs_blocks, rhs_blocks, rescaling, precision) in fixed_point_shapes() {
+                let bench_id =
+                    format!("{bench_name}::{param_name}::{label}_{lhs_blocks}x{rhs_blocks}blocks");
 
-            let ct_lhs = cpu_cks.encrypt_radix(clear_lhs, lhs_blocks);
-            let ct_rhs = cpu_cks.encrypt_radix(clear_rhs, rhs_blocks);
-            let ct_added = cpu_cks.encrypt_radix(clear_lhs, lhs_blocks);
-            let d_lhs = CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct_lhs, &streams);
-            let d_rhs = CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct_rhs, &streams);
-            let d_added = CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct_added, &streams);
+                // A left operand just under beta^L / 2 and a full-width right one:
+                // the worst case for the number of surviving block products, and the
+                // regime the divider actually runs in.
+                let clear_lhs: u128 = (1u128 << (lhs_blocks as u32 * BITS_PER_BLOCK - 1)) - 1;
+                let clear_rhs: u128 = (1u128 << (rhs_blocks as u32 * BITS_PER_BLOCK)) - 1;
 
-            group.bench_function(&bench_id, |b| {
-                b.iter(|| {
-                    black_box(sks.mul_add_fixed_point_with_rescaling(
-                        &d_lhs,
-                        &d_rhs,
-                        Some(&d_added),
-                        rescaling,
-                        precision,
-                        &streams,
-                    ));
-                })
-            });
+                let ct_lhs = cpu_cks.encrypt_radix(clear_lhs, lhs_blocks);
+                let ct_rhs = cpu_cks.encrypt_radix(clear_rhs, rhs_blocks);
+                let ct_added = cpu_cks.encrypt_radix(clear_lhs, lhs_blocks);
+                let d_lhs = CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct_lhs, &streams);
+                let d_rhs = CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct_rhs, &streams);
+                let d_added =
+                    CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct_added, &streams);
 
-            write_to_json_unchecked(
-                &bench_id,
-                param.name(),
-                "mul_add_fixed_point",
-                &OperatorType::Atomic,
-                lhs_blocks as u32 * BITS_PER_BLOCK,
-                vec![atomic_param.message_modulus().0.ilog2(); lhs_blocks],
-            );
+                group.bench_function(&bench_id, |b| {
+                    b.iter(|| {
+                        black_box(sks.mul_add_fixed_point_with_rescaling(
+                            &d_lhs,
+                            &d_rhs,
+                            Some(&d_added),
+                            rescaling,
+                            precision,
+                            &streams,
+                        ));
+                    })
+                });
+
+                write_to_json_unchecked(
+                    &bench_id,
+                    param_name.clone(),
+                    "mul_add_fixed_point",
+                    &OperatorType::Atomic,
+                    lhs_blocks as u32 * BITS_PER_BLOCK,
+                    vec![atomic_param.message_modulus().0.ilog2(); lhs_blocks],
+                );
+            }
         }
         group.finish();
     }
@@ -93,44 +111,43 @@ pub mod cuda {
         let mut group = c.benchmark_group(bench_name);
         group.sample_size(15);
 
-        let param = BENCH_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
-        let atomic_param: AtomicPatternParameters = param.into();
-        let param_name = param.name();
-
         let streams = CudaStreams::new_multi_gpu();
-        let (cpu_cks, _) = KEY_CACHE.get_from_params(atomic_param, IntegerKeyKind::Radix);
-        let sks = CudaServerKey::new(&cpu_cks, &streams);
 
-        // 32 x 32 blocks with the two addends the Goldschmidt remainder needs
-        // (bitnot of the numerator, and a trivial one).
-        let num_blocks = 32usize;
-        let bench_id = format!("{bench_name}::{param_name}::{num_blocks}blocks_2extra");
+        for (atomic_param, param_name) in param_sets() {
+            let (cpu_cks, _) = KEY_CACHE.get_from_params(atomic_param, IntegerKeyKind::Radix);
+            let sks = CudaServerKey::new(&cpu_cks, &streams);
 
-        let ct_lhs = cpu_cks.encrypt_radix(u64::MAX, num_blocks);
-        let ct_rhs = cpu_cks.encrypt_radix(u64::MAX, num_blocks);
-        let ct_extra_0 = cpu_cks.encrypt_radix(u64::MAX, num_blocks);
-        let ct_extra_1 = cpu_cks.encrypt_radix(1u64, num_blocks);
-        let d_lhs = CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct_lhs, &streams);
-        let d_rhs = CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct_rhs, &streams);
-        let d_extras = vec![
-            CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct_extra_0, &streams),
-            CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct_extra_1, &streams),
-        ];
+            // 32 x 32 blocks with the two addends the Goldschmidt remainder needs
+            // (bitnot of the numerator, and a trivial one).
+            let num_blocks = 32usize;
+            let bench_id = format!("{bench_name}::{param_name}::{num_blocks}blocks_2extra");
 
-        group.bench_function(&bench_id, |b| {
-            b.iter(|| {
-                black_box(sks.mul_low_partial_sum(&d_lhs, &d_rhs, &d_extras, false, &streams));
-            })
-        });
+            let ct_lhs = cpu_cks.encrypt_radix(u64::MAX, num_blocks);
+            let ct_rhs = cpu_cks.encrypt_radix(u64::MAX, num_blocks);
+            let ct_extra_0 = cpu_cks.encrypt_radix(u64::MAX, num_blocks);
+            let ct_extra_1 = cpu_cks.encrypt_radix(1u64, num_blocks);
+            let d_lhs = CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct_lhs, &streams);
+            let d_rhs = CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct_rhs, &streams);
+            let d_extras = vec![
+                CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct_extra_0, &streams),
+                CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct_extra_1, &streams),
+            ];
 
-        write_to_json_unchecked(
-            &bench_id,
-            param.name(),
-            "mul_low_partial_sum",
-            &OperatorType::Atomic,
-            num_blocks as u32 * BITS_PER_BLOCK,
-            vec![atomic_param.message_modulus().0.ilog2(); num_blocks],
-        );
+            group.bench_function(&bench_id, |b| {
+                b.iter(|| {
+                    black_box(sks.mul_low_partial_sum(&d_lhs, &d_rhs, &d_extras, false, &streams));
+                })
+            });
+
+            write_to_json_unchecked(
+                &bench_id,
+                param_name.clone(),
+                "mul_low_partial_sum",
+                &OperatorType::Atomic,
+                num_blocks as u32 * BITS_PER_BLOCK,
+                vec![atomic_param.message_modulus().0.ilog2(); num_blocks],
+            );
+        }
         group.finish();
     }
 }

--- a/tfhe-benchmark/benches/integer/mul_add_fixed_point.rs
+++ b/tfhe-benchmark/benches/integer/mul_add_fixed_point.rs
@@ -1,0 +1,136 @@
+//! Benchmarks for the fixed-point fused multiply-add and the mul-low term sum,
+//! driven with the exact shapes a Goldschmidt divider uses on 64-bit operands:
+//! a 34-block (68-bit) fixed point, a right operand of 5, 9 then 16 blocks, and
+//! a 32x32 mul-low for the remainder.
+//!
+//! Both operations only exist on the GPU backend, so there is no CPU
+//! counterpart to compare against here.
+
+#[cfg(feature = "gpu")]
+pub mod cuda {
+    use benchmark::params_aliases::BENCH_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+    use benchmark::utilities::{write_to_json_unchecked, OperatorType};
+    use criterion::Criterion;
+    use std::hint::black_box;
+    use tfhe::core_crypto::gpu::CudaStreams;
+    use tfhe::integer::gpu::ciphertext::CudaUnsignedRadixCiphertext;
+    use tfhe::integer::gpu::CudaServerKey;
+    use tfhe::integer::keycache::KEY_CACHE;
+    use tfhe::integer::IntegerKeyKind;
+    use tfhe::keycache::NamedParam;
+    use tfhe::shortint::AtomicPatternParameters;
+
+    const BITS_PER_BLOCK: u32 = 2;
+
+    /// (label, lhs blocks, rhs blocks, rescaling, precision bits) - the four
+    /// multiply-adds of a 64-bit Goldschmidt division.
+    fn fixed_point_shapes() -> Vec<(&'static str, usize, usize, u32, u32)> {
+        vec![
+            ("seed", 34, 5, 0, 10),
+            ("iter0", 34, 5, 4, 18),
+            ("iter1", 34, 9, 8, 34),
+            ("iter2", 34, 16, 16, 64),
+        ]
+    }
+
+    pub fn cuda_mul_add_fixed_point(c: &mut Criterion) {
+        let bench_name = "integer::cuda::mul_add_fixed_point";
+        let mut group = c.benchmark_group(bench_name);
+        group.sample_size(15);
+
+        let param = BENCH_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+        let atomic_param: AtomicPatternParameters = param.into();
+        let param_name = param.name();
+
+        let streams = CudaStreams::new_multi_gpu();
+        let (cpu_cks, _) = KEY_CACHE.get_from_params(atomic_param, IntegerKeyKind::Radix);
+        let sks = CudaServerKey::new(&cpu_cks, &streams);
+
+        for (label, lhs_blocks, rhs_blocks, rescaling, precision) in fixed_point_shapes() {
+            let bench_id =
+                format!("{bench_name}::{param_name}::{label}_{lhs_blocks}x{rhs_blocks}blocks");
+
+            // A left operand just under beta^L / 2 and a full-width right one:
+            // the worst case for the number of surviving block products, and the
+            // regime the divider actually runs in.
+            let clear_lhs: u128 = (1u128 << (lhs_blocks as u32 * BITS_PER_BLOCK - 1)) - 1;
+            let clear_rhs: u128 = (1u128 << (rhs_blocks as u32 * BITS_PER_BLOCK)) - 1;
+
+            let ct_lhs = cpu_cks.encrypt_radix(clear_lhs, lhs_blocks);
+            let ct_rhs = cpu_cks.encrypt_radix(clear_rhs, rhs_blocks);
+            let ct_added = cpu_cks.encrypt_radix(clear_lhs, lhs_blocks);
+            let d_lhs = CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct_lhs, &streams);
+            let d_rhs = CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct_rhs, &streams);
+            let d_added = CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct_added, &streams);
+
+            group.bench_function(&bench_id, |b| {
+                b.iter(|| {
+                    black_box(sks.mul_add_fixed_point_with_rescaling(
+                        &d_lhs,
+                        &d_rhs,
+                        Some(&d_added),
+                        rescaling,
+                        precision,
+                        &streams,
+                    ));
+                })
+            });
+
+            write_to_json_unchecked(
+                &bench_id,
+                param.name(),
+                "mul_add_fixed_point",
+                &OperatorType::Atomic,
+                lhs_blocks as u32 * BITS_PER_BLOCK,
+                vec![atomic_param.message_modulus().0.ilog2(); lhs_blocks],
+            );
+        }
+        group.finish();
+    }
+
+    pub fn cuda_mul_low_partial_sum(c: &mut Criterion) {
+        let bench_name = "integer::cuda::mul_low_partial_sum";
+        let mut group = c.benchmark_group(bench_name);
+        group.sample_size(15);
+
+        let param = BENCH_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+        let atomic_param: AtomicPatternParameters = param.into();
+        let param_name = param.name();
+
+        let streams = CudaStreams::new_multi_gpu();
+        let (cpu_cks, _) = KEY_CACHE.get_from_params(atomic_param, IntegerKeyKind::Radix);
+        let sks = CudaServerKey::new(&cpu_cks, &streams);
+
+        // 32 x 32 blocks with the two addends the Goldschmidt remainder needs
+        // (bitnot of the numerator, and a trivial one).
+        let num_blocks = 32usize;
+        let bench_id = format!("{bench_name}::{param_name}::{num_blocks}blocks_2extra");
+
+        let ct_lhs = cpu_cks.encrypt_radix(u64::MAX, num_blocks);
+        let ct_rhs = cpu_cks.encrypt_radix(u64::MAX, num_blocks);
+        let ct_extra_0 = cpu_cks.encrypt_radix(u64::MAX, num_blocks);
+        let ct_extra_1 = cpu_cks.encrypt_radix(1u64, num_blocks);
+        let d_lhs = CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct_lhs, &streams);
+        let d_rhs = CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct_rhs, &streams);
+        let d_extras = vec![
+            CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct_extra_0, &streams),
+            CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct_extra_1, &streams),
+        ];
+
+        group.bench_function(&bench_id, |b| {
+            b.iter(|| {
+                black_box(sks.mul_low_partial_sum(&d_lhs, &d_rhs, &d_extras, false, &streams));
+            })
+        });
+
+        write_to_json_unchecked(
+            &bench_id,
+            param.name(),
+            "mul_low_partial_sum",
+            &OperatorType::Atomic,
+            num_blocks as u32 * BITS_PER_BLOCK,
+            vec![atomic_param.message_modulus().0.ilog2(); num_blocks],
+        );
+        group.finish();
+    }
+}

--- a/tfhe/src/integer/gpu/ffi.rs
+++ b/tfhe/src/integer/gpu/ffi.rs
@@ -5372,6 +5372,186 @@ pub(crate) unsafe fn cuda_backend_unchecked_partial_sum_ciphertexts_assign<
     update_noise_degree(result, &cuda_ffi_result);
 }
 
+/// Shape selectors, mirroring the `MUL_ADD_MODE_*` defines in
+/// `cuda/include/integer/multiplication.h`.
+const MUL_ADD_MODE_FIXED_POINT: u32 = 0;
+const MUL_ADD_MODE_MUL_LOW: u32 = 1;
+
+#[allow(clippy::too_many_arguments)]
+/// Fixed-point fused multiply-add with an asymmetric right operand:
+///
+/// `result[L] = trunc_beta^(R + rescaling)(lhs[L] * rhs[R]) + added[L]`
+///
+/// The low columns whose worst-case weight stays below one output ulp
+/// (`2^precision`) are never bootstrapped. The result has as many blocks as
+/// `lhs`.
+///
+/// # Safety
+///
+/// - The data must not be moved or dropped while being used by the CUDA kernel.
+/// - This function assumes exclusive access to the passed data; violating this may lead to
+///   undefined behavior.
+pub(crate) unsafe fn cuda_backend_mul_add_fixed_point_with_rescaling<
+    T: UnsignedInteger,
+    B: Numeric,
+>(
+    streams: &CudaStreams,
+    result: &mut CudaRadixCiphertext,
+    lhs: &CudaRadixCiphertext,
+    rhs: &CudaRadixCiphertext,
+    added: Option<&CudaRadixCiphertext>,
+    rescaling: u32,
+    precision: u32,
+    bootstrapping_key: &CudaVec<B>,
+    keyswitch_key: &CudaVec<T>,
+    message_modulus: MessageModulus,
+    carry_modulus: CarryModulus,
+    bsk: &impl CudaBskParams,
+    ksk_params: CudaLweKeyswitchKeyParamsFFI,
+    ms_noise_reduction_configuration: Option<&CudaModulusSwitchNoiseReductionConfiguration>,
+) {
+    let bsk_params = bsk.params_ffi();
+    let noise_reduction_type = resolve_ms_noise_reduction_config(ms_noise_reduction_configuration);
+    let lhs_blocks = u32::try_from(lhs.d_blocks.lwe_ciphertext_count().0).unwrap();
+    let rhs_blocks = u32::try_from(rhs.d_blocks.lwe_ciphertext_count().0).unwrap();
+
+    let mut result_degrees = result.info.blocks.iter().map(|b| b.degree.0).collect();
+    let mut result_noise_levels = result.info.blocks.iter().map(|b| b.noise_level.0).collect();
+    let mut cuda_ffi_result =
+        prepare_cuda_radix_ffi(result, &mut result_degrees, &mut result_noise_levels);
+    let mut lhs_degrees = lhs.info.blocks.iter().map(|b| b.degree.0).collect();
+    let mut lhs_noise_levels = lhs.info.blocks.iter().map(|b| b.noise_level.0).collect();
+    let cuda_ffi_lhs = prepare_cuda_radix_ffi(lhs, &mut lhs_degrees, &mut lhs_noise_levels);
+    let mut rhs_degrees = rhs.info.blocks.iter().map(|b| b.degree.0).collect();
+    let mut rhs_noise_levels = rhs.info.blocks.iter().map(|b| b.noise_level.0).collect();
+    let cuda_ffi_rhs = prepare_cuda_radix_ffi(rhs, &mut rhs_degrees, &mut rhs_noise_levels);
+    let mut added_degrees: Vec<u64> = added
+        .map(|a| a.info.blocks.iter().map(|b| b.degree.0).collect())
+        .unwrap_or_default();
+    let mut added_noise_levels: Vec<u64> = added
+        .map(|a| a.info.blocks.iter().map(|b| b.noise_level.0).collect())
+        .unwrap_or_default();
+    let cuda_ffi_added =
+        added.map(|a| prepare_cuda_radix_ffi(a, &mut added_degrees, &mut added_noise_levels));
+
+    let mut mem_ptr: *mut i8 = std::ptr::null_mut();
+    scratch_cuda_mul_add_fixed_point_64_async(
+        streams.ffi(),
+        std::ptr::addr_of_mut!(mem_ptr),
+        MUL_ADD_MODE_FIXED_POINT,
+        lhs_blocks,
+        rhs_blocks,
+        rescaling,
+        precision,
+        0,
+        u32::try_from(message_modulus.0).unwrap(),
+        u32::try_from(carry_modulus.0).unwrap(),
+        bsk_params,
+        ksk_params,
+        true,
+        noise_reduction_type as u32,
+    );
+    cuda_mul_add_fixed_point_with_rescaling_64_async(
+        streams.ffi(),
+        &raw mut cuda_ffi_result,
+        &raw const cuda_ffi_lhs,
+        &raw const cuda_ffi_rhs,
+        cuda_ffi_added
+            .as_ref()
+            .map_or(std::ptr::null(), std::ptr::from_ref),
+        mem_ptr,
+        bootstrapping_key.ptr.as_ptr(),
+        keyswitch_key.ptr.as_ptr(),
+    );
+    cleanup_cuda_mul_add_fixed_point_64(streams.ffi(), std::ptr::addr_of_mut!(mem_ptr));
+    update_noise_degree(result, &cuda_ffi_result);
+}
+
+#[allow(clippy::too_many_arguments)]
+/// Low half of `lhs[n] * rhs[n]`, plus `num_extra_terms` addends of `n` blocks
+/// each passed as one radix list. Unless `propagate_carries` is set the result
+/// is the raw column sum, i.e. blocks may hold non-empty carries - which is
+/// what the Goldschmidt remainder step consumes.
+///
+/// # Safety
+///
+/// - The data must not be moved or dropped while being used by the CUDA kernel.
+/// - This function assumes exclusive access to the passed data; violating this may lead to
+///   undefined behavior.
+pub(crate) unsafe fn cuda_backend_mul_low_partial_sum<T: UnsignedInteger, B: Numeric>(
+    streams: &CudaStreams,
+    result: &mut CudaRadixCiphertext,
+    lhs: &CudaRadixCiphertext,
+    rhs: &CudaRadixCiphertext,
+    extra_terms: Option<&CudaRadixCiphertext>,
+    num_extra_terms: u32,
+    propagate_carries: bool,
+    bootstrapping_key: &CudaVec<B>,
+    keyswitch_key: &CudaVec<T>,
+    message_modulus: MessageModulus,
+    carry_modulus: CarryModulus,
+    bsk: &impl CudaBskParams,
+    ksk_params: CudaLweKeyswitchKeyParamsFFI,
+    ms_noise_reduction_configuration: Option<&CudaModulusSwitchNoiseReductionConfiguration>,
+) {
+    let bsk_params = bsk.params_ffi();
+    let noise_reduction_type = resolve_ms_noise_reduction_config(ms_noise_reduction_configuration);
+    let num_blocks = u32::try_from(lhs.d_blocks.lwe_ciphertext_count().0).unwrap();
+
+    let mut result_degrees = result.info.blocks.iter().map(|b| b.degree.0).collect();
+    let mut result_noise_levels = result.info.blocks.iter().map(|b| b.noise_level.0).collect();
+    let mut cuda_ffi_result =
+        prepare_cuda_radix_ffi(result, &mut result_degrees, &mut result_noise_levels);
+    let mut lhs_degrees = lhs.info.blocks.iter().map(|b| b.degree.0).collect();
+    let mut lhs_noise_levels = lhs.info.blocks.iter().map(|b| b.noise_level.0).collect();
+    let cuda_ffi_lhs = prepare_cuda_radix_ffi(lhs, &mut lhs_degrees, &mut lhs_noise_levels);
+    let mut rhs_degrees = rhs.info.blocks.iter().map(|b| b.degree.0).collect();
+    let mut rhs_noise_levels = rhs.info.blocks.iter().map(|b| b.noise_level.0).collect();
+    let cuda_ffi_rhs = prepare_cuda_radix_ffi(rhs, &mut rhs_degrees, &mut rhs_noise_levels);
+    let mut extra_degrees: Vec<u64> = extra_terms
+        .map(|e| e.info.blocks.iter().map(|b| b.degree.0).collect())
+        .unwrap_or_default();
+    let mut extra_noise_levels: Vec<u64> = extra_terms
+        .map(|e| e.info.blocks.iter().map(|b| b.noise_level.0).collect())
+        .unwrap_or_default();
+    let cuda_ffi_extra =
+        extra_terms.map(|e| prepare_cuda_radix_ffi(e, &mut extra_degrees, &mut extra_noise_levels));
+
+    let mut mem_ptr: *mut i8 = std::ptr::null_mut();
+    scratch_cuda_mul_add_fixed_point_64_async(
+        streams.ffi(),
+        std::ptr::addr_of_mut!(mem_ptr),
+        MUL_ADD_MODE_MUL_LOW,
+        num_blocks,
+        num_blocks,
+        0,
+        0,
+        num_extra_terms,
+        u32::try_from(message_modulus.0).unwrap(),
+        u32::try_from(carry_modulus.0).unwrap(),
+        bsk_params,
+        ksk_params,
+        true,
+        noise_reduction_type as u32,
+    );
+    cuda_mul_low_partial_sum_64_async(
+        streams.ffi(),
+        &raw mut cuda_ffi_result,
+        &raw const cuda_ffi_lhs,
+        &raw const cuda_ffi_rhs,
+        cuda_ffi_extra
+            .as_ref()
+            .map_or(std::ptr::null(), std::ptr::from_ref),
+        num_extra_terms,
+        propagate_carries,
+        mem_ptr,
+        bootstrapping_key.ptr.as_ptr(),
+        keyswitch_key.ptr.as_ptr(),
+    );
+    cleanup_cuda_mul_add_fixed_point_64(streams.ffi(), std::ptr::addr_of_mut!(mem_ptr));
+    update_noise_degree(result, &cuda_ffi_result);
+}
+
 #[allow(clippy::too_many_arguments)]
 /// # Safety
 ///

--- a/tfhe/src/integer/gpu/server_key/radix/mod.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/mod.rs
@@ -40,6 +40,7 @@ mod div_mod;
 mod even_odd;
 mod ilog2;
 mod mul;
+mod mul_add_fixed_point;
 mod neg;
 mod oprf;
 mod rotate;

--- a/tfhe/src/integer/gpu/server_key/radix/mul_add_fixed_point.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/mul_add_fixed_point.rs
@@ -1,0 +1,431 @@
+//! Fixed-point fused multiply-add with an asymmetric right operand.
+//!
+//! These are the two multiplications a Goldschmidt divider needs. Both share
+//! the invariant that makes the shape tractable: **the result is exactly as
+//! wide as the left operand**, so the output width is never a parameter. The
+//! right operand is the short one - the iteration factor, a handful of blocks
+//! against the running numerator's tens of blocks.
+//!
+//! The low columns of the product whose worst-case weight stays below one
+//! output ulp are never bootstrapped, which is what keeps the block-product
+//! count down to what the CPU implementation performs.
+
+use crate::core_crypto::gpu::CudaStreams;
+use crate::integer::gpu::ciphertext::{CudaIntegerRadixCiphertext, CudaRadixCiphertext};
+use crate::integer::gpu::server_key::{
+    CudaBootstrappingKey, CudaDynamicKeyswitchingKey, CudaServerKey,
+};
+use crate::integer::gpu::{
+    cuda_backend_mul_add_fixed_point_with_rescaling, cuda_backend_mul_low_partial_sum,
+};
+
+impl CudaServerKey {
+    /// Computes, over a radix of base `beta = message_modulus`:
+    ///
+    /// ```text
+    ///     result[L] = trunc_beta^s( lhs[L] * rhs[R] + added[L] * beta^s )
+    /// ```
+    ///
+    /// where `L = lhs.blocks()`, `R = rhs.blocks()` and `s = R + rescaling` is
+    /// the number of low blocks dropped from the product, so that `result` has
+    /// as many blocks as `lhs`.
+    ///
+    /// `precision` is the weight, in bits, of one output ulp: the low columns
+    /// of the product whose combined worst case stays below `2^precision` are
+    /// skipped entirely. The result is therefore the exact value or one ulp
+    /// below it, never above.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `rescaling` pushes the truncation threshold into the retained
+    /// output blocks, or if either operand holds a block with a non-empty
+    /// carry.
+    pub fn mul_add_fixed_point_with_rescaling<T: CudaIntegerRadixCiphertext>(
+        &self,
+        lhs: &T,
+        rhs: &T,
+        added: Option<&T>,
+        rescaling: u32,
+        precision: u32,
+        streams: &CudaStreams,
+    ) -> T {
+        let lhs_blocks = lhs.as_ref().d_blocks.lwe_ciphertext_count().0;
+        assert!(
+            rhs.as_ref().d_blocks.lwe_ciphertext_count().0 <= lhs_blocks,
+            "The right operand must not be wider than the left one"
+        );
+        if let Some(added) = added {
+            assert_eq!(
+                added.as_ref().d_blocks.lwe_ciphertext_count().0,
+                lhs_blocks,
+                "The accumulator operand must have as many blocks as the left operand"
+            );
+        }
+
+        let mut result: T = self.create_trivial_zero_radix(lhs_blocks, streams);
+        let CudaDynamicKeyswitchingKey::Standard(computing_ks_key) = &self.key_switching_key else {
+            panic!("Only the standard atomic pattern is supported on GPU")
+        };
+
+        unsafe {
+            match &self.bootstrapping_key {
+                CudaBootstrappingKey::Classic(d_bsk) => {
+                    cuda_backend_mul_add_fixed_point_with_rescaling(
+                        streams,
+                        result.as_mut(),
+                        lhs.as_ref(),
+                        rhs.as_ref(),
+                        added.map(|a| a.as_ref()),
+                        rescaling,
+                        precision,
+                        &d_bsk.d_vec,
+                        &computing_ks_key.d_vec,
+                        self.message_modulus,
+                        self.carry_modulus,
+                        d_bsk,
+                        computing_ks_key.params_ffi(),
+                        d_bsk.ms_noise_reduction_configuration.as_ref(),
+                    );
+                }
+                CudaBootstrappingKey::MultiBit(d_multibit_bsk) => {
+                    cuda_backend_mul_add_fixed_point_with_rescaling(
+                        streams,
+                        result.as_mut(),
+                        lhs.as_ref(),
+                        rhs.as_ref(),
+                        added.map(|a| a.as_ref()),
+                        rescaling,
+                        precision,
+                        &d_multibit_bsk.d_vec,
+                        &computing_ks_key.d_vec,
+                        self.message_modulus,
+                        self.carry_modulus,
+                        d_multibit_bsk,
+                        computing_ks_key.params_ffi(),
+                        None,
+                    );
+                }
+            }
+        }
+        streams.synchronize();
+        result
+    }
+
+    /// [`Self::mul_add_fixed_point_with_rescaling`] with no rescaling, i.e.
+    /// `result[L] = trunc_beta^R(lhs[L] * rhs[R] + added[L] * beta^R)`.
+    pub fn mul_add_fixed_point<T: CudaIntegerRadixCiphertext>(
+        &self,
+        lhs: &T,
+        rhs: &T,
+        added: Option<&T>,
+        precision: u32,
+        streams: &CudaStreams,
+    ) -> T {
+        self.mul_add_fixed_point_with_rescaling(lhs, rhs, added, 0, precision, streams)
+    }
+
+    /// Low half of `lhs * rhs` plus `extra_terms`, all of the same width:
+    ///
+    /// ```text
+    ///     result[n] = (lhs[n] * rhs[n] + sum(extra_terms)) mod beta^n
+    /// ```
+    ///
+    /// With `propagate_carries` the result comes back with clean carries. Left
+    /// unset, it is the raw column sum - blocks may hold non-empty carries -
+    /// which is what a Goldschmidt remainder step wants, since it inverts the
+    /// message and carry halves itself rather than propagating them.
+    pub fn mul_low_partial_sum<T: CudaIntegerRadixCiphertext>(
+        &self,
+        lhs: &T,
+        rhs: &T,
+        extra_terms: &[T],
+        propagate_carries: bool,
+        streams: &CudaStreams,
+    ) -> T {
+        let num_blocks = lhs.as_ref().d_blocks.lwe_ciphertext_count().0;
+        assert_eq!(
+            rhs.as_ref().d_blocks.lwe_ciphertext_count().0,
+            num_blocks,
+            "The mul-low shape expects two operands of the same width"
+        );
+        assert!(
+            extra_terms
+                .iter()
+                .all(|t| t.as_ref().d_blocks.lwe_ciphertext_count().0 == num_blocks),
+            "Every extra term must have as many blocks as the operands"
+        );
+
+        let mut result: T = self.create_trivial_zero_radix(num_blocks, streams);
+        let extra_list = if extra_terms.is_empty() {
+            None
+        } else {
+            Some(CudaRadixCiphertext::from_radix_ciphertext_vec(
+                extra_terms,
+                streams,
+            ))
+        };
+        let num_extra_terms = u32::try_from(extra_terms.len()).unwrap();
+
+        let CudaDynamicKeyswitchingKey::Standard(computing_ks_key) = &self.key_switching_key else {
+            panic!("Only the standard atomic pattern is supported on GPU")
+        };
+
+        unsafe {
+            match &self.bootstrapping_key {
+                CudaBootstrappingKey::Classic(d_bsk) => {
+                    cuda_backend_mul_low_partial_sum(
+                        streams,
+                        result.as_mut(),
+                        lhs.as_ref(),
+                        rhs.as_ref(),
+                        extra_list.as_ref(),
+                        num_extra_terms,
+                        propagate_carries,
+                        &d_bsk.d_vec,
+                        &computing_ks_key.d_vec,
+                        self.message_modulus,
+                        self.carry_modulus,
+                        d_bsk,
+                        computing_ks_key.params_ffi(),
+                        d_bsk.ms_noise_reduction_configuration.as_ref(),
+                    );
+                }
+                CudaBootstrappingKey::MultiBit(d_multibit_bsk) => {
+                    cuda_backend_mul_low_partial_sum(
+                        streams,
+                        result.as_mut(),
+                        lhs.as_ref(),
+                        rhs.as_ref(),
+                        extra_list.as_ref(),
+                        num_extra_terms,
+                        propagate_carries,
+                        &d_multibit_bsk.d_vec,
+                        &computing_ks_key.d_vec,
+                        self.message_modulus,
+                        self.carry_modulus,
+                        d_multibit_bsk,
+                        computing_ks_key.params_ffi(),
+                        None,
+                    );
+                }
+            }
+        }
+        streams.synchronize();
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::core_crypto::gpu::CudaStreams;
+    use crate::integer::gpu::ciphertext::CudaUnsignedRadixCiphertext;
+    use crate::integer::gpu::server_key::CudaServerKey;
+    use crate::integer::{ClientKey, RadixClientKey};
+    use crate::shortint::parameters::PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128;
+    use rand::Rng;
+
+    const BITS_PER_BLOCK: u32 = 2;
+
+    /// The five shapes the Goldschmidt divider drives these operations with, for
+    /// u64 operands at 2 bits per block: (lhs blocks, rhs blocks, rescaling,
+    /// precision bits). Fixed point is 34 blocks; the schedule (s, t) is
+    /// (5, 9), (9, 17), (16, 32) after the seed step.
+    fn fixed_point_shapes() -> Vec<(usize, usize, u32, u32)> {
+        vec![
+            (34, 5, 0, 10),   // seed: n, d <- n, d * (1 + x0)
+            (34, 5, 4, 18),   // iteration 0
+            (34, 9, 8, 34),   // iteration 1
+            (34, 16, 16, 64), // iteration 2 (numerator only)
+        ]
+    }
+
+    fn keys(
+        num_blocks: usize,
+        streams: &CudaStreams,
+    ) -> (ClientKey, RadixClientKey, CudaServerKey) {
+        let cks = RadixClientKey::new(PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128, num_blocks);
+        let sks = CudaServerKey::new(&cks, streams);
+        (cks.as_ref().clone(), cks, sks)
+    }
+
+    /// Exact reference for `(lhs * rhs + added * beta^s) >> s`.
+    ///
+    /// Written as `added + (lhs * rhs) >> s` rather than shifting `added` up
+    /// first: the two are equal because `added * beta^s` is a multiple of
+    /// `beta^s`, and this form stays inside u128 (`added << 64` would not for
+    /// the last iteration's shape).
+    fn reference(lhs: u128, rhs: u128, added: Option<u128>, shift_blocks: u32) -> u128 {
+        let shift_bits = shift_blocks * BITS_PER_BLOCK;
+        added.unwrap_or(0) + ((lhs * rhs) >> shift_bits)
+    }
+
+    #[test]
+    fn test_mul_add_fixed_point_with_rescaling_goldschmidt_shapes() {
+        let streams = CudaStreams::new_multi_gpu();
+        let mut rng = rand::thread_rng();
+
+        for (lhs_blocks, rhs_blocks, rescaling, precision) in fixed_point_shapes() {
+            let (cpu_cks, _cks, sks) = keys(lhs_blocks, &streams);
+            let shift_blocks = rhs_blocks as u32 + rescaling;
+
+            for with_added in [false, true] {
+                for _ in 0..3 {
+                    // Keep the accumulator inside its beta^W window, exactly as the
+                    // divider does: n * (1 + x) < beta^L holds there because
+                    // n < beta^L / 2.
+                    let lhs_bits = lhs_blocks as u32 * BITS_PER_BLOCK - 1;
+                    let clear_lhs: u128 = rng.gen_range(0..(1u128 << lhs_bits));
+                    let clear_rhs: u128 =
+                        rng.gen_range(0..(1u128 << (rhs_blocks as u32 * BITS_PER_BLOCK)));
+                    let clear_added = if with_added { Some(clear_lhs) } else { None };
+
+                    let ct_lhs = cpu_cks.encrypt_radix(clear_lhs, lhs_blocks);
+                    let ct_rhs = cpu_cks.encrypt_radix(clear_rhs, rhs_blocks);
+                    let d_lhs =
+                        CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct_lhs, &streams);
+                    let d_rhs =
+                        CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct_rhs, &streams);
+                    let d_added = clear_added.map(|v| {
+                        let ct = cpu_cks.encrypt_radix(v, lhs_blocks);
+                        CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct, &streams)
+                    });
+
+                    let d_res = sks.mul_add_fixed_point_with_rescaling(
+                        &d_lhs,
+                        &d_rhs,
+                        d_added.as_ref(),
+                        rescaling,
+                        precision,
+                        &streams,
+                    );
+                    let res: u128 = cpu_cks.decrypt_radix(&d_res.to_radix_ciphertext(&streams));
+
+                    let expected = reference(clear_lhs, clear_rhs, clear_added, shift_blocks);
+                    assert!(
+                        res <= expected && expected - res <= 1,
+                        "shape L={lhs_blocks} R={rhs_blocks} rescaling={rescaling} \
+                         precision={precision} added={with_added}: got {res}, expected \
+                         {expected} (truncation may only lose one ulp, and only downwards)"
+                    );
+                }
+            }
+        }
+    }
+
+    /// The seed step and the three iterations all keep `d` in [1/2, 1) and
+    /// `1 + x` in [1, 2). This drives the operation with operands of that
+    /// shape rather than uniform ones, since that is where the divider lives.
+    #[test]
+    fn test_mul_add_fixed_point_normalized_operands() {
+        let streams = CudaStreams::new_multi_gpu();
+        let mut rng = rand::thread_rng();
+        let lhs_blocks = 34usize;
+        let (cpu_cks, _cks, sks) = keys(lhs_blocks, &streams);
+
+        for (rhs_blocks, rescaling, precision) in [(5usize, 0u32, 10u32), (16, 16, 64)] {
+            let shift_blocks = rhs_blocks as u32 + rescaling;
+            // d in [1/2, 1) as a Q0.68 fixed point: the top bit of the 68-bit
+            // field is set.
+            let clear_lhs: u128 = (1u128 << 67) | (rng.gen::<u128>() & ((1u128 << 67) - 1));
+            let clear_rhs: u128 = rng.gen_range(0..(1u128 << (rhs_blocks as u32 * BITS_PER_BLOCK)));
+
+            let ct_lhs = cpu_cks.encrypt_radix(clear_lhs, lhs_blocks);
+            let ct_rhs = cpu_cks.encrypt_radix(clear_rhs, rhs_blocks);
+            let d_lhs = CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct_lhs, &streams);
+            let d_rhs = CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct_rhs, &streams);
+
+            let d_res = sks.mul_add_fixed_point_with_rescaling(
+                &d_lhs, &d_rhs, None, rescaling, precision, &streams,
+            );
+            let res: u128 = cpu_cks.decrypt_radix(&d_res.to_radix_ciphertext(&streams));
+            let expected = reference(clear_lhs, clear_rhs, None, shift_blocks);
+            assert!(
+                res <= expected && expected - res <= 1,
+                "R={rhs_blocks} rescaling={rescaling}: got {res}, expected {expected}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_mul_low_partial_sum() {
+        let streams = CudaStreams::new_multi_gpu();
+        let mut rng = rand::thread_rng();
+        let num_blocks = 32usize;
+        let (cpu_cks, _cks, sks) = keys(num_blocks, &streams);
+
+        for num_extra in [0usize, 1, 2] {
+            for _ in 0..2 {
+                let clear_lhs: u64 = rng.gen();
+                let clear_rhs: u64 = rng.gen();
+                let clear_extras: Vec<u64> = (0..num_extra).map(|_| rng.gen()).collect();
+
+                let ct_lhs = cpu_cks.encrypt_radix(clear_lhs, num_blocks);
+                let ct_rhs = cpu_cks.encrypt_radix(clear_rhs, num_blocks);
+                let d_lhs = CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct_lhs, &streams);
+                let d_rhs = CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct_rhs, &streams);
+                let d_extras: Vec<CudaUnsignedRadixCiphertext> = clear_extras
+                    .iter()
+                    .map(|v| {
+                        let ct = cpu_cks.encrypt_radix(*v, num_blocks);
+                        CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct, &streams)
+                    })
+                    .collect();
+
+                let d_res = sks.mul_low_partial_sum(&d_lhs, &d_rhs, &d_extras, true, &streams);
+                let res: u64 = cpu_cks.decrypt_radix(&d_res.to_radix_ciphertext(&streams));
+
+                let expected = clear_extras
+                    .iter()
+                    .fold(clear_lhs.wrapping_mul(clear_rhs), |acc, e| {
+                        acc.wrapping_add(*e)
+                    });
+                assert_eq!(
+                    res, expected,
+                    "mul-low with {num_extra} extra terms: {clear_lhs} * {clear_rhs} + \
+                     {clear_extras:?}"
+                );
+            }
+        }
+    }
+
+    /// The exact term list the Goldschmidt remainder step builds:
+    /// `q * d + !n + 1`, whose two's complement is `n - q * d`.
+    #[test]
+    fn test_mul_low_partial_sum_remainder_terms() {
+        let streams = CudaStreams::new_multi_gpu();
+        let num_blocks = 32usize;
+        let (cpu_cks, _cks, sks) = keys(num_blocks, &streams);
+
+        for (n, d) in [
+            (12_345_678_901_234_567u64, 987_654_321u64),
+            (u64::MAX, 3),
+            (1024, 16),
+            (0, 7),
+        ] {
+            let q = n / d;
+            let ct_q = cpu_cks.encrypt_radix(q, num_blocks);
+            let ct_d = cpu_cks.encrypt_radix(d, num_blocks);
+            let ct_not_n = cpu_cks.encrypt_radix(!n, num_blocks);
+            let ct_one = cpu_cks.encrypt_radix(1u64, num_blocks);
+
+            let d_q = CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct_q, &streams);
+            let d_d = CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct_d, &streams);
+            let d_extras = vec![
+                CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct_not_n, &streams),
+                CudaUnsignedRadixCiphertext::from_radix_ciphertext(&ct_one, &streams),
+            ];
+
+            let d_res = sks.mul_low_partial_sum(&d_q, &d_d, &d_extras, true, &streams);
+            let res: u64 = cpu_cks.decrypt_radix(&d_res.to_radix_ciphertext(&streams));
+
+            // q*d + !n + 1 == q*d - n, so the remainder is its negation.
+            let expected = q.wrapping_mul(d).wrapping_sub(n);
+            assert_eq!(res, expected, "remainder terms for {n} / {d}");
+            assert_eq!(
+                res.wrapping_neg(),
+                n - q * d,
+                "negating the term sum should give the remainder for {n} / {d}"
+            );
+        }
+    }
+}

--- a/tfhe/src/integer/gpu/server_key/radix/tests_signed/test_shift.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/tests_signed/test_shift.rs
@@ -9,10 +9,28 @@ use crate::integer::server_key::radix_parallel::tests_signed::test_shift::{
 use crate::shortint::parameters::test_params::*;
 use crate::shortint::parameters::*;
 
-create_gpu_parameterized_test!(integer_signed_unchecked_left_shift);
-create_gpu_parameterized_test!(integer_signed_unchecked_right_shift);
-create_gpu_parameterized_test!(integer_signed_left_shift);
-create_gpu_parameterized_test!(integer_signed_right_shift);
+// 2_2 goes through the block-level barrel shifter, 3_3 through the bit-level
+// one, so both paths of the CUDA backend are covered.
+create_gpu_parameterized_test!(integer_signed_unchecked_left_shift {
+    PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+    TEST_PARAM_MESSAGE_3_CARRY_3_KS_PBS_GAUSSIAN_2M128,
+    TEST_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+});
+create_gpu_parameterized_test!(integer_signed_unchecked_right_shift {
+    PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+    TEST_PARAM_MESSAGE_3_CARRY_3_KS_PBS_GAUSSIAN_2M128,
+    TEST_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+});
+create_gpu_parameterized_test!(integer_signed_left_shift {
+    PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+    TEST_PARAM_MESSAGE_3_CARRY_3_KS_PBS_GAUSSIAN_2M128,
+    TEST_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+});
+create_gpu_parameterized_test!(integer_signed_right_shift {
+    PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+    TEST_PARAM_MESSAGE_3_CARRY_3_KS_PBS_GAUSSIAN_2M128,
+    TEST_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+});
 
 fn integer_signed_unchecked_right_shift<P>(param: P)
 where

--- a/tfhe/src/integer/gpu/server_key/radix/tests_unsigned/test_shift.rs
+++ b/tfhe/src/integer/gpu/server_key/radix/tests_unsigned/test_shift.rs
@@ -9,10 +9,28 @@ use crate::integer::server_key::radix_parallel::tests_unsigned::test_shift::{
 use crate::shortint::parameters::test_params::*;
 use crate::shortint::parameters::*;
 
-create_gpu_parameterized_test!(integer_unchecked_left_shift);
-create_gpu_parameterized_test!(integer_unchecked_right_shift);
-create_gpu_parameterized_test!(integer_left_shift);
-create_gpu_parameterized_test!(integer_right_shift);
+// 2_2 goes through the block-level barrel shifter, 3_3 through the bit-level
+// one, so both paths of the CUDA backend are covered.
+create_gpu_parameterized_test!(integer_unchecked_left_shift {
+    PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+    TEST_PARAM_MESSAGE_3_CARRY_3_KS_PBS_GAUSSIAN_2M128,
+    TEST_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+});
+create_gpu_parameterized_test!(integer_unchecked_right_shift {
+    PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+    TEST_PARAM_MESSAGE_3_CARRY_3_KS_PBS_GAUSSIAN_2M128,
+    TEST_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+});
+create_gpu_parameterized_test!(integer_left_shift {
+    PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+    TEST_PARAM_MESSAGE_3_CARRY_3_KS_PBS_GAUSSIAN_2M128,
+    TEST_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+});
+create_gpu_parameterized_test!(integer_right_shift {
+    PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+    TEST_PARAM_MESSAGE_3_CARRY_3_KS_PBS_GAUSSIAN_2M128,
+    TEST_PARAM_GPU_MULTI_BIT_GROUP_4_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+});
 
 fn integer_unchecked_right_shift<P>(param: P)
 where


### PR DESCRIPTION

Saved to /tmp/claude-1000/.../scratchpad/pr-mul-add.md. For PR #3925:

# feat(gpu): fixed-point fused multiply-add with asymmetric operands

## What

Adds one new GPU operation in two shapes: a fused multiply-add where the two operands
have very different widths, the low columns of the product are never computed, and the
result is as wide as the left operand.

- `mul_add_fixed_point_with_rescaling` — `result[L] = trunc_beta^s(lhs[L] * rhs[R] + added[L] * beta^s)`
- `mul_low_partial_sum` — low half of `lhs[n] * rhs[n]` plus caller-supplied addends

Both are exposed on `CudaServerKey`. Nothing existing changes behaviour; `mul` and
`div_rem` are untouched.

## Why

This is the multiplication a Goldschmidt divider needs, and the existing square, exact
multiplication is the wrong shape for it three times over:

- The operands are **asymmetric** — a 34-block running value against a 5, 9 or 16-block
  iteration factor, not 34 x 34.
- Most of the product is **discarded**. The result is a fixed point of the same width as
  the left operand, so everything below one output ulp is computed and then thrown away.
- The **addition is separate**, costing another pass over the accumulator.

Doing it as `mul` + shift + `add` means paying for bits that never reach the result.


## Results


### Latency

H100 SXM5, 64-bit operands, milliseconds. `mul`  gpu backend multiplication with 64 bit operands

Classical:

| GPUs | mul | mul_add 34x5 | mul_add 34x9 | mul_add 34x16 | mul_low 32x32 |
| ---- | --- | ------------ | ------------ | ------------- | ------------- |
| 1    | 76  | 49           | 58           | 62            | 72            |
| 2    | 59  | 46           | 50           | 54            | 57            |
| 4    | 51  | 44           | 48           | 53            | 54            |
| 8    | 50  | 44           | 49           | 52            | 55            |

Multi-bit:

| GPUs | mul | mul_add 34x5 | mul_add 34x9 | mul_add 34x16 | mul_low 32x32 |
| ---- | --- | ------------ | ------------ | ------------- | ------------- |
| 1    | 98  | 43           | 56           | 56            | 92            |
| 2    | 59  | 32           | 36           | 37            | 52            |
| 4    | 40  | 24           | 28           | 29            | 33            |
| 8    | 31  | 23           | 25           | 26            | 31            |

### Check-list:

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Relevant issues are marked as resolved/closed, related issues are linked in the description
* [ ] Check for breaking changes (including serialization changes) and add them to commit message following the conventional commit [specification][conventional-breaking]

[conventional-breaking]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer
